### PR TITLE
feat(mle): thread-last piping + subject-last prelude (currying migration step 3)

### DIFF
--- a/.claude/skills/mle-language/SKILL.md
+++ b/.claude/skills/mle-language/SKILL.md
@@ -74,8 +74,8 @@ let describe = (score) => Text.concat("score: ", Text.fromFloat(score))
 
 let report = (scores) =>
   scores
-    |> List.filter(isHigh)                    // pipeline: |> PREPENDS the piped value
-    |> List.map(describe)                     //   x |> g(a)  ==  g(x, a)
+    |> List.filter(isHigh)                    // pipeline: |> APPENDS the piped value (thread-last)
+    |> List.map(describe)                     //   x |> g(a)  ==  g(a, x)
     |> Text.toBullets
 
 let nudge = (p: Position): Position => { p with x: p.x + 1.0 }  // record update (fields must exist)
@@ -179,8 +179,10 @@ let grab = (s) =>
 
 ## Semantics rules that WILL bite you
 
-- **Pipelines prepend**: `x |> f(a)` is `f(x, a)`. Every builtin/prelude
-  function therefore takes its "subject" (list, scene) FIRST.
+- **Pipelines append (thread-last)**: `x |> f(a)` is `f(a, x)`. Every
+  builtin/prelude function therefore takes its "subject" (list, scene) LAST.
+  Because `|>` is syntax, `x |> f(a)` lowers directly to the saturated `f(a, x)`
+  (never a partial `f(a)`), so scene/list pipes allocate nothing.
 - **`:=` not `<-`** — `<-` is reserved for future do-block binds.
   Assignment must be followed by `;` and a continuation expression.
 - **`mut` is non-capturable**: a lambda may not read or assign an enclosing
@@ -219,23 +221,27 @@ let grab = (s) =>
 
 ## Builtins (the whole registry)
 
-`List.map(list, fn)` · `List.filter(list, fn)` · `List.fold(list, fn, init)`
+All are **subject-LAST** (the collection/subject is the final arg), so they
+thread through `|>` (which appends): `list |> List.map(fn)` == `List.map(fn, list)`.
+
+`List.map(fn, list)` · `List.filter(fn, list)` · `List.fold(fn, init, list)`
 (callback is `(acc, x) => …`) · `List.range(n)` (`[0 … n-1]`) ·
-`List.grid(rows, cols, fn)` (→ `List<List<a>>`; calls `fn(row, col)`, both
+`List.grid(fn, rows, cols)` (→ `List<List<a>>`; calls `fn(row, col)`, both
 0-based, per cell — the engine-loop form of a procedural heightmap, e.g.
-`Scene.heightmap(List.grid(r, c, height))`) ·
+`Scene.heightmap(List.grid(height, r, c))`) ·
 `List.maximum(list)` · `Text.concat(a, b)` · `Text.fromFloat(n)` ·
 `Text.fixed(n, decimals)` (fixed-decimal; `Text.fixed(42.0, 0.0)` = `"42"`, the
-`%d` shape) · `Text.toBullets(list)` · `Text.split(s, sep)` (→ `List<String>`;
-empty `sep` is an error; `Text.split("", sep)` = `[""]`) · `Text.join(list, sep)`
+`%d` shape) · `Text.toBullets(list)` · `Text.split(sep, s)` (→ `List<String>`;
+empty `sep` is an error; `Text.split(sep, "")` = `[""]`) · `Text.join(sep, list)`
 (strings only) · `Text.parseFloat(s)` (trims; unparseable → `0.0`, the F#
 `unwrap_or(0)` shape) · `Math.clamp01(n)` · `Math.sin(n)` · `Math.cos(n)` ·
-`Debug.log(value, label)` — `('a, String) => 'a`: an Elm-style trace. Logs
+`Debug.log(label, value)` — `(String, 'a) => 'a`: an Elm-style trace. Logs
 `label: <value>` (the value rendered exactly as `mle run`/`trace` displays it —
 any type) and returns `value` **unchanged**, so it's pure to the program
 result and safe to drop into a pipe: `m.x |> Debug.log("x") |> clamp(0.0, 1.0)`
-logs then passes the value on. Value-FIRST (pipelines prepend), so `label` is
-the second arg. An impure observability escape hatch — it can't affect the
+logs then passes the value on. Label-FIRST / subject-LAST (thread-last), so it
+reads Elm-style standalone (`Debug.log("x", m.x)`) AND threads in a pipe. An
+impure observability escape hatch — it can't affect the
 model/sim (a game with vs without it is byte-identical). Under plain `mle run`
 the line prints to stdout; under the runner it routes region-aware to the
 CLI's log stream (shown by default — no `-v`; `docs/cli-output.md`) — or the
@@ -254,7 +260,7 @@ Scene.model("shark.glb")                                   // glTF by path, rela
                                                            //   game dir; missing file =
                                                            //   logged error + empty fallback
 Scene.group([scene, …])
-scene |> Scene.color(r, g, b)                              // scene-first: pipes
+scene |> Scene.color(r, g, b)                              // scene-last: pipes
 scene |> Scene.lit(r, g, b)                                // diffuse+specular
 scene |> Scene.litNormalMapped(r, g, b, normalTex)         // + tangent-space
                                                            //   normal map (a
@@ -338,13 +344,13 @@ Effect.playThen(sound, msg)                                // one-shot; delivers
 AudioSource.ambient(key, sound)                            // soundScape voice: non-spatial bed
 AudioSource.at(key, sound, x, y, z)                        //   / positioned emitter (key =
                                                            //   cross-frame identity)
-source |> AudioSource.gain(g)                              // source-first: linear gain (1.0=full)
+source |> AudioSource.gain(g)                              // source-last: linear gain (1.0=full)
 AudioScene.create([source, …]) / AudioScene.empty()       // what `soundScape` returns
 
 Physics.box(w, h, d) / sphere(r) / capsule(halfH, r)       // -> Shape (box = FULL extents)
 Physics.dynamic("tag", shape)                              // simulated body
 Physics.kinematic("tag", shape) / Physics.fixed("tag", shape)
-body |> Physics.at(x, y, z)                                // body-first: pipes
+body |> Physics.at(x, y, z)                                // body-last: pipes
 body |> Physics.velocity(vx, vy, vz)
 body |> Physics.mass(m) / Physics.friction(f) / Physics.restitution(r)
 body |> Physics.sensor                                     // overlap-only, no forces

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,7 +189,8 @@ main context.
 
 - **The `mle-language` skill is the source of truth for MLE.** MLE is a small, custom language —
   do NOT guess syntax/semantics from F#/OCaml intuition (e.g. there is no `if`/`else`; the
-  conditional is a bool-literal `match`; assignment is `:=`; pipelines *prepend* the subject).
+  conditional is a bool-literal `match`; assignment is `:=`; pipelines *append* the subject
+  (thread-last: `x |> f(a)` == `f(a, x)`)).
   When a change touches the language or the prelude, update the skill in the same PR.
 - **`file = module`.** Every `.mle` in the entry's directory loads with the project — an
   unreferenced (or stray scratch) sibling still parses, checks, and evaluates. Keep scratch `.mle`

--- a/docs/mle.md
+++ b/docs/mle.md
@@ -280,7 +280,7 @@ snapshots — no GPU, fully agent-verifiable.
       Inference has teeth: unannotated bad calls, mixed lists,
       contradictory mut use, and foreign match arms are all caught now.
       *Verify (done):* both shipped games + all example goldens check
-      clean under inference; `(xs, k) => List.map(xs, (x) => x * k)`
+      clean under inference; `(xs, k) => List.map((x) => x * k, xs)`
       hovers as `(List<Float>, Float) => List<Float>`; teeth + occurs +
       ambiguity + SCC polymorphism pinned (215 mle tests).
       *Original verify:* unannotated examples get full inferred signatures (an
@@ -295,11 +295,35 @@ snapshots — no GPU, fully agent-verifiable.
       IS exhaustive, `[a, b]` alone needs a catch-all. Full stack: lexer
       (`..`), parser, lower, eval, HM types, hover/goto/rebind. Verify:
       `mle/examples/lists.mle` + goldens; run/parser/check pin tests.
-- [x] **Language: `Debug.log` trace builtin** (2026-07-06). Core `mle`-crate
-      builtin `Debug.log(value, label) : ('a, String) => 'a` — an Elm-style
+- [x] **Language: currying migration — call-site currying + thread-LAST piping**
+      (2026-07-07). Two steps landed. **Step 1** (#264): application curries at
+      the *call site* — `f(a, b)` is sugar for `((f a) b)`, so `f(a)` on a 2-arg
+      `f` is a legal partial application (a `Value::Partial`), not an arity error;
+      a saturated-call fast path keeps every direct `f(a,b)` and pipe at
+      allocation-free parity, and the checker's `Call` rule handles under/over
+      application. Multi-arg closures and `Type::Fn(Vec, ret)` are kept
+      (no nested arrows, no `f a b` syntax). **Step 3** (this): the flag-day
+      flip — `|>` now **appends** (thread-last: `x |> g(a)` ⇒ `g(a, x)`,
+      lowered directly to the saturated call, never a partial) and the whole
+      prelude/builtin surface flipped subject-first → **subject-LAST**
+      (`List.map(fn, list)`, `List.fold(fn, init, list)`, `Text.split(sep, s)`,
+      `Text.join(sep, list)`, `List.grid(fn, rows, cols)`, and every scene/body/
+      frame/target/source transform — `scene |> Scene.color(r,g,b)` now resolves
+      to `Scene.color(r, g, b, scene)`). Pipes and signatures flip together, so
+      existing piped code is untouched: the visually-rich pipe-heavy examples
+      (`lighting`, `synthwave`, `primitives`, `physics`) render **byte-identical**
+      before/after (`--fixed-time` PNG `cmp`), and the `mle bench` saturated +
+      piped corpus stays at parity. *Verify (done):* byte-identical example
+      captures; bench A/B; `cargo test -p mle` + `-p functor_runtime_common`
+      green with the reviewed golden regens. Decision record:
+      `docs/spikes/mle-currying.md`.
+- [x] **Language: `Debug.log` trace builtin** (2026-07-06; flipped label-first
+      in the currying migration step 3). Core `mle`-crate
+      builtin `Debug.log(label, value) : (String, 'a) => 'a` — an Elm-style
       trace: logs `label: <value>` (the interpreter's own `Value` display, any
       type) and returns `value` UNCHANGED, so it's pure to the program result
-      and pipe-friendly (`x |> Debug.log("x")`; value-first, label second).
+      and pipe-friendly (`x |> Debug.log("x")`; label-first / subject-last, so it
+      reads Elm-style standalone AND threads in a pipe).
       Lives in the `mle` crate (works in plain `mle run` AND under the host),
       routed through a settable, process-wide trace sink (`mle::set_trace_sink`,
       default: stdout). The Functor host installs a sink

--- a/examples/lighting/game.mle
+++ b/examples/lighting/game.mle
@@ -159,7 +159,7 @@ let pointPos = (i: Float, tts: Float) =>
 
 // An emissive marker sphere at each point light's position.
 let markers = (tts: Float) =>
-  List.map(List.range(3.0), (i) =>
+  List.range(3.0) |> List.map((i) =>
     let p = pointPos(i, tts) in
     let (r, g, b) = pointColor(i) in
     Scene.sphere()
@@ -168,7 +168,7 @@ let markers = (tts: Float) =>
       |> Scene.emissive(r, g, b))
 
 let pointLights = (tts: Float) =>
-  List.map(List.range(3.0), (i) =>
+  List.range(3.0) |> List.map((i) =>
     let p = pointPos(i, tts) in
     let (r, g, b) = pointColor(i) in
     Light.point(p.x, p.y, p.z, r, g, b, 1.4, 4.0))

--- a/examples/mpclient/game.mle
+++ b/examples/mpclient/game.mle
@@ -42,8 +42,8 @@ let init = { conn: Offline, world: [], status: "connecting" }
 // exactly 3 fields) and undoes the *100 fixed-point; draw order is irrelevant,
 // so the reversal cons introduces doesn't matter.
 let parseSnapshot = (s: String): List<Player> =>
-  List.fold(Text.split(s, "|"), (acc, row) =>
-    match Text.split(row, ",") with
+  Text.split("|", s) |> List.fold((acc, row) =>
+    match Text.split(",", row) with
     | [p, x, z] =>
         [{ pid: Text.parseFloat(p),
            x: Text.parseFloat(x) / 100.0,
@@ -104,7 +104,7 @@ let draw = (m: Model, tts: Float) =>
   // One colored cube per player in the last snapshot the server sent (same
   // framing + palette as mpserver, so panes line up in the netsim viewer).
   let playerNodes =
-    List.map(m.world, (p) =>
+    m.world |> List.map((p) =>
       let (r, g, b) = colorFor(p.pid) in
       Scene.cube()
       |> Scene.scale(0.6)

--- a/examples/mpserver/game.mle
+++ b/examples/mpserver/game.mle
@@ -55,11 +55,11 @@ let wrapAxis = (pos: Float, vel: Float, dt: Float): Float =>
 // Wire format: "pid,x*100,z*100|pid,x*100,z*100|...".
 let encodePlayer = (p: Player): String =>
   Text.join(
-    [Text.fixed(p.pid, 0.0), Text.fixed(p.x * 100.0, 0.0), Text.fixed(p.z * 100.0, 0.0)],
-    ",")
+    ",",
+    [Text.fixed(p.pid, 0.0), Text.fixed(p.x * 100.0, 0.0), Text.fixed(p.z * 100.0, 0.0)])
 
 let encode = (players: List<Player>): String =>
-  Text.join(List.map(players, encodePlayer), "|")
+  Text.join("|", List.map(encodePlayer, players))
 
 let init = { players: [], nextPid: 0.0 }
 
@@ -71,19 +71,19 @@ let update = (m: Model, msg: Msg): Model =>
       { m with players: [p, ..m.players], nextPid: m.nextPid + 1.0 }
   | Moved(cid, text) =>
       // "vx vz" -> set that client's velocity; a malformed packet is ignored.
-      (match Text.split(text, " ") with
+      (match Text.split(" ", text) with
        | [vxs, vzs] =>
            let vx = Text.parseFloat(vxs) in
            let vz = Text.parseFloat(vzs) in
            { m with players:
-               List.map(m.players, (p) =>
+               m.players |> List.map((p) =>
                  match p.cid == cid with
                  | true => { p with vx: vx, vz: vz }
                  | false => p) }
        | _ => m)
   | Left(cid) =>
       { m with players:
-          List.filter(m.players, (p) =>
+          m.players |> List.filter((p) =>
             match p.cid == cid with
             | true => false
             | false => true) }
@@ -95,10 +95,10 @@ let subscriptions = (m: Model) => Sub.listen(bind, toMsg)
 let tick = (m: Model, dt: Float, tts: Float) =>
   // Integrate, then broadcast the snapshot to every client.
   let players =
-    List.map(m.players, (p) =>
+    m.players |> List.map((p) =>
       { p with x: wrapAxis(p.x, p.vx, dt), z: wrapAxis(p.z, p.vz, dt) }) in
   let snapshot = encode(players) in
-  let sends = List.map(players, (p) => Effect.send(p.cid, snapshot)) in
+  let sends = players |> List.map((p) => Effect.send(p.cid, snapshot)) in
   ({ m with players: players }, Effect.batch(sends))
 
 // A distinct color per player id, shared with the client so a given player is
@@ -121,7 +121,7 @@ let draw = (m: Model, tts: Float) =>
   // One colored cube per player at its authoritative position, on a ground
   // plane sized to the wrap boundary (so the playfield edges are visible).
   let playerNodes =
-    List.map(m.players, (p) =>
+    m.players |> List.map((p) =>
       let (r, g, b) = colorFor(p.pid) in
       Scene.cube()
       |> Scene.scale(0.6)

--- a/examples/synthwave/game.mle
+++ b/examples/synthwave/game.mle
@@ -8,7 +8,7 @@
 //   functor -d examples/synthwave run native
 //
 // Port notes: F#'s procedural `heightmapFn rows cols fn` becomes
-// `Scene.heightmap(List.grid(rows, cols, fn))` — `List.grid` tabulates the grid
+// `Scene.heightmap(List.grid(fn, rows, cols))` — `List.grid` tabulates the grid
 // by calling the closure per cell in the engine's loop. The heightmap is a
 // unit square centered on origin, so F#'s non-uniform `Transform.scaleX/Z`
 // becomes `Scene.scaleXYZ` (sizing XZ to terrainSize while leaving Y at author
@@ -72,7 +72,7 @@ let draw = (m: Float, tts: Float) =>
   // hot-magenta edges) tiled one cell per quad, so the glowing lines align with
   // the mesh grid. Emissive = self-lit, so it glows in the dark.
   let terrain =
-    Scene.heightmap(List.grid(rows, cols, (r, c) => terrainHeight(phase, r, c)))
+    Scene.heightmap(List.grid((r, c) => terrainHeight(phase, r, c), rows, cols))
     |> Scene.scaleXYZ(terrainSize, 1.0, terrainSize)
     |> Scene.translate(0.0, -2.0, 0.0)
     |> Scene.emissiveTexture(gridTexture) in

--- a/mle/benches/README.md
+++ b/mle/benches/README.md
@@ -54,7 +54,7 @@ A benchmark is an ordinary `.mle` project whose entry defines a **zero-arg
 ```mle
 // BENCH: <one line naming what this measures>
 let step = (acc, x) => acc + x
-let main = () => List.fold(List.range(1000000), step, 0.0)
+let main = () => List.fold(step, 0.0, List.range(1000000))
 ```
 
 Rules:

--- a/mle/benches/corpus/adt.mle
+++ b/mle/benches/corpus/adt.mle
@@ -15,4 +15,4 @@ let toShape = (x) =>
   | true => Circle(x)
   | false => Rect(x, 2.0)
 let main = () =>
-  List.fold(List.range(100000), (acc, x) => acc + area(toShape(x)), 0.0)
+  List.fold((acc, x) => acc + area(toShape(x)), 0.0, List.range(100000))

--- a/mle/benches/corpus/arith_loop.mle
+++ b/mle/benches/corpus/arith_loop.mle
@@ -4,4 +4,4 @@
 //
 // Convention: `main` is the timed unit of work. Also: `mle run arith_loop.mle`.
 let step = (acc, x) => acc + x * 2.0 - x / 3.0 + Math.sin(x)
-let main = () => List.fold(List.range(500000), step, 0.0)
+let main = () => List.fold(step, 0.0, List.range(500000))

--- a/mle/benches/corpus/call_piped.mle
+++ b/mle/benches/corpus/call_piped.mle
@@ -8,4 +8,4 @@
 // Convention: `main` is the timed unit of work. Also: `mle run call_piped.mle`.
 let f = (a, b, c) => a + b * c
 let step = (acc, x) => acc + (x |> f(x, 2.0))
-let main = () => List.fold(List.range(1000000), step, 0.0)
+let main = () => List.fold(step, 0.0, List.range(1000000))

--- a/mle/benches/corpus/call_saturated.mle
+++ b/mle/benches/corpus/call_saturated.mle
@@ -9,4 +9,4 @@
 // (result: 1499998500000).
 let f = (a, b, c) => a + b * c
 let step = (acc, x) => acc + f(x, x, 2.0)
-let main = () => List.fold(List.range(1000000), step, 0.0)
+let main = () => List.fold(step, 0.0, List.range(1000000))

--- a/mle/benches/corpus/fold_floor.mle
+++ b/mle/benches/corpus/fold_floor.mle
@@ -4,4 +4,4 @@
 //
 // Convention: `main` is the timed unit of work. Also: `mle run fold_floor.mle`.
 let step = (acc, x) => acc
-let main = () => List.fold(List.range(1000000), step, 0.0)
+let main = () => List.fold(step, 0.0, List.range(1000000))

--- a/mle/benches/corpus/pattern_match.mle
+++ b/mle/benches/corpus/pattern_match.mle
@@ -11,4 +11,4 @@ let classify = (x) =>
      | true => 2.0
      | false => 1.0)
 let main = () =>
-  List.fold(List.range(200000), (acc, x) => acc + classify(x), 0.0)
+  List.fold((acc, x) => acc + classify(x), 0.0, List.range(200000))

--- a/mle/benches/corpus/record_update.mle
+++ b/mle/benches/corpus/record_update.mle
@@ -6,5 +6,5 @@
 type Acc = { sum: Float, count: Float }
 let step = (r: Acc, x: Float): Acc => { r with sum: r.sum + x, count: r.count + 1.0 }
 let main = () =>
-  let final = List.fold(List.range(100000), step, { sum: 0.0, count: 0.0 }) in
+  let final = List.fold(step, { sum: 0.0, count: 0.0 }, List.range(100000)) in
   final.sum + final.count

--- a/mle/benches/corpus/recursion.mle
+++ b/mle/benches/corpus/recursion.mle
@@ -14,4 +14,4 @@ let sumTo = (n, acc) =>
   | true => acc
   | false => sumTo(n - 1.0, acc + n)
 let main = () =>
-  List.fold(List.range(50000), (acc, x) => acc + sumTo(30.0, 0.0), 0.0)
+  List.fold((acc, x) => acc + sumTo(30.0, 0.0), 0.0, List.range(50000))

--- a/mle/examples/functions.ir
+++ b/mle/examples/functions.ir
@@ -208,6 +208,20 @@ Module {
                             },
                             args: [
                                 Expr {
+                                    id: e13,
+                                    kind: Global(
+                                        "add",
+                                    ),
+                                    span: 270..273,
+                                },
+                                Expr {
+                                    id: e14,
+                                    kind: Number(
+                                        0.0,
+                                    ),
+                                    span: 275..278,
+                                },
+                                Expr {
                                     id: e11,
                                     kind: FieldAccess {
                                         object: Expr {
@@ -221,20 +235,6 @@ Module {
                                         field: "scores",
                                     },
                                     span: 248..256,
-                                },
-                                Expr {
-                                    id: e13,
-                                    kind: Global(
-                                        "add",
-                                    ),
-                                    span: 270..273,
-                                },
-                                Expr {
-                                    id: e14,
-                                    kind: Number(
-                                        0.0,
-                                    ),
-                                    span: 275..278,
                                 },
                             ],
                         },
@@ -307,14 +307,6 @@ Module {
                                         },
                                         args: [
                                             Expr {
-                                                id: e17,
-                                                kind: Local {
-                                                    binding: b5,
-                                                    name: "players",
-                                                },
-                                                span: 333..340,
-                                            },
-                                            Expr {
                                                 id: e22,
                                                 kind: Lambda {
                                                     params: [
@@ -351,6 +343,14 @@ Module {
                                                     },
                                                 },
                                                 span: 353..368,
+                                            },
+                                            Expr {
+                                                id: e17,
+                                                kind: Local {
+                                                    binding: b5,
+                                                    name: "players",
+                                                },
+                                                span: 333..340,
                                             },
                                         ],
                                     },

--- a/mle/examples/pure_pipeline.ir
+++ b/mle/examples/pure_pipeline.ir
@@ -242,6 +242,13 @@ Module {
                                         },
                                         args: [
                                             Expr {
+                                                id: e23,
+                                                kind: Global(
+                                                    "describe",
+                                                ),
+                                                span: 457..465,
+                                            },
+                                            Expr {
                                                 id: e21,
                                                 kind: Call {
                                                     callee: Expr {
@@ -256,6 +263,13 @@ Module {
                                                     },
                                                     args: [
                                                         Expr {
+                                                            id: e20,
+                                                            kind: Global(
+                                                                "isHigh",
+                                                            ),
+                                                            span: 433..439,
+                                                        },
+                                                        Expr {
                                                             id: e18,
                                                             kind: Local {
                                                                 binding: b3,
@@ -263,23 +277,9 @@ Module {
                                                             },
                                                             span: 407..413,
                                                         },
-                                                        Expr {
-                                                            id: e20,
-                                                            kind: Global(
-                                                                "isHigh",
-                                                            ),
-                                                            span: 433..439,
-                                                        },
                                                     ],
                                                 },
                                                 span: 421..440,
-                                            },
-                                            Expr {
-                                                id: e23,
-                                                kind: Global(
-                                                    "describe",
-                                                ),
-                                                span: 457..465,
                                             },
                                         ],
                                     },

--- a/mle/examples/pure_pipeline.trace
+++ b/mle/examples/pure_pipeline.trace
@@ -1,6 +1,6 @@
 > main()
   > report([12, 3.5, 40])
-    > List.filter([12, 3.5, 40], <fn(score)>)
+    > List.filter(<fn(score)>, [12, 3.5, 40])
       > List.filter[0](12)
       < true
       > List.filter[1](3.5)
@@ -8,7 +8,7 @@
       > List.filter[2](40)
       < true
     < [12, 40]
-    > List.map([12, 40], <fn(score)>)
+    > List.map(<fn(score)>, [12, 40])
       > List.map[0](12)
         > Text.fromFloat(12)
         < "12"

--- a/mle/examples/shapes.ir
+++ b/mle/examples/shapes.ir
@@ -810,18 +810,18 @@ Module {
                                         },
                                         args: [
                                             Expr {
-                                                id: e62,
-                                                kind: Global(
-                                                    "shapes",
-                                                ),
-                                                span: 1289..1295,
-                                            },
-                                            Expr {
                                                 id: e64,
                                                 kind: Global(
                                                     "describe",
                                                 ),
                                                 span: 1308..1316,
+                                            },
+                                            Expr {
+                                                id: e62,
+                                                kind: Global(
+                                                    "shapes",
+                                                ),
+                                                span: 1289..1295,
                                             },
                                         ],
                                     },

--- a/mle/examples/strings.ast
+++ b/mle/examples/strings.ast
@@ -60,6 +60,12 @@ Program {
                                 },
                                 args: [
                                     Expr {
+                                        kind: String(
+                                            ",",
+                                        ),
+                                        span: 356..359,
+                                    },
+                                    Expr {
                                         kind: List(
                                             [
                                                 Expr {
@@ -71,7 +77,7 @@ Program {
                                                                     "fixed",
                                                                 ],
                                                             ),
-                                                            span: 357..367,
+                                                            span: 366..376,
                                                         },
                                                         args: [
                                                             Expr {
@@ -80,17 +86,17 @@ Program {
                                                                         "pid",
                                                                     ],
                                                                 ),
-                                                                span: 368..371,
+                                                                span: 377..380,
                                                             },
                                                             Expr {
                                                                 kind: Number(
                                                                     0.0,
                                                                 ),
-                                                                span: 373..376,
+                                                                span: 382..385,
                                                             },
                                                         ],
                                                     },
-                                                    span: 357..377,
+                                                    span: 366..386,
                                                 },
                                                 Expr {
                                                     kind: Call {
@@ -101,7 +107,7 @@ Program {
                                                                     "fixed",
                                                                 ],
                                                             ),
-                                                            span: 379..389,
+                                                            span: 388..398,
                                                         },
                                                         args: [
                                                             Expr {
@@ -113,26 +119,26 @@ Program {
                                                                                 "x",
                                                                             ],
                                                                         ),
-                                                                        span: 390..391,
+                                                                        span: 399..400,
                                                                     },
                                                                     rhs: Expr {
                                                                         kind: Number(
                                                                             100.0,
                                                                         ),
-                                                                        span: 394..399,
+                                                                        span: 403..408,
                                                                     },
                                                                 },
-                                                                span: 390..399,
+                                                                span: 399..408,
                                                             },
                                                             Expr {
                                                                 kind: Number(
                                                                     0.0,
                                                                 ),
-                                                                span: 401..404,
+                                                                span: 410..413,
                                                             },
                                                         ],
                                                     },
-                                                    span: 379..405,
+                                                    span: 388..414,
                                                 },
                                                 Expr {
                                                     kind: Call {
@@ -143,7 +149,7 @@ Program {
                                                                     "fixed",
                                                                 ],
                                                             ),
-                                                            span: 407..417,
+                                                            span: 416..426,
                                                         },
                                                         args: [
                                                             Expr {
@@ -155,36 +161,30 @@ Program {
                                                                                 "z",
                                                                             ],
                                                                         ),
-                                                                        span: 418..419,
+                                                                        span: 427..428,
                                                                     },
                                                                     rhs: Expr {
                                                                         kind: Number(
                                                                             100.0,
                                                                         ),
-                                                                        span: 422..427,
+                                                                        span: 431..436,
                                                                     },
                                                                 },
-                                                                span: 418..427,
+                                                                span: 427..436,
                                                             },
                                                             Expr {
                                                                 kind: Number(
                                                                     0.0,
                                                                 ),
-                                                                span: 429..432,
+                                                                span: 438..441,
                                                             },
                                                         ],
                                                     },
-                                                    span: 407..433,
+                                                    span: 416..442,
                                                 },
                                             ],
                                         ),
-                                        span: 356..434,
-                                    },
-                                    Expr {
-                                        kind: String(
-                                            ",",
-                                        ),
-                                        span: 440..443,
+                                        span: 365..443,
                                     },
                                 ],
                             },
@@ -240,18 +240,18 @@ Program {
                                 },
                                 args: [
                                     Expr {
+                                        kind: String(
+                                            "|",
+                                        ),
+                                        span: 550..553,
+                                    },
+                                    Expr {
                                         kind: Ident(
                                             [
                                                 "rows",
                                             ],
                                         ),
-                                        span: 550..554,
-                                    },
-                                    Expr {
-                                        kind: String(
-                                            "|",
-                                        ),
-                                        span: 556..559,
+                                        span: 555..559,
                                     },
                                 ],
                             },
@@ -319,16 +319,16 @@ Program {
                                         },
                                         args: [
                                             Expr {
-                                                kind: Ident(
-                                                    [
-                                                        "row",
-                                                    ],
+                                                kind: String(
+                                                    ",",
                                                 ),
                                                 span: 705..708,
                                             },
                                             Expr {
-                                                kind: String(
-                                                    ",",
+                                                kind: Ident(
+                                                    [
+                                                        "row",
+                                                    ],
                                                 ),
                                                 span: 710..713,
                                             },

--- a/mle/examples/strings.ir
+++ b/mle/examples/strings.ir
@@ -67,146 +67,146 @@ Module {
                             },
                             args: [
                                 Expr {
-                                    id: e17,
+                                    id: e1,
+                                    kind: String(
+                                        ",",
+                                    ),
+                                    span: 356..359,
+                                },
+                                Expr {
+                                    id: e18,
                                     kind: List(
                                         [
                                             Expr {
-                                                id: e4,
+                                                id: e5,
                                                 kind: Call {
                                                     callee: Expr {
-                                                        id: e1,
+                                                        id: e2,
                                                         kind: External(
                                                             [
                                                                 "Text",
                                                                 "fixed",
                                                             ],
                                                         ),
-                                                        span: 357..367,
+                                                        span: 366..376,
                                                     },
                                                     args: [
                                                         Expr {
-                                                            id: e2,
+                                                            id: e3,
                                                             kind: Local {
                                                                 binding: b0,
                                                                 name: "pid",
                                                             },
-                                                            span: 368..371,
+                                                            span: 377..380,
                                                         },
                                                         Expr {
-                                                            id: e3,
+                                                            id: e4,
                                                             kind: Number(
                                                                 0.0,
                                                             ),
-                                                            span: 373..376,
+                                                            span: 382..385,
                                                         },
                                                     ],
                                                 },
-                                                span: 357..377,
+                                                span: 366..386,
                                             },
                                             Expr {
-                                                id: e10,
+                                                id: e11,
                                                 kind: Call {
                                                     callee: Expr {
-                                                        id: e5,
+                                                        id: e6,
                                                         kind: External(
                                                             [
                                                                 "Text",
                                                                 "fixed",
                                                             ],
                                                         ),
-                                                        span: 379..389,
+                                                        span: 388..398,
                                                     },
                                                     args: [
                                                         Expr {
-                                                            id: e8,
+                                                            id: e9,
                                                             kind: Binary {
                                                                 op: Mul,
                                                                 lhs: Expr {
-                                                                    id: e6,
+                                                                    id: e7,
                                                                     kind: Local {
                                                                         binding: b1,
                                                                         name: "x",
                                                                     },
-                                                                    span: 390..391,
+                                                                    span: 399..400,
                                                                 },
                                                                 rhs: Expr {
-                                                                    id: e7,
+                                                                    id: e8,
                                                                     kind: Number(
                                                                         100.0,
                                                                     ),
-                                                                    span: 394..399,
+                                                                    span: 403..408,
                                                                 },
                                                             },
-                                                            span: 390..399,
+                                                            span: 399..408,
                                                         },
                                                         Expr {
-                                                            id: e9,
+                                                            id: e10,
                                                             kind: Number(
                                                                 0.0,
                                                             ),
-                                                            span: 401..404,
+                                                            span: 410..413,
                                                         },
                                                     ],
                                                 },
-                                                span: 379..405,
+                                                span: 388..414,
                                             },
                                             Expr {
-                                                id: e16,
+                                                id: e17,
                                                 kind: Call {
                                                     callee: Expr {
-                                                        id: e11,
+                                                        id: e12,
                                                         kind: External(
                                                             [
                                                                 "Text",
                                                                 "fixed",
                                                             ],
                                                         ),
-                                                        span: 407..417,
+                                                        span: 416..426,
                                                     },
                                                     args: [
                                                         Expr {
-                                                            id: e14,
+                                                            id: e15,
                                                             kind: Binary {
                                                                 op: Mul,
                                                                 lhs: Expr {
-                                                                    id: e12,
+                                                                    id: e13,
                                                                     kind: Local {
                                                                         binding: b2,
                                                                         name: "z",
                                                                     },
-                                                                    span: 418..419,
+                                                                    span: 427..428,
                                                                 },
                                                                 rhs: Expr {
-                                                                    id: e13,
+                                                                    id: e14,
                                                                     kind: Number(
                                                                         100.0,
                                                                     ),
-                                                                    span: 422..427,
+                                                                    span: 431..436,
                                                                 },
                                                             },
-                                                            span: 418..427,
+                                                            span: 427..436,
                                                         },
                                                         Expr {
-                                                            id: e15,
+                                                            id: e16,
                                                             kind: Number(
                                                                 0.0,
                                                             ),
-                                                            span: 429..432,
+                                                            span: 438..441,
                                                         },
                                                     ],
                                                 },
-                                                span: 407..433,
+                                                span: 416..442,
                                             },
                                         ],
                                     ),
-                                    span: 356..434,
-                                },
-                                Expr {
-                                    id: e18,
-                                    kind: String(
-                                        ",",
-                                    ),
-                                    span: 440..443,
+                                    span: 365..443,
                                 },
                             ],
                         },
@@ -266,18 +266,18 @@ Module {
                             args: [
                                 Expr {
                                     id: e22,
+                                    kind: String(
+                                        "|",
+                                    ),
+                                    span: 550..553,
+                                },
+                                Expr {
+                                    id: e23,
                                     kind: Local {
                                         binding: b3,
                                         name: "rows",
                                     },
-                                    span: 550..554,
-                                },
-                                Expr {
-                                    id: e23,
-                                    kind: String(
-                                        "|",
-                                    ),
-                                    span: 556..559,
+                                    span: 555..559,
                                 },
                             ],
                         },
@@ -350,17 +350,17 @@ Module {
                                     args: [
                                         Expr {
                                             id: e27,
-                                            kind: Local {
-                                                binding: b4,
-                                                name: "row",
-                                            },
+                                            kind: String(
+                                                ",",
+                                            ),
                                             span: 705..708,
                                         },
                                         Expr {
                                             id: e28,
-                                            kind: String(
-                                                ",",
-                                            ),
+                                            kind: Local {
+                                                binding: b4,
+                                                name: "row",
+                                            },
                                             span: 710..713,
                                         },
                                     ],

--- a/mle/examples/strings.mle
+++ b/mle/examples/strings.mle
@@ -5,15 +5,15 @@
 // Encode one player as "pid,x*100,z*100".
 let encode = (pid: Float, x: Float, z: Float): String =>
   Text.join(
-    [Text.fixed(pid, 0.0), Text.fixed(x * 100.0, 0.0), Text.fixed(z * 100.0, 0.0)],
-    ",")
+    ",",
+    [Text.fixed(pid, 0.0), Text.fixed(x * 100.0, 0.0), Text.fixed(z * 100.0, 0.0)])
 
 // The full snapshot: players joined with '|'.
-let snapshot = (rows: List<String>): String => Text.join(rows, "|")
+let snapshot = (rows: List<String>): String => Text.join("|", rows)
 
 // Decode one row back to world units (the *100 fixed-point undone).
 let parseRow = (row: String): Float * Float * Float =>
-  match Text.split(row, ",") with
+  match Text.split(",", row) with
   | [p, x, z] => (Text.parseFloat(p), Text.parseFloat(x) / 100.0, Text.parseFloat(z) / 100.0)
   | _ => (0.0, 0.0, 0.0)
 

--- a/mle/src/eval.rs
+++ b/mle/src/eval.rs
@@ -799,8 +799,10 @@ impl Interp<'_> {
     ) -> Result<Value, RunError> {
         let err = |message: String| Err(RunError { message, span });
         match b {
+            // Subject-LAST — `List.map(fn, list)`, so `list |> List.map(fn)`
+            // threads the list in as the final argument.
             Builtin::ListMap => match args.as_slice() {
-                [Value::List(items), f] => {
+                [f, Value::List(items)] => {
                     let mut out = Vec::with_capacity(items.len());
                     for (i, item) in items.iter().enumerate() {
                         out.push(self.call(
@@ -813,10 +815,11 @@ impl Interp<'_> {
                     }
                     Ok(Value::List(Rc::new(out)))
                 }
-                _ => err("List.map(list, fn) expects a list and a function".to_string()),
+                _ => err("List.map(fn, list) expects a function and a list".to_string()),
             },
+            // Subject-LAST — `List.filter(fn, list)`.
             Builtin::ListFilter => match args.as_slice() {
-                [Value::List(items), f] => {
+                [f, Value::List(items)] => {
                     let mut out = Vec::new();
                     for (i, item) in items.iter().enumerate() {
                         match self.call(
@@ -838,12 +841,13 @@ impl Interp<'_> {
                     }
                     Ok(Value::List(Rc::new(out)))
                 }
-                _ => err("List.filter(list, fn) expects a list and a function".to_string()),
+                _ => err("List.filter(fn, list) expects a function and a list".to_string()),
             },
-            // List-first like map/filter, so it composes with `|>` (the piped
-            // value is PREPENDED as the first argument — see crate::lower).
+            // Subject-LAST like map/filter, so it composes with `|>` (the piped
+            // value is APPENDED as the final argument — see crate::lower):
+            // `list |> List.fold(fn, init)` == `List.fold(fn, init, list)`.
             Builtin::ListFold => match args.as_slice() {
-                [Value::List(items), f, init] => {
+                [f, init, Value::List(items)] => {
                     let mut acc = init.clone();
                     for (i, item) in items.iter().enumerate() {
                         acc = self.call(
@@ -857,7 +861,7 @@ impl Interp<'_> {
                     Ok(acc)
                 }
                 _ => err(
-                    "List.fold(list, fn, init) expects a list, a function, and an initial value"
+                    "List.fold(fn, init, list) expects a function, an initial value, and a list"
                         .to_string(),
                 ),
             },
@@ -883,12 +887,13 @@ impl Interp<'_> {
             // Tabulate a rows×cols grid by calling `f(row, col)` for each cell
             // (both 0-based) — `[[f(0,0), f(0,1), …], …]`. It is the engine's
             // tight-loop form of a procedural heightmap
-            // (`Scene.heightmap(List.grid(rows, cols, height))`); vs a nested
-            // `List.map(List.range(…))` it skips allocating the two range lists
+            // (`Scene.heightmap(List.grid(height, rows, cols))`); vs a nested
+            // `List.map(…)` it skips allocating the two range lists
             // and the outer-map closure each frame (both interpret `f` per cell,
             // and both loop iteratively so eval depth never accumulates).
+            // Subject-LAST: the callback comes FIRST — `List.grid(fn, rows, cols)`.
             Builtin::ListGrid => match args.as_slice() {
-                [Value::Number(rows), Value::Number(cols), f]
+                [f, Value::Number(rows), Value::Number(cols)]
                     if is_function(f)
                         && rows.is_finite()
                         && cols.is_finite()
@@ -918,12 +923,12 @@ impl Interp<'_> {
                     }
                     Ok(Value::List(Rc::new(grid)))
                 }
-                [Value::Number(_), Value::Number(_), f] if is_function(f) => err(
-                    "List.grid(rows, cols, fn) needs whole, non-negative counts with at \
+                [f, Value::Number(_), Value::Number(_)] if is_function(f) => err(
+                    "List.grid(fn, rows, cols) needs whole, non-negative counts with at \
 most 1000000 cells"
                         .to_string(),
                 ),
-                _ => err("List.grid(rows, cols, fn) expects two numbers and a function".to_string()),
+                _ => err("List.grid(fn, rows, cols) expects a function and two numbers".to_string()),
             },
             Builtin::ListMaximum => match args.as_slice() {
                 [Value::List(items)] => {
@@ -995,8 +1000,9 @@ most 1000000 cells"
             },
             // The wire-protocol string trio the multiplayer ports need (the
             // F# `String.Split` / `String.concat` / `parseInt` shapes).
+            // Subject-LAST — `Text.split(sep, s)`, so `s |> Text.split(sep)`.
             Builtin::TextSplit => match args.as_slice() {
-                [Value::String(s), Value::String(sep)] => {
+                [Value::String(sep), Value::String(s)] => {
                     if sep.is_empty() {
                         return err("Text.split needs a non-empty separator".to_string());
                     }
@@ -1004,10 +1010,11 @@ most 1000000 cells"
                         s.split(sep.as_ref()).map(|p| Value::String(Rc::from(p))).collect();
                     Ok(Value::List(Rc::new(parts)))
                 }
-                _ => err("Text.split(s, sep) expects two strings".to_string()),
+                _ => err("Text.split(sep, s) expects two strings".to_string()),
             },
+            // Subject-LAST — `Text.join(sep, list)`, so `list |> Text.join(sep)`.
             Builtin::TextJoin => match args.as_slice() {
-                [Value::List(items), Value::String(sep)] => {
+                [Value::String(sep), Value::List(items)] => {
                     let mut parts = Vec::with_capacity(items.len());
                     for item in items.iter() {
                         match item {
@@ -1022,7 +1029,7 @@ most 1000000 cells"
                     }
                     Ok(Value::String(Rc::from(parts.join(sep.as_ref()).as_str())))
                 }
-                _ => err("Text.join(list, sep) expects a list of strings and a string".to_string()),
+                _ => err("Text.join(sep, list) expects a string and a list of strings".to_string()),
             },
             // Parse a number out of a (possibly space-padded) string,
             // defaulting to 0.0 on failure — mirrors the F# ports'
@@ -1049,22 +1056,25 @@ most 1000000 cells"
                 [Value::Number(n)] => Ok(Value::Number(n.cos())),
                 _ => err("Math.cos(n) expects one number".to_string()),
             },
-            // Elm-style trace: log `label: <value>` through the process-wide
-            // trace sink and return `value` UNCHANGED — an impure observability
-            // escape hatch that never touches the model/sim (so a game with vs
-            // without a `Debug.log` produces byte-identical state). Value-first
-            // so it's pipe-friendly: `x |> Debug.log("x")`. The value renders
-            // with the interpreter's own `Value` display — the same text as
+            // Elm-style trace (`Debug.log : String -> a -> a`): log
+            // `label: <subject>` through the process-wide trace sink and return
+            // the SUBJECT unchanged — an impure observability escape hatch that
+            // never touches the model/sim (so a game with vs without a
+            // `Debug.log` produces byte-identical state). Label-first /
+            // subject-LAST, so it reads naturally standalone
+            // (`Debug.log("hp", m.hp)`) AND threads in a pipe
+            // (`m.hp |> Debug.log("hp")`). The subject renders with the
+            // interpreter's own `Value` display — the same text as
             // `mle run`/`trace` — for any type. The sink decides where the line
             // goes (stdout under plain `mle run`, the region-aware log path
             // under the host); see `crate::trace`.
             Builtin::DebugLog => match args.as_slice() {
-                [value, Value::String(label)] => {
-                    crate::trace::emit(format!("{label}: {value}"));
-                    Ok(value.clone())
+                [Value::String(label), subject] => {
+                    crate::trace::emit(format!("{label}: {subject}"));
+                    Ok(subject.clone())
                 }
                 _ => err(
-                    "Debug.log(value, label) expects a value and a string label".to_string(),
+                    "Debug.log(label, subject) expects a string label and a value".to_string(),
                 ),
             },
         }

--- a/mle/src/lower.rs
+++ b/mle/src/lower.rs
@@ -75,9 +75,11 @@
 //!
 //! ## Pipeline desugaring
 //!
-//! Each pipeline stage becomes a call with the piped value **prepended** as
-//! the first argument: `x |> f` → `f(x)`, `x |> g(a)` → `g(x, a)`, so
-//! `x |> f |> g(a)` → `g(f(x), a)`. The desugared call carries the span of
+//! Each pipeline stage becomes a call with the piped value **appended** as
+//! the LAST argument (thread-last): `x |> f` → `f(x)`, `x |> g(a)` → `g(a, x)`,
+//! so `x |> f |> g(a)` → `g(a, f(x))`. Because `|>` is syntax, the stage
+//! lowers directly to the SATURATED call — `x |> g(a)` is `g(a, x)`, never a
+//! partial `g(a)` — so pipes stay allocation-free. The desugared call carries the span of
 //! its stage — which means its first argument's span lies *outside* the
 //! call's own span (it came from an earlier stage); diagnostics must not
 //! assume parent spans contain child spans. The IR has no pipeline node.
@@ -921,16 +923,22 @@ impl Lowerer<'_> {
     fn pipe_stage(&mut self, piped: Expr, stage: ast::Expr) -> Result<Expr, LowerError> {
         let span = stage.span;
         let (callee, rest) = match stage.kind {
-            // `x |> g(a)` → `g(x, a)`
+            // `x |> g(a)` → `g(a, x)`
             ast::ExprKind::Call { callee, args } => (*callee, args),
             // `x |> f` → `f(x)` (any non-call stage is called directly)
             kind => (ast::Expr { kind, span }, Vec::new()),
         };
+        // Thread-LAST: the piped value becomes the callee's FINAL argument, so
+        // `x |> g(a)` lowers directly to the saturated `g(a, x)` (never a
+        // partial `g(a)`) and a subject-last signature — `x |>
+        // Debug.log("hp")` == `Debug.log("hp", x)` — threads x in as the
+        // subject. Pipes stay allocation-free (a saturated call, no PAP).
         let callee = Box::new(self.expr(callee)?);
-        let mut args = vec![piped];
+        let mut args = Vec::with_capacity(rest.len() + 1);
         for arg in rest {
             args.push(self.expr(arg)?);
         }
+        args.push(piped);
         Ok(Expr {
             id: self.expr_id(),
             kind: ExprKind::Call { callee, args },

--- a/mle/src/types.rs
+++ b/mle/src/types.rs
@@ -7,7 +7,7 @@
 //! components of the call graph, so mutual recursion is monomorphic inside
 //! its group and forward references still work), and every use
 //! instantiates fresh (`id` at Float and String in one module is fine).
-//! Builtins carry generic schemes (`List.map : (List<'a>, ('a) => 'b) =>
+//! Builtins carry generic schemes (`List.map : (('a) => 'b, List<'a>) =>
 //! List<'b>`), so element types flow through pipelines. Lowercase names in
 //! annotations are scoped type variables (`(xs: List<a>, f: (a) => b)`).
 //!
@@ -328,8 +328,8 @@ fn free_vars_of(ty: &Type, out: &mut Vec<u32>) {
 
 /// The signature of a builtin (kept in sync with [`crate::eval`]'s registry
 /// by matching on [`Builtin`]). Generic slots are Unknown rather than
-/// instantiated type variables — e.g. `List.map : (List<T>, (T) => U) =>
-/// List<U>` is `(List<Unknown>, (Unknown) => Unknown) => List<Unknown>` — so
+/// instantiated type variables — e.g. `List.map : ((T) => U, List<T>) =>
+/// List<U>` is `((Unknown) => Unknown, List<Unknown>) => List<Unknown>` — so
 /// element types don't flow through, but arity and the known parts (like
 /// `List.filter`'s Bool-returning predicate) still check.
 pub fn builtin_signature(b: Builtin) -> Type {
@@ -340,30 +340,30 @@ pub fn builtin_signature(b: Builtin) -> Type {
     match b {
         // Generic slots are Var(0)/Var(1); every use site instantiates
         // them fresh (B7), so element types genuinely flow through.
-        // List.map : (List<'a>, ('a) => 'b) => List<'b>
+        // Subject-LAST. List.map : (('a) => 'b, List<'a>) => List<'b>
         Builtin::ListMap => func(
-            vec![List(Box::new(Var(0))), func(vec![Var(0)], Var(1))],
+            vec![func(vec![Var(0)], Var(1)), List(Box::new(Var(0)))],
             List(Box::new(Var(1))),
         ),
-        // List.filter : (List<'a>, ('a) => Bool) => List<'a>
+        // Subject-LAST. List.filter : (('a) => Bool, List<'a>) => List<'a>
         Builtin::ListFilter => func(
-            vec![List(Box::new(Var(0))), func(vec![Var(0)], Bool)],
+            vec![func(vec![Var(0)], Bool), List(Box::new(Var(0)))],
             List(Box::new(Var(0))),
         ),
-        // List.fold : (List<'a>, ('b, 'a) => 'b, 'b) => 'b
+        // Subject-LAST. List.fold : (('b, 'a) => 'b, 'b, List<'a>) => 'b
         Builtin::ListFold => func(
             vec![
-                List(Box::new(Var(0))),
                 func(vec![Var(1), Var(0)], Var(1)),
                 Var(1),
+                List(Box::new(Var(0))),
             ],
             Var(1),
         ),
         // List.range : (Float) => List<Float>
         Builtin::ListRange => func(vec![Float], List(Box::new(Float))),
-        // List.grid : (Float, Float, (Float, Float) => 'a) => List<List<'a>>
+        // Subject-LAST. List.grid : ((Float, Float) => 'a, Float, Float) => List<List<'a>>
         Builtin::ListGrid => func(
-            vec![Float, Float, func(vec![Float, Float], Var(0))],
+            vec![func(vec![Float, Float], Var(0)), Float, Float],
             List(Box::new(List(Box::new(Var(0))))),
         ),
         // List.maximum : (List<Float>) => Float
@@ -376,17 +376,18 @@ pub fn builtin_signature(b: Builtin) -> Type {
         Builtin::TextFixed => func(vec![Float, Float], String),
         // Text.toBullets : (List<String>) => String
         Builtin::TextToBullets => func(vec![List(Box::new(String))], String),
-        // Text.split : (String, String) => List<String>
+        // Subject-LAST. Text.split : (String, String) => List<String> — (sep, s)
         Builtin::TextSplit => func(vec![String, String], List(Box::new(String))),
-        // Text.join : (List<String>, String) => String
-        Builtin::TextJoin => func(vec![List(Box::new(String)), String], String),
+        // Subject-LAST. Text.join : (String, List<String>) => String — (sep, list)
+        Builtin::TextJoin => func(vec![String, List(Box::new(String))], String),
         // Text.parseFloat : (String) => Float
         Builtin::TextParseFloat => func(vec![String], Float),
         // Math.clamp01 / sin / cos : (Float) => Float
         Builtin::MathClamp01 | Builtin::MathSin | Builtin::MathCos => func(vec![Float], Float),
-        // Debug.log : ('a, String) => 'a — logs `label: value` and returns the
-        // value unchanged (Var(0) is generic, so it's transparent in a pipe).
-        Builtin::DebugLog => func(vec![Var(0), String], Var(0)),
+        // Subject-LAST. Debug.log : (String, 'a) => 'a — label first, subject
+        // last; logs `label: subject` and returns the subject unchanged (Var(0)
+        // is generic, so it's transparent in a pipe).
+        Builtin::DebugLog => func(vec![String, Var(0)], Var(0)),
     }
 }
 

--- a/mle/tests/check.rs
+++ b/mle/tests/check.rs
@@ -263,12 +263,12 @@ fn over_application_checks_surplus_against_result() {
 #[test]
 fn error_filter_predicate_must_return_bool() {
     let (message, _, _) =
-        single_diag("let g = (xs: List<Float>) => List.filter(xs, (x): Float => x)");
+        single_diag("let g = (xs: List<Float>) => List.filter((x): Float => x, xs)");
     assert_eq!(
         message,
         // B7: the element type flows from `xs` into the predicate's
-        // signature — Float, not Unknown.
-        "argument 2 of `List.filter`: expected (Float) => Bool, got (Float) => Float"
+        // signature — Float, not Unknown. Subject-last: the predicate is arg 1.
+        "argument 1 of `List.filter`: expected (Float) => Bool, got (Float) => Float"
     );
 }
 
@@ -339,7 +339,7 @@ fn records_flow_gradually() {
 fn generic_builtin_slots_stay_unknown() {
     // List.map's result is List<Unknown>, which is compatible with the
     // List<Float> that List.maximum expects (no generic instantiation).
-    assert_clean("let best = (xs: List<Float>): Float => List.maximum(List.map(xs, (x) => x))");
+    assert_clean("let best = (xs: List<Float>): Float => List.maximum(List.map((x) => x, xs))");
 }
 
 #[test]
@@ -874,7 +874,7 @@ fn mutual_recursion_infers() {
 /// line, via hover's type table.
 #[test]
 fn unannotated_defs_get_inferred_signatures() {
-    let src = "let scale = (xs, k) => List.map(xs, (x) => x * k)";
+    let src = "let scale = (xs, k) => List.map((x) => x * k, xs)";
     let module = mle::lower(mle::parse(src).unwrap()).unwrap();
     let (diags, types) = mle::check_with_types(&module);
     assert!(diags.is_empty(), "{diags:?}");
@@ -950,12 +950,13 @@ fn undeclared_type_params_are_refused() {
 /// variable never wears two names in one message. [Claude M]
 #[test]
 fn diagnostic_variables_share_one_order() {
-    let (message, _, _) = single_diag("let f = (x) => List.fold(x, x, 1.0)");
-    // x is both the list and the folder: 'a is the element type in BOTH
-    // sides of the message (got is normalized first), 'b the accumulator.
+    let (message, _, _) = single_diag("let f = (x) => List.fold(x, 1.0, x)");
+    // Subject-last `List.fold(fn, init, list)`: x is both the folder (arg 1)
+    // and the list (arg 3), so 'a — the element type — appears on BOTH sides
+    // of the message with one consistent variable order.
     assert_eq!(
         message,
-        "argument 2 of `List.fold`: expected ('b, 'a) => 'b, got List<'a>"
+        "argument 3 of `List.fold`: expected List<'a>, got (Float, 'a) => Float"
     );
 }
 

--- a/mle/tests/ir.rs
+++ b/mle/tests/ir.rs
@@ -191,21 +191,23 @@ fn pipeline_desugars_to_nested_calls() {
     let module = lower_src(src);
     let (params, body) = lambda_body(&module, 2);
 
-    // Outer call: g(<inner>, b), with the span of the `g(b)` stage.
+    // Thread-LAST: the piped value is APPENDED, so the outer call is
+    // g(b, <inner>) — the explicit stage arg `b` first, the piped `f(a)` last —
+    // with the span of the `g(b)` stage.
     let ExprKind::Call { callee, args } = &body.kind else {
         panic!("expected a call, got {body:?}");
     };
     assert!(matches!(&callee.kind, ExprKind::Global(name) if name == "g"));
     assert_eq!(args.len(), 2);
     assert!(
-        matches!(&args[1].kind, ExprKind::Local { binding, .. } if *binding == params[1].binding)
+        matches!(&args[0].kind, ExprKind::Local { binding, .. } if *binding == params[1].binding)
     );
     assert_eq!(&src[body.span.start..body.span.end], "g(b)");
 
-    // Inner call: f(a), with the span of the `f` stage.
-    let inner = &args[0];
+    // Inner call (the piped, LAST argument): f(a), with the span of the `f` stage.
+    let inner = &args[1];
     let ExprKind::Call { callee, args } = &inner.kind else {
-        panic!("expected the first argument to be a call, got {inner:?}");
+        panic!("expected the last argument to be a call, got {inner:?}");
     };
     assert!(matches!(&callee.kind, ExprKind::Global(name) if name == "f"));
     assert_eq!(args.len(), 1);

--- a/mle/tests/run.rs
+++ b/mle/tests/run.rs
@@ -208,24 +208,24 @@ fn equality_is_structural_but_not_for_functions() {
 fn text_split_join_round_trip() {
     // split then join with the same separator is identity on the wire.
     assert_eq!(
-        main_result("let main = () => Text.join(Text.split(\"a,b,c\", \",\"), \",\")"),
+        main_result("let main = () => Text.join(\",\", Text.split(\",\", \"a,b,c\"))"),
         "\"a,b,c\""
     );
     // splitting an empty string yields one empty field (like F#'s String.Split).
     assert_eq!(
-        main_result("let main = () => Text.split(\"\", \"|\")"),
+        main_result("let main = () => Text.split(\"|\", \"\")"),
         "[\"\"]"
     );
     // multi-char separator (the reason sep is a String, not a char).
     assert_eq!(
-        main_result("let main = () => Text.split(\"a::b::c\", \"::\")"),
+        main_result("let main = () => Text.split(\"::\", \"a::b::c\")"),
         "[\"a\", \"b\", \"c\"]"
     );
 }
 
 #[test]
 fn text_split_rejects_empty_separator() {
-    let (message, _, _) = run_err("let main = () => Text.split(\"abc\", \"\")");
+    let (message, _, _) = run_err("let main = () => Text.split(\"\", \"abc\")");
     assert_eq!(message, "Text.split needs a non-empty separator");
 }
 
@@ -243,7 +243,7 @@ fn text_parse_float_defaults_to_zero_on_garbage() {
 
 #[test]
 fn text_join_rejects_non_strings() {
-    let (message, _, _) = run_err("let main = () => Text.join([1.0], \",\")");
+    let (message, _, _) = run_err("let main = () => Text.join(\",\", [1.0])");
     assert_eq!(message, "Text.join expects strings, got a number");
 }
 
@@ -251,12 +251,12 @@ fn text_join_rejects_non_strings() {
 fn list_grid_tabulates_a_2d_grid() {
     // f(row, col) over a 2x3 grid, both 0-based (the procedural-heightmap form).
     assert_eq!(
-        main_result("let main = () => List.grid(2.0, 3.0, (r, c) => r * 10.0 + c)"),
+        main_result("let main = () => List.grid((r, c) => r * 10.0 + c, 2.0, 3.0)"),
         "[[0, 1, 2], [10, 11, 12]]"
     );
     // A zero dimension yields an empty structure (no closure calls).
     assert_eq!(
-        main_result("let main = () => List.grid(0.0, 3.0, (r, c) => r)"),
+        main_result("let main = () => List.grid((r, c) => r, 0.0, 3.0)"),
         "[]"
     );
 }
@@ -264,8 +264,8 @@ fn list_grid_tabulates_a_2d_grid() {
 #[test]
 fn list_grid_rejects_non_integer_or_negative_dims() {
     for src in [
-        "let main = () => List.grid(2.5, 3.0, (r, c) => r)",
-        "let main = () => List.grid(-1.0, 3.0, (r, c) => r)",
+        "let main = () => List.grid((r, c) => r, 2.5, 3.0)",
+        "let main = () => List.grid((r, c) => r, -1.0, 3.0)",
     ] {
         let (message, _, _) = run_err(src);
         assert!(
@@ -830,10 +830,10 @@ fn debug_log_returns_the_value_unchanged_and_emits_through_the_sink() {
     let sink_buf = Arc::clone(&captured);
     mle::set_trace_sink(Box::new(move |m| sink_buf.lock().unwrap().push(m)));
 
-    // Value-first and pipe-friendly: the piped subject is logged and passed on,
-    // so the arithmetic result is exactly what it would be without the trace.
+    // Label-first and pipe-friendly: the subject (last arg) is logged and passed
+    // on, so the arithmetic result is exactly what it would be without the trace.
     assert_eq!(
-        main_result("let main = () => Debug.log(41.0, \"answer\") + 1.0"),
+        main_result("let main = () => Debug.log(\"answer\", 41.0) + 1.0"),
         "42"
     );
     // Works through a pipeline too (`x |> Debug.log(label)` == the value).
@@ -845,7 +845,7 @@ fn debug_log_returns_the_value_unchanged_and_emits_through_the_sink() {
     assert_eq!(
         main_result(
             "let main = () =>\n\
-             let r = Debug.log({ x: 1.0, y: 2.0 }, \"pt\") in r.x"
+             let r = Debug.log(\"pt\", { x: 1.0, y: 2.0 }) in r.x"
         ),
         "1"
     );
@@ -864,8 +864,8 @@ fn debug_log_returns_the_value_unchanged_and_emits_through_the_sink() {
 // --- Currying / partial application (migration step 1) --------------------
 // The interpreter curries call sites: under-application yields a partial,
 // exact application dispatches as before, and over-application saturates then
-// applies the remainder to the result. Thread-first piping is UNCHANGED (the
-// pipe still PREPENDS its subject) — that flip is a later migration stage.
+// applies the remainder to the result. Piping is thread-LAST (the pipe APPENDS
+// its subject as the final argument — migration step 3).
 
 /// A partial captured in a `let ... in` binding, then saturated.
 #[test]
@@ -927,11 +927,11 @@ fn partial_passed_as_a_value() {
     );
 }
 
-/// Thread-first is PRESERVED: `xs |> List.map(f)` still lowers to the
-/// subject-FIRST call `List.map(xs, f)`, so existing pipes are unaffected by
-/// the currying mechanism.
+/// Thread-LAST: `xs |> List.map(f)` lowers to the subject-LAST call
+/// `List.map(f, xs)` (the piped subject is APPENDED as the final argument), so
+/// a piped form and the equivalent direct call agree.
 #[test]
-fn thread_first_pipe_still_prepends() {
+fn thread_last_pipe_appends() {
     assert_eq!(
         main_result(
             "let double = (x) => x * 2.0\n\
@@ -939,11 +939,11 @@ fn thread_first_pipe_still_prepends() {
         ),
         "[2, 4, 6]"
     );
-    // The un-piped subject-first form is identical.
+    // The un-piped subject-LAST form is identical.
     assert_eq!(
         main_result(
             "let double = (x) => x * 2.0\n\
-             let main = () => List.map([1.0, 2.0, 3.0], double)"
+             let main = () => List.map(double, [1.0, 2.0, 3.0])"
         ),
         "[2, 4, 6]"
     );

--- a/runtime/functor-runtime-common/src/mle_prelude.rs
+++ b/runtime/functor-runtime-common/src/mle_prelude.rs
@@ -22,50 +22,50 @@
 //!    List builtins: List.range(rows) |> List.map((r) => List.range(cols)
 //!    |> List.map((c) => f(r, c))) — F#'s `heightmapFn`, in user space)
 //! Scene.group([scene, …])                                   -> Scene
-//! Scene.color(scene, r, g, b)                               -> Scene
-//! Scene.translate(scene, x, y, z)                           -> Scene
-//! Scene.rotateX/rotateY/rotateZ(scene, angle)               -> Scene
+//! Scene.color(r, g, b, scene)                               -> Scene
+//! Scene.translate(x, y, z, scene)                           -> Scene
+//! Scene.rotateX/rotateY/rotateZ(angle, scene)               -> Scene
 //! Angle.degrees(n) / Angle.radians(n)                       -> Angle
 //!   (rotations and camera angles take Angle VALUES, never bare numbers —
 //!    degree/radian confusion is unrepresentable)
-//! Scene.scale(scene, k)                                     -> Scene
+//! Scene.scale(k, scene)                                     -> Scene
 //! Texture.file(path)                                        -> Texture
 //!   (an image loaded by the shells' asset pipeline, path relative to the
 //!    game dir — F#'s `Texture.file`; declared once and passed as a VALUE,
 //!    the Angle rule applied to assets)
-//! Scene.litTexture(scene, texture)                          -> Scene
+//! Scene.litTexture(texture, scene)                          -> Scene
 //!   (a diffuse-lit textured surface — F#'s `Material.litTexture`)
-//! Scene.emissiveTexture(scene, texture)                     -> Scene
+//! Scene.emissiveTexture(texture, scene)                     -> Scene
 //!   (a self-lit textured surface, fullbright — F#'s `Material.emissiveTexture`)
 //! Camera.lookAt(ex, ey, ez, tx, ty, tz)                     -> Camera
 //!   (up is +Y; vertical fov pinned at 45°, near/far at protocol defaults)
 //! Frame.create(camera, scene)                               -> Frame
 //! RenderTarget.named(id)                                    -> RenderTarget
-//! RenderTarget.sized(target, w, h)                          -> RenderTarget
+//! RenderTarget.sized(w, h, target)                          -> RenderTarget
 //!   (a named offscreen texture, 512x512 unless sized; declare ONCE, use the
 //!    value at both sites — the writer and the reader — so writer/reader id
 //!    typos are unrepresentable, the Angle rule applied to identity)
-//! Frame.withRenderTarget(frame, target, targetFrame)        -> Frame
+//! Frame.withRenderTarget(target, targetFrame, frame)        -> Frame
 //!   (the writer: targetFrame — its own camera/scene/lights — is rendered
 //!    into the target before frame's main pass; a scene sampling its own
 //!    target sees last frame's image)
-//! Scene.screen(scene, target)                               -> Scene
+//! Scene.screen(target, scene)                               -> Scene
 //!   (the reader: an emissive "screen" surface showing the target's texture;
 //!    an id no frame declares shows magenta and warns once)
 //! Fog.linear(near, far, r, g, b) / Fog.exp(density, r, g, b) -> Fog
-//! Frame.withFog(frame, fog)                                  -> Frame
+//! Frame.withFog(fog, frame)                                  -> Frame
 //!   (frame-level distance fog on every forward material, emissive included —
 //!    fog occludes glow; the fog color is also the pass's clear color)
 //! Ui.text(s) / Ui.textColor(r, g, b, s)                     -> View
 //! Ui.column([view, …])                                      -> View
-//! Ui.panel(view, anchor)                                    -> View
+//! Ui.panel(anchor, view)                                    -> View
 //! Ui.topLeft()                                              -> Anchor
 //!   (the optional `ui = (model) => …` hook's tree — hello's HUD shape:
 //!    text lines stacked in a column, pinned to a screen corner. Only the
 //!    corner the port needed exists; the rest arrive with a port that
-//!    needs them. `Ui.panel` takes the view FIRST, so it pipes.)
+//!    needs them. `Ui.panel` takes the view LAST, so it pipes.)
 //! Skybox.files(px, nx, py, ny, pz, nz)                       -> Skybox
-//! Frame.withSkybox(frame, sky)                               -> Frame
+//! Frame.withSkybox(sky, frame)                               -> Frame
 //!   (a cubemap sky drawn behind everything; while the six faces load the
 //!    clear color shows, a failed face disables the sky with one warning;
 //!    fog does not apply to the sky — it IS the horizon)
@@ -85,12 +85,12 @@
 //!
 //! Physics.box(w, h, d) / sphere(r) / capsule(hh, r)         -> Shape
 //! Physics.dynamic/kinematic/fixed(tag, shape)               -> Body
-//! Physics.at/velocity(body, x, y, z)                        -> Body
-//! Physics.mass/friction/restitution(body, n)                -> Body
+//! Physics.at/velocity(x, y, z, body)                        -> Body
+//! Physics.mass/friction/restitution(n, body)                -> Body
 //! Physics.sensor(body)                                      -> Body
 //! Physics.scene(gx, gy, gz, [body, …])                      -> PhysicsScene
 //! Physics.position(tag)                                     -> {x, y, z}
-//! Physics.transformed(scene, tag)                           -> Scene
+//! Physics.transformed(tag, scene)                           -> Scene
 //! Physics.applyImpulse/applyForce/setVelocity/teleport(tag, x, y, z)
 //!                                                           -> Effect
 //! ```
@@ -101,8 +101,8 @@
 //! process, so these are direct reads of live world state — the seam the
 //! dylib producers can't have.
 //!
-//! Scene-consuming functions take the scene FIRST, so they compose with
-//! `|>` (the piped value is prepended — see `mle`'s lowering docs):
+//! Scene-consuming functions take the scene LAST, so they compose with
+//! `|>` (the piped value is appended — thread-last; see `mle`'s lowering docs):
 //! `Scene.cube() |> Scene.color(1.0, 0.0, 0.0) |> Scene.translate(2.0, 0.0, 0.0)`.
 //!
 //! # Transform semantics (deliberate — see the Milestone-0 quirks)
@@ -118,7 +118,7 @@
 //! - `Scene3D::transform` right-multiplies (`self.xform * xform`), making
 //!   `translate(rotateY(x))` apply the translation *first*. Wrapping makes
 //!   each transform a parent node instead, so the outer call is applied last
-//!   in world space: `Scene.translate(Scene.rotateY(x, r), …)` rotates in
+//!   in world space: `s |> Scene.rotateY(r) |> Scene.translate(x, 0, 0)` rotates in
 //!   place, *then* moves — the order the source reads.
 
 use cgmath::Matrix4;
@@ -1018,16 +1018,16 @@ least 2 rows, each an equal-length list of at least 2 numbers",
                 }
                 _ => usage("Scene.group([scene, …])"),
             },
-            // Scene first, so they pipe: `Scene.cube() |> Scene.lit(r, g, b)`.
+            // Scene LAST (subject-last), so they pipe: `Scene.cube() |> Scene.lit(r, g, b)`.
             "Scene.lit" | "Scene.emissive" => match args.as_slice() {
-                [scene, r, g, b] => {
+                [r, g, b, scene] => {
                     let (r, g, b) = (
                         num(r, span)? as f32,
                         num(g, span)? as f32,
                         num(b, span)? as f32,
                     );
                     let Some(scene) = scene_of(scene) else {
-                        return usage(&format!("{path}(scene, r, g, b)"));
+                        return usage(&format!("{path}(r, g, b, scene)"));
                     };
                     let material = if path == "Scene.lit" {
                         MaterialDescription::lit(r, g, b, 1.0)
@@ -1039,7 +1039,7 @@ least 2 rows, each an equal-length list of at least 2 numbers",
                         xform: Matrix4::from_scale(1.0),
                     })
                 }
-                _ => usage(&format!("{path}(scene, r, g, b)")),
+                _ => usage(&format!("{path}(r, g, b, scene)")),
             },
             // An image texture by file path (relative to the game dir), the
             // MLE face of F#'s `Texture.file`. Loading is the shells' asset
@@ -1054,15 +1054,15 @@ least 2 rows, each an equal-length list of at least 2 numbers",
 the game dir",
                 ),
             },
-            // Scene first, so they pipe:
+            // Scene LAST (subject-last), so they pipe:
             // `Scene.plane() |> Scene.litTexture(Texture.file("dirt.png"))`.
             // The F# pair `Material.litTexture` / `Material.emissiveTexture`:
             // lit is shaded by the frame's lights (white albedo tint),
             // emissive renders fullbright (neon signage).
             "Scene.litTexture" | "Scene.emissiveTexture" => match args.as_slice() {
-                [scene, texture] => {
+                [texture, scene] => {
                     let Some(scene) = scene_of(scene) else {
-                        return usage(&format!("{path}(scene, texture)"));
+                        return usage(&format!("{path}(texture, scene)"));
                     };
                     let texture = texture_of(texture, path, span)?;
                     let material = if path == "Scene.litTexture" {
@@ -1075,16 +1075,16 @@ the game dir",
                         xform: Matrix4::from_scale(1.0),
                     })
                 }
-                _ => usage(&format!("{path}(scene, texture)")),
+                _ => usage(&format!("{path}(texture, scene)")),
             },
             // Lit material with a tangent-space normal map perturbing the
             // surface normal (F#'s `Material.litNormalMapped`), so the lights
             // and specular play across the bumps. `(r, g, b)` is the albedo
             // tint; the normal map is a Texture value (alpha fixed at 1.0).
             "Scene.litNormalMapped" => match args.as_slice() {
-                [scene, r, g, b, normal] => {
+                [r, g, b, normal, scene] => {
                     let Some(scene) = scene_of(scene) else {
-                        return usage("Scene.litNormalMapped(scene, r, g, b, normalMap)");
+                        return usage("Scene.litNormalMapped(r, g, b, normalMap, scene)");
                     };
                     let normal = texture_of(normal, path, span)?;
                     scene_value(Scene3D {
@@ -1101,14 +1101,14 @@ the game dir",
                         xform: Matrix4::from_scale(1.0),
                     })
                 }
-                _ => usage("Scene.litNormalMapped(scene, r, g, b, normalMap)"),
+                _ => usage("Scene.litNormalMapped(r, g, b, normalMap, scene)"),
             },
-            // Scene first, so it pipes: `Scene.cube() |> Scene.color(r, g, b)`.
+            // Scene LAST (subject-last), so it pipes: `Scene.cube() |> Scene.color(r, g, b)`.
             "Scene.color" => match args.as_slice() {
-                [scene, r, g, b] => {
+                [r, g, b, scene] => {
                     let (r, g, b) = (num(r, span)?, num(g, span)?, num(b, span)?);
                     let Some(scene) = scene_of(scene) else {
-                        return usage("Scene.color(scene, r, g, b)");
+                        return usage("Scene.color(r, g, b, scene)");
                     };
                     scene_value(Scene3D {
                         obj: SceneObject::Material(
@@ -1118,18 +1118,18 @@ the game dir",
                         xform: Matrix4::from_scale(1.0),
                     })
                 }
-                _ => usage("Scene.color(scene, r, g, b)"),
+                _ => usage("Scene.color(r, g, b, scene)"),
             },
             "Scene.translate" => match args.as_slice() {
-                [scene, x, y, z] => {
+                [x, y, z, scene] => {
                     let xform = Matrix4::from_translation(cgmath::vec3(
                         num(x, span)? as f32,
                         num(y, span)? as f32,
                         num(z, span)? as f32,
                     ));
-                    wrap_transform(scene, xform, "Scene.translate(scene, x, y, z)", span)
+                    wrap_transform(scene, xform, "Scene.translate(x, y, z, scene)", span)
                 }
-                _ => usage("Scene.translate(scene, x, y, z)"),
+                _ => usage("Scene.translate(x, y, z, scene)"),
             },
             "Angle.degrees" => match args.as_slice() {
                 [n] => Ok(host(MleAngle(Angle::from_degrees(num(n, span)? as f32)))),
@@ -1140,37 +1140,37 @@ the game dir",
                 _ => usage("Angle.radians(n)"),
             },
             "Scene.rotateX" | "Scene.rotateY" | "Scene.rotateZ" => match args.as_slice() {
-                [scene, angle] => {
+                [angle, scene] => {
                     let angle: cgmath::Rad<f32> = angle_of(angle, path, span)?.into();
                     let xform = match path {
                         "Scene.rotateX" => Matrix4::from_angle_x(angle),
                         "Scene.rotateY" => Matrix4::from_angle_y(angle),
                         _ => Matrix4::from_angle_z(angle),
                     };
-                    wrap_transform(scene, xform, &format!("{path}(scene, angle)"), span)
+                    wrap_transform(scene, xform, &format!("{path}(angle, scene)"), span)
                 }
-                _ => return usage(&format!("{path}(scene, angle)")),
+                _ => return usage(&format!("{path}(angle, scene)")),
             },
             "Scene.scale" => match args.as_slice() {
-                [scene, k] => {
+                [k, scene] => {
                     let xform = Matrix4::from_scale(num(k, span)? as f32);
-                    wrap_transform(scene, xform, "Scene.scale(scene, k)", span)
+                    wrap_transform(scene, xform, "Scene.scale(k, scene)", span)
                 }
-                _ => usage("Scene.scale(scene, k)"),
+                _ => usage("Scene.scale(k, scene)"),
             },
             // Non-uniform scale (the F# `Transform.scaleX/Y/Z`): stretch each
             // axis independently — e.g. a wide, short backdrop quad, or a
             // heightmap sized in XZ without inflating its Y heights.
             "Scene.scaleXYZ" => match args.as_slice() {
-                [scene, x, y, z] => {
+                [x, y, z, scene] => {
                     let xform = Matrix4::from_nonuniform_scale(
                         num(x, span)? as f32,
                         num(y, span)? as f32,
                         num(z, span)? as f32,
                     );
-                    wrap_transform(scene, xform, "Scene.scaleXYZ(scene, x, y, z)", span)
+                    wrap_transform(scene, xform, "Scene.scaleXYZ(x, y, z, scene)", span)
                 }
-                _ => usage("Scene.scaleXYZ(scene, x, y, z)"),
+                _ => usage("Scene.scaleXYZ(x, y, z, scene)"),
             },
             "Camera.lookAt" => match args.as_slice() {
                 [ex, ey, ez, tx, ty, tz] => Ok(host(MleCamera(Camera::look_at(
@@ -1345,10 +1345,10 @@ the game dir",
                 },
                 _ => usage(&format!("{path}(tag, shape)")),
             },
-            // Body first, so they pipe:
+            // Body LAST (subject-last), so they pipe:
             // `Physics.dynamic("crate", Physics.box(1.0, 1.0, 1.0)) |> Physics.at(0.0, 5.0, 0.0)`.
             "Physics.at" | "Physics.velocity" => match args.as_slice() {
-                [body, x, y, z] => match body_of(body) {
+                [x, y, z, body] => match body_of(body) {
                     Some(inner) => {
                         let v = [
                             num(x, span)? as f32,
@@ -1361,12 +1361,12 @@ the game dir",
                             inner.clone().with_velocity(v)
                         })))
                     }
-                    None => usage(&format!("{path}(body, x, y, z)")),
+                    None => usage(&format!("{path}(x, y, z, body)")),
                 },
-                _ => usage(&format!("{path}(body, x, y, z)")),
+                _ => usage(&format!("{path}(x, y, z, body)")),
             },
             "Physics.mass" | "Physics.friction" | "Physics.restitution" => match args.as_slice() {
-                [body, n] => match body_of(body) {
+                [n, body] => match body_of(body) {
                     Some(inner) => {
                         let n = match path {
                             "Physics.mass" => positive_num(n, span, "Physics.mass")?,
@@ -1378,9 +1378,9 @@ the game dir",
                             _ => inner.clone().with_restitution(n),
                         })))
                     }
-                    None => usage(&format!("{path}(body, n)")),
+                    None => usage(&format!("{path}(n, body)")),
                 },
-                _ => usage(&format!("{path}(body, n)")),
+                _ => usage(&format!("{path}(n, body)")),
             },
             "Physics.sensor" => match args.as_slice() {
                 [body] => match body_of(body) {
@@ -1432,7 +1432,7 @@ the game dir",
                 },
                 _ => usage("Physics.position(tag)"),
             },
-            // Scene first, so it pipes: the way MLE draws a physics body —
+            // Scene LAST (subject-last), so it pipes: the way MLE draws a physics body —
             // `Scene.cube() |> Scene.lit(…) |> Physics.transformed("crate-1")`
             // places the visual at the body's live pose (position + rotation).
             // Command EFFECTS (docs/physics.md Phase 3): fire-and-forget,
@@ -1680,13 +1680,13 @@ the Net.HttpResponse, got {}",
                 }
                 _ => usage("AudioSource.at(key, sound, x, y, z)"),
             },
-            // Source-first so it pipes: `AudioSource.ambient(…) |> AudioSource.gain(0.35)`.
+            // Source LAST (subject-last) so it pipes: `AudioSource.ambient(…) |> AudioSource.gain(0.35)`.
             "AudioSource.gain" => match args.as_slice() {
-                [source, g] => match audio_source_of(source) {
+                [g, source] => match audio_source_of(source) {
                     Some(src) => Ok(host(MleAudioSource(src.clone().with_gain(num(g, span)? as f32)))),
-                    None => usage("AudioSource.gain(source, gain)"),
+                    None => usage("AudioSource.gain(gain, source)"),
                 },
-                _ => usage("AudioSource.gain(source, gain)"),
+                _ => usage("AudioSource.gain(gain, source)"),
             },
             "AudioScene.create" => match args.as_slice() {
                 [Value::List(items)] => {
@@ -1711,9 +1711,9 @@ the Net.HttpResponse, got {}",
                 _ => usage("AudioScene.empty()"),
             },
             "Physics.transformed" => match args.as_slice() {
-                [scene, Value::String(tag)] => {
+                [Value::String(tag), scene] => {
                     let Some(inner) = scene_of(scene) else {
-                        return usage("Physics.transformed(scene, tag)");
+                        return usage("Physics.transformed(tag, scene)");
                     };
                     match live_transform(tag) {
                         Some((pos, rot)) => {
@@ -1727,7 +1727,7 @@ the Net.HttpResponse, got {}",
                         None => err(no_body(tag)),
                     }
                 }
-                _ => usage("Physics.transformed(scene, tag)"),
+                _ => usage("Physics.transformed(tag, scene)"),
             },
             "RenderTarget.named" => match args.as_slice() {
                 [Value::String(name)] if !name.is_empty() => Ok(host(MleRenderTarget(
@@ -1738,10 +1738,10 @@ the Net.HttpResponse, got {}",
 piped through RenderTarget.sized",
                 ),
             },
-            // Target first, so it pipes:
+            // Target LAST (subject-last), so it pipes:
             // `RenderTarget.named("x") |> RenderTarget.sized(256.0, 256.0)`.
             "RenderTarget.sized" => match args.as_slice() {
-                [target, w, h] => {
+                [w, h, target] => {
                     let inner = target_of(target, "RenderTarget.sized", span)?;
                     let w = positive_num(w, span, "RenderTarget.sized width")?;
                     let h = positive_num(h, span, "RenderTarget.sized height")?;
@@ -1749,17 +1749,17 @@ piped through RenderTarget.sized",
                         inner.clone().sized(w as f32, h as f32),
                     )))
                 }
-                _ => usage("RenderTarget.sized(target, width, height)"),
+                _ => usage("RenderTarget.sized(width, height, target)"),
             },
-            // Frame first, so it pipes:
+            // Frame LAST (subject-last), so it pipes:
             // `Frame.createLit(…) |> Frame.withRenderTarget(feed, feedFrame)`.
             "Frame.withRenderTarget" => match args.as_slice() {
-                [frame, target, target_frame] => {
+                [target, target_frame, frame] => {
                     let (Some(outer), Some(inner)) =
                         (frame_value(frame), frame_value(target_frame))
                     else {
                         return usage(
-                            "Frame.withRenderTarget(frame, target, targetFrame) — targetFrame \
+                            "Frame.withRenderTarget(target, targetFrame, frame) — targetFrame \
 is a Frame.create/createLit(…) rendered into the target each frame, before \
 frame's main pass",
                         );
@@ -1771,7 +1771,7 @@ frame's main pass",
                         inner.clone(),
                     ))))
                 }
-                _ => usage("Frame.withRenderTarget(frame, target, targetFrame)"),
+                _ => usage("Frame.withRenderTarget(target, targetFrame, frame)"),
             },
             "Fog.linear" => match args.as_slice() {
                 [near, far, r, g, b] => {
@@ -1801,16 +1801,16 @@ frame's main pass",
                 )))),
                 _ => usage("Fog.exp(density, r, g, b)"),
             },
-            // Frame first, so it pipes: `Frame.createLit(…) |> Frame.withFog(fog)`.
+            // Frame LAST (subject-last), so it pipes: `Frame.createLit(…) |> Frame.withFog(fog)`.
             "Frame.withFog" => match args.as_slice() {
-                [frame, fog] => {
+                [fog, frame] => {
                     let Some(inner) = frame_value(frame) else {
-                        return usage("Frame.withFog(frame, fog)");
+                        return usage("Frame.withFog(fog, frame)");
                     };
                     let fog = fog_of(fog, "Frame.withFog", span)?;
                     Ok(host(MleFrame(Frame::with_fog(inner.clone(), fog.clone()))))
                 }
-                _ => usage("Frame.withFog(frame, fog)"),
+                _ => usage("Frame.withFog(fog, frame)"),
             },
             "Skybox.files" => match args.as_slice() {
                 [Value::String(px), Value::String(nx), Value::String(py), Value::String(ny), Value::String(pz), Value::String(nz)]
@@ -1830,24 +1830,24 @@ frame's main pass",
 paths (+X, -X, +Y, -Y, +Z, -Z)",
                 ),
             },
-            // Frame first, so it pipes: `frame |> Frame.withSkybox(sky)`.
+            // Frame LAST (subject-last), so it pipes: `frame |> Frame.withSkybox(sky)`.
             "Frame.withSkybox" => match args.as_slice() {
-                [frame, sky] => {
+                [sky, frame] => {
                     let Some(inner) = frame_value(frame) else {
-                        return usage("Frame.withSkybox(frame, skybox)");
+                        return usage("Frame.withSkybox(skybox, frame)");
                     };
                     let sky = skybox_of(sky, "Frame.withSkybox", span)?;
                     Ok(host(MleFrame(Frame::with_skybox(inner.clone(), sky.clone()))))
                 }
-                _ => usage("Frame.withSkybox(frame, skybox)"),
+                _ => usage("Frame.withSkybox(skybox, frame)"),
             },
-            // Scene first, so it pipes: `Scene.quad() |> Scene.screen(feed)` —
+            // Scene LAST (subject-last), so it pipes: `Scene.quad() |> Scene.screen(feed)` —
             // an emissive (fullbright, screens glow) surface showing the
             // target's texture. A target no frame declares shows magenta.
             "Scene.screen" => match args.as_slice() {
-                [scene, target] => {
+                [target, scene] => {
                     let Some(scene) = scene_of(scene) else {
-                        return usage("Scene.screen(scene, target)");
+                        return usage("Scene.screen(target, scene)");
                     };
                     let target = target_of(target, "Scene.screen", span)?;
                     scene_value(Scene3D {
@@ -1860,7 +1860,7 @@ paths (+X, -X, +Y, -Y, +Z, -Z)",
                         xform: Matrix4::from_scale(1.0),
                     })
                 }
-                _ => usage("Scene.screen(scene, target)"),
+                _ => usage("Scene.screen(target, scene)"),
             },
             "Frame.create" => match args.as_slice() {
                 [camera, scene] => {
@@ -1916,14 +1916,14 @@ paths (+X, -X, +Y, -Y, +Z, -Z)",
                 }
                 _ => usage("Ui.column([view, …])"),
             },
-            // View first, so it pipes:
+            // View LAST (subject-last), so it pipes:
             // `Ui.column([…]) |> Ui.panel(Ui.topLeft())`. Only the corner
             // hello's HUD needed exists; the other three arrive with a port
             // that needs them.
             "Ui.panel" => match args.as_slice() {
-                [view, anchor] => {
+                [anchor, view] => {
                     let Some(view) = view_value(view) else {
-                        return usage("Ui.panel(view, anchor)");
+                        return usage("Ui.panel(anchor, view)");
                     };
                     let anchor = ui_anchor_of(anchor, span)?;
                     Ok(host(MleView(View::Panel {
@@ -1931,7 +1931,7 @@ paths (+X, -X, +Y, -Y, +Z, -Z)",
                         child: Box::new(view.clone()),
                     })))
                 }
-                _ => usage("Ui.panel(view, anchor)"),
+                _ => usage("Ui.panel(anchor, view)"),
             },
             "Ui.topLeft" => match args.as_slice() {
                 [] => Ok(host(MleUiAnchor(ui::Anchor::TopLeft))),
@@ -3121,7 +3121,7 @@ mod tests {
             "let main = () =>\n\
              Frame.create(\n\
                Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0),\n\
-               Scene.translate(Scene.rotateY(Scene.cube(), Angle.degrees(90.0)), 3.0, 0.0, 0.0))",
+               Scene.cube() |> Scene.rotateY(Angle.degrees(90.0)) |> Scene.translate(3.0, 0.0, 0.0))",
         );
         // World composition for nested Groups is parent-first:
         // world = T * R, so a cube corner rotates about the cube's own origin
@@ -3293,7 +3293,7 @@ the game dir"
     #[test]
     fn prelude_errors_are_spanned() {
         let module = mle::lower(
-            mle::parse("let main = () => Scene.color(Scene.cube(), 1.0, \"x\", 0.0)").unwrap(),
+            mle::parse("let main = () => Scene.color(1.0, \"x\", 0.0, Scene.cube())").unwrap(),
         )
         .unwrap();
         let failure = mle::run_with_host(&module, Tracing::Off, &mut FunctorHost)
@@ -3750,7 +3750,7 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
     #[test]
     fn non_finite_numbers_are_rejected_at_the_boundary() {
         let module = mle::lower(
-            mle::parse("let main = () => Scene.translate(Scene.cube(), 1.0 / 0.0, 0.0, 0.0)")
+            mle::parse("let main = () => Scene.translate(1.0 / 0.0, 0.0, 0.0, Scene.cube())")
                 .unwrap(),
         )
         .unwrap();
@@ -5181,7 +5181,7 @@ with Ui.topLeft()"
         // Debug.log in tick (the producer's reload path rebuilds the Session).
         let v2 = load(
             "let init = 0.0\n\
-             let tick = (m, dt, tts) => Debug.log(m + 1.0, \"tick m\")\n\
+             let tick = (m, dt, tts) => Debug.log(\"tick m\", m + 1.0)\n\
              let draw = (m, tts) => m",
         );
         // The trace fires on the next frame — model unaffected (returns m + 1).


### PR DESCRIPTION
The **flag-day flip** of the MLE currying migration (design record: `docs/spikes/mle-currying.md`). Step 1 (call-site currying + checker, #264) and the bench framework (#263) are already on `main`; this is the behavior-changing, atomic step. **Pipes and signatures flip together**, so existing piped code is untouched.

## The flip

- **`mle/src/lower.rs`** — `|>` now **APPENDS** the piped value (thread-last): `x |> g(a)` lowers directly to the saturated `g(a, x)`, never a partial, so scene/list pipes stay allocation-free.
- **`mle/src/eval.rs` + `mle/src/types.rs`** — the subject-first mle-crate builtins flip to **subject-LAST** with matching type signatures + arities: `List.map(fn, list)`, `List.filter(fn, list)`, `List.fold(fn, init, list)`, `List.grid(fn, rows, cols)`, `Text.split(sep, s)`, `Text.join(sep, list)`.
- **`Debug.log` label-first** — flips value-first → `Debug.log(label, value)` : `(String, 'a) => 'a`, so it reads Elm-style standalone (`Debug.log("hp", m.hp)`) **and** threads in a pipe (`m.hp |> Debug.log("hp")`).
- **`runtime/functor-runtime-common/src/mle_prelude.rs`** — all **24** subject-first host arms flip subject → last (pattern, every `usage()` string, and the module doc block): `Scene.color/lit/emissive/litTexture/emissiveTexture/litNormalMapped/translate/rotateX/Y/Z/scale/scaleXYZ/screen`, `Physics.at/velocity/mass/friction/restitution/transformed`, `Frame.withFog/withSkybox/withRenderTarget`, `RenderTarget.sized`, `AudioSource.gain`, and `Ui.panel` (added beyond the original 23 — it postdates the spike). `Physics.sensor` / `Light.castShadows` are 1-arg (no flip).
- **Examples / bench corpus** — the ~dozen direct (non-piped) call sites flip to subject-last; **piped call sites auto-adapt untouched**.
- **Docs** — the `mle-language` skill, `docs/mle.md`, and `CLAUDE.md` updated (pipelines *append* / subject-last / label-first `Debug.log`).

## Verification

**THE guardrail — examples render BYTE-IDENTICAL.** Fixed-time (`--fixed-time 2.5`) PNG capture of the pipe-heavy examples on `origin/main` vs this branch, `cmp`'d (separate baseline worktree + target dir):

```
lighting:   BYTE-IDENTICAL (397024 bytes)
synthwave:  BYTE-IDENTICAL (221041 bytes)
primitives: BYTE-IDENTICAL (350895 bytes)
physics:    BYTE-IDENTICAL (137275 bytes)
```

The flip is observably invisible to existing piped code — pipes deliver the subject to the same place.

**`mle bench` A/B** (release, same machine; time/op, branch vs main):

| benchmark | branch | main | Δ |
| --- | --- | --- | --- |
| call_saturated | 329.5 ms | 326.2 ms | +1.0% |
| call_piped | 321.6 ms | 316.5 ms | +1.6% |
| arith_loop | 168.4 ms | 166.8 ms | +1.0% |
| fold_floor | 130.2 ms | 129.7 ms | +0.4% |
| list_map | 37.4 ms | 37.2 ms | +0.3% |

All within measurement spread (~1–3%) — **at parity**. The hot path (saturated + piped calls) costs nothing.

**Goldens** — 6 `mle` snapshots regenerated and each reviewed to confirm the expected flip (piped subject moved to the END, explicit args first): `functions.ir`, `pure_pipeline.ir`, `pure_pipeline.trace`, `shapes.ir`, plus `strings.ast`/`strings.ir` (flipped source).

**Tests** — `RUST_MIN_STACK=33554432 cargo test -p mle` and `cargo test -p functor_runtime_common` green (updated the assertions that encoded old semantics). Live: `list |> List.map(f)` == `List.map(f, list)`, direct `List.map(f, list)` works, `x |> Debug.log("l")` logs `l: x`. `cargo build --bin functor` clean.

This completes the ergonomic goal: label-first threadable `Debug.log` and `list |> List.map(f)`. Since it alters visible rendering-config *semantics* but is render-identical, the `cmp` proof stands in for GIFs.

## Review

`/xreview`: Codex was unavailable (usage limit), so **Claude-only** — a thorough adversarial pass verified all builtins agree three ways (eval/types/arity), all 24 prelude arms flipped consistently (pattern ↔ usage ↔ doc block, none missed), and no example/bench/test left with a wrong-order direct call. One Medium finding (7 stale "X first" leading comments contradicting their now-subject-last arms) was fixed. No Critical/High.

🤖 Generated with [Claude Code](https://claude.com/claude-code)