### PR TITLE
feat(mle): list patterns + cons — [a,b] / [head, ..rest] / [x, ..xs]

### DIFF
--- a/.claude/skills/mle-language/SKILL.md
+++ b/.claude/skills/mle-language/SKILL.md
@@ -61,7 +61,11 @@ let sizeOf = (s: Shape): String =>
 
 let threshold = 10                            // top-level let; ints/floats are all Float (f64)
 let origin = { x: 0.0, y: 0.0 }               // record literal
-let scores = [1.0, 2.0, 3.0]                  // list literal
+let scores = [1.0, 2.0, 3.0]                  // list literal; [x, ..xs] prepends
+let sumList = (xs: List<Float>): Float =>     // list PATTERNS: [] / [a,b] / [h, ..t]
+  match xs with
+  | [] => 0.0
+  | [head, ..rest] => head + sumList(rest)    // refutable; needs a catch-all or [..r]
 let s = "text\n"                              // strings: escapes \" \\ \n \t
 let flag = true                               // bools
 

--- a/docs/mle.md
+++ b/docs/mle.md
@@ -279,6 +279,14 @@ snapshots — no GPU, fully agent-verifiable.
       `mle types` dump, goldened); the B4 diagnostic suite still passes;
       probe battery re-run (no legal program rejected).
 
+- [x] **Language: list patterns + cons** (2026-07-05). `[a, b]` / `[]` /
+      `[head, ..rest]` patterns in `match` (element + tail sub-patterns are
+      names/`_`; exact-length unless `..`), and `[x, ..xs]` cons in
+      expressions. Element types flow through both (inference with teeth:
+      `["s", ..floats]` errors); proper exhaustiveness — `[] | [h, ..t]`
+      IS exhaustive, `[a, b]` alone needs a catch-all. Full stack: lexer
+      (`..`), parser, lower, eval, HM types, hover/goto/rebind. Verify:
+      `mle/examples/lists.mle` + goldens; run/parser/check pin tests.
 - [x] **Language: generic type declarations** (done 2026-07-04, the B7
       follow-up both review engines asked for). `type Box<v> = | Full(value:
       v) | Empty` / `type Pair<x, y> = { … }`: checker-only (the runtime

--- a/mle/examples/lists.ast
+++ b/mle/examples/lists.ast
@@ -1,0 +1,540 @@
+Program {
+    items: [
+        Let(
+            LetDecl {
+                name: "sum",
+                value: Expr {
+                    kind: Lambda {
+                        params: [
+                            Param {
+                                name: "xs",
+                                ty: Some(
+                                    TypeName {
+                                        name: "List",
+                                        args: [
+                                            TypeName {
+                                                name: "Float",
+                                                args: [],
+                                                span: 217..222,
+                                            },
+                                        ],
+                                        span: 212..223,
+                                    },
+                                ),
+                                span: 208..223,
+                            },
+                        ],
+                        ret: Some(
+                            TypeName {
+                                name: "Float",
+                                args: [],
+                                span: 226..231,
+                            },
+                        ),
+                        body: Expr {
+                            kind: Match {
+                                scrutinee: Expr {
+                                    kind: Ident(
+                                        [
+                                            "xs",
+                                        ],
+                                    ),
+                                    span: 243..245,
+                                },
+                                arms: [
+                                    MatchArm {
+                                        pattern: Pattern {
+                                            kind: List {
+                                                items: [],
+                                                tail: None,
+                                            },
+                                            span: 255..257,
+                                        },
+                                        body: Expr {
+                                            kind: Number(
+                                                0.0,
+                                            ),
+                                            span: 261..264,
+                                        },
+                                        span: 253..264,
+                                    },
+                                    MatchArm {
+                                        pattern: Pattern {
+                                            kind: List {
+                                                items: [
+                                                    Pattern {
+                                                        kind: Var(
+                                                            "head",
+                                                        ),
+                                                        span: 270..274,
+                                                    },
+                                                ],
+                                                tail: Some(
+                                                    Pattern {
+                                                        kind: Var(
+                                                            "rest",
+                                                        ),
+                                                        span: 278..282,
+                                                    },
+                                                ),
+                                            },
+                                            span: 269..283,
+                                        },
+                                        body: Expr {
+                                            kind: Binary {
+                                                op: Add,
+                                                lhs: Expr {
+                                                    kind: Ident(
+                                                        [
+                                                            "head",
+                                                        ],
+                                                    ),
+                                                    span: 287..291,
+                                                },
+                                                rhs: Expr {
+                                                    kind: Call {
+                                                        callee: Expr {
+                                                            kind: Ident(
+                                                                [
+                                                                    "sum",
+                                                                ],
+                                                            ),
+                                                            span: 294..297,
+                                                        },
+                                                        args: [
+                                                            Expr {
+                                                                kind: Ident(
+                                                                    [
+                                                                        "rest",
+                                                                    ],
+                                                                ),
+                                                                span: 298..302,
+                                                            },
+                                                        ],
+                                                    },
+                                                    span: 294..303,
+                                                },
+                                            },
+                                            span: 287..303,
+                                        },
+                                        span: 267..303,
+                                    },
+                                ],
+                            },
+                            span: 237..303,
+                        },
+                    },
+                    span: 207..303,
+                },
+                span: 197..303,
+            },
+        ),
+        Let(
+            LetDecl {
+                name: "firstOr",
+                value: Expr {
+                    kind: Lambda {
+                        params: [
+                            Param {
+                                name: "xs",
+                                ty: Some(
+                                    TypeName {
+                                        name: "List",
+                                        args: [
+                                            TypeName {
+                                                name: "Float",
+                                                args: [],
+                                                span: 329..334,
+                                            },
+                                        ],
+                                        span: 324..335,
+                                    },
+                                ),
+                                span: 320..335,
+                            },
+                            Param {
+                                name: "fallback",
+                                ty: Some(
+                                    TypeName {
+                                        name: "Float",
+                                        args: [],
+                                        span: 347..352,
+                                    },
+                                ),
+                                span: 337..352,
+                            },
+                        ],
+                        ret: Some(
+                            TypeName {
+                                name: "Float",
+                                args: [],
+                                span: 355..360,
+                            },
+                        ),
+                        body: Expr {
+                            kind: Match {
+                                scrutinee: Expr {
+                                    kind: Ident(
+                                        [
+                                            "xs",
+                                        ],
+                                    ),
+                                    span: 372..374,
+                                },
+                                arms: [
+                                    MatchArm {
+                                        pattern: Pattern {
+                                            kind: List {
+                                                items: [
+                                                    Pattern {
+                                                        kind: Var(
+                                                            "x",
+                                                        ),
+                                                        span: 385..386,
+                                                    },
+                                                ],
+                                                tail: Some(
+                                                    Pattern {
+                                                        kind: Var(
+                                                            "rest",
+                                                        ),
+                                                        span: 390..394,
+                                                    },
+                                                ),
+                                            },
+                                            span: 384..395,
+                                        },
+                                        body: Expr {
+                                            kind: Ident(
+                                                [
+                                                    "x",
+                                                ],
+                                            ),
+                                            span: 399..400,
+                                        },
+                                        span: 382..400,
+                                    },
+                                    MatchArm {
+                                        pattern: Pattern {
+                                            kind: List {
+                                                items: [],
+                                                tail: None,
+                                            },
+                                            span: 405..407,
+                                        },
+                                        body: Expr {
+                                            kind: Ident(
+                                                [
+                                                    "fallback",
+                                                ],
+                                            ),
+                                            span: 411..419,
+                                        },
+                                        span: 403..419,
+                                    },
+                                ],
+                            },
+                            span: 366..419,
+                        },
+                    },
+                    span: 319..419,
+                },
+                span: 305..419,
+            },
+        ),
+        Let(
+            LetDecl {
+                name: "pair",
+                value: Expr {
+                    kind: Lambda {
+                        params: [
+                            Param {
+                                name: "xs",
+                                ty: Some(
+                                    TypeName {
+                                        name: "List",
+                                        args: [
+                                            TypeName {
+                                                name: "Float",
+                                                args: [],
+                                                span: 442..447,
+                                            },
+                                        ],
+                                        span: 437..448,
+                                    },
+                                ),
+                                span: 433..448,
+                            },
+                        ],
+                        ret: Some(
+                            TypeName {
+                                name: "*",
+                                args: [
+                                    TypeName {
+                                        name: "Float",
+                                        args: [],
+                                        span: 451..456,
+                                    },
+                                    TypeName {
+                                        name: "Float",
+                                        args: [],
+                                        span: 459..464,
+                                    },
+                                ],
+                                span: 451..464,
+                            },
+                        ),
+                        body: Expr {
+                            kind: Match {
+                                scrutinee: Expr {
+                                    kind: Ident(
+                                        [
+                                            "xs",
+                                        ],
+                                    ),
+                                    span: 476..478,
+                                },
+                                arms: [
+                                    MatchArm {
+                                        pattern: Pattern {
+                                            kind: List {
+                                                items: [
+                                                    Pattern {
+                                                        kind: Var(
+                                                            "a",
+                                                        ),
+                                                        span: 489..490,
+                                                    },
+                                                    Pattern {
+                                                        kind: Var(
+                                                            "b",
+                                                        ),
+                                                        span: 492..493,
+                                                    },
+                                                ],
+                                                tail: None,
+                                            },
+                                            span: 488..494,
+                                        },
+                                        body: Expr {
+                                            kind: Tuple(
+                                                [
+                                                    Expr {
+                                                        kind: Ident(
+                                                            [
+                                                                "a",
+                                                            ],
+                                                        ),
+                                                        span: 499..500,
+                                                    },
+                                                    Expr {
+                                                        kind: Ident(
+                                                            [
+                                                                "b",
+                                                            ],
+                                                        ),
+                                                        span: 502..503,
+                                                    },
+                                                ],
+                                            ),
+                                            span: 498..504,
+                                        },
+                                        span: 486..504,
+                                    },
+                                    MatchArm {
+                                        pattern: Pattern {
+                                            kind: Wildcard,
+                                            span: 509..510,
+                                        },
+                                        body: Expr {
+                                            kind: Tuple(
+                                                [
+                                                    Expr {
+                                                        kind: Number(
+                                                            0.0,
+                                                        ),
+                                                        span: 515..518,
+                                                    },
+                                                    Expr {
+                                                        kind: Number(
+                                                            0.0,
+                                                        ),
+                                                        span: 520..523,
+                                                    },
+                                                ],
+                                            ),
+                                            span: 514..524,
+                                        },
+                                        span: 507..524,
+                                    },
+                                ],
+                            },
+                            span: 470..524,
+                        },
+                    },
+                    span: 432..524,
+                },
+                span: 421..524,
+            },
+        ),
+        Let(
+            LetDecl {
+                name: "main",
+                value: Expr {
+                    kind: Lambda {
+                        params: [],
+                        ret: None,
+                        body: Expr {
+                            kind: Let {
+                                mutable: false,
+                                name: "xs",
+                                value: Expr {
+                                    kind: List(
+                                        [
+                                            Expr {
+                                                kind: Number(
+                                                    1.0,
+                                                ),
+                                                span: 555..558,
+                                            },
+                                            Expr {
+                                                kind: Number(
+                                                    2.0,
+                                                ),
+                                                span: 560..563,
+                                            },
+                                            Expr {
+                                                kind: Number(
+                                                    3.0,
+                                                ),
+                                                span: 565..568,
+                                            },
+                                        ],
+                                    ),
+                                    span: 554..569,
+                                },
+                                body: Expr {
+                                    kind: Tuple(
+                                        [
+                                            Expr {
+                                                kind: Call {
+                                                    callee: Expr {
+                                                        kind: Ident(
+                                                            [
+                                                                "sum",
+                                                            ],
+                                                        ),
+                                                        span: 576..579,
+                                                    },
+                                                    args: [
+                                                        Expr {
+                                                            kind: Ident(
+                                                                [
+                                                                    "xs",
+                                                                ],
+                                                            ),
+                                                            span: 580..582,
+                                                        },
+                                                    ],
+                                                },
+                                                span: 576..583,
+                                            },
+                                            Expr {
+                                                kind: Call {
+                                                    callee: Expr {
+                                                        kind: Ident(
+                                                            [
+                                                                "firstOr",
+                                                            ],
+                                                        ),
+                                                        span: 585..592,
+                                                    },
+                                                    args: [
+                                                        Expr {
+                                                            kind: Ident(
+                                                                [
+                                                                    "xs",
+                                                                ],
+                                                            ),
+                                                            span: 593..595,
+                                                        },
+                                                        Expr {
+                                                            kind: Number(
+                                                                0.0,
+                                                            ),
+                                                            span: 597..600,
+                                                        },
+                                                    ],
+                                                },
+                                                span: 585..601,
+                                            },
+                                            Expr {
+                                                kind: Call {
+                                                    callee: Expr {
+                                                        kind: Ident(
+                                                            [
+                                                                "pair",
+                                                            ],
+                                                        ),
+                                                        span: 603..607,
+                                                    },
+                                                    args: [
+                                                        Expr {
+                                                            kind: List(
+                                                                [
+                                                                    Expr {
+                                                                        kind: Number(
+                                                                            4.0,
+                                                                        ),
+                                                                        span: 609..612,
+                                                                    },
+                                                                    Expr {
+                                                                        kind: Number(
+                                                                            5.0,
+                                                                        ),
+                                                                        span: 614..617,
+                                                                    },
+                                                                ],
+                                                            ),
+                                                            span: 608..618,
+                                                        },
+                                                    ],
+                                                },
+                                                span: 603..619,
+                                            },
+                                            Expr {
+                                                kind: ListCons {
+                                                    items: [
+                                                        Expr {
+                                                            kind: Number(
+                                                                0.0,
+                                                            ),
+                                                            span: 622..625,
+                                                        },
+                                                    ],
+                                                    tail: Expr {
+                                                        kind: Ident(
+                                                            [
+                                                                "xs",
+                                                            ],
+                                                        ),
+                                                        span: 629..631,
+                                                    },
+                                                },
+                                                span: 621..632,
+                                            },
+                                        ],
+                                    ),
+                                    span: 575..633,
+                                },
+                            },
+                            span: 545..633,
+                        },
+                    },
+                    span: 537..633,
+                },
+                span: 526..633,
+            },
+        ),
+    ],
+}

--- a/mle/examples/lists.ir
+++ b/mle/examples/lists.ir
@@ -1,0 +1,573 @@
+Module {
+    types: [],
+    defs: [
+        Def {
+            id: d0,
+            name: "sum",
+            value: Expr {
+                id: e8,
+                kind: Lambda {
+                    params: [
+                        Param {
+                            binding: b0,
+                            name: "xs",
+                            ty: Some(
+                                TypeName {
+                                    name: "List",
+                                    args: [
+                                        TypeName {
+                                            name: "Float",
+                                            args: [],
+                                            span: 217..222,
+                                        },
+                                    ],
+                                    span: 212..223,
+                                },
+                            ),
+                            span: 208..223,
+                        },
+                    ],
+                    ret: Some(
+                        TypeName {
+                            name: "Float",
+                            args: [],
+                            span: 226..231,
+                        },
+                    ),
+                    body: Expr {
+                        id: e7,
+                        kind: Match {
+                            scrutinee: Expr {
+                                id: e0,
+                                kind: Local {
+                                    binding: b0,
+                                    name: "xs",
+                                },
+                                span: 243..245,
+                            },
+                            arms: [
+                                MatchArm {
+                                    pattern: Pattern {
+                                        kind: List {
+                                            items: [],
+                                            tail: None,
+                                        },
+                                        span: 255..257,
+                                    },
+                                    body: Expr {
+                                        id: e1,
+                                        kind: Number(
+                                            0.0,
+                                        ),
+                                        span: 261..264,
+                                    },
+                                    span: 253..264,
+                                },
+                                MatchArm {
+                                    pattern: Pattern {
+                                        kind: List {
+                                            items: [
+                                                Pattern {
+                                                    kind: Var {
+                                                        binding: b1,
+                                                        name: "head",
+                                                    },
+                                                    span: 270..274,
+                                                },
+                                            ],
+                                            tail: Some(
+                                                Pattern {
+                                                    kind: Var {
+                                                        binding: b2,
+                                                        name: "rest",
+                                                    },
+                                                    span: 278..282,
+                                                },
+                                            ),
+                                        },
+                                        span: 269..283,
+                                    },
+                                    body: Expr {
+                                        id: e6,
+                                        kind: Binary {
+                                            op: Add,
+                                            lhs: Expr {
+                                                id: e2,
+                                                kind: Local {
+                                                    binding: b1,
+                                                    name: "head",
+                                                },
+                                                span: 287..291,
+                                            },
+                                            rhs: Expr {
+                                                id: e5,
+                                                kind: Call {
+                                                    callee: Expr {
+                                                        id: e3,
+                                                        kind: Global(
+                                                            "sum",
+                                                        ),
+                                                        span: 294..297,
+                                                    },
+                                                    args: [
+                                                        Expr {
+                                                            id: e4,
+                                                            kind: Local {
+                                                                binding: b2,
+                                                                name: "rest",
+                                                            },
+                                                            span: 298..302,
+                                                        },
+                                                    ],
+                                                },
+                                                span: 294..303,
+                                            },
+                                        },
+                                        span: 287..303,
+                                    },
+                                    span: 267..303,
+                                },
+                            ],
+                        },
+                        span: 237..303,
+                    },
+                },
+                span: 207..303,
+            },
+            span: 197..303,
+        },
+        Def {
+            id: d1,
+            name: "firstOr",
+            value: Expr {
+                id: e13,
+                kind: Lambda {
+                    params: [
+                        Param {
+                            binding: b3,
+                            name: "xs",
+                            ty: Some(
+                                TypeName {
+                                    name: "List",
+                                    args: [
+                                        TypeName {
+                                            name: "Float",
+                                            args: [],
+                                            span: 329..334,
+                                        },
+                                    ],
+                                    span: 324..335,
+                                },
+                            ),
+                            span: 320..335,
+                        },
+                        Param {
+                            binding: b4,
+                            name: "fallback",
+                            ty: Some(
+                                TypeName {
+                                    name: "Float",
+                                    args: [],
+                                    span: 347..352,
+                                },
+                            ),
+                            span: 337..352,
+                        },
+                    ],
+                    ret: Some(
+                        TypeName {
+                            name: "Float",
+                            args: [],
+                            span: 355..360,
+                        },
+                    ),
+                    body: Expr {
+                        id: e12,
+                        kind: Match {
+                            scrutinee: Expr {
+                                id: e9,
+                                kind: Local {
+                                    binding: b3,
+                                    name: "xs",
+                                },
+                                span: 372..374,
+                            },
+                            arms: [
+                                MatchArm {
+                                    pattern: Pattern {
+                                        kind: List {
+                                            items: [
+                                                Pattern {
+                                                    kind: Var {
+                                                        binding: b5,
+                                                        name: "x",
+                                                    },
+                                                    span: 385..386,
+                                                },
+                                            ],
+                                            tail: Some(
+                                                Pattern {
+                                                    kind: Var {
+                                                        binding: b6,
+                                                        name: "rest",
+                                                    },
+                                                    span: 390..394,
+                                                },
+                                            ),
+                                        },
+                                        span: 384..395,
+                                    },
+                                    body: Expr {
+                                        id: e10,
+                                        kind: Local {
+                                            binding: b5,
+                                            name: "x",
+                                        },
+                                        span: 399..400,
+                                    },
+                                    span: 382..400,
+                                },
+                                MatchArm {
+                                    pattern: Pattern {
+                                        kind: List {
+                                            items: [],
+                                            tail: None,
+                                        },
+                                        span: 405..407,
+                                    },
+                                    body: Expr {
+                                        id: e11,
+                                        kind: Local {
+                                            binding: b4,
+                                            name: "fallback",
+                                        },
+                                        span: 411..419,
+                                    },
+                                    span: 403..419,
+                                },
+                            ],
+                        },
+                        span: 366..419,
+                    },
+                },
+                span: 319..419,
+            },
+            span: 305..419,
+        },
+        Def {
+            id: d2,
+            name: "pair",
+            value: Expr {
+                id: e22,
+                kind: Lambda {
+                    params: [
+                        Param {
+                            binding: b7,
+                            name: "xs",
+                            ty: Some(
+                                TypeName {
+                                    name: "List",
+                                    args: [
+                                        TypeName {
+                                            name: "Float",
+                                            args: [],
+                                            span: 442..447,
+                                        },
+                                    ],
+                                    span: 437..448,
+                                },
+                            ),
+                            span: 433..448,
+                        },
+                    ],
+                    ret: Some(
+                        TypeName {
+                            name: "*",
+                            args: [
+                                TypeName {
+                                    name: "Float",
+                                    args: [],
+                                    span: 451..456,
+                                },
+                                TypeName {
+                                    name: "Float",
+                                    args: [],
+                                    span: 459..464,
+                                },
+                            ],
+                            span: 451..464,
+                        },
+                    ),
+                    body: Expr {
+                        id: e21,
+                        kind: Match {
+                            scrutinee: Expr {
+                                id: e14,
+                                kind: Local {
+                                    binding: b7,
+                                    name: "xs",
+                                },
+                                span: 476..478,
+                            },
+                            arms: [
+                                MatchArm {
+                                    pattern: Pattern {
+                                        kind: List {
+                                            items: [
+                                                Pattern {
+                                                    kind: Var {
+                                                        binding: b8,
+                                                        name: "a",
+                                                    },
+                                                    span: 489..490,
+                                                },
+                                                Pattern {
+                                                    kind: Var {
+                                                        binding: b9,
+                                                        name: "b",
+                                                    },
+                                                    span: 492..493,
+                                                },
+                                            ],
+                                            tail: None,
+                                        },
+                                        span: 488..494,
+                                    },
+                                    body: Expr {
+                                        id: e17,
+                                        kind: Tuple(
+                                            [
+                                                Expr {
+                                                    id: e15,
+                                                    kind: Local {
+                                                        binding: b8,
+                                                        name: "a",
+                                                    },
+                                                    span: 499..500,
+                                                },
+                                                Expr {
+                                                    id: e16,
+                                                    kind: Local {
+                                                        binding: b9,
+                                                        name: "b",
+                                                    },
+                                                    span: 502..503,
+                                                },
+                                            ],
+                                        ),
+                                        span: 498..504,
+                                    },
+                                    span: 486..504,
+                                },
+                                MatchArm {
+                                    pattern: Pattern {
+                                        kind: Wildcard,
+                                        span: 509..510,
+                                    },
+                                    body: Expr {
+                                        id: e20,
+                                        kind: Tuple(
+                                            [
+                                                Expr {
+                                                    id: e18,
+                                                    kind: Number(
+                                                        0.0,
+                                                    ),
+                                                    span: 515..518,
+                                                },
+                                                Expr {
+                                                    id: e19,
+                                                    kind: Number(
+                                                        0.0,
+                                                    ),
+                                                    span: 520..523,
+                                                },
+                                            ],
+                                        ),
+                                        span: 514..524,
+                                    },
+                                    span: 507..524,
+                                },
+                            ],
+                        },
+                        span: 470..524,
+                    },
+                },
+                span: 432..524,
+            },
+            span: 421..524,
+        },
+        Def {
+            id: d3,
+            name: "main",
+            value: Expr {
+                id: e44,
+                kind: Lambda {
+                    params: [],
+                    ret: None,
+                    body: Expr {
+                        id: e43,
+                        kind: Let {
+                            binding: b10,
+                            name: "xs",
+                            mutable: false,
+                            value: Expr {
+                                id: e26,
+                                kind: List(
+                                    [
+                                        Expr {
+                                            id: e23,
+                                            kind: Number(
+                                                1.0,
+                                            ),
+                                            span: 555..558,
+                                        },
+                                        Expr {
+                                            id: e24,
+                                            kind: Number(
+                                                2.0,
+                                            ),
+                                            span: 560..563,
+                                        },
+                                        Expr {
+                                            id: e25,
+                                            kind: Number(
+                                                3.0,
+                                            ),
+                                            span: 565..568,
+                                        },
+                                    ],
+                                ),
+                                span: 554..569,
+                            },
+                            body: Expr {
+                                id: e42,
+                                kind: Tuple(
+                                    [
+                                        Expr {
+                                            id: e29,
+                                            kind: Call {
+                                                callee: Expr {
+                                                    id: e27,
+                                                    kind: Global(
+                                                        "sum",
+                                                    ),
+                                                    span: 576..579,
+                                                },
+                                                args: [
+                                                    Expr {
+                                                        id: e28,
+                                                        kind: Local {
+                                                            binding: b10,
+                                                            name: "xs",
+                                                        },
+                                                        span: 580..582,
+                                                    },
+                                                ],
+                                            },
+                                            span: 576..583,
+                                        },
+                                        Expr {
+                                            id: e33,
+                                            kind: Call {
+                                                callee: Expr {
+                                                    id: e30,
+                                                    kind: Global(
+                                                        "firstOr",
+                                                    ),
+                                                    span: 585..592,
+                                                },
+                                                args: [
+                                                    Expr {
+                                                        id: e31,
+                                                        kind: Local {
+                                                            binding: b10,
+                                                            name: "xs",
+                                                        },
+                                                        span: 593..595,
+                                                    },
+                                                    Expr {
+                                                        id: e32,
+                                                        kind: Number(
+                                                            0.0,
+                                                        ),
+                                                        span: 597..600,
+                                                    },
+                                                ],
+                                            },
+                                            span: 585..601,
+                                        },
+                                        Expr {
+                                            id: e38,
+                                            kind: Call {
+                                                callee: Expr {
+                                                    id: e34,
+                                                    kind: Global(
+                                                        "pair",
+                                                    ),
+                                                    span: 603..607,
+                                                },
+                                                args: [
+                                                    Expr {
+                                                        id: e37,
+                                                        kind: List(
+                                                            [
+                                                                Expr {
+                                                                    id: e35,
+                                                                    kind: Number(
+                                                                        4.0,
+                                                                    ),
+                                                                    span: 609..612,
+                                                                },
+                                                                Expr {
+                                                                    id: e36,
+                                                                    kind: Number(
+                                                                        5.0,
+                                                                    ),
+                                                                    span: 614..617,
+                                                                },
+                                                            ],
+                                                        ),
+                                                        span: 608..618,
+                                                    },
+                                                ],
+                                            },
+                                            span: 603..619,
+                                        },
+                                        Expr {
+                                            id: e41,
+                                            kind: ListCons {
+                                                items: [
+                                                    Expr {
+                                                        id: e39,
+                                                        kind: Number(
+                                                            0.0,
+                                                        ),
+                                                        span: 622..625,
+                                                    },
+                                                ],
+                                                tail: Expr {
+                                                    id: e40,
+                                                    kind: Local {
+                                                        binding: b10,
+                                                        name: "xs",
+                                                    },
+                                                    span: 629..631,
+                                                },
+                                            },
+                                            span: 621..632,
+                                        },
+                                    ],
+                                ),
+                                span: 575..633,
+                            },
+                        },
+                        span: 545..633,
+                    },
+                },
+                span: 537..633,
+            },
+            span: 526..633,
+        },
+    ],
+}

--- a/mle/examples/lists.mle
+++ b/mle/examples/lists.mle
@@ -1,0 +1,22 @@
+// List patterns and cons — `[a, b]` / `[]` / `[head, ..rest]` in match, and
+// `[x, ..xs]` prepend in expressions. Refutable, so a list match needs a
+// catch-all (`_`, a name, or `[..rest]`).
+
+let sum = (xs: List<Float>): Float =>
+  match xs with
+  | [] => 0.0
+  | [head, ..rest] => head + sum(rest)
+
+let firstOr = (xs: List<Float>, fallback: Float): Float =>
+  match xs with
+  | [x, ..rest] => x
+  | [] => fallback
+
+let pair = (xs: List<Float>): Float * Float =>
+  match xs with
+  | [a, b] => (a, b)
+  | _ => (0.0, 0.0)
+
+let main = () =>
+  let xs = [1.0, 2.0, 3.0] in
+  (sum(xs), firstOr(xs, 0.0), pair([4.0, 5.0]), [0.0, ..xs])

--- a/mle/src/ast.rs
+++ b/mle/src/ast.rs
@@ -116,6 +116,13 @@ pub enum ExprKind {
     },
     /// `[1.0, 2.0, 3.0]`
     List(Vec<Expr>),
+    /// `[a, b, ..tail]` — a list built by prepending `items` onto the list
+    /// `tail` (the cons/spread form; `..tail` must be last). Plain
+    /// `[a, b]` stays [`Self::List`].
+    ListCons {
+        items: Vec<Expr>,
+        tail: Box<Expr>,
+    },
     /// `(1.0, "a")` — at least two elements (`(e)` is grouping, not a
     /// 1-tuple).
     Tuple(Vec<Expr>),
@@ -209,6 +216,14 @@ pub enum PatternKind {
     /// `(x, _)` — element sub-patterns are variable bindings or `_` only
     /// (like ctor patterns); arity must match the matched tuple exactly.
     Tuple(Vec<Pattern>),
+    /// `[]` (empty), `[a, b]` (exact length), `[head, ..rest]` (at least
+    /// `items.len()`, `rest` binds the remainder as a list). Element and
+    /// tail sub-patterns are variable bindings or `_` only (like tuple/ctor
+    /// patterns). `tail: None` means an exact-length match.
+    List {
+        items: Vec<Pattern>,
+        tail: Option<Box<Pattern>>,
+    },
     Number(f64),
     Bool(bool),
     String(String),

--- a/mle/src/eval.rs
+++ b/mle/src/eval.rs
@@ -359,6 +359,25 @@ impl Interp<'_> {
                 }
                 Ok(Value::List(Rc::new(out)))
             }
+            ExprKind::ListCons { items, tail } => {
+                let mut out = Vec::with_capacity(items.len());
+                for item in items {
+                    out.push(self.eval(item, env)?);
+                }
+                match self.eval(tail, env)? {
+                    Value::List(rest) => {
+                        out.extend(rest.iter().cloned());
+                        Ok(Value::List(Rc::new(out)))
+                    }
+                    other => Err(RunError {
+                        message: format!(
+                            "`..` spreads a list, but the tail is {}",
+                            other.kind_name()
+                        ),
+                        span: tail.span,
+                    }),
+                }
+            }
             ExprKind::RecordUpdate { base, fields } => {
                 let base_value = self.eval(base, env)?;
                 let Value::Record(base_fields) = &base_value else {
@@ -910,6 +929,33 @@ fn match_pattern(pattern: &Pattern, value: &Value, vars: &mut Vec<(BindingId, Va
                         .iter()
                         .zip(vals.iter())
                         .all(|(p, v)| match_pattern(p, v, vars))
+            }
+            _ => false,
+        },
+        // `[a, b]` needs an exact-length list; `[h, ..t]` needs at least
+        // `items.len()` and binds `t` to the remainder.
+        PatternKind::List { items, tail } => match value {
+            Value::List(vals) => {
+                let long_enough = match tail {
+                    Some(_) => vals.len() >= items.len(),
+                    None => vals.len() == items.len(),
+                };
+                if !long_enough {
+                    return false;
+                }
+                if !items
+                    .iter()
+                    .zip(vals.iter())
+                    .all(|(p, v)| match_pattern(p, v, vars))
+                {
+                    return false;
+                }
+                if let Some(tail) = tail {
+                    let rest = Value::List(Rc::new(vals[items.len()..].to_vec()));
+                    match_pattern(tail, &rest, vars)
+                } else {
+                    true
+                }
             }
             _ => false,
         },

--- a/mle/src/goto.rs
+++ b/mle/src/goto.rs
@@ -130,6 +130,14 @@ fn pattern_binders(pattern: &Pattern, binders: &mut HashMap<u32, Span>) {
         PatternKind::Var { binding, .. } => {
             binders.insert(binding.0, pattern.span);
         }
+        PatternKind::List { items, tail } => {
+            for arg in items {
+                pattern_binders(arg, binders);
+            }
+            if let Some(tail) = tail {
+                pattern_binders(tail, binders);
+            }
+        }
         PatternKind::Ctor { args, .. } | PatternKind::Tuple(args) => {
             for arg in args {
                 pattern_binders(arg, binders);

--- a/mle/src/hover.rs
+++ b/mle/src/hover.rs
@@ -126,6 +126,14 @@ fn pattern_vars(pattern: &Pattern, types: &ExprTypes, consider: &mut impl FnMut(
                 pattern_vars(arg, types, consider);
             }
         }
+        PatternKind::List { items, tail } => {
+            for arg in items {
+                pattern_vars(arg, types, consider);
+            }
+            if let Some(tail) = tail {
+                pattern_vars(tail, types, consider);
+            }
+        }
         PatternKind::Wildcard
         | PatternKind::Number(_)
         | PatternKind::Bool(_)
@@ -142,6 +150,9 @@ pub(crate) fn children(expr: &Expr) -> Vec<&Expr> {
             .chain(fields.iter().map(|f| &f.value))
             .collect(),
         ExprKind::List(items) => items.iter().collect(),
+        ExprKind::ListCons { items, tail } => {
+            items.iter().chain(std::iter::once(tail.as_ref())).collect()
+        }
         ExprKind::Tuple(items) => items.iter().collect(),
         ExprKind::FieldAccess { object, .. } => vec![object],
         ExprKind::Call { callee, args } => std::iter::once(callee.as_ref())

--- a/mle/src/ir.rs
+++ b/mle/src/ir.rs
@@ -127,6 +127,13 @@ pub enum ExprKind {
     },
     /// `[1.0, 2.0, 3.0]`
     List(Vec<Expr>),
+    /// `[a, b, ..tail]` — a list built by prepending `items` onto the list
+    /// `tail` (the cons/spread form; `..tail` must be last). Plain
+    /// `[a, b]` stays [`Self::List`].
+    ListCons {
+        items: Vec<Expr>,
+        tail: Box<Expr>,
+    },
     /// `(1.0, "a")` — at least two elements.
     Tuple(Vec<Expr>),
     /// Reference to an enclosing `let mut` slot (never crosses a lambda
@@ -224,6 +231,14 @@ pub enum PatternKind {
     },
     /// `(x, _)` — sub-patterns are bindings or `_`; arity must match.
     Tuple(Vec<Pattern>),
+    /// `[]` (empty), `[a, b]` (exact length), `[head, ..rest]` (at least
+    /// `items.len()`, `rest` binds the remainder as a list). Element and
+    /// tail sub-patterns are variable bindings or `_` only (like tuple/ctor
+    /// patterns). `tail: None` means an exact-length match.
+    List {
+        items: Vec<Pattern>,
+        tail: Option<Box<Pattern>>,
+    },
     Number(f64),
     Bool(bool),
     String(String),

--- a/mle/src/lexer.rs
+++ b/mle/src/lexer.rs
@@ -29,6 +29,7 @@ pub enum TokenKind {
     ColonEq,
     Semi,
     Dot,
+    DotDot,
     Eq,
     EqEq,
     FatArrow,
@@ -75,6 +76,7 @@ pub fn describe(kind: &TokenKind) -> String {
         ColonEq => "`:=`".to_string(),
         Semi => "`;`".to_string(),
         Dot => "`.`".to_string(),
+        DotDot => "`..`".to_string(),
         Eq => "`=`".to_string(),
         EqEq => "`==`".to_string(),
         FatArrow => "`=>`".to_string(),
@@ -155,10 +157,16 @@ pub fn lex(src: &str, base: usize) -> Result<Vec<Token>, ParseError> {
                 i += 1;
                 TokenKind::Semi
             }
-            b'.' => {
-                i += 1;
-                TokenKind::Dot
-            }
+            b'.' => match bytes.get(i + 1) {
+                Some(b'.') => {
+                    i += 2;
+                    TokenKind::DotDot
+                }
+                _ => {
+                    i += 1;
+                    TokenKind::Dot
+                }
+            },
             b'+' => {
                 i += 1;
                 TokenKind::Plus

--- a/mle/src/lower.rs
+++ b/mle/src/lower.rs
@@ -621,6 +621,16 @@ impl Lowerer<'_> {
                 }
                 ExprKind::List(lowered)
             }
+            ast::ExprKind::ListCons { items, tail } => {
+                let mut lowered = Vec::new();
+                for item in items {
+                    lowered.push(self.expr(item)?);
+                }
+                ExprKind::ListCons {
+                    items: lowered,
+                    tail: Box::new(self.expr(*tail)?),
+                }
+            }
             ast::ExprKind::Tuple(items) => {
                 let mut lowered = Vec::new();
                 for item in items {
@@ -884,6 +894,20 @@ impl Lowerer<'_> {
                     lowered.push(self.pattern(arg, vars)?);
                 }
                 PatternKind::Tuple(lowered)
+            }
+            ast::PatternKind::List { items, tail } => {
+                let mut lowered = Vec::new();
+                for item in items {
+                    lowered.push(self.pattern(item, vars)?);
+                }
+                let tail = match tail {
+                    Some(t) => Some(Box::new(self.pattern(*t, vars)?)),
+                    None => None,
+                };
+                PatternKind::List {
+                    items: lowered,
+                    tail,
+                }
             }
             ast::PatternKind::Number(n) => PatternKind::Number(n),
             ast::PatternKind::Bool(b) => PatternKind::Bool(b),

--- a/mle/src/parser.rs
+++ b/mle/src/parser.rs
@@ -30,7 +30,7 @@
 //! tuple     := "(" expr ("," expr)+ ","? ")"
 //! record    := "{" (ident ":" expr),* "}"
 //!            | "{" expr "with" (ident ":" expr),+ "}"
-//! list      := "[" expr,* "]"
+//! list      := "[" (expr ("," expr)* ("," ".." expr)?)? "]"   (cons if ..)
 //! lambda    := "(" (ident (":" type)?),* ")" (":" type)? "=>" expr
 //! ```
 //!
@@ -587,9 +587,37 @@ rebind surface); `mut` is for `let mut … in …` inside a function"
             // Uppercase: always a constructor pattern, never a variable.
             TokenKind::Ident(_) => return self.ctor_pattern(),
             TokenKind::LParen => return self.tuple_pattern(),
+            TokenKind::LBracket => return self.list_pattern(),
             _ => return self.error("a pattern"),
         };
         Ok(Pattern { kind, span })
+    }
+
+    /// `[]` / `[a, b]` / `[head, ..rest]` — element and tail sub-patterns
+    /// are variable bindings or `_` only. `..rest` (last) binds the
+    /// remainder as a list; without it, the length must match exactly.
+    fn list_pattern(&mut self) -> Result<Pattern, ParseError> {
+        let open = self.expect(TokenKind::LBracket, "`[`")?;
+        let mut items = Vec::new();
+        let mut tail = None;
+        while self.peek_kind() != &TokenKind::RBracket {
+            if self.peek_kind() == &TokenKind::DotDot {
+                self.bump();
+                tail = Some(Box::new(self.sub_pattern()?));
+                break;
+            }
+            items.push(self.sub_pattern()?);
+            if self.peek_kind() == &TokenKind::Comma {
+                self.bump();
+            } else {
+                break;
+            }
+        }
+        let close = self.expect(TokenKind::RBracket, "`,`, `..`, or `]`")?;
+        Ok(Pattern {
+            kind: PatternKind::List { items, tail },
+            span: open.span.to(close.span),
+        })
     }
 
     /// `(x, _)` / `(a, b, c)` — sub-patterns are variable bindings or `_`
@@ -927,7 +955,21 @@ rebind surface); `mut` is for `let mut … in …` inside a function"
     fn list(&mut self) -> Result<Expr, ParseError> {
         let open = self.bump();
         let mut items = Vec::new();
+        let mut tail = None;
         while self.peek_kind() != &TokenKind::RBracket {
+            // `[a, b, ..tail]` — the spread must be last, after >=1 element.
+            if self.peek_kind() == &TokenKind::DotDot {
+                let dd = self.bump();
+                if items.is_empty() {
+                    return Err(ParseError {
+                        message: "`..tail` needs at least one element before it (`[x, ..xs]`)"
+                            .to_string(),
+                        span: dd.span,
+                    });
+                }
+                tail = Some(Box::new(self.expr()?));
+                break;
+            }
             items.push(self.expr()?);
             if self.peek_kind() == &TokenKind::Comma {
                 self.bump();
@@ -935,11 +977,13 @@ rebind surface); `mut` is for `let mut … in …` inside a function"
                 break;
             }
         }
-        let close = self.expect(TokenKind::RBracket, "`,` or `]`")?;
-        Ok(Expr {
-            kind: ExprKind::List(items),
-            span: open.span.to(close.span),
-        })
+        let close = self.expect(TokenKind::RBracket, "`,`, `..`, or `]`")?;
+        let span = open.span.to(close.span);
+        let kind = match tail {
+            Some(tail) => ExprKind::ListCons { items, tail },
+            None => ExprKind::List(items),
+        };
+        Ok(Expr { kind, span })
     }
 
     /// `(` begins either a lambda or a parenthesized expression. Scan to the

--- a/mle/src/rebind.rs
+++ b/mle/src/rebind.rs
@@ -325,6 +325,12 @@ fn collect(expr: &Expr, def: &str, path: &mut Vec<String>, index: &mut ModuleInd
                 seg(item, format!("[{i}]"), path, index);
             }
         }
+        ExprKind::ListCons { items, tail } => {
+            for (i, item) in items.iter().enumerate() {
+                seg(item, format!("[{i}]"), path, index);
+            }
+            seg(tail, "..tail".to_string(), path, index);
+        }
         ExprKind::Tuple(items) => {
             for (i, item) in items.iter().enumerate() {
                 seg(item, format!("({i})"), path, index);
@@ -416,6 +422,14 @@ fn pattern_binders(pattern: &Pattern, f: &mut impl FnMut(BindingId, &str)) {
                 pattern_binders(arg, f);
             }
         }
+        PatternKind::List { items, tail } => {
+            for arg in items {
+                pattern_binders(arg, f);
+            }
+            if let Some(tail) = tail {
+                pattern_binders(tail, f);
+            }
+        }
         PatternKind::Wildcard
         | PatternKind::Number(_)
         | PatternKind::Bool(_)
@@ -449,6 +463,12 @@ pub(crate) fn each_child<'a>(expr: &'a Expr, f: &mut impl FnMut(&'a Expr)) {
             for item in items {
                 f(item);
             }
+        }
+        ExprKind::ListCons { items, tail } => {
+            for item in items {
+                f(item);
+            }
+            f(tail);
         }
         ExprKind::Tuple(items) => {
             for item in items {

--- a/mle/src/types.rs
+++ b/mle/src/types.rs
@@ -228,6 +228,14 @@ fn pattern_var_bindings(pattern: &Pattern, f: &mut impl FnMut(u32)) {
                 pattern_var_bindings(arg, f);
             }
         }
+        PatternKind::List { items, tail } => {
+            for arg in items {
+                pattern_var_bindings(arg, f);
+            }
+            if let Some(tail) = tail {
+                pattern_var_bindings(tail, f);
+            }
+        }
         PatternKind::Wildcard
         | PatternKind::Number(_)
         | PatternKind::Bool(_)
@@ -1246,6 +1254,21 @@ the type: `type Name<{name}> = …`"
                 }
                 Type::List(Box::new(elem))
             }
+            ExprKind::ListCons { items, tail } => {
+                let elem = self.fresh();
+                for item in items {
+                    let ty = self.infer(item);
+                    self.unify(&ty, &elem, item.span, "list element");
+                }
+                let tail_ty = self.infer(tail);
+                self.unify(
+                    &tail_ty,
+                    &Type::List(Box::new(elem.clone())),
+                    tail.span,
+                    "`..` tail",
+                );
+                Type::List(Box::new(elem))
+            }
             ExprKind::RecordUpdate { base, fields } => {
                 let base_ty = self.infer(base);
                 let base_ty = self.zonk(&base_ty);
@@ -1484,6 +1507,10 @@ the type: `type Name<{name}> = …`"
         let mut saw_true = false;
         let mut saw_false = false;
         let mut covered_ctors: Vec<&str> = Vec::new();
+        // List coverage: exact-length patterns (`[a, b]` → 2) and min-length
+        // tail patterns (`[h, ..t]` → 1, matches len >= 1).
+        let mut list_exact: Vec<usize> = Vec::new();
+        let mut list_tail_mins: Vec<usize> = Vec::new();
         let mut result: Option<Type> = None;
         for arm in arms {
             // Arms after a catch-all are unreachable at runtime — they are
@@ -1493,6 +1520,13 @@ the type: `type Name<{name}> = …`"
             self.check_pattern_constraining(&arm.pattern, &scrutinee_ty, !has_catch_all);
             match &arm.pattern.kind {
                 PatternKind::Wildcard | PatternKind::Var { .. } => has_catch_all = true,
+                PatternKind::List { items, tail } => {
+                    if tail.is_some() {
+                        list_tail_mins.push(items.len());
+                    } else {
+                        list_exact.push(items.len());
+                    }
+                }
                 // Sub-patterns are irrefutable (names/`_`), so a tuple arm
                 // catches every tuple of its arity — but only if that arity
                 // CAN match the scrutinee (the mismatch itself is diagnosed
@@ -1566,6 +1600,26 @@ the type: `type Name<{name}> = …`"
 a catch-all arm (`_` or a name)"
                         ),
                     );
+                }
+                // A list match is exhaustive iff SOME `[x1..xn, ..t]`
+                // pattern bounds the tail (covering len >= n) AND every
+                // shorter length 0..n is covered by an exact pattern (or a
+                // shorter tail pattern). `[]` + `[h, ..t]` is the canonical
+                // exhaustive recursion.
+                Type::List(_) => {
+                    let covered = list_tail_mins.iter().min().is_some_and(|&min| {
+                        (0..min).all(|len| {
+                            list_exact.contains(&len) || list_tail_mins.iter().any(|&m| m <= len)
+                        })
+                    });
+                    if !covered {
+                        self.diag(
+                            expr.span,
+                            format!(
+                                "match on {scrutinee_ty} is not exhaustive: add `[..rest]`, a catch-all (`_`), or arms covering the remaining lengths"
+                            ),
+                        );
+                    }
                 }
                 // A known product with no arity-matching arm can never be
                 // handled (the per-arm mismatch diags say why each arm
@@ -1655,6 +1709,7 @@ a catch-all arm (`_` or a name)"
                 PatternKind::Tuple(args) => {
                     Some(Type::Tuple((0..args.len()).map(|_| self.fresh()).collect()))
                 }
+                PatternKind::List { .. } => Some(Type::List(Box::new(self.fresh()))),
                 PatternKind::Number(_) => Some(Type::Float),
                 PatternKind::Bool(_) => Some(Type::Bool),
                 PatternKind::String(_) => Some(Type::String),
@@ -1701,6 +1756,27 @@ value is {scrutinee} — it can never match",
                     }
                 }
             },
+            PatternKind::List { items, tail } => {
+                // Element type from the scrutinee (List<elem>); each item and
+                // the tail check against it (tail binds List<elem>).
+                let elem = match scrutinee {
+                    Type::List(elem) => (**elem).clone(),
+                    Type::Unknown | Type::Var(_) => Type::Unknown,
+                    other => {
+                        self.diag(
+                            pattern.span,
+                            format!("a list pattern cannot match {other} — it can never match"),
+                        );
+                        Type::Unknown
+                    }
+                };
+                for item in items {
+                    self.check_pattern(item, &elem);
+                }
+                if let Some(tail) = tail {
+                    self.check_pattern(tail, &Type::List(Box::new(elem)));
+                }
+            }
             PatternKind::Ctor { name, args } => match self.ctors.get(name).cloned() {
                 Some((type_name, _, field_tys)) => {
                     let mut field_tys = field_tys;

--- a/mle/tests/check.rs
+++ b/mle/tests/check.rs
@@ -93,6 +93,11 @@ fn example_tuples_checks_clean() {
     example_checks_clean("tuples");
 }
 
+#[test]
+fn example_lists_checks_clean() {
+    example_checks_clean("lists");
+}
+
 fn example_checks_clean(name: &str) {
     let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("examples");
     let src = fs::read_to_string(dir.join(format!("{name}.mle"))).unwrap();
@@ -1046,4 +1051,57 @@ fn effect_pair_arms_join_with_bare_model_arms() {
     // The lift keys on the HOST seam — a real tuple mismatch still errors.
     let diags = check_src("let f = (b, m) => match b with | true => (m, 1.0) | false => m");
     assert_eq!(diags.len(), 1, "{diags:?}");
+}
+
+// --- List patterns + cons ---
+
+/// Element types flow through cons and list patterns.
+#[test]
+fn list_patterns_flow_element_types() {
+    // A String element used as a Float via a list pattern errors (a
+    // catch-all keeps the ONLY diagnostic the type mismatch).
+    let (message, _, _) = single_diag(
+        "let f = (xs: List<String>): Float =>\n\
+         match xs with | [a, ..rest] => a + 1.0 | _ => 0.0",
+    );
+    assert!(message.contains("String"), "unexpected: {message}");
+    // Cons unifies the head with the tail's element type.
+    let (message, _, _) = single_diag("let f = (xs: List<Float>) => [\"s\", ..xs]");
+    assert!(
+        message.contains("`..` tail") || message.contains("String"),
+        "unexpected: {message}"
+    );
+}
+
+/// A list match needs a catch-all (fixed-length / `[h, ..t]` are refutable);
+/// `[..all]` counts as one.
+#[test]
+fn list_match_exhaustiveness() {
+    let (message, _, _) =
+        single_diag("let f = (xs: List<Float>): Float => match xs with | [a, b] => a + b");
+    assert!(
+        message.contains("not exhaustive: add"),
+        "unexpected: {message}"
+    );
+    // The canonical recursion [] + [h, ..t] IS exhaustive now.
+    assert_clean(
+        "let sum = (xs: List<Float>): Float =>
+         match xs with | [] => 0.0 | [h, ..t] => h + sum(t)",
+    );
+    assert_clean("let f = (xs: List<Float>): Float => match xs with | [..all] => 0.0");
+    assert_clean(
+        "let f = (xs: List<Float>): Float =>\n\
+         match xs with | [a] => a | _ => 0.0",
+    );
+}
+
+/// A list pattern against a known non-list scrutinee can never match.
+#[test]
+fn list_pattern_against_non_list() {
+    let (message, _, _) =
+        single_diag("let f = (n: Float): Float => match n with | [a, ..t] => a | _ => 0.0");
+    assert!(
+        message.contains("a list pattern cannot match Float"),
+        "unexpected: {message}"
+    );
 }

--- a/mle/tests/ir.rs
+++ b/mle/tests/ir.rs
@@ -68,6 +68,11 @@ fn golden_tuples() {
     check_golden("tuples");
 }
 
+#[test]
+fn golden_lists() {
+    check_golden("lists");
+}
+
 /// Same source must always produce byte-identical IR (stable IDs are
 /// sequential, never random or time-based).
 #[test]

--- a/mle/tests/parser.rs
+++ b/mle/tests/parser.rs
@@ -68,6 +68,11 @@ fn golden_tuples() {
     check_golden("tuples");
 }
 
+#[test]
+fn golden_lists() {
+    check_golden("lists");
+}
+
 /// Parse a deliberately broken input; return the error's (message, line, col).
 fn parse_err(src: &str) -> (String, usize, usize) {
     let err = mle::parse(src).expect_err("input should fail to parse");
@@ -408,6 +413,20 @@ fn error_uppercase_type_parameter() {
         parse_err("type Box<T> = | Full(v: T)"),
         (
             "type parameters are lowercase (`t`), like annotation type variables".to_string(),
+            1,
+            10
+        )
+    );
+}
+
+// --- List patterns + cons ---
+
+#[test]
+fn error_spread_needs_a_leading_element() {
+    assert_eq!(
+        parse_err("let a = [..xs]"),
+        (
+            "`..tail` needs at least one element before it (`[x, ..xs]`)".to_string(),
             1,
             10
         )

--- a/mle/tests/run.rs
+++ b/mle/tests/run.rs
@@ -110,6 +110,11 @@ fn golden_run_tuples() {
     check_golden("tuples", "run");
 }
 
+#[test]
+fn golden_run_lists() {
+    check_golden("lists", "run");
+}
+
 // One trace golden pins the full enter/exit format; the other examples'
 // traces exercise no additional formatting.
 #[test]
@@ -682,4 +687,46 @@ fn generic_adts_run_type_erased() {
         ),
         "(1, \"s\", 9)"
     );
+}
+
+// --- List patterns + cons ---
+
+/// Cons builds a list by prepending; list patterns destructure by length,
+/// and `[h, ..t]` binds the remainder.
+#[test]
+fn list_cons_and_patterns() {
+    assert_eq!(
+        main_result("let main = () => [0.0, ..[1.0, 2.0]]"),
+        "[0, 1, 2]"
+    );
+    assert_eq!(
+        main_result(
+            "let head = (xs) => match xs with | [] => 0.0 | [h, ..t] => h\n\
+             let main = () => (head([9.0, 8.0]), head([]))"
+        ),
+        "(9, 0)"
+    );
+    // Exact-length match: [a, b] matches only a 2-list.
+    assert_eq!(
+        main_result(
+            "let f = (xs) => match xs with | [a, b] => a + b | _ => 0.0\n\
+             let main = () => (f([3.0, 4.0]), f([3.0]), f([3.0, 4.0, 5.0]))"
+        ),
+        "(7, 0, 0)"
+    );
+    // The tail binds a list; `[..all]` matches anything.
+    assert_eq!(
+        main_result(
+            "let rest = (xs) => match xs with | [_, ..t] => t | [] => []\n\
+             let main = () => rest([1.0, 2.0, 3.0])"
+        ),
+        "[2, 3]"
+    );
+}
+
+/// `..` spreads a list; a non-list tail is a spanned runtime error.
+#[test]
+fn cons_tail_must_be_a_list() {
+    let (message, _, _) = run_err("let main = () => [1.0, ..2.0]");
+    assert_eq!(message, "`..` spreads a list, but the tail is a number");
 }


### PR DESCRIPTION
## What

Full-stack list destructuring and prepend — the F#-idiomatic list vocabulary MLE lacked (the multiplayer ports' forcing function, and generally useful):

```mle
let sum = (xs: List<Float>): Float =>
  match xs with
  | [] => 0.0
  | [head, ..rest] => head + sum(rest)      // the canonical recursion

let firstTwo = (xs) =>
  match xs with
  | [a, b] => (a, b)                         // exact-length
  | _ => (0.0, 0.0)

let prepend = (x, xs) => [x, ..xs]           // cons in expressions
```

- **`[x, ..xs]` cons** in expressions (prepend `items` onto a list tail).
- **`[]` / `[a, b]` / `[head, ..rest]` patterns** in `match` — element and tail sub-patterns are names/`_` (like tuple/ctor patterns); exact-length unless a `..` tail, which binds the remainder as a list.
- **Element types flow** through cons and patterns (HM, with teeth: `["s", ..floats]` is a type error; a list pattern on a non-list can-never-match).
- **Proper exhaustiveness**: a list match is covered iff some `[x1..xn, ..t]` bounds the tail *and* lengths `0..n` are covered — so `[] | [h, ..t]` is exhaustive, while `[a, b]` alone needs a catch-all (`_`, a name, or `[..rest]`).
- Full stack: lexer (`..` token), parser, lower, eval, HM types, hover/goto/rebind.

## Verification

`mle/examples/lists.mle` + goldens; run/parser/check pin tests (cons eval, exact/spread/empty matching, tail binding, non-list-tail runtime error, element-type flow, exhaustiveness both directions, non-list scrutinee). **234 mle tests**, lsp green. SKILL + roadmap updated.

Built inline (subagent limit until Jul 11); this unblocks the mpclient/mpserver ports, which also need the `Text.split`/`join`/`parseFloat`/`Math.floor` builtins (separate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
