### PR TITLE
fix(examples): make hello sample run with bundled assets

### DIFF
--- a/examples/hello/hello.fs
+++ b/examples/hello/hello.fs
@@ -91,7 +91,7 @@ let init (_args: array<string>) =
         
         let eff = Effect.wrapped (MovePaddle2) |> Effect.map (fun _a -> MovePaddle1);
         let colorMaterial = Material.color(0.0f, 1.0f, 0.0f, 1.0f);
-        let textureMaterial = Material.texture( Texture.file("vr_glove_color.jpg"));
+        let textureMaterial = Material.texture( Texture.file("crate.png"));
         // let barrelModel = Model.file("ExplodingBarrel.glb");
         // let renderModel = (Graphics.Scene3D.model barrelModel) |> Transform.scale 1f;
         // let renderModel = Model.file ("ExplodingBarrel.glb") |> Graphics.Scene3D.model |> Transform.scale 0.5f;


### PR DESCRIPTION
## Summary

Running the `hello` sample (`functor -d examples/hello run native`) panicked at runtime:

```
thread 'main' panicked at runtime/functor-runtime-common/src/asset/asset_handle.rs:63:21:
Failed to load asset: No such file or directory (os error 2)
```

The sample's `draw3d` referenced two assets that weren't in the repo:

- `vr_glove_color.jpg` (texture)
- `shark.glb` (model)

`examples/hello/` only shipped `crate.png`, `dirt.png`, and `ExplodingBarrel.glb`.

## Changes

- Add `shark.glb` (from [BabylonJS Assets](https://github.com/BabylonJS/Assets/), credited in the README). Force-added past the `examples/hello/.gitignore` `*.glb` rule, matching how `ExplodingBarrel.glb` is already tracked.
- Remap the texture material from the missing `vr_glove_color.jpg` to the bundled `crate.png`.

## Testing

`functor -d examples/hello run native` now runs without panicking — renders the crate-textured cylinder and the rotating shark model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)