### PR TITLE
feat(web,cli): C5 — MLE games on wasm: the interpreter producer in the browser

### DIFF
--- a/.claude/skills/mle-language/SKILL.md
+++ b/.claude/skills/mle-language/SKILL.md
@@ -211,7 +211,9 @@ debug server's `/time` advance. To *see* colliders, run with
 
 A project dir with `functor.json` `{"language": "mle", "entry": "game.mle"}`
 works with the CLI: `functor -d dir build` (typecheck, diagnostics are
-errors), `run native`, `develop` (hot reload is built in).
+errors), `run native`, `develop` (hot reload is built in), and `run wasm`
+(the `.mle` ships as text and is interpreted in the browser; hot reload is
+native-only — reload the page to pick up edits).
 
 `examples/mle-hello/game.mle` is the reference
 (`examples/mle-physics/game.mle` for the physics hook, including the

--- a/cli/src/commands/mle_project.rs
+++ b/cli/src/commands/mle_project.rs
@@ -9,12 +9,15 @@
 //!   dir, so asset paths resolve as usual).
 //! - `develop` is `run`: the MLE producer hot-reloads on save by itself — no
 //!   watchexec loop, no rebuild. State is preserved across edits.
-//! - wasm is not wired yet (docs/mle.md C5).
+//! - `run wasm` serves the project with the MLE index page (docs/mle.md C5):
+//!   nothing compiles — the `.mle` source ships as text, fetched and
+//!   interpreted by the embedded web runtime. Hot reload is native-only;
+//!   reload the page to pick up edits.
 
 use std::io::{Error, ErrorKind};
 use std::path::{Path, PathBuf};
 
-use crate::util::{self, get_nearby_bin, ShellCommand};
+use crate::util::{self, get_nearby_bin, ShellCommand, WasmDevServer};
 use crate::Environment;
 
 /// The MLE project settings read from `functor.json`.
@@ -91,15 +94,16 @@ impl MleProject {
         develop: bool,
     ) -> Result<(), Error> {
         if matches!(environment, Environment::Wasm) {
-            return Err(Error::other(
-                "mle on wasm is not wired yet (docs/mle.md Track C5) — use `run native`",
-            ));
+            return self.run_wasm(working_directory, runner_args, develop).await;
         }
         let entry = self.entry_path(working_directory)?;
         let functor_runner_exe =
             get_nearby_bin(&"functor-runner").expect("functor-runner should be available");
         if develop {
-            println!("[mle] develop: hot reload is built in — edit {} and save", self.entry);
+            println!(
+                "[mle] develop: hot reload is built in — edit {} and save",
+                self.entry
+            );
         }
         // The runner's cwd is the project dir, so the entry passes through
         // as-is — `src/game.mle` keeps its subdirectory.
@@ -176,6 +180,68 @@ with --debug-port (and --debug-bind 0.0.0.0 if remote)?"
             tokio::time::sleep(std::time::Duration::from_millis(300)).await;
         }
     }
+
+    /// Serve the project at 127.0.0.1:8080 with the MLE index page (docs/
+    /// mle.md C5). The `.mle` entry ships as text — the dev server's
+    /// filesystem route serves it from the project dir and the embedded web
+    /// runtime fetches + interprets it. Mirrors the F# wasm arm of
+    /// `commands::run` (`--no-open` handling included).
+    async fn run_wasm(
+        &self,
+        working_directory: &str,
+        runner_args: &[String],
+        develop: bool,
+    ) -> Result<(), Error> {
+        self.entry_path(working_directory)?; // fail before serving, not per fetch
+
+        // The dev server can only serve files INSIDE the project dir — an
+        // entry that escapes it (absolute, or `..`) is readable natively but
+        // unfetchable by the page. Fail loud here, not as a browser 404.
+        if entry_escapes_project(&self.entry) {
+            return Err(Error::other(format!(
+                "mle on wasm serves the project directory over HTTP, so `entry` must be a \
+relative path inside it (got {})",
+                self.entry
+            )));
+        }
+        if develop {
+            println!("[mle] develop (wasm): hot reload is native-only — reload the page to pick up edits");
+        }
+        let no_open = runner_args.iter().any(|a| a == "--no-open");
+        let ignored: Vec<&str> = runner_args
+            .iter()
+            .filter(|a| a.as_str() != "--no-open")
+            .map(|s| s.as_str())
+            .collect();
+        if !ignored.is_empty() {
+            eprintln!(
+                "warning: ignoring runner args (not supported for wasm): {}",
+                ignored.join(" ")
+            );
+        }
+
+        let wasm_server_start = WasmDevServer::start_mle(working_directory, &self.entry);
+        if no_open {
+            println!(
+                "[Functor] wasm server at http://127.0.0.1:8080 (--no-open: skipping browser)"
+            );
+        } else {
+            let cmd = if std::env::consts::OS == "windows" {
+                "start"
+            } else {
+                "open"
+            };
+            let commands = vec![ShellCommand {
+                prefix: "[Open Browser]",
+                cmd,
+                cwd: working_directory,
+                env: vec![],
+                args: vec!["http://127.0.0.1:8080"],
+            }];
+            util::ShellCommand::run_sequential(commands).await?;
+        }
+        wasm_server_start.await
+    }
 }
 
 /// Minimal HTTP POST over std::net — one dependency-free request to the
@@ -214,4 +280,28 @@ Content-Length: {}\r\nConnection: close\r\n\r\n",
         .map(|(_, b)| b.trim().to_string())
         .unwrap_or_default();
     Ok((status, body))
+}
+
+/// True when `entry` can't be served by the wasm dev server, which roots at
+/// the project directory: absolute paths and any `..` component escape it.
+fn entry_escapes_project(entry: &str) -> bool {
+    Path::new(entry).is_absolute() || entry.split(['/', '\\']).any(|seg| seg == "..")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::entry_escapes_project;
+
+    #[test]
+    fn entries_inside_the_project_are_servable() {
+        assert!(!entry_escapes_project("game.mle"));
+        assert!(!entry_escapes_project("src/game.mle"));
+    }
+
+    #[test]
+    fn escaping_entries_are_rejected() {
+        assert!(entry_escapes_project("../shared/game.mle"));
+        assert!(entry_escapes_project("src/../../game.mle"));
+        assert!(entry_escapes_project("/tmp/game.mle"));
+    }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -155,15 +155,10 @@ async fn main() -> tokio::io::Result<()> {
     {
         let res = match &args.command {
             Command::Init { .. } | Command::Inspect { .. } => unreachable!("is_routed excludes"),
-            Command::Build { environment } => {
-                if matches!(Environment::default(environment), Environment::Wasm) {
-                    Err(io::Error::other(
-                        "mle on wasm is not wired yet (docs/mle.md Track C5) — use `build native`",
-                    ))
-                } else {
-                    project.build(&working_directory_str)
-                }
-            }
+            // `build` is target-independent for MLE: the strict typecheck
+            // gate is the whole build — nothing compiles for either target
+            // (native interprets the file; wasm serves it as text).
+            Command::Build { .. } => project.build(&working_directory_str),
             Command::Run {
                 environment,
                 runner_args,

--- a/cli/src/util/wasm_dev_server.rs
+++ b/cli/src/util/wasm_dev_server.rs
@@ -5,13 +5,41 @@ use warp::{http::Response, Filter};
 pub struct WasmDevServer;
 
 const INDEX_HTML: &[u8] = include_bytes!("../../../runtime/functor-runtime-web/index.html");
+const INDEX_MLE_HTML: &str = include_str!("../../../runtime/functor-runtime-web/index-mle.html");
 const WASM_FILE: &[u8] =
     include_bytes!("../../../runtime/functor-runtime-web/pkg/functor_runtime_web_bg.wasm");
 const JS_FILE_1: &[u8] =
     include_bytes!("../../../runtime/functor-runtime-web/pkg/functor_runtime_web.js");
 
+/// Substitute the project's MLE entry file into the MLE index page: the quoted
+/// placeholder `"__MLE_ENTRY__"` becomes a JSON string literal (valid JS for
+/// any entry path, quotes and backslashes included). The page assigns it to
+/// `window.__mleGamePath`, which tells the web runtime to fetch + interpret
+/// that source (docs/mle.md Track C5).
+fn render_mle_index(entry: &str) -> String {
+    let literal = serde_json::to_string(entry)
+        .expect("a string always serializes")
+        // JSON escaping is not HTML escaping: `</script>` inside the literal
+        // would terminate the page's script block. `<\/` is the standard
+        // inline-script defense (`\/` is `/` in a JS string).
+        .replace("</", "<\\/");
+    INDEX_MLE_HTML.replace("\"__MLE_ENTRY__\"", &literal)
+}
+
 impl WasmDevServer {
     pub async fn start(working_directory: &str) -> Result<(), io::Error> {
+        Self::serve(working_directory, INDEX_HTML.to_vec()).await
+    }
+
+    /// Serve an MLE project (docs/mle.md Track C5): same embedded runtime
+    /// bundle + filesystem routes, but the index page is the MLE one — there
+    /// is no game wasm module; the runtime fetches the entry file, which the
+    /// filesystem route serves straight from the project directory.
+    pub async fn start_mle(working_directory: &str, entry: &str) -> Result<(), io::Error> {
+        Self::serve(working_directory, render_mle_index(entry).into_bytes()).await
+    }
+
+    async fn serve(working_directory: &str, index_html: Vec<u8>) -> Result<(), io::Error> {
         let wd = working_directory.to_owned();
 
         println!("Starting dev server in: {}", wd);
@@ -21,7 +49,7 @@ impl WasmDevServer {
             .map(move || {
                 Response::builder()
                     .header("Content-Type", "text/html")
-                    .body(INDEX_HTML.to_vec())
+                    .body(index_html.clone())
             })
             .boxed();
 
@@ -49,5 +77,29 @@ impl WasmDevServer {
 
         warp::serve(routes).run(([127, 0, 0, 1], 8080)).await;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::render_mle_index;
+
+    #[test]
+    fn substitutes_the_entry_as_a_js_string() {
+        let html = render_mle_index("game.mle");
+        assert!(html.contains("window.__mleGamePath = \"game.mle\""));
+        assert!(!html.contains("__MLE_ENTRY__"));
+    }
+
+    #[test]
+    fn escapes_entries_that_would_break_the_script() {
+        let html = render_mle_index("we\"ird\\name.mle");
+        assert!(html.contains("we\\\"ird\\\\name.mle"));
+    }
+
+    #[test]
+    fn escapes_a_script_terminator_in_the_entry() {
+        let html = render_mle_index("bad</script>.mle");
+        assert!(html.contains("bad<\\/script>.mle"));
     }
 }

--- a/docs/mle.md
+++ b/docs/mle.md
@@ -337,8 +337,25 @@ Starts once A2 + B3 exist.
         ADDS subscriptions starts from the current frame edge (no
         catch-up burst); prelude unit tests pin the grid math and the
         teaching errors (15/15 e2e suite).
-- [ ] **C5. Wasm.** The interpreter crate compiles to wasm32; `.mle` source
-      ships in the bundle. *Verify:* wasm build of mle-hello renders.
+- [x] **C5. Wasm** (done 2026-07-03). `MleWebGame` in the web runtime — the
+      wasm sibling of the desktop producer behind the same `GameProducer`
+      seam: identical load-contract validation, MVU subscriptions pump,
+      physics hook (rapier is pure Rust — the world steps in the browser),
+      per-frame error dedupe + last-good-frame. Nothing compiles: the `.mle`
+      source ships as TEXT — `functor run wasm` serves the project dir with
+      an MLE index page (`index-mle.html`, entry substituted in by the dev
+      server), the page sets `window.__mleGamePath`, and the runtime fetches
+      + interprets it. Page input reaches the producer via `mle_*` wasm
+      exports, queued and drained before each tick. Hot reload stays
+      native-only — on web, reload the page (the server reads the file per
+      fetch, so edits are one refresh away).
+      *Verify (done):* mle + web runtime build clean for wasm32; CLI
+      build/run wasm probes on `examples/mle-hello` — the served index page,
+      wasm bundle, and `.mle` source all curl back correctly; entry
+      substitution unit-tested; headless-Chromium probe renders the game
+      (ring + sphere) AND proves the Beat subscription folded through
+      `update` (sphere center yellow → magenta across a 1s boundary, the
+      exact beat arithmetic); `cargo test -p functor_runtime_common` green.
 - [ ] **C6. Perf gate.** Measure C4 at 60fps with headroom; bytecode VM
       (roadmap phase 7) only if the tree-walker doesn't hold.
       *Verify:* frame-time assertion in the e2e harness.

--- a/runtime/functor-runtime-web/Cargo.toml
+++ b/runtime/functor-runtime-web/Cargo.toml
@@ -8,6 +8,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 functor_runtime_common = { path = "./../functor-runtime-common" }
+# The MLE language, for the in-runtime interpreter producer (docs/mle.md C5).
+mle = { path = "../../mle" }
 fable_library_rust = { path = "./../../fable_modules/fable-library-rust" }
 glow = "0.17"
 cgmath = "0.18.0"

--- a/runtime/functor-runtime-web/index-mle.html
+++ b/runtime/functor-runtime-web/index-mle.html
@@ -1,0 +1,100 @@
+<html>
+  <!-- The MLE index page (docs/mle.md Track C5), served at `/` by the CLI's
+       dev server for `"language": "mle"` projects. Unlike index.html there is
+       no game wasm module to import: the runtime itself fetches the `.mle`
+       entry (declared via window.__mleGamePath below) and interprets it, so
+       this page only wires input into the runtime's `mle_*` exports. -->
+  <head>
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type" />
+    <style>
+      html, body { margin: 0; height: 100%; overflow: hidden; }
+      /* Fill the window; the runtime sizes the drawable buffer (and GL
+         viewport) to match this displayed size each frame, scaled for HiDPI. */
+      #canvas { display: block; width: 100%; height: 100%; }
+    </style>
+  </head>
+  <body>
+    <canvas id="canvas"></canvas>
+    <script type="module">
+
+      import init, {
+        mle_key_event,
+        mle_mouse_move,
+        mle_mouse_wheel,
+      } from "./pkg/functor_runtime_web.js";
+
+      // The MLE entry file, substituted in by the CLI's dev server (see
+      // cli/src/util/wasm_dev_server.rs). Must be set before init(): the
+      // runtime reads it at start to choose the interpreter producer over the
+      // F# game-module bridge. The runtime fetches this as a URL, so encode
+      // each path segment (spaces, '#', '?') while keeping subdirectories.
+      window.__mleGamePath = "__MLE_ENTRY__"
+        .split("/").map(encodeURIComponent).join("/");
+
+      // Map a browser KeyboardEvent.code to the canonical key code expected by
+      // the game (functor_runtime_common::Key as i32 — the same mapping as
+      // index.html). Keep in sync with that enum: A=1..Z=26, then the entries
+      // below. 0 = Unknown.
+      const keyCode = (code) => {
+        // "KeyA".."KeyZ" -> 1..26 ('A' is char code 65).
+        if (code.length === 4 && code.startsWith("Key")) {
+          return code.charCodeAt(3) - 64;
+        }
+        switch (code) {
+          case "ArrowUp": return 27;
+          case "ArrowDown": return 28;
+          case "ArrowLeft": return 29;
+          case "ArrowRight": return 30;
+          case "Space": return 31;
+          case "Enter": return 32;
+          case "Escape": return 33;
+          default: return 0;
+        }
+      };
+
+      const setupInput = () => {
+        const canvas = document.getElementById("canvas");
+
+        // Keyboard. Ignore auto-repeat (the game tracks held state itself), and
+        // swallow keys we handle so Space/arrows don't scroll the page.
+        window.addEventListener("keydown", (e) => {
+          const code = keyCode(e.code);
+          if (code === 0) return;
+          e.preventDefault();
+          if (!e.repeat) mle_key_event(code, true);
+        });
+        window.addEventListener("keyup", (e) => {
+          const code = keyCode(e.code);
+          if (code === 0) return;
+          mle_key_event(code, false);
+        });
+
+        // Mouse free-look. Pointer Lock is the browser equivalent of the
+        // desktop runtime's GLFW cursor capture: click the canvas to lock, then
+        // movementX/Y give relative motion. We accumulate it into a running
+        // position so the game's "delta = current - lastMouse" logic works the
+        // same as on native. Esc releases the lock (browser default).
+        canvas.addEventListener("click", () => canvas.requestPointerLock());
+        let ax = 0;
+        let ay = 0;
+        document.addEventListener("mousemove", (e) => {
+          ax += e.movementX;
+          ay += e.movementY;
+          mle_mouse_move(ax, ay);
+        });
+
+        canvas.addEventListener("wheel", (e) => {
+          e.preventDefault();
+          mle_mouse_wheel(Math.sign(e.deltaY));
+        });
+      };
+
+      init().then(() => {
+        // In a deterministic capture (?fixed-time), don't wire up input — a
+        // stray mouse move would turn the camera, like on native.
+        const deterministic = new URLSearchParams(window.location.search).has("fixed-time");
+        if (!deterministic) setupInput();
+      });
+    </script>
+  </body>
+</html>

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -24,6 +24,8 @@ use wasm_bindgen_futures::{spawn_local, JsFuture};
 
 use wasm_bindgen::prelude::*;
 
+mod mle_game;
+
 fn window() -> web_sys::Window {
     web_sys::window().expect("no global `window` exists")
 }
@@ -72,6 +74,31 @@ fn fixed_time_from_url() -> Option<f32> {
         }
     }
     None
+}
+
+/// The wasm counterpart of the desktop `--mle --game-path` flags: the page
+/// sets `window.__mleGamePath` to the entry file before initializing this
+/// module (the CLI's MLE index page substitutes the project's `functor.json`
+/// entry — see `index-mle.html` / the CLI's `wasm_dev_server.rs`), and the
+/// runtime fetches + interprets that source instead of bridging to a game
+/// wasm module. Absent (the F# path) this returns `None`.
+fn mle_game_path() -> Option<String> {
+    js_sys::Reflect::get(&window(), &JsValue::from_str("__mleGamePath"))
+        .ok()
+        .and_then(|v| v.as_string())
+}
+
+/// Fetch the `.mle` source and build the interpreter producer. Failures are
+/// rendered strings (fetch status, parse/load position, contract violation)
+/// for `run_async` to fail loud with.
+async fn create_mle_game(path: &str) -> Result<mle_game::MleWebGame, String> {
+    let (status, src) = perform_fetch(HttpMethod::Get, path, &[], &[])
+        .await
+        .map_err(|e| format!("cannot fetch {path}: {e}"))?;
+    if status != 200 {
+        return Err(format!("cannot fetch {path}: HTTP {status}"));
+    }
+    mle_game::MleWebGame::create(path, src)
 }
 
 #[wasm_bindgen]
@@ -247,6 +274,13 @@ fn dispatch_net_commands(game: &dyn GameProducer) {
     }
 }
 
+// NOTE: completions push through a fresh stateless `WasmGame` (the F# game
+// module holds the real state behind the wasm_bindgen externs). The MLE
+// producer (`mle_game::MleWebGame`) is NOT reachable from here — safe today
+// because MLE has no effects (its drains return "[]", so nothing ever needs
+// completing), but when MLE grows effects (Track B6/C4b-2) these sites need a
+// shared handle to the live producer or they'll throw `game is not defined`
+// on the MLE page.
 async fn perform_and_push(cmd: NetCommand) {
     let NetCommand::HttpRequest {
         token,
@@ -739,6 +773,9 @@ fn dispatch_conn_commands(game: &dyn GameProducer, state: &Rc<RefCell<WsClient>>
 fn ws_connect(state: &Rc<RefCell<WsClient>>, key: String, url: String) {
     // Idempotent by key (matches the native host); a re-declared connection
     // reattaches rather than opening a second socket.
+    // NOTE: like perform_and_push, event callbacks push through `WasmGame`
+    // (the F# externs) — unreachable on the MLE page until MLE grows effects;
+    // see the note on perform_and_push.
     if state.borrow().by_key.contains_key(&key) {
         return;
     }
@@ -817,6 +854,25 @@ impl AssetLoader for WasmAssetLoader {
 }
 
 async fn run_async() -> Result<(), JsValue> {
+    // Choose the producer for this page (docs/mle.md Track A2/C5): an MLE
+    // entry declared by the page runs through the in-runtime interpreter;
+    // otherwise the wasm_bindgen bridge to the F# game module. The concrete
+    // WasmGame stays the completion target for async pushes (fetch results,
+    // WebSocket events — see its doc): the MLE producer has no effects yet
+    // (its drains return "[]"), so no completion ever needs to reach it.
+    // Revisit when MLE grows effects (Track C4b-2).
+    let mut game: Box<dyn GameProducer> = match mle_game_path() {
+        Some(path) => match create_mle_game(&path).await {
+            Ok(game) => Box::new(game),
+            Err(message) => {
+                let rendered = format!("[mle] error: {message}");
+                web_sys::console::error_1(&rendered.as_str().into());
+                return Err(JsValue::from_str(&rendered));
+            }
+        },
+        None => Box::new(WasmGame),
+    };
+
     // Load game
     unsafe {
         // Create a context from a WebGL2 context on wasm32 targets
@@ -904,14 +960,6 @@ async fn run_async() -> Result<(), JsValue> {
         gl.clear_color(0.1, 0.2, 0.3, 1.0);
 
         gl.enable(glow::DEPTH_TEST);
-        // The producer this loop drives — the wasm_bindgen bridge to the game
-        // module, behind the shared GameProducer seam (docs/mle.md, Track A2).
-        // Deliberately the concrete type, not a Box<dyn>: the async completions
-        // (fetch results, WebSocket events) push through their own stateless
-        // WasmGame, so swapping in a different web producer requires threading
-        // a shared handle into perform_and_push/ws_connect first — a boxed
-        // producer here would compile and then silently lose those events.
-        let mut game = WasmGame;
         let ws_state = Rc::new(RefCell::new(WsClient::default()));
         let f = Rc::new(RefCell::new(None));
         let g = f.clone();
@@ -970,22 +1018,27 @@ async fn run_async() -> Result<(), JsValue> {
 
             last_time = now;
 
+            // Deliver page input queued since the last frame (the MLE path's
+            // `mle_*` exports; empty and free on the F# path, whose page feeds
+            // the game module directly).
+            mle_game::drain_input(&mut *game);
+
             game.tick(frame_time.clone());
 
             // Perform any networking commands this frame's tick queued; results
             // are pushed back into the inbox asynchronously and decoded by a later
             // tick (see dispatch_net_commands).
-            dispatch_net_commands(&game);
+            dispatch_net_commands(&*game);
             // Play any one-shot sounds this frame's tick queued (fetch + decode
             // the first time, then from the cache).
-            dispatch_audio_commands(&game);
-            dispatch_conn_commands(&game, &ws_state);
+            dispatch_audio_commands(&*game);
+            dispatch_conn_commands(&*game, &ws_state);
 
             let frame: Frame = game.render(frame_time.clone());
 
             // Soundscape: aim the listener from this frame's camera, then
             // reconcile the desired looping voices against the live ones.
-            update_soundscape(&game, &frame.camera);
+            update_soundscape(&*game, &frame.camera);
 
             // Match the drawable buffer to the canvas's displayed (CSS) size,
             // scaled for HiDPI, so the view follows browser/window resizes. In

--- a/runtime/functor-runtime-web/src/mle_game.rs
+++ b/runtime/functor-runtime-web/src/mle_game.rs
@@ -1,0 +1,446 @@
+//! The MLE producer for the web shell (docs/mle.md Track C5): the wasm
+//! sibling of the desktop runner's `mle_game.rs`, behind the same
+//! `GameProducer` seam. Same load-time contract validation and per-frame
+//! semantics — the MVU pair (subscriptions fold through `update` before
+//! `tick`), the optional `physics` hook (tick → physics → draw), a bad frame
+//! keeps the last good model/frame, per-frame errors dedupe — but adapted to
+//! the browser:
+//!
+//! - the `.mle` source arrives over HTTP (fetched by `run_async` from the dev
+//!   server, which serves the project directory) instead of the filesystem;
+//! - no hot reload (the browser reloads the whole page — like the F# bridge's
+//!   `check_hot_reload` no-op);
+//! - no per-frame perf stats (`std::time::Instant` panics on wasm; the C6
+//!   perf gate measures natively);
+//! - input events arrive from the page via the `mle_*` wasm exports below,
+//!   queued and drained by the frame loop each frame before `tick` (DOM
+//!   handlers fire between rAF callbacks, never mid-frame).
+
+use std::cell::RefCell;
+
+use functor_runtime_common::mle_prelude::{
+    frame_value, physics_scene_value, sub_messages_for_frame, FunctorHost,
+};
+use functor_runtime_common::physics;
+use functor_runtime_common::protocol::GameProducer;
+use functor_runtime_common::ui::View;
+use functor_runtime_common::{Frame, FrameTime};
+use mle::{Session, Value};
+use wasm_bindgen::prelude::*;
+
+pub struct MleWebGame {
+    path: String,
+    src: String,
+    session: Session,
+    model: Value,
+    has_input: bool,
+    has_mouse_move: bool,
+    has_mouse_wheel: bool,
+    has_subscriptions: bool,
+    /// The previous frame's total-time, the left edge of the `(prev, tts]`
+    /// window subscriptions fire over. `None` until the first frame has run
+    /// (nothing fires on frame one — mirroring the F# executor and the
+    /// desktop producer).
+    prev_tts: Option<f64>,
+    has_physics: bool,
+    /// The last successfully drawn frame, kept so a bad draw shows the last
+    /// good picture instead of a blank.
+    last_frame: Frame,
+    /// The last per-frame error logged, to avoid flooding the console at
+    /// 60fps with the same message (a persistent error logs once until it
+    /// changes).
+    last_error: Option<String>,
+}
+
+impl MleWebGame {
+    /// Load, check, and contract-validate fetched game source — the web
+    /// counterpart of the desktop `load_game`. Errors come back as fully
+    /// rendered strings (`path:line:col: message`) for `run_async` to fail
+    /// loud with (there is no keep-running fallback: a page load either gets
+    /// a valid game or a console error).
+    pub fn create(path: &str, src: String) -> Result<MleWebGame, String> {
+        let render = |stage: &str, span: mle::Span, message: &str| {
+            let (line, col) = mle::line_col(&src, span.start);
+            format!("cannot {stage} {path}:{line}:{col}: {message}")
+        };
+        let program = mle::parse(&src).map_err(|e| render("parse", e.span, &e.message))?;
+        let module = mle::lower(program).map_err(|e| render("load", e.span, &e.message))?;
+        // Type diagnostics are advisory in the dev loop: warn, keep going
+        // (the CLI's `build` is the strict gate).
+        for diag in mle::check(&module) {
+            let (line, col) = mle::line_col(&src, diag.span.start);
+            web_sys::console::warn_1(
+                &format!("warning: {path}:{line}:{col}: {}", diag.message).into(),
+            );
+        }
+        let session = Session::load(&module, &mut FunctorHost)
+            .map_err(|f| render("load", f.error.span, &f.error.message))?;
+        // The producer contract is knowable at load — fail here, not once per
+        // frame: `init` must be a model VALUE, `tick`/`draw` functions of the
+        // right arity.
+        let init = session
+            .global("init")
+            .ok_or_else(|| format!("{path} has no top-level `let init = …`"))?;
+        if matches!(
+            init,
+            Value::Closure(_) | Value::Builtin(_) | Value::HostFn(_)
+        ) {
+            return Err(format!(
+                "{path}: `init` must be a model value, not a function"
+            ));
+        }
+        require_function(path, &session, "tick", 3)?;
+        require_function(path, &session, "draw", 2)?;
+        // `input` is optional (many games are non-interactive), but when
+        // present it must honor the contract: (model, key, isDown) => model.
+        let has_input = session.global("input").is_some();
+        if has_input {
+            require_function(path, &session, "input", 3)?;
+        }
+        // Same deal for the mouse: `mouseMove(model, x, y)` in window pixels,
+        // `mouseWheel(model, delta)`.
+        let has_mouse_move = session.global("mouseMove").is_some();
+        if has_mouse_move {
+            require_function(path, &session, "mouseMove", 3)?;
+        }
+        let has_mouse_wheel = session.global("mouseWheel").is_some();
+        if has_mouse_wheel {
+            require_function(path, &session, "mouseWheel", 2)?;
+        }
+        // The MVU pair: `subscriptions(model)` declares timers whose fired
+        // messages fold through `update(model, msg)` — so subscriptions
+        // without an update have nowhere to deliver.
+        let has_subscriptions = session.global("subscriptions").is_some();
+        if has_subscriptions {
+            require_function(path, &session, "subscriptions", 1)?;
+            if session.global("update").is_none() {
+                return Err(format!(
+                    "{path}: `subscriptions` produces messages but there is no \
+`let update = (model, msg) => …` to receive them"
+                ));
+            }
+        }
+        if session.global("update").is_some() {
+            require_function(path, &session, "update", 2)?;
+        }
+        // Optional physics: `physics(model) => Physics.scene(…)` declares the
+        // bodies that should exist; the host reconciles + fixed-steps the
+        // world after each tick (docs/physics.md). Rapier is pure Rust, so
+        // the world runs in the browser exactly as it does natively.
+        let has_physics = session.global("physics").is_some();
+        if has_physics {
+            require_function(path, &session, "physics", 1)?;
+        }
+        web_sys::console::log_1(&format!("[mle] loaded {path}").into());
+        Ok(MleWebGame {
+            path: path.to_string(),
+            src,
+            session,
+            model: init,
+            has_input,
+            has_mouse_move,
+            has_mouse_wheel,
+            has_subscriptions,
+            prev_tts: None,
+            has_physics,
+            last_frame: empty_frame(),
+            last_error: None,
+        })
+    }
+
+    /// Fire subscription timers over `(prev_tts, tts]` and fold their
+    /// messages through `update`, before this frame's `tick` — the message
+    /// drain seam (docs/mle.md C4b-2), same semantics as the desktop
+    /// producer. Errors report per message and processing continues.
+    fn pump_subscriptions(&mut self, tts: f64) {
+        // Advance the window even without subscriptions (or on frame one),
+        // so the edge is always sane.
+        let prev = self.prev_tts.replace(tts);
+        if !self.has_subscriptions {
+            return;
+        }
+        let Some(prev) = prev else {
+            return;
+        };
+        let subs =
+            match self
+                .session
+                .call("subscriptions", vec![self.model.clone()], &mut FunctorHost)
+            {
+                Ok(subs) => subs,
+                Err(err) => return self.frame_error("subscriptions", &err),
+            };
+        let msgs = match sub_messages_for_frame(&subs, prev, tts) {
+            Ok(msgs) => msgs,
+            Err(message) => return self.log_once(format!("[mle] {message}")),
+        };
+        for msg in msgs {
+            match self
+                .session
+                .call("update", vec![self.model.clone(), msg], &mut FunctorHost)
+            {
+                Ok(model) => self.model = model,
+                Err(err) => self.frame_error("update", &err),
+            }
+        }
+    }
+
+    /// The frame's physics phase (docs/physics.md): ask the game what bodies
+    /// should exist, reconcile the singleton world to match, and advance it
+    /// in fixed substeps. Runs after `tick` so declarations come from the
+    /// settled model, and before `render` so `Physics.position`/
+    /// `Physics.transformed` in `draw` read the just-stepped world.
+    fn step_physics(&mut self, dts: f32) {
+        if !self.has_physics {
+            return;
+        }
+        let args = vec![self.model.clone()];
+        match self.session.call("physics", args, &mut FunctorHost) {
+            Ok(value) => match physics_scene_value(&value) {
+                Some(scene) => {
+                    physics::with_world(physics::DEFAULT_WORLD, |w| {
+                        w.reconcile(scene);
+                        w.step_frame(dts);
+                    });
+                }
+                None => self.log_once(format!(
+                    "[mle] physics must return Physics.scene(gx, gy, gz, [body, …]), got {}",
+                    value.kind_name()
+                )),
+            },
+            Err(err) => self.frame_error("physics", &err),
+        }
+    }
+
+    /// Report a per-frame error with its source position, once per distinct
+    /// message (a 60fps loop must not flood the console with one persistent
+    /// bug).
+    fn frame_error(&mut self, stage: &str, err: &mle::RunError) {
+        let (line, col) = mle::line_col(&self.src, err.span.start);
+        let rendered = format!(
+            "[mle] {stage} error at {}:{line}:{col}: {}",
+            self.path, err.message
+        );
+        self.log_once(rendered);
+    }
+
+    fn log_once(&mut self, rendered: String) {
+        if self.last_error.as_deref() != Some(rendered.as_str()) {
+            web_sys::console::error_1(&rendered.as_str().into());
+            self.last_error = Some(rendered);
+        }
+    }
+}
+
+impl GameProducer for MleWebGame {
+    // Hot reload is native-only (docs/mle.md C3); on web, reload the page.
+    fn check_hot_reload(&mut self, _frame_time: FrameTime) {}
+
+    fn tick(&mut self, frame_time: FrameTime) {
+        // Subscriptions first, so `tick` sees a model that has absorbed this
+        // frame's messages (the F# executor's ordering).
+        self.pump_subscriptions(frame_time.tts as f64);
+        let args = vec![
+            self.model.clone(),
+            Value::Number(frame_time.dts as f64),
+            Value::Number(frame_time.tts as f64),
+        ];
+        match self.session.call("tick", args, &mut FunctorHost) {
+            Ok(model) => self.model = model,
+            Err(err) => self.frame_error("tick", &err),
+        }
+        self.step_physics(frame_time.dts);
+    }
+
+    fn key_event(&mut self, code: i32, is_down: bool) {
+        // The optional `input` entry point: (model, key, isDown) => model.
+        // Keys cross as their canonical names ("W", "Up", "Space") — the same
+        // spelling the desktop producer and SDK use.
+        if !self.has_input {
+            return;
+        }
+        let Some(key) = functor_runtime_common::Key::from_i32(code) else {
+            return;
+        };
+        let args = vec![
+            self.model.clone(),
+            Value::String(std::rc::Rc::from(format!("{key:?}").as_str())),
+            Value::Bool(is_down),
+        ];
+        match self.session.call("input", args, &mut FunctorHost) {
+            Ok(model) => self.model = model,
+            Err(err) => self.frame_error("input", &err),
+        }
+    }
+
+    fn mouse_move(&mut self, x: i32, y: i32) {
+        if !self.has_mouse_move {
+            return;
+        }
+        let args = vec![
+            self.model.clone(),
+            Value::Number(x as f64),
+            Value::Number(y as f64),
+        ];
+        match self.session.call("mouseMove", args, &mut FunctorHost) {
+            Ok(model) => self.model = model,
+            Err(err) => self.frame_error("mouseMove", &err),
+        }
+    }
+
+    fn mouse_wheel(&mut self, delta: i32) {
+        if !self.has_mouse_wheel {
+            return;
+        }
+        let args = vec![self.model.clone(), Value::Number(delta as f64)];
+        match self.session.call("mouseWheel", args, &mut FunctorHost) {
+            Ok(model) => self.model = model,
+            Err(err) => self.frame_error("mouseWheel", &err),
+        }
+    }
+
+    fn render(&mut self, frame_time: FrameTime) -> Frame {
+        let args = vec![self.model.clone(), Value::Number(frame_time.tts as f64)];
+        match self.session.call("draw", args, &mut FunctorHost) {
+            Ok(value) => match frame_value(&value) {
+                Some(frame) => self.last_frame = frame.clone(),
+                None => {
+                    let rendered = format!(
+                        "[mle] draw must return Frame.create(camera, scene), got {}",
+                        value.kind_name()
+                    );
+                    self.log_once(rendered);
+                }
+            },
+            Err(err) => self.frame_error("draw", &err),
+        }
+        // On failure this is the last good frame — a bad draw must not blank
+        // the canvas.
+        self.last_frame.clone()
+    }
+
+    fn ui(&self) -> View {
+        View::empty()
+    }
+
+    fn state_debug(&self) -> String {
+        self.model.to_string()
+    }
+
+    // MLE has no effects yet (docs/mle.md Track B): nothing to drain, nothing
+    // pushed back.
+    fn net_drain_commands(&self) -> String {
+        "[]".to_string()
+    }
+    fn net_push_http_response(&mut self, _token: i32, _status: i32, _body: String) {}
+    fn net_push_http_error(&mut self, _token: i32, _message: String) {}
+    fn audio_drain_commands(&self) -> String {
+        "[]".to_string()
+    }
+    fn audio_scene_json(&self) -> String {
+        "{\"sources\":[]}".to_string()
+    }
+    fn net_drain_conn_commands(&self) -> String {
+        "[]".to_string()
+    }
+    fn net_push_connected(&mut self, _key: String, _conn: i32) {}
+    fn net_push_conn_message(&mut self, _key: String, _conn: i32, _text: String) {}
+    fn net_push_disconnected(&mut self, _key: String, _conn: i32) {}
+    fn net_push_conn_error(&mut self, _key: String, _conn: i32, _message: String) {}
+    fn audio_push_finished(&mut self, _token: i32) {}
+
+    fn quit(&mut self) {}
+}
+
+/// `name` must be a function of `arity` params — a contract violation is
+/// reportable at load, and the alternative is one error per frame, forever.
+fn require_function(path: &str, session: &Session, name: &str, arity: usize) -> Result<(), String> {
+    match session.global(name) {
+        Some(Value::Closure(closure)) if closure.params.len() == arity => Ok(()),
+        Some(Value::Closure(closure)) => Err(format!(
+            "{path}: `{name}` must take {arity} parameter(s), takes {}",
+            closure.params.len()
+        )),
+        Some(other) => Err(format!(
+            "{path}: `{name}` must be a function, got {}",
+            other.kind_name()
+        )),
+        None => Err(format!("{path} has no top-level `let {name} = …`")),
+    }
+}
+
+fn empty_frame() -> Frame {
+    use cgmath::{Matrix4, SquareMatrix};
+    Frame::new(
+        functor_runtime_common::Camera::default(),
+        functor_runtime_common::Scene3D {
+            obj: functor_runtime_common::SceneObject::Group(vec![]),
+            xform: Matrix4::identity(),
+        },
+    )
+}
+
+// --- Page → producer input bridge. ------------------------------------------
+//
+// The F# path feeds input straight into the game wasm module (index.html calls
+// `key_event_wasm` etc. on it); the MLE game lives *inside* this runtime, so
+// the MLE index page calls the `mle_*` exports below instead. Events queue
+// here and the frame loop drains them into the producer before each tick.
+
+enum InputEvent {
+    Key { code: i32, is_down: bool },
+    MouseMove { x: i32, y: i32 },
+    MouseWheel { delta: i32 },
+}
+
+thread_local! {
+    static INPUT_QUEUE: RefCell<Vec<InputEvent>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Far more events than one frame can produce; if the frame loop never starts
+/// (a failed game load leaves the page's handlers wired but nothing
+/// draining), the queue must not grow forever.
+const INPUT_QUEUE_CAP: usize = 1024;
+
+fn push_input(event: InputEvent) {
+    INPUT_QUEUE.with(|q| {
+        let mut q = q.borrow_mut();
+        if q.len() < INPUT_QUEUE_CAP {
+            q.push(event);
+        }
+    });
+}
+
+/// Deliver a keyboard event (`code` = `functor_runtime_common::Key` as i32,
+/// the same wire mapping index.html uses for the F# path).
+#[wasm_bindgen]
+pub fn mle_key_event(code: i32, is_down: bool) {
+    push_input(InputEvent::Key { code, is_down });
+}
+
+/// Deliver a mouse position in window pixels (the page accumulates pointer-lock
+/// movement deltas, matching the desktop's absolute cursor position).
+#[wasm_bindgen]
+pub fn mle_mouse_move(x: i32, y: i32) {
+    push_input(InputEvent::MouseMove { x, y });
+}
+
+/// Deliver a mouse-wheel event (vertical scroll offset, ±1 per notch).
+#[wasm_bindgen]
+pub fn mle_mouse_wheel(delta: i32) {
+    push_input(InputEvent::MouseWheel { delta });
+}
+
+/// Drain the queued page input into the producer, in arrival order. Called by
+/// the frame loop before `tick`. Empty (and free) on the F# path — its page
+/// never calls the `mle_*` exports.
+pub fn drain_input(game: &mut dyn GameProducer) {
+    let events = INPUT_QUEUE.with(|q| std::mem::take(&mut *q.borrow_mut()));
+    for event in events {
+        match event {
+            InputEvent::Key { code, is_down } => game.key_event(code, is_down),
+            InputEvent::MouseMove { x, y } => game.mouse_move(x, y),
+            InputEvent::MouseWheel { delta } => game.mouse_wheel(delta),
+        }
+    }
+}


### PR DESCRIPTION
## What

MLE games run in the browser (roadmap C5): the interpreter compiles to wasm32, the `.mle` **source ships as text** and is fetched + interpreted by the web runtime — nothing compiles in the game loop, same as native.

- **`MleWebGame`** (`runtime/functor-runtime-web/src/mle_game.rs`) mirrors the desktop producer's semantics line-for-line: load-contract validation, per-frame error dedupe + last-good-frame, the **C4b-2 subscriptions pump** (`prev_tts` window → `sub_messages_for_frame` → fold through `update` before `tick`), and **physics** (`step_physics` reconcile + fixed-step — rapier3d is pure Rust and was already in the wasm dep tree). Hot reload stays native-only; on wasm, edits are one page-reload away (the dev server reads the file per request).
- **Producer selection**: `run_async` boxes `dyn GameProducer` and picks MLE vs the F# `WasmGame` bridge via `window.__mleGamePath`; `index-mle.html` wires keys/pointer-lock/wheel into new `mle_*` exports through a capped input queue.
- **CLI**: `functor -d proj run wasm` serves MLE projects at 127.0.0.1:8080 (mirrors the F# arm, `--no-open` included); `build wasm` works; `develop` explains reload-the-page. An entry that escapes the project dir (`../`, absolute) fails loud at launch with a teaching error instead of a browser 404.

## Review

Built by a subagent that ran the full cross-engine `/xreview` itself (Claude + Codex, no Critical/High): entry-escape guard, per-segment `encodeURIComponent`, `</script>`-in-entry escaping (tested), input-queue cap, and flagged-for-B6 comments where net/audio completions still route to the F# producer. Known-and-accepted: the browser-opens-before-server-binds race (inherited verbatim from the F# arm) and ~250 lines of producer mirroring vs desktop (extraction into shared code is a natural follow-up once B6 settles the contract).

I then rebased onto current main — one conflict (`mle_project.rs`, where main's new `push`/reload-source feature and this branch's `run_wasm` landed in the same impl) resolved as a union — and re-verified: wasm32 check clean, CLI 5/5 (incl. the new entry-guard + escaping tests), `build wasm` + `run wasm` probes serve the bundle and the `.mle` source.

## Proof it renders (headless Chromium, driven by the agent)

![mle-hello on wasm](https://gist.githubusercontent.com/tommy-xr/9c1d6f8ef5b04fb7e32f95096ad86c70/raw/mle-wasm-frame.png)

<sub>`examples/mle-hello` interpreted in the browser: the ring of gradient cubes + centerpiece sphere. A two-capture probe also verified the **Beat subscription folds through `update` on wasm** — sphere yellow at beat 0 → magenta at beat 1, the exact color arithmetic of `update`.</sub>

Manual check: `./target/debug/functor -d examples/mle-hello run wasm` → ring of 12 bobbing gradient cubes around a pulsing sphere whose color snaps once per second; canvas click pointer-locks.

## Verification

- `cargo build -p mle --target wasm32-unknown-unknown` clean; `cargo check -p functor-runtime-web --target wasm32-unknown-unknown` 0 errors (warning count identical to main)
- `npm run build:cli` clean (no uuid regression); `functor build wasm` → `[mle] …: ok`; `run wasm --no-open` serves `/`, `/game.mle`, `/pkg/*.js`, `/pkg/*.wasm` (curled)
- `cargo test -p functor_runtime_common` 116, `-p functor-cli` 5/5, `-p mle` green
- docs/mle.md C5 → [x]; skill's CLI section mentions `run wasm`

This also unblocks **D4** (live game preview in the VSCode extension).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
