### PR TITLE
chore: strip debug info from third-party deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,14 @@ members = [
     "src",
 ]
 
+# Strip debug info from all third-party dependencies. Our own crates keep full
+# debug info; the deps don't need it, and their debuginfo dominates target/ size
+# (it was repeatedly filling the disk during development). The per-package
+# opt-level overrides below still apply and inherit `debug = false` from this
+# wildcard.
+[profile.dev.package."*"]
+debug = false
+
 # Image decoding runs in the asset pipeline at game load; unoptimized it is
 # 10-100x slower, which makes texture-heavy models (e.g. a 47MB fish.glb)
 # appear to never load in debug builds of functor-runner. Optimize just the

--- a/examples/hello/build-native/Cargo.toml
+++ b/examples/hello/build-native/Cargo.toml
@@ -24,6 +24,8 @@ fable_library_rust = { path = "./../../../fable_modules/fable-library-rust" }
 # https://github.com/erezsh/hexx/commit/45773dd471f352a5a424e274048d17da96a9e116
 [profile.dev.package."*"]
 opt-level = 3
+# Deps don't need debug info, and it dominates target/ size.
+debug = false
 
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld.exe"

--- a/examples/lighting/build-native/Cargo.toml
+++ b/examples/lighting/build-native/Cargo.toml
@@ -24,6 +24,8 @@ fable_library_rust = { path = "./../../../fable_modules/fable-library-rust" }
 # https://github.com/erezsh/hexx/commit/45773dd471f352a5a424e274048d17da96a9e116
 [profile.dev.package."*"]
 opt-level = 3
+# Deps don't need debug info, and it dominates target/ size.
+debug = false
 
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld.exe"


### PR DESCRIPTION
Adds `[profile.dev.package."*"] debug = false` (workspace + the native example build-profiles) so dependency crates build without debug info. Dep debuginfo dominates the dev `target/` size — it was repeatedly filling the disk during development. Our own crates keep full debug info; existing per-package `opt-level = 3` overrides still apply (and now inherit `debug = false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)