### PR TITLE
test(sdk): network-simulation e2e — 2 clients + a server

### DIFF
--- a/tools/functor-sdk/README.md
+++ b/tools/functor-sdk/README.md
@@ -41,10 +41,16 @@ spawning one (and won't kill it on dispose).
 
 ## Multiplayer simulation
 
-`stepAll(clients, dt)` advances several clients by one lockstep frame. Launch N
-runners on separate ports (networked via `Sub.connect`/`Sub.listen`), pin every
-clock, and `stepAll` them each tick to keep simulations in sync — the
-out-of-process counterpart to the in-process `functor-netsim` harness.
+Launch N runners on separate debug ports, networked via `Sub.connect`/`Sub.listen`,
+and drive them together — the out-of-process counterpart to the in-process
+`functor-netsim` harness. `waitFor(poll, predicate, opts)` (and the
+`client.waitForState(predicate, opts)` shorthand) polls until an async condition
+holds, e.g. network convergence; `stepAll(clients, dt)` advances every client by
+one lockstep frame.
+
+`test/multiplayer.e2e.test.ts` does exactly this end-to-end: it launches one
+`mpserver` + two `mpclient` runners and waits until the server tracks 2 players
+and each client converges on a 2-player world.
 
 ```ts
 await using a = await FunctorRunner.launch({ gameDir: "examples/pong", port: 8077 });
@@ -63,13 +69,18 @@ npm test          # unit tests only (no runtime needed)
 npm run test:e2e  # FUNCTOR_E2E=1 — launches a real functor-runner
 ```
 
-The e2e tests require the runner binary and the game dylib to be built, and a
-display to open the GL window:
+The e2e tests require the runner binary and the relevant game dylibs to be built,
+and a display to open the GL window:
 
 ```sh
 cargo build --bin functor-runner
-./target/debug/functor -d examples/hello build native
+./target/debug/functor -d examples/hello build native      # held-input test
+./target/debug/functor -d examples/mpserver build native   # multiplayer test
+./target/debug/functor -d examples/mpclient build native   # multiplayer test
 ```
+
+(If a build reports a missing `*.rs`, the Fable cache is stale — regenerate with
+`dotnet fable <example>/<name>.fsproj --lang rust --outDir . --noCache`.)
 
 The headline e2e (`held-input.e2e.test.ts`) is the durable guard for the
 input→state→step loop: inject `up`, step a frame, assert the model's `held.up`

--- a/tools/functor-sdk/src/game.ts
+++ b/tools/functor-sdk/src/game.ts
@@ -1,5 +1,11 @@
 import type { HttpClient } from "./client.js";
-import type { InputCommand, KeyName, RuntimeState, Scene } from "./types.js";
+import type {
+  InputCommand,
+  KeyName,
+  RuntimeState,
+  Scene,
+  WaitForOptions,
+} from "./types.js";
 
 /** Default per-step delta time (seconds), ~one frame at 60 Hz. */
 export const DEFAULT_STEP_DT = 1 / 60;
@@ -103,6 +109,46 @@ export class FunctorClient {
   /** Resume following the wall clock. */
   async resume(): Promise<void> {
     await this.http.postText("/time", { type: "resume" });
+  }
+
+  /** Poll `state()` until `predicate` holds, or throw on timeout. Useful for
+   * async conditions like network convergence. */
+  waitForState(
+    predicate: (state: RuntimeState) => boolean,
+    opts?: WaitForOptions,
+  ): Promise<RuntimeState> {
+    return waitFor(() => this.state(), predicate, opts);
+  }
+}
+
+/** Poll `poll()` until `predicate(value)` is true, then return that value;
+ * throw if it doesn't happen within the timeout. A throwing `poll()` is treated
+ * as "not ready yet" and retried (e.g. a transient `/state` hiccup mid-
+ * convergence), with the last error surfaced if the deadline passes. */
+export async function waitFor<T>(
+  poll: () => Promise<T>,
+  predicate: (value: T) => boolean,
+  opts: WaitForOptions = {},
+): Promise<T> {
+  const timeoutMs = opts.timeoutMs ?? 10_000;
+  const intervalMs = opts.intervalMs ?? 100;
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  for (;;) {
+    try {
+      const value = await poll();
+      lastError = undefined;
+      if (predicate(value)) return value;
+    } catch (err) {
+      lastError = err;
+    }
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      const what = opts.description ? ` waiting for ${opts.description}` : "";
+      const cause = lastError === undefined ? "" : ` (last error: ${lastError})`;
+      throw new Error(`waitFor timed out after ${timeoutMs}ms${what}${cause}`);
+    }
+    await new Promise((r) => setTimeout(r, Math.min(intervalMs, remaining)));
   }
 }
 

--- a/tools/functor-sdk/src/index.ts
+++ b/tools/functor-sdk/src/index.ts
@@ -1,9 +1,10 @@
 export { HttpClient, HttpError } from "./client.js";
-export { DEFAULT_STEP_DT, FunctorClient, stepAll } from "./game.js";
+export { DEFAULT_STEP_DT, FunctorClient, stepAll, waitFor } from "./game.js";
 export {
   defaultDylibName,
   findRepoRoot,
   formatCrashOutput,
   FunctorRunner,
+  waitForPort,
 } from "./server.js";
 export type * from "./types.js";

--- a/tools/functor-sdk/src/server.ts
+++ b/tools/functor-sdk/src/server.ts
@@ -1,11 +1,49 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
+import { createConnection } from "node:net";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import { StringDecoder } from "node:string_decoder";
 
 import { HttpClient } from "./client.js";
 import { FunctorClient } from "./game.js";
-import type { LaunchOptions } from "./types.js";
+import type { LaunchOptions, WaitForOptions } from "./types.js";
+
+/** Resolve once a TCP connection to `host:port` succeeds, or throw on timeout.
+ * Useful to wait for a game's `Sub.listen` socket to be bound before launching
+ * clients (the debug `/state` readiness only proves the render loop is running,
+ * not that a game-level listener has bound yet). */
+export async function waitForPort(
+  host: string,
+  port: number,
+  opts: WaitForOptions = {},
+): Promise<void> {
+  const timeoutMs = opts.timeoutMs ?? 10_000;
+  const intervalMs = opts.intervalMs ?? 100;
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (await tryConnect(host, port)) {
+      return;
+    }
+    if (Date.now() >= deadline) {
+      const what = opts.description ? ` (${opts.description})` : "";
+      throw new Error(`${host}:${port} not accepting connections after ${timeoutMs}ms${what}`);
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
+function tryConnect(host: string, port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = createConnection({ host, port });
+    const settle = (ok: boolean) => {
+      socket.destroy();
+      resolve(ok);
+    };
+    socket.once("connect", () => settle(true));
+    socket.once("error", () => settle(false));
+    socket.setTimeout(1_000, () => settle(false));
+  });
+}
 
 /** Walk up from a directory until a cargo workspace root is found. */
 export function findRepoRoot(startDir: string): string | undefined {

--- a/tools/functor-sdk/src/types.ts
+++ b/tools/functor-sdk/src/types.ts
@@ -51,6 +51,16 @@ export type InputCommand =
   | { type: "mouse_move"; x: number; y: number }
   | { type: "mouse_wheel"; delta: number };
 
+/** Options for polling helpers like `waitFor` / `waitForState`. */
+export interface WaitForOptions {
+  /** Total time to wait before giving up, ms (default 10_000). */
+  timeoutMs?: number;
+  /** Poll interval, ms (default 100). */
+  intervalMs?: number;
+  /** Phrase used in the timeout error message ("…waiting for <description>"). */
+  description?: string;
+}
+
 /** Options for launching a `functor-runner` process. */
 export interface LaunchOptions {
   /** Game directory containing `build-native/` (the runner's cwd, for assets).

--- a/tools/functor-sdk/test/multiplayer.e2e.test.ts
+++ b/tools/functor-sdk/test/multiplayer.e2e.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { findRepoRoot, FunctorRunner, waitForPort } from "../src/index.js";
+
+// End-to-end network simulation: one mpserver + two mpclient runners, each its
+// own process on its own debug port, networked over a real WebSocket. Requires
+// the mpserver/mpclient dylibs and the runner binary to be built, plus a display:
+//
+//   cargo build --bin functor-runner
+//   ./target/debug/functor -d examples/mpserver build native
+//   ./target/debug/functor -d examples/mpclient build native
+//   FUNCTOR_E2E=1 node --test dist/test/
+const e2eEnabled = process.env.FUNCTOR_E2E === "1";
+
+// The example models are exposed only as Rust Debug text (the game model isn't
+// Serialize yet), so these read the `model` string. An F# list renders as a
+// Fable linked list — `List { root: Some(Node_1 { head: <elem>, tail: ... }) }`
+// — not a Rust `[..]`, so we count elements by their `head:` markers. These get
+// simpler once a structured model snapshot lands.
+const serverPlayerCount = (model: string): number =>
+  (model.match(/head:\s*Player\s*\{/g) ?? []).length;
+
+const clientStatus = (model: string): string =>
+  model.match(/status:\s*"([^"]*)"/)?.[1] ?? "";
+
+// Each world element is a `(pid, x, z)` tuple, i.e. `head: (`.
+const clientWorldCount = (model: string): number =>
+  (model.match(/head:\s*\(/g) ?? []).length;
+
+test(
+  "two clients connect to a server and converge on a shared world",
+  { skip: !e2eEnabled, timeout: 180_000 },
+  async () => {
+    const repoRoot = findRepoRoot(process.cwd());
+    assert.ok(repoRoot, "must run from within the functor workspace");
+
+    // All three debug ports derive from one base so the test is self-consistent
+    // when relocated. (The ws port is fixed at 9001 by the example games.)
+    const base = Number(process.env.FUNCTOR_E2E_PORT ?? 8095);
+    const launch = (game: string, port: number) =>
+      FunctorRunner.launch({
+        gameDir: join(repoRoot, "examples", game),
+        repoRoot,
+        port,
+        launchTimeoutMs: 30_000,
+      });
+
+    // Server first, and wait for its Sub.listen socket to actually bind before
+    // launching clients — mpclient connects once with no retry, so a client that
+    // races ahead of the listener would land in "error" and never converge.
+    await using server = await launch("mpserver", base);
+    await waitForPort("127.0.0.1", 9001, {
+      timeoutMs: 15_000,
+      description: "mpserver ws listener",
+    });
+
+    // mpclient auto-moves on connect, so no input injection is needed.
+    await using clientA = await launch("mpclient", base + 1);
+    await using clientB = await launch("mpclient", base + 2);
+
+    const waitOpts = { timeoutMs: 20_000, intervalMs: 200 };
+
+    // The server should accept both connections and track a player for each.
+    const serverState = await server.waitForState(
+      (s) => serverPlayerCount(s.model) === 2,
+      { ...waitOpts, description: "server to track 2 players" },
+    );
+    assert.equal(serverPlayerCount(serverState.model), 2);
+
+    // Each client should reach "in-world" and see both players in the snapshot
+    // the server broadcasts — i.e. the clients converge on a shared world. The
+    // waitForState calls already enforce this (they throw on timeout); asserting
+    // on their converged return value documents intent without a racy re-fetch.
+    for (const [name, client] of [
+      ["A", clientA],
+      ["B", clientB],
+    ] as const) {
+      const converged = await client.waitForState(
+        (s) => clientStatus(s.model) === "in-world" && clientWorldCount(s.model) === 2,
+        { ...waitOpts, description: `client ${name} to see both players` },
+      );
+      assert.equal(clientStatus(converged.model), "in-world");
+      assert.equal(clientWorldCount(converged.model), 2, `client ${name} sees both players`);
+    }
+  },
+);

--- a/tools/functor-sdk/test/unit.test.ts
+++ b/tools/functor-sdk/test/unit.test.ts
@@ -3,7 +3,7 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { test } from "node:test";
 
-import { findRepoRoot, formatCrashOutput, stepAll } from "../src/index.js";
+import { findRepoRoot, formatCrashOutput, stepAll, waitFor } from "../src/index.js";
 
 // Pure unit tests — no runtime required, always run.
 
@@ -47,4 +47,52 @@ test("stepAll advances every client by the same dt, concurrently", async () => {
   await stepAll(clients, 0.25);
 
   assert.deepEqual(calls, [0.25, 0.25, 0.25]);
+});
+
+test("waitFor returns once the predicate holds", async () => {
+  let n = 0;
+  const value = await waitFor(
+    async () => ++n,
+    (v) => v >= 3,
+    { intervalMs: 1 },
+  );
+  assert.equal(value, 3);
+});
+
+test("waitFor retries when poll throws, then resolves", async () => {
+  let n = 0;
+  const value = await waitFor(
+    async () => {
+      n++;
+      if (n < 3) throw new Error("transient");
+      return n;
+    },
+    (v) => v >= 3,
+    { intervalMs: 1 },
+  );
+  assert.equal(value, 3);
+});
+
+test("waitFor surfaces the last poll error on timeout", async () => {
+  await assert.rejects(
+    waitFor(
+      async () => {
+        throw new Error("boom");
+      },
+      () => true,
+      { timeoutMs: 20, intervalMs: 5, description: "x" },
+    ),
+    /timed out after 20ms waiting for x \(last error: Error: boom\)/,
+  );
+});
+
+test("waitFor throws on timeout with the description", async () => {
+  await assert.rejects(
+    waitFor(
+      async () => false,
+      (v) => v === true,
+      { timeoutMs: 20, intervalMs: 5, description: "the impossible" },
+    ),
+    /timed out after 20ms waiting for the impossible/,
+  );
 });


### PR DESCRIPTION
**Stacked on #144** (structured input state) → #143 → #142. Merge in order.

The network-simulation e2e you asked about — and the first real exercise of the SDK's multi-runner / multiplayer purpose. It launches **one `mpserver` + two `mpclient`** `functor-runner` processes (each its own debug port, talking over a real WebSocket on `127.0.0.1:9001`) and waits until the server tracks 2 players and **each client converges on a 2-player world**. This is the out-of-process counterpart to the in-process `functor-netsim` harness.

## SDK additions
- **`waitFor(poll, predicate, opts)`** + **`client.waitForState(predicate, opts)`** — poll until an async condition holds (network convergence). Retries a throwing `poll()` as "not ready yet" and surfaces the last error on timeout.
- **`waitForPort(host, port, opts)`** — wait for a game's `Sub.listen` socket to actually bind (the debug `/state` readiness only proves the render loop runs, not that a game-level listener is up).

## Test
`test/multiplayer.e2e.test.ts` (gated `FUNCTOR_E2E=1`). The example game models are exposed only as Rust `Debug` text (not `Serialize` yet), so the test parses the Fable-list Debug shape (`List { root: Some(Node_1 { head: <elem>, ... }) }`) — a concrete motivator for the deferred structured-model snapshot.

Prereq dylibs: `functor -d examples/mpserver build native` and `… mpclient …` (documented in the SDK README, incl. the stale-Fable-cache `--noCache` note).

## Adversarial review (Claude + Codex) — applied
Both engines flagged that `waitFor` aborted on a transient `poll()` error (fixed: retry until deadline) and the ws-listen/connect race (fixed: `waitForPort` before launching clients; `mpclient` connects once with no retry). Also: derive all debug ports from one base, and assert on the converged snapshot instead of a racy re-fetch.

## Testing
`npm run test:e2e` → 12/12 (incl. 2 clients converging on the server, plus new `waitFor` retry/timeout unit tests), ~2.8s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)