### PR TITLE
feat(physics,mle): Phase 4 — Physics.raycast as a deferred tagger effect

### DIFF
--- a/.claude/skills/mle-language/SKILL.md
+++ b/.claude/skills/mle-language/SKILL.md
@@ -257,11 +257,6 @@ another query answers immediately (the world already stepped). Under the
 fake/replay runners raycasts are canned/recorded — physics-query logic is
 testable with no world at all.
 
-**B7 gotcha — effect-returning entry points**: mixing bare-`model` arms
-with `(model, effect)` arms in one match trips the occurs check
-(`'a = 'a * Unknown`), and `mle check` (= `functor build`) fails. Until
-the `effect[...]` header work lands, return tuples UNIFORMLY, padding with
-`Effect.none()`: `| _ => (model, Effect.none())`.
 
 A runner-hosted game (`functor-runner --mle --game-path game.mle`) defines:
 

--- a/.claude/skills/mle-language/SKILL.md
+++ b/.claude/skills/mle-language/SKILL.md
@@ -217,6 +217,10 @@ scene |> Physics.transformed("tag")                        // scene at the body'
 Physics.applyImpulse("tag", x, y, z)                       // -> Effect (fire-and-forget)
 Physics.applyForce("tag", x, y, z)                         //   force lasts ONE stepped frame
 Physics.setVelocity("tag", x, y, z) / Physics.teleport("tag", x, y, z)
+Physics.raycast(ox, oy, oz, dx, dy, dz, maxDist, tagger)   // -> Effect (QUERY): tagger gets
+                                                           //   {hit, x, y, z, nx, ny, nz,
+                                                           //    distance, tag} — hit: false
+                                                           //   (zeroed) for a miss
 ```
 
 `Physics.position` / `Physics.transformed` read the live stepped world
@@ -233,9 +237,31 @@ tagger: nothing folds back through `update`; observe outcomes via the
 physics reads. Commands queue at perform time and apply at the next
 stepped frame's first substep, **after reconcile** — so declaring a body
 and commanding it in the same frame works. A command naming an unknown tag
-is a deduped `[mle]` warning, not an error (the body may have despawned in
-flight). `teleport` moves the live body without touching its declaration
-(no snap-back next frame).
+(or a non-dynamic body) is a deduped `[mle]` warning, not an error (the
+body may have despawned in flight). `teleport` moves the live body without
+touching its declaration (no snap-back next frame). Command effects need
+no `update` hook (they produce no message).
+
+`Physics.raycast` is a **query effect**: DEFERRED through the frame's
+pre-step drains and performed right after the physics step — "commands
+apply at the step; queries answer after it" — so the tagger's record
+answers against THIS frame's fresh world, and any model change it causes
+is visible in this frame's `draw`. (On a frame where the fixed-step
+accumulator takes zero substeps — normal at >60fps — queries carry to the
+next simulated frame, like pending commands: they never answer against a
+world that hasn't stepped.) Rays see sensor colliders too — a trigger
+volume can occlude the solid body behind it. The tagger may be a plain closure
+(`(hit) => hit` makes the record itself the message) or a ctor. A `GotHit`
+handler chaining a command queues it for next frame's step; chaining
+another query answers immediately (the world already stepped). Under the
+fake/replay runners raycasts are canned/recorded — physics-query logic is
+testable with no world at all.
+
+**B7 gotcha — effect-returning entry points**: mixing bare-`model` arms
+with `(model, effect)` arms in one match trips the occurs check
+(`'a = 'a * Unknown`), and `mle check` (= `functor build`) fails. Until
+the `effect[...]` header work lands, return tuples UNIFORMLY, padding with
+`Effect.none()`: `| _ => (model, Effect.none())`.
 
 A runner-hosted game (`functor-runner --mle --game-path game.mle`) defines:
 

--- a/docs/physics.md
+++ b/docs/physics.md
@@ -182,7 +182,17 @@ module Physics =
     let teleport     (tag: string) (pos: Vector3)     : effect<'msg>
 ```
 
-**Queries — async tagger** (the `Effect.httpGet` shape: token-keyed registry,
+**Queries — tagger effects.** *Shipped (Phase 4) on the MLE surface*:
+`Physics.raycast(ox, oy, oz, dx, dy, dz, maxDist, tagger)` — the tagger
+receives `{hit: Bool, x, y, z, nx, ny, nz, distance, tag}`. Queries are
+**deferred**: held through the frame's pre-step effect drains and performed
+right after the physics step, their messages folding through a second
+`update` pass before `draw` — "commands apply at the step; queries answer
+after it" — so results are same-frame **fresh** (the staleness the original
+frame order implied is designed out). Results ride the B6.5 structured effect
+log, so the fake/replay runners can can/replay raycasts — physics-query logic
+is testable without a world. `shapeCast` follows the same seam later. The F#
+sketch (the `Effect.httpGet` shape: token-keyed registry,
 result delivered as a message next drain):
 
 ```fsharp
@@ -627,7 +637,7 @@ It's worth building in two steps, because they exercise different machinery:
 | **2c. `examples/mle-physics`** | Crates settling on a ground slab, hot-reload demo, golden scenario, PR GIF/PNG. | native (MLE) |
 | **2b. Debug visualization** | Rapier `debug-render` feature, `World::debug_lines()`, depth-tested line pass, `--debug-render physics` mode. **Shipped.** | native |
 | **3. Commands** | `Physics.applyImpulse`/`applyForce`/`setVelocity`/`teleport` as B6 effect variants: queued at perform time, applied after the frame's reconcile before its first substep; forces last one stepped frame; recorded as `timeline::Command::Apply` in the goldens. **Shipped (MLE).** | native+wasm (MLE) |
-| **4. Queries** | `raycast`/`shapeCast` (async tagger, token registry). | both |
+| **4. Queries** | `Physics.raycast` as a deferred tagger effect over the B6.5 structured-payload broker (`EffectValue`); performed post-step for same-frame freshness; fake/replay runners can raycasts. `shapeCast` deferred until a game needs it. **Shipped (MLE).** | native+wasm (MLE) |
 | **5. Collision events** | `Physics.events` sub. | both |
 | **5b. Entity abstraction** | `Entities<'e>` + `Archetype` model-layer library, `Scene3D.instances` primitive, reconcile bail-out + tag interning, despawn-on-collision; `hello-physics` grows a bullet/debris archetype. | both |
 | **6. Pause/rewind/replay** | timeline-control effects + keyboard wiring + egui status overlay (the culmination). | both |

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -104,12 +104,6 @@ behind a `GameProducer` trait until MLE wins). Language design notes live in
 - [ ] Track C: MLE behind the seam — prelude, `MleProducer` + mle-hello golden,
       hot-reload payoff demo, MVU parity, wasm, perf gate (C1–C6).
 - [ ] Endgame: port examples, then delete the F#/Fable pipeline (E1–E3).
-- [ ] B7 regression: mixing bare-`model` and `(model, effect)` match arms in an
-      entry point trips the occurs check (`'a = 'a * Unknown`), rejecting the
-      documented B6 contract — a legal dynamic program fails `mle check` /
-      `functor build`. Workaround (uniform tuple arms + `Effect.none()`) is in
-      the mle-language skill and `examples/mle-physics`; the `effect[...]`
-      header work is the planned fix.
 
 ## Live variables / fast iteration
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -104,6 +104,12 @@ behind a `GameProducer` trait until MLE wins). Language design notes live in
 - [ ] Track C: MLE behind the seam — prelude, `MleProducer` + mle-hello golden,
       hot-reload payoff demo, MVU parity, wasm, perf gate (C1–C6).
 - [ ] Endgame: port examples, then delete the F#/Fable pipeline (E1–E3).
+- [ ] B7 regression: mixing bare-`model` and `(model, effect)` match arms in an
+      entry point trips the occurs check (`'a = 'a * Unknown`), rejecting the
+      documented B6 contract — a legal dynamic program fails `mle check` /
+      `functor build`. Workaround (uniform tuple arms + `Effect.none()`) is in
+      the mle-language skill and `examples/mle-physics`; the `effect[...]`
+      header work is the planned fix.
 
 ## Live variables / fast iteration
 

--- a/examples/mle-physics/game.mle
+++ b/examples/mle-physics/game.mle
@@ -1,9 +1,12 @@
-// mle-physics — the reference physics example (docs/physics.md, Phase 2c+3).
+// mle-physics — the reference physics example (docs/physics.md, Phase 2c+3+4).
 // Crates and a ball tumble onto a slab, drawn at their live simulated poses
 // via Physics.transformed. Press SPACE to re-drop everything: the changed
 // declared spawn poses teleport the bodies (the divergence rule) and the
 // pile falls again. Press K to KICK the ball — a Physics.applyImpulse
-// effect, returned beside the model, applied at the next physics step. Run
+// effect, returned beside the model, applied at the next physics step.
+// Press R to fire a RAY straight down over the pile: the raycast's result
+// record folds through `update`, which kicks whatever the ray hit — a query
+// chaining into a command, answered against this frame's stepped world. Run
 // with:
 //
 //   functor-runner --mle --game-path examples/mle-physics/game.mle
@@ -63,21 +66,47 @@ let tick = (model, dt, tts) => model
 // Rising-edge detection: GLFW delivers key REPEATS as `isDown = true` too,
 // so holding SPACE would re-drop every repeat without the spaceHeld latch.
 // The kick fires on K's RELEASE instead — key-ups never repeat, so no latch
-// is needed; it returns `(model, effect)`, the B6 effect shape.
+// is needed. Every arm returns `(model, effect)` UNIFORMLY (with
+// Effect.none() where there is nothing to do): mixing bare-model and
+// tupled arms trips the B7 checker's occurs check ('a = 'a * Unknown) —
+// see the mle-language skill's "B7 gotcha"; the effect[...] header work
+// (docs/mle.md) is the planned fix.
 let input = (model, key, isDown) =>
   match key with
   | "Space" =>
     (match isDown with
-     | false => { model with spaceHeld: false }
+     | false => ({ model with spaceHeld: false }, Effect.none())
      | true =>
        (match model.spaceHeld with
-        | true => model
-        | false => { model with drop: model.drop + 1.0, spaceHeld: true }))
+        | true => (model, Effect.none())
+        | false => ({ model with drop: model.drop + 1.0, spaceHeld: true }, Effect.none())))
   | "K" =>
     (match isDown with
-     | true => model
+     | true => (model, Effect.none())
      | false => (model, Physics.applyImpulse("ball", 0.0, 5.5, 0.0)))
-  | _ => model
+  | "R" =>
+    (match isDown with
+     | true => (model, Effect.none())
+     | false =>
+       // Aim straight down over THIS generation's crate-0 spawn — effect
+       // arguments are ordinary expressions of the model. The tagger is a
+       // plain closure, so the result record IS the message.
+       (model,
+        Physics.raycast(scatterX(model.drop, 0.0), 8.0, scatterZ(model.drop, 0.0),
+                        0.0, -1.0, 0.0, 20.0, (hit) => hit)))
+  | _ => (model, Effect.none())
+
+// Receives the raycast result after this frame's physics step (fresh —
+// "commands apply at the step; queries answer after it"): kick whatever the
+// ray hit. Misses leave the model alone, and so does the slab — kicking a
+// fixed body would just warn.
+let update = (model, msg) =>
+  match msg.hit with
+  | false => (model, Effect.none())
+  | true =>
+    (match msg.tag == "ground" with
+     | true => (model, Effect.none())
+     | false => (model, Physics.applyImpulse(msg.tag, 0.0, 6.0, 0.0)))
 
 let draw = (model, tts) =>
   Frame.createLit(

--- a/examples/mle-physics/game.mle
+++ b/examples/mle-physics/game.mle
@@ -66,27 +66,23 @@ let tick = (model, dt, tts) => model
 // Rising-edge detection: GLFW delivers key REPEATS as `isDown = true` too,
 // so holding SPACE would re-drop every repeat without the spaceHeld latch.
 // The kick fires on K's RELEASE instead — key-ups never repeat, so no latch
-// is needed. Every arm returns `(model, effect)` UNIFORMLY (with
-// Effect.none() where there is nothing to do): mixing bare-model and
-// tupled arms trips the B7 checker's occurs check ('a = 'a * Unknown) —
-// see the mle-language skill's "B7 gotcha"; the effect[...] header work
-// (docs/mle.md) is the planned fix.
+// is needed; arms mix plain-model and (model, effect) returns freely.
 let input = (model, key, isDown) =>
   match key with
   | "Space" =>
     (match isDown with
-     | false => ({ model with spaceHeld: false }, Effect.none())
+     | false => { model with spaceHeld: false }
      | true =>
        (match model.spaceHeld with
-        | true => (model, Effect.none())
-        | false => ({ model with drop: model.drop + 1.0, spaceHeld: true }, Effect.none())))
+        | true => model
+        | false => { model with drop: model.drop + 1.0, spaceHeld: true }))
   | "K" =>
     (match isDown with
-     | true => (model, Effect.none())
+     | true => model
      | false => (model, Physics.applyImpulse("ball", 0.0, 5.5, 0.0)))
   | "R" =>
     (match isDown with
-     | true => (model, Effect.none())
+     | true => model
      | false =>
        // Aim straight down over THIS generation's crate-0 spawn — effect
        // arguments are ordinary expressions of the model. The tagger is a
@@ -94,7 +90,7 @@ let input = (model, key, isDown) =>
        (model,
         Physics.raycast(scatterX(model.drop, 0.0), 8.0, scatterZ(model.drop, 0.0),
                         0.0, -1.0, 0.0, 20.0, (hit) => hit)))
-  | _ => (model, Effect.none())
+  | _ => model
 
 // Receives the raycast result after this frame's physics step (fresh —
 // "commands apply at the step; queries answer after it"): kick whatever the
@@ -102,10 +98,10 @@ let input = (model, key, isDown) =>
 // fixed body would just warn.
 let update = (model, msg) =>
   match msg.hit with
-  | false => (model, Effect.none())
+  | false => model
   | true =>
     (match msg.tag == "ground" with
-     | true => (model, Effect.none())
+     | true => model
      | false => (model, Physics.applyImpulse(msg.tag, 0.0, 6.0, 0.0)))
 
 let draw = (model, tts) =>

--- a/runtime/functor-runtime-common/src/mle_prelude.rs
+++ b/runtime/functor-runtime-common/src/mle_prelude.rs
@@ -171,6 +171,17 @@ pub enum EffectTree {
     /// The game observes the outcome through the physics reads, not a
     /// message.
     Physics(physics::PhysicsCommand),
+    /// A physics query (docs/physics.md Phase 4). Unlike `Now`/`Random`,
+    /// queries are **deferred**: the pre-step drain holds them and the
+    /// driver performs them right after the frame's physics step, so the
+    /// tagger's record answers against the FRESH world ("commands apply at
+    /// the step; queries answer after it").
+    Raycast {
+        origin: [f32; 3],
+        dir: [f32; 3],
+        max_dist: f32,
+        tagger: Value,
+    },
 }
 
 pub struct MleEffect(pub EffectTree);
@@ -181,6 +192,31 @@ pub struct MleEffect(pub EffectTree);
 pub trait EffectRunner {
     fn now(&mut self) -> f64;
     fn random(&mut self) -> f64;
+    /// The raycast result record (`{hit, x, y, z, nx, ny, nz, distance,
+    /// tag}` — `hit: false` with zeroed fields for a miss). `Real` asks the
+    /// singleton physics world; `Fake`/`Replay` return canned/recorded
+    /// records — physics queries are testable without a world at all.
+    fn raycast(&mut self, origin: [f32; 3], dir: [f32; 3], max_dist: f32) -> EffectValue;
+}
+
+/// The tagger-facing record for a raycast result. Always the full shape —
+/// `hit: Bool` discriminates — so field access typechecks on both arms.
+pub fn ray_result_value(hit: Option<physics::RayHit>) -> EffectValue {
+    let (h, p, n, d, tag) = match hit {
+        Some(hit) => (true, hit.position, hit.normal, hit.distance, hit.tag),
+        None => (false, [0.0; 3], [0.0; 3], 0.0, String::new()),
+    };
+    EffectValue::Record(vec![
+        ("hit".to_string(), EffectValue::Bool(h)),
+        ("x".to_string(), EffectValue::Number(p[0] as f64)),
+        ("y".to_string(), EffectValue::Number(p[1] as f64)),
+        ("z".to_string(), EffectValue::Number(p[2] as f64)),
+        ("nx".to_string(), EffectValue::Number(n[0] as f64)),
+        ("ny".to_string(), EffectValue::Number(n[1] as f64)),
+        ("nz".to_string(), EffectValue::Number(n[2] as f64)),
+        ("distance".to_string(), EffectValue::Number(d as f64)),
+        ("tag".to_string(), EffectValue::Text(tag)),
+    ])
 }
 
 /// The structured effect log keeps this many most-recent records — enforced
@@ -274,6 +310,12 @@ impl EffectRunner for RealEffects {
     fn now(&mut self) -> f64 {
         epoch_seconds()
     }
+    fn raycast(&mut self, origin: [f32; 3], dir: [f32; 3], max_dist: f32) -> EffectValue {
+        ray_result_value(
+            physics::with_world(physics::DEFAULT_WORLD, |w| w.raycast(origin, dir, max_dist))
+                .flatten(),
+        )
+    }
     fn random(&mut self) -> f64 {
         // xorshift64*; map the top 53 bits into [0, 1).
         let mut x = self.rng_state;
@@ -291,6 +333,10 @@ pub struct FakeEffects {
     pub now: f64,
     pub randoms: Vec<f64>,
     next: usize,
+    /// Canned raycast results, cycled like `randoms`; empty = every ray
+    /// misses. Test physics-query handling with no world at all.
+    pub ray_hits: Vec<EffectValue>,
+    next_ray: usize,
 }
 
 impl FakeEffects {
@@ -299,7 +345,14 @@ impl FakeEffects {
             now,
             randoms,
             next: 0,
+            ray_hits: Vec::new(),
+            next_ray: 0,
         }
+    }
+
+    pub fn with_ray_hits(mut self, ray_hits: Vec<EffectValue>) -> FakeEffects {
+        self.ray_hits = ray_hits;
+        self
     }
 }
 
@@ -310,6 +363,14 @@ impl EffectRunner for FakeEffects {
     fn random(&mut self) -> f64 {
         let v = self.randoms[self.next % self.randoms.len()];
         self.next += 1;
+        v
+    }
+    fn raycast(&mut self, _origin: [f32; 3], _dir: [f32; 3], _max_dist: f32) -> EffectValue {
+        if self.ray_hits.is_empty() {
+            return ray_result_value(None);
+        }
+        let v = self.ray_hits[self.next_ray % self.ray_hits.len()].clone();
+        self.next_ray += 1;
         v
     }
 }
@@ -356,6 +417,9 @@ impl EffectRunner for ReplayEffects {
     }
     fn random(&mut self) -> f64 {
         self.take_number("random")
+    }
+    fn raycast(&mut self, _origin: [f32; 3], _dir: [f32; 3], _max_dist: f32) -> EffectValue {
+        self.take("physics.raycast")
     }
 }
 
@@ -588,6 +652,7 @@ const PATHS: &[&str] = &[
     "Physics.applyForce",
     "Physics.setVelocity",
     "Physics.teleport",
+    "Physics.raycast",
 ];
 
 impl Host for FunctorHost {
@@ -997,6 +1062,42 @@ the game dir",
                     Ok(host(MleEffect(EffectTree::Physics(command))))
                 }
                 _ => usage(&format!("{path}(tag, x, y, z)")),
+            },
+            // Query EFFECT (docs/physics.md Phase 4): deferred until after
+            // the frame's physics step, then the tagger receives the result
+            // record `{hit, x, y, z, nx, ny, nz, distance, tag}` (hit: false
+            // with zeroed fields for a miss) — fresh, same-frame.
+            "Physics.raycast" => match args.as_slice() {
+                [ox, oy, oz, dx, dy, dz, max_dist, tagger @ (Value::Closure(_) | Value::Ctor { .. })] =>
+                {
+                    let origin = [
+                        num(ox, span)? as f32,
+                        num(oy, span)? as f32,
+                        num(oz, span)? as f32,
+                    ];
+                    let dir = [
+                        num(dx, span)? as f32,
+                        num(dy, span)? as f32,
+                        num(dz, span)? as f32,
+                    ];
+                    if dir == [0.0, 0.0, 0.0] {
+                        return err("Physics.raycast: the direction must not be zero".to_string());
+                    }
+                    let max_dist =
+                        positive_num(max_dist, span, "Physics.raycast maxDist")? as f32;
+                    Ok(host(MleEffect(EffectTree::Raycast {
+                        origin,
+                        dir,
+                        max_dist,
+                        tagger: tagger.clone(),
+                    })))
+                }
+                [_, _, _, _, _, _, _, other] => err(format!(
+                    "Physics.raycast(ox, oy, oz, dx, dy, dz, maxDist, tagger): the tagger \
+                     must be a function of the result record, got {}",
+                    other.kind_name()
+                )),
+                _ => usage("Physics.raycast(ox, oy, oz, dx, dy, dz, maxDist, tagger)"),
             },
             "Physics.transformed" => match args.as_slice() {
                 [scene, Value::String(tag)] => {
@@ -1410,6 +1511,12 @@ pub fn contains_effect(value: &Value) -> bool {
 /// is appended to `log` (the structured effect log; replay's input).
 /// Errors report through `report` (deduped by the producer) and drop that
 /// effect — one bad tagger must not stall the rest.
+///
+/// Physics QUERIES are not performed here: they come back in the returned
+/// list for the driver to hold until after the frame's physics step, then
+/// hand to [`perform_deferred_queries`] — so their taggers answer against
+/// the fresh world ("commands apply at the step; queries answer after it").
+#[must_use = "deferred physics queries must be performed after the step"]
 pub fn drain_effects(
     session: &mle::Session,
     model: &mut Value,
@@ -1417,9 +1524,71 @@ pub fn drain_effects(
     runner: &mut dyn EffectRunner,
     log: &mut EffectLog,
     report: &mut dyn FnMut(String),
+) -> Vec<EffectTree> {
+    let mut deferred = Vec::new();
+    drain_mode(
+        session,
+        model,
+        vec![first],
+        runner,
+        log,
+        report,
+        Some(&mut deferred),
+    );
+    deferred
+}
+
+/// Does this effect tree produce MESSAGES (tagger results that must fold
+/// through `update`)? Tagger-less trees — physics commands, `Effect.none`,
+/// batches thereof — drain fine without an `update` hook; the producers'
+/// "effects returned but there is no update" guard must only fire for trees
+/// that actually need one. (The guard predates tagger-less effects; gating
+/// on it unconditionally silently dropped physics commands from
+/// update-less games.)
+pub fn needs_update(tree: &EffectTree) -> bool {
+    match tree {
+        EffectTree::None | EffectTree::Physics(_) => false,
+        EffectTree::Now { .. } | EffectTree::Random { .. } | EffectTree::Raycast { .. } => true,
+        EffectTree::Batch(items) => items.iter().any(needs_update),
+    }
+}
+
+/// The post-step half of the query story: perform queries deferred by
+/// [`drain_effects`], folding their tagger messages through `update`.
+/// Chained effects drain to the same fixed point — further queries answer
+/// immediately (the world already stepped this frame); further commands
+/// queue for the next frame's step, as always.
+pub fn perform_deferred_queries(
+    session: &mle::Session,
+    model: &mut Value,
+    deferred: Vec<EffectTree>,
+    runner: &mut dyn EffectRunner,
+    log: &mut EffectLog,
+    report: &mut dyn FnMut(String),
 ) {
+    if deferred.is_empty() {
+        return;
+    }
+    drain_mode(session, model, deferred, runner, log, report, None);
+}
+
+fn drain_mode(
+    session: &mle::Session,
+    model: &mut Value,
+    queue: Vec<EffectTree>,
+    runner: &mut dyn EffectRunner,
+    log: &mut EffectLog,
+    report: &mut dyn FnMut(String),
+    // `Some` = pre-step drain: hold queries here instead of performing.
+    // `None` = post-step drain: answer queries now.
+    mut defer_queries: Option<&mut Vec<EffectTree>>,
+) {
+    // Each drain invocation gets its own cap, so a frame that defers queries
+    // is bounded by 2×MAX (pre-step + post-step) — the cap's job is to bound
+    // runaway chains, not to meter exactly N.
     const MAX_EFFECTS_PER_FRAME: usize = 1000;
-    let mut queue: Vec<EffectTree> = vec![first];
+    let mut queue: Vec<EffectTree> = queue;
+    queue.reverse(); // treat the input list as front-of-queue, in order
     // Counts every DEQUEUED node (None and Batch structure included), and is
     // checked BEFORE the runner performs anything — so a runaway chain can't
     // consume unbounded frame time through structural nodes, and the capped
@@ -1467,6 +1636,29 @@ dropping the rest"
                 }
                 continue;
             }
+            EffectTree::Raycast {
+                origin,
+                dir,
+                max_dist,
+                tagger,
+            } => match defer_queries.as_deref_mut() {
+                Some(deferred) => {
+                    // Pre-step: hold the query for the post-step drain (not
+                    // performed, not logged — it hasn't happened yet).
+                    deferred.push(EffectTree::Raycast {
+                        origin,
+                        dir,
+                        max_dist,
+                        tagger,
+                    });
+                    continue;
+                }
+                None => (
+                    "physics.raycast",
+                    runner.raycast(origin, dir, max_dist),
+                    tagger,
+                ),
+            },
             EffectTree::Now { tagger } => ("now", runner.now().into(), tagger),
             EffectTree::Random { tagger } => ("random", runner.random().into(), tagger),
         };
@@ -2170,7 +2362,7 @@ Fog.linear(near, far, r, g, b) or Fog.exp(density, r, g, b)"
         let mut model = Value::Number(0.0);
         let mut log = EffectLog::new();
         let mut runner = FakeEffects::new(0.0, vec![]);
-        drain_effects(
+        let deferred = drain_effects(
             &session,
             &mut model,
             tree.clone(),
@@ -2178,6 +2370,7 @@ Fog.linear(near, far, r, g, b) or Fog.exp(density, r, g, b)"
             &mut log,
             &mut |m| panic!("unexpected report: {m}"),
         );
+        assert!(deferred.is_empty(), "nothing should defer here");
         assert_eq!(log.len(), 1);
         assert_eq!(log[0].kind, "physics.applyImpulse");
         // The structured log records the TARGET, not a filler number.
@@ -2351,7 +2544,7 @@ Fog.linear(near, far, r, g, b) or Fog.exp(density, r, g, b)"
                 .expect("roll");
             let (m, fx) = split_model_effect(returned);
             model = m;
-            drain_effects(
+            let deferred = drain_effects(
                 &session,
                 &mut model,
                 fx.expect("an effect"),
@@ -2359,6 +2552,7 @@ Fog.linear(near, far, r, g, b) or Fog.exp(density, r, g, b)"
                 &mut log,
                 &mut |msg| panic!("unexpected report: {msg}"),
             );
+            assert!(deferred.is_empty(), "nothing should defer here");
             (model.to_string(), log)
         };
         // Fake world: random = 0.25, now = 99.5 — exact arithmetic.
@@ -2392,6 +2586,140 @@ Fog.linear(near, far, r, g, b) or Fog.exp(density, r, g, b)"
         assert!((0.0..1.0).contains(&r0));
         assert_eq!(real_log[1].kind, "now");
         assert!(real_model.starts_with("{ rolls: 0."));
+    }
+
+    /// The Phase 4 query path end to end: a raycast effect DEFERS through the
+    /// pre-step drain, then answers post-step against the live world, its
+    /// record folding through `update` — and the fake/replay runners answer
+    /// without a world at all.
+    #[test]
+    fn raycast_effects_defer_then_answer_post_step() {
+        crate::physics::remove_world(crate::physics::DEFAULT_WORLD);
+        // `update` swaps the model for the hit record (tagger = a closure, so
+        // the record itself is the message).
+        let src = "let update = (m, msg) => msg\n\
+                   let main = () => Physics.raycast(0.0, 5.0, 0.0, 0.0, -1.0, 0.0, 100.0, (hit) => hit)";
+        let module = mle::lower(mle::parse(src).unwrap()).unwrap();
+        let session = mle::Session::load(&module, &mut FunctorHost)
+            .unwrap_or_else(|f| panic!("load failed: {}", f.error.message));
+        let record = mle::run_with_host(&module, Tracing::Off, &mut FunctorHost)
+            .unwrap_or_else(|f| panic!("run failed: {}", f.error.message));
+        let effect = match record.outcome {
+            mle::RunOutcome::Main(value) => value,
+            _ => panic!("expected main"),
+        };
+        let Value::HostData(data) = &effect else {
+            panic!("expected an Effect")
+        };
+        let tree = data.as_any().downcast_ref::<MleEffect>().unwrap().0.clone();
+        let EffectTree::Raycast { tagger, .. } = &tree else {
+            panic!("expected a raycast effect");
+        };
+        let tagger = tagger.clone();
+
+        // A settled body for the ray to hit.
+        crate::physics::with_world(crate::physics::DEFAULT_WORLD, |w| {
+            w.reconcile(&crate::physics::PhysicsScene::create(
+                [0.0, 0.0, 0.0],
+                vec![crate::physics::Body::fixed(
+                    "slab".to_string(),
+                    crate::physics::Shape::Cuboid {
+                        extents: [4.0, 1.0, 4.0],
+                    },
+                )],
+            ));
+            w.step_fixed();
+        });
+
+        let mut model = Value::Number(0.0);
+        let mut log = EffectLog::new();
+        let mut runner = RealEffects::new();
+        let mut fail = |m: String| panic!("unexpected report: {m}");
+
+        // Pre-step drain: DEFERRED — nothing performed, nothing logged.
+        let deferred = drain_effects(&session, &mut model, tree, &mut runner, &mut log, &mut fail);
+        assert_eq!(deferred.len(), 1);
+        assert!(log.is_empty());
+        assert!(matches!(model, Value::Number(_)), "model must be untouched");
+
+        // Post-step drain: performed against the live world.
+        perform_deferred_queries(&session, &mut model, deferred, &mut runner, &mut log, &mut fail);
+        assert_eq!(log.len(), 1);
+        assert_eq!(log[0].kind, "physics.raycast");
+        let Value::Record(fields) = &model else {
+            panic!("update should have received the hit record");
+        };
+        let field = |name: &str| {
+            fields
+                .iter()
+                .find(|(k, _)| k == name)
+                .map(|(_, v)| v.clone())
+                .unwrap()
+        };
+        assert!(matches!(field("hit"), Value::Bool(true)));
+        assert!(matches!(field("tag"), Value::String(s) if &*s == "slab"));
+        assert!(matches!(field("y"), Value::Number(n) if (n - 0.5).abs() < 1e-4));
+
+        // Replay: the recorded log answers with no world consulted.
+        crate::physics::remove_world(crate::physics::DEFAULT_WORLD);
+        let mut replay_model = Value::Number(0.0);
+        let mut replay_log = EffectLog::new();
+        let mut replay = ReplayEffects::new(log.clone());
+        let deferred = drain_effects(
+            &session,
+            &mut replay_model,
+            EffectTree::Raycast {
+                origin: [0.0, 5.0, 0.0],
+                dir: [0.0, -1.0, 0.0],
+                max_dist: 100.0,
+                tagger: tagger.clone(),
+            },
+            &mut replay,
+            &mut replay_log,
+            &mut fail,
+        );
+        perform_deferred_queries(
+            &session,
+            &mut replay_model,
+            deferred,
+            &mut replay,
+            &mut replay_log,
+            &mut fail,
+        );
+        assert_eq!(replay_log, log, "replay must reproduce the log");
+        assert_eq!(replay_model.to_string(), model.to_string());
+
+        // Fake: canned hits, no world.
+        let mut fake = FakeEffects::new(0.0, vec![]).with_ray_hits(vec![ray_result_value(None)]);
+        let miss = fake.raycast([0.0; 3], [0.0, -1.0, 0.0], 10.0);
+        let EffectValue::Record(f) = &miss else {
+            panic!()
+        };
+        assert!(f.iter().any(|(k, v)| k == "hit" && *v == EffectValue::Bool(false)));
+    }
+
+    /// Tagger-less trees (physics commands) don't require an `update` hook;
+    /// message-producing ones do — the drivers' drop-guard keys on this.
+    #[test]
+    fn needs_update_distinguishes_taggered_from_fire_and_forget() {
+        let cmd = EffectTree::Physics(crate::physics::PhysicsCommand::ApplyImpulse {
+            tag: "x".to_string(),
+            impulse: [0.0; 3],
+        });
+        assert!(!needs_update(&EffectTree::None));
+        assert!(!needs_update(&cmd));
+        assert!(!needs_update(&EffectTree::Batch(vec![
+            EffectTree::None,
+            cmd.clone()
+        ])));
+        let tagged = EffectTree::Raycast {
+            origin: [0.0; 3],
+            dir: [0.0, -1.0, 0.0],
+            max_dist: 1.0,
+            tagger: Value::Number(0.0), // shape only; construction validates real taggers
+        };
+        assert!(needs_update(&tagged));
+        assert!(needs_update(&EffectTree::Batch(vec![cmd, tagged])));
     }
 
     /// Structured effect values convert to the MLE values taggers receive,
@@ -2466,7 +2794,7 @@ Fog.linear(near, far, r, g, b) or Fog.exp(density, r, g, b)"
         let mut model = Value::Number(0.0);
         let mut log = EffectLog::new();
         let mut reports = Vec::new();
-        drain_effects(
+        let deferred = drain_effects(
             &session,
             &mut model,
             EffectTree::Random {
@@ -2476,6 +2804,7 @@ Fog.linear(near, far, r, g, b) or Fog.exp(density, r, g, b)"
             &mut log,
             &mut |msg| reports.push(msg),
         );
+        assert!(deferred.is_empty(), "nothing should defer here");
         // The log bound is enforced INSIDE the drain (not after), and the
         // cap fires before performing the over-limit effect.
         assert_eq!(log.len(), EFFECT_LOG_CAP, "log bounded mid-drain");
@@ -2495,7 +2824,7 @@ Fog.linear(near, far, r, g, b) or Fog.exp(density, r, g, b)"
         let mut model = Value::Number(0.0);
         let mut log = EffectLog::new();
         let mut reports = Vec::new();
-        drain_effects(
+        let deferred = drain_effects(
             &session,
             &mut model,
             EffectTree::Batch(vec![EffectTree::None; 1500]),
@@ -2503,6 +2832,7 @@ Fog.linear(near, far, r, g, b) or Fog.exp(density, r, g, b)"
             &mut log,
             &mut |msg| reports.push(msg),
         );
+        assert!(deferred.is_empty(), "nothing should defer here");
         assert!(log.is_empty(), "nothing performed");
         assert!(reports.iter().any(|r| r.contains("per-frame cap")));
     }

--- a/runtime/functor-runtime-common/src/physics/world.rs
+++ b/runtime/functor-runtime-common/src/physics/world.rs
@@ -72,6 +72,16 @@ const MAX_PENDING_COMMANDS: usize = 1024;
 /// must not become the leak it exists to report.
 const MAX_COMMAND_WARNINGS: usize = 64;
 
+/// The nearest intersection from [`World::raycast`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct RayHit {
+    pub tag: String,
+    pub position: [f32; 3],
+    pub normal: [f32; 3],
+    /// World units from the ray origin (the direction is normalized).
+    pub distance: f32,
+}
+
 /// One colored wireframe segment from [`World::debug_lines`], in world space.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize)]
 pub struct DebugLine {
@@ -330,6 +340,48 @@ impl World {
         let rb = self.bodies.get(*rb_handle)?;
         let v = rb.linvel();
         Some([v.x, v.y, v.z])
+    }
+
+    /// Cast a ray against the live world (docs/physics.md Phase 4): the
+    /// nearest hit's tag, world-space point, surface normal, and distance.
+    /// `dir` need not be normalized (it is here, so `max_dist` is in world
+    /// units); a zero direction yields `None`.
+    ///
+    /// Answers against the broad phase **as of the last step** — a world that
+    /// has never stepped misses everything (the MLE drivers hold deferred
+    /// queries until a frame that actually substepped, so game code only sees
+    /// answers from a simulated world; direct callers should step first).
+    /// Sensor colliders are hittable like any other (rapier's default query
+    /// filter) — an invisible trigger volume can occlude a solid body behind
+    /// it.
+    pub fn raycast(&self, origin: [f32; 3], dir: [f32; 3], max_dist: f32) -> Option<RayHit> {
+        let d = vec3(dir);
+        let len = d.length();
+        if !(len.is_finite() && len > 0.0) {
+            return None;
+        }
+        let ray = rapier3d::prelude::Ray::new(vec3(origin), d / len);
+        let pipeline = self.broad_phase.as_query_pipeline(
+            self.narrow_phase.query_dispatcher(),
+            &self.bodies,
+            &self.colliders,
+            QueryFilter::default(),
+        );
+        let (col_handle, hit) = pipeline.cast_ray_and_get_normal(&ray, max_dist, true)?;
+        // Reverse handle→tag lookup: scenes are small; a scan beats carrying
+        // a second map in every snapshot.
+        let tag = self
+            .tags
+            .iter()
+            .find(|(_, &(_, col))| col == col_handle)
+            .map(|(tag, _)| tag.clone())?;
+        let point = ray.origin + ray.dir * hit.time_of_impact;
+        Some(RayHit {
+            tag,
+            position: [point.x, point.y, point.z],
+            normal: [hit.normal.x, hit.normal.y, hit.normal.z],
+            distance: hit.time_of_impact,
+        })
     }
 
     /// The world as colored wireframe line segments, via Rapier's own debug
@@ -992,6 +1044,37 @@ mod tests {
         let warnings = w.take_command_warnings();
         assert_eq!(warnings.len(), 1, "{warnings:?}");
         assert!(warnings[0].contains("non-dynamic"), "{warnings:?}");
+    }
+
+    #[test]
+    fn raycast_hits_the_nearest_body_with_tag_point_and_normal() {
+        let mut w = World::new([0.0, 0.0, 0.0]);
+        // The crate floats clear of the ground in a ZERO-gravity scene (the
+        // shared `scene()` helper declares -9.81, which would sag it a step),
+        // so the asserted geometry is exact: center 0.7, top face at 1.2.
+        w.reconcile(&PhysicsScene::create(
+            [0.0, 0.0, 0.0],
+            vec![ground(), crate_at("a", [0.0, 0.7, 0.0])],
+        ));
+        // The broad phase ingests colliders at the step — mirror the real
+        // query path, which always runs post-step.
+        w.step_fixed();
+        // Straight down from above: the crate's top face wins over the ground
+        // beneath it.
+        let hit = w.raycast([0.0, 5.0, 0.0], [0.0, -1.0, 0.0], 100.0).unwrap();
+        assert_eq!(hit.tag, "a");
+        assert!((hit.position[1] - 1.2).abs() < 1e-4, "{:?}", hit.position);
+        assert!((hit.normal[1] - 1.0).abs() < 1e-4, "{:?}", hit.normal);
+        assert!((hit.distance - 3.8).abs() < 1e-4, "{}", hit.distance);
+        // Direction need not be normalized: distance stays in world units.
+        let hit2 = w.raycast([0.0, 5.0, 0.0], [0.0, -7.0, 0.0], 100.0).unwrap();
+        assert!((hit2.distance - 3.8).abs() < 1e-4);
+        // Beyond max distance, zero direction: misses. Off to the side: the
+        // ground.
+        assert!(w.raycast([0.0, 5.0, 0.0], [0.0, -1.0, 0.0], 3.0).is_none());
+        assert!(w.raycast([0.0, 5.0, 0.0], [0.0, 0.0, 0.0], 10.0).is_none());
+        let g = w.raycast([5.0, 5.0, 5.0], [0.0, -1.0, 0.0], 100.0).unwrap();
+        assert_eq!(g.tag, "ground");
     }
 
     #[test]

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -29,8 +29,9 @@
 use std::time::Instant;
 
 use functor_runtime_common::mle_prelude::{
-    contains_effect, drain_effects, frame_value, physics_scene_value, split_model_effect,
-    sub_messages_for_frame, EffectLog, FunctorHost, RealEffects,
+    contains_effect, drain_effects, frame_value, needs_update, perform_deferred_queries,
+    physics_scene_value, split_model_effect, sub_messages_for_frame, EffectLog, EffectTree,
+    FunctorHost, RealEffects,
 };
 use functor_runtime_common::physics;
 use functor_runtime_common::ui::View;
@@ -66,6 +67,10 @@ pub struct MleGame {
     /// The structured effect log (last `EFFECT_LOG_CAP` performed effects) —
     /// LLM-readable, and the input format for replay.
     effect_log: EffectLog,
+    /// Physics queries deferred by the frame's pre-step drains, performed
+    /// right after the physics step so their taggers answer against the
+    /// fresh world ("commands apply at the step; queries answer after it").
+    deferred_queries: Vec<EffectTree>,
     /// The last successfully drawn frame, kept so a bad draw shows the last
     /// good picture instead of a blank.
     last_frame: Frame,
@@ -233,6 +238,7 @@ impl MleGame {
             has_physics: loaded.has_physics,
             effect_runner: RealEffects::new(),
             effect_log: EffectLog::new(),
+            deferred_queries: Vec::new(),
             last_frame: empty_frame(),
             last_error: None,
             frames: 0,
@@ -266,25 +272,30 @@ impl MleGame {
     /// fixed substeps. Runs after `tick` so declarations come from the settled
     /// model, and before `render` so `Physics.position`/`Physics.transformed`
     /// in `draw` read the just-stepped world.
-    fn step_physics(&mut self, dts: f32) {
+    /// Returns the number of fixed substeps taken (0 when there is no
+    /// `physics` hook, the hook errored, or the accumulator hasn't reached a
+    /// full step yet).
+    fn step_physics(&mut self, dts: f32) -> u32 {
         if !self.has_physics {
-            return;
+            return 0;
         }
         let args = vec![self.model.clone()];
         match self.session.call("physics", args, &mut FunctorHost) {
             Ok(value) => match physics_scene_value(&value) {
                 Some(scene) => {
-                    let warnings = physics::with_world(physics::DEFAULT_WORLD, |w| {
+                    let (steps, warnings) = physics::with_world(physics::DEFAULT_WORLD, |w| {
                         w.reconcile(scene);
-                        w.step_frame(dts);
-                        w.take_command_warnings()
-                    });
+                        let steps = w.step_frame(dts);
+                        (steps, w.take_command_warnings())
+                    })
+                    .unwrap_or((0, Vec::new()));
                     // Command effects apply asynchronously (queued at perform
                     // time, applied at the step), so their problems — unknown
                     // tag, queue overflow — surface here, deduped.
-                    for warning in warnings.into_iter().flatten() {
+                    for warning in warnings {
                         self.report_once(format!("[mle] {warning}"));
                     }
+                    return steps;
                 }
                 None => self.report_once(format!(
                     "[mle] physics must return Physics.scene(gx, gy, gz, [body, …]), got {}",
@@ -293,6 +304,7 @@ impl MleGame {
             },
             Err(err) => self.frame_error("physics", &err),
         }
+        0
     }
 
     /// Take an entry point's return: split off any `(model, effect)` pair,
@@ -315,7 +327,11 @@ not data; return them beside the model as `(model, effect)` instead of storing t
             );
         }
         let Some(effects) = effects else { return };
-        if self.session.global("update").is_none() {
+        // Only MESSAGE-producing effects need an `update` to receive them —
+        // tagger-less physics commands must not be dropped over a missing
+        // hook (that guard silently ate them; caught by capture-verifying
+        // the mle-physics kick).
+        if needs_update(&effects) && self.session.global("update").is_none() {
             self.report_once(
                 "[mle] effects returned but there is no `let update = (model, msg) => …` \
 to receive their messages; dropping them"
@@ -324,7 +340,7 @@ to receive their messages; dropping them"
             return;
         }
         let mut reports: Vec<String> = Vec::new();
-        drain_effects(
+        let deferred = drain_effects(
             &self.session,
             &mut self.model,
             effects,
@@ -332,6 +348,9 @@ to receive their messages; dropping them"
             &mut self.effect_log,
             &mut |message| reports.push(message),
         );
+        // Physics queries wait for the post-step drain (end of `tick`), so
+        // their taggers answer against THIS frame's stepped world.
+        self.deferred_queries.extend(deferred);
         for message in reports {
             self.report_once(message);
         }
@@ -406,6 +425,10 @@ to receive their messages; dropping them"
             physics::remove_world(physics::DEFAULT_WORLD);
         }
         self.last_error = None;
+        // A deferred query holds a tagger — a closure into the OLD session;
+        // drop them rather than let them dangle (the same rule the F#
+        // executor applies to in-flight HTTP taggers).
+        self.deferred_queries.clear();
         report.rebound
     }
 
@@ -510,7 +533,31 @@ impl Game for MleGame {
         }
         self.tick_ns += started.elapsed().as_nanos() as u64;
         let physics_started = Instant::now();
-        self.step_physics(frame_time.dts);
+        let physics_steps = self.step_physics(frame_time.dts);
+        // Post-step query drain: deferred raycasts answer against the world
+        // just stepped; their messages fold through `update` before `draw`,
+        // so this frame's render already reflects them.
+        // On a ZERO-substep frame (the accumulator short of FIXED_DT — normal
+        // right after load and at >60fps) queries stay deferred, like pending
+        // commands, so they never answer against a world that hasn't
+        // simulated. Games without a physics hook answer immediately (the
+        // lazily-created empty world gives sane misses).
+        let world_ready = physics_steps > 0 || !self.has_physics;
+        if world_ready && !self.deferred_queries.is_empty() {
+            let deferred = std::mem::take(&mut self.deferred_queries);
+            let mut reports: Vec<String> = Vec::new();
+            perform_deferred_queries(
+                &self.session,
+                &mut self.model,
+                deferred,
+                &mut self.effect_runner,
+                &mut self.effect_log,
+                &mut |message| reports.push(message),
+            );
+            for message in reports {
+                self.report_once(message);
+            }
+        }
         self.physics_ns += physics_started.elapsed().as_nanos() as u64;
         self.frames += 1;
         self.report_stats();

--- a/runtime/functor-runtime-web/src/mle_game.rs
+++ b/runtime/functor-runtime-web/src/mle_game.rs
@@ -22,8 +22,9 @@
 use std::cell::RefCell;
 
 use functor_runtime_common::mle_prelude::{
-    contains_effect, drain_effects, frame_value, physics_scene_value, split_model_effect,
-    sub_messages_for_frame, EffectLog, FunctorHost, RealEffects,
+    contains_effect, drain_effects, frame_value, needs_update, perform_deferred_queries,
+    physics_scene_value, split_model_effect, sub_messages_for_frame, EffectLog, EffectTree,
+    FunctorHost, RealEffects,
 };
 use functor_runtime_common::physics;
 use functor_runtime_common::protocol::GameProducer;
@@ -56,6 +57,10 @@ pub struct MleWebGame {
     effect_runner: RealEffects,
     /// The structured effect log (bounded inside the drain).
     effect_log: EffectLog,
+    /// Physics queries deferred by the frame's pre-step drains, performed
+    /// right after the physics step so their taggers answer against the
+    /// fresh world ("commands apply at the step; queries answer after it").
+    deferred_queries: Vec<EffectTree>,
     /// The last successfully drawn frame, kept so a bad draw shows the last
     /// good picture instead of a blank.
     last_frame: Frame,
@@ -194,6 +199,7 @@ impl MleWebGame {
             prev_tts: None,
             effect_runner: RealEffects::new(),
             effect_log: EffectLog::new(),
+            deferred_queries: Vec::new(),
             has_physics: loaded.has_physics,
             last_frame: empty_frame(),
             last_error: None,
@@ -227,6 +233,9 @@ impl MleWebGame {
         if !self.has_physics {
             physics::remove_world(physics::DEFAULT_WORLD);
         }
+        // A deferred query holds a tagger — a closure into the OLD session;
+        // drop them rather than let them dangle.
+        self.deferred_queries.clear();
         self.last_error = None;
         report.rebound
     }
@@ -251,7 +260,10 @@ not data; return them beside the model as `(model, effect)` instead of storing t
             );
         }
         let Some(effects) = effects else { return };
-        if self.session.global("update").is_none() {
+        // Only MESSAGE-producing effects need an `update` to receive them —
+        // tagger-less physics commands must not be dropped over a missing
+        // hook (mirrors the desktop producer).
+        if needs_update(&effects) && self.session.global("update").is_none() {
             self.log_once(
                 "[mle] effects returned but there is no `let update = (model, msg) => …` \
 to receive their messages; dropping them"
@@ -260,7 +272,7 @@ to receive their messages; dropping them"
             return;
         }
         let mut reports: Vec<String> = Vec::new();
-        drain_effects(
+        let deferred = drain_effects(
             &self.session,
             &mut self.model,
             effects,
@@ -268,6 +280,9 @@ to receive their messages; dropping them"
             &mut self.effect_log,
             &mut |message| reports.push(message),
         );
+        // Physics queries wait for the post-step drain (end of `tick`), so
+        // their taggers answer against THIS frame's stepped world.
+        self.deferred_queries.extend(deferred);
         for message in reports {
             self.log_once(message);
         }
@@ -311,25 +326,30 @@ to receive their messages; dropping them"
     /// in fixed substeps. Runs after `tick` so declarations come from the
     /// settled model, and before `render` so `Physics.position`/
     /// `Physics.transformed` in `draw` read the just-stepped world.
-    fn step_physics(&mut self, dts: f32) {
+    /// Returns the number of fixed substeps taken (0 when there is no
+    /// `physics` hook, the hook errored, or the accumulator hasn't reached a
+    /// full step yet).
+    fn step_physics(&mut self, dts: f32) -> u32 {
         if !self.has_physics {
-            return;
+            return 0;
         }
         let args = vec![self.model.clone()];
         match self.session.call("physics", args, &mut FunctorHost) {
             Ok(value) => match physics_scene_value(&value) {
                 Some(scene) => {
-                    let warnings = physics::with_world(physics::DEFAULT_WORLD, |w| {
+                    let (steps, warnings) = physics::with_world(physics::DEFAULT_WORLD, |w| {
                         w.reconcile(scene);
-                        w.step_frame(dts);
-                        w.take_command_warnings()
-                    });
+                        let steps = w.step_frame(dts);
+                        (steps, w.take_command_warnings())
+                    })
+                    .unwrap_or((0, Vec::new()));
                     // Command effects apply asynchronously (queued at perform
                     // time, applied at the step), so their problems — unknown
                     // tag, queue overflow — surface here, deduped.
-                    for warning in warnings.into_iter().flatten() {
+                    for warning in warnings {
                         self.log_once(format!("[mle] {warning}"));
                     }
+                    return steps;
                 }
                 None => self.log_once(format!(
                     "[mle] physics must return Physics.scene(gx, gy, gz, [body, …]), got {}",
@@ -338,6 +358,7 @@ to receive their messages; dropping them"
             },
             Err(err) => self.frame_error("physics", &err),
         }
+        0
     }
 
     /// Report a per-frame error with its source position, once per distinct
@@ -401,7 +422,30 @@ impl GameProducer for MleWebGame {
             Ok(returned) => self.absorb(returned),
             Err(err) => self.frame_error("tick", &err),
         }
-        self.step_physics(frame_time.dts);
+        let physics_steps = self.step_physics(frame_time.dts);
+        // Post-step query drain: deferred raycasts answer against the world
+        // just stepped; their messages fold through `update` before `draw`.
+        // On a ZERO-substep frame (the accumulator short of FIXED_DT — normal
+        // right after load and at >60fps) queries stay deferred, like pending
+        // commands, so they never answer against a world that hasn't
+        // simulated. Games without a physics hook answer immediately (the
+        // lazily-created empty world gives sane misses).
+        let world_ready = physics_steps > 0 || !self.has_physics;
+        if world_ready && !self.deferred_queries.is_empty() {
+            let deferred = std::mem::take(&mut self.deferred_queries);
+            let mut reports: Vec<String> = Vec::new();
+            perform_deferred_queries(
+                &self.session,
+                &mut self.model,
+                deferred,
+                &mut self.effect_runner,
+                &mut self.effect_log,
+                &mut |message| reports.push(message),
+            );
+            for message in reports {
+                self.log_once(message);
+            }
+        }
     }
 
     fn key_event(&mut self, code: i32, is_down: bool) {


### PR DESCRIPTION
Phase **4** of docs/physics.md, **stacked on #206** (B6.5 structured payloads). The Elm-shaped query story we agreed on, with the freshness design: **"commands apply at the step; queries answer after it."**

```mle
| \"R\" => (model, Physics.raycast(ox, oy, oz, 0.0, -1.0, 0.0, 20.0, (hit) => hit))

let update = (model, msg) =>
  match msg.hit with
  | false => (model, Effect.none())
  | true  => (model, Physics.applyImpulse(msg.tag, 0.0, 6.0, 0.0))   // query → command chain
```

![raycast](https://gist.githubusercontent.com/tommy-xr/6df320c875411eca6ba65931e051dfbe/raw/raycast.gif)

| R: the ray's hit record kicks crate-0 | K: the ball kick (bug-fixed, see below) |
| --- | --- |
| ![ray](https://gist.githubusercontent.com/tommy-xr/6df320c875411eca6ba65931e051dfbe/raw/crate-kicked-by-ray.png) | ![kick](https://gist.githubusercontent.com/tommy-xr/6df320c875411eca6ba65931e051dfbe/raw/ball-kick-fixed.png) |

## The freshness design, implemented

Raycasts **defer** through the frame's pre-step effect drains and perform **right after the physics step**, their `{hit: Bool, x, y, z, nx, ny, nz, distance, tag}` records folding through a second `update` pass before `draw` — same-frame results against the *fresh* world. A zero-substep frame (accumulator short of `FIXED_DT` — normal at >60fps and on the first frame after load) carries queries to the next simulated frame, like pending commands, so a query can never answer against a world that hasn't stepped (review caught the init-frame false-miss). Chained queries answer immediately post-step; chained commands queue for the next step. `EffectRunner` grows `raycast` on all three runners — **fake/replay can can/replay raycasts**, so physics-query logic tests with no world at all (the property that motivated the tagger shape).

## Also in this PR: a real bug found by honest verification

The drivers' *"no update → drop effects"* guard (from B6) silently ate **tagger-less physics commands** — the mle-physics K-kick **never actually worked**, and my Phase 3 "live verification" was fooled by settling noise (headless scene-hash comparisons) and a residual-bounce GIF. Capture-verifying this PR exposed it: the drop warning fired and the ball stayed grounded. Fixed by keying the guard on a new `needs_update()` (message-producing effects only); the kick is now verified unmistakably airborne. Known remaining choice, flagged by both reviewers: a *mixed* batch (command + taggered effect) with no `update` still drops whole — acceptable, since the taggered half is already a bug in such a game.

## Pre-existing B7 regression, worked around + filed

Mixing bare-`model` and `(model, effect)` match arms trips the HM occurs check (`'a = 'a * Unknown`) — the documented B6 contract fails `mle check`/`functor build` on current `main` (the merged example already fails). The example now uses uniform tuple arms padded with `Effect.none()`; the gotcha is documented in the mle-language skill and filed in `docs/todo.md` (the `effect[...]` header work looks like the intended fix).

## Testing

- **143 tests** (raycast geometry incl. unnormalized dirs; defer-then-perform end-to-end with real/fake/replay runners; `needs_update`; a probe game asserting the full pipeline via `/state`)
- strict + wasm checks clean on all three crates; `mle check` clean on the example
- Live captures above; cross-engine review run — both engines' findings addressed (test `#[must_use]` hygiene, the zero-substep gate, sensor-hit documentation, effect-cap note) or explicitly declined with rationale (per-frame cap is 2× across the two drains — bounded, which is the cap's job)

Next: Phase 5 collision events (sensor volumes come alive), then Phase 6 pause/rewind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)