### PR TITLE
feat(mle,examples): port mpserver to MLE (E2)

### DIFF
--- a/examples/mle-mpserver/functor.json
+++ b/examples/mle-mpserver/functor.json
@@ -1,0 +1,1 @@
+{ "language": "mle", "entry": "game.mle" }

--- a/examples/mle-mpserver/game.mle
+++ b/examples/mle-mpserver/game.mle
@@ -1,0 +1,141 @@
+// mle-mpserver — the MLE port of examples/mpserver (roadmap E2, docs/mle.md).
+//
+// Authoritative multiplayer server: tracks a player per connection, integrates
+// their movement, and broadcasts the whole world to every client each tick.
+// Naive (full-state, no delta, no prediction) — enough to prove the loop and to
+// drive deterministically through the netsim. Pairs with mle-mpclient.
+//
+//   functor -d examples/mle-mpserver run native
+//
+// Notes on the port from F#:
+//   - `Sub.listen(bind, toMsg)` binds the address; each accepted client
+//     surfaces through the `toMsg` closure carrying its own connection id,
+//     which we reply to with `Effect.send`.
+//   - The wire snapshot uses fixed-point integers (`x * 100`). `Text.fixed(n,
+//     0.0)` ROUNDS (F# `int(...)` truncates), so an encoded coordinate can
+//     differ from F# by <=0.01 world units — sub-visual. (F# integrates in
+//     float32, MLE in f64, so positions agree to well within that 0.01 wire
+//     unit rather than being bit-identical.)
+//   - MLE has no `%` or `<>`, so `mod4` (bounded recursion) picks the color
+//     and a bool-literal match expresses "not equal".
+
+type Player = { cid: Float, pid: Float, x: Float, z: Float, vx: Float, vz: Float }
+
+type Model = { players: List<Player>, nextPid: Float }
+
+type Msg =
+  | Joined(cid: Float)
+  | Moved(cid: Float, text: String)
+  | Left(cid: Float)
+  | NetErr(text: String)
+
+let bind = "127.0.0.1:9001"
+let speed = 2.0
+let arena = 4.0
+
+// NetEvent -> a game-specific Msg (a closure tagger, per the F# original).
+let toMsg = (ev: Net.NetEvent): Msg =>
+  match ev with
+  | Net.Connected(cid) => Joined(cid)
+  | Net.Message(cid, text) => Moved(cid, text)
+  | Net.Disconnected(cid) => Left(cid)
+  | Net.Error(cid, message) => NetErr(message)
+
+// Integrate one axis a frame, wrapping around the arena edges (asteroids-style)
+// so entities stay in a fixed playfield instead of drifting off-screen.
+let wrapAxis = (pos: Float, vel: Float, dt: Float): Float =>
+  let p = pos + vel * speed * dt in
+  match p > arena with
+  | true => p - 2.0 * arena
+  | false =>
+    (match p < -arena with
+     | true => p + 2.0 * arena
+     | false => p)
+
+// Wire format: "pid,x*100,z*100|pid,x*100,z*100|...".
+let encodePlayer = (p: Player): String =>
+  Text.join(
+    [Text.fixed(p.pid, 0.0), Text.fixed(p.x * 100.0, 0.0), Text.fixed(p.z * 100.0, 0.0)],
+    ",")
+
+let encode = (players: List<Player>): String =>
+  Text.join(List.map(players, encodePlayer), "|")
+
+let init = { players: [], nextPid: 0.0 }
+
+let update = (m: Model, msg: Msg): Model =>
+  match msg with
+  | Joined(cid) =>
+      // Spawn the new player on its own z-lane so players don't overlap.
+      let p = { cid: cid, pid: m.nextPid, x: -2.0, z: m.nextPid * 1.8 - 1.8, vx: 0.0, vz: 0.0 } in
+      { m with players: [p, ..m.players], nextPid: m.nextPid + 1.0 }
+  | Moved(cid, text) =>
+      // "vx vz" -> set that client's velocity; a malformed packet is ignored.
+      (match Text.split(text, " ") with
+       | [vxs, vzs] =>
+           let vx = Text.parseFloat(vxs) in
+           let vz = Text.parseFloat(vzs) in
+           { m with players:
+               List.map(m.players, (p) =>
+                 match p.cid == cid with
+                 | true => { p with vx: vx, vz: vz }
+                 | false => p) }
+       | _ => m)
+  | Left(cid) =>
+      { m with players:
+          List.filter(m.players, (p) =>
+            match p.cid == cid with
+            | true => false
+            | false => true) }
+  | NetErr(_) => m
+
+// Declaring the listener in `subscriptions` keeps the server bound.
+let subscriptions = (m: Model) => Sub.listen(bind, toMsg)
+
+let tick = (m: Model, dt: Float, tts: Float) =>
+  // Integrate, then broadcast the snapshot to every client.
+  let players =
+    List.map(m.players, (p) =>
+      { p with x: wrapAxis(p.x, p.vx, dt), z: wrapAxis(p.z, p.vz, dt) }) in
+  let snapshot = encode(players) in
+  let sends = List.map(players, (p) => Effect.send(p.cid, snapshot)) in
+  ({ m with players: players }, Effect.batch(sends))
+
+// A distinct color per player id, shared with the client so a given player is
+// the same color in every pane. MLE has no `%`, so mod4 wraps by recursion —
+// bounded by the demo's small player count (the z-lane spawn runs players off
+// the arena past a handful, so pid stays small).
+let mod4 = (n: Float): Float =>
+  match n < 4.0 with
+  | true => n
+  | false => mod4(n - 4.0)
+
+let colorFor = (pid: Float): Float * Float * Float =>
+  match mod4(pid) with
+  | 0.0 => (0.90, 0.35, 0.35)
+  | 1.0 => (0.35, 0.60, 0.95)
+  | 2.0 => (0.45, 0.85, 0.45)
+  | _ => (0.95, 0.80, 0.35)
+
+let draw = (m: Model, tts: Float) =>
+  // One colored cube per player at its authoritative position, on a ground
+  // plane sized to the wrap boundary (so the playfield edges are visible).
+  let playerNodes =
+    List.map(m.players, (p) =>
+      let (r, g, b) = colorFor(p.pid) in
+      Scene.cube()
+      |> Scene.scale(0.6)
+      |> Scene.translate(p.x, 0.0, p.z)
+      |> Scene.lit(r, g, b)) in
+  let ground =
+    Scene.plane() |> Scene.scale(2.0 * arena) |> Scene.lit(0.18, 0.2, 0.28) in
+  let scene = Scene.group([ground, ..playerNodes]) in
+  // Top-down-ish view so player movement stays on screen.
+  let camera =
+    Camera.firstPerson(
+      0.0, 9.0, -2.0,
+      Angle.radians(0.0), Angle.radians(-1.2), Angle.degrees(70.0)) in
+  Frame.createLit(
+    camera, scene,
+    [ Light.ambient(0.35, 0.35, 0.42),
+      Light.directional(-0.4, -1.0, -0.35, 1.0, 0.95, 0.85, 1.1) ])

--- a/runtime/functor-runtime-common/src/mle_prelude.rs
+++ b/runtime/functor-runtime-common/src/mle_prelude.rs
@@ -4001,6 +4001,107 @@ the game dir"
         }
     }
 
+    /// Headless server-lifecycle test for the `mle-mpserver` port (roadmap E2),
+    /// with no socket. Loads the SHIPPED `game.mle` so this tracks the example,
+    /// and exercises the whole server spine — `toMsg` decoding, the
+    /// join/move/left `update` logic, `wrapAxis` integration, the `Text.*` wire
+    /// encoding, and the broadcast-the-whole-world-to-every-client `Effect.send`
+    /// (the naive server's defining behavior), plus a malformed packet ignored
+    /// and a disconnect dropping a player.
+    #[test]
+    fn mpserver_broadcasts_the_world_to_every_client() {
+        // load_single_source injects the built-in Net module, like the runner.
+        let src = include_str!("../../../examples/mle-mpserver/game.mle");
+        let project = mle::project::load_single_source("game", src)
+            .unwrap_or_else(|e| panic!("load mpserver: {}", e.render()));
+        let session = mle::Session::load(&project.module, &mut FunctorHost)
+            .unwrap_or_else(|f| panic!("session: {}", f.error.message));
+
+        // toMsg(event) folded through update; update returns a bare Model here.
+        fn call(session: &mle::Session, name: &str, args: Vec<Value>) -> Value {
+            let f = session.global(name).unwrap_or_else(|| panic!("no `{name}`"));
+            session
+                .apply(f, args, name, &mut FunctorHost)
+                .unwrap_or_else(|e| panic!("{name}: {}", e.message))
+        }
+        fn feed(session: &mle::Session, model: Value, ev: Value) -> Value {
+            let msg = call(session, "toMsg", vec![ev]);
+            split_model_effect(call(session, "update", vec![model, msg])).0
+        }
+        // One tick's broadcast, drained into (conn, payload) Send pairs.
+        fn broadcast(session: &mle::Session, model: Value) -> (Value, Vec<(u64, Vec<u8>)>) {
+            crate::net::drain_conn_commands(); // clear
+            let (mut m, fx) = split_model_effect(call(
+                session,
+                "tick",
+                vec![model, Value::Number(0.5), Value::Number(0.5)],
+            ));
+            let mut log = EffectLog::new();
+            if let Some(tree) = fx {
+                let _ = drain_effects(
+                    session,
+                    &mut m,
+                    tree,
+                    &mut FakeEffects::new(0.0, vec![]),
+                    &mut log,
+                    &mut |r| panic!("unexpected report: {r}"),
+                );
+            }
+            let sends = crate::net::drain_conn_commands()
+                .into_iter()
+                .filter_map(|c| match c {
+                    crate::net::ConnCommand::Send { conn, payload } => Some((conn, payload)),
+                    _ => None,
+                })
+                .collect();
+            (m, sends)
+        }
+        let event =
+            |kind, id: u64, text: &str| net_event_value(kind, id, text).to_mle();
+
+        // The listener is declared on the arena address.
+        let subs = call(&session, "subscriptions", vec![session.global("init").unwrap()]);
+        let conns = net_conn_subs(&subs).expect("a Sub tree");
+        assert!(conns.len() == 1 && conns[0].listen && conns[0].key == "127.0.0.1:9001");
+
+        // Two clients join (pid 0 on cid 1, pid 1 on cid 2), each sends a
+        // velocity, and a single-token packet from cid 1 is IGNORED (its
+        // velocity is not reset — a 2-token "vx vz" is the only valid form).
+        let mut model = session.global("init").unwrap();
+        model = feed(&session, model, event(NetEventKind::Connected, 1, ""));
+        model = feed(&session, model, event(NetEventKind::Connected, 2, ""));
+        model = feed(&session, model, event(NetEventKind::Message, 1, "1 0")); // pid 0: +x
+        model = feed(&session, model, event(NetEventKind::Message, 2, "0 1")); // pid 1: +z
+        model = feed(&session, model, event(NetEventKind::Message, 1, "junk")); // ignored
+
+        // Tick (dt = 0.5). pid 0: x = -2 + 1·2·0.5 = -1.0, z = -1.8 -> "0,-100,-180".
+        // pid 1: x = -2.0, z = 0 + 1·2·0.5 = 1.0 -> "1,-200,100". pid 0 still
+        // moving proves the "junk" packet did NOT reset its velocity.
+        let (model, sends) = broadcast(&session, model);
+        // The WHOLE world goes to EVERY client — two identical full snapshots.
+        let snapshot = b"1,-200,100|0,-100,-180".to_vec();
+        assert_eq!(sends.len(), 2, "one Send per client, got: {sends:?}");
+        let mut recipients: Vec<u64> = sends.iter().map(|(c, _)| *c).collect();
+        recipients.sort();
+        assert_eq!(recipients, vec![1, 2], "broadcast reaches both clients");
+        assert!(
+            sends.iter().all(|(_, p)| *p == snapshot),
+            "every client receives the full world, got: {sends:?}"
+        );
+
+        // Client 1 disconnects -> Left drops pid 0. The next tick broadcasts
+        // only pid 1, and only to the client that is still connected (cid 2).
+        let model = feed(&session, model, event(NetEventKind::Disconnected, 1, ""));
+        let (_, sends) = broadcast(&session, model);
+        assert_eq!(sends.len(), 1, "only the remaining client is served: {sends:?}");
+        assert_eq!(sends[0].0, 2);
+        assert!(
+            sends[0].1.starts_with(b"1,"),
+            "snapshot no longer contains pid 0, got: {:?}",
+            String::from_utf8_lossy(&sends[0].1)
+        );
+    }
+
     // Ui teaching errors: non-View children and unbranded anchors fail loud.
     #[test]
     fn ui_teaches_its_usage() {


### PR DESCRIPTION
## What

The MLE port of `examples/mpserver` (roadmap **E2**, `docs/mle.md`) — an authoritative multiplayer server that tracks a player per connection, integrates movement, and broadcasts the whole world to every client each tick. Pairs with the upcoming `mle-mpclient`.

Builds on the `Text.split`/`join`/`parseFloat` builtins from #220 (now on `main`).

## The port

Uses the existing net surface (`Sub.listen` + a closure tagger, `Effect.send`) and the string builtins for the `"pid,x*100,z*100|..."` wire snapshot. MLE has no `%`, `<>`, or `if`, so the F# translation:

- `mod4` wraps colors by bounded recursion (no `%`), bounded by the demo's small player count.
- "not equal" (the `Left`/`Moved` filters) is a bool-literal `match`.
- `Text.fixed(n, 0.0)` rounds where F# `int()` truncates — a ≤0.01 wire-unit difference, sub-visual, documented in the header.

## Verification

1. **Typecheck**: `functor -d examples/mle-mpserver build` → clean.
2. **Renders**: a headless `--capture-frame` draws the lit ground plane (top-down, matching F# mpserver's empty scene).
3. **Lifecycle test** (`mpserver_broadcasts_the_world_to_every_client`, no socket): loads the shipped `game.mle` and drives two clients joining + moving, a malformed packet ignored, the **full-world broadcast reaching BOTH clients**, and a disconnect dropping a player. **190 `functor_runtime_common` tests pass.**

## Review

Ran cross-engine `/xreview`. No Critical/High. Applied both engines' agreed finding (the original single-client test under-covered broadcast-to-all → strengthened to multi-client + disconnect + malformed) and a doc fix (F# integrates in `float32`, MLE in `f64` → positions agree well within the wire unit rather than bit-identical). Left out-of-contract findings (fractional velocities the integer-direction protocol never sends; `mod4` recursion bounded by the demo scale) as documented non-issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)