### PR TITLE
feat(mle,runtime): C4b-2 — the MVU pair: update/messages + subscriptions

### DIFF
--- a/.claude/skills/mle-language/SKILL.md
+++ b/.claude/skills/mle-language/SKILL.md
@@ -150,6 +150,8 @@ Light.ambient(r, g, b) / Light.point(px, py, pz, r, g, b, intensity, range)
 Light.directional(dx, dy, dz, r, g, b, intensity) |> Light.castShadows
 Frame.create(camera, scene)                                // what draw returns
 Frame.createLit(camera, scene, [light, …])                 // lit + shadowed
+Time.seconds(1.0) / Time.millis(500.0)                     // Duration VALUES only
+Sub.every(duration, msg) / Sub.none() / Sub.batch([sub,…]) // what subscriptions returns
 
 Physics.box(w, h, d) / sphere(r) / capsule(halfH, r)       // -> Shape (box = FULL extents)
 Physics.dynamic("tag", shape)                              // simulated body
@@ -180,18 +182,30 @@ let draw = (model, tts) => Frame.create(camera, scene)
 let input = (model, key, isDown) => model'  // OPTIONAL; key = "W"/"Up"/"Space"
 let mouseMove = (model, x, y) => model'     // OPTIONAL; window pixels
 let mouseWheel = (model, delta) => model'   // OPTIONAL
+let update = (model, msg) => model'         // OPTIONAL; msgs are ADT variants
+let subscriptions = (model) => Sub.every(Time.seconds(1.0), Beat)
+                                            // OPTIONAL, but requires update
 let physics = (model) => Physics.scene(0.0, -9.81, 0.0, [body, …])  // OPTIONAL
 ```
 
-Frame order: `tick` → `physics` (reconcile + fixed-step, 60Hz accumulator)
-→ `draw` — physics reads in `draw` see this frame's stepped world; reads in
-`tick` see the *previous* frame's (so on the very first frame, and inside
-the `physics` hook itself, declared bodies don't exist yet — keep reads in
-`draw`). The physics world survives hot reload (like the model); deleting
-the `physics` hook drops it. Gotcha: `--fixed-time T` pins the clock with
-`dts = 0`, so physics **never steps** under it — bodies render at their
+Subscription timers are **stateless**: `Sub.every` fires when an integer
+multiple of its period lies in `(prevTts, tts]` — the global time grid, so
+a long frame fires ONCE (missed boundaries collapse) and timers tick right
+through a hot reload. Fired messages fold through `update` before `tick`.
+Durations, like Angles, are branded values — `Sub.every(0.5, …)` is a
+teaching error; say `Time.seconds(0.5)` or `Time.millis(500.0)`.
+
+Frame order: subscriptions→`update` → `tick` → `physics` (reconcile +
+fixed-step, 60Hz accumulator) → `draw` — physics reads in `draw` see this
+frame's stepped world; reads in `tick` see the *previous* frame's (so on
+the very first frame, and inside the `physics` hook itself, declared bodies
+don't exist yet — keep reads in `draw`). The physics world survives hot
+reload (like the model); deleting the `physics` hook drops it. Gotcha:
+`--fixed-time T` pins the clock with `dts = 0`, so physics **never steps**
+under it (and the subscription grid never crosses) — bodies render at their
 declared pose. Capture physics with plain `--capture-time` (and a settled
-scene for reproducibility) instead.
+scene for reproducibility) instead; capture timer-driven changes via the
+debug server's `/time` advance.
 
 A project dir with `functor.json` `{"language": "mle", "entry": "game.mle"}`
 works with the CLI: `functor -d dir build` (typecheck, diagnostics are

--- a/docs/mle.md
+++ b/docs/mle.md
@@ -294,8 +294,22 @@ Starts once A2 + B3 exist.
         ports the F# golden scene (shadow-casting sun, orbiting colored
         point lights, emissive markers) — **0.000% pixels over the golden
         tolerance vs the F# render** at the same fixed time.
-      - [ ] **C4b-2** (wants B5's ADTs for messages): `update`/messages,
-        subscriptions, effect-queue drain semantics.
+      - [x] **C4b-2. The MVU pair** (done 2026-07-03): optional
+        `update(model, msg)` + `subscriptions(model)` entry points
+        (messages are B5 ADT variants); prelude grows `Sub.every/none/
+        batch` and branded `Time.seconds/millis` Durations (the Angle
+        rule, applied to time). `Sub.every` is stateless — it fires when
+        the global time grid crosses in `(prevTts, tts]`, the F#
+        `crossedBoundary` rule verbatim — so timers need no identity and
+        tick right through a hot reload; fired messages fold through
+        `update` before `tick`, the drain seam B6's effects will feed.
+        `examples/mle-hello` gains a once-per-second Beat.
+        *Verify (done):* pinned-clock SDK e2e proves exact arithmetic —
+        one message per period step, millis/seconds parity, a long frame
+        collapses missed boundaries into ONE firing, and a reload that
+        ADDS subscriptions starts from the current frame edge (no
+        catch-up burst); prelude unit tests pin the grid math and the
+        teaching errors (15/15 e2e suite).
 - [ ] **C5. Wasm.** The interpreter crate compiles to wasm32; `.mle` source
       ships in the bundle. *Verify:* wasm build of mle-hello renders.
 - [ ] **C6. Perf gate.** Measure C4 at 60fps with headroom; bytecode VM

--- a/examples/mle-hello/game.mle
+++ b/examples/mle-hello/game.mle
@@ -4,7 +4,9 @@
 //   functor-runner --mle --game-path examples/mle-hello/game.mle
 //
 // The producer contract: `init` is the initial model value; `tick` steps it;
-// `draw` returns a Frame. Transforms apply outermost-last, so
+// `draw` returns a Frame; `subscriptions` declares timers whose messages
+// fold through `update` (the full MVU loop — here, a once-per-second Beat
+// cycles the centerpiece's color). Transforms apply outermost-last, so
 // `|> Scene.translate(radius…) |> Scene.rotateY(angle)` places a cube on the
 // ring at `angle`.
 
@@ -18,19 +20,28 @@ let ringCube = (spin: Float, i: Float) =>
     |> Scene.translate(4.0, Math.sin(i + spin * 3.0) * 0.6, 0.0)
     |> Scene.rotateY(Angle.radians(i * tau / count + spin))
 
-let centerpiece = (spin: Float) =>
+let centerpiece = (spin: Float, beat: Float) =>
   Scene.sphere()
-    |> Scene.color(1.0, 0.8, 0.2)
+    |> Scene.color(1.0, 0.5 + 0.5 * Math.cos(beat * 2.1), 0.5 + 0.5 * Math.sin(beat * 1.3))
     |> Scene.scale(1.1 + 0.25 * Math.sin(spin * 4.0))
 
-let init = { spin: 0.0 }
+type Msg =
+  | Beat
+
+let init = { spin: 0.0, beat: 0.0 }
 
 let tick = (model, dt: Float, tts: Float) => { model with spin: model.spin + dt * 0.5 }
+
+let update = (model, msg) =>
+  match msg with
+  | Beat => { model with beat: model.beat + 1.0 }
+
+let subscriptions = (model) => Sub.every(Time.seconds(1.0), Beat)
 
 let draw = (model, tts: Float) =>
   Frame.create(
     Camera.lookAt(0.0, 3.5, -9.0, 0.0, 0.0, 0.0),
     Scene.group([
-      centerpiece(model.spin),
+      centerpiece(model.spin, model.beat),
       Scene.group(List.range(count) |> List.map((i) => ringCube(model.spin, i))),
     ]))

--- a/runtime/functor-runtime-common/src/mle_prelude.rs
+++ b/runtime/functor-runtime-common/src/mle_prelude.rs
@@ -102,15 +102,17 @@ pub struct MleDuration(pub f64);
 /// lies in `(prevTts, tts]` — a pure function of the global clock. No
 /// per-timer identity, no frame-to-frame diffing, and it survives a hot
 /// reload for free. A non-positive period never fires.
+///
+/// Precision: `tts` is f32-sourced (the protocol's `FrameTime`), so with a
+/// period that has no exact binary representation a boundary can land one
+/// frame late — but the floor comparison is monotone and telescoping over
+/// adjacent frame windows, so a firing is never lost or doubled (and the F#
+/// executor computes on the same f32s: exact parity).
+#[derive(Clone)]
 pub enum SubTree {
     None,
-    Every {
-        period_seconds: f64,
-        msg: Value,
-    },
-    /// Children are `Sub` host values, validated at construction; the walk
-    /// re-checks via [`sub_of`] (cheap) rather than storing a parallel tree.
-    Batch(Vec<Value>),
+    Every { period_seconds: f64, msg: Value },
+    Batch(Vec<SubTree>),
 }
 
 pub struct MleSub(pub SubTree);
@@ -705,15 +707,19 @@ impl Host for FunctorHost {
             },
             "Sub.batch" => match args.as_slice() {
                 [Value::List(items)] => {
+                    let mut subs = Vec::with_capacity(items.len());
                     for item in items.iter() {
-                        if sub_of(item).is_none() {
-                            return err(format!(
-                                "Sub.batch items must be Subs, got {}",
-                                item.kind_name()
-                            ));
+                        match sub_of(item) {
+                            Some(sub) => subs.push(sub.0.clone()),
+                            None => {
+                                return err(format!(
+                                    "Sub.batch items must be Subs, got {}",
+                                    item.kind_name()
+                                ))
+                            }
                         }
                     }
-                    Ok(host(MleSub(SubTree::Batch(items.to_vec()))))
+                    Ok(host(MleSub(SubTree::Batch(subs))))
                 }
                 _ => usage("Sub.batch([sub, …])"),
             },
@@ -811,16 +817,11 @@ pub fn sub_messages_for_frame(subs: &Value, prev_tts: f64, tts: f64) -> Result<V
         ));
     };
     let mut msgs = Vec::new();
-    collect_fired(&sub.0, prev_tts, tts, &mut msgs)?;
+    collect_fired(&sub.0, prev_tts, tts, &mut msgs);
     Ok(msgs)
 }
 
-fn collect_fired(
-    sub: &SubTree,
-    prev_tts: f64,
-    tts: f64,
-    msgs: &mut Vec<Value>,
-) -> Result<(), String> {
+fn collect_fired(sub: &SubTree, prev_tts: f64, tts: f64, msgs: &mut Vec<Value>) {
     match sub {
         SubTree::None => {}
         SubTree::Every {
@@ -835,13 +836,10 @@ fn collect_fired(
         }
         SubTree::Batch(items) => {
             for item in items.iter() {
-                // Validated at construction; a miss here is a host bug.
-                let inner = sub_of(item).ok_or("internal: non-Sub in Sub.batch")?;
-                collect_fired(&inner.0, prev_tts, tts, msgs)?;
+                collect_fired(item, prev_tts, tts, msgs);
             }
         }
     }
-    Ok(())
 }
 
 /// Physical dimensions (shape extents, radii, mass) must be strictly
@@ -1360,6 +1358,34 @@ Scene.cube() |> Scene.rotateY(Angle.radians(1.5707964)))",
              ])";
         assert_eq!(fired(src, 1.9, 2.0), ["Slow", "Fast(2)"]);
         assert_eq!(fired(src, 2.0, 2.5), ["Fast(2)"]);
+    }
+
+    /// Walking a non-binary period over noisy f32-sourced frame times, the
+    /// firing count telescopes exactly: fires = boundary count of the whole
+    /// span, no message lost or doubled, no matter where the frame edges
+    /// land. (Timing may jitter by a frame; the COUNT is exact.)
+    #[test]
+    fn firing_count_telescopes_over_noisy_frames() {
+        let sub = eval(
+            "type Msg = | Pulse\n\
+             let main = () => Sub.every(Time.millis(300.0), Pulse)",
+        );
+        // f32-truncated, uneven frame edges (dt ~16.7ms), like the runner's.
+        let mut edges: Vec<f64> = Vec::new();
+        let mut t: f32 = 0.5;
+        for i in 0..600 {
+            t += 0.0167 + (i % 7) as f32 * 0.0011;
+            edges.push(t as f64);
+        }
+        let mut fires = 0;
+        for pair in edges.windows(2) {
+            fires += sub_messages_for_frame(&sub, pair[0], pair[1])
+                .expect("a Sub tree")
+                .len();
+        }
+        let (first, last) = (edges[0], edges[edges.len() - 1]);
+        let expected = ((last / 0.3).floor() - (first / 0.3).floor()) as usize;
+        assert_eq!(fires, expected, "over ({first}, {last}]");
     }
 
     /// Bare numbers are not durations — the Angle teaching error, for time.

--- a/runtime/functor-runtime-common/src/mle_prelude.rs
+++ b/runtime/functor-runtime-common/src/mle_prelude.rs
@@ -22,6 +22,12 @@
 //! Camera.lookAt(ex, ey, ez, tx, ty, tz)                     -> Camera
 //!   (up is +Y; vertical fov pinned at 45°, near/far at protocol defaults)
 //! Frame.create(camera, scene)                               -> Frame
+//! Time.seconds(n) / Time.millis(n)                          -> Duration
+//!   (like Angle: timing functions take Duration VALUES, never bare
+//!    numbers — seconds/milliseconds confusion is unrepresentable)
+//! Sub.every(duration, msg) / Sub.none() / Sub.batch([sub,…]) -> Sub
+//!   (the game's `subscriptions` returns one of these; fired messages are
+//!    folded through `update` — see the producers' drain seam)
 //!
 //! Physics.box(w, h, d) / sphere(r) / capsule(hh, r)         -> Shape
 //! Physics.dynamic/kinematic/fixed(tag, shape)               -> Body
@@ -81,11 +87,57 @@ pub struct MleFrame(pub Frame);
 /// A [`Light`] as an opaque MLE value.
 pub struct MleLight(pub Light);
 
+/// A duration as an opaque MLE value — `Time.seconds(…)`/`Time.millis(…)`.
+/// Timing functions accept ONLY this, never a bare number, making
+/// seconds/milliseconds confusion unrepresentable (the Angle rule, applied
+/// to time). Stored canonically in seconds.
+pub struct MleDuration(pub f64);
+
+/// A subscription tree as an opaque MLE value — what the game's
+/// `subscriptions(model)` returns. The declarative dual of effects: a
+/// standing "while the model looks like this, listen to these".
+///
+/// `Every` is deliberately stateless (mirroring the F# runtime's
+/// `Sub.crossedBoundary`): it fires when an integer multiple of its period
+/// lies in `(prevTts, tts]` — a pure function of the global clock. No
+/// per-timer identity, no frame-to-frame diffing, and it survives a hot
+/// reload for free. A non-positive period never fires.
+pub enum SubTree {
+    None,
+    Every {
+        period_seconds: f64,
+        msg: Value,
+    },
+    /// Children are `Sub` host values, validated at construction; the walk
+    /// re-checks via [`sub_of`] (cheap) rather than storing a parallel tree.
+    Batch(Vec<Value>),
+}
+
+pub struct MleSub(pub SubTree);
+
 /// An [`Angle`] as an opaque MLE value — `Angle.degrees(…)`/`Angle.radians(…)`.
 /// Rotation/camera functions accept ONLY this, never a bare number, making
 /// degree/radian confusion unrepresentable (the F# side's `Math.Angle`
 /// discipline, carried across the boundary).
 pub struct MleAngle(pub Angle);
+
+impl HostData for MleDuration {
+    fn type_name(&self) -> &'static str {
+        "Duration"
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+impl HostData for MleSub {
+    fn type_name(&self) -> &'static str {
+        "Sub"
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
 
 impl HostData for MleAngle {
     fn type_name(&self) -> &'static str {
@@ -218,6 +270,11 @@ const PATHS: &[&str] = &[
     "Light.castShadows",
     "Frame.create",
     "Frame.createLit",
+    "Time.seconds",
+    "Time.millis",
+    "Sub.none",
+    "Sub.every",
+    "Sub.batch",
     "Physics.box",
     "Physics.sphere",
     "Physics.capsule",
@@ -603,9 +660,9 @@ impl Host for FunctorHost {
                         Some((pos, rot)) => {
                             // cgmath's Quaternion::new is scalar-FIRST (w, x, y, z).
                             let rotation = cgmath::Quaternion::new(rot[3], rot[0], rot[1], rot[2]);
-                            let xform = Matrix4::from_translation(cgmath::vec3(
-                                pos[0], pos[1], pos[2],
-                            )) * Matrix4::from(rotation);
+                            let xform =
+                                Matrix4::from_translation(cgmath::vec3(pos[0], pos[1], pos[2]))
+                                    * Matrix4::from(rotation);
                             scene_value(group(vec![inner.clone()], xform))
                         }
                         None => err(no_body(tag)),
@@ -624,6 +681,41 @@ impl Host for FunctorHost {
                     Ok(host(MleFrame(Frame::new(camera.0.clone(), scene.clone()))))
                 }
                 _ => usage("Frame.create(camera, scene)"),
+            },
+            "Time.seconds" => match args.as_slice() {
+                [n] => Ok(host(MleDuration(num(n, span)?))),
+                _ => usage("Time.seconds(n)"),
+            },
+            "Time.millis" => match args.as_slice() {
+                [n] => Ok(host(MleDuration(num(n, span)? / 1000.0))),
+                _ => usage("Time.millis(n)"),
+            },
+            "Sub.none" => match args.as_slice() {
+                [] => Ok(host(MleSub(SubTree::None))),
+                _ => usage("Sub.none()"),
+            },
+            // The msg is any MLE value (typically an ADT variant), held by
+            // the host and handed back verbatim when the timer fires.
+            "Sub.every" => match args.as_slice() {
+                [duration, msg] => Ok(host(MleSub(SubTree::Every {
+                    period_seconds: duration_of(duration, "Sub.every", span)?,
+                    msg: msg.clone(),
+                }))),
+                _ => usage("Sub.every(duration, msg)"),
+            },
+            "Sub.batch" => match args.as_slice() {
+                [Value::List(items)] => {
+                    for item in items.iter() {
+                        if sub_of(item).is_none() {
+                            return err(format!(
+                                "Sub.batch items must be Subs, got {}",
+                                item.kind_name()
+                            ));
+                        }
+                    }
+                    Ok(host(MleSub(SubTree::Batch(items.to_vec()))))
+                }
+                _ => usage("Sub.batch([sub, …])"),
             },
             _ => err(format!("internal: unregistered prelude path `{path}`")),
         }
@@ -671,6 +763,85 @@ Angle.degrees(…) or Angle.radians(…)"
             span,
         }),
     }
+}
+
+/// Extract a duration in seconds — timing functions accept ONLY Duration
+/// values, so a bare number gets a teaching error instead of a silent unit
+/// guess (the [`angle_of`] rule, applied to time).
+fn duration_of(value: &Value, what: &str, span: Span) -> Result<f64, RunError> {
+    match value {
+        Value::HostData(data) => data
+            .as_any()
+            .downcast_ref::<MleDuration>()
+            .map(|d| d.0)
+            .ok_or_else(|| RunError {
+                message: format!("{what}: expected a Duration, got {}", value.kind_name()),
+                span,
+            }),
+        Value::Number(_) => Err(RunError {
+            message: format!(
+                "{what}: expected a Duration, got a bare number — say which unit: \
+Time.seconds(…) or Time.millis(…)"
+            ),
+            span,
+        }),
+        other => Err(RunError {
+            message: format!("{what}: expected a Duration, got {}", other.kind_name()),
+            span,
+        }),
+    }
+}
+
+fn sub_of(value: &Value) -> Option<&MleSub> {
+    match value {
+        Value::HostData(data) => data.as_any().downcast_ref::<MleSub>(),
+        _ => None,
+    }
+}
+
+/// The messages a subscription tree fires in the frame interval
+/// `(prev_tts, tts]`, in declaration order. `subs` is the raw value the
+/// game's `subscriptions(model)` returned — a non-Sub is an error string the
+/// producer reports like any other per-frame error.
+pub fn sub_messages_for_frame(subs: &Value, prev_tts: f64, tts: f64) -> Result<Vec<Value>, String> {
+    let Some(sub) = sub_of(subs) else {
+        return Err(format!(
+            "subscriptions must return a Sub (Sub.every / Sub.none / Sub.batch), got {}",
+            subs.kind_name()
+        ));
+    };
+    let mut msgs = Vec::new();
+    collect_fired(&sub.0, prev_tts, tts, &mut msgs)?;
+    Ok(msgs)
+}
+
+fn collect_fired(
+    sub: &SubTree,
+    prev_tts: f64,
+    tts: f64,
+    msgs: &mut Vec<Value>,
+) -> Result<(), String> {
+    match sub {
+        SubTree::None => {}
+        SubTree::Every {
+            period_seconds: p,
+            msg,
+        } => {
+            // An integer multiple of the period lies in (prev_tts, tts] —
+            // the F# runtime's `Sub.crossedBoundary`, verbatim.
+            if *p > 0.0 && (tts / p).floor() > (prev_tts / p).floor() {
+                msgs.push(msg.clone());
+            }
+        }
+        SubTree::Batch(items) => {
+            for item in items.iter() {
+                // Validated at construction; a miss here is a host bug.
+                let inner = sub_of(item).ok_or("internal: non-Sub in Sub.batch")?;
+                collect_fired(&inner.0, prev_tts, tts, msgs)?;
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Physical dimensions (shape extents, radii, mass) must be strictly
@@ -1030,7 +1201,9 @@ Scene.cube() |> Scene.rotateY(Angle.radians(1.5707964)))",
             "let main = () => Physics.scene(0.0, -9.81, 0.0, [\n\
                Physics.dynamic(\"ball\", Physics.sphere(0.5)) |> Physics.at(0.0, 5.0, 0.0)])",
         );
-        let scene = physics_scene_value(&declare).expect("a PhysicsScene").clone();
+        let scene = physics_scene_value(&declare)
+            .expect("a PhysicsScene")
+            .clone();
         crate::physics::with_world(crate::physics::DEFAULT_WORLD, |w| {
             w.reconcile(&scene);
             for _ in 0..30 {
@@ -1054,9 +1227,7 @@ Scene.cube() |> Scene.rotateY(Angle.radians(1.5707964)))",
         assert!(y < 5.0, "ball should have fallen, y = {y}");
 
         // …and Physics.transformed places a scene node at the live pose.
-        let drawn = eval(
-            "let main = () => Scene.sphere() |> Physics.transformed(\"ball\")",
-        );
+        let drawn = eval("let main = () => Scene.sphere() |> Physics.transformed(\"ball\")");
         let scene3d = scene_of(&drawn).expect("a Scene");
         assert!((scene3d.xform.w.y as f64 - y).abs() < 1e-6);
 
@@ -1068,8 +1239,14 @@ Scene.cube() |> Scene.rotateY(Angle.radians(1.5707964)))",
     #[test]
     fn non_positive_dimensions_are_rejected() {
         for (src, needle) in [
-            ("Physics.sphere(-0.5)", "Physics.sphere radius must be positive"),
-            ("Physics.box(1.0, 0.0, 1.0)", "Physics.box height must be positive"),
+            (
+                "Physics.sphere(-0.5)",
+                "Physics.sphere radius must be positive",
+            ),
+            (
+                "Physics.box(1.0, 0.0, 1.0)",
+                "Physics.box height must be positive",
+            ),
             (
                 "Physics.dynamic(\"x\", Physics.sphere(0.5)) |> Physics.mass(0.0)",
                 "Physics.mass must be positive",
@@ -1079,10 +1256,8 @@ Scene.cube() |> Scene.rotateY(Angle.radians(1.5707964)))",
                 "Physics.friction must not be negative",
             ),
         ] {
-            let module = mle::lower(
-                mle::parse(&format!("let main = () => {src}")).unwrap(),
-            )
-            .unwrap();
+            let module =
+                mle::lower(mle::parse(&format!("let main = () => {src}")).unwrap()).unwrap();
             let failure = mle::run_with_host(&module, Tracing::Off, &mut FunctorHost)
                 .err()
                 .unwrap_or_else(|| panic!("`{src}` should fail"));
@@ -1098,10 +1273,9 @@ Scene.cube() |> Scene.rotateY(Angle.radians(1.5707964)))",
     #[test]
     fn physics_read_of_unknown_tag_is_a_spanned_error() {
         crate::physics::remove_world(crate::physics::DEFAULT_WORLD);
-        let module = mle::lower(
-            mle::parse("let main = () => Physics.position(\"ghost\")").unwrap(),
-        )
-        .unwrap();
+        let module =
+            mle::lower(mle::parse("let main = () => Physics.position(\"ghost\")").unwrap())
+                .unwrap();
         let failure = mle::run_with_host(&module, Tracing::Off, &mut FunctorHost)
             .err()
             .expect("should fail");
@@ -1138,5 +1312,91 @@ Scene.cube() |> Scene.rotateY(Angle.radians(1.5707964)))",
             .err()
             .expect("should fail");
         assert_eq!(failure.error.message, "expected a finite number, got inf");
+    }
+
+    /// The messages fired by `main`'s sub tree over `(prev, tts]`, as display
+    /// strings ("Pulse", "Beat(2)").
+    fn fired(src: &str, prev: f64, tts: f64) -> Vec<String> {
+        sub_messages_for_frame(&eval(src), prev, tts)
+            .expect("a Sub tree")
+            .iter()
+            .map(|m| m.to_string())
+            .collect()
+    }
+
+    const PULSE: &str = "type Msg = | Pulse\n\
+         let main = () => Sub.every(Time.seconds(1.0), Pulse)";
+
+    /// `Every` fires exactly when an integer multiple of the period lies in
+    /// `(prev, tts]` — boundary inclusive on the right, and a long frame that
+    /// skips several boundaries still fires ONCE (floor comparison, exactly
+    /// the F# `Sub.crossedBoundary`).
+    #[test]
+    fn every_fires_on_the_global_time_grid() {
+        assert!(fired(PULSE, 0.5, 0.9).is_empty());
+        assert_eq!(fired(PULSE, 0.9, 1.0), ["Pulse"]);
+        assert!(fired(PULSE, 1.0, 1.5).is_empty());
+        assert_eq!(fired(PULSE, 2.9, 4.1), ["Pulse"]);
+    }
+
+    /// `Time.millis(500)` and `Time.seconds(0.5)` are the same duration.
+    #[test]
+    fn millis_and_seconds_agree() {
+        let millis = "type Msg = | Pulse\n\
+             let main = () => Sub.every(Time.millis(500.0), Pulse)";
+        assert_eq!(fired(millis, 0.9, 1.0), ["Pulse"]);
+        assert!(fired(millis, 1.0, 1.4).is_empty());
+    }
+
+    /// Batches fire in declaration order; `Sub.none` fires nothing; the msg
+    /// crosses back verbatim (here, a parameterful variant).
+    #[test]
+    fn batch_collects_in_declaration_order() {
+        let src = "type Msg = | Fast(n: Float) | Slow\n\
+             let main = () => Sub.batch([\n\
+               Sub.every(Time.seconds(2.0), Slow),\n\
+               Sub.none(),\n\
+               Sub.every(Time.millis(500.0), Fast(2.0)),\n\
+             ])";
+        assert_eq!(fired(src, 1.9, 2.0), ["Slow", "Fast(2)"]);
+        assert_eq!(fired(src, 2.0, 2.5), ["Fast(2)"]);
+    }
+
+    /// Bare numbers are not durations — the Angle teaching error, for time.
+    #[test]
+    fn bare_numbers_are_not_durations() {
+        let module = mle::lower(
+            mle::parse("type Msg = | Pulse\nlet main = () => Sub.every(0.5, Pulse)").unwrap(),
+        )
+        .unwrap();
+        let failure = mle::run_with_host(&module, Tracing::Off, &mut FunctorHost)
+            .err()
+            .expect("should fail");
+        assert_eq!(
+            failure.error.message,
+            "Sub.every: expected a Duration, got a bare number — say which unit: \
+Time.seconds(…) or Time.millis(…)"
+        );
+    }
+
+    /// A `subscriptions` that returns something else is a reportable error,
+    /// and non-Subs are rejected at `Sub.batch` construction.
+    #[test]
+    fn non_subs_are_rejected() {
+        let err = sub_messages_for_frame(&Value::Number(1.0), 0.0, 1.0)
+            .err()
+            .expect("should fail");
+        assert_eq!(
+            err,
+            "subscriptions must return a Sub (Sub.every / Sub.none / Sub.batch), got a number"
+        );
+        let module = mle::lower(mle::parse("let main = () => Sub.batch([1.0])").unwrap()).unwrap();
+        let failure = mle::run_with_host(&module, Tracing::Off, &mut FunctorHost)
+            .err()
+            .expect("should fail");
+        assert_eq!(
+            failure.error.message,
+            "Sub.batch items must be Subs, got a number"
+        );
     }
 }

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -10,6 +10,9 @@
 //! let init = { … }                       // the initial model (a value)
 //! let tick = (model, dt, tts) => model'  // per-frame step
 //! let draw = (model, tts) => Frame.create(camera, scene)
+//! // optional MVU pair (C4b-2) — timer messages fold through update:
+//! let update = (model, msg) => model'
+//! let subscriptions = (model) => Sub.every(Time.seconds(1.0), Msg)
 //! let physics = (model) => Physics.scene(gx, gy, gz, [body, …])  // OPTIONAL
 //! ```
 //!
@@ -25,7 +28,9 @@
 
 use std::time::Instant;
 
-use functor_runtime_common::mle_prelude::{frame_value, physics_scene_value, FunctorHost};
+use functor_runtime_common::mle_prelude::{
+    frame_value, physics_scene_value, sub_messages_for_frame, FunctorHost,
+};
 use functor_runtime_common::physics;
 use functor_runtime_common::ui::View;
 use functor_runtime_common::{Frame, FrameTime};
@@ -42,6 +47,13 @@ pub struct MleGame {
     has_input: bool,
     has_mouse_move: bool,
     has_mouse_wheel: bool,
+    has_subscriptions: bool,
+    /// The previous frame's total-time, the left edge of the `(prev, tts]`
+    /// window subscriptions fire over. `None` until the first frame has run
+    /// (nothing fires on frame one — mirroring the F# executor). Producer
+    /// state, not model state: it survives a hot reload, and the stateless
+    /// time-grid semantics of `Sub.every` do the rest.
+    prev_tts: Option<f64>,
     has_physics: bool,
     /// The last successfully drawn frame, kept so a bad draw shows the last
     /// good picture instead of a blank.
@@ -71,6 +83,7 @@ struct Loaded {
     has_input: bool,
     has_mouse_move: bool,
     has_mouse_wheel: bool,
+    has_subscriptions: bool,
     has_physics: bool,
 }
 
@@ -124,6 +137,22 @@ fn load_game(path: &str) -> Result<Loaded, String> {
     if has_mouse_wheel {
         require_function(path, &session, "mouseWheel", 2)?;
     }
+    // The MVU pair: `subscriptions(model)` declares timers whose fired
+    // messages fold through `update(model, msg)` — so subscriptions without
+    // an update have nowhere to deliver.
+    let has_subscriptions = session.global("subscriptions").is_some();
+    if has_subscriptions {
+        require_function(path, &session, "subscriptions", 1)?;
+        if session.global("update").is_none() {
+            return Err(format!(
+                "{path}: `subscriptions` produces messages but there is no \
+`let update = (model, msg) => …` to receive them"
+            ));
+        }
+    }
+    if session.global("update").is_some() {
+        require_function(path, &session, "update", 2)?;
+    }
     // Optional physics: `physics(model) => Physics.scene(…)` declares the
     // bodies that should exist; the host reconciles + fixed-steps the world
     // after each tick (docs/physics.md).
@@ -138,6 +167,7 @@ fn load_game(path: &str) -> Result<Loaded, String> {
         has_input,
         has_mouse_move,
         has_mouse_wheel,
+        has_subscriptions,
         has_physics,
     })
 }
@@ -171,6 +201,8 @@ impl MleGame {
             has_input: loaded.has_input,
             has_mouse_move: loaded.has_mouse_move,
             has_mouse_wheel: loaded.has_mouse_wheel,
+            has_subscriptions: loaded.has_subscriptions,
+            prev_tts: None,
             has_physics: loaded.has_physics,
             last_frame: empty_frame(),
             last_error: None,
@@ -227,6 +259,46 @@ impl MleGame {
         }
     }
 
+    /// Fire subscription timers over `(prev_tts, tts]` and fold their
+    /// messages through `update`, before this frame's `tick` — the message
+    /// drain seam (docs/mle.md C4b-2; B6's effects will feed this same
+    /// path). Subscriptions are recomputed from the current model each
+    /// frame, so a model change can silence a timer. Errors report per
+    /// message and processing continues — one bad message must not stall
+    /// the rest, and dedupe keeps a persistent bug to one line.
+    fn pump_subscriptions(&mut self, tts: f64) {
+        // Advance the window even without subscriptions (or on frame one),
+        // so a hot reload that ADDS subscriptions starts from a sane edge.
+        let prev = self.prev_tts.replace(tts);
+        if !self.has_subscriptions {
+            return;
+        }
+        let Some(prev) = prev else {
+            return;
+        };
+        let subs =
+            match self
+                .session
+                .call("subscriptions", vec![self.model.clone()], &mut FunctorHost)
+            {
+                Ok(subs) => subs,
+                Err(err) => return self.frame_error("subscriptions", &err),
+            };
+        let msgs = match sub_messages_for_frame(&subs, prev, tts) {
+            Ok(msgs) => msgs,
+            Err(message) => return self.report_once(format!("[mle] {message}")),
+        };
+        for msg in msgs {
+            match self
+                .session
+                .call("update", vec![self.model.clone(), msg], &mut FunctorHost)
+            {
+                Ok(model) => self.model = model,
+                Err(err) => self.frame_error("update", &err),
+            }
+        }
+    }
+
     fn report_stats(&mut self) {
         if self.frames > 0 && self.frames % STATS_EVERY == 0 {
             let tick_us = self.tick_ns as f64 / STATS_EVERY as f64 / 1000.0;
@@ -267,6 +339,9 @@ impl Game for MleGame {
                 self.has_input = loaded.has_input;
                 self.has_mouse_move = loaded.has_mouse_move;
                 self.has_mouse_wheel = loaded.has_mouse_wheel;
+                self.has_subscriptions = loaded.has_subscriptions;
+                // prev_tts is deliberately kept: `Sub.every` fires on the
+                // global time grid, so timers tick right through a reload.
                 self.has_physics = loaded.has_physics;
                 // The physics world is deliberately KEPT, like the model: it
                 // lives in this process's registry, so bodies stay where they
@@ -284,13 +359,18 @@ takes effect on restart)",
                 );
             }
             Err(message) => {
-                self.report_once(format!("[mle] reload failed, keeping old program: {message}"));
+                self.report_once(format!(
+                    "[mle] reload failed, keeping old program: {message}"
+                ));
             }
         }
     }
 
     fn tick(&mut self, frame_time: FrameTime) {
         let started = Instant::now();
+        // Subscriptions first, so `tick` sees a model that has absorbed this
+        // frame's messages (the F# executor's ordering).
+        self.pump_subscriptions(frame_time.tts as f64);
         let args = vec![
             self.model.clone(),
             Value::Number(frame_time.dts as f64),
@@ -430,4 +510,52 @@ fn empty_frame() -> Frame {
             xform: Matrix4::identity(),
         },
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Write `src` to a temp .mle file and return `load_game`'s error.
+    fn load_err(name: &str, src: &str) -> String {
+        let path =
+            std::env::temp_dir().join(format!("mle-game-test-{}-{name}.mle", std::process::id()));
+        std::fs::write(&path, src).expect("write temp game");
+        let err = load_game(path.to_str().expect("utf-8 temp path"))
+            .err()
+            .expect("load should fail");
+        let _ = std::fs::remove_file(&path);
+        err
+    }
+
+    const BASE: &str = "let init = { n: 0.0 }\n\
+         let tick = (m, dt, tts) => m\n\
+         let draw = (m, tts) => Frame.create(Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0), Scene.cube())\n";
+
+    /// Subscriptions produce messages; without an `update` they have nowhere
+    /// to go — a load error, not a per-frame one.
+    #[test]
+    fn subscriptions_require_update() {
+        let err = load_err(
+            "subs-no-update",
+            &format!("{BASE}let subscriptions = (m) => Sub.none()\n"),
+        );
+        assert!(
+            err.contains("no `let update = (model, msg) => …` to receive them"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// The MVU pair is arity-validated at load like every other entry point.
+    #[test]
+    fn update_arity_is_validated() {
+        let err = load_err(
+            "update-arity",
+            &format!("{BASE}let update = (m) => m\nlet subscriptions = (m) => Sub.none()\n"),
+        );
+        assert!(
+            err.contains("`update` must take 2 parameter(s), takes 1"),
+            "unexpected error: {err}"
+        );
+    }
 }

--- a/tools/functor-sdk/test/mle-subscriptions.e2e.test.ts
+++ b/tools/functor-sdk/test/mle-subscriptions.e2e.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { findRepoRoot, FunctorRunner, waitFor } from "../src/index.js";
+
+// C4b-2 end-to-end (docs/mle.md): subscriptions fire on the global time
+// grid and their messages fold through `update`. With the debug clock
+// pinned, stepping by EXACTLY one period crosses exactly one grid boundary
+// regardless of phase — so every assertion is exact arithmetic:
+//
+//   - two 1s steps        -> two Beat messages (and Time.millis(1000)
+//                            fires in lockstep — unit parity)
+//   - one 4s step         -> ONE Beat (a long frame collapses missed
+//                            boundaries, the F# Sub.crossedBoundary rule)
+//   - reload that ADDS a subscription -> next 1s step fires once, no burst
+//
+// Opt-in like the other e2e suites: npm run test:e2e[:headless]
+const e2eEnabled = process.env.FUNCTOR_E2E === "1";
+const headless = process.env.FUNCTOR_E2E_HEADLESS === "1";
+
+// Beat (seconds) and Echo (millis) share a 1s period: their counts must
+// stay in lockstep, or the unit conversion is wrong.
+const subscribed = `type Msg =
+  | Beat
+  | Echo
+let init = { beats: 0.0, echoes: 0.0 }
+let tick = (m, dt, tts) => m
+let update = (m, msg) =>
+  match msg with
+  | Beat => { m with beats: m.beats + 1.0 }
+  | Echo => { m with echoes: m.echoes + 1.0 }
+let subscriptions = (m) => Sub.batch([
+  Sub.every(Time.seconds(1.0), Beat),
+  Sub.every(Time.millis(1000.0), Echo),
+])
+let draw = (m, tts) =>
+  Frame.create(Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0), Scene.cube())
+`;
+
+// The same game with no subscriptions/update — the reload starting point.
+const unsubscribed = `let init = { beats: 0.0, echoes: 0.0 }
+let tick = (m, dt, tts) => m
+let draw = (m, tts) =>
+  Frame.create(Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0), Scene.cube())
+`;
+
+/** A named Float field of the runner's `/state` model (MLE Value display). */
+function fieldOf(model: string, name: string): number {
+  const m = model.match(new RegExp(`${name}:\\s*(-?[\\d.]+)`));
+  assert.ok(m, `could not find ${name} in model: ${model}`);
+  return Number(m[1]);
+}
+
+test(
+  "Sub.every fires on the global time grid and folds through update",
+  { skip: !e2eEnabled, timeout: 120_000 },
+  async () => {
+    const repoRoot = findRepoRoot(process.cwd());
+    assert.ok(repoRoot, "must run from within the functor workspace");
+
+    const dir = mkdtempSync(join(tmpdir(), "mle-subs-"));
+    const mlePath = join(dir, "game.mle");
+    writeFileSync(mlePath, unsubscribed);
+
+    await using runner = await FunctorRunner.launch({
+      gameDir: dir,
+      repoRoot,
+      mlePath,
+      port: Number(process.env.FUNCTOR_E2E_PORT ?? 8099),
+      headless,
+    });
+
+    await runner.pause();
+
+    // Hot-reload subscriptions IN: the timer window must start from the
+    // current frame's edge, not t=0 — otherwise this first step would fire
+    // a burst of catch-up Beats for every second since launch.
+    writeFileSync(mlePath, subscribed);
+    await waitFor(
+      async () => runner.logs(),
+      (lines) => lines.some((l) => l.includes("hot-reloaded")),
+      { timeoutMs: 10_000, description: "hot reload observed in logs" },
+    );
+    await runner.step(1.0);
+    const model = (await runner.state()).model;
+    assert.equal(
+      fieldOf(model, "beats"),
+      1,
+      `one period after subscribing should fire exactly one Beat: ${model}`,
+    );
+
+    // One step per period -> one message per step, exactly.
+    await runner.step(1.0);
+    await runner.step(1.0);
+    let beats = fieldOf((await runner.state()).model, "beats");
+    assert.equal(beats, 3, `two more 1s steps should make 3 beats, got ${beats}`);
+
+    // Time.millis(1000) fires in lockstep with Time.seconds(1.0).
+    const echoes = fieldOf((await runner.state()).model, "echoes");
+    assert.equal(echoes, beats, `millis/seconds parity: ${echoes} vs ${beats}`);
+
+    // A long frame collapses missed boundaries into ONE firing (the F#
+    // crossedBoundary rule: floor comparison, not a counter).
+    await runner.step(4.0);
+    beats = fieldOf((await runner.state()).model, "beats");
+    assert.equal(beats, 4, `a 4s frame fires Beat once, not four times: ${beats}`);
+  },
+);


### PR DESCRIPTION
## What

The last structural piece of the Elm loop for MLE games: optional **`update(model, msg)`** and **`subscriptions(model)`** entry points, with messages as B5 ADT variants.

```mle
type Msg = | Beat

let update = (model, msg) =>
  match msg with
  | Beat => { model with beat: model.beat + 1.0 }

let subscriptions = (model) => Sub.every(Time.seconds(1.0), Beat)
```

- **Prelude**: `Sub.every(duration, msg)` / `Sub.none()` / `Sub.batch([…])`, plus branded **`Time.seconds` / `Time.millis`** Duration values — the Angle rule applied to time: `Sub.every(0.5, …)` is a teaching error ("say which unit").
- **Stateless timers**: `Sub.every` fires when an integer multiple of its period lies in `(prevTts, tts]` — the F# executor's `Sub.crossedBoundary` verbatim. No per-timer identity, no diffing; a long frame collapses missed boundaries into ONE firing; timers tick right through a hot reload.
- **Drain seam**: fired messages fold through `update` before `tick` (the F# ordering). B6's effects will feed this same path. The producer advances the window every frame even without subscriptions, so a reload that *adds* them starts from the current edge — no catch-up burst.
- **Load contract**: `subscriptions` requires `update` (messages need a receiver); both arity-validated at load like every entry point.
- `examples/mle-hello` gains a once-per-second Beat that cycles the centerpiece color — the reference example now shows the full MVU loop.

## Demo

![beat demo](https://gist.githubusercontent.com/tommy-xr/73d81d1fd78c43d4e2c31be0b5f1bacd/raw/mle-beat.gif)

<sub>3.6s of game time at dt=0.1 via the debug server's `/time` + `/capture` (deterministic, headless-driven): the ring spins continuously while `Beat` snaps the centerpiece color once per second — four snaps in the loop.</sub>

### Before → after

![before/after](https://gist.githubusercontent.com/tommy-xr/73d81d1fd78c43d4e2c31be0b5f1bacd/raw/beforeafter.png)

<sub>Same time-advance schedule on the same runner; only the game source differs. Ring phase differs slightly (wall-clock startup before the clock pin) — the subject is the centerpiece: constant gold before, Beat-cycled after.</sub>

![still](https://gist.githubusercontent.com/tommy-xr/73d81d1fd78c43d4e2c31be0b5f1bacd/raw/mle-beat-still.png)

## Review

Codex CLI reviewed (adversarial, correctness-focused). The Claude reviewer was unavailable (subagent session limit) — compensated with a direct inspection pass of the producer/main-loop ordering, per the established fallback.

- **[Codex M — accepted, documented + pinned]** f32-sourced `tts` + non-binary periods can land a boundary one frame late. This is exactly the F# executor's arithmetic on the same f32s (parity), and the floor comparison telescopes: a new unit test walks 600 noisy f32 frame edges against a 0.3s period and proves the firing COUNT is exact — never lost, never doubled.
- **[Codex M — disputed with evidence]** Claimed `step()`/`state()` race in the e2e: the runner applies `pending_step` at the top of the frame and drains debug requests only after render, so a sequential awaiting client's follow-up always lands the frame after its step applied; the drain exits on `Empty` nanoseconds after replying, orders of magnitude before a follow-up HTTP request can arrive. The identical pattern in the merged hot-reload e2e is consistently green. (A *concurrent* client could overwrite `pending_step`, but that's the debug server's pre-existing single-drain design, unchanged here.)
- **[Codex L — fixed]** `Sub.batch` now stores a typed `Vec<SubTree>` instead of re-downcasting child `Value`s, removing an impossible internal-error path.

## Verification

- **Pinned-clock SDK e2e** (`mle-subscriptions.e2e.test.ts`), all exact arithmetic: one message per period step; `Time.millis(1000)` fires in lockstep with `Time.seconds(1.0)`; a 4s frame fires ONCE; a hot reload that adds subscriptions fires exactly once on the next period step (no burst). Full e2e suite **15/15**.
- Prelude unit tests: grid math, batch ordering, teaching errors, telescoping precision pin — `cargo test -p functor_runtime_common` **110 passed**.
- Producer load-contract unit tests (subscriptions-without-update, update arity) — desktop suite green.
- GIF frames verified programmatically: centerpiece pixel-diff spikes exactly at the four grid crossings (2–7× baseline motion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
