### PR TITLE
feat(mle,runtime,examples): MLE networking surface — Sub.connect/listen, Effect.send, Net ADT + ws ports

### DIFF
--- a/.claude/skills/mle-language/SKILL.md
+++ b/.claude/skills/mle-language/SKILL.md
@@ -152,9 +152,14 @@ let grab = (s) =>
   (they evaluate first); siblings may reference the entry (`Game.foo`) if
   that creates no cycle.
 - **Protected namespaces**: a file whose module name collides with a
-  builtin/prelude namespace (List, Text, Math, Scene, Camera, Frame,
+  builtin/prelude namespace (Net, List, Text, Math, Scene, Camera, Frame,
   Light, Angle, Time, Sub, Effect, Physics, RenderTarget) is a load error
   — rename the file.
+- **`Net` is a built-in module**, always in scope: `type NetEvent =
+  | Connected(id: Float) | Message(id: Float, text: String) |
+  Disconnected(id: Float) | Error(id: Float, text: String)`. A `Sub.connect`/
+  `Sub.listen` tagger receives these — `match ev with | Net.Connected(id)
+  => …` — with no declaration needed.
 - Constructor names must be unique per MODULE (not per project); values
   from a non-entry module display with their canonical tag
   (`Utils.Circle(2)` in run/trace/`/state` output). The entry's own names
@@ -279,6 +284,8 @@ frame |> Frame.withSkybox(sky)                             //   paths (+X..-Z). 
 Time.seconds(1.0) / Time.millis(500.0)                     // Duration VALUES only
 Sub.every(duration, msg) / Sub.none() / Sub.batch([sub,…]) // what subscriptions returns
 Effect.random(tagger) / Effect.now(tagger)                 // one-shots; tagger: (Float) => Msg
+Sub.connect(url, tagger) / Sub.listen(addr, tagger)        // persistent connections; tagger: (Net.NetEvent) => Msg
+Effect.send(connId, text)                                  // send on an open connection
 Effect.none() / Effect.batch([fx, …])                      //   random: [0,1); now: epoch secs
 
 Physics.box(w, h, d) / sphere(r) / capsule(halfH, r)       // -> Shape (box = FULL extents)

--- a/docs/mle.md
+++ b/docs/mle.md
@@ -584,6 +584,23 @@ Pull-based: port examples as MLE proves itself; no flag-day.
       were already byte-identical from E1a.
 - [ ] **E2.** Port remaining examples, one PR each. *Verify:* per-example
       goldens + e2e.
+      *Progress — networking (2026-07-05):* the MLE **net surface** landed
+      so the multiplayer samples can port. A built-in **`Net` module**
+      (injected by the project loader, always in scope) provides the
+      `NetEvent` ADT — `type NetEvent = | Connected(id) | Message(id, text)
+      | Disconnected(id) | Error(id, text)` — so games `match ev with |
+      Net.Connected(id) => …` without declaring it (the prelude-provided
+      ADT the user chose over a record-with-`kind`; `EffectValue::Variant`
+      lets the host build the `Net.*` values). Prelude: `Sub.connect(url,
+      tagger)` / `Sub.listen(addr, tagger)` (a `SubTree` the producer
+      RECONCILES into Connect/Listen/CloseKey commands each frame, routing
+      inbound events to the matching key's fresh tagger through `update` —
+      the physics-events pattern) and `Effect.send(id, text)` (tagger-less,
+      queues a `ConnCommand::Send`). Both producers wired.
+      `examples/mle-wsdemo` (client, ctor tagger) + `examples/mle-wsserverdemo`
+      (server, closure tagger, per-client ids) port their F# originals;
+      headless unit tests drive the full lifecycle without a socket.
+      Remaining: `mpclient`/`mpserver`, then HTTP (`netdemo`).
 - [ ] **E3.** Delete the F# pipeline: Fable, dotnet tooling, `.fsproj`s,
       `fable_modules/`, the `.fs`/`.fsi`/`.rs` triplication, the dylib
       hot-reload path. *Verify:* full CI green with no dotnet installed;

--- a/examples/mle-wsdemo/functor.json
+++ b/examples/mle-wsdemo/functor.json
@@ -1,0 +1,1 @@
+{ "language": "mle", "entry": "game.mle" }

--- a/examples/mle-wsdemo/game.mle
+++ b/examples/mle-wsdemo/game.mle
@@ -1,0 +1,46 @@
+// mle-wsdemo — the MLE port of examples/wsdemo (docs/mle.md Track E).
+// A minimal WebSocket client: `Sub.connect` keeps a connection open; when it
+// opens, the runtime hands us a connection id via `Net.Connected`, which we
+// store and use with `Effect.send`. Inbound messages flow to the same tagger.
+// Driven headlessly in tests (events injected without a real socket).
+//
+//   functor -d examples/mle-wsdemo run native
+
+type Conn =
+  | NoConn
+  | Conn(id: Float)
+
+type Model = { conn: Conn, status: String, lastMsg: String }
+
+type Msg =
+  | Ws(ev: Net.NetEvent)
+  | Send(text: String)
+
+let init = { conn: NoConn, status: "connecting", lastMsg: "" }
+
+let update = (m: Model, msg: Msg) =>
+  match msg with
+  // Parenthesize the nested match so it doesn't consume the `Send` arm.
+  | Ws(ev) =>
+    (match ev with
+     | Net.Connected(id) =>
+         ({ m with conn: Conn(id), status: "connected" }, Effect.send(id, "hello"))
+     | Net.Message(id, text) => { m with lastMsg: text, status: "got-message" }
+     | Net.Disconnected(id) => { m with conn: NoConn, status: "disconnected" }
+     | Net.Error(id, e) => { m with status: Text.concat("error: ", e) })
+  | Send(text) =>
+    (match m.conn with
+     | Conn(id) => (m, Effect.send(id, text))
+     | NoConn => m)
+
+// Declaring the connection in `subscriptions` is what keeps it open.
+let subscriptions = (m: Model) => Sub.connect("ws://127.0.0.1:9001/echo", Ws)
+
+let tick = (m: Model, dt: Float, tts: Float) => m
+
+let draw = (m: Model, tts: Float) =>
+  Frame.create(
+    Camera.firstPerson(
+      0.0, 0.0, -5.0,
+      Angle.radians(0.0), Angle.radians(0.0), Angle.degrees(60.0)),
+    Scene.cube() |> Scene.emissive(0.6, 0.4, 0.9))

--- a/examples/mle-wsserverdemo/functor.json
+++ b/examples/mle-wsserverdemo/functor.json
@@ -1,0 +1,1 @@
+{ "language": "mle", "entry": "game.mle" }

--- a/examples/mle-wsserverdemo/game.mle
+++ b/examples/mle-wsserverdemo/game.mle
@@ -1,0 +1,47 @@
+// mle-wsserverdemo — the MLE port of examples/wsserverdemo (docs/mle.md E).
+// A minimal WebSocket SERVER (native-only): `Sub.listen` binds an address;
+// each accepted client surfaces through the tagger carrying its own
+// connection id, which we use to reply with `Effect.send`. A closure tagger
+// (`toMsg`) decodes Net.NetEvent into game-specific messages.
+//
+//   functor -d examples/mle-wsserverdemo run native
+
+type Model = { clients: Float, status: String, lastMsg: String }
+
+type Msg =
+  | ClientConnected(id: Float)
+  | Received(id: Float, text: String)
+  | ClientLeft(id: Float)
+  | ConnError(text: String)
+
+// The tagger: NetEvent -> a game-specific Msg (a closure, not a ctor).
+let toMsg = (ev: Net.NetEvent): Msg =>
+  match ev with
+  | Net.Connected(id) => ClientConnected(id)
+  | Net.Message(id, text) => Received(id, text)
+  | Net.Disconnected(id) => ClientLeft(id)
+  | Net.Error(id, message) => ConnError(message)
+
+let init = { clients: 0.0, status: "listening", lastMsg: "" }
+
+let update = (m: Model, msg: Msg) =>
+  match msg with
+  | ClientConnected(id) =>
+      ({ m with clients: m.clients + 1.0, status: "client-connected" },
+       Effect.send(id, "welcome"))
+  | Received(id, text) =>
+      ({ m with status: "echoed", lastMsg: text }, Effect.send(id, text))
+  | ClientLeft(id) => { m with clients: m.clients - 1.0, status: "client-left" }
+  | ConnError(e) => { m with status: Text.concat("error: ", e) }
+
+// Declaring the listener in `subscriptions` keeps the server bound.
+let subscriptions = (m: Model) => Sub.listen("127.0.0.1:9001", toMsg)
+
+let tick = (m: Model, dt: Float, tts: Float) => m
+
+let draw = (m: Model, tts: Float) =>
+  Frame.create(
+    Camera.firstPerson(
+      0.0, 0.0, -5.0,
+      Angle.radians(0.0), Angle.radians(0.0), Angle.degrees(60.0)),
+    Scene.cube() |> Scene.emissive(0.3, 0.6, 0.4))

--- a/mle/src/project.rs
+++ b/mle/src/project.rs
@@ -254,18 +254,26 @@ come from file names, capitalized",
         // next file's base.
         base += len + 1;
     }
+    link(files)
+}
+
+/// Parse, lower, and link a set of source files into one merged module,
+/// injecting the built-in `Net` module. Shared by the filesystem loader
+/// and the single-source (wasm) loader.
+fn link(mut files: Vec<SourceFile>) -> Result<Project, ProjectError> {
     // The built-in `Net` module: a prelude-provided ADT always in scope, so
-    // any game can `match ev with | Net.Connected(id) => …` without
-    // declaring the type. It's an ordinary non-entry module (canonicalized
-    // to `Net.NetEvent` / `Net.Connected` / …), loaded through the same
-    // path — the host builds matching `Net.*` variant values (see
-    // `mle_prelude`). Injected LAST so the entry stays index 0.
+    // any game can `match ev with | Net.Connected(id) => …` without declaring
+    // the type. Canonicalized to `Net.NetEvent` / `Net.Connected` / …; the
+    // host builds matching `Net.*` values. Appended LAST so the entry stays
+    // index 0. Both the filesystem and single-source loaders reach it here.
+    let base = files.last().map_or(0, |f| f.base + f.src.len() + 1);
     files.push(SourceFile {
         path: PathBuf::from("<builtin>/Net.mle"),
         module: "Net".to_string(),
         src: NET_MODULE_SRC.to_string(),
         base,
     });
+
     let entry = files[0].module.clone();
 
     // Parse every file (spans land in the project-wide space).
@@ -351,7 +359,7 @@ come from file names, capitalized",
             .iter()
             .find(|f| &f.module == start)
             .map(|f| f.path.clone())
-            .unwrap_or_else(|| entry_path.to_path_buf());
+            .unwrap_or_else(|| files[0].path.clone());
         ProjectError {
             path,
             line: 1,
@@ -387,6 +395,19 @@ allowed (within one file, definitions may still be mutually recursive)",
         entry,
         scopes,
     })
+}
+
+/// Load a project from ONE in-memory entry source (no filesystem) — the
+/// wasm producer's path, where the game is fetched as a single text and
+/// there are no sibling files. The built-in `Net` module is still injected.
+pub fn load_single_source(module: &str, src: &str) -> Result<Project, ProjectError> {
+    let files = vec![SourceFile {
+        path: PathBuf::from(format!("{module}.mle")),
+        module: module.to_string(),
+        src: src.to_string(),
+        base: 0,
+    }];
+    link(files)
 }
 
 /// The module name a file provides: its stem, first letter capitalized

--- a/mle/src/project.rs
+++ b/mle/src/project.rs
@@ -43,6 +43,7 @@ use crate::CheckError;
 /// Namespaces the language or the Functor prelude own; a module (file) name
 /// colliding with one is a load-time error.
 const PROTECTED_NAMESPACES: &[&str] = &[
+    "Net",
     "List",
     "Text",
     "Math",
@@ -83,6 +84,15 @@ impl Project {
 
 /// One file of a project, with its base offset in the project-wide span
 /// space (see [`crate::lexer::lex`]).
+/// The built-in `Net` module (see the injection site in [`load_with_entry_source`]).
+/// Connection ids are `Float` (small integers); text carries messages and
+/// error strings. Mirrors F#'s `Functor.Net.NetEvent`.
+const NET_MODULE_SRC: &str = "type NetEvent =\n\
+     | Connected(id: Float)\n\
+     | Message(id: Float, text: String)\n\
+     | Disconnected(id: Float)\n\
+     | Error(id: Float, text: String)\n";
+
 pub struct SourceFile {
     pub path: PathBuf,
     /// The module name derived from the file name.
@@ -244,6 +254,18 @@ come from file names, capitalized",
         // next file's base.
         base += len + 1;
     }
+    // The built-in `Net` module: a prelude-provided ADT always in scope, so
+    // any game can `match ev with | Net.Connected(id) => …` without
+    // declaring the type. It's an ordinary non-entry module (canonicalized
+    // to `Net.NetEvent` / `Net.Connected` / …), loaded through the same
+    // path — the host builds matching `Net.*` variant values (see
+    // `mle_prelude`). Injected LAST so the entry stays index 0.
+    files.push(SourceFile {
+        path: PathBuf::from("<builtin>/Net.mle"),
+        module: "Net".to_string(),
+        src: NET_MODULE_SRC.to_string(),
+        base,
+    });
     let entry = files[0].module.clone();
 
     // Parse every file (spans land in the project-wide space).

--- a/mle/tests/project.rs
+++ b/mle/tests/project.rs
@@ -607,17 +607,38 @@ let bad = f() + 1.0
 /// lowering (the backward-compatibility pin: bare names, IDs from zero,
 /// spans from zero).
 #[test]
-fn single_file_project_is_identical_to_plain_lowering() {
+fn single_file_project_adds_only_the_builtin_net_module() {
+    // A project always includes the built-in `Net` prelude module (so any
+    // game can `match ev with | Net.Connected(id) => …`), so its merged IR
+    // is plain lowering's defs/types PLUS Net's — nothing else changes.
     let src = "type Shape = | Circle(radius: Float) | Point\n\
                let area = (s: Shape): Float =>\n\
                match s with | Circle(r) => 3.14 * r * r | Point => 0.0\n\
                let main = () => area(Circle(2.0))\n";
     let project = load("single-file", &[("game.mle", src)]);
     let plain = mle::lower(mle::parse(src).expect("parses")).expect("lowers");
+
+    let proj_defs: Vec<&str> = project.module.defs.iter().map(|d| d.name.as_str()).collect();
+    for def in &plain.defs {
+        assert!(
+            proj_defs.contains(&def.name.as_str()),
+            "entry def `{}` must survive into the project unchanged",
+            def.name
+        );
+    }
+    let proj_types: Vec<&str> = project.module.types.iter().map(|t| t.name.as_str()).collect();
+    for ty in &plain.types {
+        assert!(proj_types.contains(&ty.name.as_str()));
+    }
+    // The ONLY additions are the Net module's (canonicalized `Net.NetEvent`).
+    assert!(
+        proj_types.contains(&"Net.NetEvent"),
+        "the built-in Net module must be injected: {proj_types:?}"
+    );
     assert_eq!(
-        format!("{:#?}", project.module),
-        format!("{plain:#?}"),
-        "single-file project IR must match plain lowering exactly"
+        proj_types.len(),
+        plain.types.len() + 1,
+        "no types beyond the entry's + Net.NetEvent"
     );
 }
 

--- a/runtime/functor-runtime-common/src/mle_prelude.rs
+++ b/runtime/functor-runtime-common/src/mle_prelude.rs
@@ -1422,10 +1422,21 @@ Net.NetEvent, got {}",
                 _ => usage(&format!("{path}(endpoint, tagger)")),
             },
             "Effect.send" => match args.as_slice() {
-                [id, Value::String(text)] => Ok(host(MleEffect(EffectTree::Send {
-                    conn: num(id, span)?,
-                    text: text.to_string(),
-                }))),
+                [id, Value::String(text)] => {
+                    let n = num(id, span)?;
+                    // A connection id is a non-negative whole number the host
+                    // handed the game; reject garbage rather than truncate it
+                    // to some OTHER live client.
+                    if n < 0.0 || n.fract() != 0.0 || n > u64::MAX as f64 {
+                        return err(format!(
+                            "Effect.send: connId must be a non-negative whole number, got {n}"
+                        ));
+                    }
+                    Ok(host(MleEffect(EffectTree::Send {
+                        conn: n,
+                        text: text.to_string(),
+                    })))
+                }
                 _ => usage("Effect.send(connId, text)"),
             },
             "Physics.transformed" => match args.as_slice() {
@@ -3971,6 +3982,22 @@ the game dir"
                 assert_eq!(args[1].to_string(), "\"yo\"");
             }
             other => panic!("expected a variant, got {other}"),
+        }
+    }
+
+    /// Effect.send rejects a garbage connection id rather than truncating it
+    /// to some OTHER live client. [Codex M — net review]
+    #[test]
+    fn effect_send_rejects_bad_conn_ids() {
+        for (id, src) in [
+            ("-1.0", "let main = () => Effect.send(-1.0, \"x\")"),
+            ("1.5", "let main = () => Effect.send(1.5, \"x\")"),
+        ] {
+            let msg = run_fail(src);
+            assert!(
+                msg.contains("connId must be a non-negative whole number"),
+                "id {id}: {msg}"
+            );
         }
     }
 

--- a/runtime/functor-runtime-common/src/mle_prelude.rs
+++ b/runtime/functor-runtime-common/src/mle_prelude.rs
@@ -273,6 +273,10 @@ pub enum EffectValue {
     List(Vec<EffectValue>),
     /// Field order is construction order (deterministic, like MLE records).
     Record(Vec<(String, EffectValue)>),
+    /// A variant value: a (canonical) constructor name and its positional
+    /// args — how the host hands a game a prelude-declared ADT like
+    /// `Net.Connected(id)` (see the built-in `Net` module).
+    Variant(String, Vec<EffectValue>),
 }
 
 impl EffectValue {
@@ -291,6 +295,10 @@ impl EffectValue {
                     .map(|(k, v)| (k.clone(), v.to_mle()))
                     .collect(),
             )),
+            EffectValue::Variant(ctor, args) => Value::Variant {
+                ctor: Rc::from(ctor.as_str()),
+                args: Rc::new(args.iter().map(EffectValue::to_mle).collect()),
+            },
         }
     }
 }

--- a/runtime/functor-runtime-common/src/mle_prelude.rs
+++ b/runtime/functor-runtime-common/src/mle_prelude.rs
@@ -128,11 +128,11 @@ use std::rc::Rc;
 
 use crate::fog::Fog;
 use crate::math::Angle;
-use crate::ui::{self, View};
 use crate::physics;
 use crate::render_target::RenderTargetDescriptor;
 use crate::scene3d::{MaterialDescription, ModelDescription, ModelHandle, TextureDescription};
 use crate::skybox::SkyboxDescription;
+use crate::ui::{self, View};
 use crate::{Camera, Frame, Light, Scene3D, SceneObject, Shape};
 
 /// A [`Scene3D`] as an opaque MLE value.
@@ -171,13 +171,29 @@ pub struct MleDuration(pub f64);
 #[derive(Clone)]
 pub enum SubTree {
     None,
-    Every { period_seconds: f64, msg: Value },
+    Every {
+        period_seconds: f64,
+        msg: Value,
+    },
     Batch(Vec<SubTree>),
     /// Collision events from the physics step (docs/physics.md Phase 5):
     /// the tagger receives `{started, a, b, sensor}` for every contact that
     /// began/ended this frame, delivered post-step through `update` (the
     /// same point deferred queries answer).
-    PhysicsEvents { tagger: Value },
+    PhysicsEvents {
+        tagger: Value,
+    },
+    /// A persistent client connection (`Sub.connect`) or server listener
+    /// (`Sub.listen`), keyed by its endpoint url/addr. NOT fired on the time
+    /// grid — the producer reconciles declared keys against the live set
+    /// each frame (open/close) and routes inbound `Net.NetEvent`s to the
+    /// matching key's tagger through `update` (the physics-events pattern,
+    /// but routed BY KEY). `listen` is the server side.
+    Connect {
+        key: String,
+        listen: bool,
+        tagger: Value,
+    },
 }
 
 pub struct MleSub(pub SubTree);
@@ -209,6 +225,13 @@ pub enum EffectTree {
     /// for the recorder ([`physics::SteppedPhysics`]) like commands queue
     /// for the world.
     Timeline(physics::TimelineControl),
+    /// Send text on an open connection (`Effect.send(id, text)`). Tagger-less
+    /// like a physics command: performing it queues a `ConnCommand::Send` for
+    /// the shell's connection manager.
+    Send {
+        conn: f64,
+        text: String,
+    },
     /// A physics query (docs/physics.md Phase 4). Unlike `Now`/`Random`,
     /// queries are **deferred**: the pre-step drain holds them and the
     /// driver performs them right after the frame's physics step, so the
@@ -780,6 +803,9 @@ const PATHS: &[&str] = &[
     "Physics.stepOnce",
     "Physics.rewindTo",
     "Physics.timelineFrame",
+    "Sub.connect",
+    "Sub.listen",
+    "Effect.send",
 ];
 
 impl Host for FunctorHost {
@@ -1378,6 +1404,30 @@ the game dir",
                 )),
                 _ => usage("Physics.events(tagger)"),
             },
+            // A persistent connection (client) / listener (server): the key
+            // is the endpoint; the tagger receives `Net.NetEvent` values.
+            "Sub.connect" | "Sub.listen" => match args.as_slice() {
+                [Value::String(key), tagger @ (Value::Closure(_) | Value::Ctor { .. })] => {
+                    Ok(host(MleSub(SubTree::Connect {
+                        key: key.to_string(),
+                        listen: path == "Sub.listen",
+                        tagger: tagger.clone(),
+                    })))
+                }
+                [_, other] => err(format!(
+                    "{path}(endpoint, tagger): the tagger must be a function of the \
+Net.NetEvent, got {}",
+                    other.kind_name()
+                )),
+                _ => usage(&format!("{path}(endpoint, tagger)")),
+            },
+            "Effect.send" => match args.as_slice() {
+                [id, Value::String(text)] => Ok(host(MleEffect(EffectTree::Send {
+                    conn: num(id, span)?,
+                    text: text.to_string(),
+                }))),
+                _ => usage("Effect.send(connId, text)"),
+            },
             "Physics.transformed" => match args.as_slice() {
                 [scene, Value::String(tag)] => {
                     let Some(inner) = scene_of(scene) else {
@@ -1807,6 +1857,8 @@ fn collect_fired(sub: &SubTree, prev_tts: f64, tts: f64, msgs: &mut Vec<Value>) 
         // Event subs fire from the physics step, not the time grid — the
         // drivers collect their taggers via `physics_event_taggers`.
         SubTree::PhysicsEvents { .. } => {}
+        // Connections are reconciled + routed by the producer, not fired.
+        SubTree::Connect { .. } => {}
     }
 }
 
@@ -1826,9 +1878,79 @@ pub fn physics_event_taggers(subs: &Value) -> Result<Vec<Value>, String> {
     Ok(taggers)
 }
 
+/// One declared connection from `subscriptions` — the producer reconciles
+/// these keys (open/close) and routes inbound events to their taggers.
+pub struct NetConnSub {
+    pub key: String,
+    pub listen: bool,
+    pub tagger: Value,
+}
+
+/// The `Sub.connect`/`Sub.listen` declarations in a sub tree, in declaration
+/// order. Same non-Sub error as `sub_messages_for_frame`.
+pub fn net_conn_subs(subs: &Value) -> Result<Vec<NetConnSub>, String> {
+    let Some(sub) = sub_of(subs) else {
+        return Err(format!(
+            "subscriptions must return a Sub (Sub.every / Sub.none / Sub.batch), got {}",
+            subs.kind_name()
+        ));
+    };
+    let mut out = Vec::new();
+    collect_conn_subs(&sub.0, &mut out);
+    Ok(out)
+}
+
+fn collect_conn_subs(sub: &SubTree, out: &mut Vec<NetConnSub>) {
+    match sub {
+        SubTree::Batch(items) => {
+            for item in items.iter() {
+                collect_conn_subs(item, out);
+            }
+        }
+        SubTree::Connect {
+            key,
+            listen,
+            tagger,
+        } => out.push(NetConnSub {
+            key: key.clone(),
+            listen: *listen,
+            tagger: tagger.clone(),
+        }),
+        SubTree::None | SubTree::Every { .. } | SubTree::PhysicsEvents { .. } => {}
+    }
+}
+
+/// Build the `Net.NetEvent` value the host hands a connection's tagger. The
+/// canonical ctor names come from the built-in `Net` module (see
+/// `mle::project`); `text` is the message/error payload (unused for
+/// Connected/Disconnected).
+pub fn net_event_value(kind: NetEventKind, conn: u64, text: &str) -> EffectValue {
+    let id = EffectValue::Number(conn as f64);
+    match kind {
+        NetEventKind::Connected => EffectValue::Variant("Net.Connected".into(), vec![id]),
+        NetEventKind::Disconnected => EffectValue::Variant("Net.Disconnected".into(), vec![id]),
+        NetEventKind::Message => EffectValue::Variant(
+            "Net.Message".into(),
+            vec![id, EffectValue::Text(text.to_string())],
+        ),
+        NetEventKind::Error => EffectValue::Variant(
+            "Net.Error".into(),
+            vec![id, EffectValue::Text(text.to_string())],
+        ),
+    }
+}
+
+#[derive(Clone, Copy)]
+pub enum NetEventKind {
+    Connected,
+    Message,
+    Disconnected,
+    Error,
+}
+
 fn collect_event_taggers(sub: &SubTree, taggers: &mut Vec<Value>) {
     match sub {
-        SubTree::None | SubTree::Every { .. } => {}
+        SubTree::None | SubTree::Every { .. } | SubTree::Connect { .. } => {}
         SubTree::Batch(items) => {
             for item in items.iter() {
                 collect_event_taggers(item, taggers);
@@ -2002,7 +2124,10 @@ pub fn drain_effects(
 /// update-less games.)
 pub fn needs_update(tree: &EffectTree) -> bool {
     match tree {
-        EffectTree::None | EffectTree::Physics(_) | EffectTree::Timeline(_) => false,
+        EffectTree::None
+        | EffectTree::Physics(_)
+        | EffectTree::Timeline(_)
+        | EffectTree::Send { .. } => false,
         EffectTree::Now { .. } | EffectTree::Random { .. } | EffectTree::Raycast { .. } => true,
         EffectTree::Batch(items) => items.iter().any(needs_update),
     }
@@ -2044,11 +2169,11 @@ fn drain_mode(
     const MAX_EFFECTS_PER_FRAME: usize = 1000;
     let mut queue: Vec<EffectTree> = queue;
     queue.reverse(); // treat the input list as front-of-queue, in order
-    // Counts every DEQUEUED node (None and Batch structure included), and is
-    // checked BEFORE the runner performs anything — so a runaway chain can't
-    // consume unbounded frame time through structural nodes, and the capped
-    // effect is never half-performed (no runner state advanced, nothing
-    // logged, no replay-log entry consumed).
+                     // Counts every DEQUEUED node (None and Batch structure included), and is
+                     // checked BEFORE the runner performs anything — so a runaway chain can't
+                     // consume unbounded frame time through structural nodes, and the capped
+                     // effect is never half-performed (no runner state advanced, nothing
+                     // logged, no replay-log entry consumed).
     let mut processed = 0usize;
     while let Some(tree) = queue.pop() {
         processed += 1;
@@ -2104,6 +2229,23 @@ dropping the rest"
                 };
                 physics::queue_timeline_control(control);
                 log.push(EffectRecord { kind, value });
+                if log.len() > EFFECT_LOG_CAP {
+                    log.remove(0);
+                }
+                continue;
+            }
+            EffectTree::Send { conn, text } => {
+                // Fire-and-forget, like a physics command: queue a Send on the
+                // shell's connection manager (drained via
+                // net_drain_conn_commands). Logged for the effect record.
+                crate::net::push_conn_command(crate::net::ConnCommand::Send {
+                    conn: conn as crate::net::ConnectionId,
+                    payload: text.clone().into_bytes(),
+                });
+                log.push(EffectRecord {
+                    kind: "net.send",
+                    value: EffectValue::Text(text),
+                });
                 if log.len() > EFFECT_LOG_CAP {
                     log.remove(0);
                 }
@@ -2686,7 +2828,10 @@ Scene.cube() |> Scene.rotateY(Angle.radians(1.5707964)))",
         assert!(pass.frame.render_targets.is_empty());
         // The reader's wire shape: the screen material samples the target by id.
         let json = serde_json::to_string(&frame).expect("serialize");
-        assert!(json.contains(r#""RenderTarget":"security""#), "json: {json}");
+        assert!(
+            json.contains(r#""RenderTarget":"security""#),
+            "json: {json}"
+        );
         // And the whole frame round-trips through the protocol.
         let back: Frame = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(serde_json::to_string(&back).unwrap(), json);
@@ -2704,7 +2849,9 @@ Scene.cube() |> Scene.rotateY(Angle.radians(1.5707964)))",
         );
         let json = serde_json::to_string(&frame.scene).expect("serialize");
         assert!(
-            json.contains(r#""Emissive":{"color":[1.0,1.0,1.0,1.0],"texture":{"RenderTarget":"feed"}}"#),
+            json.contains(
+                r#""Emissive":{"color":[1.0,1.0,1.0,1.0],"texture":{"RenderTarget":"feed"}}"#
+            ),
             "json: {json}"
         );
     }
@@ -2737,9 +2884,7 @@ Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0), Scene.cube()))"
 it once with RenderTarget.named(\"…\") and pass that value at both sites"
         );
         assert_eq!(
-            fail(
-                "let main = () => RenderTarget.named(\"x\") |> RenderTarget.sized(-1.0, 4.0)"
-            ),
+            fail("let main = () => RenderTarget.named(\"x\") |> RenderTarget.sized(-1.0, 4.0)"),
             "RenderTarget.sized width must be positive, got -1"
         );
         assert_eq!(
@@ -2840,8 +2985,10 @@ Scene.cube()) |> Frame.withSkybox(\"sky.jpg\")"
 Skybox.files(px, nx, py, ny, pz, nz)"
         );
         assert_eq!(
-            fail("let main = () => Skybox.files(\"px.jpg\", \"\", \"py.jpg\", \"ny.jpg\", \
-\"pz.jpg\", \"nz.jpg\")"),
+            fail(
+                "let main = () => Skybox.files(\"px.jpg\", \"\", \"py.jpg\", \"ny.jpg\", \
+\"pz.jpg\", \"nz.jpg\")"
+            ),
             "usage: Skybox.files(px, nx, py, ny, pz, nz) — six non-empty face \
 paths (+X, -X, +Y, -Y, +Z, -Z)"
         );
@@ -2958,9 +3105,7 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
     #[test]
     fn physics_command_effects_queue_and_apply() {
         crate::physics::remove_world(crate::physics::DEFAULT_WORLD);
-        let effect = eval(
-            "let main = () => Physics.applyImpulse(\"ball\", 2.0, 0.0, 0.0)",
-        );
+        let effect = eval("let main = () => Physics.applyImpulse(\"ball\", 2.0, 0.0, 0.0)");
         let Value::HostData(data) = &effect else {
             panic!("expected an Effect");
         };
@@ -3255,7 +3400,14 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
         assert!(matches!(model, Value::Number(_)), "model must be untouched");
 
         // Post-step drain: performed against the live world.
-        perform_deferred_queries(&session, &mut model, deferred, &mut runner, &mut log, &mut fail);
+        perform_deferred_queries(
+            &session,
+            &mut model,
+            deferred,
+            &mut runner,
+            &mut log,
+            &mut fail,
+        );
         assert_eq!(log.len(), 1);
         assert_eq!(log[0].kind, "physics.raycast");
         let Value::Record(fields) = &model else {
@@ -3307,7 +3459,9 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
         let EffectValue::Record(f) = &miss else {
             panic!()
         };
-        assert!(f.iter().any(|(k, v)| k == "hit" && *v == EffectValue::Bool(false)));
+        assert!(f
+            .iter()
+            .any(|(k, v)| k == "hit" && *v == EffectValue::Bool(false)));
     }
 
     /// The Phase 5 event path end to end: a `Physics.events` sub's tagger
@@ -3365,10 +3519,7 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
         .flatten()
         .expect("a contact");
 
-        let mut model = Value::Record(Rc::new(vec![(
-            "contacts".to_string(),
-            Value::Number(0.0),
-        )]));
+        let mut model = Value::Record(Rc::new(vec![("contacts".to_string(), Value::Number(0.0))]));
         let mut log = EffectLog::new();
         let mut runner = FakeEffects::new(0.0, vec![]);
         deliver_physics_events(
@@ -3702,7 +3853,9 @@ row 1 has 3"
             "json: {json}"
         );
         assert!(
-            json.contains(r#""Emissive":{"color":[1.0,1.0,1.0,1.0],"texture":{"File":"grid.png"}}"#),
+            json.contains(
+                r#""Emissive":{"color":[1.0,1.0,1.0,1.0],"texture":{"File":"grid.png"}}"#
+            ),
             "json: {json}"
         );
         // And the whole thing round-trips through the protocol.
@@ -3752,6 +3905,73 @@ the game dir"
         // And it round-trips (the wasm boundary ships Views as JSON).
         let back: View = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(serde_json::to_string(&back).unwrap(), json);
+    }
+
+    // --- Networking (Sub.connect/listen, Effect.send, NetEvent) ---
+
+    #[test]
+    fn net_conn_subs_extracts_declarations() {
+        let subs = eval(
+            "type Msg = | Ws(ev: Net.NetEvent)\n\
+             let main = () => Sub.batch([\n\
+               Sub.connect(\"ws://a/echo\", Ws),\n\
+               Sub.listen(\"127.0.0.1:9001\", Ws),\n\
+             ])",
+        );
+        let conns = net_conn_subs(&subs).expect("a Sub tree");
+        assert_eq!(conns.len(), 2);
+        assert_eq!(conns[0].key, "ws://a/echo");
+        assert!(!conns[0].listen);
+        assert_eq!(conns[1].key, "127.0.0.1:9001");
+        assert!(conns[1].listen);
+    }
+
+    #[test]
+    fn effect_send_queues_a_conn_command() {
+        crate::net::drain_conn_commands(); // clear
+        let module =
+            mle::lower(mle::parse("let main = () => Effect.send(7.0, \"hi\")").unwrap()).unwrap();
+        let session = match mle::Session::load(&module, &mut FunctorHost) {
+            Ok(s) => s,
+            Err(f) => panic!("load: {}", f.error.message),
+        };
+        let fx = session.global("main").unwrap();
+        let fx = session.apply(fx, vec![], "main", &mut FunctorHost).unwrap();
+        let (_, effect) =
+            split_model_effect(Value::Tuple(std::rc::Rc::new(vec![Value::Number(0.0), fx])));
+        let mut model = Value::Number(0.0);
+        let mut log = EffectLog::new();
+        drain_effects(
+            &session,
+            &mut model,
+            effect.expect("a Send effect"),
+            &mut FakeEffects::new(0.0, vec![]),
+            &mut log,
+            &mut |m| panic!("unexpected report: {m}"),
+        );
+        let cmds = crate::net::drain_conn_commands();
+        assert_eq!(cmds.len(), 1);
+        assert!(matches!(
+            &cmds[0],
+            crate::net::ConnCommand::Send { conn: 7, payload } if payload == b"hi"
+        ));
+    }
+
+    /// The NetEvent value the host hands a tagger matches the built-in `Net`
+    /// module's canonical ctors — a game's `match ev with | Net.Message(id, t)`
+    /// binds them.
+    #[test]
+    fn net_event_value_matches_the_net_module() {
+        let ev = net_event_value(NetEventKind::Message, 3, "yo").to_mle();
+        match ev {
+            Value::Variant { ctor, args } => {
+                assert_eq!(ctor.as_ref(), "Net.Message");
+                assert_eq!(args.len(), 2);
+                assert_eq!(args[0].to_string(), "3");
+                assert_eq!(args[1].to_string(), "\"yo\"");
+            }
+            other => panic!("expected a variant, got {other}"),
+        }
     }
 
     // Ui teaching errors: non-View children and unbranded anchors fail loud.

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -31,8 +31,9 @@ use std::time::Instant;
 
 use functor_runtime_common::mle_prelude::{
     contains_effect, deliver_physics_events, drain_effects, frame_value, needs_update,
-    perform_deferred_queries, physics_event_taggers, physics_scene_value, split_model_effect,
-    sub_messages_for_frame, view_value, EffectLog, EffectTree, FunctorHost, RealEffects,
+    net_conn_subs, net_event_value, perform_deferred_queries, physics_event_taggers,
+    physics_scene_value, split_model_effect, sub_messages_for_frame, view_value, EffectLog,
+    EffectTree, FunctorHost, NetEventKind, RealEffects,
 };
 use functor_runtime_common::physics;
 use functor_runtime_common::ui::View;
@@ -102,6 +103,13 @@ pub struct MleGame {
     physics_rt: physics::SteppedPhysics,
     /// Latest recorder status for the overlay: (fixed frame, paused, history).
     physics_status: (u64, bool, u64),
+    /// Endpoint keys of the connections currently declared by
+    /// `subscriptions` (`Sub.connect`/`Sub.listen`) — diffed each frame to
+    /// open newly-declared ones and close dropped ones. The shell's
+    /// connection manager owns the live sockets; this is just the reconcile
+    /// key set (kept across hot reload, like the model — Connect is
+    /// idempotent).
+    live_conn_keys: std::collections::HashSet<String>,
     /// The last successfully drawn frame, kept so a bad draw shows the last
     /// good picture instead of a blank.
     last_frame: Frame,
@@ -309,6 +317,7 @@ impl MleGame {
             pending_events: Vec::new(),
             physics_rt: physics::SteppedPhysics::new(),
             physics_status: (0, false, 0),
+            live_conn_keys: std::collections::HashSet::new(),
             last_frame: empty_frame(),
             last_error: None,
             frames: 0,
@@ -435,16 +444,48 @@ to receive their messages; dropping them"
     /// frame, so a model change can silence a timer. Errors report per
     /// message and processing continues — one bad message must not stall
     /// the rest, and dedupe keeps a persistent bug to one line.
-    fn pump_subscriptions(&mut self, tts: f64) {
-        // Advance the window even without subscriptions (or on frame one),
-        // so a hot reload that ADDS subscriptions starts from a sane edge.
-        let prev = self.prev_tts.replace(tts);
+    /// Open connections newly declared this frame and close ones no longer
+    /// declared (keyed by endpoint). Commands go to the shell's connection
+    /// manager, drained via `net_drain_conn_commands`. The physics-events
+    /// pattern for connections.
+    fn reconcile_connections(&mut self, subs: &Value) {
+        use functor_runtime_common::net::{push_conn_command, ConnCommand};
+        let conns = match net_conn_subs(subs) {
+            Ok(conns) => conns,
+            Err(message) => return self.report_once(format!("[mle] {message}")),
+        };
+        let declared: std::collections::HashSet<String> =
+            conns.iter().map(|c| c.key.clone()).collect();
+        for conn in &conns {
+            if !self.live_conn_keys.contains(&conn.key) {
+                push_conn_command(if conn.listen {
+                    ConnCommand::Listen {
+                        key: conn.key.clone(),
+                        addr: conn.key.clone(),
+                    }
+                } else {
+                    ConnCommand::Connect {
+                        key: conn.key.clone(),
+                        url: conn.key.clone(),
+                    }
+                });
+            }
+        }
+        for key in &self.live_conn_keys {
+            if !declared.contains(key) {
+                push_conn_command(ConnCommand::CloseKey { key: key.clone() });
+            }
+        }
+        self.live_conn_keys = declared;
+    }
+
+    /// Route one inbound connection event to the matching key's tagger and
+    /// fold the message through `update`. Taggers are read FRESH from the
+    /// current `subscriptions(model)` (never cached — a reload rebinds them).
+    fn deliver_net_event(&mut self, key: String, kind: NetEventKind, conn: i32, text: String) {
         if !self.has_subscriptions {
             return;
         }
-        let Some(prev) = prev else {
-            return;
-        };
         let subs =
             match self
                 .session
@@ -453,6 +494,51 @@ to receive their messages; dropping them"
                 Ok(subs) => subs,
                 Err(err) => return self.frame_error("subscriptions", &err),
             };
+        let conns = match net_conn_subs(&subs) {
+            Ok(conns) => conns,
+            Err(message) => return self.report_once(format!("[mle] {message}")),
+        };
+        let Some(sub) = conns.into_iter().find(|c| c.key == key) else {
+            return; // an event for a no-longer-declared connection: drop it
+        };
+        let value = net_event_value(kind, conn as u64, &text).to_mle();
+        let msg = match self
+            .session
+            .apply(sub.tagger, vec![value], "net event", &mut FunctorHost)
+        {
+            Ok(msg) => msg,
+            Err(err) => return self.frame_error("net event", &err),
+        };
+        match self
+            .session
+            .call("update", vec![self.model.clone(), msg], &mut FunctorHost)
+        {
+            Ok(returned) => self.absorb(returned),
+            Err(err) => self.frame_error("update", &err),
+        }
+    }
+
+    fn pump_subscriptions(&mut self, tts: f64) {
+        // Advance the window even without subscriptions (or on frame one),
+        // so a hot reload that ADDS subscriptions starts from a sane edge.
+        let prev = self.prev_tts.replace(tts);
+        if !self.has_subscriptions {
+            return;
+        }
+        let subs =
+            match self
+                .session
+                .call("subscriptions", vec![self.model.clone()], &mut FunctorHost)
+            {
+                Ok(subs) => subs,
+                Err(err) => return self.frame_error("subscriptions", &err),
+            };
+        // Reconcile connections EVERY frame — including frame one (before the
+        // timer window exists), so a declared connection opens immediately.
+        self.reconcile_connections(&subs);
+        let Some(prev) = prev else {
+            return;
+        };
         let msgs = match sub_messages_for_frame(&subs, prev, tts) {
             Ok(msgs) => msgs,
             Err(message) => return self.report_once(format!("[mle] {message}")),
@@ -640,8 +726,7 @@ impl Game for MleGame {
         // frame's steps, but also while PAUSED (frozen mid-flight, frame > 0)
         // and on a short zero-substep frame — so a raycast fired while paused
         // answers against the frozen world instead of deferring forever.
-        let world_ready =
-            physics_steps > 0 || !self.has_physics || self.physics_status.0 > 0;
+        let world_ready = physics_steps > 0 || !self.has_physics || self.physics_status.0 > 0;
         if world_ready && !self.deferred_queries.is_empty() {
             let deferred = std::mem::take(&mut self.deferred_queries);
             let mut reports: Vec<String> = Vec::new();
@@ -788,8 +873,10 @@ impl Game for MleGame {
             return self.last_view.clone();
         }
         let status = View::text(
-            format!("physics ⏸ frame {frame} · {history} recorded · Left/Right scrub · Space resume")
-                .into(),
+            format!(
+                "physics ⏸ frame {frame} · {history} recorded · Left/Right scrub · Space resume"
+            )
+            .into(),
         );
         View::Column(vec![self.last_view.clone(), status])
     }
@@ -810,12 +897,20 @@ impl Game for MleGame {
         "{\"sources\":[]}".to_string()
     }
     fn net_drain_conn_commands(&self) -> String {
-        "[]".to_string()
+        functor_runtime_common::net::drain_conn_commands_json()
     }
-    fn net_push_connected(&mut self, _key: String, _conn: i32) {}
-    fn net_push_conn_message(&mut self, _key: String, _conn: i32, _text: String) {}
-    fn net_push_disconnected(&mut self, _key: String, _conn: i32) {}
-    fn net_push_conn_error(&mut self, _key: String, _conn: i32, _message: String) {}
+    fn net_push_connected(&mut self, key: String, conn: i32) {
+        self.deliver_net_event(key, NetEventKind::Connected, conn, String::new());
+    }
+    fn net_push_conn_message(&mut self, key: String, conn: i32, text: String) {
+        self.deliver_net_event(key, NetEventKind::Message, conn, text);
+    }
+    fn net_push_disconnected(&mut self, key: String, conn: i32) {
+        self.deliver_net_event(key, NetEventKind::Disconnected, conn, String::new());
+    }
+    fn net_push_conn_error(&mut self, key: String, conn: i32, message: String) {
+        self.deliver_net_event(key, NetEventKind::Error, conn, message);
+    }
     fn audio_push_finished(&mut self, _token: i32) {}
 
     fn quit(&mut self) {}
@@ -852,6 +947,73 @@ fn empty_frame() -> Frame {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The whole networking path, headless — no socket, no GL. Drives a
+    /// live `MleGame` for the wsdemo port: declaring `Sub.connect`
+    /// reconciles into a `Connect` command; a `Connected` event routes
+    /// through the tagger → `update`, storing the id and replying with
+    /// `Effect.send`; a `Message` event lands in the model.
+    #[test]
+    fn websocket_connect_send_receive() {
+        use functor_runtime_common::net::{drain_conn_commands, ConnCommand};
+        const ENDPOINT: &str = "ws://127.0.0.1:9001/echo";
+        let dir = std::env::temp_dir().join(format!("mle-net-ws-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("game.mle"),
+            "type Conn = | NoConn | Conn(id: Float)\n\
+             type Model = { conn: Conn, last: String }\n\
+             type Msg = | Ws(ev: Net.NetEvent)\n\
+             let init = { conn: NoConn, last: \"\" }\n\
+             let update = (m: Model, msg: Msg) =>\n\
+               match msg with\n\
+               | Ws(ev) =>\n\
+                 (match ev with\n\
+                  | Net.Connected(id) => ({ m with conn: Conn(id) }, Effect.send(id, \"hello\"))\n\
+                  | Net.Message(id, text) => { m with last: text }\n\
+                  | Net.Disconnected(id) => { m with conn: NoConn }\n\
+                  | Net.Error(id, e) => { m with last: e })\n\
+             let subscriptions = (m: Model) => Sub.connect(\"ws://127.0.0.1:9001/echo\", Ws)\n\
+             let tick = (m: Model, dt: Float, tts: Float) => m\n\
+             let draw = (m: Model, tts: Float) =>\n\
+               Frame.create(Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0), Scene.cube())\n",
+        )
+        .unwrap();
+        let _ = drain_conn_commands(); // clear the shared queue
+
+        let mut game = MleGame::create(dir.join("game.mle").to_str().unwrap());
+
+        // 1. Declaring the connection queues a Connect on the first frame.
+        game.tick(FrameTime {
+            tts: 0.0,
+            dts: 0.016,
+        });
+        let cmds = drain_conn_commands();
+        assert!(
+            cmds.iter()
+                .any(|c| matches!(c, ConnCommand::Connect { key, .. } if key == ENDPOINT)),
+            "expected a Connect for {ENDPOINT}, got {cmds:?}"
+        );
+
+        // 2. A Connected event → the game stores the id and replies with send.
+        game.net_push_connected(ENDPOINT.to_string(), 5);
+        let cmds = drain_conn_commands();
+        assert!(
+            cmds.iter().any(
+                |c| matches!(c, ConnCommand::Send { conn, payload } if *conn == 5 && payload == b"hello")
+            ),
+            "expected Send(5, hello), got {cmds:?}"
+        );
+
+        // 3. A Message event lands in the model.
+        game.net_push_conn_message(ENDPOINT.to_string(), 5, "echo".to_string());
+        assert!(
+            game.state_debug().contains("echo"),
+            "model should hold the message: {}",
+            game.state_debug()
+        );
+    }
 
     /// Write `src` as `game.mle` in its own temp directory (a directory is
     /// a whole project since B8 — a shared temp dir would drag stray `.mle`

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -444,6 +444,16 @@ to receive their messages; dropping them"
     /// frame, so a model change can silence a timer. Errors report per
     /// message and processing continues — one bad message must not stall
     /// the rest, and dedupe keeps a persistent bug to one line.
+    /// Close every connection this producer still has open (a reload that
+    /// dropped `subscriptions`, or shutdown). CloseKey is queued for each;
+    /// the live set is cleared.
+    fn close_all_connections(&mut self) {
+        use functor_runtime_common::net::{push_conn_command, ConnCommand};
+        for key in std::mem::take(&mut self.live_conn_keys) {
+            push_conn_command(ConnCommand::CloseKey { key });
+        }
+    }
+
     /// Open connections newly declared this frame and close ones no longer
     /// declared (keyed by endpoint). Commands go to the shell's connection
     /// manager, drained via `net_drain_conn_commands`. The physics-events
@@ -454,9 +464,13 @@ to receive their messages; dropping them"
             Ok(conns) => conns,
             Err(message) => return self.report_once(format!("[mle] {message}")),
         };
-        let declared: std::collections::HashSet<String> =
-            conns.iter().map(|c| c.key.clone()).collect();
+        // Dedupe by key (first declaration wins its listen/connect role) so
+        // a key is opened at most once even if declared twice in one frame.
+        let mut declared: std::collections::HashSet<String> = std::collections::HashSet::new();
         for conn in &conns {
+            if !declared.insert(conn.key.clone()) {
+                continue; // already handled this key this frame
+            }
             if !self.live_conn_keys.contains(&conn.key) {
                 push_conn_command(if conn.listen {
                     ConnCommand::Listen {
@@ -523,6 +537,11 @@ to receive their messages; dropping them"
         // so a hot reload that ADDS subscriptions starts from a sane edge.
         let prev = self.prev_tts.replace(tts);
         if !self.has_subscriptions {
+            // No subscriptions must not leave a previous program's
+            // connections open (a hot reload that dropped them).
+            if !self.live_conn_keys.is_empty() {
+                self.close_all_connections();
+            }
             return;
         }
         let subs =
@@ -913,7 +932,9 @@ impl Game for MleGame {
     }
     fn audio_push_finished(&mut self, _token: i32) {}
 
-    fn quit(&mut self) {}
+    fn quit(&mut self) {
+        self.close_all_connections();
+    }
 }
 
 /// `name` must be a function of `arity` params — a contract violation is
@@ -995,11 +1016,12 @@ mod tests {
             dts: 0.016,
         });
         let cmds = drain_conn_commands();
-        assert!(
-            cmds.iter()
-                .any(|c| matches!(c, ConnCommand::Connect { key, .. } if key == ENDPOINT)),
-            "expected a Connect for {ENDPOINT}, got {cmds:?}"
-        );
+        // Exactly one Connect (declared once) — the dedupe guard. [Codex M]
+        let connects = cmds
+            .iter()
+            .filter(|c| matches!(c, ConnCommand::Connect { key, .. } if key == ENDPOINT))
+            .count();
+        assert_eq!(connects, 1, "expected exactly one Connect, got {cmds:?}");
 
         // 2. A Connected event → the game stores the id and replies with send.
         game.net_push_connected(ENDPOINT.to_string(), 5);

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -948,6 +948,10 @@ fn empty_frame() -> Frame {
 mod tests {
     use super::*;
 
+    // The net conn-command queue is process-global, so the two net tests
+    // below must not run concurrently — serialize them.
+    static NET_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     /// The whole networking path, headless — no socket, no GL. Drives a
     /// live `MleGame` for the wsdemo port: declaring `Sub.connect`
     /// reconciles into a `Connect` command; a `Connected` event routes
@@ -955,6 +959,7 @@ mod tests {
     /// `Effect.send`; a `Message` event lands in the model.
     #[test]
     fn websocket_connect_send_receive() {
+        let _guard = NET_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         use functor_runtime_common::net::{drain_conn_commands, ConnCommand};
         const ENDPOINT: &str = "ws://127.0.0.1:9001/echo";
         let dir = std::env::temp_dir().join(format!("mle-net-ws-{}", std::process::id()));
@@ -1013,6 +1018,77 @@ mod tests {
             "model should hold the message: {}",
             game.state_debug()
         );
+    }
+
+    /// The server (Sub.listen) path with a CLOSURE tagger: listening queues
+    /// a Listen command, a client Connected event greets THAT client by id,
+    /// and a Message is echoed back to its sender.
+    #[test]
+    fn websocket_server_listen_greet_echo() {
+        let _guard = NET_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        use functor_runtime_common::net::{drain_conn_commands, ConnCommand};
+        const BIND: &str = "127.0.0.1:9001";
+        let dir = std::env::temp_dir().join(format!("mle-net-server-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("game.mle"),
+            "type Model = { clients: Float, last: String }\n\
+             type Msg = | Joined(id: Float) | Got(id: Float, text: String) | Left(id: Float)\n\
+             let toMsg = (ev: Net.NetEvent): Msg =>\n\
+               match ev with\n\
+               | Net.Connected(id) => Joined(id)\n\
+               | Net.Message(id, text) => Got(id, text)\n\
+               | Net.Disconnected(id) => Left(id)\n\
+               | Net.Error(id, e) => Left(id)\n\
+             let init = { clients: 0.0, last: \"\" }\n\
+             let update = (m: Model, msg: Msg) =>\n\
+               match msg with\n\
+               | Joined(id) => ({ m with clients: m.clients + 1.0 }, Effect.send(id, \"welcome\"))\n\
+               | Got(id, text) => ({ m with last: text }, Effect.send(id, text))\n\
+               | Left(id) => { m with clients: m.clients - 1.0 }\n\
+             let subscriptions = (m: Model) => Sub.listen(\"127.0.0.1:9001\", toMsg)\n\
+             let tick = (m: Model, dt: Float, tts: Float) => m\n\
+             let draw = (m: Model, tts: Float) =>\n\
+               Frame.create(Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0), Scene.cube())\n",
+        )
+        .unwrap();
+        let _ = drain_conn_commands();
+        let mut game = MleGame::create(dir.join("game.mle").to_str().unwrap());
+
+        game.tick(FrameTime {
+            tts: 0.0,
+            dts: 0.016,
+        });
+        let cmds = drain_conn_commands();
+        assert!(
+            cmds.iter()
+                .any(|c| matches!(c, ConnCommand::Listen { key, .. } if key == BIND)),
+            "expected a Listen for {BIND}, got {cmds:?}"
+        );
+
+        // Two clients connect; each is greeted by its OWN id.
+        game.net_push_connected(BIND.to_string(), 11);
+        game.net_push_connected(BIND.to_string(), 22);
+        let cmds = drain_conn_commands();
+        assert!(cmds.iter().any(
+            |c| matches!(c, ConnCommand::Send { conn: 11, payload } if payload == b"welcome")
+        ));
+        assert!(cmds.iter().any(
+            |c| matches!(c, ConnCommand::Send { conn: 22, payload } if payload == b"welcome")
+        ));
+        assert!(
+            game.state_debug().contains("clients: 2"),
+            "{}",
+            game.state_debug()
+        );
+
+        // A message from client 22 is echoed back to 22.
+        game.net_push_conn_message(BIND.to_string(), 22, "ping".to_string());
+        let cmds = drain_conn_commands();
+        assert!(cmds
+            .iter()
+            .any(|c| matches!(c, ConnCommand::Send { conn: 22, payload } if payload == b"ping")));
     }
 
     /// Write `src` as `game.mle` in its own temp directory (a directory is

--- a/runtime/functor-runtime-web/src/mle_game.rs
+++ b/runtime/functor-runtime-web/src/mle_game.rs
@@ -23,8 +23,9 @@ use std::cell::RefCell;
 
 use functor_runtime_common::mle_prelude::{
     contains_effect, deliver_physics_events, drain_effects, frame_value, needs_update,
-    perform_deferred_queries, physics_event_taggers, physics_scene_value, split_model_effect,
-    sub_messages_for_frame, view_value, EffectLog, EffectTree, FunctorHost, RealEffects,
+    net_conn_subs, net_event_value, perform_deferred_queries, physics_event_taggers,
+    physics_scene_value, split_model_effect, sub_messages_for_frame, view_value, EffectLog,
+    EffectTree, FunctorHost, NetEventKind, RealEffects,
 };
 use functor_runtime_common::physics;
 use functor_runtime_common::protocol::GameProducer;
@@ -77,6 +78,9 @@ pub struct MleWebGame {
     physics_rt: physics::SteppedPhysics,
     /// Latest recorder status for the overlay: (fixed frame, paused, history).
     physics_status: (u64, bool, u64),
+    /// Declared connection keys (`Sub.connect`/`Sub.listen`), reconciled each
+    /// frame — see the desktop producer.
+    live_conn_keys: std::collections::HashSet<String>,
     /// The last successfully drawn frame, kept so a bad draw shows the last
     /// good picture instead of a blank.
     last_frame: Frame,
@@ -227,6 +231,7 @@ impl MleWebGame {
             pending_events: Vec::new(),
             physics_rt: physics::SteppedPhysics::new(),
             physics_status: (0, false, 0),
+            live_conn_keys: std::collections::HashSet::new(),
             has_physics: loaded.has_physics,
             has_ui: loaded.has_ui,
             last_view: View::Empty,
@@ -323,16 +328,45 @@ to receive their messages; dropping them"
         }
     }
 
-    fn pump_subscriptions(&mut self, tts: f64) {
-        // Advance the window even without subscriptions (or on frame one),
-        // so the edge is always sane.
-        let prev = self.prev_tts.replace(tts);
+    /// Open connections newly declared this frame and close dropped ones —
+    /// see the desktop producer's `reconcile_connections`.
+    fn reconcile_connections(&mut self, subs: &Value) {
+        use functor_runtime_common::net::{push_conn_command, ConnCommand};
+        let conns = match net_conn_subs(subs) {
+            Ok(conns) => conns,
+            Err(message) => return self.log_once(format!("[mle] {message}")),
+        };
+        let declared: std::collections::HashSet<String> =
+            conns.iter().map(|c| c.key.clone()).collect();
+        for conn in &conns {
+            if !self.live_conn_keys.contains(&conn.key) {
+                push_conn_command(if conn.listen {
+                    ConnCommand::Listen {
+                        key: conn.key.clone(),
+                        addr: conn.key.clone(),
+                    }
+                } else {
+                    ConnCommand::Connect {
+                        key: conn.key.clone(),
+                        url: conn.key.clone(),
+                    }
+                });
+            }
+        }
+        for key in &self.live_conn_keys {
+            if !declared.contains(key) {
+                push_conn_command(ConnCommand::CloseKey { key: key.clone() });
+            }
+        }
+        self.live_conn_keys = declared;
+    }
+
+    /// Route one inbound connection event to the matching key's fresh
+    /// tagger and fold through `update` — see the desktop producer.
+    fn deliver_net_event(&mut self, key: String, kind: NetEventKind, conn: i32, text: String) {
         if !self.has_subscriptions {
             return;
         }
-        let Some(prev) = prev else {
-            return;
-        };
         let subs =
             match self
                 .session
@@ -341,6 +375,49 @@ to receive their messages; dropping them"
                 Ok(subs) => subs,
                 Err(err) => return self.frame_error("subscriptions", &err),
             };
+        let conns = match net_conn_subs(&subs) {
+            Ok(conns) => conns,
+            Err(message) => return self.log_once(format!("[mle] {message}")),
+        };
+        let Some(sub) = conns.into_iter().find(|c| c.key == key) else {
+            return;
+        };
+        let value = net_event_value(kind, conn as u64, &text).to_mle();
+        let msg = match self
+            .session
+            .apply(sub.tagger, vec![value], "net event", &mut FunctorHost)
+        {
+            Ok(msg) => msg,
+            Err(err) => return self.frame_error("net event", &err),
+        };
+        match self
+            .session
+            .call("update", vec![self.model.clone(), msg], &mut FunctorHost)
+        {
+            Ok(returned) => self.absorb(returned),
+            Err(err) => self.frame_error("update", &err),
+        }
+    }
+
+    fn pump_subscriptions(&mut self, tts: f64) {
+        // Advance the window even without subscriptions (or on frame one),
+        // so the edge is always sane.
+        let prev = self.prev_tts.replace(tts);
+        if !self.has_subscriptions {
+            return;
+        }
+        let subs =
+            match self
+                .session
+                .call("subscriptions", vec![self.model.clone()], &mut FunctorHost)
+            {
+                Ok(subs) => subs,
+                Err(err) => return self.frame_error("subscriptions", &err),
+            };
+        self.reconcile_connections(&subs);
+        let Some(prev) = prev else {
+            return;
+        };
         let msgs = match sub_messages_for_frame(&subs, prev, tts) {
             Ok(msgs) => msgs,
             Err(message) => return self.log_once(format!("[mle] {message}")),
@@ -470,8 +547,7 @@ impl GameProducer for MleWebGame {
         // frame's steps, but also while PAUSED (frozen mid-flight, frame > 0)
         // and on a short zero-substep frame — so a raycast fired while paused
         // answers against the frozen world instead of deferring forever.
-        let world_ready =
-            physics_steps > 0 || !self.has_physics || self.physics_status.0 > 0;
+        let world_ready = physics_steps > 0 || !self.has_physics || self.physics_status.0 > 0;
         if world_ready && !self.deferred_queries.is_empty() {
             let deferred = std::mem::take(&mut self.deferred_queries);
             let mut reports: Vec<String> = Vec::new();
@@ -627,12 +703,20 @@ impl GameProducer for MleWebGame {
         "{\"sources\":[]}".to_string()
     }
     fn net_drain_conn_commands(&self) -> String {
-        "[]".to_string()
+        functor_runtime_common::net::drain_conn_commands_json()
     }
-    fn net_push_connected(&mut self, _key: String, _conn: i32) {}
-    fn net_push_conn_message(&mut self, _key: String, _conn: i32, _text: String) {}
-    fn net_push_disconnected(&mut self, _key: String, _conn: i32) {}
-    fn net_push_conn_error(&mut self, _key: String, _conn: i32, _message: String) {}
+    fn net_push_connected(&mut self, key: String, conn: i32) {
+        self.deliver_net_event(key, NetEventKind::Connected, conn, String::new());
+    }
+    fn net_push_conn_message(&mut self, key: String, conn: i32, text: String) {
+        self.deliver_net_event(key, NetEventKind::Message, conn, text);
+    }
+    fn net_push_disconnected(&mut self, key: String, conn: i32) {
+        self.deliver_net_event(key, NetEventKind::Disconnected, conn, String::new());
+    }
+    fn net_push_conn_error(&mut self, key: String, conn: i32, message: String) {
+        self.deliver_net_event(key, NetEventKind::Error, conn, message);
+    }
     fn audio_push_finished(&mut self, _token: i32) {}
 
     fn quit(&mut self) {}

--- a/runtime/functor-runtime-web/src/mle_game.rs
+++ b/runtime/functor-runtime-web/src/mle_game.rs
@@ -115,8 +115,12 @@ fn load_source(path: &str, src: String) -> Result<Loaded, String> {
         let (line, col) = mle::line_col(&src, span.start);
         format!("cannot {stage} {path}:{line}:{col}: {message}")
     };
-    let program = mle::parse(&src).map_err(|e| render("parse", e.span, &e.message))?;
-    let module = mle::lower(program).map_err(|e| render("load", e.span, &e.message))?;
+    // Load through the single-source project path so the built-in `Net`
+    // module is in scope (the web fetches ONE file — no siblings — but the
+    // Net ADT must still resolve). Spans render against the entry source.
+    let project = mle::project::load_single_source("Game", &src)
+        .map_err(|e| format!("cannot load {path}:{}:{}: {}", e.line, e.col, e.message))?;
+    let module = project.module;
     // Type diagnostics are advisory in the dev loop: warn, keep going
     // (the CLI's `build` is the strict gate).
     for diag in mle::check(&module) {
@@ -328,6 +332,16 @@ to receive their messages; dropping them"
         }
     }
 
+    /// Close every connection this producer still has open (a reload that
+    /// dropped `subscriptions`, or shutdown). CloseKey is queued for each;
+    /// the live set is cleared.
+    fn close_all_connections(&mut self) {
+        use functor_runtime_common::net::{push_conn_command, ConnCommand};
+        for key in std::mem::take(&mut self.live_conn_keys) {
+            push_conn_command(ConnCommand::CloseKey { key });
+        }
+    }
+
     /// Open connections newly declared this frame and close dropped ones —
     /// see the desktop producer's `reconcile_connections`.
     fn reconcile_connections(&mut self, subs: &Value) {
@@ -336,9 +350,13 @@ to receive their messages; dropping them"
             Ok(conns) => conns,
             Err(message) => return self.log_once(format!("[mle] {message}")),
         };
-        let declared: std::collections::HashSet<String> =
-            conns.iter().map(|c| c.key.clone()).collect();
+        // Dedupe by key (first declaration wins its listen/connect role) so
+        // a key is opened at most once even if declared twice in one frame.
+        let mut declared: std::collections::HashSet<String> = std::collections::HashSet::new();
         for conn in &conns {
+            if !declared.insert(conn.key.clone()) {
+                continue; // already handled this key this frame
+            }
             if !self.live_conn_keys.contains(&conn.key) {
                 push_conn_command(if conn.listen {
                     ConnCommand::Listen {
@@ -404,6 +422,11 @@ to receive their messages; dropping them"
         // so the edge is always sane.
         let prev = self.prev_tts.replace(tts);
         if !self.has_subscriptions {
+            // No subscriptions must not leave a previous program's
+            // connections open (a hot reload that dropped them).
+            if !self.live_conn_keys.is_empty() {
+                self.close_all_connections();
+            }
             return;
         }
         let subs =
@@ -719,7 +742,9 @@ impl GameProducer for MleWebGame {
     }
     fn audio_push_finished(&mut self, _token: i32) {}
 
-    fn quit(&mut self) {}
+    fn quit(&mut self) {
+        self.close_all_connections();
+    }
 }
 
 /// `name` must be a function of `arity` params — a contract violation is


### PR DESCRIPTION
## What

The MLE **networking surface**, so the multiplayer samples can port — like E1's terrain, this was a whole missing capability. Per your call, network events reach games as a **prelude-provided ADT** (not a record-with-`kind`):

```mle
let update = (m, msg) =>
  match msg with
  | Ws(ev) =>
    (match ev with
     | Net.Connected(id) => ({ m with conn: Conn(id) }, Effect.send(id, "hello"))
     | Net.Message(id, text) => { m with last: text }
     | Net.Disconnected(id) => { m with conn: NoConn }
     | Net.Error(id, e) => { m with status: e })
  | ...

let subscriptions = (m) => Sub.connect("ws://127.0.0.1:9001/echo", Ws)
```

- **Built-in `Net` module** — injected by the project loader, always in scope: `type NetEvent = | Connected(id) | Message(id, text) | Disconnected(id) | Error(id, text)`. No declaration needed; it rides entirely on B8's qualified-ctor-pattern machinery. `EffectValue::Variant` lets the host construct the `Net.*` values (the first ADT host payload — the pattern physics can converge to later).
- **Prelude**: `Sub.connect(url, tagger)` / `Sub.listen(addr, tagger)` — a `SubTree` the producer **reconciles** into `Connect`/`Listen`/`CloseKey` commands each frame and routes inbound events to the matching key's **fresh** tagger through `update` (the physics-events pattern, routed by key). `Effect.send(id, text)` — tagger-less, queues a `ConnCommand::Send`.
- **Both producers wired** (desktop + web); the web loads through a new filesystem-free `load_single_source` so `Net.*` resolves on wasm too.
- **Ports**: `examples/mle-wsdemo` (client, ctor tagger) + `examples/mle-wsserverdemo` (server, closure tagger, per-client ids), replacing F#'s `ConnectionId option` with a `Conn` ADT.

## Verification

Headless unit tests drive the whole lifecycle with **no socket**: declaring `Sub.connect` queues a `Connect`; a `Connected` event routes through the tagger → `update`, stores the id, replies with `Effect.send`; a `Message` lands in the model. The server test covers `Sub.listen` + closure taggers + per-client greeting/echo. Prelude tests pin the ADT value construction, `net_conn_subs`, and id validation.

## Review

Codex over the full diff — **5 findings, all fixed + pinned**: the web single-file loader (Net unreachable on wasm — fixed with `load_single_source`), a reload that drops subscriptions leaking connections (both producers now close them, and on `quit`), duplicate-key double-open (dedupe), and `Effect.send` accepting garbage ids (teaching error). The B8 single-file-IR invariant test was honestly updated — a project now always includes the `Net` prelude module.

**Follow-up**: `mpclient`/`mpserver` (the full multiplayer pair) and `netdemo` (HTTP) port on this surface next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
