### PR TITLE
feat(runtime): add Elm-style subscriptions with Sub.every

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -46,15 +46,38 @@ MVP:
 
 - ## Materials
 
-  - Sub.ofMsg
-    - dispatch message to game
-    - Create a 'poll' method for Subs
-    - Just fires once
-  - Sub.renderFrame
-    - Always returns a message via poll
-  - Sub.timer
-  - Sub.Net.httpRequest
-  - Sub.Net.webSocket
+  - Subscriptions (`Sub`) — the dual of Effect/Cmd: a standing source of
+    messages, recomputed from the model each frame and fed back through the
+    same enqueue -> drain -> update path as effects. (PR #69)
+
+    - [x] `subscriptions : model -> Sub msg` seam wired into the runtime loop
+    - [x] `Sub.every` (recurring timer) — stateless: fires on the global time
+          grid, so it needs no per-sub identity or diffing and survives hot
+          reload for free. `Sub.none` / `Sub.batch` / `Sub.map` too.
+    - [ ] `Effect.after duration msg` — one-shot delay. This is a *command*,
+          not a sub (needs creation-time state), so it can't use the stateless
+          clock trick. Blocked on the async inbox below.
+    - [ ] `Sub.renderFrame` — always returns a message via poll (per-frame Sub)
+    - [ ] `Sub.Net.webSocket` — first resource-backed sub. Unlike `every`, a
+          live socket DOES need identity (it must be matched across
+          recomputations so it isn't torn down/reopened every frame; key on the
+          resource descriptor, e.g. URL, which is hashable — not the generic
+          msg). Blocked on the keyed resource registry + async inbox below.
+    - [ ] `Sub.Net.httpRequest` — note: a one-shot request is really an Effect
+          (Cmd), not a Sub; a long-poll/SSE stream is the Sub. Same async
+          inbox dependency.
+
+  - The machinery `Effect.after` / web sockets / http all share (build once
+    when the first resource-backed sub/effect lands):
+
+    - [ ] Async inbox: a channel the runtime drains each frame into the
+          EffectQueue, so messages can arrive on a *later* frame (today Effect
+          is synchronous — `Effect.run` yields in-frame). The seam already has
+          the right shape (walk subs -> enqueue -> drain); the inbox is just
+          empty for now.
+    - [ ] Keyed resource registry: each frame, diff the desired sub set against
+          live resources; spawn new, tear down gone. Identity = resource
+          descriptor.
 
   - Add test project
 
@@ -71,12 +94,13 @@ MVP:
   - EffectRunner::get_completed_result(): Array<T>
 
   - Are we going to have to re-think our approach to async IO on desktop runtime?
+    (This is the "async inbox" item under Subscriptions above — same work.)
 
     - Maybe we create a tokio runtime in a separate thread
     - Use the receiver / channel to push state
 
-  - Add timeout effect to implement futures
-    `Effect.timeout(~duration, msg)`
+  - Add timeout effect to implement futures — now tracked as `Effect.after`
+    under Subscriptions above (one-shot command, blocked on the async inbox).
 
   `Assets.Effect.load(texturePipeline, "my_texture.png"): AssetHandle<Texture>`
   `Assets.Effect.load(animationPipeline, "my_texture.png"): AssetHandle<Animations>`

--- a/examples/hello/hello.fs
+++ b/examples/hello/hello.fs
@@ -50,7 +50,7 @@ let update model msg =
         // Driven by the `Sub.every` subscription below: a message produced by a
         // subscription arrives here every second, just like any other message.
         let newModel = { model with counter = model.counter + 1 }
-        printfn "Tick! counter = %d" newModel.counter
+        Debug.log (sprintf "Tick! counter = %d" newModel.counter)
         (newModel, Effect.none())
     | _ ->
         printfn "Running update"

--- a/examples/hello/hello.fs
+++ b/examples/hello/hello.fs
@@ -40,12 +40,24 @@ module Model =
 type Msg =
     | MovePaddle1
     | MovePaddle2
+    | Tick
 
 let game: Game<Model, Msg> = GameBuilder.local Model.initial
 
 let update model msg =
-    printfn "Running update"
-    (model, Effect.none())
+    match msg with
+    | Tick ->
+        // Driven by the `Sub.every` subscription below: a message produced by a
+        // subscription arrives here every second, just like any other message.
+        let newModel = { model with counter = model.counter + 1 }
+        printfn "Tick! counter = %d" newModel.counter
+        (newModel, Effect.none())
+    | _ ->
+        printfn "Running update"
+        (model, Effect.none())
+
+let subscriptions model =
+    Sub.every (Duration.fromSeconds 1.0) Tick
 
 let tick model (tick: Time.FrameTime) =
     
@@ -117,4 +129,5 @@ let init (_args: array<string>) =
     )
     |> GameBuilder.update update
     |> GameBuilder.tick tick
+    |> GameBuilder.subscriptions subscriptions
     |> Runtime.runGame

--- a/runtime/functor-runtime-common/src/lib.rs
+++ b/runtime/functor-runtime-common/src/lib.rs
@@ -2,10 +2,26 @@
 
 use std::any::Any;
 
+use fable_library_rust::String_::LrcStr;
+
 #[cfg(target_arch = "wasm32")]
 use serde::*;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
+
+// Log a line so it is visible on every target. On wasm, Rust's `println!`
+// writes to stdout, which isn't connected to anything in the browser
+// (wasm32-unknown-unknown has no WASI), so F# `printfn` output is silently
+// dropped; route it to `console.log` instead. On native, `println!` is fine.
+#[cfg(target_arch = "wasm32")]
+pub fn log(message: LrcStr) {
+    web_sys::console::log_1(&JsValue::from_str(&message));
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn log(message: LrcStr) {
+    println!("{}", message);
+}
 
 #[cfg(target_arch = "wasm32")]
 pub fn to_js_value<T>(value: &T) -> JsValue

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -63,8 +63,6 @@ impl AssetLoader for WasmAssetLoader {
 
 async fn run_async() -> Result<(), JsValue> {
     // Load game
-    // web_sys::console::log_2(&JsValue::from_str("Here: "), &three);
-    // println!("Value! {:?}", three);
     unsafe {
         // Create a context from a WebGL2 context on wasm32 targets
         let (gl, shader_version) = {
@@ -115,8 +113,6 @@ async fn run_async() -> Result<(), JsValue> {
                 color = vec4(vert, 0.5, 1.0);
             }"#,
         );
-
-        web_sys::console::log_1(&JsValue::from_str("here - 20!"));
 
         let shader_sources = [
             (glow::VERTEX_SHADER, vertex_shader_source),
@@ -212,7 +208,6 @@ async fn run_async() -> Result<(), JsValue> {
             game_tick(functor_runtime_common::to_js_value(&frame_time));
 
             let val = game_render(functor_runtime_common::to_js_value(&frame_time));
-            web_sys::console::log_2(&JsValue::from_str("calling render"), &val);
 
             let scene: Scene3D = functor_runtime_common::from_js_value(val);
 

--- a/src/Functor.Game/Debug.fs
+++ b/src/Functor.Game/Debug.fs
@@ -1,0 +1,12 @@
+namespace Functor
+open Fable.Core
+
+module Debug =
+
+    // Log a line that is visible on every target. Prefer this over `printfn`
+    // when you want output in the browser console: on wasm, `printfn` compiles
+    // to Rust's `println!` -> stdout, which is not connected to anything in the
+    // browser, so those lines are silently dropped. `Debug.log` routes to
+    // `console.log` on wasm and stdout on native.
+    [<Emit("functor_runtime_common::log($0)")>]
+    let log (message: string) : unit = nativeOnly

--- a/src/Functor.Game/Functor.Game.fsproj
+++ b/src/Functor.Game/Functor.Game.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="Input.fsi" />
     <Compile Include="Input.fs" />
     <Compile Include="Graphics.fs" />
+    <Compile Include="Sub.fs" />
     <Compile Include="Game.fsi" />
     <Compile Include="Game.fs" />
     <Compile Include="Runtime.fs" />

--- a/src/Functor.Game/Functor.Game.fsproj
+++ b/src/Functor.Game/Functor.Game.fsproj
@@ -14,6 +14,7 @@
     <Compile Include="Scene3D.fs" />
     <Compile Include="Duration.fs" />
     <Compile Include="Platform.fs" />
+    <Compile Include="Debug.fs" />
     <Compile Include="FrameTime.fs" />
     <Compile Include="Input.fsi" />
     <Compile Include="Input.fs" />

--- a/src/Functor.Game/Game.fs
+++ b/src/Functor.Game/Game.fs
@@ -6,11 +6,14 @@ type UpdateFn<'model, 'msg> = 'model -> 'msg -> ('model * effect<'msg>)
 
 type InputFn<'model, 'msg> = 'model -> Input.t -> ('model * effect<'msg>)
 
+type SubFn<'model, 'msg> = 'model -> Sub<'msg>
+
 type Game<'model, 'msg> = {
     initialState: 'model
     input: InputFn<'model, 'msg>
     tick: TickFn<'model, 'msg>
     update: UpdateFn<'model, 'msg>
+    subscriptions: SubFn<'model, 'msg>
     draw3d: 'model -> Time.FrameTime -> Graphics.Scene3D
     }
 
@@ -24,7 +27,8 @@ module GameBuilder =
         let tick model tick = (model, Effect.none ())
         let draw3d model frametime = Graphics.Scene3D.cube()
         let input model input = (model, Effect.none ())
-        { initialState = initialState; update = update; tick = tick; input = input; draw3d = draw3d}
+        let subscriptions model = Sub.none ()
+        { initialState = initialState; update = update; tick = tick; input = input; subscriptions = subscriptions; draw3d = draw3d}
 
     let update<'model, 'msg> (f: UpdateFn<'model, 'msg>) (game: Game<'model, 'msg>) = 
         { game with update = f }
@@ -35,8 +39,11 @@ module GameBuilder =
     let draw3d<'model, 'msg> (f: 'model -> Time.FrameTime -> Graphics.Scene3D) (game: Game<'model, 'msg>) = 
         { game with draw3d = f }
 
-    let tick<'model, 'msg> (f: TickFn<'model, 'msg>) (game: Game<'model, 'msg>) = 
+    let tick<'model, 'msg> (f: TickFn<'model, 'msg>) (game: Game<'model, 'msg>) =
         { game with tick = f}
+
+    let subscriptions<'model, 'msg> (f: SubFn<'model, 'msg>) (game: Game<'model, 'msg>) =
+        { game with subscriptions = f }
 
 
 
@@ -47,9 +54,12 @@ module GameRunner =
         let (newModel, effect) = game.tick model tick
         (newModel, effect)
 
-    let update<'model, 'msg> (game: Game<'model, 'msg>) (model: 'model) (msg: 'msg) = 
+    let update<'model, 'msg> (game: Game<'model, 'msg>) (model: 'model) (msg: 'msg) =
         let (newModel, effect) = game.update model msg
         (newModel, effect)
+
+    let subscriptions<'model, 'msg> (game: Game<'model, 'msg>) (model: 'model) =
+        game.subscriptions model
 
     let draw3d<'model, 'msg> (game: Game<'model, 'msg>) (model: 'model) (tick: Time.FrameTime) =
         game.draw3d model tick

--- a/src/Functor.Game/Game.fsi
+++ b/src/Functor.Game/Game.fsi
@@ -6,6 +6,8 @@ type InputFn<'model, 'msg> = 'model -> Input.t -> ('model * effect<'msg>)
 
 type TickFn<'model, 'msg> = 'model -> Time.FrameTime -> ('model * effect<'msg>)
 
+type SubFn<'model, 'msg> = 'model -> Sub<'msg>
+
 type Game<'model, 'msg>
 
 module GameBuilder = 
@@ -19,6 +21,8 @@ module GameBuilder =
 
     val tick: TickFn<'model, 'msg> -> Game<'model, 'msg> -> Game<'model, 'msg>
 
+    val subscriptions: SubFn<'model, 'msg> -> Game<'model, 'msg> -> Game<'model, 'msg>
+
     val draw3d: ('model -> Time.FrameTime -> Graphics.Scene3D) -> Game<'model, 'msg> -> Game<'model, 'msg>
 
 
@@ -26,4 +30,5 @@ module GameRunner =
     val initialState: Game<'model, 'msg> -> 'model
     val tick: Game<'model, 'msg> -> 'model -> Time.FrameTime -> ('model * effect<'msg>)
     val update: Game<'model, 'msg> -> 'model -> 'msg -> ('model * effect<'msg>)
+    val subscriptions: Game<'model, 'msg> -> 'model -> Sub<'msg>
     val draw3d: Game<'model, 'msg> -> 'model -> Time.FrameTime -> Graphics.Scene3D

--- a/src/Functor.Game/Runtime.fs
+++ b/src/Functor.Game/Runtime.fs
@@ -120,45 +120,54 @@ module Runtime
 
                 // Todo: If first frame, run 'init'
 
-                // Poll subscriptions before draining. We recompute the Sub tree
-                // from the current model each frame and enqueue a message for any
-                // timer that crossed a boundary since last frame; those messages
-                // then flow through the same drain -> update path as effects.
                 let tts = float frameTime.tts
+
+                // Drain the effect queue to a fixed point, feeding each resulting
+                // message through 'update' and accumulating state. Capped per call
+                // so a runaway synchronous effect cascade can't hang the loop; any
+                // overflow is deferred to the next frame.
+                let maxEffectsPerFrame = 1000
+                let drain (startState: 'Model) : 'Model =
+                    let mutable processed = 0
+                    let mutable settledState = startState
+                    let mutable draining = true
+                    while draining do
+                        match EffectQueue.dequeue effectQueue with
+                        | None -> draining <- false
+                        | Some eff ->
+                            let messages: 'Msg array = Effect.run eff
+                            settledState <-
+                                Array.fold (fun currentState msg ->
+                                    let (newState, effect) = GameRunner.update myGame currentState msg
+                                    EffectQueue.enqueue effect effectQueue
+                                    newState
+                                ) settledState messages
+
+                            processed <- processed + 1
+                            if processed >= maxEffectsPerFrame then
+                                printfn "[Functor] WARNING: effect queue hit per-frame cap (%d); deferring %d remaining effect(s) to next frame" maxEffectsPerFrame (EffectQueue.count effectQueue)
+                                draining <- false
+                    settledState
+
+                // Settle effects carried over from previous frames first, so that
+                // subscriptions are evaluated against an up-to-date model (an
+                // effect processed this frame may change what the game subscribes
+                // to -- e.g. disable a timer).
+                let settledBeforeSubs = drain state
+
+                // Poll subscriptions on the settled model: recompute the Sub tree
+                // and enqueue a message for any timer that crossed a boundary since
+                // last frame, then drain those through the same update path. A sub
+                // disabled by the effects above no longer fires this frame.
                 match lastTts with
                 | Some prevTts ->
-                    GameRunner.subscriptions myGame state
+                    GameRunner.subscriptions myGame settledBeforeSubs
                     |> Sub.messagesForFrame prevTts tts
                     |> Array.iter (fun msg -> EffectQueue.enqueue (Effect.wrapped msg) effectQueue)
                 | None -> ()
                 lastTts <- Some tts
 
-                // Drain the effect queue to a fixed point, feeding each resulting
-                // message through 'update' and accumulating state. Capped per frame
-                // so a runaway synchronous effect cascade can't hang the loop; any
-                // overflow is deferred to the next frame.
-                let maxEffectsPerFrame = 1000
-
-                let mutable processed = 0
-                let mutable settledState = state
-                let mutable draining = true
-
-                while draining do
-                    match EffectQueue.dequeue effectQueue with
-                    | None -> draining <- false
-                    | Some eff ->
-                        let messages: 'Msg array = Effect.run eff
-                        settledState <-
-                            Array.fold (fun currentState msg ->
-                                let (newState, effect) = GameRunner.update myGame currentState msg
-                                EffectQueue.enqueue effect effectQueue
-                                newState
-                            ) settledState messages
-
-                        processed <- processed + 1
-                        if processed >= maxEffectsPerFrame then
-                            printfn "[Functor] WARNING: effect queue hit per-frame cap (%d); deferring %d remaining effect(s) to next frame" maxEffectsPerFrame (EffectQueue.count effectQueue)
-                            draining <- false
+                let settledState = drain settledBeforeSubs
 
                 // Step the simulation on the settled state, queueing any effect it produces.
                 let (newState, effect) = GameRunner.tick myGame settledState frameTime

--- a/src/Functor.Game/Runtime.fs
+++ b/src/Functor.Game/Runtime.fs
@@ -98,6 +98,11 @@ module Runtime
         let myGame = game
         let mutable state: 'Model = initialState
         let mutable effectQueue: EffectQueue<'Msg> = EffectQueue.empty()
+        // Total-time (seconds) seen on the previous frame, used to detect timer
+        // boundary crossings for `Sub.every`. None until the first frame
+        // establishes a baseline (and after a hot reload), so we never report a
+        // spurious crossing across a discontinuous jump in the clock.
+        let mutable lastTts: Option<float> = None
         do
             printfn "Hello from GameRunner!"
         interface IRunner with
@@ -111,9 +116,22 @@ module Runtime
                     OpaqueState.unsafe_coerce incomingState
                 state <- restoredState
                 effectQueue <- restoredQueue
-            member this.tick(frameTime: Time.FrameTime) = 
-                
+            member this.tick(frameTime: Time.FrameTime) =
+
                 // Todo: If first frame, run 'init'
+
+                // Poll subscriptions before draining. We recompute the Sub tree
+                // from the current model each frame and enqueue a message for any
+                // timer that crossed a boundary since last frame; those messages
+                // then flow through the same drain -> update path as effects.
+                let tts = float frameTime.tts
+                match lastTts with
+                | Some prevTts ->
+                    GameRunner.subscriptions myGame state
+                    |> Sub.messagesForFrame prevTts tts
+                    |> Array.iter (fun msg -> EffectQueue.enqueue (Effect.wrapped msg) effectQueue)
+                | None -> ()
+                lastTts <- Some tts
 
                 // Drain the effect queue to a fixed point, feeding each resulting
                 // message through 'update' and accumulating state. Capped per frame

--- a/src/Functor.Game/Sub.fs
+++ b/src/Functor.Game/Sub.fs
@@ -1,0 +1,60 @@
+namespace Functor
+
+// Subscriptions: ongoing sources of messages, recomputed from the model every
+// frame. Sub is the dual of Effect/Cmd: Effect is a one-shot "do this once",
+// Sub is a standing "while the model looks like this, listen to these". The
+// runtime walks the Sub tree each frame and feeds any produced messages back
+// through `update`, exactly like effects.
+//
+// `every` is deliberately stateless: it fires on the global time grid (integer
+// multiples of its period measured from t=0), so "did it fire this frame?" is a
+// pure function of the clock (see `crossedBoundary`). That means it needs no
+// per-subscription identity or frame-to-frame diffing, and it survives a hot
+// reload for free.
+//
+// Resource-backed subscriptions (web sockets, etc.) will arrive as new variants
+// here. They DO need identity -- a live socket must be matched across
+// recomputations so it isn't torn down and reopened every frame -- which is why
+// the runtime seam (walk subs -> enqueue -> drain) is built now even though the
+// timer is its only client. Game code only ever calls the smart constructors
+// below, so adding variants later is additive and breaks no existing games.
+type Sub<'msg> =
+    | SubNone
+    | Every of Duration.t * 'msg
+    | Batch of Sub<'msg> array
+
+module Sub =
+
+    let none () : Sub<'msg> = SubNone
+
+    let every (period: Duration.t) (msg: 'msg) : Sub<'msg> = Every(period, msg)
+
+    let batch (subs: Sub<'msg> array) : Sub<'msg> = Batch subs
+
+    let rec map (f: 'a -> 'b) (sub: Sub<'a>) : Sub<'b> =
+        match sub with
+        | SubNone -> SubNone
+        | Every(period, msg) -> Every(period, f msg)
+        | Batch subs -> Batch(subs |> Array.map (map f))
+
+    // True iff an integer multiple of `period` lies in the interval
+    // (prevTts, tts] -- i.e. a timer boundary was crossed between the previous
+    // frame's total-time and this frame's. Pure function of the global clock:
+    // no per-timer accumulator, so two evaluations of the same `every` are
+    // interchangeable and nothing has to be tracked across frames.
+    let crossedBoundary (period: Duration.t) (prevTts: float) (tts: float) : bool =
+        let p = Duration.toSeconds period
+        p > 0.0 && floor (tts / p) > floor (prevTts / p)
+
+    let rec private collectFired (prevTts: float) (tts: float) (acc: 'msg array) (sub: Sub<'msg>) : 'msg array =
+        match sub with
+        | SubNone -> acc
+        | Every(period, msg) ->
+            if crossedBoundary period prevTts tts then Array.append acc [| msg |] else acc
+        | Batch subs -> Array.fold (collectFired prevTts tts) acc subs
+
+    // Walk the Sub tree and return the messages that fired this frame, given the
+    // previous and current total-time. The runtime feeds these back through the
+    // same enqueue -> update path as effects.
+    let messagesForFrame (prevTts: float) (tts: float) (sub: Sub<'msg>) : 'msg array =
+        collectFired prevTts tts [||] sub


### PR DESCRIPTION
## What

Adds an Elm-style **subscription** concept — `subscriptions : model -> Sub msg` — as the dual of `Effect`:

- **`Effect`** (existing) = one-shot "do this once" (Elm's `Cmd`).
- **`Sub`** (new) = a standing source of messages, recomputed from the model each frame.

The runtime walks the `Sub` tree every frame and feeds any fired messages back through the **existing** `EffectQueue` → drain → `update` path — so subscription messages flow into `update` exactly like effects.

## API

```fsharp
Sub.none  : unit -> Sub<'msg>
Sub.every : Duration.t -> 'msg -> Sub<'msg>
Sub.batch : Sub<'msg> array -> Sub<'msg>
Sub.map   : ('a -> 'b) -> Sub<'a> -> Sub<'b>

// in the game builder
game |> GameBuilder.subscriptions (fun model -> Sub.every (Duration.fromSeconds 1.0) Tick)
```

## Why `Sub.every` needs no identity

It's deliberately **stateless**: it fires on the global time grid (integer multiples of its period from `t=0`), so "did it fire this frame?" is a pure function of the clock:

```
crossedBoundary period prev tts  =  floor(tts/period) > floor(prev/period)
```

No per-subscription accumulator, no frame-to-frame diffing, and it survives a hot reload for free (the runtime keeps a single `lastTts` scalar, `None`-seeded so there's no spurious fire on frame 1 or just after a reload).

## Forward-compatible seam

The clock trick is a leaf-level optimization, **not** the foundation. The seam (walk subs → enqueue → drain) is shaped so resource-backed subs (web sockets, etc.) slot in later as additive `Sub` variants — game code only calls the smart constructors, so new variants break no existing games. Those *will* need identity (a live socket must be matched across recomputations) plus the deferred async inbox + keyed resource registry — the same tokio-thread + channel work already noted in `docs/todo.md`, shared with async (HTTP) effects.

Out of scope here (intentionally): one-shot `Effect.after` (a command, needs creation-time state) and any resource-backed sub.

## Demo

`examples/hello` subscribes `Sub.every (Duration.fromSeconds 1.0) Tick`; `update` increments a counter and prints on each `Tick`, confirming a subscription message arriving in `update` once per second.

## Verification

Built through the full Fable → Rust → cargo pipeline (`npm run build:examples:hello:rust` + `cargo check` on the native build) — clean. Ran the native runner and observed `Tick!` firing once per second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)