### PR TITLE
feat(site): pixel-type accents + status tooltip seam

### DIFF
--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -134,7 +134,7 @@ const playerFrame = (page) => {
   // Live edit → unmistakable green sphere.
   await page.evaluate((s) => window.__sandbox.setSource(s), GREEN);
   await page.waitForFunction(
-    () => window.__sandbox.status().text.includes("model preserved"),
+    () => window.__sandbox.status().message.includes("model preserved"),
     { timeout: 5000 }
   );
   await sleep(400);

--- a/site/docs.html
+++ b/site/docs.html
@@ -11,7 +11,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Orbitron:wght@600;800&family=JetBrains+Mono:ital,wght@0,400;0,600;1,400&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Orbitron:wght@600;800&family=Press+Start+2P&family=JetBrains+Mono:ital,wght@0,400;0,600;1,400&display=swap"
       rel="stylesheet"
     />
     <link rel="stylesheet" href="styles.css" />

--- a/site/index.html
+++ b/site/index.html
@@ -11,7 +11,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Orbitron:wght@600;800&family=JetBrains+Mono:ital,wght@0,400;0,600;1,400&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Orbitron:wght@600;800&family=Press+Start+2P&family=JetBrains+Mono:ital,wght@0,400;0,600;1,400&display=swap"
       rel="stylesheet"
     />
     <link rel="stylesheet" href="styles.css" />

--- a/site/sandbox.html
+++ b/site/sandbox.html
@@ -11,7 +11,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Orbitron:wght@600;800&family=JetBrains+Mono:ital,wght@0,400;0,600;1,400&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Orbitron:wght@600;800&family=Press+Start+2P&family=JetBrains+Mono:ital,wght@0,400;0,600;1,400&display=swap"
       rel="stylesheet"
     />
     <link rel="stylesheet" href="styles.css" />

--- a/site/src/sandbox.js
+++ b/site/src/sandbox.js
@@ -33,6 +33,9 @@ let pushTimer = null;
 const setStatus = (state, text, detail = "") => {
   statusPill.dataset.state = state;
   statusPill.textContent = text;
+  // Every transition clears the tooltip (the ok branch below re-sets it) so
+  // a stale "model preserved" can't contradict a later error or fresh load.
+  statusPill.title = "";
   statusLog.textContent = detail;
   statusLog.hidden = detail === "";
 };
@@ -88,8 +91,14 @@ window.addEventListener("message", (event) => {
     // A reply from the outgoing document (its WindowProxy survives the src
     // swap) must not overwrite the "loading…" status of the incoming one.
     if (!previewReady) return;
-    if (data.ok) setStatus("live", `● live — ${data.message}`);
-    else setStatus("error", "✖ error", data.message);
+    if (data.ok) {
+      setStatus("live", "● live");
+      // The runtime's status line ("reloaded … model preserved") stays
+      // reachable — hover the pill, or the e2e's status() seam below.
+      statusPill.title = data.message;
+    } else {
+      setStatus("error", "✖ error", data.message);
+    }
   }
 });
 
@@ -189,6 +198,7 @@ window.__sandbox = {
   status: () => ({
     state: statusPill.dataset.state,
     text: statusPill.textContent,
+    message: statusPill.title,
     detail: statusLog.textContent,
   }),
 };

--- a/site/styles.css
+++ b/site/styles.css
@@ -17,6 +17,7 @@
   --red: #ff5d7a;
   --font-display: "Orbitron", system-ui, sans-serif;
   --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, monospace;
+  --font-arcade: "Press Start 2P", "Orbitron", monospace;
 }
 
 * {
@@ -94,13 +95,14 @@ a:hover {
 }
 
 .hero-tagline {
-  font-family: var(--font-display);
-  font-weight: 600;
-  font-size: clamp(1rem, 2.6vw, 1.5rem);
-  letter-spacing: 0.12em;
+  font-family: var(--font-arcade);
+  font-size: clamp(0.7rem, 1.6vw, 1rem);
+  line-height: 1.8;
+  letter-spacing: 0.08em;
   color: var(--text);
-  margin: 12px 0 0;
+  margin: 18px 0 0;
   text-transform: uppercase;
+  text-shadow: 0 0 12px rgba(39, 232, 247, 0.5);
 }
 
 .hero-sub {
@@ -119,13 +121,13 @@ a:hover {
 
 .button-primary,
 .button-ghost {
-  font-family: var(--font-display);
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  padding: 12px 26px;
+  font-family: var(--font-arcade);
+  letter-spacing: 0.06em;
+  padding: 14px 26px;
   border-radius: 4px;
   text-transform: uppercase;
-  font-size: 0.9rem;
+  font-size: 0.7rem;
+  line-height: 1.4;
 }
 
 .button-primary {
@@ -269,11 +271,10 @@ a:hover {
 }
 
 .wordmark {
-  font-family: var(--font-display);
-  font-weight: 800;
-  letter-spacing: 0.12em;
+  font-family: var(--font-arcade);
+  letter-spacing: 0.05em;
   color: var(--text);
-  font-size: 0.95rem;
+  font-size: 0.7rem;
 }
 
 .wordmark-accent {
@@ -316,8 +317,9 @@ a:hover {
 }
 
 .status-pill {
-  font-size: 0.8rem;
-  padding: 5px 12px;
+  font-family: var(--font-arcade);
+  font-size: 0.55rem;
+  padding: 7px 12px;
   border-radius: 999px;
   border: 1px solid var(--line);
   white-space: nowrap;


### PR DESCRIPTION
Follows #198 / #203.

## What

The typography that survived the vibe experiments: **Press Start 2P pixel-type accents** over the existing synthwave look — wordmark, hero tagline, buttons, and the sandbox status pill. Retrocomputing by type; the wording stays neutral (a virtual-arcade room hero, CRT scanline overlays, and INSERT COIN / READY P1 arcade language were all prototyped and dropped by design review).

Also a small status-pill improvement that came out of review: the runtime's real reload message ("reloaded … model preserved") moves to the pill's tooltip and the `window.__sandbox.status().message` test seam, cleared on every status transition so a stale success message can never contradict an error state.

## Before → after

![before/after landing](https://gist.githubusercontent.com/tommy-xr/c9d929b43c3db1637aef9fb69cf1fded/raw/vibe-beforeafter.png)

<sub>landing: same synthwave hero, pixel-type buttons and tagline</sub>

![sandbox](https://gist.githubusercontent.com/tommy-xr/c9d929b43c3db1637aef9fb69cf1fded/raw/vibe-final-sandbox.png)

<sub>sandbox: pixel-type chrome, plain "● live" status with the reload detail in the tooltip</sub>

## Verification

`npm run test:site` — 13/13 checks pass; the live-edit check asserts on `status().message` (the tooltip seam). Cross-engine review (Claude + Codex) ran on the arcade-wording iteration of this diff; the wording was then neutralized per design review with no logic changes beyond the reviewed tooltip seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
