### PR TITLE
docs: LLM-native editor + concurrency architecture notes

### DIFF
--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -1,0 +1,72 @@
+# Concurrency / parallelism
+
+Status: **notes / forward-looking** (no committed engineering yet). Design intent
+for when the engine becomes CPU-bound. The headline: the functional architecture
+makes the *safe* kinds of parallelism nearly free, and the determinism the rest of
+the design rests on (`docs/physics.md`) sets a hard rule for the rest.
+
+## Three kinds of parallelism (don't conflate them)
+
+1. **Pipeline across frames** — render frame N while simulating frame N+1.
+2. **Data-parallel within a system** — physics islands, entity update, cull/draw.
+3. **Many independent worlds** — server rooms/matches, the netsim's N instances.
+
+"Run all the systems in parallel" overstates it: within a single frame,
+`tick → physics → render` is a **dependency chain**, not a fan-out (physics needs
+the post-tick model; render needs the post-physics transforms). Only the work that
+doesn't feed the sim — audio, asset loading, some AI — is genuinely
+frame-internal-parallel.
+
+## The big win is nearly free: the sim‖render pipeline
+
+Decoupling the sim thread from the render thread (render N while simulating N+1) is
+the largest classic parallelism win, and immutability makes it **free** here.
+`draw3d : model -> Frame` is a pure function of an immutable model, and `Frame` is
+an immutable description — so the render thread can read frame N's `Frame` with no
+locks while the sim builds N+1. The hand-rolled "snapshot the world for the render
+thread" double-buffering that mutable engines agonize over simply falls out. Same
+for audio (`soundScape -> AudioScene`) and the physics view.
+
+The general statement: **the functional boundaries are the concurrency
+boundaries.** The functional-core / imperative-shell split *is* the thread split —
+the pure core produces immutable values; the shell consumers (GL renderer, audio
+output, asset IO) read them on their own threads. You don't have to *find* the safe
+hand-off points; the purity boundary already named them.
+
+## The determinism rule (load-bearing)
+
+Parallelism must never make a frame's outcome depend on thread scheduling, or
+rewind / netcode / replay / LLM-observability all break. That gives a clean split:
+
+- **Output-only systems (render, audio)** → parallelize **freely**. They don't feed
+  the sim, so non-determinism there is invisible to the `Timeline`.
+- **Feedback systems (physics)** → parallelize **only deterministically.** Lean on
+  Rapier's `enhanced-determinism` (it already solves islands in parallel with
+  order-independent results); don't hand-parallelize the solver.
+- **The update / effect-drain core** → stays **serial.** Message order is part of
+  determinism. Pure per-entity work *inside* a tick (`Entities.update`) can
+  `par_iter` only if the combine is order-independent.
+
+## Rough priority
+
+1. **Sim‖render pipeline split** — biggest win, cheapest given immutability, and
+   rendering is usually the frame-time hog.
+2. **Rapier's internal parallelism** — free; just enable it.
+3. **Data-parallel entity update** — `par_iter` over `Entities<'e>` once counts
+   demand it (thousands), not before.
+4. **Many independent worlds** — embarrassingly parallel; the netsim already runs N
+   instances, and server room/match sharding scales across cores cleanly.
+5. **Audio / asset loading off the critical path** — real but low-stakes background
+   work, not the bottleneck.
+
+## Caveats
+
+- **Don't parallelize prematurely.** Small games are CPU-cheap; task-spawn/sync
+  overhead can *lose*, and the deterministic-replay property is worth more than the
+  speedup until you're actually CPU-bound.
+- **wasm threading is more constrained than native** (SharedArrayBuffer + workers),
+  so the parallelism story is target-dependent. Treat it as an optimization layer,
+  not a foundational assumption.
+- **Replayability is sacred.** The moment parallelism makes the *feedback* path
+  scheduling-dependent, you've traded away the determinism everything else relies
+  on. That's the one line not to cross.

--- a/docs/llm-native-editor.md
+++ b/docs/llm-native-editor.md
@@ -1,0 +1,82 @@
+# LLM-native: the editor is a conversation
+
+Status: **notes / vision** (no committed engineering yet). This jots down the
+thinking behind design principle #2 (LLM-native) in `CLAUDE.md` — *why* the
+runtime is built to be driven and observed without a GPU window, and where that
+leads.
+
+## Thesis
+
+A traditional engine ships a heavyweight editor (Unity/Unreal/Godot) as the
+primary authoring surface. Functor's bet is different: **the LLM plus a fast
+iteration loop becomes the editor** — the same way an agentic coding tool displaces
+much of what an IDE used to do. You don't click panels to build the game; you
+direct an LLM that authors the game's pure F# data and functions, runs it, looks at
+the result, and iterates.
+
+This is **load-bearing strategy, not a feature.** A full editor is one of the
+largest line items in any engine, and "we'd also have to build the editor" is one
+of the main reasons small-team / functional engines die from scope (see the
+prior-art discussion in `docs/physics.md`). Not building one is what keeps the
+project survivable — *provided* the runtime is introspectable enough that an LLM
+can stand in for the editor's eyes.
+
+## What transfers, and what doesn't
+
+The agentic-coding analogy holds for the parts of game-making that are really
+**authoring and data-wrangling in disguise** — and that's most of the structural
+work:
+
+- **LLM-subsumable (~80%):** scene composition, entity wiring, game rules, spawn
+  logic, component/material config, netcode plumbing, bulk edits ("20 crates in a
+  grid", "add a patrol AI"), refactors. Functor's serializable-F#-data surface is
+  the LLM's home turf.
+- **Stays human — perceptual / feel judgment:** does the jump *feel* right, is the
+  light too harsh, does the camera shake read, is the animation timed well. A
+  multimodal model can critique a still frame, but judging 60fps motion and feel is
+  weak. The human role shifts from **operator to director/critic.**
+
+So the editor doesn't vanish — it **collapses from a *manipulation* surface into an
+*observation / direction* surface.** You say "warmer, softer," look at the result,
+and redirect, instead of dragging a light.
+
+## The real bottleneck is the observation loop
+
+LLMs are already good at the authoring. What's historically missing is the LLM
+being able to **see results and iterate without a human relaying them.** Closing
+that loop is exactly what principle #2 provides:
+
+- headless frame capture (already shipped — `--capture-frame` / `--fixed-time`),
+- serializable / inspectable state (`emit_state`; MVU makes the model plain data),
+- the debug runtime on the backlog (`/state`, `/scene`, raycast — see
+  `docs/todo.md`),
+- a text-only runtime path that needs no GL window.
+
+Those are the LLM's **hands and eyes**: author → capture → read state → diff →
+iterate → surface candidates for the human's perceptual call. Functor is closer to
+this than it sounds — frame capture + a debug server + deterministic replay is most
+of the sensory apparatus already.
+
+## Synergy with determinism / rewind
+
+The determinism + rewind `Timeline` designed for physics/netcode
+(`docs/physics.md`) doubles as an **LLM-editor primitive**: capture a session,
+rewind to frame K, make a change, replay, and diff the outcome — *time-travel
+authoring / what-if iteration.* The golden-image tests are the regression half of
+the same loop. The determinism investment pays off twice — once for netcode, once
+for LLM-driven iteration. Keeping replayability sacred (see
+`docs/concurrency.md`) keeps the game LLM-observable even as it grows.
+
+## Caveats / open questions
+
+- **Keep a thin direct-manipulation surface.** Fine spatial/feel tuning ("nudge
+  3 units until it looks right") is a 2-second human drag and a miserable LLM
+  round-trip. Kill the *bloated* editor, not all direct manipulation — a live view
+  plus a few sliders/gizmos still wins for that one class of task.
+- **The black-frame problem.** An LLM staring at a wrong render has little to go on
+  unless the runtime exposes rich introspection. The value of LLM-as-editor is
+  directly proportional to how introspectable the runtime is — which is why #2 is
+  load-bearing, not a nicety.
+- **Discoverability for non-experts.** Editors teach what's possible by showing
+  panels; a conversation requires knowing what to ask (or the LLM suggesting). The
+  LLM can likely do the teaching, but it's an open UX question.


### PR DESCRIPTION
Two forward-looking design notes, jotting down architecture direction discussed alongside the physics work (#139). **Notes / vision only — no engineering committed.**

## `docs/llm-native-editor.md`
The reasoning behind design principle #2 (LLM-native):
- the LLM + a fast iteration loop as the authoring surface, the way agentic coding displaces much of the IDE
- **why this is load-bearing strategy:** skipping a Unity-class editor is one of the main things that keeps a small-team / functional engine survivable
- what's LLM-subsumable (~80% — scene/wiring/rules/netcode authoring) vs. what stays human (perceptual / feel judgment); the editor collapses from a *manipulation* surface to an *observation / direction* one
- the real bottleneck is the **observation loop**, closed by #2 (frame capture, serializable state, the debug runtime, text-only path)
- the determinism + rewind `Timeline` doubles as a **time-travel authoring** primitive

## `docs/concurrency.md`
Forward-looking parallelism intent:
- three distinct kinds (frame pipeline / data-parallel / many-worlds); "all systems in parallel" overstates it — `tick → physics → render` is a dependency chain
- immutability makes the **sim‖render pipeline split nearly free** — *the functional boundaries are the concurrency boundaries*
- the **load-bearing determinism rule:** parallelize outputs (render/audio) freely, the feedback path (physics) only deterministically, keep the update/drain core serial

Both reference `docs/physics.md` (#139) where relevant. Independent of that PR — can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)