### PR TITLE
feat(mle): B1 parser — surface AST with spans, mle CLI, example goldens

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "1"
 
 members = [
     "cli",
+    "mle",
     "runtime/functor-netsim",
     "runtime/functor-runtime-common",
     "runtime/functor-runtime-desktop",

--- a/docs/mle.md
+++ b/docs/mle.md
@@ -119,9 +119,10 @@ Roadmap phases from `~/notes/ideas/mle-language/roadmap.md`, scoped to what
 Functor needs (notebook features deferred). Every step is `cargo test` +
 snapshots — no GPU, fully agent-verifiable.
 
-- [ ] **B1. Examples + parser → AST.** `.mle` subset: `let`, functions, records,
-      field access, literals, pipelines, type annotations; source spans.
-      *Verify:* AST snapshots per example; `mle parse`; errors point at spans.
+- [x] **B1. Examples + parser → AST.** (the `mle/` crate) `.mle` subset: `let`,
+      functions, records, field access, literals, pipelines, type annotations;
+      source spans. *Verify:* AST snapshots per example (`UPDATE_GOLDENS=1` to
+      regenerate); `mle parse`; errors point at spans. (done)
 - [ ] **B2. AST → core IR.** Stable IDs, name resolution, pipeline desugaring,
       spans on every node. *Verify:* `mle ir` snapshot fixtures (the
       parser↔runtime contract).

--- a/mle/Cargo.toml
+++ b/mle/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "mle"
+version = "0.1.0"
+edition = "2021"
+
+# Zero dependencies by design (docs/mle.md Track B): the lexer/parser are
+# hand-rolled so the language crate stays trivially portable (native + wasm)
+# and free of parser-generator toolchains.
+[dependencies]
+
+[[bin]]
+name = "mle"
+path = "src/main.rs"

--- a/mle/examples/functions.ast
+++ b/mle/examples/functions.ast
@@ -1,0 +1,416 @@
+Program {
+    items: [
+        Type(
+            TypeDecl {
+                name: "Player",
+                fields: [
+                    FieldTy {
+                        name: "name",
+                        ty: TypeName {
+                            name: "String",
+                            args: [],
+                            span: 96..102,
+                        },
+                        span: 90..102,
+                    },
+                    FieldTy {
+                        name: "scores",
+                        ty: TypeName {
+                            name: "List",
+                            args: [
+                                TypeName {
+                                    name: "Float",
+                                    args: [],
+                                    span: 117..122,
+                                },
+                            ],
+                            span: 112..123,
+                        },
+                        span: 104..123,
+                    },
+                ],
+                span: 74..125,
+            },
+        ),
+        Let(
+            LetDecl {
+                name: "add",
+                value: Expr {
+                    kind: Lambda {
+                        params: [
+                            Param {
+                                name: "a",
+                                ty: Some(
+                                    TypeName {
+                                        name: "Float",
+                                        args: [],
+                                        span: 141..146,
+                                    },
+                                ),
+                                span: 138..146,
+                            },
+                            Param {
+                                name: "b",
+                                ty: Some(
+                                    TypeName {
+                                        name: "Float",
+                                        args: [],
+                                        span: 151..156,
+                                    },
+                                ),
+                                span: 148..156,
+                            },
+                        ],
+                        ret: Some(
+                            TypeName {
+                                name: "Float",
+                                args: [],
+                                span: 159..164,
+                            },
+                        ),
+                        body: Expr {
+                            kind: Binary {
+                                op: Add,
+                                lhs: Expr {
+                                    kind: Ident(
+                                        [
+                                            "a",
+                                        ],
+                                    ),
+                                    span: 168..169,
+                                },
+                                rhs: Expr {
+                                    kind: Ident(
+                                        [
+                                            "b",
+                                        ],
+                                    ),
+                                    span: 172..173,
+                                },
+                            },
+                            span: 168..173,
+                        },
+                    },
+                    span: 137..173,
+                },
+                span: 127..173,
+            },
+        ),
+        Let(
+            LetDecl {
+                name: "average",
+                value: Expr {
+                    kind: Lambda {
+                        params: [
+                            Param {
+                                name: "a",
+                                ty: None,
+                                span: 190..191,
+                            },
+                            Param {
+                                name: "b",
+                                ty: None,
+                                span: 193..194,
+                            },
+                        ],
+                        ret: None,
+                        body: Expr {
+                            kind: Binary {
+                                op: Div,
+                                lhs: Expr {
+                                    kind: Binary {
+                                        op: Add,
+                                        lhs: Expr {
+                                            kind: Ident(
+                                                [
+                                                    "a",
+                                                ],
+                                            ),
+                                            span: 200..201,
+                                        },
+                                        rhs: Expr {
+                                            kind: Ident(
+                                                [
+                                                    "b",
+                                                ],
+                                            ),
+                                            span: 204..205,
+                                        },
+                                    },
+                                    span: 199..206,
+                                },
+                                rhs: Expr {
+                                    kind: Number(
+                                        2.0,
+                                    ),
+                                    span: 209..212,
+                                },
+                            },
+                            span: 199..212,
+                        },
+                    },
+                    span: 189..212,
+                },
+                span: 175..212,
+            },
+        ),
+        Let(
+            LetDecl {
+                name: "total",
+                value: Expr {
+                    kind: Lambda {
+                        params: [
+                            Param {
+                                name: "p",
+                                ty: Some(
+                                    TypeName {
+                                        name: "Player",
+                                        args: [],
+                                        span: 230..236,
+                                    },
+                                ),
+                                span: 227..236,
+                            },
+                        ],
+                        ret: Some(
+                            TypeName {
+                                name: "Float",
+                                args: [],
+                                span: 239..244,
+                            },
+                        ),
+                        body: Expr {
+                            kind: Call {
+                                callee: Expr {
+                                    kind: Ident(
+                                        [
+                                            "fold",
+                                        ],
+                                    ),
+                                    span: 248..252,
+                                },
+                                args: [
+                                    Expr {
+                                        kind: Ident(
+                                            [
+                                                "add",
+                                            ],
+                                        ),
+                                        span: 253..256,
+                                    },
+                                    Expr {
+                                        kind: Number(
+                                            0.0,
+                                        ),
+                                        span: 258..261,
+                                    },
+                                    Expr {
+                                        kind: FieldAccess {
+                                            object: Expr {
+                                                kind: Ident(
+                                                    [
+                                                        "p",
+                                                    ],
+                                                ),
+                                                span: 263..264,
+                                            },
+                                            field: "scores",
+                                        },
+                                        span: 263..271,
+                                    },
+                                ],
+                            },
+                            span: 248..272,
+                        },
+                    },
+                    span: 226..272,
+                },
+                span: 214..272,
+            },
+        ),
+        Let(
+            LetDecl {
+                name: "bestTotal",
+                value: Expr {
+                    kind: Lambda {
+                        params: [
+                            Param {
+                                name: "players",
+                                ty: Some(
+                                    TypeName {
+                                        name: "List",
+                                        args: [
+                                            TypeName {
+                                                name: "Player",
+                                                args: [],
+                                                span: 305..311,
+                                            },
+                                        ],
+                                        span: 300..312,
+                                    },
+                                ),
+                                span: 291..312,
+                            },
+                        ],
+                        ret: Some(
+                            TypeName {
+                                name: "Float",
+                                args: [],
+                                span: 315..320,
+                            },
+                        ),
+                        body: Expr {
+                            kind: Pipeline {
+                                head: Expr {
+                                    kind: Ident(
+                                        [
+                                            "players",
+                                        ],
+                                    ),
+                                    span: 326..333,
+                                },
+                                stages: [
+                                    Expr {
+                                        kind: Call {
+                                            callee: Expr {
+                                                kind: Ident(
+                                                    [
+                                                        "map",
+                                                    ],
+                                                ),
+                                                span: 337..340,
+                                            },
+                                            args: [
+                                                Expr {
+                                                    kind: Lambda {
+                                                        params: [
+                                                            Param {
+                                                                name: "p",
+                                                                ty: None,
+                                                                span: 342..343,
+                                                            },
+                                                        ],
+                                                        ret: None,
+                                                        body: Expr {
+                                                            kind: Call {
+                                                                callee: Expr {
+                                                                    kind: Ident(
+                                                                        [
+                                                                            "total",
+                                                                        ],
+                                                                    ),
+                                                                    span: 348..353,
+                                                                },
+                                                                args: [
+                                                                    Expr {
+                                                                        kind: Ident(
+                                                                            [
+                                                                                "p",
+                                                                            ],
+                                                                        ),
+                                                                        span: 354..355,
+                                                                    },
+                                                                ],
+                                                            },
+                                                            span: 348..356,
+                                                        },
+                                                    },
+                                                    span: 341..356,
+                                                },
+                                            ],
+                                        },
+                                        span: 337..357,
+                                    },
+                                    Expr {
+                                        kind: Ident(
+                                            [
+                                                "maximum",
+                                            ],
+                                        ),
+                                        span: 361..368,
+                                    },
+                                ],
+                            },
+                            span: 326..368,
+                        },
+                    },
+                    span: 290..368,
+                },
+                span: 274..368,
+            },
+        ),
+        Let(
+            LetDecl {
+                name: "isWinner",
+                value: Expr {
+                    kind: Lambda {
+                        params: [
+                            Param {
+                                name: "p",
+                                ty: None,
+                                span: 386..387,
+                            },
+                            Param {
+                                name: "cutoff",
+                                ty: None,
+                                span: 389..395,
+                            },
+                        ],
+                        ret: None,
+                        body: Expr {
+                            kind: Binary {
+                                op: Lt,
+                                lhs: Expr {
+                                    kind: Ident(
+                                        [
+                                            "cutoff",
+                                        ],
+                                    ),
+                                    span: 400..406,
+                                },
+                                rhs: Expr {
+                                    kind: Call {
+                                        callee: Expr {
+                                            kind: Ident(
+                                                [
+                                                    "total",
+                                                ],
+                                            ),
+                                            span: 409..414,
+                                        },
+                                        args: [
+                                            Expr {
+                                                kind: Ident(
+                                                    [
+                                                        "p",
+                                                    ],
+                                                ),
+                                                span: 415..416,
+                                            },
+                                        ],
+                                    },
+                                    span: 409..417,
+                                },
+                            },
+                            span: 400..417,
+                        },
+                    },
+                    span: 385..417,
+                },
+                span: 370..417,
+            },
+        ),
+        Let(
+            LetDecl {
+                name: "debug",
+                value: Expr {
+                    kind: Bool(
+                        false,
+                    ),
+                    span: 431..436,
+                },
+                span: 419..436,
+            },
+        ),
+    ],
+}

--- a/mle/examples/functions.mle
+++ b/mle/examples/functions.mle
@@ -1,0 +1,16 @@
+// Higher-order functions, inline lambdas, and generic type annotations.
+
+type Player = { name: String, scores: List<Float> }
+
+let add = (a: Float, b: Float): Float => a + b
+
+let average = (a, b) => (a + b) / 2.0
+
+let total = (p: Player): Float => fold(add, 0.0, p.scores)
+
+let bestTotal = (players: List<Player>): Float =>
+  players |> map((p) => total(p)) |> maximum
+
+let isWinner = (p, cutoff) => cutoff < total(p)
+
+let debug = false

--- a/mle/examples/pure-pipeline.ast
+++ b/mle/examples/pure-pipeline.ast
@@ -1,0 +1,276 @@
+Program {
+    items: [
+        Let(
+            LetDecl {
+                name: "threshold",
+                value: Expr {
+                    kind: Number(
+                        10.0,
+                    ),
+                    span: 123..125,
+                },
+                span: 107..125,
+            },
+        ),
+        Let(
+            LetDecl {
+                name: "isHigh",
+                value: Expr {
+                    kind: Lambda {
+                        params: [
+                            Param {
+                                name: "score",
+                                ty: Some(
+                                    TypeName {
+                                        name: "Float",
+                                        args: [],
+                                        span: 148..153,
+                                    },
+                                ),
+                                span: 141..153,
+                            },
+                        ],
+                        ret: Some(
+                            TypeName {
+                                name: "Bool",
+                                args: [],
+                                span: 156..160,
+                            },
+                        ),
+                        body: Expr {
+                            kind: Binary {
+                                op: Gt,
+                                lhs: Expr {
+                                    kind: Ident(
+                                        [
+                                            "score",
+                                        ],
+                                    ),
+                                    span: 164..169,
+                                },
+                                rhs: Expr {
+                                    kind: Ident(
+                                        [
+                                            "threshold",
+                                        ],
+                                    ),
+                                    span: 172..181,
+                                },
+                            },
+                            span: 164..181,
+                        },
+                    },
+                    span: 140..181,
+                },
+                span: 127..181,
+            },
+        ),
+        Let(
+            LetDecl {
+                name: "describe",
+                value: Expr {
+                    kind: Lambda {
+                        params: [
+                            Param {
+                                name: "score",
+                                ty: None,
+                                span: 199..204,
+                            },
+                        ],
+                        ret: None,
+                        body: Expr {
+                            kind: Call {
+                                callee: Expr {
+                                    kind: Ident(
+                                        [
+                                            "concat",
+                                        ],
+                                    ),
+                                    span: 209..215,
+                                },
+                                args: [
+                                    Expr {
+                                        kind: String(
+                                            "score: ",
+                                        ),
+                                        span: 216..225,
+                                    },
+                                    Expr {
+                                        kind: Call {
+                                            callee: Expr {
+                                                kind: Ident(
+                                                    [
+                                                        "Text",
+                                                        "fromFloat",
+                                                    ],
+                                                ),
+                                                span: 227..241,
+                                            },
+                                            args: [
+                                                Expr {
+                                                    kind: Ident(
+                                                        [
+                                                            "score",
+                                                        ],
+                                                    ),
+                                                    span: 242..247,
+                                                },
+                                            ],
+                                        },
+                                        span: 227..248,
+                                    },
+                                ],
+                            },
+                            span: 209..249,
+                        },
+                    },
+                    span: 198..249,
+                },
+                span: 183..249,
+            },
+        ),
+        Let(
+            LetDecl {
+                name: "normalized",
+                value: Expr {
+                    kind: Lambda {
+                        params: [
+                            Param {
+                                name: "score",
+                                ty: None,
+                                span: 334..339,
+                            },
+                        ],
+                        ret: None,
+                        body: Expr {
+                            kind: Pipeline {
+                                head: Expr {
+                                    kind: Binary {
+                                        op: Div,
+                                        lhs: Expr {
+                                            kind: Ident(
+                                                [
+                                                    "score",
+                                                ],
+                                            ),
+                                            span: 344..349,
+                                        },
+                                        rhs: Expr {
+                                            kind: Number(
+                                                100.0,
+                                            ),
+                                            span: 352..357,
+                                        },
+                                    },
+                                    span: 344..357,
+                                },
+                                stages: [
+                                    Expr {
+                                        kind: Ident(
+                                            [
+                                                "clamp01",
+                                            ],
+                                        ),
+                                        span: 361..368,
+                                    },
+                                ],
+                            },
+                            span: 344..368,
+                        },
+                    },
+                    span: 333..368,
+                },
+                span: 316..368,
+            },
+        ),
+        Let(
+            LetDecl {
+                name: "report",
+                value: Expr {
+                    kind: Lambda {
+                        params: [
+                            Param {
+                                name: "scores",
+                                ty: None,
+                                span: 384..390,
+                            },
+                        ],
+                        ret: None,
+                        body: Expr {
+                            kind: Pipeline {
+                                head: Expr {
+                                    kind: Ident(
+                                        [
+                                            "scores",
+                                        ],
+                                    ),
+                                    span: 397..403,
+                                },
+                                stages: [
+                                    Expr {
+                                        kind: Call {
+                                            callee: Expr {
+                                                kind: Ident(
+                                                    [
+                                                        "filter",
+                                                    ],
+                                                ),
+                                                span: 411..417,
+                                            },
+                                            args: [
+                                                Expr {
+                                                    kind: Ident(
+                                                        [
+                                                            "isHigh",
+                                                        ],
+                                                    ),
+                                                    span: 418..424,
+                                                },
+                                            ],
+                                        },
+                                        span: 411..425,
+                                    },
+                                    Expr {
+                                        kind: Call {
+                                            callee: Expr {
+                                                kind: Ident(
+                                                    [
+                                                        "map",
+                                                    ],
+                                                ),
+                                                span: 433..436,
+                                            },
+                                            args: [
+                                                Expr {
+                                                    kind: Ident(
+                                                        [
+                                                            "describe",
+                                                        ],
+                                                    ),
+                                                    span: 437..445,
+                                                },
+                                            ],
+                                        },
+                                        span: 433..446,
+                                    },
+                                    Expr {
+                                        kind: Ident(
+                                            [
+                                                "Text",
+                                                "toBullets",
+                                            ],
+                                        ),
+                                        span: 454..468,
+                                    },
+                                ],
+                            },
+                            span: 397..468,
+                        },
+                    },
+                    span: 383..468,
+                },
+                span: 370..468,
+            },
+        ),
+    ],
+}

--- a/mle/examples/pure-pipeline.mle
+++ b/mle/examples/pure-pipeline.mle
@@ -1,0 +1,17 @@
+// Format player scores as a bulleted report — pipelines, qualified names,
+// strings, and comparisons.
+
+let threshold = 10
+
+let isHigh = (score: Float): Bool => score > threshold
+
+let describe = (score) => concat("score: ", Text.fromFloat(score))
+
+// Pipelines bind loosest: the division happens before the `|>`.
+let normalized = (score) => score / 100.0 |> clamp01
+
+let report = (scores) =>
+  scores
+    |> filter(isHigh)
+    |> map(describe)
+    |> Text.toBullets

--- a/mle/examples/records.ast
+++ b/mle/examples/records.ast
@@ -1,0 +1,514 @@
+Program {
+    items: [
+        Type(
+            TypeDecl {
+                name: "Position",
+                fields: [
+                    FieldTy {
+                        name: "x",
+                        ty: TypeName {
+                            name: "Float",
+                            args: [],
+                            span: 162..167,
+                        },
+                        span: 159..167,
+                    },
+                    FieldTy {
+                        name: "y",
+                        ty: TypeName {
+                            name: "Float",
+                            args: [],
+                            span: 172..177,
+                        },
+                        span: 169..177,
+                    },
+                ],
+                span: 141..179,
+            },
+        ),
+        Type(
+            TypeDecl {
+                name: "Velocity",
+                fields: [
+                    FieldTy {
+                        name: "dx",
+                        ty: TypeName {
+                            name: "Float",
+                            args: [],
+                            span: 202..207,
+                        },
+                        span: 198..207,
+                    },
+                    FieldTy {
+                        name: "dy",
+                        ty: TypeName {
+                            name: "Float",
+                            args: [],
+                            span: 213..218,
+                        },
+                        span: 209..218,
+                    },
+                ],
+                span: 180..220,
+            },
+        ),
+        Let(
+            LetDecl {
+                name: "origin",
+                value: Expr {
+                    kind: Record(
+                        [
+                            Field {
+                                name: "x",
+                                value: Expr {
+                                    kind: Number(
+                                        0.0,
+                                    ),
+                                    span: 240..243,
+                                },
+                                span: 237..243,
+                            },
+                            Field {
+                                name: "y",
+                                value: Expr {
+                                    kind: Number(
+                                        0.0,
+                                    ),
+                                    span: 248..251,
+                                },
+                                span: 245..251,
+                            },
+                        ],
+                    ),
+                    span: 235..253,
+                },
+                span: 222..253,
+            },
+        ),
+        Let(
+            LetDecl {
+                name: "move",
+                value: Expr {
+                    kind: Lambda {
+                        params: [
+                            Param {
+                                name: "p",
+                                ty: Some(
+                                    TypeName {
+                                        name: "Position",
+                                        args: [],
+                                        span: 270..278,
+                                    },
+                                ),
+                                span: 267..278,
+                            },
+                            Param {
+                                name: "v",
+                                ty: Some(
+                                    TypeName {
+                                        name: "Velocity",
+                                        args: [],
+                                        span: 283..291,
+                                    },
+                                ),
+                                span: 280..291,
+                            },
+                            Param {
+                                name: "dt",
+                                ty: Some(
+                                    TypeName {
+                                        name: "Float",
+                                        args: [],
+                                        span: 297..302,
+                                    },
+                                ),
+                                span: 293..302,
+                            },
+                        ],
+                        ret: Some(
+                            TypeName {
+                                name: "Position",
+                                args: [],
+                                span: 305..313,
+                            },
+                        ),
+                        body: Expr {
+                            kind: Record(
+                                [
+                                    Field {
+                                        name: "x",
+                                        value: Expr {
+                                            kind: Binary {
+                                                op: Add,
+                                                lhs: Expr {
+                                                    kind: FieldAccess {
+                                                        object: Expr {
+                                                            kind: Ident(
+                                                                [
+                                                                    "p",
+                                                                ],
+                                                            ),
+                                                            span: 324..325,
+                                                        },
+                                                        field: "x",
+                                                    },
+                                                    span: 324..327,
+                                                },
+                                                rhs: Expr {
+                                                    kind: Binary {
+                                                        op: Mul,
+                                                        lhs: Expr {
+                                                            kind: FieldAccess {
+                                                                object: Expr {
+                                                                    kind: Ident(
+                                                                        [
+                                                                            "v",
+                                                                        ],
+                                                                    ),
+                                                                    span: 330..331,
+                                                                },
+                                                                field: "dx",
+                                                            },
+                                                            span: 330..334,
+                                                        },
+                                                        rhs: Expr {
+                                                            kind: Ident(
+                                                                [
+                                                                    "dt",
+                                                                ],
+                                                            ),
+                                                            span: 337..339,
+                                                        },
+                                                    },
+                                                    span: 330..339,
+                                                },
+                                            },
+                                            span: 324..339,
+                                        },
+                                        span: 321..339,
+                                    },
+                                    Field {
+                                        name: "y",
+                                        value: Expr {
+                                            kind: Binary {
+                                                op: Add,
+                                                lhs: Expr {
+                                                    kind: FieldAccess {
+                                                        object: Expr {
+                                                            kind: Ident(
+                                                                [
+                                                                    "p",
+                                                                ],
+                                                            ),
+                                                            span: 344..345,
+                                                        },
+                                                        field: "y",
+                                                    },
+                                                    span: 344..347,
+                                                },
+                                                rhs: Expr {
+                                                    kind: Binary {
+                                                        op: Mul,
+                                                        lhs: Expr {
+                                                            kind: FieldAccess {
+                                                                object: Expr {
+                                                                    kind: Ident(
+                                                                        [
+                                                                            "v",
+                                                                        ],
+                                                                    ),
+                                                                    span: 350..351,
+                                                                },
+                                                                field: "dy",
+                                                            },
+                                                            span: 350..354,
+                                                        },
+                                                        rhs: Expr {
+                                                            kind: Ident(
+                                                                [
+                                                                    "dt",
+                                                                ],
+                                                            ),
+                                                            span: 357..359,
+                                                        },
+                                                    },
+                                                    span: 350..359,
+                                                },
+                                            },
+                                            span: 344..359,
+                                        },
+                                        span: 341..359,
+                                    },
+                                ],
+                            ),
+                            span: 319..361,
+                        },
+                    },
+                    span: 266..361,
+                },
+                span: 255..361,
+            },
+        ),
+        Let(
+            LetDecl {
+                name: "delta",
+                value: Expr {
+                    kind: Lambda {
+                        params: [
+                            Param {
+                                name: "a",
+                                ty: Some(
+                                    TypeName {
+                                        name: "Position",
+                                        args: [],
+                                        span: 379..387,
+                                    },
+                                ),
+                                span: 376..387,
+                            },
+                            Param {
+                                name: "b",
+                                ty: Some(
+                                    TypeName {
+                                        name: "Position",
+                                        args: [],
+                                        span: 392..400,
+                                    },
+                                ),
+                                span: 389..400,
+                            },
+                        ],
+                        ret: Some(
+                            TypeName {
+                                name: "Position",
+                                args: [],
+                                span: 403..411,
+                            },
+                        ),
+                        body: Expr {
+                            kind: Record(
+                                [
+                                    Field {
+                                        name: "x",
+                                        value: Expr {
+                                            kind: Binary {
+                                                op: Sub,
+                                                lhs: Expr {
+                                                    kind: FieldAccess {
+                                                        object: Expr {
+                                                            kind: Ident(
+                                                                [
+                                                                    "a",
+                                                                ],
+                                                            ),
+                                                            span: 422..423,
+                                                        },
+                                                        field: "x",
+                                                    },
+                                                    span: 422..425,
+                                                },
+                                                rhs: Expr {
+                                                    kind: FieldAccess {
+                                                        object: Expr {
+                                                            kind: Ident(
+                                                                [
+                                                                    "b",
+                                                                ],
+                                                            ),
+                                                            span: 428..429,
+                                                        },
+                                                        field: "x",
+                                                    },
+                                                    span: 428..431,
+                                                },
+                                            },
+                                            span: 422..431,
+                                        },
+                                        span: 419..431,
+                                    },
+                                    Field {
+                                        name: "y",
+                                        value: Expr {
+                                            kind: Binary {
+                                                op: Sub,
+                                                lhs: Expr {
+                                                    kind: FieldAccess {
+                                                        object: Expr {
+                                                            kind: Ident(
+                                                                [
+                                                                    "a",
+                                                                ],
+                                                            ),
+                                                            span: 436..437,
+                                                        },
+                                                        field: "y",
+                                                    },
+                                                    span: 436..439,
+                                                },
+                                                rhs: Expr {
+                                                    kind: FieldAccess {
+                                                        object: Expr {
+                                                            kind: Ident(
+                                                                [
+                                                                    "b",
+                                                                ],
+                                                            ),
+                                                            span: 442..443,
+                                                        },
+                                                        field: "y",
+                                                    },
+                                                    span: 442..445,
+                                                },
+                                            },
+                                            span: 436..445,
+                                        },
+                                        span: 433..445,
+                                    },
+                                ],
+                            ),
+                            span: 417..447,
+                        },
+                    },
+                    span: 375..447,
+                },
+                span: 363..447,
+            },
+        ),
+        Let(
+            LetDecl {
+                name: "mirror",
+                value: Expr {
+                    kind: Lambda {
+                        params: [
+                            Param {
+                                name: "p",
+                                ty: Some(
+                                    TypeName {
+                                        name: "Position",
+                                        args: [],
+                                        span: 466..474,
+                                    },
+                                ),
+                                span: 463..474,
+                            },
+                        ],
+                        ret: Some(
+                            TypeName {
+                                name: "Position",
+                                args: [],
+                                span: 477..485,
+                            },
+                        ),
+                        body: Expr {
+                            kind: Record(
+                                [
+                                    Field {
+                                        name: "x",
+                                        value: Expr {
+                                            kind: Neg(
+                                                Expr {
+                                                    kind: FieldAccess {
+                                                        object: Expr {
+                                                            kind: Ident(
+                                                                [
+                                                                    "p",
+                                                                ],
+                                                            ),
+                                                            span: 495..496,
+                                                        },
+                                                        field: "x",
+                                                    },
+                                                    span: 495..498,
+                                                },
+                                            ),
+                                            span: 494..498,
+                                        },
+                                        span: 491..498,
+                                    },
+                                    Field {
+                                        name: "y",
+                                        value: Expr {
+                                            kind: FieldAccess {
+                                                object: Expr {
+                                                    kind: Ident(
+                                                        [
+                                                            "p",
+                                                        ],
+                                                    ),
+                                                    span: 503..504,
+                                                },
+                                                field: "y",
+                                            },
+                                            span: 503..506,
+                                        },
+                                        span: 500..506,
+                                    },
+                                ],
+                            ),
+                            span: 489..508,
+                        },
+                    },
+                    span: 462..508,
+                },
+                span: 449..508,
+            },
+        ),
+        Let(
+            LetDecl {
+                name: "isOrigin",
+                value: Expr {
+                    kind: Lambda {
+                        params: [
+                            Param {
+                                name: "p",
+                                ty: Some(
+                                    TypeName {
+                                        name: "Position",
+                                        args: [],
+                                        span: 529..537,
+                                    },
+                                ),
+                                span: 526..537,
+                            },
+                        ],
+                        ret: Some(
+                            TypeName {
+                                name: "Bool",
+                                args: [],
+                                span: 540..544,
+                            },
+                        ),
+                        body: Expr {
+                            kind: Binary {
+                                op: Eq,
+                                lhs: Expr {
+                                    kind: FieldAccess {
+                                        object: Expr {
+                                            kind: Ident(
+                                                [
+                                                    "p",
+                                                ],
+                                            ),
+                                            span: 548..549,
+                                        },
+                                        field: "x",
+                                    },
+                                    span: 548..551,
+                                },
+                                rhs: Expr {
+                                    kind: Number(
+                                        0.0,
+                                    ),
+                                    span: 555..558,
+                                },
+                            },
+                            span: 548..558,
+                        },
+                    },
+                    span: 525..558,
+                },
+                span: 510..558,
+            },
+        ),
+    ],
+}

--- a/mle/examples/records.mle
+++ b/mle/examples/records.mle
@@ -1,0 +1,17 @@
+// Positions and velocities — record types, record literals, field access,
+// arithmetic, and unary minus (the roadmap's `move` example).
+
+type Position = { x: Float, y: Float }
+type Velocity = { dx: Float, dy: Float }
+
+let origin = { x: 0.0, y: 0.0 }
+
+let move = (p: Position, v: Velocity, dt: Float): Position =>
+  { x: p.x + v.dx * dt, y: p.y + v.dy * dt }
+
+let delta = (a: Position, b: Position): Position =>
+  { x: a.x - b.x, y: a.y - b.y }
+
+let mirror = (p: Position): Position => { x: -p.x, y: p.y }
+
+let isOrigin = (p: Position): Bool => p.x == 0.0

--- a/mle/src/ast.rs
+++ b/mle/src/ast.rs
@@ -1,0 +1,134 @@
+//! Surface AST for the B1 syntax subset. Every node carries a [`Span`].
+//!
+//! Deliberately close to the source: pipelines stay explicit
+//! ([`ExprKind::Pipeline`]) rather than desugaring to nested calls — lowering
+//! is B2's job (the core IR), and keeping the surface shape makes error spans
+//! and future formatting honest.
+
+use crate::span::Span;
+
+#[derive(Debug)]
+pub struct Program {
+    pub items: Vec<Item>,
+}
+
+#[derive(Debug)]
+pub enum Item {
+    Let(LetDecl),
+    Type(TypeDecl),
+}
+
+/// `let name = expr` — the expr may be a lambda (`let f = (a, b) => …`).
+#[derive(Debug)]
+pub struct LetDecl {
+    pub name: String,
+    pub value: Expr,
+    pub span: Span,
+}
+
+/// `type Position = { x: Float, y: Float }` — record types only in B1.
+#[derive(Debug)]
+pub struct TypeDecl {
+    pub name: String,
+    pub fields: Vec<FieldTy>,
+    pub span: Span,
+}
+
+/// One `name: Type` entry of a type declaration.
+#[derive(Debug)]
+pub struct FieldTy {
+    pub name: String,
+    pub ty: TypeName,
+    pub span: Span,
+}
+
+/// A type reference: a name plus optional generic arguments (`Float`,
+/// `List<String>`, `Position`).
+#[derive(Debug)]
+pub struct TypeName {
+    pub name: String,
+    pub args: Vec<TypeName>,
+    pub span: Span,
+}
+
+#[derive(Debug)]
+pub struct Expr {
+    pub kind: ExprKind,
+    pub span: Span,
+}
+
+#[derive(Debug)]
+pub enum ExprKind {
+    /// Ints and floats both parse to f64 (MLE has one number type for now).
+    Number(f64),
+    String(String),
+    Bool(bool),
+    /// A possibly-qualified name: `x` is `["x"]`, `Text.toBullets` is
+    /// `["Text", "toBullets"]`. The parser absorbs a `.segment` into the
+    /// name while the segment left of the `.` starts uppercase (a module or
+    /// type qualifier); a lowercase name followed by `.` is [`Self::FieldAccess`]
+    /// instead (`position.x`). The rule is purely syntactic — field access on
+    /// a value bound to an uppercase name also parses as a qualified name;
+    /// B2 name resolution reinterprets the segments against the environment
+    /// (nothing is lost: segments and span are preserved).
+    Ident(Vec<String>),
+    /// `{ x: 1.0, y: 2.0 }`
+    Record(Vec<Field>),
+    /// `position.x`
+    FieldAccess {
+        object: Box<Expr>,
+        field: String,
+    },
+    /// `(a: Type, b) : RetType => body` — param and return annotations are
+    /// optional.
+    Lambda {
+        params: Vec<Param>,
+        ret: Option<TypeName>,
+        body: Box<Expr>,
+    },
+    /// `f(x, y)`
+    Call {
+        callee: Box<Expr>,
+        args: Vec<Expr>,
+    },
+    /// `head |> stages[0] |> stages[1] …` — kept explicit, not desugared
+    /// (see module docs).
+    Pipeline {
+        head: Box<Expr>,
+        stages: Vec<Expr>,
+    },
+    Binary {
+        op: BinOp,
+        lhs: Box<Expr>,
+        rhs: Box<Expr>,
+    },
+    /// Unary minus.
+    Neg(Box<Expr>),
+}
+
+/// One `name: value` entry of a record expression.
+#[derive(Debug)]
+pub struct Field {
+    pub name: String,
+    pub value: Expr,
+    pub span: Span,
+}
+
+/// A lambda parameter with its optional type annotation.
+#[derive(Debug)]
+pub struct Param {
+    pub name: String,
+    pub ty: Option<TypeName>,
+    pub span: Span,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum BinOp {
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Lt,
+    Gt,
+    Eq,
+}

--- a/mle/src/lexer.rs
+++ b/mle/src/lexer.rs
@@ -1,0 +1,267 @@
+//! Hand-rolled lexer for the B1 subset. Produces spanned tokens; the stream
+//! always ends with exactly one `Eof` token so the parser can peek ahead
+//! without bounds checks.
+
+use crate::span::Span;
+use crate::ParseError;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum TokenKind {
+    Number(f64),
+    Str(String),
+    Ident(String),
+    Let,
+    Type,
+    True,
+    False,
+    LParen,
+    RParen,
+    LBrace,
+    RBrace,
+    Comma,
+    Colon,
+    Dot,
+    Eq,
+    EqEq,
+    FatArrow,
+    PipeGt,
+    Plus,
+    Minus,
+    Star,
+    Slash,
+    Lt,
+    Gt,
+    Eof,
+}
+
+#[derive(Debug, Clone)]
+pub struct Token {
+    pub kind: TokenKind,
+    pub span: Span,
+}
+
+/// Human-readable token description for error messages.
+pub fn describe(kind: &TokenKind) -> String {
+    use TokenKind::*;
+    match kind {
+        Number(n) => format!("number `{n}`"),
+        Str(_) => "a string".to_string(),
+        Ident(name) => format!("`{name}`"),
+        Let => "`let`".to_string(),
+        Type => "`type`".to_string(),
+        True => "`true`".to_string(),
+        False => "`false`".to_string(),
+        LParen => "`(`".to_string(),
+        RParen => "`)`".to_string(),
+        LBrace => "`{`".to_string(),
+        RBrace => "`}`".to_string(),
+        Comma => "`,`".to_string(),
+        Colon => "`:`".to_string(),
+        Dot => "`.`".to_string(),
+        Eq => "`=`".to_string(),
+        EqEq => "`==`".to_string(),
+        FatArrow => "`=>`".to_string(),
+        PipeGt => "`|>`".to_string(),
+        Plus => "`+`".to_string(),
+        Minus => "`-`".to_string(),
+        Star => "`*`".to_string(),
+        Slash => "`/`".to_string(),
+        Lt => "`<`".to_string(),
+        Gt => "`>`".to_string(),
+        Eof => "end of input".to_string(),
+    }
+}
+
+pub fn lex(src: &str) -> Result<Vec<Token>, ParseError> {
+    let bytes = src.as_bytes();
+    let mut tokens = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        let start = i;
+        let kind = match bytes[i] {
+            b' ' | b'\t' | b'\r' | b'\n' => {
+                i += 1;
+                continue;
+            }
+            // Line comment: `//` to end of line.
+            b'/' if bytes.get(i + 1) == Some(&b'/') => {
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+                continue;
+            }
+            b'(' => {
+                i += 1;
+                TokenKind::LParen
+            }
+            b')' => {
+                i += 1;
+                TokenKind::RParen
+            }
+            b'{' => {
+                i += 1;
+                TokenKind::LBrace
+            }
+            b'}' => {
+                i += 1;
+                TokenKind::RBrace
+            }
+            b',' => {
+                i += 1;
+                TokenKind::Comma
+            }
+            b':' => {
+                i += 1;
+                TokenKind::Colon
+            }
+            b'.' => {
+                i += 1;
+                TokenKind::Dot
+            }
+            b'+' => {
+                i += 1;
+                TokenKind::Plus
+            }
+            // No negative number literals — unary minus is the parser's job.
+            b'-' => {
+                i += 1;
+                TokenKind::Minus
+            }
+            b'*' => {
+                i += 1;
+                TokenKind::Star
+            }
+            b'/' => {
+                i += 1;
+                TokenKind::Slash
+            }
+            b'<' => {
+                i += 1;
+                TokenKind::Lt
+            }
+            b'>' => {
+                i += 1;
+                TokenKind::Gt
+            }
+            b'=' => match bytes.get(i + 1) {
+                Some(b'=') => {
+                    i += 2;
+                    TokenKind::EqEq
+                }
+                Some(b'>') => {
+                    i += 2;
+                    TokenKind::FatArrow
+                }
+                _ => {
+                    i += 1;
+                    TokenKind::Eq
+                }
+            },
+            b'|' => match bytes.get(i + 1) {
+                Some(b'>') => {
+                    i += 2;
+                    TokenKind::PipeGt
+                }
+                _ => {
+                    return Err(ParseError {
+                        message: "unexpected character `|`".to_string(),
+                        span: Span::new(i, i + 1),
+                    })
+                }
+            },
+            b'"' => {
+                let (kind, next) = lex_string(src, i)?;
+                i = next;
+                kind
+            }
+            b'0'..=b'9' => {
+                while i < bytes.len() && bytes[i].is_ascii_digit() {
+                    i += 1;
+                }
+                if i + 1 < bytes.len() && bytes[i] == b'.' && bytes[i + 1].is_ascii_digit() {
+                    i += 1;
+                    while i < bytes.len() && bytes[i].is_ascii_digit() {
+                        i += 1;
+                    }
+                }
+                let n = src[start..i].parse().expect("digit runs parse as f64");
+                TokenKind::Number(n)
+            }
+            b'a'..=b'z' | b'A'..=b'Z' | b'_' => {
+                while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
+                    i += 1;
+                }
+                match &src[start..i] {
+                    "let" => TokenKind::Let,
+                    "type" => TokenKind::Type,
+                    "true" => TokenKind::True,
+                    "false" => TokenKind::False,
+                    name => TokenKind::Ident(name.to_string()),
+                }
+            }
+            _ => {
+                let c = src[i..].chars().next().expect("lex is on a char boundary");
+                return Err(ParseError {
+                    message: format!("unexpected character `{c}`"),
+                    span: Span::new(i, i + c.len_utf8()),
+                });
+            }
+        };
+        tokens.push(Token {
+            kind,
+            span: Span::new(start, i),
+        });
+    }
+    tokens.push(Token {
+        kind: TokenKind::Eof,
+        span: Span::new(src.len(), src.len()),
+    });
+    Ok(tokens)
+}
+
+/// Lex a string literal starting at its opening quote. Escapes: `\"`, `\\`,
+/// `\n`, `\t`. Returns the token kind and the index just past the closing
+/// quote. An unterminated string reports its span at the opening quote.
+fn lex_string(src: &str, start: usize) -> Result<(TokenKind, usize), ParseError> {
+    let bytes = src.as_bytes();
+    let mut out: Vec<u8> = Vec::new();
+    let mut i = start + 1;
+    loop {
+        match bytes.get(i) {
+            None => {
+                return Err(ParseError {
+                    message: "unterminated string".to_string(),
+                    span: Span::new(start, start + 1),
+                })
+            }
+            Some(b'"') => {
+                let s = String::from_utf8(out).expect("string contents are valid UTF-8");
+                return Ok((TokenKind::Str(s), i + 1));
+            }
+            Some(b'\\') => {
+                let escaped = match bytes.get(i + 1) {
+                    Some(b'"') => b'"',
+                    Some(b'\\') => b'\\',
+                    Some(b'n') => b'\n',
+                    Some(b't') => b'\t',
+                    _ => {
+                        // Size the span by the escaped char's UTF-8 width so
+                        // it stays sliceable (spans must be char-boundary
+                        // aligned); a `\` at end of input spans just itself.
+                        let escaped_len = src[i + 1..].chars().next().map_or(0, char::len_utf8);
+                        return Err(ParseError {
+                            message: "unknown escape sequence".to_string(),
+                            span: Span::new(i, i + 1 + escaped_len),
+                        });
+                    }
+                };
+                out.push(escaped);
+                i += 2;
+            }
+            Some(&b) => {
+                out.push(b);
+                i += 1;
+            }
+        }
+    }
+}

--- a/mle/src/lib.rs
+++ b/mle/src/lib.rs
@@ -1,0 +1,22 @@
+//! MLE surface parser — Track B1 of `docs/mle.md`.
+//!
+//! Lexer + hand-rolled recursive-descent parser producing a surface AST in
+//! which every node carries a byte-offset [`Span`] (line/col derive from the
+//! source via [`line_col`]). Parser only: no IR, no name resolution, no
+//! typechecking, no evaluation — those are milestones B2+.
+
+pub mod ast;
+mod lexer;
+mod parser;
+mod span;
+
+pub use parser::parse;
+pub use span::{line_col, Span};
+
+/// A lex or parse failure: a message plus the span of the offending source.
+/// Render positions with [`line_col`] (`file:line:col: message`).
+#[derive(Debug)]
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+}

--- a/mle/src/main.rs
+++ b/mle/src/main.rs
@@ -1,0 +1,37 @@
+//! The `mle` CLI. B1 exposes one subcommand:
+//!
+//! ```text
+//! mle parse <file.mle>
+//! ```
+//!
+//! Prints the surface AST (pretty-Debug) on success; on failure prints
+//! `file:line:col: error: message` to stderr and exits nonzero.
+
+use std::process::exit;
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    match args.as_slice() {
+        [command, path] if command == "parse" => {
+            let src = match std::fs::read_to_string(path) {
+                Ok(src) => src,
+                Err(err) => {
+                    eprintln!("error: cannot read {path}: {err}");
+                    exit(1);
+                }
+            };
+            match mle::parse(&src) {
+                Ok(program) => println!("{program:#?}"),
+                Err(err) => {
+                    let (line, col) = mle::line_col(&src, err.span.start);
+                    eprintln!("{path}:{line}:{col}: error: {}", err.message);
+                    exit(1);
+                }
+            }
+        }
+        _ => {
+            eprintln!("usage: mle parse <file.mle>");
+            exit(2);
+        }
+    }
+}

--- a/mle/src/parser.rs
+++ b/mle/src/parser.rs
@@ -1,0 +1,498 @@
+//! Recursive-descent parser for the B1 subset.
+//!
+//! Grammar (whitespace and newlines are insignificant):
+//!
+//! ```text
+//! program   := (letDecl | typeDecl)*
+//! letDecl   := "let" ident "=" expr
+//! typeDecl  := "type" ident "=" "{" (ident ":" type),* "}"
+//! type      := ident ("<" type ("," type)* ">")?
+//! expr      := pipeline
+//! pipeline  := cmp ("|>" cmp)*
+//! cmp       := add (("<" | ">" | "==") add)*        (left-assoc)
+//! add       := mul (("+" | "-") mul)*               (left-assoc)
+//! mul       := unary (("*" | "/") unary)*           (left-assoc)
+//! unary     := "-" unary | postfix
+//! postfix   := primary ("(" expr,* ")" | "." ident)*
+//! primary   := number | string | "true" | "false" | qualifiedIdent
+//!            | record | lambda | "(" expr ")"
+//! record    := "{" (ident ":" expr),* "}"
+//! lambda    := "(" (ident (":" type)?),* ")" (":" type)? "=>" expr
+//! ```
+//!
+//! Comma lists allow a trailing comma. `(` is disambiguated between lambda
+//! and parenthesized expression by scanning to the matching `)`: it is a
+//! lambda iff the next token is `=>` or `:` (a return-type annotation).
+
+use crate::ast::*;
+use crate::lexer::{describe, lex, Token, TokenKind};
+use crate::span::Span;
+use crate::ParseError;
+
+/// Parse a whole source file into a [`Program`].
+pub fn parse(src: &str) -> Result<Program, ParseError> {
+    let tokens = lex(src)?;
+    Parser {
+        tokens,
+        pos: 0,
+        depth: 0,
+    }
+    .program()
+}
+
+/// Nesting cap for the recursive entry points: pathological input
+/// (`((((…))))`) must fail as a clean spanned error, not a stack overflow —
+/// MLE sources may be machine-generated. Each nesting level costs ~10 debug
+/// frames, so the cap must fit a 2 MiB test-thread stack with margin.
+const MAX_DEPTH: usize = 100;
+
+struct Parser {
+    tokens: Vec<Token>,
+    pos: usize,
+    depth: usize,
+}
+
+impl Parser {
+    fn peek(&self) -> &Token {
+        &self.tokens[self.pos]
+    }
+
+    fn peek_kind(&self) -> &TokenKind {
+        &self.tokens[self.pos].kind
+    }
+
+    /// Kind of the token `n` past the cursor, clamped to the trailing `Eof`.
+    fn nth_kind(&self, n: usize) -> &TokenKind {
+        let idx = (self.pos + n).min(self.tokens.len() - 1);
+        &self.tokens[idx].kind
+    }
+
+    /// Consume and return the current token; never advances past `Eof`.
+    fn bump(&mut self) -> Token {
+        let token = self.tokens[self.pos].clone();
+        if token.kind != TokenKind::Eof {
+            self.pos += 1;
+        }
+        token
+    }
+
+    fn error<T>(&self, expected: &str) -> Result<T, ParseError> {
+        Err(ParseError {
+            message: format!("expected {expected}, found {}", describe(self.peek_kind())),
+            span: self.peek().span,
+        })
+    }
+
+    fn expect(&mut self, kind: TokenKind, expected: &str) -> Result<Token, ParseError> {
+        if self.peek_kind() == &kind {
+            Ok(self.bump())
+        } else {
+            self.error(expected)
+        }
+    }
+
+    fn expect_ident(&mut self, expected: &str) -> Result<(String, Span), ParseError> {
+        match self.peek_kind() {
+            TokenKind::Ident(name) => {
+                let name = name.clone();
+                Ok((name, self.bump().span))
+            }
+            _ => self.error(expected),
+        }
+    }
+
+    fn program(&mut self) -> Result<Program, ParseError> {
+        let mut items = Vec::new();
+        while self.peek_kind() != &TokenKind::Eof {
+            match self.peek_kind() {
+                TokenKind::Let => items.push(Item::Let(self.let_decl()?)),
+                TokenKind::Type => items.push(Item::Type(self.type_decl()?)),
+                _ => return self.error("`let` or `type` at top level"),
+            }
+        }
+        Ok(Program { items })
+    }
+
+    fn let_decl(&mut self) -> Result<LetDecl, ParseError> {
+        let kw = self.bump();
+        let (name, _) = self.expect_ident("a name after `let`")?;
+        self.expect(TokenKind::Eq, "`=`")?;
+        let value = self.expr()?;
+        let span = kw.span.to(value.span);
+        Ok(LetDecl { name, value, span })
+    }
+
+    fn type_decl(&mut self) -> Result<TypeDecl, ParseError> {
+        let kw = self.bump();
+        let (name, _) = self.expect_ident("a name after `type`")?;
+        self.expect(TokenKind::Eq, "`=`")?;
+        self.expect(TokenKind::LBrace, "`{`")?;
+        let mut fields = Vec::new();
+        while self.peek_kind() != &TokenKind::RBrace {
+            let (field_name, field_span) = self.expect_ident("a field name")?;
+            self.expect(TokenKind::Colon, "`:` after field name")?;
+            let ty = self.type_name()?;
+            fields.push(FieldTy {
+                span: field_span.to(ty.span),
+                name: field_name,
+                ty,
+            });
+            if self.peek_kind() == &TokenKind::Comma {
+                self.bump();
+            } else {
+                break;
+            }
+        }
+        let close = self.expect(TokenKind::RBrace, "`,` or `}`")?;
+        Ok(TypeDecl {
+            name,
+            fields,
+            span: kw.span.to(close.span),
+        })
+    }
+
+    fn type_name(&mut self) -> Result<TypeName, ParseError> {
+        self.depth += 1;
+        if self.depth > MAX_DEPTH {
+            return Err(ParseError {
+                message: "type nested too deeply".to_string(),
+                span: self.peek().span,
+            });
+        }
+        let (name, mut span) = self.expect_ident("a type name")?;
+        let mut args = Vec::new();
+        if self.peek_kind() == &TokenKind::Lt {
+            self.bump();
+            loop {
+                args.push(self.type_name()?);
+                if self.peek_kind() == &TokenKind::Comma {
+                    self.bump();
+                    if self.peek_kind() == &TokenKind::Gt {
+                        break; // trailing comma
+                    }
+                } else {
+                    break;
+                }
+            }
+            let close = self.expect(TokenKind::Gt, "`,` or `>`")?;
+            span = span.to(close.span);
+        }
+        self.depth -= 1;
+        Ok(TypeName { name, args, span })
+    }
+
+    fn expr(&mut self) -> Result<Expr, ParseError> {
+        self.depth += 1;
+        if self.depth > MAX_DEPTH {
+            return Err(ParseError {
+                message: "expression nested too deeply".to_string(),
+                span: self.peek().span,
+            });
+        }
+        let result = self.pipeline();
+        self.depth -= 1;
+        result
+    }
+
+    fn pipeline(&mut self) -> Result<Expr, ParseError> {
+        let head = self.comparison()?;
+        if self.peek_kind() != &TokenKind::PipeGt {
+            return Ok(head);
+        }
+        let mut stages = Vec::new();
+        while self.peek_kind() == &TokenKind::PipeGt {
+            self.bump();
+            stages.push(self.comparison()?);
+        }
+        let span = head
+            .span
+            .to(stages.last().expect("at least one stage").span);
+        Ok(Expr {
+            kind: ExprKind::Pipeline {
+                head: Box::new(head),
+                stages,
+            },
+            span,
+        })
+    }
+
+    fn comparison(&mut self) -> Result<Expr, ParseError> {
+        use TokenKind::*;
+        self.left_assoc(
+            &[(Lt, BinOp::Lt), (Gt, BinOp::Gt), (EqEq, BinOp::Eq)],
+            Self::additive,
+        )
+    }
+
+    fn additive(&mut self) -> Result<Expr, ParseError> {
+        use TokenKind::*;
+        self.left_assoc(
+            &[(Plus, BinOp::Add), (Minus, BinOp::Sub)],
+            Self::multiplicative,
+        )
+    }
+
+    fn multiplicative(&mut self) -> Result<Expr, ParseError> {
+        use TokenKind::*;
+        self.left_assoc(&[(Star, BinOp::Mul), (Slash, BinOp::Div)], Self::unary)
+    }
+
+    fn left_assoc(
+        &mut self,
+        ops: &[(TokenKind, BinOp)],
+        next: fn(&mut Self) -> Result<Expr, ParseError>,
+    ) -> Result<Expr, ParseError> {
+        let mut lhs = next(self)?;
+        loop {
+            let Some((_, op)) = ops.iter().find(|(kind, _)| kind == self.peek_kind()) else {
+                return Ok(lhs);
+            };
+            let op = *op;
+            self.bump();
+            let rhs = next(self)?;
+            let span = lhs.span.to(rhs.span);
+            lhs = Expr {
+                kind: ExprKind::Binary {
+                    op,
+                    lhs: Box::new(lhs),
+                    rhs: Box::new(rhs),
+                },
+                span,
+            };
+        }
+    }
+
+    // Iterative (not recursive) so `----x` chains can't grow the stack past
+    // the `expr` depth guard.
+    fn unary(&mut self) -> Result<Expr, ParseError> {
+        let mut minus_spans = Vec::new();
+        while self.peek_kind() == &TokenKind::Minus {
+            minus_spans.push(self.bump().span);
+        }
+        let mut expr = self.postfix()?;
+        for minus_span in minus_spans.into_iter().rev() {
+            let span = minus_span.to(expr.span);
+            expr = Expr {
+                kind: ExprKind::Neg(Box::new(expr)),
+                span,
+            };
+        }
+        Ok(expr)
+    }
+
+    fn postfix(&mut self) -> Result<Expr, ParseError> {
+        let mut expr = self.primary()?;
+        loop {
+            match self.peek_kind() {
+                TokenKind::LParen => {
+                    self.bump();
+                    let mut args = Vec::new();
+                    while self.peek_kind() != &TokenKind::RParen {
+                        args.push(self.expr()?);
+                        if self.peek_kind() == &TokenKind::Comma {
+                            self.bump();
+                        } else {
+                            break;
+                        }
+                    }
+                    let close = self.expect(TokenKind::RParen, "`,` or `)`")?;
+                    let span = expr.span.to(close.span);
+                    expr = Expr {
+                        kind: ExprKind::Call {
+                            callee: Box::new(expr),
+                            args,
+                        },
+                        span,
+                    };
+                }
+                TokenKind::Dot => {
+                    self.bump();
+                    let (field, field_span) = self.expect_ident("a field name after `.`")?;
+                    let span = expr.span.to(field_span);
+                    expr = Expr {
+                        kind: ExprKind::FieldAccess {
+                            object: Box::new(expr),
+                            field,
+                        },
+                        span,
+                    };
+                }
+                _ => return Ok(expr),
+            }
+        }
+    }
+
+    fn primary(&mut self) -> Result<Expr, ParseError> {
+        let span = self.peek().span;
+        match self.peek_kind() {
+            TokenKind::Number(n) => {
+                let n = *n;
+                self.bump();
+                Ok(Expr {
+                    kind: ExprKind::Number(n),
+                    span,
+                })
+            }
+            TokenKind::Str(s) => {
+                let s = s.clone();
+                self.bump();
+                Ok(Expr {
+                    kind: ExprKind::String(s),
+                    span,
+                })
+            }
+            TokenKind::True => {
+                self.bump();
+                Ok(Expr {
+                    kind: ExprKind::Bool(true),
+                    span,
+                })
+            }
+            TokenKind::False => {
+                self.bump();
+                Ok(Expr {
+                    kind: ExprKind::Bool(false),
+                    span,
+                })
+            }
+            TokenKind::Ident(_) => self.ident_expr(),
+            TokenKind::LBrace => self.record(),
+            TokenKind::LParen => {
+                if self.lambda_ahead() {
+                    self.lambda()
+                } else {
+                    self.paren()
+                }
+            }
+            _ => self.error("an expression"),
+        }
+    }
+
+    /// A possibly-qualified identifier. `.segment`s are absorbed into the
+    /// name while the segment left of the `.` starts uppercase (a module or
+    /// type qualifier, e.g. `Text.toBullets`); once a segment starts
+    /// lowercase, any further `.` is field access (handled by [`Self::postfix`]).
+    fn ident_expr(&mut self) -> Result<Expr, ParseError> {
+        let (first, mut span) = self.expect_ident("an identifier")?;
+        let mut segments = vec![first];
+        while starts_uppercase(segments.last().expect("non-empty"))
+            && self.peek_kind() == &TokenKind::Dot
+            && matches!(self.nth_kind(1), TokenKind::Ident(_))
+        {
+            self.bump();
+            let (segment, segment_span) = self.expect_ident("an identifier")?;
+            span = span.to(segment_span);
+            segments.push(segment);
+        }
+        Ok(Expr {
+            kind: ExprKind::Ident(segments),
+            span,
+        })
+    }
+
+    fn record(&mut self) -> Result<Expr, ParseError> {
+        let open = self.bump();
+        let mut fields = Vec::new();
+        while self.peek_kind() != &TokenKind::RBrace {
+            let (name, name_span) = self.expect_ident("a field name")?;
+            self.expect(TokenKind::Colon, "`:` after field name")?;
+            let value = self.expr()?;
+            fields.push(Field {
+                span: name_span.to(value.span),
+                name,
+                value,
+            });
+            if self.peek_kind() == &TokenKind::Comma {
+                self.bump();
+            } else {
+                break;
+            }
+        }
+        let close = self.expect(TokenKind::RBrace, "`,` or `}`")?;
+        Ok(Expr {
+            kind: ExprKind::Record(fields),
+            span: open.span.to(close.span),
+        })
+    }
+
+    /// `(` begins either a lambda or a parenthesized expression. Scan to the
+    /// matching `)` (depth-counted): it is a lambda iff the token after it is
+    /// `=>` or `:` (a return-type annotation). An unmatched `(` falls through
+    /// to the paren-expression path, which reports the error at the offending
+    /// token.
+    fn lambda_ahead(&self) -> bool {
+        let mut depth = 0usize;
+        let mut i = self.pos;
+        loop {
+            match &self.tokens[i].kind {
+                TokenKind::LParen => depth += 1,
+                TokenKind::RParen => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return matches!(
+                            self.tokens[i + 1].kind,
+                            TokenKind::FatArrow | TokenKind::Colon
+                        );
+                    }
+                }
+                TokenKind::Eof => return false,
+                _ => {}
+            }
+            i += 1;
+        }
+    }
+
+    fn lambda(&mut self) -> Result<Expr, ParseError> {
+        let open = self.bump();
+        let mut params = Vec::new();
+        while self.peek_kind() != &TokenKind::RParen {
+            let (name, name_span) = self.expect_ident("a parameter name")?;
+            let (ty, span) = if self.peek_kind() == &TokenKind::Colon {
+                self.bump();
+                let ty = self.type_name()?;
+                let span = name_span.to(ty.span);
+                (Some(ty), span)
+            } else {
+                (None, name_span)
+            };
+            params.push(Param { name, ty, span });
+            if self.peek_kind() == &TokenKind::Comma {
+                self.bump();
+            } else {
+                break;
+            }
+        }
+        self.expect(TokenKind::RParen, "`,` or `)`")?;
+        let ret = if self.peek_kind() == &TokenKind::Colon {
+            self.bump();
+            Some(self.type_name()?)
+        } else {
+            None
+        };
+        self.expect(TokenKind::FatArrow, "`=>`")?;
+        let body = self.expr()?;
+        let span = open.span.to(body.span);
+        Ok(Expr {
+            kind: ExprKind::Lambda {
+                params,
+                ret,
+                body: Box::new(body),
+            },
+            span,
+        })
+    }
+
+    /// Parentheses don't create an AST node; the inner expression's span is
+    /// widened to cover them so every span still maps to exact source text.
+    fn paren(&mut self) -> Result<Expr, ParseError> {
+        let open = self.bump();
+        let mut expr = self.expr()?;
+        let close = self.expect(TokenKind::RParen, "`)`")?;
+        expr.span = open.span.to(close.span);
+        Ok(expr)
+    }
+}
+
+fn starts_uppercase(s: &str) -> bool {
+    s.chars().next().is_some_and(char::is_uppercase)
+}

--- a/mle/src/span.rs
+++ b/mle/src/span.rs
@@ -1,0 +1,49 @@
+use std::fmt;
+
+/// Half-open byte range into the source text. Byte offsets are the single
+/// source of truth; line/col are derived on demand by [`line_col`] so AST
+/// nodes stay small and slicing `&src[span.start..span.end]` always yields
+/// the exact source text of a node.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct Span {
+    pub start: usize,
+    pub end: usize,
+}
+
+impl Span {
+    pub fn new(start: usize, end: usize) -> Span {
+        Span { start, end }
+    }
+
+    /// The span from the start of `self` to the end of `other`.
+    pub fn to(self, other: Span) -> Span {
+        Span::new(self.start, other.end)
+    }
+}
+
+// Compact `start..end` form keeps the pretty-Debug AST (and the committed
+// `.ast` goldens) readable.
+impl fmt::Debug for Span {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}..{}", self.start, self.end)
+    }
+}
+
+/// 1-based (line, column) of a byte offset. Columns count characters from the
+/// start of the line.
+pub fn line_col(src: &str, offset: usize) -> (usize, usize) {
+    let mut line = 1;
+    let mut col = 1;
+    for (i, c) in src.char_indices() {
+        if i >= offset {
+            break;
+        }
+        if c == '\n' {
+            line += 1;
+            col = 1;
+        } else {
+            col += 1;
+        }
+    }
+    (line, col)
+}

--- a/mle/tests/parser.rs
+++ b/mle/tests/parser.rs
@@ -1,0 +1,164 @@
+//! B1 verification (docs/mle.md): AST snapshot goldens per example,
+//! parse-error message + position assertions, and span → source-text sanity.
+
+use mle::ast::{ExprKind, Item};
+use mle::Span;
+use std::fs;
+use std::path::Path;
+
+/// Parse `examples/{name}.mle` and compare the pretty-Debug AST against the
+/// committed `examples/{name}.ast` golden.
+/// Regenerate with `UPDATE_GOLDENS=1 cargo test -p mle`.
+fn check_golden(name: &str) {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("examples");
+    let src_path = dir.join(format!("{name}.mle"));
+    let golden_path = dir.join(format!("{name}.ast"));
+    let src = fs::read_to_string(&src_path).unwrap();
+    let program = match mle::parse(&src) {
+        Ok(program) => program,
+        Err(err) => {
+            let (line, col) = mle::line_col(&src, err.span.start);
+            panic!(
+                "{}:{line}:{col}: error: {}",
+                src_path.display(),
+                err.message
+            );
+        }
+    };
+    let actual = format!("{program:#?}\n");
+    if std::env::var_os("UPDATE_GOLDENS").is_some() {
+        fs::write(&golden_path, &actual).unwrap();
+        return;
+    }
+    let expected = fs::read_to_string(&golden_path).unwrap_or_else(|_| {
+        panic!(
+            "missing golden {} — generate with UPDATE_GOLDENS=1 cargo test -p mle",
+            golden_path.display()
+        )
+    });
+    assert_eq!(
+        actual, expected,
+        "AST for {name}.mle diverged from {name}.ast — if intended, \
+         regenerate with UPDATE_GOLDENS=1 cargo test -p mle"
+    );
+}
+
+#[test]
+fn golden_pure_pipeline() {
+    check_golden("pure-pipeline");
+}
+
+#[test]
+fn golden_records() {
+    check_golden("records");
+}
+
+#[test]
+fn golden_functions() {
+    check_golden("functions");
+}
+
+/// Parse a deliberately broken input; return the error's (message, line, col).
+fn parse_err(src: &str) -> (String, usize, usize) {
+    let err = mle::parse(src).expect_err("input should fail to parse");
+    let (line, col) = mle::line_col(src, err.span.start);
+    (err.message, line, col)
+}
+
+#[test]
+fn error_missing_let_name() {
+    assert_eq!(
+        parse_err("let = 1"),
+        ("expected a name after `let`, found `=`".to_string(), 1, 5)
+    );
+}
+
+#[test]
+fn error_unterminated_string() {
+    assert_eq!(
+        parse_err("let s = \"abc"),
+        ("unterminated string".to_string(), 1, 9)
+    );
+}
+
+#[test]
+fn error_record_field_missing_colon() {
+    assert_eq!(
+        parse_err("let p = { x: 1.0, y }"),
+        (
+            "expected `:` after field name, found `}`".to_string(),
+            1,
+            21
+        )
+    );
+}
+
+#[test]
+fn error_unclosed_paren() {
+    assert_eq!(
+        parse_err("let f = (a, b => a"),
+        ("expected `)`, found `,`".to_string(), 1, 11)
+    );
+}
+
+#[test]
+fn error_missing_operand_reports_second_line() {
+    assert_eq!(
+        parse_err("let a = 1\nlet b = 2 +"),
+        (
+            "expected an expression, found end of input".to_string(),
+            2,
+            12
+        )
+    );
+}
+
+/// Pathological nesting must fail as a clean parse error, not a stack
+/// overflow (MLE sources may be machine-generated).
+#[test]
+fn error_deeply_nested_expression() {
+    let src = format!("let x = {}1{}", "(".repeat(300), ")".repeat(300));
+    let err = mle::parse(&src).expect_err("should hit the depth limit");
+    assert_eq!(err.message, "expression nested too deeply");
+}
+
+#[test]
+fn generic_args_allow_trailing_comma() {
+    assert!(mle::parse("type T = { xs: List<Float,> }").is_ok());
+}
+
+/// Error spans must stay sliceable (char-boundary aligned) even when the
+/// offending character is multi-byte.
+#[test]
+fn unknown_escape_span_is_sliceable() {
+    let src = "let s = \"a\\é\"";
+    let err = mle::parse(src).expect_err("unknown escape should fail");
+    assert_eq!(err.message, "unknown escape sequence");
+    assert_eq!(&src[err.span.start..err.span.end], "\\é");
+}
+
+fn text(src: &str, span: Span) -> &str {
+    &src[span.start..span.end]
+}
+
+/// Spans are byte offsets into the source: slicing a node's span must yield
+/// its exact source text.
+#[test]
+fn spans_map_to_source_text() {
+    let src = "let move = (p) => p.x + speed * 2.0";
+    let program = mle::parse(src).unwrap();
+    let Item::Let(decl) = &program.items[0] else {
+        panic!("expected a let declaration");
+    };
+    assert_eq!(text(src, decl.span), src);
+    assert_eq!(text(src, decl.value.span), "(p) => p.x + speed * 2.0");
+    let ExprKind::Lambda { body, .. } = &decl.value.kind else {
+        panic!("expected a lambda");
+    };
+    assert_eq!(text(src, body.span), "p.x + speed * 2.0");
+    let ExprKind::Binary { lhs, rhs, .. } = &body.kind else {
+        panic!("expected a binary expression");
+    };
+    assert_eq!(text(src, lhs.span), "p.x");
+    assert_eq!(text(src, rhs.span), "speed * 2.0");
+}


### PR DESCRIPTION
## What

Track **B1** of `docs/mle.md`: the first real slice of the MLE language — a zero-dependency `mle/` crate in the root workspace:

- **Lexer + hand-rolled recursive-descent parser** → a surface AST where every node carries a byte-offset span (line/col derivable for diagnostics). Grammar documented in the parser module doc.
- **Supported subset** (exactly B1's): comments, literals, identifiers + qualified names, records, field access, top-level `let`, lambdas with optional type annotations, calls, pipelines (`|>`, kept as an explicit AST node — desugaring is B2's lowering), arithmetic/comparison with conventional precedence, parens, `type X = { ... }` declarations.
- **CLI:** `mle parse <file.mle>` — AST on stdout, or `file:line:col: error: msg` + exit 1.
- **Examples + goldens:** `pure-pipeline.mle`, `records.mle`, `functions.mle` with committed `.ast` snapshots (`UPDATE_GOLDENS=1 cargo test -p mle` regenerates).

## Verification

- `cargo test -p mle` — **12/12**: 3 goldens, 5 parse-error message+position tests, span-sanity, recursion-depth-limit, trailing-comma, escape-span.
- `cargo build -p mle`, `cargo build -p functor-runtime-desktop` (workspace intact), `cargo fmt --check`, `cargo clippy` — clean.
- Cross-engine review (/xreview, Claude + Codex): no Critical/High; three confirmed findings fixed and re-validated (recursion-depth cap replacing a stack-overflow abort, escape-error span char-boundary alignment, trailing comma in generic type args).

## Notes

- Qualified-name vs field-access disambiguation is purely syntactic for now (uppercase first segment ⇒ qualified name); real resolution is B2.
- Independent of #154 (Track A1) — the two tracks meet at C1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)