### PR TITLE
feat(debug-server): POST /input and /time to drive the game

### DIFF
--- a/runtime/functor-runtime-desktop/Cargo.toml
+++ b/runtime/functor-runtime-desktop/Cargo.toml
@@ -17,6 +17,7 @@ fable_library_rust = { path = "./../../fable_modules/fable-library-rust" }
 glow = "0.13.1"
 cgmath = "0.18.0"
 image = "0.25"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 notify = "6.1.1"
 notify-debouncer-full = "0.3.1"

--- a/runtime/functor-runtime-desktop/src/debug_server.rs
+++ b/runtime/functor-runtime-desktop/src/debug_server.rs
@@ -15,6 +15,7 @@
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread;
 
+use serde::Deserialize;
 use tiny_http::{Header, Method, Response, Server};
 
 /// A snapshot of runtime state the GL loop can read on the main thread, returned
@@ -44,6 +45,29 @@ impl RuntimeState {
     }
 }
 
+/// An input event to inject via `POST /input`. JSON is tagged by `type`:
+/// `{"type":"key","key":"w","down":true}`,
+/// `{"type":"mouse_move","x":10,"y":20}`,
+/// `{"type":"mouse_wheel","delta":1}`.
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum InputCommand {
+    Key { key: String, down: bool },
+    MouseMove { x: i32, y: i32 },
+    MouseWheel { delta: i32 },
+}
+
+/// A clock command via `POST /time`: `{"type":"set","tts":2.0}` pins the frame
+/// time, `{"type":"advance","dts":0.5}` steps it once (with that dt), and
+/// `{"type":"resume"}` returns to wall-clock.
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum TimeCommand {
+    Set { tts: f32 },
+    Advance { dts: f32 },
+    Resume,
+}
+
 /// A request from the HTTP thread to the GL loop. Each variant carries a
 /// one-shot `Sender` the GL loop uses to reply; the HTTP handler blocks on the
 /// matching `Receiver`.
@@ -54,6 +78,10 @@ pub enum DebugRequest {
     State(Sender<RuntimeState>),
     /// `GET /scene` — reply with the current frame (camera + scene) as JSON.
     Scene(Sender<String>),
+    /// `POST /input` — inject a key/mouse event; reply Ok or an error message.
+    Input(InputCommand, Sender<Result<(), String>>),
+    /// `POST /time` — set/advance/resume the clock; reply once applied.
+    Time(TimeCommand, Sender<()>),
 }
 
 /// Start the debug HTTP server on a background thread. Returns the receiving end
@@ -73,7 +101,7 @@ pub fn spawn(port: u16) -> Receiver<DebugRequest> {
     println!("[debug-server] listening on http://{}", addr);
 
     thread::spawn(move || {
-        for request in server.incoming_requests() {
+        for mut request in server.incoming_requests() {
             let method = request.method().clone();
             let url = request.url().to_string();
             // Strip any query string for routing.
@@ -140,6 +168,71 @@ pub fn spawn(port: u16) -> Receiver<DebugRequest> {
                         Err(_) => {
                             let _ = request
                                 .respond(Response::from_string("scene failed").with_status_code(500));
+                        }
+                    }
+                }
+                (Method::Post, "/input") => {
+                    let mut body = String::new();
+                    if request.as_reader().read_to_string(&mut body).is_err() {
+                        let _ = request.respond(Response::from_string("bad body").with_status_code(400));
+                        continue;
+                    }
+                    let cmd: InputCommand = match serde_json::from_str(&body) {
+                        Ok(c) => c,
+                        Err(e) => {
+                            let _ = request.respond(
+                                Response::from_string(format!("bad input json: {}", e))
+                                    .with_status_code(400),
+                            );
+                            continue;
+                        }
+                    };
+                    let (resp_tx, resp_rx) = mpsc::channel();
+                    if tx.send(DebugRequest::Input(cmd, resp_tx)).is_err() {
+                        let _ = request.respond(Response::from_string("runtime gone").with_status_code(503));
+                        continue;
+                    }
+                    match resp_rx.recv() {
+                        Ok(Ok(())) => {
+                            let _ = request.respond(Response::from_string("ok"));
+                        }
+                        Ok(Err(msg)) => {
+                            let _ = request.respond(Response::from_string(msg).with_status_code(400));
+                        }
+                        Err(_) => {
+                            let _ = request
+                                .respond(Response::from_string("input failed").with_status_code(500));
+                        }
+                    }
+                }
+                (Method::Post, "/time") => {
+                    let mut body = String::new();
+                    if request.as_reader().read_to_string(&mut body).is_err() {
+                        let _ = request.respond(Response::from_string("bad body").with_status_code(400));
+                        continue;
+                    }
+                    let cmd: TimeCommand = match serde_json::from_str(&body) {
+                        Ok(c) => c,
+                        Err(e) => {
+                            let _ = request.respond(
+                                Response::from_string(format!("bad time json: {}", e))
+                                    .with_status_code(400),
+                            );
+                            continue;
+                        }
+                    };
+                    let (resp_tx, resp_rx) = mpsc::channel();
+                    if tx.send(DebugRequest::Time(cmd, resp_tx)).is_err() {
+                        let _ = request.respond(Response::from_string("runtime gone").with_status_code(503));
+                        continue;
+                    }
+                    match resp_rx.recv() {
+                        Ok(()) => {
+                            let _ = request.respond(Response::from_string("ok"));
+                        }
+                        Err(_) => {
+                            let _ = request
+                                .respond(Response::from_string("time failed").with_status_code(500));
                         }
                     }
                 }

--- a/runtime/functor-runtime-desktop/src/main.rs
+++ b/runtime/functor-runtime-desktop/src/main.rs
@@ -65,6 +65,30 @@ fn map_key(key: Key) -> InputKey {
     }
 }
 
+/// Map a key name (case-insensitive: "w", "Up", "space", …) to the engine key
+/// code passed across the game boundary, for the debug server's POST /input.
+/// Letters rely on the contiguous A..Z discriminants.
+fn key_code_from_str(name: &str) -> Option<i32> {
+    let name = name.to_ascii_lowercase();
+    if name.len() == 1 {
+        let c = name.as_bytes()[0];
+        if c.is_ascii_lowercase() {
+            return Some((c - b'a') as i32 + InputKey::A as i32);
+        }
+    }
+    let key = match name.as_str() {
+        "up" => InputKey::Up,
+        "down" => InputKey::Down,
+        "left" => InputKey::Left,
+        "right" => InputKey::Right,
+        "space" => InputKey::Space,
+        "enter" => InputKey::Enter,
+        "escape" => InputKey::Escape,
+        _ => return None,
+    };
+    Some(key as i32)
+}
+
 use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
@@ -219,6 +243,11 @@ pub async fn main() {
         let start_time = Instant::now();
         let mut last_time: f32 = 0.0;
         let mut frame_count: u64 = 0;
+        // Debug-server clock control (POST /time). `held_time` pins the frame
+        // time to a constant (None = follow wall clock); `pending_step` applies a
+        // one-shot dt advance on the next frame. Seeded from --fixed-time.
+        let mut held_time: Option<f32> = args.fixed_time;
+        let mut pending_step: Option<f32> = None;
 
         use glfw::Context;
 
@@ -244,21 +273,28 @@ pub async fn main() {
 
         while !window.should_close() {
             let elapsed_time = start_time.elapsed().as_secs_f32();
-            // --fixed-time pins the time handed to the game to a constant, so
-            // the rendered pose (animations, anything driven by FrameTime) is
-            // deterministic regardless of frame rate or asset-load timing. Used
-            // with --capture-frame for reproducible golden images. The capture
-            // trigger below still keys off wall-clock elapsed, so the loop runs
-            // long enough for assets to load before the shot is taken.
-            let time: FrameTime = match args.fixed_time {
-                Some(fixed) => FrameTime {
-                    dts: 0.0,
-                    tts: fixed,
-                },
-                None => FrameTime {
-                    dts: elapsed_time - last_time,
-                    tts: elapsed_time,
-                },
+            // The frame time handed to the game. Pinning it (--fixed-time, or the
+            // debug server's /time) makes the rendered pose deterministic — used
+            // for reproducible captures / golden images. The capture trigger
+            // below still keys off wall-clock elapsed, so the loop runs long
+            // enough for assets to load before a shot is taken.
+            let time: FrameTime = if let Some(step) = pending_step.take() {
+                // One-shot /time advance: step the clock by `step` with a matching
+                // dts so the simulation integrates the interval, then stay held.
+                let new_tts = held_time.unwrap_or(last_time) + step;
+                held_time = Some(new_tts);
+                FrameTime {
+                    dts: step,
+                    tts: new_tts,
+                }
+            } else {
+                match held_time {
+                    Some(tts) => FrameTime { dts: 0.0, tts },
+                    None => FrameTime {
+                        dts: elapsed_time - last_time,
+                        tts: elapsed_time,
+                    },
+                }
             };
             last_time = elapsed_time;
 
@@ -373,6 +409,46 @@ pub async fn main() {
                             let json = serde_json::to_string_pretty(&frame)
                                 .unwrap_or_else(|e| format!("{{\"error\":{:?}}}", e.to_string()));
                             let _ = resp.send(json);
+                        }
+                        debug_server::DebugRequest::Input(cmd, resp) => {
+                            // Inject input as if it came from the window; the game
+                            // applies it immediately, so the next /state reflects it.
+                            let result = match cmd {
+                                debug_server::InputCommand::Key { key, down } => {
+                                    match key_code_from_str(&key) {
+                                        Some(code) => {
+                                            game.key_event(code, down);
+                                            Ok(())
+                                        }
+                                        None => Err(format!("unknown key: {}", key)),
+                                    }
+                                }
+                                debug_server::InputCommand::MouseMove { x, y } => {
+                                    game.mouse_move(x, y);
+                                    Ok(())
+                                }
+                                debug_server::InputCommand::MouseWheel { delta } => {
+                                    game.mouse_wheel(delta);
+                                    Ok(())
+                                }
+                            };
+                            let _ = resp.send(result);
+                        }
+                        debug_server::DebugRequest::Time(cmd, resp) => {
+                            match cmd {
+                                debug_server::TimeCommand::Set { tts } => {
+                                    held_time = Some(tts);
+                                    pending_step = None;
+                                }
+                                debug_server::TimeCommand::Advance { dts } => {
+                                    pending_step = Some(dts);
+                                }
+                                debug_server::TimeCommand::Resume => {
+                                    held_time = None;
+                                    pending_step = None;
+                                }
+                            }
+                            let _ = resp.send(());
                         }
                     }
                 }


### PR DESCRIPTION
Completes the debug runtime's **drive + observe** loop. We had observe (`/state`, `/scene`, `/capture`); this adds *drive*, so an LLM or test can control the game and watch the result deterministically.

## Endpoints (localhost, behind `--debug-port`)

**`POST /input`** — inject input, applied immediately (next `/state` reflects it). Tagged JSON:
```
{"type":"key","key":"w","down":true}
{"type":"mouse_move","x":100,"y":200}
{"type":"mouse_wheel","delta":1}
```
Keys are case-insensitive names (`w`, `Up`, `space`, …); unknown key → 400.

**`POST /time`** — control the clock:
```
{"type":"set","tts":2.0}      # pin frame time (deterministic pose)
{"type":"advance","dts":0.5}  # step once with that dt (integrates the sim)
{"type":"resume"}             # back to wall-clock
```
Seeded from `--fixed-time`.

## How
Both reuse the existing `DebugRequest` mpsc channel from #83/#84: the HTTP thread parses the body (serde) and the GL/main thread applies it (`/input` → the game's existing `key_event`/`mouse_move`/`mouse_wheel`; `/time` → loop clock state). No GL on the HTTP thread.

## Why it matters
Deterministic, automatable end-to-end tests are now possible: **set input → step time → read `/state`/`/scene` → assert** — no window interaction, fully reproducible.

## Verified (curl'd live)
- `/time set tts=5` → `/state` tts = 5.0 (held).
- `/input key w down` → model `held: HeldKeys { up: true, … }`.
- `/input mouse_move 100,200` → model `lastMouse: Some((100.0, 200.0))`.
- `/time advance dts=1` with W held → eye moved `-5.0 → -2.0` (exactly speed×dt = 3×1), tts 2.0 → 3.0.
- bad key → 400 `unknown key: nope`.
- `cargo test -p functor_runtime_common` → 17 passed. (Desktop-only change; wasm/F# untouched.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)