### PR TITLE
feat(mle,examples): port mpclient to MLE (E2)

### DIFF
--- a/examples/mle-mpclient/functor.json
+++ b/examples/mle-mpclient/functor.json
@@ -1,0 +1,1 @@
+{ "language": "mle", "entry": "game.mle" }

--- a/examples/mle-mpclient/game.mle
+++ b/examples/mle-mpclient/game.mle
@@ -1,0 +1,123 @@
+// mle-mpclient — the MLE port of examples/mpclient (roadmap E2, docs/mle.md).
+//
+// Multiplayer client: connects to mle-mpserver, sends its movement input, and
+// renders the world snapshots the server broadcasts. It holds NO authoritative
+// state — it just draws what the server last sent (naive, so movement lags by
+// the round trip). WASD drives it live; on connect it auto-moves +x so a
+// headless test produces motion with no input injection.
+//
+//   functor -d examples/mle-mpclient run native
+//
+// Port notes (same as mle-mpserver): MLE has no `%` (mod4 recursion picks the
+// shared color palette) and no Option (a ConnState ADT holds the connection id
+// once the socket opens; `Text.fixed` rounding matches mle-mpserver's wire).
+
+type Player = { pid: Float, x: Float, z: Float }
+
+type ConnState =
+  | Online(id: Float)
+  | Offline
+
+type Model = { conn: ConnState, world: List<Player>, status: String }
+
+type Msg =
+  | Joined(id: Float)
+  | Snapshot(text: String)
+  | Dropped
+  | ConnErr(text: String)
+
+let serverUrl = "ws://127.0.0.1:9001/play"
+
+// NetEvent -> a game-specific Msg (a closure tagger, per the F# original).
+let toMsg = (ev: Net.NetEvent): Msg =>
+  match ev with
+  | Net.Connected(id) => Joined(id)
+  | Net.Message(_, text) => Snapshot(text)
+  | Net.Disconnected(_) => Dropped
+  | Net.Error(_, message) => ConnErr(message)
+
+let init = { conn: Offline, world: [], status: "connecting" }
+
+// "pid,x*100,z*100|..." -> [Player]. Fold+cons filters malformed rows (not
+// exactly 3 fields) and undoes the *100 fixed-point; draw order is irrelevant,
+// so the reversal cons introduces doesn't matter.
+let parseSnapshot = (s: String): List<Player> =>
+  List.fold(Text.split(s, "|"), (acc, row) =>
+    match Text.split(row, ",") with
+    | [p, x, z] =>
+        [{ pid: Text.parseFloat(p),
+           x: Text.parseFloat(x) / 100.0,
+           z: Text.parseFloat(z) / 100.0 }, ..acc]
+    | _ => acc,
+    [])
+
+let update = (m: Model, msg: Msg) =>
+  match msg with
+  // On connect, auto-move +x so a headless test produces motion with no input.
+  | Joined(id) => ({ m with conn: Online(id), status: "connected" }, Effect.send(id, "1 0"))
+  | Snapshot(text) => { m with world: parseSnapshot(text), status: "in-world" }
+  | Dropped => { m with conn: Offline, status: "disconnected" }
+  | ConnErr(message) => { m with status: Text.concat("error: ", message) }
+
+// Declaring the connection in `subscriptions` keeps it open.
+let subscriptions = (m: Model) => Sub.connect(serverUrl, toMsg)
+
+let tick = (m: Model, dt: Float, tts: Float) => m
+
+// WASD -> a velocity string the server understands; other keys send nothing.
+let velocityFor = (key: String): String =>
+  match key with
+  | "W" => "0 1"
+  | "S" => "0 -1"
+  | "A" => "-1 0"
+  | "D" => "1 0"
+  | _ => ""
+
+// Key down sends the direction; key release sends a stop. Both need the live
+// connection id, so nothing is sent until the socket has opened.
+let input = (m: Model, key: String, isDown: Bool) =>
+  match m.conn with
+  | Offline => m
+  | Online(id) =>
+    (match isDown with
+     | true =>
+       (match velocityFor(key) with
+        | "" => m
+        | v => (m, Effect.send(id, v)))
+     | false => (m, Effect.send(id, "0 0")))
+
+// Same palette as mle-mpserver, keyed by player id, so a player is the same
+// color in every pane. MLE has no `%`, so mod4 wraps by recursion.
+let mod4 = (n: Float): Float =>
+  match n < 4.0 with
+  | true => n
+  | false => mod4(n - 4.0)
+
+let colorFor = (pid: Float): Float * Float * Float =>
+  match mod4(pid) with
+  | 0.0 => (0.90, 0.35, 0.35)
+  | 1.0 => (0.35, 0.60, 0.95)
+  | 2.0 => (0.45, 0.85, 0.45)
+  | _ => (0.95, 0.80, 0.35)
+
+let draw = (m: Model, tts: Float) =>
+  // One colored cube per player in the last snapshot the server sent (same
+  // framing + palette as mle-mpserver, so panes line up in the netsim viewer).
+  let playerNodes =
+    List.map(m.world, (p) =>
+      let (r, g, b) = colorFor(p.pid) in
+      Scene.cube()
+      |> Scene.scale(0.6)
+      |> Scene.translate(p.x, 0.0, p.z)
+      |> Scene.lit(r, g, b)) in
+  let ground =
+    Scene.plane() |> Scene.scale(8.0) |> Scene.lit(0.18, 0.2, 0.28) in
+  let scene = Scene.group([ground, ..playerNodes]) in
+  let camera =
+    Camera.firstPerson(
+      0.0, 9.0, -2.0,
+      Angle.radians(0.0), Angle.radians(-1.2), Angle.degrees(70.0)) in
+  Frame.createLit(
+    camera, scene,
+    [ Light.ambient(0.35, 0.35, 0.42),
+      Light.directional(-0.4, -1.0, -0.35, 1.0, 0.95, 0.85, 1.1) ])

--- a/runtime/functor-runtime-common/src/mle_prelude.rs
+++ b/runtime/functor-runtime-common/src/mle_prelude.rs
@@ -4102,6 +4102,133 @@ the game dir"
         );
     }
 
+    /// Headless client-lifecycle test for the `mle-mpclient` port (roadmap E2),
+    /// with no socket. Loads the SHIPPED `game.mle` and drives connect (auto-move
+    /// sent), a snapshot decoded into the world, WASD `input` producing sends,
+    /// and a disconnect. The snapshot fed in is the exact wire string the
+    /// `mle-mpserver` port broadcasts, so this doubles as a wire round-trip check
+    /// between the two ports.
+    #[test]
+    fn mpclient_decodes_snapshots_and_sends_input() {
+        let src = include_str!("../../../examples/mle-mpclient/game.mle");
+        let project = mle::project::load_single_source("game", src)
+            .unwrap_or_else(|e| panic!("load mpclient: {}", e.render()));
+        let session = mle::Session::load(&project.module, &mut FunctorHost)
+            .unwrap_or_else(|f| panic!("session: {}", f.error.message));
+        fn call(session: &mle::Session, name: &str, args: Vec<Value>) -> Value {
+            let f = session.global(name).unwrap_or_else(|| panic!("no `{name}`"));
+            session
+                .apply(f, args, name, &mut FunctorHost)
+                .unwrap_or_else(|e| panic!("{name}: {}", e.message))
+        }
+        fn field<'a>(v: &'a Value, name: &str) -> &'a Value {
+            match v {
+                Value::Record(fields) => fields
+                    .iter()
+                    .find(|(n, _)| n == name)
+                    .map(|(_, v)| v)
+                    .unwrap_or_else(|| panic!("no field `{name}`")),
+                other => panic!("not a record: {other}"),
+            }
+        }
+        fn num(v: &Value) -> f64 {
+            match v {
+                Value::Number(n) => *n,
+                other => panic!("not a number: {other}"),
+            }
+        }
+        // Drain whatever an entry point emitted into (conn, payload) Send pairs.
+        fn sends_of(session: &mle::Session, returned: Value) -> Vec<(u64, Vec<u8>)> {
+            crate::net::drain_conn_commands(); // clear
+            let (mut m, fx) = split_model_effect(returned);
+            if let Some(tree) = fx {
+                let mut log = EffectLog::new();
+                let _ = drain_effects(
+                    session,
+                    &mut m,
+                    tree,
+                    &mut FakeEffects::new(0.0, vec![]),
+                    &mut log,
+                    &mut |r| panic!("unexpected report: {r}"),
+                );
+            }
+            crate::net::drain_conn_commands()
+                .into_iter()
+                .filter_map(|c| match c {
+                    crate::net::ConnCommand::Send { conn, payload } => Some((conn, payload)),
+                    _ => None,
+                })
+                .collect()
+        }
+        let event = |kind, id: u64, text: &str| net_event_value(kind, id, text).to_mle();
+        let key = |k: &str| Value::String(std::rc::Rc::from(k));
+
+        // subscriptions declares an OUTBOUND connection (not a listener).
+        let subs = call(&session, "subscriptions", vec![session.global("init").unwrap()]);
+        let conns = net_conn_subs(&subs).expect("a Sub tree");
+        assert!(!conns[0].listen && conns[0].key == "ws://127.0.0.1:9001/play");
+
+        // The socket opens (id 5): store it and auto-move +x (Effect.send "1 0").
+        let connected = call(&session, "toMsg", vec![event(NetEventKind::Connected, 5, "")]);
+        let joined = call(&session, "update", vec![session.global("init").unwrap(), connected]);
+        let (model, _) = split_model_effect(joined.clone());
+        assert_eq!(field(&model, "conn").to_string(), "Online(5)");
+        assert_eq!(field(&model, "status").to_string(), "\"connected\"");
+        assert_eq!(sends_of(&session, joined), vec![(5, b"1 0".to_vec())]);
+
+        // WASD `input` (the trickiest hook: nested match, mixed bare/tuple arms)
+        // sends the mapped velocity on keydown, a stop on keyup, and NOTHING for
+        // a non-WASD key or before the socket opens.
+        assert_eq!(
+            sends_of(&session, call(&session, "input", vec![model.clone(), key("W"), Value::Bool(true)])),
+            vec![(5, b"0 1".to_vec())]
+        );
+        assert_eq!(
+            sends_of(&session, call(&session, "input", vec![model.clone(), key("A"), Value::Bool(true)])),
+            vec![(5, b"-1 0".to_vec())]
+        );
+        assert!(
+            sends_of(&session, call(&session, "input", vec![model.clone(), key("X"), Value::Bool(true)])).is_empty(),
+            "a non-WASD key sends nothing"
+        );
+        assert_eq!(
+            sends_of(&session, call(&session, "input", vec![model.clone(), key("W"), Value::Bool(false)])),
+            vec![(5, b"0 0".to_vec())],
+            "key release sends a stop"
+        );
+        assert!(
+            sends_of(&session, call(&session, "input", vec![session.global("init").unwrap(), key("W"), Value::Bool(true)])).is_empty(),
+            "input before connect sends nothing"
+        );
+
+        // A server snapshot (the exact wire string mle-mpserver broadcasts)
+        // decodes into the world, binding each pid to its own coordinates.
+        let msg = call(&session, "toMsg", vec![event(NetEventKind::Message, 5, "1,-200,100|0,-100,-180")]);
+        let (model, _) = split_model_effect(call(&session, "update", vec![model, msg]));
+        assert_eq!(field(&model, "status").to_string(), "\"in-world\"");
+        let world = match field(&model, "world") {
+            Value::List(items) => items.clone(),
+            other => panic!("world is not a list: {other}"),
+        };
+        assert_eq!(world.len(), 2, "two players decoded, got: {}", field(&model, "world"));
+        let at = |pid: f64| -> (f64, f64) {
+            let p = world
+                .iter()
+                .find(|p| num(field(p, "pid")) == pid)
+                .unwrap_or_else(|| panic!("no player pid {pid}"));
+            (num(field(p, "x")), num(field(p, "z")))
+        };
+        // *100 fixed-point undone, per-pid (a swapped decoder would fail here).
+        assert_eq!(at(0.0), (-1.0, -1.8));
+        assert_eq!(at(1.0), (-2.0, 1.0));
+
+        // Disconnect drops the connection and clears the id.
+        let dropped = call(&session, "toMsg", vec![event(NetEventKind::Disconnected, 5, "")]);
+        let (model, _) = split_model_effect(call(&session, "update", vec![model, dropped]));
+        assert_eq!(field(&model, "conn").to_string(), "Offline");
+        assert_eq!(field(&model, "status").to_string(), "\"disconnected\"");
+    }
+
     // Ui teaching errors: non-View children and unbranded anchors fail loud.
     #[test]
     fn ui_teaches_its_usage() {


### PR DESCRIPTION
## What

The MLE port of `examples/mpclient` (roadmap **E2**, `docs/mle.md`) — the client half of the multiplayer pair. Connects to the server, decodes the broadcast snapshots into a world it renders, and sends WASD movement input.

> 🔗 **Pairs with #223** (`mle-mpserver`). Independent PR (both branch off `main`), but they're the two halves of one demo — **merge #223 first** so `examples/mle-mpserver/` exists alongside this. Both touch `mle_prelude.rs` adjacently; whichever lands second may need a trivial rebase.

## The port

Uses `Sub.connect` + a closure tagger and the `Text.split`/`parseFloat` builtins (#220, on `main`) to decode the `"pid,x*100,z*100|..."` wire format. Same F# translation workarounds as mle-mpserver: a **`ConnState` ADT** stands in for `Option` (MLE has none), **`mod4` recursion** for the shared color palette (no `%`), and the optional **`input(model, key, isDown)`** hook returns mixed bare-model / `(model, effect)` arms for keydown-velocity vs keyup-stop. On connect it auto-moves `+x` so a headless run shows motion with no input.

## Verification

1. **Typecheck**: `functor -d examples/mle-mpclient build` → clean.
2. **Renders**: headless `--capture-frame` draws the world (ground + player cubes).
3. **Lifecycle test** (`mpclient_decodes_snapshots_and_sends_input`, no socket): drives connect (auto-move sent), the **WASD `input` hook** (keydown velocity, keyup stop, non-WASD and pre-connect no-ops — the trickiest nested-match code), a snapshot decoded with **each pid bound to its own coordinates**, and a disconnect. The snapshot fed in is the **exact wire string mle-mpserver broadcasts**, so the test doubles as a client↔server wire round-trip check. **190 `functor_runtime_common` tests pass.**

## Review

Ran cross-engine `/xreview`. No Critical/High. Applied both engines' findings: the world assertions now bind each pid to exact coordinates (a swapped decoder would fail), and the `input()` hook — previously uncovered despite the test name — is now exercised across all its branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)