### PR TITLE
Native WebSocket host (tokio-tungstenite)

### DIFF
--- a/runtime/functor-runtime-desktop/Cargo.toml
+++ b/runtime/functor-runtime-desktop/Cargo.toml
@@ -34,6 +34,13 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 # Audio playback (the host owns the device so it survives hot reload). cpal needs
 # ALSA dev headers on Linux (libasound2-dev) — installed in the Build Native CI.
 rodio = { version = "0.19", default-features = false, features = ["symphonia-wav", "symphonia-vorbis"] }
+tokio-tungstenite = "0.21"
+futures-util = "0.3"
+
+[dev-dependencies]
+libloading = "0.8.3"
+functor_runtime_common = { path = "./../functor-runtime-common" }
+fable_library_rust = { path = "./../../fable_modules/fable-library-rust" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", features=["HtmlCanvasElement", "WebGl2RenderingContext", "Window"] }

--- a/runtime/functor-runtime-desktop/src/game.rs
+++ b/runtime/functor-runtime-desktop/src/game.rs
@@ -37,6 +37,16 @@ pub trait Game {
     /// `functor_runtime_common::audio::AudioCommand`), via the dylib's
     /// `audio_drain_commands_json` export. The host plays them on its own device.
     fn audio_drain_commands(&self) -> String;
+    /// Take the persistent-connection commands (connect/send/close) the game has
+    /// queued this frame, as a JSON array of `functor_runtime_common::net::ConnCommand`.
+    fn net_drain_conn_commands(&self) -> String;
+
+    /// Deliver a connection event into the game's inbound queue, tagged with the
+    /// connection's key (its endpoint url).
+    fn net_push_connected(&mut self, key: String, conn: i32);
+    fn net_push_conn_message(&mut self, key: String, conn: i32, text: String);
+    fn net_push_disconnected(&mut self, key: String, conn: i32);
+    fn net_push_conn_error(&mut self, key: String, conn: i32, message: String);
 
     fn quit(&mut self);
 }

--- a/runtime/functor-runtime-desktop/src/hot_reload_game.rs
+++ b/runtime/functor-runtime-desktop/src/hot_reload_game.rs
@@ -136,6 +136,79 @@ impl Game for HotReloadGame {
         }
     }
 
+
+    fn net_drain_conn_commands(&self) -> String {
+        unsafe {
+            let func: Symbol<fn() -> fable_library_rust::String_::LrcStr> = self
+                .library
+                .as_ref()
+                .unwrap()
+                .get(b"net_drain_conn_commands_json")
+                .unwrap();
+            func().to_string()
+        }
+    }
+
+    fn net_push_connected(&mut self, key: String, conn: i32) {
+        unsafe {
+            let func: Symbol<fn(fable_library_rust::String_::LrcStr, i32)> = self
+                .library
+                .as_ref()
+                .unwrap()
+                .get(b"net_push_connected")
+                .unwrap();
+            func(fable_library_rust::String_::fromString(key), conn)
+        }
+    }
+
+    fn net_push_conn_message(&mut self, key: String, conn: i32, text: String) {
+        unsafe {
+            let func: Symbol<
+                fn(fable_library_rust::String_::LrcStr, i32, fable_library_rust::String_::LrcStr),
+            > = self
+                .library
+                .as_ref()
+                .unwrap()
+                .get(b"net_push_conn_message")
+                .unwrap();
+            func(
+                fable_library_rust::String_::fromString(key),
+                conn,
+                fable_library_rust::String_::fromString(text),
+            )
+        }
+    }
+
+    fn net_push_disconnected(&mut self, key: String, conn: i32) {
+        unsafe {
+            let func: Symbol<fn(fable_library_rust::String_::LrcStr, i32)> = self
+                .library
+                .as_ref()
+                .unwrap()
+                .get(b"net_push_disconnected")
+                .unwrap();
+            func(fable_library_rust::String_::fromString(key), conn)
+        }
+    }
+
+    fn net_push_conn_error(&mut self, key: String, conn: i32, message: String) {
+        unsafe {
+            let func: Symbol<
+                fn(fable_library_rust::String_::LrcStr, i32, fable_library_rust::String_::LrcStr),
+            > = self
+                .library
+                .as_ref()
+                .unwrap()
+                .get(b"net_push_conn_error")
+                .unwrap();
+            func(
+                fable_library_rust::String_::fromString(key),
+                conn,
+                fable_library_rust::String_::fromString(message),
+            )
+        }
+    }
+
     fn quit(&mut self) {
         if let Some(handle) = self.watcher_thread.take() {
             handle.join().expect("Failed to join watcher thread");

--- a/runtime/functor-runtime-desktop/src/main.rs
+++ b/runtime/functor-runtime-desktop/src/main.rs
@@ -23,6 +23,7 @@ mod game;
 mod hot_reload_game;
 mod net_dispatch;
 mod static_game;
+mod ws_host;
 
 /// Translate a GLFW key into the canonical engine key code passed across the
 /// game boundary. Unmapped keys become InputKey::Unknown.
@@ -307,6 +308,12 @@ pub async fn main() {
         let http_client = reqwest::Client::new();
         let (net_tx, net_rx) = std::sync::mpsc::channel::<net_dispatch::NetResult>();
 
+        // WebSocket connections. Commands (connect/send/close) are drained each
+        // frame and performed by the manager on tokio tasks; socket events return
+        // over this channel and are pushed into the game on the main thread.
+        let (ws_tx, ws_rx) = std::sync::mpsc::channel::<ws_host::HostNetEvent>();
+        let mut ws_manager = ws_host::WsManager::new(ws_tx);
+
         // Audio device, owned by the host (survives hot reload). `None` when no
         // device is available — audio commands are then drained and dropped.
         let audio_player = audio::AudioPlayer::new();
@@ -384,6 +391,25 @@ pub async fn main() {
                 }
             }
 
+            // Likewise deliver WebSocket events before tick, so the executor routes
+            // them to the connection's decoder this frame.
+            while let Ok(event) = ws_rx.try_recv() {
+                match event {
+                    ws_host::HostNetEvent::Connected { key, id } => {
+                        game.net_push_connected(key, id as i32)
+                    }
+                    ws_host::HostNetEvent::Message { key, id, text } => {
+                        game.net_push_conn_message(key, id as i32, text)
+                    }
+                    ws_host::HostNetEvent::Disconnected { key, id } => {
+                        game.net_push_disconnected(key, id as i32)
+                    }
+                    ws_host::HostNetEvent::Error { key, id, message } => {
+                        game.net_push_conn_error(key, id as i32, message)
+                    }
+                }
+            }
+
             game.tick(time.clone());
 
             // Perform any networking commands this frame's tick queued. Each runs
@@ -405,6 +431,22 @@ pub async fn main() {
                         }
                     }
                     Err(e) => eprintln!("[net] bad commands json: {e}"),
+                }
+            }
+
+            // Perform any WebSocket commands this frame's tick queued (connect /
+            // send / close). The manager owns the sockets; events return via ws_rx.
+            let conn_json = game.net_drain_conn_commands();
+            if conn_json != "[]" {
+                match serde_json::from_str::<Vec<functor_runtime_common::net::ConnCommand>>(
+                    &conn_json,
+                ) {
+                    Ok(commands) => {
+                        for cmd in commands {
+                            ws_manager.handle(cmd);
+                        }
+                    }
+                    Err(e) => eprintln!("[net] bad conn commands json: {e}"),
                 }
             }
 

--- a/runtime/functor-runtime-desktop/src/static_game.rs
+++ b/runtime/functor-runtime-desktop/src/static_game.rs
@@ -89,6 +89,55 @@ impl Game for StaticGame {
         }
     }
 
+
+    fn net_drain_conn_commands(&self) -> String {
+        unsafe {
+            let func: Symbol<fn() -> fable_library_rust::String_::LrcStr> =
+                self.library.get(b"net_drain_conn_commands_json").unwrap();
+            func().to_string()
+        }
+    }
+
+    fn net_push_connected(&mut self, key: String, conn: i32) {
+        unsafe {
+            let func: Symbol<fn(fable_library_rust::String_::LrcStr, i32)> =
+                self.library.get(b"net_push_connected").unwrap();
+            func(fable_library_rust::String_::fromString(key), conn)
+        }
+    }
+
+    fn net_push_conn_message(&mut self, key: String, conn: i32, text: String) {
+        unsafe {
+            let func: Symbol<fn(fable_library_rust::String_::LrcStr, i32, fable_library_rust::String_::LrcStr)> =
+                self.library.get(b"net_push_conn_message").unwrap();
+            func(
+                fable_library_rust::String_::fromString(key),
+                conn,
+                fable_library_rust::String_::fromString(text),
+            )
+        }
+    }
+
+    fn net_push_disconnected(&mut self, key: String, conn: i32) {
+        unsafe {
+            let func: Symbol<fn(fable_library_rust::String_::LrcStr, i32)> =
+                self.library.get(b"net_push_disconnected").unwrap();
+            func(fable_library_rust::String_::fromString(key), conn)
+        }
+    }
+
+    fn net_push_conn_error(&mut self, key: String, conn: i32, message: String) {
+        unsafe {
+            let func: Symbol<fn(fable_library_rust::String_::LrcStr, i32, fable_library_rust::String_::LrcStr)> =
+                self.library.get(b"net_push_conn_error").unwrap();
+            func(
+                fable_library_rust::String_::fromString(key),
+                conn,
+                fable_library_rust::String_::fromString(message),
+            )
+        }
+    }
+
     fn quit(&mut self) {
         // Noop - nothing to do yet
     }

--- a/runtime/functor-runtime-desktop/src/ws_host.rs
+++ b/runtime/functor-runtime-desktop/src/ws_host.rs
@@ -1,0 +1,253 @@
+//! Native WebSocket host (Phase 2 host side, docs/multiplayer.md).
+//!
+//! The game declares connections via `Sub.connect`; the executor reconciles them
+//! into plain-data [`ConnCommand`]s. Each frame the main loop drains those and
+//! hands them to [`WsManager`], which owns the live `tokio-tungstenite` sockets.
+//! Socket I/O runs on tokio tasks; events come back over a channel and are pushed
+//! into the game on the main thread next frame (so all dylib calls stay on one
+//! thread), mirroring the HTTP dispatch.
+
+use std::collections::HashMap;
+use std::sync::mpsc::Sender;
+
+use functor_runtime_common::net::ConnCommand;
+use futures_util::{SinkExt, StreamExt};
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+use tokio_tungstenite::tungstenite::Message;
+
+/// A socket event for the main loop to push into the game (keyed by the
+/// connection's endpoint, the routing key the executor expects).
+pub enum HostNetEvent {
+    Connected { key: String, id: u64 },
+    Message { key: String, id: u64, text: String },
+    Disconnected { key: String, id: u64 },
+    Error { key: String, id: u64, message: String },
+}
+
+/// What the per-connection task should do next.
+enum OutMsg {
+    Send(Vec<u8>),
+    Close,
+}
+
+struct Conn {
+    id: u64,
+    out: UnboundedSender<OutMsg>,
+}
+
+/// Owns the live connections and turns [`ConnCommand`]s into socket operations.
+pub struct WsManager {
+    by_key: HashMap<String, Conn>,
+    key_by_id: HashMap<u64, String>,
+    next_id: u64,
+    events: Sender<HostNetEvent>,
+}
+
+impl WsManager {
+    pub fn new(events: Sender<HostNetEvent>) -> WsManager {
+        WsManager {
+            by_key: HashMap::new(),
+            key_by_id: HashMap::new(),
+            next_id: 1,
+            events,
+        }
+    }
+
+    pub fn handle(&mut self, cmd: ConnCommand) {
+        match cmd {
+            ConnCommand::Connect { key, url } => self.connect(key, url),
+            // Server (`listen`) is native-only and lands in a later PR.
+            ConnCommand::Listen { .. } => {}
+            ConnCommand::Send { conn, payload } => self.send(conn, payload),
+            ConnCommand::CloseConn { conn } => {
+                if let Some(key) = self.key_by_id.get(&conn).cloned() {
+                    self.close_key(&key);
+                }
+            }
+            ConnCommand::CloseKey { key } => self.close_key(&key),
+        }
+    }
+
+    fn connect(&mut self, key: String, url: String) {
+        // Idempotent by key: a re-declared connection (e.g. after a hot reload)
+        // reattaches to the live socket instead of opening a second one.
+        if self.by_key.contains_key(&key) {
+            return;
+        }
+        let id = self.next_id;
+        self.next_id += 1;
+        let (out_tx, out_rx) = unbounded_channel::<OutMsg>();
+        self.by_key.insert(key.clone(), Conn { id, out: out_tx });
+        self.key_by_id.insert(id, key.clone());
+        tokio::spawn(run_connection(key, id, url, out_rx, self.events.clone()));
+    }
+
+    fn send(&mut self, conn: u64, payload: Vec<u8>) {
+        if let Some(key) = self.key_by_id.get(&conn) {
+            if let Some(c) = self.by_key.get(key) {
+                // Drop is harmless: a closed connection just ignores the send.
+                let _ = c.out.send(OutMsg::Send(payload));
+            }
+        }
+    }
+
+    fn close_key(&mut self, key: &str) {
+        if let Some(c) = self.by_key.remove(key) {
+            self.key_by_id.remove(&c.id);
+            let _ = c.out.send(OutMsg::Close);
+        }
+    }
+}
+
+/// One connection's lifetime: connect, then pump outgoing sends and incoming
+/// frames until either side closes. Emits Connected/Message/Disconnected/Error.
+async fn run_connection(
+    key: String,
+    id: u64,
+    url: String,
+    mut out_rx: UnboundedReceiver<OutMsg>,
+    events: Sender<HostNetEvent>,
+) {
+    let ws = match tokio_tungstenite::connect_async(&url).await {
+        Ok((ws, _resp)) => ws,
+        Err(e) => {
+            let _ = events.send(HostNetEvent::Error {
+                key,
+                id,
+                message: e.to_string(),
+            });
+            return;
+        }
+    };
+    let _ = events.send(HostNetEvent::Connected {
+        key: key.clone(),
+        id,
+    });
+
+    let (mut write, mut read) = ws.split();
+    loop {
+        tokio::select! {
+            out = out_rx.recv() => match out {
+                Some(OutMsg::Send(payload)) => {
+                    // Send valid UTF-8 as a text frame, else binary.
+                    let msg = match String::from_utf8(payload) {
+                        Ok(text) => Message::Text(text),
+                        Err(e) => Message::Binary(e.into_bytes()),
+                    };
+                    if write.send(msg).await.is_err() {
+                        break;
+                    }
+                }
+                Some(OutMsg::Close) | None => {
+                    let _ = write.send(Message::Close(None)).await;
+                    break;
+                }
+            },
+            incoming = read.next() => match incoming {
+                Some(Ok(Message::Text(text))) => {
+                    let _ = events.send(HostNetEvent::Message { key: key.clone(), id, text });
+                }
+                Some(Ok(Message::Binary(data))) => {
+                    let _ = events.send(HostNetEvent::Message {
+                        key: key.clone(),
+                        id,
+                        text: String::from_utf8_lossy(&data).to_string(),
+                    });
+                }
+                Some(Ok(Message::Close(_))) | None => break,
+                // Ping/Pong/frame: handled by tungstenite / ignored here.
+                Some(Ok(_)) => {}
+                Some(Err(e)) => {
+                    let _ = events.send(HostNetEvent::Error {
+                        key: key.clone(),
+                        id,
+                        message: e.to_string(),
+                    });
+                    break;
+                }
+            },
+        }
+    }
+
+    let _ = events.send(HostNetEvent::Disconnected { key, id });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    /// A localhost WebSocket echo server on an OS-assigned port. Hermetic.
+    async fn spawn_echo_server() -> u16 {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                tokio::spawn(async move {
+                    let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+                    while let Some(Ok(msg)) = ws.next().await {
+                        if msg.is_text() || msg.is_binary() {
+                            let _ = ws.send(msg).await;
+                        }
+                    }
+                });
+            }
+        });
+        port
+    }
+
+    fn recv(rx: &std::sync::mpsc::Receiver<HostNetEvent>) -> HostNetEvent {
+        rx.recv_timeout(Duration::from_secs(5))
+            .expect("expected a host net event within 5s")
+    }
+
+    // Multi-thread so the test thread can block on recv while tasks run.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn connect_send_and_echo_back() {
+        let port = spawn_echo_server().await;
+        let (tx, rx) = std::sync::mpsc::channel();
+        let mut mgr = WsManager::new(tx);
+        let key = format!("ws://127.0.0.1:{port}/");
+
+        mgr.handle(ConnCommand::Connect {
+            key: key.clone(),
+            url: key.clone(),
+        });
+
+        let id = match recv(&rx) {
+            HostNetEvent::Connected { key: k, id } => {
+                assert_eq!(k, key);
+                id
+            }
+            _ => panic!("expected Connected first"),
+        };
+
+        mgr.handle(ConnCommand::Send {
+            conn: id,
+            payload: b"ping".to_vec(),
+        });
+
+        match recv(&rx) {
+            HostNetEvent::Message { id: i, text, .. } => {
+                assert_eq!(i, id);
+                assert_eq!(text, "ping");
+            }
+            _ => panic!("expected the echoed Message"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn connect_to_dead_port_errors() {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let mut mgr = WsManager::new(tx);
+        // Port 1 is privileged and almost certainly closed.
+        mgr.handle(ConnCommand::Connect {
+            key: "ws://127.0.0.1:1/".into(),
+            url: "ws://127.0.0.1:1/".into(),
+        });
+        match recv(&rx) {
+            HostNetEvent::Error { .. } => {}
+            _ => panic!("expected an Error connecting to a dead port"),
+        }
+    }
+}


### PR DESCRIPTION
**Stacked on #114** (base `multiplayer-websockets`). Makes `Sub.connect` / `Effect.send` open and drive real WebSocket connections on the **native desktop** runtime. Server (`listen`) and the web (`web-sys`) client are follow-ups.

## What's here

Each frame the desktop loop delivers socket events into the game (**before** tick, so the executor routes them that frame), runs `tick`, then drains the `ConnCommand`s tick queued and hands them to a `WsManager` that owns the live `tokio-tungstenite` sockets:
- **Connect** — idempotent by key (re-declared after a hot reload → reattach); one task per connection pumps outgoing sends + incoming frames, emitting `Connected`/`Message`/`Disconnected`/`Error`.
- **Send** — text frame for valid UTF-8, binary otherwise. **Close** — graceful.
- Events return over a channel and are pushed on the main thread (all dylib calls on one thread), mirroring the reqwest dispatch.

`Game` trait grows `net_drain_conn_commands` + the `net_push_*` connection methods, implemented for `StaticGame` and `HotReloadGame`.

## Verification

Hermetic `#[tokio::test]`s drive `WsManager` against a **localhost echo server** (real sockets, no GL): `connect_send_and_echo_back` and `connect_to_dead_port_errors`.

```sh
cargo test -p functor-runtime-desktop --bin functor-runner ws_host
```

With `tests/net_ws.rs` (executor inject test from #114), both halves of the round trip are covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)