### PR TITLE
docs: sweep human docs to thread-last piping (currying migration closer)

### DIFF
--- a/docs/cli-output.md
+++ b/docs/cli-output.md
@@ -112,7 +112,7 @@ so `-v --quiet` still shows only warn/error. Under `--json` the level gate still
 
 ### MLE `Debug.log` — the always-visible `trace` tier (PR-4b)
 
-MLE's `Debug.log(value, label)` builtin (an Elm-style trace: logs `label: <value>`, returns
+MLE's `Debug.log(label, value)` builtin (an Elm-style trace: logs `label: <value>`, returns
 `value` unchanged; see the `mle-language` skill) reuses this same region-aware log path — but with
 **one deliberate difference from the `-v`-gated `log` facade**: a `Debug.log` is *explicit user
 intent*, so it must show **by default, without `-v`**. It rides a distinct, always-visible
@@ -313,7 +313,7 @@ keypress in a focused window, never on a piped/`--json`/captured run.)
   region-aware path; `-v/--verbose` + `RUST_LOG` set the level (quiet warn/error default). Converts
   the runtime's informational `println!`s (asset-load debug, Xreal status). PR-4b adds the MLE
   `Debug.log` builtin through the same path.
-- **PR-4b (this):** the MLE `Debug.log(value, label)` builtin — a pipe-friendly Elm-style trace
+- **PR-4b (this):** the MLE `Debug.log(label, value)` builtin — a pipe-friendly Elm-style trace
   routed through the region-aware log path as the always-visible `trace` tier (shown by default, no
   `-v`, since it's explicit user intent). The `mle` crate owns a settable trace sink (default:
   stdout, for plain `mle run`); the host forwards it into `RuntimeEvent::MleTrace` →

--- a/site/docs.html
+++ b/site/docs.html
@@ -263,9 +263,9 @@ let area = (s: Shape): Float =>
 
           <h3>Pipelines</h3>
           <p>
-            <code>|></code> <strong>prepends</strong> the piped value:
-            <code>x |> f(a)</code> is <code>f(x, a)</code>. Every prelude function therefore
-            takes its subject (list, scene, body) first.
+            <code>|></code> <strong>appends</strong> the piped value:
+            <code>x |> f(a)</code> is <code>f(a, x)</code>. Every prelude function therefore
+            takes its subject (list, scene, body) last (thread-last, F#/Elm-style).
           </p>
           <pre class="mle">let isHigh = (score) => score > 10.0
 let describe = (score) => Text.concat("score: ", Text.fromFloat(score))
@@ -399,8 +399,8 @@ let span = (a, b) =>
           <h2>Builtins</h2>
           <table>
             <tbody>
-              <tr><td><code>List.map(list, fn)</code> · <code>List.filter(list, fn)</code></td><td rowspan="2">the subject comes first — pipeline-friendly</td></tr>
-              <tr><td><code>List.fold(list, fn, init)</code> — callback is <code>(acc, x) => …</code></td></tr>
+              <tr><td><code>List.map(fn, list)</code> · <code>List.filter(fn, list)</code></td><td rowspan="2">data comes last — pipeline-friendly (F#/Elm-style)</td></tr>
+              <tr><td><code>List.fold(fn, init, list)</code> — callback is <code>(acc, x) => …</code></td></tr>
               <tr><td><code>List.range(n)</code></td><td><code>[0 … n-1]</code></td></tr>
               <tr><td><code>List.maximum(list)</code></td><td></td></tr>
               <tr><td><code>Text.concat(a, b)</code> · <code>Text.fromFloat(n)</code> · <code>Text.toBullets(list)</code></td><td></td></tr>
@@ -412,7 +412,7 @@ let span = (a, b) =>
         <section id="sharp-edges">
           <h2>Sharp edges</h2>
           <ul>
-            <li><code>x |> f(a)</code> is <code>f(x, a)</code> — pipelines <em>prepend</em>.</li>
+            <li><code>x |> f(a)</code> is <code>f(a, x)</code> — pipelines <em>append</em> (thread-last).</li>
             <li>Assignment is <code>:=</code> (not <code>&lt;-</code>) and must be followed by <code>;</code> and a continuation.</li>
             <li>No <code>if</code>/<code>else</code> — use a bool-literal <code>match</code>.</li>
             <li>Angles, Durations, and render targets are branded <em>values</em> — <code>Sub.every(0.5, …)</code> and <code>Scene.rotateY(1.57)</code> are errors.</li>


### PR DESCRIPTION
Final PR of the MLE currying migration: a docs prose sweep so the remaining **human-facing** docs describe the new curried, thread-**LAST** model.

## The model (now consistent everywhere)
- `x |> f(a)` == `f(a, x)` — the pipeline **appends** the piped value (thread-last, F#/Elm-style).
- Every prelude/builtin takes its subject/data **last**: `List.map(fn, list)`, `List.filter(fn, list)`, `List.fold(fn, init, list)`, `Scene.color(r,g,b,scene)`.
- `Debug.log(label, value)` — label first, value last.

## Swept
- **`site/docs.html`** — the MLE language page:
  - Pipelines prose: "prepends" / `f(x, a)` / "subject … first" → "appends" / `f(a, x)` / "subject … last (thread-last, F#/Elm-style)".
  - Builtins signature table: `List.map(list, fn)` · `List.filter(list, fn)` · `List.fold(list, fn, init)` → `List.map(fn, list)` · `List.filter(fn, list)` · `List.fold(fn, init, list)`, caption "data comes last — pipeline-friendly (F#/Elm-style)".
  - Sharp-edges line: `f(x, a)` / "prepend" → `f(a, x)` / "append (thread-last)".
- **`docs/cli-output.md`** — `Debug.log(value, label)` → `Debug.log(label, value)` (two mentions).

Piped code samples (`x |> f(a)`) are textually identical under both orderings, so they were verified and left untouched (`site/examples/hero.mle`, the `report` sample, the Scene pipe chains). The site-local `hero.mle` is already thread-last consistent.

## Verification
- Final `grep -rniE 'prepend|f\(x, ?a\)|thread-first|subject.*first'` over README / site / docs (minus the excluded set) → **zero stale hits**.
- The docs page's runnable `report` sample (`|> List.filter(isHigh) |> List.map(describe) |> Text.toBullets`) checks and runs clean under the new model (`mle check` / `run`).
- `site/docs.html` is a **source** page copied verbatim into the gitignored `site/dist/` at build time — no generated output to reconcile.

Closes the currying migration; the agent-facing surfaces (`CLAUDE.md`, the `mle-language` skill, `docs/mle.md`) were already flipped in #265/#266.

## Review
`/xreview`: Claude reviewer confirmed all flipped signatures/samples are correct and complete for the new model, with no missed stale wording. Codex was **unavailable** (usage limit), so this was a Claude-only review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)