### PR TITLE
feat(time-travel): T6d forward-ghosting — composite N stepped frames (--ghost)

### DIFF
--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -130,6 +130,17 @@ pub trait GameProducer {
         None
     }
 
+    /// Forward-step the scene `divisions` fixed frames of `dt` seconds from
+    /// `start_tts` and return the drawn [`crate::Frame`] for each — the
+    /// forward-ghosting trajectory preview (docs/time-travel.md T6d). The shell
+    /// composites the returned frames into one image (chronophotography), so
+    /// moving elements smear into a strobe of their future positions. Each frame
+    /// carries the *paused* camera so only world motion smears, not the view.
+    /// The default is empty (no ghosting) for producers without a model history.
+    fn ghost_frames(&self, _divisions: usize, _dt: f32, _start_tts: f64) -> Vec<crate::Frame> {
+        Vec::new()
+    }
+
     /// Seek the whole scene to a rendered frame for DISPLAY, WITHOUT branching
     /// (docs/time-travel.md T3, the draggable scrubber): restore model + world
     /// so the user can scrub back and forth freely while paused. The future is

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -33,7 +33,7 @@ use functor_runtime_common::mle_prelude::{
     audio_scene_of, clear_audio_completions, clear_http_taggers, frame_value, view_value,
     EffectLog, EffectRunner, EffectTree, FunctorHost, NetEventKind, RealEffects,
 };
-use functor_runtime_common::mle_producer::{FrameCtx, Reporter, SpanSource};
+use functor_runtime_common::mle_producer::{forward_step_scene, FrameCtx, Reporter, SpanSource};
 use functor_runtime_common::physics;
 use functor_runtime_common::timetravel::SceneRecorder;
 use functor_runtime_common::ui::View;
@@ -568,6 +568,45 @@ impl Game for MleGame {
 
     fn current_scene_tts(&self) -> Option<f64> {
         self.recorder.current_scene_frame_tts()
+    }
+
+    /// Forward-ghosting (docs/time-travel.md T6d): step the scene forward
+    /// `divisions` fixed frames of `dt` from `start_tts` (a dry run over
+    /// throwaway state — the live producer is untouched), then `draw` each
+    /// stepped model at its division time and return the frames for the shell to
+    /// composite. Division `i` draws at `tts = start_tts + (i+1)*dt`, matching
+    /// the time `forward_step_scene` stepped the model to. Each frame's camera is
+    /// overridden to the paused view (`last_frame.camera`) so only world motion
+    /// smears. A draw that errors or doesn't return a Frame is skipped, so the
+    /// result may be shorter than `divisions`.
+    fn ghost_frames(&self, divisions: usize, dt: f32, start_tts: f64) -> Vec<Frame> {
+        let stepped = forward_step_scene(
+            &self.session,
+            &self.model,
+            self.has_physics,
+            self.has_subscriptions,
+            self.prev_tts,
+            start_tts as f32,
+            dt,
+            divisions,
+        );
+        let mut frames = Vec::with_capacity(stepped.len());
+        for (i, (model_i, _world)) in stepped.iter().enumerate() {
+            // Match forward_step_scene's f32 division-time arithmetic exactly, so
+            // each redrawn frame's tts equals the tts its model was stepped at.
+            let tts = (start_tts as f32 + (i as f32 + 1.0) * dt) as f64;
+            let args = vec![model_i.clone(), Value::Number(tts)];
+            // A draw error or non-Frame return for a division is skipped, not fatal.
+            if let Ok(value) = self.session.call("draw", args, &mut FunctorHost) {
+                if let Some(frame) = frame_value(&value) {
+                    let mut frame = frame.clone();
+                    // Freeze the view: composite only world motion, not the camera.
+                    frame.camera = self.last_frame.camera.clone();
+                    frames.push(frame);
+                }
+            }
+        }
+        frames
     }
 
     /// Non-destructive scrub — delegated to the shared [`SceneRecorder`]

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -221,6 +221,20 @@ pub struct Args {
     #[arg(long, value_enum, default_value_t = CompositeDemoArg::Off)]
     composite_demo: CompositeDemoArg,
 
+    /// Forward-ghosting trajectory preview (docs/time-travel.md T6d): composite
+    /// N forward-stepped frames into one image (chronophotography), so moving
+    /// elements smear into a strobe of their ~2s future positions while static
+    /// geometry stays solid. Off by default; when on it composites every frame
+    /// (no pause gating), so it's deterministically capturable under
+    /// --fixed-time. The window is fixed at ~2s (`dt = 2.0 / --ghost-divisions`).
+    #[arg(long)]
+    ghost: bool,
+
+    /// Number of forward divisions composited by --ghost (clamped to 8, the
+    /// compositor max). More divisions = a finer strobe over the same ~2s window.
+    #[arg(long, default_value_t = 8)]
+    ghost_divisions: usize,
+
     /// Eye separation for --stereo-sbs, in world units. The default assumes
     /// meter-scale worlds (human IPD ≈ 64mm); raise it for larger-unit worlds
     /// to deepen the 3D effect.
@@ -908,6 +922,28 @@ Escape again to quit"
             // The game supplies the camera/scene/lights as part of its frame.
             let frame = game.render(time.clone());
 
+            // Forward-ghosting (docs/time-travel.md T6d): when --ghost is on, step
+            // the scene forward over a ~2s window and collect a Frame per division
+            // (a dry run — the live producer is untouched), for the compositor arm
+            // in the render ladder below. Empty when --ghost is off (or the
+            // producer has no model history, e.g. web's trait default). `start_tts
+            // = time.tts` (under --fixed-time T, that's T, so the ghost projects
+            // T+dt … T+N·dt). Always composites when on — no pause gating — so it's
+            // deterministically capturable under --fixed-time.
+            // Gate on the full ladder condition so we don't pay the dry-run + N
+            // draws only to have stereo / composite-demo outrank the ghost arm.
+            let ghost_frames = if args.ghost
+                && !args.stereo_sbs
+                && args.composite_demo == CompositeDemoArg::Off
+            {
+                const MAX_GHOST: usize = 8;
+                let divisions = args.ghost_divisions.clamp(1, MAX_GHOST);
+                let dt = 2.0 / divisions as f32;
+                game.ghost_frames(divisions, dt, time.tts as f64)
+            } else {
+                Vec::new()
+            };
+
             // The camera actually viewed/heard: the game's camera, rotated by
             // the head orientation when Xreal tracking is on.
             let view_camera = match &xreal_tracker {
@@ -1021,6 +1057,25 @@ Escape again to quit"
                     &shadow_map,
                     &frames,
                     &[0.5, 0.5],
+                    time.clone(),
+                    viewport,
+                    args.debug_render.into(),
+                );
+            } else if !ghost_frames.is_empty() {
+                // Forward-ghosting (docs/time-travel.md T6d): composite the ~2s
+                // forward-stepped frames (computed above) at equal weight so moving
+                // elements strobe across their future and static geometry stays
+                // solid. Empty (→ this arm skipped) when --ghost is off or the
+                // producer yields no frames, so live rendering is unchanged.
+                let weights = vec![1.0f32; ghost_frames.len()];
+                functor_runtime_common::render_composited_frames(
+                    &gl,
+                    shader_version,
+                    asset_cache.clone(),
+                    &scene_context,
+                    &shadow_map,
+                    &ghost_frames,
+                    &weights,
                     time.clone(),
                     viewport,
                     args.debug_render.into(),


### PR DESCRIPTION
## T6d — forward-ghosting (`--ghost`)

The Bret-Victor payoff: composite N forward-stepped frames into one image (chronophotography), so time-driven motion **strobes across its future** over a frozen scene. First target: `examples/mle-lighting` — its orbiting point lights smear into faint multi-copies of their next ~2 seconds while the geometry stays solid.

Pure wiring of two already-merged primitives — **no common-crate changes**:
- `GameProducer::ghost_frames(divisions, dt, start_tts) -> Vec<Frame>` (default empty; desktop `MleGame` impl): runs the merged **T6b `forward_step_scene`** (dry-run — live state untouched), redraws each stepped `(model_i, tts_i)`, and **freezes each ghost frame's camera** to the live view so only world motion smears.
- `--ghost` (+ `--ghost-divisions`, default 8, clamped to `MAX_COMPOSITE=8`; ~2s window) adds a render-ladder arm that composites the ghost frames via the merged **T5 `render_composited_frames`** at equal weights (average). Off by default; always composites when on (no pause gating — deterministically capturable under `--fixed-time`).

### Verification (visual)
Before/after below: `--ghost` turns each single point-light marker into a strobed trail of ~8 faint copies (blue arcing left, red across the middle, green sweeping right), floor lighting softening as the lights average, all static geometry solid.
- **Byte-identical goldens** (all 7 scenarios, 0.000%) — `--ghost` off by default, live rendering unchanged.
- `cargo test` green (201 common + 35 desktop); `--features strict` clean; wasm builds (web uses the trait default).

### Review
Cross-engine `/xreview` (Claude + Codex), with the captures as visual evidence — both confirmed the strobe exercises the feature. No Critical/High/Medium. Two Low fixes applied: matched the `f32` division-time arithmetic between step and redraw (invariant), and gated the ghost computation on the full ladder condition (no wasted dry-run under `--stereo`/`--composite-demo`).

### Deliberate first-cut scope (follow-ups)
All-at-once (no progressive accumulator), `--ghost` flag (no interactive pause-gating / scrubber wiring), desktop-native (web uses the no-op default), and `tts`-driven games project exactly — physics-*reading* games project approximately until the world-scoped host lands (documented in T6b). Input-log/chasm-demo is the other T6 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Visuals

**Before → after** (same `--fixed-time 2`): without `--ghost` each orbiting point-light marker is a single instant; with `--ghost` each strobes into a trail of ~8 faint copies across its next ~2s future (chronophotography), while static geometry stays solid.

![before/after — --ghost forward-ghosting](https://gist.githubusercontent.com/tommy-xr/0cf1ec3ca8249e6c7e84e05545af13f5/raw/t6d-beforeafter.png)

Sweeping the ghost forward in time (`--fixed-time` 1.0→3.4, all with `--ghost`) — the strobed trails orbit as time advances while the scene geometry holds still:

![forward-ghosting demo](https://gist.githubusercontent.com/tommy-xr/0cf1ec3ca8249e6c7e84e05545af13f5/raw/t6d-ghost.gif)

<sub>Rendered headlessly via `--capture-frame` / `--fixed-time` (deterministic, no screen recording).</sub>
