### PR TITLE
feat(mle,runtime): B6 — the minimal effect broker: Effect.* with real/fake/replay runners

### DIFF
--- a/.claude/skills/mle-language/SKILL.md
+++ b/.claude/skills/mle-language/SKILL.md
@@ -165,6 +165,8 @@ Frame.create(camera, scene)                                // what draw returns
 Frame.createLit(camera, scene, [light, …])                 // lit + shadowed
 Time.seconds(1.0) / Time.millis(500.0)                     // Duration VALUES only
 Sub.every(duration, msg) / Sub.none() / Sub.batch([sub,…]) // what subscriptions returns
+Effect.random(tagger) / Effect.now(tagger)                 // one-shots; tagger: (Float) => Msg
+Effect.none() / Effect.batch([fx, …])                      //   random: [0,1); now: epoch secs
 
 Physics.box(w, h, d) / sphere(r) / capsule(halfH, r)       // -> Shape (box = FULL extents)
 Physics.dynamic("tag", shape)                              // simulated body
@@ -196,6 +198,9 @@ let input = (model, key, isDown) => model'  // OPTIONAL; key = "W"/"Up"/"Space"
 let mouseMove = (model, x, y) => model'     // OPTIONAL; window pixels
 let mouseWheel = (model, delta) => model'   // OPTIONAL
 let update = (model, msg) => model'         // OPTIONAL; msgs are ADT variants
+                                            // ANY entry point may instead return
+                                            // (model', effect) — a 2-tuple whose
+                                            // second element is an Effect value
 let subscriptions = (model) => Sub.every(Time.seconds(1.0), Beat)
                                             // OPTIONAL, but requires update
 let physics = (model) => Physics.scene(0.0, -9.81, 0.0, [body, …])  // OPTIONAL
@@ -207,6 +212,14 @@ a long frame fires ONCE (missed boundaries collapse) and timers tick right
 through a hot reload. Fired messages fold through `update` before `tick`.
 Durations, like Angles, are branded values — `Sub.every(0.5, …)` is a
 teaching error; say `Time.seconds(0.5)` or `Time.millis(500.0)`.
+
+Effects are one-shot commands: the producer performs each one, applies its
+tagger to the result (`Effect.random(Rolled)` → `Rolled(0.42)`), and folds
+the message back through `update` — which may itself return more effects
+(drained same-frame to a fixed point, capped). Every performed effect
+lands in a structured log; under a fake/replay runner the same program is
+exactly deterministic (that's the test seam). Taggers must be functions —
+`Effect.now(3.0)` is a construction-time error.
 
 Frame order: subscriptions→`update` → `tick` → `physics` (reconcile +
 fixed-step, 60Hz accumulator) → `draw` — physics reads in `draw` see this

--- a/docs/mle.md
+++ b/docs/mle.md
@@ -214,9 +214,25 @@ snapshots — no GPU, fully agent-verifiable.
       non-match, structural equality, `(e)` stays grouping, 1-tuple and
       mut-destructure teaching errors, element types flow through
       patterns, closures inside tuples rebind); 205 mle tests green.
-- [ ] **B6. Minimal effect broker.** `Clock.Now`, `Random` with real/fake/replay
-      handlers; `update`/`tick` return `(model, effects)` tuples. *Verify:* same
-      program under real vs fake vs replay; structured effect log.
+- [x] **B6. Minimal effect broker** (done 2026-07-03). `Effect.none/now/
+      random/batch` prelude values (taggers validated callable at
+      construction); any entry point may return a `(model, effect)` tuple —
+      `split_model_effect` sniffs the pair (an Effect value in model data is
+      meaningless, so the sniff is unambiguous) and both producers funnel
+      every return through one `absorb` path. `drain_effects` (shared,
+      prelude-level) performs each effect through an **EffectRunner** —
+      `RealEffects` (wasm-safe clock: `Date.now()` on wasm32, where
+      `SystemTime` panics), `FakeEffects`, `ReplayEffects` — applies the
+      tagger via the new `Session::apply`, folds the message through
+      `update`, and drains chained effects to a fixed point (1000/frame
+      cap). Every performed effect lands in the **structured EffectLog**
+      (`{kind, value}` — replay's input format). Taggers run same-frame, so
+      no closure outlives its session (no reload hazard). *Verify (done):*
+      the broker contract as exact arithmetic — same program under fake and
+      replay produces the same model, the fake run's log IS replay's input,
+      divergent replay fails loud with position; construction teaching
+      errors; runaway-chain cap; SDK e2e through the real runner (key →
+      Effect.random → chained Effect.now → both sentinels replaced).
 - [x] **Language: record updates + local mutability** (2026-07-02; design:
       `~/notes/ideas/mle-language/mutability.md`). `{ base with x: 1.0 }`
       pure record updates; expression-level `let [mut] x = e in body` with

--- a/mle/src/eval.rs
+++ b/mle/src/eval.rs
@@ -216,6 +216,28 @@ impl Session {
         };
         interp.call(callee, args, name.to_string(), Span::new(0, 0), None)
     }
+
+    /// Apply a function VALUE (a closure the host is holding — e.g. an
+    /// effect's tagger) with `args`. Same execution shape as [`Self::call`];
+    /// the label names it in traces/errors.
+    pub fn apply(
+        &self,
+        callee: Value,
+        args: Vec<Value>,
+        label: &str,
+        host: &mut dyn Host,
+    ) -> Result<Value, RunError> {
+        let mut interp = Interp {
+            globals: self.globals.clone(),
+            mut_slots: HashMap::new(),
+            trace: Vec::new(),
+            tracing: Tracing::Off,
+            depth: 0,
+            call_depth: 0,
+            host,
+        };
+        interp.call(callee, args, label.to_string(), Span::new(0, 0), None)
+    }
 }
 
 struct Interp<'h> {

--- a/runtime/functor-runtime-common/src/mle_prelude.rs
+++ b/runtime/functor-runtime-common/src/mle_prelude.rs
@@ -28,6 +28,13 @@
 //! Sub.every(duration, msg) / Sub.none() / Sub.batch([sub,…]) -> Sub
 //!   (the game's `subscriptions` returns one of these; fired messages are
 //!    folded through `update` — see the producers' drain seam)
+//! Effect.none() / Effect.batch([fx,…])                       -> Effect
+//! Effect.now(tagger) / Effect.random(tagger)                 -> Effect
+//!   (one-shot commands: `update`/`tick` may return `(model, effect)`
+//!    tuples; the producer performs each effect via its EffectRunner —
+//!    real, fake, or replay — and folds `tagger(result)` back through
+//!    `update`, draining to a fixed point. Taggers run same-frame, so no
+//!    closure ever outlives its session.)
 //!
 //! Physics.box(w, h, d) / sphere(r) / capsule(hh, r)         -> Shape
 //! Physics.dynamic/kinematic/fixed(tag, shape)               -> Body
@@ -117,6 +124,157 @@ pub enum SubTree {
 
 pub struct MleSub(pub SubTree);
 
+/// A one-shot effect as an opaque MLE value — what `update`/`tick` may
+/// return beside the model (`(model, effect)`). The imperative dual of
+/// [`SubTree`]: "do this once, then hand my tagger the result". Performed
+/// by the producer through an [`EffectRunner`] (real / fake / replay), so
+/// the same program is testable and replayable — the B6 broker contract.
+#[derive(Clone)]
+pub enum EffectTree {
+    None,
+    /// Wall-clock time: the tagger gets seconds since the Unix epoch.
+    Now {
+        tagger: Value,
+    },
+    /// A uniform float in [0, 1).
+    Random {
+        tagger: Value,
+    },
+    Batch(Vec<EffectTree>),
+}
+
+pub struct MleEffect(pub EffectTree);
+
+/// Performs effects. `Real` asks the world; `Fake` gives fixed values
+/// (tests); `Replay` feeds back a recorded [`EffectLog`] — same program,
+/// three worlds, one contract (docs/mle.md B6).
+pub trait EffectRunner {
+    fn now(&mut self) -> f64;
+    fn random(&mut self) -> f64;
+}
+
+/// One performed effect: what kind, and what value the tagger received —
+/// the structured effect log (LLM-readable, and the input to replay).
+#[derive(Clone, Debug, PartialEq)]
+pub struct EffectRecord {
+    pub kind: &'static str,
+    pub value: f64,
+}
+
+pub type EffectLog = Vec<EffectRecord>;
+
+/// The real world: system clock, xorshift PRNG seeded from it (no new
+/// dependency; game-quality randomness, not crypto).
+pub struct RealEffects {
+    rng_state: u64,
+}
+
+/// Epoch seconds from the platform clock. `std::time::SystemTime` is
+/// unimplemented on `wasm32-unknown-unknown` (it panics), so the browser
+/// build asks `Date.now()` instead.
+fn epoch_seconds() -> f64 {
+    #[cfg(target_arch = "wasm32")]
+    {
+        js_sys::Date::now() / 1000.0
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs_f64())
+            .unwrap_or(0.0)
+    }
+}
+
+impl RealEffects {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> RealEffects {
+        let seed = (epoch_seconds() * 1e9) as u64;
+        RealEffects {
+            rng_state: seed | 1,
+        }
+    }
+}
+
+impl EffectRunner for RealEffects {
+    fn now(&mut self) -> f64 {
+        epoch_seconds()
+    }
+    fn random(&mut self) -> f64 {
+        // xorshift64*; map the top 53 bits into [0, 1).
+        let mut x = self.rng_state;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.rng_state = x;
+        (x.wrapping_mul(0x2545_F491_4F6C_DD1D) >> 11) as f64 / (1u64 << 53) as f64
+    }
+}
+
+/// Fixed answers, for tests: `now` is a constant, `random` cycles a
+/// sequence.
+pub struct FakeEffects {
+    pub now: f64,
+    pub randoms: Vec<f64>,
+    next: usize,
+}
+
+impl FakeEffects {
+    pub fn new(now: f64, randoms: Vec<f64>) -> FakeEffects {
+        FakeEffects {
+            now,
+            randoms,
+            next: 0,
+        }
+    }
+}
+
+impl EffectRunner for FakeEffects {
+    fn now(&mut self) -> f64 {
+        self.now
+    }
+    fn random(&mut self) -> f64 {
+        let v = self.randoms[self.next % self.randoms.len()];
+        self.next += 1;
+        v
+    }
+}
+
+/// Replays a recorded log in order. A kind mismatch means the program
+/// diverged from the recording — fail loud with the position.
+pub struct ReplayEffects {
+    log: EffectLog,
+    next: usize,
+}
+
+impl ReplayEffects {
+    pub fn new(log: EffectLog) -> ReplayEffects {
+        ReplayEffects { log, next: 0 }
+    }
+    fn take(&mut self, kind: &'static str) -> f64 {
+        let record = self
+            .log
+            .get(self.next)
+            .unwrap_or_else(|| panic!("replay log exhausted at effect {}", self.next));
+        assert_eq!(
+            record.kind, kind,
+            "replay diverged at effect {}: recorded {}, program asked for {kind}",
+            self.next, record.kind
+        );
+        self.next += 1;
+        record.value
+    }
+}
+
+impl EffectRunner for ReplayEffects {
+    fn now(&mut self) -> f64 {
+        self.take("now")
+    }
+    fn random(&mut self) -> f64 {
+        self.take("random")
+    }
+}
+
 /// An [`Angle`] as an opaque MLE value — `Angle.degrees(…)`/`Angle.radians(…)`.
 /// Rotation/camera functions accept ONLY this, never a bare number, making
 /// degree/radian confusion unrepresentable (the F# side's `Math.Angle`
@@ -135,6 +293,15 @@ impl HostData for MleDuration {
 impl HostData for MleSub {
     fn type_name(&self) -> &'static str {
         "Sub"
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+impl HostData for MleEffect {
+    fn type_name(&self) -> &'static str {
+        "Effect"
     }
     fn as_any(&self) -> &dyn std::any::Any {
         self
@@ -277,6 +444,10 @@ const PATHS: &[&str] = &[
     "Sub.none",
     "Sub.every",
     "Sub.batch",
+    "Effect.none",
+    "Effect.now",
+    "Effect.random",
+    "Effect.batch",
     "Physics.box",
     "Physics.sphere",
     "Physics.capsule",
@@ -705,6 +876,50 @@ impl Host for FunctorHost {
                 }))),
                 _ => usage("Sub.every(duration, msg)"),
             },
+            "Effect.none" => match args.as_slice() {
+                [] => Ok(host(MleEffect(EffectTree::None))),
+                _ => usage("Effect.none()"),
+            },
+            // The tagger is an MLE function value, applied by the producer
+            // with the performed result; validated as callable here so a
+            // `Effect.now(3.0)` fails at construction, not mid-drain.
+            "Effect.now" | "Effect.random" => match args.as_slice() {
+                [tagger @ (Value::Closure(_) | Value::Ctor { .. })] => {
+                    let tree = if path == "Effect.now" {
+                        EffectTree::Now {
+                            tagger: tagger.clone(),
+                        }
+                    } else {
+                        EffectTree::Random {
+                            tagger: tagger.clone(),
+                        }
+                    };
+                    Ok(host(MleEffect(tree)))
+                }
+                [other] => err(format!(
+                    "{path}(tagger): the tagger must be a function of the result, got {}",
+                    other.kind_name()
+                )),
+                _ => usage(&format!("{path}(tagger)")),
+            },
+            "Effect.batch" => match args.as_slice() {
+                [Value::List(items)] => {
+                    let mut fx = Vec::with_capacity(items.len());
+                    for item in items.iter() {
+                        match effect_of(item) {
+                            Some(effect) => fx.push(effect.0.clone()),
+                            None => {
+                                return err(format!(
+                                    "Effect.batch items must be Effects, got {}",
+                                    item.kind_name()
+                                ))
+                            }
+                        }
+                    }
+                    Ok(host(MleEffect(EffectTree::Batch(fx))))
+                }
+                _ => usage("Effect.batch([effect, …])"),
+            },
             "Sub.batch" => match args.as_slice() {
                 [Value::List(items)] => {
                     let mut subs = Vec::with_capacity(items.len());
@@ -868,6 +1083,95 @@ fn non_negative_num(value: &Value, span: Span, what: &str) -> Result<f64, RunErr
             message: format!("{what} must not be negative, got {n}"),
             span,
         })
+    }
+}
+
+fn effect_of(value: &Value) -> Option<&MleEffect> {
+    match value {
+        Value::HostData(data) => data.as_any().downcast_ref::<MleEffect>(),
+        _ => None,
+    }
+}
+
+/// Split an entry point's return into (model, effect). The pair contract:
+/// a 2-tuple whose SECOND element is an Effect value means "model plus
+/// commands" — anything else is just the model. (Effect values only come
+/// from `Effect.*`, and one in ordinary model data would be meaningless,
+/// so the sniff is unambiguous in practice.)
+pub fn split_model_effect(value: Value) -> (Value, Option<EffectTree>) {
+    if let Value::Tuple(items) = &value {
+        if items.len() == 2 {
+            if let Some(effect) = effect_of(&items[1]) {
+                let tree = effect.0.clone();
+                return (items[0].clone(), Some(tree));
+            }
+        }
+    }
+    (value, None)
+}
+
+/// Perform `first` and drain to a fixed point: each performed effect's
+/// tagger result is folded through `update`, whose return may carry MORE
+/// effects — capped so a self-sustaining chain cannot hang the frame (the
+/// F# executor's `maxEffectsPerFrame` discipline). Every performed effect
+/// is appended to `log` (the structured effect log; replay's input).
+/// Errors report through `report` (deduped by the producer) and drop that
+/// effect — one bad tagger must not stall the rest.
+pub fn drain_effects(
+    session: &mle::Session,
+    model: &mut Value,
+    first: EffectTree,
+    runner: &mut dyn EffectRunner,
+    log: &mut EffectLog,
+    report: &mut dyn FnMut(String),
+) {
+    const MAX_EFFECTS_PER_FRAME: usize = 1000;
+    let mut queue: Vec<EffectTree> = vec![first];
+    let mut performed = 0usize;
+    while let Some(tree) = queue.pop() {
+        let (kind, value, tagger) = match tree {
+            EffectTree::None => continue,
+            EffectTree::Batch(items) => {
+                // Preserve declaration order against the LIFO queue.
+                for item in items.into_iter().rev() {
+                    queue.push(item);
+                }
+                continue;
+            }
+            EffectTree::Now { tagger } => ("now", runner.now(), tagger),
+            EffectTree::Random { tagger } => ("random", runner.random(), tagger),
+        };
+        performed += 1;
+        if performed > MAX_EFFECTS_PER_FRAME {
+            report(format!(
+                "[mle] effect drain hit the per-frame cap ({MAX_EFFECTS_PER_FRAME}); \
+dropping the rest"
+            ));
+            return;
+        }
+        log.push(EffectRecord { kind, value });
+        let msg = match session.apply(
+            tagger,
+            vec![Value::Number(value)],
+            &format!("Effect.{kind} tagger"),
+            &mut FunctorHost,
+        ) {
+            Ok(msg) => msg,
+            Err(e) => {
+                report(format!("[mle] Effect.{kind} tagger error: {}", e.message));
+                continue;
+            }
+        };
+        match session.call("update", vec![model.clone(), msg], &mut FunctorHost) {
+            Ok(returned) => {
+                let (next_model, more) = split_model_effect(returned);
+                *model = next_model;
+                if let Some(more) = more {
+                    queue.push(more);
+                }
+            }
+            Err(e) => report(format!("[mle] update error: {}", e.message)),
+        }
     }
 }
 
@@ -1386,6 +1690,139 @@ Scene.cube() |> Scene.rotateY(Angle.radians(1.5707964)))",
         let (first, last) = (edges[0], edges[edges.len() - 1]);
         let expected = ((last / 0.3).floor() - (first / 0.3).floor()) as usize;
         assert_eq!(fires, expected, "over ({first}, {last}]");
+    }
+
+    /// The B6 broker contract: the same program under fake and replay
+    /// runners produces the SAME model — the fake run's structured log IS
+    /// replay's input. (Real differs only in the values the world supplies.)
+    #[test]
+    fn same_program_under_fake_and_replay() {
+        let src = "type Msg = | Rolled(n: Float) | Stamped(t: Float)\n\
+             let update = (m, msg) =>\n\
+               match msg with\n\
+               | Rolled(n) => ({ m with rolls: m.rolls + n }, Effect.now(Stamped))\n\
+               | Stamped(t) => { m with at: t }\n\
+             let roll = (m) => (m, Effect.random(Rolled))";
+        let module = mle::lower(mle::parse(src).expect("parse")).expect("lower");
+        let session = match mle::Session::load(&module, &mut FunctorHost) {
+            Ok(session) => session,
+            Err(failure) => panic!("load failed: {}", failure.error.message),
+        };
+        let init = || {
+            Value::Record(std::rc::Rc::new(vec![
+                ("rolls".to_string(), Value::Number(0.0)),
+                ("at".to_string(), Value::Number(0.0)),
+            ]))
+        };
+        let run = |runner: &mut dyn EffectRunner| {
+            let mut model = init();
+            let mut log = EffectLog::new();
+            let returned = session
+                .call("roll", vec![model.clone()], &mut FunctorHost)
+                .expect("roll");
+            let (m, fx) = split_model_effect(returned);
+            model = m;
+            drain_effects(
+                &session,
+                &mut model,
+                fx.expect("an effect"),
+                runner,
+                &mut log,
+                &mut |msg| panic!("unexpected report: {msg}"),
+            );
+            (model.to_string(), log)
+        };
+        // Fake world: random = 0.25, now = 99.5 — exact arithmetic.
+        let (fake_model, fake_log) = run(&mut FakeEffects::new(99.5, vec![0.25]));
+        assert_eq!(fake_model, "{ rolls: 0.25, at: 99.5 }");
+        assert_eq!(
+            fake_log,
+            vec![
+                EffectRecord {
+                    kind: "random",
+                    value: 0.25
+                },
+                EffectRecord {
+                    kind: "now",
+                    value: 99.5
+                },
+            ]
+        );
+        // Replay the log: same model, no world consulted.
+        let (replay_model, replay_log) = run(&mut ReplayEffects::new(fake_log.clone()));
+        assert_eq!(replay_model, fake_model);
+        assert_eq!(replay_log, fake_log);
+        // The real world: same SHAPE (both effects performed, chain drained),
+        // world-supplied values.
+        let (real_model, real_log) = run(&mut RealEffects::new());
+        assert_eq!(real_log.len(), 2);
+        assert_eq!(real_log[0].kind, "random");
+        assert!((0.0..1.0).contains(&real_log[0].value));
+        assert_eq!(real_log[1].kind, "now");
+        assert!(real_model.starts_with("{ rolls: 0."));
+    }
+
+    /// A diverged replay fails loud with the position, not silently wrong.
+    #[test]
+    #[should_panic(expected = "replay diverged at effect 0")]
+    fn replay_divergence_fails_loud() {
+        ReplayEffects::new(vec![EffectRecord {
+            kind: "now",
+            value: 1.0,
+        }])
+        .random();
+    }
+
+    /// Effect construction refuses non-function taggers, and batches refuse
+    /// non-effects — construction-time teaching errors, not mid-drain ones.
+    #[test]
+    fn effect_construction_is_validated() {
+        let module = mle::lower(mle::parse("let main = () => Effect.now(3.0)").unwrap()).unwrap();
+        let failure = mle::run_with_host(&module, mle::Tracing::Off, &mut FunctorHost)
+            .err()
+            .expect("should fail");
+        assert_eq!(
+            failure.error.message,
+            "Effect.now(tagger): the tagger must be a function of the result, got a number"
+        );
+        let module =
+            mle::lower(mle::parse("let main = () => Effect.batch([1.0])").unwrap()).unwrap();
+        let failure = mle::run_with_host(&module, mle::Tracing::Off, &mut FunctorHost)
+            .err()
+            .expect("should fail");
+        assert_eq!(
+            failure.error.message,
+            "Effect.batch items must be Effects, got a number"
+        );
+    }
+
+    /// The drain cap stops a self-sustaining effect chain instead of hanging
+    /// the frame.
+    #[test]
+    fn effect_drain_cap_stops_runaway_chains() {
+        let src = "type Msg = | Again(n: Float)\n\
+             let again = (n) => Again(n)\n\
+             let update = (m, msg) => (m + 1.0, Effect.random(Again))";
+        let module = mle::lower(mle::parse(src).expect("parse")).expect("lower");
+        let session = match mle::Session::load(&module, &mut FunctorHost) {
+            Ok(session) => session,
+            Err(failure) => panic!("load failed: {}", failure.error.message),
+        };
+        let mut model = Value::Number(0.0);
+        let mut log = EffectLog::new();
+        let mut reports = Vec::new();
+        drain_effects(
+            &session,
+            &mut model,
+            EffectTree::Random {
+                tagger: session.global("again").expect("tagger fn"),
+            },
+            &mut FakeEffects::new(0.0, vec![0.5]),
+            &mut log,
+            &mut |msg| reports.push(msg),
+        );
+        assert_eq!(log.len(), 1000, "cap bounds performed effects");
+        assert!(reports.iter().any(|r| r.contains("per-frame cap")));
     }
 
     /// Bare numbers are not durations — the Angle teaching error, for time.

--- a/runtime/functor-runtime-common/src/mle_prelude.rs
+++ b/runtime/functor-runtime-common/src/mle_prelude.rs
@@ -153,6 +153,10 @@ pub trait EffectRunner {
     fn random(&mut self) -> f64;
 }
 
+/// The structured effect log keeps this many most-recent records — enforced
+/// INSIDE the drain, so the bound holds even mid-frame.
+pub const EFFECT_LOG_CAP: usize = 256;
+
 /// One performed effect: what kind, and what value the tagger received —
 /// the structured effect log (LLM-readable, and the input to replay).
 #[derive(Clone, Debug, PartialEq)]
@@ -1095,9 +1099,11 @@ fn effect_of(value: &Value) -> Option<&MleEffect> {
 
 /// Split an entry point's return into (model, effect). The pair contract:
 /// a 2-tuple whose SECOND element is an Effect value means "model plus
-/// commands" — anything else is just the model. (Effect values only come
-/// from `Effect.*`, and one in ordinary model data would be meaningless,
-/// so the sniff is unambiguous in practice.)
+/// commands" — anything else is just the model. Effects are COMMANDS, not
+/// data: one stored inside the model would make this sniff ambiguous
+/// (`(0.0, Effect.none())` as a model would be mis-split), so producers
+/// refuse an Effect inside `init` at load and warn if one appears in an
+/// adopted model ([`contains_effect`]).
 pub fn split_model_effect(value: Value) -> (Value, Option<EffectTree>) {
     if let Value::Tuple(items) = &value {
         if items.len() == 2 {
@@ -1108,6 +1114,19 @@ pub fn split_model_effect(value: Value) -> (Value, Option<EffectTree>) {
         }
     }
     (value, None)
+}
+
+/// Does an Effect value lurk anywhere inside `value`? Effects are commands,
+/// not model data — see [`split_model_effect`]. Early-exits; containers
+/// only (host values are opaque and cannot hold MLE values).
+pub fn contains_effect(value: &Value) -> bool {
+    match value {
+        Value::HostData(data) => data.as_any().downcast_ref::<MleEffect>().is_some(),
+        Value::Tuple(items) | Value::List(items) => items.iter().any(contains_effect),
+        Value::Record(fields) => fields.iter().any(|(_, v)| contains_effect(v)),
+        Value::Variant { args, .. } => args.iter().any(contains_effect),
+        _ => false,
+    }
 }
 
 /// Perform `first` and drain to a fixed point: each performed effect's
@@ -1127,8 +1146,21 @@ pub fn drain_effects(
 ) {
     const MAX_EFFECTS_PER_FRAME: usize = 1000;
     let mut queue: Vec<EffectTree> = vec![first];
-    let mut performed = 0usize;
+    // Counts every DEQUEUED node (None and Batch structure included), and is
+    // checked BEFORE the runner performs anything — so a runaway chain can't
+    // consume unbounded frame time through structural nodes, and the capped
+    // effect is never half-performed (no runner state advanced, nothing
+    // logged, no replay-log entry consumed).
+    let mut processed = 0usize;
     while let Some(tree) = queue.pop() {
+        processed += 1;
+        if processed > MAX_EFFECTS_PER_FRAME {
+            report(format!(
+                "[mle] effect drain hit the per-frame cap ({MAX_EFFECTS_PER_FRAME}); \
+dropping the rest"
+            ));
+            return;
+        }
         let (kind, value, tagger) = match tree {
             EffectTree::None => continue,
             EffectTree::Batch(items) => {
@@ -1141,15 +1173,10 @@ pub fn drain_effects(
             EffectTree::Now { tagger } => ("now", runner.now(), tagger),
             EffectTree::Random { tagger } => ("random", runner.random(), tagger),
         };
-        performed += 1;
-        if performed > MAX_EFFECTS_PER_FRAME {
-            report(format!(
-                "[mle] effect drain hit the per-frame cap ({MAX_EFFECTS_PER_FRAME}); \
-dropping the rest"
-            ));
-            return;
-        }
         log.push(EffectRecord { kind, value });
+        if log.len() > EFFECT_LOG_CAP {
+            log.remove(0);
+        }
         let msg = match session.apply(
             tagger,
             vec![Value::Number(value)],
@@ -1821,8 +1848,51 @@ Scene.cube() |> Scene.rotateY(Angle.radians(1.5707964)))",
             &mut log,
             &mut |msg| reports.push(msg),
         );
-        assert_eq!(log.len(), 1000, "cap bounds performed effects");
+        // The log bound is enforced INSIDE the drain (not after), and the
+        // cap fires before performing the over-limit effect.
+        assert_eq!(log.len(), EFFECT_LOG_CAP, "log bounded mid-drain");
         assert!(reports.iter().any(|r| r.contains("per-frame cap")));
+    }
+
+    /// Structural nodes count toward the cap too — a giant batch of
+    /// `Effect.none()` cannot consume unbounded frame time. [Codex M]
+    #[test]
+    fn structural_nodes_count_toward_the_cap() {
+        let module =
+            mle::lower(mle::parse("let noop = (m, msg) => m").expect("parse")).expect("lower");
+        let session = match mle::Session::load(&module, &mut FunctorHost) {
+            Ok(session) => session,
+            Err(failure) => panic!("load failed: {}", failure.error.message),
+        };
+        let mut model = Value::Number(0.0);
+        let mut log = EffectLog::new();
+        let mut reports = Vec::new();
+        drain_effects(
+            &session,
+            &mut model,
+            EffectTree::Batch(vec![EffectTree::None; 1500]),
+            &mut FakeEffects::new(0.0, vec![0.5]),
+            &mut log,
+            &mut |msg| reports.push(msg),
+        );
+        assert!(log.is_empty(), "nothing performed");
+        assert!(reports.iter().any(|r| r.contains("per-frame cap")));
+    }
+
+    /// Effects are commands, not data — the deep scan that backs the
+    /// producers' init rejection and adopted-model warning. [Codex H]
+    #[test]
+    fn contains_effect_finds_nested_effects() {
+        let fx = eval("let main = () => Effect.none()");
+        assert!(contains_effect(&fx));
+        let nested = Value::Record(std::rc::Rc::new(vec![(
+            "inner".to_string(),
+            Value::List(std::rc::Rc::new(vec![Value::Tuple(std::rc::Rc::new(
+                vec![Value::Number(1.0), fx],
+            ))])),
+        )]));
+        assert!(contains_effect(&nested));
+        assert!(!contains_effect(&Value::Number(1.0)));
     }
 
     /// Bare numbers are not durations — the Angle teaching error, for time.

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -29,8 +29,8 @@
 use std::time::Instant;
 
 use functor_runtime_common::mle_prelude::{
-    drain_effects, frame_value, physics_scene_value, split_model_effect, sub_messages_for_frame,
-    EffectLog, FunctorHost, RealEffects,
+    contains_effect, drain_effects, frame_value, physics_scene_value, split_model_effect,
+    sub_messages_for_frame, EffectLog, FunctorHost, RealEffects,
 };
 use functor_runtime_common::physics;
 use functor_runtime_common::ui::View;
@@ -84,7 +84,6 @@ pub struct MleGame {
 }
 
 const STATS_EVERY: u64 = 300;
-const EFFECT_LOG_CAP: usize = 256;
 
 /// A successfully loaded, contract-validated game module.
 struct Loaded {
@@ -137,6 +136,12 @@ fn load_source(path: &str, src: String) -> Result<Loaded, String> {
     ) {
         return Err(format!(
             "{path}: `init` must be a model value, not a function"
+        ));
+    }
+    if functor_runtime_common::mle_prelude::contains_effect(&init) {
+        return Err(format!(
+            "{path}: `init` contains an Effect value — Effects are commands, not data; \
+return them beside the model as `(model, effect)`"
         ));
     }
     require_function(path, &session, "tick", 3)?;
@@ -291,6 +296,17 @@ impl MleGame {
     fn absorb(&mut self, returned: Value) {
         let (model, effects) = split_model_effect(returned);
         self.model = model;
+        // Effects are commands, not data — one stored in the model would
+        // make the pair sniff ambiguous on a later return (see
+        // `split_model_effect`). Warn loud; the model is small (it is
+        // interpreted every frame anyway) so the scan is cheap.
+        if contains_effect(&self.model) {
+            self.report_once(
+                "[mle] the model contains an Effect value — Effects are commands, \
+not data; return them beside the model as `(model, effect)` instead of storing them"
+                    .to_string(),
+            );
+        }
         let Some(effects) = effects else { return };
         if self.session.global("update").is_none() {
             self.report_once(
@@ -311,10 +327,6 @@ to receive their messages; dropping them"
         );
         for message in reports {
             self.report_once(message);
-        }
-        if self.effect_log.len() > EFFECT_LOG_CAP {
-            let excess = self.effect_log.len() - EFFECT_LOG_CAP;
-            self.effect_log.drain(..excess);
         }
     }
 
@@ -651,6 +663,23 @@ mod tests {
         );
         assert!(
             err.contains("no `let update = (model, msg) => …` to receive them"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// Effects are commands, not data: an Effect inside `init` would make
+    /// the pair sniff ambiguous — rejected at load. [Codex H — B6 review]
+    #[test]
+    fn init_containing_an_effect_is_rejected() {
+        let err = load_err(
+            "init-effect",
+            "let init = (0.0, Effect.none())
+             let tick = (m, dt, tts) => m
+             let draw = (m, tts) => Frame.create(Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0), Scene.cube())
+",
+        );
+        assert!(
+            err.contains("`init` contains an Effect value"),
             "unexpected error: {err}"
         );
     }

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -29,7 +29,8 @@
 use std::time::Instant;
 
 use functor_runtime_common::mle_prelude::{
-    frame_value, physics_scene_value, sub_messages_for_frame, FunctorHost,
+    drain_effects, frame_value, physics_scene_value, split_model_effect, sub_messages_for_frame,
+    EffectLog, FunctorHost, RealEffects,
 };
 use functor_runtime_common::physics;
 use functor_runtime_common::ui::View;
@@ -58,6 +59,13 @@ pub struct MleGame {
     /// time-grid semantics of `Sub.every` do the rest.
     prev_tts: Option<f64>,
     has_physics: bool,
+    /// Performs `Effect.*` commands — the real world in the runner; the
+    /// drain logic itself is `mle_prelude::drain_effects` (tested there
+    /// with fake/replay runners).
+    effect_runner: RealEffects,
+    /// The structured effect log (last `EFFECT_LOG_CAP` performed effects) —
+    /// LLM-readable, and the input format for replay.
+    effect_log: EffectLog,
     /// The last successfully drawn frame, kept so a bad draw shows the last
     /// good picture instead of a blank.
     last_frame: Frame,
@@ -76,6 +84,7 @@ pub struct MleGame {
 }
 
 const STATS_EVERY: u64 = 300;
+const EFFECT_LOG_CAP: usize = 256;
 
 /// A successfully loaded, contract-validated game module.
 struct Loaded {
@@ -217,6 +226,8 @@ impl MleGame {
             has_subscriptions: loaded.has_subscriptions,
             prev_tts: None,
             has_physics: loaded.has_physics,
+            effect_runner: RealEffects::new(),
+            effect_log: EffectLog::new(),
             last_frame: empty_frame(),
             last_error: None,
             frames: 0,
@@ -272,6 +283,41 @@ impl MleGame {
         }
     }
 
+    /// Take an entry point's return: split off any `(model, effect)` pair,
+    /// adopt the model, and drain the effects to a fixed point through
+    /// `update` (docs/mle.md B6). Every producer path that runs game code
+    /// funnels through here, so effects work uniformly from tick, input,
+    /// mouse, and subscription messages.
+    fn absorb(&mut self, returned: Value) {
+        let (model, effects) = split_model_effect(returned);
+        self.model = model;
+        let Some(effects) = effects else { return };
+        if self.session.global("update").is_none() {
+            self.report_once(
+                "[mle] effects returned but there is no `let update = (model, msg) => …` \
+to receive their messages; dropping them"
+                    .to_string(),
+            );
+            return;
+        }
+        let mut reports: Vec<String> = Vec::new();
+        drain_effects(
+            &self.session,
+            &mut self.model,
+            effects,
+            &mut self.effect_runner,
+            &mut self.effect_log,
+            &mut |message| reports.push(message),
+        );
+        for message in reports {
+            self.report_once(message);
+        }
+        if self.effect_log.len() > EFFECT_LOG_CAP {
+            let excess = self.effect_log.len() - EFFECT_LOG_CAP;
+            self.effect_log.drain(..excess);
+        }
+    }
+
     /// Fire subscription timers over `(prev_tts, tts]` and fold their
     /// messages through `update`, before this frame's `tick` — the message
     /// drain seam (docs/mle.md C4b-2; B6's effects will feed this same
@@ -306,7 +352,7 @@ impl MleGame {
                 .session
                 .call("update", vec![self.model.clone(), msg], &mut FunctorHost)
             {
-                Ok(model) => self.model = model,
+                Ok(returned) => self.absorb(returned),
                 Err(err) => self.frame_error("update", &err),
             }
         }
@@ -440,7 +486,7 @@ impl Game for MleGame {
             Value::Number(frame_time.tts as f64),
         ];
         match self.session.call("tick", args, &mut FunctorHost) {
-            Ok(model) => self.model = model,
+            Ok(returned) => self.absorb(returned),
             Err(err) => self.frame_error("tick", &err),
         }
         self.tick_ns += started.elapsed().as_nanos() as u64;
@@ -467,7 +513,7 @@ impl Game for MleGame {
             Value::Bool(is_down),
         ];
         match self.session.call("input", args, &mut FunctorHost) {
-            Ok(model) => self.model = model,
+            Ok(returned) => self.absorb(returned),
             Err(err) => self.frame_error("input", &err),
         }
     }
@@ -481,7 +527,7 @@ impl Game for MleGame {
             Value::Number(y as f64),
         ];
         match self.session.call("mouseMove", args, &mut FunctorHost) {
-            Ok(model) => self.model = model,
+            Ok(returned) => self.absorb(returned),
             Err(err) => self.frame_error("mouseMove", &err),
         }
     }
@@ -492,7 +538,7 @@ impl Game for MleGame {
         }
         let args = vec![self.model.clone(), Value::Number(delta as f64)];
         match self.session.call("mouseWheel", args, &mut FunctorHost) {
-            Ok(model) => self.model = model,
+            Ok(returned) => self.absorb(returned),
             Err(err) => self.frame_error("mouseWheel", &err),
         }
     }

--- a/runtime/functor-runtime-web/src/mle_game.rs
+++ b/runtime/functor-runtime-web/src/mle_game.rs
@@ -19,8 +19,8 @@
 use std::cell::RefCell;
 
 use functor_runtime_common::mle_prelude::{
-    drain_effects, frame_value, physics_scene_value, split_model_effect, sub_messages_for_frame,
-    EffectLog, FunctorHost, RealEffects,
+    contains_effect, drain_effects, frame_value, physics_scene_value, split_model_effect,
+    sub_messages_for_frame, EffectLog, FunctorHost, RealEffects,
 };
 use functor_runtime_common::physics;
 use functor_runtime_common::protocol::GameProducer;
@@ -95,6 +95,12 @@ impl MleWebGame {
                 "{path}: `init` must be a model value, not a function"
             ));
         }
+        if functor_runtime_common::mle_prelude::contains_effect(&init) {
+            return Err(format!(
+                "{path}: `init` contains an Effect value — Effects are commands, not data; \
+return them beside the model as `(model, effect)`"
+            ));
+        }
         require_function(path, &session, "tick", 3)?;
         require_function(path, &session, "draw", 2)?;
         // `input` is optional (many games are non-interactive), but when
@@ -164,9 +170,19 @@ impl MleWebGame {
     /// adopt the model, and drain the effects to a fixed point through
     /// `update` (docs/mle.md B6) — mirrors the desktop producer.
     fn absorb(&mut self, returned: Value) {
-        const EFFECT_LOG_CAP: usize = 256;
         let (model, effects) = split_model_effect(returned);
         self.model = model;
+        // Effects are commands, not data — one stored in the model would
+        // make the pair sniff ambiguous on a later return (see
+        // `split_model_effect`). Warn loud; the model is small (it is
+        // interpreted every frame anyway) so the scan is cheap.
+        if contains_effect(&self.model) {
+            self.log_once(
+                "[mle] the model contains an Effect value — Effects are commands, \
+not data; return them beside the model as `(model, effect)` instead of storing them"
+                    .to_string(),
+            );
+        }
         let Some(effects) = effects else { return };
         if self.session.global("update").is_none() {
             self.log_once(
@@ -187,10 +203,6 @@ to receive their messages; dropping them"
         );
         for message in reports {
             self.log_once(message);
-        }
-        if self.effect_log.len() > EFFECT_LOG_CAP {
-            let excess = self.effect_log.len() - EFFECT_LOG_CAP;
-            self.effect_log.drain(..excess);
         }
     }
 

--- a/runtime/functor-runtime-web/src/mle_game.rs
+++ b/runtime/functor-runtime-web/src/mle_game.rs
@@ -19,7 +19,8 @@
 use std::cell::RefCell;
 
 use functor_runtime_common::mle_prelude::{
-    frame_value, physics_scene_value, sub_messages_for_frame, FunctorHost,
+    drain_effects, frame_value, physics_scene_value, split_model_effect, sub_messages_for_frame,
+    EffectLog, FunctorHost, RealEffects,
 };
 use functor_runtime_common::physics;
 use functor_runtime_common::protocol::GameProducer;
@@ -43,6 +44,11 @@ pub struct MleWebGame {
     /// desktop producer).
     prev_tts: Option<f64>,
     has_physics: bool,
+    /// Performs `Effect.*` commands (B6). `RealEffects` is wasm-safe: its
+    /// clock is `Date.now()` on this target.
+    effect_runner: RealEffects,
+    /// The structured effect log (bounded) — see the desktop producer.
+    effect_log: EffectLog,
     /// The last successfully drawn frame, kept so a bad draw shows the last
     /// good picture instead of a blank.
     last_frame: Frame,
@@ -142,6 +148,8 @@ impl MleWebGame {
             has_mouse_wheel,
             has_subscriptions,
             prev_tts: None,
+            effect_runner: RealEffects::new(),
+            effect_log: EffectLog::new(),
             has_physics,
             last_frame: empty_frame(),
             last_error: None,
@@ -152,6 +160,40 @@ impl MleWebGame {
     /// messages through `update`, before this frame's `tick` — the message
     /// drain seam (docs/mle.md C4b-2), same semantics as the desktop
     /// producer. Errors report per message and processing continues.
+    /// Take an entry point's return: split off any `(model, effect)` pair,
+    /// adopt the model, and drain the effects to a fixed point through
+    /// `update` (docs/mle.md B6) — mirrors the desktop producer.
+    fn absorb(&mut self, returned: Value) {
+        const EFFECT_LOG_CAP: usize = 256;
+        let (model, effects) = split_model_effect(returned);
+        self.model = model;
+        let Some(effects) = effects else { return };
+        if self.session.global("update").is_none() {
+            self.log_once(
+                "[mle] effects returned but there is no `let update = (model, msg) => …` \
+to receive their messages; dropping them"
+                    .to_string(),
+            );
+            return;
+        }
+        let mut reports: Vec<String> = Vec::new();
+        drain_effects(
+            &self.session,
+            &mut self.model,
+            effects,
+            &mut self.effect_runner,
+            &mut self.effect_log,
+            &mut |message| reports.push(message),
+        );
+        for message in reports {
+            self.log_once(message);
+        }
+        if self.effect_log.len() > EFFECT_LOG_CAP {
+            let excess = self.effect_log.len() - EFFECT_LOG_CAP;
+            self.effect_log.drain(..excess);
+        }
+    }
+
     fn pump_subscriptions(&mut self, tts: f64) {
         // Advance the window even without subscriptions (or on frame one),
         // so the edge is always sane.
@@ -179,7 +221,7 @@ impl MleWebGame {
                 .session
                 .call("update", vec![self.model.clone(), msg], &mut FunctorHost)
             {
-                Ok(model) => self.model = model,
+                Ok(returned) => self.absorb(returned),
                 Err(err) => self.frame_error("update", &err),
             }
         }
@@ -246,7 +288,7 @@ impl GameProducer for MleWebGame {
             Value::Number(frame_time.tts as f64),
         ];
         match self.session.call("tick", args, &mut FunctorHost) {
-            Ok(model) => self.model = model,
+            Ok(returned) => self.absorb(returned),
             Err(err) => self.frame_error("tick", &err),
         }
         self.step_physics(frame_time.dts);
@@ -268,7 +310,7 @@ impl GameProducer for MleWebGame {
             Value::Bool(is_down),
         ];
         match self.session.call("input", args, &mut FunctorHost) {
-            Ok(model) => self.model = model,
+            Ok(returned) => self.absorb(returned),
             Err(err) => self.frame_error("input", &err),
         }
     }
@@ -283,7 +325,7 @@ impl GameProducer for MleWebGame {
             Value::Number(y as f64),
         ];
         match self.session.call("mouseMove", args, &mut FunctorHost) {
-            Ok(model) => self.model = model,
+            Ok(returned) => self.absorb(returned),
             Err(err) => self.frame_error("mouseMove", &err),
         }
     }
@@ -294,7 +336,7 @@ impl GameProducer for MleWebGame {
         }
         let args = vec![self.model.clone(), Value::Number(delta as f64)];
         match self.session.call("mouseWheel", args, &mut FunctorHost) {
-            Ok(model) => self.model = model,
+            Ok(returned) => self.absorb(returned),
             Err(err) => self.frame_error("mouseWheel", &err),
         }
     }

--- a/tools/functor-sdk/test/mle-effects.e2e.test.ts
+++ b/tools/functor-sdk/test/mle-effects.e2e.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { findRepoRoot, FunctorRunner } from "../src/index.js";
+
+// B6 end-to-end (docs/mle.md): a key press returns `(model, effect)`; the
+// runner performs the effect through its real EffectRunner and folds the
+// tagger's message back through `update`. Real-world values aren't exact,
+// so the assertions are structural: the roll lands in [0, 1), the stamp is
+// a plausible wall-clock epoch, and both replaced their sentinels — proof
+// the whole chain (pair split → perform → tagger → update) ran in the
+// shipped runner. Exact-value determinism is pinned at the unit level
+// (fake/replay runners in mle_prelude).
+const e2eEnabled = process.env.FUNCTOR_E2E === "1";
+const headless = process.env.FUNCTOR_E2E_HEADLESS === "1";
+
+const game = `type Msg =
+  | Rolled(n: Float)
+  | Stamped(t: Float)
+let init = { roll: -1.0, at: -1.0 }
+let tick = (m, dt, tts) => m
+let update = (m, msg) =>
+  match msg with
+  | Rolled(n) => ({ m with roll: n }, Effect.now(Stamped))
+  | Stamped(t) => { m with at: t }
+let input = (m, key, isDown) =>
+  match isDown with
+  | true => (m, Effect.random(Rolled))
+  | false => m
+let draw = (m, tts) =>
+  Frame.create(Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0), Scene.cube())
+`;
+
+function fieldOf(model: string, name: string): number {
+  const m = model.match(new RegExp(`${name}:\\s*(-?[\\d.]+)`));
+  assert.ok(m, `could not find ${name} in model: ${model}`);
+  return Number(m[1]);
+}
+
+test(
+  "Effect.random/now perform through the runner and fold back via update",
+  { skip: !e2eEnabled, timeout: 120_000 },
+  async () => {
+    const repoRoot = findRepoRoot(process.cwd());
+    assert.ok(repoRoot, "must run from within the functor workspace");
+
+    const dir = mkdtempSync(join(tmpdir(), "mle-effects-"));
+    const mlePath = join(dir, "game.mle");
+    writeFileSync(mlePath, game);
+
+    await using runner = await FunctorRunner.launch({
+      gameDir: dir,
+      repoRoot,
+      mlePath,
+      port: Number(process.env.FUNCTOR_E2E_PORT ?? 8101),
+      headless,
+    });
+
+    await runner.pause();
+    let model = (await runner.state()).model;
+    assert.equal(fieldOf(model, "roll"), -1, `sentinel intact: ${model}`);
+
+    // One key press = one Effect.random, whose update chains an Effect.now.
+    await runner.key("Space", true);
+    await runner.step(0.1);
+    model = (await runner.state()).model;
+    const roll = fieldOf(model, "roll");
+    const at = fieldOf(model, "at");
+    assert.ok(roll >= 0 && roll < 1, `roll in [0,1): ${model}`);
+    // A real wall clock: after 2020, before 2100.
+    assert.ok(at > 1.6e9 && at < 4.1e9, `epoch stamp plausible: ${model}`);
+  },
+);


### PR DESCRIPTION
## What

One-shot commands close the MVU loop (roadmap **B6**), using #187's tuples for the contract shape: **any entry point may return `(model, effect)`**.

```mle
type Msg = | Rolled(n: Float) | Stamped(t: Float)

let update = (m, msg) =>
  match msg with
  | Rolled(n) => ({ m with roll: n }, Effect.now(Stamped))   // effects can chain
  | Stamped(t) => { m with at: t }

let input = (m, key, isDown) =>
  match isDown with
  | true => (m, Effect.random(Rolled))
  | false => m
```

- **Prelude**: `Effect.none/now/random/batch` — taggers validated callable at construction (`Effect.now(3.0)` is a teaching error). `Effect.now` → epoch seconds; `Effect.random` → [0, 1).
- **The broker**: `drain_effects` (prelude-level, **shared by both producers** — the C5 duplication lesson applied) performs each effect through an **`EffectRunner`**, applies the tagger via the new `Session::apply`, folds the message through `update`, and drains chained effects to a fixed point. Both producers funnel every entry-point return through one `absorb`.
- **Three worlds, one contract**: `RealEffects` (system clock + xorshift; the clock is `Date.now()` on wasm32, where `SystemTime` *panics*), `FakeEffects` (fixed values, for tests), `ReplayEffects` (feeds a recorded log back; divergence fails loud with the position).
- **Structured `EffectLog`**: `{kind, value}` records, bounded at 256 — LLM-readable, and exactly replay's input format.
- **Effects are commands, not data** (the contract that keeps the pair sniff unambiguous): an Effect inside `init` is a load error; one appearing in an adopted model draws a loud warning.
- Taggers run same-frame, so no closure outlives its session — no reload hazard (unlike F#'s Http taggers, which must be dropped on reload).

## Review

Codex CLI (adversarial): 1 High + 2 Medium + 2 Low — all addressed with pin tests:
- **[H — fixed]** The pair sniff could silently mis-split `let init = (0.0, Effect.none())`. Now enforced as the effects-are-not-data contract above (load rejection + deep-scan warning) instead of an ergonomics-killing wrapper type.
- **[M — fixed]** The drain cap now counts every dequeued node (a 1500-element batch of `Effect.none` can't consume unbounded frame time) and is checked *before* performing — the over-limit effect never half-runs (no RNG advanced, no replay entry consumed).
- **[L — fixed]** The log bound holds *mid-drain*, not just after.
- **[L — accepted]** `Session::apply`/`call` clone the globals map per invocation — pre-existing pattern, Rc-cheap values, cap-bounded; noted for the C6 perf gate.

(Claude reviewer unavailable — subagent session limit; Codex + implementation-time self-review per the established fallback.)

## Verification

- **The B6 contract as exact arithmetic**: the same program under `FakeEffects` and `ReplayEffects` produces the same model, and the fake run's log **is** replay's input; real differs only in world-supplied values (shape asserted). Divergent replay fails loud with position.
- Construction teaching errors, runaway-chain cap, structural-node cap, mid-drain log bound, nested-effect scan, init rejection — all pinned.
- **SDK e2e through the real runner**: key press → `Effect.random` → chained `Effect.now` → both sentinels replaced with a [0,1) roll and a plausible epoch stamp. Full suite **17/17**.
- 124 runtime-common / 24 desktop tests; wasm32 check clean for both `mle` and the web runtime.
- docs/mle.md B6 → [x]; skill documents `Effect.*`, the pair contract, and the determinism seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
