### PR TITLE
feat(debug-runtime): GET / endpoint index + docs

### DIFF
--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -1,0 +1,93 @@
+# Debug runtime
+
+An optional HTTP control server on the desktop runtime (`functor-runner`) that lets
+an external client — a script, a test, or an LLM — **observe** and **drive** a running
+game without a GPU window of its own. It is the runtime arm of Functor's LLM-native
+goal: capture frames, query state, control the frame clock, and inject input over a
+localhost socket.
+
+Start it by passing `--debug-port <PORT>`:
+
+```sh
+# via the CLI (rebuilds + runs the game)
+./target/debug/functor -d examples/hello run native --debug-port 8077
+
+# or the runner directly, against an already-built dylib
+#   (cwd must be the game dir so assets resolve)
+cd examples/hello
+functor-runner --game-path build-native/target/debug/libgame_native.dylib --debug-port 8077
+```
+
+The server binds **localhost only** (`127.0.0.1:<PORT>`). HTTP handlers never touch GL;
+each request is handed to the render loop and fulfilled once per frame.
+
+## Endpoints
+
+`GET /` returns this list as JSON (discoverability).
+
+| Method & path | Purpose |
+| --- | --- |
+| `POST /capture` | PNG (`image/png`) of the next rendered frame |
+| `GET /state` | runtime state JSON: `frame`, `tts`, `viewport`, `model` (Rust `Debug` text) |
+| `GET /scene` | current frame as JSON: `camera` + `scene` + `lights` |
+| `POST /input` | inject input (see below) |
+| `POST /time` | control the frame clock (see below) |
+
+### `POST /input`
+
+JSON is tagged by `type`. Unknown keys/shapes return **400** with a message.
+
+```jsonc
+{"type":"key","key":"w","down":true}      // key press / release
+{"type":"mouse_move","x":10,"y":20}       // absolute cursor position
+{"type":"mouse_wheel","delta":1}          // scroll
+```
+
+### `POST /time` — frame-loop control
+
+```jsonc
+{"type":"set","tts":2.0}        // PAUSE: pin game time to a constant (dts=0)
+{"type":"advance","dts":0.016}  // STEP: run exactly one frame with this dt, then hold
+{"type":"resume"}               // RESUME: follow wall-clock again
+```
+
+`--fixed-time <T>` pins the clock from launch (equivalent to an initial `set`).
+While the clock is pinned, **user keyboard/mouse input from the window is ignored**, but
+injected `/input` still applies — so an external driver has deterministic control.
+
+## Two workflows
+
+**Observe a human playing.** Leave the clock on wall-clock and poll:
+
+```sh
+curl -s localhost:8077/state | jq        # frame, time, model
+curl -s localhost:8077/scene | jq .camera
+curl -s -X POST localhost:8077/capture -o frame.png
+```
+
+**Drive the game (LLM / test plays it).** Pin the clock, act, step, observe — a
+deterministic loop:
+
+```sh
+H=localhost:8077
+curl -s -X POST $H/time  -d '{"type":"set","tts":0}'             # pause
+curl -s -X POST $H/input -d '{"type":"key","key":"up","down":true}'
+curl -s -X POST $H/time  -d '{"type":"advance","dts":0.016}'      # step one frame
+curl -s $H/state | jq .model                                     # see the effect
+curl -s -X POST $H/capture -o step.png
+```
+
+## Tooling
+
+A typed TypeScript SDK over these endpoints (single-client + a multi-client lockstep
+session for simulating multiplayer games) lives in `tools/functor-sdk` *(planned)*.
+
+## Future directions
+
+- **Multiplayer simulation.** Launch N runner instances, each on its own
+  `--debug-port`, networked via `Sub.connect`/`Sub.listen`; pin all clocks and step
+  them in lockstep, injecting input and observing state per client. This is the
+  out-of-process counterpart to the in-process `functor-netsim` harness.
+- **Richer observation.** A structured (parseable) state snapshot and a held-input
+  summary, beyond today's `Debug`-text `model`.
+- **Discoverability/ergonomics.** First-class `pause` / single-`step` verbs.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -7,11 +7,17 @@ golden tests), see `CLAUDE.md` and `git log`.
 
 ## Validation tooling
 
-- [ ] **Debug runtime** (north star): an HTTP/stdin trigger on `functor-runner`
-      for on-demand capture + state queries, à la shock2quest's `debug_runtime`
-      (`/screenshot`, raycast, entity-state). Grow it out of the existing capture
-      path rather than a separate binary; MVU already makes state serializable
-      (`emit_state`).
+- Debug runtime: the `--debug-port` HTTP control server exists (`/capture`,
+      `/state`, `/scene`, `/input`, `/time` clock control, `GET /` index — see
+      `docs/debug-runtime.md`). Remaining:
+  - [ ] **TypeScript SDK** (`tools/functor-sdk`): typed client over the endpoints
+        (single-client + a multi-client lockstep session for **multiplayer
+        simulation** — N runners, pinned clocks, stepped together), plus a gated
+        e2e harness driving `hello`. First e2e guard: inject `up` → step → assert
+        `model.held.up`.
+  - [ ] Richer observation: a structured (parseable) state snapshot + held-input
+        summary, beyond today's `Debug`-text `model`.
+  - [ ] Raycast / entity-state queries (à la shock2quest's `debug_runtime`).
 - [ ] Headless/offscreen render path (e.g. llvmpipe under xvfb) at a fixed
       resolution so the golden-image test can run in CI (today it's `#[ignore]`d).
 - [ ] WASM capture path (today wasm screenshots need an external headless browser).

--- a/runtime/functor-runtime-desktop/src/debug_server.rs
+++ b/runtime/functor-runtime-desktop/src/debug_server.rs
@@ -10,7 +10,9 @@
 //! `main.rs`) and fulfills them with framebuffer data / runtime state it can
 //! only read on the main thread.
 //!
-//! This is the seed of a richer debug runtime (future `/input`, `/time`, etc.).
+//! Endpoints: `GET /` (index), `POST /capture`, `GET /state`, `GET /scene`,
+//! `POST /input`, `POST /time`. See `docs/debug-runtime.md` for usage and the
+//! observe-vs-drive workflows.
 
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread;
@@ -235,6 +237,25 @@ pub fn spawn(port: u16) -> Receiver<DebugRequest> {
                                 .respond(Response::from_string("time failed").with_status_code(500));
                         }
                     }
+                }
+                (Method::Get, "/") => {
+                    // Static endpoint index for discoverability (e.g. an LLM
+                    // probing the port). No GL access needed, so reply directly.
+                    let body = serde_json::json!({
+                        "service": "functor debug runtime",
+                        "endpoints": {
+                            "GET /": "this endpoint index",
+                            "POST /capture": "PNG (image/png) of the next rendered frame",
+                            "GET /state": "runtime state JSON: frame, tts, viewport, model (Debug text)",
+                            "GET /scene": "current frame as JSON: camera + scene + lights",
+                            "POST /input": "inject input — {\"type\":\"key\",\"key\":\"w\",\"down\":true} | {\"type\":\"mouse_move\",\"x\":0,\"y\":0} | {\"type\":\"mouse_wheel\",\"delta\":1}",
+                            "POST /time": "clock control — {\"type\":\"set\",\"tts\":2.0} (pause) | {\"type\":\"advance\",\"dts\":0.016} (step one frame) | {\"type\":\"resume\"}"
+                        }
+                    })
+                    .to_string();
+                    let header =
+                        Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..]).unwrap();
+                    let _ = request.respond(Response::from_string(body).with_header(header));
                 }
                 _ => {
                     let _ = request.respond(Response::from_string("not found").with_status_code(404));


### PR DESCRIPTION
Housekeeping for the existing `--debug-port` HTTP control server (it already exposes `/capture`, `/state`, `/scene`, `/input`, and `/time` clock control). This adds **discoverability + documentation**, not new control surface — the first slice of building out the debug-runtime tooling.

## Changes
- **`GET /`** returns a JSON index of the available endpoints, so a script or LLM probing the port can discover them. Static reply, no GL round-trip.
- **`docs/debug-runtime.md`** (new): how to start it, every endpoint, the two workflows (**observe a human** vs **drive the game**), and the verified curl recipes. Includes a *Future directions* section, notably **multiplayer simulation** — N runner instances on separate `--debug-port`s, networked via `Sub.connect`/`Sub.listen`, clocks pinned and stepped in lockstep; the out-of-process complement to the in-process `functor-netsim` harness.
- **`docs/todo.md`**: the "Debug runtime (north star)" item was stale — the server exists. Replaced it with the real remaining work: a TypeScript SDK + gated e2e harness (single-client **and** a multi-client lockstep session for multiplayer sim), richer/parseable observation state, and raycast/entity-state queries.
- Refreshed the `debug_server.rs` module doc (the `/input`/`/time` endpoints it called "future" now exist).

## Context
Verified the full server live first (pin/step/resume, input→state, capture, scene, key validation all work). This PR is the first increment of the broader debug-runtime build-out; the TypeScript SDK + e2e harness is the next PR (first e2e guard: inject `up` → step a frame → assert `model.held.up`).

## Testing
`cargo build -p functor-runtime-desktop` clean. Live: `GET /` returns the endpoint index; unknown paths still 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)