### PR TITLE
feat(mle): B2 — lower the surface AST to a name-resolved core IR

### DIFF
--- a/docs/mle.md
+++ b/docs/mle.md
@@ -129,9 +129,10 @@ snapshots — no GPU, fully agent-verifiable.
       functions, records, field access, literals, pipelines, type annotations;
       source spans. *Verify:* AST snapshots per example (`UPDATE_GOLDENS=1` to
       regenerate); `mle parse`; errors point at spans. (done)
-- [ ] **B2. AST → core IR.** Stable IDs, name resolution, pipeline desugaring,
+- [x] **B2. AST → core IR.** Stable IDs, name resolution, pipeline desugaring,
       spans on every node. *Verify:* `mle ir` snapshot fixtures (the
-      parser↔runtime contract).
+      parser↔runtime contract). (done — top-level defs are mutually visible
+      and carry their name as the stable hot-reload identity)
 - [ ] **B3. Interpreter + run/trace.** Literals, records, calls, locals; run
       record with captured values. *Verify:* `mle run` / `mle trace` goldens.
 - [ ] **B4. Basic types.** Primitives, records, function signatures, mismatch

--- a/mle/examples/functions.ast
+++ b/mle/examples/functions.ast
@@ -184,10 +184,11 @@ Program {
                                 callee: Expr {
                                     kind: Ident(
                                         [
+                                            "List",
                                             "fold",
                                         ],
                                     ),
-                                    span: 248..252,
+                                    span: 248..257,
                                 },
                                 args: [
                                     Expr {
@@ -196,13 +197,13 @@ Program {
                                                 "add",
                                             ],
                                         ),
-                                        span: 253..256,
+                                        span: 258..261,
                                     },
                                     Expr {
                                         kind: Number(
                                             0.0,
                                         ),
-                                        span: 258..261,
+                                        span: 263..266,
                                     },
                                     Expr {
                                         kind: FieldAccess {
@@ -212,20 +213,20 @@ Program {
                                                         "p",
                                                     ],
                                                 ),
-                                                span: 263..264,
+                                                span: 268..269,
                                             },
                                             field: "scores",
                                         },
-                                        span: 263..271,
+                                        span: 268..276,
                                     },
                                 ],
                             },
-                            span: 248..272,
+                            span: 248..277,
                         },
                     },
-                    span: 226..272,
+                    span: 226..277,
                 },
-                span: 214..272,
+                span: 214..277,
             },
         ),
         Let(
@@ -243,20 +244,20 @@ Program {
                                             TypeName {
                                                 name: "Player",
                                                 args: [],
-                                                span: 305..311,
+                                                span: 310..316,
                                             },
                                         ],
-                                        span: 300..312,
+                                        span: 305..317,
                                     },
                                 ),
-                                span: 291..312,
+                                span: 296..317,
                             },
                         ],
                         ret: Some(
                             TypeName {
                                 name: "Float",
                                 args: [],
-                                span: 315..320,
+                                span: 320..325,
                             },
                         ),
                         body: Expr {
@@ -267,7 +268,7 @@ Program {
                                             "players",
                                         ],
                                     ),
-                                    span: 326..333,
+                                    span: 331..338,
                                 },
                                 stages: [
                                     Expr {
@@ -275,10 +276,11 @@ Program {
                                             callee: Expr {
                                                 kind: Ident(
                                                     [
+                                                        "List",
                                                         "map",
                                                     ],
                                                 ),
-                                                span: 337..340,
+                                                span: 342..350,
                                             },
                                             args: [
                                                 Expr {
@@ -287,7 +289,7 @@ Program {
                                                             Param {
                                                                 name: "p",
                                                                 ty: None,
-                                                                span: 342..343,
+                                                                span: 352..353,
                                                             },
                                                         ],
                                                         ret: None,
@@ -299,7 +301,7 @@ Program {
                                                                             "total",
                                                                         ],
                                                                     ),
-                                                                    span: 348..353,
+                                                                    span: 358..363,
                                                                 },
                                                                 args: [
                                                                     Expr {
@@ -308,35 +310,36 @@ Program {
                                                                                 "p",
                                                                             ],
                                                                         ),
-                                                                        span: 354..355,
+                                                                        span: 364..365,
                                                                     },
                                                                 ],
                                                             },
-                                                            span: 348..356,
+                                                            span: 358..366,
                                                         },
                                                     },
-                                                    span: 341..356,
+                                                    span: 351..366,
                                                 },
                                             ],
                                         },
-                                        span: 337..357,
+                                        span: 342..367,
                                     },
                                     Expr {
                                         kind: Ident(
                                             [
+                                                "List",
                                                 "maximum",
                                             ],
                                         ),
-                                        span: 361..368,
+                                        span: 371..383,
                                     },
                                 ],
                             },
-                            span: 326..368,
+                            span: 331..383,
                         },
                     },
-                    span: 290..368,
+                    span: 295..383,
                 },
-                span: 274..368,
+                span: 279..383,
             },
         ),
         Let(
@@ -348,12 +351,12 @@ Program {
                             Param {
                                 name: "p",
                                 ty: None,
-                                span: 386..387,
+                                span: 401..402,
                             },
                             Param {
                                 name: "cutoff",
                                 ty: None,
-                                span: 389..395,
+                                span: 404..410,
                             },
                         ],
                         ret: None,
@@ -366,7 +369,7 @@ Program {
                                             "cutoff",
                                         ],
                                     ),
-                                    span: 400..406,
+                                    span: 415..421,
                                 },
                                 rhs: Expr {
                                     kind: Call {
@@ -376,7 +379,7 @@ Program {
                                                     "total",
                                                 ],
                                             ),
-                                            span: 409..414,
+                                            span: 424..429,
                                         },
                                         args: [
                                             Expr {
@@ -385,19 +388,19 @@ Program {
                                                         "p",
                                                     ],
                                                 ),
-                                                span: 415..416,
+                                                span: 430..431,
                                             },
                                         ],
                                     },
-                                    span: 409..417,
+                                    span: 424..432,
                                 },
                             },
-                            span: 400..417,
+                            span: 415..432,
                         },
                     },
-                    span: 385..417,
+                    span: 400..432,
                 },
-                span: 370..417,
+                span: 385..432,
             },
         ),
         Let(
@@ -407,9 +410,9 @@ Program {
                     kind: Bool(
                         false,
                     ),
-                    span: 431..436,
+                    span: 446..451,
                 },
-                span: 419..436,
+                span: 434..451,
             },
         ),
     ],

--- a/mle/examples/functions.ir
+++ b/mle/examples/functions.ir
@@ -1,0 +1,442 @@
+Module {
+    types: [
+        TypeDef {
+            id: d0,
+            name: "Player",
+            fields: [
+                FieldTy {
+                    name: "name",
+                    ty: TypeName {
+                        name: "String",
+                        args: [],
+                        span: 96..102,
+                    },
+                    span: 90..102,
+                },
+                FieldTy {
+                    name: "scores",
+                    ty: TypeName {
+                        name: "List",
+                        args: [
+                            TypeName {
+                                name: "Float",
+                                args: [],
+                                span: 117..122,
+                            },
+                        ],
+                        span: 112..123,
+                    },
+                    span: 104..123,
+                },
+            ],
+            span: 74..125,
+        },
+    ],
+    defs: [
+        Def {
+            id: d1,
+            name: "add",
+            value: Expr {
+                id: e3,
+                kind: Lambda {
+                    params: [
+                        Param {
+                            binding: b0,
+                            name: "a",
+                            ty: Some(
+                                TypeName {
+                                    name: "Float",
+                                    args: [],
+                                    span: 141..146,
+                                },
+                            ),
+                            span: 138..146,
+                        },
+                        Param {
+                            binding: b1,
+                            name: "b",
+                            ty: Some(
+                                TypeName {
+                                    name: "Float",
+                                    args: [],
+                                    span: 151..156,
+                                },
+                            ),
+                            span: 148..156,
+                        },
+                    ],
+                    ret: Some(
+                        TypeName {
+                            name: "Float",
+                            args: [],
+                            span: 159..164,
+                        },
+                    ),
+                    body: Expr {
+                        id: e2,
+                        kind: Binary {
+                            op: Add,
+                            lhs: Expr {
+                                id: e0,
+                                kind: Local {
+                                    binding: b0,
+                                    name: "a",
+                                },
+                                span: 168..169,
+                            },
+                            rhs: Expr {
+                                id: e1,
+                                kind: Local {
+                                    binding: b1,
+                                    name: "b",
+                                },
+                                span: 172..173,
+                            },
+                        },
+                        span: 168..173,
+                    },
+                },
+                span: 137..173,
+            },
+            span: 127..173,
+        },
+        Def {
+            id: d2,
+            name: "average",
+            value: Expr {
+                id: e9,
+                kind: Lambda {
+                    params: [
+                        Param {
+                            binding: b2,
+                            name: "a",
+                            ty: None,
+                            span: 190..191,
+                        },
+                        Param {
+                            binding: b3,
+                            name: "b",
+                            ty: None,
+                            span: 193..194,
+                        },
+                    ],
+                    ret: None,
+                    body: Expr {
+                        id: e8,
+                        kind: Binary {
+                            op: Div,
+                            lhs: Expr {
+                                id: e6,
+                                kind: Binary {
+                                    op: Add,
+                                    lhs: Expr {
+                                        id: e4,
+                                        kind: Local {
+                                            binding: b2,
+                                            name: "a",
+                                        },
+                                        span: 200..201,
+                                    },
+                                    rhs: Expr {
+                                        id: e5,
+                                        kind: Local {
+                                            binding: b3,
+                                            name: "b",
+                                        },
+                                        span: 204..205,
+                                    },
+                                },
+                                span: 199..206,
+                            },
+                            rhs: Expr {
+                                id: e7,
+                                kind: Number(
+                                    2.0,
+                                ),
+                                span: 209..212,
+                            },
+                        },
+                        span: 199..212,
+                    },
+                },
+                span: 189..212,
+            },
+            span: 175..212,
+        },
+        Def {
+            id: d3,
+            name: "total",
+            value: Expr {
+                id: e16,
+                kind: Lambda {
+                    params: [
+                        Param {
+                            binding: b4,
+                            name: "p",
+                            ty: Some(
+                                TypeName {
+                                    name: "Player",
+                                    args: [],
+                                    span: 230..236,
+                                },
+                            ),
+                            span: 227..236,
+                        },
+                    ],
+                    ret: Some(
+                        TypeName {
+                            name: "Float",
+                            args: [],
+                            span: 239..244,
+                        },
+                    ),
+                    body: Expr {
+                        id: e15,
+                        kind: Call {
+                            callee: Expr {
+                                id: e10,
+                                kind: External(
+                                    [
+                                        "List",
+                                        "fold",
+                                    ],
+                                ),
+                                span: 248..257,
+                            },
+                            args: [
+                                Expr {
+                                    id: e11,
+                                    kind: Global(
+                                        "add",
+                                    ),
+                                    span: 258..261,
+                                },
+                                Expr {
+                                    id: e12,
+                                    kind: Number(
+                                        0.0,
+                                    ),
+                                    span: 263..266,
+                                },
+                                Expr {
+                                    id: e14,
+                                    kind: FieldAccess {
+                                        object: Expr {
+                                            id: e13,
+                                            kind: Local {
+                                                binding: b4,
+                                                name: "p",
+                                            },
+                                            span: 268..269,
+                                        },
+                                        field: "scores",
+                                    },
+                                    span: 268..276,
+                                },
+                            ],
+                        },
+                        span: 248..277,
+                    },
+                },
+                span: 226..277,
+            },
+            span: 214..277,
+        },
+        Def {
+            id: d4,
+            name: "bestTotal",
+            value: Expr {
+                id: e26,
+                kind: Lambda {
+                    params: [
+                        Param {
+                            binding: b5,
+                            name: "players",
+                            ty: Some(
+                                TypeName {
+                                    name: "List",
+                                    args: [
+                                        TypeName {
+                                            name: "Player",
+                                            args: [],
+                                            span: 310..316,
+                                        },
+                                    ],
+                                    span: 305..317,
+                                },
+                            ),
+                            span: 296..317,
+                        },
+                    ],
+                    ret: Some(
+                        TypeName {
+                            name: "Float",
+                            args: [],
+                            span: 320..325,
+                        },
+                    ),
+                    body: Expr {
+                        id: e25,
+                        kind: Call {
+                            callee: Expr {
+                                id: e24,
+                                kind: External(
+                                    [
+                                        "List",
+                                        "maximum",
+                                    ],
+                                ),
+                                span: 371..383,
+                            },
+                            args: [
+                                Expr {
+                                    id: e23,
+                                    kind: Call {
+                                        callee: Expr {
+                                            id: e18,
+                                            kind: External(
+                                                [
+                                                    "List",
+                                                    "map",
+                                                ],
+                                            ),
+                                            span: 342..350,
+                                        },
+                                        args: [
+                                            Expr {
+                                                id: e17,
+                                                kind: Local {
+                                                    binding: b5,
+                                                    name: "players",
+                                                },
+                                                span: 331..338,
+                                            },
+                                            Expr {
+                                                id: e22,
+                                                kind: Lambda {
+                                                    params: [
+                                                        Param {
+                                                            binding: b6,
+                                                            name: "p",
+                                                            ty: None,
+                                                            span: 352..353,
+                                                        },
+                                                    ],
+                                                    ret: None,
+                                                    body: Expr {
+                                                        id: e21,
+                                                        kind: Call {
+                                                            callee: Expr {
+                                                                id: e19,
+                                                                kind: Global(
+                                                                    "total",
+                                                                ),
+                                                                span: 358..363,
+                                                            },
+                                                            args: [
+                                                                Expr {
+                                                                    id: e20,
+                                                                    kind: Local {
+                                                                        binding: b6,
+                                                                        name: "p",
+                                                                    },
+                                                                    span: 364..365,
+                                                                },
+                                                            ],
+                                                        },
+                                                        span: 358..366,
+                                                    },
+                                                },
+                                                span: 351..366,
+                                            },
+                                        ],
+                                    },
+                                    span: 342..367,
+                                },
+                            ],
+                        },
+                        span: 371..383,
+                    },
+                },
+                span: 295..383,
+            },
+            span: 279..383,
+        },
+        Def {
+            id: d5,
+            name: "isWinner",
+            value: Expr {
+                id: e32,
+                kind: Lambda {
+                    params: [
+                        Param {
+                            binding: b7,
+                            name: "p",
+                            ty: None,
+                            span: 401..402,
+                        },
+                        Param {
+                            binding: b8,
+                            name: "cutoff",
+                            ty: None,
+                            span: 404..410,
+                        },
+                    ],
+                    ret: None,
+                    body: Expr {
+                        id: e31,
+                        kind: Binary {
+                            op: Lt,
+                            lhs: Expr {
+                                id: e27,
+                                kind: Local {
+                                    binding: b8,
+                                    name: "cutoff",
+                                },
+                                span: 415..421,
+                            },
+                            rhs: Expr {
+                                id: e30,
+                                kind: Call {
+                                    callee: Expr {
+                                        id: e28,
+                                        kind: Global(
+                                            "total",
+                                        ),
+                                        span: 424..429,
+                                    },
+                                    args: [
+                                        Expr {
+                                            id: e29,
+                                            kind: Local {
+                                                binding: b7,
+                                                name: "p",
+                                            },
+                                            span: 430..431,
+                                        },
+                                    ],
+                                },
+                                span: 424..432,
+                            },
+                        },
+                        span: 415..432,
+                    },
+                },
+                span: 400..432,
+            },
+            span: 385..432,
+        },
+        Def {
+            id: d6,
+            name: "debug",
+            value: Expr {
+                id: e33,
+                kind: Bool(
+                    false,
+                ),
+                span: 446..451,
+            },
+            span: 434..451,
+        },
+    ],
+}

--- a/mle/examples/functions.mle
+++ b/mle/examples/functions.mle
@@ -6,10 +6,10 @@ let add = (a: Float, b: Float): Float => a + b
 
 let average = (a, b) => (a + b) / 2.0
 
-let total = (p: Player): Float => fold(add, 0.0, p.scores)
+let total = (p: Player): Float => List.fold(add, 0.0, p.scores)
 
 let bestTotal = (players: List<Player>): Float =>
-  players |> map((p) => total(p)) |> maximum
+  players |> List.map((p) => total(p)) |> List.maximum
 
 let isWinner = (p, cutoff) => cutoff < total(p)
 

--- a/mle/examples/pure-pipeline.ast
+++ b/mle/examples/pure-pipeline.ast
@@ -83,17 +83,18 @@ Program {
                                 callee: Expr {
                                     kind: Ident(
                                         [
+                                            "Text",
                                             "concat",
                                         ],
                                     ),
-                                    span: 209..215,
+                                    span: 209..220,
                                 },
                                 args: [
                                     Expr {
                                         kind: String(
                                             "score: ",
                                         ),
-                                        span: 216..225,
+                                        span: 221..230,
                                     },
                                     Expr {
                                         kind: Call {
@@ -104,7 +105,7 @@ Program {
                                                         "fromFloat",
                                                     ],
                                                 ),
-                                                span: 227..241,
+                                                span: 232..246,
                                             },
                                             args: [
                                                 Expr {
@@ -113,20 +114,20 @@ Program {
                                                             "score",
                                                         ],
                                                     ),
-                                                    span: 242..247,
+                                                    span: 247..252,
                                                 },
                                             ],
                                         },
-                                        span: 227..248,
+                                        span: 232..253,
                                     },
                                 ],
                             },
-                            span: 209..249,
+                            span: 209..254,
                         },
                     },
-                    span: 198..249,
+                    span: 198..254,
                 },
-                span: 183..249,
+                span: 183..254,
             },
         ),
         Let(
@@ -138,7 +139,7 @@ Program {
                             Param {
                                 name: "score",
                                 ty: None,
-                                span: 334..339,
+                                span: 339..344,
                             },
                         ],
                         ret: None,
@@ -153,34 +154,35 @@ Program {
                                                     "score",
                                                 ],
                                             ),
-                                            span: 344..349,
+                                            span: 349..354,
                                         },
                                         rhs: Expr {
                                             kind: Number(
                                                 100.0,
                                             ),
-                                            span: 352..357,
+                                            span: 357..362,
                                         },
                                     },
-                                    span: 344..357,
+                                    span: 349..362,
                                 },
                                 stages: [
                                     Expr {
                                         kind: Ident(
                                             [
+                                                "Math",
                                                 "clamp01",
                                             ],
                                         ),
-                                        span: 361..368,
+                                        span: 366..378,
                                     },
                                 ],
                             },
-                            span: 344..368,
+                            span: 349..378,
                         },
                     },
-                    span: 333..368,
+                    span: 338..378,
                 },
-                span: 316..368,
+                span: 321..378,
             },
         ),
         Let(
@@ -192,7 +194,7 @@ Program {
                             Param {
                                 name: "scores",
                                 ty: None,
-                                span: 384..390,
+                                span: 394..400,
                             },
                         ],
                         ret: None,
@@ -204,7 +206,7 @@ Program {
                                             "scores",
                                         ],
                                     ),
-                                    span: 397..403,
+                                    span: 407..413,
                                 },
                                 stages: [
                                     Expr {
@@ -212,10 +214,11 @@ Program {
                                             callee: Expr {
                                                 kind: Ident(
                                                     [
+                                                        "List",
                                                         "filter",
                                                     ],
                                                 ),
-                                                span: 411..417,
+                                                span: 421..432,
                                             },
                                             args: [
                                                 Expr {
@@ -224,21 +227,22 @@ Program {
                                                             "isHigh",
                                                         ],
                                                     ),
-                                                    span: 418..424,
+                                                    span: 433..439,
                                                 },
                                             ],
                                         },
-                                        span: 411..425,
+                                        span: 421..440,
                                     },
                                     Expr {
                                         kind: Call {
                                             callee: Expr {
                                                 kind: Ident(
                                                     [
+                                                        "List",
                                                         "map",
                                                     ],
                                                 ),
-                                                span: 433..436,
+                                                span: 448..456,
                                             },
                                             args: [
                                                 Expr {
@@ -247,11 +251,11 @@ Program {
                                                             "describe",
                                                         ],
                                                     ),
-                                                    span: 437..445,
+                                                    span: 457..465,
                                                 },
                                             ],
                                         },
-                                        span: 433..446,
+                                        span: 448..466,
                                     },
                                     Expr {
                                         kind: Ident(
@@ -260,16 +264,16 @@ Program {
                                                 "toBullets",
                                             ],
                                         ),
-                                        span: 454..468,
+                                        span: 474..488,
                                     },
                                 ],
                             },
-                            span: 397..468,
+                            span: 407..488,
                         },
                     },
-                    span: 383..468,
+                    span: 393..488,
                 },
-                span: 370..468,
+                span: 380..488,
             },
         ),
     ],

--- a/mle/examples/pure-pipeline.ir
+++ b/mle/examples/pure-pipeline.ir
@@ -1,0 +1,298 @@
+Module {
+    types: [],
+    defs: [
+        Def {
+            id: d0,
+            name: "threshold",
+            value: Expr {
+                id: e0,
+                kind: Number(
+                    10.0,
+                ),
+                span: 123..125,
+            },
+            span: 107..125,
+        },
+        Def {
+            id: d1,
+            name: "isHigh",
+            value: Expr {
+                id: e4,
+                kind: Lambda {
+                    params: [
+                        Param {
+                            binding: b0,
+                            name: "score",
+                            ty: Some(
+                                TypeName {
+                                    name: "Float",
+                                    args: [],
+                                    span: 148..153,
+                                },
+                            ),
+                            span: 141..153,
+                        },
+                    ],
+                    ret: Some(
+                        TypeName {
+                            name: "Bool",
+                            args: [],
+                            span: 156..160,
+                        },
+                    ),
+                    body: Expr {
+                        id: e3,
+                        kind: Binary {
+                            op: Gt,
+                            lhs: Expr {
+                                id: e1,
+                                kind: Local {
+                                    binding: b0,
+                                    name: "score",
+                                },
+                                span: 164..169,
+                            },
+                            rhs: Expr {
+                                id: e2,
+                                kind: Global(
+                                    "threshold",
+                                ),
+                                span: 172..181,
+                            },
+                        },
+                        span: 164..181,
+                    },
+                },
+                span: 140..181,
+            },
+            span: 127..181,
+        },
+        Def {
+            id: d2,
+            name: "describe",
+            value: Expr {
+                id: e11,
+                kind: Lambda {
+                    params: [
+                        Param {
+                            binding: b1,
+                            name: "score",
+                            ty: None,
+                            span: 199..204,
+                        },
+                    ],
+                    ret: None,
+                    body: Expr {
+                        id: e10,
+                        kind: Call {
+                            callee: Expr {
+                                id: e5,
+                                kind: External(
+                                    [
+                                        "Text",
+                                        "concat",
+                                    ],
+                                ),
+                                span: 209..220,
+                            },
+                            args: [
+                                Expr {
+                                    id: e6,
+                                    kind: String(
+                                        "score: ",
+                                    ),
+                                    span: 221..230,
+                                },
+                                Expr {
+                                    id: e9,
+                                    kind: Call {
+                                        callee: Expr {
+                                            id: e7,
+                                            kind: External(
+                                                [
+                                                    "Text",
+                                                    "fromFloat",
+                                                ],
+                                            ),
+                                            span: 232..246,
+                                        },
+                                        args: [
+                                            Expr {
+                                                id: e8,
+                                                kind: Local {
+                                                    binding: b1,
+                                                    name: "score",
+                                                },
+                                                span: 247..252,
+                                            },
+                                        ],
+                                    },
+                                    span: 232..253,
+                                },
+                            ],
+                        },
+                        span: 209..254,
+                    },
+                },
+                span: 198..254,
+            },
+            span: 183..254,
+        },
+        Def {
+            id: d3,
+            name: "normalized",
+            value: Expr {
+                id: e17,
+                kind: Lambda {
+                    params: [
+                        Param {
+                            binding: b2,
+                            name: "score",
+                            ty: None,
+                            span: 339..344,
+                        },
+                    ],
+                    ret: None,
+                    body: Expr {
+                        id: e16,
+                        kind: Call {
+                            callee: Expr {
+                                id: e15,
+                                kind: External(
+                                    [
+                                        "Math",
+                                        "clamp01",
+                                    ],
+                                ),
+                                span: 366..378,
+                            },
+                            args: [
+                                Expr {
+                                    id: e14,
+                                    kind: Binary {
+                                        op: Div,
+                                        lhs: Expr {
+                                            id: e12,
+                                            kind: Local {
+                                                binding: b2,
+                                                name: "score",
+                                            },
+                                            span: 349..354,
+                                        },
+                                        rhs: Expr {
+                                            id: e13,
+                                            kind: Number(
+                                                100.0,
+                                            ),
+                                            span: 357..362,
+                                        },
+                                    },
+                                    span: 349..362,
+                                },
+                            ],
+                        },
+                        span: 366..378,
+                    },
+                },
+                span: 338..378,
+            },
+            span: 321..378,
+        },
+        Def {
+            id: d4,
+            name: "report",
+            value: Expr {
+                id: e27,
+                kind: Lambda {
+                    params: [
+                        Param {
+                            binding: b3,
+                            name: "scores",
+                            ty: None,
+                            span: 394..400,
+                        },
+                    ],
+                    ret: None,
+                    body: Expr {
+                        id: e26,
+                        kind: Call {
+                            callee: Expr {
+                                id: e25,
+                                kind: External(
+                                    [
+                                        "Text",
+                                        "toBullets",
+                                    ],
+                                ),
+                                span: 474..488,
+                            },
+                            args: [
+                                Expr {
+                                    id: e24,
+                                    kind: Call {
+                                        callee: Expr {
+                                            id: e22,
+                                            kind: External(
+                                                [
+                                                    "List",
+                                                    "map",
+                                                ],
+                                            ),
+                                            span: 448..456,
+                                        },
+                                        args: [
+                                            Expr {
+                                                id: e21,
+                                                kind: Call {
+                                                    callee: Expr {
+                                                        id: e19,
+                                                        kind: External(
+                                                            [
+                                                                "List",
+                                                                "filter",
+                                                            ],
+                                                        ),
+                                                        span: 421..432,
+                                                    },
+                                                    args: [
+                                                        Expr {
+                                                            id: e18,
+                                                            kind: Local {
+                                                                binding: b3,
+                                                                name: "scores",
+                                                            },
+                                                            span: 407..413,
+                                                        },
+                                                        Expr {
+                                                            id: e20,
+                                                            kind: Global(
+                                                                "isHigh",
+                                                            ),
+                                                            span: 433..439,
+                                                        },
+                                                    ],
+                                                },
+                                                span: 421..440,
+                                            },
+                                            Expr {
+                                                id: e23,
+                                                kind: Global(
+                                                    "describe",
+                                                ),
+                                                span: 457..465,
+                                            },
+                                        ],
+                                    },
+                                    span: 448..466,
+                                },
+                            ],
+                        },
+                        span: 474..488,
+                    },
+                },
+                span: 393..488,
+            },
+            span: 380..488,
+        },
+    ],
+}

--- a/mle/examples/pure-pipeline.mle
+++ b/mle/examples/pure-pipeline.mle
@@ -5,13 +5,13 @@ let threshold = 10
 
 let isHigh = (score: Float): Bool => score > threshold
 
-let describe = (score) => concat("score: ", Text.fromFloat(score))
+let describe = (score) => Text.concat("score: ", Text.fromFloat(score))
 
 // Pipelines bind loosest: the division happens before the `|>`.
-let normalized = (score) => score / 100.0 |> clamp01
+let normalized = (score) => score / 100.0 |> Math.clamp01
 
 let report = (scores) =>
   scores
-    |> filter(isHigh)
-    |> map(describe)
+    |> List.filter(isHigh)
+    |> List.map(describe)
     |> Text.toBullets

--- a/mle/examples/records.ir
+++ b/mle/examples/records.ir
@@ -1,0 +1,546 @@
+Module {
+    types: [
+        TypeDef {
+            id: d0,
+            name: "Position",
+            fields: [
+                FieldTy {
+                    name: "x",
+                    ty: TypeName {
+                        name: "Float",
+                        args: [],
+                        span: 162..167,
+                    },
+                    span: 159..167,
+                },
+                FieldTy {
+                    name: "y",
+                    ty: TypeName {
+                        name: "Float",
+                        args: [],
+                        span: 172..177,
+                    },
+                    span: 169..177,
+                },
+            ],
+            span: 141..179,
+        },
+        TypeDef {
+            id: d1,
+            name: "Velocity",
+            fields: [
+                FieldTy {
+                    name: "dx",
+                    ty: TypeName {
+                        name: "Float",
+                        args: [],
+                        span: 202..207,
+                    },
+                    span: 198..207,
+                },
+                FieldTy {
+                    name: "dy",
+                    ty: TypeName {
+                        name: "Float",
+                        args: [],
+                        span: 213..218,
+                    },
+                    span: 209..218,
+                },
+            ],
+            span: 180..220,
+        },
+    ],
+    defs: [
+        Def {
+            id: d2,
+            name: "origin",
+            value: Expr {
+                id: e2,
+                kind: Record(
+                    [
+                        Field {
+                            name: "x",
+                            value: Expr {
+                                id: e0,
+                                kind: Number(
+                                    0.0,
+                                ),
+                                span: 240..243,
+                            },
+                            span: 237..243,
+                        },
+                        Field {
+                            name: "y",
+                            value: Expr {
+                                id: e1,
+                                kind: Number(
+                                    0.0,
+                                ),
+                                span: 248..251,
+                            },
+                            span: 245..251,
+                        },
+                    ],
+                ),
+                span: 235..253,
+            },
+            span: 222..253,
+        },
+        Def {
+            id: d3,
+            name: "move",
+            value: Expr {
+                id: e18,
+                kind: Lambda {
+                    params: [
+                        Param {
+                            binding: b0,
+                            name: "p",
+                            ty: Some(
+                                TypeName {
+                                    name: "Position",
+                                    args: [],
+                                    span: 270..278,
+                                },
+                            ),
+                            span: 267..278,
+                        },
+                        Param {
+                            binding: b1,
+                            name: "v",
+                            ty: Some(
+                                TypeName {
+                                    name: "Velocity",
+                                    args: [],
+                                    span: 283..291,
+                                },
+                            ),
+                            span: 280..291,
+                        },
+                        Param {
+                            binding: b2,
+                            name: "dt",
+                            ty: Some(
+                                TypeName {
+                                    name: "Float",
+                                    args: [],
+                                    span: 297..302,
+                                },
+                            ),
+                            span: 293..302,
+                        },
+                    ],
+                    ret: Some(
+                        TypeName {
+                            name: "Position",
+                            args: [],
+                            span: 305..313,
+                        },
+                    ),
+                    body: Expr {
+                        id: e17,
+                        kind: Record(
+                            [
+                                Field {
+                                    name: "x",
+                                    value: Expr {
+                                        id: e9,
+                                        kind: Binary {
+                                            op: Add,
+                                            lhs: Expr {
+                                                id: e4,
+                                                kind: FieldAccess {
+                                                    object: Expr {
+                                                        id: e3,
+                                                        kind: Local {
+                                                            binding: b0,
+                                                            name: "p",
+                                                        },
+                                                        span: 324..325,
+                                                    },
+                                                    field: "x",
+                                                },
+                                                span: 324..327,
+                                            },
+                                            rhs: Expr {
+                                                id: e8,
+                                                kind: Binary {
+                                                    op: Mul,
+                                                    lhs: Expr {
+                                                        id: e6,
+                                                        kind: FieldAccess {
+                                                            object: Expr {
+                                                                id: e5,
+                                                                kind: Local {
+                                                                    binding: b1,
+                                                                    name: "v",
+                                                                },
+                                                                span: 330..331,
+                                                            },
+                                                            field: "dx",
+                                                        },
+                                                        span: 330..334,
+                                                    },
+                                                    rhs: Expr {
+                                                        id: e7,
+                                                        kind: Local {
+                                                            binding: b2,
+                                                            name: "dt",
+                                                        },
+                                                        span: 337..339,
+                                                    },
+                                                },
+                                                span: 330..339,
+                                            },
+                                        },
+                                        span: 324..339,
+                                    },
+                                    span: 321..339,
+                                },
+                                Field {
+                                    name: "y",
+                                    value: Expr {
+                                        id: e16,
+                                        kind: Binary {
+                                            op: Add,
+                                            lhs: Expr {
+                                                id: e11,
+                                                kind: FieldAccess {
+                                                    object: Expr {
+                                                        id: e10,
+                                                        kind: Local {
+                                                            binding: b0,
+                                                            name: "p",
+                                                        },
+                                                        span: 344..345,
+                                                    },
+                                                    field: "y",
+                                                },
+                                                span: 344..347,
+                                            },
+                                            rhs: Expr {
+                                                id: e15,
+                                                kind: Binary {
+                                                    op: Mul,
+                                                    lhs: Expr {
+                                                        id: e13,
+                                                        kind: FieldAccess {
+                                                            object: Expr {
+                                                                id: e12,
+                                                                kind: Local {
+                                                                    binding: b1,
+                                                                    name: "v",
+                                                                },
+                                                                span: 350..351,
+                                                            },
+                                                            field: "dy",
+                                                        },
+                                                        span: 350..354,
+                                                    },
+                                                    rhs: Expr {
+                                                        id: e14,
+                                                        kind: Local {
+                                                            binding: b2,
+                                                            name: "dt",
+                                                        },
+                                                        span: 357..359,
+                                                    },
+                                                },
+                                                span: 350..359,
+                                            },
+                                        },
+                                        span: 344..359,
+                                    },
+                                    span: 341..359,
+                                },
+                            ],
+                        ),
+                        span: 319..361,
+                    },
+                },
+                span: 266..361,
+            },
+            span: 255..361,
+        },
+        Def {
+            id: d4,
+            name: "delta",
+            value: Expr {
+                id: e30,
+                kind: Lambda {
+                    params: [
+                        Param {
+                            binding: b3,
+                            name: "a",
+                            ty: Some(
+                                TypeName {
+                                    name: "Position",
+                                    args: [],
+                                    span: 379..387,
+                                },
+                            ),
+                            span: 376..387,
+                        },
+                        Param {
+                            binding: b4,
+                            name: "b",
+                            ty: Some(
+                                TypeName {
+                                    name: "Position",
+                                    args: [],
+                                    span: 392..400,
+                                },
+                            ),
+                            span: 389..400,
+                        },
+                    ],
+                    ret: Some(
+                        TypeName {
+                            name: "Position",
+                            args: [],
+                            span: 403..411,
+                        },
+                    ),
+                    body: Expr {
+                        id: e29,
+                        kind: Record(
+                            [
+                                Field {
+                                    name: "x",
+                                    value: Expr {
+                                        id: e23,
+                                        kind: Binary {
+                                            op: Sub,
+                                            lhs: Expr {
+                                                id: e20,
+                                                kind: FieldAccess {
+                                                    object: Expr {
+                                                        id: e19,
+                                                        kind: Local {
+                                                            binding: b3,
+                                                            name: "a",
+                                                        },
+                                                        span: 422..423,
+                                                    },
+                                                    field: "x",
+                                                },
+                                                span: 422..425,
+                                            },
+                                            rhs: Expr {
+                                                id: e22,
+                                                kind: FieldAccess {
+                                                    object: Expr {
+                                                        id: e21,
+                                                        kind: Local {
+                                                            binding: b4,
+                                                            name: "b",
+                                                        },
+                                                        span: 428..429,
+                                                    },
+                                                    field: "x",
+                                                },
+                                                span: 428..431,
+                                            },
+                                        },
+                                        span: 422..431,
+                                    },
+                                    span: 419..431,
+                                },
+                                Field {
+                                    name: "y",
+                                    value: Expr {
+                                        id: e28,
+                                        kind: Binary {
+                                            op: Sub,
+                                            lhs: Expr {
+                                                id: e25,
+                                                kind: FieldAccess {
+                                                    object: Expr {
+                                                        id: e24,
+                                                        kind: Local {
+                                                            binding: b3,
+                                                            name: "a",
+                                                        },
+                                                        span: 436..437,
+                                                    },
+                                                    field: "y",
+                                                },
+                                                span: 436..439,
+                                            },
+                                            rhs: Expr {
+                                                id: e27,
+                                                kind: FieldAccess {
+                                                    object: Expr {
+                                                        id: e26,
+                                                        kind: Local {
+                                                            binding: b4,
+                                                            name: "b",
+                                                        },
+                                                        span: 442..443,
+                                                    },
+                                                    field: "y",
+                                                },
+                                                span: 442..445,
+                                            },
+                                        },
+                                        span: 436..445,
+                                    },
+                                    span: 433..445,
+                                },
+                            ],
+                        ),
+                        span: 417..447,
+                    },
+                },
+                span: 375..447,
+            },
+            span: 363..447,
+        },
+        Def {
+            id: d5,
+            name: "mirror",
+            value: Expr {
+                id: e37,
+                kind: Lambda {
+                    params: [
+                        Param {
+                            binding: b5,
+                            name: "p",
+                            ty: Some(
+                                TypeName {
+                                    name: "Position",
+                                    args: [],
+                                    span: 466..474,
+                                },
+                            ),
+                            span: 463..474,
+                        },
+                    ],
+                    ret: Some(
+                        TypeName {
+                            name: "Position",
+                            args: [],
+                            span: 477..485,
+                        },
+                    ),
+                    body: Expr {
+                        id: e36,
+                        kind: Record(
+                            [
+                                Field {
+                                    name: "x",
+                                    value: Expr {
+                                        id: e33,
+                                        kind: Neg(
+                                            Expr {
+                                                id: e32,
+                                                kind: FieldAccess {
+                                                    object: Expr {
+                                                        id: e31,
+                                                        kind: Local {
+                                                            binding: b5,
+                                                            name: "p",
+                                                        },
+                                                        span: 495..496,
+                                                    },
+                                                    field: "x",
+                                                },
+                                                span: 495..498,
+                                            },
+                                        ),
+                                        span: 494..498,
+                                    },
+                                    span: 491..498,
+                                },
+                                Field {
+                                    name: "y",
+                                    value: Expr {
+                                        id: e35,
+                                        kind: FieldAccess {
+                                            object: Expr {
+                                                id: e34,
+                                                kind: Local {
+                                                    binding: b5,
+                                                    name: "p",
+                                                },
+                                                span: 503..504,
+                                            },
+                                            field: "y",
+                                        },
+                                        span: 503..506,
+                                    },
+                                    span: 500..506,
+                                },
+                            ],
+                        ),
+                        span: 489..508,
+                    },
+                },
+                span: 462..508,
+            },
+            span: 449..508,
+        },
+        Def {
+            id: d6,
+            name: "isOrigin",
+            value: Expr {
+                id: e42,
+                kind: Lambda {
+                    params: [
+                        Param {
+                            binding: b6,
+                            name: "p",
+                            ty: Some(
+                                TypeName {
+                                    name: "Position",
+                                    args: [],
+                                    span: 529..537,
+                                },
+                            ),
+                            span: 526..537,
+                        },
+                    ],
+                    ret: Some(
+                        TypeName {
+                            name: "Bool",
+                            args: [],
+                            span: 540..544,
+                        },
+                    ),
+                    body: Expr {
+                        id: e41,
+                        kind: Binary {
+                            op: Eq,
+                            lhs: Expr {
+                                id: e39,
+                                kind: FieldAccess {
+                                    object: Expr {
+                                        id: e38,
+                                        kind: Local {
+                                            binding: b6,
+                                            name: "p",
+                                        },
+                                        span: 548..549,
+                                    },
+                                    field: "x",
+                                },
+                                span: 548..551,
+                            },
+                            rhs: Expr {
+                                id: e40,
+                                kind: Number(
+                                    0.0,
+                                ),
+                                span: 555..558,
+                            },
+                        },
+                        span: 548..558,
+                    },
+                },
+                span: 525..558,
+            },
+            span: 510..558,
+        },
+    ],
+}

--- a/mle/src/ast.rs
+++ b/mle/src/ast.rs
@@ -1,9 +1,9 @@
 //! Surface AST for the B1 syntax subset. Every node carries a [`Span`].
 //!
 //! Deliberately close to the source: pipelines stay explicit
-//! ([`ExprKind::Pipeline`]) rather than desugaring to nested calls — lowering
-//! is B2's job (the core IR), and keeping the surface shape makes error spans
-//! and future formatting honest.
+//! ([`ExprKind::Pipeline`]) rather than desugaring to nested calls — that is
+//! lowering's job ([`crate::lower`], the core IR), and keeping the surface
+//! shape makes error spans and future formatting honest.
 
 use crate::span::Span;
 

--- a/mle/src/ir.rs
+++ b/mle/src/ir.rs
@@ -1,0 +1,145 @@
+//! Core IR for the B2 milestone — the lowered, name-resolved form of a
+//! parsed program, produced by [`crate::lower`]. Differences from the
+//! surface AST:
+//!
+//! - **Stable IDs.** Every top-level item, lambda parameter, and expression
+//!   node carries a deterministic sequential ID assigned during lowering
+//!   (file order / traversal order), so the same source always produces
+//!   byte-identical IR. Top-level items *also* carry their name — the stable
+//!   name-based identity that future hot-reload rebinds on (docs/mle.md B5).
+//! - **Names are resolved** (see [`crate::lower`] for the rules): every
+//!   identifier is a [`ExprKind::Local`], [`ExprKind::Global`], or
+//!   [`ExprKind::External`] reference.
+//! - **No pipelines.** `x |> f |> g(a)` desugars to `g(f(x), a)` during
+//!   lowering (see [`crate::lower`]); the IR has no pipeline node.
+//! - **Spans everywhere.** Every node keeps the source span of the AST node
+//!   it came from.
+//! - **Type annotations stay symbolic** ([`TypeName`] carried through
+//!   verbatim) — no inference or checking until B4.
+
+use crate::ast::{BinOp, FieldTy, TypeName};
+use crate::span::Span;
+use std::fmt;
+
+/// ID of a top-level item ([`TypeDef`] or [`Def`]), assigned in file order.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct DefId(pub(crate) u32);
+
+/// ID of a value binding (a lambda parameter), assigned in traversal order.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct BindingId(pub(crate) u32);
+
+/// ID of an expression node, assigned in traversal order.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct ExprId(pub(crate) u32);
+
+// Compact `d0` / `b0` / `e0` forms keep the pretty-Debug IR (and the
+// committed `.ir` goldens) readable, like `Span`'s `start..end`.
+impl fmt::Debug for DefId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "d{}", self.0)
+    }
+}
+
+impl fmt::Debug for BindingId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "b{}", self.0)
+    }
+}
+
+impl fmt::Debug for ExprId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "e{}", self.0)
+    }
+}
+
+/// A lowered source file. Item order within each list is file order;
+/// [`DefId`]s number types and defs together, also in file order.
+#[derive(Debug)]
+pub struct Module {
+    pub types: Vec<TypeDef>,
+    pub defs: Vec<Def>,
+}
+
+/// `type Position = { x: Float, y: Float }` — fields keep their symbolic
+/// [`TypeName`]s; other types reference this one by name.
+#[derive(Debug)]
+pub struct TypeDef {
+    pub id: DefId,
+    pub name: String,
+    pub fields: Vec<FieldTy>,
+    pub span: Span,
+}
+
+/// A lowered top-level `let`. `name` is the def's stable identity.
+#[derive(Debug)]
+pub struct Def {
+    pub id: DefId,
+    pub name: String,
+    pub value: Expr,
+    pub span: Span,
+}
+
+#[derive(Debug)]
+pub struct Expr {
+    pub id: ExprId,
+    pub kind: ExprKind,
+    pub span: Span,
+}
+
+#[derive(Debug)]
+pub enum ExprKind {
+    Number(f64),
+    String(String),
+    Bool(bool),
+    /// Reference to an enclosing lambda's parameter. `name` duplicates the
+    /// binding's name for readability; `binding` is authoritative.
+    Local {
+        binding: BindingId,
+        name: String,
+    },
+    /// Reference to a top-level `let` in the same file.
+    Global(String),
+    /// A qualified name (`Text.toBullets`) that resolved to nothing in this
+    /// file — kept symbolic until the builtin registry arrives in B3.
+    External(Vec<String>),
+    /// `{ x: 1.0, y: 2.0 }`
+    Record(Vec<Field>),
+    /// `position.x`
+    FieldAccess {
+        object: Box<Expr>,
+        field: String,
+    },
+    Lambda {
+        params: Vec<Param>,
+        ret: Option<TypeName>,
+        body: Box<Expr>,
+    },
+    Call {
+        callee: Box<Expr>,
+        args: Vec<Expr>,
+    },
+    Binary {
+        op: BinOp,
+        lhs: Box<Expr>,
+        rhs: Box<Expr>,
+    },
+    Neg(Box<Expr>),
+}
+
+/// One `name: value` entry of a record expression.
+#[derive(Debug)]
+pub struct Field {
+    pub name: String,
+    pub value: Expr,
+    pub span: Span,
+}
+
+/// A lambda parameter: its binding ID plus the annotation B1 parsed.
+#[derive(Debug)]
+pub struct Param {
+    pub binding: BindingId,
+    pub name: String,
+    pub ty: Option<TypeName>,
+    pub span: Span,
+}

--- a/mle/src/lib.rs
+++ b/mle/src/lib.rs
@@ -1,15 +1,19 @@
-//! MLE surface parser — Track B1 of `docs/mle.md`.
+//! MLE surface parser and core IR — Tracks B1 + B2 of `docs/mle.md`.
 //!
 //! Lexer + hand-rolled recursive-descent parser producing a surface AST in
 //! which every node carries a byte-offset [`Span`] (line/col derive from the
-//! source via [`line_col`]). Parser only: no IR, no name resolution, no
-//! typechecking, no evaluation — those are milestones B2+.
+//! source via [`line_col`]), and a lowering pass ([`lower`]) from that AST to
+//! the name-resolved core IR ([`ir`]). No typechecking, no evaluation —
+//! those are milestones B3+.
 
 pub mod ast;
+pub mod ir;
 mod lexer;
+mod lower;
 mod parser;
 mod span;
 
+pub use lower::lower;
 pub use parser::parse;
 pub use span::{line_col, Span};
 
@@ -17,6 +21,14 @@ pub use span::{line_col, Span};
 /// Render positions with [`line_col`] (`file:line:col: message`).
 #[derive(Debug)]
 pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+}
+
+/// A lowering failure (e.g. an unresolved name): same shape and rendering as
+/// [`ParseError`].
+#[derive(Debug)]
+pub struct LowerError {
     pub message: String,
     pub span: Span,
 }

--- a/mle/src/lower.rs
+++ b/mle/src/lower.rs
@@ -1,0 +1,264 @@
+//! AST → core-IR lowering — Track B2 of `docs/mle.md`. Assigns stable IDs,
+//! resolves names, and desugars pipelines. No typechecking, no evaluation.
+//!
+//! ## Top-level visibility
+//!
+//! Top-level `let`s are **mutually visible**: a def may reference another def
+//! declared later in the file (top-level bindings behave letrec-style, as in
+//! other functional languages), so definition order never forces a
+//! topological rewrite of game code. Because a def's *name* is its stable
+//! identity (the hot-reload rebind key, docs/mle.md B5), duplicate top-level
+//! names are lowering errors rather than shadowing.
+//!
+//! ## Name resolution
+//!
+//! For an identifier `first(.rest)*` (the parser only builds multi-segment
+//! names while the qualifier segment starts uppercase — see
+//! [`crate::ast::ExprKind::Ident`]):
+//!
+//! - `first` names an enclosing lambda parameter → [`ExprKind::Local`]
+//!   (innermost scope wins, so a parameter shadows a same-named global);
+//!   any remaining segments become [`ExprKind::FieldAccess`] on it.
+//! - `first` names a top-level `let` → [`ExprKind::Global`]; remaining
+//!   segments likewise become field access.
+//! - Otherwise, a qualified name (`Text.toBullets`) → [`ExprKind::External`],
+//!   kept symbolic until the builtin registry arrives in B3 — and an
+//!   unqualified name is an "unknown name" error at the identifier's span.
+//!
+//! ## Pipeline desugaring
+//!
+//! Each pipeline stage becomes a call with the piped value **prepended** as
+//! the first argument: `x |> f` → `f(x)`, `x |> g(a)` → `g(x, a)`, so
+//! `x |> f |> g(a)` → `g(f(x), a)`. The desugared call carries the span of
+//! its stage. The IR has no pipeline node.
+
+use crate::ast;
+use crate::ir::*;
+use crate::span::Span;
+use crate::LowerError;
+use std::collections::HashSet;
+
+/// Lower a parsed [`ast::Program`] to an IR [`Module`].
+pub fn lower(program: ast::Program) -> Result<Module, LowerError> {
+    // Pass 1: collect top-level names so defs are mutually visible (see
+    // module docs) and duplicates fail loud. Types and values are separate
+    // namespaces.
+    let mut globals = HashSet::new();
+    let mut type_names = HashSet::new();
+    for item in &program.items {
+        let (names, name, span) = match item {
+            ast::Item::Let(decl) => (&mut globals, &decl.name, decl.span),
+            ast::Item::Type(decl) => (&mut type_names, &decl.name, decl.span),
+        };
+        if !names.insert(name.clone()) {
+            return Err(LowerError {
+                message: format!("duplicate definition `{name}`"),
+                span,
+            });
+        }
+    }
+
+    // Pass 2: lower items in file order.
+    let mut lowerer = Lowerer {
+        globals,
+        scopes: Vec::new(),
+        next_binding: 0,
+        next_expr: 0,
+    };
+    let mut types = Vec::new();
+    let mut defs = Vec::new();
+    for (index, item) in program.items.into_iter().enumerate() {
+        let id = DefId(index as u32);
+        match item {
+            ast::Item::Type(decl) => types.push(TypeDef {
+                id,
+                name: decl.name,
+                fields: decl.fields,
+                span: decl.span,
+            }),
+            ast::Item::Let(decl) => defs.push(Def {
+                id,
+                name: decl.name,
+                value: lowerer.expr(decl.value)?,
+                span: decl.span,
+            }),
+        }
+    }
+    Ok(Module { types, defs })
+}
+
+struct Lowerer {
+    globals: HashSet<String>,
+    /// One scope per enclosing lambda; lookup walks innermost-first.
+    scopes: Vec<Vec<(String, BindingId)>>,
+    next_binding: u32,
+    next_expr: u32,
+}
+
+impl Lowerer {
+    fn expr_id(&mut self) -> ExprId {
+        let id = ExprId(self.next_expr);
+        self.next_expr += 1;
+        id
+    }
+
+    // Recursion depth is bounded by the parser's `MAX_DEPTH` guard, so
+    // lowering needs no depth check of its own.
+    fn expr(&mut self, expr: ast::Expr) -> Result<Expr, LowerError> {
+        let span = expr.span;
+        let kind = match expr.kind {
+            ast::ExprKind::Ident(segments) => return self.ident(segments, span),
+            ast::ExprKind::Pipeline { head, stages } => {
+                let mut piped = self.expr(*head)?;
+                for stage in stages {
+                    piped = self.pipe_stage(piped, stage)?;
+                }
+                return Ok(piped);
+            }
+            ast::ExprKind::Number(n) => ExprKind::Number(n),
+            ast::ExprKind::String(s) => ExprKind::String(s),
+            ast::ExprKind::Bool(b) => ExprKind::Bool(b),
+            ast::ExprKind::Record(fields) => {
+                let mut lowered = Vec::new();
+                for field in fields {
+                    lowered.push(Field {
+                        name: field.name,
+                        value: self.expr(field.value)?,
+                        span: field.span,
+                    });
+                }
+                ExprKind::Record(lowered)
+            }
+            ast::ExprKind::FieldAccess { object, field } => ExprKind::FieldAccess {
+                object: Box::new(self.expr(*object)?),
+                field,
+            },
+            ast::ExprKind::Lambda { params, ret, body } => {
+                let mut scope = Vec::new();
+                let mut lowered = Vec::new();
+                for param in params {
+                    let binding = BindingId(self.next_binding);
+                    self.next_binding += 1;
+                    scope.push((param.name.clone(), binding));
+                    lowered.push(Param {
+                        binding,
+                        name: param.name,
+                        ty: param.ty,
+                        span: param.span,
+                    });
+                }
+                self.scopes.push(scope);
+                let body = self.expr(*body);
+                self.scopes.pop();
+                ExprKind::Lambda {
+                    params: lowered,
+                    ret,
+                    body: Box::new(body?),
+                }
+            }
+            ast::ExprKind::Call { callee, args } => {
+                let callee = Box::new(self.expr(*callee)?);
+                let mut lowered = Vec::new();
+                for arg in args {
+                    lowered.push(self.expr(arg)?);
+                }
+                ExprKind::Call {
+                    callee,
+                    args: lowered,
+                }
+            }
+            ast::ExprKind::Binary { op, lhs, rhs } => ExprKind::Binary {
+                op,
+                lhs: Box::new(self.expr(*lhs)?),
+                rhs: Box::new(self.expr(*rhs)?),
+            },
+            ast::ExprKind::Neg(inner) => ExprKind::Neg(Box::new(self.expr(*inner)?)),
+        };
+        Ok(Expr {
+            id: self.expr_id(),
+            kind,
+            span,
+        })
+    }
+
+    /// Desugar one pipeline stage (see module docs): the already-lowered
+    /// `piped` value becomes the first argument of the stage's call.
+    fn pipe_stage(&mut self, piped: Expr, stage: ast::Expr) -> Result<Expr, LowerError> {
+        let span = stage.span;
+        let (callee, rest) = match stage.kind {
+            // `x |> g(a)` → `g(x, a)`
+            ast::ExprKind::Call { callee, args } => (*callee, args),
+            // `x |> f` → `f(x)` (any non-call stage is called directly)
+            kind => (ast::Expr { kind, span }, Vec::new()),
+        };
+        let callee = Box::new(self.expr(callee)?);
+        let mut args = vec![piped];
+        for arg in rest {
+            args.push(self.expr(arg)?);
+        }
+        Ok(Expr {
+            id: self.expr_id(),
+            kind: ExprKind::Call { callee, args },
+            span,
+        })
+    }
+
+    /// Resolve an identifier per the module-doc rules. Every node of a
+    /// reinterpreted field-access chain keeps the whole identifier's span
+    /// (the AST node it came from).
+    fn ident(&mut self, segments: Vec<String>, span: Span) -> Result<Expr, LowerError> {
+        let first = &segments[0];
+        let base = if let Some(binding) = self.lookup(first) {
+            Some(ExprKind::Local {
+                binding,
+                name: first.clone(),
+            })
+        } else if self.globals.contains(first) {
+            Some(ExprKind::Global(first.clone()))
+        } else {
+            None
+        };
+        let kind = match base {
+            Some(kind) => kind,
+            None if segments.len() > 1 => {
+                return Ok(Expr {
+                    id: self.expr_id(),
+                    kind: ExprKind::External(segments),
+                    span,
+                })
+            }
+            None => {
+                return Err(LowerError {
+                    message: format!("unknown name `{first}`"),
+                    span,
+                })
+            }
+        };
+        let mut expr = Expr {
+            id: self.expr_id(),
+            kind,
+            span,
+        };
+        // `Foo.bar` where `Foo` is a binding: the qualifier syntax was really
+        // field access on that value (see `ast::ExprKind::Ident`).
+        for field in segments.into_iter().skip(1) {
+            expr = Expr {
+                id: self.expr_id(),
+                kind: ExprKind::FieldAccess {
+                    object: Box::new(expr),
+                    field,
+                },
+                span,
+            };
+        }
+        Ok(expr)
+    }
+
+    fn lookup(&self, name: &str) -> Option<BindingId> {
+        self.scopes
+            .iter()
+            .rev()
+            .find_map(|scope| scope.iter().rev().find(|(n, _)| n == name))
+            .map(|(_, binding)| *binding)
+    }
+}

--- a/mle/src/lower.rs
+++ b/mle/src/lower.rs
@@ -8,7 +8,11 @@
 //! other functional languages), so definition order never forces a
 //! topological rewrite of game code. Because a def's *name* is its stable
 //! identity (the hot-reload rebind key, docs/mle.md B5), duplicate top-level
-//! names are lowering errors rather than shadowing.
+//! names are lowering errors rather than shadowing. Types and values are
+//! **separate namespaces** (as in F#/OCaml): `type Foo` and `let Foo` may
+//! coexist — each namespace keys its own identities — but a duplicate within
+//! either namespace is an error. Duplicate parameter names within one lambda
+//! are errors for the same reason (the last one would silently win).
 //!
 //! ## Name resolution
 //!
@@ -30,7 +34,9 @@
 //! Each pipeline stage becomes a call with the piped value **prepended** as
 //! the first argument: `x |> f` → `f(x)`, `x |> g(a)` → `g(x, a)`, so
 //! `x |> f |> g(a)` → `g(f(x), a)`. The desugared call carries the span of
-//! its stage. The IR has no pipeline node.
+//! its stage — which means its first argument's span lies *outside* the
+//! call's own span (it came from an earlier stage); diagnostics must not
+//! assume parent spans contain child spans. The IR has no pipeline node.
 
 use crate::ast;
 use crate::ir::*;
@@ -134,9 +140,15 @@ impl Lowerer {
                 field,
             },
             ast::ExprKind::Lambda { params, ret, body } => {
-                let mut scope = Vec::new();
+                let mut scope: Vec<(String, BindingId)> = Vec::new();
                 let mut lowered = Vec::new();
                 for param in params {
+                    if scope.iter().any(|(n, _)| *n == param.name) {
+                        return Err(LowerError {
+                            message: format!("duplicate parameter `{}`", param.name),
+                            span: param.span,
+                        });
+                    }
                     let binding = BindingId(self.next_binding);
                     self.next_binding += 1;
                     scope.push((param.name.clone(), binding));

--- a/mle/src/main.rs
+++ b/mle/src/main.rs
@@ -1,18 +1,19 @@
-//! The `mle` CLI. B1 exposes one subcommand:
+//! The `mle` CLI. Two subcommands:
 //!
 //! ```text
-//! mle parse <file.mle>
+//! mle parse <file.mle>   # print the surface AST (pretty-Debug)
+//! mle ir <file.mle>      # parse + lower; print the core IR (pretty-Debug)
 //! ```
 //!
-//! Prints the surface AST (pretty-Debug) on success; on failure prints
-//! `file:line:col: error: message` to stderr and exits nonzero.
+//! On failure (parse or lowering) prints `file:line:col: error: message` to
+//! stderr and exits nonzero.
 
 use std::process::exit;
 
 fn main() {
     let args: Vec<String> = std::env::args().skip(1).collect();
     match args.as_slice() {
-        [command, path] if command == "parse" => {
+        [command, path] if command == "parse" || command == "ir" => {
             let src = match std::fs::read_to_string(path) {
                 Ok(src) => src,
                 Err(err) => {
@@ -20,18 +21,28 @@ fn main() {
                     exit(1);
                 }
             };
-            match mle::parse(&src) {
-                Ok(program) => println!("{program:#?}"),
-                Err(err) => {
-                    let (line, col) = mle::line_col(&src, err.span.start);
-                    eprintln!("{path}:{line}:{col}: error: {}", err.message);
-                    exit(1);
-                }
+            let program = match mle::parse(&src) {
+                Ok(program) => program,
+                Err(err) => fail(path, &src, err.span, &err.message),
+            };
+            if command == "parse" {
+                println!("{program:#?}");
+                return;
+            }
+            match mle::lower(program) {
+                Ok(module) => println!("{module:#?}"),
+                Err(err) => fail(path, &src, err.span, &err.message),
             }
         }
         _ => {
-            eprintln!("usage: mle parse <file.mle>");
+            eprintln!("usage: mle <parse|ir> <file.mle>");
             exit(2);
         }
     }
+}
+
+fn fail(path: &str, src: &str, span: mle::Span, message: &str) -> ! {
+    let (line, col) = mle::line_col(src, span.start);
+    eprintln!("{path}:{line}:{col}: error: {message}");
+    exit(1);
 }

--- a/mle/tests/ir.rs
+++ b/mle/tests/ir.rs
@@ -184,3 +184,21 @@ fn pipeline_desugars_to_nested_calls() {
     );
     assert_eq!(&src[inner.span.start..inner.span.end], "f");
 }
+
+#[test]
+fn error_duplicate_parameter() {
+    let (message, line, col) = lower_err("let f = (a, a) => a");
+    assert_eq!(message, "duplicate parameter `a`");
+    assert_eq!((line, col), (1, 13));
+}
+
+// Types and values are separate namespaces (as in F#/OCaml) — `type Foo` and
+// `let Foo` coexist; each namespace keys its own hot-reload identities.
+#[test]
+fn type_and_let_may_share_a_name() {
+    let module = lower_src("type Foo = { x: Float }\nlet Foo = 1");
+    assert_eq!(module.types.len(), 1);
+    assert_eq!(module.defs.len(), 1);
+    assert_eq!(module.types[0].name, "Foo");
+    assert_eq!(module.defs[0].name, "Foo");
+}

--- a/mle/tests/ir.rs
+++ b/mle/tests/ir.rs
@@ -1,0 +1,186 @@
+//! B2 verification (docs/mle.md): IR snapshot goldens per example,
+//! lowering determinism, name-resolution error + span assertions, and the
+//! pipeline-desugar shape.
+
+use mle::ir::{Expr, ExprKind, Module};
+use std::fs;
+use std::path::Path;
+
+/// Parse + lower `src`, panicking with a rendered position on failure.
+fn lower_src(src: &str) -> Module {
+    let program = mle::parse(src).expect("source should parse");
+    match mle::lower(program) {
+        Ok(module) => module,
+        Err(err) => {
+            let (line, col) = mle::line_col(src, err.span.start);
+            panic!("{line}:{col}: error: {}", err.message);
+        }
+    }
+}
+
+/// Lower `examples/{name}.mle` and compare the pretty-Debug IR against the
+/// committed `examples/{name}.ir` golden.
+/// Regenerate with `UPDATE_GOLDENS=1 cargo test -p mle`.
+fn check_golden(name: &str) {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("examples");
+    let src = fs::read_to_string(dir.join(format!("{name}.mle"))).unwrap();
+    let golden_path = dir.join(format!("{name}.ir"));
+    let actual = format!("{:#?}\n", lower_src(&src));
+    if std::env::var_os("UPDATE_GOLDENS").is_some() {
+        fs::write(&golden_path, &actual).unwrap();
+        return;
+    }
+    let expected = fs::read_to_string(&golden_path).unwrap_or_else(|_| {
+        panic!(
+            "missing golden {} — generate with UPDATE_GOLDENS=1 cargo test -p mle",
+            golden_path.display()
+        )
+    });
+    assert_eq!(
+        actual, expected,
+        "IR for {name}.mle diverged from {name}.ir — if intended, \
+         regenerate with UPDATE_GOLDENS=1 cargo test -p mle"
+    );
+}
+
+#[test]
+fn golden_pure_pipeline() {
+    check_golden("pure-pipeline");
+}
+
+#[test]
+fn golden_records() {
+    check_golden("records");
+}
+
+#[test]
+fn golden_functions() {
+    check_golden("functions");
+}
+
+/// Same source must always produce byte-identical IR (stable IDs are
+/// sequential, never random or time-based).
+#[test]
+fn lowering_is_deterministic() {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("examples");
+    let src = fs::read_to_string(dir.join("functions.mle")).unwrap();
+    let first = format!("{:#?}", lower_src(&src));
+    let second = format!("{:#?}", lower_src(&src));
+    assert_eq!(first, second);
+}
+
+/// Lower a deliberately broken input; return the error's (message, line, col).
+fn lower_err(src: &str) -> (String, usize, usize) {
+    let program = mle::parse(src).expect("source should parse");
+    let err = mle::lower(program).expect_err("source should fail to lower");
+    let (line, col) = mle::line_col(src, err.span.start);
+    (err.message, line, col)
+}
+
+#[test]
+fn error_unknown_name() {
+    assert_eq!(
+        lower_err("let f = (a) => a + b"),
+        ("unknown name `b`".to_string(), 1, 20)
+    );
+}
+
+/// A lowering error's position points at the offending identifier itself.
+#[test]
+fn error_span_points_at_identifier() {
+    assert_eq!(
+        lower_err("let f = (a) =>\n  velocity * a"),
+        ("unknown name `velocity`".to_string(), 2, 3)
+    );
+}
+
+/// Duplicate top-level names are errors: a def's name is its stable identity
+/// (the hot-reload rebind key), so shadowing at the top level is not allowed.
+#[test]
+fn error_duplicate_definition() {
+    assert_eq!(
+        lower_err("let a = 1\nlet a = 2"),
+        ("duplicate definition `a`".to_string(), 2, 1)
+    );
+}
+
+/// The lambda body of `defs[index]`, as (params, body).
+fn lambda_body(module: &Module, index: usize) -> (&[mle::ir::Param], &Expr) {
+    let ExprKind::Lambda { params, body, .. } = &module.defs[index].value.kind else {
+        panic!("expected def {index} to be a lambda");
+    };
+    (params, body)
+}
+
+/// A parameter named like a global resolves to the parameter, not the global.
+#[test]
+fn param_shadows_global() {
+    let module = lower_src("let speed = 1.0\nlet f = (speed) => speed");
+    let (params, body) = lambda_body(&module, 1);
+    let ExprKind::Local { binding, name } = &body.kind else {
+        panic!("expected the body to resolve to a local, got {body:?}");
+    };
+    assert_eq!(name, "speed");
+    assert_eq!(*binding, params[0].binding);
+}
+
+/// Top-level defs are mutually visible: a def may call one declared later in
+/// the file.
+#[test]
+fn global_resolves_before_its_definition() {
+    let module = lower_src("let first = () => second()\nlet second = () => 1.0");
+    let (_, body) = lambda_body(&module, 0);
+    let ExprKind::Call { callee, .. } = &body.kind else {
+        panic!("expected a call, got {body:?}");
+    };
+    assert!(matches!(&callee.kind, ExprKind::Global(name) if name == "second"));
+}
+
+/// `Pos.x` parses as a qualified name (uppercase qualifier), but when `Pos`
+/// is a binding it must resolve to field access on it, not an external.
+#[test]
+fn qualified_name_on_binding_is_field_access() {
+    let module = lower_src("let getX = (Pos) => Pos.x");
+    let (params, body) = lambda_body(&module, 0);
+    let ExprKind::FieldAccess { object, field } = &body.kind else {
+        panic!("expected field access, got {body:?}");
+    };
+    assert_eq!(field, "x");
+    let ExprKind::Local { binding, .. } = &object.kind else {
+        panic!("expected the object to be a local, got {object:?}");
+    };
+    assert_eq!(*binding, params[0].binding);
+}
+
+/// `a |> f |> g(b)` desugars to `g(f(a), b)`: each stage becomes a call with
+/// the piped value prepended as the first argument, no pipeline node remains,
+/// and each desugared call carries the span of its stage.
+#[test]
+fn pipeline_desugars_to_nested_calls() {
+    let src = "let f = (x) => x\nlet g = (x, y) => x\nlet r = (a, b) => a |> f |> g(b)";
+    let module = lower_src(src);
+    let (params, body) = lambda_body(&module, 2);
+
+    // Outer call: g(<inner>, b), with the span of the `g(b)` stage.
+    let ExprKind::Call { callee, args } = &body.kind else {
+        panic!("expected a call, got {body:?}");
+    };
+    assert!(matches!(&callee.kind, ExprKind::Global(name) if name == "g"));
+    assert_eq!(args.len(), 2);
+    assert!(
+        matches!(&args[1].kind, ExprKind::Local { binding, .. } if *binding == params[1].binding)
+    );
+    assert_eq!(&src[body.span.start..body.span.end], "g(b)");
+
+    // Inner call: f(a), with the span of the `f` stage.
+    let inner = &args[0];
+    let ExprKind::Call { callee, args } = &inner.kind else {
+        panic!("expected the first argument to be a call, got {inner:?}");
+    };
+    assert!(matches!(&callee.kind, ExprKind::Global(name) if name == "f"));
+    assert_eq!(args.len(), 1);
+    assert!(
+        matches!(&args[0].kind, ExprKind::Local { binding, .. } if *binding == params[0].binding)
+    );
+    assert_eq!(&src[inner.span.start..inner.span.end], "f");
+}


### PR DESCRIPTION
## What

Track **B2** of `docs/mle.md`: `mle/src/ir.rs` + `mle/src/lower.rs` — the surface AST lowers to a core IR, plus an `mle ir <file.mle>` CLI subcommand and `.ir` goldens next to the examples.

- **Stable IDs** on every def/param/expression (deterministic post-order counters); top-level defs also carry their **name** as the stable identity that B5's hot-reload rebind will key on.
- **Name resolution:** lambda params → `Local(binding)` (innermost wins, shadowing works); top-level defs → `Global(name)`, **mutually visible** letrec-style (a def may call one declared later); qualified names (`List.map`) stay symbolic `External` until B3's registry; unknown unqualified names are spanned errors. Types and values are **separate namespaces** (as in F#/OCaml), each keying its own identities; duplicates *within* a namespace — and duplicate lambda params — are errors.
- **Pipeline desugaring:** piped value prepended as first argument (`x |> f |> g(a)` → `g(f(x), a)`); no pipeline node in the IR; desugared calls carry their stage's span (documented caveat: that span doesn't contain the first argument's).
- Spans on every IR node; type annotations carried symbolically (no inference — that's B4).

## Verification

- `cargo test -p mle` — **25/25** (12 B1 parser tests unchanged + 13 IR: 3 goldens with `UPDATE_GOLDENS=1` regen, determinism, desugar shape, shadowing, forward reference, duplicate def/param errors, namespace pin, error-span accuracy). fmt + clippy clean.
- CLI: `mle ir` prints readable IR (exit 0); parse/lowering errors print `file:line:col: error: msg` (exit 1).
- Cross-engine review (/xreview, Claude + Codex): no Critical/High. Fixes applied: duplicate lambda params now error ([verified-by-execution] Claude finding), and the type/value namespace contradiction both engines flagged is resolved + documented + pinned.

## Notes

- Two example programs gained qualified stdlib names (`List.map` vs `map`) to be honest under the resolution rules; their `.ast` goldens were regenerated via the sanctioned flow.
- Stacked purely on `main` (B1 merged as #155). Next: B3 (interpreter + run/trace over this IR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)