### PR TITLE
feat(physics): 1b — the Simulatable/Timeline rewind seam

### DIFF
--- a/docs/physics.md
+++ b/docs/physics.md
@@ -386,7 +386,9 @@ trait Simulatable {
     type Event;
     fn snapshot(&self) -> Self::Snapshot;
     fn restore(&mut self, s: &Self::Snapshot);
-    fn step(&mut self, dt: Fixed, cmds: &[Self::Command]) -> Vec<Self::Event>;
+    // The timestep is a fixed property of the sim (FIXED_DT), not a parameter —
+    // variable dt can't sneak in through this seam.
+    fn step(&mut self, cmds: &[Self::Command]) -> Vec<Self::Event>;
 }
 
 /// The SWAPPABLE part. The sim loop and netcode name only this trait.
@@ -398,15 +400,20 @@ trait Timeline<S: Simulatable> {
 }
 ```
 
-Strategies are tiny impls of one trait:
+The three strategies turned out to differ in *snapshot cadence only*, so they
+are one impl (`TimelineLog`, in `physics/timeline.rs`) with three constructors
+rather than three types:
 
-- **`KeyframeLog`** (default, the hybrid) — snapshot every N frames + always log
-  commands; `seek` restores nearest keyframe ≤ frame then `step`s forward. Bounded
-  memory *and* seek.
-- **`SnapshotRing`** — full snapshot every frame; `seek` = `restore(ring[frame])`.
-  O(1) seek, heavy memory. (Used as the oracle in strategy-equivalence goldens.)
-- **`ReplayOnly`** — one snapshot at frame 0; `seek` restores it and replays
-  0→frame. Lightest memory, leans hardest on determinism.
+- **`TimelineLog::keyframes(n)`** (default, the hybrid) — snapshot every N
+  frames + always log commands; `seek` restores nearest keyframe ≤ frame then
+  `step`s forward. Bounded memory *and* seek.
+- **`TimelineLog::snapshot_ring()`** — full snapshot every frame; `seek` is one
+  restore. O(1) seek, heavy memory. (The oracle in the strategy-equivalence
+  golden.)
+- **`TimelineLog::replay_only()`** — one snapshot at the first frame; `seek`
+  restores it and replays 0→frame. Lightest memory, leans hardest on
+  determinism. (`prune` is a documented no-op — the base snapshot is the only
+  restore point.)
 
 Reconciliation is written **once, against the trait**, and never changes when the
 strategy is swapped:
@@ -415,9 +422,9 @@ strategy is swapped:
 fn reconcile<S, T: Timeline<S>>(tl: &mut T, sim: &mut S,
                                 k: Frame, authoritative: &S::Snapshot, now: Frame) {
     sim.restore(authoritative);          // server truth at frame K
-    tl.overwrite(k, authoritative);      // correct recorded history at K
-    for (_f, cmds) in tl.commands_since(k) {
-        sim.step(FIXED_DT, cmds);        // replay OUR local inputs K+1..now
+    tl.overwrite(k, authoritative);      // correct recorded history at K (lands in 7b)
+    for cmds in tl.commands_since(k) {
+        sim.step(cmds);                  // replay OUR local inputs K+1..now
     }
 }
 ```
@@ -425,7 +432,10 @@ fn reconcile<S, T: Timeline<S>>(tl: &mut T, sim: &mut S,
 The trait contract — `seek(K)` equals restoring a valid earlier state and stepping
 forward with recorded commands — *is* the determinism invariant the netcode rests
 on. The F# surface stays thin (`Physics.rewindTo`, `pause`, `resume`, `stepOnce`);
-strategy choice is runtime config, defaulting to `KeyframeLog`.
+strategy choice is runtime config, defaulting to `keyframes(n)`. Two pieces are
+deliberately deferred to their consuming phases: `overwrite` (7b, server history
+correction) and truncate-on-record-after-seek (Phase 6, rewind-then-*branch* —
+until then a seek is resumed by replaying `commands_since`, not re-recording).
 
 ## Netcode (server-authoritative first)
 
@@ -558,7 +568,7 @@ It's worth building in two steps, because they exercise different machinery:
 | Phase | Scope | Targets |
 | --- | --- | --- |
 | **1a. World spine** | Rapier dep (`serde-serialize`, default features), `physics` module (`PhysicsScene`/`Body`/`reconcile`/`WorldId` registry), fixed-step accumulator, snapshot + text/JSON dump. Determinism + restore-replay goldens. **No F# surface.** | native+wasm (Rust) |
-| **1b. Timeline seam** | `Simulatable` + `Timeline` traits, `KeyframeLog` (default) + `SnapshotRing` + `ReplayOnly`, strategy-equivalence + replay goldens. | native+wasm (Rust) |
+| **1b. Timeline seam** | `Simulatable` + `Timeline` traits, `TimelineLog` with the three cadences (`keyframes(n)` default / `snapshot_ring` / `replay_only`), strategy-equivalence + replay goldens. | native+wasm (Rust) |
 | **2. `physicsScape` + read-back** | `Game` hook + builder/runner, reconcile pipeline, `DrawContext` record on `draw3d` (`ctx.physics` view), `Physics.synced` sub, `examples/hello-physics`. | both |
 | **2b. Debug visualization** | Rapier `debug-render` feature, `World::debug_lines()`, line pass in both shells, `--debug-render physics` mode + keyboard toggle in `hello-physics`. | both |
 | **3. Commands** | `applyImpulse`/`applyForce`/`setVelocity`/`teleport` (plain-data effects). | both |

--- a/runtime/functor-runtime-common/src/physics/goldens.rs
+++ b/runtime/functor-runtime-common/src/physics/goldens.rs
@@ -82,6 +82,64 @@ fn determinism_golden_two_worlds_stay_byte_identical() {
     assert!(pos[1] < 2.0 && pos[1] > 0.0, "unexpected rest pose {pos:?}");
 }
 
+/// Drive a `Timeline` + sim through the scripted scenario (the `Simulatable`
+/// path: commands, not direct reconcile calls).
+fn drive<T: Timeline<World>>(tl: &mut T, sim: &mut World, frames: u64) {
+    for f in 0..frames {
+        let cmds = vec![Command::DeclareScene(scene_at(f))];
+        tl.record(f, sim, &cmds);
+        sim.step(&cmds);
+    }
+}
+
+#[test]
+fn strategy_equivalence_golden_keyframes_match_snapshot_ring_for_every_seek() {
+    // Record the same run through both cadences (keyframes-every-16 leaves
+    // most frames snapshot-less; the every-frame ring is the O(1) oracle).
+    let mut kf = TimelineLog::keyframes(16);
+    let mut kf_sim = World::new([0.0, -9.81, 0.0]);
+    drive(&mut kf, &mut kf_sim, FRAMES);
+
+    let mut ring = TimelineLog::snapshot_ring();
+    let mut ring_sim = World::new([0.0, -9.81, 0.0]);
+    drive(&mut ring, &mut ring_sim, FRAMES);
+
+    // Every recorded frame must seek byte-identical under both strategies —
+    // this is both rewind-correctness and a determinism check (the doc's
+    // trait contract: seek(K) == restore-earlier + re-step).
+    for k in 0..FRAMES {
+        kf.seek(k, &mut kf_sim);
+        ring.seek(k, &mut ring_sim);
+        assert!(
+            Simulatable::snapshot(&kf_sim) == Simulatable::snapshot(&ring_sim),
+            "strategies disagree at seek({k})"
+        );
+    }
+}
+
+#[test]
+fn replay_golden_replayonly_seek_to_end_matches_live_run() {
+    let mut live = World::new([0.0, -9.81, 0.0]);
+    let mut tl = TimelineLog::replay_only();
+    drive(&mut tl, &mut live, FRAMES);
+    let live_end = Simulatable::snapshot(&live);
+
+    // The replay-only cadence holds a single frame-0 snapshot; seeking the
+    // last frame replays the entire command log through fresh arenas.
+    let mut replayed = World::new([0.0, 0.0, 0.0]);
+    tl.seek(FRAMES - 1, &mut replayed);
+    // seek lands on the *pre-step* state of the last frame; finish with the
+    // log's own final entry to compare against the live end state.
+    for cmds in tl.commands_since(FRAMES - 1).to_vec() {
+        replayed.step(&cmds);
+    }
+
+    assert!(
+        Simulatable::snapshot(&replayed) == live_end,
+        "ReplayOnly seek-to-end diverged from the live run"
+    );
+}
+
 #[test]
 fn restore_golden_snapshot_plus_replay_matches_live_run() {
     // Snapshot at frame 20 — *before* the despawn (30), respawn (60), and

--- a/runtime/functor-runtime-common/src/physics/mod.rs
+++ b/runtime/functor-runtime-common/src/physics/mod.rs
@@ -21,6 +21,7 @@
 
 mod registry;
 mod scene;
+mod timeline;
 mod world;
 
 #[cfg(test)]
@@ -28,4 +29,5 @@ mod goldens;
 
 pub use registry::*;
 pub use scene::*;
+pub use timeline::*;
 pub use world::*;

--- a/runtime/functor-runtime-common/src/physics/timeline.rs
+++ b/runtime/functor-runtime-common/src/physics/timeline.rs
@@ -1,0 +1,374 @@
+//! The rewind seam: `Simulatable` + `Timeline` (docs/physics.md, "Rewind").
+//!
+//! The **command log is the invariant** — server-authoritative prediction needs
+//! it regardless of rewind strategy. The only thing that varies between
+//! strategies is **snapshot cadence**, and therefore how `seek` reconstructs a
+//! frame. So the whole design is two small traits: anything rewindable
+//! implements [`Simulatable`]; the swappable strategy implements [`Timeline`].
+//! The sim loop and (later) the netcode reconciler name only the traits.
+//!
+//! ## The frame convention
+//!
+//! `record(f, sim, cmds)` is called at the **start** of frame `f`, with `sim`
+//! in the pre-step state and `cmds` the commands about to be applied; the
+//! driver then calls `sim.step(cmds)`. `seek(f)` restores that same pre-step
+//! state of frame `f`. Frames are recorded consecutively from the first
+//! `record` call.
+//!
+//! The trait contract — `seek(K)` equals restoring a valid earlier snapshot
+//! and re-stepping with the recorded commands — **is** the determinism
+//! invariant (docs/physics.md); the strategy-equivalence golden in
+//! `goldens.rs` asserts it byte-for-byte with the every-frame cadence as the
+//! oracle.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::{PhysicsScene, World};
+
+/// A fixed-step frame number.
+pub type Frame = u64;
+
+/// One frame's worth of input to a physics [`World`] step. This is what a
+/// replay re-executes, so it must capture *everything* that can change the
+/// world: today that's the declared scene (whose history is also the
+/// insert/remove history Rapier arena handles depend on); Phase 3 adds
+/// impulse/force commands as further variants.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum Command {
+    DeclareScene(PhysicsScene),
+}
+
+/// Events produced by a step. None yet — Phase 5 (collision events) populates
+/// this; the variant-less enum keeps the seam in place at zero cost.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Event {}
+
+/// Anything rewindable. Physics is the first impl; the whole game model
+/// (serializable + input-driven) could be a second later.
+pub trait Simulatable {
+    /// Full serializable state — restoring it resumes bit-exact.
+    type Snapshot;
+    /// Per-frame inputs (see [`Command`] for physics).
+    type Command;
+    type Event;
+
+    fn snapshot(&self) -> Self::Snapshot;
+    fn restore(&mut self, s: &Self::Snapshot);
+    /// Apply one frame's commands, then advance one fixed step. (The timestep
+    /// is a fixed property of the sim — `FIXED_DT` for physics — not a
+    /// parameter, so a variable dt can't sneak in through this seam.)
+    fn step(&mut self, cmds: &[Self::Command]) -> Vec<Self::Event>;
+}
+
+impl Simulatable for World {
+    type Snapshot = Vec<u8>;
+    type Command = Command;
+    type Event = Event;
+
+    fn snapshot(&self) -> Vec<u8> {
+        World::snapshot(self)
+    }
+
+    fn restore(&mut self, s: &Vec<u8>) {
+        // A Timeline only restores snapshots it recorded itself, so a parse
+        // failure is a corrupted history — unrecoverable, and loud is right.
+        World::restore(self, s).expect("timeline snapshot failed to restore");
+    }
+
+    fn step(&mut self, cmds: &[Command]) -> Vec<Event> {
+        for cmd in cmds {
+            match cmd {
+                Command::DeclareScene(scene) => self.reconcile(scene),
+            }
+        }
+        self.step_fixed();
+        Vec::new()
+    }
+}
+
+/// The SWAPPABLE part: how history is stored and how `seek` reconstructs a
+/// frame. Strategy choice is runtime config; the loop names only this trait.
+pub trait Timeline<S: Simulatable> {
+    /// Record frame `frame` — `sim` pre-step, `cmds` about to be applied.
+    ///
+    /// Frames must be recorded consecutively (each call `= last + 1`).
+    /// Recording after a `seek` (rewind-then-*branch*) additionally requires
+    /// truncating the forward history — that lands with the pause/rewind
+    /// culmination (Phase 6); until then, resume a seek by replaying
+    /// [`Timeline::commands_since`], not by re-recording.
+    fn record(&mut self, frame: Frame, sim: &S, cmds: &[S::Command]);
+    /// Restore `sim` to the pre-step state of `frame`.
+    ///
+    /// Panics if `frame` was never recorded or has been pruned away.
+    fn seek(&mut self, frame: Frame, sim: &mut S);
+    /// The recorded commands for every frame `>= frame`, in frame order.
+    ///
+    /// Panics if `frame` predates the (possibly pruned) history — a silently
+    /// clamped window would replay wrong-frame commands. `frame` one past the
+    /// last recorded frame yields an empty slice.
+    fn commands_since(&self, frame: Frame) -> &[Vec<S::Command>];
+    /// Drop history before `frame` (memory bound / server-confirmed), keeping
+    /// enough that every frame `>= frame` stays seekable. How much can
+    /// actually be dropped is strategy-dependent: the floor is the newest
+    /// snapshot at or before `frame` (for the replay-only cadence that is the
+    /// first frame, so `prune` is a documented no-op).
+    fn prune(&mut self, frame: Frame);
+}
+
+/// The one [`Timeline`] implementation: a contiguous per-frame command log
+/// plus snapshots at a fixed cadence. The doc's three strategies are
+/// *cadences* of this single type, picked by constructor — they differ in
+/// nothing else.
+pub struct TimelineLog<S: Simulatable> {
+    /// Snapshot every `interval` recorded frames (1 = every frame).
+    interval: u64,
+    /// Frame number of `commands[0]`; meaningless until `commands` is
+    /// non-empty.
+    base: Frame,
+    commands: Vec<Vec<S::Command>>,
+    keyframes: BTreeMap<Frame, S::Snapshot>,
+}
+
+impl<S: Simulatable> TimelineLog<S>
+where
+    S::Command: Clone,
+{
+    /// The default strategy (`KeyframeLog`): snapshot every `interval` frames
+    /// + always log commands; `seek` restores the nearest keyframe ≤ frame and
+    /// steps forward. Bounded memory *and* bounded seek.
+    pub fn keyframes(interval: u64) -> TimelineLog<S> {
+        assert!(interval > 0, "keyframe interval must be at least 1");
+        TimelineLog {
+            interval,
+            base: 0,
+            commands: Vec::new(),
+            keyframes: BTreeMap::new(),
+        }
+    }
+
+    /// `SnapshotRing`: a snapshot every frame — O(1) seek, heavy memory. The
+    /// oracle in the strategy-equivalence golden.
+    pub fn snapshot_ring() -> TimelineLog<S> {
+        TimelineLog::keyframes(1)
+    }
+
+    /// `ReplayOnly`: one snapshot at the first recorded frame; `seek` replays
+    /// from it. Lightest memory, leans hardest on determinism. `prune` is a
+    /// no-op (the base snapshot is the only restore point).
+    pub fn replay_only() -> TimelineLog<S> {
+        TimelineLog::keyframes(u64::MAX)
+    }
+
+    fn next_frame(&self) -> Option<Frame> {
+        (!self.commands.is_empty()).then(|| self.base + self.commands.len() as u64)
+    }
+}
+
+impl<S: Simulatable> Timeline<S> for TimelineLog<S>
+where
+    S::Command: Clone,
+{
+    fn record(&mut self, frame: Frame, sim: &S, cmds: &[S::Command]) {
+        match self.next_frame() {
+            None => self.base = frame,
+            Some(next) => assert_eq!(
+                frame, next,
+                "timeline frames must be recorded consecutively"
+            ),
+        }
+        if (frame - self.base) % self.interval == 0 {
+            self.keyframes.insert(frame, sim.snapshot());
+        }
+        self.commands.push(cmds.to_vec());
+    }
+
+    fn seek(&mut self, frame: Frame, sim: &mut S) {
+        let next = self.next_frame().expect("seek on an empty timeline");
+        assert!(
+            frame >= self.base && frame < next,
+            "seek({frame}) outside recorded history [{}, {})",
+            self.base,
+            next
+        );
+        // Restore the nearest keyframe at or before `frame`, then re-step with
+        // the recorded commands. Determinism makes this land bit-exact.
+        let (&kf, snapshot) = self
+            .keyframes
+            .range(..=frame)
+            .next_back()
+            .expect("no keyframe at or below a recorded frame (pruned?)");
+        sim.restore(snapshot);
+        for f in kf..frame {
+            sim.step(&self.commands[(f - self.base) as usize]);
+        }
+    }
+
+    fn commands_since(&self, frame: Frame) -> &[Vec<S::Command>] {
+        let Some(next) = self.next_frame() else {
+            return &[]; // nothing recorded yet
+        };
+        assert!(
+            frame >= self.base && frame <= next,
+            "commands_since({frame}) outside recorded history [{}, {}]",
+            self.base,
+            next
+        );
+        &self.commands[(frame - self.base) as usize..]
+    }
+
+    fn prune(&mut self, frame: Frame) {
+        // The new floor is the greatest keyframe <= frame, so `frame` itself
+        // (and everything after) stays seekable.
+        let Some((&floor, _)) = self.keyframes.range(..=frame).next_back() else {
+            return;
+        };
+        self.keyframes = self.keyframes.split_off(&floor);
+        self.commands.drain(..(floor - self.base) as usize);
+        self.base = floor;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::physics::{Body, Shape, DEFAULT_GRAVITY};
+
+    /// A tiny scripted world: one falling crate, teleported at frame 5.
+    fn cmds_at(frame: Frame) -> Vec<Command> {
+        let pos = if frame < 5 {
+            [0.0, 5.0, 0.0]
+        } else {
+            [2.0, 8.0, 0.0]
+        };
+        let body = Body::dynamic(
+            "a".to_string(),
+            Shape::Cuboid {
+                extents: [1.0, 1.0, 1.0],
+            },
+        )
+        .at(pos);
+        vec![Command::DeclareScene(PhysicsScene::create(
+            DEFAULT_GRAVITY,
+            vec![body],
+        ))]
+    }
+
+    fn drive<T: Timeline<World>>(tl: &mut T, sim: &mut World, from: Frame, to: Frame) {
+        for f in from..to {
+            let cmds = cmds_at(f);
+            tl.record(f, sim, &cmds);
+            sim.step(&cmds);
+        }
+    }
+
+    #[test]
+    fn seek_restores_a_recorded_frame_bit_exact() {
+        let mut tl = TimelineLog::keyframes(4);
+        let mut sim = World::new(DEFAULT_GRAVITY);
+        let mut at_7 = Vec::new();
+        for f in 0..20 {
+            if f == 7 {
+                at_7 = Simulatable::snapshot(&sim);
+            }
+            let cmds = cmds_at(f);
+            tl.record(f, &sim, &cmds);
+            sim.step(&cmds);
+        }
+
+        // 7 is not a keyframe (cadence 4): seek restores keyframe 4 and
+        // re-steps 4..7.
+        tl.seek(7, &mut sim);
+        assert!(Simulatable::snapshot(&sim) == at_7, "seek(7) diverged");
+    }
+
+    #[test]
+    fn seek_then_resim_forward_matches_the_original_run() {
+        let mut tl = TimelineLog::keyframes(8);
+        let mut sim = World::new(DEFAULT_GRAVITY);
+        drive(&mut tl, &mut sim, 0, 20);
+        let live_end = Simulatable::snapshot(&sim);
+
+        // Rewind to 10, then re-step with the recorded commands (the netcode
+        // reconcile shape: seek K, replay commands K..now).
+        tl.seek(10, &mut sim);
+        for cmds in tl.commands_since(10).to_vec() {
+            sim.step(&cmds);
+        }
+        assert!(
+            Simulatable::snapshot(&sim) == live_end,
+            "seek + command replay diverged from the live run"
+        );
+    }
+
+    #[test]
+    fn prune_keeps_later_frames_seekable() {
+        let mut tl = TimelineLog::keyframes(4);
+        let mut sim = World::new(DEFAULT_GRAVITY);
+        drive(&mut tl, &mut sim, 0, 20);
+        let at_10 = {
+            let mut probe = World::new(DEFAULT_GRAVITY);
+            tl.seek(10, &mut probe);
+            Simulatable::snapshot(&probe)
+        };
+
+        tl.prune(10);
+        let mut probe = World::new(DEFAULT_GRAVITY);
+        tl.seek(10, &mut probe);
+        assert!(Simulatable::snapshot(&probe) == at_10, "prune broke seek(10)");
+        // The floor keyframe is 8, so frames 8..20 (12 of them) remain.
+        assert_eq!(tl.commands_since(8).len(), 12);
+    }
+
+    #[test]
+    fn commands_since_one_past_the_end_is_empty() {
+        let mut tl = TimelineLog::keyframes(4);
+        let mut sim = World::new(DEFAULT_GRAVITY);
+        drive(&mut tl, &mut sim, 0, 8);
+        assert!(tl.commands_since(8).is_empty());
+        assert_eq!(tl.commands_since(6).len(), 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "outside recorded history")]
+    fn commands_since_before_pruned_history_panics() {
+        let mut tl = TimelineLog::keyframes(4);
+        let mut sim = World::new(DEFAULT_GRAVITY);
+        drive(&mut tl, &mut sim, 0, 8);
+        tl.prune(6); // floor = keyframe 4
+        tl.commands_since(2);
+    }
+
+    #[test]
+    fn replay_only_prune_is_a_no_op() {
+        let mut tl = TimelineLog::replay_only();
+        let mut sim = World::new(DEFAULT_GRAVITY);
+        drive(&mut tl, &mut sim, 0, 10);
+        tl.prune(8);
+        // The base snapshot is the only restore point, so nothing was dropped
+        // and every frame stays seekable.
+        assert_eq!(tl.commands_since(0).len(), 10);
+        let mut probe = World::new(DEFAULT_GRAVITY);
+        tl.seek(9, &mut probe);
+    }
+
+    #[test]
+    #[should_panic(expected = "outside recorded history")]
+    fn seek_before_recorded_history_panics() {
+        let mut tl = TimelineLog::keyframes(4);
+        let mut sim = World::new(DEFAULT_GRAVITY);
+        drive(&mut tl, &mut sim, 0, 8);
+        tl.prune(6);
+        tl.seek(2, &mut sim);
+    }
+
+    #[test]
+    #[should_panic(expected = "recorded consecutively")]
+    fn non_consecutive_record_panics() {
+        let mut tl = TimelineLog::snapshot_ring();
+        let sim = World::new(DEFAULT_GRAVITY);
+        tl.record(0, &sim, &cmds_at(0));
+        tl.record(2, &sim, &cmds_at(2));
+    }
+}


### PR DESCRIPTION
Phase **1b** of docs/physics.md, **stacked on #170** (the 1a world spine). The rewind/replay machinery that pause/rewind (Phase 6) and netcode prediction (Phase 7b) both sit on.

## What's here

- **`Simulatable`** (`snapshot`/`restore`/`step`) with `World` as the first impl. `step` takes commands only — the timestep is a fixed property of the sim (`FIXED_DT`), so a variable dt can't sneak in through the seam.
- **`Command`** — `DeclareScene` is the per-frame input a replay re-executes (its history is also the insert/remove history Rapier arena handles depend on). Phase 3 adds impulse/force variants; `Event` is a variant-less placeholder until Phase 5.
- **`Timeline`** (`record`/`seek`/`commands_since`/`prune`) with **one impl, `TimelineLog`**: the doc's three strategies turned out to differ in *snapshot cadence only*, so they're constructors, not types — `keyframes(n)` (default), `snapshot_ring()` (every frame; the goldens' oracle), `replay_only()` (single base snapshot; `prune` is a documented no-op). This also makes the doc's "strategy choice is runtime config" trivially true.
- **Frame convention** (documented in the module header): `record(f)`/`seek(f)` refer to the *pre-step* state of frame `f`; frames record consecutively; out-of-range `seek`/`commands_since` panic loudly rather than silently clamping to a wrong-window replay.
- **Deferred to their consuming phases**, noted in code + doc: `overwrite` (7b, server history correction) and truncate-on-record-after-seek (Phase 6, rewind-then-*branch* — until then a seek is resumed via `commands_since`, not re-recording).

## Goldens (both in CI via plain `cargo test`)

- **Strategy-equivalence**: the same 120-frame scripted run (despawn/respawn + teleport) recorded through `keyframes(16)` and `snapshot_ring()`; `seek(K)` byte-identical for **every** K — rewind-correctness and determinism in one assertion.
- **Replay**: `replay_only()` seek-to-end plus the log's own final commands lands byte-identical to the live run.

## Testing

- `cargo test -p functor_runtime_common` — 101 passed (28 physics: 8 new timeline unit tests + 4 goldens)
- `--features strict` and `--target wasm32-unknown-unknown` — clean
- Cross-engine review (`/xreview`) run on this slice; the agreed finding (silently-clamping `commands_since` returning a wrong replay window) fixed with panics + tests, plus the ReplayOnly-prune contract documented and the three wrapper types collapsed per the simplicity review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)