### PR TITLE
feat(mle): host-agnostic prelude injection hook (load_with_prelude)

### DIFF
--- a/mle/src/project.rs
+++ b/mle/src/project.rs
@@ -253,6 +253,21 @@ pub fn load_with_overrides(
     entry_path: &Path,
     overrides: &HashMap<PathBuf, String>,
 ) -> Result<Project, ProjectError> {
+    load_with_prelude(entry_path, overrides, &[])
+}
+
+/// [`load_with_overrides`], plus a set of injected PRELUDE interface modules —
+/// `(module name, .mlei source)` pairs describing host-provided values
+/// (`Scene.*`, `Camera.*`, …). Unlike project files they are not read from the
+/// directory and are EXEMPT from the protected-namespace check: they are
+/// precisely what defines those namespaces. This is the host's seam to give
+/// the checker real types for its externals (see `docs/mlei.md`); plain `mle`
+/// callers pass nothing, so the language stays host-agnostic.
+pub fn load_with_prelude(
+    entry_path: &Path,
+    overrides: &HashMap<PathBuf, String>,
+    prelude: &[(String, String)],
+) -> Result<Project, ProjectError> {
     let at = |path: &Path, message: String| ProjectError {
         path: path.to_path_buf(),
         line: 1,
@@ -309,6 +324,18 @@ come from file names, capitalized",
         // +1 gap: a span at one file's very end never collides with the
         // next file's base.
         base += len + 1;
+    }
+    // Injected prelude interface modules — after the project files, exempt
+    // from the protected-namespace check (they OWN those namespaces).
+    for (module, src) in prelude {
+        files.push(SourceFile {
+            interface: true,
+            path: PathBuf::from(format!("<prelude>/{module}.mlei")),
+            module: module.clone(),
+            src: src.clone(),
+            base,
+        });
+        base += src.len() + 1;
     }
     link(files)
 }

--- a/mle/tests/project.rs
+++ b/mle/tests/project.rs
@@ -994,3 +994,36 @@ fn interface_member_lowers_to_external() {
     );
     assert_eq!(number(&value), 42.0);
 }
+
+/// Injected prelude interface modules (mlei 2e) give the checker real types
+/// for host externals — exempt from the protected-namespace check, since they
+/// OWN those namespaces. `Scene.*` types against the injected `Scene` module.
+#[test]
+fn injected_prelude_types_host_externals() {
+    let scratch = Scratch::new(
+        "prelude-inject",
+        &[(
+            "game.mle",
+            "let ok = () => Scene.color(1.0, 0.0, 0.0, Scene.cube())\n\
+             let bad = () => Scene.color(1.0, 0.0, 0.0, 3.0)",
+        )],
+    );
+    let prelude = [(
+        "Scene".to_string(),
+        "type Node\n\
+         let cube : () => Node\n\
+         let color : (Float, Float, Float, Node) => Node"
+            .to_string(),
+    )];
+    let project =
+        mle::project::load_with_prelude(&scratch.entry, &Default::default(), &prelude)
+            .unwrap_or_else(|e| panic!("prelude load: {}", e.render()));
+    let diags = project.check();
+    // Only the deliberate `3.0` misuse; `Scene.cube()` → `Scene.Node` is fine.
+    assert_eq!(diags.len(), 1, "{diags:?}");
+    assert!(
+        diags[0].message.contains("expected Scene.Node"),
+        "unexpected: {}",
+        diags[0].message
+    );
+}


### PR DESCRIPTION
The **2e foundation** (`docs/mlei.md`): a seam for a host to give the checker real types for its externals, without coupling the host-agnostic `mle` crate to any host.

`project::load_with_prelude(entry, overrides, &[(module, .mlei source)])` loads a project **plus** injected prelude interface modules. Unlike project files they aren't read from disk and are **exempt from the protected-namespace check** — they're what *defines* `Scene`/`Camera`/… . `load_with_overrides` becomes `load_with_prelude(…, &[])`, so plain `mle check` passes nothing and the language stays host-agnostic (per the chosen architecture: a shared `functor-prelude` crate, coming next, supplies the `.mlei` text to the runtime + LSP).

Tested: an injected `Scene` interface types host externals — `Scene.cube()` → `Scene.Node`, and `Scene.color(…, 3.0)` → `expected Scene.Node, got Float`.

Small, self-contained infra. Next: the `functor-prelude` crate + a drift test against the host's `const PATHS` list + runtime/LSP wiring (delegated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)