### PR TITLE
feat(time-travel): F2 — forward-ghost a scripted jump (tweak-a-constant demo)

### DIFF
--- a/examples/mario/game.mle
+++ b/examples/mario/game.mle
@@ -30,7 +30,12 @@ let chasmHalf = 3.0       // gap spans x in [-chasmHalf, chasmHalf] -> width 6.0
 let leftEdge = -11.0      // outer x of the left platform
 let rightEdge = 11.0      // outer x of the right platform
 let startX = -6.0         // character spawn (on the left platform)
-let fallLimit = -15.0     // fall past this (into the chasm) and respawn
+let fallLimit = -2.0      // fall past this (into the chasm) and respawn.
+                          // Shallow on purpose: a weak jump that dips into the
+                          // gap respawns BEFORE its x reaches the right edge
+                          // (chasmHalf 3.0), so it visibly FALLS IN rather than
+                          // snapping up onto the far platform from below. The
+                          // default jump clears with y still above this line.
 
 // Character box half-extents (feet are at model.y; the box is drawn centered
 // half a height above).

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -136,8 +136,22 @@ pub trait GameProducer {
     /// composites the returned frames into one image (chronophotography), so
     /// moving elements smear into a strobe of their future positions. Each frame
     /// carries the *paused* camera so only world motion smears, not the view.
-    /// The default is empty (no ghosting) for producers without a model history.
-    fn ghost_frames(&self, _divisions: usize, _dt: f32, _start_tts: f64) -> Vec<crate::Frame> {
+    ///
+    /// `script_inputs` is the F2 forward-ghost-a-script mode (docs/time-travel.md
+    /// F2): when `Some`, the ghost forward-steps from the current live model (the
+    /// anchor) replaying THIS per-fine-step input slice instead of the recorder's
+    /// own input log — so editing a constant and hot-reloading re-renders the
+    /// scripted trajectory (the Bret-Victor "tweak a constant, see the arc" loop).
+    /// When `None`, the T6d behavior: replay the recorder's recorded inputs after
+    /// the fork point. The default is empty (no ghosting) for producers without a
+    /// model history.
+    fn ghost_frames(
+        &self,
+        _divisions: usize,
+        _dt: f32,
+        _start_tts: f64,
+        _script_inputs: Option<&[Vec<crate::RecordedInput>]>,
+    ) -> Vec<crate::Frame> {
         Vec::new()
     }
 

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -607,14 +607,35 @@ impl Game for MleGame {
     /// (`last_frame.camera`) so only world motion smears. A draw that errors or
     /// doesn't return a Frame is skipped, so the result may be shorter than
     /// `divisions`.
-    fn ghost_frames(&self, divisions: usize, dt: f32, start_tts: f64) -> Vec<Frame> {
+    ///
+    /// `script_inputs` selects the input source (docs/time-travel.md F2). When
+    /// `Some`, the ghost forward-steps from `self.model` (the live anchor — K is
+    /// NOT resolved from the recorder) replaying the caller-supplied SCRIPT slice,
+    /// so the strobe is the *scripted* trajectory under the current code. When
+    /// `None`, the T6d behavior: resolve K and replay the recorder's own log.
+    fn ghost_frames(
+        &self,
+        divisions: usize,
+        dt: f32,
+        start_tts: f64,
+        script_inputs: Option<&[Vec<functor_runtime_common::RecordedInput>]>,
+    ) -> Vec<Frame> {
         // Replay the recorded inputs for the frames AFTER the fork point K, so a
         // recorded jump/run ghosts (docs/time-travel.md T6b). The input log is
         // per-rendered-frame = per-fine-step (both 1/60), so it feeds the fine
-        // step index directly. Beyond the recorded window the step coasts.
-        let inputs = match self.recorder.current_scene_frame() {
-            Some(k) => self.recorder.inputs_from(k + 1),
-            None => Vec::new(),
+        // step index directly. Beyond the recorded window the step coasts. Under
+        // F2 (`script_inputs = Some`) the caller's per-fine-step script slice is
+        // used directly, forward-stepping from the current anchor model.
+        let recorded;
+        let inputs: &[Vec<functor_runtime_common::RecordedInput>] = match script_inputs {
+            Some(slice) => slice,
+            None => {
+                recorded = match self.recorder.current_scene_frame() {
+                    Some(k) => self.recorder.inputs_from(k + 1),
+                    None => Vec::new(),
+                };
+                &recorded
+            }
         };
         // Fine sub-step at 1/60; round the division width to a whole number of
         // sub-steps (≥1). At the default 8 divisions over a ~2s window that's

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -872,7 +872,11 @@ pub fn run(args: Args) {
             // wall-clock, so frame N is always the same sim state. Queued as a
             // one-shot step (which the clock consumes in `frame()` below), making
             // every rendered frame a single fixed dt regardless of real timing.
-            if input_script.is_some() {
+            // Under --ghost the script drives the GHOST, not the live game (F2,
+            // docs/time-travel.md): the live game stays at its init anchor, so
+            // don't fixed-step its clock — the ghost forward-step supplies the
+            // deterministic sub-dt itself.
+            if input_script.is_some() && !args.ghost {
                 clock.step(args.script_dt);
             }
             // The frame time handed to the game. Pinning it (--fixed-time, or the
@@ -1031,8 +1035,10 @@ Escape again to quit"
 
             // Scripted input (docs/time-travel.md T6b): feed this frame's events
             // through the SAME `key_event` path the live GLFW handlers use, before
-            // tick, so this frame's tick sees the scripted key state.
-            if let Some(script) = &input_script {
+            // tick, so this frame's tick sees the scripted key state. Under --ghost
+            // the script drives the GHOST instead (F2): leave the live game at its
+            // init anchor so the strobed arc reads against a clean, static pose.
+            if let Some(script) = input_script.as_ref().filter(|_| !args.ghost) {
                 if let Some(events) = script.get(&frame_count) {
                     for ev in events {
                         if let RecordedInput::Key { code, is_down } = ev {
@@ -1073,7 +1079,24 @@ Escape again to quit"
                 const MAX_GHOST: usize = 8;
                 let divisions = args.ghost_divisions.clamp(1, MAX_GHOST);
                 let dt = 2.0 / divisions as f32;
-                game.ghost_frames(divisions, dt, time.tts as f64)
+                // F2 (docs/time-travel.md): when an --input-script is loaded, the
+                // ghost previews the SCRIPT's trajectory from the live anchor
+                // (mario at init) rather than the recorder's own input log. Build a
+                // per-fine-step slice covering the ghost window (frame f → the
+                // script's events at f, empty when it has none). The fine step is
+                // 1/60 and script frames advance by 1/60, so the frame index maps
+                // straight to the fine-step index. `None` keeps the T6d behavior
+                // (e.g. the lighting ghost, which has no script).
+                let script_slice: Option<Vec<Vec<RecordedInput>>> =
+                    input_script.as_ref().map(|script| {
+                        let sub_dt = 1.0f32 / 60.0;
+                        let steps_per_division = ((dt / sub_dt).round() as usize).max(1);
+                        let total = (divisions * steps_per_division) as u64;
+                        (0..total)
+                            .map(|f| script.get(&f).cloned().unwrap_or_default())
+                            .collect()
+                    });
+                game.ghost_frames(divisions, dt, time.tts as f64, script_slice.as_deref())
             } else {
                 Vec::new()
             };


### PR DESCRIPTION
**The finale.** Stacked on #253 (F1). When `--ghost` runs with `--input-script`, the forward-ghost replays the SCRIPT from the **live model anchor** (mario at init) — the live game is not script-driven, so the anchor holds — and editing `jumpVelocity` + hot-reload re-renders the ghost under the new code. This delivers the **tweak-a-constant-until-the-jump-clears** demo without any cross-reload timeline re-derivation.

- `ghost_frames` gains `script_inputs: Option<&[Vec<RecordedInput>]>` (Some → replay the script from `self.model`; None → the existing recorded-log path). `run.rs` builds the per-fine-step script slice and gates the live-drive paths with `!args.ghost`.
- `examples/mario/game.mle`: `fallLimit` −15 → −2 so a weak jump actually **falls into the chasm** (decisiveness — before, run-speed carried mario across).

### Verification (agent-verifiable Bret-Victor)
Same script, one constant: **jumpVelocity 12 → the strobed arc clears the gap and lands on the right; jumpVelocity 9 → the arc drops into the chasm and mario respawns at the start.** (before/after below). Live version: edit `jumpVelocity` while running → the ghost re-renders under the new code.
- Mario forward-step determinism test still passes (default clears); byte-identical goldens (`--ghost`/`--input-script` opt-in); strict + wasm clean.
- Cross-engine /xreview: no Critical/High/Medium; visual confirmed decisive. One Low (duplicated fine-step math between run.rs and ghost_frames — in lockstep today, no defect) deferred as optional cleanup.

Completes the T6 time-travel arc: compositor → game clock → forward-step → input log → **tweak a constant, watch the ghost clear the chasm.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Visuals

![jumpVelocity 12 clears / jumpVelocity 9 misses](https://gist.githubusercontent.com/tommy-xr/f3c0cb56fb5bcad45910d97f77e12f34/raw/tweak.png)

<sub>Same `--input-script` jump, one constant changed: **jumpVelocity 12 clears** the chasm (arc lands on the right), **jumpVelocity 9 misses** (arc drops into the gap, mario respawns at the start). The forward-ghost strobe previews the trajectory; the live version re-renders on hot-reload.</sub>
