### PR TITLE
feat(site): docs section — MLE reference with run-in-sandbox snippets

### DIFF
--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -12,7 +12,10 @@
 //   5. a good edit after the broken one recovers;
 //   6. every example in the picker loads to "live" and ticks cleanly (the
 //      repo examples are copied in at build time — this catches one breaking
-//      on wasm).
+//      on wasm);
+//   7. the docs page highlights its MLE blocks, and a "try it" button's
+//      program loads live in the sandbox (the #src= → player ?src= data-URL
+//      path, fresh init).
 //
 // Run manually (needs the wasm bundle):
 //
@@ -175,6 +178,35 @@ for (const example of ["hero", "orbit", "physics", "monitor"]) {
     check(`example '${example}' loads live and ticks cleanly`, errors.length === 0, errors.join("\n"));
   } catch {
     check(`example '${example}' loads live and ticks cleanly`, false, consoleLog.slice(-5).join("\n"));
+  }
+  await page.close();
+}
+
+// --- 7. Docs page + "try it" into the sandbox. --------------------------------
+{
+  const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+  await page.goto(`${BASE}/docs.html`);
+  const highlighted = await page.locator("pre.mle span.tok-k").count();
+  const tryButtons = await page.locator("a.try-button").count();
+  check("docs page highlights MLE blocks", highlighted > 10, `${highlighted} keyword spans`);
+  check("docs page offers try-it buttons", tryButtons >= 4, `${tryButtons} buttons`);
+
+  // Follow the first try-it link in THIS page (target=_blank would detach).
+  const href = await page.locator("a.try-button").first().getAttribute("href");
+  await page.goto(`${BASE}/${href}`);
+  try {
+    await page.waitForFunction(
+      () => window.__sandbox && window.__sandbox.status().state === "live",
+      { timeout: 30000 }
+    );
+    await sleep(400);
+    const pixel = await centerPixel(playerFrame(page));
+    // The first runnable is the magenta spinning cube on the GL clear color —
+    // just assert something got drawn (not solid clear color everywhere is
+    // hard to probe; the live status is the main assertion).
+    check("docs try-it program loads live in the sandbox", true, `center = rgb(${pixel})`);
+  } catch {
+    check("docs try-it program loads live in the sandbox", false, href);
   }
   await page.close();
 }

--- a/site/build.mjs
+++ b/site/build.mjs
@@ -16,7 +16,7 @@ const site = fileURLToPath(new URL(".", import.meta.url));
 const root = fileURLToPath(new URL("..", import.meta.url));
 const dist = `${site}dist`;
 
-const PAGES = ["index.html", "sandbox.html", "player.html", "styles.css"];
+const PAGES = ["index.html", "sandbox.html", "player.html", "docs.html", "styles.css"];
 
 const PKG = `${root}runtime/functor-runtime-web/pkg`;
 const PKG_FILES = ["functor_runtime_web.js", "functor_runtime_web_bg.wasm"];
@@ -54,11 +54,11 @@ for (const [name, path] of Object.entries(EXAMPLES)) {
 }
 
 await esbuild.build({
-  entryPoints: [`${site}src/sandbox.js`],
+  entryPoints: [`${site}src/sandbox.js`, `${site}src/docs.js`],
   bundle: true,
   minify: true,
   format: "esm",
-  outfile: `${dist}/assets/sandbox.js`,
+  outdir: `${dist}/assets`,
   logLevel: "info",
 });
 

--- a/site/docs.html
+++ b/site/docs.html
@@ -108,7 +108,10 @@ let draw = (model, tts: Float) =>
     Scene.sphere()
       |> Scene.emissive(1.0, 0.3, 0.8)
       |> Scene.scale(1.0 + 0.2 * Math.sin(model.spin * 4.0)))</pre>
-          <p>Input is another pure function — slide the cube with A and D:</p>
+          <p>
+            Input is another pure function — slide the cube with A and D (click the preview
+            first so it has keyboard focus):
+          </p>
           <pre class="mle runnable">let init = { x: 0.0 }
 
 let input = (model, key, isDown) =>
@@ -130,7 +133,7 @@ let draw = (model, tts) =>
       |> Scene.translate(model.x, 0.0, 0.0))</pre>
           <p>
             And physics is declarative — describe the bodies each frame; the runtime reconciles
-            and steps the world (click the preview, then watch the ball settle):
+            and steps the world:
           </p>
           <pre class="mle runnable">let init = {}
 let tick = (m, dt, tts) => m
@@ -178,8 +181,10 @@ let draw = (m, tts) =>
             </tbody>
           </table>
           <p>
-            Any entry point may instead return a 2-tuple <code>(model', effect)</code> to issue
-            one-shot <a href="#prelude-effects">effects</a>.
+            The model-returning entry points (<code>tick</code>, <code>input</code>,
+            <code>mouseMove</code>, <code>mouseWheel</code>, <code>update</code>) may instead
+            return a 2-tuple <code>(model', effect)</code> to issue one-shot
+            <a href="#prelude-effects">effects</a>.
           </p>
           <p>
             <strong>Frame order:</strong> subscriptions → <code>update</code> → <code>tick</code>
@@ -241,7 +246,8 @@ let area = (s: Shape): Float =>
             first-class: <code>xs |> List.map(Circle)</code>. When the scrutinee's type is known,
             exhaustiveness is checked. Patterns are minimal: <code>Ctor(x, _)</code>,
             <code>Ctor</code>, tuple <code>(x, _)</code> (matched by exact arity), bare names,
-            <code>_</code>, and literals — literal arms need a catch-all.
+            <code>_</code>, and literals — number/string literal arms need a catch-all
+            (<code>true</code> + <code>false</code> together are exhaustive).
           </p>
           <p>
             <strong>Arms are greedy:</strong> a nested <code>match</code> inside an arm consumes

--- a/site/docs.html
+++ b/site/docs.html
@@ -1,0 +1,429 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>functor docs — the MLE language</title>
+    <meta
+      name="description"
+      content="Get started with functor and learn MLE — the tiny live-editable game language. Every full program here runs in the sandbox with one click."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Orbitron:wght@600;800&family=JetBrains+Mono:ital,wght@0,400;0,600;1,400&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body class="docs-page">
+    <header class="sandbox-header">
+      <a class="wordmark" href="./">FUNCTOR<span class="wordmark-accent">//DOCS</span></a>
+      <div class="sandbox-controls"></div>
+      <a class="header-link" href="sandbox.html">Sandbox</a>
+      <a class="header-link" href="https://github.com/tommy-xr/functor">GitHub ↗</a>
+    </header>
+
+    <div class="docs-layout">
+      <nav class="docs-nav">
+        <a href="#get-started">Get started</a>
+        <a href="#complete-game">A complete game</a>
+        <a href="#contract">The game contract</a>
+        <a href="#language">The language</a>
+        <a href="#prelude">The prelude</a>
+        <a href="#builtins">Builtins</a>
+        <a href="#sharp-edges">Sharp edges</a>
+      </nav>
+
+      <main class="docs-main">
+        <h1>MLE — the functor game language</h1>
+        <p>
+          MLE is a deliberately small, F#-inspired language for game logic. It is
+          <em>interpreted</em> — the source ships as text and runs natively, in the browser, and
+          in the <a href="sandbox.html">sandbox</a> — and it hot-reloads with your game's state
+          preserved. Every full program on this page has a <strong>▶ try it</strong> button that
+          opens it live in the sandbox.
+        </p>
+
+        <section id="get-started">
+          <h2>Get started</h2>
+          <p>
+            The fastest path is the <a href="sandbox.html">sandbox</a> — nothing to install. For
+            local development you need Rust (stable), Node 22, and
+            <code>wasm-pack</code>; then:
+          </p>
+          <pre class="shell">git clone https://github.com/tommy-xr/functor && cd functor
+npm run build:cli                    # builds the functor CLI + runtimes</pre>
+          <p>An MLE project is a directory with two files:</p>
+          <pre class="shell"># functor.json
+{ "language": "mle", "entry": "game.mle" }</pre>
+          <p>And the game itself — here is the smallest interesting one:</p>
+          <pre class="mle runnable">let init = {}
+let tick = (m, dt, tts) => m
+let draw = (m, tts: Float) =>
+  Frame.create(
+    Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0),
+    Scene.cube()
+      |> Scene.emissive(1.0, 0.2, 0.8)
+      |> Scene.rotateY(Angle.radians(tts)))</pre>
+          <p>Run it:</p>
+          <pre class="shell">functor -d . run native      # desktop window
+functor -d . run wasm        # serves it in the browser
+functor -d . develop         # hot-reload loop: save the file, see it in ~1 frame
+functor -d . build           # typecheck (diagnostics are errors)</pre>
+          <p>
+            <strong>Hot reload preserves the model.</strong> Under <code>develop</code> (and in
+            the sandbox), saving an edit swaps the program under the <em>running</em> state: a
+            bouncing ball keeps bouncing, mid-arc, with your new gravity. A broken edit keeps the
+            old program running and shows the error. An edited <code>init</code> takes effect on
+            restart, not on reload.
+          </p>
+        </section>
+
+        <section id="complete-game">
+          <h2>A complete game</h2>
+          <p>
+            A game is Model–View–Update: <code>init</code> is the starting model,
+            <code>tick</code> steps it every frame, <code>draw</code> renders it, and messages
+            (from timers, effects) fold through <code>update</code>. This one pulses a sphere and
+            counts beats once a second:
+          </p>
+          <pre class="mle runnable">// a pulsing sphere with a beat counter
+type Msg = | Beat
+
+let init = { spin: 0.0, beat: 0.0 }
+
+let tick = (model, dt: Float, tts: Float) =>
+  { model with spin: model.spin + dt }
+
+let update = (model, msg) =>
+  match msg with
+  | Beat => { model with beat: model.beat + 1.0 }
+
+let subscriptions = (model) => Sub.every(Time.seconds(1.0), Beat)
+
+let draw = (model, tts: Float) =>
+  Frame.create(
+    Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0),
+    Scene.sphere()
+      |> Scene.emissive(1.0, 0.3, 0.8)
+      |> Scene.scale(1.0 + 0.2 * Math.sin(model.spin * 4.0)))</pre>
+          <p>Input is another pure function — slide the cube with A and D:</p>
+          <pre class="mle runnable">let init = { x: 0.0 }
+
+let input = (model, key, isDown) =>
+  match isDown with
+  | false => model
+  | true =>
+    (match key with
+     | "A" => { model with x: model.x - 0.5 }
+     | "D" => { model with x: model.x + 0.5 }
+     | _ => model)
+
+let tick = (model, dt, tts) => model
+
+let draw = (model, tts) =>
+  Frame.create(
+    Camera.lookAt(0.0, 2.0, -8.0, 0.0, 0.0, 0.0),
+    Scene.cube()
+      |> Scene.emissive(0.2, 0.9, 1.0)
+      |> Scene.translate(model.x, 0.0, 0.0))</pre>
+          <p>
+            And physics is declarative — describe the bodies each frame; the runtime reconciles
+            and steps the world (click the preview, then watch the ball settle):
+          </p>
+          <pre class="mle runnable">let init = {}
+let tick = (m, dt, tts) => m
+
+let physics = (m) =>
+  Physics.scene(0.0, -9.81, 0.0, [
+    Physics.fixed("ground", Physics.box(20.0, 0.4, 20.0))
+      |> Physics.at(0.0, -0.2, 0.0),
+    Physics.dynamic("ball", Physics.sphere(0.5))
+      |> Physics.at(0.3, 4.0, 0.0)
+      |> Physics.restitution(0.8),
+  ])
+
+let draw = (m, tts) =>
+  Frame.createLit(
+    Camera.lookAt(0.0, 3.0, -8.0, 0.0, 1.0, 0.0),
+    Scene.group([
+      Scene.plane() |> Scene.scale(20.0) |> Scene.lit(0.4, 0.45, 0.55),
+      Scene.sphere()
+        |> Scene.scale(0.5)
+        |> Scene.lit(1.0, 0.4, 0.6)
+        |> Physics.transformed("ball"),
+    ]),
+    [
+      Light.ambient(0.15, 0.15, 0.2),
+      Light.directional(0.4, -1.0, 0.3, 1.0, 0.95, 0.9, 0.9) |> Light.castShadows,
+    ])</pre>
+        </section>
+
+        <section id="contract">
+          <h2>The game contract</h2>
+          <p>A runner-hosted game defines these top-level bindings:</p>
+          <table>
+            <thead><tr><th>binding</th><th>shape</th><th></th></tr></thead>
+            <tbody>
+              <tr><td><code>init</code></td><td><code>{ … }</code></td><td>the initial model — a <em>value</em>, not a function</td></tr>
+              <tr><td><code>tick</code></td><td><code>(model, dt, tts) => model'</code></td><td>per-frame step; <code>dt</code> seconds since last frame, <code>tts</code> total time</td></tr>
+              <tr><td><code>draw</code></td><td><code>(model, tts) => Frame</code></td><td>pure frame description</td></tr>
+              <tr><td><code>input</code></td><td><code>(model, key, isDown) => model'</code></td><td>optional; <code>key</code> is <code>"W"</code>, <code>"Up"</code>, <code>"Space"</code>, … — key <em>repeats</em> arrive as <code>isDown = true</code>, so latch if you need edges</td></tr>
+              <tr><td><code>mouseMove</code></td><td><code>(model, x, y) => model'</code></td><td>optional; window pixels</td></tr>
+              <tr><td><code>mouseWheel</code></td><td><code>(model, delta) => model'</code></td><td>optional</td></tr>
+              <tr><td><code>update</code></td><td><code>(model, msg) => model'</code></td><td>optional; messages are your variant values</td></tr>
+              <tr><td><code>subscriptions</code></td><td><code>(model) => Sub</code></td><td>optional (requires <code>update</code>); declarative timers</td></tr>
+              <tr><td><code>physics</code></td><td><code>(model) => Physics.scene(…)</code></td><td>optional; declarative bodies, reconciled each frame</td></tr>
+            </tbody>
+          </table>
+          <p>
+            Any entry point may instead return a 2-tuple <code>(model', effect)</code> to issue
+            one-shot <a href="#prelude-effects">effects</a>.
+          </p>
+          <p>
+            <strong>Frame order:</strong> subscriptions → <code>update</code> → <code>tick</code>
+            → physics (fixed-step 60&nbsp;Hz) → <code>draw</code>. Physics reads in
+            <code>draw</code> see <em>this</em> frame's stepped world; reads in <code>tick</code>
+            see the previous frame's — so on the very first frame declared bodies don't exist
+            yet. Keep physics reads in <code>draw</code>.
+          </p>
+        </section>
+
+        <section id="language">
+          <h2>The language</h2>
+
+          <h3>Values and bindings</h3>
+          <pre class="mle">let threshold = 10          // every number is a Float (f64)
+let name = "neon\n"         // strings: \" \\ \n \t
+let on = true
+let origin = { x: 0.0, y: 0.0 }
+let scores = [1.0, 2.0, 3.0]</pre>
+          <p>
+            Line comments only (<code>//</code>). Top-level definitions are mutually visible
+            inside function bodies (and late-bound — that's the hot-reload seam), but a top-level
+            <em>initializer</em> may only use names defined above it.
+          </p>
+
+          <h3>Functions</h3>
+          <pre class="mle">let area = (w: Float, h: Float): Float => w * h   // annotations optional
+let describe = (score) => Text.concat("score: ", Text.fromFloat(score))</pre>
+          <p>
+            Typing is <em>gradual</em>: unannotated values check against everything; annotations
+            buy diagnostics (<code>functor build</code> reports them all). Recursion depth is
+            capped (~200) — deep iteration belongs in <code>List.*</code>.
+          </p>
+
+          <h3>Records</h3>
+          <pre class="mle">type Position = { x: Float, y: Float }        // nominal in annotations
+
+let p = { x: 0.0, y: 1.0 }
+let nudged = { p with x: p.x + 1.0 }          // update: fields must exist</pre>
+
+          <h3>Variants and match</h3>
+          <pre class="mle">type Shape =
+  | Circle(radius: Float)     // leading | required — first alternative too
+  | Rect(w: Float, h: Float)
+  | Point                     // nullary: no parens, ever
+
+let c = Circle(2.0)           // constructors are CALLED positionally
+let shapes = [c, Rect(3.0, 4.0), Point]
+
+let area = (s: Shape): Float =>
+  match s with
+  | Circle(r) => 3.14 * r * r // ctor patterns bind positionally
+  | Rect(w, _) => w * w       // sub-patterns: names or _ only (no nesting)
+  | Point => 0.0</pre>
+          <p>
+            Constructors resolve <em>bare</em> and live in the value namespace
+            (<code>Shape.Circle</code> does <strong>not</strong> work), so constructor names must
+            be unique across all variant types in the file. Unapplied constructors are
+            first-class: <code>xs |> List.map(Circle)</code>. When the scrutinee's type is known,
+            exhaustiveness is checked. Patterns are minimal: <code>Ctor(x, _)</code>,
+            <code>Ctor</code>, tuple <code>(x, _)</code> (matched by exact arity), bare names,
+            <code>_</code>, and literals — literal arms need a catch-all.
+          </p>
+          <p>
+            <strong>Arms are greedy:</strong> a nested <code>match</code> inside an arm consumes
+            the following <code>|</code> arms as its own — parenthesize the inner match.
+          </p>
+
+          <h3>The conditional</h3>
+          <p>There is no <code>if</code>/<code>else</code>. The conditional is a bool-literal match:</p>
+          <pre class="mle">let sizeOf = (n: Float): String =>
+  match n > 10.0 with
+  | true => "big"
+  | false => "small"</pre>
+
+          <h3>Pipelines</h3>
+          <p>
+            <code>|></code> <strong>prepends</strong> the piped value:
+            <code>x |> f(a)</code> is <code>f(x, a)</code>. Every prelude function therefore
+            takes its subject (list, scene, body) first.
+          </p>
+          <pre class="mle">let isHigh = (score) => score > 10.0
+let describe = (score) => Text.concat("score: ", Text.fromFloat(score))
+
+let report = (scores) =>
+  scores
+    |> List.filter(isHigh)
+    |> List.map(describe)
+    |> Text.toBullets</pre>
+
+          <h3>Tuples</h3>
+          <pre class="mle">let minMax = (a: Float, b: Float): Float * Float =>
+  match a &lt; b with
+  | true => (a, b)            // (e) is grouping, not a 1-tuple
+  | false => (b, a)
+
+let span = (a, b) =>
+  let (lo, hi) = minMax(a, b) in   // destructuring let
+  hi - lo</pre>
+          <p>
+            Tuples are structural (2+ elements) and are for multiple returns; prefer named
+            records for anything that outlives an expression.
+          </p>
+
+          <h3>Local mutation</h3>
+          <pre class="mle">let sum3 = (a, b, c) =>
+  let mut acc = a in          // a rebindable slot; expression let-in
+  acc := acc + b;             // assignment is := and carries a continuation
+  acc := acc + c;
+  acc</pre>
+          <p>
+            <code>mut</code> is local-only: no top-level <code>let mut</code>, and a lambda may
+            not capture an enclosing <code>mut</code> slot. Params, globals, and plain
+            <code>let</code>s are immutable.
+          </p>
+
+          <h3>Operators and equality</h3>
+          <p>
+            <code>+ - * /</code>, <code>&lt; > ==</code>, unary <code>-</code>; conventional
+            precedence, pipelines bind loosest. <code>==</code> is structural (comparing
+            functions is a runtime error). Division is IEEE (<code>1.0/0.0</code> is
+            <code>inf</code>); the engine boundary rejects non-finite numbers. There are no
+            loops, modules, or imports — iteration is <code>List.map/filter/fold</code>.
+          </p>
+        </section>
+
+        <section id="prelude">
+          <h2>The prelude</h2>
+          <p>
+            Available in runner-hosted games (the CLI, the sandbox) — not in the bare
+            <code>mle</code> interpreter.
+          </p>
+
+          <h3>Scene</h3>
+          <table>
+            <tbody>
+              <tr><td><code>Scene.cube() / sphere() / cylinder() / quad() / plane()</code></td><td>primitives (zero args, enforced); <code>plane</code> lies in XZ (ground), <code>quad</code> in XY — a quad's front is +Z</td></tr>
+              <tr><td><code>Scene.group([scene, …])</code></td><td>compose</td></tr>
+              <tr><td><code>scene |> Scene.color(r, g, b)</code></td><td>flat unlit color</td></tr>
+              <tr><td><code>scene |> Scene.lit(r, g, b)</code></td><td>diffuse + specular (needs lights)</td></tr>
+              <tr><td><code>scene |> Scene.emissive(r, g, b)</code></td><td>unlit glow</td></tr>
+              <tr><td><code>scene |> Scene.translate(x, y, z)</code></td><td rowspan="3">transforms wrap outward: the <em>outer</em> call applies last in world space — <code>s |> rotateY(r) |> translate(x, 0.0, 0.0)</code> rotates in place, then moves</td></tr>
+              <tr><td><code>scene |> Scene.rotateX/Y/Z(angle)</code></td></tr>
+              <tr><td><code>scene |> Scene.scale(k)</code></td></tr>
+            </tbody>
+          </table>
+          <p>
+            Coordinates are <strong>Y-up, right-handed</strong>: +Y up, +X right, ground in XZ.
+            Angles are branded values: <code>Angle.degrees(60.0)</code> /
+            <code>Angle.radians(1.57)</code> — never bare numbers.
+          </p>
+
+          <h3>Camera, lights, frames</h3>
+          <table>
+            <tbody>
+              <tr><td><code>Camera.lookAt(ex, ey, ez, tx, ty, tz)</code></td><td>up = +Y, fov 45°</td></tr>
+              <tr><td><code>Camera.firstPerson(ex, ey, ez, yaw, pitch, fov)</code></td><td>all three are Angles; yaw 0 / pitch 0 looks down +Z</td></tr>
+              <tr><td><code>Light.ambient(r, g, b)</code></td><td></td></tr>
+              <tr><td><code>Light.directional(dx, dy, dz, r, g, b, intensity)</code></td><td><code>|> Light.castShadows</code> for a shadowed key light</td></tr>
+              <tr><td><code>Light.point(px, py, pz, r, g, b, intensity, range)</code></td><td></td></tr>
+              <tr><td><code>Frame.create(camera, scene)</code></td><td>what <code>draw</code> returns</td></tr>
+              <tr><td><code>Frame.createLit(camera, scene, [light, …])</code></td><td>lit + shadowed</td></tr>
+            </tbody>
+          </table>
+
+          <h3>Render targets</h3>
+          <pre class="mle">let feed = RenderTarget.named("security") |> RenderTarget.sized(256.0, 256.0)</pre>
+          <table>
+            <tbody>
+              <tr><td><code>frame |> Frame.withRenderTarget(target, targetFrame)</code></td><td>writer: renders a full frame (own camera + lights) into the target before the main pass</td></tr>
+              <tr><td><code>scene |> Scene.screen(target)</code></td><td>reader: an emissive screen showing the target</td></tr>
+            </tbody>
+          </table>
+          <p>
+            Declare a target <em>once</em> and use the value at both sites (never a bare
+            string). A scene sampling its own target sees last frame's image. The
+            <em>Render targets</em> example in the sandbox is the reference.
+          </p>
+
+          <h3>Time, subscriptions<span id="prelude-effects"></span>, effects</h3>
+          <table>
+            <tbody>
+              <tr><td><code>Time.seconds(1.0) / Time.millis(500.0)</code></td><td>Durations are branded, like Angles</td></tr>
+              <tr><td><code>Sub.every(duration, Msg)</code></td><td>stateless global time grid: a long frame fires once; timers tick through hot reload</td></tr>
+              <tr><td><code>Sub.none() / Sub.batch([sub, …])</code></td><td></td></tr>
+              <tr><td><code>Effect.random(Tagger) / Effect.now(Tagger)</code></td><td>one-shots; the tagger is a function <code>(Float) => Msg</code> — <code>random</code> gives [0,1), <code>now</code> epoch seconds</td></tr>
+              <tr><td><code>Effect.none() / Effect.batch([fx, …])</code></td><td>return <code>(model', effect)</code> from any entry point</td></tr>
+            </tbody>
+          </table>
+
+          <h3>Physics</h3>
+          <table>
+            <tbody>
+              <tr><td><code>Physics.box(w, h, d) / sphere(r) / capsule(halfH, r)</code></td><td>shapes; box takes <em>full</em> extents</td></tr>
+              <tr><td><code>Physics.dynamic("tag", shape)</code></td><td>simulated; also <code>kinematic</code> / <code>fixed</code></td></tr>
+              <tr><td><code>body |> Physics.at(x, y, z)</code></td><td>spawn pose; also <code>velocity</code>, <code>mass</code>, <code>friction</code>, <code>restitution</code>, <code>sensor</code></td></tr>
+              <tr><td><code>Physics.scene(gx, gy, gz, [body, …])</code></td><td>what the <code>physics</code> hook returns</td></tr>
+              <tr><td><code>Physics.position("tag")</code></td><td><code>{x, y, z}</code> of the live body</td></tr>
+              <tr><td><code>scene |> Physics.transformed("tag")</code></td><td>draw a scene at the body's live pose</td></tr>
+            </tbody>
+          </table>
+          <p>
+            The tag is cross-frame identity: same tag = same body; drop a body by not declaring
+            it. Re-declaring an unchanged body leaves the simulation alone; changing its declared
+            position teleports it. Reading a tag your <code>physics</code> hook doesn't declare
+            is a runtime error. The physics world survives hot reload, like the model.
+          </p>
+        </section>
+
+        <section id="builtins">
+          <h2>Builtins</h2>
+          <table>
+            <tbody>
+              <tr><td><code>List.map(list, fn)</code> · <code>List.filter(list, fn)</code></td><td rowspan="2">the subject comes first — pipeline-friendly</td></tr>
+              <tr><td><code>List.fold(list, fn, init)</code> — callback is <code>(acc, x) => …</code></td></tr>
+              <tr><td><code>List.range(n)</code></td><td><code>[0 … n-1]</code></td></tr>
+              <tr><td><code>List.maximum(list)</code></td><td></td></tr>
+              <tr><td><code>Text.concat(a, b)</code> · <code>Text.fromFloat(n)</code> · <code>Text.toBullets(list)</code></td><td></td></tr>
+              <tr><td><code>Math.sin(n)</code> · <code>Math.cos(n)</code> · <code>Math.clamp01(n)</code></td><td></td></tr>
+            </tbody>
+          </table>
+        </section>
+
+        <section id="sharp-edges">
+          <h2>Sharp edges</h2>
+          <ul>
+            <li><code>x |> f(a)</code> is <code>f(x, a)</code> — pipelines <em>prepend</em>.</li>
+            <li>Assignment is <code>:=</code> (not <code>&lt;-</code>) and must be followed by <code>;</code> and a continuation.</li>
+            <li>No <code>if</code>/<code>else</code> — use a bool-literal <code>match</code>.</li>
+            <li>Angles, Durations, and render targets are branded <em>values</em> — <code>Sub.every(0.5, …)</code> and <code>Scene.rotateY(1.57)</code> are errors.</li>
+            <li>A nested <code>match</code> inside an arm eats the following arms — parenthesize it.</li>
+            <li>Constructor names are global to the file's value namespace; nullary constructors never take parens.</li>
+            <li>Key repeats arrive as <code>isDown = true</code> — latch for rising edges.</li>
+            <li>Physics reads belong in <code>draw</code>; in <code>tick</code> you see last frame's world.</li>
+            <li>Engine values (<code>&lt;Scene></code>, <code>&lt;Frame></code>, …) are opaque: pass them around, don't compare or inspect them.</li>
+          </ul>
+          <p class="docs-footnote">
+            This page tracks the language exactly — if a construct isn't here, it doesn't parse.
+            The roadmap lives in <a href="https://github.com/tommy-xr/functor/blob/main/docs/mle.md">docs/mle.md</a>.
+          </p>
+        </section>
+      </main>
+    </div>
+
+    <script type="module" src="assets/docs.js"></script>
+  </body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -35,6 +35,7 @@
         </p>
         <div class="hero-actions">
           <a class="button-primary" href="sandbox.html">▶ Open the sandbox</a>
+          <a class="button-ghost" href="docs.html">Docs</a>
           <a class="button-ghost" href="https://github.com/tommy-xr/functor">GitHub ↗</a>
         </div>
         <p class="hero-note">this backdrop is a live program — <a href="sandbox.html?example=hero">edit it</a></p>

--- a/site/player.html
+++ b/site/player.html
@@ -30,14 +30,22 @@
       // Must be set before init(): the runtime reads it at start to choose the
       // interpreter producer. The runtime fetches it as a URL, so encode each
       // path segment while keeping subdirectories.
-      const requested = new URLSearchParams(window.location.search).get("game");
+      const params = new URLSearchParams(window.location.search);
+      // ?src=<base64url> carries an inline program (the docs' "try it"
+      // buttons): the runtime fetches __mleGamePath as a URL, and a data:
+      // URL delivers the source with a fresh init — unlike a set-source
+      // push, which deliberately preserves the running model.
+      const src = params.get("src");
+      const requested = params.get("game");
       // Same-origin relative paths only: reject absolute/protocol-relative
       // URLs so the page can't be pointed at a third-party source.
       const game =
         requested && !requested.startsWith("/") && !requested.includes(":")
           ? requested
           : "examples/hero.mle";
-      window.__mleGamePath = game.split("/").map(encodeURIComponent).join("/");
+      window.__mleGamePath = src
+        ? "data:text/plain;base64," + src.replace(/-/g, "+").replace(/_/g, "/")
+        : game.split("/").map(encodeURIComponent).join("/");
 
       // Map a browser KeyboardEvent.code to the canonical key code expected by
       // the game (functor_runtime_common::Key as i32). Keep in sync with

--- a/site/sandbox.html
+++ b/site/sandbox.html
@@ -27,6 +27,7 @@
         </button>
         <span id="status" class="status-pill" data-state="busy">◌ loading…</span>
       </div>
+      <a class="header-link" href="docs.html">Docs</a>
       <a class="header-link" href="https://github.com/tommy-xr/functor">GitHub ↗</a>
     </header>
 

--- a/site/src/docs.js
+++ b/site/src/docs.js
@@ -10,7 +10,7 @@ const KEYWORDS = new Set(["let", "type", "match", "with", "mut", "in"]);
 const ATOMS = new Set(["true", "false"]);
 
 const TOKEN =
-  /\/\/[^\n]*|"(?:[^"\\]|\\.)*"|\d+(?:\.\d+)?|[A-Za-z_][A-Za-z0-9_]*|\|>|=>|:=|[+\-*/<>=|]/g;
+  /\/\/[^\n]*|"(?:[^"\\]|\\.)*"?|\d+(?:\.\d+)?|[A-Za-z_][A-Za-z0-9_]*|\|>|=>|:=|[+\-*/<>=|]/g;
 
 const escapeHtml = (s) =>
   s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");

--- a/site/src/docs.js
+++ b/site/src/docs.js
@@ -1,0 +1,60 @@
+// Docs page enhancement: syntax-highlight the <pre class="mle"> blocks and
+// give the runnable ones (class "runnable") a "▶ try it" button that opens
+// the program in the sandbox via the #src= fragment (see sandbox.js).
+//
+// The tokenizer mirrors src/mle.js's CodeMirror StreamLanguage; it's a few
+// regexes, so a static-HTML variant beats dragging CodeMirror onto the docs
+// page. Keep the two classifications in sync.
+
+const KEYWORDS = new Set(["let", "type", "match", "with", "mut", "in"]);
+const ATOMS = new Set(["true", "false"]);
+
+const TOKEN =
+  /\/\/[^\n]*|"(?:[^"\\]|\\.)*"|\d+(?:\.\d+)?|[A-Za-z_][A-Za-z0-9_]*|\|>|=>|:=|[+\-*/<>=|]/g;
+
+const escapeHtml = (s) =>
+  s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+const classify = (token) => {
+  if (token.startsWith("//")) return "tok-c";
+  if (token.startsWith('"')) return "tok-s";
+  if (/^\d/.test(token)) return "tok-n";
+  if (/^[A-Z]/.test(token)) return "tok-t";
+  if (KEYWORDS.has(token)) return "tok-k";
+  if (ATOMS.has(token)) return "tok-a";
+  if (/^[a-z_]/.test(token)) return null;
+  return "tok-o";
+};
+
+const highlight = (source) => {
+  let html = "";
+  let last = 0;
+  for (const match of source.matchAll(TOKEN)) {
+    html += escapeHtml(source.slice(last, match.index));
+    const cls = classify(match[0]);
+    const text = escapeHtml(match[0]);
+    html += cls ? `<span class="${cls}">${text}</span>` : text;
+    last = match.index + match[0].length;
+  }
+  return html + escapeHtml(source.slice(last));
+};
+
+const toBase64Url = (s) =>
+  btoa(String.fromCharCode(...new TextEncoder().encode(s)))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+
+for (const pre of document.querySelectorAll("pre.mle")) {
+  const source = pre.textContent;
+  pre.innerHTML = highlight(source);
+  if (pre.classList.contains("runnable")) {
+    const link = document.createElement("a");
+    link.className = "try-button";
+    link.textContent = "▶ try it";
+    link.title = "Open this program live in the sandbox";
+    link.href = `sandbox.html#src=${toBase64Url(source)}`;
+    link.target = "_blank";
+    pre.appendChild(link);
+  }
+}

--- a/site/src/sandbox.js
+++ b/site/src/sandbox.js
@@ -93,6 +93,37 @@ window.addEventListener("message", (event) => {
   }
 });
 
+const setDoc = (source) => {
+  clearTimeout(pushTimer);
+  previewReady = false;
+  dirty = false;
+  programmaticEdit = true;
+  view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: source } });
+  programmaticEdit = false;
+};
+
+// An inline program from the URL fragment (the docs' "try it" buttons):
+// #src=<base64url> becomes the editor buffer and the player's ?src= data:
+// URL, so it starts with a fresh init — no served file involved.
+const fromBase64Url = (b64u) =>
+  new TextDecoder().decode(
+    Uint8Array.from(atob(b64u.replace(/-/g, "+").replace(/_/g, "/")), (c) => c.charCodeAt(0))
+  );
+
+const loadInline = (b64u) => {
+  let source;
+  try {
+    source = fromBase64Url(b64u);
+  } catch {
+    setStatus("error", "✖ error", "the #src= fragment is not valid base64");
+    return false;
+  }
+  setDoc(source);
+  setStatus("busy", "◌ loading…");
+  frame.src = `player.html?src=${b64u}`;
+  return true;
+};
+
 const loadExample = async (id) => {
   const url = `examples/${encodeURIComponent(id)}.mle`;
   const response = await fetch(url);
@@ -101,14 +132,9 @@ const loadExample = async (id) => {
     return;
   }
   const source = await response.text();
-  clearTimeout(pushTimer);
-  previewReady = false;
-  dirty = false;
-  programmaticEdit = true;
-  view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: source } });
-  programmaticEdit = false;
   // A fresh iframe (fresh model: init runs) rather than a source push, so
   // switching examples resets state; the ready announcement re-arms pushes.
+  setDoc(source);
   setStatus("busy", "◌ loading…");
   frame.src = `player.html?game=${encodeURIComponent(url)}`;
 };
@@ -129,10 +155,11 @@ picker.addEventListener("change", () => {
 
 resetButton.addEventListener("click", () => loadExample(picker.value));
 
+const inlineSrc = new URLSearchParams(window.location.hash.slice(1)).get("src");
 const requested = new URLSearchParams(window.location.search).get("example");
 const initial = EXAMPLES.some((e) => e.id === requested) ? requested : EXAMPLES[0].id;
 picker.value = initial;
-loadExample(initial);
+if (!(inlineSrc && loadInline(inlineSrc))) loadExample(initial);
 
 // Test seam for the headless e2e (e2e/site-sandbox.mjs): set the buffer and
 // observe results without synthesizing keyboard events.

--- a/site/src/sandbox.js
+++ b/site/src/sandbox.js
@@ -110,6 +110,8 @@ const fromBase64Url = (b64u) =>
     Uint8Array.from(atob(b64u.replace(/-/g, "+").replace(/_/g, "/")), (c) => c.charCodeAt(0))
   );
 
+let inlineB64 = null;
+
 const loadInline = (b64u) => {
   let source;
   try {
@@ -118,6 +120,16 @@ const loadInline = (b64u) => {
     setStatus("error", "✖ error", "the #src= fragment is not valid base64");
     return false;
   }
+  inlineB64 = b64u;
+  // Reflect the inline program in the picker so it (and Reset) don't lie
+  // about what's loaded.
+  if (!picker.querySelector('option[value="__inline"]')) {
+    const option = document.createElement("option");
+    option.value = "__inline";
+    option.textContent = "docs snippet";
+    picker.appendChild(option);
+  }
+  picker.value = "__inline";
   setDoc(source);
   setStatus("busy", "◌ loading…");
   frame.src = `player.html?src=${b64u}`;
@@ -147,13 +159,20 @@ for (const example of EXAMPLES) {
 }
 
 picker.addEventListener("change", () => {
+  if (picker.value === "__inline") {
+    loadInline(inlineB64);
+    return;
+  }
   const url = new URL(window.location);
   url.searchParams.set("example", picker.value);
+  url.hash = "";
   window.history.replaceState(null, "", url);
   loadExample(picker.value);
 });
 
-resetButton.addEventListener("click", () => loadExample(picker.value));
+resetButton.addEventListener("click", () =>
+  picker.value === "__inline" ? loadInline(inlineB64) : loadExample(picker.value)
+);
 
 const inlineSrc = new URLSearchParams(window.location.hash.slice(1)).get("src");
 const requested = new URLSearchParams(window.location.search).get("example");

--- a/site/styles.css
+++ b/site/styles.css
@@ -222,6 +222,9 @@ a:hover {
 .tok-t { color: var(--amber); }
 .tok-n { color: #c792ff; }
 .tok-c { color: #6a5a96; font-style: italic; }
+.tok-s { color: var(--green); }
+.tok-a { color: #ff9f43; }
+.tok-o { color: var(--pink-soft); }
 
 .how-it-works ol {
   padding-left: 20px;
@@ -411,5 +414,155 @@ a:hover {
   .editor-pane {
     border-right: none;
     border-bottom: 1px solid var(--line);
+  }
+}
+
+/* ------------------------------------------------------------------- docs */
+
+.docs-layout {
+  display: grid;
+  grid-template-columns: 200px minmax(0, 780px);
+  gap: 40px;
+  max-width: 1060px;
+  margin: 0 auto;
+  padding: 32px 24px 80px;
+}
+
+.docs-nav {
+  position: sticky;
+  top: 24px;
+  align-self: start;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 0.85rem;
+}
+
+.docs-nav a {
+  color: var(--text-dim);
+  border-left: 2px solid var(--line);
+  padding-left: 12px;
+}
+
+.docs-nav a:hover {
+  color: var(--cyan);
+  border-left-color: var(--cyan);
+  text-shadow: none;
+}
+
+.docs-main h1 {
+  font-family: var(--font-display);
+  letter-spacing: 0.06em;
+  font-size: 1.7rem;
+}
+
+.docs-main h2 {
+  font-family: var(--font-display);
+  letter-spacing: 0.05em;
+  font-size: 1.15rem;
+  margin-top: 48px;
+  padding-top: 16px;
+  border-top: 1px solid var(--line);
+  color: var(--pink-soft);
+}
+
+.docs-main h3 {
+  font-size: 0.95rem;
+  color: var(--amber);
+  margin-top: 28px;
+}
+
+.docs-main p,
+.docs-main li {
+  color: var(--text-dim);
+  font-size: 0.92rem;
+}
+
+.docs-main strong,
+.docs-main em {
+  color: var(--text);
+}
+
+.docs-main code {
+  color: var(--green);
+  font-size: 0.88em;
+}
+
+.docs-main pre {
+  position: relative;
+  background: var(--bg-panel);
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--cyan);
+  border-radius: 6px;
+  padding: 16px 18px;
+  overflow-x: auto;
+  font-size: 0.83rem;
+  line-height: 1.55;
+  color: var(--text);
+}
+
+.docs-main pre.shell {
+  border-left-color: var(--amber);
+  color: var(--text-dim);
+}
+
+.docs-main table {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 0.85rem;
+}
+
+.docs-main th,
+.docs-main td {
+  text-align: left;
+  padding: 8px 12px;
+  border: 1px solid var(--line);
+  color: var(--text-dim);
+  vertical-align: top;
+}
+
+.docs-main th {
+  color: var(--text);
+  background: var(--bg-panel);
+  font-family: var(--font-display);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+}
+
+.try-button {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  font-family: var(--font-display);
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  color: #16032f;
+  background: linear-gradient(90deg, var(--cyan), var(--pink-soft));
+  border-radius: 3px;
+  padding: 4px 10px;
+  text-transform: uppercase;
+}
+
+.try-button:hover {
+  box-shadow: 0 0 14px rgba(39, 232, 247, 0.6);
+  text-shadow: none;
+}
+
+.docs-footnote {
+  margin-top: 32px;
+  font-size: 0.8rem;
+  font-style: italic;
+}
+
+@media (max-width: 720px) {
+  .docs-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .docs-nav {
+    position: static;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 12px;
   }
 }


### PR DESCRIPTION
Follows #198 (merged).

## What

A **docs section** for the site: `docs.html` is a full MLE reference — get started, a complete game, the game contract, a language tour, the prelude, builtins, and sharp edges — in the same synthwave theme, with client-side syntax highlighting (`src/docs.js`, a static-HTML mirror of the editor tokenizer).

**Every full program has a "▶ try it" button** that opens it live in the sandbox. That runs on a new inline-source path: docs link to `sandbox.html#src=<base64url>`; the sandbox seeds its editor from the fragment and points the player at `player.html?src=`, which hands the runtime a `data:` URL to fetch — so snippets start with a **fresh `init`** (unlike a set-source push, which deliberately preserves the running model). This is also the foundation for share-via-URL later.

## Screenshots

![The MLE reference](https://gist.githubusercontent.com/tommy-xr/24cbe63334ef96079a0c84e5e7478550/raw/docs-top.png)

<sub>The MLE reference</sub>

![try it — docs snippet in the sandbox](https://gist.githubusercontent.com/tommy-xr/24cbe63334ef96079a0c84e5e7478550/raw/docs-tryit.png)

<sub>▶ try it — a docs snippet opens live in the sandbox (fresh init via the `data:` URL path)</sub>

![docs → sandbox flow](https://gist.githubusercontent.com/tommy-xr/24cbe63334ef96079a0c84e5e7478550/raw/docs-flow.gif)

<sub>docs → sandbox flow</sub>

## Accuracy

The page documents the language against `.claude/skills/mle-language/SKILL.md` (the spec). All 13 MLE blocks typecheck standalone via `mle check`. Cross-engine review (Claude + Codex) verified the contract table, frame order, prelude signatures, and builtins against the spec and the runtime — including one catch where the effects claim was broader than what the runtime's `absorb` actually accepts (now scoped to the model-returning hooks).

## Verification

`npm run test:site` — 13/13 checks, including three new docs checks: MLE blocks highlight, try-it buttons exist, and a try-it program loads to live through the `#src=` → `data:` URL path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
