### PR TITLE
feat(runtime): Implement init startup effect

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -81,7 +81,7 @@ MVP:
   `Assets.Effect.load(texturePipeline, "my_texture.png"): AssetHandle<Texture>`
   `Assets.Effect.load(animationPipeline, "my_texture.png"): AssetHandle<Animations>`
 
-  - `init` function
+  - [x] `init` function (startup effect via `GameBuilder.init`, seeded into the effect queue at construction)
 
   - Get update function working
 

--- a/examples/hello/hello.fs
+++ b/examples/hello/hello.fs
@@ -117,4 +117,5 @@ let init (_args: array<string>) =
     )
     |> GameBuilder.update update
     |> GameBuilder.tick tick
+    |> GameBuilder.init (Effect.wrapped MovePaddle1)
     |> Runtime.runGame

--- a/runtime/functor-runtime-common/src/effect.rs
+++ b/runtime/functor-runtime-common/src/effect.rs
@@ -1,9 +1,23 @@
+use std::fmt;
+
 use fable_library_rust::{NativeArray_, Native_::Func1};
 
 #[derive(Clone)]
 pub enum Effect<T: Clone + 'static> {
     None,
     Wrapped(T),
+}
+
+// Implement Debug manually so it doesn't require `T: Debug`. This lets types
+// that embed an Effect (e.g. the generated Game record) derive Debug, while
+// keeping effects opaque - the payload is plain data but not necessarily printable.
+impl<T: Clone + 'static> fmt::Debug for Effect<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Effect::None => f.write_str("Effect::None"),
+            Effect::Wrapped(_) => f.write_str("Effect::Wrapped(..)"),
+        }
+    }
 }
 
 impl<T: Clone + 'static> Effect<T> {

--- a/runtime/functor-runtime-common/src/effect_queue.rs
+++ b/runtime/functor-runtime-common/src/effect_queue.rs
@@ -14,6 +14,15 @@ impl<T: Clone + 'static> EffectQueue<T> {
         }
     }
 
+    /// Build a queue pre-seeded with a single startup effect. A `None` effect
+    /// yields an empty queue. Used to inject a game's `init` effect at runner
+    /// construction so it drains on the first tick (see Runtime.fs GameExecutor).
+    pub fn seeded(effect: Effect<T>) -> EffectQueue<T> {
+        let queue = EffectQueue::new();
+        EffectQueue::enqueue(&queue, effect);
+        queue
+    }
+
     pub fn count(effect_queue: &EffectQueue<T>) -> i32 {
         effect_queue.queue.borrow().len() as i32
     }
@@ -69,6 +78,27 @@ mod tests {
     fn enqueue_ignores_none_effects() {
         let q = EffectQueue::<i32>::new();
         EffectQueue::enqueue(&q, Effect::none());
+        assert_eq!(EffectQueue::count(&q), 0);
+        assert!(EffectQueue::dequeue(&q).is_none());
+    }
+
+    #[test]
+    fn seeded_with_wrapped_holds_single_startup_effect() {
+        // A game's `init` effect is seeded into the queue at construction and
+        // must be delivered exactly once when the runner drains on first tick.
+        let q = EffectQueue::seeded(Effect::wrapped(7));
+        assert_eq!(EffectQueue::count(&q), 1);
+        match EffectQueue::dequeue(&q) {
+            Some(Effect::Wrapped(v)) => assert_eq!(v, 7),
+            _ => panic!("expected the seeded startup effect"),
+        }
+        assert_eq!(EffectQueue::count(&q), 0);
+    }
+
+    #[test]
+    fn seeded_with_none_is_empty() {
+        // A game without an `init` effect (Effect::none) starts with nothing queued.
+        let q = EffectQueue::<i32>::seeded(Effect::none());
         assert_eq!(EffectQueue::count(&q), 0);
         assert!(EffectQueue::dequeue(&q).is_none());
     }

--- a/src/Functor.Game/EffectQueue.fs
+++ b/src/Functor.Game/EffectQueue.fs
@@ -9,6 +9,9 @@ module EffectQueue =
     [<Emit("functor_runtime_common::EffectQueue::new()")>]
     let empty (): EffectQueue<_> = nativeOnly
 
+    [<Emit("functor_runtime_common::EffectQueue::seeded($0)")>]
+    let seeded (eff: effect<'a>): EffectQueue<'a> = nativeOnly
+
     [<Emit("functor_runtime_common::EffectQueue::count(&$0)")>]
     let count (effectQueue: EffectQueue<'a>): int = nativeOnly
 

--- a/src/Functor.Game/Game.fs
+++ b/src/Functor.Game/Game.fs
@@ -8,6 +8,7 @@ type InputFn<'model, 'msg> = 'model -> Input.t -> ('model * effect<'msg>)
 
 type Game<'model, 'msg> = {
     initialState: 'model
+    init: effect<'msg>
     input: InputFn<'model, 'msg>
     tick: TickFn<'model, 'msg>
     update: UpdateFn<'model, 'msg>
@@ -24,9 +25,15 @@ module GameBuilder =
         let tick model tick = (model, Effect.none ())
         let draw3d model frametime = Graphics.Scene3D.cube()
         let input model input = (model, Effect.none ())
-        { initialState = initialState; update = update; tick = tick; input = input; draw3d = draw3d}
+        { initialState = initialState; init = Effect.none (); update = update; tick = tick; input = input; draw3d = draw3d}
 
-    let update<'model, 'msg> (f: UpdateFn<'model, 'msg>) (game: Game<'model, 'msg>) = 
+    /// Set the startup effect, run once when the game first loads. Unlike 'tick'
+    /// effects, this fires before the first frame and is *not* re-run across a
+    /// hot reload (the persisted effect queue is restored instead).
+    let init (effect: effect<'msg>) (game: Game<'model, 'msg>) =
+        { game with init = effect }
+
+    let update<'model, 'msg> (f: UpdateFn<'model, 'msg>) (game: Game<'model, 'msg>) =
         { game with update = f }
 
     let input<'model, 'msg> (f: InputFn<'model, 'msg>) (game: Game<'model, 'msg>) =     
@@ -40,8 +47,10 @@ module GameBuilder =
 
 
 
-module GameRunner = 
+module GameRunner =
     let initialState (game: Game<'model, 'msg>) = game.initialState
+
+    let init (game: Game<'model, 'msg>) = game.init
 
     let tick<'model, 'msg> (game: Game<'model, 'msg>) (model: 'model) (tick: Time.FrameTime) = 
         let (newModel, effect) = game.tick model tick

--- a/src/Functor.Game/Game.fsi
+++ b/src/Functor.Game/Game.fsi
@@ -13,6 +13,8 @@ module GameBuilder =
 
     val local : initialState:'model -> Game<'model, 'msg>
 
+    val init : effect<'msg> -> Game<'model, 'msg> -> Game<'model, 'msg>
+
     val update : UpdateFn<'model, 'msg> -> Game<'model, 'msg> -> Game<'model, 'msg>
 
     val input : InputFn<'model, 'msg> -> Game<'model, 'msg> -> Game<'model, 'msg>
@@ -24,6 +26,7 @@ module GameBuilder =
 
 module GameRunner =
     val initialState: Game<'model, 'msg> -> 'model
+    val init: Game<'model, 'msg> -> effect<'msg>
     val tick: Game<'model, 'msg> -> 'model -> Time.FrameTime -> ('model * effect<'msg>)
     val update: Game<'model, 'msg> -> 'model -> 'msg -> ('model * effect<'msg>)
     val draw3d: Game<'model, 'msg> -> 'model -> Time.FrameTime -> Graphics.Scene3D

--- a/src/Functor.Game/Runtime.fs
+++ b/src/Functor.Game/Runtime.fs
@@ -97,7 +97,11 @@ module Runtime
     type GameExecutor<'Msg, 'Model>(game: Game<'Model, 'Msg>, initialState: 'Model) =
         let myGame = game
         let mutable state: 'Model = initialState
-        let mutable effectQueue: EffectQueue<'Msg> = EffectQueue.empty()
+        // Seed the queue with the game's startup ('init') effect. Because this
+        // happens at construction, a genuine first load drains it on the first
+        // tick, while a hot reload immediately overwrites the queue via setState
+        // - so the startup effect runs exactly once, never on reload.
+        let mutable effectQueue: EffectQueue<'Msg> = EffectQueue.seeded (GameRunner.init game)
         do
             printfn "Hello from GameRunner!"
         interface IRunner with
@@ -111,9 +115,10 @@ module Runtime
                     OpaqueState.unsafe_coerce incomingState
                 state <- restoredState
                 effectQueue <- restoredQueue
-            member this.tick(frameTime: Time.FrameTime) = 
-                
-                // Todo: If first frame, run 'init'
+            member this.tick(frameTime: Time.FrameTime) =
+
+                // The game's 'init' effect is seeded into the queue at construction
+                // (see above), so it drains here on the first tick like any other effect.
 
                 // Drain the effect queue to a fixed point, feeding each resulting
                 // message through 'update' and accumulating state. Capped per frame


### PR DESCRIPTION
## What

Adds a game-level **`init` effect** (Elm-style) that runs exactly once when a game first loads, before the first frame. This is the natural follow-up to the recently-landed effect queue (#57, #59): the plumbing existed, but almost nothing *fed* it. Until now the only entry point was `initialState` — plain data with no effect — so a game had no way to kick off a startup effect (e.g. asset loading).

## How

- **`GameBuilder.init`** sets the startup effect (defaults to `Effect.none`), composing with the existing builder pipeline:
  ```fsharp
  game
  |> GameBuilder.update update
  |> GameBuilder.tick tick
  |> GameBuilder.init (Effect.wrapped LoadAssets)
  |> Runtime.runGame
  ```
- **`EffectQueue::seeded`** builds a queue pre-seeded with a single effect. The `GameExecutor` seeds the queue with the `init` effect *at construction*, so it drains on the first tick like any other effect — no special first-frame latch needed.
- **Hot-reload safe by construction:** because seeding happens in the constructor, a reload immediately overwrites the queue via `setState` with the persisted queue — so `init` runs once on a genuine load and *never* on reload. This preserves the [plain-data effect-queue invariant](https://github.com/tommy-xr/functor) (queued effects stay plain data; no closures crossing the dylib boundary).
- **`Debug` for `Effect<T>`** (manual impl, no `T: Debug` bound) so the generated `Game` record — which now embeds the init effect — can still `derive(Debug)`.

## Naming note

The pre-existing exported `init` symbol (in `hello.fs`) is the *library-load hook* that builds the game and calls `runGame` — infrastructure, unrelated to this. The new `GameBuilder.init` is user-space and Elm-flavored.

## Testing

- New `EffectQueue::seeded` unit tests: a wrapped startup effect is delivered exactly once; a `None` startup yields an empty queue. (`cargo test -p functor_runtime_common` — all effect tests green.)
- The `hello` example now uses `GameBuilder.init`, exercising the path end-to-end through the F#→Rust→cargo build.
- Verified `functor-runtime-desktop` builds with `--features=strict` and the `hello` native build compiles the regenerated Game/Runtime.

> Note: the F# `GameExecutor` orchestration itself isn't unit-tested — there's no F# test harness yet ("Add test project" remains an open todo, and CI doesn't run `cargo test`). The init *mechanism* is tested at the `EffectQueue` layer where it's expressible; the orchestration is covered by the example build. A pre-existing, unrelated test failure (`model::skeleton::tests::test_absolute_transforms`) also fails on clean `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)