### PR TITLE
refactor(runtime): shared render_frame path for native + wasm shells

### DIFF
--- a/runtime/functor-runtime-common/src/lib.rs
+++ b/runtime/functor-runtime-common/src/lib.rs
@@ -81,6 +81,7 @@ pub mod math;
 pub mod model;
 pub mod render;
 mod render_context;
+mod renderer;
 mod scene3d;
 mod shader;
 pub mod shadow;
@@ -96,6 +97,7 @@ pub use frame_time::*;
 pub use input::*;
 pub use light::*;
 pub use render_context::*;
+pub use renderer::*;
 pub use scene3d::*;
 pub use viewport::*;
 

--- a/runtime/functor-runtime-common/src/renderer.rs
+++ b/runtime/functor-runtime-common/src/renderer.rs
@@ -1,0 +1,104 @@
+use std::sync::Arc;
+
+use cgmath::{Matrix4, SquareMatrix};
+use glow::HasContext;
+
+use crate::asset::AssetCache;
+use crate::material::BasicMaterial;
+use crate::shadow::{self, ShadowMap};
+use crate::{
+    DebugRenderMode, Frame, FrameTime, RenderContext, RenderPass, Scene3D, SceneContext,
+    ShadowUniforms, Viewport,
+};
+
+/// Render one `Frame` to the currently-bound (default) framebuffer.
+///
+/// This is the *shared* per-frame render path: both shells — the desktop runner
+/// (`functor-runtime-desktop`) and the web runtime (`functor-runtime-web`) — call
+/// this with their own GL context, so the shadow + forward orchestration lives in
+/// one type-checked place instead of being copy-pasted (and drifting) between the
+/// two. The shells keep only what is genuinely platform-specific: creating the GL
+/// context, obtaining the `Frame` (dylib FFI vs. JsValue marshalling), computing
+/// the viewport (window framebuffer vs. canvas), input, and frame capture.
+///
+/// Steps, mirroring what each shell used to do inline:
+/// 1. Shadow pass — render the scene into `shadow_map` from the first
+///    shadow-casting light (directional or spot), producing `ShadowUniforms`.
+/// 2. Forward pass — clear, then `Scene3D::render` with the lights + shadow map.
+pub fn render_frame(
+    gl: &glow::Context,
+    shader_version: &str,
+    asset_cache: Arc<AssetCache>,
+    scene_context: &SceneContext,
+    shadow_map: &ShadowMap,
+    frame: &Frame,
+    frame_time: FrameTime,
+    viewport: Viewport,
+    debug_render_mode: DebugRenderMode,
+) {
+    // Shadow pass: render the scene into the shadow map from the first
+    // shadow-casting light (directional or spot), before the main pass. Skinned
+    // casters come for free via the shared depth pass in `Scene3D::render`.
+    let shadow = frame
+        .lights
+        .iter()
+        .enumerate()
+        .find_map(|(i, l)| shadow::light_space_matrix(l).map(|m| (i, m)))
+        .map(|(light_index, light_space_matrix)| {
+            shadow::render_shadow_pass(
+                gl,
+                shader_version,
+                asset_cache.clone(),
+                frame_time.clone(),
+                &frame.lights,
+                &frame.scene,
+                scene_context,
+                shadow_map,
+                light_space_matrix,
+            );
+            ShadowUniforms {
+                depth_texture: shadow_map.depth_texture,
+                light_space_matrix,
+                light_index: light_index as i32,
+            }
+        });
+
+    // Main (forward) pass into the bound framebuffer. Reset the clear color (the
+    // shadow pass cleared its depth-color buffer to white).
+    unsafe {
+        gl.viewport(0, 0, viewport.width as i32, viewport.height as i32);
+        gl.clear_color(0.1, 0.2, 0.3, 1.0);
+        gl.clear(glow::COLOR_BUFFER_BIT | glow::DEPTH_BUFFER_BIT);
+    }
+
+    let render_context = RenderContext {
+        gl,
+        shader_version,
+        asset_cache: asset_cache.clone(),
+        frame_time,
+        debug_render_mode,
+        lights: &frame.lights,
+        render_pass: RenderPass::Forward,
+        shadow,
+    };
+
+    // The game supplies the camera; derive view/projection from it + the aspect.
+    let world_matrix = Matrix4::identity();
+    let view_matrix = frame.camera.view_matrix();
+    let projection_matrix = frame.camera.projection_matrix(viewport.aspect());
+
+    // Root material for nodes that don't set their own (scenes typically override
+    // per-node); initialized against this frame's context.
+    let mut root_material = BasicMaterial::create();
+    root_material.initialize(&render_context);
+
+    Scene3D::render(
+        &frame.scene,
+        &render_context,
+        scene_context,
+        &world_matrix,
+        &projection_matrix,
+        &view_matrix,
+        &root_material,
+    );
+}

--- a/runtime/functor-runtime-desktop/src/main.rs
+++ b/runtime/functor-runtime-desktop/src/main.rs
@@ -4,9 +4,7 @@ use std::env;
 use std::sync::Arc;
 use std::time::Instant;
 
-use cgmath::{vec4, Matrix4};
 use functor_runtime_common::asset::AssetCache;
-use functor_runtime_common::material::ColorMaterial;
 use functor_runtime_common::{FrameTime, SceneContext};
 use functor_runtime_common::Key as InputKey;
 use glfw::{Action, Key};
@@ -262,8 +260,6 @@ pub async fn main() {
 
         gl.enable(glow::DEPTH_TEST);
 
-        let world_matrix = Matrix4::from_nonuniform_scale(1.0, 1.0, 1.0);
-
         let start_time = Instant::now();
         let mut last_time: f32 = 0.0;
         let mut frame_count: u64 = 0;
@@ -366,71 +362,17 @@ pub async fn main() {
             // The game supplies the camera/scene/lights as part of its frame.
             let frame = game.render(time.clone());
 
-            // Shadow pass: render the scene into the shadow map from the first
-            // shadow-casting light (directional or spot), before the main pass.
-            let shadow = frame
-                .lights
-                .iter()
-                .enumerate()
-                .find_map(|(i, l)| {
-                    functor_runtime_common::shadow::light_space_matrix(l).map(|m| (i, m))
-                })
-                .map(|(light_index, light_space_matrix)| {
-                    functor_runtime_common::shadow::render_shadow_pass(
-                        &gl,
-                        shader_version,
-                        asset_cache.clone(),
-                        time.clone(),
-                        &frame.lights,
-                        &frame.scene,
-                        &scene_context,
-                        &shadow_map,
-                        light_space_matrix,
-                    );
-                    functor_runtime_common::ShadowUniforms {
-                        depth_texture: shadow_map.depth_texture,
-                        light_space_matrix,
-                        light_index: light_index as i32,
-                    }
-                });
-
-            // Main (forward) pass into the window framebuffer. Reset the clear
-            // color (the shadow pass cleared its depth-color buffer to white).
-            gl.viewport(0, 0, fb_width, fb_height);
-            gl.clear_color(0.1, 0.2, 0.3, 1.0);
-            gl.clear(glow::COLOR_BUFFER_BIT | glow::DEPTH_BUFFER_BIT);
-
-            let render_context = functor_runtime_common::RenderContext {
-                gl: &gl,
+            // Shadow + forward passes, shared with the web runtime.
+            functor_runtime_common::render_frame(
+                &gl,
                 shader_version,
-                asset_cache: asset_cache.clone(),
-                frame_time: time.clone(),
-                debug_render_mode: args.debug_render.into(),
-                lights: &frame.lights,
-                render_pass: functor_runtime_common::RenderPass::Forward,
-                shadow,
-            };
-
-            let view_matrix = frame.camera.view_matrix();
-            let projection_matrix = frame.camera.projection_matrix(viewport.aspect());
-
-            // TODO: Factor out to pass in current_material
-            // let mut basic_material = BasicMaterial::create();
-            // basic_material.initialize(&context);
-
-            // asset.get().bind(0, &context);
-
-            let mut color_material = ColorMaterial::create(vec4(1.0, 0.0, 0.0, 1.0));
-            color_material.initialize(&render_context);
-
-            functor_runtime_common::Scene3D::render(
-                &frame.scene,
-                &render_context,
+                asset_cache.clone(),
                 &scene_context,
-                &world_matrix,
-                &projection_matrix,
-                &view_matrix,
-                &color_material,
+                &shadow_map,
+                &frame,
+                time.clone(),
+                viewport,
+                args.debug_render.into(),
             );
 
             if let Some(capture_path) = &args.capture_frame {

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -7,16 +7,14 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use cgmath::Matrix4;
 use functor_runtime_common::asset::pipelines::TexturePipeline;
 use functor_runtime_common::asset::{AssetCache, AssetLoader};
 use functor_runtime_common::geometry::Geometry;
 use functor_runtime_common::io::load_bytes_async;
-use functor_runtime_common::material::BasicMaterial;
 use functor_runtime_common::texture::{
     RuntimeTexture, Texture2D, TextureData, TextureFormat, TextureOptions, PNG,
 };
-use functor_runtime_common::{Frame, FrameTime, RenderContext, SceneContext};
+use functor_runtime_common::{Frame, FrameTime, SceneContext};
 use glow::*;
 use js_sys::{Function, Object, Reflect, WebAssembly};
 use wasm_bindgen::JsValue;
@@ -232,42 +230,11 @@ async fn run_async() -> Result<(), JsValue> {
             };
 
             last_time = now;
-            let world_matrix = Matrix4::from_nonuniform_scale(1.0, 1.0, 1.0);
 
             game_tick(functor_runtime_common::to_js_value(&frame_time));
 
             let val = game_render(functor_runtime_common::to_js_value(&frame_time));
             let frame: Frame = functor_runtime_common::from_js_value(val);
-
-            // Shadow pass: render the scene into the shadow map from the first
-            // shadow-casting light (directional or spot), before the main pass.
-            // Mirrors the desktop runtime; skinned casters come for free via the
-            // shared depth pass in Scene3D::render.
-            let shadow = frame
-                .lights
-                .iter()
-                .enumerate()
-                .find_map(|(i, l)| {
-                    functor_runtime_common::shadow::light_space_matrix(l).map(|m| (i, m))
-                })
-                .map(|(light_index, light_space_matrix)| {
-                    functor_runtime_common::shadow::render_shadow_pass(
-                        &gl,
-                        shader_version,
-                        asset_cache.clone(),
-                        frame_time.clone(),
-                        &frame.lights,
-                        &frame.scene,
-                        &scene_context,
-                        &shadow_map,
-                        light_space_matrix,
-                    );
-                    functor_runtime_common::ShadowUniforms {
-                        depth_texture: shadow_map.depth_texture,
-                        light_space_matrix,
-                        light_index: light_index as i32,
-                    }
-                });
 
             // Match the drawable buffer to the canvas's displayed (CSS) size,
             // scaled for HiDPI, so the view follows browser/window resizes.
@@ -282,41 +249,17 @@ async fn run_async() -> Result<(), JsValue> {
             }
             let viewport = functor_runtime_common::Viewport::new(canvas.width(), canvas.height());
 
-            // Main (forward) pass into the canvas. Reset the clear color (the
-            // shadow pass cleared its depth-color buffer to white).
-            gl.viewport(0, 0, viewport.width as i32, viewport.height as i32);
-            gl.clear_color(0.1, 0.2, 0.3, 1.0);
-            gl.clear(glow::COLOR_BUFFER_BIT | glow::DEPTH_BUFFER_BIT);
-
-            // Built after the frame so it can carry the frame's lights + shadow.
-            let render_ctx = RenderContext {
-                gl: &gl,
+            // Shadow + forward passes, shared with the desktop runtime.
+            functor_runtime_common::render_frame(
+                &gl,
                 shader_version,
-                asset_cache: asset_cache.clone(),
-                frame_time: frame_time.clone(),
-                debug_render_mode,
-                lights: &frame.lights,
-                render_pass: functor_runtime_common::RenderPass::Forward,
-                shadow,
-            };
-
-            // The game supplies the camera; derive view/projection from it.
-            let view_matrix = frame.camera.view_matrix();
-            let projection_matrix = frame.camera.projection_matrix(viewport.aspect());
-
-            let mut basic_material = BasicMaterial::create();
-            basic_material.initialize(&render_ctx);
-
-            // asset.get().bind(0, &render_ctx);
-
-            functor_runtime_common::Scene3D::render(
-                &frame.scene,
-                &render_ctx,
+                asset_cache.clone(),
                 &scene_context,
-                &world_matrix,
-                &projection_matrix,
-                &view_matrix,
-                &basic_material,
+                &shadow_map,
+                &frame,
+                frame_time.clone(),
+                viewport,
+                debug_render_mode,
             );
 
             // Schedule ourself for another requestAnimationFrame callback.


### PR DESCRIPTION
First step toward unifying the native + wasm validation harness: collapse the
duplicated per-frame render orchestration into one shared function so the two
runtimes can't drift.

## Why

The shadow + forward render path was copy-pasted in both shells
(`functor-runtime-desktop/main.rs` and `functor-runtime-web/lib.rs`). That
duplication is exactly what caused the #103/#104 break — wasm kept calling the
renamed-away `render_directional_shadow` while desktop was updated. The two had
also silently diverged on the root material (`ColorMaterial` red vs
`BasicMaterial`).

## What

- New `functor_runtime_common::render_frame(gl, …, frame, viewport, debug_mode)`:
  shadow pass (first casting light → `render_shadow_pass` → `ShadowUniforms`)
  then the forward `Scene3D::render`.
- Both shells call it. They keep only genuinely platform-specific glue: GL/context
  creation, obtaining the `Frame` (dylib FFI vs. JsValue), viewport source
  (window framebuffer vs. canvas), input, and frame capture.

One orchestration, type-checked in the common crate that **every** CI job
compiles — so a future API change is a single call site and can't drift between
targets again. Net **−113 lines** across the shells.

## Validation (behavior-preserving)

- `cargo build --features=strict` (desktop) and `cargo check --target wasm32`
  (web) both clean.
- The wasm Playwright golden still matches the committed reference.
- A native `--fixed-time 2` lighting capture is identical to the committed
  native golden (the root-material unification has no visible effect — nothing
  relied on the red `ColorMaterial` fallback).

Stacked on #104. Next: unify the golden *validation* itself (a shared scenario
list — scene + fixed-time + tolerance — driven against both targets), now that
both exercise the same `render_frame`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)