### PR TITLE
fix(mle): B6-contract lift in the match-arm join — effect games check again

### DIFF
--- a/.claude/skills/mle-language/SKILL.md
+++ b/.claude/skills/mle-language/SKILL.md
@@ -251,6 +251,8 @@ through a hot reload. Fired messages fold through `update` before `tick`.
 Durations, like Angles, are branded values — `Sub.every(0.5, …)` is a
 teaching error; say `Time.seconds(0.5)` or `Time.millis(500.0)`.
 
+A bare-model arm and a `(model, effect)` arm may mix in one match — the
+checker lifts bare to `(model, Effect.none())`, matching the producer.
 Effects are one-shot commands: the producer performs each one, applies its
 tagger to the result (`Effect.random(Rolled)` → `Rolled(0.42)`), and folds
 the message back through `update` — which may itself return more effects

--- a/mle/src/types.rs
+++ b/mle/src/types.rs
@@ -1452,18 +1452,7 @@ the type: `type Name<{name}> = …`"
             let body_ty = self.infer(&arm.body);
             result = Some(match result {
                 None => body_ty,
-                Some(prev) => {
-                    if !self.unify_rec(&prev, &body_ty, arm.body.span, "match arm") {
-                        let (prev_n, body_n) = self.normalize_pair(&prev, &body_ty);
-                        self.diag(
-                            arm.body.span,
-                            format!("match arms have incompatible types {prev_n} and {body_n}"),
-                        );
-                        Type::Unknown
-                    } else {
-                        self.zonk(&prev)
-                    }
-                }
+                Some(prev) => self.join_arms(prev, body_ty, arm.body.span),
             });
         }
         // Exhaustiveness fires only where the scrutinee's type is known —
@@ -1537,6 +1526,39 @@ a catch-all arm (`_` or a name)"
             }
         }
         result.unwrap_or(Type::Unknown)
+    }
+
+    /// Join two match arms' types. Plain unification, with ONE contract
+    /// lift first: the B6 producer treats a bare model as
+    /// `(model, Effect.none())`, so an arm returning `m` beside an arm
+    /// returning `(m, effect)` joins as the PAIR — otherwise the unifier
+    /// is asked for the infinite type `'a = 'a * Unknown` and every
+    /// effect-returning game fails `functor build`. The lift keys on the
+    /// pair's second element being the host seam (Unknown), so real tuple
+    /// mismatches (`(m, 1.0)` vs `m`) still error.
+    fn join_arms(&mut self, prev: Type, body: Type, span: Span) -> Type {
+        let (p, b) = (self.zonk(&prev), self.zonk(&body));
+        for (pair, bare) in [(&p, &b), (&b, &p)] {
+            if let Type::Tuple(items) = pair {
+                if items.len() == 2
+                    && items[1] == Type::Unknown
+                    && !matches!(bare, Type::Tuple(_))
+                    && self.unify_rec(bare, &items[0], span, "match arm")
+                {
+                    return Type::Tuple(vec![self.zonk(&items[0]), Type::Unknown]);
+                }
+            }
+        }
+        if !self.unify_rec(&p, &b, span, "match arm") {
+            let (prev_n, body_n) = self.normalize_pair(&p, &b);
+            self.diag(
+                span,
+                format!("match arms have incompatible types {prev_n} and {body_n}"),
+            );
+            Type::Unknown
+        } else {
+            self.zonk(&p)
+        }
     }
 
     /// Check one pattern against the scrutinee's type and record its

--- a/mle/tests/check.rs
+++ b/mle/tests/check.rs
@@ -1019,3 +1019,26 @@ fn functions_inside_generic_nominals_cannot_compare() {
     );
     assert_eq!(message, "functions cannot be compared with `==`");
 }
+
+/// The B6 contract lift: a bare-model arm beside a (model, effect) arm
+/// joins as the pair (the producer treats bare as (m, Effect.none())) —
+/// without this, every effect game failed `functor build` on the occurs
+/// check ('a = 'a * Unknown). Both arm orders; annotated models too.
+#[test]
+fn effect_pair_arms_join_with_bare_model_arms() {
+    for src in [
+        "type Msg = | Roll | Rolled(n: Float)\n\
+         let update = (m, msg) => match msg with | Roll => (m, Effect.random(Rolled)) | Rolled(n) => m",
+        "type Msg = | Roll | Rolled(n: Float)\n\
+         let update = (m, msg) => match msg with | Rolled(n) => m | Roll => (m, Effect.random(Rolled))",
+        "type Model = { roll: Float }\n\
+         type Msg = | Roll | Rolled(n: Float)\n\
+         let update = (m: Model, msg) => match msg with | Roll => (m, Effect.random(Rolled)) | Rolled(n) => { m with roll: n }",
+    ] {
+        let diags = check_src(src);
+        assert!(diags.is_empty(), "should lift: {src}\n{diags:?}");
+    }
+    // The lift keys on the HOST seam — a real tuple mismatch still errors.
+    let diags = check_src("let f = (b, m) => match b with | true => (m, 1.0) | false => m");
+    assert_eq!(diags.len(), 1, "{diags:?}");
+}


### PR DESCRIPTION
## What

B7's arm-join unification (a correct review fix) collided with B6's union-shaped return contract: a bare-model arm beside a `(model, effect)` arm asks the unifier for the infinite type `'a = 'a * Unknown`, so **every effect-returning game failed `mle check` / `functor build` on main** — masked because the runner treats diagnostics as warnings. Diagnosed from the B8 agent's report.

## Fix

`join_arms` applies the same lift the producer applies at runtime (`split_model_effect` treats a bare model as `(m, Effect.none())`): when one arm is a 2-tuple whose second element is the host seam (`Unknown`) and the other arm unifies with its **first** element, the join is the pair type. The lift keys on `Unknown`, so real tuple mismatches (`(m, 1.0)` vs `m`) still error. The principled fix — typed effect signatures / the `effect[...]` header the B7 roadmap note anticipated — remains the roadmap item; this restores the documented B6 ergonomics under HM today.

## Verification

Pinned: both arm orders, annotated models, and the negative case — **250 mle tests green**. The skill documents the mixing rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)