### PR TITLE
docs(e3): rewrite the F#→Fable narrative for the MLE-only pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,22 +4,28 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this is
 
-Functor is a functional toolkit for building 3D games in **F#**. You write a game against the
-`Functor.Game` library; [Fable](https://fable.io/) transpiles the F# to **Rust**, which is then
-compiled to one of two targets:
+Functor is a functional toolkit for building 3D games in **MLE** — Functor's own interpreted,
+F#-inspired game-logic language (roadmap and design: `docs/mle.md`; syntax/semantics source of
+truth: the **`mle-language` skill**, `.claude/skills/mle-language/`). You write a game as a `.mle`
+file. There is **no transpile or compile step for game logic**: the Rust runtime *interprets* the
+`.mle` directly, on one of two targets:
 
-- **native** — a dynamic library (`libgame_native` dylib) loaded by the `functor-runner` desktop
-  runtime (GLFW + OpenGL), with hot-reloading.
-- **wasm** — a WebAssembly bundle (`wasm-pack`) served to the browser (WebGL2).
+- **native** — the `functor-runner` desktop runtime (GLFW + OpenGL) loads and runs your `.mle`,
+  with hot-reloading on save.
+- **wasm** — the web runtime (WebGL2) ships the `.mle` source as text and interprets it in the
+  browser.
+
+The same tree-walking interpreter runs everywhere Rust runs. (Functor formerly used F# + Fable →
+Rust; that pipeline was deleted in roadmap **E3** — see `docs/mle.md`.)
 
 ## Design principles
 
 These shape how features should be built. Weigh changes against them.
 
 1. **Functional-core, imperative shell.** Push as much logic as possible into the pure functional
-   core (the F# game framework and game code: `init`/`update`/`tick`/`draw3d` are pure functions
-   of `model`). Keep side effects (rendering, GLFW/window, file IO, the dylib/wasm boundary) in the
-   thin imperative shell — the Rust runtimes under `runtime/`.
+   core (the MLE game logic: `init`/`update`/`tick`/`draw` are pure functions of `model`). Keep
+   side effects (rendering, GLFW/window, file IO, the interpreter/wasm boundary) in the thin
+   imperative shell — the Rust runtimes under `runtime/`.
 2. **LLM-native.** Functor functionality must be introspectable by LLMs at runtime — favor live
    evaluation, a text-only runtime path, and serializable/inspectable state over opaque binary
    state. When adding runtime capabilities, preserve the ability to drive and observe the game
@@ -31,19 +37,24 @@ These shape how features should be built. Weigh changes against them.
 
 ## Architecture
 
-**The MVU loop (Elm-style).** A game is a `Game<'model, 'msg>` record (`src/Functor.Game/Game.fs`)
-built fluently via `GameBuilder` and handed to `Runtime.runGame`:
+**The MVU loop (Elm-style).** A game is a set of top-level MLE bindings the runner looks up by
+name (contract in the `mle-language` skill; reference: `examples/mle-hello-gltf/game.mle`):
 
-- `initialState: 'model`
-- `init  : effect<'msg>` — startup effect, seeded into the queue at construction so it drains
-  before the first frame; **not** re-run across a hot reload (`setState` starts the reloaded
-  runner with an empty queue, discarding the constructor-seeded effect)
-- `input : 'model -> Input.t -> 'model * effect<'msg>` — keyboard/mouse events, applied immediately
-- `tick  : 'model -> FrameTime -> 'model * effect<'msg>` — per-frame simulation step
-- `update: 'model -> 'msg -> 'model * effect<'msg>` — handles messages produced by effects
-- `subscriptions: 'model -> Sub<'msg>` — declarative timers (`Sub.every`), polled each frame
-- `draw3d: 'model -> FrameTime -> Graphics.Frame` — pure frame description: a `Camera` plus a
-  `Scene3D` (`Frame.create camera scene`)
+- `init` — the initial model, a plain MLE value
+- `input = (model, key, isDown) => model'` — OPTIONAL; keyboard events, keys as canonical names
+  ("W", "Up", "Space"). `mouseMove`/`mouseWheel` are the analogous optional entry points
+- `tick = (model, dt, tts) => model'` — per-frame simulation step
+- `update = (model, msg) => model'` — OPTIONAL; handles messages (ADT variants) from subscriptions/effects
+- `subscriptions = (model) => Sub.every(...)` — OPTIONAL declarative timers, polled each frame (requires `update`)
+- `draw = (model, tts) => Frame.create(camera, scene)` — pure frame description: a `Camera` plus a scene
+- `physics = (model) => Physics.scene(...)`, `soundScape = (model) => AudioScene.create(...)`,
+  `ui = (model) => …` — OPTIONAL hooks
+
+The model-updating entry points (`tick`, `input`, `mouseMove`, `mouseWheel`, `update`) may return
+a `(model', effect)` tuple instead of a bare model, whose effect result folds back through
+`update`. `init` is a plain value (an Effect in it is rejected at load); `draw`/`physics`/
+`soundScape`/`ui`/`subscriptions` return their own specific values. The model is a plain
+`mle::Value` the host holds between frames.
 
 **Coordinates: Y-up, right-handed** (like OpenGL / glTF / Unity / Godot; *not* Unreal's Z-up). +Y
 is up, +X is right, and the ground is the XZ plane. The camera's up is `[0,1,0]` and view uses
@@ -51,54 +62,56 @@ is up, +X is right, and the ground is the XZ plane. The camera's up is `[0,1,0]`
 pitch looking up. glTF models are authored Y-up, so this matches imported assets with no conversion.
 By convention, `plane` geometry lies in XZ (ground) and `quad` in XY (screen/wall-facing).
 
-`Runtime.GameExecutor` (`src/Functor.Game/Runtime.fs`) is the heart of the loop: each frame it
-**drains the effect queue to a fixed point** (capped at `maxEffectsPerFrame = 1000` to avoid
-hangs), feeding messages through `update` and re-enqueueing new effects, before running `tick` on
-the settled state. The exact per-frame ordering (subscriptions are polled between drains) is
-documented by comments in the executor itself.
+**The effect broker drains to a fixed point.** Each frame the producer folds subscription
+messages and effect results through `update`, **draining the effect queue to a fixed point**
+(capped at 1000 effects/frame to avoid hangs) before running `tick` on the settled state. The
+frame order is `subscriptions → update → tick → physics → draw`. This machinery is shared,
+prelude-level Rust in `functor_runtime_common::mle_prelude` (`drain_effects`, an `EffectRunner`:
+`RealEffects` / `FakeEffects` / `ReplayEffects`), consumed by both producers — every performed
+effect lands in a structured log, so under a fake/replay runner the same program is exactly
+deterministic (the test seam).
 
-**The F#→Rust boundary is thin bindings, not reimplementations.** Many `Functor.Game` types are
-`[<Erase; Emit(...)>]` shims over Rust runtime types. For example `EffectQueue.fs` and the
-`effect` type are F# facades over `functor_runtime_common::EffectQueue` / effect types in
-`runtime/functor-runtime-common/src/`. When you change behavior, the real implementation usually
-lives in the Rust runtime, with an F# `Emit` binding mirroring its signature — keep the two in sync.
+**The MLE producer is the seam between game logic and the shells.** `mle_game.rs` (desktop) and
+its wasm sibling in `runtime/functor-runtime-web/` run `.mle` logic through an `mle::Session` with
+the **Functor prelude** (`FunctorHost` in `functor_runtime_common::mle_prelude`): the host-provided
+externals that make `Scene.*` / `Camera.*` / `Frame.*` / `Light.*` / `Physics.*` / `Effect.*` /
+`Sub.*` resolve to real protocol values. Both producers implement the shared
+`functor_runtime_common::protocol::GameProducer` trait the runtime loop consumes; the versioned
+logic↔runtime boundary is enumerated in `functor_runtime_common::protocol`. When you add or change
+a prelude surface, the real implementation lives in `mle_prelude.rs` and both producers must wire it.
 
-**Hot-reload and state persistence.** The desktop runtime can run a game statically
-(`static_game.rs`) or hot-reloaded (`hot_reload_game.rs`, via the `--hot` flag). Across a reload,
-`getState`/`setState` (the `emit_state`/`set_state` `no_mangle` exports in `Runtime.fs`) carry
-**the model only** in an `OpaqueState`; pending effects are deliberately dropped (an `Http`
-effect's tagger is a closure into the old dylib and would dangle — see `getState`'s comment in
-`Runtime.fs`). Preserve this contract when touching executor state; the full boundary is
-enumerated in `functor_runtime_common::protocol`.
-
-**Two runtime exports.** `Runtime.Native` exposes `no_mangle` functions for the dylib;
-`Runtime.Wasm` exposes `wasm_bindgen` equivalents (`_wasm` suffix, marshalling through JsValue;
-no state pair — hot-reload is native-only). New runtime entry points generally need a parallel
-native + wasm pair — see both modules in `Runtime.fs` for the current list.
+**Hot-reload and state persistence.** MLE hot-reload is built into the producer: it polls the
+project files' mtime each frame and on change reparses → rechecks → builds a new `Session` with
+**the model preserved** (it is a plain value the host holds). Closures stored *inside* the model
+rebind to the edited code, carrying their captured values over (matched by the enclosing def's
+name; a renamed/deleted def keeps its old body with a loud `[mle]` warning). A broken edit prints
+once and keeps the old program running. The physics world (like the model) survives reload. Pending
+effects are reset on reload (an in-flight HTTP tagger would dangle). Native watches every project
+`.mle`; on wasm, hot-reload is native-only (reload the page, or push source via a
+`{ type: "mle-set-source", source }` postMessage). See the `mle-language` skill for the exact rules.
 
 ### Layout
 
 | Path | What it is |
 | --- | --- |
-| `src/Functor.Game/` | The F# game framework (`Game`, `Runtime`, `Scene3D`/`Graphics`, `Frame`, `Camera`, `Input`, `Effect`, `EffectQueue`, `Sub`, `Math`, `Time`) |
-| `src/` | `functor-lib` — Rust crate Fable emits from `Functor.Game` (lib path is the generated `Platform.rs`) |
-| `runtime/functor-runtime-common/` | Shared Rust runtime: rendering, assets, geometry, materials, `Effect`/`EffectQueue` |
-| `runtime/functor-runtime-desktop/` | Desktop runtime → the `functor-runner` binary (GLFW/OpenGL) |
-| `runtime/functor-runtime-web/` | Web runtime (WebGL2) → wasm bundle |
-| `cli/` | The `functor` CLI (`build`/`run`/`develop`/`init`) |
-| `examples/hello/` | Sample game (`hello.fs` — a lineup of glTF sample models with a WASD + mouse free-look camera); `build-native/` and `build-wasm/` are the per-target compile crates |
+| `mle/` | The MLE language crate — parser, IR, interpreter (`Session`), typechecker; `mle parse/ir/run/trace/check` |
+| `runtime/functor-runtime-common/` | Shared Rust runtime: rendering, assets, geometry, materials, the effect broker, and the MLE prelude (`mle_prelude::FunctorHost`) |
+| `runtime/functor-runtime-desktop/` | Desktop runtime → the `functor-runner` binary (GLFW/OpenGL); the native MLE producer (`mle_game.rs`) |
+| `runtime/functor-runtime-web/` | Web runtime (WebGL2) → wasm bundle; the wasm MLE producer (`mle_game.rs`) |
+| `cli/` | The `functor` CLI (`build`/`run`/`develop`/`init`); MLE projects route through `cli/src/commands/mle_project.rs` |
+| `tools/` | Editor tooling: `mle-vscode` (extension), `mle-lsp` (language server), `functor-sdk` (TS debug-runtime SDK) |
+| `examples/mle-*/` | Sample games (each a dir with `functor.json` + `game.mle`) — e.g. `mle-hello-gltf`, `mle-primitives`, `mle-lighting`, `mle-physics` |
 | `docs/todo.md` | The backlog — incomplete work only |
 
-The `.fs`/`.fsi` pairs in `src/Functor.Game/` use the `.fsi` signature file as the public API — update both when changing a module's surface.
+MLE files use `file = module`: every sibling `.mle` in the entry's directory loads with it. The
+language, prelude, and semantics are documented in the **`mle-language` skill** — treat it and
+`docs/mle.md` as the source of truth, and keep the skill in sync when you change the language.
 
 ## Commands
 
-**Prerequisites:** .NET SDK 8, Rust stable + `wasm32-unknown-unknown` target, Node 22 / npm 10,
-`wasm-pack`, and `watchexec` (only for `develop`). Fable runs as a local dotnet tool (`fable 4.17.0`).
-
-```sh
-dotnet tool restore           # one-time: install the Fable local tool
-```
+**Prerequisites:** Rust stable + `wasm32-unknown-unknown` target, Node 22 / npm 10, and
+`wasm-pack`. **No .NET / Fable** — the toolchain is Rust + Node only. (`watchexec` is optional;
+MLE hot-reload is built into the runtime, so `develop` does not need it.)
 
 **Build the CLI.** Order matters — the CLI embeds the web runtime bundle at compile time via
 `include_bytes!`, so the wasm bundle must exist before the `functor` binary is built:
@@ -110,28 +123,32 @@ npm run build:cli   # functor-runner, then the wasm bundle, then the functor CLI
 Produces `target/debug/functor` (CLI) and `target/debug/functor-runner` (desktop runtime). The CLI
 looks for `functor-runner` next to itself — keep them together.
 
-**Run / build a game.** The CLI operates on a directory containing a `functor.json` (`-d` points to it):
+**Run / build a game.** The CLI operates on a directory with a `functor.json`
+(`{"language": "mle", "entry": "game.mle"}`); `-d` points to it:
 
 ```sh
-./target/debug/functor -d examples/hello run native   # opens a window (native is the default env)
-./target/debug/functor -d examples/hello run wasm      # serves wasm at http://127.0.0.1:8080
-./target/debug/functor -d examples/hello build [native|wasm]
-./target/debug/functor -d examples/hello develop [native|wasm]   # hot-reload loop (needs watchexec)
+./target/debug/functor -d examples/mle-primitives run native   # opens a window (native is the default env)
+./target/debug/functor -d examples/mle-primitives run wasm      # serves the .mle + wasm at http://127.0.0.1:8080
+./target/debug/functor -d examples/mle-primitives build [native|wasm]
+./target/debug/functor -d examples/mle-primitives develop [native|wasm]   # = run; MLE hot-reload is built in
 ```
 
-Under the hood, `build`/`run`: (1) Fable transpiles `hello.fs` → `hello.rs` + `fable_modules/`;
-(2) `cargo build` in `build-native/` or `wasm-pack build` in `build-wasm/`; (3) native loads the
-dylib via `functor-runner`, wasm serves the bundle.
+Under the hood: `build` typechecks the whole `.mle` project (diagnostics are errors). `run native`
+spawns `functor-runner --mle --game-path <entry>` from the game dir; the runner **interprets** the
+`.mle` each frame — nothing compiles. `run wasm` serves the project directory: the `.mle` ships as
+text and is interpreted by the embedded web runtime. `develop` is `run` (hot-reload is built in; on
+wasm, reload the page).
 
-**Transpile F# only:** `npm run build:examples:hello:rust`
-(`dotnet fable examples/hello/hello.fsproj --lang rust --outDir .`).
+**Verify the language without a GPU:** `cargo run -q -p mle -- run|check|trace|parse|ir <file.mle>`
+drives the interpreter/typechecker headlessly (the plain-`mle` prelude, no engine host). See the
+`mle-language` skill.
 
 **Capture a frame to PNG** (no OS screen-recording permission needed — the runner reads back its
 own framebuffer; ideal for verifying rendering changes). The CLI forwards extra args to
 `functor-runner` (a leading `--` is optional):
 
 ```sh
-./target/debug/functor -d examples/hello run native \
+./target/debug/functor -d examples/mle-primitives run native \
   --capture-frame /tmp/frame.png --capture-time 3        # capture after 3s of wall-clock, then exit
 ```
 
@@ -143,13 +160,16 @@ or captures the cursor, so capture runs don't steal input from the user. For deb
 sessions (`--debug-port`) prefer passing `--hidden` explicitly — or `--headless` when no pixels
 are needed at all (see `docs/debug-runtime.md`).
 
-**Golden-image test:** `npm run test:golden` renders `hello` at a fixed time and compares the
-capture to a committed reference (`runtime/functor-runtime-desktop/tests/golden.rs`). It's
-`#[ignore]`d (needs a GL display + the built dylib), so it runs locally/manually, not in CI.
-Goldens are renderer/display-specific — the regeneration command is in the test's doc comment.
+**Golden-image test:** `npm run test:golden` renders the MLE samples (`mle-hello-gltf`,
+`mle-lighting`, `mle-primitives`, `mle-synthwave` — the scenarios in `golden-scenarios.json`) at a
+fixed time and compares each capture to a committed reference
+(`runtime/functor-runtime-desktop/tests/golden.rs`). It's `#[ignore]`d (needs a GL display), so it
+runs locally/manually, not in CI. Goldens are renderer/display-specific — the regeneration command
+is in the test's doc comment.
 
-**Tests** are Rust, in `functor-runtime-common`, with test modules alongside source:
-`cargo test -p functor_runtime_common`.
+**Tests** are Rust: the runtime in `functor-runtime-common`
+(`cargo test -p functor_runtime_common`, includes the MLE prelude) and the language in the `mle`
+crate (`cargo test -p mle`; `UPDATE_GOLDENS=1` regenerates its snapshots).
 
 ## Visual changes
 
@@ -167,24 +187,27 @@ main context.
 
 ## Gotchas
 
-- **uuid / wasm:** the generated `fable_library_rust` depends on `uuid`. It's constrained to
-  `>=1.8, <1.12` in `runtime/functor-runtime-common/Cargo.toml` (shared by every workspace);
-  without this, `wasm-pack build` fails with `could not find RngImp in imp` because newer uuid pulls
-  `getrandom 0.3+` which needs an explicit RNG backend for `wasm32-unknown-unknown`. If hit, confirm
-  the constraint or pin with `cargo update -p uuid --precise 1.11.1`.
-- `examples/hello/build-native` and `build-wasm` are **separate Cargo workspaces** (`[workspace]`)
-  that compile the generated `../hello.rs` as a `dylib`/`cdylib` respectively; they are not part of
-  the root workspace.
+- **The `mle-language` skill is the source of truth for MLE.** MLE is a small, custom language —
+  do NOT guess syntax/semantics from F#/OCaml intuition (e.g. there is no `if`/`else`; the
+  conditional is a bool-literal `match`; assignment is `:=`; pipelines *prepend* the subject).
+  When a change touches the language or the prelude, update the skill in the same PR.
+- **`file = module`.** Every `.mle` in the entry's directory loads with the project — an
+  unreferenced (or stray scratch) sibling still parses, checks, and evaluates. Keep scratch `.mle`
+  files in their own directory, and don't leave a broken sibling next to a game.
+- **The engine prelude only exists under the host.** `Scene.*`/`Camera.*`/`Frame.*`/`Physics.*`
+  etc. resolve only in runner-hosted MLE (and tests via `functor_runtime_common::mle_prelude`), NOT
+  in a plain `cargo run -p mle -- run`. Branded values (`Angle`, `Time`/`Duration`, `Fog`, render
+  targets) refuse bare numbers/strings with a teaching error — pass `Angle.degrees(60.0)`, not `60`.
 - `cli/src/main.rs`'s `Init` command is currently a TODO stub.
-- **`functor run` does not rebuild the runtimes.** It only rebuilds the *game* (Fable transpile +
-  dylib / wasm-pack). The asset pipeline and rendering execute in the shells, which are prebuilt:
+- **`functor run` does not rebuild the runtimes.** It only (re)loads the *game* `.mle`, which the
+  runner interprets. The asset pipeline and rendering execute in the shells, which are prebuilt:
   natively in the `functor-runner` binary, and on wasm in the web-runtime bundle that is
-  `include_bytes!`-embedded into the `functor` CLI. After changing `runtime/` crates, run
-  `npm run build:cli` first or the running shell silently won't have your change.
+  `include_bytes!`-embedded into the `functor` CLI. After changing `runtime/` crates (including the
+  MLE prelude), run `npm run build:cli` first or the running shell silently won't have your change.
 - **Sample glTF assets vary wildly in units.** The demo assets come from
   [BabylonJS/Assets](https://github.com/BabylonJS/Assets/) (`meshes/*.glb`): `ExplodingBarrel.glb`
   is ~72 units tall, Mixamo-style humanoids (`Xbot.glb`) are centimeter scale, and `fish.glb` is an
-  entire multi-fish scene — hence the per-model `Transform.scale` values in `examples/hello`. No
-  models are checked in (`*.glb` is gitignored there); fetch them with `npm run fetch:assets`. A
+  entire multi-fish scene — hence the per-model `Scene.scale` values in `examples/mle-hello-gltf`.
+  No models are checked in (`*.glb` is gitignored there); fetch them with `npm run fetch:assets`. A
   missing asset logs an error and renders as the fallback (empty) asset.
 - `AGENTS.md` is a symlink to this file — edit `CLAUDE.md` only.

--- a/README.md
+++ b/README.md
@@ -2,39 +2,54 @@
 
 # functor
 
-Functor: A functional toolkit for building 3D games in F#.
+Functor: A functional toolkit for building 3D games in **MLE**, Functor's own
+interpreted, F#-inspired game-logic language.
 
-You write your game in **F#** against the `Functor.Game` library. [Fable](https://fable.io/)
-transpiles that F# to **Rust**, which is then compiled to one of two targets:
+You write your game as a `.mle` file. There is **no transpile or compile step for
+game logic** — the Rust runtime *interprets* the `.mle` directly:
 
-- **native** — a dynamic library loaded by the `functor-runner` desktop runtime (GLFW + OpenGL),
-  with hot-reloading for fast iteration.
-- **wasm** — a WebAssembly bundle (built with `wasm-pack`) served to the browser (WebGL2).
+- **native** — the `functor-runner` desktop runtime (GLFW + OpenGL) loads and runs
+  your `.mle`, with hot-reloading on save for fast iteration.
+- **wasm** — the web runtime (WebGL2) ships the `.mle` source as text and
+  interprets it in the browser.
+
+The same interpreter runs everywhere Rust runs. The heavy per-frame work
+(rendering, skinning, physics) stays in the Rust shell; only the game logic is
+MLE.
 
 ## Writing a game
 
-Games follow an Elm-style MVU loop: your model is immutable, and `input`/`tick`/`update` are pure
-functions that return a new model plus an `effect` (which can produce messages handled by
-`update`). `draw3d` describes a frame — a camera plus a scene — from the model. A game is built
-fluently with `GameBuilder`:
+Games follow an Elm-style MVU loop: your model is an immutable value, and
+`input`/`tick`/`update` are pure functions that return a new model (optionally
+paired with an `effect`, whose result is folded back through `update`). `draw`
+describes a frame — a camera plus a scene — from the model. A runner-hosted game
+defines these top-level MLE bindings:
 
-```fsharp
-GameBuilder.local initialModel
-|> GameBuilder.init (Effect.wrapped Start)  // startup effect, run once before the first frame
-|> GameBuilder.input input                  // 'model -> Input.t      -> 'model * effect<'msg>
-|> GameBuilder.tick tick                    // 'model -> FrameTime    -> 'model * effect<'msg>
-|> GameBuilder.update update                // 'model -> 'msg         -> 'model * effect<'msg>
-|> GameBuilder.subscriptions subscriptions  // 'model -> Sub<'msg>    (timers, e.g. Sub.every)
-|> GameBuilder.draw3d draw3d                // 'model -> FrameTime    -> Graphics.Frame
-|> Runtime.runGame
+```mle
+let init = { … }                        // the initial model (a value)
+let tick = (model, dt, tts) => model'   // per-frame step
+let draw = (model, tts) => Frame.create(camera, scene)
+let input = (model, key, isDown) => model'         // OPTIONAL; key = "W"/"Up"/"Space"
+let update = (model, msg) => model'                // OPTIONAL; msgs are ADT variants
+let subscriptions = (model) => Sub.every(Time.seconds(1.0), Beat)  // OPTIONAL timers
+let physics = (model) => Physics.scene(0.0, -9.81, 0.0, [body, …]) // OPTIONAL
+let soundScape = (model) => AudioScene.create([source, …])         // OPTIONAL looping audio
 ```
 
-See `examples/hello/hello.fs` for a complete game using all of these.
+The model-updating entry points (`tick`, `input`, `mouseMove`, `mouseWheel`,
+`update`) may return a `(model', effect)` tuple instead of a bare model; the
+effect's result folds back through `update`. (`init` is a plain value — no
+effect; `draw`/`physics`/`soundScape`/`ui`/`subscriptions` return their own
+specific values.) The full language and prelude
+(`Scene.*` / `Camera.*` / `Frame.*` / `Light.*` / `Physics.*` / …)
+are documented in the `mle-language` skill (`.claude/skills/mle-language/`) and
+`docs/mle.md`. See `examples/mle-hello-gltf/game.mle` or
+`examples/mle-primitives/game.mle` for complete games.
 
 ## Design principles
 
 - **Functional-core, imperative shell.** As much functionality as possible lives in the pure
-  functional core; side effects are pushed to a thin imperative shell.
+  functional core (the MLE game logic); side effects are pushed to a thin imperative shell.
 - **LLM-native.** Functor functionality is introspectable by LLMs at runtime — favoring live
   evaluation, a text-only runtime, and inspectable state.
 - **Simplicity and incrementality.** Prefer small, incremental PRs, leveraging stacked PRs where
@@ -45,37 +60,33 @@ See `examples/hello/hello.fs` for a complete game using all of these.
 
 | Path | What it is |
 | --- | --- |
-| `src/Functor.Game/` | The F# game framework (`Game`, `Scene3D`, `Camera`, `Input`, `Effect`, `Sub`, `Math`, …) |
-| `src/` | `functor-lib` — the Rust crate produced by Fable from `Functor.Game` |
-| `runtime/functor-runtime-common/` | Shared Rust runtime: rendering, assets, geometry, materials |
-| `runtime/functor-runtime-desktop/` | Desktop runtime; builds the `functor-runner` binary (native/GLFW) |
-| `runtime/functor-runtime-web/` | Web runtime (WebGL2); built into a wasm bundle |
+| `mle/` | The MLE language crate — parser, IR, interpreter, typechecker (`mle parse`/`ir`/`run`/`trace`/`check`) |
+| `runtime/functor-runtime-common/` | Shared Rust runtime: rendering, assets, geometry, materials, the MLE prelude (`FunctorHost`) |
+| `runtime/functor-runtime-desktop/` | Desktop runtime; builds the `functor-runner` binary (native/GLFW), including the MLE producer |
+| `runtime/functor-runtime-web/` | Web runtime (WebGL2); built into a wasm bundle, interprets the `.mle` in the browser |
 | `cli/` | The `functor` CLI (`build` / `run` / `develop`; `init` is not yet implemented) |
-| `examples/hello/` | Sample game (`hello.fs`) — a lineup of glTF sample models with a WASD + mouse free-look camera |
+| `tools/` | Editor tooling: `mle-vscode` (extension), `mle-lsp` (language server), `functor-sdk` (TS debug-runtime SDK) |
+| `examples/mle-*/` | Sample games — e.g. `mle-hello-gltf` (a lineup of glTF sample models with a WASD + mouse free-look camera), `mle-primitives`, `mle-lighting` |
 
 ## Prerequisites
 
 Install the following (the versions in parentheses are known-good):
 
-- [.NET SDK 8](https://dotnet.microsoft.com/download) (`8.0.x`) — runs Fable
 - [Rust](https://rustup.rs/) stable (`1.91`) with the wasm target:
   `rustup target add wasm32-unknown-unknown`
 - [Node.js + npm](https://nodejs.org/) (`node 22`, `npm 10`)
 - [`wasm-pack`](https://rustwasm.github.io/wasm-pack/) (`0.12+`) — `npm install -g wasm-pack`
-- [`watchexec`](https://github.com/watchexec/watchexec) — only needed for `functor develop`
+
+`watchexec` is no longer needed — MLE hot-reload is built into the runtime, so
+`functor develop` needs no external file watcher. There is also **no .NET / Fable
+dependency**: the toolchain is Rust + Node only.
 
 On Linux you also need the native GL/X11 dev packages (see
 `.github/workflows/build-native.yml` for the exact `apt` list).
 
 ## Building the CLI
 
-One-time, install the Fable local tool:
-
-```sh
-dotnet tool restore
-```
-
-Then build the CLI. **Order matters:** the CLI embeds the web runtime bundle at compile
+Build the CLI. **Order matters:** the CLI embeds the web runtime bundle at compile
 time (via `include_bytes!`), so the wasm bundle must exist before the `functor` binary is built.
 
 ```sh
@@ -94,24 +105,28 @@ This produces two binaries in `target/debug/`: `functor` (the CLI) and `functor-
 (the desktop runtime). The CLI looks for `functor-runner` next to itself, so keep them
 together.
 
-## Running the sample (`examples/hello`)
+## Running a sample (`examples/mle-hello-gltf`)
 
-First, fetch the sample's model assets (they aren't checked in; they download from
-[BabylonJS Assets](https://github.com/BabylonJS/Assets/)):
+Some samples reference glTF model assets that aren't checked in (they download from
+[BabylonJS Assets](https://github.com/BabylonJS/Assets/)); fetch them first:
 
 ```sh
 npm run fetch:assets
 ```
 
-The CLI operates on a directory containing a `functor.json`. Point it at the example with
-`-d`. The `run` command transpiles the F#, compiles the game, and launches it:
+The CLI operates on a directory containing a `functor.json`
+(`{"language": "mle", "entry": "game.mle"}`). Point it at the example with `-d`.
+The `run` command interprets the game's `.mle` and launches it — no build step:
 
 ```sh
 # Native — opens a window
-./target/debug/functor -d examples/hello run native
+./target/debug/functor -d examples/mle-hello-gltf run native
 
-# Web — builds the wasm bundle, serves it, and opens http://127.0.0.1:8080
-./target/debug/functor -d examples/hello run wasm
+# A primitives-only sample (no assets needed)
+./target/debug/functor -d examples/mle-primitives run native
+
+# Web — serves the .mle + wasm bundle at http://127.0.0.1:8080
+./target/debug/functor -d examples/mle-primitives run wasm
 ```
 
 `native` is the default environment, so `... run` is equivalent to `... run native`.
@@ -120,18 +135,20 @@ The CLI operates on a directory containing a `functor.json`. Point it at the exa
 
 | Command | Description |
 | --- | --- |
-| `functor -d <dir> build [native\|wasm]` | Transpile F# → Rust and compile the game |
-| `functor -d <dir> run [native\|wasm]` | Build, then run (native window / browser) |
-| `functor -d <dir> develop [native\|wasm]` | Hot-reload dev loop (requires `watchexec`) |
+| `functor -d <dir> build [native\|wasm]` | Typecheck the `.mle` project (diagnostics are errors) |
+| `functor -d <dir> run [native\|wasm]` | Interpret and run the game (native window / browser) |
+| `functor -d <dir> develop [native\|wasm]` | Same as `run` — MLE hot-reload is built into the runtime |
 
 ### What `build`/`run` do under the hood
 
-1. `npm run build:examples:hello:rust` — Fable transpiles `examples/hello/hello.fs` to
-   Rust (`examples/hello/hello.rs`) and generates `fable_modules/`.
-2. `cargo build` in `examples/hello/build-native` (native) or
-   `wasm-pack build` in `examples/hello/build-wasm` (wasm) — compiles the game.
-3. (native) `functor-runner` loads the resulting `libgame_native` dylib;
-   (wasm) a dev server serves the bundle to the browser.
+1. `build` loads the project (the entry `.mle` plus every sibling `.mle` — file = module)
+   and typechecks the whole program; diagnostics are errors here.
+2. (native) `run` spawns `functor-runner --mle --game-path <entry>` from the game
+   directory; the runner **interprets** the `.mle` each frame and hot-reloads it on
+   save, preserving the model.
+3. (wasm) `run` serves the project directory — the `.mle` ships as text; the embedded
+   web runtime fetches and interprets it. (File-watch hot-reload is native-only;
+   reload the page to pick up saved edits.)
 
 ## Credits
 

--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -9,13 +9,13 @@ localhost socket.
 Start it by passing `--debug-port <PORT>`:
 
 ```sh
-# via the CLI (rebuilds + runs the game)
-./target/debug/functor -d examples/hello run native --debug-port 8077
+# via the CLI (runs the game — the runner interprets the .mle)
+./target/debug/functor -d examples/mle-hello-gltf run native --debug-port 8077
 
-# or the runner directly, against an already-built dylib
+# or the runner directly, against the .mle entry
 #   (cwd must be the game dir so assets resolve)
-cd examples/hello
-functor-runner --game-path build-native/target/debug/libgame_native.dylib --debug-port 8077
+cd examples/mle-hello-gltf
+functor-runner --mle --game-path game.mle --debug-port 8077
 ```
 
 The server binds **localhost by default** (`127.0.0.1:<PORT>`); `--debug-bind 0.0.0.0`
@@ -31,10 +31,10 @@ without GLFW/OpenGL, so no display (or GPU) is needed. Ideal for CI, scripted ru
 and LLM-driven control:
 
 ```sh
-functor-runner --game-path <dylib> --debug-port 8077 --headless
+functor-runner --mle --game-path game.mle --debug-port 8077 --headless
 ```
 
-`/`, `/state`, `/scene`, `/input`, and `/time` all work (the game's `draw3d`
+`/`, `/state`, `/scene`, `/input`, and `/time` all work (the game's `draw`
 produces a pure `Frame`, so `/scene` is real data with no rendering). This is the
 runtime expression of the LLM-native principle: drive and observe a game with no
 GPU window. Limitations vs. windowed:
@@ -54,7 +54,7 @@ work unchanged (audio too). `--capture-frame` implies `--hidden` — a scripted
 screenshot run has no reason to grab your mouse.
 
 ```sh
-functor-runner --game-path <dylib> --debug-port 8077 --hidden
+functor-runner --mle --game-path game.mle --debug-port 8077 --hidden
 ```
 
 ## Endpoints
@@ -97,7 +97,7 @@ injected `/input` still applies — so an external driver has deterministic cont
 The body is the raw `.mle` source. The runner validates it and swaps the session with
 **the model preserved** — the same semantics as the file-watch reload. A broken push
 returns **400** with the rendered load error and keeps the old program running; producers
-whose logic isn't source-shaped (compiled dylibs, replays) also return 400. This is the
+whose logic isn't source-shaped (e.g. the `--replay` producer) also return 400. This is the
 remote develop path: run the game on another machine or device
 (`--debug-port <P> --debug-bind 0.0.0.0`), then push from the project dir:
 

--- a/docs/llm-native-editor.md
+++ b/docs/llm-native-editor.md
@@ -11,7 +11,7 @@ A traditional engine ships a heavyweight editor (Unity/Unreal/Godot) as the
 primary authoring surface. Functor's bet is different: **the LLM plus a fast
 iteration loop becomes the editor** — the same way an agentic coding tool displaces
 much of what an IDE used to do. You don't click panels to build the game; you
-direct an LLM that authors the game's pure F# data and functions, runs it, looks at
+direct an LLM that authors the game's pure MLE data and functions, runs it, looks at
 the result, and iterates.
 
 This is **load-bearing strategy, not a feature.** A full editor is one of the
@@ -29,7 +29,7 @@ work:
 
 - **LLM-subsumable (~80%):** scene composition, entity wiring, game rules, spawn
   logic, component/material config, netcode plumbing, bulk edits ("20 crates in a
-  grid", "add a patrol AI"), refactors. Functor's serializable-F#-data surface is
+  grid", "add a patrol AI"), refactors. Functor's serializable-MLE-data surface is
   the LLM's home turf.
 - **Stays human — perceptual / feel judgment:** does the jump *feel* right, is the
   light too harsh, does the camera shake read, is the animation timed well. A
@@ -47,7 +47,8 @@ being able to **see results and iterate without a human relaying them.** Closing
 that loop is exactly what principle #2 provides:
 
 - headless frame capture (already shipped — `--capture-frame` / `--fixed-time`),
-- serializable / inspectable state (`emit_state`; MVU makes the model plain data),
+- serializable / inspectable state (the MLE model is a plain value, surfaced at the debug
+  server's `GET /state`),
 - the debug runtime on the backlog (`/state`, `/scene`, raycast — see
   `docs/todo.md`),
 - a text-only runtime path that needs no GL window.

--- a/docs/mle.md
+++ b/docs/mle.md
@@ -1,9 +1,17 @@
 # MLE: replacing F#/Fable with our own language
 
-> Design + phased roadmap. Each step is independently verifiable and lands as its
-> own small PR. The endgame is a complete replacement of the F#/Fable pipeline,
-> but nothing here requires a flag-day — F# and MLE coexist behind one seam until
-> MLE wins on every axis.
+> **STATUS: COMPLETE (2026-07-05).** The endgame landed — MLE is now the *only*
+> game-logic language, and the F#/Fable pipeline (Fable, dotnet tooling,
+> `.fsproj`s, `fable_modules/`, the `.fs`/`.fsi`/`.rs` triplication, the dylib
+> hot-reload path) has been deleted (roadmap **E3**, below). `npm run build:cli`
+> needs only Rust + Node. This document is retained as the design record and the
+> history of how MLE was built; the `mle-language` skill is the live source of
+> truth for the language as it exists today.
+
+> Design + phased roadmap. Each step was independently verifiable and landed as
+> its own small PR. The endgame was a complete replacement of the F#/Fable
+> pipeline, reached pull-based (no flag-day): F# and MLE coexisted behind one
+> seam until MLE won on every axis.
 
 ## Problem
 
@@ -590,7 +598,8 @@ Pull-based: port examples as MLE proves itself; no flag-day.
       heightmap-shading (documented in the game.mle header). Camera,
       input math, model lineup, lit primitives, neon sphere, and lights
       were already byte-identical from E1a.
-- [ ] **E2.** Port remaining examples, one PR each. *Verify:* per-example
+- [x] **E2.** Port remaining examples, one PR each (done 2026-07-05 — every
+      sample is now an `examples/mle-*` project). *Verify:* per-example
       goldens + e2e.
       *Progress — networking (2026-07-05):* the MLE **net surface** landed
       so the multiplayer samples can port. A built-in **`Net` module**
@@ -609,10 +618,10 @@ Pull-based: port examples as MLE proves itself; no flag-day.
       (server, closure tagger, per-client ids) port their F# originals;
       headless unit tests drive the full lifecycle without a socket.
       Remaining: `mpclient`/`mpserver`, then HTTP (`netdemo`).
-- [ ] **E3.** Delete the F# pipeline: Fable, dotnet tooling, `.fsproj`s,
+- [x] **E3.** Delete the F# pipeline: Fable, dotnet tooling, `.fsproj`s,
       `fable_modules/`, the `.fs`/`.fsi`/`.rs` triplication, the dylib
-      hot-reload path. *Verify:* full CI green with no dotnet installed;
-      `npm run build:cli` needs only Rust + Node.
+      hot-reload path (done — the atomic cut). *Verify (done):* CI green with
+      no dotnet installed; `npm run build:cli` needs only Rust + Node.
 
 ## Sequencing & risks
 

--- a/docs/multiplayer.md
+++ b/docs/multiplayer.md
@@ -21,16 +21,15 @@ not part of it.
 
 The MVU loop's hot-reload behavior shapes the API:
 
-- **The effect queue is no longer persisted across hot reload** (changed during
-  the HTTP work — see `effects-plain-data-invariant`). `getState`/`setState`
-  persist **only the model**; the queue is reset to empty on reload. This *lifts*
-  the old "effects must be plain data" rule, so an `Effect` may now carry a
-  closure — which is what lets HTTP use the Elm `expect` shape (the request `Cmd`
-  carries a `tagger : Result -> Msg`).
-- **A closure cannot cross a dylib swap.** So the request→response tagger is held
-  in a thread-local, dylib-bound registry, not in `OpaqueState`. On hot reload an
-  in-flight request loses its tagger; the response is dropped with a warning
-  (a deliberate, dev-only trade).
+- **The effect queue is not persisted across hot reload.** MLE reload preserves
+  **only the model** (a plain value the host holds); the queue is reset to empty.
+  An `Effect` may carry a closure — which is what lets HTTP use the Elm `expect`
+  shape (the request carries a `tagger : Result -> Msg`).
+- **An in-flight request's tagger cannot survive a reload.** The request→response
+  tagger is held in a token-keyed registry, not in the model. On hot reload the
+  model is preserved (and closures stored *inside* it rebind), but a pending
+  request loses its tagger and the response is dropped with a warning (a
+  deliberate, dev-only trade).
 - **Subs are recomputed every frame and not persisted.** For *persistent
   connections* (WebSocket/TCP/UDP, Phase 2+), a `Sub` still carries the inbound
   decoder and the connection identity, so a live socket is matched across
@@ -43,11 +42,11 @@ Elm-style; persistent connections are a `Sub` (inbound/identity) + `Effect`
 ## Architecture
 
 ```
-        ┌──────────────────────── F# functional core ────────────────────────┐
+        ┌──────────────────────── MLE functional core ───────────────────────┐
         │  subscriptions: model -> Sub   (inbound + connection lifecycle)     │
         │  update/tick   -> effect       (outbound, PLAIN DATA only)          │
         └─────────────────────────────────┬───────────────────────────────────┘
-                                           │  (thin Emit shims)
+                                           │  (the MLE producer + prelude)
         ┌──────────────────────────────────▼──────────────── imperative shell ─┐
         │  ConnectionManager  — owns live connections, keyed by sub identity     │
         │  AsyncInbox         — thread-safe queue; drained ONCE per frame        │
@@ -70,41 +69,40 @@ Elm-style; persistent connections are a `Sub` (inbound/identity) + `Effect`
   each frame: open newly-declared connections, tear down removed ones, keyed by a
   stable identity (endpoint / user key), not the generic msg.
 
-## API (F#)
+## API (MLE)
 
-**HTTP — Elm `Http.get { expect = ... }` style (shipped, Phase 1).** A single
-`Effect` carries the tagger; the response comes back as a message through
-`update`. No subscription.
+**HTTP — Elm `Http.get { expect = ... }` style (shipped).** A single `Effect`
+carries the tagger; the response comes back as a message through `update`. No
+subscription.
 
-```fsharp
-Effect.httpGet  (url: string) (tagger: Net.HttpResponse -> 'msg) : effect<'msg>
-Effect.httpPost (url: string) (body: string) (tagger: Net.HttpResponse -> 'msg) : effect<'msg>
-// Net.HttpResponse: .ok .status .body .error   (the result handed to the tagger)
+```mle
+Effect.httpGet(url, tagger)        // tagger: (HttpResponse) => Msg
+Effect.httpPost(url, body, tagger) // the response record is handed to the tagger
 ```
 
 Under the hood: the request gets an auto token; running the effect registers the
-tagger (keyed by token) in a thread-local registry and queues a plain-data
-command for the host to perform; when the response lands, the executor applies the
-tagger and delivers the message.
+tagger (keyed by token) and queues a plain-data command for the host to perform;
+when the response lands, the broker applies the tagger and delivers the message.
+`examples/mle-netdemo` is the port.
 
 **Persistent connections — `Sub` (inbound/identity) + `Effect` (send)**
-(WebSocket/TCP/UDP, Phase 2+):
+(WebSockets shipped):
 
-```fsharp
+```mle
 // client: declares a desired connection; runtime keeps it open + reconnects
-Sub.connect (endpoint: Endpoint) (decode: NetEvent -> 'msg)
+Sub.connect(url, tagger)   // tagger: (Net.NetEvent) => Msg
 // server: accepts many; yields per-client events (native only for TCP/UDP/WS)
-Sub.listen  (bind: Endpoint)     (decode: NetEvent -> 'msg)
+Sub.listen(addr, tagger)   // tagger: (Net.NetEvent) => Msg
 
-Effect.send      (id: ConnectionId) (payload: byte[]) : effect<'msg>
-Effect.broadcast (ids)              (payload: byte[]) : effect<'msg>
-Effect.close     (id: ConnectionId)                   : effect<'msg>
+Effect.send(connId, text)  // send on an open connection
 ```
 
-`NetEvent = Connected of ConnectionId | Message of ConnectionId * byte[]
-          | Disconnected of ConnectionId | Error of ConnectionId * string`.
-`ConnectionId` is assigned by the runtime and reported via the `Connected` event;
-the game stores it in its model and names it in send effects.
+`Net` is a built-in module, always in scope:
+`type NetEvent = | Connected(id: Float) | Message(id: Float, text: String) |
+Disconnected(id: Float) | Error(id: Float, text: String)`. The connection id is
+assigned by the runtime and reported via `Connected`; the game stores it in its
+model and names it in `Effect.send`. `examples/mle-wsdemo` (client) and
+`examples/mle-wsserverdemo` (server) are the ports.
 
 ## Test harness / SDK
 
@@ -125,11 +123,10 @@ sim.kill(clientB); ...; sim.restart(clientB)
 assert_eq!(sim.state(clientA).entities, sim.state(server).entities)
 ```
 
-Enabling refactor: today there's a single global `currentRunner` per dylib
-(`Runtime.fs`), so one process can't host a server + many clients. Generalize the
-`no_mangle` / `wasm_bindgen` exports to a **handle-based API** (`create_runner()
--> Handle`, `tick(h)`, `inject_net(h, ...)`, `get_state(h)`). This also subsumes
-today's single-instance hot-reload case.
+This shipped as the `functor-netsim` crate: many `mle::Session`-backed game
+instances share a `VirtualTransport` bus in one process, stepped in lockstep. (An
+`mle::Session` is a plain owned value, so hosting a server + many clients in one
+process is natural — there is no per-process global runner to work around.)
 
 **B. Multi-process integration harness.** Real `functor-runner` processes driven
 over an extended debug-server API (add `/net` inject + `/tick` step to the

--- a/docs/physics.md
+++ b/docs/physics.md
@@ -64,7 +64,7 @@ Like rendering and audio, physics must be **drivable and observable headlessly**
 ## Design constraints (from the architecture)
 
 - **Physics-as-shell, model-as-truth.** A Rapier world is a large mutable bag of
-  solver state; it is *not* stored in the F# model. It lives runtime-side in
+  solver state; it is *not* stored in the MLE model. It lives runtime-side in
   `functor-runtime-common` as a cache/accelerator — exactly like the renderer and
   the audio voice registry. The model holds plain, serializable data; the live
   world is reconstructible from a snapshot or an input replay.
@@ -117,8 +117,7 @@ Like rendering and audio, physics must be **drivable and observable headlessly**
 ## Surface: MLE-first
 
 **The game-facing surface lands in MLE, not F#** (decided 2026-07-03; see
-`docs/language-direction.md` — Functor is investing in MLE as the game-logic
-layer). The design below is unchanged — declarative scene, divergence rule,
+`docs/mle.md` — MLE is now Functor's only game-logic layer). The design below is unchanged — declarative scene, divergence rule,
 commands, subs — but the shipping vocabulary is the MLE prelude
 (`functor_runtime_common::mle_prelude`, documented in the `mle-language`
 skill):
@@ -404,8 +403,8 @@ are just the two common collections; a model can carry as many as its netcode ne
   **instanced rendering** (`Scene3D.instances mesh transforms` → one draw call),
   **reconcile bail-out + tag interning** (steady-state diff is near-free), and the
   **`Physics.events` sub** (despawn-on-collision).
-- **`Entities` is a recommended pattern, not a mandate.** It ships in
-  `Functor.Game` as the default, but a game can swap in its own entity model
+- **`Entities` is a recommended pattern, not a mandate.** It would ship as a
+  default MLE module, but a game can swap in its own entity model
   (ECS-ish, hierarchical) on the same primitives — Functor doesn't impose one.
 
 ## Determinism

--- a/docs/time-travel.md
+++ b/docs/time-travel.md
@@ -57,8 +57,8 @@ It builds directly on three existing threads and should be read alongside them:
 `docs/physics.md` (the `Simulatable`/`Timeline` seam this generalizes),
 `docs/llm-native-editor.md` (which already frames rewind as an *authoring*
 primitive, not just a debugging one), and `docs/debug-runtime.md` (the
-frame-clock control that already exists). The surface is **MLE-first** — F# is
-no longer a target (`docs/language-direction.md`).
+frame-clock control that already exists). The surface is **MLE-only** — the
+F#/Fable pipeline has been removed (`docs/mle.md`).
 
 Inspiration: the [Tomorrow Corporation tech
 demo](https://www.youtube.com/watch?v=72y2EC5fkcE) (whole-program time travel as
@@ -96,7 +96,7 @@ Any>` (`OpaqueState`) bound to one dylib generation, opaque to the runtime and
 not clonable-as-data from the shell. The in-process interpreter is the enabling
 fact — the shell *owns* the model value and can version it directly. Whole-game
 rewind is one of the concrete payoffs of the MLE pivot
-(`docs/language-direction.md`).
+(`docs/mle.md`).
 
 ### One frame, one clock
 
@@ -261,7 +261,7 @@ frame snapshot is `(model, world)`, a fork is just *keeping* the old future
 instead of `truncate_from`-ing it, holding two model+world states, and calling
 the pure `draw` on each. The only new **engine** capability is a render pass that
 composites a second scene at reduced opacity (~50%). Everything else is already
-there: two models, one pure `draw3d`, one blend.
+there: two models, one pure `draw`, one blend.
 
 ### Trajectory preview — forward-ghosting (Inventing on Principle)
 
@@ -270,7 +270,7 @@ this is **chronophotography**: from the paused snapshot, step the whole scene
 forward over a window (start with ~2s / 10 divisions) and composite the divisions
 into one image, each at `1/divisions` weight. Static geometry averages to itself
 (solid); anything moving smears into a faint strobe of its own future positions.
-It needs **no new scene-description API** — you call the existing `draw3d` on each
+It needs **no new scene-description API** — you call the existing `draw` on each
 stepped state — and it captures *all* motion, not one hand-picked entity, so it
 works for any scene under a fixed camera.
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -65,7 +65,7 @@ The networking design + phased roadmap that drives these items lives in
       — most likely `tick : model -> FrameTime -> Input.State -> ...` — so games
       ask `Input.State.isKeyDown state Key.W` instead of rebuilding held-key state
       from up/down events. Keep events too (press/release edges matter). Held-set
-      is derived state: rebuild from events, don't persist in `OpaqueState`.
+      is derived state: rebuild from events, don't persist it across a reload.
 - [ ] Game-controller and VR-controller events (`Input` has TODO placeholders).
 
 ## CLI
@@ -80,7 +80,7 @@ The networking design + phased roadmap that drives these items lives in
 Design + phased roadmap: `docs/physics.md` (Rapier-backed, functional
 `physicsScape` reconcile, deterministic fixed-step, `Simulatable`/`Timeline`
 rewind seam, server-authoritative prediction). First step = Phase 1, the Rust-only
-shell spine (no F# surface).
+shell spine (no game-language surface).
 
 - [ ] Phase 1: Rapier dep + `physics` module + fixed-step + `Timeline` traits +
       determinism goldens.
@@ -110,27 +110,20 @@ iteration" item below (T6, trajectory preview).
 
 ## Language (MLE)
 
-Design + phased roadmap: `docs/mle.md` (replace F#/Fable with a custom
-Rust-hosted interpreted language; data-protocol seam first, F# and MLE coexist
-behind a `GameProducer` trait until MLE wins). Language design notes live in
-`~/notes/ideas/mle-language/`.
-
-- [ ] Milestone 0: throwaway perf spike — interpreted tick/draw at 60fps +
-      hot-reload latency numbers, embedded in `functor-runner` behind a flag.
-- [ ] Track A: data seam — versioned serde protocol (A1), `GameProducer` trait
-      (A2), proof producer (A3). No MLE required; valuable standalone.
-- [ ] Track B: MLE vertical slice — parser → IR → interpreter → types →
-      ADTs/closures → effect broker (B1–B6), in-repo `mle/` crates.
-- [ ] Track C: MLE behind the seam — prelude, `MleProducer` + mle-hello golden,
-      hot-reload payoff demo, MVU parity, wasm, perf gate (C1–C6).
-- [ ] Endgame: port examples, then delete the F#/Fable pipeline (E1–E3).
+**SHIPPED** — MLE is now Functor's only game-logic language; the F#/Fable
+pipeline was deleted (roadmap E3). The full history and design record is in
+`docs/mle.md` (all tracks/checkboxes done); the live language reference is the
+`mle-language` skill. Remaining language follow-ups tracked there: `.mlei`
+interface files (B8 part 2), LSP cross-file support, and wasm/live-preview
+multi-file.
 
 ## Live variables / fast iteration
 
 - [ ] Live-variable debugging: a `Constant`-style function (name + value) editable
       at runtime, backed by a string→value map. See
-      [const-tweaker](https://github.com/tversteeg/const-tweaker); may need a
-      custom Fable build for token reloading.
+      [const-tweaker](https://github.com/tversteeg/const-tweaker). (MLE hot-reload
+      already rebinds edited top-level values live; this is the finer-grained,
+      no-reload knob.)
 
 ## Audio
 

--- a/tools/functor-sdk/README.md
+++ b/tools/functor-sdk/README.md
@@ -18,7 +18,8 @@ npm run build     # tsc -> dist/
 ```ts
 import { FunctorRunner, stepAll } from "@functor/sdk";
 
-// Launch a game and drive it deterministically.
+// Launch a game and drive it deterministically. MLE games are run via `mlePath`
+// (the runner interprets the .mle — nothing to build).
 await using game = await FunctorRunner.launch({
   gameDir: "examples/mle-hello-gltf",
   mlePath: "examples/mle-hello-gltf/game.mle",
@@ -86,13 +87,18 @@ npm test          # unit tests only (no runtime needed)
 npm run test:e2e  # FUNCTOR_E2E=1 — launches a real functor-runner
 ```
 
-The e2e tests require the runner binary to be built, and a display to open the
-GL window. The games are MLE sources (`examples/mle-*`) interpreted in place, so
-there is no per-game build step:
+The e2e tests require the runner binary and a display to open the GL window. MLE
+games need no build step — the runner interprets the `.mle` directly — so only
+`functor-runner` has to be built:
 
 ```sh
 cargo build --bin functor-runner
 ```
+
+(The games driven by the tests are `examples/mle-hello-gltf` — the held-input
+test — and `examples/mle-mpserver` / `examples/mle-mpclient` — the multiplayer
+test. A `build` step is optional: `functor -d <dir> build native` just
+typechecks the `.mle`.)
 
 The headline e2e (`held-input.e2e.test.ts`) is the durable guard for the
 input→state→step loop: inject `up`, step a frame, assert the model's `held.up`


### PR DESCRIPTION
## What

Roadmap **E3** is complete — the F#/Fable→Rust game-logic pipeline was deleted (commit \`09035a4\`) and game logic is now written **only in MLE**, Functor's interpreted F#-inspired language, interpreted directly by the Rust runtime (no build step for game logic). This PR rewrites the developer docs to match that reality: it removes the F#→Fable→Rust narrative and describes the MLE-only pipeline accurately.

Scope: docs only (no \`site/\` — a separate agent owns it; no \`mle-*\` dir renames — a later PR does that).

## Files

- **README.md** — build/run walkthrough rewritten around MLE examples (\`mle-hello-gltf\` / \`mle-primitives\`), the \`functor.json\` \`{"language":"mle"}\` contract, and the interpret-not-transpile pipeline. Dropped every dotnet/Fable prerequisite; \`npm run build:cli\` is Rust + Node only.
- **CLAUDE.md** — "What this is", Architecture (the MLE producer + \`FunctorHost\` prelude, the shared effect broker, MLE hot-reload with model preservation + closure rebind), Layout table (\`mle/\` crate, \`examples/mle-*\`), Commands, and Gotchas (deleted the uuid/Fable + per-example-workspace notes; added MLE-relevant ones). Points at the \`mle-language\` skill + \`docs/mle.md\` as the source of truth.
- **docs/mle.md** — marked the endgame **COMPLETE** (E1/E2/E3 checkboxes done + a status banner); kept the roadmap as the design/history record.
- **docs/{debug-runtime, multiplayer, physics, time-travel, llm-native-editor, todo}.md** — fixed F# example refs, the \`game_native\` dylib commands (→ \`functor-runner --mle --game-path game.mle\`), the dead \`docs/language-direction.md\` links (→ \`docs/mle.md\`), and the Fable narrative → MLE.
- **tools/functor-sdk/README.md** — F# game examples → MLE ports; the SDK drives MLE games via \`mlePath\`.

## Verification

Every documented command was actually run against this branch:
- \`npm run build:cli\` succeeds with only Rust + Node (no .NET installed path).
- \`functor -d examples/mle-primitives build native\` → typechecks; \`run native --capture-frame … --fixed-time 2\` → wrote a PNG.
- \`functor -d examples/mle-hello-gltf build native\`, \`functor -d examples/mle-lighting build native\` → ok.
- \`functor -d examples/mle-primitives run wasm\` → serves the index page + \`game.mle\` (both HTTP 200).
- \`npm run test:golden\` scenarios are the \`mle-*\` samples (\`golden-scenarios.json\`).

## Review

Ran cross-engine review (Claude subagent + Codex CLI). Claude: accurate, no correctness defects. Codex caught one real overstatement in the new prose — "**any** entry point may return \`(model, effect)\`" — which is false (\`init\` rejects effects; \`draw\`/\`physics\`/\`soundScape\`/\`ui\` return their own host values). Fixed in README + CLAUDE.md to name the model-updating entry points only. Also fixed a stale \`emit_state\` (deleted F# export) reference in llm-native-editor.md.

### Intentionally kept F# mentions (historical/by-design)
- \`docs/mle.md\` — the roadmap's "Problem" section and Track A boundary description (\`no_mangle\` exports in \`Runtime.fs\`) are the **historical design record** of why/how MLE replaced F#.
- \`docs/physics.md\` — the "API (F# — reference design, deferred)" section is an explicitly-retained alternative design ("the design below is unchanged … the shipping vocabulary is the MLE prelude").
- \`docs/time-travel.md\` — the "F#/Fable path could never do this cleanly" contrast explains *why* the MLE pivot enabled whole-game rewind.
- Callouts like "F#-inspired language" and "no .NET / Fable dependency".

### Out of scope (noted, not touched)
Codex also flagged pre-existing **backlog staleness** unrelated to the F#→MLE narrative: \`docs/todo.md\` still lists shipped networking (\`Sub.connect\`/\`listen\`, \`Effect.httpGet\`), physics (Phase 1 / pause-rewind), and time-travel (T1–T3) work as TODO, and \`docs/debug-runtime.md\`/\`todo.md\` describe the (now-shipped) TypeScript SDK as planned. The task scoped \`todo.md\` to "F# items only", so these are left for a follow-up backlog-sweep PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)