### PR TITLE
refactor(time-travel,mle): unify the duplicated MVU frame body (T6a)

### DIFF
--- a/runtime/functor-runtime-common/src/frame_time.rs
+++ b/runtime/functor-runtime-common/src/frame_time.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Copy, Serialize, Deserialize)]
 pub struct FrameTime {
     // tts - total time in seconds
     pub tts: f32,

--- a/runtime/functor-runtime-common/src/lib.rs
+++ b/runtime/functor-runtime-common/src/lib.rs
@@ -82,6 +82,7 @@ mod light;
 pub mod material;
 pub mod math;
 pub mod mle_prelude;
+pub mod mle_producer;
 pub mod model;
 pub mod net;
 pub mod physics;

--- a/runtime/functor-runtime-common/src/mle_producer.rs
+++ b/runtime/functor-runtime-common/src/mle_producer.rs
@@ -1,0 +1,518 @@
+//! The shared MVU per-frame body for the MLE producers (docs/time-travel.md
+//! T6a). Both shells — the desktop `functor-runner` and the web/wasm runtime —
+//! run the SAME game contract and per-frame orchestration; only I/O differs
+//! (file-watch vs editor push, winit vs DOM input *delivery*, stderr vs the
+//! browser console, native perf timing). Historically the frame body and its
+//! private helpers were copy-pasted between the two `mle_game.rs` producers;
+//! this module owns them once so they can never drift.
+//!
+//! Two pieces:
+//!
+//! - [`Reporter`] — per-frame error reporting: dedupe a persistent message to
+//!   one line (a 60fps loop must not flood the sink) and render error spans to
+//!   `path:line:col`. The SINK (stderr / console) is a shell-supplied `fn`
+//!   pointer and the source rendering is a [`SpanSource`], so this stays in
+//!   shared code without pulling in `web_sys`.
+//! - [`FrameCtx`] — a transient bundle of `&mut` borrows of the producer's
+//!   per-frame state. Its methods ARE the frame body (`before_physics` /
+//!   `physics_phase` / `record_frame`, or `run_frame` for all three) and the
+//!   duplicated helpers (`absorb`, `pump_subscriptions`, `step_physics`,
+//!   `deliver_*`). Each producer builds a `FrameCtx` from its owned fields and
+//!   drives the phases; the leaf logic (`drain_effects`, `SceneRecorder`,
+//!   `SteppedPhysics`) stays where it already lives.
+//!
+//! Input *delivery* is deliberately NOT unified (the shells queue/interleave it
+//! differently); live input still funnels through [`FrameCtx::absorb`], so the
+//! frame body begins at the scrub-commit and never absorbs live input itself.
+
+use std::collections::HashSet;
+
+use mle::{line_col, project::SourceMap, RunError, Session, Span, Value};
+
+use crate::mle_prelude::{
+    contains_effect, deliver_physics_events, drain_effects, http_response_value, needs_update,
+    net_conn_subs, net_event_value, perform_deferred_queries, physics_event_taggers,
+    physics_scene_value, split_model_effect, sub_messages_for_frame, take_audio_completion,
+    take_http_tagger, EffectLog, EffectTree, FunctorHost, NetEventKind, RealEffects,
+};
+use crate::net::{push_conn_command, ConnCommand, HttpResult};
+use crate::physics::{PhysicsEvent, SteppedPhysics};
+use crate::timetravel::SceneRecorder;
+use crate::FrameTime;
+
+/// Where a producer resolves per-frame error spans to `path:line:col: message`.
+/// The two shells hold their source differently (a multi-file project map on
+/// desktop; the single fetched entry source on web), so this captures both.
+pub enum SpanSource {
+    /// Desktop: a whole-project source map (multi-file, project-wide spans).
+    Project(SourceMap),
+    /// Web: the single fetched entry source plus its label path.
+    Single { src: String, path: String },
+}
+
+impl SpanSource {
+    fn render(&self, span: Span, message: &str) -> String {
+        match self {
+            SpanSource::Project(map) => map.render(span.start, message),
+            SpanSource::Single { src, path } => {
+                let (line, col) = line_col(src, span.start);
+                format!("{path}:{line}:{col}: {message}")
+            }
+        }
+    }
+}
+
+/// Per-frame error reporting, shared by both producers. Dedupes a persistent
+/// message to one line and renders `RunError` spans to source positions. The
+/// output SINK differs per shell (stderr vs the browser console) — supplied as
+/// a plain `fn` pointer at construction — as does the source rendering
+/// ([`SpanSource`]).
+pub struct Reporter {
+    last_error: Option<String>,
+    source: SpanSource,
+    emit: fn(&str),
+}
+
+impl Reporter {
+    pub fn new(source: SpanSource, emit: fn(&str)) -> Reporter {
+        Reporter {
+            last_error: None,
+            source,
+            emit,
+        }
+    }
+
+    /// Swap the source rendered against — a hot reload / push replaced it.
+    pub fn set_source(&mut self, source: SpanSource) {
+        self.source = source;
+    }
+
+    /// Clear the dedupe slot: a reload starts a fresh error stream.
+    pub fn reset(&mut self) {
+        self.last_error = None;
+    }
+
+    /// Print a message once per distinct string — a 60fps loop must not flood
+    /// the sink with one persistent bug.
+    pub fn report_once(&mut self, message: String) {
+        if self.last_error.as_deref() != Some(message.as_str()) {
+            (self.emit)(&message);
+            self.last_error = Some(message);
+        }
+    }
+
+    /// Render + report a per-frame `RunError` at its source position (deduped).
+    /// The span identifies the file too (project-wide spans), so an error in a
+    /// sibling module names that module's file.
+    pub fn frame_error(&mut self, stage: &str, err: &RunError) {
+        let rendered = format!(
+            "[mle] {stage} error at {}",
+            self.source.render(err.span, &err.message)
+        );
+        self.report_once(rendered);
+    }
+}
+
+/// A transient bundle of `&mut` borrows of a producer's per-frame state. The
+/// shared MVU frame body and its helpers run through it, so both shells execute
+/// byte-identical game logic. Built cheaply (all borrows) whenever a producer
+/// needs to run frame work, and dropped at the end of the call.
+pub struct FrameCtx<'a> {
+    pub session: &'a Session,
+    pub model: &'a mut Value,
+    pub physics_rt: &'a mut SteppedPhysics,
+    pub physics_status: &'a mut (u64, bool, u64),
+    pub recorder: &'a mut SceneRecorder,
+    pub effect_runner: &'a mut RealEffects,
+    pub effect_log: &'a mut EffectLog,
+    pub deferred_queries: &'a mut Vec<EffectTree>,
+    pub pending_events: &'a mut Vec<PhysicsEvent>,
+    pub live_conn_keys: &'a mut HashSet<String>,
+    pub prev_tts: &'a mut Option<f64>,
+    pub has_physics: bool,
+    pub has_subscriptions: bool,
+    pub reporter: &'a mut Reporter,
+}
+
+impl FrameCtx<'_> {
+    /// One full MVU frame: scrub-commit → subscriptions → tick+absorb → physics
+    /// (step + query drain + events) → record. Used by shells that don't split
+    /// the frame for perf timing (web). Desktop calls the three phases directly
+    /// so it can time `tick` and `physics` separately.
+    pub fn run_frame(&mut self, frame_time: FrameTime) {
+        self.before_physics(frame_time);
+        self.physics_phase(frame_time);
+        self.record_frame(frame_time);
+    }
+
+    /// The pre-physics phase: commit a resuming scrub, pump subscriptions, then
+    /// run `tick` and absorb its result. (Desktop times this as `tick_ns`.)
+    pub fn before_physics(&mut self, frame_time: FrameTime) {
+        // Committing a scrub (docs/time-travel.md T3): if play resumes (dts > 0)
+        // while the draggable bar is parked on an earlier frame, branch the
+        // timeline from there BEFORE this frame advances — and drop any in-flight
+        // frame work so it doesn't cross the branch (the reload discipline).
+        if frame_time.dts > 0.0
+            && self.recorder.commit_scrub_if_resuming(
+                self.model,
+                self.physics_rt,
+                self.physics_status,
+                self.has_physics,
+            )
+        {
+            self.deferred_queries.clear();
+            self.pending_events.clear();
+        }
+        // Subscriptions first, so `tick` sees a model that has absorbed this
+        // frame's messages (the F# executor's ordering).
+        self.pump_subscriptions(frame_time.tts as f64);
+        let args = vec![
+            self.model.clone(),
+            Value::Number(frame_time.dts as f64),
+            Value::Number(frame_time.tts as f64),
+        ];
+        match self.session.call("tick", args, &mut FunctorHost) {
+            Ok(returned) => self.absorb(returned),
+            Err(err) => self.reporter.frame_error("tick", &err),
+        }
+    }
+
+    /// The physics phase: reconcile + fixed-step the world, then drain deferred
+    /// queries and deliver collision events against the just-stepped world.
+    /// (Desktop times this as `physics_ns`.)
+    pub fn physics_phase(&mut self, frame_time: FrameTime) {
+        let physics_steps = self.step_physics(frame_time.dts as f32);
+        // Post-step query drain: deferred raycasts answer against the world
+        // just stepped; their messages fold through `update` before `draw`,
+        // so this frame's render already reflects them.
+        // On a ZERO-substep frame (the accumulator short of FIXED_DT — normal
+        // right after load and at >60fps) queries stay deferred, like pending
+        // commands, so they never answer against a world that hasn't
+        // simulated. Games without a physics hook answer immediately (the
+        // lazily-created empty world gives sane misses).
+        // A query answers once the world has EVER stepped: normally this
+        // frame's steps, but also while PAUSED (frozen mid-flight, frame > 0)
+        // and on a short zero-substep frame — so a raycast fired while paused
+        // answers against the frozen world instead of deferring forever.
+        let world_ready = physics_steps > 0 || !self.has_physics || self.physics_status.0 > 0;
+        if world_ready && !self.deferred_queries.is_empty() {
+            let deferred = std::mem::take(self.deferred_queries);
+            let mut reports: Vec<String> = Vec::new();
+            perform_deferred_queries(
+                self.session,
+                self.model,
+                deferred,
+                self.effect_runner,
+                self.effect_log,
+                &mut |message| reports.push(message),
+            );
+            for message in reports {
+                self.reporter.report_once(message);
+            }
+        }
+        // Collision events (docs/physics.md Phase 5): this frame's contact
+        // transitions, delivered to the `Physics.events` taggers of the
+        // CURRENT model's subscriptions — post-step, alongside query answers.
+        let events = std::mem::take(self.pending_events);
+        if !events.is_empty() && self.has_subscriptions {
+            match self
+                .session
+                .call("subscriptions", vec![self.model.clone()], &mut FunctorHost)
+            {
+                Ok(subs) => match physics_event_taggers(&subs) {
+                    Ok(taggers) if !taggers.is_empty() => {
+                        let mut reports: Vec<String> = Vec::new();
+                        deliver_physics_events(
+                            self.session,
+                            self.model,
+                            &taggers,
+                            &events,
+                            self.effect_runner,
+                            self.effect_log,
+                            &mut |message| reports.push(message),
+                        );
+                        for message in reports {
+                            self.reporter.report_once(message);
+                        }
+                    }
+                    Ok(_) => {}
+                    Err(message) => self.reporter.report_once(format!("[mle] {message}")),
+                },
+                Err(err) => self.reporter.frame_error("subscriptions", &err),
+            }
+        }
+    }
+
+    /// Record the settled model of this rendered frame (docs/time-travel.md T1)
+    /// plus the physics fixed-frame the world reached, in lockstep, so a coupled
+    /// rewind can restore both. `physics_status.0` is the world's current fixed
+    /// frame.
+    ///
+    /// Skip a PAUSED frame (`dts == 0`, i.e. the clock pinned): the sim hasn't
+    /// advanced, so recording would only pile up frozen duplicates — inflating
+    /// the timeline and pushing a rewind target past the real history.
+    /// `dts == 0` is exactly the pinned-and-not-stepping case (a one-shot step
+    /// carries `dts > 0`).
+    pub fn record_frame(&mut self, frame_time: FrameTime) {
+        if frame_time.dts > 0.0 {
+            self.recorder.record(self.model, self.physics_status.0);
+        }
+    }
+
+    /// Take an entry point's return: split off any `(model, effect)` pair,
+    /// adopt the model, and drain the effects to a fixed point through `update`
+    /// (docs/mle.md B6). Every producer path that runs game code funnels through
+    /// here, so effects work uniformly from tick, input, mouse, and messages.
+    pub fn absorb(&mut self, returned: Value) {
+        let (model, effects) = split_model_effect(returned);
+        *self.model = model;
+        // Effects are commands, not data — one stored in the model would make
+        // the pair sniff ambiguous on a later return (see `split_model_effect`).
+        if contains_effect(self.model) {
+            self.reporter.report_once(
+                "[mle] the model contains an Effect value — Effects are commands, \
+not data; return them beside the model as `(model, effect)` instead of storing them"
+                    .to_string(),
+            );
+        }
+        let Some(effects) = effects else { return };
+        // Only MESSAGE-producing effects need an `update` to receive them —
+        // tagger-less physics commands must not be dropped over a missing hook.
+        if needs_update(&effects) && self.session.global("update").is_none() {
+            self.reporter.report_once(
+                "[mle] effects returned but there is no `let update = (model, msg) => …` \
+to receive their messages; dropping them"
+                    .to_string(),
+            );
+            return;
+        }
+        let mut reports: Vec<String> = Vec::new();
+        let deferred = drain_effects(
+            self.session,
+            self.model,
+            effects,
+            self.effect_runner,
+            self.effect_log,
+            &mut |message| reports.push(message),
+        );
+        // Physics queries wait for the post-step drain (end of the frame), so
+        // their taggers answer against THIS frame's stepped world.
+        self.deferred_queries.extend(deferred);
+        for message in reports {
+            self.reporter.report_once(message);
+        }
+    }
+
+    /// Fire subscription timers over `(prev_tts, tts]` and fold their messages
+    /// through `update`, before this frame's `tick` — the message drain seam
+    /// (docs/mle.md C4b-2). Subscriptions are recomputed from the current model
+    /// each frame, so a model change can silence a timer. Errors report per
+    /// message and processing continues.
+    fn pump_subscriptions(&mut self, tts: f64) {
+        // Advance the window even without subscriptions (or on frame one), so a
+        // hot reload that ADDS subscriptions starts from a sane edge.
+        let prev = self.prev_tts.replace(tts);
+        if !self.has_subscriptions {
+            // No subscriptions must not leave a previous program's connections
+            // open (a hot reload that dropped them).
+            if !self.live_conn_keys.is_empty() {
+                self.close_all_connections();
+            }
+            return;
+        }
+        let subs = match self
+            .session
+            .call("subscriptions", vec![self.model.clone()], &mut FunctorHost)
+        {
+            Ok(subs) => subs,
+            Err(err) => return self.reporter.frame_error("subscriptions", &err),
+        };
+        // Reconcile connections EVERY frame — including frame one (before the
+        // timer window exists), so a declared connection opens immediately.
+        self.reconcile_connections(&subs);
+        let Some(prev) = prev else {
+            return;
+        };
+        let msgs = match sub_messages_for_frame(&subs, prev, tts) {
+            Ok(msgs) => msgs,
+            Err(message) => return self.reporter.report_once(format!("[mle] {message}")),
+        };
+        for msg in msgs {
+            match self
+                .session
+                .call("update", vec![self.model.clone(), msg], &mut FunctorHost)
+            {
+                Ok(returned) => self.absorb(returned),
+                Err(err) => self.reporter.frame_error("update", &err),
+            }
+        }
+    }
+
+    /// The frame's physics phase (docs/physics.md): ask the game what bodies
+    /// should exist, reconcile the singleton world to match, and advance it in
+    /// fixed substeps. Runs after `tick` so declarations come from the settled
+    /// model, and before `render` so `Physics.position`/`Physics.transformed`
+    /// in `draw` read the just-stepped world. Returns the number of fixed
+    /// substeps taken (0 when there is no `physics` hook, the hook errored, or
+    /// the accumulator hasn't reached a full step yet).
+    fn step_physics(&mut self, dts: f32) -> u32 {
+        if !self.has_physics {
+            return 0;
+        }
+        let args = vec![self.model.clone()];
+        match self.session.call("physics", args, &mut FunctorHost) {
+            Ok(value) => match physics_scene_value(&value) {
+                Some(scene) => {
+                    // The recorded drive (Phase 6): every fixed frame goes
+                    // through the Timeline, so pause/rewind/replay work.
+                    let advanced = self.physics_rt.advance(scene, dts);
+                    *self.pending_events = advanced.events;
+                    *self.physics_status = advanced.status;
+                    let steps = advanced.steps;
+                    let warnings = advanced.warnings;
+                    // Command effects apply asynchronously (queued at perform
+                    // time, applied at the step), so their problems — unknown
+                    // tag, queue overflow — surface here, deduped.
+                    for warning in warnings {
+                        self.reporter.report_once(format!("[mle] {warning}"));
+                    }
+                    return steps;
+                }
+                None => self.reporter.report_once(format!(
+                    "[mle] physics must return Physics.scene(gx, gy, gz, [body, …]), got {}",
+                    value.kind_name()
+                )),
+            },
+            Err(err) => self.reporter.frame_error("physics", &err),
+        }
+        0
+    }
+
+    /// Close every connection this producer still has open (a reload that
+    /// dropped `subscriptions`, or shutdown). CloseKey is queued for each; the
+    /// live set is cleared.
+    pub fn close_all_connections(&mut self) {
+        for key in std::mem::take(self.live_conn_keys) {
+            push_conn_command(ConnCommand::CloseKey { key });
+        }
+    }
+
+    /// Open connections newly declared this frame and close ones no longer
+    /// declared (keyed by endpoint). Commands go to the shell's connection
+    /// manager, drained via `net_drain_conn_commands`. The physics-events
+    /// pattern for connections.
+    fn reconcile_connections(&mut self, subs: &Value) {
+        let conns = match net_conn_subs(subs) {
+            Ok(conns) => conns,
+            Err(message) => return self.reporter.report_once(format!("[mle] {message}")),
+        };
+        // Dedupe by key (first declaration wins its listen/connect role) so a
+        // key is opened at most once even if declared twice in one frame.
+        let mut declared: HashSet<String> = HashSet::new();
+        for conn in &conns {
+            if !declared.insert(conn.key.clone()) {
+                continue; // already handled this key this frame
+            }
+            if !self.live_conn_keys.contains(&conn.key) {
+                push_conn_command(if conn.listen {
+                    ConnCommand::Listen {
+                        key: conn.key.clone(),
+                        addr: conn.key.clone(),
+                    }
+                } else {
+                    ConnCommand::Connect {
+                        key: conn.key.clone(),
+                        url: conn.key.clone(),
+                    }
+                });
+            }
+        }
+        for key in self.live_conn_keys.iter() {
+            if !declared.contains(key) {
+                push_conn_command(ConnCommand::CloseKey { key: key.clone() });
+            }
+        }
+        *self.live_conn_keys = declared;
+    }
+
+    /// Route one inbound connection event to the matching key's tagger and fold
+    /// the message through `update`. Taggers are read FRESH from the current
+    /// `subscriptions(model)` (never cached — a reload rebinds them).
+    pub fn deliver_net_event(&mut self, key: String, kind: NetEventKind, conn: i32, text: String) {
+        if !self.has_subscriptions {
+            return;
+        }
+        let subs = match self
+            .session
+            .call("subscriptions", vec![self.model.clone()], &mut FunctorHost)
+        {
+            Ok(subs) => subs,
+            Err(err) => return self.reporter.frame_error("subscriptions", &err),
+        };
+        let conns = match net_conn_subs(&subs) {
+            Ok(conns) => conns,
+            Err(message) => return self.reporter.report_once(format!("[mle] {message}")),
+        };
+        let Some(sub) = conns.into_iter().find(|c| c.key == key) else {
+            return; // an event for a no-longer-declared connection: drop it
+        };
+        let value = net_event_value(kind, conn as u64, &text).to_mle();
+        let msg = match self
+            .session
+            .apply(sub.tagger, vec![value], "net event", &mut FunctorHost)
+        {
+            Ok(msg) => msg,
+            Err(err) => return self.reporter.frame_error("net event", &err),
+        };
+        match self
+            .session
+            .call("update", vec![self.model.clone(), msg], &mut FunctorHost)
+        {
+            Ok(returned) => self.absorb(returned),
+            Err(err) => self.reporter.frame_error("update", &err),
+        }
+    }
+
+    /// Route a completed HTTP request to the tagger registered when the request
+    /// fired (frames ago), folding the resulting message through `update`. An
+    /// orphaned token — a hot reload dropped its tagger while the request was in
+    /// flight — is silently ignored.
+    pub fn deliver_http_result(&mut self, result: HttpResult) {
+        let Some(tagger) = take_http_tagger(result.token) else {
+            return;
+        };
+        let value = http_response_value(&result);
+        let msg = match self
+            .session
+            .apply(tagger, vec![value], "http response", &mut FunctorHost)
+        {
+            Ok(msg) => msg,
+            Err(err) => return self.reporter.frame_error("http response", &err),
+        };
+        match self
+            .session
+            .call("update", vec![self.model.clone(), msg], &mut FunctorHost)
+        {
+            Ok(returned) => self.absorb(returned),
+            Err(err) => self.reporter.frame_error("update", &err),
+        }
+    }
+
+    /// Route a finished `playThen` one-shot to the completion MESSAGE registered
+    /// when it fired (frames ago), folding it through `update`. Unlike
+    /// `deliver_http_result` there is no tagger: the message is delivered
+    /// verbatim. An orphaned token — a reload dropped its message mid-flight —
+    /// is silently ignored.
+    pub fn deliver_audio_completion(&mut self, token: u64) {
+        let Some(message) = take_audio_completion(token) else {
+            return;
+        };
+        match self
+            .session
+            .call("update", vec![self.model.clone(), message], &mut FunctorHost)
+        {
+            Ok(returned) => self.absorb(returned),
+            Err(err) => self.reporter.frame_error("update", &err),
+        }
+    }
+}

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -30,12 +30,10 @@
 use std::time::Instant;
 
 use functor_runtime_common::mle_prelude::{
-    audio_scene_of, clear_audio_completions, clear_http_taggers, contains_effect,
-    deliver_physics_events, drain_effects, frame_value, http_response_value, needs_update,
-    net_conn_subs, net_event_value, perform_deferred_queries, physics_event_taggers,
-    physics_scene_value, split_model_effect, sub_messages_for_frame, take_audio_completion,
-    take_http_tagger, view_value, EffectLog, EffectTree, FunctorHost, NetEventKind, RealEffects,
+    audio_scene_of, clear_audio_completions, clear_http_taggers, frame_value, view_value,
+    EffectLog, EffectTree, FunctorHost, NetEventKind, RealEffects,
 };
+use functor_runtime_common::mle_producer::{FrameCtx, Reporter, SpanSource};
 use functor_runtime_common::physics;
 use functor_runtime_common::timetravel::SceneRecorder;
 use functor_runtime_common::ui::View;
@@ -59,8 +57,6 @@ pub struct MleGame {
     /// changes on disk (last-write-wins, from either side — the existing
     /// push contract, now per file).
     pushed_entry: Option<String>,
-    /// Renders the merged module's project-wide spans back to file:line:col.
-    sources: SourceMap,
     /// The lowered (merged) module the current session came from — kept so
     /// a reload can rebind model-stored closures (old module × new module).
     module: mle::ir::Module,
@@ -128,10 +124,9 @@ pub struct MleGame {
     /// The last successfully drawn frame, kept so a bad draw shows the last
     /// good picture instead of a blank.
     last_frame: Frame,
-    /// The last per-frame error printed, to avoid flooding stderr at 60fps
-    /// with the same message (a persistent error prints once until it
-    /// changes).
-    last_error: Option<String>,
+    /// Per-frame error reporting (dedupe + stderr sink + project-span
+    /// rendering) — shared with the web producer (`mle_producer::Reporter`).
+    reporter: Reporter,
     // rolling per-frame eval cost, printed every STATS_EVERY frames (the C6
     // perf gate watches these). Physics is engine cost, not MLE eval cost, so
     // it gets its own counter — a heavy scene must not read as an interpreter
@@ -323,7 +318,6 @@ impl MleGame {
             path: path.to_string(),
             stamp,
             pushed_entry: None,
-            sources: loaded.sources,
             module: loaded.module,
             session: loaded.session,
             model: loaded.init,
@@ -346,7 +340,7 @@ impl MleGame {
             recorder: SceneRecorder::new(),
             live_conn_keys: std::collections::HashSet::new(),
             last_frame: empty_frame(),
-            last_error: None,
+            reporter: Reporter::new(SpanSource::Project(loaded.sources), report_to_stderr),
             frames: 0,
             tick_ns: 0,
             physics_ns: 0,
@@ -354,293 +348,26 @@ impl MleGame {
         }
     }
 
-    /// Print a per-frame problem once per distinct message — a 60fps loop must
-    /// not flood stderr with one persistent bug.
-    fn report_once(&mut self, rendered: String) {
-        if self.last_error.as_deref() != Some(rendered.as_str()) {
-            eprintln!("{rendered}");
-            self.last_error = Some(rendered);
-        }
-    }
-
-    /// Report a per-frame error with its source position (deduped). The
-    /// span identifies the file too (project-wide spans), so an error inside
-    /// a sibling module names that module's file.
-    fn frame_error(&mut self, stage: &str, err: &mle::RunError) {
-        let rendered = format!(
-            "[mle] {stage} error at {}",
-            self.sources.render(err.span.start, &err.message)
-        );
-        self.report_once(rendered);
-    }
-
-    /// The frame's physics phase (docs/physics.md): ask the game what bodies
-    /// should exist, reconcile the singleton world to match, and advance it in
-    /// fixed substeps. Runs after `tick` so declarations come from the settled
-    /// model, and before `render` so `Physics.position`/`Physics.transformed`
-    /// in `draw` read the just-stepped world.
-    /// Returns the number of fixed substeps taken (0 when there is no
-    /// `physics` hook, the hook errored, or the accumulator hasn't reached a
-    /// full step yet).
-    fn step_physics(&mut self, dts: f32) -> u32 {
-        if !self.has_physics {
-            return 0;
-        }
-        let args = vec![self.model.clone()];
-        match self.session.call("physics", args, &mut FunctorHost) {
-            Ok(value) => match physics_scene_value(&value) {
-                Some(scene) => {
-                    // The recorded drive (Phase 6): every fixed frame goes
-                    // through the Timeline, so pause/rewind/replay work.
-                    let advanced = self.physics_rt.advance(scene, dts);
-                    self.pending_events = advanced.events;
-                    self.physics_status = advanced.status;
-                    let steps = advanced.steps;
-                    let warnings = advanced.warnings;
-                    // Command effects apply asynchronously (queued at perform
-                    // time, applied at the step), so their problems — unknown
-                    // tag, queue overflow — surface here, deduped.
-                    for warning in warnings {
-                        self.report_once(format!("[mle] {warning}"));
-                    }
-                    return steps;
-                }
-                None => self.report_once(format!(
-                    "[mle] physics must return Physics.scene(gx, gy, gz, [body, …]), got {}",
-                    value.kind_name()
-                )),
-            },
-            Err(err) => self.frame_error("physics", &err),
-        }
-        0
-    }
-
-    /// Take an entry point's return: split off any `(model, effect)` pair,
-    /// adopt the model, and drain the effects to a fixed point through
-    /// `update` (docs/mle.md B6). Every producer path that runs game code
-    /// funnels through here, so effects work uniformly from tick, input,
-    /// mouse, and subscription messages.
-    fn absorb(&mut self, returned: Value) {
-        let (model, effects) = split_model_effect(returned);
-        self.model = model;
-        // Effects are commands, not data — one stored in the model would
-        // make the pair sniff ambiguous on a later return (see
-        // `split_model_effect`). Warn loud; the model is small (it is
-        // interpreted every frame anyway) so the scan is cheap.
-        if contains_effect(&self.model) {
-            self.report_once(
-                "[mle] the model contains an Effect value — Effects are commands, \
-not data; return them beside the model as `(model, effect)` instead of storing them"
-                    .to_string(),
-            );
-        }
-        let Some(effects) = effects else { return };
-        // Only MESSAGE-producing effects need an `update` to receive them —
-        // tagger-less physics commands must not be dropped over a missing
-        // hook (that guard silently ate them; caught by capture-verifying
-        // the mle-physics kick).
-        if needs_update(&effects) && self.session.global("update").is_none() {
-            self.report_once(
-                "[mle] effects returned but there is no `let update = (model, msg) => …` \
-to receive their messages; dropping them"
-                    .to_string(),
-            );
-            return;
-        }
-        let mut reports: Vec<String> = Vec::new();
-        let deferred = drain_effects(
-            &self.session,
-            &mut self.model,
-            effects,
-            &mut self.effect_runner,
-            &mut self.effect_log,
-            &mut |message| reports.push(message),
-        );
-        // Physics queries wait for the post-step drain (end of `tick`), so
-        // their taggers answer against THIS frame's stepped world.
-        self.deferred_queries.extend(deferred);
-        for message in reports {
-            self.report_once(message);
-        }
-    }
-
-    /// Fire subscription timers over `(prev_tts, tts]` and fold their
-    /// messages through `update`, before this frame's `tick` — the message
-    /// drain seam (docs/mle.md C4b-2; B6's effects will feed this same
-    /// path). Subscriptions are recomputed from the current model each
-    /// frame, so a model change can silence a timer. Errors report per
-    /// message and processing continues — one bad message must not stall
-    /// the rest, and dedupe keeps a persistent bug to one line.
-    /// Close every connection this producer still has open (a reload that
-    /// dropped `subscriptions`, or shutdown). CloseKey is queued for each;
-    /// the live set is cleared.
-    fn close_all_connections(&mut self) {
-        use functor_runtime_common::net::{push_conn_command, ConnCommand};
-        for key in std::mem::take(&mut self.live_conn_keys) {
-            push_conn_command(ConnCommand::CloseKey { key });
-        }
-    }
-
-    /// Open connections newly declared this frame and close ones no longer
-    /// declared (keyed by endpoint). Commands go to the shell's connection
-    /// manager, drained via `net_drain_conn_commands`. The physics-events
-    /// pattern for connections.
-    fn reconcile_connections(&mut self, subs: &Value) {
-        use functor_runtime_common::net::{push_conn_command, ConnCommand};
-        let conns = match net_conn_subs(subs) {
-            Ok(conns) => conns,
-            Err(message) => return self.report_once(format!("[mle] {message}")),
-        };
-        // Dedupe by key (first declaration wins its listen/connect role) so
-        // a key is opened at most once even if declared twice in one frame.
-        let mut declared: std::collections::HashSet<String> = std::collections::HashSet::new();
-        for conn in &conns {
-            if !declared.insert(conn.key.clone()) {
-                continue; // already handled this key this frame
-            }
-            if !self.live_conn_keys.contains(&conn.key) {
-                push_conn_command(if conn.listen {
-                    ConnCommand::Listen {
-                        key: conn.key.clone(),
-                        addr: conn.key.clone(),
-                    }
-                } else {
-                    ConnCommand::Connect {
-                        key: conn.key.clone(),
-                        url: conn.key.clone(),
-                    }
-                });
-            }
-        }
-        for key in &self.live_conn_keys {
-            if !declared.contains(key) {
-                push_conn_command(ConnCommand::CloseKey { key: key.clone() });
-            }
-        }
-        self.live_conn_keys = declared;
-    }
-
-    /// Route one inbound connection event to the matching key's tagger and
-    /// fold the message through `update`. Taggers are read FRESH from the
-    /// current `subscriptions(model)` (never cached — a reload rebinds them).
-    fn deliver_net_event(&mut self, key: String, kind: NetEventKind, conn: i32, text: String) {
-        if !self.has_subscriptions {
-            return;
-        }
-        let subs =
-            match self
-                .session
-                .call("subscriptions", vec![self.model.clone()], &mut FunctorHost)
-            {
-                Ok(subs) => subs,
-                Err(err) => return self.frame_error("subscriptions", &err),
-            };
-        let conns = match net_conn_subs(&subs) {
-            Ok(conns) => conns,
-            Err(message) => return self.report_once(format!("[mle] {message}")),
-        };
-        let Some(sub) = conns.into_iter().find(|c| c.key == key) else {
-            return; // an event for a no-longer-declared connection: drop it
-        };
-        let value = net_event_value(kind, conn as u64, &text).to_mle();
-        let msg = match self
-            .session
-            .apply(sub.tagger, vec![value], "net event", &mut FunctorHost)
-        {
-            Ok(msg) => msg,
-            Err(err) => return self.frame_error("net event", &err),
-        };
-        match self
-            .session
-            .call("update", vec![self.model.clone(), msg], &mut FunctorHost)
-        {
-            Ok(returned) => self.absorb(returned),
-            Err(err) => self.frame_error("update", &err),
-        }
-    }
-
-    /// Route a completed HTTP request to the tagger registered when the request
-    /// fired (frames ago), folding the resulting message through `update`. The
-    /// arrival hook (the shell calls this when net_dispatch completes). An
-    /// orphaned token — a hot reload dropped its tagger while the request was
-    /// in flight — is silently ignored.
-    fn deliver_http_result(&mut self, result: functor_runtime_common::net::HttpResult) {
-        let Some(tagger) = take_http_tagger(result.token) else {
-            return;
-        };
-        let value = http_response_value(&result);
-        let msg = match self
-            .session
-            .apply(tagger, vec![value], "http response", &mut FunctorHost)
-        {
-            Ok(msg) => msg,
-            Err(err) => return self.frame_error("http response", &err),
-        };
-        match self
-            .session
-            .call("update", vec![self.model.clone(), msg], &mut FunctorHost)
-        {
-            Ok(returned) => self.absorb(returned),
-            Err(err) => self.frame_error("update", &err),
-        }
-    }
-
-    /// Route a finished `playThen` one-shot to the completion MESSAGE registered
-    /// when it fired (frames ago), folding it through `update`. Unlike
-    /// `deliver_http_result` there is no tagger: the message is delivered
-    /// verbatim. An orphaned token — a reload dropped its message mid-flight —
-    /// is silently ignored.
-    fn deliver_audio_completion(&mut self, token: u64) {
-        let Some(message) = take_audio_completion(token) else {
-            return;
-        };
-        match self
-            .session
-            .call("update", vec![self.model.clone(), message], &mut FunctorHost)
-        {
-            Ok(returned) => self.absorb(returned),
-            Err(err) => self.frame_error("update", &err),
-        }
-    }
-
-    fn pump_subscriptions(&mut self, tts: f64) {
-        // Advance the window even without subscriptions (or on frame one),
-        // so a hot reload that ADDS subscriptions starts from a sane edge.
-        let prev = self.prev_tts.replace(tts);
-        if !self.has_subscriptions {
-            // No subscriptions must not leave a previous program's
-            // connections open (a hot reload that dropped them).
-            if !self.live_conn_keys.is_empty() {
-                self.close_all_connections();
-            }
-            return;
-        }
-        let subs =
-            match self
-                .session
-                .call("subscriptions", vec![self.model.clone()], &mut FunctorHost)
-            {
-                Ok(subs) => subs,
-                Err(err) => return self.frame_error("subscriptions", &err),
-            };
-        // Reconcile connections EVERY frame — including frame one (before the
-        // timer window exists), so a declared connection opens immediately.
-        self.reconcile_connections(&subs);
-        let Some(prev) = prev else {
-            return;
-        };
-        let msgs = match sub_messages_for_frame(&subs, prev, tts) {
-            Ok(msgs) => msgs,
-            Err(message) => return self.report_once(format!("[mle] {message}")),
-        };
-        for msg in msgs {
-            match self
-                .session
-                .call("update", vec![self.model.clone(), msg], &mut FunctorHost)
-            {
-                Ok(returned) => self.absorb(returned),
-                Err(err) => self.frame_error("update", &err),
-            }
+    /// Bundle this producer's per-frame state into the shared [`FrameCtx`]
+    /// (docs/time-travel.md T6a) — the frame body and its helpers (`absorb`,
+    /// `pump_subscriptions`, `step_physics`, `deliver_*`) live there, one copy
+    /// for both shells. A cheap borrow-only view, rebuilt per call.
+    fn ctx(&mut self) -> FrameCtx<'_> {
+        FrameCtx {
+            session: &self.session,
+            model: &mut self.model,
+            physics_rt: &mut self.physics_rt,
+            physics_status: &mut self.physics_status,
+            recorder: &mut self.recorder,
+            effect_runner: &mut self.effect_runner,
+            effect_log: &mut self.effect_log,
+            deferred_queries: &mut self.deferred_queries,
+            pending_events: &mut self.pending_events,
+            live_conn_keys: &mut self.live_conn_keys,
+            prev_tts: &mut self.prev_tts,
+            has_physics: self.has_physics,
+            has_subscriptions: self.has_subscriptions,
+            reporter: &mut self.reporter,
         }
     }
 
@@ -661,7 +388,7 @@ to receive their messages; dropping them"
         for warning in &report.warnings {
             eprintln!("[mle] reload: {warning}");
         }
-        self.sources = loaded.sources;
+        self.reporter.set_source(SpanSource::Project(loaded.sources));
         self.module = loaded.module;
         self.session = loaded.session;
         self.has_input = loaded.has_input;
@@ -684,7 +411,7 @@ to receive their messages; dropping them"
             // Deleting the `ui` hook drops the HUD (the physics-world rule).
             self.last_view = View::Empty;
         }
-        self.last_error = None;
+        self.reporter.reset();
         // A deferred query or in-flight HTTP request holds a tagger — a closure
         // into the OLD session; drop them rather than let them dangle. A late
         // HTTP response for a dropped token arrives orphaned and is ignored.
@@ -768,7 +495,7 @@ impl Game for MleGame {
                 );
             }
             Err(message) => {
-                self.report_once(format!(
+                self.reporter.report_once(format!(
                     "[mle] reload failed, keeping old program: {message}"
                 ));
             }
@@ -852,111 +579,16 @@ impl Game for MleGame {
     }
 
     fn tick(&mut self, frame_time: FrameTime) {
+        // The frame body lives in the shared `FrameCtx` (docs/time-travel.md
+        // T6a); native splits it at the physics boundary to keep the separate
+        // `tick_ns` / `physics_ns` perf counters the C6 gate watches.
         let started = Instant::now();
-        // Committing a scrub (docs/time-travel.md T3): if play resumes (dts > 0)
-        // while the draggable bar is parked on an earlier frame, branch the
-        // timeline from there BEFORE this frame advances — and drop any in-flight
-        // frame work so it doesn't cross the branch (the reload discipline).
-        if frame_time.dts > 0.0
-            && self.recorder.commit_scrub_if_resuming(
-                &mut self.model,
-                &mut self.physics_rt,
-                &mut self.physics_status,
-                self.has_physics,
-            )
-        {
-            self.deferred_queries.clear();
-            self.pending_events.clear();
-        }
-        // Subscriptions first, so `tick` sees a model that has absorbed this
-        // frame's messages (the F# executor's ordering).
-        self.pump_subscriptions(frame_time.tts as f64);
-        let args = vec![
-            self.model.clone(),
-            Value::Number(frame_time.dts as f64),
-            Value::Number(frame_time.tts as f64),
-        ];
-        match self.session.call("tick", args, &mut FunctorHost) {
-            Ok(returned) => self.absorb(returned),
-            Err(err) => self.frame_error("tick", &err),
-        }
+        self.ctx().before_physics(frame_time);
         self.tick_ns += started.elapsed().as_nanos() as u64;
         let physics_started = Instant::now();
-        let physics_steps = self.step_physics(frame_time.dts);
-        // Post-step query drain: deferred raycasts answer against the world
-        // just stepped; their messages fold through `update` before `draw`,
-        // so this frame's render already reflects them.
-        // On a ZERO-substep frame (the accumulator short of FIXED_DT — normal
-        // right after load and at >60fps) queries stay deferred, like pending
-        // commands, so they never answer against a world that hasn't
-        // simulated. Games without a physics hook answer immediately (the
-        // lazily-created empty world gives sane misses).
-        // A query answers once the world has EVER stepped: normally this
-        // frame's steps, but also while PAUSED (frozen mid-flight, frame > 0)
-        // and on a short zero-substep frame — so a raycast fired while paused
-        // answers against the frozen world instead of deferring forever.
-        let world_ready = physics_steps > 0 || !self.has_physics || self.physics_status.0 > 0;
-        if world_ready && !self.deferred_queries.is_empty() {
-            let deferred = std::mem::take(&mut self.deferred_queries);
-            let mut reports: Vec<String> = Vec::new();
-            perform_deferred_queries(
-                &self.session,
-                &mut self.model,
-                deferred,
-                &mut self.effect_runner,
-                &mut self.effect_log,
-                &mut |message| reports.push(message),
-            );
-            for message in reports {
-                self.report_once(message);
-            }
-        }
-        // Collision events (docs/physics.md Phase 5): this frame's contact
-        // transitions, delivered to the `Physics.events` taggers of the
-        // CURRENT model's subscriptions — post-step, alongside query answers.
-        let events = std::mem::take(&mut self.pending_events);
-        if !events.is_empty() && self.has_subscriptions {
-            match self
-                .session
-                .call("subscriptions", vec![self.model.clone()], &mut FunctorHost)
-            {
-                Ok(subs) => match physics_event_taggers(&subs) {
-                    Ok(taggers) if !taggers.is_empty() => {
-                        let mut reports: Vec<String> = Vec::new();
-                        deliver_physics_events(
-                            &self.session,
-                            &mut self.model,
-                            &taggers,
-                            &events,
-                            &mut self.effect_runner,
-                            &mut self.effect_log,
-                            &mut |message| reports.push(message),
-                        );
-                        for message in reports {
-                            self.report_once(message);
-                        }
-                    }
-                    Ok(_) => {}
-                    Err(message) => self.report_once(format!("[mle] {message}")),
-                },
-                Err(err) => self.frame_error("subscriptions", &err),
-            }
-        }
+        self.ctx().physics_phase(frame_time);
         self.physics_ns += physics_started.elapsed().as_nanos() as u64;
-        // Record the settled model of this rendered frame (docs/time-travel.md
-        // T1) — after all of this frame's input / subscriptions / tick / query
-        // / event effects have folded into `self.model` — plus the physics
-        // fixed-frame the world reached, in lockstep, so a coupled rewind can
-        // restore both. `physics_status.0` is the world's current fixed frame.
-        //
-        // Skip a PAUSED frame (`dts == 0`, i.e. the clock pinned): the sim
-        // hasn't advanced, so recording would only pile up frozen duplicates —
-        // inflating the timeline and pushing a rewind target past the real
-        // history. `dts == 0` is exactly the pinned-and-not-stepping case
-        // (a one-shot step carries `dts > 0`). [xreview]
-        if frame_time.dts > 0.0 {
-            self.recorder.record(&self.model, self.physics_status.0);
-        }
+        self.ctx().record_frame(frame_time);
         self.frames += 1;
         self.report_stats();
     }
@@ -977,8 +609,8 @@ impl Game for MleGame {
             Value::Bool(is_down),
         ];
         match self.session.call("input", args, &mut FunctorHost) {
-            Ok(returned) => self.absorb(returned),
-            Err(err) => self.frame_error("input", &err),
+            Ok(returned) => self.ctx().absorb(returned),
+            Err(err) => self.reporter.frame_error("input", &err),
         }
     }
     fn mouse_move(&mut self, x: i32, y: i32) {
@@ -991,8 +623,8 @@ impl Game for MleGame {
             Value::Number(y as f64),
         ];
         match self.session.call("mouseMove", args, &mut FunctorHost) {
-            Ok(returned) => self.absorb(returned),
-            Err(err) => self.frame_error("mouseMove", &err),
+            Ok(returned) => self.ctx().absorb(returned),
+            Err(err) => self.reporter.frame_error("mouseMove", &err),
         }
     }
 
@@ -1002,8 +634,8 @@ impl Game for MleGame {
         }
         let args = vec![self.model.clone(), Value::Number(delta as f64)];
         match self.session.call("mouseWheel", args, &mut FunctorHost) {
-            Ok(returned) => self.absorb(returned),
-            Err(err) => self.frame_error("mouseWheel", &err),
+            Ok(returned) => self.ctx().absorb(returned),
+            Err(err) => self.reporter.frame_error("mouseWheel", &err),
         }
     }
 
@@ -1013,12 +645,12 @@ impl Game for MleGame {
         match self.session.call("draw", args, &mut FunctorHost) {
             Ok(value) => match frame_value(&value) {
                 Some(frame) => self.last_frame = frame.clone(),
-                None => self.report_once(format!(
+                None => self.reporter.report_once(format!(
                     "[mle] draw must return Frame.create(camera, scene), got {}",
                     value.kind_name()
                 )),
             },
-            Err(err) => self.frame_error("draw", &err),
+            Err(err) => self.reporter.frame_error("draw", &err),
         }
         // The optional HUD, evaluated beside `draw` (same settled model) and
         // cached — `Game::ui` is a `&self` accessor, and errors need `&mut`
@@ -1030,12 +662,12 @@ impl Game for MleGame {
             {
                 Ok(value) => match view_value(&value) {
                     Some(view) => self.last_view = view.clone(),
-                    None => self.report_once(format!(
+                    None => self.reporter.report_once(format!(
                         "[mle] ui must return a View (Ui.text / Ui.column / Ui.panel), got {}",
                         value.kind_name()
                     )),
                 },
-                Err(err) => self.frame_error("ui", &err),
+                Err(err) => self.reporter.frame_error("ui", &err),
             }
         }
         // The optional soundscape, evaluated beside `draw` (same settled model)
@@ -1052,13 +684,13 @@ impl Game for MleGame {
                         self.last_soundscape_json =
                             functor_runtime_common::audio::scene_to_json(scene)
                     }
-                    None => self.report_once(format!(
+                    None => self.reporter.report_once(format!(
                         "[mle] soundScape must return an AudioScene (AudioScene.create / \
 AudioScene.empty), got {}",
                         value.kind_name()
                     )),
                 },
-                Err(err) => self.frame_error("soundScape", &err),
+                Err(err) => self.reporter.frame_error("soundScape", &err),
             }
         }
         self.draw_ns += started.elapsed().as_nanos() as u64;
@@ -1097,7 +729,7 @@ AudioScene.empty), got {}",
         functor_runtime_common::net::drain_commands_json()
     }
     fn net_push_http_response(&mut self, token: i32, status: i32, body: String) {
-        self.deliver_http_result(functor_runtime_common::net::HttpResult {
+        self.ctx().deliver_http_result(functor_runtime_common::net::HttpResult {
             token: token as u64,
             status: status as u16,
             body: body.into_bytes(),
@@ -1105,7 +737,7 @@ AudioScene.empty), got {}",
         });
     }
     fn net_push_http_error(&mut self, token: i32, message: String) {
-        self.deliver_http_result(functor_runtime_common::net::HttpResult {
+        self.ctx().deliver_http_result(functor_runtime_common::net::HttpResult {
             token: token as u64,
             status: 0,
             body: Vec::new(),
@@ -1127,23 +759,23 @@ AudioScene.empty), got {}",
         functor_runtime_common::net::drain_conn_commands_json()
     }
     fn net_push_connected(&mut self, key: String, conn: i32) {
-        self.deliver_net_event(key, NetEventKind::Connected, conn, String::new());
+        self.ctx().deliver_net_event(key, NetEventKind::Connected, conn, String::new());
     }
     fn net_push_conn_message(&mut self, key: String, conn: i32, text: String) {
-        self.deliver_net_event(key, NetEventKind::Message, conn, text);
+        self.ctx().deliver_net_event(key, NetEventKind::Message, conn, text);
     }
     fn net_push_disconnected(&mut self, key: String, conn: i32) {
-        self.deliver_net_event(key, NetEventKind::Disconnected, conn, String::new());
+        self.ctx().deliver_net_event(key, NetEventKind::Disconnected, conn, String::new());
     }
     fn net_push_conn_error(&mut self, key: String, conn: i32, message: String) {
-        self.deliver_net_event(key, NetEventKind::Error, conn, message);
+        self.ctx().deliver_net_event(key, NetEventKind::Error, conn, message);
     }
     fn audio_push_finished(&mut self, token: i32) {
-        self.deliver_audio_completion(token as u64);
+        self.ctx().deliver_audio_completion(token as u64);
     }
 
     fn quit(&mut self) {
-        self.close_all_connections();
+        self.ctx().close_all_connections();
     }
 }
 
@@ -1162,6 +794,11 @@ fn require_function(path: &str, session: &Session, name: &str, arity: usize) -> 
         )),
         None => Err(format!("{path} has no top-level `let {name} = …`")),
     }
+}
+
+/// The desktop `Reporter` sink: per-frame problems go to stderr.
+fn report_to_stderr(message: &str) {
+    eprintln!("{message}");
 }
 
 /// The silent soundscape's wire form — the default before/without a

--- a/runtime/functor-runtime-web/src/mle_game.rs
+++ b/runtime/functor-runtime-web/src/mle_game.rs
@@ -22,12 +22,10 @@
 use std::cell::RefCell;
 
 use functor_runtime_common::mle_prelude::{
-    audio_scene_of, clear_audio_completions, clear_http_taggers, contains_effect,
-    deliver_physics_events, drain_effects, frame_value, http_response_value, needs_update,
-    net_conn_subs, net_event_value, perform_deferred_queries, physics_event_taggers,
-    physics_scene_value, split_model_effect, sub_messages_for_frame, take_audio_completion,
-    take_http_tagger, view_value, EffectLog, EffectTree, FunctorHost, NetEventKind, RealEffects,
+    audio_scene_of, clear_audio_completions, clear_http_taggers, contains_effect, frame_value,
+    view_value, EffectLog, EffectTree, FunctorHost, NetEventKind, RealEffects,
 };
+use functor_runtime_common::mle_producer::{FrameCtx, Reporter, SpanSource};
 use functor_runtime_common::physics;
 use functor_runtime_common::protocol::GameProducer;
 use functor_runtime_common::timetravel::SceneRecorder;
@@ -38,7 +36,6 @@ use wasm_bindgen::prelude::*;
 
 pub struct MleWebGame {
     path: String,
-    src: String,
     /// The lowered module the current session came from — kept (like the
     /// desktop producer) so a pushed reload can rebind model-stored closures
     /// (old module × new module).
@@ -98,10 +95,10 @@ pub struct MleWebGame {
     /// The last successfully drawn frame, kept so a bad draw shows the last
     /// good picture instead of a blank.
     last_frame: Frame,
-    /// The last per-frame error logged, to avoid flooding the console at
-    /// 60fps with the same message (a persistent error logs once until it
-    /// changes).
-    last_error: Option<String>,
+    /// Per-frame error reporting (dedupe + browser-console sink + single-source
+    /// span rendering) — shared with the desktop producer
+    /// (`mle_producer::Reporter`).
+    reporter: Reporter,
 }
 
 /// A successfully loaded, contract-validated game module (the desktop
@@ -242,8 +239,14 @@ impl MleWebGame {
         let loaded = load_source(path, src)?;
         web_sys::console::log_1(&format!("[mle] loaded {path}").into());
         Ok(MleWebGame {
+            reporter: Reporter::new(
+                SpanSource::Single {
+                    src: loaded.src,
+                    path: path.to_string(),
+                },
+                report_to_console,
+            ),
             path: path.to_string(),
-            src: loaded.src,
             module: loaded.module,
             session: loaded.session,
             model: loaded.init,
@@ -266,7 +269,6 @@ impl MleWebGame {
             has_ui: loaded.has_ui,
             last_view: View::Empty,
             last_frame: empty_frame(),
-            last_error: None,
         })
     }
 
@@ -286,7 +288,10 @@ impl MleWebGame {
         for warning in &report.warnings {
             web_sys::console::warn_1(&format!("[mle] reload: {warning}").into());
         }
-        self.src = loaded.src;
+        self.reporter.set_source(SpanSource::Single {
+            src: loaded.src,
+            path: self.path.clone(),
+        });
         self.module = loaded.module;
         self.session = loaded.session;
         self.has_input = loaded.has_input;
@@ -320,282 +325,30 @@ impl MleWebGame {
             // Deleting the `ui` hook drops the HUD (the physics-world rule).
             self.last_view = View::Empty;
         }
-        self.last_error = None;
+        self.reporter.reset();
         report.rebound
     }
 
-    /// Fire subscription timers over `(prev_tts, tts]` and fold their
-    /// messages through `update`, before this frame's `tick` — the message
-    /// drain seam (docs/mle.md C4b-2), same semantics as the desktop
-    /// producer. Errors report per message and processing continues.
-    /// Take an entry point's return: split off any `(model, effect)` pair,
-    /// adopt the model, and drain the effects to a fixed point through
-    /// `update` (docs/mle.md B6) — mirrors the desktop producer.
-    fn absorb(&mut self, returned: Value) {
-        let (model, effects) = split_model_effect(returned);
-        self.model = model;
-        // Effects are commands, not data — one stored in the model would
-        // make the pair sniff ambiguous on a later return.
-        if contains_effect(&self.model) {
-            self.log_once(
-                "[mle] the model contains an Effect value — Effects are commands, \
-not data; return them beside the model as `(model, effect)` instead of storing them"
-                    .to_string(),
-            );
-        }
-        let Some(effects) = effects else { return };
-        // Only MESSAGE-producing effects need an `update` to receive them —
-        // tagger-less physics commands must not be dropped over a missing
-        // hook (mirrors the desktop producer).
-        if needs_update(&effects) && self.session.global("update").is_none() {
-            self.log_once(
-                "[mle] effects returned but there is no `let update = (model, msg) => …` \
-to receive their messages; dropping them"
-                    .to_string(),
-            );
-            return;
-        }
-        let mut reports: Vec<String> = Vec::new();
-        let deferred = drain_effects(
-            &self.session,
-            &mut self.model,
-            effects,
-            &mut self.effect_runner,
-            &mut self.effect_log,
-            &mut |message| reports.push(message),
-        );
-        // Physics queries wait for the post-step drain (end of `tick`), so
-        // their taggers answer against THIS frame's stepped world.
-        self.deferred_queries.extend(deferred);
-        for message in reports {
-            self.log_once(message);
-        }
-    }
-
-    /// Close every connection this producer still has open (a reload that
-    /// dropped `subscriptions`, or shutdown). CloseKey is queued for each;
-    /// the live set is cleared.
-    fn close_all_connections(&mut self) {
-        use functor_runtime_common::net::{push_conn_command, ConnCommand};
-        for key in std::mem::take(&mut self.live_conn_keys) {
-            push_conn_command(ConnCommand::CloseKey { key });
-        }
-    }
-
-    /// Open connections newly declared this frame and close dropped ones —
-    /// see the desktop producer's `reconcile_connections`.
-    fn reconcile_connections(&mut self, subs: &Value) {
-        use functor_runtime_common::net::{push_conn_command, ConnCommand};
-        let conns = match net_conn_subs(subs) {
-            Ok(conns) => conns,
-            Err(message) => return self.log_once(format!("[mle] {message}")),
-        };
-        // Dedupe by key (first declaration wins its listen/connect role) so
-        // a key is opened at most once even if declared twice in one frame.
-        let mut declared: std::collections::HashSet<String> = std::collections::HashSet::new();
-        for conn in &conns {
-            if !declared.insert(conn.key.clone()) {
-                continue; // already handled this key this frame
-            }
-            if !self.live_conn_keys.contains(&conn.key) {
-                push_conn_command(if conn.listen {
-                    ConnCommand::Listen {
-                        key: conn.key.clone(),
-                        addr: conn.key.clone(),
-                    }
-                } else {
-                    ConnCommand::Connect {
-                        key: conn.key.clone(),
-                        url: conn.key.clone(),
-                    }
-                });
-            }
-        }
-        for key in &self.live_conn_keys {
-            if !declared.contains(key) {
-                push_conn_command(ConnCommand::CloseKey { key: key.clone() });
-            }
-        }
-        self.live_conn_keys = declared;
-    }
-
-    /// Route one inbound connection event to the matching key's fresh
-    /// tagger and fold through `update` — see the desktop producer.
-    fn deliver_net_event(&mut self, key: String, kind: NetEventKind, conn: i32, text: String) {
-        if !self.has_subscriptions {
-            return;
-        }
-        let subs =
-            match self
-                .session
-                .call("subscriptions", vec![self.model.clone()], &mut FunctorHost)
-            {
-                Ok(subs) => subs,
-                Err(err) => return self.frame_error("subscriptions", &err),
-            };
-        let conns = match net_conn_subs(&subs) {
-            Ok(conns) => conns,
-            Err(message) => return self.log_once(format!("[mle] {message}")),
-        };
-        let Some(sub) = conns.into_iter().find(|c| c.key == key) else {
-            return;
-        };
-        let value = net_event_value(kind, conn as u64, &text).to_mle();
-        let msg = match self
-            .session
-            .apply(sub.tagger, vec![value], "net event", &mut FunctorHost)
-        {
-            Ok(msg) => msg,
-            Err(err) => return self.frame_error("net event", &err),
-        };
-        match self
-            .session
-            .call("update", vec![self.model.clone(), msg], &mut FunctorHost)
-        {
-            Ok(returned) => self.absorb(returned),
-            Err(err) => self.frame_error("update", &err),
-        }
-    }
-
-    /// Route a completed HTTP request to the tagger registered when the request
-    /// fired (frames ago), folding the resulting message through `update`. An
-    /// orphaned token — a reload dropped its tagger mid-flight — is ignored.
-    fn deliver_http_result(&mut self, result: functor_runtime_common::net::HttpResult) {
-        let Some(tagger) = take_http_tagger(result.token) else {
-            return;
-        };
-        let value = http_response_value(&result);
-        let msg = match self
-            .session
-            .apply(tagger, vec![value], "http response", &mut FunctorHost)
-        {
-            Ok(msg) => msg,
-            Err(err) => return self.frame_error("http response", &err),
-        };
-        match self
-            .session
-            .call("update", vec![self.model.clone(), msg], &mut FunctorHost)
-        {
-            Ok(returned) => self.absorb(returned),
-            Err(err) => self.frame_error("update", &err),
-        }
-    }
-
-    /// Route a finished `playThen` one-shot to the completion MESSAGE registered
-    /// when it fired, folding it verbatim through `update` (no tagger — the
-    /// desktop producer's `deliver_audio_completion`). NOTE: the web audio
-    /// backend (`lib.rs::play_one_shot`) does not yet report one-shot finishes,
-    /// so this is unreached on wasm today; kept symmetric with desktop so it is
-    /// correct the moment the shell reports a finish.
-    fn deliver_audio_completion(&mut self, token: u64) {
-        let Some(message) = take_audio_completion(token) else {
-            return;
-        };
-        match self
-            .session
-            .call("update", vec![self.model.clone(), message], &mut FunctorHost)
-        {
-            Ok(returned) => self.absorb(returned),
-            Err(err) => self.frame_error("update", &err),
-        }
-    }
-
-    fn pump_subscriptions(&mut self, tts: f64) {
-        // Advance the window even without subscriptions (or on frame one),
-        // so the edge is always sane.
-        let prev = self.prev_tts.replace(tts);
-        if !self.has_subscriptions {
-            // No subscriptions must not leave a previous program's
-            // connections open (a hot reload that dropped them).
-            if !self.live_conn_keys.is_empty() {
-                self.close_all_connections();
-            }
-            return;
-        }
-        let subs =
-            match self
-                .session
-                .call("subscriptions", vec![self.model.clone()], &mut FunctorHost)
-            {
-                Ok(subs) => subs,
-                Err(err) => return self.frame_error("subscriptions", &err),
-            };
-        self.reconcile_connections(&subs);
-        let Some(prev) = prev else {
-            return;
-        };
-        let msgs = match sub_messages_for_frame(&subs, prev, tts) {
-            Ok(msgs) => msgs,
-            Err(message) => return self.log_once(format!("[mle] {message}")),
-        };
-        for msg in msgs {
-            match self
-                .session
-                .call("update", vec![self.model.clone(), msg], &mut FunctorHost)
-            {
-                Ok(returned) => self.absorb(returned),
-                Err(err) => self.frame_error("update", &err),
-            }
-        }
-    }
-
-    /// The frame's physics phase (docs/physics.md): ask the game what bodies
-    /// should exist, reconcile the singleton world to match, and advance it
-    /// in fixed substeps. Runs after `tick` so declarations come from the
-    /// settled model, and before `render` so `Physics.position`/
-    /// `Physics.transformed` in `draw` read the just-stepped world.
-    /// Returns the number of fixed substeps taken (0 when there is no
-    /// `physics` hook, the hook errored, or the accumulator hasn't reached a
-    /// full step yet).
-    fn step_physics(&mut self, dts: f32) -> u32 {
-        if !self.has_physics {
-            return 0;
-        }
-        let args = vec![self.model.clone()];
-        match self.session.call("physics", args, &mut FunctorHost) {
-            Ok(value) => match physics_scene_value(&value) {
-                Some(scene) => {
-                    // The recorded drive (Phase 6): every fixed frame goes
-                    // through the Timeline, so pause/rewind/replay work.
-                    let advanced = self.physics_rt.advance(scene, dts);
-                    self.pending_events = advanced.events;
-                    self.physics_status = advanced.status;
-                    let steps = advanced.steps;
-                    let warnings = advanced.warnings;
-                    // Command effects apply asynchronously (queued at perform
-                    // time, applied at the step), so their problems — unknown
-                    // tag, queue overflow — surface here, deduped.
-                    for warning in warnings {
-                        self.log_once(format!("[mle] {warning}"));
-                    }
-                    return steps;
-                }
-                None => self.log_once(format!(
-                    "[mle] physics must return Physics.scene(gx, gy, gz, [body, …]), got {}",
-                    value.kind_name()
-                )),
-            },
-            Err(err) => self.frame_error("physics", &err),
-        }
-        0
-    }
-
-    /// Report a per-frame error with its source position, once per distinct
-    /// message (a 60fps loop must not flood the console with one persistent
-    /// bug).
-    fn frame_error(&mut self, stage: &str, err: &mle::RunError) {
-        let (line, col) = mle::line_col(&self.src, err.span.start);
-        let rendered = format!(
-            "[mle] {stage} error at {}:{line}:{col}: {}",
-            self.path, err.message
-        );
-        self.log_once(rendered);
-    }
-
-    fn log_once(&mut self, rendered: String) {
-        if self.last_error.as_deref() != Some(rendered.as_str()) {
-            web_sys::console::error_1(&rendered.as_str().into());
-            self.last_error = Some(rendered);
+    /// Bundle this producer's per-frame state into the shared [`FrameCtx`]
+    /// (docs/time-travel.md T6a) — the frame body and its helpers (`absorb`,
+    /// `pump_subscriptions`, `step_physics`, `deliver_*`) live there, one copy
+    /// for both shells. A cheap borrow-only view, rebuilt per call.
+    fn ctx(&mut self) -> FrameCtx<'_> {
+        FrameCtx {
+            session: &self.session,
+            model: &mut self.model,
+            physics_rt: &mut self.physics_rt,
+            physics_status: &mut self.physics_status,
+            recorder: &mut self.recorder,
+            effect_runner: &mut self.effect_runner,
+            effect_log: &mut self.effect_log,
+            deferred_queries: &mut self.deferred_queries,
+            pending_events: &mut self.pending_events,
+            live_conn_keys: &mut self.live_conn_keys,
+            prev_tts: &mut self.prev_tts,
+            has_physics: self.has_physics,
+            has_subscriptions: self.has_subscriptions,
+            reporter: &mut self.reporter,
         }
     }
 }
@@ -664,99 +417,10 @@ impl GameProducer for MleWebGame {
     }
 
     fn tick(&mut self, frame_time: FrameTime) {
-        // Committing a scrub (docs/time-travel.md T3): if play resumes (dts > 0)
-        // while the scrubber is parked on an earlier frame, branch the timeline
-        // from there BEFORE this frame advances, dropping in-flight frame work
-        // that must not cross the branch (the desktop producer's rule).
-        if frame_time.dts > 0.0
-            && self.recorder.commit_scrub_if_resuming(
-                &mut self.model,
-                &mut self.physics_rt,
-                &mut self.physics_status,
-                self.has_physics,
-            )
-        {
-            self.deferred_queries.clear();
-            self.pending_events.clear();
-        }
-        // Subscriptions first, so `tick` sees a model that has absorbed this
-        // frame's messages (the F# executor's ordering).
-        self.pump_subscriptions(frame_time.tts as f64);
-        let args = vec![
-            self.model.clone(),
-            Value::Number(frame_time.dts as f64),
-            Value::Number(frame_time.tts as f64),
-        ];
-        match self.session.call("tick", args, &mut FunctorHost) {
-            Ok(returned) => self.absorb(returned),
-            Err(err) => self.frame_error("tick", &err),
-        }
-        let physics_steps = self.step_physics(frame_time.dts);
-        // Post-step query drain: deferred raycasts answer against the world
-        // just stepped; their messages fold through `update` before `draw`.
-        // On a ZERO-substep frame (the accumulator short of FIXED_DT — normal
-        // right after load and at >60fps) queries stay deferred, like pending
-        // commands, so they never answer against a world that hasn't
-        // simulated. Games without a physics hook answer immediately (the
-        // lazily-created empty world gives sane misses).
-        // A query answers once the world has EVER stepped: normally this
-        // frame's steps, but also while PAUSED (frozen mid-flight, frame > 0)
-        // and on a short zero-substep frame — so a raycast fired while paused
-        // answers against the frozen world instead of deferring forever.
-        let world_ready = physics_steps > 0 || !self.has_physics || self.physics_status.0 > 0;
-        if world_ready && !self.deferred_queries.is_empty() {
-            let deferred = std::mem::take(&mut self.deferred_queries);
-            let mut reports: Vec<String> = Vec::new();
-            perform_deferred_queries(
-                &self.session,
-                &mut self.model,
-                deferred,
-                &mut self.effect_runner,
-                &mut self.effect_log,
-                &mut |message| reports.push(message),
-            );
-            for message in reports {
-                self.log_once(message);
-            }
-        }
-        // Collision events (docs/physics.md Phase 5): this frame's contact
-        // transitions, delivered to the `Physics.events` taggers of the
-        // CURRENT model's subscriptions — post-step, alongside query answers.
-        let events = std::mem::take(&mut self.pending_events);
-        if !events.is_empty() && self.has_subscriptions {
-            match self
-                .session
-                .call("subscriptions", vec![self.model.clone()], &mut FunctorHost)
-            {
-                Ok(subs) => match physics_event_taggers(&subs) {
-                    Ok(taggers) if !taggers.is_empty() => {
-                        let mut reports: Vec<String> = Vec::new();
-                        deliver_physics_events(
-                            &self.session,
-                            &mut self.model,
-                            &taggers,
-                            &events,
-                            &mut self.effect_runner,
-                            &mut self.effect_log,
-                            &mut |message| reports.push(message),
-                        );
-                        for message in reports {
-                            self.log_once(message);
-                        }
-                    }
-                    Ok(_) => {}
-                    Err(message) => self.log_once(format!("[mle] {message}")),
-                },
-                Err(err) => self.frame_error("subscriptions", &err),
-            }
-        }
-        // Record the settled model + physics fixed-frame of this rendered frame
-        // (docs/time-travel.md T1), after all of this frame's effects have
-        // folded into `self.model`. Skip a paused frame (`dts == 0`) so it
-        // doesn't pile up frozen duplicates (the desktop producer's rule).
-        if frame_time.dts > 0.0 {
-            self.recorder.record(&self.model, self.physics_status.0);
-        }
+        // The whole MVU frame body lives in the shared `FrameCtx`
+        // (docs/time-travel.md T6a). Web runs it as one call — unlike native it
+        // has no per-frame perf timing to split it at the physics boundary.
+        self.ctx().run_frame(frame_time);
     }
 
     fn key_event(&mut self, code: i32, is_down: bool) {
@@ -775,8 +439,8 @@ impl GameProducer for MleWebGame {
             Value::Bool(is_down),
         ];
         match self.session.call("input", args, &mut FunctorHost) {
-            Ok(returned) => self.absorb(returned),
-            Err(err) => self.frame_error("input", &err),
+            Ok(returned) => self.ctx().absorb(returned),
+            Err(err) => self.reporter.frame_error("input", &err),
         }
     }
 
@@ -790,8 +454,8 @@ impl GameProducer for MleWebGame {
             Value::Number(y as f64),
         ];
         match self.session.call("mouseMove", args, &mut FunctorHost) {
-            Ok(returned) => self.absorb(returned),
-            Err(err) => self.frame_error("mouseMove", &err),
+            Ok(returned) => self.ctx().absorb(returned),
+            Err(err) => self.reporter.frame_error("mouseMove", &err),
         }
     }
 
@@ -801,8 +465,8 @@ impl GameProducer for MleWebGame {
         }
         let args = vec![self.model.clone(), Value::Number(delta as f64)];
         match self.session.call("mouseWheel", args, &mut FunctorHost) {
-            Ok(returned) => self.absorb(returned),
-            Err(err) => self.frame_error("mouseWheel", &err),
+            Ok(returned) => self.ctx().absorb(returned),
+            Err(err) => self.reporter.frame_error("mouseWheel", &err),
         }
     }
 
@@ -816,10 +480,10 @@ impl GameProducer for MleWebGame {
                         "[mle] draw must return Frame.create(camera, scene), got {}",
                         value.kind_name()
                     );
-                    self.log_once(rendered);
+                    self.reporter.report_once(rendered);
                 }
             },
-            Err(err) => self.frame_error("draw", &err),
+            Err(err) => self.reporter.frame_error("draw", &err),
         }
         // The optional HUD, evaluated beside `draw` (same settled model) and
         // cached — `ui()` is a `&self` accessor, and errors need `&mut`
@@ -831,12 +495,12 @@ impl GameProducer for MleWebGame {
             {
                 Ok(value) => match view_value(&value) {
                     Some(view) => self.last_view = view.clone(),
-                    None => self.log_once(format!(
+                    None => self.reporter.report_once(format!(
                         "[mle] ui must return a View (Ui.text / Ui.column / Ui.panel), got {}",
                         value.kind_name()
                     )),
                 },
-                Err(err) => self.frame_error("ui", &err),
+                Err(err) => self.reporter.frame_error("ui", &err),
             }
         }
         // The optional soundscape, evaluated beside `draw` (same settled model)
@@ -852,13 +516,13 @@ impl GameProducer for MleWebGame {
                         self.last_soundscape_json =
                             functor_runtime_common::audio::scene_to_json(scene)
                     }
-                    None => self.log_once(format!(
+                    None => self.reporter.report_once(format!(
                         "[mle] soundScape must return an AudioScene (AudioScene.create / \
 AudioScene.empty), got {}",
                         value.kind_name()
                     )),
                 },
-                Err(err) => self.frame_error("soundScape", &err),
+                Err(err) => self.reporter.frame_error("soundScape", &err),
             }
         }
         // On failure this is the last good frame — a bad draw must not blank
@@ -880,7 +544,7 @@ AudioScene.empty), got {}",
         functor_runtime_common::net::drain_commands_json()
     }
     fn net_push_http_response(&mut self, token: i32, status: i32, body: String) {
-        self.deliver_http_result(functor_runtime_common::net::HttpResult {
+        self.ctx().deliver_http_result(functor_runtime_common::net::HttpResult {
             token: token as u64,
             status: status as u16,
             body: body.into_bytes(),
@@ -888,7 +552,7 @@ AudioScene.empty), got {}",
         });
     }
     fn net_push_http_error(&mut self, token: i32, message: String) {
-        self.deliver_http_result(functor_runtime_common::net::HttpResult {
+        self.ctx().deliver_http_result(functor_runtime_common::net::HttpResult {
             token: token as u64,
             status: 0,
             body: Vec::new(),
@@ -910,23 +574,23 @@ AudioScene.empty), got {}",
         functor_runtime_common::net::drain_conn_commands_json()
     }
     fn net_push_connected(&mut self, key: String, conn: i32) {
-        self.deliver_net_event(key, NetEventKind::Connected, conn, String::new());
+        self.ctx().deliver_net_event(key, NetEventKind::Connected, conn, String::new());
     }
     fn net_push_conn_message(&mut self, key: String, conn: i32, text: String) {
-        self.deliver_net_event(key, NetEventKind::Message, conn, text);
+        self.ctx().deliver_net_event(key, NetEventKind::Message, conn, text);
     }
     fn net_push_disconnected(&mut self, key: String, conn: i32) {
-        self.deliver_net_event(key, NetEventKind::Disconnected, conn, String::new());
+        self.ctx().deliver_net_event(key, NetEventKind::Disconnected, conn, String::new());
     }
     fn net_push_conn_error(&mut self, key: String, conn: i32, message: String) {
-        self.deliver_net_event(key, NetEventKind::Error, conn, message);
+        self.ctx().deliver_net_event(key, NetEventKind::Error, conn, message);
     }
     fn audio_push_finished(&mut self, token: i32) {
-        self.deliver_audio_completion(token as u64);
+        self.ctx().deliver_audio_completion(token as u64);
     }
 
     fn quit(&mut self) {
-        self.close_all_connections();
+        self.ctx().close_all_connections();
     }
 }
 
@@ -945,6 +609,11 @@ fn require_function(path: &str, session: &Session, name: &str, arity: usize) -> 
         )),
         None => Err(format!("{path} has no top-level `let {name} = …`")),
     }
+}
+
+/// The web `Reporter` sink: per-frame problems go to the browser console.
+fn report_to_console(message: &str) {
+    web_sys::console::error_1(&message.into());
 }
 
 /// The silent soundscape's wire form — the default before/without a


### PR DESCRIPTION
## T6a — unify the duplicated MVU frame body

Foundation for T6 (forward-step/ghosting). The per-frame MVU `tick` orchestration and its helpers (`absorb`, `pump_subscriptions`, `step_physics`, `deliver_net_event`/`deliver_http_result`/`deliver_audio_completion`, `reconcile_connections`) were **copy-pasted** across the desktop and web MLE producers. This extracts them into one shared `functor-runtime-common::mle_producer` (`FrameCtx` + `Reporter`); both producers' `tick` become thin wrappers. Net **−175 lines**, and the two loops can no longer drift.

**Pure behavior-preserving refactor — no new feature.** Input *delivery* stays per-shell (the shells queue/interleave it differently; it already funnels through the shared `absorb`), so the shared body begins at the scrub-commit. `Reporter` (a `fn` sink + `SpanSource`) captures the only real divergence — stderr-vs-console + project-map-vs-single-source span rendering — keeping `web_sys` out of the common crate.

### Verification (this is a refactor — the bar is "nothing changed")
- **Byte-identical goldens:** `examples/mle-physics` renders identical before/after at `--fixed-time 2` and `3.5` (`cmp` → identical).
- `cargo test -p functor_runtime_common` (206) + `-p functor-runtime-desktop` (incl. the recorder/scrub tests that drive seek/rewind/record through the new `ctx()` path) green.
- `npm run test:golden` passes (0px over tolerance); `--features strict` clean; `cargo check --target wasm32-unknown-unknown` + `wasm-pack build` compile.

### Review
Cross-engine `/xreview` (Claude + Codex). Claude: faithful, no behavioral drift (line-by-line vs both deleted originals). Codex: one Low — `deliver_http_result` labelled the `update`-fold error `"http response"` instead of `"update"`; **fixed**.

### Noted, out of scope (separate follow-ups)
- Pre-existing bug: `rewind_scene_to` clears http/audio taggers on desktop but not web.
- Pre-existing gap: the scrubber doesn't snapshot the render clock (`tts`), so time-driven visuals (e.g. `mle-lighting`) don't visibly rewind — being fixed in a stacked follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
