### PR TITLE
Effect queue: drain-to-fixed-point, hot-reload persistence, and tests

### DIFF
--- a/runtime/functor-runtime-common/src/effect.rs
+++ b/runtime/functor-runtime-common/src/effect.rs
@@ -36,3 +36,27 @@ impl<T: Clone + 'static> Effect<T> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_none_distinguishes_variants() {
+        assert!(Effect::is_none(&Effect::<i32>::none()));
+        assert!(!Effect::is_none(&Effect::wrapped(1)));
+    }
+
+    #[test]
+    fn run_none_yields_no_messages() {
+        let msgs = Effect::<i32>::run(Effect::none());
+        assert_eq!(NativeArray_::count(msgs), 0);
+    }
+
+    #[test]
+    fn run_wrapped_yields_single_message() {
+        let msgs = Effect::run(Effect::wrapped(42));
+        assert_eq!(NativeArray_::count(msgs.clone()), 1);
+        assert!(NativeArray_::contains(msgs, 42));
+    }
+}

--- a/runtime/functor-runtime-common/src/effect_queue.rs
+++ b/runtime/functor-runtime-common/src/effect_queue.rs
@@ -36,3 +36,40 @@ impl<T: Clone + 'static> fmt::Debug for EffectQueue<T> {
         f.debug_struct("EffectQueue").finish()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_queue_is_empty() {
+        let q = EffectQueue::<i32>::new();
+        assert_eq!(EffectQueue::count(&q), 0);
+        assert!(EffectQueue::dequeue(&q).is_none());
+    }
+
+    #[test]
+    fn enqueue_dequeue_is_fifo() {
+        let q = EffectQueue::new();
+        EffectQueue::enqueue(&q, Effect::wrapped(1));
+        EffectQueue::enqueue(&q, Effect::wrapped(2));
+        EffectQueue::enqueue(&q, Effect::wrapped(3));
+        assert_eq!(EffectQueue::count(&q), 3);
+
+        for expected in [1, 2, 3] {
+            match EffectQueue::dequeue(&q) {
+                Some(Effect::Wrapped(v)) => assert_eq!(v, expected),
+                _ => panic!("expected Wrapped({expected})"),
+            }
+        }
+        assert_eq!(EffectQueue::count(&q), 0);
+    }
+
+    #[test]
+    fn enqueue_ignores_none_effects() {
+        let q = EffectQueue::<i32>::new();
+        EffectQueue::enqueue(&q, Effect::none());
+        assert_eq!(EffectQueue::count(&q), 0);
+        assert!(EffectQueue::dequeue(&q).is_none());
+    }
+}

--- a/src/Functor.Game/Runtime.fs
+++ b/src/Functor.Game/Runtime.fs
@@ -102,38 +102,49 @@ module Runtime
             printfn "Hello from GameRunner!"
         interface IRunner with
             member this.getState() =
-                OpaqueState.to_opaque_type state
+                // Bundle the pending effect queue with the model so in-flight
+                // effects survive a hot reload (the new runner starts with an
+                // empty queue otherwise, dropping effects enqueued across frames).
+                OpaqueState.to_opaque_type (state, effectQueue)
             member this.setState(incomingState) =
-                state <- OpaqueState.unsafe_coerce incomingState
+                let (restoredState, restoredQueue): ('Model * EffectQueue<'Msg>) =
+                    OpaqueState.unsafe_coerce incomingState
+                state <- restoredState
+                effectQueue <- restoredQueue
             member this.tick(frameTime: Time.FrameTime) = 
                 
                 // Todo: If first frame, run 'init'
 
-                printfn "Effect count: %d" (EffectQueue.count effectQueue)
-                // Todo: Run any pending effects
-                // Print the number of pending effects in the queue
+                // Drain the effect queue to a fixed point, feeding each resulting
+                // message through 'update' and accumulating state. Capped per frame
+                // so a runaway synchronous effect cascade can't hang the loop; any
+                // overflow is deferred to the next frame.
+                let maxEffectsPerFrame = 1000
 
-                let maybe_effect = EffectQueue.dequeue effectQueue;
+                let mutable processed = 0
+                let mutable settledState = state
+                let mutable draining = true
 
-                let finalState = 
-                    match maybe_effect with 
-                    | None -> 
-                        printfn "No effect"
-                        state
-                    | Some _e -> 
-                        let arr: 'Msg array = Effect.run _e
+                while draining do
+                    match EffectQueue.dequeue effectQueue with
+                    | None -> draining <- false
+                    | Some eff ->
+                        let messages: 'Msg array = Effect.run eff
+                        settledState <-
+                            Array.fold (fun currentState msg ->
+                                let (newState, effect) = GameRunner.update myGame currentState msg
+                                EffectQueue.enqueue effect effectQueue
+                                newState
+                            ) settledState messages
 
-                        Array.fold (fun (currentState) msg ->
-                            let (newState, effect) = GameRunner.update myGame state msg
-                            EffectQueue.enqueue effect effectQueue
-                            newState
-                        ) (state) arr
+                        processed <- processed + 1
+                        if processed >= maxEffectsPerFrame then
+                            printfn "[Functor] WARNING: effect queue hit per-frame cap (%d); deferring %d remaining effect(s) to next frame" maxEffectsPerFrame (EffectQueue.count effectQueue)
+                            draining <- false
 
-                let (newState, effect) = GameRunner.tick myGame finalState frameTime
-
-                EffectQueue.enqueue effect effectQueue;
-
-                // Todo: Run tick effects
+                // Step the simulation on the settled state, queueing any effect it produces.
+                let (newState, effect) = GameRunner.tick myGame settledState frameTime
+                EffectQueue.enqueue effect effectQueue
 
                 state <- newState
                 ()


### PR DESCRIPTION
Follow-up to #57. Hardens the effect queue with three fixes and adds unit tests for the queue primitives.

## Changes

**1. Fix multi-message state threading (`Runtime.fs`)**
The effect-processing fold applied each `update` against the original `state` instead of the accumulator, so when an effect yielded more than one message all but the last were discarded. Now threads `currentState` through the fold. Latent today (effects yield 0–1 messages) but a trap for any future batch/multi-effect variant.

**2. Drain the queue to a fixed point each frame (`Runtime.fs`)**
Replaced the previous one-effect-per-frame drain — which added per-frame latency and let the queue grow unbounded under load — with a drain-to-empty loop, capped at 1000 effects/frame. On overflow it logs a `[Functor] WARNING:` and defers the remainder to the next frame. Models Elm's drain-to-fixed-point, bounded like Bevy's frame-scoped events; the cap is a safety net until effects become async.

**3. Preserve pending effects across hot reload (`Runtime.fs`)**
`getState`/`setState` now bundle `(state, effectQueue)` into the opaque runtime state, so effects enqueued by `tick`/`update` survive a dev hot reload instead of being dropped when the new runner starts with an empty queue. Rides the same soundness assumption already used for the model; safe as long as effects stay plain data (no closures).

## Tests
Six unit tests in `functor-runtime-common`, matching the existing per-file `#[cfg(test)]` convention:
- `effect.rs` — `is_none` variant discrimination; `run` yields 0 messages for `None`, 1 for `Wrapped`.
- `effect_queue.rs` — empty-queue behavior; FIFO ordering + count; `None` effects are filtered, not queued.

All pass. The drain loop / fold logic lives in F#-transpiled-to-Rust inside `GameExecutor` and has no lightweight test seam yet — extracting it into a pure function is noted as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)