### PR TITLE
feat(runtime,sdk): C3 — hot reload with model preservation, e2e-proven

### DIFF
--- a/.claude/skills/mle-language/SKILL.md
+++ b/.claude/skills/mle-language/SKILL.md
@@ -114,7 +114,9 @@ let draw = (model, tts) => Frame.create(camera, scene)
 ```
 
 `examples/mle-hello/game.mle` is the reference. The model shows live at the
-debug server's `GET /state`.
+debug server's `GET /state`. **Hot reload is on by default**: saving the
+`.mle` file reloads it in ~1 frame with the model preserved (a broken edit
+keeps the old program running; an edited `init` takes effect on restart).
 
 Transforms wrap in Group nodes: the **outer call applies last in world
 space** — `s |> Scene.rotateY(r) |> Scene.translate(x, 0.0, 0.0)` rotates in

--- a/docs/mle.md
+++ b/docs/mle.md
@@ -238,10 +238,21 @@ Starts once A2 + B3 exist.
       *Verify (done):* byte-identical `--fixed-time` captures; headless
       `/state` shows the live MLE model. (`functor.json` `language` field —
       CLI wiring — deferred to C4 alongside input.)
-- [ ] **C3. Hot-reload — the payoff.** File-watch → reparse → rebind, model
-      preserved (already serializable data; no dylib, no cargo, no cache).
-      *Verify:* SDK e2e: mutate state → edit `.mle` → assert state survived AND
-      behavior changed; assert edit→frame latency budget.
+- [x] **C3. Hot-reload — the payoff.** The producer polls the file's mtime
+      each frame; on change: reparse → recheck → new `Session`, **model
+      preserved** (it is a plain value the host holds — the C2 architecture's
+      whole point). A broken edit prints once and keeps the old program;
+      contract violations (missing `tick`, function `init`) reject the new
+      session the same way. Reload observed at **0.14ms** re-parse +
+      ≤ 1 frame poll — versus the multi-second Fable+cargo loop this project
+      exists to kill. Caveat until B5: closure values stored *inside* the
+      model keep pre-reload bodies (globals rebind; stored closures need the
+      `(stable-id, env)` representation).
+      *Verify (done):* SDK e2e (`mle-hot-reload.e2e.test.ts`, headless): with
+      the debug clock pinned, spin `0.3` + one post-edit step = exactly
+      `0.3 + dt×(-5)` — state survived AND behavior changed as arithmetic,
+      not a race; latency asserted < 100ms; broken-edit resilience asserted.
+      The SDK gained an `mlePath` launch option.
 - [ ] **C4. MVU parity.** Full `Game` contract (init/update/tick/input/
       subscriptions/draw3d, effect-queue drain-to-fixed-point semantics) from
       MLE. *Verify:* port `examples/primitives`; golden-compare vs the F#

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -95,6 +95,10 @@ fn file_mtime(path: &str) -> std::time::SystemTime {
 
 impl MleGame {
     pub fn create(path: &str) -> MleGame {
+        // Stat BEFORE reading: an edit that lands mid-load then compares
+        // unequal on the next frame and triggers a reload, instead of being
+        // silently absorbed into a stale session.
+        let mtime = file_mtime(path);
         let loaded = match load_game(path) {
             Ok(loaded) => loaded,
             Err(message) => {
@@ -105,7 +109,7 @@ impl MleGame {
         println!("[mle] loaded {path}");
         MleGame {
             path: path.to_string(),
-            mtime: file_mtime(path),
+            mtime,
             src: loaded.src,
             session: loaded.session,
             model: loaded.init,

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -28,6 +28,7 @@ use crate::game::Game;
 
 pub struct MleGame {
     path: String,
+    mtime: std::time::SystemTime,
     src: String,
     session: Session,
     model: Value,
@@ -47,63 +48,67 @@ pub struct MleGame {
 
 const STATS_EVERY: u64 = 300;
 
-fn fail(path: &str, stage: &str, src: &str, span: mle::Span, message: &str) -> ! {
-    let (line, col) = mle::line_col(src, span.start);
-    eprintln!("error: cannot {stage} {path}:{line}:{col}: {message}");
-    std::process::exit(1);
+/// A successfully loaded, contract-validated game module.
+struct Loaded {
+    src: String,
+    session: Session,
+    init: Value,
+}
+
+/// Load, check, and contract-validate a game file. Errors come back as fully
+/// rendered strings (`path:line:col: message`) so `create` can exit loud with
+/// them and hot-reload can print-and-keep-running with the same text.
+fn load_game(path: &str) -> Result<Loaded, String> {
+    let src = std::fs::read_to_string(path).map_err(|e| format!("cannot read {path}: {e}"))?;
+    let render = |stage: &str, span: mle::Span, message: &str| {
+        let (line, col) = mle::line_col(&src, span.start);
+        format!("cannot {stage} {path}:{line}:{col}: {message}")
+    };
+    let program = mle::parse(&src).map_err(|e| render("parse", e.span, &e.message))?;
+    let module = mle::lower(program).map_err(|e| render("load", e.span, &e.message))?;
+    // Type diagnostics are advisory in the dev loop: print, keep going.
+    for diag in mle::check(&module) {
+        let (line, col) = mle::line_col(&src, diag.span.start);
+        eprintln!("warning: {path}:{line}:{col}: {}", diag.message);
+    }
+    let session = Session::load(&module, &mut FunctorHost)
+        .map_err(|f| render("load", f.error.span, &f.error.message))?;
+    // The producer contract is knowable at load — fail here, not once per
+    // frame: `init` must be a model VALUE, `tick`/`draw` functions of the
+    // right arity.
+    let init = session
+        .global("init")
+        .ok_or_else(|| format!("{path} has no top-level `let init = …`"))?;
+    if matches!(init, Value::Closure(_) | Value::Builtin(_) | Value::HostFn(_)) {
+        return Err(format!("{path}: `init` must be a model value, not a function"));
+    }
+    require_function(path, &session, "tick", 3)?;
+    require_function(path, &session, "draw", 2)?;
+    Ok(Loaded { src, session, init })
+}
+
+fn file_mtime(path: &str) -> std::time::SystemTime {
+    std::fs::metadata(path)
+        .and_then(|m| m.modified())
+        .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
 }
 
 impl MleGame {
     pub fn create(path: &str) -> MleGame {
-        let src = std::fs::read_to_string(path).unwrap_or_else(|e| {
-            eprintln!("error: cannot read {path}: {e}");
-            std::process::exit(1);
-        });
-        let program = match mle::parse(&src) {
-            Ok(program) => program,
-            Err(err) => fail(path, "parse", &src, err.span, &err.message),
+        let loaded = match load_game(path) {
+            Ok(loaded) => loaded,
+            Err(message) => {
+                eprintln!("error: {message}");
+                std::process::exit(1);
+            }
         };
-        let module = match mle::lower(program) {
-            Ok(module) => module,
-            Err(err) => fail(path, "load", &src, err.span, &err.message),
-        };
-        // Type diagnostics are advisory in the dev loop: print, keep going.
-        for diag in mle::check(&module) {
-            let (line, col) = mle::line_col(&src, diag.span.start);
-            eprintln!("warning: {path}:{line}:{col}: {}", diag.message);
-        }
-        let session = match Session::load(&module, &mut FunctorHost) {
-            Ok(session) => session,
-            Err(failure) => fail(
-                path,
-                "load",
-                &src,
-                failure.error.span,
-                &failure.error.message,
-            ),
-        };
-        // The producer contract is knowable at load — fail loud here, not
-        // once per frame: `init` must be a model VALUE, `tick`/`draw` must
-        // be functions of the right arity.
-        let model = session.global("init").unwrap_or_else(|| {
-            eprintln!("error: {path} has no top-level `let init = …`");
-            std::process::exit(1);
-        });
-        if matches!(
-            model,
-            Value::Closure(_) | Value::Builtin(_) | Value::HostFn(_)
-        ) {
-            eprintln!("error: {path}: `init` must be a model value, not a function");
-            std::process::exit(1);
-        }
-        require_function(path, &session, "tick", 3);
-        require_function(path, &session, "draw", 2);
         println!("[mle] loaded {path}");
         MleGame {
             path: path.to_string(),
-            src,
-            session,
-            model,
+            mtime: file_mtime(path),
+            src: loaded.src,
+            session: loaded.session,
+            model: loaded.init,
             last_frame: empty_frame(),
             last_error: None,
             frames: 0,
@@ -143,7 +148,40 @@ impl MleGame {
 
 impl Game for MleGame {
     fn check_hot_reload(&mut self, _frame_time: FrameTime) {
-        // C3: file-watch → reparse → new Session, model preserved.
+        // Poll the file's mtime (a stat per frame is ~free) and swap in a new
+        // session on change. THE MODEL IS KEPT: it is a plain value the host
+        // holds, so state survives the edit and all functions rebind — the
+        // dev-loop payoff the language was built for (docs/mle.md C3). A
+        // broken edit prints and keeps the old program running. Caveat until
+        // B5: closure VALUES stored inside the model keep their pre-reload
+        // bodies (globals rebind; stored closures need the (stable-id, env)
+        // representation).
+        let mtime = file_mtime(&self.path);
+        if mtime == self.mtime {
+            return;
+        }
+        self.mtime = mtime;
+        let started = Instant::now();
+        match load_game(&self.path) {
+            Ok(loaded) => {
+                self.src = loaded.src;
+                self.session = loaded.session;
+                self.last_error = None;
+                println!(
+                    "[mle] hot-reloaded {} in {:.2}ms (model preserved; an edited `init` \
+takes effect on restart)",
+                    self.path,
+                    started.elapsed().as_secs_f64() * 1000.0
+                );
+            }
+            Err(message) => {
+                let rendered = format!("[mle] reload failed, keeping old program: {message}");
+                if self.last_error.as_deref() != Some(rendered.as_str()) {
+                    eprintln!("{rendered}");
+                    self.last_error = Some(rendered);
+                }
+            }
+        }
     }
 
     fn tick(&mut self, frame_time: FrameTime) {
@@ -222,29 +260,20 @@ impl Game for MleGame {
     fn quit(&mut self) {}
 }
 
-/// Exit loud at load if `name` is not a function of `arity` params — the
-/// alternative is one error per frame, forever.
-fn require_function(path: &str, session: &Session, name: &str, arity: usize) {
+/// `name` must be a function of `arity` params — a contract violation is
+/// reportable at load, and the alternative is one error per frame, forever.
+fn require_function(path: &str, session: &Session, name: &str, arity: usize) -> Result<(), String> {
     match session.global(name) {
-        Some(Value::Closure(closure)) if closure.params.len() == arity => {}
-        Some(Value::Closure(closure)) => {
-            eprintln!(
-                "error: {path}: `{name}` must take {arity} parameter(s), takes {}",
-                closure.params.len()
-            );
-            std::process::exit(1);
-        }
-        Some(other) => {
-            eprintln!(
-                "error: {path}: `{name}` must be a function, got {}",
-                other.kind_name()
-            );
-            std::process::exit(1);
-        }
-        None => {
-            eprintln!("error: {path} has no top-level `let {name} = …`");
-            std::process::exit(1);
-        }
+        Some(Value::Closure(closure)) if closure.params.len() == arity => Ok(()),
+        Some(Value::Closure(closure)) => Err(format!(
+            "{path}: `{name}` must take {arity} parameter(s), takes {}",
+            closure.params.len()
+        )),
+        Some(other) => Err(format!(
+            "{path}: `{name}` must be a function, got {}",
+            other.kind_name()
+        )),
+        None => Err(format!("{path} has no top-level `let {name} = …`")),
     }
 }
 

--- a/tools/functor-sdk/src/server.ts
+++ b/tools/functor-sdk/src/server.ts
@@ -141,13 +141,17 @@ export class FunctorRunner extends FunctorClient implements AsyncDisposable {
 
     const runnerBin =
       options.runnerBin ?? join(repoRoot, "target", "debug", runnerExe());
-    const dylibPath =
-      options.dylibPath ??
-      join(gameDir, "build-native", "target", "debug", defaultDylibName());
+    // An .mle source runs through the interpreter; otherwise a built dylib.
+    const gamePath = options.mlePath
+      ? isAbsolute(options.mlePath)
+        ? options.mlePath
+        : resolve(options.mlePath)
+      : (options.dylibPath ??
+        join(gameDir, "build-native", "target", "debug", defaultDylibName()));
 
     for (const [label, path] of [
       ["functor-runner", runnerBin],
-      ["game dylib", dylibPath],
+      [options.mlePath ? "mle game source" : "game dylib", gamePath],
     ] as const) {
       if (!existsSync(path)) {
         throw new Error(
@@ -158,7 +162,10 @@ export class FunctorRunner extends FunctorClient implements AsyncDisposable {
       }
     }
 
-    const runnerArgs = ["--game-path", dylibPath, "--debug-port", String(port)];
+    const runnerArgs = ["--game-path", gamePath, "--debug-port", String(port)];
+    if (options.mlePath) {
+      runnerArgs.push("--mle");
+    }
     if (options.headless) {
       runnerArgs.push("--headless");
     }

--- a/tools/functor-sdk/src/server.ts
+++ b/tools/functor-sdk/src/server.ts
@@ -141,6 +141,9 @@ export class FunctorRunner extends FunctorClient implements AsyncDisposable {
 
     const runnerBin =
       options.runnerBin ?? join(repoRoot, "target", "debug", runnerExe());
+    if (options.mlePath && options.dylibPath) {
+      throw new Error("mlePath and dylibPath are mutually exclusive");
+    }
     // An .mle source runs through the interpreter; otherwise a built dylib.
     const gamePath = options.mlePath
       ? isAbsolute(options.mlePath)

--- a/tools/functor-sdk/src/types.ts
+++ b/tools/functor-sdk/src/types.ts
@@ -72,6 +72,10 @@ export interface LaunchOptions {
   runnerBin?: string;
   /** Path to the game dylib (default `<gameDir>/build-native/target/debug/<libgame_native>`). */
   dylibPath?: string;
+  /** Path to an `.mle` game source instead of a dylib: launches the runner
+   * with `--mle` (the MLE interpreter — docs/mle.md Track C2/C3). Mutually
+   * exclusive with `dylibPath`; `gameDir` stays the runner's cwd. */
+  mlePath?: string;
   /** Cargo workspace root (default: walk up from `gameDir`). */
   repoRoot?: string;
   /** Max time to wait for the runtime to be ready, ms (default 60_000). */

--- a/tools/functor-sdk/test/mle-hot-reload.e2e.test.ts
+++ b/tools/functor-sdk/test/mle-hot-reload.e2e.test.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { findRepoRoot, FunctorRunner, waitFor } from "../src/index.js";
+
+// The C3 payoff, end-to-end (docs/mle.md): edit a running MLE game's source
+// and assert the model SURVIVED the reload while the behavior CHANGED — with
+// the debug clock pinned, the assertion is exact arithmetic, not a race.
+// Headless-friendly (no GL needed); opt-in like the other e2e suites:
+//
+//   npm run test:e2e[:headless]
+const e2eEnabled = process.env.FUNCTOR_E2E === "1";
+const headless = process.env.FUNCTOR_E2E_HEADLESS === "1";
+
+const game = (speed: string) => `let speed = ${speed}
+let init = { spin: 0.0 }
+let tick = (m, dt, tts) => { m with spin: m.spin + dt * speed }
+let draw = (m, tts) =>
+  Frame.create(Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0), Scene.cube())
+`;
+
+/** The spin field of the runner's `/state` model (MLE Value display). */
+function spinOf(model: string): number {
+  const m = model.match(/spin:\s*(-?[\d.]+)/);
+  assert.ok(m, `could not find spin in model: ${model}`);
+  return Number(m[1]);
+}
+
+test(
+  "editing a running .mle game preserves the model and rebinds behavior",
+  { skip: !e2eEnabled, timeout: 120_000 },
+  async () => {
+    const repoRoot = findRepoRoot(process.cwd());
+    assert.ok(repoRoot, "must run from within the functor workspace");
+
+    const dir = mkdtempSync(join(tmpdir(), "mle-reload-"));
+    const mlePath = join(dir, "game.mle");
+    writeFileSync(mlePath, game("1.0"));
+
+    await using runner = await FunctorRunner.launch({
+      gameDir: dir,
+      repoRoot,
+      mlePath,
+      port: Number(process.env.FUNCTOR_E2E_PORT ?? 8093),
+      headless,
+    });
+
+    // Pin the clock: every state change below is an explicit, exact step.
+    // (The game free-runs on the wall clock between launch and pause, so all
+    // assertions are RELATIVE to the pinned baseline.)
+    await runner.pause();
+    const base = spinOf((await runner.state()).model);
+    const DT = 0.1;
+    for (let i = 0; i < 3; i++) await runner.step(DT);
+    const before = spinOf((await runner.state()).model);
+    assert.ok(
+      Math.abs(before - base - 3 * DT) < 1e-4,
+      `three steps at speed 1.0 should add ~0.3 to ${base}, got ${before}`,
+    );
+
+    // Edit the SOURCE of the running game: reverse and amplify the speed.
+    writeFileSync(mlePath, game("-5.0"));
+    // The reload is polled once per frame; in pinned-clock mode frames keep
+    // running (the loop isn't blocked), so give it a moment, then step once.
+    await waitFor(
+      async () => runner.logs(),
+      (lines) => lines.some((l) => l.includes("hot-reloaded")),
+      { timeoutMs: 10_000, description: "hot reload observed in logs" },
+    );
+    await runner.step(DT);
+    const after = spinOf((await runner.state()).model);
+
+    // THE assertion: the new spin is the OLD value plus one step of the NEW
+    // behavior — state survived the edit AND the edit took effect.
+    assert.ok(
+      Math.abs(after - (before + DT * -5.0)) < 1e-4,
+      `expected ${before} + ${DT}*-5 = ${before + DT * -5}, got ${after} ` +
+        `(a reset-to-init would give ${DT * -5})`,
+    );
+
+    // The reload was fast: the runner logs its re-parse+reload latency.
+    const line = runner.logs().find((l) => l.includes("hot-reloaded"));
+    assert.ok(line, "reload log line present");
+    const ms = Number(line!.match(/in ([\d.]+)ms/)?.[1]);
+    assert.ok(ms < 100, `reload should be well under 100ms, took ${ms}ms`);
+
+    // A BROKEN edit fails loud but keeps the old program running.
+    writeFileSync(mlePath, "let broken = ((");
+    await waitFor(
+      async () => runner.logs(),
+      (lines) => lines.some((l) => l.includes("reload failed")),
+      { timeoutMs: 10_000, description: "broken reload reported" },
+    );
+    await runner.step(DT);
+    const still = spinOf((await runner.state()).model);
+    assert.ok(
+      Math.abs(still - (after + DT * -5.0)) < 1e-4,
+      `the old program should keep running after a broken edit, got ${still}`,
+    );
+  },
+);


### PR DESCRIPTION
## What

Track **C3** — the payoff the project was pitched on:

- The MLE producer polls its file's mtime each frame; on change it reparses, rechecks, and swaps in a new `Session` while **keeping the model** — it's a plain value the host holds, which is exactly why C2 was architected that way. Edit→frame is one poll frame + **~0.14ms** of re-parse, versus the multi-second Fable+cargo loop this language exists to kill.
- A broken edit (or a contract violation in the new source — missing `tick`, function `init`) prints once and keeps the old program running. An edited `init` is explicitly documented as taking effect on restart.
- Caveat until B5 (documented in code + roadmap): closure values stored *inside* the model keep their pre-reload bodies; globals rebind.
- The SDK gains an `mlePath` launch option (`--mle` instead of a dylib; mutually exclusive with `dylibPath`, enforced).

## Verification

- **The C3 verify criterion is an executable, headless e2e** (`mle-hot-reload.e2e.test.ts`): with the debug clock pinned, the continuity assertion is exact arithmetic — `spin(before) + dt × newSpeed == spin(after)` (a reset-to-init would give a distinguishable value) — plus a `< 100ms` latency assertion parsed from the reload log, and broken-edit resilience (the old program keeps stepping). **13/13 e2e suite green**, all cargo suites green.
- Review: Codex probed clean apart from a launch-guard Medium (fixed: `mlePath`/`dylibPath` now mutually exclusive); its sandbox couldn't do live-edit probes, and the Claude reviewer hit the account session limit mid-run — compensated by direct inspection, which found and fixed a real load/stat ordering hole (an edit landing mid-load was silently lost; stat-first makes it reload next frame).

## Demo

```
$ functor-runner --mle --game-path examples/mle-hello/game.mle
[mle] loaded examples/mle-hello/game.mle
# …edit the file, save…
[mle] hot-reloaded examples/mle-hello/game.mle in 0.14ms (model preserved; an edited `init` takes effect on restart)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)