### PR TITLE
feat(cli): headless glTF model inspector (functor inspect model)

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,3 +15,4 @@ serde_json = "1.0.117"
 tokio = { version = "1", features = ["full"] }
 libloading = "0.8.3"
 warp = "0.3.7"
+functor_runtime_common = { path = "../runtime/functor-runtime-common" }

--- a/cli/src/commands/inspect.rs
+++ b/cli/src/commands/inspect.rs
@@ -1,0 +1,90 @@
+use std::fs;
+use std::io;
+use std::path::Path;
+
+use functor_runtime_common::inspect::{inspect_model, Aabb, ModelReport};
+
+/// Inspect a glTF/glb model on the CPU and print a text report. No GL context
+/// is created, so this is safe to run headless (CI / scripts / LLMs).
+pub async fn execute_model(path: &str, time: Option<f32>) -> io::Result<()> {
+    let model_path = Path::new(path);
+    if !model_path.exists() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("Model not found: {}", path),
+        ));
+    }
+
+    let bytes = fs::read(model_path)?;
+
+    let report = inspect_model(bytes, time)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+    print_report(path, &report);
+    Ok(())
+}
+
+fn format_aabb(aabb: &Aabb) -> String {
+    if aabb.is_empty() {
+        return "<empty>".to_string();
+    }
+    format!(
+        "min ({:.4}, {:.4}, {:.4})  max ({:.4}, {:.4}, {:.4})",
+        aabb.min.x, aabb.min.y, aabb.min.z, aabb.max.x, aabb.max.y, aabb.max.z
+    )
+}
+
+fn print_report(path: &str, report: &ModelReport) {
+    println!("Model: {}", path);
+    println!();
+
+    println!("Meshes: {}", report.mesh_count);
+    println!("Primitives: {}", report.primitives.len());
+    for (i, p) in report.primitives.iter().enumerate() {
+        println!(
+            "  [{}] {} - vertices: {}, indices: {}, joints: {}, weights: {}, skinned: {}",
+            i,
+            p.mesh_name,
+            p.vertex_count,
+            p.index_count,
+            p.joint_count,
+            p.weight_count,
+            p.has_skinning,
+        );
+    }
+    println!();
+
+    if report.has_skeleton {
+        println!("Skeleton: present ({} joints)", report.joint_count);
+    } else {
+        println!("Skeleton: none");
+    }
+    println!();
+
+    if report.animations.is_empty() {
+        println!("Animations: none");
+    } else {
+        println!("Animations: {}", report.animations.len());
+        for a in &report.animations {
+            println!("  - {} ({:.4}s)", a.name, a.duration);
+        }
+    }
+    println!();
+
+    println!("Static AABB: {}", format_aabb(&report.static_aabb));
+
+    match &report.skinned_aabb {
+        Some(s) => {
+            println!(
+                "Skinned AABB @ t={:.4} (anim '{}', sampled {:.4}s): {}",
+                s.requested_time,
+                s.animation_name,
+                s.sampled_time,
+                format_aabb(&s.aabb),
+            );
+        }
+        None => {
+            println!("Skinned AABB: not computed (no --time, or model is not animated/skinned)");
+        }
+    }
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod build;
 pub mod develop;
+pub mod inspect;
 pub mod run;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -49,11 +49,41 @@ enum Command {
         #[arg(value_enum)]
         environment: Option<Environment>,
     },
+    /// Inspect assets headlessly (no GPU/GL context).
+    Inspect {
+        #[command(subcommand)]
+        target: InspectTarget,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum InspectTarget {
+    /// Load a glTF/glb model and print a CPU-side text report.
+    Model {
+        /// Path to the .glb / .gltf file.
+        #[arg()]
+        path: String,
+
+        /// Sample the skinned AABB at this time (seconds) for animated models.
+        #[arg(long)]
+        time: Option<f32>,
+    },
 }
 
 #[tokio::main]
 async fn main() -> tokio::io::Result<()> {
     let args = Args::parse();
+
+    // `inspect` operates on an arbitrary asset path and does not need a game
+    // project, so handle it before the functor.json validation below.
+    if let Command::Inspect { target } = &args.command {
+        let res = match target {
+            InspectTarget::Model { path, time } => {
+                commands::inspect::execute_model(path, *time).await
+            }
+        };
+        return finish(res);
+    }
 
     let working_directory = get_working_directory(&args);
     let functor_json_path = validate_metadata_path(&working_directory);
@@ -86,8 +116,14 @@ async fn main() -> tokio::io::Result<()> {
             commands::develop::execute(&working_directory_str, &Environment::default(environment))
                 .await
         }
+        // Handled earlier (before functor.json validation).
+        Command::Inspect { .. } => unreachable!(),
     };
 
+    finish(res)
+}
+
+fn finish(res: io::Result<()>) -> tokio::io::Result<()> {
     match res {
         Ok(()) => {
             println!("Done");

--- a/runtime/functor-runtime-common/src/inspect.rs
+++ b/runtime/functor-runtime-common/src/inspect.rs
@@ -1,0 +1,487 @@
+//! Headless, CPU-only glTF/glb inspection.
+//!
+//! This mirrors the *pure* parsing in
+//! [`crate::asset::pipelines::model_pipeline`] (positions / indices / joints /
+//! weights and the skeleton), but deliberately avoids anything that needs a GL
+//! context (no `Texture2D`, no GL mesh buffers). The result is a plain data
+//! struct that can be formatted to text by callers (e.g. the CLI), so models
+//! can be inspected from scripts, CI, or LLMs without a GPU window.
+
+use std::collections::HashMap;
+use std::io::Cursor;
+
+use cgmath::{vec3, vec4, Matrix4, Quaternion, Vector3, Vector4};
+use gltf::buffer::Source as BufferSource;
+
+use crate::animation::{Animation, AnimationChannel, AnimationProperty, AnimationValue, Keyframe};
+use crate::model::{Skeleton, SkeletonBuilder};
+
+/// An axis-aligned bounding box in model space.
+#[derive(Clone, Copy, Debug)]
+pub struct Aabb {
+    pub min: Vector3<f32>,
+    pub max: Vector3<f32>,
+}
+
+impl Aabb {
+    fn empty() -> Aabb {
+        Aabb {
+            min: vec3(f32::INFINITY, f32::INFINITY, f32::INFINITY),
+            max: vec3(f32::NEG_INFINITY, f32::NEG_INFINITY, f32::NEG_INFINITY),
+        }
+    }
+
+    fn extend(&mut self, p: Vector3<f32>) {
+        self.min.x = self.min.x.min(p.x);
+        self.min.y = self.min.y.min(p.y);
+        self.min.z = self.min.z.min(p.z);
+        self.max.x = self.max.x.max(p.x);
+        self.max.y = self.max.y.max(p.y);
+        self.max.z = self.max.z.max(p.z);
+    }
+
+    /// True if no points were ever added.
+    pub fn is_empty(&self) -> bool {
+        self.min.x > self.max.x
+    }
+}
+
+/// A single skinned vertex, kept CPU-side for AABB computation.
+struct SkinnedVertex {
+    position: Vector3<f32>,
+    joint_indices: Vector4<f32>,
+    weights: Vector4<f32>,
+}
+
+/// Per-primitive inspection report.
+#[derive(Clone, Debug)]
+pub struct PrimitiveReport {
+    /// The owning mesh's name (glTF names live on the mesh, not the primitive).
+    pub mesh_name: String,
+    pub vertex_count: usize,
+    pub index_count: usize,
+    pub joint_count: usize,
+    pub weight_count: usize,
+    /// True when the primitive carries both JOINTS_0 and WEIGHTS_0.
+    pub has_skinning: bool,
+}
+
+/// A single animation's summary.
+#[derive(Clone, Debug)]
+pub struct AnimationReport {
+    pub name: String,
+    pub duration: f32,
+}
+
+/// The full model inspection report.
+#[derive(Clone, Debug)]
+pub struct ModelReport {
+    pub primitives: Vec<PrimitiveReport>,
+    pub mesh_count: usize,
+    /// Number of joints in the skeleton (0 if no skeleton).
+    pub joint_count: i32,
+    pub has_skeleton: bool,
+    pub animations: Vec<AnimationReport>,
+    /// Model-space AABB of the static (bind-pose) mesh positions.
+    pub static_aabb: Aabb,
+    /// Skinned AABB at the requested time, if `--time` was given and the model
+    /// is skinned and has at least one animation.
+    pub skinned_aabb: Option<SkinnedAabbReport>,
+}
+
+/// The skinned AABB plus the context used to produce it.
+#[derive(Clone, Debug)]
+pub struct SkinnedAabbReport {
+    pub animation_name: String,
+    pub requested_time: f32,
+    /// The time actually sampled (`requested_time % duration`).
+    pub sampled_time: f32,
+    pub aabb: Aabb,
+}
+
+/// Inspect a glb/glTF byte buffer. When `time` is `Some` and the model is
+/// skinned with at least one animation, the skinned AABB at that time is also
+/// computed.
+pub fn inspect_model(bytes: Vec<u8>, time: Option<f32>) -> Result<ModelReport, String> {
+    let cursor = Cursor::new(bytes);
+    let gltf = gltf::Gltf::from_slice(cursor.get_ref())
+        .map_err(|e| format!("Failed to parse glTF/glb: {}", e))?;
+    let document = gltf.document;
+    let blob = gltf.blob;
+
+    // Resolve buffers. Only embedded (.glb binary blob) buffers are supported;
+    // external .bin URIs would require resolving relative to the file.
+    let mut buffers_data = Vec::new();
+    for buffer in document.buffers() {
+        let data = match buffer.source() {
+            BufferSource::Bin => blob
+                .as_ref()
+                .ok_or_else(|| "No binary blob in GLB file".to_string())?
+                .clone(),
+            BufferSource::Uri(uri) => {
+                return Err(format!(
+                    "External buffers are not supported by the inspector: {}",
+                    uri
+                ));
+            }
+        };
+        buffers_data.push(gltf::buffer::Data(data));
+    }
+
+    let mut primitives: Vec<PrimitiveReport> = Vec::new();
+    let mut skinned_vertices: Vec<SkinnedVertex> = Vec::new();
+    let mut static_aabb = Aabb::empty();
+    let mut mesh_count: usize = 0;
+    let mut maybe_skeleton: Option<Skeleton> = None;
+
+    for scene in document.scenes() {
+        for node in scene.nodes() {
+            inspect_node(
+                &node,
+                &buffers_data,
+                &mut primitives,
+                &mut skinned_vertices,
+                &mut static_aabb,
+                &mut mesh_count,
+                &mut maybe_skeleton,
+            );
+        }
+    }
+
+    let animations = process_animations(&document, &buffers_data);
+
+    let has_skeleton = maybe_skeleton.is_some();
+    let skeleton = maybe_skeleton.unwrap_or_else(Skeleton::empty);
+    let joint_count = skeleton.get_joint_count();
+
+    let any_skinned = primitives.iter().any(|p| p.has_skinning);
+
+    // Compute the skinned AABB only when asked for a time, the mesh is skinned,
+    // and there is an animation to sample.
+    let skinned_aabb = match time {
+        Some(t) if any_skinned && has_skeleton && !animations.is_empty() => {
+            let animation = &animations[0];
+            let sampled_time = if animation.duration > 0.0 {
+                t.rem_euclid(animation.duration)
+            } else {
+                0.0
+            };
+            let animated = Skeleton::animate(&skeleton, animation, sampled_time);
+            let skinning_transforms = animated.get_skinning_transforms();
+
+            let mut aabb = Aabb::empty();
+            for v in &skinned_vertices {
+                let p = skin_position(v, &skinning_transforms);
+                aabb.extend(p);
+            }
+
+            Some(SkinnedAabbReport {
+                animation_name: animation.name.clone(),
+                requested_time: t,
+                sampled_time,
+                aabb,
+            })
+        }
+        _ => None,
+    };
+
+    let animation_reports = animations
+        .iter()
+        .map(|a| AnimationReport {
+            name: a.name.clone(),
+            duration: a.duration,
+        })
+        .collect();
+
+    Ok(ModelReport {
+        primitives,
+        mesh_count,
+        joint_count,
+        has_skeleton,
+        animations: animation_reports,
+        static_aabb,
+        skinned_aabb,
+    })
+}
+
+/// Transform a skinned vertex's position by the weighted sum of its joint
+/// matrices. This mirrors the skinned vertex shader in
+/// [`crate::material::skinned_material`]:
+/// `skinMatrix = sum(weight_i * jointTransforms[jointIndex_i])`.
+fn skin_position(v: &SkinnedVertex, skinning_transforms: &[Matrix4<f32>]) -> Vector3<f32> {
+    let identity = Matrix4::from_scale(1.0);
+    let joint = |i: f32| -> Matrix4<f32> {
+        let idx = i as usize;
+        skinning_transforms.get(idx).copied().unwrap_or(identity)
+    };
+
+    let skin_matrix = joint(v.joint_indices.x) * v.weights.x
+        + joint(v.joint_indices.y) * v.weights.y
+        + joint(v.joint_indices.z) * v.weights.z
+        + joint(v.joint_indices.w) * v.weights.w;
+
+    let p = skin_matrix * vec4(v.position.x, v.position.y, v.position.z, 1.0);
+    vec3(p.x, p.y, p.z)
+}
+
+fn inspect_node(
+    node: &gltf::Node,
+    buffers: &[gltf::buffer::Data],
+    primitives: &mut Vec<PrimitiveReport>,
+    skinned_vertices: &mut Vec<SkinnedVertex>,
+    static_aabb: &mut Aabb,
+    mesh_count: &mut usize,
+    maybe_skeleton: &mut Option<Skeleton>,
+) {
+    if let Some(mesh) = node.mesh() {
+        *mesh_count += 1;
+        let mesh_name = mesh.name().unwrap_or("<no name>").to_owned();
+
+        for primitive in mesh.primitives() {
+            let reader = primitive.reader(|buffer| Some(&buffers[buffer.index()]));
+
+            let positions = reader
+                .read_positions()
+                .map(|v| v.collect::<Vec<_>>())
+                .unwrap_or_default();
+
+            let indices = reader
+                .read_indices()
+                .map(|v| v.into_u32().collect::<Vec<_>>())
+                .unwrap_or_default();
+
+            let joints = reader
+                .read_joints(0)
+                .map(|v| v.into_u16().collect::<Vec<_>>())
+                .unwrap_or_default();
+
+            let weights = reader
+                .read_weights(0)
+                .map(|v| v.into_f32().collect::<Vec<_>>())
+                .unwrap_or_default();
+
+            let has_skinning = !joints.is_empty() && !weights.is_empty();
+
+            // Static AABB from raw bind-pose positions, and keep skinned
+            // vertices for the optional animated AABB. We replicate the
+            // pipeline's defaults (weight all on joint 0 when absent) so the
+            // skinned math matches the runtime.
+            for (i, pos) in positions.iter().enumerate() {
+                let position = vec3(pos[0], pos[1], pos[2]);
+                static_aabb.extend(position);
+
+                let joint = joints.get(i).copied().unwrap_or([0, 0, 0, 0]);
+                let weight = weights.get(i).copied().unwrap_or([1.0, 0.0, 0.0, 0.0]);
+                skinned_vertices.push(SkinnedVertex {
+                    position,
+                    joint_indices: vec4(
+                        joint[0] as f32,
+                        joint[1] as f32,
+                        joint[2] as f32,
+                        joint[3] as f32,
+                    ),
+                    weights: vec4(weight[0], weight[1], weight[2], weight[3]),
+                });
+            }
+
+            primitives.push(PrimitiveReport {
+                mesh_name: mesh_name.clone(),
+                vertex_count: positions.len(),
+                index_count: indices.len(),
+                joint_count: joints.len(),
+                weight_count: weights.len(),
+                has_skinning,
+            });
+        }
+    }
+
+    if let Some(skin) = node.skin() {
+        let reader = skin.reader(|buffer| Some(&buffers[buffer.index()]));
+
+        let inverse_bind_matrices = reader
+            .read_inverse_bind_matrices()
+            .map(|v| v.map(Matrix4::from).collect::<Vec<Matrix4<f32>>>())
+            .unwrap_or_default();
+
+        let joints = skin.joints().collect::<Vec<_>>();
+
+        let mut joint_index_to_parent_index: HashMap<usize, usize> = HashMap::new();
+        for joint in joints.iter() {
+            for child in joint.children() {
+                joint_index_to_parent_index.insert(child.index(), joint.index());
+            }
+        }
+
+        let mut skeleton_builder = SkeletonBuilder::create(inverse_bind_matrices);
+
+        for (i, joint) in joints.iter().enumerate() {
+            let name = joint.name().unwrap_or("None");
+            let transform = joint.transform().matrix().into();
+            let parent_index_i32 = joint_index_to_parent_index
+                .get(&joint.index())
+                .map(|u| *u as i32);
+
+            skeleton_builder.add_joint(
+                i,
+                joint.index() as i32,
+                name.to_owned(),
+                parent_index_i32,
+                transform,
+            );
+        }
+
+        *maybe_skeleton = Some(skeleton_builder.build());
+    }
+
+    for child in node.children() {
+        inspect_node(
+            &child,
+            buffers,
+            primitives,
+            skinned_vertices,
+            static_aabb,
+            mesh_count,
+            maybe_skeleton,
+        );
+    }
+}
+
+/// CPU parse of animation channels. Identical in structure to the model
+/// pipeline's `process_animations`, kept here so the inspector does not depend
+/// on the GL-bound pipeline.
+fn process_animations(document: &gltf::Document, buffers: &[gltf::buffer::Data]) -> Vec<Animation> {
+    let mut animations = Vec::new();
+
+    for animation in document.animations() {
+        let animation_name = animation.name().unwrap_or("Unnamed Animation").to_owned();
+        let mut channels = Vec::new();
+        let mut max_time = 0.0;
+
+        for channel in animation.channels() {
+            let target = channel.target();
+            let node_index = target.node().index();
+            let property = match target.property() {
+                gltf::animation::Property::Translation => AnimationProperty::Translation,
+                gltf::animation::Property::Rotation => AnimationProperty::Rotation,
+                gltf::animation::Property::Scale => AnimationProperty::Scale,
+                gltf::animation::Property::MorphTargetWeights => AnimationProperty::Weights,
+            };
+
+            let reader = channel.reader(|buffer| Some(&buffers[buffer.index()]));
+
+            let input_times: Vec<f32> = match reader.read_inputs() {
+                Some(inputs) => inputs.collect(),
+                None => continue,
+            };
+
+            let output_values = match reader.read_outputs() {
+                Some(outputs) => outputs,
+                None => continue,
+            };
+
+            let mut keyframes = Vec::new();
+            max_time = input_times
+                .iter()
+                .cloned()
+                .fold(max_time, |a: f32, b: f32| a.max(b));
+
+            match output_values {
+                gltf::animation::util::ReadOutputs::Translations(translations) => {
+                    for (i, translation) in translations.enumerate() {
+                        keyframes.push(Keyframe {
+                            time: input_times[i],
+                            value: AnimationValue::Translation(vec3(
+                                translation[0],
+                                translation[1],
+                                translation[2],
+                            )),
+                        });
+                    }
+                }
+                gltf::animation::util::ReadOutputs::Rotations(rotations) => {
+                    for (i, rotation) in rotations.into_f32().enumerate() {
+                        keyframes.push(Keyframe {
+                            time: input_times[i],
+                            value: AnimationValue::Rotation(Quaternion {
+                                v: vec3(rotation[0], rotation[1], rotation[2]),
+                                s: rotation[3],
+                            }),
+                        });
+                    }
+                }
+                gltf::animation::util::ReadOutputs::Scales(scales) => {
+                    for (i, scale) in scales.enumerate() {
+                        keyframes.push(Keyframe {
+                            time: input_times[i],
+                            value: AnimationValue::Scale(vec3(scale[0], scale[1], scale[2])),
+                        });
+                    }
+                }
+                gltf::animation::util::ReadOutputs::MorphTargetWeights(_weights) => {
+                    // Morph targets are not modeled by the runtime; skip.
+                }
+            }
+
+            channels.push(AnimationChannel {
+                target_node_index: node_index,
+                target_property: property,
+                keyframes,
+            });
+        }
+
+        animations.push(Animation {
+            name: animation_name,
+            channels,
+            duration: max_time,
+        });
+    }
+
+    animations
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn aabb_extend_tracks_min_max() {
+        let mut aabb = Aabb::empty();
+        assert!(aabb.is_empty());
+        aabb.extend(vec3(1.0, -2.0, 3.0));
+        aabb.extend(vec3(-1.0, 5.0, 0.0));
+        assert!(!aabb.is_empty());
+        assert_eq!(aabb.min, vec3(-1.0, -2.0, 0.0));
+        assert_eq!(aabb.max, vec3(1.0, 5.0, 3.0));
+    }
+
+    #[test]
+    fn skin_position_identity_passthrough() {
+        // A vertex fully weighted to joint 0 with an identity transform should
+        // come back unchanged.
+        let v = SkinnedVertex {
+            position: vec3(2.0, 3.0, 4.0),
+            joint_indices: vec4(0.0, 0.0, 0.0, 0.0),
+            weights: vec4(1.0, 0.0, 0.0, 0.0),
+        };
+        let transforms = vec![Matrix4::from_scale(1.0)];
+        let p = skin_position(&v, &transforms);
+        assert_eq!(p, vec3(2.0, 3.0, 4.0));
+    }
+
+    #[test]
+    fn skin_position_applies_weighted_translation() {
+        // Two joints, each translating, with equal weight: position should be
+        // the average of the two translations applied.
+        let v = SkinnedVertex {
+            position: vec3(0.0, 0.0, 0.0),
+            joint_indices: vec4(0.0, 1.0, 0.0, 0.0),
+            weights: vec4(0.5, 0.5, 0.0, 0.0),
+        };
+        let transforms = vec![
+            Matrix4::from_translation(vec3(10.0, 0.0, 0.0)),
+            Matrix4::from_translation(vec3(0.0, 20.0, 0.0)),
+        ];
+        let p = skin_position(&v, &transforms);
+        assert_eq!(p, vec3(5.0, 10.0, 0.0));
+    }
+}

--- a/runtime/functor-runtime-common/src/lib.rs
+++ b/runtime/functor-runtime-common/src/lib.rs
@@ -73,6 +73,7 @@ mod frame;
 mod frame_time;
 pub mod geometry;
 mod input;
+pub mod inspect;
 pub mod io;
 pub mod material;
 pub mod math;


### PR DESCRIPTION
Adds `functor inspect model <file.glb> [--time T]` — a **CPU-only, no-GL** glTF inspector for humans, scripts, CI, and LLMs. The model-inspector tier from the validation-tooling plan (docs/todo.md).

It parses the glb directly and reuses the *pure* parts of the asset pipeline (skeleton building via `SkeletonBuilder`, `Skeleton::animate`) without creating any `Texture2D` / GL buffers, so it opens no window. Reports per-mesh vertex/index/joint/weight counts + skinned flag, skeleton joint count, animation names + durations, the static AABB, and (with `--time`) the **skinned AABB** at that time — the skinning math mirrors the `skinned_material` vertex shader exactly.

### Why it's useful
It would have caught both skinned-material bugs at a glance: zero-vertex meshes (the crash) and a skeleton that doesn't move (the rest-pose bug — visible as a skinned AABB that doesn't differ from the static one). Text-only output is diffable, so it can back regression checks too.

### Wiring
- New `functor_runtime_common::inspect` module (pure data → `ModelReport`), with 3 unit tests.
- Thin CLI formatter in `cli/src/commands/inspect.rs`; new `Inspect` subcommand dispatched before `functor.json` validation (it operates on an arbitrary asset path, not a game project).
- `cli` now depends on `functor_runtime_common` (it didn't before).

### Verified (reproduced locally)
```
$ functor inspect model examples/hello/shark.glb --time 0.5
  [0] shark.2.mesh - vertices: 27440, indices: 153597, joints: 27440, weights: 27440, skinned: true
  Skeleton: present (35 joints) ; Animations: swimming/circling/bite
  Static AABB  min (-341.6,-63.8,-911.2) max (341.6,537.7,780.5)
  Skinned AABB @0.5 (swimming) min (-310.6,-54.1,-870.6) max (368.1,535.7,777.9)   # differs → skeleton applied
$ functor inspect model examples/hello/ExplodingBarrel.glb     # 5 non-skinned meshes, real vertex counts, no skeleton
$ functor inspect model /tmp/nope.glb                          # "Model not found", exit 1
```
No window opens; 
running 17 tests
test camera::tests::projection_uses_viewport_aspect ... ok
test camera::tests::wider_aspect_widens_horizontally_without_stretching ... ok
test effect::tests::is_none_distinguishes_variants ... ok
test effect_queue::tests::enqueue_dequeue_is_fifo ... ok
test effect::tests::run_wrapped_yields_single_message ... ok
test effect_queue::tests::enqueue_ignores_none_effects ... ok
test effect_queue::tests::new_queue_is_empty ... ok
test effect::tests::run_none_yields_no_messages ... ok
test effect_queue::tests::seeded_with_none_is_empty ... ok
test effect_queue::tests::seeded_with_wrapped_holds_single_startup_effect ... ok
test inspect::tests::aabb_extend_tracks_min_max ... ok
test inspect::tests::skin_position_applies_weighted_translation ... ok
test inspect::tests::skin_position_identity_passthrough ... ok
test tests::it_works ... ok
test viewport::tests::aspect_guards_degenerate_sizes ... ok
test viewport::tests::aspect_is_width_over_height ... ok
test model::skeleton::tests::test_absolute_transforms ... ok

test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s → 17 passed.

### Follow-ups
- `--time` samples animation index 0 only (no by-name selection yet).
- Static AABB is in model/local space (per-node transforms not baked in).
- Embedded-buffer glb only (external .bin/image URIs error cleanly).

Implemented by a delegated agent; reviewed, re-verified, and the agent worktree cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)