### PR TITLE
feat(sdk): TypeScript SDK + e2e harness for the debug runtime

### DIFF
--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -1,0 +1,93 @@
+# Debug runtime
+
+An optional HTTP control server on the desktop runtime (`functor-runner`) that lets
+an external client — a script, a test, or an LLM — **observe** and **drive** a running
+game without a GPU window of its own. It is the runtime arm of Functor's LLM-native
+goal: capture frames, query state, control the frame clock, and inject input over a
+localhost socket.
+
+Start it by passing `--debug-port <PORT>`:
+
+```sh
+# via the CLI (rebuilds + runs the game)
+./target/debug/functor -d examples/hello run native --debug-port 8077
+
+# or the runner directly, against an already-built dylib
+#   (cwd must be the game dir so assets resolve)
+cd examples/hello
+functor-runner --game-path build-native/target/debug/libgame_native.dylib --debug-port 8077
+```
+
+The server binds **localhost only** (`127.0.0.1:<PORT>`). HTTP handlers never touch GL;
+each request is handed to the render loop and fulfilled once per frame.
+
+## Endpoints
+
+`GET /` returns this list as JSON (discoverability).
+
+| Method & path | Purpose |
+| --- | --- |
+| `POST /capture` | PNG (`image/png`) of the next rendered frame |
+| `GET /state` | runtime state JSON: `frame`, `tts`, `viewport`, `model` (Rust `Debug` text) |
+| `GET /scene` | current frame as JSON: `camera` + `scene` + `lights` |
+| `POST /input` | inject input (see below) |
+| `POST /time` | control the frame clock (see below) |
+
+### `POST /input`
+
+JSON is tagged by `type`. Unknown keys/shapes return **400** with a message.
+
+```jsonc
+{"type":"key","key":"w","down":true}      // key press / release
+{"type":"mouse_move","x":10,"y":20}       // absolute cursor position
+{"type":"mouse_wheel","delta":1}          // scroll
+```
+
+### `POST /time` — frame-loop control
+
+```jsonc
+{"type":"set","tts":2.0}        // PAUSE: pin game time to a constant (dts=0)
+{"type":"advance","dts":0.016}  // STEP: run exactly one frame with this dt, then hold
+{"type":"resume"}               // RESUME: follow wall-clock again
+```
+
+`--fixed-time <T>` pins the clock from launch (equivalent to an initial `set`).
+While the clock is pinned, **user keyboard/mouse input from the window is ignored**, but
+injected `/input` still applies — so an external driver has deterministic control.
+
+## Two workflows
+
+**Observe a human playing.** Leave the clock on wall-clock and poll:
+
+```sh
+curl -s localhost:8077/state | jq        # frame, time, model
+curl -s localhost:8077/scene | jq .camera
+curl -s -X POST localhost:8077/capture -o frame.png
+```
+
+**Drive the game (LLM / test plays it).** Pin the clock, act, step, observe — a
+deterministic loop:
+
+```sh
+H=localhost:8077
+curl -s -X POST $H/time  -d '{"type":"set","tts":0}'             # pause
+curl -s -X POST $H/input -d '{"type":"key","key":"up","down":true}'
+curl -s -X POST $H/time  -d '{"type":"advance","dts":0.016}'      # step one frame
+curl -s $H/state | jq .model                                     # see the effect
+curl -s -X POST $H/capture -o step.png
+```
+
+## Tooling
+
+A typed TypeScript SDK over these endpoints (single-client + a multi-client lockstep
+session for simulating multiplayer games) lives in `tools/functor-sdk` *(planned)*.
+
+## Future directions
+
+- **Multiplayer simulation.** Launch N runner instances, each on its own
+  `--debug-port`, networked via `Sub.connect`/`Sub.listen`; pin all clocks and step
+  them in lockstep, injecting input and observing state per client. This is the
+  out-of-process counterpart to the in-process `functor-netsim` harness.
+- **Richer observation.** A structured (parseable) state snapshot and a held-input
+  summary, beyond today's `Debug`-text `model`.
+- **Discoverability/ergonomics.** First-class `pause` / single-`step` verbs.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -7,11 +7,17 @@ golden tests), see `CLAUDE.md` and `git log`.
 
 ## Validation tooling
 
-- [ ] **Debug runtime** (north star): an HTTP/stdin trigger on `functor-runner`
-      for on-demand capture + state queries, à la shock2quest's `debug_runtime`
-      (`/screenshot`, raycast, entity-state). Grow it out of the existing capture
-      path rather than a separate binary; MVU already makes state serializable
-      (`emit_state`).
+- Debug runtime: the `--debug-port` HTTP control server exists (`/capture`,
+      `/state`, `/scene`, `/input`, `/time` clock control, `GET /` index — see
+      `docs/debug-runtime.md`). Remaining:
+  - [ ] **TypeScript SDK** (`tools/functor-sdk`): typed client over the endpoints
+        (single-client + a multi-client lockstep session for **multiplayer
+        simulation** — N runners, pinned clocks, stepped together), plus a gated
+        e2e harness driving `hello`. First e2e guard: inject `up` → step → assert
+        `model.held.up`.
+  - [ ] Richer observation: a structured (parseable) state snapshot + held-input
+        summary, beyond today's `Debug`-text `model`.
+  - [ ] Raycast / entity-state queries (à la shock2quest's `debug_runtime`).
 - [ ] Headless/offscreen render path (e.g. llvmpipe under xvfb) at a fixed
       resolution so the golden-image test can run in CI (today it's `#[ignore]`d).
 - [ ] WASM capture path (today wasm screenshots need an external headless browser).

--- a/runtime/functor-runtime-desktop/src/debug_server.rs
+++ b/runtime/functor-runtime-desktop/src/debug_server.rs
@@ -10,7 +10,9 @@
 //! `main.rs`) and fulfills them with framebuffer data / runtime state it can
 //! only read on the main thread.
 //!
-//! This is the seed of a richer debug runtime (future `/input`, `/time`, etc.).
+//! Endpoints: `GET /` (index), `POST /capture`, `GET /state`, `GET /scene`,
+//! `POST /input`, `POST /time`. See `docs/debug-runtime.md` for usage and the
+//! observe-vs-drive workflows.
 
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread;
@@ -235,6 +237,25 @@ pub fn spawn(port: u16) -> Receiver<DebugRequest> {
                                 .respond(Response::from_string("time failed").with_status_code(500));
                         }
                     }
+                }
+                (Method::Get, "/") => {
+                    // Static endpoint index for discoverability (e.g. an LLM
+                    // probing the port). No GL access needed, so reply directly.
+                    let body = serde_json::json!({
+                        "service": "functor debug runtime",
+                        "endpoints": {
+                            "GET /": "this endpoint index",
+                            "POST /capture": "PNG (image/png) of the next rendered frame",
+                            "GET /state": "runtime state JSON: frame, tts, viewport, model (Debug text)",
+                            "GET /scene": "current frame as JSON: camera + scene + lights",
+                            "POST /input": "inject input — {\"type\":\"key\",\"key\":\"w\",\"down\":true} | {\"type\":\"mouse_move\",\"x\":0,\"y\":0} | {\"type\":\"mouse_wheel\",\"delta\":1}",
+                            "POST /time": "clock control — {\"type\":\"set\",\"tts\":2.0} (pause) | {\"type\":\"advance\",\"dts\":0.016} (step one frame) | {\"type\":\"resume\"}"
+                        }
+                    })
+                    .to_string();
+                    let header =
+                        Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..]).unwrap();
+                    let _ = request.respond(Response::from_string(body).with_header(header));
                 }
                 _ => {
                     let _ = request.respond(Response::from_string("not found").with_status_code(404));

--- a/tools/functor-sdk/.gitignore
+++ b/tools/functor-sdk/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/tools/functor-sdk/README.md
+++ b/tools/functor-sdk/README.md
@@ -1,0 +1,76 @@
+# @functor/sdk
+
+A Playwright-style TypeScript SDK for driving the functor **debug runtime** — the
+`--debug-port` HTTP control server on `functor-runner` (see
+[`docs/debug-runtime.md`](../../docs/debug-runtime.md)). It lets a script, test, or
+LLM **observe** and **drive** a running game headlessly.
+
+## Install & build
+
+```sh
+cd tools/functor-sdk
+npm install
+npm run build     # tsc -> dist/
+```
+
+## Usage
+
+```ts
+import { FunctorRunner, stepAll } from "@functor/sdk";
+
+// Launch a game and drive it deterministically.
+await using game = await FunctorRunner.launch({ gameDir: "examples/hello" });
+
+await game.pause();              // pin the clock
+await game.keyDown("up");        // inject input
+await game.step();               // advance exactly one frame
+const state = await game.state();// observe the result
+const png = await game.capture();// PNG bytes of the frame
+// `await using` shuts the runtime down at scope exit.
+```
+
+`FunctorRunner.connect(url)` attaches to an already-running runtime instead of
+spawning one (and won't kill it on dispose).
+
+### Observe vs. drive
+
+- **Observe a human playing:** leave the clock alone and poll `state()`,
+  `scene()`, `capture()`.
+- **Drive it:** `pause()` → `keyDown`/`mouseMove` → `step()` → `state()`. Pinned
+  time ignores window input but honors injected input, so it's deterministic.
+
+## Multiplayer simulation
+
+`stepAll(clients, dt)` advances several clients by one lockstep frame. Launch N
+runners on separate ports (networked via `Sub.connect`/`Sub.listen`), pin every
+clock, and `stepAll` them each tick to keep simulations in sync — the
+out-of-process counterpart to the in-process `functor-netsim` harness.
+
+```ts
+await using a = await FunctorRunner.launch({ gameDir: "examples/pong", port: 8077 });
+await using b = await FunctorRunner.launch({ gameDir: "examples/pong", port: 8078 });
+await Promise.all([a.pause(), b.pause()]);
+for (let frame = 0; frame < 600; frame++) {
+  await a.keyDown("up");        // per-client input
+  await stepAll([a, b]);        // both advance one frame together
+}
+```
+
+## Tests
+
+```sh
+npm test          # unit tests only (no runtime needed)
+npm run test:e2e  # FUNCTOR_E2E=1 — launches a real functor-runner
+```
+
+The e2e tests require the runner binary and the game dylib to be built, and a
+display to open the GL window:
+
+```sh
+cargo build --bin functor-runner
+./target/debug/functor -d examples/hello build native
+```
+
+The headline e2e (`held-input.e2e.test.ts`) is the durable guard for the
+input→state→step loop: inject `up`, step a frame, assert the model's `held.up`
+flips true (and back on release), then capture a valid PNG.

--- a/tools/functor-sdk/package-lock.json
+++ b/tools/functor-sdk/package-lock.json
@@ -1,0 +1,50 @@
+{
+  "name": "@functor/sdk",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@functor/sdk",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^22.10.0",
+        "typescript": "^5.7.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/tools/functor-sdk/package.json
+++ b/tools/functor-sdk/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@functor/sdk",
+  "version": "0.1.0",
+  "description": "Playwright-style TypeScript SDK for driving the functor debug runtime (--debug-port)",
+  "type": "module",
+  "private": true,
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/src/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "tsc && node --test \"dist/test/*.test.js\"",
+    "test:e2e": "tsc && FUNCTOR_E2E=1 node --test \"dist/test/*.test.js\""
+  },
+  "engines": {
+    "node": ">=20.4"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/tools/functor-sdk/src/client.ts
+++ b/tools/functor-sdk/src/client.ts
@@ -1,0 +1,63 @@
+/** Error thrown when the debug runtime returns a non-2xx response. */
+export class HttpError extends Error {
+  constructor(
+    public readonly method: string,
+    public readonly url: string,
+    public readonly status: number,
+    public readonly body: string,
+  ) {
+    super(`${method} ${url} failed with status ${status}: ${body}`);
+    this.name = "HttpError";
+  }
+}
+
+/** Thin typed wrapper over fetch for the debug runtime's API.
+ *
+ * The functor debug runtime is not uniformly JSON: `/state` and `/scene` return
+ * JSON, `/input` and `/time` return the literal text `ok`, and `/capture`
+ * returns binary PNG. This client exposes one method per response shape. */
+export class HttpClient {
+  /** @param timeoutMs per-request timeout; prevents a stuck connection (TCP
+   * accepted but no response) from hanging readiness polling forever. */
+  constructor(
+    public readonly baseUrl: string,
+    private readonly timeoutMs = 10_000,
+  ) {}
+
+  /** GET a JSON body. */
+  async getJson<T>(path: string): Promise<T> {
+    const res = await this.send("GET", path);
+    return JSON.parse(await res.text()) as T;
+  }
+
+  /** POST a JSON body to an endpoint that replies with plain text (e.g. `ok`). */
+  async postText(path: string, body?: unknown): Promise<string> {
+    const res = await this.send("POST", path, body);
+    return res.text();
+  }
+
+  /** POST a JSON body to an endpoint that replies with binary (e.g. a PNG). */
+  async postBinary(path: string, body?: unknown): Promise<Buffer> {
+    const res = await this.send("POST", path, body);
+    return Buffer.from(await res.arrayBuffer());
+  }
+
+  private async send(
+    method: string,
+    path: string,
+    body?: unknown,
+  ): Promise<Response> {
+    const url = `${this.baseUrl}${path}`;
+    const response = await fetch(url, {
+      method,
+      headers:
+        body !== undefined ? { "Content-Type": "application/json" } : undefined,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+      signal: AbortSignal.timeout(this.timeoutMs),
+    });
+    if (!response.ok) {
+      throw new HttpError(method, url, response.status, await response.text());
+    }
+    return response;
+  }
+}

--- a/tools/functor-sdk/src/game.ts
+++ b/tools/functor-sdk/src/game.ts
@@ -1,0 +1,104 @@
+import type { HttpClient } from "./client.js";
+import type { InputCommand, RuntimeState, Scene } from "./types.js";
+
+/** Default per-step delta time (seconds), ~one frame at 60 Hz. */
+export const DEFAULT_STEP_DT = 1 / 60;
+
+/** A high-level client for a single running game (one debug port).
+ *
+ * Two ways to use it: **observe** (`state`, `scene`, `capture`) a game that's
+ * running on the wall clock, or **drive** it deterministically by pinning the
+ * clock (`pause`), injecting input, and advancing a frame at a time (`step`). */
+export class FunctorClient {
+  constructor(protected readonly http: HttpClient) {}
+
+  // --- Observe -------------------------------------------------------------
+
+  /** Current runtime state: frame, game time, viewport, and model (Debug text). */
+  state(): Promise<RuntimeState> {
+    return this.http.getJson<RuntimeState>("/state");
+  }
+
+  /** Current frame description: camera + scene + lights. */
+  scene(): Promise<Scene> {
+    return this.http.getJson<Scene>("/scene");
+  }
+
+  /** Capture the next rendered frame as PNG bytes. */
+  capture(): Promise<Buffer> {
+    return this.http.postBinary("/capture");
+  }
+
+  // --- Drive: input --------------------------------------------------------
+
+  /** Inject a raw input command. */
+  async input(cmd: InputCommand): Promise<void> {
+    await this.http.postText("/input", cmd);
+  }
+
+  /** Press or release a key (e.g. "w", "up", "space"). */
+  key(key: string, down: boolean): Promise<void> {
+    return this.input({ type: "key", key, down });
+  }
+
+  keyDown(key: string): Promise<void> {
+    return this.key(key, true);
+  }
+
+  keyUp(key: string): Promise<void> {
+    return this.key(key, false);
+  }
+
+  /** Move the mouse cursor to an absolute position. */
+  mouseMove(x: number, y: number): Promise<void> {
+    return this.input({ type: "mouse_move", x, y });
+  }
+
+  /** Scroll the mouse wheel. */
+  mouseWheel(delta: number): Promise<void> {
+    return this.input({ type: "mouse_wheel", delta });
+  }
+
+  // --- Drive: clock --------------------------------------------------------
+
+  /** Pin the game clock so it stops advancing (a "pause"). With no argument,
+   * pins at the current game time; pass `tts` to pin at a specific time. */
+  async pause(tts?: number): Promise<void> {
+    const at = tts ?? (await this.state()).tts;
+    await this.http.postText("/time", { type: "set", tts: at });
+  }
+
+  /** Advance the clock by one step (default ~one 60 Hz frame), then hold. */
+  async step(dts: number = DEFAULT_STEP_DT): Promise<void> {
+    await this.http.postText("/time", { type: "advance", dts });
+  }
+
+  /** Advance `n` steps, one frame at a time. */
+  async stepFrames(n: number, dts: number = DEFAULT_STEP_DT): Promise<void> {
+    for (let i = 0; i < n; i++) {
+      await this.step(dts);
+    }
+  }
+
+  /** Resume following the wall clock. */
+  async resume(): Promise<void> {
+    await this.http.postText("/time", { type: "resume" });
+  }
+}
+
+/** Advance several clients by one lockstep frame, concurrently.
+ *
+ * The building block for **multiplayer simulation**: pin every client's clock,
+ * then `stepAll` them by the same dt each tick so their simulations stay in
+ * sync (the out-of-process analogue of the in-process `functor-netsim`
+ * harness).
+ *
+ * Rejects (via `Promise.all`) if any client's step fails — but the others may
+ * already have advanced, so a rejection means the simulation is desynced with
+ * no automatic rollback; treat it as terminal for the run. */
+export function stepAll(
+  clients: readonly Pick<FunctorClient, "step">[],
+  dts: number = DEFAULT_STEP_DT,
+): Promise<void[]> {
+  return Promise.all(clients.map((c) => c.step(dts)));
+}

--- a/tools/functor-sdk/src/index.ts
+++ b/tools/functor-sdk/src/index.ts
@@ -1,0 +1,9 @@
+export { HttpClient, HttpError } from "./client.js";
+export { DEFAULT_STEP_DT, FunctorClient, stepAll } from "./game.js";
+export {
+  defaultDylibName,
+  findRepoRoot,
+  formatCrashOutput,
+  FunctorRunner,
+} from "./server.js";
+export type * from "./types.js";

--- a/tools/functor-sdk/src/server.ts
+++ b/tools/functor-sdk/src/server.ts
@@ -1,0 +1,246 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import { StringDecoder } from "node:string_decoder";
+
+import { HttpClient } from "./client.js";
+import { FunctorClient } from "./game.js";
+import type { LaunchOptions } from "./types.js";
+
+/** Walk up from a directory until a cargo workspace root is found. */
+export function findRepoRoot(startDir: string): string | undefined {
+  let dir = startDir;
+  for (;;) {
+    const manifest = join(dir, "Cargo.toml");
+    if (
+      existsSync(manifest) &&
+      readFileSync(manifest, "utf8").includes("[workspace]")
+    ) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      return undefined;
+    }
+    dir = parent;
+  }
+}
+
+/** The platform-specific default game dylib filename produced by build-native. */
+export function defaultDylibName(): string {
+  switch (process.platform) {
+    case "darwin":
+      return "libgame_native.dylib";
+    case "win32":
+      return "game_native.dll";
+    default:
+      return "libgame_native.so";
+  }
+}
+
+const MAX_LOG_LINES = 2000;
+const MAX_ERROR_LOG_LINES = 120;
+
+/** Pick the most useful slice of runtime output for an error message: from the
+ * last panic line onward (with a little context), else the last ~30 lines. */
+export function formatCrashOutput(logLines: string[]): string {
+  const panicIndex = logLines.findLastIndex((line) =>
+    line.includes("panicked at"),
+  );
+  const start = panicIndex >= 0 ? Math.max(0, panicIndex - 2) : -30;
+  return logLines.slice(start).slice(0, MAX_ERROR_LOG_LINES).join("\n");
+}
+
+/** A {@link FunctorClient} whose `functor-runner` process is owned by the SDK.
+ *
+ * Supports `await using` for automatic shutdown:
+ *
+ * ```ts
+ * await using game = await FunctorRunner.launch({ gameDir: "examples/hello" });
+ * ```
+ */
+export class FunctorRunner extends FunctorClient implements AsyncDisposable {
+  /** Set if the spawned child emitted an 'error' (e.g. it couldn't be spawned). */
+  private spawnError?: Error;
+
+  private constructor(
+    http: HttpClient,
+    private readonly child: ChildProcess | undefined,
+    private readonly logLines: string[],
+  ) {
+    super(http);
+  }
+
+  /** Recent stdout/stderr from the spawned runtime (ring buffer). */
+  logs(): string[] {
+    return [...this.logLines];
+  }
+
+  /** Connect to an already-running debug runtime; does not own the process. */
+  static async connect(baseUrl = "http://127.0.0.1:8077"): Promise<FunctorRunner> {
+    const runner = new FunctorRunner(new HttpClient(baseUrl), undefined, []);
+    await runner.state();
+    return runner;
+  }
+
+  /** Spawn `functor-runner --debug-port` against a built game dylib and wait
+   * until the render loop is serving requests. Requires the runner binary and
+   * the game dylib to already be built. */
+  static async launch(options: LaunchOptions): Promise<FunctorRunner> {
+    const port = options.port ?? 8077;
+    // Resolve the game dir to an absolute path up front, so the dylib path, the
+    // spawn cwd, and repo-root discovery are all consistent regardless of the
+    // caller's process cwd.
+    const gameDir = isAbsolute(options.gameDir)
+      ? options.gameDir
+      : resolve(options.gameDir);
+    const repoRoot = options.repoRoot ?? findRepoRoot(gameDir);
+    if (repoRoot === undefined) {
+      throw new Error(
+        "Could not find cargo workspace root; pass repoRoot explicitly",
+      );
+    }
+
+    const runnerBin =
+      options.runnerBin ?? join(repoRoot, "target", "debug", runnerExe());
+    const dylibPath =
+      options.dylibPath ??
+      join(gameDir, "build-native", "target", "debug", defaultDylibName());
+
+    for (const [label, path] of [
+      ["functor-runner", runnerBin],
+      ["game dylib", dylibPath],
+    ] as const) {
+      if (!existsSync(path)) {
+        throw new Error(
+          `${label} not found at ${path}. Build it first ` +
+            `(e.g. \`functor -d ${options.gameDir} build native\` and ` +
+            `\`cargo build --bin functor-runner\`).`,
+        );
+      }
+    }
+
+    const logLines: string[] = [];
+    const child = spawn(
+      runnerBin,
+      ["--game-path", dylibPath, "--debug-port", String(port)],
+      {
+        cwd: gameDir,
+        env: {
+          ...process.env,
+          RUST_BACKTRACE: process.env.RUST_BACKTRACE ?? "1",
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+
+    // Decode stdout/stderr line-by-line, holding any trailing partial line (and
+    // any split multibyte char) until the rest arrives, so log lines — and the
+    // panic line formatCrashOutput looks for — aren't fragmented across chunks.
+    const decoder = new StringDecoder("utf8");
+    let residual = "";
+    const capture = (chunk: Buffer) => {
+      const lines = (residual + decoder.write(chunk)).split("\n");
+      residual = lines.pop() ?? "";
+      for (const line of lines) {
+        logLines.push(line);
+        if (logLines.length > MAX_LOG_LINES) logLines.shift();
+        if (options.echoLogs) process.stderr.write(`[functor-runner] ${line}\n`);
+      }
+    };
+    child.stdout?.on("data", capture);
+    child.stderr?.on("data", capture);
+
+    const runner = new FunctorRunner(
+      new HttpClient(`http://127.0.0.1:${port}`),
+      child,
+      logLines,
+    );
+    // A spawn failure (e.g. EACCES, ENOMEM — not caught by the existsSync checks
+    // above, which are also TOCTOU) emits 'error' with no other signal; without
+    // a listener Node rethrows it as a fatal uncaught exception. Record it so
+    // readiness fails fast. ('error' is emitted asynchronously, so attaching
+    // here — before the first await — cannot miss it.)
+    child.once("error", (err) => {
+      runner.spawnError = err;
+    });
+
+    try {
+      await runner.waitUntilReady(options.launchTimeoutMs ?? 60_000);
+    } catch (error) {
+      await runner.shutdown();
+      throw new Error(
+        `functor-runner failed to start: ${error}\nRecent output:\n${formatCrashOutput(logLines)}`,
+      );
+    }
+
+    return runner;
+  }
+
+  private async waitUntilReady(timeoutMs: number): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+      if (this.spawnError) {
+        throw this.spawnError;
+      }
+      if (
+        this.child &&
+        (this.child.exitCode !== null || this.child.signalCode !== null)
+      ) {
+        throw new Error(
+          `process exited early (code ${this.child.exitCode}, signal ${this.child.signalCode})`,
+        );
+      }
+      try {
+        // /state round-trips through the per-frame request channel, so it only
+        // succeeds once the render loop is actually running (the HTTP thread
+        // starts first and would answer too early on its own).
+        await this.state();
+        return;
+      } catch {
+        if (Date.now() >= deadline) {
+          throw new Error(`runtime not ready after ${timeoutMs}ms`);
+        }
+        await new Promise((r) => setTimeout(r, 500));
+      }
+    }
+  }
+
+  /** Stop the spawned runtime (SIGTERM, escalating to SIGKILL). No-op if this
+   * runner connected to an externally-owned process. */
+  async shutdown(): Promise<void> {
+    const child = this.child;
+    if (child === undefined || hasExited(child)) {
+      return;
+    }
+    await new Promise<void>((settle) => {
+      // Re-check inside the promise: the child may have exited between the guard
+      // above and attaching the listener — otherwise we'd await an 'exit' that
+      // already fired and hang forever (a signal-killed child has exitCode null).
+      if (hasExited(child)) {
+        settle();
+        return;
+      }
+      const killTimer = setTimeout(() => child.kill("SIGKILL"), 5_000);
+      child.once("exit", () => {
+        clearTimeout(killTimer);
+        settle();
+      });
+      child.kill("SIGTERM");
+    });
+  }
+
+  async [Symbol.asyncDispose](): Promise<void> {
+    await this.shutdown();
+  }
+}
+
+function runnerExe(): string {
+  return process.platform === "win32" ? "functor-runner.exe" : "functor-runner";
+}
+
+/** A child has exited if it has either an exit code or a terminating signal
+ * (a signal-killed process reports `exitCode === null`, `signalCode` set). */
+function hasExited(child: ChildProcess): boolean {
+  return child.exitCode !== null || child.signalCode !== null;
+}

--- a/tools/functor-sdk/src/types.ts
+++ b/tools/functor-sdk/src/types.ts
@@ -1,0 +1,54 @@
+/** Runtime state from `GET /state`. `model` is the game model rendered with
+ * Rust's pretty-`Debug` (not structured JSON yet), so reading specific fields
+ * from it is best-effort string matching for now. */
+export interface RuntimeState {
+  frame: number;
+  tts: number;
+  viewport: { width: number; height: number };
+  model: string;
+}
+
+export type Vec3 = [number, number, number];
+
+/** Camera block from `GET /scene`. */
+export interface Camera {
+  eye: Vec3;
+  target: Vec3;
+  up: Vec3;
+  fov_radians: number;
+  near: number;
+  far: number;
+}
+
+/** The frame description from `GET /scene` (camera + scene + lights). The scene
+ * and lights are passed through as-is for now. */
+export interface Scene {
+  camera: Camera;
+  scene: unknown;
+  lights: unknown;
+}
+
+/** An input event for `POST /input`, tagged by `type`. */
+export type InputCommand =
+  | { type: "key"; key: string; down: boolean }
+  | { type: "mouse_move"; x: number; y: number }
+  | { type: "mouse_wheel"; delta: number };
+
+/** Options for launching a `functor-runner` process. */
+export interface LaunchOptions {
+  /** Game directory containing `build-native/` (the runner's cwd, for assets).
+   * e.g. an absolute path to `examples/hello`. */
+  gameDir: string;
+  /** Debug-runtime HTTP port (default 8077). */
+  port?: number;
+  /** Path to the `functor-runner` binary (default `<repoRoot>/target/debug/functor-runner`). */
+  runnerBin?: string;
+  /** Path to the game dylib (default `<gameDir>/build-native/target/debug/<libgame_native>`). */
+  dylibPath?: string;
+  /** Cargo workspace root (default: walk up from `gameDir`). */
+  repoRoot?: string;
+  /** Max time to wait for the runtime to be ready, ms (default 60_000). */
+  launchTimeoutMs?: number;
+  /** Echo runtime stdout/stderr to this process's stderr (default false). */
+  echoLogs?: boolean;
+}

--- a/tools/functor-sdk/test/held-input.e2e.test.ts
+++ b/tools/functor-sdk/test/held-input.e2e.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { findRepoRoot, FunctorRunner } from "../src/index.js";
+
+// End-to-end against a real functor-runner. Requires the runner binary and the
+// `hello` game dylib to be built, and a display to open the GL window, so it's
+// opt-in:
+//
+//   npm run test:e2e        (or FUNCTOR_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.FUNCTOR_E2E === "1";
+
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+/** Best-effort read of `held.up` from the model's Debug string, e.g.
+ * `... held: HeldKeys { up: true, down: false, ... } ...`. Whitespace-tolerant,
+ * but still coupled to the Rust Debug layout (model is stringly-typed today —
+ * see types.ts; a structured snapshot would let us drop this regex). */
+function heldUp(model: string): boolean {
+  const m = model.match(/HeldKeys\s*\{\s*up:\s*(true|false)/);
+  assert.ok(m, `could not find HeldKeys.up in model: ${model.slice(0, 200)}`);
+  return m[1] === "true";
+}
+
+test(
+  "injected key is reflected in game state across a manual step",
+  { skip: !e2eEnabled, timeout: 120_000 },
+  async () => {
+    const repoRoot = findRepoRoot(process.cwd());
+    assert.ok(repoRoot, "must run from within the functor workspace");
+
+    await using game = await FunctorRunner.launch({
+      gameDir: join(repoRoot, "examples", "hello"),
+      repoRoot,
+      port: Number(process.env.FUNCTOR_E2E_PORT ?? 8090),
+    });
+
+    // Pin the clock so the only thing that changes state is what we inject.
+    await game.pause();
+
+    // Baseline: nothing held.
+    await game.step();
+    assert.equal(heldUp((await game.state()).model), false, "up should start released");
+
+    // Positive: press 'up', step a frame, observe held.up flip true.
+    await game.keyDown("up");
+    await game.step();
+    assert.equal(
+      heldUp((await game.state()).model),
+      true,
+      "up should be held after keyDown + step (regression: input not reaching the game)",
+    );
+
+    // Negative: release 'up', step, observe it flip back.
+    await game.keyUp("up");
+    await game.step();
+    assert.equal(heldUp((await game.state()).model), false, "up should release after keyUp + step");
+
+    // The render path produces a valid PNG.
+    const png = await game.capture();
+    assert.ok(png.length > 0, "capture should return bytes");
+    assert.ok(
+      png.subarray(0, 8).equals(PNG_MAGIC),
+      "capture should be a PNG (magic bytes)",
+    );
+  },
+);

--- a/tools/functor-sdk/test/launch-failure.e2e.test.ts
+++ b/tools/functor-sdk/test/launch-failure.e2e.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { findRepoRoot, FunctorRunner } from "../src/index.js";
+
+// Verifies a launch failure surfaces a useful error rather than hanging.
+const e2eEnabled = process.env.FUNCTOR_E2E === "1";
+
+test(
+  "launching against a missing dylib rejects with an actionable error",
+  { skip: !e2eEnabled, timeout: 30_000 },
+  async () => {
+    const repoRoot = findRepoRoot(process.cwd());
+    assert.ok(repoRoot, "must run from within the functor workspace");
+
+    await assert.rejects(
+      FunctorRunner.launch({
+        gameDir: join(repoRoot, "examples", "hello"),
+        repoRoot,
+        dylibPath: join(repoRoot, "does", "not", "exist.dylib"),
+        port: Number(process.env.FUNCTOR_E2E_PORT ?? 8091),
+      }),
+      (error: Error) => {
+        assert.match(error.message, /game dylib not found/);
+        assert.match(error.message, /Build it first/);
+        return true;
+      },
+    );
+  },
+);

--- a/tools/functor-sdk/test/unit.test.ts
+++ b/tools/functor-sdk/test/unit.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { findRepoRoot, formatCrashOutput, stepAll } from "../src/index.js";
+
+// Pure unit tests — no runtime required, always run.
+
+test("findRepoRoot walks up to the cargo workspace root", () => {
+  const root = findRepoRoot(process.cwd());
+  assert.ok(root !== undefined, "should find a workspace root from the SDK dir");
+  assert.ok(
+    existsSync(join(root, "Cargo.toml")),
+    "found root should contain Cargo.toml",
+  );
+});
+
+test("findRepoRoot returns undefined when there's no workspace above", () => {
+  assert.equal(findRepoRoot("/"), undefined);
+});
+
+test("formatCrashOutput keeps the panic and its context", () => {
+  const lines = ["init", "loading", "ok", "panicked at foo.rs:1", "stack:", "  0: x"];
+  const out = formatCrashOutput(lines);
+  assert.match(out, /panicked at foo\.rs:1/);
+  assert.match(out, /0: x/, "should include lines after the panic");
+  assert.match(out, /ok/, "should include a little context before the panic");
+});
+
+test("formatCrashOutput falls back to the tail when there's no panic", () => {
+  const lines = Array.from({ length: 50 }, (_, i) => `line ${i}`);
+  const out = formatCrashOutput(lines);
+  assert.match(out, /line 49/, "should include the last line");
+  assert.doesNotMatch(out, /line 0\b/, "should drop the earliest lines");
+});
+
+test("stepAll advances every client by the same dt, concurrently", async () => {
+  const calls: number[] = [];
+  const fake = () => ({
+    step: async (dt: number) => {
+      calls.push(dt);
+    },
+  });
+  const clients = [fake(), fake(), fake()];
+
+  await stepAll(clients, 0.25);
+
+  assert.deepEqual(calls, [0.25, 0.25, 0.25]);
+});

--- a/tools/functor-sdk/tsconfig.json
+++ b/tools/functor-sdk/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2023"],
+    "types": ["node"],
+    "strict": true,
+    "declaration": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*", "test/**/*"]
+}


### PR DESCRIPTION
**Stacked on #142** (debug-runtime `GET /` index + docs). Review/merge that first.

A Playwright-style TypeScript SDK (`tools/functor-sdk`, `@functor/sdk`) over the `--debug-port` HTTP control server, mirroring shock2quest's `tools/shock2-sdk`. This is the tooling that makes the debug runtime usable in the agent-verifiable workflow (CLAUDE.md §7).

## What's here
- **`FunctorClient`** — observe (`state`, `scene`, `capture`) and drive (`key`/`keyDown`/`keyUp`, `mouseMove`, `mouseWheel`, `pause`/`step`/`stepFrames`/`resume`) one game on one port.
- **`FunctorRunner.launch()` / `connect()`** — own a spawned `functor-runner` (with `await using` disposal, `/state` readiness, captured crash output) or attach to a running one.
- **`stepAll()`** — lockstep advance across clients: the primitive for **out-of-process multiplayer simulation** (N runners on separate ports, pinned clocks, stepped together — the complement to in-process `functor-netsim`).
- **`HttpClient`** — handles functor's mixed responses (JSON `/state` `/scene`, text `ok` `/input` `/time`, binary PNG `/capture`) with per-request timeouts.

## Tests
- Pure **unit** tests (always run): `findRepoRoot`, `formatCrashOutput`, `stepAll`.
- Gated **e2e** (`FUNCTOR_E2E=1`): the durable guard launches `hello`, pins the clock, injects `up`, steps a frame, asserts `model.held.up` flips true (then back on release), and captures a valid PNG. Plus a launch-failure test (missing dylib → actionable error).
- Verified locally: `npm test` (5 unit pass), `npm run test:e2e` (7/7 pass against a real runner in ~2.8s).

## Adversarial review (Claude + Codex) — applied before merge
Ran `/xreview`-style; fixes folded in:
- **shutdown() hang** when the child exited via signal (both engines flagged) — guard on `exitCode || signalCode` + in-promise re-check.
- Missing **`child.on("error")`** → a spawn failure could crash the host; now recorded and surfaced.
- **Per-request fetch timeout** so readiness can't hang on a stuck connection.
- **Resolve `gameDir` to absolute** before deriving dylib path / cwd / repo root.
- **Line-buffered log capture** (`StringDecoder`) so panic lines aren't fragmented across chunks.
- Reuse `shutdown()` on the failed-launch path; `engines: node>=20.4` (for `Symbol.asyncDispose`); drop dead `postJson`; document `stepAll` failure semantics.

Deferred (documented, non-blocking): structured/parseable state to replace the Debug-string regex in the e2e; a port-preflight (today a stale runner on the same port is caught via the child's bind-failure early-exit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)