### PR TITLE
ci: Bump actions to Node 24 runtimes ahead of the cutover

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -15,10 +15,10 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "8.0.x"
 
@@ -31,12 +31,10 @@ jobs:
           dotnet --list-sdks
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2.4.1
+        uses: actions/setup-node@v6
 
       - name: Setup Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Rust build
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -15,10 +15,10 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "8.0.x"
 
@@ -31,12 +31,10 @@ jobs:
           dotnet --list-sdks
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2.4.1
+        uses: actions/setup-node@v6
 
       - name: Setup Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Rust build
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## What

GitHub is removing the **Node 20 Actions runtime** (forced to Node 24 on **2026-06-16**). This bumps every action in our workflows to a major that runs on Node 24, so we don't start failing/warning at the cutover.

| Action | Before | After | Runtime |
|---|---|---|---|
| `actions/checkout` | `@v2` | `@v6` | node24 |
| `actions/setup-dotnet` | `@v1` | `@v5` | node24 (`dotnet-version` input unchanged) |
| `actions/setup-node` | `@v2.4.1` | `@v6` | node24 |
| `actions-rs/toolchain` | `@v1` | **`dtolnay/rust-toolchain@stable`** | composite (no node) |
| `Swatinem/rust-cache` | `@v2` | `@v2` (unchanged) | already node24 (v2.9.1) |

- **`actions-rs/toolchain` → `dtolnay/rust-toolchain@stable`:** the old one is archived/unmaintained; dtolnay's is the de-facto standard and a *composite* action (no Node runtime at all). The `toolchain: stable` input is encoded in the `@stable` tag, so the `with:` block is dropped.
- **`Swatinem/rust-cache@v2` left alone:** its latest (v2.9.1) already runs on Node 24, and leaving the line untouched avoids colliding with the cache-ordering fix in #66.

Applied identically to `build-native.yml` and `build-wasm.yml`. I verified each target version's `runs.using` is `node24` (or composite) via the GitHub API before bumping.

## Scope note

Per discussion, this is the **minimal cutover** — it keeps our existing npm/node usage as-is. (We separately confirmed node could be removed entirely — it's only used as a wasm-pack installer and a wrapper for `dotnet fable` — but that's deliberately out of scope here.)

## Verification

YAML validated; no deprecated refs remain. CI on this PR exercises all bumped actions across the win/mac/linux matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)