### PR TITLE
feat(time-travel): T6b-3 — scripted-input capture for deterministic headless runs

### DIFF
--- a/examples/mario/jump.script
+++ b/examples/mario/jump.script
@@ -1,0 +1,16 @@
+# Scripted input that clears the chasm in examples/mario (docs/time-travel.md T6b).
+# Format: <frame:int> <KeyName> <down|up>. Frames advance by --script-dt (1/60 s
+# by default); events are applied before that frame's tick. Fed to a headless
+# --input-script run and captured with --capture-at-frame to prove, with no
+# human, that mario runs off the left platform, jumps, and lands on the right.
+#
+# mario spawns grounded at x = -6 on the left platform (solid x in (-11, -3)).
+# Hold Right from frame 0; at frame 18 (x ~= -3.6, still grounded) jump Up. The
+# 6.4-unit jump arc carries mario over the 6.0-wide chasm; he lands ~frame 69 at
+# x ~= 3.3 on the right platform. Release Right just after landing so he stops
+# there instead of running off the far edge.
+
+0  Right down
+18 Up    down
+19 Up    up
+71 Right up

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -13,8 +13,8 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use functor_runtime_common::asset::AssetCache;
-use functor_runtime_common::{Frame, GameClock, SceneContext};
-use std::collections::BTreeSet;
+use functor_runtime_common::{Frame, GameClock, RecordedInput, SceneContext};
+use std::collections::{BTreeSet, HashMap};
 
 use functor_runtime_common::Key as InputKey;
 use glfw::{Action, Key};
@@ -88,6 +88,46 @@ fn key_from_str(name: &str) -> Option<InputKey> {
         "escape" => Some(InputKey::Escape),
         _ => None,
     }
+}
+
+/// Parse an `--input-script` file into a frame → events map for deterministic
+/// scripted playback (docs/time-travel.md T6b). Each non-blank, non-comment
+/// line is `<frame:int> <KeyName> <down|up>` — e.g. `0 Right down`, `18 Up down`.
+/// `#` starts a comment (to end of line); the key name goes through the same
+/// `key_from_str` map the debug server's POST /input uses. Events are stored as
+/// raw `RecordedInput::Key` so playback re-runs the identical live input path.
+fn parse_input_script(path: &str) -> Result<HashMap<u64, Vec<RecordedInput>>, String> {
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| format!("cannot read input script {path}: {e}"))?;
+    let mut map: HashMap<u64, Vec<RecordedInput>> = HashMap::new();
+    for (i, raw) in text.lines().enumerate() {
+        let lineno = i + 1;
+        let line = raw.split('#').next().unwrap_or("").trim();
+        if line.is_empty() {
+            continue;
+        }
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() != 3 {
+            return Err(format!(
+                "{path}:{lineno}: expected `<frame> <Key> <down|up>`, got `{raw}`"
+            ));
+        }
+        let frame: u64 = parts[0]
+            .parse()
+            .map_err(|_| format!("{path}:{lineno}: bad frame number `{}`", parts[0]))?;
+        let key = key_from_str(parts[1])
+            .ok_or_else(|| format!("{path}:{lineno}: unknown key `{}`", parts[1]))?;
+        let is_down = match parts[2].to_ascii_lowercase().as_str() {
+            "down" => true,
+            "up" => false,
+            other => return Err(format!("{path}:{lineno}: expected `down|up`, got `{other}`")),
+        };
+        map.entry(frame).or_default().push(RecordedInput::Key {
+            code: key as i32,
+            is_down,
+        });
+    }
+    Ok(map)
 }
 
 use clap::Parser;
@@ -186,6 +226,30 @@ pub struct Args {
     #[arg(long)]
     fixed_time: Option<f32>,
 
+    /// Drive the game deterministically from a scripted input file instead of
+    /// live window input (docs/time-travel.md T6b). Each line is
+    /// `<frame:int> <KeyName> <down|up>` (KeyName like `Right`, `Up`, `A`,
+    /// `Space`); `#` starts a comment. The sim advances by a FIXED `--script-dt`
+    /// per rendered frame (not wall-clock), and each frame's scripted events are
+    /// fed before that frame's tick, so frame N is always the same sim state —
+    /// combine with `--capture-frame`/`--capture-at-frame` for reproducible
+    /// stills. Off by default (goldens/live runs unaffected).
+    #[arg(long, conflicts_with = "fixed_time")]
+    input_script: Option<String>,
+
+    /// Fixed per-frame timestep (seconds) for `--input-script` deterministic
+    /// playback. Default is one 60 Hz frame. Must be positive and finite — a
+    /// zero/negative/NaN dt would stall or reverse the sim clock.
+    #[arg(long, default_value_t = 1.0 / 60.0, value_parser = parse_script_dt)]
+    script_dt: f32,
+
+    /// Capture `--capture-frame` at this exact deterministic sim frame (0-based),
+    /// then exit — instead of the wall-clock `--capture-time` trigger. Intended
+    /// with `--input-script`, so captures at frames 0, 3, 6, … are reproducible
+    /// stills of a scripted run.
+    #[arg(long, requires = "capture_frame")]
+    capture_at_frame: Option<u64>,
+
     /// Start an HTTP control server on <--debug-bind>:<PORT> exposing
     /// POST /capture (image/png of the next frame), GET /state (runtime JSON),
     /// and POST /reload-source (network hot-reload for MLE games).
@@ -255,6 +319,17 @@ pub struct Args {
     /// not a dead background thread.
     #[arg(long, default_value = xreal::DEFAULT_ADDR)]
     xreal_addr: std::net::SocketAddr,
+}
+
+/// `--script-dt` must be a positive, finite timestep: a zero/NaN dt would stall
+/// the sim clock and a negative one would run it backwards, breaking the
+/// deterministic-playback contract.
+fn parse_script_dt(s: &str) -> Result<f32, String> {
+    let v: f32 = s.parse().map_err(|e| format!("{e}"))?;
+    if !v.is_finite() || v <= 0.0 {
+        return Err("must be a positive, finite timestep in seconds".into());
+    }
+    Ok(v)
 }
 
 /// `--stereo-ipd` must be a positive, finite world-unit distance: NaN/inf
@@ -594,6 +669,28 @@ pub fn run(args: Args) {
         std::process::exit(1);
     };
 
+    // Scripted deterministic input (docs/time-travel.md T6b). Parsed up front so
+    // a malformed script is a clean CLI error before any window/GL work. None
+    // (the default) leaves live input and the wall-clock capture trigger
+    // untouched.
+    let input_script: Option<HashMap<u64, Vec<RecordedInput>>> =
+        args.input_script.as_ref().map(|path| match parse_input_script(path) {
+            Ok(map) => map,
+            Err(e) => {
+                eprintln!("error: {e}");
+                std::process::exit(1);
+            }
+        });
+
+    // `--capture-at-frame` only names a *deterministic* sim frame when playback
+    // advances by a fixed dt — i.e. under `--input-script`. Without it the loop
+    // runs on wall-clock time, so "frame N" is not reproducible; refuse rather
+    // than silently capture a non-deterministic frame.
+    if args.capture_at_frame.is_some() && input_script.is_none() {
+        eprintln!("error: --capture-at-frame requires --input-script (its frame index is only deterministic under scripted fixed-dt playback)");
+        std::process::exit(1);
+    }
+
     // Optional debug control server. Runs on its own thread; the GL loop drains
     // its request channel once per frame (see below). None when --debug-port is
     // not given, so behavior is unchanged.
@@ -762,6 +859,14 @@ pub fn run(args: Args) {
 
         while !window.should_close() {
             let elapsed_time = start_time.elapsed().as_secs_f32();
+            // Scripted deterministic playback (docs/time-travel.md T6b): advance
+            // the game clock by a FIXED --script-dt this frame instead of
+            // wall-clock, so frame N is always the same sim state. Queued as a
+            // one-shot step (which the clock consumes in `frame()` below), making
+            // every rendered frame a single fixed dt regardless of real timing.
+            if input_script.is_some() {
+                clock.step(args.script_dt);
+            }
             // The frame time handed to the game. Pinning it (--fixed-time, or the
             // debug server's /time) makes the rendered pose deterministic — used
             // for reproducible captures / golden images. The capture trigger
@@ -914,6 +1019,19 @@ Escape again to quit"
             // (Windowed-only: the headless loop has no audio device.)
             while let Ok(token) = audio_rx.try_recv() {
                 game.audio_push_finished(token as i32);
+            }
+
+            // Scripted input (docs/time-travel.md T6b): feed this frame's events
+            // through the SAME `key_event` path the live GLFW handlers use, before
+            // tick, so this frame's tick sees the scripted key state.
+            if let Some(script) = &input_script {
+                if let Some(events) = script.get(&frame_count) {
+                    for ev in events {
+                        if let RecordedInput::Key { code, is_down } = ev {
+                            game.key_event(*code, *is_down);
+                        }
+                    }
+                }
             }
 
             game.tick(time.clone());
@@ -1192,7 +1310,14 @@ Escape again to quit"
             }
 
             if let Some(capture_path) = &args.capture_frame {
-                if elapsed_time >= args.capture_time {
+                // Shoot at an exact deterministic sim frame (--capture-at-frame,
+                // for scripted runs) or after --capture-time wall-clock seconds
+                // (the default, so assets have time to load).
+                let shoot = match args.capture_at_frame {
+                    Some(n) => frame_count == n,
+                    None => elapsed_time >= args.capture_time,
+                };
+                if shoot {
                     capture_framebuffer(
                         &gl,
                         fb_width as u32,
@@ -1234,4 +1359,50 @@ Escape again to quit"
     }
 
     game.quit();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_tmp(name: &str, contents: &str) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(name);
+        std::fs::File::create(&path)
+            .unwrap()
+            .write_all(contents.as_bytes())
+            .unwrap();
+        path
+    }
+
+    #[test]
+    fn parse_input_script_maps_frames_to_events() {
+        let path = write_tmp(
+            "functor-test-jump.script",
+            "# comment\n\n0  Right down   # hold right\n18 Up down\n18 A down\n71 Right up\n",
+        );
+        let map = parse_input_script(path.to_str().unwrap()).unwrap();
+        assert_eq!(map[&0].len(), 1);
+        assert!(matches!(
+            map[&0][0],
+            RecordedInput::Key { code, is_down: true } if code == InputKey::Right as i32
+        ));
+        // Two events on the same frame accumulate in order.
+        assert_eq!(map[&18].len(), 2);
+        assert!(matches!(
+            map[&18][0],
+            RecordedInput::Key { code, is_down: true } if code == InputKey::Up as i32
+        ));
+        assert!(matches!(map[&71][0], RecordedInput::Key { is_down: false, .. }));
+    }
+
+    #[test]
+    fn parse_input_script_rejects_malformed_lines() {
+        let bad = write_tmp("functor-test-bad.script", "0 Right\n");
+        assert!(parse_input_script(bad.to_str().unwrap()).is_err());
+        let bad_key = write_tmp("functor-test-badkey.script", "0 Nope down\n");
+        assert!(parse_input_script(bad_key.to_str().unwrap()).is_err());
+        let bad_dir = write_tmp("functor-test-baddir.script", "0 Right sideways\n");
+        assert!(parse_input_script(bad_dir.to_str().unwrap()).is_err());
+    }
 }


### PR DESCRIPTION
## T6b-3 — scripted-input capture (deterministic headless runs)

Drive a game through a fixed input sequence with no human, deterministically — so the **chasm demo is agent-verifiable**: `examples/mario` runs off the left platform, jumps, and lands on the right, captured headlessly.

- **`--input-script <FILE>`** — a text script, lines `<frame> <KeyName> <down|up>` (`#` comments ok), fed through the same `key_event` path the live handlers use, before each frame's `tick`.
- **`--script-dt <f32>`** (default 1/60) — fixed per-frame dt via the shared `GameClock`, so wall-clock is bypassed and frame N is always the same sim state (reproducible).
- **`--capture-at-frame <N>`** — shoot `--capture-frame` at an exact sim frame. Capturing at frames 0,3,6,… yields a reproducible GIF of the jump.
- **`examples/mario/jump.script`** — hold Right from frame 0, `Up` at frame 18 (grounded), release Right at 71: the 6.4-unit arc clears the 6.0 chasm.

All new behavior is guarded by `--input-script` (and `conflicts_with = fixed_time`), so live runs and the golden path are untouched.

### Verification
- **Captured the arc** (below): frame 0 mario on the left platform (x≈-5.9) → frame 42 airborne over the chasm → frame 69 landed on the right (x≈3.3). Cleared with no human input.
- `cargo test` green (202 common + 38 desktop, incl. 2 new parser tests); `--features strict` clean; wasm check + `--release` build clean; **goldens byte-identical**.
- Cross-engine `/xreview`: both engines, no Critical/High/Medium, both visually confirmed the arc; two Low (unchecked `--script-dt`; `--capture-at-frame` determinism guard) fixed.

### Scope / deferred
Live deterministic playback + capture only. The mario *ghost strobe* is deferred to the tweak-loop finale — it needs `forward_step_scene` sub-stepping (the coarse 8-division spacing can't integrate a velocity-arc faithfully). `--input-script` is windowed-only (capture needs GL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Visuals

![mario clearing the chasm](https://gist.githubusercontent.com/tommy-xr/627a837a84ff3a3bc54c7b0a35989ec2/raw/mario-jump.gif)

<sub>`mario` clearing the chasm — driven entirely by `--input-script`, captured headlessly and deterministically (no human input).</sub>

![jump sequence: left platform, airborne, landed](https://gist.githubusercontent.com/tommy-xr/627a837a84ff3a3bc54c7b0a35989ec2/raw/mario-jump-strip.png)
