### PR TITLE
feat(mle): B5 part 1 — variant types (ADTs) + match, through the whole stack

### DIFF
--- a/.claude/skills/mle-language/SKILL.md
+++ b/.claude/skills/mle-language/SKILL.md
@@ -106,10 +106,11 @@ and the conditional is a **bool-literal match**
   works anywhere (`Shape.Circle` does NOT — it stays an unknown external),
   which is why ctor names must be unique ACROSS all variant types in the
   module, and `let Circle = …` alongside a ctor `Circle` is a
-  duplicate-definition error. Locals (params, pattern vars) may still
-  shadow a ctor.
+  duplicate-definition error. An (uppercase) param may still shadow a ctor;
+  pattern vars can't (they are forced lowercase).
 - **Patterns are minimal**: `Ctor(x, _)` / `Ctor` / bare name / `_` /
-  literals (`true`, `false`, numbers, strings — equality match). Ctor
+  literals (`true`, `false`, numbers incl. negative, strings — equality
+  match). Ctor
   sub-patterns are names or `_` only — no nested ctors, no literals inside.
   Pattern vars are immutable bindings; lambdas may capture them. First
   matching arm wins; no arm matching is a spanned runtime error. Unapplied

--- a/.claude/skills/mle-language/SKILL.md
+++ b/.claude/skills/mle-language/SKILL.md
@@ -31,6 +31,26 @@ regenerates). VSCode gets live parse/lower/type diagnostics and
 // line comments only
 type Position = { x: Float, y: Float }        // record types; nominal in annotations
 
+type Shape =                                  // variant types (ADTs); nominal like records
+  | Circle(radius: Float)                     // leading | REQUIRED, first alternative too
+  | Rect(w: Float, h: Float)                  // fields named in the decl…
+  | Point                                     // …nullary ctor: no parens, ever
+
+let c = Circle(2.0)                           // …but ctors are CALLED positionally
+let shapes = [c, Rect(3.0, 4.0), Point]       // bare Point IS the value
+
+let area = (s: Shape): Float =>
+  match s with                                // match: | pattern => full-expression body
+  | Circle(r) => 3.14 * r * r                 // ctor patterns bind positionally
+  | Rect(w, _) => w * w                       // sub-patterns: names or _ ONLY (no nesting)
+  | Point => 0.0                              // exhaustiveness checked when s's type is known
+
+let sizeOf = (s: Shape): String =>
+  match area(s) > 10.0 with                   // bool-literal match = the ONLY conditional
+  | true => "big"
+  | false => "small"                          // number/string literal arms exist too
+                                              // (they need a catch-all: `| x =>` or `| _ =>`)
+
 let threshold = 10                            // top-level let; ints/floats are all Float (f64)
 let origin = { x: 0.0, y: 0.0 }               // record literal
 let scores = [1.0, 2.0, 3.0]                  // list literal
@@ -58,10 +78,10 @@ let main = () => report([12.0, 3.5, 40.0])    // zero-param main is run's entry 
 ```
 
 Operators: `+ - * /` `< > ==` (conventional precedence; pipelines bind
-loosest), unary `-`. There is **no** if/else, match, loops, strings
-concatenation operator, modules, or imports yet — iteration is
-`List.map/filter/fold`, conditionals don't exist (design them out or wait
-for the roadmap).
+loosest), unary `-`. There is **no** if/else, loops, string-concatenation
+operator, modules, or imports yet — iteration is `List.map/filter/fold`,
+and the conditional is a **bool-literal match**
+(`match x > 3.0 with | true => a | false => b`).
 
 ## Semantics rules that WILL bite you
 
@@ -78,8 +98,27 @@ for the roadmap).
 - **Equality `==` is structural**; comparing functions is a runtime error.
 - **Division is IEEE** (`1.0/0.0` = `inf`); the engine boundary rejects
   non-finite numbers.
+- **Greedy match arms**: arm bodies are full expressions, so a nested
+  `match` inside an arm consumes the following `|` arms as its own —
+  parenthesize the inner match (F#/OCaml convention). The leading `|` is
+  required before every arm and every variant alternative, first included.
+- **Constructors resolve bare and live in the VALUE namespace**: `Circle(2.0)`
+  works anywhere (`Shape.Circle` does NOT — it stays an unknown external),
+  which is why ctor names must be unique ACROSS all variant types in the
+  module, and `let Circle = …` alongside a ctor `Circle` is a
+  duplicate-definition error. Locals (params, pattern vars) may still
+  shadow a ctor.
+- **Patterns are minimal**: `Ctor(x, _)` / `Ctor` / bare name / `_` /
+  literals (`true`, `false`, numbers, strings — equality match). Ctor
+  sub-patterns are names or `_` only — no nested ctors, no literals inside.
+  Pattern vars are immutable bindings; lambdas may capture them. First
+  matching arm wins; no arm matching is a spanned runtime error. Unapplied
+  ctors are first-class (`xs |> List.map(Circle)`); the runtime checks ctor
+  ARITY only (field types are the checker's job).
 - **Duplicates are errors**: top-level names (per namespace — `type Foo` and
-  `let Foo` may coexist), record fields (literal and update), lambda params.
+  `let Foo` may coexist, but constructors share the value namespace with
+  `let`s), record fields (literal and update), lambda params, pattern
+  variables within one pattern.
 - Recursion depth is capped (~200); deep iteration belongs in `List.*`.
 
 ## Builtins (the whole registry)
@@ -141,9 +180,12 @@ inspected, compared, or serialized.
 ## Typechecking model (gradual)
 
 `mle check` fires only where BOTH sides are known; unannotated = `Unknown` =
-compatible with everything. Annotations buy diagnostics. Record annotations
-are nominal; the runtime is structural. A `mut` slot's type fixes at its
-initializer. Full Hindley–Milner is roadmapped (B7) after effects.
+compatible with everything. Annotations buy diagnostics. Record and variant
+annotations are nominal; the runtime is structural. A `mut` slot's type
+fixes at its initializer. A known-typed `match` scrutinee buys exhaustiveness
+checking (all ctors, or `true`+`false`, or a catch-all) and typed pattern
+variables; arm results must agree where known. Full Hindley–Milner is
+roadmapped (B7) after effects.
 
 ## Keeping this skill honest
 

--- a/docs/mle.md
+++ b/docs/mle.md
@@ -167,10 +167,22 @@ snapshots — no GPU, fully agent-verifiable.
       + committed `broken.check` diagnostic golden (all diagnostics, sorted,
       `file:line:col`); per-diagnostic message/span unit tests; the three
       examples check clean. (done)
-- [ ] **B5. Match/ADTs + storable closures.** The game-logic essentials;
-      closures serialize as `(stable-id, env)`. *Verify:* serialize a value
-      graph containing a closure → deserialize → call it; rename-then-restore
-      fails loud.
+- [ ] **B5. Match/ADTs + storable closures.** The game-logic essentials.
+      **Part 1 — ADTs + `match` — done (2026-07-03):** variant `type`
+      declarations (`| Ctor(name: Type, …)` / nullary `| Ctor`; leading `|`
+      required, first alternative included); constructors live in the value
+      namespace (resolve bare, unique across types, collide with `let`s),
+      are called positionally, and are first-class when unapplied; `match
+      expr with | pattern => expr` with constructor/variable/`_`/literal
+      patterns (bool-literal arms are the language's first conditional; arms
+      parse greedily — parenthesize nested matches); structural variant
+      equality; gradual checking with exhaustiveness (missing ctors named),
+      foreign-ctor/literal-compatibility diagnostics, typed pattern
+      variables, and arm-result joins; hover for ctor signatures and pattern
+      vars; `examples/shapes.mle` + goldens. **Remaining: storable
+      closures** serialized as `(stable-id, env)`. *Verify:* serialize a
+      value graph containing a closure → deserialize → call it;
+      rename-then-restore fails loud.
 - [ ] **B6. Minimal effect broker.** `Clock.Now`, `Random` with real/fake/replay
       handlers. *Verify:* same program under real vs fake vs replay; structured
       effect log.

--- a/mle/examples/functions.ast
+++ b/mle/examples/functions.ast
@@ -3,32 +3,34 @@ Program {
         Type(
             TypeDecl {
                 name: "Player",
-                fields: [
-                    FieldTy {
-                        name: "name",
-                        ty: TypeName {
-                            name: "String",
-                            args: [],
-                            span: 96..102,
+                body: Record(
+                    [
+                        FieldTy {
+                            name: "name",
+                            ty: TypeName {
+                                name: "String",
+                                args: [],
+                                span: 96..102,
+                            },
+                            span: 90..102,
                         },
-                        span: 90..102,
-                    },
-                    FieldTy {
-                        name: "scores",
-                        ty: TypeName {
-                            name: "List",
-                            args: [
-                                TypeName {
-                                    name: "Float",
-                                    args: [],
-                                    span: 117..122,
-                                },
-                            ],
-                            span: 112..123,
+                        FieldTy {
+                            name: "scores",
+                            ty: TypeName {
+                                name: "List",
+                                args: [
+                                    TypeName {
+                                        name: "Float",
+                                        args: [],
+                                        span: 117..122,
+                                    },
+                                ],
+                                span: 112..123,
+                            },
+                            span: 104..123,
                         },
-                        span: 104..123,
-                    },
-                ],
+                    ],
+                ),
                 span: 74..125,
             },
         ),

--- a/mle/examples/functions.ir
+++ b/mle/examples/functions.ir
@@ -3,32 +3,34 @@ Module {
         TypeDef {
             id: d0,
             name: "Player",
-            fields: [
-                FieldTy {
-                    name: "name",
-                    ty: TypeName {
-                        name: "String",
-                        args: [],
-                        span: 96..102,
+            body: Record(
+                [
+                    FieldTy {
+                        name: "name",
+                        ty: TypeName {
+                            name: "String",
+                            args: [],
+                            span: 96..102,
+                        },
+                        span: 90..102,
                     },
-                    span: 90..102,
-                },
-                FieldTy {
-                    name: "scores",
-                    ty: TypeName {
-                        name: "List",
-                        args: [
-                            TypeName {
-                                name: "Float",
-                                args: [],
-                                span: 117..122,
-                            },
-                        ],
-                        span: 112..123,
+                    FieldTy {
+                        name: "scores",
+                        ty: TypeName {
+                            name: "List",
+                            args: [
+                                TypeName {
+                                    name: "Float",
+                                    args: [],
+                                    span: 117..122,
+                                },
+                            ],
+                            span: 112..123,
+                        },
+                        span: 104..123,
                     },
-                    span: 104..123,
-                },
-            ],
+                ],
+            ),
             span: 74..125,
         },
     ],

--- a/mle/examples/records.ast
+++ b/mle/examples/records.ast
@@ -3,52 +3,56 @@ Program {
         Type(
             TypeDecl {
                 name: "Position",
-                fields: [
-                    FieldTy {
-                        name: "x",
-                        ty: TypeName {
-                            name: "Float",
-                            args: [],
-                            span: 162..167,
+                body: Record(
+                    [
+                        FieldTy {
+                            name: "x",
+                            ty: TypeName {
+                                name: "Float",
+                                args: [],
+                                span: 162..167,
+                            },
+                            span: 159..167,
                         },
-                        span: 159..167,
-                    },
-                    FieldTy {
-                        name: "y",
-                        ty: TypeName {
-                            name: "Float",
-                            args: [],
-                            span: 172..177,
+                        FieldTy {
+                            name: "y",
+                            ty: TypeName {
+                                name: "Float",
+                                args: [],
+                                span: 172..177,
+                            },
+                            span: 169..177,
                         },
-                        span: 169..177,
-                    },
-                ],
+                    ],
+                ),
                 span: 141..179,
             },
         ),
         Type(
             TypeDecl {
                 name: "Velocity",
-                fields: [
-                    FieldTy {
-                        name: "dx",
-                        ty: TypeName {
-                            name: "Float",
-                            args: [],
-                            span: 202..207,
+                body: Record(
+                    [
+                        FieldTy {
+                            name: "dx",
+                            ty: TypeName {
+                                name: "Float",
+                                args: [],
+                                span: 202..207,
+                            },
+                            span: 198..207,
                         },
-                        span: 198..207,
-                    },
-                    FieldTy {
-                        name: "dy",
-                        ty: TypeName {
-                            name: "Float",
-                            args: [],
-                            span: 213..218,
+                        FieldTy {
+                            name: "dy",
+                            ty: TypeName {
+                                name: "Float",
+                                args: [],
+                                span: 213..218,
+                            },
+                            span: 209..218,
                         },
-                        span: 209..218,
-                    },
-                ],
+                    ],
+                ),
                 span: 180..220,
             },
         ),

--- a/mle/examples/records.ir
+++ b/mle/examples/records.ir
@@ -3,51 +3,55 @@ Module {
         TypeDef {
             id: d0,
             name: "Position",
-            fields: [
-                FieldTy {
-                    name: "x",
-                    ty: TypeName {
-                        name: "Float",
-                        args: [],
-                        span: 162..167,
+            body: Record(
+                [
+                    FieldTy {
+                        name: "x",
+                        ty: TypeName {
+                            name: "Float",
+                            args: [],
+                            span: 162..167,
+                        },
+                        span: 159..167,
                     },
-                    span: 159..167,
-                },
-                FieldTy {
-                    name: "y",
-                    ty: TypeName {
-                        name: "Float",
-                        args: [],
-                        span: 172..177,
+                    FieldTy {
+                        name: "y",
+                        ty: TypeName {
+                            name: "Float",
+                            args: [],
+                            span: 172..177,
+                        },
+                        span: 169..177,
                     },
-                    span: 169..177,
-                },
-            ],
+                ],
+            ),
             span: 141..179,
         },
         TypeDef {
             id: d1,
             name: "Velocity",
-            fields: [
-                FieldTy {
-                    name: "dx",
-                    ty: TypeName {
-                        name: "Float",
-                        args: [],
-                        span: 202..207,
+            body: Record(
+                [
+                    FieldTy {
+                        name: "dx",
+                        ty: TypeName {
+                            name: "Float",
+                            args: [],
+                            span: 202..207,
+                        },
+                        span: 198..207,
                     },
-                    span: 198..207,
-                },
-                FieldTy {
-                    name: "dy",
-                    ty: TypeName {
-                        name: "Float",
-                        args: [],
-                        span: 213..218,
+                    FieldTy {
+                        name: "dy",
+                        ty: TypeName {
+                            name: "Float",
+                            args: [],
+                            span: 213..218,
+                        },
+                        span: 209..218,
                     },
-                    span: 209..218,
-                },
-            ],
+                ],
+            ),
             span: 180..220,
         },
     ],

--- a/mle/examples/shapes.ast
+++ b/mle/examples/shapes.ast
@@ -3,52 +3,54 @@ Program {
         Type(
             TypeDecl {
                 name: "Shape",
-                variants: [
-                    VariantDecl {
-                        name: "Circle",
-                        fields: [
-                            FieldTy {
-                                name: "radius",
-                                ty: TypeName {
-                                    name: "Float",
-                                    args: [],
-                                    span: 320..325,
+                body: Variants(
+                    [
+                        VariantDecl {
+                            name: "Circle",
+                            fields: [
+                                FieldTy {
+                                    name: "radius",
+                                    ty: TypeName {
+                                        name: "Float",
+                                        args: [],
+                                        span: 320..325,
+                                    },
+                                    span: 312..325,
                                 },
-                                span: 312..325,
-                            },
-                        ],
-                        span: 305..326,
-                    },
-                    VariantDecl {
-                        name: "Rect",
-                        fields: [
-                            FieldTy {
-                                name: "w",
-                                ty: TypeName {
-                                    name: "Float",
-                                    args: [],
-                                    span: 339..344,
+                            ],
+                            span: 305..326,
+                        },
+                        VariantDecl {
+                            name: "Rect",
+                            fields: [
+                                FieldTy {
+                                    name: "w",
+                                    ty: TypeName {
+                                        name: "Float",
+                                        args: [],
+                                        span: 339..344,
+                                    },
+                                    span: 336..344,
                                 },
-                                span: 336..344,
-                            },
-                            FieldTy {
-                                name: "h",
-                                ty: TypeName {
-                                    name: "Float",
-                                    args: [],
-                                    span: 349..354,
+                                FieldTy {
+                                    name: "h",
+                                    ty: TypeName {
+                                        name: "Float",
+                                        args: [],
+                                        span: 349..354,
+                                    },
+                                    span: 346..354,
                                 },
-                                span: 346..354,
-                            },
-                        ],
-                        span: 331..355,
-                    },
-                    VariantDecl {
-                        name: "Point",
-                        fields: [],
-                        span: 360..365,
-                    },
-                ],
+                            ],
+                            span: 331..355,
+                        },
+                        VariantDecl {
+                            name: "Point",
+                            fields: [],
+                            span: 360..365,
+                        },
+                    ],
+                ),
                 span: 288..365,
             },
         ),

--- a/mle/examples/shapes.ast
+++ b/mle/examples/shapes.ast
@@ -1,0 +1,794 @@
+Program {
+    items: [
+        Type(
+            TypeDecl {
+                name: "Shape",
+                variants: [
+                    VariantDecl {
+                        name: "Circle",
+                        fields: [
+                            FieldTy {
+                                name: "radius",
+                                ty: TypeName {
+                                    name: "Float",
+                                    args: [],
+                                    span: 320..325,
+                                },
+                                span: 312..325,
+                            },
+                        ],
+                        span: 305..326,
+                    },
+                    VariantDecl {
+                        name: "Rect",
+                        fields: [
+                            FieldTy {
+                                name: "w",
+                                ty: TypeName {
+                                    name: "Float",
+                                    args: [],
+                                    span: 339..344,
+                                },
+                                span: 336..344,
+                            },
+                            FieldTy {
+                                name: "h",
+                                ty: TypeName {
+                                    name: "Float",
+                                    args: [],
+                                    span: 349..354,
+                                },
+                                span: 346..354,
+                            },
+                        ],
+                        span: 331..355,
+                    },
+                    VariantDecl {
+                        name: "Point",
+                        fields: [],
+                        span: 360..365,
+                    },
+                ],
+                span: 288..365,
+            },
+        ),
+        Let(
+            LetDecl {
+                name: "pi",
+                value: Expr {
+                    kind: Number(
+                        3.14159,
+                    ),
+                    span: 376..383,
+                },
+                span: 367..383,
+            },
+        ),
+        Let(
+            LetDecl {
+                name: "area",
+                value: Expr {
+                    kind: Lambda {
+                        params: [
+                            Param {
+                                name: "s",
+                                ty: Some(
+                                    TypeName {
+                                        name: "Shape",
+                                        args: [],
+                                        span: 400..405,
+                                    },
+                                ),
+                                span: 397..405,
+                            },
+                        ],
+                        ret: Some(
+                            TypeName {
+                                name: "Float",
+                                args: [],
+                                span: 408..413,
+                            },
+                        ),
+                        body: Expr {
+                            kind: Match {
+                                scrutinee: Expr {
+                                    kind: Ident(
+                                        [
+                                            "s",
+                                        ],
+                                    ),
+                                    span: 425..426,
+                                },
+                                arms: [
+                                    MatchArm {
+                                        pattern: Pattern {
+                                            kind: Ctor {
+                                                name: "Circle",
+                                                args: [
+                                                    Pattern {
+                                                        kind: Var(
+                                                            "r",
+                                                        ),
+                                                        span: 443..444,
+                                                    },
+                                                ],
+                                            },
+                                            span: 436..445,
+                                        },
+                                        body: Expr {
+                                            kind: Binary {
+                                                op: Mul,
+                                                lhs: Expr {
+                                                    kind: Binary {
+                                                        op: Mul,
+                                                        lhs: Expr {
+                                                            kind: Ident(
+                                                                [
+                                                                    "pi",
+                                                                ],
+                                                            ),
+                                                            span: 449..451,
+                                                        },
+                                                        rhs: Expr {
+                                                            kind: Ident(
+                                                                [
+                                                                    "r",
+                                                                ],
+                                                            ),
+                                                            span: 454..455,
+                                                        },
+                                                    },
+                                                    span: 449..455,
+                                                },
+                                                rhs: Expr {
+                                                    kind: Ident(
+                                                        [
+                                                            "r",
+                                                        ],
+                                                    ),
+                                                    span: 458..459,
+                                                },
+                                            },
+                                            span: 449..459,
+                                        },
+                                        span: 434..459,
+                                    },
+                                    MatchArm {
+                                        pattern: Pattern {
+                                            kind: Ctor {
+                                                name: "Rect",
+                                                args: [
+                                                    Pattern {
+                                                        kind: Var(
+                                                            "w",
+                                                        ),
+                                                        span: 469..470,
+                                                    },
+                                                    Pattern {
+                                                        kind: Var(
+                                                            "h",
+                                                        ),
+                                                        span: 472..473,
+                                                    },
+                                                ],
+                                            },
+                                            span: 464..474,
+                                        },
+                                        body: Expr {
+                                            kind: Binary {
+                                                op: Mul,
+                                                lhs: Expr {
+                                                    kind: Ident(
+                                                        [
+                                                            "w",
+                                                        ],
+                                                    ),
+                                                    span: 478..479,
+                                                },
+                                                rhs: Expr {
+                                                    kind: Ident(
+                                                        [
+                                                            "h",
+                                                        ],
+                                                    ),
+                                                    span: 482..483,
+                                                },
+                                            },
+                                            span: 478..483,
+                                        },
+                                        span: 462..483,
+                                    },
+                                    MatchArm {
+                                        pattern: Pattern {
+                                            kind: Ctor {
+                                                name: "Point",
+                                                args: [],
+                                            },
+                                            span: 488..493,
+                                        },
+                                        body: Expr {
+                                            kind: Number(
+                                                0.0,
+                                            ),
+                                            span: 497..500,
+                                        },
+                                        span: 486..500,
+                                    },
+                                ],
+                            },
+                            span: 419..500,
+                        },
+                    },
+                    span: 396..500,
+                },
+                span: 385..500,
+            },
+        ),
+        Let(
+            LetDecl {
+                name: "isRound",
+                value: Expr {
+                    kind: Lambda {
+                        params: [
+                            Param {
+                                name: "s",
+                                ty: Some(
+                                    TypeName {
+                                        name: "Shape",
+                                        args: [],
+                                        span: 520..525,
+                                    },
+                                ),
+                                span: 517..525,
+                            },
+                        ],
+                        ret: Some(
+                            TypeName {
+                                name: "Bool",
+                                args: [],
+                                span: 528..532,
+                            },
+                        ),
+                        body: Expr {
+                            kind: Match {
+                                scrutinee: Expr {
+                                    kind: Ident(
+                                        [
+                                            "s",
+                                        ],
+                                    ),
+                                    span: 544..545,
+                                },
+                                arms: [
+                                    MatchArm {
+                                        pattern: Pattern {
+                                            kind: Ctor {
+                                                name: "Circle",
+                                                args: [
+                                                    Pattern {
+                                                        kind: Wildcard,
+                                                        span: 562..563,
+                                                    },
+                                                ],
+                                            },
+                                            span: 555..564,
+                                        },
+                                        body: Expr {
+                                            kind: Bool(
+                                                true,
+                                            ),
+                                            span: 568..572,
+                                        },
+                                        span: 553..572,
+                                    },
+                                    MatchArm {
+                                        pattern: Pattern {
+                                            kind: Wildcard,
+                                            span: 577..578,
+                                        },
+                                        body: Expr {
+                                            kind: Bool(
+                                                false,
+                                            ),
+                                            span: 582..587,
+                                        },
+                                        span: 575..587,
+                                    },
+                                ],
+                            },
+                            span: 538..587,
+                        },
+                    },
+                    span: 516..587,
+                },
+                span: 502..587,
+            },
+        ),
+        Let(
+            LetDecl {
+                name: "sizeOf",
+                value: Expr {
+                    kind: Lambda {
+                        params: [
+                            Param {
+                                name: "s",
+                                ty: Some(
+                                    TypeName {
+                                        name: "Shape",
+                                        args: [],
+                                        span: 649..654,
+                                    },
+                                ),
+                                span: 646..654,
+                            },
+                        ],
+                        ret: Some(
+                            TypeName {
+                                name: "String",
+                                args: [],
+                                span: 657..663,
+                            },
+                        ),
+                        body: Expr {
+                            kind: Match {
+                                scrutinee: Expr {
+                                    kind: Binary {
+                                        op: Gt,
+                                        lhs: Expr {
+                                            kind: Call {
+                                                callee: Expr {
+                                                    kind: Ident(
+                                                        [
+                                                            "area",
+                                                        ],
+                                                    ),
+                                                    span: 675..679,
+                                                },
+                                                args: [
+                                                    Expr {
+                                                        kind: Ident(
+                                                            [
+                                                                "s",
+                                                            ],
+                                                        ),
+                                                        span: 680..681,
+                                                    },
+                                                ],
+                                            },
+                                            span: 675..682,
+                                        },
+                                        rhs: Expr {
+                                            kind: Number(
+                                                10.0,
+                                            ),
+                                            span: 685..689,
+                                        },
+                                    },
+                                    span: 675..689,
+                                },
+                                arms: [
+                                    MatchArm {
+                                        pattern: Pattern {
+                                            kind: Bool(
+                                                true,
+                                            ),
+                                            span: 699..703,
+                                        },
+                                        body: Expr {
+                                            kind: String(
+                                                "big",
+                                            ),
+                                            span: 707..712,
+                                        },
+                                        span: 697..712,
+                                    },
+                                    MatchArm {
+                                        pattern: Pattern {
+                                            kind: Bool(
+                                                false,
+                                            ),
+                                            span: 717..722,
+                                        },
+                                        body: Expr {
+                                            kind: String(
+                                                "small",
+                                            ),
+                                            span: 726..733,
+                                        },
+                                        span: 715..733,
+                                    },
+                                ],
+                            },
+                            span: 669..733,
+                        },
+                    },
+                    span: 645..733,
+                },
+                span: 632..733,
+            },
+        ),
+        Let(
+            LetDecl {
+                name: "describe",
+                value: Expr {
+                    kind: Lambda {
+                        params: [
+                            Param {
+                                name: "s",
+                                ty: Some(
+                                    TypeName {
+                                        name: "Shape",
+                                        args: [],
+                                        span: 961..966,
+                                    },
+                                ),
+                                span: 958..966,
+                            },
+                        ],
+                        ret: Some(
+                            TypeName {
+                                name: "String",
+                                args: [],
+                                span: 969..975,
+                            },
+                        ),
+                        body: Expr {
+                            kind: Match {
+                                scrutinee: Expr {
+                                    kind: Ident(
+                                        [
+                                            "s",
+                                        ],
+                                    ),
+                                    span: 987..988,
+                                },
+                                arms: [
+                                    MatchArm {
+                                        pattern: Pattern {
+                                            kind: Ctor {
+                                                name: "Point",
+                                                args: [],
+                                            },
+                                            span: 998..1003,
+                                        },
+                                        body: Expr {
+                                            kind: String(
+                                                "a point",
+                                            ),
+                                            span: 1007..1016,
+                                        },
+                                        span: 996..1016,
+                                    },
+                                    MatchArm {
+                                        pattern: Pattern {
+                                            kind: Var(
+                                                "other",
+                                            ),
+                                            span: 1021..1026,
+                                        },
+                                        body: Expr {
+                                            kind: Match {
+                                                scrutinee: Expr {
+                                                    kind: Call {
+                                                        callee: Expr {
+                                                            kind: Ident(
+                                                                [
+                                                                    "isRound",
+                                                                ],
+                                                            ),
+                                                            span: 1042..1049,
+                                                        },
+                                                        args: [
+                                                            Expr {
+                                                                kind: Ident(
+                                                                    [
+                                                                        "other",
+                                                                    ],
+                                                                ),
+                                                                span: 1050..1055,
+                                                            },
+                                                        ],
+                                                    },
+                                                    span: 1042..1056,
+                                                },
+                                                arms: [
+                                                    MatchArm {
+                                                        pattern: Pattern {
+                                                            kind: Bool(
+                                                                true,
+                                                            ),
+                                                            span: 1070..1074,
+                                                        },
+                                                        body: Expr {
+                                                            kind: Call {
+                                                                callee: Expr {
+                                                                    kind: Ident(
+                                                                        [
+                                                                            "Text",
+                                                                            "concat",
+                                                                        ],
+                                                                    ),
+                                                                    span: 1078..1089,
+                                                                },
+                                                                args: [
+                                                                    Expr {
+                                                                        kind: String(
+                                                                            "a round ",
+                                                                        ),
+                                                                        span: 1090..1100,
+                                                                    },
+                                                                    Expr {
+                                                                        kind: Call {
+                                                                            callee: Expr {
+                                                                                kind: Ident(
+                                                                                    [
+                                                                                        "Text",
+                                                                                        "concat",
+                                                                                    ],
+                                                                                ),
+                                                                                span: 1102..1113,
+                                                                            },
+                                                                            args: [
+                                                                                Expr {
+                                                                                    kind: Call {
+                                                                                        callee: Expr {
+                                                                                            kind: Ident(
+                                                                                                [
+                                                                                                    "sizeOf",
+                                                                                                ],
+                                                                                            ),
+                                                                                            span: 1114..1120,
+                                                                                        },
+                                                                                        args: [
+                                                                                            Expr {
+                                                                                                kind: Ident(
+                                                                                                    [
+                                                                                                        "other",
+                                                                                                    ],
+                                                                                                ),
+                                                                                                span: 1121..1126,
+                                                                                            },
+                                                                                        ],
+                                                                                    },
+                                                                                    span: 1114..1127,
+                                                                                },
+                                                                                Expr {
+                                                                                    kind: String(
+                                                                                        " shape",
+                                                                                    ),
+                                                                                    span: 1129..1137,
+                                                                                },
+                                                                            ],
+                                                                        },
+                                                                        span: 1102..1138,
+                                                                    },
+                                                                ],
+                                                            },
+                                                            span: 1078..1139,
+                                                        },
+                                                        span: 1068..1139,
+                                                    },
+                                                    MatchArm {
+                                                        pattern: Pattern {
+                                                            kind: Bool(
+                                                                false,
+                                                            ),
+                                                            span: 1148..1153,
+                                                        },
+                                                        body: Expr {
+                                                            kind: Call {
+                                                                callee: Expr {
+                                                                    kind: Ident(
+                                                                        [
+                                                                            "Text",
+                                                                            "concat",
+                                                                        ],
+                                                                    ),
+                                                                    span: 1157..1168,
+                                                                },
+                                                                args: [
+                                                                    Expr {
+                                                                        kind: String(
+                                                                            "a boxy ",
+                                                                        ),
+                                                                        span: 1169..1178,
+                                                                    },
+                                                                    Expr {
+                                                                        kind: Call {
+                                                                            callee: Expr {
+                                                                                kind: Ident(
+                                                                                    [
+                                                                                        "Text",
+                                                                                        "concat",
+                                                                                    ],
+                                                                                ),
+                                                                                span: 1180..1191,
+                                                                            },
+                                                                            args: [
+                                                                                Expr {
+                                                                                    kind: Call {
+                                                                                        callee: Expr {
+                                                                                            kind: Ident(
+                                                                                                [
+                                                                                                    "sizeOf",
+                                                                                                ],
+                                                                                            ),
+                                                                                            span: 1192..1198,
+                                                                                        },
+                                                                                        args: [
+                                                                                            Expr {
+                                                                                                kind: Ident(
+                                                                                                    [
+                                                                                                        "other",
+                                                                                                    ],
+                                                                                                ),
+                                                                                                span: 1199..1204,
+                                                                                            },
+                                                                                        ],
+                                                                                    },
+                                                                                    span: 1192..1205,
+                                                                                },
+                                                                                Expr {
+                                                                                    kind: String(
+                                                                                        " shape",
+                                                                                    ),
+                                                                                    span: 1207..1215,
+                                                                                },
+                                                                            ],
+                                                                        },
+                                                                        span: 1180..1216,
+                                                                    },
+                                                                ],
+                                                            },
+                                                            span: 1157..1217,
+                                                        },
+                                                        span: 1146..1217,
+                                                    },
+                                                ],
+                                            },
+                                            span: 1036..1217,
+                                        },
+                                        span: 1019..1217,
+                                    },
+                                ],
+                            },
+                            span: 981..1217,
+                        },
+                    },
+                    span: 957..1217,
+                },
+                span: 942..1217,
+            },
+        ),
+        Let(
+            LetDecl {
+                name: "shapes",
+                value: Expr {
+                    kind: List(
+                        [
+                            Expr {
+                                kind: Call {
+                                    callee: Expr {
+                                        kind: Ident(
+                                            [
+                                                "Circle",
+                                            ],
+                                        ),
+                                        span: 1233..1239,
+                                    },
+                                    args: [
+                                        Expr {
+                                            kind: Number(
+                                                2.0,
+                                            ),
+                                            span: 1240..1243,
+                                        },
+                                    ],
+                                },
+                                span: 1233..1244,
+                            },
+                            Expr {
+                                kind: Call {
+                                    callee: Expr {
+                                        kind: Ident(
+                                            [
+                                                "Rect",
+                                            ],
+                                        ),
+                                        span: 1246..1250,
+                                    },
+                                    args: [
+                                        Expr {
+                                            kind: Number(
+                                                3.0,
+                                            ),
+                                            span: 1251..1254,
+                                        },
+                                        Expr {
+                                            kind: Number(
+                                                4.0,
+                                            ),
+                                            span: 1256..1259,
+                                        },
+                                    ],
+                                },
+                                span: 1246..1260,
+                            },
+                            Expr {
+                                kind: Ident(
+                                    [
+                                        "Point",
+                                    ],
+                                ),
+                                span: 1262..1267,
+                            },
+                        ],
+                    ),
+                    span: 1232..1268,
+                },
+                span: 1219..1268,
+            },
+        ),
+        Let(
+            LetDecl {
+                name: "main",
+                value: Expr {
+                    kind: Lambda {
+                        params: [],
+                        ret: None,
+                        body: Expr {
+                            kind: Pipeline {
+                                head: Expr {
+                                    kind: Ident(
+                                        [
+                                            "shapes",
+                                        ],
+                                    ),
+                                    span: 1289..1295,
+                                },
+                                stages: [
+                                    Expr {
+                                        kind: Call {
+                                            callee: Expr {
+                                                kind: Ident(
+                                                    [
+                                                        "List",
+                                                        "map",
+                                                    ],
+                                                ),
+                                                span: 1299..1307,
+                                            },
+                                            args: [
+                                                Expr {
+                                                    kind: Ident(
+                                                        [
+                                                            "describe",
+                                                        ],
+                                                    ),
+                                                    span: 1308..1316,
+                                                },
+                                            ],
+                                        },
+                                        span: 1299..1317,
+                                    },
+                                    Expr {
+                                        kind: Ident(
+                                            [
+                                                "Text",
+                                                "toBullets",
+                                            ],
+                                        ),
+                                        span: 1321..1335,
+                                    },
+                                ],
+                            },
+                            span: 1289..1335,
+                        },
+                    },
+                    span: 1281..1335,
+                },
+                span: 1270..1335,
+            },
+        ),
+    ],
+}

--- a/mle/examples/shapes.ir
+++ b/mle/examples/shapes.ir
@@ -3,52 +3,54 @@ Module {
         TypeDef {
             id: d0,
             name: "Shape",
-            variants: [
-                VariantDecl {
-                    name: "Circle",
-                    fields: [
-                        FieldTy {
-                            name: "radius",
-                            ty: TypeName {
-                                name: "Float",
-                                args: [],
-                                span: 320..325,
+            body: Variants(
+                [
+                    VariantDecl {
+                        name: "Circle",
+                        fields: [
+                            FieldTy {
+                                name: "radius",
+                                ty: TypeName {
+                                    name: "Float",
+                                    args: [],
+                                    span: 320..325,
+                                },
+                                span: 312..325,
                             },
-                            span: 312..325,
-                        },
-                    ],
-                    span: 305..326,
-                },
-                VariantDecl {
-                    name: "Rect",
-                    fields: [
-                        FieldTy {
-                            name: "w",
-                            ty: TypeName {
-                                name: "Float",
-                                args: [],
-                                span: 339..344,
+                        ],
+                        span: 305..326,
+                    },
+                    VariantDecl {
+                        name: "Rect",
+                        fields: [
+                            FieldTy {
+                                name: "w",
+                                ty: TypeName {
+                                    name: "Float",
+                                    args: [],
+                                    span: 339..344,
+                                },
+                                span: 336..344,
                             },
-                            span: 336..344,
-                        },
-                        FieldTy {
-                            name: "h",
-                            ty: TypeName {
-                                name: "Float",
-                                args: [],
-                                span: 349..354,
+                            FieldTy {
+                                name: "h",
+                                ty: TypeName {
+                                    name: "Float",
+                                    args: [],
+                                    span: 349..354,
+                                },
+                                span: 346..354,
                             },
-                            span: 346..354,
-                        },
-                    ],
-                    span: 331..355,
-                },
-                VariantDecl {
-                    name: "Point",
-                    fields: [],
-                    span: 360..365,
-                },
-            ],
+                        ],
+                        span: 331..355,
+                    },
+                    VariantDecl {
+                        name: "Point",
+                        fields: [],
+                        span: 360..365,
+                    },
+                ],
+            ),
             span: 288..365,
         },
     ],

--- a/mle/examples/shapes.ir
+++ b/mle/examples/shapes.ir
@@ -1,0 +1,837 @@
+Module {
+    types: [
+        TypeDef {
+            id: d0,
+            name: "Shape",
+            variants: [
+                VariantDecl {
+                    name: "Circle",
+                    fields: [
+                        FieldTy {
+                            name: "radius",
+                            ty: TypeName {
+                                name: "Float",
+                                args: [],
+                                span: 320..325,
+                            },
+                            span: 312..325,
+                        },
+                    ],
+                    span: 305..326,
+                },
+                VariantDecl {
+                    name: "Rect",
+                    fields: [
+                        FieldTy {
+                            name: "w",
+                            ty: TypeName {
+                                name: "Float",
+                                args: [],
+                                span: 339..344,
+                            },
+                            span: 336..344,
+                        },
+                        FieldTy {
+                            name: "h",
+                            ty: TypeName {
+                                name: "Float",
+                                args: [],
+                                span: 349..354,
+                            },
+                            span: 346..354,
+                        },
+                    ],
+                    span: 331..355,
+                },
+                VariantDecl {
+                    name: "Point",
+                    fields: [],
+                    span: 360..365,
+                },
+            ],
+            span: 288..365,
+        },
+    ],
+    defs: [
+        Def {
+            id: d1,
+            name: "pi",
+            value: Expr {
+                id: e0,
+                kind: Number(
+                    3.14159,
+                ),
+                span: 376..383,
+            },
+            span: 367..383,
+        },
+        Def {
+            id: d2,
+            name: "area",
+            value: Expr {
+                id: e12,
+                kind: Lambda {
+                    params: [
+                        Param {
+                            binding: b0,
+                            name: "s",
+                            ty: Some(
+                                TypeName {
+                                    name: "Shape",
+                                    args: [],
+                                    span: 400..405,
+                                },
+                            ),
+                            span: 397..405,
+                        },
+                    ],
+                    ret: Some(
+                        TypeName {
+                            name: "Float",
+                            args: [],
+                            span: 408..413,
+                        },
+                    ),
+                    body: Expr {
+                        id: e11,
+                        kind: Match {
+                            scrutinee: Expr {
+                                id: e1,
+                                kind: Local {
+                                    binding: b0,
+                                    name: "s",
+                                },
+                                span: 425..426,
+                            },
+                            arms: [
+                                MatchArm {
+                                    pattern: Pattern {
+                                        kind: Ctor {
+                                            name: "Circle",
+                                            args: [
+                                                Pattern {
+                                                    kind: Var {
+                                                        binding: b1,
+                                                        name: "r",
+                                                    },
+                                                    span: 443..444,
+                                                },
+                                            ],
+                                        },
+                                        span: 436..445,
+                                    },
+                                    body: Expr {
+                                        id: e6,
+                                        kind: Binary {
+                                            op: Mul,
+                                            lhs: Expr {
+                                                id: e4,
+                                                kind: Binary {
+                                                    op: Mul,
+                                                    lhs: Expr {
+                                                        id: e2,
+                                                        kind: Global(
+                                                            "pi",
+                                                        ),
+                                                        span: 449..451,
+                                                    },
+                                                    rhs: Expr {
+                                                        id: e3,
+                                                        kind: Local {
+                                                            binding: b1,
+                                                            name: "r",
+                                                        },
+                                                        span: 454..455,
+                                                    },
+                                                },
+                                                span: 449..455,
+                                            },
+                                            rhs: Expr {
+                                                id: e5,
+                                                kind: Local {
+                                                    binding: b1,
+                                                    name: "r",
+                                                },
+                                                span: 458..459,
+                                            },
+                                        },
+                                        span: 449..459,
+                                    },
+                                    span: 434..459,
+                                },
+                                MatchArm {
+                                    pattern: Pattern {
+                                        kind: Ctor {
+                                            name: "Rect",
+                                            args: [
+                                                Pattern {
+                                                    kind: Var {
+                                                        binding: b2,
+                                                        name: "w",
+                                                    },
+                                                    span: 469..470,
+                                                },
+                                                Pattern {
+                                                    kind: Var {
+                                                        binding: b3,
+                                                        name: "h",
+                                                    },
+                                                    span: 472..473,
+                                                },
+                                            ],
+                                        },
+                                        span: 464..474,
+                                    },
+                                    body: Expr {
+                                        id: e9,
+                                        kind: Binary {
+                                            op: Mul,
+                                            lhs: Expr {
+                                                id: e7,
+                                                kind: Local {
+                                                    binding: b2,
+                                                    name: "w",
+                                                },
+                                                span: 478..479,
+                                            },
+                                            rhs: Expr {
+                                                id: e8,
+                                                kind: Local {
+                                                    binding: b3,
+                                                    name: "h",
+                                                },
+                                                span: 482..483,
+                                            },
+                                        },
+                                        span: 478..483,
+                                    },
+                                    span: 462..483,
+                                },
+                                MatchArm {
+                                    pattern: Pattern {
+                                        kind: Ctor {
+                                            name: "Point",
+                                            args: [],
+                                        },
+                                        span: 488..493,
+                                    },
+                                    body: Expr {
+                                        id: e10,
+                                        kind: Number(
+                                            0.0,
+                                        ),
+                                        span: 497..500,
+                                    },
+                                    span: 486..500,
+                                },
+                            ],
+                        },
+                        span: 419..500,
+                    },
+                },
+                span: 396..500,
+            },
+            span: 385..500,
+        },
+        Def {
+            id: d3,
+            name: "isRound",
+            value: Expr {
+                id: e17,
+                kind: Lambda {
+                    params: [
+                        Param {
+                            binding: b4,
+                            name: "s",
+                            ty: Some(
+                                TypeName {
+                                    name: "Shape",
+                                    args: [],
+                                    span: 520..525,
+                                },
+                            ),
+                            span: 517..525,
+                        },
+                    ],
+                    ret: Some(
+                        TypeName {
+                            name: "Bool",
+                            args: [],
+                            span: 528..532,
+                        },
+                    ),
+                    body: Expr {
+                        id: e16,
+                        kind: Match {
+                            scrutinee: Expr {
+                                id: e13,
+                                kind: Local {
+                                    binding: b4,
+                                    name: "s",
+                                },
+                                span: 544..545,
+                            },
+                            arms: [
+                                MatchArm {
+                                    pattern: Pattern {
+                                        kind: Ctor {
+                                            name: "Circle",
+                                            args: [
+                                                Pattern {
+                                                    kind: Wildcard,
+                                                    span: 562..563,
+                                                },
+                                            ],
+                                        },
+                                        span: 555..564,
+                                    },
+                                    body: Expr {
+                                        id: e14,
+                                        kind: Bool(
+                                            true,
+                                        ),
+                                        span: 568..572,
+                                    },
+                                    span: 553..572,
+                                },
+                                MatchArm {
+                                    pattern: Pattern {
+                                        kind: Wildcard,
+                                        span: 577..578,
+                                    },
+                                    body: Expr {
+                                        id: e15,
+                                        kind: Bool(
+                                            false,
+                                        ),
+                                        span: 582..587,
+                                    },
+                                    span: 575..587,
+                                },
+                            ],
+                        },
+                        span: 538..587,
+                    },
+                },
+                span: 516..587,
+            },
+            span: 502..587,
+        },
+        Def {
+            id: d4,
+            name: "sizeOf",
+            value: Expr {
+                id: e26,
+                kind: Lambda {
+                    params: [
+                        Param {
+                            binding: b5,
+                            name: "s",
+                            ty: Some(
+                                TypeName {
+                                    name: "Shape",
+                                    args: [],
+                                    span: 649..654,
+                                },
+                            ),
+                            span: 646..654,
+                        },
+                    ],
+                    ret: Some(
+                        TypeName {
+                            name: "String",
+                            args: [],
+                            span: 657..663,
+                        },
+                    ),
+                    body: Expr {
+                        id: e25,
+                        kind: Match {
+                            scrutinee: Expr {
+                                id: e22,
+                                kind: Binary {
+                                    op: Gt,
+                                    lhs: Expr {
+                                        id: e20,
+                                        kind: Call {
+                                            callee: Expr {
+                                                id: e18,
+                                                kind: Global(
+                                                    "area",
+                                                ),
+                                                span: 675..679,
+                                            },
+                                            args: [
+                                                Expr {
+                                                    id: e19,
+                                                    kind: Local {
+                                                        binding: b5,
+                                                        name: "s",
+                                                    },
+                                                    span: 680..681,
+                                                },
+                                            ],
+                                        },
+                                        span: 675..682,
+                                    },
+                                    rhs: Expr {
+                                        id: e21,
+                                        kind: Number(
+                                            10.0,
+                                        ),
+                                        span: 685..689,
+                                    },
+                                },
+                                span: 675..689,
+                            },
+                            arms: [
+                                MatchArm {
+                                    pattern: Pattern {
+                                        kind: Bool(
+                                            true,
+                                        ),
+                                        span: 699..703,
+                                    },
+                                    body: Expr {
+                                        id: e23,
+                                        kind: String(
+                                            "big",
+                                        ),
+                                        span: 707..712,
+                                    },
+                                    span: 697..712,
+                                },
+                                MatchArm {
+                                    pattern: Pattern {
+                                        kind: Bool(
+                                            false,
+                                        ),
+                                        span: 717..722,
+                                    },
+                                    body: Expr {
+                                        id: e24,
+                                        kind: String(
+                                            "small",
+                                        ),
+                                        span: 726..733,
+                                    },
+                                    span: 715..733,
+                                },
+                            ],
+                        },
+                        span: 669..733,
+                    },
+                },
+                span: 645..733,
+            },
+            span: 632..733,
+        },
+        Def {
+            id: d5,
+            name: "describe",
+            value: Expr {
+                id: e52,
+                kind: Lambda {
+                    params: [
+                        Param {
+                            binding: b6,
+                            name: "s",
+                            ty: Some(
+                                TypeName {
+                                    name: "Shape",
+                                    args: [],
+                                    span: 961..966,
+                                },
+                            ),
+                            span: 958..966,
+                        },
+                    ],
+                    ret: Some(
+                        TypeName {
+                            name: "String",
+                            args: [],
+                            span: 969..975,
+                        },
+                    ),
+                    body: Expr {
+                        id: e51,
+                        kind: Match {
+                            scrutinee: Expr {
+                                id: e27,
+                                kind: Local {
+                                    binding: b6,
+                                    name: "s",
+                                },
+                                span: 987..988,
+                            },
+                            arms: [
+                                MatchArm {
+                                    pattern: Pattern {
+                                        kind: Ctor {
+                                            name: "Point",
+                                            args: [],
+                                        },
+                                        span: 998..1003,
+                                    },
+                                    body: Expr {
+                                        id: e28,
+                                        kind: String(
+                                            "a point",
+                                        ),
+                                        span: 1007..1016,
+                                    },
+                                    span: 996..1016,
+                                },
+                                MatchArm {
+                                    pattern: Pattern {
+                                        kind: Var {
+                                            binding: b7,
+                                            name: "other",
+                                        },
+                                        span: 1021..1026,
+                                    },
+                                    body: Expr {
+                                        id: e50,
+                                        kind: Match {
+                                            scrutinee: Expr {
+                                                id: e31,
+                                                kind: Call {
+                                                    callee: Expr {
+                                                        id: e29,
+                                                        kind: Global(
+                                                            "isRound",
+                                                        ),
+                                                        span: 1042..1049,
+                                                    },
+                                                    args: [
+                                                        Expr {
+                                                            id: e30,
+                                                            kind: Local {
+                                                                binding: b7,
+                                                                name: "other",
+                                                            },
+                                                            span: 1050..1055,
+                                                        },
+                                                    ],
+                                                },
+                                                span: 1042..1056,
+                                            },
+                                            arms: [
+                                                MatchArm {
+                                                    pattern: Pattern {
+                                                        kind: Bool(
+                                                            true,
+                                                        ),
+                                                        span: 1070..1074,
+                                                    },
+                                                    body: Expr {
+                                                        id: e40,
+                                                        kind: Call {
+                                                            callee: Expr {
+                                                                id: e32,
+                                                                kind: External(
+                                                                    [
+                                                                        "Text",
+                                                                        "concat",
+                                                                    ],
+                                                                ),
+                                                                span: 1078..1089,
+                                                            },
+                                                            args: [
+                                                                Expr {
+                                                                    id: e33,
+                                                                    kind: String(
+                                                                        "a round ",
+                                                                    ),
+                                                                    span: 1090..1100,
+                                                                },
+                                                                Expr {
+                                                                    id: e39,
+                                                                    kind: Call {
+                                                                        callee: Expr {
+                                                                            id: e34,
+                                                                            kind: External(
+                                                                                [
+                                                                                    "Text",
+                                                                                    "concat",
+                                                                                ],
+                                                                            ),
+                                                                            span: 1102..1113,
+                                                                        },
+                                                                        args: [
+                                                                            Expr {
+                                                                                id: e37,
+                                                                                kind: Call {
+                                                                                    callee: Expr {
+                                                                                        id: e35,
+                                                                                        kind: Global(
+                                                                                            "sizeOf",
+                                                                                        ),
+                                                                                        span: 1114..1120,
+                                                                                    },
+                                                                                    args: [
+                                                                                        Expr {
+                                                                                            id: e36,
+                                                                                            kind: Local {
+                                                                                                binding: b7,
+                                                                                                name: "other",
+                                                                                            },
+                                                                                            span: 1121..1126,
+                                                                                        },
+                                                                                    ],
+                                                                                },
+                                                                                span: 1114..1127,
+                                                                            },
+                                                                            Expr {
+                                                                                id: e38,
+                                                                                kind: String(
+                                                                                    " shape",
+                                                                                ),
+                                                                                span: 1129..1137,
+                                                                            },
+                                                                        ],
+                                                                    },
+                                                                    span: 1102..1138,
+                                                                },
+                                                            ],
+                                                        },
+                                                        span: 1078..1139,
+                                                    },
+                                                    span: 1068..1139,
+                                                },
+                                                MatchArm {
+                                                    pattern: Pattern {
+                                                        kind: Bool(
+                                                            false,
+                                                        ),
+                                                        span: 1148..1153,
+                                                    },
+                                                    body: Expr {
+                                                        id: e49,
+                                                        kind: Call {
+                                                            callee: Expr {
+                                                                id: e41,
+                                                                kind: External(
+                                                                    [
+                                                                        "Text",
+                                                                        "concat",
+                                                                    ],
+                                                                ),
+                                                                span: 1157..1168,
+                                                            },
+                                                            args: [
+                                                                Expr {
+                                                                    id: e42,
+                                                                    kind: String(
+                                                                        "a boxy ",
+                                                                    ),
+                                                                    span: 1169..1178,
+                                                                },
+                                                                Expr {
+                                                                    id: e48,
+                                                                    kind: Call {
+                                                                        callee: Expr {
+                                                                            id: e43,
+                                                                            kind: External(
+                                                                                [
+                                                                                    "Text",
+                                                                                    "concat",
+                                                                                ],
+                                                                            ),
+                                                                            span: 1180..1191,
+                                                                        },
+                                                                        args: [
+                                                                            Expr {
+                                                                                id: e46,
+                                                                                kind: Call {
+                                                                                    callee: Expr {
+                                                                                        id: e44,
+                                                                                        kind: Global(
+                                                                                            "sizeOf",
+                                                                                        ),
+                                                                                        span: 1192..1198,
+                                                                                    },
+                                                                                    args: [
+                                                                                        Expr {
+                                                                                            id: e45,
+                                                                                            kind: Local {
+                                                                                                binding: b7,
+                                                                                                name: "other",
+                                                                                            },
+                                                                                            span: 1199..1204,
+                                                                                        },
+                                                                                    ],
+                                                                                },
+                                                                                span: 1192..1205,
+                                                                            },
+                                                                            Expr {
+                                                                                id: e47,
+                                                                                kind: String(
+                                                                                    " shape",
+                                                                                ),
+                                                                                span: 1207..1215,
+                                                                            },
+                                                                        ],
+                                                                    },
+                                                                    span: 1180..1216,
+                                                                },
+                                                            ],
+                                                        },
+                                                        span: 1157..1217,
+                                                    },
+                                                    span: 1146..1217,
+                                                },
+                                            ],
+                                        },
+                                        span: 1036..1217,
+                                    },
+                                    span: 1019..1217,
+                                },
+                            ],
+                        },
+                        span: 981..1217,
+                    },
+                },
+                span: 957..1217,
+            },
+            span: 942..1217,
+        },
+        Def {
+            id: d6,
+            name: "shapes",
+            value: Expr {
+                id: e61,
+                kind: List(
+                    [
+                        Expr {
+                            id: e55,
+                            kind: Call {
+                                callee: Expr {
+                                    id: e53,
+                                    kind: Ctor {
+                                        name: "Circle",
+                                        arity: 1,
+                                    },
+                                    span: 1233..1239,
+                                },
+                                args: [
+                                    Expr {
+                                        id: e54,
+                                        kind: Number(
+                                            2.0,
+                                        ),
+                                        span: 1240..1243,
+                                    },
+                                ],
+                            },
+                            span: 1233..1244,
+                        },
+                        Expr {
+                            id: e59,
+                            kind: Call {
+                                callee: Expr {
+                                    id: e56,
+                                    kind: Ctor {
+                                        name: "Rect",
+                                        arity: 2,
+                                    },
+                                    span: 1246..1250,
+                                },
+                                args: [
+                                    Expr {
+                                        id: e57,
+                                        kind: Number(
+                                            3.0,
+                                        ),
+                                        span: 1251..1254,
+                                    },
+                                    Expr {
+                                        id: e58,
+                                        kind: Number(
+                                            4.0,
+                                        ),
+                                        span: 1256..1259,
+                                    },
+                                ],
+                            },
+                            span: 1246..1260,
+                        },
+                        Expr {
+                            id: e60,
+                            kind: Ctor {
+                                name: "Point",
+                                arity: 0,
+                            },
+                            span: 1262..1267,
+                        },
+                    ],
+                ),
+                span: 1232..1268,
+            },
+            span: 1219..1268,
+        },
+        Def {
+            id: d7,
+            name: "main",
+            value: Expr {
+                id: e68,
+                kind: Lambda {
+                    params: [],
+                    ret: None,
+                    body: Expr {
+                        id: e67,
+                        kind: Call {
+                            callee: Expr {
+                                id: e66,
+                                kind: External(
+                                    [
+                                        "Text",
+                                        "toBullets",
+                                    ],
+                                ),
+                                span: 1321..1335,
+                            },
+                            args: [
+                                Expr {
+                                    id: e65,
+                                    kind: Call {
+                                        callee: Expr {
+                                            id: e63,
+                                            kind: External(
+                                                [
+                                                    "List",
+                                                    "map",
+                                                ],
+                                            ),
+                                            span: 1299..1307,
+                                        },
+                                        args: [
+                                            Expr {
+                                                id: e62,
+                                                kind: Global(
+                                                    "shapes",
+                                                ),
+                                                span: 1289..1295,
+                                            },
+                                            Expr {
+                                                id: e64,
+                                                kind: Global(
+                                                    "describe",
+                                                ),
+                                                span: 1308..1316,
+                                            },
+                                        ],
+                                    },
+                                    span: 1299..1317,
+                                },
+                            ],
+                        },
+                        span: 1321..1335,
+                    },
+                },
+                span: 1281..1335,
+            },
+            span: 1270..1335,
+        },
+    ],
+}

--- a/mle/examples/shapes.mle
+++ b/mle/examples/shapes.mle
@@ -1,0 +1,44 @@
+// Shapes as a variant type — constructor declarations and calls, and every
+// B5 pattern kind: constructors with bindings, a nullary constructor, `_`
+// wildcards (top-level and inside a constructor), bool-literal arms (the
+// language's first conditional), and a catch-all variable.
+
+type Shape =
+  | Circle(radius: Float)
+  | Rect(w: Float, h: Float)
+  | Point
+
+let pi = 3.14159
+
+let area = (s: Shape): Float =>
+  match s with
+  | Circle(r) => pi * r * r
+  | Rect(w, h) => w * h
+  | Point => 0.0
+
+let isRound = (s: Shape): Bool =>
+  match s with
+  | Circle(_) => true
+  | _ => false
+
+// The first conditional: match on a Bool.
+let sizeOf = (s: Shape): String =>
+  match area(s) > 10.0 with
+  | true => "big"
+  | false => "small"
+
+// Arm bodies are full expressions, so this nested match is greedy: it is
+// only unambiguous because it sits in the LAST arm — anywhere else it would
+// need parentheses (see the parser's grammar notes).
+let describe = (s: Shape): String =>
+  match s with
+  | Point => "a point"
+  | other =>
+      match isRound(other) with
+      | true => Text.concat("a round ", Text.concat(sizeOf(other), " shape"))
+      | false => Text.concat("a boxy ", Text.concat(sizeOf(other), " shape"))
+
+let shapes = [Circle(2.0), Rect(3.0, 4.0), Point]
+
+let main = () =>
+  shapes |> List.map(describe) |> Text.toBullets

--- a/mle/examples/shapes.run
+++ b/mle/examples/shapes.run
@@ -1,0 +1,1 @@
+"- a round big shape\n- a boxy big shape\n- a point"

--- a/mle/src/ast.rs
+++ b/mle/src/ast.rs
@@ -6,7 +6,6 @@
 //! shape makes error spans and future formatting honest.
 
 use crate::span::Span;
-use std::fmt;
 
 #[derive(Debug)]
 pub struct Program {
@@ -29,24 +28,11 @@ pub struct LetDecl {
 
 /// `type Position = { x: Float, y: Float }` (a record type) or
 /// `type Shape = | Circle(radius: Float) | Point` (a variant type).
+#[derive(Debug)]
 pub struct TypeDecl {
     pub name: String,
     pub body: TypeBody,
     pub span: Span,
-}
-
-// Hand-written so the pretty-Debug output (and the committed `.ast` goldens)
-// keeps the pre-variant `fields:` shape for record declarations.
-impl fmt::Debug for TypeDecl {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut s = f.debug_struct("TypeDecl");
-        s.field("name", &self.name);
-        match &self.body {
-            TypeBody::Record(fields) => s.field("fields", fields),
-            TypeBody::Variants(variants) => s.field("variants", variants),
-        };
-        s.field("span", &self.span).finish()
-    }
 }
 
 /// What a `type` declares: a record shape, or one-or-more variant

--- a/mle/src/ast.rs
+++ b/mle/src/ast.rs
@@ -6,6 +6,7 @@
 //! shape makes error spans and future formatting honest.
 
 use crate::span::Span;
+use std::fmt;
 
 #[derive(Debug)]
 pub struct Program {
@@ -26,9 +27,41 @@ pub struct LetDecl {
     pub span: Span,
 }
 
-/// `type Position = { x: Float, y: Float }` — record types only in B1.
-#[derive(Debug)]
+/// `type Position = { x: Float, y: Float }` (a record type) or
+/// `type Shape = | Circle(radius: Float) | Point` (a variant type).
 pub struct TypeDecl {
+    pub name: String,
+    pub body: TypeBody,
+    pub span: Span,
+}
+
+// Hand-written so the pretty-Debug output (and the committed `.ast` goldens)
+// keeps the pre-variant `fields:` shape for record declarations.
+impl fmt::Debug for TypeDecl {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut s = f.debug_struct("TypeDecl");
+        s.field("name", &self.name);
+        match &self.body {
+            TypeBody::Record(fields) => s.field("fields", fields),
+            TypeBody::Variants(variants) => s.field("variants", variants),
+        };
+        s.field("span", &self.span).finish()
+    }
+}
+
+/// What a `type` declares: a record shape, or one-or-more variant
+/// constructors (each `|`-led, including the first).
+#[derive(Debug)]
+pub enum TypeBody {
+    Record(Vec<FieldTy>),
+    Variants(Vec<VariantDecl>),
+}
+
+/// One `| Ctor(name: Type, …)` / `| Ctor` alternative of a variant type.
+/// Fields are named in the declaration (self-documenting) but constructors
+/// are *called* positionally: `Circle(2.0)`.
+#[derive(Debug)]
+pub struct VariantDecl {
     pub name: String,
     pub fields: Vec<FieldTy>,
     pub span: Span,
@@ -130,6 +163,48 @@ pub enum ExprKind {
     },
     /// Unary minus.
     Neg(Box<Expr>),
+    /// `match expr with | pattern => expr | …` — first matching arm wins,
+    /// top to bottom. Arm bodies are full expressions, so a nested `match`
+    /// inside an arm greedily consumes the following `|` arms — parenthesize
+    /// inner matches (the F#/OCaml convention; see [`crate::parser`]).
+    Match {
+        scrutinee: Box<Expr>,
+        arms: Vec<MatchArm>,
+    },
+}
+
+/// One `| pattern => body` arm of a `match`.
+#[derive(Debug)]
+pub struct MatchArm {
+    pub pattern: Pattern,
+    pub body: Expr,
+    pub span: Span,
+}
+
+#[derive(Debug)]
+pub struct Pattern {
+    pub kind: PatternKind,
+    pub span: Span,
+}
+
+/// The deliberately-minimal B5 pattern language: constructor patterns whose
+/// sub-patterns are variable bindings or `_` (no deeper nesting), bare
+/// variables, `_`, and literal (equality) patterns.
+#[derive(Debug)]
+pub enum PatternKind {
+    /// `_` — matches anything, binds nothing.
+    Wildcard,
+    /// A bare lowercase name — matches anything, binds it.
+    Var(String),
+    /// `Circle(r)` / `Point` — an uppercase name is always a constructor
+    /// pattern (never a variable).
+    Ctor {
+        name: String,
+        args: Vec<Pattern>,
+    },
+    Number(f64),
+    Bool(bool),
+    String(String),
 }
 
 /// One `name: value` entry of a record expression.

--- a/mle/src/eval.rs
+++ b/mle/src/eval.rs
@@ -30,7 +30,7 @@
 //! marker event) after [`MAX_TRACE_EVENTS`] so a hot loop can't produce an
 //! unbounded transcript; evaluation itself continues.
 
-use crate::ir::{Def, Expr, ExprKind, Module};
+use crate::ir::{BindingId, Def, Expr, ExprKind, Module, Pattern, PatternKind};
 use crate::span::Span;
 use crate::value::{Closure, Env, Value};
 use crate::RunError;
@@ -259,13 +259,15 @@ impl Interp<'_> {
             Value::Closure(closure) if closure.params.is_empty() => {
                 self.call(main.clone(), vec![], "main".to_string(), def.span, None)
             }
-            // Builtins and host functions take arguments by definition, so
-            // they get the same error as a parameterful closure rather than
-            // printing as a value.
-            Value::Closure(_) | Value::Builtin(_) | Value::HostFn(_) => Err(RunError {
-                message: "`main` must take no parameters to be runnable".to_string(),
-                span: def.span,
-            }),
+            // Builtins, host functions, and unapplied constructors take
+            // arguments by definition, so they get the same error as a
+            // parameterful closure rather than printing as a value.
+            Value::Closure(_) | Value::Builtin(_) | Value::HostFn(_) | Value::Ctor { .. } => {
+                Err(RunError {
+                    message: "`main` must take no parameters to be runnable".to_string(),
+                    span: def.span,
+                })
+            }
             // A non-function `main` is just a value; report it directly.
             _ => Ok(main),
         }
@@ -473,6 +475,36 @@ impl Interp<'_> {
                     span: expr.span,
                 }),
             },
+            // A nullary constructor used bare IS the variant value; a
+            // parameterful one is a callable constructor (so `List.map(xs,
+            // Circle)` works like any function argument).
+            ExprKind::Ctor { name, arity } => {
+                if *arity == 0 {
+                    Ok(Value::Variant {
+                        ctor: Rc::from(name.as_str()),
+                        args: Rc::new(Vec::new()),
+                    })
+                } else {
+                    Ok(Value::Ctor {
+                        name: Rc::from(name.as_str()),
+                        arity: *arity,
+                    })
+                }
+            }
+            ExprKind::Match { scrutinee, arms } => {
+                let value = self.eval(scrutinee, env)?;
+                for arm in arms {
+                    let mut vars = Vec::new();
+                    if match_pattern(&arm.pattern, &value, &mut vars) {
+                        let child = env.child(vars);
+                        return self.eval(&arm.body, &child);
+                    }
+                }
+                Err(RunError {
+                    message: format!("no pattern matched {value}"),
+                    span: expr.span,
+                })
+            }
         }
     }
 
@@ -572,6 +604,23 @@ impl Interp<'_> {
                     let env = closure.env.child(vars);
                     let body = closure.body.clone();
                     self.eval(&body, &env)
+                }
+            }
+            Value::Ctor { name, arity } => {
+                if args.len() != *arity {
+                    let who = match via {
+                        Some(builtin) => format!("the function passed to {builtin}"),
+                        None => format!("`{label}`"),
+                    };
+                    Err(RunError {
+                        message: format!("{who} takes {arity} argument(s), got {}", args.len()),
+                        span,
+                    })
+                } else {
+                    Ok(Value::Variant {
+                        ctor: name.clone(),
+                        args: Rc::new(args),
+                    })
                 }
             }
             Value::Builtin(b) => self.call_builtin(*b, args, span),
@@ -779,6 +828,38 @@ impl Interp<'_> {
     }
 }
 
+/// Does `pattern` match `value`? Appends each pattern variable's binding on
+/// the way (bindings are only used if the whole pattern matched — a pattern
+/// either fully matches or its arm is skipped, and sub-patterns are leaves,
+/// so a partial append can never observe a half-match). Pure: literal
+/// patterns compare primitively, so no function-equality error can arise.
+fn match_pattern(pattern: &Pattern, value: &Value, vars: &mut Vec<(BindingId, Value)>) -> bool {
+    match &pattern.kind {
+        PatternKind::Wildcard => true,
+        PatternKind::Var { binding, .. } => {
+            vars.push((*binding, value.clone()));
+            true
+        }
+        PatternKind::Ctor { name, args } => match value {
+            // Same constructor AND same arg count: lowering fixes the
+            // pattern's arity to the declaration, but the VALUE may come
+            // from a host (`Session::call`) — mismatched args are a
+            // non-match, not UB.
+            Value::Variant { ctor, args: vals } if ctor.as_ref() == name => {
+                args.len() == vals.len()
+                    && args
+                        .iter()
+                        .zip(vals.iter())
+                        .all(|(p, v)| match_pattern(p, v, vars))
+            }
+            _ => false,
+        },
+        PatternKind::Number(n) => matches!(value, Value::Number(v) if v == n),
+        PatternKind::Bool(b) => matches!(value, Value::Bool(v) if v == b),
+        PatternKind::String(s) => matches!(value, Value::String(v) if v.as_ref() == s),
+    }
+}
+
 /// Structural equality for `==`. Functions have no equality — comparing them
 /// is a runtime error rather than a silent `false`.
 fn value_eq(a: &Value, b: &Value, span: Span) -> Result<bool, RunError> {
@@ -809,11 +890,27 @@ fn value_eq(a: &Value, b: &Value, span: Span) -> Result<bool, RunError> {
             }
             Ok(true)
         }
-        (Value::Closure(_) | Value::Builtin(_) | Value::HostFn(_), _)
-        | (_, Value::Closure(_) | Value::Builtin(_) | Value::HostFn(_)) => Err(RunError {
-            message: "functions cannot be compared with `==`".to_string(),
-            span,
-        }),
+        // Structural: same constructor, equal args (a function argument
+        // still raises the function-comparison error below).
+        (Value::Variant { ctor: xc, args: xs }, Value::Variant { ctor: yc, args: ys }) => {
+            if xc != yc || xs.len() != ys.len() {
+                return Ok(false);
+            }
+            for (x, y) in xs.iter().zip(ys.iter()) {
+                if !value_eq(x, y, span)? {
+                    return Ok(false);
+                }
+            }
+            Ok(true)
+        }
+        // An unapplied constructor is a function value — no equality.
+        (Value::Closure(_) | Value::Builtin(_) | Value::HostFn(_) | Value::Ctor { .. }, _)
+        | (_, Value::Closure(_) | Value::Builtin(_) | Value::HostFn(_) | Value::Ctor { .. }) => {
+            Err(RunError {
+                message: "functions cannot be compared with `==`".to_string(),
+                span,
+            })
+        }
         (Value::HostData(_), _) | (_, Value::HostData(_)) => Err(RunError {
             message: "host values cannot be compared with `==`".to_string(),
             span,
@@ -832,6 +929,7 @@ pub(crate) fn callee_label(callee: &Expr) -> String {
         ExprKind::Global(name) => name.clone(),
         ExprKind::Local { name, .. } => name.clone(),
         ExprKind::External(path) => path.join("."),
+        ExprKind::Ctor { name, .. } => name.clone(),
         _ => "<lambda>".to_string(),
     }
 }

--- a/mle/src/hover.rs
+++ b/mle/src/hover.rs
@@ -11,7 +11,7 @@
 //! typed; see [`crate::types`]).
 
 use crate::ast::TypeName;
-use crate::ir::{Expr, ExprKind, Module};
+use crate::ir::{Expr, ExprKind, Module, Pattern, PatternKind};
 use crate::span::Span;
 use crate::types::{ExprTypes, Type};
 
@@ -35,10 +35,7 @@ pub fn hover_text(module: &Module, types: &ExprTypes, offset: usize) -> Option<(
         // The definition name itself: inside the def's span but before its
         // value (i.e. the `let name =` part).
         if def.span.start <= offset && offset < def.value.span.start {
-            let ty = types
-                .get(&def.value.id.raw())
-                .cloned()
-                .unwrap_or(Type::Unknown);
+            let ty = types.expr(def.value.id).cloned().unwrap_or(Type::Unknown);
             consider(
                 Span::new(def.span.start, def.value.span.start),
                 format!("{} : {ty}", def.name),
@@ -50,9 +47,14 @@ pub fn hover_text(module: &Module, types: &ExprTypes, offset: usize) -> Option<(
 }
 
 fn visit(expr: &Expr, types: &ExprTypes, consider: &mut impl FnMut(Span, String)) {
-    let ty = types.get(&expr.id.raw()).cloned().unwrap_or(Type::Unknown);
+    let ty = types.expr(expr.id).cloned().unwrap_or(Type::Unknown);
     match &expr.kind {
         ExprKind::Local { name, .. } | ExprKind::Global(name) => {
+            consider(expr.span, format!("{name} : {ty}"));
+        }
+        // A constructor reference hovers with its signature
+        // (`Circle : (Float) => Shape`; nullary: `Point : Shape`).
+        ExprKind::Ctor { name, .. } => {
             consider(expr.span, format!("{name} : {ty}"));
         }
         ExprKind::LocalMut { name, .. } => {
@@ -70,7 +72,7 @@ fn visit(expr: &Expr, types: &ExprTypes, consider: &mut impl FnMut(Span, String)
         } => {
             // The binder-name region (`let [mut] name =`), like def names.
             if expr.span.start < value.span.start {
-                let value_ty = types.get(&value.id.raw()).cloned().unwrap_or(Type::Unknown);
+                let value_ty = types.expr(value.id).cloned().unwrap_or(Type::Unknown);
                 let label = if *mutable {
                     format!("mut {name} : {value_ty}")
                 } else {
@@ -94,6 +96,14 @@ fn visit(expr: &Expr, types: &ExprTypes, consider: &mut impl FnMut(Span, String)
             }
             visit(body, types, consider);
         }
+        ExprKind::Match { scrutinee, arms } => {
+            consider(expr.span, ty.to_string());
+            visit(scrutinee, types, consider);
+            for arm in arms {
+                pattern_vars(&arm.pattern, types, consider);
+                visit(&arm.body, types, consider);
+            }
+        }
         _ => {
             consider(expr.span, ty.to_string());
             for child in children(expr) {
@@ -103,7 +113,28 @@ fn visit(expr: &Expr, types: &ExprTypes, consider: &mut impl FnMut(Span, String)
     }
 }
 
-/// The direct sub-expressions of a node (Lambda handled by the caller).
+/// Pattern variables hover like binder names: `name : Type`, from the
+/// checker's binding table (a pattern variable has no expression node).
+fn pattern_vars(pattern: &Pattern, types: &ExprTypes, consider: &mut impl FnMut(Span, String)) {
+    match &pattern.kind {
+        PatternKind::Var { binding, name } => {
+            let ty = types.binding(*binding).cloned().unwrap_or(Type::Unknown);
+            consider(pattern.span, format!("{name} : {ty}"));
+        }
+        PatternKind::Ctor { args, .. } => {
+            for arg in args {
+                pattern_vars(arg, types, consider);
+            }
+        }
+        PatternKind::Wildcard
+        | PatternKind::Number(_)
+        | PatternKind::Bool(_)
+        | PatternKind::String(_) => {}
+    }
+}
+
+/// The direct sub-expressions of a node (Lambda and Match handled by the
+/// caller).
 fn children(expr: &Expr) -> Vec<&Expr> {
     match &expr.kind {
         ExprKind::Record(fields) => fields.iter().map(|f| &f.value).collect(),
@@ -119,6 +150,9 @@ fn children(expr: &Expr) -> Vec<&Expr> {
         ExprKind::Neg(inner) => vec![inner],
         ExprKind::Let { value, body, .. } => vec![value, body],
         ExprKind::Assign { value, rest, .. } => vec![value, rest],
+        ExprKind::Match { scrutinee, arms } => std::iter::once(scrutinee.as_ref())
+            .chain(arms.iter().map(|arm| &arm.body))
+            .collect(),
         ExprKind::Number(_)
         | ExprKind::String(_)
         | ExprKind::Bool(_)
@@ -126,6 +160,7 @@ fn children(expr: &Expr) -> Vec<&Expr> {
         | ExprKind::LocalMut { .. }
         | ExprKind::Global(_)
         | ExprKind::External(_)
+        | ExprKind::Ctor { .. }
         | ExprKind::Lambda { .. } => vec![],
     }
 }
@@ -205,6 +240,49 @@ mod tests {
         let module = crate::lower(crate::parse(src).unwrap()).unwrap();
         let (_, types) = check_with_types(&module);
         assert!(hover_text(&module, &types, src.len()).is_none());
+    }
+
+    // --- Variants + match (B5 part 1) ---
+
+    const SHAPE: &str = "type Shape = | Circle(r: Float) | Point\n";
+
+    #[test]
+    fn hover_on_a_ctor_shows_its_signature() {
+        let src = format!("{SHAPE}let c = Circle(2.0)");
+        let text = hover_at(&src, "Circle(2.0)").unwrap();
+        assert_eq!(text, "Circle : (Float) => Shape");
+    }
+
+    #[test]
+    fn hover_on_a_nullary_ctor_shows_the_variant_type() {
+        let src = format!("{SHAPE}let p = Point");
+        let offset = src.rfind("Point").unwrap();
+        let module = crate::lower(crate::parse(&src).unwrap()).unwrap();
+        let (_, types) = check_with_types(&module);
+        let (_, text) = hover_text(&module, &types, offset).unwrap();
+        assert_eq!(text, "Point : Shape");
+    }
+
+    #[test]
+    fn hover_on_a_pattern_var_shows_the_field_type() {
+        let src =
+            format!("{SHAPE}let f = (s: Shape): Float => match s with | Circle(r) => r | _ => 0.0");
+        let text = hover_at(&src, "r) =>").unwrap();
+        assert_eq!(text, "r : Float");
+    }
+
+    #[test]
+    fn hover_on_a_catch_all_var_shows_the_scrutinee_type() {
+        let src = format!("{SHAPE}let f = (s: Shape): Float => match s with | other => 0.0");
+        let text = hover_at(&src, "other =>").unwrap();
+        assert_eq!(text, "other : Shape");
+    }
+
+    #[test]
+    fn hover_on_a_match_shows_its_joined_type() {
+        let src = "let f = (b: Bool) => match b with | true => 1.0 | false => 0.0";
+        let text = hover_at(src, "match").unwrap();
+        assert_eq!(text, "Float");
     }
 }
 

--- a/mle/src/hover.rs
+++ b/mle/src/hover.rs
@@ -150,10 +150,10 @@ fn children(expr: &Expr) -> Vec<&Expr> {
         ExprKind::Neg(inner) => vec![inner],
         ExprKind::Let { value, body, .. } => vec![value, body],
         ExprKind::Assign { value, rest, .. } => vec![value, rest],
-        ExprKind::Match { scrutinee, arms } => std::iter::once(scrutinee.as_ref())
-            .chain(arms.iter().map(|arm| &arm.body))
-            .collect(),
-        ExprKind::Number(_)
+        // Match is caller-handled (see the doc comment): `visit` must walk
+        // pattern-var spans too, which are not expression nodes.
+        ExprKind::Match { .. }
+        | ExprKind::Number(_)
         | ExprKind::String(_)
         | ExprKind::Bool(_)
         | ExprKind::Local { .. }

--- a/mle/src/ir.rs
+++ b/mle/src/ir.rs
@@ -17,7 +17,7 @@
 //! - **Type annotations stay symbolic** ([`TypeName`] carried through
 //!   verbatim) — no inference or checking until B4.
 
-use crate::ast::{BinOp, FieldTy, TypeName};
+use crate::ast::{BinOp, TypeBody, TypeName};
 use crate::span::Span;
 use std::fmt;
 use std::rc::Rc;
@@ -70,14 +70,30 @@ pub struct Module {
     pub defs: Vec<Def>,
 }
 
-/// `type Position = { x: Float, y: Float }` — fields keep their symbolic
-/// [`TypeName`]s; other types reference this one by name.
-#[derive(Debug)]
+/// `type Position = { x: Float, y: Float }` or
+/// `type Shape = | Circle(radius: Float) | Point` — the body ([`TypeBody`])
+/// is carried through from the AST verbatim, fields keeping their symbolic
+/// [`TypeName`]s; other types reference this one by name. Constructor names
+/// live in the *value* namespace (see [`crate::lower`]).
 pub struct TypeDef {
     pub id: DefId,
     pub name: String,
-    pub fields: Vec<FieldTy>,
+    pub body: TypeBody,
     pub span: Span,
+}
+
+// Hand-written so the pretty-Debug output (and the committed `.ir` goldens)
+// keeps the pre-variant `fields:` shape for record declarations.
+impl fmt::Debug for TypeDef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut s = f.debug_struct("TypeDef");
+        s.field("id", &self.id).field("name", &self.name);
+        match &self.body {
+            TypeBody::Record(fields) => s.field("fields", fields),
+            TypeBody::Variants(variants) => s.field("variants", variants),
+        };
+        s.field("span", &self.span).finish()
+    }
 }
 
 /// A lowered top-level `let`. `name` is the def's stable identity.
@@ -166,6 +182,58 @@ pub enum ExprKind {
         rhs: Box<Expr>,
     },
     Neg(Box<Expr>),
+    /// Reference to a declared variant constructor (an uppercase identifier
+    /// that resolved against the module's constructors — see
+    /// [`crate::lower`]). `arity` is the declared field count, carried here
+    /// so evaluation needs no type-table lookup: a nullary constructor
+    /// evaluates directly to its variant value, a parameterful one to a
+    /// callable constructor value.
+    Ctor {
+        name: String,
+        arity: usize,
+    },
+    /// `match scrutinee with | pattern => body | …` — first matching arm
+    /// wins; no arm matching is a runtime error.
+    Match {
+        scrutinee: Box<Expr>,
+        arms: Vec<MatchArm>,
+    },
+}
+
+/// One lowered `| pattern => body` arm. Pattern variables are bindings
+/// scoped to `body` (they may shadow; duplicates within one pattern are
+/// lowering errors).
+#[derive(Debug)]
+pub struct MatchArm {
+    pub pattern: Pattern,
+    pub body: Expr,
+    pub span: Span,
+}
+
+#[derive(Debug)]
+pub struct Pattern {
+    pub kind: PatternKind,
+    pub span: Span,
+}
+
+/// The lowered pattern language (see [`crate::ast::PatternKind`]);
+/// variables carry their [`BindingId`]s.
+#[derive(Debug)]
+pub enum PatternKind {
+    Wildcard,
+    Var {
+        binding: BindingId,
+        name: String,
+    },
+    /// Lowering guarantees `name` is a declared constructor and `args`
+    /// matches its declared field count.
+    Ctor {
+        name: String,
+        args: Vec<Pattern>,
+    },
+    Number(f64),
+    Bool(bool),
+    String(String),
 }
 
 /// One `name: value` entry of a record expression.

--- a/mle/src/ir.rs
+++ b/mle/src/ir.rs
@@ -75,25 +75,12 @@ pub struct Module {
 /// is carried through from the AST verbatim, fields keeping their symbolic
 /// [`TypeName`]s; other types reference this one by name. Constructor names
 /// live in the *value* namespace (see [`crate::lower`]).
+#[derive(Debug)]
 pub struct TypeDef {
     pub id: DefId,
     pub name: String,
     pub body: TypeBody,
     pub span: Span,
-}
-
-// Hand-written so the pretty-Debug output (and the committed `.ir` goldens)
-// keeps the pre-variant `fields:` shape for record declarations.
-impl fmt::Debug for TypeDef {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut s = f.debug_struct("TypeDef");
-        s.field("id", &self.id).field("name", &self.name);
-        match &self.body {
-            TypeBody::Record(fields) => s.field("fields", fields),
-            TypeBody::Variants(variants) => s.field("variants", variants),
-        };
-        s.field("span", &self.span).finish()
-    }
 }
 
 /// A lowered top-level `let`. `name` is the def's stable identity.

--- a/mle/src/lexer.rs
+++ b/mle/src/lexer.rs
@@ -17,6 +17,7 @@ pub enum TokenKind {
     Mut,
     With,
     In,
+    Match,
     LParen,
     RParen,
     LBrace,
@@ -32,6 +33,7 @@ pub enum TokenKind {
     EqEq,
     FatArrow,
     PipeGt,
+    Pipe,
     Plus,
     Minus,
     Star,
@@ -61,6 +63,7 @@ pub fn describe(kind: &TokenKind) -> String {
         Mut => "`mut`".to_string(),
         With => "`with`".to_string(),
         In => "`in`".to_string(),
+        Match => "`match`".to_string(),
         LParen => "`(`".to_string(),
         RParen => "`)`".to_string(),
         LBrace => "`{`".to_string(),
@@ -76,6 +79,7 @@ pub fn describe(kind: &TokenKind) -> String {
         EqEq => "`==`".to_string(),
         FatArrow => "`=>`".to_string(),
         PipeGt => "`|>`".to_string(),
+        Pipe => "`|`".to_string(),
         Plus => "`+`".to_string(),
         Minus => "`-`".to_string(),
         Star => "`*`".to_string(),
@@ -194,11 +198,10 @@ pub fn lex(src: &str) -> Result<Vec<Token>, ParseError> {
                     i += 2;
                     TokenKind::PipeGt
                 }
+                // Bare `|` begins a variant alternative or a match arm.
                 _ => {
-                    return Err(ParseError {
-                        message: "unexpected character `|`".to_string(),
-                        span: Span::new(i, i + 1),
-                    })
+                    i += 1;
+                    TokenKind::Pipe
                 }
             },
             b'"' => {
@@ -231,6 +234,7 @@ pub fn lex(src: &str) -> Result<Vec<Token>, ParseError> {
                     "mut" => TokenKind::Mut,
                     "with" => TokenKind::With,
                     "in" => TokenKind::In,
+                    "match" => TokenKind::Match,
                     name => TokenKind::Ident(name.to_string()),
                 }
             }

--- a/mle/src/lower.rs
+++ b/mle/src/lower.rs
@@ -91,6 +91,15 @@ pub fn lower(program: ast::Program) -> Result<Module, LowerError> {
                 }
             }
             ast::Item::Type(decl) => {
+                // Builtin type names would shadow the primitives in
+                // annotations (the checker resolves `Float` before user
+                // types), yielding nonsense like "expected Float, got Float".
+                if matches!(decl.name.as_str(), "Float" | "Bool" | "String" | "List") {
+                    return Err(LowerError {
+                        message: format!("cannot redeclare builtin type `{}`", decl.name),
+                        span: decl.span,
+                    });
+                }
                 if !type_names.insert(decl.name.clone()) {
                     return Err(LowerError {
                         message: format!("duplicate definition `{}`", decl.name),

--- a/mle/src/lower.rs
+++ b/mle/src/lower.rs
@@ -11,8 +11,12 @@
 //! names are lowering errors rather than shadowing. Types and values are
 //! **separate namespaces** (as in F#/OCaml): `type Foo` and `let Foo` may
 //! coexist — each namespace keys its own identities — but a duplicate within
-//! either namespace is an error. Duplicate parameter names within one lambda
-//! are errors for the same reason (the last one would silently win).
+//! either namespace is an error. **Constructors live in the value
+//! namespace**: they resolve bare (`Circle(2.0)`, not `Shape.Circle`), so a
+//! constructor name must be unique across every variant type in the module
+//! AND must not collide with a top-level `let` — both are lowering errors.
+//! Duplicate parameter names within one lambda are errors for the same
+//! reason (the last one would silently win).
 //!
 //! ## Name resolution
 //!
@@ -21,13 +25,26 @@
 //! [`crate::ast::ExprKind::Ident`]):
 //!
 //! - `first` names an enclosing lambda parameter → [`ExprKind::Local`]
-//!   (innermost scope wins, so a parameter shadows a same-named global);
-//!   any remaining segments become [`ExprKind::FieldAccess`] on it.
+//!   (innermost scope wins, so a parameter — or a pattern variable — shadows
+//!   a same-named global or constructor); any remaining segments become
+//!   [`ExprKind::FieldAccess`] on it.
 //! - `first` names a top-level `let` → [`ExprKind::Global`]; remaining
 //!   segments likewise become field access.
+//! - `first` names a declared variant constructor → [`ExprKind::Ctor`]
+//!   (the `Type.Ctor` qualified form is deliberately NOT supported — a
+//!   qualified name whose head is a type name stays an unknown external).
 //! - Otherwise, a qualified name (`Text.toBullets`) → [`ExprKind::External`],
 //!   kept symbolic until the builtin registry arrives in B3 — and an
 //!   unqualified name is an "unknown name" error at the identifier's span.
+//!
+//! ## Match lowering
+//!
+//! Pattern variables get fresh [`BindingId`]s scoped to their arm's body
+//! (each arm is its own scope level — bindings never leak between arms);
+//! they are plain immutable bindings, so lambdas may capture them. A
+//! duplicate variable within one pattern, an unknown constructor in a
+//! pattern, and a constructor pattern whose sub-pattern count differs from
+//! the declared field count are all lowering errors.
 //!
 //! ## Pipeline desugaring
 //!
@@ -42,31 +59,73 @@ use crate::ast;
 use crate::ir::*;
 use crate::span::Span;
 use crate::LowerError;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 /// Lower a parsed [`ast::Program`] to an IR [`Module`].
 pub fn lower(program: ast::Program) -> Result<Module, LowerError> {
     // Pass 1: collect top-level names so defs are mutually visible (see
     // module docs) and duplicates fail loud. Types and values are separate
-    // namespaces.
+    // namespaces; constructors join the VALUE namespace (they resolve bare),
+    // so they must not collide with `let`s or with each other — across
+    // variant types too.
     let mut globals = HashSet::new();
+    let mut ctors: HashMap<String, usize> = HashMap::new();
     let mut type_names = HashSet::new();
     for item in &program.items {
-        let (names, name, span) = match item {
-            ast::Item::Let(decl) => (&mut globals, &decl.name, decl.span),
-            ast::Item::Type(decl) => (&mut type_names, &decl.name, decl.span),
-        };
-        if !names.insert(name.clone()) {
-            return Err(LowerError {
-                message: format!("duplicate definition `{name}`"),
-                span,
-            });
+        match item {
+            ast::Item::Let(decl) => {
+                if ctors.contains_key(&decl.name) {
+                    return Err(LowerError {
+                        message: format!(
+                            "duplicate definition `{}` (constructors live in the value namespace)",
+                            decl.name
+                        ),
+                        span: decl.span,
+                    });
+                }
+                if !globals.insert(decl.name.clone()) {
+                    return Err(LowerError {
+                        message: format!("duplicate definition `{}`", decl.name),
+                        span: decl.span,
+                    });
+                }
+            }
+            ast::Item::Type(decl) => {
+                if !type_names.insert(decl.name.clone()) {
+                    return Err(LowerError {
+                        message: format!("duplicate definition `{}`", decl.name),
+                        span: decl.span,
+                    });
+                }
+                if let ast::TypeBody::Variants(variants) = &decl.body {
+                    for variant in variants {
+                        if ctors.contains_key(&variant.name) {
+                            return Err(LowerError {
+                                message: format!("duplicate constructor `{}`", variant.name),
+                                span: variant.span,
+                            });
+                        }
+                        if globals.contains(&variant.name) {
+                            return Err(LowerError {
+                                message: format!(
+                                    "duplicate definition `{}` (constructors live in the value \
+namespace)",
+                                    variant.name
+                                ),
+                                span: variant.span,
+                            });
+                        }
+                        ctors.insert(variant.name.clone(), variant.fields.len());
+                    }
+                }
+            }
         }
     }
 
     // Pass 2: lower items in file order.
     let mut lowerer = Lowerer {
         globals,
+        ctors,
         scopes: Vec::new(),
         next_binding: 0,
         next_expr: 0,
@@ -79,7 +138,7 @@ pub fn lower(program: ast::Program) -> Result<Module, LowerError> {
             ast::Item::Type(decl) => types.push(TypeDef {
                 id,
                 name: decl.name,
-                fields: decl.fields,
+                body: decl.body,
                 span: decl.span,
             }),
             ast::Item::Let(decl) => defs.push(Def {
@@ -95,6 +154,9 @@ pub fn lower(program: ast::Program) -> Result<Module, LowerError> {
 
 struct Lowerer {
     globals: HashSet<String>,
+    /// Declared variant constructors: name → declared field count. Part of
+    /// the value namespace (pass 1 guarantees no overlap with `globals`).
+    ctors: HashMap<String, usize>,
     /// One level per enclosing lambda or `let … in`; lookup walks
     /// innermost-first. A lambda's level is a *boundary*: a `mut` binding
     /// found past one has been captured, which is an error (see the module
@@ -326,12 +388,96 @@ impl Lowerer {
                 }
             }
             ast::ExprKind::Neg(inner) => ExprKind::Neg(Box::new(self.expr(*inner)?)),
+            ast::ExprKind::Match { scrutinee, arms } => {
+                // The scrutinee is evaluated outside any arm's scope.
+                let scrutinee = Box::new(self.expr(*scrutinee)?);
+                let mut lowered = Vec::new();
+                for arm in arms {
+                    let mut vars: Vec<(String, BindingId, bool)> = Vec::new();
+                    let pattern = self.pattern(arm.pattern, &mut vars)?;
+                    // One scope level per arm: pattern variables are visible
+                    // in that arm's body only (they never leak to later
+                    // arms) and are plain immutable bindings — a lambda may
+                    // capture them.
+                    self.scopes.push(ScopeLevel {
+                        lambda_boundary: false,
+                        vars,
+                    });
+                    let body = self.expr(arm.body);
+                    self.scopes.pop();
+                    lowered.push(MatchArm {
+                        pattern,
+                        body: body?,
+                        span: arm.span,
+                    });
+                }
+                ExprKind::Match {
+                    scrutinee,
+                    arms: lowered,
+                }
+            }
         };
         Ok(Expr {
             id: self.expr_id(),
             kind,
             span,
         })
+    }
+
+    /// Lower one pattern, appending its variable bindings to `vars` (the
+    /// caller pushes them as the arm body's scope). Pattern nesting is
+    /// bounded by the grammar (constructor sub-patterns are leaves), so
+    /// recursion depth is at most two.
+    fn pattern(
+        &mut self,
+        pattern: ast::Pattern,
+        vars: &mut Vec<(String, BindingId, bool)>,
+    ) -> Result<Pattern, LowerError> {
+        let span = pattern.span;
+        let kind = match pattern.kind {
+            ast::PatternKind::Wildcard => PatternKind::Wildcard,
+            ast::PatternKind::Var(name) => {
+                if vars.iter().any(|(n, _, _)| *n == name) {
+                    return Err(LowerError {
+                        message: format!("duplicate pattern variable `{name}`"),
+                        span,
+                    });
+                }
+                let binding = BindingId(self.next_binding);
+                self.next_binding += 1;
+                vars.push((name.clone(), binding, false));
+                PatternKind::Var { binding, name }
+            }
+            ast::PatternKind::Ctor { name, args } => {
+                let Some(&arity) = self.ctors.get(&name) else {
+                    return Err(LowerError {
+                        message: format!("unknown constructor `{name}`"),
+                        span,
+                    });
+                };
+                if args.len() != arity {
+                    return Err(LowerError {
+                        message: format!(
+                            "`{name}` has {arity} field(s), but the pattern names {}",
+                            args.len()
+                        ),
+                        span,
+                    });
+                }
+                let mut lowered = Vec::new();
+                for arg in args {
+                    lowered.push(self.pattern(arg, vars)?);
+                }
+                PatternKind::Ctor {
+                    name,
+                    args: lowered,
+                }
+            }
+            ast::PatternKind::Number(n) => PatternKind::Number(n),
+            ast::PatternKind::Bool(b) => PatternKind::Bool(b),
+            ast::PatternKind::String(s) => PatternKind::String(s),
+        };
+        Ok(Pattern { kind, span })
     }
 
     /// Desugar one pipeline stage (see module docs): the already-lowered
@@ -381,6 +527,11 @@ impl Lowerer {
             }
         } else if self.globals.contains(first) {
             Some(ExprKind::Global(first.clone()))
+        } else if let Some(&arity) = self.ctors.get(first) {
+            Some(ExprKind::Ctor {
+                name: first.clone(),
+                arity,
+            })
         } else {
             None
         };

--- a/mle/src/parser.rs
+++ b/mle/src/parser.rs
@@ -13,7 +13,7 @@
 //! assign    := ident ":=" expr ";" expr
 //! match     := "match" expr "with" ("|" pattern "=>" expr)+
 //! pattern   := "_" | lowerIdent | upperIdent ("(" subpat,+ ")")?
-//!            | "true" | "false" | number | string
+//!            | "true" | "false" | "-"? number | string
 //! subpat    := "_" | lowerIdent
 //! pipeline  := cmp ("|>" cmp)*
 //! cmp       := add (("<" | ">" | "==") add)*        (left-assoc)
@@ -374,6 +374,19 @@ rebind surface); `mut` is for `let mut … in …` inside a function"
     }
 
     fn pattern(&mut self) -> Result<Pattern, ParseError> {
+        // A leading `-` folds into a number literal — patterns contain no
+        // expressions, so this is the only unary minus they need.
+        if self.peek_kind() == &TokenKind::Minus {
+            if let TokenKind::Number(n) = self.nth_kind(1) {
+                let n = *n;
+                let minus = self.bump();
+                let number = self.bump();
+                return Ok(Pattern {
+                    kind: PatternKind::Number(-n),
+                    span: minus.span.to(number.span),
+                });
+            }
+        }
         let span = self.peek().span;
         let kind = match self.peek_kind() {
             TokenKind::Number(n) => {

--- a/mle/src/parser.rs
+++ b/mle/src/parser.rs
@@ -5,11 +5,16 @@
 //! ```text
 //! program   := (letDecl | typeDecl)*
 //! letDecl   := "let" ident "=" expr
-//! typeDecl  := "type" ident "=" "{" (ident ":" type),* "}"
+//! typeDecl  := "type" ident "=" ("{" (ident ":" type),* "}" | variant+)
+//! variant   := "|" upperIdent ("(" (ident ":" type),+ ")")?
 //! type      := ident ("<" type ("," type)* ">")?
-//! expr      := letIn | assign | pipeline
+//! expr      := letIn | assign | match | pipeline
 //! letIn     := "let" "mut"? ident "=" expr "in" expr
 //! assign    := ident ":=" expr ";" expr
+//! match     := "match" expr "with" ("|" pattern "=>" expr)+
+//! pattern   := "_" | lowerIdent | upperIdent ("(" subpat,+ ")")?
+//!            | "true" | "false" | number | string
+//! subpat    := "_" | lowerIdent
 //! pipeline  := cmp ("|>" cmp)*
 //! cmp       := add (("<" | ">" | "==") add)*        (left-assoc)
 //! add       := mul (("+" | "-") mul)*               (left-assoc)
@@ -27,6 +32,13 @@
 //! Comma lists allow a trailing comma. `(` is disambiguated between lambda
 //! and parenthesized expression by scanning to the matching `)`: it is a
 //! lambda iff the next token is `=>` or `:` (a return-type annotation).
+//!
+//! **Greedy match arms.** Arm bodies are full expressions, so a nested
+//! `match` inside an arm consumes the following `|` arms as its own —
+//! parenthesize the inner match to return to the outer one (the same
+//! convention as F#/OCaml). The leading `|` is required before *every* arm
+//! (and every variant alternative), including the first — that keeps the
+//! layout-free grammar unambiguous.
 
 use crate::ast::*;
 use crate::lexer::{describe, lex, Token, TokenKind};
@@ -138,29 +150,89 @@ rebind surface); `mut` is for `let mut … in …` inside a function"
         let kw = self.bump();
         let (name, _) = self.expect_ident("a name after `type`")?;
         self.expect(TokenKind::Eq, "`=`")?;
-        self.expect(TokenKind::LBrace, "`{`")?;
-        let mut fields = Vec::new();
-        while self.peek_kind() != &TokenKind::RBrace {
-            let (field_name, field_span) = self.expect_ident("a field name")?;
-            self.expect(TokenKind::Colon, "`:` after field name")?;
-            let ty = self.type_name()?;
-            fields.push(FieldTy {
-                span: field_span.to(ty.span),
-                name: field_name,
-                ty,
-            });
-            if self.peek_kind() == &TokenKind::Comma {
+        match self.peek_kind() {
+            TokenKind::LBrace => {
                 self.bump();
-            } else {
-                break;
+                let mut fields = Vec::new();
+                while self.peek_kind() != &TokenKind::RBrace {
+                    let (field_name, field_span) = self.expect_ident("a field name")?;
+                    self.expect(TokenKind::Colon, "`:` after field name")?;
+                    let ty = self.type_name()?;
+                    fields.push(FieldTy {
+                        span: field_span.to(ty.span),
+                        name: field_name,
+                        ty,
+                    });
+                    if self.peek_kind() == &TokenKind::Comma {
+                        self.bump();
+                    } else {
+                        break;
+                    }
+                }
+                let close = self.expect(TokenKind::RBrace, "`,` or `}`")?;
+                Ok(TypeDecl {
+                    name,
+                    body: TypeBody::Record(fields),
+                    span: kw.span.to(close.span),
+                })
             }
+            TokenKind::Pipe => {
+                let mut variants = Vec::new();
+                while self.peek_kind() == &TokenKind::Pipe {
+                    self.bump();
+                    variants.push(self.variant_decl()?);
+                }
+                let span = kw
+                    .span
+                    .to(variants.last().expect("at least one variant").span);
+                Ok(TypeDecl {
+                    name,
+                    body: TypeBody::Variants(variants),
+                    span,
+                })
+            }
+            // A leading `|` is required before every alternative, including
+            // the first (see the module docs).
+            _ => self.error("`{` (a record type) or `|` (a variant alternative)"),
         }
-        let close = self.expect(TokenKind::RBrace, "`,` or `}`")?;
-        Ok(TypeDecl {
-            name,
-            fields,
-            span: kw.span.to(close.span),
-        })
+    }
+
+    /// One `Ctor(name: Type, …)` / `Ctor` alternative (its leading `|`
+    /// already consumed).
+    fn variant_decl(&mut self) -> Result<VariantDecl, ParseError> {
+        let (name, name_span) = self.expect_ident("a constructor name after `|`")?;
+        if !starts_uppercase(&name) {
+            return Err(ParseError {
+                message: format!("constructor name `{name}` must start uppercase"),
+                span: name_span,
+            });
+        }
+        let mut fields = Vec::new();
+        let mut span = name_span;
+        if self.peek_kind() == &TokenKind::LParen {
+            self.bump();
+            loop {
+                let (field_name, field_span) = self.expect_ident("a field name")?;
+                self.expect(TokenKind::Colon, "`:` after field name")?;
+                let ty = self.type_name()?;
+                fields.push(FieldTy {
+                    span: field_span.to(ty.span),
+                    name: field_name,
+                    ty,
+                });
+                if self.peek_kind() == &TokenKind::Comma {
+                    self.bump();
+                    if self.peek_kind() == &TokenKind::RParen {
+                        break; // trailing comma
+                    }
+                } else {
+                    break;
+                }
+            }
+            let close = self.expect(TokenKind::RParen, "`,` or `)`")?;
+            span = name_span.to(close.span);
+        }
+        Ok(VariantDecl { name, fields, span })
     }
 
     fn type_name(&mut self) -> Result<TypeName, ParseError> {
@@ -203,6 +275,7 @@ rebind surface); `mut` is for `let mut … in …` inside a function"
         }
         let result = match self.peek_kind() {
             TokenKind::Let => self.let_in(),
+            TokenKind::Match => self.match_expr(),
             TokenKind::Ident(_) if self.nth_kind(1) == &TokenKind::ColonEq => self.assign(),
             _ => {
                 let expr = self.pipeline();
@@ -265,6 +338,121 @@ rebind surface); `mut` is for `let mut … in …` inside a function"
             },
             span,
         })
+    }
+
+    /// `match expr with | pattern => expr | …` — lowest-precedence, like
+    /// let-in. Arm bodies are full expressions, so arms are consumed
+    /// greedily (see the module docs).
+    fn match_expr(&mut self) -> Result<Expr, ParseError> {
+        let kw = self.bump();
+        let scrutinee = self.expr()?;
+        self.expect(TokenKind::With, "`with` after the match scrutinee")?;
+        if self.peek_kind() != &TokenKind::Pipe {
+            // A leading `|` is required before every arm, including the first.
+            return self.error("`|` to begin a match arm");
+        }
+        let mut arms = Vec::new();
+        while self.peek_kind() == &TokenKind::Pipe {
+            let bar = self.bump();
+            let pattern = self.pattern()?;
+            self.expect(TokenKind::FatArrow, "`=>` after the pattern")?;
+            let body = self.expr()?;
+            arms.push(MatchArm {
+                span: bar.span.to(body.span),
+                pattern,
+                body,
+            });
+        }
+        let span = kw.span.to(arms.last().expect("at least one arm").span);
+        Ok(Expr {
+            kind: ExprKind::Match {
+                scrutinee: Box::new(scrutinee),
+                arms,
+            },
+            span,
+        })
+    }
+
+    fn pattern(&mut self) -> Result<Pattern, ParseError> {
+        let span = self.peek().span;
+        let kind = match self.peek_kind() {
+            TokenKind::Number(n) => {
+                let n = *n;
+                self.bump();
+                PatternKind::Number(n)
+            }
+            TokenKind::Str(s) => {
+                let s = s.clone();
+                self.bump();
+                PatternKind::String(s)
+            }
+            TokenKind::True => {
+                self.bump();
+                PatternKind::Bool(true)
+            }
+            TokenKind::False => {
+                self.bump();
+                PatternKind::Bool(false)
+            }
+            TokenKind::Ident(name) if name == "_" => {
+                self.bump();
+                PatternKind::Wildcard
+            }
+            TokenKind::Ident(name) if !starts_uppercase(name) => {
+                let name = name.clone();
+                self.bump();
+                PatternKind::Var(name)
+            }
+            // Uppercase: always a constructor pattern, never a variable.
+            TokenKind::Ident(_) => return self.ctor_pattern(),
+            _ => return self.error("a pattern"),
+        };
+        Ok(Pattern { kind, span })
+    }
+
+    /// `Circle(r, _)` / `Point` — sub-patterns are variable bindings or `_`
+    /// only (the deliberately-minimal B5 pattern language; no nesting).
+    fn ctor_pattern(&mut self) -> Result<Pattern, ParseError> {
+        let (name, name_span) = self.expect_ident("a constructor name")?;
+        let mut args = Vec::new();
+        let mut span = name_span;
+        if self.peek_kind() == &TokenKind::LParen {
+            self.bump();
+            loop {
+                args.push(self.sub_pattern()?);
+                if self.peek_kind() == &TokenKind::Comma {
+                    self.bump();
+                    if self.peek_kind() == &TokenKind::RParen {
+                        break; // trailing comma
+                    }
+                } else {
+                    break;
+                }
+            }
+            let close = self.expect(TokenKind::RParen, "`,` or `)`")?;
+            span = name_span.to(close.span);
+        }
+        Ok(Pattern {
+            kind: PatternKind::Ctor { name, args },
+            span,
+        })
+    }
+
+    fn sub_pattern(&mut self) -> Result<Pattern, ParseError> {
+        let span = self.peek().span;
+        let kind = match self.peek_kind() {
+            TokenKind::Ident(name) if name == "_" => {
+                self.bump();
+                PatternKind::Wildcard
+            }
+            TokenKind::Ident(name) if !starts_uppercase(name) => {
+                let name = name.clone();
+                self.bump();
+                PatternKind::Var(name)
+            }
+            _ => return self.error("a binding name or `_` (constructor patterns do not nest)"),
+        };
+        Ok(Pattern { kind, span })
     }
 
     fn pipeline(&mut self) -> Result<Expr, ParseError> {

--- a/mle/src/types.rs
+++ b/mle/src/types.rs
@@ -928,7 +928,11 @@ is {other}"
             // errors.
             BinOp::Eq => {
                 match (lhs, rhs) {
-                    (Type::Fn(..), Type::Fn(..)) => {
+                    // One known function operand is enough: the runtime
+                    // rejects `==` whenever EITHER side is a function
+                    // (closure, builtin, or unapplied constructor), so the
+                    // other operand's type — even Unknown — cannot save it.
+                    (Type::Fn(..), _) | (_, Type::Fn(..)) => {
                         self.diag(
                             node_span,
                             "functions cannot be compared with `==`".to_string(),

--- a/mle/src/types.rs
+++ b/mle/src/types.rs
@@ -12,6 +12,8 @@
 //! - Primitives `Float`, `String`, `Bool` (numbers are all Float).
 //! - Declared record types (`type Position = { x: Float, y: Float }`) —
 //!   nominal, by name.
+//! - Declared variant types (`type Shape = | Circle(radius: Float) | Point`)
+//!   — nominal, by name, like records.
 //! - `List<T>`.
 //! - Function types, from lambda annotations
 //!   (`(a: Float, b: Float): Float => …`); an unannotated return type is the
@@ -37,7 +39,17 @@
 //! with generic slots as Unknown (no instantiation: `List.map`'s element
 //! types simply aren't tracked); return annotations against the body's type;
 //! and type-argument arity (`Position<Float>` is an error, an *unknown* type
-//! name is not).
+//! name is not). Constructors carry function types from their declarations
+//! (`Circle : (Float) => Shape`; nullary constructors are the variant type
+//! itself), so construction checks like any call. `match` checks pattern
+//! compatibility against a known scrutinee type (a foreign constructor, a
+//! literal of the wrong type), binds pattern variables to the declared field
+//! types (a bare-variable arm binds the scrutinee's type), requires
+//! **exhaustiveness** when the scrutinee's type is known — every constructor
+//! of a variant type, both `true` and `false` for Bool, and always a
+//! catch-all for Float/String literal matches, unless a catch-all arm
+//! exists — and joins the arm result types (compatible where known; the
+//! match's type is Unknown unless all arms agree exactly).
 //!
 //! Top-level `let`s contribute what their value's shape declares (a lambda's
 //! annotations, a literal's type), then a quiet single-pass inference
@@ -49,9 +61,9 @@
 //! [`check`] walks the whole module and returns **every** diagnostic, sorted
 //! by source position — it never stops at the first error.
 
-use crate::ast::{BinOp, TypeName};
+use crate::ast::{BinOp, TypeBody, TypeName};
 use crate::eval::{builtin, callee_label, Builtin};
-use crate::ir::{Expr, ExprKind, Field, Module};
+use crate::ir::{BindingId, Expr, ExprId, ExprKind, Field, MatchArm, Module, Pattern, PatternKind};
 use crate::span::Span;
 use crate::CheckError;
 use std::collections::HashMap;
@@ -67,6 +79,8 @@ pub enum Type {
     List(Box<Type>),
     /// A declared record type, nominal by name.
     Record(String),
+    /// A declared variant type, nominal by name.
+    Variant(String),
     Fn(Vec<Type>, Box<Type>),
 }
 
@@ -78,7 +92,7 @@ impl fmt::Display for Type {
             Type::String => write!(f, "String"),
             Type::Bool => write!(f, "Bool"),
             Type::List(elem) => write!(f, "List<{elem}>"),
-            Type::Record(name) => write!(f, "{name}"),
+            Type::Record(name) | Type::Variant(name) => write!(f, "{name}"),
             Type::Fn(params, ret) => {
                 write!(f, "(")?;
                 for (i, param) in params.iter().enumerate() {
@@ -105,6 +119,7 @@ pub fn compatible(a: &Type, b: &Type) -> bool {
         }
         (Type::List(x), Type::List(y)) => compatible(x, y),
         (Type::Record(x), Type::Record(y)) => x == y,
+        (Type::Variant(x), Type::Variant(y)) => x == y,
         (Type::Fn(p1, r1), Type::Fn(p2, r2)) => {
             p1.len() == p2.len()
                 && p1.iter().zip(p2).all(|(x, y)| compatible(x, y))
@@ -160,10 +175,24 @@ pub fn builtin_signature(b: Builtin) -> Type {
     }
 }
 
-/// The checker's best-known type for every expression node, keyed by the
-/// node's raw [`crate::ir::ExprId`] — the substrate for editor hover
-/// (see [`crate::hover`]).
-pub type ExprTypes = HashMap<u32, Type>;
+/// The checker's best-known types — the substrate for editor hover (see
+/// [`crate::hover`]): one table per expression node ([`ExprId`]) and one per
+/// value binding ([`BindingId`] — lambda params, `let … in`s, and pattern
+/// variables, whose types have no expression node of their own).
+pub struct ExprTypes {
+    exprs: HashMap<u32, Type>,
+    bindings: HashMap<u32, Type>,
+}
+
+impl ExprTypes {
+    pub fn expr(&self, id: ExprId) -> Option<&Type> {
+        self.exprs.get(&id.raw())
+    }
+
+    pub fn binding(&self, id: BindingId) -> Option<&Type> {
+        self.bindings.get(&id.0)
+    }
+}
 
 /// Check a lowered module; returns every diagnostic, sorted by position.
 /// Empty means clean.
@@ -176,6 +205,8 @@ pub fn check(module: &Module) -> Vec<CheckError> {
 pub fn check_with_types(module: &Module) -> (Vec<CheckError>, ExprTypes) {
     let mut checker = Checker {
         records: HashMap::new(),
+        variants: HashMap::new(),
+        ctors: HashMap::new(),
         globals: HashMap::new(),
         locals: HashMap::new(),
         diags: Vec::new(),
@@ -186,15 +217,40 @@ pub fn check_with_types(module: &Module) -> (Vec<CheckError>, ExprTypes) {
     // Record type names first (nominal references may be forward), then
     // resolve each declaration's field types (reporting bad type arity).
     for decl in &module.types {
-        checker.records.insert(decl.name.clone(), Vec::new());
+        match &decl.body {
+            TypeBody::Record(_) => {
+                checker.records.insert(decl.name.clone(), Vec::new());
+            }
+            TypeBody::Variants(variants) => {
+                checker.variants.insert(
+                    decl.name.clone(),
+                    variants.iter().map(|v| v.name.clone()).collect(),
+                );
+            }
+        }
     }
     for decl in &module.types {
-        let fields = decl
-            .fields
-            .iter()
-            .map(|f| (f.name.clone(), checker.resolve_type(&f.ty, true)))
-            .collect();
-        checker.records.insert(decl.name.clone(), fields);
+        match &decl.body {
+            TypeBody::Record(decl_fields) => {
+                let fields = decl_fields
+                    .iter()
+                    .map(|f| (f.name.clone(), checker.resolve_type(&f.ty, true)))
+                    .collect();
+                checker.records.insert(decl.name.clone(), fields);
+            }
+            TypeBody::Variants(variants) => {
+                for variant in variants {
+                    let fields = variant
+                        .fields
+                        .iter()
+                        .map(|f| checker.resolve_type(&f.ty, true))
+                        .collect();
+                    checker
+                        .ctors
+                        .insert(variant.name.clone(), (decl.name.clone(), fields));
+                }
+            }
+        }
     }
 
     // Global signatures before bodies, so forward references between
@@ -239,12 +295,24 @@ pub fn check_with_types(module: &Module) -> (Vec<CheckError>, ExprTypes) {
     }
 
     checker.diags.sort_by_key(|d| d.span.start);
-    (checker.diags, checker.expr_types)
+    (
+        checker.diags,
+        ExprTypes {
+            exprs: checker.expr_types,
+            bindings: checker.locals,
+        },
+    )
 }
 
 struct Checker {
     /// Declared record types: name → resolved fields, in declaration order.
     records: HashMap<String, Vec<(String, Type)>>,
+    /// Declared variant types: name → constructor names, in declaration
+    /// order (the exhaustiveness universe).
+    variants: HashMap<String, Vec<String>>,
+    /// Declared constructors: name → (owning variant type, field types in
+    /// declaration order). Names are module-unique (lowering enforces it).
+    ctors: HashMap<String, (String, Vec<Type>)>,
     globals: HashMap<String, Type>,
     /// Parameter types by binding ID (IDs are unique module-wide, so entries
     /// are never shadowed or popped).
@@ -255,7 +323,7 @@ struct Checker {
     quiet: bool,
     /// Best-known type per expression, recorded by [`Checker::infer`]. The
     /// loud pass runs last, so its (better-informed) types win.
-    expr_types: ExprTypes,
+    expr_types: HashMap<u32, Type>,
 }
 
 /// Prefer the known parts of two views of the same definition's type: the
@@ -325,6 +393,12 @@ impl Checker {
                     return arity_error(self, 0);
                 }
                 Type::Record(name.to_string())
+            }
+            name if self.variants.contains_key(name) => {
+                if !ty.args.is_empty() {
+                    return arity_error(self, 0);
+                }
+                Type::Variant(name.to_string())
             }
             // Unrecognized (a generic like `T`, or a type this module doesn't
             // declare): Unknown, not an error. Still resolve any arguments so
@@ -655,6 +729,174 @@ impl Checker {
                 }
                 Type::Float
             }
+            // A constructor reference: nullary is the variant value itself,
+            // parameterful is a function from its declared field types.
+            ExprKind::Ctor { name, .. } => match self.ctors.get(name) {
+                Some((type_name, fields)) => {
+                    if fields.is_empty() {
+                        Type::Variant(type_name.clone())
+                    } else {
+                        Type::Fn(fields.clone(), Box::new(Type::Variant(type_name.clone())))
+                    }
+                }
+                // Unreachable (lowering rejects unknown constructors) —
+                // stay gradual rather than panic.
+                None => Type::Unknown,
+            },
+            ExprKind::Match { scrutinee, arms } => self.check_match(expr, scrutinee, arms),
+        }
+    }
+
+    /// Check a `match` (see the module doc): pattern compatibility against
+    /// the scrutinee's type, pattern-variable binding types, exhaustiveness
+    /// where the scrutinee's type is known, and the arm-result join.
+    fn check_match(&mut self, expr: &Expr, scrutinee: &Expr, arms: &[MatchArm]) -> Type {
+        let scrutinee_ty = self.infer(scrutinee);
+        let mut has_catch_all = false;
+        let mut saw_true = false;
+        let mut saw_false = false;
+        let mut covered_ctors: Vec<&str> = Vec::new();
+        let mut result: Option<Type> = None;
+        for arm in arms {
+            self.check_pattern(&arm.pattern, &scrutinee_ty);
+            match &arm.pattern.kind {
+                PatternKind::Wildcard | PatternKind::Var { .. } => has_catch_all = true,
+                PatternKind::Ctor { name, .. } => covered_ctors.push(name),
+                PatternKind::Bool(true) => saw_true = true,
+                PatternKind::Bool(false) => saw_false = true,
+                PatternKind::Number(_) | PatternKind::String(_) => {}
+            }
+            // All arms must agree where known; the match's type is the join
+            // (Unknown as soon as the arms aren't literally the same type).
+            let body_ty = self.infer(&arm.body);
+            result = Some(match result {
+                None => body_ty,
+                Some(prev) => {
+                    if !compatible(&prev, &body_ty) {
+                        self.diag(
+                            arm.body.span,
+                            format!("match arms have incompatible types {prev} and {body_ty}"),
+                        );
+                    }
+                    if prev == body_ty {
+                        prev
+                    } else {
+                        Type::Unknown
+                    }
+                }
+            });
+        }
+        // Exhaustiveness fires only where the scrutinee's type is known —
+        // gradual, like every other check.
+        if !has_catch_all {
+            match &scrutinee_ty {
+                Type::Variant(name) => {
+                    let missing: Vec<String> = self
+                        .variants
+                        .get(name)
+                        .map(|declared| {
+                            declared
+                                .iter()
+                                .filter(|c| !covered_ctors.contains(&c.as_str()))
+                                .map(|c| format!("`{c}`"))
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    if !missing.is_empty() {
+                        self.diag(
+                            expr.span,
+                            format!(
+                                "match on `{name}` is not exhaustive: missing {}",
+                                missing.join(", ")
+                            ),
+                        );
+                    }
+                }
+                Type::Bool => {
+                    if !(saw_true && saw_false) {
+                        let missing = match (saw_true, saw_false) {
+                            (false, true) => "`true`",
+                            (true, false) => "`false`",
+                            _ => "`true`, `false`",
+                        };
+                        self.diag(
+                            expr.span,
+                            format!("match on Bool is not exhaustive: missing {missing}"),
+                        );
+                    }
+                }
+                // Literal patterns can never cover all numbers or strings.
+                Type::Float | Type::String => {
+                    self.diag(
+                        expr.span,
+                        format!(
+                            "match on {scrutinee_ty} is not exhaustive: literal patterns need \
+a catch-all arm (`_` or a name)"
+                        ),
+                    );
+                }
+                // Unknown stays gradual; List/Record/Fn scrutinees already
+                // drew per-pattern compatibility diagnostics above.
+                _ => {}
+            }
+        }
+        result.unwrap_or(Type::Unknown)
+    }
+
+    /// Check one pattern against the scrutinee's type and record its
+    /// variables' binding types (a bare variable binds the scrutinee's type;
+    /// constructor sub-patterns bind the declared field types).
+    fn check_pattern(&mut self, pattern: &Pattern, scrutinee: &Type) {
+        match &pattern.kind {
+            PatternKind::Wildcard => {}
+            PatternKind::Var { binding, .. } => {
+                self.locals.insert(binding.0, scrutinee.clone());
+            }
+            PatternKind::Ctor { name, args } => match self.ctors.get(name).cloned() {
+                Some((type_name, field_tys)) => {
+                    match scrutinee {
+                        Type::Variant(s) if *s != type_name => {
+                            self.diag(
+                                pattern.span,
+                                format!("`{name}` is not a constructor of `{s}`"),
+                            );
+                        }
+                        Type::Unknown | Type::Variant(_) => {}
+                        other => {
+                            self.diag(
+                                pattern.span,
+                                format!(
+                                    "pattern `{name}` matches `{type_name}`, but the scrutinee \
+is {other}"
+                                ),
+                            );
+                        }
+                    }
+                    // Lowering fixed the pattern's arity to the declaration.
+                    for (sub, field_ty) in args.iter().zip(&field_tys) {
+                        self.check_pattern(sub, field_ty);
+                    }
+                }
+                // Unreachable (lowering rejects unknown constructors) —
+                // stay gradual rather than panic.
+                None => {
+                    for sub in args {
+                        self.check_pattern(sub, &Type::Unknown);
+                    }
+                }
+            },
+            PatternKind::Number(_) => self.literal_pattern(scrutinee, Type::Float, pattern.span),
+            PatternKind::Bool(_) => self.literal_pattern(scrutinee, Type::Bool, pattern.span),
+            PatternKind::String(_) => self.literal_pattern(scrutinee, Type::String, pattern.span),
+        }
+    }
+
+    fn literal_pattern(&mut self, scrutinee: &Type, literal: Type, span: Span) {
+        if !compatible(scrutinee, &literal) {
+            self.diag(
+                span,
+                format!("pattern matches {literal}, but the scrutinee is {scrutinee}"),
+            );
         }
     }
 

--- a/mle/src/value.rs
+++ b/mle/src/value.rs
@@ -20,6 +20,21 @@ pub enum Value {
     List(Rc<Vec<Value>>),
     /// Field order is the construction order (deterministic output).
     Record(Rc<Vec<(String, Value)>>),
+    /// A variant-type value: a constructor applied to its (positional)
+    /// arguments. Nullary constructors are variants with no args.
+    /// Equality is structural (same constructor, equal args).
+    Variant {
+        ctor: Rc<str>,
+        args: Rc<Vec<Value>>,
+    },
+    /// An unapplied parameterful constructor (`Circle` passed as a value,
+    /// e.g. to `List.map`) — callable; applying it with the declared arity
+    /// yields a [`Value::Variant`]. Nullary constructors never produce this
+    /// (used bare, they ARE the variant value).
+    Ctor {
+        name: Rc<str>,
+        arity: usize,
+    },
     Closure(Rc<Closure>),
     Builtin(crate::eval::Builtin),
     /// A host-provided external function (see [`crate::eval::Host`]),
@@ -107,6 +122,21 @@ impl fmt::Display for Value {
                 }
                 write!(f, " }}")
             }
+            Value::Variant { ctor, args } => {
+                write!(f, "{ctor}")?;
+                if args.is_empty() {
+                    return Ok(());
+                }
+                write!(f, "(")?;
+                for (i, arg) in args.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{arg}")?;
+                }
+                write!(f, ")")
+            }
+            Value::Ctor { name, .. } => write!(f, "<ctor {name}>"),
             Value::Closure(closure) => {
                 write!(f, "<fn(")?;
                 for (i, param) in closure.params.iter().enumerate() {
@@ -133,6 +163,8 @@ impl Value {
             Value::Bool(_) => "a bool",
             Value::List(_) => "a list",
             Value::Record(_) => "a record",
+            Value::Variant { .. } => "a variant",
+            Value::Ctor { .. } => "a constructor",
             Value::Closure(_) => "a function",
             Value::Builtin(_) => "a builtin",
             Value::HostFn(_) => "a host function",

--- a/mle/tests/check.rs
+++ b/mle/tests/check.rs
@@ -78,6 +78,11 @@ fn example_functions_checks_clean() {
     example_checks_clean("functions");
 }
 
+#[test]
+fn example_shapes_checks_clean() {
+    example_checks_clean("shapes");
+}
+
 fn example_checks_clean(name: &str) {
     let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("examples");
     let src = fs::read_to_string(dir.join(format!("{name}.mle"))).unwrap();
@@ -419,4 +424,191 @@ fn let_in_types_flow_to_the_body() {
 #[test]
 fn gradual_mut_never_false_positives() {
     assert_clean("let f = (x) => let mut a = x in a := a + 1.0; { a with n: a }");
+}
+
+// --- Variants + match (B5 part 1) ---
+
+const SHAPE: &str = "type Shape = | Circle(r: Float) | Rect(w: Float, h: Float) | Point\n";
+
+/// Non-exhaustive match on a known variant type: the diagnostic names the
+/// missing constructor(s), in declaration order.
+#[test]
+fn error_non_exhaustive_variant_match() {
+    let (message, line, col) = single_diag(&format!(
+        "{SHAPE}let f = (s: Shape): Float => match s with | Circle(r) => r"
+    ));
+    assert_eq!(
+        message,
+        "match on `Shape` is not exhaustive: missing `Rect`, `Point`"
+    );
+    assert_eq!((line, col), (2, 30));
+}
+
+/// A catch-all arm (`_` or a variable) makes any match exhaustive.
+#[test]
+fn catch_all_arms_are_exhaustive() {
+    assert_clean(&format!(
+        "{SHAPE}let f = (s: Shape): Float => match s with | Circle(r) => r | _ => 0.0"
+    ));
+    assert_clean(&format!(
+        "{SHAPE}let f = (s: Shape): Float => match s with | Circle(r) => r | other => 0.0"
+    ));
+}
+
+/// Every constructor covered is exhaustive without a catch-all.
+#[test]
+fn full_ctor_coverage_is_exhaustive() {
+    assert_clean(&format!(
+        "{SHAPE}let f = (s: Shape): Float => match s with | Circle(r) => r | Rect(w, h) => w * h | Point => 0.0"
+    ));
+}
+
+/// A constructor from another variant type can never match.
+#[test]
+fn error_foreign_ctor_in_a_match() {
+    let (message, line, col) = single_diag(&format!(
+        "{SHAPE}type Blob = | Splat(size: Float)\n\
+         let f = (s: Shape): Float => match s with | Splat(n) => n | _ => 0.0"
+    ));
+    assert_eq!(message, "`Splat` is not a constructor of `Shape`");
+    assert_eq!((line, col), (3, 45));
+}
+
+/// A constructor pattern against a known non-variant scrutinee.
+#[test]
+fn error_ctor_pattern_against_a_float() {
+    let (message, _, _) = single_diag(&format!(
+        "{SHAPE}let f = (x: Float): Float => match x with | Circle(r) => r | _ => 0.0"
+    ));
+    assert_eq!(
+        message,
+        "pattern `Circle` matches `Shape`, but the scrutinee is Float"
+    );
+}
+
+/// A literal pattern of the wrong type against a known scrutinee.
+#[test]
+fn error_literal_pattern_against_a_variant() {
+    let (message, _, _) = single_diag(&format!(
+        "{SHAPE}let f = (s: Shape): Float => match s with | true => 1.0 | _ => 0.0"
+    ));
+    assert_eq!(message, "pattern matches Bool, but the scrutinee is Shape");
+}
+
+/// Bool matches: `true` + `false` (or a catch-all) is exhaustive; a missing
+/// literal is named.
+#[test]
+fn bool_match_exhaustiveness() {
+    assert_clean("let f = (b: Bool): Float => match b with | true => 1.0 | false => 0.0");
+    assert_clean("let f = (b: Bool): Float => match b with | true => 1.0 | _ => 0.0");
+    let (message, _, _) = single_diag("let f = (b: Bool): Float => match b with | true => 1.0");
+    assert_eq!(message, "match on Bool is not exhaustive: missing `false`");
+}
+
+/// Number/string literal matches can never cover their type: they require a
+/// catch-all arm when the scrutinee's type is known.
+#[test]
+fn literal_matches_require_a_catch_all() {
+    let (message, _, _) =
+        single_diag("let f = (x: Float): Float => match x with | 1.0 => 1.0 | 2.0 => 2.0");
+    assert_eq!(
+        message,
+        "match on Float is not exhaustive: literal patterns need a catch-all arm (`_` or a name)"
+    );
+    assert_clean("let f = (x: Float): Float => match x with | 1.0 => 1.0 | _ => 0.0");
+    let (message, _, _) = single_diag("let f = (x: String): Float => match x with | \"a\" => 1.0");
+    assert_eq!(
+        message,
+        "match on String is not exhaustive: literal patterns need a catch-all arm (`_` or a name)"
+    );
+}
+
+/// Arm result types must agree where known; the match's type is their join.
+#[test]
+fn error_incompatible_arm_types() {
+    let (message, _, _) =
+        single_diag("let f = (b: Bool) => match b with | true => 1.0 | false => \"no\"");
+    assert_eq!(
+        message,
+        "match arms have incompatible types Float and String"
+    );
+}
+
+/// The joined match type flows onward (here: into a return-type check).
+#[test]
+fn match_type_flows_to_the_return_annotation() {
+    let (message, _, _) =
+        single_diag("let f = (b: Bool): String => match b with | true => 1.0 | false => 0.0");
+    assert_eq!(message, "return value: expected String, got Float");
+}
+
+/// Pattern variables get the declared field types — they flow into arm
+/// bodies…
+#[test]
+fn pattern_vars_get_declared_field_types() {
+    let (message, _, _) = single_diag(&format!(
+        "{SHAPE}let f = (s: Shape): String => match s with | Circle(r) => Text.concat(r, \"!\") | _ => \"\""
+    ));
+    assert_eq!(
+        message,
+        "argument 1 of `Text.concat`: expected String, got Float"
+    );
+}
+
+/// …and a catch-all variable binds the scrutinee's type.
+#[test]
+fn catch_all_var_binds_the_scrutinee_type() {
+    let (message, _, _) = single_diag(&format!(
+        "{SHAPE}let area = (s: Shape): Float => 1.0\n\
+         let f = (s: Shape): Float => match s with | other => area(other) + other"
+    ));
+    assert_eq!(message, "`+` needs Float operands, got Shape");
+}
+
+/// Construction checks like any call: declared field types and arity.
+#[test]
+fn error_ctor_argument_type_and_arity() {
+    let (message, _, _) = single_diag(&format!("{SHAPE}let x = () => Circle(\"s\")"));
+    assert_eq!(
+        message,
+        "argument 1 of `Circle`: expected Float, got String"
+    );
+    let (message, _, _) = single_diag(&format!("{SHAPE}let x = () => Rect(1.0)"));
+    assert_eq!(message, "`Rect` takes 2 argument(s), got 1");
+}
+
+/// Variant types are nominal in annotations, like records.
+#[test]
+fn variant_return_annotations_check() {
+    assert_clean(&format!("{SHAPE}let f = (): Shape => Circle(2.0)"));
+    assert_clean(&format!("{SHAPE}let f = (): Shape => Point"));
+    let (message, _, _) = single_diag(&format!("{SHAPE}let f = (): Shape => 1.0"));
+    assert_eq!(message, "return value: expected Shape, got Float");
+}
+
+// Gradual: these must NOT error.
+
+/// An Unknown scrutinee is unchecked: no exhaustiveness demands, ctor and
+/// literal arms of any mix, and pattern variables still get their declared
+/// field types without ever false-positives.
+#[test]
+fn gradual_match_never_false_positives() {
+    assert_clean(&format!(
+        "{SHAPE}let f = (s) => match s with | Circle(r) => r | 1.0 => 2.0 | \"s\" => 3.0"
+    ));
+    // A match on an unannotated call result is unchecked too.
+    assert_clean(&format!(
+        "{SHAPE}let g = (s) => s\n\
+         let f = (s) => match g(s) with | Point => 1.0"
+    ));
+}
+
+/// Mixed known/Unknown arm types join to Unknown (no diagnostic), so the
+/// match result stays gradual.
+#[test]
+fn mixed_unknown_arm_types_stay_gradual() {
+    assert_clean(&format!(
+        "{SHAPE}let g = (x) => x\n\
+         let f = (b: Bool): String => match b with | true => g(1.0) | false => \"s\""
+    ));
 }

--- a/mle/tests/check.rs
+++ b/mle/tests/check.rs
@@ -343,6 +343,20 @@ fn function_equality_is_an_error() {
     assert_eq!(diags[0].0, "functions cannot be compared with `==`");
 }
 
+// ONE known function operand is enough — the runtime rejects `==` whenever
+// either side is a function (including an unapplied constructor), so an
+// Unknown other side cannot make it succeed. [Codex M — B5 review]
+#[test]
+fn function_equality_against_unknown_is_an_error() {
+    let diags = check_src(
+        "type Shape =\n\
+         | Circle(radius: Float)\n\
+         let f = (x): Bool => Circle == x",
+    );
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0].0, "functions cannot be compared with `==`");
+}
+
 // A record literal can never satisfy a known non-record type. [Claude M1]
 #[test]
 fn record_literal_in_float_position_errors() {

--- a/mle/tests/ir.rs
+++ b/mle/tests/ir.rs
@@ -58,6 +58,11 @@ fn golden_functions() {
     check_golden("functions");
 }
 
+#[test]
+fn golden_shapes() {
+    check_golden("shapes");
+}
+
 /// Same source must always produce byte-identical IR (stable IDs are
 /// sequential, never random or time-based).
 #[test]
@@ -251,4 +256,146 @@ fn error_assign_to_global() {
 fn error_duplicate_update_field() {
     let (message, _, _) = lower_err("let f = (p) => { p with x: 1.0, x: 2.0 }");
     assert_eq!(message, "duplicate record field `x`");
+}
+
+// --- Variants + match (B5 part 1) ---
+
+/// Constructors resolve bare, so a name shared by two variant types would be
+/// ambiguous — unique ACROSS types, not just within one.
+#[test]
+fn error_ctor_collision_across_types() {
+    let (message, line, col) = lower_err(
+        "type Shape = | Circle(r: Float)\n\
+         type Blob = | Circle(r: Float)",
+    );
+    assert_eq!(message, "duplicate constructor `Circle`");
+    assert_eq!((line, col), (2, 15));
+}
+
+#[test]
+fn error_ctor_collision_within_a_type() {
+    let (message, _, _) = lower_err("type Shape = | Circle(r: Float) | Circle(d: Float)");
+    assert_eq!(message, "duplicate constructor `Circle`");
+}
+
+/// Constructors live in the VALUE namespace: `let Circle` and a constructor
+/// `Circle` collide (in either declaration order).
+#[test]
+fn error_ctor_collides_with_let() {
+    let expected = "duplicate definition `Circle` (constructors live in the value namespace)";
+    let (message, line, col) = lower_err("let Circle = 1\ntype Shape = | Circle(r: Float)");
+    assert_eq!(message, expected);
+    assert_eq!((line, col), (2, 16));
+    let (message, line, col) = lower_err("type Shape = | Circle(r: Float)\nlet Circle = 1");
+    assert_eq!(message, expected);
+    assert_eq!((line, col), (2, 1));
+}
+
+/// …but `type Shape` itself stays in the type namespace: a `let Shape` is
+/// fine, and `Shape.Circle` is deliberately NOT a constructor reference
+/// (only bare `Circle` is) — it stays an unknown external.
+#[test]
+fn qualified_ctor_form_is_not_supported() {
+    let module = lower_src("type Shape = | Circle(r: Float)\nlet f = () => Shape.Circle(1.0)");
+    let (_, body) = lambda_body(&module, 0);
+    let ExprKind::Call { callee, .. } = &body.kind else {
+        panic!("expected a call, got {body:?}");
+    };
+    assert!(
+        matches!(&callee.kind, ExprKind::External(path) if path == &["Shape", "Circle"]),
+        "expected an external, got {callee:?}"
+    );
+}
+
+/// A bare uppercase identifier resolves to a constructor reference; the
+/// declared arity rides along in the IR.
+#[test]
+fn bare_ctor_resolves_with_arity() {
+    let module = lower_src("type Shape = | Circle(r: Float) | Point\nlet f = () => Circle(2.0)");
+    let (_, body) = lambda_body(&module, 0);
+    let ExprKind::Call { callee, .. } = &body.kind else {
+        panic!("expected a call, got {body:?}");
+    };
+    assert!(
+        matches!(&callee.kind, ExprKind::Ctor { name, arity } if name == "Circle" && *arity == 1),
+        "expected a ctor ref, got {callee:?}"
+    );
+}
+
+/// A local binding shadows a constructor, exactly like it shadows a global.
+#[test]
+fn param_shadows_ctor() {
+    let module = lower_src("type Shape = | Circle(r: Float)\nlet f = (Circle) => Circle");
+    let (params, body) = lambda_body(&module, 0);
+    let ExprKind::Local { binding, .. } = &body.kind else {
+        panic!("expected a local, got {body:?}");
+    };
+    assert_eq!(*binding, params[0].binding);
+}
+
+/// An unknown constructor in a pattern is a lowering error (in expressions
+/// an unknown uppercase name is the existing "unknown name" error).
+#[test]
+fn error_unknown_ctor_in_pattern() {
+    let (message, line, col) = lower_err("let f = (s) => match s with | Nope => 1.0");
+    assert_eq!(message, "unknown constructor `Nope`");
+    assert_eq!((line, col), (1, 31));
+}
+
+/// A constructor pattern must name exactly the declared field count.
+#[test]
+fn error_pattern_arity_mismatch() {
+    let (message, _, _) = lower_err(
+        "type Shape = | Circle(r: Float)\n\
+         let f = (s) => match s with | Circle(a, b) => a | _ => 0.0",
+    );
+    assert_eq!(message, "`Circle` has 1 field(s), but the pattern names 2");
+
+    let (message, _, _) = lower_err(
+        "type Shape = | Circle(r: Float)\n\
+         let f = (s) => match s with | Circle => 1.0 | _ => 0.0",
+    );
+    assert_eq!(message, "`Circle` has 1 field(s), but the pattern names 0");
+}
+
+#[test]
+fn error_duplicate_pattern_variable() {
+    let (message, line, col) = lower_err(
+        "type Shape = | Rect(w: Float, h: Float)\n\
+         let f = (s) => match s with | Rect(a, a) => a | _ => 0.0",
+    );
+    assert_eq!(message, "duplicate pattern variable `a`");
+    assert_eq!((line, col), (2, 39));
+}
+
+/// Pattern variables are scoped to their own arm's body — they never leak
+/// into later arms.
+#[test]
+fn pattern_vars_do_not_leak_between_arms() {
+    let (message, _, _) = lower_err(
+        "type Shape = | Circle(r: Float) | Point\n\
+         let f = (s) => match s with | Circle(r) => r | Point => r",
+    );
+    assert_eq!(message, "unknown name `r`");
+}
+
+/// Pattern variables are plain immutable bindings: lambdas may capture them
+/// (unlike `mut` slots)…
+#[test]
+fn lambdas_may_capture_pattern_vars() {
+    let module = lower_src(
+        "type Shape = | Circle(r: Float)\n\
+         let f = (s) => match s with | Circle(r) => (x) => r + x | _ => (x) => x",
+    );
+    assert_eq!(module.defs.len(), 1);
+}
+
+/// …and they cannot be assigned.
+#[test]
+fn error_assign_to_pattern_var() {
+    let (message, _, _) = lower_err(
+        "type Shape = | Circle(r: Float)\n\
+         let f = (s) => match s with | Circle(r) => r := 1.0; r | _ => 0.0",
+    );
+    assert_eq!(message, "cannot assign to immutable binding `r`");
 }

--- a/mle/tests/ir.rs
+++ b/mle/tests/ir.rs
@@ -90,6 +90,16 @@ fn error_unknown_name() {
     );
 }
 
+/// Redeclaring a builtin type name would shadow the primitive in annotations
+/// ("expected Float, got Float"). [Claude L — B5 review]
+#[test]
+fn error_redeclare_builtin_type() {
+    let (message, _, _) = lower_err("type Float = | Foo");
+    assert_eq!(message, "cannot redeclare builtin type `Float`");
+    let (message, _, _) = lower_err("type List = { head: Float }");
+    assert_eq!(message, "cannot redeclare builtin type `List`");
+}
+
 /// A lowering error's position points at the offending identifier itself.
 #[test]
 fn error_span_points_at_identifier() {

--- a/mle/tests/parser.rs
+++ b/mle/tests/parser.rs
@@ -58,6 +58,11 @@ fn golden_functions() {
     check_golden("functions");
 }
 
+#[test]
+fn golden_shapes() {
+    check_golden("shapes");
+}
+
 /// Parse a deliberately broken input; return the error's (message, line, col).
 fn parse_err(src: &str) -> (String, usize, usize) {
     let err = mle::parse(src).expect_err("input should fail to parse");
@@ -182,4 +187,162 @@ fn assignment_to_field_is_a_targeted_error() {
         "got: {}",
         err.message
     );
+}
+
+// --- Variant declarations + match (B5 part 1) ---
+
+/// Both `type` bodies parse; the variant form allows nullary constructors
+/// and trailing commas in a constructor's field list.
+#[test]
+fn variant_declaration_forms_parse() {
+    assert!(
+        mle::parse("type Shape = | Circle(radius: Float) | Rect(w: Float, h: Float,) | Point")
+            .is_ok()
+    );
+    assert!(mle::parse("type Answer = | Yes").is_ok());
+}
+
+/// The leading `|` is required before the FIRST alternative too.
+#[test]
+fn error_variant_requires_leading_bar() {
+    assert_eq!(
+        parse_err("type Shape = Circle(radius: Float)"),
+        (
+            "expected `{` (a record type) or `|` (a variant alternative), found `Circle`"
+                .to_string(),
+            1,
+            14
+        )
+    );
+}
+
+#[test]
+fn error_lowercase_constructor_name() {
+    assert_eq!(
+        parse_err("type Shape = | circle(radius: Float)"),
+        (
+            "constructor name `circle` must start uppercase".to_string(),
+            1,
+            16
+        )
+    );
+}
+
+/// A constructor's fields are named in the declaration.
+#[test]
+fn error_variant_field_needs_a_name() {
+    assert_eq!(
+        parse_err("type Shape = | Circle(Float)"),
+        (
+            "expected `:` after field name, found `)`".to_string(),
+            1,
+            28
+        )
+    );
+}
+
+#[test]
+fn match_parses_all_pattern_kinds() {
+    let src = "let f = (s) => match s with\n\
+               | Circle(r, _) => r\n\
+               | Point => 0.0\n\
+               | true => 1.0\n\
+               | 2.0 => 2.0\n\
+               | \"s\" => 3.0\n\
+               | x => x\n\
+               | _ => 0.0";
+    let program = mle::parse(src).unwrap();
+    let Item::Let(decl) = &program.items[0] else {
+        panic!("expected a let declaration");
+    };
+    let ExprKind::Lambda { body, .. } = &decl.value.kind else {
+        panic!("expected a lambda");
+    };
+    let ExprKind::Match { arms, .. } = &body.kind else {
+        panic!("expected a match, got {body:?}");
+    };
+    assert_eq!(arms.len(), 7);
+    use mle::ast::PatternKind::*;
+    assert!(
+        matches!(&arms[0].pattern.kind, Ctor { name, args } if name == "Circle" && args.len() == 2)
+    );
+    assert!(
+        matches!(&arms[1].pattern.kind, Ctor { name, args } if name == "Point" && args.is_empty())
+    );
+    assert!(matches!(&arms[2].pattern.kind, Bool(true)));
+    assert!(matches!(&arms[3].pattern.kind, Number(n) if *n == 2.0));
+    assert!(matches!(&arms[4].pattern.kind, String(s) if s == "s"));
+    assert!(matches!(&arms[5].pattern.kind, Var(name) if name == "x"));
+    assert!(matches!(&arms[6].pattern.kind, Wildcard));
+}
+
+/// The leading `|` is required before the first arm.
+#[test]
+fn error_match_requires_leading_bar() {
+    assert_eq!(
+        parse_err("let f = (s) => match s with s => 1.0"),
+        (
+            "expected `|` to begin a match arm, found `s`".to_string(),
+            1,
+            29
+        )
+    );
+}
+
+/// Sub-patterns are bindings or `_` only — constructor patterns don't nest.
+#[test]
+fn error_nested_constructor_pattern() {
+    assert_eq!(
+        parse_err("let f = (s) => match s with | Circle(Point) => 1.0 | _ => 0.0"),
+        (
+            "expected a binding name or `_` (constructor patterns do not nest), found `Point`"
+                .to_string(),
+            1,
+            38
+        )
+    );
+}
+
+/// GREEDY ARMS: a nested match inside an arm consumes the following `|`
+/// arms as its own; parenthesizing restores them to the outer match (the
+/// documented F#/OCaml convention).
+#[test]
+fn nested_match_consumes_following_arms_greedily() {
+    let arms_of = |src: &str| -> (usize, usize) {
+        let program = mle::parse(src).unwrap();
+        let Item::Let(decl) = &program.items[0] else {
+            panic!("expected a let declaration");
+        };
+        let ExprKind::Match { arms, .. } = &decl.value.kind else {
+            panic!("expected a match, got {:?}", decl.value.kind);
+        };
+        let ExprKind::Match { arms: inner, .. } = &arms[0].body.kind else {
+            panic!("expected the first arm body to be a match");
+        };
+        (arms.len(), inner.len())
+    };
+    // Unparenthesized: the inner match eats `| false => 2.0`.
+    let (outer, inner) =
+        arms_of("let x = match true with | true => match false with | true => 1.0 | false => 2.0");
+    assert_eq!((outer, inner), (1, 2));
+    // Parenthesized: the outer match keeps its two arms.
+    let (outer, inner) = arms_of(
+        "let x = match true with | true => (match false with | true => 1.0) | false => 2.0",
+    );
+    assert_eq!((outer, inner), (2, 1));
+}
+
+/// `match` binds loosest, like let-in: an arm body is a full expression.
+#[test]
+fn match_arm_bodies_are_full_expressions() {
+    let src = "let x = match true with | true => 1.0 + 2.0 | false => 0.0";
+    let program = mle::parse(src).unwrap();
+    let Item::Let(decl) = &program.items[0] else {
+        panic!("expected a let declaration");
+    };
+    let ExprKind::Match { arms, .. } = &decl.value.kind else {
+        panic!("expected a match");
+    };
+    assert_eq!(arms.len(), 2);
+    assert!(matches!(&arms[0].body.kind, ExprKind::Binary { .. }));
 }

--- a/mle/tests/run.rs
+++ b/mle/tests/run.rs
@@ -100,6 +100,11 @@ fn golden_run_functions() {
     check_golden("functions", "run");
 }
 
+#[test]
+fn golden_run_shapes() {
+    check_golden("shapes", "run");
+}
+
 // One trace golden pins the full enter/exit format; the other examples'
 // traces exercise no additional formatting.
 #[test]
@@ -434,4 +439,140 @@ fn new_builtins_evaluate() {
     assert_eq!(main_result("let main = () => List.range(-3.0)"), "[]");
     assert_eq!(main_result("let main = () => Math.sin(0.0)"), "0");
     assert_eq!(main_result("let main = () => Math.cos(0.0)"), "1");
+}
+
+// --- Variants + match (B5 part 1) ---
+
+const SHAPE: &str = "type Shape = | Circle(r: Float) | Rect(w: Float, h: Float) | Point\n";
+
+/// First matching arm wins, top to bottom — a catch-all above a more
+/// specific arm shadows it.
+#[test]
+fn first_matching_arm_wins() {
+    assert_eq!(
+        main_result("let main = () => match 1.0 with | x => \"first\" | 1.0 => \"second\""),
+        "\"first\""
+    );
+    assert_eq!(
+        main_result("let main = () => match 2.0 with | 1.0 => \"a\" | 2.0 => \"b\" | _ => \"c\""),
+        "\"b\""
+    );
+}
+
+#[test]
+fn constructor_patterns_bind_positionally() {
+    assert_eq!(
+        main_result(&format!(
+            "{SHAPE}let main = () => match Rect(3.0, 4.0) with | Circle(r) => r | Rect(w, h) => w * h | Point => 0.0"
+        )),
+        "12"
+    );
+    assert_eq!(
+        main_result(&format!(
+            "{SHAPE}let main = () => match Point with | Point => \"origin\" | _ => \"elsewhere\""
+        )),
+        "\"origin\""
+    );
+}
+
+/// No arm matching is a spanned runtime error naming the value.
+#[test]
+fn error_no_pattern_matched() {
+    let (message, line, col) = run_err(&format!(
+        "{SHAPE}let main = () => match Circle(2.0) with | Point => 0.0"
+    ));
+    assert_eq!(message, "no pattern matched Circle(2)");
+    assert_eq!((line, col), (2, 18));
+}
+
+/// Variants display as `Ctor(args…)` / bare `Ctor`, and equality is
+/// structural: same constructor, equal args.
+#[test]
+fn variant_display_and_structural_equality() {
+    assert_eq!(
+        main_result(&format!("{SHAPE}let main = () => [Circle(2.0), Point]")),
+        "[Circle(2), Point]"
+    );
+    assert_eq!(
+        main_result(&format!(
+            "{SHAPE}let main = () => Circle(2.0) == Circle(1.0 + 1.0)"
+        )),
+        "true"
+    );
+    assert_eq!(
+        main_result(&format!("{SHAPE}let main = () => Circle(2.0) == Point")),
+        "false"
+    );
+    // Different kinds are simply unequal, like everywhere else.
+    assert_eq!(
+        main_result(&format!("{SHAPE}let main = () => Circle(2.0) == 2.0")),
+        "false"
+    );
+}
+
+/// A function argument inside a variant hits the same function-comparison
+/// error as everywhere else. (Constructors check arity at runtime, not
+/// field types — the checker owns those.)
+#[test]
+fn error_variant_equality_over_functions() {
+    let (message, _, _) = run_err(&format!(
+        "{SHAPE}let main = () => Circle((x) => x) == Circle((x) => x)"
+    ));
+    assert_eq!(message, "functions cannot be compared with `==`");
+}
+
+/// An unapplied constructor is a function value with no equality.
+#[test]
+fn error_comparing_unapplied_ctors() {
+    let (message, _, _) = run_err(&format!("{SHAPE}let main = () => Circle == Circle"));
+    assert_eq!(message, "functions cannot be compared with `==`");
+}
+
+#[test]
+fn error_ctor_arity_at_runtime() {
+    let (message, _, _) = run_err(&format!("{SHAPE}let main = () => Circle(1.0, 2.0)"));
+    assert_eq!(message, "`Circle` takes 1 argument(s), got 2");
+    let (message, _, _) = run_err(&format!("{SHAPE}let main = () => Circle()"));
+    assert_eq!(message, "`Circle` takes 1 argument(s), got 0");
+}
+
+/// A parameterful constructor is first-class: it pipes through the builtins
+/// like any function.
+#[test]
+fn ctor_as_a_function_argument() {
+    assert_eq!(
+        main_result(&format!(
+            "{SHAPE}let main = () => [1.0, 2.0] |> List.map(Circle)"
+        )),
+        "[Circle(1), Circle(2)]"
+    );
+}
+
+/// A nullary constructor used bare IS the value — calling it is calling a
+/// variant, not a function.
+#[test]
+fn error_calling_a_nullary_ctor() {
+    let (message, _, _) = run_err(&format!("{SHAPE}let main = () => Point()"));
+    assert_eq!(message, "cannot call a variant");
+}
+
+/// Bool-literal matches are the language's first conditional.
+#[test]
+fn bool_match_is_a_conditional() {
+    assert_eq!(
+        main_result("let main = () => match 4.0 > 3.0 with | true => \"yes\" | false => \"no\""),
+        "\"yes\""
+    );
+}
+
+/// Lambdas may capture pattern variables (plain immutable bindings).
+#[test]
+fn closures_capture_pattern_vars() {
+    assert_eq!(
+        main_result(&format!(
+            "{SHAPE}let f = (s) => match s with | Circle(r) => (x) => r + x | _ => (x) => x\n\
+             let main = () => f(Circle(2.0))(3.0)"
+        )),
+        "5"
+    );
 }

--- a/mle/tests/run.rs
+++ b/mle/tests/run.rs
@@ -475,6 +475,19 @@ fn constructor_patterns_bind_positionally() {
     );
 }
 
+/// A leading `-` folds into a number-literal pattern. [Claude L — B5 review]
+#[test]
+fn negative_number_literal_pattern() {
+    assert_eq!(
+        main_result("let main = () => match 0.0 - 1.0 with | -1.0 => \"neg\" | _ => \"other\""),
+        "\"neg\""
+    );
+    assert_eq!(
+        main_result("let main = () => match 1.0 with | -1.0 => \"neg\" | _ => \"other\""),
+        "\"other\""
+    );
+}
+
 /// No arm matching is a spanned runtime error naming the value.
 #[test]
 fn error_no_pattern_matched() {


### PR DESCRIPTION
## What

The game-logic essentials: **variant `type` declarations and `match` expressions**, end-to-end through lexer → parser → lowering → interpreter → gradual typechecker → hover/LSP — the prerequisite for C4b-2 (messages as ADT variants).

```mle
type Shape =
  | Circle(radius: Float)
  | Rect(w: Float, h: Float)
  | Point

let area = (s: Shape): Float =>
  match s with
  | Circle(r) => 3.14 * r * r
  | Rect(w, _) => w * w
  | Point => 0.0
```

Design points (all documented in the `mle-language` skill, updated in this PR):
- **Ctors resolve bare and live in the value namespace** — unique across all variant types in a module; nullary ctors used bare ARE the value; parameterful ctors are first-class (`xs |> List.map(Circle)`) with runtime arity checks.
- **Patterns are deliberately shallow** (B5 scope): `Ctor(x, _)` / `Ctor` / var / `_` / literals — incl. negative numbers; no nested ctor patterns. First arm wins; no match is a spanned runtime error.
- **Greedy arm bodies** (F#/OCaml convention): nested `match` consumes following `|` arms — parenthesize. Leading `|` required before every arm/alternative.
- **Exhaustiveness** is checked when the scrutinee's type is known (variant ctors, `true`+`false`, literals-need-catch-all) and stays gradual for `Unknown`.
- Bool-literal match is now the language's conditional (`match x > 3.0 with | true => … | false => …`).

New golden example `mle/examples/shapes.mle` exercises the whole feature; `.ast`/`.ir`/`.run`/`.trace`/`.check` goldens committed.

## Cross-engine review (Claude subagent + Codex CLI)

Verdict: "correct, tightly scoped, unusually well-tested — ship it" (Claude); both engines' findings addressed in the follow-up commit:

- **[Codex M — fixed]** `==` with ONE known function operand (e.g. `Circle == x`, `x` unannotated) passed `check` but was a guaranteed runtime error — the checker now diagnoses whenever either side is known-`Fn`. Pin test added.
- **[Claude L — fixed]** Negative number literals couldn't be pattern-matched; `| -1.0 =>` now parses (patterns contain no expressions, so this is the only unary minus they need).
- **[Claude L — fixed]** `type Float = | Foo` shadowed the primitive in annotations → nonsense "expected Float, got Float"; redeclaring `Float`/`Bool`/`String`/`List` is now a lowering error (also fixes the pre-existing record variant of the same hole).
- **[BOTH — fixed]** Hand-written `Debug` impls kept old golden field names at the cost of permanent duplicate formatting logic — replaced with derived `Debug` + mechanical golden regen.
- **[Claude L — fixed]** Dead `Match` arm in hover's `children()`; SKILL.md shadowing nit.

## Verification

- `cargo test -p mle` — **179 tests**, all suites green (incl. new pin tests for every review finding)
- `cargo test -p functor_runtime_common` — 104 passed (on latest main: physics + #173 Angle)
- `cargo test -p mle-lsp` — 11 passed; `cargo build -p functor-runtime-desktop` clean
- CLI probes: `mle run/check/trace mle/examples/shapes.mle` clean
- No runtime changes needed: the `MleGame` producer holds the model as an opaque `Value`, so variant models flow through untouched (C4b-2 will exercise this as messages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
