### PR TITLE
feat(geometry): quad + plane primitives (and document the Y-up convention)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,12 @@ built fluently via `GameBuilder` and handed to `Runtime.runGame`:
 - `draw3d: 'model -> FrameTime -> Graphics.Frame` — pure frame description: a `Camera` plus a
   `Scene3D` (`Frame.create camera scene`)
 
+**Coordinates: Y-up, right-handed** (like OpenGL / glTF / Unity / Godot; *not* Unreal's Z-up). +Y
+is up, +X is right, and the ground is the XZ plane. The camera's up is `[0,1,0]` and view uses
+`look_at_rh`; `Camera.firstPerson` treats yaw = 0 / pitch = 0 as looking down **+Z**, with positive
+pitch looking up. glTF models are authored Y-up, so this matches imported assets with no conversion.
+By convention, `plane` geometry lies in XZ (ground) and `quad` in XY (screen/wall-facing).
+
 `Runtime.GameExecutor` (`src/Functor.Game/Runtime.fs`) is the heart of the loop: each frame it
 **drains the effect queue to a fixed point** (capped at `maxEffectsPerFrame = 1000` to avoid
 hangs), feeding messages through `update` and re-enqueueing new effects, before running `tick` on

--- a/examples/hello/hello.fs
+++ b/examples/hello/hello.fs
@@ -184,6 +184,7 @@ let init (_args: array<string>) =
         let eff = Effect.wrapped (MovePaddle2) |> Effect.map (fun _a -> MovePaddle1);
         let colorMaterial = Material.color(0.0f, 1.0f, 0.0f, 1.0f);
         let textureMaterial = Material.texture( Texture.file("crate.png"));
+        let groundMaterial = Material.texture( Texture.file("dirt.png"));
         // let barrelModel = Model.file("ExplodingBarrel.glb");
         // let renderModel = (Graphics.Scene3D.model barrelModel) |> Transform.scale 1f;
         // let renderModel = Model.file ("ExplodingBarrel.glb") |> Graphics.Scene3D.model |> Transform.scale 0.5f;
@@ -191,14 +192,17 @@ let init (_args: array<string>) =
         // let renderModel = Model.file ("vr_glove_model2.glb") |> modify |> Graphics.Scene3D.model |> Transform.scale 5f;
 
         // A lineup of glTF samples from BabylonJS/Assets exercising the model
-        // pipeline. Skinned + animated: shark, fish, Xbot, HVGirl. Non-skinned:
+        // pipeline. Skinned + animated: shark, fish, Xbot. Non-skinned:
         // ExplodingBarrel. Raw model units vary wildly (the barrel is ~72 units
-        // tall, the humanoids are Mixamo-style cm scale), hence the per-model
-        // scales.
+        // tall, Xbot is Mixamo-style cm scale), hence the per-model scales.
         let sample (path: string) = path |> Model.file |> Graphics.Scene3D.model
 
         let scene =
             group([|
+                // Ground plane (XZ, Y-up) beneath the lineup.
+                material (groundMaterial, [|
+                    plane() |> Transform.translateY -2.5f |> Transform.translateZ 4.0f |> Transform.scale 30.0f;
+                |]);
                 material (textureMaterial, [|
                     cylinder() |> Transform.translateY -2.5f;
                 |]);
@@ -212,9 +216,6 @@ let init (_args: array<string>) =
                 sample "Xbot.glb"
                 |> Transform.translateX 1.5f |> Transform.translateY -1.0f |> Transform.translateZ 3.0f
                 |> Transform.scale 0.015f;
-                sample "HVGirl.glb"
-                |> Transform.translateX -1.5f |> Transform.translateY -1.0f |> Transform.translateZ 3.0f
-                |> Transform.scale 0.03f;
                 sample "ExplodingBarrel.glb"
                 |> Transform.translateY -1.5f |> Transform.translateZ 3.0f
                 |> Transform.scale 0.02f;

--- a/runtime/functor-runtime-common/src/geometry/mod.rs
+++ b/runtime/functor-runtime-common/src/geometry/mod.rs
@@ -7,12 +7,16 @@ mod cylinder;
 mod empty_mesh;
 mod indexed_mesh;
 mod mesh;
+mod plane;
+mod quad;
 mod sphere;
 pub use cube::*;
 pub use cylinder::*;
 pub use empty_mesh::*;
 pub use indexed_mesh::*;
 pub use mesh::*;
+pub use plane::*;
+pub use quad::*;
 pub use sphere::*;
 
 // pub mod plane {

--- a/runtime/functor-runtime-common/src/geometry/plane.rs
+++ b/runtime/functor-runtime-common/src/geometry/plane.rs
@@ -1,0 +1,34 @@
+use cgmath::{vec2, vec3};
+
+use crate::render::VertexPositionTexture;
+
+use super::{Geometry, IndexedMesh};
+
+/// A unit square in the XZ plane (y = 0), centered at the origin — the ground.
+/// Y-up convention, so this lies flat; size it with `Transform.scale`.
+pub struct Plane;
+
+impl Plane {
+    pub fn create() -> Box<dyn Geometry> {
+        let vertices = vec![
+            VertexPositionTexture {
+                position: vec3(-0.5, 0.0, -0.5),
+                uv: vec2(0.0, 0.0),
+            },
+            VertexPositionTexture {
+                position: vec3(0.5, 0.0, -0.5),
+                uv: vec2(1.0, 0.0),
+            },
+            VertexPositionTexture {
+                position: vec3(0.5, 0.0, 0.5),
+                uv: vec2(1.0, 1.0),
+            },
+            VertexPositionTexture {
+                position: vec3(-0.5, 0.0, 0.5),
+                uv: vec2(0.0, 1.0),
+            },
+        ];
+        let indices = vec![0, 1, 2, 2, 3, 0];
+        Box::new(IndexedMesh::create(vertices, indices))
+    }
+}

--- a/runtime/functor-runtime-common/src/geometry/quad.rs
+++ b/runtime/functor-runtime-common/src/geometry/quad.rs
@@ -1,0 +1,34 @@
+use cgmath::{vec2, vec3};
+
+use crate::render::VertexPositionTexture;
+
+use super::{Geometry, IndexedMesh};
+
+/// A unit square in the XY plane (z = 0), centered at the origin, facing +Z.
+/// The atom for sprites / billboards / UI; size it with `Transform.scale`.
+pub struct Quad;
+
+impl Quad {
+    pub fn create() -> Box<dyn Geometry> {
+        let vertices = vec![
+            VertexPositionTexture {
+                position: vec3(-0.5, -0.5, 0.0),
+                uv: vec2(0.0, 0.0),
+            },
+            VertexPositionTexture {
+                position: vec3(0.5, -0.5, 0.0),
+                uv: vec2(1.0, 0.0),
+            },
+            VertexPositionTexture {
+                position: vec3(0.5, 0.5, 0.0),
+                uv: vec2(1.0, 1.0),
+            },
+            VertexPositionTexture {
+                position: vec3(-0.5, 0.5, 0.0),
+                uv: vec2(0.0, 1.0),
+            },
+        ];
+        let indices = vec![0, 1, 2, 2, 3, 0];
+        Box::new(IndexedMesh::create(vertices, indices))
+    }
+}

--- a/runtime/functor-runtime-common/src/scene3d/mod.rs
+++ b/runtime/functor-runtime-common/src/scene3d/mod.rs
@@ -33,6 +33,8 @@ pub struct SceneContext {
     cube: RefCell<Box<dyn Geometry>>,
     cylinder: RefCell<Mesh>,
     sphere: RefCell<Mesh>,
+    quad: RefCell<Box<dyn Geometry>>,
+    plane: RefCell<Box<dyn Geometry>>,
 }
 
 impl SceneContext {
@@ -41,6 +43,8 @@ impl SceneContext {
             cube: RefCell::new(geometry::Cube::create()),
             sphere: RefCell::new(geometry::Sphere::create()),
             cylinder: RefCell::new(geometry::Cylinder::create()),
+            quad: RefCell::new(geometry::Quad::create()),
+            plane: RefCell::new(geometry::Plane::create()),
             texture_pipeline: asset::build_pipeline(Box::new(TexturePipeline)),
             model_pipeline: asset::build_pipeline(Box::new(ModelPipeline)),
         }
@@ -52,6 +56,8 @@ pub enum Shape {
     Cube,
     Sphere,
     Cylinder,
+    Quad,
+    Plane,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -83,6 +89,20 @@ impl Scene3D {
     pub fn sphere() -> Self {
         Scene3D {
             obj: SceneObject::Geometry(Shape::Sphere),
+            xform: Matrix4::identity(),
+        }
+    }
+
+    pub fn quad() -> Self {
+        Scene3D {
+            obj: SceneObject::Geometry(Shape::Quad),
+            xform: Matrix4::identity(),
+        }
+    }
+
+    pub fn plane() -> Self {
+        Scene3D {
+            obj: SceneObject::Geometry(Shape::Plane),
             xform: Matrix4::identity(),
         }
     }
@@ -320,6 +340,28 @@ impl Scene3D {
                 );
 
                 scene_context.sphere.borrow_mut().draw(&render_context.gl);
+            }
+            SceneObject::Geometry(Shape::Quad) => {
+                let xform = world_matrix * self.xform;
+                current_material.draw_opaque(
+                    &render_context,
+                    &projection_matrix,
+                    &view_matrix,
+                    &xform,
+                    &skinning_data,
+                );
+                scene_context.quad.borrow_mut().draw(&render_context.gl);
+            }
+            SceneObject::Geometry(Shape::Plane) => {
+                let xform = world_matrix * self.xform;
+                current_material.draw_opaque(
+                    &render_context,
+                    &projection_matrix,
+                    &view_matrix,
+                    &xform,
+                    &skinning_data,
+                );
+                scene_context.plane.borrow_mut().draw(&render_context.gl);
             }
         }
     }

--- a/scripts/fetch-assets.mjs
+++ b/scripts/fetch-assets.mjs
@@ -16,7 +16,6 @@ const ASSETS = [
   "ExplodingBarrel.glb",
   "fish.glb",
   "Xbot.glb",
-  "HVGirl.glb",
 ];
 
 async function exists(filePath) {

--- a/src/Functor.Game/Scene3D.fs
+++ b/src/Functor.Game/Scene3D.fs
@@ -20,6 +20,14 @@ module Scene3D =
     [<Emit("functor_runtime_common::Scene3D::cylinder()")>]
     let cylinder(): Scene3D = nativeOnly
 
+    // A unit square in the XZ plane (the ground); size it with Transform.scale.
+    [<Emit("functor_runtime_common::Scene3D::plane()")>]
+    let plane(): Scene3D = nativeOnly
+
+    // A unit square in the XY plane (screen/wall-facing); for sprites/billboards.
+    [<Emit("functor_runtime_common::Scene3D::quad()")>]
+    let quad(): Scene3D = nativeOnly
+
     [<Emit("functor_runtime_common::Scene3D::group($0)")>]
     let group (items: Scene3D[]): Scene3D = nativeOnly
 


### PR DESCRIPTION
Adds the two flat primitives the demo games keep needing — a **ground** and a **billboard/sprite** surface — alongside cube/sphere/cylinder, and uses the ground plane in the hello sample.

## What
- **`plane()`** — a unit square in the **XZ** plane (the ground, Y-up). Floors for the FPS / asteroids / terrain demos.
- **`quad()`** — a unit square in the **XY** plane (screen/wall-facing). The atom for sprites, billboards, particles, UI.

Both size with `Transform.scale`, and follow the existing pattern exactly: a `Shape` variant, a cached geometry instance in `SceneContext`, a render arm, a `Scene3D::` constructor, and an F# `Graphics.Scene3D` binding.

## Coordinate convention (documented in CLAUDE.md)
Confirmed in code and now written down: **Y-up, right-handed** (camera up `[0,1,0]`, `look_at_rh`, +Z forward). Matches OpenGL / glTF / Unity / Godot (not Unreal's Z-up), and the glTF assets we load — so imported models need no conversion. By convention `plane` = XZ (ground), `quad` = XY (screen-facing).

## Sample
`examples/hello` now renders a dirt-textured **ground plane** under the model lineup (which previously floated in empty space), demonstrating `plane()`. Also drops the HVGirl model from the scene and the `fetch:assets` list.

## Verified
Captured frames via `--capture-frame`: the ground plane reads as a textured floor to the horizon with the barrel sitting on it; `quad` (tested separately) renders as a screen-facing square. `cargo test -p functor_runtime_common` → 17 passed; native **and** wasm builds compile.

## Follow-ups
- **heightmap** next (the synthwave-terrain demo) — needs a *subdivided* plane, introducing parameterized geometry (today's primitives are unit/parameterless + cached).
- A camera-facing **Sprite** helper (quad + billboard-toward-eye) for sprites proper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
