### PR TITLE
feat(mle,examples): HTTP effect primitive + netdemo port (E2)

### DIFF
--- a/examples/mle-netdemo/functor.json
+++ b/examples/mle-netdemo/functor.json
@@ -1,0 +1,1 @@
+{ "language": "mle", "entry": "game.mle" }

--- a/examples/mle-netdemo/game.mle
+++ b/examples/mle-netdemo/game.mle
@@ -1,0 +1,55 @@
+// mle-netdemo — the MLE port of examples/netdemo (roadmap E2, docs/mle.md).
+//
+// A minimal HTTP sample in the Elm `Http.get { expect = ... }` style: it fires
+// an HTTP GET whose result is tagged into a message and reflected into the
+// model. Meant to be driven HEADLESSLY — the model is fully visible via the
+// debug server's /state, and a response can be injected without a real server
+// (see runtime/functor-runtime-common http tests). `draw` is deliberately tiny;
+// the interesting state is the textual phase.
+//
+//   functor -d examples/mle-netdemo run native
+//
+// Port note: MLE's `init` is a plain value (no F# `GameBuilder.init` effect
+// seed), so the request is fired ONCE on the first frame from `tick` — a bare
+// model on later frames, a `(model, effect)` pair on frame 0.
+
+// Where the request is in its lifecycle.
+type Phase =
+  | Loading
+  | Done(status: Float, body: String)
+  | Failed(text: String)
+
+type Model = { phase: Phase, frame: Float }
+
+// The HTTP result, tagged back to us. `Net.HttpResponse` is the built-in ADT
+// `| Response(status, body) | Failure(error)` (a completed request vs a
+// transport error); MLE patterns don't nest, so `update` inner-matches it.
+type Msg =
+  | GotResponse(resp: Net.HttpResponse)
+
+let endpoint = "http://127.0.0.1:9000/hello"
+
+let init = { phase: Loading, frame: 0.0 }
+
+let update = (m: Model, msg: Msg) =>
+  match msg with
+  | GotResponse(resp) =>
+    (match resp with
+     | Net.Response(status, body) => { m with phase: Done(status, body) }
+     | Net.Failure(err) => { m with phase: Failed(err) })
+
+// Fire the request once, on the first frame (the F# startup-effect seed); the
+// runtime applies the `GotResponse` tagger when the response lands.
+let tick = (m: Model, dt: Float, tts: Float) =>
+  match m.frame == 0.0 with
+  | true => ({ m with frame: 1.0 }, Effect.httpGet(endpoint, GotResponse))
+  | false => { m with frame: m.frame + 1.0 }
+
+let draw = (m: Model, tts: Float) =>
+  // A single emissive cube so there's something on screen; the meaningful
+  // state is the textual phase, inspected via /state.
+  Frame.create(
+    Camera.firstPerson(
+      0.0, 0.0, -5.0,
+      Angle.radians(0.0), Angle.radians(0.0), Angle.degrees(60.0)),
+    Scene.cube() |> Scene.emissive(0.2, 0.9, 0.6))

--- a/mle/src/project.rs
+++ b/mle/src/project.rs
@@ -86,12 +86,17 @@ impl Project {
 /// space (see [`crate::lexer::lex`]).
 /// The built-in `Net` module (see the injection site in [`load_with_entry_source`]).
 /// Connection ids are `Float` (small integers); text carries messages and
-/// error strings. Mirrors F#'s `Functor.Net.NetEvent`.
+/// error strings. Mirrors F#'s `Functor.Net.NetEvent`. `HttpResponse` is the
+/// value handed to an `Effect.httpGet`/`httpPost` tagger: `Response` for a
+/// completed request (any HTTP status), `Failure` for a transport error.
 const NET_MODULE_SRC: &str = "type NetEvent =\n\
      | Connected(id: Float)\n\
      | Message(id: Float, text: String)\n\
      | Disconnected(id: Float)\n\
-     | Error(id: Float, text: String)\n";
+     | Error(id: Float, text: String)\n\
+     type HttpResponse =\n\
+     | Response(status: Float, body: String)\n\
+     | Failure(error: String)\n";
 
 pub struct SourceFile {
     pub path: PathBuf,

--- a/mle/tests/project.rs
+++ b/mle/tests/project.rs
@@ -630,15 +630,16 @@ fn single_file_project_adds_only_the_builtin_net_module() {
     for ty in &plain.types {
         assert!(proj_types.contains(&ty.name.as_str()));
     }
-    // The ONLY additions are the Net module's (canonicalized `Net.NetEvent`).
+    // The ONLY additions are the Net module's (canonicalized `Net.NetEvent`
+    // and `Net.HttpResponse`).
     assert!(
-        proj_types.contains(&"Net.NetEvent"),
+        proj_types.contains(&"Net.NetEvent") && proj_types.contains(&"Net.HttpResponse"),
         "the built-in Net module must be injected: {proj_types:?}"
     );
     assert_eq!(
         proj_types.len(),
-        plain.types.len() + 1,
-        "no types beyond the entry's + Net.NetEvent"
+        plain.types.len() + 2,
+        "no types beyond the entry's + Net.NetEvent + Net.HttpResponse"
     );
 }
 

--- a/runtime/functor-runtime-common/src/mle_prelude.rs
+++ b/runtime/functor-runtime-common/src/mle_prelude.rs
@@ -232,6 +232,19 @@ pub enum EffectTree {
         conn: f64,
         text: String,
     },
+    /// An HTTP request (`Effect.httpGet`/`httpPost`). Unlike `Now`/`Random`
+    /// (same-frame) or `Raycast` (same-frame deferred), the response lands
+    /// FRAMES later: performing it mints a token, queues a
+    /// `NetCommand::HttpRequest`, and registers `tagger` by token
+    /// ([`register_http_tagger`]). When the shell pushes the response
+    /// back, the producer's per-frame pump applies the tagger to a
+    /// `Net.HttpResponse` and folds the message through `update`.
+    Http {
+        method: crate::net::HttpMethod,
+        url: String,
+        body: String,
+        tagger: Value,
+    },
     /// A physics query (docs/physics.md Phase 4). Unlike `Now`/`Random`,
     /// queries are **deferred**: the pre-step drain holds them and the
     /// driver performs them right after the frame's physics step, so the
@@ -806,6 +819,8 @@ const PATHS: &[&str] = &[
     "Sub.connect",
     "Sub.listen",
     "Effect.send",
+    "Effect.httpGet",
+    "Effect.httpPost",
 ];
 
 impl Host for FunctorHost {
@@ -1439,6 +1454,43 @@ Net.NetEvent, got {}",
                 }
                 _ => usage("Effect.send(connId, text)"),
             },
+            // httpGet(url, tagger) / httpPost(url, body, tagger). The tagger is
+            // a function of the Net.HttpResponse, validated callable here so a
+            // typo fails at construction, not frames later when the response
+            // lands. Performing it (drain) mints a token, queues the request,
+            // and registers the tagger by token — see EffectTree::Http.
+            "Effect.httpGet" => match args.as_slice() {
+                [Value::String(url), tagger @ (Value::Closure(_) | Value::Ctor { .. })] => {
+                    Ok(host(MleEffect(EffectTree::Http {
+                        method: crate::net::HttpMethod::Get,
+                        url: url.to_string(),
+                        body: String::new(),
+                        tagger: tagger.clone(),
+                    })))
+                }
+                [Value::String(_), other] => err(format!(
+                    "Effect.httpGet(url, tagger): the tagger must be a function of the \
+Net.HttpResponse, got {}",
+                    other.kind_name()
+                )),
+                _ => usage("Effect.httpGet(url, tagger)"),
+            },
+            "Effect.httpPost" => match args.as_slice() {
+                [Value::String(url), Value::String(body), tagger @ (Value::Closure(_) | Value::Ctor { .. })] => {
+                    Ok(host(MleEffect(EffectTree::Http {
+                        method: crate::net::HttpMethod::Post,
+                        url: url.to_string(),
+                        body: body.to_string(),
+                        tagger: tagger.clone(),
+                    })))
+                }
+                [Value::String(_), Value::String(_), other] => err(format!(
+                    "Effect.httpPost(url, body, tagger): the tagger must be a function of \
+the Net.HttpResponse, got {}",
+                    other.kind_name()
+                )),
+                _ => usage("Effect.httpPost(url, body, tagger)"),
+            },
             "Physics.transformed" => match args.as_slice() {
                 [scene, Value::String(tag)] => {
                     let Some(inner) = scene_of(scene) else {
@@ -1951,6 +2003,56 @@ pub fn net_event_value(kind: NetEventKind, conn: u64, text: &str) -> EffectValue
     }
 }
 
+/// Build the `Net.HttpResponse` value handed to an `Effect.httpGet`/`httpPost`
+/// tagger: `Response(status, body)` for a completed request (any HTTP status),
+/// `Failure(error)` for a transport error. Canonical ctor names from the
+/// built-in `Net` module (see `mle::project`).
+pub fn http_response_value(result: &crate::net::HttpResult) -> Value {
+    let variant = if result.is_ok() {
+        EffectValue::Variant(
+            "Net.Response".into(),
+            vec![
+                EffectValue::Number(result.status as f64),
+                EffectValue::Text(result.body_text()),
+            ],
+        )
+    } else {
+        EffectValue::Variant("Net.Failure".into(), vec![EffectValue::Text(result.error_text())])
+    };
+    variant.to_mle()
+}
+
+thread_local! {
+    /// In-flight `Effect.httpGet`/`httpPost` taggers, keyed by request token —
+    /// the MLE analogue of the F# `net::registry`. Populated when the effect is
+    /// performed (see `EffectTree::Http`); drained by the producer's HTTP
+    /// arrival hook when the response lands. The map is self-draining: the
+    /// shell's dispatch (`net_dispatch::perform_http`) returns EXACTLY ONE
+    /// completion per request — a `Response` for any HTTP status or an `Error`
+    /// for a transport failure — so every registered token is later taken. It
+    /// is bounded by concurrently in-flight requests, and cleared on hot reload
+    /// (an in-flight tagger closes over the OLD session and must not outlive
+    /// it — the same rule the producer applies to deferred queries).
+    static PENDING_HTTP: std::cell::RefCell<std::collections::HashMap<u64, Value>> =
+        std::cell::RefCell::new(std::collections::HashMap::new());
+}
+
+/// Register an HTTP tagger for `token` (see [`PENDING_HTTP`]).
+pub fn register_http_tagger(token: u64, tagger: Value) {
+    PENDING_HTTP.with(|m| m.borrow_mut().insert(token, tagger));
+}
+
+/// Take the tagger registered for a completed request's `token`, if any (a hot
+/// reload clears the map, so a late response can arrive orphaned — dropped).
+pub fn take_http_tagger(token: u64) -> Option<Value> {
+    PENDING_HTTP.with(|m| m.borrow_mut().remove(&token))
+}
+
+/// Drop all in-flight HTTP taggers (called on hot reload).
+pub fn clear_http_taggers() {
+    PENDING_HTTP.with(|m| m.borrow_mut().clear());
+}
+
 #[derive(Clone, Copy)]
 pub enum NetEventKind {
     Connected,
@@ -2138,7 +2240,10 @@ pub fn needs_update(tree: &EffectTree) -> bool {
         EffectTree::None
         | EffectTree::Physics(_)
         | EffectTree::Timeline(_)
-        | EffectTree::Send { .. } => false,
+        | EffectTree::Send { .. }
+        // The request is fire-and-forget; its RESPONSE needs `update`, but
+        // that arrives frames later through the producer's HTTP pump.
+        | EffectTree::Http { .. } => false,
         EffectTree::Now { .. } | EffectTree::Random { .. } | EffectTree::Raycast { .. } => true,
         EffectTree::Batch(items) => items.iter().any(needs_update),
     }
@@ -2256,6 +2361,34 @@ dropping the rest"
                 log.push(EffectRecord {
                     kind: "net.send",
                     value: EffectValue::Text(text),
+                });
+                if log.len() > EFFECT_LOG_CAP {
+                    log.remove(0);
+                }
+                continue;
+            }
+            EffectTree::Http {
+                method,
+                url,
+                body,
+                tagger,
+            } => {
+                // Fire-and-forget request (like Send): mint a token, register
+                // the tagger by it, and queue the HttpRequest for the shell to
+                // perform. The response lands frames later; the producer's HTTP
+                // pump applies the tagger then. Logged for the effect record.
+                let token = crate::net::next_token();
+                register_http_tagger(token, tagger);
+                crate::net::push_command(crate::net::NetCommand::HttpRequest {
+                    token,
+                    method,
+                    url: url.clone(),
+                    headers: Vec::new(),
+                    body: body.into_bytes(),
+                });
+                log.push(EffectRecord {
+                    kind: "net.http",
+                    value: EffectValue::Text(url),
                 });
                 if log.len() > EFFECT_LOG_CAP {
                     log.remove(0);
@@ -3999,6 +4132,98 @@ the game dir"
                 "id {id}: {msg}"
             );
         }
+    }
+
+    #[test]
+    fn http_get_rejects_a_non_function_tagger() {
+        assert!(run_fail("let main = () => Effect.httpGet(\"http://x\", 3.0)")
+            .contains("the tagger must be a function of the Net.HttpResponse"));
+    }
+
+    /// The `http_response_value` builder maps a transport error to `Net.Failure`
+    /// and any completed request (incl. a 404) to `Net.Response`.
+    #[test]
+    fn http_response_value_maps_ok_and_error() {
+        let ok = http_response_value(&crate::net::HttpResult {
+            token: 1,
+            status: 404,
+            body: b"nope".to_vec(),
+            error: None,
+        });
+        assert_eq!(ok.to_string(), "Net.Response(404, \"nope\")");
+        let failed = http_response_value(&crate::net::HttpResult {
+            token: 1,
+            status: 0,
+            body: vec![],
+            error: Some("dns".to_string()),
+        });
+        assert_eq!(failed.to_string(), "Net.Failure(\"dns\")");
+    }
+
+    /// Headless HTTP round trip (roadmap E2, the netdemo primitive), with no
+    /// network — the interpreter analogue of the F# `net_http.rs` test.
+    /// Firing `Effect.httpGet` queues a `NetCommand::HttpRequest` and registers
+    /// the tagger by token; when the response lands (frames later), routing it
+    /// through the tagger → `update` moves the model to `Done(status, body)`.
+    #[test]
+    fn http_request_response_round_trip() {
+        let _ = crate::net::drain_commands(); // clear the shared queue
+        clear_http_taggers();
+        let src = "\
+            type Phase = | Loading | Done(status: Float, body: String) | Failed(text: String)\n\
+            type Model = { phase: Phase }\n\
+            type Msg = | Got(resp: Net.HttpResponse)\n\
+            let init = { phase: Loading }\n\
+            let fetch = Effect.httpGet(\"http://127.0.0.1:9000/hello\", Got)\n\
+            let update = (m: Model, msg: Msg) =>\n\
+              match msg with\n\
+              | Got(resp) =>\n\
+                (match resp with\n\
+                 | Net.Response(status, body) => { m with phase: Done(status, body) }\n\
+                 | Net.Failure(err) => { m with phase: Failed(err) })\n";
+        let project = mle::project::load_single_source("game", src)
+            .unwrap_or_else(|e| panic!("load: {}", e.render()));
+        let session = mle::Session::load(&project.module, &mut FunctorHost)
+            .unwrap_or_else(|f| panic!("session: {}", f.error.message));
+
+        // Perform the fetch effect: queues the request + registers the tagger.
+        let fetch = effect_of(&session.global("fetch").unwrap()).unwrap().0.clone();
+        let mut model = session.global("init").unwrap();
+        let mut log = EffectLog::new();
+        let _ = drain_effects(
+            &session,
+            &mut model,
+            fetch,
+            &mut FakeEffects::new(0.0, vec![]),
+            &mut log,
+            &mut |m| panic!("unexpected report: {m}"),
+        );
+        // One HttpRequest command was queued, carrying the request's token.
+        let token = match crate::net::drain_commands().as_slice() {
+            [crate::net::NetCommand::HttpRequest { token, method, url, .. }] => {
+                assert_eq!(*method, crate::net::HttpMethod::Get);
+                assert_eq!(url, "http://127.0.0.1:9000/hello");
+                *token
+            }
+            other => panic!("expected one HttpRequest, got: {other:?}"),
+        };
+        assert_eq!(log.last().map(|r| r.kind), Some("net.http"));
+
+        // The response lands: route it through the registered tagger → update.
+        let tagger = take_http_tagger(token).expect("a tagger for the token");
+        let resp = http_response_value(&crate::net::HttpResult {
+            token,
+            status: 200,
+            body: b"hello!".to_vec(),
+            error: None,
+        });
+        let msg = session.apply(tagger, vec![resp], "http", &mut FunctorHost).unwrap();
+        let (model, _) =
+            split_model_effect(session.call("update", vec![model, msg], &mut FunctorHost).unwrap());
+        assert_eq!(model.to_string(), "{ phase: Done(200, \"hello!\") }");
+
+        // The token is consumed (a duplicate/late response finds no tagger).
+        assert!(take_http_tagger(token).is_none());
     }
 
     /// Headless server-lifecycle test for the `mle-mpserver` port (roadmap E2),

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -30,10 +30,10 @@
 use std::time::Instant;
 
 use functor_runtime_common::mle_prelude::{
-    contains_effect, deliver_physics_events, drain_effects, frame_value, needs_update,
-    net_conn_subs, net_event_value, perform_deferred_queries, physics_event_taggers,
-    physics_scene_value, split_model_effect, sub_messages_for_frame, view_value, EffectLog,
-    EffectTree, FunctorHost, NetEventKind, RealEffects,
+    clear_http_taggers, contains_effect, deliver_physics_events, drain_effects, frame_value,
+    http_response_value, needs_update, net_conn_subs, net_event_value, perform_deferred_queries,
+    physics_event_taggers, physics_scene_value, split_model_effect, sub_messages_for_frame,
+    take_http_tagger, view_value, EffectLog, EffectTree, FunctorHost, NetEventKind, RealEffects,
 };
 use functor_runtime_common::physics;
 use functor_runtime_common::timetravel::{History, DEFAULT_HISTORY_FRAMES};
@@ -557,6 +557,32 @@ to receive their messages; dropping them"
         }
     }
 
+    /// Route a completed HTTP request to the tagger registered when the request
+    /// fired (frames ago), folding the resulting message through `update`. The
+    /// arrival hook (the shell calls this when net_dispatch completes). An
+    /// orphaned token — a hot reload dropped its tagger while the request was
+    /// in flight — is silently ignored.
+    fn deliver_http_result(&mut self, result: functor_runtime_common::net::HttpResult) {
+        let Some(tagger) = take_http_tagger(result.token) else {
+            return;
+        };
+        let value = http_response_value(&result);
+        let msg = match self
+            .session
+            .apply(tagger, vec![value], "http response", &mut FunctorHost)
+        {
+            Ok(msg) => msg,
+            Err(err) => return self.frame_error("http response", &err),
+        };
+        match self
+            .session
+            .call("update", vec![self.model.clone(), msg], &mut FunctorHost)
+        {
+            Ok(returned) => self.absorb(returned),
+            Err(err) => self.frame_error("update", &err),
+        }
+    }
+
     fn pump_subscriptions(&mut self, tts: f64) {
         // Advance the window even without subscriptions (or on frame one),
         // so a hot reload that ADDS subscriptions starts from a sane edge.
@@ -632,11 +658,12 @@ to receive their messages; dropping them"
             self.last_view = View::Empty;
         }
         self.last_error = None;
-        // A deferred query holds a tagger — a closure into the OLD session;
-        // drop them rather than let them dangle (the same rule the F#
-        // executor applies to in-flight HTTP taggers).
+        // A deferred query or in-flight HTTP request holds a tagger — a closure
+        // into the OLD session; drop them rather than let them dangle. A late
+        // HTTP response for a dropped token arrives orphaned and is ignored.
         self.deferred_queries.clear();
         self.pending_events.clear();
+        clear_http_taggers();
         // Reload is a model-history BOUNDARY: the retained snapshots can hold
         // closures bound to the old module, so — unlike the live model, which
         // `rebind_value` migrates above — they can't safely cross a reload.
@@ -819,6 +846,7 @@ impl Game for MleGame {
         // reload discipline); between-frame callers have these empty already.
         self.deferred_queries.clear();
         self.pending_events.clear();
+        clear_http_taggers();
         for warning in &warnings {
             self.report_once(format!("[mle] {warning}"));
         }
@@ -1028,10 +1056,26 @@ impl Game for MleGame {
     }
 
     fn net_drain_commands(&self) -> String {
-        "[]".to_string()
+        // HttpRequest commands (Effect.httpGet/httpPost), performed by the
+        // shell's net_dispatch; the response returns via net_push_http_*.
+        functor_runtime_common::net::drain_commands_json()
     }
-    fn net_push_http_response(&mut self, _token: i32, _status: i32, _body: String) {}
-    fn net_push_http_error(&mut self, _token: i32, _message: String) {}
+    fn net_push_http_response(&mut self, token: i32, status: i32, body: String) {
+        self.deliver_http_result(functor_runtime_common::net::HttpResult {
+            token: token as u64,
+            status: status as u16,
+            body: body.into_bytes(),
+            error: None,
+        });
+    }
+    fn net_push_http_error(&mut self, token: i32, message: String) {
+        self.deliver_http_result(functor_runtime_common::net::HttpResult {
+            token: token as u64,
+            status: 0,
+            body: Vec::new(),
+            error: Some(message),
+        });
+    }
     fn audio_drain_commands(&self) -> String {
         "[]".to_string()
     }

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -311,13 +311,6 @@ fn dispatch_net_commands(game: &dyn GameProducer) {
     }
 }
 
-// NOTE: completions push through a fresh stateless `WasmGame` (the F# game
-// module holds the real state behind the wasm_bindgen externs). The MLE
-// producer (`mle_game::MleWebGame`) is NOT reachable from here — safe today
-// because MLE has no effects (its drains return "[]", so nothing ever needs
-// completing), but when MLE grows effects (Track B6/C4b-2) these sites need a
-// shared handle to the live producer or they'll throw `game is not defined`
-// on the MLE page.
 async fn perform_and_push(cmd: NetCommand) {
     let NetCommand::HttpRequest {
         token,
@@ -327,11 +320,24 @@ async fn perform_and_push(cmd: NetCommand) {
         body,
     } = cmd;
     let token = token as i32;
-    // WasmGame is stateless, so the async completion pushes through its own
-    // instance (see the WasmGame doc).
-    match perform_fetch(method, &url, &headers, &body).await {
-        Ok((status, text)) => WasmGame.net_push_http_response(token, status, text),
-        Err(message) => WasmGame.net_push_http_error(token, message),
+    let result = perform_fetch(method, &url, &headers, &body).await;
+    // Route the completion to the LIVE producer via the shared GAME handle —
+    // the F# page's WasmGame (backed by the wasm_bindgen externs) OR the MLE
+    // page's MleWebGame (which folds the response through `update`). Pushing
+    // through a fresh `WasmGame` instead would throw `game is not defined` on
+    // the MLE page (no JS game module). This runs as a fetch microtask, never
+    // mid-frame, so the borrow can't collide with the frame loop (as with
+    // `mle_set_source`).
+    let Some(game) = GAME.with(|g| g.borrow().clone()) else {
+        return;
+    };
+    let Ok(mut game) = game.try_borrow_mut() else {
+        web_sys::console::error_1(&"[net] http completion arrived mid-frame; dropped".into());
+        return;
+    };
+    match result {
+        Ok((status, text)) => game.net_push_http_response(token, status, text),
+        Err(message) => game.net_push_http_error(token, message),
     }
 }
 

--- a/runtime/functor-runtime-web/src/mle_game.rs
+++ b/runtime/functor-runtime-web/src/mle_game.rs
@@ -22,10 +22,10 @@
 use std::cell::RefCell;
 
 use functor_runtime_common::mle_prelude::{
-    contains_effect, deliver_physics_events, drain_effects, frame_value, needs_update,
-    net_conn_subs, net_event_value, perform_deferred_queries, physics_event_taggers,
-    physics_scene_value, split_model_effect, sub_messages_for_frame, view_value, EffectLog,
-    EffectTree, FunctorHost, NetEventKind, RealEffects,
+    clear_http_taggers, contains_effect, deliver_physics_events, drain_effects, frame_value,
+    http_response_value, needs_update, net_conn_subs, net_event_value, perform_deferred_queries,
+    physics_event_taggers, physics_scene_value, split_model_effect, sub_messages_for_frame,
+    take_http_tagger, view_value, EffectLog, EffectTree, FunctorHost, NetEventKind, RealEffects,
 };
 use functor_runtime_common::physics;
 use functor_runtime_common::protocol::GameProducer;
@@ -281,10 +281,11 @@ impl MleWebGame {
         if !self.has_physics {
             physics::remove_world(physics::DEFAULT_WORLD);
         }
-        // A deferred query holds a tagger — a closure into the OLD session;
-        // drop them rather than let them dangle.
+        // A deferred query or in-flight HTTP request holds a tagger — a closure
+        // into the OLD session; drop them rather than let them dangle.
         self.deferred_queries.clear();
         self.pending_events.clear();
+        clear_http_taggers();
         // Reload is a model-history BOUNDARY (see the desktop producer): the
         // retained snapshots can hold old-module closures, so they can't cross
         // a reload; `rendered_frame` stays monotonic so recording resumes
@@ -422,6 +423,30 @@ to receive their messages; dropping them"
         {
             Ok(msg) => msg,
             Err(err) => return self.frame_error("net event", &err),
+        };
+        match self
+            .session
+            .call("update", vec![self.model.clone(), msg], &mut FunctorHost)
+        {
+            Ok(returned) => self.absorb(returned),
+            Err(err) => self.frame_error("update", &err),
+        }
+    }
+
+    /// Route a completed HTTP request to the tagger registered when the request
+    /// fired (frames ago), folding the resulting message through `update`. An
+    /// orphaned token — a reload dropped its tagger mid-flight — is ignored.
+    fn deliver_http_result(&mut self, result: functor_runtime_common::net::HttpResult) {
+        let Some(tagger) = take_http_tagger(result.token) else {
+            return;
+        };
+        let value = http_response_value(&result);
+        let msg = match self
+            .session
+            .apply(tagger, vec![value], "http response", &mut FunctorHost)
+        {
+            Ok(msg) => msg,
+            Err(err) => return self.frame_error("http response", &err),
         };
         match self
             .session
@@ -731,13 +756,27 @@ impl GameProducer for MleWebGame {
         self.model.to_string()
     }
 
-    // MLE has no effects yet (docs/mle.md Track B): nothing to drain, nothing
-    // pushed back.
     fn net_drain_commands(&self) -> String {
-        "[]".to_string()
+        // HttpRequest commands (Effect.httpGet/httpPost); the page's fetch host
+        // performs them and returns the response via net_push_http_*.
+        functor_runtime_common::net::drain_commands_json()
     }
-    fn net_push_http_response(&mut self, _token: i32, _status: i32, _body: String) {}
-    fn net_push_http_error(&mut self, _token: i32, _message: String) {}
+    fn net_push_http_response(&mut self, token: i32, status: i32, body: String) {
+        self.deliver_http_result(functor_runtime_common::net::HttpResult {
+            token: token as u64,
+            status: status as u16,
+            body: body.into_bytes(),
+            error: None,
+        });
+    }
+    fn net_push_http_error(&mut self, token: i32, message: String) {
+        self.deliver_http_result(functor_runtime_common::net::HttpResult {
+            token: token as u64,
+            status: 0,
+            body: Vec::new(),
+            error: Some(message),
+        });
+    }
     fn audio_drain_commands(&self) -> String {
         "[]".to_string()
     }


### PR DESCRIPTION
## What

Adds async **HTTP** to MLE (roadmap **E2**, `docs/mle.md`) — the last networking gap — so `examples/netdemo` can port. This is the primitive originally flagged in the porting inventory.

The design challenge: unlike `Effect.now`/`random` (same-frame) or `Physics.raycast` (same-frame deferred), an HTTP response lands **frames later**, so the tagger is stored by token and applied on a future frame (mirroring the `route_conn_event` async-net pattern).

## Surface

- **`Net.HttpResponse`** — a new built-in `Net`-module ADT `| Response(status, body) | Failure(error)` (a completed request of any HTTP status vs a transport error), injected alongside `Net.NetEvent`.
- **`Effect.httpGet(url, tagger)` / `httpPost(url, body, tagger)`** → a new `EffectTree::Http` (tagger validated callable at construction).

## Plumbing

- Performing `Http` (in the drain) mints a token (`net::next_token`), queues a `NetCommand::HttpRequest`, and registers the MLE tagger in a thread-local `PENDING_HTTP` map. It's **self-draining**: the shell's `net_dispatch::perform_http` returns exactly one completion per request; the map is cleared on hot reload / rewind (an in-flight tagger closes over the old session).
- Both producers: `net_drain_commands` forwards the request queue (performed by the existing producer-agnostic `net_dispatch`); `net_push_http_response`/`error` route the result through `http_response_value` → the tagger → `update` → `absorb`.

## Port

`examples/mle-netdemo` fires the request **once on the first frame** — MLE's `init` is a plain value with no F# `GameBuilder.init` startup-effect seed — and reflects the phase into the model (`Loading` → `Done(status, body)` / `Failed(error)`), inspectable via `/state`.

## Verification

- **3 new prelude tests**, incl. `http_request_response_round_trip` (fire → request queued with token → tagger routes response → model `Done(200, "hello!")`), the ok/failure mapping, and tagger validation.
- **Real headless end-to-end**: ran `mle-netdemo` headless against a local HTTP server; the model reached `Done(200, "hello from netdemo")` via `/state` (real `reqwest` dispatch → tagger → update).
- `functor -d examples/mle-netdemo build` clean; `functor_runtime_common` (193) + `mle` (299) green; web wasm compiles.

## Review

Cross-engine `/xreview`. Fixed the one **High** finding: the web runtime routed HTTP completions through a dead stateless `WasmGame` (the MLE page has no JS `game` object, so responses never reached `MleWebGame` — a limitation the code's own comment predicted). Now routes through the live `GAME` handle, correct for both the F# and MLE pages. Documented the tagger-map lifecycle guarantee (Medium). Low findings (deferred-error diagnostic, `deliver_http_result` duplication matching the existing `deliver_net_event` house style) noted as acceptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)