### PR TITLE
feat(cli): live-region TUI + sticky telemetry panel (UX pass PR-2b)

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,6 +13,9 @@ path = "src/main.rs"
 mle = { path = "../mle" }
 clap = { version = "4.5.6", features = ["derive"] }
 colored = "2.1.0"
+# The ink-style live region: spinners + a sticky telemetry panel above
+# scrollback, on an interactive TTY only (see cli/src/output/live.rs).
+indicatif = "0.17"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.117"
 tokio = { version = "1", features = ["full"] }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -152,6 +152,19 @@ async fn main() -> tokio::io::Result<()> {
 
     output::init(args.json, args.quiet, args.no_color);
 
+    // When the live (ink-style) renderer is up, a Ctrl-C would otherwise kill
+    // the process mid-draw and leave the sticky live region stranded on screen.
+    // Arm a handler that wipes it and restores the terminal first. Only the live
+    // path is affected — the plain/json signal behavior is unchanged.
+    if output::live_active() {
+        tokio::spawn(async {
+            if tokio::signal::ctrl_c().await.is_ok() {
+                output::cleanup();
+                process::exit(130);
+            }
+        });
+    }
+
     // `inspect` is a DATA command: it prints a report (its own `--format
     // text|json` is its dual mode) to stdout, so it bypasses the event stream
     // to keep that stdout payload pure. It also runs before functor.json

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -7,10 +7,13 @@
 //! the schema and the renderer-selection rule.
 
 use std::io::{IsTerminal, Write};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::OnceLock;
 
 use colored::Colorize;
 use serde::Serialize;
+
+mod live;
 
 /// Diagnostic severity (an MLE check error is `Error`; `Warning` is reserved
 /// for the runtime's permissive dev-loop diagnostics routed later).
@@ -138,6 +141,11 @@ impl Event {
 /// One source of truth, two presentations.
 pub trait Renderer: Send + Sync {
     fn render(&self, event: &Event);
+
+    /// Restore the terminal (wipe any live region, show the cursor). A no-op for
+    /// the plain/json renderers; the live renderer overrides it. Invoked from
+    /// the panic hook and the Ctrl-C handler (see [`cleanup`]).
+    fn cleanup(&self) {}
 }
 
 /// ndjson: one compact JSON object per line, flushed. No color, ever.
@@ -301,6 +309,7 @@ fn format_duration(ms: u64) -> String {
 }
 
 static RENDERER: OnceLock<Box<dyn Renderer>> = OnceLock::new();
+static LIVE_ACTIVE: AtomicBool = AtomicBool::new(false);
 
 /// Select and install the process-wide renderer from the global flags +
 /// environment. Called once at startup, before any command logic runs. See
@@ -315,12 +324,47 @@ pub fn init(json: bool, quiet: bool, no_color: bool) {
         && !no_color;
     colored::control::set_override(color);
 
+    // The live (ink-style) renderer activates ONLY on an interactive, color-
+    // allowed TTY, and never under --quiet (which keeps its exact minimal plain
+    // output). Every machine-facing path — --json, --quiet, non-TTY, CI,
+    // NO_COLOR, --no-color — keeps the plain/json renderer, byte-for-byte.
     let renderer: Box<dyn Renderer> = if json {
         Box::new(JsonRenderer)
+    } else if quiet {
+        Box::new(PlainRenderer { quiet })
+    } else if color {
+        LIVE_ACTIVE.store(true, Ordering::Relaxed);
+        install_terminal_guard();
+        Box::new(live::LiveRenderer::new())
     } else {
         Box::new(PlainRenderer { quiet })
     };
     let _ = RENDERER.set(renderer);
+}
+
+/// True when the live renderer is installed. `main` uses this to arm a Ctrl-C
+/// handler that restores the terminal, without changing the (unchanged) signal
+/// behavior of the plain/json paths.
+pub fn live_active() -> bool {
+    LIVE_ACTIVE.load(Ordering::Relaxed)
+}
+
+/// Wipe the live region and restore the cursor. Idempotent and safe to call
+/// from a panic hook or a signal handler; a no-op for the plain/json renderers.
+pub fn cleanup() {
+    if let Some(renderer) = RENDERER.get() {
+        renderer.cleanup();
+    }
+}
+
+/// Chain a panic hook that restores the terminal before the default hook runs,
+/// so a panic mid-render never leaves a stuck live region / hidden cursor.
+fn install_terminal_guard() {
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        cleanup();
+        previous(info);
+    }));
 }
 
 /// Emit an event to the installed renderer. A no-op if [`init`] was never

--- a/cli/src/output/live.rs
+++ b/cli/src/output/live.rs
@@ -1,0 +1,306 @@
+//! The ink-style human renderer: a live region above stable scrollback.
+//!
+//! Selected only on an interactive TTY with color allowed (see
+//! [`super::init`]); every other path — `--json`, `--quiet`, non-TTY / piped /
+//! `CI` / `NO_COLOR` / `--no-color` — keeps the plain [`super::PlainRenderer`]
+//! or [`super::JsonRenderer`], byte-for-byte unchanged. So the machine-facing
+//! streams never see a spinner or a control char.
+//!
+//! Two behaviors, both driven by the same [`Event`] stream — no formatting is
+//! duplicated: finished/one-shot lines reuse [`super::PlainRenderer::lines`] and
+//! are committed to scrollback with [`MultiProgress::println`]; only the *live*
+//! bits (an in-flight phase spinner, and the sticky `run native` telemetry
+//! panel fed by `frame_stats`/`hot_reload`) are rendered here.
+//!
+//! 1. **`build` / `develop`:** the checking phase shows a braille spinner that
+//!    resolves to a stable `✓ checked …` line in scrollback.
+//! 2. **`run native`:** a sticky multi-line telemetry panel (fps / tick / draw /
+//!    frame / a budget bar / last hot-reload) pinned at the bottom, above
+//!    scrollback. It refreshes on each `frame_stats` event and stays *alive*
+//!    between them via indicatif's cheap `enable_steady_tick` (spinner +
+//!    elapsed) — no per-frame work is added to the game loop.
+
+use std::io::Write;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use colored::Colorize;
+use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
+
+use super::{Event, PlainRenderer, Renderer};
+
+/// One in-flight phase's frame-cost sample, kept so a hot-reload can redraw the
+/// panel immediately without waiting for the next `frame_stats`.
+#[derive(Clone, Copy)]
+struct Stats {
+    tick_us: f64,
+    draw_us: f64,
+    frame_us: Option<f64>,
+    budget_pct: Option<f64>,
+}
+
+/// The sticky `run native` telemetry panel.
+struct Panel {
+    bar: ProgressBar,
+    /// Wall-clock of the previous `frame_stats`, to measure real fps from the
+    /// frame count between two samples.
+    last_stats_at: Option<Instant>,
+    fps: Option<f64>,
+    stats: Option<Stats>,
+    last_reload: Option<String>,
+}
+
+impl Panel {
+    /// Rebuild the panel's message block from the latest stats + reload note.
+    fn refresh(&self) {
+        let mut lines: Vec<String> = Vec::new();
+        match self.stats {
+            Some(s) => {
+                let fps = match self.fps {
+                    Some(f) => format!("{f:.0}"),
+                    None => "—".to_string(),
+                };
+                let mut row = format!(
+                    "  fps {} · tick {} · draw {}",
+                    fps.bold(),
+                    format!("{:.0}µs", s.tick_us).cyan(),
+                    format!("{:.0}µs", s.draw_us).cyan(),
+                );
+                if let Some(frame_us) = s.frame_us {
+                    row.push_str(&format!(" · frame {}", format!("{frame_us:.0}µs").cyan()));
+                }
+                lines.push(row);
+                if let Some(pct) = s.budget_pct {
+                    lines.push(format!("  {}", budget_bar(pct)));
+                }
+            }
+            None => lines.push(format!("  {}", "warming up…".dimmed())),
+        }
+        if let Some(reload) = &self.last_reload {
+            lines.push(format!("  {} {}", "↻".cyan(), reload));
+        }
+        self.bar.set_message(lines.join("\n"));
+    }
+}
+
+/// A 20-cell budget bar for the frame's share of the 60 fps (16.7 ms) budget.
+/// Green under budget, yellow tight, red over.
+fn budget_bar(pct: f64) -> String {
+    const CELLS: usize = 20;
+    let filled = ((pct / 100.0) * CELLS as f64).round().clamp(0.0, CELLS as f64) as usize;
+    let bar = format!("{}{}", "█".repeat(filled), "░".repeat(CELLS - filled));
+    let bar = if pct >= 100.0 {
+        bar.red()
+    } else if pct >= 70.0 {
+        bar.yellow()
+    } else {
+        bar.green()
+    };
+    format!("[{bar}] {} of 16.7ms budget", format!("{pct:.0}%").dimmed())
+}
+
+struct Inner {
+    /// The in-flight phase spinner (checking), if any.
+    spinner: Option<ProgressBar>,
+    /// The sticky telemetry panel (`run native`), if any.
+    panel: Option<Panel>,
+    /// The project's basename, for the panel header.
+    project: Option<String>,
+}
+
+/// The ink-style renderer. `mp` (a cheap `Arc` handle) lives outside the lock so
+/// [`cleanup`](Self::cleanup) can wipe the live region from a panic hook /
+/// Ctrl-C handler without contending for `inner`.
+pub struct LiveRenderer {
+    mp: MultiProgress,
+    inner: Mutex<Inner>,
+}
+
+impl LiveRenderer {
+    pub fn new() -> Self {
+        // Draw to stdout to keep human output on one fd (as documented). On a
+        // non-terminal this target auto-degrades to a no-op, so it can never
+        // leak control chars — though selection already gates us to a TTY.
+        let mp = MultiProgress::with_draw_target(ProgressDrawTarget::stdout());
+        LiveRenderer {
+            mp,
+            inner: Mutex::new(Inner {
+                spinner: None,
+                panel: None,
+                project: None,
+            }),
+        }
+    }
+
+    /// Commit finished/one-shot lines to stable scrollback (above the live
+    /// bars). Reuses the plain renderer's formatting — the single source of
+    /// truth for how an event reads.
+    fn commit(&self, event: &Event) {
+        for line in PlainRenderer::lines(event) {
+            let _ = self.mp.println(line);
+        }
+    }
+
+    fn finish_spinner(inner: &mut Inner) {
+        if let Some(pb) = inner.spinner.take() {
+            pb.finish_and_clear();
+        }
+    }
+
+    fn clear_panel(inner: &mut Inner) {
+        if let Some(panel) = inner.panel.take() {
+            panel.bar.finish_and_clear();
+        }
+    }
+}
+
+impl Renderer for LiveRenderer {
+    fn render(&self, event: &Event) {
+        let mut inner = self.inner.lock().unwrap();
+        match event {
+            // The routed commands (build/run/develop) all typecheck first: show
+            // a checking spinner that resolves on `mle_loaded`. Other commands
+            // (push/init) have no build phase — just commit their line.
+            Event::CommandStarted {
+                command, project, ..
+            } => {
+                inner.project = project.as_ref().map(|p| basename(p));
+                if matches!(command.as_str(), "build" | "run" | "develop") {
+                    let pb = self.mp.add(phase_spinner());
+                    pb.set_message(format!(
+                        "checking {}",
+                        inner.project.as_deref().unwrap_or("project")
+                    ));
+                    pb.enable_steady_tick(Duration::from_millis(80));
+                    inner.spinner = Some(pb);
+                } else {
+                    self.commit(event);
+                }
+            }
+            // Checking resolved: drop the spinner, commit the stable ✓ line.
+            Event::MleLoaded { .. } => {
+                Self::finish_spinner(&mut inner);
+                self.commit(event);
+            }
+            // Native runtime is up: retire any spinner, raise the sticky panel.
+            Event::RuntimeReady => {
+                Self::finish_spinner(&mut inner);
+                let bar = self.mp.add(ProgressBar::new_spinner());
+                bar.set_style(panel_style());
+                bar.set_prefix(inner.project.clone().unwrap_or_default());
+                bar.enable_steady_tick(Duration::from_millis(120));
+                let panel = Panel {
+                    bar,
+                    last_stats_at: None,
+                    fps: None,
+                    stats: None,
+                    last_reload: None,
+                };
+                panel.refresh();
+                inner.panel = Some(panel);
+            }
+            Event::FrameStats {
+                tick_us,
+                draw_us,
+                frame_us,
+                budget_pct,
+                over_n_frames,
+            } => {
+                if let Some(panel) = inner.panel.as_mut() {
+                    let now = Instant::now();
+                    if let Some(prev) = panel.last_stats_at {
+                        let secs = now.duration_since(prev).as_secs_f64();
+                        if secs > 0.0 {
+                            panel.fps = Some(*over_n_frames as f64 / secs);
+                        }
+                    }
+                    panel.last_stats_at = Some(now);
+                    panel.stats = Some(Stats {
+                        tick_us: *tick_us,
+                        draw_us: *draw_us,
+                        frame_us: *frame_us,
+                        budget_pct: *budget_pct,
+                    });
+                    panel.refresh();
+                } else {
+                    // No panel (e.g. stats without a prior ready) — fall back to
+                    // a scrollback line rather than dropping the sample.
+                    self.commit(event);
+                }
+            }
+            // A hot-reload: record it on the panel (shown immediately) AND keep
+            // it in scrollback history.
+            Event::HotReload { message, .. } => {
+                if let Some(panel) = inner.panel.as_mut() {
+                    panel.last_reload = Some(message.clone());
+                    panel.refresh();
+                }
+                self.commit(event);
+            }
+            // A failed check/load or a fatal error: abandon the spinner, tear
+            // the panel down, and commit the diagnostic.
+            Event::Diagnostic { .. } => {
+                Self::finish_spinner(&mut inner);
+                self.commit(event);
+            }
+            Event::Error { .. } => {
+                Self::finish_spinner(&mut inner);
+                Self::clear_panel(&mut inner);
+                self.commit(event);
+            }
+            Event::CommandFinished { .. } => {
+                Self::finish_spinner(&mut inner);
+                Self::clear_panel(&mut inner);
+                self.commit(event);
+            }
+            // Everything else is a plain scrollback line (serving, info,
+            // warning, capture, asset error, reload).
+            _ => self.commit(event),
+        }
+    }
+
+    fn cleanup(&self) {
+        // Called from the panic hook / Ctrl-C handler: wipe the live region and
+        // (belt-and-suspenders) restore the cursor, so the terminal is never
+        // left mangled. No `inner` lock is taken (MultiProgress is internally
+        // synchronized), so this is safe even mid-render. Write the show-cursor
+        // escape to STDOUT — the same fd the live region draws to — so it lands
+        // on the terminal even when stderr is redirected, and never leaks a
+        // control byte into a captured stderr. Do it FIRST, so recovery does not
+        // depend on `clear()` returning.
+        {
+            let mut out = std::io::stdout().lock();
+            let _ = write!(out, "\x1b[?25h");
+            let _ = out.flush();
+        }
+        let _ = self.mp.clear();
+    }
+}
+
+/// A braille phase spinner (⠋⠙⠹…) in cyan.
+fn phase_spinner() -> ProgressBar {
+    let pb = ProgressBar::new_spinner();
+    pb.set_style(
+        ProgressStyle::with_template("{spinner:.cyan} {msg}")
+            .unwrap()
+            .tick_chars("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏ "),
+    );
+    pb
+}
+
+/// The sticky telemetry panel: a header line (animated spinner + elapsed) over a
+/// multi-line `{msg}` block of stats.
+fn panel_style() -> ProgressStyle {
+    ProgressStyle::with_template("{spinner:.green.bold} running {prefix:.bold} · {elapsed}\n{msg}")
+        .unwrap()
+        .tick_chars("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏⠋")
+}
+
+/// Last path component, for a compact project label.
+fn basename(path: &str) -> String {
+    path.rsplit(['/', '\\'])
+        .next()
+        .filter(|s| !s.is_empty())
+        .unwrap_or(path)
+        .to_string()
+}

--- a/docs/cli-output.md
+++ b/docs/cli-output.md
@@ -8,7 +8,8 @@ startup, turns that stream into either human-readable text or newline-delimited 
 as structured data.
 
 ```
-command logic ──emit(Event)──▶ ┌─ PlainRenderer  (human text; color on a TTY)
+command logic ──emit(Event)──▶ ┌─ LiveRenderer   (ink-style live region; interactive color TTY)
+                               ├─ PlainRenderer  (human text; --quiet / non-TTY / CI / NO_COLOR)
                                └─ JsonRenderer   (ndjson: one {type,…} object per line)
 ```
 
@@ -36,12 +37,24 @@ Selected once at startup from flags + environment:
 | ----------------------------------- | ---------------------------------------- | ----- |
 | `--json`                            | `JsonRenderer` — ndjson                   | never |
 | `--quiet`                           | `PlainRenderer`, minimal (errors + final status only) | per rule below |
-| stdout **not a TTY**, or `CI` set   | `PlainRenderer` — **plain text** (no ANSI) | off   |
-| interactive TTY (default)           | `PlainRenderer` — human text              | on    |
+| color allowed (interactive TTY, no `NO_COLOR`/`--no-color`/`CI`) | `LiveRenderer` — ink-style live region (PR-2b) | on |
+| otherwise (non-TTY / `CI` / `NO_COLOR` / `--no-color`) | `PlainRenderer` — **plain text** (no ANSI) | off |
 
 Color is enabled only when **stdout is a TTY** and `NO_COLOR` is unset and `--no-color` is
 not passed and `CI` is unset. `--json` never colors. This is enforced globally via
 `colored::control::set_override`, so a dumb terminal / pipe / `NO_COLOR` never leaks ANSI.
+
+The **`LiveRenderer`** (PR-2b, `cli/src/output/live.rs`) is the ink-style human path: an
+in-flight phase spinner that resolves to a stable `✓` line in scrollback, and — for
+`run native` — a sticky multi-line telemetry panel (fps / tick / draw / frame / a budget bar
+/ last hot-reload) pinned above scrollback, fed by `frame_stats`/`hot_reload`. It activates
+**only** on a color-allowed TTY and never under `--quiet`, so every machine-facing path
+(`--json`, `--quiet`, non-TTY, `CI`, `NO_COLOR`, `--no-color`) keeps the plain/json renderer
+byte-for-byte — no spinner or control char reaches a piped/CI/agent stream. It reuses
+`PlainRenderer::lines` for every committed line (no formatting is duplicated), animates via
+indicatif's cheap `enable_steady_tick` (never touching the game loop's hot path), and wipes
+the live region + restores the cursor on Ctrl-C (a `tokio::signal::ctrl_c` handler) and on
+panic (a chained panic hook).
 
 **Confirmed defaults:** non-TTY (piped/redirected) → **plain text**, *not* ndjson. `--json`
 is the explicit opt-in to ndjson. TTY detection uses `std::io::IsTerminal` (std, no dep).
@@ -166,8 +179,11 @@ focused window with a real user, never on a piped/`--json`/captured run.)
 - **PR-2a (this):** route the in-process runtime output (frame stats, capture, hot-reload, asset
   errors, ready) through the event sink above, so `run/develop native --json` is clean ndjson.
   `PlainRenderer` prints the new events as plain lines; `JsonRenderer` serializes them. No TUI.
-- **PR-2b:** the ink-style human renderer (spinners, a live region above scrollback, a sticky
-  telemetry panel that consumes `frame_stats`, grouped styled sections). Builds on PR-2a's events.
-- **PR-3:** rich MLE diagnostics (source line + caret), actionable error hints, polish.
+- **PR-2b (this):** the ink-style `LiveRenderer` — a phase spinner that resolves to a stable
+  `✓` line, and a sticky `run native` telemetry panel that consumes `frame_stats`/`hot_reload`,
+  above scrollback. TTY-only; the machine paths are untouched. (A full-screen `--dashboard` is
+  explicitly out of scope.)
+- **PR-3:** rich MLE diagnostics (source line + caret), actionable error hints, ASCII fallback
+  for dumb terminals, polish.
 </content>
 </invoke>


### PR DESCRIPTION
## What

**PR-2b of the CLI UX pass** — the ink-style **human** renderer: a live region above stable scrollback (Ink / cargo / vite style, **not** a full-screen TUI). Built on `indicatif` (MultiProgress + spinners + a sticky bottom section). Two behaviors, both driven by PR-2a's `Event` stream — no new event model, no duplicated formatting:

1. **`build` / `develop`** — an in-flight braille phase spinner (`⠋ checking primitives`) that resolves to a stable `✓ checked game.mle` line in scrollback.
2. **`run native` / `develop native`** — a **sticky multi-line telemetry panel** pinned above scrollback: fps · tick µs · draw µs · frame µs · a budget bar · last hot-reload — fed by the `frame_stats` and `hot_reload` events PR-2a routes.

```
⠸ running lighting · 4s
  fps 1076 · tick 14µs · draw 153µs · frame 167µs
  [░░░░░░░░░░░░░░░░░░░░] 1% of 16.7ms budget
  ↻ hot-reloaded game.mle in 2.20ms (model preserved; …)
```

A full-screen `--dashboard` is intentionally **out of scope**.

## Scope discipline — only the TTY human path changes

The live renderer is selected by the existing rule and activates **only on a color-allowed interactive TTY, never under `--quiet`**:

| condition (first match) | renderer |
| --- | --- |
| `--json` | `JsonRenderer` (ndjson) — unchanged |
| `--quiet` | `PlainRenderer{quiet}` — unchanged |
| color allowed (interactive TTY, no `NO_COLOR`/`--no-color`/`CI`) | **`LiveRenderer`** (new) |
| otherwise (non-TTY / `CI` / `NO_COLOR` / `--no-color`) | `PlainRenderer` — unchanged |

So `--json`, `--quiet`, non-TTY/piped/CI, and `NO_COLOR`/`--no-color` are **byte-for-byte unchanged** — PR-2a's clean-ndjson win does not regress. Verified: `build --json` and `run native --json` diff-identical to the base (modulo the `duration_ms` timing field); piped `build | cat -v` has zero ANSI; `NO_COLOR=1` / `--no-color` on a TTY stay plain.

## Design notes

- **Single-source formatting.** Committed scrollback lines reuse `PlainRenderer::lines` via `MultiProgress::println` — the `Event` enum stays the one source of truth. Only the *live* bits (phase spinner, sticky panel) are rendered in `live.rs`.
- **Liveliness without churn.** The panel stays alive **between** the ~5 s `frame_stats` windows via indicatif's cheap `enable_steady_tick` (spinner + elapsed). The runtime cadence is **unchanged** (300-frame window) — no added `--json` line volume, no per-frame hot-path cost. fps is measured in the renderer from the frame count between two `frame_stats` samples (honest, no runtime change).
- **Graceful cleanup.** The live region is wiped and the cursor restored on **Ctrl-C** (a `tokio::signal::ctrl_c` handler armed only in the live path) and on **panic** (a chained panic hook). The show-cursor escape writes to **stdout** (the draw target) so it lands even when stderr is redirected.

## Verification

- Headless guardrails re-run green: `build --json` valid ndjson / zero raw lines; `run native --json --capture-frame … --fixed-time 2 --capture-time 5` → zero raw lines, all events present, PNG written; `build | cat -v` zero ANSI; `--quiet` and `NO_COLOR`/`--no-color` unchanged.
- TTY captured under a PTY (macOS `script` + a `pty.spawn` harness): braille spinner animates and resolves to `✓`; the sticky panel shows live tick/draw/fps that update; Ctrl-C wipes the region and restores the cursor on stdout; hot-reload still snappy (~2.2 ms) and surfaces as both a scrollback `↻` line and the panel's "last reload".
- `cargo build --bin functor` clean; `functor-cli`, `functor_runtime_common` (202), `mle`, desktop lib (36) tests all pass.
- Reviewed with `/xreview` (Claude subagent + Codex): clean, no Critical/High. Both engines **agreed** the cursor-restore was written to the wrong fd (stderr vs the stdout draw target) — **fixed**. Codex's docs-diagram nit — **fixed**.

## Stacking

Stacked on **PR-2a (#252)**, which **squash-merged to `main`** during this work. Per plan, this PR is rebased **`--onto origin/main`** (dropping the merged base) and targets **`main`** directly — the diff is exactly the 5 PR-2b files.

**Next (PR-3, not in this PR):** rich MLE diagnostics (source-line + caret), actionable error hints, and an ASCII fallback for dumb terminals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
