### PR TITLE
feat(cli): JSON output + animation selection for `inspect model`

### DIFF
--- a/cli/src/commands/inspect.rs
+++ b/cli/src/commands/inspect.rs
@@ -2,11 +2,28 @@ use std::fs;
 use std::io;
 use std::path::Path;
 
+use clap::ValueEnum;
+
 use functor_runtime_common::inspect::{inspect_model, Aabb, ModelReport};
 
-/// Inspect a glTF/glb model on the CPU and print a text report. No GL context
-/// is created, so this is safe to run headless (CI / scripts / LLMs).
-pub async fn execute_model(path: &str, time: Option<f32>) -> io::Result<()> {
+/// How to render an inspection report.
+#[derive(ValueEnum, Clone, Debug, Default)]
+pub enum OutputFormat {
+    /// Human-readable text (the default).
+    #[default]
+    Text,
+    /// Machine-readable JSON, for scripts / CI / LLMs.
+    Json,
+}
+
+/// Inspect a glTF/glb model on the CPU and print a report. No GL context is
+/// created, so this is safe to run headless (CI / scripts / LLMs).
+pub async fn execute_model(
+    path: &str,
+    time: Option<f32>,
+    animation: Option<&str>,
+    format: OutputFormat,
+) -> io::Result<()> {
     let model_path = Path::new(path);
     if !model_path.exists() {
         return Err(io::Error::new(
@@ -17,10 +34,25 @@ pub async fn execute_model(path: &str, time: Option<f32>) -> io::Result<()> {
 
     let bytes = fs::read(model_path)?;
 
-    let report = inspect_model(bytes, time)
+    let report = inspect_model(bytes, time, animation)
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
-    print_report(path, &report);
+    match format {
+        OutputFormat::Text => print_report(path, &report),
+        OutputFormat::Json => print_json(path, &report)?,
+    }
+    Ok(())
+}
+
+/// Print the report as JSON, with the source path alongside it.
+fn print_json(path: &str, report: &ModelReport) -> io::Result<()> {
+    let value = serde_json::json!({
+        "model": path,
+        "report": report,
+    });
+    let s = serde_json::to_string_pretty(&value)
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    println!("{}", s);
     Ok(())
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -80,8 +80,8 @@ enum InspectTarget {
         #[arg(long)]
         time: Option<f32>,
 
-        /// Animation to sample for the skinned AABB (by name). Defaults to the
-        /// first animation. Implies sampling even without --time (at t=0).
+        /// Animation to sample for the skinned AABB, by name or index. Defaults
+        /// to the first animation. Implies sampling even without --time (at t=0).
         #[arg(long)]
         animation: Option<String>,
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -79,6 +79,15 @@ enum InspectTarget {
         /// Sample the skinned AABB at this time (seconds) for animated models.
         #[arg(long)]
         time: Option<f32>,
+
+        /// Animation to sample for the skinned AABB (by name). Defaults to the
+        /// first animation. Implies sampling even without --time (at t=0).
+        #[arg(long)]
+        animation: Option<String>,
+
+        /// Output format for the report.
+        #[arg(long, value_enum, default_value_t = commands::inspect::OutputFormat::Text)]
+        format: commands::inspect::OutputFormat,
     },
 }
 
@@ -90,8 +99,19 @@ async fn main() -> tokio::io::Result<()> {
     // project, so handle it before the functor.json validation below.
     if let Command::Inspect { target } = &args.command {
         let res = match target {
-            InspectTarget::Model { path, time } => {
-                commands::inspect::execute_model(path, *time).await
+            InspectTarget::Model {
+                path,
+                time,
+                animation,
+                format,
+            } => {
+                commands::inspect::execute_model(
+                    path,
+                    *time,
+                    animation.as_deref(),
+                    format.clone(),
+                )
+                .await
             }
         };
         return finish(res);
@@ -153,7 +173,9 @@ async fn main() -> tokio::io::Result<()> {
 fn finish(res: io::Result<()>) -> tokio::io::Result<()> {
     match res {
         Ok(()) => {
-            println!("Done");
+            // Status goes to stderr so stdout stays pure data (e.g. JSON from
+            // `inspect ... --format json` is directly pipeable).
+            eprintln!("Done");
             Ok(())
         }
         Err(error) => {

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -12,10 +12,6 @@ golden tests), see `CLAUDE.md` and `git log`.
       (`/screenshot`, raycast, entity-state). Grow it out of the existing capture
       path rather than a separate binary; MVU already makes state serializable
       (`emit_state`).
-- [ ] **Model inspector** — `functor inspect model <file.glb> [--time T]`: run the
-      asset pipeline CPU-side and print per-mesh vertex/index/joint counts and
-      skinned AABBs. Text-only, no GPU, diffable. Would have caught both
-      skinned-material bugs (zero-vertex meshes, wrong joint rest pose).
 - [ ] Headless/offscreen render path (e.g. llvmpipe under xvfb) at a fixed
       resolution so the golden-image test can run in CI (today it's `#[ignore]`d).
 - [ ] WASM capture path (today wasm screenshots need an external headless browser).

--- a/runtime/functor-runtime-common/src/inspect.rs
+++ b/runtime/functor-runtime-common/src/inspect.rs
@@ -12,6 +12,7 @@ use std::io::Cursor;
 
 use cgmath::{vec3, vec4, Matrix4, Quaternion, Vector3, Vector4};
 use gltf::buffer::Source as BufferSource;
+use serde::Serialize;
 
 use crate::animation::{Animation, AnimationChannel, AnimationProperty, AnimationValue, Keyframe};
 use crate::model::{Skeleton, SkeletonBuilder};
@@ -46,6 +47,26 @@ impl Aabb {
     }
 }
 
+/// An empty `Aabb` carries infinities (see [`Aabb::empty`]), which are not
+/// valid JSON numbers. Serialize as `null` when empty, otherwise as
+/// `{ "min": [x, y, z], "max": [x, y, z] }` — matching the codebase's plain
+/// `[f32; 3]` convention for geometry (see `light.rs`).
+impl Serialize for Aabb {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        if self.is_empty() {
+            return serializer.serialize_none();
+        }
+        let mut s = serializer.serialize_struct("Aabb", 2)?;
+        s.serialize_field("min", &[self.min.x, self.min.y, self.min.z])?;
+        s.serialize_field("max", &[self.max.x, self.max.y, self.max.z])?;
+        s.end()
+    }
+}
+
 /// A single skinned vertex, kept CPU-side for AABB computation.
 struct SkinnedVertex {
     position: Vector3<f32>,
@@ -54,7 +75,7 @@ struct SkinnedVertex {
 }
 
 /// Per-primitive inspection report.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub struct PrimitiveReport {
     /// The owning mesh's name (glTF names live on the mesh, not the primitive).
     pub mesh_name: String,
@@ -67,14 +88,14 @@ pub struct PrimitiveReport {
 }
 
 /// A single animation's summary.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub struct AnimationReport {
     pub name: String,
     pub duration: f32,
 }
 
 /// The full model inspection report.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub struct ModelReport {
     pub primitives: Vec<PrimitiveReport>,
     pub mesh_count: usize,
@@ -90,7 +111,7 @@ pub struct ModelReport {
 }
 
 /// The skinned AABB plus the context used to produce it.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub struct SkinnedAabbReport {
     pub animation_name: String,
     pub requested_time: f32,
@@ -99,10 +120,17 @@ pub struct SkinnedAabbReport {
     pub aabb: Aabb,
 }
 
-/// Inspect a glb/glTF byte buffer. When `time` is `Some` and the model is
-/// skinned with at least one animation, the skinned AABB at that time is also
-/// computed.
-pub fn inspect_model(bytes: Vec<u8>, time: Option<f32>) -> Result<ModelReport, String> {
+/// Inspect a glb/glTF byte buffer. The skinned AABB is computed when the model
+/// is skinned with at least one animation and the caller asks to sample a pose —
+/// i.e. either `time` is `Some` or `animation_name` is `Some` (an omitted `time`
+/// defaults to `0.0`). `animation_name` selects which animation to sample; when
+/// `None`, the first animation is used. An `animation_name` that doesn't exist
+/// is an error that lists the available animations.
+pub fn inspect_model(
+    bytes: Vec<u8>,
+    time: Option<f32>,
+    animation_name: Option<&str>,
+) -> Result<ModelReport, String> {
     let cursor = Cursor::new(bytes);
     let gltf = gltf::Gltf::from_slice(cursor.get_ref())
         .map_err(|e| format!("Failed to parse glTF/glb: {}", e))?;
@@ -156,11 +184,37 @@ pub fn inspect_model(bytes: Vec<u8>, time: Option<f32>) -> Result<ModelReport, S
 
     let any_skinned = primitives.iter().any(|p| p.has_skinning);
 
-    // Compute the skinned AABB only when asked for a time, the mesh is skinned,
-    // and there is an animation to sample.
-    let skinned_aabb = match time {
-        Some(t) if any_skinned && has_skeleton && !animations.is_empty() => {
-            let animation = &animations[0];
+    // Pick the animation to sample: by name if given (erroring with the
+    // available names if it doesn't exist), otherwise the first one.
+    let selected_animation = match animation_name {
+        Some(name) => match animations.iter().find(|a| a.name == name) {
+            Some(a) => Some(a),
+            None => {
+                let available = if animations.is_empty() {
+                    "<none>".to_string()
+                } else {
+                    animations
+                        .iter()
+                        .map(|a| a.name.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                };
+                return Err(format!(
+                    "Animation '{}' not found. Available: {}",
+                    name, available
+                ));
+            }
+        },
+        None => animations.first(),
+    };
+
+    // Compute the skinned AABB only when the caller asked to sample a pose
+    // (a time and/or an animation name), the mesh is skinned, and there is an
+    // animation to sample. An omitted time defaults to 0.0.
+    let want_pose = time.is_some() || animation_name.is_some();
+    let skinned_aabb = match selected_animation {
+        Some(animation) if want_pose && any_skinned && has_skeleton => {
+            let t = time.unwrap_or(0.0);
             let sampled_time = if animation.duration > 0.0 {
                 t.rem_euclid(animation.duration)
             } else {

--- a/runtime/functor-runtime-common/src/inspect.rs
+++ b/runtime/functor-runtime-common/src/inspect.rs
@@ -47,17 +47,22 @@ impl Aabb {
     }
 }
 
-/// An empty `Aabb` carries infinities (see [`Aabb::empty`]), which are not
-/// valid JSON numbers. Serialize as `null` when empty, otherwise as
-/// `{ "min": [x, y, z], "max": [x, y, z] }` — matching the codebase's plain
-/// `[f32; 3]` convention for geometry (see `light.rs`).
+/// An empty `Aabb` carries infinities (see [`Aabb::empty`]), and malformed/NaN
+/// vertex data can leave non-finite coordinates; serde_json renders non-finite
+/// floats as JSON `null`, which would corrupt the `[x, y, z]` arrays. So when the
+/// box is empty or any coordinate is non-finite, serialize the whole `Aabb` as
+/// `null`; otherwise `{ "min": [x, y, z], "max": [x, y, z] }` — matching the
+/// codebase's plain `[f32; 3]` convention for geometry (see `light.rs`).
 impl Serialize for Aabb {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
         use serde::ser::SerializeStruct;
-        if self.is_empty() {
+        let coords = [
+            self.min.x, self.min.y, self.min.z, self.max.x, self.max.y, self.max.z,
+        ];
+        if self.is_empty() || coords.iter().any(|c| !c.is_finite()) {
             return serializer.serialize_none();
         }
         let mut s = serializer.serialize_struct("Aabb", 2)?;
@@ -105,8 +110,9 @@ pub struct ModelReport {
     pub animations: Vec<AnimationReport>,
     /// Model-space AABB of the static (bind-pose) mesh positions.
     pub static_aabb: Aabb,
-    /// Skinned AABB at the requested time, if `--time` was given and the model
-    /// is skinned and has at least one animation.
+    /// Skinned AABB at the sampled pose, if a pose was requested (a `time`
+    /// and/or an `animation_name`) and the model is skinned with at least one
+    /// animation.
     pub skinned_aabb: Option<SkinnedAabbReport>,
 }
 
@@ -131,6 +137,15 @@ pub fn inspect_model(
     time: Option<f32>,
     animation_name: Option<&str>,
 ) -> Result<ModelReport, String> {
+    // Reject non-finite sample times up front: they would otherwise flow into
+    // `requested_time`/`sampled_time` and serialize as JSON `null`, yielding a
+    // "successful" but semantically broken report.
+    if let Some(t) = time {
+        if !t.is_finite() {
+            return Err(format!("time must be a finite number, got {}", t));
+        }
+    }
+
     let cursor = Cursor::new(bytes);
     let gltf = gltf::Gltf::from_slice(cursor.get_ref())
         .map_err(|e| format!("Failed to parse glTF/glb: {}", e))?;
@@ -184,27 +199,35 @@ pub fn inspect_model(
 
     let any_skinned = primitives.iter().any(|p| p.has_skinning);
 
-    // Pick the animation to sample: by name if given (erroring with the
-    // available names if it doesn't exist), otherwise the first one.
+    // Pick the animation to sample. If a selector is given, prefer an exact name
+    // match, then fall back to a numeric index — so unnamed or duplicate-named
+    // animations (glTF allows both) stay addressable. With no selector, use the
+    // first animation. An unresolvable selector errors with an index-annotated
+    // list of what's available.
     let selected_animation = match animation_name {
-        Some(name) => match animations.iter().find(|a| a.name == name) {
-            Some(a) => Some(a),
-            None => {
-                let available = if animations.is_empty() {
-                    "<none>".to_string()
-                } else {
-                    animations
-                        .iter()
-                        .map(|a| a.name.as_str())
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                };
-                return Err(format!(
-                    "Animation '{}' not found. Available: {}",
-                    name, available
-                ));
+        Some(selector) => {
+            let by_name = animations.iter().find(|a| a.name == selector);
+            let by_index = || selector.parse::<usize>().ok().and_then(|i| animations.get(i));
+            match by_name.or_else(by_index) {
+                Some(a) => Some(a),
+                None => {
+                    let available = if animations.is_empty() {
+                        "<none>".to_string()
+                    } else {
+                        animations
+                            .iter()
+                            .enumerate()
+                            .map(|(i, a)| format!("{}: {}", i, a.name))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    };
+                    return Err(format!(
+                        "Animation '{}' not found (use a name or index). Available: {}",
+                        selector, available
+                    ));
+                }
             }
-        },
+        }
         None => animations.first(),
     };
 
@@ -537,5 +560,44 @@ mod tests {
         ];
         let p = skin_position(&v, &transforms);
         assert_eq!(p, vec3(5.0, 10.0, 0.0));
+    }
+
+    #[test]
+    fn aabb_serializes_finite_box_as_min_max() {
+        let mut aabb = Aabb::empty();
+        aabb.extend(vec3(-1.0, -2.0, -3.0));
+        aabb.extend(vec3(1.0, 2.0, 3.0));
+        let v = serde_json::to_value(aabb).unwrap();
+        assert_eq!(v["min"], serde_json::json!([-1.0, -2.0, -3.0]));
+        assert_eq!(v["max"], serde_json::json!([1.0, 2.0, 3.0]));
+    }
+
+    #[test]
+    fn aabb_serializes_empty_or_nonfinite_as_null() {
+        // Empty (never extended) -> null, not a struct full of infinities.
+        assert!(serde_json::to_value(Aabb::empty()).unwrap().is_null());
+
+        // Any non-finite coordinate -> null, so the [x,y,z] arrays never contain
+        // JSON `null` (serde_json's rendering of non-finite floats). Constructed
+        // directly: `extend`'s min/max would otherwise swallow NaN and clamp
+        // infinities, so this exercises the serialize guard in isolation.
+        let nan_box = Aabb {
+            min: vec3(f32::NAN, 0.0, 0.0),
+            max: vec3(1.0, 1.0, 1.0),
+        };
+        assert!(serde_json::to_value(nan_box).unwrap().is_null());
+
+        let inf_box = Aabb {
+            min: vec3(0.0, 0.0, 0.0),
+            max: vec3(f32::INFINITY, 1.0, 1.0),
+        };
+        assert!(serde_json::to_value(inf_box).unwrap().is_null());
+    }
+
+    #[test]
+    fn inspect_model_rejects_non_finite_time() {
+        // The time guard runs before any glTF parsing, so empty bytes are fine.
+        let err = inspect_model(Vec::new(), Some(f32::NAN), None).unwrap_err();
+        assert!(err.contains("finite"), "unexpected error: {}", err);
     }
 }


### PR DESCRIPTION
Extends the headless glTF model inspector (#82) to be machine-consumable and to support animation testing.

## What & why
- **`--format json|text`** — the inspector now emits structured JSON, giving scripts / CI / LLMs a stable, parseable contract over the report (directly serves the LLM-native design principle). `text` remains the default, so existing usage is unchanged.
  - `Aabb` serializes as `null` when empty (an empty AABB holds infinities, which aren't valid JSON numbers) and as `{ "min": [x,y,z], "max": [x,y,z] }` otherwise — matching the `[f32;3]` geometry convention in `light.rs`.
  - JSON shape: `{ "model": <path>, "report": { ... } }`.
- **Status to stderr** — `finish`'s `"Done"` line moved from stdout to stderr so `--format json` produces clean, pipeable stdout. (The `Failed:` counterpart was already on stderr.)
- **`--animation <name>`** — sample the skinned AABB against a named animation instead of always the first. Defaults to the first animation (preserves prior behavior); supplying `--animation` implies sampling even without `--time` (at t=0). An unknown name errors with the available list, e.g. `Animation 'jump' not found. Available: idle, agree, run, ...`.
- **Docs** — removed the now-complete "Model inspector" bullet from `docs/todo.md` (the base inspector shipped in #82 but was never cleared from the backlog).

Note: glTF animations are time-based (no inherent frame rate), so `--time T` is the pose/"frame" selector in seconds.

## Testing
- `cargo test -p functor_runtime_common` — 54 passed.
- Manual, against fetched assets:
  - `inspect model Xbot.glb --time 0.5 --format json` → valid JSON (verified via a Python parse), pure stdout.
  - `--animation walk --time 0.3`, `--animation run` (no `--time`, t=0), unknown-name error, and `--animation` on a non-animated model (`Available: <none>`) all behave as intended.
  - `text` default output unchanged.

No end-to-end unit test for `inspect_model` was added: `.glb` fixtures are gitignored and there's no byte-fixture test harness. Happy to add a checked-in fixture + test if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)