### PR TITLE
feat(audio): one-shot sound effects on wasm (Web Audio)

### DIFF
--- a/runtime/functor-runtime-web/Cargo.toml
+++ b/runtime/functor-runtime-web/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = "1.0"
 
 [dependencies.web-sys]
 version = "0.3.4"
-features = ['Blob', 'HtmlCanvasElement', 'WebGl2RenderingContext', 'console', 'Window', 'Location', 'Performance', 'PerformanceTiming', 'Document', 'Element', 'Request', 'RequestInit', 'Response', 'Headers']
+features = ['Blob', 'HtmlCanvasElement', 'WebGl2RenderingContext', 'console', 'Window', 'Location', 'Performance', 'PerformanceTiming', 'Document', 'Element', 'Request', 'RequestInit', 'Response', 'Headers', 'AudioContext', 'BaseAudioContext', 'AudioBuffer', 'AudioBufferSourceNode', 'AudioDestinationNode', 'AudioNode', 'AudioParam', 'GainNode']
 
 [profile.release]
 codegen-units = 1

--- a/runtime/functor-runtime-web/index.html
+++ b/runtime/functor-runtime-web/index.html
@@ -20,7 +20,8 @@
         mouse_wheel_wasm,
         net_drain_commands_json_wasm,
         net_push_http_response_wasm,
-        net_push_http_error_wasm
+        net_push_http_error_wasm,
+        audio_drain_commands_json_wasm
       } from "./build-wasm/pkg/game_wasm.js";
       import startRuntime from "./pkg/functor_runtime_web.js";
 
@@ -103,6 +104,9 @@
           net_push_http_response_wasm(token, status, body);
         window.game.net_push_http_error = (token, message) =>
           net_push_http_error_wasm(token, message);
+        // Audio bridge (see functor-runtime-web dispatch_audio_commands).
+        window.game.audio_drain_commands_json_wasm = () =>
+          audio_drain_commands_json_wasm();
 
         // In a deterministic capture (?fixed-time), don't wire up input — a
         // stray mouse move would turn the camera, like on native.

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -91,6 +91,11 @@ extern "C" {
 
     #[wasm_bindgen(js_namespace = game, js_name = net_push_http_error)]
     fn game_net_push_http_error(token: i32, message: JsValue);
+
+    // Audio bridge into the game module (see Runtime.Wasm): the game queues
+    // play commands as a JSON string, which the host plays via Web Audio.
+    #[wasm_bindgen(js_namespace = game, js_name = audio_drain_commands_json_wasm)]
+    fn game_audio_drain_commands() -> JsValue;
 }
 
 fn http_method_str(method: HttpMethod) -> &'static str {
@@ -177,6 +182,111 @@ async fn perform_fetch(
         .await
         .map_err(js_err)?;
     Ok((status, text_value.as_string().unwrap_or_default()))
+}
+
+thread_local! {
+    // The Web Audio device, created lazily on the first sound (so it's spun up
+    // inside the user-gesture that triggered it, and never on pages with no
+    // audio). Decoded buffers are cached by path so repeat plays are instant.
+    static AUDIO_CTX: RefCell<Option<web_sys::AudioContext>> = const { RefCell::new(None) };
+    static AUDIO_BUFFERS: RefCell<std::collections::HashMap<String, web_sys::AudioBuffer>> =
+        RefCell::new(std::collections::HashMap::new());
+}
+
+fn audio_context() -> Option<web_sys::AudioContext> {
+    AUDIO_CTX.with(|c| {
+        if c.borrow().is_none() {
+            match web_sys::AudioContext::new() {
+                Ok(ctx) => *c.borrow_mut() = Some(ctx),
+                Err(e) => {
+                    web_sys::console::error_1(&format!("[audio] no AudioContext: {e:?}").into())
+                }
+            }
+        }
+        c.borrow().clone()
+    })
+}
+
+/// Drain the game's queued audio commands and play each via Web Audio. Mirrors
+/// `dispatch_net_commands`; called each frame after `tick`.
+fn dispatch_audio_commands() {
+    let json = game_audio_drain_commands()
+        .as_string()
+        .unwrap_or_else(|| "[]".to_string());
+    if json == "[]" {
+        return;
+    }
+    match serde_json::from_str::<Vec<functor_runtime_common::audio::AudioCommand>>(&json) {
+        Ok(commands) => {
+            for cmd in commands {
+                spawn_local(play_one_shot(cmd));
+            }
+        }
+        Err(e) => web_sys::console::error_1(&format!("[audio] bad commands json: {e}").into()),
+    }
+}
+
+async fn play_one_shot(cmd: functor_runtime_common::audio::AudioCommand) {
+    use wasm_bindgen::JsCast;
+    let functor_runtime_common::audio::AudioCommand::PlayOneShot { sound, gain } = cmd;
+
+    let ctx = match audio_context() {
+        Some(c) => c,
+        None => return,
+    };
+    // Browsers start the context suspended until a user gesture; the play is
+    // driven by one (a keypress), so a best-effort resume is enough.
+    let _ = ctx.resume();
+
+    // Decode on first use, then serve from the cache.
+    let cached = AUDIO_BUFFERS.with(|b| b.borrow().get(&sound).cloned());
+    let buffer = match cached {
+        Some(b) => b,
+        None => {
+            let bytes = match functor_runtime_common::io::load_bytes_async(&sound).await {
+                Ok(b) => b,
+                Err(e) => {
+                    web_sys::console::error_1(&format!("[audio] load '{sound}': {e}").into());
+                    return;
+                }
+            };
+            // decodeAudioData wants an ArrayBuffer (and detaches it); the
+            // Uint8Array copies the bytes into a standalone JS buffer.
+            let array = js_sys::Uint8Array::from(&bytes[..]);
+            let promise = match ctx.decode_audio_data(&array.buffer()) {
+                Ok(p) => p,
+                Err(e) => {
+                    web_sys::console::error_1(&format!("[audio] decode '{sound}': {e:?}").into());
+                    return;
+                }
+            };
+            let buf: web_sys::AudioBuffer = match JsFuture::from(promise).await {
+                Ok(v) => match v.dyn_into() {
+                    Ok(b) => b,
+                    Err(_) => return,
+                },
+                Err(e) => {
+                    web_sys::console::error_1(&format!("[audio] decode '{sound}': {e:?}").into());
+                    return;
+                }
+            };
+            AUDIO_BUFFERS.with(|b| b.borrow_mut().insert(sound.clone(), buf.clone()));
+            buf
+        }
+    };
+
+    // source -> gain -> speakers.
+    let source = match ctx.create_buffer_source() {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    source.set_buffer(Some(&buffer));
+    if let Ok(gain_node) = ctx.create_gain() {
+        gain_node.gain().set_value(gain);
+        let _ = source.connect_with_audio_node(&gain_node);
+        let _ = gain_node.connect_with_audio_node(&ctx.destination());
+    }
+    let _ = source.start();
 }
 
 #[wasm_bindgen(start)]
@@ -341,6 +451,9 @@ async fn run_async() -> Result<(), JsValue> {
             // are pushed back into the inbox asynchronously and decoded by a later
             // tick (see dispatch_net_commands).
             dispatch_net_commands();
+            // Play any one-shot sounds this frame's tick queued (fetch + decode
+            // the first time, then from the cache).
+            dispatch_audio_commands();
 
             let val = game_render(functor_runtime_common::to_js_value(&frame_time));
             let frame: Frame = functor_runtime_common::from_js_value(val);

--- a/src/Functor.Game/Runtime.fs
+++ b/src/Functor.Game/Runtime.fs
@@ -112,6 +112,15 @@ module Runtime
         let net_push_http_error_wasm (token: int, message: JsValue) : unit =
             netPushHttpErrorJs token message
 
+        // Audio bridge for the web runtime (mirrors the native export). The host
+        // drains the queued audio commands each frame and plays them via Web Audio.
+        [<Emit("functor_runtime_common::to_js_value(&functor_runtime_common::audio::drain_commands_json())")>]
+        let private audioDrainCommandsJs () : JsValue = nativeOnly
+
+        /// Host: take the queued audio commands as a JSON string (JsValue).
+        [<OuterAttr("wasm_bindgen")>]
+        let audio_drain_commands_json_wasm () : JsValue = audioDrainCommandsJs ()
+
 
     ///////////////////////////////
     // Native API


### PR DESCRIPTION
**PR 3 of audio**: `Audio.play` now works in the browser, mirroring the native
rodio path (#120). Independent off `main`.

## How (mirrors the native + net-wasm patterns)
The game queues `AudioCommand`s exactly as on native; the **web runtime** drains
them each frame (after `tick`, next to the net dispatch) and plays each via Web
Audio.

- **F#**: an `audio_drain_commands_json_wasm` export in `Runtime.Wasm` (mirrors
  the net wasm export).
- **web runtime**: imports it; `dispatch_audio_commands` parses the JSON and
  plays each one-shot through a lazily-created `AudioContext` — `fetch` +
  `decodeAudioData` on first use, then served from a per-path `AudioBuffer`
  cache; `source → gain → destination`. The context is created on the first
  sound (inside the user gesture that triggered it) and resumed best-effort.
- **index.html**: wires the new export onto `window.game` (it hand-wires the
  game namespace rather than auto-exposing exports); added the Web Audio
  `web-sys` features.

## Validation
- Web runtime + game wasm build clean (`cargo check --target wasm32`, full
  `build:cli`).
- The **wasm golden passes**: the audio drain is a no-op `[]` each frame in the
  golden scene, so rendering is unaffected — and a missing export would fail
  wasm instantiation (page error), so a green golden confirms the export/import
  wiring resolves. Audible check: serve a sample and press space.

> Note: this branch is off `main`, which still has the pre-#122 golden timing
> (the 30-frame loop). If its `golden-wasm` flakes, that's the #112 infra flake
> #122 fixes — rebasing onto main after #122 merges clears it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)