### PR TITLE
fix(cli): report child process failures instead of always printing Done

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -87,9 +87,17 @@ async fn main() -> tokio::io::Result<()> {
                 .await
         }
     };
-    println!("Done");
 
-    Ok(())
+    match res {
+        Ok(()) => {
+            println!("Done");
+            Ok(())
+        }
+        Err(error) => {
+            eprintln!("Failed: {}", error);
+            process::exit(1);
+        }
+    }
 }
 
 fn validate_metadata_path(working_directory: &PathBuf) -> PathBuf {

--- a/cli/src/util/shell_command.rs
+++ b/cli/src/util/shell_command.rs
@@ -44,6 +44,21 @@ impl<'A> ShellCommand<'A> {
             // Wait for process to finish
             tokio::spawn(stdout_handle).await?;
             tokio::spawn(stderr_handle).await?;
+
+            let status = child.wait().await?;
+            if !status.success() {
+                let detail = describe_exit(&status);
+                eprintln!(
+                    "{}: {} {}",
+                    command_spec.prefix.red(),
+                    command_spec.cmd,
+                    detail
+                );
+                return Err(Error::new(
+                    io::ErrorKind::Other,
+                    format!("{} {}", command_spec.cmd, detail),
+                ));
+            }
         }
 
         Ok(())
@@ -85,6 +100,30 @@ impl<'A> ShellCommand<'A> {
 
         Ok(())
     }
+}
+
+fn describe_exit(status: &std::process::ExitStatus) -> String {
+    if let Some(code) = status.code() {
+        return format!("failed with exit code {}", code);
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        if let Some(signal) = status.signal() {
+            let name = match signal {
+                4 => " (SIGILL: illegal instruction)",
+                6 => " (SIGABRT: abort — often a Rust panic)",
+                8 => " (SIGFPE: arithmetic error)",
+                10 => " (SIGBUS: bus error)",
+                11 => " (SIGSEGV: segmentation fault)",
+                _ => "",
+            };
+            return format!("terminated by signal {}{}", signal, name);
+        }
+    }
+
+    "exited abnormally".to_string()
 }
 
 async fn handle_output(prefix: String, stream: impl tokio::io::AsyncRead + Unpin, is_stdout: bool) {


### PR DESCRIPTION
Previously `functor run native` printed `Done` and exited 0 even when `functor-runner` was killed by a segfault — the CLI never awaited the child's exit status, so crashes were indistinguishable from clean exits.

- `ShellCommand::run_sequential` now waits on the child and, on failure, prints which command failed and how (exit code, or signal number with a name for the common ones: SIGSEGV, SIGABRT, …) and returns an error.
- `main` no longer ignores the command result: it prints `Failed: …` and exits 1.

Verified by running `functor -d examples/hello run native` and sending the runner SIGSEGV:

```
[Functor Runner]: ...functor-runner terminated by signal 11 (SIGSEGV: segmentation fault)
Failed: ...functor-runner terminated by signal 11 (SIGSEGV: segmentation fault)
(exit code 1)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)