### PR TITLE
feat(mle): abstract (opaque) types — type SceneNode

### DIFF
--- a/.claude/skills/mle-language/SKILL.md
+++ b/.claude/skills/mle-language/SKILL.md
@@ -44,6 +44,10 @@ type Shape =                                  // variant types (ADTs); nominal l
   | Rect(w: Float, h: Float)                  // fields named in the decl…
   | Point                                     // …nullary ctor: no parens, ever
 
+type SceneNode                                // ABSTRACT type (no `= body`): an opaque nominal —
+                                              //   no fields, no constructor; host code makes its
+                                              //   values. Use it in annotations (`(n: SceneNode)`).
+
 let c = Circle(2.0)                           // …but ctors are CALLED positionally
 let shapes = [c, Rect(3.0, 4.0), Point]       // bare Point IS the value
 

--- a/mle/src/ast.rs
+++ b/mle/src/ast.rs
@@ -53,12 +53,15 @@ pub struct TypeDecl {
     pub span: Span,
 }
 
-/// What a `type` declares: a record shape, or one-or-more variant
-/// constructors (each `|`-led, including the first).
+/// What a `type` declares: a record shape, one-or-more variant constructors
+/// (each `|`-led, including the first), or — with no `= body` — an ABSTRACT
+/// (opaque) nominal type: a named handle with no fields and no constructors,
+/// produced/consumed only by host functions (`type SceneNode`).
 #[derive(Debug)]
 pub enum TypeBody {
     Record(Vec<FieldTy>),
     Variants(Vec<VariantDecl>),
+    Abstract,
 }
 
 /// One `| Ctor(name: Type, …)` / `| Ctor` alternative of a variant type.

--- a/mle/src/goto.rs
+++ b/mle/src/goto.rs
@@ -251,6 +251,8 @@ fn type_body_fields(body: &TypeBody) -> Vec<&TypeName> {
             .iter()
             .flat_map(|VariantDecl { fields, .. }| fields.iter().map(|f| &f.ty))
             .collect(),
+        // An abstract type has no annotated fields.
+        TypeBody::Abstract => Vec::new(),
     }
 }
 

--- a/mle/src/lower.rs
+++ b/mle/src/lower.rs
@@ -537,6 +537,8 @@ impl Lowerer<'_> {
                 .collect()
         };
         Ok(match body {
+            // No fields to canonicalize — an abstract type is opaque.
+            ast::TypeBody::Abstract => ast::TypeBody::Abstract,
             ast::TypeBody::Record(fields) => ast::TypeBody::Record(canon_fields(self, fields)?),
             ast::TypeBody::Variants(variants) => ast::TypeBody::Variants(
                 variants

--- a/mle/src/parser.rs
+++ b/mle/src/parser.rs
@@ -207,7 +207,8 @@ rebind surface); `mut` is for `let mut … in …` inside a function"
 
     fn type_decl(&mut self) -> Result<TypeDecl, ParseError> {
         let kw = self.bump();
-        let (name, _) = self.expect_ident("a name after `type`")?;
+        let (name, name_span) = self.expect_ident("a name after `type`")?;
+        let mut end_span = name_span;
         // Optional type parameters: `type Box<a, b> = …` — lowercase names
         // (uppercase would shadow declared types; the checker enforces the
         // case, the grammar just collects idents).
@@ -241,9 +242,25 @@ rebind surface); `mut` is for `let mut … in …` inside a function"
                     break;
                 }
             }
-            self.expect(TokenKind::Gt, "`,` or `>`")?;
+            end_span = self.expect(TokenKind::Gt, "`,` or `>`")?.span;
         }
-        self.expect(TokenKind::Eq, "`=`")?;
+        // No `= body` → an ABSTRACT type: an opaque nominal (`type SceneNode`),
+        // no fields or constructors — host code produces/consumes its values.
+        if self.peek_kind() != &TokenKind::Eq {
+            // A `{`/`|` here means a forgotten `=` (`type P { … }`), not an
+            // abstract type — keep the targeted diagnostic instead of letting
+            // the body surface as a confusing top-level error.
+            if matches!(self.peek_kind(), TokenKind::LBrace | TokenKind::Pipe) {
+                return self.error("`=` before the type body");
+            }
+            return Ok(TypeDecl {
+                name,
+                params,
+                body: TypeBody::Abstract,
+                span: kw.span.to(end_span),
+            });
+        }
+        self.bump(); // `=`
         match self.peek_kind() {
             TokenKind::LBrace => {
                 self.bump();

--- a/mle/src/types.rs
+++ b/mle/src/types.rs
@@ -499,6 +499,14 @@ fn check_impl(
                     ),
                 );
             }
+            // An opaque nominal: a variant with NO constructors, so
+            // annotations resolve to `Type::Variant` (reusing unify/display)
+            // and its values can only come from host code.
+            TypeBody::Abstract => {
+                checker
+                    .variants
+                    .insert(decl.name.clone(), (decl.params.len(), Vec::new()));
+            }
         }
     }
     checker.in_type_decl = true;
@@ -541,6 +549,8 @@ fn check_impl(
                     );
                 }
             }
+            // Nothing to resolve — an abstract type has no fields or ctors.
+            TypeBody::Abstract => {}
         }
     }
 

--- a/mle/tests/check.rs
+++ b/mle/tests/check.rs
@@ -1377,3 +1377,66 @@ fn binding_annotation_flows_into_body() {
     );
     assert_eq!(message, "`Position` has no field `z`");
 }
+
+// ── abstract (opaque) types (mlei slice 2c) ──────────────────────────────
+
+/// A `type Name` with no body is an opaque nominal: it resolves in
+/// annotations and unifies with itself.
+#[test]
+fn abstract_type_resolves_and_unifies() {
+    assert_clean(
+        "type SceneNode\n\
+         let identity = (n: SceneNode): SceneNode => n\n\
+         let pair = (a: SceneNode, b: SceneNode): SceneNode => a",
+    );
+    // Also usable in a 2b binding annotation and generic position.
+    assert_clean(
+        "type SceneNode\n\
+         let mk = (n: SceneNode): List<SceneNode> => let one: SceneNode = n in [one]",
+    );
+}
+
+/// An abstract type is distinct from every other type — a mismatch is caught.
+#[test]
+fn abstract_type_mismatch_is_flagged() {
+    let (message, _, _) = single_diag("type SceneNode\nlet bad = (n: SceneNode): Float => n");
+    assert_eq!(message, "return value: expected Float, got SceneNode");
+}
+
+/// An abstract type has NO constructor — its values come only from host code,
+/// so naming it as a value is an unresolved name (at lowering).
+#[test]
+fn abstract_type_has_no_constructor() {
+    let program = mle::parse("type SceneNode\nlet bad = () => SceneNode").expect("parse");
+    let err = mle::lower(program).expect_err("SceneNode is a type, not a value");
+    assert!(err.message.contains("SceneNode"), "unexpected: {}", err.message);
+}
+
+/// Abstract types may be generic: `type Handle<a>`.
+#[test]
+fn generic_abstract_type() {
+    assert_clean(
+        "type Handle<a>\n\
+         let use = (h: Handle<Float>): Handle<Float> => h",
+    );
+    // Arity is enforced, like other nominal types.
+    let (message, _, _) = single_diag("type Handle<a>\nlet f = (h: Handle): Float => 0.0");
+    assert!(
+        message.contains("Handle") && message.contains("type argument"),
+        "{message}"
+    );
+}
+
+/// Forgetting `=` on a type decl keeps its targeted diagnostic — it is NOT
+/// silently swallowed as an abstract type (mlei 2c review, Finding 1).
+#[test]
+fn forgotten_type_equals_is_diagnosed() {
+    for src in ["type Point { x: Float }", "type Shape | Circle(r: Float)"] {
+        let err = mle::parse(src).expect_err("a missing `=` should error");
+        assert!(
+            err.message.contains("`=` before the type body"),
+            "unexpected for {src:?}: {}",
+            err.message
+        );
+    }
+}


### PR DESCRIPTION
A `type` declaration with **no `= body`** is now an **abstract (opaque) type**: a named nominal handle with no fields and no constructor, whose values are produced/consumed only by host code.

**mlei slice 2c** (`docs/mlei.md`) — this is how host value types (`SceneNode`, `Camera`, `Frame`, …) get *named*, so `Scene.*` signatures can resolve to real types in 2d/2e instead of `Unknown`.

```mle
type SceneNode                                   // opaque — no body
let cube = (): SceneNode => …                    // usable in annotations (and 2b bindings)
```

## What it does
- **AST:** `TypeBody::Abstract`.
- **Parser:** the type body is now optional; no `=` → abstract. A `{`/`|` after the name stays a *forgotten-`=`* error (targeted diagnostic preserved — a review catch).
- **Checker:** registered as a nominal with **no constructors**, reusing the variant machinery — annotations resolve to `Type::Variant(name, args)`, so unify + display come for free (shows `SceneNode`, not "variant"), and naming it as a value is an unresolved name (only host code makes its values).
- Generic abstract types (`type Handle<a>`) work; arity enforced.

Verified: distinct abstract types don't unify; `Box<Float>` ≠ `Box<String>`; `match` on one only checks with a catch-all (no exhaustiveness panic); cross-module `Utils.SceneNode` resolves; a name clash is a load error.

## Review
`/xreview` (Claude engine — Codex rate-limited) confirmed the representation choice is sound and found **one Medium** — the forgotten-`=` typo (`type Point { … }`) was being swallowed as an abstract type + a confusing downstream error. **Fixed and regression-tested**: it now reports `expected \`=\` before the type body` at the `{`/`|`.

## Tests
Resolves/unifies, mismatch, no constructor, generic + arity, forgotten-`=`. `cargo test -p mle -p mle-lsp` green (116 check tests); no golden churn; skill updated.

## Next
2d — `val` signatures + `.mlei` grammar + interface-only modules → 2e — ship the host prelude `.mlei` (the payoff: real `Scene.*`/`Camera.*` types).

🤖 Generated with [Claude Code](https://claude.com/claude-code)