### PR TITLE
feat(netsim-viz): per-client info overlay

### DIFF
--- a/runtime/functor-netsim/src/lib.rs
+++ b/runtime/functor-netsim/src/lib.rs
@@ -26,6 +26,34 @@ pub use functor_runtime_common::net::LinkProfile as Link;
 
 pub type InstanceId = usize;
 
+/// Whether an instance is acting as a server (another instance connected to a
+/// bind it listens on) or a plain client. Derived from the live routing tables.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClientRole {
+    Server,
+    Client,
+}
+
+impl ClientRole {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ClientRole::Server => "server",
+            ClientRole::Client => "client",
+        }
+    }
+}
+
+/// A snapshot of one instance's network-facing state, for visualizers/telemetry.
+pub struct ClientInfo {
+    pub id: InstanceId,
+    pub node: NodeId,
+    pub role: ClientRole,
+    /// Active connections this instance currently holds.
+    pub connections: usize,
+    /// In-flight packets addressed to this instance (inbound, not yet delivered).
+    pub inbound_in_flight: usize,
+}
+
 /// The authority (host:port) of an endpoint, ignoring scheme and path, so a
 /// client url ("ws://127.0.0.1:9001/echo") matches a server bind ("127.0.0.1:9001").
 fn authority(endpoint: &str) -> &str {
@@ -201,6 +229,34 @@ impl NetSim {
 
     pub fn is_empty(&self) -> bool {
         self.instances.is_empty()
+    }
+
+    /// The current simulation frame (number of [`step`](Self::step)s taken).
+    pub fn frame(&self) -> u64 {
+        self.frame
+    }
+
+    /// Total packets in flight across the whole virtual network right now.
+    pub fn in_flight(&self) -> usize {
+        self.vnet.in_flight_len()
+    }
+
+    /// Per-instance network-facing snapshot (role, node, live connections,
+    /// inbound traffic) — for a visualizer overlay or a test assertion.
+    pub fn client_info(&self, id: InstanceId) -> ClientInfo {
+        let node = self.instances[id].node;
+        let role = if self.listeners.values().any(|(lid, _)| *lid == id) {
+            ClientRole::Server
+        } else {
+            ClientRole::Client
+        };
+        ClientInfo {
+            id,
+            node,
+            role,
+            connections: self.instances[id].keys.len(),
+            inbound_in_flight: self.vnet.in_flight_to(node),
+        }
     }
 
     /// The frame (camera + scene) an instance would render at this time — for a

--- a/runtime/functor-runtime-common/Cargo.toml
+++ b/runtime/functor-runtime-common/Cargo.toml
@@ -12,6 +12,12 @@ strict = []
 [dependencies]
 cgmath = "0.18.0"
 glow = "0.17"
+# In-game text/UI overlay. egui is the immediate-mode backend living entirely in
+# this shell; `egui_glow` paints through the same glow::Context the runtime owns.
+# `default-features = false` drops egui_glow's winit/clipboard glue we don't use;
+# egui keeps its default bundled font (default_fonts) so text actually renders.
+egui = "0.34"
+egui_glow = { version = "0.34", default-features = false }
 image = "0.25.1"
 once_cell = "1.19.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/runtime/functor-runtime-common/src/lib.rs
+++ b/runtime/functor-runtime-common/src/lib.rs
@@ -89,6 +89,7 @@ mod shader;
 pub mod shadow;
 mod shader_program;
 pub mod texture;
+pub mod ui;
 mod viewport;
 
 pub use camera::*;

--- a/runtime/functor-runtime-common/src/net/virtual_net.rs
+++ b/runtime/functor-runtime-common/src/net/virtual_net.rs
@@ -105,6 +105,18 @@ impl VirtualNet {
         self.now
     }
 
+    /// Number of packets currently in flight (sent but not yet delivered) —
+    /// a cheap measure of live network activity, for visualizers/telemetry.
+    pub fn in_flight_len(&self) -> usize {
+        self.in_flight.len()
+    }
+
+    /// Number of in-flight packets whose destination is `node` (inbound traffic
+    /// not yet delivered to it).
+    pub fn in_flight_to(&self, node: NodeId) -> usize {
+        self.in_flight.iter().filter(|p| p.dest == node).count()
+    }
+
     /// Register a new node (game instance) and return its id.
     pub fn add_node(&mut self) -> NodeId {
         let id = self.next_node;

--- a/runtime/functor-runtime-common/src/ui.rs
+++ b/runtime/functor-runtime-common/src/ui.rs
@@ -1,0 +1,125 @@
+//! In-game text overlay, rendered with egui on top of the 3D frame.
+//!
+//! This is the *shared* 2D pass: the shells (desktop runner, web runtime) and the
+//! netsim visualizer call it after [`crate::render_frame`], handing it a set of
+//! absolutely-positioned text labels. egui lives entirely here in the imperative
+//! shell — game code never touches it. A declarative `model -> View` F# API will
+//! later sit on top of this, lowering to the same `Label` list.
+//!
+//! egui is *immediate mode* (imperative); Functor is MVU (declarative). They
+//! reconcile by giving egui one job — rendering/layout/text — while the engine's
+//! public surface stays declarative. This module is that seam.
+
+use std::sync::Arc;
+
+use glow::HasContext;
+
+/// A single piece of screen-space text. `x`/`y` are in **points** measured from the
+/// top-left corner (points == pixels when `pixels_per_point` is 1.0).
+pub struct Label {
+    pub text: String,
+    pub x: f32,
+    pub y: f32,
+    pub color: [u8; 3],
+}
+
+impl Label {
+    /// A white label at `(x, y)` points from the top-left.
+    pub fn new(text: impl Into<String>, x: f32, y: f32) -> Self {
+        Self {
+            text: text.into(),
+            x,
+            y,
+            color: [255, 255, 255],
+        }
+    }
+
+    pub fn with_color(mut self, color: [u8; 3]) -> Self {
+        self.color = color;
+        self
+    }
+}
+
+/// Owns the egui context and the glow painter (font-atlas texture + shaders).
+///
+/// Construct once with the runtime's shared GL context, then call [`Self::draw`]
+/// each frame after the 3D pass. The painter holds an `Arc<glow::Context>`, so the
+/// shell must keep its context in an `Arc` and hand a clone here.
+pub struct TextOverlay {
+    ctx: egui::Context,
+    painter: egui_glow::Painter,
+    gl: Arc<glow::Context>,
+}
+
+impl TextOverlay {
+    pub fn new(gl: Arc<glow::Context>) -> Self {
+        // `None` shader version -> egui_glow autodetects (GL 4.1 core vs WebGL2);
+        // empty prefix, no dithering. Panics only on a GL too old for egui, which
+        // can't happen given the runtime already requires GL3.3+/WebGL2.
+        let painter = egui_glow::Painter::new(gl.clone(), "", None, false)
+            .expect("failed to create egui_glow painter");
+        Self {
+            ctx: egui::Context::default(),
+            painter,
+            gl,
+        }
+    }
+
+    /// Paint `labels` over the bound framebuffer. `width`/`height` are the physical
+    /// framebuffer size in pixels; `pixels_per_point` maps points -> pixels (1.0 on
+    /// a non-HiDPI display; the device pixel ratio on retina / browser canvases).
+    pub fn draw(&mut self, width: u32, height: u32, pixels_per_point: f32, labels: &[Label]) {
+        if width == 0 || height == 0 || labels.is_empty() {
+            return;
+        }
+
+        self.ctx.set_pixels_per_point(pixels_per_point);
+        let screen_points = egui::vec2(
+            width as f32 / pixels_per_point,
+            height as f32 / pixels_per_point,
+        );
+        let raw_input = egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(egui::Pos2::ZERO, screen_points)),
+            ..Default::default()
+        };
+
+        let output = self.ctx.run_ui(raw_input, |ui| {
+            // Labels are floating, Context-attached Areas rather than children of
+            // the root Ui, so pull the context back out of the supplied `ui`.
+            let ctx = ui.ctx().clone();
+            for (i, label) in labels.iter().enumerate() {
+                // Each label is its own non-interactive Area pinned at (x, y), so
+                // labels never push each other around — callers place them exactly.
+                egui::Area::new(egui::Id::new(("functor_overlay", i)))
+                    .fixed_pos(egui::pos2(label.x, label.y))
+                    .interactable(false)
+                    .show(&ctx, |ui| {
+                        let [r, g, b] = label.color;
+                        ui.label(
+                            egui::RichText::new(&label.text)
+                                .monospace()
+                                .color(egui::Color32::from_rgb(r, g, b)),
+                        );
+                    });
+            }
+        });
+
+        let primitives = self.ctx.tessellate(output.shapes, output.pixels_per_point);
+        self.painter.paint_and_update_textures(
+            [width, height],
+            output.pixels_per_point,
+            &primitives,
+            &output.textures_delta,
+        );
+
+        // egui_glow mutates global GL state (enables BLEND + SCISSOR, leaves
+        // DEPTH_TEST as-is) and does not restore it. The shared 3D path enables
+        // DEPTH_TEST only once at startup and re-arms SCISSOR per frame, so reset
+        // to the slate the next 3D frame expects.
+        unsafe {
+            self.gl.disable(glow::SCISSOR_TEST);
+            self.gl.disable(glow::BLEND);
+            self.gl.enable(glow::DEPTH_TEST);
+        }
+    }
+}

--- a/runtime/functor-runtime-desktop/src/bin/netsim_viz.rs
+++ b/runtime/functor-runtime-desktop/src/bin/netsim_viz.rs
@@ -23,8 +23,9 @@
 use std::sync::Arc;
 use std::time::Instant;
 
-use functor_netsim::NetSim;
+use functor_netsim::{ClientRole, NetSim};
 use functor_runtime_common::asset::AssetCache;
+use functor_runtime_common::ui::{Label, TextOverlay};
 use functor_runtime_common::{DebugRenderMode, FrameTime, SceneContext, Viewport};
 use glfw::Context;
 use glow::*;
@@ -116,19 +117,35 @@ fn main() {
         window.make_current();
         window.set_key_polling(true);
 
-        let gl = glow::Context::from_loader_function(|s| window.get_proc_address(s) as *const _);
+        // Arc so the egui overlay painter can share the same GL context.
+        let gl =
+            Arc::new(glow::Context::from_loader_function(|s| window.get_proc_address(s) as *const _));
         gl.enable(glow::DEPTH_TEST);
 
         let asset_cache = Arc::new(AssetCache::new());
         let scene_context = SceneContext::new();
         let shadow_map = functor_runtime_common::shadow::ShadowMap::new(&gl, 2048);
+        // Per-client text overlay (id/role/connections/in-flight/fps) on each pane.
+        let mut overlay = TextOverlay::new(gl.clone());
 
         let start = Instant::now();
         let mut paused = false;
         let mut step_once = false;
         let mut frames: u32 = 0;
+        // Smoothed viewer frame rate (EMA), shown in each pane's overlay.
+        let mut last_frame = Instant::now();
+        let mut fps = 0.0f32;
 
         while !window.should_close() {
+            // Smoothed viewer FPS for the overlay (EMA over instantaneous dt).
+            let frame_start = Instant::now();
+            let dt = frame_start.duration_since(last_frame).as_secs_f32();
+            last_frame = frame_start;
+            if dt > 0.0 {
+                let inst = 1.0 / dt;
+                fps = if fps == 0.0 { inst } else { fps * 0.9 + inst * 0.1 };
+            }
+
             glfw.poll_events();
             for (_, event) in glfw::flush_messages(&events) {
                 if let glfw::WindowEvent::Key(key, _, glfw::Action::Press, _) = event {
@@ -183,6 +200,45 @@ fn main() {
                     DebugRenderMode::Default,
                 );
             }
+
+            // Per-client info overlay on top of all panes, in a single egui pass.
+            // Each pane's labels are offset to its column's x origin.
+            let frame_no = sim.frame();
+            let mut labels: Vec<Label> = Vec::new();
+            for i in 0..panes {
+                let info = sim.client_info(i);
+                let x = (i as i32 * (pane_w + gap)).max(0) as f32 + 8.0;
+                let role_color = match info.role {
+                    ClientRole::Server => [120, 230, 140],
+                    ClientRole::Client => [180, 200, 255],
+                };
+                let dim = [170, 170, 185];
+                labels.push(
+                    Label::new(
+                        format!("#{} {} · {}", info.id, info.role.as_str(), paths[i]),
+                        x,
+                        8.0,
+                    )
+                    .with_color(role_color),
+                );
+                labels.push(
+                    Label::new(
+                        format!("node {} · {} conn", info.node, info.connections),
+                        x,
+                        26.0,
+                    )
+                    .with_color(dim),
+                );
+                labels.push(
+                    Label::new(format!("inbound {}", info.inbound_in_flight), x, 42.0)
+                        .with_color(dim),
+                );
+                labels.push(
+                    Label::new(format!("{:.0} fps · frame {}", fps, frame_no), x, 58.0)
+                        .with_color(dim),
+                );
+            }
+            overlay.draw(fb_w as u32, fb_h as u32, 1.0, &labels);
 
             // Snapshot the whole window once we've stepped far enough, then exit.
             frames += 1;

--- a/runtime/functor-runtime-desktop/src/main.rs
+++ b/runtime/functor-runtime-desktop/src/main.rs
@@ -262,6 +262,12 @@ pub async fn main() {
             (gl, "#version 410", window, glfw, events)
         };
 
+        // Share the GL context via Arc so the egui text-overlay painter can keep
+        // its own reference (egui_glow::Painter requires Arc<glow::Context>). The
+        // rest of the runtime keeps using `&gl`, which derefs through the Arc.
+        let gl = std::sync::Arc::new(gl);
+        let mut text_overlay = functor_runtime_common::ui::TextOverlay::new(gl.clone());
+
         gl.clear_color(0.1, 0.2, 0.3, 1.0);
 
         gl.enable(glow::DEPTH_TEST);
@@ -513,6 +519,20 @@ pub async fn main() {
                 time.clone(),
                 viewport,
                 args.debug_render.into(),
+            );
+
+            // 2D text overlay on top of the 3D frame. Drawn before capture so it
+            // appears in --capture-frame PNGs. Hardcoded label for now; a
+            // declarative `model -> View` path lands in a later PR.
+            text_overlay.draw(
+                fb_width as u32,
+                fb_height as u32,
+                1.0,
+                &[functor_runtime_common::ui::Label::new(
+                    "functor · egui overlay",
+                    12.0,
+                    12.0,
+                )],
             );
 
             if let Some(capture_path) = &args.capture_frame {


### PR DESCRIPTION
Stacked on #134 (egui overlay) → #133 (glow bump). **Merge those first.**

## What

Each pane of `functor-netsim-viz` now shows a live per-client text overlay (using the egui `ui::TextOverlay` from #134):

```
#0 server · mpserver
node 0 · 2 conn
inbound 0
60 fps · frame 1234
```

- **id + role** — server/client, derived from the live listener routing table
- **node id + active connection count**
- **inbound in-flight packets** — live network activity toward this node
- **smoothed viewer FPS + current sim frame**

Server panes are tinted green, clients blue. It's a single egui pass over the whole window, with each pane's labels offset to its column — drawn before capture so it shows up in `--capture` PNGs.

## NetSim telemetry (new, read-only)

```rust
sim.client_info(id) -> ClientInfo { id, node, role, connections, inbound_in_flight }
sim.frame() -> u64
sim.in_flight() -> usize
```
backed by two cheap `VirtualNet` accessors (`in_flight_len`, `in_flight_to`). Purely additive — useful for test assertions too, not just the viewer.

## Notes

- These are **in-process** instances, so "id" is the logical `InstanceId`, not an OS pid.
- The viewer uses the default **PERFECT** link, so an explicit latency readout isn't meaningful yet — it becomes useful once `set_link`/`partition` are surfaced in the tool (follow-up). `inbound in-flight` already reflects real routing activity.

## Verification

- ✅ `cargo build -p functor-runtime-desktop --bin functor-netsim-viz` — clean
- ✅ `cargo test -p functor-netsim -p functor_runtime_common` (net) — 21 passed
- ⏳ On-screen `--capture` PNG batched with the other UI captures (disk now freed; can run on request)

🤖 Generated with [Claude Code](https://claude.com/claude-code)