### PR TITLE
feat(time-travel): F1 — sub-stepping in the forward-step (accurate velocity arcs)

### DIFF
--- a/runtime/functor-runtime-common/src/mle_producer.rs
+++ b/runtime/functor-runtime-common/src/mle_producer.rs
@@ -291,10 +291,15 @@ impl FrameCtx<'_> {
         }
     }
 
-    /// Deterministically step the whole scene forward `divisions` fixed frames
-    /// from the CURRENT ctx state, collecting the stepped `(model,
-    /// world-snapshot)` per division — the headless forward-step that feeds
-    /// forward-ghosting (docs/time-travel.md T6b). It runs the frame body MINUS
+    /// Deterministically step the whole scene forward from the CURRENT ctx
+    /// state, snapshotting the stepped `(model, world-snapshot)` at each of
+    /// `divisions` division boundaries — the headless forward-step that feeds
+    /// forward-ghosting (docs/time-travel.md T6b). To keep velocity-integrated
+    /// motion (e.g. `examples/mario`'s Euler-integrated jump) FAITHFUL, the sim
+    /// is advanced at a FINE `sub_dt` (`steps_per_division` sub-ticks per
+    /// snapshot) but sampled only at the boundaries: `divisions` snapshots,
+    /// `divisions * steps_per_division` fine ticks total, over a window of
+    /// `divisions * steps_per_division * sub_dt`. It runs the frame body MINUS
     /// the scrub-commit (starts at `subscriptions_and_tick`, never
     /// `before_physics`, so it can't branch the throwaway recorder) and MINUS
     /// `record_frame` (nothing is committed to live history).
@@ -304,9 +309,12 @@ impl FrameCtx<'_> {
     /// global queues), a deterministic runner, and `physics_rt` pointed at a
     /// throwaway world — so the live producer state stays untouched.
     ///
-    /// The forward-step computes its OWN division time (it does NOT read the
-    /// shell `GameClock`): division `i` runs `FrameTime { dts, tts = start_tts +
-    /// (i+1)*dts }`.
+    /// The forward-step computes its OWN fine-step time (it does NOT read the
+    /// shell `GameClock`): fine step `s` (the running counter across all
+    /// divisions) runs `FrameTime { dts: sub_dt, tts = start_tts +
+    /// (s+1)*sub_dt }`. A division boundary lands after `steps_per_division`
+    /// such steps, so division `div`'s snapshot has `tts = start_tts +
+    /// (div+1)*steps_per_division*sub_dt`.
     ///
     /// The determinism boundary — where the projected model diverges from a
     /// live continuation (the physics WORLD snapshot is always exact):
@@ -325,34 +333,44 @@ impl FrameCtx<'_> {
     ///   — a frame body that neither reads physics nor commands it — matches
     ///   exactly, model AND world.
     ///
-    /// `inputs` is the recorded input log for the divisions being stepped
-    /// (index `i` = division `i`'s events, i.e. fork frame `K + 1 + i`). At the
-    /// TOP of each division its recorded events are REPLAYED (mirroring the live
-    /// order — input arrives before `tick`) so a recorded jump replays. Beyond
-    /// the recorded window (`inputs` runs out) the step COASTS on held state.
+    /// `inputs` is the recorded input log, now indexed per FINE step (not per
+    /// division): index `s` = fine step `s`'s events, i.e. fork frame
+    /// `K + 1 + s` (each rendered frame is one fine step at `sub_dt = 1/60`). At
+    /// the TOP of each fine step its recorded events are REPLAYED (mirroring the
+    /// live order — input arrives before `tick`) so a recorded jump replays.
+    /// Beyond the recorded window (`inputs` runs out) the step COASTS on held
+    /// state.
     pub fn step_scene_forward(
         &mut self,
         divisions: usize,
-        dts: f32,
+        steps_per_division: usize,
+        sub_dt: f32,
         start_tts: f32,
         inputs: &[Vec<RecordedInput>],
     ) -> Vec<(Value, Option<Vec<u8>>)> {
         let mut out = Vec::with_capacity(divisions);
-        for i in 0..divisions {
-            // Replay this division's recorded inputs before the frame body, so
-            // the model absorbs them exactly as the live frame did (coast when
-            // the log has no entry for this division).
-            if let Some(events) = inputs.get(i) {
-                for event in events {
-                    self.replay_input(*event);
+        let mut step = 0usize;
+        for _div in 0..divisions {
+            for _ in 0..steps_per_division {
+                // Replay this fine step's recorded inputs before the frame body,
+                // so the model absorbs them exactly as the live frame did (coast
+                // when the log has no entry for this step).
+                if let Some(events) = inputs.get(step) {
+                    for event in events {
+                        self.replay_input(*event);
+                    }
                 }
+                let frame_time = FrameTime {
+                    dts: sub_dt,
+                    tts: start_tts + (step as f32 + 1.0) * sub_dt,
+                };
+                self.subscriptions_and_tick(frame_time);
+                self.physics_phase(frame_time);
+                step += 1;
             }
-            let frame_time = FrameTime {
-                dts,
-                tts: start_tts + (i as f32 + 1.0) * dts,
-            };
-            self.subscriptions_and_tick(frame_time);
-            self.physics_phase(frame_time);
+            // Snapshot only at the division boundary — the strobe still has
+            // `divisions` frames, but each is the result of accurate fine
+            // integration over `steps_per_division` sub-ticks.
             let world = if self.has_physics {
                 self.physics_rt.snapshot_world()
             } else {
@@ -695,8 +713,9 @@ impl Drop for DryWorld {
 /// runner, `suppress_outbound = true`, and (when the game has physics) a
 /// throwaway physics world seeded from a snapshot of the live
 /// [`physics::DEFAULT_WORLD`] driven by a fresh [`SteppedPhysics::for_world`]
-/// — then steps the scene forward `divisions` fixed frames, returning the
-/// stepped `(model, world-snapshot)` per division.
+/// — then steps the scene forward at the fine `sub_dt` (`steps_per_division`
+/// sub-ticks per snapshot), returning the stepped `(model, world-snapshot)` at
+/// each of the `divisions` division boundaries.
 ///
 /// The live producer state (model, world, recorder, clock, and the global
 /// effect / net / audio queues) is COMPLETELY untouched: the throwaway world
@@ -711,8 +730,9 @@ pub fn forward_step_scene(
     has_subscriptions: bool,
     prev_tts: Option<f64>,
     start_tts: f32,
-    dts: f32,
+    sub_dt: f32,
     divisions: usize,
+    steps_per_division: usize,
     inputs: &[Vec<RecordedInput>],
 ) -> Vec<(Value, Option<Vec<u8>>)> {
     // Dry-run physics: snapshot the live world and restore it into a fresh
@@ -778,7 +798,7 @@ pub fn forward_step_scene(
             suppress_outbound: true,
             reporter: &mut reporter,
         };
-        ctx.step_scene_forward(divisions, dts, start_tts, inputs)
+        ctx.step_scene_forward(divisions, steps_per_division, sub_dt, start_tts, inputs)
     };
 
     // `dry_world`'s `Drop` removes the throwaway world here (and on any unwind

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -577,23 +577,34 @@ impl Game for MleGame {
         self.recorder.current_scene_frame_tts()
     }
 
-    /// Forward-ghosting (docs/time-travel.md T6d): step the scene forward
-    /// `divisions` fixed frames of `dt` from `start_tts` (a dry run over
-    /// throwaway state — the live producer is untouched), then `draw` each
-    /// stepped model at its division time and return the frames for the shell to
-    /// composite. Division `i` draws at `tts = start_tts + (i+1)*dt`, matching
-    /// the time `forward_step_scene` stepped the model to. Each frame's camera is
-    /// overridden to the paused view (`last_frame.camera`) so only world motion
-    /// smears. A draw that errors or doesn't return a Frame is skipped, so the
-    /// result may be shorter than `divisions`.
+    /// Forward-ghosting (docs/time-travel.md T6d): step the scene forward over a
+    /// window of `divisions` divisions, each `dt` wide, from `start_tts` (a dry
+    /// run over throwaway state — the live producer is untouched), then `draw`
+    /// each stepped model at its division-boundary time and return the frames for
+    /// the shell to composite. To keep velocity-integrated motion (mario's jump)
+    /// faithful, each division is advanced in FINE `sub_dt = 1/60` sub-steps
+    /// (`steps_per_division ≈ dt / sub_dt`) and sampled only at the boundary, so
+    /// the strobe still has `divisions` frames but each is accurate integration.
+    /// Division `div` draws at `tts = start_tts + (div+1)*steps_per_division*sub_dt`,
+    /// matching the time `forward_step_scene` stepped the model to (the same f32
+    /// arithmetic). Each frame's camera is overridden to the paused view
+    /// (`last_frame.camera`) so only world motion smears. A draw that errors or
+    /// doesn't return a Frame is skipped, so the result may be shorter than
+    /// `divisions`.
     fn ghost_frames(&self, divisions: usize, dt: f32, start_tts: f64) -> Vec<Frame> {
         // Replay the recorded inputs for the frames AFTER the fork point K, so a
-        // recorded jump/run ghosts (docs/time-travel.md T6b). Beyond the recorded
-        // window the forward-step coasts on held state.
+        // recorded jump/run ghosts (docs/time-travel.md T6b). The input log is
+        // per-rendered-frame = per-fine-step (both 1/60), so it feeds the fine
+        // step index directly. Beyond the recorded window the step coasts.
         let inputs = match self.recorder.current_scene_frame() {
             Some(k) => self.recorder.inputs_from(k + 1),
             None => Vec::new(),
         };
+        // Fine sub-step at 1/60; round the division width to a whole number of
+        // sub-steps (≥1). At the default 8 divisions over a ~2s window that's
+        // dt = 0.25 → ~15 fine steps per division.
+        let sub_dt = 1.0f32 / 60.0;
+        let steps_per_division = ((dt / sub_dt).round() as usize).max(1);
         let stepped = forward_step_scene(
             &self.session,
             &self.model,
@@ -601,15 +612,17 @@ impl Game for MleGame {
             self.has_subscriptions,
             self.prev_tts,
             start_tts as f32,
-            dt,
+            sub_dt,
             divisions,
+            steps_per_division,
             &inputs,
         );
         let mut frames = Vec::with_capacity(stepped.len());
         for (i, (model_i, _world)) in stepped.iter().enumerate() {
-            // Match forward_step_scene's f32 division-time arithmetic exactly, so
+            // Match forward_step_scene's f32 division-boundary tts exactly, so
             // each redrawn frame's tts equals the tts its model was stepped at.
-            let tts = (start_tts as f32 + (i as f32 + 1.0) * dt) as f64;
+            let tts =
+                (start_tts as f32 + (i as f32 + 1.0) * steps_per_division as f32 * sub_dt) as f64;
             let args = vec![model_i.clone(), Value::Number(tts)];
             // A draw error or non-Frame return for a division is skipped, not fatal.
             if let Ok(value) = self.session.call("draw", args, &mut FunctorHost) {
@@ -1499,16 +1512,18 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// The deterministic headless forward-step (docs/time-travel.md T6b): from a
-    /// fork point, `forward_step_scene` steps the whole scene forward N frames
-    /// and produces EXACTLY the sequence a live run produces — model (`Value`
-    /// via `to_string`) and physics world (snapshot bytes) both byte-equal —
-    /// WITHOUT touching the live producer state. The game is pure (no `Now` /
-    /// unseeded `Random`): a ball falls onto a slab and a contact counter folds
-    /// through `update`, so both the model and the world genuinely evolve and
-    /// stay coupled. A game reading wall-clock `Now` / unseeded `Random` would
-    /// NOT match — the determinism boundary; a `tts`-driven / seeded game does,
-    /// since the forward-step supplies `tts`.
+    /// The deterministic SUB-STEPPED headless forward-step (docs/time-travel.md
+    /// T6b / F1): from a fork point, `forward_step_scene` steps the whole scene
+    /// forward at a fine `sub_dt = 1/60` (`STEPS_PER_DIV` sub-ticks per division)
+    /// and its DIVISION-BOUNDARY snapshots reproduce EXACTLY the sequence a fresh
+    /// 1/60 live continuation produces — model (`Value` via `to_string`) and
+    /// physics world (snapshot bytes) both byte-equal — WITHOUT touching the live
+    /// producer state. The game is pure (no `Now` / unseeded `Random`): a ball
+    /// falls onto a slab and a contact counter folds through `update`, so both
+    /// the model and the world genuinely evolve and stay coupled. A game reading
+    /// wall-clock `Now` / unseeded `Random` would NOT match — the determinism
+    /// boundary; a `tts`-driven / seeded game does, since the forward-step
+    /// supplies `tts`.
     #[test]
     fn forward_step_is_deterministic_and_non_destructive() {
         // The physics registry is a per-thread thread-local shared by every
@@ -1535,15 +1550,19 @@ mod tests {
         .expect("write game");
         let mut game = MleGame::create(dir.join("game.mle").to_str().expect("utf-8 path"));
 
-        const DT: f32 = physics::FIXED_DT;
+        // Fine sub-step at 1/60 (= FIXED_DT, so each fine tick is one physics
+        // step); the forward-step snapshots every STEPS_PER_DIV fine ticks.
+        const SUB_DT: f32 = physics::FIXED_DT;
         const K: usize = 45;
-        const N: usize = 25;
+        const DIVISIONS: usize = 5;
+        const STEPS_PER_DIV: usize = 5;
+        const N: usize = DIVISIONS * STEPS_PER_DIV; // total fine ticks in the window
 
         // Drive K frames to the fork point.
         let mut tts = 0.0f32;
         for _ in 0..K {
-            tts += DT;
-            game.tick(FrameTime { tts, dts: DT });
+            tts += SUB_DT;
+            game.tick(FrameTime { tts, dts: SUB_DT });
         }
 
         // Capture the fork state + a baseline of the live producer state.
@@ -1554,7 +1573,8 @@ mod tests {
         let live_world_before = physics::with_world(physics::DEFAULT_WORLD, |w| w.snapshot());
         let live_frame_before = game.physics_status.0;
 
-        // Forward-step N frames from the fork — a dry run over throwaway state.
+        // Forward-step DIVISIONS divisions (STEPS_PER_DIV fine ticks each) from
+        // the fork — a dry run over throwaway state.
         let forward = functor_runtime_common::mle_producer::forward_step_scene(
             &game.session,
             &fork_model,
@@ -1562,8 +1582,9 @@ mod tests {
             game.has_subscriptions,
             fork_prev_tts,
             fork_tts,
-            DT,
-            N,
+            SUB_DT,
+            DIVISIONS,
+            STEPS_PER_DIV,
             &[],
         );
 
@@ -1579,16 +1600,17 @@ mod tests {
             "live fixed frame untouched"
         );
 
-        // The live continuation: the ground truth the forward-step must match.
+        // The live continuation at 1/60: the ground truth the sub-stepped
+        // forward-step must match at its division boundaries.
         let mut live: Vec<(String, Option<Vec<u8>>)> = Vec::with_capacity(N);
         for _ in 0..N {
-            tts += DT;
-            game.tick(FrameTime { tts, dts: DT });
+            tts += SUB_DT;
+            game.tick(FrameTime { tts, dts: SUB_DT });
             let world = physics::with_world(physics::DEFAULT_WORLD, |w| w.snapshot());
             live.push((game.model.to_string(), world));
         }
 
-        assert_eq!(forward.len(), live.len(), "division count");
+        assert_eq!(forward.len(), DIVISIONS, "division count");
         // The scene genuinely evolves: the world moves across the window and the
         // ball lands (a Contact folds `hits` up through `update`).
         assert_ne!(live[0].1, live[N - 1].1, "world should move over the window");
@@ -1598,9 +1620,13 @@ mod tests {
             "the ball should have landed within the window: {}",
             game.model.to_string()
         );
-        for (i, ((fwd_m, fwd_w), (live_m, live_w))) in forward.iter().zip(live.iter()).enumerate() {
-            assert_eq!(fwd_m.to_string(), *live_m, "model diverged at division {i}");
-            assert_eq!(fwd_w, live_w, "world diverged at division {i}");
+        // Each forward DIVISION-BOUNDARY snapshot matches the live 1/60 frame at
+        // fine step (div+1)*STEPS_PER_DIV — proving the ARC is accurate at fine dt.
+        for (div, (fwd_m, fwd_w)) in forward.iter().enumerate() {
+            let live_idx = (div + 1) * STEPS_PER_DIV - 1;
+            let (live_m, live_w) = &live[live_idx];
+            assert_eq!(fwd_m.to_string(), *live_m, "model diverged at division {div}");
+            assert_eq!(fwd_w, live_w, "world diverged at division {div}");
         }
 
         physics::remove_world(physics::DEFAULT_WORLD);
@@ -1639,9 +1665,11 @@ mod tests {
         let mut game = MleGame::create(mario);
         assert!(!game.has_physics, "mario must have no physics hook");
 
-        const DT: f32 = 1.0 / 60.0;
+        const SUB_DT: f32 = 1.0 / 60.0; // fine sub-step (one rendered frame)
         const K: usize = 10; // pre-jump fork point (still running left of the edge)
-        const N: usize = 75; // continuation window: run to the edge, jump, land, run
+        const DIVISIONS: usize = 15;
+        const STEPS_PER_DIV: usize = 5;
+        const N: usize = DIVISIONS * STEPS_PER_DIV; // 75 fine frames: run to the edge, jump, land, run
 
         // Hold Right from the very first frame (a single key-down, then held).
         game.key_event(Key::Right as i32, true);
@@ -1649,8 +1677,8 @@ mod tests {
         // Phase 1: drive K frames of running to the fork point (pre-jump).
         let mut tts = 0.0f32;
         for _ in 0..K {
-            tts += DT;
-            game.tick(FrameTime { tts, dts: DT });
+            tts += SUB_DT;
+            game.tick(FrameTime { tts, dts: SUB_DT });
         }
         let fork_model = game.model.clone();
         let fork_prev_tts = game.prev_tts;
@@ -1669,13 +1697,13 @@ mod tests {
             // timing the jump at the edge). One press, gated on grounded.
             if !jumped
                 && field(&game.model, "grounded") == 1.0
-                && field(&game.model, "x") + (8.0 * DT as f64) >= -3.0
+                && field(&game.model, "x") + (8.0 * SUB_DT as f64) >= -3.0
             {
                 game.key_event(Key::Up as i32, true);
                 jumped = true;
             }
-            tts += DT;
-            game.tick(FrameTime { tts, dts: DT });
+            tts += SUB_DT;
+            game.tick(FrameTime { tts, dts: SUB_DT });
             live.push((field(&game.model, "x"), field(&game.model, "y")));
         }
         assert!(jumped, "the scripted jump must have fired");
@@ -1694,7 +1722,8 @@ mod tests {
             .count();
         assert_eq!(up_events, 1, "exactly one recorded jump");
 
-        // Forward-step from the PRE-JUMP fork, replaying the recorded inputs.
+        // Forward-step from the PRE-JUMP fork, replaying the recorded inputs,
+        // SUB-STEPPED at 1/60 (STEPS_PER_DIV fine ticks per division snapshot).
         let forward = functor_runtime_common::mle_producer::forward_step_scene(
             &game.session,
             &fork_model,
@@ -1702,23 +1731,28 @@ mod tests {
             game.has_subscriptions,
             fork_prev_tts,
             fork_tts,
-            DT,
-            N,
+            SUB_DT,
+            DIVISIONS,
+            STEPS_PER_DIV,
             &inputs,
         );
-        assert_eq!(forward.len(), live.len(), "division count");
+        assert_eq!(forward.len(), DIVISIONS, "division count");
 
-        // (a) The projected trajectory matches the live continuation division for
-        // division — the replayed jump reproduces the recorded arc exactly.
-        for (i, ((fwd_m, _w), (lx, ly))) in forward.iter().zip(live.iter()).enumerate() {
+        // (a) Each forward DIVISION-BOUNDARY snapshot matches the live 1/60 frame
+        // at fine step (div+1)*STEPS_PER_DIV — the replayed jump reproduces the
+        // recorded arc EXACTLY at fine dt (velocity-integrated jump projected
+        // faithfully, not coarsely).
+        for (div, (fwd_m, _w)) in forward.iter().enumerate() {
+            let live_idx = (div + 1) * STEPS_PER_DIV - 1;
+            let (lx, ly) = live[live_idx];
             assert!(
                 (field(fwd_m, "x") - lx).abs() < 1e-9,
-                "x diverged at division {i}: {} vs {lx}",
+                "x diverged at division {div}: {} vs {lx}",
                 field(fwd_m, "x")
             );
             assert!(
                 (field(fwd_m, "y") - ly).abs() < 1e-9,
-                "y diverged at division {i}: {} vs {ly}",
+                "y diverged at division {div}: {} vs {ly}",
                 field(fwd_m, "y")
             );
         }


### PR DESCRIPTION
First half of the finale. Sub-steps the deterministic forward-step at 1/60 (snapshotting at the 8 division boundaries) so velocity arcs like mario's jump integrate faithfully — coarse one-tick-per-division was fine for tts-driven `lighting` but wrong for `mario`. Determinism tests match a 1/60 live run (mario clears the chasm, 1e-9); `lighting` ghost + goldens byte-identical; strict + wasm clean. Cross-engine /xreview clean (Codex Medium — input log variable-dt vs fixed-1/60 replay — pre-existing, moot for the finale's script-replay). Next: F2 wires `--ghost`+`--input-script` for the tweak-a-constant demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)