### PR TITLE
feat(physics,runtime): 2b — collider wireframe overlay (--debug-render physics)

### DIFF
--- a/.claude/skills/mle-language/SKILL.md
+++ b/.claude/skills/mle-language/SKILL.md
@@ -205,7 +205,9 @@ reload (like the model); deleting the `physics` hook drops it. Gotcha:
 under it (and the subscription grid never crosses) — bodies render at their
 declared pose. Capture physics with plain `--capture-time` (and a settled
 scene for reproducibility) instead; capture timer-driven changes via the
-debug server's `/time` advance.
+debug server's `/time` advance. To *see* colliders, run with
+`--debug-render physics`: normal shading plus the live world's wireframes
+(collider outlines, contacts, body frames).
 
 A project dir with `functor.json` `{"language": "mle", "entry": "game.mle"}`
 works with the CLI: `functor -d dir build` (typecheck, diagnostics are

--- a/docs/physics.md
+++ b/docs/physics.md
@@ -541,22 +541,22 @@ all control is via the keyboard, exactly as scoped.
 
 ## Debug visualization (wireframes via Rapier's debug renderer)
 
-Rapier ships its own debug renderer behind the **`debug-render`** feature:
-`DebugRenderPipeline` walks the live world and emits colored line segments —
-collider wireframes, contacts, joints, rigid-body frames, with granular passes
-(`render_colliders` / `render_contacts` / …) — through a one-method
-`DebugRenderBackend` trait (`draw_line(object, a, b, color)`). We adopt it
-rather than writing our own:
+**Shipped (Phase 2b).** Rapier ships its own debug renderer behind the
+**`debug-render`** feature: `DebugRenderPipeline` walks the live world and
+emits colored line segments — collider wireframes, contacts, joints,
+rigid-body frames — through a one-method `DebugRenderBackend` trait. We adopt
+it rather than writing our own:
 
-- **Engine side**: `World::debug_lines() -> Vec<Line>` (a tiny backend impl that
-  collects segments into plain data). Render-only, world-untouched — zero
-  determinism impact — and being plain data it is *also text-dumpable*, the
-  line-set sibling of `World::dump()` for headless/LLM inspection.
-- **Shell side**: both runtimes draw the line list as a GL line pass over the
-  frame. `functor-runner` already has a `--debug-render <mode>` flag — physics
-  wireframes become a mode (e.g. `--debug-render physics`), so captures and
-  golden scenarios can show physics state with no game-code changes; a runtime
-  keyboard toggle joins the pause/rewind keys in `hello-physics`.
+- **Engine side**: `World::debug_lines() -> Vec<DebugLine>` (a tiny backend
+  impl collecting segments into plain RGBA'd data). Render-only,
+  world-untouched — zero determinism impact — and being plain serializable
+  data it is *also text-dumpable*, the line-set sibling of `World::dump()`.
+- **Shell side**: `--debug-render physics` renders the frame with normal
+  shading, then `render_debug_lines` draws the collected segments as a
+  depth-tested GL line pass (`LEQUAL`, so lines coincident with collider
+  surfaces don't z-fight) — works in mono and stereo, and in captures
+  (`--capture-frame`) with no game-code changes. Native-only until the wasm
+  shell grows a physics world.
 
 This is the visual proof of reconcile correctness (declared scene vs what the
 solver actually holds) and makes divergence bugs — a body the renderer draws in
@@ -618,7 +618,7 @@ It's worth building in two steps, because they exercise different machinery:
 | **1b. Timeline seam** | `Simulatable` + `Timeline` traits, `TimelineLog` with the three cadences (`keyframes(n)` default / `snapshot_ring` / `replay_only`), strategy-equivalence + replay goldens. | native+wasm (Rust) |
 | **2. MLE surface + read-back** | `Physics.*` prelude (shape/body/scene builders, `position`/`transformed` live reads), optional `physics` hook in the MLE driver (tick → reconcile+fixed-step → draw), prelude tests. | native (MLE) |
 | **2c. `examples/mle-physics`** | Crates settling on a ground slab, hot-reload demo, golden scenario, PR GIF/PNG. | native (MLE) |
-| **2b. Debug visualization** | Rapier `debug-render` feature, `World::debug_lines()`, line pass, `--debug-render physics` mode. | native |
+| **2b. Debug visualization** | Rapier `debug-render` feature, `World::debug_lines()`, depth-tested line pass, `--debug-render physics` mode. **Shipped.** | native |
 | **3. Commands** | `applyImpulse`/`applyForce`/`setVelocity`/`teleport` (plain-data effects). | both |
 | **4. Queries** | `raycast`/`shapeCast` (async tagger, token registry). | both |
 | **5. Collision events** | `Physics.events` sub. | both |

--- a/runtime/functor-runtime-common/Cargo.toml
+++ b/runtime/functor-runtime-common/Cargo.toml
@@ -28,8 +28,9 @@ once_cell = "1.19.0"
 # `enhanced-determinism` (we need local single-binary determinism, which rapier
 # gives by default; the flag trades SIMD/parallel for cross-platform determinism
 # we don't need) — plus `serde-serialize` for byte-exact world snapshots
-# (rewind/replay/netcode Timeline).
-rapier3d = { version = "0.33", features = ["serde-serialize"] }
+# (rewind/replay/netcode Timeline) and `debug-render` for the collider
+# wireframe overlay (`--debug-render physics`; render-only, no sim impact).
+rapier3d = { version = "0.33", features = ["serde-serialize", "debug-render"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 fable_library_rust = { path = "./../../fable_modules/fable-library-rust" }

--- a/runtime/functor-runtime-common/src/physics/world.rs
+++ b/runtime/functor-runtime-common/src/physics/world.rs
@@ -30,6 +30,35 @@ pub const FIXED_DT: f32 = 1.0 / 60.0;
 /// unboundedly.
 pub const MAX_SUBSTEPS_PER_FRAME: u32 = 8;
 
+/// One colored wireframe segment from [`World::debug_lines`], in world space.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+pub struct DebugLine {
+    pub a: [f32; 3],
+    pub b: [f32; 3],
+    /// Plain RGBA in 0..1 (converted from the HSLA rapier emits).
+    pub color: [f32; 4],
+}
+
+/// Rapier's debug colors are HSLA; convert once at collection so consumers
+/// (GL overlay, text dumps) get ordinary RGBA.
+fn hsla_to_rgba([h, s, l, a]: [f32; 4]) -> [f32; 4] {
+    let c = (1.0 - (2.0 * l - 1.0).abs()) * s;
+    // rem_euclid: a negative hue must land in [0, 360), not keep its sign
+    // (Rust `%` would send it to sector 0 with a negative chroma offset).
+    let hp = h.rem_euclid(360.0) / 60.0;
+    let x = c * (1.0 - (hp % 2.0 - 1.0).abs());
+    let (r, g, b) = match hp as u32 {
+        0 => (c, x, 0.0),
+        1 => (x, c, 0.0),
+        2 => (0.0, c, x),
+        3 => (0.0, x, c),
+        4 => (x, 0.0, c),
+        _ => (c, 0.0, x),
+    };
+    let m = l - c / 2.0;
+    [r + m, g + m, b + m, a]
+}
+
 /// A live Rapier world plus the reconcile bookkeeping that maps declared
 /// [`Body`] tags onto Rapier handles.
 #[derive(Serialize, Deserialize)]
@@ -198,6 +227,50 @@ impl World {
         let rb = self.bodies.get(*rb_handle)?;
         let v = rb.linvel();
         Some([v.x, v.y, v.z])
+    }
+
+    /// The world as colored wireframe line segments, via Rapier's own debug
+    /// renderer (docs/physics.md, "Debug visualization"): collider shapes,
+    /// rigid-body frames, joints, and contacts. Render-only — reads the world,
+    /// never steps it — and plain data, so it works for a GL overlay and for
+    /// headless/text inspection alike.
+    pub fn debug_lines(&self) -> Vec<DebugLine> {
+        struct Collect(Vec<DebugLine>);
+        impl DebugRenderBackend for Collect {
+            fn draw_line(
+                &mut self,
+                _object: DebugRenderObject,
+                a: Vector,
+                b: Vector,
+                color: DebugColor,
+            ) {
+                self.0.push(DebugLine {
+                    a: [a.x, a.y, a.z],
+                    b: [b.x, b.y, b.z],
+                    color: hsla_to_rgba(color),
+                });
+            }
+        }
+
+        let mut collect = Collect(Vec::new());
+        // The pipeline is scratch state (like PhysicsPipeline); a debug-only
+        // path can afford to rebuild it per call. Rapier's default mode omits
+        // CONTACTS — add it back, since touching-points are exactly what a
+        // physics debug view is for. (This is rapier's DebugRenderMode, not
+        // the crate's shading enum of the same name.)
+        DebugRenderPipeline::new(
+            DebugRenderStyle::default(),
+            DebugRenderMode::default() | DebugRenderMode::CONTACTS,
+        )
+        .render(
+            &mut collect,
+            &self.bodies,
+            &self.colliders,
+            &self.impulse_joints,
+            &self.multibody_joints,
+            &self.narrow_phase,
+        );
+        collect.0
     }
 
     /// Headless observability (docs/physics.md, "drivable and observable
@@ -615,6 +688,36 @@ mod tests {
         restored.restore(&snap).unwrap();
         assert_eq!(restored.frame(), w.frame());
         assert!(restored.snapshot() == snap, "restored snapshot differs");
+    }
+
+    #[test]
+    fn hsla_converts_to_expected_rgba() {
+        // Pure green, and rapier's default dynamic-collider crimson.
+        assert_eq!(hsla_to_rgba([120.0, 1.0, 0.5, 1.0]), [0.0, 1.0, 0.0, 1.0]);
+        let [r, g, b, a] = hsla_to_rgba([340.0, 1.0, 0.3, 1.0]);
+        assert!(r > 0.55 && g == 0.0 && b > 0.15 && a == 1.0, "{r} {g} {b}");
+        // Negative hue lands in [0,360) instead of producing negative chroma.
+        let [r, ..] = hsla_to_rgba([-30.0, 1.0, 0.5, 1.0]);
+        assert!((0.0..=1.0).contains(&r));
+    }
+
+    #[test]
+    fn debug_lines_cover_declared_bodies() {
+        let mut w = World::new([0.0, -9.81, 0.0]);
+        assert!(w.debug_lines().is_empty());
+        w.reconcile(&scene(vec![ground(), crate_at("a", [0.0, 0.51, 0.0])]));
+        for _ in 0..30 {
+            w.step_fixed();
+        }
+        let lines = w.debug_lines();
+        // Two cuboid colliders' worth of wireframe + body axes + the resting
+        // contact — the exact count is rapier's business; non-empty and finite
+        // is the contract.
+        assert!(lines.len() > 20, "expected a real wireframe, got {}", lines.len());
+        for line in &lines {
+            assert!(line.a.iter().chain(&line.b).all(|v| v.is_finite()));
+            assert!(line.color.iter().all(|c| (0.0..=1.0).contains(c)));
+        }
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/render_context.rs
+++ b/runtime/functor-runtime-common/src/render_context.rs
@@ -39,6 +39,12 @@ pub enum DebugRenderMode {
     /// the guard for the tangent vertex attribute (glTF import + analytic
     /// generation), as `Normals` is for normals.
     Tangents,
+    /// Normal shading plus a physics wireframe overlay: the live world's
+    /// colliders/contacts as colored lines (rapier's debug renderer via
+    /// `physics::World::debug_lines`), making declared-vs-simulated divergence
+    /// visible at a glance. Native-only today (the wasm shell has no physics
+    /// world yet, so on wasm this shades like `Default`).
+    Physics,
 }
 
 impl DebugRenderMode {
@@ -50,6 +56,7 @@ impl DebugRenderMode {
             DebugRenderMode::Default => "default",
             DebugRenderMode::Normals => "normals",
             DebugRenderMode::Tangents => "tangents",
+            DebugRenderMode::Physics => "physics",
         }
     }
 
@@ -60,6 +67,7 @@ impl DebugRenderMode {
             "default" => Some(DebugRenderMode::Default),
             "normals" => Some(DebugRenderMode::Normals),
             "tangents" => Some(DebugRenderMode::Tangents),
+            "physics" => Some(DebugRenderMode::Physics),
             _ => None,
         }
     }
@@ -71,7 +79,12 @@ mod tests {
 
     #[test]
     fn from_label_roundtrips_every_variant() {
-        for mode in [DebugRenderMode::Default, DebugRenderMode::Normals] {
+        for mode in [
+            DebugRenderMode::Default,
+            DebugRenderMode::Normals,
+            DebugRenderMode::Tangents,
+            DebugRenderMode::Physics,
+        ] {
             assert_eq!(DebugRenderMode::from_label(mode.label()), Some(mode));
         }
     }

--- a/runtime/functor-runtime-common/src/renderer.rs
+++ b/runtime/functor-runtime-common/src/renderer.rs
@@ -120,3 +120,137 @@ pub fn render_frame(
         &root_material,
     );
 }
+
+/// Draw a batch of colored world-space line segments over the current
+/// framebuffer — the physics wireframe overlay (`--debug-render physics`,
+/// lines from `physics::World::debug_lines`). Depth-tested against the frame
+/// just rendered, so wireframes sit *on* their bodies instead of x-raying
+/// through the scene.
+///
+/// Debug-only path: the shader and buffers are built and torn down per call,
+/// matching the crate's per-frame material style — simplicity over premature
+/// caching for a diagnostic overlay.
+///
+/// Precondition: call immediately after `render_frame` with the same
+/// camera/viewport — the GL viewport and scissor are inherited from it (the
+/// `viewport` parameter is used for the aspect ratio only), which is what
+/// clips the overlay to the right pane in stereo/multi-pane layouts.
+pub fn render_debug_lines(
+    gl: &glow::Context,
+    shader_version: &str,
+    camera: &Camera,
+    viewport: Viewport,
+    lines: &[crate::physics::DebugLine],
+) {
+    if lines.is_empty() {
+        return;
+    }
+
+    // Interleave [pos.xyz, color.rgba] per vertex, two vertices per line.
+    let mut vertices: Vec<f32> = Vec::with_capacity(lines.len() * 14);
+    for line in lines {
+        for p in [line.a, line.b] {
+            vertices.extend_from_slice(&p);
+            vertices.extend_from_slice(&line.color);
+        }
+    }
+
+    let view_projection: Matrix4<f32> =
+        camera.projection_matrix(viewport.aspect()) * camera.view_matrix();
+
+    unsafe {
+        let program = gl.create_program().expect("create debug line program");
+        let sources = [
+            (
+                glow::VERTEX_SHADER,
+                format!(
+                    "{shader_version}\n\
+                     layout(location = 0) in vec3 a_pos;\n\
+                     layout(location = 1) in vec4 a_color;\n\
+                     uniform mat4 u_view_projection;\n\
+                     out vec4 v_color;\n\
+                     void main() {{\n\
+                         v_color = a_color;\n\
+                         gl_Position = u_view_projection * vec4(a_pos, 1.0);\n\
+                     }}"
+                ),
+            ),
+            (
+                glow::FRAGMENT_SHADER,
+                format!(
+                    "{shader_version}\n\
+                     precision mediump float;\n\
+                     in vec4 v_color;\n\
+                     out vec4 frag_color;\n\
+                     void main() {{ frag_color = v_color; }}"
+                ),
+            ),
+        ];
+        let mut shaders = Vec::new();
+        for (kind, source) in sources {
+            let shader = gl.create_shader(kind).expect("create debug line shader");
+            gl.shader_source(shader, &source);
+            gl.compile_shader(shader);
+            if !gl.get_shader_compile_status(shader) {
+                panic!(
+                    "debug line shader failed to compile: {}",
+                    gl.get_shader_info_log(shader)
+                );
+            }
+            gl.attach_shader(program, shader);
+            shaders.push(shader);
+        }
+        gl.link_program(program);
+        if !gl.get_program_link_status(program) {
+            panic!(
+                "debug line program failed to link: {}",
+                gl.get_program_info_log(program)
+            );
+        }
+        for shader in shaders {
+            gl.detach_shader(program, shader);
+            gl.delete_shader(shader);
+        }
+
+        gl.use_program(Some(program));
+        // Same matrix→slice idiom as `shader_program::set_uniform_matrix4`.
+        let mvp = cgmath::conv::array4x4(view_projection);
+        let mvp_raw = core::slice::from_raw_parts(mvp.as_ptr() as *const f32, 16);
+        gl.uniform_matrix_4_f32_slice(
+            gl.get_uniform_location(program, "u_view_projection")
+                .as_ref(),
+            false,
+            mvp_raw,
+        );
+
+        let vao = gl.create_vertex_array().expect("create debug line vao");
+        gl.bind_vertex_array(Some(vao));
+        let vbo = gl.create_buffer().expect("create debug line vbo");
+        gl.bind_buffer(glow::ARRAY_BUFFER, Some(vbo));
+        // Same raw-bytes view the mesh upload path uses (indexed_mesh.rs).
+        let vertices_u8: &[u8] = core::slice::from_raw_parts(
+            vertices.as_ptr() as *const u8,
+            std::mem::size_of_val(vertices.as_slice()),
+        );
+        gl.buffer_data_u8_slice(glow::ARRAY_BUFFER, vertices_u8, glow::STREAM_DRAW);
+        let stride = (7 * std::mem::size_of::<f32>()) as i32;
+        gl.enable_vertex_attrib_array(0);
+        gl.vertex_attrib_pointer_f32(0, 3, glow::FLOAT, false, stride, 0);
+        gl.enable_vertex_attrib_array(1);
+        gl.vertex_attrib_pointer_f32(1, 4, glow::FLOAT, false, stride, 3 * 4);
+
+        // Wireframes lie exactly ON collider surfaces, so with LESS half their
+        // pixels lose the depth test to the coincident face (z-fighting).
+        // LEQUAL lets equal-depth line pixels win; restore LESS after.
+        gl.depth_func(glow::LEQUAL);
+        gl.draw_arrays(glow::LINES, 0, (vertices.len() / 7) as i32);
+        gl.depth_func(glow::LESS);
+
+        gl.bind_vertex_array(None);
+        gl.bind_buffer(glow::ARRAY_BUFFER, None);
+        gl.use_program(None);
+        gl.delete_buffer(vbo);
+        gl.delete_vertex_array(vao);
+        gl.delete_program(program);
+    }
+}

--- a/runtime/functor-runtime-common/src/scene3d/mod.rs
+++ b/runtime/functor-runtime-common/src/scene3d/mod.rs
@@ -224,7 +224,9 @@ impl Scene3D {
             Some(m)
         } else {
             match render_context.debug_render_mode {
-                DebugRenderMode::Default => None,
+                // Physics mode shades normally — its wireframes are a separate
+                // overlay pass (`render_debug_lines`), not a material override.
+                DebugRenderMode::Default | DebugRenderMode::Physics => None,
                 DebugRenderMode::Normals => {
                     let mut m = NormalDebugMaterial::create();
                     m.initialize(render_context);
@@ -257,8 +259,10 @@ impl Scene3D {
                         // the matching diagnostic material (the skinned variant
                         // deforms the normal by the joint blend).
                         let is_skinned = hydrated_model.skeleton.get_joint_count() > 0;
-                        let debug_override =
-                            render_context.debug_render_mode != DebugRenderMode::Default;
+                        let debug_override = !matches!(
+                            render_context.debug_render_mode,
+                            DebugRenderMode::Default | DebugRenderMode::Physics
+                        );
                         // In the depth pass, draw the model with a depth material
                         // that still skins (so animated models cast a correctly
                         // deforming shadow), else the lit material or the matching
@@ -268,8 +272,14 @@ impl Scene3D {
                             (true, true) => SkinnedDepthMaterial::create(),
                             (true, false) => DepthMaterial::create(),
                             (false, _) => match render_context.debug_render_mode {
-                                DebugRenderMode::Default if is_skinned => SkinnedMaterial::create(),
-                                DebugRenderMode::Default => BasicMaterial::create(),
+                                DebugRenderMode::Default | DebugRenderMode::Physics
+                                    if is_skinned =>
+                                {
+                                    SkinnedMaterial::create()
+                                }
+                                DebugRenderMode::Default | DebugRenderMode::Physics => {
+                                    BasicMaterial::create()
+                                }
                                 DebugRenderMode::Normals if is_skinned => {
                                     SkinnedNormalDebugMaterial::create()
                                 }

--- a/runtime/functor-runtime-desktop/src/main.rs
+++ b/runtime/functor-runtime-desktop/src/main.rs
@@ -105,6 +105,8 @@ enum DebugRenderArg {
     Normals,
     /// Visualize world-space surface tangents as RGB.
     Tangents,
+    /// Normal shading plus the physics collider/contact wireframe overlay.
+    Physics,
 }
 
 impl From<DebugRenderArg> for functor_runtime_common::DebugRenderMode {
@@ -113,6 +115,7 @@ impl From<DebugRenderArg> for functor_runtime_common::DebugRenderMode {
             DebugRenderArg::Default => functor_runtime_common::DebugRenderMode::Default,
             DebugRenderArg::Normals => functor_runtime_common::DebugRenderMode::Normals,
             DebugRenderArg::Tangents => functor_runtime_common::DebugRenderMode::Tangents,
+            DebugRenderArg::Physics => functor_runtime_common::DebugRenderMode::Physics,
         }
     }
 }
@@ -878,6 +881,18 @@ Escape again to quit"
                 player.respatialize_voices();
             }
 
+            // Physics wireframe overlay (--debug-render physics): collect the
+            // live world's lines once per frame, drawn over each rendered view
+            // below. Read-only; an empty/no-physics world yields no lines.
+            let physics_debug_lines = matches!(args.debug_render, DebugRenderArg::Physics)
+                .then(|| {
+                    functor_runtime_common::physics::with_world(
+                        functor_runtime_common::physics::DEFAULT_WORLD,
+                        |w| w.debug_lines(),
+                    )
+                })
+                .flatten();
+
             // Shadow + forward passes, shared with the web runtime. In stereo
             // mode, render the same frame twice — once per eye camera into each
             // half of the window. (The shadow pass runs per eye; it must start
@@ -907,6 +922,15 @@ Escape again to quit"
                         *eye_viewport,
                         args.debug_render.into(),
                     );
+                    if let Some(lines) = &physics_debug_lines {
+                        functor_runtime_common::render_debug_lines(
+                            &gl,
+                            shader_version,
+                            camera,
+                            *eye_viewport,
+                            lines,
+                        );
+                    }
                 }
             } else {
                 functor_runtime_common::render_frame(
@@ -921,6 +945,15 @@ Escape again to quit"
                     viewport,
                     args.debug_render.into(),
                 );
+                if let Some(lines) = &physics_debug_lines {
+                    functor_runtime_common::render_debug_lines(
+                        &gl,
+                        shader_version,
+                        &view_camera,
+                        viewport,
+                        lines,
+                    );
+                }
             }
 
             // 2D UI overlay: the game's declarative `ui model` View, lowered to a


### PR DESCRIPTION
Phase **2b** of docs/physics.md: Rapier's own debug renderer surfaced as a render mode. `--debug-render physics` renders the frame with **normal shading plus the live world's wireframes** — collider outlines, contacts, joints, body frames — so declared-vs-simulated divergence is visible at a glance.

![wireframes](https://gist.githubusercontent.com/tommy-xr/be266ba8a954620d1766f6abdd9fc37a/raw/physics-wireframes.gif)

| mid-fall — outlines on airborne bodies | at rest — contacts + slab boundary |
| --- | --- |
| ![mid](https://gist.githubusercontent.com/tommy-xr/be266ba8a954620d1766f6abdd9fc37a/raw/wire-midfall.png) | ![rest](https://gist.githubusercontent.com/tommy-xr/be266ba8a954620d1766f6abdd9fc37a/raw/wire-rest.png) |

## How it's built

- **Engine**: `World::debug_lines() → Vec<DebugLine>` — a one-method `DebugRenderBackend` collector over rapier's `DebugRenderPipeline` (the `debug-render` feature; render-only, zero determinism impact). HSLA→RGBA conversion happens at collection so consumers get plain color data; being serializable, the line set is also text-dumpable — the wireframe sibling of `World::dump()`.
- **Mode**: `DebugRenderMode::Physics` shades like `Default` (all three `scene3d` dispatch points) — the wireframes are a separate overlay pass, not a material override. Label plumbing (`--debug-render physics`, `/render-mode`, URL query) comes via the existing `label`/`from_label` seam.
- **Overlay pass**: `render_debug_lines` — a self-contained GL line pass (per-call program/VAO/VBO, torn down after; a deliberate simplicity trade for a diagnostic path). Drawn with **`LEQUAL` depth** during the pass: wireframes lie exactly on collider surfaces, so with `LESS` half their pixels z-fight with the coincident face (verified before/after in captures). Works in mono, per-eye stereo, and `--capture-frame`.

## Review findings addressed

- **[AGREED both engines]** rapier's default debug mode omits `CONTACTS` while the docs promised them — contacts now explicitly enabled (visible as markers where bodies rest).
- Hue conversion hardened with `rem_euclid` (negative hue can't produce negative chroma) + unit tests; the viewport/scissor-inheritance precondition documented on the pass.
- Verified clean by review: GL state restoration (depth func, VAO-scoped attribs, teardown order), stereo scissor interplay, exhaustive `DebugRenderMode` matches across the workspace, and the lazy world-0 creation for non-physics games (empty world, zero lines, early-out).

## Testing

- `cargo test -p functor_runtime_common` — 118 passed (new: HSLA conversion, debug-lines coverage/finiteness)
- `--features strict` + wasm32 checks clean (on wasm, `physics` parses and shades like `Default` — no world exists there yet; documented on the variant)
- Live captures of `examples/mle-physics` above

🤖 Generated with [Claude Code](https://claude.com/claude-code)