### PR TITLE
feat(runtime): --stereo-sbs side-by-side stereo rendering in functor-runner

### DIFF
--- a/runtime/functor-runtime-common/src/camera.rs
+++ b/runtime/functor-runtime-common/src/camera.rs
@@ -49,6 +49,46 @@ impl Camera {
         Camera::look_at(eye, target, [0.0, 1.0, 0.0], fov)
     }
 
+    /// Split this camera into (left, right) eye cameras for stereo rendering,
+    /// separated by `ipd` (inter-pupillary distance, world units) along the
+    /// camera's right vector. Both eye and target shift together, keeping the
+    /// two gaze axes parallel (no toe-in — convergence comes from the viewer's
+    /// eyes, not the projection). Falls back to the original camera for a
+    /// degenerate gaze (eye == target, or looking exactly along `up`), so a
+    /// bad frame can't inject NaNs into the view matrix.
+    pub fn stereo_eyes(&self, ipd: f32) -> (Camera, Camera) {
+        let forward = vec3(
+            self.target[0] - self.eye[0],
+            self.target[1] - self.eye[1],
+            self.target[2] - self.eye[2],
+        );
+        let right = forward.cross(vec3(self.up[0], self.up[1], self.up[2]));
+        let len = (right.x * right.x + right.y * right.y + right.z * right.z).sqrt();
+        if !len.is_normal() {
+            return (self.clone(), self.clone());
+        }
+        let half = ipd / 2.0;
+        let shift = [
+            right.x / len * half,
+            right.y / len * half,
+            right.z / len * half,
+        ];
+        let shifted = |sign: f32| Camera {
+            eye: [
+                self.eye[0] + sign * shift[0],
+                self.eye[1] + sign * shift[1],
+                self.eye[2] + sign * shift[2],
+            ],
+            target: [
+                self.target[0] + sign * shift[0],
+                self.target[1] + sign * shift[1],
+                self.target[2] + sign * shift[2],
+            ],
+            ..self.clone()
+        };
+        (shifted(-1.0), shifted(1.0))
+    }
+
     pub fn view_matrix(&self) -> Matrix4<f32> {
         Matrix4::look_at_rh(
             Point3::new(self.eye[0], self.eye[1], self.eye[2]),
@@ -96,6 +136,73 @@ mod tests {
         // Horizontal scale shrinks by exactly the aspect ratio (so geometry
         // keeps its proportions; you just see more to the sides).
         assert!(approx(wide.x.x, square.x.x / 2.0));
+    }
+
+    // Eyes must sit `ipd` apart along the camera's right vector, with both
+    // gaze axes parallel to the original — the property that makes SBS stereo
+    // fuse correctly instead of toeing in.
+    #[test]
+    fn stereo_eyes_are_ipd_apart_with_parallel_gaze() {
+        // Looking down +Z from the origin, up = +Y, so right = -X… verify by
+        // construction instead: separation vector must have length ipd and be
+        // perpendicular to both forward and up.
+        let cam = Camera::look_at(
+            [1.0, 2.0, 3.0],
+            [4.0, 2.5, 7.0],
+            [0.0, 1.0, 0.0],
+            Angle::from_degrees(60.0),
+        );
+        let ipd = 0.064;
+        let (l, r) = cam.stereo_eyes(ipd);
+
+        let sep = [
+            r.eye[0] - l.eye[0],
+            r.eye[1] - l.eye[1],
+            r.eye[2] - l.eye[2],
+        ];
+        let sep_len = (sep[0] * sep[0] + sep[1] * sep[1] + sep[2] * sep[2]).sqrt();
+        assert!(approx(sep_len, ipd));
+
+        // Gaze direction identical for both eyes (parallel axes)…
+        for i in 0..3 {
+            let lg = l.target[i] - l.eye[i];
+            let rg = r.target[i] - r.eye[i];
+            let og = cam.target[i] - cam.eye[i];
+            assert!(approx(lg, og));
+            assert!(approx(rg, og));
+        }
+        // …and the separation is horizontal (perpendicular to up).
+        assert!(approx(sep[1], 0.0));
+        // Original camera sits at the midpoint.
+        for i in 0..3 {
+            assert!(approx((l.eye[i] + r.eye[i]) / 2.0, cam.eye[i]));
+        }
+    }
+
+    // A degenerate gaze (target == eye, or forward parallel to up) must not
+    // produce NaN cameras — fall back to the mono camera for that frame.
+    #[test]
+    fn stereo_eyes_degenerate_gaze_falls_back_to_mono() {
+        let stacked = Camera::look_at(
+            [0.0, 0.0, 0.0],
+            [0.0, 5.0, 0.0], // looking straight along up
+            [0.0, 1.0, 0.0],
+            Angle::from_degrees(45.0),
+        );
+        let zero = Camera::look_at(
+            [1.0, 1.0, 1.0],
+            [1.0, 1.0, 1.0], // eye == target
+            [0.0, 1.0, 0.0],
+            Angle::from_degrees(45.0),
+        );
+        for cam in [stacked, zero] {
+            let (l, r) = cam.stereo_eyes(0.064);
+            for v in [l.eye, l.target, r.eye, r.target] {
+                assert!(v.iter().all(|c| c.is_finite()));
+            }
+            assert_eq!(l.eye, cam.eye);
+            assert_eq!(r.eye, cam.eye);
+        }
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/renderer.rs
+++ b/runtime/functor-runtime-common/src/renderer.rs
@@ -7,7 +7,7 @@ use crate::asset::AssetCache;
 use crate::material::BasicMaterial;
 use crate::shadow::{self, ShadowMap};
 use crate::{
-    DebugRenderMode, Frame, FrameTime, RenderContext, RenderPass, Scene3D, SceneContext,
+    Camera, DebugRenderMode, Frame, FrameTime, RenderContext, RenderPass, Scene3D, SceneContext,
     ShadowUniforms, Viewport,
 };
 
@@ -32,6 +32,9 @@ pub fn render_frame(
     scene_context: &SceneContext,
     shadow_map: &ShadowMap,
     frame: &Frame,
+    // The camera to render from — usually `&frame.camera`; stereo shells pass
+    // each per-eye camera (`Camera::stereo_eyes`) with a per-eye viewport.
+    camera: &Camera,
     frame_time: FrameTime,
     viewport: Viewport,
     debug_render_mode: DebugRenderMode,
@@ -99,8 +102,8 @@ pub fn render_frame(
 
     // The game supplies the camera; derive view/projection from it + the aspect.
     let world_matrix = Matrix4::identity();
-    let view_matrix = frame.camera.view_matrix();
-    let projection_matrix = frame.camera.projection_matrix(viewport.aspect());
+    let view_matrix = camera.view_matrix();
+    let projection_matrix = camera.projection_matrix(viewport.aspect());
 
     // Root material for nodes that don't set their own (scenes typically override
     // per-node); initialized against this frame's context.

--- a/runtime/functor-runtime-desktop/src/bin/netsim_viz.rs
+++ b/runtime/functor-runtime-desktop/src/bin/netsim_viz.rs
@@ -211,6 +211,7 @@ fn main() {
                     &scene_context,
                     &shadow_map,
                     &frame,
+                    &frame.camera,
                     time.clone(),
                     viewport,
                     DebugRenderMode::Default,

--- a/runtime/functor-runtime-desktop/src/main.rs
+++ b/runtime/functor-runtime-desktop/src/main.rs
@@ -188,8 +188,19 @@ struct Args {
     /// Eye separation for --stereo-sbs, in world units. The default assumes
     /// meter-scale worlds (human IPD ≈ 64mm); raise it for larger-unit worlds
     /// to deepen the 3D effect.
-    #[arg(long, default_value_t = 0.064)]
+    #[arg(long, default_value_t = 0.064, value_parser = parse_stereo_ipd)]
     stereo_ipd: f32,
+}
+
+/// `--stereo-ipd` must be a positive, finite world-unit distance: NaN/inf
+/// would poison the eye cameras' view matrices, and a negative value would
+/// silently swap the eyes (inverted depth).
+fn parse_stereo_ipd(s: &str) -> Result<f32, String> {
+    let v: f32 = s.parse().map_err(|e| format!("{e}"))?;
+    if !v.is_finite() || v <= 0.0 {
+        return Err("must be a positive, finite distance in world units".into());
+    }
+    Ok(v)
 }
 
 /// Read back the framebuffer just rendered (called before swap_buffers, so the
@@ -808,10 +819,13 @@ Escape again to quit"
             // as the netsim viewer's panes.)
             if args.stereo_sbs {
                 let (left_cam, right_cam) = frame.camera.stereo_eyes(args.stereo_ipd);
+                // Odd widths: the right eye absorbs the extra column, so the
+                // two viewports tile the framebuffer exactly (no stale strip).
                 let half_w = (fb_width as u32) / 2;
+                let right_w = fb_width as u32 - half_w;
                 let eyes = [
                     (left_cam, functor_runtime_common::Viewport::with_offset(0, 0, half_w, fb_height as u32)),
-                    (right_cam, functor_runtime_common::Viewport::with_offset(half_w, 0, half_w, fb_height as u32)),
+                    (right_cam, functor_runtime_common::Viewport::with_offset(half_w, 0, right_w, fb_height as u32)),
                 ];
                 for (camera, eye_viewport) in &eyes {
                     gl.disable(glow::SCISSOR_TEST);

--- a/runtime/functor-runtime-desktop/src/main.rs
+++ b/runtime/functor-runtime-desktop/src/main.rs
@@ -175,6 +175,21 @@ struct Args {
     /// now; glTF models are unaffected until normal import lands.
     #[arg(long, value_enum, default_value_t = DebugRenderArg::Default)]
     debug_render: DebugRenderArg,
+
+    /// Render side-by-side stereo: the frame's camera is split into left/right
+    /// eye cameras (`--stereo-ipd` apart, parallel gaze) rendered into the
+    /// left|right halves of the window — the "full SBS" layout 3D displays
+    /// accept (e.g. Xreal glasses in 3D mode, which treat a 3840x1080 signal
+    /// as two 1920x1080 eyes). The UI overlay is drawn once across the whole
+    /// window, so it won't fuse in 3D — fine for dev, not for shipping.
+    #[arg(long)]
+    stereo_sbs: bool,
+
+    /// Eye separation for --stereo-sbs, in world units. The default assumes
+    /// meter-scale worlds (human IPD ≈ 64mm); raise it for larger-unit worlds
+    /// to deepen the 3D effect.
+    #[arg(long, default_value_t = 0.064)]
+    stereo_ipd: f32,
 }
 
 /// Read back the framebuffer just rendered (called before swap_buffers, so the
@@ -786,18 +801,47 @@ Escape again to quit"
                 player.respatialize_voices();
             }
 
-            // Shadow + forward passes, shared with the web runtime.
-            functor_runtime_common::render_frame(
-                &gl,
-                shader_version,
-                asset_cache.clone(),
-                &scene_context,
-                &shadow_map,
-                &frame,
-                time.clone(),
-                viewport,
-                args.debug_render.into(),
-            );
+            // Shadow + forward passes, shared with the web runtime. In stereo
+            // mode, render the same frame twice — once per eye camera into each
+            // half of the window. (The shadow pass runs per eye; it must start
+            // unscissored, so scissor is reset before each call — same contract
+            // as the netsim viewer's panes.)
+            if args.stereo_sbs {
+                let (left_cam, right_cam) = frame.camera.stereo_eyes(args.stereo_ipd);
+                let half_w = (fb_width as u32) / 2;
+                let eyes = [
+                    (left_cam, functor_runtime_common::Viewport::with_offset(0, 0, half_w, fb_height as u32)),
+                    (right_cam, functor_runtime_common::Viewport::with_offset(half_w, 0, half_w, fb_height as u32)),
+                ];
+                for (camera, eye_viewport) in &eyes {
+                    gl.disable(glow::SCISSOR_TEST);
+                    functor_runtime_common::render_frame(
+                        &gl,
+                        shader_version,
+                        asset_cache.clone(),
+                        &scene_context,
+                        &shadow_map,
+                        &frame,
+                        camera,
+                        time.clone(),
+                        *eye_viewport,
+                        args.debug_render.into(),
+                    );
+                }
+            } else {
+                functor_runtime_common::render_frame(
+                    &gl,
+                    shader_version,
+                    asset_cache.clone(),
+                    &scene_context,
+                    &shadow_map,
+                    &frame,
+                    &frame.camera,
+                    time.clone(),
+                    viewport,
+                    args.debug_render.into(),
+                );
+            }
 
             // 2D UI overlay: the game's declarative `ui model` View, lowered to a
             // text overlay on top of the 3D frame. Drawn before capture so it

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -1019,6 +1019,7 @@ async fn run_async() -> Result<(), JsValue> {
                 &scene_context,
                 &shadow_map,
                 &frame,
+                &frame.camera,
                 frame_time.clone(),
                 viewport,
                 debug_render_mode,


### PR DESCRIPTION
## What

First slice of the VR/Xreal track: render the game in side-by-side stereo for SBS 3D displays (e.g. Xreal One glasses in 3D mode, which treat a 3840x1080 signal as two 1920x1080 eyes).

- `Camera::stereo_eyes(ipd)` (functor-runtime-common): splits a camera into left/right eye cameras `ipd` apart along the camera's right vector, gaze axes parallel (no toe-in). Unit-tested: separation length, parallel gaze, midpoint, degenerate-gaze fallback (no NaNs).
- `render_frame` takes the camera explicitly (usually `&frame.camera`) so shells can render one `Frame` per eye without cloning the scene. Mono callers (web, netsim, default runner) unchanged.
- `functor-runner --stereo-sbs [--stereo-ipd <world units>]`: renders left|right halves, scissor reset per eye per the netsim pane contract. Odd widths tile exactly (right eye absorbs the extra column); `--stereo-ipd` rejects non-finite/non-positive values.

## Why

Foundation for both the Xreal dev-display path (3DoF head tracking next, IMU-over-TCP already verified on hardware) and the eventual Quest OpenXR runtime's per-eye rendering — same seam, shell-supplied camera + viewport.

## Demo

![side-by-side stereo demo](https://gist.githubusercontent.com/tommy-xr/3436930849cae43604ae72a2e4d85ba8/raw/stereo-demo.gif)

<sub>Side-by-side stereo of `examples/mle-hello` — left|right eye views with horizontal parallax. Rendered headlessly via `--capture-frame` / `--fixed-time`.</sub>

![stereo still](https://gist.githubusercontent.com/tommy-xr/3436930849cae43604ae72a2e4d85ba8/raw/stereo-still.png)

<sub>Mono (default) for comparison:</sub>

![mono still](https://gist.githubusercontent.com/tommy-xr/3436930849cae43604ae72a2e4d85ba8/raw/mono-still.png)

## Verification

- `cargo test -p functor_runtime_common` — 75 passed (4 new stereo/camera property tests)
- All desktop bins + wasm target compile; mono render path textually unchanged
- Headless capture of `examples/mle-hello` in SBS shows correct parallax (near objects shift more than far; halves vertically aligned; programmatic check: left/right differ, mostly explained by horizontal shift)
- /xreview (Claude + Codex): no Critical/High; both [AGREED] findings fixed and re-validated (capture byte-identical after fixes)

Known/accepted: shadow pass runs per eye (camera-independent, so 2x waste — noted for a later split of `render_frame`); UI text overlay draws once across the full window so it won't fuse in 3D (dev-only concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
