### PR TITLE
feat(tooling): .mle editor support — VSCode extension + LSP diagnostics (Track D)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "runtime/functor-runtime-desktop",
     "runtime/functor-runtime-web",
     "src",
+    "tools/mle-lsp",
 ]
 
 # Debug info dominated target/ size (it was repeatedly filling the disk during

--- a/docs/mle.md
+++ b/docs/mle.md
@@ -184,15 +184,34 @@ Starts once A2 + B3 exist.
       (roadmap phase 7) only if the tree-walker doesn't hold.
       *Verify:* frame-time assertion in the e2e harness.
 
+## Track D — IDE tooling
+
+First-class `.mle` editor support, built on the `mle` crate's front-end
+(`parse`/`lower`/`line_col`) — independent of the runtime tracks.
+
+- [x] **D1. TextMate grammar + VSCode extension.** `tools/mle-vscode/`:
+      grammar, language configuration (comments/brackets/auto-close), and a
+      plain-JS LSP client launching `mle-lsp` from PATH. *Verify:* grammar +
+      manifests JSON-checked and `test/sample.mle` (every construct) kept
+      parse/lower-clean by `cargo test -p mle-lsp`; visual check in the editor.
+- [x] **D2. LSP diagnostics.** `tools/mle-lsp/`: hand-rolled stdio LSP server
+      (blocking loop + serde_json, no async framework) publishing parse/lower
+      errors as spanned diagnostics on open/change. *Verify:* framed-protocol
+      e2e test drives the real binary (broken doc → diagnostic, fix → clear,
+      unknown method → MethodNotFound).
+- [ ] **D3. Hover types & go-to-definition.** Deferred: hover needs B4's
+      typechecker; go-to-def needs a use→definition query over the IR (it
+      already carries spans on every node, but no query API yet).
+
 ## Endgame — replace F#
 
 Pull-based: port examples as MLE proves itself; no flag-day.
 
-- [ ] **D1.** Port `examples/hello` (glTF lineup, free-look camera) — the
+- [ ] **E1.** Port `examples/hello` (glTF lineup, free-look camera) — the
       real-world bar. *Verify:* golden parity.
-- [ ] **D2.** Port remaining examples, one PR each. *Verify:* per-example
+- [ ] **E2.** Port remaining examples, one PR each. *Verify:* per-example
       goldens + e2e.
-- [ ] **D3.** Delete the F# pipeline: Fable, dotnet tooling, `.fsproj`s,
+- [ ] **E3.** Delete the F# pipeline: Fable, dotnet tooling, `.fsproj`s,
       `fable_modules/`, the `.fs`/`.fsi`/`.rs` triplication, the dylib
       hot-reload path. *Verify:* full CI green with no dotnet installed;
       `npm run build:cli` needs only Rust + Node.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -102,7 +102,7 @@ behind a `GameProducer` trait until MLE wins). Language design notes live in
       ADTs/closures → effect broker (B1–B6), in-repo `mle/` crates.
 - [ ] Track C: MLE behind the seam — prelude, `MleProducer` + mle-hello golden,
       hot-reload payoff demo, MVU parity, wasm, perf gate (C1–C6).
-- [ ] Endgame: port examples, then delete the F#/Fable pipeline (D1–D3).
+- [ ] Endgame: port examples, then delete the F#/Fable pipeline (E1–E3).
 
 ## Live variables / fast iteration
 

--- a/tools/mle-lsp/Cargo.toml
+++ b/tools/mle-lsp/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "mle-lsp"
+version = "0.1.0"
+edition = "2021"
+
+# Deliberately tiny (docs/mle.md Track D): a blocking stdio loop needs no
+# async runtime or LSP framework — serde_json (already in the tree) is the
+# only dependency besides the language crate itself.
+[dependencies]
+mle = { path = "../../mle" }
+serde_json = "1.0"
+
+[[bin]]
+name = "mle-lsp"
+path = "src/main.rs"

--- a/tools/mle-lsp/src/main.rs
+++ b/tools/mle-lsp/src/main.rs
@@ -8,31 +8,50 @@
 //! bill of health) is published via `textDocument/publishDiagnostics`.
 //!
 //! Document sync is **full** (`textDocumentSync: 1`): every change carries
-//! the whole buffer, so the server keeps no incremental state beyond a
-//! uri→text map.
+//! the whole buffer, so the server keeps no state at all — diagnostics are
+//! computed straight from the incoming text.
 
-use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Write};
 
 use serde_json::{json, Value};
 
 /// JSON-RPC "method not found" (LSP inherits JSON-RPC 2.0 error codes).
 const METHOD_NOT_FOUND: i64 = -32601;
+/// JSON-RPC "invalid request" — requests after `shutdown`.
+const INVALID_REQUEST: i64 = -32600;
 
 fn main() {
     let stdin = std::io::stdin();
     let stdout = std::io::stdout();
-    serve(&mut BufReader::new(stdin.lock()), &mut stdout.lock());
+    let code = serve(&mut BufReader::new(stdin.lock()), &mut stdout.lock());
+    std::process::exit(code);
 }
 
 /// The server loop: read framed messages until `exit` (or EOF), dispatching
-/// requests (messages with an `id`) and notifications.
-fn serve(reader: &mut impl BufRead, writer: &mut impl Write) {
-    let mut documents: HashMap<String, String> = HashMap::new();
+/// requests (messages with an `id`) and notifications. Returns the process
+/// exit code: per the LSP spec, `exit` after `shutdown` is 0, `exit` without
+/// it is 1 (EOF — the client vanished — is a quiet 0).
+fn serve(reader: &mut impl BufRead, writer: &mut impl Write) -> i32 {
+    let mut shutdown_seen = false;
     while let Some(message) = read_message(reader) {
         let method = message["method"].as_str().unwrap_or("").to_string();
         let id = message.get("id").cloned();
         let params = &message["params"];
+        // Post-shutdown, the only valid message is `exit`: requests get
+        // InvalidRequest per the spec; notifications are dropped.
+        if shutdown_seen && method != "exit" {
+            if let Some(id) = id {
+                let error = json!({
+                    "code": INVALID_REQUEST,
+                    "message": "server is shutting down",
+                });
+                write_message(
+                    writer,
+                    &json!({ "jsonrpc": "2.0", "id": id, "error": error }),
+                );
+            }
+            continue;
+        }
         match (method.as_str(), id) {
             // --- Requests (have an id; must be answered). ---
             ("initialize", Some(id)) => {
@@ -46,6 +65,7 @@ fn serve(reader: &mut impl BufRead, writer: &mut impl Write) {
                 );
             }
             ("shutdown", Some(id)) => {
+                shutdown_seen = true;
                 write_message(
                     writer,
                     &json!({ "jsonrpc": "2.0", "id": id, "result": null }),
@@ -62,37 +82,25 @@ fn serve(reader: &mut impl BufRead, writer: &mut impl Write) {
                 );
             }
             // --- Notifications (no id; never answered). ---
-            ("exit", None) => return,
+            ("exit", None) => return i32::from(!shutdown_seen),
             ("textDocument/didOpen", None) => {
-                let uri = params["textDocument"]["uri"]
-                    .as_str()
-                    .unwrap_or("")
-                    .to_string();
-                let text = params["textDocument"]["text"]
-                    .as_str()
-                    .unwrap_or("")
-                    .to_string();
-                publish_diagnostics(writer, &uri, &text);
-                documents.insert(uri, text);
+                let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
+                let text = params["textDocument"]["text"].as_str().unwrap_or("");
+                publish_diagnostics(writer, uri, text);
             }
             ("textDocument/didChange", None) => {
-                let uri = params["textDocument"]["uri"]
-                    .as_str()
-                    .unwrap_or("")
-                    .to_string();
+                let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
                 // Full sync: the last content change is the whole new buffer.
                 if let Some(text) = params["contentChanges"]
                     .as_array()
                     .and_then(|changes| changes.last())
                     .and_then(|change| change["text"].as_str())
                 {
-                    publish_diagnostics(writer, &uri, text);
-                    documents.insert(uri, text.to_string());
+                    publish_diagnostics(writer, uri, text);
                 }
             }
             ("textDocument/didClose", None) => {
                 let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
-                documents.remove(uri);
                 // Clear stale squiggles for the closed file.
                 write_diagnostics(writer, uri, vec![]);
             }
@@ -100,6 +108,7 @@ fn serve(reader: &mut impl BufRead, writer: &mut impl Write) {
             (_, None) => {}
         }
     }
+    0
 }
 
 /// Run the MLE front-end over `text` and publish the outcome: one Error
@@ -136,39 +145,58 @@ fn write_diagnostics(writer: &mut impl Write, uri: &str, diagnostics: Vec<Value>
     );
 }
 
-/// Convert a byte-offset [`mle::Span`] to an LSP range. `mle::line_col` is
-/// 1-based; LSP positions are 0-based, so both line and character shift down
-/// by one. The span is half-open, matching LSP's exclusive `end`.
+/// Convert a byte-offset [`mle::Span`] to an LSP range. The span is
+/// half-open, matching LSP's exclusive `end`. LSP positions count characters
+/// in **UTF-16 code units** (the default encoding; this server doesn't
+/// negotiate another), not chars — an astral-plane character earlier on the
+/// line counts as two.
 fn span_to_range(text: &str, span: mle::Span) -> Value {
-    let (start_line, start_col) = mle::line_col(text, span.start);
-    let (end_line, end_col) = mle::line_col(text, span.end);
     json!({
-        "start": { "line": start_line - 1, "character": start_col - 1 },
-        "end": { "line": end_line - 1, "character": end_col - 1 },
+        "start": lsp_position(text, span.start),
+        "end": lsp_position(text, span.end),
     })
 }
 
-/// Read one `Content-Length`-framed message. Returns `None` on EOF or a
-/// malformed frame (either way the server has nothing left to do).
+fn lsp_position(text: &str, offset: usize) -> Value {
+    let prefix = &text[..offset.min(text.len())];
+    let line = prefix.matches('\n').count();
+    let line_start = prefix.rfind('\n').map_or(0, |i| i + 1);
+    let character = prefix[line_start..].encode_utf16().count();
+    json!({ "line": line, "character": character })
+}
+
+/// Read one `Content-Length`-framed message. Returns `None` only when the
+/// stream is done (EOF, short read, missing `Content-Length`); a frame whose
+/// body is valid length but invalid JSON is skipped — the stream is still
+/// framed-in-sync, so one garbage message must not kill diagnostics for the
+/// whole session.
 fn read_message(reader: &mut impl BufRead) -> Option<Value> {
-    let mut content_length: Option<usize> = None;
     loop {
-        let mut line = String::new();
-        if reader.read_line(&mut line).ok()? == 0 {
-            return None; // EOF
+        let mut content_length: Option<usize> = None;
+        loop {
+            let mut line = String::new();
+            if reader.read_line(&mut line).ok()? == 0 {
+                return None; // EOF
+            }
+            let line = line.trim_end();
+            if line.is_empty() {
+                break; // blank line ends the header block
+            }
+            // Header names are case-insensitive (RFC 9110, and clients vary).
+            if let Some((name, value)) = line.split_once(':') {
+                if name.eq_ignore_ascii_case("content-length") {
+                    content_length = value.trim().parse().ok();
+                }
+            }
+            // Other headers (Content-Type) are ignored.
         }
-        let line = line.trim_end();
-        if line.is_empty() {
-            break; // blank line ends the header block
+        let mut body = vec![0; content_length?];
+        reader.read_exact(&mut body).ok()?;
+        match serde_json::from_slice(&body) {
+            Ok(message) => return Some(message),
+            Err(_) => continue, // skip the garbage frame, keep serving
         }
-        if let Some(value) = line.strip_prefix("Content-Length:") {
-            content_length = value.trim().parse().ok();
-        }
-        // Other headers (Content-Type) are ignored.
     }
-    let mut body = vec![0; content_length?];
-    reader.read_exact(&mut body).ok()?;
-    serde_json::from_slice(&body).ok()
 }
 
 fn write_message(writer: &mut impl Write, message: &Value) {
@@ -220,5 +248,76 @@ mod tests {
     #[test]
     fn read_message_returns_none_on_eof() {
         assert!(read_message(&mut &b""[..]).is_none());
+    }
+}
+
+#[cfg(test)]
+mod review_tests {
+    use super::*;
+
+    // A garbage frame must not kill the session — the next valid frame is
+    // served. [review High]
+    #[test]
+    fn garbage_frame_is_skipped() {
+        let framed =
+            b"Content-Length: 5\r\n\r\n{oopsContent-Length: 16\r\n\r\n{\"method\":\"foo\"}";
+        let message = read_message(&mut &framed[..]).unwrap();
+        assert_eq!(message["method"], "foo");
+    }
+
+    // LSP characters are UTF-16 code units: the emoji is 2 units, so an
+    // error after it lands 2 further than the char count. [review Medium]
+    #[test]
+    fn positions_count_utf16_code_units() {
+        let text = "let s = \"\u{1F642}\" @";
+        let at = text.find('@').unwrap();
+        let pos = lsp_position(text, at);
+        assert_eq!(pos["character"], 13); // 12 chars, but the emoji counts twice
+    }
+
+    // exit without shutdown is code 1; after shutdown, 0. [review Low]
+    #[test]
+    fn exit_code_reflects_shutdown() {
+        let exit_only = b"Content-Length: 17\r\n\r\n{\"method\":\"exit\"}";
+        let mut out = Vec::new();
+        assert_eq!(serve(&mut &exit_only[..], &mut out), 1);
+
+        let shutdown_then_exit = b"Content-Length: 36\r\n\r\n{\"id\":1,\"method\":\"shutdown\"}\
+Content-Length: 17\r\n\r\n{\"method\":\"exit\"}";
+        let mut out = Vec::new();
+        assert_eq!(serve(&mut &shutdown_then_exit[..], &mut out), 0);
+    }
+}
+
+#[cfg(test)]
+mod codex_review_tests {
+    use super::*;
+
+    // Header names are case-insensitive. [review Low, probe-verified]
+    #[test]
+    fn lowercase_content_length_is_accepted() {
+        let framed = b"content-length: 16\r\n\r\n{\"method\":\"foo\"}";
+        let message = read_message(&mut &framed[..]).unwrap();
+        assert_eq!(message["method"], "foo");
+    }
+
+    // After shutdown, only exit is honored: notifications are dropped
+    // (no diagnostics published) and requests get InvalidRequest.
+    #[test]
+    fn post_shutdown_traffic_is_refused() {
+        let open = r#"{"method":"textDocument/didOpen","params":{"textDocument":{"uri":"file:///x.mle","text":"let = 3"}}}"#;
+        let req = r#"{"id":2,"method":"initialize","params":{}}"#;
+        let shutdown = r#"{"id":1,"method":"shutdown"}"#;
+        let mut input = Vec::new();
+        for body in [shutdown, open, req] {
+            input.extend_from_slice(
+                format!("Content-Length: {}\r\n\r\n{body}", body.len()).as_bytes(),
+            );
+        }
+        let mut out = Vec::new();
+        assert_eq!(serve(&mut &input[..], &mut out), 0); // EOF after refusals
+        let out = String::from_utf8(out).unwrap();
+        assert!(!out.contains("publishDiagnostics"), "out: {out}");
+        assert!(out.contains("-32600"), "out: {out}");
     }
 }

--- a/tools/mle-lsp/src/main.rs
+++ b/tools/mle-lsp/src/main.rs
@@ -1,0 +1,224 @@
+//! `mle-lsp` — a minimal Language Server for `.mle` files (docs/mle.md
+//! Track D).
+//!
+//! Hand-rolled LSP over stdio: a blocking read loop with `Content-Length`
+//! framing and `serde_json` dispatch — no async runtime, no LSP framework.
+//! The one feature is diagnostics: on `didOpen`/`didChange` the buffer is fed
+//! through [`mle::parse`] and [`mle::lower`], and the first error (or a clean
+//! bill of health) is published via `textDocument/publishDiagnostics`.
+//!
+//! Document sync is **full** (`textDocumentSync: 1`): every change carries
+//! the whole buffer, so the server keeps no incremental state beyond a
+//! uri→text map.
+
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Write};
+
+use serde_json::{json, Value};
+
+/// JSON-RPC "method not found" (LSP inherits JSON-RPC 2.0 error codes).
+const METHOD_NOT_FOUND: i64 = -32601;
+
+fn main() {
+    let stdin = std::io::stdin();
+    let stdout = std::io::stdout();
+    serve(&mut BufReader::new(stdin.lock()), &mut stdout.lock());
+}
+
+/// The server loop: read framed messages until `exit` (or EOF), dispatching
+/// requests (messages with an `id`) and notifications.
+fn serve(reader: &mut impl BufRead, writer: &mut impl Write) {
+    let mut documents: HashMap<String, String> = HashMap::new();
+    while let Some(message) = read_message(reader) {
+        let method = message["method"].as_str().unwrap_or("").to_string();
+        let id = message.get("id").cloned();
+        let params = &message["params"];
+        match (method.as_str(), id) {
+            // --- Requests (have an id; must be answered). ---
+            ("initialize", Some(id)) => {
+                let result = json!({
+                    "capabilities": { "textDocumentSync": 1 },
+                    "serverInfo": { "name": "mle-lsp" },
+                });
+                write_message(
+                    writer,
+                    &json!({ "jsonrpc": "2.0", "id": id, "result": result }),
+                );
+            }
+            ("shutdown", Some(id)) => {
+                write_message(
+                    writer,
+                    &json!({ "jsonrpc": "2.0", "id": id, "result": null }),
+                );
+            }
+            (_, Some(id)) => {
+                let error = json!({
+                    "code": METHOD_NOT_FOUND,
+                    "message": format!("method not found: {method}"),
+                });
+                write_message(
+                    writer,
+                    &json!({ "jsonrpc": "2.0", "id": id, "error": error }),
+                );
+            }
+            // --- Notifications (no id; never answered). ---
+            ("exit", None) => return,
+            ("textDocument/didOpen", None) => {
+                let uri = params["textDocument"]["uri"]
+                    .as_str()
+                    .unwrap_or("")
+                    .to_string();
+                let text = params["textDocument"]["text"]
+                    .as_str()
+                    .unwrap_or("")
+                    .to_string();
+                publish_diagnostics(writer, &uri, &text);
+                documents.insert(uri, text);
+            }
+            ("textDocument/didChange", None) => {
+                let uri = params["textDocument"]["uri"]
+                    .as_str()
+                    .unwrap_or("")
+                    .to_string();
+                // Full sync: the last content change is the whole new buffer.
+                if let Some(text) = params["contentChanges"]
+                    .as_array()
+                    .and_then(|changes| changes.last())
+                    .and_then(|change| change["text"].as_str())
+                {
+                    publish_diagnostics(writer, &uri, text);
+                    documents.insert(uri, text.to_string());
+                }
+            }
+            ("textDocument/didClose", None) => {
+                let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
+                documents.remove(uri);
+                // Clear stale squiggles for the closed file.
+                write_diagnostics(writer, uri, vec![]);
+            }
+            // initialized, $/… and any other notification: deliberately ignored.
+            (_, None) => {}
+        }
+    }
+}
+
+/// Run the MLE front-end over `text` and publish the outcome: one Error
+/// diagnostic for the first parse/lower failure, or an empty list (which
+/// clears previous diagnostics) when the module is clean.
+fn publish_diagnostics(writer: &mut impl Write, uri: &str, text: &str) {
+    let error = match mle::parse(text) {
+        Err(err) => Some((err.message, err.span)),
+        Ok(program) => match mle::lower(program) {
+            Err(err) => Some((err.message, err.span)),
+            Ok(_) => None,
+        },
+    };
+    let diagnostics = match error {
+        Some((message, span)) => vec![json!({
+            "range": span_to_range(text, span),
+            "severity": 1, // Error
+            "source": "mle",
+            "message": message,
+        })],
+        None => vec![],
+    };
+    write_diagnostics(writer, uri, diagnostics);
+}
+
+fn write_diagnostics(writer: &mut impl Write, uri: &str, diagnostics: Vec<Value>) {
+    write_message(
+        writer,
+        &json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/publishDiagnostics",
+            "params": { "uri": uri, "diagnostics": diagnostics },
+        }),
+    );
+}
+
+/// Convert a byte-offset [`mle::Span`] to an LSP range. `mle::line_col` is
+/// 1-based; LSP positions are 0-based, so both line and character shift down
+/// by one. The span is half-open, matching LSP's exclusive `end`.
+fn span_to_range(text: &str, span: mle::Span) -> Value {
+    let (start_line, start_col) = mle::line_col(text, span.start);
+    let (end_line, end_col) = mle::line_col(text, span.end);
+    json!({
+        "start": { "line": start_line - 1, "character": start_col - 1 },
+        "end": { "line": end_line - 1, "character": end_col - 1 },
+    })
+}
+
+/// Read one `Content-Length`-framed message. Returns `None` on EOF or a
+/// malformed frame (either way the server has nothing left to do).
+fn read_message(reader: &mut impl BufRead) -> Option<Value> {
+    let mut content_length: Option<usize> = None;
+    loop {
+        let mut line = String::new();
+        if reader.read_line(&mut line).ok()? == 0 {
+            return None; // EOF
+        }
+        let line = line.trim_end();
+        if line.is_empty() {
+            break; // blank line ends the header block
+        }
+        if let Some(value) = line.strip_prefix("Content-Length:") {
+            content_length = value.trim().parse().ok();
+        }
+        // Other headers (Content-Type) are ignored.
+    }
+    let mut body = vec![0; content_length?];
+    reader.read_exact(&mut body).ok()?;
+    serde_json::from_slice(&body).ok()
+}
+
+fn write_message(writer: &mut impl Write, message: &Value) {
+    let body = message.to_string();
+    // A write failure means the client is gone; exiting quietly beats a panic.
+    let _ = write!(writer, "Content-Length: {}\r\n\r\n{body}", body.len());
+    let _ = writer.flush();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn span_to_range_is_zero_based_with_end_position() {
+        // "let = 3": the parse error spans the `=` at bytes 4..5.
+        let text = "let = 3";
+        let range = span_to_range(text, mle::Span::new(4, 5));
+        assert_eq!(
+            range,
+            json!({
+                "start": { "line": 0, "character": 4 },
+                "end": { "line": 0, "character": 5 },
+            })
+        );
+    }
+
+    #[test]
+    fn span_to_range_crosses_lines() {
+        let text = "let a = 1\nlet b = 2\n";
+        // Span of `b = 2` on line 2 (bytes 14..19).
+        let range = span_to_range(text, mle::Span::new(14, 19));
+        assert_eq!(
+            range,
+            json!({
+                "start": { "line": 1, "character": 4 },
+                "end": { "line": 1, "character": 9 },
+            })
+        );
+    }
+
+    #[test]
+    fn read_message_parses_a_framed_body() {
+        let framed = b"Content-Length: 16\r\n\r\n{\"method\":\"foo\"}";
+        let message = read_message(&mut &framed[..]).unwrap();
+        assert_eq!(message["method"], "foo");
+    }
+
+    #[test]
+    fn read_message_returns_none_on_eof() {
+        assert!(read_message(&mut &b""[..]).is_none());
+    }
+}

--- a/tools/mle-lsp/tests/e2e.rs
+++ b/tools/mle-lsp/tests/e2e.rs
@@ -1,0 +1,152 @@
+//! End-to-end test: spawn the real `mle-lsp` binary and speak framed LSP to
+//! it over stdin/stdout — initialize, open a broken document, assert the
+//! diagnostic, fix it, assert the clear, and check unknown requests get
+//! MethodNotFound without killing the server.
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+
+use serde_json::{json, Value};
+
+struct Server {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+}
+
+impl Server {
+    fn spawn() -> Server {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_mle-lsp"))
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("spawn mle-lsp");
+        let stdin = child.stdin.take().unwrap();
+        let stdout = BufReader::new(child.stdout.take().unwrap());
+        Server {
+            child,
+            stdin,
+            stdout,
+        }
+    }
+
+    fn send(&mut self, message: Value) {
+        let body = message.to_string();
+        write!(self.stdin, "Content-Length: {}\r\n\r\n{body}", body.len()).unwrap();
+        self.stdin.flush().unwrap();
+    }
+
+    fn recv(&mut self) -> Value {
+        let mut content_length = 0;
+        loop {
+            let mut line = String::new();
+            self.stdout.read_line(&mut line).expect("read header");
+            let line = line.trim_end();
+            if line.is_empty() {
+                break;
+            }
+            if let Some(value) = line.strip_prefix("Content-Length:") {
+                content_length = value.trim().parse().expect("content length");
+            }
+        }
+        let mut body = vec![0; content_length];
+        self.stdout.read_exact(&mut body).expect("read body");
+        serde_json::from_slice(&body).expect("parse body")
+    }
+}
+
+const URI: &str = "file:///tmp/e2e.mle";
+
+#[test]
+fn diagnostics_over_real_stdio() {
+    let mut server = Server::spawn();
+
+    // initialize → full-sync capability advertised.
+    server.send(json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": { "capabilities": {} },
+    }));
+    let response = server.recv();
+    assert_eq!(response["id"], 1);
+    assert_eq!(response["result"]["capabilities"]["textDocumentSync"], 1);
+
+    server.send(json!({ "jsonrpc": "2.0", "method": "initialized", "params": {} }));
+
+    // didOpen with a broken document → one Error diagnostic at the `=`
+    // (bytes 4..5, i.e. 0-based line 0 chars 4..5).
+    server.send(json!({
+        "jsonrpc": "2.0", "method": "textDocument/didOpen",
+        "params": { "textDocument": {
+            "uri": URI, "languageId": "mle", "version": 1, "text": "let = 3",
+        } },
+    }));
+    let publish = server.recv();
+    assert_eq!(publish["method"], "textDocument/publishDiagnostics");
+    assert_eq!(publish["params"]["uri"], URI);
+    let diagnostics = publish["params"]["diagnostics"].as_array().unwrap();
+    assert_eq!(diagnostics.len(), 1, "expected one diagnostic: {publish}");
+    let diagnostic = &diagnostics[0];
+    assert_eq!(diagnostic["severity"], 1);
+    assert_eq!(
+        diagnostic["message"],
+        "expected a name after `let`, found `=`"
+    );
+    assert_eq!(
+        diagnostic["range"],
+        json!({
+            "start": { "line": 0, "character": 4 },
+            "end": { "line": 0, "character": 5 },
+        })
+    );
+
+    // An unknown request gets MethodNotFound and the server keeps serving.
+    server.send(json!({
+        "jsonrpc": "2.0", "id": 2, "method": "textDocument/hover",
+        "params": {},
+    }));
+    let response = server.recv();
+    assert_eq!(response["id"], 2);
+    assert_eq!(response["error"]["code"], -32601);
+
+    // didChange to valid source → diagnostics clear (empty array).
+    server.send(json!({
+        "jsonrpc": "2.0", "method": "textDocument/didChange",
+        "params": {
+            "textDocument": { "uri": URI, "version": 2 },
+            "contentChanges": [ { "text": "let x = 3" } ],
+        },
+    }));
+    let publish = server.recv();
+    assert_eq!(publish["method"], "textDocument/publishDiagnostics");
+    assert_eq!(publish["params"]["uri"], URI);
+    assert_eq!(publish["params"]["diagnostics"], json!([]));
+
+    // Clean shutdown.
+    server.send(json!({ "jsonrpc": "2.0", "id": 3, "method": "shutdown" }));
+    assert_eq!(server.recv()["id"], 3);
+    server.send(json!({ "jsonrpc": "2.0", "method": "exit" }));
+    let status = server.child.wait().expect("wait for exit");
+    assert!(status.success(), "server exited with {status}");
+}
+
+/// The VSCode extension's grammar and manifests must at least be valid JSON
+/// (visual verification happens in the editor — see tools/mle-vscode/README).
+/// The highlighting sample must also be a valid MLE module, so it stays in
+/// step with the language.
+#[test]
+fn vscode_extension_assets_are_well_formed() {
+    let extension_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/../mle-vscode");
+    for file in [
+        "syntaxes/mle.tmLanguage.json",
+        "language-configuration.json",
+        "package.json",
+    ] {
+        let path = format!("{extension_dir}/{file}");
+        let text = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+        serde_json::from_str::<Value>(&text).unwrap_or_else(|e| panic!("parse {path}: {e}"));
+    }
+
+    let sample = std::fs::read_to_string(format!("{extension_dir}/test/sample.mle")).unwrap();
+    let program = mle::parse(&sample).expect("sample.mle parses");
+    mle::lower(program).expect("sample.mle lowers");
+}

--- a/tools/mle-vscode/README.md
+++ b/tools/mle-vscode/README.md
@@ -1,0 +1,49 @@
+# MLE for VSCode
+
+Language support for `.mle` files (docs/mle.md Track D):
+
+- **Syntax highlighting** — TextMate grammar (`syntaxes/mle.tmLanguage.json`).
+- **Diagnostics** — parse/lower errors as you type, via the `mle-lsp` language
+  server (`tools/mle-lsp` in this repo) speaking LSP over stdio.
+
+## Prerequisite: `mle-lsp` on PATH
+
+The extension launches the `mle-lsp` **binary from your PATH** — it is not
+bundled. Build and install it from the repo root:
+
+```sh
+cargo install --path tools/mle-lsp
+# or: cargo build -p mle-lsp && ln -s "$PWD/target/debug/mle-lsp" ~/.local/bin/
+```
+
+Without it, highlighting still works but diagnostics are silently absent
+(VSCode reports the failed server launch in the Output panel).
+
+## Install
+
+```sh
+cd tools/mle-vscode
+npm install                      # fetches vscode-languageclient
+npx @vscode/vsce package         # produces mle-vscode-0.1.0.vsix
+code --install-extension mle-vscode-0.1.0.vsix
+```
+
+## Develop (F5 dev host)
+
+Open `tools/mle-vscode/` as the workspace folder in VSCode, run `npm install`
+once, then press **F5** ("Run Extension") to launch an Extension Development
+Host with the extension loaded. Open any `.mle` file — e.g.
+`test/sample.mle` or `mle/examples/*.mle`.
+
+## Grammar: regenerate and test
+
+The grammar is hand-written JSON — edit `syntaxes/mle.tmLanguage.json`
+directly (there is no generation step). Two levels of verification:
+
+- **Automated sanity:** `cargo test -p mle-lsp` checks the grammar,
+  `language-configuration.json`, and `package.json` are valid JSON, and that
+  `test/sample.mle` (which exercises every construct) still parses and lowers
+  with the current `mle` crate.
+- **Visual verification happens in the editor:** open `test/sample.mle` in the
+  dev host and eyeball the scopes with
+  `Developer: Inspect Editor Tokens and Scopes`.

--- a/tools/mle-vscode/client/extension.js
+++ b/tools/mle-vscode/client/extension.js
@@ -1,0 +1,24 @@
+// MLE extension entry point: start an LSP client for `.mle` documents,
+// launching the `mle-lsp` binary from PATH (see ../README.md for how to get
+// it there). Plain JS on purpose — no bundler or TS build step; the only
+// runtime dependency is vscode-languageclient.
+const { LanguageClient } = require("vscode-languageclient/node");
+
+let client;
+
+function activate() {
+  client = new LanguageClient(
+    "mle",
+    "MLE Language Server",
+    // Resolved from PATH; stdio is the vscode-languageclient default.
+    { command: "mle-lsp" },
+    { documentSelector: [{ language: "mle" }] }
+  );
+  client.start();
+}
+
+function deactivate() {
+  return client ? client.stop() : undefined;
+}
+
+module.exports = { activate, deactivate };

--- a/tools/mle-vscode/language-configuration.json
+++ b/tools/mle-vscode/language-configuration.json
@@ -1,0 +1,22 @@
+{
+  "comments": {
+    "lineComment": "//"
+  },
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ],
+  "autoClosingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "(", "close": ")" },
+    { "open": "\"", "close": "\"", "notIn": ["string"] }
+  ],
+  "surroundingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"],
+    ["\"", "\""]
+  ]
+}

--- a/tools/mle-vscode/package.json
+++ b/tools/mle-vscode/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "mle-vscode",
+  "displayName": "MLE",
+  "description": "Language support for MLE (.mle): syntax highlighting and diagnostics via the mle-lsp language server.",
+  "version": "0.1.0",
+  "publisher": "functor",
+  "license": "MIT",
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": [
+    "Programming Languages"
+  ],
+  "main": "./client/extension.js",
+  "activationEvents": [
+    "onLanguage:mle"
+  ],
+  "contributes": {
+    "languages": [
+      {
+        "id": "mle",
+        "aliases": [
+          "MLE",
+          "mle"
+        ],
+        "extensions": [
+          ".mle"
+        ],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "mle",
+        "scopeName": "source.mle",
+        "path": "./syntaxes/mle.tmLanguage.json"
+      }
+    ]
+  },
+  "dependencies": {
+    "vscode-languageclient": "^9.0.1"
+  }
+}

--- a/tools/mle-vscode/syntaxes/mle.tmLanguage.json
+++ b/tools/mle-vscode/syntaxes/mle.tmLanguage.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "MLE",
+  "scopeName": "source.mle",
+  "patterns": [
+    { "include": "#comment" },
+    { "include": "#string" },
+    { "include": "#keyword" },
+    { "include": "#boolean" },
+    { "include": "#number" },
+    { "include": "#qualified-name" },
+    { "include": "#type-name" },
+    { "include": "#operator" },
+    { "include": "#punctuation" }
+  ],
+  "repository": {
+    "comment": {
+      "name": "comment.line.double-slash.mle",
+      "match": "//.*$"
+    },
+    "string": {
+      "name": "string.quoted.double.mle",
+      "begin": "\"",
+      "end": "\"",
+      "beginCaptures": {
+        "0": { "name": "punctuation.definition.string.begin.mle" }
+      },
+      "endCaptures": {
+        "0": { "name": "punctuation.definition.string.end.mle" }
+      },
+      "patterns": [
+        {
+          "name": "constant.character.escape.mle",
+          "match": "\\\\[\\\\\"nt]"
+        },
+        {
+          "name": "invalid.illegal.unknown-escape.mle",
+          "match": "\\\\."
+        }
+      ]
+    },
+    "keyword": {
+      "name": "keyword.control.mle",
+      "match": "\\b(let|type)\\b"
+    },
+    "boolean": {
+      "name": "constant.language.boolean.mle",
+      "match": "\\b(true|false)\\b"
+    },
+    "number": {
+      "name": "constant.numeric.mle",
+      "match": "\\b[0-9]+(\\.[0-9]+)?\\b"
+    },
+    "qualified-name": {
+      "comment": "Module access like `List.map` / `Text.concat`",
+      "match": "\\b([A-Z][A-Za-z0-9_]*)(\\.)([a-z][A-Za-z0-9_]*)\\b",
+      "captures": {
+        "1": { "name": "entity.name.namespace.mle" },
+        "2": { "name": "punctuation.accessor.mle" },
+        "3": { "name": "support.function.mle" }
+      }
+    },
+    "type-name": {
+      "comment": "Any other uppercase identifier is a type: `type` decl names, annotations after `:`, and generic arguments (`List<Float>`)",
+      "name": "entity.name.type.mle",
+      "match": "\\b[A-Z][A-Za-z0-9_]*\\b"
+    },
+    "operator": {
+      "patterns": [
+        {
+          "name": "keyword.operator.pipeline.mle",
+          "match": "\\|>"
+        },
+        {
+          "name": "storage.type.function.arrow.mle",
+          "match": "=>"
+        },
+        {
+          "name": "keyword.operator.comparison.mle",
+          "match": "==|<|>"
+        },
+        {
+          "name": "keyword.operator.assignment.mle",
+          "match": "="
+        },
+        {
+          "name": "keyword.operator.arithmetic.mle",
+          "match": "[+*/]|-"
+        }
+      ]
+    },
+    "punctuation": {
+      "patterns": [
+        {
+          "name": "punctuation.separator.comma.mle",
+          "match": ","
+        },
+        {
+          "name": "punctuation.separator.key-value.mle",
+          "match": ":"
+        },
+        {
+          "name": "punctuation.accessor.mle",
+          "match": "\\."
+        },
+        {
+          "name": "punctuation.section.braces.mle",
+          "match": "[{}]"
+        },
+        {
+          "name": "punctuation.section.brackets.mle",
+          "match": "[\\[\\]]"
+        },
+        {
+          "name": "punctuation.section.parens.mle",
+          "match": "[()]"
+        }
+      ]
+    }
+  }
+}

--- a/tools/mle-vscode/test/sample.mle
+++ b/tools/mle-vscode/test/sample.mle
@@ -1,0 +1,43 @@
+// Highlighting sample — exercises every MLE construct the grammar knows.
+// Kept valid (parse + lower) by the `vscode_extension_assets_are_well_formed`
+// test in tools/mle-lsp/tests/e2e.rs.
+
+// Type declarations: record types, generic annotations.
+type Position = { x: Float, y: Float }
+type Player = { name: String, scores: List<Float> }
+
+// Literals: numbers, booleans, strings with escapes.
+let debug = false
+let enabled = true
+let threshold = 10
+let pi = 3.14
+let banner = "scores:\n\t\"final\" \\ report"
+
+// Lambdas with and without annotations; arithmetic and unary minus.
+let add = (a: Float, b: Float): Float => a + b
+let average = (a, b) => (a + b) / 2.0
+let negate = (n) => -n
+let scaled = (n) => n * 100.0 - threshold
+
+// Records, field access, comparisons.
+let origin = { x: 0.0, y: 0.0 }
+let mirror = (p: Position): Position => { x: -p.x, y: p.y }
+let isOrigin = (p: Position): Bool => p.x == 0.0
+let isHigh = (score: Float): Bool => score > threshold
+let isLow = (score: Float): Bool => score < threshold
+
+// Pipelines and qualified names (trailing commas allowed in lists/records).
+let total = (p: Player): Float => p.scores |> List.fold(add, 0.0)
+let normalized = (score) => score / 100.0 |> Math.clamp01
+let report = (scores) =>
+  scores
+    |> List.filter(isHigh)
+    |> List.map((s) => Text.concat("score: ", Text.fromFloat(s)))
+    |> Text.toBullets
+
+let main = () =>
+  report([
+    12.0,
+    3.5,
+    40.0,
+  ])


### PR DESCRIPTION
## What

New **Track D — IDE tooling** (docs/mle.md; the endgame renumbered D→E to keep track letters unique):

- **`tools/mle-lsp`** — a minimal Language Server for `.mle`, hand-rolled over stdio (serde_json only — no tower-lsp/tokio): `Content-Length` framing (case-insensitive headers, garbage-frame resilient), initialize/shutdown/exit lifecycle with spec-correct exit codes and post-shutdown refusal, full-sync didOpen/didChange/didClose, and **live parse+lower diagnostics** published with correct 0-based, UTF-16-code-unit LSP ranges from mle's spans. Clears diagnostics when the buffer becomes valid and on close.
- **`tools/mle-vscode`** — TextMate grammar (scopes matched against the real lexer: escape set, number forms, `|>`/`=>`/`==` ordering, qualified names), language configuration (comments/brackets/auto-close), and a plain-JS `vscode-languageclient` extension launching `mle-lsp` from PATH. README covers install/dev-run.

## Verification

- **11 tests**: 9 unit + 2 e2e that spawn the real binary and speak framed LSP over stdio — broken document → diagnostic with the right message/range, edit to valid → diagnostics clear, unknown request → MethodNotFound without dying. Grammar JSON validity is test-checked; `test/sample.mle` (every construct) parses+lowers by test.
- Built by a background agent (which finished the implementation, then hit its session limit mid-review); I verified independently and ran the full cross-engine review. **Six probe-verified findings fixed**: malformed-frame crash (High — one bad frame killed the session), char-vs-UTF-16 columns (squiggles misplaced after emoji), dead uri→text state, exit-code spec, post-shutdown traffic, case-sensitive headers. Accepted cosmetic: generic angle brackets scope as operators (both engines flagged; regex-grammar limitation, noted for later).

## Notes

- Diagnostics currently cover parse+lower; wiring in `mle check` (#161) is a one-line follow-up once B4 merges.
- Merge order vs #160/#161: independent code, shared `docs/mle.md` — whichever merges last may need a trivial doc rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)