### PR TITLE
feat(physics): 1a — world spine (rapier, declarative scene, reconcile, determinism goldens)

### DIFF
--- a/docs/physics.md
+++ b/docs/physics.md
@@ -15,9 +15,14 @@ shape every decision:
    `physicsScape : model -> PhysicsScene` declares the bodies that *should* exist,
    reconciled against a live world each frame — the same shape as `draw3d`
    (`Scene3D`) and `soundScape` (`AudioScene`).
-2. **Determinism.** Same inputs → same simulation, byte-for-byte, so we can
-   rewind, replay, and verify in the deterministic netsim. This forces a fixed
-   timestep and deterministic body ordering from day one.
+2. **Local determinism.** Same binary, same inputs → same simulation,
+   byte-for-byte — so we can rewind, replay, and verify in the deterministic
+   netsim. *Local* (single-binary) determinism is sufficient for every scenario
+   we target — replay, time-travel debugging, and both netcode modes (there is
+   only single ownership at any time) — and Rapier provides it with default
+   features. Cross-platform determinism is a **non-goal** (see Determinism).
+   This still forces a fixed timestep and deterministic body ordering from day
+   one.
 3. **Rewindable + networkable.** Pause / rewind / replay locally, and — the north
    star — client-side prediction + server reconciliation for the multiplayer
    target (`docs/multiplayer.md`'s netcode epic). Both are the *same machinery*:
@@ -316,20 +321,54 @@ are just the two common collections; a model can carry as many as its netcode ne
 
 ## Determinism
 
+**The requirement is local (single-binary) determinism, and Rapier provides it
+with default features**: the same simulation, on the same machine, with the same
+Rapier and rustc versions, produces bit-identical results
+([Rapier docs](https://rapier.rs/docs/user_guides/rust/determinism/)). This tier
+covers everything we're building:
+
+- **Rewind / replay / time-travel debugging** — re-simulation happens in the same
+  process that recorded the history.
+- **Mode A (server-authoritative + prediction)** — the client replays *its own*
+  inputs on *its own* machine, starting from a server snapshot that arrives *as
+  data*; it never has to bit-match the server's simulation. Float divergence
+  between client and server just means slightly larger corrections, which
+  converge.
+- **Mode B (split ownership, state-sync)** — each entity is simulated by exactly
+  one owner, who broadcasts its state; peers render it kinematically. Nobody
+  re-simulates anyone else's entities, so nothing needs to match across machines.
+
+**Cross-platform determinism (native ↔ wasm, x86 ↔ ARM) is a non-goal.** It is
+only needed for *input-only lockstep* — everyone simulates everything from
+inputs, no state on the wire — a mode we don't plan to build. Rapier's
+`enhanced-determinism` flag provides it, but it is mutually exclusive with
+`simd-stable` / `simd-nightly` / `parallel`, so it trades solver performance for
+a guarantee we don't need. It stays documented here as the escape hatch if
+lockstep ever becomes real, with fixed-point as the further fallback if
+cross-target goldens won't converge (Photon Quantum's path). One consequence
+worth naming: recording a repro on desktop and replaying it in the browser is
+out of scope — a replay is bound to the binary that recorded it.
+
+What local determinism requires from us (the fine print):
+
 - **Fixed-step accumulator** in the shell (never variable dt).
-- Rapier features **`enhanced-determinism`** + **`serde-serialize`**.
-- **Deterministic reconcile order** (sort by tag) for spawn/despawn/insert.
+- Rapier feature **`serde-serialize`** (snapshots); otherwise **default
+  features** — no `enhanced-determinism`. (If we later enable `parallel`, first
+  verify it is deterministic run-to-run on one machine — the Phase 1 golden
+  catches this.)
+- **Deterministic reconcile order across the whole world history, removals
+  included.** Rapier arena handles depend on the full insert/*remove* sequence,
+  not just the final set of bodies — so the reconcile diff (sort by tag) must be
+  fully deterministic for despawns too. Snapshot-based seeks (`KeyframeLog`,
+  `SnapshotRing`) are safe by construction (serde restores the arenas exactly);
+  `ReplayOnly` re-executes the history and leans on this.
+- **Replays are valid per-build only.** Fine for time-travel debugging (same
+  session) and netcode (ephemeral); don't persist replays as long-lived
+  artifacts. Hot-reloading the *game dylib* is safe — Rapier lives in the
+  runtime shell, which is unchanged — but rebuilding the *runtime* invalidates
+  recorded history.
 - No wall-clock / unseeded RNG leakage (netsim already uses a seeded SplitMix64).
-
-Two determinism tiers, with very different costs — this drives the netcode order:
-
-- **Single-binary replay determinism** (same build re-simulating its own recent
-  frames). Cheap and robust with the above. **Enough for server-authoritative +
-  prediction.**
-- **Cross-platform determinism** (native ↔ wasm, x86 ↔ ARM). Hard — f32 / libm
-  differences. Required only for lockstep / peer-owned simulation. **Validate with
-  goldens; never assume.** (Serious deterministic-netcode engines go fixed-point
-  for this reason — a fallback if cross-target goldens won't converge.)
+- **Validate with goldens; never assume** (Phase 1).
 
 ## Rewind: the `Simulatable` / `Timeline` seam
 
@@ -397,9 +436,31 @@ strategy choice is runtime config, defaulting to `KeyframeLog`.
   client declares its own player `Local` (predicted) and everything else `Remote`
   (kinematic, interpolated from snapshots). On an authoritative snapshot for frame
   K, `reconcile` restores K and replays stored local inputs K→now.
-- **Mode B — split ownership** (deferred; needs cross-platform determinism). Each
-  entity's `Authority` decides who simulates it; peers render others as kinematic.
-  Same reconciler; gated behind the cross-target determinism goldens.
+- **Mode B — split ownership** (deferred). Each entity's `Authority` decides who
+  simulates it; peers render others as kinematic, driven from broadcast state.
+  Owner-is-truth, so this needs **no cross-machine determinism at all** — see
+  Determinism.
+
+**Authority boundaries have a consistency problem that no determinism tier
+solves:** when two differently-owned dynamic bodies collide (my ball hits your
+ball), each owner resolves the contact seeing the other body as kinematic
+(infinite mass), and the two outcomes can disagree physically. This is resolved
+by design — ownership handoff on contact, or routing contested interactions
+through the server — not by determinism. Deferring Mode B defers this too, but
+any split-ownership scene (including the `mpserver`/`mpclient` demo below) hits
+it as soon as owned bodies can touch.
+
+**Target topology (networked VR): client-owned player movement, server-owned
+everything else.** Each client is authoritative over its own player pose —
+head/hands are tracked input; there is nothing sensible for a server to
+"correct" — declared `Local` and broadcast as state; peers render it
+`Remote`/kinematic. Every other physics body (props, projectiles, grabbed
+objects) is server-owned, so all contested interactions resolve in one place
+(the Source model — see Prior art). This is a small, fixed instance of the
+authority machinery above: pure state-sync, no cross-machine determinism, and
+the boundary problem reduces to player-touches-prop, which the server
+arbitrates (the player body is kinematic to the server's world, so props can't
+push the player — the usual VR choice).
 
 ## Culmination: pause / rewind / replay via keyboard
 
@@ -420,6 +481,29 @@ An `examples/hello-physics` scene (a few `dynamic` boxes settling on a `fixedBod
 plane) drives this. The egui overlay shows **read-only status** — current frame,
 paused/live, timeline strategy, history depth — since egui input isn't wired yet;
 all control is via the keyboard, exactly as scoped.
+
+## Debug visualization (wireframes via Rapier's debug renderer)
+
+Rapier ships its own debug renderer behind the **`debug-render`** feature:
+`DebugRenderPipeline` walks the live world and emits colored line segments —
+collider wireframes, contacts, joints, rigid-body frames, with granular passes
+(`render_colliders` / `render_contacts` / …) — through a one-method
+`DebugRenderBackend` trait (`draw_line(object, a, b, color)`). We adopt it
+rather than writing our own:
+
+- **Engine side**: `World::debug_lines() -> Vec<Line>` (a tiny backend impl that
+  collects segments into plain data). Render-only, world-untouched — zero
+  determinism impact — and being plain data it is *also text-dumpable*, the
+  line-set sibling of `World::dump()` for headless/LLM inspection.
+- **Shell side**: both runtimes draw the line list as a GL line pass over the
+  frame. `functor-runner` already has a `--debug-render <mode>` flag — physics
+  wireframes become a mode (e.g. `--debug-render physics`), so captures and
+  golden scenarios can show physics state with no game-code changes; a runtime
+  keyboard toggle joins the pause/rewind keys in `hello-physics`.
+
+This is the visual proof of reconcile correctness (declared scene vs what the
+solver actually holds) and makes divergence bugs — a body the renderer draws in
+one place and physics has in another — visible immediately.
 
 ## Test harness (extends `functor-netsim`)
 
@@ -473,8 +557,10 @@ It's worth building in two steps, because they exercise different machinery:
 
 | Phase | Scope | Targets |
 | --- | --- | --- |
-| **1. Shell spine** | Rapier dep (`enhanced-determinism` + `serde-serialize`), `physics` module (`PhysicsScene`/`Body`/`reconcile`/`WorldId` registry), fixed-step accumulator, `Simulatable` + `Timeline` traits, `KeyframeLog`, snapshot + text/JSON dump. Determinism + strategy-equivalence + replay goldens. **No F# surface.** | native+wasm (Rust) |
+| **1a. World spine** | Rapier dep (`serde-serialize`, default features), `physics` module (`PhysicsScene`/`Body`/`reconcile`/`WorldId` registry), fixed-step accumulator, snapshot + text/JSON dump. Determinism + restore-replay goldens. **No F# surface.** | native+wasm (Rust) |
+| **1b. Timeline seam** | `Simulatable` + `Timeline` traits, `KeyframeLog` (default) + `SnapshotRing` + `ReplayOnly`, strategy-equivalence + replay goldens. | native+wasm (Rust) |
 | **2. `physicsScape` + read-back** | `Game` hook + builder/runner, reconcile pipeline, `DrawContext` record on `draw3d` (`ctx.physics` view), `Physics.synced` sub, `examples/hello-physics`. | both |
+| **2b. Debug visualization** | Rapier `debug-render` feature, `World::debug_lines()`, line pass in both shells, `--debug-render physics` mode + keyboard toggle in `hello-physics`. | both |
 | **3. Commands** | `applyImpulse`/`applyForce`/`setVelocity`/`teleport` (plain-data effects). | both |
 | **4. Queries** | `raycast`/`shapeCast` (async tagger, token registry). | both |
 | **5. Collision events** | `Physics.events` sub. | both |
@@ -482,7 +568,10 @@ It's worth building in two steps, because they exercise different machinery:
 | **6. Pause/rewind/replay** | timeline-control effects + keyboard wiring + egui status overlay (the culmination). | both |
 | **7a. Networked physics (state-sync)** | `Authority`, `mpserver`/`mpclient` grown to client-owned balls + server-owned objects, kinematic `Remote` + interpolation. No prediction. | both |
 | **7b. Prediction + reconciliation** | Server-authoritative ball, client input + prediction, structural `server`/`client` collections (network snapshot = `server`; reconcile = field swap), `Timeline` reconcile, `netsim_viz` ghosts + divergence metrics, latency-sweep convergence tests. | both |
-| **8. Cross-target determinism** | native↔wasm determinism validation (gated on Phase 1 goldens); fixed-point fallback if needed. | both |
+
+(No cross-target determinism phase: neither netcode mode needs it — see
+Determinism. `enhanced-determinism` + cross-target goldens is the documented
+escape hatch if input-only lockstep is ever pursued.)
 
 ## Prior art
 
@@ -497,6 +586,19 @@ It's worth building in two steps, because they exercise different machinery:
   stack — the closest living reference); Photon Quantum (commercial deterministic
   ECS + **fixed-point** physics — the proof that cross-platform determinism pushes
   you to fixed-point).
+- **Authority models in shipped games**: **Source / HL2** — the server owns
+  *all* VPhysics; props are never client-predicted, only interpolated ~100 ms in
+  the past. The one predicted subsystem is the hand-written, deterministic
+  shared player-movement code, replayed against the input buffer on each
+  authoritative update (Mode A restricted to a tiny engine-free state). The
+  gravity gun is a server-side shadow controller velocity-steering the held prop
+  toward a view attachment — so the prop visibly lags the predicted view in
+  HL2DM; ragdolls/gibs are client-only cosmetics (our `client` collection).
+  Ownership conflicts are *defined away* by never splitting ownership; the
+  budget goes to hiding latency (prediction, interpolation, lag compensation).
+  **Rocket League** — also server-authoritative, but the client predicts the
+  *entire* Bullet world at a fixed 120 Hz tick and resimulates on correction:
+  the closest shipped proof of Mode A / Phase 7b over a whole physics world.
 - **Networked-physics literature**: Gabriel Gambetta, *Fast-Paced Multiplayer*
   (prediction / reconciliation / interpolation — read first); Glenn Fiedler,
   *Networked Physics* (lockstep vs. snapshot vs. state-sync, for physics

--- a/runtime/functor-runtime-common/Cargo.toml
+++ b/runtime/functor-runtime-common/Cargo.toml
@@ -24,6 +24,12 @@ egui = "0.34"
 egui_glow = { version = "0.34", default-features = false }
 image = "0.25.1"
 once_cell = "1.19.0"
+# Rigid-body physics (docs/physics.md). Default features only — NO
+# `enhanced-determinism` (we need local single-binary determinism, which rapier
+# gives by default; the flag trades SIMD/parallel for cross-platform determinism
+# we don't need) — plus `serde-serialize` for byte-exact world snapshots
+# (rewind/replay/netcode Timeline).
+rapier3d = { version = "0.33", features = ["serde-serialize"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 fable_library_rust = { path = "./../../fable_modules/fable-library-rust" }

--- a/runtime/functor-runtime-common/src/lib.rs
+++ b/runtime/functor-runtime-common/src/lib.rs
@@ -82,6 +82,7 @@ pub mod math;
 pub mod mle_prelude;
 pub mod model;
 pub mod net;
+pub mod physics;
 pub mod protocol;
 pub mod render;
 mod render_context;

--- a/runtime/functor-runtime-common/src/physics/goldens.rs
+++ b/runtime/functor-runtime-common/src/physics/goldens.rs
@@ -1,0 +1,106 @@
+//! Determinism goldens (docs/physics.md, "Test harness").
+//!
+//! These are the executable form of the determinism contract: same build, same
+//! declared-scene history, same fixed steps → **byte-identical snapshots**.
+//! They run under plain `cargo test -p functor_runtime_common` (no GL, no
+//! dylibs), so CI exercises them on every platform.
+//!
+//! The scripted scenario deliberately includes a despawn *and* a respawn:
+//! Rapier arena handles depend on the full insert/remove history, and this is
+//! the fine-print requirement most likely to regress silently.
+
+use super::*;
+
+/// The declared scene as a pure function of the frame number: a ground slab and
+/// three stacked crates; crate "c" despawns at frame 30 and respawns offset at
+/// frame 60 (exercising arena-slot reuse); crate "b" gets teleported at frame
+/// 90 (exercising the divergence rule mid-replay).
+fn scene_at(frame: u64) -> PhysicsScene {
+    let ground = Body::fixed(
+        "ground".to_string(),
+        Shape::Cuboid {
+            extents: [20.0, 0.2, 20.0],
+        },
+    );
+    let a = Body::dynamic(
+        "a".to_string(),
+        Shape::Cuboid {
+            extents: [1.0, 1.0, 1.0],
+        },
+    )
+    .at([0.0, 2.0, 0.0]);
+    let b_pos = if frame < 90 {
+        [0.2, 3.5, 0.1]
+    } else {
+        [3.0, 4.0, 0.0]
+    };
+    let b = Body::dynamic(
+        "b".to_string(),
+        Shape::Cuboid {
+            extents: [1.0, 1.0, 1.0],
+        },
+    )
+    .at(b_pos);
+    let c = Body::dynamic("c".to_string(), Shape::Sphere { radius: 0.5 }).at(if frame < 30 {
+        [-0.1, 5.0, 0.2]
+    } else {
+        [1.5, 6.0, -0.5]
+    });
+
+    let mut bodies = vec![ground, a, b];
+    if !(30..60).contains(&frame) {
+        bodies.push(c);
+    }
+    PhysicsScene::create([0.0, -9.81, 0.0], bodies)
+}
+
+const FRAMES: u64 = 120;
+
+/// Drive a world through the scripted scenario up to (excluding) `to`.
+fn run(world: &mut World, from: u64, to: u64) {
+    for f in from..to {
+        world.reconcile(&scene_at(f));
+        world.step_fixed();
+    }
+}
+
+#[test]
+fn determinism_golden_two_worlds_stay_byte_identical() {
+    let mut a = World::new([0.0, -9.81, 0.0]);
+    let mut b = World::new([0.0, -9.81, 0.0]);
+    for f in 0..FRAMES {
+        let scene = scene_at(f);
+        a.reconcile(&scene);
+        b.reconcile(&scene);
+        a.step_fixed();
+        b.step_fixed();
+        assert!(a.snapshot() == b.snapshot(), "worlds diverged at frame {f}");
+    }
+    // Sanity: the scenario actually simulated something (crates fell and hit
+    // the ground), so byte-equality above wasn't comparing static worlds.
+    let (pos, _) = a.body_transform("a").unwrap();
+    assert!(pos[1] < 2.0 && pos[1] > 0.0, "unexpected rest pose {pos:?}");
+}
+
+#[test]
+fn restore_golden_snapshot_plus_replay_matches_live_run() {
+    // Snapshot at frame 20 — *before* the despawn (30), respawn (60), and
+    // teleport (90) — so the replayed window exercises removal, arena-slot
+    // reuse, and the divergence rule against serde-restored arenas.
+    let mut live = World::new([0.0, -9.81, 0.0]);
+    run(&mut live, 0, 20);
+    let checkpoint = live.snapshot();
+    run(&mut live, 20, FRAMES);
+
+    // Restore the checkpoint and replay the same declared scenes forward: this
+    // is exactly what the Timeline's `seek` does (Phase 1 of the rewind seam),
+    // and it must land byte-identical to the live run.
+    let mut resumed = World::new([0.0, 0.0, 0.0]);
+    resumed.restore(&checkpoint).unwrap();
+    run(&mut resumed, 20, FRAMES);
+
+    assert!(
+        resumed.snapshot() == live.snapshot(),
+        "restored+replayed world diverged from the live run"
+    );
+}

--- a/runtime/functor-runtime-common/src/physics/mod.rs
+++ b/runtime/functor-runtime-common/src/physics/mod.rs
@@ -1,0 +1,31 @@
+//! Rigid-body physics — the Phase 1a "world spine" of `docs/physics.md`
+//! (Phase 1b adds the `Simulatable`/`Timeline` rewind seam on top).
+//!
+//! Physics is *described, not commanded*: the game declares the bodies that
+//! should exist as a [`PhysicsScene`] (the physics analogue of `Scene3D` /
+//! `AudioScene`), and the shell reconciles that declaration against a live
+//! Rapier [`World`] each frame. The Rapier world is a cache/accelerator living
+//! runtime-side — it is never stored in the game model; the model holds plain
+//! data and the world is reconstructible from a snapshot or a replay.
+//!
+//! Determinism contract (see the Determinism section of the doc): **local,
+//! single-binary determinism** — same build, same declared-scene history, same
+//! fixed steps → byte-identical snapshots. Rapier provides this with default
+//! features; what this module must uphold is a fixed timestep (never variable
+//! dt) and a fully deterministic insert/remove history (Rapier arena handles
+//! depend on it), which is why reconciliation orders despawns by tag and keeps
+//! spawns in declaration order.
+//!
+//! No F# surface yet — that lands in Phase 2 (`physicsScape`). Everything here
+//! is exercised headlessly by the determinism goldens (`cargo test`, no GPU).
+
+mod registry;
+mod scene;
+mod world;
+
+#[cfg(test)]
+mod goldens;
+
+pub use registry::*;
+pub use scene::*;
+pub use world::*;

--- a/runtime/functor-runtime-common/src/physics/registry.rs
+++ b/runtime/functor-runtime-common/src/physics/registry.rs
@@ -1,0 +1,104 @@
+//! `WorldId`-keyed registry of live physics worlds (docs/physics.md,
+//! "Singleton now, explicit worlds later — for free").
+//!
+//! The `physicsScape`-driven world is [`DEFAULT_WORLD`] (id 0), created lazily
+//! on first touch. Every engine call is world-parameterized from day one; the
+//! future F# surface just defaults the id, and explicit `PhysicsWorld.t` values
+//! later map to [`create_world`] with zero engine refactor.
+//!
+//! Like the HTTP tagger registry (`net::registry`), this is a thread-local:
+//! the game loop is single-threaded, and living outside the game model means
+//! it survives hot reloads of the game dylib (the world is shell state, like
+//! the renderer and audio voices).
+
+use std::cell::{Cell, RefCell};
+use std::collections::BTreeMap;
+
+use super::{World, DEFAULT_GRAVITY};
+
+pub type WorldId = u32;
+
+/// The singleton `physicsScape`-driven world.
+pub const DEFAULT_WORLD: WorldId = 0;
+
+thread_local! {
+    static WORLDS: RefCell<BTreeMap<WorldId, World>> = const { RefCell::new(BTreeMap::new()) };
+    static NEXT_ID: Cell<WorldId> = const { Cell::new(1) };
+}
+
+/// Create an explicit world with its own gravity, returning its id.
+pub fn create_world(gravity: [f32; 3]) -> WorldId {
+    let id = NEXT_ID.with(|c| {
+        let id = c.get();
+        c.set(id + 1);
+        id
+    });
+    WORLDS.with(|w| w.borrow_mut().insert(id, World::new(gravity)));
+    id
+}
+
+/// Drop a world and all its bodies. Removing [`DEFAULT_WORLD`] resets it — the
+/// next touch recreates it empty.
+pub fn remove_world(id: WorldId) {
+    WORLDS.with(|w| w.borrow_mut().remove(&id));
+}
+
+/// Run `f` against the world `id`. [`DEFAULT_WORLD`] is created on first touch
+/// (standard gravity — the per-frame reconcile overwrites it anyway); an
+/// unknown explicit id yields `None`. Do not call `with_world` from inside `f`
+/// (the registry is borrowed for the duration).
+pub fn with_world<R>(id: WorldId, f: impl FnOnce(&mut World) -> R) -> Option<R> {
+    WORLDS.with(|w| {
+        let mut worlds = w.borrow_mut();
+        if id == DEFAULT_WORLD {
+            worlds
+                .entry(DEFAULT_WORLD)
+                .or_insert_with(|| World::new(DEFAULT_GRAVITY));
+        }
+        worlds.get_mut(&id).map(f)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::physics::{Body, PhysicsScene, Shape};
+
+    #[test]
+    fn default_world_is_created_on_first_touch() {
+        remove_world(DEFAULT_WORLD);
+        let frame = with_world(DEFAULT_WORLD, |w| w.frame());
+        assert_eq!(frame, Some(0));
+    }
+
+    #[test]
+    fn unknown_world_is_none_and_created_worlds_are_independent() {
+        assert_eq!(with_world(9999, |w| w.frame()), None);
+
+        let a = create_world([0.0, -9.81, 0.0]);
+        let b = create_world([0.0, 0.0, 0.0]);
+        assert_ne!(a, b);
+
+        with_world(a, |w| {
+            w.reconcile(&PhysicsScene::create(
+                [0.0, -9.81, 0.0],
+                vec![Body::dynamic(
+                    "x".to_string(),
+                    Shape::Sphere { radius: 0.5 },
+                )],
+            ));
+        });
+        assert_eq!(
+            with_world(a, |w| w.body_transform("x").is_some()),
+            Some(true)
+        );
+        assert_eq!(
+            with_world(b, |w| w.body_transform("x").is_some()),
+            Some(false)
+        );
+
+        remove_world(a);
+        assert_eq!(with_world(a, |w| w.frame()), None);
+        remove_world(b);
+    }
+}

--- a/runtime/functor-runtime-common/src/physics/scene.rs
+++ b/runtime/functor-runtime-common/src/physics/scene.rs
@@ -1,0 +1,168 @@
+//! Declarative physics scene types (docs/physics.md).
+//!
+//! A [`PhysicsScene`] is the full set of bodies the game wants to exist this
+//! frame — what `physicsScape model` will return in Phase 2. Pure, serializable
+//! data; it crosses the dylib boundary as JSON (like `AudioScene`), and the
+//! per-frame declared-scene history is exactly what a replay re-executes, so
+//! these types carry no handles or live state.
+
+use serde::{Deserialize, Serialize};
+
+/// Standard gravity, Y-up (the coordinate convention — see CLAUDE.md).
+pub const DEFAULT_GRAVITY: [f32; 3] = [0.0, -9.81, 0.0];
+
+/// Collision shape for a body. Deliberately independent of the render-side
+/// `scene3d` shapes: physics extents are gameplay data, not visuals.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum Shape {
+    /// Axis-aligned box, given as *full* extents (width, height, depth).
+    Cuboid { extents: [f32; 3] },
+    Sphere { radius: f32 },
+    /// Capsule along the local Y axis: a segment of `2 * half_height` with
+    /// spherical caps of `radius`.
+    Capsule { half_height: f32, radius: f32 },
+}
+
+/// How the body participates in simulation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BodyKind {
+    /// Fully simulated: integrates under gravity, forces, and contacts.
+    Dynamic,
+    /// Position-driven: moved to the declared pose each frame, pushes dynamic
+    /// bodies but is not pushed back (the shape `Remote` bodies take).
+    Kinematic,
+    /// Never moves ("fixed" — `static` is a reserved word). Ground, walls.
+    Fixed,
+}
+
+/// Who simulates this body (docs/physics.md, Authority + divergence). Inert in
+/// Phase 1 — recorded in the declaration so netcode phases can key off it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Authority {
+    /// This instance simulates the body.
+    Local,
+    /// Another instance owns it; the named source drives the declared pose.
+    Remote(String),
+}
+
+/// One declared body in a [`PhysicsScene`]. `tag` is the cross-frame identity
+/// (like an `AudioSource` key): the same tag across frames is the same live
+/// body. The divergence rule in `World::reconcile` compares a body against its
+/// previous declaration — only *changed* fields are written to the live world,
+/// so a dynamic body the game keeps declaring at its spawn pose still falls
+/// freely, while declaring a *new* pose teleports it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Body {
+    pub tag: String,
+    pub kind: BodyKind,
+    pub shape: Shape,
+    pub position: [f32; 3],
+    /// Unit quaternion, `[x, y, z, w]`.
+    pub rotation: [f32; 4],
+    pub velocity: [f32; 3],
+    /// `None` uses Rapier's shape-density default.
+    #[serde(default)]
+    pub mass: Option<f32>,
+    pub friction: f32,
+    pub restitution: f32,
+    /// A sensor detects overlaps but produces no contact forces.
+    pub sensor: bool,
+    pub authority: Authority,
+}
+
+impl Body {
+    fn new(tag: String, kind: BodyKind, shape: Shape) -> Body {
+        Body {
+            tag,
+            kind,
+            shape,
+            position: [0.0, 0.0, 0.0],
+            rotation: [0.0, 0.0, 0.0, 1.0],
+            velocity: [0.0, 0.0, 0.0],
+            mass: None,
+            // Rapier's collider defaults.
+            friction: 0.5,
+            restitution: 0.0,
+            sensor: false,
+            authority: Authority::Local,
+        }
+    }
+
+    /// A simulated body (`Local` authority).
+    pub fn dynamic(tag: String, shape: Shape) -> Body {
+        Body::new(tag, BodyKind::Dynamic, shape)
+    }
+
+    /// A position-driven body (the shape `Remote` bodies take).
+    pub fn kinematic(tag: String, shape: Shape) -> Body {
+        Body::new(tag, BodyKind::Kinematic, shape)
+    }
+
+    /// A body that never moves (ground, walls).
+    pub fn fixed(tag: String, shape: Shape) -> Body {
+        Body::new(tag, BodyKind::Fixed, shape)
+    }
+
+    pub fn at(mut self, position: [f32; 3]) -> Body {
+        self.position = position;
+        self
+    }
+
+    /// Orientation as a unit quaternion `[x, y, z, w]`.
+    pub fn facing(mut self, rotation: [f32; 4]) -> Body {
+        self.rotation = rotation;
+        self
+    }
+
+    pub fn with_velocity(mut self, velocity: [f32; 3]) -> Body {
+        self.velocity = velocity;
+        self
+    }
+
+    pub fn with_mass(mut self, mass: f32) -> Body {
+        self.mass = Some(mass);
+        self
+    }
+
+    pub fn with_friction(mut self, friction: f32) -> Body {
+        self.friction = friction;
+        self
+    }
+
+    pub fn with_restitution(mut self, restitution: f32) -> Body {
+        self.restitution = restitution;
+        self
+    }
+
+    pub fn as_sensor(mut self) -> Body {
+        self.sensor = true;
+        self
+    }
+
+    pub fn with_authority(mut self, authority: Authority) -> Body {
+        self.authority = authority;
+        self
+    }
+}
+
+/// The full set of bodies the game wants this frame — what `physicsScape model`
+/// returns (Phase 2). Reconciled against the live world by `World::reconcile`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PhysicsScene {
+    pub gravity: [f32; 3],
+    pub bodies: Vec<Body>,
+}
+
+impl PhysicsScene {
+    pub fn create(gravity: [f32; 3], bodies: Vec<Body>) -> PhysicsScene {
+        PhysicsScene { gravity, bodies }
+    }
+
+    /// No bodies, standard gravity.
+    pub fn empty() -> PhysicsScene {
+        PhysicsScene {
+            gravity: DEFAULT_GRAVITY,
+            bodies: Vec::new(),
+        }
+    }
+}

--- a/runtime/functor-runtime-common/src/physics/world.rs
+++ b/runtime/functor-runtime-common/src/physics/world.rs
@@ -1,0 +1,637 @@
+//! The live physics world: Rapier state, reconcile, fixed-step, snapshots.
+//!
+//! A [`World`] is the imperative-shell half of physics (docs/physics.md): it
+//! owns the mutable Rapier solver state and is driven by two inputs only — the
+//! per-frame declared [`PhysicsScene`] (via [`World::reconcile`]) and fixed
+//! time steps (via [`World::step_frame`]). Given the same build and the same
+//! sequence of those inputs, two worlds stay byte-identical (the determinism
+//! goldens in `goldens.rs` assert exactly this).
+//!
+//! Snapshots serialize the *whole* world — every Rapier set plus broad/narrow
+//! phase and this module's own bookkeeping — so `restore` resumes bit-exact
+//! mid-flight. Rapier's scratch `PhysicsPipeline` is deliberately skipped
+//! (recreated on restore; it holds no simulation-visible state).
+
+use std::collections::BTreeMap;
+
+use rapier3d::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use super::{Body, BodyKind, PhysicsScene, Shape};
+
+/// The fixed simulation timestep. `step_frame` accumulates real dt and steps
+/// the world in whole `FIXED_DT` substeps — Rapier is never stepped with a
+/// variable dt (nondeterministic and unstable).
+pub const FIXED_DT: f32 = 1.0 / 60.0;
+
+/// Spiral-of-death guard: the most fixed substeps one `step_frame` will run.
+/// A hitch longer than `MAX_SUBSTEPS_PER_FRAME * FIXED_DT` of real time drops
+/// the backlog (simulation time falls behind wall clock) instead of stepping
+/// unboundedly.
+pub const MAX_SUBSTEPS_PER_FRAME: u32 = 8;
+
+/// A live Rapier world plus the reconcile bookkeeping that maps declared
+/// [`Body`] tags onto Rapier handles.
+#[derive(Serialize, Deserialize)]
+pub struct World {
+    gravity: [f32; 3],
+    integration_parameters: IntegrationParameters,
+    #[serde(skip, default = "PhysicsPipeline::new")]
+    pipeline: PhysicsPipeline,
+    islands: IslandManager,
+    broad_phase: BroadPhaseBvh,
+    narrow_phase: NarrowPhase,
+    bodies: RigidBodySet,
+    colliders: ColliderSet,
+    impulse_joints: ImpulseJointSet,
+    multibody_joints: MultibodyJointSet,
+    ccd_solver: CCDSolver,
+    /// tag → live handles. `BTreeMap` so iteration (despawn order, dumps,
+    /// serialization) is deterministic — a requirement, not a nicety.
+    tags: BTreeMap<String, (RigidBodyHandle, ColliderHandle)>,
+    /// Last-declared body per tag — the memory behind the divergence rule:
+    /// reconcile writes a field to the live body only when the new declaration
+    /// *differs from this cache*; an unchanged declaration leaves the body to
+    /// the simulation.
+    declared: BTreeMap<String, Body>,
+    accumulator: f32,
+    frame: u64,
+}
+
+impl World {
+    pub fn new(gravity: [f32; 3]) -> World {
+        let mut integration_parameters = IntegrationParameters::default();
+        integration_parameters.dt = FIXED_DT;
+        World {
+            gravity,
+            integration_parameters,
+            pipeline: PhysicsPipeline::new(),
+            islands: IslandManager::new(),
+            broad_phase: BroadPhaseBvh::default(),
+            narrow_phase: NarrowPhase::new(),
+            bodies: RigidBodySet::new(),
+            colliders: ColliderSet::new(),
+            impulse_joints: ImpulseJointSet::new(),
+            multibody_joints: MultibodyJointSet::new(),
+            ccd_solver: CCDSolver::new(),
+            tags: BTreeMap::new(),
+            declared: BTreeMap::new(),
+            accumulator: 0.0,
+            frame: 0,
+        }
+    }
+
+    /// Fixed frames stepped since creation (or since the restored snapshot's
+    /// origin).
+    pub fn frame(&self) -> u64 {
+        self.frame
+    }
+
+    /// Diff the declared scene against the last-declared cache and apply the
+    /// difference to the live world.
+    ///
+    /// Ordering is load-bearing for determinism (Rapier arena handles depend on
+    /// the full insert/remove history), so the scene is canonicalized *by tag*:
+    /// despawns first, then spawns/updates, both in tag order. Sorting — rather
+    /// than declaration order — makes the handle history invariant to how the
+    /// game happened to assemble the body list (docs/physics.md, "sort by
+    /// tag"). A tag repeated in the scene keeps its first occurrence (mirrors
+    /// `audio::reconcile`).
+    pub fn reconcile(&mut self, scene: &PhysicsScene) {
+        self.gravity = scene.gravity;
+
+        let mut wanted: BTreeMap<&String, &Body> = BTreeMap::new();
+        for body in &scene.bodies {
+            wanted.entry(&body.tag).or_insert(body); // first occurrence wins
+        }
+
+        // Despawns: live tags no longer declared, in tag order.
+        let gone: Vec<String> = self
+            .tags
+            .keys()
+            .filter(|t| !wanted.contains_key(t))
+            .cloned()
+            .collect();
+        for tag in &gone {
+            self.despawn(tag);
+        }
+
+        // Spawns / updates, in tag order.
+        for (tag, body) in wanted {
+            match self.declared.get(tag) {
+                None => self.spawn(body),
+                Some(prev) if prev != body => {
+                    let prev = prev.clone();
+                    self.apply_divergence(&prev, body);
+                }
+                Some(_) => {} // unchanged: the simulation owns this body
+            }
+            self.declared.insert(tag.clone(), body.clone());
+        }
+    }
+
+    /// Accumulate real (variable) dt and run whole fixed substeps, carrying the
+    /// remainder. Returns the number of substeps taken.
+    pub fn step_frame(&mut self, real_dt: f32) -> u32 {
+        self.accumulator += real_dt.max(0.0);
+        let mut steps = 0;
+        while self.accumulator >= FIXED_DT && steps < MAX_SUBSTEPS_PER_FRAME {
+            self.step_fixed();
+            self.accumulator -= FIXED_DT;
+            steps += 1;
+        }
+        if steps == MAX_SUBSTEPS_PER_FRAME && self.accumulator >= FIXED_DT {
+            // Hitch longer than the cap: drop the whole-step backlog rather
+            // than owing ever more substeps, but keep the sub-step remainder so
+            // the step phase is preserved.
+            self.accumulator %= FIXED_DT;
+        }
+        steps
+    }
+
+    /// Advance exactly one fixed step.
+    pub fn step_fixed(&mut self) {
+        self.pipeline.step(
+            Vector::new(self.gravity[0], self.gravity[1], self.gravity[2]),
+            &self.integration_parameters,
+            &mut self.islands,
+            &mut self.broad_phase,
+            &mut self.narrow_phase,
+            &mut self.bodies,
+            &mut self.colliders,
+            &mut self.impulse_joints,
+            &mut self.multibody_joints,
+            &mut self.ccd_solver,
+            &(),
+            &(),
+        );
+        self.frame += 1;
+    }
+
+    /// Serialize the full world. Byte-equality of two snapshots is the
+    /// determinism oracle the goldens assert. JSON keeps snapshots
+    /// text-inspectable (LLM-native); if size ever matters the encoding can
+    /// swap without touching callers.
+    pub fn snapshot(&self) -> Vec<u8> {
+        serde_json::to_vec(self).expect("physics world state is always serializable")
+    }
+
+    /// Restore a snapshot taken by [`World::snapshot`], resuming the simulation
+    /// bit-exact from that frame.
+    pub fn restore(&mut self, bytes: &[u8]) -> Result<(), serde_json::Error> {
+        *self = serde_json::from_slice(bytes)?;
+        Ok(())
+    }
+
+    /// Live pose of a declared body: `(position, rotation-quaternion-xyzw)`.
+    pub fn body_transform(&self, tag: &str) -> Option<([f32; 3], [f32; 4])> {
+        let (rb_handle, _) = self.tags.get(tag)?;
+        let rb = self.bodies.get(*rb_handle)?;
+        let pos = rb.translation();
+        let rot = rb.rotation();
+        Some(([pos.x, pos.y, pos.z], [rot.x, rot.y, rot.z, rot.w]))
+    }
+
+    /// Live linear velocity of a declared body.
+    pub fn body_velocity(&self, tag: &str) -> Option<[f32; 3]> {
+        let (rb_handle, _) = self.tags.get(tag)?;
+        let rb = self.bodies.get(*rb_handle)?;
+        let v = rb.linvel();
+        Some([v.x, v.y, v.z])
+    }
+
+    /// Headless observability (docs/physics.md, "drivable and observable
+    /// headlessly"): the world as JSON — frame counter plus per-tag transform,
+    /// velocity, and sleep state, in tag order.
+    pub fn dump(&self) -> String {
+        #[derive(Serialize)]
+        struct BodyDump<'a> {
+            tag: &'a str,
+            position: [f32; 3],
+            rotation: [f32; 4],
+            velocity: [f32; 3],
+            sleeping: bool,
+        }
+        #[derive(Serialize)]
+        struct WorldDump<'a> {
+            frame: u64,
+            bodies: Vec<BodyDump<'a>>,
+        }
+
+        let bodies = self
+            .tags
+            .iter()
+            .filter_map(|(tag, (rb_handle, _))| {
+                let rb = self.bodies.get(*rb_handle)?;
+                let pos = rb.translation();
+                let rot = rb.rotation();
+                let vel = rb.linvel();
+                Some(BodyDump {
+                    tag,
+                    position: [pos.x, pos.y, pos.z],
+                    rotation: [rot.x, rot.y, rot.z, rot.w],
+                    velocity: [vel.x, vel.y, vel.z],
+                    sleeping: rb.is_sleeping(),
+                })
+            })
+            .collect();
+
+        serde_json::to_string(&WorldDump {
+            frame: self.frame,
+            bodies,
+        })
+        .expect("physics dump is always serializable")
+    }
+
+    // ── reconcile internals ─────────────────────────────────────────────
+
+    fn spawn(&mut self, body: &Body) {
+        let builder = match body.kind {
+            BodyKind::Dynamic => RigidBodyBuilder::dynamic(),
+            BodyKind::Kinematic => RigidBodyBuilder::kinematic_position_based(),
+            BodyKind::Fixed => RigidBodyBuilder::fixed(),
+        };
+        let rb = builder
+            .pose(pose_of(body))
+            .linvel(vec3(body.velocity))
+            .build();
+
+        let mut collider = collider_of(&body.shape)
+            .friction(body.friction)
+            .restitution(body.restitution)
+            .sensor(body.sensor);
+        if let Some(mass) = body.mass {
+            collider = collider.mass(mass);
+        }
+
+        let rb_handle = self.bodies.insert(rb);
+        let col_handle =
+            self.colliders
+                .insert_with_parent(collider.build(), rb_handle, &mut self.bodies);
+        self.tags.insert(body.tag.clone(), (rb_handle, col_handle));
+    }
+
+    fn despawn(&mut self, tag: &str) {
+        if let Some((rb_handle, _)) = self.tags.remove(tag) {
+            // Removes attached colliders and joints too.
+            self.bodies.remove(
+                rb_handle,
+                &mut self.islands,
+                &mut self.colliders,
+                &mut self.impulse_joints,
+                &mut self.multibody_joints,
+                true,
+            );
+        }
+        self.declared.remove(tag);
+    }
+
+    /// The declaration for an existing tag changed: write exactly the changed
+    /// fields into the live body (docs/physics.md, Authority + divergence).
+    /// Structural changes (kind/shape/mass) rebuild the body wholesale — the
+    /// tag is the identity, not the handle — but the rebuilt body keeps its
+    /// *live* pose/velocities for every field whose declaration didn't change:
+    /// a mass change on a falling crate must not teleport it back to its
+    /// declared spawn pose.
+    fn apply_divergence(&mut self, prev: &Body, next: &Body) {
+        if prev.kind != next.kind || prev.shape != next.shape || prev.mass != next.mass {
+            let live = self.tags.get(&next.tag).and_then(|(rb, _)| {
+                let rb = self.bodies.get(*rb)?;
+                Some((*rb.position(), rb.linvel(), rb.angvel()))
+            });
+            self.despawn(&next.tag);
+            self.spawn(next);
+            if let (Some((pose, linvel, angvel)), Some((rb_handle, _))) =
+                (live, self.tags.get(&next.tag).copied())
+            {
+                let rb = &mut self.bodies[rb_handle];
+                if prev.position == next.position && prev.rotation == next.rotation {
+                    rb.set_position(pose, true);
+                }
+                if prev.velocity == next.velocity {
+                    rb.set_linvel(linvel, true);
+                }
+                // Angular velocity is never declarable — always physics-owned.
+                rb.set_angvel(angvel, true);
+            }
+            return;
+        }
+
+        let (rb_handle, col_handle) = self.tags[&next.tag];
+
+        if prev.position != next.position || prev.rotation != next.rotation {
+            let pose = pose_of(next);
+            let rb = &mut self.bodies[rb_handle];
+            // Skip the write when the declaration merely caught up with the
+            // simulation (the `Physics.synced` steady state: the model
+            // re-declares last frame's physics output). The values would be a
+            // no-op, but `wake_up = true` isn't — writing would keep every
+            // synced body permanently awake.
+            if *rb.position() != pose {
+                match next.kind {
+                    // Kinematic bodies are *driven*: the next pose is a target
+                    // the solver moves them to over the step (so they carry
+                    // velocity into contacts) rather than an instant teleport.
+                    BodyKind::Kinematic => rb.set_next_kinematic_position(pose),
+                    _ => rb.set_position(pose, true),
+                }
+            }
+        }
+        if prev.velocity != next.velocity {
+            let rb = &mut self.bodies[rb_handle];
+            let v = vec3(next.velocity);
+            if rb.linvel() != v {
+                rb.set_linvel(v, true);
+            }
+        }
+        if prev.friction != next.friction {
+            self.colliders[col_handle].set_friction(next.friction);
+        }
+        if prev.restitution != next.restitution {
+            self.colliders[col_handle].set_restitution(next.restitution);
+        }
+        if prev.sensor != next.sensor {
+            self.colliders[col_handle].set_sensor(next.sensor);
+        }
+        // `authority` is inert in Phase 1: cached (by reconcile) but never
+        // written to the live world.
+    }
+}
+
+fn vec3(v: [f32; 3]) -> Vector {
+    Vector::new(v[0], v[1], v[2])
+}
+
+fn pose_of(body: &Body) -> Pose {
+    // Normalize the declared quaternion: `from_xyzw` doesn't, and a degenerate
+    // rotation (all zeros, or junk off the future JSON boundary) would
+    // NaN-poison the solver — which `snapshot` can't even flag (serde_json
+    // writes non-finite floats as `null`, so the failure surfaces at `restore`,
+    // far from the cause).
+    let q = Rotation::from_xyzw(
+        body.rotation[0],
+        body.rotation[1],
+        body.rotation[2],
+        body.rotation[3],
+    );
+    let rotation = if q.length_squared().is_finite() && q.length_squared() > f32::EPSILON {
+        q.normalize()
+    } else {
+        Rotation::IDENTITY
+    };
+    Pose::from_parts(vec3(body.position), rotation)
+}
+
+fn collider_of(shape: &Shape) -> ColliderBuilder {
+    match *shape {
+        Shape::Cuboid { extents } => {
+            ColliderBuilder::cuboid(extents[0] / 2.0, extents[1] / 2.0, extents[2] / 2.0)
+        }
+        Shape::Sphere { radius } => ColliderBuilder::ball(radius),
+        Shape::Capsule {
+            half_height,
+            radius,
+        } => ColliderBuilder::capsule_y(half_height, radius),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ground() -> Body {
+        Body::fixed(
+            "ground".to_string(),
+            Shape::Cuboid {
+                extents: [20.0, 0.2, 20.0],
+            },
+        )
+    }
+
+    fn crate_at(tag: &str, position: [f32; 3]) -> Body {
+        Body::dynamic(
+            tag.to_string(),
+            Shape::Cuboid {
+                extents: [1.0, 1.0, 1.0],
+            },
+        )
+        .at(position)
+    }
+
+    fn scene(bodies: Vec<Body>) -> PhysicsScene {
+        PhysicsScene::create([0.0, -9.81, 0.0], bodies)
+    }
+
+    #[test]
+    fn reconcile_spawns_and_despawns_by_tag() {
+        let mut w = World::new([0.0, -9.81, 0.0]);
+        w.reconcile(&scene(vec![ground(), crate_at("a", [0.0, 3.0, 0.0])]));
+        assert!(w.body_transform("ground").is_some());
+        assert!(w.body_transform("a").is_some());
+
+        w.reconcile(&scene(vec![ground()]));
+        assert!(w.body_transform("a").is_none());
+        assert!(w.body_transform("ground").is_some());
+    }
+
+    #[test]
+    fn duplicate_tags_keep_first_occurrence() {
+        let mut w = World::new([0.0, -9.81, 0.0]);
+        w.reconcile(&scene(vec![
+            crate_at("a", [0.0, 1.0, 0.0]),
+            crate_at("a", [9.0, 9.0, 9.0]),
+        ]));
+        let (pos, _) = w.body_transform("a").unwrap();
+        assert_eq!(pos, [0.0, 1.0, 0.0]);
+    }
+
+    #[test]
+    fn unchanged_declaration_leaves_the_simulation_alone() {
+        let mut w = World::new([0.0, -9.81, 0.0]);
+        let s = scene(vec![crate_at("a", [0.0, 5.0, 0.0])]);
+        w.reconcile(&s);
+        for _ in 0..30 {
+            w.step_fixed();
+        }
+        let (fallen, _) = w.body_transform("a").unwrap();
+        assert!(fallen[1] < 5.0, "body should have fallen, got {fallen:?}");
+
+        // Re-declaring the same scene must not snap the body back to its
+        // declared spawn position — the declaration didn't change.
+        w.reconcile(&s);
+        let (after, _) = w.body_transform("a").unwrap();
+        assert_eq!(after, fallen);
+    }
+
+    #[test]
+    fn changed_declaration_teleports() {
+        let mut w = World::new([0.0, -9.81, 0.0]);
+        w.reconcile(&scene(vec![crate_at("a", [0.0, 5.0, 0.0])]));
+        for _ in 0..30 {
+            w.step_fixed();
+        }
+        w.reconcile(&scene(vec![crate_at("a", [2.0, 10.0, 0.0])]));
+        let (pos, _) = w.body_transform("a").unwrap();
+        assert_eq!(pos, [2.0, 10.0, 0.0]);
+    }
+
+    #[test]
+    fn velocity_change_applies_without_teleporting() {
+        let mut w = World::new([0.0, 0.0, 0.0]);
+        let body = crate_at("a", [0.0, 5.0, 0.0]);
+        w.reconcile(&scene(vec![body.clone()]));
+        w.reconcile(&scene(vec![body.with_velocity([3.0, 0.0, 0.0])]));
+        let (pos, _) = w.body_transform("a").unwrap();
+        assert_eq!(pos, [0.0, 5.0, 0.0]);
+        assert_eq!(w.body_velocity("a").unwrap(), [3.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn structural_rebuild_keeps_live_state_for_unchanged_fields() {
+        let mut w = World::new([0.0, -9.81, 0.0]);
+        let falling = crate_at("a", [0.0, 5.0, 0.0]);
+        w.reconcile(&scene(vec![falling.clone()]));
+        for _ in 0..30 {
+            w.step_fixed();
+        }
+        let (fallen, _) = w.body_transform("a").unwrap();
+        let vel = w.body_velocity("a").unwrap();
+        assert!(fallen[1] < 5.0 && vel[1] < 0.0);
+
+        // Change ONLY the mass (a structural rebuild). Position/velocity
+        // declarations are unchanged, so the rebuilt body must keep its live
+        // fallen pose and momentum — not snap back to the declared spawn.
+        w.reconcile(&scene(vec![falling.with_mass(10.0)]));
+        let (pos, _) = w.body_transform("a").unwrap();
+        assert_eq!(pos, fallen);
+        assert_eq!(w.body_velocity("a").unwrap(), vel);
+    }
+
+    #[test]
+    fn degenerate_declared_rotation_falls_back_to_identity() {
+        let mut w = World::new([0.0, 0.0, 0.0]);
+        w.reconcile(&scene(vec![
+            crate_at("a", [0.0, 1.0, 0.0]).facing([0.0, 0.0, 0.0, 0.0])
+        ]));
+        w.step_fixed();
+        let (_, rot) = w.body_transform("a").unwrap();
+        assert_eq!(rot, [0.0, 0.0, 0.0, 1.0]);
+        // And the world is still snapshot/restore-clean (no NaN poisoning).
+        let snap = w.snapshot();
+        let mut r = World::new([0.0, 0.0, 0.0]);
+        r.restore(&snap).unwrap();
+    }
+
+    #[test]
+    fn redeclaring_the_live_pose_does_not_wake_a_sleeping_body() {
+        let mut w = World::new([0.0, -9.81, 0.0]);
+        w.reconcile(&scene(vec![ground(), crate_at("a", [0.0, 0.7, 0.0])]));
+        // Let the crate settle and fall asleep.
+        for _ in 0..300 {
+            w.step_fixed();
+        }
+        let dump: serde_json::Value = serde_json::from_str(&w.dump()).unwrap();
+        assert_eq!(
+            dump["bodies"][0]["sleeping"], true,
+            "crate should be asleep: {dump}"
+        );
+
+        // Declare the body at its *live* rest pose (a changed declaration — the
+        // synced steady state). The write must be skipped so the body sleeps on.
+        let (rest, rot) = w.body_transform("a").unwrap();
+        w.reconcile(&scene(vec![
+            ground(),
+            crate_at("a", rest).facing(rot).with_velocity([0.0, 0.0, 0.0]),
+        ]));
+        w.step_fixed();
+        let dump: serde_json::Value = serde_json::from_str(&w.dump()).unwrap();
+        assert_eq!(dump["bodies"][0]["sleeping"], true, "body was woken");
+    }
+
+    #[test]
+    fn reconcile_is_invariant_to_declaration_order() {
+        let mut x = World::new([0.0, -9.81, 0.0]);
+        let mut y = World::new([0.0, -9.81, 0.0]);
+        let (a, b) = (crate_at("a", [0.0, 2.0, 0.0]), crate_at("b", [0.5, 3.0, 0.0]));
+        x.reconcile(&scene(vec![a.clone(), b.clone()]));
+        y.reconcile(&scene(vec![b, a]));
+        for _ in 0..30 {
+            x.step_fixed();
+            y.step_fixed();
+        }
+        assert!(
+            x.snapshot() == y.snapshot(),
+            "handle history depends on declaration order"
+        );
+    }
+
+    #[test]
+    fn kind_change_rebuilds_the_body() {
+        let mut w = World::new([0.0, -9.81, 0.0]);
+        w.reconcile(&scene(vec![crate_at("a", [0.0, 5.0, 0.0])]));
+        // Flip to fixed: the body must stop integrating.
+        let fixed = Body::fixed(
+            "a".to_string(),
+            Shape::Cuboid {
+                extents: [1.0, 1.0, 1.0],
+            },
+        )
+        .at([0.0, 5.0, 0.0]);
+        w.reconcile(&scene(vec![fixed]));
+        for _ in 0..30 {
+            w.step_fixed();
+        }
+        let (pos, _) = w.body_transform("a").unwrap();
+        assert_eq!(pos, [0.0, 5.0, 0.0]);
+    }
+
+    #[test]
+    fn accumulator_carries_the_remainder() {
+        let mut w = World::new([0.0, 0.0, 0.0]);
+        assert_eq!(w.step_frame(FIXED_DT * 1.5), 1);
+        // 0.5 dt left over; another 1.5 makes 2.0 → two steps.
+        assert_eq!(w.step_frame(FIXED_DT * 1.5), 2);
+        assert_eq!(w.frame(), 3);
+    }
+
+    #[test]
+    fn substeps_are_capped_and_backlog_dropped() {
+        let mut w = World::new([0.0, 0.0, 0.0]);
+        assert_eq!(w.step_frame(1.0), MAX_SUBSTEPS_PER_FRAME);
+        // Backlog was dropped: a normal frame takes exactly one substep again.
+        assert_eq!(w.step_frame(FIXED_DT), 1);
+    }
+
+    #[test]
+    fn snapshot_restore_round_trips_byte_exact() {
+        let mut w = World::new([0.0, -9.81, 0.0]);
+        w.reconcile(&scene(vec![ground(), crate_at("a", [0.0, 3.0, 0.0])]));
+        for _ in 0..20 {
+            w.step_fixed();
+        }
+        let snap = w.snapshot();
+
+        let mut restored = World::new([0.0, 0.0, 0.0]);
+        restored.restore(&snap).unwrap();
+        assert_eq!(restored.frame(), w.frame());
+        assert!(restored.snapshot() == snap, "restored snapshot differs");
+    }
+
+    #[test]
+    fn dump_lists_bodies_in_tag_order() {
+        let mut w = World::new([0.0, -9.81, 0.0]);
+        w.reconcile(&scene(vec![
+            crate_at("b", [0.0, 1.0, 0.0]),
+            crate_at("a", [0.0, 2.0, 0.0]),
+        ]));
+        let dump: serde_json::Value = serde_json::from_str(&w.dump()).unwrap();
+        let tags: Vec<&str> = dump["bodies"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|b| b["tag"].as_str().unwrap())
+            .collect();
+        assert_eq!(tags, vec!["a", "b"]);
+        assert_eq!(dump["frame"], 0);
+    }
+}


### PR DESCRIPTION
Phase **1a** of [docs/physics.md](../blob/physics-1-shell-spine/docs/physics.md): the pure-Rust physics spine in `functor-runtime-common`. No F# surface, no shell wiring — that's Phase 2. Verified entirely headlessly (`cargo test`, no GL), so the goldens run in existing CI.

## What's here

- **rapier3d 0.33** — default features + `serde-serialize`, deliberately **no `enhanced-determinism`**: the requirement is *local* (single-binary) determinism, which Rapier provides by default; the flag would trade SIMD/parallel for cross-platform determinism we don't need (doc's Determinism section, updated in this PR, has the full argument).
- **Declarative scene types** (`scene.rs`) — `PhysicsScene` / `Body` / `Shape` / `BodyKind` / `Authority`, plain serde data mirroring the F# API sketch; the future Fable Emit shims construct these directly.
- **`World`** (`world.rs`) — owns the Rapier sets; **reconcile-by-tag** with the divergence rule (changed declaration → write only the changed fields; unchanged → the simulation owns the body; structural changes rebuild but keep live pose/momentum); **fixed-step accumulator** (1/60, capped substeps, phase-preserving backlog drop); **byte-exact snapshots** (`snapshot`/`restore`); `dump()` JSON for headless/LLM observability.
- **Determinism details**: reconcile canonicalizes by tag so the Rapier arena *handle history* is invariant to declaration order; despawns are sorted; duplicate tags first-wins (mirrors `audio::reconcile`). Our bookkeeping maps are `BTreeMap` so serialization order is fixed.
- **`WorldId` registry** (`registry.rs`) — thread-local, lazily-created singleton world 0, following the `net::registry` pattern (survives game-dylib hot reload).
- **Goldens** (`goldens.rs`):
  - *Determinism*: two worlds driven by the same declared-scene script stay **byte-identical every frame** for 120 frames — the script includes a despawn + respawn (arena-slot reuse) and a mid-run teleport.
  - *Restore+replay*: a frame-20 snapshot restored into a fresh world and replayed forward lands byte-identical to the live run — the invariant the Phase 1b `Timeline` seek rests on.

## docs/physics.md updates (same session)

Local-determinism framing (cross-platform is a **non-goal**; `enhanced-determinism` documented as the lockstep-only escape hatch), the authority-boundary consistency note, the VR target topology (client-owned player pose, server-owned everything else), Source/Rocket League prior art, the debug-visualization plan (Rapier `debug-render` → line pass, Phase 2b), and the roadmap split 1a/1b.

## Testing

- `cargo test -p functor_runtime_common` — 91 passed (20 physics incl. both goldens)
- `cargo check -p functor_runtime_common --features strict` — clean
- `cargo check -p functor_runtime_common --target wasm32-unknown-unknown` — compiles (one pre-existing deprecation in `io/`, untouched)
- Cross-engine review (`/xreview`: Claude + Codex) run; all agreed findings fixed and re-validated (structural-rebuild state preservation, tag-order canonicalization, quaternion normalization, sleep-preserving no-op writes).

Stacked next: **1b — the `Simulatable`/`Timeline` rewind seam** (`KeyframeLog`/`SnapshotRing`/`ReplayOnly` + strategy-equivalence and replay goldens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)