### PR TITLE
feat(runtime): --headless mode (no GL window) + SDK support

### DIFF
--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -21,6 +21,26 @@ functor-runner --game-path build-native/target/debug/libgame_native.dylib --debu
 The server binds **localhost only** (`127.0.0.1:<PORT>`). HTTP handlers never touch GL;
 each request is handed to the render loop and fulfilled once per frame.
 
+## Headless mode
+
+Add `--headless` to run with **no GL window** — the game loop and debug server run
+without GLFW/OpenGL, so no display (or GPU) is needed. Ideal for CI, scripted runs,
+and LLM-driven control:
+
+```sh
+functor-runner --game-path <dylib> --debug-port 8077 --headless
+```
+
+`/`, `/state`, `/scene`, `/input`, and `/time` all work (the game's `draw3d`
+produces a pure `Frame`, so `/scene` is real data with no rendering). This is the
+runtime expression of the LLM-native principle: drive and observe a game with no
+GPU window. Limitations vs. windowed:
+
+- `/capture` is unavailable (no pixels to read back) and returns `503`.
+- Audio isn't played, and `Audio.playThen` completion messages are **not**
+  delivered — don't gate game logic on audio completion when running headless.
+- `--capture-frame` is rejected (it needs GL).
+
 ## Endpoints
 
 `GET /` returns this list as JSON (discoverability).

--- a/runtime/functor-runtime-desktop/src/debug_server.rs
+++ b/runtime/functor-runtime-desktop/src/debug_server.rs
@@ -80,12 +80,21 @@ pub enum TimeCommand {
     Resume,
 }
 
+/// Why a `POST /capture` couldn't return pixels. Maps to an HTTP status:
+/// `Unavailable` → 503 (no GL, e.g. `--headless`), `Failed` → 500 (a real
+/// readback/encode error).
+pub enum CaptureError {
+    Unavailable(String),
+    Failed(String),
+}
+
 /// A request from the HTTP thread to the GL loop. Each variant carries a
 /// one-shot `Sender` the GL loop uses to reply; the HTTP handler blocks on the
 /// matching `Receiver`.
 pub enum DebugRequest {
-    /// `POST /capture` — reply with PNG bytes of the next rendered frame.
-    Capture(Sender<Vec<u8>>),
+    /// `POST /capture` — reply with PNG bytes of the next rendered frame, or a
+    /// [`CaptureError`] (unavailable in `--headless`, or a readback failure).
+    Capture(Sender<Result<Vec<u8>, CaptureError>>),
     /// `GET /state` — reply with the current runtime state.
     State(Sender<RuntimeState>),
     /// `GET /scene` — reply with the current frame (camera + scene) as JSON.
@@ -121,17 +130,27 @@ pub fn spawn(port: u16) -> Receiver<DebugRequest> {
 
             match (&method, path.as_str()) {
                 (Method::Post, "/capture") => {
-                    let (resp_tx, resp_rx) = mpsc::channel::<Vec<u8>>();
+                    let (resp_tx, resp_rx) = mpsc::channel::<Result<Vec<u8>, CaptureError>>();
                     if tx.send(DebugRequest::Capture(resp_tx)).is_err() {
                         let _ = request.respond(Response::from_string("runtime gone").with_status_code(503));
                         continue;
                     }
                     match resp_rx.recv() {
-                        Ok(png) => {
+                        Ok(Ok(png)) => {
                             let header =
                                 Header::from_bytes(&b"Content-Type"[..], &b"image/png"[..]).unwrap();
                             let resp = Response::from_data(png).with_header(header);
                             let _ = request.respond(resp);
+                        }
+                        // No GL to read back (e.g. headless) — Service Unavailable.
+                        Ok(Err(CaptureError::Unavailable(msg))) => {
+                            let _ = request
+                                .respond(Response::from_string(msg).with_status_code(503));
+                        }
+                        // A genuine readback/encode failure — Internal Error.
+                        Ok(Err(CaptureError::Failed(msg))) => {
+                            let _ = request
+                                .respond(Response::from_string(msg).with_status_code(500));
                         }
                         Err(_) => {
                             let _ = request

--- a/runtime/functor-runtime-desktop/src/main.rs
+++ b/runtime/functor-runtime-desktop/src/main.rs
@@ -124,6 +124,14 @@ struct Args {
     #[arg(long)]
     hot: bool,
 
+    /// Run without a GL window: drive the game loop + debug server headlessly
+    /// (no GLFW/OpenGL). `/state`, `/scene`, `/input`, `/time` work; `/capture`
+    /// is unavailable (no rendering), and audio isn't played (so `Audio.playThen`
+    /// completions aren't delivered). Incompatible with `--capture-frame`. For
+    /// CI / scripted / LLM-driven runs.
+    #[arg(long)]
+    headless: bool,
+
     /// Write a PNG of the rendered frame to this path, then exit. The capture
     /// happens on the first frame after --capture-time seconds of wall-clock
     /// time, so assets have a chance to load.
@@ -207,6 +215,208 @@ unsafe fn capture_framebuffer(gl: &glow::Context, width: u32, height: u32, path:
     }
 }
 
+/// Headless game loop: drives the game + debug server with no GL window, for CI /
+/// scripted / LLM-driven runs (`--headless`). Mirrors the windowed loop's game,
+/// networking, and debug handling, minus everything that needs GL — rendering,
+/// the framebuffer capture, and the GLFW event stream. `game.render` still runs
+/// (it returns a pure `Frame`, no GL) to power `GET /scene`; `POST /capture`
+/// returns an error since there is nothing rendered to read back.
+fn run_headless(
+    mut game: Box<dyn Game>,
+    debug_requests: Option<std::sync::mpsc::Receiver<debug_server::DebugRequest>>,
+    fixed_time: Option<f32>,
+) {
+    println!("[functor-runner] headless mode — no GL window; /capture unavailable");
+
+    let start_time = Instant::now();
+    let mut last_time: f32 = 0.0;
+    let mut frame_count: u64 = 0;
+    let mut held_time: Option<f32> = fixed_time;
+    let mut pending_step: Option<f32> = None;
+    let mut held_keys: BTreeSet<InputKey> = BTreeSet::new();
+    let mut mouse_pos: (i32, i32) = (0, 0);
+
+    // Same networking machinery as the windowed loop — driving networked/stateful
+    // games is the whole point of a headless runner. Audio is omitted (no device
+    // context), but queued audio commands are still drained so they don't pile up.
+    let http_client = reqwest::Client::new();
+    let (net_tx, net_rx) = std::sync::mpsc::channel::<net_dispatch::NetResult>();
+    let (ws_tx, ws_rx) = std::sync::mpsc::channel::<ws_host::HostNetEvent>();
+    let mut ws_manager = ws_host::WsManager::new(ws_tx);
+
+    loop {
+        let elapsed = start_time.elapsed().as_secs_f32();
+        // Same clock control as the windowed loop (--fixed-time / POST /time).
+        let time: FrameTime = if let Some(step) = pending_step.take() {
+            let new_tts = held_time.unwrap_or(last_time) + step;
+            held_time = Some(new_tts);
+            FrameTime {
+                dts: step,
+                tts: new_tts,
+            }
+        } else {
+            match held_time {
+                Some(tts) => FrameTime { dts: 0.0, tts },
+                None => FrameTime {
+                    dts: elapsed - last_time,
+                    tts: elapsed,
+                },
+            }
+        };
+        last_time = elapsed;
+
+        // Pick up a hot-reloaded dylib (no-op for a static game), matching the
+        // windowed loop. Keep this loop's per-frame ordering in sync with the
+        // windowed loop above, which is the source of truth.
+        game.check_hot_reload(time.clone());
+
+        // Deliver async net/ws results into the game before tick (same ordering as
+        // the windowed loop, so this frame's executor drain sees them).
+        while let Ok(result) = net_rx.try_recv() {
+            match result {
+                net_dispatch::NetResult::Response {
+                    token,
+                    status,
+                    body,
+                } => game.net_push_http_response(token, status, body),
+                net_dispatch::NetResult::Error { token, message } => {
+                    game.net_push_http_error(token, message)
+                }
+            }
+        }
+        while let Ok(event) = ws_rx.try_recv() {
+            match event {
+                ws_host::HostNetEvent::Connected { key, id } => {
+                    game.net_push_connected(key, id as i32)
+                }
+                ws_host::HostNetEvent::Message { key, id, text } => {
+                    game.net_push_conn_message(key, id as i32, text)
+                }
+                ws_host::HostNetEvent::Disconnected { key, id } => {
+                    game.net_push_disconnected(key, id as i32)
+                }
+                ws_host::HostNetEvent::Error { key, id, message } => {
+                    game.net_push_conn_error(key, id as i32, message)
+                }
+            }
+        }
+
+        game.tick(time.clone());
+
+        // HTTP commands this tick queued -> tokio tasks (results return via net_rx).
+        let commands_json = game.net_drain_commands();
+        if commands_json != "[]" {
+            match serde_json::from_str::<Vec<functor_runtime_common::net::NetCommand>>(&commands_json)
+            {
+                Ok(commands) => {
+                    for cmd in commands {
+                        let tx = net_tx.clone();
+                        let client = http_client.clone();
+                        tokio::spawn(async move {
+                            let _ = tx.send(net_dispatch::perform_http(&client, cmd).await);
+                        });
+                    }
+                }
+                Err(e) => eprintln!("[net] bad commands json: {e}"),
+            }
+        }
+
+        // WebSocket commands this tick queued (connect / listen / send / close).
+        let conn_json = game.net_drain_conn_commands();
+        if conn_json != "[]" {
+            match serde_json::from_str::<Vec<functor_runtime_common::net::ConnCommand>>(&conn_json) {
+                Ok(commands) => {
+                    for cmd in commands {
+                        ws_manager.handle(cmd);
+                    }
+                }
+                Err(e) => eprintln!("[net] bad conn commands json: {e}"),
+            }
+        }
+
+        // The frame description is pure data (no GL); it powers GET /scene. Drain
+        // and drop audio commands (no device in headless) so they don't pile up.
+        let frame = game.render(time.clone());
+        let _ = game.audio_drain_commands();
+
+        if let Some(rx) = &debug_requests {
+            while let Ok(req) = rx.try_recv() {
+                match req {
+                    debug_server::DebugRequest::Capture(resp) => {
+                        let _ = resp.send(Err(debug_server::CaptureError::Unavailable(
+                            "capture is unavailable in --headless mode".to_string(),
+                        )));
+                    }
+                    debug_server::DebugRequest::State(resp) => {
+                        let _ = resp.send(debug_server::RuntimeState {
+                            frame: frame_count,
+                            tts: time.tts,
+                            width: 0,
+                            height: 0,
+                            model: game.state_debug(),
+                            held_keys: held_keys.iter().copied().collect(),
+                            mouse: mouse_pos,
+                        });
+                    }
+                    debug_server::DebugRequest::Scene(resp) => {
+                        let json = serde_json::to_string_pretty(&frame)
+                            .unwrap_or_else(|e| format!("{{\"error\":{:?}}}", e.to_string()));
+                        let _ = resp.send(json);
+                    }
+                    debug_server::DebugRequest::Input(cmd, resp) => {
+                        let result = match cmd {
+                            debug_server::InputCommand::Key { key, down } => {
+                                match key_from_str(&key) {
+                                    Some(k) => {
+                                        game.key_event(k as i32, down);
+                                        if down {
+                                            held_keys.insert(k);
+                                        } else {
+                                            held_keys.remove(&k);
+                                        }
+                                        Ok(())
+                                    }
+                                    None => Err(format!("unknown key: {}", key)),
+                                }
+                            }
+                            debug_server::InputCommand::MouseMove { x, y } => {
+                                mouse_pos = (x, y);
+                                game.mouse_move(x, y);
+                                Ok(())
+                            }
+                            debug_server::InputCommand::MouseWheel { delta } => {
+                                game.mouse_wheel(delta);
+                                Ok(())
+                            }
+                        };
+                        let _ = resp.send(result);
+                    }
+                    debug_server::DebugRequest::Time(cmd, resp) => {
+                        match cmd {
+                            debug_server::TimeCommand::Set { tts } => {
+                                held_time = Some(tts);
+                                pending_step = None;
+                            }
+                            debug_server::TimeCommand::Advance { dts } => {
+                                pending_step = Some(dts);
+                            }
+                            debug_server::TimeCommand::Resume => {
+                                held_time = None;
+                                pending_step = None;
+                            }
+                        }
+                        let _ = resp.send(());
+                    }
+                }
+            }
+        }
+
+        frame_count += 1;
+        // Cap the loop near 60 Hz so it doesn't busy-spin a core.
+        std::thread::sleep(std::time::Duration::from_millis(16));
+    }
+}
+
 #[tokio::main]
 pub async fn main() {
     // Load game
@@ -227,6 +437,18 @@ pub async fn main() {
     // its request channel once per frame (see below). None when --debug-port is
     // not given, so behavior is unchanged.
     let debug_requests = args.debug_port.map(debug_server::spawn);
+
+    // Headless: drive the game + debug server with no GL window, and return.
+    if args.headless {
+        if args.capture_frame.is_some() {
+            eprintln!(
+                "error: --capture-frame is not supported with --headless (no GL to read back)"
+            );
+            std::process::exit(1);
+        }
+        run_headless(game, debug_requests, args.fixed_time);
+        return;
+    }
 
     unsafe {
         let (gl, shader_version, mut window, mut glfw, events) = {
@@ -569,15 +791,10 @@ pub async fn main() {
                 while let Ok(req) = rx.try_recv() {
                     match req {
                         debug_server::DebugRequest::Capture(resp) => {
-                            match encode_framebuffer_png(&gl, fb_width as u32, fb_height as u32) {
-                                Ok(png) => {
-                                    let _ = resp.send(png);
-                                }
-                                Err(e) => {
-                                    eprintln!("[debug-server] capture failed: {}", e);
-                                    // Dropping `resp` signals failure to the handler.
-                                }
-                            }
+                            let _ = resp.send(
+                                encode_framebuffer_png(&gl, fb_width as u32, fb_height as u32)
+                                    .map_err(debug_server::CaptureError::Failed),
+                            );
                         }
                         debug_server::DebugRequest::State(resp) => {
                             let _ = resp.send(debug_server::RuntimeState {

--- a/tools/functor-sdk/README.md
+++ b/tools/functor-sdk/README.md
@@ -32,6 +32,10 @@ const png = await game.capture();// PNG bytes of the frame
 `FunctorRunner.connect(url)` attaches to an already-running runtime instead of
 spawning one (and won't kill it on dispose).
 
+Pass `headless: true` to launch with no GL window (`--headless`) — no display
+needed, ideal for CI. `state()`, `scene()`, `input()`, and the clock controls all
+work; `capture()` is unavailable (it returns a 503 — there are no pixels).
+
 ### Observe vs. drive
 
 - **Observe a human playing:** leave the clock alone and poll `state()`,

--- a/tools/functor-sdk/package.json
+++ b/tools/functor-sdk/package.json
@@ -15,7 +15,8 @@
   "scripts": {
     "build": "tsc",
     "test": "tsc && node --test \"dist/test/*.test.js\"",
-    "test:e2e": "tsc && FUNCTOR_E2E=1 node --test \"dist/test/*.test.js\""
+    "test:e2e": "tsc && FUNCTOR_E2E=1 node --test \"dist/test/*.test.js\"",
+    "test:e2e:headless": "tsc && FUNCTOR_E2E=1 FUNCTOR_E2E_HEADLESS=1 node --test \"dist/test/*.test.js\""
   },
   "engines": {
     "node": ">=20.4"

--- a/tools/functor-sdk/src/server.ts
+++ b/tools/functor-sdk/src/server.ts
@@ -158,11 +158,13 @@ export class FunctorRunner extends FunctorClient implements AsyncDisposable {
       }
     }
 
+    const runnerArgs = ["--game-path", dylibPath, "--debug-port", String(port)];
+    if (options.headless) {
+      runnerArgs.push("--headless");
+    }
+
     const logLines: string[] = [];
-    const child = spawn(
-      runnerBin,
-      ["--game-path", dylibPath, "--debug-port", String(port)],
-      {
+    const child = spawn(runnerBin, runnerArgs, {
         cwd: gameDir,
         env: {
           ...process.env,

--- a/tools/functor-sdk/src/types.ts
+++ b/tools/functor-sdk/src/types.ts
@@ -78,4 +78,7 @@ export interface LaunchOptions {
   launchTimeoutMs?: number;
   /** Echo runtime stdout/stderr to this process's stderr (default false). */
   echoLogs?: boolean;
+  /** Run the runtime with no GL window (`--headless`): no display needed, but
+   * `capture()` is unavailable. Ideal for CI / headless machines. */
+  headless?: boolean;
 }

--- a/tools/functor-sdk/test/held-input.e2e.test.ts
+++ b/tools/functor-sdk/test/held-input.e2e.test.ts
@@ -10,6 +10,8 @@ import { findRepoRoot, FunctorRunner } from "../src/index.js";
 //
 //   npm run test:e2e        (or FUNCTOR_E2E=1 node --test dist/test/)
 const e2eEnabled = process.env.FUNCTOR_E2E === "1";
+// Headless (no GL window) is the CI path; capture is unavailable there.
+const headless = process.env.FUNCTOR_E2E_HEADLESS === "1";
 
 const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 
@@ -34,6 +36,7 @@ test(
       gameDir: join(repoRoot, "examples", "hello"),
       repoRoot,
       port: Number(process.env.FUNCTOR_E2E_PORT ?? 8090),
+      headless,
     });
 
     // Pin the clock so the only thing that changes state is what we inject.
@@ -59,12 +62,14 @@ test(
     assert.equal(await game.isKeyDown("Up"), false, "runtime should report Up released");
     assert.equal(gameSawUp((await game.state()).model), false, "game should see up released");
 
-    // The render path produces a valid PNG.
-    const png = await game.capture();
-    assert.ok(png.length > 0, "capture should return bytes");
-    assert.ok(
-      png.subarray(0, 8).equals(PNG_MAGIC),
-      "capture should be a PNG (magic bytes)",
-    );
+    // The render path produces a valid PNG — windowed only (headless has no GL).
+    if (!headless) {
+      const png = await game.capture();
+      assert.ok(png.length > 0, "capture should return bytes");
+      assert.ok(
+        png.subarray(0, 8).equals(PNG_MAGIC),
+        "capture should be a PNG (magic bytes)",
+      );
+    }
   },
 );

--- a/tools/functor-sdk/test/multiplayer.e2e.test.ts
+++ b/tools/functor-sdk/test/multiplayer.e2e.test.ts
@@ -13,6 +13,7 @@ import { findRepoRoot, FunctorRunner, waitForPort } from "../src/index.js";
 //   ./target/debug/functor -d examples/mpclient build native
 //   FUNCTOR_E2E=1 node --test dist/test/
 const e2eEnabled = process.env.FUNCTOR_E2E === "1";
+const headless = process.env.FUNCTOR_E2E_HEADLESS === "1";
 
 // The example models are exposed only as Rust Debug text (the game model isn't
 // Serialize yet), so these read the `model` string. An F# list renders as a
@@ -45,6 +46,7 @@ test(
         repoRoot,
         port,
         launchTimeoutMs: 30_000,
+        headless,
       });
 
     // Server first, and wait for its Sub.listen socket to actually bind before


### PR DESCRIPTION
**Stacked on #145** (net-sim e2e) → #144 → … Merge in order.

PR1 of "headless first, then CI". Adds a `--headless` mode to `functor-runner` so the game loop + debug server run with **no GL window** (no GLFW/OpenGL) — no display or GPU needed. This is the runtime expression of CLAUDE.md principle #2 (drive + observe a game with no GPU window), and the basis for running the SDK e2e on CI **without xvfb**.

## Runtime
- **`--headless`** → a new `run_headless` loop. `/`, `/state`, `/scene`, `/input`, `/time` all work — the game's `draw3d` returns a pure `Frame`, so `/scene` is real data with no rendering. `/capture` returns **503** (no pixels).
- `DebugRequest::Capture` now carries `Result<Vec<u8>, CaptureError>`: `Unavailable → 503` (headless), `Failed → 500` (a real readback/encode error — previously these were dropped → generic 500).
- Mirrors the windowed loop's per-frame ordering, **including `check_hot_reload`**; **rejects `--headless --capture-frame`** (which would otherwise hang). Audio isn't played and `Audio.playThen` completions aren't delivered (documented).

## SDK
- `LaunchOptions.headless` (passes `--headless`). The e2e run headless under `FUNCTOR_E2E_HEADLESS=1` via a new `test:e2e:headless` script, gating the held-input `/capture` assertion off when headless.

## Adversarial review (Claude + Codex) — applied
Both engines flagged that the headless copy had **dropped `check_hot_reload`** (fixed) and that **`playThen` completions** aren't delivered (documented); plus the **`--capture-frame` hang** (now rejected), the **503-vs-500** capture semantics (now split), and that the **headless path had no runnable script** (added `test:e2e:headless`). The duplication that caused these is called out in a "keep in sync" comment; de-duping via shared helpers is a noted follow-up (kept the windowed GL path untouched on purpose — it has no native CI coverage).

## Testing
Both validated locally: `test:e2e:headless` 12/12 (no windows, 1.2s) and windowed `test:e2e` 12/12 (capture path, 3s). Guard: `--headless --capture-frame` exits 1 with a clear message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)