### PR TITLE
feat(mle): let-binding type annotations — let name: Type = value

### DIFF
--- a/.claude/skills/mle-language/SKILL.md
+++ b/.claude/skills/mle-language/SKILL.md
@@ -60,7 +60,8 @@ let sizeOf = (s: Shape): String =>
                                               // (they need a catch-all: `| x =>` or `| _ =>`)
 
 let threshold = 10                            // top-level let; ints/floats are all Float (f64)
-let origin = { x: 0.0, y: 0.0 }               // record literal
+let origin: Position = { x: 0.0, y: 0.0 }     // OPTIONAL binding annotation `let name: Type = …`
+                                              //   (checked against the value; also on `let … in`)
 let scores = [1.0, 2.0, 3.0]                  // list literal; [x, ..xs] prepends
 let sumList = (xs: List<Float>): Float =>     // list PATTERNS: [] / [a,b] / [h, ..t]
   match xs with

--- a/mle/examples/functions.ast
+++ b/mle/examples/functions.ast
@@ -38,6 +38,7 @@ Program {
         Let(
             LetDecl {
                 name: "add",
+                ty: None,
                 value: Expr {
                     kind: Lambda {
                         params: [
@@ -102,6 +103,7 @@ Program {
         Let(
             LetDecl {
                 name: "average",
+                ty: None,
                 value: Expr {
                     kind: Lambda {
                         params: [
@@ -160,6 +162,7 @@ Program {
         Let(
             LetDecl {
                 name: "total",
+                ty: None,
                 value: Expr {
                     kind: Lambda {
                         params: [
@@ -242,6 +245,7 @@ Program {
         Let(
             LetDecl {
                 name: "bestTotal",
+                ty: None,
                 value: Expr {
                     kind: Lambda {
                         params: [
@@ -355,6 +359,7 @@ Program {
         Let(
             LetDecl {
                 name: "isWinner",
+                ty: None,
                 value: Expr {
                     kind: Lambda {
                         params: [
@@ -416,6 +421,7 @@ Program {
         Let(
             LetDecl {
                 name: "debug",
+                ty: None,
                 value: Expr {
                     kind: Bool(
                         false,
@@ -428,6 +434,7 @@ Program {
         Let(
             LetDecl {
                 name: "main",
+                ty: None,
                 value: Expr {
                     kind: Lambda {
                         params: [],

--- a/mle/examples/functions.ir
+++ b/mle/examples/functions.ir
@@ -39,6 +39,7 @@ Module {
         Def {
             id: d1,
             name: "add",
+            ty: None,
             value: Expr {
                 id: e3,
                 kind: Lambda {
@@ -106,6 +107,7 @@ Module {
         Def {
             id: d2,
             name: "average",
+            ty: None,
             value: Expr {
                 id: e9,
                 kind: Lambda {
@@ -169,6 +171,7 @@ Module {
         Def {
             id: d3,
             name: "total",
+            ty: None,
             value: Expr {
                 id: e16,
                 kind: Lambda {
@@ -248,6 +251,7 @@ Module {
         Def {
             id: d4,
             name: "bestTotal",
+            ty: None,
             value: Expr {
                 id: e26,
                 kind: Lambda {
@@ -368,6 +372,7 @@ Module {
         Def {
             id: d5,
             name: "isWinner",
+            ty: None,
             value: Expr {
                 id: e32,
                 kind: Lambda {
@@ -432,6 +437,7 @@ Module {
         Def {
             id: d6,
             name: "debug",
+            ty: None,
             value: Expr {
                 id: e33,
                 kind: Bool(
@@ -444,6 +450,7 @@ Module {
         Def {
             id: d7,
             name: "main",
+            ty: None,
             value: Expr {
                 id: e47,
                 kind: Lambda {

--- a/mle/examples/lists.ast
+++ b/mle/examples/lists.ast
@@ -3,6 +3,7 @@ Program {
         Let(
             LetDecl {
                 name: "sum",
+                ty: None,
                 value: Expr {
                     kind: Lambda {
                         params: [
@@ -132,6 +133,7 @@ Program {
         Let(
             LetDecl {
                 name: "firstOr",
+                ty: None,
                 value: Expr {
                     kind: Lambda {
                         params: [
@@ -245,6 +247,7 @@ Program {
         Let(
             LetDecl {
                 name: "pair",
+                ty: None,
                 value: Expr {
                     kind: Lambda {
                         params: [
@@ -380,6 +383,7 @@ Program {
         Let(
             LetDecl {
                 name: "main",
+                ty: None,
                 value: Expr {
                     kind: Lambda {
                         params: [],
@@ -388,6 +392,7 @@ Program {
                             kind: Let {
                                 mutable: false,
                                 name: "xs",
+                                ty: None,
                                 value: Expr {
                                     kind: List(
                                         [

--- a/mle/examples/lists.ir
+++ b/mle/examples/lists.ir
@@ -4,6 +4,7 @@ Module {
         Def {
             id: d0,
             name: "sum",
+            ty: None,
             value: Expr {
                 id: e8,
                 kind: Lambda {
@@ -139,6 +140,7 @@ Module {
         Def {
             id: d1,
             name: "firstOr",
+            ty: None,
             value: Expr {
                 id: e13,
                 kind: Lambda {
@@ -257,6 +259,7 @@ Module {
         Def {
             id: d2,
             name: "pair",
+            ty: None,
             value: Expr {
                 id: e22,
                 kind: Lambda {
@@ -400,6 +403,7 @@ Module {
         Def {
             id: d3,
             name: "main",
+            ty: None,
             value: Expr {
                 id: e44,
                 kind: Lambda {
@@ -411,6 +415,7 @@ Module {
                             binding: b10,
                             name: "xs",
                             mutable: false,
+                            ty: None,
                             value: Expr {
                                 id: e26,
                                 kind: List(

--- a/mle/examples/pure_pipeline.ast
+++ b/mle/examples/pure_pipeline.ast
@@ -3,6 +3,7 @@ Program {
         Let(
             LetDecl {
                 name: "threshold",
+                ty: None,
                 value: Expr {
                     kind: Number(
                         10.0,
@@ -15,6 +16,7 @@ Program {
         Let(
             LetDecl {
                 name: "isHigh",
+                ty: None,
                 value: Expr {
                     kind: Lambda {
                         params: [
@@ -68,6 +70,7 @@ Program {
         Let(
             LetDecl {
                 name: "describe",
+                ty: None,
                 value: Expr {
                     kind: Lambda {
                         params: [
@@ -133,6 +136,7 @@ Program {
         Let(
             LetDecl {
                 name: "normalized",
+                ty: None,
                 value: Expr {
                     kind: Lambda {
                         params: [
@@ -188,6 +192,7 @@ Program {
         Let(
             LetDecl {
                 name: "report",
+                ty: None,
                 value: Expr {
                     kind: Lambda {
                         params: [
@@ -279,6 +284,7 @@ Program {
         Let(
             LetDecl {
                 name: "main",
+                ty: None,
                 value: Expr {
                     kind: Lambda {
                         params: [],

--- a/mle/examples/pure_pipeline.ir
+++ b/mle/examples/pure_pipeline.ir
@@ -4,6 +4,7 @@ Module {
         Def {
             id: d0,
             name: "threshold",
+            ty: None,
             value: Expr {
                 id: e0,
                 kind: Number(
@@ -16,6 +17,7 @@ Module {
         Def {
             id: d1,
             name: "isHigh",
+            ty: None,
             value: Expr {
                 id: e4,
                 kind: Lambda {
@@ -70,6 +72,7 @@ Module {
         Def {
             id: d2,
             name: "describe",
+            ty: None,
             value: Expr {
                 id: e11,
                 kind: Lambda {
@@ -141,6 +144,7 @@ Module {
         Def {
             id: d3,
             name: "normalized",
+            ty: None,
             value: Expr {
                 id: e17,
                 kind: Lambda {
@@ -201,6 +205,7 @@ Module {
         Def {
             id: d4,
             name: "report",
+            ty: None,
             value: Expr {
                 id: e27,
                 kind: Lambda {
@@ -297,6 +302,7 @@ Module {
         Def {
             id: d5,
             name: "main",
+            ty: None,
             value: Expr {
                 id: e34,
                 kind: Lambda {

--- a/mle/examples/records.ast
+++ b/mle/examples/records.ast
@@ -61,6 +61,7 @@ Program {
         Let(
             LetDecl {
                 name: "origin",
+                ty: None,
                 value: Expr {
                     kind: Record(
                         [
@@ -94,6 +95,7 @@ Program {
         Let(
             LetDecl {
                 name: "move",
+                ty: None,
                 value: Expr {
                     kind: Lambda {
                         params: [
@@ -258,6 +260,7 @@ Program {
         Let(
             LetDecl {
                 name: "delta",
+                ty: None,
                 value: Expr {
                     kind: Lambda {
                         params: [
@@ -383,6 +386,7 @@ Program {
         Let(
             LetDecl {
                 name: "mirror",
+                ty: None,
                 value: Expr {
                     kind: Lambda {
                         params: [
@@ -462,6 +466,7 @@ Program {
         Let(
             LetDecl {
                 name: "isOrigin",
+                ty: None,
                 value: Expr {
                     kind: Lambda {
                         params: [
@@ -519,6 +524,7 @@ Program {
         Let(
             LetDecl {
                 name: "nudge",
+                ty: None,
                 value: Expr {
                     kind: Lambda {
                         params: [
@@ -595,6 +601,7 @@ Program {
         Let(
             LetDecl {
                 name: "main",
+                ty: None,
                 value: Expr {
                     kind: Lambda {
                         params: [],
@@ -603,6 +610,7 @@ Program {
                             kind: Let {
                                 mutable: false,
                                 name: "moved",
+                                ty: None,
                                 value: Expr {
                                     kind: Call {
                                         callee: Expr {

--- a/mle/examples/records.ir
+++ b/mle/examples/records.ir
@@ -61,6 +61,7 @@ Module {
         Def {
             id: d2,
             name: "origin",
+            ty: None,
             value: Expr {
                 id: e2,
                 kind: Record(
@@ -96,6 +97,7 @@ Module {
         Def {
             id: d3,
             name: "move",
+            ty: None,
             value: Expr {
                 id: e18,
                 kind: Lambda {
@@ -272,6 +274,7 @@ Module {
         Def {
             id: d4,
             name: "delta",
+            ty: None,
             value: Expr {
                 id: e30,
                 kind: Lambda {
@@ -406,6 +409,7 @@ Module {
         Def {
             id: d5,
             name: "mirror",
+            ty: None,
             value: Expr {
                 id: e37,
                 kind: Lambda {
@@ -490,6 +494,7 @@ Module {
         Def {
             id: d6,
             name: "isOrigin",
+            ty: None,
             value: Expr {
                 id: e42,
                 kind: Lambda {
@@ -551,6 +556,7 @@ Module {
         Def {
             id: d7,
             name: "nudge",
+            ty: None,
             value: Expr {
                 id: e49,
                 kind: Lambda {
@@ -632,6 +638,7 @@ Module {
         Def {
             id: d8,
             name: "main",
+            ty: None,
             value: Expr {
                 id: e61,
                 kind: Lambda {
@@ -643,6 +650,7 @@ Module {
                             binding: b8,
                             name: "moved",
                             mutable: false,
+                            ty: None,
                             value: Expr {
                                 id: e56,
                                 kind: Call {

--- a/mle/examples/shapes.ast
+++ b/mle/examples/shapes.ast
@@ -58,6 +58,7 @@ Program {
         Let(
             LetDecl {
                 name: "pi",
+                ty: None,
                 value: Expr {
                     kind: Number(
                         3.14159,
@@ -70,6 +71,7 @@ Program {
         Let(
             LetDecl {
                 name: "area",
+                ty: None,
                 value: Expr {
                     kind: Lambda {
                         params: [
@@ -230,6 +232,7 @@ Program {
         Let(
             LetDecl {
                 name: "isRound",
+                ty: None,
                 value: Expr {
                     kind: Lambda {
                         params: [
@@ -310,6 +313,7 @@ Program {
         Let(
             LetDecl {
                 name: "sizeOf",
+                ty: None,
                 value: Expr {
                     kind: Lambda {
                         params: [
@@ -413,6 +417,7 @@ Program {
         Let(
             LetDecl {
                 name: "describe",
+                ty: None,
                 value: Expr {
                     kind: Lambda {
                         params: [
@@ -666,6 +671,7 @@ Program {
         Let(
             LetDecl {
                 name: "shapes",
+                ty: None,
                 value: Expr {
                     kind: List(
                         [
@@ -735,6 +741,7 @@ Program {
         Let(
             LetDecl {
                 name: "main",
+                ty: None,
                 value: Expr {
                     kind: Lambda {
                         params: [],

--- a/mle/examples/shapes.ir
+++ b/mle/examples/shapes.ir
@@ -59,6 +59,7 @@ Module {
         Def {
             id: d1,
             name: "pi",
+            ty: None,
             value: Expr {
                 id: e0,
                 kind: Number(
@@ -71,6 +72,7 @@ Module {
         Def {
             id: d2,
             name: "area",
+            ty: None,
             value: Expr {
                 id: e12,
                 kind: Lambda {
@@ -239,6 +241,7 @@ Module {
         Def {
             id: d3,
             name: "isRound",
+            ty: None,
             value: Expr {
                 id: e17,
                 kind: Lambda {
@@ -323,6 +326,7 @@ Module {
         Def {
             id: d4,
             name: "sizeOf",
+            ty: None,
             value: Expr {
                 id: e26,
                 kind: Lambda {
@@ -432,6 +436,7 @@ Module {
         Def {
             id: d5,
             name: "describe",
+            ty: None,
             value: Expr {
                 id: e52,
                 kind: Lambda {
@@ -702,6 +707,7 @@ Module {
         Def {
             id: d6,
             name: "shapes",
+            ty: None,
             value: Expr {
                 id: e61,
                 kind: List(
@@ -776,6 +782,7 @@ Module {
         Def {
             id: d7,
             name: "main",
+            ty: None,
             value: Expr {
                 id: e68,
                 kind: Lambda {

--- a/mle/examples/strings.ast
+++ b/mle/examples/strings.ast
@@ -3,6 +3,7 @@ Program {
         Let(
             LetDecl {
                 name: "encode",
+                ty: None,
                 value: Expr {
                     kind: Lambda {
                         params: [
@@ -199,6 +200,7 @@ Program {
         Let(
             LetDecl {
                 name: "snapshot",
+                ty: None,
                 value: Expr {
                     kind: Lambda {
                         params: [
@@ -266,6 +268,7 @@ Program {
         Let(
             LetDecl {
                 name: "parseRow",
+                ty: None,
                 value: Expr {
                     kind: Lambda {
                         params: [
@@ -514,6 +517,7 @@ Program {
         Let(
             LetDecl {
                 name: "main",
+                ty: None,
                 value: Expr {
                     kind: Lambda {
                         params: [],
@@ -522,6 +526,7 @@ Program {
                             kind: Let {
                                 mutable: false,
                                 name: "wire",
+                                ty: None,
                                 value: Expr {
                                     kind: Call {
                                         callee: Expr {

--- a/mle/examples/strings.ir
+++ b/mle/examples/strings.ir
@@ -4,6 +4,7 @@ Module {
         Def {
             id: d0,
             name: "encode",
+            ty: None,
             value: Expr {
                 id: e20,
                 kind: Lambda {
@@ -220,6 +221,7 @@ Module {
         Def {
             id: d1,
             name: "snapshot",
+            ty: None,
             value: Expr {
                 id: e25,
                 kind: Lambda {
@@ -291,6 +293,7 @@ Module {
         Def {
             id: d2,
             name: "parseRow",
+            ty: None,
             value: Expr {
                 id: e49,
                 kind: Lambda {
@@ -562,6 +565,7 @@ Module {
         Def {
             id: d3,
             name: "main",
+            ty: None,
             value: Expr {
                 id: e73,
                 kind: Lambda {
@@ -573,6 +577,7 @@ Module {
                             binding: b8,
                             name: "wire",
                             mutable: false,
+                            ty: None,
                             value: Expr {
                                 id: e63,
                                 kind: Call {

--- a/mle/examples/tuples.ast
+++ b/mle/examples/tuples.ast
@@ -38,6 +38,7 @@ Program {
         Let(
             LetDecl {
                 name: "minMax",
+                ty: None,
                 value: Expr {
                     kind: Lambda {
                         params: [
@@ -184,6 +185,7 @@ Program {
         Let(
             LetDecl {
                 name: "span",
+                ty: None,
                 value: Expr {
                     kind: Lambda {
                         params: [
@@ -290,6 +292,7 @@ Program {
         Let(
             LetDecl {
                 name: "describe",
+                ty: None,
                 value: Expr {
                     kind: Lambda {
                         params: [
@@ -417,6 +420,7 @@ Program {
         Let(
             LetDecl {
                 name: "step",
+                ty: None,
                 value: Expr {
                     kind: Lambda {
                         params: [
@@ -544,6 +548,7 @@ Program {
         Let(
             LetDecl {
                 name: "main",
+                ty: None,
                 value: Expr {
                     kind: Lambda {
                         params: [],

--- a/mle/examples/tuples.ir
+++ b/mle/examples/tuples.ir
@@ -39,6 +39,7 @@ Module {
         Def {
             id: d1,
             name: "minMax",
+            ty: None,
             value: Expr {
                 id: e10,
                 kind: Lambda {
@@ -191,6 +192,7 @@ Module {
         Def {
             id: d2,
             name: "span",
+            ty: None,
             value: Expr {
                 id: e19,
                 kind: Lambda {
@@ -303,6 +305,7 @@ Module {
         Def {
             id: d3,
             name: "describe",
+            ty: None,
             value: Expr {
                 id: e28,
                 kind: Lambda {
@@ -438,6 +441,7 @@ Module {
         Def {
             id: d4,
             name: "step",
+            ty: None,
             value: Expr {
                 id: e38,
                 kind: Lambda {
@@ -574,6 +578,7 @@ Module {
         Def {
             id: d5,
             name: "main",
+            ty: None,
             value: Expr {
                 id: e65,
                 kind: Lambda {

--- a/mle/src/ast.rs
+++ b/mle/src/ast.rs
@@ -29,10 +29,13 @@ pub struct OpenDecl {
     pub span: Span,
 }
 
-/// `let name = expr` — the expr may be a lambda (`let f = (a, b) => …`).
+/// `let name = expr` or `let name: Type = expr` — the expr may be a lambda
+/// (`let f = (a, b) => …`). An optional binding type annotation (`ty`) is
+/// checked against the value (see `crate::types`).
 #[derive(Debug)]
 pub struct LetDecl {
     pub name: String,
+    pub ty: Option<TypeName>,
     pub value: Expr,
     pub span: Span,
 }
@@ -133,6 +136,7 @@ pub enum ExprKind {
     Let {
         mutable: bool,
         name: String,
+        ty: Option<TypeName>,
         value: Box<Expr>,
         body: Box<Expr>,
     },

--- a/mle/src/ir.rs
+++ b/mle/src/ir.rs
@@ -85,11 +85,14 @@ pub struct TypeDef {
     pub span: Span,
 }
 
-/// A lowered top-level `let`. `name` is the def's stable identity.
+/// A lowered top-level `let`. `name` is the def's stable identity. `ty` is the
+/// optional binding annotation (`let name: Type = …`), carried symbolically
+/// for the checker.
 #[derive(Debug)]
 pub struct Def {
     pub id: DefId,
     pub name: String,
+    pub ty: Option<TypeName>,
     pub value: Expr,
     pub span: Span,
 }
@@ -142,11 +145,12 @@ pub enum ExprKind {
         binding: BindingId,
         name: String,
     },
-    /// `let [mut] name = value in body`.
+    /// `let [mut] name [: ty] = value in body`.
     Let {
         binding: BindingId,
         name: String,
         mutable: bool,
+        ty: Option<TypeName>,
         value: Box<Expr>,
         body: Box<Expr>,
     },

--- a/mle/src/lower.rs
+++ b/mle/src/lower.rs
@@ -377,6 +377,7 @@ qualify uses (`{prev}.{name}` / `{}.{name}`)",
                 defs.push(Def {
                     id,
                     name: lowerer.self_qualify(&decl.name),
+                    ty: decl.ty,
                     value: lowerer.expr(decl.value)?,
                     span: decl.span,
                 });
@@ -666,6 +667,7 @@ impl Lowerer<'_> {
             ast::ExprKind::Let {
                 mutable,
                 name,
+                ty,
                 value,
                 body,
             } => {
@@ -684,6 +686,7 @@ impl Lowerer<'_> {
                     binding,
                     name,
                     mutable,
+                    ty,
                     value,
                     body: Box::new(body?),
                 }

--- a/mle/src/parser.rs
+++ b/mle/src/parser.rs
@@ -170,6 +170,18 @@ impl Parser {
         })
     }
 
+    /// An optional `: Type` binding annotation between a `let` binder name and
+    /// its `=`. A binding is not in return position, so a function type here
+    /// needs no extra parens: `let f: (Float) => Float = …`.
+    fn opt_binding_annotation(&mut self) -> Result<Option<TypeName>, ParseError> {
+        if self.peek_kind() == &TokenKind::Colon {
+            self.bump();
+            Ok(Some(self.type_name()?))
+        } else {
+            Ok(None)
+        }
+    }
+
     fn let_decl(&mut self) -> Result<LetDecl, ParseError> {
         let kw = self.bump();
         if self.peek_kind() == &TokenKind::Mut {
@@ -181,10 +193,16 @@ rebind surface); `mut` is for `let mut … in …` inside a function"
             });
         }
         let (name, _) = self.expect_ident("a name after `let`")?;
+        let ty = self.opt_binding_annotation()?;
         self.expect(TokenKind::Eq, "`=`")?;
         let value = self.expr()?;
         let span = kw.span.to(value.span);
-        Ok(LetDecl { name, value, span })
+        Ok(LetDecl {
+            name,
+            ty,
+            value,
+            span,
+        })
     }
 
     fn type_decl(&mut self) -> Result<TypeDecl, ParseError> {
@@ -522,6 +540,7 @@ rebind surface); `mut` is for `let mut … in …` inside a function"
             });
         }
         let (name, _) = self.expect_ident("a name after `let`")?;
+        let ty = self.opt_binding_annotation()?;
         self.expect(TokenKind::Eq, "`=`")?;
         let value = self.expr()?;
         self.expect(TokenKind::In, "`in`")?;
@@ -531,6 +550,7 @@ rebind surface); `mut` is for `let mut … in …` inside a function"
             kind: ExprKind::Let {
                 mutable,
                 name,
+                ty,
                 value: Box::new(value),
                 body: Box::new(body),
             },

--- a/mle/src/types.rs
+++ b/mle/src/types.rs
@@ -549,29 +549,41 @@ fn check_impl(
 
     // Placeholder signatures: annotation-derived, with FRESH inference
     // variables where nothing is annotated (B7 — this is what makes
-    // unannotated code inferable instead of Unknown). Resolution is silent;
-    // the body pass resolves the same annotations again and reports once.
+    // unannotated code inferable instead of Unknown). Param/return annotation
+    // resolution is silent here (the body pass resolves them again and reports
+    // once); a whole-binding `def.ty` is the exception — resolved once, so it
+    // reports here.
     for def in &module.defs {
         checker.annot_vars.clear();
-        let ty = match &def.value.kind {
-            ExprKind::Lambda { params, ret, .. } => {
-                // Param names, so a partial application of this def can name
-                // the arguments it is still missing.
-                checker.def_param_names.insert(
-                    def.name.clone(),
-                    params.iter().map(|p| p.name.clone()).collect(),
-                );
-                let params = params
-                    .iter()
-                    .map(|p| checker.resolve_annotation(p.ty.as_ref(), false))
-                    .collect();
-                let ret = checker.resolve_annotation(ret.as_ref(), false);
-                Type::Fn(params, Box::new(ret))
-            }
-            ExprKind::Number(_) => Type::Float,
-            ExprKind::String(_) => Type::String,
-            ExprKind::Bool(_) => Type::Bool,
-            _ => checker.fresh(),
+        // Param names, so a partial application of this def can name the
+        // arguments it is still missing — recorded even for annotated defs.
+        if let ExprKind::Lambda { params, .. } = &def.value.kind {
+            checker.def_param_names.insert(
+                def.name.clone(),
+                params.iter().map(|p| p.name.clone()).collect(),
+            );
+        }
+        let ty = match &def.ty {
+            // A binding annotation IS the signature (`let f: (Float) => Float
+            // = …`); the body pass checks the value against it. Resolved with
+            // `report:true` — unlike param/return annotations (re-resolved in
+            // the body pass), `def.ty` is resolved ONCE here, so its own
+            // diagnostics (e.g. an arity error) must be emitted now or lost.
+            Some(annot) => checker.resolve_type(annot, true),
+            None => match &def.value.kind {
+                ExprKind::Lambda { params, ret, .. } => {
+                    let params = params
+                        .iter()
+                        .map(|p| checker.resolve_annotation(p.ty.as_ref(), false))
+                        .collect();
+                    let ret = checker.resolve_annotation(ret.as_ref(), false);
+                    Type::Fn(params, Box::new(ret))
+                }
+                ExprKind::Number(_) => Type::Float,
+                ExprKind::String(_) => Type::String,
+                ExprKind::Bool(_) => Type::Bool,
+                _ => checker.fresh(),
+            },
         };
         checker.globals.insert(def.name.clone(), ty);
     }
@@ -597,13 +609,20 @@ fn check_impl(
                 .get(&def.name)
                 .cloned()
                 .unwrap_or(Type::Unknown);
-            let inferred = checker.infer(&def.value);
-            checker.unify(
-                &inferred,
-                &placeholder,
-                def.value.span,
-                &format!("`{}`", def.name),
-            );
+            if def.ty.is_some() {
+                // Check the value against its binding annotation — flows the
+                // type in (unannotated params/returns get it) and checks
+                // literals structurally (`let m: Model = { wrong }`).
+                checker.expect(&def.value, &placeholder, &format!("`{}`", def.name));
+            } else {
+                let inferred = checker.infer(&def.value);
+                checker.unify(
+                    &inferred,
+                    &placeholder,
+                    def.value.span,
+                    &format!("`{}`", def.name),
+                );
+            }
         }
         for &i in &group {
             let def = &module.defs[i];
@@ -1232,6 +1251,38 @@ the type: `type Name<{name}> = …`"
                 }
                 self.expr_types.insert(expr.id.raw(), expected.clone());
             }
+            // A lambda against a known function type: push the expected param
+            // types INTO the body (so `let f: (Position) => Float = (p) => p.x`
+            // checks `p.x`), and check the body against the expected return.
+            // A param/return that also carries its own annotation must agree.
+            (ExprKind::Lambda { params, ret, body }, Type::Fn(exp_params, exp_ret))
+                if params.len() == exp_params.len() =>
+            {
+                for (param, exp) in params.iter().zip(exp_params) {
+                    let ty = if param.ty.is_some() {
+                        let declared = self.resolve_annotation(param.ty.as_ref(), true);
+                        self.unify(
+                            &declared,
+                            exp,
+                            param.span,
+                            &format!("parameter `{}`", param.name),
+                        );
+                        declared
+                    } else {
+                        exp.clone()
+                    };
+                    self.locals.insert(param.binding.0, ty);
+                }
+                let ret_ty = if ret.is_some() {
+                    let declared = self.resolve_annotation(ret.as_ref(), true);
+                    self.unify(&declared, exp_ret, body.span, "return value");
+                    declared
+                } else {
+                    (**exp_ret).clone()
+                };
+                self.expect(body, &ret_ty, "return value");
+                self.expr_types.insert(expr.id.raw(), expected.clone());
+            }
             _ => {
                 let got = self.infer(expr);
                 let expected = self.zonk(expected);
@@ -1509,11 +1560,23 @@ missing {missing}. Did you forget an argument?"
                 .unwrap_or(Type::Unknown),
             ExprKind::Let {
                 binding,
+                name,
+                ty,
                 value,
                 body,
                 ..
             } => {
-                let value_ty = self.infer(value);
+                let value_ty = match ty {
+                    // An annotated let-in binding: check the value against it
+                    // (flows in, checks literals), then the binder has that
+                    // type.
+                    Some(annot) => {
+                        let expected = self.resolve_type(annot, true);
+                        self.expect(value, &expected, &format!("`{name}`"));
+                        expected
+                    }
+                    None => self.infer(value),
+                };
                 self.locals.insert(binding.0, value_ty);
                 self.infer(body)
             }

--- a/mle/tests/check.rs
+++ b/mle/tests/check.rs
@@ -356,8 +356,10 @@ fn error_filter_predicate_must_return_bool() {
     assert_eq!(
         message,
         // B7: the element type flows from `xs` into the predicate's
-        // signature — Float, not Unknown. Subject-last: the predicate is arg 1.
-        "argument 1 of `List.filter`: expected (Float) => Bool, got (Float) => Float"
+        // signature — Float, not Unknown. The expected function type flows
+        // INTO the predicate, so the mismatch localizes to its return value
+        // rather than the whole callback (mlei 2b `(Lambda, Fn)` checking).
+        "return value: expected Bool, got Float"
     );
 }
 
@@ -1250,16 +1252,19 @@ fn function_type_annotation_on_a_parameter() {
     assert_clean("let twice = (f: (Float) => Float, x: Float): Float => f(f(x))");
 }
 
-/// A function-typed argument is checked against its declared signature.
+/// A function-typed argument is checked against its declared signature — the
+/// expected `(Float) => Float` flows into the lambda, so a `(String) => String`
+/// argument flags both its param and its return precisely.
 #[test]
 fn function_typed_argument_is_checked() {
-    let (message, _, _) = single_diag(
+    let diags = check_src(
         "let apply = (f: (Float) => Float, x: Float): Float => f(x)\n\
          let bad = () => apply((s: String): String => s, 1.0)",
     );
+    let msgs: Vec<&str> = diags.iter().map(|(m, _, _)| m.as_str()).collect();
     assert!(
-        message.contains("expected") && message.contains("=>"),
-        "unexpected: {message}"
+        msgs.iter().any(|m| m.contains("parameter `s`") && m.contains("expected Float")),
+        "want a param mismatch, got {msgs:?}"
     );
 }
 
@@ -1306,4 +1311,69 @@ fn empty_parens_require_an_arrow() {
         mle::parse("let f = (x: ()): Float => 0.0").is_err(),
         "`()` alone is not a type"
     );
+}
+
+// ── let-binding type annotations (mlei slice 2b) ─────────────────────────
+
+/// A top-level binding annotation checks against the value and flows into an
+/// unannotated body: `let f: (Float) => Float = (x) => …` gives `x: Float`.
+#[test]
+fn top_level_binding_annotation() {
+    assert_clean("let x: Float = 3.0");
+    assert_clean("let f: (Float) => Float = (x) => x + 1.0");
+    assert_clean("type M = { a: Bool }\nlet m: M = { a: true }");
+}
+
+/// A binding annotation is enforced — a simple, a record-literal, and a
+/// function return-type mismatch all error.
+#[test]
+fn binding_annotation_mismatch_is_flagged() {
+    let (message, _, _) = single_diag("let x: Bool = 3.0");
+    assert_eq!(message, "`x`: expected Bool, got Float");
+
+    let (message, _, _) = single_diag("type M = { a: Bool }\nlet m: M = { a: 3.0 }");
+    assert_eq!(message, "field `a` of `M`: expected Bool, got Float");
+
+    // The annotation flows `x: Float` in and pushes the expected return into
+    // the body, so the mismatch localizes to the return value.
+    let (message, _, _) = single_diag("let f: (Float) => Bool = (x) => x");
+    assert_eq!(message, "return value: expected Bool, got Float");
+}
+
+/// let-in bindings take annotations too, checked the same way.
+#[test]
+fn let_in_binding_annotation() {
+    assert_clean("let g = () => let y: Float = 3.0 in y + 1.0");
+    let (message, _, _) = single_diag("let g = () => let y: Bool = 3.0 in y");
+    assert_eq!(message, "`y`: expected Bool, got Float");
+}
+
+/// A `mut` let-in binding can be annotated.
+#[test]
+fn annotated_mut_binding() {
+    assert_clean("let f = (n: Float): Float => let mut acc: Float = n in acc := acc + 1.0; acc");
+}
+
+/// An invalid binding annotation (here a `List` arity error) reports at the
+/// top level — not only inside `let … in` (mlei 2b review: was swallowed
+/// because a top-level `def.ty` is resolved just once, silently).
+#[test]
+fn invalid_top_level_annotation_reports() {
+    let (message, _, _) = single_diag("let xs: List = [1.0, 2.0]");
+    assert!(
+        message.contains('`') && message.to_lowercase().contains("type argument"),
+        "want an arity diagnostic, got {message:?}"
+    );
+}
+
+/// A binding annotation's param types flow into an unannotated lambda body,
+/// so a bad field access against the declared param type is caught (mlei 2b
+/// review Finding 2 — the `(Lambda, Fn)` checking path).
+#[test]
+fn binding_annotation_flows_into_body() {
+    let (message, _, _) = single_diag(
+        "type Position = { x: Float }\n\
+         let getX: (Position) => Float = (p) => p.z",
+    );
+    assert_eq!(message, "`Position` has no field `z`");
 }


### PR DESCRIPTION
Bindings couldn't carry a type — `let x: Float = 3.0` and `let f: (Float) => Float = (x) => x` both errored at the `:`. This adds the annotation to both top-level `let`s and `let … in`, checked against the value.

**mlei slice 2b** (`docs/mlei.md`) — the implementation-side twin of the `val` signatures coming in 2d, and the thing that makes `let update: (Model, Msg) => Model = …` writable *and* checkable.

## What it does
- **AST/IR:** `ty: Option<TypeName>` on `LetDecl` / `Def` / the `Let` node, carried symbolically through lowering (like param annotations).
- **Parser:** an optional `: Type` between a binder name and `=`. A binding isn't in return position, so a function type here needs no extra parens.
- **Checker:** an annotated top-level def's annotation *is* its seeded signature (so callers see it), and the body is checked against it. A new `(Lambda, Fn)` case in `expect` pushes the expected param types **into the body** — so `let getX: (Position) => Float = (p) => p.x` actually checks `p.x`, and mismatches localize to the offending param/return. `let … in` annotations check the same way.

Surfaces everywhere: hover, inlay, and **codelens** all show the annotated type (`update : (Model, Float) => Model`), nominal types included.

## Bonus
The `(Lambda, Fn)` flow also sharpens **argument**-lambda diagnostics — a predicate passed to `List.filter` now flags its *return value* (`expected Bool, got Float`) instead of the whole callback.

## Review
`/xreview` (Claude engine — Codex rate-limited) found two real issues, **both fixed and tested**:
1. **High:** invalid top-level annotations were swallowed — `def.ty` is resolved once, silently. Now resolved with `report:true` (an arity error like `let xs: List = …` reports, matching the `let … in` path).
2. **Medium:** the annotation didn't actually flow into an unannotated lambda body — the `(Lambda, Fn)` case above delivers it, turning "check the value against the signature" from half-done into real.

## Tests / verification
- New: top-level + let-in annotations, simple/record/return mismatches, annotated `mut`, invalid-annotation reporting, param-flow-into-body.
- `cargo test -p mle -p mle-lsp` green (111 check tests); goldens regenerated (the new `ty: None` field); LSP hover/codelens resolve the real type; skill updated.

## Next (per `docs/mlei.md`)
2c abstract types (`type SceneNode`) → 2d `val`/`.mlei`/interface-only modules → 2e host prelude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)