### PR TITLE
test(netsim): drive MLE games in the netsim + repoint mp/sim tests (E3 phase 0b)

### DIFF
--- a/runtime/functor-netsim/Cargo.toml
+++ b/runtime/functor-netsim/Cargo.toml
@@ -8,3 +8,11 @@ functor_runtime_common = { path = "./../functor-runtime-common" }
 fable_library_rust = { path = "./../../fable_modules/fable-library-rust" }
 libloading = "0.8.3"
 serde_json = "1.0"
+
+# The desktop runtime provides the `MleGame` producer the mp/sim tests drive as
+# their instances (E3 phase 0b). It is a DEV-dependency only: the library itself
+# dispatches over `Box<dyn GameProducer>` and never names an MLE game, so this
+# dev-only edge — the desktop lib normal-depends on this crate for its
+# `functor-netsim-viz` bin — is an allowed dev-dependency cycle, not a real one.
+[dev-dependencies]
+functor-runtime-desktop = { path = "./../functor-runtime-desktop" }

--- a/runtime/functor-netsim/src/lib.rs
+++ b/runtime/functor-netsim/src/lib.rs
@@ -1,10 +1,20 @@
 //! In-process deterministic multiplayer harness (Phase 3 of `docs/multiplayer.md`).
 //!
-//! `NetSim` loads N game dylibs as **independent instances** (each a private copy,
-//! so its `currentRunner` / net queues are its own), wires them through the
-//! Phase 0 [`VirtualNet`] (latency / jitter / loss / partition), and steps them in
-//! lockstep. A server + N clients can thus be driven and asserted deterministically
-//! — no real sockets, no GL, byte-for-byte reproducible from a seed.
+//! `NetSim` drives N game **instances** through the Phase 0 [`VirtualNet`]
+//! (latency / jitter / loss / partition), stepped in lockstep. A server + N
+//! clients can thus be driven and asserted deterministically — no real sockets,
+//! no GL, byte-for-byte reproducible from a seed.
+//!
+//! An instance is one of two [`Backend`]s:
+//!
+//! * **`Dylib`** — an F# game dylib loaded as a *private copy*, so its
+//!   `currentRunner` / net queues are its own (module statics don't collide
+//!   between instances).
+//! * **`Producer`** — an in-process [`GameProducer`] (e.g. an MLE game),
+//!   driven through the shared runtime. All producers share this process's
+//!   *process-global* net-command queue (`net::CONN_OUT`), so the harness must
+//!   drain each instance's outbound commands ATOMICALLY right after running its
+//!   game code (see [`NetSim::step`]) to keep them isolated per instance.
 //!
 //! Routing reuses the games' own `Sub.connect` / `Sub.listen`: a client's connect
 //! url is matched to a server's listen bind by *authority* (host:port). The
@@ -19,6 +29,7 @@ use fable_library_rust::String_::{fromString, LrcStr};
 use functor_runtime_common::net::{
     ConnCommand, ConnectionId, LinkProfile, NetEvent, NodeId, VirtualNet,
 };
+use functor_runtime_common::protocol::GameProducer;
 use functor_runtime_common::FrameTime;
 use libloading::{Library, Symbol};
 
@@ -61,21 +72,38 @@ fn authority(endpoint: &str) -> &str {
     after_scheme.split('/').next().unwrap_or(after_scheme)
 }
 
-/// One loaded game instance. The dylib is copied to a unique temp path so each
-/// instance gets independent module statics; the copy is removed on drop.
+/// How one instance's game logic is hosted.
+enum Backend {
+    /// An F# game dylib, loaded as a private copy so its module statics
+    /// (`currentRunner`, net queues) don't collide with other instances. The
+    /// copy lives at `temp` and is removed on drop.
+    Dylib { lib: Library, temp: PathBuf },
+    /// An in-process [`GameProducer`] (e.g. an MLE game). Its net-command
+    /// queue is PROCESS-GLOBAL and shared with every other producer instance,
+    /// so the harness drains it atomically per instance — see [`NetSim::step`].
+    Producer(Box<dyn GameProducer>),
+}
+
+/// One game instance driven by the sim, over either backend.
 struct Instance {
-    lib: Library,
+    backend: Backend,
     node: NodeId,
     /// This instance's routing key (the url/bind its game used) per connection.
     keys: HashMap<ConnectionId, String>,
-    temp: PathBuf,
+    /// Outbound conn commands this instance's game code has produced but not
+    /// yet routed. Captured right after each game-code call (tick, event
+    /// delivery) so a shared producer queue stays attributed to the right
+    /// instance; routed on the NEXT frame — matching the dylib path, where an
+    /// event reply sits in the private queue until the next post-tick drain.
+    outbox: Vec<ConnCommand>,
 }
 
 impl Instance {
-    fn load(src: &str, node: NodeId) -> Instance {
-        // Each instance loads a private copy so its module statics (currentRunner,
-        // net queues) are independent. The temp name is unique process-wide so
-        // concurrent sims / tests never clobber each other's copies.
+    fn load_dylib(src: &str, node: NodeId) -> Instance {
+        // Each dylib instance loads a private copy so its module statics
+        // (currentRunner, net queues) are independent. The temp name is unique
+        // process-wide so concurrent sims / tests never clobber each other's
+        // copies.
         static NEXT: AtomicU64 = AtomicU64::new(0);
         let uid = NEXT.fetch_add(1, Ordering::Relaxed);
         let suffix = std::path::Path::new(src)
@@ -93,81 +121,120 @@ impl Instance {
             init();
         }
         Instance {
-            lib,
+            backend: Backend::Dylib { lib, temp },
             node,
             keys: HashMap::new(),
-            temp,
+            outbox: Vec::new(),
         }
     }
 
-    fn tick(&self, time: FrameTime) {
-        unsafe {
-            let f: Symbol<fn(FrameTime)> = self.lib.get(b"tick").unwrap();
-            f(time);
+    fn from_producer(producer: Box<dyn GameProducer>, node: NodeId) -> Instance {
+        // The producer is already constructed (e.g. `MleGame::create` has
+        // evaluated `init`), mirroring the dylib path's `init()` call above.
+        Instance {
+            backend: Backend::Producer(producer),
+            node,
+            keys: HashMap::new(),
+            outbox: Vec::new(),
+        }
+    }
+
+    fn tick(&mut self, time: FrameTime) {
+        match &mut self.backend {
+            Backend::Dylib { lib, .. } => unsafe {
+                let f: Symbol<fn(FrameTime)> = lib.get(b"tick").unwrap();
+                f(time);
+            },
+            Backend::Producer(p) => p.tick(time),
         }
     }
 
     fn drain_conn_commands(&self) -> Vec<ConnCommand> {
-        unsafe {
-            let f: Symbol<fn() -> LrcStr> = self.lib.get(b"net_drain_conn_commands_json").unwrap();
-            serde_json::from_str(&f().to_string()).unwrap_or_default()
+        let json = match &self.backend {
+            Backend::Dylib { lib, .. } => unsafe {
+                let f: Symbol<fn() -> LrcStr> = lib.get(b"net_drain_conn_commands_json").unwrap();
+                f().to_string()
+            },
+            Backend::Producer(p) => p.net_drain_conn_commands(),
+        };
+        serde_json::from_str(&json).unwrap_or_default()
+    }
+
+    fn push_connected(&mut self, key: &str, id: i32) {
+        match &mut self.backend {
+            Backend::Dylib { lib, .. } => unsafe {
+                let f: Symbol<fn(LrcStr, i32)> = lib.get(b"net_push_connected").unwrap();
+                f(fromString(key.to_string()), id);
+            },
+            Backend::Producer(p) => p.net_push_connected(key.to_string(), id),
         }
     }
 
-    fn push_connected(&self, key: &str, id: i32) {
-        unsafe {
-            let f: Symbol<fn(LrcStr, i32)> = self.lib.get(b"net_push_connected").unwrap();
-            f(fromString(key.to_string()), id);
+    fn push_message(&mut self, key: &str, id: i32, text: &str) {
+        match &mut self.backend {
+            Backend::Dylib { lib, .. } => unsafe {
+                let f: Symbol<fn(LrcStr, i32, LrcStr)> = lib.get(b"net_push_conn_message").unwrap();
+                f(fromString(key.to_string()), id, fromString(text.to_string()));
+            },
+            Backend::Producer(p) => p.net_push_conn_message(key.to_string(), id, text.to_string()),
         }
     }
 
-    fn push_message(&self, key: &str, id: i32, text: &str) {
-        unsafe {
-            let f: Symbol<fn(LrcStr, i32, LrcStr)> =
-                self.lib.get(b"net_push_conn_message").unwrap();
-            f(fromString(key.to_string()), id, fromString(text.to_string()));
+    fn push_disconnected(&mut self, key: &str, id: i32) {
+        match &mut self.backend {
+            Backend::Dylib { lib, .. } => unsafe {
+                let f: Symbol<fn(LrcStr, i32)> = lib.get(b"net_push_disconnected").unwrap();
+                f(fromString(key.to_string()), id);
+            },
+            Backend::Producer(p) => p.net_push_disconnected(key.to_string(), id),
         }
     }
 
-    fn push_disconnected(&self, key: &str, id: i32) {
-        unsafe {
-            let f: Symbol<fn(LrcStr, i32)> = self.lib.get(b"net_push_disconnected").unwrap();
-            f(fromString(key.to_string()), id);
+    fn push_error(&mut self, key: &str, id: i32, message: &str) {
+        match &mut self.backend {
+            Backend::Dylib { lib, .. } => unsafe {
+                let f: Symbol<fn(LrcStr, i32, LrcStr)> = lib.get(b"net_push_conn_error").unwrap();
+                f(
+                    fromString(key.to_string()),
+                    id,
+                    fromString(message.to_string()),
+                );
+            },
+            Backend::Producer(p) => p.net_push_conn_error(key.to_string(), id, message.to_string()),
         }
     }
 
-    fn push_error(&self, key: &str, id: i32, message: &str) {
-        unsafe {
-            let f: Symbol<fn(LrcStr, i32, LrcStr)> = self.lib.get(b"net_push_conn_error").unwrap();
-            f(
-                fromString(key.to_string()),
-                id,
-                fromString(message.to_string()),
-            );
-        }
-    }
-
-    /// The game model, Rust-`Debug`-formatted (for assertions).
+    /// The game model, `Debug`-formatted (dylib) / pretty-printed (producer),
+    /// for assertions. Free-form text — consumers must not parse it (see
+    /// `protocol::GameProducer::state_debug`).
     fn state(&self) -> String {
-        unsafe {
-            let f: Symbol<fn() -> LrcStr> = self.lib.get(b"emit_state_debug").unwrap();
-            f().to_string()
+        match &self.backend {
+            Backend::Dylib { lib, .. } => unsafe {
+                let f: Symbol<fn() -> LrcStr> = lib.get(b"emit_state_debug").unwrap();
+                f().to_string()
+            },
+            Backend::Producer(p) => p.state_debug(),
         }
     }
 
     /// The instance's frame (camera + scene) at this time, for a visualizer.
-    fn render(&self, time: FrameTime) -> functor_runtime_common::Frame {
-        unsafe {
-            let f: Symbol<fn(FrameTime) -> functor_runtime_common::Frame> =
-                self.lib.get(b"test_render").unwrap();
-            f(time)
+    fn render(&mut self, time: FrameTime) -> functor_runtime_common::Frame {
+        match &mut self.backend {
+            Backend::Dylib { lib, .. } => unsafe {
+                let f: Symbol<fn(FrameTime) -> functor_runtime_common::Frame> =
+                    lib.get(b"test_render").unwrap();
+                f(time)
+            },
+            Backend::Producer(p) => p.render(time),
         }
     }
 }
 
 impl Drop for Instance {
     fn drop(&mut self) {
-        let _ = std::fs::remove_file(&self.temp);
+        if let Backend::Dylib { temp, .. } = &self.backend {
+            let _ = std::fs::remove_file(temp);
+        }
     }
 }
 
@@ -196,7 +263,20 @@ impl NetSim {
     pub fn add(&mut self, dylib_path: &str) -> InstanceId {
         let node = self.vnet.add_node();
         let id = self.instances.len();
-        self.instances.push(Instance::load(dylib_path, node));
+        self.instances.push(Instance::load_dylib(dylib_path, node));
+        id
+    }
+
+    /// Add an already-constructed in-process [`GameProducer`] (e.g. an
+    /// `MleGame`) as a new instance. Returns its id.
+    ///
+    /// Unlike a dylib, producers share this process's runtime — including the
+    /// process-global net-command queue — so [`step`](Self::step) drains each
+    /// one's outbound commands atomically to keep them isolated.
+    pub fn add_producer(&mut self, producer: Box<dyn GameProducer>) -> InstanceId {
+        let node = self.vnet.add_node();
+        let id = self.instances.len();
+        self.instances.push(Instance::from_producer(producer, node));
         id
     }
 
@@ -261,7 +341,8 @@ impl NetSim {
 
     /// The frame (camera + scene) an instance would render at this time — for a
     /// visualizer that draws each instance's view (see `functor-netsim-viz`).
-    pub fn render(&self, id: InstanceId, time: FrameTime) -> functor_runtime_common::Frame {
+    /// Takes `&mut self`: a producer evaluates its `draw` (and caches) here.
+    pub fn render(&mut self, id: InstanceId, time: FrameTime) -> functor_runtime_common::Frame {
         self.instances[id].render(time)
     }
 
@@ -273,16 +354,24 @@ impl NetSim {
             tts: self.frame as f32 * self.dt,
             dts: self.dt,
         };
-        for inst in &self.instances {
+        // Tick each instance and drain the commands IT produced ATOMICALLY —
+        // so a producer sharing the process-global conn queue (MLE) stays
+        // isolated: each drain reads only the instance that just ticked. The
+        // dylib path has a private queue, so the sequencing is a harmless
+        // no-op there.
+        for inst in &mut self.instances {
             inst.tick(time.clone());
+            let cmds = inst.drain_conn_commands();
+            inst.outbox.extend(cmds);
         }
         self.frame += 1;
 
-        // Collect all commands, then register listeners before connects so order
-        // within a frame doesn't matter.
+        // Collect all pending commands (this frame's ticks + last frame's
+        // delivered-event replies), then register listeners before connects so
+        // order within a frame doesn't matter.
         let mut commands: Vec<(InstanceId, ConnCommand)> = Vec::new();
-        for (id, inst) in self.instances.iter().enumerate() {
-            for cmd in inst.drain_conn_commands() {
+        for (id, inst) in self.instances.iter_mut().enumerate() {
+            for cmd in inst.outbox.drain(..) {
                 commands.push((id, cmd));
             }
         }
@@ -318,7 +407,14 @@ impl NetSim {
     fn open(&mut self, client: InstanceId, client_key: String) {
         let Some((server, server_key)) = self.listeners.get(authority(&client_key)).cloned() else {
             // No matching listener: surface a connection error to the client.
+            // This runs the client's game code (a producer's `update`), which
+            // may queue an outbound command onto the shared queue — drain it
+            // into THIS client's outbox atomically, so the deliver phase can't
+            // misattribute it to another instance (matches the tick/deliver
+            // drains). [xreview]
             self.instances[client].push_error(&client_key, 0, "no listener for endpoint");
+            let cmds = self.instances[client].drain_conn_commands();
+            self.instances[client].outbox.extend(cmds);
             return;
         };
         let client_node = self.instances[client].node;
@@ -364,6 +460,14 @@ impl NetSim {
                     }
                 }
             }
+            // Capture any outbound commands the delivered events produced (e.g.
+            // an MLE `update` replying with `Effect.send`) BEFORE moving to the
+            // next instance — again atomic, so a shared producer queue stays
+            // attributed here. Held in this instance's outbox and routed next
+            // frame, matching the dylib path where such a reply waits in the
+            // private queue until the next post-tick drain.
+            let cmds = self.instances[id].drain_conn_commands();
+            self.instances[id].outbox.extend(cmds);
         }
     }
 

--- a/runtime/functor-netsim/tests/mp.rs
+++ b/runtime/functor-netsim/tests/mp.rs
@@ -1,51 +1,55 @@
-//! Netsim test of the multiplayer prototype: one authoritative `mpserver` and two
-//! `mpclient`s, run as independent in-process instances through the virtual
-//! network and stepped deterministically. Proves the full loop -- clients connect,
-//! the server spawns + simulates them, broadcasts world snapshots, and both
-//! clients converge on the same world -- with no GL and no sockets.
+//! Netsim test of the multiplayer prototype: one authoritative `mle-mpserver`
+//! and two `mle-mpclient`s, run as independent in-process MLE producers through
+//! the virtual network and stepped deterministically. Proves the full loop --
+//! clients connect, the server spawns + simulates them, broadcasts world
+//! snapshots, and both clients converge on the same world -- with no GL and no
+//! sockets.
 //!
-//! Ignored by default; build the samples first:
+//! The instances are `.mle` games (E3 phase 0b): no dylib build is needed, only
+//! the committed `examples/mle-*/game.mle` sources. Still `#[ignore]`d by
+//! default (they pull in the full desktop runtime as a dev-dependency); run
+//! with:
 //!
 //! ```sh
-//! ./target/debug/functor -d examples/mpserver build native
-//! ./target/debug/functor -d examples/mpclient build native
 //! cargo test -p functor-netsim --test mp -- --ignored --nocapture
 //! ```
 
-use functor_netsim::{Link, NetSim};
+use functor_netsim::{InstanceId, Link, NetSim};
+use functor_runtime_desktop::mle_game::MleGame;
 
-fn dylib(sample: &str) -> String {
-    let name = format!(
-        "{}game_native{}",
-        std::env::consts::DLL_PREFIX,
-        std::env::consts::DLL_SUFFIX
-    );
+// MLE producers share this process's global conn-command queue, so the tests in
+// this binary (cargo runs them as parallel threads) must not build/step their
+// sims concurrently. Serialize them, and clear any residue at each test's start.
+static NET_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn mle_path(sample: &str) -> String {
     std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("../..")
-        .join(format!("examples/{sample}/build-native/target/debug/{name}"))
+        .join(format!("examples/{sample}/game.mle"))
         .to_str()
         .unwrap()
         .to_string()
 }
 
-fn require(samples: &[&str]) {
-    for s in samples {
-        assert!(
-            std::path::Path::new(&dylib(s)).exists(),
-            "build {s} first (see this test's doc comment)"
-        );
-    }
+fn add_mle(sim: &mut NetSim, sample: &str) -> InstanceId {
+    let path = mle_path(sample);
+    assert!(
+        std::path::Path::new(&path).exists(),
+        "missing {path} (the committed MLE example)"
+    );
+    sim.add_producer(Box::new(MleGame::create(&path)))
 }
 
 #[test]
-#[ignore = "needs mpserver + mpclient built native"]
+#[ignore = "pulls the desktop runtime dev-dependency; run with --ignored"]
 fn server_broadcasts_world_and_clients_converge() {
-    require(&["mpserver", "mpclient"]);
+    let _guard = NET_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _ = functor_runtime_common::net::drain_conn_commands();
 
     let mut sim = NetSim::new(1);
-    let server = sim.add(&dylib("mpserver"));
-    let c1 = sim.add(&dylib("mpclient"));
-    let c2 = sim.add(&dylib("mpclient"));
+    let server = add_mle(&mut sim, "mle-mpserver");
+    let c1 = add_mle(&mut sim, "mle-mpclient");
+    let c2 = add_mle(&mut sim, "mle-mpclient");
 
     // Let everyone connect and a few snapshots flow.
     sim.step_n(20);
@@ -87,13 +91,14 @@ fn world_of(state: &str) -> &str {
 }
 
 #[test]
-#[ignore = "needs mpserver + mpclient built native"]
+#[ignore = "pulls the desktop runtime dev-dependency; run with --ignored"]
 fn latency_delays_what_the_client_sees() {
-    require(&["mpserver", "mpclient"]);
+    let _guard = NET_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _ = functor_runtime_common::net::drain_conn_commands();
 
     let mut sim = NetSim::new(1);
-    let server = sim.add(&dylib("mpserver"));
-    let client = sim.add(&dylib("mpclient"));
+    let server = add_mle(&mut sim, "mle-mpserver");
+    let client = add_mle(&mut sim, "mle-mpclient");
     // A laggy link: the client's view trails the server.
     sim.set_link(
         client,

--- a/runtime/functor-netsim/tests/sim.rs
+++ b/runtime/functor-netsim/tests/sim.rs
@@ -1,53 +1,55 @@
 //! End-to-end netsim tests: a real server game + a real client game, run as
-//! independent in-process instances, wired through the virtual network and
+//! independent in-process MLE producers, wired through the virtual network and
 //! stepped deterministically — no GL, no sockets.
 //!
-//! Uses the `wsserverdemo` (echo + greet) and `wsdemo` (connect + send) samples.
-//! Their authorities match (127.0.0.1:9001) so the harness routes the client to
-//! the server.
+//! Uses the `mle-wsserverdemo` (greet + echo) and `mle-wsdemo` (connect + send)
+//! samples. Their authorities match (127.0.0.1:9001) so the harness routes the
+//! client to the server.
 //!
-//! Ignored by default: needs both sample dylibs built. Run with:
+//! The instances are `.mle` games (E3 phase 0b): no dylib build is needed, only
+//! the committed `examples/mle-*/game.mle` sources. Still `#[ignore]`d by
+//! default (they pull in the full desktop runtime as a dev-dependency); run
+//! with:
 //!
 //! ```sh
-//! ./target/debug/functor -d examples/wsserverdemo build native
-//! ./target/debug/functor -d examples/wsdemo build native
 //! cargo test -p functor-netsim --test sim -- --ignored --nocapture
 //! ```
 
-use functor_netsim::{Link, NetSim};
+use functor_netsim::{InstanceId, Link, NetSim};
+use functor_runtime_desktop::mle_game::MleGame;
 
-fn dylib(sample: &str) -> String {
-    let name = format!(
-        "{}game_native{}",
-        std::env::consts::DLL_PREFIX,
-        std::env::consts::DLL_SUFFIX
-    );
+// MLE producers share this process's global conn-command queue, so the tests in
+// this binary (cargo runs them as parallel threads) must not build/step their
+// sims concurrently. Serialize them, and clear any residue at each test's start.
+static NET_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn mle_path(sample: &str) -> String {
     std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("../..")
-        .join(format!("examples/{sample}/build-native/target/debug/{name}"))
+        .join(format!("examples/{sample}/game.mle"))
         .to_str()
         .unwrap()
         .to_string()
 }
 
-fn require_samples() -> (String, String) {
-    let server = dylib("wsserverdemo");
-    let client = dylib("wsdemo");
+fn add_mle(sim: &mut NetSim, sample: &str) -> InstanceId {
+    let path = mle_path(sample);
     assert!(
-        std::path::Path::new(&server).exists() && std::path::Path::new(&client).exists(),
-        "build the samples first (see this test's doc comment)"
+        std::path::Path::new(&path).exists(),
+        "missing {path} (the committed MLE example)"
     );
-    (server, client)
+    sim.add_producer(Box::new(MleGame::create(&path)))
 }
 
 #[test]
-#[ignore = "needs wsserverdemo + wsdemo built native"]
+#[ignore = "pulls the desktop runtime dev-dependency; run with --ignored"]
 fn server_and_client_exchange_messages() {
-    let (server_dylib, client_dylib) = require_samples();
+    let _guard = NET_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _ = functor_runtime_common::net::drain_conn_commands();
 
     let mut sim = NetSim::new(1);
-    let server = sim.add(&server_dylib);
-    let client = sim.add(&client_dylib);
+    let server = add_mle(&mut sim, "mle-wsserverdemo");
+    let client = add_mle(&mut sim, "mle-wsdemo");
 
     // Default (perfect) link: the exchange settles in a handful of frames.
     sim.step_n(10);
@@ -65,13 +67,14 @@ fn server_and_client_exchange_messages() {
 }
 
 #[test]
-#[ignore = "needs wsserverdemo + wsdemo built native"]
+#[ignore = "pulls the desktop runtime dev-dependency; run with --ignored"]
 fn latency_delays_delivery_deterministically() {
-    let (server_dylib, client_dylib) = require_samples();
+    let _guard = NET_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _ = functor_runtime_common::net::drain_conn_commands();
 
     let mut sim = NetSim::new(1);
-    let server = sim.add(&server_dylib);
-    let client = sim.add(&client_dylib);
+    let server = add_mle(&mut sim, "mle-wsserverdemo");
+    let client = add_mle(&mut sim, "mle-wsdemo");
     // 8-tick one-way latency on the client<->server link.
     sim.set_link(
         client,

--- a/runtime/functor-runtime-desktop/src/lib.rs
+++ b/runtime/functor-runtime-desktop/src/lib.rs
@@ -1,0 +1,11 @@
+//! Library facade for the desktop runtime's game producers, so in-process
+//! drivers in OTHER crates can construct them (the `functor-netsim` harness
+//! drives an [`mle_game::MleGame`] as one of its instances — E3 phase 0b).
+//!
+//! The binaries (`functor-runner` via `main.rs`, `functor-netsim-viz`) keep
+//! their own module tree; this exposes only the producers an external driver
+//! needs. Keep it minimal — it exists for the test/harness seam, not as the
+//! runner's public API.
+
+pub mod game;
+pub mod mle_game;


### PR DESCRIPTION
## What

E3 phase 0b of the F#-removal program (docs/mle.md): teach the in-process network simulator (`functor-netsim`) to drive **MLE games**, and repoint its two integration test files off the F# dylibs onto the MLE ports — preserving the deterministic multiplayer-convergence + latency coverage.

`functor-netsim` used to load N game **dylibs**, each a private copy so every instance owned its process-global net-command statics. MLE games aren't dylibs: one shared runtime drives them, and the outbound net-command queue (`net::CONN_OUT`) is a **process-global** static, so N MLE instances share one queue.

## How

- **`Instance` → backend enum.** `Backend::Dylib { lib, temp }` (the existing raw-symbol path, unchanged) or `Backend::Producer(Box<dyn GameProducer>)` (an in-process producer such as `MleGame`). Each `Instance` method dispatches to either the dylib `no_mangle` symbols or the corresponding `GameProducer` trait method.
- **`NetSim::add_producer(Box<dyn GameProducer>)`** alongside `add(dylib_path)`. The library dispatches over the `GameProducer` trait (already available via `functor_runtime_common`), so it never names an MLE game — `functor-runtime-desktop` (which provides `MleGame`) is a **dev-dependency**, keeping the dependency graph acyclic (desktop's lib normal-depends on netsim for its `functor-netsim-viz` bin; the reverse edge is dev-only).
- **`step` reordered for the shared queue.** Each instance is now **ticked + drained atomically** (`for each i: i.tick(); i.outbox += drain()`), so a drain reads only the instance that just ticked. Deliver-phase (event-reply) commands are captured into a per-instance `outbox` right after each `push_*`, and routed the **next** frame — exactly matching the dylib path, where such a reply waits in the private queue until the next post-tick drain. Safe for dylibs (private queues → ordering is a no-op), correct for MLE (shared queue → isolation via strict sequencing).
- **Tests repointed** to `mle-mpserver` + 2× `mle-mpclient` (mp.rs) and `mle-wsserverdemo` + `mle-wsdemo` (sim.rs) via a small `add_mle` helper. Same behavioral assertions (server tracks 2 players; both clients converge on the same world; a message is absent early / present after the link delay). No dylib build needed — the `.mle` sources are committed. A per-binary `Mutex` + queue-drain serializes the tests, since MLE producers share the process-global queue and cargo runs a binary's tests as parallel threads.

## New library facade

`functor-runtime-desktop` was a binary-only package; added a minimal `src/lib.rs` exposing just `game` + `mle_game` so an external driver (the harness) can construct `MleGame`. The binaries keep their own module tree.

## Verification

- `cargo build -p functor-netsim` clean; `functor-runner`, `functor-netsim-viz`, `functor` all build.
- `cargo test -p functor-netsim -- --ignored` — all 4 tests pass, reliably across repeated runs (determinism is the point). Convergence confirmed in the captured output: both clients render byte-identical `world` lists; the server reaches `nextPid: 2`.
- Desktop lib unit tests (incl. the MLE net tests) still green.

## Review

`/xreview` (Claude subagent + Codex CLI). Applied the one actionable finding: the `open()` no-listener error reply also runs producer game code, so it now drains that instance's queue atomically too (same isolation rule as tick/deliver).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
