### PR TITLE
feat(runtime,cli): network hot-reload for MLE — POST /reload-source + functor push

### DIFF
--- a/cli/src/commands/mle_project.rs
+++ b/cli/src/commands/mle_project.rs
@@ -115,4 +115,94 @@ impl MleProject {
         }];
         util::ShellCommand::run_sequential(commands).await
     }
+
+    /// Push the entry source to a running runner's `POST /reload-source`
+    /// (its debug server) — once, or on every save with `watch`. The runner
+    /// validates the pushed source and keeps its old program on a broken
+    /// push, so errors come back as the 400 body and the loop just keeps
+    /// watching. A transport failure (runner not up yet, cable out) retries
+    /// on the next poll rather than losing the edit.
+    pub async fn push(
+        &self,
+        working_directory: &str,
+        addr: &str,
+        watch: bool,
+    ) -> Result<(), Error> {
+        let path = self.entry_path(working_directory)?;
+        let mtime = |p: &Path| std::fs::metadata(p).and_then(|m| m.modified()).ok();
+        if watch {
+            println!(
+                "[mle] watching {} — pushing to http://{addr}/reload-source on save (Ctrl-C to stop)",
+                self.entry
+            );
+        }
+        // `None` != any real mtime, so the first iteration always pushes.
+        let mut pushed: Option<std::time::SystemTime> = None;
+        loop {
+            let current = mtime(&path);
+            if current != pushed {
+                let src = std::fs::read_to_string(&path)?;
+                match post_reload_source(addr, &src) {
+                    Ok((200, body)) => {
+                        println!("[mle] {body}");
+                        pushed = current;
+                    }
+                    Ok((status, body)) => {
+                        // The runner rejected the source (a load error) —
+                        // that's this revision's verdict; wait for the next
+                        // edit rather than re-pushing the same broken text.
+                        eprintln!("[mle] push rejected ({status}): {body}");
+                        pushed = current;
+                        if !watch {
+                            return Err(Error::other("push rejected"));
+                        }
+                    }
+                    Err(e) => {
+                        if !watch {
+                            return Err(Error::other(format!(
+                                "cannot reach http://{addr}/reload-source: {e} — is the \
+runner up with --debug-port (and --debug-bind 0.0.0.0 if remote)?"
+                            )));
+                        }
+                        eprintln!("[mle] push failed ({e}); retrying…");
+                    }
+                }
+            }
+            if !watch && pushed.is_some() {
+                return Ok(());
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        }
+    }
+}
+
+/// Minimal HTTP POST over std::net — one dependency-free request to the
+/// runner's tiny_http server. Returns (status, body). `Connection: close`
+/// keeps the read side trivial (read to EOF, split headers off).
+fn post_reload_source(addr: &str, source: &str) -> Result<(u16, String), Error> {
+    use std::io::{Read, Write};
+    let timeout = std::time::Duration::from_secs(5);
+    let mut stream = std::net::TcpStream::connect(addr)?;
+    stream.set_read_timeout(Some(timeout))?;
+    stream.set_write_timeout(Some(timeout))?;
+    write!(
+        stream,
+        "POST /reload-source HTTP/1.1\r\nHost: {addr}\r\nContent-Type: text/plain\r\n\
+Content-Length: {}\r\nConnection: close\r\n\r\n",
+        source.len()
+    )?;
+    stream.write_all(source.as_bytes())?;
+    let mut response = String::new();
+    stream.read_to_string(&mut response)?;
+    let status = response
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|code| code.parse::<u16>().ok())
+        .ok_or_else(|| Error::other(format!("malformed HTTP response: {response:.80}")))?;
+    let body = response
+        .split_once("\r\n\r\n")
+        .map(|(_, b)| b.trim().to_string())
+        .unwrap_or_default();
+    Ok((status, body))
 }

--- a/cli/src/commands/mle_project.rs
+++ b/cli/src/commands/mle_project.rs
@@ -119,9 +119,9 @@ impl MleProject {
     /// Push the entry source to a running runner's `POST /reload-source`
     /// (its debug server) — once, or on every save with `watch`. The runner
     /// validates the pushed source and keeps its old program on a broken
-    /// push, so errors come back as the 400 body and the loop just keeps
-    /// watching. A transport failure (runner not up yet, cable out) retries
-    /// on the next poll rather than losing the edit.
+    /// push, so errors come back as the 400 body and the watch loop just
+    /// keeps watching. A transport failure (runner not up yet, cable out)
+    /// retries on the next poll rather than losing the edit.
     pub async fn push(
         &self,
         working_directory: &str,
@@ -129,47 +129,49 @@ impl MleProject {
         watch: bool,
     ) -> Result<(), Error> {
         let path = self.entry_path(working_directory)?;
-        let mtime = |p: &Path| std::fs::metadata(p).and_then(|m| m.modified()).ok();
-        if watch {
-            println!(
-                "[mle] watching {} — pushing to http://{addr}/reload-source on save (Ctrl-C to stop)",
-                self.entry
-            );
+        if !watch {
+            let src = std::fs::read_to_string(&path)?;
+            return match post_reload_source(addr, &src).map_err(|e| {
+                Error::other(format!(
+                    "cannot reach http://{addr}/reload-source: {e} — is the runner up \
+with --debug-port (and --debug-bind 0.0.0.0 if remote)?"
+                ))
+            })? {
+                (200, body) => {
+                    println!("[mle] {body}");
+                    Ok(())
+                }
+                (status, body) => Err(Error::other(format!("push rejected ({status}): {body}"))),
+            };
         }
-        // `None` != any real mtime, so the first iteration always pushes.
-        let mut pushed: Option<std::time::SystemTime> = None;
+
+        println!(
+            "[mle] watching {} — pushing to http://{addr}/reload-source on save (Ctrl-C to stop)",
+            self.entry
+        );
+        // Track the last content ATTEMPTED, not the file mtime: coarse-mtime
+        // filesystems can miss rapid saves, and atomic-save editors briefly
+        // unlink the file mid-save (a failed read here just waits for the
+        // next poll). A rejected push records its content too — that
+        // revision's verdict is in; wait for the next edit.
+        let mut attempted: Option<String> = None;
         loop {
-            let current = mtime(&path);
-            if current != pushed {
-                let src = std::fs::read_to_string(&path)?;
-                match post_reload_source(addr, &src) {
-                    Ok((200, body)) => {
-                        println!("[mle] {body}");
-                        pushed = current;
-                    }
-                    Ok((status, body)) => {
-                        // The runner rejected the source (a load error) —
-                        // that's this revision's verdict; wait for the next
-                        // edit rather than re-pushing the same broken text.
-                        eprintln!("[mle] push rejected ({status}): {body}");
-                        pushed = current;
-                        if !watch {
-                            return Err(Error::other("push rejected"));
+            if let Ok(src) = std::fs::read_to_string(&path) {
+                if attempted.as_deref() != Some(src.as_str()) {
+                    match post_reload_source(addr, &src) {
+                        Ok((200, body)) => {
+                            println!("[mle] {body}");
+                            attempted = Some(src);
                         }
-                    }
-                    Err(e) => {
-                        if !watch {
-                            return Err(Error::other(format!(
-                                "cannot reach http://{addr}/reload-source: {e} — is the \
-runner up with --debug-port (and --debug-bind 0.0.0.0 if remote)?"
-                            )));
+                        Ok((status, body)) => {
+                            eprintln!("[mle] push rejected ({status}): {body}");
+                            attempted = Some(src);
                         }
-                        eprintln!("[mle] push failed ({e}); retrying…");
+                        // Transport failure: leave `attempted` unset so the
+                        // same content retries on the next poll.
+                        Err(e) => eprintln!("[mle] push failed ({e}); retrying…"),
                     }
                 }
-            }
-            if !watch && pushed.is_some() {
-                return Ok(());
             }
             tokio::time::sleep(std::time::Duration::from_millis(300)).await;
         }
@@ -181,8 +183,15 @@ runner up with --debug-port (and --debug-bind 0.0.0.0 if remote)?"
 /// keeps the read side trivial (read to EOF, split headers off).
 fn post_reload_source(addr: &str, source: &str) -> Result<(u16, String), Error> {
     use std::io::{Read, Write};
+    use std::net::ToSocketAddrs;
     let timeout = std::time::Duration::from_secs(5);
-    let mut stream = std::net::TcpStream::connect(addr)?;
+    // connect_timeout, not connect: a blackholed host must fail in 5s, not
+    // the OS's ~75s TCP give-up.
+    let sockaddr = addr
+        .to_socket_addrs()?
+        .next()
+        .ok_or_else(|| Error::other(format!("cannot resolve {addr}")))?;
+    let mut stream = std::net::TcpStream::connect_timeout(&sockaddr, timeout)?;
     stream.set_read_timeout(Some(timeout))?;
     stream.set_write_timeout(Some(timeout))?;
     write!(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -66,6 +66,20 @@ enum Command {
         #[command(subcommand)]
         target: InspectTarget,
     },
+    /// Push the game's MLE source to a running functor-runner over the
+    /// network (POST /reload-source on its debug server) — the remote develop
+    /// loop. The runner can be on another machine or device; reloads preserve
+    /// the model. MLE projects only.
+    Push {
+        /// The runner's debug server, host:port. Start the runner with
+        /// `--debug-port <PORT>` (plus `--debug-bind 0.0.0.0` when remote).
+        addr: String,
+
+        /// Keep watching the entry file and re-push on every save,
+        /// instead of pushing once and exiting.
+        #[arg(long)]
+        watch: bool,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -126,12 +140,15 @@ async fn main() -> tokio::io::Result<()> {
     println!("Running command: {:?}", args.command);
 
     // An MLE project (functor.json: `"language": "mle"`) routes build/run/
-    // develop to the interpreter — no Fable, no cargo, hot reload built in.
-    // Only build/run/develop are language-routed; anything else (Init, and
-    // Inspect handled earlier) falls through to the normal dispatch.
+    // develop/push to the interpreter — no Fable, no cargo, hot reload built
+    // in. Only those are language-routed; anything else (Init, and Inspect
+    // handled earlier) falls through to the normal dispatch.
     let is_routed = matches!(
         &args.command,
-        Command::Build { .. } | Command::Run { .. } | Command::Develop { .. }
+        Command::Build { .. }
+            | Command::Run { .. }
+            | Command::Develop { .. }
+            | Command::Push { .. }
     );
     if let Some(project) = commands::mle_project::detect(&working_directory_str)
         .filter(|_| is_routed)
@@ -174,6 +191,9 @@ async fn main() -> tokio::io::Result<()> {
                         true,
                     )
                     .await
+            }
+            Command::Push { addr, watch } => {
+                project.push(&working_directory_str, addr, *watch).await
             }
         };
         return finish(res);
@@ -218,6 +238,10 @@ async fn main() -> tokio::io::Result<()> {
             )
             .await
         }
+        Command::Push { .. } => Err(io::Error::other(
+            "push requires an MLE project (functor.json with \"language\": \"mle\") — \
+compiled games reload from their rebuilt dylib, not pushed source",
+        )),
         // Handled earlier (before functor.json validation).
         Command::Inspect { .. } => unreachable!(),
     };

--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -18,8 +18,11 @@ cd examples/hello
 functor-runner --game-path build-native/target/debug/libgame_native.dylib --debug-port 8077
 ```
 
-The server binds **localhost only** (`127.0.0.1:<PORT>`). HTTP handlers never touch GL;
-each request is handed to the render loop and fulfilled once per frame.
+The server binds **localhost by default** (`127.0.0.1:<PORT>`); `--debug-bind 0.0.0.0`
+exposes it to the LAN for remote develop (see `POST /reload-source`) — there is no auth,
+so bind wide only on networks where arbitrary game-code pushes are acceptable. HTTP
+handlers never touch GL; each request is handed to the render loop and fulfilled once
+per frame.
 
 ## Headless mode
 
@@ -65,6 +68,7 @@ functor-runner --game-path <dylib> --debug-port 8077 --hidden
 | `GET /scene` | current frame as JSON: `camera` + `scene` + `lights` |
 | `POST /input` | inject input (see below) |
 | `POST /time` | control the frame clock (see below) |
+| `POST /reload-source` | swap game logic from the request body (see below) |
 
 ### `POST /input`
 
@@ -87,6 +91,22 @@ JSON is tagged by `type`. Unknown keys/shapes return **400** with a message.
 `--fixed-time <T>` pins the clock from launch (equivalent to an initial `set`).
 While the clock is pinned, **user keyboard/mouse input from the window is ignored**, but
 injected `/input` still applies — so an external driver has deterministic control.
+
+### `POST /reload-source` — network hot-reload (MLE)
+
+The body is the raw `.mle` source. The runner validates it and swaps the session with
+**the model preserved** — the same semantics as the file-watch reload. A broken push
+returns **400** with the rendered load error and keeps the old program running; producers
+whose logic isn't source-shaped (compiled dylibs, replays) also return 400. This is the
+remote develop path: run the game on another machine or device
+(`--debug-port <P> --debug-bind 0.0.0.0`), then push from the project dir:
+
+```sh
+functor -d mygame push <host>:<port>          # push once
+functor -d mygame push <host>:<port> --watch  # re-push on every save
+```
+
+(`curl --data-binary @game.mle http://<host>:<port>/reload-source` works too.)
 
 ## Two workflows
 

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -86,6 +86,17 @@ pub trait GameProducer {
     /// page) may never call it.
     fn check_hot_reload(&mut self, frame_time: crate::FrameTime);
 
+    /// Replace the game's logic from source text pushed over the wire — the
+    /// network hot-reload path (a dev machine pushing to a runner on another
+    /// device, e.g. a headset). Same semantics as the file-watch reload:
+    /// the model is preserved, a broken push keeps the old program running.
+    /// `Ok` carries a short status line for the pusher. The default is the
+    /// honest refusal for producers whose logic isn't source-shaped
+    /// (compiled dylibs, replays).
+    fn reload_source(&mut self, _source: &str) -> Result<String, String> {
+        Err("this producer does not support source reload (not an .mle game)".to_string())
+    }
+
     fn tick(&mut self, frame_time: crate::FrameTime);
 
     /// Deliver a keyboard event. `code` is a [`crate::Key`] as `i32`.

--- a/runtime/functor-runtime-desktop/src/debug_server.rs
+++ b/runtime/functor-runtime-desktop/src/debug_server.rs
@@ -14,6 +14,7 @@
 //! `POST /input`, `POST /time`. See `docs/debug-runtime.md` for usage and the
 //! observe-vs-drive workflows.
 
+use std::io::Read;
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread;
 
@@ -285,8 +286,32 @@ pub fn spawn(bind: &str, port: u16) -> Receiver<DebugRequest> {
                     }
                 }
                 (Method::Post, "/reload-source") => {
+                    // This endpoint can be LAN-exposed (--debug-bind), so
+                    // bound the body: game source is KBs, and an unbounded
+                    // read_to_string is an OOM invitation. Chunked bodies
+                    // (no declared length) are rejected the same way.
+                    const MAX_SOURCE_BYTES: usize = 4 * 1024 * 1024;
+                    match request.body_length() {
+                        Some(len) if len <= MAX_SOURCE_BYTES => {}
+                        _ => {
+                            let _ = request.respond(
+                                Response::from_string(
+                                    "source too large (or missing Content-Length); limit is 4MB",
+                                )
+                                .with_status_code(413),
+                            );
+                            continue;
+                        }
+                    }
                     let mut body = String::new();
-                    if request.as_reader().read_to_string(&mut body).is_err() {
+                    let mut reader = request.as_reader();
+                    // (&mut reader): `take` needs Sized, and `as_reader`
+                    // hands back `&mut dyn Read`.
+                    if std::io::Read::take(&mut reader, MAX_SOURCE_BYTES as u64 + 1)
+                        .read_to_string(&mut body)
+                        .is_err()
+                        || body.len() > MAX_SOURCE_BYTES
+                    {
                         let _ = request
                             .respond(Response::from_string("bad body").with_status_code(400));
                         continue;

--- a/runtime/functor-runtime-desktop/src/debug_server.rs
+++ b/runtime/functor-runtime-desktop/src/debug_server.rs
@@ -103,15 +103,22 @@ pub enum DebugRequest {
     Input(InputCommand, Sender<Result<(), String>>),
     /// `POST /time` — set/advance/resume the clock; reply once applied.
     Time(TimeCommand, Sender<()>),
+    /// `POST /reload-source` — swap the game's logic from the pushed source
+    /// (body = the raw `.mle` text), preserving the model. Ok carries a status
+    /// line; Err the load error (400) — a broken push keeps the old program.
+    ReloadSource(String, Sender<Result<String, String>>),
 }
 
 /// Start the debug HTTP server on a background thread. Returns the receiving end
 /// of the request channel; the GL loop should `try_recv()` it once per frame.
-/// Binds localhost only.
-pub fn spawn(port: u16) -> Receiver<DebugRequest> {
+/// `bind` is the interface to listen on — 127.0.0.1 (the default) keeps it
+/// local; 0.0.0.0 exposes it to the LAN for remote develop (`/reload-source`
+/// from a dev machine to a runner on another device). There is no auth: only
+/// bind wide on networks where arbitrary game-code pushes are acceptable.
+pub fn spawn(bind: &str, port: u16) -> Receiver<DebugRequest> {
     let (tx, rx) = mpsc::channel::<DebugRequest>();
 
-    let addr = format!("127.0.0.1:{}", port);
+    let addr = format!("{}:{}", bind, port);
     let server = match Server::http(&addr) {
         Ok(s) => s,
         Err(e) => {
@@ -277,6 +284,36 @@ pub fn spawn(port: u16) -> Receiver<DebugRequest> {
                         }
                     }
                 }
+                (Method::Post, "/reload-source") => {
+                    let mut body = String::new();
+                    if request.as_reader().read_to_string(&mut body).is_err() {
+                        let _ = request
+                            .respond(Response::from_string("bad body").with_status_code(400));
+                        continue;
+                    }
+                    let (resp_tx, resp_rx) = mpsc::channel();
+                    if tx.send(DebugRequest::ReloadSource(body, resp_tx)).is_err() {
+                        let _ = request
+                            .respond(Response::from_string("runtime gone").with_status_code(503));
+                        continue;
+                    }
+                    match resp_rx.recv() {
+                        Ok(Ok(status)) => {
+                            let _ = request.respond(Response::from_string(status));
+                        }
+                        // A load error in the pushed source (or a producer
+                        // that can't reload) — the pusher's mistake: 400.
+                        Ok(Err(msg)) => {
+                            let _ =
+                                request.respond(Response::from_string(msg).with_status_code(400));
+                        }
+                        Err(_) => {
+                            let _ = request.respond(
+                                Response::from_string("reload failed").with_status_code(500),
+                            );
+                        }
+                    }
+                }
                 (Method::Get, "/") => {
                     // Static endpoint index for discoverability (e.g. an LLM
                     // probing the port). No GL access needed, so reply directly.
@@ -288,7 +325,8 @@ pub fn spawn(port: u16) -> Receiver<DebugRequest> {
                             "GET /state": "runtime state JSON: frame, tts, viewport, input (held_keys + mouse), model (Debug text)",
                             "GET /scene": "current frame as JSON: camera + scene + lights",
                             "POST /input": "inject input — {\"type\":\"key\",\"key\":\"w\",\"down\":true} | {\"type\":\"mouse_move\",\"x\":0,\"y\":0} | {\"type\":\"mouse_wheel\",\"delta\":1}",
-                            "POST /time": "clock control — {\"type\":\"set\",\"tts\":2.0} (pause) | {\"type\":\"advance\",\"dts\":0.016} (step one frame) | {\"type\":\"resume\"}"
+                            "POST /time": "clock control — {\"type\":\"set\",\"tts\":2.0} (pause) | {\"type\":\"advance\",\"dts\":0.016} (step one frame) | {\"type\":\"resume\"}",
+                            "POST /reload-source": "swap game logic from the request body (raw .mle source), model preserved — 400 with the load error on a broken push"
                         }
                     })
                     .to_string();

--- a/runtime/functor-runtime-desktop/src/main.rs
+++ b/runtime/functor-runtime-desktop/src/main.rs
@@ -173,11 +173,19 @@ struct Args {
     #[arg(long)]
     fixed_time: Option<f32>,
 
-    /// Start an HTTP control server on 127.0.0.1:<PORT> (localhost only) exposing
-    /// POST /capture (image/png of the next frame) and GET /state (runtime JSON).
+    /// Start an HTTP control server on <--debug-bind>:<PORT> exposing
+    /// POST /capture (image/png of the next frame), GET /state (runtime JSON),
+    /// and POST /reload-source (network hot-reload for MLE games).
     /// Omit to disable the server entirely.
     #[arg(long)]
     debug_port: Option<u16>,
+
+    /// Interface the debug server binds to. The default keeps it local;
+    /// 0.0.0.0 exposes it to the LAN for remote develop (a dev machine
+    /// pushing source to this runner). No auth — bind wide only on networks
+    /// where arbitrary game-code pushes are acceptable.
+    #[arg(long, default_value = "127.0.0.1")]
+    debug_bind: String,
 
     /// Override shading with a diagnostic view across the whole frame (e.g.
     /// `normals` to visualize surface normals as color). Primitives only for
@@ -424,6 +432,9 @@ fn service_debug_request(
                 .unwrap_or_else(|e| format!("{{\"error\":{:?}}}", e.to_string()));
             let _ = resp.send(json);
         }
+        debug_server::DebugRequest::ReloadSource(source, resp) => {
+            let _ = resp.send(game.reload_source(&source));
+        }
         debug_server::DebugRequest::Input(cmd, resp) => {
             let result = match cmd {
                 debug_server::InputCommand::Key { key, down } => match key_from_str(&key) {
@@ -567,7 +578,9 @@ pub async fn main() {
     // Optional debug control server. Runs on its own thread; the GL loop drains
     // its request channel once per frame (see below). None when --debug-port is
     // not given, so behavior is unchanged.
-    let debug_requests = args.debug_port.map(debug_server::spawn);
+    let debug_requests = args
+        .debug_port
+        .map(|port| debug_server::spawn(&args.debug_bind, port));
 
     // Headless: drive the game + debug server with no GL window, and return.
     if args.headless {

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -96,6 +96,13 @@ struct Loaded {
 /// them and hot-reload can print-and-keep-running with the same text.
 fn load_game(path: &str) -> Result<Loaded, String> {
     let src = std::fs::read_to_string(path).map_err(|e| format!("cannot read {path}: {e}"))?;
+    load_source(path, src)
+}
+
+/// The source-shaped half of [`load_game`]: check and contract-validate
+/// already-obtained source. `path` is only a label for error rendering — the
+/// network reload path (`reload_source`) has no file behind the source.
+fn load_source(path: &str, src: String) -> Result<Loaded, String> {
     let render = |stage: &str, span: mle::Span, message: &str| {
         let (line, col) = mle::line_col(&src, span.start);
         format!("cannot {stage} {path}:{line}:{col}: {message}")
@@ -305,6 +312,38 @@ impl MleGame {
         }
     }
 
+    /// Swap in a freshly loaded program, KEEPING THE MODEL — the shared tail
+    /// of both reload paths (file watch and network push). `init` from the
+    /// new program is deliberately unused: state survives the edit, and
+    /// closures stored in the model rebind to the edited code (B5 part 2,
+    /// `mle::rebind_value`). The physics world is deliberately KEPT too, like
+    /// the model: it lives in this process's registry, so bodies stay where
+    /// they are across the edit and the next frame's declaration re-diffs
+    /// against them (removing the `physics` hook drops the world). `prev_tts`
+    /// is kept as well: `Sub.every` fires on the global time grid, so timers
+    /// tick right through a reload. Returns the number of stored closures
+    /// rebound, for the status line.
+    fn swap_in(&mut self, loaded: Loaded) -> usize {
+        let (model, report) = mle::rebind_value(&self.model, &self.module, &loaded.module);
+        self.model = model;
+        for warning in &report.warnings {
+            eprintln!("[mle] reload: {warning}");
+        }
+        self.src = loaded.src;
+        self.module = loaded.module;
+        self.session = loaded.session;
+        self.has_input = loaded.has_input;
+        self.has_mouse_move = loaded.has_mouse_move;
+        self.has_mouse_wheel = loaded.has_mouse_wheel;
+        self.has_subscriptions = loaded.has_subscriptions;
+        self.has_physics = loaded.has_physics;
+        if !self.has_physics {
+            physics::remove_world(physics::DEFAULT_WORLD);
+        }
+        self.last_error = None;
+        report.rebound
+    }
+
     fn report_stats(&mut self) {
         if self.frames > 0 && self.frames % STATS_EVERY == 0 {
             let tick_us = self.tick_ns as f64 / STATS_EVERY as f64 / 1000.0;
@@ -341,31 +380,9 @@ impl Game for MleGame {
         let started = Instant::now();
         match load_game(&self.path) {
             Ok(loaded) => {
-                let (model, report) = mle::rebind_value(&self.model, &self.module, &loaded.module);
-                self.model = model;
-                for warning in &report.warnings {
-                    eprintln!("[mle] reload: {warning}");
-                }
-                self.src = loaded.src;
-                self.module = loaded.module;
-                self.session = loaded.session;
-                self.has_input = loaded.has_input;
-                self.has_mouse_move = loaded.has_mouse_move;
-                self.has_mouse_wheel = loaded.has_mouse_wheel;
-                self.has_subscriptions = loaded.has_subscriptions;
-                // prev_tts is deliberately kept: `Sub.every` fires on the
-                // global time grid, so timers tick right through a reload.
-                self.has_physics = loaded.has_physics;
-                // The physics world is deliberately KEPT, like the model: it
-                // lives in this process's registry, so bodies stay where they
-                // are across the edit and the next frame's declaration
-                // re-diffs against them (removing the hook drops the world).
-                if !self.has_physics {
-                    physics::remove_world(physics::DEFAULT_WORLD);
-                }
-                self.last_error = None;
-                let stored = if report.rebound > 0 {
-                    format!("; {} stored closure(s) rebound", report.rebound)
+                let rebound = self.swap_in(loaded);
+                let stored = if rebound > 0 {
+                    format!("; {rebound} stored closure(s) rebound")
                 } else {
                     String::new()
                 };
@@ -382,6 +399,29 @@ impl Game for MleGame {
                 ));
             }
         }
+    }
+
+    fn reload_source(&mut self, source: &str) -> Result<String, String> {
+        // Same semantics as the file-watch path: model preserved, a broken
+        // push keeps the old program (and the error goes back to the pusher,
+        // who is looking at the source that caused it). The on-disk file is
+        // untouched — a later save still wins via the mtime watcher
+        // (last-write-wins, from either side).
+        let started = Instant::now();
+        let loaded = load_source(&self.path, source.to_string())?;
+        let rebound = self.swap_in(loaded);
+        let stored = if rebound > 0 {
+            format!("; {rebound} stored closure(s) rebound")
+        } else {
+            String::new()
+        };
+        let status = format!(
+            "reloaded {} from pushed source in {:.2}ms (model preserved{stored})",
+            self.path,
+            started.elapsed().as_secs_f64() * 1000.0
+        );
+        println!("[mle] {status}");
+        Ok(status)
     }
 
     fn tick(&mut self, frame_time: FrameTime) {

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -415,6 +415,11 @@ impl Game for MleGame {
         } else {
             String::new()
         };
+        // Absorb any disk mtime observed up to now: a save that landed
+        // earlier this frame (after check_hot_reload ran, before this push
+        // was serviced) is by definition older than the push and must not
+        // revert it next frame. Saves after this instant still win.
+        self.mtime = file_mtime(&self.path);
         let status = format!(
             "reloaded {} from pushed source in {:.2}ms (model preserved{stored})",
             self.path,


### PR DESCRIPTION
## What

The remote develop loop for MLE games — the piece that makes the future headset story work (the runtime shell ships once; games deploy as text over the network):

- **`GameProducer::reload_source`** (default: honest refusal for compiled/replay producers). `MleGame` implements it through the same `swap_in` as the file-watch reload: **model preserved**, physics world kept, broken push keeps the old program and returns the rendered load error.
- **`POST /reload-source`** on the debug server (body = raw `.mle` source; 4MB cap → 413), plus **`--debug-bind`** to expose it beyond localhost (documented no-auth caveat).
- **`functor push <addr> [--watch]`** for MLE projects: one-shot or push-on-save, dependency-free HTTP client (connect timeout 5s), content-keyed watch (immune to coarse mtimes and atomic-save editors), transport failures retry, rejections wait for the next edit.
- `docs/debug-runtime.md` documents the endpoint + workflow.

## Verification (all headless / scriptable)

- Push swaps code live in <1ms with model continuity proven (`spin` kept increasing across reloads, never reset); camera change confirms new code runs.
- Broken push → 400 with `path:line:col` error; old program keeps rendering.
- Watch mode: save → repush; broken save → rejection logged, runner unaffected.
- 5MB body → 413, server unaffected; one-shot to a dead port fails in 15ms with a actionable message; non-MLE projects refused with an explanation.
- `cargo test`: 18 runner + 110 common green; wasm target compiles (trait default covers the web bridge).

## Review

/xreview (Claude + Codex): no Critical. Both-engine [AGREED] fixes: body cap, connect timeout. Codex-only High fixed: a disk save landing in the same frame before a push was serviced would silently revert the push next frame — `reload_source` now absorbs the observed mtime. All fixes re-validated end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)