### PR TITLE
feat(vscode,web): D4 — live game preview in the editor, model-preserving reload in the browser

### DIFF
--- a/.claude/skills/mle-language/SKILL.md
+++ b/.claude/skills/mle-language/SKILL.md
@@ -238,8 +238,11 @@ debug server's `/time` advance. To *see* colliders, run with
 A project dir with `functor.json` `{"language": "mle", "entry": "game.mle"}`
 works with the CLI: `functor -d dir build` (typecheck, diagnostics are
 errors), `run native`, `develop` (hot reload is built in), and `run wasm`
-(the `.mle` ships as text and is interpreted in the browser; hot reload is
-native-only — reload the page to pick up edits).
+(the `.mle` ships as text and is interpreted in the browser; file-watch hot
+reload is native-only — reload the page to pick up saved edits, or push
+source with a `{ type: "mle-set-source", source }` postMessage to the page
+for a model-preserving in-place reload; the VSCode **"MLE: Open Live
+Preview"** command does exactly that from the live buffer as you type).
 
 `examples/mle-hello/game.mle` is the reference
 (`examples/mle-physics/game.mle` for the physics hook, including the

--- a/docs/mle.md
+++ b/docs/mle.md
@@ -405,19 +405,29 @@ First-class `.mle` editor support, built on the `mle` crate's front-end
 - [ ] **D3b. Go-to-definition.** Needs a use→definition query over the IR
       (it already carries spans on every node, but no query API yet); the
       hover node-walk is the natural starting point.
-- [ ] **D4. Live game preview in the editor** (needs C5). A VSCode webview
-      panel hosting the wasm runtime: the extension pushes the LIVE buffer
-      (debounced, unsaved included) into the webview, and a new
-      `set_source(src)` wasm export mirrors the native reload path —
-      parse → lower → check-as-warnings → `Session::load` →
-      `mle::rebind_value` on the held model. `Session`/`rebind` are pure
-      Rust, so **model-preserving hot reload runs in the browser**: type,
-      and the running game updates beside the editor without losing state
-      (a broken edit keeps the old program, same as native). v1 serves via
+- [x] **D4. Live game preview in the editor** (done 2026-07-03, needs C5).
+      A VSCode webview panel hosting the wasm runtime: the extension's
+      **"MLE: Open Live Preview"** command serves the project
+      (`functor run wasm --no-open`, binary from `mle.functorPath`) in a
+      full-size iframe and pushes the LIVE buffer (300ms debounce, unsaved
+      included) into it, and the new `mle_set_source` wasm export mirrors
+      the native reload path — parse → lower → check-as-warnings →
+      `Session::load` → `mle::rebind_value` on the held model (the web
+      producer keeps its lowered `Module` like the desktop one).
+      `Session`/`rebind` are pure Rust, so **model-preserving hot reload
+      runs in the browser**: type, and the running game updates beside the
+      editor without losing state (a broken edit keeps the old program,
+      same as native; the error lands in the status bar). v1 serves via
       `functor run wasm` + iframe; a bundled self-contained runtime can
-      come later. *Verify:* e2e-drive the wasm page directly
-      (`set_source` twice, assert model survived + behavior changed);
-      manual: edit `mle-hello` live in the panel.
+      come later. *Verify (done):* headless-Chromium e2e
+      (`node e2e/mle-preview-reload.mjs`, self-serving) drives the page's
+      postMessage seam on `mle-hello`: a green push reloads with "model
+      preserved" and the center pixel turns green; a probe whose tick
+      errors iff `spin <= 0.5` runs clean while its inversion errors —
+      spin only exceeds 0.5 by accumulating ACROSS reloads, so the model
+      demonstrably survived; a broken push is rejected with the parse
+      error and the old program keeps rendering; a push after the broken
+      one lands (12/12); manual: edit `mle-hello` live in the panel.
 
 ## Endgame — replace F#
 

--- a/e2e/mle-preview-reload.mjs
+++ b/e2e/mle-preview-reload.mjs
@@ -1,0 +1,204 @@
+// D4 e2e: model-preserving hot reload on wasm, driven over the page's
+// postMessage seam — the exact path the VSCode live-preview panel uses
+// (extension → webview → iframe is just plumbing on top of this).
+//
+// Serves examples/mle-hello with the built CLI, then drives headless
+// Chromium through the full story:
+//
+//   1. the original game renders (red-dominant pulsing centerpiece);
+//   2. a pushed source with a green emissive centerpiece reloads OK
+//      ("model preserved") and the pixels actually change to green;
+//   3. a probe push whose `tick` errors IFF `model.spin <= 0.5` runs clean —
+//      spin only exceeds 0.5 by accumulating across the reloads, so the
+//      model demonstrably survived;
+//   4. the inverted probe (errors IFF spin > 0.5) DOES error — proving the
+//      probe fires and the accumulated value is real, not a lucky default;
+//   5. a broken push (parse error) is rejected with the rendered error and
+//      the old program keeps rendering;
+//   6. a good push after the broken one still works.
+//
+// Run manually (not part of `playwright test` — it owns its own server):
+//
+//   npm run build:cli   # once, so target/debug/functor embeds the runtime
+//   node e2e/mle-preview-reload.mjs
+import { spawn } from "node:child_process";
+import { chromium } from "@playwright/test";
+
+const BASE = "http://127.0.0.1:8080";
+const ROOT = new URL("..", import.meta.url).pathname;
+
+// --- The pushed sources. -----------------------------------------------------
+
+// The model shape mle-hello's init establishes: { spin, beat }. Every push
+// keeps `tick` accumulating spin at 0.5/s so the survival probes have a
+// value that only time-across-reloads can produce.
+const TICK = `let tick = (model, dt: Float, tts: Float) => { model with spin: model.spin + dt * 0.5 }`;
+// A static, unmistakably green frame — draw ignores the model, so the pixel
+// assertion can't be confused by animation phase.
+const GREEN_DRAW = `let draw = (model, tts: Float) =>
+  Frame.create(
+    Camera.lookAt(0.0, 0.0, -6.0, 0.0, 0.0, 0.0),
+    Scene.sphere() |> Scene.emissive(0.1, 1.0, 0.2) |> Scene.scale(2.0))`;
+
+const V_GREEN = `let init = { spin: 0.0, beat: 0.0 }
+${TICK}
+${GREEN_DRAW}
+`;
+
+// Errors at runtime IFF the condition picks the probe arm (a missing-field
+// access is a spanned runtime error; a fresh init has spin = 0.0).
+const probe = (cond) => `let probeBoom = (m) => m.thisFieldDoesNotExist
+let init = { spin: 0.0, beat: 0.0 }
+let tick = (model, dt: Float, tts: Float) =>
+  match ${cond} with
+  | true => { model with spin: model.spin + dt * 0.5 }
+  | false => probeBoom(model)
+${GREEN_DRAW}
+`;
+const V_PROBE_SURVIVED = probe("model.spin > 0.5"); // clean iff model kept
+const V_PROBE_INVERTED = probe("model.spin < 0.5"); // errors iff model kept
+
+const V_BROKEN = "let init = {\n"; // parse error
+
+// --- Harness. ----------------------------------------------------------------
+
+let failures = 0;
+const check = (name, ok, detail = "") => {
+  console.log(`${ok ? "PASS" : "FAIL"}: ${name}${ok || !detail ? "" : ` — ${detail}`}`);
+  if (!ok) failures += 1;
+};
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const server = spawn("./target/debug/functor", ["-d", "examples/mle-hello", "run", "wasm", "--no-open"], {
+  cwd: ROOT,
+  stdio: "ignore",
+});
+process.on("exit", () => server.kill());
+
+// Wait for the dev server.
+for (let i = 0; ; i++) {
+  try {
+    await fetch(BASE);
+    break;
+  } catch {
+    if (i > 100) throw new Error("dev server never came up");
+    await sleep(200);
+  }
+}
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width: 640, height: 480 } });
+const consoleLog = [];
+page.on("console", (m) => consoleLog.push(`${m.type()}: ${m.text()}`));
+page.on("pageerror", (e) => consoleLog.push(`pageerror: ${e}`));
+
+await page.goto(BASE);
+for (let i = 0; !consoleLog.some((m) => m.includes("[mle] loaded")); i++) {
+  if (i > 100) throw new Error(`game never loaded:\n${consoleLog.join("\n")}`);
+  await sleep(200);
+}
+
+// Collect set-source results (posted back to the sender — here, the window
+// itself) and expose a helper to push source and await its result.
+await page.evaluate(() => {
+  window.__results = [];
+  window.addEventListener("message", (e) => {
+    if (e.data && e.data.type === "mle-set-source-result") window.__results.push(e.data);
+  });
+});
+const push = async (source) => {
+  const before = await page.evaluate(() => window.__results.length);
+  await page.evaluate((s) => window.postMessage({ type: "mle-set-source", source: s }, "*"), source);
+  await page.waitForFunction((n) => window.__results.length > n, before, { timeout: 5000 });
+  return page.evaluate(() => window.__results[window.__results.length - 1]);
+};
+
+// Sample the center pixel of the WebGL canvas. drawImage runs inside a rAF
+// callback registered after the runtime's, so it copies the just-rendered
+// buffer before compositing clears it (the canvas has no
+// preserveDrawingBuffer).
+const centerPixel = () =>
+  page.evaluate(
+    () =>
+      new Promise((resolve) => {
+        requestAnimationFrame(() => {
+          const gl = document.getElementById("canvas");
+          const c = document.createElement("canvas");
+          c.width = gl.width;
+          c.height = gl.height;
+          const ctx = c.getContext("2d");
+          ctx.drawImage(gl, 0, 0);
+          const d = ctx.getImageData((c.width / 2) | 0, (c.height / 2) | 0, 1, 1).data;
+          resolve([d[0], d[1], d[2]]);
+        });
+      })
+  );
+
+// 1. Let the game run so spin accumulates past the probe threshold
+//    (0.5/s × ~1.6s ≈ 0.8), then pin down the original look: mle-hello's
+//    centerpiece color has red = 1.0 always.
+await sleep(1600);
+const before = await centerPixel();
+check("original centerpiece is red-dominant", before[0] > 150, `center = rgb(${before})`);
+
+// 2. Push the green game: reload OK, model preserved, pixels change.
+const green = await push(V_GREEN);
+check("green push accepted", green.ok === true, JSON.stringify(green));
+check(
+  "green push status says model preserved",
+  green.ok && green.message.includes("model preserved"),
+  green.message
+);
+await sleep(400);
+const after = await centerPixel();
+check(
+  "render changed to the pushed green",
+  after[1] > 150 && after[0] < 100,
+  `center = rgb(${after})`
+);
+
+// 3. Survival probe: tick errors unless spin > 0.5 — a value only the
+//    PRESERVED model has (a fresh init restarts at 0.0).
+const survived = await push(V_PROBE_SURVIVED);
+check("survival probe accepted", survived.ok === true, JSON.stringify(survived));
+const errCount = () => consoleLog.filter((m) => m.includes("[mle] tick error")).length;
+const errsBefore = errCount();
+await sleep(700);
+check(
+  "model SURVIVED the reloads (probe tick runs clean)",
+  errCount() === errsBefore,
+  consoleLog.slice(-3).join("\n")
+);
+
+// 4. Inverted probe: must error — proving the probe fires and spin really
+//    is the accumulated value.
+const inverted = await push(V_PROBE_INVERTED);
+check("inverted probe accepted", inverted.ok === true, JSON.stringify(inverted));
+await sleep(700);
+check("inverted probe errors (accumulated spin is real)", errCount() > errsBefore);
+
+// 5. Broken push: rejected with the rendered parse error; the old program
+//    keeps rendering (still the static green frame).
+const broken = await push(V_BROKEN);
+check("broken push rejected", broken.ok === false, JSON.stringify(broken));
+check(
+  "broken push reports the parse error",
+  !broken.ok && broken.message.includes("cannot parse"),
+  broken.message
+);
+await sleep(400);
+const stillGreen = await centerPixel();
+check(
+  "old program keeps rendering after the broken push",
+  stillGreen[1] > 150 && stillGreen[0] < 100,
+  `center = rgb(${stillGreen})`
+);
+
+// 6. A good push after the broken one still lands.
+const recovered = await push(V_PROBE_SURVIVED);
+check("push after broken push works", recovered.ok === true, JSON.stringify(recovered));
+
+await browser.close();
+server.kill();
+console.log(failures === 0 ? "\nALL CHECKS PASSED" : `\n${failures} CHECK(S) FAILED`);
+process.exit(failures === 0 ? 0 : 1);

--- a/e2e/mle-preview-reload.mjs
+++ b/e2e/mle-preview-reload.mjs
@@ -22,10 +22,11 @@
 //   npm run build:cli   # once, so target/debug/functor embeds the runtime
 //   node e2e/mle-preview-reload.mjs
 import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { chromium } from "@playwright/test";
 
 const BASE = "http://127.0.0.1:8080";
-const ROOT = new URL("..", import.meta.url).pathname;
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
 
 // --- The pushed sources. -----------------------------------------------------
 

--- a/runtime/functor-runtime-web/index-mle.html
+++ b/runtime/functor-runtime-web/index-mle.html
@@ -111,9 +111,19 @@
             message = String(e);
           }
           if (event.source) {
-            event.source.postMessage({ type: "mle-set-source-result", ok, message }, "*");
+            event.source.postMessage(
+              { type: "mle-set-source-result", ok, message },
+              event.origin || "*"
+            );
           }
         });
+        // Tell a hosting frame the push seam is live — the editor panel
+        // flushes the current buffer on this (edits made while the server
+        // and wasm were still starting would otherwise be dropped), and its
+        // absence tells the panel it's NOT looking at an MLE preview page.
+        if (window.parent !== window) {
+          window.parent.postMessage({ type: "mle-preview-ready" }, "*");
+        }
       };
 
       init().then(() => {

--- a/runtime/functor-runtime-web/index-mle.html
+++ b/runtime/functor-runtime-web/index-mle.html
@@ -21,6 +21,7 @@
         mle_key_event,
         mle_mouse_move,
         mle_mouse_wheel,
+        mle_set_source,
       } from "./pkg/functor_runtime_web.js";
 
       // The MLE entry file, substituted in by the CLI's dev server (see
@@ -89,11 +90,38 @@
         });
       };
 
+      // Editor live-preview bridge (docs/mle.md D4): a hosting page (the
+      // VSCode webview's iframe bridge, or a test driving this page directly)
+      // posts the full .mle source and the runtime hot-swaps it, model
+      // preserved — the postMessage face of the desktop runner's
+      // POST /reload-source. Accept any origin (this page already runs
+      // arbitrary game code served locally), but reply only to the sender.
+      const setupSetSource = () => {
+        window.addEventListener("message", (event) => {
+          const data = event.data;
+          if (!data || data.type !== "mle-set-source" || typeof data.source !== "string") return;
+          let ok = true;
+          let message = "";
+          try {
+            message = mle_set_source(data.source);
+          } catch (e) {
+            // A broken push: the wasm export throws the rendered load error
+            // and the old program keeps running.
+            ok = false;
+            message = String(e);
+          }
+          if (event.source) {
+            event.source.postMessage({ type: "mle-set-source-result", ok, message }, "*");
+          }
+        });
+      };
+
       init().then(() => {
         // In a deterministic capture (?fixed-time), don't wire up input — a
         // stray mouse move would turn the camera, like on native.
         const deterministic = new URLSearchParams(window.location.search).has("fixed-time");
         if (!deterministic) setupInput();
+        setupSetSource();
       });
     </script>
   </body>

--- a/runtime/functor-runtime-web/index-mle.html
+++ b/runtime/functor-runtime-web/index-mle.html
@@ -21,6 +21,7 @@
         mle_key_event,
         mle_mouse_move,
         mle_mouse_wheel,
+        mle_is_running,
         mle_set_source,
       } from "./pkg/functor_runtime_web.js";
 
@@ -94,10 +95,12 @@
       // VSCode webview's iframe bridge, or a test driving this page directly)
       // posts the full .mle source and the runtime hot-swaps it, model
       // preserved — the postMessage face of the desktop runner's
-      // POST /reload-source. Accept any origin (this page already runs
-      // arbitrary game code served locally), but reply only to the sender.
+      // POST /reload-source. Pushes are accepted only from the HOSTING
+      // frame (the game code running in this page could otherwise spoof
+      // them); replies go only to the sender.
       const setupSetSource = () => {
         window.addEventListener("message", (event) => {
+          if (event.source !== window.parent) return;
           const data = event.data;
           if (!data || data.type !== "mle-set-source" || typeof data.source !== "string") return;
           let ok = true;
@@ -117,12 +120,22 @@
             );
           }
         });
-        // Tell a hosting frame the push seam is live — the editor panel
+        // Tell the hosting frame the push seam is live — the editor panel
         // flushes the current buffer on this (edits made while the server
         // and wasm were still starting would otherwise be dropped), and its
         // absence tells the panel it's NOT looking at an MLE preview page.
+        // "Live" means the PRODUCER is installed, not just the wasm module:
+        // run_async still has to fetch the source, so poll — a ready sent
+        // before mle_is_running() would invite a push that gets dropped.
         if (window.parent !== window) {
-          window.parent.postMessage({ type: "mle-preview-ready" }, "*");
+          const announce = () => {
+            if (mle_is_running()) {
+              window.parent.postMessage({ type: "mle-preview-ready" }, "*");
+            } else {
+              setTimeout(announce, 50);
+            }
+          };
+          announce();
         }
       };
 

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -101,6 +101,35 @@ async fn create_mle_game(path: &str) -> Result<mle_game::MleWebGame, String> {
     mle_game::MleWebGame::create(path, src)
 }
 
+thread_local! {
+    /// The live producer, shared between the frame loop and the
+    /// `mle_set_source` export below (docs/mle.md D4). `None` until
+    /// `run_async` has built it (still fetching, or the load failed).
+    static GAME: RefCell<Option<Rc<RefCell<Box<dyn GameProducer>>>>> =
+        const { RefCell::new(None) };
+}
+
+/// Hot-swap the running game's logic from pushed `.mle` source — the wasm
+/// counterpart of the desktop runner's `POST /reload-source` (docs/mle.md
+/// D4). Same semantics: the model is preserved (`mle::rebind_value`), a
+/// broken push keeps the old program running. `Ok` carries a short status
+/// line; `Err` (a JS throw) the rendered load error. On the F# page the
+/// producer's default `reload_source` refuses honestly.
+#[wasm_bindgen]
+pub fn mle_set_source(source: String) -> Result<String, String> {
+    let game = GAME.with(|g| g.borrow().clone());
+    let Some(game) = game else {
+        return Err("game is not running yet (still loading, or the load failed)".to_string());
+    };
+    // JS is single-threaded and postMessage handlers never run mid-frame, so
+    // this borrow can't collide with the frame loop's — but a panic here
+    // would poison the page, so refuse instead of unwrapping.
+    let Ok(mut game) = game.try_borrow_mut() else {
+        return Err("runtime is mid-frame; retry".to_string());
+    };
+    game.reload_source(&source)
+}
+
 #[wasm_bindgen]
 extern "C" {
     #[wasm_bindgen(js_namespace = game, js_name = render)]
@@ -861,7 +890,7 @@ async fn run_async() -> Result<(), JsValue> {
     // WebSocket events — see its doc): the MLE producer has no effects yet
     // (its drains return "[]"), so no completion ever needs to reach it.
     // Revisit when MLE grows effects (Track C4b-2).
-    let mut game: Box<dyn GameProducer> = match mle_game_path() {
+    let game: Box<dyn GameProducer> = match mle_game_path() {
         Some(path) => match create_mle_game(&path).await {
             Ok(game) => Box::new(game),
             Err(message) => {
@@ -872,6 +901,10 @@ async fn run_async() -> Result<(), JsValue> {
         },
         None => Box::new(WasmGame),
     };
+    // Share the producer with the `mle_set_source` export (docs/mle.md D4):
+    // the frame loop below and the editor push path borrow the same instance.
+    let game = Rc::new(RefCell::new(game));
+    GAME.with(|g| *g.borrow_mut() = Some(game.clone()));
 
     // Load game
     unsafe {
@@ -1006,6 +1039,10 @@ async fn run_async() -> Result<(), JsValue> {
         let mut sized = false;
 
         *g.borrow_mut() = Some(Closure::new(move || {
+            // The frame's exclusive borrow of the shared producer. Cannot
+            // collide with `mle_set_source`: JS is single-threaded, and
+            // message handlers only run between rAF callbacks.
+            let mut game = game.borrow_mut();
             let now = performance.now() as f32;
             // Pin the frame time when `?fixed-time` is set (deterministic capture).
             let frame_time = match fixed_time {
@@ -1021,24 +1058,24 @@ async fn run_async() -> Result<(), JsValue> {
             // Deliver page input queued since the last frame (the MLE path's
             // `mle_*` exports; empty and free on the F# path, whose page feeds
             // the game module directly).
-            mle_game::drain_input(&mut *game);
+            mle_game::drain_input(&mut **game);
 
             game.tick(frame_time.clone());
 
             // Perform any networking commands this frame's tick queued; results
             // are pushed back into the inbox asynchronously and decoded by a later
             // tick (see dispatch_net_commands).
-            dispatch_net_commands(&*game);
+            dispatch_net_commands(&**game);
             // Play any one-shot sounds this frame's tick queued (fetch + decode
             // the first time, then from the cache).
-            dispatch_audio_commands(&*game);
-            dispatch_conn_commands(&*game, &ws_state);
+            dispatch_audio_commands(&**game);
+            dispatch_conn_commands(&**game, &ws_state);
 
             let frame: Frame = game.render(frame_time.clone());
 
             // Soundscape: aim the listener from this frame's camera, then
             // reconcile the desired looping voices against the live ones.
-            update_soundscape(&*game, &frame.camera);
+            update_soundscape(&**game, &frame.camera);
 
             // Match the drawable buffer to the canvas's displayed (CSS) size,
             // scaled for HiDPI, so the view follows browser/window resizes. In

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -109,6 +109,14 @@ thread_local! {
         const { RefCell::new(None) };
 }
 
+/// Is the game producer installed yet? The preview page polls this before
+/// announcing readiness — a push before the producer exists would be
+/// dropped ("game is not running yet").
+#[wasm_bindgen]
+pub fn mle_is_running() -> bool {
+    GAME.with(|g| g.borrow().is_some())
+}
+
 /// Hot-swap the running game's logic from pushed `.mle` source — the wasm
 /// counterpart of the desktop runner's `POST /reload-source` (docs/mle.md
 /// D4). Same semantics: the model is preserved (`mle::rebind_value`), a
@@ -493,10 +501,7 @@ fn spatial_head(
 
 /// Fetch + decode a sound to an `AudioBuffer`, caching by path so repeat uses
 /// (one-shots and looping voices) are instant. `None` on any load/decode error.
-async fn decode_buffer(
-    ctx: &web_sys::AudioContext,
-    sound: &str,
-) -> Option<web_sys::AudioBuffer> {
+async fn decode_buffer(ctx: &web_sys::AudioContext, sound: &str) -> Option<web_sys::AudioBuffer> {
     use wasm_bindgen::JsCast;
 
     if let Some(b) = AUDIO_BUFFERS.with(|b| b.borrow().get(sound).cloned()) {

--- a/runtime/functor-runtime-web/src/mle_game.rs
+++ b/runtime/functor-runtime-web/src/mle_game.rs
@@ -8,8 +8,11 @@
 //!
 //! - the `.mle` source arrives over HTTP (fetched by `run_async` from the dev
 //!   server, which serves the project directory) instead of the filesystem;
-//! - no hot reload (the browser reloads the whole page — like the F# bridge's
-//!   `check_hot_reload` no-op);
+//! - no file-watch hot reload (there is no filesystem to watch), but the
+//!   PUSH path exists (docs/mle.md D4): `reload_source` mirrors the desktop
+//!   runner's `POST /reload-source` — parse → lower → check-as-warnings →
+//!   `Session::load` → `mle::rebind_value` on the held model — reachable
+//!   from the page via the `mle_set_source` wasm export in `lib.rs`;
 //! - no per-frame perf stats (`std::time::Instant` panics on wasm; the C6
 //!   perf gate measures natively);
 //! - input events arrive from the page via the `mle_*` wasm exports below,
@@ -32,6 +35,10 @@ use wasm_bindgen::prelude::*;
 pub struct MleWebGame {
     path: String,
     src: String,
+    /// The lowered module the current session came from — kept (like the
+    /// desktop producer) so a pushed reload can rebind model-stored closures
+    /// (old module × new module).
+    module: mle::ir::Module,
     session: Session,
     model: Value,
     has_input: bool,
@@ -47,7 +54,7 @@ pub struct MleWebGame {
     /// Performs `Effect.*` commands (B6). `RealEffects` is wasm-safe: its
     /// clock is `Date.now()` on this target.
     effect_runner: RealEffects,
-    /// The structured effect log (bounded) — see the desktop producer.
+    /// The structured effect log (bounded inside the drain).
     effect_log: EffectLog,
     /// The last successfully drawn frame, kept so a bad draw shows the last
     /// good picture instead of a blank.
@@ -58,108 +65,170 @@ pub struct MleWebGame {
     last_error: Option<String>,
 }
 
-impl MleWebGame {
-    /// Load, check, and contract-validate fetched game source — the web
-    /// counterpart of the desktop `load_game`. Errors come back as fully
-    /// rendered strings (`path:line:col: message`) for `run_async` to fail
-    /// loud with (there is no keep-running fallback: a page load either gets
-    /// a valid game or a console error).
-    pub fn create(path: &str, src: String) -> Result<MleWebGame, String> {
-        let render = |stage: &str, span: mle::Span, message: &str| {
-            let (line, col) = mle::line_col(&src, span.start);
-            format!("cannot {stage} {path}:{line}:{col}: {message}")
-        };
-        let program = mle::parse(&src).map_err(|e| render("parse", e.span, &e.message))?;
-        let module = mle::lower(program).map_err(|e| render("load", e.span, &e.message))?;
-        // Type diagnostics are advisory in the dev loop: warn, keep going
-        // (the CLI's `build` is the strict gate).
-        for diag in mle::check(&module) {
-            let (line, col) = mle::line_col(&src, diag.span.start);
-            web_sys::console::warn_1(
-                &format!("warning: {path}:{line}:{col}: {}", diag.message).into(),
-            );
-        }
-        let session = Session::load(&module, &mut FunctorHost)
-            .map_err(|f| render("load", f.error.span, &f.error.message))?;
-        // The producer contract is knowable at load — fail here, not once per
-        // frame: `init` must be a model VALUE, `tick`/`draw` functions of the
-        // right arity.
-        let init = session
-            .global("init")
-            .ok_or_else(|| format!("{path} has no top-level `let init = …`"))?;
-        if matches!(
-            init,
-            Value::Closure(_) | Value::Builtin(_) | Value::HostFn(_)
-        ) {
-            return Err(format!(
-                "{path}: `init` must be a model value, not a function"
-            ));
-        }
-        if functor_runtime_common::mle_prelude::contains_effect(&init) {
-            return Err(format!(
-                "{path}: `init` contains an Effect value — Effects are commands, not data; \
+/// A successfully loaded, contract-validated game module (the desktop
+/// producer's `Loaded`, verbatim minus the file-shaped fields).
+struct Loaded {
+    src: String,
+    module: mle::ir::Module,
+    session: Session,
+    init: Value,
+    has_input: bool,
+    has_mouse_move: bool,
+    has_mouse_wheel: bool,
+    has_subscriptions: bool,
+    has_physics: bool,
+}
+
+/// Load, check, and contract-validate game source — the web counterpart of
+/// the desktop `load_source`, shared by the page-load path (`create`) and
+/// the editor push path (`reload_source`). Errors come back as fully
+/// rendered strings (`path:line:col: message`); `path` is only a label for
+/// error rendering.
+fn load_source(path: &str, src: String) -> Result<Loaded, String> {
+    let render = |stage: &str, span: mle::Span, message: &str| {
+        let (line, col) = mle::line_col(&src, span.start);
+        format!("cannot {stage} {path}:{line}:{col}: {message}")
+    };
+    let program = mle::parse(&src).map_err(|e| render("parse", e.span, &e.message))?;
+    let module = mle::lower(program).map_err(|e| render("load", e.span, &e.message))?;
+    // Type diagnostics are advisory in the dev loop: warn, keep going
+    // (the CLI's `build` is the strict gate).
+    for diag in mle::check(&module) {
+        let (line, col) = mle::line_col(&src, diag.span.start);
+        web_sys::console::warn_1(&format!("warning: {path}:{line}:{col}: {}", diag.message).into());
+    }
+    let session = Session::load(&module, &mut FunctorHost)
+        .map_err(|f| render("load", f.error.span, &f.error.message))?;
+    // The producer contract is knowable at load — fail here, not once per
+    // frame: `init` must be a model VALUE, `tick`/`draw` functions of the
+    // right arity.
+    let init = session
+        .global("init")
+        .ok_or_else(|| format!("{path} has no top-level `let init = …`"))?;
+    if matches!(
+        init,
+        Value::Closure(_) | Value::Builtin(_) | Value::HostFn(_)
+    ) {
+        return Err(format!(
+            "{path}: `init` must be a model value, not a function"
+        ));
+    }
+    if contains_effect(&init) {
+        return Err(format!(
+            "{path}: `init` contains an Effect value — Effects are commands, not data; \
 return them beside the model as `(model, effect)`"
+        ));
+    }
+    require_function(path, &session, "tick", 3)?;
+    require_function(path, &session, "draw", 2)?;
+    // `input` is optional (many games are non-interactive), but when
+    // present it must honor the contract: (model, key, isDown) => model.
+    let has_input = session.global("input").is_some();
+    if has_input {
+        require_function(path, &session, "input", 3)?;
+    }
+    // Same deal for the mouse: `mouseMove(model, x, y)` in window pixels,
+    // `mouseWheel(model, delta)`.
+    let has_mouse_move = session.global("mouseMove").is_some();
+    if has_mouse_move {
+        require_function(path, &session, "mouseMove", 3)?;
+    }
+    let has_mouse_wheel = session.global("mouseWheel").is_some();
+    if has_mouse_wheel {
+        require_function(path, &session, "mouseWheel", 2)?;
+    }
+    // The MVU pair: `subscriptions(model)` declares timers whose fired
+    // messages fold through `update(model, msg)` — so subscriptions
+    // without an update have nowhere to deliver.
+    let has_subscriptions = session.global("subscriptions").is_some();
+    if has_subscriptions {
+        require_function(path, &session, "subscriptions", 1)?;
+        if session.global("update").is_none() {
+            return Err(format!(
+                "{path}: `subscriptions` produces messages but there is no \
+`let update = (model, msg) => …` to receive them"
             ));
         }
-        require_function(path, &session, "tick", 3)?;
-        require_function(path, &session, "draw", 2)?;
-        // `input` is optional (many games are non-interactive), but when
-        // present it must honor the contract: (model, key, isDown) => model.
-        let has_input = session.global("input").is_some();
-        if has_input {
-            require_function(path, &session, "input", 3)?;
-        }
-        // Same deal for the mouse: `mouseMove(model, x, y)` in window pixels,
-        // `mouseWheel(model, delta)`.
-        let has_mouse_move = session.global("mouseMove").is_some();
-        if has_mouse_move {
-            require_function(path, &session, "mouseMove", 3)?;
-        }
-        let has_mouse_wheel = session.global("mouseWheel").is_some();
-        if has_mouse_wheel {
-            require_function(path, &session, "mouseWheel", 2)?;
-        }
-        // The MVU pair: `subscriptions(model)` declares timers whose fired
-        // messages fold through `update(model, msg)` — so subscriptions
-        // without an update have nowhere to deliver.
-        let has_subscriptions = session.global("subscriptions").is_some();
-        if has_subscriptions {
-            require_function(path, &session, "subscriptions", 1)?;
-            if session.global("update").is_none() {
-                return Err(format!(
-                    "{path}: `subscriptions` produces messages but there is no \
-`let update = (model, msg) => …` to receive them"
-                ));
-            }
-        }
-        if session.global("update").is_some() {
-            require_function(path, &session, "update", 2)?;
-        }
-        // Optional physics: `physics(model) => Physics.scene(…)` declares the
-        // bodies that should exist; the host reconciles + fixed-steps the
-        // world after each tick (docs/physics.md). Rapier is pure Rust, so
-        // the world runs in the browser exactly as it does natively.
-        let has_physics = session.global("physics").is_some();
-        if has_physics {
-            require_function(path, &session, "physics", 1)?;
-        }
+    }
+    if session.global("update").is_some() {
+        require_function(path, &session, "update", 2)?;
+    }
+    // Optional physics: `physics(model) => Physics.scene(…)` declares the
+    // bodies that should exist; the host reconciles + fixed-steps the
+    // world after each tick (docs/physics.md). Rapier is pure Rust, so
+    // the world runs in the browser exactly as it does natively.
+    let has_physics = session.global("physics").is_some();
+    if has_physics {
+        require_function(path, &session, "physics", 1)?;
+    }
+    Ok(Loaded {
+        src,
+        module,
+        session,
+        init,
+        has_input,
+        has_mouse_move,
+        has_mouse_wheel,
+        has_subscriptions,
+        has_physics,
+    })
+}
+
+impl MleWebGame {
+    /// Build the producer from fetched game source. Errors come back fully
+    /// rendered for `run_async` to fail loud with (there is no keep-running
+    /// fallback: a page load either gets a valid game or a console error).
+    pub fn create(path: &str, src: String) -> Result<MleWebGame, String> {
+        let loaded = load_source(path, src)?;
         web_sys::console::log_1(&format!("[mle] loaded {path}").into());
         Ok(MleWebGame {
             path: path.to_string(),
-            src,
-            session,
-            model: init,
-            has_input,
-            has_mouse_move,
-            has_mouse_wheel,
-            has_subscriptions,
+            src: loaded.src,
+            module: loaded.module,
+            session: loaded.session,
+            model: loaded.init,
+            has_input: loaded.has_input,
+            has_mouse_move: loaded.has_mouse_move,
+            has_mouse_wheel: loaded.has_mouse_wheel,
+            has_subscriptions: loaded.has_subscriptions,
             prev_tts: None,
             effect_runner: RealEffects::new(),
             effect_log: EffectLog::new(),
-            has_physics,
+            has_physics: loaded.has_physics,
             last_frame: empty_frame(),
             last_error: None,
         })
+    }
+
+    /// Swap in a freshly loaded program, KEEPING THE MODEL — the desktop
+    /// producer's `swap_in`, verbatim. `init` from the new program is
+    /// deliberately unused: state survives the edit, and closures stored in
+    /// the model rebind to the edited code (B5 part 2, `mle::rebind_value`).
+    /// The physics world is deliberately KEPT too, like the model: it lives
+    /// in this process's registry, so bodies stay where they are across the
+    /// edit (removing the `physics` hook drops the world). `prev_tts` is kept
+    /// as well: `Sub.every` fires on the global time grid, so timers tick
+    /// right through a reload. Returns the number of stored closures rebound,
+    /// for the status line.
+    fn swap_in(&mut self, loaded: Loaded) -> usize {
+        let (model, report) = mle::rebind_value(&self.model, &self.module, &loaded.module);
+        self.model = model;
+        for warning in &report.warnings {
+            web_sys::console::warn_1(&format!("[mle] reload: {warning}").into());
+        }
+        self.src = loaded.src;
+        self.module = loaded.module;
+        self.session = loaded.session;
+        self.has_input = loaded.has_input;
+        self.has_mouse_move = loaded.has_mouse_move;
+        self.has_mouse_wheel = loaded.has_mouse_wheel;
+        self.has_subscriptions = loaded.has_subscriptions;
+        self.has_physics = loaded.has_physics;
+        if !self.has_physics {
+            physics::remove_world(physics::DEFAULT_WORLD);
+        }
+        self.last_error = None;
+        report.rebound
     }
 
     /// Fire subscription timers over `(prev_tts, tts]` and fold their
@@ -173,9 +242,7 @@ return them beside the model as `(model, effect)`"
         let (model, effects) = split_model_effect(returned);
         self.model = model;
         // Effects are commands, not data — one stored in the model would
-        // make the pair sniff ambiguous on a later return (see
-        // `split_model_effect`). Warn loud; the model is small (it is
-        // interpreted every frame anyway) so the scan is cheap.
+        // make the pair sniff ambiguous on a later return.
         if contains_effect(&self.model) {
             self.log_once(
                 "[mle] the model contains an Effect value — Effects are commands, \
@@ -287,8 +354,32 @@ to receive their messages; dropping them"
 }
 
 impl GameProducer for MleWebGame {
-    // Hot reload is native-only (docs/mle.md C3); on web, reload the page.
+    // File-watch hot reload is native-only (docs/mle.md C3) — there is no
+    // filesystem here. The PUSH path below is the web's reload.
     fn check_hot_reload(&mut self, _frame_time: FrameTime) {}
+
+    fn reload_source(&mut self, source: &str) -> Result<String, String> {
+        // The editor push path (docs/mle.md D4), same semantics as the
+        // desktop runner's `POST /reload-source`: model preserved, a broken
+        // push keeps the old program (and the error goes back to the pusher,
+        // who is looking at the source that caused it). No mtime bookkeeping
+        // — the browser has no file watcher; pushes are the only reload.
+        let started = js_sys::Date::now();
+        let loaded = load_source(&self.path, source.to_string())?;
+        let rebound = self.swap_in(loaded);
+        let stored = if rebound > 0 {
+            format!("; {rebound} stored closure(s) rebound")
+        } else {
+            String::new()
+        };
+        let status = format!(
+            "reloaded {} from pushed source in {:.2}ms (model preserved{stored})",
+            self.path,
+            js_sys::Date::now() - started
+        );
+        web_sys::console::log_1(&format!("[mle] {status}").into());
+        Ok(status)
+    }
 
     fn tick(&mut self, frame_time: FrameTime) {
         // Subscriptions first, so `tick` sees a model that has absorbed this

--- a/tools/mle-vscode/README.md
+++ b/tools/mle-vscode/README.md
@@ -5,6 +5,14 @@ Language support for `.mle` files (docs/mle.md Track D):
 - **Syntax highlighting** — TextMate grammar (`syntaxes/mle.tmLanguage.json`).
 - **Diagnostics** — parse/lower errors as you type, via the `mle-lsp` language
   server (`tools/mle-lsp` in this repo) speaking LSP over stdio.
+- **Live preview** — the **"MLE: Open Live Preview"** command (docs/mle.md D4)
+  serves the active file's project with `functor run wasm` in a webview panel
+  beside the editor, and hot-reloads it from the **live buffer** (unsaved
+  included, ~300ms debounce) with the model preserved — type, and the running
+  game updates without losing state. A broken edit keeps the old program
+  running; push results land in the status bar (errors also in the
+  "MLE Preview" output channel). Needs the `functor` CLI on PATH (or point
+  the `mle.functorPath` setting at the binary).
 
 ## Prerequisite: `mle-lsp` on PATH
 

--- a/tools/mle-vscode/client/extension.js
+++ b/tools/mle-vscode/client/extension.js
@@ -16,9 +16,14 @@ let client;
 // panel would kill the server out from under the other. Re-running the
 // command reveals the existing panel instead.
 let previewPanel;
+// The preview's dev-server child process — module-scoped so deactivate()
+// can kill it even if the panel outlives the command's closure (extension
+// reload/disable with the panel open must not orphan the server).
+let previewChild;
 
 // Where `functor run wasm` serves the game — fixed by the CLI's dev server.
 const PREVIEW_URL = "http://127.0.0.1:8080";
+const PREVIEW_ORIGIN = new URL(PREVIEW_URL).origin;
 // Edits push the full live buffer after this quiet period; the reload itself
 // is ~1ms in the runtime, so this is the whole edit→preview latency.
 const PUSH_DEBOUNCE_MS = 300;
@@ -41,6 +46,13 @@ function activate(context) {
 }
 
 function deactivate() {
+  // The panel usually kills its child on dispose, but extension
+  // reload/disable can tear us down with the panel still open — don't
+  // orphan the dev server on port 8080.
+  if (previewChild) {
+    previewChild.kill();
+    previewChild = undefined;
+  }
   return client ? client.stop() : undefined;
 }
 
@@ -132,6 +144,7 @@ async function openLivePreview() {
   const child = spawn(functorPath, ["-d", project.dir, "run", "wasm", "--no-open"], {
     cwd: project.dir,
   });
+  previewChild = child;
   child.stdout.on("data", (d) => log(d.toString()));
   child.stderr.on("data", (d) => log(d.toString()));
   child.on("error", (e) => {
@@ -155,8 +168,31 @@ async function openLivePreview() {
   // Push results surface here, non-modally: green check on a good reload,
   // the load error on a broken one (the old program keeps running).
   const status = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
+  // Readiness is the page's own announcement (origin-checked in the
+  // bridge): it proves 8080 is really the MLE preview — anything else
+  // answering HTTP there never sends it — and it's the moment to flush the
+  // CURRENT buffer, so edits made before the runtime came up (or while the
+  // file sat unsaved) are not dropped.
+  let ready = false;
+  let readyTimeout;
+  const pushCurrentBuffer = async () => {
+    try {
+      const doc = await vscode.workspace.openTextDocument(entryPath);
+      panel.webview.postMessage({ type: "mle-set-source", source: doc.getText() });
+    } catch (e) {
+      log(`[push] cannot read ${entryPath}: ${e}\n`);
+    }
+  };
   panel.webview.onDidReceiveMessage((msg) => {
-    if (!msg || msg.type !== "mle-set-source-result") return;
+    if (!msg) return;
+    if (msg.type === "mle-preview-ready") {
+      if (ready) return;
+      ready = true;
+      clearTimeout(readyTimeout);
+      pushCurrentBuffer();
+      return;
+    }
+    if (msg.type !== "mle-set-source-result") return;
     if (msg.ok) {
       status.text = "$(check) MLE preview: reloaded";
       status.tooltip = msg.message;
@@ -183,7 +219,9 @@ async function openLivePreview() {
   panel.onDidDispose(() => {
     disposed = true;
     previewPanel = undefined;
+    previewChild = undefined;
     clearTimeout(debounce);
+    clearTimeout(readyTimeout);
     changeSub.dispose();
     status.dispose();
     child.kill();
@@ -196,6 +234,13 @@ async function openLivePreview() {
   if (disposed) return;
   if (up) {
     panel.webview.postMessage({ type: "mle-preview-navigate", url: PREVIEW_URL });
+    readyTimeout = setTimeout(() => {
+      if (ready || disposed) return;
+      vscode.window.showErrorMessage(
+        `MLE: ${PREVIEW_URL} answered but never announced the MLE preview — ` +
+          `is something else using that port?`
+      );
+    }, SERVER_WAIT_MS);
   } else {
     vscode.window.showErrorMessage(
       `MLE: the functor dev server did not come up at ${PREVIEW_URL} — see the "MLE Preview" output.`
@@ -236,11 +281,15 @@ function previewHtml() {
           frame.style.display = "block";
           document.getElementById("waiting").style.display = "none";
         } else if (data.type === "mle-set-source") {
-          // Extension → game page. The game page accepts any origin (it
-          // already runs arbitrary local game code) and replies to us.
+          // Extension → game page (the page only accepts pushes from its
+          // parent — us).
           if (frame.contentWindow) frame.contentWindow.postMessage(data, "*");
-        } else if (data.type === "mle-set-source-result") {
-          // Game page → extension.
+        } else if (data.type === "mle-set-source-result" || data.type === "mle-preview-ready") {
+          // Game page → extension. Only trust the page we framed: anything
+          // else on that port (or the game code itself) must not spoof
+          // results or readiness.
+          if (event.source !== frame.contentWindow) return;
+          if (event.origin && event.origin !== "${PREVIEW_ORIGIN}") return;
           vscode.postMessage(data);
         }
       });

--- a/tools/mle-vscode/client/extension.js
+++ b/tools/mle-vscode/client/extension.js
@@ -1,12 +1,26 @@
-// MLE extension entry point: start an LSP client for `.mle` documents,
-// launching the `mle-lsp` binary from PATH (see ../README.md for how to get
-// it there). Plain JS on purpose — no bundler or TS build step; the only
-// runtime dependency is vscode-languageclient.
+// MLE extension entry point: an LSP client for `.mle` documents (launching
+// the `mle-lsp` binary from PATH — see ../README.md for how to get it there)
+// and the live game preview panel (docs/mle.md D4). Plain JS on purpose — no
+// bundler or TS build step; the only runtime dependency is
+// vscode-languageclient.
+const vscode = require("vscode");
+const fs = require("node:fs");
+const http = require("node:http");
+const path = require("node:path");
+const { spawn } = require("node:child_process");
 const { LanguageClient } = require("vscode-languageclient/node");
 
 let client;
 
-function activate() {
+// Where `functor run wasm` serves the game — fixed by the CLI's dev server.
+const PREVIEW_URL = "http://127.0.0.1:8080";
+// Edits push the full live buffer after this quiet period; the reload itself
+// is ~1ms in the runtime, so this is the whole edit→preview latency.
+const PUSH_DEBOUNCE_MS = 300;
+// How long to wait for the dev server to come up (first run may compile).
+const SERVER_WAIT_MS = 30000;
+
+function activate(context) {
   client = new LanguageClient(
     "mle",
     "MLE Language Server",
@@ -15,10 +29,204 @@ function activate() {
     { documentSelector: [{ language: "mle" }] }
   );
   client.start();
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("mle.openLivePreview", openLivePreview)
+  );
 }
 
 function deactivate() {
   return client ? client.stop() : undefined;
+}
+
+// Walk up from an .mle file to the functor.json declaring an MLE project —
+// the directory `functor -d <dir>` operates on. Returns { dir, entry } or
+// null. A functor.json for another language (or an unreadable one) is
+// skipped and the walk continues, so nested projects resolve correctly.
+function findMleProject(fromFile) {
+  let dir = path.dirname(fromFile);
+  for (;;) {
+    const manifest = path.join(dir, "functor.json");
+    if (fs.existsSync(manifest)) {
+      try {
+        const json = JSON.parse(fs.readFileSync(manifest, "utf8"));
+        if (json.language === "mle" && typeof json.entry === "string") {
+          return { dir, entry: json.entry };
+        }
+      } catch {
+        // Unparseable manifest: keep walking.
+      }
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+// Poll the dev server until it answers (the CLI may still be starting up).
+function waitForServer(timeoutMs) {
+  return new Promise((resolve) => {
+    const deadline = Date.now() + timeoutMs;
+    const poll = () => {
+      const req = http.get(PREVIEW_URL, (res) => {
+        res.resume();
+        resolve(true);
+      });
+      req.on("error", () => {
+        if (Date.now() > deadline) resolve(false);
+        else setTimeout(poll, 300);
+      });
+    };
+    poll();
+  });
+}
+
+// "MLE: Open Live Preview" — serve the active file's project with
+// `functor run wasm` and host the running game in a webview panel that
+// hot-reloads from the LIVE buffer (unsaved included), model preserved.
+async function openLivePreview() {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor || !editor.document.fileName.endsWith(".mle")) {
+    vscode.window.showErrorMessage(
+      "MLE: open the project's .mle file first — the preview serves the project it belongs to."
+    );
+    return;
+  }
+  const project = findMleProject(editor.document.fileName);
+  if (!project) {
+    vscode.window.showErrorMessage(
+      `MLE: no functor.json with "language": "mle" found in any directory above ` +
+        `${editor.document.fileName} — create one ({"language": "mle", "entry": "game.mle"}) ` +
+        "in the project directory."
+    );
+    return;
+  }
+  const entryPath = path.resolve(project.dir, project.entry);
+
+  // The dev server child. If 8080 is already served (a second panel, or a
+  // manual `functor run wasm`) this child exits with a bind error — logged
+  // to the output channel — and the panel simply attaches to the running
+  // server.
+  const functorPath =
+    vscode.workspace.getConfiguration("mle").get("functorPath") || "functor";
+  const output = vscode.window.createOutputChannel("MLE Preview");
+  const child = spawn(functorPath, ["-d", project.dir, "run", "wasm", "--no-open"], {
+    cwd: project.dir,
+  });
+  child.stdout.on("data", (d) => output.append(d.toString()));
+  child.stderr.on("data", (d) => output.append(d.toString()));
+  child.on("error", (e) => {
+    vscode.window.showErrorMessage(
+      `MLE: cannot start "${functorPath}" (${e.message}) — set mle.functorPath to the functor CLI binary.`
+    );
+  });
+  child.on("exit", (code) => output.appendLine(`[functor exited with code ${code}]`));
+
+  const panel = vscode.window.createWebviewPanel(
+    "mleLivePreview",
+    `MLE Live Preview — ${path.basename(project.dir)}`,
+    vscode.ViewColumn.Beside,
+    // Scripts run the bridge below; retainContextWhenHidden keeps the game
+    // (and its model) alive when the panel is tabbed away.
+    { enableScripts: true, retainContextWhenHidden: true }
+  );
+  panel.webview.html = previewHtml();
+
+  // Push results surface here, non-modally: green check on a good reload,
+  // the load error on a broken one (the old program keeps running).
+  const status = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
+  panel.webview.onDidReceiveMessage((msg) => {
+    if (!msg || msg.type !== "mle-set-source-result") return;
+    if (msg.ok) {
+      status.text = "$(check) MLE preview: reloaded";
+      status.tooltip = msg.message;
+    } else {
+      status.text = "$(error) MLE preview: push failed";
+      status.tooltip = msg.message;
+      output.appendLine(`[push] ${msg.message}`);
+    }
+    status.show();
+  });
+
+  // Push the full live buffer (unsaved included) on every edit to the entry
+  // file, debounced. The runtime keeps the model across the swap, so state
+  // survives typing; a broken buffer keeps the old program running.
+  let debounce;
+  const changeSub = vscode.workspace.onDidChangeTextDocument((e) => {
+    if (path.resolve(e.document.fileName) !== entryPath) return;
+    clearTimeout(debounce);
+    debounce = setTimeout(() => {
+      panel.webview.postMessage({ type: "mle-set-source", source: e.document.getText() });
+    }, PUSH_DEBOUNCE_MS);
+  });
+
+  let disposed = false;
+  panel.onDidDispose(() => {
+    disposed = true;
+    clearTimeout(debounce);
+    changeSub.dispose();
+    status.dispose();
+    child.kill();
+    output.dispose();
+  });
+
+  // Point the iframe at the dev server once it answers (the webview shows
+  // "starting…" until then).
+  const up = await waitForServer(SERVER_WAIT_MS);
+  if (disposed) return;
+  if (up) {
+    panel.webview.postMessage({ type: "mle-preview-navigate", url: PREVIEW_URL });
+  } else {
+    vscode.window.showErrorMessage(
+      `MLE: the functor dev server did not come up at ${PREVIEW_URL} — see the "MLE Preview" output.`
+    );
+  }
+}
+
+// The panel document: a full-size iframe hosting the game page, plus the
+// message bridge — extension → webview → iframe for source pushes, and
+// iframe → webview → extension for results. The game page itself does the
+// reload (see index-mle.html's mle-set-source listener in the runtime).
+function previewHtml() {
+  return `<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="Content-Security-Policy"
+          content="default-src 'none'; frame-src ${PREVIEW_URL}; script-src 'unsafe-inline'; style-src 'unsafe-inline'" />
+    <style>
+      html, body { margin: 0; padding: 0; width: 100%; height: 100%; overflow: hidden; }
+      #frame { border: 0; width: 100%; height: 100%; display: none; }
+      #waiting { font-family: sans-serif; padding: 1em; opacity: 0.7; }
+    </style>
+  </head>
+  <body>
+    <div id="waiting">Starting the functor dev server…</div>
+    <iframe id="frame"></iframe>
+    <script>
+      const vscode = acquireVsCodeApi();
+      const frame = document.getElementById("frame");
+      // Messages from the extension and from the iframe arrive on the same
+      // window listener; the disjoint "type" fields route them.
+      window.addEventListener("message", (event) => {
+        const data = event.data;
+        if (!data) return;
+        if (data.type === "mle-preview-navigate") {
+          frame.src = data.url;
+          frame.style.display = "block";
+          document.getElementById("waiting").style.display = "none";
+        } else if (data.type === "mle-set-source") {
+          // Extension → game page. The game page accepts any origin (it
+          // already runs arbitrary local game code) and replies to us.
+          if (frame.contentWindow) frame.contentWindow.postMessage(data, "*");
+        } else if (data.type === "mle-set-source-result") {
+          // Game page → extension.
+          vscode.postMessage(data);
+        }
+      });
+    </script>
+  </body>
+</html>`;
 }
 
 module.exports = { activate, deactivate };

--- a/tools/mle-vscode/client/extension.js
+++ b/tools/mle-vscode/client/extension.js
@@ -11,6 +11,11 @@ const { spawn } = require("node:child_process");
 const { LanguageClient } = require("vscode-languageclient/node");
 
 let client;
+// The open preview panel, if any. A singleton: the dev server owns a fixed
+// port, so a second panel would race the first for it — and closing either
+// panel would kill the server out from under the other. Re-running the
+// command reveals the existing panel instead.
+let previewPanel;
 
 // Where `functor run wasm` serves the game — fixed by the CLI's dev server.
 const PREVIEW_URL = "http://127.0.0.1:8080";
@@ -68,10 +73,13 @@ function waitForServer(timeoutMs) {
   return new Promise((resolve) => {
     const deadline = Date.now() + timeoutMs;
     const poll = () => {
-      const req = http.get(PREVIEW_URL, (res) => {
+      const req = http.get(PREVIEW_URL, { timeout: 2000 }, (res) => {
         res.resume();
         resolve(true);
       });
+      // A connected-but-silent socket must not stall the poll past the
+      // deadline; destroy() surfaces as the error event below.
+      req.on("timeout", () => req.destroy());
       req.on("error", () => {
         if (Date.now() > deadline) resolve(false);
         else setTimeout(poll, 300);
@@ -85,6 +93,10 @@ function waitForServer(timeoutMs) {
 // `functor run wasm` and host the running game in a webview panel that
 // hot-reloads from the LIVE buffer (unsaved included), model preserved.
 async function openLivePreview() {
+  if (previewPanel) {
+    previewPanel.reveal();
+    return;
+  }
   const editor = vscode.window.activeTextEditor;
   if (!editor || !editor.document.fileName.endsWith(".mle")) {
     vscode.window.showErrorMessage(
@@ -110,17 +122,24 @@ async function openLivePreview() {
   const functorPath =
     vscode.workspace.getConfiguration("mle").get("functorPath") || "functor";
   const output = vscode.window.createOutputChannel("MLE Preview");
+  // The child outlives the panel by a beat (kill() on dispose, exit later),
+  // so every output write is gated on the panel still being alive — VSCode
+  // throws on appending to a disposed channel.
+  let disposed = false;
+  const log = (text) => {
+    if (!disposed) output.append(text);
+  };
   const child = spawn(functorPath, ["-d", project.dir, "run", "wasm", "--no-open"], {
     cwd: project.dir,
   });
-  child.stdout.on("data", (d) => output.append(d.toString()));
-  child.stderr.on("data", (d) => output.append(d.toString()));
+  child.stdout.on("data", (d) => log(d.toString()));
+  child.stderr.on("data", (d) => log(d.toString()));
   child.on("error", (e) => {
     vscode.window.showErrorMessage(
       `MLE: cannot start "${functorPath}" (${e.message}) — set mle.functorPath to the functor CLI binary.`
     );
   });
-  child.on("exit", (code) => output.appendLine(`[functor exited with code ${code}]`));
+  child.on("exit", (code) => log(`[functor exited with code ${code}]\n`));
 
   const panel = vscode.window.createWebviewPanel(
     "mleLivePreview",
@@ -130,6 +149,7 @@ async function openLivePreview() {
     // (and its model) alive when the panel is tabbed away.
     { enableScripts: true, retainContextWhenHidden: true }
   );
+  previewPanel = panel;
   panel.webview.html = previewHtml();
 
   // Push results surface here, non-modally: green check on a good reload,
@@ -143,7 +163,7 @@ async function openLivePreview() {
     } else {
       status.text = "$(error) MLE preview: push failed";
       status.tooltip = msg.message;
-      output.appendLine(`[push] ${msg.message}`);
+      log(`[push] ${msg.message}\n`);
     }
     status.show();
   });
@@ -160,9 +180,9 @@ async function openLivePreview() {
     }, PUSH_DEBOUNCE_MS);
   });
 
-  let disposed = false;
   panel.onDidDispose(() => {
     disposed = true;
+    previewPanel = undefined;
     clearTimeout(debounce);
     changeSub.dispose();
     status.dispose();

--- a/tools/mle-vscode/package.json
+++ b/tools/mle-vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mle-vscode",
   "displayName": "MLE",
-  "description": "Language support for MLE (.mle): syntax highlighting and diagnostics via the mle-lsp language server.",
+  "description": "Language support for MLE (.mle): syntax highlighting and diagnostics via the mle-lsp language server, plus a live game preview panel with model-preserving hot reload.",
   "version": "0.1.0",
   "publisher": "functor",
   "license": "MIT",
@@ -16,6 +16,22 @@
     "onLanguage:mle"
   ],
   "contributes": {
+    "commands": [
+      {
+        "command": "mle.openLivePreview",
+        "title": "MLE: Open Live Preview"
+      }
+    ],
+    "configuration": {
+      "title": "MLE",
+      "properties": {
+        "mle.functorPath": {
+          "type": "string",
+          "default": "functor",
+          "description": "Path to the `functor` CLI binary the live preview uses to serve the game (resolved from PATH by default)."
+        }
+      }
+    },
     "languages": [
       {
         "id": "mle",


### PR DESCRIPTION
## What

Roadmap **D4**: a VSCode webview panel hosting the running wasm game, hot-reloaded from the **live buffer** (unsaved included), model preserved — the C3 payoff inside the editor.

- **`mle_set_source`** (wasm export): the browser counterpart of the native runner's `POST /reload-source` — parse → lower → check-as-warnings → `Session::load` → **`mle::rebind_value`** on the held model. A broken push keeps the old program running and returns the rendered error. `load_game` refactored into `load_source(path, src)`, shared by page load and pushes. Producer state (subscription window, effect runner/log, physics world) survives the swap, matching the desktop contract.
- **The page** announces `mle-preview-ready` to its hosting frame — but only once `mle_is_running()` (the producer install is async behind the source fetch), and accepts pushes only from its parent frame.
- **The extension** ("MLE: Open Live Preview"): finds the `functor.json` project, spawns `functor run wasm --no-open` (`mle.functorPath` setting), opens a singleton panel with an iframe bridge, and pushes the buffer on a 300ms debounce. On readiness it **flushes the current buffer** (dirty-open files preview correctly), and readiness doubles as proof-of-right-service — if something else answers on 8080 without announcing, you get an error, not a silently framed foreign page. Push results land in the status bar; panel dispose *and* extension deactivate kill the dev server.

## How it was built

By a subagent (instructed to commit incrementally after the last one died with everything uncommitted — it paid off: when this one also hit the session limit, all four milestones were already committed and only a final polish pass needed finishing). I completed the polish, rebased onto main — resolving `mle_game.rs` against B6 (#190): D4's `load_source` structure + B6's effects wiring unioned — and re-verified.

Codex review: **2 High + 3 Medium, all fixed** (initial-flush gap, ready-before-producer race — closed with the `mle_is_running` poll — wrong-service detection, message spoofing at both ends, deactivate teardown). Claude reviewer unavailable (subagent limit).

## Verification

- **Playwright e2e** (`e2e/mle-preview-reload.mjs`) drives the exact postMessage seam the panel uses: push green source → status says model preserved, render changes; survival probe proves accumulated spin is real (its inverted twin errors); broken push → rejected with the parse error, old program keeps rendering; recovery push works. **12/12 checks**, re-run after a full `npm run build:cli` rebuild of the rebased code.
- `cargo check -p functor-runtime-web --target wasm32-unknown-unknown` clean; `node --check` on the extension.
- docs/mle.md D4 → [x]; the skill notes the wasm reload story.

## Manual check (the fun one)

Open `examples/mle-hello/game.mle`, run **"MLE: Open Live Preview"**, and type — change the centerpiece color and watch it change beside the editor *without the ring losing its spin*. A syntax error mid-edit shows in the status bar while the game keeps running; fixing it recovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
