### PR TITLE
feat(time-travel,debug): POST /rewind — drive the coupled scene rewind live

### DIFF
--- a/runtime/functor-runtime-desktop/src/debug_server.rs
+++ b/runtime/functor-runtime-desktop/src/debug_server.rs
@@ -81,6 +81,15 @@ pub enum TimeCommand {
     Resume,
 }
 
+/// A coupled scene rewind via `POST /rewind`: `{"frame": 42}` restores the
+/// whole scene — model AND physics world — to the end of that RENDERED frame
+/// (docs/time-travel.md T1). Pin the clock first (`POST /time {"type":"set"}`)
+/// so the scene stays at the rewound frame instead of simulating forward.
+#[derive(Debug, serde::Deserialize)]
+pub struct RewindCommand {
+    pub frame: u64,
+}
+
 /// Why a `POST /capture` couldn't return pixels. Maps to an HTTP status:
 /// `Unavailable` → 503 (no GL, e.g. `--headless`), `Failed` → 500 (a real
 /// readback/encode error).
@@ -108,6 +117,10 @@ pub enum DebugRequest {
     /// (body = the raw `.mle` text), preserving the model. Ok carries a status
     /// line; Err the load error (400) — a broken push keeps the old program.
     ReloadSource(String, Sender<Result<String, String>>),
+    /// `POST /rewind` — coupled scene rewind to a rendered frame. Ok carries a
+    /// status line; Err (400) if the producer can't rewind or the frame is
+    /// unrecorded/pruned.
+    Rewind(u64, Sender<Result<String, String>>),
 }
 
 /// Start the debug HTTP server on a background thread. Returns the receiving end
@@ -285,6 +298,45 @@ pub fn spawn(bind: &str, port: u16) -> Receiver<DebugRequest> {
                         }
                     }
                 }
+                (Method::Post, "/rewind") => {
+                    let mut body = String::new();
+                    if request.as_reader().read_to_string(&mut body).is_err() {
+                        let _ = request
+                            .respond(Response::from_string("bad body").with_status_code(400));
+                        continue;
+                    }
+                    let cmd: RewindCommand = match serde_json::from_str(&body) {
+                        Ok(c) => c,
+                        Err(e) => {
+                            let _ = request.respond(
+                                Response::from_string(format!("bad rewind json: {e}"))
+                                    .with_status_code(400),
+                            );
+                            continue;
+                        }
+                    };
+                    let (resp_tx, resp_rx) = mpsc::channel();
+                    if tx.send(DebugRequest::Rewind(cmd.frame, resp_tx)).is_err() {
+                        let _ = request
+                            .respond(Response::from_string("runtime gone").with_status_code(503));
+                        continue;
+                    }
+                    match resp_rx.recv() {
+                        Ok(Ok(status)) => {
+                            let _ = request.respond(Response::from_string(status));
+                        }
+                        Ok(Err(message)) => {
+                            let _ = request.respond(
+                                Response::from_string(message).with_status_code(400),
+                            );
+                        }
+                        Err(_) => {
+                            let _ = request.respond(
+                                Response::from_string("rewind failed").with_status_code(500),
+                            );
+                        }
+                    }
+                }
                 (Method::Post, "/reload-source") => {
                     // This endpoint can be LAN-exposed (--debug-bind), so
                     // bound the body: game source is KBs, and an unbounded
@@ -351,7 +403,8 @@ pub fn spawn(bind: &str, port: u16) -> Receiver<DebugRequest> {
                             "GET /scene": "current frame as JSON: camera + scene + lights",
                             "POST /input": "inject input — {\"type\":\"key\",\"key\":\"w\",\"down\":true} | {\"type\":\"mouse_move\",\"x\":0,\"y\":0} | {\"type\":\"mouse_wheel\",\"delta\":1}",
                             "POST /time": "clock control — {\"type\":\"set\",\"tts\":2.0} (pause) | {\"type\":\"advance\",\"dts\":0.016} (step one frame) | {\"type\":\"resume\"}",
-                            "POST /reload-source": "swap game logic from the request body (raw .mle source), model preserved — 400 with the load error on a broken push"
+                            "POST /reload-source": "swap game logic from the request body (raw .mle source), model preserved — 400 with the load error on a broken push",
+                            "POST /rewind": "coupled scene rewind — {\"frame\":42} restores model + physics to that rendered frame (pin the clock first); 400 if unrecorded/pruned"
                         }
                     })
                     .to_string();

--- a/runtime/functor-runtime-desktop/src/main.rs
+++ b/runtime/functor-runtime-desktop/src/main.rs
@@ -438,6 +438,9 @@ fn service_debug_request(
         debug_server::DebugRequest::ReloadSource(source, resp) => {
             let _ = resp.send(game.reload_source(&source));
         }
+        debug_server::DebugRequest::Rewind(frame, resp) => {
+            let _ = resp.send(game.rewind_scene_to(frame));
+        }
         debug_server::DebugRequest::Input(cmd, resp) => {
             let result = match cmd {
                 debug_server::InputCommand::Key { key, down } => match key_from_str(&key) {


### PR DESCRIPTION
The first **live trigger** for the T1 coupled rewind (#222): a debug-server endpoint that calls `GameProducer::rewind_scene_to`, so an external client can scrub the **whole scene** — model + physics world — over HTTP. This is the shell-owned scrubber's backend, ahead of the egui overlay (`docs/time-travel.md` T1/T3).

## Rewind in action

![coupled scene rewind demo](https://gist.githubusercontent.com/tommy-xr/120546e23fc68471c61fc80c2b6d0238/raw/rewind_demo.gif)

<sub>Driven entirely over HTTP against `examples/mle-physics`: the crates fall, then a single `POST /rewind` snaps the **whole scene** — model + physics world — back to the drop, and stepping the clock forward re-simulates the fall. The paused scrubber HUD shows the rendered frame. Captured headlessly via the debug server's `/time` + `/capture`.</sub>

![still — crates mid-fall](https://gist.githubusercontent.com/tommy-xr/120546e23fc68471c61fc80c2b6d0238/raw/rewind_still.png)

## What's here

- **`POST /rewind {"frame": N}`** → `DebugRequest::Rewind` → `game.rewind_scene_to(N)`, replying the status line (200) or the refusal (400 — e.g. an unrecorded/pruned frame). Added to the `GET /` endpoint index.
- Dispatched in `service_debug_request` (shared by the windowed and headless loops).

## Verified live (see visuals below)

Against `examples/mle-physics`, driven entirely over HTTP:
```sh
curl -X POST :PORT/time   -d '{"type":"set","tts":0}'      # pin the clock
curl -X POST :PORT/input  -d '{"type":"key","key":"Space","down":true}'   # fresh drop
# ...advance 45 frames: crates fall into mid-air...
curl -X POST :PORT/rewind -d '{"frame":1332}'              # -> "rewound scene to rendered frame 1332"
# ...the whole pile snaps back up; advance again and it re-simulates...
```
Both paths were exercised: the **exact** rewind (`rewound scene to rendered frame 1332`) and the **honest clamp** (`requested 3, clamped to the recorded window` — frame 3 had been pruned from the 900-frame window).

## Note
No HTTP-level unit test (debug_server has none; the endpoint is thin glue over the already-tested `rewind_scene_to`, and the live capture above is the end-to-end check). Web has no debug server, so the web scrubber lands with the egui overlay (T3, cross-shell).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
