### PR TITLE
feat(mle): call-site currying + partial application (currying migration step 1/5)

### DIFF
--- a/mle/examples/checks/broken.check
+++ b/mle/examples/checks/broken.check
@@ -5,7 +5,6 @@ broken.mle:16:13: error: `==` compares different types Float and String (always 
 broken.mle:20:36: error: record literal for `Position` is missing field `y`
 broken.mle:20:44: error: `Position` has no field `z`
 broken.mle:23:36: error: `Position` has no field `z`
-broken.mle:27:13: error: `shift` takes 2 argument(s), got 1
 broken.mle:28:37: error: argument 2 of `shift`: expected Float, got String
 broken.mle:31:25: error: argument 1 of `Text.concat`: expected String, got Float
 broken.mle:35:17: error: `Position` takes 0 type argument(s), got 1

--- a/mle/src/eval.rs
+++ b/mle/src/eval.rs
@@ -40,10 +40,17 @@ use std::rc::Rc;
 /// Evaluation depth cap: pathological or unboundedly recursive MLE code must
 /// fail as a clean spanned error, not a host stack overflow. Counts *every*
 /// nested `eval` entry (expression nesting and calls alike), so it bounds
-/// host stack usage directly. Like the parser's `MAX_DEPTH`, the cap must fit
-/// a 2 MiB test-thread stack in debug builds (each eval level costs several
-/// KB of debug frames); deep iteration belongs in the iterative builtins
+/// host stack usage directly. Deep iteration belongs in the iterative builtins
 /// (`List.map`/`fold`), not user-level recursion.
+///
+/// Kept at 200 through the currying migration (measured, debug build,
+/// Apple Silicon): 200 levels of the deepest recursion need ≈2.24 MiB of stack
+/// on this branch vs ≈2.18 MiB pre-currying — the call-site arity gate adds
+/// only ~320 bytes/level because the partial/over-application logic lives in an
+/// out-of-line `#[cold]` helper ([`Interp::call_curried`]), not `call`'s hot
+/// frame. Both already exceed a 2 MiB test-thread stack, so the suite runs with
+/// a bumped `RUST_MIN_STACK` regardless; the ~64 KiB currying delta is well
+/// within that and the 8 MiB release stack, so the cap need not drop.
 const MAX_EVAL_DEPTH: usize = 200;
 
 /// Trace-event cap; see the module doc.
@@ -631,6 +638,26 @@ impl Interp<'_> {
         span: Span,
         via: Option<&'static str>,
     ) -> Result<Value, RunError> {
+        // Currying: a cheap arity pre-check gates the three curried cases. The
+        // SATURATED case (`args.len() == arity` — every direct `f(a, b)` and
+        // every pipe) falls straight through to the original dispatch below
+        // with NO extra allocation and NO extra stack frame. The partial /
+        // over-application / partial-unwrap cases are handled by the `#[cold]`
+        // [`Self::call_curried`] so their locals never enlarge this hot frame
+        // (the per-recursion stack cost feeds the eval-depth cap's budget, so
+        // keeping this frame lean matters).
+        match callee_arity(&callee) {
+            Some(arity) if args.len() == arity => {}
+            Some(arity) => return self.call_curried(callee, args, Some(arity), label, span, via),
+            // A partial is unwrapped and re-dispatched on its underlying callee.
+            None if matches!(callee, Value::Partial(_)) => {
+                return self.call_curried(callee, args, None, label, span, via)
+            }
+            // Host fn (arity unknown) — treated as saturated; the host
+            // validates its own arg count.
+            None => {}
+        }
+        // ---- Saturated (or host) dispatch — the original body, unchanged ----
         self.trace_enter(&label, &args);
         self.call_depth += 1;
         let result = match &callee {
@@ -684,6 +711,49 @@ impl Interp<'_> {
             self.trace_exit(value);
         }
         result
+    }
+
+    /// Currying's COLD paths — under-application, over-application, and
+    /// partial-unwrap. Kept out of [`Self::call`]'s hot frame (`#[cold]`) so
+    /// the saturated path pays nothing for them. `arity` is the callee's known
+    /// arity (`None` only for a `Partial` being unwrapped). Each branch that
+    /// dispatches re-enters `self.call`, which re-runs the arity gate and does
+    /// its own tracing, so the outer call neither traces nor bumps
+    /// `call_depth` for these cases.
+    #[cold]
+    #[inline(never)]
+    fn call_curried(
+        &mut self,
+        callee: Value,
+        args: Vec<Value>,
+        arity: Option<usize>,
+        label: String,
+        span: Span,
+        via: Option<&'static str>,
+    ) -> Result<Value, RunError> {
+        // A partial absorbs the new args and re-dispatches on its underlying
+        // callable with the combined argument list.
+        if let Value::Partial(partial) = &callee {
+            let mut combined = partial.applied.clone();
+            combined.extend(args);
+            return self.call(partial.callee.clone(), combined, label, span, via);
+        }
+        let arity = arity.expect("non-partial cold path carries its arity");
+        if args.len() < arity {
+            // Under-applied → capture what we have as a partial. (The count
+            // still needed is derived from the callee's arity at display time,
+            // so we store only the callee and the args supplied so far.)
+            return Ok(Value::Partial(Rc::new(crate::value::Partial {
+                callee,
+                applied: args,
+            })));
+        }
+        // Over-applied → saturate with the first `arity` args, then apply the
+        // leftover args to the result (which must itself be callable).
+        let mut rest = args;
+        let now = rest.drain(..arity).collect();
+        let saturated = self.call(callee, now, label.clone(), span, via)?;
+        self.call(saturated, rest, label, span, None)
     }
 
     fn trace_enter(&mut self, callee: &str, args: &[Value]) {
@@ -1128,8 +1198,22 @@ fn value_eq(a: &Value, b: &Value, span: Span) -> Result<bool, RunError> {
             Ok(true)
         }
         // An unapplied constructor is a function value — no equality.
-        (Value::Closure(_) | Value::Builtin(_) | Value::HostFn(_) | Value::Ctor { .. }, _)
-        | (_, Value::Closure(_) | Value::Builtin(_) | Value::HostFn(_) | Value::Ctor { .. }) => {
+        (
+            Value::Closure(_)
+            | Value::Partial(_)
+            | Value::Builtin(_)
+            | Value::HostFn(_)
+            | Value::Ctor { .. },
+            _,
+        )
+        | (
+            _,
+            Value::Closure(_)
+            | Value::Partial(_)
+            | Value::Builtin(_)
+            | Value::HostFn(_)
+            | Value::Ctor { .. },
+        ) => {
             Err(RunError {
                 message: "functions cannot be compared with `==`".to_string(),
                 span,
@@ -1169,8 +1253,49 @@ fn element_label(b: Builtin, i: usize) -> String {
 fn is_function(v: &Value) -> bool {
     matches!(
         v,
-        Value::Closure(_) | Value::Builtin(_) | Value::HostFn(_) | Value::Ctor { .. }
+        Value::Closure(_)
+            | Value::Partial(_)
+            | Value::Builtin(_)
+            | Value::HostFn(_)
+            | Value::Ctor { .. }
     )
+}
+
+/// The statically-known arity of a callable, or `None` when it isn't known
+/// here (host functions — the host validates its own arg count; partials are
+/// unwrapped before this is consulted). Drives partial vs saturated vs
+/// over-application in [`Interp::call`].
+fn callee_arity(v: &Value) -> Option<usize> {
+    match v {
+        Value::Closure(c) => Some(c.params.len()),
+        Value::Ctor { arity, .. } => Some(*arity),
+        Value::Builtin(b) => Some(builtin_arity(*b)),
+        _ => None,
+    }
+}
+
+/// A builtin's argument count — currying needs each builtin's arity to decide
+/// partial vs saturated vs over-application. Must stay in sync with
+/// [`Interp::call_builtin`] (and [`crate::types::builtin_signature`]).
+pub fn builtin_arity(b: Builtin) -> usize {
+    match b {
+        Builtin::ListFold | Builtin::ListGrid => 3,
+        Builtin::ListMap
+        | Builtin::ListFilter
+        | Builtin::TextConcat
+        | Builtin::TextFixed
+        | Builtin::TextSplit
+        | Builtin::TextJoin
+        | Builtin::DebugLog => 2,
+        Builtin::ListRange
+        | Builtin::ListMaximum
+        | Builtin::TextFromFloat
+        | Builtin::TextToBullets
+        | Builtin::TextParseFloat
+        | Builtin::MathClamp01
+        | Builtin::MathSin
+        | Builtin::MathCos => 1,
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/mle/src/rebind.rs
+++ b/mle/src/rebind.rs
@@ -134,6 +134,17 @@ fn walk(value: &Value, old: &ModuleIndex, new: &ModuleIndex, report: &mut Rebind
             args: Rc::new(args.iter().map(|v| walk(v, old, new, report)).collect()),
         },
         Value::Closure(closure) => rebind_closure(closure, old, new, report),
+        // Rebind the captured callee and the already-applied args. (The count
+        // still needed is derived from the rebound callee's arity at display
+        // time, so a hot-reload that changes it can never leave a stale count.)
+        Value::Partial(partial) => Value::Partial(Rc::new(crate::value::Partial {
+            callee: walk(&partial.callee, old, new, report),
+            applied: partial
+                .applied
+                .iter()
+                .map(|v| walk(v, old, new, report))
+                .collect(),
+        })),
     }
 }
 

--- a/mle/src/types.rs
+++ b/mle/src/types.rs
@@ -1058,6 +1058,50 @@ the type: `type Name<{name}> = …`"
         }
     }
 
+    /// Over-application: a call supplied more args than the callee's `params`.
+    /// The first `arity` args are already checked against the params; here the
+    /// surplus args (from index `arity` on) are applied to `ret`, which must
+    /// itself be a function, `Unknown`, or an unsolved `Var`. Returns the type
+    /// after consuming them.
+    fn over_apply(
+        &mut self,
+        callee: &Expr,
+        args: &[Expr],
+        arity: usize,
+        ret: Type,
+        span: Span,
+    ) -> Type {
+        let mut result = ret;
+        for (i, arg) in args.iter().enumerate().skip(arity) {
+            // Re-zonk each iteration: an earlier surplus arg's `expect` may have
+            // solved a var that makes this result concrete (e.g. a `Var` now a
+            // `Fn`), and we want to check against the solved shape, not the
+            // stale one.
+            result = self.zonk(&result);
+            match result {
+                Type::Fn(ps, r) if !ps.is_empty() => {
+                    let what = format!("argument {} of `{}`", i + 1, callee_label(callee));
+                    self.expect(arg, &ps[0], &what);
+                    result = if ps.len() == 1 {
+                        *r
+                    } else {
+                        Type::Fn(ps[1..].to_vec(), r)
+                    };
+                }
+                Type::Unknown | Type::Var(_) => {
+                    self.infer(arg);
+                    result = Type::Unknown;
+                }
+                other => {
+                    self.diag(span, format!("cannot call {other}, not a function"));
+                    self.infer(arg);
+                    result = Type::Unknown;
+                }
+            }
+        }
+        result
+    }
+
     /// Check `expr` against a known expected type. Record and list literals
     /// are checked structurally against the expectation (this is where record
     /// literals meet their declared types); anything else is inferred and
@@ -1409,28 +1453,36 @@ the type: `type Name<{name}> = …`"
             ExprKind::Call { callee, args } => {
                 let callee_ty = self.infer(callee);
                 match callee_ty {
+                    // Currying: a call may supply FEWER args (partial
+                    // application → a function of the remaining params), an
+                    // EXACT count (→ the return type), or MORE (over-
+                    // application → apply the leftover to the result, which
+                    // must itself be a function).
                     Type::Fn(params, ret) => {
-                        if params.len() != args.len() {
-                            self.diag(
-                                expr.span,
-                                format!(
-                                    "`{}` takes {} argument(s), got {}",
-                                    callee_label(callee),
-                                    params.len(),
-                                    args.len()
-                                ),
-                            );
-                            for arg in args {
-                                self.infer(arg);
+                        // Check every arg that pairs with a declared param.
+                        for (i, (arg, param_ty)) in
+                            args.iter().zip(params.iter()).enumerate()
+                        {
+                            let what = format!("argument {} of `{}`", i + 1, callee_label(callee));
+                            self.expect(arg, param_ty, &what);
+                        }
+                        match args.len().cmp(&params.len()) {
+                            std::cmp::Ordering::Equal => *ret,
+                            // Under-applied: the value is a function of the
+                            // params not yet supplied. (A future diagnostic can
+                            // flag a partial that reaches a non-function
+                            // position; today it surfaces at the eventual use
+                            // site as a type mismatch.)
+                            std::cmp::Ordering::Less => {
+                                Type::Fn(params[args.len()..].to_vec(), ret)
                             }
-                        } else {
-                            for (i, (arg, param_ty)) in args.iter().zip(&params).enumerate() {
-                                let what =
-                                    format!("argument {} of `{}`", i + 1, callee_label(callee));
-                                self.expect(arg, param_ty, &what);
+                            // Over-applied: saturate, then apply the surplus
+                            // args to the result type via a synthetic curried
+                            // call — the result must itself be a function.
+                            std::cmp::Ordering::Greater => {
+                                self.over_apply(callee, args, params.len(), *ret, expr.span)
                             }
                         }
-                        *ret
                     }
                     Type::Var(_) => {
                         let arg_tys: Vec<Type> = args.iter().map(|arg| self.infer(arg)).collect();

--- a/mle/src/value.rs
+++ b/mle/src/value.rs
@@ -38,6 +38,12 @@ pub enum Value {
         arity: usize,
     },
     Closure(Rc<Closure>),
+    /// A partially-applied callable: the underlying callable plus the
+    /// arguments supplied so far. Produced only when a call supplies FEWER
+    /// arguments than the callee's arity; calling it with the remaining
+    /// arguments saturates and dispatches. The saturated call path never
+    /// allocates one.
+    Partial(Rc<Partial>),
     Builtin(crate::eval::Builtin),
     /// A host-provided external function (see [`crate::eval::Host`]),
     /// identified by its qualified path (`Scene.cube`).
@@ -68,6 +74,19 @@ pub struct Closure {
     /// closures design note). Guarded by body pointer identity there, so a
     /// stale id from an older module can never mis-rebind.
     pub expr_id: crate::ir::ExprId,
+}
+
+/// A partially-applied callable. `callee` is the underlying callable (a
+/// closure, constructor, or builtin — never a host fn, which the host
+/// saturates, nor another `Partial`, which is unwrapped before capture);
+/// `applied` are the arguments already supplied. Only produced when a call
+/// supplies FEWER args than the callee's arity — the saturated call path never
+/// allocates one. The count still needed is derived from the callee's arity
+/// (see `Display`), so it can never drift out of sync (e.g. after a hot-reload
+/// that changes the callee's parameter count).
+pub struct Partial {
+    pub callee: Value,
+    pub applied: Vec<Value>,
 }
 
 /// Lexical environment: one scope per enclosing lambda call, as a persistent
@@ -165,6 +184,18 @@ impl fmt::Display for Value {
                 }
                 write!(f, ")>")
             }
+            Value::Partial(p) => {
+                // How many args are still needed, derived live from the
+                // callee's arity (a Partial's callee is always a closure,
+                // ctor, or builtin — see [`Partial`]).
+                let arity = match &p.callee {
+                    Value::Closure(c) => c.params.len(),
+                    Value::Ctor { arity, .. } => *arity,
+                    Value::Builtin(b) => crate::eval::builtin_arity(*b),
+                    _ => p.applied.len(),
+                };
+                write!(f, "<partial {} more>", arity.saturating_sub(p.applied.len()))
+            }
             Value::Builtin(b) => write!(f, "<builtin {}>", builtin_name(*b)),
             Value::HostFn(path) => write!(f, "<host {path}>"),
             Value::HostData(data) => write!(f, "<{}>", data.type_name()),
@@ -185,6 +216,7 @@ impl Value {
             Value::Variant { .. } => "a variant",
             Value::Ctor { .. } => "a constructor",
             Value::Closure(_) => "a function",
+            Value::Partial(_) => "a partially-applied function",
             Value::Builtin(_) => "a builtin",
             Value::HostFn(_) => "a host function",
             Value::HostData(data) => data.type_name(),

--- a/mle/tests/check.rs
+++ b/mle/tests/check.rs
@@ -185,14 +185,17 @@ fn error_field_access_on_a_float() {
     assert_eq!((line, col), (1, 23));
 }
 
+// Currying: under-application is a legal partial application, not an arity
+// error — `f(1.0)` on a 2-arg `f` yields a `(Float) => Float`. (The crisp
+// "takes N argument(s)" error is the accepted quality regression of the
+// currying migration; a dedicated "partial reaches a non-function position"
+// diagnostic is planned to recover it.)
 #[test]
-fn error_call_arity() {
-    let (message, line, col) = single_diag(
+fn partial_application_of_user_function_is_accepted() {
+    assert_clean(
         "let f = (a: Float, b: Float): Float => a + b\n\
          let g = () => f(1.0)",
     );
-    assert_eq!(message, "`f` takes 2 argument(s), got 1");
-    assert_eq!((line, col), (2, 15));
 }
 
 #[test]
@@ -215,10 +218,44 @@ fn error_builtin_argument_type() {
     assert_eq!((line, col), (1, 28));
 }
 
+// Currying: a partially-applied builtin is a legal value, not an arity error
+// — `Text.concat("a")` is a `(String) => String`.
 #[test]
-fn error_builtin_arity() {
-    let (message, _, _) = single_diag("let x = () => Text.concat(\"a\")");
-    assert_eq!(message, "`Text.concat` takes 2 argument(s), got 1");
+fn partial_application_of_builtin_is_accepted() {
+    assert_clean("let x = () => Text.concat(\"a\")");
+}
+
+// Currying: a partial has the type of the not-yet-supplied params, so
+// saturating it later still checks its remaining argument.
+#[test]
+fn partial_application_then_saturate_checks() {
+    assert_clean(
+        "let f = (a: Float, b: Float): Float => a + b\n\
+         let g = () => let inc = f(1.0) in inc(2.0)",
+    );
+    let (message, _, _) = single_diag(
+        "let f = (a: Float, b: Float): Float => a + b\n\
+         let g = () => let inc = f(1.0) in inc(\"s\")",
+    );
+    assert_eq!(message, "argument 1 of `inc`: expected Float, got String");
+}
+
+// Currying: over-application checks the surplus args against the result type,
+// which must itself be a function.
+#[test]
+fn over_application_checks_surplus_against_result() {
+    // A curried function over-applied in one call — clean, and the surplus arg
+    // is checked against the inner function's param.
+    assert_clean(
+        "let adder = (a: Float) => (b: Float) => a + b\n\
+         let main = () => adder(3.0, 4.0)",
+    );
+    // Over-applying a non-function result is an error.
+    let (message, _, _) = single_diag(
+        "let f = (a: Float): Float => a\n\
+         let g = () => f(1.0, 2.0)",
+    );
+    assert_eq!(message, "cannot call Float, not a function");
 }
 
 // A builtin's known callback shape checks: List.filter's predicate must
@@ -608,16 +645,18 @@ fn catch_all_var_binds_the_scrutinee_type() {
     assert_eq!(message, "`+` needs Float operands, got Shape");
 }
 
-/// Construction checks like any call: declared field types and arity.
+/// Construction checks like any call: declared field types are enforced on the
+/// supplied args, and (currying) a partially-applied constructor is a legal
+/// value rather than an arity error.
 #[test]
-fn error_ctor_argument_type_and_arity() {
+fn error_ctor_argument_type_and_partial() {
     let (message, _, _) = single_diag(&format!("{SHAPE}let x = () => Circle(\"s\")"));
     assert_eq!(
         message,
         "argument 1 of `Circle`: expected Float, got String"
     );
-    let (message, _, _) = single_diag(&format!("{SHAPE}let x = () => Rect(1.0)"));
-    assert_eq!(message, "`Rect` takes 2 argument(s), got 1");
+    // `Rect(1.0)` on a 2-arg ctor is a legal partial `(Float) => Shape`.
+    assert_clean(&format!("{SHAPE}let x = () => Rect(1.0)"));
 }
 
 /// Variant types are nominal in annotations, like records.

--- a/mle/tests/run.rs
+++ b/mle/tests/run.rs
@@ -157,13 +157,17 @@ fn error_top_level_forward_value_reference() {
     assert_eq!((line, col), (1, 9));
 }
 
+// Currying: under-application yields a partial rather than a runtime arity
+// error (the accepted quality regression of the currying migration).
 #[test]
-fn error_arity_mismatch() {
-    let (message, _, _) = run_err(
-        "let f = (a, b) => a + b\n\
-         let main = () => f(1.0)",
+fn under_application_yields_a_partial() {
+    assert_eq!(
+        main_result(
+            "let f = (a, b) => a + b\n\
+             let main = () => f(1.0)"
+        ),
+        "<partial 1 more>"
     );
-    assert_eq!(message, "`f` takes 2 argument(s), got 1");
 }
 
 #[test]
@@ -326,15 +330,17 @@ fn maximum_ignores_nan_unless_all_nan() {
     );
 }
 
+// Currying: a partially-applied callback is no longer a runtime arity error —
+// each element maps to a partial. (The old "blames the callback" arity message
+// is unreachable now that under-application is legal.)
 #[test]
-fn arity_error_blames_the_callback_not_the_builtin() {
-    let (message, _, _) = run_err(
-        "let add = (a, b) => a + b\n\
-         let main = () => [1.0] |> List.map(add)",
-    );
+fn partial_callback_maps_to_partials() {
     assert_eq!(
-        message,
-        "the function passed to List.map takes 2 argument(s), got 1"
+        main_result(
+            "let add = (a, b) => a + b\n\
+             let main = () => [1.0] |> List.map(add)"
+        ),
+        "[<partial 1 more>]"
     );
 }
 
@@ -663,12 +669,17 @@ fn error_comparing_unapplied_ctors() {
     assert_eq!(message, "functions cannot be compared with `==`");
 }
 
+// Currying: over-applying a saturated constructor is still an error (the
+// resulting variant isn't callable); under-applying it (here, zero args) is a
+// legal partial rather than an arity error.
 #[test]
-fn error_ctor_arity_at_runtime() {
+fn ctor_over_application_at_runtime_errors() {
     let (message, _, _) = run_err(&format!("{SHAPE}let main = () => Circle(1.0, 2.0)"));
-    assert_eq!(message, "`Circle` takes 1 argument(s), got 2");
-    let (message, _, _) = run_err(&format!("{SHAPE}let main = () => Circle()"));
-    assert_eq!(message, "`Circle` takes 1 argument(s), got 0");
+    assert_eq!(message, "cannot call a variant");
+    assert_eq!(
+        main_result(&format!("{SHAPE}let main = () => Circle()")),
+        "<partial 1 more>"
+    );
 }
 
 /// A parameterful constructor is first-class: it pipes through the builtins
@@ -847,5 +858,93 @@ fn debug_log_returns_the_value_unchanged_and_emits_through_the_sink() {
             "piped: 3".to_string(),
             "pt: { x: 1, y: 2 }".to_string(),
         ]
+    );
+}
+
+// --- Currying / partial application (migration step 1) --------------------
+// The interpreter curries call sites: under-application yields a partial,
+// exact application dispatches as before, and over-application saturates then
+// applies the remainder to the result. Thread-first piping is UNCHANGED (the
+// pipe still PREPENDS its subject) — that flip is a later migration stage.
+
+/// A partial captured in a `let ... in` binding, then saturated.
+#[test]
+fn partial_then_saturate() {
+    assert_eq!(
+        main_result(
+            "let add = (a, b) => a + b\n\
+             let main = () => let inc = add(1.0) in inc(10.0)"
+        ),
+        "11"
+    );
+    // Same, but the partial lives in a top-level binding across defs.
+    assert_eq!(
+        main_result(
+            "let add = (a, b) => a + b\n\
+             let inc = add(1.0)\n\
+             let main = () => inc(41.0)"
+        ),
+        "42"
+    );
+}
+
+/// Over-application: saturate with the callee's arity, then apply the leftover
+/// args to the resulting function.
+#[test]
+fn over_application_applies_remainder_to_result() {
+    assert_eq!(
+        main_result(
+            "let adder = (a) => (b) => a + b\n\
+             let main = () => adder(3.0, 4.0)"
+        ),
+        "7"
+    );
+}
+
+/// A partially-applied constructor is a first-class value; saturating it
+/// builds the variant.
+#[test]
+fn constructor_partial_then_saturate() {
+    assert_eq!(
+        main_result(&format!(
+            "{SHAPE}let mkTall = Rect(2.0)\n\
+             let main = () => mkTall(5.0)"
+        )),
+        "Rect(2, 5)"
+    );
+}
+
+/// A partial passed as a value flows through a builtin like any function —
+/// each element saturates it.
+#[test]
+fn partial_passed_as_a_value() {
+    assert_eq!(
+        main_result(
+            "let add = (a, b) => a + b\n\
+             let main = () => [1.0, 2.0, 3.0] |> List.map(add(10.0))"
+        ),
+        "[11, 12, 13]"
+    );
+}
+
+/// Thread-first is PRESERVED: `xs |> List.map(f)` still lowers to the
+/// subject-FIRST call `List.map(xs, f)`, so existing pipes are unaffected by
+/// the currying mechanism.
+#[test]
+fn thread_first_pipe_still_prepends() {
+    assert_eq!(
+        main_result(
+            "let double = (x) => x * 2.0\n\
+             let main = () => [1.0, 2.0, 3.0] |> List.map(double)"
+        ),
+        "[2, 4, 6]"
+    );
+    // The un-piped subject-first form is identical.
+    assert_eq!(
+        main_result(
+            "let double = (x) => x * 2.0\n\
+             let main = () => List.map([1.0, 2.0, 3.0], double)"
+        ),
+        "[2, 4, 6]"
     );
 }


### PR DESCRIPTION
## What & why

Step **1 of 5** of the MLE currying migration (design record: `docs/spikes/mle-currying.md`). This is the **pure-additions foundation**: it adds call-site currying + partial application to the interpreter and generalizes the typechecker to accept partial/over-application.

**Thread-first is PRESERVED — zero behavior change for existing valid code.** `|>` still **prepends** its subject and the prelude / `List.map` stay **subject-first**. Flipping to thread-last (and the prelude flip, `Debug.log`, docs/skill) is stages 3–5, deliberately out of scope here. Stages 1–2 land first to de-risk.

## Mechanism

**Interpreter** (`eval.rs`, `value.rs`, `rebind.rs`)
- New `Value::Partial { callee, applied }` — a partially-applied callable (closure / ctor / builtin).
- An **arity gate** at the top of `Interp::call`:
  - `args.len() == arity` → falls straight through to the **existing saturated dispatch, unchanged — no added allocation, no extra stack frame** (the perf-critical fast path).
  - `args.len() < arity` → allocates a `Value::Partial` in a `#[cold] #[inline(never)]` `call_curried` helper.
  - `args.len() > arity` → saturate, then apply the remainder to the result.
- Multi-arg closures kept (no lambda desugaring). **Constructors curry too.** `builtin_arity` mirrors `call_builtin`; `rebind` walks a `Partial` on hot-reload. The "still-needed" count is derived from the callee's arity at display time, so it can never drift after a hot-reload.

**Typechecker** (`types.rs`)
- Generalized `Call` rule: equal → return type (as today); fewer → `Type::Fn(remaining_params, ret)`; more → check the surplus against the result via `over_apply`. **`Type::Fn(Vec, ret)` unchanged** (no curried arrows); HM unification/generalization/instantiation untouched. The under-application arm is structured so a future "partial reaches a non-function position" diagnostic slots in cleanly.

## Accepted error-quality regression (by design)

Under-application is now a legal partial rather than the crisp `` `f` takes N argument(s), got M ``, so a genuine mistake surfaces later as a type mismatch (or, if the partial is dropped, silently). This is inherent to currying and accepted for this PR; a dedicated diagnostic is planned. Two known follow-ups surfaced by review (tracked, out of scope here):
- Partially applying a **host function** typechecks but fails at runtime (the runtime doesn't model host arity at the call site).
- An over-applied **nullary `Fn([], r)`** intermediate mis-reads as "not a function".

## Perf — saturated fast path at parity

Release, Apple Silicon, ~2M calls, median of 9:

| Corpus | base | branch |
| --- | --- | --- |
| saturated (`fold` of 2-arg calls) | 0.25 s | 0.25 s |
| piped (`map`+`fold`) | 0.29 s | 0.30 s |

The arity gate costs nothing on the hot path; only genuine under-application allocates.

## Depth cap — kept at 200 (measured, not the spike's blind 160)

The spike blindly dropped `MAX_EVAL_DEPTH` 200→160. Measured here instead: because the partial/over-application logic is out-of-line (`#[cold]`), the gate adds only **~320 bytes/level**, so 200-level recursion needs **~2.24 MiB** vs **~2.18 MiB** on base. Both already exceed a 2 MiB test-thread stack, so the suite already runs with a bumped `RUST_MIN_STACK` regardless — the ~64 KiB delta is well within that and the 8 MiB release stack. **Cap stays 200**; no legitimate recursion depth lost.

## Tests

`RUST_MIN_STACK=33554432 cargo test -p mle` fully green. New coverage: partial-then-saturate (`let g = f(a) in g(b)`), over-application, partial constructor, a partial passed as a value, and explicit confirmation that `xs |> List.map(f)` still works via **prepend** (subject-first). The four existing arity-error tests were updated to the new (accepted) semantics; the **only** golden delta is a single removed arity line in `broken.check`. All other goldens (run/trace/ir) unchanged — valid-program behavior is byte-identical.

## Review

Cross-engine `/xreview`: Claude reviewer found **no Critical/High** (fast path confirmed allocation/frame-free, `builtin_arity` in sync, `drain(..arity)` panic-safe, recursion terminating). Two Low findings applied: dropped the near-dead `Partial.remaining` field (now derived, can't go stale) and re-zonk in `over_apply`'s loop for checker precision. **Codex was unusable** (stuck on a poisoned session reviewing an unrelated worktree despite `-C`/prompt) — proceeded Claude-only per the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)