### PR TITLE
feat(time-travel): T6b-2 — frame-indexed input log + replay in forward-step

### DIFF
--- a/runtime/functor-runtime-common/src/input.rs
+++ b/runtime/functor-runtime-common/src/input.rs
@@ -45,6 +45,26 @@ pub enum Key {
     Escape,
 }
 
+/// One recorded input event at the raw boundary scalars — pre-`Key::from_i32`,
+/// pre-name-formatting — so a replay re-runs the *identical* path the live
+/// frame took (docs/time-travel.md, "The event log"). It is PLAIN DATA — `Copy`
+/// scalars holding no `Rc`/closure into the old module — which is exactly why
+/// the frame-indexed input log survives a hot reload even though the
+/// closure-holding model snapshots do not. Both shells buffer these in
+/// `key_event`/`mouse_move`/`mouse_wheel` and flush a frame's worth into the
+/// recorder; the forward-step replays them. (`Serialize`/`Deserialize` are for
+/// the future on-disk/wire event log, T7 — unused by the in-session replay.)
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub enum RecordedInput {
+    /// A keyboard event carrying the raw `Key as i32` code (not the resolved
+    /// `Key`), so replay re-runs `Key::from_i32` exactly as the live path does.
+    Key { code: i32, is_down: bool },
+    /// A pointer position in window pixels.
+    MouseMove { x: i32, y: i32 },
+    /// A wheel notch (±1 per notch).
+    MouseWheel { delta: i32 },
+}
+
 impl Key {
     /// All key variants in discriminant order. Keep in sync with the enum above
     /// (guarded by `from_i32_round_trips`).

--- a/runtime/functor-runtime-common/src/mle_producer.rs
+++ b/runtime/functor-runtime-common/src/mle_producer.rs
@@ -35,6 +35,7 @@ use crate::mle_prelude::{
     physics_scene_value, split_model_effect, sub_messages_for_frame, take_audio_completion,
     take_http_tagger, EffectLog, EffectRunner, EffectTree, FakeEffects, FunctorHost, NetEventKind,
 };
+use crate::input::{Key, RecordedInput};
 use crate::net::{push_conn_command, ConnCommand, HttpResult};
 use crate::physics::{self, PhysicsEvent, SteppedPhysics};
 use crate::timetravel::SceneRecorder;
@@ -129,6 +130,12 @@ pub struct FrameCtx<'a> {
     pub pending_events: &'a mut Vec<PhysicsEvent>,
     pub live_conn_keys: &'a mut HashSet<String>,
     pub prev_tts: &'a mut Option<f64>,
+    /// This frame's buffered input events (docs/time-travel.md T6b): each shell
+    /// appends to it in `key_event`/`mouse_move`/`mouse_wheel`, and
+    /// [`Self::record_frame`] flushes a played frame's worth into the recorder's
+    /// input log (or drains-and-drops it on a paused frame). The dry-run
+    /// forward-step points this at a throwaway buffer.
+    pub input_buf: &'a mut Vec<RecordedInput>,
     pub has_physics: bool,
     pub has_subscriptions: bool,
     /// Suppress OUTBOUND effects (physics command / timeline / send / http /
@@ -270,8 +277,17 @@ impl FrameCtx<'_> {
     /// carries `dts > 0`).
     pub fn record_frame(&mut self, frame_time: FrameTime) {
         if frame_time.dts > 0.0 {
+            // Record this frame's inputs FIRST (keyed at the recorder's current
+            // `rendered_frame`), then the model — `record` advances the clock, so
+            // both must land on the same frame (docs/time-travel.md T6b).
+            self.recorder.record_inputs(std::mem::take(self.input_buf));
             self.recorder
                 .record(self.model, self.physics_status.0, frame_time.tts as f64);
+        } else {
+            // Paused frame (`dts == 0`): drain-and-drop the buffer. Paused frames
+            // aren't part of the played timeline, so their buffered inputs must
+            // NOT leak into the next stepped frame's recorded events.
+            self.input_buf.clear();
         }
     }
 
@@ -308,14 +324,29 @@ impl FrameCtx<'_> {
     ///   (follow-up, alongside the input log). The coast case the T6b test covers
     ///   — a frame body that neither reads physics nor commands it — matches
     ///   exactly, model AND world.
+    ///
+    /// `inputs` is the recorded input log for the divisions being stepped
+    /// (index `i` = division `i`'s events, i.e. fork frame `K + 1 + i`). At the
+    /// TOP of each division its recorded events are REPLAYED (mirroring the live
+    /// order — input arrives before `tick`) so a recorded jump replays. Beyond
+    /// the recorded window (`inputs` runs out) the step COASTS on held state.
     pub fn step_scene_forward(
         &mut self,
         divisions: usize,
         dts: f32,
         start_tts: f32,
+        inputs: &[Vec<RecordedInput>],
     ) -> Vec<(Value, Option<Vec<u8>>)> {
         let mut out = Vec::with_capacity(divisions);
         for i in 0..divisions {
+            // Replay this division's recorded inputs before the frame body, so
+            // the model absorbs them exactly as the live frame did (coast when
+            // the log has no entry for this division).
+            if let Some(events) = inputs.get(i) {
+                for event in events {
+                    self.replay_input(*event);
+                }
+            }
             let frame_time = FrameTime {
                 dts,
                 tts: start_tts + (i as f32 + 1.0) * dts,
@@ -330,6 +361,47 @@ impl FrameCtx<'_> {
             out.push((self.model.clone(), world));
         }
         out
+    }
+
+    /// Replay one recorded input event during the forward-step, mirroring the
+    /// LIVE path (`key_event`/`mouse_move`/`mouse_wheel`): call the game's
+    /// `input`/`mouseMove`/`mouseWheel` entry point with the SAME reconstructed
+    /// args, then [`Self::absorb`] the result (which honors `suppress_outbound`,
+    /// so nothing escapes). A `Key` re-runs `Key::from_i32` on the raw code just
+    /// as the live path does; an unknown code is dropped, like live. An entry
+    /// point the game doesn't define resolves to an interpreter error, reported
+    /// (and silenced) through the dry-run reporter.
+    fn replay_input(&mut self, event: RecordedInput) {
+        let (entry, args) = match event {
+            RecordedInput::Key { code, is_down } => {
+                let Some(key) = Key::from_i32(code) else {
+                    return;
+                };
+                (
+                    "input",
+                    vec![
+                        self.model.clone(),
+                        Value::String(std::rc::Rc::from(format!("{key:?}").as_str())),
+                        Value::Bool(is_down),
+                    ],
+                )
+            }
+            RecordedInput::MouseMove { x, y } => (
+                "mouseMove",
+                vec![
+                    self.model.clone(),
+                    Value::Number(x as f64),
+                    Value::Number(y as f64),
+                ],
+            ),
+            RecordedInput::MouseWheel { delta } => {
+                ("mouseWheel", vec![self.model.clone(), Value::Number(delta as f64)])
+            }
+        };
+        match self.session.call(entry, args, &mut FunctorHost) {
+            Ok(returned) => self.absorb(returned),
+            Err(err) => self.reporter.frame_error(entry, &err),
+        }
     }
 
     /// Take an entry point's return: split off any `(model, effect)` pair,
@@ -641,6 +713,7 @@ pub fn forward_step_scene(
     start_tts: f32,
     dts: f32,
     divisions: usize,
+    inputs: &[Vec<RecordedInput>],
 ) -> Vec<(Value, Option<Vec<u8>>)> {
     // Dry-run physics: snapshot the live world and restore it into a fresh
     // throwaway world, so stepping forward never touches the live world,
@@ -675,6 +748,9 @@ pub fn forward_step_scene(
     let mut pending_events: Vec<PhysicsEvent> = Vec::new();
     let mut live_conn_keys: HashSet<String> = HashSet::new();
     let mut prev_tts = prev_tts;
+    // Throwaway input buffer: the forward-step replays `inputs` directly and
+    // never records, so this stays empty — it just satisfies the borrow.
+    let mut input_buf: Vec<RecordedInput> = Vec::new();
     let mut reporter = Reporter::new(
         SpanSource::Single {
             src: String::new(),
@@ -696,12 +772,13 @@ pub fn forward_step_scene(
             pending_events: &mut pending_events,
             live_conn_keys: &mut live_conn_keys,
             prev_tts: &mut prev_tts,
+            input_buf: &mut input_buf,
             has_physics,
             has_subscriptions,
             suppress_outbound: true,
             reporter: &mut reporter,
         };
-        ctx.step_scene_forward(divisions, dts, start_tts)
+        ctx.step_scene_forward(divisions, dts, start_tts, inputs)
     };
 
     // `dry_world`'s `Drop` removes the throwaway world here (and on any unwind

--- a/runtime/functor-runtime-common/src/timetravel.rs
+++ b/runtime/functor-runtime-common/src/timetravel.rs
@@ -32,6 +32,7 @@ use std::collections::VecDeque;
 
 use mle::Value;
 
+use crate::input::RecordedInput;
 use crate::physics::SteppedPhysics;
 
 /// A fixed-step frame number — the same index space as
@@ -191,6 +192,13 @@ pub struct SceneRecorder {
     /// `tts` so `tts`-driven visuals (orbiting lights, `sin(tts)` bobbing)
     /// rewind too, not just model/world state (docs/time-travel.md).
     tts_history: History<f64>,
+    /// The frame-indexed input log (docs/time-travel.md T6, "The event log"):
+    /// each rendered frame's recorded input events, keyed in LOCKSTEP with
+    /// `model_history`. Unlike the other three rings this is PLAIN DATA
+    /// (`RecordedInput`), so it deliberately SURVIVES a hot reload — the log is
+    /// what lets "tweak a constant, replay my recorded inputs" work. Alignment
+    /// with the (reset) model ring holds because both key off `rendered_frame`.
+    input_history: History<Vec<RecordedInput>>,
     /// The rendered-frame index the next snapshot records at; monotonic.
     rendered_frame: u64,
     /// While dragging: the frame the scrubber has non-destructively seeked to.
@@ -210,14 +218,19 @@ impl SceneRecorder {
             model_history: History::bounded(DEFAULT_HISTORY_FRAMES),
             world_frame_history: History::bounded(DEFAULT_HISTORY_FRAMES),
             tts_history: History::bounded(DEFAULT_HISTORY_FRAMES),
+            input_history: History::bounded(DEFAULT_HISTORY_FRAMES),
             rendered_frame: 0,
             scrub_pos: None,
         }
     }
 
-    /// Hot-reload boundary: drop the rings (their snapshots can hold old-module
+    /// Hot-reload boundary: drop the snapshot rings (they can hold old-module
     /// closures) but keep `rendered_frame` monotonic so recording resumes
-    /// consecutively, and clear any scrub.
+    /// consecutively, and clear any scrub. The `input_history` is deliberately
+    /// NOT dropped: it is plain data (`RecordedInput`), so the input log SURVIVES
+    /// a reload (docs/time-travel.md, "The event log") — the one difference from
+    /// the closure-holding model/world/tts rings. It stays aligned because it too
+    /// keys off the single monotonic `rendered_frame`.
     pub fn reset_on_reload(&mut self) {
         self.model_history = History::bounded(DEFAULT_HISTORY_FRAMES);
         self.world_frame_history = History::bounded(DEFAULT_HISTORY_FRAMES);
@@ -235,6 +248,38 @@ impl SceneRecorder {
             .record(self.rendered_frame, &physics_fixed_frame);
         self.tts_history.record(self.rendered_frame, &tts);
         self.rendered_frame += 1;
+    }
+
+    /// Record this rendered frame's input events, keyed by the CURRENT
+    /// `rendered_frame` — so it lands on the same frame as the matching
+    /// [`Self::record`]. It does NOT advance the clock; call it JUST BEFORE
+    /// `record` (which does), so both key off the same frame. An empty `Vec` is
+    /// recorded for input-free frames, keeping the ring consecutive with the
+    /// model ring.
+    pub fn record_inputs(&mut self, inputs: Vec<RecordedInput>) {
+        self.input_history.record(self.rendered_frame, &inputs);
+    }
+
+    /// The recorded input events of `frame` — empty if that frame is outside the
+    /// retained input window (never recorded, or pruned).
+    pub fn inputs_at(&self, frame: u64) -> &[RecordedInput] {
+        match self.input_history.recorded_range() {
+            Some((lo, hi)) if frame >= lo && frame <= hi => self.input_history.seek(frame),
+            _ => &[],
+        }
+    }
+
+    /// The recorded inputs for frames `start..=newest`, contiguous, so the
+    /// forward-step can replay them in order (division `i` gets index `i`). Empty
+    /// if nothing at/after `start` is retained. Frames before the retained floor
+    /// are skipped; `start` is clamped up to the floor.
+    pub fn inputs_from(&self, start: u64) -> Vec<Vec<RecordedInput>> {
+        match self.input_history.recorded_range() {
+            Some((lo, hi)) => (start.max(lo)..=hi)
+                .map(|f| self.input_history.seek(f).clone())
+                .collect(),
+            None => Vec::new(),
+        }
     }
 
     /// The render clock `tts` to draw at WHILE SCRUBBING — the recorded `tts` of
@@ -343,6 +388,9 @@ impl SceneRecorder {
         self.model_history.truncate_from(frame + 1);
         self.world_frame_history.truncate_from(frame + 1);
         self.tts_history.truncate_from(frame + 1);
+        // Truncate the input log too: a destructive branch discards the old
+        // future consistently across all four rings (docs/time-travel.md T6b).
+        self.input_history.truncate_from(frame + 1);
         self.rendered_frame = frame + 1;
         self.scrub_pos = None;
         let clamped = if frame == target {
@@ -554,6 +602,45 @@ mod tests {
         rec.seek_scene_to(4, &mut model, &mut physics, &mut status, false)
             .expect("seek");
         assert_eq!(rec.scrub_render_tts(), Some(40.0));
+    }
+
+    // --- the input log: record → read back, and survive a reload (T6b) ---
+
+    #[test]
+    fn input_log_records_reads_back_and_survives_reload() {
+        let mut rec = SceneRecorder::new();
+        // Record three frames, keying inputs in lockstep with the model (the
+        // order the producer's `record_frame` uses: inputs first, then model).
+        let f0 = vec![RecordedInput::Key { code: 30, is_down: true }];
+        let f1: Vec<RecordedInput> = vec![];
+        let f2 = vec![
+            RecordedInput::MouseMove { x: 5, y: 7 },
+            RecordedInput::MouseWheel { delta: -1 },
+        ];
+        for inputs in [&f0, &f1, &f2] {
+            rec.record_inputs(inputs.clone());
+            rec.record(&Value::Number(0.0), 0, 0.0);
+        }
+
+        // Round-trip: each frame reads back exactly what was recorded.
+        assert_eq!(rec.inputs_at(0).len(), 1);
+        assert!(matches!(
+            rec.inputs_at(0)[0],
+            RecordedInput::Key { code: 30, is_down: true }
+        ));
+        assert!(rec.inputs_at(1).is_empty());
+        assert_eq!(rec.inputs_at(2).len(), 2);
+        // A frame outside the recorded window reads back empty, not a panic.
+        assert!(rec.inputs_at(99).is_empty());
+        // `inputs_from` is contiguous from the start frame.
+        assert_eq!(rec.inputs_from(1).len(), 2); // frames 1 and 2
+
+        // A hot reload drops the model ring but KEEPS the input log (plain data
+        // survives reload, docs/time-travel.md).
+        rec.reset_on_reload();
+        assert_eq!(rec.scene_frame_range(), None, "model ring reset on reload");
+        assert_eq!(rec.inputs_at(0).len(), 1, "input log survives the reload");
+        assert_eq!(rec.inputs_at(2).len(), 2, "input log survives the reload");
     }
 
     #[test]

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -114,6 +114,11 @@ pub struct MleGame {
     /// settled `model` + physics fixed-frame each rendered frame and seeks/
     /// rewinds them together. Shared with the web producer (one tested impl).
     recorder: SceneRecorder,
+    /// This frame's buffered input events (docs/time-travel.md T6b): appended in
+    /// `key_event`/`mouse_move`/`mouse_wheel` beside the live `session.call`, and
+    /// flushed into `recorder`'s input log by `record_frame` (plain data, so the
+    /// log survives a hot reload).
+    input_buf: Vec<functor_runtime_common::RecordedInput>,
     /// Endpoint keys of the connections currently declared by
     /// `subscriptions` (`Sub.connect`/`Sub.listen`) — diffed each frame to
     /// open newly-declared ones and close dropped ones. The shell's
@@ -338,6 +343,7 @@ impl MleGame {
             physics_rt: physics::SteppedPhysics::new(),
             physics_status: (0, false, 0),
             recorder: SceneRecorder::new(),
+            input_buf: Vec::new(),
             live_conn_keys: std::collections::HashSet::new(),
             last_frame: empty_frame(),
             reporter: Reporter::new(SpanSource::Project(loaded.sources), report_to_stderr),
@@ -365,6 +371,7 @@ impl MleGame {
             pending_events: &mut self.pending_events,
             live_conn_keys: &mut self.live_conn_keys,
             prev_tts: &mut self.prev_tts,
+            input_buf: &mut self.input_buf,
             has_physics: self.has_physics,
             has_subscriptions: self.has_subscriptions,
             suppress_outbound: false,
@@ -580,6 +587,13 @@ impl Game for MleGame {
     /// smears. A draw that errors or doesn't return a Frame is skipped, so the
     /// result may be shorter than `divisions`.
     fn ghost_frames(&self, divisions: usize, dt: f32, start_tts: f64) -> Vec<Frame> {
+        // Replay the recorded inputs for the frames AFTER the fork point K, so a
+        // recorded jump/run ghosts (docs/time-travel.md T6b). Beyond the recorded
+        // window the forward-step coasts on held state.
+        let inputs = match self.recorder.current_scene_frame() {
+            Some(k) => self.recorder.inputs_from(k + 1),
+            None => Vec::new(),
+        };
         let stepped = forward_step_scene(
             &self.session,
             &self.model,
@@ -589,6 +603,7 @@ impl Game for MleGame {
             start_tts as f32,
             dt,
             divisions,
+            &inputs,
         );
         let mut frames = Vec::with_capacity(stepped.len());
         for (i, (model_i, _world)) in stepped.iter().enumerate() {
@@ -656,6 +671,10 @@ impl Game for MleGame {
             Ok(returned) => self.ctx().absorb(returned),
             Err(err) => self.reporter.frame_error("input", &err),
         }
+        // Buffer the raw event for the frame-indexed input log (T6b): flushed
+        // into the recorder by `record_frame`, replayed by the forward-step.
+        self.input_buf
+            .push(functor_runtime_common::RecordedInput::Key { code, is_down });
     }
     fn mouse_move(&mut self, x: i32, y: i32) {
         if !self.has_mouse_move {
@@ -670,6 +689,8 @@ impl Game for MleGame {
             Ok(returned) => self.ctx().absorb(returned),
             Err(err) => self.reporter.frame_error("mouseMove", &err),
         }
+        self.input_buf
+            .push(functor_runtime_common::RecordedInput::MouseMove { x, y });
     }
 
     fn mouse_wheel(&mut self, delta: i32) {
@@ -681,6 +702,8 @@ impl Game for MleGame {
             Ok(returned) => self.ctx().absorb(returned),
             Err(err) => self.reporter.frame_error("mouseWheel", &err),
         }
+        self.input_buf
+            .push(functor_runtime_common::RecordedInput::MouseWheel { delta });
     }
 
     fn render(&mut self, frame_time: FrameTime) -> Frame {
@@ -1541,6 +1564,7 @@ mod tests {
             fork_tts,
             DT,
             N,
+            &[],
         );
 
         // The live producer state is UNCHANGED by the forward-step.
@@ -1581,5 +1605,136 @@ mod tests {
 
         physics::remove_world(physics::DEFAULT_WORLD);
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The frame-indexed input log payoff (docs/time-travel.md T6b): forward-
+    /// stepping the REAL `examples/mario` game while REPLAYING its recorded input
+    /// log reproduces a scripted jump exactly, and the projected character clears
+    /// the chasm. Mario has no `physics` hook (`has_physics = false`), so the
+    /// projection is exact — the whole state forward-steps in `tick`, driven only
+    /// by the replayed inputs. This is the "record a jump, replay it forward"
+    /// demo, runtime-verified headlessly.
+    #[test]
+    fn mario_forward_step_replays_recorded_jump_and_clears_chasm() {
+        use functor_runtime_common::Key;
+
+        fn field(v: &Value, name: &str) -> f64 {
+            match v {
+                Value::Record(fields) => match &fields.iter().find(|(k, _)| k == name).unwrap().1 {
+                    Value::Number(x) => *x,
+                    Value::Bool(b) => {
+                        if *b {
+                            1.0
+                        } else {
+                            0.0
+                        }
+                    }
+                    other => panic!("{name} is not a number/bool: {other}"),
+                },
+                _ => panic!("model is not a record"),
+            }
+        }
+
+        let mario = concat!(env!("CARGO_MANIFEST_DIR"), "/../../examples/mario/game.mle");
+        let mut game = MleGame::create(mario);
+        assert!(!game.has_physics, "mario must have no physics hook");
+
+        const DT: f32 = 1.0 / 60.0;
+        const K: usize = 10; // pre-jump fork point (still running left of the edge)
+        const N: usize = 75; // continuation window: run to the edge, jump, land, run
+
+        // Hold Right from the very first frame (a single key-down, then held).
+        game.key_event(Key::Right as i32, true);
+
+        // Phase 1: drive K frames of running to the fork point (pre-jump).
+        let mut tts = 0.0f32;
+        for _ in 0..K {
+            tts += DT;
+            game.tick(FrameTime { tts, dts: DT });
+        }
+        let fork_model = game.model.clone();
+        let fork_prev_tts = game.prev_tts;
+        let fork_tts = tts;
+        // The fork is pre-jump: grounded, running, still well left of the chasm.
+        assert_eq!(field(&fork_model, "grounded"), 1.0, "fork must be grounded");
+        assert!(field(&fork_model, "x") < -3.0, "fork must be left of the edge");
+
+        // Phase 2: the live continuation — run to the edge and JUMP at the last
+        // grounded frame before walking off (the optimal launch), then land. This
+        // fills the recorder's input log for frames K.. and is the ground truth.
+        let mut live: Vec<(f64, f64)> = Vec::with_capacity(N);
+        let mut jumped = false;
+        for _ in 0..N {
+            // Jump just before walking off the left platform (mirrors a player
+            // timing the jump at the edge). One press, gated on grounded.
+            if !jumped
+                && field(&game.model, "grounded") == 1.0
+                && field(&game.model, "x") + (8.0 * DT as f64) >= -3.0
+            {
+                game.key_event(Key::Up as i32, true);
+                jumped = true;
+            }
+            tts += DT;
+            game.tick(FrameTime { tts, dts: DT });
+            live.push((field(&game.model, "x"), field(&game.model, "y")));
+        }
+        assert!(jumped, "the scripted jump must have fired");
+
+        // The recorded input log for the continuation frames (K..), replayed by
+        // the forward-step. `current_scene_frame` is the newest recorded frame
+        // (K + N - 1); ghosting resolves K from it, so replay frames K.. .
+        let inputs = game.recorder.inputs_from(K as u64);
+        assert_eq!(inputs.len(), N, "one input entry per continuation frame");
+        // The jump was recorded as a single Up key-down somewhere in the window.
+        let up_events: usize = inputs
+            .iter()
+            .flatten()
+            .filter(|e| matches!(e, functor_runtime_common::RecordedInput::Key { code, is_down }
+                if *code == Key::Up as i32 && *is_down))
+            .count();
+        assert_eq!(up_events, 1, "exactly one recorded jump");
+
+        // Forward-step from the PRE-JUMP fork, replaying the recorded inputs.
+        let forward = functor_runtime_common::mle_producer::forward_step_scene(
+            &game.session,
+            &fork_model,
+            game.has_physics,
+            game.has_subscriptions,
+            fork_prev_tts,
+            fork_tts,
+            DT,
+            N,
+            &inputs,
+        );
+        assert_eq!(forward.len(), live.len(), "division count");
+
+        // (a) The projected trajectory matches the live continuation division for
+        // division — the replayed jump reproduces the recorded arc exactly.
+        for (i, ((fwd_m, _w), (lx, ly))) in forward.iter().zip(live.iter()).enumerate() {
+            assert!(
+                (field(fwd_m, "x") - lx).abs() < 1e-9,
+                "x diverged at division {i}: {} vs {lx}",
+                field(fwd_m, "x")
+            );
+            assert!(
+                (field(fwd_m, "y") - ly).abs() < 1e-9,
+                "y diverged at division {i}: {} vs {ly}",
+                field(fwd_m, "y")
+            );
+        }
+
+        // (b) The character CLEARS the chasm: it lands on the RIGHT platform
+        // (x past chasmHalf 3.0 and inside rightEdge 11.0), grounded — not fallen
+        // into the gap and respawned.
+        let (final_x, _final_y) = *live.last().unwrap();
+        assert!(
+            final_x > 3.0 && final_x < 11.0,
+            "character should have cleared the chasm and landed on the right platform, final x = {final_x}"
+        );
+        assert_eq!(
+            field(&game.model, "grounded"),
+            1.0,
+            "character should be grounded on the right platform"
+        );
     }
 }

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -852,19 +852,27 @@ Escape again to quit"
                             println!("[xreal] recentered");
                         }
                     }
-                    // Always honor key releases and focus-loss, even while other
-                    // input is ignored (pinned clock) — otherwise a key held at
-                    // the pin transition, or released after alt-tab, would stick
-                    // in held_keys forever. Releases can only *clear* input, so
-                    // they don't perturb a pinned/deterministic pose.
+                    // Always honor the SHELL bookkeeping for key releases and
+                    // focus-loss, even while other input is ignored (pinned clock)
+                    // — otherwise a key held at the pin transition, or released
+                    // after alt-tab, would stick in held_keys forever. But while
+                    // pinned we must NOT deliver the release to the game: the
+                    // input log only records/replays what reaches the model, and a
+                    // paused frame drops its input buffer, so an unlogged release
+                    // would diverge forward-step replay. Gate the game delivery on
+                    // !ignore_user_input while keeping held_keys/cursor bookkeeping.
                     glfw::WindowEvent::Key(key, _, Action::Release, _) => {
                         let k = map_key(key);
-                        game.key_event(k as i32, false);
+                        if !ignore_user_input {
+                            game.key_event(k as i32, false);
+                        }
                         held_keys.remove(&k);
                     }
                     glfw::WindowEvent::Focus(false) => {
                         for k in std::mem::take(&mut held_keys) {
-                            game.key_event(k as i32, false);
+                            if !ignore_user_input {
+                                game.key_event(k as i32, false);
+                            }
                         }
                         // Hand the pointer back when the window loses focus
                         // (cmd-tab to the editor); a click recaptures.

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -971,8 +971,10 @@ async fn run_async() -> Result<(), JsValue> {
             last_time = now;
 
             // Deliver page input queued since the last frame (the MLE path's
-            // `mle_*` exports).
-            mle_game::drain_input(&mut **game);
+            // `mle_*` exports). While paused, drain-and-discard: no input may
+            // reach the model on a paused frame (the input log would otherwise
+            // diverge replay), and draining stops the queue bursting on resume.
+            mle_game::drain_input(&mut **game, !clock.is_paused());
 
             game.tick(frame_time.clone());
 

--- a/runtime/functor-runtime-web/src/mle_game.rs
+++ b/runtime/functor-runtime-web/src/mle_game.rs
@@ -89,6 +89,11 @@ pub struct MleWebGame {
     /// the desktop producer (one tested impl): records the settled `model` +
     /// physics fixed-frame each rendered frame and seeks/rewinds them together.
     recorder: SceneRecorder,
+    /// This frame's buffered input events (docs/time-travel.md T6b): appended in
+    /// `key_event`/`mouse_move`/`mouse_wheel` beside the live `session.call`, and
+    /// flushed into `recorder`'s input log by `record_frame` (plain data, so the
+    /// log survives a reload). Shared shape with the desktop producer.
+    input_buf: Vec<functor_runtime_common::RecordedInput>,
     /// Declared connection keys (`Sub.connect`/`Sub.listen`), reconciled each
     /// frame — see the desktop producer.
     live_conn_keys: std::collections::HashSet<String>,
@@ -262,6 +267,7 @@ impl MleWebGame {
             physics_rt: physics::SteppedPhysics::new(),
             physics_status: (0, false, 0),
             recorder: SceneRecorder::new(),
+            input_buf: Vec::new(),
             live_conn_keys: std::collections::HashSet::new(),
             has_physics: loaded.has_physics,
             has_soundscape: loaded.has_soundscape,
@@ -346,6 +352,7 @@ impl MleWebGame {
             pending_events: &mut self.pending_events,
             live_conn_keys: &mut self.live_conn_keys,
             prev_tts: &mut self.prev_tts,
+            input_buf: &mut self.input_buf,
             has_physics: self.has_physics,
             has_subscriptions: self.has_subscriptions,
             suppress_outbound: false,
@@ -447,6 +454,10 @@ impl GameProducer for MleWebGame {
             Ok(returned) => self.ctx().absorb(returned),
             Err(err) => self.reporter.frame_error("input", &err),
         }
+        // Buffer the raw event for the frame-indexed input log (T6b): flushed
+        // into the recorder by `record_frame`, replayed by the forward-step.
+        self.input_buf
+            .push(functor_runtime_common::RecordedInput::Key { code, is_down });
     }
 
     fn mouse_move(&mut self, x: i32, y: i32) {
@@ -462,6 +473,8 @@ impl GameProducer for MleWebGame {
             Ok(returned) => self.ctx().absorb(returned),
             Err(err) => self.reporter.frame_error("mouseMove", &err),
         }
+        self.input_buf
+            .push(functor_runtime_common::RecordedInput::MouseMove { x, y });
     }
 
     fn mouse_wheel(&mut self, delta: i32) {
@@ -473,6 +486,8 @@ impl GameProducer for MleWebGame {
             Ok(returned) => self.ctx().absorb(returned),
             Err(err) => self.reporter.frame_error("mouseWheel", &err),
         }
+        self.input_buf
+            .push(functor_runtime_common::RecordedInput::MouseWheel { delta });
     }
 
     fn render(&mut self, frame_time: FrameTime) -> Frame {
@@ -651,11 +666,10 @@ fn empty_frame() -> Frame {
 // (index-mle.html) calls the `mle_*` exports below. Events queue here and the
 // frame loop drains them into the producer before each tick.
 
-enum InputEvent {
-    Key { code: i32, is_down: bool },
-    MouseMove { x: i32, y: i32 },
-    MouseWheel { delta: i32 },
-}
+// The page-input queue carries the SAME plain-data shape the recorder logs, so
+// reuse the shared `RecordedInput` (T6b) rather than a parallel private enum —
+// `drain_input` dispatches its variants unchanged.
+use functor_runtime_common::RecordedInput as InputEvent;
 
 thread_local! {
     static INPUT_QUEUE: RefCell<Vec<InputEvent>> = const { RefCell::new(Vec::new()) };
@@ -697,8 +711,17 @@ pub fn mle_mouse_wheel(delta: i32) {
 /// Drain the queued page input into the producer, in arrival order. Called by
 /// the frame loop before `tick`. Empty (and free) on the F# path — its page
 /// never calls the `mle_*` exports.
-pub fn drain_input(game: &mut dyn GameProducer) {
+///
+/// When `deliver` is false (the clock is paused), the queue is still drained but
+/// its events are DISCARDED — never dispatched to the game. This mirrors the
+/// desktop pinned-clock gate: while paused, NO input may reach the model, so the
+/// frame-indexed input log has nothing unlogged to diverge forward-step replay.
+/// Draining (rather than leaving the queue) also stops it bursting on resume.
+pub fn drain_input(game: &mut dyn GameProducer, deliver: bool) {
     let events = INPUT_QUEUE.with(|q| std::mem::take(&mut *q.borrow_mut()));
+    if !deliver {
+        return;
+    }
     for event in events {
         match event {
             InputEvent::Key { code, is_down } => game.key_event(code, is_down),


### PR DESCRIPTION
## T6b-2 — frame-indexed input log + replay in the forward-step

Records each frame's inputs as plain data and replays them in the deterministic forward-step, so **forward-ghosting replays a recorded jump**. This is the piece that makes the chasm demo interactive.

- **`RecordedInput`** (`input.rs`) — shared plain-data enum (`Key{code,is_down}`, `MouseMove`, `MouseWheel`); web's private `InputEvent` collapses into it.
- **Record (both shells):** a per-frame input buffer, appended in `key_event`/`mouse_*`, flushed by `FrameCtx::record_frame` into `SceneRecorder::record_inputs` under the same `dts>0` gate as the model record (so both key off the same `rendered_frame`).
- **`input_history`** — a 4th `History` ring in lockstep with model/world/tts, **truncated on `rewind_scene_to`** with them, but deliberately **not cleared on `reset_on_reload`**: the log is plain data and survives a hot reload (unlike the closure-holding model/world/tts rings).
- **Replay:** `step_scene_forward` replays each division's recorded inputs (via `absorb`, effects suppressed) before its tick; desktop `ghost_frames` resolves the anchor frame K and passes `inputs_from(K+1)`.

### Verification
- **Determinism test on real `examples/mario`** (no physics → exact): from a pre-jump fork, the forward-step replaying the recorded input log matches a fresh live continuation **to 1e-9 division-for-division, and the character clears the chasm** (lands on the far platform). This finally runtime-verifies mario's knife-edge tuning.
- **Byte-identical goldens** (recording is passive); `cargo test` 202 common + 36 desktop green; strict + wasm clean.

### Review
Cross-engine `/xreview`. Claude traced the `input_history` alignment across reload/prune/rewind/scrub/replay — sound. **Codex caught a Medium** the determinism test missed: a paused/pinned frame delivered input that mutated the model but wasn't logged → replay divergence. **Fixed** — pinned frames no longer deliver game input (extended the existing press-gate to key-releases + focus-loss on desktop, and gated web's `drain_input` dispatch), so paused input is inert and the log stays faithful. Re-validated (determinism + goldens green).

### Unlocked / deferred
**Now:** play `mario`, jump, pause, scrub back before the jump, `--ghost` → your recorded jump replays as the strobed arc. **Deferred:** cross-reload re-derivation (replay under a *tweaked* constant — the full "tweak until it clears" loop); a scripted-input capture hook (headless GIF); web ghosting (trait-default no-op today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
