### PR TITLE
feat(cli): rich MLE diagnostics + error hints + ASCII fallback (UX pass PR-3/3, closes)

### DIFF
--- a/cli/src/commands/mle_project.rs
+++ b/cli/src/commands/mle_project.rs
@@ -72,12 +72,19 @@ impl MleProject {
         let project = match mle::project::load(&path) {
             Ok(project) => project,
             Err(e) => {
+                // A load error (parse / bad module / cycle) carries only its
+                // position; re-read the file to recover the offending line for
+                // the caret. Missing/short file → no source line (fail soft).
+                let source_line = std::fs::read_to_string(&e.path)
+                    .ok()
+                    .and_then(|src| nth_line(&src, e.line));
                 emit(Event::Diagnostic {
                     severity: Severity::Error,
                     file: Some(e.path.display().to_string()),
                     line: Some(e.line),
                     col: Some(e.col),
                     message: e.message.clone(),
+                    source_line,
                 });
                 return Err(Error::other(format!("cannot load the {display} project")));
             }
@@ -85,12 +92,15 @@ impl MleProject {
         let diags = project.check();
         for diag in &diags {
             let (file, line, col) = project.sources.resolve(diag.span.start);
+            // The source is already in memory (the SourceFile) — no extra IO.
+            let source_line = nth_line(&file.src, line);
             emit(Event::Diagnostic {
                 severity: Severity::Error,
                 file: Some(file.path.display().to_string()),
                 line: Some(line),
                 col: Some(col),
                 message: diag.message.clone(),
+                source_line,
             });
         }
         if diags.is_empty() {
@@ -350,6 +360,15 @@ Content-Length: {}\r\nConnection: close\r\n\r\n",
     Ok((status, body))
 }
 
+/// The 1-based `line`th line of `src`, without its newline — `None` when the
+/// line is out of range (a defensive fail-soft: the caret is a nicety, never a
+/// hard dependency of surfacing the diagnostic).
+fn nth_line(src: &str, line: usize) -> Option<String> {
+    line.checked_sub(1)
+        .and_then(|idx| src.lines().nth(idx))
+        .map(str::to_string)
+}
+
 /// True when `entry` can't be served by the wasm dev server, which roots at
 /// the project directory: absolute paths and any `..` component escape it.
 fn entry_escapes_project(entry: &str) -> bool {
@@ -358,7 +377,22 @@ fn entry_escapes_project(entry: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::entry_escapes_project;
+    use super::{entry_escapes_project, nth_line};
+
+    #[test]
+    fn nth_line_returns_the_1_based_line_without_newline() {
+        let src = "one\ntwo\nthree";
+        assert_eq!(nth_line(src, 1).as_deref(), Some("one"));
+        assert_eq!(nth_line(src, 3).as_deref(), Some("three"));
+    }
+
+    #[test]
+    fn nth_line_fails_soft_out_of_range() {
+        // Line 0 (never valid, 1-based) and past-the-end → None, not a panic.
+        assert_eq!(nth_line("only\n", 0), None);
+        assert_eq!(nth_line("only\n", 5), None);
+        assert_eq!(nth_line("", 1), None);
+    }
 
     #[test]
     fn entries_inside_the_project_are_servable() {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -34,6 +34,10 @@ struct Args {
     #[arg(long, global = true)]
     no_color: bool,
 
+    /// Use ASCII-only glyphs (auto-detected on a dumb / non-UTF-8 terminal).
+    #[arg(long, global = true)]
+    ascii: bool,
+
     #[command(subcommand)]
     command: Command,
 }
@@ -150,7 +154,7 @@ async fn main() -> tokio::io::Result<()> {
     let started = Instant::now();
     let args = Args::parse();
 
-    output::init(args.json, args.quiet, args.no_color);
+    output::init(args.json, args.quiet, args.no_color, args.ascii);
 
     // When the live (ink-style) renderer is up, a Ctrl-C would otherwise kill
     // the process mid-draw and leave the sticky live region stranded on screen.
@@ -323,16 +327,34 @@ fn finish(res: io::Result<()>, started: Instant) -> tokio::io::Result<()> {
             Ok(())
         }
         Err(error) => {
-            emit(Event::Error {
-                message: error.to_string(),
-                hint: None,
-            });
+            let message = error.to_string();
+            let hint = hint_for(&message);
+            emit(Event::Error { message, hint });
             emit(Event::CommandFinished {
                 ok: false,
                 duration_ms,
             });
             process::exit(1);
         }
+    }
+}
+
+/// An actionable hint for the common, recognizable CLI failures — matched on the
+/// (locally-defined) error message. Targeted on purpose: most errors have no
+/// useful generic advice, so they get none.
+fn hint_for(message: &str) -> Option<String> {
+    if message.contains("functor.json not found") {
+        Some(
+            "point -d at an MLE project directory (one containing a functor.json), \
+e.g. `functor -d examples/primitives build`"
+                .to_string(),
+        )
+    } else if message.contains("not an MLE project") {
+        Some("add `\"language\": \"mle\"` to the project's functor.json".to_string())
+    } else if message.contains("mle entry not found") {
+        Some("check the `entry` field in functor.json (defaults to game.mle)".to_string())
+    } else {
+        None
     }
 }
 

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -46,7 +46,10 @@ pub enum Event {
     CommandFinished { ok: bool, duration_ms: u64 },
     /// A `build` typecheck passed (`entry` plus `sibling_count` sibling modules).
     MleLoaded { entry: String, sibling_count: usize },
-    /// An MLE check / load error, positioned in its file.
+    /// An MLE check / load error, positioned in its file. `source_line` is the
+    /// raw offending line (no caret baked in) so the human renderer can draw a
+    /// rustc-style caret under `col`; machine consumers get the same structured
+    /// fields and can render their own. Omitted from JSON when absent.
     Diagnostic {
         severity: Severity,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -56,6 +59,8 @@ pub enum Event {
         #[serde(skip_serializing_if = "Option::is_none")]
         col: Option<usize>,
         message: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        source_line: Option<String>,
     },
     /// The wasm dev server bound and is serving.
     ServerListening { url: String },
@@ -188,7 +193,7 @@ impl PlainRenderer {
                 project,
                 env,
             } => {
-                let mut s = format!("{} {}", "▸".cyan(), command.bold());
+                let mut s = format!("{} {}", g_bullet().cyan(), command.bold());
                 if let Some(project) = project {
                     s.push_str(&format!(" {}", project.dimmed()));
                 }
@@ -200,9 +205,9 @@ impl PlainRenderer {
             Event::CommandFinished { ok, duration_ms } => {
                 let dur = format_duration(*duration_ms).dimmed();
                 if *ok {
-                    vec![format!("{} done {}", "✓".green(), dur)]
+                    vec![format!("{} done {}", g_ok().green(), dur)]
                 } else {
-                    vec![format!("{} failed {}", "✗".red(), dur)]
+                    vec![format!("{} failed {}", g_fail().red(), dur)]
                 }
             }
             Event::MleLoaded {
@@ -216,7 +221,7 @@ impl PlainRenderer {
                 };
                 vec![format!(
                     "{} checked {}{}",
-                    "✓".green(),
+                    g_ok().green(),
                     entry,
                     siblings.dimmed()
                 )]
@@ -227,6 +232,7 @@ impl PlainRenderer {
                 line,
                 col,
                 message,
+                source_line,
             } => {
                 let label = match severity {
                     Severity::Error => "error".red().bold(),
@@ -237,10 +243,15 @@ impl PlainRenderer {
                     (Some(f), _, _) => format!("{f}: "),
                     _ => String::new(),
                 };
-                vec![format!("{label}: {}{message}", loc.dimmed())]
+                let mut out = vec![format!("{label}: {}{message}", loc.dimmed())];
+                // rustc-style source line + caret, when we resolved the line.
+                if let (Some(src), Some(l), Some(c)) = (source_line, line, col) {
+                    out.extend(caret_block(src, *l, *c, *severity));
+                }
+                out
             }
             Event::ServerListening { url } => {
-                vec![format!("{} serving {}", "◈".cyan(), url.underline())]
+                vec![format!("{} serving {}", g_serve().cyan(), url.underline())]
             }
             Event::Info { message } => vec![message.clone()],
             Event::Warning { message } => {
@@ -253,7 +264,7 @@ impl PlainRenderer {
                 }
                 out
             }
-            Event::RuntimeReady => vec![format!("{} running", "▸".cyan())],
+            Event::RuntimeReady => vec![format!("{} running", g_bullet().cyan())],
             Event::FrameStats {
                 tick_us,
                 draw_us,
@@ -275,11 +286,11 @@ impl PlainRenderer {
                 )]
             }
             Event::CaptureWritten { path } => {
-                vec![format!("{} captured {}", "✓".green(), path)]
+                vec![format!("{} captured {}", g_ok().green(), path)]
             }
             Event::HotReload { ok, message } => {
                 if *ok {
-                    vec![format!("{} {message}", "↻".cyan())]
+                    vec![format!("{} {message}", g_reload().cyan())]
                 } else {
                     vec![format!("{}: {message}", "reload".yellow().bold())]
                 }
@@ -295,7 +306,7 @@ impl PlainRenderer {
                     loc.dimmed()
                 )]
             }
-            Event::Reload => vec![format!("{} reload", "↻".cyan())],
+            Event::Reload => vec![format!("{} reload", g_reload().cyan())],
         }
     }
 }
@@ -308,13 +319,104 @@ fn format_duration(ms: u64) -> String {
     }
 }
 
+/// A rustc-style source-line + caret block under column `col` (1-based). The
+/// caret indent copies the source line's own prefix (tabs kept as tabs) so it
+/// lands under the right glyph regardless of tab width.
+fn caret_block(source_line: &str, line: usize, col: usize, severity: Severity) -> Vec<String> {
+    let n = line.to_string();
+    let gutter = " ".repeat(n.len());
+    let bar = "|".dimmed();
+    let indent: String = source_line
+        .chars()
+        .take(col.saturating_sub(1))
+        .map(|c| if c == '\t' { '\t' } else { ' ' })
+        .collect();
+    let caret = match severity {
+        Severity::Error => "^".red().bold(),
+        Severity::Warning => "^".yellow().bold(),
+    };
+    vec![
+        format!("{gutter} {bar}"),
+        format!("{} {bar} {source_line}", n.dimmed()),
+        format!("{gutter} {bar} {indent}{caret}"),
+    ]
+}
+
+// ── ASCII fallback ───────────────────────────────────────────────────────────
+// A single source of truth for the status glyphs. On a dumb / non-UTF-8 terminal
+// (or under `--ascii`) they degrade to plain ASCII so output is never mojibake.
+// Decided once in `init`; read here and by the live renderer.
+
+static ASCII: AtomicBool = AtomicBool::new(false);
+
+/// Whether the CLI is in ASCII-only mode (dumb terminal / non-UTF-8 locale /
+/// `--ascii`). The live renderer reads this for its spinner + bar glyphs too.
+pub(crate) fn ascii() -> bool {
+    ASCII.load(Ordering::Relaxed)
+}
+
+pub(crate) fn g_bullet() -> &'static str {
+    if ascii() {
+        "->"
+    } else {
+        "▸"
+    }
+}
+pub(crate) fn g_ok() -> &'static str {
+    if ascii() {
+        "[ok]"
+    } else {
+        "✓"
+    }
+}
+pub(crate) fn g_fail() -> &'static str {
+    if ascii() {
+        "[x]"
+    } else {
+        "✗"
+    }
+}
+pub(crate) fn g_serve() -> &'static str {
+    if ascii() {
+        "::"
+    } else {
+        "◈"
+    }
+}
+pub(crate) fn g_reload() -> &'static str {
+    if ascii() {
+        "~"
+    } else {
+        "↻"
+    }
+}
+
+/// Decide ASCII-only mode: an explicit `--ascii`, a dumb `TERM`, or a locale
+/// (`LC_ALL` / `LC_CTYPE` / `LANG`, first one set wins) that is set but is not
+/// UTF-8. An unset locale is treated as UTF-8, so the default stays unchanged.
+fn detect_ascii(force_ascii: bool) -> bool {
+    if force_ascii {
+        return true;
+    }
+    if std::env::var("TERM").as_deref() == Ok("dumb") {
+        return true;
+    }
+    let locale = ["LC_ALL", "LC_CTYPE", "LANG"]
+        .iter()
+        .find_map(|k| std::env::var(k).ok().filter(|v| !v.is_empty()));
+    match locale {
+        Some(v) => !v.to_ascii_lowercase().replace('-', "").contains("utf8"),
+        None => false,
+    }
+}
+
 static RENDERER: OnceLock<Box<dyn Renderer>> = OnceLock::new();
 static LIVE_ACTIVE: AtomicBool = AtomicBool::new(false);
 
 /// Select and install the process-wide renderer from the global flags +
 /// environment. Called once at startup, before any command logic runs. See
 /// `docs/cli-output.md` for the selection table.
-pub fn init(json: bool, quiet: bool, no_color: bool) {
+pub fn init(json: bool, quiet: bool, no_color: bool, ascii: bool) {
     // Color only on a real TTY, and never under NO_COLOR / --no-color / CI /
     // --json. Enforced globally so no code path can leak ANSI.
     let color = !json
@@ -323,6 +425,10 @@ pub fn init(json: bool, quiet: bool, no_color: bool) {
         && std::env::var_os("CI").is_none()
         && !no_color;
     colored::control::set_override(color);
+
+    // ASCII glyph fallback — decided once, alongside color. `--json` is pure
+    // structured data (no glyphs), so leave it on the default there.
+    ASCII.store(!json && detect_ascii(ascii), Ordering::Relaxed);
 
     // The live (ink-style) renderer activates ONLY on an interactive, color-
     // allowed TTY, and never under --quiet (which keeps its exact minimal plain

--- a/cli/src/output/live.rs
+++ b/cli/src/output/live.rs
@@ -77,7 +77,7 @@ impl Panel {
             None => lines.push(format!("  {}", "warming up…".dimmed())),
         }
         if let Some(reload) = &self.last_reload {
-            lines.push(format!("  {} {}", "↻".cyan(), reload));
+            lines.push(format!("  {} {}", super::g_reload().cyan(), reload));
         }
         self.bar.set_message(lines.join("\n"));
     }
@@ -88,7 +88,8 @@ impl Panel {
 fn budget_bar(pct: f64) -> String {
     const CELLS: usize = 20;
     let filled = ((pct / 100.0) * CELLS as f64).round().clamp(0.0, CELLS as f64) as usize;
-    let bar = format!("{}{}", "█".repeat(filled), "░".repeat(CELLS - filled));
+    let (full, empty) = if super::ascii() { ("#", "-") } else { ("█", "░") };
+    let bar = format!("{}{}", full.repeat(filled), empty.repeat(CELLS - filled));
     let bar = if pct >= 100.0 {
         bar.red()
     } else if pct >= 70.0 {
@@ -277,13 +278,18 @@ impl Renderer for LiveRenderer {
     }
 }
 
-/// A braille phase spinner (⠋⠙⠹…) in cyan.
+/// A braille phase spinner (⠋⠙⠹…) in cyan — ASCII (`|/-\`) on a dumb terminal.
 fn phase_spinner() -> ProgressBar {
+    let ticks = if super::ascii() {
+        "|/-\\ "
+    } else {
+        "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏ "
+    };
     let pb = ProgressBar::new_spinner();
     pb.set_style(
         ProgressStyle::with_template("{spinner:.cyan} {msg}")
             .unwrap()
-            .tick_chars("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏ "),
+            .tick_chars(ticks),
     );
     pb
 }
@@ -291,9 +297,14 @@ fn phase_spinner() -> ProgressBar {
 /// The sticky telemetry panel: a header line (animated spinner + elapsed) over a
 /// multi-line `{msg}` block of stats.
 fn panel_style() -> ProgressStyle {
+    let ticks = if super::ascii() {
+        "|/-\\|"
+    } else {
+        "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏⠋"
+    };
     ProgressStyle::with_template("{spinner:.green.bold} running {prefix:.bold} · {elapsed}\n{msg}")
         .unwrap()
-        .tick_chars("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏⠋")
+        .tick_chars(ticks)
 }
 
 /// Last path component, for a compact project label.

--- a/docs/cli-output.md
+++ b/docs/cli-output.md
@@ -60,8 +60,18 @@ panic (a chained panic hook).
 is the explicit opt-in to ndjson. TTY detection uses `std::io::IsTerminal` (std, no dep).
 
 Flags are **global** (accepted before or after the subcommand): `--json`, `--quiet`,
-`--no-color`. `--json` takes precedence: under `--json`, `--quiet` is a no-op (the full
+`--no-color`, `--ascii`. `--json` takes precedence: under `--json`, `--quiet` is a no-op (the full
 event stream is emitted — machine consumers filter it themselves).
+
+**ASCII glyph fallback (PR-3).** The human renderers use unicode status glyphs (`▸ ✓ ✗ ◈ ↻`) and a
+braille spinner / block budget bar. On a terminal that can't render them, they degrade to ASCII
+(`-> [ok] [x] :: ~`, a `|/-\` spinner, a `#`/`-` bar) so output is never mojibake. This is decided
+**once in `init`, alongside the color decision, from a single source** (`output::ascii()`, read by
+both the plain and live renderers), when any of: `--ascii` is passed, `TERM=dumb`, or the locale
+(`LC_ALL` / `LC_CTYPE` / `LANG`, first set wins) is set but not UTF-8. An **unset** locale is treated
+as UTF-8, so the default is unchanged. `--json` is pure structured data (no glyphs) and is
+unaffected. ASCII mode is orthogonal to color: a color TTY under `TERM=dumb`/`--ascii` keeps its
+colored live region but swaps in the ASCII glyphs.
 
 ## The `Event` schema (stable API)
 
@@ -75,7 +85,7 @@ when absent (`skip_serializing_if`). Every line of `--json` output is one of the
 | `command_started`  | `command` (string), `project` (string?), `env` (string?)     | a command begins |
 | `command_finished` | `ok` (bool), `duration_ms` (number)                          | a command ends |
 | `mle_loaded`       | `entry` (string), `sibling_count` (number)                   | `build` typecheck passes |
-| `diagnostic`       | `severity` (`"error"`\|`"warning"`), `file` (string?), `line` (number?), `col` (number?), `message` (string) | an MLE check / load error |
+| `diagnostic`       | `severity` (`"error"`\|`"warning"`), `file` (string?), `line` (number?), `col` (number?), `message` (string), `source_line` (string?) | an MLE check / load error |
 | `server_listening` | `url` (string)                                               | the wasm dev server binds |
 | `info`             | `message` (string)                                           | neutral status (e.g. hot-reload hint, a push ack) |
 | `warning`          | `message` (string)                                           | non-fatal issue (e.g. ignored wasm runner args) |
@@ -93,10 +103,40 @@ A build with a type error:
 
 ```json
 {"type":"command_started","command":"build","project":"scratch/broken"}
-{"type":"diagnostic","severity":"error","file":"scratch/broken/game.mle","line":3,"col":5,"message":"..."}
+{"type":"diagnostic","severity":"error","file":"scratch/broken/game.mle","line":4,"col":11,"message":"`+` needs Float operands, got String","source_line":"  model + \"not a number\""}
 {"type":"error","message":"1 type error(s) in the scratch/broken/game.mle project"}
 {"type":"command_finished","ok":false,"duration_ms":4}
 ```
+
+### Rich diagnostics — the source line + caret (PR-3)
+
+`diagnostic` carries an **optional `source_line`**: the raw offending line of source
+(newline-stripped, **no caret baked in**). The CLI fills it for check errors straight from the
+in-memory source, and for load/parse errors by re-reading the file (missing file / out-of-range
+line → the field is simply omitted, `skip_serializing_if`). The `--json` schema stays structured
+and stable: `source_line` is one more optional string field, and machine consumers still read
+`line`/`col` and render their own pointer.
+
+The **human** renderer turns those fields into a rustc-style block — the location header, then the
+source line in a numbered gutter, then a caret under `col`:
+
+```
+error: game.mle:4:11: `+` needs Float operands, got String
+  |
+4 |   model + "not a number"
+  |           ^
+```
+
+The caret indent copies the source line's own leading run (tabs kept as tabs), so it stays aligned
+regardless of tab width. `col` is 1-based, counting characters from the start of the line.
+
+### Actionable error hints (PR-3)
+
+The `error` event's optional `hint` is populated for the common, recognizable CLI failures
+(`functor.json not found` → *point `-d` at an MLE project directory*; a project missing
+`"language": "mle"`; a missing `entry` file). Hints are **targeted** — most errors have no useful
+generic advice and carry none. Both renderers show the hint (human: a `hint:` line under the error;
+`--json`: the `hint` field).
 
 ### Implemented in PR-2a (runtime-side — routed through the event sink)
 
@@ -183,7 +223,8 @@ focused window with a real user, never on a piped/`--json`/captured run.)
   `✓` line, and a sticky `run native` telemetry panel that consumes `frame_stats`/`hot_reload`,
   above scrollback. TTY-only; the machine paths are untouched. (A full-screen `--dashboard` is
   explicitly out of scope.)
-- **PR-3:** rich MLE diagnostics (source line + caret), actionable error hints, ASCII fallback
-  for dumb terminals, polish.
+- **PR-3 (this, closes the pass):** rich MLE diagnostics (the `source_line` field + a human caret
+  block), actionable error `hint`s for common failures, and an ASCII glyph fallback for dumb /
+  non-UTF-8 terminals (`--ascii`).
 </content>
 </invoke>


### PR DESCRIPTION
**This closes the `functor` CLI output/UX modernization pass** (PR-1 #249, PR-2a #252, PR-2b #254 → this is PR-3/3). It's the final polish over the existing `Event` enum + `Renderer` trait (`PlainRenderer` / `JsonRenderer` / `LiveRenderer`), not a new mechanism.

## What this adds

### 1. Rich MLE diagnostics (source line + caret)
The `diagnostic` event gains an optional `source_line: Option<String>` — the raw offending line, **no caret baked in**. The CLI fills it from the **in-memory source** for check errors (zero extra IO) and by **re-reading the file** for parse/load errors (missing file / out-of-range line → the field is simply omitted). The human renderer turns `source_line` + `col` into a rustc-style block:

```
error: game.mle:4:11: `+` needs Float operands, got String
  |
4 |   model + "not a number"
  |           ^
```

The caret indent copies the source line's own leading run (tabs kept as tabs) so it stays aligned. `--json` stays **structured and schema-stable**: `source_line` is one more `skip_serializing_if` optional string; `line`/`col` are untouched; the caret is never serialized. Multi-error files render one block per diagnostic.

### 2. Actionable error hints
Populates the existing `error{hint?}` for the common, recognizable failures via a single `hint_for` in `finish` (matched on locally-defined messages): `functor.json not found` → *point `-d` at an MLE project directory*; a project missing `"language": "mle"`; a missing `entry` file. Targeted, not speculative — everything else gets no hint. Shown in both modes (human `hint:` line / `--json` `hint` field).

### 3. ASCII glyph fallback for dumb terminals
`--ascii`, `TERM=dumb`, or a non-UTF-8 locale (`LC_ALL`/`LC_CTYPE`/`LANG`, first set wins) swaps the unicode glyphs (`▸✓✗◈↻`), braille spinner, and block budget bar for ASCII (`-> [ok] [x] :: ~`, a `|/-\` spinner, a `#`/`-` bar). Decided **once in `output::init` alongside the color decision** and single-sourced via `output::ascii()` + the `g_*` glyph helpers, read by both the plain and live renderers. An unset locale is treated as UTF-8, so the default is unchanged; `--json` is unaffected.

## Guardrails re-verified (PR-1/2a/2b not regressed)
- `run native --json --capture-frame … --fixed-time 2 --capture-time 4` → **zero raw stdout lines**, all valid ndjson (`command_started`/`mle_loaded`/`runtime_ready`/`frame_stats`/`capture_written`/`command_finished`).
- piped plain + broken-build diagnostics + `--json` → **zero ANSI (ESC) bytes**; `--ascii` piped → pure ASCII.
- Locale precedence verified: `LC_ALL=C` overrides `LANG=UTF-8` → ASCII; `LC_CTYPE=UTF-8` overrides `LANG=C` → unicode; `C`/`POSIX`/`ISO8859-1` → ASCII.
- `--quiet` unchanged; the unicode live TUI (braille spinner + telemetry panel) still renders on a color TTY.

## Tests
`cargo build --bin functor` clean; `functor_runtime_common` (202), `mle` (35 + suites), desktop lib, and `functor-cli` (incl. new `nth_line` fail-soft tests) all green.

## Review
`/xreview`: the Claude engine returned a **clean verdict — no Critical/High/Medium findings**, confirming panic-free source reading, stable+clean `--json`, correct caret math, single-sourced ASCII decision, and preserved locale default. (The Codex engine was unavailable — usage limit.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)