### PR TITLE
fix(time-travel): fixed-timestep model loop + interactive scrubber/ghost fixes

### DIFF
--- a/runtime/functor-runtime-common/src/game_clock.rs
+++ b/runtime/functor-runtime-common/src/game_clock.rs
@@ -21,13 +21,34 @@
 
 use crate::FrameTime;
 
+/// The fixed model timestep, in seconds — the interval `tick` advances by under
+/// [`GameClock::fixed_frames`]. It is `1/60`, matching BOTH the physics fixed
+/// step (`physics::world::FIXED_DT`) — so the model and physics fixed-frames
+/// advance in lockstep — AND the forward-ghost's `sub_dt`, so one recorded frame
+/// IS exactly one forward-step fine step (the mapping the ghost replay assumes;
+/// docs/time-travel.md). Recording at variable wall-clock dt breaks that mapping
+/// and scrambles the strobe.
+pub const FIXED_DT: f32 = 1.0 / 60.0;
+
+/// Spiral-of-death clamp: never run more than this many fixed model steps for a
+/// single rendered frame. After a long stall (breakpoint, alt-tab, a heavy load
+/// frame) the backlog is capped rather than replayed as a burst — mirrors
+/// physics' `MAX_SUBSTEPS_PER_FRAME`.
+const MAX_SUBSTEPS: usize = 8;
+
 /// A frame-time source shared by the desktop and web shells. Constructed once
 /// per session (seeded with the shell's fixed-time option) and called each
-/// frame via [`GameClock::frame`].
+/// rendered frame via [`GameClock::fixed_frames`] (the fixed-timestep model
+/// loop) — or the legacy one-tick [`GameClock::frame`].
 pub struct GameClock {
     /// Accumulated game time in seconds — the `tts` handed to the game. Advances
     /// by the real frame delta while live; frozen while paused; jumps on rebase.
     game_time: f32,
+    /// Unspent real time (seconds) not yet consumed by a whole [`FIXED_DT`]
+    /// model step. [`GameClock::fixed_frames`] drains it in `FIXED_DT` chunks;
+    /// the remainder carries to the next rendered frame. Untouched by the legacy
+    /// [`GameClock::frame`] path.
+    accumulator: f32,
     /// Scrubber / debug pause. While paused, `dts = 0` and `game_time` is
     /// frozen. A queued [`GameClock::step`] also sets this.
     paused: bool,
@@ -44,6 +65,7 @@ impl GameClock {
     pub fn new(fixed_time: Option<f32>) -> Self {
         GameClock {
             game_time: 0.0,
+            accumulator: 0.0,
             paused: false,
             pending_step: None,
             fixed_time,
@@ -76,6 +98,64 @@ impl GameClock {
             dts: real_delta,
             tts: self.game_time,
         }
+    }
+
+    /// The fixed-timestep model loop: the zero-or-more [`FIXED_DT`] sub-frames to
+    /// run `tick` for this rendered frame, given the real wall-clock delta since
+    /// the last frame. Unlike [`Self::frame`] (one variable-dt tick per rendered
+    /// frame) this decouples the model rate from the render rate — so the sim is
+    /// deterministic and a recorded frame is exactly one forward-step fine step
+    /// (docs/time-travel.md). The shell runs `tick` once per returned frame, in
+    /// order, then renders ONCE at [`Self::current_tts`].
+    ///
+    /// - **Fixed-time** pins unconditionally (checked first): a single
+    ///   `{ dts: 0, tts: <const> }` — the golden-capture path runs the body once
+    ///   with `dts = 0`, byte-identical to [`Self::frame`].
+    /// - **Pending step** (Step / debug Advance): a single `{ dts: step, … }`.
+    /// - **Paused**: EMPTY — no model advance. The shell still renders the frozen
+    ///   (or scrubbed) pose once at the held `tts`.
+    /// - **Live**: accumulate `real_delta` and emit one frame per whole
+    ///   [`FIXED_DT`] of backlog, clamped to [`MAX_SUBSTEPS`] so a stall doesn't
+    ///   replay as a burst. The remainder carries to the next rendered frame, so
+    ///   at >60fps most frames emit 0 and every ~Nth emits 1; at <60fps a frame
+    ///   emits 2+ to keep the model caught up to wall-clock.
+    pub fn fixed_frames(&mut self, real_delta: f32) -> Vec<FrameTime> {
+        if let Some(t) = self.fixed_time {
+            return vec![FrameTime { dts: 0.0, tts: t }];
+        }
+        if let Some(step) = self.pending_step.take() {
+            self.game_time += step;
+            return vec![FrameTime {
+                dts: step,
+                tts: self.game_time,
+            }];
+        }
+        if self.paused {
+            return Vec::new();
+        }
+        self.accumulator += real_delta;
+        let max_backlog = FIXED_DT * MAX_SUBSTEPS as f32;
+        if self.accumulator > max_backlog {
+            self.accumulator = max_backlog;
+        }
+        let mut frames = Vec::new();
+        while self.accumulator >= FIXED_DT {
+            self.accumulator -= FIXED_DT;
+            self.game_time += FIXED_DT;
+            frames.push(FrameTime {
+                dts: FIXED_DT,
+                tts: self.game_time,
+            });
+        }
+        frames
+    }
+
+    /// The current game time (`tts`) for rendering / hot-reload / capture — the
+    /// value after this frame's fixed steps, or the frozen `game_time` while
+    /// paused, or the pinned constant under `--fixed-time`. The shell renders at
+    /// this `tts` so the drawn pose reflects the settled sim.
+    pub fn current_tts(&self) -> f32 {
+        self.fixed_time.unwrap_or(self.game_time)
     }
 
     /// Whether the scrubber/debug pause is engaged (Step also pauses).
@@ -213,5 +293,93 @@ mod tests {
         let f = clock.frame(0.1);
         assert_eq!(f.dts, 0.1);
         assert!((f.tts - 1.1).abs() < 1e-6, "rebased play at {}", f.tts);
+    }
+
+    // --- fixed_frames (the fixed-timestep model loop) ---
+
+    #[test]
+    fn fixed_frames_emit_whole_steps_at_fixed_dt() {
+        let mut clock = GameClock::new(None);
+        // One render frame worth 2.5 fixed steps of real time → 2 steps emitted,
+        // 0.5 * FIXED_DT carried.
+        let frames = clock.fixed_frames(FIXED_DT * 2.5);
+        assert_eq!(frames.len(), 2);
+        assert!((frames[0].dts - FIXED_DT).abs() < 1e-6);
+        assert!((frames[0].tts - FIXED_DT).abs() < 1e-6);
+        assert!((frames[1].tts - 2.0 * FIXED_DT).abs() < 1e-6);
+        // The carried 0.5 step + another 0.6 crosses one whole step next frame.
+        let next = clock.fixed_frames(FIXED_DT * 0.6);
+        assert_eq!(next.len(), 1);
+        assert!((next[0].tts - 3.0 * FIXED_DT).abs() < 1e-6);
+        assert!((clock.current_tts() - 3.0 * FIXED_DT).abs() < 1e-6);
+    }
+
+    #[test]
+    fn fixed_frames_above_60fps_mostly_zero_then_one() {
+        // At 144fps each render frame is ~0.4 of a fixed step: most frames emit
+        // 0, and a step lands roughly every ~2.4 frames. Over many frames the
+        // game time tracks wall-clock elapsed to within one fixed step.
+        let mut clock = GameClock::new(None);
+        let dt = 1.0 / 144.0;
+        let mut total = 0usize;
+        for _ in 0..144 {
+            total += clock.fixed_frames(dt).len();
+        }
+        // ~1s of wall-clock → ~60 fixed steps.
+        assert!((59..=61).contains(&total), "emitted {total} steps in 1s");
+        // Game time tracks wall-clock to within a fixed step (plus f32 slop from
+        // summing 144 deltas).
+        assert!((clock.current_tts() - 1.0).abs() < 2.0 * FIXED_DT);
+    }
+
+    #[test]
+    fn fixed_frames_below_60fps_catches_up_with_multiple_steps() {
+        // At 30fps each render frame is 2 fixed steps → 2 emitted per frame.
+        let mut clock = GameClock::new(None);
+        let frames = clock.fixed_frames(1.0 / 30.0);
+        assert_eq!(frames.len(), 2);
+    }
+
+    #[test]
+    fn fixed_frames_clamps_the_backlog_after_a_stall() {
+        // A 10s stall must not replay as 600 steps — capped at MAX_SUBSTEPS.
+        let mut clock = GameClock::new(None);
+        let frames = clock.fixed_frames(10.0);
+        assert_eq!(frames.len(), MAX_SUBSTEPS);
+    }
+
+    #[test]
+    fn fixed_frames_paused_emits_nothing_and_holds_tts() {
+        let mut clock = GameClock::new(None);
+        clock.fixed_frames(FIXED_DT * 3.0); // advance to 3 * FIXED_DT
+        let held = clock.current_tts();
+        clock.pause();
+        for _ in 0..100 {
+            assert!(clock.fixed_frames(1.0).is_empty());
+        }
+        // Paused: no steps, tts frozen — the shell renders the held pose.
+        assert!((clock.current_tts() - held).abs() < 1e-6);
+    }
+
+    #[test]
+    fn fixed_frames_fixed_time_is_a_single_pinned_step() {
+        let mut clock = GameClock::new(Some(2.0));
+        let frames = clock.fixed_frames(0.1);
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frames[0].dts, 0.0);
+        assert_eq!(frames[0].tts, 2.0);
+        assert_eq!(clock.current_tts(), 2.0);
+    }
+
+    #[test]
+    fn fixed_frames_step_advances_one_then_holds() {
+        let mut clock = GameClock::new(None);
+        clock.fixed_frames(FIXED_DT); // t = FIXED_DT
+        clock.step(1.0 / 60.0);
+        let a = clock.fixed_frames(1.0); // real delta ignored — one step
+        assert_eq!(a.len(), 1);
+        assert!((a[0].dts - 1.0 / 60.0).abs() < 1e-6);
+        // ...then holds (paused).
+        assert!(clock.fixed_frames(1.0).is_empty());
     }
 }

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -577,6 +577,12 @@ impl Game for MleGame {
             self.pending_events.clear();
             clear_http_taggers();
             clear_audio_completions();
+            // Drop any input buffered since the last recorded frame: the model was
+            // just restored to `target`, so a stray live event (e.g. one buffered
+            // on a 0-substep frame under the fixed-timestep loop) is now orphaned
+            // and must not be recorded into the branch — it would diverge a
+            // ghost/replay taken there (xreview).
+            self.input_buf.clear();
         }
         result
     }
@@ -641,13 +647,21 @@ impl Game for MleGame {
     /// (docs/time-travel.md T3): restore model + world for display without
     /// truncating, so the draggable bar can seek back and forth.
     fn seek_scene_to(&mut self, target: u64) -> Result<String, String> {
-        self.recorder.seek_scene_to(
+        let result = self.recorder.seek_scene_to(
             target,
             &mut self.model,
             &mut self.physics_rt,
             &mut self.physics_status,
             self.has_physics,
-        )
+        );
+        if result.is_ok() {
+            // The model was restored to `target`; drop any input buffered since
+            // the last recorded frame so a stray live event (buffered on a
+            // 0-substep frame under the fixed-timestep loop) can't be recorded
+            // into the resulting branch and diverge a ghost/replay (xreview).
+            self.input_buf.clear();
+        }
+        result
     }
 
     fn tick(&mut self, frame_time: FrameTime) {
@@ -1877,5 +1891,45 @@ mod tests {
         }
         // The strobe visibly shows the JUMP: some division rose above the ground.
         assert!(peak_y > 0.5, "the ghost should show the jump arc, peak y = {peak_y}");
+    }
+
+    /// Regression (xreview): under the fixed-timestep loop a live input can be
+    /// buffered on a 0-substep render frame — `key_event` buffers it, but no
+    /// `tick` runs that frame, so `record_frame` never drains it. If the user
+    /// then SCRUBS, the model is restored to the recorded frame while the buffered
+    /// event is left orphaned; recording it into the resulting branch on resume
+    /// would diverge a ghost/replay. `seek_scene_to` (and `rewind_scene_to`) must
+    /// drop the buffer when they restore the model.
+    #[test]
+    fn scrub_drops_input_buffered_on_a_zero_substep_frame() {
+        use functor_runtime_common::Key;
+
+        let mario = concat!(env!("CARGO_MANIFEST_DIR"), "/../../examples/mario/game.mle");
+        let mut game = MleGame::create(mario);
+
+        // Record a few frames of history at the fixed step (each tick records).
+        let sub_dt = 1.0 / 60.0;
+        for i in 0..5u32 {
+            game.tick(FrameTime {
+                tts: (i + 1) as f32 * sub_dt,
+                dts: sub_dt,
+            });
+        }
+        assert!(game.current_scene_frame().is_some(), "history recorded");
+
+        // A live input on a 0-SUBSTEP frame: buffered, but no tick drains it.
+        game.key_event(Key::Up as i32, true);
+        assert!(
+            !game.input_buf.is_empty(),
+            "input must be buffered when no tick follows it"
+        );
+
+        // Scrub back — the model is restored, so the buffered event is orphaned
+        // and must be dropped (the fix), not recorded into the branch.
+        game.seek_scene_to(1).expect("seek to an earlier frame");
+        assert!(
+            game.input_buf.is_empty(),
+            "seek must drop input orphaned by the model restore"
+        );
     }
 }

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -1771,4 +1771,111 @@ mod tests {
             "character should be grounded on the right platform"
         );
     }
+
+    /// The INTERACTIVE scrubber+ghost path end-to-end (docs/time-travel.md T6d):
+    /// record a live run+jump at the fixed 1/60 step, SCRUB back to a pre-jump
+    /// frame, then resolve the fork exactly as `mle_producer::ghost_frames` does —
+    /// `k = current_scene_frame()`, `inputs_from(k + 1)`, forward-step from the
+    /// scrubbed `model` — and assert the strobe's per-division models reproduce the
+    /// RECORDED future exactly. Unlike `mario_forward_step_...` (which hand-picks a
+    /// fork model + input slice) this exercises `seek_scene_to` +
+    /// `current_scene_frame` + `inputs_from` integration — the alignment the live
+    /// scrubber+ghost actually depends on.
+    #[test]
+    fn mario_interactive_ghost_from_scrubbed_frame_matches_recorded_future() {
+        use functor_runtime_common::Key;
+
+        fn field(v: &Value, name: &str) -> f64 {
+            match v {
+                Value::Record(fields) => match &fields.iter().find(|(k, _)| k == name).unwrap().1 {
+                    Value::Number(x) => *x,
+                    Value::Bool(b) => (*b as i32) as f64,
+                    other => panic!("{name} is not a number/bool: {other}"),
+                },
+                _ => panic!("model is not a record"),
+            }
+        }
+
+        let mario = concat!(env!("CARGO_MANIFEST_DIR"), "/../../examples/mario/game.mle");
+        let mut game = MleGame::create(mario);
+
+        const SUB_DT: f32 = 1.0 / 60.0;
+        const N: usize = 90; // run to the edge, jump, land, run on the right
+
+        // Live play at the fixed step: hold Right, jump at the edge, recording the
+        // settled (x, y) of every frame as ground truth. `game.tick` fills the
+        // recorder exactly as the shell's fixed-timestep loop now does.
+        game.key_event(Key::Right as i32, true);
+        let mut recorded: Vec<(f64, f64)> = Vec::with_capacity(N);
+        let mut tts = 0.0f32;
+        let mut jumped = false;
+        for _ in 0..N {
+            if !jumped
+                && field(&game.model, "grounded") == 1.0
+                && field(&game.model, "x") + (8.0 * SUB_DT as f64) >= -3.0
+            {
+                game.key_event(Key::Up as i32, true);
+                jumped = true;
+            }
+            tts += SUB_DT;
+            game.tick(FrameTime { tts, dts: SUB_DT });
+            recorded.push((field(&game.model, "x"), field(&game.model, "y")));
+        }
+        assert!(jumped, "the scripted jump must have fired");
+
+        // Scrub back to a PRE-JUMP frame and confirm the scene sits on it.
+        const S: u64 = 3;
+        game.seek_scene_to(S).expect("seek to S");
+        assert_eq!(game.current_scene_frame(), Some(S), "scrubbed to frame S");
+        assert!(
+            (field(&game.model, "x") - recorded[S as usize].0).abs() < 1e-9,
+            "scrubbed model must be the recorded frame S"
+        );
+        assert_eq!(field(&game.model, "grounded"), 1.0, "S is pre-jump / grounded");
+
+        // Resolve the fork EXACTLY as `ghost_frames(script_inputs = None)` does.
+        let k = game.current_scene_frame().unwrap();
+        let inputs = game.recorder.inputs_from(k + 1);
+        let start_tts = game.recorder.current_scene_frame_tts().unwrap() as f32;
+
+        const DIVISIONS: usize = 8;
+        const STEPS_PER_DIV: usize = 5;
+        let forward = functor_runtime_common::mle_producer::forward_step_scene(
+            &game.session,
+            &game.model, // the scrubbed model = seek(k)
+            game.has_physics,
+            game.has_subscriptions,
+            game.prev_tts,
+            start_tts,
+            SUB_DT,
+            DIVISIONS,
+            STEPS_PER_DIV,
+            &inputs,
+        );
+        assert_eq!(forward.len(), DIVISIONS, "division count");
+
+        // Each division boundary reproduces recorded frame S + (div+1)*STEPS — the
+        // strobe retraces the true recorded arc (exact at fixed dt).
+        let mut peak_y = f64::MIN;
+        for (div, (m, _w)) in forward.iter().enumerate() {
+            peak_y = peak_y.max(field(m, "y"));
+            let f = S as usize + (div + 1) * STEPS_PER_DIV;
+            if f >= N {
+                break; // beyond the recorded window the step coasts; stop comparing
+            }
+            let (rx, ry) = recorded[f];
+            assert!(
+                (field(m, "x") - rx).abs() < 1e-9,
+                "ghost x diverged at division {div} (frame {f}): {} vs {rx}",
+                field(m, "x")
+            );
+            assert!(
+                (field(m, "y") - ry).abs() < 1e-9,
+                "ghost y diverged at division {div} (frame {f}): {} vs {ry}",
+                field(m, "y")
+            );
+        }
+        // The strobe visibly shows the JUMP: some division rose above the ground.
+        assert!(peak_y > 0.5, "the ghost should show the jump arc, peak y = {peak_y}");
+    }
 }

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -298,6 +298,14 @@ pub struct Args {
     #[arg(long, default_value_t = 8)]
     ghost_divisions: usize,
 
+    /// Narrate the game clock + time-travel seams to stderr: pause/resume/seek
+    /// rebases (with the tts they land on), ghost on/off, and per-frame HITCH
+    /// warnings when a rendered frame's dt blows past 33ms (the tell-tale of the
+    /// ghost compositor starving the frame loop). High-signal diagnostics for the
+    /// interactive scrubber — off by default.
+    #[arg(long)]
+    debug_clock: bool,
+
     /// Eye separation for --stereo-sbs, in world units. The default assumes
     /// meter-scale worlds (human IPD ≈ 64mm); raise it for larger-unit worlds
     /// to deepen the 3D effect.
@@ -894,6 +902,17 @@ pub fn run(args: Args) {
             let time = clock.frame(elapsed_time - last_time);
             last_time = elapsed_time;
 
+            // Surface frame hitches (a dt past 33ms = under 30fps) — the
+            // signature of the ghost compositor's N forward-steps starving the
+            // loop, which reads to the user as "jerky / can't move".
+            if args.debug_clock && time.dts > 1.0 / 30.0 {
+                eprintln!(
+                    "[clock] HITCH dt={:.1}ms tts={:.3} (slow frame)",
+                    time.dts * 1000.0,
+                    time.tts
+                );
+            }
+
             game.check_hot_reload(time.clone());
 
             glfw.poll_events();
@@ -1082,7 +1101,17 @@ Escape again to quit"
             // Drive the ghost from the interactive toggle when the overlay is up,
             // and from the `--ghost` launch flag when it's hidden (the headless
             // capture path — F2 demo, goldens, tests — is byte-for-byte unchanged).
-            let ghost_active = if scrubber_visible { ghost_on } else { args.ghost };
+            //
+            // Interactive ghost only renders while PAUSED: the strobe is a preview
+            // of a frozen frame's future, and forward-stepping the scene N times
+            // every LIVE frame tanks the framerate (the "can't move with the
+            // scrubber open" bug). `is_paused()` is false under --fixed-time, so
+            // the headless `args.ghost` capture branch is unaffected.
+            let ghost_active = if scrubber_visible {
+                ghost_on && clock.is_paused()
+            } else {
+                args.ghost
+            };
             let ghost_frames = if ghost_active
                 && !args.stereo_sbs
                 && args.composite_demo == CompositeDemoArg::Off
@@ -1327,9 +1356,22 @@ Escape again to quit"
                     // it's the newest recorded frame's `tts`, which already equals
                     // the frozen `game_time` — a harmless no-op.
                     if clock.is_paused() {
-                        if let Some(tts) = game.current_scene_tts() {
-                            clock.rebase(tts as f32);
+                        match game.current_scene_tts() {
+                            Some(tts) => {
+                                if args.debug_clock {
+                                    eprintln!("[clock] resume: rebase tts={tts:.3}");
+                                }
+                                clock.rebase(tts as f32);
+                            }
+                            None if args.debug_clock => {
+                                eprintln!(
+                                    "[clock] resume: no scene tts — NOT rebased (game_time held)"
+                                );
+                            }
+                            None => {}
                         }
+                    } else if args.debug_clock {
+                        eprintln!("[clock] pause");
                     }
                     clock.toggle_pause();
                 }
@@ -1343,6 +1385,9 @@ Escape again to quit"
                         Err(e) => eprintln!("[scrubber] {e}"),
                     }
                     if let Some(tts) = game.current_scene_tts() {
+                        if args.debug_clock {
+                            eprintln!("[clock] seek frame={f}: rebase tts={tts:.3}");
+                        }
                         clock.rebase(tts as f32);
                     }
                     clock.pause();
@@ -1352,6 +1397,9 @@ Escape again to quit"
                     clock.step(1.0 / 60.0);
                 }
                 Some(functor_runtime_common::ui::ScrubberAction::SetGhost(on)) => {
+                    if args.debug_clock {
+                        eprintln!("[clock] ghost {}", if on { "on" } else { "off" });
+                    }
                     ghost_on = on;
                 }
                 Some(functor_runtime_common::ui::ScrubberAction::SetGhostDivisions(n)) => {

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use functor_runtime_common::asset::AssetCache;
-use functor_runtime_common::{Frame, GameClock, RecordedInput, SceneContext};
+use functor_runtime_common::{Frame, FrameTime, GameClock, RecordedInput, SceneContext};
 use std::collections::{BTreeSet, HashMap};
 
 use functor_runtime_common::Key as InputKey;
@@ -608,14 +608,25 @@ fn run_headless(
 
     loop {
         let elapsed = start_time.elapsed().as_secs_f32();
-        let time = clock.frame(elapsed - last_time);
+        // Fixed-timestep model loop, same as the windowed loop (docs/time-travel
+        // .md): 0..N fixed 1/60 steps per iteration (one per debug `/time advance`,
+        // one {dts:0} under a pin, none while paused). `time` carries the settled
+        // render `tts` for /scene + /state.
+        let sub_frames = clock.fixed_frames(elapsed - last_time);
         last_time = elapsed;
+        let time = FrameTime {
+            dts: 0.0,
+            tts: clock.current_tts(),
+        };
 
         // Same per-frame ordering as the windowed loop (the source of truth),
         // minus everything that needs GL.
         game.check_hot_reload(time.clone());
         deliver_net_ws(&mut *game, &net_rx, &ws_rx);
-        game.tick(time.clone());
+        for sub in &sub_frames {
+            game.tick(sub.clone());
+            frame_count += 1;
+        }
         dispatch_net_ws(&mut *game, &net_tx, &http_client, &mut ws_manager);
 
         // The frame is pure data (no GL); it powers GET /scene. Drain and drop
@@ -645,7 +656,6 @@ fn run_headless(
             }
         }
 
-        frame_count += 1;
         // Cap the loop near 60 Hz so it doesn't busy-spin a core.
         std::thread::sleep(std::time::Duration::from_millis(16));
     }
@@ -894,21 +904,31 @@ pub fn run(args: Args) {
             if input_script.is_some() && !args.ghost {
                 clock.step(args.script_dt);
             }
-            // The frame time handed to the game. Pinning it (--fixed-time, or the
-            // debug server's /time) makes the rendered pose deterministic — used
-            // for reproducible captures / golden images. The capture trigger
-            // below still keys off wall-clock elapsed, so the loop runs long
-            // enough for assets to load before a shot is taken.
-            let time = clock.frame(elapsed_time - last_time);
+            // The fixed-timestep model loop (docs/time-travel.md): advance `tick`
+            // in whole 1/60 steps decoupled from the render rate, so the sim is
+            // deterministic and a recorded frame is exactly one forward-step fine
+            // step (the ghost replay's assumption). Scripted playback queued a
+            // one-shot `step` above, so this yields exactly one sub-frame then;
+            // --fixed-time / the debug pin yields one {dts:0} sub-frame; paused
+            // yields none. `time` is the RENDER frame time — the settled `tts` the
+            // frame is drawn / hot-reloaded / reported at (its `dts` is unused by
+            // render/draw). Capture still keys off wall-clock `elapsed_time` so the
+            // loop runs long enough for assets to load before a shot.
+            let real_delta = elapsed_time - last_time;
+            let sub_frames = clock.fixed_frames(real_delta);
             last_time = elapsed_time;
+            let time = FrameTime {
+                dts: 0.0,
+                tts: clock.current_tts(),
+            };
 
-            // Surface frame hitches (a dt past 33ms = under 30fps) — the
+            // Surface frame hitches (a real delta past 33ms = under 30fps) — the
             // signature of the ghost compositor's N forward-steps starving the
             // loop, which reads to the user as "jerky / can't move".
-            if args.debug_clock && time.dts > 1.0 / 30.0 {
+            if args.debug_clock && real_delta > 1.0 / 30.0 {
                 eprintln!(
                     "[clock] HITCH dt={:.1}ms tts={:.3} (slow frame)",
-                    time.dts * 1000.0,
+                    real_delta * 1000.0,
                     time.tts
                 );
             }
@@ -1059,22 +1079,31 @@ Escape again to quit"
                 game.audio_push_finished(token as i32);
             }
 
-            // Scripted input (docs/time-travel.md T6b): feed this frame's events
-            // through the SAME `key_event` path the live GLFW handlers use, before
-            // tick, so this frame's tick sees the scripted key state. Under --ghost
-            // the script drives the GHOST instead (F2): leave the live game at its
-            // init anchor so the strobed arc reads against a clean, static pose.
-            if let Some(script) = input_script.as_ref().filter(|_| !args.ghost) {
-                if let Some(events) = script.get(&frame_count) {
-                    for ev in events {
-                        if let RecordedInput::Key { code, is_down } = ev {
-                            game.key_event(*code, *is_down);
+            // Run this render frame's fixed model steps (0..N). Scripted input
+            // (docs/time-travel.md T6b) is fed per fixed frame through the SAME
+            // `key_event` path the live GLFW handlers use, before that frame's
+            // tick. Under --ghost the script drives the GHOST instead (F2): leave
+            // the live game at its init anchor so the strobed arc reads against a
+            // clean, static pose. `--capture-at-frame` fires on the fixed frame it
+            // names — scripted playback is exactly one fixed step per render frame,
+            // so that index stays deterministic.
+            let mut capture_due = false;
+            for sub in &sub_frames {
+                if let Some(script) = input_script.as_ref().filter(|_| !args.ghost) {
+                    if let Some(events) = script.get(&frame_count) {
+                        for ev in events {
+                            if let RecordedInput::Key { code, is_down } = ev {
+                                game.key_event(*code, *is_down);
+                            }
                         }
                     }
                 }
+                game.tick(sub.clone());
+                if args.capture_at_frame == Some(frame_count) {
+                    capture_due = true;
+                }
+                frame_count += 1;
             }
-
-            game.tick(time.clone());
 
             // Perform the HTTP + WebSocket commands this frame's tick queued
             // (shared with the headless loop).
@@ -1416,7 +1445,7 @@ Escape again to quit"
                 // for scripted runs) or after --capture-time wall-clock seconds
                 // (the default, so assets have time to load).
                 let shoot = match args.capture_at_frame {
-                    Some(n) => frame_count == n,
+                    Some(_) => capture_due,
                     None => elapsed_time >= args.capture_time,
                 };
                 if shoot {
@@ -1456,7 +1485,6 @@ Escape again to quit"
             }
 
             window.swap_buffers();
-            frame_count += 1;
         }
     }
 

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -1045,14 +1045,19 @@ async fn run_async() -> Result<(), JsValue> {
             let viewport = functor_runtime_common::Viewport::new(canvas.width(), canvas.height());
 
             // Forward-ghosting (docs/time-travel.md T6d): when the DOM ghost
-            // toggle is on, forward-step the scene over `ghost_window` seconds in
-            // `ghost_divisions` slices and composite them at equal weight, so
-            // moving elements strobe across their future and static geometry stays
-            // solid. `None` = the recorded-log/coast path (web has no
-            // --input-script). Empty (→ this arm skipped) leaves live rendering
-            // unchanged. The web scrubber is always visible, so there is no
-            // overlay gate (unlike native's `~`).
-            let ghosts = if ghost_on {
+            // toggle is on AND the clock is paused, forward-step the scene over
+            // `ghost_window` seconds in `ghost_divisions` slices and composite them
+            // at equal weight, so moving elements strobe across their future and
+            // static geometry stays solid. `None` = the recorded-log/coast path
+            // (web has no --input-script). Empty (→ this arm skipped) leaves live
+            // rendering unchanged.
+            //
+            // Gated on `is_paused()` to match the desktop shell: the strobe is a
+            // preview of a FROZEN frame's future, and forward-stepping the scene N
+            // times every LIVE rAF frame would starve the wasm render loop (the
+            // interpreter forward-step is costly on WebGL2). Pause via the DOM
+            // scrubber to see it.
+            let ghosts = if ghost_on && clock.is_paused() {
                 let divisions = ghost_divisions.clamp(1, 8);
                 let dt = ghost_window / divisions as f32;
                 game.ghost_frames(divisions, dt, frame_time.tts as f64, None)

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -979,20 +979,31 @@ async fn run_async() -> Result<(), JsValue> {
                 }
             }
 
-            // `?fixed-time` pins unconditionally (deterministic capture); pause
-            // freezes; a queued step advances one frame; else the clock advances
-            // by the real frame delta.
-            let frame_time = clock.frame((now - last_time) / 1000.0);
-
+            // Fixed-timestep model loop (docs/time-travel.md), mirroring the
+            // desktop shells: advance `tick` in whole 1/60 steps decoupled from
+            // the render (rAF) rate, so the sim is deterministic and a recorded
+            // frame is exactly one forward-step fine step (the ghost replay's
+            // assumption). `?fixed-time` yields one {dts:0} sub-frame (golden
+            // capture unchanged); a queued step yields one; paused yields none.
+            // `frame_time` is the RENDER frame time — the settled `tts` the frame
+            // is drawn / soundscaped / scrub-published at (its `dts` is unused).
+            let sub_frames = clock.fixed_frames((now - last_time) / 1000.0);
             last_time = now;
+            let frame_time = FrameTime {
+                dts: 0.0,
+                tts: clock.current_tts(),
+            };
 
             // Deliver page input queued since the last frame (the MLE path's
-            // `mle_*` exports). While paused, drain-and-discard: no input may
-            // reach the model on a paused frame (the input log would otherwise
-            // diverge replay), and draining stops the queue bursting on resume.
+            // `mle_*` exports), once per rendered frame before this frame's steps.
+            // While paused, drain-and-discard: no input may reach the model on a
+            // paused frame (the input log would otherwise diverge replay), and
+            // draining stops the queue bursting on resume.
             mle_game::drain_input(&mut **game, !clock.is_paused());
 
-            game.tick(frame_time.clone());
+            for sub in &sub_frames {
+                game.tick(sub.clone());
+            }
 
             // Perform any networking commands this frame's tick queued; results
             // are pushed back into the inbox asynchronously and decoded by a later

--- a/runtime/functor-runtime-web/src/mle_game.rs
+++ b/runtime/functor-runtime-web/src/mle_game.rs
@@ -402,18 +402,27 @@ impl GameProducer for MleWebGame {
         if result.is_ok() {
             self.deferred_queries.clear();
             self.pending_events.clear();
+            // Model restored to `target`; drop orphaned buffered input so it can't
+            // record into the branch (fixed-timestep 0-substep buffering, xreview).
+            self.input_buf.clear();
         }
         result
     }
 
     fn seek_scene_to(&mut self, target: u64) -> Result<String, String> {
-        self.recorder.seek_scene_to(
+        let result = self.recorder.seek_scene_to(
             target,
             &mut self.model,
             &mut self.physics_rt,
             &mut self.physics_status,
             self.has_physics,
-        )
+        );
+        if result.is_ok() {
+            // Same as rewind: the model was restored, so buffered input since the
+            // last recorded frame is orphaned and must not enter the branch.
+            self.input_buf.clear();
+        }
+        result
     }
 
     fn current_scene_frame(&self) -> Option<u64> {


### PR DESCRIPTION
## What & why

Fixes the interactive **scrubber + forward-ghost** (docs/time-travel.md): the strobe
was scrambled/unusable during live play. Two root causes, fixed here:

1. **The ghost composited every live frame** while the scrubber overlay was open —
   N (≤8) full forward-sims per frame starved the loop ("can't move with the
   scrubber open"). Now the interactive ghost only renders while **paused** (its
   strobe is a preview of a *frozen* frame). `--fixed-time` capture path unchanged.
2. **Recording ran at variable wall-clock dt** (e.g. 140fps), but the forward-step
   replay assumes *one recorded frame == one 1/60 fine step* (`mle_producer.rs:338`).
   The mismatch scrambled the arc. Fixed by a **fixed-timestep model loop**: `tick`
   now advances in whole 1/60 steps decoupled from the render rate, so the sim is
   deterministic (live == replay == ghost) and in lockstep with physics' existing
   1/60 accumulator.

## Commits
- **slice 1** — gate the interactive ghost on `is_paused()`; add `--debug-clock`
  diagnostics (pause/resume/seek rebases, ghost on/off, per-frame HITCH warnings).
- **3a** — `GameClock::fixed_frames(real_delta) -> Vec<FrameTime>`: accumulator that
  emits 0..N whole `FIXED_DT` (1/60) sub-frames per rendered frame (clamped to
  MAX_SUBSTEPS=8), plus `current_tts()`. Pure, 12 unit tests.
- **3b** — wire both desktop loops (windowed + headless) to `fixed_frames`; render
  once at `current_tts()`. Scripted playback / `--capture-at-frame` / `--fixed-time`
  golden path all preserved.
- **test** — interactive scrubber→ghost path reproduces the recorded arc to 1e-9.
- **3c** — wire the web (wasm) loop the same way, so the vscode/website preview
  records at fixed 1/60 too. `?fixed-time` wasm golden unchanged.
- **fix #1 (xreview)** — clear `input_buf` on scrub/rewind restore, so a live input
  buffered on a 0-substep frame can't leak a phantom event into the branch.

## Testing
- 12 `game_clock` unit tests + 40 desktop tests (incl. two new time-travel tests) —
  all green under `--features strict`.
- wasm golden passes in headless Chromium (render + `?fixed-time` unchanged).
- mario `--fixed-time` capture byte-identical (golden path untouched).

## Review
Ran the cross-engine `xreview` (Codex was rate-limited, so single-engine Claude
adversarial). One Medium finding (the `input_buf` leak) — fixed + regression-tested
above. Two Low findings acknowledged: `GameClock::frame()` retained as documented
legacy API; `/state.frame` now counts fixed ticks (aligns with the recorder index).

## Notes
- Fixed timestep means the model runs at 60Hz with no render interpolation — on a
  >60Hz display motion may look marginally less fluid than the old variable-dt path.
  `FIXED_DT` must be 1/60 (it must equal the forward-step `sub_dt`). Render
  interpolation is a possible follow-up.
- Ghost **visibility** (the faint strobe) is intentionally a separate follow-up PR
  (bright demo cube + a `--ghost-blend` mode + a multi-scene comparison).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
