### PR TITLE
fix(mle,runtime): C2 review follow-ups — Session/main split, range panic, producer DX

### DIFF
--- a/mle/src/eval.rs
+++ b/mle/src/eval.rs
@@ -164,8 +164,9 @@ pub struct Session {
 }
 
 impl Session {
-    /// Evaluate a module's top-level defs (eagerly, in file order — the same
-    /// semantics as [`run`]) into a session.
+    /// Evaluate a module's top-level defs (eagerly, in file order) into a
+    /// session. Unlike [`run`], a `main` def is NOT called — loading a game
+    /// must not execute anything beyond its initializers.
     pub fn load(module: &Module, host: &mut dyn Host) -> Result<Session, RunFailure> {
         let mut interp = Interp {
             globals: HashMap::new(),
@@ -176,7 +177,7 @@ impl Session {
             call_depth: 0,
             host,
         };
-        match interp.run_module(module) {
+        match interp.eval_defs(module) {
             Ok(_) => Ok(Session {
                 globals: interp.globals,
             }),
@@ -232,13 +233,20 @@ struct Interp<'h> {
 }
 
 impl Interp<'_> {
-    fn run_module(&mut self, module: &Module) -> Result<RunOutcome, RunError> {
+    /// Evaluate every top-level def, eagerly, in file order (no `main` call —
+    /// that is [`Interp::run_module`]'s CLI behavior, not a load semantic).
+    fn eval_defs(&mut self, module: &Module) -> Result<Vec<(String, Value)>, RunError> {
         let mut bindings = Vec::new();
         for def in &module.defs {
             let value = self.eval(&def.value, &Env::empty())?;
             self.globals.insert(def.name.clone(), value.clone());
             bindings.push((def.name.clone(), value));
         }
+        Ok(bindings)
+    }
+
+    fn run_module(&mut self, module: &Module) -> Result<RunOutcome, RunError> {
+        let bindings = self.eval_defs(module)?;
         match module.defs.iter().find(|def| def.name == "main") {
             Some(main_def) => Ok(RunOutcome::Main(self.call_main(main_def)?)),
             None => Ok(RunOutcome::Bindings(bindings)),
@@ -687,14 +695,21 @@ impl Interp<'_> {
             },
             // NaN handling follows Rust's `f64::max` (IEEE maximumNumber):
             // NaN elements are ignored unless every element is NaN.
-            // `List.range(n)` -> [0, 1, …, n-1] as Floats; n truncates.
+            // `List.range(n)` -> [0, 1, …, n-1] as Floats; n truncates. The
+            // count must be finite and sane: MLE numbers permit `inf`
+            // (IEEE division), and `inf as usize` would ask the allocator
+            // for usize::MAX elements — a process-killing panic, not a
+            // recoverable frame error.
             Builtin::ListRange => match args.as_slice() {
-                [Value::Number(n)] => {
+                [Value::Number(n)] if n.is_finite() && *n <= 1_000_000.0 => {
                     let count = n.max(0.0) as usize;
                     Ok(Value::List(Rc::new(
                         (0..count).map(|i| Value::Number(i as f64)).collect(),
                     )))
                 }
+                [Value::Number(n)] => err(format!(
+                    "List.range needs a finite count up to 1000000, got {n}"
+                )),
                 _ => err("List.range(n) expects one number".to_string()),
             },
             Builtin::ListMaximum => match args.as_slice() {

--- a/mle/tests/run.rs
+++ b/mle/tests/run.rs
@@ -373,3 +373,65 @@ fn update_validates_target_before_evaluating_value() {
         "the replacement must not have run: {rendered}"
     );
 }
+
+// --- C2 review pins: Session semantics + new builtins ---
+
+// [AGREED by both engines] loading a module must NOT execute a `main` def —
+// a game file may define one for `mle run` debugging.
+#[test]
+fn session_load_does_not_run_main() {
+    let module = mle::lower(
+        mle::parse(
+            "let init = { n: 1.0 }\n\
+             let main = () => 1.0 + \"boom\"",
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    let session = match mle::Session::load(&module, &mut mle::NoHost) {
+        Ok(session) => session,
+        Err(failure) => panic!("load must not run main: {}", failure.error.message),
+    };
+    match session.global("init") {
+        Some(Value::Record(_)) => {}
+        Some(other) => panic!("expected the init record, got {other}"),
+        None => panic!("init missing"),
+    }
+}
+
+#[test]
+fn session_calls_top_level_functions() {
+    let module = mle::lower(mle::parse("let tick = (n) => { v: n + 1.0 }").unwrap()).unwrap();
+    let session = match mle::Session::load(&module, &mut mle::NoHost) {
+        Ok(session) => session,
+        Err(failure) => panic!("load failed: {}", failure.error.message),
+    };
+    let out = match session.call("tick", vec![Value::Number(1.0)], &mut mle::NoHost) {
+        Ok(out) => out,
+        Err(err) => panic!("call failed: {}", err.message),
+    };
+    assert_eq!(out.to_string(), "{ v: 2 }");
+    let missing = session.call("nope", vec![], &mut mle::NoHost);
+    assert!(missing.is_err());
+}
+
+// [review High] a non-finite or huge range count is a frame error, not a
+// process-killing allocator panic.
+#[test]
+fn range_rejects_non_finite_and_huge_counts() {
+    let (message, _, _) = run_err("let main = () => List.range(1.0 / 0.0)");
+    assert_eq!(
+        message,
+        "List.range needs a finite count up to 1000000, got inf"
+    );
+    let (message, _, _) = run_err("let main = () => List.range(1000000000000.0)");
+    assert!(message.starts_with("List.range needs a finite count"));
+}
+
+#[test]
+fn new_builtins_evaluate() {
+    assert_eq!(main_result("let main = () => List.range(2.7)"), "[0, 1]");
+    assert_eq!(main_result("let main = () => List.range(-3.0)"), "[]");
+    assert_eq!(main_result("let main = () => Math.sin(0.0)"), "0");
+    assert_eq!(main_result("let main = () => Math.cos(0.0)"), "1");
+}

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -28,8 +28,16 @@ use crate::game::Game;
 
 pub struct MleGame {
     path: String,
+    src: String,
     session: Session,
     model: Value,
+    /// The last successfully drawn frame, kept so a bad draw shows the last
+    /// good picture instead of a blank.
+    last_frame: Frame,
+    /// The last per-frame error printed, to avoid flooding stderr at 60fps
+    /// with the same message (a persistent error prints once until it
+    /// changes).
+    last_error: Option<String>,
     // rolling per-frame eval cost, printed every STATS_EVERY frames (the C6
     // perf gate watches these).
     frames: u64,
@@ -74,18 +82,47 @@ impl MleGame {
                 &failure.error.message,
             ),
         };
+        // The producer contract is knowable at load — fail loud here, not
+        // once per frame: `init` must be a model VALUE, `tick`/`draw` must
+        // be functions of the right arity.
         let model = session.global("init").unwrap_or_else(|| {
             eprintln!("error: {path} has no top-level `let init = …`");
             std::process::exit(1);
         });
+        if matches!(
+            model,
+            Value::Closure(_) | Value::Builtin(_) | Value::HostFn(_)
+        ) {
+            eprintln!("error: {path}: `init` must be a model value, not a function");
+            std::process::exit(1);
+        }
+        require_function(path, &session, "tick", 3);
+        require_function(path, &session, "draw", 2);
         println!("[mle] loaded {path}");
         MleGame {
             path: path.to_string(),
+            src,
             session,
             model,
+            last_frame: empty_frame(),
+            last_error: None,
             frames: 0,
             tick_ns: 0,
             draw_ns: 0,
+        }
+    }
+
+    /// Report a per-frame error with its source position, once per distinct
+    /// message (a 60fps loop must not flood stderr with one persistent bug).
+    fn frame_error(&mut self, stage: &str, err: &mle::RunError) {
+        let (line, col) = mle::line_col(&self.src, err.span.start);
+        let rendered = format!(
+            "[mle] {stage} error at {}:{line}:{col}: {}",
+            self.path, err.message
+        );
+        if self.last_error.as_deref() != Some(rendered.as_str()) {
+            eprintln!("{rendered}");
+            self.last_error = Some(rendered);
         }
     }
 
@@ -118,7 +155,7 @@ impl Game for MleGame {
         ];
         match self.session.call("tick", args, &mut FunctorHost) {
             Ok(model) => self.model = model,
-            Err(err) => eprintln!("[mle] tick error in {}: {}", self.path, err.message),
+            Err(err) => self.frame_error("tick", &err),
         }
         self.tick_ns += started.elapsed().as_nanos() as u64;
         self.frames += 1;
@@ -132,24 +169,26 @@ impl Game for MleGame {
     fn render(&mut self, frame_time: FrameTime) -> Frame {
         let started = Instant::now();
         let args = vec![self.model.clone(), Value::Number(frame_time.tts as f64)];
-        let frame = match self.session.call("draw", args, &mut FunctorHost) {
+        match self.session.call("draw", args, &mut FunctorHost) {
             Ok(value) => match frame_value(&value) {
-                Some(frame) => frame.clone(),
+                Some(frame) => self.last_frame = frame.clone(),
                 None => {
-                    eprintln!(
+                    let rendered = format!(
                         "[mle] draw must return Frame.create(camera, scene), got {}",
                         value.kind_name()
                     );
-                    empty_frame()
+                    if self.last_error.as_deref() != Some(rendered.as_str()) {
+                        eprintln!("{rendered}");
+                        self.last_error = Some(rendered);
+                    }
                 }
             },
-            Err(err) => {
-                eprintln!("[mle] draw error in {}: {}", self.path, err.message);
-                empty_frame()
-            }
-        };
+            Err(err) => self.frame_error("draw", &err),
+        }
         self.draw_ns += started.elapsed().as_nanos() as u64;
-        frame
+        // On failure this is the last good frame — a bad draw must not blank
+        // the screen.
+        self.last_frame.clone()
     }
 
     fn ui(&self) -> View {
@@ -181,6 +220,32 @@ impl Game for MleGame {
     fn audio_push_finished(&mut self, _token: i32) {}
 
     fn quit(&mut self) {}
+}
+
+/// Exit loud at load if `name` is not a function of `arity` params — the
+/// alternative is one error per frame, forever.
+fn require_function(path: &str, session: &Session, name: &str, arity: usize) {
+    match session.global(name) {
+        Some(Value::Closure(closure)) if closure.params.len() == arity => {}
+        Some(Value::Closure(closure)) => {
+            eprintln!(
+                "error: {path}: `{name}` must take {arity} parameter(s), takes {}",
+                closure.params.len()
+            );
+            std::process::exit(1);
+        }
+        Some(other) => {
+            eprintln!(
+                "error: {path}: `{name}` must be a function, got {}",
+                other.kind_name()
+            );
+            std::process::exit(1);
+        }
+        None => {
+            eprintln!("error: {path} has no top-level `let {name} = …`");
+            std::process::exit(1);
+        }
+    }
 }
 
 fn empty_frame() -> Frame {


### PR DESCRIPTION
## What

The cross-engine review of #165 completed after it merged — these are its findings, all probe-verified by both engines, as the promised follow-up:

- **[AGREED High] `Session::load` executed `main`.** Loading a game that also defines `main` (e.g. for `mle run` debugging of the same file) ran it at load — and any error/expense in it aborted the runner. `load` now evaluates top-level initializers only (`eval_defs` split out of the CLI's `run_module`); regression-pinned.
- **[High] `List.range(1.0 / 0.0)` killed the process.** `inf as usize` saturates to `usize::MAX` and the collect's reserve panics — reachable from ordinary IEEE division in game code. Now a clean spanned frame error (finite, ≤ 1e6).
- **[AGREED] Contract validated at load, loud, once:** `init` must be a model value (a function — the F# habit — was accepted and then flooded stderr with a misleading `with`-update error every frame); `tick`/`draw` must exist as functions of arity 3/2 (a missing one previously printed ~60 identical errors/sec forever).
- **Per-frame error DX:** errors render `file:line:col` (the language's stated convention), deduplicate (one print per distinct message, not per frame), and a failed `draw` returns the **last good frame** instead of blanking the screen.
- Unit tests for `Session` and the three new builtins (there were none — flagged by review; the range test would have caught the panic).

## Verification

- All suites green (7 mle + runtime); probes re-run post-fix: init-as-function and missing-`draw` fail loud at load with clear messages, `range(inf)` is a spanned error, a mid-run flaky tick freezes the model and keeps rendering.
- **Good path untouched:** the `mle-hello` `--fixed-time` capture is byte-identical to merged #165's.
- Not carried over: the reviewers' note about ~200 lines of rustfmt churn in #165 — it's merged; un-churning now would just churn again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)