### PR TITLE
netsim SDK: in-process deterministic multiplayer harness (Phase 3)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "1"
 
 members = [
     "cli",
+    "runtime/functor-netsim",
     "runtime/functor-runtime-common",
     "runtime/functor-runtime-desktop",
     "runtime/functor-runtime-web",

--- a/examples/wsserverdemo/wsserverdemo.fs
+++ b/examples/wsserverdemo/wsserverdemo.fs
@@ -9,7 +9,9 @@ open Functor
 open Functor.Math
 open Graphics
 
-let bind = "127.0.0.1:9100"
+// Authority matches wsdemo's connect url ("ws://127.0.0.1:9001/echo") so the
+// netsim harness can route a wsdemo client to this server.
+let bind = "127.0.0.1:9001"
 
 type Model =
     { clients: int

--- a/runtime/functor-netsim/Cargo.toml
+++ b/runtime/functor-netsim/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "functor-netsim"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+functor_runtime_common = { path = "./../functor-runtime-common" }
+fable_library_rust = { path = "./../../fable_modules/fable-library-rust" }
+libloading = "0.8.3"
+serde_json = "1.0"

--- a/runtime/functor-netsim/src/lib.rs
+++ b/runtime/functor-netsim/src/lib.rs
@@ -1,0 +1,297 @@
+//! In-process deterministic multiplayer harness (Phase 3 of `docs/multiplayer.md`).
+//!
+//! `NetSim` loads N game dylibs as **independent instances** (each a private copy,
+//! so its `currentRunner` / net queues are its own), wires them through the
+//! Phase 0 [`VirtualNet`] (latency / jitter / loss / partition), and steps them in
+//! lockstep. A server + N clients can thus be driven and asserted deterministically
+//! — no real sockets, no GL, byte-for-byte reproducible from a seed.
+//!
+//! Routing reuses the games' own `Sub.connect` / `Sub.listen`: a client's connect
+//! url is matched to a server's listen bind by *authority* (host:port). The
+//! `VirtualNet` connection id is used as the shared `ConnectionId` both ends see,
+//! so a send from either side routes to the other.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use fable_library_rust::String_::{fromString, LrcStr};
+use functor_runtime_common::net::{
+    ConnCommand, ConnectionId, LinkProfile, NetEvent, NodeId, VirtualNet,
+};
+use functor_runtime_common::FrameTime;
+use libloading::{Library, Symbol};
+
+pub use functor_runtime_common::net::LinkProfile as Link;
+
+pub type InstanceId = usize;
+
+/// The authority (host:port) of an endpoint, ignoring scheme and path, so a
+/// client url ("ws://127.0.0.1:9001/echo") matches a server bind ("127.0.0.1:9001").
+fn authority(endpoint: &str) -> &str {
+    let after_scheme = endpoint.split("://").last().unwrap_or(endpoint);
+    after_scheme.split('/').next().unwrap_or(after_scheme)
+}
+
+/// One loaded game instance. The dylib is copied to a unique temp path so each
+/// instance gets independent module statics; the copy is removed on drop.
+struct Instance {
+    lib: Library,
+    node: NodeId,
+    /// This instance's routing key (the url/bind its game used) per connection.
+    keys: HashMap<ConnectionId, String>,
+    temp: PathBuf,
+}
+
+impl Instance {
+    fn load(src: &str, node: NodeId) -> Instance {
+        // Each instance loads a private copy so its module statics (currentRunner,
+        // net queues) are independent. The temp name is unique process-wide so
+        // concurrent sims / tests never clobber each other's copies.
+        static NEXT: AtomicU64 = AtomicU64::new(0);
+        let uid = NEXT.fetch_add(1, Ordering::Relaxed);
+        let suffix = std::path::Path::new(src)
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("game.dylib");
+        let temp = std::env::temp_dir().join(format!(
+            "functor-netsim-{}-{uid}-{suffix}",
+            std::process::id()
+        ));
+        std::fs::copy(src, &temp).unwrap_or_else(|e| panic!("copy {src}: {e}"));
+        let lib = unsafe { Library::new(&temp).unwrap_or_else(|e| panic!("load {temp:?}: {e}")) };
+        unsafe {
+            let init: Symbol<fn()> = lib.get(b"init").unwrap();
+            init();
+        }
+        Instance {
+            lib,
+            node,
+            keys: HashMap::new(),
+            temp,
+        }
+    }
+
+    fn tick(&self, time: FrameTime) {
+        unsafe {
+            let f: Symbol<fn(FrameTime)> = self.lib.get(b"tick").unwrap();
+            f(time);
+        }
+    }
+
+    fn drain_conn_commands(&self) -> Vec<ConnCommand> {
+        unsafe {
+            let f: Symbol<fn() -> LrcStr> = self.lib.get(b"net_drain_conn_commands_json").unwrap();
+            serde_json::from_str(&f().to_string()).unwrap_or_default()
+        }
+    }
+
+    fn push_connected(&self, key: &str, id: i32) {
+        unsafe {
+            let f: Symbol<fn(LrcStr, i32)> = self.lib.get(b"net_push_connected").unwrap();
+            f(fromString(key.to_string()), id);
+        }
+    }
+
+    fn push_message(&self, key: &str, id: i32, text: &str) {
+        unsafe {
+            let f: Symbol<fn(LrcStr, i32, LrcStr)> =
+                self.lib.get(b"net_push_conn_message").unwrap();
+            f(fromString(key.to_string()), id, fromString(text.to_string()));
+        }
+    }
+
+    fn push_disconnected(&self, key: &str, id: i32) {
+        unsafe {
+            let f: Symbol<fn(LrcStr, i32)> = self.lib.get(b"net_push_disconnected").unwrap();
+            f(fromString(key.to_string()), id);
+        }
+    }
+
+    fn push_error(&self, key: &str, id: i32, message: &str) {
+        unsafe {
+            let f: Symbol<fn(LrcStr, i32, LrcStr)> = self.lib.get(b"net_push_conn_error").unwrap();
+            f(
+                fromString(key.to_string()),
+                id,
+                fromString(message.to_string()),
+            );
+        }
+    }
+
+    /// The game model, Rust-`Debug`-formatted (for assertions).
+    fn state(&self) -> String {
+        unsafe {
+            let f: Symbol<fn() -> LrcStr> = self.lib.get(b"emit_state_debug").unwrap();
+            f().to_string()
+        }
+    }
+}
+
+impl Drop for Instance {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.temp);
+    }
+}
+
+/// A deterministic in-process multiplayer simulation.
+pub struct NetSim {
+    vnet: VirtualNet,
+    instances: Vec<Instance>,
+    /// authority -> (server instance, its listen key).
+    listeners: HashMap<String, (InstanceId, String)>,
+    frame: u64,
+    dt: f32,
+}
+
+impl NetSim {
+    pub fn new(seed: u64) -> NetSim {
+        NetSim {
+            vnet: VirtualNet::new(seed),
+            instances: Vec::new(),
+            listeners: HashMap::new(),
+            frame: 0,
+            dt: 1.0 / 60.0,
+        }
+    }
+
+    /// Load a game dylib as a new instance (independent copy). Returns its id.
+    pub fn add(&mut self, dylib_path: &str) -> InstanceId {
+        let node = self.vnet.add_node();
+        let id = self.instances.len();
+        self.instances.push(Instance::load(dylib_path, node));
+        id
+    }
+
+    /// Set the link impairment (latency/jitter/loss/reorder) between two instances.
+    pub fn set_link(&mut self, a: InstanceId, b: InstanceId, profile: LinkProfile) {
+        self.vnet
+            .set_link(self.instances[a].node, self.instances[b].node, profile);
+    }
+
+    /// Cut traffic between two instances until [`heal`](Self::heal).
+    pub fn partition(&mut self, a: InstanceId, b: InstanceId) {
+        self.vnet
+            .partition(self.instances[a].node, self.instances[b].node);
+    }
+
+    pub fn heal(&mut self, a: InstanceId, b: InstanceId) {
+        self.vnet
+            .heal(self.instances[a].node, self.instances[b].node);
+    }
+
+    /// The Debug-formatted model of an instance.
+    pub fn state(&self, id: InstanceId) -> String {
+        self.instances[id].state()
+    }
+
+    /// Advance the simulation by one frame: tick every instance, route the
+    /// commands they produced through the virtual network, advance it one tick,
+    /// and deliver the resulting events back to each instance.
+    pub fn step(&mut self) {
+        let time = FrameTime {
+            tts: self.frame as f32 * self.dt,
+            dts: self.dt,
+        };
+        for inst in &self.instances {
+            inst.tick(time.clone());
+        }
+        self.frame += 1;
+
+        // Collect all commands, then register listeners before connects so order
+        // within a frame doesn't matter.
+        let mut commands: Vec<(InstanceId, ConnCommand)> = Vec::new();
+        for (id, inst) in self.instances.iter().enumerate() {
+            for cmd in inst.drain_conn_commands() {
+                commands.push((id, cmd));
+            }
+        }
+        for (id, cmd) in &commands {
+            if let ConnCommand::Listen { key, .. } = cmd {
+                self.listeners
+                    .insert(authority(key).to_string(), (*id, key.clone()));
+            }
+        }
+        for (id, cmd) in commands {
+            match cmd {
+                ConnCommand::Listen { .. } => {}
+                ConnCommand::Connect { key, .. } => self.open(id, key),
+                ConnCommand::Send { conn, payload } => {
+                    self.vnet.send(self.instances[id].node, conn, payload);
+                }
+                ConnCommand::CloseConn { conn } => self.vnet.disconnect(conn),
+                ConnCommand::CloseKey { key } => self.close_key(id, &key),
+            }
+        }
+
+        self.vnet.advance(1);
+        self.deliver();
+    }
+
+    /// Advance the simulation by `n` frames.
+    pub fn step_n(&mut self, n: usize) {
+        for _ in 0..n {
+            self.step();
+        }
+    }
+
+    fn open(&mut self, client: InstanceId, client_key: String) {
+        let Some((server, server_key)) = self.listeners.get(authority(&client_key)).cloned() else {
+            // No matching listener: surface a connection error to the client.
+            self.instances[client].push_error(&client_key, 0, "no listener for endpoint");
+            return;
+        };
+        let client_node = self.instances[client].node;
+        let server_node = self.instances[server].node;
+        let conn = self.vnet.connect(client_node, server_node);
+        self.instances[client].keys.insert(conn, client_key);
+        self.instances[server].keys.insert(conn, server_key);
+    }
+
+    fn close_key(&mut self, id: InstanceId, key: &str) {
+        let conns: Vec<ConnectionId> = self.instances[id]
+            .keys
+            .iter()
+            .filter(|(_, k)| k.as_str() == key)
+            .map(|(c, _)| *c)
+            .collect();
+        for conn in conns {
+            self.vnet.disconnect(conn);
+        }
+    }
+
+    fn deliver(&mut self) {
+        for id in 0..self.instances.len() {
+            let node = self.instances[id].node;
+            for event in self.vnet.poll(node) {
+                match event {
+                    NetEvent::Connected(conn) => {
+                        let key = self.key_for(id, conn);
+                        self.instances[id].push_connected(&key, conn as i32);
+                    }
+                    NetEvent::Message(conn, bytes) => {
+                        let key = self.key_for(id, conn);
+                        let text = String::from_utf8_lossy(&bytes).to_string();
+                        self.instances[id].push_message(&key, conn as i32, &text);
+                    }
+                    NetEvent::Disconnected(conn) => {
+                        let key = self.key_for(id, conn);
+                        self.instances[id].push_disconnected(&key, conn as i32);
+                    }
+                    NetEvent::Error(conn, message) => {
+                        let key = self.key_for(id, conn);
+                        self.instances[id].push_error(&key, conn as i32, &message);
+                    }
+                }
+            }
+        }
+    }
+
+    fn key_for(&self, id: InstanceId, conn: ConnectionId) -> String {
+        self.instances[id]
+            .keys
+            .get(&conn)
+            .cloned()
+            .unwrap_or_default()
+    }
+}

--- a/runtime/functor-netsim/tests/sim.rs
+++ b/runtime/functor-netsim/tests/sim.rs
@@ -1,0 +1,102 @@
+//! End-to-end netsim tests: a real server game + a real client game, run as
+//! independent in-process instances, wired through the virtual network and
+//! stepped deterministically — no GL, no sockets.
+//!
+//! Uses the `wsserverdemo` (echo + greet) and `wsdemo` (connect + send) samples.
+//! Their authorities match (127.0.0.1:9001) so the harness routes the client to
+//! the server.
+//!
+//! Ignored by default: needs both sample dylibs built. Run with:
+//!
+//! ```sh
+//! ./target/debug/functor -d examples/wsserverdemo build native
+//! ./target/debug/functor -d examples/wsdemo build native
+//! cargo test -p functor-netsim --test sim -- --ignored --nocapture
+//! ```
+
+use functor_netsim::{Link, NetSim};
+
+fn dylib(sample: &str) -> String {
+    let name = format!(
+        "{}game_native{}",
+        std::env::consts::DLL_PREFIX,
+        std::env::consts::DLL_SUFFIX
+    );
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(format!("examples/{sample}/build-native/target/debug/{name}"))
+        .to_str()
+        .unwrap()
+        .to_string()
+}
+
+fn require_samples() -> (String, String) {
+    let server = dylib("wsserverdemo");
+    let client = dylib("wsdemo");
+    assert!(
+        std::path::Path::new(&server).exists() && std::path::Path::new(&client).exists(),
+        "build the samples first (see this test's doc comment)"
+    );
+    (server, client)
+}
+
+#[test]
+#[ignore = "needs wsserverdemo + wsdemo built native"]
+fn server_and_client_exchange_messages() {
+    let (server_dylib, client_dylib) = require_samples();
+
+    let mut sim = NetSim::new(1);
+    let server = sim.add(&server_dylib);
+    let client = sim.add(&client_dylib);
+
+    // Default (perfect) link: the exchange settles in a handful of frames.
+    sim.step_n(10);
+
+    let client_state = sim.state(client);
+    assert!(
+        client_state.contains("got-message"),
+        "client should have received a message from the server: {client_state}"
+    );
+    let server_state = sim.state(server);
+    assert!(
+        server_state.contains("client-connected") || server_state.contains("echoed"),
+        "server should have seen the client connect: {server_state}"
+    );
+}
+
+#[test]
+#[ignore = "needs wsserverdemo + wsdemo built native"]
+fn latency_delays_delivery_deterministically() {
+    let (server_dylib, client_dylib) = require_samples();
+
+    let mut sim = NetSim::new(1);
+    let server = sim.add(&server_dylib);
+    let client = sim.add(&client_dylib);
+    // 8-tick one-way latency on the client<->server link.
+    sim.set_link(
+        client,
+        server,
+        Link {
+            latency_ticks: 8,
+            jitter_ticks: 0,
+            loss: 0.0,
+            reorder: false,
+        },
+    );
+
+    // A few frames in, the server's greeting can't have made the round trip yet.
+    sim.step_n(4);
+    assert!(
+        !sim.state(client).contains("got-message"),
+        "no message should have arrived this early under 8-tick latency: {}",
+        sim.state(client)
+    );
+
+    // Given enough frames, it does arrive.
+    sim.step_n(30);
+    assert!(
+        sim.state(client).contains("got-message"),
+        "the message should arrive once enough ticks elapse: {}",
+        sim.state(client)
+    );
+}

--- a/runtime/functor-runtime-desktop/tests/net_wsserver.rs
+++ b/runtime/functor-runtime-desktop/tests/net_wsserver.rs
@@ -25,7 +25,7 @@ use fable_library_rust::String_::{fromString, LrcStr};
 use functor_runtime_common::FrameTime;
 use libloading::{Library, Symbol};
 
-const BIND: &str = "127.0.0.1:9100";
+const BIND: &str = "127.0.0.1:9001";
 
 fn wsserverdemo_dylib() -> PathBuf {
     let dylib = format!(


### PR DESCRIPTION
**Stacked on #116** (base `multiplayer-ws-server`). The headline testing capability from `docs/multiplayer.md`: spin up a server + N clients **in one process** and drive them deterministically — no GL, no sockets, reproducible from a seed.

## What's here — `functor-netsim` crate

`NetSim` loads game dylibs as **independent instances** (each a private copy, so its `currentRunner` / net queues are its own), wires them through the Phase 0 `VirtualNet` (latency / jitter / loss / partition), and steps them in lockstep.

```rust
let mut sim = NetSim::new(seed);
let server = sim.add("…/wsserverdemo …libgame_native.dylib");
let client = sim.add("…/wsdemo …libgame_native.dylib");
sim.set_link(client, server, Link { latency_ticks: 8, loss: 0.05, .. });
sim.step_n(30);
assert!(sim.state(client).contains("got-message"));
```

- Routing reuses the games' own `Sub.connect` / `Sub.listen`, matched by **authority** (host:port); the `VirtualNet` connection id is the shared `ConnectionId` both ends see, so a send from either side routes to the other.
- Each `step()`: tick all instances → route their commands through `VirtualNet` → advance one tick → deliver events back. Temp dylib copies are process-globally unique so concurrent sims/tests don't collide.
- API: `add`, `set_link`, `partition`/`heal`, `step`/`step_n`, `state`.

## Verification

`tests/sim.rs` runs the **real** `wsserverdemo` + `wsdemo` samples as two instances:
- `server_and_client_exchange_messages` — connect → greet → send → echo flows end to end through the harness;
- `latency_delays_delivery_deterministically` — an 8-tick link provably delays delivery (nothing at frame 4, arrived by frame 34).

```sh
./target/debug/functor -d examples/wsserverdemo build native
./target/debug/functor -d examples/wsdemo build native
cargo test -p functor-netsim --test sim -- --ignored --nocapture
```

(`wsserverdemo`'s bind aligned to `wsdemo`'s authority so the harness routes them; `net_wsserver` updated to match.)

## Notes / next
This first cut covers the WebSocket-style connect/listen model with full latency/loss/partition via `VirtualNet`. Natural follow-ups: an HTTP path through the sim, snapshot/entity-sync assertions for the eventual netcode layer, and a higher-level scenario DSL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
