### PR TITLE
feat(oculus): Quest OpenXR runtime shell — cross-compiles + packages to APK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,7 @@ perf*
 # Local Journal
 .journal.md
 *.vsix
+
+# Android builds use an isolated target dir (a cleaner/analyzer race on the
+# shared target/ corrupts cross-compile fingerprints)
+target-android/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "runtime/functor-netsim",
     "runtime/functor-runtime-common",
     "runtime/functor-runtime-desktop",
+    "runtime/functor-runtime-oculus",
     "runtime/functor-runtime-web",
     "src",
     "tools/mle-lsp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ members = [
     "runtime/functor-netsim",
     "runtime/functor-runtime-common",
     "runtime/functor-runtime-desktop",
-    "runtime/functor-runtime-oculus",
     "runtime/functor-runtime-web",
     "src",
     "tools/mle-lsp",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
     "clean": "git clean -fdX",
 
     "build:cli": "cargo build --bin functor-runner && wasm-pack build runtime/functor-runtime-web --target=web && cargo build --bin functor",
+    "build:oculus": "ANDROID_HOME=${ANDROID_HOME:-/opt/homebrew/share/android-sdk} CARGO_TARGET_DIR=target-android cargo ndk -t arm64-v8a build -p functor_runtime_oculus",
+    "build:oculus:apk": "ANDROID_HOME=${ANDROID_HOME:-/opt/homebrew/share/android-sdk} ANDROID_NDK_ROOT=${ANDROID_NDK_ROOT:-/opt/homebrew/share/android-sdk/ndk/24.0.8215888} CARGO_TARGET_DIR=$PWD/target-android cargo apk build --manifest-path runtime/functor-runtime-oculus/Cargo.toml",
     "fetch:assets": "node scripts/fetch-assets.mjs",
     "generate:audio": "node scripts/generate-audio.mjs",
     "test:golden": "npm run build:examples:hello:rust && cargo build --manifest-path examples/hello/build-native/Cargo.toml && npm run build:examples:lighting:rust && cargo build --manifest-path examples/lighting/build-native/Cargo.toml && npm run build:examples:primitives:rust && cargo build --manifest-path examples/primitives/build-native/Cargo.toml && npm run build:examples:synthwave:rust && cargo build --manifest-path examples/synthwave/build-native/Cargo.toml && cargo test -p functor-runtime-desktop --test golden -- --ignored --nocapture",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "clean": "git clean -fdX",
 
     "build:cli": "cargo build --bin functor-runner && wasm-pack build runtime/functor-runtime-web --target=web && cargo build --bin functor",
-    "build:oculus": "ANDROID_HOME=${ANDROID_HOME:-/opt/homebrew/share/android-sdk} CARGO_TARGET_DIR=target-android cargo ndk -t arm64-v8a build -p functor_runtime_oculus",
+    "build:oculus": "ANDROID_HOME=${ANDROID_HOME:-/opt/homebrew/share/android-sdk} CARGO_TARGET_DIR=target-android cargo ndk -t arm64-v8a build --manifest-path runtime/functor-runtime-oculus/Cargo.toml",
     "build:oculus:apk": "ANDROID_HOME=${ANDROID_HOME:-/opt/homebrew/share/android-sdk} ANDROID_NDK_ROOT=${ANDROID_NDK_ROOT:-/opt/homebrew/share/android-sdk/ndk/24.0.8215888} CARGO_TARGET_DIR=$PWD/target-android cargo apk build --manifest-path runtime/functor-runtime-oculus/Cargo.toml",
     "fetch:assets": "node scripts/fetch-assets.mjs",
     "generate:audio": "node scripts/generate-audio.mjs",

--- a/runtime/functor-runtime-common/src/shadow.rs
+++ b/runtime/functor-runtime-common/src/shadow.rs
@@ -214,11 +214,17 @@ pub fn render_shadow_pass(
         // On desktop/web that's the default framebuffer (0) and restoring is a
         // no-op — but XR shells render into per-eye swapchain FBOs, and
         // resetting to the default there would send the whole forward pass
-        // into an invisible pbuffer.
+        // into an invisible pbuffer. Reconstructing a framebuffer key from
+        // the GL query is native-only (glow's web backend uses opaque slotmap
+        // keys); on wasm the canvas default framebuffer IS the target, so
+        // `None` is exact there.
+        #[cfg(not(target_arch = "wasm32"))]
         let previous_fbo = std::num::NonZeroU32::new(
             gl.get_parameter_i32(glow::DRAW_FRAMEBUFFER_BINDING) as u32,
         )
         .map(glow::NativeFramebuffer);
+        #[cfg(target_arch = "wasm32")]
+        let previous_fbo: Option<glow::Framebuffer> = None;
         gl.bind_framebuffer(glow::FRAMEBUFFER, Some(shadow_map.fbo));
         gl.viewport(0, 0, shadow_map.size as i32, shadow_map.size as i32);
         // Disable the scissor test for the duration of the pass: the forward pass

--- a/runtime/functor-runtime-common/src/shadow.rs
+++ b/runtime/functor-runtime-common/src/shadow.rs
@@ -210,6 +210,15 @@ pub fn render_shadow_pass(
     let identity = Matrix4::identity();
 
     unsafe {
+        // Remember the caller's render target and restore it after the pass.
+        // On desktop/web that's the default framebuffer (0) and restoring is a
+        // no-op — but XR shells render into per-eye swapchain FBOs, and
+        // resetting to the default there would send the whole forward pass
+        // into an invisible pbuffer.
+        let previous_fbo = std::num::NonZeroU32::new(
+            gl.get_parameter_i32(glow::DRAW_FRAMEBUFFER_BINDING) as u32,
+        )
+        .map(glow::NativeFramebuffer);
         gl.bind_framebuffer(glow::FRAMEBUFFER, Some(shadow_map.fbo));
         gl.viewport(0, 0, shadow_map.size as i32, shadow_map.size as i32);
         // Disable the scissor test for the duration of the pass: the forward pass
@@ -236,6 +245,6 @@ pub fn render_shadow_pass(
             &depth_material,
         );
 
-        gl.bind_framebuffer(glow::FRAMEBUFFER, None);
+        gl.bind_framebuffer(glow::FRAMEBUFFER, previous_fbo);
     }
 }

--- a/runtime/functor-runtime-oculus/Cargo.toml
+++ b/runtime/functor-runtime-oculus/Cargo.toml
@@ -7,6 +7,13 @@ edition = "2021"
 # cdylib. See README.md for the build pipeline and src/lib.rs for the
 # architecture; stack rationale (openxr from crates.io, android-activity,
 # cargo-ndk) is documented there too.
+#
+# Its OWN workspace, deliberately outside the root one (like the examples'
+# build-native crates): android-activity → ndk-sys hard-fails to compile for
+# non-Android targets, so root-workspace membership would break every bare
+# `cargo build`/`cargo check`/rust-analyzer run on the host.
+[workspace]
+
 [lib]
 crate-type = ["cdylib"]
 

--- a/runtime/functor-runtime-oculus/Cargo.toml
+++ b/runtime/functor-runtime-oculus/Cargo.toml
@@ -1,0 +1,52 @@
+[package]
+name = "functor_runtime_oculus"
+version = "0.1.0"
+edition = "2021"
+
+# The Quest (Meta Horizon OS) runtime shell: an OpenXR + EGL/GLES Android
+# cdylib. See README.md for the build pipeline and src/lib.rs for the
+# architecture; stack rationale (openxr from crates.io, android-activity,
+# cargo-ndk) is documented there too.
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+functor_runtime_common = { path = "../functor-runtime-common" }
+# Default `loaded` feature: dlopens libopenxr_loader.so at runtime — the APK
+# must bundle Meta's loader (see README), but plain `cargo ndk build` needs
+# nothing. (shock2quest-era vendoring of openxrs is obsolete: the GLES/Android
+# support it back-ported shipped upstream in openxr 0.18, Feb 2024.)
+openxr = "0.21"
+# Modern replacement for the deprecated ndk-glue: provides android_main and
+# feeds ndk-context, which openxr's initialize_android_loader() reads.
+android-activity = { version = "0.6", features = ["native-activity"] }
+khronos-egl = { version = "6.0", features = ["dynamic"] }
+libloading = "0.8"
+glow = "0.17"
+cgmath = "0.18"
+log = "0.4"
+android_logger = "0.14"
+
+# cargo-apk packaging metadata (`cargo apk build` from this directory).
+# functor-runner-on-Quest is a tool APK, like functor-runner is a binary: the
+# game arrives over the network (POST /reload-source), not baked in.
+[package.metadata.android]
+package = "dev.functor.runner"
+build_targets = ["aarch64-linux-android"]
+runtime_libs = "lib"
+
+[package.metadata.android.sdk]
+min_sdk_version = 29
+target_sdk_version = 32
+
+[[package.metadata.android.uses_feature]]
+name = "android.hardware.vr.headtracking"
+required = true
+version = 1
+
+[[package.metadata.android.application.activity.intent_filter]]
+actions = ["android.intent.action.MAIN"]
+categories = [
+    "com.oculus.intent.category.VR",
+    "android.intent.category.LAUNCHER",
+]

--- a/runtime/functor-runtime-oculus/README.md
+++ b/runtime/functor-runtime-oculus/README.md
@@ -1,0 +1,61 @@
+# functor-runtime-oculus
+
+The Quest (Meta Horizon OS) runtime shell: an OpenXR + EGL/GLES Android
+`cdylib` that renders through the same `functor_runtime_common::render_frame`
+path as the desktop and web shells. Like `functor-runner` on desktop, this is
+a **tool APK, built once** — games are not baked in; they arrive as MLE source
+over the network (the `POST /reload-source` remote-develop loop).
+
+## Status
+
+Phase 1: the OpenXR shell cross-compiles (instance/session/swapchains/frame
+loop, per-eye rendering with head-pose cameras, placeholder scene). Device
+bring-up (MLE producer, network reload, controller input, asymmetric-frustum
+projection) happens against real hardware.
+
+## Prerequisites
+
+- Android SDK with **NDK** (any recent; developed against 24.x) — set
+  `ANDROID_HOME` (e.g. `/opt/homebrew/share/android-sdk`)
+- `rustup target add aarch64-linux-android`
+- `cargo install cargo-ndk` (build the `.so`), `cargo install cargo-apk`
+  (package the APK)
+
+## Build the dylib (no device needed)
+
+```sh
+npm run build:oculus
+# = ANDROID_HOME=… cargo ndk -t arm64-v8a build -p functor_runtime_oculus
+```
+
+Android builds use `CARGO_TARGET_DIR=target-android` (a cleaner/analyzer race
+on the shared `target/` corrupts cross-compile fingerprints).
+
+## Package + install the APK
+
+`cargo apk` reads the `[package.metadata.android]` section of Cargo.toml. It
+additionally needs `ANDROID_NDK_ROOT` and `platforms;android-32` installed
+(`sdkmanager --install 'platforms;android-32'`):
+
+```sh
+npm run build:oculus:apk   # → target-android/debug/apk/functor_runtime_oculus.apk (debug-signed)
+# on-device (from runtime/functor-runtime-oculus, same env vars):
+cargo apk run              # builds + adb installs + launches on the headset
+```
+
+**One manual artifact:** OpenXR on Quest needs **Meta's loader**. Download the
+[Meta OpenXR Mobile SDK](https://developer.oculus.com/downloads/package/oculus-openxr-mobile-sdk/)
+and copy `OpenXR/Libs/Android/arm64-v8a/Release/libopenxr_loader.so` to
+`lib/arm64-v8a/` in this directory (gitignored; `runtime_libs = "lib"` bundles
+it into the APK). Without it the app aborts at startup with a clear message.
+Do not substitute the Khronos loader — Meta's is the supported path.
+
+## Architecture notes
+
+- Stack: crates.io `openxr` 0.21 (`loaded` feature) + `android-activity`
+  (native-activity) + `khronos-egl`. shock2quest's vendored openxrs fork is
+  obsolete — the GLES/Android session support it back-ported shipped upstream
+  in openxr 0.18 (Feb 2024).
+- Quest gotchas inherited from shock2quest (see comments in `src/lib.rs`):
+  manual EGL config selection (no `eglChooseConfig`), SRGB8_ALPHA8 swapchains,
+  pbuffer-backed context, two swapchains / no multiview (yet).

--- a/runtime/functor-runtime-oculus/lib/arm64-v8a/.gitignore
+++ b/runtime/functor-runtime-oculus/lib/arm64-v8a/.gitignore
@@ -1,0 +1,2 @@
+# Meta OpenXR loader goes here (see README) — never commit it
+*.so

--- a/runtime/functor-runtime-oculus/src/lib.rs
+++ b/runtime/functor-runtime-oculus/src/lib.rs
@@ -1,0 +1,478 @@
+//! The Quest (Meta Horizon OS) runtime shell: OpenXR + EGL/GLES, rendering
+//! through the same `functor_runtime_common::render_frame` path as the
+//! desktop and web shells.
+//!
+//! Phase 1 (this file): a complete, honest OpenXR shell that cross-compiles —
+//! android_main → EGL context → OpenXR instance/session → per-eye swapchains →
+//! frame loop rendering a `Frame` per eye with head-pose cameras. The scene is
+//! a placeholder until device bring-up wires the MLE producer + network
+//! reload (`POST /reload-source`) so games arrive over the network — the
+//! runtime APK ships once, games are text.
+//!
+//! Structure mirrors shock2quest's `runtimes/oculus_runtime` (the reference
+//! implementation) with its hard-won Quest gotchas kept:
+//! - EGL config chosen MANUALLY, not via `eglChooseConfig` (Android injects
+//!   multisample flags into the match).
+//! - A tiny pbuffer surface backs the context; OpenXR renders into swapchain
+//!   images, never a window surface.
+//! - Swapchains are `SRGB8_ALPHA8`; `FRAMEBUFFER_SRGB` must NOT be enabled on
+//!   top (double-sRGB washout). GLES has no GL_FRAMEBUFFER_SRGB toggle — the
+//!   sRGB encode happens because the swapchain format says so.
+//! - Two swapchains, one per eye, two render passes. Multiview
+//!   (`GL_OVR_multiview2`) is an optimization for later.
+//!
+//! Modernized vs shock2quest: crates.io `openxr` 0.21 (its vendored openxrs
+//! fork predates the 0.18 release that shipped GLES/Android support),
+//! `android-activity` instead of the deprecated `ndk-glue`.
+
+use std::sync::Arc;
+
+use android_activity::{AndroidApp, MainEvent, PollEvent};
+use cgmath::{Quaternion, Rotation, Vector3};
+use functor_runtime_common::asset::AssetCache;
+use functor_runtime_common::{Camera, Frame, FrameTime, SceneContext, Viewport};
+use khronos_egl as egl;
+use openxr as xr;
+
+/// GLES version to request. Quest 3 supports 3.2.
+const GLES_MAJOR: i32 = 3;
+const GLES_MINOR: i32 = 2;
+
+/// Color format for the swapchains (GL_SRGB8_ALPHA8): the compositor expects
+/// sRGB-encoded output, and an sRGB internal format makes GL do the encode.
+const COLOR_FORMAT: u32 = glow::SRGB8_ALPHA8;
+
+struct EglContext {
+    instance: egl::DynamicInstance<egl::EGL1_4>,
+    display: egl::Display,
+    config: egl::Config,
+    context: egl::Context,
+    /// A throwaway 16x16 pbuffer: EGL requires *some* surface to make the
+    /// context current, but all real rendering goes to swapchain FBOs.
+    _pbuffer: egl::Surface,
+}
+
+/// Create the EGL context OpenXR will share. The config is selected by hand:
+/// `eglChooseConfig` on Android silently prefers multisampled configs, which
+/// the XR compositor rejects — iterate `get_configs` and match exact
+/// attributes instead (the shock2quest lesson).
+fn init_egl() -> EglContext {
+    let lib = unsafe { libloading::Library::new("libEGL.so") }.expect("load libEGL.so");
+    let instance = unsafe { egl::DynamicInstance::<egl::EGL1_4>::load_required_from(lib) }
+        .expect("load EGL 1.4");
+
+    let display = unsafe { instance.get_display(egl::DEFAULT_DISPLAY) }.expect("EGL display");
+    instance.initialize(display).expect("EGL initialize");
+
+    let mut chosen = None;
+    let configs = {
+        let mut configs = Vec::with_capacity(64);
+        instance
+            .get_configs(display, &mut configs)
+            .expect("EGL configs");
+        configs
+    };
+    for config in configs {
+        let attr = |a: egl::Int| instance.get_config_attrib(display, config, a).unwrap_or(-1);
+        if attr(egl::RED_SIZE) == 8
+            && attr(egl::GREEN_SIZE) == 8
+            && attr(egl::BLUE_SIZE) == 8
+            && attr(egl::ALPHA_SIZE) == 8
+            && attr(egl::DEPTH_SIZE) == 0
+            && attr(egl::STENCIL_SIZE) == 0
+            && attr(egl::SAMPLES) == 0
+        {
+            chosen = Some(config);
+            break;
+        }
+    }
+    let config = chosen.expect("no 8888 EGL config without MSAA");
+
+    let context = instance
+        .create_context(
+            display,
+            config,
+            None,
+            &[
+                egl::CONTEXT_MAJOR_VERSION,
+                GLES_MAJOR,
+                egl::CONTEXT_MINOR_VERSION,
+                GLES_MINOR,
+                egl::NONE,
+            ],
+        )
+        .expect("EGL context");
+
+    let pbuffer = instance
+        .create_pbuffer_surface(
+            display,
+            config,
+            &[egl::WIDTH, 16, egl::HEIGHT, 16, egl::NONE],
+        )
+        .expect("EGL pbuffer");
+
+    instance
+        .make_current(display, Some(pbuffer), Some(pbuffer), Some(context))
+        .expect("EGL make_current");
+
+    EglContext {
+        instance,
+        display,
+        config,
+        context,
+        _pbuffer: pbuffer,
+    }
+}
+
+/// One eye's rendering target: an OpenXR swapchain plus an FBO + depth
+/// renderbuffer per swapchain image.
+struct EyeTarget {
+    swapchain: xr::Swapchain<xr::OpenGlEs>,
+    framebuffers: Vec<glow::Framebuffer>,
+    width: u32,
+    height: u32,
+}
+
+fn create_eye_target(
+    gl: &glow::Context,
+    session: &xr::Session<xr::OpenGlEs>,
+    view: &xr::ViewConfigurationView,
+) -> EyeTarget {
+    use glow::HasContext;
+    let width = view.recommended_image_rect_width;
+    let height = view.recommended_image_rect_height;
+    let swapchain = session
+        .create_swapchain(&xr::SwapchainCreateInfo {
+            create_flags: xr::SwapchainCreateFlags::EMPTY,
+            usage_flags: xr::SwapchainUsageFlags::COLOR_ATTACHMENT | xr::SwapchainUsageFlags::SAMPLED,
+            format: COLOR_FORMAT,
+            sample_count: 1,
+            width,
+            height,
+            face_count: 1,
+            array_size: 1,
+            mip_count: 1,
+        })
+        .expect("create swapchain");
+
+    // Wrap every swapchain image in an FBO with a fresh depth renderbuffer.
+    let framebuffers = swapchain
+        .enumerate_images()
+        .expect("swapchain images")
+        .into_iter()
+        .map(|texture| unsafe {
+            let fbo = gl.create_framebuffer().expect("fbo");
+            gl.bind_framebuffer(glow::FRAMEBUFFER, Some(fbo));
+            gl.framebuffer_texture_2d(
+                glow::FRAMEBUFFER,
+                glow::COLOR_ATTACHMENT0,
+                glow::TEXTURE_2D,
+                Some(glow::NativeTexture(std::num::NonZeroU32::new(texture).unwrap())),
+                0,
+            );
+            let depth = gl.create_renderbuffer().expect("depth rb");
+            gl.bind_renderbuffer(glow::RENDERBUFFER, Some(depth));
+            gl.renderbuffer_storage(
+                glow::RENDERBUFFER,
+                glow::DEPTH_COMPONENT24,
+                width as i32,
+                height as i32,
+            );
+            gl.framebuffer_renderbuffer(
+                glow::FRAMEBUFFER,
+                glow::DEPTH_ATTACHMENT,
+                glow::RENDERBUFFER,
+                Some(depth),
+            );
+            debug_assert_eq!(
+                gl.check_framebuffer_status(glow::FRAMEBUFFER),
+                glow::FRAMEBUFFER_COMPLETE
+            );
+            fbo
+        })
+        .collect();
+
+    EyeTarget {
+        swapchain,
+        framebuffers,
+        width,
+        height,
+    }
+}
+
+/// Derive a Functor `Camera` from an OpenXR eye view. The vertical field of
+/// view is symmetrized (`angle_up - angle_down`) — Quest eye frusta are
+/// mildly asymmetric, so this is approximate. TODO(device bring-up): teach
+/// the shared renderer to take a raw projection matrix so the exact
+/// asymmetric frustum (and correct stereo overlap) is used.
+fn camera_from_view(view: &xr::View) -> Camera {
+    let p = view.pose.position;
+    let o = view.pose.orientation;
+    let q = Quaternion::new(o.w, o.x, o.y, o.z);
+    let eye = Vector3::new(p.x, p.y, p.z);
+    let forward = q.rotate_vector(-Vector3::unit_z());
+    let up = q.rotate_vector(Vector3::unit_y());
+    let target = eye + forward;
+    Camera {
+        eye: [eye.x, eye.y, eye.z],
+        target: [target.x, target.y, target.z],
+        up: [up.x, up.y, up.z],
+        fov_radians: view.fov.angle_up - view.fov.angle_down,
+        near: 0.1,
+        far: 100.0,
+    }
+}
+
+/// Placeholder frame until the MLE producer is wired (device bring-up): an
+/// empty scene under a directional light — render_frame still exercises the
+/// full shadow + forward pipeline, proving the shared renderer on GLES.
+fn placeholder_frame() -> Frame {
+    use cgmath::SquareMatrix;
+    Frame::new(
+        Camera::default(),
+        functor_runtime_common::Scene3D {
+            obj: functor_runtime_common::SceneObject::Group(vec![]),
+            xform: cgmath::Matrix4::identity(),
+        },
+    )
+}
+
+#[no_mangle]
+pub fn android_main(app: AndroidApp) {
+    android_logger::init_once(
+        android_logger::Config::default()
+            .with_max_level(log::LevelFilter::Info)
+            .with_tag("functor"),
+    );
+    log::info!("functor oculus runtime starting");
+
+    let egl_ctx = init_egl();
+    let gl = unsafe {
+        glow::Context::from_loader_function(|s| {
+            egl_ctx
+                .instance
+                .get_proc_address(s)
+                .map(|p| p as *const _)
+                .unwrap_or(std::ptr::null())
+        })
+    };
+    let gl = Arc::new(gl);
+
+    // OpenXR: Meta's libopenxr_loader.so is dlopen'd (the crate's `loaded`
+    // feature); the Android loader hook must run before create_instance.
+    let entry = unsafe { xr::Entry::load() }.expect(
+        "load libopenxr_loader.so — is Meta's loader bundled in the APK? (see README)",
+    );
+    entry
+        .initialize_android_loader()
+        .expect("initialize android loader");
+
+    let mut extensions = xr::ExtensionSet::default();
+    extensions.khr_opengl_es_enable = true;
+    let instance = entry
+        .create_instance(
+            &xr::ApplicationInfo {
+                application_name: "functor-runner",
+                application_version: 0,
+                engine_name: "functor",
+                engine_version: 0,
+                api_version: xr::Version::new(1, 0, 34),
+            },
+            &extensions,
+            &[],
+        )
+        .expect("create OpenXR instance");
+    let system = instance
+        .system(xr::FormFactor::HEAD_MOUNTED_DISPLAY)
+        .expect("no HMD system");
+
+    // The runtime requires this call before create_session even though the
+    // requirements themselves are informational for GLES 3.2.
+    let _reqs = instance
+        .graphics_requirements::<xr::OpenGlEs>(system)
+        .expect("graphics requirements");
+
+    let (session, mut frame_wait, mut frame_stream) = unsafe {
+        instance.create_session::<xr::OpenGlEs>(
+            system,
+            &xr::opengles::SessionCreateInfo::Android {
+                display: egl_ctx.display.as_ptr(),
+                config: egl_ctx.config.as_ptr(),
+                context: egl_ctx.context.as_ptr(),
+            },
+        )
+    }
+    .expect("create session");
+
+    let stage = session
+        .create_reference_space(xr::ReferenceSpaceType::STAGE, xr::Posef::IDENTITY)
+        .expect("stage space");
+
+    let view_config_views = instance
+        .enumerate_view_configuration_views(system, xr::ViewConfigurationType::PRIMARY_STEREO)
+        .expect("view config views");
+    let mut eyes: Vec<EyeTarget> = view_config_views
+        .iter()
+        .map(|v| create_eye_target(&gl, &session, v))
+        .collect();
+    log::info!(
+        "swapchains ready: {}x{} per eye",
+        eyes[0].width,
+        eyes[0].height
+    );
+
+    let asset_cache = Arc::new(AssetCache::new());
+    let scene_context = SceneContext::new();
+    let shadow_map = functor_runtime_common::shadow::ShadowMap::new(&gl, 2048);
+
+    let start = std::time::Instant::now();
+    let mut last_tts = 0.0f32;
+    let mut session_running = false;
+    let mut quit = false;
+    let mut event_storage = xr::EventDataBuffer::new();
+
+    while !quit {
+        // Android lifecycle first (non-blocking).
+        app.poll_events(Some(std::time::Duration::ZERO), |event| {
+            if let PollEvent::Main(main) = event {
+                match main {
+                    MainEvent::Destroy => quit = true,
+                    // Session state (FOCUSED/VISIBLE/…) drives rendering; the
+                    // window is compositor-owned, so Pause/Resume need no GL
+                    // work here.
+                    _ => {}
+                }
+            }
+        });
+
+        // OpenXR events: drive the session state machine.
+        while let Some(event) = instance.poll_event(&mut event_storage).expect("poll_event") {
+            use xr::Event::*;
+            match event {
+                SessionStateChanged(e) => {
+                    log::info!("session state: {:?}", e.state());
+                    match e.state() {
+                        xr::SessionState::READY => {
+                            session
+                                .begin(xr::ViewConfigurationType::PRIMARY_STEREO)
+                                .expect("session begin");
+                            session_running = true;
+                        }
+                        xr::SessionState::STOPPING => {
+                            session.end().expect("session end");
+                            session_running = false;
+                        }
+                        xr::SessionState::EXITING | xr::SessionState::LOSS_PENDING => {
+                            quit = true;
+                        }
+                        _ => {}
+                    }
+                }
+                InstanceLossPending(_) => quit = true,
+                _ => {}
+            }
+        }
+
+        if !session_running {
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            continue;
+        }
+
+        let xr_frame_state = frame_wait.wait().expect("frame wait");
+        frame_stream.begin().expect("frame begin");
+
+        if !xr_frame_state.should_render {
+            frame_stream
+                .end(
+                    xr_frame_state.predicted_display_time,
+                    xr::EnvironmentBlendMode::OPAQUE,
+                    &[],
+                )
+                .expect("frame end (no render)");
+            continue;
+        }
+
+        let (_, views) = session
+            .locate_views(
+                xr::ViewConfigurationType::PRIMARY_STEREO,
+                xr_frame_state.predicted_display_time,
+                &stage,
+            )
+            .expect("locate views");
+
+        // Frame time from wall clock for now; the MLE producer step will own
+        // this the way the desktop loop does.
+        let tts = start.elapsed().as_secs_f32();
+        let frame_time = FrameTime {
+            dts: tts - last_tts,
+            tts,
+        };
+        last_tts = tts;
+
+        // TODO(device bring-up): MLE producer + debug server here — the game
+        // produces this frame; today it's the placeholder scene.
+        let frame = placeholder_frame();
+
+        for (eye, view) in eyes.iter_mut().zip(views.iter()) {
+            use glow::HasContext;
+            let image_index = eye.swapchain.acquire_image().expect("acquire") as usize;
+            eye.swapchain
+                .wait_image(xr::Duration::INFINITE)
+                .expect("wait image");
+            unsafe {
+                gl.bind_framebuffer(glow::FRAMEBUFFER, Some(eye.framebuffers[image_index]));
+                gl.disable(glow::SCISSOR_TEST);
+                gl.enable(glow::DEPTH_TEST);
+            }
+            functor_runtime_common::render_frame(
+                &gl,
+                "#version 300 es",
+                asset_cache.clone(),
+                &scene_context,
+                &shadow_map,
+                &frame,
+                &camera_from_view(view),
+                frame_time.clone(),
+                Viewport::new(eye.width, eye.height),
+                functor_runtime_common::DebugRenderMode::Default,
+            );
+            unsafe {
+                gl.bind_framebuffer(glow::FRAMEBUFFER, None);
+            }
+            eye.swapchain.release_image().expect("release image");
+        }
+
+        let rect = xr::Rect2Di {
+            offset: xr::Offset2Di { x: 0, y: 0 },
+            extent: xr::Extent2Di {
+                width: eyes[0].width as i32,
+                height: eyes[0].height as i32,
+            },
+        };
+        let projection_views: Vec<_> = views
+            .iter()
+            .zip(eyes.iter())
+            .map(|(view, eye)| {
+                xr::CompositionLayerProjectionView::new()
+                    .pose(view.pose)
+                    .fov(view.fov)
+                    .sub_image(
+                        xr::SwapchainSubImage::new()
+                            .swapchain(&eye.swapchain)
+                            .image_rect(rect),
+                    )
+            })
+            .collect();
+        frame_stream
+            .end(
+                xr_frame_state.predicted_display_time,
+                xr::EnvironmentBlendMode::OPAQUE,
+                &[&xr::CompositionLayerProjection::new()
+                    .space(&stage)
+                    .views(&projection_views)],
+            )
+            .expect("frame end");
+    }
+
+    log::info!("functor oculus runtime exiting");
+}

--- a/runtime/functor-runtime-oculus/src/lib.rs
+++ b/runtime/functor-runtime-oculus/src/lib.rs
@@ -40,6 +40,10 @@ const GLES_MINOR: i32 = 2;
 
 /// Color format for the swapchains (GL_SRGB8_ALPHA8): the compositor expects
 /// sRGB-encoded output, and an sRGB internal format makes GL do the encode.
+/// TODO(device bring-up): the shared shaders are gamma-naive (desktop/web
+/// write raw values to non-sRGB targets), so the format-driven encode here
+/// will render brighter than the desktop reference — expect to make the
+/// shared pipeline gamma-explicit once it's visible on device.
 const COLOR_FORMAT: u32 = glow::SRGB8_ALPHA8;
 
 struct EglContext {
@@ -64,9 +68,18 @@ fn init_egl() -> EglContext {
     let display = unsafe { instance.get_display(egl::DEFAULT_DISPLAY) }.expect("EGL display");
     instance.initialize(display).expect("EGL initialize");
 
+    // EGL_OPENGL_ES3_BIT: not exposed by khronos-egl's 1.4 API surface (it's
+    // an EGL 1.5 / KHR_create_context constant), value per the Khronos
+    // registry.
+    const OPENGL_ES3_BIT: egl::Int = 0x0040;
+
     let mut chosen = None;
     let configs = {
-        let mut configs = Vec::with_capacity(64);
+        // Size to the driver's real count — Adreno exposes hundreds, and a
+        // truncated list can hide the one config we need (`get_configs` fills
+        // only up to the Vec's capacity).
+        let count = instance.get_config_count(display).expect("EGL config count");
+        let mut configs = Vec::with_capacity(count);
         instance
             .get_configs(display, &mut configs)
             .expect("EGL configs");
@@ -74,6 +87,9 @@ fn init_egl() -> EglContext {
     };
     for config in configs {
         let attr = |a: egl::Int| instance.get_config_attrib(display, config, a).unwrap_or(-1);
+        // Exact 8888, no depth/stencil (per-eye renderbuffers own depth), no
+        // MSAA — plus the two masks Meta's reference ovrEgl checks: the
+        // config must back an ES3 context and a pbuffer surface.
         if attr(egl::RED_SIZE) == 8
             && attr(egl::GREEN_SIZE) == 8
             && attr(egl::BLUE_SIZE) == 8
@@ -81,12 +97,14 @@ fn init_egl() -> EglContext {
             && attr(egl::DEPTH_SIZE) == 0
             && attr(egl::STENCIL_SIZE) == 0
             && attr(egl::SAMPLES) == 0
+            && attr(egl::RENDERABLE_TYPE) & OPENGL_ES3_BIT != 0
+            && attr(egl::SURFACE_TYPE) & egl::PBUFFER_BIT != 0
         {
             chosen = Some(config);
             break;
         }
     }
-    let config = chosen.expect("no 8888 EGL config without MSAA");
+    let config = chosen.expect("no ES3-capable 8888 EGL config without MSAA");
 
     let context = instance
         .create_context(
@@ -184,9 +202,13 @@ fn create_eye_target(
                 glow::RENDERBUFFER,
                 Some(depth),
             );
-            debug_assert_eq!(
-                gl.check_framebuffer_status(glow::FRAMEBUFFER),
-                glow::FRAMEBUFFER_COMPLETE
+            // A real check, not debug_assert: in a release APK an incomplete
+            // FBO would otherwise become silent garbage on the display.
+            let status = gl.check_framebuffer_status(glow::FRAMEBUFFER);
+            assert_eq!(
+                status,
+                glow::FRAMEBUFFER_COMPLETE,
+                "swapchain framebuffer incomplete: 0x{status:x}"
             );
             fbo
         })
@@ -224,16 +246,24 @@ fn camera_from_view(view: &xr::View) -> Camera {
 }
 
 /// Placeholder frame until the MLE producer is wired (device bring-up): an
-/// empty scene under a directional light — render_frame still exercises the
-/// full shadow + forward pipeline, proving the shared renderer on GLES.
+/// empty scene under a shadow-casting directional light, so `render_frame`
+/// runs the full shadow + forward pipeline every frame — the point of phase 1
+/// is proving the shared renderer's whole GLES path, not just a clear.
 fn placeholder_frame() -> Frame {
     use cgmath::SquareMatrix;
-    Frame::new(
+    let light = functor_runtime_common::Light::Directional {
+        direction: [-0.4, -1.0, -0.3],
+        color: [1.0, 1.0, 1.0],
+        intensity: 1.0,
+        casts_shadows: true,
+    };
+    Frame::new_lit(
         Camera::default(),
         functor_runtime_common::Scene3D {
             obj: functor_runtime_common::SceneObject::Group(vec![]),
             xform: cgmath::Matrix4::identity(),
         },
+        vec![light].into(),
     )
 }
 
@@ -269,6 +299,10 @@ pub fn android_main(app: AndroidApp) {
 
     let mut extensions = xr::ExtensionSet::default();
     extensions.khr_opengl_es_enable = true;
+    // Required on Android: openxr only chains the activity/JVM context into
+    // xrCreateInstance (XrInstanceCreateInfoAndroidKHR) when this is set —
+    // without it the runtime can reject instance creation.
+    extensions.khr_android_create_instance = true;
     let instance = entry
         .create_instance(
             &xr::ApplicationInfo {
@@ -286,11 +320,23 @@ pub fn android_main(app: AndroidApp) {
         .system(xr::FormFactor::HEAD_MOUNTED_DISPLAY)
         .expect("no HMD system");
 
-    // The runtime requires this call before create_session even though the
-    // requirements themselves are informational for GLES 3.2.
-    let _reqs = instance
+    // The spec requires this call before create_session — and requires the
+    // app to verify its GLES version is inside the supported range; a clear
+    // panic here beats on-device UB.
+    let reqs = instance
         .graphics_requirements::<xr::OpenGlEs>(system)
         .expect("graphics requirements");
+    let requested = xr::Version::new(GLES_MAJOR as u16, GLES_MINOR as u16, 0);
+    log::info!(
+        "GLES {GLES_MAJOR}.{GLES_MINOR} requested; runtime supports {} – {}",
+        reqs.min_api_version_supported,
+        reqs.max_api_version_supported
+    );
+    assert!(
+        requested >= reqs.min_api_version_supported
+            && requested <= reqs.max_api_version_supported,
+        "GLES {GLES_MAJOR}.{GLES_MINOR} outside the runtime's supported range"
+    );
 
     let (session, mut frame_wait, mut frame_stream) = unsafe {
         instance.create_session::<xr::OpenGlEs>(
@@ -304,13 +350,26 @@ pub fn android_main(app: AndroidApp) {
     }
     .expect("create session");
 
+    // STAGE (floor-origin, room-scale) preferred; LOCAL (head-origin) is the
+    // portable baseline when the runtime has no stage bounds set up.
     let stage = session
         .create_reference_space(xr::ReferenceSpaceType::STAGE, xr::Posef::IDENTITY)
-        .expect("stage space");
+        .unwrap_or_else(|e| {
+            log::warn!("STAGE reference space unavailable ({e}); falling back to LOCAL");
+            session
+                .create_reference_space(xr::ReferenceSpaceType::LOCAL, xr::Posef::IDENTITY)
+                .expect("local space")
+        });
 
     let view_config_views = instance
         .enumerate_view_configuration_views(system, xr::ViewConfigurationType::PRIMARY_STEREO)
         .expect("view config views");
+    // Fail with a clear message rather than XR_ERROR_SWAPCHAIN_FORMAT_UNSUPPORTED.
+    let formats = session.enumerate_swapchain_formats().expect("formats");
+    assert!(
+        formats.contains(&COLOR_FORMAT),
+        "runtime does not offer SRGB8_ALPHA8 swapchains (offered: {formats:x?})"
+    );
     let mut eyes: Vec<EyeTarget> = view_config_views
         .iter()
         .map(|v| create_eye_target(&gl, &session, v))
@@ -326,7 +385,10 @@ pub fn android_main(app: AndroidApp) {
     let shadow_map = functor_runtime_common::shadow::ShadowMap::new(&gl, 2048);
 
     let start = std::time::Instant::now();
-    let mut last_tts = 0.0f32;
+    // Lazy: seconds pass between android_main and the first rendered frame
+    // (session READY), and the session can pause — the first frame after
+    // either must not hand the game a giant dts.
+    let mut last_tts: Option<f32> = None;
     let mut session_running = false;
     let mut quit = false;
     let mut event_storage = xr::EventDataBuffer::new();
@@ -404,10 +466,10 @@ pub fn android_main(app: AndroidApp) {
         // this the way the desktop loop does.
         let tts = start.elapsed().as_secs_f32();
         let frame_time = FrameTime {
-            dts: tts - last_tts,
+            dts: last_tts.map_or(0.0, |last| tts - last),
             tts,
         };
-        last_tts = tts;
+        last_tts = Some(tts);
 
         // TODO(device bring-up): MLE producer + debug server here — the game
         // produces this frame; today it's the placeholder scene.
@@ -442,17 +504,17 @@ pub fn android_main(app: AndroidApp) {
             eye.swapchain.release_image().expect("release image");
         }
 
-        let rect = xr::Rect2Di {
-            offset: xr::Offset2Di { x: 0, y: 0 },
-            extent: xr::Extent2Di {
-                width: eyes[0].width as i32,
-                height: eyes[0].height as i32,
-            },
-        };
         let projection_views: Vec<_> = views
             .iter()
             .zip(eyes.iter())
             .map(|(view, eye)| {
+                let rect = xr::Rect2Di {
+                    offset: xr::Offset2Di { x: 0, y: 0 },
+                    extent: xr::Extent2Di {
+                        width: eye.width as i32,
+                        height: eye.height as i32,
+                    },
+                };
                 xr::CompositionLayerProjectionView::new()
                     .pose(view.pose)
                     .fov(view.fov)


### PR DESCRIPTION
## What

`runtime/functor-runtime-oculus`: the Quest (Meta Horizon OS) runtime shell — an OpenXR + EGL/GLES 3.2 Android cdylib rendering through the shared `functor_runtime_common::render_frame`, same as desktop and web. Like `functor-runner`, the APK is a **tool built once**: games aren't baked in — they'll arrive as MLE source over the network (#183's `/reload-source`) at device bring-up.

**Phase 1 scope (this PR): the pipeline builds.** `android_main` → manual EGL config selection → OpenXR instance/session → per-eye SRGB8_ALPHA8 swapchains (FBO + depth per image) → frame loop with head-pose cameras, placeholder lit scene (exercises the full shadow + forward GLES path). Not yet run on a device — that's phase 2, explicitly.

- Stack: crates.io `openxr` 0.21 + `android-activity` + `cargo-ndk`/`cargo-apk`. shock2quest's vendored openxrs fork is obsolete (verified by diff: its back-ported GLES/Android support shipped upstream in openxr 0.18, Feb 2024). Meta's `libopenxr_loader.so` is the one manual runtime artifact (README).
- shock2quest's Quest gotchas inherited: manual EGL config (no `eglChooseConfig`), sRGB swapchains, pbuffer-backed context, two swapchains.
- **Own workspace**, outside the root one (like the examples' build crates): `ndk-sys` hard-fails host compiles, so root membership would break every bare `cargo build`/`check`/rust-analyzer run.
- One shared-crate fix that benefits all shells: `render_shadow_pass` now restores the caller's framebuffer binding instead of resetting to default (a no-op on desktop/web; on Quest, lit frames would otherwise render into the invisible pbuffer).

## Build (verified on this machine)

```sh
npm run build:oculus       # cargo ndk → target-android/aarch64-linux-android/debug/libfunctor_runtime_oculus.so
npm run build:oculus:apk   # cargo apk → signed functor_runtime_oculus.apk
```

Android builds use an isolated `CARGO_TARGET_DIR=target-android` (a cleaner/analyzer race on the shared `target/` corrupts cross-compile fingerprints).

## Review

/xreview (Claude + Codex), tuned for "will it predictably fail on device": both-engine [AGREED] fixes — shadow-pass FBO clobber, EGL config truncation at 64 + missing ES3/pbuffer capability checks. Codex Critical fixed: `khr_android_create_instance` wasn't enabled (Quest can reject `xrCreateInstance` without it). Claude High fixed: root-workspace membership broke host builds. Plus: GLES version validated against `graphics_requirements`, swapchain format asserted against enumeration, STAGE→LOCAL fallback, real FBO completeness check, first-frame dts, per-eye rects. Verified clean by review: quaternion/fov conventions, openxr 0.21 API usage, `#version 300 es` against the shared shader preamble (same as WebGL2), ShadowMap ES3 compatibility, android-activity usage, session state machine.

Desktop unchanged: 116 common tests green, runner builds, `cargo check --workspace` restored to its prior state.

## Next (phase 2, needs the Quest 3)

Meta loader `.so` → `adb install` → visual bring-up (gamma TODO documented), then MLE producer + network reload on-device, controllers, asymmetric-frustum projection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)