### PR TITLE
feat(ui): egui-backed in-game text overlay

### DIFF
--- a/runtime/functor-runtime-common/Cargo.toml
+++ b/runtime/functor-runtime-common/Cargo.toml
@@ -12,6 +12,12 @@ strict = []
 [dependencies]
 cgmath = "0.18.0"
 glow = "0.17"
+# In-game text/UI overlay. egui is the immediate-mode backend living entirely in
+# this shell; `egui_glow` paints through the same glow::Context the runtime owns.
+# `default-features = false` drops egui_glow's winit/clipboard glue we don't use;
+# egui keeps its default bundled font (default_fonts) so text actually renders.
+egui = "0.34"
+egui_glow = { version = "0.34", default-features = false }
 image = "0.25.1"
 once_cell = "1.19.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/runtime/functor-runtime-common/src/lib.rs
+++ b/runtime/functor-runtime-common/src/lib.rs
@@ -89,6 +89,7 @@ mod shader;
 pub mod shadow;
 mod shader_program;
 pub mod texture;
+pub mod ui;
 mod viewport;
 
 pub use camera::*;

--- a/runtime/functor-runtime-common/src/ui.rs
+++ b/runtime/functor-runtime-common/src/ui.rs
@@ -1,0 +1,125 @@
+//! In-game text overlay, rendered with egui on top of the 3D frame.
+//!
+//! This is the *shared* 2D pass: the shells (desktop runner, web runtime) and the
+//! netsim visualizer call it after [`crate::render_frame`], handing it a set of
+//! absolutely-positioned text labels. egui lives entirely here in the imperative
+//! shell — game code never touches it. A declarative `model -> View` F# API will
+//! later sit on top of this, lowering to the same `Label` list.
+//!
+//! egui is *immediate mode* (imperative); Functor is MVU (declarative). They
+//! reconcile by giving egui one job — rendering/layout/text — while the engine's
+//! public surface stays declarative. This module is that seam.
+
+use std::sync::Arc;
+
+use glow::HasContext;
+
+/// A single piece of screen-space text. `x`/`y` are in **points** measured from the
+/// top-left corner (points == pixels when `pixels_per_point` is 1.0).
+pub struct Label {
+    pub text: String,
+    pub x: f32,
+    pub y: f32,
+    pub color: [u8; 3],
+}
+
+impl Label {
+    /// A white label at `(x, y)` points from the top-left.
+    pub fn new(text: impl Into<String>, x: f32, y: f32) -> Self {
+        Self {
+            text: text.into(),
+            x,
+            y,
+            color: [255, 255, 255],
+        }
+    }
+
+    pub fn with_color(mut self, color: [u8; 3]) -> Self {
+        self.color = color;
+        self
+    }
+}
+
+/// Owns the egui context and the glow painter (font-atlas texture + shaders).
+///
+/// Construct once with the runtime's shared GL context, then call [`Self::draw`]
+/// each frame after the 3D pass. The painter holds an `Arc<glow::Context>`, so the
+/// shell must keep its context in an `Arc` and hand a clone here.
+pub struct TextOverlay {
+    ctx: egui::Context,
+    painter: egui_glow::Painter,
+    gl: Arc<glow::Context>,
+}
+
+impl TextOverlay {
+    pub fn new(gl: Arc<glow::Context>) -> Self {
+        // `None` shader version -> egui_glow autodetects (GL 4.1 core vs WebGL2);
+        // empty prefix, no dithering. Panics only on a GL too old for egui, which
+        // can't happen given the runtime already requires GL3.3+/WebGL2.
+        let painter = egui_glow::Painter::new(gl.clone(), "", None, false)
+            .expect("failed to create egui_glow painter");
+        Self {
+            ctx: egui::Context::default(),
+            painter,
+            gl,
+        }
+    }
+
+    /// Paint `labels` over the bound framebuffer. `width`/`height` are the physical
+    /// framebuffer size in pixels; `pixels_per_point` maps points -> pixels (1.0 on
+    /// a non-HiDPI display; the device pixel ratio on retina / browser canvases).
+    pub fn draw(&mut self, width: u32, height: u32, pixels_per_point: f32, labels: &[Label]) {
+        if width == 0 || height == 0 || labels.is_empty() {
+            return;
+        }
+
+        self.ctx.set_pixels_per_point(pixels_per_point);
+        let screen_points = egui::vec2(
+            width as f32 / pixels_per_point,
+            height as f32 / pixels_per_point,
+        );
+        let raw_input = egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(egui::Pos2::ZERO, screen_points)),
+            ..Default::default()
+        };
+
+        let output = self.ctx.run_ui(raw_input, |ui| {
+            // Labels are floating, Context-attached Areas rather than children of
+            // the root Ui, so pull the context back out of the supplied `ui`.
+            let ctx = ui.ctx().clone();
+            for (i, label) in labels.iter().enumerate() {
+                // Each label is its own non-interactive Area pinned at (x, y), so
+                // labels never push each other around — callers place them exactly.
+                egui::Area::new(egui::Id::new(("functor_overlay", i)))
+                    .fixed_pos(egui::pos2(label.x, label.y))
+                    .interactable(false)
+                    .show(&ctx, |ui| {
+                        let [r, g, b] = label.color;
+                        ui.label(
+                            egui::RichText::new(&label.text)
+                                .monospace()
+                                .color(egui::Color32::from_rgb(r, g, b)),
+                        );
+                    });
+            }
+        });
+
+        let primitives = self.ctx.tessellate(output.shapes, output.pixels_per_point);
+        self.painter.paint_and_update_textures(
+            [width, height],
+            output.pixels_per_point,
+            &primitives,
+            &output.textures_delta,
+        );
+
+        // egui_glow mutates global GL state (enables BLEND + SCISSOR, leaves
+        // DEPTH_TEST as-is) and does not restore it. The shared 3D path enables
+        // DEPTH_TEST only once at startup and re-arms SCISSOR per frame, so reset
+        // to the slate the next 3D frame expects.
+        unsafe {
+            self.gl.disable(glow::SCISSOR_TEST);
+            self.gl.disable(glow::BLEND);
+            self.gl.enable(glow::DEPTH_TEST);
+        }
+    }
+}

--- a/runtime/functor-runtime-desktop/src/main.rs
+++ b/runtime/functor-runtime-desktop/src/main.rs
@@ -262,6 +262,12 @@ pub async fn main() {
             (gl, "#version 410", window, glfw, events)
         };
 
+        // Share the GL context via Arc so the egui text-overlay painter can keep
+        // its own reference (egui_glow::Painter requires Arc<glow::Context>). The
+        // rest of the runtime keeps using `&gl`, which derefs through the Arc.
+        let gl = std::sync::Arc::new(gl);
+        let mut text_overlay = functor_runtime_common::ui::TextOverlay::new(gl.clone());
+
         gl.clear_color(0.1, 0.2, 0.3, 1.0);
 
         gl.enable(glow::DEPTH_TEST);
@@ -513,6 +519,20 @@ pub async fn main() {
                 time.clone(),
                 viewport,
                 args.debug_render.into(),
+            );
+
+            // 2D text overlay on top of the 3D frame. Drawn before capture so it
+            // appears in --capture-frame PNGs. Hardcoded label for now; a
+            // declarative `model -> View` path lands in a later PR.
+            text_overlay.draw(
+                fb_width as u32,
+                fb_height as u32,
+                1.0,
+                &[functor_runtime_common::ui::Label::new(
+                    "functor · egui overlay",
+                    12.0,
+                    12.0,
+                )],
             );
 
             if let Some(capture_path) = &args.capture_frame {


### PR DESCRIPTION
Stacked on #133 (glow 0.17 bump). **Review/merge that first.**

## What

Adds `functor_runtime_common::ui::TextOverlay` — a shared 2D text pass that paints absolutely-positioned `Label`s on top of the 3D frame, using egui as an immediate-mode backend confined to the imperative shell.

```rust
text_overlay.draw(fb_w, fb_h, 1.0, &[
    ui::Label::new("functor · egui overlay", 12.0, 12.0),
]);
```

## Design

- **egui is the backend, not the API.** It lives entirely in the Rust shell (`egui_glow::Painter` paints through the *same* `glow::Context` the runtime owns). Game code never sees egui. This preserves functional-core / MVU and sets up a later declarative `model -> View` F# API that lowers onto this same `Label` list.
- **GL state restore.** egui_glow mutates `DEPTH_TEST`/`BLEND`/`SCISSOR` and doesn't reset; `draw()` restores the slate the shared 3D path assumes (it enables `DEPTH_TEST` only once at startup).
- The desktop runner draws a demo label after `render_frame`, before capture (so it appears in `--capture-frame` PNGs).

## Scope

PR 2 of a stack: glow bump (#133) → **this** → netsim per-client overlay → declarative `model -> View`. The web shell's overlay *call* lands with the `View` PR (where both shells are driven from F#).

## Verification

- ✅ `cargo build -p functor_runtime_common` (native) — clean
- ✅ `cargo build -p functor-runtime-desktop` (functor-runner) — clean
- ✅ `cargo build -p functor-runtime-web --target wasm32-unknown-unknown` — clean (egui_glow links on wasm — the main cross-platform risk, retired)
- ⏳ On-screen capture pending (local disk space); will attach a PNG once freed

## Toolchain note

egui 0.34 requires rustc ≥ 1.92. CI uses `rust-toolchain@stable` (currently 1.96), so no CI impact; only stale local toolchains need `rustup update stable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)