### PR TITLE
Web HTTP dispatch (fetch)

### DIFF
--- a/runtime/functor-runtime-desktop/Cargo.toml
+++ b/runtime/functor-runtime-desktop/Cargo.toml
@@ -37,11 +37,6 @@ libloading = "0.8.3"
 functor_runtime_common = { path = "./../functor-runtime-common" }
 fable_library_rust = { path = "./../../fable_modules/fable-library-rust" }
 
-[dev-dependencies]
-libloading = "0.8.3"
-functor_runtime_common = { path = "./../functor-runtime-common" }
-fable_library_rust = { path = "./../../fable_modules/fable-library-rust" }
-
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", features=["HtmlCanvasElement", "WebGl2RenderingContext", "Window"] }
 wasm-bindgen = { version = "0.2" }

--- a/runtime/functor-runtime-web/Cargo.toml
+++ b/runtime/functor-runtime-web/Cargo.toml
@@ -15,10 +15,11 @@ js-sys = "0.3.69"
 wasm-bindgen = { version = "0.2.92" }
 wasm-bindgen-futures = "0.4.42"
 async-trait = "0.1.80"
+serde_json = "1.0"
 
 [dependencies.web-sys]
 version = "0.3.4"
-features = ['Blob', 'HtmlCanvasElement', 'WebGl2RenderingContext', 'console', 'Window', 'Location', 'Performance', 'PerformanceTiming', 'Document', 'Element']
+features = ['Blob', 'HtmlCanvasElement', 'WebGl2RenderingContext', 'console', 'Window', 'Location', 'Performance', 'PerformanceTiming', 'Document', 'Element', 'Request', 'RequestInit', 'Response', 'Headers']
 
 [profile.release]
 codegen-units = 1

--- a/runtime/functor-runtime-web/index.html
+++ b/runtime/functor-runtime-web/index.html
@@ -17,7 +17,10 @@
         tick_wasm,
         key_event_wasm,
         mouse_move_wasm,
-        mouse_wheel_wasm
+        mouse_wheel_wasm,
+        net_drain_commands_json_wasm,
+        net_push_http_response_wasm,
+        net_push_http_error_wasm
       } from "./build-wasm/pkg/game_wasm.js";
       import startRuntime from "./pkg/functor_runtime_web.js";
 
@@ -92,6 +95,14 @@
         window.game.tick = (frameTime) => {
           return tick_wasm(frameTime);
         }
+
+        // Networking bridge: the web runtime drains queued commands and pushes
+        // results back through these (see functor-runtime-web dispatch_net_commands).
+        window.game.net_drain_commands_json = () => net_drain_commands_json_wasm();
+        window.game.net_push_http_response = (token, status, body) =>
+          net_push_http_response_wasm(token, status, body);
+        window.game.net_push_http_error = (token, message) =>
+          net_push_http_error_wasm(token, message);
 
         // In a deterministic capture (?fixed-time), don't wire up input — a
         // stray mouse move would turn the camera, like on native.

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -11,6 +11,7 @@ use functor_runtime_common::asset::pipelines::TexturePipeline;
 use functor_runtime_common::asset::{AssetCache, AssetLoader};
 use functor_runtime_common::geometry::Geometry;
 use functor_runtime_common::io::load_bytes_async;
+use functor_runtime_common::net::{HttpMethod, NetCommand};
 use functor_runtime_common::texture::{
     RuntimeTexture, Texture2D, TextureData, TextureFormat, TextureOptions, PNG,
 };
@@ -79,6 +80,103 @@ extern "C" {
 
     #[wasm_bindgen(js_namespace = game, js_name = tick)]
     fn game_tick(frameTimeJs: JsValue);
+
+    // Networking bridge into the game module (see Runtime.Wasm). The game queues
+    // commands as a JSON string; results are pushed back as JS strings.
+    #[wasm_bindgen(js_namespace = game, js_name = net_drain_commands_json)]
+    fn game_net_drain_commands() -> JsValue;
+
+    #[wasm_bindgen(js_namespace = game, js_name = net_push_http_response)]
+    fn game_net_push_http_response(token: i32, status: i32, body: JsValue);
+
+    #[wasm_bindgen(js_namespace = game, js_name = net_push_http_error)]
+    fn game_net_push_http_error(token: i32, message: JsValue);
+}
+
+fn http_method_str(method: HttpMethod) -> &'static str {
+    match method {
+        HttpMethod::Get => "GET",
+        HttpMethod::Post => "POST",
+        HttpMethod::Put => "PUT",
+        HttpMethod::Delete => "DELETE",
+    }
+}
+
+fn js_err(v: JsValue) -> String {
+    v.as_string().unwrap_or_else(|| "fetch error".to_string())
+}
+
+/// Drain the game's queued networking commands and start a `fetch` for each. The
+/// result is pushed back into the game's inbox when the fetch resolves (a later
+/// microtask), so the next `tick` decodes it — same shape as the native loop.
+/// JS is single-threaded, so a push always completes before the next frame's tick.
+fn dispatch_net_commands() {
+    let json = game_net_drain_commands()
+        .as_string()
+        .unwrap_or_else(|| "[]".to_string());
+    if json == "[]" {
+        return;
+    }
+    match serde_json::from_str::<Vec<NetCommand>>(&json) {
+        Ok(commands) => {
+            for cmd in commands {
+                spawn_local(perform_and_push(cmd));
+            }
+        }
+        Err(e) => {
+            web_sys::console::error_1(&format!("[net] bad commands json: {e}").into());
+        }
+    }
+}
+
+async fn perform_and_push(cmd: NetCommand) {
+    let NetCommand::HttpRequest {
+        token,
+        method,
+        url,
+        headers,
+        body,
+    } = cmd;
+    let token = token as i32;
+    match perform_fetch(method, &url, &headers, &body).await {
+        Ok((status, text)) => game_net_push_http_response(token, status, JsValue::from_str(&text)),
+        Err(message) => game_net_push_http_error(token, JsValue::from_str(&message)),
+    }
+}
+
+async fn perform_fetch(
+    method: HttpMethod,
+    url: &str,
+    headers: &[(String, String)],
+    body: &[u8],
+) -> Result<(i32, String), String> {
+    use wasm_bindgen::JsCast;
+    use web_sys::{Request, RequestInit, Response};
+
+    let mut opts = RequestInit::new();
+    opts.method(http_method_str(method));
+    if !body.is_empty() {
+        let text = String::from_utf8_lossy(body).to_string();
+        opts.body(Some(&JsValue::from_str(&text)));
+    }
+
+    let request = Request::new_with_str_and_init(url, &opts).map_err(js_err)?;
+    for (name, value) in headers {
+        request.headers().set(name, value).map_err(js_err)?;
+    }
+
+    let window = web_sys::window().ok_or_else(|| "no window".to_string())?;
+    let resp_value = JsFuture::from(window.fetch_with_request(&request))
+        .await
+        .map_err(js_err)?;
+    let response: Response = resp_value
+        .dyn_into()
+        .map_err(|_| "not a Response".to_string())?;
+    let status = response.status() as i32;
+    let text_value = JsFuture::from(response.text().map_err(js_err)?)
+        .await
+        .map_err(js_err)?;
+    Ok((status, text_value.as_string().unwrap_or_default()))
 }
 
 #[wasm_bindgen(start)]
@@ -232,6 +330,11 @@ async fn run_async() -> Result<(), JsValue> {
             last_time = now;
 
             game_tick(functor_runtime_common::to_js_value(&frame_time));
+
+            // Perform any networking commands this frame's tick queued; results
+            // are pushed back into the inbox asynchronously and decoded by a later
+            // tick (see dispatch_net_commands).
+            dispatch_net_commands();
 
             let val = game_render(functor_runtime_common::to_js_value(&frame_time));
             let frame: Frame = functor_runtime_common::from_js_value(val);

--- a/src/Functor.Game/Runtime.fs
+++ b/src/Functor.Game/Runtime.fs
@@ -75,14 +75,42 @@ module Runtime
         [<OuterAttr("wasm_bindgen")>]
         let test_render_wasm (frameTimeJs: JsValue): JsValue =
             let frameTime = frameTimeJs |> UnsafeJsValue.from_js<Time.FrameTime>;
-            if currentRunner.IsSome then 
-                let ret = 
+            if currentRunner.IsSome then
+                let ret =
                     frameTime
                     |> currentRunner.Value.render
                     |> UnsafeJsValue.to_js
                 ret
-            else 
+            else
                 raise (System.Exception("No runner"))
+
+        // Networking bridge for the web runtime (mirrors the native exports). The
+        // web runtime is a separate wasm module, so it reaches the game's outbound
+        // command queue / async inbox only through these wasm_bindgen exports.
+        // Strings cross as JsValue (the existing marshalling convention) rather
+        // than via Fable's string type, to keep the wasm-bindgen ABI simple.
+        [<Emit("functor_runtime_common::to_js_value(&functor_runtime_common::net::drain_commands_json())")>]
+        let private netDrainCommandsJs () : JsValue = nativeOnly
+
+        [<Emit("functor_runtime_common::net::push_http_response($0 as u64, $1 as u16, functor_runtime_common::from_js_value::<String>($2).into_bytes())")>]
+        let private netPushHttpResponseJs (token: int) (status: int) (body: JsValue) : unit = nativeOnly
+
+        [<Emit("functor_runtime_common::net::push_http_error($0 as u64, functor_runtime_common::from_js_value::<String>($1))")>]
+        let private netPushHttpErrorJs (token: int) (message: JsValue) : unit = nativeOnly
+
+        /// Host: take the queued networking commands as a JSON string (JsValue).
+        [<OuterAttr("wasm_bindgen")>]
+        let net_drain_commands_json_wasm () : JsValue = netDrainCommandsJs ()
+
+        /// Host: deliver a completed HTTP response into the game's async inbox.
+        [<OuterAttr("wasm_bindgen")>]
+        let net_push_http_response_wasm (token: int, status: int, body: JsValue) : unit =
+            netPushHttpResponseJs token status body
+
+        /// Host: deliver a transport-level failure for a request into the inbox.
+        [<OuterAttr("wasm_bindgen")>]
+        let net_push_http_error_wasm (token: int, message: JsValue) : unit =
+            netPushHttpErrorJs token message
 
 
     ///////////////////////////////


### PR DESCRIPTION
**Stacked on #111** (base `multiplayer-host-dispatch`). Completes Phase 1 HTTP across both targets: the browser runtime now performs the game's queued requests via `fetch`, mirroring the desktop reqwest loop. First of three follow-up PRs (web → WebSockets → netsim SDK).

## What's here

Each frame the web runtime drains the game's commands (`net_drain_commands_json`), fires each as a `fetch` on `spawn_local`, and pushes the result back into the game's inbox (`net_push_http_response` / `net_push_http_error`) when it resolves — so the next `tick` applies the request's tagger and delivers the message.

- `Runtime.Wasm` gains the net export trio (strings cross as `JsValue`).
- `functor-runtime-web`: extern `game` bindings + `perform_fetch` + the dispatch loop; web-sys `Request`/`RequestInit`/`Response`/`Headers` + `serde_json`.
- `index.html` wires the new exports into the `game` namespace.

## Verification

Game wasm + web runtime compile for `wasm32-unknown-unknown`, and `wasm-pack` generates the `net_*_wasm` exports as JS-importable symbols (so the `index.html` imports resolve). Browser smoke test is manual (no headless browser in CI).

> Note: the HTTP API was reworked to the Elm `Http.get { expect = GotMsg }` style in #109 after this branch was first written; the web dispatch is unaffected (it deals in plain commands + token-keyed results), and this branch is rebased on the updated foundation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)