### PR TITLE
feat(mle,tooling): hover/quick-info + type diagnostics in the editor (D3a)

### DIFF
--- a/.claude/skills/mle-language/SKILL.md
+++ b/.claude/skills/mle-language/SKILL.md
@@ -22,7 +22,8 @@ cargo run -q -p mle -- check file.mle   # gradual typechecker: ALL diagnostics, 
 
 Errors are always `file:line:col: error: message`. Tests live in `mle/tests/`
 with goldens next to `mle/examples/` (`UPDATE_GOLDENS=1 cargo test -p mle`
-regenerates). VSCode gets live diagnostics via `tools/mle-lsp`.
+regenerates). VSCode gets live parse/lower/type diagnostics and
+`name : Type` hover via `tools/mle-lsp`.
 
 ## Syntax subset
 

--- a/docs/mle.md
+++ b/docs/mle.md
@@ -258,9 +258,16 @@ First-class `.mle` editor support, built on the `mle` crate's front-end
       errors as spanned diagnostics on open/change. *Verify:* framed-protocol
       e2e test drives the real binary (broken doc → diagnostic, fix → clear,
       unknown method → MethodNotFound).
-- [ ] **D3. Hover types & go-to-definition.** Deferred: hover needs B4's
-      typechecker; go-to-def needs a use→definition query over the IR (it
-      already carries spans on every node, but no query API yet).
+- [x] **D3a. Hover types + type diagnostics in-editor.** `mle::hover`
+      (language-aware, unit-tested: innermost node at an offset →
+      `name : Type` from the checker's per-expression table, honest
+      `Unknown` for unannotated code) behind `textDocument/hover` with
+      UTF-16-correct positions; `mle check`'s full diagnostic set now
+      publishes alongside parse/lower errors. *Verify:* 8 hover unit tests +
+      the framed e2e drives a real hover round-trip.
+- [ ] **D3b. Go-to-definition.** Needs a use→definition query over the IR
+      (it already carries spans on every node, but no query API yet); the
+      hover node-walk is the natural starting point.
 
 ## Endgame — replace F#
 

--- a/mle/src/hover.rs
+++ b/mle/src/hover.rs
@@ -1,0 +1,188 @@
+//! Hover/quick-info: what to show for a byte offset in a checked module —
+//! the language-aware half of the LSP's `textDocument/hover` (Track D). The
+//! editor server converts positions and speaks the protocol; this module
+//! decides content, so it is unit-testable without an editor.
+//!
+//! The answer is the **innermost** expression (or lambda parameter, or
+//! top-level definition name) whose span contains the offset, rendered as
+//! `name : Type` for named things and bare `Type` otherwise. Types come from
+//! the checker's per-expression table ([`crate::types::ExprTypes`]) — in
+//! unannotated code they are honestly `Unknown` (the language is gradually
+//! typed; see [`crate::types`]).
+
+use crate::ast::TypeName;
+use crate::ir::{Expr, ExprKind, Module};
+use crate::span::Span;
+use crate::types::{ExprTypes, Type};
+
+/// The hover for `offset`, if any: the span the hover applies to plus its
+/// text (one line, `name : Type` shaped).
+pub fn hover_text(module: &Module, types: &ExprTypes, offset: usize) -> Option<(Span, String)> {
+    let mut best: Option<(Span, String)> = None;
+    let mut consider = |span: Span, text: String| {
+        if span.start <= offset && offset < span.end {
+            let tighter = match &best {
+                Some((held, _)) => span.end - span.start <= held.end - held.start,
+                None => true,
+            };
+            if tighter {
+                best = Some((span, text));
+            }
+        }
+    };
+
+    for def in &module.defs {
+        // The definition name itself: inside the def's span but before its
+        // value (i.e. the `let name =` part).
+        if def.span.start <= offset && offset < def.value.span.start {
+            let ty = types
+                .get(&def.value.id.raw())
+                .cloned()
+                .unwrap_or(Type::Unknown);
+            consider(
+                Span::new(def.span.start, def.value.span.start),
+                format!("{} : {ty}", def.name),
+            );
+        }
+        visit(&def.value, types, &mut consider);
+    }
+    best
+}
+
+fn visit(expr: &Expr, types: &ExprTypes, consider: &mut impl FnMut(Span, String)) {
+    let ty = types.get(&expr.id.raw()).cloned().unwrap_or(Type::Unknown);
+    match &expr.kind {
+        ExprKind::Local { name, .. } | ExprKind::Global(name) => {
+            consider(expr.span, format!("{name} : {ty}"));
+        }
+        ExprKind::LocalMut { name, .. } => {
+            consider(expr.span, format!("mut {name} : {ty}"));
+        }
+        ExprKind::External(path) => {
+            consider(expr.span, format!("{} : {ty}", path.join(".")));
+        }
+        ExprKind::Lambda { params, body, .. } => {
+            consider(expr.span, ty.to_string());
+            for param in params.iter() {
+                let shown = param
+                    .ty
+                    .as_ref()
+                    .map(type_name_text)
+                    .unwrap_or_else(|| "Unknown".to_string());
+                consider(param.span, format!("{} : {shown}", param.name));
+            }
+            visit(body, types, consider);
+        }
+        _ => {
+            consider(expr.span, ty.to_string());
+            for child in children(expr) {
+                visit(child, types, consider);
+            }
+        }
+    }
+}
+
+/// The direct sub-expressions of a node (Lambda handled by the caller).
+fn children(expr: &Expr) -> Vec<&Expr> {
+    match &expr.kind {
+        ExprKind::Record(fields) => fields.iter().map(|f| &f.value).collect(),
+        ExprKind::RecordUpdate { base, fields } => std::iter::once(base.as_ref())
+            .chain(fields.iter().map(|f| &f.value))
+            .collect(),
+        ExprKind::List(items) => items.iter().collect(),
+        ExprKind::FieldAccess { object, .. } => vec![object],
+        ExprKind::Call { callee, args } => std::iter::once(callee.as_ref())
+            .chain(args.iter())
+            .collect(),
+        ExprKind::Binary { lhs, rhs, .. } => vec![lhs, rhs],
+        ExprKind::Neg(inner) => vec![inner],
+        ExprKind::Let { value, body, .. } => vec![value, body],
+        ExprKind::Assign { value, rest, .. } => vec![value, rest],
+        ExprKind::Number(_)
+        | ExprKind::String(_)
+        | ExprKind::Bool(_)
+        | ExprKind::Local { .. }
+        | ExprKind::LocalMut { .. }
+        | ExprKind::Global(_)
+        | ExprKind::External(_)
+        | ExprKind::Lambda { .. } => vec![],
+    }
+}
+
+/// Render a surface annotation (`List<Float>`) for param hovers, which have
+/// no expression node of their own.
+fn type_name_text(ty: &TypeName) -> String {
+    if ty.args.is_empty() {
+        return ty.name.clone();
+    }
+    let args: Vec<String> = ty.args.iter().map(type_name_text).collect();
+    format!("{}<{}>", ty.name, args.join(", "))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::check_with_types;
+
+    fn hover_at(src: &str, needle: &str) -> Option<String> {
+        let module = crate::lower(crate::parse(src).expect("parse")).expect("lower");
+        let (_, types) = check_with_types(&module);
+        let offset = src.find(needle).expect("needle present");
+        hover_text(&module, &types, offset).map(|(_, text)| text)
+    }
+
+    #[test]
+    fn hover_on_a_builtin_shows_its_signature() {
+        let text = hover_at("let f = (xs) => xs |> List.maximum", "List.maximum").unwrap();
+        assert_eq!(text, "List.maximum : (List<Float>) => Float");
+    }
+
+    #[test]
+    fn hover_on_an_annotated_param_shows_its_type() {
+        let text = hover_at("let f = (score: Float): Bool => score > 1.0", "score:").unwrap();
+        assert_eq!(text, "score : Float");
+    }
+
+    #[test]
+    fn hover_on_a_local_reference_shows_the_inferred_type() {
+        let text = hover_at("let f = (score: Float): Bool => score > 1.0", "score >").unwrap();
+        assert_eq!(text, "score : Float");
+    }
+
+    #[test]
+    fn hover_on_a_global_reference_shows_its_signature() {
+        let src = "let double = (x: Float): Float => x * 2.0\nlet main = () => double(2.0)";
+        let text = hover_at(src, "double(2.0)").unwrap();
+        assert_eq!(text, "double : (Float) => Float");
+    }
+
+    #[test]
+    fn hover_on_a_mut_binding_says_mut() {
+        let src = "let f = (x: Float) => let mut a = x in a := a + 1.0; a";
+        let offset = src.rfind("a").unwrap();
+        let module = crate::lower(crate::parse(src).unwrap()).unwrap();
+        let (_, types) = check_with_types(&module);
+        let (_, text) = hover_text(&module, &types, offset).unwrap();
+        assert_eq!(text, "mut a : Float");
+    }
+
+    #[test]
+    fn hover_on_the_definition_name_shows_its_type() {
+        let text = hover_at("let threshold = 10", "threshold").unwrap();
+        assert_eq!(text, "threshold : Float");
+    }
+
+    #[test]
+    fn unannotated_code_hovers_as_unknown() {
+        let text = hover_at("let f = (x) => x", "x)").unwrap();
+        assert_eq!(text, "x : Unknown");
+    }
+
+    #[test]
+    fn no_hover_outside_any_node() {
+        let src = "let a = 1.0";
+        let module = crate::lower(crate::parse(src).unwrap()).unwrap();
+        let (_, types) = check_with_types(&module);
+        assert!(hover_text(&module, &types, src.len()).is_none());
+    }
+}

--- a/mle/src/hover.rs
+++ b/mle/src/hover.rs
@@ -61,6 +61,27 @@ fn visit(expr: &Expr, types: &ExprTypes, consider: &mut impl FnMut(Span, String)
         ExprKind::External(path) => {
             consider(expr.span, format!("{} : {ty}", path.join(".")));
         }
+        ExprKind::Let {
+            name,
+            mutable,
+            value,
+            body,
+            ..
+        } => {
+            // The binder-name region (`let [mut] name =`), like def names.
+            if expr.span.start < value.span.start {
+                let value_ty = types.get(&value.id.raw()).cloned().unwrap_or(Type::Unknown);
+                let label = if *mutable {
+                    format!("mut {name} : {value_ty}")
+                } else {
+                    format!("{name} : {value_ty}")
+                };
+                consider(Span::new(expr.span.start, value.span.start), label);
+            }
+            consider(expr.span, ty.to_string());
+            visit(value, types, consider);
+            visit(body, types, consider);
+        }
         ExprKind::Lambda { params, body, .. } => {
             consider(expr.span, ty.to_string());
             for param in params.iter() {
@@ -184,5 +205,58 @@ mod tests {
         let module = crate::lower(crate::parse(src).unwrap()).unwrap();
         let (_, types) = check_with_types(&module);
         assert!(hover_text(&module, &types, src.len()).is_none());
+    }
+}
+
+#[cfg(test)]
+mod review_tests {
+    use super::*;
+    use crate::types::check_with_types;
+
+    fn hover_at(src: &str, needle: &str) -> String {
+        let module = crate::lower(crate::parse(src).expect("parse")).expect("lower");
+        let (_, types) = check_with_types(&module);
+        let offset = src.find(needle).expect("needle present");
+        hover_text(&module, &types, offset)
+            .map(|(_, text)| text)
+            .expect("hover present")
+    }
+
+    // [AGREED review] literals in structurally-checked positions hover with
+    // their checked type, not Unknown.
+    #[test]
+    fn checked_record_literal_hovers_with_its_type() {
+        let src = "type P = { x: Float }\nlet mk = (): P => { x: 1.0 }";
+        assert_eq!(hover_at(src, "{ x: 1.0 }"), "P");
+    }
+
+    #[test]
+    fn checked_list_literal_hovers_with_its_type() {
+        let src = "let f = (): List<Float> => [1.0, 2.0]";
+        assert_eq!(hover_at(src, "[1.0"), "List<Float>");
+    }
+
+    // [review] inner nodes of a binary spine are recorded too.
+    #[test]
+    fn inner_binary_nodes_hover_with_their_type() {
+        let src = "let f = (x: Float) => x + x + x";
+        let inner_plus = src.find('+').unwrap();
+        let module = crate::lower(crate::parse(src).unwrap()).unwrap();
+        let (_, types) = check_with_types(&module);
+        let (_, text) = hover_text(&module, &types, inner_plus).unwrap();
+        assert_eq!(text, "Float");
+    }
+
+    // [review] let/mut binder names hover with `name : Type`.
+    #[test]
+    fn let_binder_name_hovers_named() {
+        let src = "let f = (x: Float) => let y = x in y + 1.0";
+        assert_eq!(hover_at(src, "y ="), "y : Float");
+    }
+
+    #[test]
+    fn mut_binder_name_hovers_named() {
+        let src = "let f = (x: Float) => let mut a = x in a := a + 1.0; a";
+        assert_eq!(hover_at(src, "mut a ="), "mut a : Float");
     }
 }

--- a/mle/src/ir.rs
+++ b/mle/src/ir.rs
@@ -34,6 +34,14 @@ pub struct BindingId(pub(crate) u32);
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct ExprId(pub(crate) u32);
 
+impl ExprId {
+    /// The raw id, for keying external per-node tables
+    /// ([`crate::types::ExprTypes`]).
+    pub fn raw(self) -> u32 {
+        self.0
+    }
+}
+
 // Compact `d0` / `b0` / `e0` forms keep the pretty-Debug IR (and the
 // committed `.ir` goldens) readable, like `Span`'s `start..end`.
 impl fmt::Debug for DefId {

--- a/mle/src/lib.rs
+++ b/mle/src/lib.rs
@@ -10,6 +10,7 @@
 
 pub mod ast;
 pub mod eval;
+pub mod hover;
 pub mod ir;
 mod lexer;
 mod lower;
@@ -24,7 +25,7 @@ pub use eval::{
 pub use lower::lower;
 pub use parser::parse;
 pub use span::{line_col, Span};
-pub use types::check;
+pub use types::{check, check_with_types, ExprTypes};
 pub use value::{HostData, Value};
 
 /// A lex or parse failure: a message plus the span of the offending source.

--- a/mle/src/types.rs
+++ b/mle/src/types.rs
@@ -356,6 +356,10 @@ impl Checker {
         match (&expr.kind, expected) {
             (ExprKind::Record(fields), Type::Record(name)) => {
                 self.check_record_literal(fields, name, expr.span);
+                // Structural paths bypass `infer`, so record the checked
+                // type here or hover would honestly-but-wrongly say Unknown
+                // (and a stale quiet-pass entry could linger).
+                self.expr_types.insert(expr.id.raw(), expected.clone());
             }
             // A record literal can never be a primitive/list/function,
             // whatever nominal type it might otherwise satisfy.
@@ -372,6 +376,7 @@ impl Checker {
                 for item in items {
                     self.expect(item, elem, "list element");
                 }
+                self.expr_types.insert(expr.id.raw(), expected.clone());
             }
             _ => {
                 let got = self.infer(expr);
@@ -623,15 +628,18 @@ impl Checker {
                 let mut spine = Vec::new();
                 let mut leaf = expr;
                 while let ExprKind::Binary { op, lhs, rhs } = &leaf.kind {
-                    spine.push((*op, rhs.as_ref(), leaf.span));
+                    spine.push((*op, rhs.as_ref(), leaf.span, leaf.id));
                     leaf = lhs;
                 }
                 let mut acc = self.infer(leaf);
                 let mut acc_span = leaf.span;
-                for (op, rhs, node_span) in spine.into_iter().rev() {
+                for (op, rhs, node_span, node_id) in spine.into_iter().rev() {
                     let rhs_ty = self.infer(rhs);
                     acc = self.binary(op, &acc, acc_span, &rhs_ty, rhs.span, node_span);
                     acc_span = node_span;
+                    // Spine nodes never pass through the recording `infer`
+                    // wrapper (the walk is iterative) — record each here.
+                    self.expr_types.insert(node_id.raw(), acc.clone());
                 }
                 acc
             }

--- a/mle/src/types.rs
+++ b/mle/src/types.rs
@@ -158,15 +158,27 @@ pub fn builtin_signature(b: Builtin) -> Type {
     }
 }
 
+/// The checker's best-known type for every expression node, keyed by the
+/// node's raw [`crate::ir::ExprId`] — the substrate for editor hover
+/// (see [`crate::hover`]).
+pub type ExprTypes = HashMap<u32, Type>;
+
 /// Check a lowered module; returns every diagnostic, sorted by position.
 /// Empty means clean.
 pub fn check(module: &Module) -> Vec<CheckError> {
+    check_with_types(module).0
+}
+
+/// [`check`], also returning the per-expression types recorded during the
+/// (final, loud) inference pass.
+pub fn check_with_types(module: &Module) -> (Vec<CheckError>, ExprTypes) {
     let mut checker = Checker {
         records: HashMap::new(),
         globals: HashMap::new(),
         locals: HashMap::new(),
         diags: Vec::new(),
         quiet: false,
+        expr_types: HashMap::new(),
     };
 
     // Record type names first (nominal references may be forward), then
@@ -225,7 +237,7 @@ pub fn check(module: &Module) -> Vec<CheckError> {
     }
 
     checker.diags.sort_by_key(|d| d.span.start);
-    checker.diags
+    (checker.diags, checker.expr_types)
 }
 
 struct Checker {
@@ -239,6 +251,9 @@ struct Checker {
     /// Suppress diagnostics (the quiet enrichment pass — the loud pass walks
     /// the same nodes again and reports once).
     quiet: bool,
+    /// Best-known type per expression, recorded by [`Checker::infer`]. The
+    /// loud pass runs last, so its (better-informed) types win.
+    expr_types: ExprTypes,
 }
 
 /// Prefer the known parts of two views of the same definition's type: the
@@ -403,6 +418,12 @@ impl Checker {
     }
 
     fn infer(&mut self, expr: &Expr) -> Type {
+        let ty = self.infer_inner(expr);
+        self.expr_types.insert(expr.id.raw(), ty.clone());
+        ty
+    }
+
+    fn infer_inner(&mut self, expr: &Expr) -> Type {
         match &expr.kind {
             ExprKind::Number(_) => Type::Float,
             ExprKind::String(_) => Type::String,

--- a/tools/mle-lsp/src/main.rs
+++ b/tools/mle-lsp/src/main.rs
@@ -8,9 +8,12 @@
 //! bill of health) is published via `textDocument/publishDiagnostics`.
 //!
 //! Document sync is **full** (`textDocumentSync: 1`): every change carries
-//! the whole buffer, so the server keeps no state at all — diagnostics are
-//! computed straight from the incoming text.
+//! the whole buffer. The server keeps one piece of state — a uri→text map —
+//! to answer `textDocument/hover` (quick info: `name : Type` from the
+//! gradual checker, via `mle::hover`). Diagnostics cover parse, lowering,
+//! and every `mle::check` type diagnostic.
 
+use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Write};
 
 use serde_json::{json, Value};
@@ -33,6 +36,7 @@ fn main() {
 /// it is 1 (EOF — the client vanished — is a quiet 0).
 fn serve(reader: &mut impl BufRead, writer: &mut impl Write) -> i32 {
     let mut shutdown_seen = false;
+    let mut documents: HashMap<String, String> = HashMap::new();
     while let Some(message) = read_message(reader) {
         let method = message["method"].as_str().unwrap_or("").to_string();
         let id = message.get("id").cloned();
@@ -56,7 +60,7 @@ fn serve(reader: &mut impl BufRead, writer: &mut impl Write) -> i32 {
             // --- Requests (have an id; must be answered). ---
             ("initialize", Some(id)) => {
                 let result = json!({
-                    "capabilities": { "textDocumentSync": 1 },
+                    "capabilities": { "textDocumentSync": 1, "hoverProvider": true },
                     "serverInfo": { "name": "mle-lsp" },
                 });
                 write_message(
@@ -69,6 +73,17 @@ fn serve(reader: &mut impl BufRead, writer: &mut impl Write) -> i32 {
                 write_message(
                     writer,
                     &json!({ "jsonrpc": "2.0", "id": id, "result": null }),
+                );
+            }
+            ("textDocument/hover", Some(id)) => {
+                let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
+                let result = documents
+                    .get(uri)
+                    .and_then(|text| hover(text, &params["position"]))
+                    .unwrap_or(Value::Null);
+                write_message(
+                    writer,
+                    &json!({ "jsonrpc": "2.0", "id": id, "result": result }),
                 );
             }
             (_, Some(id)) => {
@@ -87,6 +102,7 @@ fn serve(reader: &mut impl BufRead, writer: &mut impl Write) -> i32 {
                 let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
                 let text = params["textDocument"]["text"].as_str().unwrap_or("");
                 publish_diagnostics(writer, uri, text);
+                documents.insert(uri.to_string(), text.to_string());
             }
             ("textDocument/didChange", None) => {
                 let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
@@ -97,10 +113,12 @@ fn serve(reader: &mut impl BufRead, writer: &mut impl Write) -> i32 {
                     .and_then(|change| change["text"].as_str())
                 {
                     publish_diagnostics(writer, uri, text);
+                    documents.insert(uri.to_string(), text.to_string());
                 }
             }
             ("textDocument/didClose", None) => {
                 let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
+                documents.remove(uri);
                 // Clear stale squiggles for the closed file.
                 write_diagnostics(writer, uri, vec![]);
             }
@@ -115,23 +133,62 @@ fn serve(reader: &mut impl BufRead, writer: &mut impl Write) -> i32 {
 /// diagnostic for the first parse/lower failure, or an empty list (which
 /// clears previous diagnostics) when the module is clean.
 fn publish_diagnostics(writer: &mut impl Write, uri: &str, text: &str) {
-    let error = match mle::parse(text) {
-        Err(err) => Some((err.message, err.span)),
-        Ok(program) => match mle::lower(program) {
-            Err(err) => Some((err.message, err.span)),
-            Ok(_) => None,
-        },
-    };
-    let diagnostics = match error {
-        Some((message, span)) => vec![json!({
+    let diagnostic = |message: &str, span: mle::Span| {
+        json!({
             "range": span_to_range(text, span),
             "severity": 1, // Error
             "source": "mle",
             "message": message,
-        })],
-        None => vec![],
+        })
+    };
+    // Parse and lowering stop at the first error; a clean module then gets
+    // ALL of the gradual checker's type diagnostics.
+    let diagnostics = match mle::parse(text) {
+        Err(err) => vec![diagnostic(&err.message, err.span)],
+        Ok(program) => match mle::lower(program) {
+            Err(err) => vec![diagnostic(&err.message, err.span)],
+            Ok(module) => mle::check(&module)
+                .into_iter()
+                .map(|err| diagnostic(&err.message, err.span))
+                .collect(),
+        },
     };
     write_diagnostics(writer, uri, diagnostics);
+}
+
+/// Answer a hover request: parse/lower/check the buffer, find the innermost
+/// node at the (UTF-16) position, and render `name : Type` as markdown.
+fn hover(text: &str, position: &Value) -> Option<Value> {
+    let offset = position_to_offset(text, position)?;
+    let module = mle::lower(mle::parse(text).ok()?).ok()?;
+    let (_, types) = mle::check_with_types(&module);
+    let (span, hover_text) = mle::hover::hover_text(&module, &types, offset)?;
+    Some(json!({
+        "contents": { "kind": "markdown", "value": format!("```mle\n{hover_text}\n```") },
+        "range": span_to_range(text, span),
+    }))
+}
+
+/// Invert [`lsp_position`]: an LSP `{line, character}` (UTF-16 code units)
+/// to a byte offset. Clamps past-end-of-line characters to the line end.
+fn position_to_offset(text: &str, position: &Value) -> Option<usize> {
+    let line = position["line"].as_u64()? as usize;
+    let character = position["character"].as_u64()? as usize;
+    let line_start = if line == 0 {
+        0
+    } else {
+        text.match_indices('\n').nth(line - 1)?.0 + 1
+    };
+    let line_text = &text[line_start..];
+    let line_text = &line_text[..line_text.find('\n').unwrap_or(line_text.len())];
+    let mut units = 0;
+    for (byte, ch) in line_text.char_indices() {
+        if units >= character {
+            return Some(line_start + byte);
+        }
+        units += ch.len_utf16();
+    }
+    Some(line_start + line_text.len())
 }
 
 fn write_diagnostics(writer: &mut impl Write, uri: &str, diagnostics: Vec<Value>) {

--- a/tools/mle-lsp/src/main.rs
+++ b/tools/mle-lsp/src/main.rs
@@ -3,9 +3,9 @@
 //!
 //! Hand-rolled LSP over stdio: a blocking read loop with `Content-Length`
 //! framing and `serde_json` dispatch — no async runtime, no LSP framework.
-//! The one feature is diagnostics: on `didOpen`/`didChange` the buffer is fed
-//! through [`mle::parse`] and [`mle::lower`], and the first error (or a clean
-//! bill of health) is published via `textDocument/publishDiagnostics`.
+//! On `didOpen`/`didChange` the buffer is fed through [`mle::parse`],
+//! [`mle::lower`], and [`mle::check`]; the first parse/lower error, or ALL
+//! type diagnostics, publish via `textDocument/publishDiagnostics`.
 //!
 //! Document sync is **full** (`textDocumentSync: 1`): every change carries
 //! the whole buffer. The server keeps one piece of state — a uri→text map —
@@ -129,9 +129,9 @@ fn serve(reader: &mut impl BufRead, writer: &mut impl Write) -> i32 {
     0
 }
 
-/// Run the MLE front-end over `text` and publish the outcome: one Error
-/// diagnostic for the first parse/lower failure, or an empty list (which
-/// clears previous diagnostics) when the module is clean.
+/// Run the MLE front-end over `text` and publish the outcome: one diagnostic
+/// for the first parse/lower failure, every `mle::check` type diagnostic for
+/// a lowered module, or an empty list (clearing squiggles) when clean.
 fn publish_diagnostics(writer: &mut impl Write, uri: &str, text: &str) {
     let diagnostic = |message: &str, span: mle::Span| {
         json!({

--- a/tools/mle-lsp/tests/e2e.rs
+++ b/tools/mle-lsp/tests/e2e.rs
@@ -137,8 +137,8 @@ fn diagnostics_over_real_stdio() {
     );
 
     // Clean shutdown.
-    server.send(json!({ "jsonrpc": "2.0", "id": 3, "method": "shutdown" }));
-    assert_eq!(server.recv()["id"], 3);
+    server.send(json!({ "jsonrpc": "2.0", "id": 4, "method": "shutdown" }));
+    assert_eq!(server.recv()["id"], 4);
     server.send(json!({ "jsonrpc": "2.0", "method": "exit" }));
     let status = server.child.wait().expect("wait for exit");
     assert!(status.success(), "server exited with {status}");

--- a/tools/mle-lsp/tests/e2e.rs
+++ b/tools/mle-lsp/tests/e2e.rs
@@ -101,7 +101,7 @@ fn diagnostics_over_real_stdio() {
 
     // An unknown request gets MethodNotFound and the server keeps serving.
     server.send(json!({
-        "jsonrpc": "2.0", "id": 2, "method": "textDocument/hover",
+        "jsonrpc": "2.0", "id": 2, "method": "textDocument/definition",
         "params": {},
     }));
     let response = server.recv();
@@ -120,6 +120,21 @@ fn diagnostics_over_real_stdio() {
     assert_eq!(publish["method"], "textDocument/publishDiagnostics");
     assert_eq!(publish["params"]["uri"], URI);
     assert_eq!(publish["params"]["diagnostics"], json!([]));
+
+    // Hover over the now-valid document: quick info for `x` at line 0 col 4.
+    server.send(json!({
+        "jsonrpc": "2.0", "id": 3, "method": "textDocument/hover",
+        "params": {
+            "textDocument": { "uri": URI },
+            "position": { "line": 0, "character": 4 },
+        },
+    }));
+    let response = server.recv();
+    assert_eq!(response["id"], 3);
+    assert_eq!(
+        response["result"]["contents"]["value"], "```mle\nx : Float\n```",
+        "hover response: {response}"
+    );
 
     // Clean shutdown.
     server.send(json!({ "jsonrpc": "2.0", "id": 3, "method": "shutdown" }));


### PR DESCRIPTION
## What

Track **D3a**: hovering any name in a `.mle` file shows `name : Type`, and the gradual checker's full diagnostic set squiggles in-editor.

- **`mle::hover`** (language-aware, in the language crate, unit-tested without an editor): innermost node at a byte offset → `name : Type` — locals, `mut` slots (labeled `mut`), globals and builtins with full signatures, annotated params, definition and binder names; honest `Unknown` for unannotated code. Powered by **`types::check_with_types`**, which exposes the checker's best-known type per expression.
- **`mle-lsp`**: `hoverProvider` capability, UTF-16-correct position conversion in both directions, markdown `mle`-fenced hover responses with ranges, and diagnostics now include **every `mle::check` type error** once parse+lower succeed (the noted B4 follow-up).

## Verification

- 13 hover unit tests + the framed-stdio e2e now drives a real hover round-trip; 9+2 mle-lsp tests; all mle suites green; fmt/clippy clean.
- Cross-engine review (/xreview), both probing the real binary over framed LSP: no Critical/High. The **[AGREED]** finding — literals in structurally-checked positions hovered `Unknown` because `expect()`'s paths bypassed the recording wrapper — fixed (plus Claude's binary-spine variant of the same root cause, and named hovers for `let`/`mut` binders). Reviewers verified clean: UTF-16 emoji round-trips, pipeline-desugared spans (hover works on a piped value even though its span lies outside the desugared call's), unopened/broken-doc hovers, diagnostic ordering/clearing.

## To use

`cargo install --path tools/mle-lsp --force` (already done on this machine), then reload VSCode — hover any identifier in a `.mle` file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)