### PR TITLE
feat(mle): partial-application-aware diagnostic — recover the forgotten-argument error

### DIFF
--- a/mle/src/types.rs
+++ b/mle/src/types.rs
@@ -464,6 +464,9 @@ fn check_impl(
         locals: HashMap::new(),
         diags: Vec::new(),
         expr_types: HashMap::new(),
+        partials: HashMap::new(),
+        def_param_names: HashMap::new(),
+        ctor_param_names: HashMap::new(),
     };
 
     // Record type names first (nominal references may be forward), then
@@ -518,6 +521,12 @@ fn check_impl(
                         variant.name.clone(),
                         (decl.name.clone(), decl.params.len(), fields),
                     );
+                    // Field names, so a partially-applied constructor can name
+                    // the arguments it is still missing.
+                    checker.ctor_param_names.insert(
+                        variant.name.clone(),
+                        variant.fields.iter().map(|f| f.name.clone()).collect(),
+                    );
                 }
             }
         }
@@ -534,6 +543,12 @@ fn check_impl(
         checker.annot_vars.clear();
         let ty = match &def.value.kind {
             ExprKind::Lambda { params, ret, .. } => {
+                // Param names, so a partial application of this def can name
+                // the arguments it is still missing.
+                checker.def_param_names.insert(
+                    def.name.clone(),
+                    params.iter().map(|p| p.name.clone()).collect(),
+                );
                 let params = params
                     .iter()
                     .map(|p| checker.resolve_annotation(p.ty.as_ref(), false))
@@ -746,6 +761,33 @@ struct Checker<'s> {
     /// Best-known type per expression, recorded by [`Checker::infer`]. The
     /// loud pass runs last, so its (better-informed) types win.
     expr_types: HashMap<u32, Type>,
+    /// Provenance for under-applied calls (partial applications), keyed by
+    /// the call expression's id — the seam for the forgotten-argument
+    /// diagnostic (see [`Checker::report_forgotten_arg`]). Purely a
+    /// diagnostic side channel: never read by unification or generalization,
+    /// so HM inference is untouched.
+    partials: HashMap<u32, PartialApp>,
+    /// Top-level def name → its lambda parameter names, in order — so a
+    /// partial application can NAME the arguments it is missing.
+    def_param_names: HashMap<String, Vec<String>>,
+    /// Constructor name → its field names, in order (same purpose).
+    ctor_param_names: HashMap<String, Vec<String>>,
+}
+
+/// An under-applied call's provenance: enough to say `` `shift` is applied to
+/// 1 of 2 arguments here — missing `dy: Float` `` when that partial later
+/// flows into a position wanting a concrete non-function value. The
+/// OCaml-Warning-5 / F#-FS0020 recovery for currying's "a forgotten argument
+/// is now a legal partial" regression.
+struct PartialApp {
+    /// The callee as the user wrote it (`callee_label`).
+    label: String,
+    /// How many arguments were supplied, and how many the callee takes.
+    applied: usize,
+    total: usize,
+    /// The not-yet-supplied parameters: name (when the callee's params are
+    /// named — user defs and constructors) plus type.
+    missing: Vec<(Option<String>, Type)>,
 }
 
 impl Checker<'_> {
@@ -1172,9 +1214,76 @@ the type: `type Name<{name}> = …`"
             _ => {
                 let got = self.infer(expr);
                 let expected = self.zonk(expected);
+                // A partial application flowing into a concrete non-function
+                // position is a forgotten argument — name it, instead of the
+                // generic "expected X, got function" mismatch.
+                if self.report_forgotten_arg(expr, &got, &expected) {
+                    return;
+                }
                 self.unify(&got, &expected, expr.span, what);
             }
         }
+    }
+
+    /// The parameter names of `callee`, when it names a def or a constructor
+    /// (a partial application uses them to name its missing arguments). A
+    /// builtin or a local function value has no names here, so the diagnostic
+    /// falls back to the parameter types alone.
+    fn callee_param_names(&self, callee: &Expr) -> Option<Vec<String>> {
+        match &callee.kind {
+            ExprKind::Global(name) => self.def_param_names.get(name).cloned(),
+            ExprKind::Ctor { name, .. } => self.ctor_param_names.get(name).cloned(),
+            _ => None,
+        }
+    }
+
+    /// If `expr` is an under-applied call whose partial-function result is
+    /// flowing into a **concrete non-function** expectation, emit a diagnostic
+    /// naming the forgotten argument(s) and return `true` (the caller then
+    /// skips the generic "expected X, got function" mismatch). This recovers
+    /// the crisp forgotten-argument error currying traded away (OCaml
+    /// Warning-5 / F# FS0020), made precise by the checker's knowledge of the
+    /// callee's full arity, param names, and types.
+    ///
+    /// The non-function guard is essential: a partial passed where a FUNCTION
+    /// is wanted (`xs |> List.map(f)` as a value, `let inc = add(1.0)` used as
+    /// a callback) or into open inference (an unsolved `Var`/`Unknown`) is a
+    /// legitimate partial and stays silent.
+    fn report_forgotten_arg(&mut self, expr: &Expr, got: &Type, expected: &Type) -> bool {
+        // The value must really be a function (i.e. a partial)…
+        if !matches!(self.zonk(got), Type::Fn(..)) {
+            return false;
+        }
+        // …meeting a CONCRETE non-function expectation.
+        match expected {
+            Type::Var(_) | Type::Unknown | Type::Fn(..) => return false,
+            _ => {}
+        }
+        // …and this exact call site is one we recorded as under-applied.
+        let Some(info) = self.partials.get(&expr.id.raw()) else {
+            return false;
+        };
+        let (label, applied, total) = (info.label.clone(), info.applied, info.total);
+        let missing_params = info.missing.clone();
+        let missing = missing_params
+            .iter()
+            .map(|(name, ty)| {
+                let ty = self.zonk(ty);
+                match name {
+                    Some(n) => format!("`{n}: {ty}`"),
+                    None => format!("`{ty}`"),
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        self.diag(
+            expr.span,
+            format!(
+                "`{label}` is applied to {applied} of {total} arguments here — \
+missing {missing}. Did you forget an argument?"
+            ),
+        );
+        true
     }
 
     /// Check a record literal against declared record type `name`: every
@@ -1470,11 +1579,34 @@ the type: `type Name<{name}> = …`"
                         match args.len().cmp(&params.len()) {
                             std::cmp::Ordering::Equal => *ret,
                             // Under-applied: the value is a function of the
-                            // params not yet supplied. (A future diagnostic can
-                            // flag a partial that reaches a non-function
-                            // position; today it surfaces at the eventual use
-                            // site as a type mismatch.)
+                            // params not yet supplied. Record its provenance so
+                            // that IF this partial later flows into a concrete
+                            // non-function position, the mismatch can name the
+                            // forgotten argument(s) instead of a generic
+                            // "expected X, got function" (see
+                            // `report_forgotten_arg`).
                             std::cmp::Ordering::Less => {
+                                let names = self.callee_param_names(callee);
+                                let missing = params[args.len()..]
+                                    .iter()
+                                    .enumerate()
+                                    .map(|(i, ty)| {
+                                        let name = names
+                                            .as_ref()
+                                            .and_then(|ns| ns.get(args.len() + i))
+                                            .cloned();
+                                        (name, ty.clone())
+                                    })
+                                    .collect();
+                                self.partials.insert(
+                                    expr.id.raw(),
+                                    PartialApp {
+                                        label: callee_label(callee),
+                                        applied: args.len(),
+                                        total: params.len(),
+                                        missing,
+                                    },
+                                );
                                 Type::Fn(params[args.len()..].to_vec(), ret)
                             }
                             // Over-applied: saturate, then apply the surplus

--- a/mle/tests/check.rs
+++ b/mle/tests/check.rs
@@ -186,10 +186,10 @@ fn error_field_access_on_a_float() {
 }
 
 // Currying: under-application is a legal partial application, not an arity
-// error — `f(1.0)` on a 2-arg `f` yields a `(Float) => Float`. (The crisp
-// "takes N argument(s)" error is the accepted quality regression of the
-// currying migration; a dedicated "partial reaches a non-function position"
-// diagnostic is planned to recover it.)
+// error — `f(1.0)` on a 2-arg `f` yields a `(Float) => Float`. Here the
+// partial is the (unannotated) return value, a genuinely function-typed
+// position, so it stays clean — the forgotten-argument diagnostic fires only
+// when a partial reaches a NON-function position (see the tests below).
 #[test]
 fn partial_application_of_user_function_is_accepted() {
     assert_clean(
@@ -256,6 +256,95 @@ fn over_application_checks_surplus_against_result() {
          let g = () => f(1.0, 2.0)",
     );
     assert_eq!(message, "cannot call Float, not a function");
+}
+
+// Currying's error-quality recovery (OCaml Warning-5 / F# FS0020): a partial
+// application flowing into a CONCRETE non-function position is a forgotten
+// argument. The diagnostic names the missing parameter(s) — precise because
+// the checker knows the callee's full arity, param names, and types.
+#[test]
+fn forgotten_argument_of_user_function_into_argument_position() {
+    let (message, line, col) = single_diag(
+        "let add = (a: Float, b: Float): Float => a + b\n\
+         let use = (x: Float): Float => x\n\
+         let main = () => use(add(1.0))",
+    );
+    assert_eq!(
+        message,
+        "`add` is applied to 1 of 2 arguments here — missing `b: Float`. \
+         Did you forget an argument?"
+    );
+    // Points at the under-applied call, not the outer call.
+    assert_eq!((line, col), (3, 22));
+}
+
+// The same recovery in a return-annotation position (a concrete non-function
+// expectation), naming the second parameter as the one forgotten.
+#[test]
+fn forgotten_argument_into_return_annotation() {
+    let (message, _, _) = single_diag(
+        "let shift = (dx: Float, dy: Float): Float => dx + dy\n\
+         let go = (): Float => shift(1.0)",
+    );
+    assert_eq!(
+        message,
+        "`shift` is applied to 1 of 2 arguments here — missing `dy: Float`. \
+         Did you forget an argument?"
+    );
+}
+
+// A builtin has no param names in its signature, so the diagnostic falls back
+// to the missing parameter's TYPE alone (still names the arity gap).
+#[test]
+fn forgotten_argument_of_builtin() {
+    let (message, _, _) = single_diag(
+        "let use = (x: String): String => x\n\
+         let main = () => use(Text.concat(\"a\"))",
+    );
+    assert_eq!(
+        message,
+        "`Text.concat` is applied to 1 of 2 arguments here — missing `String`. \
+         Did you forget an argument?"
+    );
+}
+
+// A constructor carries its field names, so the diagnostic names the missing
+// field — and the enriched message REPLACES the generic mismatch (one diag).
+#[test]
+fn forgotten_argument_of_constructor() {
+    let (message, _, _) = single_diag(
+        "type Pair = | MkPair(a: Float, b: Float)\n\
+         let use = (x: Float): Float => x\n\
+         let main = () => use(MkPair(1.0))",
+    );
+    assert_eq!(
+        message,
+        "`MkPair` is applied to 1 of 2 arguments here — missing `b: Float`. \
+         Did you forget an argument?"
+    );
+}
+
+// The discriminator must NOT fire on legitimate partials — a partial that
+// reaches a FUNCTION-typed position is intended. An inline partial passed as
+// `List.map`'s callback stays clean.
+#[test]
+fn partial_into_function_position_is_clean() {
+    assert_clean(
+        "let add = (a: Float, b: Float): Float => a + b\n\
+         let go = (xs: List<Float>): List<Float> => List.map(add(1.0), xs)",
+    );
+}
+
+// …and a partial bound to a let, then used as a callback, is also clean (the
+// binding value is inferred, never checked against a non-function expectation).
+#[test]
+fn bound_partial_used_as_callback_is_clean() {
+    assert_clean(
+        "let add = (a: Float, b: Float): Float => a + b\n\
+         let go = (xs: List<Float>): List<Float> =>\n\
+         let inc = add(1.0) in\n\
+         xs |> List.map(inc)",
+    );
 }
 
 // A builtin's known callback shape checks: List.filter's predicate must


### PR DESCRIPTION
## What & why

Fast-follow for the currying migration (#264 call-site currying, #265 thread-last flip). Since currying, **under-applying a function is a legal partial application**, so a genuinely forgotten argument no longer produces a crisp arity error — it surfaces later as a generic `expected X, got function` type mismatch, or **silently** if the partial is dropped. That was the accepted error-quality regression called out in `docs/spikes/mle-currying.md` §4.

This recovers it with the **OCaml Warning-5 / F# FS0020** technique, made *more precise* because MLE's checker knows every function's full arity, param names, and types: when a **partial application** (an under-applied call whose result is a `Type::Fn`) flows into a position expecting a **concrete non-function** type, the checker emits a targeted diagnostic that **names the missing argument(s)**:

```
`shift` is applied to 1 of 2 arguments here — missing `dy: Float`. Did you forget an argument?
```

## The discriminator (why it can't false-positive on real partials)

It fires only when **all three** hold: the value is a `Fn` (a real partial), the expected type is a **concrete non-function** (`Var`/`Unknown`/`Fn` excluded), and this exact call site was recorded as under-applied. A partial reaching a **function-typed** position (`List.map(add(1.0), xs)`, a callback binding) or **open inference** stays silent — those are intended partials. Because a `Fn` can never unify with a concrete non-function type, firing here is strictly a better rendering of an already-guaranteed error; it can never suppress a valid program.

## Mechanism

A **write-only diagnostic side channel**: the under-application arm of the `Call` rule records provenance (callee label, applied/total counts, missing `(name, type)` pairs) keyed by the call's `ExprId`; `expect`'s fallback arm reads it via `report_forgotten_arg` when a partial-origin `Fn` meets a concrete non-function expectation, and emits the enriched message *in place of* the generic mismatch (single diagnostic). **HM unification/generalization is untouched** — the table is never consulted by `unify`/`generalize`/`zonk`. Param names come from the def's lambda params (user fns) or the variant's field names (constructors); a builtin has no names in its signature, so the message falls back to the parameter's type alone.

## Tests

Added to `mle/tests/check.rs`:
- **Fires:** forgotten arg of a user function (into an argument position), into a return annotation, of a builtin (type-only fallback), of a constructor (names the field).
- **Does not fire (legit partials):** inline partial into `List.map`'s callback; a partial bound to a `let` then used as a callback. Existing accepted-partial tests (return-position, then-saturate) stay clean.

`RUST_MIN_STACK=33554432 cargo test -p mle` and `cargo test -p functor_runtime_common` both green. No check golden needed regeneration (`broken.mle` has no partial-into-non-function case). The `--json` diagnostic path is unaffected — the message is a normal `CheckError` flowing through the existing structured `Event::Diagnostic`.

## Review

`/xreview`: the Claude reviewer found **no Critical/High/Medium issues** (verified: no false-positives possible, missing-param info accurate, HM machinery intact, edge cases — over/nullary/ExprId/ordering — hold). Codex was unavailable (usage limit), so this was Claude-only.

## Scope

Focused typechecker enhancement + tests only. No currying/thread-last semantics, prelude, or examples changed — purely a better error message. The two smaller follow-ups noted by #264 (host-fn checker/runtime arity gap; nullary-`Fn([], r)` over-apply message) are **not** addressed here (out of scope — the host-fn gap needs checker knowledge of host arity; the nullary over-apply is a separate `over_apply` edge case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)