### PR TITLE
feat(debug-runtime): structured input snapshot in /state (+ SDK)

### DIFF
--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -28,7 +28,7 @@ each request is handed to the render loop and fulfilled once per frame.
 | Method & path | Purpose |
 | --- | --- |
 | `POST /capture` | PNG (`image/png`) of the next rendered frame |
-| `GET /state` | runtime state JSON: `frame`, `tts`, `viewport`, `model` (Rust `Debug` text) |
+| `GET /state` | runtime state JSON: `frame`, `tts`, `viewport`, `input` (structured `held_keys` + `mouse`), `model` (Rust `Debug` text) |
 | `GET /scene` | current frame as JSON: `camera` + `scene` + `lights` |
 | `POST /input` | inject input (see below) |
 | `POST /time` | control the frame clock (see below) |
@@ -88,6 +88,7 @@ session for simulating multiplayer games) lives in `tools/functor-sdk` *(planned
   `--debug-port`, networked via `Sub.connect`/`Sub.listen`; pin all clocks and step
   them in lockstep, injecting input and observing state per client. This is the
   out-of-process counterpart to the in-process `functor-netsim` harness.
-- **Richer observation.** A structured (parseable) state snapshot and a held-input
-  summary, beyond today's `Debug`-text `model`.
+- **Richer observation.** `/state.input` now reports held keys + mouse as structured
+  JSON (game-agnostic, runtime-owned). Still open: a parseable snapshot of the game
+  *model* itself (today `Debug` text — the model isn't `Serialize`).
 - **Discoverability/ergonomics.** First-class `pause` / single-`step` verbs.

--- a/runtime/functor-runtime-common/src/input.rs
+++ b/runtime/functor-runtime-common/src/input.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 /// boundary. The F# `Input.Key` DU mirrors these discriminants in
 /// `Input.ofKeyCode` — keep the two in sync when adding keys.
 #[repr(i32)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum Key {
     Unknown = 0,
     A = 1,
@@ -43,4 +43,41 @@ pub enum Key {
     Space,
     Enter,
     Escape,
+}
+
+impl Key {
+    /// All key variants in discriminant order. Keep in sync with the enum above
+    /// (guarded by `from_i32_round_trips`).
+    pub const ALL: [Key; 34] = [
+        Key::Unknown,
+        Key::A, Key::B, Key::C, Key::D, Key::E, Key::F, Key::G, Key::H, Key::I,
+        Key::J, Key::K, Key::L, Key::M, Key::N, Key::O, Key::P, Key::Q, Key::R,
+        Key::S, Key::T, Key::U, Key::V, Key::W, Key::X, Key::Y, Key::Z,
+        Key::Up, Key::Down, Key::Left, Key::Right, Key::Space, Key::Enter,
+        Key::Escape,
+    ];
+
+    /// The key whose `as i32` discriminant equals `value`, if any. The inverse
+    /// of `key as i32` (which is how key codes cross the dylib/wasm boundary).
+    pub fn from_i32(value: i32) -> Option<Key> {
+        Key::ALL.into_iter().find(|k| *k as i32 == value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Key;
+
+    #[test]
+    fn from_i32_round_trips() {
+        for (i, key) in Key::ALL.iter().enumerate() {
+            // Prove ALL is contiguous from 0 (not just that round-trips work) —
+            // otherwise the length-as-ceiling check below wouldn't be sound, and
+            // a gap could hide a missing variant.
+            assert_eq!(*key as i32, i as i32, "Key::ALL must be contiguous from 0");
+            assert_eq!(Key::from_i32(*key as i32), Some(*key));
+        }
+        assert_eq!(Key::from_i32(Key::ALL.len() as i32), None);
+        assert_eq!(Key::from_i32(-1), None);
+    }
 }

--- a/runtime/functor-runtime-desktop/src/debug_server.rs
+++ b/runtime/functor-runtime-desktop/src/debug_server.rs
@@ -17,6 +17,7 @@
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread;
 
+use functor_runtime_common::Key;
 use serde::Deserialize;
 use tiny_http::{Header, Method, Response, Server};
 
@@ -31,6 +32,11 @@ pub struct RuntimeState {
     pub width: u32,
     pub height: u32,
     pub model: String,
+    /// Keys currently held, maintained by the runtime (serialized by their
+    /// canonical names, ordered by key discriminant, e.g. `["W", "Up"]`).
+    pub held_keys: Vec<Key>,
+    /// Last known cursor position (x, y) in window pixels.
+    pub mouse: (i32, i32),
 }
 
 impl RuntimeState {
@@ -42,6 +48,10 @@ impl RuntimeState {
             "tts": self.tts,
             "viewport": { "width": self.width, "height": self.height },
             "model": self.model,
+            "input": {
+                "held_keys": self.held_keys,
+                "mouse": { "x": self.mouse.0, "y": self.mouse.1 },
+            },
         })
         .to_string()
     }
@@ -246,7 +256,7 @@ pub fn spawn(port: u16) -> Receiver<DebugRequest> {
                         "endpoints": {
                             "GET /": "this endpoint index",
                             "POST /capture": "PNG (image/png) of the next rendered frame",
-                            "GET /state": "runtime state JSON: frame, tts, viewport, model (Debug text)",
+                            "GET /state": "runtime state JSON: frame, tts, viewport, input (held_keys + mouse), model (Debug text)",
                             "GET /scene": "current frame as JSON: camera + scene + lights",
                             "POST /input": "inject input — {\"type\":\"key\",\"key\":\"w\",\"down\":true} | {\"type\":\"mouse_move\",\"x\":0,\"y\":0} | {\"type\":\"mouse_wheel\",\"delta\":1}",
                             "POST /time": "clock control — {\"type\":\"set\",\"tts\":2.0} (pause) | {\"type\":\"advance\",\"dts\":0.016} (step one frame) | {\"type\":\"resume\"}"

--- a/runtime/functor-runtime-desktop/src/main.rs
+++ b/runtime/functor-runtime-desktop/src/main.rs
@@ -6,6 +6,8 @@ use std::time::Instant;
 
 use functor_runtime_common::asset::AssetCache;
 use functor_runtime_common::{FrameTime, SceneContext};
+use std::collections::BTreeSet;
+
 use functor_runtime_common::Key as InputKey;
 use glfw::{Action, Key};
 use glow::*;
@@ -66,28 +68,27 @@ fn map_key(key: Key) -> InputKey {
     }
 }
 
-/// Map a key name (case-insensitive: "w", "Up", "space", …) to the engine key
-/// code passed across the game boundary, for the debug server's POST /input.
-/// Letters rely on the contiguous A..Z discriminants.
-fn key_code_from_str(name: &str) -> Option<i32> {
+/// Map a key name (case-insensitive: "w", "Up", "space", …) to the canonical
+/// engine key, for the debug server's POST /input. Letters rely on the
+/// contiguous A..Z discriminants.
+fn key_from_str(name: &str) -> Option<InputKey> {
     let name = name.to_ascii_lowercase();
     if name.len() == 1 {
         let c = name.as_bytes()[0];
         if c.is_ascii_lowercase() {
-            return Some((c - b'a') as i32 + InputKey::A as i32);
+            return InputKey::from_i32((c - b'a') as i32 + InputKey::A as i32);
         }
     }
-    let key = match name.as_str() {
-        "up" => InputKey::Up,
-        "down" => InputKey::Down,
-        "left" => InputKey::Left,
-        "right" => InputKey::Right,
-        "space" => InputKey::Space,
-        "enter" => InputKey::Enter,
-        "escape" => InputKey::Escape,
-        _ => return None,
-    };
-    Some(key as i32)
+    match name.as_str() {
+        "up" => Some(InputKey::Up),
+        "down" => Some(InputKey::Down),
+        "left" => Some(InputKey::Left),
+        "right" => Some(InputKey::Right),
+        "space" => Some(InputKey::Space),
+        "enter" => Some(InputKey::Enter),
+        "escape" => Some(InputKey::Escape),
+        _ => None,
+    }
 }
 
 use clap::Parser;
@@ -280,6 +281,11 @@ pub async fn main() {
         // one-shot dt advance on the next frame. Seeded from --fixed-time.
         let mut held_time: Option<f32> = args.fixed_time;
         let mut pending_step: Option<f32> = None;
+        // Runtime-owned input snapshot for GET /state, maintained from both the
+        // GLFW event stream and the debug server's POST /input. Generic and
+        // serializable, unlike the game model (which is Debug text only).
+        let mut held_keys: BTreeSet<InputKey> = BTreeSet::new();
+        let mut mouse_pos: (i32, i32) = (0, 0);
 
         use glfw::Context;
 
@@ -370,14 +376,31 @@ pub async fn main() {
                     glfw::WindowEvent::Key(Key::Escape, _, Action::Press, _) => {
                         window.set_should_close(true)
                     }
-                    _ if ignore_user_input => {}
-                    glfw::WindowEvent::Key(key, _, action, _) => match action {
-                        Action::Press | Action::Repeat => {
-                            game.key_event(map_key(key) as i32, true)
+                    // Always honor key releases and focus-loss, even while other
+                    // input is ignored (pinned clock) — otherwise a key held at
+                    // the pin transition, or released after alt-tab, would stick
+                    // in held_keys forever. Releases can only *clear* input, so
+                    // they don't perturb a pinned/deterministic pose.
+                    glfw::WindowEvent::Key(key, _, Action::Release, _) => {
+                        let k = map_key(key);
+                        game.key_event(k as i32, false);
+                        held_keys.remove(&k);
+                    }
+                    glfw::WindowEvent::Focus(false) => {
+                        for k in std::mem::take(&mut held_keys) {
+                            game.key_event(k as i32, false);
                         }
-                        Action::Release => game.key_event(map_key(key) as i32, false),
-                    },
+                    }
+                    _ if ignore_user_input => {}
+                    glfw::WindowEvent::Key(key, _, Action::Press | Action::Repeat, _) => {
+                        let k = map_key(key);
+                        game.key_event(k as i32, true);
+                        if k != InputKey::Unknown {
+                            held_keys.insert(k);
+                        }
+                    }
                     glfw::WindowEvent::CursorPos(x, y) => {
+                        mouse_pos = (x as i32, y as i32);
                         game.mouse_move(x as i32, y as i32)
                     }
                     glfw::WindowEvent::Scroll(_, y) => game.mouse_wheel(y as i32),
@@ -563,6 +586,8 @@ pub async fn main() {
                                 width: fb_width as u32,
                                 height: fb_height as u32,
                                 model: game.state_debug(),
+                                held_keys: held_keys.iter().copied().collect(),
+                                mouse: mouse_pos,
                             });
                         }
                         debug_server::DebugRequest::Scene(resp) => {
@@ -578,15 +603,21 @@ pub async fn main() {
                             // applies it immediately, so the next /state reflects it.
                             let result = match cmd {
                                 debug_server::InputCommand::Key { key, down } => {
-                                    match key_code_from_str(&key) {
-                                        Some(code) => {
-                                            game.key_event(code, down);
+                                    match key_from_str(&key) {
+                                        Some(k) => {
+                                            game.key_event(k as i32, down);
+                                            if down {
+                                                held_keys.insert(k);
+                                            } else {
+                                                held_keys.remove(&k);
+                                            }
                                             Ok(())
                                         }
                                         None => Err(format!("unknown key: {}", key)),
                                     }
                                 }
                                 debug_server::InputCommand::MouseMove { x, y } => {
+                                    mouse_pos = (x, y);
                                     game.mouse_move(x, y);
                                     Ok(())
                                 }

--- a/tools/functor-sdk/src/game.ts
+++ b/tools/functor-sdk/src/game.ts
@@ -1,8 +1,16 @@
 import type { HttpClient } from "./client.js";
-import type { InputCommand, RuntimeState, Scene } from "./types.js";
+import type { InputCommand, KeyName, RuntimeState, Scene } from "./types.js";
 
 /** Default per-step delta time (seconds), ~one frame at 60 Hz. */
 export const DEFAULT_STEP_DT = 1 / 60;
+
+/** Canonicalize a key name to the runtime's form (e.g. "up" -> "Up", "w" -> "W").
+ * Every canonical Key name is a single word with only its first letter capitalized. */
+function canonicalKeyName(key: string): string {
+  return key.length === 0
+    ? key
+    : key[0].toUpperCase() + key.slice(1).toLowerCase();
+}
 
 /** A high-level client for a single running game (one debug port).
  *
@@ -22,6 +30,18 @@ export class FunctorClient {
   /** Current frame description: camera + scene + lights. */
   scene(): Promise<Scene> {
     return this.http.getJson<Scene>("/scene");
+  }
+
+  /** Keys the runtime currently considers held (structured, game-agnostic). */
+  async heldKeys(): Promise<KeyName[]> {
+    return (await this.state()).input.held_keys;
+  }
+
+  /** Whether a given key is currently held. Case-insensitive: accepts either the
+   * canonical name ("Up") or the lowercase form taken by keyDown/keyUp ("up"). */
+  async isKeyDown(key: KeyName): Promise<boolean> {
+    const want = canonicalKeyName(key);
+    return (await this.heldKeys()).some((k) => k === want);
   }
 
   /** Capture the next rendered frame as PNG bytes. */

--- a/tools/functor-sdk/src/types.ts
+++ b/tools/functor-sdk/src/types.ts
@@ -1,10 +1,27 @@
-/** Runtime state from `GET /state`. `model` is the game model rendered with
- * Rust's pretty-`Debug` (not structured JSON yet), so reading specific fields
- * from it is best-effort string matching for now. */
+/** A canonical key name as reported by the runtime (`functor_runtime_common::Key`).
+ * The `(string & {})` arm keeps newly-added keys usable before the SDK is updated. */
+export type KeyName =
+  | "A" | "B" | "C" | "D" | "E" | "F" | "G" | "H" | "I" | "J" | "K" | "L" | "M"
+  | "N" | "O" | "P" | "Q" | "R" | "S" | "T" | "U" | "V" | "W" | "X" | "Y" | "Z"
+  | "Up" | "Down" | "Left" | "Right" | "Space" | "Enter" | "Escape" | "Unknown"
+  | (string & {});
+
+/** Runtime-owned input snapshot (independent of the game model). */
+export interface InputSnapshot {
+  /** Keys currently held, by canonical name. */
+  held_keys: KeyName[];
+  /** Last known cursor position in window pixels. */
+  mouse: { x: number; y: number };
+}
+
+/** Runtime state from `GET /state`. `input` is structured and game-agnostic;
+ * `model` is the game model rendered with Rust's pretty-`Debug` (not structured
+ * JSON), so reading fields from it is best-effort string matching. */
 export interface RuntimeState {
   frame: number;
   tts: number;
   viewport: { width: number; height: number };
+  input: InputSnapshot;
   model: string;
 }
 

--- a/tools/functor-sdk/test/held-input.e2e.test.ts
+++ b/tools/functor-sdk/test/held-input.e2e.test.ts
@@ -13,18 +13,18 @@ const e2eEnabled = process.env.FUNCTOR_E2E === "1";
 
 const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 
-/** Best-effort read of `held.up` from the model's Debug string, e.g.
- * `... held: HeldKeys { up: true, down: false, ... } ...`. Whitespace-tolerant,
- * but still coupled to the Rust Debug layout (model is stringly-typed today —
- * see types.ts; a structured snapshot would let us drop this regex). */
-function heldUp(model: string): boolean {
+/** Whether the hello game's model shows `held.up` set. This reads the (stringly-
+ * typed) Debug model on purpose — as an independent check that the injected key
+ * reaches the *game*, not just the runtime's own input snapshot (which is mutated
+ * in the same handler as the game key event). */
+function gameSawUp(model: string): boolean {
   const m = model.match(/HeldKeys\s*\{\s*up:\s*(true|false)/);
   assert.ok(m, `could not find HeldKeys.up in model: ${model.slice(0, 200)}`);
   return m[1] === "true";
 }
 
 test(
-  "injected key is reflected in game state across a manual step",
+  "injected key is reflected in both the runtime input state and the game",
   { skip: !e2eEnabled, timeout: 120_000 },
   async () => {
     const repoRoot = findRepoRoot(process.cwd());
@@ -39,23 +39,25 @@ test(
     // Pin the clock so the only thing that changes state is what we inject.
     await game.pause();
 
-    // Baseline: nothing held.
-    await game.step();
-    assert.equal(heldUp((await game.state()).model), false, "up should start released");
+    // Baseline: nothing held — structured snapshot AND game model.
+    assert.equal(await game.isKeyDown("Up"), false, "Up should start released");
+    assert.equal(gameSawUp((await game.state()).model), false, "game should start with up released");
 
-    // Positive: press 'up', step a frame, observe held.up flip true.
+    // Positive: press 'up', step a frame.
     await game.keyDown("up");
     await game.step();
+    assert.equal(await game.isKeyDown("Up"), true, "runtime should report Up held");
     assert.equal(
-      heldUp((await game.state()).model),
+      gameSawUp((await game.state()).model),
       true,
-      "up should be held after keyDown + step (regression: input not reaching the game)",
+      "game should see up held (regression: input not reaching the game)",
     );
 
-    // Negative: release 'up', step, observe it flip back.
+    // Negative: release 'up', step.
     await game.keyUp("up");
     await game.step();
-    assert.equal(heldUp((await game.state()).model), false, "up should release after keyUp + step");
+    assert.equal(await game.isKeyDown("Up"), false, "runtime should report Up released");
+    assert.equal(gameSawUp((await game.state()).model), false, "game should see up released");
 
     // The render path produces a valid PNG.
     const png = await game.capture();


### PR DESCRIPTION
**Stacked on #143** (TypeScript SDK) → which is stacked on #142. Merge in order.

The first slice of *richer/parseable observation state*. `GET /state` exposed game state only as the model's Rust `Debug` string — not parseable, and the SDK e2e had to regex it. The game model isn't `Serialize` (Fable emits only `Debug`), but **input is runtime-owned**, so we can expose that structurally and game-agnostically.

## Runtime
- The desktop runtime maintains a `BTreeSet<Key>` of held keys + last mouse position, updated from **both** the GLFW event stream and the debug `/input` handler, serialized as:
  ```json
  "input": { "held_keys": ["W", "Up"], "mouse": { "x": 0, "y": 0 } }
  ```
  Keys serialize by canonical name — works for any game, no model parsing.
- `functor_runtime_common::Key`: derive `Ord`/`Hash`; add `Key::ALL` + `Key::from_i32` (inverse of `key as i32`) with a contiguity test.
- **Always honor key releases and `Focus(false)`** even while input is otherwise ignored (pinned clock), so a key held across a pin transition or an alt-tab can't get stuck as permanently "held".

## SDK
- `InputSnapshot` / `KeyName` types; `state().input`; `heldKeys()` and a case-insensitive `isKeyDown()`.
- The e2e now asserts the structured `isKeyDown("Up")` (robust, game-agnostic) **and** keeps an independent `model.held.up` check — proving the key reaches the *game*, not just the runtime's own snapshot.

## Adversarial review (Claude + Codex) — applied
Both engines independently flagged **stuck-keys-while-pinned** (fixed) and that asserting only the runtime snapshot no longer proved input reaches the game (fixed — restored the game-observable check). Also strengthened the `from_i32` contiguity test and made `isKeyDown` case-insensitive.

## Testing
`cargo test -p functor_runtime_common` (58 pass incl. new contiguity test); SDK `npm run test:e2e` 7/7 against a real runner.

## Deferred (documented)
A parseable snapshot of the game *model* itself still needs the model to be `Serialize` (Fable-codegen change or a game-authored accessor) — tracked in docs/debug-runtime.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)