### PR TITLE
netsim live visualizer (functor-netsim-viz)

### DIFF
--- a/runtime/functor-netsim/src/lib.rs
+++ b/runtime/functor-netsim/src/lib.rs
@@ -126,6 +126,15 @@ impl Instance {
             f().to_string()
         }
     }
+
+    /// The instance's frame (camera + scene) at this time, for a visualizer.
+    fn render(&self, time: FrameTime) -> functor_runtime_common::Frame {
+        unsafe {
+            let f: Symbol<fn(FrameTime) -> functor_runtime_common::Frame> =
+                self.lib.get(b"test_render").unwrap();
+            f(time)
+        }
+    }
 }
 
 impl Drop for Instance {
@@ -183,6 +192,21 @@ impl NetSim {
     /// The Debug-formatted model of an instance.
     pub fn state(&self, id: InstanceId) -> String {
         self.instances[id].state()
+    }
+
+    /// Number of instances.
+    pub fn len(&self) -> usize {
+        self.instances.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.instances.is_empty()
+    }
+
+    /// The frame (camera + scene) an instance would render at this time — for a
+    /// visualizer that draws each instance's view (see `functor-netsim-viz`).
+    pub fn render(&self, id: InstanceId, time: FrameTime) -> functor_runtime_common::Frame {
+        self.instances[id].render(time)
     }
 
     /// Advance the simulation by one frame: tick every instance, route the

--- a/runtime/functor-runtime-common/src/renderer.rs
+++ b/runtime/functor-runtime-common/src/renderer.rs
@@ -63,10 +63,25 @@ pub fn render_frame(
             }
         });
 
-    // Main (forward) pass into the bound framebuffer. Reset the clear color (the
-    // shadow pass cleared its depth-color buffer to white).
+    // Main (forward) pass into the bound framebuffer, at the viewport's
+    // sub-rectangle (x,y default to 0 = full window). The scissor clips the clear
+    // and draws to this pane, so multiple instances can share one framebuffer
+    // (e.g. a netsim viewer). Reset the clear color (the shadow pass cleared its
+    // depth-color buffer to white).
     unsafe {
-        gl.viewport(0, 0, viewport.width as i32, viewport.height as i32);
+        gl.viewport(
+            viewport.x as i32,
+            viewport.y as i32,
+            viewport.width as i32,
+            viewport.height as i32,
+        );
+        gl.scissor(
+            viewport.x as i32,
+            viewport.y as i32,
+            viewport.width as i32,
+            viewport.height as i32,
+        );
+        gl.enable(glow::SCISSOR_TEST);
         gl.clear_color(0.1, 0.2, 0.3, 1.0);
         gl.clear(glow::COLOR_BUFFER_BIT | glow::DEPTH_BUFFER_BIT);
     }

--- a/runtime/functor-runtime-common/src/viewport.rs
+++ b/runtime/functor-runtime-common/src/viewport.rs
@@ -7,11 +7,33 @@ use serde::{Deserialize, Serialize};
 pub struct Viewport {
     pub width: u32,
     pub height: u32,
+    /// Bottom-left origin of this viewport within the framebuffer. 0,0 for a
+    /// full-window render; non-zero to render into a sub-rectangle (e.g. one pane
+    /// of a multi-instance view). Defaults to 0 so existing callers are unchanged.
+    #[serde(default)]
+    pub x: u32,
+    #[serde(default)]
+    pub y: u32,
 }
 
 impl Viewport {
     pub fn new(width: u32, height: u32) -> Viewport {
-        Viewport { width, height }
+        Viewport {
+            width,
+            height,
+            x: 0,
+            y: 0,
+        }
+    }
+
+    /// A viewport offset to a sub-rectangle of the framebuffer (bottom-left x,y).
+    pub fn with_offset(x: u32, y: u32, width: u32, height: u32) -> Viewport {
+        Viewport {
+            width,
+            height,
+            x,
+            y,
+        }
     }
 
     /// Width-to-height ratio for the perspective projection. Guards against a

--- a/runtime/functor-runtime-desktop/Cargo.toml
+++ b/runtime/functor-runtime-desktop/Cargo.toml
@@ -11,6 +11,13 @@ strict = ["functor_runtime_common/strict"]
 name = "functor-runner"
 path = "src/main.rs"
 
+# A live multi-pane viewer for the netsim: renders each game instance's view in
+# its own pane while stepping the simulation. Native-only (needs GL + dylib load).
+[[bin]]
+name = "functor-netsim-viz"
+path = "src/bin/netsim_viz.rs"
+required-features = []
+
 [dependencies]
 functor_runtime_common = { path = "./../functor-runtime-common" }
 fable_library_rust = { path = "./../../fable_modules/fable-library-rust" }
@@ -26,6 +33,7 @@ clap = { version = "4.5.6", features = ["derive"] }
 async-trait = "0.1.80"
 
 [target.'cfg(not(any(target_arch = "wasm32")))'.dependencies]
+functor-netsim = { path = "./../functor-netsim" }
 glfw = { version = "0.56.0" }
 libloading = "0.8.3"
 tokio = { version = "1", features = ["full"] }

--- a/runtime/functor-runtime-desktop/src/bin/netsim_viz.rs
+++ b/runtime/functor-runtime-desktop/src/bin/netsim_viz.rs
@@ -1,0 +1,146 @@
+//! A live multi-pane viewer for the netsim.
+//!
+//! Loads each game dylib as an independent instance, wires them through the
+//! virtual network, and renders every instance's view in its own column of one
+//! window while stepping the simulation each frame. So you can *watch* a
+//! server's authoritative world next to each client's (slightly lagging) view.
+//!
+//! ```sh
+//! functor-netsim-viz <dylib> [<dylib> ...]
+//! # e.g. the multiplayer prototype (server + two clients):
+//! functor-netsim-viz \
+//!   examples/mpserver/build-native/target/debug/libgame_native.dylib \
+//!   examples/mpclient/build-native/target/debug/libgame_native.dylib \
+//!   examples/mpclient/build-native/target/debug/libgame_native.dylib
+//! ```
+//!
+//! Keys: Esc quit · Space pause/resume · Right step one frame (while paused).
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use functor_netsim::NetSim;
+use functor_runtime_common::asset::AssetCache;
+use functor_runtime_common::{DebugRenderMode, FrameTime, SceneContext, Viewport};
+use glfw::Context;
+use glow::*;
+
+/// Accept either a dylib path or a sample name (resolved under `examples/`, run
+/// from the repo root) — so `functor-netsim-viz mpserver mpclient mpclient` works.
+fn resolve(arg: &str) -> String {
+    if std::path::Path::new(arg).exists() {
+        return arg.to_string();
+    }
+    let dll = format!(
+        "{}game_native{}",
+        std::env::consts::DLL_PREFIX,
+        std::env::consts::DLL_SUFFIX
+    );
+    format!("examples/{arg}/build-native/target/debug/{dll}")
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.is_empty() {
+        eprintln!("usage: functor-netsim-viz <dylib|sample> [<dylib|sample> ...]");
+        eprintln!("   e.g. functor-netsim-viz mpserver mpclient mpclient");
+        std::process::exit(2);
+    }
+
+    let mut sim = NetSim::new(1);
+    for arg in &args {
+        let path = resolve(arg);
+        assert!(
+            std::path::Path::new(&path).exists(),
+            "not found: {path} (build it: functor -d examples/{arg} build native)"
+        );
+        sim.add(&path);
+    }
+    let panes = sim.len();
+    println!("[netsim-viz] {panes} instance(s); Space=pause, Right=step, Esc=quit");
+
+    unsafe {
+        let mut glfw = glfw::init(glfw::fail_on_errors).unwrap();
+        glfw.window_hint(glfw::WindowHint::ContextVersion(4, 1));
+        glfw.window_hint(glfw::WindowHint::OpenGlProfile(glfw::OpenGlProfileHint::Core));
+        #[cfg(target_os = "macos")]
+        glfw.window_hint(glfw::WindowHint::OpenGlForwardCompat(true));
+
+        let width = (420 * panes.max(1)).min(2400) as u32;
+        let (mut window, events) = glfw
+            .create_window(width, 480, "functor netsim", glfw::WindowMode::Windowed)
+            .expect("Failed to create window");
+        window.make_current();
+        window.set_key_polling(true);
+
+        let gl = glow::Context::from_loader_function(|s| window.get_proc_address(s) as *const _);
+        gl.enable(glow::DEPTH_TEST);
+
+        let asset_cache = Arc::new(AssetCache::new());
+        let scene_context = SceneContext::new();
+        let shadow_map = functor_runtime_common::shadow::ShadowMap::new(&gl, 2048);
+
+        let start = Instant::now();
+        let mut paused = false;
+        let mut step_once = false;
+
+        while !window.should_close() {
+            glfw.poll_events();
+            for (_, event) in glfw::flush_messages(&events) {
+                if let glfw::WindowEvent::Key(key, _, glfw::Action::Press, _) = event {
+                    match key {
+                        glfw::Key::Escape => window.set_should_close(true),
+                        glfw::Key::Space => paused = !paused,
+                        glfw::Key::Right => step_once = true,
+                        _ => {}
+                    }
+                }
+            }
+
+            if !paused || step_once {
+                sim.step();
+                step_once = false;
+            }
+
+            let time = FrameTime {
+                dts: 1.0 / 60.0,
+                tts: start.elapsed().as_secs_f32(),
+            };
+
+            let (fb_w, fb_h) = window.get_framebuffer_size();
+
+            // Black the whole window first (panes scissor-clear their own area, so
+            // the gaps between them stay black as a divider).
+            gl.disable(glow::SCISSOR_TEST);
+            gl.viewport(0, 0, fb_w, fb_h);
+            gl.clear_color(0.0, 0.0, 0.0, 1.0);
+            gl.clear(glow::COLOR_BUFFER_BIT | glow::DEPTH_BUFFER_BIT);
+
+            // One column per instance, with a 1px gap.
+            let gap = 2;
+            let pane_w = ((fb_w - gap * (panes as i32 - 1)).max(1)) / panes.max(1) as i32;
+            for i in 0..panes {
+                let x = i as i32 * (pane_w + gap);
+                // The shadow pass inside render_frame must run unscissored; it
+                // re-enables + scissors the main pass to this pane.
+                gl.disable(glow::SCISSOR_TEST);
+                let frame = sim.render(i, time.clone());
+                let viewport =
+                    Viewport::with_offset(x.max(0) as u32, 0, pane_w.max(1) as u32, fb_h as u32);
+                functor_runtime_common::render_frame(
+                    &gl,
+                    "#version 410",
+                    asset_cache.clone(),
+                    &scene_context,
+                    &shadow_map,
+                    &frame,
+                    time.clone(),
+                    viewport,
+                    DebugRenderMode::Default,
+                );
+            }
+
+            window.swap_buffers();
+        }
+    }
+}

--- a/runtime/functor-runtime-desktop/src/bin/netsim_viz.rs
+++ b/runtime/functor-runtime-desktop/src/bin/netsim_viz.rs
@@ -15,6 +15,10 @@
 //! ```
 //!
 //! Keys: Esc quit · Space pause/resume · Right step one frame (while paused).
+//!
+//! For a headless-ish snapshot (still needs a GL context), `--capture <png>`
+//! steps `--capture-after` frames (default 120), writes the whole multi-pane
+//! window to a PNG, and exits — handy for sharing/reviewing the sim's output.
 
 use std::sync::Arc;
 use std::time::Instant;
@@ -39,16 +43,55 @@ fn resolve(arg: &str) -> String {
     format!("examples/{arg}/build-native/target/debug/{dll}")
 }
 
+/// Read back the default framebuffer and encode it as a PNG. GL rows are
+/// bottom-up, so flip into image (top-down) order.
+unsafe fn encode_framebuffer_png(gl: &glow::Context, width: u32, height: u32) -> Vec<u8> {
+    let stride = (width * 4) as usize;
+    let mut pixels = vec![0u8; stride * height as usize];
+    gl.read_pixels(
+        0,
+        0,
+        width as i32,
+        height as i32,
+        glow::RGBA,
+        glow::UNSIGNED_BYTE,
+        glow::PixelPackData::Slice(&mut pixels),
+    );
+    let mut flipped = vec![0u8; pixels.len()];
+    for row in 0..height as usize {
+        let src = (height as usize - 1 - row) * stride;
+        flipped[row * stride..(row + 1) * stride].copy_from_slice(&pixels[src..src + stride]);
+    }
+    let img = image::RgbaImage::from_raw(width, height, flipped).expect("framebuffer size mismatch");
+    let mut bytes: Vec<u8> = Vec::new();
+    img.write_to(&mut std::io::Cursor::new(&mut bytes), image::ImageFormat::Png)
+        .expect("encode png");
+    bytes
+}
+
 fn main() {
-    let args: Vec<String> = std::env::args().skip(1).collect();
-    if args.is_empty() {
-        eprintln!("usage: functor-netsim-viz <dylib|sample> [<dylib|sample> ...]");
+    // Split flags from the positional dylib/sample args.
+    let mut paths: Vec<String> = Vec::new();
+    let mut capture: Option<String> = None;
+    let mut capture_after: u32 = 120;
+    let mut it = std::env::args().skip(1);
+    while let Some(a) = it.next() {
+        match a.as_str() {
+            "--capture" => capture = it.next(),
+            "--capture-after" => {
+                capture_after = it.next().and_then(|s| s.parse().ok()).unwrap_or(capture_after)
+            }
+            _ => paths.push(a),
+        }
+    }
+    if paths.is_empty() {
+        eprintln!("usage: functor-netsim-viz [--capture <png> [--capture-after <n>]] <dylib|sample> ...");
         eprintln!("   e.g. functor-netsim-viz mpserver mpclient mpclient");
         std::process::exit(2);
     }
 
     let mut sim = NetSim::new(1);
-    for arg in &args {
+    for arg in &paths {
         let path = resolve(arg);
         assert!(
             std::path::Path::new(&path).exists(),
@@ -83,6 +126,7 @@ fn main() {
         let start = Instant::now();
         let mut paused = false;
         let mut step_once = false;
+        let mut frames: u32 = 0;
 
         while !window.should_close() {
             glfw.poll_events();
@@ -138,6 +182,17 @@ fn main() {
                     viewport,
                     DebugRenderMode::Default,
                 );
+            }
+
+            // Snapshot the whole window once we've stepped far enough, then exit.
+            frames += 1;
+            if let Some(path) = &capture {
+                if frames >= capture_after {
+                    let bytes = encode_framebuffer_png(&gl, fb_w as u32, fb_h as u32);
+                    std::fs::write(path, &bytes).expect("write capture");
+                    println!("[netsim-viz] captured {path} after {frames} frames");
+                    break;
+                }
             }
 
             window.swap_buffers();


### PR DESCRIPTION
**Stacked on #127** (the multiplayer prototype). Watch a netsim run: each game instance's view rendered in its own column of one window while the simulation steps — so you can *see* a server's authoritative world next to each client's (lagging) view, side by side.

## What's here

- **`NetSim::render(id, time) -> Frame` + `len()`** — expose each instance's frame (camera + scene).
- **`Viewport` gains an `x,y` offset** (defaults to `0`, so existing callers are unchanged), and **`render_frame` honors it + scissors** the clear/draws to that sub-rectangle, so multiple instances can share one framebuffer.
- **`functor-netsim-viz` binary** (desktop): loads game dylibs (or sample names, resolved under `examples/`), wires them through the virtual network, and renders each in a pane. `Space` pause · `Right` step · `Esc` quit.

## Run it

```sh
./target/debug/functor -d examples/mpserver build native
./target/debug/functor -d examples/mpclient build native
cargo build -p functor-runtime-desktop --bin functor-netsim-viz
./target/debug/functor-netsim-viz mpserver mpclient mpclient
```

Left pane = the authoritative server; the two right panes = clients. You'll see the clients' cubes trailing the server's by the link delay — and if you tweak the scenario's `set_link`, the lag changes live.

Native-only (needs GL + dylib loading); compile-verified here (a display is needed to actually run it).

> Note: the file lives at `src/bin/netsim_viz.rs` and had to be force-added past an over-broad `bin` entry in the root `.gitignore` — worth tightening that rule to `/bin` in a later cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
