### PR TITLE
test(sdk): repoint multiplayer + held-input e2e to the MLE ports (E3 phase 0c)

### DIFF
--- a/tools/functor-sdk/test/held-input.e2e.test.ts
+++ b/tools/functor-sdk/test/held-input.e2e.test.ts
@@ -4,24 +4,29 @@ import { test } from "node:test";
 
 import { findRepoRoot, FunctorRunner } from "../src/index.js";
 
-// End-to-end against a real functor-runner. Requires the runner binary and the
-// `hello` game dylib to be built, and a display to open the GL window, so it's
-// opt-in:
+// End-to-end against a real functor-runner, driving the MLE port of the `hello`
+// game (examples/mle-hello-gltf — the WASD/arrow free-look lineup). Requires the
+// runner binary built and a display to open the GL window, so it's opt-in:
 //
 //   npm run test:e2e        (or FUNCTOR_E2E=1 node --test dist/test/)
+//
+// No dylib build is needed — the `.mle` ships as text and the runner reads it
+// via --mle.
 const e2eEnabled = process.env.FUNCTOR_E2E === "1";
 // Headless (no GL window) is the CI path; capture is unavailable there.
 const headless = process.env.FUNCTOR_E2E_HEADLESS === "1";
 
 const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 
-/** Whether the hello game's model shows `held.up` set. This reads the (stringly-
+/** Whether the mle-hello-gltf model shows `held.up` set. This reads the (stringly-
  * typed) Debug model on purpose — as an independent check that the injected key
  * reaches the *game*, not just the runtime's own input snapshot (which is mutated
- * in the same handler as the game key event). */
+ * in the same handler as the game key event). The MLE model renders as a plain
+ * record (`{ held: { up: false, down: false, ... }, ... }`), so `up:` names the
+ * held-up flag uniquely. */
 function gameSawUp(model: string): boolean {
-  const m = model.match(/HeldKeys\s*\{\s*up:\s*(true|false)/);
-  assert.ok(m, `could not find HeldKeys.up in model: ${model.slice(0, 200)}`);
+  const m = model.match(/\bup:\s*(true|false)/);
+  assert.ok(m, `could not find held.up in model: ${model.slice(0, 200)}`);
   return m[1] === "true";
 }
 
@@ -32,9 +37,11 @@ test(
     const repoRoot = findRepoRoot(process.cwd());
     assert.ok(repoRoot, "must run from within the functor workspace");
 
+    const gameDir = join(repoRoot, "examples", "mle-hello-gltf");
     await using game = await FunctorRunner.launch({
-      gameDir: join(repoRoot, "examples", "hello"),
+      gameDir,
       repoRoot,
+      mlePath: join(gameDir, "game.mle"),
       port: Number(process.env.FUNCTOR_E2E_PORT ?? 8090),
       headless,
     });

--- a/tools/functor-sdk/test/multiplayer.e2e.test.ts
+++ b/tools/functor-sdk/test/multiplayer.e2e.test.ts
@@ -4,31 +4,36 @@ import { test } from "node:test";
 
 import { findRepoRoot, FunctorRunner, waitForPort } from "../src/index.js";
 
-// End-to-end network simulation: one mpserver + two mpclient runners, each its
-// own process on its own debug port, networked over a real WebSocket. Requires
-// the mpserver/mpclient dylibs and the runner binary to be built, plus a display:
+// End-to-end network simulation: one mle-mpserver + two mle-mpclient runners,
+// each its own process on its own debug port, networked over a real WebSocket.
+// These are the MLE ports of examples/mpserver + examples/mpclient — same wire
+// protocol and same auto-move-on-connect, so convergence is identical. The
+// `.mle` ships as text (no dylib build), so this only needs the runner binary
+// and a display:
 //
 //   cargo build --bin functor-runner
-//   ./target/debug/functor -d examples/mpserver build native
-//   ./target/debug/functor -d examples/mpclient build native
 //   FUNCTOR_E2E=1 node --test dist/test/
 const e2eEnabled = process.env.FUNCTOR_E2E === "1";
 const headless = process.env.FUNCTOR_E2E_HEADLESS === "1";
 
-// The example models are exposed only as Rust Debug text (the game model isn't
-// Serialize yet), so these read the `model` string. An F# list renders as a
-// Fable linked list — `List { root: Some(Node_1 { head: <elem>, tail: ... }) }`
-// — not a Rust `[..]`, so we count elements by their `head:` markers. These get
-// simpler once a structured model snapshot lands.
+// The example models are exposed only as MLE Debug text (the game model isn't
+// Serialize yet), so these read the `model` string. An MLE record renders as
+// `{ field: value, ... }` and a list as `[elem, ...]` — no Fable linked list.
+//
+// The server model is `{ players: [<Player>, ...], nextPid: N }`; each Player
+// record carries a unique `cid:` field, so counting `cid:` markers counts the
+// tracked players (equivalently, nextPid reaches 2 once both have joined).
 const serverPlayerCount = (model: string): number =>
-  (model.match(/head:\s*Player\s*\{/g) ?? []).length;
+  (model.match(/cid:/g) ?? []).length;
 
 const clientStatus = (model: string): string =>
   model.match(/status:\s*"([^"]*)"/)?.[1] ?? "";
 
-// Each world element is a `(pid, x, z)` tuple, i.e. `head: (`.
+// The client model is `{ conn: Online(id), world: [<Player>, ...], status: ... }`;
+// each world Player renders as `{ pid: p, x: .., z: .. }`, and `pid:` appears
+// nowhere else in the client model, so `pid:` markers count the world entries.
 const clientWorldCount = (model: string): number =>
-  (model.match(/head:\s*\(/g) ?? []).length;
+  (model.match(/pid:/g) ?? []).length;
 
 test(
   "two clients connect to a server and converge on a shared world",
@@ -40,27 +45,30 @@ test(
     // All three debug ports derive from one base so the test is self-consistent
     // when relocated. (The ws port is fixed at 9001 by the example games.)
     const base = Number(process.env.FUNCTOR_E2E_PORT ?? 8095);
-    const launch = (game: string, port: number) =>
-      FunctorRunner.launch({
-        gameDir: join(repoRoot, "examples", game),
+    const launch = (game: string, port: number) => {
+      const gameDir = join(repoRoot, "examples", game);
+      return FunctorRunner.launch({
+        gameDir,
         repoRoot,
+        mlePath: join(gameDir, "game.mle"),
         port,
         launchTimeoutMs: 30_000,
         headless,
       });
+    };
 
     // Server first, and wait for its Sub.listen socket to actually bind before
     // launching clients — mpclient connects once with no retry, so a client that
     // races ahead of the listener would land in "error" and never converge.
-    await using server = await launch("mpserver", base);
+    await using server = await launch("mle-mpserver", base);
     await waitForPort("127.0.0.1", 9001, {
       timeoutMs: 15_000,
-      description: "mpserver ws listener",
+      description: "mle-mpserver ws listener",
     });
 
-    // mpclient auto-moves on connect, so no input injection is needed.
-    await using clientA = await launch("mpclient", base + 1);
-    await using clientB = await launch("mpclient", base + 2);
+    // mle-mpclient auto-moves on connect, so no input injection is needed.
+    await using clientA = await launch("mle-mpclient", base + 1);
+    await using clientB = await launch("mle-mpclient", base + 2);
 
     const waitOpts = { timeoutMs: 20_000, intervalMs: 200 };
 


### PR DESCRIPTION
## What

Phase 0c of the F#-removal program (docs/mle.md E3): repoint the two SDK e2e tests that launch F# example runners to their MLE ports, so deleting F# later doesn't lose e2e coverage.

Both tests already launch via `mlePath` (the runner reads the `.mle` as text via `--mle`) — no dylib build needed. The behavioral assertions are unchanged; only the game under test and the model-parsing shape changed (F#/Fable linked-list Debug string → MLE record/list Debug string).

## Changes

### `multiplayer.e2e.test.ts`
- Launch `mle-mpserver` + 2× `mle-mpclient` (via `mlePath`) instead of the F# `mpserver`/`mpclient` dylibs. The MLE ports share the wire protocol and the auto-move-on-connect behavior, so convergence over the real WebSocket is identical.
- Rewrote model parsing to the MLE Debug shape:
  - server player count: count `cid:` markers (one per `Player` record in `players`)
  - client world count: count `pid:` markers (one per world `Player`)
  - client status: read the quoted `status: "…"` field
- Same assertions: server tracks 2 players, both clients reach `"in-world"` and see 2 players.

### `held-input.e2e.test.ts`
- Launch `examples/mle-hello-gltf` (via `mlePath`) instead of the F# `hello` dylib. Its `input` entry point stores held keys as `held: { up, down, left, right }`, so the injected `up` key is asserted by matching `up:` in the MLE Debug record.
- Preserves the pause/step flow and the windowed `capture()` → valid-PNG assertion.

## Why mle-hello-gltf for held-input

It's the direct MLE port of the F# `hello` game the old test drove, and it tracks held keys in exactly the field the assertion needs (`held.up`), so the test maps over 1:1 with no behavioral change.

## Verification

Ran windowed (so the capture path is exercised) from `tools/functor-sdk`:

```
FUNCTOR_E2E=1 node --test dist/test/held-input.e2e.test.js   → pass (3/3 runs)
FUNCTOR_E2E=1 node --test dist/test/multiplayer.e2e.test.js  → pass (4/4 runs)
```

Both pass reliably; no flakiness observed over the real socket.

Cross-engine review (Claude + Codex) found no correctness or simplicity issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)