### PR TITLE
chore(profile): dev builds emit line-tables-only debug info (debug = 1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,14 @@ members = [
     "src",
 ]
 
-# Strip debug info from all third-party dependencies. Our own crates keep full
-# debug info; the deps don't need it, and their debuginfo dominates target/ size
-# (it was repeatedly filling the disk during development). The per-package
-# opt-level overrides below still apply and inherit `debug = false` from this
-# wildcard.
+# Debug info dominated target/ size (it was repeatedly filling the disk during
+# development). Our own crates emit line-tables-only debug info (`debug = 1`) —
+# enough for file/line backtraces, without the bulky full `.debug_info` — while
+# third-party deps drop it entirely. The per-package opt-level overrides below
+# still apply and inherit `debug = false` from the wildcard.
+[profile.dev]
+debug = 1
+
 [profile.dev.package."*"]
 debug = false
 

--- a/examples/hello/build-native/Cargo.toml
+++ b/examples/hello/build-native/Cargo.toml
@@ -22,6 +22,11 @@ fable_library_rust = { path = "./../../../fable_modules/fable-library-rust" }
 # See: 
 # https://github.com/bevyengine/bevy/issues/1110
 # https://github.com/erezsh/hexx/commit/45773dd471f352a5a424e274048d17da96a9e116
+# Our own game crate: line-tables-only debug info (`debug = 1`) keeps the
+# dylib small while preserving backtraces; deps drop debug info entirely below.
+[profile.dev]
+debug = 1
+
 [profile.dev.package."*"]
 opt-level = 3
 # Deps don't need debug info, and it dominates target/ size.

--- a/examples/lighting/build-native/Cargo.toml
+++ b/examples/lighting/build-native/Cargo.toml
@@ -22,6 +22,11 @@ fable_library_rust = { path = "./../../../fable_modules/fable-library-rust" }
 # See:
 # https://github.com/bevyengine/bevy/issues/1110
 # https://github.com/erezsh/hexx/commit/45773dd471f352a5a424e274048d17da96a9e116
+# Our own game crate: line-tables-only debug info (`debug = 1`) keeps the
+# dylib small while preserving backtraces; deps drop debug info entirely below.
+[profile.dev]
+debug = 1
+
 [profile.dev.package."*"]
 opt-level = 3
 # Deps don't need debug info, and it dominates target/ size.

--- a/examples/mpclient/build-native/Cargo.toml
+++ b/examples/mpclient/build-native/Cargo.toml
@@ -22,6 +22,11 @@ fable_library_rust = { path = "./../../../fable_modules/fable-library-rust" }
 # See:
 # https://github.com/bevyengine/bevy/issues/1110
 # https://github.com/erezsh/hexx/commit/45773dd471f352a5a424e274048d17da96a9e116
+# Our own game crate: line-tables-only debug info (`debug = 1`) keeps the
+# dylib small while preserving backtraces; deps drop debug info entirely below.
+[profile.dev]
+debug = 1
+
 [profile.dev.package."*"]
 opt-level = 3
 debug = false

--- a/examples/mpserver/build-native/Cargo.toml
+++ b/examples/mpserver/build-native/Cargo.toml
@@ -22,6 +22,11 @@ fable_library_rust = { path = "./../../../fable_modules/fable-library-rust" }
 # See:
 # https://github.com/bevyengine/bevy/issues/1110
 # https://github.com/erezsh/hexx/commit/45773dd471f352a5a424e274048d17da96a9e116
+# Our own game crate: line-tables-only debug info (`debug = 1`) keeps the
+# dylib small while preserving backtraces; deps drop debug info entirely below.
+[profile.dev]
+debug = 1
+
 [profile.dev.package."*"]
 opt-level = 3
 debug = false

--- a/examples/netdemo/build-native/Cargo.toml
+++ b/examples/netdemo/build-native/Cargo.toml
@@ -22,6 +22,11 @@ fable_library_rust = { path = "./../../../fable_modules/fable-library-rust" }
 # See:
 # https://github.com/bevyengine/bevy/issues/1110
 # https://github.com/erezsh/hexx/commit/45773dd471f352a5a424e274048d17da96a9e116
+# Our own game crate: line-tables-only debug info (`debug = 1`) keeps the
+# dylib small while preserving backtraces; deps drop debug info entirely below.
+[profile.dev]
+debug = 1
+
 [profile.dev.package."*"]
 opt-level = 3
 debug = false

--- a/examples/primitives/build-native/Cargo.toml
+++ b/examples/primitives/build-native/Cargo.toml
@@ -22,6 +22,11 @@ fable_library_rust = { path = "./../../../fable_modules/fable-library-rust" }
 # See:
 # https://github.com/bevyengine/bevy/issues/1110
 # https://github.com/erezsh/hexx/commit/45773dd471f352a5a424e274048d17da96a9e116
+# Our own game crate: line-tables-only debug info (`debug = 1`) keeps the
+# dylib small while preserving backtraces; deps drop debug info entirely below.
+[profile.dev]
+debug = 1
+
 [profile.dev.package."*"]
 opt-level = 3
 # Deps don't need debug info, and it dominates target/ size.

--- a/examples/wsdemo/build-native/Cargo.toml
+++ b/examples/wsdemo/build-native/Cargo.toml
@@ -22,6 +22,11 @@ fable_library_rust = { path = "./../../../fable_modules/fable-library-rust" }
 # See:
 # https://github.com/bevyengine/bevy/issues/1110
 # https://github.com/erezsh/hexx/commit/45773dd471f352a5a424e274048d17da96a9e116
+# Our own game crate: line-tables-only debug info (`debug = 1`) keeps the
+# dylib small while preserving backtraces; deps drop debug info entirely below.
+[profile.dev]
+debug = 1
+
 [profile.dev.package."*"]
 opt-level = 3
 debug = false

--- a/examples/wsserverdemo/build-native/Cargo.toml
+++ b/examples/wsserverdemo/build-native/Cargo.toml
@@ -22,6 +22,11 @@ fable_library_rust = { path = "./../../../fable_modules/fable-library-rust" }
 # See:
 # https://github.com/bevyengine/bevy/issues/1110
 # https://github.com/erezsh/hexx/commit/45773dd471f352a5a424e274048d17da96a9e116
+# Our own game crate: line-tables-only debug info (`debug = 1`) keeps the
+# dylib small while preserving backtraces; deps drop debug info entirely below.
+[profile.dev]
+debug = 1
+
 [profile.dev.package."*"]
 opt-level = 3
 debug = false


### PR DESCRIPTION
## What

Sets `debug = 1` (line-tables-only) for the **dev** profile of our own crates and the example game dylibs, instead of the default full debug info.

## Why

Full `.debug_info` on our crates dominated `target/` size and repeatedly filled the disk during development. `debug = 1` keeps file/line tables — backtraces still resolve to source locations — while dropping the bulk, shrinking dev artifacts substantially.

## Changes

- **Root workspace** (`Cargo.toml`): add `[profile.dev] debug = 1`. Third-party deps already drop debug info via the existing `[profile.dev.package."*"] debug = false`, so this only affects our own crates.
- **Each `examples/*/build-native/Cargo.toml`** (8 separate per-game dylib workspaces): the same `[profile.dev] debug = 1`, so games scaffolded from these templates inherit the smaller-artifact default.

## Scope notes

- **Native dev builds only.** The CLI builds native with `cargo build` (dev). It builds wasm with `wasm-pack` (defaults to **release**, which already has `debug = false`), so `build-wasm` needs no change.
- Independent of the egui/glow UI work — separate PR off `main`.

## Verification

- ✅ `cargo metadata` parses the root workspace and an example `build-native` manifest with the new profiles (no TOML/profile errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)