### PR TITLE
feat(runtime): C4b-1 — mouse input, the lit prelude, the primitives port

### DIFF
--- a/.claude/skills/mle-language/SKILL.md
+++ b/.claude/skills/mle-language/SKILL.md
@@ -98,11 +98,17 @@ Available in runner-hosted MLE (and tests via
 Scene.cube() / sphere() / cylinder() / quad() / plane()   // zero args, enforced
 Scene.group([scene, …])
 scene |> Scene.color(r, g, b)                              // scene-first: pipes
+scene |> Scene.lit(r, g, b)                                // diffuse+specular
+scene |> Scene.emissive(r, g, b)                           // unlit glow
 scene |> Scene.translate(x, y, z)
 scene |> Scene.rotateX(rad) / rotateY / rotateZ
 scene |> Scene.scale(k)
 Camera.lookAt(ex, ey, ez, tx, ty, tz)                      // up=+Y, fov 45°
+Camera.firstPerson(ex, ey, ez, yawRad, pitchRad, fovDeg)
+Light.ambient(r, g, b) / Light.point(px, py, pz, r, g, b, intensity, range)
+Light.directional(dx, dy, dz, r, g, b, intensity) |> Light.castShadows
 Frame.create(camera, scene)                                // what draw returns
+Frame.createLit(camera, scene, [light, …])                 // lit + shadowed
 ```
 
 A runner-hosted game (`functor-runner --mle --game-path game.mle`) defines:
@@ -112,6 +118,8 @@ let init = { … }                       // the initial model (a value)
 let tick = (model, dt, tts) => model'  // per-frame step
 let draw = (model, tts) => Frame.create(camera, scene)
 let input = (model, key, isDown) => model'  // OPTIONAL; key = "W"/"Up"/"Space"
+let mouseMove = (model, x, y) => model'     // OPTIONAL; window pixels
+let mouseWheel = (model, delta) => model'   // OPTIONAL
 ```
 
 A project dir with `functor.json` `{"language": "mle", "entry": "game.mle"}`

--- a/docs/mle.md
+++ b/docs/mle.md
@@ -268,8 +268,16 @@ Starts once A2 + B3 exist.
         in — no watchexec), wasm errors cleanly until C5.
         *Verify (done):* SDK e2e asserts two key events reach the model
         with canonical names (14/14 suite); CLI build/run/wasm probes.
-      - [ ] **C4b.** `update`/messages, subscriptions, mouse, effect-queue
-        drain semantics; port `examples/primitives` + golden.
+      - [x] **C4b-1. Mouse + the lit prelude + the primitives port.**
+        Optional `mouseMove(model, x, y)` / `mouseWheel(model, delta)`
+        entry points; prelude grows the lit pipeline — `Scene.lit`/
+        `Scene.emissive`, all three `Light.*` kinds + `castShadows`,
+        `Camera.firstPerson`, `Frame.createLit`. `examples/mle-primitives`
+        ports the F# golden scene (shadow-casting sun, orbiting colored
+        point lights, emissive markers) — **0.000% pixels over the golden
+        tolerance vs the F# render** at the same fixed time.
+      - [ ] **C4b-2** (wants B5's ADTs for messages): `update`/messages,
+        subscriptions, effect-queue drain semantics.
 - [ ] **C5. Wasm.** The interpreter crate compiles to wasm32; `.mle` source
       ships in the bundle. *Verify:* wasm build of mle-hello renders.
 - [ ] **C6. Perf gate.** Measure C4 at 60fps with headroom; bytecode VM

--- a/examples/mle-hello/game.mle
+++ b/examples/mle-hello/game.mle
@@ -8,7 +8,7 @@
 // `|> Scene.translate(radius…) |> Scene.rotateY(angle)` places a cube on the
 // ring at `angle`.
 
-let count = 15.0
+let count = 12.0
 let tau = 6.2831853
 
 let ringCube = (spin: Float, i: Float) =>

--- a/examples/mle-hello/game.mle
+++ b/examples/mle-hello/game.mle
@@ -8,7 +8,7 @@
 // `|> Scene.translate(radius…) |> Scene.rotateY(angle)` places a cube on the
 // ring at `angle`.
 
-let count = 12.0
+let count = 15.0
 let tau = 6.2831853
 
 let ringCube = (spin: Float, i: Float) =>

--- a/examples/mle-primitives/functor.json
+++ b/examples/mle-primitives/functor.json
@@ -1,0 +1,4 @@
+{
+  "language": "mle",
+  "entry": "game.mle"
+}

--- a/examples/mle-primitives/game.mle
+++ b/examples/mle-primitives/game.mle
@@ -1,0 +1,57 @@
+// examples/mle-primitives — the MLE port of examples/primitives (F#), the
+// asset-free lit-pipeline scene: ground + three primitives under a shadow-
+// casting sun, with two colored point lights orbiting (emissive markers at
+// their positions). All animation derives from tts, so it renders
+// deterministically under --fixed-time — golden-comparable against the F#
+// original (docs/mle.md C4b).
+//
+// Transform-order note: F#'s `x |> translateX a |> scale s` right-multiplies
+// (scale hits the vertex first); MLE transforms apply OUTERMOST-LAST, so the
+// same composition reads `x |> Scene.scale(s) |> Scene.translate(a, …)`.
+
+let tau = 6.2831853
+let orbitRadius = 3.2
+
+let pointPos = (i: Float, tts: Float) =>
+  let a = tts * 0.6 + i * (tau / 2.0) in
+  { x: Math.cos(a) * orbitRadius, y: 2.2, z: Math.sin(a) * orbitRadius }
+
+// Near-white lit surfaces so the colored point lights tint them.
+let whiteShapes = () =>
+  Scene.group([
+    Scene.sphere() |> Scene.scale(0.8) |> Scene.translate(-2.2, 0.8, 0.0),
+    Scene.cube() |> Scene.translate(2.2, 0.5, 0.0),
+    Scene.cylinder() |> Scene.translate(0.0, 0.5, 2.2),
+  ]) |> Scene.lit(0.9, 0.9, 0.9)
+
+// An emissive marker sphere at a point light's position.
+let marker = (i: Float, tts: Float, r: Float, g: Float, b: Float) =>
+  let p = pointPos(i, tts) in
+  Scene.sphere()
+    |> Scene.scale(0.15)
+    |> Scene.emissive(r, g, b)
+    |> Scene.translate(p.x, p.y, p.z)
+
+let pointLight = (i: Float, tts: Float, r: Float, g: Float, b: Float) =>
+  let p = pointPos(i, tts) in
+  Light.point(p.x, p.y, p.z, r, g, b, 1.4, 4.0)
+
+let init = {}
+
+let tick = (m, dt, tts) => m
+
+let draw = (m, tts: Float) =>
+  Frame.createLit(
+    Camera.firstPerson(0.0, 3.5, -8.0, 0.0, -0.3, 60.0),
+    Scene.group([
+      Scene.plane() |> Scene.scale(24.0) |> Scene.lit(0.6, 0.6, 0.62),
+      whiteShapes(),
+      marker(0.0, tts, 1.0, 0.3, 0.25),
+      marker(1.0, tts, 0.35, 0.5, 1.0),
+    ]),
+    [
+      Light.ambient(0.1, 0.1, 0.13),
+      Light.directional(0.5, -1.0, 0.35, 1.0, 0.98, 0.95, 0.85) |> Light.castShadows,
+      pointLight(0.0, tts, 1.0, 0.3, 0.25),
+      pointLight(1.0, tts, 0.35, 0.5, 1.0),
+    ])

--- a/runtime/functor-runtime-common/src/mle_prelude.rs
+++ b/runtime/functor-runtime-common/src/mle_prelude.rs
@@ -48,7 +48,7 @@ use std::rc::Rc;
 
 use crate::math::Angle;
 use crate::scene3d::MaterialDescription;
-use crate::{Camera, Frame, Scene3D, SceneObject};
+use crate::{Camera, Frame, Light, Scene3D, SceneObject};
 
 /// A [`Scene3D`] as an opaque MLE value.
 pub struct MleScene(pub Scene3D);
@@ -58,6 +58,18 @@ pub struct MleCamera(pub Camera);
 
 /// A [`Frame`] as an opaque MLE value — what an MLE `draw` returns.
 pub struct MleFrame(pub Frame);
+
+/// A [`Light`] as an opaque MLE value.
+pub struct MleLight(pub Light);
+
+impl HostData for MleLight {
+    fn type_name(&self) -> &'static str {
+        "Light"
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
 
 impl HostData for MleScene {
     fn type_name(&self) -> &'static str {
@@ -111,8 +123,16 @@ const PATHS: &[&str] = &[
     "Scene.rotateY",
     "Scene.rotateZ",
     "Scene.scale",
+    "Scene.lit",
+    "Scene.emissive",
     "Camera.lookAt",
+    "Camera.firstPerson",
+    "Light.ambient",
+    "Light.directional",
+    "Light.point",
+    "Light.castShadows",
     "Frame.create",
+    "Frame.createLit",
 ];
 
 impl Host for FunctorHost {
@@ -160,6 +180,29 @@ impl Host for FunctorHost {
                     scene_value(group(scenes, Matrix4::from_scale(1.0)))
                 }
                 _ => usage("Scene.group([scene, …])"),
+            },
+            // Scene first, so they pipe: `Scene.cube() |> Scene.lit(r, g, b)`.
+            "Scene.lit" | "Scene.emissive" => match args.as_slice() {
+                [scene, r, g, b] => {
+                    let (r, g, b) = (
+                        num(r, span)? as f32,
+                        num(g, span)? as f32,
+                        num(b, span)? as f32,
+                    );
+                    let Some(scene) = scene_of(scene) else {
+                        return usage(&format!("{path}(scene, r, g, b)"));
+                    };
+                    let material = if path == "Scene.lit" {
+                        MaterialDescription::lit(r, g, b, 1.0)
+                    } else {
+                        MaterialDescription::emissive(r, g, b, 1.0)
+                    };
+                    scene_value(Scene3D {
+                        obj: SceneObject::Material(material, vec![scene.clone()]),
+                        xform: Matrix4::from_scale(1.0),
+                    })
+                }
+                _ => usage(&format!("{path}(scene, r, g, b)")),
             },
             // Scene first, so it pipes: `Scene.cube() |> Scene.color(r, g, b)`.
             "Scene.color" => match args.as_slice() {
@@ -226,6 +269,88 @@ impl Host for FunctorHost {
                 )))),
                 _ => usage("Camera.lookAt(ex, ey, ez, tx, ty, tz)"),
             },
+            "Camera.firstPerson" => match args.as_slice() {
+                [ex, ey, ez, yaw, pitch, fov_deg] => Ok(host(MleCamera(Camera::first_person(
+                    [
+                        num(ex, span)? as f32,
+                        num(ey, span)? as f32,
+                        num(ez, span)? as f32,
+                    ],
+                    Angle::from_radians(num(yaw, span)? as f32),
+                    Angle::from_radians(num(pitch, span)? as f32),
+                    Angle::from_degrees(num(fov_deg, span)? as f32),
+                )))),
+                _ => usage("Camera.firstPerson(ex, ey, ez, yawRad, pitchRad, fovDeg)"),
+            },
+            "Light.ambient" => match args.as_slice() {
+                [r, g, b] => Ok(host(MleLight(Light::ambient(
+                    num(r, span)? as f32,
+                    num(g, span)? as f32,
+                    num(b, span)? as f32,
+                )))),
+                _ => usage("Light.ambient(r, g, b)"),
+            },
+            "Light.directional" => match args.as_slice() {
+                [dx, dy, dz, r, g, b, intensity] => Ok(host(MleLight(Light::directional(
+                    num(dx, span)? as f32,
+                    num(dy, span)? as f32,
+                    num(dz, span)? as f32,
+                    num(r, span)? as f32,
+                    num(g, span)? as f32,
+                    num(b, span)? as f32,
+                    num(intensity, span)? as f32,
+                )))),
+                _ => usage("Light.directional(dx, dy, dz, r, g, b, intensity)"),
+            },
+            "Light.point" => match args.as_slice() {
+                [px, py, pz, r, g, b, intensity, range] => Ok(host(MleLight(Light::point(
+                    num(px, span)? as f32,
+                    num(py, span)? as f32,
+                    num(pz, span)? as f32,
+                    num(r, span)? as f32,
+                    num(g, span)? as f32,
+                    num(b, span)? as f32,
+                    num(intensity, span)? as f32,
+                    num(range, span)? as f32,
+                )))),
+                _ => usage("Light.point(px, py, pz, r, g, b, intensity, range)"),
+            },
+            // Light first, so it pipes: `Light.directional(…) |> Light.castShadows`.
+            "Light.castShadows" => match args.as_slice() {
+                [light] => match light_of(light) {
+                    Some(inner) => Ok(host(MleLight(inner.clone().cast_shadows()))),
+                    None => usage("Light.castShadows(light)"),
+                },
+                _ => usage("Light.castShadows(light)"),
+            },
+            "Frame.createLit" => match args.as_slice() {
+                [camera, scene, Value::List(lights)] => {
+                    let (Value::HostData(cam), Some(scene)) = (camera, scene_of(scene)) else {
+                        return usage("Frame.createLit(camera, scene, [light, …])");
+                    };
+                    let Some(camera) = cam.as_any().downcast_ref::<MleCamera>() else {
+                        return usage("Frame.createLit(camera, scene, [light, …])");
+                    };
+                    let mut lit = Vec::with_capacity(lights.len());
+                    for light in lights.iter() {
+                        match light_of(light) {
+                            Some(inner) => lit.push(inner.clone()),
+                            None => {
+                                return err(format!(
+                                    "Frame.createLit lights must be Lights, got {}",
+                                    light.kind_name()
+                                ))
+                            }
+                        }
+                    }
+                    Ok(host(MleFrame(Frame {
+                        camera: camera.0.clone(),
+                        scene: scene.clone(),
+                        lights: lit,
+                    })))
+                }
+                _ => usage("Frame.createLit(camera, scene, [light, …])"),
+            },
             "Frame.create" => match args.as_slice() {
                 [camera, scene] => {
                     let (Value::HostData(cam), Some(scene)) = (camera, scene_of(scene)) else {
@@ -257,6 +382,13 @@ fn num(value: &Value, span: Span) -> Result<f64, RunError> {
             message: format!("expected a number, got {}", other.kind_name()),
             span,
         }),
+    }
+}
+
+fn light_of(value: &Value) -> Option<&Light> {
+    match value {
+        Value::HostData(data) => data.as_any().downcast_ref::<MleLight>().map(|l| &l.0),
+        _ => None,
     }
 }
 
@@ -412,6 +544,35 @@ mod tests {
         for (i, child) in children.iter().enumerate() {
             assert_eq!(child.xform.w.x, i as f32);
         }
+    }
+
+    // The lit pipeline: materials, all three light kinds, shadow flag, and
+    // firstPerson camera flow into a protocol Frame with lights.
+    #[test]
+    fn lit_frame_carries_lights_and_materials() {
+        let frame = frame_of(
+            "let main = () =>
+             Frame.createLit(
+               Camera.firstPerson(0.0, 3.5, -8.0, 0.0, -0.3, 60.0),
+               Scene.group([
+                 Scene.plane() |> Scene.scale(24.0) |> Scene.lit(0.6, 0.6, 0.62),
+                 Scene.sphere() |> Scene.emissive(1.0, 0.3, 0.25),
+               ]),
+               [
+                 Light.ambient(0.1, 0.1, 0.13),
+                 Light.directional(0.5, -1.0, 0.35, 1.0, 0.98, 0.95, 0.85) |> Light.castShadows,
+                 Light.point(1.0, 2.2, 0.0, 1.0, 0.3, 0.25, 1.4, 4.0),
+               ])",
+        );
+        assert_eq!(frame.lights.len(), 3);
+        assert!(frame.lights[1].casts_shadows(), "directional casts shadows");
+        // firstPerson: 60° fov, eye as given.
+        assert!((frame.camera.fov_radians - 60.0_f32.to_radians()).abs() < 1e-5);
+        assert_eq!(frame.camera.eye, [0.0, 3.5, -8.0]);
+        // The scene serializes through the protocol (Lit/Emissive materials).
+        let json = serde_json::to_string(&frame).expect("serialize");
+        assert!(json.contains("Lit"), "json: {json}");
+        assert!(json.contains("Emissive"), "json: {json}");
     }
 
     // Host errors are spanned MLE runtime errors, not panics.

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -33,6 +33,8 @@ pub struct MleGame {
     session: Session,
     model: Value,
     has_input: bool,
+    has_mouse_move: bool,
+    has_mouse_wheel: bool,
     /// The last successfully drawn frame, kept so a bad draw shows the last
     /// good picture instead of a blank.
     last_frame: Frame,
@@ -56,6 +58,8 @@ struct Loaded {
     init: Value,
     /// The game defines the optional `input` entry point.
     has_input: bool,
+    has_mouse_move: bool,
+    has_mouse_wheel: bool,
 }
 
 /// Load, check, and contract-validate a game file. Errors come back as fully
@@ -82,8 +86,13 @@ fn load_game(path: &str) -> Result<Loaded, String> {
     let init = session
         .global("init")
         .ok_or_else(|| format!("{path} has no top-level `let init = …`"))?;
-    if matches!(init, Value::Closure(_) | Value::Builtin(_) | Value::HostFn(_)) {
-        return Err(format!("{path}: `init` must be a model value, not a function"));
+    if matches!(
+        init,
+        Value::Closure(_) | Value::Builtin(_) | Value::HostFn(_)
+    ) {
+        return Err(format!(
+            "{path}: `init` must be a model value, not a function"
+        ));
     }
     require_function(path, &session, "tick", 3)?;
     require_function(path, &session, "draw", 2)?;
@@ -93,11 +102,23 @@ fn load_game(path: &str) -> Result<Loaded, String> {
     if has_input {
         require_function(path, &session, "input", 3)?;
     }
+    // Same deal for the mouse: `mouseMove(model, x, y)` in window pixels,
+    // `mouseWheel(model, delta)`.
+    let has_mouse_move = session.global("mouseMove").is_some();
+    if has_mouse_move {
+        require_function(path, &session, "mouseMove", 3)?;
+    }
+    let has_mouse_wheel = session.global("mouseWheel").is_some();
+    if has_mouse_wheel {
+        require_function(path, &session, "mouseWheel", 2)?;
+    }
     Ok(Loaded {
         src,
         session,
         init,
         has_input,
+        has_mouse_move,
+        has_mouse_wheel,
     })
 }
 
@@ -128,6 +149,8 @@ impl MleGame {
             session: loaded.session,
             model: loaded.init,
             has_input: loaded.has_input,
+            has_mouse_move: loaded.has_mouse_move,
+            has_mouse_wheel: loaded.has_mouse_wheel,
             last_frame: empty_frame(),
             last_error: None,
             frames: 0,
@@ -186,6 +209,8 @@ impl Game for MleGame {
                 self.src = loaded.src;
                 self.session = loaded.session;
                 self.has_input = loaded.has_input;
+                self.has_mouse_move = loaded.has_mouse_move;
+                self.has_mouse_wheel = loaded.has_mouse_wheel;
                 self.last_error = None;
                 println!(
                     "[mle] hot-reloaded {} in {:.2}ms (model preserved; an edited `init` \
@@ -240,8 +265,31 @@ takes effect on restart)",
             Err(err) => self.frame_error("input", &err),
         }
     }
-    fn mouse_move(&mut self, _x: i32, _y: i32) {}
-    fn mouse_wheel(&mut self, _delta: i32) {}
+    fn mouse_move(&mut self, x: i32, y: i32) {
+        if !self.has_mouse_move {
+            return;
+        }
+        let args = vec![
+            self.model.clone(),
+            Value::Number(x as f64),
+            Value::Number(y as f64),
+        ];
+        match self.session.call("mouseMove", args, &mut FunctorHost) {
+            Ok(model) => self.model = model,
+            Err(err) => self.frame_error("mouseMove", &err),
+        }
+    }
+
+    fn mouse_wheel(&mut self, delta: i32) {
+        if !self.has_mouse_wheel {
+            return;
+        }
+        let args = vec![self.model.clone(), Value::Number(delta as f64)];
+        match self.session.call("mouseWheel", args, &mut FunctorHost) {
+            Ok(model) => self.model = model,
+            Err(err) => self.frame_error("mouseWheel", &err),
+        }
+    }
 
     fn render(&mut self, frame_time: FrameTime) -> Frame {
         let started = Instant::now();


### PR DESCRIPTION
## What

The B5-independent half of C4b (stacked on #168):

- **The lit pipeline reaches MLE.** Prelude grows `Scene.lit` / `Scene.emissive` materials, `Light.ambient` / `Light.directional` / `Light.point` with `|> Light.castShadows`, `Camera.firstPerson`, and `Frame.createLit(camera, scene, [lights])`.
- **Mouse into the model:** optional `mouseMove(model, x, y)` / `mouseWheel(model, delta)` entry points — validated at load, hot-reload-aware, deduped errors, same shape as `input`.
- **`examples/mle-primitives`** ports the F# lit-pipeline golden scene (shadow-casting sun, orbiting colored point lights with emissive markers, all `tts`-driven) — with the transform-order translation rule documented in the example (F#'s right-multiply chains ⇔ MLE's outer-last pipes).

## Verification

- **Golden parity with F#:** captured at the same `--fixed-time` as `examples/primitives`, **0.000% of pixels exceed the golden tolerance** — the only differences are sub-tolerance float dust from differing matrix association. This is the C4 verify criterion, met by the interpreter.
- Live probes: mouse events injected via the debug server land in the model (`{ mx: 123, wheel: -2 }`); prelude unit test pins the lit frame (3 lights, shadow flag, 60° fov, Lit/Emissive in the wire JSON); PATHS-drift test auto-covers the 8 new paths.
- Codex review: **zero findings** — it probed every new arm (bad light lists, castShadows on a Scene, non-finite guards, degree/radian confusion, load-time mouse contract validation) and verified port fidelity line-by-line against `primitives.fs`. Its one sandbox gap (live mouse injection) closed by the probe above. Claude reviewer still rate-limited; compensated as before.

## Notes

- Remaining **C4b-2** (wants B5's ADTs, in flight): `update`/messages, subscriptions, effect-drain semantics.
- With this, the MLE surface covers everything the F# golden guard scene needs — `mle-primitives` can join the golden manifest whenever we want CI render-regression coverage on the interpreter path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)