### PR TITLE
feat(cli): output event stream + JSON renderer (UX pass PR-1/3)

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 mle = { path = "../mle" }
 clap = { version = "4.5.6", features = ["derive"] }
 colored = "2.1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.117"
 tokio = { version = "1", features = ["full"] }
 warp = "0.3.7"

--- a/cli/src/commands/mle_project.rs
+++ b/cli/src/commands/mle_project.rs
@@ -66,7 +66,22 @@ impl MleProject {
     pub fn build(&self, working_directory: &str) -> Result<(), Error> {
         let path = self.entry_path(working_directory)?;
         let display = path.display().to_string();
-        let project = mle::project::load(&path).map_err(|e| Error::other(e.render()))?;
+        // A load failure (parse error, bad module name, cycle) is a positioned
+        // diagnostic too — surface its file:line:col structurally, like a check
+        // error, rather than flattening it into the final text-only error.
+        let project = match mle::project::load(&path) {
+            Ok(project) => project,
+            Err(e) => {
+                emit(Event::Diagnostic {
+                    severity: Severity::Error,
+                    file: Some(e.path.display().to_string()),
+                    line: Some(e.line),
+                    col: Some(e.col),
+                    message: e.message.clone(),
+                });
+                return Err(Error::other(format!("cannot load the {display} project")));
+            }
+        };
         let diags = project.check();
         for diag in &diags {
             let (file, line, col) = project.sources.resolve(diag.span.start);

--- a/cli/src/commands/mle_project.rs
+++ b/cli/src/commands/mle_project.rs
@@ -7,7 +7,7 @@
 //!   dev loop stays permissive; the build command is where they block).
 //! - `run` drives the desktop runtime's run loop IN-PROCESS on the entry file
 //!   (cwd = the game dir, so asset paths resolve as usual) — post-E3 there is a
-//!   single `functor` binary, no separate `functor-runner` child.
+//!   single `functor` binary, no separate runner child process.
 //! - `develop` is `run`: the MLE producer hot-reloads on save by itself — no
 //!   watchexec loop, no rebuild. State is preserved across edits.
 //! - `run wasm` serves the project with the MLE index page (docs/mle.md C5):
@@ -20,6 +20,7 @@ use std::path::{Path, PathBuf};
 
 use clap::Parser;
 
+use crate::output::{emit, Event, Severity};
 use crate::util::{self, ShellCommand, WasmDevServer};
 use crate::Environment;
 
@@ -68,16 +69,29 @@ impl MleProject {
         let project = mle::project::load(&path).map_err(|e| Error::other(e.render()))?;
         let diags = project.check();
         for diag in &diags {
-            let rendered = project.sources.render(diag.span.start, &diag.message);
-            eprintln!("error: {rendered}");
+            let (file, line, col) = project.sources.resolve(diag.span.start);
+            emit(Event::Diagnostic {
+                severity: Severity::Error,
+                file: Some(file.path.display().to_string()),
+                line: Some(line),
+                col: Some(col),
+                message: diag.message.clone(),
+            });
         }
         if diags.is_empty() {
-            let modules = project.sources.files().len();
-            let and_siblings = match modules {
-                1 => String::new(),
-                n => format!(" (+ {} sibling module(s))", n - 1),
-            };
-            println!("[mle] {display}{and_siblings}: ok");
+            // The user's own sibling `.mle` files: exclude the entry and the
+            // prelude-injected builtin (`<builtin>/Net.mle`).
+            let sibling_count = project
+                .sources
+                .files()
+                .iter()
+                .filter(|f| !f.path.starts_with("<builtin>"))
+                .count()
+                .saturating_sub(1);
+            emit(Event::MleLoaded {
+                entry: self.entry.clone(),
+                sibling_count,
+            });
             Ok(())
         } else {
             Err(Error::other(format!(
@@ -101,14 +115,16 @@ impl MleProject {
         }
         self.entry_path(working_directory)?; // existence validated up front
         if develop {
-            println!(
-                "[mle] develop: hot reload is built in — edit {} and save",
-                self.entry
-            );
+            emit(Event::Info {
+                message: format!(
+                    "develop: hot reload is built in — edit {} and save",
+                    self.entry
+                ),
+            });
         }
 
         // Post-E3 there is one binary: drive the desktop runtime's run loop
-        // IN-PROCESS instead of spawning a `functor-runner` child. GLFW/Cocoa
+        // IN-PROCESS instead of spawning a separate runner child. GLFW/Cocoa
         // needs the main thread, and `run` blocks on the game loop; the CLI's
         // `#[tokio::main]` drives this future on the main thread (block_on), so
         // the call lands on the main thread and inside a tokio runtime context
@@ -159,17 +175,19 @@ with --debug-port (and --debug-bind 0.0.0.0 if remote)?"
                 ))
             })? {
                 (200, body) => {
-                    println!("[mle] {body}");
+                    emit(Event::Info { message: body });
                     Ok(())
                 }
                 (status, body) => Err(Error::other(format!("push rejected ({status}): {body}"))),
             };
         }
 
-        println!(
-            "[mle] watching {} — pushing to http://{addr}/reload-source on save (Ctrl-C to stop)",
-            self.entry
-        );
+        emit(Event::Info {
+            message: format!(
+                "watching {} — pushing to http://{addr}/reload-source on save (Ctrl-C to stop)",
+                self.entry
+            ),
+        });
         // Track the last content ATTEMPTED, not the file mtime: coarse-mtime
         // filesystems can miss rapid saves, and atomic-save editors briefly
         // unlink the file mid-save (a failed read here just waits for the
@@ -181,16 +199,20 @@ with --debug-port (and --debug-bind 0.0.0.0 if remote)?"
                 if attempted.as_deref() != Some(src.as_str()) {
                     match post_reload_source(addr, &src) {
                         Ok((200, body)) => {
-                            println!("[mle] {body}");
+                            emit(Event::Info { message: body });
                             attempted = Some(src);
                         }
                         Ok((status, body)) => {
-                            eprintln!("[mle] push rejected ({status}): {body}");
+                            emit(Event::Warning {
+                                message: format!("push rejected ({status}): {body}"),
+                            });
                             attempted = Some(src);
                         }
                         // Transport failure: leave `attempted` unset so the
                         // same content retries on the next poll.
-                        Err(e) => eprintln!("[mle] push failed ({e}); retrying…"),
+                        Err(e) => emit(Event::Warning {
+                            message: format!("push failed ({e}); retrying…"),
+                        }),
                     }
                 }
             }
@@ -222,7 +244,9 @@ relative path inside it (got {})",
             )));
         }
         if develop {
-            println!("[mle] develop (wasm): hot reload is native-only — reload the page to pick up edits");
+            emit(Event::Info {
+                message: "develop (wasm): hot reload is native-only — reload the page to pick up edits".to_string(),
+            });
         }
         let no_open = runner_args.iter().any(|a| a == "--no-open");
         let ignored: Vec<&str> = runner_args
@@ -231,17 +255,19 @@ relative path inside it (got {})",
             .map(|s| s.as_str())
             .collect();
         if !ignored.is_empty() {
-            eprintln!(
-                "warning: ignoring runner args (not supported for wasm): {}",
-                ignored.join(" ")
-            );
+            emit(Event::Warning {
+                message: format!(
+                    "ignoring runner args (not supported for wasm): {}",
+                    ignored.join(" ")
+                ),
+            });
         }
 
         let wasm_server_start = WasmDevServer::start_mle(working_directory, &self.entry);
         if no_open {
-            println!(
-                "[Functor] wasm server at http://127.0.0.1:8080 (--no-open: skipping browser)"
-            );
+            emit(Event::Info {
+                message: "--no-open: skipping browser launch".to_string(),
+            });
         } else {
             let cmd = if std::env::consts::OS == "windows" {
                 "start"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,17 +1,38 @@
 use clap::{Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
+use std::time::Instant;
 use std::{env, io, process};
 
 mod commands;
+mod output;
 
 pub mod util;
 
+use output::{emit, Event};
+
+/// Functor — a functional toolkit for building 3D games in MLE.
+///
+/// Operates on a project directory (a `functor.json` with
+/// `"language": "mle"`). Add `--json` to any command for a newline-delimited
+/// JSON event stream instead of human text (see `docs/cli-output.md`).
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
-    /// Directory to override the current working directory
-    #[arg(short, long)]
+    /// Project directory (defaults to the current working directory).
+    #[arg(short, long, global = true)]
     dir: Option<PathBuf>,
+
+    /// Emit newline-delimited JSON (one event per line) instead of human text.
+    #[arg(long, global = true)]
+    json: bool,
+
+    /// Print only errors and the final status.
+    #[arg(long, global = true)]
+    quiet: bool,
+
+    /// Disable ANSI color even on an interactive terminal.
+    #[arg(long, global = true)]
+    no_color: bool,
 
     #[command(subcommand)]
     command: Command,
@@ -27,35 +48,50 @@ impl Environment {
     fn default(maybe_env: &Option<Environment>) -> Environment {
         maybe_env.clone().unwrap_or(Environment::Native)
     }
+
+    fn as_str(&self) -> &'static str {
+        match self {
+            Environment::Wasm => "wasm",
+            Environment::Native => "native",
+        }
+    }
 }
 
 #[derive(Subcommand, Debug)]
 enum Command {
+    /// Scaffold a new project from a template (not yet implemented).
     Init {
         #[arg()]
         template: String,
     },
+    /// Typecheck the MLE project (the strict build gate — diagnostics are
+    /// errors). Target-independent. E.g. `functor -d examples/primitives build`.
     Build {
         #[arg(value_enum)]
         environment: Option<Environment>,
     },
+    /// Run the game (default `native`, an OpenGL window; `wasm` serves a dev
+    /// server). E.g. `functor -d examples/primitives run native`.
     Run {
         #[arg(value_enum)]
         environment: Option<Environment>,
 
-        /// Extra arguments forwarded to functor-runner (native only). E.g.
-        /// `run native --fixed-time 2 --capture-frame f.png`. A leading `--` is
-        /// also accepted. On wasm these are ignored except `--no-open`, which
-        /// keeps the dev server but skips launching the browser.
+        /// Extra arguments forwarded to the in-process desktop runtime (native
+        /// only). E.g. `run native --fixed-time 2 --capture-frame f.png`. A
+        /// leading `--` is also accepted. On wasm these are ignored except
+        /// `--no-open`, which keeps the dev server but skips launching the browser.
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         runner_args: Vec<String>,
     },
+    /// Run with hot-reload (same as `run`; MLE reloads on save). E.g.
+    /// `functor -d examples/lighting develop native`.
     Develop {
         #[arg(value_enum)]
         environment: Option<Environment>,
 
-        /// Extra arguments forwarded to functor-runner (native only). E.g.
-        /// `develop native --debug-port 8077`. A leading `--` is also accepted.
+        /// Extra arguments forwarded to the in-process desktop runtime (native
+        /// only). E.g. `develop native --debug-port 8077`. A leading `--` is
+        /// also accepted.
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         runner_args: Vec<String>,
     },
@@ -64,12 +100,12 @@ enum Command {
         #[command(subcommand)]
         target: InspectTarget,
     },
-    /// Push the game's MLE source to a running functor-runner over the
-    /// network (POST /reload-source on its debug server) — the remote develop
-    /// loop. The runner can be on another machine or device; reloads preserve
-    /// the model. MLE projects only.
+    /// Push the game's MLE source to a running runtime over the network
+    /// (POST /reload-source on its debug server) — the remote develop loop.
+    /// The runtime can be on another machine or device; reloads preserve the
+    /// model. MLE projects only.
     Push {
-        /// The runner's debug server, host:port. Start the runner with
+        /// The runtime's debug server, host:port. Start it with
         /// `--debug-port <PORT>` (plus `--debug-bind 0.0.0.0` when remote).
         addr: String,
 
@@ -111,10 +147,15 @@ enum InspectTarget {
 // `functor_runtime_desktop::run`.
 #[tokio::main]
 async fn main() -> tokio::io::Result<()> {
+    let started = Instant::now();
     let args = Args::parse();
 
-    // `inspect` operates on an arbitrary asset path and does not need a game
-    // project, so handle it before the functor.json validation below.
+    output::init(args.json, args.quiet, args.no_color);
+
+    // `inspect` is a DATA command: it prints a report (its own `--format
+    // text|json` is its dual mode) to stdout, so it bypasses the event stream
+    // to keep that stdout payload pure. It also runs before functor.json
+    // validation, since it operates on an arbitrary asset path.
     if let Command::Inspect { target } = &args.command {
         let res = match target {
             InspectTarget::Model {
@@ -132,23 +173,33 @@ async fn main() -> tokio::io::Result<()> {
                 .await
             }
         };
-        return finish(res);
+        return finish_inspect(res);
     }
 
-    let working_directory = get_working_directory(&args);
-    // Validates functor.json exists (exits the process if not); the path itself
-    // is unused by the MLE-only dispatch below.
-    validate_metadata_path(&working_directory);
+    finish(run(&args).await, started)
+}
 
-    let working_directory_os_str = working_directory.into_os_string();
-    let working_directory_str = working_directory_os_str.into_string().unwrap();
+/// Emit `CommandStarted`, validate the project, dispatch, and return the
+/// command's result. All user-facing output flows through [`emit`].
+async fn run(args: &Args) -> io::Result<()> {
+    let working_directory = get_working_directory(args);
+    let working_directory_str = working_directory
+        .clone()
+        .into_os_string()
+        .into_string()
+        .map_err(|_| io::Error::other("project directory path is not valid UTF-8"))?;
 
-    println!("Running command: {:?}", args.command);
+    emit(Event::CommandStarted {
+        command: command_name(&args.command).to_string(),
+        project: Some(working_directory_str.clone()),
+        env: command_env(&args.command),
+    });
+
+    validate_metadata_path(&working_directory)?;
 
     // An MLE project (functor.json: `"language": "mle"`) routes build/run/
     // develop/push to the interpreter — no Fable, no cargo, hot reload built
-    // in. Only those are language-routed; anything else (Init, and Inspect
-    // handled earlier) falls through to the normal dispatch.
+    // in. Only those are language-routed; Init falls through below.
     let is_routed = matches!(
         &args.command,
         Command::Build { .. }
@@ -156,10 +207,10 @@ async fn main() -> tokio::io::Result<()> {
             | Command::Develop { .. }
             | Command::Push { .. }
     );
-    if let Some(project) = commands::mle_project::detect(&working_directory_str)
-        .filter(|_| is_routed)
+    if let Some(project) =
+        commands::mle_project::detect(&working_directory_str).filter(|_| is_routed)
     {
-        let res = match &args.command {
+        return match &args.command {
             Command::Init { .. } | Command::Inspect { .. } => unreachable!("is_routed excludes"),
             // `build` is target-independent for MLE: the strict typecheck
             // gate is the whole build — nothing compiles for either target
@@ -197,16 +248,16 @@ async fn main() -> tokio::io::Result<()> {
                 project.push(&working_directory_str, addr, *watch).await
             }
         };
-        return finish(res);
     }
 
-    let res = match &args.command {
+    match &args.command {
         Command::Init { template } => {
-            // TODO: Handle init
-            println!(
-                "TODO: Initialize with template '{}' in directory: {}",
-                template, &working_directory_str,
-            );
+            // TODO: Handle init (currently a stub — see docs/todo.md).
+            emit(Event::Info {
+                message: format!(
+                    "init is not yet implemented (template '{template}', directory {working_directory_str})"
+                ),
+            });
             Ok(())
         }
         // The F#/Fable pipeline was removed in E3: every Functor project is now
@@ -223,48 +274,81 @@ async fn main() -> tokio::io::Result<()> {
         )),
         // Handled earlier (before functor.json validation).
         Command::Inspect { .. } => unreachable!(),
-    };
-
-    finish(res)
+    }
 }
 
-fn finish(res: io::Result<()>) -> tokio::io::Result<()> {
+fn command_name(command: &Command) -> &'static str {
+    match command {
+        Command::Init { .. } => "init",
+        Command::Build { .. } => "build",
+        Command::Run { .. } => "run",
+        Command::Develop { .. } => "develop",
+        Command::Inspect { .. } => "inspect",
+        Command::Push { .. } => "push",
+    }
+}
+
+fn command_env(command: &Command) -> Option<String> {
+    match command {
+        Command::Run { environment, .. } | Command::Develop { environment, .. } => {
+            Some(Environment::default(environment).as_str().to_string())
+        }
+        _ => None,
+    }
+}
+
+/// Terminal handler for the routed commands: emit the final status through the
+/// event stream, and exit non-zero on error.
+fn finish(res: io::Result<()>, started: Instant) -> tokio::io::Result<()> {
+    let duration_ms = started.elapsed().as_millis() as u64;
     match res {
         Ok(()) => {
-            // Status goes to stderr so stdout stays pure data (e.g. JSON from
-            // `inspect ... --format json` is directly pipeable).
-            eprintln!("Done");
+            emit(Event::CommandFinished {
+                ok: true,
+                duration_ms,
+            });
             Ok(())
         }
         Err(error) => {
-            eprintln!("Failed: {}", error);
+            emit(Event::Error {
+                message: error.to_string(),
+                hint: None,
+            });
+            emit(Event::CommandFinished {
+                ok: false,
+                duration_ms,
+            });
             process::exit(1);
         }
     }
 }
 
-fn validate_metadata_path(working_directory: &PathBuf) -> PathBuf {
-    let functor_path = working_directory.join("functor.json");
-
-    if functor_path.exists() {
-        println!("Found functor.json at {}", functor_path.display());
-        // Optional: Read and parse the JSON file
-        // let content = fs::read_to_string(&functor_path).expect("Failed to read functor.json");
-        // let json: serde_json::Value = serde_json::from_str(&content).expect("Failed to parse functor.json");
-        // println!("Content of functor.json: {}", json);
-    } else {
-        eprintln!("functor.json not found in {}", working_directory.display());
-        process::exit(1);
+/// Terminal handler for `inspect` — a data command that owns stdout with its
+/// report, so it stays off the event stream. Errors go to stderr.
+fn finish_inspect(res: io::Result<()>) -> tokio::io::Result<()> {
+    match res {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            eprintln!("error: {error}");
+            process::exit(1);
+        }
     }
+}
 
-    functor_path
+/// Validate that the project directory has a `functor.json`.
+fn validate_metadata_path(working_directory: &PathBuf) -> io::Result<()> {
+    if working_directory.join("functor.json").exists() {
+        Ok(())
+    } else {
+        Err(io::Error::other(format!(
+            "functor.json not found in {}",
+            working_directory.display()
+        )))
+    }
 }
 
 fn get_working_directory(args: &Args) -> PathBuf {
-    let dir = args
-        .dir
+    args.dir
         .clone()
-        .unwrap_or_else(|| env::current_dir().expect("Failed to get current directory"));
-    println!("Hello from directory: {}", dir.display());
-    dir
+        .unwrap_or_else(|| env::current_dir().expect("Failed to get current directory"))
 }

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1,0 +1,232 @@
+//! The CLI's output event stream — one source of truth, two renderers.
+//!
+//! Command logic emits typed [`Event`]s via [`emit`]; a single [`Renderer`],
+//! selected once at startup ([`init`]), turns them into human text
+//! ([`PlainRenderer`]) or newline-delimited JSON ([`JsonRenderer`]). Command
+//! code never formats user-facing strings itself. See `docs/cli-output.md` for
+//! the schema and the renderer-selection rule.
+
+use std::io::{IsTerminal, Write};
+use std::sync::OnceLock;
+
+use colored::Colorize;
+use serde::Serialize;
+
+/// Diagnostic severity (an MLE check error is `Error`; `Warning` is reserved
+/// for the runtime's permissive dev-loop diagnostics routed later).
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Severity {
+    Error,
+    // Reserved: the runtime's permissive dev-loop diagnostics route here in PR-2.
+    #[allow(dead_code)]
+    Warning,
+}
+
+/// A user-visible thing the CLI wants to say. Serialized as
+/// `{"type": "<snake_case>", …}` — the stable machine API (see
+/// `docs/cli-output.md`). Only the PR-1 (CLI-side) variants live here; the
+/// runtime-side ones (frame stats, capture, hot-reload, asset errors) land in
+/// PR-2 with the runtime event-sink refactor.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Event {
+    /// A command began.
+    CommandStarted {
+        command: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        project: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        env: Option<String>,
+    },
+    /// A command ended (also the exit-code carrier for machine consumers).
+    CommandFinished { ok: bool, duration_ms: u64 },
+    /// A `build` typecheck passed (`entry` plus `sibling_count` sibling modules).
+    MleLoaded { entry: String, sibling_count: usize },
+    /// An MLE check / load error, positioned in its file.
+    Diagnostic {
+        severity: Severity,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        file: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        line: Option<usize>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        col: Option<usize>,
+        message: String,
+    },
+    /// The wasm dev server bound and is serving.
+    ServerListening { url: String },
+    /// Neutral status (a hot-reload hint, a push acknowledgement, …).
+    Info { message: String },
+    /// A non-fatal issue.
+    Warning { message: String },
+    /// A fatal error, emitted just before the process exits non-zero.
+    Error {
+        message: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        hint: Option<String>,
+    },
+}
+
+impl Event {
+    /// Whether `--quiet` keeps this event (errors + final status only).
+    fn is_essential(&self) -> bool {
+        matches!(
+            self,
+            Event::Error { .. } | Event::Diagnostic { .. } | Event::CommandFinished { .. }
+        )
+    }
+}
+
+/// One source of truth, two presentations.
+pub trait Renderer: Send + Sync {
+    fn render(&self, event: &Event);
+}
+
+/// ndjson: one compact JSON object per line, flushed. No color, ever.
+pub struct JsonRenderer;
+
+impl Renderer for JsonRenderer {
+    fn render(&self, event: &Event) {
+        let mut out = std::io::stdout().lock();
+        if serde_json::to_writer(&mut out, event).is_ok() {
+            let _ = out.write_all(b"\n");
+            let _ = out.flush();
+        }
+    }
+}
+
+/// Human-readable text. Color is governed globally by
+/// `colored::control::set_override` (set in [`init`]), so this renders plain
+/// on a pipe / `NO_COLOR` / `--no-color` with no ANSI leakage. No spinners or
+/// animation yet — that's the PR-2 ink-style renderer.
+pub struct PlainRenderer {
+    pub quiet: bool,
+}
+
+impl Renderer for PlainRenderer {
+    fn render(&self, event: &Event) {
+        if self.quiet && !event.is_essential() {
+            return;
+        }
+        for line in Self::lines(event) {
+            println!("{line}");
+        }
+    }
+}
+
+impl PlainRenderer {
+    fn lines(event: &Event) -> Vec<String> {
+        match event {
+            Event::CommandStarted {
+                command,
+                project,
+                env,
+            } => {
+                let mut s = format!("{} {}", "▸".cyan(), command.bold());
+                if let Some(project) = project {
+                    s.push_str(&format!(" {}", project.dimmed()));
+                }
+                if let Some(env) = env {
+                    s.push_str(&format!(" {}", format!("({env})").dimmed()));
+                }
+                vec![s]
+            }
+            Event::CommandFinished { ok, duration_ms } => {
+                let dur = format_duration(*duration_ms).dimmed();
+                if *ok {
+                    vec![format!("{} done {}", "✓".green(), dur)]
+                } else {
+                    vec![format!("{} failed {}", "✗".red(), dur)]
+                }
+            }
+            Event::MleLoaded {
+                entry,
+                sibling_count,
+            } => {
+                let siblings = match sibling_count {
+                    0 => String::new(),
+                    1 => " (+1 module)".to_string(),
+                    n => format!(" (+{n} modules)"),
+                };
+                vec![format!(
+                    "{} checked {}{}",
+                    "✓".green(),
+                    entry,
+                    siblings.dimmed()
+                )]
+            }
+            Event::Diagnostic {
+                severity,
+                file,
+                line,
+                col,
+                message,
+            } => {
+                let label = match severity {
+                    Severity::Error => "error".red().bold(),
+                    Severity::Warning => "warning".yellow().bold(),
+                };
+                let loc = match (file, line, col) {
+                    (Some(f), Some(l), Some(c)) => format!("{f}:{l}:{c}: "),
+                    (Some(f), _, _) => format!("{f}: "),
+                    _ => String::new(),
+                };
+                vec![format!("{label}: {}{message}", loc.dimmed())]
+            }
+            Event::ServerListening { url } => {
+                vec![format!("{} serving {}", "◈".cyan(), url.underline())]
+            }
+            Event::Info { message } => vec![message.clone()],
+            Event::Warning { message } => {
+                vec![format!("{}: {message}", "warning".yellow().bold())]
+            }
+            Event::Error { message, hint } => {
+                let mut out = vec![format!("{}: {message}", "error".red().bold())];
+                if let Some(hint) = hint {
+                    out.push(format!("{}: {hint}", "hint".cyan().bold()));
+                }
+                out
+            }
+        }
+    }
+}
+
+fn format_duration(ms: u64) -> String {
+    if ms < 1000 {
+        format!("in {ms}ms")
+    } else {
+        format!("in {:.1}s", ms as f64 / 1000.0)
+    }
+}
+
+static RENDERER: OnceLock<Box<dyn Renderer>> = OnceLock::new();
+
+/// Select and install the process-wide renderer from the global flags +
+/// environment. Called once at startup, before any command logic runs. See
+/// `docs/cli-output.md` for the selection table.
+pub fn init(json: bool, quiet: bool, no_color: bool) {
+    // Color only on a real TTY, and never under NO_COLOR / --no-color / CI /
+    // --json. Enforced globally so no code path can leak ANSI.
+    let color = !json
+        && std::io::stdout().is_terminal()
+        && std::env::var_os("NO_COLOR").is_none()
+        && std::env::var_os("CI").is_none()
+        && !no_color;
+    colored::control::set_override(color);
+
+    let renderer: Box<dyn Renderer> = if json {
+        Box::new(JsonRenderer)
+    } else {
+        Box::new(PlainRenderer { quiet })
+    };
+    let _ = RENDERER.set(renderer);
+}
+
+/// Emit an event to the installed renderer. A no-op if [`init`] was never
+/// called (defensive — main always calls it first).
+pub fn emit(event: Event) {
+    if let Some(renderer) = RENDERER.get() {
+        renderer.render(&event);
+    }
+}

--- a/cli/src/util/shell_command.rs
+++ b/cli/src/util/shell_command.rs
@@ -1,9 +1,10 @@
-use colored::*;
 use std::io::{self, Error};
 use std::path::Path;
 use std::process::Stdio;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command as TokioCommand;
+
+use crate::output::{emit, Event};
 
 pub struct ShellCommand<'a> {
     pub prefix: &'a str,
@@ -16,9 +17,7 @@ pub struct ShellCommand<'a> {
 impl<'A> ShellCommand<'A> {
     pub async fn run_sequential(commands: Vec<ShellCommand<'A>>) -> Result<(), Error> {
         for command_spec in commands {
-            println!("Using working dir: {}", &command_spec.cwd);
             let mut command = TokioCommand::new(&command_spec.cmd);
-            println!("-- Running command: {}", &command_spec.cmd);
 
             // Set environment variables if any
             for (key, value) in command_spec.env {
@@ -47,12 +46,8 @@ impl<'A> ShellCommand<'A> {
             let status = child.wait().await?;
             if !status.success() {
                 let detail = describe_exit(&status);
-                eprintln!(
-                    "{}: {} {}",
-                    command_spec.prefix.red(),
-                    command_spec.cmd,
-                    detail
-                );
+                // The error bubbles to the CLI's terminal handler, which emits
+                // it as an `Error` event — no direct print here.
                 return Err(Error::new(
                     io::ErrorKind::Other,
                     format!("{} {}", command_spec.cmd, detail),
@@ -65,9 +60,7 @@ impl<'A> ShellCommand<'A> {
     pub async fn run_parallel(commands: Vec<ShellCommand<'A>>) -> Result<(), Error> {
         let mut handles = vec![];
         for command_spec in commands {
-            println!("Using working dir: {}", &command_spec.cwd);
             let mut command = TokioCommand::new(&command_spec.cmd);
-            println!("-- Running command: {}", &command_spec.cmd);
 
             // Set environment variables if any
             for (key, value) in command_spec.env {
@@ -129,12 +122,11 @@ async fn handle_output(prefix: String, stream: impl tokio::io::AsyncRead + Unpin
     let mut reader = BufReader::new(stream).lines();
 
     while let Some(line) = reader.next_line().await.unwrap_or(None) {
-        let colored_prefix = if is_stdout {
-            prefix.blue()
+        let message = format!("{prefix} {line}");
+        if is_stdout {
+            emit(Event::Info { message });
         } else {
-            prefix.red()
-        };
-
-        println!("{}: {}", colored_prefix, line);
+            emit(Event::Warning { message });
+        }
     }
 }

--- a/cli/src/util/wasm_dev_server.rs
+++ b/cli/src/util/wasm_dev_server.rs
@@ -68,10 +68,18 @@ impl WasmDevServer {
         let static_routes = route_index.or(route_js1).or(route_wasm);
         let routes = static_routes.or(route_filesystem);
 
+        // Bind first, then announce — so `ServerListening` never claims a port
+        // that isn't actually accepting connections, and a bind failure (port
+        // in use) surfaces as an error event instead of a panic.
+        let (addr, server) = warp::serve(routes)
+            .try_bind_ephemeral(([127, 0, 0, 1], 8080))
+            .map_err(|e| {
+                io::Error::other(format!("cannot bind dev server to 127.0.0.1:8080: {e}"))
+            })?;
         crate::output::emit(crate::output::Event::ServerListening {
-            url: "http://127.0.0.1:8080".to_string(),
+            url: format!("http://{addr}"),
         });
-        warp::serve(routes).run(([127, 0, 0, 1], 8080)).await;
+        server.await;
         Ok(())
     }
 }

--- a/cli/src/util/wasm_dev_server.rs
+++ b/cli/src/util/wasm_dev_server.rs
@@ -37,8 +37,6 @@ impl WasmDevServer {
     async fn serve(working_directory: &str, index_html: Vec<u8>) -> Result<(), io::Error> {
         let wd = working_directory.to_owned();
 
-        println!("Starting dev server in: {}", wd);
-
         // Define routes for each file
         let route_index = warp::path::end()
             .map(move || {
@@ -70,6 +68,9 @@ impl WasmDevServer {
         let static_routes = route_index.or(route_js1).or(route_wasm);
         let routes = static_routes.or(route_filesystem);
 
+        crate::output::emit(crate::output::Event::ServerListening {
+            url: "http://127.0.0.1:8080".to_string(),
+        });
         warp::serve(routes).run(([127, 0, 0, 1], 8080)).await;
         Ok(())
     }

--- a/docs/cli-output.md
+++ b/docs/cli-output.md
@@ -46,7 +46,9 @@ not passed and `CI` is unset. `--json` never colors. This is enforced globally v
 **Confirmed defaults:** non-TTY (piped/redirected) → **plain text**, *not* ndjson. `--json`
 is the explicit opt-in to ndjson. TTY detection uses `std::io::IsTerminal` (std, no dep).
 
-Flags are **global** (accepted before the subcommand): `--json`, `--quiet`, `--no-color`.
+Flags are **global** (accepted before or after the subcommand): `--json`, `--quiet`,
+`--no-color`. `--json` takes precedence: under `--json`, `--quiet` is a no-op (the full
+event stream is emitted — machine consumers filter it themselves).
 
 ## The `Event` schema (stable API)
 

--- a/docs/cli-output.md
+++ b/docs/cli-output.md
@@ -1,0 +1,127 @@
+# CLI output — the event stream
+
+The `functor` CLI speaks **two languages from one source of truth**. Command logic
+(`build`/`run`/`develop`/`push`/`init`) never formats user-facing strings itself — it
+**emits typed [`Event`](../cli/src/output.rs)s**, and a single renderer, selected once at
+startup, turns that stream into either human-readable text or newline-delimited JSON
+(ndjson). This is design principle #2 (LLM-native): anything a human sees, an agent can get
+as structured data.
+
+```
+command logic ──emit(Event)──▶ ┌─ PlainRenderer  (human text; color on a TTY)
+                               └─ JsonRenderer   (ndjson: one {type,…} object per line)
+```
+
+If you find yourself formatting the same fact in two places, the design is wrong: add or
+extend an `Event` and let the renderers present it.
+
+This is **PR-1 of a 3-PR pass**. See "What PR-1 does *not* do" at the bottom.
+
+## Where the stream goes
+
+The event stream (both renderers) writes to **stdout**, one fd, one stream. An agent drives
+`functor build --json` and parses stdout line by line. The process **exit code** still
+signals success/failure (0 / 1); the stream is advisory.
+
+`inspect` is the **one exception**: it is a *data* command, not a status command. Its report
+is the payload and it already has its own dual mode (`--format text|json`), so it writes its
+report to stdout directly and does **not** emit lifecycle events (which would pollute the
+report JSON). `inspect` errors go to stderr. Everything else flows through the event stream.
+
+## Renderer selection
+
+Selected once at startup from flags + environment:
+
+| Condition (first match wins)        | Renderer / mode                          | Color |
+| ----------------------------------- | ---------------------------------------- | ----- |
+| `--json`                            | `JsonRenderer` — ndjson                   | never |
+| `--quiet`                           | `PlainRenderer`, minimal (errors + final status only) | per rule below |
+| stdout **not a TTY**, or `CI` set   | `PlainRenderer` — **plain text** (no ANSI) | off   |
+| interactive TTY (default)           | `PlainRenderer` — human text              | on    |
+
+Color is enabled only when **stdout is a TTY** and `NO_COLOR` is unset and `--no-color` is
+not passed and `CI` is unset. `--json` never colors. This is enforced globally via
+`colored::control::set_override`, so a dumb terminal / pipe / `NO_COLOR` never leaks ANSI.
+
+**Confirmed defaults:** non-TTY (piped/redirected) → **plain text**, *not* ndjson. `--json`
+is the explicit opt-in to ndjson. TTY detection uses `std::io::IsTerminal` (std, no dep).
+
+Flags are **global** (accepted before the subcommand): `--json`, `--quiet`, `--no-color`.
+
+## The `Event` schema (stable API)
+
+Serialized with serde as `{"type": "<snake_case>", …fields}`. Optional fields are omitted
+when absent (`skip_serializing_if`). Every line of `--json` output is one of these objects.
+
+### Implemented in PR-1 (CLI-side)
+
+| `type`             | Fields                                                        | Emitted when |
+| ------------------ | ------------------------------------------------------------ | ------------ |
+| `command_started`  | `command` (string), `project` (string?), `env` (string?)     | a command begins |
+| `command_finished` | `ok` (bool), `duration_ms` (number)                          | a command ends |
+| `mle_loaded`       | `entry` (string), `sibling_count` (number)                   | `build` typecheck passes |
+| `diagnostic`       | `severity` (`"error"`\|`"warning"`), `file` (string?), `line` (number?), `col` (number?), `message` (string) | an MLE check / load error |
+| `server_listening` | `url` (string)                                               | the wasm dev server binds |
+| `info`             | `message` (string)                                           | neutral status (e.g. hot-reload hint, a push ack) |
+| `warning`          | `message` (string)                                           | non-fatal issue (e.g. ignored wasm runner args) |
+| `error`            | `message` (string), `hint` (string?)                         | a fatal error (before exit 1) |
+
+Example (`functor -d examples/primitives build --json`):
+
+```json
+{"type":"command_started","command":"build","project":"examples/primitives"}
+{"type":"mle_loaded","entry":"game.mle","sibling_count":0}
+{"type":"command_finished","ok":true,"duration_ms":6}
+```
+
+A build with a type error:
+
+```json
+{"type":"command_started","command":"build","project":"scratch/broken"}
+{"type":"diagnostic","severity":"error","file":"scratch/broken/game.mle","line":3,"col":5,"message":"..."}
+{"type":"error","message":"1 type error(s) in the scratch/broken/game.mle project"}
+{"type":"command_finished","ok":false,"duration_ms":4}
+```
+
+### Reserved for PR-2 (runtime-side — not emitted yet)
+
+These come from the **in-process desktop runtime** (frame loop / hot-reload / asset load),
+which today still `println!`s directly. Routing them requires a runtime event-sink refactor
+(below) and lands in PR-2. Documented here so the schema is planned, not surprising:
+
+| `type`           | Fields                                                                 |
+| ---------------- | --------------------------------------------------------------------- |
+| `runtime_ready`  | —                                                                     |
+| `frame_stats`    | `tick_us`, `draw_us`, `frame_us`, `budget_pct`, `over_n_frames`       |
+| `capture_written`| `path` (string)                                                       |
+| `hot_reload`     | `ok` (bool), `message` (string)                                       |
+| `asset_error`    | `path` (string), `message` (string)                                   |
+| `reload`         | — (wasm page reload)                                                  |
+
+## Runtime-output routing — deferred to PR-2 (and why)
+
+Post-#243 `functor run native` drives the desktop runtime **in the CLI's process**, and that
+runtime currently `println!`s its own lines (`[mle] avg over 300 frames…`, capture
+confirmations, asset-load errors, hot-reload notices) straight to stdout, **bypassing the
+renderer**. Under `--json` these raw lines would corrupt the ndjson stream.
+
+Fixing this is **explicitly out of scope for PR-1** because the clean fix is a runtime change,
+not a CLI change: give the runtime a structured event sink (a callback/channel the host passes
+in) so it *emits* `FrameStats`/`CaptureWritten`/`HotReload`/`AssetError` instead of printing,
+and the CLI renders them through the same stream. That keeps the functional-core / imperative-
+shell boundary honest and makes the runtime observable to the SDK too — but it touches
+`runtime/` crates and both producers, so it is its own reviewable PR.
+
+Until then: `run`/`develop native` still print runtime lines raw on stdout. `build`, `push`,
+`run wasm` (dev server), and all CLI-side status are fully routed.
+
+## Phasing
+
+- **PR-1 (this):** the `Event` enum + `Renderer` trait + selection; `JsonRenderer` (ndjson)
+  and a plain `PlainRenderer` (no animation); retire the raw debug prints; fix the `--help`
+  wording; global `--json`/`--quiet`/`--no-color`.
+- **PR-2:** the ink-style human renderer (spinners, a live region above scrollback, grouped
+  styled sections) **and** the runtime event-sink routing above.
+- **PR-3:** rich MLE diagnostics (source line + caret), actionable error hints, polish.
+</content>
+</invoke>


### PR DESCRIPTION
## What & why

PR #243 merged `functor-runner` into a single in-process `functor` CLI and
deferred the UX polish. This is the polish, phase 1 of 3.

The CLI now speaks **two languages from one source of truth**: command logic
(`build`/`run`/`develop`/`push`/`init`) emits typed `Event`s, and a single
renderer — selected once at startup — turns the stream into human-readable text
or newline-delimited JSON (ndjson). No fact is formatted in two places. This is
design principle #2 (LLM-native): anything a human sees, an agent can parse as
structured data.

```
command logic ──emit(Event)──▶ ┌─ PlainRenderer  (human text; color on a TTY)
                               └─ JsonRenderer   (ndjson: one {type,…} object per line)
```

## What's in PR-1

- **`cli/src/output.rs`** — the `Event` enum (serde, `{type,…}`), a `Renderer`
  trait, `JsonRenderer` (ndjson, flushed) + a plain `PlainRenderer`
  (styled-but-simple; **no spinners/animation yet — that's PR-2**), and
  process-wide `emit`/`init`.
- **Renderer selection** — `--json` → ndjson; else plain text. Non-TTY / `CI`
  default is **plain text** (not ndjson); `--json` opts in. Color only on a TTY
  with `NO_COLOR`/`CI` unset and no `--no-color`, enforced globally so a pipe /
  dumb terminal never leaks ANSI. `--quiet` = errors + final status only.
- **Every command emits events** instead of printing. MLE check *and* load
  errors surface as structured `Diagnostic{file,line,col,message}` in both modes.
- **Retired the raw debug prints** (`Running command`, `Hello from directory`,
  `Found functor.json`, `Using working dir`, `-- Running command`,
  `Done`/`Failed`).
- **Fixed the `--help` wording** (no more "forwarded to functor-runner" — that
  binary is gone; `grep -rn functor-runner cli/src` is now zero) and added global
  `--json`/`--quiet`/`--no-color`.
- **`docs/cli-output.md`** — the event schema (stable machine API), the selection
  rule table, and the phasing.

`inspect` stays a **data command**: it prints its report to stdout (its own
`--format text|json` is its dual mode) and stays off the event stream so that
payload stays pure.

## Verification (headless)

- `build` human output legible; `build --json` → every line valid JSON; `build | cat`
  (piped) → clean plain text, no ANSI.
- MLE type errors *and* parse/load errors surface as `diagnostic` events with
  `file:line:col` in both modes.
- `run native --capture-frame … --fixed-time 2 --capture-time 1` still renders +
  exits; the wasm dev server binds-then-announces `server_listening`.
- `cargo build --bin functor` clean; `cargo test -p functor-cli` (5), `-p mle`
  (64), `-p functor_runtime_common` (201) all green.

Reviewed with `/xreview` (Claude + Codex). Both fixes applied: bind-then-announce
for `ServerListening`, and structured load diagnostics.

## Explicitly deferred

- **PR-2 — ink-style human renderer** (spinners, live region above scrollback,
  grouped styled sections) **+ runtime-output routing**: `run/develop native`
  drives the desktop runtime in-process, which still `println!`s frame-stats /
  capture / hot-reload / asset-errors raw to stdout, bypassing the renderer (and
  corrupting `--json` under `run native`). Routing it needs a runtime event-sink
  refactor — its own reviewable PR. See `docs/cli-output.md` → "Runtime-output
  routing".
- **PR-3 — polish**: rich MLE diagnostics (source line + caret), actionable error
  hints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
