### PR TITLE
feat(runtime): handle window/canvas resize via a Viewport

### DIFF
--- a/runtime/functor-runtime-common/src/camera.rs
+++ b/runtime/functor-runtime-common/src/camera.rs
@@ -72,3 +72,39 @@ impl Default for Camera {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn approx(a: f32, b: f32) -> bool {
+        (a - b).abs() < 1e-5
+    }
+
+    // Resizing should reveal more of the scene horizontally, not stretch it:
+    // a wider aspect leaves the vertical scale untouched and shrinks the
+    // horizontal scale proportionally (cgmath puts f/aspect in m[0][0], f in
+    // m[1][1]). This is the property that makes window/canvas resize correct.
+    #[test]
+    fn wider_aspect_widens_horizontally_without_stretching() {
+        let cam = Camera::default();
+        let square = cam.projection_matrix(1.0);
+        let wide = cam.projection_matrix(2.0);
+
+        // Vertical scale unchanged across aspect ratios.
+        assert!(approx(wide.y.y, square.y.y));
+        // Horizontal scale shrinks by exactly the aspect ratio (so geometry
+        // keeps its proportions; you just see more to the sides).
+        assert!(approx(wide.x.x, square.x.x / 2.0));
+    }
+
+    #[test]
+    fn projection_uses_viewport_aspect() {
+        let cam = Camera::default();
+        let viewport = crate::Viewport::new(1600, 400); // aspect 4.0
+        let direct = cam.projection_matrix(4.0);
+        let via_viewport = cam.projection_matrix(viewport.aspect());
+        assert!(approx(direct.x.x, via_viewport.x.x));
+        assert!(approx(direct.y.y, via_viewport.y.y));
+    }
+}

--- a/runtime/functor-runtime-common/src/lib.rs
+++ b/runtime/functor-runtime-common/src/lib.rs
@@ -83,6 +83,7 @@ mod scene3d;
 mod shader;
 mod shader_program;
 pub mod texture;
+mod viewport;
 
 pub use camera::*;
 pub use effect::*;
@@ -92,6 +93,7 @@ pub use frame_time::*;
 pub use input::*;
 pub use render_context::*;
 pub use scene3d::*;
+pub use viewport::*;
 
 #[cfg(test)]
 mod tests {

--- a/runtime/functor-runtime-common/src/viewport.rs
+++ b/runtime/functor-runtime-common/src/viewport.rs
@@ -1,0 +1,48 @@
+use serde::{Deserialize, Serialize};
+
+/// The drawable surface size in pixels. The runtimes query their window /
+/// canvas each frame and build one of these; rendering derives the GL viewport
+/// and the camera's projection aspect from it, so resizing "just works".
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Viewport {
+    pub width: u32,
+    pub height: u32,
+}
+
+impl Viewport {
+    pub fn new(width: u32, height: u32) -> Viewport {
+        Viewport { width, height }
+    }
+
+    /// Width-to-height ratio for the perspective projection. Guards against a
+    /// zero (or zero-height) surface — which happens transiently while a window
+    /// is minimized or a canvas hasn't been laid out yet — so we never feed a
+    /// NaN/infinity into the projection matrix.
+    pub fn aspect(&self) -> f32 {
+        if self.width == 0 || self.height == 0 {
+            1.0
+        } else {
+            self.width as f32 / self.height as f32
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn aspect_is_width_over_height() {
+        assert_eq!(Viewport::new(800, 600).aspect(), 800.0 / 600.0);
+        assert_eq!(Viewport::new(1920, 1080).aspect(), 1920.0 / 1080.0);
+    }
+
+    #[test]
+    fn aspect_guards_degenerate_sizes() {
+        // No NaN/infinity while minimized or before first layout.
+        assert_eq!(Viewport::new(800, 0).aspect(), 1.0);
+        assert_eq!(Viewport::new(0, 600).aspect(), 1.0);
+        assert_eq!(Viewport::new(0, 0).aspect(), 1.0);
+        assert!(Viewport::new(1024, 0).aspect().is_finite());
+    }
+}

--- a/runtime/functor-runtime-desktop/src/main.rs
+++ b/runtime/functor-runtime-desktop/src/main.rs
@@ -192,6 +192,13 @@ pub async fn main() {
 
             game.tick(time.clone());
 
+            // Follow window resizes: query the drawable size each frame and set
+            // the GL viewport to match. Framebuffer size is in pixels, so this
+            // handles HiDPI/retina correctly.
+            let (fb_width, fb_height) = window.get_framebuffer_size();
+            let viewport = functor_runtime_common::Viewport::new(fb_width as u32, fb_height as u32);
+            gl.viewport(0, 0, fb_width, fb_height);
+
             gl.clear(glow::COLOR_BUFFER_BIT | glow::DEPTH_BUFFER_BIT);
 
             let render_context = functor_runtime_common::RenderContext {
@@ -204,9 +211,8 @@ pub async fn main() {
             // The game supplies the camera as part of its frame; derive the
             // view/projection matrices from it.
             let frame = game.render(time.clone());
-            let aspect = SCR_WIDTH as f32 / SCR_HEIGHT as f32;
             let view_matrix = frame.camera.view_matrix();
-            let projection_matrix = frame.camera.projection_matrix(aspect);
+            let projection_matrix = frame.camera.projection_matrix(viewport.aspect());
 
             // TODO: Factor out to pass in current_material
             // let mut basic_material = BasicMaterial::create();

--- a/runtime/functor-runtime-web/index.html
+++ b/runtime/functor-runtime-web/index.html
@@ -1,9 +1,15 @@
 <html>
   <head>
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type" />
+    <style>
+      html, body { margin: 0; height: 100%; overflow: hidden; }
+      /* Fill the window; the runtime sizes the drawable buffer (and GL
+         viewport) to match this displayed size each frame, scaled for HiDPI. */
+      #canvas { display: block; width: 100%; height: 100%; }
+    </style>
   </head>
   <body>
-    <canvas id="canvas" width="640" height="480"></canvas>
+    <canvas id="canvas"></canvas>
     <script type="module">
 
       import init1, {

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -24,8 +24,6 @@ use wasm_bindgen_futures::{spawn_local, JsFuture};
 
 use wasm_bindgen::prelude::*;
 
-const SCR_WIDTH: u32 = 800;
-const SCR_HEIGHT: u32 = 600;
 fn window() -> web_sys::Window {
     web_sys::window().expect("no global `window` exists")
 }
@@ -64,7 +62,7 @@ async fn run_async() -> Result<(), JsValue> {
     // Load game
     unsafe {
         // Create a context from a WebGL2 context on wasm32 targets
-        let (gl, shader_version) = {
+        let (gl, shader_version, canvas) = {
             use wasm_bindgen::JsCast;
             let canvas = web_sys::window()
                 .unwrap()
@@ -81,7 +79,7 @@ async fn run_async() -> Result<(), JsValue> {
                 .dyn_into::<web_sys::WebGl2RenderingContext>()
                 .unwrap();
             let gl = glow::Context::from_webgl2_context(webgl2_context);
-            (gl, "#version 300 es")
+            (gl, "#version 300 es", canvas)
         };
 
         let vertex_array = gl
@@ -197,10 +195,23 @@ async fn run_async() -> Result<(), JsValue> {
             let val = game_render(functor_runtime_common::to_js_value(&frame_time));
             let frame: Frame = functor_runtime_common::from_js_value(val);
 
+            // Match the drawable buffer to the canvas's displayed (CSS) size,
+            // scaled for HiDPI, so the view follows browser/window resizes.
+            let dpr = web_sys::window().unwrap().device_pixel_ratio();
+            let draw_w = ((canvas.client_width() as f64) * dpr).round().max(0.0) as u32;
+            let draw_h = ((canvas.client_height() as f64) * dpr).round().max(0.0) as u32;
+            if canvas.width() != draw_w {
+                canvas.set_width(draw_w);
+            }
+            if canvas.height() != draw_h {
+                canvas.set_height(draw_h);
+            }
+            let viewport = functor_runtime_common::Viewport::new(canvas.width(), canvas.height());
+            gl.viewport(0, 0, viewport.width as i32, viewport.height as i32);
+
             // The game supplies the camera; derive view/projection from it.
-            let aspect = SCR_WIDTH as f32 / SCR_HEIGHT as f32;
             let view_matrix = frame.camera.view_matrix();
-            let projection_matrix = frame.camera.projection_matrix(aspect);
+            let projection_matrix = frame.camera.projection_matrix(viewport.aspect());
 
             let mut basic_material = BasicMaterial::create();
             basic_material.initialize(&render_ctx);


### PR DESCRIPTION
## What

Makes the native window and the web canvas scale properly on resize. Today both runtimes **hardcode the surface size** (`800×600`) for the projection aspect and **never call `gl.viewport`**, so resizing stretches/clips the image — and the web canvas is a fixed `640×480` (with the aspect even mismatched at `800/600`). Now both query their drawable size each frame and render to match.

Independent branch off `main` (parallel to #74; only `index.html` overlaps, minimally).

## Changes

- **common**: `Viewport { width, height }` with `aspect()` that guards zero / zero-height surfaces (minimized window, pre-layout canvas) so we never feed `NaN`/∞ into the projection.
- **desktop** (`main.rs`): per-frame `window.get_framebuffer_size()` → `gl.viewport(0,0,w,h)` + `camera.projection_matrix(viewport.aspect())`. Framebuffer size is in pixels, so HiDPI/retina is correct.
- **web** (`lib.rs` + `index.html`): canvas fills the window via CSS; the runtime sizes the drawable buffer to displayed-size × `devicePixelRatio` each frame (only when it changed) → `gl.viewport` + aspect.

Per-frame size query means resize "just works" with no event plumbing on the Rust side.

## Testing — the interesting part

Resize *looks* untestable (GPU + window + DOM), but the part that actually regresses is **pure**, so it's covered by `cargo test` (headless):

- `Viewport::aspect()` — including the zero/zero-height guard (no NaN/divide-by-zero).
- A `Camera` test locks in the **resize invariant**: a wider aspect widens the horizontal FOV while the vertical scale stays fixed — i.e. geometry keeps its proportions, you just see more to the sides (cgmath puts `f/aspect` in `m[0][0]`, `f` in `m[1][1]`). This is the property that catches stretching / swapped w&h / div-by-zero.

```
proj(2.0).y.y == proj(1.0).y.y       // vertical fixed
proj(2.0).x.x == proj(1.0).x.x / 2   // horizontal widens by aspect
Viewport{w, 0}.aspect() is finite     // no NaN
```

The imperative `gl.viewport` / DOM sizing stays in the thin shell and is verified manually (drag the native window; resize the browser). That split is the functional-core / imperative-shell principle. A heavier offscreen image-diff test (noted in `docs/todo.md`) is deliberately out of scope.

## Verification

- `cargo test -p functor_runtime_common`: 14 passed (4 new).
- Desktop runtime + web wasm (`wasm-pack`) + `functor` CLI build clean.
- ⚠️ Browser/native visual resize not automated here — needs a manual window/canvas drag. (Remember `npm run build:cli` for the web side, since `index.html` + runtime are embedded.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)