### PR TITLE
chore(deps): bump glow 0.13 → 0.16

### DIFF
--- a/runtime/functor-runtime-common/Cargo.toml
+++ b/runtime/functor-runtime-common/Cargo.toml
@@ -11,7 +11,7 @@ strict = []
 
 [dependencies]
 cgmath = "0.18.0"
-glow = "0.13.1"
+glow = "0.16"
 image = "0.25.1"
 once_cell = "1.19.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/runtime/functor-runtime-common/src/shadow.rs
+++ b/runtime/functor-runtime-common/src/shadow.rs
@@ -34,7 +34,7 @@ impl ShadowMap {
                 0,
                 glow::RGBA,
                 glow::UNSIGNED_BYTE,
-                None,
+                glow::PixelUnpackData::Slice(None),
             );
             gl.tex_parameter_i32(glow::TEXTURE_2D, glow::TEXTURE_MIN_FILTER, glow::NEAREST as i32);
             gl.tex_parameter_i32(glow::TEXTURE_2D, glow::TEXTURE_MAG_FILTER, glow::NEAREST as i32);

--- a/runtime/functor-runtime-common/src/texture/texture_2d.rs
+++ b/runtime/functor-runtime-common/src/texture/texture_2d.rs
@@ -82,7 +82,7 @@ impl RenderableAsset for TextureData {
                 0,
                 format,
                 glow::UNSIGNED_BYTE,
-                Some(&self.bytes),
+                glow::PixelUnpackData::Slice(Some(&self.bytes)),
             );
 
             gl.bind_texture(glow::TEXTURE_2D, None);

--- a/runtime/functor-runtime-desktop/Cargo.toml
+++ b/runtime/functor-runtime-desktop/Cargo.toml
@@ -21,7 +21,7 @@ required-features = []
 [dependencies]
 functor_runtime_common = { path = "./../functor-runtime-common" }
 fable_library_rust = { path = "./../../fable_modules/fable-library-rust" }
-glow = "0.13.1"
+glow = "0.16"
 cgmath = "0.18.0"
 image = "0.25"
 serde = { version = "1", features = ["derive"] }

--- a/runtime/functor-runtime-desktop/src/bin/netsim_viz.rs
+++ b/runtime/functor-runtime-desktop/src/bin/netsim_viz.rs
@@ -55,7 +55,7 @@ unsafe fn encode_framebuffer_png(gl: &glow::Context, width: u32, height: u32) ->
         height as i32,
         glow::RGBA,
         glow::UNSIGNED_BYTE,
-        glow::PixelPackData::Slice(&mut pixels),
+        glow::PixelPackData::Slice(Some(&mut pixels)),
     );
     let mut flipped = vec![0u8; pixels.len()];
     for row in 0..height as usize {

--- a/runtime/functor-runtime-desktop/src/main.rs
+++ b/runtime/functor-runtime-desktop/src/main.rs
@@ -170,7 +170,7 @@ unsafe fn encode_framebuffer_png(
         height as i32,
         glow::RGBA,
         glow::UNSIGNED_BYTE,
-        glow::PixelPackData::Slice(&mut pixels),
+        glow::PixelPackData::Slice(Some(&mut pixels)),
     );
 
     // GL rows are bottom-up; flip into image (top-down) order.

--- a/runtime/functor-runtime-web/Cargo.toml
+++ b/runtime/functor-runtime-web/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 [dependencies]
 functor_runtime_common = { path = "./../functor-runtime-common" }
 fable_library_rust = { path = "./../../fable_modules/fable-library-rust" }
-glow = "0.13.1"
+glow = "0.16"
 cgmath = "0.18.0"
 js-sys = "0.3.69"
 wasm-bindgen = { version = "0.2.92" }


### PR DESCRIPTION
## What

Bumps `glow` from **0.13.1 → 0.16** across the three runtime crates (`functor-runtime-common`, `-desktop`, `-web`).

## Why

This is the first step toward an egui-based in-game **UI / text overlay**. `egui_glow::Painter` must share the *same* `glow::Context` type the runtime already creates and hands to `render_frame`, so the runtime and egui have to agree on one glow version. The latest egui (0.34.x) targets **glow 0.16**; pinning to an older egui to keep glow 0.13 would mean adopting a 2-year-old egui. Bumping is the cheaper, forward-looking choice.

## The changes

Pure binding-layer bump. The only code edits track glow's unified pixel data-passing enums:

- `tex_image_2d` now takes `PixelUnpackData::Slice(...)` instead of a bare `Option<&[u8]>` — `shadow.rs`, `texture/texture_2d.rs`
- `read_pixels`'s `PixelPackData::Slice` now wraps `Option<&mut [u8]>` — `main.rs`, `bin/netsim_viz.rs`

No behavioral change — a binding-version bump regenerates identical GL calls.

## Verification

- ✅ `cargo build -p functor_runtime_common -p functor-runtime-desktop` (functor-runner + functor-netsim-viz) — clean
- ✅ `cargo build -p functor-runtime-web --target wasm32-unknown-unknown` — clean
- ⏳ Golden image (`npm run test:golden`) — expected byte-identical; needs a local GL display to run

🤖 Generated with [Claude Code](https://claude.com/claude-code)