### PR TITLE
feat(mle): generic type declarations — type Box<v>, checker-only

### DIFF
--- a/.claude/skills/mle-language/SKILL.md
+++ b/.claude/skills/mle-language/SKILL.md
@@ -31,6 +31,10 @@ regenerates). VSCode gets live parse/lower/type diagnostics and
 // line comments only
 type Position = { x: Float, y: Float }        // record types; nominal in annotations
 
+type Box<v> =                                 // GENERIC declarations: lowercase params
+  | Full(value: v)                            //   Box<Float> and Box<String> coexist;
+  | Empty                                     //   params substitute through fields/patterns
+
 type Shape =                                  // variant types (ADTs); nominal like records
   | Circle(radius: Float)                     // leading | REQUIRED, first alternative too
   | Rect(w: Float, h: Float)                  // fields named in the decl…
@@ -305,7 +309,9 @@ lowercase annotation names are type variables (`(xs: List<a>, f: (a) =>
 b): List<b>`). Inference has teeth: unannotated bad calls, mixed-element
 lists, and contradictory `mut` use are errors now. `Unknown` remains ONLY
 at genuinely-dynamic seams (host values, unrecognized Uppercase type
-names) and absorbs anything. Record literals resolve nominally, F#-style:
+names) and absorbs anything. Generic declarations (`type Pair<x, y> = { first: x, second: y }`)
+instantiate fresh per use; an UNDECLARED lowercase name in a declaration is
+a teaching error. Record literals resolve nominally, F#-style:
 the unique declared type with exactly that field set (no match = anonymous
 data, still fine; two same-shaped declarations make a bare literal
 ambiguous — annotate). A `mut` slot's type fixes at its initializer. A

--- a/docs/mle.md
+++ b/docs/mle.md
@@ -279,6 +279,19 @@ snapshots — no GPU, fully agent-verifiable.
       `mle types` dump, goldened); the B4 diagnostic suite still passes;
       probe battery re-run (no legal program rejected).
 
+- [x] **Language: generic type declarations** (done 2026-07-04, the B7
+      follow-up both review engines asked for). `type Box<v> = | Full(value:
+      v) | Empty` / `type Pair<x, y> = { … }`: checker-only (the runtime
+      was already type-erased) — declarations store parameter placeholders
+      in an out-of-band Var namespace (the builtin-scheme trick),
+      substituted at every use; ctors instantiate fresh per use; record
+      literals solve the parameters; patterns take the scrutinee's
+      arguments; arity + duplicate/uppercase/undeclared-param teaching
+      errors. Found and fixed: three type walkers (zonk / instantiate /
+      renumber) predating generics treated nominal types as leaves, so
+      vars inside `Box<'a>` never substituted. *Verify:* Box/Pair at two
+      types in one module; instantiation constrains; pattern-field types
+      flow; erased-runtime pin; goldens.
 - [ ] **B8. `.mlei` interface files** (added 2026-07-02; design already in
       `~/notes` `syntax.md` — the OCaml `.mli` split). A module's public
       contract as a checked file: exported types (including **abstract**

--- a/mle/examples/functions.ast
+++ b/mle/examples/functions.ast
@@ -3,6 +3,7 @@ Program {
         Type(
             TypeDecl {
                 name: "Player",
+                params: [],
                 body: Record(
                     [
                         FieldTy {

--- a/mle/examples/functions.ir
+++ b/mle/examples/functions.ir
@@ -3,6 +3,7 @@ Module {
         TypeDef {
             id: d0,
             name: "Player",
+            params: [],
             body: Record(
                 [
                     FieldTy {

--- a/mle/examples/records.ast
+++ b/mle/examples/records.ast
@@ -3,6 +3,7 @@ Program {
         Type(
             TypeDecl {
                 name: "Position",
+                params: [],
                 body: Record(
                     [
                         FieldTy {
@@ -31,6 +32,7 @@ Program {
         Type(
             TypeDecl {
                 name: "Velocity",
+                params: [],
                 body: Record(
                     [
                         FieldTy {

--- a/mle/examples/records.ir
+++ b/mle/examples/records.ir
@@ -3,6 +3,7 @@ Module {
         TypeDef {
             id: d0,
             name: "Position",
+            params: [],
             body: Record(
                 [
                     FieldTy {
@@ -30,6 +31,7 @@ Module {
         TypeDef {
             id: d1,
             name: "Velocity",
+            params: [],
             body: Record(
                 [
                     FieldTy {

--- a/mle/examples/shapes.ast
+++ b/mle/examples/shapes.ast
@@ -3,6 +3,7 @@ Program {
         Type(
             TypeDecl {
                 name: "Shape",
+                params: [],
                 body: Variants(
                     [
                         VariantDecl {

--- a/mle/examples/shapes.ir
+++ b/mle/examples/shapes.ir
@@ -3,6 +3,7 @@ Module {
         TypeDef {
             id: d0,
             name: "Shape",
+            params: [],
             body: Variants(
                 [
                     VariantDecl {

--- a/mle/examples/tuples.ast
+++ b/mle/examples/tuples.ast
@@ -3,6 +3,7 @@ Program {
         Type(
             TypeDecl {
                 name: "Msg",
+                params: [],
                 body: Variants(
                     [
                         VariantDecl {

--- a/mle/examples/tuples.ir
+++ b/mle/examples/tuples.ir
@@ -3,6 +3,7 @@ Module {
         TypeDef {
             id: d0,
             name: "Msg",
+            params: [],
             body: Variants(
                 [
                     VariantDecl {

--- a/mle/src/ast.rs
+++ b/mle/src/ast.rs
@@ -27,10 +27,14 @@ pub struct LetDecl {
 }
 
 /// `type Position = { x: Float, y: Float }` (a record type) or
-/// `type Shape = | Circle(radius: Float) | Point` (a variant type).
+/// `type Shape = | Circle(radius: Float) | Point` (a variant type),
+/// optionally generic: `type Box<a> = | Full(v: a) | Empty`.
 #[derive(Debug)]
 pub struct TypeDecl {
     pub name: String,
+    /// Declared type parameters, lowercase (`<a, b>`); empty when the
+    /// declaration is not generic.
+    pub params: Vec<String>,
     pub body: TypeBody,
     pub span: Span,
 }

--- a/mle/src/ir.rs
+++ b/mle/src/ir.rs
@@ -79,6 +79,8 @@ pub struct Module {
 pub struct TypeDef {
     pub id: DefId,
     pub name: String,
+    /// Declared type parameters (`type Box<a>` → `["a"]`).
+    pub params: Vec<String>,
     pub body: TypeBody,
     pub span: Span,
 }

--- a/mle/src/lower.rs
+++ b/mle/src/lower.rs
@@ -145,6 +145,7 @@ namespace)",
         let id = DefId(index as u32);
         match item {
             ast::Item::Type(decl) => types.push(TypeDef {
+                params: decl.params.clone(),
                 id,
                 name: decl.name,
                 body: decl.body,

--- a/mle/src/parser.rs
+++ b/mle/src/parser.rs
@@ -5,7 +5,8 @@
 //! ```text
 //! program   := (letDecl | typeDecl)*
 //! letDecl   := "let" ident "=" expr
-//! typeDecl  := "type" ident "=" ("{" (ident ":" type),* "}" | variant+)
+//! typeDecl  := "type" ident ("<" ident ("," ident)* ">")?
+//!              "=" ("{" (ident ":" type),* "}" | variant+)
 //! variant   := "|" upperIdent ("(" (ident ":" type),+ ")")?
 //! type      := tatom ("*" tatom)*                    (flat products)
 //! tatom     := ident ("<" type ("," type)* ">")?
@@ -153,6 +154,41 @@ rebind surface); `mut` is for `let mut … in …` inside a function"
     fn type_decl(&mut self) -> Result<TypeDecl, ParseError> {
         let kw = self.bump();
         let (name, _) = self.expect_ident("a name after `type`")?;
+        // Optional type parameters: `type Box<a, b> = …` — lowercase names
+        // (uppercase would shadow declared types; the checker enforces the
+        // case, the grammar just collects idents).
+        let mut params = Vec::new();
+        if self.peek_kind() == &TokenKind::Lt {
+            self.bump();
+            loop {
+                let (param, param_span) = self.expect_ident("a type parameter name")?;
+                if !param.chars().next().is_some_and(char::is_lowercase) {
+                    return Err(ParseError {
+                        message: format!(
+                            "type parameters are lowercase (`{}`), like annotation type variables",
+                            param.to_lowercase()
+                        ),
+                        span: param_span,
+                    });
+                }
+                if params.contains(&param) {
+                    return Err(ParseError {
+                        message: format!("duplicate type parameter `{param}`"),
+                        span: param_span,
+                    });
+                }
+                params.push(param);
+                if self.peek_kind() == &TokenKind::Comma {
+                    self.bump();
+                    if self.peek_kind() == &TokenKind::Gt {
+                        break; // trailing comma
+                    }
+                } else {
+                    break;
+                }
+            }
+            self.expect(TokenKind::Gt, "`,` or `>`")?;
+        }
         self.expect(TokenKind::Eq, "`=`")?;
         match self.peek_kind() {
             TokenKind::LBrace => {
@@ -176,6 +212,7 @@ rebind surface); `mut` is for `let mut … in …` inside a function"
                 let close = self.expect(TokenKind::RBrace, "`,` or `}`")?;
                 Ok(TypeDecl {
                     name,
+                    params,
                     body: TypeBody::Record(fields),
                     span: kw.span.to(close.span),
                 })
@@ -191,6 +228,7 @@ rebind surface); `mut` is for `let mut … in …` inside a function"
                     .to(variants.last().expect("at least one variant").span);
                 Ok(TypeDecl {
                     name,
+                    params,
                     body: TypeBody::Variants(variants),
                     span,
                 })

--- a/mle/src/types.rs
+++ b/mle/src/types.rs
@@ -210,6 +210,10 @@ fn contains_fn(ty: &Type) -> bool {
     match ty {
         Type::Fn(..) => true,
         Type::Tuple(elems) => elems.iter().any(contains_fn),
+        // A generic nominal can carry a function in its ARGUMENTS
+        // (`Box<(Float) => Float>`) even when the declaration's own fields
+        // are just parameters — recurse. [Codex H — generics review]
+        Type::Record(_, args) | Type::Variant(_, args) => args.iter().any(contains_fn),
         _ => false,
     }
 }
@@ -417,7 +421,10 @@ pub fn check_with_types(module: &Module) -> (Vec<CheckError>, ExprTypes) {
             TypeBody::Variants(variants) => {
                 checker.variants.insert(
                     decl.name.clone(),
-                    variants.iter().map(|v| v.name.clone()).collect(),
+                    (
+                        decl.params.len(),
+                        variants.iter().map(|v| v.name.clone()).collect(),
+                    ),
                 );
             }
         }
@@ -651,9 +658,12 @@ struct Checker {
     /// out-of-band namespace like the builtins': never unified raw, always
     /// [`subst_params`]-substituted first.
     records: HashMap<String, (usize, Vec<(String, Type)>)>,
-    /// Declared variant types: name → constructor names, in declaration
-    /// order (the exhaustiveness universe).
-    variants: HashMap<String, Vec<String>>,
+    /// Declared variant types: name → (type-parameter count, constructor
+    /// names in declaration order — the exhaustiveness universe). The param
+    /// count is pre-seeded before field resolution, so recursive and
+    /// forward generic references (`type L<a> = | Cons(h: a, t: L<a>)`)
+    /// resolve at the right arity. [Codex H — generics review]
+    variants: HashMap<String, (usize, Vec<String>)>,
     /// Declared constructors: name → (owning variant type, field types in
     /// declaration order). Names are module-unique (lowering enforces it).
     /// ctor name → (owning type, its param count, field types with the
@@ -838,15 +848,6 @@ impl Checker {
         Scheme { vars, ty }
     }
 
-    /// Zonk with display normalization: free variables renumber to 'a, 'b, …
-    /// in first-appearance order — hover and signatures read cleanly.
-    fn zonk_normalized(&self, ty: &Type) -> Type {
-        let ty = self.zonk(ty);
-        let mut order = Vec::new();
-        free_vars_of(&ty, &mut order);
-        renumber_with(&ty, &order)
-    }
-
     /// Normalize TWO types with ONE shared variable order — a diagnostic
     /// showing both sides must name the same variable the same way (and
     /// different variables differently).
@@ -914,12 +915,7 @@ impl Checker {
                 Type::Record(name.to_string(), args)
             }
             name if self.variants.contains_key(name) => {
-                let params = self
-                    .ctors
-                    .values()
-                    .find(|(t, _, _)| t == name)
-                    .map(|(_, p, _)| *p)
-                    .unwrap_or(0);
+                let params = self.variants.get(name).map(|(p, _)| *p).unwrap_or(0);
                 if ty.args.len() != params {
                     return arity_error(self, params);
                 }
@@ -1481,7 +1477,7 @@ the type: `type Name<{name}> = …`"
                     let missing: Vec<String> = self
                         .variants
                         .get(name)
-                        .map(|declared| {
+                        .map(|(_, declared)| {
                             declared
                                 .iter()
                                 .filter(|c| !covered_ctors.contains(&c.as_str()))
@@ -1739,8 +1735,23 @@ is {other}"
                             "functions cannot be compared with `==`".to_string(),
                         );
                     }
-                    (Type::Record(x, _), Type::Record(y, _)) => {
-                        if x != y && !self.same_record_shape(x, y) {
+                    (Type::Record(x, xargs), Type::Record(y, yargs)) => {
+                        // Same declaration, incompatible arguments: the
+                        // substituted fields cannot be equal — certainly
+                        // false. [Codex H — generics review]
+                        if x == y
+                            && (xargs.len() != yargs.len()
+                                || xargs.iter().zip(yargs).any(|(a, b)| !compatible(a, b)))
+                        {
+                            self.diag(
+                                node_span,
+                                format!(
+                                    "`==` compares records with different shapes \
+                                     ({lhs} and {rhs}) — always false"
+                                ),
+                            );
+                        }
+                        if x != y && !self.same_record_shape(x, xargs, y, yargs) {
                             self.diag(
                                 node_span,
                                 format!(
@@ -1769,14 +1780,19 @@ is {other}"
     /// Whether two declared record types have the same field-name set with
     /// pairwise-compatible types — i.e. their values can be structurally
     /// equal at runtime.
-    fn same_record_shape(&self, x: &str, y: &str) -> bool {
+    /// Compare two record types' SUBSTITUTED field shapes — raw declaration
+    /// fields hold parameter placeholders whose `compatible` is trivially
+    /// true, hiding concrete disagreements. [Codex H — generics review]
+    fn same_record_shape(&self, x: &str, xargs: &[Type], y: &str, yargs: &[Type]) -> bool {
         let (Some((_, xf)), Some((_, yf))) = (self.records.get(x), self.records.get(y)) else {
             return true; // unknown decl: stay gradual
         };
         xf.len() == yf.len()
-            && xf
-                .iter()
-                .all(|(name, ty)| yf.iter().any(|(n, t)| n == name && compatible(ty, t)))
+            && xf.iter().all(|(name, ty)| {
+                yf.iter().any(|(n, t)| {
+                    n == name && compatible(&subst_params(ty, xargs), &subst_params(t, yargs))
+                })
+            })
     }
 
     fn require_float(&mut self, op: BinOp, ty: &Type, span: Span) {

--- a/mle/src/types.rs
+++ b/mle/src/types.rs
@@ -97,10 +97,12 @@ pub enum Type {
     /// A product type: `Float * Float` in annotations. Structural, like the
     /// runtime.
     Tuple(Vec<Type>),
-    /// A declared record type, nominal by name.
-    Record(String),
-    /// A declared variant type, nominal by name.
-    Variant(String),
+    /// A declared record type, nominal by name, with its type arguments
+    /// (`Pair<Float, String>`; empty for non-generic declarations).
+    Record(String, Vec<Type>),
+    /// A declared variant type, nominal by name, with its type arguments
+    /// (`Box<Float>`).
+    Variant(String, Vec<Type>),
     Fn(Vec<Type>, Box<Type>),
 }
 
@@ -124,7 +126,20 @@ impl fmt::Display for Type {
                 }
                 Ok(())
             }
-            Type::Record(name) | Type::Variant(name) => write!(f, "{name}"),
+            Type::Record(name, args) | Type::Variant(name, args) => {
+                write!(f, "{name}")?;
+                if args.is_empty() {
+                    return Ok(());
+                }
+                write!(f, "<")?;
+                for (i, arg) in args.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{arg}")?;
+                }
+                write!(f, ">")
+            }
             Type::Fn(params, ret) => {
                 write!(f, "(")?;
                 for (i, param) in params.iter().enumerate() {
@@ -175,8 +190,10 @@ pub fn compatible(a: &Type, b: &Type) -> bool {
         (Type::Tuple(xs), Type::Tuple(ys)) => {
             xs.len() == ys.len() && xs.iter().zip(ys).all(|(x, y)| compatible(x, y))
         }
-        (Type::Record(x), Type::Record(y)) => x == y,
-        (Type::Variant(x), Type::Variant(y)) => x == y,
+        (Type::Record(x, xa), Type::Record(y, ya))
+        | (Type::Variant(x, xa), Type::Variant(y, ya)) => {
+            x == y && xa.len() == ya.len() && xa.iter().zip(ya).all(|(a, b)| compatible(a, b))
+        }
         (Type::Fn(p1, r1), Type::Fn(p2, r2)) => {
             p1.len() == p2.len()
                 && p1.iter().zip(p2).all(|(x, y)| compatible(x, y))
@@ -214,6 +231,35 @@ fn pattern_var_bindings(pattern: &Pattern, f: &mut impl FnMut(u32)) {
     }
 }
 
+/// Substitute declaration parameter placeholders (`Var(i)`, i < args.len())
+/// with concrete type arguments — how generic record/variant field types
+/// meet their use sites. Non-generic declarations contain no placeholders,
+/// so this is the identity for them.
+fn subst_params(ty: &Type, args: &[Type]) -> Type {
+    if args.is_empty() {
+        return ty.clone();
+    }
+    match ty {
+        Type::Var(v) => args
+            .get(*v as usize)
+            .cloned()
+            .unwrap_or_else(|| Type::Var(*v)),
+        Type::List(e) => Type::List(Box::new(subst_params(e, args))),
+        Type::Tuple(es) => Type::Tuple(es.iter().map(|e| subst_params(e, args)).collect()),
+        Type::Fn(ps, r) => Type::Fn(
+            ps.iter().map(|p| subst_params(p, args)).collect(),
+            Box::new(subst_params(r, args)),
+        ),
+        Type::Record(n, a) => {
+            Type::Record(n.clone(), a.iter().map(|t| subst_params(t, args)).collect())
+        }
+        Type::Variant(n, a) => {
+            Type::Variant(n.clone(), a.iter().map(|t| subst_params(t, args)).collect())
+        }
+        other => other.clone(),
+    }
+}
+
 /// Rewrite variables to their position in `order` (display normalization).
 fn renumber_with(ty: &Type, order: &[u32]) -> Type {
     match ty {
@@ -226,6 +272,14 @@ fn renumber_with(ty: &Type, order: &[u32]) -> Type {
         Type::Fn(ps, r) => Type::Fn(
             ps.iter().map(|p| renumber_with(p, order)).collect(),
             Box::new(renumber_with(r, order)),
+        ),
+        Type::Record(n, args) => Type::Record(
+            n.clone(),
+            args.iter().map(|a| renumber_with(a, order)).collect(),
+        ),
+        Type::Variant(n, args) => Type::Variant(
+            n.clone(),
+            args.iter().map(|a| renumber_with(a, order)).collect(),
         ),
         other => other.clone(),
     }
@@ -251,12 +305,12 @@ fn free_vars_of(ty: &Type, out: &mut Vec<u32>) {
             }
             free_vars_of(ret, out);
         }
-        Type::Unknown
-        | Type::Float
-        | Type::String
-        | Type::Bool
-        | Type::Record(_)
-        | Type::Variant(_) => {}
+        Type::Record(_, args) | Type::Variant(_, args) => {
+            for arg in args {
+                free_vars_of(arg, out);
+            }
+        }
+        Type::Unknown | Type::Float | Type::String | Type::Bool => {}
     }
 }
 
@@ -356,7 +410,9 @@ pub fn check_with_types(module: &Module) -> (Vec<CheckError>, ExprTypes) {
     for decl in &module.types {
         match &decl.body {
             TypeBody::Record(_) => {
-                checker.records.insert(decl.name.clone(), Vec::new());
+                checker
+                    .records
+                    .insert(decl.name.clone(), (decl.params.len(), Vec::new()));
             }
             TypeBody::Variants(variants) => {
                 checker.variants.insert(
@@ -368,13 +424,24 @@ pub fn check_with_types(module: &Module) -> (Vec<CheckError>, ExprTypes) {
     }
     checker.in_type_decl = true;
     for decl in &module.types {
+        // Declared params resolve to out-of-band placeholders Var(0..n); an
+        // UNDECLARED lowercase name in a declaration is still the teaching
+        // error (see resolve_type).
+        checker.annot_vars.clear();
+        for (i, param) in decl.params.iter().enumerate() {
+            checker
+                .annot_vars
+                .insert(param.clone(), Type::Var(i as u32));
+        }
         match &decl.body {
             TypeBody::Record(decl_fields) => {
                 let fields = decl_fields
                     .iter()
                     .map(|f| (f.name.clone(), checker.resolve_type(&f.ty, true)))
                     .collect();
-                checker.records.insert(decl.name.clone(), fields);
+                checker
+                    .records
+                    .insert(decl.name.clone(), (decl.params.len(), fields));
             }
             TypeBody::Variants(variants) => {
                 for variant in variants {
@@ -383,15 +450,17 @@ pub fn check_with_types(module: &Module) -> (Vec<CheckError>, ExprTypes) {
                         .iter()
                         .map(|f| checker.resolve_type(&f.ty, true))
                         .collect();
-                    checker
-                        .ctors
-                        .insert(variant.name.clone(), (decl.name.clone(), fields));
+                    checker.ctors.insert(
+                        variant.name.clone(),
+                        (decl.name.clone(), decl.params.len(), fields),
+                    );
                 }
             }
         }
     }
 
     checker.in_type_decl = false;
+    checker.annot_vars.clear();
 
     // Placeholder signatures: annotation-derived, with FRESH inference
     // variables where nothing is annotated (B7 — this is what makes
@@ -577,13 +646,19 @@ struct Checker {
     /// them to their variable for the def's duration.
     annot_vars: HashMap<String, Type>,
     /// Declared record types: name → resolved fields, in declaration order.
-    records: HashMap<String, Vec<(String, Type)>>,
+    /// name → (type-parameter count, fields). Field types hold parameter
+    /// PLACEHOLDERS as `Type::Var(i)` with i < the param count — an
+    /// out-of-band namespace like the builtins': never unified raw, always
+    /// [`subst_params`]-substituted first.
+    records: HashMap<String, (usize, Vec<(String, Type)>)>,
     /// Declared variant types: name → constructor names, in declaration
     /// order (the exhaustiveness universe).
     variants: HashMap<String, Vec<String>>,
     /// Declared constructors: name → (owning variant type, field types in
     /// declaration order). Names are module-unique (lowering enforces it).
-    ctors: HashMap<String, (String, Vec<Type>)>,
+    /// ctor name → (owning type, its param count, field types with the
+    /// same placeholder convention as `records`).
+    ctors: HashMap<String, (String, usize, Vec<Type>)>,
     globals: HashMap<String, Type>,
     /// Parameter types by binding ID (IDs are unique module-wide, so entries
     /// are never shadowed or popped).
@@ -619,6 +694,12 @@ impl Checker {
                 params.iter().map(|p| self.zonk(p)).collect(),
                 Box::new(self.zonk(ret)),
             ),
+            Type::Record(n, args) => {
+                Type::Record(n.clone(), args.iter().map(|a| self.zonk(a)).collect())
+            }
+            Type::Variant(n, args) => {
+                Type::Variant(n.clone(), args.iter().map(|a| self.zonk(a)).collect())
+            }
             other => other.clone(),
         }
     }
@@ -650,8 +731,17 @@ impl Checker {
             (Type::Float, Type::Float)
             | (Type::String, Type::String)
             | (Type::Bool, Type::Bool) => true,
-            (Type::Record(x), Type::Record(y)) if x == y => true,
-            (Type::Variant(x), Type::Variant(y)) if x == y => true,
+            (Type::Record(x, xa), Type::Record(y, ya))
+            | (Type::Variant(x, xa), Type::Variant(y, ya))
+                if x == y && xa.len() == ya.len() =>
+            {
+                let (xa, ya) = (xa.clone(), ya.clone());
+                let mut ok = true;
+                for (a, b) in xa.iter().zip(ya.iter()) {
+                    ok &= self.unify_rec(a, b, span, what);
+                }
+                ok
+            }
             (Type::List(x), Type::List(y)) => self.unify_rec(x, y, span, what),
             (Type::Tuple(xs), Type::Tuple(ys)) if xs.len() == ys.len() => {
                 let mut ok = true;
@@ -718,6 +808,12 @@ impl Checker {
                     ps.iter().map(|p| walk(p, mapping)).collect(),
                     Box::new(walk(r, mapping)),
                 ),
+                Type::Record(n, args) => {
+                    Type::Record(n.clone(), args.iter().map(|a| walk(a, mapping)).collect())
+                }
+                Type::Variant(n, args) => {
+                    Type::Variant(n.clone(), args.iter().map(|a| walk(a, mapping)).collect())
+                }
                 other => other.clone(),
             }
         }
@@ -806,16 +902,33 @@ impl Checker {
                     .collect(),
             ),
             name if self.records.contains_key(name) => {
-                if !ty.args.is_empty() {
-                    return arity_error(self, 0);
+                let params = self.records.get(name).map(|(p, _)| *p).unwrap_or(0);
+                if ty.args.len() != params {
+                    return arity_error(self, params);
                 }
-                Type::Record(name.to_string())
+                let args = ty
+                    .args
+                    .iter()
+                    .map(|arg| self.resolve_type(arg, report))
+                    .collect();
+                Type::Record(name.to_string(), args)
             }
             name if self.variants.contains_key(name) => {
-                if !ty.args.is_empty() {
-                    return arity_error(self, 0);
+                let params = self
+                    .ctors
+                    .values()
+                    .find(|(t, _, _)| t == name)
+                    .map(|(_, p, _)| *p)
+                    .unwrap_or(0);
+                if ty.args.len() != params {
+                    return arity_error(self, params);
                 }
-                Type::Variant(name.to_string())
+                let args = ty
+                    .args
+                    .iter()
+                    .map(|arg| self.resolve_type(arg, report))
+                    .collect();
+                Type::Variant(name.to_string(), args)
             }
             // A lowercase name is a TYPE VARIABLE, scoped to the enclosing
             // def's signature: `(xs: List<a>, f: (a) => b): List<b>`. The
@@ -828,19 +941,20 @@ impl Checker {
                 if !ty.args.is_empty() {
                     return arity_error(self, 0);
                 }
+                if let Some(var) = self.annot_vars.get(name) {
+                    return var.clone();
+                }
                 if self.in_type_decl {
                     if report {
                         self.diag(
                             ty.span,
                             format!(
-                                "type variables (`{name}`) are not supported in type declarations yet — generic type declarations are a roadmap item"
+                                "undeclared type parameter `{name}` — declare it on \
+the type: `type Name<{name}> = …`"
                             ),
                         );
                     }
                     return Type::Unknown;
-                }
-                if let Some(var) = self.annot_vars.get(name) {
-                    return var.clone();
                 }
                 let var = self.fresh();
                 self.annot_vars.insert(name.to_string(), var.clone());
@@ -886,8 +1000,9 @@ impl Checker {
             return;
         }
         match (&expr.kind, expected) {
-            (ExprKind::Record(fields), Type::Record(name)) => {
-                self.check_record_literal(fields, name, expr.span);
+            (ExprKind::Record(fields), Type::Record(name, targs)) => {
+                let targs = targs.clone();
+                self.check_record_literal(fields, name, &targs, expr.span);
                 // Structural paths bypass `infer`, so record the checked
                 // type here or hover would honestly-but-wrongly say Unknown
                 // (and a stale quiet-pass entry could linger).
@@ -943,8 +1058,8 @@ impl Checker {
     /// Check a record literal against declared record type `name`: every
     /// literal field must exist in the declaration and match its type, and
     /// every declared field must be present.
-    fn check_record_literal(&mut self, fields: &[Field], name: &str, span: Span) {
-        let decl = self
+    fn check_record_literal(&mut self, fields: &[Field], name: &str, args: &[Type], span: Span) {
+        let (_, decl) = self
             .records
             .get(name)
             .cloned()
@@ -953,7 +1068,7 @@ impl Checker {
             match decl.iter().find(|(n, _)| n == &field.name) {
                 Some((_, field_ty)) => {
                     let what = format!("field `{}` of `{name}`", field.name);
-                    let field_ty = field_ty.clone();
+                    let field_ty = subst_params(field_ty, args);
                     self.expect(&field.value, &field_ty, &what);
                 }
                 None => {
@@ -1023,7 +1138,7 @@ impl Checker {
                 let matches: Vec<String> = self
                     .records
                     .iter()
-                    .filter(|(_, decl)| {
+                    .filter(|(_, (_, decl))| {
                         let mut declared: Vec<&str> =
                             decl.iter().map(|(n, _)| n.as_str()).collect();
                         declared.sort_unstable();
@@ -1034,8 +1149,13 @@ impl Checker {
                 match matches.as_slice() {
                     [name] => {
                         let name = name.clone();
-                        self.check_record_literal(fields, &name, expr.span);
-                        Type::Record(name)
+                        // Generic declarations get fresh arguments, solved
+                        // by the literal's field types (Pair<Float, String>
+                        // from { first: 1.0, second: "s" }).
+                        let params = self.records.get(&name).map(|(p, _)| *p).unwrap_or(0);
+                        let args: Vec<Type> = (0..params).map(|_| self.fresh()).collect();
+                        self.check_record_literal(fields, &name, &args, expr.span);
+                        Type::Record(name, args)
                     }
                     [] => {
                         for field in fields {
@@ -1074,14 +1194,15 @@ impl Checker {
                 let base_ty = self.infer(base);
                 let base_ty = self.zonk(&base_ty);
                 match &base_ty {
-                    Type::Record(name) => {
+                    Type::Record(name, targs) => {
                         let name = name.clone();
+                        let targs = targs.clone();
                         for field in fields {
                             let decl_ty = self
                                 .records
                                 .get(&name)
-                                .and_then(|decl| decl.iter().find(|(n, _)| n == &field.name))
-                                .map(|(_, ty)| ty.clone());
+                                .and_then(|(_, decl)| decl.iter().find(|(n, _)| n == &field.name))
+                                .map(|(_, ty)| subst_params(ty, &targs));
                             match decl_ty {
                                 Some(ty) => {
                                     let what = format!("field `{}` of `{name}`", field.name);
@@ -1149,12 +1270,12 @@ impl Checker {
                 let object_ty = self.infer(object);
                 let object_ty = self.zonk(&object_ty);
                 match &object_ty {
-                    Type::Record(name) => {
+                    Type::Record(name, targs) => {
                         let field_ty = self
                             .records
                             .get(name)
-                            .and_then(|decl| decl.iter().find(|(n, _)| n == field))
-                            .map(|(_, ty)| ty.clone());
+                            .and_then(|(_, decl)| decl.iter().find(|(n, _)| n == field))
+                            .map(|(_, ty)| subst_params(ty, targs));
                         match field_ty {
                             Some(ty) => ty,
                             None => {
@@ -1277,12 +1398,16 @@ impl Checker {
             }
             // A constructor reference: nullary is the variant value itself,
             // parameterful is a function from its declared field types.
-            ExprKind::Ctor { name, .. } => match self.ctors.get(name) {
-                Some((type_name, fields)) => {
+            ExprKind::Ctor { name, .. } => match self.ctors.get(name).cloned() {
+                Some((type_name, params, fields)) => {
+                    // Fresh arguments per USE — `Full(1.0)` and `Full("s")`
+                    // coexist as Box<Float> and Box<String>.
+                    let args: Vec<Type> = (0..params).map(|_| self.fresh()).collect();
                     if fields.is_empty() {
-                        Type::Variant(type_name.clone())
+                        Type::Variant(type_name, args)
                     } else {
-                        Type::Fn(fields.clone(), Box::new(Type::Variant(type_name.clone())))
+                        let fields = fields.iter().map(|f| subst_params(f, &args)).collect();
+                        Type::Fn(fields, Box::new(Type::Variant(type_name, args)))
                     }
                 }
                 // Unreachable (lowering rejects unknown constructors) —
@@ -1352,7 +1477,7 @@ impl Checker {
         let scrutinee_ty = self.zonk(&scrutinee_ty);
         if !has_catch_all {
             match &scrutinee_ty {
-                Type::Variant(name) => {
+                Type::Variant(name, _) => {
                     let missing: Vec<String> = self
                         .variants
                         .get(name)
@@ -1440,11 +1565,15 @@ a catch-all arm (`_` or a name)"
                 });
                 return;
             }
+            let ctor_info = match &pattern.kind {
+                PatternKind::Ctor { name, .. } => self.ctors.get(name).cloned(),
+                _ => None,
+            };
             let constrained: Option<Type> = match &pattern.kind {
-                PatternKind::Ctor { name, .. } => self
-                    .ctors
-                    .get(name)
-                    .map(|(type_name, _)| Type::Variant(type_name.clone())),
+                PatternKind::Ctor { .. } => ctor_info.map(|(type_name, params, _)| {
+                    let targs = (0..params).map(|_| self.fresh()).collect();
+                    Type::Variant(type_name, targs)
+                }),
                 PatternKind::Tuple(args) => {
                     Some(Type::Tuple((0..args.len()).map(|_| self.fresh()).collect()))
                 }
@@ -1495,15 +1624,22 @@ value is {scrutinee} — it can never match",
                 }
             },
             PatternKind::Ctor { name, args } => match self.ctors.get(name).cloned() {
-                Some((type_name, field_tys)) => {
+                Some((type_name, _, field_tys)) => {
+                    let mut field_tys = field_tys;
                     match scrutinee {
-                        Type::Variant(s) if *s != type_name => {
+                        Type::Variant(s, _) if *s != type_name => {
                             self.diag(
                                 pattern.span,
                                 format!("`{name}` is not a constructor of `{s}`"),
                             );
                         }
-                        Type::Unknown | Type::Variant(_) => {}
+                        Type::Variant(_, targs) => {
+                            // The scrutinee's arguments give the pattern's
+                            // field types (Full(v) on Box<Float> binds
+                            // v: Float).
+                            field_tys = field_tys.iter().map(|f| subst_params(f, targs)).collect();
+                        }
+                        Type::Unknown => {}
                         other => {
                             self.diag(
                                 pattern.span,
@@ -1603,7 +1739,7 @@ is {other}"
                             "functions cannot be compared with `==`".to_string(),
                         );
                     }
-                    (Type::Record(x), Type::Record(y)) => {
+                    (Type::Record(x, _), Type::Record(y, _)) => {
                         if x != y && !self.same_record_shape(x, y) {
                             self.diag(
                                 node_span,
@@ -1634,7 +1770,7 @@ is {other}"
     /// pairwise-compatible types — i.e. their values can be structurally
     /// equal at runtime.
     fn same_record_shape(&self, x: &str, y: &str) -> bool {
-        let (Some(xf), Some(yf)) = (self.records.get(x), self.records.get(y)) else {
+        let (Some((_, xf)), Some((_, yf))) = (self.records.get(x), self.records.get(y)) else {
             return true; // unknown decl: stay gradual
         };
         xf.len() == yf.len()

--- a/mle/tests/check.rs
+++ b/mle/tests/check.rs
@@ -975,3 +975,47 @@ fn generic_arity_is_checked() {
     );
     assert_eq!(message, "`Box` takes 1 type argument(s), got 0");
 }
+
+// --- Generics review fixes (Codex) ---
+
+/// Recursive and forward generic references resolve at the declared arity
+/// (variant param counts are pre-seeded, like records). [Codex H]
+#[test]
+fn recursive_generic_declarations_resolve() {
+    assert_clean(
+        "type L<a> = | Cons(h: a, t: L<a>) | Nil\n\
+         let sum = (l: L<Float>): Float =>\n\
+           match l with\n\
+           | Cons(h, t) => h + sum(t)\n\
+           | Nil => 0.0\n\
+         let go = () => sum(Cons(1.0, Cons(2.0, Nil)))",
+    );
+}
+
+/// Same declaration with incompatible arguments is certainly-false `==`;
+/// cross-declaration shape comparison uses SUBSTITUTED fields. [Codex H]
+#[test]
+fn generic_record_equality_certainty() {
+    let (message, _, _) = single_diag(
+        "type R<a> = { x: a }\n\
+         let eq = (a: R<String>, b: R<Float>): Bool => a == b",
+    );
+    assert!(message.contains("always false"), "unexpected: {message}");
+    let (message, _, _) = single_diag(
+        "type R<a> = { x: a }\n\
+         type S = { x: Float }\n\
+         let eq = (r: R<String>, s: S): Bool => r == s",
+    );
+    assert!(message.contains("always false"), "unexpected: {message}");
+}
+
+/// A function smuggled through a generic ARGUMENT is still a certain `==`
+/// runtime error. [Codex H]
+#[test]
+fn functions_inside_generic_nominals_cannot_compare() {
+    let (message, _, _) = single_diag(
+        "type Box<a> = | Full(v: a)\n\
+         let main = (): Bool => Full((x) => x) == Full((x) => x)",
+    );
+    assert_eq!(message, "functions cannot be compared with `==`");
+}

--- a/mle/tests/check.rs
+++ b/mle/tests/check.rs
@@ -884,10 +884,10 @@ fn inferred_scrutinees_get_exhaustiveness() {
 /// a declaration-held variable would be module-global (first use pins it
 /// for everyone). [BOTH engines]
 #[test]
-fn type_decl_variables_are_refused() {
+fn undeclared_type_params_are_refused() {
     let (message, _, _) = single_diag("type Box = | Full(v: a) | Empty\nlet p = Full(1.0)");
     assert!(
-        message.contains("type variables (`a`) are not supported in type declarations yet"),
+        message.contains("undeclared type parameter `a` — declare it on the type"),
         "unexpected: {message}"
     );
 }
@@ -903,4 +903,75 @@ fn diagnostic_variables_share_one_order() {
         message,
         "argument 2 of `List.fold`: expected ('b, 'a) => 'b, got List<'a>"
     );
+}
+
+// --- Generic type declarations ---
+
+/// The whole point: one declaration, many instantiations — Box<Float> and
+/// Box<String> coexist, and element types flow through patterns.
+#[test]
+fn generic_adts_instantiate_per_use() {
+    assert_clean(
+        "type Box<v> = | Full(value: v) | Empty\n\
+         let unwrapOr = (b: Box<v>, fallback: v): v =>\n\
+           match b with\n\
+           | Full(value) => value\n\
+           | Empty => fallback\n\
+         let a = unwrapOr(Full(41.0), 0.0) + 1.0\n\
+         let b = Text.concat(unwrapOr(Full(\"hi\"), \"\"), \"!\")",
+    );
+    // …and the instantiation CONSTRAINS: a Float box can't take a String
+    // fallback.
+    let (message, _, _) = single_diag(
+        "type Box<v> = | Full(value: v) | Empty\n\
+         let unwrapOr = (b: Box<v>, fallback: v): v =>\n\
+           match b with\n\
+           | Full(value) => value\n\
+           | Empty => fallback\n\
+         let bad = unwrapOr(Full(1.0), \"s\")",
+    );
+    assert_eq!(
+        message,
+        "argument 2 of `unwrapOr`: expected Float, got String"
+    );
+}
+
+/// Generic records: literals solve the parameters, field access and `with`
+/// updates substitute them.
+#[test]
+fn generic_records_solve_from_literals() {
+    assert_clean(
+        "type Pair<x, y> = { first: x, second: y }\n\
+         let swap = (p: Pair<x, y>): Pair<y, x> => { first: p.second, second: p.first }\n\
+         let go = () => swap({ first: 1.0, second: \"s\" }).second + 1.0",
+    );
+    let (message, _, _) = single_diag(
+        "type Pair<x, y> = { first: x, second: y }\n\
+         let go = (): Float => { first: 1.0, second: \"s\" }.second",
+    );
+    assert_eq!(message, "return value: expected Float, got String");
+}
+
+/// Pattern fields get the scrutinee's arguments (Full(v) on Box<Float>
+/// binds v: Float — and arithmetic on it checks).
+#[test]
+fn pattern_fields_take_scrutinee_arguments() {
+    let (message, _, _) = single_diag(
+        "type Box<v> = | Full(value: v) | Empty\n\
+         let f = (b: Box<String>): Float =>\n\
+           match b with\n\
+           | Full(value) => value + 1.0\n\
+           | Empty => 0.0",
+    );
+    assert_eq!(message, "`+` needs Float operands, got String");
+}
+
+/// Type-argument arity is checked against the declaration.
+#[test]
+fn generic_arity_is_checked() {
+    let (message, _, _) = single_diag(
+        "type Box<v> = | Full(value: v) | Empty\n\
+         let f = (b: Box) => b",
+    );
+    assert_eq!(message, "`Box` takes 1 type argument(s), got 0");
 }

--- a/mle/tests/parser.rs
+++ b/mle/tests/parser.rs
@@ -391,3 +391,25 @@ fn error_mut_cannot_destructure() {
         )
     );
 }
+
+// --- Generic type declarations ---
+
+#[test]
+fn error_duplicate_type_parameter() {
+    assert_eq!(
+        parse_err("type Pair<a, a> = { x: a }"),
+        ("duplicate type parameter `a`".to_string(), 1, 14)
+    );
+}
+
+#[test]
+fn error_uppercase_type_parameter() {
+    assert_eq!(
+        parse_err("type Box<T> = | Full(v: T)"),
+        (
+            "type parameters are lowercase (`t`), like annotation type variables".to_string(),
+            1,
+            10
+        )
+    );
+}

--- a/mle/tests/run.rs
+++ b/mle/tests/run.rs
@@ -632,3 +632,18 @@ fn destructuring_let_arity_mismatch_fails_loud() {
         run_err("let f = (t) => let (a, b) = t in a + b\nlet main = () => f((1.0, 2.0, 3.0))");
     assert_eq!(message, "no pattern matched (1, 2, 3)");
 }
+
+/// Generic ADTs at runtime: the checker's parameters are erased — one Box
+/// works at every type (the runtime was already untyped; this pins that
+/// generics stayed checker-only).
+#[test]
+fn generic_adts_run_type_erased() {
+    assert_eq!(
+        main_result(
+            "type Box<v> = | Full(value: v) | Empty\n\
+             let orElse = (b, d) => match b with | Full(v) => v | Empty => d\n\
+             let main = () => (orElse(Full(1.0), 0.0), orElse(Full(\"s\"), \"\"), orElse(Empty, 9.0))"
+        ),
+        "(1, \"s\", 9)"
+    );
+}


### PR DESCRIPTION
## What

The B7 follow-up both review engines asked for — **generic type declarations**:

```mle
type Box<v> = | Full(value: v) | Empty
type Pair<x, y> = { first: x, second: y }
type L<a> = | Cons(h: a, t: L<a>) | Nil     // recursion works

let unwrapOr = (b: Box<v>, fallback: v): v =>
  match b with
  | Full(value) => value
  | Empty => fallback
-- Full(41.0) and Full("hi") coexist as Box<Float> / Box<String>
```

- **Checker-only**: the runtime was already type-erased (pinned by a run test using one `Box` at three types). Declarations store parameter placeholders in an out-of-band `Var` namespace (the builtin-scheme trick), substituted at every use; `Type::Record/Variant` carry arguments, unified element-wise.
- Ctors instantiate **fresh per use**; record literals **solve** the parameters; field access/`with` substitute; ctor patterns take the **scrutinee's** arguments (`Full(v)` on `Box<String>` binds `v: String` — and `v + 1.0` errors); arity + duplicate/uppercase/undeclared-param teaching errors.

## The bug hunt

While building, a scratch probe caught a subtle class: **three type walkers predating generics (`zonk`, `instantiate`, `renumber_with`) treated nominal types as leaves** — a variable inside `Box<'a>` never substituted, so a generic def's first use silently monomorphized it. All three recurse now.

Codex review then found **three more Highs, all fixed + pinned**: variant param counts weren't pre-seeded (recursive/forward generic references resolved at arity 0 — no linked lists!); `==` certainty ignored generic arguments (`R<String> == R<Float>` checked clean, and raw placeholder fields made cross-declaration shapes trivially "compatible"); and `contains_fn` missed functions smuggled through generic arguments. (Claude reviewer skipped this round — Codex ran probes against the built binary, and the walker class was already flushed out by the in-build probe.)

## Verification

- 232 mle tests: Box/Pair at multiple types, instantiation constrains (Float box refuses String fallback), `swap : Pair<x, y> => Pair<y, x>`, pattern-field flow, recursive `L<a>` with a working `sum`, equality certainty both directions, erased-runtime pin, parser teaching errors
- Goldens regenerated (decls gained `params`); lsp/common (139)/desktop green; both games + example goldens check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
