### PR TITLE
feat(mle): B4 — gradual annotation-based typechecking, mle check

### DIFF
--- a/docs/mle.md
+++ b/docs/mle.md
@@ -153,8 +153,20 @@ snapshots — no GPU, fully agent-verifiable.
       values — kept even when the run fails. *Verify:* `.run` goldens per
       example, a `.trace` golden, and a semantics/runtime-error suite
       (closures, late binding, arity, depth caps, NaN policy). (done)
-- [ ] **B4. Basic types.** Primitives, records, function signatures, mismatch
-      diagnostics. *Verify:* diagnostic snapshots on broken examples.
+- [x] **B4. Basic types.** Gradual checking over the core IR (`mle check`),
+      with annotations, not inference: primitives (`Float`/`String`/`Bool`),
+      nominal declared record types, `List<T>`, and function types from
+      lambda annotations. Anything unannotated or unrecognized (e.g. a
+      generic parameter) is Unknown, and a check fires only where both sides
+      are known — so unannotated code never false-positives. Checks:
+      arithmetic/comparison/`==`/negation operand types, record literals and
+      field access against declared record types, call arity + argument
+      types (builtins carry real signatures with generic slots as Unknown),
+      return-annotation mismatches, and type-argument arity. `mle run` stays
+      check-free (integration comes later). *Verify:* `examples/broken.mle`
+      + committed `broken.check` diagnostic golden (all diagnostics, sorted,
+      `file:line:col`); per-diagnostic message/span unit tests; the three
+      examples check clean. (done)
 - [ ] **B5. Match/ADTs + storable closures.** The game-logic essentials;
       closures serialize as `(stable-id, env)`. *Verify:* serialize a value
       graph containing a closure → deserialize → call it; rename-then-restore

--- a/docs/mle.md
+++ b/docs/mle.md
@@ -174,6 +174,20 @@ snapshots — no GPU, fully agent-verifiable.
 - [ ] **B6. Minimal effect broker.** `Clock.Now`, `Random` with real/fake/replay
       handlers. *Verify:* same program under real vs fake vs replay; structured
       effect log.
+- [ ] **B7. Hindley–Milner inference** (decided 2026-07-02; **after effects
+      land** — B6 + the `effect[...]` header checking, so type inference and
+      effect rows are designed against each other, not retrofitted). Upgrade
+      the B4 gradual checker to real inference: type variables + unification,
+      let-polymorphism, and generic instantiation (element types flow through
+      `List.map`; `Unknown` shrinks to genuinely-dynamic seams like host
+      values). Gates to clear first: the nominal-vs-structural record
+      decision (B4 checks nominally, the runtime is structural — inference
+      with teeth needs one answer), and unification-error UX (every mismatch
+      must cite the source spans of *both* sides — legible errors were the
+      reason annotations came first; see `~/notes` `open-questions.md`).
+      *Verify:* unannotated examples get full inferred signatures (an
+      `mle types` dump, goldened); the B4 diagnostic suite still passes;
+      probe battery re-run (no legal program rejected).
 
 ## Track C — MLE as a second producer behind the seam
 

--- a/mle/examples/broken.check
+++ b/mle/examples/broken.check
@@ -1,0 +1,11 @@
+broken.mle:8:36: error: `+` needs Float operands, got String
+broken.mle:10:37: error: `>` needs Float operands, got Bool
+broken.mle:13:39: error: unary `-` needs a Float operand, got Bool
+broken.mle:16:13: error: `==` compares different types Float and String (always false)
+broken.mle:20:36: error: record literal for `Position` is missing field `y`
+broken.mle:20:44: error: `Position` has no field `z`
+broken.mle:23:36: error: `Position` has no field `z`
+broken.mle:27:13: error: `shift` takes 2 argument(s), got 1
+broken.mle:28:37: error: argument 2 of `shift`: expected Float, got String
+broken.mle:31:25: error: argument 1 of `Text.concat`: expected String, got Float
+broken.mle:35:17: error: `Position` takes 0 type argument(s), got 1

--- a/mle/examples/broken.mle
+++ b/mle/examples/broken.mle
@@ -1,0 +1,35 @@
+// Deliberately broken — exercises the B4 checker's diagnostics. The
+// committed broken.check golden pins the full `mle check` output; this file
+// is NOT covered by the parse/ir/run goldens (it never runs).
+
+type Position = { x: Float, y: Float }
+
+// Arithmetic and comparison operands must be Float when known.
+let bad = (a: Float): Float => a + "one"
+
+let compare = (flag: Bool): Bool => flag > 1.0
+
+// Unary minus needs a Float.
+let negated = (flag: Bool): Float => -flag
+
+// `==` across two different known types is always false.
+let never = 1.0 == "1"
+
+// A record literal checked against the return annotation: `z` is not a
+// field of Position, and `y` is missing.
+let make = (x: Float): Position => { x: x, z: 0.0 }
+
+// Field access on a known record type.
+let getZ = (p: Position): Float => p.z
+
+// Calls with a known signature: arity and argument types.
+let shift = (p: Position, dx: Float): Position => { x: p.x + dx, y: p.y }
+let moved = shift({ x: 1.0, y: 2.0 })
+let far = shift({ x: 1.0, y: 2.0 }, "far")
+
+// Builtins have real signatures too.
+let shout = Text.concat(1.0, "!")
+
+// A known type name applied at the wrong arity (an *unknown* name would be
+// fine — it could be a generic parameter).
+let scale = (p: Position<Float>): Position => p

--- a/mle/src/eval.rs
+++ b/mle/src/eval.rs
@@ -637,8 +637,10 @@ fn value_eq(a: &Value, b: &Value, span: Span) -> Result<bool, RunError> {
     }
 }
 
-/// The trace label for a call site, from its callee's IR shape.
-fn callee_label(callee: &Expr) -> String {
+/// The trace label for a call site, from its callee's IR shape. Also used by
+/// the typechecker ([`crate::types`]) so its call diagnostics name callees
+/// the same way.
+pub(crate) fn callee_label(callee: &Expr) -> String {
     match &callee.kind {
         ExprKind::Global(name) => name.clone(),
         ExprKind::Local { name, .. } => name.clone(),

--- a/mle/src/lib.rs
+++ b/mle/src/lib.rs
@@ -1,11 +1,12 @@
-//! MLE surface parser, core IR, and interpreter — Tracks B1–B3 of
-//! `docs/mle.md`.
+//! MLE surface parser, core IR, interpreter, and typechecker — Tracks B1–B4
+//! of `docs/mle.md`.
 //!
 //! Lexer + hand-rolled recursive-descent parser producing a surface AST in
 //! which every node carries a byte-offset [`Span`] (line/col derive from the
 //! source via [`line_col`]); a lowering pass ([`lower`]) from that AST to the
-//! name-resolved core IR ([`ir`]); and a tree-walking interpreter over the IR
-//! ([`eval`]) with an optional call trace. No typechecking — that is B4.
+//! name-resolved core IR ([`ir`]); a tree-walking interpreter over the IR
+//! ([`eval`]) with an optional call trace; and a gradual typechecker over the
+//! IR ([`types`]) — checking with annotations, not inference.
 
 pub mod ast;
 pub mod eval;
@@ -14,6 +15,7 @@ mod lexer;
 mod lower;
 mod parser;
 mod span;
+pub mod types;
 pub mod value;
 
 pub use eval::{
@@ -22,6 +24,7 @@ pub use eval::{
 pub use lower::lower;
 pub use parser::parse;
 pub use span::{line_col, Span};
+pub use types::check;
 pub use value::{HostData, Value};
 
 /// A lex or parse failure: a message plus the span of the offending source.
@@ -44,6 +47,15 @@ pub struct LowerError {
 /// non-function, …): same shape and rendering as [`ParseError`].
 #[derive(Debug)]
 pub struct RunError {
+    pub message: String,
+    pub span: Span,
+}
+
+/// One typechecking diagnostic: same shape and rendering as [`ParseError`].
+/// Unlike the other error kinds, [`check`] collects *all* of them rather
+/// than stopping at the first.
+#[derive(Debug)]
+pub struct CheckError {
     pub message: String,
     pub span: Span,
 }

--- a/mle/src/main.rs
+++ b/mle/src/main.rs
@@ -1,25 +1,28 @@
-//! The `mle` CLI. Four subcommands:
+//! The `mle` CLI. Five subcommands:
 //!
 //! ```text
 //! mle parse <file.mle>   # print the surface AST (pretty-Debug)
 //! mle ir <file.mle>      # parse + lower; print the core IR (pretty-Debug)
+//! mle check <file.mle>   # typecheck; silent when clean, all diagnostics when not
 //! mle run <file.mle>     # evaluate; print main's result, or every binding
 //! mle trace <file.mle>   # evaluate with the call trace; print the trace
 //! ```
 //!
-//! On failure (parse, lowering, or runtime) prints
-//! `file:line:col: error: message` to stderr and exits nonzero.
+//! On failure (parse, lowering, checking, or runtime) prints
+//! `file:line:col: error: message` to stderr and exits nonzero. `check` is
+//! the one command that reports *every* diagnostic, one per line, rather
+//! than stopping at the first; `run` deliberately does not typecheck.
 
 use std::process::exit;
 
 fn main() {
     let args: Vec<String> = std::env::args().skip(1).collect();
     let (command, path) = match args.as_slice() {
-        [command, path] if ["parse", "ir", "run", "trace"].contains(&command.as_str()) => {
+        [command, path] if ["parse", "ir", "check", "run", "trace"].contains(&command.as_str()) => {
             (command.as_str(), path)
         }
         _ => {
-            eprintln!("usage: mle <parse|ir|run|trace> <file.mle>");
+            eprintln!("usage: mle <parse|ir|check|run|trace> <file.mle>");
             exit(2);
         }
     };
@@ -44,6 +47,17 @@ fn main() {
     };
     if command == "ir" {
         println!("{module:#?}");
+        return;
+    }
+    if command == "check" {
+        let diags = mle::check(&module);
+        for diag in &diags {
+            let (line, col) = mle::line_col(&src, diag.span.start);
+            eprintln!("{path}:{line}:{col}: error: {}", diag.message);
+        }
+        if !diags.is_empty() {
+            exit(1);
+        }
         return;
     }
     let tracing = if command == "trace" {

--- a/mle/src/types.rs
+++ b/mle/src/types.rs
@@ -1,0 +1,545 @@
+//! Basic typechecking over the core IR — Track B4 of `docs/mle.md`.
+//!
+//! This is **gradual checking with annotations, not inference**: anything
+//! unannotated — and any type name that isn't a primitive, `List`, or a
+//! declared record type (e.g. a generic parameter like `T`) — is
+//! [`Type::Unknown`], and Unknown is compatible with everything. A check only
+//! fires where **both** sides are known, so unannotated code never produces a
+//! false positive; annotations buy diagnostics.
+//!
+//! ## The type language
+//!
+//! - Primitives `Float`, `String`, `Bool` (numbers are all Float).
+//! - Declared record types (`type Position = { x: Float, y: Float }`) —
+//!   nominal, by name.
+//! - `List<T>`.
+//! - Function types, from lambda annotations
+//!   (`(a: Float, b: Float): Float => …`); an unannotated return type is the
+//!   body's type when that is known.
+//!
+//! ## What is checked
+//!
+//! Arithmetic/comparison/unary-minus operand types; `==` across two
+//! *different* known types (always `false` — almost certainly a bug); record
+//! literals against a declared record type where one is expected (a return
+//! annotation, an argument of a call with a known signature); field access on
+//! a known record type; call arity and argument types where the callee's
+//! function type is known — including the builtins, whose signatures live in
+//! [`builtin_signature`] with generic slots as Unknown (no instantiation:
+//! `List.map`'s element types simply aren't tracked); return annotations
+//! against the body's type; and type-argument arity (`Position<Float>` is an
+//! error, an *unknown* type name is not).
+//!
+//! Top-level `let`s contribute what their value's shape declares (a lambda's
+//! annotations, a literal's type); everything else is Unknown. Signatures are
+//! collected before bodies are checked, so forward references between
+//! functions see full signatures (matching the interpreter's late binding).
+//!
+//! [`check`] walks the whole module and returns **every** diagnostic, sorted
+//! by source position — it never stops at the first error.
+
+use crate::ast::{BinOp, TypeName};
+use crate::eval::{builtin, callee_label, Builtin};
+use crate::ir::{Expr, ExprKind, Field, Module};
+use crate::span::Span;
+use crate::CheckError;
+use std::collections::HashMap;
+use std::fmt;
+
+#[derive(Clone, PartialEq)]
+pub enum Type {
+    /// Not known statically; compatible with everything (see module docs).
+    Unknown,
+    Float,
+    String,
+    Bool,
+    List(Box<Type>),
+    /// A declared record type, nominal by name.
+    Record(String),
+    Fn(Vec<Type>, Box<Type>),
+}
+
+impl fmt::Display for Type {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Type::Unknown => write!(f, "Unknown"),
+            Type::Float => write!(f, "Float"),
+            Type::String => write!(f, "String"),
+            Type::Bool => write!(f, "Bool"),
+            Type::List(elem) => write!(f, "List<{elem}>"),
+            Type::Record(name) => write!(f, "{name}"),
+            Type::Fn(params, ret) => {
+                write!(f, "(")?;
+                for (i, param) in params.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{param}")?;
+                }
+                write!(f, ") => {ret}")
+            }
+        }
+    }
+}
+
+/// Gradual compatibility: true unless the two types are known to disagree.
+/// Unknown (at any depth) is compatible with everything, so this returning
+/// `false` means the code *cannot* be well-typed at runtime.
+pub fn compatible(a: &Type, b: &Type) -> bool {
+    match (a, b) {
+        (Type::Unknown, _) | (_, Type::Unknown) => true,
+        (Type::Float, Type::Float) | (Type::String, Type::String) | (Type::Bool, Type::Bool) => {
+            true
+        }
+        (Type::List(x), Type::List(y)) => compatible(x, y),
+        (Type::Record(x), Type::Record(y)) => x == y,
+        (Type::Fn(p1, r1), Type::Fn(p2, r2)) => {
+            p1.len() == p2.len()
+                && p1.iter().zip(p2).all(|(x, y)| compatible(x, y))
+                && compatible(r1, r2)
+        }
+        _ => false,
+    }
+}
+
+/// The signature of a builtin (kept in sync with [`crate::eval`]'s registry
+/// by matching on [`Builtin`]). Generic slots are Unknown rather than
+/// instantiated type variables — e.g. `List.map : (List<T>, (T) => U) =>
+/// List<U>` is `(List<Unknown>, (Unknown) => Unknown) => List<Unknown>` — so
+/// element types don't flow through, but arity and the known parts (like
+/// `List.filter`'s Bool-returning predicate) still check.
+pub fn builtin_signature(b: Builtin) -> Type {
+    use Type::*;
+    fn func(params: Vec<Type>, ret: Type) -> Type {
+        Fn(params, Box::new(ret))
+    }
+    match b {
+        // List.map : (List<T>, (T) => U) => List<U>
+        Builtin::ListMap => func(
+            vec![List(Box::new(Unknown)), func(vec![Unknown], Unknown)],
+            List(Box::new(Unknown)),
+        ),
+        // List.filter : (List<T>, (T) => Bool) => List<T>
+        Builtin::ListFilter => func(
+            vec![List(Box::new(Unknown)), func(vec![Unknown], Bool)],
+            List(Box::new(Unknown)),
+        ),
+        // List.fold : (List<T>, (U, T) => U, U) => U
+        Builtin::ListFold => func(
+            vec![
+                List(Box::new(Unknown)),
+                func(vec![Unknown, Unknown], Unknown),
+                Unknown,
+            ],
+            Unknown,
+        ),
+        // List.maximum : (List<Float>) => Float
+        Builtin::ListMaximum => func(vec![List(Box::new(Float))], Float),
+        // Text.concat : (String, String) => String
+        Builtin::TextConcat => func(vec![String, String], String),
+        // Text.fromFloat : (Float) => String
+        Builtin::TextFromFloat => func(vec![Float], String),
+        // Text.toBullets : (List<String>) => String
+        Builtin::TextToBullets => func(vec![List(Box::new(String))], String),
+        // Math.clamp01 : (Float) => Float
+        Builtin::MathClamp01 => func(vec![Float], Float),
+    }
+}
+
+/// Check a lowered module; returns every diagnostic, sorted by position.
+/// Empty means clean.
+pub fn check(module: &Module) -> Vec<CheckError> {
+    let mut checker = Checker {
+        records: HashMap::new(),
+        globals: HashMap::new(),
+        locals: HashMap::new(),
+        diags: Vec::new(),
+    };
+
+    // Record type names first (nominal references may be forward), then
+    // resolve each declaration's field types (reporting bad type arity).
+    for decl in &module.types {
+        checker.records.insert(decl.name.clone(), Vec::new());
+    }
+    for decl in &module.types {
+        let fields = decl
+            .fields
+            .iter()
+            .map(|f| (f.name.clone(), checker.resolve_type(&f.ty, true)))
+            .collect();
+        checker.records.insert(decl.name.clone(), fields);
+    }
+
+    // Global signatures before bodies, so forward references between
+    // functions see full signatures (the interpreter late-binds globals the
+    // same way). Resolution is silent here — the body pass resolves the same
+    // annotations again and reports once.
+    for def in &module.defs {
+        let ty = match &def.value.kind {
+            ExprKind::Lambda { params, ret, .. } => Type::Fn(
+                params
+                    .iter()
+                    .map(|p| checker.resolve_annotation(p.ty.as_ref(), false))
+                    .collect(),
+                Box::new(checker.resolve_annotation(ret.as_ref(), false)),
+            ),
+            ExprKind::Number(_) => Type::Float,
+            ExprKind::String(_) => Type::String,
+            ExprKind::Bool(_) => Type::Bool,
+            _ => Type::Unknown,
+        };
+        checker.globals.insert(def.name.clone(), ty);
+    }
+
+    for def in &module.defs {
+        checker.infer(&def.value);
+    }
+
+    checker.diags.sort_by_key(|d| d.span.start);
+    checker.diags
+}
+
+struct Checker {
+    /// Declared record types: name → resolved fields, in declaration order.
+    records: HashMap<String, Vec<(String, Type)>>,
+    globals: HashMap<String, Type>,
+    /// Parameter types by binding ID (IDs are unique module-wide, so entries
+    /// are never shadowed or popped).
+    locals: HashMap<u32, Type>,
+    diags: Vec<CheckError>,
+}
+
+impl Checker {
+    fn diag(&mut self, span: Span, message: String) {
+        self.diags.push(CheckError { message, span });
+    }
+
+    /// Resolve an annotation to a [`Type`]. Unknown type *names* are not
+    /// errors (they may be generics like `T`); a recognized name applied at
+    /// the wrong arity is. `report: false` resolves silently (the signature
+    /// pre-pass, whose annotations the body pass resolves again).
+    fn resolve_type(&mut self, ty: &TypeName, report: bool) -> Type {
+        let arity_error = |checker: &mut Checker, takes: usize| {
+            if report {
+                checker.diag(
+                    ty.span,
+                    format!(
+                        "`{}` takes {takes} type argument(s), got {}",
+                        ty.name,
+                        ty.args.len()
+                    ),
+                );
+            }
+            Type::Unknown
+        };
+        match ty.name.as_str() {
+            "Float" | "String" | "Bool" => {
+                if !ty.args.is_empty() {
+                    return arity_error(self, 0);
+                }
+                match ty.name.as_str() {
+                    "Float" => Type::Float,
+                    "String" => Type::String,
+                    _ => Type::Bool,
+                }
+            }
+            "List" => {
+                if ty.args.len() != 1 {
+                    return arity_error(self, 1);
+                }
+                Type::List(Box::new(self.resolve_type(&ty.args[0], report)))
+            }
+            name if self.records.contains_key(name) => {
+                if !ty.args.is_empty() {
+                    return arity_error(self, 0);
+                }
+                Type::Record(name.to_string())
+            }
+            // Unrecognized (a generic like `T`, or a type this module doesn't
+            // declare): Unknown, not an error. Still resolve any arguments so
+            // nested annotations (`T<Position<Float>>`) get their diagnostics.
+            _ => {
+                for arg in &ty.args {
+                    self.resolve_type(arg, report);
+                }
+                Type::Unknown
+            }
+        }
+    }
+
+    fn resolve_annotation(&mut self, ty: Option<&TypeName>, report: bool) -> Type {
+        match ty {
+            Some(ty) => self.resolve_type(ty, report),
+            None => Type::Unknown,
+        }
+    }
+
+    /// Check `expr` against a known expected type. Record and list literals
+    /// are checked structurally against the expectation (this is where record
+    /// literals meet their declared types); anything else is inferred and
+    /// tested for compatibility. `what` names the expectation for the
+    /// diagnostic ("argument 2 of `move`", "field `x` of `Position`").
+    fn expect(&mut self, expr: &Expr, expected: &Type, what: &str) {
+        if *expected == Type::Unknown {
+            self.infer(expr);
+            return;
+        }
+        match (&expr.kind, expected) {
+            (ExprKind::Record(fields), Type::Record(name)) => {
+                self.check_record_literal(fields, name, expr.span);
+            }
+            (ExprKind::List(items), Type::List(elem)) => {
+                for item in items {
+                    self.expect(item, elem, "list element");
+                }
+            }
+            _ => {
+                let got = self.infer(expr);
+                if !compatible(&got, expected) {
+                    self.diag(expr.span, format!("{what}: expected {expected}, got {got}"));
+                }
+            }
+        }
+    }
+
+    /// Check a record literal against declared record type `name`: every
+    /// literal field must exist in the declaration and match its type, and
+    /// every declared field must be present.
+    fn check_record_literal(&mut self, fields: &[Field], name: &str, span: Span) {
+        let decl = self
+            .records
+            .get(name)
+            .cloned()
+            .expect("Type::Record names a declaration");
+        for field in fields {
+            match decl.iter().find(|(n, _)| n == &field.name) {
+                Some((_, field_ty)) => {
+                    let what = format!("field `{}` of `{name}`", field.name);
+                    let field_ty = field_ty.clone();
+                    self.expect(&field.value, &field_ty, &what);
+                }
+                None => {
+                    self.diag(
+                        field.span,
+                        format!("`{name}` has no field `{}`", field.name),
+                    );
+                    self.infer(&field.value);
+                }
+            }
+        }
+        for (declared, _) in &decl {
+            if !fields.iter().any(|f| &f.name == declared) {
+                self.diag(
+                    span,
+                    format!("record literal for `{name}` is missing field `{declared}`"),
+                );
+            }
+        }
+    }
+
+    fn infer(&mut self, expr: &Expr) -> Type {
+        match &expr.kind {
+            ExprKind::Number(_) => Type::Float,
+            ExprKind::String(_) => Type::String,
+            ExprKind::Bool(_) => Type::Bool,
+            ExprKind::Local { binding, .. } => self
+                .locals
+                .get(&binding.0)
+                .cloned()
+                .unwrap_or(Type::Unknown),
+            ExprKind::Global(name) => self.globals.get(name).cloned().unwrap_or(Type::Unknown),
+            // An unregistered external is a runtime concern (the module set
+            // may grow); the checker only knows the builtins' signatures.
+            ExprKind::External(path) => match builtin(path) {
+                Some(b) => builtin_signature(b),
+                None => Type::Unknown,
+            },
+            // A record literal with no expected type stays Unknown — record
+            // types are nominal, and nothing here names one (see `expect` for
+            // the checked positions).
+            ExprKind::Record(fields) => {
+                for field in fields {
+                    self.infer(&field.value);
+                }
+                Type::Unknown
+            }
+            ExprKind::List(items) => {
+                let mut elem: Option<Type> = None;
+                for item in items {
+                    let ty = self.infer(item);
+                    elem = match elem {
+                        None => Some(ty),
+                        Some(prev) if prev == ty => Some(prev),
+                        Some(_) => Some(Type::Unknown),
+                    };
+                }
+                Type::List(Box::new(elem.unwrap_or(Type::Unknown)))
+            }
+            ExprKind::FieldAccess { object, field } => {
+                let object_ty = self.infer(object);
+                match &object_ty {
+                    Type::Record(name) => {
+                        let field_ty = self
+                            .records
+                            .get(name)
+                            .and_then(|decl| decl.iter().find(|(n, _)| n == field))
+                            .map(|(_, ty)| ty.clone());
+                        match field_ty {
+                            Some(ty) => ty,
+                            None => {
+                                self.diag(expr.span, format!("`{name}` has no field `{field}`"));
+                                Type::Unknown
+                            }
+                        }
+                    }
+                    Type::Unknown => Type::Unknown,
+                    other => {
+                        self.diag(expr.span, format!("`.{field}` on {other}, not a record"));
+                        Type::Unknown
+                    }
+                }
+            }
+            ExprKind::Lambda { params, ret, body } => {
+                let param_tys: Vec<Type> = params
+                    .iter()
+                    .map(|p| self.resolve_annotation(p.ty.as_ref(), true))
+                    .collect();
+                for (param, ty) in params.iter().zip(&param_tys) {
+                    self.locals.insert(param.binding.0, ty.clone());
+                }
+                let ret_ty = self.resolve_annotation(ret.as_ref(), true);
+                let body_ty = if ret_ty == Type::Unknown {
+                    self.infer(body)
+                } else {
+                    self.expect(body, &ret_ty, "return value");
+                    ret_ty
+                };
+                Type::Fn(param_tys, Box::new(body_ty))
+            }
+            ExprKind::Call { callee, args } => {
+                let callee_ty = self.infer(callee);
+                match callee_ty {
+                    Type::Fn(params, ret) => {
+                        if params.len() != args.len() {
+                            self.diag(
+                                expr.span,
+                                format!(
+                                    "`{}` takes {} argument(s), got {}",
+                                    callee_label(callee),
+                                    params.len(),
+                                    args.len()
+                                ),
+                            );
+                            for arg in args {
+                                self.infer(arg);
+                            }
+                        } else {
+                            for (i, (arg, param_ty)) in args.iter().zip(&params).enumerate() {
+                                let what =
+                                    format!("argument {} of `{}`", i + 1, callee_label(callee));
+                                self.expect(arg, param_ty, &what);
+                            }
+                        }
+                        *ret
+                    }
+                    Type::Unknown => {
+                        for arg in args {
+                            self.infer(arg);
+                        }
+                        Type::Unknown
+                    }
+                    other => {
+                        self.diag(expr.span, format!("cannot call {other}, not a function"));
+                        for arg in args {
+                            self.infer(arg);
+                        }
+                        Type::Unknown
+                    }
+                }
+            }
+            ExprKind::Binary { .. } => {
+                // Left-assoc chains nest down the lhs with no parser depth
+                // guard — walk the spine iteratively, like lower and eval.
+                let mut spine = Vec::new();
+                let mut leaf = expr;
+                while let ExprKind::Binary { op, lhs, rhs } = &leaf.kind {
+                    spine.push((*op, rhs.as_ref(), leaf.span));
+                    leaf = lhs;
+                }
+                let mut acc = self.infer(leaf);
+                let mut acc_span = leaf.span;
+                for (op, rhs, node_span) in spine.into_iter().rev() {
+                    let rhs_ty = self.infer(rhs);
+                    acc = self.binary(op, &acc, acc_span, &rhs_ty, rhs.span, node_span);
+                    acc_span = node_span;
+                }
+                acc
+            }
+            ExprKind::Neg(inner) => {
+                let ty = self.infer(inner);
+                if !compatible(&ty, &Type::Float) {
+                    self.diag(
+                        inner.span,
+                        format!("unary `-` needs a Float operand, got {ty}"),
+                    );
+                }
+                Type::Float
+            }
+        }
+    }
+
+    fn binary(
+        &mut self,
+        op: BinOp,
+        lhs: &Type,
+        lhs_span: Span,
+        rhs: &Type,
+        rhs_span: Span,
+        node_span: Span,
+    ) -> Type {
+        match op {
+            BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div => {
+                self.require_float(op, lhs, lhs_span);
+                self.require_float(op, rhs, rhs_span);
+                Type::Float
+            }
+            BinOp::Lt | BinOp::Gt => {
+                self.require_float(op, lhs, lhs_span);
+                self.require_float(op, rhs, rhs_span);
+                Type::Bool
+            }
+            // `==` across two different known types is always `false` —
+            // almost certainly a bug, so it is an error, not a lint.
+            BinOp::Eq => {
+                if !compatible(lhs, rhs) {
+                    self.diag(
+                        node_span,
+                        format!("`==` compares different types {lhs} and {rhs} (always false)"),
+                    );
+                }
+                Type::Bool
+            }
+        }
+    }
+
+    fn require_float(&mut self, op: BinOp, ty: &Type, span: Span) {
+        if !compatible(ty, &Type::Float) {
+            self.diag(
+                span,
+                format!("`{}` needs Float operands, got {ty}", op_str(op)),
+            );
+        }
+    }
+}
+
+fn op_str(op: BinOp) -> &'static str {
+    match op {
+        BinOp::Add => "+",
+        BinOp::Sub => "-",
+        BinOp::Mul => "*",
+        BinOp::Div => "/",
+        BinOp::Lt => "<",
+        BinOp::Gt => ">",
+        BinOp::Eq => "==",
+    }
+}

--- a/mle/src/types.rs
+++ b/mle/src/types.rs
@@ -15,25 +15,36 @@
 //! - `List<T>`.
 //! - Function types, from lambda annotations
 //!   (`(a: Float, b: Float): Float => …`); an unannotated return type is the
-//!   body's type when that is known.
+//!   body's type when that is known (inferred in a single quiet enrichment
+//!   pass — a *chain* of unannotated-return functions may stay Unknown).
+//!
+//! Note that nominality exists **only in annotations**: the runtime's record
+//! equality and field access are structural (`value_eq` has no type tags), so
+//! nominal diagnostics catch annotation-level intent, not runtime crashes.
 //!
 //! ## What is checked
 //!
-//! Arithmetic/comparison/unary-minus operand types; `==` across two
-//! *different* known types (always `false` — almost certainly a bug); record
-//! literals against a declared record type where one is expected (a return
-//! annotation, an argument of a call with a known signature); field access on
-//! a known record type; call arity and argument types where the callee's
-//! function type is known — including the builtins, whose signatures live in
-//! [`builtin_signature`] with generic slots as Unknown (no instantiation:
-//! `List.map`'s element types simply aren't tracked); return annotations
-//! against the body's type; and type-argument arity (`Position<Float>` is an
-//! error, an *unknown* type name is not).
+//! Arithmetic/comparison/unary-minus operand types; `==` across known types
+//! that *cannot* be equal at runtime (different primitive/list/function
+//! kinds, or record types whose declared field shapes differ — equality is
+//! structural, so same-shaped nominal types may legitimately compare) and on
+//! two functions (always a runtime error); record literals against a declared
+//! record type where one is expected (a return annotation, an argument of a
+//! call with a known signature) and against any *non*-record expectation (a
+//! record literal is never a Float); field access on a known record type;
+//! call arity and argument types where the callee's function type is known —
+//! including the builtins, whose signatures live in [`builtin_signature`]
+//! with generic slots as Unknown (no instantiation: `List.map`'s element
+//! types simply aren't tracked); return annotations against the body's type;
+//! and type-argument arity (`Position<Float>` is an error, an *unknown* type
+//! name is not).
 //!
 //! Top-level `let`s contribute what their value's shape declares (a lambda's
-//! annotations, a literal's type); everything else is Unknown. Signatures are
-//! collected before bodies are checked, so forward references between
-//! functions see full signatures (matching the interpreter's late binding).
+//! annotations, a literal's type), then a quiet single-pass inference
+//! upgrades what it can (an unannotated lambda return, a list literal's
+//! element type). Signatures are collected before bodies are checked, so
+//! forward references between functions see full signatures (matching the
+//! interpreter's late binding).
 //!
 //! [`check`] walks the whole module and returns **every** diagnostic, sorted
 //! by source position — it never stops at the first error.
@@ -83,8 +94,9 @@ impl fmt::Display for Type {
 }
 
 /// Gradual compatibility: true unless the two types are known to disagree.
-/// Unknown (at any depth) is compatible with everything, so this returning
-/// `false` means the code *cannot* be well-typed at runtime.
+/// Unknown (at any depth) is compatible with everything. (Incompatibility is
+/// an annotation-level claim, not a runtime guarantee — nominality only
+/// exists in annotations; see the module doc.)
 pub fn compatible(a: &Type, b: &Type) -> bool {
     match (a, b) {
         (Type::Unknown, _) | (_, Type::Unknown) => true,
@@ -154,6 +166,7 @@ pub fn check(module: &Module) -> Vec<CheckError> {
         globals: HashMap::new(),
         locals: HashMap::new(),
         diags: Vec::new(),
+        quiet: false,
     };
 
     // Record type names first (nominal references may be forward), then
@@ -191,6 +204,22 @@ pub fn check(module: &Module) -> Vec<CheckError> {
         checker.globals.insert(def.name.clone(), ty);
     }
 
+    // Quiet enrichment: one inference pass upgrades what annotations alone
+    // couldn't say (an unannotated lambda's return from its body, a list
+    // literal's element type), so the diagnostic pass below checks against
+    // the best-known signatures. Single pass by design — a chain of
+    // unannotated-return functions stays Unknown (gradual, no fixed point).
+    checker.quiet = true;
+    for def in &module.defs {
+        let inferred = checker.infer(&def.value);
+        let entry = checker
+            .globals
+            .get_mut(&def.name)
+            .expect("inserted in the pre-pass");
+        *entry = merge_known(entry.clone(), inferred);
+    }
+    checker.quiet = false;
+
     for def in &module.defs {
         checker.infer(&def.value);
     }
@@ -207,11 +236,36 @@ struct Checker {
     /// are never shadowed or popped).
     locals: HashMap<u32, Type>,
     diags: Vec<CheckError>,
+    /// Suppress diagnostics (the quiet enrichment pass — the loud pass walks
+    /// the same nodes again and reports once).
+    quiet: bool,
+}
+
+/// Prefer the known parts of two views of the same definition's type: the
+/// annotation-derived signature, upgraded by inference where the annotation
+/// said Unknown.
+fn merge_known(stored: Type, inferred: Type) -> Type {
+    match (stored, inferred) {
+        (Type::Unknown, inferred) => inferred,
+        (Type::Fn(params, ret), Type::Fn(inferred_params, inferred_ret))
+            if params.len() == inferred_params.len() =>
+        {
+            let params = params
+                .into_iter()
+                .zip(inferred_params)
+                .map(|(s, i)| merge_known(s, i))
+                .collect();
+            Type::Fn(params, Box::new(merge_known(*ret, *inferred_ret)))
+        }
+        (stored, _) => stored,
+    }
 }
 
 impl Checker {
     fn diag(&mut self, span: Span, message: String) {
-        self.diags.push(CheckError { message, span });
+        if !self.quiet {
+            self.diags.push(CheckError { message, span });
+        }
     }
 
     /// Resolve an annotation to a [`Type`]. Unknown type *names* are not
@@ -287,6 +341,17 @@ impl Checker {
         match (&expr.kind, expected) {
             (ExprKind::Record(fields), Type::Record(name)) => {
                 self.check_record_literal(fields, name, expr.span);
+            }
+            // A record literal can never be a primitive/list/function,
+            // whatever nominal type it might otherwise satisfy.
+            (ExprKind::Record(fields), _) => {
+                self.diag(
+                    expr.span,
+                    format!("{what}: expected {expected}, got a record literal"),
+                );
+                for field in fields {
+                    self.infer(&field.value);
+                }
             }
             (ExprKind::List(items), Type::List(elem)) => {
                 for item in items {
@@ -508,18 +573,58 @@ impl Checker {
                 self.require_float(op, rhs, rhs_span);
                 Type::Bool
             }
-            // `==` across two different known types is always `false` —
-            // almost certainly a bug, so it is an error, not a lint.
+            // `==` is an error only where the runtime outcome is certain:
+            // comparing functions always fails at runtime, and operands whose
+            // known types cannot be equal always yield `false`. Runtime
+            // equality is STRUCTURAL, so two same-shaped nominal record types
+            // may legitimately compare — only differing declared shapes are
+            // errors.
             BinOp::Eq => {
-                if !compatible(lhs, rhs) {
-                    self.diag(
-                        node_span,
-                        format!("`==` compares different types {lhs} and {rhs} (always false)"),
-                    );
+                match (lhs, rhs) {
+                    (Type::Fn(..), Type::Fn(..)) => {
+                        self.diag(
+                            node_span,
+                            "functions cannot be compared with `==`".to_string(),
+                        );
+                    }
+                    (Type::Record(x), Type::Record(y)) => {
+                        if x != y && !self.same_record_shape(x, y) {
+                            self.diag(
+                                node_span,
+                                format!(
+                                    "`==` compares records with different shapes \
+                                     ({x} and {y}) — always false"
+                                ),
+                            );
+                        }
+                    }
+                    _ => {
+                        if !compatible(lhs, rhs) {
+                            self.diag(
+                                node_span,
+                                format!(
+                                    "`==` compares different types {lhs} and {rhs} (always false)"
+                                ),
+                            );
+                        }
+                    }
                 }
                 Type::Bool
             }
         }
+    }
+
+    /// Whether two declared record types have the same field-name set with
+    /// pairwise-compatible types — i.e. their values can be structurally
+    /// equal at runtime.
+    fn same_record_shape(&self, x: &str, y: &str) -> bool {
+        let (Some(xf), Some(yf)) = (self.records.get(x), self.records.get(y)) else {
+            return true; // unknown decl: stay gradual
+        };
+        xf.len() == yf.len()
+            && xf
+                .iter()
+                .all(|(name, ty)| yf.iter().any(|(n, t)| n == name && compatible(ty, t)))
     }
 
     fn require_float(&mut self, op: BinOp, ty: &Type, span: Span) {

--- a/mle/tests/check.rs
+++ b/mle/tests/check.rs
@@ -1,0 +1,300 @@
+//! B4 verification (docs/mle.md): the `broken.mle` diagnostic golden, the
+//! shipped examples checking clean, individual diagnostic message + position
+//! assertions, and gradual-typing cases that must NOT error.
+
+use std::fs;
+use std::path::Path;
+
+/// Parse + lower `src` and typecheck it; returns each diagnostic as
+/// (message, line, col).
+fn check_src(src: &str) -> Vec<(String, usize, usize)> {
+    let program = mle::parse(src).expect("source should parse");
+    let module = mle::lower(program).expect("source should lower");
+    mle::check(&module)
+        .into_iter()
+        .map(|diag| {
+            let (line, col) = mle::line_col(src, diag.span.start);
+            (diag.message, line, col)
+        })
+        .collect()
+}
+
+/// Assert `src` produces exactly one diagnostic, and return it.
+fn single_diag(src: &str) -> (String, usize, usize) {
+    let mut diags = check_src(src);
+    assert_eq!(diags.len(), 1, "expected one diagnostic, got {diags:?}");
+    diags.remove(0)
+}
+
+fn assert_clean(src: &str) {
+    let diags = check_src(src);
+    assert!(diags.is_empty(), "expected no diagnostics, got {diags:?}");
+}
+
+/// The `mle check` diagnostics for `examples/broken.mle`, compared against
+/// the committed `broken.check` golden (rendered exactly as the CLI prints
+/// them). Regenerate with `UPDATE_GOLDENS=1 cargo test -p mle`.
+#[test]
+fn golden_check_broken() {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("examples");
+    let src = fs::read_to_string(dir.join("broken.mle")).unwrap();
+    let golden_path = dir.join("broken.check");
+    let actual: String = check_src(&src)
+        .into_iter()
+        .map(|(message, line, col)| format!("broken.mle:{line}:{col}: error: {message}\n"))
+        .collect();
+    assert!(!actual.is_empty(), "broken.mle should produce diagnostics");
+    if std::env::var_os("UPDATE_GOLDENS").is_some() {
+        fs::write(&golden_path, &actual).unwrap();
+        return;
+    }
+    let expected = fs::read_to_string(&golden_path).unwrap_or_else(|_| {
+        panic!(
+            "missing golden {} — generate with UPDATE_GOLDENS=1 cargo test -p mle",
+            golden_path.display()
+        )
+    });
+    assert_eq!(
+        actual, expected,
+        "diagnostics for broken.mle diverged from broken.check — if intended, \
+         regenerate with UPDATE_GOLDENS=1 cargo test -p mle"
+    );
+}
+
+// The shipped examples are annotated and must check clean.
+
+#[test]
+fn example_pure_pipeline_checks_clean() {
+    example_checks_clean("pure-pipeline");
+}
+
+#[test]
+fn example_records_checks_clean() {
+    example_checks_clean("records");
+}
+
+#[test]
+fn example_functions_checks_clean() {
+    example_checks_clean("functions");
+}
+
+fn example_checks_clean(name: &str) {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("examples");
+    let src = fs::read_to_string(dir.join(format!("{name}.mle"))).unwrap();
+    let diags = check_src(&src);
+    assert!(
+        diags.is_empty(),
+        "{name}.mle should check clean, got {diags:?}"
+    );
+}
+
+// Individual diagnostics: message text and position.
+
+#[test]
+fn error_arithmetic_on_a_string() {
+    let (message, line, col) = single_diag("let f = (a: Float) => a + \"s\"");
+    assert_eq!(message, "`+` needs Float operands, got String");
+    assert_eq!((line, col), (1, 27));
+}
+
+#[test]
+fn error_comparison_on_a_bool() {
+    let (message, line, col) = single_diag("let f = (b: Bool) =>\n  b < 1.0");
+    assert_eq!(message, "`<` needs Float operands, got Bool");
+    assert_eq!((line, col), (2, 3));
+}
+
+#[test]
+fn error_equality_across_known_types() {
+    let (message, line, col) = single_diag("let x = 1.0 == \"1\"");
+    assert_eq!(
+        message,
+        "`==` compares different types Float and String (always false)"
+    );
+    assert_eq!((line, col), (1, 9));
+}
+
+#[test]
+fn error_negating_a_bool() {
+    let (message, line, col) = single_diag("let f = (b: Bool) => -b");
+    assert_eq!(message, "unary `-` needs a Float operand, got Bool");
+    assert_eq!((line, col), (1, 23));
+}
+
+#[test]
+fn error_record_literal_extra_and_missing_fields() {
+    let diags = check_src("type P = { x: Float }\nlet f = (): P => { y: 1.0 }");
+    // Sorted by position: the missing-field diagnostic sits at the record
+    // literal's opening brace, before the extra field.
+    assert_eq!(
+        diags,
+        [
+            (
+                "record literal for `P` is missing field `x`".to_string(),
+                2,
+                18
+            ),
+            ("`P` has no field `y`".to_string(), 2, 20),
+        ]
+    );
+}
+
+#[test]
+fn error_record_literal_field_type() {
+    let (message, line, col) = single_diag("type P = { x: Float }\nlet f = (): P => { x: \"s\" }");
+    assert_eq!(message, "field `x` of `P`: expected Float, got String");
+    assert_eq!((line, col), (2, 23));
+}
+
+#[test]
+fn error_field_access_missing_field() {
+    let (message, line, col) = single_diag("type P = { x: Float }\nlet f = (p: P) => p.z");
+    assert_eq!(message, "`P` has no field `z`");
+    assert_eq!((line, col), (2, 19));
+}
+
+#[test]
+fn error_field_access_on_a_float() {
+    let (message, line, col) = single_diag("let f = (a: Float) => a.x");
+    assert_eq!(message, "`.x` on Float, not a record");
+    assert_eq!((line, col), (1, 23));
+}
+
+#[test]
+fn error_call_arity() {
+    let (message, line, col) = single_diag(
+        "let f = (a: Float, b: Float): Float => a + b\n\
+         let g = () => f(1.0)",
+    );
+    assert_eq!(message, "`f` takes 2 argument(s), got 1");
+    assert_eq!((line, col), (2, 15));
+}
+
+#[test]
+fn error_call_argument_type() {
+    let (message, line, col) = single_diag(
+        "let f = (a: Float): Float => a\n\
+         let g = () => f(\"s\")",
+    );
+    assert_eq!(message, "argument 1 of `f`: expected Float, got String");
+    assert_eq!((line, col), (2, 17));
+}
+
+#[test]
+fn error_builtin_argument_type() {
+    let (message, line, col) = single_diag("let x = () => Math.clamp01(\"s\")");
+    assert_eq!(
+        message,
+        "argument 1 of `Math.clamp01`: expected Float, got String"
+    );
+    assert_eq!((line, col), (1, 28));
+}
+
+#[test]
+fn error_builtin_arity() {
+    let (message, _, _) = single_diag("let x = () => Text.concat(\"a\")");
+    assert_eq!(message, "`Text.concat` takes 2 argument(s), got 1");
+}
+
+// A builtin's known callback shape checks: List.filter's predicate must
+// return Bool (the generic slots stay Unknown, so only the Bool part fires).
+#[test]
+fn error_filter_predicate_must_return_bool() {
+    let (message, _, _) =
+        single_diag("let g = (xs: List<Float>) => List.filter(xs, (x): Float => x)");
+    assert_eq!(
+        message,
+        "argument 2 of `List.filter`: expected (Unknown) => Bool, got (Unknown) => Float"
+    );
+}
+
+#[test]
+fn error_return_annotation_mismatch() {
+    let (message, line, col) = single_diag("let f = (): Bool => 1.0");
+    assert_eq!(message, "return value: expected Bool, got Float");
+    assert_eq!((line, col), (1, 21));
+}
+
+#[test]
+fn error_calling_a_known_non_function() {
+    let (message, line, col) = single_diag("let x = 1.0\nlet g = () => x()");
+    assert_eq!(message, "cannot call Float, not a function");
+    assert_eq!((line, col), (2, 15));
+}
+
+// A *known* type name applied at the wrong arity is an error (check #8)…
+#[test]
+fn error_type_argument_arity() {
+    let (message, line, col) = single_diag("type P = { x: Float }\nlet f = (p: P<Float>) => p");
+    assert_eq!(message, "`P` takes 0 type argument(s), got 1");
+    assert_eq!((line, col), (2, 13));
+
+    let (message, _, _) = single_diag("let f = (xs: List) => xs");
+    assert_eq!(message, "`List` takes 1 type argument(s), got 0");
+}
+
+// Gradual typing: these must NOT error.
+
+// …but an *unknown* type name is not an error — it may be a generic
+// parameter (`T`) or a type this module doesn't declare.
+#[test]
+fn unknown_type_names_are_not_errors() {
+    assert_clean("let id = (x: T): T => x");
+    // An Unknown annotation checks against nothing, even with a known body.
+    assert_clean("let f = (x: T): T => 1.0");
+}
+
+#[test]
+fn unannotated_code_is_unchecked() {
+    // No annotations anywhere: every check needs a known side, so nothing
+    // fires — even though `f(\"s\", 1.0)` would fail at runtime.
+    assert_clean(
+        "let f = (a, b) => a + b\n\
+         let g = () => f(\"s\", true)",
+    );
+    // A call through an unannotated parameter is unchecked too.
+    assert_clean("let apply = (f) => f(1.0, 2.0)");
+}
+
+#[test]
+fn records_flow_gradually() {
+    // `mk`'s unannotated return type is Unknown, so passing its result where
+    // a Position is expected (and accessing fields on it) is unchecked.
+    assert_clean(
+        "type Position = { x: Float, y: Float }\n\
+         let mk = () => { x: 1.0, y: 2.0 }\n\
+         let getX = (p: Position): Float => p.x\n\
+         let go = () => getX(mk()) + mk().y",
+    );
+}
+
+#[test]
+fn generic_builtin_slots_stay_unknown() {
+    // List.map's result is List<Unknown>, which is compatible with the
+    // List<Float> that List.maximum expects (no generic instantiation).
+    assert_clean("let best = (xs: List<Float>): Float => List.maximum(List.map(xs, (x) => x))");
+}
+
+#[test]
+fn forward_type_declarations_resolve() {
+    // Record type names resolve regardless of declaration order.
+    assert_clean("let getX = (p: Later): Float => p.x\ntype Later = { x: Float }");
+}
+
+// Expected types propagate into list literals element by element, so a list
+// of record literals checks against List<Player> — and a bad element is
+// caught (the one non-gradual list case).
+#[test]
+fn expected_list_types_check_elements() {
+    assert_clean(
+        "type P = { x: Float }\n\
+         let f = (ps: List<P>): List<P> => ps\n\
+         let go = () => f([{ x: 1.0 }, { x: 2.0 }])",
+    );
+    let (message, _, _) = single_diag(
+        "type P = { x: Float }\n\
+         let f = (ps: List<P>): List<P> => ps\n\
+         let go = () => f([{ y: 1.0, x: 0.0 }])",
+    );
+    assert_eq!(message, "`P` has no field `y`");
+}

--- a/mle/tests/check.rs
+++ b/mle/tests/check.rs
@@ -298,3 +298,83 @@ fn expected_list_types_check_elements() {
     );
     assert_eq!(message, "`P` has no field `y`");
 }
+
+// --- Cross-engine review pins (C1-stack review of B4) ---
+
+// Runtime equality is structural: two same-shaped nominal types may compare
+// (and can be true) — NOT an error. [Claude H1]
+#[test]
+fn same_shaped_records_may_compare() {
+    assert_clean(
+        "type A = { x: Float }\n\
+         type B = { x: Float }\n\
+         let same = (a: A, b: B): Bool => a == b",
+    );
+}
+
+// Differing declared shapes guarantee structural inequality — error.
+#[test]
+fn different_shaped_records_compare_error() {
+    let diags = check_src(
+        "type A = { x: Float }\n\
+         type B = { y: Float }\n\
+         let never = (a: A, b: B): Bool => a == b",
+    );
+    assert_eq!(diags.len(), 1);
+    assert!(diags[0]
+        .0
+        .contains("`==` compares records with different shapes"));
+}
+
+// Comparing two known functions always fails at runtime. [Claude L2]
+#[test]
+fn function_equality_is_an_error() {
+    let diags = check_src(
+        "let f = (x: Float): Float => x\n\
+         let g = (x: Float): Float => x\n\
+         let bad = (): Bool => f == g",
+    );
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0].0, "functions cannot be compared with `==`");
+}
+
+// A record literal can never satisfy a known non-record type. [Claude M1]
+#[test]
+fn record_literal_in_float_position_errors() {
+    let diags = check_src(
+        "let f = (a: Float): Float => a + a\n\
+         let main = () => f({ x: 1.0 })",
+    );
+    assert_eq!(diags.len(), 1);
+    assert_eq!(
+        diags[0].0,
+        "argument 1 of `f`: expected Float, got a record literal"
+    );
+}
+
+// Quiet enrichment: an unannotated lambda return is inferred from its body,
+// so downstream checks fire. [Codex High, probe 1]
+#[test]
+fn inferred_return_type_flows_to_callers() {
+    let diags = check_src(
+        "let f = (a: Float) => a\n\
+         let main = (): Bool => f(1.0)",
+    );
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0].0, "return value: expected Bool, got Float");
+}
+
+// Quiet enrichment: a top-level list literal contributes its element type.
+// [Codex High, probe 2]
+#[test]
+fn top_level_list_literal_type_flows() {
+    let diags = check_src(
+        "let xs = [1.0]\n\
+         let main = (): String => Text.toBullets(xs)",
+    );
+    assert_eq!(diags.len(), 1);
+    assert_eq!(
+        diags[0].0,
+        "argument 1 of `Text.toBullets`: expected List<String>, got List<Float>"
+    );
+}


### PR DESCRIPTION
## What

Track **B4** of `docs/mle.md` (stacked on #160 — both touch the same mle files): a **gradual, annotation-based** typechecker over the core IR (`mle/src/types.rs`) and an `mle check <file>` subcommand.

- Type language: `Float`/`String`/`Bool`, nominal declared record types, `List<T>`, function types from lambda annotations, and **Unknown** — anything unannotated or unrecognized, compatible with everything. Checks fire only where both sides are known: unannotated code never false-positives; annotations buy diagnostics.
- Checked: arithmetic/comparison operand types; `==` where the runtime outcome is certain (different known kinds; records **only when declared shapes differ** — runtime equality is structural; functions — always a runtime error); record literals against declared types (missing/extra/mistyped fields) *and* against non-record expectations; field access on known records; call arity + argument types where the callee's type is known, including a builtin signature table kept compiler-enforced in sync with the interpreter; return annotations; type-argument arity.
- Global signatures come from annotations plus a **quiet single-pass inference enrichment** (an unannotated return, a top-level list literal's element type), so forward references check against best-known types.
- `mle check`: silent + exit 0 clean; **all** diagnostics (sorted by position) + exit 1 otherwise. Not wired into `run` (deliberate; comes with effect checking later).

## Verification

- **81 tests** (32 check + 14 ir + 12 parser + 23 run): a `broken.mle` diagnostic golden (11 diagnostics, one per line, exact positions), 3 examples-check-clean tests, per-diagnostic message+position tests, gradual must-NOT-error tests, and six review-pin tests. fmt/clippy clean.
- Built by a background agent, then cross-engine reviewed (/xreview) with **execution probes** — both engines ran `mle run` vs `mle check` on adversarial snippets. Confirmed findings all fixed: a false positive (same-shaped nominal records rejected with a factually wrong message — Claude), a scope-claimed false negative (inferable signatures ignored — Codex), record-literal-vs-Float checking clean (Claude), fn `==` fn unchecked (Claude). The core gradual guarantee — legal running code never rejected — survived both engines' probe batteries after fixes.

## Notes

- With this + the C1 host seam, `mle check` can later learn prelude signatures (`Scene.color : (Scene, Float, Float, Float) => Scene`) via the same table pattern.
- The Track D IDE agent's LSP will surface these diagnostics in-editor once both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)