### PR TITLE
feat(runtime,game): cubemap skyboxes — a frame-level six-face sky

### DIFF
--- a/runtime/functor-runtime-common/src/asset/asset_handle.rs
+++ b/runtime/functor-runtime-common/src/asset/asset_handle.rs
@@ -13,17 +13,9 @@ pub struct AssetHandle<T> {
 
 impl<T> AssetHandle<T> {
     pub fn get(&self) -> Arc<T> {
-        let mut state = self.state.borrow_mut();
-        if let Some(asset_state) = state.take() {
-            let new_state = asset_state.ensure_loaded();
-            let ret = match &new_state {
-                AssetState::Loaded(asset) => asset.clone(),
-                AssetState::Loading(_) | AssetState::Failed => self.fallback_asset.clone(),
-            };
-            *state = Some(new_state);
-            ret
-        } else {
-            panic!("Should never happen")
+        match self.poll_state() {
+            AssetPollState::Loaded(asset) => asset,
+            AssetPollState::Loading | AssetPollState::Failed => self.fallback_asset.clone(),
         }
     }
 
@@ -36,6 +28,32 @@ impl<T> AssetHandle<T> {
             fallback_asset,
         }
     }
+
+    /// Advance a pending load and report the true state — unlike `get`, never
+    /// substitutes the fallback. For assets assembled from several files (a
+    /// cubemap's six faces) that must ALL be ready before GPU hydration.
+    pub fn poll_state(&self) -> AssetPollState<T> {
+        let mut state = self.state.borrow_mut();
+        if let Some(asset_state) = state.take() {
+            let new_state = asset_state.ensure_loaded();
+            let ret = match &new_state {
+                AssetState::Loaded(asset) => AssetPollState::Loaded(asset.clone()),
+                AssetState::Loading(_) => AssetPollState::Loading,
+                AssetState::Failed => AssetPollState::Failed,
+            };
+            *state = Some(new_state);
+            ret
+        } else {
+            panic!("Should never happen")
+        }
+    }
+}
+
+/// The observable state of an [`AssetHandle`], from [`AssetHandle::poll_state`].
+pub enum AssetPollState<T> {
+    Loading,
+    Loaded(Arc<T>),
+    Failed,
 }
 
 pub enum AssetState<T> {
@@ -73,5 +91,29 @@ impl<T> AssetState<T> {
         } else {
             self
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn poll_state_reports_loaded_without_fallback() {
+        let handle = AssetHandle::new(async { Ok(Arc::new(7)) }, Arc::new(0));
+        match handle.poll_state() {
+            AssetPollState::Loaded(v) => assert_eq!(*v, 7),
+            _ => panic!("expected Loaded"),
+        }
+        // get() agrees once loaded.
+        assert_eq!(*handle.get(), 7);
+    }
+
+    #[test]
+    fn poll_state_reports_failed_where_get_substitutes_the_fallback() {
+        let handle = AssetHandle::new(async { Err("nope".to_string()) }, Arc::new(42));
+        assert!(matches!(handle.poll_state(), AssetPollState::Failed));
+        // get() keeps its fallback contract.
+        assert_eq!(*handle.get(), 42);
     }
 }

--- a/runtime/functor-runtime-common/src/asset/pipelines/mod.rs
+++ b/runtime/functor-runtime-common/src/asset/pipelines/mod.rs
@@ -3,3 +3,6 @@ pub use texture_pipeline::*;
 
 mod model_pipeline;
 pub use model_pipeline::*;
+
+mod raw_image_pipeline;
+pub use raw_image_pipeline::*;

--- a/runtime/functor-runtime-common/src/asset/pipelines/raw_image_pipeline.rs
+++ b/runtime/functor-runtime-common/src/asset/pipelines/raw_image_pipeline.rs
@@ -1,0 +1,65 @@
+use crate::{
+    asset::{AssetCache, AssetPipeline},
+    texture::{PixelFormat, TextureData},
+};
+
+/// Decode an image file to raw pixels (`TextureData`) with NO GL hydration —
+/// for assets assembled from several files before a single GPU upload (a
+/// cubemap's six faces), where per-file `Texture2D`s would be wasted 2D
+/// textures. Decodes directly via the image crate (any format it recognizes,
+/// no sprite color-keying); an unrecognized or corrupt file becomes a 0×0
+/// sentinel the assembler treats as a failed face (`process` is infallible by
+/// trait, and a bad asset must warn-and-disable, never panic the runtime).
+pub struct RawImagePipeline;
+
+impl AssetPipeline<TextureData> for RawImagePipeline {
+    fn process(
+        &self,
+        bytes: Vec<u8>,
+        _asset_cache: &AssetCache,
+        _context: crate::asset::AssetPipelineContext,
+    ) -> TextureData {
+        match image::load_from_memory(&bytes) {
+            Ok(image) => TextureData::from_image(image),
+            Err(e) => {
+                eprintln!("[raw-image] cannot decode image: {e}");
+                TextureData {
+                    bytes: vec![],
+                    width: 0,
+                    height: 0,
+                    format: PixelFormat::RGBA,
+                }
+            }
+        }
+    }
+
+    fn unloaded_asset(&self, _context: crate::asset::AssetPipelineContext) -> TextureData {
+        TextureData::solid_color([128, 128, 128, 255])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::asset::AssetPipelineContext;
+
+    fn process(bytes: Vec<u8>) -> TextureData {
+        RawImagePipeline.process(bytes, &AssetCache::new(), AssetPipelineContext {})
+    }
+
+    // A recognized-but-corrupt file must become the 0x0 sentinel, not a panic
+    // (the render thread polls asset futures — a panic aborts the runtime).
+    #[test]
+    fn corrupt_image_becomes_the_sentinel() {
+        // A valid PNG magic with a truncated body.
+        let corrupt = vec![0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 0, 0];
+        let data = process(corrupt);
+        assert_eq!((data.width, data.height), (0, 0));
+    }
+
+    #[test]
+    fn unrecognized_bytes_become_the_sentinel() {
+        let data = process(vec![1, 2, 3, 4]);
+        assert_eq!((data.width, data.height), (0, 0));
+    }
+}

--- a/runtime/functor-runtime-common/src/frame.rs
+++ b/runtime/functor-runtime-common/src/frame.rs
@@ -1,7 +1,10 @@
 use fable_library_rust::NativeArray_::Array;
 use serde::{Deserialize, Serialize};
 
-use crate::{fog::Fog, render_target::RenderTargetDescriptor, Camera, Light, Scene3D};
+use crate::{
+    fog::Fog, render_target::RenderTargetDescriptor, skybox::SkyboxDescription, Camera, Light,
+    Scene3D,
+};
 
 /// A named offscreen pass: `frame` (its own camera/scene/lights) is rendered
 /// into `target`'s texture before the owning frame's main pass, and sampled via
@@ -28,6 +31,9 @@ pub struct Frame {
     /// Frame-level distance fog; its color also drives the pass's clear color.
     #[serde(default)]
     pub fog: Option<Fog>,
+    /// A cubemap skybox drawn behind everything (fog does not apply to it).
+    #[serde(default)]
+    pub skybox: Option<SkyboxDescription>,
 }
 
 impl Frame {
@@ -40,6 +46,7 @@ impl Frame {
             lights: vec![],
             render_targets: vec![],
             fog: None,
+            skybox: None,
         }
     }
 
@@ -50,6 +57,7 @@ impl Frame {
             lights: lights.to_vec(),
             render_targets: vec![],
             fog: None,
+            skybox: None,
         }
     }
 
@@ -73,6 +81,14 @@ impl Frame {
     /// first so it pipes (`frame |> Frame.withFog(fog)`).
     pub fn with_fog(mut frame: Frame, fog: Fog) -> Frame {
         frame.fog = Some(fog);
+        frame
+    }
+
+    /// A cubemap skybox for this frame's pass, drawn behind everything right
+    /// after the clear. Subject-first so it pipes
+    /// (`frame |> Frame.withSkybox(sky)`).
+    pub fn with_skybox(mut frame: Frame, skybox: SkyboxDescription) -> Frame {
+        frame.skybox = Some(skybox);
         frame
     }
 }

--- a/runtime/functor-runtime-common/src/lib.rs
+++ b/runtime/functor-runtime-common/src/lib.rs
@@ -92,6 +92,7 @@ mod renderer;
 mod scene3d;
 mod shader;
 pub mod shadow;
+pub mod skybox;
 mod shader_program;
 pub mod texture;
 pub mod ui;
@@ -108,6 +109,7 @@ pub use light::*;
 pub use render_context::*;
 pub use render_target::RenderTargetDescriptor;
 pub use renderer::*;
+pub use skybox::SkyboxDescription;
 pub use scene3d::*;
 pub use viewport::*;
 

--- a/runtime/functor-runtime-common/src/mle_prelude.rs
+++ b/runtime/functor-runtime-common/src/mle_prelude.rs
@@ -759,6 +759,7 @@ impl Host for FunctorHost {
                         lights: lit,
                         render_targets: vec![],
                         fog: None,
+                        skybox: None,
                     })))
                 }
                 _ => usage("Frame.createLit(camera, scene, [light, …])"),

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -252,6 +252,9 @@ mod tests {
                 frame: Frame::new(Camera::default(), Scene3D::cube()),
             }],
             fog: Some(crate::fog::Fog::linear(4.0, 30.0, 0.5, 0.6, 0.7)),
+            skybox: Some(crate::skybox::SkyboxDescription::new(
+                "px.jpg", "nx.jpg", "py.jpg", "ny.jpg", "pz.jpg", "nz.jpg",
+            )),
         };
         assert_json_stable(&frame);
 
@@ -265,6 +268,7 @@ mod tests {
         assert!(legacy.lights.is_empty());
         assert!(legacy.render_targets.is_empty());
         assert!(legacy.fog.is_none());
+        assert!(legacy.skybox.is_none());
     }
 
     // The render-target wire vocabulary: the reader (a texture by target id)
@@ -281,6 +285,17 @@ mod tests {
         assert_wire(
             &RenderTargetDescriptor::new("feed"),
             r#"{"id":"feed","width":512,"height":512}"#,
+        );
+    }
+
+    // The skybox wire vocabulary: six face paths in GL upload order.
+    #[test]
+    fn skybox_wire_is_pinned() {
+        use crate::skybox::SkyboxDescription;
+
+        assert_wire(
+            &SkyboxDescription::new("px.jpg", "nx.jpg", "py.jpg", "ny.jpg", "pz.jpg", "nz.jpg"),
+            r#"{"px":"px.jpg","nx":"nx.jpg","py":"py.jpg","ny":"ny.jpg","pz":"pz.jpg","nz":"nz.jpg"}"#,
         );
     }
 

--- a/runtime/functor-runtime-common/src/renderer.rs
+++ b/runtime/functor-runtime-common/src/renderer.rs
@@ -131,6 +131,7 @@ target frame are ignored (depth 1 only)",
             debug_render_mode,
             shadow,
             pass.frame.fog.as_ref(),
+            pass.frame.skybox.as_ref(),
             width as f32 / height as f32,
         );
         unsafe {
@@ -186,6 +187,7 @@ target frame are ignored (depth 1 only)",
         debug_render_mode,
         shadow,
         frame.fog.as_ref(),
+        frame.skybox.as_ref(),
         viewport.aspect(),
     );
 }
@@ -244,6 +246,7 @@ fn forward_pass(
     debug_render_mode: DebugRenderMode,
     shadow: Option<ShadowUniforms>,
     fog: Option<&crate::fog::Fog>,
+    skybox: Option<&crate::skybox::SkyboxDescription>,
     aspect: f32,
 ) {
     let render_context = RenderContext {
@@ -263,6 +266,12 @@ fn forward_pass(
     let world_matrix = Matrix4::identity();
     let view_matrix = camera.view_matrix();
     let projection_matrix = camera.projection_matrix(aspect);
+
+    // The skybox draws first, behind everything (it writes no depth); fog
+    // does not apply to it — the sky IS the horizon.
+    if let Some(desc) = skybox {
+        scene_context.draw_skybox(&render_context, desc, &projection_matrix, &view_matrix);
+    }
 
     // Root material for nodes that don't set their own (scenes typically override
     // per-node); initialized against this frame's context.

--- a/runtime/functor-runtime-common/src/scene3d/mod.rs
+++ b/runtime/functor-runtime-common/src/scene3d/mod.rs
@@ -11,8 +11,8 @@ use fable_library_rust::NativeArray_::Array;
 use crate::{
     asset::{
         self,
-        pipelines::{ModelPipeline, TexturePipeline},
-        AssetHandle, BuiltAssetPipeline,
+        pipelines::{ModelPipeline, RawImagePipeline, TexturePipeline},
+        AssetCache, AssetHandle, AssetPollState, BuiltAssetPipeline,
     },
     geometry::{self, Geometry},
     material::{
@@ -23,7 +23,10 @@ use crate::{
     math::Angle,
     model::{Model, Skeleton},
     render_target::{warn_line, RenderTargetBuffers, RenderTargetDescriptor},
-    texture::{RuntimeTexture, Texture2D},
+    shader::{Shader, ShaderType},
+    shader_program::{ShaderProgram, UniformLocation},
+    skybox::{SkyboxDescription, SKYBOX_FRAGMENT_SHADER_SOURCE, SKYBOX_VERTEX_SHADER_SOURCE},
+    texture::{RuntimeTexture, Texture2D, TextureData},
     DebugRenderMode, RenderContext, RenderPass,
 };
 
@@ -52,6 +55,27 @@ pub struct SceneContext {
     render_targets: RefCell<HashMap<String, RenderTargetBuffers>>,
     render_target_warned: RefCell<HashSet<String>>,
     fallback_texture: RefCell<Option<glow::Texture>>,
+    // Cubemap skyboxes, keyed by the joined six face paths. Like render
+    // targets they persist across frames/hot reloads and are never evicted
+    // (TODO). Faces decode through `raw_image_pipeline` (no GL hydration);
+    // the cubemap uploads once when all six are ready.
+    raw_image_pipeline: Arc<BuiltAssetPipeline<TextureData>>,
+    skyboxes: RefCell<HashMap<String, SkyboxEntry>>,
+    skybox_program: RefCell<Option<(ShaderProgram, SkyboxUniforms)>>,
+}
+
+enum SkyboxEntry {
+    /// Six pending face loads, in `SkyboxDescription::faces` order.
+    Loading(Vec<Arc<AssetHandle<TextureData>>>),
+    Ready(glow::Texture),
+    /// A face failed to load or validate; warned once, never retried.
+    Failed,
+}
+
+struct SkyboxUniforms {
+    view_loc: UniformLocation,
+    projection_loc: UniformLocation,
+    skybox_loc: UniformLocation,
 }
 
 impl SceneContext {
@@ -68,6 +92,9 @@ impl SceneContext {
             render_targets: RefCell::new(HashMap::new()),
             render_target_warned: RefCell::new(HashSet::new()),
             fallback_texture: RefCell::new(None),
+            raw_image_pipeline: asset::build_pipeline(Box::new(RawImagePipeline)),
+            skyboxes: RefCell::new(HashMap::new()),
+            skybox_program: RefCell::new(None),
         }
     }
 
@@ -151,6 +178,198 @@ impl SceneContext {
     pub fn warn_once(&self, key: &str, message: &str) {
         if self.render_target_warned.borrow_mut().insert(key.to_string()) {
             warn_line(message);
+        }
+    }
+
+    /// The cubemap for `desc`, once all six faces have loaded. `None` while
+    /// faces are still loading (skip the draw — the clear color shows) or
+    /// after a failure (warned once, never retried).
+    fn skybox_texture(
+        &self,
+        gl: &glow::Context,
+        asset_cache: &Arc<AssetCache>,
+        desc: &SkyboxDescription,
+    ) -> Option<glow::Texture> {
+        let key = desc.faces().join("\n");
+        let mut skyboxes = self.skyboxes.borrow_mut();
+        let entry = skyboxes.entry(key.clone()).or_insert_with(|| {
+            SkyboxEntry::Loading(
+                desc.faces()
+                    .iter()
+                    .map(|path| {
+                        asset_cache
+                            .load_asset_with_pipeline(self.raw_image_pipeline.clone(), path)
+                    })
+                    .collect(),
+            )
+        });
+
+        match entry {
+            SkyboxEntry::Ready(texture) => Some(*texture),
+            SkyboxEntry::Failed => None,
+            SkyboxEntry::Loading(handles) => {
+                // Poll EVERY handle each call: futures only advance when
+                // polled (noop waker), and a wasm fetch doesn't even start
+                // until its first poll — an early return on the first
+                // pending face would serialize the six downloads.
+                let mut faces: Vec<Arc<TextureData>> = Vec::with_capacity(6);
+                let mut pending = false;
+                let mut failed: Option<&str> = None;
+                for (handle, path) in handles.iter().zip(desc.faces()) {
+                    match handle.poll_state() {
+                        AssetPollState::Loaded(data) => faces.push(data),
+                        AssetPollState::Loading => pending = true,
+                        AssetPollState::Failed => failed = Some(path),
+                    }
+                }
+                if let Some(path) = failed {
+                    let message = format!(
+                        "[skybox] face \"{path}\" failed to load — skybox \
+disabled for this set"
+                    );
+                    *entry = SkyboxEntry::Failed;
+                    drop(skyboxes);
+                    self.warn_once(&key, &message);
+                    return None;
+                }
+                if pending {
+                    return None;
+                }
+                // All six decoded: validate (square, uniform, non-empty —
+                // a 0x0 face is the raw pipeline's undecodable sentinel).
+                let (w, h) = (faces[0].width, faces[0].height);
+                let valid =
+                    w > 0 && w == h && faces.iter().all(|f| f.width == w && f.height == h);
+                if !valid {
+                    *entry = SkyboxEntry::Failed;
+                    drop(skyboxes);
+                    self.warn_once(
+                        &key,
+                        "[skybox] faces must all be square and the same size — \
+skybox disabled for this set",
+                    );
+                    return None;
+                }
+                let texture = unsafe {
+                    let texture = gl.create_texture().expect("skybox cubemap");
+                    gl.bind_texture(glow::TEXTURE_CUBE_MAP, Some(texture));
+                    for (i, face) in faces.iter().enumerate() {
+                        gl.tex_image_2d(
+                            glow::TEXTURE_CUBE_MAP_POSITIVE_X + i as u32,
+                            0,
+                            glow::RGBA8 as i32,
+                            w as i32,
+                            h as i32,
+                            0,
+                            glow::RGBA,
+                            glow::UNSIGNED_BYTE,
+                            glow::PixelUnpackData::Slice(Some(&face.bytes)),
+                        );
+                    }
+                    gl.tex_parameter_i32(
+                        glow::TEXTURE_CUBE_MAP,
+                        glow::TEXTURE_MIN_FILTER,
+                        glow::LINEAR as i32,
+                    );
+                    gl.tex_parameter_i32(
+                        glow::TEXTURE_CUBE_MAP,
+                        glow::TEXTURE_MAG_FILTER,
+                        glow::LINEAR as i32,
+                    );
+                    // Single declared mip level: unambiguously complete (the
+                    // ShadowMap/render-target macOS recipe).
+                    gl.tex_parameter_i32(glow::TEXTURE_CUBE_MAP, glow::TEXTURE_BASE_LEVEL, 0);
+                    gl.tex_parameter_i32(glow::TEXTURE_CUBE_MAP, glow::TEXTURE_MAX_LEVEL, 0);
+                    gl.tex_parameter_i32(
+                        glow::TEXTURE_CUBE_MAP,
+                        glow::TEXTURE_WRAP_S,
+                        glow::CLAMP_TO_EDGE as i32,
+                    );
+                    gl.tex_parameter_i32(
+                        glow::TEXTURE_CUBE_MAP,
+                        glow::TEXTURE_WRAP_T,
+                        glow::CLAMP_TO_EDGE as i32,
+                    );
+                    gl.tex_parameter_i32(
+                        glow::TEXTURE_CUBE_MAP,
+                        glow::TEXTURE_WRAP_R,
+                        glow::CLAMP_TO_EDGE as i32,
+                    );
+                    gl.bind_texture(glow::TEXTURE_CUBE_MAP, None);
+                    texture
+                };
+                *entry = SkyboxEntry::Ready(texture);
+                Some(texture)
+            }
+        }
+    }
+
+    /// Draw `desc`'s skybox: right after the pass's clear, before
+    /// `Scene3D::render`. The unit cube is drawn from the inside (this
+    /// engine never enables face culling), glued to the camera by a
+    /// translation-stripped view, at NDC depth 1.0 (`gl_Position.xyww`) —
+    /// LEQUAL lets it pass against the cleared depth, and `depth_mask(false)`
+    /// keeps it from occluding anything. Skipped (clear color shows) while
+    /// faces load or after a face failure.
+    pub fn draw_skybox(
+        &self,
+        render_context: &RenderContext,
+        desc: &SkyboxDescription,
+        projection_matrix: &Matrix4<f32>,
+        view_matrix: &Matrix4<f32>,
+    ) {
+        let gl = render_context.gl;
+        let Some(texture) = self.skybox_texture(gl, &render_context.asset_cache, desc) else {
+            return;
+        };
+
+        {
+            let mut program = self.skybox_program.borrow_mut();
+            if program.is_none() {
+                let vertex = Shader::build(
+                    gl,
+                    ShaderType::Vertex,
+                    SKYBOX_VERTEX_SHADER_SOURCE,
+                    render_context.shader_version,
+                );
+                let fragment = Shader::build(
+                    gl,
+                    ShaderType::Fragment,
+                    SKYBOX_FRAGMENT_SHADER_SOURCE,
+                    render_context.shader_version,
+                );
+                let shader = ShaderProgram::link(gl, &vertex, &fragment);
+                let uniforms = SkyboxUniforms {
+                    view_loc: shader.get_uniform_location(gl, "view"),
+                    projection_loc: shader.get_uniform_location(gl, "projection"),
+                    skybox_loc: shader.get_uniform_location(gl, "skybox"),
+                };
+                *program = Some((shader, uniforms));
+            }
+        }
+
+        // Strip the view translation so the box is centered on the camera.
+        let mut view = *view_matrix;
+        view.w = cgmath::vec4(0.0, 0.0, 0.0, 1.0);
+
+        let program = self.skybox_program.borrow();
+        let (shader, uniforms) = program.as_ref().expect("skybox program just initialized");
+        unsafe {
+            shader.use_program(gl);
+            shader.set_uniform_matrix4(gl, &uniforms.view_loc, &view);
+            shader.set_uniform_matrix4(gl, &uniforms.projection_loc, projection_matrix);
+            shader.set_uniform_1i(gl, &uniforms.skybox_loc, 0);
+            gl.active_texture(glow::TEXTURE0);
+            gl.bind_texture(glow::TEXTURE_CUBE_MAP, Some(texture));
+
+            gl.depth_func(glow::LEQUAL);
+            gl.depth_mask(false);
+        }
+        self.cube.borrow_mut().draw(gl);
+        unsafe {
+            gl.depth_mask(true);
+            gl.depth_func(glow::LESS);
+            gl.bind_texture(glow::TEXTURE_CUBE_MAP, None);
         }
     }
 }

--- a/runtime/functor-runtime-common/src/skybox.rs
+++ b/runtime/functor-runtime-common/src/skybox.rs
@@ -1,0 +1,106 @@
+use fable_library_rust::String_::LrcStr;
+use serde::{Deserialize, Serialize};
+
+/// The six faces of a cubemap skybox, by asset path (+X, -X, +Y, -Y, +Z, -Z —
+/// the GL `TEXTURE_CUBE_MAP_POSITIVE_X + i` upload order). Frame-level: drawn
+/// behind everything right after the pass's clear, so render-target inner
+/// frames can carry their own sky. While the faces load, the pass's clear
+/// color shows; a face that fails to load disables the skybox with one
+/// warning. Fog does NOT apply to the skybox — it IS the horizon.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SkyboxDescription {
+    pub px: String,
+    pub nx: String,
+    pub py: String,
+    pub ny: String,
+    pub pz: String,
+    pub nz: String,
+}
+
+impl SkyboxDescription {
+    pub fn new(
+        px: impl Into<String>,
+        nx: impl Into<String>,
+        py: impl Into<String>,
+        ny: impl Into<String>,
+        pz: impl Into<String>,
+        nz: impl Into<String>,
+    ) -> SkyboxDescription {
+        SkyboxDescription {
+            px: px.into(),
+            nx: nx.into(),
+            py: py.into(),
+            ny: ny.into(),
+            pz: pz.into(),
+            nz: nz.into(),
+        }
+    }
+
+    /// F# boundary constructor (the `TextureDescription::file` shim style).
+    pub fn files(
+        px: LrcStr,
+        nx: LrcStr,
+        py: LrcStr,
+        ny: LrcStr,
+        pz: LrcStr,
+        nz: LrcStr,
+    ) -> SkyboxDescription {
+        SkyboxDescription::new(
+            px.to_string(),
+            nx.to_string(),
+            py.to_string(),
+            ny.to_string(),
+            pz.to_string(),
+            nz.to_string(),
+        )
+    }
+
+    /// The faces in GL upload order (`TEXTURE_CUBE_MAP_POSITIVE_X + i`).
+    pub fn faces(&self) -> [&str; 6] {
+        [&self.px, &self.nx, &self.py, &self.ny, &self.pz, &self.nz]
+    }
+}
+
+// The skybox draw's shaders (used by `SceneContext::draw_skybox`). The unit
+// cube's positions double as the cubemap sample direction; the view matrix
+// arrives translation-stripped, so the box is glued to the camera.
+pub const SKYBOX_VERTEX_SHADER_SOURCE: &str = r#"
+        layout (location = 0) in vec3 inPos;
+
+        uniform mat4 view;        // rotation-only (translation stripped CPU-side)
+        uniform mat4 projection;
+
+        out vec3 texDir;
+
+        void main() {
+            texDir = inPos;
+            vec4 pos = projection * view * vec4(inPos, 1.0);
+            // z = w -> NDC depth exactly 1.0: never near/far-clipped regardless
+            // of the camera's near plane (the cube's size is irrelevant), and
+            // it passes the LEQUAL depth test against the cleared 1.0.
+            gl_Position = pos.xyww;
+        }
+"#;
+
+pub const SKYBOX_FRAGMENT_SHADER_SOURCE: &str = r#"
+        out vec4 fragColor;
+
+        in vec3 texDir;
+
+        uniform samplerCube skybox;
+
+        void main() {
+            fragColor = texture(skybox, texDir);
+        }
+"#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn faces_are_in_gl_upload_order() {
+        let sky = SkyboxDescription::new("px", "nx", "py", "ny", "pz", "nz");
+        assert_eq!(sky.faces(), ["px", "nx", "py", "ny", "pz", "nz"]);
+    }
+}

--- a/src/Functor.Game/Frame.fs
+++ b/src/Functor.Game/Frame.fs
@@ -30,3 +30,8 @@ module Frame =
     /// overlay mode shades normally, so fog applies there.
     [<Emit("functor_runtime_common::Frame::with_fog($1, $0)")>]
     let withFog (fog: Fog) (frame: Frame): Frame = nativeOnly
+
+    /// A cubemap skybox drawn behind everything, right after the frame's
+    /// clear (render-target inner frames can carry their own).
+    [<Emit("functor_runtime_common::Frame::with_skybox($1, $0)")>]
+    let withSkybox (skybox: Skybox) (frame: Frame): Frame = nativeOnly

--- a/src/Functor.Game/Scene3D.fs
+++ b/src/Functor.Game/Scene3D.fs
@@ -22,6 +22,7 @@ type SpotLight =
 [<Erase; Emit("functor_runtime_common::Light")>] type Light = | Noop
 [<Erase; Emit("functor_runtime_common::RenderTargetDescriptor")>] type RenderTarget = | Noop
 [<Erase; Emit("functor_runtime_common::Fog")>] type Fog = | Noop
+[<Erase; Emit("functor_runtime_common::SkyboxDescription")>] type Skybox = | Noop
 
 module Scene3D =
 
@@ -172,6 +173,14 @@ module Scene3D =
         /// atmospheric falloff.
         let exp (density: float32) (color: Color): Fog =
             expRaw (density, color.r, color.g, color.b)
+
+    module Skybox =
+        /// The six cube faces by path (+X, -X, +Y, -Y, +Z, -Z), fetched like
+        /// any file texture. While the faces load, the frame's clear color
+        /// shows; a face that fails to load disables the skybox with one
+        /// warning. Fog does not apply to the skybox — it IS the horizon.
+        [<Emit("functor_runtime_common::SkyboxDescription::files($0, $1, $2, $3, $4, $5)")>]
+        let files (px: string) (nx: string) (py: string) (ny: string) (pz: string) (nz: string): Skybox = nativeOnly
 
     module RenderTarget =
         /// A named offscreen render target, 512x512 until piped through `sized`.


### PR DESCRIPTION
Third of the atmosphere stack (#201 fog engine → #202 fog MLE → this → skybox MLE + demo). Adds **cubemap skyboxes**:

```fsharp
let sky = Skybox.files "sky_px.jpg" "sky_nx.jpg" "sky_py.jpg" "sky_ny.jpg" "sky_pz.jpg" "sky_nz.jpg"
frame |> Frame.withSkybox sky
```

## Design

- `SkyboxDescription { px..nz }` (the BabylonJS six-face convention, GL upload order) rides on `Frame` (`#[serde(default)]`, wire-pinned) — render-target inner frames can carry their own sky. Fog does **not** apply to the skybox: it *is* the horizon.
- **Loading**: a decode-only `RawImagePipeline` (`AssetPipeline<TextureData>` — any image-crate format, no sprite color-keying, and a corrupt/unrecognized file becomes a 0×0 sentinel instead of a panic) plus the new `AssetHandle::poll_state`, which reports true `Loading/Loaded/Failed` instead of `get()`'s fallback substitution — a cubemap needs all six faces before one GPU upload. All six handles are polled every frame (futures only advance when polled; wasm fetches start on first poll — polling all six keeps the downloads parallel). `SceneContext` caches the built cubemap by the joined face paths (survives hot reloads, the render-target pattern). While loading, the pass's clear color shows; a failed/invalid face (non-square, mismatched, undecodable) disables that sky with one warning.
- **Draw**: the shared unit cube from inside (face culling is never enabled in this engine), translation-stripped view, `gl_Position.xyww` (NDC depth exactly 1.0 — immune to near-plane clipping, passes LEQUAL against the cleared depth), `depth_mask(false)` around the draw, state restored; scissor deliberately inherited from the pane. Cubemap upload uses the ShadowMap macOS-completeness recipe (single declared mip, CLAMP_TO_EDGE on S/T/R).

## Verification

- `cargo test -p functor_runtime_common` — 151 passed (`poll_state` semantics, sentinel decode incl. a corrupt-PNG regression test, wire pins, `faces()` order).
- `npm run build:cli` — native + wasm compile (`samplerCube` has a default precision in GLSL ES 3.00).
- Temporary `hello` caller (built + rendered + reverted): the TropicalSunnyDay sky wraps the horizon right-side-up behind the scene — screenshot below. Untouched frames render exactly as before (the draw only runs when `Frame.skybox` is `Some`).
- Cross-engine review (`/xreview`, Claude + Codex): fixes applied — decode-directly-in-pipeline [AGREED: corrupt faces panicked via the shared loader's `expect`; also bypasses sprite color-keying that would have eaten cyan sky pixels], poll-all-six-faces (wasm downloads were serialized), and `get()` deduplicated onto `poll_state`.
- Known follow-up: face-orientation evidence is one heading; the stacked MLE demo PR captures multiple headings via its orbiting camera.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Before → after

![before/after: hello without and with skybox](https://gist.githubusercontent.com/tommy-xr/39d58b703637e9db5eb4ed072c644606/raw/sky-beforeafter.png)

<sub>hello at the same `--fixed-time 2.0`: left no skybox (clear color), right with a temporary TropicalSunnyDay `Skybox.files` caller — the cubemap sky wraps the horizon behind the terrain. Captured headlessly; the caller was reverted (the sample is golden-pinned).</sub>
