### PR TITLE
feat(debug-server): readable model (/state) and scene (/scene) introspection

### DIFF
--- a/runtime/functor-runtime-desktop/Cargo.toml
+++ b/runtime/functor-runtime-desktop/Cargo.toml
@@ -17,6 +17,7 @@ fable_library_rust = { path = "./../../fable_modules/fable-library-rust" }
 glow = "0.13.1"
 cgmath = "0.18.0"
 image = "0.25"
+serde_json = "1"
 notify = "6.1.1"
 notify-debouncer-full = "0.3.1"
 tempfile = "3.10.1"

--- a/runtime/functor-runtime-desktop/src/debug_server.rs
+++ b/runtime/functor-runtime-desktop/src/debug_server.rs
@@ -18,24 +18,29 @@ use std::thread;
 use tiny_http::{Header, Method, Response, Server};
 
 /// A snapshot of runtime state the GL loop can read on the main thread, returned
-/// for `GET /state`. Kept deliberately small for this first slice — model/game
-/// state is opaque across the dylib boundary (`emit_state` bundles model + effect
-/// queue into binary `OpaqueState` for hot-reload, not JSON), so we report the
-/// runtime status the shell owns.
+/// for `GET /state`. `model` is the live game model rendered with Rust's
+/// pretty-`Debug` formatter (via the dylib's `emit_state_debug` export) — readable
+/// for any game with zero game-author effort, since Fable derives `Debug` on every
+/// generated type. (The model isn't `Serialize`, so this is Debug text, not JSON.)
 pub struct RuntimeState {
     pub frame: u64,
     pub tts: f32,
     pub width: u32,
     pub height: u32,
+    pub model: String,
 }
 
 impl RuntimeState {
-    /// Hand-rolled JSON so we don't pull in serde just for this.
+    /// Built with `serde_json` so the (multi-line, quote-bearing) `model` debug
+    /// string is correctly escaped into the JSON.
     pub fn to_json(&self) -> String {
-        format!(
-            "{{\"frame\":{},\"tts\":{},\"viewport\":{{\"width\":{},\"height\":{}}}}}",
-            self.frame, self.tts, self.width, self.height
-        )
+        serde_json::json!({
+            "frame": self.frame,
+            "tts": self.tts,
+            "viewport": { "width": self.width, "height": self.height },
+            "model": self.model,
+        })
+        .to_string()
     }
 }
 
@@ -47,6 +52,8 @@ pub enum DebugRequest {
     Capture(Sender<Vec<u8>>),
     /// `GET /state` — reply with the current runtime state.
     State(Sender<RuntimeState>),
+    /// `GET /scene` — reply with the current frame (camera + scene) as JSON.
+    Scene(Sender<String>),
 }
 
 /// Start the debug HTTP server on a background thread. Returns the receiving end
@@ -111,6 +118,28 @@ pub fn spawn(port: u16) -> Receiver<DebugRequest> {
                         Err(_) => {
                             let _ = request
                                 .respond(Response::from_string("state failed").with_status_code(500));
+                        }
+                    }
+                }
+                (Method::Get, "/scene") => {
+                    let (resp_tx, resp_rx) = mpsc::channel::<String>();
+                    if tx.send(DebugRequest::Scene(resp_tx)).is_err() {
+                        let _ = request.respond(Response::from_string("runtime gone").with_status_code(503));
+                        continue;
+                    }
+                    match resp_rx.recv() {
+                        Ok(json) => {
+                            let header = Header::from_bytes(
+                                &b"Content-Type"[..],
+                                &b"application/json"[..],
+                            )
+                            .unwrap();
+                            let resp = Response::from_string(json).with_header(header);
+                            let _ = request.respond(resp);
+                        }
+                        Err(_) => {
+                            let _ = request
+                                .respond(Response::from_string("scene failed").with_status_code(500));
                         }
                     }
                 }

--- a/runtime/functor-runtime-desktop/src/game.rs
+++ b/runtime/functor-runtime-desktop/src/game.rs
@@ -16,5 +16,10 @@ pub trait Game {
 
     fn render(&mut self, frame_time: FrameTime) -> Frame;
 
+    /// A pretty-printed (Rust `Debug`) view of the live game model, for
+    /// introspection. Produced by the game dylib's `emit_state_debug` export;
+    /// works for any game because Fable derives `Debug` on every generated type.
+    fn state_debug(&self) -> String;
+
     fn quit(&mut self);
 }

--- a/runtime/functor-runtime-desktop/src/hot_reload_game.rs
+++ b/runtime/functor-runtime-desktop/src/hot_reload_game.rs
@@ -76,6 +76,18 @@ impl Game for HotReloadGame {
         }
     }
 
+    fn state_debug(&self) -> String {
+        unsafe {
+            let func: Symbol<fn() -> fable_library_rust::String_::LrcStr> = self
+                .library
+                .as_ref()
+                .unwrap()
+                .get(b"emit_state_debug")
+                .unwrap();
+            func().to_string()
+        }
+    }
+
     fn quit(&mut self) {
         if let Some(handle) = self.watcher_thread.take() {
             handle.join().expect("Failed to join watcher thread");

--- a/runtime/functor-runtime-desktop/src/main.rs
+++ b/runtime/functor-runtime-desktop/src/main.rs
@@ -363,7 +363,16 @@ pub async fn main() {
                                 tts: time.tts,
                                 width: fb_width as u32,
                                 height: fb_height as u32,
+                                model: game.state_debug(),
                             });
+                        }
+                        debug_server::DebugRequest::Scene(resp) => {
+                            // Serialize the frame we just rendered (camera +
+                            // scene). Frame derives Serialize for the wasm path,
+                            // so this is real JSON, not Debug text.
+                            let json = serde_json::to_string_pretty(&frame)
+                                .unwrap_or_else(|e| format!("{{\"error\":{:?}}}", e.to_string()));
+                            let _ = resp.send(json);
                         }
                     }
                 }

--- a/runtime/functor-runtime-desktop/src/static_game.rs
+++ b/runtime/functor-runtime-desktop/src/static_game.rs
@@ -49,6 +49,14 @@ impl Game for StaticGame {
         }
     }
 
+    fn state_debug(&self) -> String {
+        unsafe {
+            let func: Symbol<fn() -> fable_library_rust::String_::LrcStr> =
+                self.library.get(b"emit_state_debug").unwrap();
+            func().to_string()
+        }
+    }
+
     fn quit(&mut self) {
         // Noop - nothing to do yet
     }

--- a/src/Functor.Game/Runtime.fs
+++ b/src/Functor.Game/Runtime.fs
@@ -1,6 +1,7 @@
 module Runtime
 
     open Fable.Core.Rust
+    open Fable.Core
 
     open Platform
     open Functor
@@ -11,6 +12,7 @@ module Runtime
         abstract member render: Time.FrameTime -> Graphics.Frame
         abstract member getState: unit -> OpaqueState
         abstract member setState: OpaqueState -> unit
+        abstract member stateDebug: unit -> string
 
     let mutable currentRunner: Option<IRunner> = None
 
@@ -129,9 +131,16 @@ module Runtime
 
         [<OuterAttr("no_mangle")>]
         let set_state(opaqueState: OpaqueState): unit =
-            if currentRunner.IsSome then 
+            if currentRunner.IsSome then
                 currentRunner.Value.setState(opaqueState)
-            else 
+            else
+                raise (System.Exception("No runner"))
+
+        [<OuterAttr("no_mangle")>]
+        let emit_state_debug(): string =
+            if currentRunner.IsSome then
+                currentRunner.Value.stateDebug()
+            else
                 raise (System.Exception("No runner"))
 
         [<OuterAttr("no_mangle")>]
@@ -141,7 +150,12 @@ module Runtime
             else 
                 raise (System.Exception("No runner"))
 
-    type GameExecutor<'Msg, 'Model>(game: Game<'Model, 'Msg>, initialState: 'Model) =
+    // `formatState` renders the live model for introspection (the debug server's
+    // /state). It is supplied by `runGame` (which is `inline`, so the `sprintf
+    // "%A"` is emitted at the game's concrete call site where the model's derived
+    // Debug is available) — keeping this generic executor free of a Debug bound
+    // that Fable can't express on a type parameter.
+    type GameExecutor<'Msg, 'Model>(game: Game<'Model, 'Msg>, initialState: 'Model, formatState: 'Model -> string) =
         let myGame = game
         let mutable state: 'Model = initialState
         // Seed the queue with the game's startup ('init') effect. Because this
@@ -167,6 +181,7 @@ module Runtime
                     OpaqueState.unsafe_coerce incomingState
                 state <- restoredState
                 effectQueue <- restoredQueue
+            member this.stateDebug() = formatState state
             member this.tick(frameTime: Time.FrameTime) =
 
                 // The game's 'init' effect is seeded into the queue at construction
@@ -241,9 +256,16 @@ module Runtime
                 // Scene3D.cube()
 
 
-    let runGame<'Msg, 'Model>(game: Game<'Model, 'Msg>) =
+    // Holds the module-level mutable assignment so it is emitted in this module
+    // rather than inlined into the game's crate (where Fable can't assign to it).
+    let setRunner (runner: IRunner) =
+        currentRunner <- Some(runner)
+
+    // `inline` so the model formatter below is generated at the game's concrete
+    // call site, where the model's Fable-derived Debug instance is available.
+    let inline runGame<'Msg, 'Model>(game: Game<'Model, 'Msg>) =
         printfn "runGame"
-        let runner = GameExecutor<'Msg, 'Model>(game, GameRunner.initialState game)
-        currentRunner <- Some(runner :> IRunner)
-        ()
+        let formatState = fun (m: 'Model) -> sprintf "%A" m
+        let runner = GameExecutor<'Msg, 'Model>(game, GameRunner.initialState game, formatState)
+        setRunner (runner :> IRunner)
 


### PR DESCRIPTION
Makes the debug runtime's state actually *readable*, with **zero burden on the game author** (no changes to game F#).

## What

- **`GET /state`** now includes the live game **model** rendered with Rust `Debug`:
  ```json
  { "frame": 84, "tts": 3.39, "viewport": {"width":1600,"height":1200},
    "model": "Model { paddle1: Paddle { position: Point2 { x: 0.0, y: 0.0 }, ... }, ball: Ball { ... }, counter: 257, eye: Vector3 { x: 0.0, y: 0.0, z: -5.0 }, ... }" }
  ```
- **`GET /scene`** returns the current frame (camera + scene graph) as **real JSON** (camera eye/target/fov, then the `Group`/`Material`/`Geometry` tree with transforms).

## How (and why this needed care)

The model crosses the dylib boundary as an opaque `Box<dyn Any>` and isn't `Serialize`. But Fable derives `Debug` on **every** generated type, so `Debug` formatting is the zero-effort, fully-general path.

The catch: the runtime is generic over the model, and **Fable can't express a `Debug` bound on a type parameter** (its `%A` emits `{:?}` *without* bounding the param, so generic Debug formatting won't compile). The fix: `runGame` is now `inline` and supplies a model-formatting closure to the executor, so the `sprintf "%A"` is generated at the game's **concrete** call site (where the derived `Debug` is available). The generic executor just calls the stored closure — no bound required. (The module-mutable `currentRunner` assignment moved into a non-inline `setRunner` so it isn't emitted into the game's crate.)

- New `emit_state_debug` native export (framework F#); desktop `Game` trait gains `state_debug()` to read it (returns a Fable string → `String`).
- `/scene` is free real JSON: `Frame`/`Scene3D` already derive `Serialize` for the wasm path, so `serde_json` just works.
- `/state` JSON is now built with `serde_json` so the multi-line model string is escaped correctly.

## Verified
- `/state` shows the full hello `Model`; `/scene` shows camera + `Group`/`Material(Texture crate.png)`/`Geometry Cylinder` with xforms (curl'd live).
- `cargo test -p functor_runtime_common` → 17 passed; **native and wasm** builds of hello compile (shared `runGame` change).

## Follow-ups
- `/state` model is Debug text, not JSON (the model isn't `Serialize`; real JSON would need build-level serde-derive injection — noted previously).
- `POST /input` and `POST /time` can reuse the same channel plumbing next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)