### PR TITLE
feat(physics,mle): Phase 3 — command effects (applyImpulse/applyForce/setVelocity/teleport)

### DIFF
--- a/.claude/skills/mle-language/SKILL.md
+++ b/.claude/skills/mle-language/SKILL.md
@@ -178,6 +178,9 @@ body |> Physics.sensor                                     // overlap-only, no f
 Physics.scene(gx, gy, gz, [body, …])                       // what `physics` returns
 Physics.position("tag")                                    // {x, y, z} of the LIVE body
 scene |> Physics.transformed("tag")                        // scene at the body's live pose
+Physics.applyImpulse("tag", x, y, z)                       // -> Effect (fire-and-forget)
+Physics.applyForce("tag", x, y, z)                         //   force lasts ONE stepped frame
+Physics.setVelocity("tag", x, y, z) / Physics.teleport("tag", x, y, z)
 ```
 
 `Physics.position` / `Physics.transformed` read the live stepped world
@@ -187,6 +190,16 @@ so only read tags your `physics` hook declares. The tag is cross-frame
 identity: same tag = same body; drop a body by not declaring it.
 Re-declaring an *unchanged* body leaves the simulation alone; *changing*
 its declared position teleports it (the divergence rule, docs/physics.md).
+
+Physics **command effects** are returned beside the model like any effect
+— `(model, Physics.applyImpulse("ball", 0.0, 5.0, 0.0))` — but carry no
+tagger: nothing folds back through `update`; observe outcomes via the
+physics reads. Commands queue at perform time and apply at the next
+stepped frame's first substep, **after reconcile** — so declaring a body
+and commanding it in the same frame works. A command naming an unknown tag
+is a deduped `[mle]` warning, not an error (the body may have despawned in
+flight). `teleport` moves the live body without touching its declaration
+(no snap-back next frame).
 
 A runner-hosted game (`functor-runner --mle --game-path game.mle`) defines:
 

--- a/docs/physics.md
+++ b/docs/physics.md
@@ -165,7 +165,13 @@ module PhysicsScene =
     let empty  () : PhysicsScene
 ```
 
-**Commands — plain-data effects** (operate on the default singleton world; later
+**Commands — plain-data effects.** *Shipped (Phase 3) on the MLE surface as B6
+effect variants* — `Physics.applyImpulse("tag", x, y, z)` etc., returned beside
+the model; tagger-less (outcomes are observed via the physics reads). Commands
+queue at perform time and apply **after the frame's reconcile, before its first
+substep** (so same-frame declare+command works); `applyForce` lasts exactly one
+stepped frame; they are the Timeline's `Command::Apply` replay input. The F#
+sketch (operate on the default singleton world; later
 overloads take an explicit world):
 
 ```fsharp
@@ -555,8 +561,9 @@ it rather than writing our own:
   shading, then `render_debug_lines` draws the collected segments as a
   depth-tested GL line pass (`LEQUAL`, so lines coincident with collider
   surfaces don't z-fight) — works in mono and stereo, and in captures
-  (`--capture-frame`) with no game-code changes. Native-only until the wasm
-  shell grows a physics world.
+  (`--capture-frame`) with no game-code changes. The overlay pass is wired
+  natively only (the wasm shell steps physics since C5, but its renderer
+  doesn't draw the line pass yet).
 
 This is the visual proof of reconcile correctness (declared scene vs what the
 solver actually holds) and makes divergence bugs — a body the renderer draws in
@@ -619,7 +626,7 @@ It's worth building in two steps, because they exercise different machinery:
 | **2. MLE surface + read-back** | `Physics.*` prelude (shape/body/scene builders, `position`/`transformed` live reads), optional `physics` hook in the MLE driver (tick → reconcile+fixed-step → draw), prelude tests. | native (MLE) |
 | **2c. `examples/mle-physics`** | Crates settling on a ground slab, hot-reload demo, golden scenario, PR GIF/PNG. | native (MLE) |
 | **2b. Debug visualization** | Rapier `debug-render` feature, `World::debug_lines()`, depth-tested line pass, `--debug-render physics` mode. **Shipped.** | native |
-| **3. Commands** | `applyImpulse`/`applyForce`/`setVelocity`/`teleport` (plain-data effects). | both |
+| **3. Commands** | `Physics.applyImpulse`/`applyForce`/`setVelocity`/`teleport` as B6 effect variants: queued at perform time, applied after the frame's reconcile before its first substep; forces last one stepped frame; recorded as `timeline::Command::Apply` in the goldens. **Shipped (MLE).** | native+wasm (MLE) |
 | **4. Queries** | `raycast`/`shapeCast` (async tagger, token registry). | both |
 | **5. Collision events** | `Physics.events` sub. | both |
 | **5b. Entity abstraction** | `Entities<'e>` + `Archetype` model-layer library, `Scene3D.instances` primitive, reconcile bail-out + tag interning, despawn-on-collision; `hello-physics` grows a bullet/debris archetype. | both |

--- a/examples/mle-physics/game.mle
+++ b/examples/mle-physics/game.mle
@@ -1,8 +1,10 @@
-// mle-physics — the reference physics example (docs/physics.md, Phase 2c).
+// mle-physics — the reference physics example (docs/physics.md, Phase 2c+3).
 // Crates and a ball tumble onto a slab, drawn at their live simulated poses
 // via Physics.transformed. Press SPACE to re-drop everything: the changed
 // declared spawn poses teleport the bodies (the divergence rule) and the
-// pile falls again. Run with:
+// pile falls again. Press K to KICK the ball — a Physics.applyImpulse
+// effect, returned beside the model, applied at the next physics step. Run
+// with:
 //
 //   functor-runner --mle --game-path examples/mle-physics/game.mle
 //   functor -d examples/mle-physics run native
@@ -37,8 +39,10 @@ let bodyAt = (drop, i) =>
   match i with
   | 0.0 => Physics.fixed("ground", Physics.box(24.0, 0.4, 24.0)) |> Physics.at(0.0, -0.2, 0.0)
   | 1.0 =>
+    // Nearly-vertical drop beside the crates (the small drop-dependent wobble
+    // keeps SPACE's re-drop teleport firing), so the ball settles in frame.
     (Physics.dynamic("ball", Physics.sphere(0.6))
-      |> Physics.at(scatterX(drop, 9.0) * 0.5, 5.5, scatterZ(drop, 9.0) * 0.5)
+      |> Physics.at(3.2 + scatterX(drop, 9.0) * 0.2, 5.5, 0.5 + scatterZ(drop, 9.0) * 0.2)
       |> Physics.restitution(0.55))
   | n => crateBody(drop, n - 2.0)
 
@@ -58,6 +62,8 @@ let tick = (model, dt, tts) => model
 
 // Rising-edge detection: GLFW delivers key REPEATS as `isDown = true` too,
 // so holding SPACE would re-drop every repeat without the spaceHeld latch.
+// The kick fires on K's RELEASE instead — key-ups never repeat, so no latch
+// is needed; it returns `(model, effect)`, the B6 effect shape.
 let input = (model, key, isDown) =>
   match key with
   | "Space" =>
@@ -67,6 +73,10 @@ let input = (model, key, isDown) =>
        (match model.spaceHeld with
         | true => model
         | false => { model with drop: model.drop + 1.0, spaceHeld: true }))
+  | "K" =>
+    (match isDown with
+     | true => model
+     | false => (model, Physics.applyImpulse("ball", 0.0, 5.5, 0.0)))
   | _ => model
 
 let draw = (model, tts) =>

--- a/runtime/functor-runtime-common/src/mle_prelude.rs
+++ b/runtime/functor-runtime-common/src/mle_prelude.rs
@@ -44,6 +44,8 @@
 //! Physics.scene(gx, gy, gz, [body, …])                      -> PhysicsScene
 //! Physics.position(tag)                                     -> {x, y, z}
 //! Physics.transformed(scene, tag)                           -> Scene
+//! Physics.applyImpulse/applyForce/setVelocity/teleport(tag, x, y, z)
+//!                                                           -> Effect
 //! ```
 //!
 //! The `Physics.*` reads target the singleton world the shell reconciles and
@@ -141,6 +143,12 @@ pub enum EffectTree {
         tagger: Value,
     },
     Batch(Vec<EffectTree>),
+    /// A fire-and-forget physics command (docs/physics.md Phase 3): no
+    /// tagger — performing it queues the command on the singleton world,
+    /// applied at the next stepped frame's first substep (after reconcile).
+    /// The game observes the outcome through the physics reads, not a
+    /// message.
+    Physics(physics::PhysicsCommand),
 }
 
 pub struct MleEffect(pub EffectTree);
@@ -467,6 +475,10 @@ const PATHS: &[&str] = &[
     "Physics.scene",
     "Physics.position",
     "Physics.transformed",
+    "Physics.applyImpulse",
+    "Physics.applyForce",
+    "Physics.setVelocity",
+    "Physics.teleport",
 ];
 
 impl Host for FunctorHost {
@@ -829,6 +841,37 @@ impl Host for FunctorHost {
             // Scene first, so it pipes: the way MLE draws a physics body —
             // `Scene.cube() |> Scene.lit(…) |> Physics.transformed("crate-1")`
             // places the visual at the body's live pose (position + rotation).
+            // Command EFFECTS (docs/physics.md Phase 3): fire-and-forget,
+            // returned beside the model like any effect —
+            // `(model, Physics.applyImpulse("ball", 0.0, 5.0, 0.0))`.
+            // Performing one queues it on the singleton world; it applies at
+            // the next stepped frame's first substep, AFTER reconcile — so a
+            // body declared and commanded in the same frame works.
+            "Physics.applyImpulse" | "Physics.applyForce" | "Physics.setVelocity"
+            | "Physics.teleport" => match args.as_slice() {
+                [Value::String(tag), x, y, z] => {
+                    let tag = tag.to_string();
+                    let v = [
+                        num(x, span)? as f32,
+                        num(y, span)? as f32,
+                        num(z, span)? as f32,
+                    ];
+                    let command = match path {
+                        "Physics.applyImpulse" => {
+                            physics::PhysicsCommand::ApplyImpulse { tag, impulse: v }
+                        }
+                        "Physics.applyForce" => {
+                            physics::PhysicsCommand::ApplyForce { tag, force: v }
+                        }
+                        "Physics.setVelocity" => {
+                            physics::PhysicsCommand::SetVelocity { tag, velocity: v }
+                        }
+                        _ => physics::PhysicsCommand::Teleport { tag, position: v },
+                    };
+                    Ok(host(MleEffect(EffectTree::Physics(command))))
+                }
+                _ => usage(&format!("{path}(tag, x, y, z)")),
+            },
             "Physics.transformed" => match args.as_slice() {
                 [scene, Value::String(tag)] => {
                     let Some(inner) = scene_of(scene) else {
@@ -1168,6 +1211,25 @@ dropping the rest"
                 // Preserve declaration order against the LIFO queue.
                 for item in items.into_iter().rev() {
                     queue.push(item);
+                }
+                continue;
+            }
+            EffectTree::Physics(command) => {
+                // Fire-and-forget: queue on the singleton world, log the kind
+                // (there is no result value to feed a tagger), continue. Not
+                // routed through the runner — commands are per-frame *inputs*
+                // recorded by the physics Timeline, not environment reads that
+                // replay must fake.
+                let kind = match &command {
+                    physics::PhysicsCommand::ApplyImpulse { .. } => "physics.applyImpulse",
+                    physics::PhysicsCommand::ApplyForce { .. } => "physics.applyForce",
+                    physics::PhysicsCommand::SetVelocity { .. } => "physics.setVelocity",
+                    physics::PhysicsCommand::Teleport { .. } => "physics.teleport",
+                };
+                physics::with_world(physics::DEFAULT_WORLD, |w| w.queue_command(command));
+                log.push(EffectRecord { kind, value: 0.0 });
+                if log.len() > EFFECT_LOG_CAP {
+                    log.remove(0);
                 }
                 continue;
             }
@@ -1597,6 +1659,56 @@ Scene.cube() |> Scene.rotateY(Angle.radians(1.5707964)))",
                 failure.error.message
             );
         }
+    }
+
+    // The Phase 3 command path end to end: an entry point returns
+    // (model, Physics.applyImpulse(…)); draining queues the command on the
+    // singleton world; the next step applies it.
+    #[test]
+    fn physics_command_effects_queue_and_apply() {
+        crate::physics::remove_world(crate::physics::DEFAULT_WORLD);
+        let effect = eval(
+            "let main = () => Physics.applyImpulse(\"ball\", 2.0, 0.0, 0.0)",
+        );
+        let Value::HostData(data) = &effect else {
+            panic!("expected an Effect");
+        };
+        let tree = &data.as_any().downcast_ref::<MleEffect>().expect("Effect").0;
+
+        // Drain it the way the producer does (no session/update involvement —
+        // physics effects are tagger-less).
+        let module = mle::lower(mle::parse("let update = (m, msg) => m").unwrap()).unwrap();
+        let session = mle::Session::load(&module, &mut FunctorHost)
+            .unwrap_or_else(|f| panic!("load failed: {}", f.error.message));
+        let mut model = Value::Number(0.0);
+        let mut log = EffectLog::new();
+        let mut runner = FakeEffects::new(0.0, vec![]);
+        drain_effects(
+            &session,
+            &mut model,
+            tree.clone(),
+            &mut runner,
+            &mut log,
+            &mut |m| panic!("unexpected report: {m}"),
+        );
+        assert_eq!(log.len(), 1);
+        assert_eq!(log[0].kind, "physics.applyImpulse");
+
+        // The command sits queued on world 0; a declared body + step applies it.
+        crate::physics::with_world(crate::physics::DEFAULT_WORLD, |w| {
+            w.reconcile(&crate::physics::PhysicsScene::create(
+                [0.0, 0.0, 0.0],
+                vec![crate::physics::Body::dynamic(
+                    "ball".to_string(),
+                    crate::physics::Shape::Sphere { radius: 0.5 },
+                )],
+            ));
+            w.step_frame(1.0 / 60.0);
+            let v = w.body_velocity("ball").unwrap();
+            assert!(v[0] > 0.0, "impulse not applied: {v:?}");
+            assert!(w.take_command_warnings().is_empty());
+        });
+        crate::physics::remove_world(crate::physics::DEFAULT_WORLD);
     }
 
     // A missing tag is a loud spanned error, not a sentinel value.

--- a/runtime/functor-runtime-common/src/physics/goldens.rs
+++ b/runtime/functor-runtime-common/src/physics/goldens.rs
@@ -56,11 +56,25 @@ fn scene_at(frame: u64) -> PhysicsScene {
 
 const FRAMES: u64 = 120;
 
-/// Drive a world through the scripted scenario up to (excluding) `to`.
+/// The frame's full command list — the declared scene, plus (at frame 45) an
+/// impulse kicking crate "a", exercising the Phase 3 command path: queued,
+/// applied after reconcile, replayed like any other input.
+fn commands_at(frame: u64) -> Vec<Command> {
+    let mut cmds = vec![Command::DeclareScene(scene_at(frame))];
+    if frame == 45 {
+        cmds.push(Command::Apply(PhysicsCommand::ApplyImpulse {
+            tag: "a".to_string(),
+            impulse: [0.0, 4.0, 1.5],
+        }));
+    }
+    cmds
+}
+
+/// Drive a world through the scripted scenario up to (excluding) `to`, via
+/// the `Simulatable` seam (the same path the Timeline replays through).
 fn run(world: &mut World, from: u64, to: u64) {
     for f in from..to {
-        world.reconcile(&scene_at(f));
-        world.step_fixed();
+        world.step(&commands_at(f));
     }
 }
 
@@ -69,12 +83,13 @@ fn determinism_golden_two_worlds_stay_byte_identical() {
     let mut a = World::new([0.0, -9.81, 0.0]);
     let mut b = World::new([0.0, -9.81, 0.0]);
     for f in 0..FRAMES {
-        let scene = scene_at(f);
-        a.reconcile(&scene);
-        b.reconcile(&scene);
-        a.step_fixed();
-        b.step_fixed();
-        assert!(a.snapshot() == b.snapshot(), "worlds diverged at frame {f}");
+        let cmds = commands_at(f);
+        a.step(&cmds);
+        b.step(&cmds);
+        assert!(
+            World::snapshot(&a) == World::snapshot(&b),
+            "worlds diverged at frame {f}"
+        );
     }
     // Sanity: the scenario actually simulated something (crates fell and hit
     // the ground), so byte-equality above wasn't comparing static worlds.
@@ -82,11 +97,12 @@ fn determinism_golden_two_worlds_stay_byte_identical() {
     assert!(pos[1] < 2.0 && pos[1] > 0.0, "unexpected rest pose {pos:?}");
 }
 
-/// Drive a `Timeline` + sim through the scripted scenario (the `Simulatable`
-/// path: commands, not direct reconcile calls).
+/// Drive a `Timeline` + sim through the scripted scenario — including the
+/// frame-45 impulse, so every `seek` in the goldens below also proves that
+/// recorded commands re-apply during replay.
 fn drive<T: Timeline<World>>(tl: &mut T, sim: &mut World, frames: u64) {
     for f in 0..frames {
-        let cmds = vec![Command::DeclareScene(scene_at(f))];
+        let cmds = commands_at(f);
         tl.record(f, sim, &cmds);
         sim.step(&cmds);
     }

--- a/runtime/functor-runtime-common/src/physics/timeline.rs
+++ b/runtime/functor-runtime-common/src/physics/timeline.rs
@@ -25,19 +25,20 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use super::{PhysicsScene, World};
+use super::{PhysicsCommand, PhysicsScene, World};
 
 /// A fixed-step frame number.
 pub type Frame = u64;
 
 /// One frame's worth of input to a physics [`World`] step. This is what a
 /// replay re-executes, so it must capture *everything* that can change the
-/// world: today that's the declared scene (whose history is also the
-/// insert/remove history Rapier arena handles depend on); Phase 3 adds
-/// impulse/force commands as further variants.
+/// world: the declared scene (whose history is also the insert/remove
+/// history Rapier arena handles depend on) and the frame's fire-and-forget
+/// commands (impulses/forces/teleports — Phase 3).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Command {
     DeclareScene(PhysicsScene),
+    Apply(PhysicsCommand),
 }
 
 /// Events produced by a step. None yet — Phase 5 (collision events) populates
@@ -81,9 +82,20 @@ impl Simulatable for World {
         for cmd in cmds {
             match cmd {
                 Command::DeclareScene(scene) => self.reconcile(scene),
+                Command::Apply(command) => self.queue_command(command.clone()),
             }
         }
+        // Same per-frame command discipline as `step_frame`: queued commands
+        // land after this frame's reconcile, forces last exactly one frame.
+        // NOTE one live-vs-timeline difference: `step_frame` may run 0–8
+        // substeps per rendered frame (commands carry over a zero-substep
+        // frame), while this seam is exactly one fixed step per recorded
+        // frame. Recording live play (Phase 6) must record commands against
+        // the FIXED frame they actually applied on, not the rendered frame
+        // they were issued on.
+        self.apply_pending();
         self.step_fixed();
+        self.clear_frame_forces();
         Vec::new()
     }
 }

--- a/runtime/functor-runtime-common/src/physics/world.rs
+++ b/runtime/functor-runtime-common/src/physics/world.rs
@@ -30,6 +30,48 @@ pub const FIXED_DT: f32 = 1.0 / 60.0;
 /// unboundedly.
 pub const MAX_SUBSTEPS_PER_FRAME: u32 = 8;
 
+/// A fire-and-forget command against a declared body (docs/physics.md,
+/// Phase 3): plain serializable data, queued via [`World::queue_command`] and
+/// applied at the frame's **first fixed substep, after reconcile** — so a
+/// body declared and commanded in the same frame works. Being plain data,
+/// commands are also the Timeline's replayable per-frame input
+/// (`timeline::Command::Apply`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum PhysicsCommand {
+    /// Instantaneous momentum change.
+    ApplyImpulse { tag: String, impulse: [f32; 3] },
+    /// A force applied for this frame's substeps only (cleared at frame end —
+    /// no rapier force persistence to forget about).
+    ApplyForce { tag: String, force: [f32; 3] },
+    SetVelocity { tag: String, velocity: [f32; 3] },
+    /// Move the live body without touching its declaration (the declared
+    /// cache is unchanged, so the next frame's unchanged declaration does not
+    /// snap it back).
+    Teleport { tag: String, position: [f32; 3] },
+}
+
+impl PhysicsCommand {
+    /// The command's tag and short kind name, for warnings and logs.
+    pub fn tag_and_kind(&self) -> (&str, &'static str) {
+        match self {
+            PhysicsCommand::ApplyImpulse { tag, .. } => (tag, "applyImpulse"),
+            PhysicsCommand::ApplyForce { tag, .. } => (tag, "applyForce"),
+            PhysicsCommand::SetVelocity { tag, .. } => (tag, "setVelocity"),
+            PhysicsCommand::Teleport { tag, .. } => (tag, "teleport"),
+        }
+    }
+}
+
+/// Commands queued while no physics step consumes them (a game firing
+/// commands without a `physics` hook) are bounded — drop-with-warning beats
+/// unbounded growth.
+const MAX_PENDING_COMMANDS: usize = 1024;
+
+/// Warnings are bounded too: they are only freed by a driver draining them,
+/// and a driver that never steps the world never drains — the warning buffer
+/// must not become the leak it exists to report.
+const MAX_COMMAND_WARNINGS: usize = 64;
+
 /// One colored wireframe segment from [`World::debug_lines`], in world space.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize)]
 pub struct DebugLine {
@@ -85,6 +127,21 @@ pub struct World {
     declared: BTreeMap<String, Body>,
     accumulator: f32,
     frame: u64,
+    /// Commands awaiting the next stepped frame (serialized: a snapshot taken
+    /// between queue and step must restore them for bit-exact resume).
+    #[serde(default)]
+    pending: Vec<PhysicsCommand>,
+    /// Bodies given an [`PhysicsCommand::ApplyForce`] this frame — their
+    /// forces are cleared once the frame's substeps finish. Intra-call state:
+    /// populated and cleared within one `step_frame`/`step`, so it is always
+    /// empty at any snapshot point (hence not serialized).
+    #[serde(skip, default)]
+    forced: Vec<RigidBodyHandle>,
+    /// Command problems (unknown tag, overflow) for the driver to report —
+    /// commands are applied asynchronously, so there is no call site to error
+    /// at. Drain with [`World::take_command_warnings`].
+    #[serde(skip, default)]
+    command_warnings: Vec<String>,
 }
 
 impl World {
@@ -107,6 +164,42 @@ impl World {
             declared: BTreeMap::new(),
             accumulator: 0.0,
             frame: 0,
+            pending: Vec::new(),
+            forced: Vec::new(),
+            command_warnings: Vec::new(),
+        }
+    }
+
+    /// Queue a command for the next stepped frame (applied after that frame's
+    /// reconcile, before its first substep). Problems surface later through
+    /// [`World::take_command_warnings`].
+    pub fn queue_command(&mut self, command: PhysicsCommand) {
+        if self.pending.len() >= MAX_PENDING_COMMANDS {
+            let (tag, kind) = command.tag_and_kind();
+            self.push_command_warning(format!(
+                "physics command queue full ({MAX_PENDING_COMMANDS}); dropping {kind} \
+                 \"{tag}\" (is anything stepping the world?)"
+            ));
+            return;
+        }
+        self.pending.push(command);
+    }
+
+    /// Problems from asynchronously-applied commands (unknown tags, queue
+    /// overflow), drained for the driver to report.
+    pub fn take_command_warnings(&mut self) -> Vec<String> {
+        std::mem::take(&mut self.command_warnings)
+    }
+
+    /// Warning texts are stable per (kind, tag) — no per-frame payloads — so
+    /// the drivers' report-once dedupe actually holds for a persistent bug.
+    fn push_command_warning(&mut self, warning: String) {
+        match self.command_warnings.len().cmp(&MAX_COMMAND_WARNINGS) {
+            std::cmp::Ordering::Less => self.command_warnings.push(warning),
+            std::cmp::Ordering::Equal => self
+                .command_warnings
+                .push("further physics command warnings suppressed until drained".to_string()),
+            std::cmp::Ordering::Greater => {}
         }
     }
 
@@ -161,8 +254,17 @@ impl World {
 
     /// Accumulate real (variable) dt and run whole fixed substeps, carrying the
     /// remainder. Returns the number of substeps taken.
+    ///
+    /// Queued commands apply immediately before the first substep — and stay
+    /// pending through a zero-substep frame, so a command is never consumed by
+    /// a frame that doesn't simulate (a frame-lasting force would otherwise be
+    /// lost without ever integrating).
     pub fn step_frame(&mut self, real_dt: f32) -> u32 {
         self.accumulator += real_dt.max(0.0);
+        if self.accumulator < FIXED_DT {
+            return 0;
+        }
+        self.apply_pending();
         let mut steps = 0;
         while self.accumulator >= FIXED_DT && steps < MAX_SUBSTEPS_PER_FRAME {
             self.step_fixed();
@@ -175,6 +277,7 @@ impl World {
             // the step phase is preserved.
             self.accumulator %= FIXED_DT;
         }
+        self.clear_frame_forces();
         steps
     }
 
@@ -314,6 +417,63 @@ impl World {
             bodies,
         })
         .expect("physics dump is always serializable")
+    }
+
+    /// Apply every queued command to the live world (call after reconcile,
+    /// before the frame's substeps). Unknown tags become warnings — the body
+    /// may have despawned since the command was issued, which is a race the
+    /// game can't avoid, so it must not be fatal.
+    pub(super) fn apply_pending(&mut self) {
+        for command in std::mem::take(&mut self.pending) {
+            let (tag, kind) = command.tag_and_kind();
+            let (tag, kind) = (tag.to_string(), kind);
+            let Some(&(rb_handle, _)) = self.tags.get(tag.as_str()) else {
+                self.push_command_warning(format!(
+                    "physics {kind} for unknown tag \"{tag}\""
+                ));
+                continue;
+            };
+            // Rapier silently ignores impulses/forces/velocities on
+            // non-dynamic bodies — warn instead, matching the unknown-tag
+            // contract. (Teleport is meaningful for every kind.)
+            let is_dynamic = self.bodies[rb_handle].is_dynamic();
+            if !matches!(command, PhysicsCommand::Teleport { .. }) && !is_dynamic {
+                self.push_command_warning(format!(
+                    "physics {kind} on non-dynamic body \"{tag}\" has no effect"
+                ));
+                continue;
+            }
+            let rb = &mut self.bodies[rb_handle];
+            match &command {
+                PhysicsCommand::ApplyImpulse { impulse, .. } => {
+                    rb.apply_impulse(vec3(*impulse), true);
+                }
+                PhysicsCommand::ApplyForce { force, .. } => {
+                    // The force persists for ALL of this frame's substeps and
+                    // clears after — so a multi-substep hitch frame integrates
+                    // it longer than a normal frame. Deliberate: "one frame of
+                    // push", matching how the game experiences frames.
+                    rb.add_force(vec3(*force), true);
+                    self.forced.push(rb_handle);
+                }
+                PhysicsCommand::SetVelocity { velocity, .. } => {
+                    rb.set_linvel(vec3(*velocity), true);
+                }
+                PhysicsCommand::Teleport { position, .. } => {
+                    let rotation = *rb.rotation();
+                    rb.set_position(Pose::from_parts(vec3(*position), rotation), true);
+                }
+            }
+        }
+    }
+
+    /// Forces last exactly one stepped frame (see [`PhysicsCommand::ApplyForce`]).
+    pub(super) fn clear_frame_forces(&mut self) {
+        for handle in std::mem::take(&mut self.forced) {
+            if let Some(rb) = self.bodies.get_mut(handle) {
+                rb.reset_forces(false);
+            }
+        }
     }
 
     // ── reconcile internals ─────────────────────────────────────────────
@@ -688,6 +848,150 @@ mod tests {
         restored.restore(&snap).unwrap();
         assert_eq!(restored.frame(), w.frame());
         assert!(restored.snapshot() == snap, "restored snapshot differs");
+    }
+
+    #[test]
+    fn commands_apply_at_the_frames_first_substep() {
+        let mut w = World::new([0.0, 0.0, 0.0]);
+        w.reconcile(&scene(vec![crate_at("a", [0.0, 5.0, 0.0])]));
+        w.queue_command(PhysicsCommand::ApplyImpulse {
+            tag: "a".to_string(),
+            impulse: [1.0, 0.0, 0.0],
+        });
+        // Zero-substep frame: the command stays pending, nothing applied.
+        assert_eq!(w.step_frame(FIXED_DT / 4.0), 0);
+        assert_eq!(w.body_velocity("a").unwrap(), [0.0, 0.0, 0.0]);
+        // The next stepping frame consumes it (default cube mass = 1: dv = 1).
+        assert_eq!(w.step_frame(FIXED_DT), 1);
+        assert!(w.body_velocity("a").unwrap()[0] > 0.0);
+        assert!(w.take_command_warnings().is_empty());
+    }
+
+    #[test]
+    fn set_velocity_and_teleport_commands_apply() {
+        let mut w = World::new([0.0, 0.0, 0.0]);
+        w.reconcile(&scene(vec![crate_at("a", [0.0, 5.0, 0.0])]));
+        w.queue_command(PhysicsCommand::SetVelocity {
+            tag: "a".to_string(),
+            velocity: [0.0, 0.0, 2.0],
+        });
+        w.queue_command(PhysicsCommand::Teleport {
+            tag: "a".to_string(),
+            position: [3.0, 1.0, 0.0],
+        });
+        w.step_frame(FIXED_DT);
+        let (pos, _) = w.body_transform("a").unwrap();
+        // Teleported, then integrated one 1/60 step of vz = 2.
+        assert_eq!(pos[0], 3.0);
+        assert!((pos[2] - 2.0 * FIXED_DT).abs() < 1e-5);
+        // Teleport did NOT touch the declaration: re-declaring the original
+        // spawn pose is unchanged → no snap-back (the divergence rule).
+        w.reconcile(&scene(vec![crate_at("a", [0.0, 5.0, 0.0])]));
+        let (after, _) = w.body_transform("a").unwrap();
+        assert_eq!(after[0], 3.0);
+    }
+
+    #[test]
+    fn forces_last_exactly_one_stepped_frame() {
+        let mut w = World::new([0.0, 0.0, 0.0]);
+        w.reconcile(&scene(vec![crate_at("a", [0.0, 5.0, 0.0])]));
+        w.queue_command(PhysicsCommand::ApplyForce {
+            tag: "a".to_string(),
+            force: [6.0, 0.0, 0.0],
+        });
+        w.step_frame(FIXED_DT);
+        let v1 = w.body_velocity("a").unwrap()[0];
+        assert!(v1 > 0.0, "force should have accelerated the body");
+        // Next frame: the force is gone; velocity holds (no gravity/friction
+        // in the air).
+        w.step_frame(FIXED_DT);
+        let v2 = w.body_velocity("a").unwrap()[0];
+        assert!((v2 - v1).abs() < 1e-6, "force leaked into the next frame");
+    }
+
+    #[test]
+    fn command_for_unknown_tag_warns_instead_of_failing() {
+        let mut w = World::new([0.0, 0.0, 0.0]);
+        w.reconcile(&scene(vec![crate_at("a", [0.0, 5.0, 0.0])]));
+        w.queue_command(PhysicsCommand::ApplyImpulse {
+            tag: "ghost".to_string(),
+            impulse: [1.0, 0.0, 0.0],
+        });
+        w.step_frame(FIXED_DT);
+        let warnings = w.take_command_warnings();
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("ghost"), "{warnings:?}");
+        // Drained: asking again yields nothing.
+        assert!(w.take_command_warnings().is_empty());
+    }
+
+    #[test]
+    fn pending_commands_survive_a_snapshot() {
+        let mut w = World::new([0.0, 0.0, 0.0]);
+        w.reconcile(&scene(vec![crate_at("a", [0.0, 5.0, 0.0])]));
+        w.queue_command(PhysicsCommand::ApplyImpulse {
+            tag: "a".to_string(),
+            impulse: [1.0, 0.0, 0.0],
+        });
+        let snap = w.snapshot();
+        let mut restored = World::new([0.0, 0.0, 0.0]);
+        restored.restore(&snap).unwrap();
+        w.step_frame(FIXED_DT);
+        restored.step_frame(FIXED_DT);
+        assert!(
+            w.snapshot() == restored.snapshot(),
+            "pending command lost across snapshot/restore"
+        );
+        assert!(restored.body_velocity("a").unwrap()[0] > 0.0);
+    }
+
+    #[test]
+    fn command_queue_overflow_drops_with_warning() {
+        let mut w = World::new([0.0, 0.0, 0.0]);
+        for _ in 0..=MAX_PENDING_COMMANDS {
+            w.queue_command(PhysicsCommand::ApplyImpulse {
+                tag: "a".to_string(),
+                impulse: [0.0, 0.0, 0.0],
+            });
+        }
+        let warnings = w.take_command_warnings();
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("queue full"), "{warnings:?}");
+    }
+
+    #[test]
+    fn command_warnings_are_bounded_when_never_drained() {
+        // A driver that never steps/drains (e.g. no `physics` hook) must not
+        // leak: both the queue AND the warning buffer are capped.
+        let mut w = World::new([0.0, 0.0, 0.0]);
+        for _ in 0..(MAX_PENDING_COMMANDS + MAX_COMMAND_WARNINGS + 100) {
+            w.queue_command(PhysicsCommand::ApplyImpulse {
+                tag: "a".to_string(),
+                impulse: [0.0, 0.0, 0.0],
+            });
+        }
+        let warnings = w.take_command_warnings();
+        assert_eq!(warnings.len(), MAX_COMMAND_WARNINGS + 1);
+        assert!(warnings.last().unwrap().contains("suppressed"), "{warnings:?}");
+    }
+
+    #[test]
+    fn command_on_non_dynamic_body_warns() {
+        let mut w = World::new([0.0, 0.0, 0.0]);
+        w.reconcile(&scene(vec![ground()]));
+        w.queue_command(PhysicsCommand::ApplyImpulse {
+            tag: "ground".to_string(),
+            impulse: [0.0, 9.0, 0.0],
+        });
+        // Teleport IS meaningful for a fixed body: no warning for it.
+        w.queue_command(PhysicsCommand::Teleport {
+            tag: "ground".to_string(),
+            position: [0.0, -0.2, 0.0],
+        });
+        w.step_frame(FIXED_DT);
+        let warnings = w.take_command_warnings();
+        assert_eq!(warnings.len(), 1, "{warnings:?}");
+        assert!(warnings[0].contains("non-dynamic"), "{warnings:?}");
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/render_context.rs
+++ b/runtime/functor-runtime-common/src/render_context.rs
@@ -42,8 +42,9 @@ pub enum DebugRenderMode {
     /// Normal shading plus a physics wireframe overlay: the live world's
     /// colliders/contacts as colored lines (rapier's debug renderer via
     /// `physics::World::debug_lines`), making declared-vs-simulated divergence
-    /// visible at a glance. Native-only today (the wasm shell has no physics
-    /// world yet, so on wasm this shades like `Default`).
+    /// visible at a glance. The overlay pass is wired natively only (the web
+    /// renderer doesn't call `render_debug_lines` yet), so on wasm this
+    /// shades like `Default`.
     Physics,
 }
 

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -274,10 +274,17 @@ impl MleGame {
         match self.session.call("physics", args, &mut FunctorHost) {
             Ok(value) => match physics_scene_value(&value) {
                 Some(scene) => {
-                    physics::with_world(physics::DEFAULT_WORLD, |w| {
+                    let warnings = physics::with_world(physics::DEFAULT_WORLD, |w| {
                         w.reconcile(scene);
                         w.step_frame(dts);
+                        w.take_command_warnings()
                     });
+                    // Command effects apply asynchronously (queued at perform
+                    // time, applied at the step), so their problems — unknown
+                    // tag, queue overflow — surface here, deduped.
+                    for warning in warnings.into_iter().flatten() {
+                        self.report_once(format!("[mle] {warning}"));
+                    }
                 }
                 None => self.report_once(format!(
                     "[mle] physics must return Physics.scene(gx, gy, gz, [body, …]), got {}",

--- a/runtime/functor-runtime-web/src/mle_game.rs
+++ b/runtime/functor-runtime-web/src/mle_game.rs
@@ -252,10 +252,17 @@ to receive their messages; dropping them"
         match self.session.call("physics", args, &mut FunctorHost) {
             Ok(value) => match physics_scene_value(&value) {
                 Some(scene) => {
-                    physics::with_world(physics::DEFAULT_WORLD, |w| {
+                    let warnings = physics::with_world(physics::DEFAULT_WORLD, |w| {
                         w.reconcile(scene);
                         w.step_frame(dts);
+                        w.take_command_warnings()
                     });
+                    // Command effects apply asynchronously (queued at perform
+                    // time, applied at the step), so their problems — unknown
+                    // tag, queue overflow — surface here, deduped.
+                    for warning in warnings.into_iter().flatten() {
+                        self.log_once(format!("[mle] {warning}"));
+                    }
                 }
                 None => self.log_once(format!(
                     "[mle] physics must return Physics.scene(gx, gy, gz, [body, …]), got {}",


### PR DESCRIPTION
Phase **3** of docs/physics.md, riding the B6 effect broker (#190): physics commands as fire-and-forget effects.

```mle
let input = (model, key, isDown) =>
  match key with
  | \"K\" =>
    (match isDown with
     | true => model
     | false => (model, Physics.applyImpulse(\"ball\", 0.0, 5.5, 0.0)))  // ← the B6 shape
  | _ => model
```

![kick](https://gist.githubusercontent.com/tommy-xr/431caeeb24983f3d99467473ce93951d/raw/kick.gif)

| settled | mid-hop after K |
| --- | --- |
| ![before](https://gist.githubusercontent.com/tommy-xr/431caeeb24983f3d99467473ce93951d/raw/before-kick.png) | ![hop](https://gist.githubusercontent.com/tommy-xr/431caeeb24983f3d99467473ce93951d/raw/mid-hop.png) |

## Semantics (the part worth reviewing)

- **Queue-at-perform, apply-at-step**: commands queue when the effect drains and apply at the next stepped frame's **first substep, after reconcile** — so declaring a body and commanding it in the same frame works, and a zero-substep frame carries commands forward rather than consuming them unsimulated.
- **`applyForce` lasts exactly one stepped frame** (added before the substeps, cleared after); **`teleport` doesn't touch the declaration** — no snap-back from the divergence rule next frame.
- **Tagger-less effects**: nothing folds back through `update`; outcomes are observed via `Physics.position`/`Physics.transformed`. Each performed command lands in the structured effect log.
- **Warnings, not errors** for unknown-tag / non-dynamic-body / queue-full commands (they apply asynchronously — the body may have despawned in flight): stable per-(kind, tag) texts so the drivers' dedupe holds, a bounded buffer (64 + suppression marker) so an undrained world can't leak, drained by **both** the desktop and web MLE drivers.
- **Replay-ready**: `timeline::Command::Apply` records commands as per-frame inputs; all three goldens now drive through `Simulatable::step` with a frame-45 impulse, so every `seek` proves recorded commands re-apply byte-identically. Pending commands are serialized (a snapshot between queue and step restores bit-exact — tested).

## Review notes

Cross-engine review attempted; Codex produced no findings file this run, so the Claude reviewer carried it (noted per the xreview failure protocol). Its findings all addressed: the unbounded-warning leak on never-drained worlds (High — fixed with the bounded buffer + web-driver drain), per-(kind,tag) warning texts, `forced`-list `serde(skip)`, a live-vs-timeline substep-semantics note on `Simulatable::step` for the Phase 6 recorder, and stale "wasm has no physics" claims (the web shell **does** step physics since C5 — commands work there; the 2b wireframe overlay remains the only native-only piece).

## Testing

- `cargo test -p functor_runtime_common` — **136 passed** (10 new: command/step interplay, force-one-frame, teleport-no-snap-back, snapshot-of-pending, warning bounds, non-dynamic warnings, end-to-end MLE effect → world)
- strict + wasm32 checks on `functor_runtime_common` **and** `functor-runtime-web`
- Live: K-release kick via debug-server key injection — scene changes, zero warnings

Next per the roadmap: Phase 4 (raycast/shapecast queries) and 5 (collision events → `update` messages, now trivial with B6's message plumbing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)