### PR TITLE
feat(mle): Debug.log — pipe-friendly trace through the region-aware log path (logging PR-4b)

### DIFF
--- a/.claude/skills/mle-language/SKILL.md
+++ b/.claude/skills/mle-language/SKILL.md
@@ -156,9 +156,9 @@ let grab = (s) =>
   (they evaluate first); siblings may reference the entry (`Game.foo`) if
   that creates no cycle.
 - **Protected namespaces**: a file whose module name collides with a
-  builtin/prelude namespace (Net, List, Text, Math, Scene, Camera, Frame,
-  Light, Angle, Time, Sub, Effect, Physics, RenderTarget) is a load error
-  — rename the file.
+  builtin/prelude namespace (Net, List, Text, Math, Debug, Scene, Camera,
+  Frame, Light, Angle, Time, Sub, Effect, Physics, RenderTarget) is a load
+  error — rename the file.
 - **`Net` is a built-in module**, always in scope: `type NetEvent =
   | Connected(id: Float) | Message(id: Float, text: String) |
   Disconnected(id: Float) | Error(id: Float, text: String)`. A `Sub.connect`/
@@ -229,7 +229,19 @@ let grab = (s) =>
 `%d` shape) · `Text.toBullets(list)` · `Text.split(s, sep)` (→ `List<String>`;
 empty `sep` is an error; `Text.split("", sep)` = `[""]`) · `Text.join(list, sep)`
 (strings only) · `Text.parseFloat(s)` (trims; unparseable → `0.0`, the F#
-`unwrap_or(0)` shape) · `Math.clamp01(n)` · `Math.sin(n)` · `Math.cos(n)`
+`unwrap_or(0)` shape) · `Math.clamp01(n)` · `Math.sin(n)` · `Math.cos(n)` ·
+`Debug.log(value, label)` — `('a, String) => 'a`: an Elm-style trace. Logs
+`label: <value>` (the value rendered exactly as `mle run`/`trace` displays it —
+any type) and returns `value` **unchanged**, so it's pure to the program
+result and safe to drop into a pipe: `m.x |> Debug.log("x") |> clamp(0.0, 1.0)`
+logs then passes the value on. Value-FIRST (pipelines prepend), so `label` is
+the second arg. An impure observability escape hatch — it can't affect the
+model/sim (a game with vs without it is byte-identical). Under plain `mle run`
+the line prints to stdout; under the runner it routes region-aware to the
+CLI's log stream (shown by default — no `-v`; `docs/cli-output.md`) — or the
+browser console on wasm. Not rate-limited: a `Debug.log` in `tick`/`draw` fires
+every frame (~60/s), so prefer an event path (`input`/`update`), or remove it
+when done.
 
 ## Functor prelude (only under the engine host — `FunctorHost`)
 

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -26,11 +26,15 @@ pub enum Severity {
     Warning,
 }
 
-/// The level of a free-form [`Event::Log`] line. Mirrors the `log` crate's
-/// levels (trace folds into `Debug`); serialized snake_case for the JSON schema.
+/// The level of a free-form [`Event::Log`] line. `Debug`/`Info`/`Warn`/`Error`
+/// mirror the `log` crate's levels (its `Trace` folds into `Debug`) and are
+/// gated by verbosity (`-v`); `Trace` is a distinct, always-visible tier used
+/// only for explicit MLE `Debug.log` traces (which are user intent, so they
+/// show by default — see `docs/cli-output.md`). Serialized snake_case.
 #[derive(Debug, Clone, Copy, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum LogLevel {
+    Trace,
     Debug,
     Info,
     Warn,
@@ -154,6 +158,13 @@ impl From<functor_runtime_common::events::RuntimeEvent> for Event {
             R::CaptureWritten { path } => Event::CaptureWritten { path },
             R::HotReload { ok, message } => Event::HotReload { ok, message },
             R::AssetError { path, message } => Event::AssetError { path, message },
+            // An MLE `Debug.log` trace: explicit user intent, so it's an
+            // always-visible `Trace`-level log (not `-v`-gated like the `log`
+            // facade). The message is already `"label: value"`.
+            R::MleTrace { message } => Event::Log {
+                level: LogLevel::Trace,
+                message,
+            },
         }
     }
 }
@@ -340,6 +351,7 @@ impl PlainRenderer {
             Event::Log { level, message } => {
                 // ASCII-safe level tags (`[debug]` … already plain ASCII).
                 let tag = match level {
+                    LogLevel::Trace => "[trace]".magenta(),
                     LogLevel::Debug => "[debug]".dimmed(),
                     LogLevel::Info => "[info]".cyan(),
                     LogLevel::Warn => "[warn]".yellow().bold(),

--- a/docs/cli-output.md
+++ b/docs/cli-output.md
@@ -110,6 +110,33 @@ debug/info firehose. `--quiet` independently suppresses any log below `warn` in 
 so `-v --quiet` still shows only warn/error. Under `--json` the level gate still applies (a default
 `--json` run carries warn/error logs; `-v --json` carries debug/info too) — always as valid ndjson.
 
+### MLE `Debug.log` — the always-visible `trace` tier (PR-4b)
+
+MLE's `Debug.log(value, label)` builtin (an Elm-style trace: logs `label: <value>`, returns
+`value` unchanged; see the `mle-language` skill) reuses this same region-aware log path — but with
+**one deliberate difference from the `-v`-gated `log` facade**: a `Debug.log` is *explicit user
+intent*, so it must show **by default, without `-v`**. It rides a distinct, always-visible
+`LogLevel::Trace` tier (rendered `[trace]`), so it is never subject to the `log` `max_level` gate
+above. `--quiet` still suppresses it (quiet is an explicit "shut up" — `Trace` is not essential).
+
+**Why it bypasses the `-v` gate cleanly.** The `-v`/`max_level` gate lives entirely in the `log`
+facade (`EventLogger` in `cli/src/output.rs`). A `Debug.log` does **not** travel that facade — it
+travels the typed `functor_runtime_common::events` sink as a new `RuntimeEvent::MleTrace { message }`
+(the same structured sink as `frame_stats`/`asset_error`), which the CLI maps to
+`Event::Log { level: Trace, message }`. So it never touches `max_level`, yet lands as the same
+region-aware `Event::Log` (above the live panel via `MultiProgress::println`; one more ndjson object
+under `--json`).
+
+**The mle → host sink (dependency-clean).** The `mle` crate must not depend on the runtime/CLI, so
+it owns a process-wide, settable trace sink (`mle::set_trace_sink`, default: print `label: value` to
+stdout — plain `mle run` has no renderer of its own). The Functor host installs the sink once at
+producer startup (`functor_runtime_common::mle_prelude::install_debug_log_sink`), forwarding each
+trace into `events::emit(RuntimeEvent::MleTrace { … })`. The dependency edge stays
+`cli → functor_runtime_common → mle`, never the reverse. Because the sink lives on the *process*
+(not any interpreter `Session`), it **survives MLE hot-reload's `Session` rebuild** — a `Debug.log`
+added to a game live starts routing region-aware on the next frame, never falling back to a raw
+`println!`.
+
 ## The `Event` schema (stable API)
 
 Serialized with serde as `{"type": "<snake_case>", …fields}`. Optional fields are omitted
@@ -204,17 +231,19 @@ Example tail of `functor -d examples/lighting run native --json` (frame stats + 
 {"type":"capture_written","path":"/tmp/frame.png"}
 ```
 
-### The `log` event (PR-4a)
+### The `log` event (PR-4a, PR-4b)
 
 The one free-form event — any `log::{debug,info,warn,error}!` in the CLI or the in-process runtime,
-funneled through the region-aware renderer (see [Logging & verbosity](#logging--verbosity-pr-4a)).
+funneled through the region-aware renderer (see [Logging & verbosity](#logging--verbosity-pr-4a)) —
+plus the always-visible `trace` tier that carries MLE `Debug.log` output (PR-4b).
 
-| `type` | Fields                                                                    | Emitted when |
-| ------ | ------------------------------------------------------------------------- | ------------ |
-| `log`  | `level` (`"debug"`\|`"info"`\|`"warn"`\|`"error"`), `message` (string)     | a `log!` call passes the active level |
+| `type` | Fields                                                                              | Emitted when |
+| ------ | ----------------------------------------------------------------------------------- | ------------ |
+| `log`  | `level` (`"trace"`\|`"debug"`\|`"info"`\|`"warn"`\|`"error"`), `message` (string)     | a `log!` passes the active level, or an MLE `Debug.log` runs (`trace`, always shown) |
 
 ```json
 {"type":"log","level":"debug","message":"loaded asset 'grid-neon.png' (24601 bytes)"}
+{"type":"log","level":"trace","message":"player x: 3.14"}
 ```
 
 ## Runtime-output routing — the event sink (PR-2a)
@@ -279,10 +308,17 @@ keypress in a focused window, never on a piped/`--json`/captured run.)
 - **PR-3 (closes the UX pass):** rich MLE diagnostics (the `source_line` field + a human caret
   block), actionable error `hint`s for common failures, and an ASCII glyph fallback for dumb /
   non-UTF-8 terminals (`--ascii`).
-- **PR-4a (this):** region-aware logging — the `log` event + a `log::Log` facade the CLI installs,
+- **PR-4a:** region-aware logging — the `log` event + a `log::Log` facade the CLI installs,
   so any `log::{debug,info,warn,error}!` (CLI or in-process runtime) renders through the same
   region-aware path; `-v/--verbose` + `RUST_LOG` set the level (quiet warn/error default). Converts
   the runtime's informational `println!`s (asset-load debug, Xreal status). PR-4b adds the MLE
   `Debug.log` builtin through the same path.
+- **PR-4b (this):** the MLE `Debug.log(value, label)` builtin — a pipe-friendly Elm-style trace
+  routed through the region-aware log path as the always-visible `trace` tier (shown by default, no
+  `-v`, since it's explicit user intent). The `mle` crate owns a settable trace sink (default:
+  stdout, for plain `mle run`); the host forwards it into `RuntimeEvent::MleTrace` →
+  `Event::Log { level: trace }`, keeping the `cli → runtime → mle` dependency direction clean. The
+  process-global sink survives hot-reload's `Session` rebuild. (See
+  [MLE `Debug.log`](#mle-debuglog--the-always-visible-trace-tier-pr-4b).)
 </content>
 </invoke>

--- a/docs/mle.md
+++ b/docs/mle.md
@@ -295,6 +295,25 @@ snapshots — no GPU, fully agent-verifiable.
       IS exhaustive, `[a, b]` alone needs a catch-all. Full stack: lexer
       (`..`), parser, lower, eval, HM types, hover/goto/rebind. Verify:
       `mle/examples/lists.mle` + goldens; run/parser/check pin tests.
+- [x] **Language: `Debug.log` trace builtin** (2026-07-06). Core `mle`-crate
+      builtin `Debug.log(value, label) : ('a, String) => 'a` — an Elm-style
+      trace: logs `label: <value>` (the interpreter's own `Value` display, any
+      type) and returns `value` UNCHANGED, so it's pure to the program result
+      and pipe-friendly (`x |> Debug.log("x")`; value-first, label second).
+      Lives in the `mle` crate (works in plain `mle run` AND under the host),
+      routed through a settable, process-wide trace sink (`mle::set_trace_sink`,
+      default: stdout). The Functor host installs a sink
+      (`mle_prelude::install_debug_log_sink`) that forwards each trace into the
+      CLI's region-aware log path as `RuntimeEvent::MleTrace` →
+      `Event::Log { level: trace }` — shown BY DEFAULT (explicit user intent, so
+      it bypasses the `-v` gate), still clean ndjson under `--json`, and the
+      process-global sink survives hot-reload's `Session` rebuild. `Debug` is a
+      protected module namespace. Purely observability: a game with vs without
+      it is byte-identical (verified). *Verify (done):* mle run/check +
+      value-unchanged/sink unit tests; a headless hot-reload regression test in
+      the common producer seam (a `Debug.log` added live routes through the
+      surviving sink); `--json` ndjson-validity + determinism (PNG byte-identity)
+      + protected-namespace checks. Design: `docs/cli-output.md` (PR-4b).
 - [x] **Language: generic type declarations** (done 2026-07-04, the B7
       follow-up both review engines asked for). `type Box<v> = | Full(value:
       v) | Empty` / `type Pair<x, y> = { … }`: checker-only (the runtime

--- a/mle/src/eval.rs
+++ b/mle/src/eval.rs
@@ -979,6 +979,24 @@ most 1000000 cells"
                 [Value::Number(n)] => Ok(Value::Number(n.cos())),
                 _ => err("Math.cos(n) expects one number".to_string()),
             },
+            // Elm-style trace: log `label: <value>` through the process-wide
+            // trace sink and return `value` UNCHANGED — an impure observability
+            // escape hatch that never touches the model/sim (so a game with vs
+            // without a `Debug.log` produces byte-identical state). Value-first
+            // so it's pipe-friendly: `x |> Debug.log("x")`. The value renders
+            // with the interpreter's own `Value` display — the same text as
+            // `mle run`/`trace` — for any type. The sink decides where the line
+            // goes (stdout under plain `mle run`, the region-aware log path
+            // under the host); see `crate::trace`.
+            Builtin::DebugLog => match args.as_slice() {
+                [value, Value::String(label)] => {
+                    crate::trace::emit(format!("{label}: {value}"));
+                    Ok(value.clone())
+                }
+                _ => err(
+                    "Debug.log(value, label) expects a value and a string label".to_string(),
+                ),
+            },
         }
     }
 }
@@ -1173,6 +1191,7 @@ pub enum Builtin {
     TextJoin,
     TextParseFloat,
     MathClamp01,
+    DebugLog,
 }
 
 /// Resolve an [`ExprKind::External`] path against the registry.
@@ -1195,6 +1214,7 @@ pub fn builtin(path: &[String]) -> Option<Builtin> {
         "Math.clamp01" => Builtin::MathClamp01,
         "Math.sin" => Builtin::MathSin,
         "Math.cos" => Builtin::MathCos,
+        "Debug.log" => Builtin::DebugLog,
         _ => return None,
     })
 }
@@ -1218,6 +1238,7 @@ pub fn builtin_name(b: Builtin) -> &'static str {
         Builtin::MathClamp01 => "Math.clamp01",
         Builtin::MathSin => "Math.sin",
         Builtin::MathCos => "Math.cos",
+        Builtin::DebugLog => "Debug.log",
     }
 }
 

--- a/mle/src/lib.rs
+++ b/mle/src/lib.rs
@@ -19,6 +19,7 @@ mod parser;
 pub mod project;
 pub mod rebind;
 mod span;
+pub mod trace;
 pub mod types;
 pub mod value;
 
@@ -30,6 +31,7 @@ pub use lower::lower;
 pub use parser::parse;
 pub use rebind::{rebind_value, RebindReport};
 pub use span::{line_col, Span};
+pub use trace::set_trace_sink;
 pub use types::{check, check_with_types, ExprTypes};
 pub use value::{HostData, Value};
 

--- a/mle/src/project.rs
+++ b/mle/src/project.rs
@@ -57,6 +57,7 @@ const PROTECTED_NAMESPACES: &[&str] = &[
     "Effect",
     "Physics",
     "RenderTarget",
+    "Debug",
 ];
 
 /// A loaded multi-file program: the merged module plus the per-file source

--- a/mle/src/trace.rs
+++ b/mle/src/trace.rs
@@ -1,0 +1,44 @@
+//! The `Debug.log` trace sink.
+//!
+//! `Debug.log(value, label)` (see [`crate::eval`]) is an Elm-style trace: it
+//! logs `label: <value>` and returns `value` unchanged. Where that line *goes*
+//! is a host decision, so the destination is a process-wide, settable sink:
+//!
+//! - **Plain `mle run`** (no host installed): the default sink prints
+//!   `label: value` to stdout — the interpreter has no renderer of its own.
+//! - **Under the Functor host** (the runner): the shell installs a sink that
+//!   forwards the line into the CLI's region-aware log path (an `Event::Log`),
+//!   so a trace lands ABOVE the live telemetry panel / as an ndjson log event
+//!   instead of corrupting stdout (see `docs/cli-output.md`).
+//!
+//! The `mle` crate must not depend on the runtime/CLI, so this is a bare
+//! `Fn(String)` callback the host owns — the same "runtime installs a sink"
+//! shape as `functor_runtime_common::events`. It lives on the *process* (not any
+//! interpreter `Session`), so it survives MLE hot-reload's `Session` rebuild for
+//! free. Unlike `events`' `OnceLock` it is *re-settable* (an `RwLock`) for one
+//! reason: the test seam swaps in a per-test capturing sink. Host installs are
+//! idempotent (a stateless closure), so overwriting is harmless.
+
+use std::sync::RwLock;
+
+type Sink = Box<dyn Fn(String) + Send + Sync>;
+
+static SINK: RwLock<Option<Sink>> = RwLock::new(None);
+
+/// Install the process-wide `Debug.log` trace sink. The host calls this once at
+/// startup to route traces into its own logging path; a later call overwrites
+/// the previous sink (host installs are idempotent, and the test seam swaps in a
+/// capturing sink this way).
+pub fn set_trace_sink(sink: Sink) {
+    *SINK.write().unwrap() = Some(sink);
+}
+
+/// Emit one already-formatted `Debug.log` line (`"label: value"`). With a sink
+/// installed it routes there; otherwise — plain `mle run`, tests, a bare
+/// interpreter — it prints to stdout, the interpreter's only renderer.
+pub fn emit(message: String) {
+    match SINK.read().unwrap().as_ref() {
+        Some(sink) => sink(message),
+        None => println!("{message}"),
+    }
+}

--- a/mle/src/types.rs
+++ b/mle/src/types.rs
@@ -384,6 +384,9 @@ pub fn builtin_signature(b: Builtin) -> Type {
         Builtin::TextParseFloat => func(vec![String], Float),
         // Math.clamp01 / sin / cos : (Float) => Float
         Builtin::MathClamp01 | Builtin::MathSin | Builtin::MathCos => func(vec![Float], Float),
+        // Debug.log : ('a, String) => 'a — logs `label: value` and returns the
+        // value unchanged (Var(0) is generic, so it's transparent in a pipe).
+        Builtin::DebugLog => func(vec![Var(0), String], Var(0)),
     }
 }
 

--- a/mle/tests/project.rs
+++ b/mle/tests/project.rs
@@ -425,6 +425,24 @@ namespace `Scene` — rename the file"
     );
 }
 
+/// `Debug` is protected (the `Debug.log` builtin's namespace), so a sibling
+/// `debug.mle` can't shadow it — a load error names the collision.
+#[test]
+fn debug_namespace_module_name_is_refused() {
+    let err = load_err(
+        "protected-debug",
+        &[
+            ("game.mle", "let main = () => 0.0\n"),
+            ("debug.mle", "let log = 1.0\n"),
+        ],
+    );
+    assert_eq!(
+        err,
+        "debug.mle:1:1: module name `Debug` (from debug.mle) collides with the builtin/prelude \
+namespace `Debug` — rename the file"
+    );
+}
+
 #[test]
 fn non_identifier_file_stems_are_refused() {
     let err = load_err(
@@ -530,7 +548,7 @@ let main = () => p.x
             ),
             // Same field shape, never referenced, never opened.
             (
-                "debug.mle",
+                "extra.mle",
                 "type Point = { x: Float, y: Float }
 ",
             ),

--- a/mle/tests/run.rs
+++ b/mle/tests/run.rs
@@ -806,3 +806,46 @@ fn cons_tail_must_be_a_list() {
     let (message, _, _) = run_err("let main = () => [1.0, ..2.0]");
     assert_eq!(message, "`..` spreads a list, but the tail is a number");
 }
+
+/// `Debug.log(value, label)` is an Elm-style trace: it emits `label: <value>`
+/// through the process-wide sink AND returns the value UNCHANGED (so it is
+/// transparent to the program result and can't affect the model/sim).
+#[test]
+fn debug_log_returns_the_value_unchanged_and_emits_through_the_sink() {
+    use std::sync::{Arc, Mutex};
+
+    // A capturing sink stands in for the real (host) region-aware one.
+    let captured: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_buf = Arc::clone(&captured);
+    mle::set_trace_sink(Box::new(move |m| sink_buf.lock().unwrap().push(m)));
+
+    // Value-first and pipe-friendly: the piped subject is logged and passed on,
+    // so the arithmetic result is exactly what it would be without the trace.
+    assert_eq!(
+        main_result("let main = () => Debug.log(41.0, \"answer\") + 1.0"),
+        "42"
+    );
+    // Works through a pipeline too (`x |> Debug.log(label)` == the value).
+    assert_eq!(
+        main_result("let main = () => 3.0 |> Debug.log(\"piped\") |> Math.clamp01"),
+        "1"
+    );
+    // Any value type renders with the interpreter's own display (records here).
+    assert_eq!(
+        main_result(
+            "let main = () =>\n\
+             let r = Debug.log({ x: 1.0, y: 2.0 }, \"pt\") in r.x"
+        ),
+        "1"
+    );
+
+    let lines = captured.lock().unwrap();
+    assert_eq!(
+        *lines,
+        vec![
+            "answer: 41".to_string(),
+            "piped: 3".to_string(),
+            "pt: { x: 1, y: 2 }".to_string(),
+        ]
+    );
+}

--- a/runtime/functor-runtime-common/src/events.rs
+++ b/runtime/functor-runtime-common/src/events.rs
@@ -47,6 +47,12 @@ pub enum RuntimeEvent {
         path: Option<String>,
         message: String,
     },
+    /// An MLE `Debug.log(value, label)` trace — the already-formatted
+    /// `"label: value"` line. Unlike the `-v`-gated `log` facade, this is
+    /// EXPLICIT user intent, so the shell shows it by default (the CLI maps it
+    /// to an always-visible `Event::Log`; see `docs/cli-output.md`). Fired only
+    /// where a game places a `Debug.log`; a default game emits none.
+    MleTrace { message: String },
 }
 
 type Sink = Box<dyn Fn(RuntimeEvent) + Send + Sync>;

--- a/runtime/functor-runtime-common/src/mle_prelude.rs
+++ b/runtime/functor-runtime-common/src/mle_prelude.rs
@@ -783,6 +783,21 @@ pub fn physics_scene_value(value: &Value) -> Option<&physics::PhysicsScene> {
 /// The prelude host. Stateless; construct one per interpreter session.
 pub struct FunctorHost;
 
+/// Route MLE `Debug.log` traces into the runtime's region-aware event stream.
+///
+/// The `mle` crate owns a process-wide trace sink (default: print to stdout, for
+/// plain `mle run`). The shell calls this once at producer startup to redirect
+/// it into [`events::emit`] as a [`RuntimeEvent::MleTrace`], which the CLI maps
+/// to an always-visible, region-aware `Event::Log` (above the live panel / a
+/// structured ndjson log event) — see `docs/cli-output.md`. It is installed on
+/// the process, NOT on any `Session`, so it survives hot-reload's `Session`
+/// rebuild for free; re-calling it is idempotent (the closure is stateless).
+pub fn install_debug_log_sink() {
+    mle::set_trace_sink(Box::new(|message| {
+        crate::events::emit(crate::events::RuntimeEvent::MleTrace { message });
+    }));
+}
+
 const PATHS: &[&str] = &[
     "Scene.cube",
     "Scene.sphere",
@@ -5113,6 +5128,81 @@ with Ui.topLeft()"
         assert_eq!(
             run_fail("let main = () => Ui.textColor(1.0, \"x\", 0.0, \"a\")"),
             "expected a number, got a string"
+        );
+    }
+
+    /// `Debug.log` added to `tick` via HOT-RELOAD fires on the next frame AND
+    /// still routes through the installed sink — the sink lives on the process
+    /// (installed once at host startup, not on any `Session`), so it survives
+    /// the reload's `Session` rebuild. This regression-guards the failure mode
+    /// where a live-added `Debug.log` would fall back to a raw stdout
+    /// `println!` and corrupt the ndjson stream / live telemetry panel.
+    ///
+    /// The test provides a CAPTURING sink (standing in for the real
+    /// region-aware one `install_debug_log_sink` wires up) and reads back the
+    /// emitted lines.
+    #[test]
+    fn debug_log_added_by_hot_reload_still_routes_through_the_installed_sink() {
+        use std::sync::{Arc, Mutex};
+
+        let captured: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink_buf = Arc::clone(&captured);
+        // The sink is process-global; installed once, BEFORE the reload.
+        mle::set_trace_sink(Box::new(move |m| sink_buf.lock().unwrap().push(m)));
+
+        fn load(src: &str) -> mle::Session {
+            let module = mle::lower(mle::parse(src).expect("parse")).expect("lower");
+            mle::Session::load(&module, &mut FunctorHost)
+                .unwrap_or_else(|f| panic!("load failed: {}", f.error.message))
+        }
+        fn tick(session: &mle::Session, m: f64) -> Value {
+            session
+                .call(
+                    "tick",
+                    vec![Value::Number(m), Value::Number(0.016), Value::Number(1.0)],
+                    &mut FunctorHost,
+                )
+                .expect("tick")
+        }
+
+        // v1: tick has NO Debug.log. A frame emits nothing.
+        let v1 = load(
+            "let init = 0.0\n\
+             let tick = (m, dt, tts) => m + 1.0\n\
+             let draw = (m, tts) => m",
+        );
+        assert_eq!(tick(&v1, 3.0).to_string(), "4");
+        assert!(
+            captured.lock().unwrap().is_empty(),
+            "no trace before a Debug.log is added"
+        );
+
+        // Hot-reload: a NEW Session built from edited source that ADDS a
+        // Debug.log in tick (the producer's reload path rebuilds the Session).
+        let v2 = load(
+            "let init = 0.0\n\
+             let tick = (m, dt, tts) => Debug.log(m + 1.0, \"tick m\")\n\
+             let draw = (m, tts) => m",
+        );
+        // The trace fires on the next frame — model unaffected (returns m + 1).
+        assert_eq!(tick(&v2, 4.0).to_string(), "5");
+        assert_eq!(
+            *captured.lock().unwrap(),
+            vec!["tick m: 5".to_string()],
+            "the added Debug.log routed through the sink that survived the reload"
+        );
+
+        // The reverse: reload back to a Debug.log-free tick → it stops cleanly.
+        let v3 = load(
+            "let init = 0.0\n\
+             let tick = (m, dt, tts) => m + 1.0\n\
+             let draw = (m, tts) => m",
+        );
+        let _ = tick(&v3, 9.0);
+        assert_eq!(
+            captured.lock().unwrap().len(),
+            1,
+            "removing the Debug.log stops emission (still just the one line)"
         );
     }
 }

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -314,6 +314,10 @@ fn project_stamp(path: &str) -> Vec<(PathBuf, SystemTime)> {
 
 impl MleGame {
     pub fn create(path: &str) -> MleGame {
+        // Route MLE `Debug.log` traces into the region-aware event stream (once
+        // per process; survives hot-reload's Session rebuild — the sink is
+        // installed on the process, not the Session). See mle_prelude.
+        functor_runtime_common::mle_prelude::install_debug_log_sink();
         // Stat BEFORE reading: an edit that lands mid-load then compares
         // unequal on the next frame and triggers a reload, instead of being
         // silently absorbed into a stale session.

--- a/runtime/functor-runtime-web/src/mle_game.rs
+++ b/runtime/functor-runtime-web/src/mle_game.rs
@@ -241,6 +241,14 @@ impl MleWebGame {
     /// rendered for `run_async` to fail loud with (there is no keep-running
     /// fallback: a page load either gets a valid game or a console error).
     pub fn create(path: &str, src: String) -> Result<MleWebGame, String> {
+        // Route MLE `Debug.log` traces to the browser console (once per process;
+        // the process-global sink survives hot-reload). The web runtime has no
+        // CLI event stream, so — unlike native, which forwards into the
+        // region-aware log path — a trace goes straight to `console.log`, the
+        // web equivalent of plain `mle run`'s stdout.
+        mle::set_trace_sink(Box::new(|message| {
+            web_sys::console::log_1(&JsValue::from_str(&message));
+        }));
         let loaded = load_source(path, src)?;
         web_sys::console::log_1(&format!("[mle] loaded {path}").into());
         Ok(MleWebGame {


### PR DESCRIPTION
Closes the CLI logging work (stacked on **PR-4a** #261, now merged): the MLE `Debug.log` builtin, routed through PR-4a's region-aware log path.

## The feature — `Debug.log(value, label) -> value`

An Elm-style trace: logs `label: <value>` and returns `value` **unchanged**. Value-first so it's pipe-friendly (MLE pipelines prepend the subject):

```
m.player.x |> Debug.log("player x") |> clamp(0.0, 10.0)   // logs "player x: 3.14", returns 3.14
Debug.log(m.hp, "hp")                                      // logs "hp: 100", returns 100
```

The value renders with the interpreter's own `Value` display (same as `mle run`/`trace`), so it works for **any** type — Float/String/record/ADT/tuple/list. Purely observability: it can't touch the model/sim, so a game with vs without a `Debug.log` is byte-identical.

## Where it lives + how it routes

- A **core builtin in the `mle` crate**, so it works in BOTH plain `mle run` (prints `label: value` to stdout — the interpreter's only renderer) and under the runner host.
- The `mle` crate owns a settable, process-wide **trace sink** (`mle::set_trace_sink`, `mle/src/trace.rs`; default = stdout). The `mle` crate does **not** depend on the runtime/CLI — the host installs the sink. **Native** forwards each trace into a new `functor_runtime_common::events::RuntimeEvent::MleTrace`, which the CLI maps to `Event::Log { level: Trace }`; **wasm** routes to the browser console. Dependency direction stays clean: `cli → functor_runtime_common → mle`.
- The sink lives on the **process** (not any `Session`), so it survives MLE hot-reload's `Session` rebuild — a `Debug.log` added live routes on the next frame, never falling back to a raw `println!`.

## Shows by default, region-aware

`Debug.log` is **explicit user intent**, so it must show **without `-v`** (unlike PR-4a's `-v`-gated internal `log::debug!`). It rides a distinct, always-visible **`LogLevel::Trace`** tier that travels the typed events sink (not the `log` facade), so PR-4a's `max_level`/`-v` gate never applies. Still region-aware (committed above the live telemetry panel via `MultiProgress::println`), still one ndjson `log` object under `--json`. `--quiet` suppresses it (quiet is an explicit "shut up").

## Language

`Debug` added to MLE's **protected namespaces** (a sibling `debug.mle` is a load error). Typecheck signature: generic `('a, String) => 'a` (transparent in a pipe). The `mle-language` skill, `docs/mle.md`, and `docs/cli-output.md` are updated in this PR.

## Verify

- **Plain `mle run`:** `Debug.log` of Float/record/ADT/list all print `label: value` to stdout; program result unaffected (`Debug.log(41.0, "answer") + 1.0` → `42`); pipe-transparent. `mle check` accepts the generic signature, flows the type through a pipe, and rejects a non-String label.
- **Under the host (native `--json`):** trace shows as a valid ndjson `{"type":"log","level":"trace","message":"label: value"}` **by default, no `-v`**; the full run stays valid ndjson (**0 RAW** across 4768 lines). Piped plain shows `[trace] …` with **0 ANSI**; a live-TTY (PTY) run shows it **above an intact** telemetry panel. `--quiet` suppresses it.
- **Determinism:** proven byte-identical with vs without a `Debug.log` — a value-fold (`(true, X, X)`) and a `--fixed-time --capture-frame` PNG (`cmp` byte-identical) of the same game with the calls added to `tick`+`draw`.
- **Protected namespace:** a sibling `debug.mle` fails to load, naming the collision.
- **Tests:** new `mle` unit test (value returned unchanged + sink called, across types) and a **headless hot-reload regression test** in the common producer seam (a `Debug.log` added live routes through the surviving process-global sink). `cargo test -p mle` / `-p functor_runtime_common` / `-p functor-cli` all green; `cargo build --bin functor` clean; web runtime compiles for wasm32.

## Review

`/xreview` run (cross-engine). **Codex was at its usage limit**, so this was a **Claude-only** adversarial review — verdict **clean, no Critical/High**; all correctness axes (determinism, dependency-cleanliness, shows-by-default/ungated, valid ndjson, RwLock safety, `LogLevel::Trace` non-regression, thread-safety) verified. Addressed the Low notes: web sink now routes to `console.log` (was a silent no-op), trimmed an overstated comment, and documented the per-frame flooding caveat in the skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
