### PR TITLE
feat(physics,mle): Phase 6 — pause/rewind/replay (the culmination)

### DIFF
--- a/.claude/skills/mle-language/SKILL.md
+++ b/.claude/skills/mle-language/SKILL.md
@@ -293,6 +293,9 @@ Physics.raycast(ox, oy, oz, dx, dy, dz, maxDist, tagger)   // -> Effect (QUERY):
 Physics.events(tagger)                                     // -> Sub (from `subscriptions`):
                                                            //   tagger gets {started, a, b,
                                                            //   sensor} per contact begin/end
+Physics.pause() / Physics.resume() / Physics.stepOnce()   // -> Effect: recorder controls
+Physics.rewindTo(frame)                                    // -> Effect: seek (resume = branch)
+Physics.timelineFrame()                                    // -> Float: current fixed frame
 ```
 
 `Physics.position` / `Physics.transformed` read the live stepped world
@@ -337,6 +340,16 @@ b: Text, sensor: Bool}` — `a`/`b` are the pair's tags in rapier's
 a `Physics.sensor` body (no contact forces). Events for a pair whose body
 was despawned this frame are dropped (there is nothing left to name), and
 a frame's undelivered events never carry over.
+
+The physics drive is **recorded** (docs/physics.md, the culmination):
+`Physics.pause()`/`resume()`/`stepOnce()` freeze and single-step the
+simulation; `Physics.rewindTo(frame)` seeks the recorded timeline and
+`Physics.timelineFrame()` reads the current fixed frame (for scrub math,
+e.g. `rewindTo(timelineFrame() - 10.0)`). These are fire-and-forget
+effects (no tagger). Resuming after a rewind **branches** — the old future
+is discarded, so a different input replays a different timeline. History is
+bounded (~15s at 60Hz); rewind clamps to it. Everything is deterministic:
+replaying identical inputs from a rewind reproduces the run byte-for-byte.
 
 
 A runner-hosted game (`functor-runner --mle --game-path game.mle`) defines:

--- a/docs/physics.md
+++ b/docs/physics.md
@@ -535,25 +535,37 @@ the boundary problem reduces to player-touches-prop, which the server
 arbitrates (the player body is kinematic to the server's world, so props can't
 push the player — the usual VR choice).
 
-## Culmination: pause / rewind / replay via keyboard
+## Culmination: pause / rewind / replay via keyboard — SHIPPED
 
-The first user-visible payoff, and the proof the `Timeline` works. Input is
-event-only today (no polling snapshot), and `Input.Key` already has
-`Space`/`Left`/`Right`/`P`/`R`, so controls map onto `KeyDown` edges — the same
-scheme `netsim_viz` already uses (Space = pause, Right = step):
+The user-visible payoff, and the proof the `Timeline` works at runtime. The
+shell-side `SteppedPhysics` recorder (`physics/driver.rs`) replaces the
+drivers' direct `reconcile + step_frame` with per-fixed-frame recording
+through `TimelineLog`: each substep is recorded with exactly the `Command`s
+that produce it (the frame's `DeclareScene` + any queued `PhysicsCommand`s),
+then run through `Simulatable::step` — the **same path a `seek` replays**, so
+live and replayed frames are byte-identical by construction (the recorder
+tests assert this). Controls arrive as tagger-less effects queued for the
+recorder (the world's command-queue pattern, one level up).
 
-- **Space** → `Physics.pause` / `Physics.resume` (toggle).
-- **Left / Right** (while paused) → `Physics.rewindTo (frame ∓ 1)` /
-  `Physics.stepOnce`. Scrub the world; `draw3d` reads the rewound state via the
-  `Physics.View`, so the scene visibly moves backward/forward.
-- **R** → rewind to frame 0 and `resume` — deterministic **replay** (no new input)
-  re-runs the identical simulation; applying a fresh impulse instead **branches**
-  it, demonstrating determinism live.
+The `examples/mle-physics` bindings:
 
-An `examples/hello-physics` scene (a few `dynamic` boxes settling on a `fixedBody`
-plane) drives this. The egui overlay shows **read-only status** — current frame,
-paused/live, timeline strategy, history depth — since egui input isn't wired yet;
-all control is via the keyboard, exactly as scoped.
+- **P** -> `Physics.pause()` / `Physics.resume()` (toggle). Paused, real time
+  doesn't accumulate — resuming never fast-forwards.
+- **Left / Right** -> `Physics.rewindTo(Physics.timelineFrame() - 10.0)` /
+  `Physics.stepOnce()`. Scrub backward (10 fixed frames per key-repeat) and
+  single-step forward; `draw` reads the rewound world live
+  (`Physics.transformed`), so the scene visibly moves.
+- **G** -> `rewindTo(0)` + `resume` — deterministic **replay** from the oldest
+  recorded frame; pressing **K** mid-replay applies a fresh impulse and
+  **branches** the timeline (`TimelineLog::truncate_from` discards the old
+  future), demonstrating determinism-and-divergence live.
+
+The status overlay (`View`, the existing 2D text layer) shows **read-only
+status** — current fixed frame, history depth, the scrub keys — while paused;
+all *control* is via the keyboard, since egui input isn't wired. History is
+bounded (~15s at 60Hz, pruned each frame); `rewindTo` clamps to it. Frame 0's
+pre-step state is the empty world, so the rewind floor is frame 1 (the world's
+first stepped state) — reads never hit an empty world.
 
 ## Debug visualization (wireframes via Rapier's debug renderer)
 
@@ -640,7 +652,7 @@ It's worth building in two steps, because they exercise different machinery:
 | **4. Queries** | `Physics.raycast` as a deferred tagger effect over the B6.5 structured-payload broker (`EffectValue`); performed post-step for same-frame freshness; fake/replay runners can raycasts. `shapeCast` deferred until a game needs it. **Shipped (MLE).** | native+wasm (MLE) |
 | **5. Collision events** | `Physics.events(tagger)` sub: contact begin/end as `{started, a, b, sensor}` records, collected per fixed substep (rapier `ActiveEvents::COLLISION_EVENTS` on every collider), delivered post-step through `update`; `Simulatable::step` now returns the frame's events (the doc's original seam). **Shipped (MLE).** | native+wasm (MLE) |
 | **5b. Entity abstraction** | `Entities<'e>` + `Archetype` model-layer library, `Scene3D.instances` primitive, reconcile bail-out + tag interning, despawn-on-collision; `hello-physics` grows a bullet/debris archetype. | both |
-| **6. Pause/rewind/replay** | timeline-control effects + keyboard wiring + egui status overlay (the culmination). | both |
+| **6. Pause/rewind/replay** | `SteppedPhysics` recorder over the 1b `Timeline`: `Physics.pause`/`resume`/`stepOnce`/`rewindTo` control effects, `timelineFrame` read, per-fixed-frame recording (byte-identical to replay by construction), rewind-then-branch via `TimelineLog::truncate_from`, bounded history, read-only status overlay + keyboard scrub in `mle-physics`. **Shipped (MLE).** | native+wasm (MLE) |
 | **7a. Networked physics (state-sync)** | `Authority`, `mpserver`/`mpclient` grown to client-owned balls + server-owned objects, kinematic `Remote` + interpolation. No prediction. | both |
 | **7b. Prediction + reconciliation** | Server-authoritative ball, client input + prediction, structural `server`/`client` collections (network snapshot = `server`; reconcile = field swap), `Timeline` reconcile, `netsim_viz` ghosts + divergence metrics, latency-sweep convergence tests. | both |
 

--- a/docs/physics.md
+++ b/docs/physics.md
@@ -1,9 +1,39 @@
 # Physics design
 
-Status: **active** (design; no code yet). This is the design doc and roadmap for
-physics in Functor. It builds on the same seams as `docs/multiplayer.md` (effect
-queue, subs, the `functor-netsim` deterministic harness) and supersedes the
-`Physics` stub in `docs/todo.md`.
+Status: **the core roadmap is shipped** (Phases 1a–6, on the MLE surface). This
+is the design doc *and* the record of what landed; it builds on the same seams
+as `docs/multiplayer.md` (effect queue, subs, the `functor-netsim` deterministic
+harness) and supersedes the `Physics` stub in `docs/todo.md`.
+
+### What shipped (as of 2026-07-05)
+
+Rigid-body physics is live in `runtime/functor-runtime-common/src/physics/`
+(pure Rust: `scene`/`world`/`timeline`/`driver`/`registry`), driven from the
+**MLE** game surface (`mle_prelude.rs` `Physics.*`; the `mle-language` skill is
+the vocabulary reference). Every phase below is annotated **Shipped** in the
+roadmap table; the highlights:
+
+- **Declarative bodies** (`Physics.scene`/`dynamic`/`kinematic`/`fixed` + the
+  divergence rule), **live reads** (`Physics.position`/`transformed`),
+  **commands** (impulse/force/velocity/teleport), **raycast queries**,
+  **collision events** (`Physics.events`), and **pause/rewind/replay**
+  (`Physics.pause`/`resume`/`stepOnce`/`rewindTo`) — all on the MLE prelude,
+  native + wasm.
+- **Determinism goldens**, the `Simulatable`/`Timeline` rewind seam, and a
+  `--debug-render physics` collider-wireframe overlay (native).
+- `examples/mle-physics` exercises the whole surface (K kick, R raycast, P/Left/
+  Right/G timeline scrub, contact-flash).
+
+**Not yet built:** the model-layer `Entities`/`Archetype` abstraction (5b),
+networked physics (7a/7b — the `mpserver`/`mpclient` demo), and cross-target
+determinism (8, likely unneeded). See the roadmap table.
+
+**Design-doc note:** the surface shipped on **MLE**, so the F#-shaped API
+sketches below (`physicsScape`, `DrawContext`/`Physics.View`, the token-keyed
+query registry) are the **retained reference design**, not what runs — the
+`## Surface: MLE-first` section explains the pivot. Types and semantics map
+one-for-one to the Rust engine; an F# surface would just need the boundary
+plumbing MLE's in-process interpreter made unnecessary.
 
 ## Goal
 
@@ -41,9 +71,11 @@ Like rendering and audio, physics must be **drivable and observable headlessly**
 - **The effect queue is no longer persisted across hot reload** (see
   `multiplayer.md` / `effects-plain-data-invariant`). So physics *commands*
   (impulse/force/teleport — plain data) and *queries* (raycast/shapecast, which
-  carry a `tagger` closure) both work the way HTTP does: the tagger is held in a
-  thread-local, dylib-bound registry keyed by token, and an in-flight query loses
-  its tagger across a reload (dropped with a warning — a dev-only trade).
+  carry a `tagger`) are effects, not persisted state. *(This bullet describes
+  the F# design where the tagger would ride a thread-local, dylib-bound token
+  registry like HTTP. What shipped is simpler: MLE runs in-process, so a query
+  defers within the frame and its tagger is applied post-step directly — no
+  token registry, no cross-reload dangling. See `## Surface: MLE-first`.)*
 - **Subs are recomputed each frame and not persisted.** Collision/contact events
   and the per-frame step read-back are delivered as `Sub`s, matched across
   recomputations by their decoder identity.
@@ -67,7 +99,7 @@ Like rendering and audio, physics must be **drivable and observable headlessly**
         │  WorldRegistry      — WorldId -> live Rapier world (singleton = id 0)  │
         │  reconcile()        — diff PhysicsScene vs live bodies, keyed by tag   │
         │  fixed-step driver  — accumulator; step(dt, cmds) -> events            │
-        │  Timeline (trait)   — KeyframeLog | SnapshotRing | ReplayOnly          │
+        │  Timeline (trait)   — TimelineLog: keyframes(n) | snapshot_ring | replay_only │
         │  Simulatable (trait)— snapshot / restore / step  (Rapier serde)        │
         └───────────────────────────────────────────────────────────────────────┘
             native: functor-runner            │   wasm: web-runtime bundle
@@ -422,9 +454,9 @@ What local determinism requires from us (the fine print):
 - **Deterministic reconcile order across the whole world history, removals
   included.** Rapier arena handles depend on the full insert/*remove* sequence,
   not just the final set of bodies — so the reconcile diff (sort by tag) must be
-  fully deterministic for despawns too. Snapshot-based seeks (`KeyframeLog`,
-  `SnapshotRing`) are safe by construction (serde restores the arenas exactly);
-  `ReplayOnly` re-executes the history and leans on this.
+  fully deterministic for despawns too. Snapshot-based seeks (`keyframes(n)`,
+  `snapshot_ring`) are safe by construction (serde restores the arenas exactly);
+  `replay_only` re-executes the history and leans on this.
 - **Replays are valid per-build only.** Fine for time-travel debugging (same
   session) and netcode (ephemeral); don't persist replays as long-lived
   artifacts. Hot-reloading the *game dylib* is safe — Rapier lives in the
@@ -593,15 +625,19 @@ one place and physics has in another — visible immediately.
 
 ## Test harness (extends `functor-netsim`)
 
-The deterministic netsim (`docs/multiplayer.md` Phase 3) is the verification tool:
+The deterministic netsim (`docs/multiplayer.md` Phase 3) is the verification tool.
+The first three goldens are **shipped** (pure Rust, no GL, in
+`physics/goldens.rs`, run under `cargo test`); the last two are the netcode
+phase (7):
 
-- **Determinism golden** (pure Rust, no GL): step an identical scene + identical
+- **Determinism golden** *(shipped)*: step an identical scene + identical
   command log in two fresh worlds for N frames; assert byte-identical snapshots
   each frame.
-- **Strategy-equivalence golden**: run the same `Simulatable` + command log through
-  `KeyframeLog` and `SnapshotRing`; assert `seek(K)` is byte-identical for every K.
-  This is both rewind-correctness and a determinism check.
-- **Replay golden**: record an input log, `ReplayOnly`-seek to the end, assert it
+- **Strategy-equivalence golden** *(shipped)*: run the same `Simulatable` +
+  command log through `TimelineLog::keyframes(n)` and `snapshot_ring()`; assert
+  `seek(K)` is byte-identical for every K. Both rewind-correctness and a
+  determinism check.
+- **Replay golden** *(shipped)*: `replay_only()`-seek to the end, assert it
   matches a live run.
 - **Convergence under latency/loss** (extends `tests/mp.rs`): server + 2 clients
   with a physics scene under `LinkProfile { latency, jitter, loss }`; assert each
@@ -643,15 +679,15 @@ It's worth building in two steps, because they exercise different machinery:
 
 | Phase | Scope | Targets |
 | --- | --- | --- |
-| **1a. World spine** | Rapier dep (`serde-serialize`, default features), `physics` module (`PhysicsScene`/`Body`/`reconcile`/`WorldId` registry), fixed-step accumulator, snapshot + text/JSON dump. Determinism + restore-replay goldens. **No F# surface.** | native+wasm (Rust) |
-| **1b. Timeline seam** | `Simulatable` + `Timeline` traits, `TimelineLog` with the three cadences (`keyframes(n)` default / `snapshot_ring` / `replay_only`), strategy-equivalence + replay goldens. | native+wasm (Rust) |
-| **2. MLE surface + read-back** | `Physics.*` prelude (shape/body/scene builders, `position`/`transformed` live reads), optional `physics` hook in the MLE driver (tick → reconcile+fixed-step → draw), prelude tests. | native (MLE) |
-| **2c. `examples/mle-physics`** | Crates settling on a ground slab, hot-reload demo, golden scenario, PR GIF/PNG. | native (MLE) |
+| **1a. World spine** | Rapier dep (`serde-serialize`, default features), `physics` module (`PhysicsScene`/`Body`/`reconcile`/`WorldId` registry), fixed-step accumulator, snapshot + text/JSON dump. Determinism + restore-replay goldens. No game surface. **Shipped.** | native+wasm (Rust) |
+| **1b. Timeline seam** | `Simulatable` + `Timeline` traits, `TimelineLog` with the three cadences (`keyframes(n)` default / `snapshot_ring` / `replay_only`), strategy-equivalence + replay goldens. **Shipped.** | native+wasm (Rust) |
+| **2. MLE surface + read-back** | `Physics.*` prelude (shape/body/scene builders, `position`/`transformed` live reads), optional `physics` hook in the MLE driver (tick → reconcile+fixed-step → draw), prelude tests. **Shipped (MLE).** | native+wasm (MLE) |
+| **2c. `examples/mle-physics`** | Crates settling on a ground slab, hot-reload demo, PR GIF/PNG. **Shipped (MLE).** | native (MLE) |
 | **2b. Debug visualization** | Rapier `debug-render` feature, `World::debug_lines()`, depth-tested line pass, `--debug-render physics` mode. **Shipped.** | native |
 | **3. Commands** | `Physics.applyImpulse`/`applyForce`/`setVelocity`/`teleport` as B6 effect variants: queued at perform time, applied after the frame's reconcile before its first substep; forces last one stepped frame; recorded as `timeline::Command::Apply` in the goldens. **Shipped (MLE).** | native+wasm (MLE) |
 | **4. Queries** | `Physics.raycast` as a deferred tagger effect over the B6.5 structured-payload broker (`EffectValue`); performed post-step for same-frame freshness; fake/replay runners can raycasts. `shapeCast` deferred until a game needs it. **Shipped (MLE).** | native+wasm (MLE) |
 | **5. Collision events** | `Physics.events(tagger)` sub: contact begin/end as `{started, a, b, sensor}` records, collected per fixed substep (rapier `ActiveEvents::COLLISION_EVENTS` on every collider), delivered post-step through `update`; `Simulatable::step` now returns the frame's events (the doc's original seam). **Shipped (MLE).** | native+wasm (MLE) |
-| **5b. Entity abstraction** | `Entities<'e>` + `Archetype` model-layer library, `Scene3D.instances` primitive, reconcile bail-out + tag interning, despawn-on-collision; `hello-physics` grows a bullet/debris archetype. | both |
+| **5b. Entity abstraction** | `Entities<'e>` + `Archetype` model-layer library, `Scene3D.instances` primitive, reconcile bail-out + tag interning, despawn-on-collision; `mle-physics` grows a bullet/debris archetype. | both |
 | **6. Pause/rewind/replay** | `SteppedPhysics` recorder over the 1b `Timeline`: `Physics.pause`/`resume`/`stepOnce`/`rewindTo` control effects, `timelineFrame` read, per-fixed-frame recording (byte-identical to replay by construction), rewind-then-branch via `TimelineLog::truncate_from`, bounded history, read-only status overlay + keyboard scrub in `mle-physics`. **Shipped (MLE).** | native+wasm (MLE) |
 | **7a. Networked physics (state-sync)** | `Authority`, `mpserver`/`mpclient` grown to client-owned balls + server-owned objects, kinematic `Remote` + interpolation. No prediction. | both |
 | **7b. Prediction + reconciliation** | Server-authoritative ball, client input + prediction, structural `server`/`client` collections (network snapshot = `server`; reconcile = field swap), `Timeline` reconcile, `netsim_viz` ghosts + divergence metrics, latency-sweep convergence tests. | both |

--- a/examples/mle-physics/game.mle
+++ b/examples/mle-physics/game.mle
@@ -8,7 +8,12 @@
 // record folds through `update`, which kicks whatever the ray hit — a query
 // chaining into a command, answered against this frame's stepped world.
 // Collision events (Physics.events) flash whatever the ball touches: the
-// touched crate glows until the ball's next contact. Run with:
+// touched crate glows until the ball's next contact. And the TIMELINE
+// (docs/physics.md, the culmination): P pauses (the overlay shows the
+// frame), Left scrubs BACKWARD through recorded history, Right steps one
+// fixed frame forward, G rewinds to the oldest recorded frame and resumes
+// — a live replay; kick differently this time and the timeline branches.
+// Run with:
 //
 //   functor-runner --mle --game-path examples/mle-physics/game.mle
 //   functor -d examples/mle-physics run native
@@ -70,7 +75,7 @@ type Msg<h, e> =
   | GotHit(hit: h)
   | Contact(ev: e)
 
-let init = { drop: 0.0, spaceHeld: false, hot: "" }
+let init = { drop: 0.0, spaceHeld: false, hot: "", paused: false, pHeld: false }
 
 let tick = (model, dt, tts) => model
 
@@ -101,6 +106,33 @@ let input = (model, key, isDown) =>
        (model,
         Physics.raycast(scatterX(model.drop, 0.0), 8.0, scatterZ(model.drop, 0.0),
                         0.0, -1.0, 0.0, 20.0, GotHit)))
+  | "P" =>
+    (match isDown with
+     | false => { model with pHeld: false }
+     | true =>
+       (match model.pHeld with
+        | true => model
+        | false =>
+          (match model.paused with
+           | false => ({ model with paused: true, pHeld: true }, Physics.pause())
+           | true => ({ model with paused: false, pHeld: true }, Physics.resume()))))
+  | "Left" =>
+    // Scrub: 10 fixed frames per press/repeat (key repeats make this a
+    // smooth reverse). The clamp to recorded history is the recorder's job.
+    (match isDown with
+     | false => model
+     | true => (model, Physics.rewindTo(Physics.timelineFrame() - 10.0)))
+  | "Right" =>
+    // One fixed frame forward (only meaningful while paused).
+    (match isDown with
+     | false => model
+     | true => (model, Physics.stepOnce()))
+  | "G" =>
+    // Replay: back to the oldest recorded frame, playing. Press K mid-replay
+    // and the timeline BRANCHES from that point.
+    (match isDown with
+     | false => model
+     | true => ({ model with paused: false }, Effect.batch([Physics.rewindTo(0.0), Physics.resume()])))
   | _ => model
 
 // Contact events name both tags in rapier's pair order — find the ball's

--- a/runtime/functor-runtime-common/src/mle_prelude.rs
+++ b/runtime/functor-runtime-common/src/mle_prelude.rs
@@ -199,6 +199,10 @@ pub enum EffectTree {
     /// The game observes the outcome through the physics reads, not a
     /// message.
     Physics(physics::PhysicsCommand),
+    /// A timeline control (docs/physics.md Phase 6): tagger-less, queued
+    /// for the recorder ([`physics::SteppedPhysics`]) like commands queue
+    /// for the world.
+    Timeline(physics::TimelineControl),
     /// A physics query (docs/physics.md Phase 4). Unlike `Now`/`Random`,
     /// queries are **deferred**: the pre-step drain holds them and the
     /// driver performs them right after the frame's physics step, so the
@@ -742,6 +746,11 @@ const PATHS: &[&str] = &[
     "Physics.teleport",
     "Physics.raycast",
     "Physics.events",
+    "Physics.pause",
+    "Physics.resume",
+    "Physics.stepOnce",
+    "Physics.rewindTo",
+    "Physics.timelineFrame",
 ];
 
 impl Host for FunctorHost {
@@ -1285,6 +1294,44 @@ the game dir",
                     other.kind_name()
                 )),
                 _ => usage("Physics.raycast(ox, oy, oz, dx, dy, dz, maxDist, tagger)"),
+            },
+            // Timeline-control EFFECTS (docs/physics.md Phase 6): pause /
+            // resume / stepOnce freeze and single-step the recorded physics
+            // drive; rewindTo(frame) seeks the timeline (resuming from there
+            // BRANCHES — the old future is discarded). Fire-and-forget.
+            "Physics.pause" | "Physics.resume" | "Physics.stepOnce" => match args.as_slice() {
+                [] => {
+                    let control = match path {
+                        "Physics.pause" => physics::TimelineControl::Pause,
+                        "Physics.resume" => physics::TimelineControl::Resume,
+                        _ => physics::TimelineControl::StepOnce,
+                    };
+                    Ok(host(MleEffect(EffectTree::Timeline(control))))
+                }
+                _ => usage(&format!("{path}()")),
+            },
+            "Physics.rewindTo" => match args.as_slice() {
+                [frame] => {
+                    // Clamping to the recorded range is the RECORDER's job, so
+                    // any finite frame is accepted here — in particular a
+                    // negative `timelineFrame() - 10.0` early on floors to 0,
+                    // rather than erroring before it reaches the clamp.
+                    let frame = num(frame, span)?.max(0.0) as u64;
+                    Ok(host(MleEffect(EffectTree::Timeline(
+                        physics::TimelineControl::RewindTo(frame),
+                    ))))
+                }
+                _ => usage("Physics.rewindTo(frame)"),
+            },
+            // The recorder's clock, for rewind math: the CURRENT fixed frame
+            // (reads like Physics.position — the live world, in-process).
+            "Physics.timelineFrame" => match args.as_slice() {
+                [] => {
+                    let frame = physics::with_world(physics::DEFAULT_WORLD, |w| w.frame())
+                        .unwrap_or(0);
+                    Ok(Value::Number(frame as f64))
+                }
+                _ => usage("Physics.timelineFrame()"),
             },
             // Collision-event SUB (docs/physics.md Phase 5): what
             // `subscriptions` returns (alone or in Sub.batch). The tagger
@@ -1897,7 +1944,7 @@ pub fn drain_effects(
 /// update-less games.)
 pub fn needs_update(tree: &EffectTree) -> bool {
     match tree {
-        EffectTree::None | EffectTree::Physics(_) => false,
+        EffectTree::None | EffectTree::Physics(_) | EffectTree::Timeline(_) => false,
         EffectTree::Now { .. } | EffectTree::Random { .. } | EffectTree::Raycast { .. } => true,
         EffectTree::Batch(items) => items.iter().any(needs_update),
     }
@@ -1981,6 +2028,24 @@ dropping the rest"
                     kind,
                     value: EffectValue::Text(tag),
                 });
+                if log.len() > EFFECT_LOG_CAP {
+                    log.remove(0);
+                }
+                continue;
+            }
+            EffectTree::Timeline(control) => {
+                let kind = match control {
+                    physics::TimelineControl::Pause => "physics.pause",
+                    physics::TimelineControl::Resume => "physics.resume",
+                    physics::TimelineControl::StepOnce => "physics.stepOnce",
+                    physics::TimelineControl::RewindTo(_) => "physics.rewindTo",
+                };
+                let value = match control {
+                    physics::TimelineControl::RewindTo(f) => EffectValue::Number(f as f64),
+                    _ => EffectValue::Bool(true),
+                };
+                physics::queue_timeline_control(control);
+                log.push(EffectRecord { kind, value });
                 if log.len() > EFFECT_LOG_CAP {
                     log.remove(0);
                 }

--- a/runtime/functor-runtime-common/src/physics/driver.rs
+++ b/runtime/functor-runtime-common/src/physics/driver.rs
@@ -1,0 +1,456 @@
+//! The recorded physics drive (docs/physics.md, Phase 6 — the culmination):
+//! pause / rewind / step / replay over the 1b `Timeline` seam.
+//!
+//! [`SteppedPhysics`] replaces the drivers' direct `reconcile + step_frame`
+//! call with per-fixed-frame recording: each substep is recorded through
+//! [`TimelineLog`] with exactly the [`Command`]s that produce it (the frame's
+//! declared scene on its first substep, plus any queued
+//! [`super::PhysicsCommand`]s), then stepped through `Simulatable::step` —
+//! the SAME path a `seek` replays, so live and replayed frames are
+//! byte-identical by construction (the strategy-equivalence goldens' claim,
+//! now load-bearing at runtime).
+//!
+//! Timeline CONTROLS (pause / resume / stepOnce / rewindTo) arrive as
+//! tagger-less effects, queued on a shell-side control queue (like physics
+//! commands, but targeting the recorder rather than the world) and applied
+//! at the next [`SteppedPhysics::advance`].
+
+use std::cell::RefCell;
+
+use super::{
+    with_world, Command, PhysicsEvent, PhysicsScene, Simulatable, Timeline, TimelineLog, World,
+    WorldId, DEFAULT_WORLD, FIXED_DT, MAX_SUBSTEPS_PER_FRAME,
+};
+
+/// Snapshot cadence for the live recorder: every half second at 60Hz. Seeks
+/// replay at most 29 frames — imperceptible — while snapshots stay rare.
+const KEYFRAME_INTERVAL: u64 = 30;
+
+/// How much history the recorder keeps: 15 seconds at 60Hz. Pruned each
+/// frame, so memory is bounded no matter how long the game runs.
+const HISTORY_FRAMES: u64 = 900;
+
+/// A control against the recorder (docs/physics.md Phase 6): plain data,
+/// queued by the `Physics.pause`/`resume`/`stepOnce`/`rewindTo` effects.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum TimelineControl {
+    Pause,
+    Resume,
+    /// Advance exactly one fixed frame while paused.
+    StepOnce,
+    /// Restore the pre-step state of this fixed frame and truncate the
+    /// recorded future (resuming from here BRANCHES the timeline).
+    RewindTo(u64),
+}
+
+thread_local! {
+    /// Pending timeline controls (the recorder's analogue of the world's
+    /// command queue). Bounded: a game without a physics drive must not leak.
+    static CONTROLS: RefCell<Vec<TimelineControl>> = const { RefCell::new(Vec::new()) };
+}
+
+const MAX_PENDING_CONTROLS: usize = 64;
+
+/// Queue a control for the next [`SteppedPhysics::advance`] (called by the
+/// effect drain, in-process — same seam as `World::queue_command`).
+pub fn queue_timeline_control(control: TimelineControl) {
+    CONTROLS.with(|c| {
+        let mut controls = c.borrow_mut();
+        if controls.len() < MAX_PENDING_CONTROLS {
+            controls.push(control);
+        }
+    });
+}
+
+fn take_timeline_controls() -> Vec<TimelineControl> {
+    CONTROLS.with(|c| std::mem::take(&mut *c.borrow_mut()))
+}
+
+/// What one [`SteppedPhysics::advance`] did, for the driver to surface.
+pub struct Advanced {
+    /// Fixed substeps simulated this frame (0 while paused or when the
+    /// accumulator hasn't reached a full step).
+    pub steps: u32,
+    /// The frame's contact transitions (empty while paused).
+    pub events: Vec<PhysicsEvent>,
+    /// Command/control problems to report (deduped by the driver).
+    pub warnings: Vec<String>,
+    /// The recorder's state after this frame, for status overlays:
+    /// `(current_fixed_frame, paused, recorded_history_len)`.
+    pub status: (u64, bool, u64),
+}
+
+/// The per-driver recorded physics drive. Owns the pause flag, the fixed-step
+/// accumulator, and the `TimelineLog` — the `World` itself stays in the
+/// registry (shared with reads, wireframes, and hot reload).
+pub struct SteppedPhysics {
+    world: WorldId,
+    timeline: TimelineLog<World>,
+    paused: bool,
+    accumulator: f32,
+    /// Whether any frame has simulated yet. The first non-paused advance is
+    /// floored to one step, so the world is reconciled+stepped before the
+    /// first draw even when the first frame's dt is short — otherwise
+    /// draw-time reads (`Physics.position`/`transformed`) would find an empty
+    /// world. (Reconcile lives INSIDE the recorded step so replay reproduces
+    /// it byte-exact, so we can't reconcile eagerly for draw — we step once
+    /// instead.)
+    started: bool,
+}
+
+impl Default for SteppedPhysics {
+    fn default() -> SteppedPhysics {
+        SteppedPhysics::new()
+    }
+}
+
+impl SteppedPhysics {
+    pub fn new() -> SteppedPhysics {
+        SteppedPhysics {
+            world: DEFAULT_WORLD,
+            timeline: TimelineLog::keyframes(KEYFRAME_INTERVAL),
+            paused: false,
+            accumulator: 0.0,
+            started: false,
+        }
+    }
+
+    /// One rendered frame's worth of recorded physics: apply queued controls,
+    /// then simulate whole fixed substeps from `real_dt` (unless paused),
+    /// recording each through the Timeline. The declared `scene` reconciles
+    /// on the frame's first recorded substep — identical semantics to
+    /// `World::step_frame`, but every fixed frame is now seekable.
+    pub fn advance(&mut self, scene: &PhysicsScene, real_dt: f32) -> Advanced {
+        let mut out = Advanced {
+            steps: 0,
+            events: Vec::new(),
+            warnings: Vec::new(),
+            status: (0, self.paused, 0),
+        };
+
+        // Controls first, so a pause/rewind issued last frame takes effect
+        // before this frame simulates.
+        let mut step_once = false;
+        for control in take_timeline_controls() {
+            match control {
+                TimelineControl::Pause => self.paused = true,
+                TimelineControl::Resume => self.paused = false,
+                TimelineControl::StepOnce => step_once = true,
+                TimelineControl::RewindTo(frame) => {
+                    self.rewind_to(frame, &mut out.warnings);
+                }
+            }
+        }
+
+        let simulate = if self.paused {
+            // Paused: real time doesn't accumulate (resuming later must not
+            // fast-forward), but an explicit stepOnce advances one frame.
+            self.accumulator = 0.0;
+            step_once
+        } else {
+            self.accumulator += real_dt.max(0.0);
+            // Bootstrap: guarantee the very first frame simulates one step so
+            // the world exists for the first draw. Floors, never adds — a
+            // full-dt first frame (the tests) still yields exactly one step.
+            if !self.started {
+                self.accumulator = self.accumulator.max(FIXED_DT);
+            }
+            self.accumulator >= FIXED_DT
+        };
+        if simulate {
+            self.started = true;
+        }
+
+        if simulate {
+            let steps = if self.paused {
+                1
+            } else {
+                let whole = (self.accumulator / FIXED_DT) as u32;
+                let steps = whole.min(MAX_SUBSTEPS_PER_FRAME);
+                self.accumulator -= steps as f32 * FIXED_DT;
+                if whole > MAX_SUBSTEPS_PER_FRAME {
+                    // Hitch: drop the whole-step backlog, keep the phase
+                    // (the same discipline as World::step_frame).
+                    self.accumulator %= FIXED_DT;
+                }
+                steps
+            };
+            let (events, warnings) = with_world(self.world, |w| {
+                let mut events = Vec::new();
+                for i in 0..steps {
+                    // The declared scene reconciles on the first substep; a
+                    // repeat declaration is a no-op via the divergence cache,
+                    // so recording it per-frame would also be correct — but
+                    // one DeclareScene per rendered frame keeps the log lean.
+                    let mut cmds: Vec<Command> = Vec::new();
+                    if i == 0 {
+                        cmds.push(Command::DeclareScene(scene.clone()));
+                        for command in w.take_pending_commands() {
+                            cmds.push(Command::Apply(command));
+                        }
+                    }
+                    self.timeline.record(w.frame(), w, &cmds);
+                    events.extend(w.step(&cmds));
+                }
+                (events, w.take_command_warnings())
+            })
+            .unwrap_or((Vec::new(), Vec::new()));
+            out.steps = steps;
+            out.events = events;
+            out.warnings.extend(warnings);
+            self.timeline
+                .prune(self.current_frame().saturating_sub(HISTORY_FRAMES));
+        }
+
+        out.status = (self.current_frame(), self.paused, self.history_len());
+        out
+    }
+
+    fn rewind_to(&mut self, frame: u64, warnings: &mut Vec<String>) {
+        let (lo, hi) = match self.recorded_range() {
+            Some(range) => range,
+            None => {
+                warnings.push("physics rewindTo: nothing recorded yet".to_string());
+                return;
+            }
+        };
+        if hi == 0 {
+            // Only the empty frame-0 exists — nothing meaningful to seek to
+            // (frame 0's pre-step state is the empty world, before any
+            // reconcile, which draw-reads can't use).
+            warnings.push("physics rewindTo: no stepped frame recorded yet".to_string());
+            return;
+        }
+        // Pre-step of fixed frame 0 is the empty world, so the practical floor
+        // is frame 1 (= the world after its first step).
+        let floor = if lo == 0 { 1 } else { lo };
+        let target = frame.clamp(floor, hi);
+        with_world(self.world, |w| {
+            // Commands queued THIS frame (before the rewind) survive the
+            // restore: a rewind+command in one frame lands the command at the
+            // branch's first step, rather than the snapshot silently dropping
+            // it. (Two reviewers flagged the drop.)
+            let carried = w.take_pending_commands();
+            self.timeline.seek(target, w);
+            // A seek re-simulates from a keyframe; the replayed steps emit
+            // contact events and command warnings nobody should re-observe.
+            let _ = w.take_events();
+            let _ = w.take_command_warnings();
+            for command in carried {
+                w.queue_command(command);
+            }
+        });
+        // The old future is gone: recording resumes (and BRANCHES) from here.
+        self.timeline.truncate_from(target);
+    }
+
+    fn current_frame(&self) -> u64 {
+        with_world(self.world, |w| w.frame()).unwrap_or(0)
+    }
+
+    fn history_len(&self) -> u64 {
+        self.recorded_range().map(|(lo, hi)| hi - lo + 1).unwrap_or(0)
+    }
+
+    /// The seekable fixed-frame range `(oldest, newest)`, if anything has
+    /// been recorded.
+    fn recorded_range(&self) -> Option<(u64, u64)> {
+        self.timeline.recorded_range()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::physics::{remove_world, Body, Shape};
+
+    fn scene_at(t: u64) -> PhysicsScene {
+        PhysicsScene::create(
+            [0.0, -9.81, 0.0],
+            vec![
+                Body::fixed(
+                    "ground".to_string(),
+                    Shape::Cuboid {
+                        extents: [20.0, 0.4, 20.0],
+                    },
+                ),
+                Body::dynamic(
+                    "a".to_string(),
+                    Shape::Cuboid {
+                        extents: [1.0, 1.0, 1.0],
+                    },
+                )
+                .at(if t < 30 { [0.0, 4.0, 0.0] } else { [0.5, 5.0, 0.0] }),
+            ],
+        )
+    }
+
+    fn snapshot() -> Vec<u8> {
+        with_world(DEFAULT_WORLD, |w| w.snapshot()).unwrap()
+    }
+
+    fn fresh() -> SteppedPhysics {
+        remove_world(DEFAULT_WORLD);
+        let _ = take_timeline_controls(); // hygiene: prior test leftovers
+        SteppedPhysics::new()
+    }
+
+    #[test]
+    fn pause_freezes_and_step_once_advances_exactly_one() {
+        let mut sp = fresh();
+        for t in 0..10 {
+            sp.advance(&scene_at(t), FIXED_DT);
+        }
+        let before = snapshot();
+        queue_timeline_control(TimelineControl::Pause);
+        let out = sp.advance(&scene_at(10), FIXED_DT);
+        assert_eq!(out.steps, 0);
+        assert!(out.status.1, "should report paused");
+        assert!(snapshot() == before, "paused frame must not simulate");
+        // Wall-clock passing while paused must not fast-forward on resume.
+        for t in 11..20 {
+            sp.advance(&scene_at(t), FIXED_DT * 3.0);
+        }
+        assert!(snapshot() == before);
+        // stepOnce advances exactly one fixed frame.
+        queue_timeline_control(TimelineControl::StepOnce);
+        let out = sp.advance(&scene_at(20), FIXED_DT);
+        assert_eq!(out.steps, 1);
+        assert!(snapshot() != before);
+    }
+
+    #[test]
+    fn rewind_restores_and_replay_is_byte_identical() {
+        let mut sp = fresh();
+        // Run A: 0..40 rendered frames (one substep each), snapshotting the
+        // world state at frame 20 and the end.
+        let mut snap_20 = Vec::new();
+        for t in 0..40 {
+            if t == 20 {
+                snap_20 = snapshot();
+            }
+            sp.advance(&scene_at(t), FIXED_DT);
+        }
+        let end_a = snapshot();
+
+        // Rewind to fixed frame 20 (pre-step state of 20 == post-step of 19
+        // == what we snapshotted before advancing frame 20).
+        queue_timeline_control(TimelineControl::Pause);
+        queue_timeline_control(TimelineControl::RewindTo(20));
+        let out = sp.advance(&scene_at(40), FIXED_DT);
+        assert!(out.warnings.is_empty(), "{:?}", out.warnings);
+        assert!(
+            snapshot() == snap_20,
+            "rewind must restore the recorded frame byte-exact"
+        );
+
+        // Resume and replay the same declared scenes: local determinism makes
+        // the branch land byte-identical to run A.
+        queue_timeline_control(TimelineControl::Resume);
+        for t in 20..40 {
+            sp.advance(&scene_at(t), FIXED_DT);
+        }
+        assert!(
+            snapshot() == end_a,
+            "replaying identical inputs must reproduce run A"
+        );
+    }
+
+    #[test]
+    fn rewind_clamps_to_recorded_history() {
+        let mut sp = fresh();
+        // Nothing recorded yet: rewind warns instead of panicking.
+        queue_timeline_control(TimelineControl::RewindTo(3));
+        let out = sp.advance(&scene_at(0), 0.0);
+        assert_eq!(out.warnings.len(), 1, "{:?}", out.warnings);
+
+        for t in 0..5 {
+            sp.advance(&scene_at(t), FIXED_DT);
+        }
+        // Past the newest end: clamped, no warning. (Rewinding to the OLDEST
+        // frame truncates the entire history — by design: the future is
+        // discarded — so the far-future clamp is tested first.)
+        queue_timeline_control(TimelineControl::RewindTo(9_999));
+        let out = sp.advance(&scene_at(5), 0.0);
+        assert!(out.warnings.is_empty(), "{:?}", out.warnings);
+        queue_timeline_control(TimelineControl::RewindTo(0));
+        let out = sp.advance(&scene_at(5), 0.0);
+        assert!(out.warnings.is_empty(), "{:?}", out.warnings);
+    }
+
+    #[test]
+    fn command_queued_with_a_rewind_lands_on_the_branch() {
+        let mut sp = fresh();
+        for t in 0..20 {
+            sp.advance(&scene_at(t), FIXED_DT);
+        }
+        // Same frame: rewind to 10 AND queue an impulse. The impulse must
+        // survive the seek and apply at the branch's first step.
+        queue_timeline_control(TimelineControl::RewindTo(10));
+        with_world(DEFAULT_WORLD, |w| {
+            w.queue_command(crate::physics::PhysicsCommand::ApplyImpulse {
+                tag: "a".to_string(),
+                impulse: [5.0, 0.0, 0.0],
+            })
+        });
+        let out = sp.advance(&scene_at(20), FIXED_DT);
+        assert!(out.warnings.is_empty(), "{:?}", out.warnings);
+        // The branch's first step applied the +x impulse.
+        let vx = with_world(DEFAULT_WORLD, |w| w.body_velocity("a").unwrap()[0]).unwrap();
+        assert!(vx > 0.0, "the same-frame impulse was dropped by the rewind: vx={vx}");
+    }
+
+    #[test]
+    fn scrub_below_zero_clamps_without_erroring() {
+        // The example's `rewindTo(timelineFrame() - 10.0)` goes negative in
+        // the first 10 frames; the prelude floors it to 0 and the recorder
+        // clamps to the floor — no error, no panic.
+        let mut sp = fresh();
+        for t in 0..5 {
+            sp.advance(&scene_at(t), FIXED_DT);
+        }
+        queue_timeline_control(TimelineControl::Pause);
+        queue_timeline_control(TimelineControl::RewindTo(0)); // the floored negative
+        let out = sp.advance(&scene_at(5), 0.0);
+        assert!(out.warnings.is_empty(), "{:?}", out.warnings);
+        // And a rewind before ANY step warns rather than seeking the empty world.
+        let mut sp2 = fresh();
+        queue_timeline_control(TimelineControl::RewindTo(0));
+        let out = sp2.advance(&scene_at(0), 0.0);
+        assert_eq!(out.warnings.len(), 1, "{:?}", out.warnings);
+    }
+
+    #[test]
+    fn recorded_commands_replay_through_a_seek() {
+        let mut sp = fresh();
+        // Impulse at fixed frame 10; snapshot the pre-step state of 20.
+        let mut snap_20 = Vec::new();
+        for t in 0..30 {
+            if t == 10 {
+                with_world(DEFAULT_WORLD, |w| {
+                    w.queue_command(crate::physics::PhysicsCommand::ApplyImpulse {
+                        tag: "a".to_string(),
+                        impulse: [2.0, 3.0, 0.0],
+                    })
+                });
+            }
+            if t == 20 {
+                snap_20 = snapshot();
+            }
+            sp.advance(&scene_at(t), FIXED_DT);
+        }
+        // Rewinding to 20 seeks: keyframe 0 restored, frames 0..19 replayed
+        // FROM THE LOG — including frame 10's recorded Command::Apply. Landing
+        // byte-identical proves commands replay. (Post-rewind the future is
+        // truncated — a resumed run is a BRANCH and only re-runs what the
+        // game issues again; that is the design, not a loss.)
+        queue_timeline_control(TimelineControl::Pause);
+        queue_timeline_control(TimelineControl::RewindTo(20));
+        let out = sp.advance(&scene_at(30), 0.0);
+        assert!(out.warnings.is_empty(), "{:?}", out.warnings);
+        assert!(
+            snapshot() == snap_20,
+            "seek must re-apply recorded commands to land byte-exact"
+        );
+    }
+}

--- a/runtime/functor-runtime-common/src/physics/mod.rs
+++ b/runtime/functor-runtime-common/src/physics/mod.rs
@@ -19,6 +19,7 @@
 //! No F# surface yet — that lands in Phase 2 (`physicsScape`). Everything here
 //! is exercised headlessly by the determinism goldens (`cargo test`, no GPU).
 
+mod driver;
 mod registry;
 mod scene;
 mod timeline;
@@ -27,6 +28,9 @@ mod world;
 #[cfg(test)]
 mod goldens;
 
+// `driver::SteppedPhysics` is the production drive: the recorded wrapper the
+// MLE shells call instead of `World::step_frame` directly (Phase 6).
+pub use driver::*;
 pub use registry::*;
 pub use scene::*;
 pub use timeline::*;

--- a/runtime/functor-runtime-common/src/physics/timeline.rs
+++ b/runtime/functor-runtime-common/src/physics/timeline.rs
@@ -174,6 +174,31 @@ where
         TimelineLog::keyframes(u64::MAX)
     }
 
+    /// Drop all recorded history at and after `frame` — the record-after-seek
+    /// truncation rewind-then-BRANCH needs (docs/physics.md, the culmination):
+    /// after `seek(f)`, `truncate_from(f)` makes `record(f, …)` legal again,
+    /// and the old future is gone. Keyframes at or after `frame` go too (a
+    /// re-recorded frame re-snapshots on its cadence).
+    pub fn truncate_from(&mut self, frame: Frame) {
+        let Some(next) = self.next_frame() else { return };
+        if frame >= next {
+            return;
+        }
+        assert!(
+            frame >= self.base,
+            "truncate_from({frame}) predates recorded history (base {})",
+            self.base
+        );
+        self.commands.truncate((frame - self.base) as usize);
+        self.keyframes.retain(|&k, _| k < frame);
+    }
+
+    /// The seekable range `(oldest, newest)` — `None` until something is
+    /// recorded. Prune moves the floor; truncate moves the ceiling.
+    pub fn recorded_range(&self) -> Option<(Frame, Frame)> {
+        self.next_frame().map(|next| (self.base, next - 1))
+    }
+
     fn next_frame(&self) -> Option<Frame> {
         (!self.commands.is_empty()).then(|| self.base + self.commands.len() as u64)
     }

--- a/runtime/functor-runtime-common/src/physics/world.rs
+++ b/runtime/functor-runtime-common/src/physics/world.rs
@@ -40,8 +40,9 @@ pub const MAX_SUBSTEPS_PER_FRAME: u32 = 8;
 pub enum PhysicsCommand {
     /// Instantaneous momentum change.
     ApplyImpulse { tag: String, impulse: [f32; 3] },
-    /// A force applied for this frame's substeps only (cleared at frame end —
-    /// no rapier force persistence to forget about).
+    /// A force applied for one fixed step (cleared after — no rapier force
+    /// persistence to forget about). Under the recorded drive each substep is
+    /// a recorded frame, so a force lasts exactly one fixed step.
     ApplyForce { tag: String, force: [f32; 3] },
     SetVelocity { tag: String, velocity: [f32; 3] },
     /// Move the live body without touching its declaration (the declared
@@ -213,6 +214,13 @@ impl World {
             return;
         }
         self.pending.push(command);
+    }
+
+    /// Drain the queued commands without applying them — the recorded drive
+    /// (Phase 6) folds them into the frame's Timeline command list instead,
+    /// so replay reproduces them.
+    pub fn take_pending_commands(&mut self) -> Vec<PhysicsCommand> {
+        std::mem::take(&mut self.pending)
     }
 
     /// Problems from asynchronously-applied commands (unknown tags, queue

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -96,6 +96,12 @@ pub struct MleGame {
     /// This frame's contact transitions, delivered post-step to the
     /// `Physics.events` taggers of the current `subscriptions(model)`.
     pending_events: Vec<functor_runtime_common::physics::PhysicsEvent>,
+    /// The recorded physics drive (docs/physics.md Phase 6): the Timeline
+    /// recorder + pause flag + fixed-step accumulator. The World stays in
+    /// the registry; this owns the rewind machinery over it.
+    physics_rt: physics::SteppedPhysics,
+    /// Latest recorder status for the overlay: (fixed frame, paused, history).
+    physics_status: (u64, bool, u64),
     /// The last successfully drawn frame, kept so a bad draw shows the last
     /// good picture instead of a blank.
     last_frame: Frame,
@@ -301,6 +307,8 @@ impl MleGame {
             effect_log: EffectLog::new(),
             deferred_queries: Vec::new(),
             pending_events: Vec::new(),
+            physics_rt: physics::SteppedPhysics::new(),
+            physics_status: (0, false, 0),
             last_frame: empty_frame(),
             last_error: None,
             frames: 0,
@@ -346,14 +354,13 @@ impl MleGame {
         match self.session.call("physics", args, &mut FunctorHost) {
             Ok(value) => match physics_scene_value(&value) {
                 Some(scene) => {
-                    let (steps, events, warnings) =
-                        physics::with_world(physics::DEFAULT_WORLD, |w| {
-                            w.reconcile(scene);
-                            let steps = w.step_frame(dts);
-                            (steps, w.take_events(), w.take_command_warnings())
-                        })
-                        .unwrap_or((0, Vec::new(), Vec::new()));
-                    self.pending_events = events;
+                    // The recorded drive (Phase 6): every fixed frame goes
+                    // through the Timeline, so pause/rewind/replay work.
+                    let advanced = self.physics_rt.advance(scene, dts);
+                    self.pending_events = advanced.events;
+                    self.physics_status = advanced.status;
+                    let steps = advanced.steps;
+                    let warnings = advanced.warnings;
                     // Command effects apply asynchronously (queued at perform
                     // time, applied at the step), so their problems — unknown
                     // tag, queue overflow — surface here, deduped.
@@ -629,7 +636,12 @@ impl Game for MleGame {
         // commands, so they never answer against a world that hasn't
         // simulated. Games without a physics hook answer immediately (the
         // lazily-created empty world gives sane misses).
-        let world_ready = physics_steps > 0 || !self.has_physics;
+        // A query answers once the world has EVER stepped: normally this
+        // frame's steps, but also while PAUSED (frozen mid-flight, frame > 0)
+        // and on a short zero-substep frame — so a raycast fired while paused
+        // answers against the frozen world instead of deferring forever.
+        let world_ready =
+            physics_steps > 0 || !self.has_physics || self.physics_status.0 > 0;
         if world_ready && !self.deferred_queries.is_empty() {
             let deferred = std::mem::take(&mut self.deferred_queries);
             let mut reports: Vec<String> = Vec::new();
@@ -765,7 +777,21 @@ impl Game for MleGame {
     }
 
     fn ui(&self) -> View {
-        self.last_view.clone()
+        // The game's own `ui` view, plus a read-only recorder status line
+        // while paused (docs/physics.md, the culmination) — shown only when
+        // paused so live play stays clean. All physics CONTROL is via the
+        // game's keyboard bindings (egui input isn't wired). Composing via a
+        // column keeps both: an `Empty` game view (e.g. mle-physics has no
+        // `ui` hook) renders nothing, leaving just the status.
+        let (frame, paused, history) = self.physics_status;
+        if !paused {
+            return self.last_view.clone();
+        }
+        let status = View::text(
+            format!("physics ⏸ frame {frame} · {history} recorded · Left/Right scrub · Space resume")
+                .into(),
+        );
+        View::Column(vec![self.last_view.clone(), status])
     }
 
     fn state_debug(&self) -> String {

--- a/runtime/functor-runtime-web/src/mle_game.rs
+++ b/runtime/functor-runtime-web/src/mle_game.rs
@@ -71,6 +71,12 @@ pub struct MleWebGame {
     /// This frame's contact transitions, delivered post-step to the
     /// `Physics.events` taggers of the current `subscriptions(model)`.
     pending_events: Vec<functor_runtime_common::physics::PhysicsEvent>,
+    /// The recorded physics drive (docs/physics.md Phase 6): the Timeline
+    /// recorder + pause flag + fixed-step accumulator. The World stays in
+    /// the registry; this owns the rewind machinery over it.
+    physics_rt: physics::SteppedPhysics,
+    /// Latest recorder status for the overlay: (fixed frame, paused, history).
+    physics_status: (u64, bool, u64),
     /// The last successfully drawn frame, kept so a bad draw shows the last
     /// good picture instead of a blank.
     last_frame: Frame,
@@ -219,6 +225,8 @@ impl MleWebGame {
             effect_log: EffectLog::new(),
             deferred_queries: Vec::new(),
             pending_events: Vec::new(),
+            physics_rt: physics::SteppedPhysics::new(),
+            physics_status: (0, false, 0),
             has_physics: loaded.has_physics,
             has_ui: loaded.has_ui,
             last_view: View::Empty,
@@ -364,14 +372,13 @@ to receive their messages; dropping them"
         match self.session.call("physics", args, &mut FunctorHost) {
             Ok(value) => match physics_scene_value(&value) {
                 Some(scene) => {
-                    let (steps, events, warnings) =
-                        physics::with_world(physics::DEFAULT_WORLD, |w| {
-                            w.reconcile(scene);
-                            let steps = w.step_frame(dts);
-                            (steps, w.take_events(), w.take_command_warnings())
-                        })
-                        .unwrap_or((0, Vec::new(), Vec::new()));
-                    self.pending_events = events;
+                    // The recorded drive (Phase 6): every fixed frame goes
+                    // through the Timeline, so pause/rewind/replay work.
+                    let advanced = self.physics_rt.advance(scene, dts);
+                    self.pending_events = advanced.events;
+                    self.physics_status = advanced.status;
+                    let steps = advanced.steps;
+                    let warnings = advanced.warnings;
                     // Command effects apply asynchronously (queued at perform
                     // time, applied at the step), so their problems — unknown
                     // tag, queue overflow — surface here, deduped.
@@ -459,7 +466,12 @@ impl GameProducer for MleWebGame {
         // commands, so they never answer against a world that hasn't
         // simulated. Games without a physics hook answer immediately (the
         // lazily-created empty world gives sane misses).
-        let world_ready = physics_steps > 0 || !self.has_physics;
+        // A query answers once the world has EVER stepped: normally this
+        // frame's steps, but also while PAUSED (frozen mid-flight, frame > 0)
+        // and on a short zero-substep frame — so a raycast fired while paused
+        // answers against the frozen world instead of deferring forever.
+        let world_ready =
+            physics_steps > 0 || !self.has_physics || self.physics_status.0 > 0;
         if world_ready && !self.deferred_queries.is_empty() {
             let deferred = std::mem::take(&mut self.deferred_queries);
             let mut reports: Vec<String> = Vec::new();


### PR DESCRIPTION
**Phase 6 of docs/physics.md — the culmination, and the last of the core roadmap.** Pause, rewind, single-step, and deterministic replay, proving the 1b `Timeline` seam works at runtime.

![pause/rewind/replay](https://gist.githubusercontent.com/tommy-xr/cb481d57fcf432e0ae24661cfac0d0e0/raw/rewind.gif)

Paused, the status overlay reads the recorder state; the flashed crate still glows (Phase 5); the ball hangs frozen mid-arc:

![paused overlay](https://gist.githubusercontent.com/tommy-xr/cb481d57fcf432e0ae24661cfac0d0e0/raw/paused-overlay.png)

## The design

A shell-side recorder — `SteppedPhysics` (`physics/driver.rs`) — replaces the drivers' direct `reconcile + step_frame` with **per-fixed-frame recording through `TimelineLog`**: each substep is recorded with exactly the `Command`s that produce it (the frame's `DeclareScene` + any queued `PhysicsCommand`s), then run through `Simulatable::step` — **the same path a `seek` replays**. So live play and rewind/replay are byte-identical *by construction*, not by luck.

- **Controls** (`Physics.pause`/`resume`/`stepOnce`/`rewindTo`) are tagger-less effects over a thread-local control queue — the world's command-queue pattern, one level up. `Physics.timelineFrame()` reads the current fixed frame for scrub math.
- **Rewind-then-branch**: `TimelineLog::truncate_from` discards the old future when you resume from a seek, so a different input replays a different timeline — determinism *and* divergence, live.
- **Bounded**: ~15s of history at 60Hz, pruned each frame; `rewindTo` clamps to it.

## The hard part: byte-identity

My first cut reconciled eagerly every frame so draw-reads always found bodies — which **broke** byte-identity (the double reconcile diverged from replay's single one; caught by instrumenting a 34-byte snapshot difference). The shipped design instead floors the *first* advance to one step (a `started` flag), so the world exists for the first draw without any out-of-band reconcile. Three goldens now assert the invariant: rewind-restores-byte-exact, replay-byte-identical, and recorded-commands-replay-through-seek.

## The example

`examples/mle-physics`: **P** pause-toggle, **Left** scrub (10 fixed frames per key-repeat), **Right** single-step, **G** replay-from-oldest — kick with **K** mid-replay to branch the timeline. Desktop shows a read-only paused status overlay via the existing `View` text layer.

## Review (two engines)

Both flagged the same-frame command+rewind drop (a queued impulse lost when `seek` overwrites the world's pending queue) — now the command survives the seek and lands on the branch (tested). Also fixed: `rewindTo` accepts any frame and clamps in the recorder (so the example's `timelineFrame() - 10` doesn't error negative in the first 10 frames — the phase's own headline control), empty-frame-0 seek guarded, deferred queries answer against the frozen paused world, replayed-warning leakage drained, stale `ApplyForce` doc corrected.

## Testing

- **166 tests** (pause-freeze/step-once, byte-exact rewind + replay, commands-through-seek, same-frame-rewind+command, scrub-below-zero clamp, rewind-clamps)
- strict + wasm clean on all three crates; `mle check` clean on the example
- Live via debug-server key injection: pause froze the scene, Left scrubbed back, Right stepped, G replayed, the overlay rendered, **zero errors** — including aggressive early-scrub (the negative-frame repro)

This completes the physics roadmap: **1a** engine spine → **1b** Timeline → **2** MLE surface → **2b** wireframes → **3** commands → **4** raycast → **5** collision events → **6** pause/rewind/replay. Everything the doc scoped, shipped and shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)