### PR TITLE
feat(mle): B7 — Hindley–Milner inference with gradual seams

### DIFF
--- a/.claude/skills/mle-language/SKILL.md
+++ b/.claude/skills/mle-language/SKILL.md
@@ -262,15 +262,23 @@ place, then moves (the order the source reads). Engine values (`<Scene>`,
 `<Camera>`, `<Frame>`) are opaque: they can be passed around but not
 inspected, compared, or serialized.
 
-## Typechecking model (gradual)
+## Typechecking model (Hindley–Milner + gradual seams)
 
-`mle check` fires only where BOTH sides are known; unannotated = `Unknown` =
-compatible with everything. Annotations buy diagnostics. Record and variant
-annotations are nominal; the runtime is structural. A `mut` slot's type
-fixes at its initializer. A known-typed `match` scrutinee buys exhaustiveness
-checking (all ctors, or `true`+`false`, or a catch-all) and typed pattern
-variables; arm results must agree where known. Full Hindley–Milner is
-roadmapped (B7) after effects.
+`mle check` runs REAL INFERENCE (B7): unannotated code gets full types via
+unification with let-polymorphism — generic functions instantiate fresh at
+every use, element types flow through `List.map`/`filter`/`fold`, and
+lowercase annotation names are type variables (`(xs: List<a>, f: (a) =>
+b): List<b>`). Inference has teeth: unannotated bad calls, mixed-element
+lists, and contradictory `mut` use are errors now. `Unknown` remains ONLY
+at genuinely-dynamic seams (host values, unrecognized Uppercase type
+names) and absorbs anything. Record literals resolve nominally, F#-style:
+the unique declared type with exactly that field set (no match = anonymous
+data, still fine; two same-shaped declarations make a bare literal
+ambiguous — annotate). A `mut` slot's type fixes at its initializer. A
+`match`'s patterns CONSTRAIN its scrutinee (first ctor arm pins the
+variant type; a foreign literal arm is a can-never-match error);
+exhaustiveness checks all ctors / `true`+`false` / catch-all; arm results
+must agree.
 
 ## Keeping this skill honest
 

--- a/docs/mle.md
+++ b/docs/mle.md
@@ -248,7 +248,7 @@ snapshots — no GPU, fully agent-verifiable.
       REFUSE bare numbers with a teaching error — degree/radian confusion
       is unrepresentable, matching the F# side's `Math.Angle` discipline.
       Tier 2 (F#-style units of measure with unit algebra) rides on B7.
-- [ ] **B7. Hindley–Milner inference** (decided 2026-07-02; **after effects
+- [x] **B7. Hindley–Milner inference** (done 2026-07-04; decided 2026-07-02; **after effects
       land** — B6 + the `effect[...]` header checking, so type inference and
       effect rows are designed against each other, not retrofitted). Upgrade
       the B4 gradual checker to real inference: type variables + unification,
@@ -259,7 +259,23 @@ snapshots — no GPU, fully agent-verifiable.
       with teeth needs one answer), and unification-error UX (every mismatch
       must cite the source spans of *both* sides — legible errors were the
       reason annotations came first; see `~/notes` `open-questions.md`).
-      *Verify:* unannotated examples get full inferred signatures (an
+      **Done:** type variables + unification with occurs check;
+      let-polymorphism generalized per SCC of the def call graph (mutual
+      recursion monomorphic inside its group; `id` at two types in one
+      module works); generic builtin schemes (element types flow through
+      `List.map`/`filter`/`fold`); lowercase annotation names are scoped
+      type variables; record literals resolve nominally F#-style (user
+      decision: unique field-set match, ambiguity asks for annotation;
+      anonymous records stay gradual); Unknown remains ONLY the
+      host/dynamic seam and never binds a variable; conflicts report once
+      with full zonked types, labeled by where the expectation came from.
+      Inference has teeth: unannotated bad calls, mixed lists,
+      contradictory mut use, and foreign match arms are all caught now.
+      *Verify (done):* both shipped games + all example goldens check
+      clean under inference; `(xs, k) => List.map(xs, (x) => x * k)`
+      hovers as `(List<Float>, Float) => List<Float>`; teeth + occurs +
+      ambiguity + SCC polymorphism pinned (215 mle tests).
+      *Original verify:* unannotated examples get full inferred signatures (an
       `mle types` dump, goldened); the B4 diagnostic suite still passes;
       probe battery re-run (no legal program rejected).
 

--- a/mle/src/rebind.rs
+++ b/mle/src/rebind.rs
@@ -424,7 +424,7 @@ fn pattern_binders(pattern: &Pattern, f: &mut impl FnMut(BindingId, &str)) {
 }
 
 /// Apply `f` to every direct child expression of `expr`.
-pub(crate) fn each_child(expr: &Expr, f: &mut impl FnMut(&Expr)) {
+pub(crate) fn each_child<'a>(expr: &'a Expr, f: &mut impl FnMut(&'a Expr)) {
     match &expr.kind {
         ExprKind::Number(_)
         | ExprKind::String(_)

--- a/mle/src/rebind.rs
+++ b/mle/src/rebind.rs
@@ -424,7 +424,7 @@ fn pattern_binders(pattern: &Pattern, f: &mut impl FnMut(BindingId, &str)) {
 }
 
 /// Apply `f` to every direct child expression of `expr`.
-fn each_child(expr: &Expr, f: &mut impl FnMut(&Expr)) {
+pub(crate) fn each_child(expr: &Expr, f: &mut impl FnMut(&Expr)) {
     match &expr.kind {
         ExprKind::Number(_)
         | ExprKind::String(_)

--- a/mle/src/types.rs
+++ b/mle/src/types.rs
@@ -1,11 +1,23 @@
-//! Basic typechecking over the core IR — Track B4 of `docs/mle.md`.
+//! Typechecking over the core IR — B4's gradual checker upgraded to real
+//! **Hindley–Milner inference** (Track B7 of `docs/mle.md`).
 //!
-//! This is **gradual checking with annotations, not inference**: anything
-//! unannotated — and any type name that isn't a primitive, `List`, or a
-//! declared record type (e.g. a generic parameter like `T`) — is
-//! [`Type::Unknown`], and Unknown is compatible with everything. A check only
-//! fires where **both** sides are known, so unannotated code never produces a
-//! false positive; annotations buy diagnostics.
+//! Unannotated code gets genuine types: fresh inference variables, solved
+//! by unification, with **let-polymorphism** — each top-level def
+//! generalizes as its dependency group finishes (strongly-connected
+//! components of the call graph, so mutual recursion is monomorphic inside
+//! its group and forward references still work), and every use
+//! instantiates fresh (`id` at Float and String in one module is fine).
+//! Builtins carry generic schemes (`List.map : (List<'a>, ('a) => 'b) =>
+//! List<'b>`), so element types flow through pipelines. Lowercase names in
+//! annotations are scoped type variables (`(xs: List<a>, f: (a) => b)`).
+//!
+//! **Gradualness survives at the seams**: [`Type::Unknown`] remains for
+//! host values and unrecognized UPPERCASE type names, absorbs anything in
+//! unification, and never binds a variable — dynamic where the world is
+//! dynamic, inferred everywhere else. Record literals resolve NOMINALLY,
+//! F#-style: the unique declared type with exactly that field set (no
+//! match → anonymous data, still gradual; several → ambiguity error
+//! asking for an annotation).
 //!
 //! ## The type language
 //!
@@ -72,7 +84,14 @@ use std::fmt;
 #[derive(Clone, PartialEq)]
 pub enum Type {
     /// Not known statically; compatible with everything (see module docs).
+    /// After B7 this is the GRADUAL seam only (host values, unknown
+    /// uppercase type names) — unannotated code gets real [`Type::Var`]s.
     Unknown,
+    /// An inference variable (B7). Solved through the checker's
+    /// substitution; a variable still free after a def's inference is
+    /// GENERALIZED there (let-polymorphism) and instantiated fresh at every
+    /// use. Displays as `'a`, `'b`, … (normalized per top-level def).
+    Var(u32),
     Float,
     String,
     Bool,
@@ -91,6 +110,9 @@ impl fmt::Display for Type {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Type::Unknown => write!(f, "Unknown"),
+            // Raw display; hover/errors normalize vars to 'a, 'b first
+            // (see `Checker::zonk_normalized`).
+            Type::Var(v) => write!(f, "'{}", var_name(*v)),
             Type::Float => write!(f, "Float"),
             Type::String => write!(f, "String"),
             Type::Bool => write!(f, "Bool"),
@@ -119,6 +141,25 @@ impl fmt::Display for Type {
     }
 }
 
+/// Spell an inference variable: 0 → a, 1 → b, …, 26 → a1, ….
+fn var_name(v: u32) -> String {
+    let letter = (b'a' + (v % 26) as u8) as char;
+    if v < 26 {
+        letter.to_string()
+    } else {
+        format!("{letter}{}", v / 26)
+    }
+}
+
+/// A polymorphic type: universally quantified variables plus a body. What
+/// a top-level def (or generalized `let`-bound lambda) contributes to the
+/// environment; instantiated with fresh variables at every use site.
+#[derive(Clone)]
+pub struct Scheme {
+    pub vars: Vec<u32>,
+    pub ty: Type,
+}
+
 /// Gradual compatibility: true unless the two types are known to disagree.
 /// Unknown (at any depth) is compatible with everything. (Incompatibility is
 /// an annotation-level claim, not a runtime guarantee — nominality only
@@ -126,6 +167,9 @@ impl fmt::Display for Type {
 pub fn compatible(a: &Type, b: &Type) -> bool {
     match (a, b) {
         (Type::Unknown, _) | (_, Type::Unknown) => true,
+        // An unsolved variable is compatible with anything at this level of
+        // scrutiny (the unifier is where variables get COMMITTED).
+        (Type::Var(_), _) | (_, Type::Var(_)) => true,
         (Type::Float, Type::Float) | (Type::String, Type::String) | (Type::Bool, Type::Bool) => {
             true
         }
@@ -155,6 +199,35 @@ fn contains_fn(ty: &Type) -> bool {
     }
 }
 
+/// Free inference variables of `ty`, appended to `out` (deduplicated).
+fn free_vars_of(ty: &Type, out: &mut Vec<u32>) {
+    match ty {
+        Type::Var(v) => {
+            if !out.contains(v) {
+                out.push(*v);
+            }
+        }
+        Type::List(elem) => free_vars_of(elem, out),
+        Type::Tuple(elems) => {
+            for elem in elems {
+                free_vars_of(elem, out);
+            }
+        }
+        Type::Fn(params, ret) => {
+            for param in params {
+                free_vars_of(param, out);
+            }
+            free_vars_of(ret, out);
+        }
+        Type::Unknown
+        | Type::Float
+        | Type::String
+        | Type::Bool
+        | Type::Record(_)
+        | Type::Variant(_) => {}
+    }
+}
+
 /// The signature of a builtin (kept in sync with [`crate::eval`]'s registry
 /// by matching on [`Builtin`]). Generic slots are Unknown rather than
 /// instantiated type variables — e.g. `List.map : (List<T>, (T) => U) =>
@@ -167,24 +240,26 @@ pub fn builtin_signature(b: Builtin) -> Type {
         Fn(params, Box::new(ret))
     }
     match b {
-        // List.map : (List<T>, (T) => U) => List<U>
+        // Generic slots are Var(0)/Var(1); every use site instantiates
+        // them fresh (B7), so element types genuinely flow through.
+        // List.map : (List<'a>, ('a) => 'b) => List<'b>
         Builtin::ListMap => func(
-            vec![List(Box::new(Unknown)), func(vec![Unknown], Unknown)],
-            List(Box::new(Unknown)),
+            vec![List(Box::new(Var(0))), func(vec![Var(0)], Var(1))],
+            List(Box::new(Var(1))),
         ),
-        // List.filter : (List<T>, (T) => Bool) => List<T>
+        // List.filter : (List<'a>, ('a) => Bool) => List<'a>
         Builtin::ListFilter => func(
-            vec![List(Box::new(Unknown)), func(vec![Unknown], Bool)],
-            List(Box::new(Unknown)),
+            vec![List(Box::new(Var(0))), func(vec![Var(0)], Bool)],
+            List(Box::new(Var(0))),
         ),
-        // List.fold : (List<T>, (U, T) => U, U) => U
+        // List.fold : (List<'a>, ('b, 'a) => 'b, 'b) => 'b
         Builtin::ListFold => func(
             vec![
-                List(Box::new(Unknown)),
-                func(vec![Unknown, Unknown], Unknown),
-                Unknown,
+                List(Box::new(Var(0))),
+                func(vec![Var(1), Var(0)], Var(1)),
+                Var(1),
             ],
-            Unknown,
+            Var(1),
         ),
         // List.range : (Float) => List<Float>
         Builtin::ListRange => func(vec![Float], List(Box::new(Float))),
@@ -230,6 +305,10 @@ pub fn check(module: &Module) -> Vec<CheckError> {
 /// (final, loud) inference pass.
 pub fn check_with_types(module: &Module) -> (Vec<CheckError>, ExprTypes) {
     let mut checker = Checker {
+        subst: HashMap::new(),
+        next_var: 0,
+        schemes: HashMap::new(),
+        annot_vars: HashMap::new(),
         records: HashMap::new(),
         variants: HashMap::new(),
         ctors: HashMap::new(),
@@ -279,58 +358,166 @@ pub fn check_with_types(module: &Module) -> (Vec<CheckError>, ExprTypes) {
         }
     }
 
-    // Global signatures before bodies, so forward references between
-    // functions see full signatures (the interpreter late-binds globals the
-    // same way). Resolution is silent here — the body pass resolves the same
-    // annotations again and reports once.
+    // Placeholder signatures: annotation-derived, with FRESH inference
+    // variables where nothing is annotated (B7 — this is what makes
+    // unannotated code inferable instead of Unknown). Resolution is silent;
+    // the body pass resolves the same annotations again and reports once.
     for def in &module.defs {
+        checker.annot_vars.clear();
         let ty = match &def.value.kind {
-            ExprKind::Lambda { params, ret, .. } => Type::Fn(
-                params
+            ExprKind::Lambda { params, ret, .. } => {
+                let params = params
                     .iter()
                     .map(|p| checker.resolve_annotation(p.ty.as_ref(), false))
-                    .collect(),
-                Box::new(checker.resolve_annotation(ret.as_ref(), false)),
-            ),
+                    .collect();
+                let ret = checker.resolve_annotation(ret.as_ref(), false);
+                Type::Fn(params, Box::new(ret))
+            }
             ExprKind::Number(_) => Type::Float,
             ExprKind::String(_) => Type::String,
             ExprKind::Bool(_) => Type::Bool,
-            _ => Type::Unknown,
+            _ => checker.fresh(),
         };
         checker.globals.insert(def.name.clone(), ty);
     }
 
-    // Quiet enrichment: one inference pass upgrades what annotations alone
-    // couldn't say (an unannotated lambda's return from its body, a list
-    // literal's element type), so the diagnostic pass below checks against
-    // the best-known signatures. Single pass by design — a chain of
-    // unannotated-return functions stays Unknown (gradual, no fixed point).
-    checker.quiet = true;
-    for def in &module.defs {
-        let inferred = checker.infer(&def.value);
-        let entry = checker
-            .globals
-            .get_mut(&def.name)
-            .expect("inserted in the pre-pass");
-        *entry = merge_known(entry.clone(), inferred);
-    }
-    checker.quiet = false;
-
-    for def in &module.defs {
-        checker.infer(&def.value);
+    // Infer in dependency order, one strongly-connected component at a
+    // time: within a group (mutual recursion) uses are monomorphic — the
+    // standard HM letrec rule — and each def GENERALIZES as its group
+    // finishes, so later defs instantiate real schemes (`id` used at Float
+    // and String in one module works).
+    for group in scc_groups(module) {
+        for &i in &group {
+            let def = &module.defs[i];
+            checker.annot_vars.clear();
+            let placeholder = checker
+                .globals
+                .get(&def.name)
+                .cloned()
+                .unwrap_or(Type::Unknown);
+            let inferred = checker.infer(&def.value);
+            checker.unify(
+                &inferred,
+                &placeholder,
+                def.value.span,
+                &format!("`{}`", def.name),
+            );
+        }
+        for &i in &group {
+            let def = &module.defs[i];
+            let ty = checker
+                .globals
+                .get(&def.name)
+                .cloned()
+                .unwrap_or(Type::Unknown);
+            let scheme = checker.generalize(&ty);
+            checker.schemes.insert(def.name.clone(), scheme);
+        }
     }
 
     checker.diags.sort_by_key(|d| d.span.start);
-    (
-        checker.diags,
-        ExprTypes {
-            exprs: checker.expr_types,
-            bindings: checker.locals,
-        },
-    )
+    let exprs = checker
+        .expr_types
+        .iter()
+        .map(|(id, ty)| (*id, checker.zonk_normalized(ty)))
+        .collect();
+    let bindings = checker
+        .locals
+        .iter()
+        .map(|(id, ty)| (*id, checker.zonk_normalized(ty)))
+        .collect();
+    (checker.diags, ExprTypes { exprs, bindings })
+}
+
+/// Strongly-connected components of the def call graph (edges = `Global`
+/// references), in dependency order — the generalization boundaries.
+/// Iterative Tarjan; module-sized inputs, no recursion depth concerns.
+fn scc_groups(module: &Module) -> Vec<Vec<usize>> {
+    let index_of: HashMap<&str, usize> = module
+        .defs
+        .iter()
+        .enumerate()
+        .map(|(i, d)| (d.name.as_str(), i))
+        .collect();
+    let n = module.defs.len();
+    let mut edges: Vec<Vec<usize>> = vec![Vec::new(); n];
+    for (i, def) in module.defs.iter().enumerate() {
+        fn refs(expr: &Expr, index_of: &HashMap<&str, usize>, out: &mut Vec<usize>) {
+            if let ExprKind::Global(name) = &expr.kind {
+                if let Some(&j) = index_of.get(name.as_str()) {
+                    if !out.contains(&j) {
+                        out.push(j);
+                    }
+                }
+            }
+            crate::rebind::each_child(expr, &mut |child| refs(child, index_of, out));
+        }
+        refs(&def.value, &index_of, &mut edges[i]);
+    }
+    // Tarjan, iterative.
+    let mut index = vec![usize::MAX; n];
+    let mut low = vec![0usize; n];
+    let mut on_stack = vec![false; n];
+    let mut stack: Vec<usize> = Vec::new();
+    let mut next_index = 0usize;
+    let mut components: Vec<Vec<usize>> = Vec::new();
+    for start in 0..n {
+        if index[start] != usize::MAX {
+            continue;
+        }
+        // (node, next child position)
+        let mut call: Vec<(usize, usize)> = vec![(start, 0)];
+        while let Some(&mut (v, ref mut ci)) = call.last_mut() {
+            if *ci == 0 {
+                index[v] = next_index;
+                low[v] = next_index;
+                next_index += 1;
+                stack.push(v);
+                on_stack[v] = true;
+            }
+            if *ci < edges[v].len() {
+                let w = edges[v][*ci];
+                *ci += 1;
+                if index[w] == usize::MAX {
+                    call.push((w, 0));
+                } else if on_stack[w] {
+                    low[v] = low[v].min(index[w]);
+                }
+            } else {
+                if low[v] == index[v] {
+                    let mut component = Vec::new();
+                    loop {
+                        let w = stack.pop().expect("tarjan stack");
+                        on_stack[w] = false;
+                        component.push(w);
+                        if w == v {
+                            break;
+                        }
+                    }
+                    components.push(component);
+                }
+                call.pop();
+                if let Some(&mut (parent, _)) = call.last_mut() {
+                    low[parent] = low[parent].min(low[v]);
+                }
+            }
+        }
+    }
+    components
 }
 
 struct Checker {
+    /// The substitution: solved inference variables (B7). Types are read
+    /// through it via [`Checker::zonk`].
+    subst: HashMap<u32, Type>,
+    next_var: u32,
+    /// Generalized top-level defs (populated as each dependency group
+    /// finishes inference); instantiated fresh at every later use.
+    schemes: HashMap<String, Scheme>,
+    /// Lowercase annotation names in the CURRENT def's signature are scoped
+    /// type variables (`(xs: List<a>, f: (a) => b): List<b>`); this maps
+    /// them to their variable for the def's duration.
+    annot_vars: HashMap<String, Type>,
     /// Declared record types: name → resolved fields, in declaration order.
     records: HashMap<String, Vec<(String, Type)>>,
     /// Declared variant types: name → constructor names, in declaration
@@ -352,31 +539,177 @@ struct Checker {
     expr_types: HashMap<u32, Type>,
 }
 
-/// Prefer the known parts of two views of the same definition's type: the
-/// annotation-derived signature, upgraded by inference where the annotation
-/// said Unknown.
-fn merge_known(stored: Type, inferred: Type) -> Type {
-    match (stored, inferred) {
-        (Type::Unknown, inferred) => inferred,
-        (Type::Fn(params, ret), Type::Fn(inferred_params, inferred_ret))
-            if params.len() == inferred_params.len() =>
-        {
-            let params = params
-                .into_iter()
-                .zip(inferred_params)
-                .map(|(s, i)| merge_known(s, i))
-                .collect();
-            Type::Fn(params, Box::new(merge_known(*ret, *inferred_ret)))
-        }
-        (stored, _) => stored,
-    }
-}
-
 impl Checker {
     fn diag(&mut self, span: Span, message: String) {
         if !self.quiet {
             self.diags.push(CheckError { message, span });
         }
+    }
+
+    fn fresh(&mut self) -> Type {
+        let v = self.next_var;
+        self.next_var += 1;
+        Type::Var(v)
+    }
+
+    /// Apply the substitution deeply — the type with everything solved so
+    /// far written through.
+    fn zonk(&self, ty: &Type) -> Type {
+        match ty {
+            Type::Var(v) => match self.subst.get(v) {
+                Some(solved) => self.zonk(solved),
+                None => Type::Var(*v),
+            },
+            Type::List(elem) => Type::List(Box::new(self.zonk(elem))),
+            Type::Tuple(elems) => Type::Tuple(elems.iter().map(|e| self.zonk(e)).collect()),
+            Type::Fn(params, ret) => Type::Fn(
+                params.iter().map(|p| self.zonk(p)).collect(),
+                Box::new(self.zonk(ret)),
+            ),
+            other => other.clone(),
+        }
+    }
+
+    /// Unify two types, committing variable solutions. On a real conflict,
+    /// reports ONE diagnostic at `span` showing the full zonked types
+    /// (`got` = `a`, `expected` = `b`) — component mismatches inside lists,
+    /// tuples, or functions surface as the whole types, which is what the
+    /// source position actually shows. `Unknown` absorbs anything (the gradual
+    /// seam); `origin` cites where the expected type came from.
+    fn unify(&mut self, a: &Type, b: &Type, span: Span, what: &str) -> bool {
+        if self.unify_rec(a, b, span, what) {
+            return true;
+        }
+        let (got, expected) = (self.zonk_normalized(a), self.zonk_normalized(b));
+        self.mismatch(&expected, &got, span, what);
+        false
+    }
+
+    /// The recursive worker: solves what it can, returns false on conflict
+    /// WITHOUT reporting (the wrapper reports once, with full types).
+    fn unify_rec(&mut self, a: &Type, b: &Type, span: Span, what: &str) -> bool {
+        let a = self.zonk(a);
+        let b = self.zonk(b);
+        match (&a, &b) {
+            (Type::Unknown, _) | (_, Type::Unknown) => true,
+            (Type::Var(v), _) => self.bind(*v, &b, span, what),
+            (_, Type::Var(v)) => self.bind(*v, &a, span, what),
+            (Type::Float, Type::Float)
+            | (Type::String, Type::String)
+            | (Type::Bool, Type::Bool) => true,
+            (Type::Record(x), Type::Record(y)) if x == y => true,
+            (Type::Variant(x), Type::Variant(y)) if x == y => true,
+            (Type::List(x), Type::List(y)) => self.unify_rec(x, y, span, what),
+            (Type::Tuple(xs), Type::Tuple(ys)) if xs.len() == ys.len() => {
+                let mut ok = true;
+                for (x, y) in xs.clone().iter().zip(ys.clone().iter()) {
+                    ok &= self.unify_rec(x, y, span, what);
+                }
+                ok
+            }
+            (Type::Fn(p1, r1), Type::Fn(p2, r2)) if p1.len() == p2.len() => {
+                let (p1, r1, p2, r2) = (p1.clone(), r1.clone(), p2.clone(), r2.clone());
+                let mut ok = true;
+                for (x, y) in p1.iter().zip(p2.iter()) {
+                    ok &= self.unify_rec(x, y, span, what);
+                }
+                ok & self.unify_rec(&r1, &r2, span, what)
+            }
+            _ => false,
+        }
+    }
+
+    /// Solve variable `v` as `ty` (occurs-checked: `'a = List<'a>` is an
+    /// infinite type, reported rather than looped on).
+    fn bind(&mut self, v: u32, ty: &Type, span: Span, what: &str) -> bool {
+        if let Type::Var(w) = ty {
+            if *w == v {
+                return true;
+            }
+        }
+        let mut free = Vec::new();
+        free_vars_of(ty, &mut free);
+        if free.contains(&v) {
+            self.diag(
+                span,
+                format!(
+                    "{what}: cannot construct the infinite type '{} = {ty}",
+                    var_name(v)
+                ),
+            );
+            // Reported here; treat as absorbed so the wrapper doesn't add a
+            // second, vaguer mismatch for the same conflict.
+            return true;
+        }
+        self.subst.insert(v, ty.clone());
+        true
+    }
+
+    /// Report a unification conflict. The `what` label names where the
+    /// expectation came from ("argument 2 of `f`", "return value", "list
+    /// element") — the legible-error contract.
+    fn mismatch(&mut self, expected: &Type, got: &Type, span: Span, what: &str) {
+        self.diag(span, format!("{what}: expected {expected}, got {got}"));
+    }
+
+    /// Instantiate a scheme: quantified variables become fresh ones.
+    fn instantiate(&mut self, scheme: &Scheme) -> Type {
+        if scheme.vars.is_empty() {
+            return scheme.ty.clone();
+        }
+        let mapping: HashMap<u32, Type> = scheme.vars.iter().map(|v| (*v, self.fresh())).collect();
+        fn walk(ty: &Type, mapping: &HashMap<u32, Type>) -> Type {
+            match ty {
+                Type::Var(v) => mapping.get(v).cloned().unwrap_or(Type::Var(*v)),
+                Type::List(e) => Type::List(Box::new(walk(e, mapping))),
+                Type::Tuple(es) => Type::Tuple(es.iter().map(|e| walk(e, mapping)).collect()),
+                Type::Fn(ps, r) => Type::Fn(
+                    ps.iter().map(|p| walk(p, mapping)).collect(),
+                    Box::new(walk(r, mapping)),
+                ),
+                other => other.clone(),
+            }
+        }
+        // NOT zonked: a real scheme's body is zonked at generalization time
+        // (and its quantified vars are unsolved by construction), while a
+        // builtin signature's literal Var(0)/Var(1) ids live OUTSIDE the
+        // checker's namespace — zonking them here would read unrelated
+        // solutions (the var-collision bug the `functions.mle` golden
+        // caught: List.map's 'a arriving pre-solved as Float).
+        walk(&scheme.ty, &mapping)
+    }
+
+    /// Generalize a def's zonked type: every still-free variable is
+    /// quantified (top-level defs close over nothing that could pin one).
+    fn generalize(&self, ty: &Type) -> Scheme {
+        let ty = self.zonk(ty);
+        let mut vars = Vec::new();
+        free_vars_of(&ty, &mut vars);
+        Scheme { vars, ty }
+    }
+
+    /// Zonk with display normalization: free variables renumber to 'a, 'b, …
+    /// in first-appearance order — hover and signatures read cleanly.
+    fn zonk_normalized(&self, ty: &Type) -> Type {
+        let ty = self.zonk(ty);
+        let mut order = Vec::new();
+        free_vars_of(&ty, &mut order);
+        fn renumber(ty: &Type, order: &[u32]) -> Type {
+            match ty {
+                Type::Var(v) => {
+                    let idx = order.iter().position(|o| o == v).expect("collected") as u32;
+                    Type::Var(idx)
+                }
+                Type::List(e) => Type::List(Box::new(renumber(e, order))),
+                Type::Tuple(es) => Type::Tuple(es.iter().map(|e| renumber(e, order)).collect()),
+                Type::Fn(ps, r) => Type::Fn(
+                    ps.iter().map(|p| renumber(p, order)).collect(),
+                    Box::new(renumber(r, order)),
+                ),
+                other => other.clone(),
+            }
+        }
+        renumber(&ty, &order)
     }
 
     /// Resolve an annotation to a [`Type`]. Unknown type *names* are not
@@ -434,9 +767,23 @@ impl Checker {
                 }
                 Type::Variant(name.to_string())
             }
-            // Unrecognized (a generic like `T`, or a type this module doesn't
-            // declare): Unknown, not an error. Still resolve any arguments so
-            // nested annotations (`T<Position<Float>>`) get their diagnostics.
+            // A lowercase name is a TYPE VARIABLE, scoped to the enclosing
+            // def's signature: `(xs: List<a>, f: (a) => b): List<b>`. The
+            // same name maps to the same variable within one def.
+            name if name.chars().next().is_some_and(char::is_lowercase) => {
+                if !ty.args.is_empty() {
+                    return arity_error(self, 0);
+                }
+                if let Some(var) = self.annot_vars.get(name) {
+                    return var.clone();
+                }
+                let var = self.fresh();
+                self.annot_vars.insert(name.to_string(), var.clone());
+                var
+            }
+            // Unrecognized UPPERCASE names stay Unknown — the gradual seam
+            // for host-side types this module doesn't declare. Still resolve
+            // any arguments so nested annotations get their diagnostics.
             _ => {
                 for arg in &ty.args {
                     self.resolve_type(arg, report);
@@ -449,7 +796,9 @@ impl Checker {
     fn resolve_annotation(&mut self, ty: Option<&TypeName>, report: bool) -> Type {
         match ty {
             Some(ty) => self.resolve_type(ty, report),
-            None => Type::Unknown,
+            // Unannotated: a real inference variable, not Unknown — this is
+            // what B7 buys.
+            None => self.fresh(),
         }
     }
 
@@ -459,8 +808,16 @@ impl Checker {
     /// tested for compatibility. `what` names the expectation for the
     /// diagnostic ("argument 2 of `move`", "field `x` of `Position`").
     fn expect(&mut self, expr: &Expr, expected: &Type, what: &str) {
+        let expected = &self.zonk(expected);
         if *expected == Type::Unknown {
             self.infer(expr);
+            return;
+        }
+        // An unsolved variable has no structure to check literals against —
+        // infer and commit it.
+        if let Type::Var(_) = expected {
+            let got = self.infer(expr);
+            self.unify(&got, expected, expr.span, what);
             return;
         }
         match (&expr.kind, expected) {
@@ -512,9 +869,8 @@ impl Checker {
             }
             _ => {
                 let got = self.infer(expr);
-                if !compatible(&got, expected) {
-                    self.diag(expr.span, format!("{what}: expected {expected}, got {got}"));
-                }
+                let expected = self.zonk(expected);
+                self.unify(&got, &expected, expr.span, what);
             }
         }
     }
@@ -573,36 +929,85 @@ impl Checker {
                 .get(&binding.0)
                 .cloned()
                 .unwrap_or(Type::Unknown),
-            ExprKind::Global(name) => self.globals.get(name).cloned().unwrap_or(Type::Unknown),
+            ExprKind::Global(name) => match self.schemes.get(name).cloned() {
+                Some(scheme) => self.instantiate(&scheme),
+                // Same dependency group: monomorphic placeholder (the HM
+                // letrec rule).
+                None => self.globals.get(name).cloned().unwrap_or(Type::Unknown),
+            },
             // An unregistered external is a runtime concern (the module set
             // may grow); the checker only knows the builtins' signatures.
             ExprKind::External(path) => match builtin(path) {
-                Some(b) => builtin_signature(b),
+                Some(b) => {
+                    let sig = builtin_signature(b);
+                    let mut vars = Vec::new();
+                    free_vars_of(&sig, &mut vars);
+                    self.instantiate(&Scheme { vars, ty: sig })
+                }
                 None => Type::Unknown,
             },
-            // A record literal with no expected type stays Unknown — record
-            // types are nominal, and nothing here names one (see `expect` for
-            // the checked positions).
+            // A record literal resolves NOMINALLY, F#-style (B7, user
+            // decision): the unique declared type with exactly this field
+            // set. No match → anonymous record data, still gradual
+            // (Unknown); several matches → ambiguous, ask for an
+            // annotation. (`expect` handles annotated positions with
+            // tailored diagnostics before this is reached.)
             ExprKind::Record(fields) => {
-                for field in fields {
-                    self.infer(&field.value);
+                let mut names: Vec<&str> = fields.iter().map(|f| f.name.as_str()).collect();
+                names.sort_unstable();
+                let matches: Vec<String> = self
+                    .records
+                    .iter()
+                    .filter(|(_, decl)| {
+                        let mut declared: Vec<&str> =
+                            decl.iter().map(|(n, _)| n.as_str()).collect();
+                        declared.sort_unstable();
+                        declared == names
+                    })
+                    .map(|(name, _)| name.clone())
+                    .collect();
+                match matches.as_slice() {
+                    [name] => {
+                        let name = name.clone();
+                        self.check_record_literal(fields, &name, expr.span);
+                        Type::Record(name)
+                    }
+                    [] => {
+                        for field in fields {
+                            self.infer(&field.value);
+                        }
+                        Type::Unknown
+                    }
+                    several => {
+                        let mut several: Vec<&str> = several.iter().map(|s| s.as_str()).collect();
+                        several.sort_unstable();
+                        self.diag(
+                            expr.span,
+                            format!(
+                                "ambiguous record literal: fields match {} — annotate which one is meant",
+                                several.join(" and ")
+                            ),
+                        );
+                        for field in fields {
+                            self.infer(&field.value);
+                        }
+                        Type::Unknown
+                    }
                 }
-                Type::Unknown
             }
             ExprKind::List(items) => {
-                let mut elem: Option<Type> = None;
+                // One element type, unified across all items — mixed lists
+                // are now real errors (inference with teeth).
+                let elem = self.fresh();
                 for item in items {
                     let ty = self.infer(item);
-                    elem = match elem {
-                        None => Some(ty),
-                        Some(prev) if prev == ty => Some(prev),
-                        Some(_) => Some(Type::Unknown),
-                    };
+                    self.unify(&ty, &elem, item.span, "list element");
                 }
-                Type::List(Box::new(elem.unwrap_or(Type::Unknown)))
+                Type::List(Box::new(elem))
             }
             ExprKind::RecordUpdate { base, fields } => {
                 let base_ty = self.infer(base);
+                let base_ty = self.zonk(&base_ty);
                 match &base_ty {
                     Type::Record(name) => {
                         let name = name.clone();
@@ -628,7 +1033,7 @@ impl Checker {
                         }
                         base_ty
                     }
-                    Type::Unknown => {
+                    Type::Unknown | Type::Var(_) => {
                         for field in fields {
                             self.infer(&field.value);
                         }
@@ -677,6 +1082,7 @@ impl Checker {
             }
             ExprKind::FieldAccess { object, field } => {
                 let object_ty = self.infer(object);
+                let object_ty = self.zonk(&object_ty);
                 match &object_ty {
                     Type::Record(name) => {
                         let field_ty = self
@@ -692,7 +1098,9 @@ impl Checker {
                             }
                         }
                     }
-                    Type::Unknown => Type::Unknown,
+                    // No row polymorphism: an unsolved object stays
+                    // gradual rather than guessing a nominal type.
+                    Type::Unknown | Type::Var(_) => Type::Unknown,
                     other => {
                         self.diag(expr.span, format!("`.{field}` on {other}, not a record"));
                         Type::Unknown
@@ -707,14 +1115,17 @@ impl Checker {
                 for (param, ty) in params.iter().zip(&param_tys) {
                     self.locals.insert(param.binding.0, ty.clone());
                 }
+                let annotated = ret.is_some();
                 let ret_ty = self.resolve_annotation(ret.as_ref(), true);
-                let body_ty = if ret_ty == Type::Unknown {
-                    self.infer(body)
-                } else {
+                if annotated {
+                    // expect() keeps the tailored record/list/tuple literal
+                    // diagnostics for annotated returns.
                     self.expect(body, &ret_ty, "return value");
-                    ret_ty
-                };
-                Type::Fn(param_tys, Box::new(body_ty))
+                } else {
+                    let body_ty = self.infer(body);
+                    self.unify(&body_ty, &ret_ty, body.span, "return value");
+                }
+                Type::Fn(param_tys, Box::new(ret_ty))
             }
             ExprKind::Call { callee, args } => {
                 let callee_ty = self.infer(callee);
@@ -741,6 +1152,14 @@ impl Checker {
                             }
                         }
                         *ret
+                    }
+                    Type::Var(_) => {
+                        let arg_tys: Vec<Type> = args.iter().map(|arg| self.infer(arg)).collect();
+                        let ret = self.fresh();
+                        let wanted = Type::Fn(arg_tys, Box::new(ret.clone()));
+                        let what = format!("call of `{}`", callee_label(callee));
+                        self.unify(&callee_ty, &wanted, expr.span, &what);
+                        ret
                     }
                     Type::Unknown => {
                         for arg in args {
@@ -811,6 +1230,7 @@ impl Checker {
     /// where the scrutinee's type is known, and the arm-result join.
     fn check_match(&mut self, expr: &Expr, scrutinee: &Expr, arms: &[MatchArm]) -> Type {
         let scrutinee_ty = self.infer(scrutinee);
+        let scrutinee_ty = self.zonk(&scrutinee_ty);
         let mut has_catch_all = false;
         let mut saw_true = false;
         let mut saw_false = false;
@@ -927,6 +1347,30 @@ a catch-all arm (`_` or a name)"
     /// variables' binding types (a bare variable binds the scrutinee's type;
     /// constructor sub-patterns bind the declared field types).
     fn check_pattern(&mut self, pattern: &Pattern, scrutinee: &Type) {
+        let scrutinee = &self.zonk(scrutinee);
+        // A variable scrutinee is CONSTRAINED by the pattern: a ctor pattern
+        // makes it the owning variant type, a tuple pattern a product of
+        // fresh elements, a literal its primitive — then check proceeds with
+        // the solved structure.
+        if let Type::Var(_) = scrutinee {
+            let constrained: Option<Type> = match &pattern.kind {
+                PatternKind::Ctor { name, .. } => self
+                    .ctors
+                    .get(name)
+                    .map(|(type_name, _)| Type::Variant(type_name.clone())),
+                PatternKind::Tuple(args) => {
+                    Some(Type::Tuple((0..args.len()).map(|_| self.fresh()).collect()))
+                }
+                PatternKind::Number(_) => Some(Type::Float),
+                PatternKind::Bool(_) => Some(Type::Bool),
+                PatternKind::String(_) => Some(Type::String),
+                PatternKind::Wildcard | PatternKind::Var { .. } => None,
+            };
+            if let Some(constrained) = constrained {
+                self.unify(scrutinee, &constrained, pattern.span, "match pattern");
+                return self.check_pattern(pattern, &constrained);
+            }
+        }
         match &pattern.kind {
             PatternKind::Wildcard => {}
             PatternKind::Var { binding, .. } => {
@@ -1038,6 +1482,23 @@ is {other}"
             // may legitimately compare — only differing declared shapes are
             // errors.
             BinOp::Eq => {
+                let (lhs, rhs) = (&self.zonk(lhs), &self.zonk(rhs));
+                // A known function on EITHER side is a certain runtime error
+                // regardless of the other side — check before variables get
+                // a chance to unify with it.
+                if contains_fn(lhs) || contains_fn(rhs) {
+                    self.diag(
+                        node_span,
+                        "functions cannot be compared with `==`".to_string(),
+                    );
+                    return Type::Bool;
+                }
+                // Otherwise equality constrains unsolved sides together
+                // (comparing a Float to a String is certainly false).
+                if matches!(lhs, Type::Var(_)) || matches!(rhs, Type::Var(_)) {
+                    self.unify(lhs, rhs, node_span, "`==` operands");
+                    return Type::Bool;
+                }
                 match (lhs, rhs) {
                     // One known function operand is enough: the runtime
                     // rejects `==` whenever EITHER side is a function
@@ -1092,7 +1553,17 @@ is {other}"
     }
 
     fn require_float(&mut self, op: BinOp, ty: &Type, span: Span) {
-        if !compatible(ty, &Type::Float) {
+        let ty = self.zonk(ty);
+        if let Type::Var(_) = ty {
+            self.unify(
+                &ty,
+                &Type::Float,
+                span,
+                &format!("`{}` operand", op_str(op)),
+            );
+            return;
+        }
+        if !compatible(&ty, &Type::Float) {
             self.diag(
                 span,
                 format!("`{}` needs Float operands, got {ty}", op_str(op)),

--- a/mle/src/types.rs
+++ b/mle/src/types.rs
@@ -47,9 +47,9 @@
 //! call with a known signature) and against any *non*-record expectation (a
 //! record literal is never a Float); field access on a known record type;
 //! call arity and argument types where the callee's function type is known —
-//! including the builtins, whose signatures live in [`builtin_signature`]
-//! with generic slots as Unknown (no instantiation: `List.map`'s element
-//! types simply aren't tracked); return annotations against the body's type;
+//! including the builtins, whose generic schemes live in
+//! [`builtin_signature`] and instantiate fresh at every use (element types
+//! flow through `List.map`); return annotations against the body's type;
 //! and type-argument arity (`Position<Float>` is an error, an *unknown* type
 //! name is not). Constructors carry function types from their declarations
 //! (`Circle : (Float) => Shape`; nullary constructors are the variant type
@@ -63,12 +63,10 @@
 //! exists — and joins the arm result types (compatible where known; the
 //! match's type is Unknown unless all arms agree exactly).
 //!
-//! Top-level `let`s contribute what their value's shape declares (a lambda's
-//! annotations, a literal's type), then a quiet single-pass inference
-//! upgrades what it can (an unannotated lambda return, a list literal's
-//! element type). Signatures are collected before bodies are checked, so
-//! forward references between functions see full signatures (matching the
-//! interpreter's late binding).
+//! Top-level `let`s get placeholder signatures (annotations, with fresh
+//! variables for whatever is unannotated) before bodies are checked, so
+//! forward references see full signatures (matching the interpreter's late
+//! binding); bodies then infer in dependency (SCC) order and generalize.
 //!
 //! [`check`] walks the whole module and returns **every** diagnostic, sorted
 //! by source position — it never stops at the first error.
@@ -199,6 +197,40 @@ fn contains_fn(ty: &Type) -> bool {
     }
 }
 
+/// Every variable binding a pattern introduces (shallow — the pattern
+/// language has no nesting beyond ctor/tuple args).
+fn pattern_var_bindings(pattern: &Pattern, f: &mut impl FnMut(u32)) {
+    match &pattern.kind {
+        PatternKind::Var { binding, .. } => f(binding.0),
+        PatternKind::Ctor { args, .. } | PatternKind::Tuple(args) => {
+            for arg in args {
+                pattern_var_bindings(arg, f);
+            }
+        }
+        PatternKind::Wildcard
+        | PatternKind::Number(_)
+        | PatternKind::Bool(_)
+        | PatternKind::String(_) => {}
+    }
+}
+
+/// Rewrite variables to their position in `order` (display normalization).
+fn renumber_with(ty: &Type, order: &[u32]) -> Type {
+    match ty {
+        Type::Var(v) => {
+            let idx = order.iter().position(|o| o == v).expect("collected") as u32;
+            Type::Var(idx)
+        }
+        Type::List(e) => Type::List(Box::new(renumber_with(e, order))),
+        Type::Tuple(es) => Type::Tuple(es.iter().map(|e| renumber_with(e, order)).collect()),
+        Type::Fn(ps, r) => Type::Fn(
+            ps.iter().map(|p| renumber_with(p, order)).collect(),
+            Box::new(renumber_with(r, order)),
+        ),
+        other => other.clone(),
+    }
+}
+
 /// Free inference variables of `ty`, appended to `out` (deduplicated).
 fn free_vars_of(ty: &Type, out: &mut Vec<u32>) {
     match ty {
@@ -308,6 +340,7 @@ pub fn check_with_types(module: &Module) -> (Vec<CheckError>, ExprTypes) {
         subst: HashMap::new(),
         next_var: 0,
         schemes: HashMap::new(),
+        in_type_decl: false,
         annot_vars: HashMap::new(),
         records: HashMap::new(),
         variants: HashMap::new(),
@@ -315,7 +348,6 @@ pub fn check_with_types(module: &Module) -> (Vec<CheckError>, ExprTypes) {
         globals: HashMap::new(),
         locals: HashMap::new(),
         diags: Vec::new(),
-        quiet: false,
         expr_types: HashMap::new(),
     };
 
@@ -334,6 +366,7 @@ pub fn check_with_types(module: &Module) -> (Vec<CheckError>, ExprTypes) {
             }
         }
     }
+    checker.in_type_decl = true;
     for decl in &module.types {
         match &decl.body {
             TypeBody::Record(decl_fields) => {
@@ -357,6 +390,8 @@ pub fn check_with_types(module: &Module) -> (Vec<CheckError>, ExprTypes) {
             }
         }
     }
+
+    checker.in_type_decl = false;
 
     // Placeholder signatures: annotation-derived, with FRESH inference
     // variables where nothing is annotated (B7 — this is what makes
@@ -416,15 +451,32 @@ pub fn check_with_types(module: &Module) -> (Vec<CheckError>, ExprTypes) {
     }
 
     checker.diags.sort_by_key(|d| d.span.start);
-    let exprs = checker
+    // ONE display order for the whole table: the same variable must hover
+    // as the same 'a everywhere (per-entry renumbering showed `q : 'a`
+    // while the signature said 'b — review F5c).
+    let mut order: Vec<u32> = Vec::new();
+    let mut expr_items: Vec<(u32, Type)> = checker
         .expr_types
         .iter()
-        .map(|(id, ty)| (*id, checker.zonk_normalized(ty)))
+        .map(|(id, ty)| (*id, checker.zonk(ty)))
         .collect();
-    let bindings = checker
+    expr_items.sort_by_key(|(id, _)| *id);
+    let mut binding_items: Vec<(u32, Type)> = checker
         .locals
         .iter()
-        .map(|(id, ty)| (*id, checker.zonk_normalized(ty)))
+        .map(|(id, ty)| (*id, checker.zonk(ty)))
+        .collect();
+    binding_items.sort_by_key(|(id, _)| *id);
+    for (_, ty) in expr_items.iter().chain(binding_items.iter()) {
+        free_vars_of(ty, &mut order);
+    }
+    let exprs = expr_items
+        .into_iter()
+        .map(|(id, ty)| (id, renumber_with(&ty, &order)))
+        .collect();
+    let bindings = binding_items
+        .into_iter()
+        .map(|(id, ty)| (id, renumber_with(&ty, &order)))
         .collect();
     (checker.diags, ExprTypes { exprs, bindings })
 }
@@ -442,17 +494,20 @@ fn scc_groups(module: &Module) -> Vec<Vec<usize>> {
     let n = module.defs.len();
     let mut edges: Vec<Vec<usize>> = vec![Vec::new(); n];
     for (i, def) in module.defs.iter().enumerate() {
-        fn refs(expr: &Expr, index_of: &HashMap<&str, usize>, out: &mut Vec<usize>) {
+        // Iterative worklist — the only whole-tree walk in `check`, and a
+        // deep binary spine must not overflow the stack (the lowerer and
+        // eval walk spines iteratively for the same reason).
+        let mut work: Vec<&Expr> = vec![&def.value];
+        while let Some(expr) = work.pop() {
             if let ExprKind::Global(name) = &expr.kind {
                 if let Some(&j) = index_of.get(name.as_str()) {
-                    if !out.contains(&j) {
-                        out.push(j);
+                    if !edges[i].contains(&j) {
+                        edges[i].push(j);
                     }
                 }
             }
-            crate::rebind::each_child(expr, &mut |child| refs(child, index_of, out));
+            crate::rebind::each_child(expr, &mut |child| work.push(child));
         }
-        refs(&def.value, &index_of, &mut edges[i]);
     }
     // Tarjan, iterative.
     let mut index = vec![usize::MAX; n];
@@ -514,6 +569,9 @@ struct Checker {
     /// Generalized top-level defs (populated as each dependency group
     /// finishes inference); instantiated fresh at every later use.
     schemes: HashMap<String, Scheme>,
+    /// Resolving a TYPE DECLARATION's field annotations (lowercase names
+    /// are refused there — see `resolve_type`).
+    in_type_decl: bool,
     /// Lowercase annotation names in the CURRENT def's signature are scoped
     /// type variables (`(xs: List<a>, f: (a) => b): List<b>`); this maps
     /// them to their variable for the def's duration.
@@ -531,9 +589,6 @@ struct Checker {
     /// are never shadowed or popped).
     locals: HashMap<u32, Type>,
     diags: Vec<CheckError>,
-    /// Suppress diagnostics (the quiet enrichment pass — the loud pass walks
-    /// the same nodes again and reports once).
-    quiet: bool,
     /// Best-known type per expression, recorded by [`Checker::infer`]. The
     /// loud pass runs last, so its (better-informed) types win.
     expr_types: HashMap<u32, Type>,
@@ -541,9 +596,7 @@ struct Checker {
 
 impl Checker {
     fn diag(&mut self, span: Span, message: String) {
-        if !self.quiet {
-            self.diags.push(CheckError { message, span });
-        }
+        self.diags.push(CheckError { message, span });
     }
 
     fn fresh(&mut self) -> Type {
@@ -580,7 +633,7 @@ impl Checker {
         if self.unify_rec(a, b, span, what) {
             return true;
         }
-        let (got, expected) = (self.zonk_normalized(a), self.zonk_normalized(b));
+        let (got, expected) = self.normalize_pair(a, b);
         self.mismatch(&expected, &got, span, what);
         false
     }
@@ -630,12 +683,10 @@ impl Checker {
         let mut free = Vec::new();
         free_vars_of(ty, &mut free);
         if free.contains(&v) {
+            let (var, ty) = self.normalize_pair(&Type::Var(v), ty);
             self.diag(
                 span,
-                format!(
-                    "{what}: cannot construct the infinite type '{} = {ty}",
-                    var_name(v)
-                ),
+                format!("{what}: cannot construct the infinite type {var} = {ty}"),
             );
             // Reported here; treat as absorbed so the wrapper doesn't add a
             // second, vaguer mismatch for the same conflict.
@@ -670,12 +721,15 @@ impl Checker {
                 other => other.clone(),
             }
         }
-        // NOT zonked: a real scheme's body is zonked at generalization time
-        // (and its quantified vars are unsolved by construction), while a
-        // builtin signature's literal Var(0)/Var(1) ids live OUTSIDE the
-        // checker's namespace — zonking them here would read unrelated
-        // solutions (the var-collision bug the `functions.mle` golden
-        // caught: List.map's 'a arriving pre-solved as Float).
+        // NOT zonked — the load-bearing invariant: a real scheme's body is
+        // zonked at generalization and its quantified vars never re-enter
+        // unification (same-group uses go through the monomorphic
+        // placeholder, later uses through fresh instantiations), while a
+        // builtin signature's literal Var(0)/Var(1) ids DO collide with
+        // live checker variables — the no-zonk rule is exactly what keeps
+        // that collision inert (zonking here read unrelated solutions: the
+        // var-collision bug the `functions.mle` golden caught, List.map's
+        // 'a arriving pre-solved as Float).
         walk(&scheme.ty, &mapping)
     }
 
@@ -694,22 +748,18 @@ impl Checker {
         let ty = self.zonk(ty);
         let mut order = Vec::new();
         free_vars_of(&ty, &mut order);
-        fn renumber(ty: &Type, order: &[u32]) -> Type {
-            match ty {
-                Type::Var(v) => {
-                    let idx = order.iter().position(|o| o == v).expect("collected") as u32;
-                    Type::Var(idx)
-                }
-                Type::List(e) => Type::List(Box::new(renumber(e, order))),
-                Type::Tuple(es) => Type::Tuple(es.iter().map(|e| renumber(e, order)).collect()),
-                Type::Fn(ps, r) => Type::Fn(
-                    ps.iter().map(|p| renumber(p, order)).collect(),
-                    Box::new(renumber(r, order)),
-                ),
-                other => other.clone(),
-            }
-        }
-        renumber(&ty, &order)
+        renumber_with(&ty, &order)
+    }
+
+    /// Normalize TWO types with ONE shared variable order — a diagnostic
+    /// showing both sides must name the same variable the same way (and
+    /// different variables differently).
+    fn normalize_pair(&self, a: &Type, b: &Type) -> (Type, Type) {
+        let (a, b) = (self.zonk(a), self.zonk(b));
+        let mut order = Vec::new();
+        free_vars_of(&a, &mut order);
+        free_vars_of(&b, &mut order);
+        (renumber_with(&a, &order), renumber_with(&b, &order))
     }
 
     /// Resolve an annotation to a [`Type`]. Unknown type *names* are not
@@ -769,10 +819,25 @@ impl Checker {
             }
             // A lowercase name is a TYPE VARIABLE, scoped to the enclosing
             // def's signature: `(xs: List<a>, f: (a) => b): List<b>`. The
-            // same name maps to the same variable within one def.
+            // same name maps to the same variable within one def. In TYPE
+            // DECLARATIONS they are refused — generic type declarations
+            // aren't designed yet, and a declaration-held variable would be
+            // module-global (first use pins it for everyone; both review
+            // engines' probe). [F4 — B7 review]
             name if name.chars().next().is_some_and(char::is_lowercase) => {
                 if !ty.args.is_empty() {
                     return arity_error(self, 0);
+                }
+                if self.in_type_decl {
+                    if report {
+                        self.diag(
+                            ty.span,
+                            format!(
+                                "type variables (`{name}`) are not supported in type declarations yet — generic type declarations are a roadmap item"
+                            ),
+                        );
+                    }
+                    return Type::Unknown;
                 }
                 if let Some(var) = self.annot_vars.get(name) {
                     return var.clone();
@@ -1199,7 +1264,10 @@ impl Checker {
             }
             ExprKind::Neg(inner) => {
                 let ty = self.infer(inner);
-                if !compatible(&ty, &Type::Float) {
+                let ty = self.zonk(&ty);
+                if let Type::Var(_) = ty {
+                    self.unify(&ty, &Type::Float, inner.span, "unary `-` operand");
+                } else if !compatible(&ty, &Type::Float) {
                     self.diag(
                         inner.span,
                         format!("unary `-` needs a Float operand, got {ty}"),
@@ -1237,14 +1305,18 @@ impl Checker {
         let mut covered_ctors: Vec<&str> = Vec::new();
         let mut result: Option<Type> = None;
         for arm in arms {
-            self.check_pattern(&arm.pattern, &scrutinee_ty);
+            // Arms after a catch-all are unreachable at runtime — they are
+            // still CHECKED (garbage draws diagnostics) but must not
+            // CONSTRAIN the scrutinee (an unreachable `"s"` arm must not
+            // pin an inferred scrutinee to String). [Codex M — B7 review]
+            self.check_pattern_constraining(&arm.pattern, &scrutinee_ty, !has_catch_all);
             match &arm.pattern.kind {
                 PatternKind::Wildcard | PatternKind::Var { .. } => has_catch_all = true,
                 // Sub-patterns are irrefutable (names/`_`), so a tuple arm
                 // catches every tuple of its arity — but only if that arity
                 // CAN match the scrutinee (the mismatch itself is diagnosed
                 // in check_pattern; it must not also count as exhaustive).
-                PatternKind::Tuple(args) => match &scrutinee_ty {
+                PatternKind::Tuple(args) => match &self.zonk(&scrutinee_ty) {
                     Type::Tuple(elems) if elems.len() != args.len() => {}
                     _ => has_catch_all = true,
                 },
@@ -1253,28 +1325,31 @@ impl Checker {
                 PatternKind::Bool(false) => saw_false = true,
                 PatternKind::Number(_) | PatternKind::String(_) => {}
             }
-            // All arms must agree where known; the match's type is the join
-            // (Unknown as soon as the arms aren't literally the same type).
+            // Arms UNIFY into one result type — a var arm is constrained by
+            // its siblings instead of collapsing the match to Unknown.
+            // [BOTH engines — B7 review]
             let body_ty = self.infer(&arm.body);
             result = Some(match result {
                 None => body_ty,
                 Some(prev) => {
-                    if !compatible(&prev, &body_ty) {
+                    if !self.unify_rec(&prev, &body_ty, arm.body.span, "match arm") {
+                        let (prev_n, body_n) = self.normalize_pair(&prev, &body_ty);
                         self.diag(
                             arm.body.span,
-                            format!("match arms have incompatible types {prev} and {body_ty}"),
+                            format!("match arms have incompatible types {prev_n} and {body_n}"),
                         );
-                    }
-                    if prev == body_ty {
-                        prev
-                    } else {
                         Type::Unknown
+                    } else {
+                        self.zonk(&prev)
                     }
                 }
             });
         }
         // Exhaustiveness fires only where the scrutinee's type is known —
-        // gradual, like every other check.
+        // RE-ZONKED: the arms' patterns may have just SOLVED it (the
+        // stale-zonk hole both engines found: an inferred-scrutinee match
+        // silently skipped exhaustiveness). [BOTH engines, High]
+        let scrutinee_ty = self.zonk(&scrutinee_ty);
         if !has_catch_all {
             match &scrutinee_ty {
                 Type::Variant(name) => {
@@ -1347,12 +1422,24 @@ a catch-all arm (`_` or a name)"
     /// variables' binding types (a bare variable binds the scrutinee's type;
     /// constructor sub-patterns bind the declared field types).
     fn check_pattern(&mut self, pattern: &Pattern, scrutinee: &Type) {
+        self.check_pattern_constraining(pattern, scrutinee, true);
+    }
+
+    fn check_pattern_constraining(&mut self, pattern: &Pattern, scrutinee: &Type, constrain: bool) {
         let scrutinee = &self.zonk(scrutinee);
         // A variable scrutinee is CONSTRAINED by the pattern: a ctor pattern
         // makes it the owning variant type, a tuple pattern a product of
         // fresh elements, a literal its primitive — then check proceeds with
-        // the solved structure.
+        // the solved structure. (Unreachable arms pass constrain: false —
+        // they are checked but must not solve the scrutinee.)
         if let Type::Var(_) = scrutinee {
+            if !constrain {
+                // Bind this arm's variables gradually and stop.
+                pattern_var_bindings(pattern, &mut |binding| {
+                    self.locals.insert(binding, Type::Unknown);
+                });
+                return;
+            }
             let constrained: Option<Type> = match &pattern.kind {
                 PatternKind::Ctor { name, .. } => self
                     .ctors
@@ -1493,9 +1580,13 @@ is {other}"
                     );
                     return Type::Bool;
                 }
-                // Otherwise equality constrains unsolved sides together
-                // (comparing a Float to a String is certainly false).
-                if matches!(lhs, Type::Var(_)) || matches!(rhs, Type::Var(_)) {
+                // Otherwise equality constrains unsolved sides together —
+                // vars at ANY depth, not just top level (`(x, 1.0) ==
+                // (1.0, 1.0)` must pin x). [Codex H — B7 review]
+                let mut vars = Vec::new();
+                free_vars_of(lhs, &mut vars);
+                free_vars_of(rhs, &mut vars);
+                if !vars.is_empty() {
                     self.unify(lhs, rhs, node_span, "`==` operands");
                     return Type::Bool;
                 }

--- a/mle/tests/check.rs
+++ b/mle/tests/check.rs
@@ -214,7 +214,9 @@ fn error_filter_predicate_must_return_bool() {
         single_diag("let g = (xs: List<Float>) => List.filter(xs, (x): Float => x)");
     assert_eq!(
         message,
-        "argument 2 of `List.filter`: expected (Unknown) => Bool, got (Unknown) => Float"
+        // B7: the element type flows from `xs` into the predicate's
+        // signature — Float, not Unknown.
+        "argument 2 of `List.filter`: expected (Float) => Bool, got (Float) => Float"
     );
 }
 
@@ -255,14 +257,17 @@ fn unknown_type_names_are_not_errors() {
 }
 
 #[test]
-fn unannotated_code_is_unchecked() {
-    // No annotations anywhere: every check needs a known side, so nothing
-    // fires — even though `f(\"s\", 1.0)` would fail at runtime.
-    assert_clean(
+fn unannotated_code_is_inferred() {
+    // B7: no annotations anywhere, and the arithmetic still pins `f` to
+    // (Float, Float) => Float — the bad call is caught by INFERENCE.
+    let diags = check_src(
         "let f = (a, b) => a + b\n\
          let g = () => f(\"s\", true)",
     );
-    // A call through an unannotated parameter is unchecked too.
+    assert_eq!(diags.len(), 2, "{diags:?}");
+    assert_eq!(diags[0].0, "argument 1 of `f`: expected Float, got String");
+    assert_eq!(diags[1].0, "argument 2 of `f`: expected Float, got Bool");
+    // A call through an unannotated parameter CONSTRAINS it instead.
     assert_clean("let apply = (f) => f(1.0, 2.0)");
 }
 
@@ -441,8 +446,12 @@ fn let_in_types_flow_to_the_body() {
 }
 
 #[test]
-fn gradual_mut_never_false_positives() {
-    assert_clean("let f = (x) => let mut a = x in a := a + 1.0; { a with n: a }");
+fn contradictory_mut_use_is_caught() {
+    // B7: `a := a + 1.0` pins the slot to Float, so the record update on it
+    // is a contradiction — caught, where the gradual checker stayed silent.
+    let (message, _, _) =
+        single_diag("let f = (x) => let mut a = x in a := a + 1.0; { a with n: a }");
+    assert_eq!(message, "`with` update on Float, not a record");
 }
 
 // --- Variants + match (B5 part 1) ---
@@ -611,11 +620,24 @@ fn variant_return_annotations_check() {
 /// literal arms of any mix, and pattern variables still get their declared
 /// field types without ever false-positives.
 #[test]
-fn gradual_match_never_false_positives() {
-    assert_clean(&format!(
+fn match_patterns_constrain_the_scrutinee() {
+    // B7: the first ctor pattern pins the scrutinee to Shape; foreign
+    // literal arms are can-never-match errors now (a match has ONE
+    // scrutinee type — the F#/Elm reading).
+    let diags = check_src(&format!(
         "{SHAPE}let f = (s) => match s with | Circle(r) => r | 1.0 => 2.0 | \"s\" => 3.0"
     ));
-    // A match on an unannotated call result is unchecked too.
+    assert_eq!(diags.len(), 2, "{diags:?}");
+    assert_eq!(
+        diags[0].0,
+        "pattern matches Float, but the scrutinee is Shape"
+    );
+    assert_eq!(
+        diags[1].0,
+        "pattern matches String, but the scrutinee is Shape"
+    );
+    // Constraining flows THROUGH calls: g is the identity, so matching
+    // g(s) against Point pins s to Shape — cleanly.
     assert_clean(&format!(
         "{SHAPE}let g = (s) => s\n\
          let f = (s) => match g(s) with | Point => 1.0"
@@ -704,4 +726,95 @@ fn matching_arity_arm_satisfies_exhaustiveness() {
     );
     assert_eq!(diags.len(), 1, "{diags:?}");
     assert!(diags[0].0.contains("names 3 element(s)"));
+}
+
+// --- B7: Hindley–Milner inference ---
+
+/// Let-polymorphism with teeth: `id` used at Float AND String in one
+/// module (the SCC-ordered generalization — whole-module letrec would
+/// have rejected this).
+#[test]
+fn polymorphic_defs_instantiate_per_use() {
+    assert_clean(
+        "let id = (x) => x\n\
+         let a = id(1.0)\n\
+         let b = id(\"s\")\n\
+         let both = (n: Float, s: String) => (id(n) + 1.0, Text.concat(id(s), \"!\"))",
+    );
+}
+
+/// Lowercase annotation names are scoped type variables — the generic
+/// annotations the roadmap promised.
+#[test]
+fn lowercase_annotations_are_type_variables() {
+    assert_clean(
+        "let first = (pair: a * b): a => match pair with | (x, _) => x\n\
+         let go = () => (first((1.0, \"s\")) + 1.0, first((true, 2.0)))",
+    );
+    // …and they CONSTRAIN: both params share `a`, so mixed args error.
+    let (message, _, _) = single_diag(
+        "let same = (x: a, y: a): a => x\n\
+         let bad = () => same(1.0, \"s\")",
+    );
+    assert_eq!(message, "argument 2 of `same`: expected Float, got String");
+}
+
+/// The occurs check: `'a = List<'a>` is an infinite type, reported not
+/// looped on.
+#[test]
+fn occurs_check_reports_infinite_types() {
+    let (message, _, _) = single_diag("let g = (f) => f(f)");
+    assert!(
+        message.contains("cannot construct the infinite type"),
+        "unexpected: {message}"
+    );
+}
+
+/// Mixed-element lists are real errors now (one element type, unified).
+#[test]
+fn mixed_lists_are_errors() {
+    let (message, _, _) = single_diag("let xs = [1.0, \"s\"]");
+    assert_eq!(message, "list element: expected Float, got String");
+}
+
+/// Ambiguous record literals ask for an annotation (nominal F#-style
+/// resolution — the B7 record decision).
+#[test]
+fn ambiguous_record_literals_ask_for_annotation() {
+    let (message, _, _) = single_diag(
+        "type Vec2 = { x: Float, y: Float }\n\
+         type Point2 = { x: Float, y: Float }\n\
+         let p = { x: 1.0, y: 2.0 }",
+    );
+    assert_eq!(
+        message,
+        "ambiguous record literal: fields match Point2 and Vec2 — annotate which one is meant"
+    );
+}
+
+/// Inference flows through mutual recursion (one SCC, monomorphic inside,
+/// generalized after).
+#[test]
+fn mutual_recursion_infers() {
+    assert_clean(
+        "let even = (n) => match n < 1.0 with | true => true | false => odd(n - 1.0)\n\
+         let odd = (n) => match n < 1.0 with | true => false | false => even(n - 1.0)\n\
+         let use = (): Bool => even(4.0)",
+    );
+}
+
+/// Unannotated code gets full inferred signatures — the roadmap's verify
+/// line, via hover's type table.
+#[test]
+fn unannotated_defs_get_inferred_signatures() {
+    let src = "let scale = (xs, k) => List.map(xs, (x) => x * k)";
+    let module = mle::lower(mle::parse(src).unwrap()).unwrap();
+    let (diags, types) = mle::check_with_types(&module);
+    assert!(diags.is_empty(), "{diags:?}");
+    // The def's value expression carries the full inferred signature.
+    let ty = types
+        .expr(module.defs[0].value.id)
+        .expect("type recorded")
+        .to_string();
+    assert_eq!(ty, "(List<Float>, Float) => List<Float>");
 }

--- a/mle/tests/check.rs
+++ b/mle/tests/check.rs
@@ -627,31 +627,44 @@ fn match_patterns_constrain_the_scrutinee() {
     let diags = check_src(&format!(
         "{SHAPE}let f = (s) => match s with | Circle(r) => r | 1.0 => 2.0 | \"s\" => 3.0"
     ));
-    assert_eq!(diags.len(), 2, "{diags:?}");
-    assert_eq!(
-        diags[0].0,
-        "pattern matches Float, but the scrutinee is Shape"
-    );
-    assert_eq!(
-        diags[1].0,
-        "pattern matches String, but the scrutinee is Shape"
-    );
+    // Three diags: the two foreign arms AND the exhaustiveness hole the
+    // review found (the ctor arm solved the scrutinee, so the re-zonked
+    // exhaustiveness check now fires on inferred scrutinees too).
+    assert_eq!(diags.len(), 3, "{diags:?}");
+    let has = |needle: &str| diags.iter().any(|(m, _, _)| m.contains(needle));
+    assert!(has(
+        "match on `Shape` is not exhaustive: missing `Rect`, `Point`"
+    ));
+    assert!(has("pattern matches Float, but the scrutinee is Shape"));
+    assert!(has("pattern matches String, but the scrutinee is Shape"));
     // Constraining flows THROUGH calls: g is the identity, so matching
-    // g(s) against Point pins s to Shape — cleanly.
-    assert_clean(&format!(
+    // g(s) against Point pins s to Shape — and the inferred scrutinee gets
+    // the SAME exhaustiveness protection an annotated one does.
+    let diags = check_src(&format!(
         "{SHAPE}let g = (s) => s\n\
          let f = (s) => match g(s) with | Point => 1.0"
     ));
+    assert_eq!(diags.len(), 1, "{diags:?}");
+    assert!(diags[0]
+        .0
+        .contains("match on `Shape` is not exhaustive: missing `Circle`, `Rect`"));
 }
 
 /// Mixed known/Unknown arm types join to Unknown (no diagnostic), so the
 /// match result stays gradual.
 #[test]
-fn mixed_unknown_arm_types_stay_gradual() {
-    assert_clean(&format!(
+fn polymorphic_arm_results_are_constrained() {
+    // B7: `g` is the identity, so `g(1.0)` IS Float — returning it where
+    // the annotation promises String is caught at the arm join (the old
+    // gradual checker saw Unknown and stayed silent).
+    let (message, _, _) = single_diag(&format!(
         "{SHAPE}let g = (x) => x\n\
          let f = (b: Bool): String => match b with | true => g(1.0) | false => \"s\""
     ));
+    assert_eq!(
+        message,
+        "match arms have incompatible types Float and String"
+    );
 }
 
 // --- Tuples ---
@@ -817,4 +830,77 @@ fn unannotated_defs_get_inferred_signatures() {
         .expect("type recorded")
         .to_string();
     assert_eq!(ty, "(List<Float>, Float) => List<Float>");
+}
+
+// --- B7 review fixes (both engines) ---
+
+/// Unary `-` constrains its operand like binary arithmetic — a check-clean
+/// negate-a-string is gone. [BOTH engines]
+#[test]
+fn unary_minus_constrains_the_operand() {
+    let (message, _, _) = single_diag("let f = (x) => -x\nlet y = f(\"s\")");
+    assert_eq!(message, "argument 1 of `f`: expected Float, got String");
+}
+
+/// Match arms unify into ONE result type — a var arm is pinned by its
+/// siblings instead of collapsing the match to Unknown. [BOTH engines]
+#[test]
+fn arm_results_unify() {
+    let (message, _, _) = single_diag(
+        "let f = (b, x) => match b with | true => x | false => 1.0\n\
+         let z = f(true, \"s\")",
+    );
+    assert_eq!(message, "argument 2 of `f`: expected Float, got String");
+}
+
+/// `==` pins variables at ANY depth, not just top level. [Codex H]
+#[test]
+fn equality_constrains_nested_variables() {
+    let (message, _, _) = single_diag("let f = (x) => (x, 1.0) == (1.0, 1.0)\nlet y = f((z) => z)");
+    assert_eq!(message, "argument 1 of `f`: expected Float, got ('a) => 'a");
+}
+
+/// Unreachable arms (after a catch-all) are checked but must not CONSTRAIN
+/// the scrutinee. [Codex M]
+#[test]
+fn unreachable_arms_do_not_constrain() {
+    assert_clean("let f = (x) => (match x with | _ => 1.0 | \"s\" => 2.0) + x");
+}
+
+/// Bool and literal matches on INFERRED scrutinees get exhaustiveness too
+/// (the stale-zonk hole). [BOTH engines, High]
+#[test]
+fn inferred_scrutinees_get_exhaustiveness() {
+    let (message, _, _) = single_diag("let f = (x) => match x with | true => 1.0");
+    assert!(
+        message.contains("match on Bool is not exhaustive: missing `false`"),
+        "unexpected: {message}"
+    );
+    let (message, _, _) = single_diag("let f = (x) => match x with | 2.0 => 1.0");
+    assert!(message.contains("not exhaustive"), "unexpected: {message}");
+}
+
+/// Type variables in DECLARATIONS are refused with a teaching error —
+/// a declaration-held variable would be module-global (first use pins it
+/// for everyone). [BOTH engines]
+#[test]
+fn type_decl_variables_are_refused() {
+    let (message, _, _) = single_diag("type Box = | Full(v: a) | Empty\nlet p = Full(1.0)");
+    assert!(
+        message.contains("type variables (`a`) are not supported in type declarations yet"),
+        "unexpected: {message}"
+    );
+}
+
+/// Diagnostics normalize BOTH sides with one variable order — the same
+/// variable never wears two names in one message. [Claude M]
+#[test]
+fn diagnostic_variables_share_one_order() {
+    let (message, _, _) = single_diag("let f = (x) => List.fold(x, x, 1.0)");
+    // x is both the list and the folder: 'a is the element type in BOTH
+    // sides of the message (got is normalized first), 'b the accumulator.
+    assert_eq!(
+        message,
+        "argument 2 of `List.fold`: expected ('b, 'a) => 'b, got List<'a>"
+    );
 }


### PR DESCRIPTION
## What

B4's gradual checker upgraded to **real Hindley–Milner inference** (roadmap B7 — "real inference for unannotated code, and generics"):

```mle
let scale = (xs, k) => List.map(xs, (x) => x * k)
-- infers, and hovers as: (List<Float>, Float) => List<Float>

let first = (pair: a * b): a => match pair with | (x, _) => x
-- lowercase annotation names are type variables; used at (Float, String) AND (Bool, Float)
```

- **Type variables + unification** with occurs check; conflicts report **once**, with full zonked types, labeled by where the expectation came from ("argument 2 of `List.fold`: expected ('b, 'a) => 'b, got List<'a>" — one variable order across both sides).
- **Let-polymorphism per SCC** of the def call graph — the structural piece MLE's mutually-visible top level demanded: mutual recursion is monomorphic inside its group (the letrec rule), forward references work, and `id` at Float and String in one module instantiates fresh both times.
- **Generic builtin schemes** — element types genuinely flow through `List.map`/`filter`/`fold`.
- **Records resolve nominally, F#-style** (user decision): a literal takes the unique declared type with exactly its field set; anonymous records stay gradual; same-shaped declarations make a bare literal a clear ambiguity error. No row polymorphism.
- **`Unknown` shrinks to the honest dynamic seam** (host values, unrecognized Uppercase names): absorbs in unification, never binds a variable.
- **Teeth**: unannotated bad calls, mixed-element lists, contradictory `mut` use, foreign match arms, and non-exhaustive inferred matches are all errors now. Four old tests pinning gradual silence re-pinned to the new diagnostics.

## Cross-engine review — both engines ran empirical probes

Claude (type-theory brief) + Codex, with strong agreement; **all findings fixed and pinned**:
- **[BOTH, High]** Exhaustiveness used the *pre-arm* zonk of the scrutinee — inferred-scrutinee matches (the headline feature!) silently skipped it; the reviewer's probe was a check-clean program that crashed at runtime, and one of my own tests "unknowingly pinned the bug". Re-zonked after the arm loop.
- **[BOTH]** Unary `-` didn't constrain its operand; arm results joined with `compatible` instead of unifying (var arms never pinned, match collapsed to Unknown). Both unify now.
- **[Codex, High]** `==` missed variables nested inside structure. **[Codex, Med]** Unreachable arms after a catch-all falsely constrained the scrutinee.
- **[BOTH, Med]** Lowercase vars in *type declarations* were module-global (first use pinned `type Box = | Full(v: a)` for the whole file) — refused with a teaching error until generic ADTs are designed.
- **[Claude, Med/Low]** Pair-consistent variable naming in every diagnostic + one global hover order; iterative SCC walk (deep-spine stack safety); doc drift and dead code removed.

Attacks that did **not** land (verified by the reviewer): value-restriction unsoundness (MLE has no ref cells and `mut` can't be captured, so generalizing non-values is sound here), the no-zonk instantiate invariant, same-group scheme consultation, Tarjan correctness, pattern order effects.

Mid-build, the `functions.mle` golden caught a var-namespace collision: builtin signatures' literal `Var(0)/Var(1)` were being zonked through the checker's own substitution — `List.map`'s `'a` arrived pre-solved as Float. The fix (instantiate raw) is commented as the load-bearing invariant.

## Verification

- **222 mle tests** (7 inference-win pins: SCC polymorphism, annotation vars, occurs, ambiguity, mixed lists, inferred signatures; 7 review-fix pins; all teeth re-pins)
- Both shipped games + every example golden check clean under full inference
- Full inferred signature verified via the hover table; `mle-lsp`, runtime-common (127), desktop all green
- docs/mle.md B7 → [x]; SKILL.md typechecking section rewritten for the new model

🤖 Generated with [Claude Code](https://claude.com/claude-code)
