### PR TITLE
feat(time-travel,ui): T2+T3 — shell-owned egui scrubber overlay (first cut)

### DIFF
--- a/runtime/functor-runtime-common/src/physics/driver.rs
+++ b/runtime/functor-runtime-common/src/physics/driver.rs
@@ -218,6 +218,36 @@ impl SteppedPhysics {
         warnings
     }
 
+    /// Seek the recorded world to a fixed frame WITHOUT truncating the future
+    /// (docs/time-travel.md T3, the draggable scrubber): unlike
+    /// [`Self::rewind_to_frame`], the recorded history is left intact, so the
+    /// caller can seek back and forth freely while paused. Branching (discarding
+    /// the future) only happens later, when play resumes from a scrubbed point
+    /// via `rewind_to_frame`. Returns clamp/range warnings.
+    pub fn seek_to_frame(&mut self, frame: u64) -> Vec<String> {
+        let mut warnings = Vec::new();
+        let (lo, hi) = match self.recorded_range() {
+            Some(range) => range,
+            None => {
+                warnings.push("physics seek: nothing recorded yet".to_string());
+                return warnings;
+            }
+        };
+        if hi == 0 {
+            warnings.push("physics seek: no stepped frame recorded yet".to_string());
+            return warnings;
+        }
+        let floor = if lo == 0 { 1 } else { lo };
+        let target = frame.clamp(floor, hi);
+        with_world(self.world, |w| {
+            self.timeline.seek(target, w);
+            // The replayed steps re-emit events/warnings nobody should re-observe.
+            let _ = w.take_events();
+            let _ = w.take_command_warnings();
+        });
+        warnings
+    }
+
     /// The fixed-frame range a rewind can restore EXACTLY: the practical floor
     /// (frame 0's pre-step is the empty pre-reconcile world, so 1 is the real
     /// floor) through the newest recorded frame. `None` until something has

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -114,6 +114,21 @@ pub trait GameProducer {
         None
     }
 
+    /// The recorded rendered-frame window `(oldest, newest)` the scrubber can
+    /// seek within (docs/time-travel.md T3). `None` if nothing is recorded.
+    fn scene_frame_range(&self) -> Option<(u64, u64)> {
+        None
+    }
+
+    /// Seek the whole scene to a rendered frame for DISPLAY, WITHOUT branching
+    /// (docs/time-travel.md T3, the draggable scrubber): restore model + world
+    /// so the user can scrub back and forth freely while paused. The future is
+    /// discarded only when play resumes from the scrubbed point (which commits
+    /// a `rewind_scene_to` branch). The default is the honest refusal.
+    fn seek_scene_to(&mut self, _rendered_frame: u64) -> Result<String, String> {
+        Err("this producer does not support scene seek".to_string())
+    }
+
     fn tick(&mut self, frame_time: crate::FrameTime);
 
     /// Deliver a keyboard event. `code` is a [`crate::Key`] as `i32`.

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -107,6 +107,13 @@ pub trait GameProducer {
         Err("this producer does not support scene rewind".to_string())
     }
 
+    /// The newest recorded rendered frame — what the time-travel scrubber shows
+    /// and rewinds relative to (docs/time-travel.md T1). `None` for producers
+    /// that don't record a model history.
+    fn current_scene_frame(&self) -> Option<u64> {
+        None
+    }
+
     fn tick(&mut self, frame_time: crate::FrameTime);
 
     /// Deliver a keyboard event. `code` is a [`crate::Key`] as `i32`.

--- a/runtime/functor-runtime-common/src/timetravel.rs
+++ b/runtime/functor-runtime-common/src/timetravel.rs
@@ -242,15 +242,21 @@ impl SceneRecorder {
 
     /// If play resumes (`dts > 0`) while parked on an earlier frame, branch the
     /// timeline from there BEFORE the frame advances. Call at the top of `tick`.
+    /// Returns `true` if a branch was committed, so the producer can drop any
+    /// in-flight frame work that must not cross the branch (deferred queries /
+    /// pending events — the reload discipline).
     pub fn commit_scrub_if_resuming(
         &mut self,
         model: &mut Value,
         physics: &mut SteppedPhysics,
         physics_status: &mut (u64, bool, u64),
         has_physics: bool,
-    ) {
+    ) -> bool {
         if let Some(k) = self.scrub_pos.take() {
             let _ = self.rewind_scene_to(k, model, physics, physics_status, has_physics);
+            true
+        } else {
+            false
         }
     }
 
@@ -273,6 +279,8 @@ impl SceneRecorder {
         let physics_target = self.physics_seek_target(frame, physics, has_physics)?;
         *model = self.model_history.seek(frame).clone();
         if let Some(fixed) = physics_target {
+            // Warnings are empty on every reachable coupled seek: `physics_seek_
+            // target` already validated `fixed` against the seekable range.
             let _ = physics.seek_to_frame(fixed);
             physics_status.0 = physics.current_fixed_frame();
         }

--- a/runtime/functor-runtime-common/src/timetravel.rs
+++ b/runtime/functor-runtime-common/src/timetravel.rs
@@ -30,6 +30,10 @@
 
 use std::collections::VecDeque;
 
+use mle::Value;
+
+use crate::physics::SteppedPhysics;
+
 /// A fixed-step frame number — the same index space as
 /// [`crate::physics::timeline::Frame`].
 pub type Frame = u64;
@@ -163,10 +167,187 @@ impl<T: Clone> History<T> {
     }
 }
 
+/// The coupled time-travel recorder shared by both MLE shells (docs/time-travel.md
+/// T1–T3): records the MVU `model` and the physics fixed-frame in lockstep each
+/// rendered frame, and seeks/rewinds them together. It owns the recording rings
+/// and the scrub state; the producer keeps ownership of the `model` and the
+/// [`SteppedPhysics`] and hands them in, so this one implementation drives the
+/// desktop and web producers identically (no drift).
+///
+/// The master clock is the RENDERED frame; the physics world couples via
+/// `world_frame_history` (the fixed frame each rendered frame ended at). A
+/// **scrub** ([`Self::seek_scene_to`]) is non-destructive so the draggable bar
+/// can drag back and forth; the future is discarded only when play resumes from
+/// the scrubbed point ([`Self::commit_scrub_if_resuming`], which branches via
+/// [`Self::rewind_scene_to`]). Every coupled seek is **exact-or-refused** — it
+/// never lands the model and world on different times.
+pub struct SceneRecorder {
+    model_history: History<Value>,
+    /// The physics fixed-frame reached at the end of each rendered frame,
+    /// recorded in LOCKSTEP with `model_history`.
+    world_frame_history: History<u64>,
+    /// The rendered-frame index the next snapshot records at; monotonic.
+    rendered_frame: u64,
+    /// While dragging: the frame the scrubber has non-destructively seeked to.
+    /// `Some` = "scrubbing" (future intact); committed on resume.
+    scrub_pos: Option<u64>,
+}
+
+impl Default for SceneRecorder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SceneRecorder {
+    pub fn new() -> SceneRecorder {
+        SceneRecorder {
+            model_history: History::bounded(DEFAULT_HISTORY_FRAMES),
+            world_frame_history: History::bounded(DEFAULT_HISTORY_FRAMES),
+            rendered_frame: 0,
+            scrub_pos: None,
+        }
+    }
+
+    /// Hot-reload boundary: drop the rings (their snapshots can hold old-module
+    /// closures) but keep `rendered_frame` monotonic so recording resumes
+    /// consecutively, and clear any scrub.
+    pub fn reset_on_reload(&mut self) {
+        self.model_history = History::bounded(DEFAULT_HISTORY_FRAMES);
+        self.world_frame_history = History::bounded(DEFAULT_HISTORY_FRAMES);
+        self.scrub_pos = None;
+    }
+
+    /// Record the settled `model` and the world's current fixed frame for this
+    /// rendered frame. Call at the end of `tick` only when the sim advanced
+    /// (`dts > 0`) — a paused frame would pile up frozen duplicates.
+    pub fn record(&mut self, model: &Value, physics_fixed_frame: u64) {
+        self.model_history.record(self.rendered_frame, model);
+        self.world_frame_history
+            .record(self.rendered_frame, &physics_fixed_frame);
+        self.rendered_frame += 1;
+    }
+
+    /// The frame the handle sits on (the scrubbed-to frame while dragging, else
+    /// the newest recorded frame).
+    pub fn current_scene_frame(&self) -> Option<u64> {
+        self.scrub_pos
+            .or_else(|| self.model_history.recorded_range().map(|(_, hi)| hi))
+    }
+
+    /// The seekable window `(oldest, newest)` — the draggable range.
+    pub fn scene_frame_range(&self) -> Option<(u64, u64)> {
+        self.model_history.recorded_range()
+    }
+
+    /// If play resumes (`dts > 0`) while parked on an earlier frame, branch the
+    /// timeline from there BEFORE the frame advances. Call at the top of `tick`.
+    pub fn commit_scrub_if_resuming(
+        &mut self,
+        model: &mut Value,
+        physics: &mut SteppedPhysics,
+        physics_status: &mut (u64, bool, u64),
+        has_physics: bool,
+    ) {
+        if let Some(k) = self.scrub_pos.take() {
+            let _ = self.rewind_scene_to(k, model, physics, physics_status, has_physics);
+        }
+    }
+
+    /// Non-destructive scrub for the draggable bar: restore `model` + world to
+    /// `target` for DISPLAY without truncating, so the caller can seek back and
+    /// forth. Exact-or-refused.
+    pub fn seek_scene_to(
+        &mut self,
+        target: u64,
+        model: &mut Value,
+        physics: &mut SteppedPhysics,
+        physics_status: &mut (u64, bool, u64),
+        has_physics: bool,
+    ) -> Result<String, String> {
+        let (lo, hi) = self
+            .model_history
+            .recorded_range()
+            .ok_or_else(|| "seek: nothing recorded yet".to_string())?;
+        let frame = target.clamp(lo, hi);
+        let physics_target = self.physics_seek_target(frame, physics, has_physics)?;
+        *model = self.model_history.seek(frame).clone();
+        if let Some(fixed) = physics_target {
+            let _ = physics.seek_to_frame(fixed);
+            physics_status.0 = physics.current_fixed_frame();
+        }
+        self.scrub_pos = Some(frame);
+        Ok(format!("scrubbed to rendered frame {frame}"))
+    }
+
+    /// Coupled rewind: restore `model` + world to `target` and BRANCH the
+    /// recorded future from there (`rendered_frame` resets to `target + 1`).
+    /// Exact-or-refused: verifies the physics frame is restorable BEFORE
+    /// mutating, returning `Err` (touching nothing) if it was pruned.
+    pub fn rewind_scene_to(
+        &mut self,
+        target: u64,
+        model: &mut Value,
+        physics: &mut SteppedPhysics,
+        physics_status: &mut (u64, bool, u64),
+        has_physics: bool,
+    ) -> Result<String, String> {
+        let (lo, hi) = self
+            .model_history
+            .recorded_range()
+            .ok_or_else(|| "rewind: nothing recorded yet".to_string())?;
+        let frame = target.clamp(lo, hi);
+        let physics_target = self.physics_seek_target(frame, physics, has_physics)?;
+        *model = self.model_history.seek(frame).clone();
+        if let Some(fixed) = physics_target {
+            let _ = physics.rewind_to_frame(fixed);
+            physics_status.0 = physics.current_fixed_frame();
+        }
+        self.model_history.truncate_from(frame + 1);
+        self.world_frame_history.truncate_from(frame + 1);
+        self.rendered_frame = frame + 1;
+        self.scrub_pos = None;
+        let clamped = if frame == target {
+            String::new()
+        } else {
+            format!(" (requested {target}, clamped to the recorded window)")
+        };
+        Ok(format!("rewound scene to rendered frame {frame}{clamped}"))
+    }
+
+    /// Resolve the physics fixed-frame to seek for rendered `frame` WITHOUT
+    /// mutating: `Ok(None)` = no seek needed (no physics, or the frame's end-
+    /// state is already the live append), `Ok(Some(fixed))` = exact seek,
+    /// `Err` = pruned (refuse rather than desync). Compares against the newest
+    /// RECORDED frame, not the live world frame — after a non-destructive scrub
+    /// the world is parked mid-history, and using the live frame would skip the
+    /// truncate on the branch commit and panic on the next (non-consecutive)
+    /// record.
+    fn physics_seek_target(
+        &self,
+        frame: u64,
+        physics: &SteppedPhysics,
+        has_physics: bool,
+    ) -> Result<Option<u64>, String> {
+        if !has_physics {
+            return Ok(None);
+        }
+        let want = *self.world_frame_history.seek(frame);
+        match physics.seekable_range() {
+            None => Ok(None),
+            Some((_, hi)) if want > hi => Ok(None),
+            Some((flo, hi)) if want >= flo && want <= hi => Ok(Some(want)),
+            _ => Err(format!(
+                "cannot seek to rendered frame {frame}: its physics frame {want} has \
+                 been pruned from the {DEFAULT_HISTORY_FRAMES}-frame world history"
+            )),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mle::Value;
     use std::rc::Rc;
 
     // --- the generic ring, exercised over a trivial Clone state ---

--- a/runtime/functor-runtime-common/src/ui.rs
+++ b/runtime/functor-runtime-common/src/ui.rs
@@ -477,7 +477,7 @@ impl Scrubber {
 
         ScrubberOutput {
             action,
-            wants_pointer: self.ctx.wants_pointer_input(),
+            wants_pointer: self.ctx.egui_wants_pointer_input(),
         }
     }
 }

--- a/runtime/functor-runtime-common/src/ui.rs
+++ b/runtime/functor-runtime-common/src/ui.rs
@@ -349,7 +349,11 @@ pub struct PointerState {
 /// The time-travel state the shell hands the scrubber to render.
 #[derive(Clone, Copy)]
 pub struct ScrubberState {
+    /// The frame the handle sits on (the scrubbed-to frame, or the newest).
     pub frame: u64,
+    /// The seekable window `(oldest, newest)` — the draggable range. `None`
+    /// until something is recorded (the slider is then hidden).
+    pub range: Option<(u64, u64)>,
     pub paused: bool,
 }
 
@@ -357,7 +361,8 @@ pub struct ScrubberState {
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum ScrubberAction {
     TogglePause,
-    RewindBy(u64),
+    /// Non-destructive scrub to a rendered frame (dragging the timeline).
+    SeekTo(u64),
     Step,
 }
 
@@ -447,15 +452,34 @@ impl Scrubber {
                 .show(&ctx, |ui| {
                     egui::Frame::popup(ui.style()).show(ui, |ui| {
                         ui.horizontal(|ui| {
+                            let label = match state.range {
+                                Some((_, hi)) => format!("time-travel · {} / {hi}", state.frame),
+                                None => format!("time-travel · frame {}", state.frame),
+                            };
                             ui.label(
-                                egui::RichText::new(format!("time-travel · frame {}", state.frame))
-                                    .font(egui::FontId::monospace(UI_FONT_SIZE)),
+                                egui::RichText::new(label).font(egui::FontId::monospace(UI_FONT_SIZE)),
                             );
                             if ui.button(if state.paused { "Resume" } else { "Pause" }).clicked() {
                                 action = Some(ScrubberAction::TogglePause);
                             }
-                            if ui.button("<< 30").clicked() {
-                                action = Some(ScrubberAction::RewindBy(30));
+                            // The draggable timeline: drag anywhere in the
+                            // recorded window to scrub (non-destructive). Only
+                            // shown once there's a range to drag across.
+                            if let Some((lo, hi)) = state.range {
+                                if hi > lo {
+                                    let mut f = state.frame.clamp(lo, hi);
+                                    ui.spacing_mut().slider_width = 260.0;
+                                    let slider = ui.add(
+                                        egui::Slider::new(&mut f, lo..=hi)
+                                            .show_value(false)
+                                            .handle_shape(egui::style::HandleShape::Rect {
+                                                aspect_ratio: 0.5,
+                                            }),
+                                    );
+                                    if slider.changed() {
+                                        action = Some(ScrubberAction::SeekTo(f));
+                                    }
+                                }
                             }
                             if ui.button("Step >").clicked() {
                                 action = Some(ScrubberAction::Step);

--- a/runtime/functor-runtime-common/src/ui.rs
+++ b/runtime/functor-runtime-common/src/ui.rs
@@ -214,6 +214,18 @@ fn anchor_id(anchor: Anchor) -> u8 {
 /// Construct once with the runtime's shared GL context, then call [`Self::draw`]
 /// each frame after the 3D pass. The painter holds an `Arc<glow::Context>`, so the
 /// shell must keep its context in an `Arc` and hand a clone here.
+/// Restore the GL state the shared 3D path expects after an egui pass.
+/// egui_glow enables BLEND + SCISSOR and leaves DEPTH_TEST as-is; the 3D path
+/// enables DEPTH_TEST once at startup and re-arms SCISSOR per frame, so reset
+/// to that slate. Shared by every egui pass ([`TextOverlay`], [`Scrubber`]).
+fn restore_gl_after_egui(gl: &glow::Context) {
+    unsafe {
+        gl.disable(glow::SCISSOR_TEST);
+        gl.disable(glow::BLEND);
+        gl.enable(glow::DEPTH_TEST);
+    }
+}
+
 pub struct TextOverlay {
     ctx: egui::Context,
     painter: egui_glow::Painter,
@@ -321,11 +333,7 @@ impl TextOverlay {
         // DEPTH_TEST as-is) and does not restore it. The shared 3D path enables
         // DEPTH_TEST only once at startup and re-arms SCISSOR per frame, so reset
         // to the slate the next 3D frame expects.
-        unsafe {
-            self.gl.disable(glow::SCISSOR_TEST);
-            self.gl.disable(glow::BLEND);
-            self.gl.enable(glow::DEPTH_TEST);
-        }
+        restore_gl_after_egui(&self.gl);
     }
 }
 
@@ -465,11 +473,7 @@ impl Scrubber {
             &output.textures_delta,
         );
         // Restore the GL slate the 3D path expects (see `TextOverlay::run_and_paint`).
-        unsafe {
-            self.gl.disable(glow::SCISSOR_TEST);
-            self.gl.disable(glow::BLEND);
-            self.gl.enable(glow::DEPTH_TEST);
-        }
+        restore_gl_after_egui(&self.gl);
 
         ScrubberOutput {
             action,

--- a/runtime/functor-runtime-common/src/ui.rs
+++ b/runtime/functor-runtime-common/src/ui.rs
@@ -328,3 +328,152 @@ impl TextOverlay {
         }
     }
 }
+
+/// Pointer state fed to an interactive overlay, in physical framebuffer pixels.
+/// `pos` is `None` while the cursor is captured for free-look (the overlay is
+/// not being pointed at), so the scrubber neither hovers nor clicks.
+#[derive(Clone, Copy, Default)]
+pub struct PointerState {
+    pub pos: Option<(f32, f32)>,
+    pub primary_down: bool,
+}
+
+/// The time-travel state the shell hands the scrubber to render.
+#[derive(Clone, Copy)]
+pub struct ScrubberState {
+    pub frame: u64,
+    pub paused: bool,
+}
+
+/// A control the user activated in the scrubber this frame.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ScrubberAction {
+    TogglePause,
+    RewindBy(u64),
+    Step,
+}
+
+/// The scrubber's output for one frame.
+pub struct ScrubberOutput {
+    pub action: Option<ScrubberAction>,
+    /// egui is using the pointer (hovering/clicking a control), so the shell
+    /// must NOT treat the click as a free-look recapture.
+    pub wants_pointer: bool,
+}
+
+/// The shell-owned time-travel scrubber (docs/time-travel.md T3): an imperative
+/// egui panel — separate from the game's declarative [`View`] — that drives the
+/// coupled scene rewind. It keeps its OWN `egui::Context` so its pointer/click
+/// accounting never interleaves with the game HUD's [`TextOverlay`] frames.
+/// Runtime-owned, not a game hook.
+pub struct Scrubber {
+    ctx: egui::Context,
+    painter: egui_glow::Painter,
+    gl: Arc<glow::Context>,
+    last_primary_down: bool,
+}
+
+impl Scrubber {
+    pub fn new(gl: Arc<glow::Context>) -> Self {
+        let painter = egui_glow::Painter::new(gl.clone(), "", None, false)
+            .expect("failed to create egui_glow painter for the scrubber");
+        Self {
+            ctx: egui::Context::default(),
+            painter,
+            gl,
+            last_primary_down: false,
+        }
+    }
+
+    /// Draw the scrubber and return any control the user activated plus whether
+    /// egui wants the pointer this frame. `width`/`height` are physical pixels.
+    pub fn draw(
+        &mut self,
+        width: u32,
+        height: u32,
+        pixels_per_point: f32,
+        pointer: PointerState,
+        state: ScrubberState,
+    ) -> ScrubberOutput {
+        if width == 0 || height == 0 {
+            return ScrubberOutput {
+                action: None,
+                wants_pointer: false,
+            };
+        }
+        self.ctx.set_pixels_per_point(pixels_per_point);
+        let screen_points = egui::vec2(
+            width as f32 / pixels_per_point,
+            height as f32 / pixels_per_point,
+        );
+
+        // Synthesize egui pointer events from the shell's current pointer state:
+        // a move every frame, and a button event on the press/release EDGE (egui
+        // needs both to register a click).
+        let mut events = Vec::new();
+        if let Some((px, py)) = pointer.pos {
+            let pos = egui::pos2(px / pixels_per_point, py / pixels_per_point);
+            events.push(egui::Event::PointerMoved(pos));
+            if pointer.primary_down != self.last_primary_down {
+                events.push(egui::Event::PointerButton {
+                    pos,
+                    button: egui::PointerButton::Primary,
+                    pressed: pointer.primary_down,
+                    modifiers: egui::Modifiers::default(),
+                });
+            }
+        }
+        self.last_primary_down = pointer.primary_down;
+
+        let raw_input = egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(egui::Pos2::ZERO, screen_points)),
+            events,
+            ..Default::default()
+        };
+
+        let mut action = None;
+        let output = self.ctx.run_ui(raw_input, |ui| {
+            let ctx = ui.ctx().clone();
+            egui::Area::new(egui::Id::new("functor_scrubber"))
+                .anchor(egui::Align2::CENTER_BOTTOM, egui::vec2(0.0, -MARGIN))
+                .show(&ctx, |ui| {
+                    egui::Frame::popup(ui.style()).show(ui, |ui| {
+                        ui.horizontal(|ui| {
+                            ui.label(
+                                egui::RichText::new(format!("time-travel · frame {}", state.frame))
+                                    .font(egui::FontId::monospace(UI_FONT_SIZE)),
+                            );
+                            if ui.button(if state.paused { "Resume" } else { "Pause" }).clicked() {
+                                action = Some(ScrubberAction::TogglePause);
+                            }
+                            if ui.button("<< 30").clicked() {
+                                action = Some(ScrubberAction::RewindBy(30));
+                            }
+                            if ui.button("Step >").clicked() {
+                                action = Some(ScrubberAction::Step);
+                            }
+                        });
+                    });
+                });
+        });
+
+        let primitives = self.ctx.tessellate(output.shapes, output.pixels_per_point);
+        self.painter.paint_and_update_textures(
+            [width, height],
+            output.pixels_per_point,
+            &primitives,
+            &output.textures_delta,
+        );
+        // Restore the GL slate the 3D path expects (see `TextOverlay::run_and_paint`).
+        unsafe {
+            self.gl.disable(glow::SCISSOR_TEST);
+            self.gl.disable(glow::BLEND);
+            self.gl.enable(glow::DEPTH_TEST);
+        }
+
+        ScrubberOutput {
+            action,
+            wants_pointer: self.ctx.wants_pointer_input(),
+        }
+    }
+}

--- a/runtime/functor-runtime-desktop/src/main.rs
+++ b/runtime/functor-runtime-desktop/src/main.rs
@@ -836,6 +836,10 @@ Escape again to quit"
                         // (cmd-tab to the editor); a click recaptures.
                         window.set_cursor_mode(glfw::CursorMode::Normal);
                         cursor_captured = false;
+                        // A button held at focus-loss may never get its release
+                        // (alt-tab), which would leave egui holding a stuck
+                        // press — clear it so the scrubber stays live. [xreview]
+                        mouse_primary_down = false;
                     }
                     _ if ignore_user_input => {}
                     glfw::WindowEvent::Key(key, _, Action::Press | Action::Repeat, _) => {
@@ -1009,13 +1013,25 @@ Escape again to quit"
             // The shell-owned time-travel scrubber (docs/time-travel.md T3),
             // drawn over the frame (so it shows in captures) and interactive
             // when the cursor is released.
+            // The cursor (GLFW window/logical coords) must be scaled to
+            // framebuffer pixels to line up with egui's layout space (which we
+            // drive in physical pixels, ppp = 1.0) — otherwise the panel is
+            // unclickable on a HiDPI/retina display (fb = 2× window). [xreview]
+            let (win_w, _) = window.get_size();
+            let dpi_scale = if win_w > 0 {
+                fb_width as f32 / win_w as f32
+            } else {
+                1.0
+            };
             let scrubber_out = scrubber.draw(
                 fb_width as u32,
                 fb_height as u32,
                 1.0,
                 functor_runtime_common::ui::PointerState {
-                    pos: (!cursor_captured && !hidden)
-                        .then_some((mouse_pos.0 as f32, mouse_pos.1 as f32)),
+                    pos: (!cursor_captured && !hidden).then_some((
+                        mouse_pos.0 as f32 * dpi_scale,
+                        mouse_pos.1 as f32 * dpi_scale,
+                    )),
                     primary_down: mouse_primary_down,
                 },
                 functor_runtime_common::ui::ScrubberState {
@@ -1040,6 +1056,8 @@ Escape again to quit"
                     }
                 }
                 Some(functor_runtime_common::ui::ScrubberAction::Step) => {
+                    // Step implies pause: advance exactly one frame, then hold.
+                    held_time = Some(time.tts);
                     pending_step = Some(1.0 / 60.0);
                 }
                 None => {}

--- a/runtime/functor-runtime-desktop/src/main.rs
+++ b/runtime/functor-runtime-desktop/src/main.rs
@@ -1036,6 +1036,7 @@ Escape again to quit"
                 },
                 functor_runtime_common::ui::ScrubberState {
                     frame: game.current_scene_frame().unwrap_or(0),
+                    range: game.scene_frame_range(),
                     paused: held_time.is_some(),
                 },
             );
@@ -1045,15 +1046,15 @@ Escape again to quit"
                     held_time = if held_time.is_some() { None } else { Some(time.tts) };
                     pending_step = None;
                 }
-                Some(functor_runtime_common::ui::ScrubberAction::RewindBy(n)) => {
-                    if let Some(f) = game.current_scene_frame() {
-                        match game.rewind_scene_to(f.saturating_sub(n)) {
-                            Ok(status) => println!("[scrubber] {status}"),
-                            Err(e) => eprintln!("[scrubber] {e}"),
-                        }
-                        // Pin the clock so the rewound scene stays put.
-                        held_time = Some(time.tts);
+                Some(functor_runtime_common::ui::ScrubberAction::SeekTo(f)) => {
+                    // Dragging the timeline: non-destructive seek, and pin the
+                    // clock so the scene parks on the scrubbed frame (resuming
+                    // from there is what commits the branch).
+                    match game.seek_scene_to(f) {
+                        Ok(_) => {}
+                        Err(e) => eprintln!("[scrubber] {e}"),
                     }
+                    held_time = Some(time.tts);
                 }
                 Some(functor_runtime_common::ui::ScrubberAction::Step) => {
                     // Step implies pause: advance exactly one frame, then hold.

--- a/runtime/functor-runtime-desktop/src/main.rs
+++ b/runtime/functor-runtime-desktop/src/main.rs
@@ -666,6 +666,9 @@ pub async fn main() {
         // cursor for free-look).
         let mut mouse_primary_down = false;
         let mut scrubber_wants_pointer = false;
+        // The time-travel console (`~`): shown by default; `~` toggles it, and
+        // opening it frees the cursor so you can scrub right away.
+        let mut scrubber_visible = true;
 
         gl.clear_color(0.1, 0.2, 0.3, 1.0);
 
@@ -778,6 +781,23 @@ Escape again to quit"
                             );
                         } else {
                             window.set_should_close(true)
+                        }
+                    }
+                    // `~` toggles the time-travel console. Opening it frees the
+                    // cursor (so you can scrub immediately); closing returns to
+                    // free-look. Before the `ignore_user_input` catch-all so it
+                    // works while the clock is pinned (paused). Never grabs the
+                    // pointer on a hidden window.
+                    glfw::WindowEvent::Key(Key::GraveAccent, _, Action::Press, _) => {
+                        scrubber_visible = !scrubber_visible;
+                        if !hidden {
+                            if scrubber_visible {
+                                window.set_cursor_mode(glfw::CursorMode::Normal);
+                                cursor_captured = false;
+                            } else {
+                                window.set_cursor_mode(glfw::CursorMode::Disabled);
+                                cursor_captured = true;
+                            }
                         }
                     }
                     // Left click while released: if it lands on a scrubber
@@ -1023,23 +1043,30 @@ Escape again to quit"
             } else {
                 1.0
             };
-            let scrubber_out = scrubber.draw(
-                fb_width as u32,
-                fb_height as u32,
-                1.0,
-                functor_runtime_common::ui::PointerState {
-                    pos: (!cursor_captured && !hidden).then_some((
-                        mouse_pos.0 as f32 * dpi_scale,
-                        mouse_pos.1 as f32 * dpi_scale,
-                    )),
-                    primary_down: mouse_primary_down,
-                },
-                functor_runtime_common::ui::ScrubberState {
-                    frame: game.current_scene_frame().unwrap_or(0),
-                    range: game.scene_frame_range(),
-                    paused: held_time.is_some(),
-                },
-            );
+            let scrubber_out = if scrubber_visible {
+                scrubber.draw(
+                    fb_width as u32,
+                    fb_height as u32,
+                    1.0,
+                    functor_runtime_common::ui::PointerState {
+                        pos: (!cursor_captured && !hidden).then_some((
+                            mouse_pos.0 as f32 * dpi_scale,
+                            mouse_pos.1 as f32 * dpi_scale,
+                        )),
+                        primary_down: mouse_primary_down,
+                    },
+                    functor_runtime_common::ui::ScrubberState {
+                        frame: game.current_scene_frame().unwrap_or(0),
+                        range: game.scene_frame_range(),
+                        paused: held_time.is_some(),
+                    },
+                )
+            } else {
+                functor_runtime_common::ui::ScrubberOutput {
+                    action: None,
+                    wants_pointer: false,
+                }
+            };
             scrubber_wants_pointer = scrubber_out.wants_pointer;
             match scrubber_out.action {
                 Some(functor_runtime_common::ui::ScrubberAction::TogglePause) => {

--- a/runtime/functor-runtime-desktop/src/main.rs
+++ b/runtime/functor-runtime-desktop/src/main.rs
@@ -658,6 +658,14 @@ pub async fn main() {
         // rest of the runtime keeps using `&gl`, which derefs through the Arc.
         let gl = std::sync::Arc::new(gl);
         let mut text_overlay = functor_runtime_common::ui::TextOverlay::new(gl.clone());
+        // The shell-owned time-travel scrubber (docs/time-travel.md T3), drawn
+        // over the frame; interactive when the cursor is released (Escape).
+        let mut scrubber = functor_runtime_common::ui::Scrubber::new(gl.clone());
+        // Primary mouse-button state for the scrubber, and whether egui wanted
+        // the pointer last frame (so a click on a control doesn't recapture the
+        // cursor for free-look).
+        let mut mouse_primary_down = false;
+        let mut scrubber_wants_pointer = false;
 
         gl.clear_color(0.1, 0.2, 0.3, 1.0);
 
@@ -772,13 +780,33 @@ Escape again to quit"
                             window.set_should_close(true)
                         }
                     }
-                    // A click while released recaptures for free-look. Never
-                    // on a hidden window — it must not grab the pointer.
-                    glfw::WindowEvent::MouseButton(_, Action::Press, _)
+                    // Left click while released: if it lands on a scrubber
+                    // control (egui wanted the pointer last frame) it drives the
+                    // scrubber; otherwise it recaptures for free-look. Press/
+                    // release edges feed egui's click detection. Never on a
+                    // hidden window — it must not grab the pointer. These arms
+                    // sit BEFORE the `ignore_user_input` catch-all so the
+                    // scrubber stays usable while the clock is pinned (paused).
+                    glfw::WindowEvent::MouseButton(glfw::MouseButtonLeft, action, _)
                         if !cursor_captured && !hidden =>
                     {
-                        window.set_cursor_mode(glfw::CursorMode::Disabled);
-                        cursor_captured = true;
+                        match action {
+                            Action::Press => {
+                                if scrubber_wants_pointer {
+                                    mouse_primary_down = true;
+                                } else {
+                                    window.set_cursor_mode(glfw::CursorMode::Disabled);
+                                    cursor_captured = true;
+                                }
+                            }
+                            Action::Release => mouse_primary_down = false,
+                            Action::Repeat => {}
+                        }
+                    }
+                    // Track the cursor for the scrubber while released (but never
+                    // drive the camera — you're pointing at the overlay).
+                    glfw::WindowEvent::CursorPos(x, y) if !cursor_captured => {
+                        mouse_pos = (x as i32, y as i32);
                     }
                     // F1 recenters head tracking (runner-level, never reaches
                     // the game): current head pose becomes "straight ahead".
@@ -977,6 +1005,45 @@ Escape again to quit"
             // appears in --capture-frame PNGs.
             let ui_view = game.ui();
             text_overlay.draw_view(fb_width as u32, fb_height as u32, 1.0, &ui_view);
+
+            // The shell-owned time-travel scrubber (docs/time-travel.md T3),
+            // drawn over the frame (so it shows in captures) and interactive
+            // when the cursor is released.
+            let scrubber_out = scrubber.draw(
+                fb_width as u32,
+                fb_height as u32,
+                1.0,
+                functor_runtime_common::ui::PointerState {
+                    pos: (!cursor_captured && !hidden)
+                        .then_some((mouse_pos.0 as f32, mouse_pos.1 as f32)),
+                    primary_down: mouse_primary_down,
+                },
+                functor_runtime_common::ui::ScrubberState {
+                    frame: game.current_scene_frame().unwrap_or(0),
+                    paused: held_time.is_some(),
+                },
+            );
+            scrubber_wants_pointer = scrubber_out.wants_pointer;
+            match scrubber_out.action {
+                Some(functor_runtime_common::ui::ScrubberAction::TogglePause) => {
+                    held_time = if held_time.is_some() { None } else { Some(time.tts) };
+                    pending_step = None;
+                }
+                Some(functor_runtime_common::ui::ScrubberAction::RewindBy(n)) => {
+                    if let Some(f) = game.current_scene_frame() {
+                        match game.rewind_scene_to(f.saturating_sub(n)) {
+                            Ok(status) => println!("[scrubber] {status}"),
+                            Err(e) => eprintln!("[scrubber] {e}"),
+                        }
+                        // Pin the clock so the rewound scene stays put.
+                        held_time = Some(time.tts);
+                    }
+                }
+                Some(functor_runtime_common::ui::ScrubberAction::Step) => {
+                    pending_step = Some(1.0 / 60.0);
+                }
+                None => {}
+            }
 
             if let Some(capture_path) = &args.capture_frame {
                 if elapsed_time >= args.capture_time {

--- a/runtime/functor-runtime-desktop/src/main.rs
+++ b/runtime/functor-runtime-desktop/src/main.rs
@@ -666,9 +666,10 @@ pub async fn main() {
         // cursor for free-look).
         let mut mouse_primary_down = false;
         let mut scrubber_wants_pointer = false;
-        // The time-travel console (`~`): shown by default; `~` toggles it, and
-        // opening it frees the cursor so you can scrub right away.
-        let mut scrubber_visible = true;
+        // The time-travel console (`~`): HIDDEN by default in the native game
+        // (it's a dev tool you summon with `~`, which also frees the cursor so
+        // you can scrub right away). The wasm/vscode preview shows it always.
+        let mut scrubber_visible = false;
 
         gl.clear_color(0.1, 0.2, 0.3, 1.0);
 

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -37,7 +37,7 @@ use functor_runtime_common::mle_prelude::{
     take_http_tagger, view_value, EffectLog, EffectTree, FunctorHost, NetEventKind, RealEffects,
 };
 use functor_runtime_common::physics;
-use functor_runtime_common::timetravel::{History, DEFAULT_HISTORY_FRAMES};
+use functor_runtime_common::timetravel::SceneRecorder;
 use functor_runtime_common::ui::View;
 use functor_runtime_common::{Frame, FrameTime};
 use mle::project::SourceMap;
@@ -114,32 +114,10 @@ pub struct MleGame {
     physics_rt: physics::SteppedPhysics,
     /// Latest recorder status for the overlay: (fixed frame, paused, history).
     physics_status: (u64, bool, u64),
-    /// The model half of the time-travel recorder (docs/time-travel.md T1):
-    /// one snapshot of the settled `model` per rendered frame, into a bounded
-    /// ring. The master scrub clock is the RENDERED frame (every game has one,
-    /// even with no physics), counted by `rendered_frame`. `rewind_scene_to`
-    /// seeks it to restore the model; `world_frame_history` couples the physics
-    /// world to the same rendered-frame index. RESET on hot reload (see
-    /// `swap_in`): snapshots can hold old-module closures, so unlike the live
-    /// model they can't cross a reload.
-    model_history: History<Value>,
-    /// The physics fixed-frame the world had reached at the END of each
-    /// rendered frame — recorded in LOCKSTEP with `model_history` (same index,
-    /// same reset/truncate), so a coupled `rewind_scene_to(R)` can restore the
-    /// world to the fixed frame that rendered-frame R ended at. Empty of
-    /// meaning (all zero) for games with no `physics` hook.
-    world_frame_history: History<u64>,
-    /// The rendered-frame index the next `model_history` snapshot records at;
-    /// monotonic, one per `tick`. Deliberately its own counter — the
-    /// time-travel clock, kept independent of `frames` (a stats-only counter,
-    /// numerically equal today but free to be reset/repurposed for stats), the
-    /// way the physics recorder owns its own fixed-frame clock.
-    rendered_frame: u64,
-    /// While the draggable scrubber is dragging (docs/time-travel.md T3), the
-    /// rendered frame it has NON-destructively seeked to for display. `Some`
-    /// means "scrubbing": the recorded future is intact so the user can drag
-    /// back and forth; it's committed (branched) only when play resumes.
-    scrub_pos: Option<u64>,
+    /// The coupled time-travel recorder (docs/time-travel.md T1–T3): records the
+    /// settled `model` + physics fixed-frame each rendered frame and seeks/
+    /// rewinds them together. Shared with the web producer (one tested impl).
+    recorder: SceneRecorder,
     /// Endpoint keys of the connections currently declared by
     /// `subscriptions` (`Sub.connect`/`Sub.listen`) — diffed each frame to
     /// open newly-declared ones and close dropped ones. The shell's
@@ -365,10 +343,7 @@ impl MleGame {
             pending_events: Vec::new(),
             physics_rt: physics::SteppedPhysics::new(),
             physics_status: (0, false, 0),
-            model_history: History::bounded(DEFAULT_HISTORY_FRAMES),
-            world_frame_history: History::bounded(DEFAULT_HISTORY_FRAMES),
-            rendered_frame: 0,
-            scrub_pos: None,
+            recorder: SceneRecorder::new(),
             live_conn_keys: std::collections::HashSet::new(),
             last_frame: empty_frame(),
             last_error: None,
@@ -722,15 +697,11 @@ to receive their messages; dropping them"
         clear_audio_completions();
         // Reload is a model-history BOUNDARY: the retained snapshots can hold
         // closures bound to the old module, so — unlike the live model, which
-        // `rebind_value` migrates above — they can't safely cross a reload.
-        // `rendered_frame` stays monotonic as the global clock, so post-reload
-        // recording resumes consecutively from the current frame. (Rebinding
-        // snapshots to preserve rewind ACROSS an edit is deferred to when that
-        // feature is actually built — docs/time-travel.md.) The coupled
-        // world-frame map resets in lockstep.
-        self.model_history = History::bounded(DEFAULT_HISTORY_FRAMES);
-        self.world_frame_history = History::bounded(DEFAULT_HISTORY_FRAMES);
-        self.scrub_pos = None;
+        // `rebind_value` migrates above — they can't safely cross a reload. The
+        // recorder keeps its rendered-frame clock monotonic so recording resumes
+        // consecutively. (Rebinding snapshots to preserve rewind ACROSS an edit
+        // is deferred to when that feature is built — docs/time-travel.md.)
+        self.recorder.reset_on_reload();
         report.rebound
     }
 
@@ -750,35 +721,6 @@ to receive their messages; dropping them"
         }
     }
 
-    /// Resolve the physics fixed-frame to seek for rendered frame `frame`
-    /// WITHOUT mutating (shared by `rewind_scene_to` and `seek_scene_to`):
-    /// `Ok(None)` = no physics seek needed (no physics hook, or the frame's
-    /// end-state is already the live world), `Ok(Some(fixed))` = seek exactly
-    /// there, `Err` = that frame's physics has been pruned (refuse rather than
-    /// desync model and world). `frame` must be within the model history's
-    /// recorded range (its lockstep with `world_frame_history` guarantees the
-    /// seek below is in range).
-    fn physics_seek_target(&self, frame: u64) -> Result<Option<u64>, String> {
-        if !self.has_physics {
-            return Ok(None);
-        }
-        let want = *self.world_frame_history.seek(frame);
-        match self.physics_rt.seekable_range() {
-            None => Ok(None), // nothing stepped yet
-            // Compare against the newest RECORDED frame, not the live world
-            // frame: after a non-destructive scrub the world is parked mid-
-            // history, so `current_fixed_frame` isn't the timeline's end — using
-            // it would skip the truncate on the branch commit and panic on the
-            // next (non-consecutive) record.
-            Some((_, hi)) if want > hi => Ok(None), // end-state is the live append; no recorded frame to seek
-            Some((flo, hi)) if want >= flo && want <= hi => Ok(Some(want)),
-            _ => Err(format!(
-                "cannot seek to rendered frame {frame}: its physics frame {want} has \
-                 been pruned from the {}-frame world history",
-                DEFAULT_HISTORY_FRAMES
-            )),
-        }
-    }
 }
 
 impl Game for MleGame {
@@ -865,109 +807,62 @@ impl Game for MleGame {
         Ok(status)
     }
 
-    /// Coupled scene rewind (docs/time-travel.md T1): restore the model AND the
-    /// physics world to the end of rendered frame `target`, then branch the
-    /// recorded future from there. The model comes from `model_history`; the
-    /// world is rewound to the fixed frame that frame recorded in
-    /// `world_frame_history` (the two rings are lockstep). `rendered_frame`
-    /// resets to `frame + 1` so recording resumes consecutively on the branch.
-    /// Shell-driven — the caller (debug server / scrubber overlay) is expected
-    /// to have the clock pinned so the scene stays put after the seek.
-    ///
-    /// The coupled seek is **exact or refused**, never silently desynced: the
-    /// two rings run on different clocks and windows (the model keeps N rendered
-    /// frames; physics keeps N *fixed* frames), so a rendered frame can outlive
-    /// the physics frame it needs (sustained sub-60fps prunes fixed frames
-    /// faster). Rather than let the physics seek clamp to a different time than
-    /// the model — committing a branch where model and world disagree — this
-    /// verifies the physics frame is exactly restorable BEFORE mutating
-    /// anything, and returns `Err` (touching nothing) otherwise.
+    /// Coupled scene rewind — delegated to the shared [`SceneRecorder`]
+    /// (docs/time-travel.md T1). Restores model + world to `target` and branches
+    /// the future; exact-or-refused. After a successful branch, drop any
+    /// in-flight frame work so it doesn't carry across (the reload discipline).
     fn rewind_scene_to(&mut self, target: u64) -> Result<String, String> {
-        let (lo, hi) = self
-            .model_history
-            .recorded_range()
-            .ok_or_else(|| "rewind: nothing recorded yet".to_string())?;
-        let frame = target.clamp(lo, hi);
-        // Resolve the physics seek WITHOUT mutating, so a refusal (pruned frame)
-        // leaves the whole scene untouched (no half-rewound state).
-        let physics_target = self.physics_seek_target(frame)?;
-
-        // Feasible — commit. Model first, then the (already-validated) world.
-        self.model = self.model_history.seek(frame).clone();
-        let mut warnings = Vec::new();
-        if let Some(fixed) = physics_target {
-            warnings = self.physics_rt.rewind_to_frame(fixed);
-            // Keep the cached status in step with the rewound world, so the next
-            // frame records the branch's fixed frame (not the stale future one)
-            // even if that frame's physics hook errors, and the overlay is right.
-            self.physics_status.0 = self.physics_rt.current_fixed_frame();
+        let result = self.recorder.rewind_scene_to(
+            target,
+            &mut self.model,
+            &mut self.physics_rt,
+            &mut self.physics_status,
+            self.has_physics,
+        );
+        if result.is_ok() {
+            // No in-flight frame work should carry across the branch (matches
+            // the reload discipline); between-frame callers have these empty.
+            self.deferred_queries.clear();
+            self.pending_events.clear();
+            clear_http_taggers();
+            clear_audio_completions();
         }
-        // Branch both rings from the seek point, and resume recording there.
-        self.model_history.truncate_from(frame + 1);
-        self.world_frame_history.truncate_from(frame + 1);
-        self.rendered_frame = frame + 1;
-        self.scrub_pos = None;
-        // No in-flight frame work should carry across the branch (matches the
-        // reload discipline); between-frame callers have these empty already.
-        self.deferred_queries.clear();
-        self.pending_events.clear();
-        clear_http_taggers();
-        clear_audio_completions();
-        for warning in &warnings {
-            self.report_once(format!("[mle] {warning}"));
-        }
-        let clamped = if frame == target {
-            String::new()
-        } else {
-            format!(" (requested {target}, clamped to the recorded window)")
-        };
-        Ok(format!("rewound scene to rendered frame {frame}{clamped}"))
+        result
     }
 
     fn current_scene_frame(&self) -> Option<u64> {
-        // While scrubbing, the "current" frame is where the handle sits, not the
-        // (untruncated) newest recorded frame.
-        self.scrub_pos
-            .or_else(|| self.model_history.recorded_range().map(|(_, hi)| hi))
+        self.recorder.current_scene_frame()
     }
 
     fn scene_frame_range(&self) -> Option<(u64, u64)> {
-        self.model_history.recorded_range()
+        self.recorder.scene_frame_range()
     }
 
-    /// Non-destructive scrub (docs/time-travel.md T3): restore model + world to
-    /// `target` for DISPLAY without truncating, so the draggable bar can seek
-    /// back and forth. The branch is committed later, when play resumes from
-    /// `scrub_pos` (see `tick`). Exact-or-refused like `rewind_scene_to`.
+    /// Non-destructive scrub — delegated to the shared [`SceneRecorder`]
+    /// (docs/time-travel.md T3): restore model + world for display without
+    /// truncating, so the draggable bar can seek back and forth.
     fn seek_scene_to(&mut self, target: u64) -> Result<String, String> {
-        let (lo, hi) = self
-            .model_history
-            .recorded_range()
-            .ok_or_else(|| "seek: nothing recorded yet".to_string())?;
-        let frame = target.clamp(lo, hi);
-        let physics_target = self.physics_seek_target(frame)?;
-        self.model = self.model_history.seek(frame).clone();
-        if let Some(fixed) = physics_target {
-            let warnings = self.physics_rt.seek_to_frame(fixed);
-            self.physics_status.0 = self.physics_rt.current_fixed_frame();
-            for warning in &warnings {
-                self.report_once(format!("[mle] {warning}"));
-            }
-        }
-        self.scrub_pos = Some(frame);
-        Ok(format!("scrubbed to rendered frame {frame}"))
+        self.recorder.seek_scene_to(
+            target,
+            &mut self.model,
+            &mut self.physics_rt,
+            &mut self.physics_status,
+            self.has_physics,
+        )
     }
 
     fn tick(&mut self, frame_time: FrameTime) {
         let started = Instant::now();
         // Committing a scrub (docs/time-travel.md T3): if play resumes (dts > 0)
         // while the draggable bar is parked on an earlier frame, branch the
-        // timeline from there BEFORE this frame advances — so the discarded
-        // future is exactly everything after where the user let go.
+        // timeline from there BEFORE this frame advances.
         if frame_time.dts > 0.0 {
-            if let Some(k) = self.scrub_pos.take() {
-                let _ = self.rewind_scene_to(k);
-            }
+            self.recorder.commit_scrub_if_resuming(
+                &mut self.model,
+                &mut self.physics_rt,
+                &mut self.physics_status,
+                self.has_physics,
+            );
         }
         // Subscriptions first, so `tick` sees a model that has absorbed this
         // frame's messages (the F# executor's ordering).
@@ -1056,10 +951,7 @@ impl Game for MleGame {
         // history. `dts == 0` is exactly the pinned-and-not-stepping case
         // (a one-shot step carries `dts > 0`). [xreview]
         if frame_time.dts > 0.0 {
-            self.model_history.record(self.rendered_frame, &self.model);
-            self.world_frame_history
-                .record(self.rendered_frame, &self.physics_status.0);
-            self.rendered_frame += 1;
+            self.recorder.record(&self.model, self.physics_status.0);
         }
         self.frames += 1;
         self.report_stats();
@@ -1597,18 +1489,20 @@ mod tests {
         let mut game = MleGame::create(dir.join("game.mle").to_str().expect("utf-8 path"));
 
         // Nothing recorded until the first frame runs.
-        assert_eq!(game.model_history.recorded_range(), None);
+        assert_eq!(game.recorder.scene_frame_range(), None);
 
         for _ in 0..5 {
             game.tick(FrameTime { tts: 0.0, dts: 0.016 });
         }
 
-        // Five rendered frames, indexed 0..4; each holds that frame's settled
-        // model (n incremented once per tick), and seeking is exact.
-        assert_eq!(game.model_history.recorded_range(), Some((0, 4)));
-        assert_eq!(n_of(game.model_history.seek(0)), 1.0);
-        assert_eq!(n_of(game.model_history.seek(4)), 5.0);
-        // Recording left the live model untouched.
+        // Five rendered frames, indexed 0..4; recording left the live model
+        // untouched (n incremented once per tick).
+        assert_eq!(game.recorder.scene_frame_range(), Some((0, 4)));
+        assert_eq!(n_of(&game.model), 5.0);
+        // Each frame holds that frame's settled model — seeking is exact.
+        game.seek_scene_to(0).expect("seek 0");
+        assert_eq!(n_of(&game.model), 1.0);
+        game.seek_scene_to(4).expect("seek 4");
         assert_eq!(n_of(&game.model), 5.0);
 
         let _ = std::fs::remove_dir_all(&dir);
@@ -1633,13 +1527,13 @@ mod tests {
         for _ in 0..3 {
             game.tick(FrameTime { tts: 0.0, dts: 0.016 });
         }
-        assert_eq!(game.model_history.recorded_range(), Some((0, 2)));
+        assert_eq!(game.recorder.scene_frame_range(), Some((0, 2)));
 
         // Push a fresh (compatible) source: the model is rebound and KEPT, but
         // the history ring is reset.
         game.reload_source(src).expect("reload should succeed");
         assert_eq!(
-            game.model_history.recorded_range(),
+            game.recorder.scene_frame_range(),
             None,
             "reload must reset the model history"
         );
@@ -1647,7 +1541,7 @@ mod tests {
         // Recording resumes at the current (monotonic) rendered frame — the
         // fresh ring re-bases there, so no non-consecutive panic.
         game.tick(FrameTime { tts: 0.0, dts: 0.016 });
-        assert_eq!(game.model_history.recorded_range(), Some((3, 3)));
+        assert_eq!(game.recorder.scene_frame_range(), Some((3, 3)));
 
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -1724,9 +1618,9 @@ mod tests {
             (y_after - y_at_9).abs() > 1e-4,
             "physics still at frame 9 after rewind"
         );
-        // Both rings branched from the seek point; recording resumes at 4.
-        assert_eq!(game.model_history.recorded_range(), Some((0, 3)));
-        assert_eq!(game.rendered_frame, 4);
+        // Both rings branched from the seek point (range truncated to 0..3;
+        // recording resumes at 4).
+        assert_eq!(game.recorder.scene_frame_range(), Some((0, 3)));
 
         physics::remove_world(physics::DEFAULT_WORLD);
         let _ = std::fs::remove_dir_all(&dir);
@@ -1833,7 +1727,7 @@ mod tests {
         assert!(status.contains("frame 7"), "unexpected status: {status}");
         // World untouched (no physics seek), model still current.
         assert!((ball_y() - y_before).abs() < 1e-6, "latest-frame rewind moved the world");
-        assert_eq!(game.model_history.recorded_range(), Some((0, 7)));
+        assert_eq!(game.recorder.scene_frame_range(), Some((0, 7)));
 
         physics::remove_world(physics::DEFAULT_WORLD);
         let _ = std::fs::remove_dir_all(&dir);

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -909,6 +909,10 @@ impl Game for MleGame {
         Ok(format!("rewound scene to rendered frame {frame}{clamped}"))
     }
 
+    fn current_scene_frame(&self) -> Option<u64> {
+        self.model_history.recorded_range().map(|(_, hi)| hi)
+    }
+
     fn tick(&mut self, frame_time: FrameTime) {
         let started = Instant::now();
         // Subscriptions first, so `tick` sees a model that has absorbed this

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -135,6 +135,11 @@ pub struct MleGame {
     /// numerically equal today but free to be reset/repurposed for stats), the
     /// way the physics recorder owns its own fixed-frame clock.
     rendered_frame: u64,
+    /// While the draggable scrubber is dragging (docs/time-travel.md T3), the
+    /// rendered frame it has NON-destructively seeked to for display. `Some`
+    /// means "scrubbing": the recorded future is intact so the user can drag
+    /// back and forth; it's committed (branched) only when play resumes.
+    scrub_pos: Option<u64>,
     /// Endpoint keys of the connections currently declared by
     /// `subscriptions` (`Sub.connect`/`Sub.listen`) — diffed each frame to
     /// open newly-declared ones and close dropped ones. The shell's
@@ -363,6 +368,7 @@ impl MleGame {
             model_history: History::bounded(DEFAULT_HISTORY_FRAMES),
             world_frame_history: History::bounded(DEFAULT_HISTORY_FRAMES),
             rendered_frame: 0,
+            scrub_pos: None,
             live_conn_keys: std::collections::HashSet::new(),
             last_frame: empty_frame(),
             last_error: None,
@@ -724,6 +730,7 @@ to receive their messages; dropping them"
         // world-frame map resets in lockstep.
         self.model_history = History::bounded(DEFAULT_HISTORY_FRAMES);
         self.world_frame_history = History::bounded(DEFAULT_HISTORY_FRAMES);
+        self.scrub_pos = None;
         report.rebound
     }
 
@@ -740,6 +747,36 @@ to receive their messages; dropping them"
             self.tick_ns = 0;
             self.physics_ns = 0;
             self.draw_ns = 0;
+        }
+    }
+
+    /// Resolve the physics fixed-frame to seek for rendered frame `frame`
+    /// WITHOUT mutating (shared by `rewind_scene_to` and `seek_scene_to`):
+    /// `Ok(None)` = no physics seek needed (no physics hook, or the frame's
+    /// end-state is already the live world), `Ok(Some(fixed))` = seek exactly
+    /// there, `Err` = that frame's physics has been pruned (refuse rather than
+    /// desync model and world). `frame` must be within the model history's
+    /// recorded range (its lockstep with `world_frame_history` guarantees the
+    /// seek below is in range).
+    fn physics_seek_target(&self, frame: u64) -> Result<Option<u64>, String> {
+        if !self.has_physics {
+            return Ok(None);
+        }
+        let want = *self.world_frame_history.seek(frame);
+        match self.physics_rt.seekable_range() {
+            None => Ok(None), // nothing stepped yet
+            // Compare against the newest RECORDED frame, not the live world
+            // frame: after a non-destructive scrub the world is parked mid-
+            // history, so `current_fixed_frame` isn't the timeline's end — using
+            // it would skip the truncate on the branch commit and panic on the
+            // next (non-consecutive) record.
+            Some((_, hi)) if want > hi => Ok(None), // end-state is the live append; no recorded frame to seek
+            Some((flo, hi)) if want >= flo && want <= hi => Ok(Some(want)),
+            _ => Err(format!(
+                "cannot seek to rendered frame {frame}: its physics frame {want} has \
+                 been pruned from the {}-frame world history",
+                DEFAULT_HISTORY_FRAMES
+            )),
         }
     }
 }
@@ -851,37 +888,14 @@ impl Game for MleGame {
             .recorded_range()
             .ok_or_else(|| "rewind: nothing recorded yet".to_string())?;
         let frame = target.clamp(lo, hi);
-
-        // Decide the physics seek WITHOUT mutating, so a refusal leaves the
-        // whole scene untouched (no half-rewound state).
-        enum PhysicsSeek {
-            None,          // no physics, or end-of-frame is already the live world
-            To(u64),       // exact seek to this fixed frame
-        }
-        let physics_seek = if self.has_physics {
-            let want = *self.world_frame_history.seek(frame);
-            match self.physics_rt.seekable_range() {
-                // `want` past the newest recorded frame == the current live
-                // world (no physics step happened after this rendered frame),
-                // so the world is already at end-of-frame — no seek needed.
-                _ if want >= self.physics_rt.current_fixed_frame() => PhysicsSeek::None,
-                Some((flo, hi)) if want >= flo && want <= hi => PhysicsSeek::To(want),
-                _ => {
-                    return Err(format!(
-                        "cannot rewind to rendered frame {frame}: its physics frame \
-                         {want} has been pruned from the {}-frame world history",
-                        DEFAULT_HISTORY_FRAMES
-                    ));
-                }
-            }
-        } else {
-            PhysicsSeek::None
-        };
+        // Resolve the physics seek WITHOUT mutating, so a refusal (pruned frame)
+        // leaves the whole scene untouched (no half-rewound state).
+        let physics_target = self.physics_seek_target(frame)?;
 
         // Feasible — commit. Model first, then the (already-validated) world.
         self.model = self.model_history.seek(frame).clone();
         let mut warnings = Vec::new();
-        if let PhysicsSeek::To(fixed) = physics_seek {
+        if let Some(fixed) = physics_target {
             warnings = self.physics_rt.rewind_to_frame(fixed);
             // Keep the cached status in step with the rewound world, so the next
             // frame records the branch's fixed frame (not the stale future one)
@@ -892,6 +906,7 @@ impl Game for MleGame {
         self.model_history.truncate_from(frame + 1);
         self.world_frame_history.truncate_from(frame + 1);
         self.rendered_frame = frame + 1;
+        self.scrub_pos = None;
         // No in-flight frame work should carry across the branch (matches the
         // reload discipline); between-frame callers have these empty already.
         self.deferred_queries.clear();
@@ -910,11 +925,50 @@ impl Game for MleGame {
     }
 
     fn current_scene_frame(&self) -> Option<u64> {
-        self.model_history.recorded_range().map(|(_, hi)| hi)
+        // While scrubbing, the "current" frame is where the handle sits, not the
+        // (untruncated) newest recorded frame.
+        self.scrub_pos
+            .or_else(|| self.model_history.recorded_range().map(|(_, hi)| hi))
+    }
+
+    fn scene_frame_range(&self) -> Option<(u64, u64)> {
+        self.model_history.recorded_range()
+    }
+
+    /// Non-destructive scrub (docs/time-travel.md T3): restore model + world to
+    /// `target` for DISPLAY without truncating, so the draggable bar can seek
+    /// back and forth. The branch is committed later, when play resumes from
+    /// `scrub_pos` (see `tick`). Exact-or-refused like `rewind_scene_to`.
+    fn seek_scene_to(&mut self, target: u64) -> Result<String, String> {
+        let (lo, hi) = self
+            .model_history
+            .recorded_range()
+            .ok_or_else(|| "seek: nothing recorded yet".to_string())?;
+        let frame = target.clamp(lo, hi);
+        let physics_target = self.physics_seek_target(frame)?;
+        self.model = self.model_history.seek(frame).clone();
+        if let Some(fixed) = physics_target {
+            let warnings = self.physics_rt.seek_to_frame(fixed);
+            self.physics_status.0 = self.physics_rt.current_fixed_frame();
+            for warning in &warnings {
+                self.report_once(format!("[mle] {warning}"));
+            }
+        }
+        self.scrub_pos = Some(frame);
+        Ok(format!("scrubbed to rendered frame {frame}"))
     }
 
     fn tick(&mut self, frame_time: FrameTime) {
         let started = Instant::now();
+        // Committing a scrub (docs/time-travel.md T3): if play resumes (dts > 0)
+        // while the draggable bar is parked on an earlier frame, branch the
+        // timeline from there BEFORE this frame advances — so the discarded
+        // future is exactly everything after where the user let go.
+        if frame_time.dts > 0.0 {
+            if let Some(k) = self.scrub_pos.take() {
+                let _ = self.rewind_scene_to(k);
+            }
+        }
         // Subscriptions first, so `tick` sees a model that has absorbed this
         // frame's messages (the F# executor's ordering).
         self.pump_subscriptions(frame_time.tts as f64);
@@ -1673,6 +1727,65 @@ mod tests {
         // Both rings branched from the seek point; recording resumes at 4.
         assert_eq!(game.model_history.recorded_range(), Some((0, 3)));
         assert_eq!(game.rendered_frame, 4);
+
+        physics::remove_world(physics::DEFAULT_WORLD);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The draggable scrubber (docs/time-travel.md T3): `seek_scene_to` is
+    /// NON-destructive — you can seek back and forth freely (the range stays
+    /// intact) — and the future is branched only when play RESUMES from the
+    /// scrubbed frame.
+    #[test]
+    fn scrub_is_non_destructive_then_branches_on_resume() {
+        fn n_of(v: &Value) -> f64 {
+            match v {
+                Value::Record(fields) => match &fields.iter().find(|(k, _)| k == "n").unwrap().1 {
+                    Value::Number(x) => *x,
+                    _ => panic!("n not a number"),
+                },
+                _ => panic!("not a record"),
+            }
+        }
+        physics::remove_world(physics::DEFAULT_WORLD);
+        let dir = std::env::temp_dir().join(format!("mle-game-test-{}-scrub", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create temp project dir");
+        std::fs::write(
+            dir.join("game.mle"),
+            "let init = { n: 0.0 }\n\
+             let tick = (m, dt, tts) => { m with n: m.n + 1.0 }\n\
+             let physics = (m) => Physics.scene(0.0, -9.81, 0.0, [\n\
+             \x20 Physics.dynamic(\"ball\", Physics.sphere(0.5)) |> Physics.at(0.0, 8.0, 0.0)])\n\
+             let draw = (m, tts) => Frame.create(Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0), Scene.cube())\n",
+        )
+        .expect("write game");
+        let mut game = MleGame::create(dir.join("game.mle").to_str().expect("utf-8 path"));
+
+        let dt = FrameTime { tts: 0.0, dts: physics::FIXED_DT };
+        for _ in 0..10 {
+            game.tick(dt.clone());
+        }
+        assert_eq!(game.scene_frame_range(), Some((0, 9)));
+
+        // Scrub back, forward, back — the window never shrinks (non-destructive),
+        // and the model follows the handle.
+        game.seek_scene_to(3).expect("seek 3");
+        assert_eq!(n_of(&game.model), 4.0);
+        assert_eq!(game.current_scene_frame(), Some(3));
+        assert_eq!(game.scene_frame_range(), Some((0, 9)), "seek must not truncate");
+        game.seek_scene_to(7).expect("seek 7");
+        assert_eq!(n_of(&game.model), 8.0, "can scrub FORWARD again (non-destructive)");
+        assert_eq!(game.scene_frame_range(), Some((0, 9)));
+        game.seek_scene_to(2).expect("seek 2");
+        assert_eq!(n_of(&game.model), 3.0);
+
+        // Resume (dts > 0): the branch commits from frame 2 — the future after 2
+        // is discarded, and recording continues at frame 3.
+        game.tick(dt.clone());
+        assert_eq!(game.current_scene_frame(), Some(3), "no longer scrubbing");
+        assert_eq!(game.scene_frame_range(), Some((0, 3)), "future branched away");
+        assert_eq!(n_of(&game.model), 4.0, "model advanced from the scrubbed frame");
 
         physics::remove_world(physics::DEFAULT_WORLD);
         let _ = std::fs::remove_dir_all(&dir);

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -855,14 +855,18 @@ impl Game for MleGame {
         let started = Instant::now();
         // Committing a scrub (docs/time-travel.md T3): if play resumes (dts > 0)
         // while the draggable bar is parked on an earlier frame, branch the
-        // timeline from there BEFORE this frame advances.
-        if frame_time.dts > 0.0 {
-            self.recorder.commit_scrub_if_resuming(
+        // timeline from there BEFORE this frame advances — and drop any in-flight
+        // frame work so it doesn't cross the branch (the reload discipline).
+        if frame_time.dts > 0.0
+            && self.recorder.commit_scrub_if_resuming(
                 &mut self.model,
                 &mut self.physics_rt,
                 &mut self.physics_status,
                 self.has_physics,
-            );
+            )
+        {
+            self.deferred_queries.clear();
+            self.pending_events.clear();
         }
         // Subscriptions first, so `tick` sees a model that has absorbed this
         // frame's messages (the F# executor's ordering).

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -995,10 +995,18 @@ impl Game for MleGame {
         // / event effects have folded into `self.model` — plus the physics
         // fixed-frame the world reached, in lockstep, so a coupled rewind can
         // restore both. `physics_status.0` is the world's current fixed frame.
-        self.model_history.record(self.rendered_frame, &self.model);
-        self.world_frame_history
-            .record(self.rendered_frame, &self.physics_status.0);
-        self.rendered_frame += 1;
+        //
+        // Skip a PAUSED frame (`dts == 0`, i.e. the clock pinned): the sim
+        // hasn't advanced, so recording would only pile up frozen duplicates —
+        // inflating the timeline and pushing a rewind target past the real
+        // history. `dts == 0` is exactly the pinned-and-not-stepping case
+        // (a one-shot step carries `dts > 0`). [xreview]
+        if frame_time.dts > 0.0 {
+            self.model_history.record(self.rendered_frame, &self.model);
+            self.world_frame_history
+                .record(self.rendered_frame, &self.physics_status.0);
+            self.rendered_frame += 1;
+        }
         self.frames += 1;
         self.report_stats();
     }

--- a/runtime/functor-runtime-web/Cargo.toml
+++ b/runtime/functor-runtime-web/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = "1.0"
 
 [dependencies.web-sys]
 version = "0.3.4"
-features = ['Blob', 'HtmlCanvasElement', 'WebGl2RenderingContext', 'console', 'Window', 'Location', 'Performance', 'PerformanceTiming', 'Document', 'Element', 'Request', 'RequestInit', 'Response', 'Headers', 'AudioContext', 'BaseAudioContext', 'AudioBuffer', 'AudioBufferSourceNode', 'AudioDestinationNode', 'AudioNode', 'AudioParam', 'GainNode', 'StereoPannerNode', 'WebSocket', 'MessageEvent', 'CloseEvent', 'ErrorEvent']
+features = ['Blob', 'HtmlCanvasElement', 'WebGl2RenderingContext', 'console', 'Window', 'Location', 'Performance', 'PerformanceTiming', 'Document', 'Element', 'Request', 'RequestInit', 'Response', 'Headers', 'AudioContext', 'BaseAudioContext', 'AudioBuffer', 'AudioBufferSourceNode', 'AudioDestinationNode', 'AudioNode', 'AudioParam', 'GainNode', 'StereoPannerNode', 'WebSocket', 'MessageEvent', 'CloseEvent', 'ErrorEvent', 'EventTarget', 'MouseEvent']
 
 [profile.release]
 codegen-units = 1

--- a/runtime/functor-runtime-web/Cargo.toml
+++ b/runtime/functor-runtime-web/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = "1.0"
 
 [dependencies.web-sys]
 version = "0.3.4"
-features = ['Blob', 'HtmlCanvasElement', 'WebGl2RenderingContext', 'console', 'Window', 'Location', 'Performance', 'PerformanceTiming', 'Document', 'Element', 'Request', 'RequestInit', 'Response', 'Headers', 'AudioContext', 'BaseAudioContext', 'AudioBuffer', 'AudioBufferSourceNode', 'AudioDestinationNode', 'AudioNode', 'AudioParam', 'GainNode', 'StereoPannerNode', 'WebSocket', 'MessageEvent', 'CloseEvent', 'ErrorEvent', 'EventTarget', 'MouseEvent']
+features = ['Blob', 'HtmlCanvasElement', 'WebGl2RenderingContext', 'console', 'Window', 'Location', 'Performance', 'PerformanceTiming', 'Document', 'Element', 'Request', 'RequestInit', 'Response', 'Headers', 'AudioContext', 'BaseAudioContext', 'AudioBuffer', 'AudioBufferSourceNode', 'AudioDestinationNode', 'AudioNode', 'AudioParam', 'GainNode', 'StereoPannerNode', 'WebSocket', 'MessageEvent', 'CloseEvent', 'ErrorEvent']
 
 [profile.release]
 codegen-units = 1

--- a/runtime/functor-runtime-web/index-mle.html
+++ b/runtime/functor-runtime-web/index-mle.html
@@ -21,11 +21,35 @@
         border: 1px solid rgba(255,255,255,0.15); border-radius: 6px;
       }
       #mouselook:hover { background: rgba(40,40,48,0.85); }
+      /* The time-travel scrubber — native DOM OUTSIDE the canvas, so its
+         controls never fight the game's pointer handling (docs/time-travel.md
+         T3). Hidden until the runtime has recorded some history. */
+      #scrubber {
+        position: fixed; left: 50%; bottom: 14px; transform: translateX(-50%);
+        z-index: 10; display: none; align-items: center; gap: 10px;
+        font: 12px/1 monospace; color: #eee; padding: 8px 12px;
+        background: rgba(20,20,24,0.82); border-radius: 8px;
+        border: 1px solid rgba(255,255,255,0.14);
+      }
+      #scrubber button {
+        font: 12px/1 monospace; color: #eee; cursor: pointer;
+        background: rgba(80,80,90,0.6); border: 1px solid rgba(255,255,255,0.15);
+        border-radius: 5px; padding: 5px 9px;
+      }
+      #scrubber button:hover { background: rgba(110,110,125,0.7); }
+      #scrub-slider { width: 320px; accent-color: #e0803a; }
+      #scrub-label { min-width: 150px; }
     </style>
   </head>
   <body>
     <canvas id="canvas"></canvas>
     <button id="mouselook" title="Control the camera with the mouse; Esc to release">🖱 mouse look</button>
+    <div id="scrubber">
+      <span id="scrub-label">time-travel</span>
+      <button id="scrub-pause">Pause</button>
+      <input id="scrub-slider" type="range" min="0" max="0" value="0" step="1" />
+      <button id="scrub-step">Step ▸</button>
+    </div>
     <script type="module">
 
       import init, {
@@ -34,6 +58,12 @@
         mle_mouse_wheel,
         mle_is_running,
         mle_set_source,
+        mle_scene_frame,
+        mle_scene_range,
+        mle_seek_scene,
+        mle_scrub_toggle_pause,
+        mle_scrub_step,
+        mle_scrub_paused,
       } from "./pkg/functor_runtime_web.js";
 
       // The MLE entry file, substituted in by the CLI's dev server (see
@@ -109,6 +139,49 @@
         });
       };
 
+      // The time-travel scrubber (docs/time-travel.md T3). Native DOM controls
+      // drive the runtime through the `mle_scrub_*` exports and poll the
+      // published view state each frame to track the handle. Coalesce drags to
+      // one seek per frame, and don't fight the user's drag by writing the
+      // slider value while they hold it.
+      const setupScrubber = () => {
+        const el = document.getElementById("scrubber");
+        const label = document.getElementById("scrub-label");
+        const pause = document.getElementById("scrub-pause");
+        const slider = document.getElementById("scrub-slider");
+        const step = document.getElementById("scrub-step");
+
+        let scrubbing = false;
+        let pendingSeek = null;
+        slider.addEventListener("pointerdown", () => (scrubbing = true));
+        window.addEventListener("pointerup", () => (scrubbing = false));
+        slider.addEventListener("input", () => (pendingSeek = Number(slider.value)));
+        pause.addEventListener("click", () => mle_scrub_toggle_pause());
+        step.addEventListener("click", () => mle_scrub_step());
+
+        const update = () => {
+          if (pendingSeek !== null) {
+            mle_seek_scene(pendingSeek);
+            pendingSeek = null;
+          }
+          const range = mle_scene_range(); // [] or [lo, hi]
+          if (range.length === 2) {
+            el.style.display = "flex";
+            const lo = range[0], hi = range[1];
+            slider.min = lo;
+            slider.max = hi;
+            const frame = mle_scene_frame();
+            if (!scrubbing) slider.value = frame; // don't tug the handle mid-drag
+            label.textContent = `time-travel · ${frame | 0} / ${hi | 0}`;
+            pause.textContent = mle_scrub_paused() ? "Resume" : "Pause";
+          } else {
+            el.style.display = "none"; // nothing recorded yet
+          }
+          requestAnimationFrame(update);
+        };
+        requestAnimationFrame(update);
+      };
+
       // Editor live-preview bridge (docs/mle.md D4): a hosting page (the
       // VSCode webview's iframe bridge, or a test driving this page directly)
       // posts the full .mle source and the runtime hot-swaps it, model
@@ -161,7 +234,10 @@
         // In a deterministic capture (?fixed-time), don't wire up input — a
         // stray mouse move would turn the camera, like on native.
         const deterministic = new URLSearchParams(window.location.search).has("fixed-time");
-        if (!deterministic) setupInput();
+        if (!deterministic) {
+          setupInput();
+          setupScrubber();
+        }
         setupSetSource();
       });
     </script>

--- a/runtime/functor-runtime-web/index-mle.html
+++ b/runtime/functor-runtime-web/index-mle.html
@@ -11,10 +11,21 @@
       /* Fill the window; the runtime sizes the drawable buffer (and GL
          viewport) to match this displayed size each frame, scaled for HiDPI. */
       #canvas { display: block; width: 100%; height: 100%; }
+      /* Explicit mouse-look toggle. The cursor stays FREE by default so the
+         time-travel scrubber is usable without the pointer being grabbed on
+         every click; press this (or Esc to release) to control the camera. */
+      #mouselook {
+        position: fixed; top: 10px; left: 10px; z-index: 10;
+        font: 12px/1 monospace; padding: 6px 10px; cursor: pointer;
+        color: #ddd; background: rgba(20,20,24,0.72);
+        border: 1px solid rgba(255,255,255,0.15); border-radius: 6px;
+      }
+      #mouselook:hover { background: rgba(40,40,48,0.85); }
     </style>
   </head>
   <body>
     <canvas id="canvas"></canvas>
+    <button id="mouselook" title="Control the camera with the mouse; Esc to release">🖱 mouse look</button>
     <script type="module">
 
       import init, {
@@ -72,14 +83,21 @@
         });
 
         // Mouse free-look. Pointer Lock is the browser equivalent of the
-        // desktop runtime's GLFW cursor capture: click the canvas to lock, then
-        // movementX/Y give relative motion. We accumulate it into a running
-        // position so the game's "delta = current - lastMouse" logic works the
-        // same as on native. Esc releases the lock (browser default).
-        canvas.addEventListener("click", () => canvas.requestPointerLock());
+        // desktop runtime's GLFW cursor capture, giving movementX/Y relative
+        // motion. Entered EXPLICITLY via the "mouse look" button (not on every
+        // canvas click) so the cursor stays free for the time-travel scrubber;
+        // Esc releases the lock (browser default). We accumulate movement into a
+        // running position so the game's "delta = current - lastMouse" works the
+        // same as on native.
+        document
+          .getElementById("mouselook")
+          .addEventListener("click", () => canvas.requestPointerLock());
         let ax = 0;
         let ay = 0;
         document.addEventListener("mousemove", (e) => {
+          // Only drive the camera while in look mode (pointer locked); otherwise
+          // moving the cursor to the scrubber must not rotate the view.
+          if (document.pointerLockElement !== canvas) return;
           ax += e.movementX;
           ay += e.movementY;
           mle_mouse_move(ax, ay);

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -1049,51 +1049,14 @@ async fn run_async() -> Result<(), JsValue> {
         // a short warm-up so the page is static for screenshotting.
         let mut sized = false;
 
-        // The time-travel scrubber (docs/time-travel.md T3): ALWAYS VISIBLE in
-        // the web/vscode preview (it's the dev surface). Its own egui context.
-        let mut scrubber = functor_runtime_common::ui::Scrubber::new(gl.clone());
-        // Pause/step control (the web analogue of the desktop runner's
-        // held_time/pending_step): when `held_time` is `Some`, the clock is
-        // pinned (dts = 0) so a scrubbed frame stays put; a one-shot step
-        // carries dts > 0.
+        // Time-travel clock control (docs/time-travel.md T3). The scrubber UI is
+        // NATIVE DOM on web (index-mle.html) — outside the canvas, so no
+        // pointer-lock clash — driving the runtime through the `mle_scrub_*`
+        // exports (in mle_game.rs). This loop owns the clock: when `held_time`
+        // is `Some` it's pinned (dts = 0) so a scrubbed frame stays put; a
+        // one-shot step carries dts > 0.
         let mut held_time: Option<f32> = None;
         let mut pending_step: Option<f32> = None;
-        // Pointer state written by the DOM mouse listeners below, read by the
-        // frame loop: (cursor x, y in CSS px, primary-button down, press-latch).
-        // The latch holds a press for at least one frame so a full click that
-        // starts AND ends between two rAF callbacks still delivers its edge
-        // (the frame reads `down || latch`, then consumes the latch) [xreview].
-        let pointer = Rc::new(std::cell::RefCell::new((0.0f32, 0.0f32, false, false)));
-        {
-            use wasm_bindgen::JsCast;
-            let p = pointer.clone();
-            let mm = Closure::<dyn FnMut(_)>::new(move |e: web_sys::MouseEvent| {
-                let mut p = p.borrow_mut();
-                p.0 = e.offset_x() as f32;
-                p.1 = e.offset_y() as f32;
-            });
-            let _ = canvas.add_event_listener_with_callback("mousemove", mm.as_ref().unchecked_ref());
-            mm.forget();
-            let p = pointer.clone();
-            let md = Closure::<dyn FnMut(_)>::new(move |e: web_sys::MouseEvent| {
-                if e.button() == 0 {
-                    let mut p = p.borrow_mut();
-                    p.2 = true;
-                    p.3 = true;
-                }
-            });
-            let _ = canvas.add_event_listener_with_callback("mousedown", md.as_ref().unchecked_ref());
-            md.forget();
-            // Release on the window so a mouse-up outside the canvas still counts.
-            let p = pointer.clone();
-            let mu = Closure::<dyn FnMut(_)>::new(move |e: web_sys::MouseEvent| {
-                if e.button() == 0 {
-                    p.borrow_mut().2 = false;
-                }
-            });
-            let _ = window.add_event_listener_with_callback("mouseup", mu.as_ref().unchecked_ref());
-            mu.forget();
-        }
 
         *g.borrow_mut() = Some(Closure::new(move || {
             // The frame's exclusive borrow of the shared producer. Cannot
@@ -1101,6 +1064,27 @@ async fn run_async() -> Result<(), JsValue> {
             // message handlers only run between rAF callbacks.
             let mut game = game.borrow_mut();
             let now = performance.now() as f32;
+            let raw_tts = (now - initial_time) / 1000.0;
+
+            // Apply scrubber controls from the DOM (pause / step / seek). This
+            // loop owns the clock, so it fills the pin time and drives the seek.
+            for control in mle_game::take_scrub_controls() {
+                match control {
+                    mle_game::ScrubControl::TogglePause => {
+                        held_time = if held_time.is_some() { None } else { Some(raw_tts) };
+                        pending_step = None;
+                    }
+                    mle_game::ScrubControl::Step => {
+                        held_time = Some(held_time.unwrap_or(raw_tts));
+                        pending_step = Some(1.0 / 60.0);
+                    }
+                    mle_game::ScrubControl::SeekTo(f) => {
+                        let _ = game.seek_scene_to(f);
+                        held_time = Some(held_time.unwrap_or(raw_tts));
+                    }
+                }
+            }
+
             // Pin the frame time when `?fixed-time` is set (deterministic
             // capture), or when the scrubber has paused the clock (`held_time`).
             // A queued step advances exactly one frame, then re-pins.
@@ -1189,50 +1173,13 @@ async fn run_async() -> Result<(), JsValue> {
             let dpr = dpr.max(1.0);
             text_overlay.draw_view(canvas.width(), canvas.height(), dpr, &view);
 
-            // The time-travel scrubber, always visible over the frame. egui
-            // lays out in points (canvas px / dpr = CSS px), so the CSS-pixel
-            // cursor is scaled to device px to line up (the desktop HiDPI fix).
-            let (px, py, down) = {
-                let mut p = pointer.borrow_mut();
-                // `down || latch` so a same-frame click still shows a pressed
-                // frame; consume the latch so the next frame sees the release.
-                let effective = p.2 || p.3;
-                p.3 = false;
-                (p.0, p.1, effective)
-            };
-            let scrubber_out = scrubber.draw(
-                canvas.width(),
-                canvas.height(),
-                dpr,
-                functor_runtime_common::ui::PointerState {
-                    pos: Some((px * dpr, py * dpr)),
-                    primary_down: down,
-                },
-                functor_runtime_common::ui::ScrubberState {
-                    frame: game.current_scene_frame().unwrap_or(0),
-                    range: game.scene_frame_range(),
-                    paused: held_time.is_some(),
-                },
+            // Publish the scrubber state for the DOM slider to poll (the UI
+            // itself is native HTML in index-mle.html, outside the canvas).
+            mle_game::publish_scrub_view(
+                game.current_scene_frame(),
+                game.scene_frame_range(),
+                held_time.is_some(),
             );
-            match scrubber_out.action {
-                Some(functor_runtime_common::ui::ScrubberAction::TogglePause) => {
-                    held_time = if held_time.is_some() {
-                        None
-                    } else {
-                        Some(frame_time.tts)
-                    };
-                    pending_step = None;
-                }
-                Some(functor_runtime_common::ui::ScrubberAction::SeekTo(f)) => {
-                    let _ = game.seek_scene_to(f);
-                    held_time = Some(frame_time.tts); // park on the scrubbed frame
-                }
-                Some(functor_runtime_common::ui::ScrubberAction::Step) => {
-                    held_time = Some(frame_time.tts);
-                    pending_step = Some(1.0 / 60.0);
-                }
-                None => {}
-            }
 
             // Schedule the next frame. In deterministic mode (?fixed-time, the
             // golden) render a short warm-up (shader compile, first-frame

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -1049,18 +1049,69 @@ async fn run_async() -> Result<(), JsValue> {
         // a short warm-up so the page is static for screenshotting.
         let mut sized = false;
 
+        // The time-travel scrubber (docs/time-travel.md T3): ALWAYS VISIBLE in
+        // the web/vscode preview (it's the dev surface). Its own egui context.
+        let mut scrubber = functor_runtime_common::ui::Scrubber::new(gl.clone());
+        // Pause/step control (the web analogue of the desktop runner's
+        // held_time/pending_step): when `held_time` is `Some`, the clock is
+        // pinned (dts = 0) so a scrubbed frame stays put; a one-shot step
+        // carries dts > 0.
+        let mut held_time: Option<f32> = None;
+        let mut pending_step: Option<f32> = None;
+        // Pointer state written by the DOM mouse listeners below, read by the
+        // frame loop: (cursor x, y in CSS px, primary-button down).
+        let pointer = Rc::new(std::cell::RefCell::new((0.0f32, 0.0f32, false)));
+        {
+            use wasm_bindgen::JsCast;
+            let p = pointer.clone();
+            let mm = Closure::<dyn FnMut(_)>::new(move |e: web_sys::MouseEvent| {
+                let mut p = p.borrow_mut();
+                p.0 = e.offset_x() as f32;
+                p.1 = e.offset_y() as f32;
+            });
+            let _ = canvas.add_event_listener_with_callback("mousemove", mm.as_ref().unchecked_ref());
+            mm.forget();
+            let p = pointer.clone();
+            let md = Closure::<dyn FnMut(_)>::new(move |e: web_sys::MouseEvent| {
+                if e.button() == 0 {
+                    p.borrow_mut().2 = true;
+                }
+            });
+            let _ = canvas.add_event_listener_with_callback("mousedown", md.as_ref().unchecked_ref());
+            md.forget();
+            // Release on the window so a mouse-up outside the canvas still counts.
+            let p = pointer.clone();
+            let mu = Closure::<dyn FnMut(_)>::new(move |e: web_sys::MouseEvent| {
+                if e.button() == 0 {
+                    p.borrow_mut().2 = false;
+                }
+            });
+            let _ = window.add_event_listener_with_callback("mouseup", mu.as_ref().unchecked_ref());
+            mu.forget();
+        }
+
         *g.borrow_mut() = Some(Closure::new(move || {
             // The frame's exclusive borrow of the shared producer. Cannot
             // collide with `mle_set_source`: JS is single-threaded, and
             // message handlers only run between rAF callbacks.
             let mut game = game.borrow_mut();
             let now = performance.now() as f32;
-            // Pin the frame time when `?fixed-time` is set (deterministic capture).
+            // Pin the frame time when `?fixed-time` is set (deterministic
+            // capture), or when the scrubber has paused the clock (`held_time`).
+            // A queued step advances exactly one frame, then re-pins.
             let frame_time = match fixed_time {
                 Some(t) => FrameTime { dts: 0.0, tts: t },
-                None => FrameTime {
-                    dts: (now - last_time) / 1000.0,
-                    tts: (now - initial_time) / 1000.0,
+                None => match (held_time, pending_step.take()) {
+                    (Some(t), Some(step)) => {
+                        let nt = t + step;
+                        held_time = Some(nt);
+                        FrameTime { dts: step, tts: nt }
+                    }
+                    (Some(t), None) => FrameTime { dts: 0.0, tts: t },
+                    (None, _) => FrameTime {
+                        dts: (now - last_time) / 1000.0,
+                        tts: (now - initial_time) / 1000.0,
+                    },
                 },
             };
 
@@ -1130,7 +1181,46 @@ async fn run_async() -> Result<(), JsValue> {
             // text overlay on top of the frame (HiDPI-aware via the device ratio).
             let view: functor_runtime_common::ui::View = game.ui();
             let dpr = web_sys::window().unwrap().device_pixel_ratio() as f32;
-            text_overlay.draw_view(canvas.width(), canvas.height(), dpr.max(1.0), &view);
+            let dpr = dpr.max(1.0);
+            text_overlay.draw_view(canvas.width(), canvas.height(), dpr, &view);
+
+            // The time-travel scrubber, always visible over the frame. egui
+            // lays out in points (canvas px / dpr = CSS px), so the CSS-pixel
+            // cursor is scaled to device px to line up (the desktop HiDPI fix).
+            let (px, py, down) = *pointer.borrow();
+            let scrubber_out = scrubber.draw(
+                canvas.width(),
+                canvas.height(),
+                dpr,
+                functor_runtime_common::ui::PointerState {
+                    pos: Some((px * dpr, py * dpr)),
+                    primary_down: down,
+                },
+                functor_runtime_common::ui::ScrubberState {
+                    frame: game.current_scene_frame().unwrap_or(0),
+                    range: game.scene_frame_range(),
+                    paused: held_time.is_some(),
+                },
+            );
+            match scrubber_out.action {
+                Some(functor_runtime_common::ui::ScrubberAction::TogglePause) => {
+                    held_time = if held_time.is_some() {
+                        None
+                    } else {
+                        Some(frame_time.tts)
+                    };
+                    pending_step = None;
+                }
+                Some(functor_runtime_common::ui::ScrubberAction::SeekTo(f)) => {
+                    let _ = game.seek_scene_to(f);
+                    held_time = Some(frame_time.tts); // park on the scrubbed frame
+                }
+                Some(functor_runtime_common::ui::ScrubberAction::Step) => {
+                    held_time = Some(frame_time.tts);
+                    pending_step = Some(1.0 / 60.0);
+                }
+                None => {}
+            }
 
             // Schedule the next frame. In deterministic mode (?fixed-time, the
             // golden) render a short warm-up (shader compile, first-frame

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -1059,8 +1059,11 @@ async fn run_async() -> Result<(), JsValue> {
         let mut held_time: Option<f32> = None;
         let mut pending_step: Option<f32> = None;
         // Pointer state written by the DOM mouse listeners below, read by the
-        // frame loop: (cursor x, y in CSS px, primary-button down).
-        let pointer = Rc::new(std::cell::RefCell::new((0.0f32, 0.0f32, false)));
+        // frame loop: (cursor x, y in CSS px, primary-button down, press-latch).
+        // The latch holds a press for at least one frame so a full click that
+        // starts AND ends between two rAF callbacks still delivers its edge
+        // (the frame reads `down || latch`, then consumes the latch) [xreview].
+        let pointer = Rc::new(std::cell::RefCell::new((0.0f32, 0.0f32, false, false)));
         {
             use wasm_bindgen::JsCast;
             let p = pointer.clone();
@@ -1074,7 +1077,9 @@ async fn run_async() -> Result<(), JsValue> {
             let p = pointer.clone();
             let md = Closure::<dyn FnMut(_)>::new(move |e: web_sys::MouseEvent| {
                 if e.button() == 0 {
-                    p.borrow_mut().2 = true;
+                    let mut p = p.borrow_mut();
+                    p.2 = true;
+                    p.3 = true;
                 }
             });
             let _ = canvas.add_event_listener_with_callback("mousedown", md.as_ref().unchecked_ref());
@@ -1187,7 +1192,14 @@ async fn run_async() -> Result<(), JsValue> {
             // The time-travel scrubber, always visible over the frame. egui
             // lays out in points (canvas px / dpr = CSS px), so the CSS-pixel
             // cursor is scaled to device px to line up (the desktop HiDPI fix).
-            let (px, py, down) = *pointer.borrow();
+            let (px, py, down) = {
+                let mut p = pointer.borrow_mut();
+                // `down || latch` so a same-frame click still shows a pressed
+                // frame; consume the latch so the next frame sees the release.
+                let effective = p.2 || p.3;
+                p.3 = false;
+                (p.0, p.1, effective)
+            };
             let scrubber_out = scrubber.draw(
                 canvas.width(),
                 canvas.height(),

--- a/runtime/functor-runtime-web/src/mle_game.rs
+++ b/runtime/functor-runtime-web/src/mle_game.rs
@@ -30,7 +30,7 @@ use functor_runtime_common::mle_prelude::{
 };
 use functor_runtime_common::physics;
 use functor_runtime_common::protocol::GameProducer;
-use functor_runtime_common::timetravel::{History, DEFAULT_HISTORY_FRAMES};
+use functor_runtime_common::timetravel::SceneRecorder;
 use functor_runtime_common::ui::View;
 use functor_runtime_common::{Frame, FrameTime};
 use mle::{Session, Value};
@@ -88,13 +88,10 @@ pub struct MleWebGame {
     physics_rt: physics::SteppedPhysics,
     /// Latest recorder status for the overlay: (fixed frame, paused, history).
     physics_status: (u64, bool, u64),
-    /// The model half of the time-travel recorder (docs/time-travel.md T1) —
-    /// one snapshot of the settled `model` per rendered frame into a bounded
-    /// ring, keyed by the RENDERED-frame clock (`rendered_frame`). The web
-    /// sibling of the desktop producer's field; recording only for now.
-    model_history: History<Value>,
-    /// The rendered-frame index the next `model_history` snapshot records at.
-    rendered_frame: u64,
+    /// The coupled time-travel recorder (docs/time-travel.md T1–T3), shared with
+    /// the desktop producer (one tested impl): records the settled `model` +
+    /// physics fixed-frame each rendered frame and seeks/rewinds them together.
+    recorder: SceneRecorder,
     /// Declared connection keys (`Sub.connect`/`Sub.listen`), reconciled each
     /// frame — see the desktop producer.
     live_conn_keys: std::collections::HashSet<String>,
@@ -261,8 +258,7 @@ impl MleWebGame {
             pending_events: Vec::new(),
             physics_rt: physics::SteppedPhysics::new(),
             physics_status: (0, false, 0),
-            model_history: History::bounded(DEFAULT_HISTORY_FRAMES),
-            rendered_frame: 0,
+            recorder: SceneRecorder::new(),
             live_conn_keys: std::collections::HashSet::new(),
             has_physics: loaded.has_physics,
             has_soundscape: loaded.has_soundscape,
@@ -316,9 +312,9 @@ impl MleWebGame {
         clear_audio_completions();
         // Reload is a model-history BOUNDARY (see the desktop producer): the
         // retained snapshots can hold old-module closures, so they can't cross
-        // a reload; `rendered_frame` stays monotonic so recording resumes
-        // consecutively.
-        self.model_history = History::bounded(DEFAULT_HISTORY_FRAMES);
+        // a reload; the recorder keeps its rendered-frame clock monotonic so
+        // recording resumes consecutively.
+        self.recorder.reset_on_reload();
         self.has_ui = loaded.has_ui;
         if !self.has_ui {
             // Deleting the `ui` hook drops the HUD (the physics-world rule).
@@ -632,7 +628,53 @@ impl GameProducer for MleWebGame {
         Ok(status)
     }
 
+    /// Coupled scene rewind — delegated to the shared [`SceneRecorder`]
+    /// (docs/time-travel.md T1), identical to the desktop producer.
+    fn rewind_scene_to(&mut self, target: u64) -> Result<String, String> {
+        let result = self.recorder.rewind_scene_to(
+            target,
+            &mut self.model,
+            &mut self.physics_rt,
+            &mut self.physics_status,
+            self.has_physics,
+        );
+        if result.is_ok() {
+            self.deferred_queries.clear();
+            self.pending_events.clear();
+        }
+        result
+    }
+
+    fn seek_scene_to(&mut self, target: u64) -> Result<String, String> {
+        self.recorder.seek_scene_to(
+            target,
+            &mut self.model,
+            &mut self.physics_rt,
+            &mut self.physics_status,
+            self.has_physics,
+        )
+    }
+
+    fn current_scene_frame(&self) -> Option<u64> {
+        self.recorder.current_scene_frame()
+    }
+
+    fn scene_frame_range(&self) -> Option<(u64, u64)> {
+        self.recorder.scene_frame_range()
+    }
+
     fn tick(&mut self, frame_time: FrameTime) {
+        // Committing a scrub (docs/time-travel.md T3): if play resumes (dts > 0)
+        // while the scrubber is parked on an earlier frame, branch the timeline
+        // from there BEFORE this frame advances (the desktop producer's rule).
+        if frame_time.dts > 0.0 {
+            self.recorder.commit_scrub_if_resuming(
+                &mut self.model,
+                &mut self.physics_rt,
+                &mut self.physics_status,
+                self.has_physics,
+            );
+        }
         // Subscriptions first, so `tick` sees a model that has absorbed this
         // frame's messages (the F# executor's ordering).
         self.pump_subscriptions(frame_time.tts as f64);
@@ -704,14 +746,12 @@ impl GameProducer for MleWebGame {
                 Err(err) => self.frame_error("subscriptions", &err),
             }
         }
-        // Record the settled model of this rendered frame (docs/time-travel.md
-        // T1), after all of this frame's effects have folded into `self.model`.
-        // Skip a paused frame (`dts == 0`) so it doesn't pile up frozen
-        // duplicates (the desktop producer's rule; web has no clock pin today,
-        // so this never fires, but keeps the two shells in step).
+        // Record the settled model + physics fixed-frame of this rendered frame
+        // (docs/time-travel.md T1), after all of this frame's effects have
+        // folded into `self.model`. Skip a paused frame (`dts == 0`) so it
+        // doesn't pile up frozen duplicates (the desktop producer's rule).
         if frame_time.dts > 0.0 {
-            self.model_history.record(self.rendered_frame, &self.model);
-            self.rendered_frame += 1;
+            self.recorder.record(&self.model, self.physics_status.0);
         }
     }
 

--- a/runtime/functor-runtime-web/src/mle_game.rs
+++ b/runtime/functor-runtime-web/src/mle_game.rs
@@ -666,14 +666,18 @@ impl GameProducer for MleWebGame {
     fn tick(&mut self, frame_time: FrameTime) {
         // Committing a scrub (docs/time-travel.md T3): if play resumes (dts > 0)
         // while the scrubber is parked on an earlier frame, branch the timeline
-        // from there BEFORE this frame advances (the desktop producer's rule).
-        if frame_time.dts > 0.0 {
-            self.recorder.commit_scrub_if_resuming(
+        // from there BEFORE this frame advances, dropping in-flight frame work
+        // that must not cross the branch (the desktop producer's rule).
+        if frame_time.dts > 0.0
+            && self.recorder.commit_scrub_if_resuming(
                 &mut self.model,
                 &mut self.physics_rt,
                 &mut self.physics_status,
                 self.has_physics,
-            );
+            )
+        {
+            self.deferred_queries.clear();
+            self.pending_events.clear();
         }
         // Subscriptions first, so `tick` sees a model that has absorbed this
         // frame's messages (the F# executor's ordering).

--- a/runtime/functor-runtime-web/src/mle_game.rs
+++ b/runtime/functor-runtime-web/src/mle_game.rs
@@ -706,8 +706,13 @@ impl GameProducer for MleWebGame {
         }
         // Record the settled model of this rendered frame (docs/time-travel.md
         // T1), after all of this frame's effects have folded into `self.model`.
-        self.model_history.record(self.rendered_frame, &self.model);
-        self.rendered_frame += 1;
+        // Skip a paused frame (`dts == 0`) so it doesn't pile up frozen
+        // duplicates (the desktop producer's rule; web has no clock pin today,
+        // so this never fires, but keeps the two shells in step).
+        if frame_time.dts > 0.0 {
+            self.model_history.record(self.rendered_frame, &self.model);
+            self.rendered_frame += 1;
+        }
     }
 
     fn key_event(&mut self, code: i32, is_down: bool) {

--- a/runtime/functor-runtime-web/src/mle_game.rs
+++ b/runtime/functor-runtime-web/src/mle_game.rs
@@ -1028,3 +1028,97 @@ pub fn drain_input(game: &mut dyn GameProducer) {
         }
     }
 }
+
+// --- Time-travel scrubber ↔ DOM bridge (docs/time-travel.md T3) -------------
+//
+// On web the scrubber is NATIVE DOM (index-mle.html), not egui-in-canvas, so
+// its widgets sit OUTSIDE the game canvas — their clicks never reach the canvas
+// (no pointer-lock clash) and they render as accessible browser controls. The
+// page calls the `mle_scrub_*` write exports (queued here, applied by the frame
+// loop, which owns the clock) and polls the read exports each frame; the loop
+// publishes the current view state. The coupled-rewind LOGIC stays shared
+// (`SceneRecorder`); only the UI surface differs from desktop.
+
+/// A control from the DOM scrubber, applied by the frame loop.
+pub enum ScrubControl {
+    TogglePause,
+    Step,
+    SeekTo(u64),
+}
+
+thread_local! {
+    static SCRUB_CONTROLS: RefCell<Vec<ScrubControl>> = const { RefCell::new(Vec::new()) };
+    /// Published each frame for the page's slider: `(frame, lo, hi, paused)`.
+    /// `frame`/`lo`/`hi` are `-1.0` when nothing is recorded yet.
+    static SCRUB_VIEW: RefCell<(f64, f64, f64, bool)> =
+        const { RefCell::new((-1.0, -1.0, -1.0, false)) };
+}
+
+const SCRUB_CONTROLS_CAP: usize = 256;
+
+fn push_scrub(control: ScrubControl) {
+    SCRUB_CONTROLS.with(|c| {
+        let mut c = c.borrow_mut();
+        if c.len() < SCRUB_CONTROLS_CAP {
+            c.push(control);
+        }
+    });
+}
+
+/// Drain the queued scrubber controls; the frame loop applies them (it owns the
+/// clock pin and the game).
+pub fn take_scrub_controls() -> Vec<ScrubControl> {
+    SCRUB_CONTROLS.with(|c| std::mem::take(&mut *c.borrow_mut()))
+}
+
+/// Publish this frame's scrubber state for the page to poll.
+pub fn publish_scrub_view(frame: Option<u64>, range: Option<(u64, u64)>, paused: bool) {
+    let f = frame.map(|f| f as f64).unwrap_or(-1.0);
+    let (lo, hi) = range
+        .map(|(l, h)| (l as f64, h as f64))
+        .unwrap_or((-1.0, -1.0));
+    SCRUB_VIEW.with(|v| *v.borrow_mut() = (f, lo, hi, paused));
+}
+
+/// Page → runtime: toggle pause (pin/unpin the clock).
+#[wasm_bindgen]
+pub fn mle_scrub_toggle_pause() {
+    push_scrub(ScrubControl::TogglePause);
+}
+
+/// Page → runtime: advance exactly one frame, then hold.
+#[wasm_bindgen]
+pub fn mle_scrub_step() {
+    push_scrub(ScrubControl::Step);
+}
+
+/// Page → runtime: non-destructively scrub to a rendered frame (slider drag).
+#[wasm_bindgen]
+pub fn mle_seek_scene(frame: f64) {
+    if frame >= 0.0 {
+        push_scrub(ScrubControl::SeekTo(frame as u64));
+    }
+}
+
+/// Runtime → page: the current handle frame (`-1` if nothing recorded).
+#[wasm_bindgen]
+pub fn mle_scene_frame() -> f64 {
+    SCRUB_VIEW.with(|v| v.borrow().0)
+}
+
+/// Runtime → page: the seekable window as `[lo, hi]`, or `[]` if empty.
+#[wasm_bindgen]
+pub fn mle_scene_range() -> Vec<f64> {
+    let (_, lo, hi, _) = SCRUB_VIEW.with(|v| *v.borrow());
+    if lo < 0.0 {
+        vec![]
+    } else {
+        vec![lo, hi]
+    }
+}
+
+/// Runtime → page: whether the clock is currently pinned.
+#[wasm_bindgen]
+pub fn mle_scrub_paused() -> bool {
+    SCRUB_VIEW.with(|v| v.borrow().3)
+}


### PR DESCRIPTION
Pointer input into egui (**T2**) plus a first-cut interactive **time-travel scrubber** (**T3**) on the desktop runner, driving the coupled scene rewind (#222) directly — no debug server needed to scrub live. Renders as a bottom bar: **`time-travel · frame N  [Pause] [<< 30] [Step >]`**.

## The scrubber

![time-travel scrubber](https://gist.githubusercontent.com/tommy-xr/0f7b6fcf0fd504e09a8a6fbd6ef9966e/raw/scrubber.png)

<sub>The shell-owned scrubber overlay (bottom bar). Clicks drive the coupled scene rewind directly; interaction needs a real window to tune.</sub>

## What's here

- **`ui::Scrubber`** — an imperative egui panel with its *own* `egui::Context` (so its pointer/click accounting never interleaves with the game HUD's `TextOverlay`). Synthesizes egui pointer events from the shell's cursor pos + primary-button edge; returns the activated `ScrubberAction` (`TogglePause` / `RewindBy` / `Step`) and `wants_pointer`.
- **`GameProducer::current_scene_frame()`** (default `None`; `MleGame` returns the newest recorded rendered frame) — what the scrubber shows and rewinds relative to.
- **`main`**: tracks the cursor while released, draws the scrubber over the frame, applies its action (pause = pin the clock; rewind = seek + auto-pin so the scene stays put; step = one-frame advance). **Click arbitration**: a left-click on a control feeds egui instead of recapturing the cursor for free-look; the pointer arms sit before the `ignore_user_input` catch-all so the scrubber works while paused.

## Review (xreview, applied)

Cross-engine review found a **High** and several Mediums, all fixed in the second commit:
- **HiDPI (High)** — the cursor is in window/logical coords but egui lays out in framebuffer pixels, so the panel was **unclickable on a retina display** (headless capture can't catch this). Now the cursor is scaled to fb pixels before feeding egui.
- **Paused inflation (Medium)** — a pinned clock (`dts == 0`) kept recording frozen duplicate frames, inflating the timeline and defeating `<< 30`. *(The GIF-capture agent independently hit the same root cause.)* Now recording skips `dts == 0` frames. **Verified:** the recorder's newest frame held at 894 → 894 across a second of idle-while-paused.
- **Stuck press on focus-loss (Medium)** — `mouse_primary_down` now cleared in `Focus(false)`.
- **Step implies pause**; **dedup** the GL-restore into one helper.

Two Lows left as noted follow-ups: a one-frame `wants_pointer` arbitration race (self-correcting), and the `paused` label lagging a frame.

## Status
Builds clean; common **190**, desktop **32**, web wasm clean. The panel renders (verified via `--capture-frame`); **click behaviour needs a real window to tune** — this is the first cut for a tight visual-iteration loop. Native only; web parity + a `~` toggle key are follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
