### PR TITLE
feat(mle): interface files (.mlei) — bodyless signatures + interface-only modules

### DIFF
--- a/.claude/skills/mle-language/SKILL.md
+++ b/.claude/skills/mle-language/SKILL.md
@@ -182,9 +182,36 @@ let grab = (s) =>
   closures rebind per module — a def moved between files is a rename and
   keeps its old body with a warning).
 - Current limits: `run wasm` and the VSCode live preview interpret ONE
-  source text (multi-file is native-only for now); the LSP checks single
-  files in isolation, so a project file's `open`/cross-module references
-  show as unknown there; `.mlei` interface files are B8 part 2.
+  source text (multi-file is native-only for now).
+
+### Interface files (`.mlei`)
+
+A sibling `.mlei` is an INTERFACE module: it declares **types** and **bodyless
+value signatures** for values the **host runtime** implements. (A module is
+either a `.mle` or a `.mlei`, never both — same-stem files are a load error —
+so there is no paired-`.mle` implementation.) Bodies are forbidden in a
+`.mlei`; a bodyless `let` is forbidden in a `.mle`.
+
+```mle
+// widget.mlei                              → interface module Widget
+type Handle                                 // abstract type (opaque; host-made)
+let make : () => Handle                     // bodyless SIGNATURE (the chosen form —
+let size : (Handle) => Float                //   `let name : Type`, no `= body`)
+```
+
+```mle
+// game.mle
+let area = (h: Widget.Handle): Float => Widget.size(h)   // qualified; typed by widget.mlei
+open Widget                                              // …or open, bringing make/size/Handle bare
+```
+
+- Signatures give the checker real types for what were `Unknown` externals
+  (`Widget.make()` is `Widget.Handle`, not `Unknown`), and mismatches are
+  caught. They surface in hover / inlay / codelens like any type.
+- **Runtime is unchanged**: an interface member stays an `External` (the host
+  provides its value at run time), so `.mlei` is a pure check-time overlay.
+- This is how the engine prelude's types will be declared (`Scene`, `Camera`,
+  … — currently `Unknown`).
 
 ## Semantics rules that WILL bite you
 

--- a/mle/examples/functions.ir
+++ b/mle/examples/functions.ir
@@ -575,4 +575,5 @@ Module {
             span: 455..576,
         },
     ],
+    signatures: [],
 }

--- a/mle/examples/lists.ir
+++ b/mle/examples/lists.ir
@@ -575,4 +575,5 @@ Module {
             span: 527..634,
         },
     ],
+    signatures: [],
 }

--- a/mle/examples/pure_pipeline.ir
+++ b/mle/examples/pure_pipeline.ir
@@ -358,4 +358,5 @@ Module {
             span: 490..532,
         },
     ],
+    signatures: [],
 }

--- a/mle/examples/records.ir
+++ b/mle/examples/records.ir
@@ -742,4 +742,5 @@ Module {
             span: 684..772,
         },
     ],
+    signatures: [],
 }

--- a/mle/examples/shapes.ir
+++ b/mle/examples/shapes.ir
@@ -844,4 +844,5 @@ Module {
             span: 1270..1335,
         },
     ],
+    signatures: [],
 }

--- a/mle/examples/strings.ir
+++ b/mle/examples/strings.ir
@@ -748,4 +748,5 @@ Module {
             span: 840..984,
         },
     ],
+    signatures: [],
 }

--- a/mle/examples/tuples.ir
+++ b/mle/examples/tuples.ir
@@ -807,4 +807,5 @@ Module {
             span: 935..1062,
         },
     ],
+    signatures: [],
 }

--- a/mle/src/ast.rs
+++ b/mle/src/ast.rs
@@ -17,6 +17,18 @@ pub enum Item {
     Let(LetDecl),
     Type(TypeDecl),
     Open(OpenDecl),
+    /// A bodyless value SIGNATURE (`let name : Type`), only in interface files
+    /// (`.mlei`): the type of a value the host implements (a module is either a
+    /// `.mle` or a `.mlei`, never both, so there is no paired implementation).
+    Sig(SigDecl),
+}
+
+/// `let name : Type` in a `.mlei` — a value signature with no body.
+#[derive(Debug)]
+pub struct SigDecl {
+    pub name: String,
+    pub ty: TypeName,
+    pub span: Span,
 }
 
 /// `open Utils` — bring a sibling module's defs, constructors, and types

--- a/mle/src/ir.rs
+++ b/mle/src/ir.rs
@@ -68,6 +68,21 @@ impl fmt::Debug for ExprId {
 pub struct Module {
     pub types: Vec<TypeDef>,
     pub defs: Vec<Def>,
+    /// Bodyless value signatures from interface (`.mlei`) modules: the
+    /// declared type of a HOST-implemented value (`Scene.cube : () =>
+    /// SceneNode`). They give the checker types for otherwise-`Unknown`
+    /// externals; they have no body, so evaluation never sees them (the host
+    /// provides the value at runtime — there is no paired `.mle`).
+    pub signatures: Vec<Signature>,
+}
+
+/// One `.mlei` value signature: a canonical name (`Scene.cube`) and its
+/// declared type (carried symbolically, like a def annotation).
+#[derive(Debug)]
+pub struct Signature {
+    pub name: String,
+    pub ty: TypeName,
+    pub span: Span,
 }
 
 /// `type Position = { x: Float, y: Float }` or

--- a/mle/src/lib.rs
+++ b/mle/src/lib.rs
@@ -30,7 +30,7 @@ pub use eval::{
     Tracing,
 };
 pub use lower::lower;
-pub use parser::parse;
+pub use parser::{parse, parse_interface};
 pub use rebind::{rebind_value, RebindReport};
 pub use span::{line_col, Span};
 pub use trace::set_trace_sink;

--- a/mle/src/lower.rs
+++ b/mle/src/lower.rs
@@ -105,6 +105,10 @@ pub(crate) struct Exports {
     pub defs: HashSet<String>,
     pub ctors: HashMap<String, usize>,
     pub types: HashSet<String>,
+    /// Interface (`.mlei`) value signature names — a qualified reference to one
+    /// stays an [`ExprKind::External`] (host-resolved at runtime), unlike a
+    /// `def` which becomes a [`ExprKind::Global`].
+    pub signatures: HashSet<String>,
 }
 
 pub(crate) fn exports_of(program: &ast::Program) -> Exports {
@@ -123,6 +127,9 @@ pub(crate) fn exports_of(program: &ast::Program) -> Exports {
                             .insert(variant.name.clone(), variant.fields.len());
                     }
                 }
+            }
+            ast::Item::Sig(decl) => {
+                exports.signatures.insert(decl.name.clone());
             }
             ast::Item::Open(_) => {}
         }
@@ -175,20 +182,25 @@ fn lower_module(
     for item in &program.items {
         match item {
             ast::Item::Open(_) => {}
-            ast::Item::Let(decl) => {
-                if ctors.contains_key(&decl.name) {
+            // A signature shares the value namespace with `let`s for DUPLICATE
+            // DETECTION only — it is never lowered to a `Global` (references
+            // stay `External`; `.mlei` files have no value expressions, so
+            // `globals` is only read for defs). Grouped here purely to reuse
+            // the collision checks.
+            ast::Item::Let(ast::LetDecl { name, span, .. })
+            | ast::Item::Sig(ast::SigDecl { name, span, .. }) => {
+                if ctors.contains_key(name) {
                     return Err(LowerError {
                         message: format!(
-                            "duplicate definition `{}` (constructors live in the value namespace)",
-                            decl.name
+                            "duplicate definition `{name}` (constructors live in the value namespace)"
                         ),
-                        span: decl.span,
+                        span: *span,
                     });
                 }
-                if !globals.insert(decl.name.clone()) {
+                if !globals.insert(name.clone()) {
                     return Err(LowerError {
-                        message: format!("duplicate definition `{}`", decl.name),
-                        span: decl.span,
+                        message: format!("duplicate definition `{name}`"),
+                        span: *span,
                     });
                 }
             }
@@ -273,15 +285,27 @@ project entry (this file is being lowered on its own)",
             });
         };
         deps.insert(decl.module.clone());
-        // Value namespace: the opened module's defs and constructors.
-        let mut values: Vec<(&String, Option<usize>)> = exports
+        // Value namespace: the opened module's defs, constructors, and
+        // interface signatures.
+        let mut values: Vec<(&String, OpenedName)> = exports
             .defs
             .iter()
-            .map(|d| (d, None))
-            .chain(exports.ctors.iter().map(|(c, a)| (c, Some(*a))))
+            .map(|d| (d, OpenedName::Def(decl.module.clone())))
+            .chain(
+                exports
+                    .ctors
+                    .iter()
+                    .map(|(c, a)| (c, OpenedName::Ctor(decl.module.clone(), *a))),
+            )
+            .chain(
+                exports
+                    .signatures
+                    .iter()
+                    .map(|s| (s, OpenedName::Signature(decl.module.clone()))),
+            )
             .collect();
         values.sort_by_key(|(name, _)| name.as_str().to_string());
-        for (name, arity) in values {
+        for (name, opened) in values {
             if globals.contains(name) || ctors.contains_key(name) {
                 return Err(LowerError {
                     message: format!(
@@ -305,10 +329,6 @@ uses as `{}.{name}` instead of opening",
                     span: decl.span,
                 });
             }
-            let opened = match arity {
-                Some(arity) => OpenedName::Ctor(decl.module.clone(), arity),
-                None => OpenedName::Def(decl.module.clone()),
-            };
             open_values.insert(name.clone(), opened);
         }
         // Type namespace.
@@ -355,6 +375,7 @@ qualify uses (`{prev}.{name}` / `{}.{name}`)",
     let mut next_def = bases.def;
     let mut types = Vec::new();
     let mut defs = Vec::new();
+    let mut signatures = Vec::new();
     for item in program.items {
         match item {
             // Opens were consumed in pass 1b; they leave no IR (and no
@@ -382,6 +403,16 @@ qualify uses (`{prev}.{name}` / `{}.{name}`)",
                     span: decl.span,
                 });
             }
+            // An interface signature: no body, no DefId. Canonicalize its name
+            // and type (which may reference this module's — or another's —
+            // types) so the checker can type externals against it.
+            ast::Item::Sig(decl) => {
+                signatures.push(Signature {
+                    name: lowerer.self_qualify(&decl.name),
+                    ty: lowerer.canon_type(decl.ty)?,
+                    span: decl.span,
+                });
+            }
         }
     }
     let bases = IdBases {
@@ -389,7 +420,15 @@ qualify uses (`{prev}.{name}` / `{}.{name}`)",
         binding: lowerer.next_binding,
         expr: lowerer.next_expr,
     };
-    Ok((Module { types, defs }, bases, lowerer.deps))
+    Ok((
+        Module {
+            types,
+            defs,
+            signatures,
+        },
+        bases,
+        lowerer.deps,
+    ))
 }
 
 /// A name an `open` brought into scope: which module provides it, and (for
@@ -398,12 +437,17 @@ qualify uses (`{prev}.{name}` / `{}.{name}`)",
 enum OpenedName {
     Def(String),
     Ctor(String, usize),
+    /// An interface (`.mlei`) signature — a bare use resolves to an
+    /// [`ExprKind::External`], like a qualified one.
+    Signature(String),
 }
 
 impl OpenedName {
     fn module(&self) -> &str {
         match self {
-            OpenedName::Def(module) | OpenedName::Ctor(module, _) => module,
+            OpenedName::Def(module)
+            | OpenedName::Ctor(module, _)
+            | OpenedName::Signature(module) => module,
         }
     }
 }
@@ -994,6 +1038,10 @@ impl Lowerer<'_> {
                         arity,
                     })
                 }
+                // An opened interface signature stays External (host-resolved).
+                OpenedName::Signature(module) => {
+                    Some(ExprKind::External(vec![module, first.clone()]))
+                }
             }
         } else {
             None
@@ -1022,6 +1070,11 @@ impl Lowerer<'_> {
                         name: self.qualify(&module, member),
                         arity,
                     }
+                } else if exports.signatures.contains(member) {
+                    // An interface (`.mlei`) signature: keep it EXTERNAL so the
+                    // host resolves the value at runtime (like an unknown
+                    // qualified name) — the checker types it from the signature.
+                    ExprKind::External(vec![module.clone(), member.clone()])
                 } else {
                     return Err(LowerError {
                         message: format!("module `{module}` has no `{member}`"),

--- a/mle/src/parser.rs
+++ b/mle/src/parser.rs
@@ -59,15 +59,33 @@ pub fn parse(src: &str) -> Result<Program, ParseError> {
     parse_with_base(src, 0)
 }
 
+/// Parse an INTERFACE file (`.mlei`): top-level `let name : Type` is a bodyless
+/// signature (not a definition), and a `let … = …` with a body is an error.
+/// `type` declarations (including abstract) and `open` are unchanged.
+pub fn parse_interface(src: &str) -> Result<Program, ParseError> {
+    parse_interface_with_base(src, 0)
+}
+
 /// [`parse`] with a span base: every span is offset by `base`, placing the
 /// file in a project-wide span space (see [`crate::lexer::lex`] and
 /// [`crate::project`]).
 pub(crate) fn parse_with_base(src: &str, base: usize) -> Result<Program, ParseError> {
+    parse_impl(src, base, false)
+}
+
+/// [`parse_interface`] with a span base (the `.mlei` sibling of
+/// [`parse_with_base`]).
+pub(crate) fn parse_interface_with_base(src: &str, base: usize) -> Result<Program, ParseError> {
+    parse_impl(src, base, true)
+}
+
+fn parse_impl(src: &str, base: usize, interface: bool) -> Result<Program, ParseError> {
     let tokens = lex(src, base)?;
     Parser {
         tokens,
         pos: 0,
         depth: 0,
+        interface,
     }
     .program()
 }
@@ -82,6 +100,8 @@ struct Parser {
     tokens: Vec<Token>,
     pos: usize,
     depth: usize,
+    /// Parsing a `.mlei` interface file: `let` is a bodyless signature.
+    interface: bool,
 }
 
 impl Parser {
@@ -137,7 +157,7 @@ impl Parser {
         let mut items = Vec::new();
         while self.peek_kind() != &TokenKind::Eof {
             match self.peek_kind() {
-                TokenKind::Let => items.push(Item::Let(self.let_decl()?)),
+                TokenKind::Let => items.push(self.let_item()?),
                 TokenKind::Type => items.push(Item::Type(self.type_decl()?)),
                 // `open` is contextual: only an `open` in item position is
                 // the module directive, so the name stays usable elsewhere.
@@ -182,7 +202,9 @@ impl Parser {
         }
     }
 
-    fn let_decl(&mut self) -> Result<LetDecl, ParseError> {
+    /// A top-level `let` item — a definition (`let name [: T] = value`) in a
+    /// `.mle`, or a bodyless signature (`let name : T`) in a `.mlei`.
+    fn let_item(&mut self) -> Result<Item, ParseError> {
         let kw = self.bump();
         if self.peek_kind() == &TokenKind::Mut {
             return Err(ParseError {
@@ -192,17 +214,36 @@ rebind surface); `mut` is for `let mut … in …` inside a function"
                 span: self.peek().span,
             });
         }
-        let (name, _) = self.expect_ident("a name after `let`")?;
+        let (name, name_span) = self.expect_ident("a name after `let`")?;
         let ty = self.opt_binding_annotation()?;
+        if self.interface {
+            // `.mlei`: a bodyless signature `let name : Type`.
+            let ty = ty.ok_or_else(|| ParseError {
+                message: "a signature needs a type: `let name : Type`".to_string(),
+                span: name_span,
+            })?;
+            if self.peek_kind() == &TokenKind::Eq {
+                // A full-sentence message, so build the error directly rather
+                // than routing through `error()`'s "expected …, found …" shape.
+                return Err(ParseError {
+                    message:
+                        "interface files (.mlei) declare signatures, not definitions — drop the `= …`"
+                            .to_string(),
+                    span: self.peek().span,
+                });
+            }
+            let span = kw.span.to(ty.span);
+            return Ok(Item::Sig(SigDecl { name, ty, span }));
+        }
         self.expect(TokenKind::Eq, "`=`")?;
         let value = self.expr()?;
         let span = kw.span.to(value.span);
-        Ok(LetDecl {
+        Ok(Item::Let(LetDecl {
             name,
             ty,
             value,
             span,
-        })
+        }))
     }
 
     fn type_decl(&mut self) -> Result<TypeDecl, ParseError> {

--- a/mle/src/project.rs
+++ b/mle/src/project.rs
@@ -35,7 +35,7 @@ use std::path::{Path, PathBuf};
 use crate::ast;
 use crate::ir::Module;
 use crate::lower::{exports_of, lower_in_project, Exports, IdBases, ProjectEnv};
-use crate::parser::{capitalize, parse_with_base};
+use crate::parser::{capitalize, parse_interface_with_base, parse_with_base};
 use crate::span::line_col;
 use crate::types::RecordLiteralScopes;
 use crate::CheckError;
@@ -113,6 +113,13 @@ pub struct SourceFile {
     pub module: String,
     pub src: String,
     pub base: usize,
+    /// A `.mlei` interface file (bodyless signatures), vs a `.mle`.
+    pub interface: bool,
+}
+
+/// Whether a path is an interface file (`.mlei`).
+fn is_interface(path: &Path) -> bool {
+    path.extension().and_then(|e| e.to_str()) == Some("mlei")
 }
 
 /// Renders project-wide span offsets back to `file:line:col`.
@@ -204,8 +211,11 @@ pub fn project_files(entry_path: &Path) -> std::io::Result<Vec<PathBuf>> {
         .filter_map(|entry| entry.ok())
         .map(|entry| entry.path())
         .filter(|path| {
-            path.extension().and_then(|e| e.to_str()) == Some("mle")
-                && path.is_file()
+            // `.mle` implementations and `.mlei` interface files both load.
+            matches!(
+                path.extension().and_then(|e| e.to_str()),
+                Some("mle" | "mlei")
+            ) && path.is_file()
                 && path.file_name() != entry_path.file_name()
         })
         .collect();
@@ -290,6 +300,7 @@ come from file names, capitalized",
         };
         let len = src.len();
         files.push(SourceFile {
+            interface: is_interface(path),
             path: path.clone(),
             module,
             src,
@@ -313,6 +324,7 @@ fn link(mut files: Vec<SourceFile>) -> Result<Project, ProjectError> {
     // index 0. Both the filesystem and single-source loaders reach it here.
     let base = files.last().map_or(0, |f| f.base + f.src.len() + 1);
     files.push(SourceFile {
+        interface: false,
         path: PathBuf::from("<builtin>/Net.mle"),
         module: "Net".to_string(),
         src: NET_MODULE_SRC.to_string(),
@@ -335,8 +347,13 @@ fn link(mut files: Vec<SourceFile>) -> Result<Project, ProjectError> {
     };
     let mut programs: Vec<ast::Program> = Vec::new();
     for (index, file) in files.iter().enumerate() {
-        let program = parse_with_base(&file.src, file.base)
-            .map_err(|e| render_span(&files, index, e.span, &e.message))?;
+        let parse = if file.interface {
+            parse_interface_with_base
+        } else {
+            parse_with_base
+        };
+        let program =
+            parse(&file.src, file.base).map_err(|e| render_span(&files, index, e.span, &e.message))?;
         programs.push(program);
     }
 
@@ -392,6 +409,15 @@ fn link(mut files: Vec<SourceFile>) -> Result<Project, ProjectError> {
             .map_err(|e| render_span(&files, index, e.span, &e.message))?;
         bases = next;
         lowered.push(module);
+        // An interface module has no runtime initializers, so its out-edges
+        // are meaningless for evaluation order and cannot form a real cycle.
+        // Dropping them lets a signature reference a consumer's type
+        // (`render : (Game.Model) => …`) without a spurious cycle error.
+        let module_deps = if file.interface {
+            HashSet::new()
+        } else {
+            module_deps
+        };
         deps.insert(file.module.clone(), module_deps);
     }
 
@@ -422,6 +448,7 @@ allowed (within one file, definitions may still be mutually recursive)",
     let mut merged = Module {
         types: Vec::new(),
         defs: Vec::new(),
+        signatures: Vec::new(),
     };
     let mut by_module: HashMap<String, Module> = files
         .iter()
@@ -432,6 +459,7 @@ allowed (within one file, definitions may still be mutually recursive)",
         let module = by_module.remove(name).expect("ordered once");
         merged.types.extend(module.types);
         merged.defs.extend(module.defs);
+        merged.signatures.extend(module.signatures);
     }
 
     Ok(Project {
@@ -447,6 +475,7 @@ allowed (within one file, definitions may still be mutually recursive)",
 /// there are no sibling files. The built-in `Net` module is still injected.
 pub fn load_single_source(module: &str, src: &str) -> Result<Project, ProjectError> {
     let files = vec![SourceFile {
+        interface: false,
         path: PathBuf::from(format!("{module}.mle")),
         module: module.to_string(),
         src: src.to_string(),
@@ -470,6 +499,7 @@ pub fn load_single_file(path: &Path, src: &str) -> Result<Project, ProjectError>
         _ => "Main".to_string(),
     };
     let files = vec![SourceFile {
+        interface: is_interface(path),
         path: path.to_path_buf(),
         module,
         src: src.to_string(),

--- a/mle/src/types.rs
+++ b/mle/src/types.rs
@@ -467,6 +467,7 @@ fn check_impl(
         subst: HashMap::new(),
         next_var: 0,
         schemes: HashMap::new(),
+        signatures: HashMap::new(),
         in_type_decl: false,
         annot_vars: HashMap::new(),
         records: HashMap::new(),
@@ -555,6 +556,17 @@ fn check_impl(
     }
 
     checker.in_type_decl = false;
+    checker.annot_vars.clear();
+
+    // Interface (`.mlei`) value signatures: resolve each declared type now that
+    // all types (including the interfaces' own) are registered, and generalize
+    // it — an `External` reference then instantiates it fresh (like a builtin).
+    for sig in &module.signatures {
+        checker.annot_vars.clear();
+        let ty = checker.resolve_type(&sig.ty, true);
+        let scheme = checker.generalize(&ty);
+        checker.signatures.insert(sig.name.clone(), scheme);
+    }
     checker.annot_vars.clear();
 
     // Placeholder signatures: annotation-derived, with FRESH inference
@@ -770,6 +782,10 @@ struct Checker<'s> {
     /// Generalized top-level defs (populated as each dependency group
     /// finishes inference); instantiated fresh at every later use.
     schemes: HashMap<String, Scheme>,
+    /// Interface (`.mlei`) value signatures, keyed by canonical name
+    /// (`Scene.cube`); an `External` reference to one is typed from here
+    /// instead of `Unknown`, instantiated fresh per use.
+    signatures: HashMap<String, Scheme>,
     /// Resolving a TYPE DECLARATION's field annotations (lowercase names
     /// are refused there — see `resolve_type`).
     in_type_decl: bool,
@@ -1437,7 +1453,12 @@ missing {missing}. Did you forget an argument?"
                     free_vars_of(&sig, &mut vars);
                     self.instantiate(&Scheme { vars, ty: sig })
                 }
-                None => Type::Unknown,
+                // An interface (`.mlei`) signature gives a host external a real
+                // type; otherwise it stays the gradual seam (`Unknown`).
+                None => match self.signatures.get(&path.join(".")).cloned() {
+                    Some(scheme) => self.instantiate(&scheme),
+                    None => Type::Unknown,
+                },
             },
             // A record literal resolves NOMINALLY, F#-style (B7, user
             // decision): the unique declared type with exactly this field

--- a/mle/tests/project.rs
+++ b/mle/tests/project.rs
@@ -865,3 +865,132 @@ fn shipped_hello_cubes_multifile_checks_clean() {
     let diags = project.check();
     assert!(diags.is_empty(), "hello-cubes checks clean: {diags:?}");
 }
+
+// ── interface files (.mlei) — mlei slice 2d ──────────────────────────────
+
+/// A `.mlei` gives host-implemented values real types: a sibling `.mle`'s
+/// `Widget.make()` / `Widget.size(h)` type against `widget.mlei` and check
+/// clean.
+#[test]
+fn interface_file_types_externals() {
+    let project = load(
+        "mlei-basic",
+        &[
+            (
+                "game.mle",
+                "let build = (): Widget.Handle => Widget.make()\n\
+                 let area = (h: Widget.Handle): Float => Widget.size(h)",
+            ),
+            (
+                "widget.mlei",
+                "type Handle\n\
+                 let make : () => Handle\n\
+                 let size : (Handle) => Float",
+            ),
+        ],
+    );
+    let diags = project.check();
+    assert!(diags.is_empty(), "should check clean: {diags:?}");
+}
+
+/// An interface signature is enforced — a wrong argument type is caught, with
+/// the interface's nominal type in the message.
+#[test]
+fn interface_signature_mismatch_is_flagged() {
+    let project = load(
+        "mlei-mismatch",
+        &[
+            ("game.mle", "let bad = (): Float => Widget.size(3.0)"),
+            (
+                "widget.mlei",
+                "type Handle\nlet size : (Handle) => Float",
+            ),
+        ],
+    );
+    let diags = project.check();
+    assert_eq!(diags.len(), 1, "{diags:?}");
+    assert!(
+        diags[0].message.contains("expected Widget.Handle"),
+        "unexpected: {}",
+        diags[0].message
+    );
+}
+
+/// `open` brings an interface's signatures (and types) unqualified.
+#[test]
+fn open_brings_interface_signatures() {
+    let project = load(
+        "mlei-open",
+        &[
+            ("game.mle", "open Widget\nlet f = (): Float => size(make())"),
+            (
+                "widget.mlei",
+                "type Handle\n\
+                 let make : () => Handle\n\
+                 let size : (Handle) => Float",
+            ),
+        ],
+    );
+    let diags = project.check();
+    assert!(diags.is_empty(), "should check clean: {diags:?}");
+}
+
+/// A body in a `.mlei` is a load error with a clear message — interface files
+/// declare, not define.
+#[test]
+fn body_in_interface_file_is_rejected() {
+    let err = load_err(
+        "mlei-body",
+        &[
+            ("game.mle", "let main = () => 1.0"),
+            ("widget.mlei", "let make : Float = 3.0"),
+        ],
+    );
+    assert!(
+        err.contains("declare signatures, not definitions"),
+        "unexpected: {err}"
+    );
+}
+
+/// An interface signature may reference a type in the module that USES it (a
+/// host callback typed against the app's own `Model`). Interface modules have
+/// no runtime initializers, so this is NOT a real cycle (mlei 2d review).
+#[test]
+fn interface_signature_may_reference_a_consumer_type() {
+    let project = load(
+        "mlei-consumer-type",
+        &[
+            (
+                "game.mle",
+                "type Model = { n: Float }\n\
+                 let sc = (m: Model): Widget.Handle => Widget.render(m)",
+            ),
+            (
+                "widget.mlei",
+                "type Handle\nlet render : (Game.Model) => Handle",
+            ),
+        ],
+    );
+    let diags = project.check();
+    assert!(diags.is_empty(), "no false cycle: {diags:?}");
+}
+
+/// An interface member still resolves as an External at runtime (host-backed),
+/// so a `.mle`-only project keeps running unchanged.
+#[test]
+fn interface_member_lowers_to_external() {
+    // The game references Widget.make but never calls it; run `main`, which is
+    // pure — proving the .mlei presence doesn't disturb evaluation.
+    let value = run_main(
+        "mlei-runtime",
+        &[
+            (
+                "game.mle",
+                "let unused = (): Widget.Handle => Widget.make()\n\
+                 let main = () => 40.0 + 2.0",
+            ),
+            ("widget.mlei", "type Handle\nlet make : () => Handle"),
+        ],
+    );
+    assert_eq!(number(&value), 42.0);
+}


### PR DESCRIPTION
A sibling **`.mlei`** is an interface module: it declares **types** and **bodyless value signatures** (`let name : Type`) for values the **host runtime** implements. This is the biggest slice of the `docs/mlei.md` arc — **2d** — and the mechanism 2e will use to bundle the engine prelude so `Scene.*` / `Camera.*` get real types instead of `Unknown`.

```mle
// widget.mlei                          → interface module Widget
type Handle                             // opaque (2c)
let make : () => Handle                 // bodyless signature (the chosen form)
let size : (Handle) => Float

// game.mle
let area = (h: Widget.Handle): Float => Widget.size(h)   // typed by widget.mlei
open Widget                                              // …or open, bringing make/size/Handle bare
```

## Design
- **Parser** (`parse_interface`): in a `.mlei`, top-level `let name : Type` is a bodyless signature (`Item::Sig`); a body is an error, and a bodyless `let` in a `.mle` stays an error.
- **Loader**: `.mlei` siblings are discovered + parsed as interfaces; their types merge into the project (abstract types via 2c), their signatures into `Module.signatures`.
- **Runtime-safety invariant** (the crux): a qualified interface member (`Widget.make`) lowers to `ExprKind::External` — host-resolved at runtime, **never a `Global`** (which would crash the interpreter on a missing body). `open` brings signatures unqualified too.
- **Checker**: resolves each signature to a generalized scheme (keyed by canonical name) and types matching `External` refs from it — `Widget.make()` is `Widget.Handle`, mismatches caught. It surfaces in the LSP: hover on `Widget.make` shows `() => Widget.Handle` via the sibling interface (the project-aware LSP already discovers `.mlei`).

So `.mlei` is a pure **check-time overlay**; the runtime path is unchanged (verified: a `.mle`-only project still runs with a `.mlei` present).

## Review
`/xreview` (Claude engine — Codex rate-limited) **confirmed the core runtime-safety invariant sound** and found one **High** + doc fixes, all applied:
- **High:** an interface signature typed against a *consumer's* type (`render : (Game.Model) => …`) produced a false dependency cycle. Fixed — interface modules contribute no eval-order out-edges (they have no initializers); regression-tested.
- Docs: dropped the inaccurate "paired `.mle`" phrasing (a module is `.mle` **or** `.mlei`, never both); fixed a mangled body-in-`.mlei` diagnostic; clarified the `globals`-dedup reliance.

## Tests / verification
types-externals, mismatch caught, `open` brings signatures, body-in-`.mlei` rejected (clean message), runtime-preserved, consumer-type (no false cycle). `cargo test -p mle -p mle-lsp` green; goldens regenerated (`Module.signatures`); skill updated.

## Next — 2e
Author + bundle the engine prelude `.mlei` (`include_str!`), load by default (with a protected-namespace exemption so the prelude may own `Scene`/`Camera`/…), + a drift test vs the host registry. The payoff: real host types with zero annotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)