### PR TITLE
feat(sdk): launch hidden by default, visible: true escape hatch

### DIFF
--- a/tools/functor-sdk/README.md
+++ b/tools/functor-sdk/README.md
@@ -32,9 +32,13 @@ const png = await game.capture();// PNG bytes of the frame
 `FunctorRunner.connect(url)` attaches to an already-running runtime instead of
 spawning one (and won't kill it on dispose).
 
-Pass `headless: true` to launch with no GL window (`--headless`) — no display
-needed, ideal for CI. `state()`, `scene()`, `input()`, and the clock controls all
-work; `capture()` is unavailable (it returns a 503 — there are no pixels).
+By default the runner is launched with `--hidden`: the GL window is never shown
+and never steals focus or the cursor, but keeps its GL context, so `capture()`
+works. Pass `visible: true` to show the window (e.g. to watch a script drive the
+game), or `headless: true` to launch with no GL window at all (`--headless`) — no
+display needed, ideal for CI. Headless, `state()`, `scene()`, `input()`, and the
+clock controls all work; `capture()` is unavailable (it returns a 503 — there are
+no pixels).
 
 ### Observe vs. drive
 

--- a/tools/functor-sdk/src/server.ts
+++ b/tools/functor-sdk/src/server.ts
@@ -144,6 +144,9 @@ export class FunctorRunner extends FunctorClient implements AsyncDisposable {
     if (options.mlePath && options.dylibPath) {
       throw new Error("mlePath and dylibPath are mutually exclusive");
     }
+    if (options.headless && options.visible) {
+      throw new Error("headless and visible are mutually exclusive");
+    }
     // An .mle source runs through the interpreter; otherwise a built dylib.
     const gamePath = options.mlePath
       ? isAbsolute(options.mlePath)
@@ -171,6 +174,10 @@ export class FunctorRunner extends FunctorClient implements AsyncDisposable {
     }
     if (options.headless) {
       runnerArgs.push("--headless");
+    } else if (!options.visible) {
+      // Hidden by default: the window keeps its GL context (capture() works)
+      // but is never shown and never steals focus or the cursor.
+      runnerArgs.push("--hidden");
     }
 
     const logLines: string[] = [];

--- a/tools/functor-sdk/src/types.ts
+++ b/tools/functor-sdk/src/types.ts
@@ -85,4 +85,9 @@ export interface LaunchOptions {
   /** Run the runtime with no GL window (`--headless`): no display needed, but
    * `capture()` is unavailable. Ideal for CI / headless machines. */
   headless?: boolean;
+  /** Show the GL window. By default (and unless `headless`), the runner is
+   * launched with `--hidden`: the window is never shown and never steals focus
+   * or the cursor, but keeps its GL context so `capture()` works. Pass `true`
+   * to watch the game while a script drives it. */
+  visible?: boolean;
 }


### PR DESCRIPTION
## What

Follow-up to #178. `FunctorRunner.launch()` now passes `--hidden` for every non-headless launch: the runner window keeps its GL context (so `capture()` works) but is never shown and never steals focus or the cursor — the right default for an SDK whose purpose is scripted/LLM-driven control.

- `visible: true` is the escape hatch — show the window to watch a script drive the game.
- `{ headless: true, visible: true }` throws (mirrors the SDK's `mlePath`/`dylibPath` precedent and the runner's own `--hidden`/`--headless` clap conflict, rather than a silent precedence pick).
- README + `LaunchOptions` docs updated.

Note: non-headless `launch()` now requires a `functor-runner` built at or after #178 (older binaries reject `--hidden` at startup; the SDK surfaces the clap error via its crash output).

## Verification

- `tsc` clean; unit tests 9/9.
- e2e (`FUNCTOR_E2E=1`): `held-input` (non-headless launch + `capture()` returns a real PNG from the hidden window), `mle-input` + `mle-hot-reload` (`--mle --hidden` interpreter path), `launch-failure`, all pass — 13/13.
- Cross-engine review (`/xreview`: Claude + Codex): clean apart from one agreed finding — the silent `headless`-wins-over-`visible` resolution — fixed with the thrown error above and re-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)