### PR TITLE
feat(protocol): formalize + version the logic↔runtime contract (MLE Track A1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,8 @@ built fluently via `GameBuilder` and handed to `Runtime.runGame`:
 
 - `initialState: 'model`
 - `init  : effect<'msg>` — startup effect, seeded into the queue at construction so it drains
-  before the first frame; **not** re-run across a hot reload (the persisted queue is restored)
+  before the first frame; **not** re-run across a hot reload (`setState` starts the reloaded
+  runner with an empty queue, discarding the constructor-seeded effect)
 - `input : 'model -> Input.t -> 'model * effect<'msg>` — keyboard/mouse events, applied immediately
 - `tick  : 'model -> FrameTime -> 'model * effect<'msg>` — per-frame simulation step
 - `update: 'model -> 'msg -> 'model * effect<'msg>` — handles messages produced by effects
@@ -64,9 +65,11 @@ lives in the Rust runtime, with an F# `Emit` binding mirroring its signature —
 
 **Hot-reload and state persistence.** The desktop runtime can run a game statically
 (`static_game.rs`) or hot-reloaded (`hot_reload_game.rs`, via the `--hot` flag). Across a reload,
-`getState`/`setState` (the `emit_state`/`set_state` `no_mangle` exports in `Runtime.fs`) bundle
-**both the model and the pending effect queue** into an `OpaqueState` so in-flight effects survive
-the reload. Preserve this contract when touching executor state.
+`getState`/`setState` (the `emit_state`/`set_state` `no_mangle` exports in `Runtime.fs`) carry
+**the model only** in an `OpaqueState`; pending effects are deliberately dropped (an `Http`
+effect's tagger is a closure into the old dylib and would dangle — see `getState`'s comment in
+`Runtime.fs`). Preserve this contract when touching executor state; the full boundary is
+enumerated in `functor_runtime_common::protocol`.
 
 **Two runtime exports.** `Runtime.Native` exposes `no_mangle` functions for the dylib;
 `Runtime.Wasm` exposes `wasm_bindgen` equivalents (`_wasm` suffix, marshalling through JsValue;

--- a/docs/mle.md
+++ b/docs/mle.md
@@ -97,11 +97,17 @@ Today the boundary is a shared-crate ABI (`test_render` returns a
 `Graphics.Frame` struct; ~20 `no_mangle` exports in `Runtime.fs`), not a
 versioned protocol.
 
-- [ ] **A1. Formalize the protocol.** Version the logic↔runtime contract in
-      `functor-runtime-common`: `Frame`/`Scene3D` out, `Effect` out, `Input` +
-      `FrameTime` in, `OpaqueState` for persistence — all serde-serializable.
-      *Verify:* round-trip serde tests per boundary type; existing goldens
-      byte-identical with the F# producer.
+- [x] **A1. Formalize the protocol.** Version the logic↔runtime contract in
+      `functor-runtime-common` (`protocol.rs`: `PROTOCOL_VERSION` + the full
+      boundary enumeration): `Frame`/`Scene3D`/`View` out, effect *commands*
+      (`NetCommand`/`ConnCommand`/`AudioCommand`/`AudioScene`) out, `Input`
+      key codes + `FrameTime` in — all serde round-trip-tested. Two pieces are
+      documented as **in-process only**, not (yet) data: `OpaqueState` (an
+      any-box with a layout assumption — made serializable by Track C's
+      data-native state) and `Effect`/`EffectQueue` themselves (message
+      payloads + HTTP taggers are closures; their commands cross as data).
+      *Verify:* round-trip serde tests per boundary type (done); rendering
+      code untouched so goldens are unaffected.
 - [ ] **A2. `GameProducer` trait.** Abstract the runtime's "thing that ticks and
       draws" — today hardcoded to dylib exports (`static_game.rs`,
       `hot_reload_game.rs`) and wasm-bindgen calls — behind one trait the loop

--- a/runtime/functor-runtime-common/src/lib.rs
+++ b/runtime/functor-runtime-common/src/lib.rs
@@ -81,6 +81,7 @@ pub mod material;
 pub mod math;
 pub mod model;
 pub mod net;
+pub mod protocol;
 pub mod render;
 mod render_context;
 mod renderer;

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -1,0 +1,212 @@
+//! The logic↔runtime protocol: the versioned contract between a game's pure
+//! logic (today the Fable-generated F# dylib/wasm module; later any producer —
+//! see `docs/mle.md`, Track A) and the imperative runtime shells.
+//!
+//! Everything that crosses the boundary is enumerated here, split by whether it
+//! crosses **as serializable data** (the protocol proper — language-neutral,
+//! introspectable, what a second producer must speak) or **in-process only**
+//! (a same-binary handoff that is *not* yet part of the data protocol). The
+//! round-trip tests below pin the serialized shape of every data type; changing
+//! one is a protocol change and should bump [`PROTOCOL_VERSION`].
+//!
+//! # Per-frame, runtime → logic
+//!
+//! - [`crate::FrameTime`] — `tts`/`dts` seconds.
+//! - Input events, as scalars: key code ([`crate::Key`] as `i32`) + down flag,
+//!   mouse position (`i32` pixels), wheel delta (`i32`). The `Key` enum is the
+//!   canonical code space on both sides.
+//!
+//! # Per-frame, logic → runtime
+//!
+//! - [`crate::Frame`] — camera + [`crate::Scene3D`] + [`crate::Light`]s; the
+//!   value returned by `draw3d`, also serialized verbatim for `GET /scene`.
+//! - [`crate::ui::View`] — the declarative UI tree (`emit_ui`).
+//! - Drained command queues, each a JSON array over the boundary:
+//!   [`crate::net::NetCommand`] (HTTP), [`crate::net::ConnCommand`]
+//!   (connections), [`crate::audio::AudioCommand`] (one-shots).
+//! - [`crate::audio::AudioScene`] — the desired soundscape, reconciled by the
+//!   host against its live voices.
+//!
+//! # Async, runtime → logic (inbox pushes)
+//!
+//! - HTTP results: `(token, status, body)` / `(token, message)` scalars,
+//!   matching [`crate::net::NetInbound`].
+//! - Connection events: `(key, conn, text)` scalars; kinds as in
+//!   `KeyedEvent::kind`.
+//! - Audio one-shot completions: `token`.
+//!
+//! # In-process only (NOT part of the data protocol — known limitations)
+//!
+//! - [`crate::OpaqueState`] — the hot-reload state bundle (model + pending
+//!   effect queue) is a `Box<dyn Any>` moved between dylib generations with a
+//!   layout-compatibility assumption, not serialized data. A data-native state
+//!   representation is what makes state durable/inspectable across producers
+//!   (`docs/mle.md`, Track C).
+//! - [`crate::Effect`] / [`crate::EffectQueue`] — effect *commands* cross as
+//!   data (above), but message payloads and `Http` taggers are closures, so
+//!   the queue itself cannot cross the boundary.
+
+/// Version of the serialized logic↔runtime contract. Bump when the serialized
+/// shape of any type enumerated in this module changes incompatibly.
+pub const PROTOCOL_VERSION: u32 = 1;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audio::{AudioScene, AudioSource};
+    use crate::net::{ConnCommand, HttpMethod, NetCommand, NetInbound};
+    use crate::ui::{Anchor, View};
+    use crate::{Camera, Frame, FrameTime, Key, Light, Scene3D, SceneObject};
+
+    /// Round-trip a value through JSON and assert the serialized form is
+    /// stable (serialize → deserialize → serialize gives the same string).
+    /// Used for types without `PartialEq` (e.g. anything holding a `Matrix4`).
+    fn assert_json_stable<T: serde::Serialize + serde::de::DeserializeOwned>(value: &T) {
+        let json = serde_json::to_string(value).expect("serialize");
+        let back: T = serde_json::from_str(&json).expect("deserialize");
+        let json2 = serde_json::to_string(&back).expect("re-serialize");
+        assert_eq!(json, json2);
+    }
+
+    /// Round-trip a `PartialEq` value through JSON and assert equality.
+    fn assert_round_trips<T>(value: &T)
+    where
+        T: serde::Serialize + serde::de::DeserializeOwned + PartialEq + std::fmt::Debug,
+    {
+        let json = serde_json::to_string(value).expect("serialize");
+        let back: T = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(*value, back);
+    }
+
+    #[test]
+    fn version_is_pinned() {
+        assert_eq!(PROTOCOL_VERSION, 1);
+    }
+
+    // A representative draw3d output: every SceneObject variant, transformed
+    // geometry, a material wrapper, and all four light kinds.
+    #[test]
+    fn frame_round_trips() {
+        use crate::math::Angle;
+        use crate::{MaterialDescription, ModelDescription, ModelHandle};
+        use cgmath::{Matrix4, SquareMatrix};
+        use fable_library_rust::NativeArray_;
+
+        let scene = Scene3D {
+            obj: SceneObject::Group(vec![
+                Scene3D {
+                    obj: SceneObject::Material(
+                        MaterialDescription::color(1.0, 0.5, 0.25, 1.0),
+                        vec![Scene3D::cube()
+                            .rotate_y(Angle::from_degrees(45.0))
+                            .translate_x(2.0)],
+                    ),
+                    xform: Matrix4::identity(),
+                },
+                Scene3D::sphere().scale_y(2.0),
+                Scene3D::heightmap(2, 2, NativeArray_::array_from(vec![0.0, 0.5, 1.0, 0.25])),
+                Scene3D::model(ModelDescription {
+                    handle: ModelHandle::File("barrel.glb".to_string()),
+                    overrides: vec![],
+                }),
+            ]),
+            xform: Matrix4::identity(),
+        };
+        let frame = Frame {
+            camera: Camera::default(),
+            scene,
+            lights: vec![
+                Light::ambient(0.1, 0.1, 0.1),
+                Light::directional(-1.0, -1.0, 0.0, 1.0, 1.0, 1.0, 0.8).cast_shadows(),
+                Light::point(0.0, 2.0, 0.0, 1.0, 0.0, 0.0, 1.0, 10.0),
+            ],
+        };
+        assert_json_stable(&frame);
+
+        // `lights` was added to Frame later; a frame serialized without it
+        // must still decode (serde(default)) — old producers stay readable.
+        let legacy: Frame =
+            serde_json::from_str(r#"{"camera":{"eye":[0.0,0.0,-5.0],"target":[0.0,0.0,0.0],"up":[0.0,1.0,0.0],"fov_radians":0.785,"near":0.1,"far":100.0},"scene":{"obj":{"Geometry":"Cube"},"xform":[[1.0,0.0,0.0,0.0],[0.0,1.0,0.0,0.0],[0.0,0.0,1.0,0.0],[0.0,0.0,0.0,1.0]]}}"#)
+                .expect("frame without lights decodes");
+        assert!(legacy.lights.is_empty());
+    }
+
+    #[test]
+    fn frame_time_and_key_codes_round_trip() {
+        let time = FrameTime { tts: 12.5, dts: 0.016 };
+        let json = serde_json::to_string(&time).unwrap();
+        let back: FrameTime = serde_json::from_str(&json).unwrap();
+        assert_eq!(time.tts, back.tts);
+        assert_eq!(time.dts, back.dts);
+
+        for key in [Key::A, Key::Z, Key::Up, Key::Space, Key::Escape, Key::Unknown] {
+            assert_round_trips(&key);
+        }
+    }
+
+    #[test]
+    fn net_commands_round_trip() {
+        assert_round_trips(&NetCommand::HttpRequest {
+            token: 7,
+            method: HttpMethod::Post,
+            url: "https://example.com/state".to_string(),
+            headers: vec![("content-type".to_string(), "application/json".to_string())],
+            body: b"{}".to_vec(),
+        });
+        for cmd in [
+            ConnCommand::Connect {
+                key: "ws://server".to_string(),
+                url: "ws://server".to_string(),
+            },
+            ConnCommand::Listen {
+                key: "0.0.0.0:9001".to_string(),
+                addr: "0.0.0.0:9001".to_string(),
+            },
+            ConnCommand::CloseKey {
+                key: "ws://server".to_string(),
+            },
+        ] {
+            assert_round_trips(&cmd);
+        }
+        assert_round_trips(&NetInbound::HttpResponse {
+            token: 7,
+            status: 200,
+            body: b"ok".to_vec(),
+        });
+    }
+
+    #[test]
+    fn audio_boundary_round_trips() {
+        let scene = AudioScene::new(vec![
+            AudioSource::ambient("bed".to_string(), "wind.ogg".to_string()),
+            AudioSource::at("fountain".to_string(), "water.ogg".to_string(), 1.0, 0.0, 2.0),
+        ]);
+        assert_round_trips(&scene);
+        // The exact hop the runtimes use (audio_scene_json).
+        let json = crate::audio::scene_to_json(&scene);
+        let back: AudioScene = serde_json::from_str(&json).unwrap();
+        assert_eq!(scene, back);
+    }
+
+    #[test]
+    fn ui_view_round_trips() {
+        let view = View::Panel {
+            anchor: Anchor::TopRight,
+            child: Box::new(View::Column(vec![
+                View::Text {
+                    text: "score: 10".to_string(),
+                    color: [255, 255, 0],
+                    font: None,
+                },
+                View::Empty,
+            ])),
+        };
+        assert_json_stable(&view);
+
+        // A Text serialized before the optional `font` field existed must
+        // still decode (serde(default)).
+        let legacy: View =
+            serde_json::from_str(r#"{"Text":{"text":"hi","color":[1,2,3]}}"#).unwrap();
+        assert_json_stable(&legacy);
+    }
+}

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -4,17 +4,19 @@
 //!
 //! Everything that crosses the boundary is enumerated here, split by whether it
 //! crosses **as serializable data** (the protocol proper — language-neutral,
-//! introspectable, what a second producer must speak) or **in-process only**
-//! (a same-binary handoff that is *not* yet part of the data protocol). The
-//! round-trip tests below pin the serialized shape of every data type; changing
-//! one is a protocol change and should bump [`PROTOCOL_VERSION`].
+//! introspectable, what a second producer must speak), as **unversioned debug
+//! text**, or **in-process only** (a same-binary handoff that is *not* yet part
+//! of the data protocol). The tests below pin the wire shape of the data types;
+//! changing one is a protocol change and should bump [`PROTOCOL_VERSION`].
 //!
 //! # Per-frame, runtime → logic
 //!
 //! - [`crate::FrameTime`] — `tts`/`dts` seconds.
 //! - Input events, as scalars: key code ([`crate::Key`] as `i32`) + down flag,
-//!   mouse position (`i32` pixels), wheel delta (`i32`). The `Key` enum is the
-//!   canonical code space on both sides.
+//!   mouse position (`i32` pixels), wheel delta (`i32`). The `Key` enum's
+//!   **`i32` discriminants** are the wire representation on both sides
+//!   (mirrored by F# `Input.ofKeyCode`) — inserting a variant mid-enum is a
+//!   protocol break even though serde names don't change.
 //!
 //! # Per-frame, logic → runtime
 //!
@@ -35,32 +37,58 @@
 //!   `KeyedEvent::kind`.
 //! - Audio one-shot completions: `token`.
 //!
+//! # Debug text (unversioned, human/LLM-facing — not protocol data)
+//!
+//! - `emit_state_debug` → `String`: a Rust-`Debug` pretty-print of the live
+//!   model, surfaced as the `model` field of the debug server's `GET /state`.
+//!   Free-form by design; consumers must not parse it.
+//!
 //! # In-process only (NOT part of the data protocol — known limitations)
 //!
-//! - [`crate::OpaqueState`] — the hot-reload state bundle (model + pending
-//!   effect queue) is a `Box<dyn Any>` moved between dylib generations with a
-//!   layout-compatibility assumption, not serialized data. A data-native state
-//!   representation is what makes state durable/inspectable across producers
-//!   (`docs/mle.md`, Track C).
+//! - [`crate::OpaqueState`] — the hot-reload state bundle is a `Box<dyn Any>`
+//!   moved between dylib generations with a layout-compatibility assumption,
+//!   not serialized data. It carries the **model only**: pending effects are
+//!   deliberately dropped on reload (an `Http` effect's tagger is a closure
+//!   into the old dylib and would dangle — see `getState` in
+//!   `src/Functor.Game/Runtime.fs`). A data-native state representation is
+//!   what makes state durable/inspectable across producers (`docs/mle.md`,
+//!   Track C).
 //! - [`crate::Effect`] / [`crate::EffectQueue`] — effect *commands* cross as
 //!   data (above), but message payloads and `Http` taggers are closures, so
 //!   the queue itself cannot cross the boundary.
+//! - Control signals with no payload: the dylib `init` entry point and `quit`.
 
-/// Version of the serialized logic↔runtime contract. Bump when the serialized
-/// shape of any type enumerated in this module changes incompatibly.
+/// Version of the serialized logic↔runtime contract. Bump when the wire shape
+/// of any type enumerated in this module changes incompatibly. Informational
+/// for now — nothing transmits or checks it until Track A2's producer seam
+/// consumes it.
 pub const PROTOCOL_VERSION: u32 = 1;
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::audio::{AudioScene, AudioSource};
+    use crate::audio::{AudioCommand, AudioScene, AudioSource};
     use crate::net::{ConnCommand, HttpMethod, NetCommand, NetInbound};
     use crate::ui::{Anchor, View};
     use crate::{Camera, Frame, FrameTime, Key, Light, Scene3D, SceneObject};
 
+    /// Pin a value's exact wire form: it must serialize to `expected` and
+    /// decode back from it. This is what makes a serde rename / retagging /
+    /// field change fail a test (round-trip-only checks are self-consistent
+    /// and would stay green).
+    fn assert_wire<T>(value: &T, expected: &str)
+    where
+        T: serde::Serialize + serde::de::DeserializeOwned + PartialEq + std::fmt::Debug,
+    {
+        assert_eq!(serde_json::to_string(value).expect("serialize"), expected);
+        let back: T = serde_json::from_str(expected).expect("deserialize");
+        assert_eq!(*value, back);
+    }
+
     /// Round-trip a value through JSON and assert the serialized form is
     /// stable (serialize → deserialize → serialize gives the same string).
-    /// Used for types without `PartialEq` (e.g. anything holding a `Matrix4`).
+    /// For types that don't derive `PartialEq` and are too large to pin as a
+    /// literal (`Frame`); shape pinning for those relies on the hard-coded
+    /// legacy-decode literals below.
     fn assert_json_stable<T: serde::Serialize + serde::de::DeserializeOwned>(value: &T) {
         let json = serde_json::to_string(value).expect("serialize");
         let back: T = serde_json::from_str(&json).expect("deserialize");
@@ -68,23 +96,9 @@ mod tests {
         assert_eq!(json, json2);
     }
 
-    /// Round-trip a `PartialEq` value through JSON and assert equality.
-    fn assert_round_trips<T>(value: &T)
-    where
-        T: serde::Serialize + serde::de::DeserializeOwned + PartialEq + std::fmt::Debug,
-    {
-        let json = serde_json::to_string(value).expect("serialize");
-        let back: T = serde_json::from_str(&json).expect("deserialize");
-        assert_eq!(*value, back);
-    }
-
-    #[test]
-    fn version_is_pinned() {
-        assert_eq!(PROTOCOL_VERSION, 1);
-    }
-
-    // A representative draw3d output: every SceneObject variant, transformed
-    // geometry, a material wrapper, and all four light kinds.
+    // A representative draw3d output: every Shape variant, every SceneObject
+    // variant, transformed geometry, a material wrapper, and all four light
+    // kinds.
     #[test]
     fn frame_round_trips() {
         use crate::math::Angle;
@@ -104,6 +118,9 @@ mod tests {
                     xform: Matrix4::identity(),
                 },
                 Scene3D::sphere().scale_y(2.0),
+                Scene3D::cylinder(),
+                Scene3D::quad(),
+                Scene3D::plane(),
                 Scene3D::heightmap(2, 2, NativeArray_::array_from(vec![0.0, 0.5, 1.0, 0.25])),
                 Scene3D::model(ModelDescription {
                     handle: ModelHandle::File("barrel.glb".to_string()),
@@ -119,12 +136,16 @@ mod tests {
                 Light::ambient(0.1, 0.1, 0.1),
                 Light::directional(-1.0, -1.0, 0.0, 1.0, 1.0, 1.0, 0.8).cast_shadows(),
                 Light::point(0.0, 2.0, 0.0, 1.0, 0.0, 0.0, 1.0, 10.0),
+                Light::spot(
+                    0.0, 3.0, 0.0, 0.0, -1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 15.0, 0.5,
+                ),
             ],
         };
         assert_json_stable(&frame);
 
         // `lights` was added to Frame later; a frame serialized without it
         // must still decode (serde(default)) — old producers stay readable.
+        // This literal also pins the minimal Frame wire shape.
         let legacy: Frame =
             serde_json::from_str(r#"{"camera":{"eye":[0.0,0.0,-5.0],"target":[0.0,0.0,0.0],"up":[0.0,1.0,0.0],"fov_radians":0.785,"near":0.1,"far":100.0},"scene":{"obj":{"Geometry":"Cube"},"xform":[[1.0,0.0,0.0,0.0],[0.0,1.0,0.0,0.0],[0.0,0.0,1.0,0.0],[0.0,0.0,0.0,1.0]]}}"#)
                 .expect("frame without lights decodes");
@@ -132,64 +153,139 @@ mod tests {
     }
 
     #[test]
-    fn frame_time_and_key_codes_round_trip() {
+    fn frame_time_round_trips() {
         let time = FrameTime { tts: 12.5, dts: 0.016 };
         let json = serde_json::to_string(&time).unwrap();
         let back: FrameTime = serde_json::from_str(&json).unwrap();
         assert_eq!(time.tts, back.tts);
         assert_eq!(time.dts, back.dts);
+    }
 
-        for key in [Key::A, Key::Z, Key::Up, Key::Space, Key::Escape, Key::Unknown] {
-            assert_round_trips(&key);
-        }
+    // The wire representation of a key is its i32 discriminant (key_event /
+    // Input.ofKeyCode), NOT its serde name — anchor the discriminant table so
+    // inserting a variant mid-enum (which renumbers everything after it) fails
+    // here instead of silently breaking every F# game's input.
+    #[test]
+    fn key_discriminants_are_pinned() {
+        assert_eq!(Key::Unknown as i32, 0);
+        assert_eq!(Key::A as i32, 1);
+        assert_eq!(Key::Z as i32, 26);
+        assert_eq!(Key::Up as i32, 27);
+        assert_eq!(Key::Down as i32, 28);
+        assert_eq!(Key::Left as i32, 29);
+        assert_eq!(Key::Right as i32, 30);
+        assert_eq!(Key::Space as i32, 31);
+        assert_eq!(Key::Enter as i32, 32);
+        assert_eq!(Key::Escape as i32, 33);
+        // Serde uses the names (the debug server's held_keys), pinned too.
+        assert_wire(&Key::W, r#""W""#);
+        assert_wire(&Key::Escape, r#""Escape""#);
     }
 
     #[test]
-    fn net_commands_round_trip() {
-        assert_round_trips(&NetCommand::HttpRequest {
-            token: 7,
-            method: HttpMethod::Post,
-            url: "https://example.com/state".to_string(),
-            headers: vec![("content-type".to_string(), "application/json".to_string())],
-            body: b"{}".to_vec(),
-        });
-        for cmd in [
-            ConnCommand::Connect {
+    fn net_commands_are_pinned() {
+        assert_wire(
+            &NetCommand::HttpRequest {
+                token: 7,
+                method: HttpMethod::Post,
+                url: "https://example.com/state".to_string(),
+                headers: vec![("content-type".to_string(), "application/json".to_string())],
+                body: b"{}".to_vec(),
+            },
+            r#"{"HttpRequest":{"token":7,"method":"Post","url":"https://example.com/state","headers":[["content-type","application/json"]],"body":[123,125]}}"#,
+        );
+        // All five ConnCommand variants; Send also pins ConnectionId (u64) and
+        // the bytes-as-number-array payload encoding.
+        assert_wire(
+            &ConnCommand::Connect {
                 key: "ws://server".to_string(),
                 url: "ws://server".to_string(),
             },
-            ConnCommand::Listen {
+            r#"{"Connect":{"key":"ws://server","url":"ws://server"}}"#,
+        );
+        assert_wire(
+            &ConnCommand::Listen {
                 key: "0.0.0.0:9001".to_string(),
                 addr: "0.0.0.0:9001".to_string(),
             },
-            ConnCommand::CloseKey {
+            r#"{"Listen":{"key":"0.0.0.0:9001","addr":"0.0.0.0:9001"}}"#,
+        );
+        assert_wire(
+            &ConnCommand::Send {
+                conn: 3,
+                payload: vec![1, 2],
+            },
+            r#"{"Send":{"conn":3,"payload":[1,2]}}"#,
+        );
+        assert_wire(&ConnCommand::CloseConn { conn: 3 }, r#"{"CloseConn":{"conn":3}}"#);
+        assert_wire(
+            &ConnCommand::CloseKey {
                 key: "ws://server".to_string(),
             },
-        ] {
-            assert_round_trips(&cmd);
-        }
-        assert_round_trips(&NetInbound::HttpResponse {
-            token: 7,
-            status: 200,
-            body: b"ok".to_vec(),
-        });
+            r#"{"CloseKey":{"key":"ws://server"}}"#,
+        );
+        // Both NetInbound variants.
+        assert_wire(
+            &NetInbound::HttpResponse {
+                token: 7,
+                status: 200,
+                body: b"ok".to_vec(),
+            },
+            r#"{"HttpResponse":{"token":7,"status":200,"body":[111,107]}}"#,
+        );
+        assert_wire(
+            &NetInbound::HttpError {
+                token: 7,
+                message: "timeout".to_string(),
+            },
+            r#"{"HttpError":{"token":7,"message":"timeout"}}"#,
+        );
     }
 
     #[test]
-    fn audio_boundary_round_trips() {
+    fn audio_boundary_is_pinned() {
+        // The one-shot command in its fullest form (completion token + spatial
+        // position — Audio.playThen / Audio.playAt).
+        assert_wire(
+            &AudioCommand::PlayOneShot {
+                token: Some(5),
+                sound: "laser.wav".to_string(),
+                gain: 0.5,
+                position: Some([1.0, 2.0, 3.0]),
+            },
+            r#"{"PlayOneShot":{"token":5,"sound":"laser.wav","gain":0.5,"position":[1.0,2.0,3.0]}}"#,
+        );
+        // A command serialized before `position` existed must still decode
+        // (serde(default)).
+        let legacy: AudioCommand = serde_json::from_str(
+            r#"{"PlayOneShot":{"token":null,"sound":"laser.wav","gain":1.0}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            legacy,
+            AudioCommand::PlayOneShot {
+                token: None,
+                sound: "laser.wav".to_string(),
+                gain: 1.0,
+                position: None,
+            }
+        );
+
         let scene = AudioScene::new(vec![
             AudioSource::ambient("bed".to_string(), "wind.ogg".to_string()),
             AudioSource::at("fountain".to_string(), "water.ogg".to_string(), 1.0, 0.0, 2.0),
         ]);
-        assert_round_trips(&scene);
+        assert_wire(
+            &scene,
+            r#"{"sources":[{"key":"bed","sound":"wind.ogg","gain":1.0,"position":null},{"key":"fountain","sound":"water.ogg","gain":1.0,"position":[1.0,0.0,2.0]}]}"#,
+        );
         // The exact hop the runtimes use (audio_scene_json).
-        let json = crate::audio::scene_to_json(&scene);
-        let back: AudioScene = serde_json::from_str(&json).unwrap();
+        let back: AudioScene = serde_json::from_str(&crate::audio::scene_to_json(&scene)).unwrap();
         assert_eq!(scene, back);
     }
 
     #[test]
-    fn ui_view_round_trips() {
+    fn ui_view_is_pinned() {
         let view = View::Panel {
             anchor: Anchor::TopRight,
             child: Box::new(View::Column(vec![
@@ -201,7 +297,12 @@ mod tests {
                 View::Empty,
             ])),
         };
-        assert_json_stable(&view);
+        // View doesn't derive PartialEq, so pin the encode side directly and
+        // check the decode side re-encodes identically.
+        let expected = r#"{"Panel":{"anchor":"TopRight","child":{"Column":[{"Text":{"text":"score: 10","color":[255,255,0],"font":null}},"Empty"]}}}"#;
+        assert_eq!(serde_json::to_string(&view).unwrap(), expected);
+        let back: View = serde_json::from_str(expected).unwrap();
+        assert_eq!(serde_json::to_string(&back).unwrap(), expected);
 
         // A Text serialized before the optional `font` field existed must
         // still decode (serde(default)).


### PR DESCRIPTION
## What

Track **A1** of `docs/mle.md` (stacked on #153): a new `functor_runtime_common::protocol` module that makes the logic↔runtime contract explicit and versioned:

- `PROTOCOL_VERSION` const (seed for A2's producer seam to consume).
- Module docs enumerating the full boundary by surface: per-frame in (`FrameTime`, `Key` codes), per-frame out (`Frame`/`Scene3D`, `View`, drained `NetCommand`/`ConnCommand`/`AudioCommand` queues, `AudioScene`), async inbox pushes, and — honestly labeled — the two **in-process-only** pieces that are *not* data: `OpaqueState` (any-box + layout assumption; becomes serializable with Track C's data-native state) and `Effect`/`EffectQueue` (closures; their *commands* cross as data).
- Serde round-trip tests pinning the wire shape of every data type, including backward-compat decodes for `serde(default)` fields (`Frame.lights`, `View::Text.font`).

## Why

The decision-proof first step of the MLE plan: both the current F# producer and a future MLE producer must speak the same serializable contract. Changing any pinned shape is now a visible protocol change (bump the version).

## Verification

- `cargo test -p functor_runtime_common` — 64/64 pass (6 new).
- No runtime/rendering code touched (one `pub mod` line in `lib.rs`), so goldens are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)