### PR TITLE
feat(time-travel): T1 — History<T> model snapshot ring + design doc

### DIFF
--- a/docs/time-travel.md
+++ b/docs/time-travel.md
@@ -1,0 +1,230 @@
+# Time-travel tooling
+
+Status: **design / vision** — the enabling machinery is shipped (the physics
+`Timeline`, `docs/physics.md` Phase 6 / #215), but the generic whole-scene tool
+is not yet built. This is the design doc and the stacked-PR plan for turning
+that machinery into **generic time-travel tooling across the whole game**: pause,
+scrub, rewind, replay, branch — and the authoring experiences those unlock.
+
+It builds directly on three existing threads and should be read alongside them:
+`docs/physics.md` (the `Simulatable`/`Timeline` seam this generalizes),
+`docs/llm-native-editor.md` (which already frames rewind as an *authoring*
+primitive, not just a debugging one), and `docs/debug-runtime.md` (the
+frame-clock control that already exists). The surface is **MLE-first** — F# is
+no longer a target (`docs/language-direction.md`).
+
+Inspiration: the [Tomorrow Corporation tech
+demo](https://www.youtube.com/watch?v=72y2EC5fkcE) (whole-program time travel as
+a first-class part of the runtime) and Bret Victor's *Inventing on Principle*
+(tweak a constant, see the consequence across time immediately).
+
+## The core idea
+
+**Today's rewind rewinds physics, not the game.** Phase 6's `SteppedPhysics`
+recorder records and replays only the Rapier `World` through a
+`TimelineLog<World>`. The MVU `model` — which in a Functor game *is* the game
+state (score, AI, spawn generation, animation timers, UI state, everything
+non-physics) — is never snapshotted. Scrub back in `examples/mle-physics` today
+and the crate *poses* move, but any model-resident state stays pinned at "now."
+That is correct for a physics demo and insufficient for a whole-game scrubber.
+
+"Generic tooling across the scene" therefore has a precise meaning: **rewind the
+model too.** The good news is that the codebase already anticipated exactly this.
+The `Simulatable` trait carries the comment *"Physics is the first impl; the
+whole game model (serializable + input-driven) could be a second later,"* and the
+entire `Timeline` / `TimelineLog` / hybrid-keyframe machinery is already generic
+over `S: Simulatable`. The only coupling to physics is the single `impl
+Simulatable for World` plus `SteppedPhysics` being hard-typed to it.
+
+### Why MLE makes this nearly free
+
+The MLE model is an `mle::Value` that derives `Clone`, is `Rc`-shared, and is
+cheap to clone. Snapshotting the entire model every frame is `model.clone()`
+into a ring buffer — and because MLE values are immutable and structurally
+shared, adjacent frames share every unchanged sub-tree, so the memory cost is
+close to "what changed this frame," not "the whole model, 900 times."
+
+The F#/Fable path could never do this cleanly: its hot-reload state is a `Box<dyn
+Any>` (`OpaqueState`) bound to one dylib generation, opaque to the runtime and
+not clonable-as-data from the shell. The in-process interpreter is the enabling
+fact — the shell *owns* the model value and can version it directly. Whole-game
+rewind is one of the concrete payoffs of the MLE pivot
+(`docs/language-direction.md`).
+
+### One frame, one clock
+
+The clean north-star framing is a single **frame-level `Simulatable`** whose
+`Snapshot` is `(model, worldSnapshot)` and whose `Command` is the frame's input
+events. Its `step` runs one full MVU frame: drain inputs → `update` → `tick` →
+physics reconcile + fixed-step → subscriptions/read-back. The model's evolution
+is not independent of physics (game code reads `Physics.position` in `update` /
+`draw`), so they must advance and seek together under **one frame index**. Today
+physics owns its own frame counter and the model has none — unifying that clock
+is a required step (Phase 1 below).
+
+Cadence is an implementation choice the existing `TimelineLog` already supports:
+the model half is cheap (`Value` clone → could snapshot every frame), the world
+half is expensive (serde-JSON of the whole Rapier world → keyframe every N +
+input-log replay, exactly as physics does today). A seek restores the nearest
+keyframe ≤ target and re-steps forward replaying recorded commands — the same
+path a live frame takes, so live and replayed frames stay identical by
+construction (the invariant physics already proves with goldens).
+
+## What exists vs. what's missing
+
+| Piece | Status |
+| --- | --- |
+| Generic `Timeline`/`Simulatable`/`TimelineLog` (keyframe + input-log hybrid, `truncate_from` branch, bounded history) | **Shipped**, already generic (`physics/timeline.rs`) |
+| Physics world as a `Simulatable` | **Shipped** (`impl Simulatable for World`) |
+| **Model as a `Simulatable`** (snapshot = `Value::clone`, command = frame inputs) | *Missing — the core piece* |
+| **Unified frame clock** coupling model + world (seek both to frame N) | *Missing — physics owns its counter; model has none* |
+| Whole-game frame-clock pause/step/resume | **Shipped** as debug server `POST /time` (pins `dts=0`) — desktop only |
+| egui backend in both shells (real `Context` + `Painter`, v0.34) | **Shipped** (`ui.rs`, both runners) |
+| **egui receiving pointer input / clicks** | *Missing — `RawInput` is empty, every element `.interactable(false)`* |
+| **Mouse clicks reaching game/overlay at all** | *Missing — `MouseEvent` is only `MouseMove`/`MouseWheel`; button presses feed cursor-capture only* |
+| Interactive UI (buttons with actions) | *Missing — `View` is `Empty/Text/Row/Column/Panel`, not parameterized over a message* |
+| Web debug server / control channel | *Missing — but egui itself runs on web* |
+| Serializable model (disk/wire) | *Missing (`Closure`/`HostData` aren't `Serialize`) — **not needed** for in-session rewind* |
+
+Beyond the physics pieces in #215, the load-bearing gaps are exactly three:
+**(1)** a `Simulatable` over the model, **(2)** a unified frame clock, **(3)**
+pointer/click input plumbing. Everything else is already present or optional.
+
+## Architecture: a shell-owned tool
+
+**The scrubber is runtime-owned, not game-authored.** It is tempting to build the
+overlay out of Functor's own UI primitives (dogfooding the interactive-UI
+feature), but that couples shipping the tool to shipping a general UI-actions
+capability. Instead:
+
+- **The scrubber is a shell-side egui panel** — a timeline bar, transport
+  (play/pause/step), a scrub handle, a frame counter — that drives the generic
+  `Timeline` directly. It renders in **both** shells because egui already runs in
+  both, needs **no game-facing API**, and requires no game to opt in. "Always
+  exposed in the browser / VSCode plugin" comes for free: the VSCode live preview
+  is just `functor run wasm` in a webview, so a shell-owned overlay in the web
+  runtime *is* the VSCode overlay — one implementation, both surfaces.
+- **Interactive MLE UI (buttons with actions) is a separate feature.** MLE
+  closures are storable, so a `Button { label, onClick }` `View` variant is
+  natural; it needs egui fed real pointer input and a return channel into
+  `update`. It is independently valuable and the scrubber is a good *second*
+  consumer to dogfood it — but the tool must not block on it.
+
+The shared substrate both want is the *same one thing*: **wire pointer position +
+click into the runtime and into egui.** Do it once (Phase 2) and the shell
+scrubber lights up immediately; game-facing interactive UI becomes a follow-on
+that reuses the same plumbing.
+
+**Toggle:** `~` (tilde) opens/closes the overlay natively — the Quake-console
+convention devs already expect; TAB stays free for in-game use. On web / VSCode
+the overlay defaults to visible.
+
+```
+        ┌───────────── MLE game (functional core) ─────────────┐
+        │  init / update / tick / draw / physics / ui  (pure)   │
+        └───────────────────────────┬───────────────────────────┘
+                                     │  inputs (Command)  +  Value model
+        ┌────────────────────────────▼──────────── imperative shell ─┐
+        │  FrameTimeline : Simulatable                                │
+        │    Snapshot = (Value model, World snapshot)                 │
+        │    Command  = frame input events                            │
+        │    step     = drain→update→tick→physics step→read-back      │
+        │  TimelineLog<FrameTimeline>  (keyframe + input log, bounded) │
+        │  one frame clock  ·  seek(N) restores model AND world       │
+        │                                                             │
+        │  egui scrubber overlay  ── drives ──►  TimelineControl      │
+        │   (shell-owned; `~` toggle; default-on web/VSCode)          │
+        └─────────────────────────────────────────────────────────────┘
+            native: functor-runner        │   wasm: web-runtime (= VSCode preview)
+```
+
+## The determinism boundary
+
+State it up front, because it decides how much of the tool needs the pure-replay
+discipline:
+
+- **Scrubbing backward needs no determinism.** Restoring a stored snapshot (model
+  clone + world restore) is exact by construction. Plain pause + scrub-back works
+  even for games that read the wall clock or do IO.
+- **Replay-forward, branching, and the trajectory predictor need pure model
+  evolution** — the model must be a function of `(prev model, inputs, physics
+  read-back)` with no wall-clock, no unseeded RNG, no Http-dependent state. This
+  is the same rule physics already enforces (`docs/physics.md` Determinism); the
+  model must adopt it for those features.
+- **Side-effecting effects during replay** (Http, Audio) must be suppressed or
+  replayed-from-log, exactly as physics commands already are — a replayed frame
+  must not re-fire a network request. Physics commands are already plain-data and
+  recorded; the generic recorder extends the same treatment to the rest.
+- **Replays are per-build, in-session.** Snapshots are live in-process values
+  (`Value` + Rapier world), not serialized artifacts — fine for time-travel
+  debugging and authoring, out of scope for persisting a timeline to disk or
+  sending it over the wire. A data-native, serializable model (needed for that,
+  and already flagged in `docs/debug-runtime.md` and `protocol.rs`) is a separate,
+  larger effort and explicitly **not** required for anything here.
+
+## The authoring experiences it unlocks
+
+These are the reason to build it — and both reduce to the same primitive: *you
+can snapshot and deterministically step the whole game forward.*
+
+### Forked timelines, overlaid
+
+Snapshot a frame, then let play continue two ways and show both at once. Once a
+frame snapshot is `(model, world)`, a fork is just *keeping* the old future
+instead of `truncate_from`-ing it, holding two model+world states, and calling
+the pure `draw` on each. The only new **engine** capability is a render pass that
+composites a second scene at reduced opacity (~50%). Everything else is already
+there: two models, one pure `draw3d`, one blend.
+
+### Trajectory preview (Inventing on Principle)
+
+Tweak a constant, see the ball's whole path over time. This is "run the future
+headlessly and plot it": from the current snapshot, step the model+world forward
+N frames deterministically, sample a position each frame, and draw the path as a
+polyline trail. It needs **(a)** deterministic forward simulation — the replay
+machinery from Phase 1 — and **(b)** a polyline/trail draw primitive (the physics
+`debug_lines` pass is already most of it). The "tweak a constant" half rides
+existing hot-reload: `POST /reload-source` swaps the `.mle` with the model
+preserved, the future is re-run, the trail redraws. Once interactive UI exists, a
+slider makes it continuous — the full Bret Victor loop. This is the single most
+compelling demo in the set and it is within reach.
+
+## LLM-native angle
+
+The same machinery is an **authoring/observation primitive**, not just a player
+toy — `docs/llm-native-editor.md` already makes this argument. Capture a session,
+rewind to frame K, change game logic, replay, and diff the outcome is
+*time-travel authoring / what-if iteration*; the golden-image tests are the
+regression half of the same loop. Every phase below is buildable and verifiable
+headlessly (pure Rust + MLE, no GPU window) up to the point where pixels are
+actually required (the overlay render and the opacity/trail passes) — matching
+the project's "design for agent verifiability" rule.
+
+## Roadmap (small, stacked PRs)
+
+| Phase | Scope | Targets |
+| --- | --- | --- |
+| **T1. Model `Simulatable` + unified clock** | A frame-level `Simulatable` (snapshot = `Value` clone + world snapshot; command = frame inputs) and one frame index that seeks model and world together. Goldens: scrub-back restores the model value-exact; replay-forward is identical (mirrors the physics goldens). No UI. | native+wasm (Rust+MLE) |
+| **T2. Pointer/click input plumbing** | Deliver mouse-button events to the runtime, feed real `RawInput` to egui, drop `.interactable(false)`. Unblocks both the scrubber and interactive game UI. | native+wasm |
+| **T3. Shell-owned scrubber overlay** | egui timeline bar + transport (play/pause/step) + scrub handle driving the generic `Timeline`; `~` toggle (native), default-on (web/VSCode). This is the Tomorrow-Corporation whole-game scrubber. | native+wasm |
+| **T4. Interactive MLE `View`** | `View` gains an action-carrying node (`Button { label, onClick }`, storable MLE closure); egui hit-tests and dispatches back into `update`. Separable, independently useful; the scrubber can be re-skinned in it later as a dogfood. | native+wasm (MLE) |
+| **T5. Fork + overlay** | Keep-the-branch instead of truncate; hold two model+world states; renderer composite pass drawing a second `draw` output at ~50% opacity. | both |
+| **T6. Trajectory preview** | Deterministic forward-sim of N frames + a polyline/trail draw primitive; wire to hot-reload for the tweak-a-constant loop; slider once T4 lands. The *Inventing on Principle* demo. | both |
+
+T1–T3 deliver the whole-game scrubber. T5–T6 are the showstopper authoring
+experiences.
+
+## Prior art
+
+- **Whole-program time travel**: the [Tomorrow Corporation tech
+  demo](https://www.youtube.com/watch?v=72y2EC5fkcE) — time travel, live editing,
+  and inspection as first-class runtime features, the north star for this doc.
+- **Reactive authoring**: Bret Victor, *Inventing on Principle* (2012) — editing a
+  value and seeing its effect across time immediately; the trajectory-preview
+  target.
+- **Deterministic rollback** (the engine lineage this reuses): GGPO / `ggrs` /
+  `bevy_ggrs`, and the `Simulatable`/`Timeline` seam in `docs/physics.md` — the
+  same restore-and-replay machinery, here generalized from the physics world to
+  the whole frame.
+- **Immediate-mode debug UI**: egui (already integrated in both shells) — the
+  scrubber's rendering substrate; the work is feeding it input, not adopting it.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -90,6 +90,24 @@ shell spine (no F# surface).
 - [ ] Networked physics: grow `mpserver`/`mpclient` to client-owned balls +
       server-owned objects (state-sync, then prediction).
 
+## Time-travel tooling
+
+Design + phased roadmap: `docs/time-travel.md` (generalize #215's physics rewind
+into a generic, shell-owned whole-game scrubber — pause/scrub/rewind/replay/branch
+— plus the authoring experiences it unlocks). Builds on the physics
+`Simulatable`/`Timeline` seam; MLE-first. Overlaps the "Live variables / fast
+iteration" item below (T6, trajectory preview).
+
+- [ ] T1: model as a `Simulatable` (snapshot = `Value` clone, command = frame
+      inputs) + a unified frame clock seeking model and physics together; goldens.
+- [ ] T2: pointer/click input plumbing (real `RawInput` to egui; deliver mouse
+      buttons to the runtime) — unblocks the scrubber and interactive UI.
+- [ ] T3: shell-owned egui scrubber overlay; `~` toggle (native), default-on (web/VSCode).
+- [ ] T4: interactive MLE `View` (`Button { label, onClick }`, storable closure).
+- [ ] T5: forked timelines + ~50%-opacity render composite.
+- [ ] T6: trajectory preview (deterministic forward-sim + trail draw) — the
+      *Inventing on Principle* demo.
+
 ## Language (MLE)
 
 Design + phased roadmap: `docs/mle.md` (replace F#/Fable with a custom

--- a/runtime/functor-runtime-common/src/lib.rs
+++ b/runtime/functor-runtime-common/src/lib.rs
@@ -95,6 +95,7 @@ pub mod shadow;
 pub mod skybox;
 mod shader_program;
 pub mod texture;
+pub mod timetravel;
 pub mod ui;
 mod viewport;
 

--- a/runtime/functor-runtime-common/src/timetravel.rs
+++ b/runtime/functor-runtime-common/src/timetravel.rs
@@ -1,0 +1,325 @@
+//! The model half of the time-travel Timeline (docs/time-travel.md, T1).
+//!
+//! [`History`] is a bounded, per-frame snapshot ring of a cheaply-cloneable
+//! state — in Functor that state is the MLE `model` (`mle::Value`). It is the
+//! counterpart of the physics [`crate::physics::timeline::TimelineLog`], but
+//! deliberately simpler:
+//!
+//! - **The physics `TimelineLog` keyframes + replays** because its snapshot (a
+//!   whole serialized Rapier world) is expensive, so it stores one every N
+//!   frames and re-steps forward to reconstruct the rest. That leans on
+//!   determinism.
+//! - **`History` snapshots every frame directly.** The MLE model is `Rc`-shared
+//!   and immutable, so a clone is a handful of refcount bumps and adjacent
+//!   frames structurally share every unchanged sub-tree (the
+//!   `structural_sharing_*` test proves it). Because a scrub-back is a plain
+//!   restore of a stored value — never a re-step — **scrubbing backward needs
+//!   no determinism at all** (docs/time-travel.md, "The determinism boundary").
+//!
+//! ## The frame convention
+//!
+//! `record(f, state)` stores the *settled* state of frame `f` (in Functor: the
+//! model after that frame's input/subscriptions/tick have folded in). `seek(f)`
+//! returns exactly that stored state. Frames must be recorded consecutively;
+//! `truncate_from` reopens an earlier frame for re-recording (rewind-then-branch,
+//! mirroring `TimelineLog::truncate_from`).
+//!
+//! `Frame` is the same `u64` fixed-frame index the physics timeline uses; a
+//! later increment unifies the two under one clock so a single `seek` restores
+//! model *and* world together (docs/time-travel.md, "One frame, one clock").
+
+use std::collections::VecDeque;
+
+/// A fixed-step frame number — the same index space as
+/// [`crate::physics::timeline::Frame`].
+pub type Frame = u64;
+
+/// A bounded per-frame snapshot ring of `T`. Records the settled state of each
+/// consecutive frame and restores any frame still in the retained window. See
+/// the module docs for why this is a plain ring, not a keyframe log.
+pub struct History<T> {
+    /// Frame number of `snapshots[0]`; valid once anything has been recorded.
+    base: Frame,
+    /// One snapshot per recorded frame, oldest first.
+    snapshots: VecDeque<T>,
+    /// The frame the *next* `record` must use — `None` until the first record.
+    /// This is deliberately distinct from "`snapshots` is empty": after a
+    /// `truncate_from` empties the ring, `next` stays `Some(branch_point)` so
+    /// re-recording resumes at the right frame. Keying "next frame" off an
+    /// empty `snapshots` instead would let a post-truncate `record` silently
+    /// reset the base and resurrect a pruned frame (Codex xreview).
+    next: Option<Frame>,
+    /// Retain at most this many frames — the oldest is dropped when a `record`
+    /// would exceed it. `None` = unbounded.
+    capacity: Option<usize>,
+}
+
+impl<T: Clone> History<T> {
+    /// Retain at most `capacity` frames (must be >= 1); older frames are pruned
+    /// as new ones arrive. Functor sizes this to ~15s of history, matching the
+    /// physics recorder's `HISTORY_FRAMES`.
+    pub fn bounded(capacity: usize) -> History<T> {
+        assert!(capacity >= 1, "history capacity must be at least 1");
+        History {
+            base: 0,
+            snapshots: VecDeque::new(),
+            next: None,
+            capacity: Some(capacity),
+        }
+    }
+
+    /// Retain every frame — for tests and short deterministic runs where the
+    /// whole history fits in memory.
+    pub fn unbounded() -> History<T> {
+        History {
+            base: 0,
+            snapshots: VecDeque::new(),
+            next: None,
+            capacity: None,
+        }
+    }
+
+    /// Record the settled state of `frame`. Frames must be recorded
+    /// consecutively (each call `= last + 1`); the first recorded frame sets
+    /// the base. When the ring is full the oldest frame is dropped, advancing
+    /// the base.
+    pub fn record(&mut self, frame: Frame, state: &T) {
+        match self.next {
+            None => self.base = frame,
+            Some(next) => assert_eq!(
+                frame, next,
+                "history frames must be recorded consecutively"
+            ),
+        }
+        self.snapshots.push_back(state.clone());
+        if let Some(cap) = self.capacity {
+            while self.snapshots.len() > cap {
+                self.snapshots.pop_front();
+                self.base += 1;
+            }
+        }
+        self.next = Some(self.base + self.snapshots.len() as u64);
+    }
+
+    /// The stored state of `frame`. Panics if `frame` is outside the retained
+    /// window — a silently clamped read would restore the wrong frame.
+    pub fn seek(&self, frame: Frame) -> &T {
+        let (oldest, newest) = self.recorded_range().expect("seek on an empty history");
+        assert!(
+            frame >= oldest && frame <= newest,
+            "seek({frame}) outside recorded history [{oldest}, {newest}]"
+        );
+        &self.snapshots[(frame - self.base) as usize]
+    }
+
+    /// The most recently recorded state, or `None` if nothing is recorded yet.
+    pub fn latest(&self) -> Option<&T> {
+        self.snapshots.back()
+    }
+
+    /// The seekable range `(oldest, newest)` inclusive — `None` until something
+    /// is recorded. `bounded` pruning moves the floor; `truncate_from` moves
+    /// the ceiling.
+    pub fn recorded_range(&self) -> Option<(Frame, Frame)> {
+        (!self.snapshots.is_empty())
+            .then(|| (self.base, self.base + self.snapshots.len() as u64 - 1))
+    }
+
+    /// Drop all recorded frames at and after `frame` — the record-after-seek
+    /// truncation that rewind-then-*branch* needs (mirrors
+    /// `TimelineLog::truncate_from`): after seeking back to `frame`,
+    /// `truncate_from(frame)` makes `record(frame, …)` legal again and the old
+    /// future is gone. A `frame` at or past the end is a no-op; one before the
+    /// retained window panics (the branch point was pruned away).
+    pub fn truncate_from(&mut self, frame: Frame) {
+        let Some(next) = self.next else { return };
+        if frame >= next {
+            return;
+        }
+        assert!(
+            frame >= self.base,
+            "truncate_from({frame}) predates recorded history (base {})",
+            self.base
+        );
+        self.snapshots.truncate((frame - self.base) as usize);
+        // Even when this empties the ring (`frame == base`), the next legal
+        // record frame is `frame` — hold it so re-recording branches cleanly
+        // instead of resetting the base.
+        self.next = Some(frame);
+    }
+
+    /// Number of frames currently retained.
+    pub fn len(&self) -> usize {
+        self.snapshots.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.snapshots.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mle::Value;
+    use std::rc::Rc;
+
+    // --- the generic ring, exercised over a trivial Clone state ---
+
+    #[test]
+    fn record_then_seek_returns_each_frame() {
+        let mut h = History::unbounded();
+        for f in 0..10 {
+            h.record(f, &(f * 100));
+        }
+        assert_eq!(h.recorded_range(), Some((0, 9)));
+        for f in 0..10 {
+            assert_eq!(*h.seek(f), f * 100);
+        }
+        assert_eq!(h.latest(), Some(&900));
+    }
+
+    #[test]
+    fn bounded_prunes_the_oldest_frames() {
+        let mut h = History::bounded(5);
+        for f in 0..10 {
+            h.record(f, &f);
+        }
+        // Only the last 5 frames survive.
+        assert_eq!(h.len(), 5);
+        assert_eq!(h.recorded_range(), Some((5, 9)));
+        assert_eq!(*h.seek(5), 5);
+        assert_eq!(*h.seek(9), 9);
+    }
+
+    #[test]
+    #[should_panic(expected = "outside recorded history")]
+    fn seek_below_the_pruned_floor_panics() {
+        let mut h = History::bounded(5);
+        for f in 0..10 {
+            h.record(f, &f);
+        }
+        h.seek(4); // pruned away
+    }
+
+    #[test]
+    fn truncate_from_drops_the_future_and_reopens_recording() {
+        let mut h = History::unbounded();
+        for f in 0..10 {
+            h.record(f, &(f as i64));
+        }
+        // Rewind to 6 and branch: the old 6..10 is discarded.
+        h.truncate_from(6);
+        assert_eq!(h.recorded_range(), Some((0, 5)));
+        // Re-record from the branch point with different values.
+        for f in 6..9 {
+            h.record(f, &(-(f as i64)));
+        }
+        assert_eq!(h.recorded_range(), Some((0, 8)));
+        assert_eq!(*h.seek(5), 5);
+        assert_eq!(*h.seek(6), -6, "the branch overwrote the old future");
+        assert_eq!(*h.seek(8), -8);
+    }
+
+    #[test]
+    #[should_panic(expected = "recorded consecutively")]
+    fn branch_to_empty_still_enforces_the_next_frame() {
+        // Truncating exactly at the retained floor empties the ring; the next
+        // record must still resume at the branch point, not silently reset the
+        // base and resurrect a pruned frame (Codex xreview).
+        let mut h = History::bounded(5);
+        for f in 0..10 {
+            h.record(f, &f); // retained 5..9
+        }
+        h.truncate_from(5); // legal branch point; empties the ring
+        assert!(h.is_empty());
+        assert_eq!(h.recorded_range(), None);
+        h.record(0, &0); // frame 0 was pruned away — must panic, not be accepted
+    }
+
+    #[test]
+    fn branch_to_empty_then_rerecord_at_the_branch_point() {
+        let mut h = History::bounded(5);
+        for f in 0..10 {
+            h.record(f, &f);
+        }
+        h.truncate_from(5); // empties the ring, next legal frame is 5
+        h.record(5, &555); // resumes at the branch point
+        assert_eq!(h.recorded_range(), Some((5, 5)));
+        assert_eq!(*h.seek(5), 555);
+    }
+
+    #[test]
+    fn truncate_from_past_the_end_is_a_noop() {
+        let mut h = History::unbounded();
+        for f in 0..5 {
+            h.record(f, &f);
+        }
+        h.truncate_from(5);
+        h.truncate_from(99);
+        assert_eq!(h.recorded_range(), Some((0, 4)));
+    }
+
+    #[test]
+    #[should_panic(expected = "recorded consecutively")]
+    fn non_consecutive_record_panics() {
+        let mut h = History::unbounded();
+        h.record(0, &0);
+        h.record(2, &2);
+    }
+
+    // --- the real payload: an mle::Value model ---
+
+    fn field<'a>(v: &'a Value, name: &str) -> &'a Value {
+        match v {
+            Value::Record(fields) => {
+                &fields.iter().find(|(k, _)| k == name).expect("field").1
+            }
+            _ => panic!("not a record"),
+        }
+    }
+
+    /// Build `{ shared: <shared>, n: <n> }` — models sharing a `shared` field
+    /// keep the same `Rc` allocation for it.
+    fn model(shared: &Value, n: f64) -> Value {
+        Value::Record(Rc::new(vec![
+            ("shared".to_string(), shared.clone()),
+            ("n".to_string(), Value::Number(n)),
+        ]))
+    }
+
+    #[test]
+    fn value_model_restores_exact() {
+        let shared = Value::List(Rc::new(vec![Value::Number(1.0), Value::Number(2.0)]));
+        let mut h = History::unbounded();
+        // Simulate `{ model with n: n + 1 }` evolving each frame.
+        for f in 0..8 {
+            h.record(f, &model(&shared, f as f64));
+        }
+        // A scrub back returns the exact settled model of that frame (compared
+        // via the canonical Display form — Value has no PartialEq).
+        assert_eq!(h.seek(3).to_string(), model(&shared, 3.0).to_string());
+        assert_eq!(h.seek(0).to_string(), model(&shared, 0.0).to_string());
+    }
+
+    #[test]
+    fn structural_sharing_survives_snapshots() {
+        // One `shared` sub-tree referenced by every frame's model.
+        let shared = Value::List(Rc::new(vec![Value::Number(1.0), Value::Number(2.0)]));
+        let mut h = History::unbounded();
+        h.record(0, &model(&shared, 0.0));
+        h.record(1, &model(&shared, 1.0));
+
+        // The stored snapshots hold the *same* allocation for `shared`, not a
+        // deep copy — this is why a 900-frame ring of a large model stays cheap
+        // (docs/time-travel.md, "Why MLE makes this nearly free").
+        let s0 = field(h.seek(0), "shared");
+        let s1 = field(h.seek(1), "shared");
+        match (s0, s1) {
+            (Value::List(a), Value::List(b)) => {
+                assert!(Rc::ptr_eq(a, b), "the shared sub-tree was deep-copied");
+            }
+            _ => panic!("shared field is not a list"),
+        }
+    }
+}


### PR DESCRIPTION
First slice of **generic, whole-game time-travel tooling** — generalizing #215's physics-only rewind into a scrubber over the entire MVU scene. This PR lands the reusable primitive **and the design doc**, with **no game wiring yet** — the same increment shape physics used for its 1a/1b `Timeline` seam ("no game surface"). The wiring (record the live model each frame, unify the clock with the physics recorder) is the next, stacked PR.

## The idea (see `docs/time-travel.md`)

Today's rewind only rewinds the Rapier **world**; the MVU **`model`** — the real game state (score, AI, spawn generation, timers, UI) — is never snapshotted. "Generic tooling across the scene" therefore means: **rewind the model too.** MLE makes that nearly free — the model is an `Rc`-shared `mle::Value`, so a per-frame clone is a handful of refcount bumps and adjacent frames structurally share every unchanged sub-tree. (F#/Fable's `Box<dyn Any>` `OpaqueState` could never do this cleanly — a concrete payoff of the MLE pivot.)

## What's here

- **`docs/time-travel.md`** — full design + a **T1–T6 stacked-PR roadmap** (exists-vs-missing table, shell-owned egui scrubber architecture, the determinism boundary, and the two authoring payoffs: forked-timeline overlay and the Bret Victor trajectory preview).
- **`timetravel::History<T>`** — a bounded per-frame snapshot ring, the model counterpart of the physics `TimelineLog`. It snapshots **every** frame directly instead of keyframe+replay (the model is cheap; the serialized Rapier world is not), so **scrubbing backward needs no determinism at all**. Mirrors the `TimelineLog` vocabulary: `record` / `seek` / `recorded_range` / `truncate_from`, with consecutive-frame and rewind-then-branch semantics.
- **`docs/todo.md`** — T1–T6 checklist under a new Time-travel section.

## Tests

10 unit tests, including two over a real `mle::Value` model:
- `value_model_restores_exact` — a settled model restores value-exact after scrubbing back.
- `structural_sharing_survives_snapshots` — `Rc::ptr_eq` proves stored snapshots **share** sub-trees rather than deep-copying (the bounded-memory thesis).

Full crate suite: **183 passed, 0 failed**, no new warnings, clippy clean on the module.

## Review

Ran cross-engine `/xreview` (Claude subagent + Codex). Both cleared the ring arithmetic as sound and consistent with `TimelineLog`. Fixed the one **Medium** Codex raised: a `truncate_from` that empties the ring used to lose the frame position, so the next `record` could silently reset the base and resurrect a pruned frame (exactly the rewind-then-branch path this exists for). Now a `next: Option<Frame>` tracks the next legal record frame independently of snapshot emptiness; two tests cover it. Consciously skipped the **Low** (`u64::MAX` overflow — ~10¹⁰ years away at 60 fps, and matches the accepted `TimelineLog` shape).

## Not in this PR (next, stacked)
Wiring `History` into `MleGame` (record the model each frame), unifying the frame clock with the physics `SteppedPhysics` recorder so one `seek` restores model **and** world together, and an integration test — the point where it touches the live MVU loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)