### PR TITLE
feat(input): wire keyboard and mouse events through the runtime

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -67,6 +67,31 @@ MVP:
           (Cmd), not a Sub; a long-poll/SSE stream is the Sub. Same async
           inbox dependency.
 
+  - Input (`Input`) — discrete keyboard/mouse events fed through the pure
+    `input : model -> Input.t -> model * effect` seam, mirroring `update`.
+    Events cross the F#/Rust boundary as primitives; the runtime builds the
+    `Input.t` DU F#-side so game code can pattern-match it.
+
+    - [x] `key_event` / `mouse_move` / `mouse_wheel` boundary exports (native +
+          parallel wasm), desktop GLFW event dispatch, canonical `Key` enum in
+          functor-runtime-common mirrored by `Input.ofKeyCode`.
+    - [x] Interactive `hello` sample: WASD / arrows move the scene (held-key
+          state reconstructed in the model, integrated in `tick`).
+    - [ ] Polling snapshot (fast follow): an `Input.State` (keys currently down
+          + mouse pos/scroll), maintained by the runtime from the same event
+          stream, handed to the pure core — most likely into `tick`
+          (`model -> FrameTime -> Input.State -> ...`) so movement code can ask
+          `Input.State.isKeyDown state Key.W` instead of every game rebuilding
+          held-key state from up/down events. Keep events too (press/release
+          edges still matter for discrete actions). Open: snapshot in `tick`
+          signature vs. a queryable accessor; held-set is derived state so
+          rebuild from events rather than persist in `OpaqueState`.
+    - [ ] Web runtime: translate browser keyboard/mouse events into the
+          `key_event_wasm` / `mouse_move_wasm` / `mouse_wheel_wasm` exports (the
+          exports exist; the JS glue that calls them does not yet).
+    - [ ] Game controller and VR controller events (`Input` has TODO
+          placeholders).
+
   - The machinery `Effect.after` / web sockets / http all share (build once
     when the first resource-backed sub/effect lands):
 

--- a/runtime/functor-runtime-common/src/input.rs
+++ b/runtime/functor-runtime-common/src/input.rs
@@ -1,0 +1,46 @@
+use serde::{Deserialize, Serialize};
+
+/// Canonical key identifier shared across the F# <-> Rust boundary and all
+/// runtimes (desktop GLFW, web). Producers (e.g. the desktop runtime's
+/// `glfw::Key` mapping in `functor-runtime-desktop`) translate their platform
+/// key into this enum and pass its `as i32` discriminant across the dylib/wasm
+/// boundary. The F# `Input.Key` DU mirrors these discriminants in
+/// `Input.ofKeyCode` — keep the two in sync when adding keys.
+#[repr(i32)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Key {
+    Unknown = 0,
+    A = 1,
+    B,
+    C,
+    D,
+    E,
+    F,
+    G,
+    H,
+    I,
+    J,
+    K,
+    L,
+    M,
+    N,
+    O,
+    P,
+    Q,
+    R,
+    S,
+    T,
+    U,
+    V,
+    W,
+    X,
+    Y,
+    Z,
+    Up,
+    Down,
+    Left,
+    Right,
+    Space,
+    Enter,
+    Escape,
+}

--- a/runtime/functor-runtime-common/src/lib.rs
+++ b/runtime/functor-runtime-common/src/lib.rs
@@ -70,6 +70,7 @@ mod effect;
 mod effect_queue;
 mod frame_time;
 pub mod geometry;
+mod input;
 pub mod io;
 pub mod material;
 pub mod math;
@@ -84,6 +85,7 @@ pub mod texture;
 pub use effect::*;
 pub use effect_queue::*;
 pub use frame_time::*;
+pub use input::*;
 pub use render_context::*;
 pub use scene3d::*;
 

--- a/runtime/functor-runtime-desktop/src/game.rs
+++ b/runtime/functor-runtime-desktop/src/game.rs
@@ -5,6 +5,15 @@ pub trait Game {
 
     fn tick(&mut self, frame_time: FrameTime);
 
+    /// Deliver a keyboard event. `code` is a functor_runtime_common::Key as i32.
+    fn key_event(&mut self, code: i32, is_down: bool);
+
+    /// Deliver a mouse-move event in window pixel coordinates.
+    fn mouse_move(&mut self, x: i32, y: i32);
+
+    /// Deliver a mouse-wheel event (vertical scroll offset).
+    fn mouse_wheel(&mut self, delta: i32);
+
     fn render(&mut self, frame_time: FrameTime) -> Scene3D;
 
     fn quit(&mut self);

--- a/runtime/functor-runtime-desktop/src/hot_reload_game.rs
+++ b/runtime/functor-runtime-desktop/src/hot_reload_game.rs
@@ -52,6 +52,30 @@ impl Game for HotReloadGame {
         }
     }
 
+    fn key_event(&mut self, code: i32, is_down: bool) {
+        unsafe {
+            let func: Symbol<fn(i32, bool)> =
+                self.library.as_ref().unwrap().get(b"key_event").unwrap();
+            func(code, is_down)
+        }
+    }
+
+    fn mouse_move(&mut self, x: i32, y: i32) {
+        unsafe {
+            let func: Symbol<fn(i32, i32)> =
+                self.library.as_ref().unwrap().get(b"mouse_move").unwrap();
+            func(x, y)
+        }
+    }
+
+    fn mouse_wheel(&mut self, delta: i32) {
+        unsafe {
+            let func: Symbol<fn(i32)> =
+                self.library.as_ref().unwrap().get(b"mouse_wheel").unwrap();
+            func(delta)
+        }
+    }
+
     fn quit(&mut self) {
         if let Some(handle) = self.watcher_thread.take() {
             handle.join().expect("Failed to join watcher thread");

--- a/runtime/functor-runtime-desktop/src/main.rs
+++ b/runtime/functor-runtime-desktop/src/main.rs
@@ -9,6 +9,7 @@ use cgmath::{vec4, Matrix4};
 use functor_runtime_common::asset::AssetCache;
 use functor_runtime_common::material::ColorMaterial;
 use functor_runtime_common::{FrameTime, SceneContext};
+use functor_runtime_common::Key as InputKey;
 use glfw::{Action, Key};
 use glow::*;
 use hot_reload_game::HotReloadGame;
@@ -22,6 +23,47 @@ const SCR_HEIGHT: u32 = 600;
 mod game;
 mod hot_reload_game;
 mod static_game;
+
+/// Translate a GLFW key into the canonical engine key code passed across the
+/// game boundary. Unmapped keys become InputKey::Unknown.
+fn map_key(key: Key) -> InputKey {
+    match key {
+        Key::A => InputKey::A,
+        Key::B => InputKey::B,
+        Key::C => InputKey::C,
+        Key::D => InputKey::D,
+        Key::E => InputKey::E,
+        Key::F => InputKey::F,
+        Key::G => InputKey::G,
+        Key::H => InputKey::H,
+        Key::I => InputKey::I,
+        Key::J => InputKey::J,
+        Key::K => InputKey::K,
+        Key::L => InputKey::L,
+        Key::M => InputKey::M,
+        Key::N => InputKey::N,
+        Key::O => InputKey::O,
+        Key::P => InputKey::P,
+        Key::Q => InputKey::Q,
+        Key::R => InputKey::R,
+        Key::S => InputKey::S,
+        Key::T => InputKey::T,
+        Key::U => InputKey::U,
+        Key::V => InputKey::V,
+        Key::W => InputKey::W,
+        Key::X => InputKey::X,
+        Key::Y => InputKey::Y,
+        Key::Z => InputKey::Z,
+        Key::Up => InputKey::Up,
+        Key::Down => InputKey::Down,
+        Key::Left => InputKey::Left,
+        Key::Right => InputKey::Right,
+        Key::Space => InputKey::Space,
+        Key::Enter => InputKey::Enter,
+        Key::Escape => InputKey::Escape,
+        _ => InputKey::Unknown,
+    }
+}
 
 use clap::Parser;
 
@@ -74,6 +116,7 @@ pub async fn main() {
             window.make_current();
             window.set_key_polling(true);
             window.set_cursor_pos_polling(true);
+            window.set_scroll_polling(true);
             window.set_framebuffer_size_polling(true);
             // window.set_cursor_mode(glfw::CursorMode::Disabled);
 
@@ -134,6 +177,16 @@ pub async fn main() {
                     glfw::WindowEvent::Key(Key::Escape, _, Action::Press, _) => {
                         window.set_should_close(true)
                     }
+                    glfw::WindowEvent::Key(key, _, action, _) => match action {
+                        Action::Press | Action::Repeat => {
+                            game.key_event(map_key(key) as i32, true)
+                        }
+                        Action::Release => game.key_event(map_key(key) as i32, false),
+                    },
+                    glfw::WindowEvent::CursorPos(x, y) => {
+                        game.mouse_move(x as i32, y as i32)
+                    }
+                    glfw::WindowEvent::Scroll(_, y) => game.mouse_wheel(y as i32),
                     _ => {}
                 }
             }

--- a/runtime/functor-runtime-desktop/src/static_game.rs
+++ b/runtime/functor-runtime-desktop/src/static_game.rs
@@ -28,6 +28,27 @@ impl Game for StaticGame {
         }
     }
 
+    fn key_event(&mut self, code: i32, is_down: bool) {
+        unsafe {
+            let func: Symbol<fn(i32, bool)> = self.library.get(b"key_event").unwrap();
+            func(code, is_down)
+        }
+    }
+
+    fn mouse_move(&mut self, x: i32, y: i32) {
+        unsafe {
+            let func: Symbol<fn(i32, i32)> = self.library.get(b"mouse_move").unwrap();
+            func(x, y)
+        }
+    }
+
+    fn mouse_wheel(&mut self, delta: i32) {
+        unsafe {
+            let func: Symbol<fn(i32)> = self.library.get(b"mouse_wheel").unwrap();
+            func(delta)
+        }
+    }
+
     fn quit(&mut self) {
         // Noop - nothing to do yet
     }

--- a/src/Functor.Game/Game.fs
+++ b/src/Functor.Game/Game.fs
@@ -70,5 +70,9 @@ module GameRunner =
     let subscriptions<'model, 'msg> (game: Game<'model, 'msg>) (model: 'model) =
         game.subscriptions model
 
+    let input<'model, 'msg> (game: Game<'model, 'msg>) (model: 'model) (event: Input.t) =
+        let (newModel, effect) = game.input model event
+        (newModel, effect)
+
     let draw3d<'model, 'msg> (game: Game<'model, 'msg>) (model: 'model) (tick: Time.FrameTime) =
         game.draw3d model tick

--- a/src/Functor.Game/Game.fsi
+++ b/src/Functor.Game/Game.fsi
@@ -34,4 +34,5 @@ module GameRunner =
     val tick: Game<'model, 'msg> -> 'model -> Time.FrameTime -> ('model * effect<'msg>)
     val update: Game<'model, 'msg> -> 'model -> 'msg -> ('model * effect<'msg>)
     val subscriptions: Game<'model, 'msg> -> 'model -> Sub<'msg>
+    val input: Game<'model, 'msg> -> 'model -> Input.t -> ('model * effect<'msg>)
     val draw3d: Game<'model, 'msg> -> 'model -> Time.FrameTime -> Graphics.Scene3D

--- a/src/Functor.Game/Input.fs
+++ b/src/Functor.Game/Input.fs
@@ -1,19 +1,39 @@
 module Input
+    /// Logical key identifier. Mirrors functor_runtime_common::Key — the
+    /// runtime passes a canonical integer code across the boundary which
+    /// ofKeyCode maps back to this DU.
+    type Key =
+        | Unknown
+        | A | B | C | D | E | F | G | H | I | J | K | L | M
+        | N | O | P | Q | R | S | T | U | V | W | X | Y | Z
+        | Up | Down | Left | Right
+        | Space | Enter | Escape
+
     module KeyboardEvent =
-        type t = 
-            | KeyDown of char
-            | KeyUp of char
+        type t =
+            | KeyDown of Key
+            | KeyUp of Key
 
     module MouseEvent =
-        type t = 
+        type t =
             | MouseMove of int * int
             | MouseWheel of int
 
     // TODO: Game Controller event
     // TODO: VR Controller event
 
-    type t = 
-        | KeyboardEvent of KeyboardEvent.t
-        | MouseEvent of MouseEvent.t
+    type t =
+        | Keyboard of KeyboardEvent.t
+        | Mouse of MouseEvent.t
 
-
+    /// Map a canonical integer key code (functor_runtime_common::Key as i32)
+    /// to a Key. Must stay in sync with that enum's #[repr(i32)] values.
+    let ofKeyCode (code: int): Key =
+        match code with
+        | 1 -> A | 2 -> B | 3 -> C | 4 -> D | 5 -> E | 6 -> F | 7 -> G
+        | 8 -> H | 9 -> I | 10 -> J | 11 -> K | 12 -> L | 13 -> M
+        | 14 -> N | 15 -> O | 16 -> P | 17 -> Q | 18 -> R | 19 -> S
+        | 20 -> T | 21 -> U | 22 -> V | 23 -> W | 24 -> X | 25 -> Y | 26 -> Z
+        | 27 -> Up | 28 -> Down | 29 -> Left | 30 -> Right
+        | 31 -> Space | 32 -> Enter | 33 -> Escape
+        | _ -> Unknown

--- a/src/Functor.Game/Input.fsi
+++ b/src/Functor.Game/Input.fsi
@@ -1,18 +1,31 @@
 module Input
+    /// Logical key identifier. Mirrors functor_runtime_common::Key — the
+    /// runtime passes a canonical integer code across the boundary which
+    /// ofKeyCode maps back to this DU.
+    type Key =
+        | Unknown
+        | A | B | C | D | E | F | G | H | I | J | K | L | M
+        | N | O | P | Q | R | S | T | U | V | W | X | Y | Z
+        | Up | Down | Left | Right
+        | Space | Enter | Escape
+
     module KeyboardEvent =
-        type t = 
-            | KeyDown of char
-            | KeyUp of char
+        type t =
+            | KeyDown of Key
+            | KeyUp of Key
 
     module MouseEvent =
-        type t = 
+        type t =
             | MouseMove of int * int
             | MouseWheel of int
 
     // TODO: Game Controller event
     // TODO: VR Controller event
 
-    type t = 
-        | KeyboardEvent of KeyboardEvent.t
-        | MouseEvent of MouseEvent.t
+    type t =
+        | Keyboard of KeyboardEvent.t
+        | Mouse of MouseEvent.t
 
+    /// Map a canonical integer key code (functor_runtime_common::Key as i32)
+    /// to a Key. Must stay in sync with that enum's #[repr(i32)] values.
+    val ofKeyCode: code:int -> Key

--- a/src/Functor.Game/Runtime.fs
+++ b/src/Functor.Game/Runtime.fs
@@ -7,6 +7,7 @@ module Runtime
 
     type IRunner =
         abstract member tick: Time.FrameTime -> unit
+        abstract member input: Input.t -> unit
         abstract member render: Time.FrameTime -> Graphics.Scene3D
         abstract member getState: unit -> OpaqueState
         abstract member setState: OpaqueState -> unit
@@ -47,6 +48,29 @@ module Runtime
                 raise (System.Exception("No runner"))
 
         [<OuterAttr("wasm_bindgen")>]
+        let key_event_wasm (code: int, isDown: bool): unit =
+            if currentRunner.IsSome then
+                let key = Input.ofKeyCode code
+                let kev = if isDown then Input.KeyboardEvent.KeyDown key else Input.KeyboardEvent.KeyUp key
+                currentRunner.Value.input(Input.Keyboard kev)
+            else
+                raise (System.Exception("No runner"))
+
+        [<OuterAttr("wasm_bindgen")>]
+        let mouse_move_wasm (x: int, y: int): unit =
+            if currentRunner.IsSome then
+                currentRunner.Value.input(Input.Mouse (Input.MouseEvent.MouseMove (x, y)))
+            else
+                raise (System.Exception("No runner"))
+
+        [<OuterAttr("wasm_bindgen")>]
+        let mouse_wheel_wasm (delta: int): unit =
+            if currentRunner.IsSome then
+                currentRunner.Value.input(Input.Mouse (Input.MouseEvent.MouseWheel delta))
+            else
+                raise (System.Exception("No runner"))
+
+        [<OuterAttr("wasm_bindgen")>]
         let test_render_wasm (frameTimeJs: JsValue): JsValue =
             let frameTime = frameTimeJs |> UnsafeJsValue.from_js<Time.FrameTime>;
             if currentRunner.IsSome then 
@@ -71,6 +95,29 @@ module Runtime
             if currentRunner.IsSome then 
                 currentRunner.Value.tick(frameTime)
             else 
+                raise (System.Exception("No runner"))
+
+        [<OuterAttr("no_mangle")>]
+        let key_event(code: int, isDown: bool) =
+            if currentRunner.IsSome then
+                let key = Input.ofKeyCode code
+                let kev = if isDown then Input.KeyboardEvent.KeyDown key else Input.KeyboardEvent.KeyUp key
+                currentRunner.Value.input(Input.Keyboard kev)
+            else
+                raise (System.Exception("No runner"))
+
+        [<OuterAttr("no_mangle")>]
+        let mouse_move(x: int, y: int) =
+            if currentRunner.IsSome then
+                currentRunner.Value.input(Input.Mouse (Input.MouseEvent.MouseMove (x, y)))
+            else
+                raise (System.Exception("No runner"))
+
+        [<OuterAttr("no_mangle")>]
+        let mouse_wheel(delta: int) =
+            if currentRunner.IsSome then
+                currentRunner.Value.input(Input.Mouse (Input.MouseEvent.MouseWheel delta))
+            else
                 raise (System.Exception("No runner"))
 
         [<OuterAttr("no_mangle")>]
@@ -180,7 +227,15 @@ module Runtime
 
                 state <- newState
                 ()
-            member this.render(frameTime: Time.FrameTime) = 
+            member this.input(event: Input.t) =
+                // Feed the event through the game's pure 'input' handler. The
+                // resulting model is applied immediately; any effect it produces
+                // is enqueued and drained by the next 'tick' (alongside its own).
+                let (newState, effect) = GameRunner.input myGame state event
+                EffectQueue.enqueue effect effectQueue
+                state <- newState
+                ()
+            member this.render(frameTime: Time.FrameTime) =
                 GameRunner.draw3d myGame state frameTime
                 // printfn "Hello from GameRunner.render!"
                 // Scene3D.cube()


### PR DESCRIPTION
## What

Connects the existing-but-dead `input` hook end to end so games can receive keyboard and mouse events. This is the **plumbing slice**; an interactive sample is stacked on top.

Before this, the `Game` record had an `input` field and `Input.t` existed, but nothing called it — `IRunner` had no input method, the runtime never invoked `game.input`, and the desktop event loop threw away all key/cursor events except Escape.

## Changes

- **Canonical `Key` enum** (`#[repr(i32)]`) in `functor-runtime-common` — the single source of truth for key identity across the F#/Rust boundary and all runtimes.
- **F# `Input`** — `KeyDown of char` → `KeyDown of Key` (char couldn't express arrows/space), `Input.ofKeyCode` mirroring the Rust repr, and outer DU cases renamed `Keyboard`/`Mouse` to avoid a name clash with the submodules.
- **Runtime** — `input` added to `IRunner`; `GameExecutor` feeds events through the pure `input` handler, applies the model immediately, and enqueues any effect (drained by the next `tick`). Native `key_event`/`mouse_move`/`mouse_wheel` exports + parallel `*_wasm` exports.
- **Desktop** — `Game` trait + static/hot-reload loaders look up the new symbols; `main.rs` maps `glfw::Key` → canonical `Key`, enables scroll polling, and dispatches Key/CursorPos/Scroll events (Escape-to-close preserved).
- **`todo.md`** — documents the polling-snapshot fast follow (held-key state for movement) plus controller/VR and web JS-glue follow-ups.

## Design notes

- **Primitives at the boundary, not a shared `InputEvent` enum:** Fable-Rust constructs shim types well but can't pattern-match a foreign Rust enum, so the boundary passes ints/bools and the F# DU is built F#-side — keeping `Input.t` a real DU that game code can `match` on.
- The key numbering is a deliberate dual contract: `functor_runtime_common::Key` (producers) ↔ `Input.ofKeyCode` (the one consumer), both commented to stay in sync. Minimum unavoidable for a DU on each side of the FFI.
- `*_wasm` exports exist for parity; the browser→export JS glue is a future web slice (noted in `todo.md`).

## Testing

- F# → Rust transpile: clean
- Native dylib builds; `nm` confirms `key_event`/`mouse_move`/`mouse_wheel` exported
- `cargo build` (common + desktop) and `cargo test -p functor_runtime_common` (10 passed): green

🤖 Generated with [Claude Code](https://claude.com/claude-code)