### PR TITLE
fix(lighting): disable scissor in shadow pass (un-slice shadows)

### DIFF
--- a/runtime/functor-runtime-common/src/shadow.rs
+++ b/runtime/functor-runtime-common/src/shadow.rs
@@ -212,6 +212,14 @@ pub fn render_shadow_pass(
     unsafe {
         gl.bind_framebuffer(glow::FRAMEBUFFER, Some(shadow_map.fbo));
         gl.viewport(0, 0, shadow_map.size as i32, shadow_map.size as i32);
+        // Disable the scissor test for the duration of the pass: the forward pass
+        // leaves SCISSOR_TEST enabled (clipped to the window's viewport pane), and
+        // since the shadow pass runs first each frame it would otherwise inherit
+        // that rectangle — clipping the clear and the caster geometry to a
+        // window-sized corner of the (larger) shadow map and slicing off shadows
+        // that project past it. The shadow FBO owns the whole texture, so no
+        // scissoring is wanted here; the forward pass re-enables it afterward.
+        gl.disable(glow::SCISSOR_TEST);
         // Clear the depth-color buffer to 1.0 (far) so untouched texels never
         // shadow anything.
         gl.clear_color(1.0, 1.0, 1.0, 1.0);


### PR DESCRIPTION
## What

Fixes a shadow-map regression visible in `examples/lighting` on native: the shark and spheres cast **sliced / clipped shadows**.

## Root cause

A scissor-test leak between render passes, introduced in #128 (netsim viewer's shared framebuffer):

- The forward pass enables `GL_SCISSOR_TEST` clipped to the window viewport (`renderer.rs`) and never disables it.
- The shadow pass runs **first** each frame and renders into the full **2048×2048** shadow FBO. On every frame after the first, it inherited the still-enabled scissor rectangle sized to the **800×600** window.
- Both the depth-buffer clear and the caster geometry were clipped to a window-sized corner of the shadow map, so any shadow projecting past that boundary got sliced off.

Frame 1 looked fine (scissor not yet enabled), so only a live run showed it. The golden test misses it because `hello` casts no shadows.

## The fix

Disable `SCISSOR_TEST` at the start of `render_shadow_pass` — the shadow FBO owns the whole texture, so no scissoring is wanted there. The forward pass re-enables it right after. This lives in shared code, so it covers both the native and web shells.

## Verification

- ✅ `cargo build -p functor-runtime-desktop` — clean
- ✅ Captured `examples/lighting` on native (`run native --capture-frame ... --capture-time 6`): the shark and spheres now cast complete, un-clipped shadows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)