### PR TITLE
feat(mle): interpreter benchmark framework + seed corpus (`mle bench`)

### DIFF
--- a/mle/benches/README.md
+++ b/mle/benches/README.md
@@ -1,0 +1,140 @@
+# MLE interpreter benchmarks
+
+A dependency-light, headless harness for timing the **MLE interpreter** on a
+corpus of `.mle` micro-benchmarks. It exists to validate interpreter
+performance across current and future language features — e.g. to confirm the
+pending currying spike doesn't regress the call hot path.
+
+> **This is a diagnostic / A-B tool, not a CI gate.** Absolute numbers are
+> machine-dependent, and raw perf thresholds flake on shared CI hardware. Do
+> **not** wire `mle bench` into per-PR CI as a pass/fail assertion. Use it to
+> compare two versions *on the same machine* (see [A-B a change](#a-b-a-change)).
+
+## Run it
+
+```sh
+npm run bench                                   # the whole corpus, human table
+cargo run -q --release -p mle -- bench --all    # same thing, directly
+cargo run -q --release -p mle -- bench mle/benches/corpus/call_saturated.mle   # one file
+cargo run -q --release -p mle -- bench <dir>    # every *.mle in a directory
+cargo run -q --release -p mle -- bench --all --json    # machine-readable output
+```
+
+Always build `--release` — a debug interpreter is many times slower and not
+representative.
+
+## What it measures
+
+The **interpreter's evaluation hot path, isolated from parsing and lowering.**
+Each benchmark file is parsed, lowered, and loaded into an `mle::Session`
+**once** (untimed); the harness then times *repeated evaluation of `main()`*.
+So `time/op` is the cost of one `main()` evaluation — not startup, parse, or
+typecheck. Each timed call goes through `Session::call`, which stands up a fresh
+interpreter over the session's globals exactly as the runtime does per frame, so
+the number tracks real per-frame cost.
+
+## Methodology (why the numbers are reproducible)
+
+1. **Warmup** — evaluate `main()` for ~50 ms, discarding results (warms caches /
+   branch predictor).
+2. **Auto-calibrate** — grow the iteration count until one timed batch takes
+   ≥ 100 ms, so a fast bench isn't dominated by clock resolution.
+3. **Median of 5** — report the median ns/op across 5 timed batches, plus the
+   min/max `spread` as a stability signal (typically < 3%).
+
+Timing uses `std::time::Instant` only — no `criterion`, no extra deps, so the
+harness stays trivially runnable. `spread` is `(max - min) / median`; if it is
+large on your machine, close background load and re-run.
+
+## The benchmark-file convention
+
+A benchmark is an ordinary `.mle` project whose entry defines a **zero-arg
+`let main`** that performs the unit of work to be timed:
+
+```mle
+// BENCH: <one line naming what this measures>
+let step = (acc, x) => acc + x
+let main = () => List.fold(List.range(1000000), step, 0.0)
+```
+
+Rules:
+
+- **`main` is the timed unit.** Put the work *inside* `main` (or functions it
+  calls), not in a top-level `let` initializer — initializers run once at load
+  (untimed), so work there is invisible to the harness.
+- Every benchmark file is therefore also a normal program:
+  `mle run corpus/<file>.mle` prints `main()`'s result. Handy for verifying a
+  benchmark is correct before trusting its timing.
+- The harness uses the plain-`mle` prelude (no engine host), so benchmarks may
+  use only core builtins (`List.*`, `Text.*`, `Math.*`, user code) — **not**
+  `Scene.*`/`Camera.*`/etc., which resolve only under the runtime host.
+- Because a directory is one MLE project (`file = module`), every `.mle` in
+  `corpus/` loads together. Keep each self-contained; sibling `main`/helper
+  names don't collide (they are per-module).
+
+## A-B a change
+
+Absolute ns/op is machine-specific, so the useful signal is a **before/after on
+the same machine**:
+
+```sh
+# on the base ref
+git switch main
+cargo run -q --release -p mle -- bench --all --json > /tmp/before.json
+
+# on your branch
+git switch my-feature
+cargo run -q --release -p mle -- bench --all --json > /tmp/after.json
+
+# compare ns_per_op per benchmark
+```
+
+Run each side 2–3× to confirm the delta exceeds the `spread`. For call-overhead
+questions specifically, subtract `fold_floor` (the empty-step baseline) from the
+call benches to isolate per-call cost from range-building + fold overhead.
+
+## Adding a benchmark
+
+1. Drop a `corpus/<name>.mle` with a `// BENCH:` header naming what it measures
+   and a zero-arg `let main`.
+2. Size the work so one `main()` call is at least a few hundred microseconds
+   (fold/map over a range) — sub-microsecond benches are mostly noise.
+3. Verify it: `cargo run -q --release -p mle -- run mle/benches/corpus/<name>.mle`.
+4. It joins the table automatically (`--all` globs the directory).
+
+Note: `call_partial.mle` (partial application / currying overhead) is **not**
+included — it requires currying, which is not in `main`. It joins the corpus
+when the currying spike lands.
+
+## Corpus
+
+| file | measures |
+| --- | --- |
+| `call_saturated.mle` | saturated multi-arg closure calls (~2M/eval) — the call hot path |
+| `call_piped.mle` | piped calls that lower to a saturated call (the pipe hot path) |
+| `fold_floor.mle` | the baseline: `List.range(1M)` + a 1M no-op fold (subtract to isolate call cost) |
+| `list_map.mle` | `List.map` + `List.filter` pipeline over 100k, with intermediate allocations |
+| `arith_loop.mle` | arithmetic-heavy fold (mul/add/div + `Math.sin`) over 500k |
+| `recursion.mle` | self-recursion at volume (~1.5M shallow recursive calls) |
+| `pattern_match.mle` | nested bool-literal `match` dispatch over 200k |
+| `adt.mle` | ADT construct + variant-pattern match over 100k |
+| `record_update.mle` | `{ r with … }` record update threaded through a 100k fold |
+
+## Baseline (for orientation only — your numbers will differ)
+
+Apple M3 (Mac15,12), rustc 1.96.0, `--release`:
+
+```
+benchmark               iters       time/op         ops/s    spread
+adt                         2      57.6  ms          17.4      0.4%
+arith_loop                  1     165.8  ms           6.0      0.6%
+call_piped                  1     322.4  ms           3.1      1.6%
+call_saturated              1     329.1  ms           3.0      2.8%
+fold_floor                  1     130.6  ms           7.7      0.7%
+list_map                    3      37.5  ms          26.6      0.2%
+pattern_match               2      70.0  ms          14.3      0.7%
+record_update               4      30.9  ms          32.4      1.8%
+recursion                   1     357.4  ms           2.8      0.7%
+```
+
+The full `--all` run takes ~14 s on that machine (the 1M-fold benches dominate).

--- a/mle/benches/corpus/adt.mle
+++ b/mle/benches/corpus/adt.mle
@@ -1,0 +1,18 @@
+// BENCH: ADT construct + match -- a 100k fold that builds a Shape variant per
+// element and matches it to compute an area. Measures constructor allocation
+// and variant-pattern dispatch together.
+//
+// Convention: `main` is the timed unit of work. Also: `mle run adt.mle`.
+type Shape =
+  | Circle(radius: Float)
+  | Rect(w: Float, h: Float)
+let area = (s: Shape): Float =>
+  match s with
+  | Circle(r) => 3.14159 * r * r
+  | Rect(w, h) => w * h
+let toShape = (x) =>
+  match x > 50000.0 with
+  | true => Circle(x)
+  | false => Rect(x, 2.0)
+let main = () =>
+  List.fold(List.range(100000), (acc, x) => acc + area(toShape(x)), 0.0)

--- a/mle/benches/corpus/arith_loop.mle
+++ b/mle/benches/corpus/arith_loop.mle
@@ -1,0 +1,7 @@
+// BENCH: arithmetic-heavy fold -- 500k iterations, each doing several float
+// ops (mul / add / div) plus a Math.sin builtin call. Measures numeric
+// expression evaluation and builtin dispatch rather than call overhead.
+//
+// Convention: `main` is the timed unit of work. Also: `mle run arith_loop.mle`.
+let step = (acc, x) => acc + x * 2.0 - x / 3.0 + Math.sin(x)
+let main = () => List.fold(List.range(500000), step, 0.0)

--- a/mle/benches/corpus/call_piped.mle
+++ b/mle/benches/corpus/call_piped.mle
@@ -1,0 +1,11 @@
+// BENCH: piped calls that lower to a saturated call (the pipe hot path).
+// Shape: same 1,000,000-element fold, but each step threads x through a pipe:
+//   x |> f(x, 2.0)
+// A pipe is pure syntax, so it lowers DIRECTLY to a single saturated call --
+// no intermediate partial-application value is materialized. This confirms
+// scene-building pipes (`scene |> Scene.color(..) |> ..`) stay free.
+//
+// Convention: `main` is the timed unit of work. Also: `mle run call_piped.mle`.
+let f = (a, b, c) => a + b * c
+let step = (acc, x) => acc + (x |> f(x, 2.0))
+let main = () => List.fold(List.range(1000000), step, 0.0)

--- a/mle/benches/corpus/call_saturated.mle
+++ b/mle/benches/corpus/call_saturated.mle
@@ -1,0 +1,12 @@
+// BENCH: saturated multi-arg calls (the interpreter's call hot path).
+// Shape: fold over a 1,000,000-element range; each step makes one 2-arg call
+// (step) that makes one 3-arg call (f) -- ~2M fully-saturated closure calls,
+// all arguments supplied exactly. This is the number that decides whether
+// currying costs anything on the hot path: it is a pure call-overhead loop.
+//
+// Convention: `main` is the unit of work the bench harness times (see
+// mle/benches/README.md). Also runnable directly: `mle run call_saturated.mle`
+// (result: 1499998500000).
+let f = (a, b, c) => a + b * c
+let step = (acc, x) => acc + f(x, x, 2.0)
+let main = () => List.fold(List.range(1000000), step, 0.0)

--- a/mle/benches/corpus/fold_floor.mle
+++ b/mle/benches/corpus/fold_floor.mle
@@ -1,0 +1,7 @@
+// BENCH: the constant floor -- List.range(1M) allocation + a 1M-iteration
+// List.fold whose step does no work. Subtract this from the other 1M-fold
+// benches to isolate the per-call cost from range building + fold overhead.
+//
+// Convention: `main` is the timed unit of work. Also: `mle run fold_floor.mle`.
+let step = (acc, x) => acc
+let main = () => List.fold(List.range(1000000), step, 0.0)

--- a/mle/benches/corpus/list_map.mle
+++ b/mle/benches/corpus/list_map.mle
@@ -1,0 +1,12 @@
+// BENCH: List.map + List.filter pipeline over a 100k list. Exercises the
+// builtin map/filter hot path plus one closure dispatch per element, and the
+// intermediate list allocations between stages.
+//
+// Convention: `main` is the timed unit of work. Also: `mle run list_map.mle`.
+let double = (x) => x * 2.0
+let isBig = (x) => x > 100000.0
+let main = () =>
+  List.range(100000)
+    |> List.map(double)
+    |> List.filter(isBig)
+    |> List.fold((acc, x) => acc + x, 0.0)

--- a/mle/benches/corpus/pattern_match.mle
+++ b/mle/benches/corpus/pattern_match.mle
@@ -1,0 +1,14 @@
+// BENCH: match-arm dispatch -- a 200k fold whose step classifies each element
+// with nested bool-literal matches (MLE's only conditional). Measures match
+// evaluation and arm selection, with no deep recursion.
+//
+// Convention: `main` is the timed unit of work. Also: `mle run pattern_match.mle`.
+let classify = (x) =>
+  match x > 150000.0 with
+  | true => 3.0
+  | false =>
+    (match x > 50000.0 with
+     | true => 2.0
+     | false => 1.0)
+let main = () =>
+  List.fold(List.range(200000), (acc, x) => acc + classify(x), 0.0)

--- a/mle/benches/corpus/record_update.mle
+++ b/mle/benches/corpus/record_update.mle
@@ -1,0 +1,10 @@
+// BENCH: record update `{ r with ... }` -- a 100k fold that threads a record
+// accumulator, updating two fields each step. Measures record clone + field
+// update per iteration.
+//
+// Convention: `main` is the timed unit of work. Also: `mle run record_update.mle`.
+type Acc = { sum: Float, count: Float }
+let step = (r: Acc, x: Float): Acc => { r with sum: r.sum + x, count: r.count + 1.0 }
+let main = () =>
+  let final = List.fold(List.range(100000), step, { sum: 0.0, count: 0.0 }) in
+  final.sum + final.count

--- a/mle/benches/corpus/recursion.mle
+++ b/mle/benches/corpus/recursion.mle
@@ -1,0 +1,17 @@
+// BENCH: self-recursion -- a 50k fold whose step calls `sumTo`, which recurses
+// to a fixed depth of 30 via a bool-literal match base case (MLE has no loops;
+// iteration that is not a List.* builtin is recursion). ~1.5M recursive calls
+// total. Measures call/return + environment overhead of MLE recursion.
+//
+// Depth per call is kept shallow: the interpreter caps evaluation nesting
+// (MAX_EVAL_DEPTH), so unbounded user recursion is intentionally not a thing --
+// deep iteration belongs in List.fold. Here recursion is exercised at volume
+// (many shallow recursions) rather than one deep one.
+//
+// Convention: `main` is the timed unit of work. Also: `mle run recursion.mle`.
+let sumTo = (n, acc) =>
+  match n < 1.0 with
+  | true => acc
+  | false => sumTo(n - 1.0, acc + n)
+let main = () =>
+  List.fold(List.range(50000), (acc, x) => acc + sumTo(30.0, 0.0), 0.0)

--- a/mle/src/bench.rs
+++ b/mle/src/bench.rs
@@ -1,0 +1,269 @@
+//! `mle bench` — a dependency-light interpreter microbenchmark harness.
+//!
+//! # What it measures
+//!
+//! The MLE *interpreter*, isolated from parsing and lowering. A benchmark file
+//! is an ordinary `.mle` project whose entry defines a zero-arg `let main`; the
+//! harness parses + lowers + loads it **once** (untimed), then times *repeated
+//! evaluation of `main()`*. So the reported number is per-`main()`-evaluation
+//! cost — the tree-walking interpreter's hot path — not startup, parse, or
+//! typecheck. (Each timed call goes through [`mle::Session::call`], which spins
+//! up a fresh interpreter over the session's globals exactly as the runtime
+//! does per frame, so the number is representative of live per-frame cost.)
+//!
+//! # Methodology (reproducibility)
+//!
+//! 1. **Warmup** — evaluate `main()` for [`WARMUP`] wall-clock, discarding
+//!    results (warms caches / branch predictor / any lazy init).
+//! 2. **Auto-calibrate** — grow the iteration count until one timed batch takes
+//!    at least [`MIN_BATCH`], so short benches aren't dominated by clock noise.
+//! 3. **Median of [`SAMPLES`]** — take that many timed batches and report the
+//!    median ns/op, plus the min/max spread as a stability signal.
+//!
+//! Absolute numbers are **machine-dependent**: this is a diagnostic / A-B tool,
+//! not a pass/fail gate. To evaluate a change, run it on the base ref and on
+//! your branch *on the same machine* and compare. See `mle/benches/README.md`.
+
+use std::hint::black_box;
+use std::path::{Path, PathBuf};
+use std::process::exit;
+use std::time::{Duration, Instant};
+
+/// Warmup wall-clock before timing begins.
+const WARMUP: Duration = Duration::from_millis(50);
+/// Floor duration for one timed batch; the iteration count is calibrated up to
+/// meet it so the clock's resolution isn't the thing being measured.
+const MIN_BATCH: Duration = Duration::from_millis(100);
+/// Number of timed batches; the reported ns/op is their median.
+const SAMPLES: usize = 5;
+
+/// One benchmark's result. `*_ns` are per-`main()`-evaluation nanoseconds.
+pub struct BenchResult {
+    pub name: String,
+    pub iters: u64,
+    pub samples: usize,
+    pub median_ns: f64,
+    pub min_ns: f64,
+    pub max_ns: f64,
+}
+
+/// CLI entry: `mle bench [--all] [--json] [<file.mle> | <dir>]`.
+pub fn main(args: &[String]) -> ! {
+    let mut json = false;
+    let mut all = false;
+    let mut path: Option<&str> = None;
+    for arg in args {
+        match arg.as_str() {
+            "--json" => json = true,
+            "--all" => all = true,
+            other if other.starts_with('-') => {
+                eprintln!("mle bench: unknown flag `{other}`");
+                exit(2);
+            }
+            other => {
+                if path.is_some() {
+                    eprintln!("mle bench: expected a single file or directory");
+                    exit(2);
+                }
+                path = Some(other);
+            }
+        }
+    }
+
+    // Resolve the set of benchmark files to run.
+    let files = match (all, path) {
+        (true, _) | (false, None) => collect_dir(&default_corpus()),
+        (false, Some(p)) => {
+            let p = Path::new(p);
+            if p.is_dir() {
+                collect_dir(p)
+            } else {
+                Ok(vec![p.to_path_buf()])
+            }
+        }
+    };
+    let files = files.unwrap_or_else(|err| {
+        eprintln!("mle bench: {err}");
+        exit(1);
+    });
+    if files.is_empty() {
+        eprintln!("mle bench: no .mle benchmarks found");
+        exit(1);
+    }
+
+    let mut results = Vec::with_capacity(files.len());
+    for file in &files {
+        match run_one(file) {
+            Ok(result) => results.push(result),
+            Err(err) => {
+                eprintln!("{err}");
+                exit(1);
+            }
+        }
+    }
+
+    if json {
+        print!("{}", render_json(&results));
+    } else {
+        print!("{}", render_table(&results));
+    }
+    exit(0);
+}
+
+/// Parse + lower + load `path` once, then time repeated `main()` evaluation.
+pub fn run_one(path: &Path) -> Result<BenchResult, String> {
+    let project = mle::project::load(path).map_err(|err| err.render())?;
+    let mut host = mle::NoHost;
+    let session =
+        mle::Session::load(&project.module, &mut host).map_err(|f| render_error(&project, &f.error))?;
+    if session.global("main").is_none() {
+        return Err(format!(
+            "{}: no zero-arg `let main` to benchmark (see mle/benches/README.md)",
+            path.display()
+        ));
+    }
+    // One real evaluation up front: surfaces a runtime error (or an arity
+    // mismatch if `main` takes args) as a clean diagnostic before timing.
+    session
+        .call("main", Vec::new(), &mut host)
+        .map_err(|err| render_error(&project, &err))?;
+
+    // Warmup.
+    let warm_start = Instant::now();
+    while warm_start.elapsed() < WARMUP {
+        black_box(time_batch(&session, 1));
+    }
+
+    // Calibrate the iteration count up to the batch floor.
+    let iters = calibrate(&session);
+
+    // Median of SAMPLES timed batches.
+    let mut per_op: Vec<f64> = (0..SAMPLES)
+        .map(|_| time_batch(&session, iters).as_nanos() as f64 / iters as f64)
+        .collect();
+    per_op.sort_by(|a, b| a.partial_cmp(b).expect("finite timings"));
+
+    Ok(BenchResult {
+        name: bench_name(path),
+        iters,
+        samples: SAMPLES,
+        median_ns: per_op[per_op.len() / 2],
+        min_ns: per_op[0],
+        max_ns: per_op[per_op.len() - 1],
+    })
+}
+
+/// Time `n` back-to-back `main()` evaluations; `black_box` the result so the
+/// optimizer can't elide the work.
+fn time_batch(session: &mle::Session, n: u64) -> Duration {
+    let mut host = mle::NoHost;
+    let start = Instant::now();
+    for _ in 0..n {
+        let value = session
+            .call("main", Vec::new(), &mut host)
+            .expect("main validated before timing");
+        black_box(value);
+    }
+    start.elapsed()
+}
+
+/// Grow the iteration count until a batch takes at least [`MIN_BATCH`].
+fn calibrate(session: &mle::Session) -> u64 {
+    let mut iters: u64 = 1;
+    loop {
+        let elapsed = time_batch(session, iters);
+        if elapsed >= MIN_BATCH || iters >= 1_000_000_000 {
+            return iters.max(1);
+        }
+        // Scale toward the floor with headroom; always at least double so we
+        // converge quickly even when `elapsed` is near zero.
+        let factor = (MIN_BATCH.as_secs_f64() / elapsed.as_secs_f64().max(1e-9)).max(2.0);
+        iters = ((iters as f64 * factor).ceil() as u64).max(iters + 1);
+    }
+}
+
+fn bench_name(path: &Path) -> String {
+    path.file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| path.display().to_string())
+}
+
+/// The committed corpus directory, resolved relative to the crate at build time
+/// so `mle bench --all` works from any cwd.
+fn default_corpus() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("benches/corpus")
+}
+
+/// All `*.mle` files in `dir`, sorted by name (stable table order).
+fn collect_dir(dir: &Path) -> Result<Vec<PathBuf>, String> {
+    let mut files: Vec<PathBuf> = std::fs::read_dir(dir)
+        .map_err(|err| format!("cannot read {}: {err}", dir.display()))?
+        .filter_map(|entry| entry.ok().map(|e| e.path()))
+        .filter(|p| p.extension().is_some_and(|ext| ext == "mle"))
+        .collect();
+    files.sort();
+    Ok(files)
+}
+
+fn render_error(project: &mle::project::Project, err: &mle::RunError) -> String {
+    let (file, line, col) = project.sources.resolve(err.span.start);
+    format!("{}:{line}:{col}: error: {}", file.path.display(), err.message)
+}
+
+/// Pretty-print a per-op nanosecond count with an appropriate unit.
+fn fmt_time(ns: f64) -> String {
+    if ns >= 1_000_000_000.0 {
+        format!("{:.2} s", ns / 1_000_000_000.0)
+    } else if ns >= 1_000_000.0 {
+        format!("{:.2} ms", ns / 1_000_000.0)
+    } else if ns >= 1_000.0 {
+        format!("{:.2} us", ns / 1_000.0)
+    } else {
+        format!("{ns:.1} ns")
+    }
+}
+
+fn render_table(results: &[BenchResult]) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "mle interpreter benchmarks — median of {SAMPLES} samples, \u{2265}{}ms/sample, after {}ms warmup.\n",
+        MIN_BATCH.as_millis(),
+        WARMUP.as_millis()
+    ));
+    out.push_str("time/op is per main() evaluation (parse + lower done once, untimed).\n");
+    out.push_str("Machine-dependent — A-B on the SAME machine; not a CI gate.\n\n");
+    out.push_str(&format!(
+        "{:<18} {:>10} {:>13} {:>13} {:>9}\n",
+        "benchmark", "iters", "time/op", "ops/s", "spread"
+    ));
+    for r in results {
+        let ops = 1_000_000_000.0 / r.median_ns;
+        let spread = (r.max_ns - r.min_ns) / r.median_ns * 100.0;
+        out.push_str(&format!(
+            "{:<18} {:>10} {:>13} {:>13.1} {:>8.1}%\n",
+            r.name,
+            r.iters,
+            fmt_time(r.median_ns),
+            ops,
+            spread
+        ));
+    }
+    out
+}
+
+fn render_json(results: &[BenchResult]) -> String {
+    let mut items = Vec::with_capacity(results.len());
+    for r in results {
+        items.push(format!(
+            "  {{\"name\": {:?}, \"iters\": {}, \"samples\": {}, \"ns_per_op\": {:.3}, \"min_ns_per_op\": {:.3}, \"max_ns_per_op\": {:.3}, \"ops_per_sec\": {:.3}}}",
+            r.name,
+            r.iters,
+            r.samples,
+            r.median_ns,
+            r.min_ns,
+            r.max_ns,
+            1_000_000_000.0 / r.median_ns
+        ));
+    }
+    format!("[\n{}\n]\n", items.join(",\n"))
+}

--- a/mle/src/main.rs
+++ b/mle/src/main.rs
@@ -1,4 +1,4 @@
-//! The `mle` CLI. Five subcommands:
+//! The `mle` CLI. Six subcommands:
 //!
 //! ```text
 //! mle parse <file.mle>   # print the surface AST (pretty-Debug; this file only)
@@ -6,6 +6,7 @@
 //! mle check <file.mle>   # typecheck the project; all diagnostics, exit 1
 //! mle run <file.mle>     # evaluate; print main's result, or the entry's bindings
 //! mle trace <file.mle>   # evaluate with the call trace; print the trace
+//! mle bench [--all] [--json] [<file.mle>|<dir>]  # time interpreter eval (see bench.rs)
 //! ```
 //!
 //! `ir`/`check`/`run`/`trace` treat the file as a project entry (B8): every
@@ -20,14 +21,23 @@
 
 use std::process::exit;
 
+mod bench;
+
 fn main() {
     let args: Vec<String> = std::env::args().skip(1).collect();
+    // `bench` takes its own flags (`--all`, `--json`) and an optional path, so
+    // it is dispatched before the rigid single-path subcommand parsing.
+    if args.first().is_some_and(|a| a == "bench") {
+        bench::main(&args[1..]);
+    }
     let (command, path) = match args.as_slice() {
         [command, path] if ["parse", "ir", "check", "run", "trace"].contains(&command.as_str()) => {
             (command.as_str(), path)
         }
         _ => {
-            eprintln!("usage: mle <parse|ir|check|run|trace> <file.mle>");
+            eprintln!(
+                "usage: mle <parse|ir|check|run|trace> <file.mle>\n       mle bench [--all] [--json] [<file.mle>|<dir>]"
+            );
             exit(2);
         }
     };

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build:cli": "wasm-pack build runtime/functor-runtime-web --target=web && cargo build --bin functor",
     "build:oculus": "ANDROID_HOME=${ANDROID_HOME:-/opt/homebrew/share/android-sdk} CARGO_TARGET_DIR=target-android cargo ndk -t arm64-v8a build --manifest-path runtime/functor-runtime-oculus/Cargo.toml",
     "build:oculus:apk": "ANDROID_HOME=${ANDROID_HOME:-/opt/homebrew/share/android-sdk} ANDROID_NDK_ROOT=${ANDROID_NDK_ROOT:-/opt/homebrew/share/android-sdk/ndk/24.0.8215888} CARGO_TARGET_DIR=$PWD/target-android cargo apk build --manifest-path runtime/functor-runtime-oculus/Cargo.toml",
+    "bench": "cargo run -q --release -p mle -- bench --all",
     "fetch:assets": "node scripts/fetch-assets.mjs",
     "generate:audio": "node scripts/generate-audio.mjs",
     "test:golden": "npm run fetch:assets && npm run build:cli && cargo test -p functor-runtime-desktop --test golden -- --ignored --nocapture",


### PR DESCRIPTION
## What

An easy-to-run, dependency-light harness for timing the **MLE interpreter** on a corpus of `.mle` micro-benchmarks. It's the reusable perf-validation tool for language work — e.g. to confirm the **pending currying spike** (`spike/mle-currying`) doesn't regress the call hot path. Independent of any currying change; this is its own PR.

> **Diagnostic / A-B tool, not a CI gate.** Absolute numbers are machine-dependent, and raw perf thresholds flake on shared CI hardware (the lesson from the earlier C6 perf gate). It is deliberately **not** wired into per-PR CI as a pass/fail assertion.

## `mle bench` UX

```sh
npm run bench                                                  # whole corpus, human table
cargo run -q --release -p mle -- bench --all                   # same, directly
cargo run -q --release -p mle -- bench mle/benches/corpus/call_saturated.mle   # one file
cargo run -q --release -p mle -- bench <dir>                   # every *.mle in a dir
cargo run -q --release -p mle -- bench --all --json            # machine-readable
```

Sample output (Apple M3, `--release`):

```
mle interpreter benchmarks — median of 5 samples, ≥100ms/sample, after 50ms warmup.
time/op is per main() evaluation (parse + lower done once, untimed).
Machine-dependent — A-B on the SAME machine; not a CI gate.

benchmark               iters       time/op         ops/s    spread
adt                         2      57.6  ms          17.4      0.4%
arith_loop                  1     165.8  ms           6.0      0.6%
call_piped                  1     322.4  ms           3.1      1.6%
call_saturated              1     329.1  ms           3.0      2.8%
fold_floor                  1     130.6  ms           7.7      0.7%
list_map                    3      37.5  ms          26.6      0.2%
pattern_match               2      70.0  ms          14.3      0.7%
record_update               4      30.9  ms          32.4      1.8%
recursion                   1     357.4  ms           2.8      0.7%
```

Spreads stay under 3% run-to-run.

## How it isolates the interpreter

A benchmark file parses + lowers + loads into an `mle::Session` **once** (untimed); the harness then times *repeated evaluation of `main()`*. So `time/op` is the interpreter's eval hot path — not startup, parse, or typecheck. Each timed call goes through `Session::call`, which stands up a fresh interpreter over the session's globals exactly as the runtime does per frame, so the number tracks real per-frame cost.

**Methodology (reproducible):** ~50ms warmup → auto-calibrate the iteration count to a ≥100ms batch floor → median of 5 timed batches, reporting `spread` = (max−min)/median as a stability signal. `std::time::Instant` only — no `criterion`, no new deps.

## Benchmark-file convention

An ordinary `.mle` project whose entry defines a **zero-arg `let main`** doing the unit of work to time (work goes *inside* `main`, so load stays untimed). Every bench is therefore also a normal program — `mle run corpus/<file>.mle` prints `main()`'s result, so correctness is verifiable before trusting timing. Uses only core builtins (`List.*`/`Text.*`/`Math.*`) — no engine host.

## Corpus (9 seeds)

| file | measures |
| --- | --- |
| `call_saturated.mle` | saturated multi-arg closure calls (~2M/eval) — the call hot path |
| `call_piped.mle` | piped calls that lower to a saturated call |
| `fold_floor.mle` | baseline: `List.range(1M)` + a 1M no-op fold (subtract to isolate call cost) |
| `list_map.mle` | `List.map` + `List.filter` pipeline over 100k |
| `arith_loop.mle` | arithmetic-heavy fold (mul/add/div + `Math.sin`) over 500k |
| `recursion.mle` | self-recursion at volume (~1.5M shallow recursive calls) |
| `pattern_match.mle` | nested bool-literal `match` dispatch over 200k |
| `adt.mle` | ADT construct + variant-pattern match over 100k |
| `record_update.mle` | `{ r with … }` threaded through a 100k fold |

The `call_saturated`/`call_piped`/`fold_floor` trio is lifted from `spike/mle-currying`'s bench corpus, adapted to today's thread-first model (each verified to parse + run on `main`). Partial-application/currying benches (`call_partial.mle`) are intentionally excluded — they require currying (not in `main`) and join the corpus when it lands (noted in the README).

## Discoverability

`npm run bench` (mirrors `test:golden` etc.).

## Verification

- `cargo build -p mle` clean; new code has no warnings/clippy issues.
- Every corpus file parses + runs via `mle run` and `mle bench`; `--json` validates via `python3 -m json.tool`.
- Error paths exit cleanly (missing `main`, unknown flag, empty corpus).
- `cargo test -p mle`: this change adds no new failures. (4 pre-existing `check.rs` arity-diagnostic failures exist on `origin/main`, unrelated to this PR — confirmed identical pass/fail with the change stashed.)

## Review

`/xreview` (cross-engine): Claude reviewer returned a **clean verdict** — no Critical/High/Medium findings; timing methodology sound, eval genuinely isolated from parse/lower, calibration/median/black_box/error-handling all correct. Codex was unavailable (usage limit) so this was Claude-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)