### PR TITLE
feat(runtime): --hidden — capture/debug runs without stealing input

### DIFF
--- a/.claude/skills/pr-visuals/SKILL.md
+++ b/.claude/skills/pr-visuals/SKILL.md
@@ -55,6 +55,8 @@ The CLI forwards capture flags to `functor-runner`:
   PNGs) — use it for stills and every GIF frame.
 - `--capture-time` is wall-clock seconds before the shot; `0.8` is enough for the
   window/GL to initialize.
+- `--capture-frame` implies `--hidden`: the GL window is never shown and never
+  steals focus or the cursor, so captures are safe to run while the user works.
 - Pick 1–2 flattering times for the stills.
 
 ## 3. Capture a looping GIF

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,11 @@ own framebuffer; ideal for verifying rendering changes). The CLI forwards extra 
 Add `--fixed-time T` to pin the game's frame time to a constant `T`, making the rendered pose
 deterministic (byte-identical PNGs) for reproducible captures and golden images.
 
+`--capture-frame` implies `--hidden`: the GL window is created invisible and never takes focus
+or captures the cursor, so capture runs don't steal input from the user. For debug-server
+sessions (`--debug-port`) prefer passing `--hidden` explicitly — or `--headless` when no pixels
+are needed at all (see `docs/debug-runtime.md`).
+
 **Golden-image test:** `npm run test:golden` renders `hello` at a fixed time and compares the
 capture to a committed reference (`runtime/functor-runtime-desktop/tests/golden.rs`). It's
 `#[ignore]`d (needs a GL display + the built dylib), so it runs locally/manually, not in CI.

--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -41,6 +41,19 @@ GPU window. Limitations vs. windowed:
   delivered — don't gate game logic on audio completion when running headless.
 - `--capture-frame` is rejected (it needs GL).
 
+## Hidden window mode
+
+If you need **pixels** but not a window, add `--hidden` instead: the GL window is
+created but never shown, never takes focus, and never captures the cursor, so a
+run doesn't steal input from whoever is at the machine. A hidden window keeps a
+valid GL context and framebuffer, so rendering, `/capture`, and `--capture-frame`
+work unchanged (audio too). `--capture-frame` implies `--hidden` — a scripted
+screenshot run has no reason to grab your mouse.
+
+```sh
+functor-runner --game-path <dylib> --debug-port 8077 --hidden
+```
+
 ## Endpoints
 
 `GET /` returns this list as JSON (discoverability).

--- a/runtime/functor-runtime-desktop/src/main.rs
+++ b/runtime/functor-runtime-desktop/src/main.rs
@@ -149,9 +149,17 @@ struct Args {
     #[arg(long)]
     headless: bool,
 
+    /// Create the GL window hidden: it is never shown, never takes focus, and
+    /// never captures the cursor, so a run doesn't steal input from the user.
+    /// A hidden window keeps a valid GL context and framebuffer, so rendering,
+    /// --capture-frame, and the debug server's /capture all work unchanged.
+    /// Implied by --capture-frame. (With --headless there is no window at all.)
+    #[arg(long, conflicts_with = "headless")]
+    hidden: bool,
+
     /// Write a PNG of the rendered frame to this path, then exit. The capture
     /// happens on the first frame after --capture-time seconds of wall-clock
-    /// time, so assets have a chance to load.
+    /// time, so assets have a chance to load. Implies --hidden.
     #[arg(long)]
     capture_frame: Option<String>,
 
@@ -531,6 +539,11 @@ pub async fn main() {
         return;
     }
 
+    // Hidden window: never shown / focused / cursor-capturing, so the run
+    // doesn't steal input from the user. Capture runs are hidden by default —
+    // there's no reason a scripted screenshot should grab the mouse.
+    let hidden = args.hidden || args.capture_frame.is_some();
+
     unsafe {
         let (gl, shader_version, mut window, mut glfw, events) = {
             use glfw::Context;
@@ -543,6 +556,9 @@ pub async fn main() {
             ));
             #[cfg(target_os = "macos")]
             glfw.window_hint(glfw::WindowHint::OpenGlForwardCompat(true));
+            if hidden {
+                glfw.window_hint(glfw::WindowHint::Visible(false));
+            }
 
             // glfw window creation
             // --------------------
@@ -562,7 +578,10 @@ pub async fn main() {
             // hot-reload loop: tweak code in the editor while the game runs);
             // click recaptures; Escape while released quits. Losing focus
             // also releases, so cmd-tabbing away hands the pointer back.
-            window.set_cursor_mode(glfw::CursorMode::Disabled);
+            // A hidden window never gets focus, so it must not grab the cursor.
+            if !hidden {
+                window.set_cursor_mode(glfw::CursorMode::Disabled);
+            }
 
             let gl =
                 glow::Context::from_loader_function(|s| window.get_proc_address(s) as *const _);
@@ -594,8 +613,9 @@ pub async fn main() {
         let mut held_keys: BTreeSet<InputKey> = BTreeSet::new();
         let mut mouse_pos: (i32, i32) = (0, 0);
         // Whether the window owns the pointer (free-look). See the Escape /
-        // MouseButton / Focus arms in the event loop.
-        let mut cursor_captured = true;
+        // MouseButton / Focus arms in the event loop. A hidden window never
+        // captures (and never receives the events that would toggle this).
+        let mut cursor_captured = !hidden;
 
         use glfw::Context;
 
@@ -681,8 +701,11 @@ Escape again to quit"
                             window.set_should_close(true)
                         }
                     }
-                    // A click while released recaptures for free-look.
-                    glfw::WindowEvent::MouseButton(_, Action::Press, _) if !cursor_captured => {
+                    // A click while released recaptures for free-look. Never
+                    // on a hidden window — it must not grab the pointer.
+                    glfw::WindowEvent::MouseButton(_, Action::Press, _)
+                        if !cursor_captured && !hidden =>
+                    {
                         window.set_cursor_mode(glfw::CursorMode::Disabled);
                         cursor_captured = true;
                     }


### PR DESCRIPTION
## What

Adds a `--hidden` flag to `functor-runner`: the GLFW window is created with `WindowHint::Visible(false)`, so it is **never shown, never takes focus, and never captures the cursor** — a run doesn't steal input from whoever is at the machine. A hidden window keeps a valid GL context and default framebuffer, so rendering, `--capture-frame`, and the debug server's `POST /capture` all work unchanged (same approach as tommy-xr/shock2quest#341).

- `--capture-frame` now **implies** `--hidden` — a scripted screenshot run has no reason to pop a window and grab the mouse.
- `--hidden` conflicts with `--headless` (there, no window exists at all). This fills the gap between the two existing modes: `--headless` = no GL/no pixels; `--hidden` = pixels, no window.
- The click-to-recapture and initial cursor-grab paths are gated on `!hidden`, so the "never captures the cursor" invariant is enforced in code.
- Documented in `docs/debug-runtime.md` (new "Hidden window mode" section).

## Verification

- **Hidden rendering is pixel-equivalent to visible.** Same binary, same `--fixed-time 2.0`, captured via the debug server with the window visible vs hidden: `hello` differs by 47/1,920,000 pixels (0.002%, tolerance 16 — same-run antialiasing wobble), `lighting` by 0 pixels. Both far under the golden suite's 1% budget.
- **Golden suite:** `primitives-t2` passes through the now-hidden capture path. `hello-t2` shows 3.5% drift against the committed reference, but the drift is **pre-existing on this machine** — a *visible*-window capture drifts by the identical 3.55%, so it is display/driver drift in the golden, unrelated to this change (goldens are documented as renderer/display-specific).
- **Debug server hidden:** `--hidden --debug-port` serves `/capture` (real 1600×1200 PNG from a never-shown window) and `/state`.
- **Flag conflict:** `--hidden --headless` is rejected by clap with a clear error.
- Cross-engine review (`/xreview`: Claude + Codex) came back clean apart from one agreed Low finding (gate click-recapture on `!hidden`), which is fixed and re-verified in this PR.

Known limitation (pre-existing, unchanged): the render loop has no explicit frame cap (`swap_buffers` pacing only), and a hidden window's swap may not block on vsync on macOS — a long-running `--hidden` session can free-run. Worth a follow-up if hidden sessions become long-lived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)