### PR TITLE
feat(mle): functor-prelude crate + Scene .mlei + check-time prelude wiring (2e-i)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "1"
 
 members = [
     "cli",
+    "functor-prelude",
     "mle",
     "runtime/functor-netsim",
     "runtime/functor-runtime-common",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,6 +11,9 @@ path = "src/main.rs"
 [dependencies]
 # The MLE language, for `language: "mle"` projects (docs/mle.md Track C4).
 mle = { path = "../mle" }
+# The host prelude `.mlei` interfaces — injected at load time so a game's
+# `Scene.*` calls typecheck against real types (docs/mlei.md).
+functor-prelude = { path = "../functor-prelude" }
 clap = { version = "4.5.6", features = ["derive"] }
 colored = "2.1.0"
 # The `log` facade: the CLI installs a logger that turns any `log!` (its own or

--- a/cli/src/commands/mle_project.rs
+++ b/cli/src/commands/mle_project.rs
@@ -69,7 +69,15 @@ impl MleProject {
         // A load failure (parse error, bad module name, cycle) is a positioned
         // diagnostic too — surface its file:line:col structurally, like a check
         // error, rather than flattening it into the final text-only error.
-        let project = match mle::project::load(&path) {
+        // Inject the host prelude `.mlei` interfaces so the game's `Scene.*`
+        // (etc.) externals typecheck against real types instead of `Unknown`
+        // (docs/mlei.md). Check-time only — runtime evaluation is unchanged
+        // (the host provides the actual values).
+        let project = match mle::project::load_with_prelude(
+            &path,
+            &std::collections::HashMap::new(),
+            &functor_prelude::modules(),
+        ) {
             Ok(project) => project,
             Err(e) => {
                 // A load error (parse / bad module / cycle) carries only its

--- a/functor-prelude/Cargo.toml
+++ b/functor-prelude/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "functor-prelude"
+version = "0.1.0"
+edition = "2021"
+
+# Zero dependencies by design: this crate is a thin holder of the host prelude
+# `.mlei` interface text so it can be depended on by BOTH the runtime
+# (functor_runtime_common) and the editor tooling (tools/mle-lsp) without
+# dragging in either's dependency graph.
+[dependencies]

--- a/functor-prelude/prelude/scene.mlei
+++ b/functor-prelude/prelude/scene.mlei
@@ -1,0 +1,48 @@
+// scene.mlei — the `Scene` host module (interface only; implemented in Rust by
+// FunctorHost in functor_runtime_common::mle_prelude). See docs/mlei.md.
+//
+// Slice 2e-i authors ONE namespace (Scene) end-to-end to prove the prelude
+// pipeline. It is authored in FULL — every `Scene.*` the host provides — because
+// an interface-only module is a CLOSED module: a reference to a member it does
+// not declare is a load error, so a partial Scene would break real games. The
+// remaining host namespaces (Camera, Physics, Effect, Light, …) are authored in
+// 2e-ii; until then they stay gradual host externals (`Unknown`), unaffected.
+//
+// Branded argument types (`Angle`, `Texture`, `RenderTarget`) name types owned
+// by not-yet-authored host modules, so they resolve to `Unknown` for now (the
+// gradual seam) and become real once 2e-ii ships those modules.
+
+// The opaque scene-node handle. Because the module is itself `Scene`, this is
+// referred to as `Scene.Node` from game code.
+type Node
+
+// Primitive geometry.
+let cube : () => Node
+let sphere : () => Node
+let cylinder : () => Node
+let quad : () => Node
+let plane : () => Node
+
+// Assets and generated surfaces.
+let model : (String) => Node
+let heightmap : (List<List<Float>>) => Node
+
+// Composition.
+let group : (List<Node>) => Node
+
+// Materials (subject-last, so they pipe: `Scene.cube() |> Scene.color(r,g,b)`).
+let color : (Float, Float, Float, Node) => Node
+let lit : (Float, Float, Float, Node) => Node
+let emissive : (Float, Float, Float, Node) => Node
+let litTexture : (Texture, Node) => Node
+let emissiveTexture : (Texture, Node) => Node
+let litNormalMapped : (Float, Float, Float, Texture, Node) => Node
+let screen : (RenderTarget, Node) => Node
+
+// Transforms.
+let translate : (Float, Float, Float, Node) => Node
+let scale : (Float, Node) => Node
+let scaleXYZ : (Float, Float, Float, Node) => Node
+let rotateX : (Angle, Node) => Node
+let rotateY : (Angle, Node) => Node
+let rotateZ : (Angle, Node) => Node

--- a/functor-prelude/src/lib.rs
+++ b/functor-prelude/src/lib.rs
@@ -1,0 +1,22 @@
+//! The Functor host prelude as MLE interface files (`.mlei`).
+//!
+//! The MLE typechecker resolves host externals (`Scene.cube`, …) against
+//! interface-only modules injected at load time (see
+//! [`mle::project::load_with_prelude`] and `docs/mlei.md`). This crate holds the
+//! authoritative `.mlei` text for those modules and exposes it as
+//! `(module name, source)` pairs — the exact shape the loader wants.
+//!
+//! The `.mlei` here declares only TYPES; the Rust implementations live in
+//! `functor_runtime_common::mle_prelude::FunctorHost`. A drift test in that
+//! crate keeps the two in sync.
+
+/// The host prelude interface modules, as `(module name, .mlei source)` pairs.
+///
+/// The module name is what qualified access uses (`Scene.cube`); it is derived
+/// here explicitly rather than from a file name so the loader gets it verbatim.
+pub fn modules() -> Vec<(String, String)> {
+    vec![(
+        "Scene".to_string(),
+        include_str!("../prelude/scene.mlei").to_string(),
+    )]
+}

--- a/runtime/functor-runtime-common/Cargo.toml
+++ b/runtime/functor-runtime-common/Cargo.toml
@@ -40,6 +40,11 @@ async-trait = "0.1.80"
 log = "0.4"
 gltf = { version = "1.4.1", features = ["names", "KHR_materials_pbrSpecularGlossiness"] }
 
+[dev-dependencies]
+# The host prelude `.mlei` interface text, for the drift test that keeps the
+# declared Scene.* signatures in sync with the `PATHS` host registry.
+functor-prelude = { path = "../../functor-prelude" }
+
 [target.'cfg(not(any(target_arch = "wasm32")))'.dependencies]
 tokio = { version = "1", features = ["full"] }
 

--- a/runtime/functor-runtime-common/src/mle_prelude.rs
+++ b/runtime/functor-runtime-common/src/mle_prelude.rs
@@ -3068,6 +3068,36 @@ mod tests {
             .clone()
     }
 
+    // Drift guard: every signature authored in the `functor-prelude` `.mlei`
+    // interfaces must name a real host external in `PATHS`, so the declared
+    // types and the Rust implementations cannot silently diverge. We parse the
+    // `.mlei` sources to extract `Module.name` signatures and check each exists.
+    //
+    // TODO(2e-ii): assert the FULL bijection (every `PATHS` entry also has a
+    // signature) once every host namespace is authored as `.mlei`.
+    #[test]
+    fn prelude_signatures_map_to_host_paths() {
+        let mut checked = 0;
+        for (module, src) in functor_prelude::modules() {
+            let program = mle::parse_interface(&src)
+                .unwrap_or_else(|e| panic!("prelude module `{module}` must parse: {}", e.message));
+            for item in &program.items {
+                if let mle::ast::Item::Sig(sig) = item {
+                    let path = format!("{module}.{}", sig.name);
+                    assert!(
+                        PATHS.contains(&path.as_str()),
+                        "prelude signature `{path}` has no matching host external in PATHS \
+(mle_prelude.rs) — a phantom signature"
+                    );
+                    checked += 1;
+                }
+            }
+        }
+        // Guard against a vacuous pass (an empty/renamed `.mlei` parsing to zero
+        // signatures would otherwise satisfy the loop trivially).
+        assert!(checked > 0, "the prelude authored no signatures to check");
+    }
+
     // The C1 verify criterion (docs/mle.md): an .mle snippet emits exactly
     // the protocol data the shells consume — pinned as the serialized wire
     // form the protocol tests use.

--- a/runtime/functor-runtime-desktop/Cargo.toml
+++ b/runtime/functor-runtime-desktop/Cargo.toml
@@ -17,6 +17,9 @@ required-features = []
 [dependencies]
 # The MLE language, for the --mle producer (docs/mle.md Track C2).
 mle = { path = "../../mle" }
+# The host prelude `.mlei` interfaces — injected at load time so a game's
+# `Scene.*` calls typecheck against real types (docs/mlei.md).
+functor-prelude = { path = "../../functor-prelude" }
 functor_runtime_common = { path = "./../functor-runtime-common" }
 glow = "0.17"
 cgmath = "0.18.0"

--- a/runtime/functor-runtime-desktop/src/mle_game.rs
+++ b/runtime/functor-runtime-desktop/src/mle_game.rs
@@ -183,7 +183,17 @@ fn load_source(path: &str, src: String) -> Result<Loaded, String> {
 }
 
 fn load_project(path: &str, entry_src: Option<String>) -> Result<Loaded, String> {
-    let project = mle::project::load_with_entry_source(std::path::Path::new(path), entry_src)
+    let entry = std::path::Path::new(path);
+    // A pushed buffer (network reload) stands in for the entry file; siblings
+    // still load from disk.
+    let overrides = match entry_src {
+        Some(src) => std::collections::HashMap::from([(entry.to_path_buf(), src)]),
+        None => std::collections::HashMap::new(),
+    };
+    // Inject the host prelude `.mlei` interfaces so `Scene.*` (etc.) typecheck
+    // against real types (docs/mlei.md). Check-time only — the FunctorHost still
+    // provides the actual runtime values.
+    let project = mle::project::load_with_prelude(entry, &overrides, &functor_prelude::modules())
         .map_err(|e| format!("cannot load {}", e.render()))?;
     // Type diagnostics are advisory in the dev loop: print, keep going.
     for diag in project.check() {


### PR DESCRIPTION
Wires the first host namespace end-to-end — **`Scene`** — so a game's `Scene.cube()` typechecks with a **real type** on the runtime path. Builds on #273's `load_with_prelude` hook (now merged). This is **slice 2e-i** of the `docs/mlei.md` arc.

## What's here
- **New `functor-prelude` crate** (zero-dep): holds the engine prelude's `.mlei` text (`include_str!`) and exposes `modules() -> Vec<(String, String)>` — the shape `load_with_prelude` wants. Depend-able by the runtime now, the LSP in 2e-iii.
- **`prelude/scene.mlei`** — the full `Scene` module: `type Node` + all 21 `Scene.*` signatures, verified line-by-line against the host `call` impl (`color : (Float,Float,Float,Node)`, `rotateY : (Angle,Node)`, `heightmap : (List<List<Float>>) => Node`, …).
- **Runtime wiring (check-time only)**: `functor build` (`cli`) and native run/hot-reload (`desktop`) load the prelude via `load_with_prelude`. Evaluation is untouched — the host still provides the values.
- **Drift test** (in `functor_runtime_common`, which sees both `PATHS` and `functor-prelude`): every `.mlei` signature maps to a real host `PATHS` entry (no phantom signatures) + a vacuous-pass guard. `TODO(2e-ii)` for the full reverse bijection.

## Key discovery — closed modules
An interface-only module is a **closed module**: referencing a member it doesn't declare is a *load* error (`lower.rs:1078`). So a *partial* `Scene` would break every game — **each injected namespace must be authored in full**. Only `Scene` is injected here; `Camera`/`Physics`/`Effect`/… stay gradual host externals (`Unknown`) until 2e-ii, unaffected. This is the guiding constraint for the rest of the authoring.

## Verification
`cargo test -p mle -p functor-prelude -p functor_runtime_common` green (incl. drift test); all example games still `functor build native` succeed; `let bad : Float = Scene.cube()` now errors `expected Float, got Scene.Node` on the prelude path while plain `mle check` stays silent. No warnings.

Implemented by a delegated agent; I reviewed the crate layout, verified all 21 signatures against the host, ran the suite, and rebased onto main. `/xreview` (Claude engine; Codex rate-limited) — no Critical/High.

## Next
- **2e-ii**: author the remaining ~18 namespaces (full each, per the closed-module rule) + flip the drift test to a hard bijection.
- **2e-iii**: wire `mle-lsp` → real host types in the editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)