### PR TITLE
feat(runtime,cli,sdk): C4a — input into the MLE model + functor.json wiring

### DIFF
--- a/.claude/skills/mle-language/SKILL.md
+++ b/.claude/skills/mle-language/SKILL.md
@@ -111,7 +111,12 @@ A runner-hosted game (`functor-runner --mle --game-path game.mle`) defines:
 let init = { … }                       // the initial model (a value)
 let tick = (model, dt, tts) => model'  // per-frame step
 let draw = (model, tts) => Frame.create(camera, scene)
+let input = (model, key, isDown) => model'  // OPTIONAL; key = "W"/"Up"/"Space"
 ```
+
+A project dir with `functor.json` `{"language": "mle", "entry": "game.mle"}`
+works with the CLI: `functor -d dir build` (typecheck, diagnostics are
+errors), `run native`, `develop` (hot reload is built in).
 
 `examples/mle-hello/game.mle` is the reference. The model shows live at the
 debug server's `GET /state`. **Hot reload is on by default**: saving the

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -9,6 +9,8 @@ name = "functor"
 path = "src/main.rs"
 
 [dependencies]
+# The MLE language, for `language: "mle"` projects (docs/mle.md Track C4).
+mle = { path = "../mle" }
 clap = { version = "4.5.6", features = ["derive"] }
 colored = "2.1.0"
 serde_json = "1.0.117"

--- a/cli/src/commands/mle_project.rs
+++ b/cli/src/commands/mle_project.rs
@@ -1,0 +1,116 @@
+//! CLI support for MLE-language projects (docs/mle.md Track C4): a
+//! `functor.json` with `"language": "mle"` routes `build`/`run`/`develop` to
+//! the interpreter instead of the Fable→cargo pipeline.
+//!
+//! - `build` is the strict gate: parse + lower + typecheck, with `mle check`
+//!   diagnostics as **errors** (the runner treats them as warnings so the
+//!   dev loop stays permissive; the build command is where they block).
+//! - `run` spawns `functor-runner --mle` on the entry file (cwd = the game
+//!   dir, so asset paths resolve as usual).
+//! - `develop` is `run`: the MLE producer hot-reloads on save by itself — no
+//!   watchexec loop, no rebuild. State is preserved across edits.
+//! - wasm is not wired yet (docs/mle.md C5).
+
+use std::io::{Error, ErrorKind};
+use std::path::{Path, PathBuf};
+
+use crate::util::{self, get_nearby_bin, ShellCommand};
+use crate::Environment;
+
+/// The MLE project settings read from `functor.json`.
+pub struct MleProject {
+    /// The game source, relative to the project dir (default `game.mle`).
+    pub entry: String,
+}
+
+/// Read `functor.json` and return the MLE project settings when
+/// `"language": "mle"` — `None` (the F#/Fable pipeline) otherwise, including
+/// for projects whose `functor.json` is empty or has no `language` field.
+pub fn detect(working_directory: &str) -> Option<MleProject> {
+    let path = Path::new(working_directory).join("functor.json");
+    let content = std::fs::read_to_string(path).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&content).ok()?;
+    if json.get("language").and_then(|v| v.as_str()) != Some("mle") {
+        return None;
+    }
+    let entry = json
+        .get("entry")
+        .and_then(|v| v.as_str())
+        .unwrap_or("game.mle")
+        .to_string();
+    Some(MleProject { entry })
+}
+
+impl MleProject {
+    fn entry_path(&self, working_directory: &str) -> Result<PathBuf, Error> {
+        let path = Path::new(working_directory).join(&self.entry);
+        if !path.exists() {
+            return Err(Error::new(
+                ErrorKind::NotFound,
+                format!("mle entry not found: {}", path.display()),
+            ));
+        }
+        Ok(path)
+    }
+
+    /// Parse + lower + typecheck the entry; `mle check` diagnostics are
+    /// build errors here (see the module doc).
+    pub fn build(&self, working_directory: &str) -> Result<(), Error> {
+        let path = self.entry_path(working_directory)?;
+        let display = path.display().to_string();
+        let src = std::fs::read_to_string(&path)?;
+        let fail = |span: mle::Span, message: &str| {
+            let (line, col) = mle::line_col(&src, span.start);
+            Error::other(format!("{display}:{line}:{col}: {message}"))
+        };
+        let program = mle::parse(&src).map_err(|e| fail(e.span, &e.message))?;
+        let module = mle::lower(program).map_err(|e| fail(e.span, &e.message))?;
+        let diags = mle::check(&module);
+        for diag in &diags {
+            let (line, col) = mle::line_col(&src, diag.span.start);
+            eprintln!("error: {display}:{line}:{col}: {}", diag.message);
+        }
+        if diags.is_empty() {
+            println!("[mle] {display}: ok");
+            Ok(())
+        } else {
+            Err(Error::other(format!(
+                "{} type error(s) in {display}",
+                diags.len()
+            )))
+        }
+    }
+
+    /// Spawn the runner on the entry (`run` and `develop` — hot reload is
+    /// built into the producer, so there is no separate watch loop).
+    pub async fn run(
+        &self,
+        working_directory: &str,
+        environment: &Environment,
+        runner_args: &[String],
+        develop: bool,
+    ) -> Result<(), Error> {
+        if matches!(environment, Environment::Wasm) {
+            return Err(Error::other(
+                "mle on wasm is not wired yet (docs/mle.md Track C5) — use `run native`",
+            ));
+        }
+        let entry = self.entry_path(working_directory)?;
+        let functor_runner_exe =
+            get_nearby_bin(&"functor-runner").expect("functor-runner should be available");
+        if develop {
+            println!("[mle] develop: hot reload is built in — edit {} and save", self.entry);
+        }
+        let entry_str = entry.file_name().unwrap().to_str().unwrap().to_string();
+        let mut args = vec!["--mle", "--game-path", entry_str.as_str()];
+        args.extend(runner_args.iter().map(|s| s.as_str()));
+        let commands = vec![ShellCommand {
+            prefix: "[Functor Runner]",
+            cmd: functor_runner_exe.to_str().unwrap(),
+            cwd: working_directory,
+            env: vec![],
+            args,
+        }];
+        util::ShellCommand::run_sequential(commands).await
+    }
+}

--- a/cli/src/commands/mle_project.rs
+++ b/cli/src/commands/mle_project.rs
@@ -101,8 +101,10 @@ impl MleProject {
         if develop {
             println!("[mle] develop: hot reload is built in — edit {} and save", self.entry);
         }
-        let entry_str = entry.file_name().unwrap().to_str().unwrap().to_string();
-        let mut args = vec!["--mle", "--game-path", entry_str.as_str()];
+        // The runner's cwd is the project dir, so the entry passes through
+        // as-is — `src/game.mle` keeps its subdirectory.
+        let _ = entry; // existence validated above
+        let mut args = vec!["--mle", "--game-path", self.entry.as_str()];
         args.extend(runner_args.iter().map(|s| s.as_str()));
         let commands = vec![ShellCommand {
             prefix: "[Functor Runner]",

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod build;
 pub mod develop;
 pub mod inspect;
+pub mod mle_project;
 pub mod run;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -127,12 +127,26 @@ async fn main() -> tokio::io::Result<()> {
 
     // An MLE project (functor.json: `"language": "mle"`) routes build/run/
     // develop to the interpreter — no Fable, no cargo, hot reload built in.
-    if let Some(project) = commands::mle_project::detect(&working_directory_str) {
+    // Only build/run/develop are language-routed; anything else (Init, and
+    // Inspect handled earlier) falls through to the normal dispatch.
+    let is_routed = matches!(
+        &args.command,
+        Command::Build { .. } | Command::Run { .. } | Command::Develop { .. }
+    );
+    if let Some(project) = commands::mle_project::detect(&working_directory_str)
+        .filter(|_| is_routed)
+    {
         let res = match &args.command {
-            Command::Init { .. } | Command::Inspect { .. } => unreachable!("handled below/earlier"),
-            Command::Build { environment } => project.build(&working_directory_str).map(|_| {
-                let _ = environment; // nothing target-specific to build
-            }),
+            Command::Init { .. } | Command::Inspect { .. } => unreachable!("is_routed excludes"),
+            Command::Build { environment } => {
+                if matches!(Environment::default(environment), Environment::Wasm) {
+                    Err(io::Error::other(
+                        "mle on wasm is not wired yet (docs/mle.md Track C5) — use `build native`",
+                    ))
+                } else {
+                    project.build(&working_directory_str)
+                }
+            }
             Command::Run {
                 environment,
                 runner_args,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -124,6 +124,47 @@ async fn main() -> tokio::io::Result<()> {
     let working_directory_str = working_directory_os_str.into_string().unwrap();
 
     println!("Running command: {:?}", args.command);
+
+    // An MLE project (functor.json: `"language": "mle"`) routes build/run/
+    // develop to the interpreter — no Fable, no cargo, hot reload built in.
+    if let Some(project) = commands::mle_project::detect(&working_directory_str) {
+        let res = match &args.command {
+            Command::Init { .. } | Command::Inspect { .. } => unreachable!("handled below/earlier"),
+            Command::Build { environment } => project.build(&working_directory_str).map(|_| {
+                let _ = environment; // nothing target-specific to build
+            }),
+            Command::Run {
+                environment,
+                runner_args,
+            } => {
+                project.build(&working_directory_str)?;
+                project
+                    .run(
+                        &working_directory_str,
+                        &Environment::default(environment),
+                        runner_args,
+                        false,
+                    )
+                    .await
+            }
+            Command::Develop {
+                environment,
+                runner_args,
+            } => {
+                project.build(&working_directory_str)?;
+                project
+                    .run(
+                        &working_directory_str,
+                        &Environment::default(environment),
+                        runner_args,
+                        true,
+                    )
+                    .await
+            }
+        };
+        return finish(res);
+    }
+
     let res = match &args.command {
         Command::Init { template } => {
             // TODO: Handle init

--- a/docs/mle.md
+++ b/docs/mle.md
@@ -257,6 +257,19 @@ Starts once A2 + B3 exist.
       subscriptions/draw3d, effect-queue drain-to-fixed-point semantics) from
       MLE. *Verify:* port `examples/primitives`; golden-compare vs the F#
       rendering.
+      - [x] **C4a. Input + CLI wiring.** Optional `input` entry point —
+        `(model, key, isDown) => model`, keys as canonical names ("W",
+        "Up") — validated at load when present, reload-aware. And
+        `functor.json` grows `"language": "mle"` (+ optional `entry`,
+        default `game.mle`): `functor build` = parse+lower+**check as
+        errors** (the strict gate; the runner keeps them warnings),
+        `run native` spawns the interpreter (proven byte-identical to a
+        direct runner invocation), `develop` = `run` (hot reload is built
+        in — no watchexec), wasm errors cleanly until C5.
+        *Verify (done):* SDK e2e asserts two key events reach the model
+        with canonical names (14/14 suite); CLI build/run/wasm probes.
+      - [ ] **C4b.** `update`/messages, subscriptions, mouse, effect-queue
+        drain semantics; port `examples/primitives` + golden.
 - [ ] **C5. Wasm.** The interpreter crate compiles to wasm32; `.mle` source
       ships in the bundle. *Verify:* wasm build of mle-hello renders.
 - [ ] **C6. Perf gate.** Measure C4 at 60fps with headroom; bytecode VM

--- a/examples/mle-hello/functor.json
+++ b/examples/mle-hello/functor.json
@@ -1,0 +1,4 @@
+{
+  "language": "mle",
+  "entry": "game.mle"
+}

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -32,6 +32,7 @@ pub struct MleGame {
     src: String,
     session: Session,
     model: Value,
+    has_input: bool,
     /// The last successfully drawn frame, kept so a bad draw shows the last
     /// good picture instead of a blank.
     last_frame: Frame,
@@ -53,6 +54,8 @@ struct Loaded {
     src: String,
     session: Session,
     init: Value,
+    /// The game defines the optional `input` entry point.
+    has_input: bool,
 }
 
 /// Load, check, and contract-validate a game file. Errors come back as fully
@@ -84,7 +87,18 @@ fn load_game(path: &str) -> Result<Loaded, String> {
     }
     require_function(path, &session, "tick", 3)?;
     require_function(path, &session, "draw", 2)?;
-    Ok(Loaded { src, session, init })
+    // `input` is optional (many games are non-interactive), but when present
+    // it must honor the contract: (model, key, isDown) => model.
+    let has_input = session.global("input").is_some();
+    if has_input {
+        require_function(path, &session, "input", 3)?;
+    }
+    Ok(Loaded {
+        src,
+        session,
+        init,
+        has_input,
+    })
 }
 
 fn file_mtime(path: &str) -> std::time::SystemTime {
@@ -113,6 +127,7 @@ impl MleGame {
             src: loaded.src,
             session: loaded.session,
             model: loaded.init,
+            has_input: loaded.has_input,
             last_frame: empty_frame(),
             last_error: None,
             frames: 0,
@@ -170,6 +185,7 @@ impl Game for MleGame {
             Ok(loaded) => {
                 self.src = loaded.src;
                 self.session = loaded.session;
+                self.has_input = loaded.has_input;
                 self.last_error = None;
                 println!(
                     "[mle] hot-reloaded {} in {:.2}ms (model preserved; an edited `init` \
@@ -204,7 +220,26 @@ takes effect on restart)",
         self.report_stats();
     }
 
-    fn key_event(&mut self, _code: i32, _is_down: bool) {}
+    fn key_event(&mut self, code: i32, is_down: bool) {
+        // The optional `input` entry point: (model, key, isDown) => model.
+        // Keys cross as their canonical names ("W", "Up", "Space") — the same
+        // spelling the debug server and SDK use.
+        if !self.has_input {
+            return;
+        }
+        let Some(key) = functor_runtime_common::Key::from_i32(code) else {
+            return;
+        };
+        let args = vec![
+            self.model.clone(),
+            Value::String(std::rc::Rc::from(format!("{key:?}").as_str())),
+            Value::Bool(is_down),
+        ];
+        match self.session.call("input", args, &mut FunctorHost) {
+            Ok(model) => self.model = model,
+            Err(err) => self.frame_error("input", &err),
+        }
+    }
     fn mouse_move(&mut self, _x: i32, _y: i32) {}
     fn mouse_wheel(&mut self, _delta: i32) {}
 

--- a/tools/functor-sdk/test/mle-input.e2e.test.ts
+++ b/tools/functor-sdk/test/mle-input.e2e.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { findRepoRoot, FunctorRunner } from "../src/index.js";
+
+// C4: key events reach the MLE model through the optional `input` entry
+// point — (model, key, isDown) => model, keys as canonical names.
+const e2eEnabled = process.env.FUNCTOR_E2E === "1";
+const headless = process.env.FUNCTOR_E2E_HEADLESS === "1";
+
+const GAME = `let init = { presses: 0.0, last: "none" }
+let input = (m, key, isDown) => { m with presses: m.presses + 1.0, last: key }
+let tick = (m, dt, tts) => m
+let draw = (m, tts) =>
+  Frame.create(Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0), Scene.cube())
+`;
+
+test(
+  "key events reach the MLE model via the input entry point",
+  { skip: !e2eEnabled, timeout: 120_000 },
+  async () => {
+    const repoRoot = findRepoRoot(process.cwd());
+    assert.ok(repoRoot, "must run from within the functor workspace");
+
+    const dir = mkdtempSync(join(tmpdir(), "mle-input-"));
+    const mlePath = join(dir, "game.mle");
+    writeFileSync(mlePath, GAME);
+
+    await using runner = await FunctorRunner.launch({
+      gameDir: dir,
+      repoRoot,
+      mlePath,
+      port: Number(process.env.FUNCTOR_E2E_PORT ?? 8094),
+      headless,
+    });
+    await runner.pause();
+
+    const model = async () => (await runner.state()).model;
+    assert.match(await model(), /presses: 0/, "no input yet");
+
+    // A press+release is two events; the key crosses as its canonical name.
+    await runner.keyDown("up");
+    await runner.keyUp("up");
+    await runner.step();
+    const after = await model();
+    assert.match(after, /presses: 2/, `expected two events in: ${after}`);
+    assert.match(after, /last: "Up"/, `expected canonical key name in: ${after}`);
+  },
+);


### PR DESCRIPTION
## What

The first half of **C4**:

- **Input reaches the model.** Optional `input` entry point: `(model, key, isDown) => model`, keys crossing as their canonical names (`"W"`, `"Up"`, `"Space"` — the same spelling the debug server and SDK use). Validated at load when present (arity 3), refreshed across hot reloads, per-frame errors deduped like tick/draw.
- **MLE projects are first-class in the CLI.** `functor.json` grows `"language": "mle"` (+ optional `"entry"`, default `game.mle`):
  - `functor build` — parse + lower + typecheck, **diagnostics as errors** (the strict gate; the runner keeps them warnings so the dev loop stays permissive). Rejects wasm with a C5 pointer.
  - `functor run native` — spawns the interpreter; capture proven **byte-identical** to a direct runner invocation.
  - `functor develop` — just `run`: hot reload is built into the producer, so the watchexec rebuild loop that defines the F# develop flow has no MLE equivalent.
  - Non-mle projects (empty/parseless `functor.json`) fall through to the Fable pipeline untouched; `init`/`inspect` never route.
- `examples/mle-hello` gains its `functor.json`.

## Verification

- New SDK e2e (`mle-input.e2e.test.ts`): two key events measurably reach the model with canonical names — **14/14 suite green** (re-run post-rebase), all cargo suites green.
- CLI probes: build ok / build-with-type-error exits 1 / run renders byte-identical / `run wasm` + `build wasm` error cleanly / subdirectory entries (`src/game.mle`) build AND run / `init` falls through.
- Review: Codex probe-verified (its High — subdir entries stripped by `file_name()` — was found in parallel by self-review and fixed; its Medium — `build wasm` succeeding — fixed). The Claude reviewer remains rate-limited; compensated by self-review, which independently caught both CLI bugs.

## Notes

- Remaining **C4b**: `update`/messages, subscriptions, mouse, effect-queue drain semantics, the `examples/primitives` port + golden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)