### PR TITLE
feat(cli): forward runner args through develop (one-command hot-reload + debug server)

### DIFF
--- a/cli/src/commands/develop.rs
+++ b/cli/src/commands/develop.rs
@@ -6,7 +6,11 @@ use std::path::{Path, PathBuf};
 use crate::util::{self, get_nearby_bin, ShellCommand};
 use crate::Environment;
 
-pub async fn execute(working_directory: &str, environment: &Environment) -> io::Result<()> {
+pub async fn execute(
+    working_directory: &str,
+    environment: &Environment,
+    runner_args: &[String],
+) -> io::Result<()> {
     let cwd_path = Path::new(working_directory);
     let build_native_path = Path::new(&"build-native");
     let build_native_wd = cwd_path.join(build_native_path);
@@ -17,6 +21,11 @@ pub async fn execute(working_directory: &str, environment: &Environment) -> io::
     let target_dir = Path::new(&"target/debug");
     let library_name = libloading::library_filename("game_native");
     let game_lib = build_native_path.join(target_dir.join(Path::new(&library_name)));
+
+    // The hot-reload runner gets the standard --hot/--game-path plus any extra
+    // args forwarded from the CLI (e.g. --debug-port).
+    let mut runner_command_args = vec!["--hot", "--game-path", game_lib.to_str().unwrap()];
+    runner_command_args.extend(runner_args.iter().map(|s| s.as_str()));
 
     let commands = vec![
         ShellCommand {
@@ -44,7 +53,7 @@ pub async fn execute(working_directory: &str, environment: &Environment) -> io::
             cmd: functor_runner_exe.to_str().unwrap(),
             cwd: working_directory,
             env: vec![],
-            args: vec!["--hot", "--game-path", game_lib.to_str().unwrap()],
+            args: runner_command_args,
         },
     ];
 

--- a/cli/src/commands/develop.rs
+++ b/cli/src/commands/develop.rs
@@ -1,14 +1,14 @@
-use colored::*;
-use std::env;
-use std::io::{self, BufRead, Error};
-use std::path::{Path, PathBuf};
+use std::io;
+use std::path::Path;
 
 use crate::util::{self, get_nearby_bin, ShellCommand};
 use crate::Environment;
 
+// `develop` is native-only (it always runs the hot-reload runner), so the
+// environment is currently ignored.
 pub async fn execute(
     working_directory: &str,
-    environment: &Environment,
+    _environment: &Environment,
     runner_args: &[String],
 ) -> io::Result<()> {
     let cwd_path = Path::new(working_directory);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -54,6 +54,11 @@ enum Command {
     Develop {
         #[arg(value_enum)]
         environment: Option<Environment>,
+
+        /// Extra arguments forwarded to functor-runner (native only). E.g.
+        /// `develop native --debug-port 8077`. A leading `--` is also accepted.
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        runner_args: Vec<String>,
     },
     /// Inspect assets headlessly (no GPU/GL context).
     Inspect {
@@ -124,11 +129,18 @@ async fn main() -> tokio::io::Result<()> {
             )
             .await
         }
-        Command::Develop { environment } => {
+        Command::Develop {
+            environment,
+            runner_args,
+        } => {
             commands::build::execute(&working_directory_str, &Environment::default(environment))
                 .await?;
-            commands::develop::execute(&working_directory_str, &Environment::default(environment))
-                .await
+            commands::develop::execute(
+                &working_directory_str,
+                &Environment::default(environment),
+                runner_args,
+            )
+            .await
         }
         // Handled earlier (before functor.json validation).
         Command::Inspect { .. } => unreachable!(),


### PR DESCRIPTION
Follow-up to the debug server / introspection work.

`functor run` already forwards trailing args to `functor-runner`; `develop` did not (it spawned the runner with a fixed `--hot --game-path`). This mirrors the `run` passthrough on `develop`, so the whole live loop is one command:

```sh
functor -d examples/hello develop native --debug-port 8077
# auto-rebuild on save (watchexec) + hot-reload runner (--hot) + debug server
# then: curl localhost:8077/state | /scene | -X POST /capture
```

A leading `--` is optional (`develop native -- --debug-port 8077` also works).

### Changes
- `Develop` gains a `runner_args` (trailing var-arg), forwarded into develop's runner `ShellCommand` alongside `--hot --game-path`.

### Verified
- `functor develop native --debug-port 8076` → the develop-launched runner logs `[debug-server] listening on http://127.0.0.1:8076` and `GET /state` returns the model. Before this, `develop` rejected the flag (`unexpected argument '--debug-port'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)