### PR TITLE
feat(time-travel): web forward-ghosting + DOM ghost toggle

### DIFF
--- a/runtime/functor-runtime-common/src/mle_producer.rs
+++ b/runtime/functor-runtime-common/src/mle_producer.rs
@@ -30,8 +30,8 @@ use std::collections::HashSet;
 use mle::{line_col, project::SourceMap, RunError, Session, Span, Value};
 
 use crate::mle_prelude::{
-    contains_effect, deliver_physics_events, drain_effects, http_response_value, needs_update,
-    net_conn_subs, net_event_value, perform_deferred_queries, physics_event_taggers,
+    contains_effect, deliver_physics_events, drain_effects, frame_value, http_response_value,
+    needs_update, net_conn_subs, net_event_value, perform_deferred_queries, physics_event_taggers,
     physics_scene_value, split_model_effect, sub_messages_for_frame, take_audio_completion,
     take_http_tagger, EffectLog, EffectRunner, EffectTree, FakeEffects, FunctorHost, NetEventKind,
 };
@@ -39,7 +39,7 @@ use crate::input::{Key, RecordedInput};
 use crate::net::{push_conn_command, ConnCommand, HttpResult};
 use crate::physics::{self, PhysicsEvent, SteppedPhysics};
 use crate::timetravel::SceneRecorder;
-use crate::FrameTime;
+use crate::{Frame, FrameTime};
 
 /// Where a producer resolves per-frame error spans to `path:line:col: message`.
 /// The two shells hold their source differently (a multi-file project map on
@@ -805,4 +805,92 @@ pub fn forward_step_scene(
     // from the step above), leaving the registry as found.
     drop(dry_world);
     result
+}
+
+/// Forward-ghosting (docs/time-travel.md T6d): the shared producer body behind
+/// both shells' `GameProducer::ghost_frames`. Step the scene forward over a
+/// window of `divisions` divisions, each `dt` wide, from `start_tts` (a dry run
+/// over throwaway state via [`forward_step_scene`] — the live producer is
+/// untouched), then `draw` each stepped model at its division-boundary time and
+/// return the frames for the shell to composite. To keep velocity-integrated
+/// motion (mario's jump) faithful, each division is advanced in FINE
+/// `sub_dt = 1/60` sub-steps (`steps_per_division ≈ dt / sub_dt`) and sampled
+/// only at the boundary, so the strobe still has `divisions` frames but each is
+/// accurate integration. Division `div` draws at
+/// `tts = start_tts + (div+1)*steps_per_division*sub_dt`, matching the time
+/// `forward_step_scene` stepped the model to (the same f32 arithmetic). Each
+/// frame's camera is overridden to the paused view (`last_frame.camera`) so only
+/// world motion smears. A draw that errors or doesn't return a Frame is skipped,
+/// so the result may be shorter than `divisions`.
+///
+/// `script_inputs` selects the input source (docs/time-travel.md F2). When
+/// `Some`, the ghost forward-steps from `model` (the live anchor — K is NOT
+/// resolved from the recorder) replaying the caller-supplied SCRIPT slice, so the
+/// strobe is the *scripted* trajectory under the current code. When `None`, the
+/// T6d behavior: resolve K and replay the recorder's own log.
+#[allow(clippy::too_many_arguments)]
+pub fn ghost_frames(
+    session: &Session,
+    model: &Value,
+    recorder: &SceneRecorder,
+    has_physics: bool,
+    has_subscriptions: bool,
+    prev_tts: Option<f64>,
+    last_frame: &Frame,
+    divisions: usize,
+    dt: f32,
+    start_tts: f64,
+    script_inputs: Option<&[Vec<RecordedInput>]>,
+) -> Vec<Frame> {
+    // Replay the recorded inputs for the frames AFTER the fork point K, so a
+    // recorded jump/run ghosts (docs/time-travel.md T6b). The input log is
+    // per-rendered-frame = per-fine-step (both 1/60), so it feeds the fine
+    // step index directly. Beyond the recorded window the step coasts. Under
+    // F2 (`script_inputs = Some`) the caller's per-fine-step script slice is
+    // used directly, forward-stepping from the current anchor model.
+    let recorded;
+    let inputs: &[Vec<RecordedInput>] = match script_inputs {
+        Some(slice) => slice,
+        None => {
+            recorded = match recorder.current_scene_frame() {
+                Some(k) => recorder.inputs_from(k + 1),
+                None => Vec::new(),
+            };
+            &recorded
+        }
+    };
+    // Fine sub-step at 1/60; round the division width to a whole number of
+    // sub-steps (≥1). At the default 8 divisions over a ~2s window that's
+    // dt = 0.25 → ~15 fine steps per division.
+    let sub_dt = 1.0f32 / 60.0;
+    let steps_per_division = ((dt / sub_dt).round() as usize).max(1);
+    let stepped = forward_step_scene(
+        session,
+        model,
+        has_physics,
+        has_subscriptions,
+        prev_tts,
+        start_tts as f32,
+        sub_dt,
+        divisions,
+        steps_per_division,
+        inputs,
+    );
+    let mut frames = Vec::with_capacity(stepped.len());
+    for (i, (model_i, _world)) in stepped.iter().enumerate() {
+        // Match forward_step_scene's f32 division-boundary tts exactly, so
+        // each redrawn frame's tts equals the tts its model was stepped at.
+        let tts = (start_tts as f32 + (i as f32 + 1.0) * steps_per_division as f32 * sub_dt) as f64;
+        let args = vec![model_i.clone(), Value::Number(tts)];
+        // A draw error or non-Frame return for a division is skipped, not fatal.
+        if let Ok(value) = session.call("draw", args, &mut FunctorHost) {
+            if let Some(frame) = frame_value(&value) {
+                let mut frame = frame.clone();
+                // Freeze the view: composite only world motion, not the camera.
+                frame.camera = last_frame.camera.clone();
+                frames.push(frame);
+            }
+        }
+    }
+    frames
 }

--- a/runtime/functor-runtime-common/src/ui.rs
+++ b/runtime/functor-runtime-common/src/ui.rs
@@ -308,15 +308,29 @@ pub struct ScrubberState {
     /// until something is recorded (the slider is then hidden).
     pub range: Option<(u64, u64)>,
     pub paused: bool,
+    /// Forward-ghosting (docs/time-travel.md T6d) toggle: composite the ~window-s
+    /// future into a strobe. Interactive companion to the `--ghost` launch flag.
+    pub ghost_on: bool,
+    /// Divisions composited by the ghost (1..=8, the compositor `MAX_GHOST` cap).
+    pub ghost_divisions: usize,
+    /// The forward window in seconds; `dt = ghost_window / ghost_divisions`.
+    pub ghost_window: f32,
 }
 
 /// A control the user activated in the scrubber this frame.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+// No `Eq`: `SetGhostWindow` carries an `f32`.
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub enum ScrubberAction {
     TogglePause,
     /// Non-destructive scrub to a rendered frame (dragging the timeline).
     SeekTo(u64),
     Step,
+    /// Toggle forward-ghosting on/off (the `ghost` checkbox).
+    SetGhost(bool),
+    /// Set the ghost's forward divisions (clamped 1..=8 by the shell).
+    SetGhostDivisions(usize),
+    /// Set the ghost's forward window in seconds.
+    SetGhostWindow(f32),
 }
 
 /// The scrubber's output for one frame.
@@ -436,6 +450,36 @@ impl Scrubber {
                             }
                             if ui.button("Step >").clicked() {
                                 action = Some(ScrubberAction::Step);
+                            }
+
+                            // Forward-ghosting controls (docs/time-travel.md T6d):
+                            // an in-app companion to the `--ghost` launch flag.
+                            ui.separator();
+                            let mut ghost_on = state.ghost_on;
+                            if ui.checkbox(&mut ghost_on, "ghost").changed() {
+                                action = Some(ScrubberAction::SetGhost(ghost_on));
+                            }
+                            // Divisions (1..=8, the compositor MAX_GHOST cap) and
+                            // the forward window in seconds (dt = window / divisions).
+                            let mut divisions = state.ghost_divisions.clamp(1, 8);
+                            if ui
+                                .add(
+                                    egui::DragValue::new(&mut divisions)
+                                        .range(1..=8)
+                                        .prefix("÷"),
+                                )
+                                .changed()
+                            {
+                                action = Some(ScrubberAction::SetGhostDivisions(divisions));
+                            }
+                            let mut window = state.ghost_window;
+                            if ui
+                                .add(
+                                    egui::Slider::new(&mut window, 0.5..=5.0).suffix("s"),
+                                )
+                                .changed()
+                            {
+                                action = Some(ScrubberAction::SetGhostWindow(window));
                             }
                         });
                     });

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -34,7 +34,7 @@ use functor_runtime_common::mle_prelude::{
     EffectLog, EffectRunner, EffectTree, FunctorHost, NetEventKind, RealEffects,
 };
 use functor_runtime_common::events::{self, RuntimeEvent};
-use functor_runtime_common::mle_producer::{forward_step_scene, FrameCtx, Reporter, SpanSource};
+use functor_runtime_common::mle_producer::{FrameCtx, Reporter, SpanSource};
 use functor_runtime_common::physics;
 use functor_runtime_common::timetravel::SceneRecorder;
 use functor_runtime_common::ui::View;
@@ -620,58 +620,21 @@ impl Game for MleGame {
         start_tts: f64,
         script_inputs: Option<&[Vec<functor_runtime_common::RecordedInput>]>,
     ) -> Vec<Frame> {
-        // Replay the recorded inputs for the frames AFTER the fork point K, so a
-        // recorded jump/run ghosts (docs/time-travel.md T6b). The input log is
-        // per-rendered-frame = per-fine-step (both 1/60), so it feeds the fine
-        // step index directly. Beyond the recorded window the step coasts. Under
-        // F2 (`script_inputs = Some`) the caller's per-fine-step script slice is
-        // used directly, forward-stepping from the current anchor model.
-        let recorded;
-        let inputs: &[Vec<functor_runtime_common::RecordedInput>] = match script_inputs {
-            Some(slice) => slice,
-            None => {
-                recorded = match self.recorder.current_scene_frame() {
-                    Some(k) => self.recorder.inputs_from(k + 1),
-                    None => Vec::new(),
-                };
-                &recorded
-            }
-        };
-        // Fine sub-step at 1/60; round the division width to a whole number of
-        // sub-steps (≥1). At the default 8 divisions over a ~2s window that's
-        // dt = 0.25 → ~15 fine steps per division.
-        let sub_dt = 1.0f32 / 60.0;
-        let steps_per_division = ((dt / sub_dt).round() as usize).max(1);
-        let stepped = forward_step_scene(
+        // The body is shared (`mle_producer::ghost_frames`) so both shells ghost
+        // through one impl; this just hands it the producer's state.
+        functor_runtime_common::mle_producer::ghost_frames(
             &self.session,
             &self.model,
+            &self.recorder,
             self.has_physics,
             self.has_subscriptions,
             self.prev_tts,
-            start_tts as f32,
-            sub_dt,
+            &self.last_frame,
             divisions,
-            steps_per_division,
-            &inputs,
-        );
-        let mut frames = Vec::with_capacity(stepped.len());
-        for (i, (model_i, _world)) in stepped.iter().enumerate() {
-            // Match forward_step_scene's f32 division-boundary tts exactly, so
-            // each redrawn frame's tts equals the tts its model was stepped at.
-            let tts =
-                (start_tts as f32 + (i as f32 + 1.0) * steps_per_division as f32 * sub_dt) as f64;
-            let args = vec![model_i.clone(), Value::Number(tts)];
-            // A draw error or non-Frame return for a division is skipped, not fatal.
-            if let Ok(value) = self.session.call("draw", args, &mut FunctorHost) {
-                if let Some(frame) = frame_value(&value) {
-                    let mut frame = frame.clone();
-                    // Freeze the view: composite only world motion, not the camera.
-                    frame.camera = self.last_frame.camera.clone();
-                    frames.push(frame);
-                }
-            }
-        }
-        frames
+            dt,
+            start_tts,
+            script_inputs,
+        )
     }
 
     /// Non-destructive scrub — delegated to the shared [`SceneRecorder`]

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -788,6 +788,13 @@ pub fn run(args: Args) {
         // (it's a dev tool you summon with `~`, which also frees the cursor so
         // you can scrub right away). The wasm/vscode preview shows it always.
         let mut scrubber_visible = false;
+        // Forward-ghosting (docs/time-travel.md T6d) state, driven interactively
+        // from the scrubber overlay. Seeded from the launch flags so `--ghost`
+        // (the headless-capture escape hatch, overlay hidden) is unchanged; when
+        // the overlay is up, these vars take over (see the `ghost_active` gate).
+        let mut ghost_on = args.ghost;
+        let mut ghost_divisions = args.ghost_divisions;
+        let mut ghost_window: f32 = 2.0;
 
         gl.clear_color(0.1, 0.2, 0.3, 1.0);
 
@@ -1072,13 +1079,17 @@ Escape again to quit"
             // deterministically capturable under --fixed-time.
             // Gate on the full ladder condition so we don't pay the dry-run + N
             // draws only to have stereo / composite-demo outrank the ghost arm.
-            let ghost_frames = if args.ghost
+            // Drive the ghost from the interactive toggle when the overlay is up,
+            // and from the `--ghost` launch flag when it's hidden (the headless
+            // capture path — F2 demo, goldens, tests — is byte-for-byte unchanged).
+            let ghost_active = if scrubber_visible { ghost_on } else { args.ghost };
+            let ghost_frames = if ghost_active
                 && !args.stereo_sbs
                 && args.composite_demo == CompositeDemoArg::Off
             {
                 const MAX_GHOST: usize = 8;
-                let divisions = args.ghost_divisions.clamp(1, MAX_GHOST);
-                let dt = 2.0 / divisions as f32;
+                let divisions = ghost_divisions.clamp(1, MAX_GHOST);
+                let dt = ghost_window / divisions as f32;
                 // F2 (docs/time-travel.md): when an --input-script is loaded, the
                 // ghost previews the SCRIPT's trajectory from the live anchor
                 // (mario at init) rather than the recorder's own input log. Build a
@@ -1296,6 +1307,9 @@ Escape again to quit"
                         frame: game.current_scene_frame().unwrap_or(0),
                         range: game.scene_frame_range(),
                         paused: clock.is_paused(),
+                        ghost_on,
+                        ghost_divisions,
+                        ghost_window,
                     },
                 )
             } else {
@@ -1336,6 +1350,15 @@ Escape again to quit"
                 Some(functor_runtime_common::ui::ScrubberAction::Step) => {
                     // Step implies pause: advance exactly one frame, then hold.
                     clock.step(1.0 / 60.0);
+                }
+                Some(functor_runtime_common::ui::ScrubberAction::SetGhost(on)) => {
+                    ghost_on = on;
+                }
+                Some(functor_runtime_common::ui::ScrubberAction::SetGhostDivisions(n)) => {
+                    ghost_divisions = n.clamp(1, 8);
+                }
+                Some(functor_runtime_common::ui::ScrubberAction::SetGhostWindow(w)) => {
+                    ghost_window = w.clamp(0.5, 5.0);
                 }
                 None => {}
             }

--- a/runtime/functor-runtime-web/index-mle.html
+++ b/runtime/functor-runtime-web/index-mle.html
@@ -39,6 +39,15 @@
       #scrubber button:hover { background: rgba(110,110,125,0.7); }
       #scrub-slider { width: 320px; accent-color: #e0803a; }
       #scrub-label { min-width: 150px; }
+      /* Forward-ghosting controls (docs/time-travel.md T6d): toggle the ghost
+         and tune its divisions / window, alongside the transport. */
+      #scrubber label { display: flex; align-items: center; gap: 4px; }
+      #scrubber input[type="number"] {
+        width: 42px; font: 12px/1 monospace; color: #eee;
+        background: rgba(80,80,90,0.6); border: 1px solid rgba(255,255,255,0.15);
+        border-radius: 5px; padding: 4px 5px;
+      }
+      #scrub-ghost { accent-color: #e0803a; }
     </style>
   </head>
   <body>
@@ -49,6 +58,15 @@
       <button id="scrub-pause">Pause</button>
       <input id="scrub-slider" type="range" min="0" max="0" value="0" step="1" />
       <button id="scrub-step">Step ▸</button>
+      <label title="Forward-ghost the scene (docs/time-travel.md T6d)">
+        <input id="scrub-ghost" type="checkbox" />ghost
+      </label>
+      <label title="Number of ghost divisions">
+        <input id="scrub-ghost-div" type="number" min="1" max="8" value="8" />÷
+      </label>
+      <label title="Ghost window (seconds)">
+        <input id="scrub-ghost-win" type="number" step="0.5" value="2" />s
+      </label>
     </div>
     <script type="module">
 
@@ -64,6 +82,7 @@
         mle_scrub_toggle_pause,
         mle_scrub_step,
         mle_scrub_paused,
+        mle_scrub_set_ghost,
       } from "./pkg/functor_runtime_web.js";
 
       // The MLE entry file, substituted in by the CLI's dev server (see
@@ -150,6 +169,9 @@
         const pause = document.getElementById("scrub-pause");
         const slider = document.getElementById("scrub-slider");
         const step = document.getElementById("scrub-step");
+        const ghost = document.getElementById("scrub-ghost");
+        const ghostDiv = document.getElementById("scrub-ghost-div");
+        const ghostWin = document.getElementById("scrub-ghost-win");
 
         let scrubbing = false;
         let pendingSeek = null;
@@ -158,6 +180,15 @@
         slider.addEventListener("input", () => (pendingSeek = Number(slider.value)));
         pause.addEventListener("click", () => mle_scrub_toggle_pause());
         step.addEventListener("click", () => mle_scrub_step());
+
+        // Forward-ghosting (docs/time-travel.md T6d): JS owns the ghost UI state
+        // and pushes the whole set on any change; the frame loop composites when
+        // the toggle is on. The web scrubber is always visible, so no overlay gate.
+        const pushGhost = () =>
+          mle_scrub_set_ghost(ghost.checked, +ghostDiv.value, +ghostWin.value);
+        ghost.addEventListener("change", pushGhost);
+        ghostDiv.addEventListener("input", pushGhost);
+        ghostWin.addEventListener("input", pushGhost);
 
         const update = () => {
           if (pendingSeek !== null) {

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -926,6 +926,13 @@ async fn run_async() -> Result<(), JsValue> {
         // golden captures.
         let mut clock = GameClock::new(fixed_time);
 
+        // Forward-ghosting (docs/time-travel.md T6d). Unlike native (gated on the
+        // `~` overlay), the web DOM scrubber is always visible, so the ghost shows
+        // whenever `ghost_on`. JS owns this UI state and pushes `SetGhost` on change.
+        let mut ghost_on = false;
+        let mut ghost_divisions: usize = 8;
+        let mut ghost_window: f32 = 2.0;
+
         *g.borrow_mut() = Some(Closure::new(move || {
             // The frame's exclusive borrow of the shared producer. Cannot
             // collide with `mle_set_source`: JS is single-threaded, and
@@ -951,6 +958,15 @@ async fn run_async() -> Result<(), JsValue> {
                         clock.toggle_pause();
                     }
                     mle_game::ScrubControl::Step => clock.step(1.0 / 60.0),
+                    mle_game::ScrubControl::SetGhost {
+                        on,
+                        divisions,
+                        window,
+                    } => {
+                        ghost_on = on;
+                        ghost_divisions = divisions;
+                        ghost_window = window;
+                    }
                     mle_game::ScrubControl::SeekTo(f) => {
                         let _ = game.seek_scene_to(f);
                         // Park on the scrubbed frame and keep the clock aligned to
@@ -1017,19 +1033,50 @@ async fn run_async() -> Result<(), JsValue> {
             }
             let viewport = functor_runtime_common::Viewport::new(canvas.width(), canvas.height());
 
+            // Forward-ghosting (docs/time-travel.md T6d): when the DOM ghost
+            // toggle is on, forward-step the scene over `ghost_window` seconds in
+            // `ghost_divisions` slices and composite them at equal weight, so
+            // moving elements strobe across their future and static geometry stays
+            // solid. `None` = the recorded-log/coast path (web has no
+            // --input-script). Empty (→ this arm skipped) leaves live rendering
+            // unchanged. The web scrubber is always visible, so there is no
+            // overlay gate (unlike native's `~`).
+            let ghosts = if ghost_on {
+                let divisions = ghost_divisions.clamp(1, 8);
+                let dt = ghost_window / divisions as f32;
+                game.ghost_frames(divisions, dt, frame_time.tts as f64, None)
+            } else {
+                Vec::new()
+            };
+
             // Shadow + forward passes, shared with the desktop runtime.
-            functor_runtime_common::render_frame(
-                &gl,
-                shader_version,
-                asset_cache.clone(),
-                &scene_context,
-                &shadow_map,
-                &frame,
-                &frame.camera,
-                frame_time.clone(),
-                viewport,
-                debug_render_mode,
-            );
+            if !ghosts.is_empty() {
+                functor_runtime_common::render_composited_frames(
+                    &gl,
+                    shader_version,
+                    asset_cache.clone(),
+                    &scene_context,
+                    &shadow_map,
+                    &ghosts,
+                    &vec![1.0f32; ghosts.len()],
+                    frame_time.clone(),
+                    viewport,
+                    debug_render_mode,
+                );
+            } else {
+                functor_runtime_common::render_frame(
+                    &gl,
+                    shader_version,
+                    asset_cache.clone(),
+                    &scene_context,
+                    &shadow_map,
+                    &frame,
+                    &frame.camera,
+                    frame_time.clone(),
+                    viewport,
+                    debug_render_mode,
+                );
+            }
 
             // 2D UI overlay: the game's declarative `ui model` View, lowered to a
             // text overlay on top of the frame (HiDPI-aware via the device ratio).

--- a/runtime/functor-runtime-web/src/mle_game.rs
+++ b/runtime/functor-runtime-web/src/mle_game.rs
@@ -772,6 +772,13 @@ pub enum ScrubControl {
     TogglePause,
     Step,
     SeekTo(u64),
+    /// Forward-ghosting (docs/time-travel.md T6d): toggle + parameters, pushed by
+    /// the DOM ghost controls. The frame loop owns the ghost state.
+    SetGhost {
+        on: bool,
+        divisions: usize,
+        window: f32,
+    },
 }
 
 thread_local! {
@@ -818,6 +825,17 @@ pub fn mle_scrub_toggle_pause() {
 #[wasm_bindgen]
 pub fn mle_scrub_step() {
     push_scrub(ScrubControl::Step);
+}
+
+/// Page → runtime: set forward-ghosting on/off and its parameters (JS owns the
+/// ghost UI state and pushes this on any change — docs/time-travel.md T6d).
+#[wasm_bindgen]
+pub fn mle_scrub_set_ghost(on: bool, divisions: usize, window: f32) {
+    push_scrub(ScrubControl::SetGhost {
+        on,
+        divisions,
+        window,
+    });
 }
 
 /// Page → runtime: non-destructively scrub to a rendered frame (slider drag).

--- a/runtime/functor-runtime-web/src/mle_game.rs
+++ b/runtime/functor-runtime-web/src/mle_game.rs
@@ -428,6 +428,32 @@ impl GameProducer for MleWebGame {
         self.recorder.current_scene_frame_tts()
     }
 
+    /// Forward-ghosting (docs/time-travel.md T6d) — delegated to the shared
+    /// producer body (`mle_producer::ghost_frames`), identical to the desktop
+    /// producer. Makes the web producer's ghost half available; the web RENDER
+    /// loop compositing them is a later slice.
+    fn ghost_frames(
+        &self,
+        divisions: usize,
+        dt: f32,
+        start_tts: f64,
+        script_inputs: Option<&[Vec<functor_runtime_common::RecordedInput>]>,
+    ) -> Vec<Frame> {
+        functor_runtime_common::mle_producer::ghost_frames(
+            &self.session,
+            &self.model,
+            &self.recorder,
+            self.has_physics,
+            self.has_subscriptions,
+            self.prev_tts,
+            &self.last_frame,
+            divisions,
+            dt,
+            start_tts,
+            script_inputs,
+        )
+    }
+
     fn tick(&mut self, frame_time: FrameTime) {
         // The whole MVU frame body lives in the shared `FrameCtx`
         // (docs/time-travel.md T6a). Web runs it as one call — unlike native it


### PR DESCRIPTION
Stacked on #257. **Web forward-ghosting + DOM toggle** — brings the ghost to the wasm runtime (VSCode live preview + website), which is where it matters most for authoring.

- `lib.rs`: the web render loop now composites — when the DOM ghost toggle is on, it produces `game.ghost_frames(divisions, dt, tts, None)` and routes through the shared `render_composited_frames` (WebGL2) instead of `render_frame`. No overlay gate (the DOM scrubber is always visible).
- `mle_game.rs`: `ScrubControl::SetGhost { on, divisions, window }` + `mle_scrub_set_ghost` wasm export.
- `index-mle.html`: a **ghost checkbox + divisions + window** inputs in the scrubber, wired to `mle_scrub_set_ghost`.

Web ghosting was previously desktop-only; the producer half was shared in #256, this wires the render loop + DOM control. `wasm-pack build` succeeds (export generated); desktop unaffected — tests + strict + byte-identical goldens.

**Needs a browser to see** (no headless web capture here): VSCode preview, or `functor -d examples/mario run wasm` + hard-reload, then tick the scrubber's ghost box.

Completes the ghost-UI-toggle series (share → native → web).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Visuals (web / WebGL2)

![Web forward-ghosting strobe](https://gist.githubusercontent.com/tommy-xr/22e1e0d4778e25496f0dfccf63a1412a/raw/ghost.png)

<sub>Web forward-ghosting in headless Chromium (Playwright): the orbiting point-lights strobed across their future — proof it renders on WebGL2, not just native.</sub>

![Ghost off vs. on](https://gist.githubusercontent.com/tommy-xr/22e1e0d4778e25496f0dfccf63a1412a/raw/beforeafter.png)

<sub>Left: ghost off (single instant). Right: ghost on — the orbiting lights and their emissive markers smear into faint future copies. Captured live via the `#scrub-ghost` DOM checkbox (which fires the `mle_scrub_set_ghost` wasm export), no screen recording.</sub>
