### PR TITLE
feat(mle): C4b-3 — the render-target surface + examples/mle-monitor

### DIFF
--- a/.claude/skills/mle-language/SKILL.md
+++ b/.claude/skills/mle-language/SKILL.md
@@ -163,6 +163,27 @@ Light.ambient(r, g, b) / Light.point(px, py, pz, r, g, b, intensity, range)
 Light.directional(dx, dy, dz, r, g, b, intensity) |> Light.castShadows
 Frame.create(camera, scene)                                // what draw returns
 Frame.createLit(camera, scene, [light, …])                 // lit + shadowed
+RenderTarget.named("id")                                   // offscreen texture, 512x512…
+RenderTarget.named("id") |> RenderTarget.sized(w, h)       // …unless sized. Declare ONCE,
+                                                           //   use the VALUE at both sites
+                                                           //   (never a bare string — the
+                                                           //   Angle rule for identity)
+frame |> Frame.withRenderTarget(target, targetFrame)       // writer: targetFrame (a full
+                                                           //   Frame.create/createLit) is
+                                                           //   rendered into the target
+                                                           //   before frame's main pass
+                                                           //   with its OWN lights — use
+                                                           //   createLit + castShadows for
+                                                           //   a lit/shadowed feed. A scene
+                                                           //   sampling its OWN target
+                                                           //   sees last frame's image
+scene |> Scene.screen(target)                              // reader: emissive screen
+                                                           //   showing the target; an
+                                                           //   undeclared id = magenta +
+                                                           //   one warning. A quad's front
+                                                           //   is +Z — rotate the monitor
+                                                           //   to face the viewer or the
+                                                           //   feed shows mirrored
 Time.seconds(1.0) / Time.millis(500.0)                     // Duration VALUES only
 Sub.every(duration, msg) / Sub.none() / Sub.batch([sub,…]) // what subscriptions returns
 Effect.random(tagger) / Effect.now(tagger)                 // one-shots; tagger: (Float) => Msg

--- a/docs/mle.md
+++ b/docs/mle.md
@@ -357,6 +357,23 @@ Starts once A2 + B3 exist.
         ADDS subscriptions starts from the current frame edge (no
         catch-up burst); prelude unit tests pin the grid math and the
         teaching errors (15/15 e2e suite).
+      - [x] **C4b-3. Render targets** (done 2026-07-04): prelude grows
+        the render-to-texture surface over the engine feature —
+        `RenderTarget.named`/`sized` (a branded handle: the Angle rule
+        applied to *identity*, so writer/reader id typos are
+        unrepresentable), `Frame.withRenderTarget(frame, target,
+        targetFrame)` (the writer: a full inner frame — camera/scene/
+        lights — rendered offscreen before the main pass, with the
+        inner frame's own lights: `Frame.createLit` + `castShadows`
+        gives a lit, shadowed feed), and `Scene.screen(scene, target)`
+        (the reader: an emissive surface showing the target's texture;
+        an undeclared id renders magenta + warns once).
+        `examples/mle-monitor` demos it: a panning security camera
+        filming the courtyard, shown live on an in-world monitor.
+        *Verify (done):* prelude unit tests pin the frame's target
+        passes, the Scene.screen wire shape, and the branded-value
+        teaching errors; deterministic `--fixed-time` captures of
+        mle-monitor show the second camera's view on the screen.
 - [x] **C5. Wasm** (done 2026-07-03). `MleWebGame` in the web runtime — the
       wasm sibling of the desktop producer behind the same `GameProducer`
       seam: identical load-contract validation, MVU subscriptions pump,

--- a/examples/mle-monitor/functor.json
+++ b/examples/mle-monitor/functor.json
@@ -1,0 +1,4 @@
+{
+  "language": "mle",
+  "entry": "game.mle"
+}

--- a/examples/mle-monitor/game.mle
+++ b/examples/mle-monitor/game.mle
@@ -1,0 +1,96 @@
+// examples/mle-monitor — render targets (the security-camera demo).
+//
+// A panning camera gadget films the courtyard; its view renders into the
+// "security" render target each frame (Frame.withRenderTarget), and the
+// monitor's screen shows it live (Scene.screen). The feed is a full frame of
+// its own — camera, scene, lights — so it is lit and shadowed like the main
+// view. All animation derives from tts, so captures are deterministic under
+// --fixed-time.
+
+// The branded target: declared ONCE, used at the writer (draw's
+// Frame.withRenderTarget) and the reader (the monitor's Scene.screen).
+let feed = RenderTarget.named("security") |> RenderTarget.sized(256.0, 256.0)
+
+// The security camera's pan angle (radians), shared by the visible gadget
+// and the feed camera so the picture matches the prop.
+// Amplitude stays inside the feed's ~±22° half-fov, so the courtyard never
+// fully leaves the picture.
+let pan = (tts: Float) => Math.sin(tts * 0.5) * 0.5
+
+// An orbiting glow so the feed visibly animates.
+let orbiter = (tts: Float) =>
+  Scene.sphere()
+    |> Scene.scale(0.45)
+    |> Scene.emissive(1.0, 0.55, 0.15)
+    |> Scene.translate(Math.cos(tts * 0.8) * 3.0, 0.6, 3.0 + Math.sin(tts * 0.8) * 2.0)
+
+// The courtyard both cameras film.
+let courtyard = (tts: Float) =>
+  Scene.group([
+    Scene.plane() |> Scene.scale(22.0) |> Scene.lit(0.55, 0.6, 0.55),
+    Scene.cube() |> Scene.lit(0.85, 0.3, 0.25) |> Scene.translate(-2.4, 0.5, 2.0),
+    Scene.cube()
+      |> Scene.scale(0.7)
+      |> Scene.rotateY(Angle.degrees(30.0))
+      |> Scene.lit(0.3, 0.5, 0.9)
+      |> Scene.translate(2.2, 0.35, 3.4),
+    Scene.cylinder() |> Scene.lit(0.9, 0.8, 0.3) |> Scene.translate(0.5, 0.5, 5.2),
+    orbiter(tts),
+  ])
+
+let lights = () => [
+  Light.ambient(0.12, 0.12, 0.15),
+  Light.directional(0.4, -1.0, 0.3, 1.0, 0.97, 0.9, 0.9) |> Light.castShadows,
+]
+
+// The visible camera prop: a head with a lens (a cylinder's axis is Y;
+// rotateX aims it along +Z), yawed by the SAME pan driving the feed camera.
+let cameraGadget = (tts: Float) =>
+  Scene.group([
+    Scene.cube() |> Scene.scale(0.45) |> Scene.lit(0.25, 0.25, 0.28),
+    Scene.cylinder()
+      |> Scene.scale(0.2)
+      |> Scene.rotateX(Angle.degrees(90.0))
+      |> Scene.lit(0.1, 0.1, 0.1)
+      |> Scene.translate(0.0, 0.0, 0.35),
+  ])
+    |> Scene.rotateY(Angle.radians(pan(tts)))
+    |> Scene.scale(0.8)
+    |> Scene.translate(0.0, 3.2, -5.0)
+
+// What the security camera sees: its own full frame — the courtyard from the
+// gadget's mount, looking where the gadget points. (The feed deliberately
+// films only the courtyard: a target's scene is independent of the main one.)
+let feedFrame = (tts: Float) =>
+  Frame.createLit(
+    Camera.lookAt(
+      0.0, 3.2, -5.0,
+      Math.sin(pan(tts)) * 8.0, 0.5, -5.0 + Math.cos(pan(tts)) * 8.0),
+    courtyard(tts),
+    lights())
+
+// The monitor: a dark bezel block with the screen on its camera-facing side.
+// A quad's front is +Z and the main camera looks down +Z, so the screen is
+// rotated 180° to face the viewer — an unrotated quad would show its back,
+// a mirrored feed.
+let monitor = () =>
+  Scene.group([
+    Scene.cube() |> Scene.scale(2.4) |> Scene.lit(0.08, 0.08, 0.09),
+    Scene.quad()
+      |> Scene.screen(feed)
+      |> Scene.rotateY(Angle.degrees(180.0))
+      |> Scene.scale(2.0)
+      |> Scene.translate(0.0, 0.0, -1.25),
+  ])
+    |> Scene.rotateY(Angle.degrees(25.0))
+    |> Scene.translate(3.1, 1.5, -0.6)
+
+let init = {}
+let tick = (m, dt, tts) => m
+
+let draw = (m, tts: Float) =>
+  Frame.createLit(
+    Camera.lookAt(0.0, 2.6, -9.5, 0.0, 1.2, 0.0),
+    Scene.group([courtyard(tts), cameraGadget(tts), monitor()]),
+    lights())
+  |> Frame.withRenderTarget(feed, feedFrame(tts))

--- a/runtime/functor-runtime-common/src/mle_prelude.rs
+++ b/runtime/functor-runtime-common/src/mle_prelude.rs
@@ -22,6 +22,18 @@
 //! Camera.lookAt(ex, ey, ez, tx, ty, tz)                     -> Camera
 //!   (up is +Y; vertical fov pinned at 45°, near/far at protocol defaults)
 //! Frame.create(camera, scene)                               -> Frame
+//! RenderTarget.named(id)                                    -> RenderTarget
+//! RenderTarget.sized(target, w, h)                          -> RenderTarget
+//!   (a named offscreen texture, 512x512 unless sized; declare ONCE, use the
+//!    value at both sites — the writer and the reader — so writer/reader id
+//!    typos are unrepresentable, the Angle rule applied to identity)
+//! Frame.withRenderTarget(frame, target, targetFrame)        -> Frame
+//!   (the writer: targetFrame — its own camera/scene/lights — is rendered
+//!    into the target before frame's main pass; a scene sampling its own
+//!    target sees last frame's image)
+//! Scene.screen(scene, target)                               -> Scene
+//!   (the reader: an emissive "screen" surface showing the target's texture;
+//!    an id no frame declares shows magenta and warns once)
 //! Time.seconds(n) / Time.millis(n)                          -> Duration
 //!   (like Angle: timing functions take Duration VALUES, never bare
 //!    numbers — seconds/milliseconds confusion is unrepresentable)
@@ -79,7 +91,8 @@ use std::rc::Rc;
 
 use crate::math::Angle;
 use crate::physics;
-use crate::scene3d::MaterialDescription;
+use crate::render_target::RenderTargetDescriptor;
+use crate::scene3d::{MaterialDescription, TextureDescription};
 use crate::{Camera, Frame, Light, Scene3D, SceneObject};
 
 /// A [`Scene3D`] as an opaque MLE value.
@@ -285,6 +298,22 @@ impl EffectRunner for ReplayEffects {
 /// discipline, carried across the boundary).
 pub struct MleAngle(pub Angle);
 
+/// A [`RenderTargetDescriptor`] as an opaque MLE value — declared once via
+/// `RenderTarget.named` and used at both sites: the writer
+/// (`Frame.withRenderTarget`) and the reader (`Scene.screen`). Both accept
+/// ONLY this, never a bare string, so a writer/reader id typo is
+/// unrepresentable (the Angle rule, applied to identity).
+pub struct MleRenderTarget(pub RenderTargetDescriptor);
+
+impl HostData for MleRenderTarget {
+    fn type_name(&self) -> &'static str {
+        "RenderTarget"
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
 impl HostData for MleDuration {
     fn type_name(&self) -> &'static str {
         "Duration"
@@ -443,6 +472,10 @@ const PATHS: &[&str] = &[
     "Light.castShadows",
     "Frame.create",
     "Frame.createLit",
+    "Frame.withRenderTarget",
+    "RenderTarget.named",
+    "RenderTarget.sized",
+    "Scene.screen",
     "Time.seconds",
     "Time.millis",
     "Sub.none",
@@ -848,6 +881,71 @@ impl Host for FunctorHost {
                 }
                 _ => usage("Physics.transformed(scene, tag)"),
             },
+            "RenderTarget.named" => match args.as_slice() {
+                [Value::String(name)] if !name.is_empty() => Ok(host(MleRenderTarget(
+                    RenderTargetDescriptor::new(name.to_string()),
+                ))),
+                _ => usage(
+                    "RenderTarget.named(\"id\") — a non-empty name; 512x512 unless \
+piped through RenderTarget.sized",
+                ),
+            },
+            // Target first, so it pipes:
+            // `RenderTarget.named("x") |> RenderTarget.sized(256.0, 256.0)`.
+            "RenderTarget.sized" => match args.as_slice() {
+                [target, w, h] => {
+                    let inner = target_of(target, "RenderTarget.sized", span)?;
+                    let w = positive_num(w, span, "RenderTarget.sized width")?;
+                    let h = positive_num(h, span, "RenderTarget.sized height")?;
+                    Ok(host(MleRenderTarget(
+                        inner.clone().sized(w as f32, h as f32),
+                    )))
+                }
+                _ => usage("RenderTarget.sized(target, width, height)"),
+            },
+            // Frame first, so it pipes:
+            // `Frame.createLit(…) |> Frame.withRenderTarget(feed, feedFrame)`.
+            "Frame.withRenderTarget" => match args.as_slice() {
+                [frame, target, target_frame] => {
+                    let (Some(outer), Some(inner)) =
+                        (frame_value(frame), frame_value(target_frame))
+                    else {
+                        return usage(
+                            "Frame.withRenderTarget(frame, target, targetFrame) — targetFrame \
+is a Frame.create/createLit(…) rendered into the target each frame, before \
+frame's main pass",
+                        );
+                    };
+                    let target = target_of(target, "Frame.withRenderTarget", span)?;
+                    Ok(host(MleFrame(Frame::with_render_target(
+                        outer.clone(),
+                        target.clone(),
+                        inner.clone(),
+                    ))))
+                }
+                _ => usage("Frame.withRenderTarget(frame, target, targetFrame)"),
+            },
+            // Scene first, so it pipes: `Scene.quad() |> Scene.screen(feed)` —
+            // an emissive (fullbright, screens glow) surface showing the
+            // target's texture. A target no frame declares shows magenta.
+            "Scene.screen" => match args.as_slice() {
+                [scene, target] => {
+                    let Some(scene) = scene_of(scene) else {
+                        return usage("Scene.screen(scene, target)");
+                    };
+                    let target = target_of(target, "Scene.screen", span)?;
+                    scene_value(Scene3D {
+                        obj: SceneObject::Material(
+                            MaterialDescription::emissive_texture(
+                                TextureDescription::render_target(target.clone()),
+                            ),
+                            vec![scene.clone()],
+                        ),
+                        xform: Matrix4::from_scale(1.0),
+                    })
+                }
+                _ => usage("Scene.screen(scene, target)"),
+            },
             "Frame.create" => match args.as_slice() {
                 [camera, scene] => {
                     let (Value::HostData(cam), Some(scene)) = (camera, scene_of(scene)) else {
@@ -1217,6 +1315,38 @@ fn scene_of(value: &Value) -> Option<&Scene3D> {
     }
 }
 
+/// Extract a [`RenderTargetDescriptor`] — both use sites accept ONLY the
+/// branded value, so the predictable mistake (a bare id string) gets a
+/// teaching error pointing at `RenderTarget.named` instead of a generic
+/// usage line (the [`angle_of`] rule, applied to identity).
+fn target_of<'a>(
+    value: &'a Value,
+    what: &str,
+    span: Span,
+) -> Result<&'a RenderTargetDescriptor, RunError> {
+    match value {
+        Value::HostData(data) => data
+            .as_any()
+            .downcast_ref::<MleRenderTarget>()
+            .map(|t| &t.0)
+            .ok_or_else(|| RunError {
+                message: format!("{what}: expected a RenderTarget, got {}", value.kind_name()),
+                span,
+            }),
+        Value::String(_) => Err(RunError {
+            message: format!(
+                "{what}: expected a RenderTarget, got a bare string — declare it once \
+with RenderTarget.named(\"…\") and pass that value at both sites"
+            ),
+            span,
+        }),
+        other => Err(RunError {
+            message: format!("{what}: expected a RenderTarget, got {}", other.kind_name()),
+            span,
+        }),
+    }
+}
+
 fn shape_of(value: &Value) -> Option<&physics::Shape> {
     match value {
         Value::HostData(data) => data.as_any().downcast_ref::<MleShape>().map(|s| &s.0),
@@ -1492,6 +1622,98 @@ Scene.cube() |> Scene.rotateY(Angle.radians(1.5707964)))",
                 "`{path}` fell through to the internal fallback: {message}"
             );
         }
+    }
+
+    // The render-target vocabulary end to end: a branded target declared once
+    // (named + sized), used at the reader (Scene.screen) and the writer
+    // (Frame.withRenderTarget) — the frame carries the pass, the scene carries
+    // the texture reference, and the whole thing speaks the protocol.
+    #[test]
+    fn mle_snippet_declares_a_render_target_frame() {
+        let frame = frame_of(
+            "let feed = RenderTarget.named(\"security\") |> RenderTarget.sized(256.0, 128.0)\n\
+             let main = () =>\n\
+             Frame.createLit(\n\
+               Camera.lookAt(0.0, 2.0, -8.0, 0.0, 1.0, 0.0),\n\
+               Scene.group([\n\
+                 Scene.plane() |> Scene.lit(0.6, 0.6, 0.6),\n\
+                 Scene.quad() |> Scene.screen(feed),\n\
+               ]),\n\
+               [Light.ambient(0.1, 0.1, 0.1)])\n\
+             |> Frame.withRenderTarget(feed, Frame.createLit(\n\
+                  Camera.lookAt(0.0, 4.0, -6.0, 0.0, 0.5, 0.0),\n\
+                  Scene.cube() |> Scene.lit(0.8, 0.2, 0.2),\n\
+                  [Light.ambient(0.2, 0.2, 0.2)]))",
+        );
+        assert_eq!(frame.render_targets.len(), 1);
+        let pass = &frame.render_targets[0];
+        assert_eq!(pass.target.id, "security");
+        assert_eq!((pass.target.width, pass.target.height), (256, 128));
+        assert_eq!(pass.frame.lights.len(), 1);
+        assert!(pass.frame.render_targets.is_empty());
+        // The reader's wire shape: the screen material samples the target by id.
+        let json = serde_json::to_string(&frame).expect("serialize");
+        assert!(json.contains(r#""RenderTarget":"security""#), "json: {json}");
+        // And the whole frame round-trips through the protocol.
+        let back: Frame = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(serde_json::to_string(&back).unwrap(), json);
+    }
+
+    // Scene.screen is an emissive (fullbright) white surface over the target's
+    // texture — screens glow, unaffected by scene lighting.
+    #[test]
+    fn screen_material_is_emissive_white_over_the_target_texture() {
+        let frame = frame_of(
+            "let main = () =>\n\
+             Frame.create(\n\
+               Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0),\n\
+               Scene.quad() |> Scene.screen(RenderTarget.named(\"feed\")))",
+        );
+        let json = serde_json::to_string(&frame.scene).expect("serialize");
+        assert!(
+            json.contains(r#""Emissive":{"color":[1.0,1.0,1.0,1.0],"texture":{"RenderTarget":"feed"}}"#),
+            "json: {json}"
+        );
+    }
+
+    // [units, tier 1 — the Angle rule applied to identity] both sites accept
+    // ONLY the branded RenderTarget value; a bare string / wrong value is a
+    // spanned usage error, so writer/reader id typos are unrepresentable.
+    #[test]
+    fn bare_strings_are_not_render_targets() {
+        let fail = |src: &str| {
+            let module = mle::lower(mle::parse(src).unwrap()).unwrap();
+            mle::run_with_host(&module, Tracing::Off, &mut FunctorHost)
+                .err()
+                .expect("should fail")
+                .error
+                .message
+        };
+        assert_eq!(
+            fail("let main = () => Scene.quad() |> Scene.screen(\"security\")"),
+            "Scene.screen: expected a RenderTarget, got a bare string — declare it once \
+with RenderTarget.named(\"…\") and pass that value at both sites"
+        );
+        assert_eq!(
+            fail(
+                "let main = () => Frame.create(Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0), \
+Scene.cube()) |> Frame.withRenderTarget(\"feed\", Frame.create(\
+Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0), Scene.cube()))"
+            ),
+            "Frame.withRenderTarget: expected a RenderTarget, got a bare string — declare \
+it once with RenderTarget.named(\"…\") and pass that value at both sites"
+        );
+        assert_eq!(
+            fail(
+                "let main = () => RenderTarget.named(\"x\") |> RenderTarget.sized(-1.0, 4.0)"
+            ),
+            "RenderTarget.sized width must be positive, got -1"
+        );
+        assert_eq!(
+            fail("let main = () => RenderTarget.named(3.0)"),
+            "usage: RenderTarget.named(\"id\") — a non-empty name; 512x512 unless \
+piped through RenderTarget.sized"
+        );
     }
 
     // The physics vocabulary: an MLE snippet declares a PhysicsScene the


### PR DESCRIPTION
Follow-up to #191 (the engine feature, now merged): this slice gives MLE the render-to-texture vocabulary and a demo sample. (Rebased onto main — picks up B6 effects and C5 wasm cleanly.)

## Prelude (mle_prelude.rs)

```mle
let feed = RenderTarget.named("security") |> RenderTarget.sized(256.0, 256.0)

// reader: an emissive screen surface showing the target's texture
Scene.quad() |> Scene.screen(feed)

// writer: a full inner frame (camera/scene/lights), rendered before the main pass
Frame.createLit(cam, world, lights) |> Frame.withRenderTarget(feed, feedFrame)
```

- The handle is **branded** (the `Angle`/`Duration` rule applied to *identity*): both sites take the value, never a bare string, so writer/reader id typos are unrepresentable. A bare string gets the teaching error — *"expected a RenderTarget, got a bare string — declare it once with RenderTarget.named(\"…\") and pass that value at both sites"*.
- The target frame renders with **its own lights** — `Frame.createLit` + `castShadows` gives a lit, shadowed feed. A scene sampling its own target sees last frame's image; an undeclared id renders magenta + warns once (engine semantics, #191).

## examples/mle-monitor

A panning security camera films the courtyard; an in-world monitor shows the feed live. The feed scene deliberately excludes the monitor/gadget (a target's scene is independent of the main frame's), the camera prop and the feed camera share the same `pan(tts)` so the picture matches the prop, and all animation derives from `tts` — captures are deterministic under `--fixed-time`. The monitor's screen is rotated 180° (a quad's front is +Z; an unrotated quad would show its back — a mirrored feed).

## Docs

`docs/mle.md` Track C4b-3 + the `mle-language` skill prelude block, updated in the same PR (the keeping-it-honest rule).

## Verification

- `cargo test -p functor_runtime_common` — 130 passed post-rebase (target passes on the frame, `Scene.screen` wire shape, branded-value teaching errors); `cargo test -p mle` unchanged.
- `functor -d examples/mle-monitor build` typechecks clean; deterministic `--fixed-time` captures show the second camera's elevated, panning view on the screen (orientation verified un-mirrored).
- Cross-engine review (`/xreview`, Claude + Codex): fixes applied — the bare-string teaching error above, pan amplitude kept inside the feed's fov (an earlier ±40° pan emptied the picture near the peaks), doc wording on target-frame lights, and regenerated capture evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Visuals

![mle-monitor render-target demo](https://gist.githubusercontent.com/tommy-xr/9485c6adab7163f6cfc176460d8e29f8/raw/mle-monitor.gif)

<sub>examples/mle-monitor: the monitor's screen is a render target showing the security camera's elevated, panning view of the same courtyard — declared in MLE with `RenderTarget.named` / `Frame.withRenderTarget` / `Scene.screen`. Rendered headlessly via `--fixed-time` / `--capture-frame`.</sub>

**t=1.0**

![still t=1.0](https://gist.githubusercontent.com/tommy-xr/9485c6adab7163f6cfc176460d8e29f8/raw/monitor.png)

**t=6.0**

![still t=6.0](https://gist.githubusercontent.com/tommy-xr/9485c6adab7163f6cfc176460d8e29f8/raw/monitor-t6.png)

<sub>The main camera is fixed between the two stills — only the feed content differs (camera pan + the orbiter's position), showing the screen is a live render target, not a static texture.</sub>
