### PR TITLE
feat(mle): author full host prelude as .mlei + hard-bijection drift test (2e-ii)

### DIFF
--- a/.claude/skills/mle-language/SKILL.md
+++ b/.claude/skills/mle-language/SKILL.md
@@ -166,8 +166,8 @@ let grab = (s) =>
   that creates no cycle.
 - **Protected namespaces**: a file whose module name collides with a
   builtin/prelude namespace (Net, List, Text, Math, Debug, Scene, Camera,
-  Frame, Light, Angle, Time, Sub, Effect, Physics, RenderTarget) is a load
-  error — rename the file.
+  Frame, Light, Fog, Skybox, Angle, Texture, Time, Sub, Effect, Physics,
+  RenderTarget, Ui, AudioSource, AudioScene) is a load error — rename the file.
 - **`Net` is a built-in module**, always in scope: `type NetEvent =
   | Connected(id: Float) | Message(id: Float, text: String) |
   Disconnected(id: Float) | Error(id: Float, text: String)`. A `Sub.connect`/
@@ -210,8 +210,15 @@ open Widget                                              // …or open, bringing
   caught. They surface in hover / inlay / codelens like any type.
 - **Runtime is unchanged**: an interface member stays an `External` (the host
   provides its value at run time), so `.mlei` is a pure check-time overlay.
-- This is how the engine prelude's types will be declared (`Scene`, `Camera`,
-  … — currently `Unknown`).
+- This is how the **engine prelude's types are declared**: the `functor-prelude`
+  crate ships a `.mlei` for every host namespace (`Scene`, `Camera`, `Frame`,
+  `Light`, `Fog`, `Skybox`, `RenderTarget`, `Texture`, `Angle`, `Time`, `Sub`,
+  `Effect`, `Physics`, `Ui`, `AudioSource`, `AudioScene`), loaded by the runner
+  so engine calls carry real types (no longer `Unknown`). Each module's primary
+  opaque handle is `Mod.T` (`Camera.T`, `Frame.T`, `Effect.T`, …); modules that
+  own several name each (`Scene.Node`; `Physics.Shape`/`Body`/`Scene`;
+  `Ui.View`/`Anchor`). Physics query/event results are records
+  (`Physics.Position`, `Physics.RayHit`, `Physics.CollisionEvent`).
 
 ## Semantics rules that WILL bite you
 

--- a/functor-prelude/prelude/angle.mlei
+++ b/functor-prelude/prelude/angle.mlei
@@ -1,0 +1,12 @@
+// angle.mlei — the `Angle` host module (interface only; implemented in Rust by
+// FunctorHost in functor_runtime_common::mle_prelude). See docs/mlei.md.
+//
+// A branded angle: rotation/camera functions accept ONLY `Angle.T` values, so a
+// bare number is rejected with a teaching error. Build one with `Angle.degrees`
+// or `Angle.radians`.
+
+// The opaque angle handle (`Angle.T` from game code).
+type T
+
+let degrees : (Float) => T
+let radians : (Float) => T

--- a/functor-prelude/prelude/audio_scene.mlei
+++ b/functor-prelude/prelude/audio_scene.mlei
@@ -1,0 +1,10 @@
+// audio_scene.mlei — the `AudioScene` host module (interface only; implemented
+// in Rust by FunctorHost in functor_runtime_common::mle_prelude). See docs/mlei.md.
+//
+// The audio scene the optional `soundScape = (model) => …` hook returns.
+
+// The opaque audio-scene handle (`AudioScene.T` from game code).
+type T
+
+let create : (List<AudioSource.T>) => T
+let empty : () => T

--- a/functor-prelude/prelude/audio_source.mlei
+++ b/functor-prelude/prelude/audio_source.mlei
@@ -1,0 +1,15 @@
+// audio_source.mlei — the `AudioSource` host module (interface only; implemented
+// in Rust by FunctorHost in functor_runtime_common::mle_prelude). See docs/mlei.md.
+//
+// Soundscape voices (the continuous, reconciled half of audio). Keyed for
+// cross-frame identity so the shell keeps a live voice playing.
+
+// The opaque audio-source handle (`AudioSource.T` from game code).
+type T
+
+// key, sound.
+let ambient : (String, String) => T
+// key, sound, x, y, z.
+let at : (String, String, Float, Float, Float) => T
+// Source LAST (subject-last), so it pipes: `AudioSource.ambient(…) |> AudioSource.gain(0.35)`.
+let gain : (Float, T) => T

--- a/functor-prelude/prelude/camera.mlei
+++ b/functor-prelude/prelude/camera.mlei
@@ -1,0 +1,10 @@
+// camera.mlei — the `Camera` host module (interface only; implemented in Rust by
+// FunctorHost in functor_runtime_common::mle_prelude). See docs/mlei.md.
+
+// The opaque camera handle (`Camera.T` from game code).
+type T
+
+// Eye + target (Y-up, right-handed), a fixed 45° fov.
+let lookAt : (Float, Float, Float, Float, Float, Float) => T
+// Eye + yaw/pitch/fov Angles: yaw = 0 / pitch = 0 looks down +Z.
+let firstPerson : (Float, Float, Float, Angle.T, Angle.T, Angle.T) => T

--- a/functor-prelude/prelude/effect.mlei
+++ b/functor-prelude/prelude/effect.mlei
@@ -1,0 +1,24 @@
+// effect.mlei — the `Effect` host module (interface only; implemented in Rust by
+// FunctorHost in functor_runtime_common::mle_prelude). See docs/mlei.md.
+//
+// Effects: fire-and-forget commands returned beside the model, folded back
+// through `update`. The `msg` type variable is the game's message type.
+
+// The opaque effect handle (`Effect.T` from game code).
+type T
+
+let none : () => T
+// The tagger is applied by the producer with the performed result value.
+let now : ((Float) => msg) => T
+let random : ((Float) => msg) => T
+let batch : (List<T>) => T
+// Send text to a live connection (connId, text).
+let send : (Float, String) => T
+// The tagger is a function of the `Net.HttpResponse`.
+let httpGet : (String, (Net.HttpResponse) => msg) => T
+let httpPost : (String, String, (Net.HttpResponse) => msg) => T
+// Fire-and-forget audio one-shots. `play` is non-spatial; `playAt` positioned.
+let play : (String) => T
+let playAt : (String, Float, Float, Float) => T
+// Play once and deliver `msg` (a message VALUE, not a tagger) when it finishes.
+let playThen : (String, msg) => T

--- a/functor-prelude/prelude/fog.mlei
+++ b/functor-prelude/prelude/fog.mlei
@@ -1,0 +1,8 @@
+// fog.mlei — the `Fog` host module (interface only; implemented in Rust by
+// FunctorHost in functor_runtime_common::mle_prelude). See docs/mlei.md.
+
+// The opaque fog handle (`Fog.T` from game code).
+type T
+
+let linear : (Float, Float, Float, Float, Float) => T
+let exp : (Float, Float, Float, Float) => T

--- a/functor-prelude/prelude/frame.mlei
+++ b/functor-prelude/prelude/frame.mlei
@@ -1,0 +1,14 @@
+// frame.mlei — the `Frame` host module (interface only; implemented in Rust by
+// FunctorHost in functor_runtime_common::mle_prelude). See docs/mlei.md.
+
+// The opaque frame handle (`Frame.T` from game code) — what `draw` returns.
+type T
+
+let create : (Camera.T, Scene.Node) => T
+let createLit : (Camera.T, Scene.Node, List<Light.T>) => T
+// Frame LAST (subject-last), so they pipe: `Frame.createLit(…) |> Frame.withFog(fog)`.
+// `withRenderTarget(target, targetFrame, frame)` renders `targetFrame` into
+// `target` each frame, before `frame`'s main pass.
+let withRenderTarget : (RenderTarget.T, T, T) => T
+let withFog : (Fog.T, T) => T
+let withSkybox : (Skybox.T, T) => T

--- a/functor-prelude/prelude/light.mlei
+++ b/functor-prelude/prelude/light.mlei
@@ -1,0 +1,13 @@
+// light.mlei — the `Light` host module (interface only; implemented in Rust by
+// FunctorHost in functor_runtime_common::mle_prelude). See docs/mlei.md.
+
+// The opaque light handle (`Light.T` from game code).
+type T
+
+let ambient : (Float, Float, Float) => T
+let directional : (Float, Float, Float, Float, Float, Float, Float) => T
+let point : (Float, Float, Float, Float, Float, Float, Float, Float) => T
+// px, py, pz, dx, dy, dz, r, g, b, intensity, range, coneAngle.
+let spot : (Float, Float, Float, Float, Float, Float, Float, Float, Float, Float, Float, Angle.T) => T
+// Light first, so it pipes: `Light.directional(…) |> Light.castShadows`.
+let castShadows : (T) => T

--- a/functor-prelude/prelude/physics.mlei
+++ b/functor-prelude/prelude/physics.mlei
@@ -1,0 +1,75 @@
+// physics.mlei — the `Physics` host module (interface only; implemented in Rust
+// by FunctorHost in functor_runtime_common::mle_prelude). See docs/mlei.md and
+// docs/physics.md (the declarative surface).
+//
+// Shapes are values, bodies are tag + shape + piped attributes, and the optional
+// `physics = (model) => Physics.scene(…)` hook declares the world each frame.
+// This module owns three opaque handles (Shape, Body, Scene) plus the plain-data
+// records the query/event APIs hand back.
+
+// Opaque handles.
+type Shape
+type Body
+type Scene
+
+// The record `Physics.position` returns — the live pose of a body.
+type Position = { x: Float, y: Float, z: Float }
+// The record a `Physics.raycast` tagger receives (hit: false with zeroed fields
+// for a miss).
+type RayHit = {
+  hit: Bool,
+  x: Float, y: Float, z: Float,
+  nx: Float, ny: Float, nz: Float,
+  distance: Float,
+  tag: String
+}
+// The record a `Physics.events` tagger receives, one per contact begin/end.
+type CollisionEvent = { started: Bool, a: String, b: String, sensor: Bool }
+
+// Shapes.
+let box : (Float, Float, Float) => Shape
+let sphere : (Float) => Shape
+let capsule : (Float, Float) => Shape
+
+// Bodies (tag, shape).
+let dynamic : (String, Shape) => Body
+let kinematic : (String, Shape) => Body
+let fixed : (String, Shape) => Body
+
+// Body LAST (subject-last), so they pipe:
+// `Physics.dynamic("crate", Physics.box(1.0, 1.0, 1.0)) |> Physics.at(0.0, 5.0, 0.0)`.
+let at : (Float, Float, Float, Body) => Body
+let velocity : (Float, Float, Float, Body) => Body
+let mass : (Float, Body) => Body
+let friction : (Float, Body) => Body
+let restitution : (Float, Body) => Body
+let sensor : (Body) => Body
+
+// The world (gx, gy, gz, bodies).
+let scene : (Float, Float, Float, List<Body>) => Scene
+
+// Reads of the LIVE stepped world (in-process, no boundary).
+let position : (String) => Position
+let timelineFrame : () => Float
+
+// Scene LAST (subject-last), so it pipes: place a visual at a body's live pose —
+// `Scene.cube() |> Physics.transformed("crate-1")`.
+let transformed : (String, Scene.Node) => Scene.Node
+
+// Command EFFECTS (tag, x, y, z).
+let applyImpulse : (String, Float, Float, Float) => Effect.T
+let applyForce : (String, Float, Float, Float) => Effect.T
+let setVelocity : (String, Float, Float, Float) => Effect.T
+let teleport : (String, Float, Float, Float) => Effect.T
+
+// Query EFFECT: ox, oy, oz, dx, dy, dz, maxDist, tagger.
+let raycast : (Float, Float, Float, Float, Float, Float, Float, (RayHit) => msg) => Effect.T
+
+// Collision-event SUB (what `subscriptions` returns).
+let events : ((CollisionEvent) => msg) => Sub.T
+
+// Timeline-control EFFECTS.
+let pause : () => Effect.T
+let resume : () => Effect.T
+let stepOnce : () => Effect.T
+let rewindTo : (Float) => Effect.T

--- a/functor-prelude/prelude/render_target.mlei
+++ b/functor-prelude/prelude/render_target.mlei
@@ -1,0 +1,12 @@
+// render_target.mlei — the `RenderTarget` host module (interface only;
+// implemented in Rust by FunctorHost in functor_runtime_common::mle_prelude).
+// See docs/mlei.md.
+
+// The opaque render-target handle (`RenderTarget.T` from game code).
+type T
+
+// A named target (512x512 unless piped through `RenderTarget.sized`).
+let named : (String) => T
+// Target LAST (subject-last), so it pipes:
+// `RenderTarget.named("x") |> RenderTarget.sized(256.0, 256.0)`.
+let sized : (Float, Float, T) => T

--- a/functor-prelude/prelude/scene.mlei
+++ b/functor-prelude/prelude/scene.mlei
@@ -1,16 +1,13 @@
 // scene.mlei — the `Scene` host module (interface only; implemented in Rust by
 // FunctorHost in functor_runtime_common::mle_prelude). See docs/mlei.md.
 //
-// Slice 2e-i authors ONE namespace (Scene) end-to-end to prove the prelude
-// pipeline. It is authored in FULL — every `Scene.*` the host provides — because
-// an interface-only module is a CLOSED module: a reference to a member it does
-// not declare is a load error, so a partial Scene would break real games. The
-// remaining host namespaces (Camera, Physics, Effect, Light, …) are authored in
-// 2e-ii; until then they stay gradual host externals (`Unknown`), unaffected.
+// It is authored in FULL — every `Scene.*` the host provides — because an
+// interface-only module is a CLOSED module: a reference to a member it does not
+// declare is a load error, so a partial Scene would break real games.
 //
-// Branded argument types (`Angle`, `Texture`, `RenderTarget`) name types owned
-// by not-yet-authored host modules, so they resolve to `Unknown` for now (the
-// gradual seam) and become real once 2e-ii ships those modules.
+// Branded argument types (`Angle.T`, `Texture.T`, `RenderTarget.T`) name types
+// owned by the sibling host modules authored in 2e-ii, so they resolve to those
+// real opaque types.
 
 // The opaque scene-node handle. Because the module is itself `Scene`, this is
 // referred to as `Scene.Node` from game code.
@@ -34,15 +31,15 @@ let group : (List<Node>) => Node
 let color : (Float, Float, Float, Node) => Node
 let lit : (Float, Float, Float, Node) => Node
 let emissive : (Float, Float, Float, Node) => Node
-let litTexture : (Texture, Node) => Node
-let emissiveTexture : (Texture, Node) => Node
-let litNormalMapped : (Float, Float, Float, Texture, Node) => Node
-let screen : (RenderTarget, Node) => Node
+let litTexture : (Texture.T, Node) => Node
+let emissiveTexture : (Texture.T, Node) => Node
+let litNormalMapped : (Float, Float, Float, Texture.T, Node) => Node
+let screen : (RenderTarget.T, Node) => Node
 
 // Transforms.
 let translate : (Float, Float, Float, Node) => Node
 let scale : (Float, Node) => Node
 let scaleXYZ : (Float, Float, Float, Node) => Node
-let rotateX : (Angle, Node) => Node
-let rotateY : (Angle, Node) => Node
-let rotateZ : (Angle, Node) => Node
+let rotateX : (Angle.T, Node) => Node
+let rotateY : (Angle.T, Node) => Node
+let rotateZ : (Angle.T, Node) => Node

--- a/functor-prelude/prelude/skybox.mlei
+++ b/functor-prelude/prelude/skybox.mlei
@@ -1,0 +1,8 @@
+// skybox.mlei — the `Skybox` host module (interface only; implemented in Rust by
+// FunctorHost in functor_runtime_common::mle_prelude). See docs/mlei.md.
+
+// The opaque skybox handle (`Skybox.T` from game code).
+type T
+
+// Six non-empty cubemap face paths (+X, -X, +Y, -Y, +Z, -Z).
+let files : (String, String, String, String, String, String) => T

--- a/functor-prelude/prelude/sub.mlei
+++ b/functor-prelude/prelude/sub.mlei
@@ -1,0 +1,18 @@
+// sub.mlei — the `Sub` host module (interface only; implemented in Rust by
+// FunctorHost in functor_runtime_common::mle_prelude). See docs/mlei.md.
+//
+// Subscriptions: what the optional `subscriptions = (model) => …` hook returns.
+// The `msg` type variable is the game's message type (typically an ADT variant).
+
+// The opaque subscription handle (`Sub.T` from game code).
+type T
+
+let none : () => T
+// The `msg` is a message VALUE, held by the host and handed back verbatim when
+// the timer fires.
+let every : (Time.T, msg) => T
+let batch : (List<T>) => T
+// A persistent connection (client) / listener (server): the tagger receives
+// `Net.NetEvent` values.
+let connect : (String, (Net.NetEvent) => msg) => T
+let listen : (String, (Net.NetEvent) => msg) => T

--- a/functor-prelude/prelude/texture.mlei
+++ b/functor-prelude/prelude/texture.mlei
@@ -1,0 +1,8 @@
+// texture.mlei — the `Texture` host module (interface only; implemented in Rust
+// by FunctorHost in functor_runtime_common::mle_prelude). See docs/mlei.md.
+
+// The opaque texture handle (`Texture.T` from game code).
+type T
+
+// An image texture by file path (relative to the game dir).
+let file : (String) => T

--- a/functor-prelude/prelude/time.mlei
+++ b/functor-prelude/prelude/time.mlei
@@ -1,0 +1,11 @@
+// time.mlei — the `Time` host module (interface only; implemented in Rust by
+// FunctorHost in functor_runtime_common::mle_prelude). See docs/mlei.md.
+//
+// A branded duration (seconds): timing functions (`Sub.every`) accept ONLY
+// `Time.T` values, so a bare number is rejected with a teaching error.
+
+// The opaque duration handle (`Time.T` from game code).
+type T
+
+let seconds : (Float) => T
+let millis : (Float) => T

--- a/functor-prelude/prelude/ui.mlei
+++ b/functor-prelude/prelude/ui.mlei
@@ -1,0 +1,17 @@
+// ui.mlei — the `Ui` host module (interface only; implemented in Rust by
+// FunctorHost in functor_runtime_common::mle_prelude). See docs/mlei.md.
+//
+// The optional `ui = (model) => …` hook's vocabulary: text lines stacked in a
+// column, pinned to a screen corner.
+
+// The opaque view handle (`Ui.View` from game code).
+type View
+// The opaque panel-anchor handle (`Ui.Anchor` from game code).
+type Anchor
+
+let text : (String) => View
+let textColor : (Float, Float, Float, String) => View
+let column : (List<View>) => View
+// View LAST (subject-last), so it pipes: `Ui.column([…]) |> Ui.panel(Ui.topLeft())`.
+let panel : (Anchor, View) => View
+let topLeft : () => Anchor

--- a/functor-prelude/src/lib.rs
+++ b/functor-prelude/src/lib.rs
@@ -15,8 +15,26 @@
 /// The module name is what qualified access uses (`Scene.cube`); it is derived
 /// here explicitly rather than from a file name so the loader gets it verbatim.
 pub fn modules() -> Vec<(String, String)> {
-    vec![(
-        "Scene".to_string(),
-        include_str!("../prelude/scene.mlei").to_string(),
-    )]
+    vec![
+        module("Scene", include_str!("../prelude/scene.mlei")),
+        module("Angle", include_str!("../prelude/angle.mlei")),
+        module("Camera", include_str!("../prelude/camera.mlei")),
+        module("Frame", include_str!("../prelude/frame.mlei")),
+        module("Light", include_str!("../prelude/light.mlei")),
+        module("Fog", include_str!("../prelude/fog.mlei")),
+        module("Skybox", include_str!("../prelude/skybox.mlei")),
+        module("RenderTarget", include_str!("../prelude/render_target.mlei")),
+        module("Texture", include_str!("../prelude/texture.mlei")),
+        module("Time", include_str!("../prelude/time.mlei")),
+        module("Sub", include_str!("../prelude/sub.mlei")),
+        module("Effect", include_str!("../prelude/effect.mlei")),
+        module("Physics", include_str!("../prelude/physics.mlei")),
+        module("Ui", include_str!("../prelude/ui.mlei")),
+        module("AudioSource", include_str!("../prelude/audio_source.mlei")),
+        module("AudioScene", include_str!("../prelude/audio_scene.mlei")),
+    ]
+}
+
+fn module(name: &str, src: &str) -> (String, String) {
+    (name.to_string(), src.to_string())
 }

--- a/mle/src/project.rs
+++ b/mle/src/project.rs
@@ -51,12 +51,18 @@ const PROTECTED_NAMESPACES: &[&str] = &[
     "Camera",
     "Frame",
     "Light",
+    "Fog",
+    "Skybox",
     "Angle",
+    "Texture",
     "Time",
     "Sub",
     "Effect",
     "Physics",
     "RenderTarget",
+    "Ui",
+    "AudioSource",
+    "AudioScene",
     "Debug",
 ];
 

--- a/mle/src/types.rs
+++ b/mle/src/types.rs
@@ -1960,20 +1960,22 @@ a catch-all arm (`_` or a name)"
     /// lift first: the B6 producer treats a bare model as
     /// `(model, Effect.none())`, so an arm returning `m` beside an arm
     /// returning `(m, effect)` joins as the PAIR — otherwise the unifier
-    /// is asked for the infinite type `'a = 'a * Unknown` and every
+    /// is asked for the infinite type `'a = 'a * Effect` and every
     /// effect-returning game fails `functor build`. The lift keys on the
-    /// pair's second element being the host seam (Unknown), so real tuple
-    /// mismatches (`(m, 1.0)` vs `m`) still error.
+    /// pair's second element being the effect seam — `Unknown` under plain
+    /// `mle` (no prelude, effects are gradual externals) or the host prelude's
+    /// opaque `Effect` type under the runner — so real tuple mismatches
+    /// (`(m, 1.0)` vs `m`) still error.
     fn join_arms(&mut self, prev: Type, body: Type, span: Span) -> Type {
         let (p, b) = (self.zonk(&prev), self.zonk(&body));
         for (pair, bare) in [(&p, &b), (&b, &p)] {
             if let Type::Tuple(items) = pair {
                 if items.len() == 2
-                    && items[1] == Type::Unknown
+                    && is_effect_seam(&items[1])
                     && !matches!(bare, Type::Tuple(_))
                     && self.unify_rec(bare, &items[0], span, "match arm")
                 {
-                    return Type::Tuple(vec![self.zonk(&items[0]), Type::Unknown]);
+                    return Type::Tuple(vec![self.zonk(&items[0]), items[1].clone()]);
                 }
             }
         }
@@ -2284,6 +2286,21 @@ is {other}"
                 format!("`{}` needs Float operands, got {ty}", op_str(op)),
             );
         }
+    }
+}
+
+/// The second element of an entry point's `(model, effect)` return, for the
+/// bare-model lift in [`Checker::join_arms`]. `Unknown` under plain `mle` (no
+/// prelude — `Effect.*` is a gradual external), or the host prelude's opaque
+/// `Effect` value type (any type owned by the `Effect` module — a user module
+/// cannot claim that name, it is a protected namespace) under the runner.
+fn is_effect_seam(ty: &Type) -> bool {
+    match ty {
+        Type::Unknown => true,
+        Type::Variant(name, _) => name
+            .rsplit_once('.')
+            .is_some_and(|(module, _)| module == "Effect"),
+        _ => false,
     }
 }
 

--- a/runtime/functor-runtime-common/src/mle_prelude.rs
+++ b/runtime/functor-runtime-common/src/mle_prelude.rs
@@ -3068,16 +3068,16 @@ mod tests {
             .clone()
     }
 
-    // Drift guard: every signature authored in the `functor-prelude` `.mlei`
-    // interfaces must name a real host external in `PATHS`, so the declared
-    // types and the Rust implementations cannot silently diverge. We parse the
-    // `.mlei` sources to extract `Module.name` signatures and check each exists.
-    //
-    // TODO(2e-ii): assert the FULL bijection (every `PATHS` entry also has a
-    // signature) once every host namespace is authored as `.mlei`.
+    // Drift guard: a HARD BIJECTION between the `functor-prelude` `.mlei`
+    // signatures and the host `PATHS`. Every `.mlei` `val`/`let` signature must
+    // name a real host external, AND every host external must have exactly one
+    // signature — so the declared types and the Rust implementations cannot
+    // silently diverge in either direction. We parse the `.mlei` sources to
+    // extract `Module.name` signatures and compare the two sets.
     #[test]
     fn prelude_signatures_map_to_host_paths() {
-        let mut checked = 0;
+        use std::collections::BTreeSet;
+        let mut signatures: BTreeSet<String> = BTreeSet::new();
         for (module, src) in functor_prelude::modules() {
             let program = mle::parse_interface(&src)
                 .unwrap_or_else(|e| panic!("prelude module `{module}` must parse: {}", e.message));
@@ -3085,17 +3085,28 @@ mod tests {
                 if let mle::ast::Item::Sig(sig) = item {
                     let path = format!("{module}.{}", sig.name);
                     assert!(
-                        PATHS.contains(&path.as_str()),
-                        "prelude signature `{path}` has no matching host external in PATHS \
-(mle_prelude.rs) — a phantom signature"
+                        signatures.insert(path.clone()),
+                        "prelude signature `{path}` is authored more than once"
                     );
-                    checked += 1;
                 }
             }
         }
-        // Guard against a vacuous pass (an empty/renamed `.mlei` parsing to zero
-        // signatures would otherwise satisfy the loop trivially).
-        assert!(checked > 0, "the prelude authored no signatures to check");
+
+        let paths: BTreeSet<String> = PATHS.iter().map(|p| p.to_string()).collect();
+
+        let phantom: Vec<&String> = signatures.difference(&paths).collect();
+        assert!(
+            phantom.is_empty(),
+            "prelude signatures with no matching host external in PATHS \
+(mle_prelude.rs) — phantom signatures: {phantom:?}"
+        );
+
+        let missing: Vec<&String> = paths.difference(&signatures).collect();
+        assert!(
+            missing.is_empty(),
+            "host externals in PATHS with no `.mlei` signature — an interface-only \
+module is CLOSED, so games referencing these break at load: {missing:?}"
+        );
     }
 
     // The C1 verify criterion (docs/mle.md): an .mle snippet emits exactly

--- a/runtime/functor-runtime-common/tests/prelude_typecheck.rs
+++ b/runtime/functor-runtime-common/tests/prelude_typecheck.rs
@@ -1,0 +1,60 @@
+//! The host prelude (`functor-prelude`) as a check-time overlay (mlei 2e):
+//! host calls get real types, and the MVU `(model, effect)` lift still works
+//! now that `Effect` has a concrete type instead of the old `Unknown` seam.
+
+use std::collections::HashMap;
+
+/// Check `src` as a single-file game WITH the host prelude injected.
+fn check(src: &str) -> Vec<String> {
+    let dir =
+        std::env::temp_dir().join(format!("functor-prelude-typecheck-{}", src.len()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("game.mle"), src).unwrap();
+    let project = match mle::project::load_with_prelude(
+        &dir.join("game.mle"),
+        &HashMap::new(),
+        &functor_prelude::modules(),
+    ) {
+        Ok(project) => project,
+        Err(e) => {
+            let _ = std::fs::remove_dir_all(&dir);
+            return vec![format!("LOAD: {}", e.render())];
+        }
+    };
+    let diags = project.check().into_iter().map(|d| d.message).collect();
+    let _ = std::fs::remove_dir_all(&dir);
+    diags
+}
+
+/// The MVU bare-model lift: an arm returning `m` beside one returning
+/// `(m, effect)` joins as the pair — even though `Effect` is now a real type,
+/// not `Unknown` (the regression `is_effect_seam` fixes).
+#[test]
+fn effect_returning_update_checks_clean() {
+    let diags = check(
+        "let update = (m, msg) =>\n\
+         match msg with | true => (m, Effect.none()) | false => m",
+    );
+    assert!(diags.is_empty(), "effect lift should check clean: {diags:?}");
+}
+
+/// …but a genuine `(model, Float)` vs `model` mismatch still errors — the lift
+/// keys on the effect seam, not any tuple.
+#[test]
+fn real_tuple_mismatch_still_errors() {
+    let diags = check("let f = (m) => match m with | true => (m, 1.0) | false => m");
+    assert!(!diags.is_empty(), "a real (m, Float) vs m mismatch must error");
+}
+
+/// Host calls carry real types from the prelude `.mlei`, across namespaces.
+#[test]
+fn host_calls_have_real_types() {
+    let diags = check("let bad : Float = Camera.lookAt(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)");
+    assert!(diags.iter().any(|m| m.contains("Camera.T")), "{diags:?}");
+    let diags = check(
+        "let bad : Float =\n\
+         Frame.create(Camera.lookAt(0.0, 0.0, 0.0, 0.0, 0.0, 0.0), Scene.cube())",
+    );
+    assert!(diags.iter().any(|m| m.contains("Frame.T")), "{diags:?}");
+}


### PR DESCRIPTION
Authors the **remaining ~15 host namespaces** as `.mlei` (2e-i shipped `Scene`), so a game's `Camera.lookAt(…)`, `Frame.create(…)`, `Physics.dynamic(…)`, `Effect.now(…)`, etc. all typecheck with **real host types** on the runtime path. This is **slice 2e-ii** — the big authoring pass.

## What's here (delegated + reviewed)
- **15 new `.mlei` files** in `functor-prelude/` — `Angle`, `Camera`, `Frame`, `Light`, `Fog`, `Skybox`, `RenderTarget`, `Texture`, `Time`, `Sub`, `Effect`, `Physics`, `Ui`, `AudioSource`, `AudioScene` — every signature derived from the host `call` arms in `mle_prelude.rs`, not guessed. **94 signatures**, each namespace authored in *full* (closed-module rule).
- **Type-naming convention:** each single-handle module's opaque type is `T` (`Camera.T`, `Frame.T`, `Effect.T`, …); multi-handle modules name each descriptively (`Physics.Shape`/`Body`/`Scene`, `Ui.View`/`Anchor`). `Scene.Node` (shipped in 2e-i) is a readable deviation, kept. Cross-namespace refs resolve (`Frame.create : (Camera.T, Scene.Node) => Frame.T`); Physics records + taggers modeled exactly (`Physics.RayHit`, `Effect.now : ((Float) => msg) => Effect.T`, `Net.NetEvent` taggers).
- **Hard-bijection drift test** (94 `.mlei` signatures ↔ 94 host `PATHS` entries, both directions + uniqueness) — the prelude can't drift from the host.

## Two necessary core changes (surfaced by giving `Effect` a real type)
1. **`mle/src/types.rs` — `is_effect_seam`.** The MVU `(model, effect)` bare-model lift keyed on the pair's 2nd element being `Unknown` (the old host seam). With a real `Effect.T`, that key went stale and **every effect-returning game failed to check**. Now the lift fires for `Unknown` (plain `mle`) *or* an `Effect`-module type (under the prelude). Verified it does **not** mask real mismatches — `(m, 1.0)` vs `m` still errors (permanent regression test added).
2. **`mle/src/project.rs`** — added the 6 newly-real modules (`Fog`, `Skybox`, `Texture`, `Ui`, `AudioSource`, `AudioScene`) to `PROTECTED_NAMESPACES` so a user file can't silently collide with a closed prelude module. All 16 injected namespaces are now protected; skill kept in sync.

## Verification
- `cargo test -p mle -p functor-prelude -p functor_runtime_common` green (incl. the 94↔94 drift test + a new `prelude_typecheck` regression suite: effect-lift clean, mismatch still errors, `Camera.T`/`Frame.T` real).
- **All 14 example games** load + check clean under the full prelude (the real closed-module test) — I re-verified this and the two core behaviors myself.
- No new warnings. (Pre-existing, unrelated: `functor-runtime-web` is wasm-only; one `mle run` stack-overflow test is environment-specific.)

Implemented by a delegated agent; I reviewed the `is_effect_seam` fix and protected-namespace change line-by-line, spot-checked signatures against the host, and ran the behavioral probes. `/xreview` (Claude engine; Codex rate-limited) — no Critical/High/Medium.

## Next — 2e-iii (the finale)
Wire `mle-lsp` to depend on `functor-prelude` → real host types in the editor: `Scene.cube() : Scene.Node`, `Camera.lookAt(…) : Camera.T` in hover/inlay/codelens, zero annotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)