### PR TITLE
feat(debug-server): POST /render-mode to toggle the debug render mode live

### DIFF
--- a/runtime/functor-runtime-desktop/src/debug_server.rs
+++ b/runtime/functor-runtime-desktop/src/debug_server.rs
@@ -28,6 +28,9 @@ pub struct RuntimeState {
     pub tts: f32,
     pub width: u32,
     pub height: u32,
+    /// The active debug render mode (e.g. `"default"`, `"normals"`), so the
+    /// toggle set via `POST /render-mode` is observable.
+    pub render_mode: String,
     pub model: String,
 }
 
@@ -39,6 +42,7 @@ impl RuntimeState {
             "frame": self.frame,
             "tts": self.tts,
             "viewport": { "width": self.width, "height": self.height },
+            "renderMode": self.render_mode,
             "model": self.model,
         })
         .to_string()
@@ -68,6 +72,14 @@ pub enum TimeCommand {
     Resume,
 }
 
+/// A render-mode command via `POST /render-mode`: `{"mode":"normals"}` or
+/// `{"mode":"default"}`. The string is validated against the runtime's known
+/// modes on the GL thread (an unknown mode replies 400).
+#[derive(Debug, Deserialize)]
+pub struct RenderModeCommand {
+    pub mode: String,
+}
+
 /// A request from the HTTP thread to the GL loop. Each variant carries a
 /// one-shot `Sender` the GL loop uses to reply; the HTTP handler blocks on the
 /// matching `Receiver`.
@@ -82,6 +94,8 @@ pub enum DebugRequest {
     Input(InputCommand, Sender<Result<(), String>>),
     /// `POST /time` — set/advance/resume the clock; reply once applied.
     Time(TimeCommand, Sender<()>),
+    /// `POST /render-mode` — switch the debug render mode; reply Ok or an error.
+    RenderMode(RenderModeCommand, Sender<Result<(), String>>),
 }
 
 /// Start the debug HTTP server on a background thread. Returns the receiving end
@@ -233,6 +247,41 @@ pub fn spawn(port: u16) -> Receiver<DebugRequest> {
                         Err(_) => {
                             let _ = request
                                 .respond(Response::from_string("time failed").with_status_code(500));
+                        }
+                    }
+                }
+                (Method::Post, "/render-mode") => {
+                    let mut body = String::new();
+                    if request.as_reader().read_to_string(&mut body).is_err() {
+                        let _ = request.respond(Response::from_string("bad body").with_status_code(400));
+                        continue;
+                    }
+                    let cmd: RenderModeCommand = match serde_json::from_str(&body) {
+                        Ok(c) => c,
+                        Err(e) => {
+                            let _ = request.respond(
+                                Response::from_string(format!("bad render-mode json: {}", e))
+                                    .with_status_code(400),
+                            );
+                            continue;
+                        }
+                    };
+                    let (resp_tx, resp_rx) = mpsc::channel();
+                    if tx.send(DebugRequest::RenderMode(cmd, resp_tx)).is_err() {
+                        let _ = request.respond(Response::from_string("runtime gone").with_status_code(503));
+                        continue;
+                    }
+                    match resp_rx.recv() {
+                        Ok(Ok(())) => {
+                            let _ = request.respond(Response::from_string("ok"));
+                        }
+                        Ok(Err(msg)) => {
+                            let _ = request.respond(Response::from_string(msg).with_status_code(400));
+                        }
+                        Err(_) => {
+                            let _ = request.respond(
+                                Response::from_string("render-mode failed").with_status_code(500),
+                            );
                         }
                     }
                 }

--- a/runtime/functor-runtime-desktop/src/main.rs
+++ b/runtime/functor-runtime-desktop/src/main.rs
@@ -109,6 +109,15 @@ impl From<DebugRenderArg> for functor_runtime_common::DebugRenderMode {
     }
 }
 
+/// The wire/label spelling of a render mode, for `GET /state` and `POST
+/// /render-mode`. Kept in sync with the `POST /render-mode` parser.
+fn render_mode_label(mode: functor_runtime_common::DebugRenderMode) -> &'static str {
+    match mode {
+        functor_runtime_common::DebugRenderMode::Default => "default",
+        functor_runtime_common::DebugRenderMode::Normals => "normals",
+    }
+}
+
 #[derive(Parser, Debug, Clone)]
 #[command(author, version, about, long_about = None)]
 struct Args {
@@ -272,6 +281,10 @@ pub async fn main() {
         // one-shot dt advance on the next frame. Seeded from --fixed-time.
         let mut held_time: Option<f32> = args.fixed_time;
         let mut pending_step: Option<f32> = None;
+        // Debug-server render-mode control (POST /render-mode). Seeded from
+        // --debug-render; mutated live by the debug server.
+        let mut current_debug_render_mode: functor_runtime_common::DebugRenderMode =
+            args.debug_render.into();
 
         use glfw::Context;
 
@@ -361,7 +374,7 @@ pub async fn main() {
                 shader_version,
                 asset_cache: asset_cache.clone(),
                 frame_time: time.clone(),
-                debug_render_mode: args.debug_render.into(),
+                debug_render_mode: current_debug_render_mode,
             };
 
             // The game supplies the camera as part of its frame; derive the
@@ -424,6 +437,8 @@ pub async fn main() {
                                 tts: time.tts,
                                 width: fb_width as u32,
                                 height: fb_height as u32,
+                                render_mode: render_mode_label(current_debug_render_mode)
+                                    .to_string(),
                                 model: game.state_debug(),
                             });
                         }
@@ -474,6 +489,26 @@ pub async fn main() {
                                 }
                             }
                             let _ = resp.send(());
+                        }
+                        debug_server::DebugRequest::RenderMode(cmd, resp) => {
+                            // Takes effect on the next frame's render_context.
+                            let result = match cmd.mode.to_ascii_lowercase().as_str() {
+                                "default" => {
+                                    current_debug_render_mode =
+                                        functor_runtime_common::DebugRenderMode::Default;
+                                    Ok(())
+                                }
+                                "normals" => {
+                                    current_debug_render_mode =
+                                        functor_runtime_common::DebugRenderMode::Normals;
+                                    Ok(())
+                                }
+                                other => Err(format!(
+                                    "unknown render mode: {} (expected default|normals)",
+                                    other
+                                )),
+                            };
+                            let _ = resp.send(result);
                         }
                     }
                 }


### PR DESCRIPTION
**Stacked on #91.** The "command" half of the normal-view toggle we planned: the `--debug-render` CLI flag (#90) is native, set-at-startup; this adds a live HTTP toggle on the debug server. Fits the LLM-native goal — drive *and* observe the renderer with no window interaction.

## What's here

- **`POST /render-mode`** `{"mode":"normals"}` / `{"mode":"default"}` — switches `DebugRenderMode` at runtime; unknown modes reply **400** with a message. Modeled on the existing `/input` handler.
- The runner keeps the mode in a mutable `current_debug_render_mode` (seeded from `--debug-render`); the per-frame `RenderContext` reads it, so a toggle takes effect on the next frame.
- **`GET /state` gains a `renderMode` field** so the active mode is observable, not just settable.

## Verification

Driven over HTTP against a running `functor-runner --debug-port 9090`:

| step | result |
| --- | --- |
| `GET /state` | `"renderMode":"default"` |
| `POST /render-mode {"mode":"normals"}` | `ok` |
| `GET /state` | `"renderMode":"normals"` |
| `POST /capture` | PNG is the **normals view** (sphere gradient, cube face colors, models + terrain as normals) — confirms the toggle changed the actual rendering, not just the state string |
| `POST /render-mode {"mode":"bogus"}` | `unknown render mode: bogus (expected default\|normals)` — **HTTP 400** |
| `POST /render-mode {"mode":"default"}` then `GET /state` | back to `"renderMode":"default"` |

## Notes

- Native debug-server only (consistent with the rest of the debug server). The separate **wasm `--debug-render` plumbing gap** from #90/#91 is still open and unrelated to this endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
