### PR TITLE
feat(examples): mle-physics — the reference physics example (Phase 2c)

### DIFF
--- a/.claude/skills/mle-language/SKILL.md
+++ b/.claude/skills/mle-language/SKILL.md
@@ -197,7 +197,10 @@ A project dir with `functor.json` `{"language": "mle", "entry": "game.mle"}`
 works with the CLI: `functor -d dir build` (typecheck, diagnostics are
 errors), `run native`, `develop` (hot reload is built in).
 
-`examples/mle-hello/game.mle` is the reference. The model shows live at the
+`examples/mle-hello/game.mle` is the reference
+(`examples/mle-physics/game.mle` for the physics hook, including the
+rising-edge input latch — GLFW key repeats arrive as `isDown = true`).
+The model shows live at the
 debug server's `GET /state`. **Hot reload is on by default**: saving the
 `.mle` file reloads it in ~1 frame with the model preserved (a broken edit
 keeps the old program running; an edited `init` takes effect on restart).

--- a/examples/mle-physics/functor.json
+++ b/examples/mle-physics/functor.json
@@ -1,0 +1,4 @@
+{
+  "language": "mle",
+  "entry": "game.mle"
+}

--- a/examples/mle-physics/game.mle
+++ b/examples/mle-physics/game.mle
@@ -1,0 +1,83 @@
+// mle-physics — the reference physics example (docs/physics.md, Phase 2c).
+// Crates and a ball tumble onto a slab, drawn at their live simulated poses
+// via Physics.transformed. Press SPACE to re-drop everything: the changed
+// declared spawn poses teleport the bodies (the divergence rule) and the
+// pile falls again. Run with:
+//
+//   functor-runner --mle --game-path examples/mle-physics/game.mle
+//   functor -d examples/mle-physics run native
+//
+// The physics world lives host-side: edit this file while it runs and (as
+// long as tags and declarations are unchanged) the bodies stay exactly
+// where they were — hot reload keeps model + world.
+
+let crateCount = 5.0
+
+// Pseudo-scatter: a deterministic hash of crate index + drop generation, so
+// every SPACE press declares fresh spawn poses without any RNG. Within a
+// generation the declarations are byte-identical each frame, so the
+// divergence rule leaves settled bodies alone (they can sleep).
+let scatterX = (drop, i) => Math.sin(i * 12.9898 + drop * 3.7) * 1.6
+let scatterZ = (drop, i) => Math.cos(i * 78.2330 + drop * 1.3) * 1.6
+
+let crateTag = (i) => Text.concat("crate-", Text.fromFloat(i))
+
+let crateBody = (drop, i) =>
+  Physics.dynamic(crateTag(i), Physics.box(1.0, 1.0, 1.0))
+    |> Physics.at(scatterX(drop, i), 3.0 + i * 1.3, scatterZ(drop, i))
+    |> Physics.friction(0.6)
+    |> Physics.restitution(0.2)
+
+// One body per slot: 0 = ground, 1 = ball, the rest = crates — built with a
+// literal match because MLE has no List.append yet. The ball's scatter seed
+// (9.0) is just a value disjoint from the crate indices 0..4. The slab sits
+// with its TOP face at y = 0, so visuals on the ground plane line up with
+// resting bodies.
+let bodyAt = (drop, i) =>
+  match i with
+  | 0.0 => Physics.fixed("ground", Physics.box(24.0, 0.4, 24.0)) |> Physics.at(0.0, -0.2, 0.0)
+  | 1.0 =>
+    (Physics.dynamic("ball", Physics.sphere(0.6))
+      |> Physics.at(scatterX(drop, 9.0) * 0.5, 5.5, scatterZ(drop, 9.0) * 0.5)
+      |> Physics.restitution(0.55))
+  | n => crateBody(drop, n - 2.0)
+
+let physics = (model) =>
+  Physics.scene(0.0, -9.81, 0.0,
+    List.range(crateCount + 2.0) |> List.map((i) => bodyAt(model.drop, i)))
+
+// Tints stay in 0..1 for any crateCount thanks to clamp01.
+let crateVisual = (i) =>
+  Scene.cube()
+    |> Scene.lit(Math.clamp01(0.55 + 0.09 * i), Math.clamp01(0.42 - 0.04 * i), 0.28)
+    |> Physics.transformed(crateTag(i))
+
+let init = { drop: 0.0, spaceHeld: false }
+
+let tick = (model, dt, tts) => model
+
+// Rising-edge detection: GLFW delivers key REPEATS as `isDown = true` too,
+// so holding SPACE would re-drop every repeat without the spaceHeld latch.
+let input = (model, key, isDown) =>
+  match key with
+  | "Space" =>
+    (match isDown with
+     | false => { model with spaceHeld: false }
+     | true =>
+       (match model.spaceHeld with
+        | true => model
+        | false => { model with drop: model.drop + 1.0, spaceHeld: true }))
+  | _ => model
+
+let draw = (model, tts) =>
+  Frame.createLit(
+    Camera.lookAt(10.5, 7.5, -10.5, 0.0, 0.8, 0.0),
+    Scene.group([
+      Scene.plane() |> Scene.scale(24.0) |> Scene.lit(0.55, 0.58, 0.62),
+      Scene.sphere() |> Scene.scale(0.6) |> Scene.lit(0.95, 0.35, 0.25) |> Physics.transformed("ball"),
+      Scene.group(List.range(crateCount) |> List.map(crateVisual)),
+    ]),
+    [
+      Light.ambient(0.12, 0.12, 0.15),
+      Light.directional(0.5, -1.0, 0.35, 1.0, 0.98, 0.95, 0.9) |> Light.castShadows,
+    ])


### PR DESCRIPTION
Phase **2c** of docs/physics.md: the first committed physics game — `examples/mle-physics`, ~85 lines of MLE. Crates and a ball tumble onto a slab, drawn at their live simulated poses; **SPACE re-drops everything** (one model field bump → changed declared poses → divergence-rule teleport).

![fall](https://gist.githubusercontent.com/tommy-xr/40e23f3bf461e98eba5d55206df4031d/raw/mle-physics-example.gif)

| mid-fall (t = 0.65s) | at rest (t = 3.0s) |
| --- | --- |
| ![mid](https://gist.githubusercontent.com/tommy-xr/40e23f3bf461e98eba5d55206df4031d/raw/mid-fall.png) | ![rest](https://gist.githubusercontent.com/tommy-xr/40e23f3bf461e98eba5d55206df4031d/raw/at-rest.png) |

## What it demonstrates (it's the example users will copy)

- The optional `physics` hook + the full `Physics.*` declarative vocabulary, with declarations as **pure functions of the model**: byte-identical within a drop generation (settled bodies sleep), one counter bump re-drops the world.
- Live world reads in `draw` via `Physics.transformed(tag)` — no transform bookkeeping in the game at all.
- A **rising-edge input latch**: GLFW delivers key *repeats* as `isDown = true`, so holding SPACE would machine-gun re-drops without it. (Found by the cross-engine review; verified by injecting repeated key-downs through the debug server — `drop` increments exactly once per press.)
- Exact physics/visual alignment, verified against the geometry sources: unit cube = `Physics.box(1,1,1)`, unit sphere × `scale(0.6)` = `Physics.sphere(0.6)`, slab top at y=0 under the plane visual.
- The no-`List.append` slot-match idiom for heterogeneous body lists, commented for copiers.

## Verification

- `mle check` clean (typecheck-as-errors, same as `functor build`)
- Live captures above (headless `--capture-time` path — no `--fixed-time`, which pins `dts = 0` and never steps physics; documented in docs/physics.md)
- SPACE latch + re-drop verified headlessly via debug-server key injection (`/state` shows `drop` advancing once per press-release cycle)
- Cross-engine review run; both engines otherwise clean, Codex's key-repeat catch fixed as above

No golden scenario yet — a deterministic physics capture needs `/time`-driven stepping rather than the fixed-time path; that recipe pairs naturally with the Phase 6 pause/rewind work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)