### PR TITLE
feat(mle): C4b-5 — the skybox surface + the finished mle-atmosphere demo

### DIFF
--- a/.claude/skills/mle-language/SKILL.md
+++ b/.claude/skills/mle-language/SKILL.md
@@ -268,6 +268,14 @@ frame |> Frame.withFog(fog)                                // distance fog on al
                                                            //   materials incl. emissive;
                                                            //   the fog color is also the
                                                            //   pass's clear color
+Skybox.files(px, nx, py, ny, pz, nz)                       // Skybox VALUES only: six face
+frame |> Frame.withSkybox(sky)                             //   paths (+X..-Z). Faces are
+                                                           //   fetched assets (not checked
+                                                           //   in) resolved from the game
+                                                           //   dir; while they load the
+                                                           //   clear color shows, a failed
+                                                           //   face = one warning + no sky.
+                                                           //   Fog never fogs the sky
 Time.seconds(1.0) / Time.millis(500.0)                     // Duration VALUES only
 Sub.every(duration, msg) / Sub.none() / Sub.batch([sub,…]) // what subscriptions returns
 Effect.random(tagger) / Effect.now(tagger)                 // one-shots; tagger: (Float) => Msg

--- a/docs/mle.md
+++ b/docs/mle.md
@@ -448,6 +448,20 @@ Starts once A2 + B3 exist.
         shape and the teaching errors; a fog-less frame renders
         BYTE-IDENTICALLY to the pre-fog engine (base-vs-fog golden
         captures compared with cmp — the engine PR's contract).
+      - [x] **C4b-5. Skybox** (done 2026-07-04): prelude grows the
+        cubemap-sky surface — branded
+        `Skybox.files(px, nx, py, ny, pz, nz)` (six non-empty face
+        paths, +X..-Z) and `Frame.withSkybox(frame, sky)`. The sky
+        draws behind everything after the pass's clear; while the six
+        faces load the clear color shows, and a failed face disables
+        the sky with one warning. Fog does not apply to the sky.
+        `examples/mle-atmosphere` gains the TropicalSunnyDay sky
+        (fetched via `npm run fetch:assets`, gitignored), with the fog
+        color tuned to the sky's horizon band so the colonnade
+        dissolves INTO the sky.
+        *Verify (done):* prelude unit tests pin the skybox wire shape,
+        face order, and teaching errors; deterministic captures show
+        the sky behind the fogged colonnade.
 - [x] **C5. Wasm** (done 2026-07-03). `MleWebGame` in the web runtime — the
       wasm sibling of the desktop producer behind the same `GameProducer`
       seam: identical load-contract validation, MVU subscriptions pump,

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -32,7 +32,9 @@ golden tests), see `CLAUDE.md` and `git log`.
 - [ ] Lighting: ambient, point, directional, ambient/positional fog, spot →
       shadow mapping. (Distance fog done 2026-07-04 — `Frame.withFog`,
       linear + exp; volumetric/positional fog still open.)
-- [ ] Cubemap / skybox (emissive lighting + reflection).
+- [ ] Cubemap / skybox (emissive lighting + reflection). (Skybox rendering
+      done 2026-07-04 — `Frame.withSkybox`, six-face cubemaps; cubemap
+      reflection/IBL still open.)
 - [ ] Camera middleware: FPSCamera, OrbitCamera.
 - [ ] In-built hands models.
 

--- a/examples/mle-atmosphere/.gitignore
+++ b/examples/mle-atmosphere/.gitignore
@@ -1,0 +1,2 @@
+# Skybox faces are fetched, not checked in (npm run fetch:assets).
+*.jpg

--- a/examples/mle-atmosphere/game.mle
+++ b/examples/mle-atmosphere/game.mle
@@ -1,13 +1,22 @@
-// examples/mle-atmosphere — distance fog (a skybox joins in the next PR).
+// examples/mle-atmosphere — distance fog + a cubemap skybox.
 //
 // A colonnade of identical pillars recedes into linear fog: every pillar has
 // the same size and albedo, so any visible difference between near and far
-// ones IS the fog. The fog color drives the clear color, so the far pillars
-// dissolve into the horizon instead of silhouetting. An emissive drifter
-// weaves through the colonnade — fog occludes glow too. All animation
-// derives from tts, so captures are deterministic under --fixed-time.
+// ones IS the fog. The fog color is tuned toward the sky's horizon band, so
+// the far pillars dissolve into the sky. An emissive drifter weaves through
+// the colonnade — fog occludes glow too (but not the sky: it IS the
+// horizon). All animation derives from tts, so captures are deterministic
+// under --fixed-time.
+//
+// The skybox faces are not checked in — run `npm run fetch:assets` first.
+// While they load, the fog color shows in place of the sky.
 
-let fog = Fog.linear(6.0, 26.0, 0.62, 0.68, 0.78)
+let fog = Fog.linear(6.0, 26.0, 0.93, 0.95, 0.96)
+
+let sky = Skybox.files(
+  "TropicalSunnyDay_px.jpg", "TropicalSunnyDay_nx.jpg",
+  "TropicalSunnyDay_py.jpg", "TropicalSunnyDay_ny.jpg",
+  "TropicalSunnyDay_pz.jpg", "TropicalSunnyDay_nz.jpg")
 
 // One pillar at depth i (world z = i * 3), staggered left/right.
 let pillar = (i: Float) =>
@@ -40,3 +49,4 @@ let draw = (m, tts: Float) =>
     ]),
     lights())
   |> Frame.withFog(fog)
+  |> Frame.withSkybox(sky)

--- a/runtime/functor-runtime-common/src/mle_prelude.rs
+++ b/runtime/functor-runtime-common/src/mle_prelude.rs
@@ -64,6 +64,11 @@
 //!    text lines stacked in a column, pinned to a screen corner. Only the
 //!    corner the port needed exists; the rest arrive with a port that
 //!    needs them. `Ui.panel` takes the view FIRST, so it pipes.)
+//! Skybox.files(px, nx, py, ny, pz, nz)                       -> Skybox
+//! Frame.withSkybox(frame, sky)                               -> Frame
+//!   (a cubemap sky drawn behind everything; while the six faces load the
+//!    clear color shows, a failed face disables the sky with one warning;
+//!    fog does not apply to the sky — it IS the horizon)
 //! Time.seconds(n) / Time.millis(n)                          -> Duration
 //!   (like Angle: timing functions take Duration VALUES, never bare
 //!    numbers — seconds/milliseconds confusion is unrepresentable)
@@ -127,6 +132,7 @@ use crate::ui::{self, View};
 use crate::physics;
 use crate::render_target::RenderTargetDescriptor;
 use crate::scene3d::{MaterialDescription, ModelDescription, ModelHandle, TextureDescription};
+use crate::skybox::SkyboxDescription;
 use crate::{Camera, Frame, Light, Scene3D, SceneObject, Shape};
 
 /// A [`Scene3D`] as an opaque MLE value.
@@ -528,6 +534,19 @@ impl HostData for MleFog {
     }
 }
 
+/// A [`SkyboxDescription`] as an opaque MLE value — `Skybox.files(…)`.
+/// `Frame.withSkybox` accepts ONLY this (the Angle rule).
+pub struct MleSkybox(pub SkyboxDescription);
+
+impl HostData for MleSkybox {
+    fn type_name(&self) -> &'static str {
+        "Skybox"
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
 impl HostData for MleDuration {
     fn type_name(&self) -> &'static str {
         "Duration"
@@ -704,6 +723,8 @@ const PATHS: &[&str] = &[
     "Frame.withFog",
     "Fog.linear",
     "Fog.exp",
+    "Frame.withSkybox",
+    "Skybox.files",
     "RenderTarget.named",
     "RenderTarget.sized",
     "Scene.screen",
@@ -1404,6 +1425,35 @@ frame's main pass",
                 }
                 _ => usage("Frame.withFog(frame, fog)"),
             },
+            "Skybox.files" => match args.as_slice() {
+                [Value::String(px), Value::String(nx), Value::String(py), Value::String(ny), Value::String(pz), Value::String(nz)]
+                    if ![px, nx, py, ny, pz, nz].iter().any(|s| s.is_empty()) =>
+                {
+                    Ok(host(MleSkybox(SkyboxDescription::new(
+                        px.to_string(),
+                        nx.to_string(),
+                        py.to_string(),
+                        ny.to_string(),
+                        pz.to_string(),
+                        nz.to_string(),
+                    ))))
+                }
+                _ => usage(
+                    "Skybox.files(px, nx, py, ny, pz, nz) — six non-empty face \
+paths (+X, -X, +Y, -Y, +Z, -Z)",
+                ),
+            },
+            // Frame first, so it pipes: `frame |> Frame.withSkybox(sky)`.
+            "Frame.withSkybox" => match args.as_slice() {
+                [frame, sky] => {
+                    let Some(inner) = frame_value(frame) else {
+                        return usage("Frame.withSkybox(frame, skybox)");
+                    };
+                    let sky = skybox_of(sky, "Frame.withSkybox", span)?;
+                    Ok(host(MleFrame(Frame::with_skybox(inner.clone(), sky.clone()))))
+                }
+                _ => usage("Frame.withSkybox(frame, skybox)"),
+            },
             // Scene first, so it pipes: `Scene.quad() |> Scene.screen(feed)` —
             // an emissive (fullbright, screens glow) surface showing the
             // target's texture. A target no frame declares shows magenta.
@@ -2057,6 +2107,37 @@ fn scene_of(value: &Value) -> Option<&Scene3D> {
     }
 }
 
+/// Extract a [`SkyboxDescription`] — `Frame.withSkybox` accepts ONLY the
+/// branded value, so the predictable mistake (a bare path string) gets a
+/// teaching error pointing at `Skybox.files` (the [`angle_of`] rule).
+fn skybox_of<'a>(
+    value: &'a Value,
+    what: &str,
+    span: Span,
+) -> Result<&'a SkyboxDescription, RunError> {
+    match value {
+        Value::HostData(data) => data
+            .as_any()
+            .downcast_ref::<MleSkybox>()
+            .map(|s| &s.0)
+            .ok_or_else(|| RunError {
+                message: format!("{what}: expected a Skybox, got {}", value.kind_name()),
+                span,
+            }),
+        Value::String(_) => Err(RunError {
+            message: format!(
+                "{what}: expected a Skybox, got a bare string — build one with \
+Skybox.files(px, nx, py, ny, pz, nz)"
+            ),
+            span,
+        }),
+        other => Err(RunError {
+            message: format!("{what}: expected a Skybox, got {}", other.kind_name()),
+            span,
+        }),
+    }
+}
+
 /// Extract a [`RenderTargetDescriptor`] — both use sites accept ONLY the
 /// branded value, so the predictable mistake (a bare id string) gets a
 /// teaching error pointing at `RenderTarget.named` instead of a generic
@@ -2640,6 +2721,56 @@ Fog.linear(near, far, r, g, b) or Fog.exp(density, r, g, b)"
         assert_eq!(
             fail("let main = () => Fog.exp(-1.0, 0.5, 0.5, 0.5)"),
             "Fog.exp density must be positive, got -1"
+        );
+    }
+
+    // The skybox vocabulary: a branded Skybox on the frame, six faces in GL
+    // upload order, round-tripping the protocol wire shape.
+    #[test]
+    fn mle_snippet_declares_a_skybox() {
+        let frame = frame_of(
+            "let sky = Skybox.files(\"px.jpg\", \"nx.jpg\", \"py.jpg\", \"ny.jpg\", \
+\"pz.jpg\", \"nz.jpg\")\n\
+             let main = () =>\n\
+             Frame.create(Camera.lookAt(0.0, 2.0, -8.0, 0.0, 1.0, 0.0), Scene.cube())\n\
+             |> Frame.withSkybox(sky)",
+        );
+        let sky = frame.skybox.as_ref().expect("skybox set");
+        assert_eq!(
+            sky.faces(),
+            ["px.jpg", "nx.jpg", "py.jpg", "ny.jpg", "pz.jpg", "nz.jpg"]
+        );
+        let json = serde_json::to_string(&frame).expect("serialize");
+        let back: Frame = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(serde_json::to_string(&back).unwrap(), json);
+    }
+
+    // [units, tier 1 — the Angle rule] Frame.withSkybox accepts ONLY the
+    // branded value; a bare path string gets the teaching error, and empty
+    // face paths are rejected at construction.
+    #[test]
+    fn bare_strings_are_not_skyboxes() {
+        let fail = |src: &str| {
+            let module = mle::lower(mle::parse(src).unwrap()).unwrap();
+            mle::run_with_host(&module, Tracing::Off, &mut FunctorHost)
+                .err()
+                .expect("should fail")
+                .error
+                .message
+        };
+        assert_eq!(
+            fail(
+                "let main = () => Frame.create(Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0), \
+Scene.cube()) |> Frame.withSkybox(\"sky.jpg\")"
+            ),
+            "Frame.withSkybox: expected a Skybox, got a bare string — build one with \
+Skybox.files(px, nx, py, ny, pz, nz)"
+        );
+        assert_eq!(
+            fail("let main = () => Skybox.files(\"px.jpg\", \"\", \"py.jpg\", \"ny.jpg\", \
+\"pz.jpg\", \"nz.jpg\")"),
+            "usage: Skybox.files(px, nx, py, ny, pz, nz) — six non-empty face \
+paths (+X, -X, +Y, -Y, +Z, -Z)"
         );
     }
 

--- a/scripts/fetch-assets.mjs
+++ b/scripts/fetch-assets.mjs
@@ -1,28 +1,44 @@
-// Fetch the sample glTF assets referenced by the examples. None are checked
-// into the repo (*.glb is gitignored). Source: BabylonJS/Assets, which is
-// credited in the README. Existing files are left alone, so this is safe to
-// re-run.
+// Fetch the sample assets referenced by the examples (glTF models, skybox
+// faces). None are checked into the repo (*.glb / example *.jpg are
+// gitignored). Source: BabylonJS/Assets, which is credited in the README.
+// Existing files are left alone, so this is safe to re-run.
 //
 // Usage: npm run fetch:assets
 
 import { writeFile, stat } from "node:fs/promises";
 import path from "node:path";
 
-const BASE_URL = "https://raw.githubusercontent.com/BabylonJS/Assets/master/meshes";
+const MESHES_BASE = "https://raw.githubusercontent.com/BabylonJS/Assets/master/meshes";
+const SKYBOX_BASE =
+  "https://raw.githubusercontent.com/BabylonJS/Assets/master/skyboxes/TropicalSunnyDay";
 
 // Which assets each sample needs (a sample loads them relative to its own dir).
 const TARGETS = [
   {
     dir: "examples/hello",
+    baseUrl: MESHES_BASE,
     assets: ["shark.glb", "ExplodingBarrel.glb", "fish.glb", "Xbot.glb"],
   },
   {
     dir: "examples/lighting",
+    baseUrl: MESHES_BASE,
     assets: ["shark.glb"],
   },
   {
     dir: "examples/mle-hello-gltf",
     assets: ["shark.glb", "ExplodingBarrel.glb", "fish.glb", "Xbot.glb"],
+  },
+  {
+    dir: "examples/mle-atmosphere",
+    baseUrl: SKYBOX_BASE,
+    assets: [
+      "TropicalSunnyDay_px.jpg",
+      "TropicalSunnyDay_nx.jpg",
+      "TropicalSunnyDay_py.jpg",
+      "TropicalSunnyDay_ny.jpg",
+      "TropicalSunnyDay_pz.jpg",
+      "TropicalSunnyDay_nz.jpg",
+    ],
   },
 ];
 
@@ -36,7 +52,7 @@ async function exists(filePath) {
 }
 
 let failures = 0;
-for (const { dir, assets } of TARGETS) {
+for (const { dir, baseUrl, assets } of TARGETS) {
   for (const name of assets) {
     const dest = path.join(dir, name);
     if (await exists(dest)) {
@@ -44,7 +60,7 @@ for (const { dir, assets } of TARGETS) {
       continue;
     }
 
-    const url = `${BASE_URL}/${name}`;
+    const url = `${baseUrl}/${name}`;
     process.stdout.write(`fetching ${dest} ... `);
     try {
       const response = await fetch(url);


### PR DESCRIPTION
Final slice of the atmosphere stack (#201 fog engine → #202 fog MLE → #204 skybox engine → this). MLE gets the skybox vocabulary and `examples/mle-atmosphere` gets its sky.

## Prelude

```mle
let sky = Skybox.files(
  "TropicalSunnyDay_px.jpg", "TropicalSunnyDay_nx.jpg",
  "TropicalSunnyDay_py.jpg", "TropicalSunnyDay_ny.jpg",
  "TropicalSunnyDay_pz.jpg", "TropicalSunnyDay_nz.jpg")

frame |> Frame.withFog(fog) |> Frame.withSkybox(sky)
```

- `Skybox.files` is a **branded value** (the `Angle` rule): six non-empty face paths in GL upload order (+X..-Z); `Frame.withSkybox` accepts only the value — a bare path string gets the teaching error pointing at `Skybox.files`.
- Engine semantics (from #204): faces resolve from the game dir, the clear color shows while they load, a failed face disables the sky with one warning, and fog never fogs the sky.

## The finished demo

`examples/mle-atmosphere` gains the TropicalSunnyDay sky, with the fog color retuned to the sky's **measured** horizon band (0.93, 0.95, 0.96 — sampled from the capture) so the colonnade dissolves *into* the sky with no seam. Faces are fetched, not checked in: `scripts/fetch-assets.mjs` grows per-target base URLs + the six-face set (BabylonJS/Assets, already credited); the example gets a `.gitignore`.

## Verification

- `cargo test -p functor_runtime_common` — 153 passed (skybox frame round-trip via MLE, face order, teaching-error pins).
- `functor -d examples/mle-atmosphere build` typechecks; `npm run build:cli`.
- Deterministic native captures at two fixed times **and a WebGL2 check**: headless Chromium screenshot of `functor run wasm` renders the same sky + fog (cubemap upload confirmed on ANGLE). Visuals below.
- Gotcha reaffirmed: asset paths resolve against the runner's cwd — capture through `functor -d <dir> run native`, not a bare `functor-runner` from the repo root (which quietly renders no sky).
- Cross-engine review (`/xreview`, Claude + Codex): fixes applied — the fog/sky horizon seam (fog color was ~0.74 vs the sky's ~0.97 horizon; retuned by sampling) [Codex] and a misattached extractor doc comment [AGREED].

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Visuals

![mle-atmosphere demo](https://gist.githubusercontent.com/tommy-xr/51a33658f542aaa82cdee1ec134cfcf0/raw/atmo-sky.gif)

<sub>examples/mle-atmosphere, finished: the colonnade dissolves into fog tuned to the TropicalSunnyDay horizon; the drifter fades as it orbits deeper. Rendered headlessly via `functor -d … run native --fixed-time / --capture-frame`.</sub>

![still t=2.0](https://gist.githubusercontent.com/tommy-xr/51a33658f542aaa82cdee1ec134cfcf0/raw/atmo-sky.png)

<sub>t=2.0</sub>

![still t=7.0](https://gist.githubusercontent.com/tommy-xr/51a33658f542aaa82cdee1ec134cfcf0/raw/atmo-sky-t7.png)

<sub>t=7.0</sub>

![wasm screenshot](https://gist.githubusercontent.com/tommy-xr/51a33658f542aaa82cdee1ec134cfcf0/raw/atmo-sky-wasm.png)

<sub>the same scene on WebGL2 (headless Chromium via `functor run wasm`) — cubemap upload verified on ANGLE.</sub>
