### PR TITLE
feat(time-travel,renderer): T5 screen-space compositor + fork-overlay demo

### DIFF
--- a/docs/time-travel.md
+++ b/docs/time-travel.md
@@ -1,10 +1,57 @@
 # Time-travel tooling
 
-Status: **design / vision** — the enabling machinery is shipped (the physics
-`Timeline`, `docs/physics.md` Phase 6 / #215), but the generic whole-scene tool
-is not yet built. This is the design doc and the stacked-PR plan for turning
-that machinery into **generic time-travel tooling across the whole game**: pause,
-scrub, rewind, replay, branch — and the authoring experiences those unlock.
+Status: **the whole-game scrubber is shipped** (T1–T3); the authoring
+experiences (T4–T6) are not yet built. This is the design doc *and* the record
+of what landed: **generic time-travel tooling across the whole game** — pause,
+scrub, rewind, replay, branch — plus the authoring experiences those unlock. It
+generalizes the physics `Timeline` (`docs/physics.md` Phase 6 / #215) from the
+Rapier world to the entire MVU model.
+
+## What shipped (as of 2026-07-05)
+
+You can pause a running MLE game and **drag a timeline scrubber to any recorded
+frame** — the whole scene (MVU `model` *and* physics world) restores together —
+on both the desktop runner and the web/VSCode preview. Exercised by
+`examples/mle-physics`.
+
+- **The coupled recorder** (`functor_runtime_common::timetravel`): a bounded
+  per-frame snapshot ring `History<T>` and a `SceneRecorder` over it. Each
+  rendered frame it records the settled `model` (an `Rc`-cheap `mle::Value`
+  clone) and, in lockstep, the physics fixed-frame the world reached. **Shared
+  by both shells** — one tested impl; the producer hands in its `model` /
+  `SteppedPhysics` / status.
+- **Coupled seek, exact-or-refused** (`rewind_scene_to` / `seek_scene_to` on the
+  `GameProducer` trait): restores model + world to a rendered frame, refusing
+  (touching nothing) rather than landing them on different times when the two
+  retention windows disagree. Non-destructive scrubbing (`seek_scene_to`) lets
+  you drag back *and* forth; the future is branched only when play resumes.
+- **Live triggers.** Desktop debug server `POST /rewind {"frame":N}` (#225); an
+  egui scrubber overlay on desktop (`~` console toggle, hidden by default); a
+  **native DOM** scrubber on web (index-mle.html, outside the canvas — see the
+  design note below).
+- **PRs:** `History` primitive #218, per-frame model recording #219, coupled
+  seek #222, `POST /rewind` #225, the scrubber + web parity #226.
+
+### Design decisions that emerged (diverged from the original plan)
+
+- **Two rings, one clock — not a single frame-level `Simulatable`.** The model
+  is `Rc`-cheap, so it uses a plain **snapshot-ring** (`History<Value>`, snapshot
+  every frame, no replay → **scrubbing backward needs no determinism**). The
+  physics world is expensive, so it keeps its existing keyframe+replay
+  `TimelineLog`. They're coupled by a **shared rendered-frame clock**:
+  `world_frame_history` maps each rendered frame to the fixed frame the world
+  ended at. The master clock is the **rendered frame** (every game has one, even
+  with no physics hook).
+- **Reload is a history boundary.** Snapshots can hold closures bound to the old
+  module, so the rings reset on hot-reload (the live model is rebound; snapshots
+  are not). "Rewind shows the earlier *code* version" (the hard frontier from the
+  prior-art notes) is deferred — the interpreter *could* do it by keeping old
+  modules alive, but that's future work.
+- **Shared logic, platform-native UI.** The `SceneRecorder` (the hard part) is
+  shared; the *UI surface* is per-platform: egui-in-canvas on desktop (no DOM
+  there), **native DOM on web** (`mle_scrub_*` wasm exports drive it). The web
+  DOM scrubber sits *outside* the game canvas, so its widgets never fight the
+  canvas's pointer-lock — a cleaner fit than mirroring desktop's egui onto web.
 
 It builds directly on three existing threads and should be read alongside them:
 `docs/physics.md` (the `Simulatable`/`Timeline` seam this generalizes),
@@ -162,6 +209,46 @@ discipline:
   and already flagged in `docs/debug-runtime.md` and `protocol.rs`) is a separate,
   larger effort and explicitly **not** required for anything here.
 
+## The event log: one spine, two directions
+
+The pieces above keep collapsing into each other because they are one structure:
+a **frame-indexed event log** where expensive state is sampled as **keyframes**
+and everything cheap is an **event stream**. Snapshots are just a keyframe
+optimization on top of an event-sourced timeline — the physics `TimelineLog` is
+*already* keyframe + command-log, and the model's snapshot ring (T1) is about to
+grow an input log (T6); those aren't two subsystems that rhyme, they're the same
+pattern on two payloads. The "unified frame clock" is really "one event log, two
+keyframe tracks."
+
+What goes on the log follows a single rule — **record only the non-reproducible
+inbound; recompute everything reproducible; suppress everything outbound**:
+
+| Class | Examples | Timeline treatment |
+| --- | --- | --- |
+| Reproducible inbound | timers / `Sub.every` (from the frame clock), **seeded** RNG | recompute — don't record |
+| Non-reproducible inbound | user input, http/ws **responses**, wall clock, unseeded RNG | **record + replay** |
+| Outbound | the effects a frame issued (http / ws / audio) | **suppress + log** (never re-fire) |
+
+Seeding RNG is what moves it from the record column to the recompute column (the
+seed becomes one more plain-data timeline entry). **Direction is the whole rule:**
+inputs and effect *responses* are inbound and get replayed; effects are outbound
+and get suppressed. Because the log is plain data it **survives a hot reload**,
+even though the model snapshots (old-module closures) do not — which is exactly
+what lets "tweak a constant, replay my recorded inputs, see if the jump now
+clears the chasm" work.
+
+Two fidelity tiers follow, and they are why coeffect replay (T8) is a separate
+phase from the input log (T6):
+
+- **Pure replay** (same code) reissues the identical effect stream, so recorded
+  responses replay **positionally** — exact and cheap.
+- **Replay under a tweak** (the point of T6) can diverge: the changed model may
+  issue a different request, so a recorded response must be **matched by identity**
+  (method+URL+body / channel+payload) and a miss is marked **diverged** on the
+  timeline, not fired live — firing live would break replay purity and can
+  double-charge / duplicate-send. Divergence-as-a-visible-marker is the right
+  LLM-native behavior, not a cop-out.
+
 ## The authoring experiences it unlocks
 
 These are the reason to build it — and both reduce to the same primitive: *you
@@ -176,18 +263,45 @@ the pure `draw` on each. The only new **engine** capability is a render pass tha
 composites a second scene at reduced opacity (~50%). Everything else is already
 there: two models, one pure `draw3d`, one blend.
 
-### Trajectory preview (Inventing on Principle)
+### Trajectory preview — forward-ghosting (Inventing on Principle)
 
-Tweak a constant, see the ball's whole path over time. This is "run the future
-headlessly and plot it": from the current snapshot, step the model+world forward
-N frames deterministically, sample a position each frame, and draw the path as a
-polyline trail. It needs **(a)** deterministic forward simulation — the replay
-machinery from Phase 1 — and **(b)** a polyline/trail draw primitive (the physics
-`debug_lines` pass is already most of it). The "tweak a constant" half rides
-existing hot-reload: `POST /reload-source` swaps the `.mle` with the model
-preserved, the future is re-run, the trail redraws. Once interactive UI exists, a
-slider makes it continuous — the full Bret Victor loop. This is the single most
-compelling demo in the set and it is within reach.
+Tweak a constant, see the whole future at once. Rather than a per-object trail,
+this is **chronophotography**: from the paused snapshot, step the whole scene
+forward over a window (start with ~2s / 10 divisions) and composite the divisions
+into one image, each at `1/divisions` weight. Static geometry averages to itself
+(solid); anything moving smears into a faint strobe of its own future positions.
+It needs **no new scene-description API** — you call the existing `draw3d` on each
+stepped state — and it captures *all* motion, not one hand-picked entity, so it
+works for any scene under a fixed camera.
+
+Two implementation points decide whether it looks right:
+
+- **Composite in screen space, not the depth buffer.** Render each division to its
+  own offscreen target (normal depth-testing *within* a division), then **average**
+  the targets. Averaging is what makes static=solid / moving=faint fall out of the
+  math — no per-object opacity logic, and it sidesteps the order-dependent garbage
+  of alpha-blending N depth-tested scenes into one buffer. A **progressive
+  running-average** (step one division per real frame, blend into an accumulator at
+  `1/(k+1)`) keeps per-frame cost at ~1 extra render, needs only two targets, and
+  *builds up* over the window — then holds until something changes. (The engine's
+  double-buffered `RenderTargetBuffers` + a fullscreen composite quad, modelled on
+  `draw_skybox`, is nearly all the machinery.)
+- **Replay recorded inputs, freeze the camera.** Forward-stepping replays the
+  frame-indexed input log (see "The event log") for frames it has, then coasts;
+  all divisions render with the *paused* camera so only world motion smears, not
+  the view.
+
+The "tweak a constant" half rides existing hot-reload: swap the `.mle` with the
+model preserved, re-run the window, the ghost redraws — so you can tweak a jump
+impulse until the arc clears a chasm and *see* it clear before you resume. This is
+the single most compelling demo in the set and it is within reach.
+
+**Fork+overlay and forward-ghosting are the same engine primitive** — a
+screen-space compositor that renders K scenes to K offscreen targets and averages
+them with weights. Fork+overlay is K=2 at (0.5, 0.5) from two branches; ghosting
+is K=N at `1/N` from one branch stepped forward. Build the compositor once and
+both land; the old polyline/trail primitive becomes an optional later "precise
+single-path read," not a prerequisite.
 
 ## LLM-native angle
 
@@ -197,22 +311,31 @@ rewind to frame K, change game logic, replay, and diff the outcome is
 *time-travel authoring / what-if iteration*; the golden-image tests are the
 regression half of the same loop. Every phase below is buildable and verifiable
 headlessly (pure Rust + MLE, no GPU window) up to the point where pixels are
-actually required (the overlay render and the opacity/trail passes) — matching
+actually required (the overlay render and the screen-space compositor pass) — matching
 the project's "design for agent verifiability" rule.
 
 ## Roadmap (small, stacked PRs)
 
-| Phase | Scope | Targets |
+| Phase | Scope | Status |
 | --- | --- | --- |
-| **T1. Model `Simulatable` + unified clock** | A frame-level `Simulatable` (snapshot = `Value` clone + world snapshot; command = frame inputs) and one frame index that seeks model and world together. Goldens: scrub-back restores the model value-exact; replay-forward is identical (mirrors the physics goldens). No UI. | native+wasm (Rust+MLE) |
-| **T2. Pointer/click input plumbing** | Deliver mouse-button events to the runtime, feed real `RawInput` to egui, drop `.interactable(false)`. Unblocks both the scrubber and interactive game UI. | native+wasm |
-| **T3. Shell-owned scrubber overlay** | egui timeline bar + transport (play/pause/step) + scrub handle driving the generic `Timeline`; `~` toggle (native), default-on (web/VSCode). This is the Tomorrow-Corporation whole-game scrubber. | native+wasm |
-| **T4. Interactive MLE `View`** | `View` gains an action-carrying node (`Button { label, onClick }`, storable MLE closure); egui hit-tests and dispatches back into `update`. Separable, independently useful; the scrubber can be re-skinned in it later as a dogfood. | native+wasm (MLE) |
-| **T5. Fork + overlay** | Keep-the-branch instead of truncate; hold two model+world states; renderer composite pass drawing a second `draw` output at ~50% opacity. | both |
-| **T6. Trajectory preview** | Deterministic forward-sim of N frames + a polyline/trail draw primitive; wire to hot-reload for the tweak-a-constant loop; slider once T4 lands. The *Inventing on Principle* demo. | both |
+| **T1. Coupled model+world recorder** | `History<T>` snapshot ring + `SceneRecorder`; per-frame model + physics-fixed-frame recording; `rewind_scene_to`/`seek_scene_to` exact-or-refused; live `POST /rewind`. Landed as a snapshot-ring + shared rendered-frame clock rather than a single frame `Simulatable` (see the design note). Headless integration tests. | **Shipped** (#218/#219/#222/#225) |
+| **T2. Pointer/click input plumbing** | Feed real pointer `RawInput` to egui (desktop); DOM mouse for the web scrubber. `.interactable(false)` dropped for the scrubber panel. | **Shipped** (#226) |
+| **T3. Scrubber overlay** | Draggable timeline (non-destructive scrub + branch-on-resume) + Pause/Step. **Desktop:** egui-in-canvas, `~` console toggle (hidden by default). **Web:** native DOM outside the canvas + "🖱 mouse look" button. | **Shipped** (#226) |
+| **T4. Interactive MLE `View`** | `View` gains an action-carrying node (`Button { label, onClick }`, storable MLE closure); egui hit-tests and dispatches back into `update`. Independent of the scrubber (which is shell-owned) — a general game-UI capability. | Not started |
+| **T5. Fork + overlay** | Keep-the-branch instead of truncate; hold two model+world states; a **screen-space compositor** (new fullscreen average pass at the tail of `render_frame`, reusing the double-buffered `RenderTargetBuffers`) renders each scene to its own target and averages them (K=2, weights 0.5/0.5). Shares its whole implementation with T6. | Not started |
+| **T6. Forward-ghosting (trajectory preview)** | A frame-indexed **input log** in the recorder (plain data, survives reload) + a headless deterministic forward-step (replay inputs, suppress effects) + the T5 compositor at K=N, `1/N` weights; wire to hot-reload for the tweak-a-constant loop; slider once T4 lands. The *Inventing on Principle* demo — no trail primitive needed. | Not started |
+| **T7. Event timeline** | Record inputs *and* effects as one plain-data event log keyed by frame (inputs in / effects out); render them as markers on the scrubber; use the log to suppress-on-replay. The event-sourcing spine the earlier phases already imply. | Not started |
+| **T8. Coeffect record/replay** | Record & replay effect *responses* (http/ws) so a recorded window re-runs faithfully. Pure replay is positional/exact; replay-under-a-tweak needs identity-matching + a visible **divergence marker** when a changed model asks for an un-recorded response (never fire live). | Later |
 
-T1–T3 deliver the whole-game scrubber. T5–T6 are the showstopper authoring
-experiences.
+T1–T3 (the whole-game scrubber) are shipped. T5–T6 are the showstopper authoring
+experiences — both now reachable because `SceneRecorder` can snapshot and
+deterministically step the whole scene, and the renderer already has the FBO
+machinery a compositor needs. T7–T8 generalize the timeline into an event log
+(and make cross-tweak outcome-diffing — the LLM-native regression loop —
+possible). The other recurring dependency, behind schema-migration across a
+reload and richer `/state`, is a **structured / serializable / versioned model
+state** (today the model isn't `Serialize`; `/state` is `Debug` text) — the
+highest-leverage non-visual foundation.
 
 ## Prior art
 

--- a/runtime/functor-runtime-common/src/composite.rs
+++ b/runtime/functor-runtime-common/src/composite.rs
@@ -1,0 +1,136 @@
+//! Screen-space compositor (docs/time-travel.md T5).
+//!
+//! The shared foundation for fork+overlay (K=2 at 0.5/0.5) and forward-ghosting
+//! (K=N at 1/N): render K pure `Frame`s into K offscreen targets, then composite
+//! them onto the backbuffer as a weighted average. The average is done
+//! **in-shader** (sample the K textures, sum with per-texture weight) rather than
+//! via GL blend state — the 3D path keeps blending off, and an exact in-shader
+//! sum makes "static geometry averages to itself (solid), motion smears (faint)"
+//! fall straight out of the math.
+//!
+//! The GL side lives in `SceneContext::draw_composite`; the per-frame
+//! orchestration in `renderer::render_composited_frames`. This module owns the
+//! shader source and the pure weight logic (unit-tested without a GL context).
+
+/// Max frames a single composite pass can average. The fragment shader unrolls a
+/// fixed-size sampler array, so this is a compile-time bound (it must match the
+/// `MAX_COMPOSITE` `#define` in the fragment source below). It also stays within
+/// the WebGL2-guaranteed 16 texture image units.
+pub const MAX_COMPOSITE: usize = 8;
+
+/// Normalize `weights` so they sum to 1.0 — the composite is then an *average*
+/// regardless of the scale the caller passes (both `[0.5, 0.5]` and `[1.0, 1.0]`
+/// average two frames; `[1/N; N]` averages N). Each weight is sanitized
+/// per-element first: only finite, non-negative values contribute; anything else
+/// (`NaN`, `Inf`, negative) is treated as 0 so a single bad entry can't poison
+/// the average or leak a `NaN` into the shader. If nothing valid remains it falls
+/// back to equal weights, so a degenerate input still renders something sensible
+/// rather than a black (or garbage) frame.
+pub fn normalize_weights(weights: &[f32]) -> Vec<f32> {
+    if weights.is_empty() {
+        return Vec::new();
+    }
+    let clean: Vec<f32> = weights
+        .iter()
+        .map(|w| if w.is_finite() && *w >= 0.0 { *w } else { 0.0 })
+        .collect();
+    let total: f32 = clean.iter().sum();
+    if total <= 0.0 {
+        let equal = 1.0 / weights.len() as f32;
+        return vec![equal; weights.len()];
+    }
+    clean.iter().map(|w| w / total).collect()
+}
+
+// A passthrough fullscreen-quad vertex shader. The unit quad
+// (`geometry::Quad`) spans [-0.5, 0.5] in XY; scaling by 2 fills NDC, and its
+// [0, 1] UVs address the offscreen targets 1:1.
+pub const COMPOSITE_VERTEX_SHADER_SOURCE: &str = r#"
+        layout (location = 0) in vec3 inPos;
+        layout (location = 1) in vec2 inUv;
+
+        out vec2 vUv;
+
+        void main() {
+            vUv = inUv;
+            gl_Position = vec4(inPos.xy * 2.0, 0.0, 1.0);
+        }
+"#;
+
+// Weighted-average of MAX_COMPOSITE textures, **manually unrolled** with literal
+// sampler indices. GLSL ES 3.00 (WebGL2) only reliably supports indexing a
+// `sampler2D[]` by constant *expressions*; a loop index is the weaker
+// "constant-index-expression" some drivers reject, so we index `uTex[0]..uTex[7]`
+// with literals to stay portable to the web path (which compiles this shader in
+// T6). Unused slots carry weight 0 (padded by the caller). The unrolled body must
+// have exactly `MAX_COMPOSITE` lines; the `#define` sizes the uniform arrays.
+pub const COMPOSITE_FRAGMENT_SHADER_SOURCE: &str = r#"
+        #define MAX_COMPOSITE 8
+
+        in vec2 vUv;
+        out vec4 fragColor;
+
+        uniform sampler2D uTex[MAX_COMPOSITE];
+        uniform float uWeight[MAX_COMPOSITE];
+
+        void main() {
+            vec3 acc = vec3(0.0);
+            acc += uWeight[0] * texture(uTex[0], vUv).rgb;
+            acc += uWeight[1] * texture(uTex[1], vUv).rgb;
+            acc += uWeight[2] * texture(uTex[2], vUv).rgb;
+            acc += uWeight[3] * texture(uTex[3], vUv).rgb;
+            acc += uWeight[4] * texture(uTex[4], vUv).rgb;
+            acc += uWeight[5] * texture(uTex[5], vUv).rgb;
+            acc += uWeight[6] * texture(uTex[6], vUv).rgb;
+            acc += uWeight[7] * texture(uTex[7], vUv).rgb;
+            fragColor = vec4(acc, 1.0);
+        }
+"#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn already_normalized_is_unchanged() {
+        assert_eq!(normalize_weights(&[0.5, 0.5]), vec![0.5, 0.5]);
+        let n = normalize_weights(&[0.1; 10]);
+        assert!(n.iter().all(|w| (w - 0.1).abs() < 1e-6));
+    }
+
+    #[test]
+    fn scales_to_sum_one() {
+        assert_eq!(normalize_weights(&[1.0, 1.0]), vec![0.5, 0.5]);
+        let n = normalize_weights(&[3.0, 1.0]);
+        assert_eq!(n, vec![0.75, 0.25]);
+        assert!((n.iter().sum::<f32>() - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn zero_total_falls_back_to_equal() {
+        assert_eq!(normalize_weights(&[0.0, 0.0]), vec![0.5, 0.5]);
+        assert_eq!(normalize_weights(&[0.0, 0.0, 0.0, 0.0]), vec![0.25; 4]);
+    }
+
+    #[test]
+    fn empty_is_empty() {
+        assert!(normalize_weights(&[]).is_empty());
+    }
+
+    #[test]
+    fn non_finite_and_negative_weights_are_dropped() {
+        // A single bad entry must not poison the average or leak NaN downstream.
+        assert_eq!(normalize_weights(&[1.0, f32::NAN]), vec![1.0, 0.0]);
+        assert_eq!(normalize_weights(&[1.0, f32::INFINITY]), vec![1.0, 0.0]);
+        assert_eq!(normalize_weights(&[3.0, -1.0]), vec![1.0, 0.0]);
+        // Nothing valid remains -> equal-weight fallback (never a black frame).
+        assert_eq!(normalize_weights(&[f32::NAN, -2.0]), vec![0.5, 0.5]);
+    }
+
+    #[test]
+    fn matches_declared_shader_bound() {
+        // The fragment shader hard-codes the array size; keep it in lockstep
+        // with the Rust bound the padding logic relies on.
+        assert!(COMPOSITE_FRAGMENT_SHADER_SOURCE.contains(&format!("#define MAX_COMPOSITE {MAX_COMPOSITE}")));
+    }
+}

--- a/runtime/functor-runtime-common/src/lib.rs
+++ b/runtime/functor-runtime-common/src/lib.rs
@@ -68,6 +68,7 @@ pub mod animation;
 pub mod asset;
 pub mod audio;
 mod camera;
+pub mod composite;
 mod effect;
 mod effect_queue;
 pub mod fog;

--- a/runtime/functor-runtime-common/src/renderer.rs
+++ b/runtime/functor-runtime-common/src/renderer.rs
@@ -192,6 +192,123 @@ target frame are ignored (depth 1 only)",
     );
 }
 
+/// Render K `Frame`s into K offscreen targets and composite them onto the bound
+/// framebuffer as a weighted average — the screen-space compositor (T5, the
+/// shared foundation for fork+overlay and forward-ghosting, docs/time-travel.md).
+///
+/// Each frame renders through the same shadow + forward path as a normal frame,
+/// into its own full-viewport-sized RGBA8 target (keyed `__composite_{i}`, reused
+/// across frames), then `SceneContext::draw_composite` sums them in-shader. The
+/// composite lands in the default framebuffer *after* the forward work and before
+/// any UI overlay, so it shows up in `--capture-frame` PNGs.
+///
+/// Inputs beyond `MAX_COMPOSITE` are dropped; `weights` is truncated/normalized
+/// to the retained count (so equal weights average). Nested render targets inside
+/// an input frame are ignored — the compositor renders each frame's main scene
+/// only (fork/ghost frames are plain scenes).
+pub fn render_composited_frames(
+    gl: &glow::Context,
+    shader_version: &str,
+    asset_cache: Arc<AssetCache>,
+    scene_context: &SceneContext,
+    shadow_map: &ShadowMap,
+    frames: &[Frame],
+    weights: &[f32],
+    frame_time: FrameTime,
+    viewport: Viewport,
+    debug_render_mode: DebugRenderMode,
+) {
+    use crate::composite::{normalize_weights, MAX_COMPOSITE};
+    use crate::render_target::RenderTargetDescriptor;
+
+    let n = frames.len().min(weights.len()).min(MAX_COMPOSITE);
+    if n == 0 {
+        return;
+    }
+    let weights = normalize_weights(&weights[..n]);
+
+    // 1. Render each input frame into its own full-viewport offscreen target.
+    let mut textures: Vec<glow::Texture> = Vec::with_capacity(n);
+    for (i, frame) in frames[..n].iter().enumerate() {
+        let id = format!("__composite_{i}");
+        let clear = crate::fog::clear_color(frame.fog.as_ref());
+        let desc = RenderTargetDescriptor {
+            id: id.clone(),
+            width: viewport.width,
+            height: viewport.height,
+        };
+        scene_context.ensure_render_target(gl, &desc, clear);
+
+        let shadow = shadow_pass(
+            gl,
+            shader_version,
+            asset_cache.clone(),
+            frame_time.clone(),
+            &frame.lights,
+            &frame.scene,
+            scene_context,
+            shadow_map,
+        );
+
+        let (fbo, width, height) = scene_context
+            .render_target_write(&id)
+            .expect("composite render target was just ensured");
+        unsafe {
+            gl.bind_framebuffer(glow::FRAMEBUFFER, Some(fbo));
+            gl.viewport(0, 0, width as i32, height as i32);
+            gl.disable(glow::SCISSOR_TEST);
+            let [r, g, b] = clear;
+            gl.clear_color(r, g, b, 1.0);
+            gl.clear(glow::COLOR_BUFFER_BIT | glow::DEPTH_BUFFER_BIT);
+        }
+        forward_pass(
+            gl,
+            shader_version,
+            asset_cache.clone(),
+            scene_context,
+            &frame.scene,
+            &frame.lights,
+            &frame.camera,
+            frame_time.clone(),
+            debug_render_mode,
+            shadow,
+            frame.fog.as_ref(),
+            frame.skybox.as_ref(),
+            width as f32 / height as f32,
+        );
+        unsafe {
+            gl.bind_framebuffer(glow::FRAMEBUFFER, None);
+        }
+        scene_context.finish_render_target_write(&id);
+        textures.push(
+            scene_context
+                .render_target_read_texture(&id)
+                .expect("composite render target just written"),
+        );
+    }
+
+    // 2. Composite the targets onto the bound (default) framebuffer, clipped to
+    //    the viewport pane (so it composes with any surrounding shell chrome).
+    unsafe {
+        gl.viewport(
+            viewport.x as i32,
+            viewport.y as i32,
+            viewport.width as i32,
+            viewport.height as i32,
+        );
+        gl.scissor(
+            viewport.x as i32,
+            viewport.y as i32,
+            viewport.width as i32,
+            viewport.height as i32,
+        );
+        gl.enable(glow::SCISSOR_TEST);
+        gl.clear_color(0.0, 0.0, 0.0, 1.0);
+        gl.clear(glow::COLOR_BUFFER_BIT | glow::DEPTH_BUFFER_BIT);
+    }
+    scene_context.draw_composite(gl, shader_version, &textures, &weights);
+}
+
 /// Shadow pass: render `scene` into `shadow_map` from the first shadow-casting
 /// light (directional or spot), before a forward pass. Skinned casters come for
 /// free via the shared depth pass in `Scene3D::render`. Ends with the default

--- a/runtime/functor-runtime-common/src/scene3d/mod.rs
+++ b/runtime/functor-runtime-common/src/scene3d/mod.rs
@@ -14,6 +14,9 @@ use crate::{
         pipelines::{ModelPipeline, RawImagePipeline, TexturePipeline},
         AssetCache, AssetHandle, AssetPollState, BuiltAssetPipeline,
     },
+    composite::{
+        COMPOSITE_FRAGMENT_SHADER_SOURCE, COMPOSITE_VERTEX_SHADER_SOURCE, MAX_COMPOSITE,
+    },
     geometry::{self, Geometry},
     material::{
         BasicMaterial, DepthMaterial, Material, NormalDebugMaterial, SkinnedDepthMaterial,
@@ -62,6 +65,9 @@ pub struct SceneContext {
     raw_image_pipeline: Arc<BuiltAssetPipeline<TextureData>>,
     skyboxes: RefCell<HashMap<String, SkyboxEntry>>,
     skybox_program: RefCell<Option<(ShaderProgram, SkyboxUniforms)>>,
+    // The screen-space compositor's fullscreen-average program, built lazily on
+    // first use and cached like the skybox program (docs/time-travel.md T5).
+    composite_program: RefCell<Option<(ShaderProgram, CompositeUniforms)>>,
 }
 
 enum SkyboxEntry {
@@ -76,6 +82,13 @@ struct SkyboxUniforms {
     view_loc: UniformLocation,
     projection_loc: UniformLocation,
     skybox_loc: UniformLocation,
+}
+
+struct CompositeUniforms {
+    /// `sampler2D uTex[MAX_COMPOSITE]` — one texture unit per input.
+    tex_loc: UniformLocation,
+    /// `float uWeight[MAX_COMPOSITE]` — the per-input blend weight.
+    weight_loc: UniformLocation,
 }
 
 impl SceneContext {
@@ -95,6 +108,7 @@ impl SceneContext {
             raw_image_pipeline: asset::build_pipeline(Box::new(RawImagePipeline)),
             skyboxes: RefCell::new(HashMap::new()),
             skybox_program: RefCell::new(None),
+            composite_program: RefCell::new(None),
         }
     }
 
@@ -370,6 +384,86 @@ skybox disabled for this set",
             gl.depth_mask(true);
             gl.depth_func(glow::LESS);
             gl.bind_texture(glow::TEXTURE_CUBE_MAP, None);
+        }
+    }
+
+    /// Composite `textures` onto the currently-bound framebuffer as a weighted
+    /// average — the screen-space compositor pass (docs/time-travel.md T5). Each
+    /// texture is a full offscreen render of one `Frame`; `weights[i]` scales
+    /// input `i` (caller normalizes to sum 1 for an average). Draws a fullscreen
+    /// quad with depth-testing off, over whatever the caller cleared, so it can
+    /// land in the default framebuffer before the UI overlay (and thus in
+    /// `--capture-frame` PNGs). Up to `MAX_COMPOSITE` inputs; extras are dropped
+    /// by the caller. The averaging is exact and in-shader — no GL blend state.
+    pub fn draw_composite(
+        &self,
+        gl: &glow::Context,
+        shader_version: &str,
+        textures: &[glow::Texture],
+        weights: &[f32],
+    ) {
+        if textures.is_empty() {
+            return;
+        }
+
+        {
+            let mut program = self.composite_program.borrow_mut();
+            if program.is_none() {
+                let vertex = Shader::build(
+                    gl,
+                    ShaderType::Vertex,
+                    COMPOSITE_VERTEX_SHADER_SOURCE,
+                    shader_version,
+                );
+                let fragment = Shader::build(
+                    gl,
+                    ShaderType::Fragment,
+                    COMPOSITE_FRAGMENT_SHADER_SOURCE,
+                    shader_version,
+                );
+                let shader = ShaderProgram::link(gl, &vertex, &fragment);
+                let uniforms = CompositeUniforms {
+                    tex_loc: shader.get_uniform_location(gl, "uTex"),
+                    weight_loc: shader.get_uniform_location(gl, "uWeight"),
+                };
+                *program = Some((shader, uniforms));
+            }
+        }
+
+        // Build the full fixed-size uniform arrays: real inputs for the first
+        // `k`, zero-weight padding for the rest (the shader unrolls to
+        // MAX_COMPOSITE). Every sampler unit is bound to a valid texture — the
+        // padding units reuse input 0, harmless since their weight is 0.
+        let k = textures.len().min(weights.len()).min(MAX_COMPOSITE);
+        let units: [i32; MAX_COMPOSITE] = std::array::from_fn(|i| i as i32);
+        let mut weight_array = [0.0f32; MAX_COMPOSITE];
+        weight_array[..k].copy_from_slice(&weights[..k]);
+
+        let program = self.composite_program.borrow();
+        let (shader, uniforms) = program
+            .as_ref()
+            .expect("composite program just initialized");
+        unsafe {
+            shader.use_program(gl);
+            shader.set_uniform_1iv(gl, &uniforms.tex_loc, &units);
+            shader.set_uniform_1fv(gl, &uniforms.weight_loc, &weight_array);
+            for (i, unit) in units.iter().enumerate() {
+                gl.active_texture(glow::TEXTURE0 + *unit as u32);
+                let texture = if i < k { textures[i] } else { textures[0] };
+                gl.bind_texture(glow::TEXTURE_2D, Some(texture));
+            }
+            // Fullscreen pass: no depth read/write wanted.
+            gl.disable(glow::DEPTH_TEST);
+        }
+        self.quad.borrow_mut().draw(gl);
+        unsafe {
+            gl.enable(glow::DEPTH_TEST);
+            // Leave the units clean so later passes don't see stale bindings.
+            for unit in units.iter() {
+                gl.active_texture(glow::TEXTURE0 + *unit as u32);
+                gl.bind_texture(glow::TEXTURE_2D, None);
+            }
+            gl.active_texture(glow::TEXTURE0);
         }
     }
 }

--- a/runtime/functor-runtime-desktop/src/main.rs
+++ b/runtime/functor-runtime-desktop/src/main.rs
@@ -120,6 +120,22 @@ impl From<DebugRenderArg> for functor_runtime_common::DebugRenderMode {
     }
 }
 
+/// Screen-space compositor smoke test (docs/time-travel.md T5). A dev/verify
+/// hook that routes the frame through `render_composited_frames` instead of the
+/// normal single-frame path.
+#[derive(clap::ValueEnum, Debug, Clone, Copy, Default, PartialEq, Eq)]
+enum CompositeDemoArg {
+    /// Normal single-frame render.
+    #[default]
+    Off,
+    /// Composite the frame with itself at 0.5/0.5 — must be pixel-identical to a
+    /// normal render (proves the pass is lossless).
+    Clone,
+    /// Overlay the frame with a world-space-offset copy of its scene at 0.5/0.5
+    /// — two "timelines" ghosted (the fork+overlay demo).
+    Fork,
+}
+
 #[derive(Parser, Debug, Clone)]
 #[command(author, version, about, long_about = None)]
 struct Args {
@@ -204,6 +220,12 @@ struct Args {
     /// window, so it won't fuse in 3D — fine for dev, not for shipping.
     #[arg(long)]
     stereo_sbs: bool,
+
+    /// Route the frame through the screen-space compositor (docs/time-travel.md
+    /// T5) instead of the normal render — a headless verification hook. See
+    /// `CompositeDemoArg`.
+    #[arg(long, value_enum, default_value_t = CompositeDemoArg::Off)]
+    composite_demo: CompositeDemoArg,
 
     /// Eye separation for --stereo-sbs, in world units. The default assumes
     /// meter-scale worlds (human IPD ≈ 64mm); raise it for larger-unit worlds
@@ -1001,6 +1023,31 @@ Escape again to quit"
                         );
                     }
                 }
+            } else if args.composite_demo != CompositeDemoArg::Off {
+                // T5 compositor smoke test: render two frames and average them.
+                // `clone` overlays the frame with itself (lossless check);
+                // `fork` overlays it with a world-space-offset copy of its scene
+                // (the fork+overlay demo — two visibly-different inputs).
+                let mut frame_b = frame.clone();
+                if args.composite_demo == CompositeDemoArg::Fork {
+                    frame_b.scene = functor_runtime_common::Scene3D {
+                        obj: functor_runtime_common::SceneObject::Group(vec![frame.scene.clone()]),
+                        xform: cgmath::Matrix4::from_translation(cgmath::vec3(6.0, 0.0, 0.0)),
+                    };
+                }
+                let frames = [frame.clone(), frame_b];
+                functor_runtime_common::render_composited_frames(
+                    &gl,
+                    shader_version,
+                    asset_cache.clone(),
+                    &scene_context,
+                    &shadow_map,
+                    &frames,
+                    &[0.5, 0.5],
+                    time.clone(),
+                    viewport,
+                    args.debug_render.into(),
+                );
             } else {
                 functor_runtime_common::render_frame(
                     &gl,


### PR DESCRIPTION
## T5 — screen-space compositor + fork-overlay demo

First slice of the T5→T6 authoring experiences (`docs/time-travel.md`). Adds a **screen-space compositor**: render K pure `Frame`s into K offscreen targets, then composite them onto the backbuffer as an exact **in-shader weighted average**. This is the shared foundation for **fork+overlay** (K=2 @ 0.5/0.5, this PR) and **forward-ghosting** (K=N @ 1/N, T6) — one primitive, two configurations.

The doc rewrite (T5–T8 roadmap, the "one event log" spine, the forward-ghosting/chronophotography design, and the shipped-status reconciliation ported forward from a stranded branch) folds into this PR.

### What's here
- `composite.rs` — the fullscreen-quad averaging shader (manually unrolled sampler reads for WebGL2 portability) + `normalize_weights` (sanitizes non-finite/negative weights; 6 unit tests).
- `SceneContext::draw_composite` — cached composite program (modelled on `draw_skybox`), fullscreen quad, depth off.
- `renderer::render_composited_frames` — renders each input `Frame` through the normal shadow+forward path into its own offscreen target, then composites onto the bound framebuffer (before the UI overlay, so it lands in `--capture-frame`).
- `--composite-demo {off|clone|fork}` desktop flag — the headless verification / demo hook.

### Verification (headless, deterministic)
- **Lossless:** `clone` (same frame composited twice @ 0.5/0.5) is **byte-identical** to a normal single render.
- **Fork:** two offset copies @ 0.5/0.5 visibly doubles all geometry + shadows at ~50% (before/after below).
- `cargo test -p functor_runtime_common` green; `--features strict` clean; `cargo check --target wasm32-unknown-unknown` + `wasm-pack build` pass.

### Review
Cross-engine `/xreview` (Claude + Codex). Visual axis confirmed by both. Fixes applied: `normalize_weights` per-element sanitize (both flagged), sampler-array manual unroll for WebGL2 (Codex). Post-fix captures re-verified byte-identical.

### Known limitation (→ T6 prerequisite)
`render_composited_frames` renders each input frame's **main scene only** — a frame that samples its *own* nested render target (e.g. `mle-monitor`) would get the fallback. Fine for the flat fork/ghost scenes here; when T6 feeds real game frames, factor the render-target prepass out of `render_frame` and run it per input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Visuals

Screen-space compositor with `--composite-demo fork` (K=2 @ 0.5/0.5): every cube + shadow is doubled at ~50% opacity, two offset timelines overlaid.

**Before → after** (both at `--fixed-time 2`, deterministic headless `--capture-frame`):

![T5 compositor before/after](https://gist.githubusercontent.com/tommy-xr/664cbdb53c166c5cd086a0df153de204/raw/t5-beforeafter.png)

<sub>Left: normal single render. Right: fork double-exposure — geometry and shadows doubled at ~50%.</sub>

![T5 compositor before/after toggle](https://gist.githubusercontent.com/tommy-xr/664cbdb53c166c5cd086a0df153de204/raw/t5-toggle.gif)

<sub>Toggle: same scene, normal render ↔ fork double-exposure.</sub>
