### PR TITLE
docs: de-stale functor-runner references (post-#243 single-binary)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ interpreted, F#-inspired game-logic language.
 You write your game as a `.mle` file. There is **no transpile or compile step for
 game logic** — the Rust runtime *interprets* the `.mle` directly:
 
-- **native** — the `functor-runner` desktop runtime (GLFW + OpenGL) loads and runs
-  your `.mle`, with hot-reloading on save for fast iteration.
+- **native** — the `functor` desktop runtime (GLFW + OpenGL), run in-process by the
+  `functor` CLI, loads and runs your `.mle`, with hot-reloading on save for fast iteration.
 - **wasm** — the web runtime (WebGL2) ships the `.mle` source as text and
   interprets it in the browser.
 
@@ -62,7 +62,7 @@ are documented in the `mle-language` skill (`.claude/skills/mle-language/`) and
 | --- | --- |
 | `mle/` | The MLE language crate — parser, IR, interpreter, typechecker (`mle parse`/`ir`/`run`/`trace`/`check`) |
 | `runtime/functor-runtime-common/` | Shared Rust runtime: rendering, assets, geometry, materials, the MLE prelude (`FunctorHost`) |
-| `runtime/functor-runtime-desktop/` | Desktop runtime; builds the `functor-runner` binary (native/GLFW), including the MLE producer |
+| `runtime/functor-runtime-desktop/` | Desktop runtime (native/GLFW), including the MLE producer — a library the `functor` CLI links in and runs in-process |
 | `runtime/functor-runtime-web/` | Web runtime (WebGL2); built into a wasm bundle, interprets the `.mle` in the browser |
 | `cli/` | The `functor` CLI (`build` / `run` / `develop`; `init` is not yet implemented) |
 | `tools/` | Editor tooling: `mle-vscode` (extension), `mle-lsp` (language server), `functor-sdk` (TS debug-runtime SDK) |
@@ -90,20 +90,18 @@ Build the CLI. **Order matters:** the CLI embeds the web runtime bundle at compi
 time (via `include_bytes!`), so the wasm bundle must exist before the `functor` binary is built.
 
 ```sh
-cargo build --bin functor-runner                            # desktop runtime
 wasm-pack build runtime/functor-runtime-web --target=web     # web bundle (embedded into the CLI)
-cargo build --bin functor                                   # the CLI itself
+cargo build --bin functor                                    # the CLI (embeds the desktop runtime)
 ```
 
-Or use the bundled convenience script, which runs all three in order:
+Or use the bundled convenience script, which runs both in order:
 
 ```sh
 npm run build:cli
 ```
 
-This produces two binaries in `target/debug/`: `functor` (the CLI) and `functor-runner`
-(the desktop runtime). The CLI looks for `functor-runner` next to itself, so keep them
-together.
+This produces a single binary in `target/debug/`: `functor` (the CLI, with the desktop
+runtime linked in as a library and run in-process — there is no separate `functor-runner`).
 
 ## Running a sample (`examples/hello`)
 
@@ -143,9 +141,9 @@ The `run` command interprets the game's `.mle` and launches it — no build step
 
 1. `build` loads the project (the entry `.mle` plus every sibling `.mle` — file = module)
    and typechecks the whole program; diagnostics are errors here.
-2. (native) `run` spawns `functor-runner --mle --game-path <entry>` from the game
-   directory; the runner **interprets** the `.mle` each frame and hot-reloads it on
-   save, preserving the model.
+2. (native) `run` runs the desktop runtime in-process on the entry `.mle` (no separate
+   process); it **interprets** the `.mle` each frame and hot-reloads it on save,
+   preserving the model.
 3. (wasm) `run` serves the project directory — the `.mle` ships as text; the embedded
    web runtime fetches and interprets it. (File-watch hot-reload is native-only;
    reload the page to pick up saved edits.)

--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -1,6 +1,7 @@
 # Debug runtime
 
-An optional HTTP control server on the desktop runtime (`functor-runner`) that lets
+An optional HTTP control server on the desktop runtime (run in-process by the `functor`
+CLI) that lets
 an external client — a script, a test, or an LLM — **observe** and **drive** a running
 game without a GPU window of its own. It is the runtime arm of Functor's LLM-native
 goal: capture frames, query state, control the frame clock, and inject input over a
@@ -9,13 +10,8 @@ localhost socket.
 Start it by passing `--debug-port <PORT>`:
 
 ```sh
-# via the CLI (runs the game — the runner interprets the .mle)
+# the CLI runs the game in-process and interprets the .mle
 ./target/debug/functor -d examples/hello run native --debug-port 8077
-
-# or the runner directly, against the .mle entry
-#   (cwd must be the game dir so assets resolve)
-cd examples/hello
-functor-runner --mle --game-path game.mle --debug-port 8077
 ```
 
 The server binds **localhost by default** (`127.0.0.1:<PORT>`); `--debug-bind 0.0.0.0`
@@ -31,7 +27,7 @@ without GLFW/OpenGL, so no display (or GPU) is needed. Ideal for CI, scripted ru
 and LLM-driven control:
 
 ```sh
-functor-runner --mle --game-path game.mle --debug-port 8077 --headless
+./target/debug/functor -d examples/hello run native --debug-port 8077 --headless
 ```
 
 `/`, `/state`, `/scene`, `/input`, and `/time` all work (the game's `draw`
@@ -54,7 +50,7 @@ work unchanged (audio too). `--capture-frame` implies `--hidden` — a scripted
 screenshot run has no reason to grab your mouse.
 
 ```sh
-functor-runner --mle --game-path game.mle --debug-port 8077 --hidden
+./target/debug/functor -d examples/hello run native --debug-port 8077 --hidden
 ```
 
 ## Endpoints

--- a/docs/mle.md
+++ b/docs/mle.md
@@ -58,7 +58,7 @@ The one real bet: **can a tree-walking interpreter run per-frame game logic at
 
 - Hand-rolled AST + minimal evaluator (no parser polish, no types, no effects)
   computing a `Scene3D`-shaped value each frame from a model + `FrameTime`,
-  embedded in `functor-runner` behind a flag.
+  embedded in the desktop runtime behind a flag.
 - Measure interpreted tick+draw cost for `hello`-scale logic (tens of entities).
 - Hot-reload: re-parse on file change, keep the model value, rebind functions;
   measure edit→visible latency.

--- a/docs/multiplayer.md
+++ b/docs/multiplayer.md
@@ -128,7 +128,7 @@ instances share a `VirtualTransport` bus in one process, stepped in lockstep. (A
 `mle::Session` is a plain owned value, so hosting a server + many clients in one
 process is natural — there is no per-process global runner to work around.)
 
-**B. Multi-process integration harness.** Real `functor-runner` processes driven
+**B. Multi-process integration harness.** Real `functor` game processes driven
 over an extended debug-server API (add `/net` inject + `/tick` step to the
 existing `/input`, `/time`, `/state`, `/scene`). Slower, less deterministic;
 validates the real I/O + serialization path. Smoke/integration only.

--- a/docs/physics.md
+++ b/docs/physics.md
@@ -102,7 +102,7 @@ Like rendering and audio, physics must be **drivable and observable headlessly**
         │  Timeline (trait)   — TimelineLog: keyframes(n) | snapshot_ring | replay_only │
         │  Simulatable (trait)— snapshot / restore / step  (Rapier serde)        │
         └───────────────────────────────────────────────────────────────────────┘
-            native: functor-runner            │   wasm: web-runtime bundle
+            native: functor (in-process)      │   wasm: web-runtime bundle
 ```
 
 - **`physicsScape` → `reconcile`** is `audio::reconcile` with a feedback edge:

--- a/docs/time-travel.md
+++ b/docs/time-travel.md
@@ -195,7 +195,7 @@ the overlay defaults to visible.
         │  egui scrubber overlay  ── drives ──►  TimelineControl      │
         │   (shell-owned; `~` toggle; default-on web/VSCode)          │
         └─────────────────────────────────────────────────────────────┘
-            native: functor-runner        │   wasm: web-runtime (= VSCode preview)
+            native: functor (in-process)  │   wasm: web-runtime (= VSCode preview)
 ```
 
 ## The determinism boundary

--- a/docs/vr.md
+++ b/docs/vr.md
@@ -22,7 +22,7 @@ games deploy over the network.
 ## Working today on the Xreal One
 
 ```sh
-functor-runner --mle --game-path examples/hello-cubes/game.mle --stereo-sbs --xreal-tracking
+functor -d examples/hello-cubes run native --stereo-sbs --xreal-tracking
 ```
 
 Glasses in 3D mode (OSD → Spatial Screen → 3D Mode → Full SBS), window

--- a/examples/hello-cubes/game.mle
+++ b/examples/hello-cubes/game.mle
@@ -1,7 +1,7 @@
 // hello-cubes — the first real-language Functor game (docs/mle.md Track C2).
 // A ring of gradient cubes orbits a pulsing sphere. Run with:
 //
-//   functor-runner --mle --game-path examples/hello-cubes/game.mle
+//   functor -d examples/hello-cubes run native
 //
 // The producer contract: `init` is the initial model value; `tick` steps it;
 // `draw` returns a Frame; `subscriptions` declares timers whose messages

--- a/examples/physics/game.mle
+++ b/examples/physics/game.mle
@@ -15,7 +15,6 @@
 // — a live replay; kick differently this time and the timeline branches.
 // Run with:
 //
-//   functor-runner --mle --game-path examples/physics/game.mle
 //   functor -d examples/physics run native
 //
 // The physics world lives host-side: edit this file while it runs and (as


### PR DESCRIPTION
## What

Post-#243 (`a4c96ac`, "merge functor-runner into a single `functor` binary"), the desktop runtime is a **library the `functor` CLI runs in-process** — there is no `functor-runner` binary anymore. ~20 docs/comments still referenced it, some with actively-wrong build/run instructions. This is a **docs/comments-only** sweep.

## Actively-wrong fixes (these misled a new user)

- **README.md** — dropped the dead `cargo build --bin functor-runner` build step; "two binaries `functor` + `functor-runner`" → a single `functor` binary with the desktop runtime linked in; "the CLI looks for `functor-runner` next to itself" removed; "(native) `run` spawns `functor-runner --mle --game-path <entry>`" → runs the runtime in-process.
- **examples/hello-cubes/game.mle**, **examples/physics/game.mle** header comments — `functor-runner --mle --game-path examples/X/game.mle` → `functor -d examples/X run native`.
- **docs/debug-runtime.md** — the `--debug-port` / `--headless` / `--hidden` examples rewritten to the real forwarded `functor -d examples/hello run native ...` form.

## Judgment-call touch-ups (minimal, label-only)

- **docs/mle.md**, **docs/physics.md** + **docs/time-travel.md** (ASCII diagram labels), **docs/multiplayer.md** — "native: functor-runner" → the single in-process `functor` runtime. Diagram `│` alignment preserved.
- **docs/vr.md** — the runnable `--stereo-sbs --xreal-tracking` command updated to the `functor -d … run native` form. The **historical PR-#175 changelog row** ("…stereo in functor-runner…") is **left as-is** — it was accurate when #175 merged.

## Verified to run (against the post-#243 `functor` binary)

- `functor -d examples/primitives build` — ok
- `functor -d examples/primitives run native --capture-frame … --fixed-time 2 --capture-time 1` — wrote the PNG
- `functor -d examples/hello run native --debug-port 8077 --headless` — debug server listened; `GET /state` returned live frame data
- `functor -d examples/hello run native --stereo-sbs --capture-frame …` — rendered a side-by-side capture (flag still forwards)

## Intentionally-kept `functor-runner` strings

- `README.md` — "…there is no separate `functor-runner`" (accurate, by design)
- `docs/vr.md:15` — the historical PR-#175 changelog entry

Grep afterward (`git grep -n functor-runner -- README.md docs examples`) shows only those two. `git diff --stat` is `.md` + `.mle` only — no code touched. Reviewed cross-engine (Claude + Codex): no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)