### PR TITLE
feat(mle-lsp): inlay hints, signature code lens, and project-aware analysis

### DIFF
--- a/examples/hello-cubes/game.mle
+++ b/examples/hello-cubes/game.mle
@@ -6,24 +6,12 @@
 // The producer contract: `init` is the initial model value; `tick` steps it;
 // `draw` returns a Frame; `subscriptions` declares timers whose messages
 // fold through `update` (the full MVU loop — here, a once-per-second Beat
-// cycles the centerpiece's color). Transforms apply outermost-last, so
-// `|> Scene.translate(radius…) |> Scene.rotateY(angle)` places a cube on the
-// ring at `angle`.
-
-let count = 12.0
-let tau = 6.2831853
-
-let ringCube = (spin: Float, i: Float) =>
-  Scene.cube()
-    |> Scene.color(0.25 + 0.75 * (i / count), 0.35, 0.95 - 0.65 * (i / count))
-    |> Scene.rotateY(Angle.radians(i * 0.7 + spin * 2.0))
-    |> Scene.translate(4.0, Math.sin(i + spin * 3.0) * 0.6, 0.0)
-    |> Scene.rotateY(Angle.radians(i * tau / count + spin))
-
-let centerpiece = (spin: Float, beat: Float) =>
-  Scene.sphere()
-    |> Scene.color(1.0, 0.5 + 0.5 * Math.cos(beat * 2.1), 0.5 + 0.5 * Math.sin(beat * 1.3))
-    |> Scene.scale(1.1 + 0.25 * Math.sin(spin * 4.0))
+// cycles the centerpiece's color).
+//
+// The scene-piece builders live in the sibling module `Pieces` (pieces.mle);
+// this file drives the MVU loop and composes them as `Pieces.ringCube` /
+// `Pieces.centerpiece`. Transforms apply outermost-last, so on the ring a
+// cube is `|> Scene.translate(radius…) |> Scene.rotateY(angle)`.
 
 type Msg =
   | Beat
@@ -42,6 +30,6 @@ let draw = (model, tts: Float) =>
   Frame.create(
     Camera.lookAt(0.0, 3.5, -9.0, 0.0, 0.0, 0.0),
     Scene.group([
-      centerpiece(model.spin, model.beat),
-      Scene.group(List.range(count) |> List.map((i) => ringCube(model.spin, i))),
+      Pieces.centerpiece(model.spin, model.beat),
+      Scene.group(List.range(Pieces.count) |> List.map((i) => Pieces.ringCube(model.spin, i))),
     ]))

--- a/examples/hello-cubes/pieces.mle
+++ b/examples/hello-cubes/pieces.mle
@@ -1,0 +1,21 @@
+// pieces.mle — the scene-piece builders for hello-cubes, split into a sibling
+// module (`file = module`, so this file IS module `Pieces`). `game.mle`
+// references these across the file boundary as `Pieces.count`,
+// `Pieces.ringCube`, `Pieces.centerpiece` — a small multi-file MLE example.
+
+let count = 12.0
+let tau = 6.2831853
+
+// One gradient cube on the ring at index `i`, given the current `spin`.
+let ringCube = (spin: Float, i: Float) =>
+  Scene.cube()
+    |> Scene.color(0.25 + 0.75 * (i / count), 0.35, 0.95 - 0.65 * (i / count))
+    |> Scene.rotateY(Angle.radians(i * 0.7 + spin * 2.0))
+    |> Scene.translate(4.0, Math.sin(i + spin * 3.0) * 0.6, 0.0)
+    |> Scene.rotateY(Angle.radians(i * tau / count + spin))
+
+// The pulsing sphere at the center of the ring.
+let centerpiece = (spin: Float, beat: Float) =>
+  Scene.sphere()
+    |> Scene.color(1.0, 0.5 + 0.5 * Math.cos(beat * 2.1), 0.5 + 0.5 * Math.sin(beat * 1.3))
+    |> Scene.scale(1.1 + 0.25 * Math.sin(spin * 4.0))

--- a/mle/src/codelens.rs
+++ b/mle/src/codelens.rs
@@ -1,0 +1,99 @@
+//! Code lenses: the inferred signature of each top-level definition, shown
+//! on the line above it — the language-aware half of the LSP's
+//! `textDocument/codeLens`. Like [`crate::hover`] / [`crate::inlay`], this
+//! module decides *content* (an anchor span + a title) and the editor server
+//! speaks the protocol, so it is unit-testable without an editor.
+//!
+//! One lens per top-level value `let`, titled `name : Type` from the
+//! checker's per-expression table ([`crate::types::ExprTypes`]) — e.g.
+//! `update : (Model, Msg) => Model` above `let update = …`. A def whose whole
+//! type is `Unknown` (the gradual seam — host values, unresolved cross-file
+//! refs) gets no lens: a bare `: Unknown` is noise, not a signature.
+
+use crate::ir::Module;
+use crate::span::Span;
+use crate::types::{ExprTypes, Type};
+
+/// One signature lens: render `title` (a `name : Type` line) on the line
+/// above `span` (the definition it describes).
+pub struct SignatureLens {
+    pub span: Span,
+    pub title: String,
+}
+
+/// A signature lens for each top-level def with a known type, in file order.
+pub fn signatures(module: &Module, types: &ExprTypes) -> Vec<SignatureLens> {
+    module
+        .defs
+        .iter()
+        .filter_map(|def| {
+            let ty = types.expr(def.value.id)?;
+            // The gradual seam: a fully-unknown def has no signature worth
+            // showing (a partial one like `(Float) => Unknown` still does).
+            if matches!(ty, Type::Unknown) {
+                return None;
+            }
+            Some(SignatureLens {
+                span: def.span,
+                title: format!("{} : {ty}", def.name),
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::check_with_types;
+
+    fn sigs(src: &str) -> Vec<String> {
+        let module = crate::lower(crate::parse(src).expect("parse")).expect("lower");
+        let (_, types) = check_with_types(&module);
+        signatures(&module, &types)
+            .into_iter()
+            .map(|s| s.title)
+            .collect()
+    }
+
+    #[test]
+    fn signature_of_a_function_def() {
+        assert_eq!(
+            sigs("let double = (x: Float): Float => x * 2.0"),
+            vec!["double : (Float) => Float"]
+        );
+    }
+
+    #[test]
+    fn signature_of_a_constant() {
+        assert_eq!(sigs("let threshold = 10.0"), vec!["threshold : Float"]);
+    }
+
+    #[test]
+    fn infers_an_unannotated_signature() {
+        // The whole signature is recovered with no annotations written.
+        assert_eq!(sigs("let f = (x) => x + 1.0"), vec!["f : (Float) => Float"]);
+    }
+
+    #[test]
+    fn polymorphic_signature() {
+        assert_eq!(sigs("let id = (x) => x"), vec!["id : ('a) => 'a"]);
+    }
+
+    #[test]
+    fn one_lens_per_def_in_file_order() {
+        assert_eq!(
+            sigs("let a = 1.0\nlet b = (x) => x + 1.0"),
+            vec!["a : Float", "b : (Float) => Float"]
+        );
+    }
+
+    #[test]
+    fn the_lens_anchors_to_its_def() {
+        let src = "let a = 1.0\nlet b = 2.0";
+        let module = crate::lower(crate::parse(src).unwrap()).unwrap();
+        let (_, types) = check_with_types(&module);
+        let lenses = signatures(&module, &types);
+        // `b`'s lens anchors at the start of its `let`, on line 2.
+        assert_eq!(&src[lenses[1].span.start..lenses[1].span.start + 5], "let b");
+    }
+}

--- a/mle/src/inlay.rs
+++ b/mle/src/inlay.rs
@@ -1,0 +1,142 @@
+//! Inlay hints: inferred-type ghost text for a checked module — the
+//! language-aware half of the LSP's `textDocument/inlayHint`. Like
+//! [`crate::hover`], this module decides *content* (offset + label) and the
+//! editor server speaks the protocol, so it is unit-testable without an
+//! editor.
+//!
+//! We annotate **unannotated lambda parameters** with their inferred type
+//! (`(x) => x + 1.0` shows `x: Float`), the same signature-inference feel as
+//! Merlin / ReasonML. Types come from the checker's per-binding table
+//! ([`crate::types::ExprTypes`]); a parameter that already carries a source
+//! annotation gets no hint (it would be redundant), and `Unknown` (the
+//! gradual seam — host values, unresolved externals) is suppressed because a
+//! `: Unknown` hint is noise, not information.
+
+use crate::ir::{Expr, ExprKind, Module, Param};
+use crate::types::{ExprTypes, Type};
+
+/// One inferred-type hint: render `label` (a leading-colon string like
+/// `: Float`) immediately after byte `offset` in the source.
+pub struct InlayHint {
+    pub offset: usize,
+    pub label: String,
+}
+
+/// Every inferred-type hint for `module`, in source order.
+pub fn inlay_hints(module: &Module, types: &ExprTypes) -> Vec<InlayHint> {
+    let mut hints = Vec::new();
+    for def in &module.defs {
+        visit(&def.value, types, &mut hints);
+    }
+    hints
+}
+
+/// Walk the expression tree, emitting a hint at each unannotated lambda
+/// parameter. Lambda and Match are handled here (they recurse into bodies /
+/// arm bodies); everything else recurses through [`crate::hover::children`],
+/// which this shares so the two walks stay in lockstep.
+fn visit(expr: &Expr, types: &ExprTypes, hints: &mut Vec<InlayHint>) {
+    match &expr.kind {
+        ExprKind::Lambda { params, body, .. } => {
+            for param in params.iter() {
+                if let Some(hint) = param_hint(param, types) {
+                    hints.push(hint);
+                }
+            }
+            visit(body, types, hints);
+        }
+        ExprKind::Match { scrutinee, arms } => {
+            visit(scrutinee, types, hints);
+            for arm in arms {
+                visit(&arm.body, types, hints);
+            }
+        }
+        _ => {
+            for child in crate::hover::children(expr) {
+                visit(child, types, hints);
+            }
+        }
+    }
+}
+
+/// A hint for one parameter, if it is unannotated and has a known type.
+fn param_hint(param: &Param, types: &ExprTypes) -> Option<InlayHint> {
+    // An annotated param already shows its type in the source.
+    if param.ty.is_some() {
+        return None;
+    }
+    let ty = types.binding(param.binding)?;
+    if matches!(ty, Type::Unknown) {
+        return None;
+    }
+    Some(InlayHint {
+        // `param.span` covers just the name for an unannotated param, so its
+        // end sits right after it: `(x‸) =>` renders as `(x: Float) =>`.
+        offset: param.span.end,
+        label: format!(": {ty}"),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::check_with_types;
+
+    fn hints(src: &str) -> Vec<(usize, String)> {
+        let module = crate::lower(crate::parse(src).expect("parse")).expect("lower");
+        let (_, types) = check_with_types(&module);
+        inlay_hints(&module, &types)
+            .into_iter()
+            .map(|h| (h.offset, h.label))
+            .collect()
+    }
+
+    #[test]
+    fn infers_an_unannotated_param() {
+        let src = "let f = (x) => x + 1.0";
+        let got = hints(src);
+        assert_eq!(got.len(), 1);
+        // The hint sits right after the `x`, labelled with the inferred type.
+        assert_eq!(got[0].1, ": Float");
+        assert_eq!(&src[got[0].0 - 1..got[0].0], "x");
+    }
+
+    #[test]
+    fn skips_an_annotated_param() {
+        assert!(hints("let f = (x: Float) => x + 1.0").is_empty());
+    }
+
+    #[test]
+    fn shows_a_polymorphic_param() {
+        // An unconstrained param is honestly generic (`'a`), like OCaml/Merlin
+        // — not `Unknown`. (`Unknown` is reserved for the gradual seam, e.g.
+        // host values under the engine prelude, and is suppressed there.)
+        let got = hints("let f = (x) => x");
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].1, ": 'a");
+    }
+
+    #[test]
+    fn hints_every_param_of_a_multi_arg_lambda() {
+        let got = hints("let f = (x, y) => x + y");
+        assert_eq!(
+            got.iter().map(|(_, l)| l.as_str()).collect::<Vec<_>>(),
+            vec![": Float", ": Float"]
+        );
+    }
+
+    #[test]
+    fn descends_into_nested_lambdas() {
+        // A curried inner lambda's param is inferred through its use.
+        let got = hints("let f = (x) => (y) => x + y");
+        assert_eq!(got.len(), 2);
+        assert!(got.iter().all(|(_, l)| l == ": Float"));
+    }
+
+    #[test]
+    fn infers_a_list_param() {
+        let got = hints("let f = (xs) => xs |> List.maximum");
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].1, ": List<Float>");
+    }
+}

--- a/mle/src/lib.rs
+++ b/mle/src/lib.rs
@@ -9,9 +9,11 @@
 //! IR ([`types`]) — checking with annotations, not inference.
 
 pub mod ast;
+pub mod codelens;
 pub mod eval;
 pub mod goto;
 pub mod hover;
+pub mod inlay;
 pub mod ir;
 mod lexer;
 mod lower;
@@ -32,7 +34,7 @@ pub use parser::parse;
 pub use rebind::{rebind_value, RebindReport};
 pub use span::{line_col, Span};
 pub use trace::set_trace_sink;
-pub use types::{check, check_with_types, ExprTypes};
+pub use types::{check, check_with_scopes_and_types, check_with_types, ExprTypes};
 pub use value::{HostData, Value};
 
 /// A lex or parse failure: a message plus the span of the offending source.

--- a/mle/src/project.rs
+++ b/mle/src/project.rs
@@ -81,6 +81,14 @@ impl Project {
     pub fn check(&self) -> Vec<CheckError> {
         crate::types::check_with_scopes(&self.module, &self.scopes)
     }
+
+    /// [`Project::check`], also returning the per-expression type table — the
+    /// project-wide input for `mle::hover` / `mle::inlay` / `mle::codelens`.
+    /// Spans (keys into the table's positions) are project-wide; render them
+    /// through [`Project::sources`].
+    pub fn check_with_types(&self) -> (Vec<CheckError>, crate::types::ExprTypes) {
+        crate::types::check_with_scopes_and_types(&self.module, &self.scopes)
+    }
 }
 
 /// One file of a project, with its base offset in the project-wide span
@@ -141,6 +149,21 @@ impl SourceMap {
     pub fn render(&self, offset: usize, message: &str) -> String {
         let (file, line, col) = self.resolve(offset);
         format!("{}:{line}:{col}: {message}", file.path.display())
+    }
+
+    /// The source file with this path, if the project has one — the LSP's
+    /// seam for mapping an editor document (a file path) to its base in the
+    /// project-wide span space. Matches on the exact path first, then on the
+    /// canonicalized path (a URI-derived path and a `read_dir` path can
+    /// differ in form: symlinks, `.`/`..`, absolute vs relative).
+    pub fn file_by_path(&self, path: &Path) -> Option<&SourceFile> {
+        if let Some(file) = self.files.iter().find(|f| f.path == path) {
+            return Some(file);
+        }
+        let canon = std::fs::canonicalize(path).ok()?;
+        self.files
+            .iter()
+            .find(|f| std::fs::canonicalize(&f.path).ok() == Some(canon.clone()))
     }
 }
 
@@ -204,6 +227,22 @@ pub fn load_with_entry_source(
     entry_path: &Path,
     entry_src: Option<String>,
 ) -> Result<Project, ProjectError> {
+    let overrides = match entry_src {
+        Some(src) => HashMap::from([(entry_path.to_path_buf(), src)]),
+        None => HashMap::new(),
+    };
+    load_with_overrides(entry_path, &overrides)
+}
+
+/// [`load`], with any project files' on-disk sources replaced by the given
+/// in-memory buffers (keyed by path). The LSP's seam: an editor holds
+/// unsaved edits for one or more open files (entry or sibling), and the rest
+/// load from disk. A key matching no project file is ignored. Matching is by
+/// exact path, then canonicalized path (see [`SourceMap::file_by_path`]).
+pub fn load_with_overrides(
+    entry_path: &Path,
+    overrides: &HashMap<PathBuf, String>,
+) -> Result<Project, ProjectError> {
     let at = |path: &Path, message: String| ProjectError {
         path: path.to_path_buf(),
         line: 1,
@@ -221,7 +260,7 @@ pub fn load_with_entry_source(
     // Derive and validate module names; read sources; assign span bases.
     let mut files: Vec<SourceFile> = Vec::new();
     let mut base = 0usize;
-    for (index, path) in paths.iter().enumerate() {
+    for path in paths.iter() {
         let module = module_name(path).map_err(|message| at(path, message))?;
         if PROTECTED_NAMESPACES.contains(&module.as_str()) {
             return Err(at(
@@ -244,9 +283,9 @@ come from file names, capitalized",
                 ),
             ));
         }
-        let src = match (index, &entry_src) {
-            (0, Some(src)) => src.clone(),
-            _ => std::fs::read_to_string(path)
+        let src = match override_for(path, overrides) {
+            Some(src) => src.clone(),
+            None => std::fs::read_to_string(path)
                 .map_err(|e| at(path, format!("cannot read {}: {e}", path.display())))?,
         };
         let len = src.len();
@@ -416,6 +455,29 @@ pub fn load_single_source(module: &str, src: &str) -> Result<Project, ProjectErr
     link(files)
 }
 
+/// Load ONE in-memory file as a single-file project, keeping its real path in
+/// the [`SourceMap`] (so [`SourceMap::file_by_path`] resolves it) — the LSP's
+/// path for a `.mle` with no `functor.json`: check just this buffer, never
+/// scanning the directory for unrelated siblings. Module name is the file's
+/// (`Main` if the stem isn't an identifier); a single file is its own bare
+/// entry, so the name only labels it.
+pub fn load_single_file(path: &Path, src: &str) -> Result<Project, ProjectError> {
+    // Fall back to `Main` for a non-identifier stem OR one that capitalizes to
+    // a protected namespace (`net.mle` → `Net`), which would otherwise collide
+    // with the builtin module `link` injects and silently fail the load.
+    let module = match module_name(path) {
+        Ok(name) if !PROTECTED_NAMESPACES.contains(&name.as_str()) => name,
+        _ => "Main".to_string(),
+    };
+    let files = vec![SourceFile {
+        path: path.to_path_buf(),
+        module,
+        src: src.to_string(),
+        base: 0,
+    }];
+    link(files)
+}
+
 /// The module name a file provides: its stem, first letter capitalized
 /// (`utils.mle` → `Utils`). The stem must be a valid identifier — module
 /// names appear in source (`Utils.clamp`).
@@ -435,6 +497,23 @@ fn module_name(path: &Path) -> Result<String, String> {
         ));
     }
     Ok(capitalize(stem))
+}
+
+/// The override source for `path`, if any: exact-path match first, then a
+/// canonicalized match (the same fail-soft matching as
+/// [`SourceMap::file_by_path`]).
+fn override_for<'a>(path: &Path, overrides: &'a HashMap<PathBuf, String>) -> Option<&'a String> {
+    if overrides.is_empty() {
+        return None;
+    }
+    if let Some(src) = overrides.get(path) {
+        return Some(src);
+    }
+    let canon = std::fs::canonicalize(path).ok()?;
+    overrides
+        .iter()
+        .find(|(key, _)| std::fs::canonicalize(key).ok() == Some(canon.clone()))
+        .map(|(_, src)| src)
 }
 
 fn file_name(path: &Path) -> String {

--- a/mle/src/types.rs
+++ b/mle/src/types.rs
@@ -444,6 +444,17 @@ pub fn check_with_types(module: &Module) -> (Vec<CheckError>, ExprTypes) {
     check_impl(module, None)
 }
 
+/// [`check_with_types`] for a merged multi-file module, with per-module
+/// record-literal scopes — the typed counterpart of [`check_with_scopes`]
+/// (`crate::project::Project::check_with_types` is the caller-facing seam,
+/// letting the LSP hover/inlay/codelens over a whole project).
+pub fn check_with_scopes_and_types(
+    module: &Module,
+    scopes: &RecordLiteralScopes,
+) -> (Vec<CheckError>, ExprTypes) {
+    check_impl(module, Some(scopes))
+}
+
 fn check_impl(
     module: &Module,
     scopes: Option<&RecordLiteralScopes>,

--- a/mle/tests/project.rs
+++ b/mle/tests/project.rs
@@ -761,3 +761,107 @@ fn same_named_defs_in_different_modules_do_not_cross_rebind() {
         .expect("apply beta");
     assert_eq!(number(&result), 1.0); // beta unchanged: 2 - 1
 }
+
+// --- Track D: project-aware LSP typed check (slice 1a) ---
+
+/// `Project::check_with_types` types the whole program, so a def in the entry
+/// that calls a sibling recovers a concrete signature — the cross-file
+/// inference the LSP's hover/inlay/codelens build on. And a hint's
+/// project-wide span resolves back to the file that owns it.
+#[test]
+fn project_typed_check_infers_across_files() {
+    let project = load(
+        "typed-xfile",
+        &[
+            // Entry calls Utils.double with no annotations anywhere.
+            ("game.mle", "let apply = (n) => Utils.double(n)\n"),
+            ("utils.mle", "let double = (x: Float): Float => x * 2.0\n"),
+        ],
+    );
+    let (diags, types) = project.check_with_types();
+    assert!(diags.is_empty(), "clean: {diags:?}");
+
+    // The entry's `apply` is inferred `(Float) => Float` across the file
+    // boundary (Utils.double is annotated Float→Float).
+    let sigs: Vec<String> = mle::codelens::signatures(&project.module, &types)
+        .into_iter()
+        .map(|s| s.title)
+        .collect();
+    assert!(
+        sigs.contains(&"apply : (Float) => Float".to_string()),
+        "signatures: {sigs:?}"
+    );
+
+    // The sibling's def is canonicalized to `Utils.double` in a project.
+    // Its signature lens carries a project-wide span; it must resolve to
+    // utils.mle, not the entry.
+    let double = mle::codelens::signatures(&project.module, &types)
+        .into_iter()
+        .find(|s| s.title.starts_with("Utils.double :"))
+        .expect("Utils.double has a signature");
+    let (file, _line, _col) = project.sources.resolve(double.span.start);
+    assert_eq!(
+        file.path.file_name().unwrap().to_str().unwrap(),
+        "utils.mle",
+        "double should resolve to its own file"
+    );
+}
+
+/// `load_with_overrides` replaces a *sibling* file's on-disk source with an
+/// in-memory buffer (the LSP editing a non-entry file), and `file_by_path`
+/// maps a path back to its project base. Disk still holds the old sibling.
+#[test]
+fn overrides_replace_a_sibling_buffer() {
+    let scratch = Scratch::new(
+        "override-sibling",
+        &[
+            ("game.mle", "let apply = (n) => Utils.tripled(n)\n"),
+            // On disk `utils.mle` has no `tripled` — loading from disk fails.
+            ("utils.mle", "let double = (x: Float): Float => x * 2.0\n"),
+        ],
+    );
+    // Disk-only load: `Utils.tripled` is unresolved (load or check fails).
+    let disk_clean = match mle::project::load(&scratch.entry) {
+        Ok(project) => project.check().is_empty(),
+        Err(_) => false,
+    };
+    assert!(!disk_clean, "disk load should not resolve Utils.tripled");
+
+    // Override the sibling buffer with a version that defines `tripled`.
+    let mut overrides = std::collections::HashMap::new();
+    overrides.insert(
+        scratch.dir.join("utils.mle"),
+        "let tripled = (x: Float): Float => x * 3.0\n".to_string(),
+    );
+    let project = mle::project::load_with_overrides(&scratch.entry, &overrides)
+        .unwrap_or_else(|e| panic!("override load: {}", e.render()));
+    assert!(project.check().is_empty(), "clean with override");
+
+    // `file_by_path` maps the sibling path to its project file (which now
+    // carries the overridden source).
+    let file = project
+        .sources
+        .file_by_path(&scratch.dir.join("utils.mle"))
+        .expect("utils.mle is a project file");
+    assert!(file.src.contains("tripled"), "override source is in the map");
+}
+
+/// The shipped multi-file example (`examples/hello-cubes` = game.mle +
+/// pieces.mle) must keep loading as a project and checking clean, so the
+/// split sample can't silently bit-rot.
+#[test]
+fn shipped_hello_cubes_multifile_checks_clean() {
+    let entry = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("examples")
+        .join("hello-cubes")
+        .join("game.mle");
+    let project = mle::project::load(&entry)
+        .unwrap_or_else(|e| panic!("hello-cubes should load: {}", e.render()));
+    assert!(
+        project.sources.files().iter().any(|f| f.module == "Pieces"),
+        "pieces.mle loads as module Pieces"
+    );
+    let diags = project.check();
+    assert!(diags.is_empty(), "hello-cubes checks clean: {diags:?}");
+}

--- a/tools/mle-lsp/src/main.rs
+++ b/tools/mle-lsp/src/main.rs
@@ -10,13 +10,17 @@
 //! Document sync is **full** (`textDocumentSync: 1`): every change carries
 //! the whole buffer. The server keeps one piece of state — a uri→text map —
 //! to answer `textDocument/hover` (quick info: `name : Type` from the
-//! gradual checker, via `mle::hover`) and `textDocument/definition`
+//! gradual checker, via `mle::hover`), `textDocument/definition`
 //! (go-to-definition via `mle::goto`; MLE is single-file, so the answer is
-//! always a `Location` in the same document). Diagnostics cover parse,
+//! always a `Location` in the same document), `textDocument/inlayHint`
+//! (inferred `: Type` ghost text on unannotated lambda params, via
+//! `mle::inlay`), and `textDocument/codeLens` (each top-level def's inferred
+//! signature above it, via `mle::codelens`). Diagnostics cover parse,
 //! lowering, and every `mle::check` type diagnostic.
 
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
 
 use serde_json::{json, Value};
 
@@ -66,6 +70,8 @@ fn serve(reader: &mut impl BufRead, writer: &mut impl Write) -> i32 {
                         "textDocumentSync": 1,
                         "hoverProvider": true,
                         "definitionProvider": true,
+                        "inlayHintProvider": true,
+                        "codeLensProvider": { "resolveProvider": false },
                     },
                     "serverInfo": { "name": "mle-lsp" },
                 });
@@ -84,8 +90,9 @@ fn serve(reader: &mut impl BufRead, writer: &mut impl Write) -> i32 {
             ("textDocument/hover", Some(id)) => {
                 let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
                 let result = documents
-                    .get(uri)
-                    .and_then(|text| hover(text, &params["position"]))
+                    .contains_key(uri)
+                    .then(|| hover(uri, &documents, &params["position"]))
+                    .flatten()
                     .unwrap_or(Value::Null);
                 write_message(
                     writer,
@@ -95,9 +102,34 @@ fn serve(reader: &mut impl BufRead, writer: &mut impl Write) -> i32 {
             ("textDocument/definition", Some(id)) => {
                 let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
                 let result = documents
-                    .get(uri)
-                    .and_then(|text| definition(text, uri, &params["position"]))
+                    .contains_key(uri)
+                    .then(|| definition(uri, &documents, &params["position"]))
+                    .flatten()
                     .unwrap_or(Value::Null);
+                write_message(
+                    writer,
+                    &json!({ "jsonrpc": "2.0", "id": id, "result": result }),
+                );
+            }
+            ("textDocument/inlayHint", Some(id)) => {
+                let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
+                let result = documents
+                    .contains_key(uri)
+                    .then(|| inlay_hints(uri, &documents, &params["range"]))
+                    .flatten()
+                    .unwrap_or_else(|| json!([]));
+                write_message(
+                    writer,
+                    &json!({ "jsonrpc": "2.0", "id": id, "result": result }),
+                );
+            }
+            ("textDocument/codeLens", Some(id)) => {
+                let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
+                let result = documents
+                    .contains_key(uri)
+                    .then(|| code_lenses(uri, &documents))
+                    .flatten()
+                    .unwrap_or_else(|| json!([]));
                 write_message(
                     writer,
                     &json!({ "jsonrpc": "2.0", "id": id, "result": result }),
@@ -173,27 +205,206 @@ fn publish_diagnostics(writer: &mut impl Write, uri: &str, text: &str) {
     write_diagnostics(writer, uri, diagnostics);
 }
 
-/// Answer a hover request: parse/lower/check the buffer, find the innermost
-/// node at the (UTF-16) position, and render `name : Type` as markdown.
-fn hover(text: &str, position: &Value) -> Option<Value> {
-    let offset = position_to_offset(text, position)?;
-    let module = mle::lower(mle::parse(text).ok()?).ok()?;
-    let (_, types) = mle::check_with_types(&module);
-    let (span, hover_text) = mle::hover::hover_text(&module, &types, offset)?;
+/// Load the MLE program an open document belongs to. With a `functor.json`
+/// above it, that's the whole multi-file project — every open buffer stands
+/// in for its on-disk file (unsaved edits count), siblings load from disk.
+/// With no `functor.json`, it's just this buffer as a single-file project
+/// (the directory is NOT scanned — unrelated `.mle` files nearby must not
+/// leak in). `None` on a non-`file:` URI or a load failure.
+fn load_project(uri: &str, documents: &HashMap<String, String>) -> Option<mle::project::Project> {
+    let path = uri_to_path(uri)?;
+    let single_file = || mle::project::load_single_file(&path, documents.get(uri)?).ok();
+    match discover_entry(&path) {
+        Some(entry) => {
+            let overrides: HashMap<PathBuf, String> = documents
+                .iter()
+                .filter_map(|(u, text)| Some((uri_to_path(u)?, text.clone())))
+                .collect();
+            // Use the project only if it loaded AND actually contains this
+            // file. A nearest `functor.json` whose entry lives in another dir,
+            // or a broken sibling that fails the load, must not strip the open
+            // buffer of all features — fall back to a single-file view.
+            match mle::project::load_with_overrides(&entry, &overrides) {
+                Ok(project) if project.sources.file_by_path(&path).is_some() => Some(project),
+                _ => single_file(),
+            }
+        }
+        None => single_file(),
+    }
+}
+
+/// Answer a hover request: load the project, find the innermost node at the
+/// (UTF-16) position in the open file, and render `name : Type` as markdown.
+/// Cross-file inference means the type can come from a sibling module.
+fn hover(uri: &str, documents: &HashMap<String, String>, position: &Value) -> Option<Value> {
+    let project = load_project(uri, documents)?;
+    let file = project.sources.file_by_path(&uri_to_path(uri)?)?;
+    let offset = file.base + position_to_offset(&file.src, position)?;
+    let (_, types) = project.check_with_types();
+    let (span, hover_text) = mle::hover::hover_text(&project.module, &types, offset)?;
+    let (_, range) = localize(&project, span)?;
     Some(json!({
         "contents": { "kind": "markdown", "value": format!("```mle\n{hover_text}\n```") },
-        "range": span_to_range(text, span),
+        "range": range,
     }))
 }
 
-/// Answer a definition request: parse/lower the buffer, resolve the
-/// reference at the (UTF-16) position via `mle::goto`, and return the
-/// definition site as a `Location` in the same document.
-fn definition(text: &str, uri: &str, position: &Value) -> Option<Value> {
-    let offset = position_to_offset(text, position)?;
-    let module = mle::lower(mle::parse(text).ok()?).ok()?;
-    let span = mle::goto::definition_span(&module, offset)?;
-    Some(json!({ "uri": uri, "range": span_to_range(text, span) }))
+/// Answer a definition request: load the project, resolve the reference at
+/// the position via `mle::goto`, and return the definition site as a
+/// `Location`. The target may live in a **sibling file** (cross-file goto),
+/// so the location's URI is whichever file owns the resolved span.
+fn definition(uri: &str, documents: &HashMap<String, String>, position: &Value) -> Option<Value> {
+    let project = load_project(uri, documents)?;
+    let file = project.sources.file_by_path(&uri_to_path(uri)?)?;
+    let offset = file.base + position_to_offset(&file.src, position)?;
+    let span = mle::goto::definition_span(&project.module, offset)?;
+    let (target_uri, range) = localize(&project, span)?;
+    Some(json!({ "uri": target_uri, "range": range }))
+}
+
+/// Answer a code-lens request: load the project and return one lens per
+/// top-level def **in the open file** with a known inferred signature
+/// (`name : Type`), anchored on the line above the def. The command is inert
+/// (empty `command`), so the lens is informational, not clickable.
+fn code_lenses(uri: &str, documents: &HashMap<String, String>) -> Option<Value> {
+    let project = load_project(uri, documents)?;
+    let file = project.sources.file_by_path(&uri_to_path(uri)?)?;
+    let (_, types) = project.check_with_types();
+    let lenses: Vec<Value> = mle::codelens::signatures(&project.module, &types)
+        .into_iter()
+        // A merged project holds every module's defs; keep only this file's.
+        .filter(|lens| owns(file, lens.span.start))
+        .map(|lens| {
+            json!({
+                "range": local_range(file, lens.span),
+                "command": { "title": lens.title, "command": "" },
+            })
+        })
+        .collect();
+    Some(Value::Array(lenses))
+}
+
+/// Answer an inlay-hint request: load the project and return an inferred-type
+/// hint (`: Type`) after each unannotated lambda parameter **in the open
+/// file**, clipped to the requested range.
+fn inlay_hints(uri: &str, documents: &HashMap<String, String>, range: &Value) -> Option<Value> {
+    let project = load_project(uri, documents)?;
+    let file = project.sources.file_by_path(&uri_to_path(uri)?)?;
+    let (_, types) = project.check_with_types();
+    // The client's range is local to the open file; lift it into the
+    // project-wide span space. A missing/unparsable end means "no filter".
+    let start = position_to_offset(&file.src, &range["start"]).map(|o| file.base + o);
+    let end = position_to_offset(&file.src, &range["end"]).map(|o| file.base + o);
+    let in_range = |offset: usize| match (start, end) {
+        // LSP ranges are half-open — `end` is exclusive.
+        (Some(s), Some(e)) => s <= offset && offset < e,
+        _ => true,
+    };
+    let hints: Vec<Value> = mle::inlay::inlay_hints(&project.module, &types)
+        .into_iter()
+        .filter(|h| owns(file, h.offset) && in_range(h.offset))
+        .map(|h| {
+            json!({
+                "position": lsp_position(&file.src, h.offset - file.base),
+                "label": h.label,
+                "kind": 1, // InlayHintKind.Type
+                "paddingLeft": false,
+                "paddingRight": false,
+            })
+        })
+        .collect();
+    Some(Value::Array(hints))
+}
+
+/// Whether project-wide `offset` falls in `file` (its half-open base range).
+fn owns(file: &mle::project::SourceFile, offset: usize) -> bool {
+    file.base <= offset && offset <= file.base + file.src.len()
+}
+
+/// A project-wide span → an LSP range local to the file it belongs to, plus
+/// that file's URI. Spans never straddle files (each node is lowered from one
+/// file), so both ends localize against the start file.
+fn localize(project: &mle::project::Project, span: mle::Span) -> Option<(String, Value)> {
+    let file = project.sources.file_at(span.start);
+    Some((path_to_uri(&file.path), local_range(file, span)))
+}
+
+/// A project-wide span → an LSP range in `file`'s local coordinates.
+fn local_range(file: &mle::project::SourceFile, span: mle::Span) -> Value {
+    let start = span.start.saturating_sub(file.base);
+    let end = span.end.saturating_sub(file.base).min(file.src.len());
+    json!({
+        "start": lsp_position(&file.src, start),
+        "end": lsp_position(&file.src, end),
+    })
+}
+
+/// The project entry for `path`: walk up for a `functor.json` and join its
+/// `entry`. `None` when there's no `functor.json` above `path` — the caller
+/// then treats the file as a standalone single-file program. Reads at most
+/// one `functor.json` per ancestor — cheap, and the tree is shallow.
+fn discover_entry(path: &Path) -> Option<PathBuf> {
+    let mut dir = path.parent();
+    while let Some(d) = dir {
+        if let Ok(text) = std::fs::read_to_string(d.join("functor.json")) {
+            if let Ok(config) = serde_json::from_str::<Value>(&text) {
+                if let Some(entry) = config["entry"].as_str() {
+                    return Some(d.join(entry));
+                }
+            }
+        }
+        dir = d.parent();
+    }
+    None
+}
+
+/// A `file:` URI → filesystem path (percent-decoded). `None` for other
+/// schemes (untitled buffers, `git:` diffs) — the server simply won't answer
+/// those, which is correct.
+fn uri_to_path(uri: &str) -> Option<PathBuf> {
+    let rest = uri.strip_prefix("file://")?;
+    Some(PathBuf::from(percent_decode(rest)))
+}
+
+/// A filesystem path → `file:` URI. Every byte that isn't an unreserved URI
+/// character (or a `/` path separator) is percent-encoded — including
+/// non-ASCII bytes, which must be escaped per-byte rather than widened to a
+/// `char` (that would double-encode). Round-trips with [`uri_to_path`] /
+/// [`percent_decode`].
+fn path_to_uri(path: &Path) -> String {
+    let mut encoded = String::from("file://");
+    for byte in path.to_string_lossy().bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' | b'/' => {
+                encoded.push(byte as char)
+            }
+            _ => encoded.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    encoded
+}
+
+/// Decode `%XX` escapes in a URI path. Non-escape bytes pass through. Works
+/// on bytes (never slicing a `&str`), so a `%` before a multi-byte character
+/// or at the string's end can't panic — the LSP must survive odd URIs, like
+/// `read_message` survives garbage frames.
+fn percent_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let hex = |b: u8| (b as char).to_digit(16);
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 3 <= bytes.len() {
+            if let (Some(hi), Some(lo)) = (hex(bytes[i + 1]), hex(bytes[i + 2])) {
+                out.push((hi * 16 + lo) as u8);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
 }
 
 /// Invert [`lsp_position`]: an LSP `{line, character}` (UTF-16 code units)
@@ -357,6 +568,26 @@ mod review_tests {
         let at = text.find('@').unwrap();
         let pos = lsp_position(text, at);
         assert_eq!(pos["character"], 13); // 12 chars, but the emoji counts twice
+    }
+
+    // [xreview High] percent_decode must not panic on a `%` before a
+    // multi-byte char or at the string's end — the old str-slice did.
+    #[test]
+    fn percent_decode_survives_malformed_escapes() {
+        assert_eq!(percent_decode("caf%C3%A9"), "café"); // valid escape
+        assert_eq!(percent_decode("%bé"), "%bé"); // % before a multi-byte char
+        assert_eq!(percent_decode("trailing%"), "trailing%"); // % at end
+        assert_eq!(percent_decode("bad%zz"), "bad%zz"); // non-hex digits
+    }
+
+    // [xreview Medium] path_to_uri must round-trip a non-ASCII path (each
+    // byte escaped, not widened to a char), so cross-file goto URIs resolve.
+    #[test]
+    fn path_to_uri_round_trips_non_ascii() {
+        let path = std::path::Path::new("/Users/café/game.mle");
+        let uri = path_to_uri(path);
+        assert!(!uri.contains('é'), "non-ascii must be percent-escaped: {uri}");
+        assert_eq!(uri_to_path(&uri).as_deref(), Some(path));
     }
 
     // exit without shutdown is code 1; after shutdown, 0. [review Low]

--- a/tools/mle-lsp/tests/e2e.rs
+++ b/tools/mle-lsp/tests/e2e.rs
@@ -74,6 +74,14 @@ fn diagnostics_over_real_stdio() {
         response["result"]["capabilities"]["definitionProvider"],
         true
     );
+    assert_eq!(
+        response["result"]["capabilities"]["inlayHintProvider"],
+        true
+    );
+    assert_eq!(
+        response["result"]["capabilities"]["codeLensProvider"]["resolveProvider"],
+        false
+    );
 
     server.send(json!({ "jsonrpc": "2.0", "method": "initialized", "params": {} }));
 
@@ -187,12 +195,147 @@ fn diagnostics_over_real_stdio() {
     assert_eq!(response["id"], 5);
     assert_eq!(response["result"], Value::Null, "expected null: {response}");
 
+    // didChange to a document with an unannotated lambda param, for inlay.
+    server.send(json!({
+        "jsonrpc": "2.0", "method": "textDocument/didChange",
+        "params": {
+            "textDocument": { "uri": URI, "version": 4 },
+            "contentChanges": [ { "text": "let f = (x) => x + 1.0" } ],
+        },
+    }));
+    assert_eq!(server.recv()["params"]["diagnostics"], json!([]));
+
+    // Inlay hints over line 0 → one `: Float` type hint right after the `x`
+    // param (byte 10 = line 0 char 10).
+    server.send(json!({
+        "jsonrpc": "2.0", "id": 6, "method": "textDocument/inlayHint",
+        "params": {
+            "textDocument": { "uri": URI },
+            "range": {
+                "start": { "line": 0, "character": 0 },
+                "end": { "line": 0, "character": 22 },
+            },
+        },
+    }));
+    let response = server.recv();
+    assert_eq!(response["id"], 6);
+    assert_eq!(
+        response["result"],
+        json!([{
+            "position": { "line": 0, "character": 10 },
+            "label": ": Float",
+            "kind": 1,
+            "paddingLeft": false,
+            "paddingRight": false,
+        }]),
+        "inlay response: {response}"
+    );
+
+    // Code lens over the same document → one inferred-signature lens for `f`,
+    // anchored on its `let` line (bytes 0..22 of the single line).
+    server.send(json!({
+        "jsonrpc": "2.0", "id": 7, "method": "textDocument/codeLens",
+        "params": { "textDocument": { "uri": URI } },
+    }));
+    let response = server.recv();
+    assert_eq!(response["id"], 7);
+    assert_eq!(
+        response["result"],
+        json!([{
+            "range": {
+                "start": { "line": 0, "character": 0 },
+                "end": { "line": 0, "character": 22 },
+            },
+            "command": { "title": "f : (Float) => Float", "command": "" },
+        }]),
+        "codeLens response: {response}"
+    );
+
     // Clean shutdown.
-    server.send(json!({ "jsonrpc": "2.0", "id": 6, "method": "shutdown" }));
-    assert_eq!(server.recv()["id"], 6);
+    server.send(json!({ "jsonrpc": "2.0", "id": 8, "method": "shutdown" }));
+    assert_eq!(server.recv()["id"], 8);
     server.send(json!({ "jsonrpc": "2.0", "method": "exit" }));
     let status = server.child.wait().expect("wait for exit");
     assert!(status.success(), "server exited with {status}");
+}
+
+/// Project-aware (Track D, slice 1b): a real `functor.json` project on disk
+/// with an entry that references a sibling. Hover on the cross-module call
+/// shows the sibling's inferred signature, and go-to-definition jumps to the
+/// sibling file — the two headline multi-file wins, over the real binary.
+#[test]
+fn project_aware_hover_and_cross_file_definition() {
+    // A scratch project: game.mle (entry) calls Utils.double from utils.mle.
+    let dir = std::env::temp_dir().join(format!("mle-lsp-e2e-project-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("scratch dir");
+    std::fs::write(
+        dir.join("functor.json"),
+        r#"{"language":"mle","entry":"game.mle"}"#,
+    )
+    .unwrap();
+    let game = "let apply = (n) => Utils.double(n)\n";
+    std::fs::write(dir.join("game.mle"), game).unwrap();
+    std::fs::write(
+        dir.join("utils.mle"),
+        "let double = (x: Float): Float => x * 2.0\n",
+    )
+    .unwrap();
+    let game_uri = format!("file://{}/game.mle", dir.display());
+    let utils_uri = format!("file://{}/utils.mle", dir.display());
+
+    let mut server = Server::spawn();
+    server.send(json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": { "capabilities": {} },
+    }));
+    server.recv();
+    server.send(json!({ "jsonrpc": "2.0", "method": "initialized", "params": {} }));
+    server.send(json!({
+        "jsonrpc": "2.0", "method": "textDocument/didOpen",
+        "params": { "textDocument": {
+            "uri": game_uri, "languageId": "mle", "version": 1, "text": game,
+        } },
+    }));
+    server.recv(); // publishDiagnostics (clean)
+
+    // Hover on the `Utils.double` call (char 19 = the `U`): the sibling's
+    // inferred signature, resolved across the file boundary.
+    let hover_col = game.find("Utils").unwrap() as i64;
+    server.send(json!({
+        "jsonrpc": "2.0", "id": 2, "method": "textDocument/hover",
+        "params": {
+            "textDocument": { "uri": game_uri },
+            "position": { "line": 0, "character": hover_col + 6 }, // inside `double`
+        },
+    }));
+    let response = server.recv();
+    assert_eq!(
+        response["result"]["contents"]["value"],
+        "```mle\nUtils.double : (Float) => Float\n```",
+        "cross-file hover: {response}"
+    );
+
+    // Go-to-definition on the same reference → a Location in utils.mle, NOT
+    // the entry: cross-file navigation.
+    server.send(json!({
+        "jsonrpc": "2.0", "id": 3, "method": "textDocument/definition",
+        "params": {
+            "textDocument": { "uri": game_uri },
+            "position": { "line": 0, "character": hover_col + 6 },
+        },
+    }));
+    let response = server.recv();
+    assert_eq!(response["result"]["uri"], utils_uri, "cross-file goto: {response}");
+    assert_eq!(
+        response["result"]["range"]["start"]["line"], 0,
+        "double is on line 0 of utils.mle: {response}"
+    );
+
+    server.send(json!({ "jsonrpc": "2.0", "id": 4, "method": "shutdown" }));
+    server.recv();
+    server.send(json!({ "jsonrpc": "2.0", "method": "exit" }));
+    server.child.wait().expect("wait for exit");
+    let _ = std::fs::remove_dir_all(&dir);
 }
 
 /// The VSCode extension's grammar and manifests must at least be valid JSON


### PR DESCRIPTION
Surfaces the Hindley–Milner checker's inferred types in the editor, and makes the MLE language server understand multi-file projects. Started as an audit of `mle-lsp`; grew into three shippable capabilities.

## What's new

**Inlay hints** (`mle::inlay`) — a `: Type` after each *unannotated* lambda parameter (annotated params skipped, `Unknown` suppressed). The Merlin/ReasonML signature-inference feel, built on the checker's existing per-binding type table.

**Signature code lens** (`mle::codelens`) — one lens per top-level def showing its inferred signature, e.g. `update : (Model, Msg) => Model`. Whole-`Unknown` defs are skipped.

**Project-aware analysis** — the server now loads the *whole program*, not a single buffer:
- Discovers the entry by walking up for `functor.json` (fallback: the open file as a single-file program — the directory is **not** scanned, so stray `.mle` files nearby can't leak in).
- Overrides every open buffer with its live text (unsaved sibling edits count), maps positions through per-file span bases.
- Answers hover / inlay / codelens / **cross-file go-to-definition** across modules. Hover on `Pieces.ringCube` in `game.mle` now resolves the signature from `pieces.mle`; F12 jumps into the sibling.

## Supporting `mle`-crate additions
- `Project::check_with_types` / `check_with_scopes_and_types` — typed whole-project check.
- `project::load_with_overrides` (override any file's source with a buffer), `load_single_file` (single-file project keeping the real path), `SourceMap::file_by_path`.

## Example
`examples/hello-cubes` is split into `game.mle` + `pieces.mle` (module `Pieces`) as a runnable multi-file sample. Renders **identically** (verified via headless `--fixed-time` capture) and is guarded by a load-clean test.

## Tests
- Unit: inlay / codelens / typed cross-file check / buffer overrides.
- E2e over the **real binary**: cross-file hover + definition against a 2-file `functor.json` project.
- Regression tests for two URI-plumbing bugs found in review: a `percent_decode` panic on a non-char-boundary slice, and non-ASCII path round-tripping in `path_to_uri` (was breaking cross-file goto URIs).

`cargo test -p mle -p mle-lsp` green.

## Review
Ran `/xreview`; Codex was rate-limited so this was the Claude engine only. It found the two URI bugs above (both fixed + regression-tested) plus two LOW robustness gaps (single-file loader now guards protected-namespace stems; open files outside the entry's dir fall back to single-file instead of losing all features). The position-boundary mapping was probed and confirmed correct.

## Known follow-ups (not in this PR)
- **Project-wide diagnostics fan-out** — diagnostics are still single-file here; a change that breaks a sibling doesn't yet squiggle it.
- **Host-aware types via `.mlei` interface files** — `Scene.*`/`Camera.*`/etc. are still `Unknown` to the checker, so signatures touching the engine API show `'a`/`Unknown`. Interface files declaring the host surface would turn those into real types.
- **Caching** — the server reloads+rechecks the project per request; fine for small projects, worth a `didChange`-invalidated cache later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)