### PR TITLE
feat(runtime): branded Angle values — degree/radian confusion is unrepresentable

### DIFF
--- a/.claude/skills/mle-language/SKILL.md
+++ b/.claude/skills/mle-language/SKILL.md
@@ -101,10 +101,11 @@ scene |> Scene.color(r, g, b)                              // scene-first: pipes
 scene |> Scene.lit(r, g, b)                                // diffuse+specular
 scene |> Scene.emissive(r, g, b)                           // unlit glow
 scene |> Scene.translate(x, y, z)
-scene |> Scene.rotateX(rad) / rotateY / rotateZ
+scene |> Scene.rotateX(angle) / rotateY / rotateZ          // Angle VALUES only:
+Angle.degrees(60.0) / Angle.radians(1.57)                  //   never bare numbers
 scene |> Scene.scale(k)
 Camera.lookAt(ex, ey, ez, tx, ty, tz)                      // up=+Y, fov 45°
-Camera.firstPerson(ex, ey, ez, yawRad, pitchRad, fovDeg)
+Camera.firstPerson(ex, ey, ez, yaw, pitch, fov)           // all three: Angles
 Light.ambient(r, g, b) / Light.point(px, py, pz, r, g, b, intensity, range)
 Light.directional(dx, dy, dz, r, g, b, intensity) |> Light.castShadows
 Frame.create(camera, scene)                                // what draw returns

--- a/docs/mle.md
+++ b/docs/mle.md
@@ -183,6 +183,12 @@ snapshots — no GPU, fully agent-verifiable.
       state/replay invariants survive untouched. Typechecked: slot types fix
       at the initializer; updates check against declared record types.
       *Verify:* 18 semantics/error/diagnostic tests + example goldens. (done)
+- [x] **Units, tier 1: branded `Angle` values** (2026-07-03; design:
+      `~/notes/ideas/mle-language/units.md`). `Angle.degrees(n)` /
+      `Angle.radians(n)` opaque host values; rotations and camera angles
+      REFUSE bare numbers with a teaching error — degree/radian confusion
+      is unrepresentable, matching the F# side's `Math.Angle` discipline.
+      Tier 2 (F#-style units of measure with unit algebra) rides on B7.
 - [ ] **B7. Hindley–Milner inference** (decided 2026-07-02; **after effects
       land** — B6 + the `effect[...]` header checking, so type inference and
       effect rows are designed against each other, not retrofitted). Upgrade

--- a/examples/mle-hello/game.mle
+++ b/examples/mle-hello/game.mle
@@ -14,9 +14,9 @@ let tau = 6.2831853
 let ringCube = (spin: Float, i: Float) =>
   Scene.cube()
     |> Scene.color(0.25 + 0.75 * (i / count), 0.35, 0.95 - 0.65 * (i / count))
-    |> Scene.rotateY(i * 0.7 + spin * 2.0)
+    |> Scene.rotateY(Angle.radians(i * 0.7 + spin * 2.0))
     |> Scene.translate(4.0, Math.sin(i + spin * 3.0) * 0.6, 0.0)
-    |> Scene.rotateY(i * tau / count + spin)
+    |> Scene.rotateY(Angle.radians(i * tau / count + spin))
 
 let centerpiece = (spin: Float) =>
   Scene.sphere()

--- a/examples/mle-primitives/game.mle
+++ b/examples/mle-primitives/game.mle
@@ -42,7 +42,9 @@ let tick = (m, dt, tts) => m
 
 let draw = (m, tts: Float) =>
   Frame.createLit(
-    Camera.firstPerson(0.0, 3.5, -8.0, 0.0, -0.3, 60.0),
+    Camera.firstPerson(
+      0.0, 3.5, -8.0,
+      Angle.radians(0.0), Angle.radians(-0.3), Angle.degrees(60.0)),
     Scene.group([
       Scene.plane() |> Scene.scale(24.0) |> Scene.lit(0.6, 0.6, 0.62),
       whiteShapes(),

--- a/runtime/functor-runtime-common/src/math/angle.rs
+++ b/runtime/functor-runtime-common/src/math/angle.rs
@@ -1,5 +1,6 @@
 use cgmath::Rad;
 
+#[derive(Clone, Copy)]
 pub struct Angle {
     ang: cgmath::Rad<f32>,
 }

--- a/runtime/functor-runtime-common/src/mle_prelude.rs
+++ b/runtime/functor-runtime-common/src/mle_prelude.rs
@@ -14,7 +14,10 @@
 //! Scene.group([scene, …])                                   -> Scene
 //! Scene.color(scene, r, g, b)                               -> Scene
 //! Scene.translate(scene, x, y, z)                           -> Scene
-//! Scene.rotateX/rotateY/rotateZ(scene, radians)             -> Scene
+//! Scene.rotateX/rotateY/rotateZ(scene, angle)               -> Scene
+//! Angle.degrees(n) / Angle.radians(n)                       -> Angle
+//!   (rotations and camera angles take Angle VALUES, never bare numbers —
+//!    degree/radian confusion is unrepresentable)
 //! Scene.scale(scene, k)                                     -> Scene
 //! Camera.lookAt(ex, ey, ez, tx, ty, tz)                     -> Camera
 //!   (up is +Y; vertical fov pinned at 45°, near/far at protocol defaults)
@@ -61,6 +64,21 @@ pub struct MleFrame(pub Frame);
 
 /// A [`Light`] as an opaque MLE value.
 pub struct MleLight(pub Light);
+
+/// An [`Angle`] as an opaque MLE value — `Angle.degrees(…)`/`Angle.radians(…)`.
+/// Rotation/camera functions accept ONLY this, never a bare number, making
+/// degree/radian confusion unrepresentable (the F# side's `Math.Angle`
+/// discipline, carried across the boundary).
+pub struct MleAngle(pub Angle);
+
+impl HostData for MleAngle {
+    fn type_name(&self) -> &'static str {
+        "Angle"
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
 
 impl HostData for MleLight {
     fn type_name(&self) -> &'static str {
@@ -125,6 +143,8 @@ const PATHS: &[&str] = &[
     "Scene.scale",
     "Scene.lit",
     "Scene.emissive",
+    "Angle.degrees",
+    "Angle.radians",
     "Camera.lookAt",
     "Camera.firstPerson",
     "Light.ambient",
@@ -232,18 +252,25 @@ impl Host for FunctorHost {
                 }
                 _ => usage("Scene.translate(scene, x, y, z)"),
             },
+            "Angle.degrees" => match args.as_slice() {
+                [n] => Ok(host(MleAngle(Angle::from_degrees(num(n, span)? as f32)))),
+                _ => usage("Angle.degrees(n)"),
+            },
+            "Angle.radians" => match args.as_slice() {
+                [n] => Ok(host(MleAngle(Angle::from_radians(num(n, span)? as f32)))),
+                _ => usage("Angle.radians(n)"),
+            },
             "Scene.rotateX" | "Scene.rotateY" | "Scene.rotateZ" => match args.as_slice() {
-                [scene, radians] => {
-                    let angle: cgmath::Rad<f32> =
-                        Angle::from_radians(num(radians, span)? as f32).into();
+                [scene, angle] => {
+                    let angle: cgmath::Rad<f32> = angle_of(angle, path, span)?.into();
                     let xform = match path {
                         "Scene.rotateX" => Matrix4::from_angle_x(angle),
                         "Scene.rotateY" => Matrix4::from_angle_y(angle),
                         _ => Matrix4::from_angle_z(angle),
                     };
-                    wrap_transform(scene, xform, &format!("{path}(scene, radians)"), span)
+                    wrap_transform(scene, xform, &format!("{path}(scene, angle)"), span)
                 }
-                _ => return usage(&format!("{path}(scene, radians)")),
+                _ => return usage(&format!("{path}(scene, angle)")),
             },
             "Scene.scale" => match args.as_slice() {
                 [scene, k] => {
@@ -270,17 +297,20 @@ impl Host for FunctorHost {
                 _ => usage("Camera.lookAt(ex, ey, ez, tx, ty, tz)"),
             },
             "Camera.firstPerson" => match args.as_slice() {
-                [ex, ey, ez, yaw, pitch, fov_deg] => Ok(host(MleCamera(Camera::first_person(
+                [ex, ey, ez, yaw, pitch, fov] => Ok(host(MleCamera(Camera::first_person(
                     [
                         num(ex, span)? as f32,
                         num(ey, span)? as f32,
                         num(ez, span)? as f32,
                     ],
-                    Angle::from_radians(num(yaw, span)? as f32),
-                    Angle::from_radians(num(pitch, span)? as f32),
-                    Angle::from_degrees(num(fov_deg, span)? as f32),
+                    angle_of(yaw, "Camera.firstPerson yaw", span)?,
+                    angle_of(pitch, "Camera.firstPerson pitch", span)?,
+                    angle_of(fov, "Camera.firstPerson fov", span)?,
                 )))),
-                _ => usage("Camera.firstPerson(ex, ey, ez, yawRad, pitchRad, fovDeg)"),
+                _ => usage(
+                    "Camera.firstPerson(ex, ey, ez, yaw, pitch, fov) — Angle values \
+(Angle.degrees/Angle.radians)",
+                ),
             },
             "Light.ambient" => match args.as_slice() {
                 [r, g, b] => Ok(host(MleLight(Light::ambient(
@@ -380,6 +410,32 @@ fn num(value: &Value, span: Span) -> Result<f64, RunError> {
         }),
         other => Err(RunError {
             message: format!("expected a number, got {}", other.kind_name()),
+            span,
+        }),
+    }
+}
+
+/// Extract an [`Angle`] — rotation/camera functions accept ONLY Angle values,
+/// so a bare number gets a teaching error instead of a silent unit guess.
+fn angle_of(value: &Value, what: &str, span: Span) -> Result<Angle, RunError> {
+    match value {
+        Value::HostData(data) => data
+            .as_any()
+            .downcast_ref::<MleAngle>()
+            .map(|a| a.0)
+            .ok_or_else(|| RunError {
+                message: format!("{what}: expected an Angle, got {}", value.kind_name()),
+                span,
+            }),
+        Value::Number(_) => Err(RunError {
+            message: format!(
+                "{what}: expected an Angle, got a bare number — say which unit: \
+Angle.degrees(…) or Angle.radians(…)"
+            ),
+            span,
+        }),
+        other => Err(RunError {
+            message: format!("{what}: expected an Angle, got {}", other.kind_name()),
             span,
         }),
     }
@@ -507,7 +563,7 @@ mod tests {
             "let main = () =>\n\
              Frame.create(\n\
                Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0),\n\
-               Scene.translate(Scene.rotateY(Scene.cube(), 1.5707964), 3.0, 0.0, 0.0))",
+               Scene.translate(Scene.rotateY(Scene.cube(), Angle.degrees(90.0)), 3.0, 0.0, 0.0))",
         );
         // World composition for nested Groups is parent-first:
         // world = T * R, so a cube corner rotates about the cube's own origin
@@ -553,7 +609,7 @@ mod tests {
         let frame = frame_of(
             "let main = () =>
              Frame.createLit(
-               Camera.firstPerson(0.0, 3.5, -8.0, 0.0, -0.3, 60.0),
+               Camera.firstPerson(0.0, 3.5, -8.0, Angle.radians(0.0), Angle.radians(-0.3), Angle.degrees(60.0)),
                Scene.group([
                  Scene.plane() |> Scene.scale(24.0) |> Scene.lit(0.6, 0.6, 0.62),
                  Scene.sphere() |> Scene.emissive(1.0, 0.3, 0.25),
@@ -586,6 +642,40 @@ mod tests {
             .err()
             .expect("should fail");
         assert_eq!(failure.error.message, "expected a number, got a string");
+    }
+
+    // [units, tier 1] rotations/camera angles refuse bare numbers with a
+    // teaching error — degree/radian confusion is unrepresentable.
+    #[test]
+    fn bare_numbers_are_not_angles() {
+        let module =
+            mle::lower(mle::parse("let main = () => Scene.cube() |> Scene.rotateY(1.57)").unwrap())
+                .unwrap();
+        let failure = mle::run_with_host(&module, Tracing::Off, &mut FunctorHost)
+            .err()
+            .expect("should fail");
+        assert_eq!(
+            failure.error.message,
+            "Scene.rotateY: expected an Angle, got a bare number — say which unit: \
+Angle.degrees(…) or Angle.radians(…)"
+        );
+    }
+
+    // Degrees and radians agree where they should: 90° == τ/4 rad.
+    #[test]
+    fn degrees_and_radians_agree() {
+        let deg = frame_of(
+            "let main = () => Frame.create(Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0), \
+Scene.cube() |> Scene.rotateY(Angle.degrees(90.0)))",
+        );
+        let rad = frame_of(
+            "let main = () => Frame.create(Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0), \
+Scene.cube() |> Scene.rotateY(Angle.radians(1.5707964)))",
+        );
+        assert_eq!(
+            serde_json::to_string(&deg.scene).unwrap(),
+            serde_json::to_string(&rad.scene).unwrap()
+        );
     }
 
     // A value the prelude doesn't serve still errors as unknown.


### PR DESCRIPTION
## What

Units **tier 1** (from the design discussion; note: `~/notes/ideas/mle-language/units.md`): angles become **values, not numbers**.

```mle
Scene.cube() |> Scene.rotateY(Angle.degrees(90.0))
Camera.firstPerson(0.0, 3.5, -8.0, Angle.radians(0.0), Angle.radians(-0.3), Angle.degrees(60.0))
```

A bare number in any angular position is a runtime error that teaches: `expected an Angle, got a bare number — say which unit: Angle.degrees(…) or Angle.radians(…)`. This is the F# engine's own `Math.Angle` discipline (see `primitives.fs`) carried across the language boundary — the deg/rad confusion the C4b review probed for existed only because the prelude had flattened angles to raw Floats + a doc comment. Runtime branding fits MLE's gradual typing better than phantom types: it enforces for all code, annotated or not.

## Verification

- Both examples migrated and **pixel-identical** to their previous captures (`cmp` clean on `mle-hello` and `mle-primitives`).
- 76/76 common tests: new pins for the teaching error and for `Angle.degrees(90) ≡ Angle.radians(τ/4)` (identical serialized scenes); the PATHS-drift walk covers the new constructors.
- Also in this stack: #171 gained a small fix — a `count = 15.0` hot-reload test edit from the working tree had been swept into the C4b commit by `git add -A`; the capture-parity checks caught it (the kind of thing they exist for).

## Notes

- **Tier 2** — real F#-style units of measure (`Float<m/s>`, unit algebra) — is roadmapped to ride on B7's Hindley–Milner, where unit polymorphism belongs; branded values migrate cleanly (`Angle ≡ Float<rad>`).
- Stacked on #171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)