### PR TITLE
feat(camera): return a camera from draw3d via a Frame

### DIFF
--- a/examples/hello/hello.fs
+++ b/examples/hello/hello.fs
@@ -165,18 +165,29 @@ let init (_args: array<string>) =
             |> Transform.translateZ 10.0f
             |> Transform.scale 0.004f;
 
-        group([|
-            material (textureMaterial, [|
-                cylinder() |> Transform.translateY -1.0f;
-                renderModel
-                |> Transform.rotateY (Math.Angle.degrees (180.0f + 10.0f * frameTime.tts * 0.5f))
-                |> Transform.rotateX (Math.Angle.degrees (0.0f * sin frameTime.tts * 2.0f))
+        let scene =
+            group([|
+                material (textureMaterial, [|
+                    cylinder() |> Transform.translateY -1.0f;
+                    renderModel
+                    |> Transform.rotateY (Math.Angle.degrees (180.0f + 10.0f * frameTime.tts * 0.5f))
+                    |> Transform.rotateX (Math.Angle.degrees (0.0f * sin frameTime.tts * 2.0f))
+                |])
+                |> Transform.translateZ ((sin (frameTime.tts * 5.0f)) * 1.0f)
             |])
-            |> Transform.translateZ ((sin (frameTime.tts * 5.0f)) * 1.0f)
-        |])
-        // Apply the input-driven offset: WASD / arrow keys move the scene.
-        |> Transform.translateX world.offset.x
-        |> Transform.translateY world.offset.y
+            // Apply the input-driven offset: WASD / arrow keys move the scene.
+            |> Transform.translateX world.offset.x
+            |> Transform.translateY world.offset.y
+
+        // Static camera for now; mouse free-look arrives in the next PR.
+        let camera =
+            Graphics.Camera.lookAt
+                (Vector3.xyz 0.0f 0.0f -5.0f)
+                Vector3.zero
+                (Vector3.xyz 0.0f 1.0f 0.0f)
+                (Math.Angle.degrees 45.0f)
+
+        Graphics.Frame.create camera scene
     )
     |> GameBuilder.update update
     |> GameBuilder.input input

--- a/runtime/functor-runtime-common/src/camera.rs
+++ b/runtime/functor-runtime-common/src/camera.rs
@@ -1,0 +1,74 @@
+use cgmath::{perspective, vec3, Matrix4, Point3, Rad};
+use serde::{Deserialize, Serialize};
+
+use crate::math::Angle;
+
+/// A camera description produced by the game's `draw3d`. Stores plain scalars
+/// (so it serializes cleanly across the wasm boundary); the runtime turns it
+/// into view/projection matrices at render time via `view_matrix` /
+/// `projection_matrix`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Camera {
+    pub eye: [f32; 3],
+    pub target: [f32; 3],
+    pub up: [f32; 3],
+    /// Vertical field of view, in radians.
+    pub fov_radians: f32,
+    pub near: f32,
+    pub far: f32,
+}
+
+impl Camera {
+    /// Look from `eye` toward `target`. `fov` is the vertical field of view.
+    pub fn look_at(eye: [f32; 3], target: [f32; 3], up: [f32; 3], fov: Angle) -> Camera {
+        let fov: Rad<f32> = fov.into();
+        Camera {
+            eye,
+            target,
+            up,
+            fov_radians: fov.0,
+            near: 0.1,
+            far: 100.0,
+        }
+    }
+
+    /// First-person camera looking from `eye` along a direction given by `yaw`
+    /// (rotation about +Y) and `pitch` (rotation about the local X axis).
+    /// yaw = 0, pitch = 0 looks down +Z; positive pitch looks up.
+    pub fn first_person(eye: [f32; 3], yaw: Angle, pitch: Angle, fov: Angle) -> Camera {
+        let yaw: Rad<f32> = yaw.into();
+        let pitch: Rad<f32> = pitch.into();
+        let (sin_yaw, cos_yaw) = yaw.0.sin_cos();
+        let (sin_pitch, cos_pitch) = pitch.0.sin_cos();
+        let forward = [cos_pitch * sin_yaw, sin_pitch, cos_pitch * cos_yaw];
+        let target = [
+            eye[0] + forward[0],
+            eye[1] + forward[1],
+            eye[2] + forward[2],
+        ];
+        Camera::look_at(eye, target, [0.0, 1.0, 0.0], fov)
+    }
+
+    pub fn view_matrix(&self) -> Matrix4<f32> {
+        Matrix4::look_at_rh(
+            Point3::new(self.eye[0], self.eye[1], self.eye[2]),
+            Point3::new(self.target[0], self.target[1], self.target[2]),
+            vec3(self.up[0], self.up[1], self.up[2]),
+        )
+    }
+
+    pub fn projection_matrix(&self, aspect: f32) -> Matrix4<f32> {
+        perspective(Rad(self.fov_radians), aspect, self.near, self.far)
+    }
+}
+
+impl Default for Camera {
+    fn default() -> Camera {
+        Camera::look_at(
+            [0.0, 0.0, -5.0],
+            [0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            Angle::from_degrees(45.0),
+        )
+    }
+}

--- a/runtime/functor-runtime-common/src/frame.rs
+++ b/runtime/functor-runtime-common/src/frame.rs
@@ -1,0 +1,18 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{Camera, Scene3D};
+
+/// What a game's `draw3d` returns each frame: the camera plus the scene to
+/// render. Intentionally a growable record (lights, post-processing, etc. can
+/// be added later) so the render boundary signature doesn't churn each time.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Frame {
+    pub camera: Camera,
+    pub scene: Scene3D,
+}
+
+impl Frame {
+    pub fn new(camera: Camera, scene: Scene3D) -> Frame {
+        Frame { camera, scene }
+    }
+}

--- a/runtime/functor-runtime-common/src/lib.rs
+++ b/runtime/functor-runtime-common/src/lib.rs
@@ -66,8 +66,10 @@ impl OpaqueState {
 
 pub mod animation;
 pub mod asset;
+mod camera;
 mod effect;
 mod effect_queue;
+mod frame;
 mod frame_time;
 pub mod geometry;
 mod input;
@@ -82,8 +84,10 @@ mod shader;
 mod shader_program;
 pub mod texture;
 
+pub use camera::*;
 pub use effect::*;
 pub use effect_queue::*;
+pub use frame::*;
 pub use frame_time::*;
 pub use input::*;
 pub use render_context::*;

--- a/runtime/functor-runtime-desktop/src/game.rs
+++ b/runtime/functor-runtime-desktop/src/game.rs
@@ -1,4 +1,4 @@
-use functor_runtime_common::{FrameTime, Scene3D};
+use functor_runtime_common::{Frame, FrameTime};
 
 pub trait Game {
     fn check_hot_reload(&mut self, frame_time: FrameTime);
@@ -14,7 +14,7 @@ pub trait Game {
     /// Deliver a mouse-wheel event (vertical scroll offset).
     fn mouse_wheel(&mut self, delta: i32);
 
-    fn render(&mut self, frame_time: FrameTime) -> Scene3D;
+    fn render(&mut self, frame_time: FrameTime) -> Frame;
 
     fn quit(&mut self);
 }

--- a/runtime/functor-runtime-desktop/src/hot_reload_game.rs
+++ b/runtime/functor-runtime-desktop/src/hot_reload_game.rs
@@ -6,7 +6,7 @@ use std::thread::JoinHandle;
 use std::{fs, process};
 use tempfile::tempdir;
 
-use functor_runtime_common::{FrameTime, OpaqueState, Scene3D};
+use functor_runtime_common::{Frame, FrameTime, OpaqueState};
 use libloading::{Library, Symbol};
 
 use crate::game::Game;
@@ -36,9 +36,9 @@ impl Game for HotReloadGame {
         }
     }
 
-    fn render(&mut self, frame_time: FrameTime) -> Scene3D {
+    fn render(&mut self, frame_time: FrameTime) -> Frame {
         unsafe {
-            let render_func: Symbol<fn(FrameTime) -> Scene3D> =
+            let render_func: Symbol<fn(FrameTime) -> Frame> =
                 self.library.as_ref().unwrap().get(b"test_render").unwrap();
             render_func(frame_time)
         }

--- a/runtime/functor-runtime-desktop/src/main.rs
+++ b/runtime/functor-runtime-desktop/src/main.rs
@@ -4,7 +4,6 @@ use std::env;
 use std::sync::Arc;
 use std::time::Instant;
 
-use cgmath::{perspective, vec3, Deg, Point3};
 use cgmath::{vec4, Matrix4};
 use functor_runtime_common::asset::AssetCache;
 use functor_runtime_common::material::ColorMaterial;
@@ -130,9 +129,6 @@ pub async fn main() {
 
         gl.enable(glow::DEPTH_TEST);
 
-        let projection_matrix: Matrix4<f32> =
-            perspective(Deg(45.0), SCR_WIDTH as f32 / SCR_HEIGHT as f32, 0.1, 100.0);
-
         let world_matrix = Matrix4::from_nonuniform_scale(1.0, 1.0, 1.0);
 
         let start_time = Instant::now();
@@ -194,12 +190,6 @@ pub async fn main() {
             game.tick(time.clone());
 
             gl.clear(glow::COLOR_BUFFER_BIT | glow::DEPTH_BUFFER_BIT);
-            let radius = 5.0;
-            let view_matrix: Matrix4<f32> = Matrix4::look_at_rh(
-                Point3::new(0.0, 0.0, -1.0 * radius),
-                Point3::new(0.0, 0.0, 0.0),
-                vec3(0.0, 1.0, 0.0),
-            );
 
             let render_context = functor_runtime_common::RenderContext {
                 gl: &gl,
@@ -208,7 +198,12 @@ pub async fn main() {
                 frame_time: time.clone(),
             };
 
-            let scene = game.render(time.clone());
+            // The game supplies the camera as part of its frame; derive the
+            // view/projection matrices from it.
+            let frame = game.render(time.clone());
+            let aspect = SCR_WIDTH as f32 / SCR_HEIGHT as f32;
+            let view_matrix = frame.camera.view_matrix();
+            let projection_matrix = frame.camera.projection_matrix(aspect);
 
             // TODO: Factor out to pass in current_material
             // let mut basic_material = BasicMaterial::create();
@@ -220,7 +215,7 @@ pub async fn main() {
             color_material.initialize(&render_context);
 
             functor_runtime_common::Scene3D::render(
-                &scene,
+                &frame.scene,
                 &render_context,
                 &scene_context,
                 &world_matrix,

--- a/runtime/functor-runtime-desktop/src/static_game.rs
+++ b/runtime/functor-runtime-desktop/src/static_game.rs
@@ -1,4 +1,4 @@
-use functor_runtime_common::{FrameTime, Scene3D};
+use functor_runtime_common::{Frame, FrameTime};
 use libloading::{Library, Symbol};
 
 use crate::game::Game;
@@ -12,10 +12,10 @@ impl Game for StaticGame {
         // Noop - nothing to do
     }
 
-    fn render(&mut self, frame_time: FrameTime) -> Scene3D {
+    fn render(&mut self, frame_time: FrameTime) -> Frame {
         // println!("Rendering");
         unsafe {
-            let render_func: Symbol<fn(FrameTime) -> Scene3D> =
+            let render_func: Symbol<fn(FrameTime) -> Frame> =
                 self.library.get(b"test_render").unwrap();
             render_func(frame_time)
         }

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -8,7 +8,6 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use cgmath::Matrix4;
-use cgmath::{perspective, vec3, Deg, Point3};
 use functor_runtime_common::asset::pipelines::TexturePipeline;
 use functor_runtime_common::asset::{AssetCache, AssetLoader};
 use functor_runtime_common::geometry::Geometry;
@@ -17,7 +16,7 @@ use functor_runtime_common::material::BasicMaterial;
 use functor_runtime_common::texture::{
     RuntimeTexture, Texture2D, TextureData, TextureFormat, TextureOptions, PNG,
 };
-use functor_runtime_common::{FrameTime, RenderContext, Scene3D, SceneContext};
+use functor_runtime_common::{Frame, FrameTime, RenderContext, SceneContext};
 use glow::*;
 use js_sys::{Function, Object, Reflect, WebAssembly};
 use wasm_bindgen::JsValue;
@@ -189,27 +188,19 @@ async fn run_async() -> Result<(), JsValue> {
                 frame_time: frame_time.clone(),
             };
 
-            let projection_matrix: Matrix4<f32> =
-                perspective(Deg(45.0), SCR_WIDTH as f32 / SCR_HEIGHT as f32, 0.1, 100.0);
-
             let world_matrix = Matrix4::from_nonuniform_scale(1.0, 1.0, 1.0);
 
             gl.clear(glow::COLOR_BUFFER_BIT | glow::DEPTH_BUFFER_BIT);
-            let radius = 5.0;
-            let time: f64 = performance.now() / 1000.0;
-            let view_matrix: Matrix4<f32> = Matrix4::look_at_rh(
-                Point3::new(0.0, 0.0, -1.0 * radius),
-                Point3::new(0.0, 0.0, 0.0),
-                vec3(0.0, 1.0, 0.0),
-            );
-
-            // let scene = Scene3D::cube();
 
             game_tick(functor_runtime_common::to_js_value(&frame_time));
 
             let val = game_render(functor_runtime_common::to_js_value(&frame_time));
+            let frame: Frame = functor_runtime_common::from_js_value(val);
 
-            let scene: Scene3D = functor_runtime_common::from_js_value(val);
+            // The game supplies the camera; derive view/projection from it.
+            let aspect = SCR_WIDTH as f32 / SCR_HEIGHT as f32;
+            let view_matrix = frame.camera.view_matrix();
+            let projection_matrix = frame.camera.projection_matrix(aspect);
 
             let mut basic_material = BasicMaterial::create();
             basic_material.initialize(&render_ctx);
@@ -217,7 +208,7 @@ async fn run_async() -> Result<(), JsValue> {
             // asset.get().bind(0, &render_ctx);
 
             functor_runtime_common::Scene3D::render(
-                &scene,
+                &frame.scene,
                 &render_ctx,
                 &scene_context,
                 &world_matrix,

--- a/src/Functor.Game/Camera.fs
+++ b/src/Functor.Game/Camera.fs
@@ -1,0 +1,25 @@
+namespace Graphics
+
+open Fable.Core
+open Functor.Math
+
+/// Camera description returned (inside a Frame) by a game's draw3d. A thin
+/// shim over functor_runtime_common::Camera; the runtime turns it into view
+/// and projection matrices.
+[<Erase; Emit("functor_runtime_common::Camera")>] type Camera = | Noop
+
+module Camera =
+
+    /// A sensible default camera (looks at the origin from -Z). Used as the
+    /// builder default so a game that never sets a camera still renders.
+    [<Emit("functor_runtime_common::Camera::default()")>]
+    let initial (): Camera = nativeOnly
+
+    /// Look from `eye` toward `target`, with `fov` as the vertical field of view.
+    [<Emit("functor_runtime_common::Camera::look_at([$0.x, $0.y, $0.z], [$1.x, $1.y, $1.z], [$2.x, $2.y, $2.z], $3)")>]
+    let lookAt (eye: Vector3) (target: Vector3) (up: Vector3) (fov: Math.Angle): Camera = nativeOnly
+
+    /// First-person camera: look from `eye` along a direction given by `yaw`
+    /// (about +Y) and `pitch`. yaw = 0, pitch = 0 looks down +Z.
+    [<Emit("functor_runtime_common::Camera::first_person([$0.x, $0.y, $0.z], $1, $2, $3)")>]
+    let firstPerson (eye: Vector3) (yaw: Math.Angle) (pitch: Math.Angle) (fov: Math.Angle): Camera = nativeOnly

--- a/src/Functor.Game/Frame.fs
+++ b/src/Functor.Game/Frame.fs
@@ -1,0 +1,13 @@
+namespace Graphics
+
+open Fable.Core
+
+/// What a game's draw3d returns: the camera plus the scene to render. A shim
+/// over functor_runtime_common::Frame. Built via Frame.create; grows to carry
+/// lights etc. later without changing the render boundary signature.
+[<Erase; Emit("functor_runtime_common::Frame")>] type Frame = | Noop
+
+module Frame =
+
+    [<Emit("functor_runtime_common::Frame::new($0, $1)")>]
+    let create (camera: Camera) (scene: Scene3D): Frame = nativeOnly

--- a/src/Functor.Game/Functor.Game.fsproj
+++ b/src/Functor.Game/Functor.Game.fsproj
@@ -8,10 +8,13 @@
     <Compile Include="EffectQueue.fs" />
     <Compile Include="Math/Angle.fs" />
     <Compile Include="Math/Vector2.fs" />
+    <Compile Include="Math/Vector3.fs" />
     <Compile Include="Math/Point2.fs" />
     <Compile Include="Time.fs" />
     <Compile Include="Duration.fsi" />
     <Compile Include="Scene3D.fs" />
+    <Compile Include="Camera.fs" />
+    <Compile Include="Frame.fs" />
     <Compile Include="Duration.fs" />
     <Compile Include="Platform.fs" />
     <Compile Include="Debug.fs" />

--- a/src/Functor.Game/Game.fs
+++ b/src/Functor.Game/Game.fs
@@ -15,7 +15,7 @@ type Game<'model, 'msg> = {
     tick: TickFn<'model, 'msg>
     update: UpdateFn<'model, 'msg>
     subscriptions: SubFn<'model, 'msg>
-    draw3d: 'model -> Time.FrameTime -> Graphics.Scene3D
+    draw3d: 'model -> Time.FrameTime -> Graphics.Frame
     }
 
 
@@ -26,7 +26,7 @@ module GameBuilder =
     let local initialState =
         let update model msg = (model, Effect.none ())
         let tick model tick = (model, Effect.none ())
-        let draw3d model frametime = Graphics.Scene3D.cube()
+        let draw3d model frametime = Graphics.Frame.create (Graphics.Camera.initial ()) (Graphics.Scene3D.cube())
         let input model input = (model, Effect.none ())
         let subscriptions model = Sub.none ()
         { initialState = initialState; init = Effect.none (); update = update; tick = tick; input = input; subscriptions = subscriptions; draw3d = draw3d}
@@ -43,7 +43,7 @@ module GameBuilder =
     let input<'model, 'msg> (f: InputFn<'model, 'msg>) (game: Game<'model, 'msg>) =     
         { game with input = f }
 
-    let draw3d<'model, 'msg> (f: 'model -> Time.FrameTime -> Graphics.Scene3D) (game: Game<'model, 'msg>) = 
+    let draw3d<'model, 'msg> (f: 'model -> Time.FrameTime -> Graphics.Frame) (game: Game<'model, 'msg>) =
         { game with draw3d = f }
 
     let tick<'model, 'msg> (f: TickFn<'model, 'msg>) (game: Game<'model, 'msg>) =
@@ -74,5 +74,5 @@ module GameRunner =
         let (newModel, effect) = game.input model event
         (newModel, effect)
 
-    let draw3d<'model, 'msg> (game: Game<'model, 'msg>) (model: 'model) (tick: Time.FrameTime) =
+    let draw3d<'model, 'msg> (game: Game<'model, 'msg>) (model: 'model) (tick: Time.FrameTime): Graphics.Frame =
         game.draw3d model tick

--- a/src/Functor.Game/Game.fsi
+++ b/src/Functor.Game/Game.fsi
@@ -25,7 +25,7 @@ module GameBuilder =
 
     val subscriptions: SubFn<'model, 'msg> -> Game<'model, 'msg> -> Game<'model, 'msg>
 
-    val draw3d: ('model -> Time.FrameTime -> Graphics.Scene3D) -> Game<'model, 'msg> -> Game<'model, 'msg>
+    val draw3d: ('model -> Time.FrameTime -> Graphics.Frame) -> Game<'model, 'msg> -> Game<'model, 'msg>
 
 
 module GameRunner =
@@ -35,4 +35,4 @@ module GameRunner =
     val update: Game<'model, 'msg> -> 'model -> 'msg -> ('model * effect<'msg>)
     val subscriptions: Game<'model, 'msg> -> 'model -> Sub<'msg>
     val input: Game<'model, 'msg> -> 'model -> Input.t -> ('model * effect<'msg>)
-    val draw3d: Game<'model, 'msg> -> 'model -> Time.FrameTime -> Graphics.Scene3D
+    val draw3d: Game<'model, 'msg> -> 'model -> Time.FrameTime -> Graphics.Frame

--- a/src/Functor.Game/Math/Vector3.fs
+++ b/src/Functor.Game/Math/Vector3.fs
@@ -1,0 +1,13 @@
+namespace Functor.Math
+
+type Vector3 = { x: float32; y: float32; z: float32 }
+
+module Vector3 =
+
+    let zero = { x = 0.0f; y = 0.0f; z = 0.0f }
+
+    let xyz x y z = { x = x; y = y; z = z }
+
+    let add (a: Vector3) (b: Vector3) = { x = a.x + b.x; y = a.y + b.y; z = a.z + b.z }
+
+    let scale s (v: Vector3) = { x = s * v.x; y = s * v.y; z = s * v.z }

--- a/src/Functor.Game/Runtime.fs
+++ b/src/Functor.Game/Runtime.fs
@@ -8,7 +8,7 @@ module Runtime
     type IRunner =
         abstract member tick: Time.FrameTime -> unit
         abstract member input: Input.t -> unit
-        abstract member render: Time.FrameTime -> Graphics.Scene3D
+        abstract member render: Time.FrameTime -> Graphics.Frame
         abstract member getState: unit -> OpaqueState
         abstract member setState: OpaqueState -> unit
 
@@ -135,7 +135,7 @@ module Runtime
                 raise (System.Exception("No runner"))
 
         [<OuterAttr("no_mangle")>]
-        let test_render(frameTime: Time.FrameTime): Graphics.Scene3D =
+        let test_render(frameTime: Time.FrameTime): Graphics.Frame =
             if currentRunner.IsSome then 
                 currentRunner.Value.render(frameTime)
             else 


### PR DESCRIPTION
## What

Stacked on #71. Adds a controllable camera by changing what `draw3d` returns: a growable **`Frame { camera; scene }`** instead of a bare `Scene3D`. The runtimes now derive the view/projection matrices from `frame.camera` instead of hardcoding a fixed `look_at`. This is the seam; mouse free-look lands in the PR on top.

## Changes

- **functor-runtime-common**: `Camera` (serializable scalars — eye/target/up + fov/near/far — with `view_matrix` / `projection_matrix(aspect)`), constructors `look_at`, `first_person` (yaw/pitch), and `Default`. New `Frame { camera, scene }`, deliberately a growable record so adding lights later won't churn the boundary signature again.
- **F#**: `Vector3`, `Graphics.Camera` (`lookAt` / `firstPerson` / `initial`) and `Graphics.Frame` (`create`) shims. `draw3d` / `GameBuilder.draw3d` / `GameRunner.draw3d` / `IRunner.render` and the native `test_render` + wasm `test_render_wasm` boundary now flow `Frame`.
- **Desktop + web runtimes**: build view/projection from `frame.camera`, render `frame.scene`; the hardcoded matrices are gone.
- **hello sample**: wraps its scene in a `Frame` with a static look-at camera — no visual change yet.

## Design notes

- `Camera` stores plain `[f32;3]`/`f32` (not cgmath types) so it serializes across the wasm boundary; matrices are computed on demand. cgmath 0.18 here has no serde feature.
- `Frame` must be a common type (not a Fable-generated F# record) because the desktop runtime has to read `.camera`/`.scene` in Rust — same reason `Scene3D`/`FrameTime` are shims.

## Testing

- Builds on all three targets: native runtime, native game dylib, wasm (`wasm-pack`).
- `cargo test -p functor_runtime_common`: 10 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)