### PR TITLE
feat(physics,mle): Phase 2 — the MLE physics surface (Physics.* prelude + hook)

### DIFF
--- a/.claude/skills/mle-language/SKILL.md
+++ b/.claude/skills/mle-language/SKILL.md
@@ -150,7 +150,26 @@ Light.ambient(r, g, b) / Light.point(px, py, pz, r, g, b, intensity, range)
 Light.directional(dx, dy, dz, r, g, b, intensity) |> Light.castShadows
 Frame.create(camera, scene)                                // what draw returns
 Frame.createLit(camera, scene, [light, …])                 // lit + shadowed
+
+Physics.box(w, h, d) / sphere(r) / capsule(halfH, r)       // -> Shape (box = FULL extents)
+Physics.dynamic("tag", shape)                              // simulated body
+Physics.kinematic("tag", shape) / Physics.fixed("tag", shape)
+body |> Physics.at(x, y, z)                                // body-first: pipes
+body |> Physics.velocity(vx, vy, vz)
+body |> Physics.mass(m) / Physics.friction(f) / Physics.restitution(r)
+body |> Physics.sensor                                     // overlap-only, no forces
+Physics.scene(gx, gy, gz, [body, …])                       // what `physics` returns
+Physics.position("tag")                                    // {x, y, z} of the LIVE body
+scene |> Physics.transformed("tag")                        // scene at the body's live pose
 ```
+
+`Physics.position` / `Physics.transformed` read the live stepped world
+(MLE runs in the shell's process — no boundary). A tag not in the world is
+a **spanned runtime error** (there is no Option-shaped return to match on),
+so only read tags your `physics` hook declares. The tag is cross-frame
+identity: same tag = same body; drop a body by not declaring it.
+Re-declaring an *unchanged* body leaves the simulation alone; *changing*
+its declared position teleports it (the divergence rule, docs/physics.md).
 
 A runner-hosted game (`functor-runner --mle --game-path game.mle`) defines:
 
@@ -161,7 +180,18 @@ let draw = (model, tts) => Frame.create(camera, scene)
 let input = (model, key, isDown) => model'  // OPTIONAL; key = "W"/"Up"/"Space"
 let mouseMove = (model, x, y) => model'     // OPTIONAL; window pixels
 let mouseWheel = (model, delta) => model'   // OPTIONAL
+let physics = (model) => Physics.scene(0.0, -9.81, 0.0, [body, …])  // OPTIONAL
 ```
+
+Frame order: `tick` → `physics` (reconcile + fixed-step, 60Hz accumulator)
+→ `draw` — physics reads in `draw` see this frame's stepped world; reads in
+`tick` see the *previous* frame's (so on the very first frame, and inside
+the `physics` hook itself, declared bodies don't exist yet — keep reads in
+`draw`). The physics world survives hot reload (like the model); deleting
+the `physics` hook drops it. Gotcha: `--fixed-time T` pins the clock with
+`dts = 0`, so physics **never steps** under it — bodies render at their
+declared pose. Capture physics with plain `--capture-time` (and a settled
+scene for reproducibility) instead.
 
 A project dir with `functor.json` `{"language": "mle", "entry": "game.mle"}`
 works with the CLI: `functor -d dir build` (typecheck, diagnostics are

--- a/docs/physics.md
+++ b/docs/physics.md
@@ -82,7 +82,48 @@ Like rendering and audio, physics must be **drivable and observable headlessly**
 - **The `Simulatable` / `Timeline` seam** keeps the rewind strategy swappable and
   is the same machinery client prediction uses.
 
-## API (F#)
+## Surface: MLE-first
+
+**The game-facing surface lands in MLE, not F#** (decided 2026-07-03; see
+`docs/language-direction.md` — Functor is investing in MLE as the game-logic
+layer). The design below is unchanged — declarative scene, divergence rule,
+commands, subs — but the shipping vocabulary is the MLE prelude
+(`functor_runtime_common::mle_prelude`, documented in the `mle-language`
+skill):
+
+```mle
+let physics = (model) =>                       // OPTIONAL game hook
+  Physics.scene(0.0, -9.81, 0.0, [
+    Physics.fixed("ground", Physics.box(20.0, 0.2, 20.0)),
+    Physics.dynamic("crate", Physics.box(1.0, 1.0, 1.0)) |> Physics.at(0.0, 5.0, 0.0),
+  ])
+
+let draw = (model, tts) =>
+  Frame.create(camera,
+    Scene.cube() |> Scene.lit(0.8, 0.5, 0.2) |> Physics.transformed("crate"))
+```
+
+MLE dissolves the read-back boundary problem outright: the interpreter runs in
+the **shell's own process**, sharing the crate statics that hold the physics
+world — so `Physics.position(tag)` / `Physics.transformed(scene, tag)` are
+direct reads of the live stepped world (frame order: `tick` → `physics`
+reconcile+step → `draw`). The dylib producers could never have this: the game
+dylib links its own copy of `functor_runtime_common`, so its statics are not
+the shell's, and a view would have to cross as per-frame data. The F# sketch
+below is retained as the reference design (types/semantics match the Rust
+engine one-for-one); an F# surface would need that data-crossing `DrawContext`
+plumbing and is deferred indefinitely.
+
+Read semantics worth knowing: physics reads of a missing tag are **loud
+spanned errors** — games read only tags their `physics` hook declares. (An
+Option-shaped variant return is possible now that MLE has `match`; loud
+remains the default because a missing declared body is a bug, not a case.)
+
+Capture gotcha: `--fixed-time` pins the clock with `dts = 0`, so physics never
+steps under it — a physics golden captures a *settled* scene via plain
+`--capture-time` (rest poses are reproducible) rather than the fixed-time path.
+
+## API (F# — reference design, deferred)
 
 **Per-frame draw context.** `draw3d` takes a `DrawContext` record (not a bare
 `FrameTime`), destructured at the call site. This is the per-frame *extension
@@ -569,8 +610,9 @@ It's worth building in two steps, because they exercise different machinery:
 | --- | --- | --- |
 | **1a. World spine** | Rapier dep (`serde-serialize`, default features), `physics` module (`PhysicsScene`/`Body`/`reconcile`/`WorldId` registry), fixed-step accumulator, snapshot + text/JSON dump. Determinism + restore-replay goldens. **No F# surface.** | native+wasm (Rust) |
 | **1b. Timeline seam** | `Simulatable` + `Timeline` traits, `TimelineLog` with the three cadences (`keyframes(n)` default / `snapshot_ring` / `replay_only`), strategy-equivalence + replay goldens. | native+wasm (Rust) |
-| **2. `physicsScape` + read-back** | `Game` hook + builder/runner, reconcile pipeline, `DrawContext` record on `draw3d` (`ctx.physics` view), `Physics.synced` sub, `examples/hello-physics`. | both |
-| **2b. Debug visualization** | Rapier `debug-render` feature, `World::debug_lines()`, line pass in both shells, `--debug-render physics` mode + keyboard toggle in `hello-physics`. | both |
+| **2. MLE surface + read-back** | `Physics.*` prelude (shape/body/scene builders, `position`/`transformed` live reads), optional `physics` hook in the MLE driver (tick → reconcile+fixed-step → draw), prelude tests. | native (MLE) |
+| **2c. `examples/mle-physics`** | Crates settling on a ground slab, hot-reload demo, golden scenario, PR GIF/PNG. | native (MLE) |
+| **2b. Debug visualization** | Rapier `debug-render` feature, `World::debug_lines()`, line pass, `--debug-render physics` mode. | native |
 | **3. Commands** | `applyImpulse`/`applyForce`/`setVelocity`/`teleport` (plain-data effects). | both |
 | **4. Queries** | `raycast`/`shapeCast` (async tagger, token registry). | both |
 | **5. Collision events** | `Physics.events` sub. | both |

--- a/runtime/functor-runtime-common/src/mle_prelude.rs
+++ b/runtime/functor-runtime-common/src/mle_prelude.rs
@@ -22,7 +22,22 @@
 //! Camera.lookAt(ex, ey, ez, tx, ty, tz)                     -> Camera
 //!   (up is +Y; vertical fov pinned at 45°, near/far at protocol defaults)
 //! Frame.create(camera, scene)                               -> Frame
+//!
+//! Physics.box(w, h, d) / sphere(r) / capsule(hh, r)         -> Shape
+//! Physics.dynamic/kinematic/fixed(tag, shape)               -> Body
+//! Physics.at/velocity(body, x, y, z)                        -> Body
+//! Physics.mass/friction/restitution(body, n)                -> Body
+//! Physics.sensor(body)                                      -> Body
+//! Physics.scene(gx, gy, gz, [body, …])                      -> PhysicsScene
+//! Physics.position(tag)                                     -> {x, y, z}
+//! Physics.transformed(scene, tag)                           -> Scene
 //! ```
+//!
+//! The `Physics.*` reads target the singleton world the shell reconciles and
+//! steps each frame from the game's optional `physics` hook (see the desktop
+//! `MleGame` driver + docs/physics.md). MLE is interpreted in the shell's own
+//! process, so these are direct reads of live world state — the seam the
+//! dylib producers can't have.
 //!
 //! Scene-consuming functions take the scene FIRST, so they compose with
 //! `|>` (the piped value is prepended — see `mle`'s lowering docs):
@@ -50,6 +65,7 @@ use mle::{Host, RunError, Span, Value};
 use std::rc::Rc;
 
 use crate::math::Angle;
+use crate::physics;
 use crate::scene3d::MaterialDescription;
 use crate::{Camera, Frame, Light, Scene3D, SceneObject};
 
@@ -74,6 +90,43 @@ pub struct MleAngle(pub Angle);
 impl HostData for MleAngle {
     fn type_name(&self) -> &'static str {
         "Angle"
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+/// A [`physics::Shape`] as an opaque MLE value.
+pub struct MleShape(pub physics::Shape);
+
+/// A declared [`physics::Body`] as an opaque MLE value.
+pub struct MleBody(pub physics::Body);
+
+/// A [`physics::PhysicsScene`] as an opaque MLE value — what an MLE `physics`
+/// hook returns.
+pub struct MlePhysicsScene(pub physics::PhysicsScene);
+
+impl HostData for MleShape {
+    fn type_name(&self) -> &'static str {
+        "Shape"
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+impl HostData for MleBody {
+    fn type_name(&self) -> &'static str {
+        "Body"
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+impl HostData for MlePhysicsScene {
+    fn type_name(&self) -> &'static str {
+        "PhysicsScene"
     }
     fn as_any(&self) -> &dyn std::any::Any {
         self
@@ -125,6 +178,18 @@ pub fn frame_value(value: &Value) -> Option<&Frame> {
     }
 }
 
+/// Extract the [`physics::PhysicsScene`] from an MLE value (a `Physics.scene`
+/// result), for the shells' physics drive.
+pub fn physics_scene_value(value: &Value) -> Option<&physics::PhysicsScene> {
+    match value {
+        Value::HostData(data) => data
+            .as_any()
+            .downcast_ref::<MlePhysicsScene>()
+            .map(|s| &s.0),
+        _ => None,
+    }
+}
+
 /// The prelude host. Stateless; construct one per interpreter session.
 pub struct FunctorHost;
 
@@ -153,6 +218,21 @@ const PATHS: &[&str] = &[
     "Light.castShadows",
     "Frame.create",
     "Frame.createLit",
+    "Physics.box",
+    "Physics.sphere",
+    "Physics.capsule",
+    "Physics.dynamic",
+    "Physics.kinematic",
+    "Physics.fixed",
+    "Physics.at",
+    "Physics.velocity",
+    "Physics.mass",
+    "Physics.friction",
+    "Physics.restitution",
+    "Physics.sensor",
+    "Physics.scene",
+    "Physics.position",
+    "Physics.transformed",
 ];
 
 impl Host for FunctorHost {
@@ -381,6 +461,158 @@ impl Host for FunctorHost {
                 }
                 _ => usage("Frame.createLit(camera, scene, [light, …])"),
             },
+            // ── Physics (docs/physics.md; the declarative surface) ─────────
+            // Shapes are values, bodies are tag + shape + piped attributes,
+            // and the optional game hook `physics = (model) => Physics.scene(…)`
+            // declares the world each frame.
+            "Physics.box" => match args.as_slice() {
+                [w, h, d] => Ok(host(MleShape(physics::Shape::Cuboid {
+                    extents: [
+                        positive_num(w, span, "Physics.box width")? as f32,
+                        positive_num(h, span, "Physics.box height")? as f32,
+                        positive_num(d, span, "Physics.box depth")? as f32,
+                    ],
+                }))),
+                _ => usage("Physics.box(width, height, depth)"),
+            },
+            "Physics.sphere" => match args.as_slice() {
+                [r] => Ok(host(MleShape(physics::Shape::Sphere {
+                    radius: positive_num(r, span, "Physics.sphere radius")? as f32,
+                }))),
+                _ => usage("Physics.sphere(radius)"),
+            },
+            "Physics.capsule" => match args.as_slice() {
+                [half_height, r] => Ok(host(MleShape(physics::Shape::Capsule {
+                    half_height: positive_num(half_height, span, "Physics.capsule halfHeight")?
+                        as f32,
+                    radius: positive_num(r, span, "Physics.capsule radius")? as f32,
+                }))),
+                _ => usage("Physics.capsule(halfHeight, radius)"),
+            },
+            "Physics.dynamic" | "Physics.kinematic" | "Physics.fixed" => match args.as_slice() {
+                [Value::String(tag), shape] => match shape_of(shape) {
+                    Some(shape) => {
+                        let tag = tag.to_string();
+                        let shape = shape.clone();
+                        Ok(host(MleBody(match path {
+                            "Physics.dynamic" => physics::Body::dynamic(tag, shape),
+                            "Physics.kinematic" => physics::Body::kinematic(tag, shape),
+                            _ => physics::Body::fixed(tag, shape),
+                        })))
+                    }
+                    None => usage(&format!("{path}(tag, shape)")),
+                },
+                _ => usage(&format!("{path}(tag, shape)")),
+            },
+            // Body first, so they pipe:
+            // `Physics.dynamic("crate", Physics.box(1.0, 1.0, 1.0)) |> Physics.at(0.0, 5.0, 0.0)`.
+            "Physics.at" | "Physics.velocity" => match args.as_slice() {
+                [body, x, y, z] => match body_of(body) {
+                    Some(inner) => {
+                        let v = [
+                            num(x, span)? as f32,
+                            num(y, span)? as f32,
+                            num(z, span)? as f32,
+                        ];
+                        Ok(host(MleBody(if path == "Physics.at" {
+                            inner.clone().at(v)
+                        } else {
+                            inner.clone().with_velocity(v)
+                        })))
+                    }
+                    None => usage(&format!("{path}(body, x, y, z)")),
+                },
+                _ => usage(&format!("{path}(body, x, y, z)")),
+            },
+            "Physics.mass" | "Physics.friction" | "Physics.restitution" => match args.as_slice() {
+                [body, n] => match body_of(body) {
+                    Some(inner) => {
+                        let n = match path {
+                            "Physics.mass" => positive_num(n, span, "Physics.mass")?,
+                            _ => non_negative_num(n, span, path)?,
+                        } as f32;
+                        Ok(host(MleBody(match path {
+                            "Physics.mass" => inner.clone().with_mass(n),
+                            "Physics.friction" => inner.clone().with_friction(n),
+                            _ => inner.clone().with_restitution(n),
+                        })))
+                    }
+                    None => usage(&format!("{path}(body, n)")),
+                },
+                _ => usage(&format!("{path}(body, n)")),
+            },
+            "Physics.sensor" => match args.as_slice() {
+                [body] => match body_of(body) {
+                    Some(inner) => Ok(host(MleBody(inner.clone().as_sensor()))),
+                    None => usage("Physics.sensor(body)"),
+                },
+                _ => usage("Physics.sensor(body)"),
+            },
+            "Physics.scene" => match args.as_slice() {
+                [gx, gy, gz, Value::List(items)] => {
+                    let gravity = [
+                        num(gx, span)? as f32,
+                        num(gy, span)? as f32,
+                        num(gz, span)? as f32,
+                    ];
+                    let mut bodies = Vec::with_capacity(items.len());
+                    for item in items.iter() {
+                        match body_of(item) {
+                            Some(body) => bodies.push(body.clone()),
+                            None => {
+                                return err(format!(
+                                    "Physics.scene bodies must be Bodies, got {}",
+                                    item.kind_name()
+                                ))
+                            }
+                        }
+                    }
+                    Ok(host(MlePhysicsScene(physics::PhysicsScene::create(
+                        gravity, bodies,
+                    ))))
+                }
+                _ => usage("Physics.scene(gx, gy, gz, [body, …])"),
+            },
+            // Reads of the LIVE stepped world (the singleton, world 0). MLE
+            // runs in the same process as the world the shell steps, so these
+            // are direct reads — no boundary, no copy (the dylib producers
+            // can't do this; MLE can). A tag that isn't in the world is a
+            // loud spanned error — declare the body before reading. (An
+            // Option-shaped variant return could come now that B5 match
+            // exists, but loud-by-default is right for the common case.)
+            "Physics.position" => match args.as_slice() {
+                [Value::String(tag)] => match live_transform(tag) {
+                    Some((pos, _)) => Ok(Value::Record(Rc::new(vec![
+                        ("x".to_string(), Value::Number(pos[0] as f64)),
+                        ("y".to_string(), Value::Number(pos[1] as f64)),
+                        ("z".to_string(), Value::Number(pos[2] as f64)),
+                    ]))),
+                    None => err(no_body(tag)),
+                },
+                _ => usage("Physics.position(tag)"),
+            },
+            // Scene first, so it pipes: the way MLE draws a physics body —
+            // `Scene.cube() |> Scene.lit(…) |> Physics.transformed("crate-1")`
+            // places the visual at the body's live pose (position + rotation).
+            "Physics.transformed" => match args.as_slice() {
+                [scene, Value::String(tag)] => {
+                    let Some(inner) = scene_of(scene) else {
+                        return usage("Physics.transformed(scene, tag)");
+                    };
+                    match live_transform(tag) {
+                        Some((pos, rot)) => {
+                            // cgmath's Quaternion::new is scalar-FIRST (w, x, y, z).
+                            let rotation = cgmath::Quaternion::new(rot[3], rot[0], rot[1], rot[2]);
+                            let xform = Matrix4::from_translation(cgmath::vec3(
+                                pos[0], pos[1], pos[2],
+                            )) * Matrix4::from(rotation);
+                            scene_value(group(vec![inner.clone()], xform))
+                        }
+                        None => err(no_body(tag)),
+                    }
+                }
+                _ => usage("Physics.transformed(scene, tag)"),
+            },
             "Frame.create" => match args.as_slice() {
                 [camera, scene] => {
                     let (Value::HostData(cam), Some(scene)) = (camera, scene_of(scene)) else {
@@ -441,6 +673,35 @@ Angle.degrees(…) or Angle.radians(…)"
     }
 }
 
+/// Physical dimensions (shape extents, radii, mass) must be strictly
+/// positive: Rapier accepts a negative radius and silently builds a
+/// degenerate collider that misbehaves far from the declaration — so reject
+/// it loud at the boundary.
+fn positive_num(value: &Value, span: Span, what: &str) -> Result<f64, RunError> {
+    let n = num(value, span)?;
+    if n > 0.0 {
+        Ok(n)
+    } else {
+        Err(RunError {
+            message: format!("{what} must be positive, got {n}"),
+            span,
+        })
+    }
+}
+
+/// Friction/restitution are coefficients: zero is meaningful, negative is not.
+fn non_negative_num(value: &Value, span: Span, what: &str) -> Result<f64, RunError> {
+    let n = num(value, span)?;
+    if n >= 0.0 {
+        Ok(n)
+    } else {
+        Err(RunError {
+            message: format!("{what} must not be negative, got {n}"),
+            span,
+        })
+    }
+}
+
 fn light_of(value: &Value) -> Option<&Light> {
     match value {
         Value::HostData(data) => data.as_any().downcast_ref::<MleLight>().map(|l| &l.0),
@@ -453,6 +714,33 @@ fn scene_of(value: &Value) -> Option<&Scene3D> {
         Value::HostData(data) => data.as_any().downcast_ref::<MleScene>().map(|s| &s.0),
         _ => None,
     }
+}
+
+fn shape_of(value: &Value) -> Option<&physics::Shape> {
+    match value {
+        Value::HostData(data) => data.as_any().downcast_ref::<MleShape>().map(|s| &s.0),
+        _ => None,
+    }
+}
+
+fn body_of(value: &Value) -> Option<&physics::Body> {
+    match value {
+        Value::HostData(data) => data.as_any().downcast_ref::<MleBody>().map(|b| &b.0),
+        _ => None,
+    }
+}
+
+/// Live pose of a body in the singleton world (the world the shell steps —
+/// same process, same crate statics as this prelude).
+fn live_transform(tag: &str) -> Option<([f32; 3], [f32; 4])> {
+    physics::with_world(physics::DEFAULT_WORLD, |w| w.body_transform(tag)).flatten()
+}
+
+fn no_body(tag: &str) -> String {
+    format!(
+        "no body tagged \"{tag}\" in the physics world (bodies exist after the \
+         frame's `physics` declaration has been reconciled and stepped)"
+    )
 }
 
 fn host(data: impl HostData + 'static) -> Value {
@@ -703,6 +991,125 @@ Scene.cube() |> Scene.rotateY(Angle.radians(1.5707964)))",
                 "`{path}` fell through to the internal fallback: {message}"
             );
         }
+    }
+
+    // The physics vocabulary: an MLE snippet declares a PhysicsScene the
+    // shells can hand to `World::reconcile` — bodies, attributes, gravity.
+    #[test]
+    fn mle_snippet_declares_a_physics_scene() {
+        let value = eval(
+            "let crate1 = Physics.dynamic(\"crate-1\", Physics.box(1.0, 1.0, 1.0))\n\
+             |> Physics.at(0.0, 5.0, 0.0)\n\
+             |> Physics.velocity(1.0, 0.0, 0.0)\n\
+             |> Physics.mass(2.0)\n\
+             |> Physics.restitution(0.5)\n\
+             let main = () => Physics.scene(0.0, -9.81, 0.0, [\n\
+               Physics.fixed(\"ground\", Physics.box(20.0, 0.2, 20.0)),\n\
+               crate1,\n\
+               Physics.kinematic(\"door\", Physics.capsule(1.0, 0.3)) |> Physics.sensor,\n\
+             ])",
+        );
+        let scene = physics_scene_value(&value).expect("a PhysicsScene");
+        assert_eq!(scene.gravity, [0.0, -9.81, 0.0]);
+        assert_eq!(scene.bodies.len(), 3);
+        assert_eq!(scene.bodies[0].tag, "ground");
+        assert_eq!(scene.bodies[1].position, [0.0, 5.0, 0.0]);
+        assert_eq!(scene.bodies[1].velocity, [1.0, 0.0, 0.0]);
+        assert_eq!(scene.bodies[1].mass, Some(2.0));
+        assert_eq!(scene.bodies[1].restitution, 0.5);
+        assert!(scene.bodies[2].sensor);
+    }
+
+    // End to end across the seam: reconcile + step the singleton world the
+    // way the MleGame driver does, then read it back from MLE — the in-process
+    // live read that is the whole point of the MLE surface.
+    #[test]
+    fn physics_reads_see_the_stepped_world() {
+        crate::physics::remove_world(crate::physics::DEFAULT_WORLD);
+        let declare = eval(
+            "let main = () => Physics.scene(0.0, -9.81, 0.0, [\n\
+               Physics.dynamic(\"ball\", Physics.sphere(0.5)) |> Physics.at(0.0, 5.0, 0.0)])",
+        );
+        let scene = physics_scene_value(&declare).expect("a PhysicsScene").clone();
+        crate::physics::with_world(crate::physics::DEFAULT_WORLD, |w| {
+            w.reconcile(&scene);
+            for _ in 0..30 {
+                w.step_fixed();
+            }
+        });
+
+        // Physics.position sees the fallen ball…
+        let pos = eval("let main = () => Physics.position(\"ball\")");
+        let Value::Record(fields) = &pos else {
+            panic!("expected a record, got {}", pos.kind_name());
+        };
+        let y = fields
+            .iter()
+            .find(|(k, _)| k == "y")
+            .and_then(|(_, v)| match v {
+                Value::Number(n) => Some(*n),
+                _ => None,
+            })
+            .expect("y field");
+        assert!(y < 5.0, "ball should have fallen, y = {y}");
+
+        // …and Physics.transformed places a scene node at the live pose.
+        let drawn = eval(
+            "let main = () => Scene.sphere() |> Physics.transformed(\"ball\")",
+        );
+        let scene3d = scene_of(&drawn).expect("a Scene");
+        assert!((scene3d.xform.w.y as f64 - y).abs() < 1e-6);
+
+        crate::physics::remove_world(crate::physics::DEFAULT_WORLD);
+    }
+
+    // Degenerate physical dimensions are boundary errors — Rapier would
+    // silently build a broken collider, and MLE can't branch to notice.
+    #[test]
+    fn non_positive_dimensions_are_rejected() {
+        for (src, needle) in [
+            ("Physics.sphere(-0.5)", "Physics.sphere radius must be positive"),
+            ("Physics.box(1.0, 0.0, 1.0)", "Physics.box height must be positive"),
+            (
+                "Physics.dynamic(\"x\", Physics.sphere(0.5)) |> Physics.mass(0.0)",
+                "Physics.mass must be positive",
+            ),
+            (
+                "Physics.dynamic(\"x\", Physics.sphere(0.5)) |> Physics.friction(-1.0)",
+                "Physics.friction must not be negative",
+            ),
+        ] {
+            let module = mle::lower(
+                mle::parse(&format!("let main = () => {src}")).unwrap(),
+            )
+            .unwrap();
+            let failure = mle::run_with_host(&module, Tracing::Off, &mut FunctorHost)
+                .err()
+                .unwrap_or_else(|| panic!("`{src}` should fail"));
+            assert!(
+                failure.error.message.contains(needle),
+                "`{src}`: got {}",
+                failure.error.message
+            );
+        }
+    }
+
+    // A missing tag is a loud spanned error, not a sentinel value.
+    #[test]
+    fn physics_read_of_unknown_tag_is_a_spanned_error() {
+        crate::physics::remove_world(crate::physics::DEFAULT_WORLD);
+        let module = mle::lower(
+            mle::parse("let main = () => Physics.position(\"ghost\")").unwrap(),
+        )
+        .unwrap();
+        let failure = mle::run_with_host(&module, Tracing::Off, &mut FunctorHost)
+            .err()
+            .expect("should fail");
+        assert!(
+            failure.error.message.contains("no body tagged \"ghost\""),
+            "got: {}",
+            failure.error.message
+        );
     }
 
     // `main` bound to a host function errors like a builtin, not a value.

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -10,7 +10,13 @@
 //! let init = { … }                       // the initial model (a value)
 //! let tick = (model, dt, tts) => model'  // per-frame step
 //! let draw = (model, tts) => Frame.create(camera, scene)
+//! let physics = (model) => Physics.scene(gx, gy, gz, [body, …])  // OPTIONAL
 //! ```
+//!
+//! Frame order with physics: tick → physics (reconcile + fixed-step the
+//! singleton world) → draw, so `Physics.position`/`Physics.transformed` in
+//! `draw` read the frame's stepped world. The world lives in this process's
+//! registry, so like the model it survives hot reload.
 //!
 //! The model is a plain MLE value the host holds between frames — the
 //! serializable-state seam hot-reload (C3) will swap sessions around.
@@ -19,7 +25,8 @@
 
 use std::time::Instant;
 
-use functor_runtime_common::mle_prelude::{frame_value, FunctorHost};
+use functor_runtime_common::mle_prelude::{frame_value, physics_scene_value, FunctorHost};
+use functor_runtime_common::physics;
 use functor_runtime_common::ui::View;
 use functor_runtime_common::{Frame, FrameTime};
 use mle::{Session, Value};
@@ -35,6 +42,7 @@ pub struct MleGame {
     has_input: bool,
     has_mouse_move: bool,
     has_mouse_wheel: bool,
+    has_physics: bool,
     /// The last successfully drawn frame, kept so a bad draw shows the last
     /// good picture instead of a blank.
     last_frame: Frame,
@@ -43,9 +51,12 @@ pub struct MleGame {
     /// changes).
     last_error: Option<String>,
     // rolling per-frame eval cost, printed every STATS_EVERY frames (the C6
-    // perf gate watches these).
+    // perf gate watches these). Physics is engine cost, not MLE eval cost, so
+    // it gets its own counter — a heavy scene must not read as an interpreter
+    // regression.
     frames: u64,
     tick_ns: u64,
+    physics_ns: u64,
     draw_ns: u64,
 }
 
@@ -60,6 +71,7 @@ struct Loaded {
     has_input: bool,
     has_mouse_move: bool,
     has_mouse_wheel: bool,
+    has_physics: bool,
 }
 
 /// Load, check, and contract-validate a game file. Errors come back as fully
@@ -112,6 +124,13 @@ fn load_game(path: &str) -> Result<Loaded, String> {
     if has_mouse_wheel {
         require_function(path, &session, "mouseWheel", 2)?;
     }
+    // Optional physics: `physics(model) => Physics.scene(…)` declares the
+    // bodies that should exist; the host reconciles + fixed-steps the world
+    // after each tick (docs/physics.md).
+    let has_physics = session.global("physics").is_some();
+    if has_physics {
+        require_function(path, &session, "physics", 1)?;
+    }
     Ok(Loaded {
         src,
         session,
@@ -119,6 +138,7 @@ fn load_game(path: &str) -> Result<Loaded, String> {
         has_input,
         has_mouse_move,
         has_mouse_wheel,
+        has_physics,
     })
 }
 
@@ -151,38 +171,74 @@ impl MleGame {
             has_input: loaded.has_input,
             has_mouse_move: loaded.has_mouse_move,
             has_mouse_wheel: loaded.has_mouse_wheel,
+            has_physics: loaded.has_physics,
             last_frame: empty_frame(),
             last_error: None,
             frames: 0,
             tick_ns: 0,
+            physics_ns: 0,
             draw_ns: 0,
         }
     }
 
-    /// Report a per-frame error with its source position, once per distinct
-    /// message (a 60fps loop must not flood stderr with one persistent bug).
-    fn frame_error(&mut self, stage: &str, err: &mle::RunError) {
-        let (line, col) = mle::line_col(&self.src, err.span.start);
-        let rendered = format!(
-            "[mle] {stage} error at {}:{line}:{col}: {}",
-            self.path, err.message
-        );
+    /// Print a per-frame problem once per distinct message — a 60fps loop must
+    /// not flood stderr with one persistent bug.
+    fn report_once(&mut self, rendered: String) {
         if self.last_error.as_deref() != Some(rendered.as_str()) {
             eprintln!("{rendered}");
             self.last_error = Some(rendered);
         }
     }
 
+    /// Report a per-frame error with its source position (deduped).
+    fn frame_error(&mut self, stage: &str, err: &mle::RunError) {
+        let (line, col) = mle::line_col(&self.src, err.span.start);
+        let rendered = format!(
+            "[mle] {stage} error at {}:{line}:{col}: {}",
+            self.path, err.message
+        );
+        self.report_once(rendered);
+    }
+
+    /// The frame's physics phase (docs/physics.md): ask the game what bodies
+    /// should exist, reconcile the singleton world to match, and advance it in
+    /// fixed substeps. Runs after `tick` so declarations come from the settled
+    /// model, and before `render` so `Physics.position`/`Physics.transformed`
+    /// in `draw` read the just-stepped world.
+    fn step_physics(&mut self, dts: f32) {
+        if !self.has_physics {
+            return;
+        }
+        let args = vec![self.model.clone()];
+        match self.session.call("physics", args, &mut FunctorHost) {
+            Ok(value) => match physics_scene_value(&value) {
+                Some(scene) => {
+                    physics::with_world(physics::DEFAULT_WORLD, |w| {
+                        w.reconcile(scene);
+                        w.step_frame(dts);
+                    });
+                }
+                None => self.report_once(format!(
+                    "[mle] physics must return Physics.scene(gx, gy, gz, [body, …]), got {}",
+                    value.kind_name()
+                )),
+            },
+            Err(err) => self.frame_error("physics", &err),
+        }
+    }
+
     fn report_stats(&mut self) {
         if self.frames > 0 && self.frames % STATS_EVERY == 0 {
             let tick_us = self.tick_ns as f64 / STATS_EVERY as f64 / 1000.0;
+            let physics_us = self.physics_ns as f64 / STATS_EVERY as f64 / 1000.0;
             let draw_us = self.draw_ns as f64 / STATS_EVERY as f64 / 1000.0;
             println!(
-                "[mle] avg over {STATS_EVERY} frames: tick {tick_us:.1}µs, draw {draw_us:.1}µs \
-                 ({:.1}% of a 60fps budget)",
-                (tick_us + draw_us) / 16_666.0 * 100.0
+                "[mle] avg over {STATS_EVERY} frames: tick {tick_us:.1}µs, physics \
+                 {physics_us:.1}µs, draw {draw_us:.1}µs ({:.1}% of a 60fps budget)",
+                (tick_us + physics_us + draw_us) / 16_666.0 * 100.0
             );
             self.tick_ns = 0;
+            self.physics_ns = 0;
             self.draw_ns = 0;
         }
     }
@@ -211,6 +267,14 @@ impl Game for MleGame {
                 self.has_input = loaded.has_input;
                 self.has_mouse_move = loaded.has_mouse_move;
                 self.has_mouse_wheel = loaded.has_mouse_wheel;
+                self.has_physics = loaded.has_physics;
+                // The physics world is deliberately KEPT, like the model: it
+                // lives in this process's registry, so bodies stay where they
+                // are across the edit and the next frame's declaration
+                // re-diffs against them (removing the hook drops the world).
+                if !self.has_physics {
+                    physics::remove_world(physics::DEFAULT_WORLD);
+                }
                 self.last_error = None;
                 println!(
                     "[mle] hot-reloaded {} in {:.2}ms (model preserved; an edited `init` \
@@ -220,11 +284,7 @@ takes effect on restart)",
                 );
             }
             Err(message) => {
-                let rendered = format!("[mle] reload failed, keeping old program: {message}");
-                if self.last_error.as_deref() != Some(rendered.as_str()) {
-                    eprintln!("{rendered}");
-                    self.last_error = Some(rendered);
-                }
+                self.report_once(format!("[mle] reload failed, keeping old program: {message}"));
             }
         }
     }
@@ -241,6 +301,9 @@ takes effect on restart)",
             Err(err) => self.frame_error("tick", &err),
         }
         self.tick_ns += started.elapsed().as_nanos() as u64;
+        let physics_started = Instant::now();
+        self.step_physics(frame_time.dts);
+        self.physics_ns += physics_started.elapsed().as_nanos() as u64;
         self.frames += 1;
         self.report_stats();
     }
@@ -297,16 +360,10 @@ takes effect on restart)",
         match self.session.call("draw", args, &mut FunctorHost) {
             Ok(value) => match frame_value(&value) {
                 Some(frame) => self.last_frame = frame.clone(),
-                None => {
-                    let rendered = format!(
-                        "[mle] draw must return Frame.create(camera, scene), got {}",
-                        value.kind_name()
-                    );
-                    if self.last_error.as_deref() != Some(rendered.as_str()) {
-                        eprintln!("{rendered}");
-                        self.last_error = Some(rendered);
-                    }
-                }
+                None => self.report_once(format!(
+                    "[mle] draw must return Frame.create(camera, scene), got {}",
+                    value.kind_name()
+                )),
             },
             Err(err) => self.frame_error("draw", &err),
         }


### PR DESCRIPTION
Phase **2** of docs/physics.md — **pivoted to an MLE-only game surface** (per docs/language-direction.md: MLE is the game-logic bet). The doc gains a "Surface: MLE-first" section; the F# `physicsScape`/`DrawContext` sketch stays as deferred reference.

**Why MLE dissolves the hard problem:** MLE is interpreted in the shell's own process, sharing the crate statics that hold the physics world — so `Physics.position`/`Physics.transformed` are *direct reads of the live stepped world*. The dylib producers could never have this (the game dylib links its own copy of `functor_runtime_common`, so its statics aren't the shell's); the F# plan needed per-frame view data plumbed through a `DrawContext` migration across nine examples. Here it's two host functions.

## The surface

```mle
let physics = (model) =>                       // OPTIONAL hook, arity-checked at load
  Physics.scene(0.0, -9.81, 0.0, [
    Physics.fixed("ground", Physics.box(20.0, 0.2, 20.0)),
    Physics.dynamic("crate", Physics.box(1.0, 1.0, 1.0)) |> Physics.at(0.0, 4.0, 0.0),
  ])

let draw = (model, tts) =>
  Frame.create(camera,
    Scene.cube() |> Scene.lit(0.9, 0.5, 0.2) |> Physics.transformed("crate"))
```

Frame order: `tick` → `physics` (reconcile + fixed-step accumulator) → `draw`, so draw-time reads see the just-stepped world. The world **survives hot reload** like the model — edit `game.mle` mid-simulation and the crates stay put. Physics gets its own perf counter so the C6 gate's tick stat stays pure interpreter cost.

Boundary validation: physical dimensions must be positive (Rapier silently builds degenerate colliders from negative radii, and MLE has no conditionals to notice); a read of an undeclared tag is a loud spanned error for the same reason.

## It works

Live `functor-runner --mle` capture — the crate falls and comes to rest on the slab, drawn entirely via `Physics.transformed`:

![fall](https://gist.githubusercontent.com/tommy-xr/a8cd81b9b079b4764b3de475444b772b/raw/mle-physics.gif)

| t = 0.3s (mid-fall) | t = 2.5s (at rest) |
| --- | --- |
| ![t0](https://gist.githubusercontent.com/tommy-xr/a8cd81b9b079b4764b3de475444b772b/raw/phys-t0.png) | ![t2](https://gist.githubusercontent.com/tommy-xr/a8cd81b9b079b4764b3de475444b772b/raw/phys-t2.png) |

## Testing

- `cargo test -p functor_runtime_common` — 106 passed (14 prelude, incl. an end-to-end that declares a scene in MLE, reconciles+steps the world, and reads the fallen pose back through `Physics.position`/`Physics.transformed`)
- `--features strict` clean on both crates; wasm32 check clean
- Cross-engine review (`/xreview`) run: the agreed finding (unvalidated physical dimensions) fixed with tests; declined the suggestion to skip `draw` on physics-hook errors — the module's contract is "a bad frame keeps the last good state and the session keeps running", and freezing the world while continuing to render is that contract.
- Documented gotcha (found in review): `--fixed-time` pins `dts = 0` so physics never steps under it — physics captures use plain `--capture-time` with settled scenes.

The `mle-language` skill is updated in the same PR (its "keeping this skill honest" rule).

Next: `examples/mle-physics` (2c) + debug wireframes (2b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)