### PR TITLE
fix(geometry): correct cylinder end-cap construction

### DIFF
--- a/runtime/functor-runtime-common/src/geometry/cylinder.rs
+++ b/runtime/functor-runtime-common/src/geometry/cylinder.rs
@@ -61,60 +61,92 @@ fn generate_cylinder(
         }
     }
 
-    // Generate the vertices and indices for the top and bottom caps
-    let top_center_index = vertices.len() as usize;
+    // Caps: each is a triangle fan of (center + a contiguous ring). The ring
+    // vertices are pushed in their own loop so a fan index is just
+    // `ring_start + slice` — the previous version interleaved top/bottom ring
+    // vertices but indexed them as one-per-slice, which built broken caps.
+    let cap_uv = |angle: f32| Vector2::new(angle.cos() * 0.5 + 0.5, angle.sin() * 0.5 + 0.5);
+
+    // Top cap (faces +Y).
+    let top_center_index = vertices.len();
     vertices.push(Vertex {
         position: Vector3::new(0.0, height / 2.0, 0.0),
         normal: Vector3::new(0.0, 1.0, 0.0),
         tex_coords: Vector2::new(0.5, 0.5),
     });
+    let top_ring_start = vertices.len();
+    for slice in 0..=slices {
+        let angle = (slice as f32 / slices as f32) * 2.0 * PI;
+        vertices.push(Vertex {
+            position: Vector3::new(angle.cos() * radius, height / 2.0, angle.sin() * radius),
+            normal: Vector3::new(0.0, 1.0, 0.0),
+            tex_coords: cap_uv(angle),
+        });
+    }
+    for slice in 0..slices as usize {
+        indices.push(top_center_index);
+        indices.push(top_ring_start + slice);
+        indices.push(top_ring_start + slice + 1);
+    }
 
-    let bottom_center_index = vertices.len() as usize;
+    // Bottom cap (faces -Y; reversed winding so it's outward-facing).
+    let bottom_center_index = vertices.len();
     vertices.push(Vertex {
         position: Vector3::new(0.0, -height / 2.0, 0.0),
         normal: Vector3::new(0.0, -1.0, 0.0),
         tex_coords: Vector2::new(0.5, 0.5),
     });
-
+    let bottom_ring_start = vertices.len();
     for slice in 0..=slices {
-        let slice_fraction = slice as f32 / slices as f32;
-        let angle = slice_fraction * 2.0 * PI;
-
-        let x = angle.cos() * radius;
-        let z = angle.sin() * radius;
-
-        let top_position = Vector3::new(x, height / 2.0, z);
-        let bottom_position = Vector3::new(x, -height / 2.0, z);
-        let normal = Vector3::new(0.0, 1.0, 0.0);
-        let tex_coords = Vector2::new(slice_fraction, 0.0);
-
+        let angle = (slice as f32 / slices as f32) * 2.0 * PI;
         vertices.push(Vertex {
-            position: top_position,
-            normal,
-            tex_coords: Vector2::new(slice_fraction, 1.0),
+            position: Vector3::new(angle.cos() * radius, -height / 2.0, angle.sin() * radius),
+            normal: Vector3::new(0.0, -1.0, 0.0),
+            tex_coords: cap_uv(angle),
         });
-
-        vertices.push(Vertex {
-            position: bottom_position,
-            normal: -normal,
-            tex_coords,
-        });
-
-        let top_index = (top_center_index + slice as usize + 1) as usize;
-        let bottom_index = (bottom_center_index + slice as usize + 1) as usize;
-
-        if slice < slices {
-            indices.push(top_center_index);
-            indices.push(top_index);
-            indices.push(top_index + 1);
-
-            indices.push(bottom_center_index);
-            indices.push(bottom_index + 1);
-            indices.push(bottom_index);
-        }
+    }
+    for slice in 0..slices as usize {
+        indices.push(bottom_center_index);
+        indices.push(bottom_ring_start + slice + 1);
+        indices.push(bottom_ring_start + slice);
     }
 
     (vertices, indices)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::generate_cylinder;
+
+    #[test]
+    fn cap_fans_are_planar_and_in_bounds() {
+        let height = 2.0;
+        let half = height / 2.0;
+        let (verts, indices) = generate_cylinder(8, 4, height, 0.5);
+
+        assert_eq!(indices.len() % 3, 0, "indices must form triangles");
+
+        // The two cap centers are the only vertices on the axis (x = z = 0).
+        let is_cap_center =
+            |&i: &usize| verts[i].position.x == 0.0 && verts[i].position.z == 0.0;
+
+        for tri in indices.chunks(3) {
+            for &i in tri {
+                assert!(i < verts.len(), "index {i} out of bounds");
+            }
+            // A triangle that touches a cap center is a cap fan triangle; all
+            // three of its vertices must lie on that cap's plane (the bug pulled
+            // in interleaved vertices from the opposite cap).
+            if tri.iter().any(is_cap_center) {
+                let y0 = verts[tri[0]].position.y;
+                assert!(
+                    y0.abs() == half && tri.iter().all(|&i| verts[i].position.y == y0),
+                    "cap fan triangle spans planes: {:?}",
+                    tri.iter().map(|&i| verts[i].position.y).collect::<Vec<_>>()
+                );
+            }
+        }
+    }
 }
 
 impl Cylinder {


### PR DESCRIPTION
The cylinder's end caps were malformed — noticed on the lighting sample's cylinder under the spot light.

## Cause

The cap loop pushed **two** vertices per slice (top then bottom, interleaved) but computed the fan indices as if there were **one per slice** (`top_center_index + slice + 1`). So e.g. slice 0's "top" index actually pointed at the bottom-center vertex, and each fan triangle pulled in interleaved vertices from the wrong cap plane.

## Fix

Rebuild each cap as a center vertex + a **contiguous ring** (its own loop), so a fan index is simply `ring_start + slice`. Bottom cap uses reversed winding so it faces outward. Cap UVs are now a proper radial disc mapping.

## Verification

- **Unit test** `cap_fans_are_planar_and_in_bounds`: every triangle touching a cap center has all three vertices on a single cap plane (`y = ±height/2`) and all indices in bounds — exactly the invariant the bug violated.
- Visual: a temporarily-prominent, tilted cylinder renders a clean solid cap (reverted; not committed).
- `hello`'s golden is **unchanged** (its cylinder sits below the terrain, so the caps aren't visible there) — no regen needed.

## Note

The `lighting` sample (#96, where the cylinder cap is clearly visible) will want its golden regenerated once this and #96 both land, since the cylinder geometry changes there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)