### PR TITLE
feat(cli): route in-process runtime output through the event stream (UX pass PR-2a)

### DIFF
--- a/cli/src/commands/mle_project.rs
+++ b/cli/src/commands/mle_project.rs
@@ -164,6 +164,16 @@ impl MleProject {
         ];
         argv.extend(runner_args.iter().cloned());
         let runtime_args = functor_runtime_desktop::Args::parse_from(argv);
+
+        // Route the in-process runtime's output through the CLI's event stream
+        // instead of letting it `println!` raw lines (which would corrupt
+        // `--json` ndjson and bypass the renderer). The runtime emits typed
+        // `RuntimeEvent`s; we map each onto an `output::Event` and render it.
+        // Dependency direction stays clean: the CLI knows the runtime, never
+        // the reverse (see docs/cli-output.md).
+        functor_runtime_common::events::set_sink(Box::new(|ev| {
+            crate::output::emit(ev.into());
+        }));
         functor_runtime_desktop::run(runtime_args);
         Ok(())
     }

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -66,6 +66,60 @@ pub enum Event {
         #[serde(skip_serializing_if = "Option::is_none")]
         hint: Option<String>,
     },
+    /// The in-process runtime loaded and is about to render.
+    RuntimeReady,
+    /// A periodic frame-cost sample from the runtime's game loop. `frame_us` is
+    /// the total (tick + physics + draw); `budget_pct` is that against a 60 fps
+    /// budget.
+    FrameStats {
+        tick_us: f64,
+        draw_us: f64,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        frame_us: Option<f64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        budget_pct: Option<f64>,
+        over_n_frames: u32,
+    },
+    /// A `--capture-frame` PNG was written.
+    CaptureWritten { path: String },
+    /// A hot-reload settled (`ok` false = the edit was rejected; the old program
+    /// keeps running).
+    HotReload { ok: bool, message: String },
+    /// An asset failed to load; the runtime serves the fallback asset.
+    AssetError {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        path: Option<String>,
+        message: String,
+    },
+    /// The wasm dev-server told a connected page to reload (not emitted by the
+    /// native runtime; wired with the wasm serve path).
+    #[allow(dead_code)]
+    Reload,
+}
+
+impl From<functor_runtime_common::events::RuntimeEvent> for Event {
+    fn from(ev: functor_runtime_common::events::RuntimeEvent) -> Self {
+        use functor_runtime_common::events::RuntimeEvent as R;
+        match ev {
+            R::Ready => Event::RuntimeReady,
+            R::FrameStats {
+                tick_us,
+                draw_us,
+                frame_us,
+                budget_pct,
+                over_n_frames,
+            } => Event::FrameStats {
+                tick_us,
+                draw_us,
+                frame_us: Some(frame_us),
+                budget_pct: Some(budget_pct),
+                over_n_frames,
+            },
+            R::CaptureWritten { path } => Event::CaptureWritten { path },
+            R::HotReload { ok, message } => Event::HotReload { ok, message },
+            R::AssetError { path, message } => Event::AssetError { path, message },
+        }
+    }
 }
 
 impl Event {
@@ -73,7 +127,10 @@ impl Event {
     fn is_essential(&self) -> bool {
         matches!(
             self,
-            Event::Error { .. } | Event::Diagnostic { .. } | Event::CommandFinished { .. }
+            Event::Error { .. }
+                | Event::Diagnostic { .. }
+                | Event::CommandFinished { .. }
+                | Event::AssetError { .. }
         )
     }
 }
@@ -188,6 +245,49 @@ impl PlainRenderer {
                 }
                 out
             }
+            Event::RuntimeReady => vec![format!("{} running", "▸".cyan())],
+            Event::FrameStats {
+                tick_us,
+                draw_us,
+                frame_us,
+                budget_pct,
+                over_n_frames,
+            } => {
+                let mut s = format!("tick {tick_us:.1}µs, draw {draw_us:.1}µs");
+                if let Some(frame_us) = frame_us {
+                    s.push_str(&format!(", frame {frame_us:.1}µs"));
+                }
+                if let Some(budget_pct) = budget_pct {
+                    s.push_str(&format!(" ({budget_pct:.1}% of 60fps)"));
+                }
+                vec![format!(
+                    "{} {}",
+                    format!("stats/{over_n_frames}").dimmed(),
+                    s.dimmed()
+                )]
+            }
+            Event::CaptureWritten { path } => {
+                vec![format!("{} captured {}", "✓".green(), path)]
+            }
+            Event::HotReload { ok, message } => {
+                if *ok {
+                    vec![format!("{} {message}", "↻".cyan())]
+                } else {
+                    vec![format!("{}: {message}", "reload".yellow().bold())]
+                }
+            }
+            Event::AssetError { path, message } => {
+                let loc = match path {
+                    Some(p) => format!("{p}: "),
+                    None => String::new(),
+                };
+                vec![format!(
+                    "{}: {}{message}",
+                    "asset error".red().bold(),
+                    loc.dimmed()
+                )]
+            }
+            Event::Reload => vec![format!("{} reload", "↻".cyan())],
         }
     }
 }

--- a/docs/cli-output.md
+++ b/docs/cli-output.md
@@ -15,7 +15,7 @@ command logic ──emit(Event)──▶ ┌─ PlainRenderer  (human text; colo
 If you find yourself formatting the same fact in two places, the design is wrong: add or
 extend an `Event` and let the renderers present it.
 
-This is **PR-1 of a 3-PR pass**. See "What PR-1 does *not* do" at the bottom.
+This is a multi-PR pass. See **Phasing** at the bottom for what each PR adds.
 
 ## Where the stream goes
 
@@ -85,45 +85,89 @@ A build with a type error:
 {"type":"command_finished","ok":false,"duration_ms":4}
 ```
 
-### Reserved for PR-2 (runtime-side — not emitted yet)
+### Implemented in PR-2a (runtime-side — routed through the event sink)
 
-These come from the **in-process desktop runtime** (frame loop / hot-reload / asset load),
-which today still `println!`s directly. Routing them requires a runtime event-sink refactor
-(below) and lands in PR-2. Documented here so the schema is planned, not surprising:
+These come from the **in-process desktop runtime** (frame loop / hot-reload / asset load), which
+used to `println!` directly. PR-2a routes them through the runtime event sink (below), so under
+`--json` they are ndjson like everything else. Optional fields are omitted when absent.
 
-| `type`           | Fields                                                                 |
-| ---------------- | --------------------------------------------------------------------- |
-| `runtime_ready`  | —                                                                     |
-| `frame_stats`    | `tick_us`, `draw_us`, `frame_us`, `budget_pct`, `over_n_frames`       |
-| `capture_written`| `path` (string)                                                       |
-| `hot_reload`     | `ok` (bool), `message` (string)                                       |
-| `asset_error`    | `path` (string), `message` (string)                                   |
-| `reload`         | — (wasm page reload)                                                  |
+| `type`            | Fields                                                                           | Emitted when |
+| ----------------- | -------------------------------------------------------------------------------- | ------------ |
+| `runtime_ready`   | —                                                                                | the runtime loaded and is about to render |
+| `frame_stats`     | `tick_us`, `draw_us`, `frame_us`?, `budget_pct`?, `over_n_frames`                | every `over_n_frames` frames (300) |
+| `capture_written` | `path` (string)                                                                  | a `--capture-frame` PNG was written |
+| `hot_reload`      | `ok` (bool), `message` (string)                                                  | a hot-reload settled (`ok:false` = rejected edit; old program kept) |
+| `asset_error`     | `path` (string?), `message` (string)                                             | an asset failed to load (fallback served) |
+| `reload`          | —                                                                                | reserved for the wasm dev-server page reload (not emitted natively yet) |
 
-## Runtime-output routing — deferred to PR-2 (and why)
+`frame_stats` folds the runtime's per-frame `tick`/`physics`/`draw` cost into three numbers:
+`tick_us` and `draw_us` are the tick and draw averages; `frame_us` is the **total** (tick +
+physics + draw), and `budget_pct` is that total against a 60 fps (16.666 ms) budget. All are
+rounded to one decimal. `over_n_frames` is the averaging window (300). This is a per-window,
+**not** per-frame, emission — see the cadence note below.
 
-Post-#243 `functor run native` drives the desktop runtime **in the CLI's process**, and that
-runtime currently `println!`s its own lines (`[mle] avg over 300 frames…`, capture
-confirmations, asset-load errors, hot-reload notices) straight to stdout, **bypassing the
-renderer**. Under `--json` these raw lines would corrupt the ndjson stream.
+Example tail of `functor -d examples/lighting run native --json` (frame stats + capture):
 
-Fixing this is **explicitly out of scope for PR-1** because the clean fix is a runtime change,
-not a CLI change: give the runtime a structured event sink (a callback/channel the host passes
-in) so it *emits* `FrameStats`/`CaptureWritten`/`HotReload`/`AssetError` instead of printing,
-and the CLI renders them through the same stream. That keeps the functional-core / imperative-
-shell boundary honest and makes the runtime observable to the SDK too — but it touches
-`runtime/` crates and both producers, so it is its own reviewable PR.
+```json
+{"type":"runtime_ready"}
+{"type":"frame_stats","tick_us":16.4,"draw_us":163.8,"frame_us":180.3,"budget_pct":1.1,"over_n_frames":300}
+{"type":"capture_written","path":"/tmp/frame.png"}
+```
 
-Until then: `run`/`develop native` still print runtime lines raw on stdout. `build`, `push`,
-`run wasm` (dev server), and all CLI-side status are fully routed.
+## Runtime-output routing — the event sink (PR-2a)
+
+Post-#243 `functor run native` drives the desktop runtime **in the CLI's process**. That runtime
+used to `println!` its own lines (`[mle] avg over 300 frames…`, capture confirmations, asset-load
+errors, hot-reload notices) straight to stdout, **bypassing the renderer** — corrupting the ndjson
+stream under `--json`. PR-2a routes them through a structured sink.
+
+**The key constraint is dependency direction: `cli` depends on the runtime crates; the runtime
+crates must never depend on `cli`.** So the event type and the sink live in the runtime, and the
+CLI installs an adapter:
+
+- `functor_runtime_common::events` defines a small `RuntimeEvent` enum (`Ready`, `FrameStats`,
+  `CaptureWritten`, `HotReload`, `AssetError`) and a process-wide sink — a
+  `OnceLock<Box<dyn Fn(RuntimeEvent) + Send + Sync>>` with `set_sink` / `emit`. It lives in the
+  *common* crate (not `-desktop`) because asset-load errors are emitted from the shared asset
+  pipeline, which both shells use.
+- The desktop runtime (`mle_game.rs`, `run.rs`) calls `events::emit(RuntimeEvent::…)` at each site
+  that used to print. The frame loop's hot path (per-frame `tick`/`draw`) does **not** emit.
+- The CLI installs the sink once, right before it calls `functor_runtime_desktop::run(…)`:
+  `events::set_sink(Box::new(|ev| output::emit(ev.into())))`. `impl From<RuntimeEvent> for
+  output::Event` (in `cli/src/output.rs`) is the whole mapping — the one place a runtime fact
+  becomes a CLI event.
+
+This keeps the functional-core / imperative-shell boundary honest and makes the runtime observable
+to the SDK too, while `cli → runtime` stays the only dependency edge.
+
+**Non-blocking / cadence.** `emit` is a cheap `OnceLock` load plus a call to the installed `Fn`;
+no lock is taken in the runtime. The renderer locks stdout, but nothing emits on the per-frame hot
+path: `frame_stats` fires once per **300-frame window** (the pre-existing averaging cadence, ~5 s
+at 60 fps — one stdout write every 300 frames, identical to the old `println!`), and the rest are
+one-shot (ready, capture) or event-driven (hot-reload, asset error). So frame time and hot-reload
+latency are unaffected.
+
+**No sink installed** (wasm, tests, a bare runtime): `emit` drops routine notices and sends
+`AssetError` to stderr, so a caller that never opted in is never corrupted and asset failures stay
+visible where they were.
+
+**Everything else stays off stdout.** A few flag-gated runtime notices have no natural event —
+`--headless` mode, the `--debug-port` "listening on…" line, `--replay` "loaded N frames" — so they
+go to **stderr**, not the event stream. That keeps stdout pure ndjson under `--json` even for the
+`--debug-port` / `--headless` combos an SDK/automation consumer uses. (Interactive, TTY-only notices
+— cursor-release hints, Xreal tracking status — remain plain stdout lines; they only fire on a
+focused window with a real user, never on a piped/`--json`/captured run.)
 
 ## Phasing
 
-- **PR-1 (this):** the `Event` enum + `Renderer` trait + selection; `JsonRenderer` (ndjson)
-  and a plain `PlainRenderer` (no animation); retire the raw debug prints; fix the `--help`
-  wording; global `--json`/`--quiet`/`--no-color`.
-- **PR-2:** the ink-style human renderer (spinners, a live region above scrollback, grouped
-  styled sections) **and** the runtime event-sink routing above.
+- **PR-1:** the `Event` enum + `Renderer` trait + selection; `JsonRenderer` (ndjson) and a plain
+  `PlainRenderer` (no animation); retire the raw debug prints; fix the `--help` wording; global
+  `--json`/`--quiet`/`--no-color`.
+- **PR-2a (this):** route the in-process runtime output (frame stats, capture, hot-reload, asset
+  errors, ready) through the event sink above, so `run/develop native --json` is clean ndjson.
+  `PlainRenderer` prints the new events as plain lines; `JsonRenderer` serializes them. No TUI.
+- **PR-2b:** the ink-style human renderer (spinners, a live region above scrollback, a sticky
+  telemetry panel that consumes `frame_stats`, grouped styled sections). Builds on PR-2a's events.
 - **PR-3:** rich MLE diagnostics (source line + caret), actionable error hints, polish.
 </content>
 </invoke>

--- a/runtime/functor-runtime-common/src/asset/asset_handle.rs
+++ b/runtime/functor-runtime-common/src/asset/asset_handle.rs
@@ -80,13 +80,13 @@ impl<T> AssetState<T> {
             match Future::poll(Pin::new(&mut future), &mut cx) {
                 Poll::Ready(Ok(texture_data)) => AssetState::Loaded(texture_data),
                 Poll::Ready(Err(e)) => {
-                    eprintln!("Failed to load asset, using fallback: {}", e);
+                    crate::events::emit(crate::events::RuntimeEvent::AssetError {
+                        path: None,
+                        message: e,
+                    });
                     AssetState::Failed
                 }
-                Poll::Pending => {
-                    println!("Waiting for texture to load...");
-                    AssetState::Loading(future)
-                }
+                Poll::Pending => AssetState::Loading(future),
             }
         } else {
             self

--- a/runtime/functor-runtime-common/src/asset/pipelines/model_pipeline.rs
+++ b/runtime/functor-runtime-common/src/asset/pipelines/model_pipeline.rs
@@ -48,7 +48,6 @@ impl AssetPipeline<Model> for ModelPipeline {
                     let buffer = &buffers_data[view.buffer().index()];
                     let start = view.offset();
                     let end = start + view.length();
-                    println!("Random image loaded: {} {}", start, end);
                     let buf = buffer[start..end].to_vec();
                     let maybe_image = image::load_from_memory(&buf);
 
@@ -58,9 +57,8 @@ impl AssetPipeline<Model> for ModelPipeline {
                         TextureData::checkerboard_pattern(4, 4, [0, 255, 0, 255])
                     }
                 }
-                ImageSource::Uri { uri, .. } => {
+                ImageSource::Uri { .. } => {
                     // Manually resolve the image data
-                    println!("External image: {}", uri);
                     TextureData::checkerboard_pattern(4, 4, [0, 0, 255, 255])
                 }
             };
@@ -72,9 +70,7 @@ impl AssetPipeline<Model> for ModelPipeline {
         let mut maybe_skeleton: Option<Skeleton> = None;
 
         for scene in document.scenes() {
-            println!("Scene {}", scene.index());
             for node in scene.nodes() {
-                println!("- Node: {:?}", node.name());
                 process_node(
                     &node,
                     &buffers_data,
@@ -205,14 +201,6 @@ fn process_node(
             if tangents.is_empty() {
                 crate::geometry::compute_tangents(&mut vertices, &indices);
             }
-            println!(
-                "-- Mesh: {:?} vertices: {} indices: {} joints: {} weights: {}",
-                mesh.name(),
-                vertices.len(),
-                indices.len(),
-                joints.len(),
-                weights.len(),
-            );
 
             // Parse material
             let material = primitive.material();
@@ -384,8 +372,7 @@ fn process_animations(document: &gltf::Document, buffers: &[gltf::buffer::Data])
                     }
                 }
                 gltf::animation::util::ReadOutputs::MorphTargetWeights(_weights) => {
-                    // TODO:
-                    println!("WARN: ignoring morph target weights; not implemented");
+                    // TODO: morph target weights are not yet applied.
                     // for (i, weight) in weights.enumerate() {
                     //     let time = input_times[i];
                     //     keyframes.push(Keyframe {

--- a/runtime/functor-runtime-common/src/asset/renderable_asset.rs
+++ b/runtime/functor-runtime-common/src/asset/renderable_asset.rs
@@ -33,7 +33,6 @@ impl<T: RenderableAsset> RuntimeRenderableAsset<T> {
             let new_state = match asset_state {
                 RenderableAssetState::Hydrated(_) => asset_state,
                 RenderableAssetState::Dehydrated(asset, options) => {
-                    println!("Hydrating asset!");
                     RenderableAssetState::Hydrated(asset.hydrate(gl_context, &options))
                 }
             };

--- a/runtime/functor-runtime-common/src/events.rs
+++ b/runtime/functor-runtime-common/src/events.rs
@@ -1,0 +1,74 @@
+//! Runtime → shell event sink.
+//!
+//! The in-process desktop runtime (frame loop, hot-reload, asset load) used to
+//! `println!` its status straight to stdout, which corrupts the CLI's ndjson
+//! stream and bypasses its renderer. Instead it now emits a typed
+//! [`RuntimeEvent`] through a process-wide sink the shell installs once at
+//! startup ([`set_sink`]).
+//!
+//! **Dependency direction.** This type + sink live in the runtime crate; the
+//! `cli` crate (which depends on the runtime, never the reverse) installs an
+//! adapter that maps each `RuntimeEvent` onto its own `output::Event` and
+//! renders it. The runtime stays oblivious to the CLI — it only knows how to
+//! emit.
+//!
+//! **Non-blocking.** [`emit`] is a cheap `OnceLock` load plus a call to the
+//! installed `Fn` — no lock is taken here. The frame loop never emits on the
+//! hot path: only [`RuntimeEvent::FrameStats`] (every ~300 frames), one-shot
+//! lifecycle events, and error/reload notices flow through, so per-frame
+//! `tick`/`draw` cost is unaffected.
+
+use std::sync::OnceLock;
+
+/// A user-visible thing the runtime wants to say — the runtime-side mirror of
+/// the CLI's `output::Event`. The shell's sink maps these onto its own event
+/// schema (see `docs/cli-output.md`).
+#[derive(Debug, Clone)]
+pub enum RuntimeEvent {
+    /// The runtime is loaded and about to render its first frame.
+    Ready,
+    /// A periodic frame-cost sample, averaged over `over_n_frames` frames.
+    /// `frame_us` is the total (`tick + physics + draw`); `budget_pct` is that
+    /// total against a 60 fps (16.666 ms) budget.
+    FrameStats {
+        tick_us: f64,
+        draw_us: f64,
+        frame_us: f64,
+        budget_pct: f64,
+        over_n_frames: u32,
+    },
+    /// A `--capture-frame` PNG was written to `path`.
+    CaptureWritten { path: String },
+    /// A hot-reload attempt settled (`ok` false on a rejected edit; the old
+    /// program keeps running).
+    HotReload { ok: bool, message: String },
+    /// An asset failed to load; the runtime serves the fallback asset.
+    AssetError {
+        path: Option<String>,
+        message: String,
+    },
+}
+
+type Sink = Box<dyn Fn(RuntimeEvent) + Send + Sync>;
+
+static SINK: OnceLock<Sink> = OnceLock::new();
+
+/// Install the process-wide runtime event sink. Called once by the shell before
+/// the runtime starts; a second call is ignored (the first wins).
+pub fn set_sink(sink: Sink) {
+    let _ = SINK.set(sink);
+}
+
+/// Emit a runtime event to the installed sink. With no sink installed (wasm,
+/// tests, or a bare runtime), errors fall back to stderr and routine notices are
+/// dropped — so nothing corrupts a caller that never opted in.
+pub fn emit(event: RuntimeEvent) {
+    if let Some(sink) = SINK.get() {
+        sink(event);
+    } else if let RuntimeEvent::AssetError { path, message } = event {
+        match path {
+            Some(path) => eprintln!("Failed to load asset '{path}', using fallback: {message}"),
+            None => eprintln!("Failed to load asset, using fallback: {message}"),
+        }
+    }
+}

--- a/runtime/functor-runtime-common/src/lib.rs
+++ b/runtime/functor-runtime-common/src/lib.rs
@@ -53,6 +53,7 @@ pub mod asset;
 pub mod audio;
 mod camera;
 pub mod composite;
+pub mod events;
 pub mod fog;
 mod frame;
 mod frame_time;

--- a/runtime/functor-runtime-desktop/src/debug_server.rs
+++ b/runtime/functor-runtime-desktop/src/debug_server.rs
@@ -140,7 +140,9 @@ pub fn spawn(bind: &str, port: u16) -> Receiver<DebugRequest> {
             std::process::exit(1);
         }
     };
-    println!("[debug-server] listening on http://{}", addr);
+    // Stderr, not stdout: `--debug-port` is a common `--json` automation combo,
+    // so this notice must not land in the CLI's ndjson stream.
+    eprintln!("[debug-server] listening on http://{}", addr);
 
     thread::spawn(move || {
         for mut request in server.incoming_requests() {

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -33,6 +33,7 @@ use functor_runtime_common::mle_prelude::{
     audio_scene_of, clear_audio_completions, clear_http_taggers, frame_value, view_value,
     EffectLog, EffectRunner, EffectTree, FunctorHost, NetEventKind, RealEffects,
 };
+use functor_runtime_common::events::{self, RuntimeEvent};
 use functor_runtime_common::mle_producer::{forward_step_scene, FrameCtx, Reporter, SpanSource};
 use functor_runtime_common::physics;
 use functor_runtime_common::timetravel::SceneRecorder;
@@ -143,6 +144,12 @@ pub struct MleGame {
 }
 
 const STATS_EVERY: u64 = 300;
+
+/// Round a microsecond figure to one decimal, matching the old stats line's
+/// `{:.1}` precision so the reported numbers stay tidy across both renderers.
+fn round1(x: f64) -> f64 {
+    (x * 10.0).round() / 10.0
+}
 
 /// A successfully loaded, contract-validated game project.
 struct Loaded {
@@ -318,7 +325,6 @@ impl MleGame {
                 std::process::exit(1);
             }
         };
-        println!("[mle] loaded {path}");
         MleGame {
             path: path.to_string(),
             stamp,
@@ -445,11 +451,14 @@ impl MleGame {
             let tick_us = self.tick_ns as f64 / STATS_EVERY as f64 / 1000.0;
             let physics_us = self.physics_ns as f64 / STATS_EVERY as f64 / 1000.0;
             let draw_us = self.draw_ns as f64 / STATS_EVERY as f64 / 1000.0;
-            println!(
-                "[mle] avg over {STATS_EVERY} frames: tick {tick_us:.1}µs, physics \
-                 {physics_us:.1}µs, draw {draw_us:.1}µs ({:.1}% of a 60fps budget)",
-                (tick_us + physics_us + draw_us) / 16_666.0 * 100.0
-            );
+            let frame_us = tick_us + physics_us + draw_us;
+            events::emit(RuntimeEvent::FrameStats {
+                tick_us: round1(tick_us),
+                draw_us: round1(draw_us),
+                frame_us: round1(frame_us),
+                budget_pct: round1(frame_us / 16_666.0 * 100.0),
+                over_n_frames: STATS_EVERY as u32,
+            });
             self.tick_ns = 0;
             self.physics_ns = 0;
             self.draw_ns = 0;
@@ -495,17 +504,21 @@ impl Game for MleGame {
                 } else {
                     String::new()
                 };
-                println!(
-                    "[mle] hot-reloaded {} in {:.2}ms (model preserved{stored}; an edited \
+                events::emit(RuntimeEvent::HotReload {
+                    ok: true,
+                    message: format!(
+                        "hot-reloaded {} in {:.2}ms (model preserved{stored}; an edited \
 `init` takes effect on restart)",
-                    self.path,
-                    started.elapsed().as_secs_f64() * 1000.0
-                );
+                        self.path,
+                        started.elapsed().as_secs_f64() * 1000.0
+                    ),
+                });
             }
             Err(message) => {
-                self.reporter.report_once(format!(
-                    "[mle] reload failed, keeping old program: {message}"
-                ));
+                events::emit(RuntimeEvent::HotReload {
+                    ok: false,
+                    message: format!("reload failed, keeping old program: {message}"),
+                });
             }
         }
     }
@@ -538,7 +551,10 @@ impl Game for MleGame {
             self.path,
             started.elapsed().as_secs_f64() * 1000.0
         );
-        println!("[mle] {status}");
+        events::emit(RuntimeEvent::HotReload {
+            ok: true,
+            message: status.clone(),
+        });
         Ok(status)
     }
 

--- a/runtime/functor-runtime-desktop/src/replay_game.rs
+++ b/runtime/functor-runtime-desktop/src/replay_game.rs
@@ -44,7 +44,9 @@ impl ReplayGame {
         if frames.is_empty() {
             load_error(path, "the recording contains no frames".to_string());
         }
-        println!("[replay] loaded {} frame(s) from {path}", frames.len());
+        // Stderr, not stdout: keep the CLI's `--json` ndjson stream clean under
+        // `--replay` too.
+        eprintln!("[replay] loaded {} frame(s) from {path}", frames.len());
         ReplayGame {
             path: path.to_string(),
             frames,

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -8,7 +8,6 @@
 //! via `tokio::spawn`, so `run` must be invoked from within a tokio runtime
 //! context.
 
-use std::env;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -390,7 +389,11 @@ unsafe fn capture_framebuffer(gl: &glow::Context, width: u32, height: u32, path:
     let result = encode_framebuffer_png(gl, width, height)
         .and_then(|bytes| std::fs::write(path, bytes).map_err(|e| e.to_string()));
     match result {
-        Ok(()) => println!("Captured frame to {}", path),
+        Ok(()) => functor_runtime_common::events::emit(
+            functor_runtime_common::events::RuntimeEvent::CaptureWritten {
+                path: path.to_string(),
+            },
+        ),
         Err(e) => {
             eprintln!("Failed to capture frame to {}: {}", path, e);
             std::process::exit(1);
@@ -576,7 +579,9 @@ fn run_headless(
     debug_requests: Option<std::sync::mpsc::Receiver<debug_server::DebugRequest>>,
     fixed_time: Option<f32>,
 ) {
-    println!("[functor-runner] headless mode — no GL window; /capture unavailable");
+    // Stderr, not stdout: keep the CLI's `--json` ndjson stream (stdout) clean
+    // even under `--headless`. This is an out-of-band notice, not an event.
+    eprintln!("[runtime] headless mode — no GL window; /capture unavailable");
 
     let start_time = Instant::now();
     let mut last_time: f32 = 0.0;
@@ -651,8 +656,6 @@ pub fn run(args: Args) {
     // Load game
 
     let game_path = args.game_path.clone();
-    println!("Using game path: {}", game_path);
-    println!("Working directory: {:?}", env::current_dir());
 
     let mut game: Box<dyn Game> = if args.replay {
         Box::new(replay_game::ReplayGame::create(game_path.as_str()))
@@ -690,6 +693,11 @@ pub fn run(args: Args) {
         eprintln!("error: --capture-at-frame requires --input-script (its frame index is only deterministic under scripted fixed-dt playback)");
         std::process::exit(1);
     }
+
+    // The game loaded and validated (incl. any scripted-input parse); the runtime
+    // is up. One-shot lifecycle notice for the shell (replaces the old
+    // game-path/working-dir debug prints).
+    functor_runtime_common::events::emit(functor_runtime_common::events::RuntimeEvent::Ready);
 
     // Optional debug control server. Runs on its own thread; the GL loop drains
     // its request channel once per frame (see below). None when --debug-port is


### PR DESCRIPTION
**Follows PR-1 (#249, merged to main).** Authored stacked on #249 (`feat/cli-ux-1-event-stream`, the event-stream foundation); since #249 squash-merged, this is now rebased onto `main` and targets `main` directly. **PR-2b** — the ink-style live-region + sticky telemetry TUI — builds on the `frame_stats` / `runtime_ready` / `hot_reload` events this PR adds.

## What & why

Post-#243, `functor run native` drives the desktop runtime **in-process**, and that runtime `println!`d its status straight to stdout — the `[mle] avg over 300 frames…` frame stats, capture confirmations, asset-load errors, hot-reload notices, plus a pile of asset-pipeline debug scaffolding (`Hydrating asset!`, `Random image loaded`, `Scene N`, `- Node`, `-- Mesh`). That **corrupted the CLI's `--json` ndjson stream** and bypassed the renderer entirely.

This PR routes all of it through PR-1's event stream. **No TUI** — that's PR-2b (the live-region + sticky telemetry panel, which consumes these `frame_stats` events). Here the `PlainRenderer` just prints the new events as plain lines and the `JsonRenderer` serializes them.

## The sink mechanism (dependency direction is the constraint)

`cli` depends on the runtime crates; the runtime must **never** depend on `cli`. So:

- `functor_runtime_common::events` (new) defines a `RuntimeEvent` enum + a process-wide sink: `OnceLock<Box<dyn Fn(RuntimeEvent) + Send + Sync>>` with `set_sink` / `emit`. It lives in *common* (not `-desktop`) because asset-load errors are emitted from the shared asset pipeline.
- The desktop runtime (`mle_game.rs`, `run.rs`) and the asset pipeline call `events::emit(…)` at each site that used to print.
- The CLI installs the sink once, right before `functor_runtime_desktop::run(…)`, mapping each `RuntimeEvent` → `output::Event` via `impl From` (the one place a runtime fact becomes a CLI event), then `output::emit()`.

**Non-blocking:** `emit` is a cheap `OnceLock` load + a call to the installed `Fn`; nothing emits on the per-frame hot path. `frame_stats` fires once per **300-frame window** (the pre-existing averaging cadence — identical cost to the old `println!`), the rest are one-shot or event-driven. Frame time and hot-reload latency are unaffected.

**No sink installed** (wasm / tests / bare runtime): routine notices drop, `AssetError` falls back to stderr — a caller that never opted in is never corrupted.

## Events added

`runtime_ready`, `frame_stats{tick_us, draw_us, frame_us?, budget_pct?, over_n_frames}`, `capture_written{path}`, `hot_reload{ok, message}`, `asset_error{path?, message}`, `reload` (reserved for the wasm path). Schema documented in `docs/cli-output.md`.

## The headline proof — clean ndjson

`functor -d examples/lighting run native --json --fixed-time 2 --capture-frame … --capture-time 3`, every stdout line piped through a JSON validator → **zero raw lines** (before: the `[mle] avg…` stats + asset-pipeline debug were raw). Also verified: plain piped output has zero ANSI escapes; `capture_written` fires and the PNG is written; a `hot_reload` event fires on a file edit; `--headless --json --debug-port` (an automation combo) is also clean ndjson.

## Review

`/xreview` (Claude + Codex). Both **AGREED** on one Medium: flag-gated stdout notices (`--headless`, `--debug-port`'s "listening on…", `--replay`) still corrupted `--json` — fixed by routing those out-of-band notices to **stderr**. Remaining `println!`s are on stderr (don't touch stdout) or interactive-TTY-only (cursor / Xreal, never fire on a piped / captured run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
