### PR TITLE
feat(web): wire browser keyboard + mouse input to the game

### DIFF
--- a/runtime/functor-runtime-web/index.html
+++ b/runtime/functor-runtime-web/index.html
@@ -6,8 +6,72 @@
     <canvas id="canvas" width="640" height="480"></canvas>
     <script type="module">
 
-      import init1, { test_render_wasm, tick_wasm } from "./build-wasm/pkg/game_wasm.js";
+      import init1, {
+        test_render_wasm,
+        tick_wasm,
+        key_event_wasm,
+        mouse_move_wasm,
+        mouse_wheel_wasm
+      } from "./build-wasm/pkg/game_wasm.js";
       import startRuntime from "./pkg/functor_runtime_web.js";
+
+      // Map a browser KeyboardEvent.code to the canonical key code expected by
+      // the game (functor_runtime_common::Key as i32, decoded by
+      // Input.ofKeyCode). Keep in sync with that enum: A=1..Z=26, then the
+      // entries below. 0 = Unknown.
+      const keyCode = (code) => {
+        // "KeyA".."KeyZ" -> 1..26 ('A' is char code 65).
+        if (code.length === 4 && code.startsWith("Key")) {
+          return code.charCodeAt(3) - 64;
+        }
+        switch (code) {
+          case "ArrowUp": return 27;
+          case "ArrowDown": return 28;
+          case "ArrowLeft": return 29;
+          case "ArrowRight": return 30;
+          case "Space": return 31;
+          case "Enter": return 32;
+          case "Escape": return 33;
+          default: return 0;
+        }
+      };
+
+      const setupInput = () => {
+        const canvas = document.getElementById("canvas");
+
+        // Keyboard. Ignore auto-repeat (the game tracks held state itself), and
+        // swallow keys we handle so Space/arrows don't scroll the page.
+        window.addEventListener("keydown", (e) => {
+          const code = keyCode(e.code);
+          if (code === 0) return;
+          e.preventDefault();
+          if (!e.repeat) key_event_wasm(code, true);
+        });
+        window.addEventListener("keyup", (e) => {
+          const code = keyCode(e.code);
+          if (code === 0) return;
+          key_event_wasm(code, false);
+        });
+
+        // Mouse free-look. Pointer Lock is the browser equivalent of the
+        // desktop runtime's GLFW cursor capture: click the canvas to lock, then
+        // movementX/Y give relative motion. We accumulate it into a running
+        // position so the game's "delta = current - lastMouse" logic works the
+        // same as on native. Esc releases the lock (browser default).
+        canvas.addEventListener("click", () => canvas.requestPointerLock());
+        let ax = 0;
+        let ay = 0;
+        document.addEventListener("mousemove", (e) => {
+          ax += e.movementX;
+          ay += e.movementY;
+          mouse_move_wasm(ax, ay);
+        });
+
+        canvas.addEventListener("wheel", (e) => {
+          e.preventDefault();
+          mouse_wheel_wasm(Math.sign(e.deltaY));
+        });
+      };
 
       const initOutput = init1();
       initOutput.then((f) => {
@@ -23,6 +87,7 @@
           return tick_wasm(frameTime);
         }
 
+        setupInput();
         startRuntime();
       });
     </script>


### PR DESCRIPTION
## What

Stacked on #73. Makes the **wasm/browser** build interactive, matching native. The wasm input exports (`key_event_wasm` / `mouse_move_wasm` / `mouse_wheel_wasm`) already existed in the game bundle since the plumbing work — nothing called them. This adds the browser-side glue in `index.html`.

**No Rust/F# changes** — `index.html` only.

## Changes

- **Keyboard**: `keydown`/`keyup` map `KeyboardEvent.code` → the canonical key code (`functor_runtime_common::Key as i32`, decoded by `Input.ofKeyCode`) and call `key_event_wasm`. Auto-repeat ignored (the game tracks held state itself); handled keys `preventDefault` so Space/arrows don't scroll the page.
- **Mouse free-look** via the **Pointer Lock API** — the browser analog of the desktop runtime's GLFW cursor capture. Click the canvas to lock; `movementX/Y` deltas are accumulated into a running position fed through `mouse_move_wasm`, so the game's existing `delta = current - lastMouse` logic in `hello.fs` works **identically** across native and web.
- **Wheel** → `mouse_wheel_wasm`.

## Design note

The browser→key-code mapping is a small JS mirror of `functor_runtime_common::Key` (the third place that numbering lives, alongside the Rust enum and F# `Input.ofKeyCode`). Letters derive arithmetically (`KeyA`..`KeyZ` → 1..26); the rest are an explicit switch. Commented to keep in sync. Passing an `i32` keeps the native dylib boundary trivially FFI-safe; a string key name would unify the mapping but complicate native, so the int + JS mirror is the deliberate tradeoff.

## ⚠️ Rebuild requirement

`index.html` is embedded into the `functor` CLI via `include_bytes!`, so this only takes effect after **`npm run build:cli`** (which rebuilds the web runtime wasm and re-embeds it + the HTML). Rebuilding the game wasm alone is not enough.

## Testing

- `npm run build:cli` builds clean (HTML embeds, runtime + CLI compile).
- Game wasm bundle exports confirmed present (`key_event_wasm` / `mouse_move_wasm` / `mouse_wheel_wasm`).
- ⚠️ Not browser-verified here — needs `functor -d examples/hello run wasm` and a click-to-lock in the browser. Mouse/key **sign conventions** match the native sample (already tuned in #73).

## Base

> ⚠️ Targets \`feat/mouse-free-look\` (#73). Retarget to \`main\` once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)