### PR TITLE
feat(mle,runtime): B5 part 2 — stored closures rebind across hot reload

### DIFF
--- a/.claude/skills/mle-language/SKILL.md
+++ b/.claude/skills/mle-language/SKILL.md
@@ -215,6 +215,10 @@ errors), `run native`, `develop` (hot reload is built in).
 debug server's `GET /state`. **Hot reload is on by default**: saving the
 `.mle` file reloads it in ~1 frame with the model preserved (a broken edit
 keeps the old program running; an edited `init` takes effect on restart).
+Closures **stored in the model** rebind too: they adopt the edited code
+with their captured values carried over (matched by the enclosing def's
+name; a closure whose def was renamed/deleted keeps its old body with a
+loud `[mle] reload:` warning).
 
 Transforms wrap in Group nodes: the **outer call applies last in world
 space** — `s |> Scene.rotateY(r) |> Scene.translate(x, 0.0, 0.0)` rotates in

--- a/docs/mle.md
+++ b/docs/mle.md
@@ -368,6 +368,19 @@ First-class `.mle` editor support, built on the `mle` crate's front-end
 - [ ] **D3b. Go-to-definition.** Needs a use→definition query over the IR
       (it already carries spans on every node, but no query API yet); the
       hover node-walk is the natural starting point.
+- [ ] **D4. Live game preview in the editor** (needs C5). A VSCode webview
+      panel hosting the wasm runtime: the extension pushes the LIVE buffer
+      (debounced, unsaved included) into the webview, and a new
+      `set_source(src)` wasm export mirrors the native reload path —
+      parse → lower → check-as-warnings → `Session::load` →
+      `mle::rebind_value` on the held model. `Session`/`rebind` are pure
+      Rust, so **model-preserving hot reload runs in the browser**: type,
+      and the running game updates beside the editor without losing state
+      (a broken edit keeps the old program, same as native). v1 serves via
+      `functor run wasm` + iframe; a bundled self-contained runtime can
+      come later. *Verify:* e2e-drive the wasm page directly
+      (`set_source` twice, assert model survived + behavior changed);
+      manual: edit `mle-hello` live in the panel.
 
 ## Endgame — replace F#
 

--- a/docs/mle.md
+++ b/docs/mle.md
@@ -196,9 +196,23 @@ snapshots — no GPU, fully agent-verifiable.
       recursive captures, deleted-def / new-capture warnings, stale-id
       guard, data passthrough); pinned-clock SDK e2e — edit a stored
       `vel` closure's body live, `x' = x + newBody(oldK · dt)` exactly.
+- [ ] **Language: tuples.** Real F#-style tuples, landing BEFORE B6 (which
+      consumes them: `update`/`tick` return `(model, effects)` pairs, the
+      F# contract's shape). Scope: `(a, b)` literals (≥ 2 elements — `(e)`
+      stays grouping); tuple patterns in `match` (`| (x, y) =>`, shallow
+      like ctor sub-patterns) and a destructuring let
+      (`let (a, b) = e in …`) since multiple-returns is the point;
+      `Float * Float` product types in annotations; `Value::Tuple` with
+      structural equality and `(1, 2)` display; checker arity + element
+      types, exhaustiveness-compatible; hover/LSP display; rebind walk;
+      no positional field access (`t.0`) — destructure instead (named
+      records stay the LLM-native default for anything that outlives an
+      expression). Skill updated in the same PR. *Verify:* semantics +
+      error + checker tests, goldens, an example using a
+      multiple-return function.
 - [ ] **B6. Minimal effect broker.** `Clock.Now`, `Random` with real/fake/replay
-      handlers. *Verify:* same program under real vs fake vs replay; structured
-      effect log.
+      handlers; `update`/`tick` return `(model, effects)` tuples. *Verify:* same
+      program under real vs fake vs replay; structured effect log.
 - [x] **Language: record updates + local mutability** (2026-07-02; design:
       `~/notes/ideas/mle-language/mutability.md`). `{ base with x: 1.0 }`
       pure record updates; expression-level `let [mut] x = e in body` with

--- a/docs/mle.md
+++ b/docs/mle.md
@@ -167,7 +167,7 @@ snapshots — no GPU, fully agent-verifiable.
       + committed `broken.check` diagnostic golden (all diagnostics, sorted,
       `file:line:col`); per-diagnostic message/span unit tests; the three
       examples check clean. (done)
-- [ ] **B5. Match/ADTs + storable closures.** The game-logic essentials.
+- [x] **B5. Match/ADTs + storable closures.** The game-logic essentials.
       **Part 1 — ADTs + `match` — done (2026-07-03):** variant `type`
       declarations (`| Ctor(name: Type, …)` / nullary `| Ctor`; leading `|`
       required, first alternative included); constructors live in the value
@@ -179,10 +179,23 @@ snapshots — no GPU, fully agent-verifiable.
       equality; gradual checking with exhaustiveness (missing ctors named),
       foreign-ctor/literal-compatibility diagnostics, typed pattern
       variables, and arm-result joins; hover for ctor signatures and pattern
-      vars; `examples/shapes.mle` + goldens. **Remaining: storable
-      closures** serialized as `(stable-id, env)`. *Verify:* serialize a
-      value graph containing a closure → deserialize → call it;
-      rename-then-restore fails loud.
+      vars; `examples/shapes.mle` + goldens.
+      **Part 2 — storable closures — done (2026-07-03):** closures stored
+      in the model rebind across a hot reload (`mle::rebind`; design:
+      `closures.md` — rebind not content-address, ids by stable name,
+      identity resolved at the boundary). A lambda's id is its def's name
+      + `#k` traversal ordinals; runtime closures carry only their ExprId
+      (both id tables derived at reload time, off the hot path); captured
+      envs carry over BY NAME with recursive rebinding through containers
+      and captured closures; unmatched ids / unresolvable captures keep
+      the old body with a loud warning, and an Rc pointer guard makes
+      stale ids from older modules unidentifiable rather than
+      misidentified. Serialize-to-bytes rides on the state protocol later
+      — the `(stable-id, env)` split is done here.
+      *Verify (done):* 7 rebind unit tests (adopt+keep-env, containers,
+      recursive captures, deleted-def / new-capture warnings, stale-id
+      guard, data passthrough); pinned-clock SDK e2e — edit a stored
+      `vel` closure's body live, `x' = x + newBody(oldK · dt)` exactly.
 - [ ] **B6. Minimal effect broker.** `Clock.Now`, `Random` with real/fake/replay
       handlers. *Verify:* same program under real vs fake vs replay; structured
       effect log.
@@ -263,9 +276,9 @@ Starts once A2 + B3 exist.
       contract violations (missing `tick`, function `init`) reject the new
       session the same way. Reload observed at **0.14ms** re-parse +
       ≤ 1 frame poll — versus the multi-second Fable+cargo loop this project
-      exists to kill. Caveat until B5: closure values stored *inside* the
-      model keep pre-reload bodies (globals rebind; stored closures need the
-      `(stable-id, env)` representation).
+      exists to kill. (The original caveat — closure values stored *inside*
+      the model kept pre-reload bodies — was removed by B5 part 2: stored
+      closures now rebind too.)
       *Verify (done):* SDK e2e (`mle-hot-reload.e2e.test.ts`, headless): with
       the debug clock pinned, spin `0.3` + one post-edit step = exactly
       `0.3 + dt×(-5)` — state survived AND behavior changed as arithmetic,

--- a/mle/src/eval.rs
+++ b/mle/src/eval.rs
@@ -435,6 +435,7 @@ impl Interp<'_> {
                 params: params.clone(),
                 body: body.clone(),
                 env: env.clone(),
+                expr_id: expr.id,
             }))),
             ExprKind::Call { callee, args } => {
                 let callee_value = self.eval(callee, env)?;

--- a/mle/src/lib.rs
+++ b/mle/src/lib.rs
@@ -15,6 +15,7 @@ pub mod ir;
 mod lexer;
 mod lower;
 mod parser;
+pub mod rebind;
 mod span;
 pub mod types;
 pub mod value;
@@ -25,6 +26,7 @@ pub use eval::{
 };
 pub use lower::lower;
 pub use parser::parse;
+pub use rebind::{rebind_value, RebindReport};
 pub use span::{line_col, Span};
 pub use types::{check, check_with_types, ExprTypes};
 pub use value::{HostData, Value};

--- a/mle/src/rebind.rs
+++ b/mle/src/rebind.rs
@@ -1,0 +1,350 @@
+//! Hot-reload rebinding for closures stored in the model — B5 part 2
+//! (docs/mle.md; design: `~/notes/ideas/mle-language/closures.md`).
+//!
+//! Globals rebind across a reload for free (they are late-bound by name at
+//! call time), but a closure VALUE held in the model keeps `Rc`s into the
+//! old module's IR — before this pass, editing a stored behavior did
+//! nothing. The design note's decisions, implemented here:
+//!
+//! - **Rebind, not content-address**: a stored closure adopts the edited
+//!   code, exactly like `tick` does. Its captured environment is carried
+//!   over — new code, old data.
+//! - **Stable ids by name, resolved at the boundary**: a lambda's id is its
+//!   enclosing def's name (`spawn`), with `#k` ordinals for lambdas after
+//!   the first in traversal order (`spawn#1`, …). Runtime closures carry
+//!   only their [`ExprId`]; both id tables are derived HERE, at reload
+//!   time, off the hot path.
+//! - **Fail loud, keep running**: a closure whose id has no match in the
+//!   new module (renamed/deleted def, shifted ordinal), or whose new body
+//!   captures a name the old env cannot supply, keeps its old behavior and
+//!   reports a warning — a reload must never kill the session.
+//!
+//! Captured-env carry-over is BY NAME: binding ids are module-specific, so
+//! the new lambda's free variables (name + new id) are resolved against the
+//! old env innermost-first via the old module's binder-name table, and a
+//! fresh single-scope env is built. Values inside that env are rebound
+//! recursively (closures capturing closures), as are values inside lists,
+//! records, and variants. MLE data is acyclic (immutable values, late-bound
+//! recursion), so the walk terminates.
+//!
+//! A stale closure from TWO reloads ago (kept once with a warning) carries
+//! an id from a module we no longer have; ids are sequential per module, so
+//! lookup could collide. The body `Rc` pointer-identity guard makes that
+//! impossible: a closure only rebinds if its body IS the old module's node
+//! for that id.
+
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use crate::ir::{BindingId, Expr, ExprId, ExprKind, Module, Param, Pattern, PatternKind};
+use crate::value::{Closure, Env, Value};
+
+/// What a reload's rebind pass did — the producer prints this.
+#[derive(Debug, Default)]
+pub struct RebindReport {
+    /// Closures rebound to new code (old env carried over).
+    pub rebound: usize,
+    /// Closures kept on their old code, with why.
+    pub warnings: Vec<String>,
+}
+
+/// One lambda of a module, keyed by stable id.
+struct LambdaInfo {
+    params: Rc<Vec<Param>>,
+    body: Rc<Expr>,
+    expr_id: ExprId,
+    /// Free variables of the body — captured LOCALS only (globals are
+    /// late-bound by name and need no carry-over): `(name, binding)` pairs
+    /// in first-use order.
+    free: Vec<(String, BindingId)>,
+}
+
+/// Both directions of a module's lambda identity, derived on demand.
+struct ModuleIndex {
+    by_stable: HashMap<String, LambdaInfo>,
+    stable_by_expr: HashMap<u32, String>,
+    /// Binder name for every binding id (params, `let`s, pattern vars) —
+    /// the table that makes old envs resolvable by name.
+    binder_names: HashMap<u32, String>,
+}
+
+/// Rebind every closure reachable from `value`: closures created by
+/// `old` whose stable id resolves in `new` get the new code with their
+/// captured env carried over by name. Everything else is preserved.
+pub fn rebind_value(value: &Value, old: &Module, new: &Module) -> (Value, RebindReport) {
+    let old_index = index_module(old);
+    let new_index = index_module(new);
+    let mut report = RebindReport::default();
+    let rebound = walk(value, &old_index, &new_index, &mut report);
+    (rebound, report)
+}
+
+fn walk(value: &Value, old: &ModuleIndex, new: &ModuleIndex, report: &mut RebindReport) -> Value {
+    match value {
+        Value::Number(_)
+        | Value::String(_)
+        | Value::Bool(_)
+        | Value::Ctor { .. }
+        | Value::Builtin(_)
+        | Value::HostFn(_)
+        // Host values are opaque to the language; they cannot hold MLE
+        // closures.
+        | Value::HostData(_) => value.clone(),
+        Value::List(items) => Value::List(Rc::new(
+            items.iter().map(|v| walk(v, old, new, report)).collect(),
+        )),
+        Value::Record(fields) => Value::Record(Rc::new(
+            fields
+                .iter()
+                .map(|(n, v)| (n.clone(), walk(v, old, new, report)))
+                .collect(),
+        )),
+        Value::Variant { ctor, args } => Value::Variant {
+            ctor: ctor.clone(),
+            args: Rc::new(args.iter().map(|v| walk(v, old, new, report)).collect()),
+        },
+        Value::Closure(closure) => rebind_closure(closure, old, new, report),
+    }
+}
+
+fn rebind_closure(
+    closure: &Rc<Closure>,
+    old: &ModuleIndex,
+    new: &ModuleIndex,
+    report: &mut RebindReport,
+) -> Value {
+    let keep = |report: &mut RebindReport, why: String| {
+        report.warnings.push(why);
+        Value::Closure(closure.clone())
+    };
+    // Identify the closure against the OLD module. The pointer guard makes a
+    // stale id (a closure kept across an earlier reload) unidentifiable
+    // rather than wrongly identified.
+    let stable = old.stable_by_expr.get(&closure.expr_id.raw()).filter(|id| {
+        old.by_stable
+            .get(id.as_str())
+            .is_some_and(|info| Rc::ptr_eq(&info.body, &closure.body))
+    });
+    let Some(stable) = stable else {
+        return keep(
+            report,
+            "a stored closure predates the previous reload; keeping its old body".to_string(),
+        );
+    };
+    let Some(info) = new.by_stable.get(stable) else {
+        return keep(
+            report,
+            format!(
+                "stored closure `{stable}` has no match after the edit \
+(renamed, deleted, or moved); keeping its old body"
+            ),
+        );
+    };
+    // Carry the captured env over BY NAME: resolve each free variable of the
+    // NEW body against the OLD env (innermost-first), rebinding the carried
+    // values themselves recursively.
+    let mut vars = Vec::with_capacity(info.free.len());
+    for (name, new_binding) in &info.free {
+        let is_name = |b: BindingId| old.binder_names.get(&b.0) == Some(name);
+        let Some(value) = closure.env.find_by(is_name) else {
+            return keep(
+                report,
+                format!(
+                    "stored closure `{stable}` now captures `{name}`, which its saved \
+environment does not have; keeping its old body"
+                ),
+            );
+        };
+        let value = walk(&value.clone(), old, new, report);
+        vars.push((*new_binding, value));
+    }
+    report.rebound += 1;
+    Value::Closure(Rc::new(Closure {
+        params: info.params.clone(),
+        body: info.body.clone(),
+        env: Env::empty().child(vars),
+        expr_id: info.expr_id,
+    }))
+}
+
+/// Derive a module's lambda-identity index (both directions) plus its
+/// binder-name table. Runs only at the reload boundary.
+fn index_module(module: &Module) -> ModuleIndex {
+    let mut index = ModuleIndex {
+        by_stable: HashMap::new(),
+        stable_by_expr: HashMap::new(),
+        binder_names: HashMap::new(),
+    };
+    for def in &module.defs {
+        let mut ordinal = 0usize;
+        collect(&def.value, &def.name, &mut ordinal, &mut index);
+    }
+    index
+}
+
+/// Walk one def's expression tree: record every binder's name, and register
+/// each lambda under `def` / `def#k` (traversal order).
+fn collect(expr: &Expr, def: &str, ordinal: &mut usize, index: &mut ModuleIndex) {
+    if let ExprKind::Lambda { params, body, .. } = &expr.kind {
+        let stable = if *ordinal == 0 {
+            def.to_string()
+        } else {
+            format!("{def}#{ordinal}")
+        };
+        *ordinal += 1;
+        for param in params.iter() {
+            index
+                .binder_names
+                .insert(param.binding.0, param.name.clone());
+        }
+        let mut free = Vec::new();
+        let mut bound: Vec<BindingId> = params.iter().map(|p| p.binding).collect();
+        free_vars(body, &mut bound, &mut free);
+        index.stable_by_expr.insert(expr.id.0, stable.clone());
+        index.by_stable.insert(
+            stable,
+            LambdaInfo {
+                params: params.clone(),
+                body: body.clone(),
+                expr_id: expr.id,
+                free,
+            },
+        );
+    }
+    each_child(expr, &mut |child| collect(child, def, ordinal, index));
+    // Binders outside lambdas (top-level initializers' `let`s) still need
+    // names for the table; pattern/let binders are recorded in free_vars for
+    // lambda bodies, so cover the rest here.
+    record_binders(expr, index);
+}
+
+fn record_binders(expr: &Expr, index: &mut ModuleIndex) {
+    match &expr.kind {
+        ExprKind::Let { binding, name, .. } => {
+            index.binder_names.insert(binding.0, name.clone());
+        }
+        ExprKind::Match { arms, .. } => {
+            for arm in arms {
+                pattern_binders(&arm.pattern, &mut |binding, name| {
+                    index.binder_names.insert(binding.0, name.to_string());
+                });
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Free variables of `body`: `Local` references whose binding is not in
+/// `bound` (params of the lambda itself plus binders introduced inside).
+/// `LocalMut` cannot cross a lambda boundary (lowering rejects the capture),
+/// so only `Local` matters. First-use order, deduplicated.
+fn free_vars(expr: &Expr, bound: &mut Vec<BindingId>, free: &mut Vec<(String, BindingId)>) {
+    match &expr.kind {
+        ExprKind::Local { binding, name } => {
+            if !bound.contains(binding) && !free.iter().any(|(_, b)| b == binding) {
+                free.push((name.clone(), *binding));
+            }
+        }
+        ExprKind::Let {
+            binding,
+            value,
+            body,
+            ..
+        } => {
+            free_vars(value, bound, free);
+            bound.push(*binding);
+            free_vars(body, bound, free);
+            bound.pop();
+        }
+        ExprKind::Match { scrutinee, arms } => {
+            free_vars(scrutinee, bound, free);
+            for arm in arms {
+                let before = bound.len();
+                pattern_binders(&arm.pattern, &mut |binding, _| bound.push(binding));
+                free_vars(&arm.body, bound, free);
+                bound.truncate(before);
+            }
+        }
+        // A nested lambda's own params bind inside it; its OTHER free vars
+        // are (transitively) free here too.
+        ExprKind::Lambda { params, body, .. } => {
+            let before = bound.len();
+            bound.extend(params.iter().map(|p| p.binding));
+            free_vars(body, bound, free);
+            bound.truncate(before);
+        }
+        _ => each_child(expr, &mut |child| free_vars(child, bound, free)),
+    }
+}
+
+fn pattern_binders(pattern: &Pattern, f: &mut impl FnMut(BindingId, &str)) {
+    match &pattern.kind {
+        PatternKind::Var { binding, name } => f(*binding, name),
+        PatternKind::Ctor { args, .. } => {
+            for arg in args {
+                pattern_binders(arg, f);
+            }
+        }
+        PatternKind::Wildcard
+        | PatternKind::Number(_)
+        | PatternKind::Bool(_)
+        | PatternKind::String(_) => {}
+    }
+}
+
+/// Apply `f` to every direct child expression of `expr`.
+fn each_child(expr: &Expr, f: &mut impl FnMut(&Expr)) {
+    match &expr.kind {
+        ExprKind::Number(_)
+        | ExprKind::String(_)
+        | ExprKind::Bool(_)
+        | ExprKind::Local { .. }
+        | ExprKind::LocalMut { .. }
+        | ExprKind::Global(_)
+        | ExprKind::External(_)
+        | ExprKind::Ctor { .. } => {}
+        ExprKind::Record(fields) => {
+            for field in fields {
+                f(&field.value);
+            }
+        }
+        ExprKind::RecordUpdate { base, fields } => {
+            f(base);
+            for field in fields {
+                f(&field.value);
+            }
+        }
+        ExprKind::List(items) => {
+            for item in items {
+                f(item);
+            }
+        }
+        ExprKind::Let { value, body, .. } => {
+            f(value);
+            f(body);
+        }
+        ExprKind::Assign { value, rest, .. } => {
+            f(value);
+            f(rest);
+        }
+        ExprKind::FieldAccess { object, .. } => f(object),
+        ExprKind::Lambda { body, .. } => f(body),
+        ExprKind::Call { callee, args } => {
+            f(callee);
+            for arg in args {
+                f(arg);
+            }
+        }
+        ExprKind::Binary { lhs, rhs, .. } => {
+            f(lhs);
+            f(rhs);
+        }
+        ExprKind::Neg(inner) => f(inner),
+        ExprKind::Match { scrutinee, arms } => {
+            f(scrutinee);
+            for arm in arms {
+                f(&arm.body);
+            }
+        }
+    }
+}

--- a/mle/src/rebind.rs
+++ b/mle/src/rebind.rs
@@ -9,28 +9,36 @@
 //! - **Rebind, not content-address**: a stored closure adopts the edited
 //!   code, exactly like `tick` does. Its captured environment is carried
 //!   over — new code, old data.
-//! - **Stable ids by name, resolved at the boundary**: a lambda's id is its
-//!   enclosing def's name (`spawn`), with `#k` ordinals for lambdas after
-//!   the first in traversal order (`spawn#1`, …). Runtime closures carry
-//!   only their [`ExprId`]; both id tables are derived HERE, at reload
-//!   time, off the hot path.
+//! - **Stable ids by name/path, never by bare index** (the note's explicit
+//!   warning): a lambda's id is its enclosing def's name plus a path of
+//!   NAMED segments where the source provides names — record fields
+//!   (`make/fn/.mul`), `let` binders (`=f`) — with positional segments
+//!   (`[2]`, `:0`, `|1`) only where nothing is named. Named positions are
+//!   stable under inserting/removing siblings; a lambda that only has a
+//!   positional identity can still drift on such edits — give it a `let`
+//!   name to give it a stable identity.
+//! - **Identity resolved at the boundary**: runtime closures carry only
+//!   their [`ExprId`]; both id tables are derived HERE, at reload time,
+//!   off the hot path.
 //! - **Fail loud, keep running**: a closure whose id has no match in the
-//!   new module (renamed/deleted def, shifted ordinal), or whose new body
-//!   captures a name the old env cannot supply, keeps its old behavior and
-//!   reports a warning — a reload must never kill the session.
+//!   new module, whose new body captures a name the old one didn't, or
+//!   whose capture is now made by a different KIND of binder (a parameter
+//!   vs a `let` vs a pattern variable) keeps its old behavior and reports
+//!   a warning — a reload must never kill the session.
 //!
-//! Captured-env carry-over is BY NAME: binding ids are module-specific, so
-//! the new lambda's free variables (name + new id) are resolved against the
-//! old env innermost-first via the old module's binder-name table, and a
-//! fresh single-scope env is built. Values inside that env are rebound
-//! recursively (closures capturing closures), as are values inside lists,
-//! records, and variants. MLE data is acyclic (immutable values, late-bound
-//! recursion), so the walk terminates.
+//! Captured-env carry-over resolves each free variable of the NEW body
+//! against the OLD lambda's own free list (name → the exact old
+//! `BindingId` the old code referred to → its value in the saved env) —
+//! never by scanning the env chain, so a stale shadowed binding of the
+//! same name can't be picked up. Carried values rebind recursively
+//! (closures capturing closures), as do values inside lists, records, and
+//! variants. MLE data is acyclic (immutable values, late-bound recursion),
+//! so the walk terminates.
 //!
 //! A stale closure from TWO reloads ago (kept once with a warning) carries
-//! an id from a module we no longer have; ids are sequential per module, so
-//! lookup could collide. The body `Rc` pointer-identity guard makes that
-//! impossible: a closure only rebinds if its body IS the old module's node
+//! an id from a module we no longer have; ids could collide, so the body
+//! `Rc` pointer-identity guard makes it unidentifiable rather than wrongly
+//! identified: a closure only rebinds if its body IS the old module's node
 //! for that id.
 
 use std::collections::HashMap;
@@ -48,6 +56,26 @@ pub struct RebindReport {
     pub warnings: Vec<String>,
 }
 
+/// What kind of binder introduced a binding — carried captures must agree
+/// (a `k` that was a parameter and is now a `let` is a semantic change the
+/// old saved value can't stand in for; see the module doc).
+#[derive(Clone, Copy, PartialEq, Debug)]
+enum BinderKind {
+    Param,
+    Let,
+    PatternVar,
+}
+
+impl BinderKind {
+    fn describe(self) -> &'static str {
+        match self {
+            BinderKind::Param => "a parameter",
+            BinderKind::Let => "a `let`",
+            BinderKind::PatternVar => "a pattern variable",
+        }
+    }
+}
+
 /// One lambda of a module, keyed by stable id.
 struct LambdaInfo {
     params: Rc<Vec<Param>>,
@@ -55,7 +83,8 @@ struct LambdaInfo {
     expr_id: ExprId,
     /// Free variables of the body — captured LOCALS only (globals are
     /// late-bound by name and need no carry-over): `(name, binding)` pairs
-    /// in first-use order.
+    /// in first-use order. Names are unique within one lambda (lexical
+    /// scoping: every free use of a name sees the same binding).
     free: Vec<(String, BindingId)>,
 }
 
@@ -63,14 +92,12 @@ struct LambdaInfo {
 struct ModuleIndex {
     by_stable: HashMap<String, LambdaInfo>,
     stable_by_expr: HashMap<u32, String>,
-    /// Binder name for every binding id (params, `let`s, pattern vars) —
-    /// the table that makes old envs resolvable by name.
-    binder_names: HashMap<u32, String>,
+    binder_kinds: HashMap<u32, BinderKind>,
 }
 
 /// Rebind every closure reachable from `value`: closures created by
 /// `old` whose stable id resolves in `new` get the new code with their
-/// captured env carried over by name. Everything else is preserved.
+/// captured env carried over. Everything else is preserved.
 pub fn rebind_value(value: &Value, old: &Module, new: &Module) -> (Value, RebindReport) {
     let old_index = index_module(old);
     let new_index = index_module(new);
@@ -113,6 +140,10 @@ fn rebind_closure(
     new: &ModuleIndex,
     report: &mut RebindReport,
 ) -> Value {
+    // A kept closure is kept ATOMICALLY: its captured env is not walked, so
+    // closures inside it stay on their old bodies too — the old body refers
+    // to old binding ids, and mixing rebuilt inner values into it would be
+    // incoherent. The warning names the outermost closure.
     let keep = |report: &mut RebindReport, why: String| {
         report.warnings.push(why);
         Value::Closure(closure.clone())
@@ -120,12 +151,12 @@ fn rebind_closure(
     // Identify the closure against the OLD module. The pointer guard makes a
     // stale id (a closure kept across an earlier reload) unidentifiable
     // rather than wrongly identified.
-    let stable = old.stable_by_expr.get(&closure.expr_id.raw()).filter(|id| {
-        old.by_stable
-            .get(id.as_str())
-            .is_some_and(|info| Rc::ptr_eq(&info.body, &closure.body))
-    });
-    let Some(stable) = stable else {
+    let old_info = old
+        .stable_by_expr
+        .get(&closure.expr_id.raw())
+        .and_then(|id| old.by_stable.get(id.as_str()).map(|info| (id, info)))
+        .filter(|(_, info)| Rc::ptr_eq(&info.body, &closure.body));
+    let Some((stable, old_info)) = old_info else {
         return keep(
             report,
             "a stored closure predates the previous reload; keeping its old body".to_string(),
@@ -140,22 +171,59 @@ fn rebind_closure(
             ),
         );
     };
-    // Carry the captured env over BY NAME: resolve each free variable of the
-    // NEW body against the OLD env (innermost-first), rebinding the carried
-    // values themselves recursively.
+    // An arity change would rebind cleanly and then fail at every call
+    // site, one frame later and with a worse message — report it HERE.
+    if info.params.len() != closure.params.len() {
+        return keep(
+            report,
+            format!(
+                "stored closure `{stable}` changed arity ({} -> {} parameters); \
+keeping its old body",
+                closure.params.len(),
+                info.params.len()
+            ),
+        );
+    }
+    // Carry the captured env over: each free variable of the NEW body must
+    // be a capture the OLD body also made (same name, same kind of binder) —
+    // then the value comes from the exact binding the old code referred to.
     let mut vars = Vec::with_capacity(info.free.len());
     for (name, new_binding) in &info.free {
-        let is_name = |b: BindingId| old.binder_names.get(&b.0) == Some(name);
-        let Some(value) = closure.env.find_by(is_name) else {
+        let Some((_, old_binding)) = old_info.free.iter().find(|(n, _)| n == name) else {
             return keep(
                 report,
                 format!(
-                    "stored closure `{stable}` now captures `{name}`, which its saved \
-environment does not have; keeping its old body"
+                    "stored closure `{stable}` now captures `{name}`, which it did not \
+capture before; keeping its old body"
                 ),
             );
         };
-        let value = walk(&value.clone(), old, new, report);
+        let (old_kind, new_kind) = (
+            old.binder_kinds.get(&old_binding.0).copied(),
+            new.binder_kinds.get(&new_binding.0).copied(),
+        );
+        if old_kind != new_kind {
+            let describe = |k: Option<BinderKind>| k.map_or("unknown", BinderKind::describe);
+            return keep(
+                report,
+                format!(
+                    "stored closure `{stable}` captures `{name}` differently after the \
+edit ({} before, {} now); keeping its old body",
+                    describe(old_kind),
+                    describe(new_kind)
+                ),
+            );
+        }
+        let Some(value) = closure.env.lookup(*old_binding) else {
+            return keep(
+                report,
+                format!(
+                    "stored closure `{stable}`: its saved environment is missing \
+`{name}`; keeping its old body"
+                ),
+            );
+        };
+        let value = walk(&value, old, new, report);
         vars.push((*new_binding, value));
     }
     report.rebound += 1;
@@ -168,76 +236,130 @@ environment does not have; keeping its old body"
 }
 
 /// Derive a module's lambda-identity index (both directions) plus its
-/// binder-name table. Runs only at the reload boundary.
+/// binder-kind table. Runs only at the reload boundary.
 fn index_module(module: &Module) -> ModuleIndex {
     let mut index = ModuleIndex {
         by_stable: HashMap::new(),
         stable_by_expr: HashMap::new(),
-        binder_names: HashMap::new(),
+        binder_kinds: HashMap::new(),
     };
     for def in &module.defs {
-        let mut ordinal = 0usize;
-        collect(&def.value, &def.name, &mut ordinal, &mut index);
+        let mut path: Vec<String> = Vec::new();
+        collect(&def.value, &def.name, &mut path, &mut index);
     }
     index
 }
 
-/// Walk one def's expression tree: record every binder's name, and register
-/// each lambda under `def` / `def#k` (traversal order).
-fn collect(expr: &Expr, def: &str, ordinal: &mut usize, index: &mut ModuleIndex) {
-    if let ExprKind::Lambda { params, body, .. } = &expr.kind {
-        let stable = if *ordinal == 0 {
-            def.to_string()
-        } else {
-            format!("{def}#{ordinal}")
-        };
-        *ordinal += 1;
-        for param in params.iter() {
-            index
-                .binder_names
-                .insert(param.binding.0, param.name.clone());
-        }
-        let mut free = Vec::new();
-        let mut bound: Vec<BindingId> = params.iter().map(|p| p.binding).collect();
-        free_vars(body, &mut bound, &mut free);
-        index.stable_by_expr.insert(expr.id.0, stable.clone());
-        index.by_stable.insert(
-            stable,
-            LambdaInfo {
-                params: params.clone(),
-                body: body.clone(),
-                expr_id: expr.id,
-                free,
-            },
-        );
-    }
-    each_child(expr, &mut |child| collect(child, def, ordinal, index));
-    // Binders outside lambdas (top-level initializers' `let`s) still need
-    // names for the table; pattern/let binders are recorded in free_vars for
-    // lambda bodies, so cover the rest here.
-    record_binders(expr, index);
-}
-
-fn record_binders(expr: &Expr, index: &mut ModuleIndex) {
+/// Walk one def's expression tree building path-based ids (see the module
+/// doc) and the binder-kind table. Every multi-child edge contributes a
+/// segment — named where the source names it — so ids are unique; a def's
+/// root lambda gets the bare def name.
+fn collect(expr: &Expr, def: &str, path: &mut Vec<String>, index: &mut ModuleIndex) {
+    let seg = |expr: &Expr, segment: String, path: &mut Vec<String>, index: &mut ModuleIndex| {
+        path.push(segment);
+        collect(expr, def, path, index);
+        path.pop();
+    };
     match &expr.kind {
-        ExprKind::Let { binding, name, .. } => {
-            index.binder_names.insert(binding.0, name.clone());
+        ExprKind::Lambda { params, body, .. } => {
+            let stable = if path.is_empty() {
+                def.to_string()
+            } else {
+                format!("{def}/{}", path.join("/"))
+            };
+            for param in params.iter() {
+                index
+                    .binder_kinds
+                    .insert(param.binding.0, BinderKind::Param);
+            }
+            let mut free = Vec::new();
+            let mut bound: Vec<BindingId> = params.iter().map(|p| p.binding).collect();
+            free_vars(body, &mut bound, &mut free);
+            index.stable_by_expr.insert(expr.id.raw(), stable.clone());
+            index.by_stable.insert(
+                stable,
+                LambdaInfo {
+                    params: params.clone(),
+                    body: body.clone(),
+                    expr_id: expr.id,
+                    free,
+                },
+            );
+            seg(body, "fn".to_string(), path, index);
         }
-        ExprKind::Match { arms, .. } => {
-            for arm in arms {
-                pattern_binders(&arm.pattern, &mut |binding, name| {
-                    index.binder_names.insert(binding.0, name.to_string());
-                });
+        ExprKind::Let {
+            binding,
+            name,
+            value,
+            body,
+            ..
+        } => {
+            index.binder_kinds.insert(binding.0, BinderKind::Let);
+            seg(value, format!("={name}"), path, index);
+            // The body is the continuation — transparent, so wrapping code
+            // in a new `let` does not shift ids further down the spine.
+            collect(body, def, path, index);
+        }
+        ExprKind::Assign {
+            name, value, rest, ..
+        } => {
+            seg(value, format!(":={name}"), path, index);
+            collect(rest, def, path, index);
+        }
+        ExprKind::Record(fields) => {
+            for field in fields {
+                seg(&field.value, format!(".{}", field.name), path, index);
             }
         }
-        _ => {}
+        ExprKind::RecordUpdate { base, fields } => {
+            seg(base, "base".to_string(), path, index);
+            for field in fields {
+                seg(&field.value, format!(".{}", field.name), path, index);
+            }
+        }
+        ExprKind::List(items) => {
+            for (i, item) in items.iter().enumerate() {
+                seg(item, format!("[{i}]"), path, index);
+            }
+        }
+        ExprKind::Call { callee, args } => {
+            seg(callee, "callee".to_string(), path, index);
+            for (i, arg) in args.iter().enumerate() {
+                seg(arg, format!(":{i}"), path, index);
+            }
+        }
+        ExprKind::Binary { lhs, rhs, .. } => {
+            seg(lhs, "lhs".to_string(), path, index);
+            seg(rhs, "rhs".to_string(), path, index);
+        }
+        ExprKind::Match { scrutinee, arms } => {
+            seg(scrutinee, "match".to_string(), path, index);
+            for (i, arm) in arms.iter().enumerate() {
+                pattern_binders(&arm.pattern, &mut |binding, _| {
+                    index.binder_kinds.insert(binding.0, BinderKind::PatternVar);
+                });
+                seg(&arm.body, format!("|{i}"), path, index);
+            }
+        }
+        // Single-child edges are transparent: uniqueness is preserved, and
+        // e.g. negating or field-accessing around a lambda keeps its id.
+        ExprKind::Neg(inner) => collect(inner, def, path, index),
+        ExprKind::FieldAccess { object, .. } => collect(object, def, path, index),
+        ExprKind::Number(_)
+        | ExprKind::String(_)
+        | ExprKind::Bool(_)
+        | ExprKind::Local { .. }
+        | ExprKind::LocalMut { .. }
+        | ExprKind::Global(_)
+        | ExprKind::External(_)
+        | ExprKind::Ctor { .. } => {}
     }
 }
 
 /// Free variables of `body`: `Local` references whose binding is not in
 /// `bound` (params of the lambda itself plus binders introduced inside).
 /// `LocalMut` cannot cross a lambda boundary (lowering rejects the capture),
-/// so only `Local` matters. First-use order, deduplicated.
+/// so only `Local` matters. First-use order, deduplicated by binding.
 fn free_vars(expr: &Expr, bound: &mut Vec<BindingId>, free: &mut Vec<(String, BindingId)>) {
     match &expr.kind {
         ExprKind::Local { binding, name } => {
@@ -251,6 +373,7 @@ fn free_vars(expr: &Expr, bound: &mut Vec<BindingId>, free: &mut Vec<(String, Bi
             body,
             ..
         } => {
+            // MLE `let` is non-recursive: the value cannot see the binding.
             free_vars(value, bound, free);
             bound.push(*binding);
             free_vars(body, bound, free);

--- a/mle/src/value.rs
+++ b/mle/src/value.rs
@@ -60,6 +60,12 @@ pub struct Closure {
     pub params: Rc<Vec<Param>>,
     pub body: Rc<Expr>,
     pub env: Env,
+    /// The lambda's node id in the module that created it — the hook
+    /// hot-reload rebinding resolves to a *stable* id at the reload boundary
+    /// (see [`crate::rebind`]; runtime closures stay lean, Decision 3 of the
+    /// closures design note). Guarded by body pointer identity there, so a
+    /// stale id from an older module can never mis-rebind.
+    pub expr_id: crate::ir::ExprId,
 }
 
 /// Lexical environment: one scope per enclosing lambda call, as a persistent
@@ -89,6 +95,20 @@ impl Env {
         while let Some(scope) = &cur.0 {
             if let Some((_, value)) = scope.vars.iter().find(|(b, _)| *b == binding) {
                 return Some(value.clone());
+            }
+            cur = &scope.parent;
+        }
+        None
+    }
+
+    /// Innermost-first search by predicate over binding ids — the reload
+    /// rebinder resolves captured names against an old env this way (ids are
+    /// module-specific, names are the stable key; see [`crate::rebind`]).
+    pub(crate) fn find_by(&self, pred: impl Fn(BindingId) -> bool) -> Option<&Value> {
+        let mut cur = self;
+        while let Some(scope) = &cur.0 {
+            if let Some((_, value)) = scope.vars.iter().rev().find(|(b, _)| pred(*b)) {
+                return Some(value);
             }
             cur = &scope.parent;
         }

--- a/mle/src/value.rs
+++ b/mle/src/value.rs
@@ -100,20 +100,6 @@ impl Env {
         }
         None
     }
-
-    /// Innermost-first search by predicate over binding ids — the reload
-    /// rebinder resolves captured names against an old env this way (ids are
-    /// module-specific, names are the stable key; see [`crate::rebind`]).
-    pub(crate) fn find_by(&self, pred: impl Fn(BindingId) -> bool) -> Option<&Value> {
-        let mut cur = self;
-        while let Some(scope) = &cur.0 {
-            if let Some((_, value)) = scope.vars.iter().rev().find(|(b, _)| pred(*b)) {
-                return Some(value);
-            }
-            cur = &scope.parent;
-        }
-        None
-    }
 }
 
 impl fmt::Display for Value {

--- a/mle/tests/rebind.rs
+++ b/mle/tests/rebind.rs
@@ -1,0 +1,195 @@
+//! B5 part 2 — closures stored in the model rebind across a hot reload:
+//! new code, old captured env (docs/mle.md; the `rebind` module docs cover
+//! the design). These tests simulate the reload seam exactly as the
+//! producer drives it: run module A to get a model holding closures, lower
+//! the edited module B, `rebind_value`, then call the stored closure
+//! through B's session.
+
+use mle::ir::Module;
+use mle::{rebind_value, NoHost, RunOutcome, Session, Tracing, Value};
+
+fn module(src: &str) -> Module {
+    mle::lower(mle::parse(src).expect("parse")).expect("lower")
+}
+
+/// `main()`'s value under `NoHost`.
+fn main_value(module: &Module) -> Value {
+    let record = match mle::run(module, Tracing::Off) {
+        Ok(record) => record,
+        Err(failure) => panic!("run failed: {}", failure.error.message),
+    };
+    match record.outcome {
+        RunOutcome::Main(value) => value,
+        _ => panic!("expected a main result"),
+    }
+}
+
+/// Call `apply(f, n)` in `module`'s session — how a reloaded program invokes
+/// a stored closure.
+fn apply(module: &Module, f: Value, n: f64) -> Value {
+    let session = match Session::load(module, &mut NoHost) {
+        Ok(session) => session,
+        Err(failure) => panic!("load failed: {}", failure.error.message),
+    };
+    match session.call("apply", vec![f, Value::Number(n)], &mut NoHost) {
+        Ok(value) => value,
+        Err(err) => panic!("apply failed: {}", err.message),
+    }
+}
+
+fn num(value: &Value) -> f64 {
+    match value {
+        Value::Number(n) => *n,
+        other => panic!("expected a number, got {other}"),
+    }
+}
+
+const APPLY: &str = "let apply = (f, n) => f(n)\n";
+
+/// The core payoff: the stored closure runs the EDITED body with the
+/// captured env carried over — new code, old data.
+#[test]
+fn stored_closure_adopts_edited_body_and_keeps_env() {
+    let a = module(&format!(
+        "{APPLY}let mul = (k) => (x) => x * k\nlet main = () => mul(3.0)"
+    ));
+    let b = module(&format!(
+        "{APPLY}let mul = (k) => (x) => x * k + 100.0\nlet main = () => mul(3.0)"
+    ));
+    let stored = main_value(&a);
+    // Sanity: pre-reload behavior.
+    assert_eq!(num(&apply(&a, stored.clone(), 2.0)), 6.0);
+    let (rebound, report) = rebind_value(&stored, &a, &b);
+    assert_eq!(report.rebound, 1, "warnings: {:?}", report.warnings);
+    // 2 * 3 + 100 — the new body, with the OLD captured k = 3.
+    assert_eq!(num(&apply(&b, rebound, 2.0)), 106.0);
+}
+
+/// Closures inside lists, records, and variants are all reached.
+#[test]
+fn closures_rebind_inside_containers() {
+    let src = |body: &str| {
+        format!(
+            "{APPLY}type Slot = | Held(f: Float)\n\
+             let mul = (k) => (x) => {body}\n\
+             let main = () => {{ fns: [mul(2.0)], slot: Held(mul(10.0)) }}"
+        )
+    };
+    let a = module(&src("x * k"));
+    let b = module(&src("x * k + 1.0"));
+    let stored = main_value(&a);
+    let (rebound, report) = rebind_value(&stored, &a, &b);
+    assert_eq!(report.rebound, 2, "warnings: {:?}", report.warnings);
+    let Value::Record(fields) = &rebound else {
+        panic!("expected the model record")
+    };
+    let Value::List(fns) = &fields[0].1 else {
+        panic!("expected fns list")
+    };
+    assert_eq!(num(&apply(&b, fns[0].clone(), 5.0)), 11.0);
+    let Value::Variant { args, .. } = &fields[1].1 else {
+        panic!("expected the Held variant")
+    };
+    assert_eq!(num(&apply(&b, args[0].clone(), 5.0)), 51.0);
+}
+
+/// A captured closure (a closure in another's env) is rebound too.
+#[test]
+fn captured_closures_rebind_recursively() {
+    let src = |body: &str| {
+        format!(
+            "{APPLY}let add = (a) => (x) => {body}\n\
+             let wrap = (f) => (x) => f(x) * 2.0\n\
+             let main = () => wrap(add(10.0))"
+        )
+    };
+    let a = module(&src("x + a"));
+    let b = module(&src("x + a + 0.5"));
+    let stored = main_value(&a);
+    let (rebound, report) = rebind_value(&stored, &a, &b);
+    // wrap#1 and the captured add#1 both rebind.
+    assert_eq!(report.rebound, 2, "warnings: {:?}", report.warnings);
+    // (5 + 10 + 0.5) * 2
+    assert_eq!(num(&apply(&b, rebound, 5.0)), 31.0);
+}
+
+/// A deleted/renamed def leaves the stored closure on its OLD body, loudly.
+#[test]
+fn deleted_def_keeps_old_body_with_warning() {
+    let a = module(&format!(
+        "{APPLY}let mul = (k) => (x) => x * k\nlet main = () => mul(3.0)"
+    ));
+    let b = module(&format!("{APPLY}let other = (x) => x\nlet main = () => 0.0"));
+    let stored = main_value(&a);
+    let (rebound, report) = rebind_value(&stored, &a, &b);
+    assert_eq!(report.rebound, 0);
+    assert_eq!(report.warnings.len(), 1);
+    assert!(
+        report.warnings[0].contains("`mul#1` has no match after the edit"),
+        "unexpected warning: {}",
+        report.warnings[0]
+    );
+    // Old behavior still runs (its body Rcs keep the old IR alive).
+    assert_eq!(num(&apply(&b, rebound, 2.0)), 6.0);
+}
+
+/// An edit that makes the closure capture a name its saved env lacks keeps
+/// the old body, loudly.
+#[test]
+fn unresolvable_new_capture_keeps_old_body_with_warning() {
+    let a = module(&format!(
+        "{APPLY}let mul = (k) => (x) => x * k\nlet main = () => mul(3.0)"
+    ));
+    let b = module(&format!(
+        "{APPLY}let mul = (k) => let j = k + 1.0 in (x) => x * j\nlet main = () => mul(3.0)"
+    ));
+    let stored = main_value(&a);
+    let (rebound, report) = rebind_value(&stored, &a, &b);
+    assert_eq!(report.rebound, 0);
+    assert!(
+        report.warnings[0].contains("now captures `j`"),
+        "unexpected warning: {}",
+        report.warnings[0]
+    );
+    assert_eq!(num(&apply(&b, rebound, 2.0)), 6.0);
+}
+
+/// The pointer-identity guard: a closure kept (with a warning) across reload
+/// A→B carries an id from A. Rebinding B→C must refuse to identify it —
+/// never mis-rebind it to whatever C happens to have at that id.
+#[test]
+fn stale_closures_from_two_reloads_ago_never_misrebind() {
+    let a = module(&format!(
+        "{APPLY}let mul = (k) => (x) => x * k\nlet main = () => mul(3.0)"
+    ));
+    // B deletes `mul` — the stored closure survives with a warning.
+    let b = module(&format!("{APPLY}let main = () => 0.0"));
+    // C reintroduces defs whose ids could collide with A's id space.
+    let c = module(&format!(
+        "{APPLY}let decoy = (q) => (x) => x * 1000.0\nlet main = () => 0.0"
+    ));
+    let stored = main_value(&a);
+    let (kept, report_ab) = rebind_value(&stored, &a, &b);
+    assert_eq!(report_ab.rebound, 0);
+    let (still, report_bc) = rebind_value(&kept, &b, &c);
+    assert_eq!(report_bc.rebound, 0);
+    assert!(
+        report_bc.warnings[0].contains("predates the previous reload"),
+        "unexpected warning: {}",
+        report_bc.warnings[0]
+    );
+    // Still the ORIGINAL behavior — not the decoy's.
+    assert_eq!(num(&apply(&c, still, 2.0)), 6.0);
+}
+
+/// Plain data passes through untouched (and cheaply — shared, not copied).
+#[test]
+fn plain_data_is_preserved() {
+    let a = module("let main = () => { n: 1.5, s: \"hi\", l: [true, false] }");
+    let b = module("let main = () => 0.0");
+    let stored = main_value(&a);
+    let (rebound, report) = rebind_value(&stored, &a, &b);
+    assert_eq!(report.rebound, 0);
+    assert!(report.warnings.is_empty());
+    assert_eq!(rebound.to_string(), stored.to_string());
+}

--- a/mle/tests/rebind.rs
+++ b/mle/tests/rebind.rs
@@ -107,7 +107,7 @@ fn captured_closures_rebind_recursively() {
     let b = module(&src("x + a + 0.5"));
     let stored = main_value(&a);
     let (rebound, report) = rebind_value(&stored, &a, &b);
-    // wrap#1 and the captured add#1 both rebind.
+    // wrap/fn and the captured add/fn both rebind.
     assert_eq!(report.rebound, 2, "warnings: {:?}", report.warnings);
     // (5 + 10 + 0.5) * 2
     assert_eq!(num(&apply(&b, rebound, 5.0)), 31.0);
@@ -119,13 +119,15 @@ fn deleted_def_keeps_old_body_with_warning() {
     let a = module(&format!(
         "{APPLY}let mul = (k) => (x) => x * k\nlet main = () => mul(3.0)"
     ));
-    let b = module(&format!("{APPLY}let other = (x) => x\nlet main = () => 0.0"));
+    let b = module(&format!(
+        "{APPLY}let other = (x) => x\nlet main = () => 0.0"
+    ));
     let stored = main_value(&a);
     let (rebound, report) = rebind_value(&stored, &a, &b);
     assert_eq!(report.rebound, 0);
     assert_eq!(report.warnings.len(), 1);
     assert!(
-        report.warnings[0].contains("`mul#1` has no match after the edit"),
+        report.warnings[0].contains("`mul/fn` has no match after the edit"),
         "unexpected warning: {}",
         report.warnings[0]
     );
@@ -192,4 +194,112 @@ fn plain_data_is_preserved() {
     assert_eq!(report.rebound, 0);
     assert!(report.warnings.is_empty());
     assert_eq!(rebound.to_string(), stored.to_string());
+}
+
+// --- Review-driven cases (Codex + Claude adversarial probes) ---
+
+/// Path-based ids use NAMED segments: inserting a sibling record field does
+/// not shift the others' identity (the ordinal-drift attack from review —
+/// under `#k` ordinals the stored `mul` would silently have become `add`).
+#[test]
+fn record_field_insertion_does_not_shift_identity() {
+    let a = module(&format!(
+        "{APPLY}let make = (k) => {{ add: (x) => x + k, mul: (x) => x * k }}\n\
+         let main = () => let m = make(3.0) in m.mul"
+    ));
+    let b = module(&format!(
+        "{APPLY}let make = (k) => {{ sub: (x) => x - k, add: (x) => x + k, mul: (x) => x * k + 1.0 }}\n\
+         let main = () => let m = make(3.0) in m.mul"
+    ));
+    let stored = main_value(&a);
+    let (rebound, report) = rebind_value(&stored, &a, &b);
+    assert_eq!(report.rebound, 1, "warnings: {:?}", report.warnings);
+    // Still mul (with its edit), never add/sub: 2 * 3 + 1.
+    assert_eq!(num(&apply(&b, rebound, 2.0)), 7.0);
+}
+
+/// A `let` body is a transparent path segment: wrapping the stored lambda's
+/// def in a new helper `let` keeps its identity (Claude's insert probe — the
+/// old code rebound to the helper and returned constant 0).
+#[test]
+fn inserting_a_helper_let_does_not_shift_identity() {
+    let a = module(&format!(
+        "{APPLY}let mk = (k) => (x) => x + k\nlet main = () => mk(10.0)"
+    ));
+    let b = module(&format!(
+        "{APPLY}let mk = (k) => let helper = (h) => 0.0 in (x) => x + k + 1.0\n\
+         let main = () => mk(10.0)"
+    ));
+    let stored = main_value(&a);
+    let (rebound, report) = rebind_value(&stored, &a, &b);
+    assert_eq!(report.rebound, 1, "warnings: {:?}", report.warnings);
+    // The stored closure is still `mk/fn` (not `helper`): 2 + 10 + 1.
+    assert_eq!(num(&apply(&b, rebound, 2.0)), 13.0);
+}
+
+/// An arity change reports at the reload boundary, not one frame later at
+/// every call site (Claude M).
+#[test]
+fn arity_change_keeps_old_body_with_warning() {
+    let a = module(&format!(
+        "{APPLY}let mk = (k) => (x) => x + k\nlet main = () => mk(10.0)"
+    ));
+    let b = module(&format!(
+        "{APPLY}let mk = (k) => (x, y) => x + y + k\nlet main = () => mk(10.0)"
+    ));
+    let stored = main_value(&a);
+    let (rebound, report) = rebind_value(&stored, &a, &b);
+    assert_eq!(report.rebound, 0);
+    assert!(
+        report.warnings[0].contains("changed arity (1 -> 2 parameters)"),
+        "unexpected warning: {}",
+        report.warnings[0]
+    );
+    assert_eq!(num(&apply(&b, rebound, 2.0)), 12.0);
+}
+
+/// A capture whose binder KIND changed (a parameter before, a `let` now)
+/// keeps the old body loudly — the saved value can't stand in for the new
+/// initializer's semantics (Codex M / Claude's shadowing probe: without the
+/// kind check, the old param value silently replaced the new `let`'s).
+#[test]
+fn capture_kind_change_keeps_old_body_with_warning() {
+    let a = module(&format!(
+        "{APPLY}let mk = (k) => (x) => x * k\nlet main = () => mk(3.0)"
+    ));
+    let b = module(&format!(
+        "{APPLY}let mk = (k) => let k = k + 1.0 in (x) => x * k\nlet main = () => mk(3.0)"
+    ));
+    let stored = main_value(&a);
+    let (rebound, report) = rebind_value(&stored, &a, &b);
+    assert_eq!(report.rebound, 0);
+    assert!(
+        report.warnings[0].contains("captures `k` differently after the edit"),
+        "unexpected warning: {}",
+        report.warnings[0]
+    );
+    assert_eq!(num(&apply(&b, rebound, 2.0)), 6.0);
+}
+
+/// The reverse shadowing direction (Claude's probe 3): the old body captured
+/// an inner `let k`, the edit removes it so the new body's `k` is the param.
+/// The kind check refuses to substitute the stale inner value.
+#[test]
+fn removed_shadow_keeps_old_body_with_warning() {
+    let a = module(&format!(
+        "{APPLY}let mk = (k) => let k = k * 10.0 in (x) => x + k\nlet main = () => mk(3.0)"
+    ));
+    let b = module(&format!(
+        "{APPLY}let mk = (k) => (x) => x + k\nlet main = () => mk(3.0)"
+    ));
+    let stored = main_value(&a);
+    let (rebound, report) = rebind_value(&stored, &a, &b);
+    assert_eq!(report.rebound, 0);
+    assert!(
+        report.warnings[0].contains("captures `k` differently after the edit"),
+        "unexpected warning: {}",
+        report.warnings[0]
+    );
+    // Old behavior: x + 30.
+    assert_eq!(num(&apply(&b, rebound, 2.0)), 32.0);
 }

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -42,6 +42,9 @@ pub struct MleGame {
     path: String,
     mtime: std::time::SystemTime,
     src: String,
+    /// The lowered module the current session came from — kept so a reload
+    /// can rebind model-stored closures (old module × new module).
+    module: mle::ir::Module,
     session: Session,
     model: Value,
     has_input: bool,
@@ -77,6 +80,7 @@ const STATS_EVERY: u64 = 300;
 /// A successfully loaded, contract-validated game module.
 struct Loaded {
     src: String,
+    module: mle::ir::Module,
     session: Session,
     init: Value,
     /// The game defines the optional `input` entry point.
@@ -162,6 +166,7 @@ fn load_game(path: &str) -> Result<Loaded, String> {
     }
     Ok(Loaded {
         src,
+        module,
         session,
         init,
         has_input,
@@ -196,6 +201,7 @@ impl MleGame {
             path: path.to_string(),
             mtime,
             src: loaded.src,
+            module: loaded.module,
             session: loaded.session,
             model: loaded.init,
             has_input: loaded.has_input,
@@ -321,11 +327,12 @@ impl Game for MleGame {
         // Poll the file's mtime (a stat per frame is ~free) and swap in a new
         // session on change. THE MODEL IS KEPT: it is a plain value the host
         // holds, so state survives the edit and all functions rebind — the
-        // dev-loop payoff the language was built for (docs/mle.md C3). A
-        // broken edit prints and keeps the old program running. Caveat until
-        // B5: closure VALUES stored inside the model keep their pre-reload
-        // bodies (globals rebind; stored closures need the (stable-id, env)
-        // representation).
+        // dev-loop payoff the language was built for (docs/mle.md C3).
+        // Closures STORED IN THE MODEL rebind too (B5 part 2,
+        // `mle::rebind`): they adopt the edited code with their captured env
+        // carried over; one that can't be matched keeps its old body with a
+        // loud warning. A broken edit prints and keeps the old program
+        // running.
         let mtime = file_mtime(&self.path);
         if mtime == self.mtime {
             return;
@@ -334,7 +341,13 @@ impl Game for MleGame {
         let started = Instant::now();
         match load_game(&self.path) {
             Ok(loaded) => {
+                let (model, report) = mle::rebind_value(&self.model, &self.module, &loaded.module);
+                self.model = model;
+                for warning in &report.warnings {
+                    eprintln!("[mle] reload: {warning}");
+                }
                 self.src = loaded.src;
+                self.module = loaded.module;
                 self.session = loaded.session;
                 self.has_input = loaded.has_input;
                 self.has_mouse_move = loaded.has_mouse_move;
@@ -351,9 +364,14 @@ impl Game for MleGame {
                     physics::remove_world(physics::DEFAULT_WORLD);
                 }
                 self.last_error = None;
+                let stored = if report.rebound > 0 {
+                    format!("; {} stored closure(s) rebound", report.rebound)
+                } else {
+                    String::new()
+                };
                 println!(
-                    "[mle] hot-reloaded {} in {:.2}ms (model preserved; an edited `init` \
-takes effect on restart)",
+                    "[mle] hot-reloaded {} in {:.2}ms (model preserved{stored}; an edited \
+`init` takes effect on restart)",
                     self.path,
                     started.elapsed().as_secs_f64() * 1000.0
                 );

--- a/tools/functor-sdk/test/mle-closure-rebind.e2e.test.ts
+++ b/tools/functor-sdk/test/mle-closure-rebind.e2e.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { findRepoRoot, FunctorRunner, waitFor } from "../src/index.js";
+
+// B5 part 2 end-to-end (docs/mle.md): a closure STORED IN THE MODEL rebinds
+// across a hot reload — it adopts the edited body while keeping its captured
+// environment. The model holds `vel = makeSpin(2.0)` (a closure capturing
+// k = 2); editing makeSpin's inner lambda changes how every already-spawned
+// vel behaves, without resetting anything. Pinned clock ⇒ the assertions are
+// exact arithmetic. Opt-in like the other e2e suites:
+//
+//   npm run test:e2e[:headless]
+const e2eEnabled = process.env.FUNCTOR_E2E === "1";
+const headless = process.env.FUNCTOR_E2E_HEADLESS === "1";
+
+const game = (body: string) => `let makeSpin = (k) => (dt) => ${body}
+let init = { vel: makeSpin(2.0), x: 0.0 }
+let tick = (m, dt, tts) => { m with x: m.x + m.vel(dt) }
+let draw = (m, tts) =>
+  Frame.create(Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0), Scene.cube())
+`;
+
+function xOf(model: string): number {
+  const m = model.match(/x:\s*(-?[\d.]+)/);
+  assert.ok(m, `could not find x in model: ${model}`);
+  return Number(m[1]);
+}
+
+test(
+  "a closure stored in the model adopts an edited body and keeps its captured env",
+  { skip: !e2eEnabled, timeout: 120_000 },
+  async () => {
+    const repoRoot = findRepoRoot(process.cwd());
+    assert.ok(repoRoot, "must run from within the functor workspace");
+
+    const dir = mkdtempSync(join(tmpdir(), "mle-rebind-"));
+    const mlePath = join(dir, "game.mle");
+    writeFileSync(mlePath, game("k * dt"));
+
+    await using runner = await FunctorRunner.launch({
+      gameDir: dir,
+      repoRoot,
+      mlePath,
+      port: Number(process.env.FUNCTOR_E2E_PORT ?? 8100),
+      headless,
+    });
+
+    await runner.pause();
+    const base = xOf((await runner.state()).model);
+    const DT = 0.25;
+    await runner.step(DT);
+    await runner.step(DT);
+    const before = xOf((await runner.state()).model);
+    // The stored closure is makeSpin(2.0): each step adds k*dt = 0.5.
+    assert.ok(
+      Math.abs(before - base - 2 * (2.0 * DT)) < 1e-4,
+      `two steps of k*dt should add 1.0 to ${base}, got ${before}`,
+    );
+
+    // Edit the INNER lambda's body — the code the stored closure points at.
+    writeFileSync(mlePath, game("k * dt * 10.0"));
+    await waitFor(
+      async () => runner.logs(),
+      (lines) => lines.some((l) => l.includes("hot-reloaded")),
+      { timeoutMs: 10_000, description: "hot reload observed in logs" },
+    );
+    // The reload log reports the rebind.
+    const line = runner.logs().find((l) => l.includes("hot-reloaded"));
+    assert.ok(
+      line!.includes("1 stored closure(s) rebound"),
+      `reload should report the rebind: ${line}`,
+    );
+
+    await runner.step(DT);
+    const after = xOf((await runner.state()).model);
+    // THE assertion: new body (k*dt*10) with the OLD captured k = 2 —
+    // and the old x, since the model itself survived too. (The edit must
+    // stay dt-proportional: paused frames still tick with dt = 0, so a
+    // constant term would accumulate while we wait for the reload.)
+    assert.ok(
+      Math.abs(after - (before + 2.0 * DT * 10.0)) < 1e-4,
+      `expected ${before} + ${2.0 * DT * 10.0}, got ${after} ` +
+        `(old-body would give ${before + 2.0 * DT})`,
+    );
+  },
+);


### PR DESCRIPTION
## What

Closures **stored in the model** now rebind across a hot reload: they adopt the edited code with their captured environment carried over — new code, old data. This removes C3's last caveat and completes **B5**; it's also the prerequisite for B6 effects (an in-flight effect's tagger is a closure the host holds across frames — the F# side must *drop* pending effects on reload precisely because those closures dangle).

Design per `closures.md` (the serializable-closures note): **rebind, not content-address** (stored behavior adopts edits, exactly like `tick`); **ids by stable name/path, never index**; **identity resolved at the boundary** — runtime closures carry only their `ExprId`, and both id tables are derived at reload time, off the hot path; **fail loud, keep running** for anything unmatched.

Mechanics (`mle/src/rebind.rs`):
- A lambda's stable id is its def's name plus a path of **named segments** where the source names them — `make/fn/.mul` (record field), `=f` (`let` binder) — with positional segments only where nothing is named. `let` bodies are transparent, so wrapping code in a helper `let` doesn't shift ids.
- Captures carry over through the **old lambda's own free list**: new free var → same name in the old captures → that exact old `BindingId` → `env.lookup`. Binder kinds must match (param vs `let` vs pattern var). Carried values rebind recursively (closures capturing closures, containers walked).
- Unmatched id, changed arity, new capture, or kind change ⇒ **loud warning + old body** (a reload never kills the session). An `Rc` pointer-identity guard makes a stale id from two reloads ago *unidentifiable* rather than wrongly identified.
- The producer keeps its lowered `Module`, rebinds the model on reload, and logs `N stored closure(s) rebound` + any warnings.

## Cross-engine review (Codex CLI + Claude subagent, the latter with empirical probes)

Both engines independently proved the first-draft ordinal ids (`mul#1`) could **silently rebind a stored closure to a sibling lambda** (field swap → stored `up` became `down`; inserted helper → stored velocity became constant zero) — violating both "correct or loud" and the design note's own never-by-index rule. All findings addressed, each now a pin test:

- **[BOTH, High — fixed]** Positional ordinals → path-based named ids. The reviewers' exact probes (record-field insertion, helper-`let` insertion) now rebind **correctly** instead of silently wrong. Residual: a lambda with *only* positional identity (list item, call arg, match arm) can still drift on sibling insertion — documented, with the guidance "give it a `let` name".
- **[BOTH, High/Med — fixed]** By-name env-chain scanning could resolve a capture to a stale shadowed binding. Now resolves through the old lambda's free list + binder-kind matching; both shadowing probe directions (param→`let`, removed inner shadow) warn and keep the old body.
- **[Claude, Med — fixed]** Arity changes now report at the reload boundary instead of failing confusingly at every call site a frame later.
- **[Claude, Low — documented]** A kept (warned) closure is kept atomically — its captured closures stay old too (the old body needs its old bindings).
- **[Claude, Low — resolved]** The `iter().rev()`/`iter()` lookup divergence died with `Env::find_by`'s deletion.

Claude's verdict pre-fix: "carefully built… but positional `#k` identity breaks the branch's own contract"; the guard/fail-loud machinery and free-var analysis were attacked and found sound (non-recursive `let`, mut-capture, match binders, pointer guard, producer ordering all verified against eval/lower semantics).

## Verification

- **12 rebind unit tests**: adopt-new-body+keep-env, containers, recursive captured closures, deleted-def / new-capture / arity / both shadowing-direction warnings, the two-reloads stale-id guard, data passthrough, and the two id-stability cases from review.
- **Pinned-clock SDK e2e** (`mle-closure-rebind.e2e.test.ts`): edit a stored `vel` closure's body live; assert `x' = x + newBody(oldK·dt)` exactly, and the reload log reports the rebind. Full e2e suite **16/16**.
- Full `mle` (8 suites), desktop, runtime-common green.
- docs/mle.md: **B5 fully checked off**; C3's stored-closure caveat removed; SKILL.md documents the rebind behavior and warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
