### PR TITLE
docs: sync CLAUDE.md and README.md with the current API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,15 +35,21 @@ These shape how features should be built. Weigh changes against them.
 built fluently via `GameBuilder` and handed to `Runtime.runGame`:
 
 - `initialState: 'model`
-- `input : 'model -> Input.t -> 'model * effect<'msg>`
+- `init  : effect<'msg>` — startup effect, seeded into the queue at construction so it drains
+  before the first frame; **not** re-run across a hot reload (the persisted queue is restored)
+- `input : 'model -> Input.t -> 'model * effect<'msg>` — keyboard/mouse events, applied immediately
 - `tick  : 'model -> FrameTime -> 'model * effect<'msg>` — per-frame simulation step
 - `update: 'model -> 'msg -> 'model * effect<'msg>` — handles messages produced by effects
-- `draw3d: 'model -> FrameTime -> Graphics.Scene3D` — pure scene description
+- `subscriptions: 'model -> Sub<'msg>` — declarative timers (`Sub.every`), polled each frame
+- `draw3d: 'model -> FrameTime -> Graphics.Frame` — pure frame description: a `Camera` plus a
+  `Scene3D` (`Frame.create camera scene`)
 
-`Runtime.GameExecutor` (`src/Functor.Game/Runtime.fs`) is the heart of the loop. Each `tick` it
-**drains the effect queue to a fixed point** (capped at `maxEffectsPerFrame = 1000` to avoid
-hangs), feeding each resulting message through `update`, then runs `tick` on the settled state.
-Effects produce `'msg` arrays via `Effect.run`; new effects are re-enqueued.
+`Runtime.GameExecutor` (`src/Functor.Game/Runtime.fs`) is the heart of the loop. Each `tick` it:
+(1) **drains the effect queue to a fixed point** (capped at `maxEffectsPerFrame = 1000` to avoid
+hangs), feeding each resulting message through `update`; (2) polls `subscriptions` on the settled
+model, enqueueing a message for each timer that crossed a boundary since last frame, and drains
+again; (3) runs `tick` on the settled state. Effects produce `'msg` arrays via `Effect.run`; new
+effects are re-enqueued.
 
 **The F#→Rust boundary is thin bindings, not reimplementations.** Many `Functor.Game` types are
 `[<Erase; Emit(...)>]` shims over Rust runtime types. For example `EffectQueue.fs` and the
@@ -57,22 +63,23 @@ lives in the Rust runtime, with an F# `Emit` binding mirroring its signature —
 **both the model and the pending effect queue** into an `OpaqueState` so in-flight effects survive
 the reload. Preserve this contract when touching executor state.
 
-**Two runtime exports.** `Runtime.Native` exposes `no_mangle` functions (`tick`, `test_render`,
-`emit_state`, `set_state`) for the dylib; `Runtime.Wasm` exposes `wasm_bindgen` functions
-(`tick_wasm`, `test_render_wasm`) that marshal `FrameTime`/`Scene3D` through JsValue. New runtime
-entry points generally need a parallel native + wasm pair.
+**Two runtime exports.** `Runtime.Native` exposes `no_mangle` functions (`tick`, `key_event`,
+`mouse_move`, `mouse_wheel`, `test_render`, `emit_state`, `set_state`) for the dylib;
+`Runtime.Wasm` exposes `wasm_bindgen` equivalents with a `_wasm` suffix (no state pair —
+hot-reload is native-only) that marshal `FrameTime`/`Frame` through JsValue. New runtime entry
+points generally need a parallel native + wasm pair.
 
 ### Layout
 
 | Path | What it is |
 | --- | --- |
-| `src/Functor.Game/` | The F# game framework (`Game`, `Runtime`, `Scene3D`/`Graphics`, `Input`, `Effect`, `EffectQueue`, `Math`, `Time`) |
+| `src/Functor.Game/` | The F# game framework (`Game`, `Runtime`, `Scene3D`/`Graphics`, `Frame`, `Camera`, `Input`, `Effect`, `EffectQueue`, `Sub`, `Math`, `Time`) |
 | `src/` | `functor-lib` — Rust crate Fable emits from `Functor.Game` (lib path is the generated `Platform.rs`) |
 | `runtime/functor-runtime-common/` | Shared Rust runtime: rendering, assets, geometry, materials, `Effect`/`EffectQueue` |
 | `runtime/functor-runtime-desktop/` | Desktop runtime → the `functor-runner` binary (GLFW/OpenGL) |
 | `runtime/functor-runtime-web/` | Web runtime (WebGL2) → wasm bundle |
 | `cli/` | The `functor` CLI (`build`/`run`/`develop`/`init`) |
-| `examples/hello/` | Sample game (Pong-style demo in `hello.fs`); `build-native/` and `build-wasm/` are the per-target compile crates |
+| `examples/hello/` | Sample game (`hello.fs` — Pong-style scene with a WASD + mouse free-look camera); `build-native/` and `build-wasm/` are the per-target compile crates |
 
 The `.fs`/`.fsi` pairs in `src/Functor.Game/` use the `.fsi` signature file as the public API — update both when changing a module's surface.
 
@@ -136,3 +143,4 @@ Test modules live alongside source (`effect.rs`, `effect_queue.rs`, `model/skele
   that compile the generated `../hello.rs` as a `dylib`/`cdylib` respectively; they are not part of
   the root workspace.
 - `cli/src/main.rs`'s `Init` command is currently a TODO stub.
+- `AGENTS.md` is a symlink to this file — edit `CLAUDE.md` only.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,12 +44,11 @@ built fluently via `GameBuilder` and handed to `Runtime.runGame`:
 - `draw3d: 'model -> FrameTime -> Graphics.Frame` — pure frame description: a `Camera` plus a
   `Scene3D` (`Frame.create camera scene`)
 
-`Runtime.GameExecutor` (`src/Functor.Game/Runtime.fs`) is the heart of the loop. Each `tick` it:
-(1) **drains the effect queue to a fixed point** (capped at `maxEffectsPerFrame = 1000` to avoid
-hangs), feeding each resulting message through `update`; (2) polls `subscriptions` on the settled
-model, enqueueing a message for each timer that crossed a boundary since last frame, and drains
-again; (3) runs `tick` on the settled state. Effects produce `'msg` arrays via `Effect.run`; new
-effects are re-enqueued.
+`Runtime.GameExecutor` (`src/Functor.Game/Runtime.fs`) is the heart of the loop: each frame it
+**drains the effect queue to a fixed point** (capped at `maxEffectsPerFrame = 1000` to avoid
+hangs), feeding messages through `update` and re-enqueueing new effects, before running `tick` on
+the settled state. The exact per-frame ordering (subscriptions are polled between drains) is
+documented by comments in the executor itself.
 
 **The F#→Rust boundary is thin bindings, not reimplementations.** Many `Functor.Game` types are
 `[<Erase; Emit(...)>]` shims over Rust runtime types. For example `EffectQueue.fs` and the
@@ -63,11 +62,10 @@ lives in the Rust runtime, with an F# `Emit` binding mirroring its signature —
 **both the model and the pending effect queue** into an `OpaqueState` so in-flight effects survive
 the reload. Preserve this contract when touching executor state.
 
-**Two runtime exports.** `Runtime.Native` exposes `no_mangle` functions (`tick`, `key_event`,
-`mouse_move`, `mouse_wheel`, `test_render`, `emit_state`, `set_state`) for the dylib;
-`Runtime.Wasm` exposes `wasm_bindgen` equivalents with a `_wasm` suffix (no state pair —
-hot-reload is native-only) that marshal `FrameTime`/`Frame` through JsValue. New runtime entry
-points generally need a parallel native + wasm pair.
+**Two runtime exports.** `Runtime.Native` exposes `no_mangle` functions for the dylib;
+`Runtime.Wasm` exposes `wasm_bindgen` equivalents (`_wasm` suffix, marshalling through JsValue;
+no state pair — hot-reload is native-only). New runtime entry points generally need a parallel
+native + wasm pair — see both modules in `Runtime.fs` for the current list.
 
 ### Layout
 
@@ -96,11 +94,7 @@ dotnet tool restore           # one-time: install the Fable local tool
 `include_bytes!`, so the wasm bundle must exist before the `functor` binary is built:
 
 ```sh
-npm run build:cli
-# equivalent to, in order:
-#   cargo build --bin functor-runner
-#   wasm-pack build runtime/functor-runtime-web --target=web
-#   cargo build --bin functor
+npm run build:cli   # functor-runner, then the wasm bundle, then the functor CLI
 ```
 
 Produces `target/debug/functor` (CLI) and `target/debug/functor-runner` (desktop runtime). The CLI
@@ -122,15 +116,8 @@ dylib via `functor-runner`, wasm serves the bundle.
 **Transpile F# only:** `npm run build:examples:hello:rust`
 (`dotnet fable examples/hello/hello.fsproj --lang rust --outDir .`).
 
-**Tests** (Rust, in `functor-runtime-common`):
-
-```sh
-cargo test                                    # whole workspace
-cargo test -p functor_runtime_common          # one crate
-cargo test -p functor_runtime_common effect    # tests matching "effect"
-```
-
-Test modules live alongside source (`effect.rs`, `effect_queue.rs`, `model/skeleton.rs`, `lib.rs`).
+**Tests** are Rust, in `functor-runtime-common`, with test modules alongside source:
+`cargo test -p functor_runtime_common`.
 
 ## Gotchas
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,26 @@ transpiles that F# to **Rust**, which is then compiled to one of two targets:
   with hot-reloading for fast iteration.
 - **wasm** — a WebAssembly bundle (built with `wasm-pack`) served to the browser (WebGL2).
 
+## Writing a game
+
+Games follow an Elm-style MVU loop: your model is immutable, and `input`/`tick`/`update` are pure
+functions that return a new model plus an `effect` (which can produce messages handled by
+`update`). `draw3d` describes a frame — a camera plus a scene — from the model. A game is built
+fluently with `GameBuilder`:
+
+```fsharp
+GameBuilder.local initialModel
+|> GameBuilder.init (Effect.wrapped Start)  // startup effect, run once before the first frame
+|> GameBuilder.input input                  // 'model -> Input.t      -> 'model * effect<'msg>
+|> GameBuilder.tick tick                    // 'model -> FrameTime    -> 'model * effect<'msg>
+|> GameBuilder.update update                // 'model -> 'msg         -> 'model * effect<'msg>
+|> GameBuilder.subscriptions subscriptions  // 'model -> Sub<'msg>    (timers, e.g. Sub.every)
+|> GameBuilder.draw3d draw3d                // 'model -> FrameTime    -> Graphics.Frame
+|> Runtime.runGame
+```
+
+See `examples/hello/hello.fs` for a complete game using all of these.
+
 ## Design principles
 
 - **Functional-core, imperative shell.** As much functionality as possible lives in the pure
@@ -25,13 +45,13 @@ transpiles that F# to **Rust**, which is then compiled to one of two targets:
 
 | Path | What it is |
 | --- | --- |
-| `src/Functor.Game/` | The F# game framework (`Game`, `Scene3D`, `Input`, `Effect`, `Math`, …) |
+| `src/Functor.Game/` | The F# game framework (`Game`, `Scene3D`, `Camera`, `Input`, `Effect`, `Sub`, `Math`, …) |
 | `src/` | `functor-lib` — the Rust crate produced by Fable from `Functor.Game` |
 | `runtime/functor-runtime-common/` | Shared Rust runtime: rendering, assets, geometry, materials |
 | `runtime/functor-runtime-desktop/` | Desktop runtime; builds the `functor-runner` binary (native/GLFW) |
 | `runtime/functor-runtime-web/` | Web runtime (WebGL2); built into a wasm bundle |
-| `cli/` | The `functor` CLI (`build` / `run` / `develop` / `init`) |
-| `examples/hello/` | Sample game — a Pong-style demo in `hello.fs` |
+| `cli/` | The `functor` CLI (`build` / `run` / `develop`; `init` is not yet implemented) |
+| `examples/hello/` | Sample game (`hello.fs`) — a Pong-style scene with a WASD + mouse free-look camera |
 
 ## Prerequisites
 
@@ -106,6 +126,6 @@ The CLI operates on a directory containing a `functor.json`. Point it at the exa
 3. (native) `functor-runner` loads the resulting `libgame_native` dylib;
    (wasm) a dev server serves the bundle to the browser.
 
-# Credits
+## Credits
 
 - Demo assets are from [BabylonJS Assets](https://github.com/BabylonJS/Assets/)


### PR DESCRIPTION
## Summary

The docs had drifted from the code after the recent input/camera work (#70–#74). This PR brings both files back in sync, adds a short "Writing a game" overview to the README, and trims CLAUDE.md's drift-prone enumerations.

**Corrections:**
- `draw3d` returns `Graphics.Frame` (camera + scene, per #72), not `Scene3D`
- The `Game` record gained `init` (startup effect, seeded at construction, not re-run across hot reload) and `subscriptions` (`Sub.every` timers)
- Runtime export docs note the input entry points and that the wasm side has no state pair (hot-reload is native-only)
- `examples/hello` description updated: it's now interactive with WASD movement and a mouse free-look camera
- Layout-table module lists include `Frame`, `Camera`, `Sub`

**Improvements:**
- README: new "Writing a game" section showing the `GameBuilder` pipeline with each function's signature
- README: note that `functor init` is not yet implemented; fix `Credits` heading level
- CLAUDE.md: gotcha noting `AGENTS.md` is a symlink to `CLAUDE.md`

**Trim (second commit):** cut CLAUDE.md content that duplicates what's trivially readable from the code and would silently go stale — the runtime export function list (the durable rule is the native+wasm pairing), the executor's per-frame step ordering (now documented by comments in `Runtime.fs`), the `npm run build:cli` expansion (duplicates `package.json`), and the generic `cargo test` variants.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
