### PR TITLE
docs(physics): pin the harness-owned-clock invariant (shock2quest lesson)

### DIFF
--- a/docs/physics.md
+++ b/docs/physics.md
@@ -392,7 +392,13 @@ out of scope — a replay is bound to the binary that recorded it.
 
 What local determinism requires from us (the fine print):
 
-- **Fixed-step accumulator** in the shell (never variable dt).
+- **Fixed-step accumulator** in the shell (never variable dt), fed **only** by
+  the harness's `FrameTime.dts` — physics has no clock of its own. This is the
+  shock2quest lesson (tommy-xr/shock2quest#298: debug-paused game, physics kept
+  integrating on wall-clock): here the debug server's `POST /time` pause/step
+  controls physics for free because pausing pins `dts = 0` and the accumulator
+  consumes nothing. Verified empirically: a paused scene is byte-identical
+  across wall-clock time; `advance` steps it exactly.
 - Rapier feature **`serde-serialize`** (snapshots); otherwise **default
   features** — no `enhanced-determinism`. (If we later enable `parallel`, first
   verify it is deterministic run-to-run on one machine — the Phase 1 golden


### PR DESCRIPTION
Tiny follow-up to #176 (this commit raced the merge by seconds and missed it).

Pins the invariant that keeps the shock2quest debug-pause bug (tommy-xr/shock2quest#298 — physics kept integrating on wall-clock while the game was paused) structurally impossible here: physics has no clock of its own, stepping only from the harness's `FrameTime.dts`, so the debug server's `POST /time` pause/step controls the simulation for free.

Verified empirically against #176: with `/time set` a physics scene's `GET /scene` JSON is byte-identical across 0.7s of wall-clock (crate frozen mid-fall); 30× `/time advance {"dts": 1/60}` steps the pose exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)