### PR TITLE
feat(mle): audio API — one-shots + soundScape (E2)

### DIFF
--- a/.claude/skills/mle-language/SKILL.md
+++ b/.claude/skills/mle-language/SKILL.md
@@ -318,6 +318,17 @@ Sub.connect(url, tagger) / Sub.listen(addr, tagger)        // persistent connect
 Effect.send(connId, text)                                  // send on an open connection
 Effect.none() / Effect.batch([fx, …])                      //   random: [0,1); now: epoch secs
 
+Effect.play(sound)                                         // one-shot: fire-and-forget,
+Effect.playAt(sound, x, y, z)                              //   non-spatial / positioned
+Effect.playThen(sound, msg)                                // one-shot; delivers msg (a VALUE,
+                                                           //   not a tagger) through `update`
+                                                           //   when the sound FINISHES
+AudioSource.ambient(key, sound)                            // soundScape voice: non-spatial bed
+AudioSource.at(key, sound, x, y, z)                        //   / positioned emitter (key =
+                                                           //   cross-frame identity)
+source |> AudioSource.gain(g)                              // source-first: linear gain (1.0=full)
+AudioScene.create([source, …]) / AudioScene.empty()       // what `soundScape` returns
+
 Physics.box(w, h, d) / sphere(r) / capsule(halfH, r)       // -> Shape (box = FULL extents)
 Physics.dynamic("tag", shape)                              // simulated body
 Physics.kinematic("tag", shape) / Physics.fixed("tag", shape)
@@ -413,6 +424,9 @@ let update = (model, msg) => model'         // OPTIONAL; msgs are ADT variants
 let subscriptions = (model) => Sub.every(Time.seconds(1.0), Beat)
                                             // OPTIONAL, but requires update
 let physics = (model) => Physics.scene(0.0, -9.81, 0.0, [body, …])  // OPTIONAL
+let soundScape = (model) => AudioScene.create([source, …])  // OPTIONAL; continuous
+                                            // looping voices, reconciled by key each
+                                            // frame (needs no `update`)
 ```
 
 Subscription timers are **stateless**: `Sub.every` fires when an integer

--- a/runtime/functor-runtime-common/src/audio.rs
+++ b/runtime/functor-runtime-common/src/audio.rs
@@ -385,17 +385,20 @@ pub fn reconcile(live: &HashMap<String, AudioSource>, desired: &AudioScene) -> V
     updates
 }
 
+/// Serializes tests that touch the process-global [`OUTBOUND`] queue (here and
+/// in `mle_prelude`), so they don't drain each other's commands under CI's
+/// parallel scheduling. `unwrap_or_else(into_inner)` shrugs off a poisoned lock
+/// from an unrelated panicking test.
+#[cfg(test)]
+pub(crate) static OUTBOUND_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    // One test, not two: `push_command`/`drain_commands` share the process-global
-    // OUTBOUND queue, so two tests touching it run in parallel and can drain each
-    // other's command (a flaky failure that showed up under CI's scheduling).
-    // Keeping it to a single test makes the queue access sequential. (The
-    // completion tests below use thread-local state, so they stand alone.)
     #[test]
     fn push_drain_round_trips_and_serializes_to_json() {
+        let _guard = OUTBOUND_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let _ = drain_commands(); // clear anything a prior run left
 
         push_command(AudioCommand::play_one_shot("gunshot.wav".to_string()));

--- a/runtime/functor-runtime-common/src/mle_prelude.rs
+++ b/runtime/functor-runtime-common/src/mle_prelude.rs
@@ -256,6 +256,26 @@ pub enum EffectTree {
         max_dist: f32,
         tagger: Value,
     },
+    /// A fire-and-forget audio one-shot (`Effect.play`/`playAt`). Tagger-less
+    /// like a physics command: performing it pushes an `AudioCommand::PlayOneShot`
+    /// on the shell's audio queue. `position` is `Some` for a spatialized
+    /// one-shot (`playAt`), `None` for a non-spatial bed (`play`).
+    PlayAudio {
+        sound: String,
+        position: Option<[f32; 3]>,
+    },
+    /// A one-shot whose completion is reported back frames later
+    /// (`Effect.playThen`). Like [`Http`], the request is fire-and-forget but
+    /// the RESULT needs `update`: performing it mints a token, registers
+    /// `message` by it ([`register_audio_completion`]), and queues a tokened
+    /// one-shot. When the shell reports the sound finished
+    /// (`audio_push_finished`), the producer delivers `message` VERBATIM
+    /// through `update` — unlike `Http`, there is no tagger to apply (F#'s
+    /// `playThen` takes a message value, not a function).
+    PlayAudioThen {
+        sound: String,
+        message: Value,
+    },
 }
 
 pub struct MleEffect(pub EffectTree);
@@ -677,6 +697,32 @@ impl HostData for MleLight {
     }
 }
 
+/// A continuous soundscape voice (`AudioSource.ambient`/`at`) as an opaque MLE
+/// value.
+pub struct MleAudioSource(pub crate::audio::AudioSource);
+
+/// The set of voices an MLE `soundScape` returns (`AudioScene.create`/`empty`)
+/// as an opaque MLE value.
+pub struct MleAudioScene(pub crate::audio::AudioScene);
+
+impl HostData for MleAudioSource {
+    fn type_name(&self) -> &'static str {
+        "AudioSource"
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+impl HostData for MleAudioScene {
+    fn type_name(&self) -> &'static str {
+        "AudioScene"
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
 impl HostData for MleScene {
     fn type_name(&self) -> &'static str {
         "Scene"
@@ -824,6 +870,14 @@ const PATHS: &[&str] = &[
     "Effect.send",
     "Effect.httpGet",
     "Effect.httpPost",
+    "Effect.play",
+    "Effect.playAt",
+    "Effect.playThen",
+    "AudioSource.ambient",
+    "AudioSource.at",
+    "AudioSource.gain",
+    "AudioScene.create",
+    "AudioScene.empty",
 ];
 
 impl Host for FunctorHost {
@@ -1559,6 +1613,88 @@ the Net.HttpResponse, got {}",
                 )),
                 _ => usage("Effect.httpPost(url, body, tagger)"),
             },
+            // Fire-and-forget audio one-shots (the dual of `soundScape`).
+            // `play` is non-spatial; `playAt` is positioned. Both queue an
+            // AudioCommand on drain — see EffectTree::PlayAudio.
+            "Effect.play" => match args.as_slice() {
+                [Value::String(sound)] => Ok(host(MleEffect(EffectTree::PlayAudio {
+                    sound: sound.to_string(),
+                    position: None,
+                }))),
+                _ => usage("Effect.play(sound)"),
+            },
+            "Effect.playAt" => match args.as_slice() {
+                [Value::String(sound), x, y, z] => Ok(host(MleEffect(EffectTree::PlayAudio {
+                    sound: sound.to_string(),
+                    position: Some([
+                        num(x, span)? as f32,
+                        num(y, span)? as f32,
+                        num(z, span)? as f32,
+                    ]),
+                }))),
+                _ => usage("Effect.playAt(sound, x, y, z)"),
+            },
+            // Play once and deliver `msg` (a message VALUE, not a tagger) when
+            // the sound finishes — see EffectTree::PlayAudioThen. Any value is a
+            // valid message, so there is nothing to validate here.
+            "Effect.playThen" => match args.as_slice() {
+                [Value::String(sound), msg] => Ok(host(MleEffect(EffectTree::PlayAudioThen {
+                    sound: sound.to_string(),
+                    message: msg.clone(),
+                }))),
+                _ => usage("Effect.playThen(sound, msg)"),
+            },
+            // Soundscape voices (the continuous, reconciled half of audio).
+            // `ambient` is a non-spatial bed; `at` is positioned. Keyed for
+            // cross-frame identity so the shell keeps a live voice playing.
+            "AudioSource.ambient" => match args.as_slice() {
+                [Value::String(key), Value::String(sound)] => Ok(host(MleAudioSource(
+                    crate::audio::AudioSource::ambient(key.to_string(), sound.to_string()),
+                ))),
+                _ => usage("AudioSource.ambient(key, sound)"),
+            },
+            "AudioSource.at" => match args.as_slice() {
+                [Value::String(key), Value::String(sound), x, y, z] => {
+                    Ok(host(MleAudioSource(crate::audio::AudioSource::at(
+                        key.to_string(),
+                        sound.to_string(),
+                        num(x, span)? as f32,
+                        num(y, span)? as f32,
+                        num(z, span)? as f32,
+                    ))))
+                }
+                _ => usage("AudioSource.at(key, sound, x, y, z)"),
+            },
+            // Source-first so it pipes: `AudioSource.ambient(…) |> AudioSource.gain(0.35)`.
+            "AudioSource.gain" => match args.as_slice() {
+                [source, g] => match audio_source_of(source) {
+                    Some(src) => Ok(host(MleAudioSource(src.clone().with_gain(num(g, span)? as f32)))),
+                    None => usage("AudioSource.gain(source, gain)"),
+                },
+                _ => usage("AudioSource.gain(source, gain)"),
+            },
+            "AudioScene.create" => match args.as_slice() {
+                [Value::List(items)] => {
+                    let mut sources = Vec::with_capacity(items.len());
+                    for item in items.iter() {
+                        match audio_source_of(item) {
+                            Some(src) => sources.push(src.clone()),
+                            None => {
+                                return err(format!(
+                                    "AudioScene.create items must be AudioSources, got {}",
+                                    item.kind_name()
+                                ))
+                            }
+                        }
+                    }
+                    Ok(host(MleAudioScene(crate::audio::AudioScene::new(sources))))
+                }
+                _ => usage("AudioScene.create([source, …])"),
+            },
+            "AudioScene.empty" => match args.as_slice() {
+                [] => Ok(host(MleAudioScene(crate::audio::AudioScene::default()))),
+                _ => usage("AudioScene.empty()"),
+            },
             "Physics.transformed" => match args.as_slice() {
                 [scene, Value::String(tag)] => {
                     let Some(inner) = scene_of(scene) else {
@@ -2121,6 +2257,58 @@ pub fn clear_http_taggers() {
     PENDING_HTTP.with(|m| m.borrow_mut().clear());
 }
 
+thread_local! {
+    /// In-flight `Effect.playThen` completion MESSAGES, keyed by the one-shot's
+    /// token — the audio analogue of [`PENDING_HTTP`]. Populated when the effect
+    /// is performed (see `EffectTree::PlayAudioThen`); drained by the producer's
+    /// audio-finished hook when the sound ends (`audio_push_finished`). Unlike
+    /// the HTTP map this holds a plain message VALUE, delivered verbatim (F#'s
+    /// `playThen` takes a message, not a tagger). Bounded by the sounds in
+    /// flight, and cleared on hot reload (a stored message may close over the
+    /// OLD session — the same rule the producer applies to HTTP taggers).
+    static PENDING_AUDIO: std::cell::RefCell<std::collections::HashMap<u64, Value>> =
+        std::cell::RefCell::new(std::collections::HashMap::new());
+}
+
+/// Cap on in-flight `playThen` completion messages. Unlike [`PENDING_HTTP`]
+/// — whose shell dispatch returns EXACTLY ONE completion per token, so the map
+/// self-drains — an audio finish is BEST-EFFORT: a sound that never starts (no
+/// device, decode failure, a headless run that drops the command), or a backend
+/// that does not report finishes (wasm today), leaves its message un-taken. This
+/// bound keeps a game that fires `playThen` in a loop from growing the map
+/// without limit; on overflow the OLDEST pending message (lowest token) is
+/// evicted — its completion, if it ever arrives, is then dropped like a
+/// hot-reloaded one.
+const PENDING_AUDIO_CAP: usize = 4096;
+
+/// Register a `playThen` completion message for `token` (see [`PENDING_AUDIO`]).
+pub fn register_audio_completion(token: u64, message: Value) {
+    PENDING_AUDIO.with(|m| {
+        let mut map = m.borrow_mut();
+        map.insert(token, message);
+        // Best-effort finishes mean this map is not self-draining; evict the
+        // oldest entry rather than grow unbounded (see PENDING_AUDIO_CAP).
+        while map.len() > PENDING_AUDIO_CAP {
+            if let Some(oldest) = map.keys().copied().min() {
+                map.remove(&oldest);
+            } else {
+                break;
+            }
+        }
+    });
+}
+
+/// Take the completion message for a finished one-shot's `token`, if any (a hot
+/// reload clears the map, so a late finish can arrive orphaned — dropped).
+pub fn take_audio_completion(token: u64) -> Option<Value> {
+    PENDING_AUDIO.with(|m| m.borrow_mut().remove(&token))
+}
+
+/// Drop all in-flight `playThen` completion messages (called on hot reload).
+pub fn clear_audio_completions() {
+    PENDING_AUDIO.with(|m| m.borrow_mut().clear());
+}
+
 #[derive(Clone, Copy)]
 pub enum NetEventKind {
     Connected,
@@ -2311,7 +2499,12 @@ pub fn needs_update(tree: &EffectTree) -> bool {
         | EffectTree::Send { .. }
         // The request is fire-and-forget; its RESPONSE needs `update`, but
         // that arrives frames later through the producer's HTTP pump.
-        | EffectTree::Http { .. } => false,
+        | EffectTree::Http { .. }
+        // Audio one-shots are fire-and-forget too. `playThen`'s completion
+        // needs `update`, but arrives frames later via the audio-finished
+        // hook — the same shape as Http.
+        | EffectTree::PlayAudio { .. }
+        | EffectTree::PlayAudioThen { .. } => false,
         EffectTree::Now { .. } | EffectTree::Random { .. } | EffectTree::Raycast { .. } => true,
         EffectTree::Batch(items) => items.iter().any(needs_update),
     }
@@ -2463,6 +2656,45 @@ dropping the rest"
                 }
                 continue;
             }
+            EffectTree::PlayAudio { sound, position } => {
+                // Fire-and-forget one-shot: push an AudioCommand on the shell's
+                // audio queue (drained via audio_drain_commands). No token —
+                // nothing folds back through update.
+                crate::audio::push_command(crate::audio::AudioCommand::PlayOneShot {
+                    token: None,
+                    sound: sound.clone(),
+                    gain: 1.0,
+                    position,
+                });
+                log.push(EffectRecord {
+                    kind: "audio.play",
+                    value: EffectValue::Text(sound),
+                });
+                if log.len() > EFFECT_LOG_CAP {
+                    log.remove(0);
+                }
+                continue;
+            }
+            EffectTree::PlayAudioThen { sound, message } => {
+                // Fire-and-forget request (like Http): mint a token, register
+                // the completion MESSAGE by it, and queue a tokened one-shot.
+                // The finish lands frames later; the producer's audio-finished
+                // hook delivers the message then. Logged for the effect record.
+                let token = crate::audio::next_token();
+                register_audio_completion(token, message);
+                crate::audio::push_command(crate::audio::AudioCommand::play_one_shot_token(
+                    token,
+                    sound.clone(),
+                ));
+                log.push(EffectRecord {
+                    kind: "audio.playThen",
+                    value: EffectValue::Text(sound),
+                });
+                if log.len() > EFFECT_LOG_CAP {
+                    log.remove(0);
+                }
+                continue;
+            }
             EffectTree::Raycast {
                 origin,
                 dir,
@@ -2530,6 +2762,22 @@ fn light_of(value: &Value) -> Option<&Light> {
 fn scene_of(value: &Value) -> Option<&Scene3D> {
     match value {
         Value::HostData(data) => data.as_any().downcast_ref::<MleScene>().map(|s| &s.0),
+        _ => None,
+    }
+}
+
+fn audio_source_of(value: &Value) -> Option<&crate::audio::AudioSource> {
+    match value {
+        Value::HostData(data) => data.as_any().downcast_ref::<MleAudioSource>().map(|s| &s.0),
+        _ => None,
+    }
+}
+
+/// Extract the [`crate::audio::AudioScene`] from an MLE value (a
+/// `soundScape` return), for the shells' soundscape reconcile.
+pub fn audio_scene_of(value: &Value) -> Option<&crate::audio::AudioScene> {
+    match value {
+        Value::HostData(data) => data.as_any().downcast_ref::<MleAudioScene>().map(|s| &s.0),
         _ => None,
     }
 }
@@ -4340,6 +4588,181 @@ the game dir"
 
         // The token is consumed (a duplicate/late response finds no tagger).
         assert!(take_http_tagger(token).is_none());
+    }
+
+    // --- audio (roadmap E2): one-shots + soundScape ---
+
+    /// `Effect.play(sound)` queues a non-spatial `PlayOneShot` AudioCommand
+    /// (fire-and-forget, no token), and `Effect.playAt` sets `position`.
+    #[test]
+    fn play_and_play_at_queue_one_shot_commands() {
+        let _guard = crate::audio::OUTBOUND_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let _ = crate::audio::drain_commands(); // clear the shared queue
+        let src = "\
+            let init = 0.0\n\
+            let shoot = Effect.play(\"gunshot.wav\")\n\
+            let blast = Effect.playAt(\"explosion.wav\", 5.0, 0.5, -2.0)\n";
+        let project = mle::project::load_single_source("game", src)
+            .unwrap_or_else(|e| panic!("load: {}", e.render()));
+        let session = mle::Session::load(&project.module, &mut FunctorHost)
+            .unwrap_or_else(|f| panic!("session: {}", f.error.message));
+        let mut model = session.global("init").unwrap();
+        let mut log = EffectLog::new();
+
+        let shoot = effect_of(&session.global("shoot").unwrap()).unwrap().0.clone();
+        let _ = drain_effects(
+            &session,
+            &mut model,
+            shoot,
+            &mut FakeEffects::new(0.0, vec![]),
+            &mut log,
+            &mut |m| panic!("unexpected report: {m}"),
+        );
+        assert_eq!(log.last().map(|r| r.kind), Some("audio.play"));
+
+        let blast = effect_of(&session.global("blast").unwrap()).unwrap().0.clone();
+        let _ = drain_effects(
+            &session,
+            &mut model,
+            blast,
+            &mut FakeEffects::new(0.0, vec![]),
+            &mut log,
+            &mut |m| panic!("unexpected report: {m}"),
+        );
+
+        assert_eq!(
+            crate::audio::drain_commands(),
+            vec![
+                crate::audio::AudioCommand::PlayOneShot {
+                    token: None,
+                    sound: "gunshot.wav".to_string(),
+                    gain: 1.0,
+                    position: None,
+                },
+                crate::audio::AudioCommand::PlayOneShot {
+                    token: None,
+                    sound: "explosion.wav".to_string(),
+                    gain: 1.0,
+                    position: Some([5.0, 0.5, -2.0]),
+                },
+            ]
+        );
+    }
+
+    /// `Effect.playThen(sound, msg)` mints a token, queues a tokened one-shot,
+    /// and registers the completion MESSAGE by that token; when the sound
+    /// finishes, taking the message and folding it through `update` moves the
+    /// model — the message is delivered verbatim (no tagger to apply).
+    #[test]
+    fn play_then_registers_message_and_completes_through_update() {
+        let _guard = crate::audio::OUTBOUND_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let _ = crate::audio::drain_commands(); // clear the shared queue
+        clear_audio_completions();
+        let src = "\
+            type Model = | Playing | Finished\n\
+            let init = Playing\n\
+            let ping = Effect.playThen(\"chime.wav\", Finished)\n\
+            let update = (m: Model, msg: Model) => msg\n";
+        let project = mle::project::load_single_source("game", src)
+            .unwrap_or_else(|e| panic!("load: {}", e.render()));
+        let session = mle::Session::load(&project.module, &mut FunctorHost)
+            .unwrap_or_else(|f| panic!("session: {}", f.error.message));
+        let mut model = session.global("init").unwrap();
+        let mut log = EffectLog::new();
+
+        let ping = effect_of(&session.global("ping").unwrap()).unwrap().0.clone();
+        let _ = drain_effects(
+            &session,
+            &mut model,
+            ping,
+            &mut FakeEffects::new(0.0, vec![]),
+            &mut log,
+            &mut |m| panic!("unexpected report: {m}"),
+        );
+        assert_eq!(log.last().map(|r| r.kind), Some("audio.playThen"));
+
+        // One tokened one-shot was queued.
+        let token = match crate::audio::drain_commands().as_slice() {
+            [crate::audio::AudioCommand::PlayOneShot { token: Some(t), sound, .. }] => {
+                assert_eq!(sound, "chime.wav");
+                *t
+            }
+            other => panic!("expected one tokened PlayOneShot, got: {other:?}"),
+        };
+
+        // The sound finishes: take the registered message and fold it through
+        // `update` (delivered verbatim — no tagger).
+        let message = take_audio_completion(token).expect("a message for the token");
+        let (model, _) = split_model_effect(
+            session
+                .call("update", vec![model, message], &mut FunctorHost)
+                .unwrap(),
+        );
+        assert_eq!(model.to_string(), "Finished");
+
+        // The token is consumed (a duplicate/late finish finds no message).
+        assert!(take_audio_completion(token).is_none());
+    }
+
+    /// `PENDING_AUDIO` is bounded: because audio finishes are best-effort (a
+    /// sound may never start or report), the completion map is NOT self-draining
+    /// like `PENDING_HTTP`. Registering past the cap evicts the oldest (lowest
+    /// token), so a game that fires `playThen` in a loop can't grow it without
+    /// limit.
+    #[test]
+    fn pending_audio_completions_are_bounded() {
+        clear_audio_completions();
+        // Fill past the cap; oldest tokens should be evicted.
+        for token in 1..=(PENDING_AUDIO_CAP as u64 + 10) {
+            register_audio_completion(token, Value::Number(token as f64));
+        }
+        // The 10 oldest are gone; the map holds exactly the cap.
+        assert!(take_audio_completion(1).is_none());
+        assert!(take_audio_completion(10).is_none());
+        // A recent token survives.
+        assert!(take_audio_completion(PENDING_AUDIO_CAP as u64 + 10).is_some());
+        clear_audio_completions();
+    }
+
+    /// A `soundScape` returning a two-voice `AudioScene` (an ambient bed with a
+    /// piped gain + a positioned emitter) serializes to JSON carrying both keys
+    /// and the gain — exactly what the shell reconciles.
+    #[test]
+    fn sound_scape_serializes_to_reconcilable_json() {
+        let src = "\
+            let init = 0.0\n\
+            let soundScape = (m) =>\n\
+              AudioScene.create([\n\
+                AudioSource.ambient(\"wind\", \"wind-loop.wav\") |> AudioSource.gain(0.35),\n\
+                AudioSource.at(\"fountain\", \"water.wav\", 5.0, 0.5, 0.0)\n\
+              ])\n";
+        let project = mle::project::load_single_source("game", src)
+            .unwrap_or_else(|e| panic!("load: {}", e.render()));
+        let session = mle::Session::load(&project.module, &mut FunctorHost)
+            .unwrap_or_else(|f| panic!("session: {}", f.error.message));
+        let model = session.global("init").unwrap();
+
+        let value = session
+            .call("soundScape", vec![model], &mut FunctorHost)
+            .unwrap();
+        let scene = audio_scene_of(&value).expect("soundScape must return an AudioScene");
+        let json = crate::audio::scene_to_json(scene);
+
+        // Round-trips through the wire form the shell deserializes.
+        let back: crate::audio::AudioScene = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.sources.len(), 2);
+        let wind = &back.sources[0];
+        assert_eq!(wind.key, "wind");
+        assert_eq!(wind.sound, "wind-loop.wav");
+        assert!((wind.gain - 0.35).abs() < 1e-6);
+        assert_eq!(wind.position, None);
+        let fountain = &back.sources[1];
+        assert_eq!(fountain.key, "fountain");
+        assert_eq!(fountain.position, Some([5.0, 0.5, 0.0]));
     }
 
     /// Headless server-lifecycle test for the `mle-mpserver` port (roadmap E2),

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -30,9 +30,10 @@
 use std::time::Instant;
 
 use functor_runtime_common::mle_prelude::{
-    clear_http_taggers, contains_effect, deliver_physics_events, drain_effects, frame_value,
-    http_response_value, needs_update, net_conn_subs, net_event_value, perform_deferred_queries,
-    physics_event_taggers, physics_scene_value, split_model_effect, sub_messages_for_frame,
+    audio_scene_of, clear_audio_completions, clear_http_taggers, contains_effect,
+    deliver_physics_events, drain_effects, frame_value, http_response_value, needs_update,
+    net_conn_subs, net_event_value, perform_deferred_queries, physics_event_taggers,
+    physics_scene_value, split_model_effect, sub_messages_for_frame, take_audio_completion,
     take_http_tagger, view_value, EffectLog, EffectTree, FunctorHost, NetEventKind, RealEffects,
 };
 use functor_runtime_common::physics;
@@ -76,6 +77,10 @@ pub struct MleGame {
     /// time-grid semantics of `Sub.every` do the rest.
     prev_tts: Option<f64>,
     has_physics: bool,
+    /// The game defines the optional `soundScape` entry point
+    /// (`soundScape(model) -> AudioScene`, the continuous-audio hook). Absent =
+    /// silence; unlike `subscriptions` it needs no `update`.
+    has_soundscape: bool,
     /// The game defines the optional `ui` entry point (`ui(model) -> View`,
     /// the 2D HUD hook).
     has_ui: bool,
@@ -84,6 +89,11 @@ pub struct MleGame {
     /// keeps the last good view (the `last_frame` rule); a reload that drops
     /// the hook clears it.
     last_view: View,
+    /// The last serialized soundscape (`soundScape model` → JSON), cached
+    /// because `audio_scene_json` is a `&self` accessor — evaluated beside
+    /// `draw` each frame so errors can `&mut`-dedupe. A bad frame keeps the
+    /// last good scene; a reload that drops the hook resets it to silence.
+    last_soundscape_json: String,
     /// Performs `Effect.*` commands — the real world in the runner; the
     /// drain logic itself is `mle_prelude::drain_effects` (tested there
     /// with fake/replay runners).
@@ -163,6 +173,7 @@ struct Loaded {
     has_mouse_wheel: bool,
     has_subscriptions: bool,
     has_physics: bool,
+    has_soundscape: bool,
     has_ui: bool,
 }
 
@@ -260,6 +271,13 @@ return them beside the model as `(model, effect)`"
     if has_physics {
         require_function(path, &session, "physics", 1)?;
     }
+    // Optional soundscape: `soundScape(model)` returns an AudioScene (the
+    // continuous, reconciled half of audio). No `update` requirement — the
+    // scene is reconciled by the shell, not folded back as a message.
+    let has_soundscape = session.global("soundScape").is_some();
+    if has_soundscape {
+        require_function(path, &session, "soundScape", 1)?;
+    }
     // Optional HUD: `ui(model)` returns a View (Ui.text / Ui.column /
     // Ui.panel), lowered to the shared text overlay — the F# `ui` hook.
     let has_ui = session.global("ui").is_some();
@@ -276,6 +294,7 @@ return them beside the model as `(model, effect)`"
         has_mouse_wheel,
         has_subscriptions,
         has_physics,
+        has_soundscape,
         has_ui,
     })
 }
@@ -331,8 +350,10 @@ impl MleGame {
             has_subscriptions: loaded.has_subscriptions,
             prev_tts: None,
             has_physics: loaded.has_physics,
+            has_soundscape: loaded.has_soundscape,
             has_ui: loaded.has_ui,
             last_view: View::Empty,
+            last_soundscape_json: empty_soundscape_json(),
             effect_runner: RealEffects::new(),
             effect_log: EffectLog::new(),
             deferred_queries: Vec::new(),
@@ -583,6 +604,24 @@ to receive their messages; dropping them"
         }
     }
 
+    /// Route a finished `playThen` one-shot to the completion MESSAGE registered
+    /// when it fired (frames ago), folding it through `update`. Unlike
+    /// `deliver_http_result` there is no tagger: the message is delivered
+    /// verbatim. An orphaned token — a reload dropped its message mid-flight —
+    /// is silently ignored.
+    fn deliver_audio_completion(&mut self, token: u64) {
+        let Some(message) = take_audio_completion(token) else {
+            return;
+        };
+        match self
+            .session
+            .call("update", vec![self.model.clone(), message], &mut FunctorHost)
+        {
+            Ok(returned) => self.absorb(returned),
+            Err(err) => self.frame_error("update", &err),
+        }
+    }
+
     fn pump_subscriptions(&mut self, tts: f64) {
         // Advance the window even without subscriptions (or on frame one),
         // so a hot reload that ADDS subscriptions starts from a sane edge.
@@ -652,6 +691,13 @@ to receive their messages; dropping them"
         if !self.has_physics {
             physics::remove_world(physics::DEFAULT_WORLD);
         }
+        self.has_soundscape = loaded.has_soundscape;
+        if !self.has_soundscape {
+            // Deleting the `soundScape` hook drops the soundscape to silence
+            // (the physics-world / `ui` rule); the shell reconciles the empty
+            // scene next frame, stopping every live voice.
+            self.last_soundscape_json = empty_soundscape_json();
+        }
         self.has_ui = loaded.has_ui;
         if !self.has_ui {
             // Deleting the `ui` hook drops the HUD (the physics-world rule).
@@ -664,6 +710,10 @@ to receive their messages; dropping them"
         self.deferred_queries.clear();
         self.pending_events.clear();
         clear_http_taggers();
+        // In-flight `playThen` completion messages close over the OLD session
+        // too — drop them alongside the HTTP taggers (a late finish for a
+        // dropped token arrives orphaned and is ignored).
+        clear_audio_completions();
         // Reload is a model-history BOUNDARY: the retained snapshots can hold
         // closures bound to the old module, so — unlike the live model, which
         // `rebind_value` migrates above — they can't safely cross a reload.
@@ -847,6 +897,7 @@ impl Game for MleGame {
         self.deferred_queries.clear();
         self.pending_events.clear();
         clear_http_taggers();
+        clear_audio_completions();
         for warning in &warnings {
             self.report_once(format!("[mle] {warning}"));
         }
@@ -1025,6 +1076,29 @@ impl Game for MleGame {
                 Err(err) => self.frame_error("ui", &err),
             }
         }
+        // The optional soundscape, evaluated beside `draw` (same settled model)
+        // and cached — `audio_scene_json` is a `&self` accessor, and errors
+        // need `&mut` dedupe. A bad frame keeps the last good scene (the
+        // last_frame rule).
+        if self.has_soundscape {
+            match self
+                .session
+                .call("soundScape", vec![self.model.clone()], &mut FunctorHost)
+            {
+                Ok(value) => match audio_scene_of(&value) {
+                    Some(scene) => {
+                        self.last_soundscape_json =
+                            functor_runtime_common::audio::scene_to_json(scene)
+                    }
+                    None => self.report_once(format!(
+                        "[mle] soundScape must return an AudioScene (AudioScene.create / \
+AudioScene.empty), got {}",
+                        value.kind_name()
+                    )),
+                },
+                Err(err) => self.frame_error("soundScape", &err),
+            }
+        }
         self.draw_ns += started.elapsed().as_nanos() as u64;
         // On failure this is the last good frame — a bad draw must not blank
         // the screen.
@@ -1077,10 +1151,15 @@ impl Game for MleGame {
         });
     }
     fn audio_drain_commands(&self) -> String {
-        "[]".to_string()
+        // One-shot commands (Effect.play/playAt/playThen), performed by the
+        // shell's audio device; a playThen finish returns via audio_push_finished.
+        functor_runtime_common::audio::drain_commands_json()
     }
     fn audio_scene_json(&self) -> String {
-        "{\"sources\":[]}".to_string()
+        // The continuous soundscape (`soundScape model`), reconciled by the
+        // shell against its live voices. Evaluated + cached in `render` (the
+        // `ui` pattern) so this stays a cheap `&self` read.
+        self.last_soundscape_json.clone()
     }
     fn net_drain_conn_commands(&self) -> String {
         functor_runtime_common::net::drain_conn_commands_json()
@@ -1097,7 +1176,9 @@ impl Game for MleGame {
     fn net_push_conn_error(&mut self, key: String, conn: i32, message: String) {
         self.deliver_net_event(key, NetEventKind::Error, conn, message);
     }
-    fn audio_push_finished(&mut self, _token: i32) {}
+    fn audio_push_finished(&mut self, token: i32) {
+        self.deliver_audio_completion(token as u64);
+    }
 
     fn quit(&mut self) {
         self.close_all_connections();
@@ -1119,6 +1200,12 @@ fn require_function(path: &str, session: &Session, name: &str, arity: usize) -> 
         )),
         None => Err(format!("{path} has no top-level `let {name} = …`")),
     }
+}
+
+/// The silent soundscape's wire form — the default before/without a
+/// `soundScape` hook (matches `AudioScene::default()` serialized).
+fn empty_soundscape_json() -> String {
+    "{\"sources\":[]}".to_string()
 }
 
 fn empty_frame() -> Frame {

--- a/runtime/functor-runtime-web/src/mle_game.rs
+++ b/runtime/functor-runtime-web/src/mle_game.rs
@@ -22,9 +22,10 @@
 use std::cell::RefCell;
 
 use functor_runtime_common::mle_prelude::{
-    clear_http_taggers, contains_effect, deliver_physics_events, drain_effects, frame_value,
-    http_response_value, needs_update, net_conn_subs, net_event_value, perform_deferred_queries,
-    physics_event_taggers, physics_scene_value, split_model_effect, sub_messages_for_frame,
+    audio_scene_of, clear_audio_completions, clear_http_taggers, contains_effect,
+    deliver_physics_events, drain_effects, frame_value, http_response_value, needs_update,
+    net_conn_subs, net_event_value, perform_deferred_queries, physics_event_taggers,
+    physics_scene_value, split_model_effect, sub_messages_for_frame, take_audio_completion,
     take_http_tagger, view_value, EffectLog, EffectTree, FunctorHost, NetEventKind, RealEffects,
 };
 use functor_runtime_common::physics;
@@ -54,6 +55,14 @@ pub struct MleWebGame {
     /// desktop producer).
     prev_tts: Option<f64>,
     has_physics: bool,
+    /// The game defines the optional `soundScape` entry point
+    /// (`soundScape(model) -> AudioScene`, the continuous-audio hook). Absent =
+    /// silence; unlike `subscriptions` it needs no `update`.
+    has_soundscape: bool,
+    /// The last serialized soundscape (`soundScape model` → JSON), cached
+    /// because `audio_scene_json` is a `&self` accessor — evaluated + deduped
+    /// in `render` (the `ui` pattern), same as the desktop producer.
+    last_soundscape_json: String,
     /// The game defines the optional `ui` entry point (`ui(model) -> View`,
     /// the 2D HUD hook).
     has_ui: bool,
@@ -110,6 +119,7 @@ struct Loaded {
     has_mouse_wheel: bool,
     has_subscriptions: bool,
     has_physics: bool,
+    has_soundscape: bool,
     has_ui: bool,
 }
 
@@ -199,6 +209,13 @@ return them beside the model as `(model, effect)`"
     if has_physics {
         require_function(path, &session, "physics", 1)?;
     }
+    // Optional soundscape: `soundScape(model)` returns an AudioScene (the
+    // continuous, reconciled half of audio). No `update` requirement — the
+    // scene is reconciled by the shell, not folded back as a message.
+    let has_soundscape = session.global("soundScape").is_some();
+    if has_soundscape {
+        require_function(path, &session, "soundScape", 1)?;
+    }
     // Optional HUD: `ui(model)` returns a View (Ui.text / Ui.column /
     // Ui.panel), lowered to the shared text overlay — the F# `ui` hook.
     let has_ui = session.global("ui").is_some();
@@ -215,6 +232,7 @@ return them beside the model as `(model, effect)`"
         has_mouse_wheel,
         has_subscriptions,
         has_physics,
+        has_soundscape,
         has_ui,
     })
 }
@@ -247,6 +265,8 @@ impl MleWebGame {
             rendered_frame: 0,
             live_conn_keys: std::collections::HashSet::new(),
             has_physics: loaded.has_physics,
+            has_soundscape: loaded.has_soundscape,
+            last_soundscape_json: empty_soundscape_json(),
             has_ui: loaded.has_ui,
             last_view: View::Empty,
             last_frame: empty_frame(),
@@ -281,11 +301,19 @@ impl MleWebGame {
         if !self.has_physics {
             physics::remove_world(physics::DEFAULT_WORLD);
         }
+        self.has_soundscape = loaded.has_soundscape;
+        if !self.has_soundscape {
+            // Deleting the `soundScape` hook drops the soundscape to silence
+            // (the physics-world / `ui` rule).
+            self.last_soundscape_json = empty_soundscape_json();
+        }
         // A deferred query or in-flight HTTP request holds a tagger — a closure
-        // into the OLD session; drop them rather than let them dangle.
+        // into the OLD session; drop them rather than let them dangle. A
+        // `playThen` completion message closes over the old session too.
         self.deferred_queries.clear();
         self.pending_events.clear();
         clear_http_taggers();
+        clear_audio_completions();
         // Reload is a model-history BOUNDARY (see the desktop producer): the
         // retained snapshots can hold old-module closures, so they can't cross
         // a reload; `rendered_frame` stays monotonic so recording resumes
@@ -451,6 +479,25 @@ to receive their messages; dropping them"
         match self
             .session
             .call("update", vec![self.model.clone(), msg], &mut FunctorHost)
+        {
+            Ok(returned) => self.absorb(returned),
+            Err(err) => self.frame_error("update", &err),
+        }
+    }
+
+    /// Route a finished `playThen` one-shot to the completion MESSAGE registered
+    /// when it fired, folding it verbatim through `update` (no tagger — the
+    /// desktop producer's `deliver_audio_completion`). NOTE: the web audio
+    /// backend (`lib.rs::play_one_shot`) does not yet report one-shot finishes,
+    /// so this is unreached on wasm today; kept symmetric with desktop so it is
+    /// correct the moment the shell reports a finish.
+    fn deliver_audio_completion(&mut self, token: u64) {
+        let Some(message) = take_audio_completion(token) else {
+            return;
+        };
+        match self
+            .session
+            .call("update", vec![self.model.clone(), message], &mut FunctorHost)
         {
             Ok(returned) => self.absorb(returned),
             Err(err) => self.frame_error("update", &err),
@@ -743,6 +790,28 @@ impl GameProducer for MleWebGame {
                 Err(err) => self.frame_error("ui", &err),
             }
         }
+        // The optional soundscape, evaluated beside `draw` (same settled model)
+        // and cached — `audio_scene_json` is a `&self` accessor, and errors
+        // need `&mut` dedupe (the `ui` pattern, same as the desktop producer).
+        if self.has_soundscape {
+            match self
+                .session
+                .call("soundScape", vec![self.model.clone()], &mut FunctorHost)
+            {
+                Ok(value) => match audio_scene_of(&value) {
+                    Some(scene) => {
+                        self.last_soundscape_json =
+                            functor_runtime_common::audio::scene_to_json(scene)
+                    }
+                    None => self.log_once(format!(
+                        "[mle] soundScape must return an AudioScene (AudioScene.create / \
+AudioScene.empty), got {}",
+                        value.kind_name()
+                    )),
+                },
+                Err(err) => self.frame_error("soundScape", &err),
+            }
+        }
         // On failure this is the last good frame — a bad draw must not blank
         // the canvas.
         self.last_frame.clone()
@@ -778,10 +847,15 @@ impl GameProducer for MleWebGame {
         });
     }
     fn audio_drain_commands(&self) -> String {
-        "[]".to_string()
+        // One-shot commands (Effect.play/playAt/playThen); the page's Web Audio
+        // host plays them. playThen finishes are not reported on wasm yet — see
+        // `deliver_audio_completion`.
+        functor_runtime_common::audio::drain_commands_json()
     }
     fn audio_scene_json(&self) -> String {
-        "{\"sources\":[]}".to_string()
+        // The continuous soundscape, evaluated + cached in `render` (the `ui`
+        // pattern) so this stays a cheap `&self` read.
+        self.last_soundscape_json.clone()
     }
     fn net_drain_conn_commands(&self) -> String {
         functor_runtime_common::net::drain_conn_commands_json()
@@ -798,7 +872,9 @@ impl GameProducer for MleWebGame {
     fn net_push_conn_error(&mut self, key: String, conn: i32, message: String) {
         self.deliver_net_event(key, NetEventKind::Error, conn, message);
     }
-    fn audio_push_finished(&mut self, _token: i32) {}
+    fn audio_push_finished(&mut self, token: i32) {
+        self.deliver_audio_completion(token as u64);
+    }
 
     fn quit(&mut self) {
         self.close_all_connections();
@@ -820,6 +896,12 @@ fn require_function(path: &str, session: &Session, name: &str, arity: usize) -> 
         )),
         None => Err(format!("{path} has no top-level `let {name} = …`")),
     }
+}
+
+/// The silent soundscape's wire form — the default before/without a
+/// `soundScape` hook (matches `AudioScene::default()` serialized).
+fn empty_soundscape_json() -> String {
+    "{\"sources\":[]}".to_string()
 }
 
 fn empty_frame() -> Frame {


### PR DESCRIPTION
## What

Wires the MLE-side audio surface (docs/mle.md **E2**), giving `.mle` games full parity with `examples/lighting`'s audio. The shell infrastructure (rodio native / Web Audio, the voice-reconcile diff) already lives in `functor_runtime_common::audio`; this PR adds the interpreter wiring only, closely mirroring the existing HTTP async pattern (`Effect.httpGet` / `EffectTree::Http` / `PENDING_HTTP` / `deliver_http_result`).

### One-shots (fire-and-forget effects)
- `Effect.play(sound)` — non-spatial one-shot.
- `Effect.playAt(sound, x, y, z)` — spatial one-shot.
- `Effect.playThen(sound, msg)` — plays once and delivers `msg` through `update` when the sound **finishes** (frames later). Unlike HTTP's tagger, `playThen` takes a message **value**, delivered verbatim (no tagger application).

### soundScape (the continuous, reconciled half)
- New optional `soundScape(model) -> AudioScene` entry point, evaluated + cached each frame (the `ui` pattern) and serialized for the shell to reconcile against its live voices.
- `AudioSource.ambient(key, sound)` / `AudioSource.at(key, sound, x, y, z)` / `source |> AudioSource.gain(g)`; `AudioScene.create([sources])` / `AudioScene.empty()`.

```mle
let soundScape = (m) =>
  AudioScene.create([
    AudioSource.ambient("wind", "wind-loop.wav") |> AudioSource.gain(0.35),
    AudioSource.at("fountain", "water.wav", 5.0, 0.5, 0.0)
  ])
```

## How
- `mle_prelude.rs`: `EffectTree::PlayAudio` / `PlayAudioThen`, opaque `MleAudioSource` / `MleAudioScene` host types, the eight prelude fns, `drain_mode` arms (`audio.play` / `audio.playThen` effect-log kinds), `needs_update` (both fire-and-forget → `false`, like `Http`), `PENDING_AUDIO` register/take/clear, and `audio_source_of` / `audio_scene_of` extractors.
- **Both producers kept symmetric** (desktop + web): `has_soundscape` load contract, `last_soundscape_json` cache, `audio_drain_commands` / `audio_scene_json` / `audio_push_finished`, `deliver_audio_completion`, and `clear_audio_completions()` at the same sites as `clear_http_taggers()` (hot reload + desktop rewind).

## Notable decision — bounded `PENDING_AUDIO`
`PENDING_HTTP` self-drains because the shell guarantees exactly one completion per request token. An audio finish is **best-effort** — a sound that never starts (no device, decode failure, headless) or a backend that doesn't report finishes (wasm today) leaves its message un-taken. So `PENDING_AUDIO` is **bounded**: past a cap it evicts the oldest entry rather than grow without limit.

## Web gap (deferred, documented)
The web audio backend (`lib.rs::play_one_shot`) does not report one-shot finishes, so `playThen` completions do **not** fire on wasm — this matches F#'s existing web behavior (its `WasmGame::audio_push_finished` is a no-op). The producer hook is kept symmetric so it's correct the moment the shell reports finishes; the bounded map prevents any leak in the meantime.

## Verification (agent-driven, no GPU)
- `cargo build` clean: `functor_runtime_common`, `functor-runtime-desktop`, `functor-runtime-web` (wasm32).
- **`functor_runtime_common`: 200 passed** (+4 new: play/playAt queue exact `AudioCommand`s, playThen token-register→complete-through-`update`, soundScape JSON round-trips to the reconcilable wire form, `PENDING_AUDIO` bound evicts oldest).
- **`mle`: 302 passed** (`RUST_MIN_STACK=33554432`, pre-existing #221). **desktop: 32 passed.**
- **End-to-end:** a scratch `.mle` game using `Effect.play` / `playAt` / `playThen` + `soundScape` typechecks (`functor build`) and runs live for 300+ frames through the real desktop shell with no MLE errors — exercising `soundScape` serialize → shell deserialize → `reconcile` each frame.

## Review
Ran the cross-engine `/xreview` (Claude subagent + Codex). Both converged on the `PENDING_AUDIO` unbounded-growth risk on the non-completing paths — **applied** the bounded-cap fix (+ test). Other notes were "consistent with the HTTP template / intentional scope" (no action).

🤖 Generated with [Claude Code](https://claude.com/claude-code)