### PR TITLE
feat(runner): optional HTTP debug control server (--debug-port)

### DIFF
--- a/runtime/functor-runtime-desktop/Cargo.toml
+++ b/runtime/functor-runtime-desktop/Cargo.toml
@@ -27,6 +27,7 @@ async-trait = "0.1.80"
 glfw = { version = "0.56.0" }
 libloading = "0.8.3"
 tokio = { version = "1", features = ["full"] }
+tiny_http = "0.12"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", features=["HtmlCanvasElement", "WebGl2RenderingContext", "Window"] }

--- a/runtime/functor-runtime-desktop/src/debug_server.rs
+++ b/runtime/functor-runtime-desktop/src/debug_server.rs
@@ -1,0 +1,125 @@
+//! Optional HTTP control server for the desktop runtime.
+//!
+//! When `functor-runner` is started with `--debug-port <PORT>`, [`spawn`] starts
+//! a blocking [`tiny_http`] server on a background thread bound to
+//! `127.0.0.1:<PORT>` (localhost only). HTTP handlers do **not** touch GL — GL
+//! must stay on the main render thread. Instead each handler builds a
+//! [`DebugRequest`] carrying a per-request response channel, hands it to the GL
+//! loop over an [`mpsc`] channel, and blocks on its own response receiver. The
+//! GL loop drains pending requests once per frame (see [`DebugRequest`]'s use in
+//! `main.rs`) and fulfills them with framebuffer data / runtime state it can
+//! only read on the main thread.
+//!
+//! This is the seed of a richer debug runtime (future `/input`, `/time`, etc.).
+
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::thread;
+
+use tiny_http::{Header, Method, Response, Server};
+
+/// A snapshot of runtime state the GL loop can read on the main thread, returned
+/// for `GET /state`. Kept deliberately small for this first slice — model/game
+/// state is opaque across the dylib boundary (`emit_state` bundles model + effect
+/// queue into binary `OpaqueState` for hot-reload, not JSON), so we report the
+/// runtime status the shell owns.
+pub struct RuntimeState {
+    pub frame: u64,
+    pub tts: f32,
+    pub width: u32,
+    pub height: u32,
+}
+
+impl RuntimeState {
+    /// Hand-rolled JSON so we don't pull in serde just for this.
+    pub fn to_json(&self) -> String {
+        format!(
+            "{{\"frame\":{},\"tts\":{},\"viewport\":{{\"width\":{},\"height\":{}}}}}",
+            self.frame, self.tts, self.width, self.height
+        )
+    }
+}
+
+/// A request from the HTTP thread to the GL loop. Each variant carries a
+/// one-shot `Sender` the GL loop uses to reply; the HTTP handler blocks on the
+/// matching `Receiver`.
+pub enum DebugRequest {
+    /// `POST /capture` — reply with PNG bytes of the next rendered frame.
+    Capture(Sender<Vec<u8>>),
+    /// `GET /state` — reply with the current runtime state.
+    State(Sender<RuntimeState>),
+}
+
+/// Start the debug HTTP server on a background thread. Returns the receiving end
+/// of the request channel; the GL loop should `try_recv()` it once per frame.
+/// Binds localhost only.
+pub fn spawn(port: u16) -> Receiver<DebugRequest> {
+    let (tx, rx) = mpsc::channel::<DebugRequest>();
+
+    let addr = format!("127.0.0.1:{}", port);
+    let server = match Server::http(&addr) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("[debug-server] failed to bind {}: {}", addr, e);
+            std::process::exit(1);
+        }
+    };
+    println!("[debug-server] listening on http://{}", addr);
+
+    thread::spawn(move || {
+        for request in server.incoming_requests() {
+            let method = request.method().clone();
+            let url = request.url().to_string();
+            // Strip any query string for routing.
+            let path = url.split('?').next().unwrap_or("").to_string();
+
+            match (&method, path.as_str()) {
+                (Method::Post, "/capture") => {
+                    let (resp_tx, resp_rx) = mpsc::channel::<Vec<u8>>();
+                    if tx.send(DebugRequest::Capture(resp_tx)).is_err() {
+                        let _ = request.respond(Response::from_string("runtime gone").with_status_code(503));
+                        continue;
+                    }
+                    match resp_rx.recv() {
+                        Ok(png) => {
+                            let header =
+                                Header::from_bytes(&b"Content-Type"[..], &b"image/png"[..]).unwrap();
+                            let resp = Response::from_data(png).with_header(header);
+                            let _ = request.respond(resp);
+                        }
+                        Err(_) => {
+                            let _ = request
+                                .respond(Response::from_string("capture failed").with_status_code(500));
+                        }
+                    }
+                }
+                (Method::Get, "/state") => {
+                    let (resp_tx, resp_rx) = mpsc::channel::<RuntimeState>();
+                    if tx.send(DebugRequest::State(resp_tx)).is_err() {
+                        let _ = request.respond(Response::from_string("runtime gone").with_status_code(503));
+                        continue;
+                    }
+                    match resp_rx.recv() {
+                        Ok(state) => {
+                            let header = Header::from_bytes(
+                                &b"Content-Type"[..],
+                                &b"application/json"[..],
+                            )
+                            .unwrap();
+                            let resp = Response::from_string(state.to_json()).with_header(header);
+                            let _ = request.respond(resp);
+                        }
+                        Err(_) => {
+                            let _ = request
+                                .respond(Response::from_string("state failed").with_status_code(500));
+                        }
+                    }
+                }
+                _ => {
+                    let _ = request.respond(Response::from_string("not found").with_status_code(404));
+                }
+            }
+        }
+    });
+
+    rx
+}

--- a/runtime/functor-runtime-desktop/src/main.rs
+++ b/runtime/functor-runtime-desktop/src/main.rs
@@ -19,6 +19,7 @@ use crate::game::Game;
 const SCR_WIDTH: u32 = 800;
 const SCR_HEIGHT: u32 = 600;
 
+mod debug_server;
 mod game;
 mod hot_reload_game;
 mod static_game;
@@ -90,13 +91,24 @@ struct Args {
     /// is deterministic — for reproducible captures / golden images.
     #[arg(long)]
     fixed_time: Option<f32>,
+
+    /// Start an HTTP control server on 127.0.0.1:<PORT> (localhost only) exposing
+    /// POST /capture (image/png of the next frame) and GET /state (runtime JSON).
+    /// Omit to disable the server entirely.
+    #[arg(long)]
+    debug_port: Option<u16>,
 }
 
 /// Read back the framebuffer just rendered (called before swap_buffers, so the
-/// back buffer) and write it as a PNG. Exits the process with an error if the
-/// capture cannot be written, so scripts don't mistake a failed capture for a
-/// pass.
-unsafe fn capture_framebuffer(gl: &glow::Context, width: u32, height: u32, path: &str) {
+/// back buffer) and encode it as PNG bytes. Returns an error string if the
+/// readback can't be turned into a valid image. Shared by `--capture-frame`
+/// (writes the bytes to a file) and the debug server's `POST /capture` (streams
+/// the bytes back over HTTP), so both produce byte-identical PNGs.
+unsafe fn encode_framebuffer_png(
+    gl: &glow::Context,
+    width: u32,
+    height: u32,
+) -> Result<Vec<u8>, String> {
     let stride = (width * 4) as usize;
     let mut pixels = vec![0u8; stride * height as usize];
     gl.read_pixels(
@@ -116,9 +128,23 @@ unsafe fn capture_framebuffer(gl: &glow::Context, width: u32, height: u32, path:
         flipped[row * stride..(row + 1) * stride].copy_from_slice(&pixels[src..src + stride]);
     }
 
-    let result = image::RgbaImage::from_raw(width, height, flipped)
-        .ok_or_else(|| "framebuffer size mismatch".to_string())
-        .and_then(|img| img.save(path).map_err(|e| e.to_string()));
+    let img = image::RgbaImage::from_raw(width, height, flipped)
+        .ok_or_else(|| "framebuffer size mismatch".to_string())?;
+    let mut bytes: Vec<u8> = Vec::new();
+    img.write_to(
+        &mut std::io::Cursor::new(&mut bytes),
+        image::ImageFormat::Png,
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(bytes)
+}
+
+/// Read back the framebuffer and write it as a PNG file. Exits the process with
+/// an error if the capture cannot be written, so scripts don't mistake a failed
+/// capture for a pass.
+unsafe fn capture_framebuffer(gl: &glow::Context, width: u32, height: u32, path: &str) {
+    let result = encode_framebuffer_png(gl, width, height)
+        .and_then(|bytes| std::fs::write(path, bytes).map_err(|e| e.to_string()));
     match result {
         Ok(()) => println!("Captured frame to {}", path),
         Err(e) => {
@@ -143,6 +169,11 @@ pub async fn main() {
     } else {
         Box::new(StaticGame::create(game_path.as_str()))
     };
+
+    // Optional debug control server. Runs on its own thread; the GL loop drains
+    // its request channel once per frame (see below). None when --debug-port is
+    // not given, so behavior is unchanged.
+    let debug_requests = args.debug_port.map(debug_server::spawn);
 
     unsafe {
         let (gl, shader_version, mut window, mut glfw, events) = {
@@ -187,6 +218,7 @@ pub async fn main() {
 
         let start_time = Instant::now();
         let mut last_time: f32 = 0.0;
+        let mut frame_count: u64 = 0;
 
         use glfw::Context;
 
@@ -308,7 +340,37 @@ pub async fn main() {
                 }
             }
 
+            // Service any pending debug-server requests now that the frame is
+            // fully rendered into the back buffer (same point --capture-frame
+            // reads from). GL stays on this thread; we only reply over channels.
+            if let Some(rx) = &debug_requests {
+                while let Ok(req) = rx.try_recv() {
+                    match req {
+                        debug_server::DebugRequest::Capture(resp) => {
+                            match encode_framebuffer_png(&gl, fb_width as u32, fb_height as u32) {
+                                Ok(png) => {
+                                    let _ = resp.send(png);
+                                }
+                                Err(e) => {
+                                    eprintln!("[debug-server] capture failed: {}", e);
+                                    // Dropping `resp` signals failure to the handler.
+                                }
+                            }
+                        }
+                        debug_server::DebugRequest::State(resp) => {
+                            let _ = resp.send(debug_server::RuntimeState {
+                                frame: frame_count,
+                                tts: time.tts,
+                                width: fb_width as u32,
+                                height: fb_height as u32,
+                            });
+                        }
+                    }
+                }
+            }
+
             window.swap_buffers();
+            frame_count += 1;
         }
     }
 


### PR DESCRIPTION
First slice of a **debug runtime** — the LLM-native, scriptable control surface from docs/todo.md. Start `functor-runner` with `--debug-port <PORT>` and it serves (localhost only):

- **`POST /capture`** → `image/png` of the next rendered frame
- **`GET /state`** → `application/json` runtime status

Without the flag, behavior is unchanged.

### Design
- HTTP runs on a **background thread** via `tiny_http` (blocking, no async — deliberately avoids entangling with tokio and the single-threaded GL loop).
- HTTP handlers never touch GL. Each builds a `DebugRequest` carrying a per-request response `Sender`, hands it to the GL loop over an `mpsc` channel, and blocks on its reply. The GL loop drains pending requests once per frame, **after the frame is rendered** (the same back-buffer point `--capture-frame` reads from).
- `capture_framebuffer` is refactored into `encode_framebuffer_png(gl,w,h) -> Vec<u8>` (shared) + a thin file-writer, so `--capture-frame` and `/capture` produce byte-identical PNGs. `--capture-frame` behavior is preserved.
- Binds `127.0.0.1` only; bind failure exits (so a bad port isn't silently ignored). Unknown route → 404; runtime gone → 503.

### /state scope
Returns `{"frame","tts","viewport":{"width","height"}}` — runtime-shell status only. The desktop `Game` trait exposes no state-read path, and `emit_state` bundles model+effect-queue into opaque binary `OpaqueState` (for hot-reload, not JSON). Readable model-state JSON is the main follow-up (needs a state-read path across the dylib boundary). JSON is hand-rolled to avoid pulling in serde for one struct.

### Verified (reproduced locally)
```
GET  /state   -> 200 application/json  {"frame":124,"tts":4.40,"viewport":{"width":1600,"height":1200}}
POST /capture -> 200 image/png  (valid PNG, 1600x1200; content = live rendered scene)
GET  /nope    -> 404
```
`--capture-frame` still works via the shared encoder; `cargo test -p functor_runtime_common` green.

### Follow-ups
- Readable model/game state in `/state` (the big one).
- `/input` (inject key/mouse) and `/time` (set/advance frame time) — reuse the same `DebugRequest` enum + mpsc plumbing.
- Requests block until the next frame is serviced (fine while rendering; would wait if the window is paused).

Implemented by a delegated agent; reviewed, re-verified, worktree cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)