### PR TITLE
feat(time-travel): native egui ghost toggle + divisions/time controls

### DIFF
--- a/runtime/functor-runtime-common/src/mle_producer.rs
+++ b/runtime/functor-runtime-common/src/mle_producer.rs
@@ -30,8 +30,8 @@ use std::collections::HashSet;
 use mle::{line_col, project::SourceMap, RunError, Session, Span, Value};
 
 use crate::mle_prelude::{
-    contains_effect, deliver_physics_events, drain_effects, http_response_value, needs_update,
-    net_conn_subs, net_event_value, perform_deferred_queries, physics_event_taggers,
+    contains_effect, deliver_physics_events, drain_effects, frame_value, http_response_value,
+    needs_update, net_conn_subs, net_event_value, perform_deferred_queries, physics_event_taggers,
     physics_scene_value, split_model_effect, sub_messages_for_frame, take_audio_completion,
     take_http_tagger, EffectLog, EffectRunner, EffectTree, FakeEffects, FunctorHost, NetEventKind,
 };
@@ -39,7 +39,7 @@ use crate::input::{Key, RecordedInput};
 use crate::net::{push_conn_command, ConnCommand, HttpResult};
 use crate::physics::{self, PhysicsEvent, SteppedPhysics};
 use crate::timetravel::SceneRecorder;
-use crate::FrameTime;
+use crate::{Frame, FrameTime};
 
 /// Where a producer resolves per-frame error spans to `path:line:col: message`.
 /// The two shells hold their source differently (a multi-file project map on
@@ -805,4 +805,92 @@ pub fn forward_step_scene(
     // from the step above), leaving the registry as found.
     drop(dry_world);
     result
+}
+
+/// Forward-ghosting (docs/time-travel.md T6d): the shared producer body behind
+/// both shells' `GameProducer::ghost_frames`. Step the scene forward over a
+/// window of `divisions` divisions, each `dt` wide, from `start_tts` (a dry run
+/// over throwaway state via [`forward_step_scene`] — the live producer is
+/// untouched), then `draw` each stepped model at its division-boundary time and
+/// return the frames for the shell to composite. To keep velocity-integrated
+/// motion (mario's jump) faithful, each division is advanced in FINE
+/// `sub_dt = 1/60` sub-steps (`steps_per_division ≈ dt / sub_dt`) and sampled
+/// only at the boundary, so the strobe still has `divisions` frames but each is
+/// accurate integration. Division `div` draws at
+/// `tts = start_tts + (div+1)*steps_per_division*sub_dt`, matching the time
+/// `forward_step_scene` stepped the model to (the same f32 arithmetic). Each
+/// frame's camera is overridden to the paused view (`last_frame.camera`) so only
+/// world motion smears. A draw that errors or doesn't return a Frame is skipped,
+/// so the result may be shorter than `divisions`.
+///
+/// `script_inputs` selects the input source (docs/time-travel.md F2). When
+/// `Some`, the ghost forward-steps from `model` (the live anchor — K is NOT
+/// resolved from the recorder) replaying the caller-supplied SCRIPT slice, so the
+/// strobe is the *scripted* trajectory under the current code. When `None`, the
+/// T6d behavior: resolve K and replay the recorder's own log.
+#[allow(clippy::too_many_arguments)]
+pub fn ghost_frames(
+    session: &Session,
+    model: &Value,
+    recorder: &SceneRecorder,
+    has_physics: bool,
+    has_subscriptions: bool,
+    prev_tts: Option<f64>,
+    last_frame: &Frame,
+    divisions: usize,
+    dt: f32,
+    start_tts: f64,
+    script_inputs: Option<&[Vec<RecordedInput>]>,
+) -> Vec<Frame> {
+    // Replay the recorded inputs for the frames AFTER the fork point K, so a
+    // recorded jump/run ghosts (docs/time-travel.md T6b). The input log is
+    // per-rendered-frame = per-fine-step (both 1/60), so it feeds the fine
+    // step index directly. Beyond the recorded window the step coasts. Under
+    // F2 (`script_inputs = Some`) the caller's per-fine-step script slice is
+    // used directly, forward-stepping from the current anchor model.
+    let recorded;
+    let inputs: &[Vec<RecordedInput>] = match script_inputs {
+        Some(slice) => slice,
+        None => {
+            recorded = match recorder.current_scene_frame() {
+                Some(k) => recorder.inputs_from(k + 1),
+                None => Vec::new(),
+            };
+            &recorded
+        }
+    };
+    // Fine sub-step at 1/60; round the division width to a whole number of
+    // sub-steps (≥1). At the default 8 divisions over a ~2s window that's
+    // dt = 0.25 → ~15 fine steps per division.
+    let sub_dt = 1.0f32 / 60.0;
+    let steps_per_division = ((dt / sub_dt).round() as usize).max(1);
+    let stepped = forward_step_scene(
+        session,
+        model,
+        has_physics,
+        has_subscriptions,
+        prev_tts,
+        start_tts as f32,
+        sub_dt,
+        divisions,
+        steps_per_division,
+        inputs,
+    );
+    let mut frames = Vec::with_capacity(stepped.len());
+    for (i, (model_i, _world)) in stepped.iter().enumerate() {
+        // Match forward_step_scene's f32 division-boundary tts exactly, so
+        // each redrawn frame's tts equals the tts its model was stepped at.
+        let tts = (start_tts as f32 + (i as f32 + 1.0) * steps_per_division as f32 * sub_dt) as f64;
+        let args = vec![model_i.clone(), Value::Number(tts)];
+        // A draw error or non-Frame return for a division is skipped, not fatal.
+        if let Ok(value) = session.call("draw", args, &mut FunctorHost) {
+            if let Some(frame) = frame_value(&value) {
+                let mut frame = frame.clone();
+                // Freeze the view: composite only world motion, not the camera.
+                frame.camera = last_frame.camera.clone();
+                frames.push(frame);
+            }
+        }
+    }
+    frames
 }

--- a/runtime/functor-runtime-common/src/ui.rs
+++ b/runtime/functor-runtime-common/src/ui.rs
@@ -308,15 +308,29 @@ pub struct ScrubberState {
     /// until something is recorded (the slider is then hidden).
     pub range: Option<(u64, u64)>,
     pub paused: bool,
+    /// Forward-ghosting (docs/time-travel.md T6d) toggle: composite the ~window-s
+    /// future into a strobe. Interactive companion to the `--ghost` launch flag.
+    pub ghost_on: bool,
+    /// Divisions composited by the ghost (1..=8, the compositor `MAX_GHOST` cap).
+    pub ghost_divisions: usize,
+    /// The forward window in seconds; `dt = ghost_window / ghost_divisions`.
+    pub ghost_window: f32,
 }
 
 /// A control the user activated in the scrubber this frame.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+// No `Eq`: `SetGhostWindow` carries an `f32`.
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub enum ScrubberAction {
     TogglePause,
     /// Non-destructive scrub to a rendered frame (dragging the timeline).
     SeekTo(u64),
     Step,
+    /// Toggle forward-ghosting on/off (the `ghost` checkbox).
+    SetGhost(bool),
+    /// Set the ghost's forward divisions (clamped 1..=8 by the shell).
+    SetGhostDivisions(usize),
+    /// Set the ghost's forward window in seconds.
+    SetGhostWindow(f32),
 }
 
 /// The scrubber's output for one frame.
@@ -436,6 +450,36 @@ impl Scrubber {
                             }
                             if ui.button("Step >").clicked() {
                                 action = Some(ScrubberAction::Step);
+                            }
+
+                            // Forward-ghosting controls (docs/time-travel.md T6d):
+                            // an in-app companion to the `--ghost` launch flag.
+                            ui.separator();
+                            let mut ghost_on = state.ghost_on;
+                            if ui.checkbox(&mut ghost_on, "ghost").changed() {
+                                action = Some(ScrubberAction::SetGhost(ghost_on));
+                            }
+                            // Divisions (1..=8, the compositor MAX_GHOST cap) and
+                            // the forward window in seconds (dt = window / divisions).
+                            let mut divisions = state.ghost_divisions.clamp(1, 8);
+                            if ui
+                                .add(
+                                    egui::DragValue::new(&mut divisions)
+                                        .range(1..=8)
+                                        .prefix("÷"),
+                                )
+                                .changed()
+                            {
+                                action = Some(ScrubberAction::SetGhostDivisions(divisions));
+                            }
+                            let mut window = state.ghost_window;
+                            if ui
+                                .add(
+                                    egui::Slider::new(&mut window, 0.5..=5.0).suffix("s"),
+                                )
+                                .changed()
+                            {
+                                action = Some(ScrubberAction::SetGhostWindow(window));
                             }
                         });
                     });

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -34,7 +34,7 @@ use functor_runtime_common::mle_prelude::{
     EffectLog, EffectRunner, EffectTree, FunctorHost, NetEventKind, RealEffects,
 };
 use functor_runtime_common::events::{self, RuntimeEvent};
-use functor_runtime_common::mle_producer::{forward_step_scene, FrameCtx, Reporter, SpanSource};
+use functor_runtime_common::mle_producer::{FrameCtx, Reporter, SpanSource};
 use functor_runtime_common::physics;
 use functor_runtime_common::timetravel::SceneRecorder;
 use functor_runtime_common::ui::View;
@@ -620,58 +620,21 @@ impl Game for MleGame {
         start_tts: f64,
         script_inputs: Option<&[Vec<functor_runtime_common::RecordedInput>]>,
     ) -> Vec<Frame> {
-        // Replay the recorded inputs for the frames AFTER the fork point K, so a
-        // recorded jump/run ghosts (docs/time-travel.md T6b). The input log is
-        // per-rendered-frame = per-fine-step (both 1/60), so it feeds the fine
-        // step index directly. Beyond the recorded window the step coasts. Under
-        // F2 (`script_inputs = Some`) the caller's per-fine-step script slice is
-        // used directly, forward-stepping from the current anchor model.
-        let recorded;
-        let inputs: &[Vec<functor_runtime_common::RecordedInput>] = match script_inputs {
-            Some(slice) => slice,
-            None => {
-                recorded = match self.recorder.current_scene_frame() {
-                    Some(k) => self.recorder.inputs_from(k + 1),
-                    None => Vec::new(),
-                };
-                &recorded
-            }
-        };
-        // Fine sub-step at 1/60; round the division width to a whole number of
-        // sub-steps (≥1). At the default 8 divisions over a ~2s window that's
-        // dt = 0.25 → ~15 fine steps per division.
-        let sub_dt = 1.0f32 / 60.0;
-        let steps_per_division = ((dt / sub_dt).round() as usize).max(1);
-        let stepped = forward_step_scene(
+        // The body is shared (`mle_producer::ghost_frames`) so both shells ghost
+        // through one impl; this just hands it the producer's state.
+        functor_runtime_common::mle_producer::ghost_frames(
             &self.session,
             &self.model,
+            &self.recorder,
             self.has_physics,
             self.has_subscriptions,
             self.prev_tts,
-            start_tts as f32,
-            sub_dt,
+            &self.last_frame,
             divisions,
-            steps_per_division,
-            &inputs,
-        );
-        let mut frames = Vec::with_capacity(stepped.len());
-        for (i, (model_i, _world)) in stepped.iter().enumerate() {
-            // Match forward_step_scene's f32 division-boundary tts exactly, so
-            // each redrawn frame's tts equals the tts its model was stepped at.
-            let tts =
-                (start_tts as f32 + (i as f32 + 1.0) * steps_per_division as f32 * sub_dt) as f64;
-            let args = vec![model_i.clone(), Value::Number(tts)];
-            // A draw error or non-Frame return for a division is skipped, not fatal.
-            if let Ok(value) = self.session.call("draw", args, &mut FunctorHost) {
-                if let Some(frame) = frame_value(&value) {
-                    let mut frame = frame.clone();
-                    // Freeze the view: composite only world motion, not the camera.
-                    frame.camera = self.last_frame.camera.clone();
-                    frames.push(frame);
-                }
-            }
-        }
-        frames
+            dt,
+            start_tts,
+            script_inputs,
+        )
     }
 
     /// Non-destructive scrub — delegated to the shared [`SceneRecorder`]

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -788,6 +788,13 @@ pub fn run(args: Args) {
         // (it's a dev tool you summon with `~`, which also frees the cursor so
         // you can scrub right away). The wasm/vscode preview shows it always.
         let mut scrubber_visible = false;
+        // Forward-ghosting (docs/time-travel.md T6d) state, driven interactively
+        // from the scrubber overlay. Seeded from the launch flags so `--ghost`
+        // (the headless-capture escape hatch, overlay hidden) is unchanged; when
+        // the overlay is up, these vars take over (see the `ghost_active` gate).
+        let mut ghost_on = args.ghost;
+        let mut ghost_divisions = args.ghost_divisions;
+        let mut ghost_window: f32 = 2.0;
 
         gl.clear_color(0.1, 0.2, 0.3, 1.0);
 
@@ -1072,13 +1079,17 @@ Escape again to quit"
             // deterministically capturable under --fixed-time.
             // Gate on the full ladder condition so we don't pay the dry-run + N
             // draws only to have stereo / composite-demo outrank the ghost arm.
-            let ghost_frames = if args.ghost
+            // Drive the ghost from the interactive toggle when the overlay is up,
+            // and from the `--ghost` launch flag when it's hidden (the headless
+            // capture path — F2 demo, goldens, tests — is byte-for-byte unchanged).
+            let ghost_active = if scrubber_visible { ghost_on } else { args.ghost };
+            let ghost_frames = if ghost_active
                 && !args.stereo_sbs
                 && args.composite_demo == CompositeDemoArg::Off
             {
                 const MAX_GHOST: usize = 8;
-                let divisions = args.ghost_divisions.clamp(1, MAX_GHOST);
-                let dt = 2.0 / divisions as f32;
+                let divisions = ghost_divisions.clamp(1, MAX_GHOST);
+                let dt = ghost_window / divisions as f32;
                 // F2 (docs/time-travel.md): when an --input-script is loaded, the
                 // ghost previews the SCRIPT's trajectory from the live anchor
                 // (mario at init) rather than the recorder's own input log. Build a
@@ -1296,6 +1307,9 @@ Escape again to quit"
                         frame: game.current_scene_frame().unwrap_or(0),
                         range: game.scene_frame_range(),
                         paused: clock.is_paused(),
+                        ghost_on,
+                        ghost_divisions,
+                        ghost_window,
                     },
                 )
             } else {
@@ -1336,6 +1350,15 @@ Escape again to quit"
                 Some(functor_runtime_common::ui::ScrubberAction::Step) => {
                     // Step implies pause: advance exactly one frame, then hold.
                     clock.step(1.0 / 60.0);
+                }
+                Some(functor_runtime_common::ui::ScrubberAction::SetGhost(on)) => {
+                    ghost_on = on;
+                }
+                Some(functor_runtime_common::ui::ScrubberAction::SetGhostDivisions(n)) => {
+                    ghost_divisions = n.clamp(1, 8);
+                }
+                Some(functor_runtime_common::ui::ScrubberAction::SetGhostWindow(w)) => {
+                    ghost_window = w.clamp(0.5, 5.0);
                 }
                 None => {}
             }

--- a/runtime/functor-runtime-web/src/mle_game.rs
+++ b/runtime/functor-runtime-web/src/mle_game.rs
@@ -428,6 +428,32 @@ impl GameProducer for MleWebGame {
         self.recorder.current_scene_frame_tts()
     }
 
+    /// Forward-ghosting (docs/time-travel.md T6d) — delegated to the shared
+    /// producer body (`mle_producer::ghost_frames`), identical to the desktop
+    /// producer. Makes the web producer's ghost half available; the web RENDER
+    /// loop compositing them is a later slice.
+    fn ghost_frames(
+        &self,
+        divisions: usize,
+        dt: f32,
+        start_tts: f64,
+        script_inputs: Option<&[Vec<functor_runtime_common::RecordedInput>]>,
+    ) -> Vec<Frame> {
+        functor_runtime_common::mle_producer::ghost_frames(
+            &self.session,
+            &self.model,
+            &self.recorder,
+            self.has_physics,
+            self.has_subscriptions,
+            self.prev_tts,
+            &self.last_frame,
+            divisions,
+            dt,
+            start_tts,
+            script_inputs,
+        )
+    }
+
     fn tick(&mut self, frame_time: FrameTime) {
         // The whole MVU frame body lives in the shared `FrameCtx`
         // (docs/time-travel.md T6a). Web runs it as one call — unlike native it


### PR DESCRIPTION
Stacked on #256. Adds an in-app **ghost toggle + divisions + time** to the native egui scrubber overlay, replacing launch-only `--ghost` for interactive use.

- `ui.rs` `Scrubber`: a `ghost` checkbox + a divisions `DragValue` (1–8) + a window `Slider` (0.5–5s) after the Step button; new `ScrubberAction::SetGhost/SetGhostDivisions/SetGhostWindow` + `ScrubberState` fields.
- `run.rs`: loop-scope `ghost_on/ghost_divisions/ghost_window` (seeded from the flags), and the render gate is now `scrubber_visible ? ghost_on : args.ghost` — the **toggle drives it when the `~` overlay is up; the `--ghost` flag still forces it for headless capture** (F2 demo, goldens). `dt = window / divisions` (time now configurable, was hard-coded ~2s).

Verified: `--ghost` flag capture unchanged; byte-identical goldens; tests + strict + wasm clean. **The live toggle feel needs in-app testing** (egui clicks aren't scriptable).

Next slice: web ghosting + DOM toggle (the wasm/VSCode-preview target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)