### PR TITLE
ci(eval): evaluate native runner on Windows (+ Linux CI revisit note)

### DIFF
--- a/.github/workflows/windows-native-eval.yml
+++ b/.github/workflows/windows-native-eval.yml
@@ -1,0 +1,67 @@
+name: Windows native eval (WIP)
+
+# Reproducer (manual): does the native functor-runner work headlessly on Windows?
+# RESULT: no — it SIGSEGVs during the loaded game's init(), the same as Linux
+# (Windows uses LoadLibrary, Linux dlopen; only macOS works). Kept as a manual
+# reproducer for the native-platform follow-up (see todo.md); not auto-run, since
+# it's red by design until the Fable lazy-static/load-time-init issue is fixed.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  windows-smoke:
+    runs-on: windows-latest
+    timeout-minutes: 40
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Restore tools
+        run: dotnet tool restore
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Transpile hello
+        run: dotnet fable examples/hello/hello.fsproj --lang rust --outDir . --noCache
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "."
+
+      - name: Build functor-runner + hello dll
+        run: |
+          cargo build --bin functor-runner
+          cargo build --manifest-path examples/hello/build-native/Cargo.toml
+
+      - name: Headless smoke — does /state serve?
+        run: |
+          set -x
+          RUNNER="$GITHUB_WORKSPACE/target/debug/functor-runner.exe"
+          DYLIB="$GITHUB_WORKSPACE/examples/hello/build-native/target/debug/game_native.dll"
+          ls -la "$RUNNER" "$DYLIB"
+          ( cd examples/hello && "$RUNNER" --game-path "$DYLIB" --headless --debug-port 8077 ) &
+          PID=$!
+          ok=0
+          for i in $(seq 1 30); do
+            if curl -sf --max-time 3 http://127.0.0.1:8077/state -o state.json 2>/dev/null; then ok=1; break; fi
+            if ! kill -0 "$PID" 2>/dev/null; then echo "!! runner exited early (crashing?)"; break; fi
+            sleep 1
+          done
+          kill "$PID" 2>/dev/null || taskkill //F //PID "$PID" 2>/dev/null || true
+          if [ "$ok" = 1 ]; then
+            echo "✅ SUCCESS: Windows headless native runner serves /state"
+            head -c 400 state.json
+          else
+            echo "❌ FAIL: Windows runner did not serve /state"
+            exit 1
+          fi

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -18,6 +18,21 @@ golden tests), see `CLAUDE.md` and `git log`.
   - [ ] Richer observation: a structured (parseable) state snapshot + held-input
         summary, beyond today's `Debug`-text `model`.
   - [ ] Raycast / entity-state queries (à la shock2quest's `debug_runtime`).
+- [ ] **Revisit: native runner on Linux + Windows (pick up with the Fable model).**
+      The native `functor-runner` SIGSEGVs on **both Linux and Windows** during the
+      loaded game's `init()`; **only macOS works**, which is why the e2e CI runs on
+      macOS (`e2e.yml`). Goal: get native Linux (and ideally Windows) working, then
+      run the e2e there too. Diagnosis (reproducers: `linux-native-debug.yml` on
+      branch `debug/linux-native-runner`, `windows-native-eval.yml` on
+      `eval/native-platform-support`): gdb on Linux shows a Fable lazy-static
+      returning a **NULL `Rc`** — `Rc<MutCell<Vec<LrcStr>>>` dropped at
+      `hello.rs:888`, so `Rc::drop` null-derefs; Windows crashes the same way.
+      **Ruled out:** `-C prefer-dynamic` (shared libstd) and `crate-type=["cdylib"]`
+      — both still crash, so it's neither std-duplication nor the crate-type. That
+      Windows (`LoadLibrary`) and Linux (`dlopen`) both fail while macOS doesn't
+      points at how Fable's generated `OnceInit`/lazy-statics initialize when the
+      crate is loaded at runtime rather than linked at startup — revisit with
+      Fable-backend knowledge.
 - [ ] Headless/offscreen render path (e.g. llvmpipe under xvfb) at a fixed
       resolution so the golden-image test can run in CI (today it's `#[ignore]`d).
 - [ ] WASM capture path (today wasm screenshots need an external headless browser).


### PR DESCRIPTION
Draft / evaluation, per the native-platform follow-up.

## Windows evaluation
A headless smoke (`windows-native-eval.yml`, `windows-latest`): build `functor-runner` + the `hello` game DLL, run `--headless`, and confirm `GET /state` serves. The native runner SIGSEGVs on **Linux** (a `dlopen`/lazy-static issue) but is fine on **macOS**; Windows uses a different loader (`LoadLibrary`), so this checks whether it works there.
- ✅ green → we can run the full e2e on Windows too.
- ❌ → Windows shares the limitation; documented alongside Linux.

(Smoke result will show in the `windows-smoke` check.)

## Note: revisit Linux CI
`docs/todo.md` now has a task to revisit running the native e2e CI on **Linux** (move the `e2e.yml` job from macOS back to ubuntu once fixed) — to **pick up with the Fable model**, since the leading suspect is Fable's generated `OnceInit`/lazy-static init under `dlopen` (TLS model). Full gdb diagnosis + ruled-out fixes (`-C prefer-dynamic`, `cdylib`) are captured there and on `debug/linux-native-runner`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)