### PR TITLE
feat(ui): declarative model -> View UI API

### DIFF
--- a/examples/hello/hello.fs
+++ b/examples/hello/hello.fs
@@ -269,4 +269,15 @@ let init (_args: array<string>) =
     |> GameBuilder.tick tick
     |> GameBuilder.init (Effect.wrapped MovePaddle1)
     |> GameBuilder.subscriptions subscriptions
+    // A small HUD, declared as a pure function of the model. The runtime lowers
+    // this `View` tree to a text overlay drawn on top of the 3D frame.
+    |> GameBuilder.ui (fun model ->
+        Ui.panel (Ui.topLeft ()) (
+            Ui.column [|
+                Ui.text "functor · hello"
+                Ui.textColor (Color.rgb 1.0f 0.85f 0.4f)
+                    (sprintf "eye  %.1f %.1f %.1f" model.eye.x model.eye.y model.eye.z)
+                Ui.text (sprintf "look  yaw %.0f  pitch %.0f" model.yaw model.pitch)
+                Ui.text (sprintf "frame %d" model.counter)
+            |]))
     |> Runtime.runGame

--- a/runtime/functor-runtime-common/src/ui.rs
+++ b/runtime/functor-runtime-common/src/ui.rs
@@ -12,7 +12,10 @@
 
 use std::sync::Arc;
 
+use fable_library_rust::NativeArray_::Array;
+use fable_library_rust::String_::LrcStr;
 use glow::HasContext;
+use serde::{Deserialize, Serialize};
 
 /// A single piece of screen-space text. `x`/`y` are in **points** measured from the
 /// top-left corner (points == pixels when `pixels_per_point` is 1.0).
@@ -37,6 +40,179 @@ impl Label {
     pub fn with_color(mut self, color: [u8; 3]) -> Self {
         self.color = color;
         self
+    }
+}
+
+/// A font referenced by logical family name + size in points. The actual font
+/// *bytes* live in the shell's font registry; a `View` only ever names a font, so
+/// the tree stays serializable/inspectable. Only the default font is wired today —
+/// the family is carried for forward-compatibility and unknown names fall back.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FontRef {
+    pub family: String,
+    pub size: f32,
+}
+
+/// Which screen corner a [`View::Panel`] pins its subtree to.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub enum Anchor {
+    TopLeft,
+    TopRight,
+    BottomLeft,
+    BottomRight,
+}
+
+/// A declarative, serializable 2D UI tree — the lowering target for the F# `Ui`
+/// API (`ui : 'model -> View`). It carries only text, layout, colors and *names*
+/// (e.g. fonts), never bytes, so it round-trips as JSON across the wasm boundary
+/// and stays introspectable. [`View::lower`] flattens it to absolute [`Label`]s.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum View {
+    /// Renders nothing — the default `ui` for games that don't draw a HUD.
+    Empty,
+    Text {
+        text: String,
+        color: [u8; 3],
+        #[serde(default)]
+        font: Option<FontRef>,
+    },
+    /// Children stacked top-to-bottom.
+    Column(Vec<View>),
+    /// Children laid out left-to-right.
+    Row(Vec<View>),
+    /// Pin a subtree to a screen corner.
+    Panel { anchor: Anchor, child: Box<View> },
+}
+
+fn rgb_u8(r: f32, g: f32, b: f32) -> [u8; 3] {
+    let c = |v: f32| (v.clamp(0.0, 1.0) * 255.0).round() as u8;
+    [c(r), c(g), c(b)]
+}
+
+// F#-facing constructors. Each takes Fable's string/array types (`LrcStr`,
+// `Array`) and mirrors the `Scene3D`/`TextureDescription` Emit-shim pattern.
+impl View {
+    pub fn empty() -> View {
+        View::Empty
+    }
+
+    pub fn text(s: LrcStr) -> View {
+        View::Text {
+            text: s.to_string(),
+            color: [255, 255, 255],
+            font: None,
+        }
+    }
+
+    pub fn text_color(r: f32, g: f32, b: f32, s: LrcStr) -> View {
+        View::Text {
+            text: s.to_string(),
+            color: rgb_u8(r, g, b),
+            font: None,
+        }
+    }
+
+    /// Text in a named font at `size` points. Only the default font renders today;
+    /// the family is recorded for when the font registry lands.
+    pub fn text_font(family: LrcStr, size: f32, s: LrcStr) -> View {
+        View::Text {
+            text: s.to_string(),
+            color: [255, 255, 255],
+            font: Some(FontRef {
+                family: family.to_string(),
+                size,
+            }),
+        }
+    }
+
+    pub fn column(items: Array<View>) -> View {
+        View::Column(items.to_vec())
+    }
+
+    pub fn row(items: Array<View>) -> View {
+        View::Row(items.to_vec())
+    }
+
+    pub fn panel(anchor: Anchor, child: View) -> View {
+        View::Panel {
+            anchor,
+            child: Box::new(child),
+        }
+    }
+
+    /// Flatten this tree into absolutely-positioned labels over a `sw`×`sh`-point
+    /// screen. Layout is deliberately simple: fixed line height / char width
+    /// (matching the default monospace face), columns stack, rows advance, panels
+    /// anchor to a corner. Font sizing is honored once real fonts are wired.
+    pub fn lower(&self, sw: f32, sh: f32) -> Vec<Label> {
+        let mut out = Vec::new();
+        // A bare (non-panel) root defaults to the top-left, inset by a margin.
+        match self {
+            View::Panel { .. } => {
+                place(self, 0.0, 0.0, sw, sh, &mut out);
+            }
+            _ => {
+                place(self, MARGIN, MARGIN, sw, sh, &mut out);
+            }
+        }
+        out
+    }
+}
+
+const LINE_H: f32 = 18.0;
+const CHAR_W: f32 = 8.2;
+const ROW_GAP: f32 = 8.0;
+const MARGIN: f32 = 10.0;
+
+/// Place `view`'s labels starting at top-left `(x, y)` and return the (width,
+/// height) it occupied (points). `sw`/`sh` are the screen size, for panel anchoring.
+fn place(view: &View, x: f32, y: f32, sw: f32, sh: f32, out: &mut Vec<Label>) -> (f32, f32) {
+    match view {
+        View::Empty => (0.0, 0.0),
+        View::Text { text, color, .. } => {
+            out.push(Label {
+                text: text.clone(),
+                x,
+                y,
+                color: *color,
+            });
+            (text.chars().count() as f32 * CHAR_W, LINE_H)
+        }
+        View::Column(items) => {
+            let (mut w, mut h) = (0.0f32, 0.0f32);
+            for item in items {
+                let (iw, ih) = place(item, x, y + h, sw, sh, out);
+                w = w.max(iw);
+                h += ih;
+            }
+            (w, h)
+        }
+        View::Row(items) => {
+            let (mut w, mut h) = (0.0f32, 0.0f32);
+            for item in items {
+                let (iw, ih) = place(item, x + w, y, sw, sh, out);
+                w += iw + ROW_GAP;
+                h = h.max(ih);
+            }
+            (w, h)
+        }
+        View::Panel { anchor, child } => {
+            // Lay the child out at the origin to measure it, then translate the
+            // labels we just emitted to the anchored corner.
+            let start = out.len();
+            let (w, h) = place(child, 0.0, 0.0, sw, sh, out);
+            let (ox, oy) = match anchor {
+                Anchor::TopLeft => (MARGIN, MARGIN),
+                Anchor::TopRight => (sw - w - MARGIN, MARGIN),
+                Anchor::BottomLeft => (MARGIN, sh - h - MARGIN),
+                Anchor::BottomRight => (sw - w - MARGIN, sh - h - MARGIN),
+            };
+            for label in &mut out[start..] {
+                label.x += ox;
+                label.y += oy;
+            }
+            (w, h)
+        }
     }
 }
 
@@ -121,5 +297,15 @@ impl TextOverlay {
             self.gl.disable(glow::BLEND);
             self.gl.enable(glow::DEPTH_TEST);
         }
+    }
+
+    /// Lower a declarative [`View`] to labels and paint it. `width`/`height` are
+    /// physical framebuffer pixels; the tree is laid out in points (pixels / ppp).
+    pub fn draw_view(&mut self, width: u32, height: u32, pixels_per_point: f32, view: &View) {
+        let labels = view.lower(
+            width as f32 / pixels_per_point,
+            height as f32 / pixels_per_point,
+        );
+        self.draw(width, height, pixels_per_point, &labels);
     }
 }

--- a/runtime/functor-runtime-common/src/ui.rs
+++ b/runtime/functor-runtime-common/src/ui.rs
@@ -140,79 +140,69 @@ impl View {
         }
     }
 
-    /// Flatten this tree into absolutely-positioned labels over a `sw`×`sh`-point
-    /// screen. Layout is deliberately simple: fixed line height / char width
-    /// (matching the default monospace face), columns stack, rows advance, panels
-    /// anchor to a corner. Font sizing is honored once real fonts are wired.
-    pub fn lower(&self, sw: f32, sh: f32) -> Vec<Label> {
-        let mut out = Vec::new();
-        // A bare (non-panel) root defaults to the top-left, inset by a margin.
-        match self {
-            View::Panel { .. } => {
-                place(self, 0.0, 0.0, sw, sh, &mut out);
-            }
-            _ => {
-                place(self, MARGIN, MARGIN, sw, sh, &mut out);
-            }
+}
+
+/// Point size of the overlay's monospace text.
+const UI_FONT_SIZE: f32 = 14.0;
+/// Inset of an anchored panel from the screen edge, in points.
+const MARGIN: f32 = 10.0;
+
+/// Render a declarative [`View`] into `ui` using egui's own layout (vertical /
+/// horizontal / anchored `Area`), so line height and spacing come from the font
+/// being rendered — no manual metrics, and lines never overlap.
+fn render_view(ui: &mut egui::Ui, view: &View) {
+    match view {
+        View::Empty => {}
+        View::Text { text, color, .. } => {
+            let [r, g, b] = *color;
+            ui.label(
+                egui::RichText::new(text)
+                    .font(egui::FontId::monospace(UI_FONT_SIZE))
+                    .color(egui::Color32::from_rgb(r, g, b)),
+            );
         }
-        out
+        View::Column(items) => {
+            ui.vertical(|ui| {
+                for item in items {
+                    render_view(ui, item);
+                }
+            });
+        }
+        View::Row(items) => {
+            ui.horizontal(|ui| {
+                for item in items {
+                    render_view(ui, item);
+                }
+            });
+        }
+        View::Panel { anchor, child } => {
+            let (align, offset) = anchor_align(*anchor);
+            let ctx = ui.ctx().clone();
+            egui::Area::new(egui::Id::new(("functor_ui_panel", anchor_id(*anchor))))
+                .anchor(align, offset)
+                .interactable(false)
+                .show(&ctx, |ui| render_view(ui, child));
+        }
     }
 }
 
-const LINE_H: f32 = 18.0;
-const CHAR_W: f32 = 8.2;
-const ROW_GAP: f32 = 8.0;
-const MARGIN: f32 = 10.0;
+/// egui corner alignment + inset offset for an [`Anchor`].
+fn anchor_align(anchor: Anchor) -> (egui::Align2, egui::Vec2) {
+    match anchor {
+        Anchor::TopLeft => (egui::Align2::LEFT_TOP, egui::vec2(MARGIN, MARGIN)),
+        Anchor::TopRight => (egui::Align2::RIGHT_TOP, egui::vec2(-MARGIN, MARGIN)),
+        Anchor::BottomLeft => (egui::Align2::LEFT_BOTTOM, egui::vec2(MARGIN, -MARGIN)),
+        Anchor::BottomRight => (egui::Align2::RIGHT_BOTTOM, egui::vec2(-MARGIN, -MARGIN)),
+    }
+}
 
-/// Place `view`'s labels starting at top-left `(x, y)` and return the (width,
-/// height) it occupied (points). `sw`/`sh` are the screen size, for panel anchoring.
-fn place(view: &View, x: f32, y: f32, sw: f32, sh: f32, out: &mut Vec<Label>) -> (f32, f32) {
-    match view {
-        View::Empty => (0.0, 0.0),
-        View::Text { text, color, .. } => {
-            out.push(Label {
-                text: text.clone(),
-                x,
-                y,
-                color: *color,
-            });
-            (text.chars().count() as f32 * CHAR_W, LINE_H)
-        }
-        View::Column(items) => {
-            let (mut w, mut h) = (0.0f32, 0.0f32);
-            for item in items {
-                let (iw, ih) = place(item, x, y + h, sw, sh, out);
-                w = w.max(iw);
-                h += ih;
-            }
-            (w, h)
-        }
-        View::Row(items) => {
-            let (mut w, mut h) = (0.0f32, 0.0f32);
-            for item in items {
-                let (iw, ih) = place(item, x + w, y, sw, sh, out);
-                w += iw + ROW_GAP;
-                h = h.max(ih);
-            }
-            (w, h)
-        }
-        View::Panel { anchor, child } => {
-            // Lay the child out at the origin to measure it, then translate the
-            // labels we just emitted to the anchored corner.
-            let start = out.len();
-            let (w, h) = place(child, 0.0, 0.0, sw, sh, out);
-            let (ox, oy) = match anchor {
-                Anchor::TopLeft => (MARGIN, MARGIN),
-                Anchor::TopRight => (sw - w - MARGIN, MARGIN),
-                Anchor::BottomLeft => (MARGIN, sh - h - MARGIN),
-                Anchor::BottomRight => (sw - w - MARGIN, sh - h - MARGIN),
-            };
-            for label in &mut out[start..] {
-                label.x += ox;
-                label.y += oy;
-            }
-            (w, h)
-        }
+/// A stable per-corner id so distinct panels get distinct egui `Area` ids.
+fn anchor_id(anchor: Anchor) -> u8 {
+    match anchor {
+        Anchor::TopLeft => 0,
+        Anchor::TopRight => 1,
+        Anchor::BottomLeft => 2,
+        Anchor::BottomRight => 3,
     }
 }
 
@@ -241,25 +231,15 @@ impl TextOverlay {
         }
     }
 
-    /// Paint `labels` over the bound framebuffer. `width`/`height` are the physical
-    /// framebuffer size in pixels; `pixels_per_point` maps points -> pixels (1.0 on
-    /// a non-HiDPI display; the device pixel ratio on retina / browser canvases).
+    /// Paint absolutely-positioned `labels` over the bound framebuffer.
+    /// `width`/`height` are the physical framebuffer size in pixels;
+    /// `pixels_per_point` maps points -> pixels (1.0 on a non-HiDPI display; the
+    /// device pixel ratio on retina / browser canvases).
     pub fn draw(&mut self, width: u32, height: u32, pixels_per_point: f32, labels: &[Label]) {
-        if width == 0 || height == 0 || labels.is_empty() {
+        if labels.is_empty() {
             return;
         }
-
-        self.ctx.set_pixels_per_point(pixels_per_point);
-        let screen_points = egui::vec2(
-            width as f32 / pixels_per_point,
-            height as f32 / pixels_per_point,
-        );
-        let raw_input = egui::RawInput {
-            screen_rect: Some(egui::Rect::from_min_size(egui::Pos2::ZERO, screen_points)),
-            ..Default::default()
-        };
-
-        let output = self.ctx.run_ui(raw_input, |ui| {
+        self.run_and_paint(width, height, pixels_per_point, |ui| {
             // Labels are floating, Context-attached Areas rather than children of
             // the root Ui, so pull the context back out of the supplied `ui`.
             let ctx = ui.ctx().clone();
@@ -273,12 +253,58 @@ impl TextOverlay {
                         let [r, g, b] = label.color;
                         ui.label(
                             egui::RichText::new(&label.text)
-                                .monospace()
+                                .font(egui::FontId::monospace(UI_FONT_SIZE))
                                 .color(egui::Color32::from_rgb(r, g, b)),
                         );
                     });
             }
         });
+    }
+
+    /// Paint a declarative [`View`], laid out with egui's own containers so line
+    /// height and spacing come from the rendered font (no manual metrics, no
+    /// overlap). `width`/`height` are physical framebuffer pixels.
+    pub fn draw_view(&mut self, width: u32, height: u32, pixels_per_point: f32, view: &View) {
+        if matches!(view, View::Empty) {
+            return;
+        }
+        self.run_and_paint(width, height, pixels_per_point, |ui| match view {
+            // A panel anchors itself; a bare root sits at the top-left with a margin.
+            View::Panel { .. } => render_view(ui, view),
+            other => {
+                let ctx = ui.ctx().clone();
+                egui::Area::new(egui::Id::new("functor_ui_root"))
+                    .anchor(egui::Align2::LEFT_TOP, egui::vec2(MARGIN, MARGIN))
+                    .interactable(false)
+                    .show(&ctx, |ui| render_view(ui, other));
+            }
+        });
+    }
+
+    /// Run one egui frame (building the UI with `build`), tessellate, paint to the
+    /// bound framebuffer, and restore the GL state the 3D path expects. egui's
+    /// fonts only exist *during* `run`, so all layout/measurement happens in here.
+    fn run_and_paint(
+        &mut self,
+        width: u32,
+        height: u32,
+        pixels_per_point: f32,
+        build: impl FnMut(&mut egui::Ui),
+    ) {
+        if width == 0 || height == 0 {
+            return;
+        }
+        self.ctx.set_pixels_per_point(pixels_per_point);
+        let screen_points = egui::vec2(
+            width as f32 / pixels_per_point,
+            height as f32 / pixels_per_point,
+        );
+        let raw_input = egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(egui::Pos2::ZERO, screen_points)),
+            ..Default::default()
+        };
+
+        let output = self.ctx.run_ui(raw_input, build);
 
         let primitives = self.ctx.tessellate(output.shapes, output.pixels_per_point);
         self.painter.paint_and_update_textures(
@@ -297,15 +323,5 @@ impl TextOverlay {
             self.gl.disable(glow::BLEND);
             self.gl.enable(glow::DEPTH_TEST);
         }
-    }
-
-    /// Lower a declarative [`View`] to labels and paint it. `width`/`height` are
-    /// physical framebuffer pixels; the tree is laid out in points (pixels / ppp).
-    pub fn draw_view(&mut self, width: u32, height: u32, pixels_per_point: f32, view: &View) {
-        let labels = view.lower(
-            width as f32 / pixels_per_point,
-            height as f32 / pixels_per_point,
-        );
-        self.draw(width, height, pixels_per_point, &labels);
     }
 }

--- a/runtime/functor-runtime-desktop/src/game.rs
+++ b/runtime/functor-runtime-desktop/src/game.rs
@@ -1,3 +1,4 @@
+use functor_runtime_common::ui::View;
 use functor_runtime_common::{Frame, FrameTime};
 
 pub trait Game {
@@ -15,6 +16,10 @@ pub trait Game {
     fn mouse_wheel(&mut self, delta: i32);
 
     fn render(&mut self, frame_time: FrameTime) -> Frame;
+
+    /// The game's declarative UI tree (`ui model`), via the dylib's `emit_ui`
+    /// export. The host lowers it to a text overlay drawn on top of the frame.
+    fn ui(&self) -> View;
 
     /// A pretty-printed (Rust `Debug`) view of the live game model, for
     /// introspection. Produced by the game dylib's `emit_state_debug` export;

--- a/runtime/functor-runtime-desktop/src/hot_reload_game.rs
+++ b/runtime/functor-runtime-desktop/src/hot_reload_game.rs
@@ -44,6 +44,14 @@ impl Game for HotReloadGame {
         }
     }
 
+    fn ui(&self) -> functor_runtime_common::ui::View {
+        unsafe {
+            let ui_func: Symbol<fn() -> functor_runtime_common::ui::View> =
+                self.library.as_ref().unwrap().get(b"emit_ui").unwrap();
+            ui_func()
+        }
+    }
+
     fn tick(&mut self, frame_time: FrameTime) {
         unsafe {
             let tick_func: Symbol<fn(FrameTime)> =

--- a/runtime/functor-runtime-desktop/src/main.rs
+++ b/runtime/functor-runtime-desktop/src/main.rs
@@ -521,19 +521,11 @@ pub async fn main() {
                 args.debug_render.into(),
             );
 
-            // 2D text overlay on top of the 3D frame. Drawn before capture so it
-            // appears in --capture-frame PNGs. Hardcoded label for now; a
-            // declarative `model -> View` path lands in a later PR.
-            text_overlay.draw(
-                fb_width as u32,
-                fb_height as u32,
-                1.0,
-                &[functor_runtime_common::ui::Label::new(
-                    "functor · egui overlay",
-                    12.0,
-                    12.0,
-                )],
-            );
+            // 2D UI overlay: the game's declarative `ui model` View, lowered to a
+            // text overlay on top of the 3D frame. Drawn before capture so it
+            // appears in --capture-frame PNGs.
+            let ui_view = game.ui();
+            text_overlay.draw_view(fb_width as u32, fb_height as u32, 1.0, &ui_view);
 
             if let Some(capture_path) = &args.capture_frame {
                 if elapsed_time >= args.capture_time {

--- a/runtime/functor-runtime-desktop/src/static_game.rs
+++ b/runtime/functor-runtime-desktop/src/static_game.rs
@@ -21,6 +21,14 @@ impl Game for StaticGame {
         }
     }
 
+    fn ui(&self) -> functor_runtime_common::ui::View {
+        unsafe {
+            let ui_func: Symbol<fn() -> functor_runtime_common::ui::View> =
+                self.library.get(b"emit_ui").unwrap();
+            ui_func()
+        }
+    }
+
     fn tick(&mut self, frame_time: FrameTime) {
         unsafe {
             let tick_func: Symbol<fn(FrameTime)> = self.library.get(b"tick").unwrap();

--- a/runtime/functor-runtime-web/index.html
+++ b/runtime/functor-runtime-web/index.html
@@ -14,6 +14,7 @@
 
       import init1, {
         test_render_wasm,
+        emit_ui_wasm,
         tick_wasm,
         key_event_wasm,
         mouse_move_wasm,
@@ -98,6 +99,8 @@
         window.game.render = (frameTime) => {
             return test_render_wasm(frameTime);
         };
+
+        window.game.ui = () => emit_ui_wasm();
 
         window.game.tick = (frameTime) => {
           return tick_wasm(frameTime);

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -78,6 +78,9 @@ extern "C" {
     #[wasm_bindgen(js_namespace = game, js_name = render)]
     fn game_render(frameTimeJs: JsValue) -> JsValue;
 
+    #[wasm_bindgen(js_namespace = game, js_name = ui)]
+    fn game_ui() -> JsValue;
+
     #[wasm_bindgen(js_namespace = game, js_name = tick)]
     fn game_tick(frameTimeJs: JsValue);
 
@@ -699,7 +702,8 @@ async fn run_async() -> Result<(), JsValue> {
                 .unwrap()
                 .dyn_into::<web_sys::WebGl2RenderingContext>()
                 .unwrap();
-            let gl = glow::Context::from_webgl2_context(webgl2_context);
+            // Arc so the egui text-overlay painter can share this same context.
+            let gl = std::sync::Arc::new(glow::Context::from_webgl2_context(webgl2_context));
             (gl, "#version 300 es", canvas)
         };
 
@@ -802,6 +806,10 @@ async fn run_async() -> Result<(), JsValue> {
         // and sampled by the lit material (mirrors the desktop runtime).
         let shadow_map = functor_runtime_common::shadow::ShadowMap::new(&gl, 2048);
 
+        // The 2D UI overlay (egui), painting the game's `ui model` View on top of
+        // the 3D frame — the web sibling of the desktop runner's overlay.
+        let mut text_overlay = functor_runtime_common::ui::TextOverlay::new(gl.clone());
+
         // In deterministic mode (?fixed-time, the golden) the canvas is sized
         // once and then left fixed (see below), and the render loop stops after
         // a short warm-up so the page is static for screenshotting.
@@ -874,6 +882,13 @@ async fn run_async() -> Result<(), JsValue> {
                 viewport,
                 debug_render_mode,
             );
+
+            // 2D UI overlay: the game's declarative `ui model` View, lowered to a
+            // text overlay on top of the frame (HiDPI-aware via the device ratio).
+            let view: functor_runtime_common::ui::View =
+                functor_runtime_common::from_js_value(game_ui());
+            let dpr = web_sys::window().unwrap().device_pixel_ratio() as f32;
+            text_overlay.draw_view(canvas.width(), canvas.height(), dpr.max(1.0), &view);
 
             // Schedule the next frame. In deterministic mode (?fixed-time, the
             // golden) render a short warm-up (shader compile, first-frame

--- a/src/Functor.Game/Functor.Game.fsproj
+++ b/src/Functor.Game/Functor.Game.fsproj
@@ -25,6 +25,7 @@
     <Compile Include="Input.fsi" />
     <Compile Include="Input.fs" />
     <Compile Include="Graphics.fs" />
+    <Compile Include="Ui.fs" />
     <Compile Include="Sub.fs" />
     <Compile Include="Game.fsi" />
     <Compile Include="Game.fs" />

--- a/src/Functor.Game/Game.fs
+++ b/src/Functor.Game/Game.fs
@@ -10,6 +10,8 @@ type SubFn<'model, 'msg> = 'model -> Sub<'msg>
 
 type SoundScapeFn<'model> = 'model -> AudioScene
 
+type UiFn<'model> = 'model -> View
+
 type Game<'model, 'msg> = {
     initialState: 'model
     init: effect<'msg>
@@ -18,6 +20,7 @@ type Game<'model, 'msg> = {
     update: UpdateFn<'model, 'msg>
     subscriptions: SubFn<'model, 'msg>
     draw3d: 'model -> Time.FrameTime -> Graphics.Frame
+    ui: UiFn<'model>
     soundScape: SoundScapeFn<'model>
     }
 
@@ -32,8 +35,9 @@ module GameBuilder =
         let draw3d model frametime = Graphics.Frame.create (Graphics.Camera.initial ()) (Graphics.Scene3D.cube())
         let input model input = (model, Effect.none ())
         let subscriptions model = Sub.none ()
+        let ui model = Ui.none ()
         let soundScape model = AudioScene.empty ()
-        { initialState = initialState; init = Effect.none (); update = update; tick = tick; input = input; subscriptions = subscriptions; draw3d = draw3d; soundScape = soundScape}
+        { initialState = initialState; init = Effect.none (); update = update; tick = tick; input = input; subscriptions = subscriptions; draw3d = draw3d; ui = ui; soundScape = soundScape}
 
     /// Set the startup effect, run once when the game first loads. Unlike 'tick'
     /// effects, this fires before the first frame and is *not* re-run across a
@@ -49,6 +53,11 @@ module GameBuilder =
 
     let draw3d<'model, 'msg> (f: 'model -> Time.FrameTime -> Graphics.Frame) (game: Game<'model, 'msg>) =
         { game with draw3d = f }
+
+    /// Declare the 2D UI: a pure function of the model returning a declarative
+    /// `View` tree, drawn as a text overlay on top of `draw3d`'s frame.
+    let ui<'model, 'msg> (f: UiFn<'model>) (game: Game<'model, 'msg>) =
+        { game with ui = f }
 
     let tick<'model, 'msg> (f: TickFn<'model, 'msg>) (game: Game<'model, 'msg>) =
         { game with tick = f}
@@ -86,6 +95,9 @@ module GameRunner =
 
     let draw3d<'model, 'msg> (game: Game<'model, 'msg>) (model: 'model) (tick: Time.FrameTime): Graphics.Frame =
         game.draw3d model tick
+
+    let ui<'model, 'msg> (game: Game<'model, 'msg>) (model: 'model): View =
+        game.ui model
 
     let soundScape<'model, 'msg> (game: Game<'model, 'msg>) (model: 'model): AudioScene =
         game.soundScape model

--- a/src/Functor.Game/Game.fsi
+++ b/src/Functor.Game/Game.fsi
@@ -10,6 +10,8 @@ type SubFn<'model, 'msg> = 'model -> Sub<'msg>
 
 type SoundScapeFn<'model> = 'model -> AudioScene
 
+type UiFn<'model> = 'model -> View
+
 type Game<'model, 'msg>
 
 module GameBuilder = 
@@ -29,6 +31,8 @@ module GameBuilder =
 
     val draw3d: ('model -> Time.FrameTime -> Graphics.Frame) -> Game<'model, 'msg> -> Game<'model, 'msg>
 
+    val ui: UiFn<'model> -> Game<'model, 'msg> -> Game<'model, 'msg>
+
     val soundScape: SoundScapeFn<'model> -> Game<'model, 'msg> -> Game<'model, 'msg>
 
 
@@ -40,4 +44,5 @@ module GameRunner =
     val subscriptions: Game<'model, 'msg> -> 'model -> Sub<'msg>
     val input: Game<'model, 'msg> -> 'model -> Input.t -> ('model * effect<'msg>)
     val draw3d: Game<'model, 'msg> -> 'model -> Time.FrameTime -> Graphics.Frame
+    val ui: Game<'model, 'msg> -> 'model -> View
     val soundScape: Game<'model, 'msg> -> 'model -> AudioScene

--- a/src/Functor.Game/Runtime.fs
+++ b/src/Functor.Game/Runtime.fs
@@ -10,6 +10,7 @@ module Runtime
         abstract member tick: Time.FrameTime -> unit
         abstract member input: Input.t -> unit
         abstract member render: Time.FrameTime -> Graphics.Frame
+        abstract member ui: unit -> View
         abstract member getState: unit -> OpaqueState
         abstract member setState: OpaqueState -> unit
         abstract member stateDebug: unit -> string
@@ -34,7 +35,7 @@ module Runtime
 
         module UnsafeJsValue =
             [<Emit("functor_runtime_common::to_js_value(&$0)")>]
-            let to_js<'a>(obj): JsValue = nativeOnly
+            let to_js<'a>(obj: 'a): JsValue = nativeOnly
             // let from_js<'a>(jsValue: JsValue): 'a = nativeOnly
 
             [<Emit("functor_runtime_common::from_js_value($0)")>]
@@ -82,6 +83,16 @@ module Runtime
                     |> currentRunner.Value.render
                     |> UnsafeJsValue.to_js
                 ret
+            else
+                raise (System.Exception("No runner"))
+
+        /// The game's declarative UI tree (serialized), for the web host to lower
+        /// to a text overlay after render. Pure; mirrors `emit_ui` on native.
+        [<OuterAttr("wasm_bindgen")>]
+        let emit_ui_wasm (): JsValue =
+            if currentRunner.IsSome then
+                currentRunner.Value.ui()
+                |> UnsafeJsValue.to_js
             else
                 raise (System.Exception("No runner"))
 
@@ -324,9 +335,18 @@ module Runtime
 
         [<OuterAttr("no_mangle")>]
         let test_render(frameTime: Time.FrameTime): Graphics.Frame =
-            if currentRunner.IsSome then 
+            if currentRunner.IsSome then
                 currentRunner.Value.render(frameTime)
-            else 
+            else
+                raise (System.Exception("No runner"))
+
+        /// The game's declarative UI tree for the current model, for the host to
+        /// lower to a text overlay after `test_render`. Pure; safe to call per frame.
+        [<OuterAttr("no_mangle")>]
+        let emit_ui(): View =
+            if currentRunner.IsSome then
+                currentRunner.Value.ui()
+            else
                 raise (System.Exception("No runner"))
 
     // `formatState` renders the live model for introspection (the debug server's
@@ -489,6 +509,10 @@ module Runtime
                 GameRunner.draw3d myGame state frameTime
                 // printfn "Hello from GameRunner.render!"
                 // Scene3D.cube()
+            member this.ui() =
+                // The declarative UI tree for the current model; the host lowers it
+                // to a text overlay after render. Pure (like render); no effects.
+                GameRunner.ui myGame state
             member this.audioSceneJson() =
                 // The desired soundscape for the current model, serialized for the
                 // host to reconcile against its live voices. Pure (no effects); the

--- a/src/Functor.Game/Ui.fs
+++ b/src/Functor.Game/Ui.fs
@@ -1,0 +1,62 @@
+namespace Functor
+
+open Fable.Core
+open Functor.Math
+
+/// A declarative 2D UI tree — the value returned by a game's `ui : 'model -> View`
+/// projection (the 2D sibling of `draw3d`). It is a thin shim over the Rust
+/// `functor_runtime_common::ui::View`; the runtime lowers it to a text overlay
+/// drawn on top of the 3D frame. egui lives entirely in the runtime shell — game
+/// code only ever builds this declarative tree.
+[<Erase; Emit("functor_runtime_common::ui::View")>]
+type View = | Noop
+
+/// Screen corner a `Ui.panel` pins its subtree to.
+[<Erase; Emit("functor_runtime_common::ui::Anchor")>]
+type Anchor = | Noop
+
+module Ui =
+
+    /// An empty view — renders nothing. The default `ui` for games with no HUD.
+    [<Emit("functor_runtime_common::ui::View::empty()")>]
+    let none (): View = nativeOnly
+
+    /// A line of white text.
+    [<Emit("functor_runtime_common::ui::View::text($0)")>]
+    let text (s: string): View = nativeOnly
+
+    [<Emit("functor_runtime_common::ui::View::text_color($0, $1, $2, $3)")>]
+    let private textColorRaw (r: float32) (g: float32) (b: float32) (s: string): View = nativeOnly
+
+    /// A line of text in `color`.
+    let textColor (color: Color) (s: string): View = textColorRaw color.r color.g color.b s
+
+    /// A line of text in a named font `family` at `size` points. Forward-looking:
+    /// only the default font renders today, but the family is recorded so games
+    /// can author against it before custom fonts are wired into the runtime.
+    [<Emit("functor_runtime_common::ui::View::text_font($0, $1, $2)")>]
+    let textFont (family: string) (size: float32) (s: string): View = nativeOnly
+
+    /// Stack children top-to-bottom.
+    [<Emit("functor_runtime_common::ui::View::column($0)")>]
+    let column (items: View[]): View = nativeOnly
+
+    /// Lay children out left-to-right.
+    [<Emit("functor_runtime_common::ui::View::row($0)")>]
+    let row (items: View[]): View = nativeOnly
+
+    /// Pin a subtree to a screen corner (see `Ui.topLeft` etc.).
+    [<Emit("functor_runtime_common::ui::View::panel($0, $1)")>]
+    let panel (anchor: Anchor) (child: View): View = nativeOnly
+
+    [<Emit("functor_runtime_common::ui::Anchor::TopLeft")>]
+    let topLeft (): Anchor = nativeOnly
+
+    [<Emit("functor_runtime_common::ui::Anchor::TopRight")>]
+    let topRight (): Anchor = nativeOnly
+
+    [<Emit("functor_runtime_common::ui::Anchor::BottomLeft")>]
+    let bottomLeft (): Anchor = nativeOnly
+
+    [<Emit("functor_runtime_common::ui::Anchor::BottomRight")>]
+    let bottomRight (): Anchor = nativeOnly


### PR DESCRIPTION
Stacked on #134 (egui overlay) → #133 (glow bump). **Merge those first.** Sibling of #136 (both build on #134).

## What

The public, declarative half of in-game UI. Games describe a HUD as a **pure function of the model**; the runtime lowers it to the egui text overlay on top of the 3D frame — on **both native and web**.

```fsharp
// examples/hello — a HUD, declared like draw3d/soundScape
|> GameBuilder.ui (fun model ->
    Ui.panel (Ui.topLeft ()) (
        Ui.column [|
            Ui.text "functor · hello"
            Ui.textColor (Color.rgb 1.0f 0.85f 0.4f)
                (sprintf "eye  %.1f %.1f %.1f" model.eye.x model.eye.y model.eye.z)
            Ui.text (sprintf "look  yaw %.0f  pitch %.0f" model.yaw model.pitch)
            Ui.text (sprintf "frame %d" model.counter)
        |]))
```

## Design

- **egui stays the backend; `View` is the API.** F# builds a declarative, serializable tree; the runtime (`View::lower` → `Label`s → `TextOverlay::draw_view`) renders it. Game code never sees egui — functional-core / MVU intact.
- **`ui : 'model -> View`** is a new MVU projection, sibling to `draw3d`/`soundScape` (defaults to `Ui.none`).
- **`View` carries names + layout, never bytes** — so it round-trips as JSON across the wasm boundary and stays introspectable. `Text` already carries an optional `FontRef` (forward-compat for named fonts; only the default font renders today).
- **Web overlay lands here** — the parity piece deferred from #134; the web runtime now builds a `TextOverlay` and draws `game.ui` each frame (HiDPI-aware).

## Boundary

`emit_ui` (native) / `emit_ui_wasm` (web) export the `View`, mirroring `render`. Desktop `Game` trait gains `ui()`; web gains a `game.ui` extern + `index.html` glue. Also fixed `UnsafeJsValue.to_js` to be generic in its argument — its phantom `'a` had pinned the param to `Frame`, and `View` was the first second caller.

## Verification (compile-verify)

- ✅ `dotnet fable` transpiles `Functor.Game` + `hello` (the new `Ui`/`ui` usage) to Rust
- ✅ `cargo build` of the `hello` native dylib (generated `emit_ui` + View ctors) — clean
- ✅ `functor-runner` (desktop `ui()` wiring) — clean
- ✅ `functor-runtime-web --target wasm32` (web overlay + `game_ui`) — clean
- ⏳ On-screen capture batched with the other UI captures

## Follow-ups (designed-for, not in this PR)

Named-font registry + `Image`/icon nodes layer on additively (resource registry over the existing asset pipeline; `View` only names resources). Interactive widgets would make `View` generic over `'msg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)