### PR TITLE
feat(cli): region-aware logging — log events + Rust log facade (logging PR-4a)

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,6 +13,9 @@ path = "src/main.rs"
 mle = { path = "../mle" }
 clap = { version = "4.5.6", features = ["derive"] }
 colored = "2.1.0"
+# The `log` facade: the CLI installs a logger that turns any `log!` (its own or
+# the in-process runtime's) into a region-aware `Event::Log` (cli/src/output.rs).
+log = "0.4"
 # The ink-style live region: spinners + a sticky telemetry panel above
 # scrollback, on an interactive TTY only (see cli/src/output/live.rs).
 indicatif = "0.17"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -38,6 +38,11 @@ struct Args {
     #[arg(long, global = true)]
     ascii: bool,
 
+    /// Show debug/info logs (default: warnings + errors only). `RUST_LOG=<level>`
+    /// overrides.
+    #[arg(short, long, global = true)]
+    verbose: bool,
+
     #[command(subcommand)]
     command: Command,
 }
@@ -154,7 +159,7 @@ async fn main() -> tokio::io::Result<()> {
     let started = Instant::now();
     let args = Args::parse();
 
-    output::init(args.json, args.quiet, args.no_color, args.ascii);
+    output::init(args.json, args.quiet, args.no_color, args.ascii, args.verbose);
 
     // When the live (ink-style) renderer is up, a Ctrl-C would otherwise kill
     // the process mid-draw and leave the sticky live region stranded on screen.

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -26,6 +26,29 @@ pub enum Severity {
     Warning,
 }
 
+/// The level of a free-form [`Event::Log`] line. Mirrors the `log` crate's
+/// levels (trace folds into `Debug`); serialized snake_case for the JSON schema.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LogLevel {
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+impl From<log::Level> for LogLevel {
+    fn from(level: log::Level) -> Self {
+        match level {
+            log::Level::Error => LogLevel::Error,
+            log::Level::Warn => LogLevel::Warn,
+            log::Level::Info => LogLevel::Info,
+            // Trace is rare and folds into Debug — the CLI has no separate tier.
+            log::Level::Debug | log::Level::Trace => LogLevel::Debug,
+        }
+    }
+}
+
 /// A user-visible thing the CLI wants to say. Serialized as
 /// `{"type": "<snake_case>", …}` — the stable machine API (see
 /// `docs/cli-output.md`). Only the PR-1 (CLI-side) variants live here; the
@@ -103,6 +126,11 @@ pub enum Event {
     /// native runtime; wired with the wasm serve path).
     #[allow(dead_code)]
     Reload,
+    /// A free-form log line — any `log::{debug,info,warn,error}!` call in the CLI
+    /// or the in-process runtime, funneled through the region-aware renderer so
+    /// it never corrupts the live panel or the ndjson stream (see
+    /// `docs/cli-output.md`).
+    Log { level: LogLevel, message: String },
 }
 
 impl From<functor_runtime_common::events::RuntimeEvent> for Event {
@@ -131,15 +159,17 @@ impl From<functor_runtime_common::events::RuntimeEvent> for Event {
 }
 
 impl Event {
-    /// Whether `--quiet` keeps this event (errors + final status only).
+    /// Whether `--quiet` keeps this event (errors + final status only). A log
+    /// line survives `--quiet` only at warn/error — debug/info are suppressed.
     fn is_essential(&self) -> bool {
-        matches!(
-            self,
+        match self {
             Event::Error { .. }
-                | Event::Diagnostic { .. }
-                | Event::CommandFinished { .. }
-                | Event::AssetError { .. }
-        )
+            | Event::Diagnostic { .. }
+            | Event::CommandFinished { .. }
+            | Event::AssetError { .. } => true,
+            Event::Log { level, .. } => matches!(level, LogLevel::Warn | LogLevel::Error),
+            _ => false,
+        }
     }
 }
 
@@ -307,6 +337,16 @@ impl PlainRenderer {
                 )]
             }
             Event::Reload => vec![format!("{} reload", g_reload().cyan())],
+            Event::Log { level, message } => {
+                // ASCII-safe level tags (`[debug]` … already plain ASCII).
+                let tag = match level {
+                    LogLevel::Debug => "[debug]".dimmed(),
+                    LogLevel::Info => "[info]".cyan(),
+                    LogLevel::Warn => "[warn]".yellow().bold(),
+                    LogLevel::Error => "[error]".red().bold(),
+                };
+                vec![format!("{tag} {message}")]
+            }
         }
     }
 }
@@ -413,10 +453,65 @@ fn detect_ascii(force_ascii: bool) -> bool {
 static RENDERER: OnceLock<Box<dyn Renderer>> = OnceLock::new();
 static LIVE_ACTIVE: AtomicBool = AtomicBool::new(false);
 
+/// Whether a log record belongs to Functor's own crates (its `target` defaults
+/// to the module path, so `functor_runtime_common::…`, `functor_cli`, `mle::…`).
+/// We scope to these so `-v` means "Functor's debug logs" — not the debug/trace
+/// firehose of transitive deps (notify/mio/tokio/hyper/glow/egui/gltf all use
+/// `log`), and so a noisy dependency warning never lands in normal CLI output.
+fn is_functor_target(target: &str) -> bool {
+    target.starts_with("functor") || target == "mle" || target.starts_with("mle::")
+}
+
+/// A `log::Log` that funnels every Functor `log::{debug,info,warn,error}!` call
+/// (from the CLI or the in-process runtime) into an [`Event::Log`], so free-form
+/// logs travel the same region-aware renderer as everything else. Level is gated
+/// cheaply by `log`'s global `max_level` (set in [`init`]); target scoping keeps
+/// dependency logs out.
+struct EventLogger;
+
+impl log::Log for EventLogger {
+    fn enabled(&self, metadata: &log::Metadata) -> bool {
+        // Global `max_level` gates the level; we additionally scope to Functor's
+        // own crates so a `-v` firehose from deps never floods the renderer.
+        is_functor_target(metadata.target())
+    }
+
+    fn log(&self, record: &log::Record) {
+        // `log!` checks `enabled` first, but be defensive against a record with a
+        // custom target that skips it.
+        if !is_functor_target(record.target()) {
+            return;
+        }
+        emit(Event::Log {
+            level: record.level().into(),
+            message: record.args().to_string(),
+        });
+    }
+
+    fn flush(&self) {}
+}
+
+/// Pick the log level: an explicit `RUST_LOG` (a bare level — `debug`, `warn`,
+/// …) wins; else `-v/--verbose` opens debug; else the quiet default (warn/error
+/// only), which keeps the CLI silent unless something needs attention.
+fn log_level(verbose: bool) -> log::LevelFilter {
+    if let Some(filter) = std::env::var("RUST_LOG")
+        .ok()
+        .and_then(|v| v.trim().parse::<log::LevelFilter>().ok())
+    {
+        return filter;
+    }
+    if verbose {
+        log::LevelFilter::Debug
+    } else {
+        log::LevelFilter::Warn
+    }
+}
+
 /// Select and install the process-wide renderer from the global flags +
 /// environment. Called once at startup, before any command logic runs. See
 /// `docs/cli-output.md` for the selection table.
-pub fn init(json: bool, quiet: bool, no_color: bool, ascii: bool) {
+pub fn init(json: bool, quiet: bool, no_color: bool, ascii: bool, verbose: bool) {
     // Color only on a real TTY, and never under NO_COLOR / --no-color / CI /
     // --json. Enforced globally so no code path can leak ANSI.
     let color = !json
@@ -446,6 +541,13 @@ pub fn init(json: bool, quiet: bool, no_color: bool, ascii: bool) {
         Box::new(PlainRenderer { quiet })
     };
     let _ = RENDERER.set(renderer);
+
+    // Install the `log` facade AFTER the renderer, so any `log!` — from the CLI
+    // or the in-process runtime — becomes an `Event::Log` routed through the
+    // region-aware renderer. `max_level` gates cheaply, so a suppressed
+    // `log::debug!` on the hot path costs almost nothing.
+    log::set_max_level(log_level(verbose));
+    let _ = log::set_boxed_logger(Box::new(EventLogger));
 }
 
 /// True when the live renderer is installed. `main` uses this to arm a Ctrl-C

--- a/docs/cli-output.md
+++ b/docs/cli-output.md
@@ -60,8 +60,8 @@ panic (a chained panic hook).
 is the explicit opt-in to ndjson. TTY detection uses `std::io::IsTerminal` (std, no dep).
 
 Flags are **global** (accepted before or after the subcommand): `--json`, `--quiet`,
-`--no-color`, `--ascii`. `--json` takes precedence: under `--json`, `--quiet` is a no-op (the full
-event stream is emitted — machine consumers filter it themselves).
+`--no-color`, `--ascii`, `-v/--verbose`. `--json` takes precedence: under `--json`, `--quiet` is a
+no-op (the full event stream is emitted — machine consumers filter it themselves).
 
 **ASCII glyph fallback (PR-3).** The human renderers use unicode status glyphs (`▸ ✓ ✗ ◈ ↻`) and a
 braille spinner / block budget bar. On a terminal that can't render them, they degrade to ASCII
@@ -72,6 +72,43 @@ both the plain and live renderers), when any of: `--ascii` is passed, `TERM=dumb
 as UTF-8, so the default is unchanged. `--json` is pure structured data (no glyphs) and is
 unaffected. ASCII mode is orthogonal to color: a color TTY under `TERM=dumb`/`--ascii` keeps its
 colored live region but swaps in the ASCII glyphs.
+
+## Logging & verbosity (PR-4a)
+
+Free-form logs are first-class events, not raw prints. Any `log::{debug,info,warn,error}!` call —
+in the CLI **or** the in-process runtime (or a runtime dependency) — is turned into an
+[`Event::Log`](#the-log-event) and travels the **same region-aware renderer** as everything else.
+This is the crux: under the live renderer a log line is committed with `MultiProgress::println`, so
+it lands in scrollback **above** the sticky telemetry panel and the panel redraws intact — a raw
+`println!` into that region would corrupt it. Under `--json` a log is one more ndjson object; under
+`PlainRenderer` it's a plain `[level] message` line.
+
+**How it's wired.** The CLI installs one process-wide `log::Log` in `output::init` (a small adapter
+in `cli/src/output.rs`) that maps each `log::Record` onto `Event::Log { level, message }` and calls
+`output::emit`. The runtime crates depend only on the `log` **facade** (never on `cli`), so a plain
+`log::debug!("…")` in `runtime/` renders cleanly with zero coupling. Structured, schema'd facts
+(`frame_stats`, `capture_written`, `hot_reload`, `asset_error`, `runtime_ready`) still go through the
+typed `functor_runtime_common::events` sink — the `log` facade is only for **free-form** diagnostics.
+
+**Scoped to Functor's crates.** The logger filters on `record.target()` (which defaults to the
+module path) to Functor's own crates — `functor*` and `mle`. Transitive deps (notify, mio, tokio,
+hyper, glow, egui, gltf, …) all use `log` too, so without this a `-v` run would drown in their
+debug/trace and any dep `warn!` would surface in normal output. Scoping keeps `-v` meaning "*Functor's*
+debug logs."
+
+**Level & verbosity.** `log`'s global `max_level` gates cheaply (a suppressed `log::debug!` on a hot
+path is nearly free — just a level compare), decided once in `init`:
+
+| Condition (first match wins) | Level shown |
+| ---------------------------- | ----------- |
+| `RUST_LOG=<level>` set (a bare `error`/`warn`/`info`/`debug`/`trace`) | that level |
+| `-v` / `--verbose`           | `debug` and up (debug/info/warn/error) |
+| otherwise (default)          | `warn` and up (warn/error only) — the CLI stays quiet |
+
+So the CLI is **quiet by default** (warnings + errors); `-v` (or `RUST_LOG=debug`) opens the
+debug/info firehose. `--quiet` independently suppresses any log below `warn` in the plain renderer,
+so `-v --quiet` still shows only warn/error. Under `--json` the level gate still applies (a default
+`--json` run carries warn/error logs; `-v --json` carries debug/info too) — always as valid ndjson.
 
 ## The `Event` schema (stable API)
 
@@ -167,6 +204,19 @@ Example tail of `functor -d examples/lighting run native --json` (frame stats + 
 {"type":"capture_written","path":"/tmp/frame.png"}
 ```
 
+### The `log` event (PR-4a)
+
+The one free-form event — any `log::{debug,info,warn,error}!` in the CLI or the in-process runtime,
+funneled through the region-aware renderer (see [Logging & verbosity](#logging--verbosity-pr-4a)).
+
+| `type` | Fields                                                                    | Emitted when |
+| ------ | ------------------------------------------------------------------------- | ------------ |
+| `log`  | `level` (`"debug"`\|`"info"`\|`"warn"`\|`"error"`), `message` (string)     | a `log!` call passes the active level |
+
+```json
+{"type":"log","level":"debug","message":"loaded asset 'grid-neon.png' (24601 bytes)"}
+```
+
 ## Runtime-output routing — the event sink (PR-2a)
 
 Post-#243 `functor run native` drives the desktop runtime **in the CLI's process**. That runtime
@@ -207,9 +257,12 @@ visible where they were.
 **Everything else stays off stdout.** A few flag-gated runtime notices have no natural event —
 `--headless` mode, the `--debug-port` "listening on…" line, `--replay` "loaded N frames" — so they
 go to **stderr**, not the event stream. That keeps stdout pure ndjson under `--json` even for the
-`--debug-port` / `--headless` combos an SDK/automation consumer uses. (Interactive, TTY-only notices
-— cursor-release hints, Xreal tracking status — remain plain stdout lines; they only fire on a
-focused window with a real user, never on a piped/`--json`/captured run.)
+`--debug-port` / `--headless` combos an SDK/automation consumer uses. Free-form runtime status that
+*doesn't* map to a structured event (e.g. Xreal connect/calibration status, or an asset-load debug
+line) now goes through the **`log` facade** (PR-4a) instead of a raw `println!`, so it too renders
+region-aware and never corrupts `--json`. (The two genuinely-interactive TTY notices — the
+cursor-release hint and the F1-recenter ack — stay plain stdout `println!`; they only fire on a
+keypress in a focused window, never on a piped/`--json`/captured run.)
 
 ## Phasing
 
@@ -223,8 +276,13 @@ focused window with a real user, never on a piped/`--json`/captured run.)
   `✓` line, and a sticky `run native` telemetry panel that consumes `frame_stats`/`hot_reload`,
   above scrollback. TTY-only; the machine paths are untouched. (A full-screen `--dashboard` is
   explicitly out of scope.)
-- **PR-3 (this, closes the pass):** rich MLE diagnostics (the `source_line` field + a human caret
+- **PR-3 (closes the UX pass):** rich MLE diagnostics (the `source_line` field + a human caret
   block), actionable error `hint`s for common failures, and an ASCII glyph fallback for dumb /
   non-UTF-8 terminals (`--ascii`).
+- **PR-4a (this):** region-aware logging — the `log` event + a `log::Log` facade the CLI installs,
+  so any `log::{debug,info,warn,error}!` (CLI or in-process runtime) renders through the same
+  region-aware path; `-v/--verbose` + `RUST_LOG` set the level (quiet warn/error default). Converts
+  the runtime's informational `println!`s (asset-load debug, Xreal status). PR-4b adds the MLE
+  `Debug.log` builtin through the same path.
 </content>
 </invoke>

--- a/runtime/functor-runtime-common/Cargo.toml
+++ b/runtime/functor-runtime-common/Cargo.toml
@@ -35,6 +35,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 futures = "0.3.30"
 async-trait = "0.1.80"
+# The `log` facade for free-form runtime diagnostics (e.g. asset-load debug
+# lines). The shell installs the logger; here we only emit through `log::*!`.
+log = "0.4"
 gltf = { version = "1.4.1", features = ["names", "KHR_materials_pbrSpecularGlossiness"] }
 
 [target.'cfg(not(any(target_arch = "wasm32")))'.dependencies]

--- a/runtime/functor-runtime-common/src/asset/asset_cache.rs
+++ b/runtime/functor-runtime-common/src/asset/asset_cache.rs
@@ -63,6 +63,15 @@ impl AssetCache {
         // If not cached, load bytes asynchronously
         let bytes_future = async move {
             let bytes = load_bytes_async2(asset_path_owned.clone()).await?;
+            // Region-aware debug line (see docs/cli-output.md): under the CLI's
+            // logger this becomes an `Event::Log` printed above the live panel;
+            // silent unless `-v`/`RUST_LOG=debug`. Fires once per asset (on the
+            // first load), not on the per-frame hot path.
+            log::debug!(
+                "loaded asset '{}' ({} bytes)",
+                asset_path_owned,
+                bytes.len()
+            );
             bytes_cache
                 .lock()
                 .unwrap()

--- a/runtime/functor-runtime-desktop/Cargo.toml
+++ b/runtime/functor-runtime-desktop/Cargo.toml
@@ -28,6 +28,9 @@ notify-debouncer-full = "0.3.1"
 tempfile = "3.10.1"
 clap = { version = "4.5.6", features = ["derive"] }
 async-trait = "0.1.80"
+# The `log` facade for free-form runtime diagnostics (routed region-aware by the
+# CLI's logger). Structured events still go through `functor_runtime_common::events`.
+log = "0.4"
 
 [target.'cfg(not(any(target_arch = "wasm32")))'.dependencies]
 functor-netsim = { path = "./../functor-netsim" }

--- a/runtime/functor-runtime-desktop/src/xreal.rs
+++ b/runtime/functor-runtime-desktop/src/xreal.rs
@@ -334,15 +334,15 @@ fn reader_loop(
     loop {
         match TcpStream::connect_timeout(addr, Duration::from_secs(2)) {
             Ok(mut stream) => {
-                println!("[xreal] connected to {addr}; calibrating (keep the glasses still)…");
+                log::info!("[xreal] connected to {addr}; calibrating (keep the glasses still)…");
                 let _ = stream.set_read_timeout(Some(Duration::from_secs(2)));
                 read_stream(&mut stream, shared, recenter_flag);
-                println!("[xreal] stream ended; reconnecting…");
+                log::info!("[xreal] stream ended; reconnecting…");
                 // The old orientation would be stale after a gap; hold the
                 // last pose (identity jump on reconnect is worse).
             }
             Err(e) => {
-                println!("[xreal] connect to {addr} failed ({e}); retrying in 2s (are the glasses plugged in?)");
+                log::warn!("[xreal] connect to {addr} failed ({e}); retrying in 2s (are the glasses plugged in?)");
             }
         }
         // Pause on both paths — an accept-then-immediate-close peer must not
@@ -382,7 +382,7 @@ fn read_stream(
                     calibration.push(sample);
                     if calibration.len() >= CALIBRATION_SAMPLES {
                         let bias = gyro_bias(&calibration);
-                        println!(
+                        log::info!(
                             "[xreal] calibrated: gyro bias [{:+.4} {:+.4} {:+.4}] rad/s — tracking live (F1 recenters)",
                             bias.x, bias.y, bias.z
                         );
@@ -406,12 +406,12 @@ fn read_stream(
                                 // the moment they're put on (gaze drops below
                                 // vertical) instead of losing the one-shot.
                                 if auto_recenter_at.take().is_some() && !manual {
-                                    println!(
+                                    log::info!(
                                         "[xreal] recentered (automatic; F1 to recenter again)"
                                     );
                                 }
                             }
-                            None if manual => println!(
+                            None if manual => log::warn!(
                                 "[xreal] recenter skipped — gaze too vertical; look ahead and press F1 again"
                             ),
                             None => {}


### PR DESCRIPTION
## Logging PR-4a — infra + Rust side

Makes logs **first-class, region-aware events**. Today logging is 43 raw `println!`/`eprintln!` in `runtime/` with no framework; a raw print into the live `run native` telemetry panel's region corrupts it. This routes free-form logs through the existing event stream so a `log!` during a live run lands as clean scrollback **above** the sticky panel, stays clean ndjson under `--json`, and honors `--quiet`.

### What's here
- **`Event::Log { level, message }`** (+ `LogLevel` enum) — serde snake_case: `{"type":"log","level":"debug","message":"…"}`.
- **Region-aware rendering** — the `LiveRenderer`'s catch-all arm commits `Log` via indicatif `MultiProgress::println`, so it lands above the panel and the panel redraws intact (no interleaving). `PlainRenderer` → `[level] message`; `JsonRenderer` → ndjson. `[debug]`/`[info]`/`[warn]`/`[error]` tags are already ASCII (fine under `--ascii`). `--quiet` keeps only warn/error logs.
- **Rust `log` facade** — a `log::Log` installed in `output::init` maps every Functor `log!` onto `Event::Log` through the region-aware path (a plain `log::debug!` in runtime code renders cleanly). **Scoped by `record.target()` to Functor's crates** (`functor*`/`mle`) so `-v` means *Functor's* debug, not the debug/trace firehose of transitive deps (notify/mio/tokio/hyper/glow/egui/gltf all use `log`). Structured facts (`frame_stats`, …) still flow through the `functor_runtime_common::events` sink.
- **Verbosity** — global `-v/--verbose` (or `RUST_LOG=<level>`) sets the level; default warn/error (quiet by default). Documented in `docs/cli-output.md`.
- **Converted the runtime's informational prints** — a new asset-load `log::debug!` in `asset_cache.rs` (the region-aware demo; fires once per asset on first load, not the per-frame hot path), and the Xreal connect/calibration status in `xreal.rs` (which previously corrupted `--json` as raw stdout). The two genuinely-interactive prints (cursor-release hint, F1-recenter ack) stay plain stdout per the doc carve-out.

### The region-aware proof (PTY)
`-v` run under a pty (`python3 pty.spawn`) — each log commits as a complete scrollback line, panel redrawn intact below, no interleaving:
```
[debug] loaded asset 'sky.png' (633 bytes)

⠹ running synthwave · 0s
  warming up…

[debug] loaded asset 'grid-neon.png' (384 bytes)

⠹ running synthwave · 0s
  warming up…
```

### Verified
- `run native -v --json --capture-frame … --fixed-time 2 --capture-time 4` → `log` events present as valid ndjson, **0 raw lines**. Default (no `-v`) `--json` → 0 log lines (dep noise filtered by target scoping).
- piped plain `| cat -v` → **0 ESC**; `--quiet` hides debug/info, keeps warn/error.
- `-v` / `RUST_LOG=debug|info|warn` level control confirmed.
- `cargo build --bin functor` clean; tests green: `functor_runtime_common` (202), `functor-cli` (7), desktop lib (38), `mle` (all).

### Review
Ran `/xreview` (Codex was at its usage limit → Claude engine only). Its Medium finding — the global logger would unleash a dependency firehose under `-v` and surface dep `warn!`s by default — is **fixed** by the `record.target()` scoping above (re-verified: dep GL banner + an egui painter-leak warn no longer appear). Low findings (Xreal positive-status now quiet-by-default; `RUST_LOG` accepts a bare level only) are deliberate, documented decisions.

**PR-4b** — the MLE `Debug.log` builtin through this same region-aware path — follows in a separate PR.
