### PR TITLE
refactor(mle): lowercase type names — float/bool/string, 'a type variables, Module.t

### DIFF
--- a/.claude/skills/mle-language/SKILL.md
+++ b/.claude/skills/mle-language/SKILL.md
@@ -33,15 +33,15 @@ regenerates). VSCode gets live parse/lower/type diagnostics,
 
 ```mle
 // line comments only
-type Position = { x: Float, y: Float }        // record types; nominal in annotations
+type Position = { x: float, y: float }        // record types; nominal in annotations
 
-type Box<v> =                                 // GENERIC declarations: lowercase params
-  | Full(value: v)                            //   Box<Float> and Box<String> coexist;
+type Box<'v> =                                // GENERIC declarations: 'v type-var params
+  | Full(value: 'v)                           //   Box<float> and Box<string> coexist;
   | Empty                                     //   params substitute through fields/patterns
 
 type Shape =                                  // variant types (ADTs); nominal like records
-  | Circle(radius: Float)                     // leading | REQUIRED, first alternative too
-  | Rect(w: Float, h: Float)                  // fields named in the decl…
+  | Circle(radius: float)                     // leading | REQUIRED, first alternative too
+  | Rect(w: float, h: float)                  // fields named in the decl…
   | Point                                     // …nullary ctor: no parens, ever
 
 type SceneNode                                // ABSTRACT type (no `= body`): an opaque nominal —
@@ -51,30 +51,30 @@ type SceneNode                                // ABSTRACT type (no `= body`): an
 let c = Circle(2.0)                           // …but ctors are CALLED positionally
 let shapes = [c, Rect(3.0, 4.0), Point]       // bare Point IS the value
 
-let area = (s: Shape): Float =>
+let area = (s: Shape): float =>
   match s with                                // match: | pattern => full-expression body
   | Circle(r) => 3.14 * r * r                 // ctor patterns bind positionally
   | Rect(w, _) => w * w                       // sub-patterns: names or _ ONLY (no nesting)
   | Point => 0.0                              // exhaustiveness checked when s's type is known
 
-let sizeOf = (s: Shape): String =>
+let sizeOf = (s: Shape): string =>
   match area(s) > 10.0 with                   // bool-literal match = the ONLY conditional
   | true => "big"
   | false => "small"                          // number/string literal arms exist too
                                               // (they need a catch-all: `| x =>` or `| _ =>`)
 
-let threshold = 10                            // top-level let; ints/floats are all Float (f64)
+let threshold = 10                            // top-level let; ints/floats are all float (f64)
 let origin: Position = { x: 0.0, y: 0.0 }     // OPTIONAL binding annotation `let name: Type = …`
                                               //   (checked against the value; also on `let … in`)
 let scores = [1.0, 2.0, 3.0]                  // list literal; [x, ..xs] prepends
-let sumList = (xs: List<Float>): Float =>     // list PATTERNS: [] / [a,b] / [h, ..t]
+let sumList = (xs: List<float>): float =>     // list PATTERNS: [] / [a,b] / [h, ..t]
   match xs with
   | [] => 0.0
   | [head, ..rest] => head + sumList(rest)    // refutable; needs a catch-all or [..r]
 let s = "text\n"                              // strings: escapes \" \\ \n \t
 let flag = true                               // bools
 
-let isHigh = (score: Float): Bool => score > threshold   // annotations OPTIONAL (gradual)
+let isHigh = (score: float): bool => score > threshold   // annotations OPTIONAL (gradual)
 let describe = (score) => Text.concat("score: ", Text.fromFloat(score))
 
 let report = (scores) =>
@@ -85,12 +85,12 @@ let report = (scores) =>
 
 let nudge = (p: Position): Position => { p with x: p.x + 1.0 }  // record update (fields must exist)
 
-let minMax = (a: Float, b: Float): (Float, Float) =>  // tuple TYPE: (A, B); value tuple: (e1,e2,…)
+let minMax = (a: float, b: float): (float, float) =>  // tuple TYPE: (A, B); value tuple: (e1,e2,…)
   match a < b with
   | true => (a, b)                            // `(e)` / `(A)` is GROUPING, not a 1-tuple
   | false => (b, a)
 
-let apply = (f: (Float) => Float, x: Float): Float => f(x)  // function TYPE: (A, B) => C, () => C
+let apply = (f: (float) => float, x: float): float => f(x)  // function TYPE: (A, B) => C, () => C
 // return-position function types need parens: (): ((A) => B) => …  (the outer => is the body)
 
 let span = (a, b) =>
@@ -111,7 +111,7 @@ loosest), unary `-`. There is **no** if/else, loops, or string-concatenation
 operator — iteration is `List.map/filter/fold`,
 and the conditional is a **bool-literal match**
 (`match x > 3.0 with | true => a | false => b`). Tuples are structural:
-`(1.0, "a") == (1.0, "a")`; tuple types annotate as `(Float, String)` and
+`(1.0, "a") == (1.0, "a")`; tuple types annotate as `(float, string)` and
 function types as `(A, B) => C` / `() => C`, with `(A)` as grouping. Prefer
 named records for anything that outlives an expression; tuples are for
 multiple returns.
@@ -129,9 +129,9 @@ still counts. File stems must be identifiers (`pure_pipeline.mle`, not
 
 ```mle
 // utils.mle                                  // → module Utils
-type Shape = | Circle(radius: Float) | Point
+type Shape = | Circle(radius: float) | Point
 let tau = 6.28
-let area = (s: Shape): Float =>
+let area = (s: Shape): float =>
   match s with
   | Circle(r) => 3.14 * r * r
   | Point => 0.0
@@ -153,7 +153,7 @@ let grab = (s) =>
 
 - **Qualified access needs NO import**: `Utils.clamp(x)`, `Utils.Circle(…)`
   (expressions and patterns, first-class when unapplied), `Utils.Shape` /
-  `Utils.Box<Float>` in annotations. `open Utils` adds unqualified access;
+  `Utils.Box<float>` in annotations. `open Utils` adds unqualified access;
   a name collision with the module's own defs or another `open` is a load
   error naming both sides (qualify instead). `open` is contextual — it
   stays a valid binding name.
@@ -169,8 +169,8 @@ let grab = (s) =>
   Frame, Light, Fog, Skybox, Angle, Texture, Time, Sub, Effect, Physics,
   RenderTarget, Ui, AudioSource, AudioScene) is a load error — rename the file.
 - **`Net` is a built-in module**, always in scope: `type NetEvent =
-  | Connected(id: Float) | Message(id: Float, text: String) |
-  Disconnected(id: Float) | Error(id: Float, text: String)`. A `Sub.connect`/
+  | Connected(id: float) | Message(id: float, text: string) |
+  Disconnected(id: float) | Error(id: float, text: string)`. A `Sub.connect`/
   `Sub.listen` tagger receives these — `match ev with | Net.Connected(id)
   => …` — with no declaration needed.
 - Constructor names must be unique per MODULE (not per project); values
@@ -196,12 +196,12 @@ so there is no paired-`.mle` implementation.) Bodies are forbidden in a
 // widget.mlei                              → interface module Widget
 type Handle                                 // abstract type (opaque; host-made)
 let make : () => Handle                     // bodyless SIGNATURE (the chosen form —
-let size : (Handle) => Float                //   `let name : Type`, no `= body`)
+let size : (Handle) => float                //   `let name : Type`, no `= body`)
 ```
 
 ```mle
 // game.mle
-let area = (h: Widget.Handle): Float => Widget.size(h)   // qualified; typed by widget.mlei
+let area = (h: Widget.Handle): float => Widget.size(h)   // qualified; typed by widget.mlei
 open Widget                                              // …or open, bringing make/size/Handle bare
 ```
 
@@ -215,10 +215,10 @@ open Widget                                              // …or open, bringing
   `Light`, `Fog`, `Skybox`, `RenderTarget`, `Texture`, `Angle`, `Time`, `Sub`,
   `Effect`, `Physics`, `Ui`, `AudioSource`, `AudioScene`), loaded by the runner
   so engine calls carry real types (no longer `Unknown`). Each module's primary
-  opaque handle is `Mod.T` (`Camera.T`, `Frame.T`, `Effect.T`, …); modules that
-  own several name each (`Scene.Node`; `Physics.Shape`/`Body`/`Scene`;
-  `Ui.View`/`Anchor`). Physics query/event results are records
-  (`Physics.Position`, `Physics.RayHit`, `Physics.CollisionEvent`).
+  opaque handle is `Mod.t` (`Camera.t`, `Frame.t`, `Effect.t`, …); modules that
+  own several name each (`Scene.t`; `Physics.shape`/`body`/`world`;
+  `Ui.view`/`anchor`). Physics query/event results are records
+  (`Physics.position`, `Physics.rayHit`, `Physics.collisionEvent`).
 
 ## Semantics rules that WILL bite you
 
@@ -269,16 +269,16 @@ thread through `|>` (which appends): `list |> List.map(fn)` == `List.map(fn, lis
 
 `List.map(fn, list)` · `List.filter(fn, list)` · `List.fold(fn, init, list)`
 (callback is `(acc, x) => …`) · `List.range(n)` (`[0 … n-1]`) ·
-`List.grid(fn, rows, cols)` (→ `List<List<a>>`; calls `fn(row, col)`, both
+`List.grid(fn, rows, cols)` (→ `List<List<'a>>`; calls `fn(row, col)`, both
 0-based, per cell — the engine-loop form of a procedural heightmap, e.g.
 `Scene.heightmap(List.grid(height, r, c))`) ·
 `List.maximum(list)` · `Text.concat(a, b)` · `Text.fromFloat(n)` ·
 `Text.fixed(n, decimals)` (fixed-decimal; `Text.fixed(42.0, 0.0)` = `"42"`, the
-`%d` shape) · `Text.toBullets(list)` · `Text.split(sep, s)` (→ `List<String>`;
+`%d` shape) · `Text.toBullets(list)` · `Text.split(sep, s)` (→ `List<string>`;
 empty `sep` is an error; `Text.split(sep, "")` = `[""]`) · `Text.join(sep, list)`
 (strings only) · `Text.parseFloat(s)` (trims; unparseable → `0.0`, the F#
 `unwrap_or(0)` shape) · `Math.clamp01(n)` · `Math.sin(n)` · `Math.cos(n)` ·
-`Debug.log(label, value)` — `(String, 'a) => 'a`: an Elm-style trace. Logs
+`Debug.log(label, value)` — `(string, 'a) => 'a`: an Elm-style trace. Logs
 `label: <value>` (the value rendered exactly as `mle run`/`trace` displays it —
 any type) and returns `value` **unchanged**, so it's pure to the program
 result and safe to drop into a pipe: `m.x |> Debug.log("x") |> clamp(0.0, 1.0)`
@@ -374,7 +374,7 @@ frame |> Frame.withSkybox(sky)                             //   paths (+X..-Z). 
                                                            //   Fog never fogs the sky
 Time.seconds(1.0) / Time.millis(500.0)                     // Duration VALUES only
 Sub.every(duration, msg) / Sub.none() / Sub.batch([sub,…]) // what subscriptions returns
-Effect.random(tagger) / Effect.now(tagger)                 // one-shots; tagger: (Float) => Msg
+Effect.random(tagger) / Effect.now(tagger)                 // one-shots; tagger: (float) => Msg
 Sub.connect(url, tagger) / Sub.listen(addr, tagger)        // persistent connections; tagger: (Net.NetEvent) => Msg
 Effect.send(connId, text)                                  // send on an open connection
 Effect.none() / Effect.batch([fx, …])                      //   random: [0,1); now: epoch secs
@@ -412,7 +412,7 @@ Physics.events(tagger)                                     // -> Sub (from `subs
                                                            //   sensor} per contact begin/end
 Physics.pause() / Physics.resume() / Physics.stepOnce()   // -> Effect: recorder controls
 Physics.rewindTo(frame)                                    // -> Effect: seek (resume = branch)
-Physics.timelineFrame()                                    // -> Float: current fixed frame
+Physics.timelineFrame()                                    // -> float: current fixed frame
 ```
 
 `Physics.position` / `Physics.transformed` read the live stepped world
@@ -451,8 +451,8 @@ testable with no world at all.
 
 `Physics.events` is a **Sub** (return it from `subscriptions`, alone or in
 `Sub.batch`; it requires `update`). Every contact begin/end from this
-frame's physics step arrives post-step as `{started: Bool, a: Text,
-b: Text, sensor: Bool}` — `a`/`b` are the pair's tags in rapier's
+frame's physics step arrives post-step as `{started: bool, a: Text,
+b: Text, sensor: bool}` — `a`/`b` are the pair's tags in rapier's
 (deterministic) order, so check both; `sensor: true` marks an overlap with
 a `Physics.sensor` body (no contact forces). Events for a pair whose body
 was despawned this frame are dropped (there is nothing left to name), and
@@ -553,13 +553,13 @@ inspected, compared, or serialized.
 `mle check` runs REAL INFERENCE (B7): unannotated code gets full types via
 unification with let-polymorphism — generic functions instantiate fresh at
 every use, element types flow through `List.map`/`filter`/`fold`, and
-lowercase annotation names are type variables (`(xs: List<a>, seed: b): List<b>`). Inference has teeth: unannotated bad calls, mixed-element
+apostrophe-prefixed annotation names are type variables (`(xs: List<'a>, seed: 'b): List<'b>`). Inference has teeth: unannotated bad calls, mixed-element
 lists, and contradictory `mut` use are errors now. `Unknown` remains ONLY
-at genuinely-dynamic seams (host values, unrecognized Uppercase type
+at genuinely-dynamic seams (host values, unrecognized type
 names) and absorbs anything. (Function TYPES cannot be written in
-annotations yet — `f: (a) => b` does not parse; leave higher-order
-parameters unannotated and let inference type them.) Generic declarations (`type Pair<x, y> = { first: x, second: y }`)
-instantiate fresh per use; an UNDECLARED lowercase name in a declaration is
+annotations yet — `f: ('a) => 'b` does not parse; leave higher-order
+parameters unannotated and let inference type them.) Generic declarations (`type Pair<'x, 'y> = { first: 'x, second: 'y }`)
+instantiate fresh per use; an UNDECLARED type variable in a declaration is
 a teaching error. Record literals resolve nominally, F#-style:
 the unique declared type with exactly that field set (no match = anonymous
 data, still fine; two same-shaped declarations make a bare literal

--- a/docs/mle.md
+++ b/docs/mle.md
@@ -162,7 +162,7 @@ snapshots — no GPU, fully agent-verifiable.
       example, a `.trace` golden, and a semantics/runtime-error suite
       (closures, late binding, arity, depth caps, NaN policy). (done)
 - [x] **B4. Basic types.** Gradual checking over the core IR (`mle check`),
-      with annotations, not inference: primitives (`Float`/`String`/`Bool`),
+      with annotations, not inference: primitives (`float`/`string`/`bool`),
       nominal declared record types, `List<T>`, and function types from
       lambda annotations. Anything unannotated or unrecognized (e.g. a
       generic parameter) is Unknown, and a check fires only where both sides
@@ -210,7 +210,7 @@ snapshots — no GPU, fully agent-verifiable.
       stays grouping); tuple patterns in `match` (`| (x, y) =>`, shallow
       like ctor sub-patterns) and a destructuring let
       (`let (a, b) = e in …`) since multiple-returns is the point;
-      `(Float, Float)` tuple types in annotations; `Value::Tuple` with
+      `(float, float)` tuple types in annotations; `Value::Tuple` with
       structural equality and `(1, 2)` display; checker arity + element
       types, exhaustiveness-compatible; hover/LSP display; rebind walk;
       no positional field access (`t.0`) — destructure instead (named
@@ -281,7 +281,7 @@ snapshots — no GPU, fully agent-verifiable.
       contradictory mut use, and foreign match arms are all caught now.
       *Verify (done):* both shipped games + all example goldens check
       clean under inference; `(xs, k) => List.map((x) => x * k, xs)`
-      hovers as `(List<Float>, Float) => List<Float>`; teeth + occurs +
+      hovers as `(List<float>, float) => List<float>`; teeth + occurs +
       ambiguity + SCC polymorphism pinned (215 mle tests).
       *Original verify:* unannotated examples get full inferred signatures (an
       `mle types` dump, goldened); the B4 diagnostic suite still passes;
@@ -319,7 +319,7 @@ snapshots — no GPU, fully agent-verifiable.
       `docs/spikes/mle-currying.md`.
 - [x] **Language: `Debug.log` trace builtin** (2026-07-06; flipped label-first
       in the currying migration step 3). Core `mle`-crate
-      builtin `Debug.log(label, value) : (String, 'a) => 'a` — an Elm-style
+      builtin `Debug.log(label, value) : (string, 'a) => 'a` — an Elm-style
       trace: logs `label: <value>` (the interpreter's own `Value` display, any
       type) and returns `value` UNCHANGED, so it's pure to the program result
       and pipe-friendly (`x |> Debug.log("x")`; label-first / subject-last, so it
@@ -339,8 +339,8 @@ snapshots — no GPU, fully agent-verifiable.
       surviving sink); `--json` ndjson-validity + determinism (PNG byte-identity)
       + protected-namespace checks. Design: `docs/cli-output.md` (PR-4b).
 - [x] **Language: generic type declarations** (done 2026-07-04, the B7
-      follow-up both review engines asked for). `type Box<v> = | Full(value:
-      v) | Empty` / `type Pair<x, y> = { … }`: checker-only (the runtime
+      follow-up both review engines asked for). `type Box<'v> = | Full(value:
+      'v) | Empty` / `type Pair<'x, 'y> = { … }`: checker-only (the runtime
       was already type-erased) — declarations store parameter placeholders
       in an out-of-band Var namespace (the builtin-scheme trick),
       substituted at every use; ctors instantiate fresh per use; record

--- a/docs/mlei.md
+++ b/docs/mlei.md
@@ -13,8 +13,8 @@ to their own bindings — so inference flows real types through engine-touching
 code instead of collapsing to `Unknown`.
 
 Today the engine API resolves to `ExprKind::External` → `Type::Unknown`, so a
-signature like `ringCube` shows `(Float, Float) => 'i` in hover/codelens instead
-of `(Float, Float) => SceneNode`. The vehicle is **interface files**: a `.mlei`
+signature like `ringCube` shows `(float, float) => 'i` in hover/codelens instead
+of `(float, float) => SceneNode`. The vehicle is **interface files**: a `.mlei`
 declares *types without implementations*, the way OCaml `.mli` / TypeScript
 `.d.ts` do.
 
@@ -26,7 +26,7 @@ and later module encapsulation).
 
 ## Current state (verified) — what parses today
 
-| Position | Simple / generic (`Float`, `List<Float>`) | `*`-tuple (`Float * Float`) | Function type (`(A) => B`) |
+| Position | Simple / generic (`float`, `List<float>`) | `*`-tuple (`float * float`) | Function type (`(A) => B`) |
 | --- | --- | --- | --- |
 | Function parameter `(x: T)` | ✅ | ✅ | ❌ |
 | Return type `(): T =>` | ✅ | ✅ | ❌ |
@@ -83,7 +83,7 @@ grammar (it stays a value-level multiply operator), and switch the type
 `(A, B)` so hover/codelens output matches the input spelling.
 
 This also fixes higher-order annotations that error today:
-`let apply = (f: (Float) => Float, x: Float) => f(x)`.
+`let apply = (f: (float) => float, x: float) => f(x)`.
 
 *Verify:* parse + check tests for every form (function, tuple, grouping, nested,
 return-parens); the migrated examples still check clean; hover/codelens now
@@ -106,7 +106,7 @@ let name : Type = value in body  // let-in
   becomes an error instead of silently `Unknown`.
 - Inlay hints: an annotated binding is skipped (like an annotated param).
 
-*Verify:* `let x: Float = 3.0` checks; a mismatched annotation errors at the
+*Verify:* `let x: float = 3.0` checks; a mismatched annotation errors at the
 value's span; inlay suppresses the hint on annotated bindings.
 
 ### 2c — Abstract types
@@ -123,8 +123,8 @@ type SceneNode           // abstract: no constructors, no fields
 - Check: abstract types are nominal and unify only with themselves (by canonical
   name, e.g. `Scene.SceneNode`); they have no constructors, so you can hold and
   pass one but only host `val`s produce/consume it. Plug into the existing
-  nominal-type table (`Type::Record(String,…)` / `Variant(String,…)`); likely a
-  new `Type::Opaque(String, Vec<Type>)` (name + type args) variant.
+  nominal-type table (`Type::Record(string,…)` / `Variant(string,…)`); likely a
+  new `Type::Opaque(string, Vec<Type>)` (name + type args) variant.
 
 *Verify:* `type T` + a function passing a `T` through checks; constructing a `T`
 (no ctor exists) errors; cross-module `Mod.T` resolves to the same nominal.
@@ -136,10 +136,10 @@ The interface file itself. A `.mlei` contains **only** declarations — no bodie
 ```
 // scene.mlei  →  module `Scene`
 type SceneNode
-type Color = { r: Float, g: Float, b: Float }   // concrete types allowed too
+type Color = { r: float, g: float, b: float }   // concrete types allowed too
 
 val cube    : () => SceneNode
-val color   : (Float, Float, Float, SceneNode) => SceneNode
+val color   : (float, float, float, SceneNode) => SceneNode
 val group   : (List<SceneNode>) => SceneNode
 val rotateY : (Angle, SceneNode) => SceneNode
 ```
@@ -178,7 +178,7 @@ and become ordinary interface-only modules owned by the bundled prelude.
 - **Drift test:** a Rust test asserting every `val` in the bundled `.mlei` maps
   to a real entry in the host registry (`mle_prelude.rs`) and vice versa, so the
   declared types and the Rust implementations cannot silently diverge.
-- Result: `ringCube : (Float, Float) => SceneNode` in hover/codelens; inlay/
+- Result: `ringCube : (float, float) => SceneNode` in hover/codelens; inlay/
   codelens across a real game stop showing `'a`/`Unknown` for engine calls.
 
 ## Module semantics summary

--- a/examples/atmosphere/game.mle
+++ b/examples/atmosphere/game.mle
@@ -19,13 +19,13 @@ let sky = Skybox.files(
   "TropicalSunnyDay_pz.jpg", "TropicalSunnyDay_nz.jpg")
 
 // One pillar at depth i (world z = i * 3), staggered left/right.
-let pillar = (i: Float) =>
+let pillar = (i: float) =>
   Scene.cube()
     |> Scene.lit(0.75, 0.55, 0.4)
     |> Scene.translate(Math.sin(i * 1.7) * 4.0, 0.5, i * 3.0)
 
 // An emissive glow weaving through the colonnade.
-let drifter = (tts: Float) =>
+let drifter = (tts: float) =>
   Scene.sphere()
     |> Scene.scale(0.5)
     |> Scene.emissive(1.0, 0.6, 0.2)
@@ -39,7 +39,7 @@ let lights = () => [
 let init = {}
 let tick = (m, dt, tts) => m
 
-let draw = (m, tts: Float) =>
+let draw = (m, tts: float) =>
   Frame.createLit(
     Camera.lookAt(0.0, 2.4, -6.0, 0.0, 1.0, 8.0),
     Scene.group([

--- a/examples/hello-cubes/game.mle
+++ b/examples/hello-cubes/game.mle
@@ -18,7 +18,7 @@ type Msg =
 
 let init = { spin: 0.0, beat: 0.0 }
 
-let tick = (model, dt: Float, tts: Float) => { model with spin: model.spin + dt * 0.5 }
+let tick = (model, dt: float, tts: float) => { model with spin: model.spin + dt * 0.5 }
 
 let update = (model, msg) =>
   match msg with
@@ -26,7 +26,7 @@ let update = (model, msg) =>
 
 let subscriptions = (model) => Sub.every(Time.seconds(1.0), Beat)
 
-let draw = (model, tts: Float) =>
+let draw = (model, tts: float) =>
   Frame.create(
     Camera.lookAt(0.0, 3.5, -9.0, 0.0, 0.0, 0.0),
     Scene.group([

--- a/examples/hello-cubes/pieces.mle
+++ b/examples/hello-cubes/pieces.mle
@@ -7,7 +7,7 @@ let count = 12.0
 let tau = 6.2831853
 
 // One gradient cube on the ring at index `i`, given the current `spin`.
-let ringCube = (spin: Float, i: Float) =>
+let ringCube = (spin: float, i: float) =>
   Scene.cube()
     |> Scene.color(0.25 + 0.75 * (i / count), 0.35, 0.95 - 0.65 * (i / count))
     |> Scene.rotateY(Angle.radians(i * 0.7 + spin * 2.0))
@@ -15,7 +15,7 @@ let ringCube = (spin: Float, i: Float) =>
     |> Scene.rotateY(Angle.radians(i * tau / count + spin))
 
 // The pulsing sphere at the center of the ring.
-let centerpiece = (spin: Float, beat: Float) =>
+let centerpiece = (spin: float, beat: float) =>
   Scene.sphere()
     |> Scene.color(1.0, 0.5 + 0.5 * Math.cos(beat * 2.1), 0.5 + 0.5 * Math.sin(beat * 1.3))
     |> Scene.scale(1.1 + 0.25 * Math.sin(spin * 4.0))

--- a/examples/hello/game.mle
+++ b/examples/hello/game.mle
@@ -52,7 +52,7 @@ let gridTexture = Texture.file("grid.png")
 // (F#'s `lastMouse: (float32 * float32) option`).
 type Mouse =
   | NoMouse
-  | MouseAt(x: Float, y: Float)
+  | MouseAt(x: float, y: float)
 
 // Fired every second by the subscription below (F#'s `Msg.Tick`).
 type Msg =

--- a/examples/lighting/game.mle
+++ b/examples/lighting/game.mle
@@ -35,7 +35,7 @@ let fountainPos = { x: 5.0, y: 0.5, z: 0.0 }
 // turns by per-frame deltas and never jumps (F#'s `lastMouse` option).
 type Mouse =
   | NoMouse
-  | MouseAt(x: Float, y: Float)
+  | MouseAt(x: float, y: float)
 
 // Delivered when the spacebar gunshot finishes playing (Effect.playThen).
 type Msg =
@@ -146,19 +146,19 @@ let update = (model, msg) =>
   | GunshotDone => model
 
 // The three orbiting point-light colors, by index: red / green / blue.
-let pointColor = (i: Float): (Float, Float, Float) =>
+let pointColor = (i: float): (float, float, float) =>
   match i with
   | 0.0 => (1.0, 0.25, 0.2)
   | 1.0 => (0.3, 1.0, 0.35)
   | _ => (0.4, 0.5, 1.0)
 
 // A point light's position at time tts: orbiting (120 degrees apart), animated.
-let pointPos = (i: Float, tts: Float) =>
+let pointPos = (i: float, tts: float) =>
   let a = tts * 0.6 + i * (tau / 3.0) in
   { x: Math.cos(a) * orbitRadius, y: orbitHeight, z: Math.sin(a) * orbitRadius }
 
 // An emissive marker sphere at each point light's position.
-let markers = (tts: Float) =>
+let markers = (tts: float) =>
   List.range(3.0) |> List.map((i) =>
     let p = pointPos(i, tts) in
     let (r, g, b) = pointColor(i) in
@@ -167,13 +167,13 @@ let markers = (tts: Float) =>
       |> Scene.translate(p.x, p.y, p.z)
       |> Scene.emissive(r, g, b))
 
-let pointLights = (tts: Float) =>
+let pointLights = (tts: float) =>
   List.range(3.0) |> List.map((i) =>
     let p = pointPos(i, tts) in
     let (r, g, b) = pointColor(i) in
     Light.point(p.x, p.y, p.z, r, g, b, 1.4, 4.0))
 
-let draw = (model, tts: Float) =>
+let draw = (model, tts: float) =>
   // Ground + a few lit objects sitting on it (each centered at y = its
   // half-height so it rests on y = 0). Near-white so the colored lights tint
   // them; the ground is a neutral grey.

--- a/examples/monitor/game.mle
+++ b/examples/monitor/game.mle
@@ -15,17 +15,17 @@ let feed = RenderTarget.named("security") |> RenderTarget.sized(256.0, 256.0)
 // and the feed camera so the picture matches the prop.
 // Amplitude stays inside the feed's ~±22° half-fov, so the courtyard never
 // fully leaves the picture.
-let pan = (tts: Float) => Math.sin(tts * 0.5) * 0.5
+let pan = (tts: float) => Math.sin(tts * 0.5) * 0.5
 
 // An orbiting glow so the feed visibly animates.
-let orbiter = (tts: Float) =>
+let orbiter = (tts: float) =>
   Scene.sphere()
     |> Scene.scale(0.45)
     |> Scene.emissive(1.0, 0.55, 0.15)
     |> Scene.translate(Math.cos(tts * 0.8) * 3.0, 0.6, 3.0 + Math.sin(tts * 0.8) * 2.0)
 
 // The courtyard both cameras film.
-let courtyard = (tts: Float) =>
+let courtyard = (tts: float) =>
   Scene.group([
     Scene.plane() |> Scene.scale(22.0) |> Scene.lit(0.55, 0.6, 0.55),
     Scene.cube() |> Scene.lit(0.85, 0.3, 0.25) |> Scene.translate(-2.4, 0.5, 2.0),
@@ -45,7 +45,7 @@ let lights = () => [
 
 // The visible camera prop: a head with a lens (a cylinder's axis is Y;
 // rotateX aims it along +Z), yawed by the SAME pan driving the feed camera.
-let cameraGadget = (tts: Float) =>
+let cameraGadget = (tts: float) =>
   Scene.group([
     Scene.cube() |> Scene.scale(0.45) |> Scene.lit(0.25, 0.25, 0.28),
     Scene.cylinder()
@@ -61,7 +61,7 @@ let cameraGadget = (tts: Float) =>
 // What the security camera sees: its own full frame — the courtyard from the
 // gadget's mount, looking where the gadget points. (The feed deliberately
 // films only the courtyard: a target's scene is independent of the main one.)
-let feedFrame = (tts: Float) =>
+let feedFrame = (tts: float) =>
   Frame.createLit(
     Camera.lookAt(
       0.0, 3.2, -5.0,
@@ -88,7 +88,7 @@ let monitor = () =>
 let init = {}
 let tick = (m, dt, tts) => m
 
-let draw = (m, tts: Float) =>
+let draw = (m, tts: float) =>
   Frame.createLit(
     Camera.lookAt(0.0, 2.6, -9.5, 0.0, 1.2, 0.0),
     Scene.group([courtyard(tts), cameraGadget(tts), monitor()]),

--- a/examples/mpclient/game.mle
+++ b/examples/mpclient/game.mle
@@ -12,19 +12,19 @@
 // shared color palette) and no Option (a ConnState ADT holds the connection id
 // once the socket opens; `Text.fixed` rounding matches mpserver's wire).
 
-type Player = { pid: Float, x: Float, z: Float }
+type Player = { pid: float, x: float, z: float }
 
 type ConnState =
-  | Online(id: Float)
+  | Online(id: float)
   | Offline
 
-type Model = { conn: ConnState, world: List<Player>, status: String }
+type Model = { conn: ConnState, world: List<Player>, status: string }
 
 type Msg =
-  | Joined(id: Float)
-  | Snapshot(text: String)
+  | Joined(id: float)
+  | Snapshot(text: string)
   | Dropped
-  | ConnErr(text: String)
+  | ConnErr(text: string)
 
 let serverUrl = "ws://127.0.0.1:9001/play"
 
@@ -41,7 +41,7 @@ let init = { conn: Offline, world: [], status: "connecting" }
 // "pid,x*100,z*100|..." -> [Player]. Fold+cons filters malformed rows (not
 // exactly 3 fields) and undoes the *100 fixed-point; draw order is irrelevant,
 // so the reversal cons introduces doesn't matter.
-let parseSnapshot = (s: String): List<Player> =>
+let parseSnapshot = (s: string): List<Player> =>
   Text.split("|", s) |> List.fold((acc, row) =>
     match Text.split(",", row) with
     | [p, x, z] =>
@@ -62,10 +62,10 @@ let update = (m: Model, msg: Msg) =>
 // Declaring the connection in `subscriptions` keeps it open.
 let subscriptions = (m: Model) => Sub.connect(serverUrl, toMsg)
 
-let tick = (m: Model, dt: Float, tts: Float) => m
+let tick = (m: Model, dt: float, tts: float) => m
 
 // WASD -> a velocity string the server understands; other keys send nothing.
-let velocityFor = (key: String): String =>
+let velocityFor = (key: string): string =>
   match key with
   | "W" => "0 1"
   | "S" => "0 -1"
@@ -75,7 +75,7 @@ let velocityFor = (key: String): String =>
 
 // Key down sends the direction; key release sends a stop. Both need the live
 // connection id, so nothing is sent until the socket has opened.
-let input = (m: Model, key: String, isDown: Bool) =>
+let input = (m: Model, key: string, isDown: bool) =>
   match m.conn with
   | Offline => m
   | Online(id) =>
@@ -88,19 +88,19 @@ let input = (m: Model, key: String, isDown: Bool) =>
 
 // Same palette as mpserver, keyed by player id, so a player is the same
 // color in every pane. MLE has no `%`, so mod4 wraps by recursion.
-let mod4 = (n: Float): Float =>
+let mod4 = (n: float): float =>
   match n < 4.0 with
   | true => n
   | false => mod4(n - 4.0)
 
-let colorFor = (pid: Float): (Float, Float, Float) =>
+let colorFor = (pid: float): (float, float, float) =>
   match mod4(pid) with
   | 0.0 => (0.90, 0.35, 0.35)
   | 1.0 => (0.35, 0.60, 0.95)
   | 2.0 => (0.45, 0.85, 0.45)
   | _ => (0.95, 0.80, 0.35)
 
-let draw = (m: Model, tts: Float) =>
+let draw = (m: Model, tts: float) =>
   // One colored cube per player in the last snapshot the server sent (same
   // framing + palette as mpserver, so panes line up in the netsim viewer).
   let playerNodes =

--- a/examples/mpserver/game.mle
+++ b/examples/mpserver/game.mle
@@ -19,15 +19,15 @@
 //   - MLE has no `%` or `<>`, so `mod4` (bounded recursion) picks the color
 //     and a bool-literal match expresses "not equal".
 
-type Player = { cid: Float, pid: Float, x: Float, z: Float, vx: Float, vz: Float }
+type Player = { cid: float, pid: float, x: float, z: float, vx: float, vz: float }
 
-type Model = { players: List<Player>, nextPid: Float }
+type Model = { players: List<Player>, nextPid: float }
 
 type Msg =
-  | Joined(cid: Float)
-  | Moved(cid: Float, text: String)
-  | Left(cid: Float)
-  | NetErr(text: String)
+  | Joined(cid: float)
+  | Moved(cid: float, text: string)
+  | Left(cid: float)
+  | NetErr(text: string)
 
 let bind = "127.0.0.1:9001"
 let speed = 2.0
@@ -43,7 +43,7 @@ let toMsg = (ev: Net.NetEvent): Msg =>
 
 // Integrate one axis a frame, wrapping around the arena edges (asteroids-style)
 // so entities stay in a fixed playfield instead of drifting off-screen.
-let wrapAxis = (pos: Float, vel: Float, dt: Float): Float =>
+let wrapAxis = (pos: float, vel: float, dt: float): float =>
   let p = pos + vel * speed * dt in
   match p > arena with
   | true => p - 2.0 * arena
@@ -53,12 +53,12 @@ let wrapAxis = (pos: Float, vel: Float, dt: Float): Float =>
      | false => p)
 
 // Wire format: "pid,x*100,z*100|pid,x*100,z*100|...".
-let encodePlayer = (p: Player): String =>
+let encodePlayer = (p: Player): string =>
   Text.join(
     ",",
     [Text.fixed(p.pid, 0.0), Text.fixed(p.x * 100.0, 0.0), Text.fixed(p.z * 100.0, 0.0)])
 
-let encode = (players: List<Player>): String =>
+let encode = (players: List<Player>): string =>
   Text.join("|", List.map(encodePlayer, players))
 
 let init = { players: [], nextPid: 0.0 }
@@ -92,7 +92,7 @@ let update = (m: Model, msg: Msg): Model =>
 // Declaring the listener in `subscriptions` keeps the server bound.
 let subscriptions = (m: Model) => Sub.listen(bind, toMsg)
 
-let tick = (m: Model, dt: Float, tts: Float) =>
+let tick = (m: Model, dt: float, tts: float) =>
   // Integrate, then broadcast the snapshot to every client.
   let players =
     m.players |> List.map((p) =>
@@ -105,19 +105,19 @@ let tick = (m: Model, dt: Float, tts: Float) =>
 // the same color in every pane. MLE has no `%`, so mod4 wraps by recursion —
 // bounded by the demo's small player count (the z-lane spawn runs players off
 // the arena past a handful, so pid stays small).
-let mod4 = (n: Float): Float =>
+let mod4 = (n: float): float =>
   match n < 4.0 with
   | true => n
   | false => mod4(n - 4.0)
 
-let colorFor = (pid: Float): (Float, Float, Float) =>
+let colorFor = (pid: float): (float, float, float) =>
   match mod4(pid) with
   | 0.0 => (0.90, 0.35, 0.35)
   | 1.0 => (0.35, 0.60, 0.95)
   | 2.0 => (0.45, 0.85, 0.45)
   | _ => (0.95, 0.80, 0.35)
 
-let draw = (m: Model, tts: Float) =>
+let draw = (m: Model, tts: float) =>
   // One colored cube per player at its authoritative position, on a ground
   // plane sized to the wrap boundary (so the playfield edges are visible).
   let playerNodes =

--- a/examples/netdemo/game.mle
+++ b/examples/netdemo/game.mle
@@ -16,10 +16,10 @@
 // Where the request is in its lifecycle.
 type Phase =
   | Loading
-  | Done(status: Float, body: String)
-  | Failed(text: String)
+  | Done(status: float, body: string)
+  | Failed(text: string)
 
-type Model = { phase: Phase, frame: Float }
+type Model = { phase: Phase, frame: float }
 
 // The HTTP result, tagged back to us. `Net.HttpResponse` is the built-in ADT
 // `| Response(status, body) | Failure(error)` (a completed request vs a
@@ -40,12 +40,12 @@ let update = (m: Model, msg: Msg) =>
 
 // Fire the request once, on the first frame (the F# startup-effect seed); the
 // runtime applies the `GotResponse` tagger when the response lands.
-let tick = (m: Model, dt: Float, tts: Float) =>
+let tick = (m: Model, dt: float, tts: float) =>
   match m.frame == 0.0 with
   | true => ({ m with frame: 1.0 }, Effect.httpGet(endpoint, GotResponse))
   | false => { m with frame: m.frame + 1.0 }
 
-let draw = (m: Model, tts: Float) =>
+let draw = (m: Model, tts: float) =>
   // A single emissive cube so there's something on screen; the meaningful
   // state is the textual phase, inspected via /state.
   Frame.create(

--- a/examples/physics/game.mle
+++ b/examples/physics/game.mle
@@ -70,9 +70,9 @@ let crateVisual = (model, i) =>
 
 // The message ADT: ctor taggers wrap each async result in its own arm —
 // raycast answers and contact events share one `update` without ambiguity.
-type Msg<h, e> =
-  | GotHit(hit: h)
-  | Contact(ev: e)
+type Msg<'h, 'e> =
+  | GotHit(hit: 'h)
+  | Contact(ev: 'e)
 
 let init = { drop: 0.0, spaceHeld: false, hot: "", paused: false, pHeld: false }
 

--- a/examples/primitives/game.mle
+++ b/examples/primitives/game.mle
@@ -12,7 +12,7 @@
 let tau = 6.2831853
 let orbitRadius = 3.2
 
-let pointPos = (i: Float, tts: Float) =>
+let pointPos = (i: float, tts: float) =>
   let a = tts * 0.6 + i * (tau / 2.0) in
   { x: Math.cos(a) * orbitRadius, y: 2.2, z: Math.sin(a) * orbitRadius }
 
@@ -25,14 +25,14 @@ let whiteShapes = () =>
   ]) |> Scene.lit(0.9, 0.9, 0.9)
 
 // An emissive marker sphere at a point light's position.
-let marker = (i: Float, tts: Float, r: Float, g: Float, b: Float) =>
+let marker = (i: float, tts: float, r: float, g: float, b: float) =>
   let p = pointPos(i, tts) in
   Scene.sphere()
     |> Scene.scale(0.15)
     |> Scene.emissive(r, g, b)
     |> Scene.translate(p.x, p.y, p.z)
 
-let pointLight = (i: Float, tts: Float, r: Float, g: Float, b: Float) =>
+let pointLight = (i: float, tts: float, r: float, g: float, b: float) =>
   let p = pointPos(i, tts) in
   Light.point(p.x, p.y, p.z, r, g, b, 1.4, 4.0)
 
@@ -40,7 +40,7 @@ let init = {}
 
 let tick = (m, dt, tts) => m
 
-let draw = (m, tts: Float) =>
+let draw = (m, tts: float) =>
   Frame.createLit(
     Camera.firstPerson(
       0.0, 3.5, -8.0,

--- a/examples/synthwave/game.mle
+++ b/examples/synthwave/game.mle
@@ -47,7 +47,7 @@ let scrollSpeed = 4.0
 // wavelength regardless of `rows`/`cols`. Rows run along +Z (into the distance);
 // cols run along X. A couple of sine ridges in depth give rolling hills, gently
 // modulated across X; the lift keeps valleys mostly at/above y = 0.
-let terrainHeight = (phase: Float, r: Float, c: Float): Float =>
+let terrainHeight = (phase: float, r: float, c: float): float =>
   let z = r * rowScale + phase in
   let x = c * colScale in
   Math.sin(z * 0.35) * 1.6
@@ -64,9 +64,9 @@ let skyTexture = Texture.file("sky.png")
 // No per-frame state: the scene is a pure function of time.
 let init = 0.0
 
-let tick = (m: Float, dt: Float, tts: Float) => m
+let tick = (m: float, dt: float, tts: float) => m
 
-let draw = (m: Float, tts: Float) =>
+let draw = (m: float, tts: float) =>
   let phase = tts * scrollSpeed in
   // The neon grid terrain: an emissive grid-cell texture (dark interior,
   // hot-magenta edges) tiled one cell per quad, so the glowing lines align with

--- a/examples/wsdemo/game.mle
+++ b/examples/wsdemo/game.mle
@@ -8,13 +8,13 @@
 
 type Conn =
   | NoConn
-  | Conn(id: Float)
+  | Conn(id: float)
 
-type Model = { conn: Conn, status: String, lastMsg: String }
+type Model = { conn: Conn, status: string, lastMsg: string }
 
 type Msg =
   | Ws(ev: Net.NetEvent)
-  | Send(text: String)
+  | Send(text: string)
 
 let init = { conn: NoConn, status: "connecting", lastMsg: "" }
 
@@ -36,9 +36,9 @@ let update = (m: Model, msg: Msg) =>
 // Declaring the connection in `subscriptions` is what keeps it open.
 let subscriptions = (m: Model) => Sub.connect("ws://127.0.0.1:9001/echo", Ws)
 
-let tick = (m: Model, dt: Float, tts: Float) => m
+let tick = (m: Model, dt: float, tts: float) => m
 
-let draw = (m: Model, tts: Float) =>
+let draw = (m: Model, tts: float) =>
   Frame.create(
     Camera.firstPerson(
       0.0, 0.0, -5.0,

--- a/examples/wsserverdemo/game.mle
+++ b/examples/wsserverdemo/game.mle
@@ -6,13 +6,13 @@
 //
 //   functor -d examples/wsserverdemo run native
 
-type Model = { clients: Float, status: String, lastMsg: String }
+type Model = { clients: float, status: string, lastMsg: string }
 
 type Msg =
-  | ClientConnected(id: Float)
-  | Received(id: Float, text: String)
-  | ClientLeft(id: Float)
-  | ConnError(text: String)
+  | ClientConnected(id: float)
+  | Received(id: float, text: string)
+  | ClientLeft(id: float)
+  | ConnError(text: string)
 
 // The tagger: NetEvent -> a game-specific Msg (a closure, not a ctor).
 let toMsg = (ev: Net.NetEvent): Msg =>
@@ -37,9 +37,9 @@ let update = (m: Model, msg: Msg) =>
 // Declaring the listener in `subscriptions` keeps the server bound.
 let subscriptions = (m: Model) => Sub.listen("127.0.0.1:9001", toMsg)
 
-let tick = (m: Model, dt: Float, tts: Float) => m
+let tick = (m: Model, dt: float, tts: float) => m
 
-let draw = (m: Model, tts: Float) =>
+let draw = (m: Model, tts: float) =>
   Frame.create(
     Camera.firstPerson(
       0.0, 0.0, -5.0,

--- a/functor-prelude/prelude/angle.mlei
+++ b/functor-prelude/prelude/angle.mlei
@@ -1,12 +1,12 @@
 // angle.mlei — the `Angle` host module (interface only; implemented in Rust by
 // FunctorHost in functor_runtime_common::mle_prelude). See docs/mlei.md.
 //
-// A branded angle: rotation/camera functions accept ONLY `Angle.T` values, so a
+// A branded angle: rotation/camera functions accept ONLY `Angle.t` values, so a
 // bare number is rejected with a teaching error. Build one with `Angle.degrees`
 // or `Angle.radians`.
 
-// The opaque angle handle (`Angle.T` from game code).
-type T
+// The opaque angle handle (`Angle.t` from game code).
+type t
 
-let degrees : (Float) => T
-let radians : (Float) => T
+let degrees : (float) => t
+let radians : (float) => t

--- a/functor-prelude/prelude/audio_scene.mlei
+++ b/functor-prelude/prelude/audio_scene.mlei
@@ -3,8 +3,8 @@
 //
 // The audio scene the optional `soundScape = (model) => …` hook returns.
 
-// The opaque audio-scene handle (`AudioScene.T` from game code).
-type T
+// The opaque audio-scene handle (`AudioScene.t` from game code).
+type t
 
-let create : (List<AudioSource.T>) => T
-let empty : () => T
+let create : (List<AudioSource.t>) => t
+let empty : () => t

--- a/functor-prelude/prelude/audio_source.mlei
+++ b/functor-prelude/prelude/audio_source.mlei
@@ -4,12 +4,12 @@
 // Soundscape voices (the continuous, reconciled half of audio). Keyed for
 // cross-frame identity so the shell keeps a live voice playing.
 
-// The opaque audio-source handle (`AudioSource.T` from game code).
-type T
+// The opaque audio-source handle (`AudioSource.t` from game code).
+type t
 
 // key, sound.
-let ambient : (String, String) => T
+let ambient : (string, string) => t
 // key, sound, x, y, z.
-let at : (String, String, Float, Float, Float) => T
+let at : (string, string, float, float, float) => t
 // Source LAST (subject-last), so it pipes: `AudioSource.ambient(…) |> AudioSource.gain(0.35)`.
-let gain : (Float, T) => T
+let gain : (float, t) => t

--- a/functor-prelude/prelude/camera.mlei
+++ b/functor-prelude/prelude/camera.mlei
@@ -1,10 +1,10 @@
 // camera.mlei — the `Camera` host module (interface only; implemented in Rust by
 // FunctorHost in functor_runtime_common::mle_prelude). See docs/mlei.md.
 
-// The opaque camera handle (`Camera.T` from game code).
-type T
+// The opaque camera handle (`Camera.t` from game code).
+type t
 
 // Eye + target (Y-up, right-handed), a fixed 45° fov.
-let lookAt : (Float, Float, Float, Float, Float, Float) => T
+let lookAt : (float, float, float, float, float, float) => t
 // Eye + yaw/pitch/fov Angles: yaw = 0 / pitch = 0 looks down +Z.
-let firstPerson : (Float, Float, Float, Angle.T, Angle.T, Angle.T) => T
+let firstPerson : (float, float, float, Angle.t, Angle.t, Angle.t) => t

--- a/functor-prelude/prelude/effect.mlei
+++ b/functor-prelude/prelude/effect.mlei
@@ -2,23 +2,23 @@
 // FunctorHost in functor_runtime_common::mle_prelude). See docs/mlei.md.
 //
 // Effects: fire-and-forget commands returned beside the model, folded back
-// through `update`. The `msg` type variable is the game's message type.
+// through `update`. The `'msg` type variable is the game's message type.
 
-// The opaque effect handle (`Effect.T` from game code).
-type T
+// The opaque effect handle (`Effect.t` from game code).
+type t
 
-let none : () => T
+let none : () => t
 // The tagger is applied by the producer with the performed result value.
-let now : ((Float) => msg) => T
-let random : ((Float) => msg) => T
-let batch : (List<T>) => T
+let now : ((float) => 'msg) => t
+let random : ((float) => 'msg) => t
+let batch : (List<t>) => t
 // Send text to a live connection (connId, text).
-let send : (Float, String) => T
+let send : (float, string) => t
 // The tagger is a function of the `Net.HttpResponse`.
-let httpGet : (String, (Net.HttpResponse) => msg) => T
-let httpPost : (String, String, (Net.HttpResponse) => msg) => T
+let httpGet : (string, (Net.HttpResponse) => 'msg) => t
+let httpPost : (string, string, (Net.HttpResponse) => 'msg) => t
 // Fire-and-forget audio one-shots. `play` is non-spatial; `playAt` positioned.
-let play : (String) => T
-let playAt : (String, Float, Float, Float) => T
-// Play once and deliver `msg` (a message VALUE, not a tagger) when it finishes.
-let playThen : (String, msg) => T
+let play : (string) => t
+let playAt : (string, float, float, float) => t
+// Play once and deliver `'msg` (a message VALUE, not a tagger) when it finishes.
+let playThen : (string, 'msg) => t

--- a/functor-prelude/prelude/fog.mlei
+++ b/functor-prelude/prelude/fog.mlei
@@ -1,8 +1,8 @@
 // fog.mlei — the `Fog` host module (interface only; implemented in Rust by
 // FunctorHost in functor_runtime_common::mle_prelude). See docs/mlei.md.
 
-// The opaque fog handle (`Fog.T` from game code).
-type T
+// The opaque fog handle (`Fog.t` from game code).
+type t
 
-let linear : (Float, Float, Float, Float, Float) => T
-let exp : (Float, Float, Float, Float) => T
+let linear : (float, float, float, float, float) => t
+let exp : (float, float, float, float) => t

--- a/functor-prelude/prelude/frame.mlei
+++ b/functor-prelude/prelude/frame.mlei
@@ -1,14 +1,14 @@
 // frame.mlei — the `Frame` host module (interface only; implemented in Rust by
 // FunctorHost in functor_runtime_common::mle_prelude). See docs/mlei.md.
 
-// The opaque frame handle (`Frame.T` from game code) — what `draw` returns.
-type T
+// The opaque frame handle (`Frame.t` from game code) — what `draw` returns.
+type t
 
-let create : (Camera.T, Scene.Node) => T
-let createLit : (Camera.T, Scene.Node, List<Light.T>) => T
+let create : (Camera.t, Scene.t) => t
+let createLit : (Camera.t, Scene.t, List<Light.t>) => t
 // Frame LAST (subject-last), so they pipe: `Frame.createLit(…) |> Frame.withFog(fog)`.
 // `withRenderTarget(target, targetFrame, frame)` renders `targetFrame` into
 // `target` each frame, before `frame`'s main pass.
-let withRenderTarget : (RenderTarget.T, T, T) => T
-let withFog : (Fog.T, T) => T
-let withSkybox : (Skybox.T, T) => T
+let withRenderTarget : (RenderTarget.t, t, t) => t
+let withFog : (Fog.t, t) => t
+let withSkybox : (Skybox.t, t) => t

--- a/functor-prelude/prelude/light.mlei
+++ b/functor-prelude/prelude/light.mlei
@@ -1,13 +1,13 @@
 // light.mlei — the `Light` host module (interface only; implemented in Rust by
 // FunctorHost in functor_runtime_common::mle_prelude). See docs/mlei.md.
 
-// The opaque light handle (`Light.T` from game code).
-type T
+// The opaque light handle (`Light.t` from game code).
+type t
 
-let ambient : (Float, Float, Float) => T
-let directional : (Float, Float, Float, Float, Float, Float, Float) => T
-let point : (Float, Float, Float, Float, Float, Float, Float, Float) => T
+let ambient : (float, float, float) => t
+let directional : (float, float, float, float, float, float, float) => t
+let point : (float, float, float, float, float, float, float, float) => t
 // px, py, pz, dx, dy, dz, r, g, b, intensity, range, coneAngle.
-let spot : (Float, Float, Float, Float, Float, Float, Float, Float, Float, Float, Float, Angle.T) => T
+let spot : (float, float, float, float, float, float, float, float, float, float, float, Angle.t) => t
 // Light first, so it pipes: `Light.directional(…) |> Light.castShadows`.
-let castShadows : (T) => T
+let castShadows : (t) => t

--- a/functor-prelude/prelude/physics.mlei
+++ b/functor-prelude/prelude/physics.mlei
@@ -4,72 +4,72 @@
 //
 // Shapes are values, bodies are tag + shape + piped attributes, and the optional
 // `physics = (model) => Physics.scene(…)` hook declares the world each frame.
-// This module owns three opaque handles (Shape, Body, Scene) plus the plain-data
+// This module owns three opaque handles (shape, body, world) plus the plain-data
 // records the query/event APIs hand back.
 
 // Opaque handles.
-type Shape
-type Body
-type Scene
+type shape
+type body
+type world
 
 // The record `Physics.position` returns — the live pose of a body.
-type Position = { x: Float, y: Float, z: Float }
+type position = { x: float, y: float, z: float }
 // The record a `Physics.raycast` tagger receives (hit: false with zeroed fields
 // for a miss).
-type RayHit = {
-  hit: Bool,
-  x: Float, y: Float, z: Float,
-  nx: Float, ny: Float, nz: Float,
-  distance: Float,
-  tag: String
+type rayHit = {
+  hit: bool,
+  x: float, y: float, z: float,
+  nx: float, ny: float, nz: float,
+  distance: float,
+  tag: string
 }
 // The record a `Physics.events` tagger receives, one per contact begin/end.
-type CollisionEvent = { started: Bool, a: String, b: String, sensor: Bool }
+type collisionEvent = { started: bool, a: string, b: string, sensor: bool }
 
 // Shapes.
-let box : (Float, Float, Float) => Shape
-let sphere : (Float) => Shape
-let capsule : (Float, Float) => Shape
+let box : (float, float, float) => shape
+let sphere : (float) => shape
+let capsule : (float, float) => shape
 
 // Bodies (tag, shape).
-let dynamic : (String, Shape) => Body
-let kinematic : (String, Shape) => Body
-let fixed : (String, Shape) => Body
+let dynamic : (string, shape) => body
+let kinematic : (string, shape) => body
+let fixed : (string, shape) => body
 
-// Body LAST (subject-last), so they pipe:
+// body LAST (subject-last), so they pipe:
 // `Physics.dynamic("crate", Physics.box(1.0, 1.0, 1.0)) |> Physics.at(0.0, 5.0, 0.0)`.
-let at : (Float, Float, Float, Body) => Body
-let velocity : (Float, Float, Float, Body) => Body
-let mass : (Float, Body) => Body
-let friction : (Float, Body) => Body
-let restitution : (Float, Body) => Body
-let sensor : (Body) => Body
+let at : (float, float, float, body) => body
+let velocity : (float, float, float, body) => body
+let mass : (float, body) => body
+let friction : (float, body) => body
+let restitution : (float, body) => body
+let sensor : (body) => body
 
 // The world (gx, gy, gz, bodies).
-let scene : (Float, Float, Float, List<Body>) => Scene
+let scene : (float, float, float, List<body>) => world
 
 // Reads of the LIVE stepped world (in-process, no boundary).
-let position : (String) => Position
-let timelineFrame : () => Float
+let position : (string) => position
+let timelineFrame : () => float
 
-// Scene LAST (subject-last), so it pipes: place a visual at a body's live pose —
+// world LAST (subject-last), so it pipes: place a visual at a body's live pose —
 // `Scene.cube() |> Physics.transformed("crate-1")`.
-let transformed : (String, Scene.Node) => Scene.Node
+let transformed : (string, Scene.t) => Scene.t
 
 // Command EFFECTS (tag, x, y, z).
-let applyImpulse : (String, Float, Float, Float) => Effect.T
-let applyForce : (String, Float, Float, Float) => Effect.T
-let setVelocity : (String, Float, Float, Float) => Effect.T
-let teleport : (String, Float, Float, Float) => Effect.T
+let applyImpulse : (string, float, float, float) => Effect.t
+let applyForce : (string, float, float, float) => Effect.t
+let setVelocity : (string, float, float, float) => Effect.t
+let teleport : (string, float, float, float) => Effect.t
 
 // Query EFFECT: ox, oy, oz, dx, dy, dz, maxDist, tagger.
-let raycast : (Float, Float, Float, Float, Float, Float, Float, (RayHit) => msg) => Effect.T
+let raycast : (float, float, float, float, float, float, float, (rayHit) => 'msg) => Effect.t
 
 // Collision-event SUB (what `subscriptions` returns).
-let events : ((CollisionEvent) => msg) => Sub.T
+let events : ((collisionEvent) => 'msg) => Sub.t
 
 // Timeline-control EFFECTS.
-let pause : () => Effect.T
-let resume : () => Effect.T
-let stepOnce : () => Effect.T
-let rewindTo : (Float) => Effect.T
+let pause : () => Effect.t
+let resume : () => Effect.t
+let stepOnce : () => Effect.t
+let rewindTo : (float) => Effect.t

--- a/functor-prelude/prelude/render_target.mlei
+++ b/functor-prelude/prelude/render_target.mlei
@@ -2,11 +2,11 @@
 // implemented in Rust by FunctorHost in functor_runtime_common::mle_prelude).
 // See docs/mlei.md.
 
-// The opaque render-target handle (`RenderTarget.T` from game code).
-type T
+// The opaque render-target handle (`RenderTarget.t` from game code).
+type t
 
 // A named target (512x512 unless piped through `RenderTarget.sized`).
-let named : (String) => T
+let named : (string) => t
 // Target LAST (subject-last), so it pipes:
 // `RenderTarget.named("x") |> RenderTarget.sized(256.0, 256.0)`.
-let sized : (Float, Float, T) => T
+let sized : (float, float, t) => t

--- a/functor-prelude/prelude/scene.mlei
+++ b/functor-prelude/prelude/scene.mlei
@@ -5,41 +5,41 @@
 // interface-only module is a CLOSED module: a reference to a member it does not
 // declare is a load error, so a partial Scene would break real games.
 //
-// Branded argument types (`Angle.T`, `Texture.T`, `RenderTarget.T`) name types
+// Branded argument types (`Angle.t`, `Texture.t`, `RenderTarget.t`) name types
 // owned by the sibling host modules authored in 2e-ii, so they resolve to those
 // real opaque types.
 
 // The opaque scene-node handle. Because the module is itself `Scene`, this is
-// referred to as `Scene.Node` from game code.
-type Node
+// referred to as `Scene.t` from game code.
+type t
 
 // Primitive geometry.
-let cube : () => Node
-let sphere : () => Node
-let cylinder : () => Node
-let quad : () => Node
-let plane : () => Node
+let cube : () => t
+let sphere : () => t
+let cylinder : () => t
+let quad : () => t
+let plane : () => t
 
 // Assets and generated surfaces.
-let model : (String) => Node
-let heightmap : (List<List<Float>>) => Node
+let model : (string) => t
+let heightmap : (List<List<float>>) => t
 
 // Composition.
-let group : (List<Node>) => Node
+let group : (List<t>) => t
 
 // Materials (subject-last, so they pipe: `Scene.cube() |> Scene.color(r,g,b)`).
-let color : (Float, Float, Float, Node) => Node
-let lit : (Float, Float, Float, Node) => Node
-let emissive : (Float, Float, Float, Node) => Node
-let litTexture : (Texture.T, Node) => Node
-let emissiveTexture : (Texture.T, Node) => Node
-let litNormalMapped : (Float, Float, Float, Texture.T, Node) => Node
-let screen : (RenderTarget.T, Node) => Node
+let color : (float, float, float, t) => t
+let lit : (float, float, float, t) => t
+let emissive : (float, float, float, t) => t
+let litTexture : (Texture.t, t) => t
+let emissiveTexture : (Texture.t, t) => t
+let litNormalMapped : (float, float, float, Texture.t, t) => t
+let screen : (RenderTarget.t, t) => t
 
 // Transforms.
-let translate : (Float, Float, Float, Node) => Node
-let scale : (Float, Node) => Node
-let scaleXYZ : (Float, Float, Float, Node) => Node
-let rotateX : (Angle.T, Node) => Node
-let rotateY : (Angle.T, Node) => Node
-let rotateZ : (Angle.T, Node) => Node
+let translate : (float, float, float, t) => t
+let scale : (float, t) => t
+let scaleXYZ : (float, float, float, t) => t
+let rotateX : (Angle.t, t) => t
+let rotateY : (Angle.t, t) => t
+let rotateZ : (Angle.t, t) => t

--- a/functor-prelude/prelude/skybox.mlei
+++ b/functor-prelude/prelude/skybox.mlei
@@ -1,8 +1,8 @@
 // skybox.mlei — the `Skybox` host module (interface only; implemented in Rust by
 // FunctorHost in functor_runtime_common::mle_prelude). See docs/mlei.md.
 
-// The opaque skybox handle (`Skybox.T` from game code).
-type T
+// The opaque skybox handle (`Skybox.t` from game code).
+type t
 
 // Six non-empty cubemap face paths (+X, -X, +Y, -Y, +Z, -Z).
-let files : (String, String, String, String, String, String) => T
+let files : (string, string, string, string, string, string) => t

--- a/functor-prelude/prelude/sub.mlei
+++ b/functor-prelude/prelude/sub.mlei
@@ -2,17 +2,17 @@
 // FunctorHost in functor_runtime_common::mle_prelude). See docs/mlei.md.
 //
 // Subscriptions: what the optional `subscriptions = (model) => …` hook returns.
-// The `msg` type variable is the game's message type (typically an ADT variant).
+// The `'msg` type variable is the game's message type (typically an ADT variant).
 
-// The opaque subscription handle (`Sub.T` from game code).
-type T
+// The opaque subscription handle (`Sub.t` from game code).
+type t
 
-let none : () => T
-// The `msg` is a message VALUE, held by the host and handed back verbatim when
+let none : () => t
+// The `'msg` is a message VALUE, held by the host and handed back verbatim when
 // the timer fires.
-let every : (Time.T, msg) => T
-let batch : (List<T>) => T
+let every : (Time.t, 'msg) => t
+let batch : (List<t>) => t
 // A persistent connection (client) / listener (server): the tagger receives
 // `Net.NetEvent` values.
-let connect : (String, (Net.NetEvent) => msg) => T
-let listen : (String, (Net.NetEvent) => msg) => T
+let connect : (string, (Net.NetEvent) => 'msg) => t
+let listen : (string, (Net.NetEvent) => 'msg) => t

--- a/functor-prelude/prelude/texture.mlei
+++ b/functor-prelude/prelude/texture.mlei
@@ -1,8 +1,8 @@
 // texture.mlei — the `Texture` host module (interface only; implemented in Rust
 // by FunctorHost in functor_runtime_common::mle_prelude). See docs/mlei.md.
 
-// The opaque texture handle (`Texture.T` from game code).
-type T
+// The opaque texture handle (`Texture.t` from game code).
+type t
 
 // An image texture by file path (relative to the game dir).
-let file : (String) => T
+let file : (string) => t

--- a/functor-prelude/prelude/time.mlei
+++ b/functor-prelude/prelude/time.mlei
@@ -2,10 +2,10 @@
 // FunctorHost in functor_runtime_common::mle_prelude). See docs/mlei.md.
 //
 // A branded duration (seconds): timing functions (`Sub.every`) accept ONLY
-// `Time.T` values, so a bare number is rejected with a teaching error.
+// `Time.t` values, so a bare number is rejected with a teaching error.
 
-// The opaque duration handle (`Time.T` from game code).
-type T
+// The opaque duration handle (`Time.t` from game code).
+type t
 
-let seconds : (Float) => T
-let millis : (Float) => T
+let seconds : (float) => t
+let millis : (float) => t

--- a/functor-prelude/prelude/ui.mlei
+++ b/functor-prelude/prelude/ui.mlei
@@ -4,14 +4,14 @@
 // The optional `ui = (model) => …` hook's vocabulary: text lines stacked in a
 // column, pinned to a screen corner.
 
-// The opaque view handle (`Ui.View` from game code).
-type View
-// The opaque panel-anchor handle (`Ui.Anchor` from game code).
-type Anchor
+// The opaque view handle (`Ui.view` from game code).
+type view
+// The opaque panel-anchor handle (`Ui.anchor` from game code).
+type anchor
 
-let text : (String) => View
-let textColor : (Float, Float, Float, String) => View
-let column : (List<View>) => View
-// View LAST (subject-last), so it pipes: `Ui.column([…]) |> Ui.panel(Ui.topLeft())`.
-let panel : (Anchor, View) => View
-let topLeft : () => Anchor
+let text : (string) => view
+let textColor : (float, float, float, string) => view
+let column : (List<view>) => view
+// view LAST (subject-last), so it pipes: `Ui.column([…]) |> Ui.panel(Ui.topLeft())`.
+let panel : (anchor, view) => view
+let topLeft : () => anchor

--- a/mle/benches/corpus/adt.mle
+++ b/mle/benches/corpus/adt.mle
@@ -4,9 +4,9 @@
 //
 // Convention: `main` is the timed unit of work. Also: `mle run adt.mle`.
 type Shape =
-  | Circle(radius: Float)
-  | Rect(w: Float, h: Float)
-let area = (s: Shape): Float =>
+  | Circle(radius: float)
+  | Rect(w: float, h: float)
+let area = (s: Shape): float =>
   match s with
   | Circle(r) => 3.14159 * r * r
   | Rect(w, h) => w * h

--- a/mle/benches/corpus/record_update.mle
+++ b/mle/benches/corpus/record_update.mle
@@ -3,8 +3,8 @@
 // update per iteration.
 //
 // Convention: `main` is the timed unit of work. Also: `mle run record_update.mle`.
-type Acc = { sum: Float, count: Float }
-let step = (r: Acc, x: Float): Acc => { r with sum: r.sum + x, count: r.count + 1.0 }
+type Acc = { sum: float, count: float }
+let step = (r: Acc, x: float): Acc => { r with sum: r.sum + x, count: r.count + 1.0 }
 let main = () =>
   let final = List.fold(step, { sum: 0.0, count: 0.0 }, List.range(100000)) in
   final.sum + final.count

--- a/mle/examples/checks/broken.check
+++ b/mle/examples/checks/broken.check
@@ -1,10 +1,10 @@
-broken.mle:8:36: error: `+` needs Float operands, got String
-broken.mle:10:37: error: `>` needs Float operands, got Bool
-broken.mle:13:39: error: unary `-` needs a Float operand, got Bool
-broken.mle:16:13: error: `==` compares different types Float and String (always false)
+broken.mle:8:36: error: `+` needs float operands, got string
+broken.mle:10:37: error: `>` needs float operands, got bool
+broken.mle:13:39: error: unary `-` needs a float operand, got bool
+broken.mle:16:13: error: `==` compares different types float and string (always false)
 broken.mle:20:36: error: record literal for `Position` is missing field `y`
 broken.mle:20:44: error: `Position` has no field `z`
 broken.mle:23:36: error: `Position` has no field `z`
-broken.mle:28:37: error: argument 2 of `shift`: expected Float, got String
-broken.mle:31:25: error: argument 1 of `Text.concat`: expected String, got Float
+broken.mle:28:37: error: argument 2 of `shift`: expected float, got string
+broken.mle:31:25: error: argument 1 of `Text.concat`: expected string, got float
 broken.mle:35:17: error: `Position` takes 0 type argument(s), got 1

--- a/mle/examples/checks/broken.mle
+++ b/mle/examples/checks/broken.mle
@@ -2,28 +2,28 @@
 // committed broken.check golden pins the full `mle check` output; this file
 // is NOT covered by the parse/ir/run goldens (it never runs).
 
-type Position = { x: Float, y: Float }
+type Position = { x: float, y: float }
 
-// Arithmetic and comparison operands must be Float when known.
-let bad = (a: Float): Float => a + "one"
+// Arithmetic and comparison operands must be float when known.
+let bad = (a: float): float => a + "one"
 
-let compare = (flag: Bool): Bool => flag > 1.0
+let compare = (flag: bool): bool => flag > 1.0
 
-// Unary minus needs a Float.
-let negated = (flag: Bool): Float => -flag
+// Unary minus needs a float.
+let negated = (flag: bool): float => -flag
 
 // `==` across two different known types is always false.
 let never = 1.0 == "1"
 
 // A record literal checked against the return annotation: `z` is not a
 // field of Position, and `y` is missing.
-let make = (x: Float): Position => { x: x, z: 0.0 }
+let make = (x: float): Position => { x: x, z: 0.0 }
 
 // Field access on a known record type.
-let getZ = (p: Position): Float => p.z
+let getZ = (p: Position): float => p.z
 
 // Calls with a known signature: arity and argument types.
-let shift = (p: Position, dx: Float): Position => { x: p.x + dx, y: p.y }
+let shift = (p: Position, dx: float): Position => { x: p.x + dx, y: p.y }
 let moved = shift({ x: 1.0, y: 2.0 })
 let far = shift({ x: 1.0, y: 2.0 }, "far")
 
@@ -32,4 +32,4 @@ let shout = Text.concat(1.0, "!")
 
 // A known type name applied at the wrong arity (an *unknown* name would be
 // fine — it could be a generic parameter).
-let scale = (p: Position<Float>): Position => p
+let scale = (p: Position<float>): Position => p

--- a/mle/examples/functions.ast
+++ b/mle/examples/functions.ast
@@ -9,7 +9,7 @@ Program {
                         FieldTy {
                             name: "name",
                             ty: TypeName {
-                                name: "String",
+                                name: "string",
                                 args: [],
                                 span: 96..102,
                             },
@@ -21,7 +21,7 @@ Program {
                                 name: "List",
                                 args: [
                                     TypeName {
-                                        name: "Float",
+                                        name: "float",
                                         args: [],
                                         span: 117..122,
                                     },
@@ -46,7 +46,7 @@ Program {
                                 name: "a",
                                 ty: Some(
                                     TypeName {
-                                        name: "Float",
+                                        name: "float",
                                         args: [],
                                         span: 141..146,
                                     },
@@ -57,7 +57,7 @@ Program {
                                 name: "b",
                                 ty: Some(
                                     TypeName {
-                                        name: "Float",
+                                        name: "float",
                                         args: [],
                                         span: 151..156,
                                     },
@@ -67,7 +67,7 @@ Program {
                         ],
                         ret: Some(
                             TypeName {
-                                name: "Float",
+                                name: "float",
                                 args: [],
                                 span: 159..164,
                             },
@@ -180,7 +180,7 @@ Program {
                         ],
                         ret: Some(
                             TypeName {
-                                name: "Float",
+                                name: "float",
                                 args: [],
                                 span: 239..244,
                             },
@@ -269,7 +269,7 @@ Program {
                         ],
                         ret: Some(
                             TypeName {
-                                name: "Float",
+                                name: "float",
                                 args: [],
                                 span: 322..327,
                             },

--- a/mle/examples/functions.ir
+++ b/mle/examples/functions.ir
@@ -9,7 +9,7 @@ Module {
                     FieldTy {
                         name: "name",
                         ty: TypeName {
-                            name: "String",
+                            name: "string",
                             args: [],
                             span: 96..102,
                         },
@@ -21,7 +21,7 @@ Module {
                             name: "List",
                             args: [
                                 TypeName {
-                                    name: "Float",
+                                    name: "float",
                                     args: [],
                                     span: 117..122,
                                 },
@@ -49,7 +49,7 @@ Module {
                             name: "a",
                             ty: Some(
                                 TypeName {
-                                    name: "Float",
+                                    name: "float",
                                     args: [],
                                     span: 141..146,
                                 },
@@ -61,7 +61,7 @@ Module {
                             name: "b",
                             ty: Some(
                                 TypeName {
-                                    name: "Float",
+                                    name: "float",
                                     args: [],
                                     span: 151..156,
                                 },
@@ -71,7 +71,7 @@ Module {
                     ],
                     ret: Some(
                         TypeName {
-                            name: "Float",
+                            name: "float",
                             args: [],
                             span: 159..164,
                         },
@@ -191,7 +191,7 @@ Module {
                     ],
                     ret: Some(
                         TypeName {
-                            name: "Float",
+                            name: "float",
                             args: [],
                             span: 239..244,
                         },
@@ -277,7 +277,7 @@ Module {
                     ],
                     ret: Some(
                         TypeName {
-                            name: "Float",
+                            name: "float",
                             args: [],
                             span: 322..327,
                         },

--- a/mle/examples/functions.mle
+++ b/mle/examples/functions.mle
@@ -1,14 +1,14 @@
 // Higher-order functions, inline lambdas, and generic type annotations.
 
-type Player = { name: String, scores: List<Float> }
+type Player = { name: string, scores: List<float> }
 
-let add = (a: Float, b: Float): Float => a + b
+let add = (a: float, b: float): float => a + b
 
 let average = (a, b) => (a + b) / 2.0
 
-let total = (p: Player): Float => p.scores |> List.fold(add, 0.0)
+let total = (p: Player): float => p.scores |> List.fold(add, 0.0)
 
-let bestTotal = (players: List<Player>): Float =>
+let bestTotal = (players: List<Player>): float =>
   players |> List.map((p) => total(p)) |> List.maximum
 
 let isWinner = (p, cutoff) => cutoff < total(p)

--- a/mle/examples/lists.ast
+++ b/mle/examples/lists.ast
@@ -14,7 +14,7 @@ Program {
                                         name: "List",
                                         args: [
                                             TypeName {
-                                                name: "Float",
+                                                name: "float",
                                                 args: [],
                                                 span: 217..222,
                                             },
@@ -27,7 +27,7 @@ Program {
                         ],
                         ret: Some(
                             TypeName {
-                                name: "Float",
+                                name: "float",
                                 args: [],
                                 span: 226..231,
                             },
@@ -144,7 +144,7 @@ Program {
                                         name: "List",
                                         args: [
                                             TypeName {
-                                                name: "Float",
+                                                name: "float",
                                                 args: [],
                                                 span: 329..334,
                                             },
@@ -158,7 +158,7 @@ Program {
                                 name: "fallback",
                                 ty: Some(
                                     TypeName {
-                                        name: "Float",
+                                        name: "float",
                                         args: [],
                                         span: 347..352,
                                     },
@@ -168,7 +168,7 @@ Program {
                         ],
                         ret: Some(
                             TypeName {
-                                name: "Float",
+                                name: "float",
                                 args: [],
                                 span: 355..360,
                             },
@@ -258,7 +258,7 @@ Program {
                                         name: "List",
                                         args: [
                                             TypeName {
-                                                name: "Float",
+                                                name: "float",
                                                 args: [],
                                                 span: 442..447,
                                             },
@@ -274,12 +274,12 @@ Program {
                                 name: "*",
                                 args: [
                                     TypeName {
-                                        name: "Float",
+                                        name: "float",
                                         args: [],
                                         span: 452..457,
                                     },
                                     TypeName {
-                                        name: "Float",
+                                        name: "float",
                                         args: [],
                                         span: 459..464,
                                     },

--- a/mle/examples/lists.ir
+++ b/mle/examples/lists.ir
@@ -17,7 +17,7 @@ Module {
                                     name: "List",
                                     args: [
                                         TypeName {
-                                            name: "Float",
+                                            name: "float",
                                             args: [],
                                             span: 217..222,
                                         },
@@ -30,7 +30,7 @@ Module {
                     ],
                     ret: Some(
                         TypeName {
-                            name: "Float",
+                            name: "float",
                             args: [],
                             span: 226..231,
                         },
@@ -153,7 +153,7 @@ Module {
                                     name: "List",
                                     args: [
                                         TypeName {
-                                            name: "Float",
+                                            name: "float",
                                             args: [],
                                             span: 329..334,
                                         },
@@ -168,7 +168,7 @@ Module {
                             name: "fallback",
                             ty: Some(
                                 TypeName {
-                                    name: "Float",
+                                    name: "float",
                                     args: [],
                                     span: 347..352,
                                 },
@@ -178,7 +178,7 @@ Module {
                     ],
                     ret: Some(
                         TypeName {
-                            name: "Float",
+                            name: "float",
                             args: [],
                             span: 355..360,
                         },
@@ -272,7 +272,7 @@ Module {
                                     name: "List",
                                     args: [
                                         TypeName {
-                                            name: "Float",
+                                            name: "float",
                                             args: [],
                                             span: 442..447,
                                         },
@@ -288,12 +288,12 @@ Module {
                             name: "*",
                             args: [
                                 TypeName {
-                                    name: "Float",
+                                    name: "float",
                                     args: [],
                                     span: 452..457,
                                 },
                                 TypeName {
-                                    name: "Float",
+                                    name: "float",
                                     args: [],
                                     span: 459..464,
                                 },

--- a/mle/examples/lists.mle
+++ b/mle/examples/lists.mle
@@ -2,17 +2,17 @@
 // `[x, ..xs]` prepend in expressions. Refutable, so a list match needs a
 // catch-all (`_`, a name, or `[..rest]`).
 
-let sum = (xs: List<Float>): Float =>
+let sum = (xs: List<float>): float =>
   match xs with
   | [] => 0.0
   | [head, ..rest] => head + sum(rest)
 
-let firstOr = (xs: List<Float>, fallback: Float): Float =>
+let firstOr = (xs: List<float>, fallback: float): float =>
   match xs with
   | [x, ..rest] => x
   | [] => fallback
 
-let pair = (xs: List<Float>): (Float, Float) =>
+let pair = (xs: List<float>): (float, float) =>
   match xs with
   | [a, b] => (a, b)
   | _ => (0.0, 0.0)

--- a/mle/examples/project/game.mle
+++ b/mle/examples/project/game.mle
@@ -2,12 +2,12 @@
 // qualified access needs no import, `open` brings a module in unqualified.
 open Vec
 
-type Ship = { pos: V2, hull: Float }
+type Ship = { pos: V2, hull: float }
 
 let steer = (ship: Ship, d: V2): Ship =>
   { ship with pos: add(ship.pos, d) }
 
-let cargo = (ship: Ship): Shapes.Box<Float> =>
+let cargo = (ship: Ship): Shapes.Box<float> =>
   match ship.hull > 0.5 with
   | true => Shapes.Full(ship.hull)
   | false => Shapes.Empty

--- a/mle/examples/project/shapes.mle
+++ b/mle/examples/project/shapes.mle
@@ -1,8 +1,8 @@
 // A generic sibling ADT: constructors and type arguments cross module
-// boundaries (`Shapes.Full(0.75)` builds a `Shapes.Box<Float>` anywhere).
+// boundaries (`Shapes.Full(0.75)` builds a `Shapes.Box<float>` anywhere).
 
-type Box<v> =
-  | Full(value: v)
+type Box<'v> =
+  | Full(value: 'v)
   | Empty
 
 let map = (b, f) =>

--- a/mle/examples/project/vec.mle
+++ b/mle/examples/project/vec.mle
@@ -1,10 +1,10 @@
 // A sibling module: `open`ed by the entry, so `add`/`origin`/`V2` resolve
 // bare there; `Vec.make` works with no open at all.
 
-type V2 = { x: Float, y: Float }
+type V2 = { x: float, y: float }
 
 let origin = { x: 0.0, y: 0.0 }
 
-let make = (x: Float, y: Float): V2 => { x: x, y: y }
+let make = (x: float, y: float): V2 => { x: x, y: y }
 
 let add = (a: V2, b: V2): V2 => { x: a.x + b.x, y: a.y + b.y }

--- a/mle/examples/pure_pipeline.ast
+++ b/mle/examples/pure_pipeline.ast
@@ -24,7 +24,7 @@ Program {
                                 name: "score",
                                 ty: Some(
                                     TypeName {
-                                        name: "Float",
+                                        name: "float",
                                         args: [],
                                         span: 148..153,
                                     },
@@ -34,7 +34,7 @@ Program {
                         ],
                         ret: Some(
                             TypeName {
-                                name: "Bool",
+                                name: "bool",
                                 args: [],
                                 span: 156..160,
                             },

--- a/mle/examples/pure_pipeline.ir
+++ b/mle/examples/pure_pipeline.ir
@@ -27,7 +27,7 @@ Module {
                             name: "score",
                             ty: Some(
                                 TypeName {
-                                    name: "Float",
+                                    name: "float",
                                     args: [],
                                     span: 148..153,
                                 },
@@ -37,7 +37,7 @@ Module {
                     ],
                     ret: Some(
                         TypeName {
-                            name: "Bool",
+                            name: "bool",
                             args: [],
                             span: 156..160,
                         },

--- a/mle/examples/pure_pipeline.mle
+++ b/mle/examples/pure_pipeline.mle
@@ -3,7 +3,7 @@
 
 let threshold = 10
 
-let isHigh = (score: Float): Bool => score > threshold
+let isHigh = (score: float): bool => score > threshold
 
 let describe = (score) => Text.concat("score: ", Text.fromFloat(score))
 

--- a/mle/examples/records.ast
+++ b/mle/examples/records.ast
@@ -9,7 +9,7 @@ Program {
                         FieldTy {
                             name: "x",
                             ty: TypeName {
-                                name: "Float",
+                                name: "float",
                                 args: [],
                                 span: 162..167,
                             },
@@ -18,7 +18,7 @@ Program {
                         FieldTy {
                             name: "y",
                             ty: TypeName {
-                                name: "Float",
+                                name: "float",
                                 args: [],
                                 span: 172..177,
                             },
@@ -38,7 +38,7 @@ Program {
                         FieldTy {
                             name: "dx",
                             ty: TypeName {
-                                name: "Float",
+                                name: "float",
                                 args: [],
                                 span: 202..207,
                             },
@@ -47,7 +47,7 @@ Program {
                         FieldTy {
                             name: "dy",
                             ty: TypeName {
-                                name: "Float",
+                                name: "float",
                                 args: [],
                                 span: 213..218,
                             },
@@ -125,7 +125,7 @@ Program {
                                 name: "dt",
                                 ty: Some(
                                     TypeName {
-                                        name: "Float",
+                                        name: "float",
                                         args: [],
                                         span: 297..302,
                                     },
@@ -484,7 +484,7 @@ Program {
                         ],
                         ret: Some(
                             TypeName {
-                                name: "Bool",
+                                name: "bool",
                                 args: [],
                                 span: 540..544,
                             },

--- a/mle/examples/records.ir
+++ b/mle/examples/records.ir
@@ -9,7 +9,7 @@ Module {
                     FieldTy {
                         name: "x",
                         ty: TypeName {
-                            name: "Float",
+                            name: "float",
                             args: [],
                             span: 162..167,
                         },
@@ -18,7 +18,7 @@ Module {
                     FieldTy {
                         name: "y",
                         ty: TypeName {
-                            name: "Float",
+                            name: "float",
                             args: [],
                             span: 172..177,
                         },
@@ -37,7 +37,7 @@ Module {
                     FieldTy {
                         name: "dx",
                         ty: TypeName {
-                            name: "Float",
+                            name: "float",
                             args: [],
                             span: 202..207,
                         },
@@ -46,7 +46,7 @@ Module {
                     FieldTy {
                         name: "dy",
                         ty: TypeName {
-                            name: "Float",
+                            name: "float",
                             args: [],
                             span: 213..218,
                         },
@@ -131,7 +131,7 @@ Module {
                             name: "dt",
                             ty: Some(
                                 TypeName {
-                                    name: "Float",
+                                    name: "float",
                                     args: [],
                                     span: 297..302,
                                 },
@@ -514,7 +514,7 @@ Module {
                     ],
                     ret: Some(
                         TypeName {
-                            name: "Bool",
+                            name: "bool",
                             args: [],
                             span: 540..544,
                         },

--- a/mle/examples/records.mle
+++ b/mle/examples/records.mle
@@ -1,12 +1,12 @@
 // Positions and velocities — record types, record literals, field access,
 // arithmetic, and unary minus (the roadmap's `move` example).
 
-type Position = { x: Float, y: Float }
-type Velocity = { dx: Float, dy: Float }
+type Position = { x: float, y: float }
+type Velocity = { dx: float, dy: float }
 
 let origin = { x: 0.0, y: 0.0 }
 
-let move = (p: Position, v: Velocity, dt: Float): Position =>
+let move = (p: Position, v: Velocity, dt: float): Position =>
   { x: p.x + v.dx * dt, y: p.y + v.dy * dt }
 
 let delta = (a: Position, b: Position): Position =>
@@ -14,7 +14,7 @@ let delta = (a: Position, b: Position): Position =>
 
 let mirror = (p: Position): Position => { x: -p.x, y: p.y }
 
-let isOrigin = (p: Position): Bool => p.x == 0.0
+let isOrigin = (p: Position): bool => p.x == 0.0
 
 // Record update syntax + an expression-level `let … in`.
 let nudge = (p: Position): Position => { p with x: p.x + 1.0 }

--- a/mle/examples/shapes.ast
+++ b/mle/examples/shapes.ast
@@ -12,7 +12,7 @@ Program {
                                 FieldTy {
                                     name: "radius",
                                     ty: TypeName {
-                                        name: "Float",
+                                        name: "float",
                                         args: [],
                                         span: 320..325,
                                     },
@@ -27,7 +27,7 @@ Program {
                                 FieldTy {
                                     name: "w",
                                     ty: TypeName {
-                                        name: "Float",
+                                        name: "float",
                                         args: [],
                                         span: 339..344,
                                     },
@@ -36,7 +36,7 @@ Program {
                                 FieldTy {
                                     name: "h",
                                     ty: TypeName {
-                                        name: "Float",
+                                        name: "float",
                                         args: [],
                                         span: 349..354,
                                     },
@@ -89,7 +89,7 @@ Program {
                         ],
                         ret: Some(
                             TypeName {
-                                name: "Float",
+                                name: "float",
                                 args: [],
                                 span: 408..413,
                             },
@@ -250,7 +250,7 @@ Program {
                         ],
                         ret: Some(
                             TypeName {
-                                name: "Bool",
+                                name: "bool",
                                 args: [],
                                 span: 528..532,
                             },
@@ -331,7 +331,7 @@ Program {
                         ],
                         ret: Some(
                             TypeName {
-                                name: "String",
+                                name: "string",
                                 args: [],
                                 span: 657..663,
                             },
@@ -435,7 +435,7 @@ Program {
                         ],
                         ret: Some(
                             TypeName {
-                                name: "String",
+                                name: "string",
                                 args: [],
                                 span: 969..975,
                             },

--- a/mle/examples/shapes.ir
+++ b/mle/examples/shapes.ir
@@ -12,7 +12,7 @@ Module {
                             FieldTy {
                                 name: "radius",
                                 ty: TypeName {
-                                    name: "Float",
+                                    name: "float",
                                     args: [],
                                     span: 320..325,
                                 },
@@ -27,7 +27,7 @@ Module {
                             FieldTy {
                                 name: "w",
                                 ty: TypeName {
-                                    name: "Float",
+                                    name: "float",
                                     args: [],
                                     span: 339..344,
                                 },
@@ -36,7 +36,7 @@ Module {
                             FieldTy {
                                 name: "h",
                                 ty: TypeName {
-                                    name: "Float",
+                                    name: "float",
                                     args: [],
                                     span: 349..354,
                                 },
@@ -92,7 +92,7 @@ Module {
                     ],
                     ret: Some(
                         TypeName {
-                            name: "Float",
+                            name: "float",
                             args: [],
                             span: 408..413,
                         },
@@ -261,7 +261,7 @@ Module {
                     ],
                     ret: Some(
                         TypeName {
-                            name: "Bool",
+                            name: "bool",
                             args: [],
                             span: 528..532,
                         },
@@ -346,7 +346,7 @@ Module {
                     ],
                     ret: Some(
                         TypeName {
-                            name: "String",
+                            name: "string",
                             args: [],
                             span: 657..663,
                         },
@@ -456,7 +456,7 @@ Module {
                     ],
                     ret: Some(
                         TypeName {
-                            name: "String",
+                            name: "string",
                             args: [],
                             span: 969..975,
                         },

--- a/mle/examples/shapes.mle
+++ b/mle/examples/shapes.mle
@@ -4,25 +4,25 @@
 // language's first conditional), and a catch-all variable.
 
 type Shape =
-  | Circle(radius: Float)
-  | Rect(w: Float, h: Float)
+  | Circle(radius: float)
+  | Rect(w: float, h: float)
   | Point
 
 let pi = 3.14159
 
-let area = (s: Shape): Float =>
+let area = (s: Shape): float =>
   match s with
   | Circle(r) => pi * r * r
   | Rect(w, h) => w * h
   | Point => 0.0
 
-let isRound = (s: Shape): Bool =>
+let isRound = (s: Shape): bool =>
   match s with
   | Circle(_) => true
   | _ => false
 
-// The first conditional: match on a Bool.
-let sizeOf = (s: Shape): String =>
+// The first conditional: match on a bool.
+let sizeOf = (s: Shape): string =>
   match area(s) > 10.0 with
   | true => "big"
   | false => "small"
@@ -30,7 +30,7 @@ let sizeOf = (s: Shape): String =>
 // Arm bodies are full expressions, so this nested match is greedy: it is
 // only unambiguous because it sits in the LAST arm — anywhere else it would
 // need parentheses (see the parser's grammar notes).
-let describe = (s: Shape): String =>
+let describe = (s: Shape): string =>
   match s with
   | Point => "a point"
   | other =>

--- a/mle/examples/strings.ast
+++ b/mle/examples/strings.ast
@@ -11,7 +11,7 @@ Program {
                                 name: "pid",
                                 ty: Some(
                                     TypeName {
-                                        name: "Float",
+                                        name: "float",
                                         args: [],
                                         span: 301..306,
                                     },
@@ -22,7 +22,7 @@ Program {
                                 name: "x",
                                 ty: Some(
                                     TypeName {
-                                        name: "Float",
+                                        name: "float",
                                         args: [],
                                         span: 311..316,
                                     },
@@ -33,7 +33,7 @@ Program {
                                 name: "z",
                                 ty: Some(
                                     TypeName {
-                                        name: "Float",
+                                        name: "float",
                                         args: [],
                                         span: 321..326,
                                     },
@@ -43,7 +43,7 @@ Program {
                         ],
                         ret: Some(
                             TypeName {
-                                name: "String",
+                                name: "string",
                                 args: [],
                                 span: 329..335,
                             },
@@ -211,7 +211,7 @@ Program {
                                         name: "List",
                                         args: [
                                             TypeName {
-                                                name: "String",
+                                                name: "string",
                                                 args: [],
                                                 span: 520..526,
                                             },
@@ -224,7 +224,7 @@ Program {
                         ],
                         ret: Some(
                             TypeName {
-                                name: "String",
+                                name: "string",
                                 args: [],
                                 span: 530..536,
                             },
@@ -276,7 +276,7 @@ Program {
                                 name: "row",
                                 ty: Some(
                                     TypeName {
-                                        name: "String",
+                                        name: "string",
                                         args: [],
                                         span: 652..658,
                                     },
@@ -289,17 +289,17 @@ Program {
                                 name: "*",
                                 args: [
                                     TypeName {
-                                        name: "Float",
+                                        name: "float",
                                         args: [],
                                         span: 662..667,
                                     },
                                     TypeName {
-                                        name: "Float",
+                                        name: "float",
                                         args: [],
                                         span: 669..674,
                                     },
                                     TypeName {
-                                        name: "Float",
+                                        name: "float",
                                         args: [],
                                         span: 676..681,
                                     },

--- a/mle/examples/strings.ir
+++ b/mle/examples/strings.ir
@@ -14,7 +14,7 @@ Module {
                             name: "pid",
                             ty: Some(
                                 TypeName {
-                                    name: "Float",
+                                    name: "float",
                                     args: [],
                                     span: 301..306,
                                 },
@@ -26,7 +26,7 @@ Module {
                             name: "x",
                             ty: Some(
                                 TypeName {
-                                    name: "Float",
+                                    name: "float",
                                     args: [],
                                     span: 311..316,
                                 },
@@ -38,7 +38,7 @@ Module {
                             name: "z",
                             ty: Some(
                                 TypeName {
-                                    name: "Float",
+                                    name: "float",
                                     args: [],
                                     span: 321..326,
                                 },
@@ -48,7 +48,7 @@ Module {
                     ],
                     ret: Some(
                         TypeName {
-                            name: "String",
+                            name: "string",
                             args: [],
                             span: 329..335,
                         },
@@ -234,7 +234,7 @@ Module {
                                     name: "List",
                                     args: [
                                         TypeName {
-                                            name: "String",
+                                            name: "string",
                                             args: [],
                                             span: 520..526,
                                         },
@@ -247,7 +247,7 @@ Module {
                     ],
                     ret: Some(
                         TypeName {
-                            name: "String",
+                            name: "string",
                             args: [],
                             span: 530..536,
                         },
@@ -303,7 +303,7 @@ Module {
                             name: "row",
                             ty: Some(
                                 TypeName {
-                                    name: "String",
+                                    name: "string",
                                     args: [],
                                     span: 652..658,
                                 },
@@ -316,17 +316,17 @@ Module {
                             name: "*",
                             args: [
                                 TypeName {
-                                    name: "Float",
+                                    name: "float",
                                     args: [],
                                     span: 662..667,
                                 },
                                 TypeName {
-                                    name: "Float",
+                                    name: "float",
                                     args: [],
                                     span: 669..674,
                                 },
                                 TypeName {
-                                    name: "Float",
+                                    name: "float",
                                     args: [],
                                     span: 676..681,
                                 },

--- a/mle/examples/strings.mle
+++ b/mle/examples/strings.mle
@@ -1,18 +1,18 @@
-// String builtins: Text.split / Text.join / Text.parseFloat — the wire-protocol
+// string builtins: Text.split / Text.join / Text.parseFloat — the wire-protocol
 // trio the multiplayer ports use to encode and decode snapshots. Fixed-point
 // integers keep the wire trivial (Text.fixed(n, 0.0) is the F# `%d` shape).
 
 // Encode one player as "pid,x*100,z*100".
-let encode = (pid: Float, x: Float, z: Float): String =>
+let encode = (pid: float, x: float, z: float): string =>
   Text.join(
     ",",
     [Text.fixed(pid, 0.0), Text.fixed(x * 100.0, 0.0), Text.fixed(z * 100.0, 0.0)])
 
 // The full snapshot: players joined with '|'.
-let snapshot = (rows: List<String>): String => Text.join("|", rows)
+let snapshot = (rows: List<string>): string => Text.join("|", rows)
 
 // Decode one row back to world units (the *100 fixed-point undone).
-let parseRow = (row: String): (Float, Float, Float) =>
+let parseRow = (row: string): (float, float, float) =>
   match Text.split(",", row) with
   | [p, x, z] => (Text.parseFloat(p), Text.parseFloat(x) / 100.0, Text.parseFloat(z) / 100.0)
   | _ => (0.0, 0.0, 0.0)

--- a/mle/examples/tuples.ast
+++ b/mle/examples/tuples.ast
@@ -12,7 +12,7 @@ Program {
                                 FieldTy {
                                     name: "dx",
                                     ty: TypeName {
-                                        name: "Float",
+                                        name: "float",
                                         args: [],
                                         span: 335..340,
                                     },
@@ -21,7 +21,7 @@ Program {
                                 FieldTy {
                                     name: "dy",
                                     ty: TypeName {
-                                        name: "Float",
+                                        name: "float",
                                         args: [],
                                         span: 346..351,
                                     },
@@ -46,7 +46,7 @@ Program {
                                 name: "a",
                                 ty: Some(
                                     TypeName {
-                                        name: "Float",
+                                        name: "float",
                                         args: [],
                                         span: 415..420,
                                     },
@@ -57,7 +57,7 @@ Program {
                                 name: "b",
                                 ty: Some(
                                     TypeName {
-                                        name: "Float",
+                                        name: "float",
                                         args: [],
                                         span: 425..430,
                                     },
@@ -70,12 +70,12 @@ Program {
                                 name: "*",
                                 args: [
                                     TypeName {
-                                        name: "Float",
+                                        name: "float",
                                         args: [],
                                         span: 434..439,
                                     },
                                     TypeName {
-                                        name: "Float",
+                                        name: "float",
                                         args: [],
                                         span: 441..446,
                                     },
@@ -303,12 +303,12 @@ Program {
                                         name: "*",
                                         args: [
                                             TypeName {
-                                                name: "Float",
+                                                name: "float",
                                                 args: [],
                                                 span: 669..674,
                                             },
                                             TypeName {
-                                                name: "String",
+                                                name: "string",
                                                 args: [],
                                                 span: 676..682,
                                             },
@@ -321,7 +321,7 @@ Program {
                         ],
                         ret: Some(
                             TypeName {
-                                name: "String",
+                                name: "string",
                                 args: [],
                                 span: 686..692,
                             },
@@ -441,12 +441,12 @@ Program {
                                 name: "*",
                                 args: [
                                     TypeName {
-                                        name: "Float",
+                                        name: "float",
                                         args: [],
                                         span: 858..863,
                                     },
                                     TypeName {
-                                        name: "Float",
+                                        name: "float",
                                         args: [],
                                         span: 865..870,
                                     },

--- a/mle/examples/tuples.ir
+++ b/mle/examples/tuples.ir
@@ -12,7 +12,7 @@ Module {
                             FieldTy {
                                 name: "dx",
                                 ty: TypeName {
-                                    name: "Float",
+                                    name: "float",
                                     args: [],
                                     span: 335..340,
                                 },
@@ -21,7 +21,7 @@ Module {
                             FieldTy {
                                 name: "dy",
                                 ty: TypeName {
-                                    name: "Float",
+                                    name: "float",
                                     args: [],
                                     span: 346..351,
                                 },
@@ -49,7 +49,7 @@ Module {
                             name: "a",
                             ty: Some(
                                 TypeName {
-                                    name: "Float",
+                                    name: "float",
                                     args: [],
                                     span: 415..420,
                                 },
@@ -61,7 +61,7 @@ Module {
                             name: "b",
                             ty: Some(
                                 TypeName {
-                                    name: "Float",
+                                    name: "float",
                                     args: [],
                                     span: 425..430,
                                 },
@@ -74,12 +74,12 @@ Module {
                             name: "*",
                             args: [
                                 TypeName {
-                                    name: "Float",
+                                    name: "float",
                                     args: [],
                                     span: 434..439,
                                 },
                                 TypeName {
-                                    name: "Float",
+                                    name: "float",
                                     args: [],
                                     span: 441..446,
                                 },
@@ -318,12 +318,12 @@ Module {
                                     name: "*",
                                     args: [
                                         TypeName {
-                                            name: "Float",
+                                            name: "float",
                                             args: [],
                                             span: 669..674,
                                         },
                                         TypeName {
-                                            name: "String",
+                                            name: "string",
                                             args: [],
                                             span: 676..682,
                                         },
@@ -336,7 +336,7 @@ Module {
                     ],
                     ret: Some(
                         TypeName {
-                            name: "String",
+                            name: "string",
                             args: [],
                             span: 686..692,
                         },
@@ -464,12 +464,12 @@ Module {
                             name: "*",
                             args: [
                                 TypeName {
-                                    name: "Float",
+                                    name: "float",
                                     args: [],
                                     span: 858..863,
                                 },
                                 TypeName {
-                                    name: "Float",
+                                    name: "float",
                                     args: [],
                                     span: 865..870,
                                 },

--- a/mle/examples/tuples.mle
+++ b/mle/examples/tuples.mle
@@ -1,13 +1,13 @@
 // Tuples: `(a, b)` literals (two or more elements — `(e)` is grouping),
-// `(Float, String)` product annotations, tuple patterns in `match`, and the
+// `(float, string)` product annotations, tuple patterns in `match`, and the
 // destructuring let (`let (a, b) = e in …`, sugar for a single-arm match).
 // Multiple returns without naming a record — B6's `(model, effects)` shape.
 
 type Msg =
-  | Moved(dx: Float, dy: Float)
+  | Moved(dx: float, dy: float)
 
 // A function returning two things at once.
-let minMax = (a: Float, b: Float): (Float, Float) =>
+let minMax = (a: float, b: float): (float, float) =>
   match a < b with
   | true => (a, b)
   | false => (b, a)
@@ -17,12 +17,12 @@ let span = (a, b) =>
   hi - lo
 
 // Tuple patterns match by exact arity; sub-patterns are names or `_`.
-let describe = (pair: (Float, String)): String =>
+let describe = (pair: (float, string)): string =>
   match pair with
   | (n, label) => Text.concat(label, Text.fromFloat(n))
 
 // Tuples nest in data structures and messages like any value.
-let step = (msg: Msg): (Float, Float) =>
+let step = (msg: Msg): (float, float) =>
   match msg with
   | Moved(dx, dy) => (dx * 2.0, dy * 2.0)
 

--- a/mle/src/codelens.rs
+++ b/mle/src/codelens.rs
@@ -58,20 +58,20 @@ mod tests {
     #[test]
     fn signature_of_a_function_def() {
         assert_eq!(
-            sigs("let double = (x: Float): Float => x * 2.0"),
-            vec!["double : (Float) => Float"]
+            sigs("let double = (x: float): float => x * 2.0"),
+            vec!["double : (float) => float"]
         );
     }
 
     #[test]
     fn signature_of_a_constant() {
-        assert_eq!(sigs("let threshold = 10.0"), vec!["threshold : Float"]);
+        assert_eq!(sigs("let threshold = 10.0"), vec!["threshold : float"]);
     }
 
     #[test]
     fn infers_an_unannotated_signature() {
         // The whole signature is recovered with no annotations written.
-        assert_eq!(sigs("let f = (x) => x + 1.0"), vec!["f : (Float) => Float"]);
+        assert_eq!(sigs("let f = (x) => x + 1.0"), vec!["f : (float) => float"]);
     }
 
     #[test]
@@ -83,7 +83,7 @@ mod tests {
     fn one_lens_per_def_in_file_order() {
         assert_eq!(
             sigs("let a = 1.0\nlet b = (x) => x + 1.0"),
-            vec!["a : Float", "b : (Float) => Float"]
+            vec!["a : float", "b : (float) => float"]
         );
     }
 

--- a/mle/src/goto.rs
+++ b/mle/src/goto.rs
@@ -277,8 +277,8 @@ mod tests {
 
     #[test]
     fn param_reference_resolves_to_the_parameter() {
-        let src = "let f = (score: Float): Bool => score > 1.0";
-        assert_eq!(def_at(src, "score >"), Some("score: Float"));
+        let src = "let f = (score: float): bool => score > 1.0";
+        assert_eq!(def_at(src, "score >"), Some("score: float"));
     }
 
     #[test]
@@ -290,13 +290,13 @@ mod tests {
     #[test]
     fn shadowing_resolves_to_the_innermost_binder() {
         // `x` in the body is the inner `let x`, not the parameter.
-        let src = "let f = (x: Float) => let x = 2.0 in x + 1.0";
+        let src = "let f = (x: float) => let x = 2.0 in x + 1.0";
         assert_eq!(def_at(src, "x +"), Some("let x = "));
     }
 
     #[test]
     fn mut_reference_and_assign_target_resolve_to_the_mut_binder() {
-        let src = "let f = (x: Float) => let mut a = x in a := a + 1.0; a";
+        let src = "let f = (x: float) => let mut a = x in a := a + 1.0; a";
         assert_eq!(def_at_last(src, "a"), Some("let mut a = "));
         assert_eq!(def_at(src, "a :="), Some("let mut a = "));
         // …but the `:=` itself is not a reference.
@@ -314,7 +314,7 @@ mod tests {
 
     #[test]
     fn global_reference_resolves_to_the_def() {
-        let src = "let double = (x: Float): Float => x * 2.0\nlet main = () => double(2.0)";
+        let src = "let double = (x: float): float => x * 2.0\nlet main = () => double(2.0)";
         assert_eq!(def_at(src, "double(2.0)"), Some("let double = "));
     }
 
@@ -330,12 +330,12 @@ mod tests {
 
     // --- Constructors ---
 
-    const SHAPE: &str = "type Shape = | Circle(r: Float) | Point\n";
+    const SHAPE: &str = "type Shape = | Circle(r: float) | Point\n";
 
     #[test]
     fn ctor_expression_resolves_to_the_variant_decl() {
         let src = format!("{SHAPE}let c = Circle(2.0)");
-        assert_eq!(def_at(&src, "Circle(2.0)"), Some("Circle(r: Float)"));
+        assert_eq!(def_at(&src, "Circle(2.0)"), Some("Circle(r: float)"));
     }
 
     #[test]
@@ -351,14 +351,14 @@ mod tests {
     #[test]
     fn ctor_pattern_resolves_to_the_variant_decl() {
         let src =
-            format!("{SHAPE}let f = (s: Shape): Float => match s with | Circle(r) => r | _ => 0.0");
-        assert_eq!(def_at(&src, "Circle(r)"), Some("Circle(r: Float)"));
+            format!("{SHAPE}let f = (s: Shape): float => match s with | Circle(r) => r | _ => 0.0");
+        assert_eq!(def_at(&src, "Circle(r)"), Some("Circle(r: float)"));
     }
 
     #[test]
     fn a_pattern_variable_is_a_binder_not_a_reference() {
         let src =
-            format!("{SHAPE}let f = (s: Shape): Float => match s with | Circle(r) => r | _ => 0.0");
+            format!("{SHAPE}let f = (s: Shape): float => match s with | Circle(r) => r | _ => 0.0");
         assert_eq!(def_at(&src, "r) =>"), None);
     }
 
@@ -366,26 +366,26 @@ mod tests {
 
     #[test]
     fn annotation_resolves_to_the_type_decl() {
-        let src = "type P = { x: Float }\nlet mk = (p: P): P => p";
-        assert_eq!(def_at(src, "P)"), Some("type P = { x: Float }"));
-        assert_eq!(def_at(src, "P =>"), Some("type P = { x: Float }"));
+        let src = "type P = { x: float }\nlet mk = (p: P): P => p";
+        assert_eq!(def_at(src, "P)"), Some("type P = { x: float }"));
+        assert_eq!(def_at(src, "P =>"), Some("type P = { x: float }"));
     }
 
     #[test]
     fn generic_argument_resolves_to_the_type_decl() {
-        let src = "type P = { x: Float }\nlet f = (ps: List<P>) => ps";
-        assert_eq!(def_at(src, "P>"), Some("type P = { x: Float }"));
+        let src = "type P = { x: float }\nlet f = (ps: List<P>) => ps";
+        assert_eq!(def_at(src, "P>"), Some("type P = { x: float }"));
     }
 
     #[test]
     fn type_decl_field_annotation_resolves_too() {
-        let src = "type P = { x: Float }\ntype Q = | Wrap(p: P)";
-        assert_eq!(def_at(src, "P)"), Some("type P = { x: Float }"));
+        let src = "type P = { x: float }\ntype Q = | Wrap(p: P)";
+        assert_eq!(def_at(src, "P)"), Some("type P = { x: float }"));
     }
 
     #[test]
     fn primitive_type_name_has_no_definition() {
-        assert_eq!(def_at("let f = (x: Float) => x", "Float"), None);
+        assert_eq!(def_at("let f = (x: float) => x", "float"), None);
     }
 
     // --- Nothing ---

--- a/mle/src/hover.rs
+++ b/mle/src/hover.rs
@@ -213,42 +213,42 @@ mod tests {
     #[test]
     fn hover_on_a_builtin_shows_its_signature() {
         let text = hover_at("let f = (xs) => xs |> List.maximum", "List.maximum").unwrap();
-        assert_eq!(text, "List.maximum : (List<Float>) => Float");
+        assert_eq!(text, "List.maximum : (List<float>) => float");
     }
 
     #[test]
     fn hover_on_an_annotated_param_shows_its_type() {
-        let text = hover_at("let f = (score: Float): Bool => score > 1.0", "score:").unwrap();
-        assert_eq!(text, "score : Float");
+        let text = hover_at("let f = (score: float): bool => score > 1.0", "score:").unwrap();
+        assert_eq!(text, "score : float");
     }
 
     #[test]
     fn hover_on_a_local_reference_shows_the_inferred_type() {
-        let text = hover_at("let f = (score: Float): Bool => score > 1.0", "score >").unwrap();
-        assert_eq!(text, "score : Float");
+        let text = hover_at("let f = (score: float): bool => score > 1.0", "score >").unwrap();
+        assert_eq!(text, "score : float");
     }
 
     #[test]
     fn hover_on_a_global_reference_shows_its_signature() {
-        let src = "let double = (x: Float): Float => x * 2.0\nlet main = () => double(2.0)";
+        let src = "let double = (x: float): float => x * 2.0\nlet main = () => double(2.0)";
         let text = hover_at(src, "double(2.0)").unwrap();
-        assert_eq!(text, "double : (Float) => Float");
+        assert_eq!(text, "double : (float) => float");
     }
 
     #[test]
     fn hover_on_a_mut_binding_says_mut() {
-        let src = "let f = (x: Float) => let mut a = x in a := a + 1.0; a";
+        let src = "let f = (x: float) => let mut a = x in a := a + 1.0; a";
         let offset = src.rfind("a").unwrap();
         let module = crate::lower(crate::parse(src).unwrap()).unwrap();
         let (_, types) = check_with_types(&module);
         let (_, text) = hover_text(&module, &types, offset).unwrap();
-        assert_eq!(text, "mut a : Float");
+        assert_eq!(text, "mut a : float");
     }
 
     #[test]
     fn hover_on_the_definition_name_shows_its_type() {
         let text = hover_at("let threshold = 10", "threshold").unwrap();
-        assert_eq!(text, "threshold : Float");
+        assert_eq!(text, "threshold : float");
     }
 
     #[test]
@@ -267,13 +267,13 @@ mod tests {
 
     // --- Variants + match (B5 part 1) ---
 
-    const SHAPE: &str = "type Shape = | Circle(r: Float) | Point\n";
+    const SHAPE: &str = "type Shape = | Circle(r: float) | Point\n";
 
     #[test]
     fn hover_on_a_ctor_shows_its_signature() {
         let src = format!("{SHAPE}let c = Circle(2.0)");
         let text = hover_at(&src, "Circle(2.0)").unwrap();
-        assert_eq!(text, "Circle : (Float) => Shape");
+        assert_eq!(text, "Circle : (float) => Shape");
     }
 
     #[test]
@@ -289,23 +289,23 @@ mod tests {
     #[test]
     fn hover_on_a_pattern_var_shows_the_field_type() {
         let src =
-            format!("{SHAPE}let f = (s: Shape): Float => match s with | Circle(r) => r | _ => 0.0");
+            format!("{SHAPE}let f = (s: Shape): float => match s with | Circle(r) => r | _ => 0.0");
         let text = hover_at(&src, "r) =>").unwrap();
-        assert_eq!(text, "r : Float");
+        assert_eq!(text, "r : float");
     }
 
     #[test]
     fn hover_on_a_catch_all_var_shows_the_scrutinee_type() {
-        let src = format!("{SHAPE}let f = (s: Shape): Float => match s with | other => 0.0");
+        let src = format!("{SHAPE}let f = (s: Shape): float => match s with | other => 0.0");
         let text = hover_at(&src, "other =>").unwrap();
         assert_eq!(text, "other : Shape");
     }
 
     #[test]
     fn hover_on_a_match_shows_its_joined_type() {
-        let src = "let f = (b: Bool) => match b with | true => 1.0 | false => 0.0";
+        let src = "let f = (b: bool) => match b with | true => 1.0 | false => 0.0";
         let text = hover_at(src, "match").unwrap();
-        assert_eq!(text, "Float");
+        assert_eq!(text, "float");
     }
 }
 
@@ -327,37 +327,37 @@ mod review_tests {
     // their checked type, not Unknown.
     #[test]
     fn checked_record_literal_hovers_with_its_type() {
-        let src = "type P = { x: Float }\nlet mk = (): P => { x: 1.0 }";
+        let src = "type P = { x: float }\nlet mk = (): P => { x: 1.0 }";
         assert_eq!(hover_at(src, "{ x: 1.0 }"), "P");
     }
 
     #[test]
     fn checked_list_literal_hovers_with_its_type() {
-        let src = "let f = (): List<Float> => [1.0, 2.0]";
-        assert_eq!(hover_at(src, "[1.0"), "List<Float>");
+        let src = "let f = (): List<float> => [1.0, 2.0]";
+        assert_eq!(hover_at(src, "[1.0"), "List<float>");
     }
 
     // [review] inner nodes of a binary spine are recorded too.
     #[test]
     fn inner_binary_nodes_hover_with_their_type() {
-        let src = "let f = (x: Float) => x + x + x";
+        let src = "let f = (x: float) => x + x + x";
         let inner_plus = src.find('+').unwrap();
         let module = crate::lower(crate::parse(src).unwrap()).unwrap();
         let (_, types) = check_with_types(&module);
         let (_, text) = hover_text(&module, &types, inner_plus).unwrap();
-        assert_eq!(text, "Float");
+        assert_eq!(text, "float");
     }
 
     // [review] let/mut binder names hover with `name : Type`.
     #[test]
     fn let_binder_name_hovers_named() {
-        let src = "let f = (x: Float) => let y = x in y + 1.0";
-        assert_eq!(hover_at(src, "y ="), "y : Float");
+        let src = "let f = (x: float) => let y = x in y + 1.0";
+        assert_eq!(hover_at(src, "y ="), "y : float");
     }
 
     #[test]
     fn mut_binder_name_hovers_named() {
-        let src = "let f = (x: Float) => let mut a = x in a := a + 1.0; a";
-        assert_eq!(hover_at(src, "mut a ="), "mut a : Float");
+        let src = "let f = (x: float) => let mut a = x in a := a + 1.0; a";
+        assert_eq!(hover_at(src, "mut a ="), "mut a : float");
     }
 }

--- a/mle/src/inlay.rs
+++ b/mle/src/inlay.rs
@@ -97,13 +97,13 @@ mod tests {
         let got = hints(src);
         assert_eq!(got.len(), 1);
         // The hint sits right after the `x`, labelled with the inferred type.
-        assert_eq!(got[0].1, ": Float");
+        assert_eq!(got[0].1, ": float");
         assert_eq!(&src[got[0].0 - 1..got[0].0], "x");
     }
 
     #[test]
     fn skips_an_annotated_param() {
-        assert!(hints("let f = (x: Float) => x + 1.0").is_empty());
+        assert!(hints("let f = (x: float) => x + 1.0").is_empty());
     }
 
     #[test]
@@ -121,7 +121,7 @@ mod tests {
         let got = hints("let f = (x, y) => x + y");
         assert_eq!(
             got.iter().map(|(_, l)| l.as_str()).collect::<Vec<_>>(),
-            vec![": Float", ": Float"]
+            vec![": float", ": float"]
         );
     }
 
@@ -130,13 +130,13 @@ mod tests {
         // A curried inner lambda's param is inferred through its use.
         let got = hints("let f = (x) => (y) => x + y");
         assert_eq!(got.len(), 2);
-        assert!(got.iter().all(|(_, l)| l == ": Float"));
+        assert!(got.iter().all(|(_, l)| l == ": float"));
     }
 
     #[test]
     fn infers_a_list_param() {
         let got = hints("let f = (xs) => xs |> List.maximum");
         assert_eq!(got.len(), 1);
-        assert_eq!(got[0].1, ": List<Float>");
+        assert_eq!(got[0].1, ": List<float>");
     }
 }

--- a/mle/src/lexer.rs
+++ b/mle/src/lexer.rs
@@ -10,6 +10,9 @@ pub enum TokenKind {
     Number(f64),
     Str(String),
     Ident(String),
+    /// A type variable in type position: `'a`, `'msg`. Stored WITH the leading
+    /// apostrophe, so the string is exactly the source spelling.
+    TypeVar(String),
     Let,
     Type,
     True,
@@ -57,6 +60,7 @@ pub fn describe(kind: &TokenKind) -> String {
         Number(n) => format!("number `{n}`"),
         Str(_) => "a string".to_string(),
         Ident(name) => format!("`{name}`"),
+        TypeVar(name) => format!("`{name}`"),
         Let => "`let`".to_string(),
         Type => "`type`".to_string(),
         True => "`true`".to_string(),
@@ -221,6 +225,21 @@ pub fn lex(src: &str, base: usize) -> Result<Vec<Token>, ParseError> {
                 let (kind, next) = lex_string(src, i, base)?;
                 i = next;
                 kind
+            }
+            // A type variable: `'a`, `'msg`. The apostrophe must be followed by
+            // an identifier char; a bare `'` is a lex error.
+            b'\'' => {
+                i += 1; // consume `'`
+                if i >= bytes.len() || !(bytes[i].is_ascii_alphabetic() || bytes[i] == b'_') {
+                    return Err(ParseError {
+                        message: "expected a type-variable name after `'` (e.g. `'a`)".to_string(),
+                        span: Span::new(base + start, base + i),
+                    });
+                }
+                while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
+                    i += 1;
+                }
+                TokenKind::TypeVar(src[start..i].to_string())
             }
             b'0'..=b'9' => {
                 while i < bytes.len() && bytes[i].is_ascii_digit() {

--- a/mle/src/lower.rs
+++ b/mle/src/lower.rs
@@ -206,9 +206,9 @@ fn lower_module(
             }
             ast::Item::Type(decl) => {
                 // Builtin type names would shadow the primitives in
-                // annotations (the checker resolves `Float` before user
-                // types), yielding nonsense like "expected Float, got Float".
-                if matches!(decl.name.as_str(), "Float" | "Bool" | "String" | "List") {
+                // annotations (the checker resolves `float` before user
+                // types), yielding nonsense like "expected float, got float".
+                if matches!(decl.name.as_str(), "float" | "bool" | "string" | "List") {
                     return Err(LowerError {
                         message: format!("cannot redeclare builtin type `{}`", decl.name),
                         span: decl.span,

--- a/mle/src/parser.rs
+++ b/mle/src/parser.rs
@@ -5,7 +5,7 @@
 //! ```text
 //! program   := (letDecl | typeDecl)*
 //! letDecl   := "let" ident "=" expr
-//! typeDecl  := "type" ident ("<" ident ("," ident)* ">")?
+//! typeDecl  := "type" ident ("<" typevar ("," typevar)* ">")?
 //!              "=" ("{" (ident ":" type),* "}" | variant+)
 //! variant   := "|" upperIdent ("(" (ident ":" type),+ ")")?
 //! type      := "(" type,* ")" "=>" type              (function: params in parens)
@@ -13,7 +13,7 @@
 //!            | tatom
 //!   (in a lambda RETURN annotation the `=>` is the body arrow, so a bare
 //!    "(" … ")" is only a tuple/group — a function return type is parenthesized)
-//! tatom     := ident ("<" type ("," type)* ">")?
+//! tatom     := typevar | ident ("<" type ("," type)* ">")?
 //! expr      := letIn | assign | match | pipeline
 //! letIn     := "let" ("mut"? ident | tuplePat) "=" expr "in" expr
 //!              (a tuple-pattern let is sugar for a single-arm match)
@@ -250,23 +250,19 @@ rebind surface); `mut` is for `let mut … in …` inside a function"
         let kw = self.bump();
         let (name, name_span) = self.expect_ident("a name after `type`")?;
         let mut end_span = name_span;
-        // Optional type parameters: `type Box<a, b> = …` — lowercase names
-        // (uppercase would shadow declared types; the checker enforces the
-        // case, the grammar just collects idents).
+        // Optional type parameters: `type Box<'a, 'b> = …` — apostrophe-prefixed
+        // type variables, like annotation type variables.
         let mut params = Vec::new();
         if self.peek_kind() == &TokenKind::Lt {
             self.bump();
             loop {
-                let (param, param_span) = self.expect_ident("a type parameter name")?;
-                if !param.chars().next().is_some_and(char::is_lowercase) {
-                    return Err(ParseError {
-                        message: format!(
-                            "type parameters are lowercase (`{}`), like annotation type variables",
-                            param.to_lowercase()
-                        ),
-                        span: param_span,
-                    });
-                }
+                let (param, param_span) = match self.peek_kind() {
+                    TokenKind::TypeVar(name) => {
+                        let name = name.clone();
+                        (name, self.bump().span)
+                    }
+                    _ => return self.error("a type parameter (e.g. `'a`)"),
+                };
                 if params.contains(&param) {
                     return Err(ParseError {
                         message: format!("duplicate type parameter `{param}`"),
@@ -510,6 +506,17 @@ rebind surface); `mut` is for `let mut … in …` inside a function"
     /// A named type with optional generic args (`Float`, `List<Float>`,
     /// `Utils.Shape`) — the atomic, non-parenthesized case of [`type_prefix`].
     fn type_atom(&mut self) -> Result<TypeName, ParseError> {
+        // A type variable (`'a`) — marked by the leading apostrophe (kept in
+        // the name so the checker can distinguish it); it takes no arguments.
+        if let TokenKind::TypeVar(name) = self.peek_kind() {
+            let name = name.clone();
+            let span = self.bump().span;
+            return Ok(TypeName {
+                name,
+                args: Vec::new(),
+                span,
+            });
+        }
         let (name, mut span) = self.qualified_type_head()?;
         let mut args = Vec::new();
         if self.peek_kind() == &TokenKind::Lt {

--- a/mle/src/project.rs
+++ b/mle/src/project.rs
@@ -331,8 +331,15 @@ come from file names, capitalized",
         // next file's base.
         base += len + 1;
     }
-    // Injected prelude interface modules — after the project files, exempt
-    // from the protected-namespace check (they OWN those namespaces).
+    push_prelude(&mut files, prelude);
+    link(files)
+}
+
+/// Append injected PRELUDE interface modules to `files` (after the project's
+/// own files), assigning span bases past the last one. They are exempt from
+/// the protected-namespace check — they OWN those namespaces.
+fn push_prelude(files: &mut Vec<SourceFile>, prelude: &[(String, String)]) {
+    let mut base = files.last().map_or(0, |f| f.base + f.src.len() + 1);
     for (module, src) in prelude {
         files.push(SourceFile {
             interface: true,
@@ -343,7 +350,6 @@ come from file names, capitalized",
         });
         base += src.len() + 1;
     }
-    link(files)
 }
 
 /// Parse, lower, and link a set of source files into one merged module,
@@ -523,7 +529,11 @@ pub fn load_single_source(module: &str, src: &str) -> Result<Project, ProjectErr
 /// scanning the directory for unrelated siblings. Module name is the file's
 /// (`Main` if the stem isn't an identifier); a single file is its own bare
 /// entry, so the name only labels it.
-pub fn load_single_file(path: &Path, src: &str) -> Result<Project, ProjectError> {
+pub fn load_single_file(
+    path: &Path,
+    src: &str,
+    prelude: &[(String, String)],
+) -> Result<Project, ProjectError> {
     // Fall back to `Main` for a non-identifier stem OR one that capitalizes to
     // a protected namespace (`net.mle` → `Net`), which would otherwise collide
     // with the builtin module `link` injects and silently fail the load.
@@ -531,13 +541,14 @@ pub fn load_single_file(path: &Path, src: &str) -> Result<Project, ProjectError>
         Ok(name) if !PROTECTED_NAMESPACES.contains(&name.as_str()) => name,
         _ => "Main".to_string(),
     };
-    let files = vec![SourceFile {
+    let mut files = vec![SourceFile {
         interface: is_interface(path),
         path: path.to_path_buf(),
         module,
         src: src.to_string(),
         base: 0,
     }];
+    push_prelude(&mut files, prelude);
     link(files)
 }
 

--- a/mle/src/types.rs
+++ b/mle/src/types.rs
@@ -113,9 +113,9 @@ impl fmt::Display for Type {
             // Raw display; hover/errors normalize vars to 'a, 'b first
             // (see `Checker::zonk_normalized`).
             Type::Var(v) => write!(f, "'{}", var_name(*v)),
-            Type::Float => write!(f, "Float"),
-            Type::String => write!(f, "String"),
-            Type::Bool => write!(f, "Bool"),
+            Type::Float => write!(f, "float"),
+            Type::String => write!(f, "string"),
+            Type::Bool => write!(f, "bool"),
             Type::List(elem) => write!(f, "List<{elem}>"),
             Type::Tuple(elems) => {
                 write!(f, "(")?;
@@ -1059,13 +1059,13 @@ impl Checker<'_> {
             Type::Unknown
         };
         match ty.name.as_str() {
-            "Float" | "String" | "Bool" => {
+            "float" | "string" | "bool" => {
                 if !ty.args.is_empty() {
                     return arity_error(self, 0);
                 }
                 match ty.name.as_str() {
-                    "Float" => Type::Float,
-                    "String" => Type::String,
+                    "float" => Type::Float,
+                    "string" => Type::String,
                     _ => Type::Bool,
                 }
             }
@@ -1116,14 +1116,12 @@ impl Checker<'_> {
                     .collect();
                 Type::Variant(name.to_string(), args)
             }
-            // A lowercase name is a TYPE VARIABLE, scoped to the enclosing
-            // def's signature: `(xs: List<a>, f: (a) => b): List<b>`. The
-            // same name maps to the same variable within one def. In TYPE
-            // DECLARATIONS they are refused — generic type declarations
-            // aren't designed yet, and a declaration-held variable would be
-            // module-global (first use pins it for everyone; both review
-            // engines' probe). [F4 — B7 review]
-            name if name.chars().next().is_some_and(char::is_lowercase) => {
+            // An apostrophe-prefixed name is a TYPE VARIABLE, scoped to the
+            // enclosing def's signature: `(xs: List<'a>, f: ('a) => 'b): List<'b>`.
+            // The same name maps to the same variable within one def. In a TYPE
+            // DECLARATION a variable must be declared on the type (`type Box<'a>`);
+            // an undeclared one is a teaching error.
+            name if name.starts_with('\'') => {
                 if !ty.args.is_empty() {
                     return arity_error(self, 0);
                 }
@@ -1784,7 +1782,7 @@ missing {missing}. Did you forget an argument?"
                 } else if !compatible(&ty, &Type::Float) {
                     self.diag(
                         inner.span,
-                        format!("unary `-` needs a Float operand, got {ty}"),
+                        format!("unary `-` needs a float operand, got {ty}"),
                     );
                 }
                 Type::Float
@@ -1901,7 +1899,7 @@ missing {missing}. Did you forget an argument?"
                         };
                         self.diag(
                             expr.span,
-                            format!("match on Bool is not exhaustive: missing {missing}"),
+                            format!("match on bool is not exhaustive: missing {missing}"),
                         );
                     }
                 }
@@ -2283,7 +2281,7 @@ is {other}"
         if !compatible(&ty, &Type::Float) {
             self.diag(
                 span,
-                format!("`{}` needs Float operands, got {ty}", op_str(op)),
+                format!("`{}` needs float operands, got {ty}", op_str(op)),
             );
         }
     }

--- a/mle/tests/check.rs
+++ b/mle/tests/check.rs
@@ -117,15 +117,15 @@ fn example_checks_clean(name: &str) {
 
 #[test]
 fn error_arithmetic_on_a_string() {
-    let (message, line, col) = single_diag("let f = (a: Float) => a + \"s\"");
-    assert_eq!(message, "`+` needs Float operands, got String");
+    let (message, line, col) = single_diag("let f = (a: float) => a + \"s\"");
+    assert_eq!(message, "`+` needs float operands, got string");
     assert_eq!((line, col), (1, 27));
 }
 
 #[test]
 fn error_comparison_on_a_bool() {
-    let (message, line, col) = single_diag("let f = (b: Bool) =>\n  b < 1.0");
-    assert_eq!(message, "`<` needs Float operands, got Bool");
+    let (message, line, col) = single_diag("let f = (b: bool) =>\n  b < 1.0");
+    assert_eq!(message, "`<` needs float operands, got bool");
     assert_eq!((line, col), (2, 3));
 }
 
@@ -134,21 +134,21 @@ fn error_equality_across_known_types() {
     let (message, line, col) = single_diag("let x = 1.0 == \"1\"");
     assert_eq!(
         message,
-        "`==` compares different types Float and String (always false)"
+        "`==` compares different types float and string (always false)"
     );
     assert_eq!((line, col), (1, 9));
 }
 
 #[test]
 fn error_negating_a_bool() {
-    let (message, line, col) = single_diag("let f = (b: Bool) => -b");
-    assert_eq!(message, "unary `-` needs a Float operand, got Bool");
+    let (message, line, col) = single_diag("let f = (b: bool) => -b");
+    assert_eq!(message, "unary `-` needs a float operand, got bool");
     assert_eq!((line, col), (1, 23));
 }
 
 #[test]
 fn error_record_literal_extra_and_missing_fields() {
-    let diags = check_src("type P = { x: Float }\nlet f = (): P => { y: 1.0 }");
+    let diags = check_src("type P = { x: float }\nlet f = (): P => { y: 1.0 }");
     // Sorted by position: the missing-field diagnostic sits at the record
     // literal's opening brace, before the extra field.
     assert_eq!(
@@ -166,34 +166,34 @@ fn error_record_literal_extra_and_missing_fields() {
 
 #[test]
 fn error_record_literal_field_type() {
-    let (message, line, col) = single_diag("type P = { x: Float }\nlet f = (): P => { x: \"s\" }");
-    assert_eq!(message, "field `x` of `P`: expected Float, got String");
+    let (message, line, col) = single_diag("type P = { x: float }\nlet f = (): P => { x: \"s\" }");
+    assert_eq!(message, "field `x` of `P`: expected float, got string");
     assert_eq!((line, col), (2, 23));
 }
 
 #[test]
 fn error_field_access_missing_field() {
-    let (message, line, col) = single_diag("type P = { x: Float }\nlet f = (p: P) => p.z");
+    let (message, line, col) = single_diag("type P = { x: float }\nlet f = (p: P) => p.z");
     assert_eq!(message, "`P` has no field `z`");
     assert_eq!((line, col), (2, 19));
 }
 
 #[test]
 fn error_field_access_on_a_float() {
-    let (message, line, col) = single_diag("let f = (a: Float) => a.x");
-    assert_eq!(message, "`.x` on Float, not a record");
+    let (message, line, col) = single_diag("let f = (a: float) => a.x");
+    assert_eq!(message, "`.x` on float, not a record");
     assert_eq!((line, col), (1, 23));
 }
 
 // Currying: under-application is a legal partial application, not an arity
-// error — `f(1.0)` on a 2-arg `f` yields a `(Float) => Float`. Here the
+// error — `f(1.0)` on a 2-arg `f` yields a `(float) => float`. Here the
 // partial is the (unannotated) return value, a genuinely function-typed
 // position, so it stays clean — the forgotten-argument diagnostic fires only
 // when a partial reaches a NON-function position (see the tests below).
 #[test]
 fn partial_application_of_user_function_is_accepted() {
     assert_clean(
-        "let f = (a: Float, b: Float): Float => a + b\n\
+        "let f = (a: float, b: float): float => a + b\n\
          let g = () => f(1.0)",
     );
 }
@@ -201,10 +201,10 @@ fn partial_application_of_user_function_is_accepted() {
 #[test]
 fn error_call_argument_type() {
     let (message, line, col) = single_diag(
-        "let f = (a: Float): Float => a\n\
+        "let f = (a: float): float => a\n\
          let g = () => f(\"s\")",
     );
-    assert_eq!(message, "argument 1 of `f`: expected Float, got String");
+    assert_eq!(message, "argument 1 of `f`: expected float, got string");
     assert_eq!((line, col), (2, 17));
 }
 
@@ -213,7 +213,7 @@ fn error_builtin_argument_type() {
     let (message, line, col) = single_diag("let x = () => Math.clamp01(\"s\")");
     assert_eq!(
         message,
-        "argument 1 of `Math.clamp01`: expected Float, got String"
+        "argument 1 of `Math.clamp01`: expected float, got string"
     );
     assert_eq!((line, col), (1, 28));
 }
@@ -230,14 +230,14 @@ fn partial_application_of_builtin_is_accepted() {
 #[test]
 fn partial_application_then_saturate_checks() {
     assert_clean(
-        "let f = (a: Float, b: Float): Float => a + b\n\
+        "let f = (a: float, b: float): float => a + b\n\
          let g = () => let inc = f(1.0) in inc(2.0)",
     );
     let (message, _, _) = single_diag(
-        "let f = (a: Float, b: Float): Float => a + b\n\
+        "let f = (a: float, b: float): float => a + b\n\
          let g = () => let inc = f(1.0) in inc(\"s\")",
     );
-    assert_eq!(message, "argument 1 of `inc`: expected Float, got String");
+    assert_eq!(message, "argument 1 of `inc`: expected float, got string");
 }
 
 // Currying: over-application checks the surplus args against the result type,
@@ -247,15 +247,15 @@ fn over_application_checks_surplus_against_result() {
     // A curried function over-applied in one call — clean, and the surplus arg
     // is checked against the inner function's param.
     assert_clean(
-        "let adder = (a: Float) => (b: Float) => a + b\n\
+        "let adder = (a: float) => (b: float) => a + b\n\
          let main = () => adder(3.0, 4.0)",
     );
     // Over-applying a non-function result is an error.
     let (message, _, _) = single_diag(
-        "let f = (a: Float): Float => a\n\
+        "let f = (a: float): float => a\n\
          let g = () => f(1.0, 2.0)",
     );
-    assert_eq!(message, "cannot call Float, not a function");
+    assert_eq!(message, "cannot call float, not a function");
 }
 
 // Currying's error-quality recovery (OCaml Warning-5 / F# FS0020): a partial
@@ -265,13 +265,13 @@ fn over_application_checks_surplus_against_result() {
 #[test]
 fn forgotten_argument_of_user_function_into_argument_position() {
     let (message, line, col) = single_diag(
-        "let add = (a: Float, b: Float): Float => a + b\n\
-         let use = (x: Float): Float => x\n\
+        "let add = (a: float, b: float): float => a + b\n\
+         let use = (x: float): float => x\n\
          let main = () => use(add(1.0))",
     );
     assert_eq!(
         message,
-        "`add` is applied to 1 of 2 arguments here — missing `b: Float`. \
+        "`add` is applied to 1 of 2 arguments here — missing `b: float`. \
          Did you forget an argument?"
     );
     // Points at the under-applied call, not the outer call.
@@ -283,12 +283,12 @@ fn forgotten_argument_of_user_function_into_argument_position() {
 #[test]
 fn forgotten_argument_into_return_annotation() {
     let (message, _, _) = single_diag(
-        "let shift = (dx: Float, dy: Float): Float => dx + dy\n\
-         let go = (): Float => shift(1.0)",
+        "let shift = (dx: float, dy: float): float => dx + dy\n\
+         let go = (): float => shift(1.0)",
     );
     assert_eq!(
         message,
-        "`shift` is applied to 1 of 2 arguments here — missing `dy: Float`. \
+        "`shift` is applied to 1 of 2 arguments here — missing `dy: float`. \
          Did you forget an argument?"
     );
 }
@@ -298,12 +298,12 @@ fn forgotten_argument_into_return_annotation() {
 #[test]
 fn forgotten_argument_of_builtin() {
     let (message, _, _) = single_diag(
-        "let use = (x: String): String => x\n\
+        "let use = (x: string): string => x\n\
          let main = () => use(Text.concat(\"a\"))",
     );
     assert_eq!(
         message,
-        "`Text.concat` is applied to 1 of 2 arguments here — missing `String`. \
+        "`Text.concat` is applied to 1 of 2 arguments here — missing `string`. \
          Did you forget an argument?"
     );
 }
@@ -313,13 +313,13 @@ fn forgotten_argument_of_builtin() {
 #[test]
 fn forgotten_argument_of_constructor() {
     let (message, _, _) = single_diag(
-        "type Pair = | MkPair(a: Float, b: Float)\n\
-         let use = (x: Float): Float => x\n\
+        "type Pair = | MkPair(a: float, b: float)\n\
+         let use = (x: float): float => x\n\
          let main = () => use(MkPair(1.0))",
     );
     assert_eq!(
         message,
-        "`MkPair` is applied to 1 of 2 arguments here — missing `b: Float`. \
+        "`MkPair` is applied to 1 of 2 arguments here — missing `b: float`. \
          Did you forget an argument?"
     );
 }
@@ -330,8 +330,8 @@ fn forgotten_argument_of_constructor() {
 #[test]
 fn partial_into_function_position_is_clean() {
     assert_clean(
-        "let add = (a: Float, b: Float): Float => a + b\n\
-         let go = (xs: List<Float>): List<Float> => List.map(add(1.0), xs)",
+        "let add = (a: float, b: float): float => a + b\n\
+         let go = (xs: List<float>): List<float> => List.map(add(1.0), xs)",
     );
 }
 
@@ -340,47 +340,47 @@ fn partial_into_function_position_is_clean() {
 #[test]
 fn bound_partial_used_as_callback_is_clean() {
     assert_clean(
-        "let add = (a: Float, b: Float): Float => a + b\n\
-         let go = (xs: List<Float>): List<Float> =>\n\
+        "let add = (a: float, b: float): float => a + b\n\
+         let go = (xs: List<float>): List<float> =>\n\
          let inc = add(1.0) in\n\
          xs |> List.map(inc)",
     );
 }
 
 // A builtin's known callback shape checks: List.filter's predicate must
-// return Bool (the generic slots stay Unknown, so only the Bool part fires).
+// return bool (the generic slots stay Unknown, so only the bool part fires).
 #[test]
 fn error_filter_predicate_must_return_bool() {
     let (message, _, _) =
-        single_diag("let g = (xs: List<Float>) => List.filter((x): Float => x, xs)");
+        single_diag("let g = (xs: List<float>) => List.filter((x): float => x, xs)");
     assert_eq!(
         message,
         // B7: the element type flows from `xs` into the predicate's
-        // signature — Float, not Unknown. The expected function type flows
+        // signature — float, not Unknown. The expected function type flows
         // INTO the predicate, so the mismatch localizes to its return value
         // rather than the whole callback (mlei 2b `(Lambda, Fn)` checking).
-        "return value: expected Bool, got Float"
+        "return value: expected bool, got float"
     );
 }
 
 #[test]
 fn error_return_annotation_mismatch() {
-    let (message, line, col) = single_diag("let f = (): Bool => 1.0");
-    assert_eq!(message, "return value: expected Bool, got Float");
+    let (message, line, col) = single_diag("let f = (): bool => 1.0");
+    assert_eq!(message, "return value: expected bool, got float");
     assert_eq!((line, col), (1, 21));
 }
 
 #[test]
 fn error_calling_a_known_non_function() {
     let (message, line, col) = single_diag("let x = 1.0\nlet g = () => x()");
-    assert_eq!(message, "cannot call Float, not a function");
+    assert_eq!(message, "cannot call float, not a function");
     assert_eq!((line, col), (2, 15));
 }
 
 // A *known* type name applied at the wrong arity is an error (check #8)…
 #[test]
 fn error_type_argument_arity() {
-    let (message, line, col) = single_diag("type P = { x: Float }\nlet f = (p: P<Float>) => p");
+    let (message, line, col) = single_diag("type P = { x: float }\nlet f = (p: P<float>) => p");
     assert_eq!(message, "`P` takes 0 type argument(s), got 1");
     assert_eq!((line, col), (2, 13));
 
@@ -402,14 +402,14 @@ fn unknown_type_names_are_not_errors() {
 #[test]
 fn unannotated_code_is_inferred() {
     // B7: no annotations anywhere, and the arithmetic still pins `f` to
-    // (Float, Float) => Float — the bad call is caught by INFERENCE.
+    // (float, float) => float — the bad call is caught by INFERENCE.
     let diags = check_src(
         "let f = (a, b) => a + b\n\
          let g = () => f(\"s\", true)",
     );
     assert_eq!(diags.len(), 2, "{diags:?}");
-    assert_eq!(diags[0].0, "argument 1 of `f`: expected Float, got String");
-    assert_eq!(diags[1].0, "argument 2 of `f`: expected Float, got Bool");
+    assert_eq!(diags[0].0, "argument 1 of `f`: expected float, got string");
+    assert_eq!(diags[1].0, "argument 2 of `f`: expected float, got bool");
     // A call through an unannotated parameter CONSTRAINS it instead.
     assert_clean("let apply = (f) => f(1.0, 2.0)");
 }
@@ -419,9 +419,9 @@ fn records_flow_gradually() {
     // `mk`'s unannotated return type is Unknown, so passing its result where
     // a Position is expected (and accessing fields on it) is unchecked.
     assert_clean(
-        "type Position = { x: Float, y: Float }\n\
+        "type Position = { x: float, y: float }\n\
          let mk = () => { x: 1.0, y: 2.0 }\n\
-         let getX = (p: Position): Float => p.x\n\
+         let getX = (p: Position): float => p.x\n\
          let go = () => getX(mk()) + mk().y",
     );
 }
@@ -429,14 +429,14 @@ fn records_flow_gradually() {
 #[test]
 fn generic_builtin_slots_stay_unknown() {
     // List.map's result is List<Unknown>, which is compatible with the
-    // List<Float> that List.maximum expects (no generic instantiation).
-    assert_clean("let best = (xs: List<Float>): Float => List.maximum(List.map((x) => x, xs))");
+    // List<float> that List.maximum expects (no generic instantiation).
+    assert_clean("let best = (xs: List<float>): float => List.maximum(List.map((x) => x, xs))");
 }
 
 #[test]
 fn forward_type_declarations_resolve() {
     // Record type names resolve regardless of declaration order.
-    assert_clean("let getX = (p: Later): Float => p.x\ntype Later = { x: Float }");
+    assert_clean("let getX = (p: Later): float => p.x\ntype Later = { x: float }");
 }
 
 // Expected types propagate into list literals element by element, so a list
@@ -445,12 +445,12 @@ fn forward_type_declarations_resolve() {
 #[test]
 fn expected_list_types_check_elements() {
     assert_clean(
-        "type P = { x: Float }\n\
+        "type P = { x: float }\n\
          let f = (ps: List<P>): List<P> => ps\n\
          let go = () => f([{ x: 1.0 }, { x: 2.0 }])",
     );
     let (message, _, _) = single_diag(
-        "type P = { x: Float }\n\
+        "type P = { x: float }\n\
          let f = (ps: List<P>): List<P> => ps\n\
          let go = () => f([{ y: 1.0, x: 0.0 }])",
     );
@@ -464,9 +464,9 @@ fn expected_list_types_check_elements() {
 #[test]
 fn same_shaped_records_may_compare() {
     assert_clean(
-        "type A = { x: Float }\n\
-         type B = { x: Float }\n\
-         let same = (a: A, b: B): Bool => a == b",
+        "type A = { x: float }\n\
+         type B = { x: float }\n\
+         let same = (a: A, b: B): bool => a == b",
     );
 }
 
@@ -474,9 +474,9 @@ fn same_shaped_records_may_compare() {
 #[test]
 fn different_shaped_records_compare_error() {
     let diags = check_src(
-        "type A = { x: Float }\n\
-         type B = { y: Float }\n\
-         let never = (a: A, b: B): Bool => a == b",
+        "type A = { x: float }\n\
+         type B = { y: float }\n\
+         let never = (a: A, b: B): bool => a == b",
     );
     assert_eq!(diags.len(), 1);
     assert!(diags[0]
@@ -488,9 +488,9 @@ fn different_shaped_records_compare_error() {
 #[test]
 fn function_equality_is_an_error() {
     let diags = check_src(
-        "let f = (x: Float): Float => x\n\
-         let g = (x: Float): Float => x\n\
-         let bad = (): Bool => f == g",
+        "let f = (x: float): float => x\n\
+         let g = (x: float): float => x\n\
+         let bad = (): bool => f == g",
     );
     assert_eq!(diags.len(), 1);
     assert_eq!(diags[0].0, "functions cannot be compared with `==`");
@@ -503,8 +503,8 @@ fn function_equality_is_an_error() {
 fn function_equality_against_unknown_is_an_error() {
     let diags = check_src(
         "type Shape =\n\
-         | Circle(radius: Float)\n\
-         let f = (x): Bool => Circle == x",
+         | Circle(radius: float)\n\
+         let f = (x): bool => Circle == x",
     );
     assert_eq!(diags.len(), 1);
     assert_eq!(diags[0].0, "functions cannot be compared with `==`");
@@ -514,13 +514,13 @@ fn function_equality_against_unknown_is_an_error() {
 #[test]
 fn record_literal_in_float_position_errors() {
     let diags = check_src(
-        "let f = (a: Float): Float => a + a\n\
+        "let f = (a: float): float => a + a\n\
          let main = () => f({ x: 1.0 })",
     );
     assert_eq!(diags.len(), 1);
     assert_eq!(
         diags[0].0,
-        "argument 1 of `f`: expected Float, got a record literal"
+        "argument 1 of `f`: expected float, got a record literal"
     );
 }
 
@@ -529,11 +529,11 @@ fn record_literal_in_float_position_errors() {
 #[test]
 fn inferred_return_type_flows_to_callers() {
     let diags = check_src(
-        "let f = (a: Float) => a\n\
-         let main = (): Bool => f(1.0)",
+        "let f = (a: float) => a\n\
+         let main = (): bool => f(1.0)",
     );
     assert_eq!(diags.len(), 1);
-    assert_eq!(diags[0].0, "return value: expected Bool, got Float");
+    assert_eq!(diags[0].0, "return value: expected bool, got float");
 }
 
 // Quiet enrichment: a top-level list literal contributes its element type.
@@ -542,12 +542,12 @@ fn inferred_return_type_flows_to_callers() {
 fn top_level_list_literal_type_flows() {
     let diags = check_src(
         "let xs = [1.0]\n\
-         let main = (): String => Text.toBullets(xs)",
+         let main = (): string => Text.toBullets(xs)",
     );
     assert_eq!(diags.len(), 1);
     assert_eq!(
         diags[0].0,
-        "argument 1 of `Text.toBullets`: expected List<String>, got List<Float>"
+        "argument 1 of `Text.toBullets`: expected List<string>, got List<float>"
     );
 }
 
@@ -555,58 +555,58 @@ fn top_level_list_literal_type_flows() {
 
 #[test]
 fn assignment_keeps_the_slot_type() {
-    let diags = check_src("let f = (x: Float) => let mut a = x in a := \"s\"; a");
+    let diags = check_src("let f = (x: float) => let mut a = x in a := \"s\"; a");
     assert_eq!(diags.len(), 1);
-    assert_eq!(diags[0].0, "assignment to `a`: expected Float, got String");
+    assert_eq!(diags[0].0, "assignment to `a`: expected float, got string");
 }
 
 #[test]
 fn update_checks_fields_against_the_declared_type() {
     let diags = check_src(
-        "type Position = { x: Float, y: Float }\n\
+        "type Position = { x: float, y: float }\n\
          let f = (p: Position): Position => { p with x: \"s\", z: 1.0 }",
     );
     assert_eq!(diags.len(), 2);
     assert_eq!(
         diags[0].0,
-        "field `x` of `Position`: expected Float, got String"
+        "field `x` of `Position`: expected float, got string"
     );
     assert_eq!(diags[1].0, "`Position` has no field `z`");
 }
 
 #[test]
 fn update_on_known_non_record_errors() {
-    let diags = check_src("let f = (x: Float) => { x with y: 1.0 }");
+    let diags = check_src("let f = (x: float) => { x with y: 1.0 }");
     assert_eq!(diags.len(), 1);
-    assert_eq!(diags[0].0, "`with` update on Float, not a record");
+    assert_eq!(diags[0].0, "`with` update on float, not a record");
 }
 
 #[test]
 fn let_in_types_flow_to_the_body() {
-    let diags = check_src("let f = (): Bool => let x = 1.0 in x");
+    let diags = check_src("let f = (): bool => let x = 1.0 in x");
     assert_eq!(diags.len(), 1);
-    assert_eq!(diags[0].0, "return value: expected Bool, got Float");
+    assert_eq!(diags[0].0, "return value: expected bool, got float");
 }
 
 #[test]
 fn contradictory_mut_use_is_caught() {
-    // B7: `a := a + 1.0` pins the slot to Float, so the record update on it
+    // B7: `a := a + 1.0` pins the slot to float, so the record update on it
     // is a contradiction — caught, where the gradual checker stayed silent.
     let (message, _, _) =
         single_diag("let f = (x) => let mut a = x in a := a + 1.0; { a with n: a }");
-    assert_eq!(message, "`with` update on Float, not a record");
+    assert_eq!(message, "`with` update on float, not a record");
 }
 
 // --- Variants + match (B5 part 1) ---
 
-const SHAPE: &str = "type Shape = | Circle(r: Float) | Rect(w: Float, h: Float) | Point\n";
+const SHAPE: &str = "type Shape = | Circle(r: float) | Rect(w: float, h: float) | Point\n";
 
 /// Non-exhaustive match on a known variant type: the diagnostic names the
 /// missing constructor(s), in declaration order.
 #[test]
 fn error_non_exhaustive_variant_match() {
     let (message, line, col) = single_diag(&format!(
-        "{SHAPE}let f = (s: Shape): Float => match s with | Circle(r) => r"
+        "{SHAPE}let f = (s: Shape): float => match s with | Circle(r) => r"
     ));
     assert_eq!(
         message,
@@ -619,10 +619,10 @@ fn error_non_exhaustive_variant_match() {
 #[test]
 fn catch_all_arms_are_exhaustive() {
     assert_clean(&format!(
-        "{SHAPE}let f = (s: Shape): Float => match s with | Circle(r) => r | _ => 0.0"
+        "{SHAPE}let f = (s: Shape): float => match s with | Circle(r) => r | _ => 0.0"
     ));
     assert_clean(&format!(
-        "{SHAPE}let f = (s: Shape): Float => match s with | Circle(r) => r | other => 0.0"
+        "{SHAPE}let f = (s: Shape): float => match s with | Circle(r) => r | other => 0.0"
     ));
 }
 
@@ -630,7 +630,7 @@ fn catch_all_arms_are_exhaustive() {
 #[test]
 fn full_ctor_coverage_is_exhaustive() {
     assert_clean(&format!(
-        "{SHAPE}let f = (s: Shape): Float => match s with | Circle(r) => r | Rect(w, h) => w * h | Point => 0.0"
+        "{SHAPE}let f = (s: Shape): float => match s with | Circle(r) => r | Rect(w, h) => w * h | Point => 0.0"
     ));
 }
 
@@ -638,8 +638,8 @@ fn full_ctor_coverage_is_exhaustive() {
 #[test]
 fn error_foreign_ctor_in_a_match() {
     let (message, line, col) = single_diag(&format!(
-        "{SHAPE}type Blob = | Splat(size: Float)\n\
-         let f = (s: Shape): Float => match s with | Splat(n) => n | _ => 0.0"
+        "{SHAPE}type Blob = | Splat(size: float)\n\
+         let f = (s: Shape): float => match s with | Splat(n) => n | _ => 0.0"
     ));
     assert_eq!(message, "`Splat` is not a constructor of `Shape`");
     assert_eq!((line, col), (3, 45));
@@ -649,11 +649,11 @@ fn error_foreign_ctor_in_a_match() {
 #[test]
 fn error_ctor_pattern_against_a_float() {
     let (message, _, _) = single_diag(&format!(
-        "{SHAPE}let f = (x: Float): Float => match x with | Circle(r) => r | _ => 0.0"
+        "{SHAPE}let f = (x: float): float => match x with | Circle(r) => r | _ => 0.0"
     ));
     assert_eq!(
         message,
-        "pattern `Circle` matches `Shape`, but the scrutinee is Float"
+        "pattern `Circle` matches `Shape`, but the scrutinee is float"
     );
 }
 
@@ -661,19 +661,19 @@ fn error_ctor_pattern_against_a_float() {
 #[test]
 fn error_literal_pattern_against_a_variant() {
     let (message, _, _) = single_diag(&format!(
-        "{SHAPE}let f = (s: Shape): Float => match s with | true => 1.0 | _ => 0.0"
+        "{SHAPE}let f = (s: Shape): float => match s with | true => 1.0 | _ => 0.0"
     ));
-    assert_eq!(message, "pattern matches Bool, but the scrutinee is Shape");
+    assert_eq!(message, "pattern matches bool, but the scrutinee is Shape");
 }
 
-/// Bool matches: `true` + `false` (or a catch-all) is exhaustive; a missing
+/// bool matches: `true` + `false` (or a catch-all) is exhaustive; a missing
 /// literal is named.
 #[test]
 fn bool_match_exhaustiveness() {
-    assert_clean("let f = (b: Bool): Float => match b with | true => 1.0 | false => 0.0");
-    assert_clean("let f = (b: Bool): Float => match b with | true => 1.0 | _ => 0.0");
-    let (message, _, _) = single_diag("let f = (b: Bool): Float => match b with | true => 1.0");
-    assert_eq!(message, "match on Bool is not exhaustive: missing `false`");
+    assert_clean("let f = (b: bool): float => match b with | true => 1.0 | false => 0.0");
+    assert_clean("let f = (b: bool): float => match b with | true => 1.0 | _ => 0.0");
+    let (message, _, _) = single_diag("let f = (b: bool): float => match b with | true => 1.0");
+    assert_eq!(message, "match on bool is not exhaustive: missing `false`");
 }
 
 /// Number/string literal matches can never cover their type: they require a
@@ -681,16 +681,16 @@ fn bool_match_exhaustiveness() {
 #[test]
 fn literal_matches_require_a_catch_all() {
     let (message, _, _) =
-        single_diag("let f = (x: Float): Float => match x with | 1.0 => 1.0 | 2.0 => 2.0");
+        single_diag("let f = (x: float): float => match x with | 1.0 => 1.0 | 2.0 => 2.0");
     assert_eq!(
         message,
-        "match on Float is not exhaustive: literal patterns need a catch-all arm (`_` or a name)"
+        "match on float is not exhaustive: literal patterns need a catch-all arm (`_` or a name)"
     );
-    assert_clean("let f = (x: Float): Float => match x with | 1.0 => 1.0 | _ => 0.0");
-    let (message, _, _) = single_diag("let f = (x: String): Float => match x with | \"a\" => 1.0");
+    assert_clean("let f = (x: float): float => match x with | 1.0 => 1.0 | _ => 0.0");
+    let (message, _, _) = single_diag("let f = (x: string): float => match x with | \"a\" => 1.0");
     assert_eq!(
         message,
-        "match on String is not exhaustive: literal patterns need a catch-all arm (`_` or a name)"
+        "match on string is not exhaustive: literal patterns need a catch-all arm (`_` or a name)"
     );
 }
 
@@ -698,10 +698,10 @@ fn literal_matches_require_a_catch_all() {
 #[test]
 fn error_incompatible_arm_types() {
     let (message, _, _) =
-        single_diag("let f = (b: Bool) => match b with | true => 1.0 | false => \"no\"");
+        single_diag("let f = (b: bool) => match b with | true => 1.0 | false => \"no\"");
     assert_eq!(
         message,
-        "match arms have incompatible types Float and String"
+        "match arms have incompatible types float and string"
     );
 }
 
@@ -709,8 +709,8 @@ fn error_incompatible_arm_types() {
 #[test]
 fn match_type_flows_to_the_return_annotation() {
     let (message, _, _) =
-        single_diag("let f = (b: Bool): String => match b with | true => 1.0 | false => 0.0");
-    assert_eq!(message, "return value: expected String, got Float");
+        single_diag("let f = (b: bool): string => match b with | true => 1.0 | false => 0.0");
+    assert_eq!(message, "return value: expected string, got float");
 }
 
 /// Pattern variables get the declared field types — they flow into arm
@@ -718,11 +718,11 @@ fn match_type_flows_to_the_return_annotation() {
 #[test]
 fn pattern_vars_get_declared_field_types() {
     let (message, _, _) = single_diag(&format!(
-        "{SHAPE}let f = (s: Shape): String => match s with | Circle(r) => Text.concat(r, \"!\") | _ => \"\""
+        "{SHAPE}let f = (s: Shape): string => match s with | Circle(r) => Text.concat(r, \"!\") | _ => \"\""
     ));
     assert_eq!(
         message,
-        "argument 1 of `Text.concat`: expected String, got Float"
+        "argument 1 of `Text.concat`: expected string, got float"
     );
 }
 
@@ -730,10 +730,10 @@ fn pattern_vars_get_declared_field_types() {
 #[test]
 fn catch_all_var_binds_the_scrutinee_type() {
     let (message, _, _) = single_diag(&format!(
-        "{SHAPE}let area = (s: Shape): Float => 1.0\n\
-         let f = (s: Shape): Float => match s with | other => area(other) + other"
+        "{SHAPE}let area = (s: Shape): float => 1.0\n\
+         let f = (s: Shape): float => match s with | other => area(other) + other"
     ));
-    assert_eq!(message, "`+` needs Float operands, got Shape");
+    assert_eq!(message, "`+` needs float operands, got Shape");
 }
 
 /// Construction checks like any call: declared field types are enforced on the
@@ -744,9 +744,9 @@ fn error_ctor_argument_type_and_partial() {
     let (message, _, _) = single_diag(&format!("{SHAPE}let x = () => Circle(\"s\")"));
     assert_eq!(
         message,
-        "argument 1 of `Circle`: expected Float, got String"
+        "argument 1 of `Circle`: expected float, got string"
     );
-    // `Rect(1.0)` on a 2-arg ctor is a legal partial `(Float) => Shape`.
+    // `Rect(1.0)` on a 2-arg ctor is a legal partial `(float) => Shape`.
     assert_clean(&format!("{SHAPE}let x = () => Rect(1.0)"));
 }
 
@@ -756,7 +756,7 @@ fn variant_return_annotations_check() {
     assert_clean(&format!("{SHAPE}let f = (): Shape => Circle(2.0)"));
     assert_clean(&format!("{SHAPE}let f = (): Shape => Point"));
     let (message, _, _) = single_diag(&format!("{SHAPE}let f = (): Shape => 1.0"));
-    assert_eq!(message, "return value: expected Shape, got Float");
+    assert_eq!(message, "return value: expected Shape, got float");
 }
 
 // Gradual: these must NOT error.
@@ -780,8 +780,8 @@ fn match_patterns_constrain_the_scrutinee() {
     assert!(has(
         "match on `Shape` is not exhaustive: missing `Rect`, `Point`"
     ));
-    assert!(has("pattern matches Float, but the scrutinee is Shape"));
-    assert!(has("pattern matches String, but the scrutinee is Shape"));
+    assert!(has("pattern matches float, but the scrutinee is Shape"));
+    assert!(has("pattern matches string, but the scrutinee is Shape"));
     // Constraining flows THROUGH calls: g is the identity, so matching
     // g(s) against Point pins s to Shape — and the inferred scrutinee gets
     // the SAME exhaustiveness protection an annotated one does.
@@ -799,16 +799,16 @@ fn match_patterns_constrain_the_scrutinee() {
 /// match result stays gradual.
 #[test]
 fn polymorphic_arm_results_are_constrained() {
-    // B7: `g` is the identity, so `g(1.0)` IS Float — returning it where
+    // B7: `g` is the identity, so `g(1.0)` IS float — returning it where
     // the annotation promises String is caught at the arm join (the old
     // gradual checker saw Unknown and stayed silent).
     let (message, _, _) = single_diag(&format!(
         "{SHAPE}let g = (x) => x\n\
-         let f = (b: Bool): String => match b with | true => g(1.0) | false => \"s\""
+         let f = (b: bool): string => match b with | true => g(1.0) | false => \"s\""
     ));
     assert_eq!(
         message,
-        "match arms have incompatible types Float and String"
+        "match arms have incompatible types float and string"
     );
 }
 
@@ -818,11 +818,11 @@ fn polymorphic_arm_results_are_constrained() {
 /// pattern is a can-never-match diagnostic.
 #[test]
 fn tuple_pattern_arity_mismatch_is_flagged() {
-    let diags = check_src("let f = (t: (Float, String)): Bool => match t with | (x, y, z) => true");
+    let diags = check_src("let f = (t: (float, string)): bool => match t with | (x, y, z) => true");
     assert_eq!(diags.len(), 2, "{diags:?}");
     let has = |needle: &str| diags.iter().any(|(m, _, _)| m.contains(needle));
     assert!(
-        has("names 3 element(s), but the matched value is (Float, String)"),
+        has("names 3 element(s), but the matched value is (float, string)"),
         "{diags:?}"
     );
     // The mismatched arm must NOT count as exhaustive: the match as a whole
@@ -836,22 +836,22 @@ fn tuple_pattern_arity_mismatch_is_flagged() {
 /// A tuple pattern against a known non-tuple can never match.
 #[test]
 fn tuple_pattern_against_non_tuple_is_flagged() {
-    let diags = check_src("let f = (n: Float) => match n with | (a, b) => a");
+    let diags = check_src("let f = (n: float) => match n with | (a, b) => a");
     assert_eq!(diags.len(), 1);
     assert!(
-        diags[0].0.contains("a tuple pattern cannot match Float"),
+        diags[0].0.contains("a tuple pattern cannot match float"),
         "unexpected: {}",
         diags[0].0
     );
 }
 
 /// Element types flow through patterns: destructuring a known product gives
-/// typed variables (a String element used as Float errors).
+/// typed variables (a String element used as float errors).
 #[test]
 fn tuple_element_types_flow_through_patterns() {
-    let diags = check_src("let f = (t: (Float, String)): Float => let (n, s) = t in n + s");
+    let diags = check_src("let f = (t: (float, string)): float => let (n, s) = t in n + s");
     assert_eq!(diags.len(), 1);
-    assert!(diags[0].0.contains("String"), "unexpected: {}", diags[0].0);
+    assert!(diags[0].0.contains("string"), "unexpected: {}", diags[0].0);
 }
 
 /// Tuple literals meet their product expectation element-wise, so a record
@@ -859,7 +859,7 @@ fn tuple_element_types_flow_through_patterns() {
 /// [Codex H — tuples review]
 #[test]
 fn tuple_elements_meet_declared_types() {
-    let diags = check_src("type P = { x: Float }\nlet main = (): (P, Float) => ({ y: 1.0 }, 2.0)");
+    let diags = check_src("type P = { x: float }\nlet main = (): (P, float) => ({ y: 1.0 }, 2.0)");
     assert!(
         diags.iter().any(|(m, _, _)| m.contains("`y`")),
         "expected the record-literal field check to fire: {diags:?}"
@@ -880,7 +880,7 @@ fn tuple_equality_with_function_elements_is_an_error() {
 #[test]
 fn matching_arity_arm_satisfies_exhaustiveness() {
     let diags = check_src(
-        "let f = (t: (Float, String)): Float => match t with | (x, y, z) => 0.0 | (x, y) => x",
+        "let f = (t: (float, string)): float => match t with | (x, y, z) => 0.0 | (x, y) => x",
     );
     assert_eq!(diags.len(), 1, "{diags:?}");
     assert!(diags[0].0.contains("names 3 element(s)"));
@@ -888,7 +888,7 @@ fn matching_arity_arm_satisfies_exhaustiveness() {
 
 // --- B7: Hindley–Milner inference ---
 
-/// Let-polymorphism with teeth: `id` used at Float AND String in one
+/// Let-polymorphism with teeth: `id` used at float AND String in one
 /// module (the SCC-ordered generalization — whole-module letrec would
 /// have rejected this).
 #[test]
@@ -897,24 +897,24 @@ fn polymorphic_defs_instantiate_per_use() {
         "let id = (x) => x\n\
          let a = id(1.0)\n\
          let b = id(\"s\")\n\
-         let both = (n: Float, s: String) => (id(n) + 1.0, Text.concat(id(s), \"!\"))",
+         let both = (n: float, s: string) => (id(n) + 1.0, Text.concat(id(s), \"!\"))",
     );
 }
 
-/// Lowercase annotation names are scoped type variables — the generic
-/// annotations the roadmap promised.
+/// Apostrophe-prefixed annotation names are scoped type variables — the
+/// generic annotations the roadmap promised.
 #[test]
-fn lowercase_annotations_are_type_variables() {
+fn apostrophe_annotations_are_type_variables() {
     assert_clean(
-        "let first = (pair: (a, b)): a => match pair with | (x, _) => x\n\
+        "let first = (pair: ('a, 'b)): 'a => match pair with | (x, _) => x\n\
          let go = () => (first((1.0, \"s\")) + 1.0, first((true, 2.0)))",
     );
-    // …and they CONSTRAIN: both params share `a`, so mixed args error.
+    // …and they CONSTRAIN: both params share `'a`, so mixed args error.
     let (message, _, _) = single_diag(
-        "let same = (x: a, y: a): a => x\n\
+        "let same = (x: 'a, y: 'a): 'a => x\n\
          let bad = () => same(1.0, \"s\")",
     );
-    assert_eq!(message, "argument 2 of `same`: expected Float, got String");
+    assert_eq!(message, "argument 2 of `same`: expected float, got string");
 }
 
 /// The occurs check: `'a = List<'a>` is an infinite type, reported not
@@ -932,7 +932,7 @@ fn occurs_check_reports_infinite_types() {
 #[test]
 fn mixed_lists_are_errors() {
     let (message, _, _) = single_diag("let xs = [1.0, \"s\"]");
-    assert_eq!(message, "list element: expected Float, got String");
+    assert_eq!(message, "list element: expected float, got string");
 }
 
 /// Ambiguous record literals ask for an annotation (nominal F#-style
@@ -940,8 +940,8 @@ fn mixed_lists_are_errors() {
 #[test]
 fn ambiguous_record_literals_ask_for_annotation() {
     let (message, _, _) = single_diag(
-        "type Vec2 = { x: Float, y: Float }\n\
-         type Point2 = { x: Float, y: Float }\n\
+        "type Vec2 = { x: float, y: float }\n\
+         type Point2 = { x: float, y: float }\n\
          let p = { x: 1.0, y: 2.0 }",
     );
     assert_eq!(
@@ -957,7 +957,7 @@ fn mutual_recursion_infers() {
     assert_clean(
         "let even = (n) => match n < 1.0 with | true => true | false => odd(n - 1.0)\n\
          let odd = (n) => match n < 1.0 with | true => false | false => even(n - 1.0)\n\
-         let use = (): Bool => even(4.0)",
+         let use = (): bool => even(4.0)",
     );
 }
 
@@ -974,7 +974,7 @@ fn unannotated_defs_get_inferred_signatures() {
         .expr(module.defs[0].value.id)
         .expect("type recorded")
         .to_string();
-    assert_eq!(ty, "(List<Float>, Float) => List<Float>");
+    assert_eq!(ty, "(List<float>, float) => List<float>");
 }
 
 // --- B7 review fixes (both engines) ---
@@ -984,7 +984,7 @@ fn unannotated_defs_get_inferred_signatures() {
 #[test]
 fn unary_minus_constrains_the_operand() {
     let (message, _, _) = single_diag("let f = (x) => -x\nlet y = f(\"s\")");
-    assert_eq!(message, "argument 1 of `f`: expected Float, got String");
+    assert_eq!(message, "argument 1 of `f`: expected float, got string");
 }
 
 /// Match arms unify into ONE result type — a var arm is pinned by its
@@ -995,14 +995,14 @@ fn arm_results_unify() {
         "let f = (b, x) => match b with | true => x | false => 1.0\n\
          let z = f(true, \"s\")",
     );
-    assert_eq!(message, "argument 2 of `f`: expected Float, got String");
+    assert_eq!(message, "argument 2 of `f`: expected float, got string");
 }
 
 /// `==` pins variables at ANY depth, not just top level. [Codex H]
 #[test]
 fn equality_constrains_nested_variables() {
     let (message, _, _) = single_diag("let f = (x) => (x, 1.0) == (1.0, 1.0)\nlet y = f((z) => z)");
-    assert_eq!(message, "argument 1 of `f`: expected Float, got ('a) => 'a");
+    assert_eq!(message, "argument 1 of `f`: expected float, got ('a) => 'a");
 }
 
 /// Unreachable arms (after a catch-all) are checked but must not CONSTRAIN
@@ -1012,13 +1012,13 @@ fn unreachable_arms_do_not_constrain() {
     assert_clean("let f = (x) => (match x with | _ => 1.0 | \"s\" => 2.0) + x");
 }
 
-/// Bool and literal matches on INFERRED scrutinees get exhaustiveness too
+/// bool and literal matches on INFERRED scrutinees get exhaustiveness too
 /// (the stale-zonk hole). [BOTH engines, High]
 #[test]
 fn inferred_scrutinees_get_exhaustiveness() {
     let (message, _, _) = single_diag("let f = (x) => match x with | true => 1.0");
     assert!(
-        message.contains("match on Bool is not exhaustive: missing `false`"),
+        message.contains("match on bool is not exhaustive: missing `false`"),
         "unexpected: {message}"
     );
     let (message, _, _) = single_diag("let f = (x) => match x with | 2.0 => 1.0");
@@ -1030,9 +1030,9 @@ fn inferred_scrutinees_get_exhaustiveness() {
 /// for everyone). [BOTH engines]
 #[test]
 fn undeclared_type_params_are_refused() {
-    let (message, _, _) = single_diag("type Box = | Full(v: a) | Empty\nlet p = Full(1.0)");
+    let (message, _, _) = single_diag("type Box = | Full(v: 'a) | Empty\nlet p = Full(1.0)");
     assert!(
-        message.contains("undeclared type parameter `a` — declare it on the type"),
+        message.contains("undeclared type parameter `'a` — declare it on the type"),
         "unexpected: {message}"
     );
 }
@@ -1047,30 +1047,30 @@ fn diagnostic_variables_share_one_order() {
     // of the message with one consistent variable order.
     assert_eq!(
         message,
-        "argument 3 of `List.fold`: expected List<'a>, got (Float, 'a) => Float"
+        "argument 3 of `List.fold`: expected List<'a>, got (float, 'a) => float"
     );
 }
 
 // --- Generic type declarations ---
 
-/// The whole point: one declaration, many instantiations — Box<Float> and
-/// Box<String> coexist, and element types flow through patterns.
+/// The whole point: one declaration, many instantiations — Box<float> and
+/// Box<string> coexist, and element types flow through patterns.
 #[test]
 fn generic_adts_instantiate_per_use() {
     assert_clean(
-        "type Box<v> = | Full(value: v) | Empty\n\
-         let unwrapOr = (b: Box<v>, fallback: v): v =>\n\
+        "type Box<'v> = | Full(value: 'v) | Empty\n\
+         let unwrapOr = (b: Box<'v>, fallback: 'v): 'v =>\n\
            match b with\n\
            | Full(value) => value\n\
            | Empty => fallback\n\
          let a = unwrapOr(Full(41.0), 0.0) + 1.0\n\
          let b = Text.concat(unwrapOr(Full(\"hi\"), \"\"), \"!\")",
     );
-    // …and the instantiation CONSTRAINS: a Float box can't take a String
+    // …and the instantiation CONSTRAINS: a float box can't take a String
     // fallback.
     let (message, _, _) = single_diag(
-        "type Box<v> = | Full(value: v) | Empty\n\
-         let unwrapOr = (b: Box<v>, fallback: v): v =>\n\
+        "type Box<'v> = | Full(value: 'v) | Empty\n\
+         let unwrapOr = (b: Box<'v>, fallback: 'v): 'v =>\n\
            match b with\n\
            | Full(value) => value\n\
            | Empty => fallback\n\
@@ -1078,7 +1078,7 @@ fn generic_adts_instantiate_per_use() {
     );
     assert_eq!(
         message,
-        "argument 2 of `unwrapOr`: expected Float, got String"
+        "argument 2 of `unwrapOr`: expected float, got string"
     );
 }
 
@@ -1087,36 +1087,36 @@ fn generic_adts_instantiate_per_use() {
 #[test]
 fn generic_records_solve_from_literals() {
     assert_clean(
-        "type Pair<x, y> = { first: x, second: y }\n\
-         let swap = (p: Pair<x, y>): Pair<y, x> => { first: p.second, second: p.first }\n\
+        "type Pair<'x, 'y> = { first: 'x, second: 'y }\n\
+         let swap = (p: Pair<'x, 'y>): Pair<'y, 'x> => { first: p.second, second: p.first }\n\
          let go = () => swap({ first: 1.0, second: \"s\" }).second + 1.0",
     );
     let (message, _, _) = single_diag(
-        "type Pair<x, y> = { first: x, second: y }\n\
-         let go = (): Float => { first: 1.0, second: \"s\" }.second",
+        "type Pair<'x, 'y> = { first: 'x, second: 'y }\n\
+         let go = (): float => { first: 1.0, second: \"s\" }.second",
     );
-    assert_eq!(message, "return value: expected Float, got String");
+    assert_eq!(message, "return value: expected float, got string");
 }
 
-/// Pattern fields get the scrutinee's arguments (Full(v) on Box<Float>
-/// binds v: Float — and arithmetic on it checks).
+/// Pattern fields get the scrutinee's arguments (Full(v) on Box<float>
+/// binds v: float — and arithmetic on it checks).
 #[test]
 fn pattern_fields_take_scrutinee_arguments() {
     let (message, _, _) = single_diag(
-        "type Box<v> = | Full(value: v) | Empty\n\
-         let f = (b: Box<String>): Float =>\n\
+        "type Box<'v> = | Full(value: 'v) | Empty\n\
+         let f = (b: Box<string>): float =>\n\
            match b with\n\
            | Full(value) => value + 1.0\n\
            | Empty => 0.0",
     );
-    assert_eq!(message, "`+` needs Float operands, got String");
+    assert_eq!(message, "`+` needs float operands, got string");
 }
 
 /// Type-argument arity is checked against the declaration.
 #[test]
 fn generic_arity_is_checked() {
     let (message, _, _) = single_diag(
-        "type Box<v> = | Full(value: v) | Empty\n\
+        "type Box<'v> = | Full(value: 'v) | Empty\n\
          let f = (b: Box) => b",
     );
     assert_eq!(message, "`Box` takes 1 type argument(s), got 0");
@@ -1129,8 +1129,8 @@ fn generic_arity_is_checked() {
 #[test]
 fn recursive_generic_declarations_resolve() {
     assert_clean(
-        "type L<a> = | Cons(h: a, t: L<a>) | Nil\n\
-         let sum = (l: L<Float>): Float =>\n\
+        "type L<'a> = | Cons(h: 'a, t: L<'a>) | Nil\n\
+         let sum = (l: L<float>): float =>\n\
            match l with\n\
            | Cons(h, t) => h + sum(t)\n\
            | Nil => 0.0\n\
@@ -1143,14 +1143,14 @@ fn recursive_generic_declarations_resolve() {
 #[test]
 fn generic_record_equality_certainty() {
     let (message, _, _) = single_diag(
-        "type R<a> = { x: a }\n\
-         let eq = (a: R<String>, b: R<Float>): Bool => a == b",
+        "type R<'a> = { x: 'a }\n\
+         let eq = (a: R<string>, b: R<float>): bool => a == b",
     );
     assert!(message.contains("always false"), "unexpected: {message}");
     let (message, _, _) = single_diag(
-        "type R<a> = { x: a }\n\
-         type S = { x: Float }\n\
-         let eq = (r: R<String>, s: S): Bool => r == s",
+        "type R<'a> = { x: 'a }\n\
+         type S = { x: float }\n\
+         let eq = (r: R<string>, s: S): bool => r == s",
     );
     assert!(message.contains("always false"), "unexpected: {message}");
 }
@@ -1160,8 +1160,8 @@ fn generic_record_equality_certainty() {
 #[test]
 fn functions_inside_generic_nominals_cannot_compare() {
     let (message, _, _) = single_diag(
-        "type Box<a> = | Full(v: a)\n\
-         let main = (): Bool => Full((x) => x) == Full((x) => x)",
+        "type Box<'a> = | Full(v: 'a)\n\
+         let main = (): bool => Full((x) => x) == Full((x) => x)",
     );
     assert_eq!(message, "functions cannot be compared with `==`");
 }
@@ -1173,12 +1173,12 @@ fn functions_inside_generic_nominals_cannot_compare() {
 #[test]
 fn effect_pair_arms_join_with_bare_model_arms() {
     for src in [
-        "type Msg = | Roll | Rolled(n: Float)\n\
+        "type Msg = | Roll | Rolled(n: float)\n\
          let update = (m, msg) => match msg with | Roll => (m, Effect.random(Rolled)) | Rolled(n) => m",
-        "type Msg = | Roll | Rolled(n: Float)\n\
+        "type Msg = | Roll | Rolled(n: float)\n\
          let update = (m, msg) => match msg with | Rolled(n) => m | Roll => (m, Effect.random(Rolled))",
-        "type Model = { roll: Float }\n\
-         type Msg = | Roll | Rolled(n: Float)\n\
+        "type Model = { roll: float }\n\
+         type Msg = | Roll | Rolled(n: float)\n\
          let update = (m: Model, msg) => match msg with | Roll => (m, Effect.random(Rolled)) | Rolled(n) => { m with roll: n }",
     ] {
         let diags = check_src(src);
@@ -1194,17 +1194,17 @@ fn effect_pair_arms_join_with_bare_model_arms() {
 /// Element types flow through cons and list patterns.
 #[test]
 fn list_patterns_flow_element_types() {
-    // A String element used as a Float via a list pattern errors (a
+    // A String element used as a float via a list pattern errors (a
     // catch-all keeps the ONLY diagnostic the type mismatch).
     let (message, _, _) = single_diag(
-        "let f = (xs: List<String>): Float =>\n\
+        "let f = (xs: List<string>): float =>\n\
          match xs with | [a, ..rest] => a + 1.0 | _ => 0.0",
     );
-    assert!(message.contains("String"), "unexpected: {message}");
+    assert!(message.contains("string"), "unexpected: {message}");
     // Cons unifies the head with the tail's element type.
-    let (message, _, _) = single_diag("let f = (xs: List<Float>) => [\"s\", ..xs]");
+    let (message, _, _) = single_diag("let f = (xs: List<float>) => [\"s\", ..xs]");
     assert!(
-        message.contains("`..` tail") || message.contains("String"),
+        message.contains("`..` tail") || message.contains("string"),
         "unexpected: {message}"
     );
 }
@@ -1214,19 +1214,19 @@ fn list_patterns_flow_element_types() {
 #[test]
 fn list_match_exhaustiveness() {
     let (message, _, _) =
-        single_diag("let f = (xs: List<Float>): Float => match xs with | [a, b] => a + b");
+        single_diag("let f = (xs: List<float>): float => match xs with | [a, b] => a + b");
     assert!(
         message.contains("not exhaustive: add"),
         "unexpected: {message}"
     );
     // The canonical recursion [] + [h, ..t] IS exhaustive now.
     assert_clean(
-        "let sum = (xs: List<Float>): Float =>
+        "let sum = (xs: List<float>): float =>
          match xs with | [] => 0.0 | [h, ..t] => h + sum(t)",
     );
-    assert_clean("let f = (xs: List<Float>): Float => match xs with | [..all] => 0.0");
+    assert_clean("let f = (xs: List<float>): float => match xs with | [..all] => 0.0");
     assert_clean(
-        "let f = (xs: List<Float>): Float =>\n\
+        "let f = (xs: List<float>): float =>\n\
          match xs with | [a] => a | _ => 0.0",
     );
 }
@@ -1235,9 +1235,9 @@ fn list_match_exhaustiveness() {
 #[test]
 fn list_pattern_against_non_list() {
     let (message, _, _) =
-        single_diag("let f = (n: Float): Float => match n with | [a, ..t] => a | _ => 0.0");
+        single_diag("let f = (n: float): float => match n with | [a, ..t] => a | _ => 0.0");
     assert!(
-        message.contains("a list pattern cannot match Float"),
+        message.contains("a list pattern cannot match float"),
         "unexpected: {message}"
     );
 }
@@ -1248,22 +1248,22 @@ fn list_pattern_against_non_list() {
 /// its type flows: `apply` applies `f` to `x`.
 #[test]
 fn function_type_annotation_on_a_parameter() {
-    assert_clean("let apply = (f: (Float) => Float, x: Float): Float => f(x)");
-    assert_clean("let twice = (f: (Float) => Float, x: Float): Float => f(f(x))");
+    assert_clean("let apply = (f: (float) => float, x: float): float => f(x)");
+    assert_clean("let twice = (f: (float) => float, x: float): float => f(f(x))");
 }
 
 /// A function-typed argument is checked against its declared signature — the
-/// expected `(Float) => Float` flows into the lambda, so a `(String) => String`
+/// expected `(float) => float` flows into the lambda, so a `(String) => String`
 /// argument flags both its param and its return precisely.
 #[test]
 fn function_typed_argument_is_checked() {
     let diags = check_src(
-        "let apply = (f: (Float) => Float, x: Float): Float => f(x)\n\
-         let bad = () => apply((s: String): String => s, 1.0)",
+        "let apply = (f: (float) => float, x: float): float => f(x)\n\
+         let bad = () => apply((s: string): string => s, 1.0)",
     );
     let msgs: Vec<&str> = diags.iter().map(|(m, _, _)| m.as_str()).collect();
     assert!(
-        msgs.iter().any(|m| m.contains("parameter `s`") && m.contains("expected Float")),
+        msgs.iter().any(|m| m.contains("parameter `s`") && m.contains("expected float")),
         "want a param mismatch, got {msgs:?}"
     );
 }
@@ -1271,35 +1271,35 @@ fn function_typed_argument_is_checked() {
 /// A zero-argument function type parses and checks.
 #[test]
 fn nullary_function_type() {
-    assert_clean("let run = (cb: () => Float): Float => cb()");
+    assert_clean("let run = (cb: () => float): float => cb()");
 }
 
 /// `(A, B)` is the tuple type spelling (the old `*` is gone).
 #[test]
 fn paren_tuple_type_annotation() {
     assert_clean(
-        "let swap = (p: (Float, String)): (String, Float) => match p with | (a, b) => (b, a)",
+        "let swap = (p: (float, string)): (string, float) => match p with | (a, b) => (b, a)",
     );
 }
 
 /// A function type used as a *return* annotation must be parenthesized — then
-/// it checks (currying: `adder(n)` returns a `(Float) => Float`).
+/// it checks (currying: `adder(n)` returns a `(float) => float`).
 #[test]
 fn parenthesized_function_return_type() {
-    assert_clean("let adder = (n: Float): ((Float) => Float) => (x: Float): Float => x + n");
+    assert_clean("let adder = (n: float): ((float) => float) => (x: float): float => x + n");
 }
 
 /// `(A)` is grouping — the same as `A`.
 #[test]
 fn parenthesized_group_is_the_inner_type() {
-    assert_clean("let f = (x: (Float)): Float => x + 1.0");
+    assert_clean("let f = (x: (float)): float => x + 1.0");
 }
 
 /// The removed `*` product spelling is now a parse error in type position.
 #[test]
 fn star_tuple_type_is_rejected() {
     assert!(
-        mle::parse("let f = (p: Float * Float): Float => 0.0").is_err(),
+        mle::parse("let f = (p: float * float): float => 0.0").is_err(),
         "`*` should no longer parse as a tuple type"
     );
 }
@@ -1308,7 +1308,7 @@ fn star_tuple_type_is_rejected() {
 #[test]
 fn empty_parens_require_an_arrow() {
     assert!(
-        mle::parse("let f = (x: ()): Float => 0.0").is_err(),
+        mle::parse("let f = (x: ()): float => 0.0").is_err(),
         "`()` alone is not a type"
     );
 }
@@ -1316,42 +1316,42 @@ fn empty_parens_require_an_arrow() {
 // ── let-binding type annotations (mlei slice 2b) ─────────────────────────
 
 /// A top-level binding annotation checks against the value and flows into an
-/// unannotated body: `let f: (Float) => Float = (x) => …` gives `x: Float`.
+/// unannotated body: `let f: (float) => float = (x) => …` gives `x: float`.
 #[test]
 fn top_level_binding_annotation() {
-    assert_clean("let x: Float = 3.0");
-    assert_clean("let f: (Float) => Float = (x) => x + 1.0");
-    assert_clean("type M = { a: Bool }\nlet m: M = { a: true }");
+    assert_clean("let x: float = 3.0");
+    assert_clean("let f: (float) => float = (x) => x + 1.0");
+    assert_clean("type M = { a: bool }\nlet m: M = { a: true }");
 }
 
 /// A binding annotation is enforced — a simple, a record-literal, and a
 /// function return-type mismatch all error.
 #[test]
 fn binding_annotation_mismatch_is_flagged() {
-    let (message, _, _) = single_diag("let x: Bool = 3.0");
-    assert_eq!(message, "`x`: expected Bool, got Float");
+    let (message, _, _) = single_diag("let x: bool = 3.0");
+    assert_eq!(message, "`x`: expected bool, got float");
 
-    let (message, _, _) = single_diag("type M = { a: Bool }\nlet m: M = { a: 3.0 }");
-    assert_eq!(message, "field `a` of `M`: expected Bool, got Float");
+    let (message, _, _) = single_diag("type M = { a: bool }\nlet m: M = { a: 3.0 }");
+    assert_eq!(message, "field `a` of `M`: expected bool, got float");
 
-    // The annotation flows `x: Float` in and pushes the expected return into
+    // The annotation flows `x: float` in and pushes the expected return into
     // the body, so the mismatch localizes to the return value.
-    let (message, _, _) = single_diag("let f: (Float) => Bool = (x) => x");
-    assert_eq!(message, "return value: expected Bool, got Float");
+    let (message, _, _) = single_diag("let f: (float) => bool = (x) => x");
+    assert_eq!(message, "return value: expected bool, got float");
 }
 
 /// let-in bindings take annotations too, checked the same way.
 #[test]
 fn let_in_binding_annotation() {
-    assert_clean("let g = () => let y: Float = 3.0 in y + 1.0");
-    let (message, _, _) = single_diag("let g = () => let y: Bool = 3.0 in y");
-    assert_eq!(message, "`y`: expected Bool, got Float");
+    assert_clean("let g = () => let y: float = 3.0 in y + 1.0");
+    let (message, _, _) = single_diag("let g = () => let y: bool = 3.0 in y");
+    assert_eq!(message, "`y`: expected bool, got float");
 }
 
 /// A `mut` let-in binding can be annotated.
 #[test]
 fn annotated_mut_binding() {
-    assert_clean("let f = (n: Float): Float => let mut acc: Float = n in acc := acc + 1.0; acc");
+    assert_clean("let f = (n: float): float => let mut acc: float = n in acc := acc + 1.0; acc");
 }
 
 /// An invalid binding annotation (here a `List` arity error) reports at the
@@ -1372,8 +1372,8 @@ fn invalid_top_level_annotation_reports() {
 #[test]
 fn binding_annotation_flows_into_body() {
     let (message, _, _) = single_diag(
-        "type Position = { x: Float }\n\
-         let getX: (Position) => Float = (p) => p.z",
+        "type Position = { x: float }\n\
+         let getX: (Position) => float = (p) => p.z",
     );
     assert_eq!(message, "`Position` has no field `z`");
 }
@@ -1399,8 +1399,8 @@ fn abstract_type_resolves_and_unifies() {
 /// An abstract type is distinct from every other type — a mismatch is caught.
 #[test]
 fn abstract_type_mismatch_is_flagged() {
-    let (message, _, _) = single_diag("type SceneNode\nlet bad = (n: SceneNode): Float => n");
-    assert_eq!(message, "return value: expected Float, got SceneNode");
+    let (message, _, _) = single_diag("type SceneNode\nlet bad = (n: SceneNode): float => n");
+    assert_eq!(message, "return value: expected float, got SceneNode");
 }
 
 /// An abstract type has NO constructor — its values come only from host code,
@@ -1412,15 +1412,15 @@ fn abstract_type_has_no_constructor() {
     assert!(err.message.contains("SceneNode"), "unexpected: {}", err.message);
 }
 
-/// Abstract types may be generic: `type Handle<a>`.
+/// Abstract types may be generic: `type Handle<'a>`.
 #[test]
 fn generic_abstract_type() {
     assert_clean(
-        "type Handle<a>\n\
-         let use = (h: Handle<Float>): Handle<Float> => h",
+        "type Handle<'a>\n\
+         let use = (h: Handle<float>): Handle<float> => h",
     );
     // Arity is enforced, like other nominal types.
-    let (message, _, _) = single_diag("type Handle<a>\nlet f = (h: Handle): Float => 0.0");
+    let (message, _, _) = single_diag("type Handle<'a>\nlet f = (h: Handle): float => 0.0");
     assert!(
         message.contains("Handle") && message.contains("type argument"),
         "{message}"
@@ -1431,7 +1431,7 @@ fn generic_abstract_type() {
 /// silently swallowed as an abstract type (mlei 2c review, Finding 1).
 #[test]
 fn forgotten_type_equals_is_diagnosed() {
-    for src in ["type Point { x: Float }", "type Shape | Circle(r: Float)"] {
+    for src in ["type Point { x: float }", "type Shape | Circle(r: float)"] {
         let err = mle::parse(src).expect_err("a missing `=` should error");
         assert!(
             err.message.contains("`=` before the type body"),

--- a/mle/tests/ir.rs
+++ b/mle/tests/ir.rs
@@ -106,12 +106,12 @@ fn error_unknown_name() {
 }
 
 /// Redeclaring a builtin type name would shadow the primitive in annotations
-/// ("expected Float, got Float"). [Claude L — B5 review]
+/// ("expected float, got float"). [Claude L — B5 review]
 #[test]
 fn error_redeclare_builtin_type() {
-    let (message, _, _) = lower_err("type Float = | Foo");
-    assert_eq!(message, "cannot redeclare builtin type `Float`");
-    let (message, _, _) = lower_err("type List = { head: Float }");
+    let (message, _, _) = lower_err("type float = | Foo");
+    assert_eq!(message, "cannot redeclare builtin type `float`");
+    let (message, _, _) = lower_err("type List = { head: float }");
     assert_eq!(message, "cannot redeclare builtin type `List`");
 }
 
@@ -228,7 +228,7 @@ fn error_duplicate_parameter() {
 // `let Foo` coexist; each namespace keys its own hot-reload identities.
 #[test]
 fn type_and_let_may_share_a_name() {
-    let module = lower_src("type Foo = { x: Float }\nlet Foo = 1");
+    let module = lower_src("type Foo = { x: float }\nlet Foo = 1");
     assert_eq!(module.types.len(), 1);
     assert_eq!(module.defs.len(), 1);
     assert_eq!(module.types[0].name, "Foo");
@@ -292,8 +292,8 @@ fn error_duplicate_update_field() {
 #[test]
 fn error_ctor_collision_across_types() {
     let (message, line, col) = lower_err(
-        "type Shape = | Circle(r: Float)\n\
-         type Blob = | Circle(r: Float)",
+        "type Shape = | Circle(r: float)\n\
+         type Blob = | Circle(r: float)",
     );
     assert_eq!(message, "duplicate constructor `Circle`");
     assert_eq!((line, col), (2, 15));
@@ -301,7 +301,7 @@ fn error_ctor_collision_across_types() {
 
 #[test]
 fn error_ctor_collision_within_a_type() {
-    let (message, _, _) = lower_err("type Shape = | Circle(r: Float) | Circle(d: Float)");
+    let (message, _, _) = lower_err("type Shape = | Circle(r: float) | Circle(d: float)");
     assert_eq!(message, "duplicate constructor `Circle`");
 }
 
@@ -310,10 +310,10 @@ fn error_ctor_collision_within_a_type() {
 #[test]
 fn error_ctor_collides_with_let() {
     let expected = "duplicate definition `Circle` (constructors live in the value namespace)";
-    let (message, line, col) = lower_err("let Circle = 1\ntype Shape = | Circle(r: Float)");
+    let (message, line, col) = lower_err("let Circle = 1\ntype Shape = | Circle(r: float)");
     assert_eq!(message, expected);
     assert_eq!((line, col), (2, 16));
-    let (message, line, col) = lower_err("type Shape = | Circle(r: Float)\nlet Circle = 1");
+    let (message, line, col) = lower_err("type Shape = | Circle(r: float)\nlet Circle = 1");
     assert_eq!(message, expected);
     assert_eq!((line, col), (2, 1));
 }
@@ -323,7 +323,7 @@ fn error_ctor_collides_with_let() {
 /// (only bare `Circle` is) — it stays an unknown external.
 #[test]
 fn qualified_ctor_form_is_not_supported() {
-    let module = lower_src("type Shape = | Circle(r: Float)\nlet f = () => Shape.Circle(1.0)");
+    let module = lower_src("type Shape = | Circle(r: float)\nlet f = () => Shape.Circle(1.0)");
     let (_, body) = lambda_body(&module, 0);
     let ExprKind::Call { callee, .. } = &body.kind else {
         panic!("expected a call, got {body:?}");
@@ -338,7 +338,7 @@ fn qualified_ctor_form_is_not_supported() {
 /// declared arity rides along in the IR.
 #[test]
 fn bare_ctor_resolves_with_arity() {
-    let module = lower_src("type Shape = | Circle(r: Float) | Point\nlet f = () => Circle(2.0)");
+    let module = lower_src("type Shape = | Circle(r: float) | Point\nlet f = () => Circle(2.0)");
     let (_, body) = lambda_body(&module, 0);
     let ExprKind::Call { callee, .. } = &body.kind else {
         panic!("expected a call, got {body:?}");
@@ -352,7 +352,7 @@ fn bare_ctor_resolves_with_arity() {
 /// A local binding shadows a constructor, exactly like it shadows a global.
 #[test]
 fn param_shadows_ctor() {
-    let module = lower_src("type Shape = | Circle(r: Float)\nlet f = (Circle) => Circle");
+    let module = lower_src("type Shape = | Circle(r: float)\nlet f = (Circle) => Circle");
     let (params, body) = lambda_body(&module, 0);
     let ExprKind::Local { binding, .. } = &body.kind else {
         panic!("expected a local, got {body:?}");
@@ -373,13 +373,13 @@ fn error_unknown_ctor_in_pattern() {
 #[test]
 fn error_pattern_arity_mismatch() {
     let (message, _, _) = lower_err(
-        "type Shape = | Circle(r: Float)\n\
+        "type Shape = | Circle(r: float)\n\
          let f = (s) => match s with | Circle(a, b) => a | _ => 0.0",
     );
     assert_eq!(message, "`Circle` has 1 field(s), but the pattern names 2");
 
     let (message, _, _) = lower_err(
-        "type Shape = | Circle(r: Float)\n\
+        "type Shape = | Circle(r: float)\n\
          let f = (s) => match s with | Circle => 1.0 | _ => 0.0",
     );
     assert_eq!(message, "`Circle` has 1 field(s), but the pattern names 0");
@@ -388,7 +388,7 @@ fn error_pattern_arity_mismatch() {
 #[test]
 fn error_duplicate_pattern_variable() {
     let (message, line, col) = lower_err(
-        "type Shape = | Rect(w: Float, h: Float)\n\
+        "type Shape = | Rect(w: float, h: float)\n\
          let f = (s) => match s with | Rect(a, a) => a | _ => 0.0",
     );
     assert_eq!(message, "duplicate pattern variable `a`");
@@ -400,7 +400,7 @@ fn error_duplicate_pattern_variable() {
 #[test]
 fn pattern_vars_do_not_leak_between_arms() {
     let (message, _, _) = lower_err(
-        "type Shape = | Circle(r: Float) | Point\n\
+        "type Shape = | Circle(r: float) | Point\n\
          let f = (s) => match s with | Circle(r) => r | Point => r",
     );
     assert_eq!(message, "unknown name `r`");
@@ -411,7 +411,7 @@ fn pattern_vars_do_not_leak_between_arms() {
 #[test]
 fn lambdas_may_capture_pattern_vars() {
     let module = lower_src(
-        "type Shape = | Circle(r: Float)\n\
+        "type Shape = | Circle(r: float)\n\
          let f = (s) => match s with | Circle(r) => (x) => r + x | _ => (x) => x",
     );
     assert_eq!(module.defs.len(), 1);
@@ -421,7 +421,7 @@ fn lambdas_may_capture_pattern_vars() {
 #[test]
 fn error_assign_to_pattern_var() {
     let (message, _, _) = lower_err(
-        "type Shape = | Circle(r: Float)\n\
+        "type Shape = | Circle(r: float)\n\
          let f = (s) => match s with | Circle(r) => r := 1.0; r | _ => 0.0",
     );
     assert_eq!(message, "cannot assign to immutable binding `r`");

--- a/mle/tests/parser.rs
+++ b/mle/tests/parser.rs
@@ -146,7 +146,7 @@ fn error_deeply_nested_expression() {
 
 #[test]
 fn generic_args_allow_trailing_comma() {
-    assert!(mle::parse("type T = { xs: List<Float,> }").is_ok());
+    assert!(mle::parse("type T = { xs: List<float,> }").is_ok());
 }
 
 /// Error spans must stay sliceable (char-boundary aligned) even when the
@@ -213,7 +213,7 @@ fn assignment_to_field_is_a_targeted_error() {
 #[test]
 fn variant_declaration_forms_parse() {
     assert!(
-        mle::parse("type Shape = | Circle(radius: Float) | Rect(w: Float, h: Float,) | Point")
+        mle::parse("type Shape = | Circle(radius: float) | Rect(w: float, h: float,) | Point")
             .is_ok()
     );
     assert!(mle::parse("type Answer = | Yes").is_ok());
@@ -223,7 +223,7 @@ fn variant_declaration_forms_parse() {
 #[test]
 fn error_variant_requires_leading_bar() {
     assert_eq!(
-        parse_err("type Shape = Circle(radius: Float)"),
+        parse_err("type Shape = Circle(radius: float)"),
         (
             "expected `{` (a record type) or `|` (a variant alternative), found `Circle`"
                 .to_string(),
@@ -236,7 +236,7 @@ fn error_variant_requires_leading_bar() {
 #[test]
 fn error_lowercase_constructor_name() {
     assert_eq!(
-        parse_err("type Shape = | circle(radius: Float)"),
+        parse_err("type Shape = | circle(radius: float)"),
         (
             "constructor name `circle` must start uppercase".to_string(),
             1,
@@ -249,7 +249,7 @@ fn error_lowercase_constructor_name() {
 #[test]
 fn error_variant_field_needs_a_name() {
     assert_eq!(
-        parse_err("type Shape = | Circle(Float)"),
+        parse_err("type Shape = | Circle(float)"),
         (
             "expected `:` after field name, found `)`".to_string(),
             1,
@@ -407,17 +407,17 @@ fn error_mut_cannot_destructure() {
 #[test]
 fn error_duplicate_type_parameter() {
     assert_eq!(
-        parse_err("type Pair<a, a> = { x: a }"),
-        ("duplicate type parameter `a`".to_string(), 1, 14)
+        parse_err("type Pair<'a, 'a> = { x: 'a }"),
+        ("duplicate type parameter `'a`".to_string(), 1, 15)
     );
 }
 
 #[test]
-fn error_uppercase_type_parameter() {
+fn error_non_typevar_type_parameter() {
     assert_eq!(
         parse_err("type Box<T> = | Full(v: T)"),
         (
-            "type parameters are lowercase (`t`), like annotation type variables".to_string(),
+            "expected a type parameter (e.g. `'a`), found `T`".to_string(),
             1,
             10
         )

--- a/mle/tests/project.rs
+++ b/mle/tests/project.rs
@@ -124,9 +124,9 @@ fn qualified_values_and_ctors_work_without_open() {
             ),
             (
                 "util.mle",
-                "type Carton = | Wrapped(value: Float)\n\
+                "type Carton = | Wrapped(value: float)\n\
                  let base = 10.0\n\
-                 let wrap = (n: Float): Carton => Wrapped(n)\n",
+                 let wrap = (n: float): Carton => Wrapped(n)\n",
             ),
         ],
     );
@@ -146,7 +146,7 @@ fn qualified_ctor_is_first_class() {
             ),
             (
                 "util.mle",
-                "type Carton = | Wrapped(value: Float)\n\
+                "type Carton = | Wrapped(value: float)\n\
                  let unwrap = (c) => match c with | Wrapped(n) => n\n",
             ),
         ],
@@ -272,12 +272,12 @@ fn open_brings_defs_ctors_and_types_into_scope() {
             (
                 "game.mle",
                 "open Util\n\
-                 let grab = (c: Carton): Float => match c with | Wrapped(n) => n\n\
+                 let grab = (c: Carton): float => match c with | Wrapped(n) => n\n\
                  let main = () => grab(Wrapped(base))\n",
             ),
             (
                 "util.mle",
-                "type Carton = | Wrapped(value: Float)\nlet base = 42.0\n",
+                "type Carton = | Wrapped(value: float)\nlet base = 42.0\n",
             ),
         ],
     );
@@ -324,9 +324,9 @@ fn open_type_collision_is_an_error() {
         &[
             (
                 "game.mle",
-                "open Util\ntype Carton = { x: Float }\nlet main = () => 0.0\n",
+                "open Util\ntype Carton = { x: float }\nlet main = () => 0.0\n",
             ),
-            ("util.mle", "type Carton = | Wrapped(value: Float)\n"),
+            ("util.mle", "type Carton = | Wrapped(value: float)\n"),
         ],
     );
     assert_eq!(
@@ -483,7 +483,7 @@ fn unreferenced_sibling_diagnostics_surface_with_their_file() {
             ("game.mle", "let main = () => 0.0\n"),
             (
                 "util.mle",
-                "// an unreferenced module with a type error\nlet bad = (a: Float): Float => a + \"one\"\n",
+                "// an unreferenced module with a type error\nlet bad = (a: float): float => a + \"one\"\n",
             ),
         ],
     );
@@ -511,11 +511,11 @@ fn cross_module_generics_check() {
             (
                 "game.mle",
                 "open Boxes\n\
-                 let good = (b: Box<Float>): Float =>\n\
+                 let good = (b: Box<float>): float =>\n\
                  match b with | Full(v) => v + 1.0 | Empty => 0.0\n\
                  let bad = () => good(Full(\"nope\"))\n",
             ),
-            ("boxes.mle", "type Box<v> = | Full(value: v) | Empty\n"),
+            ("boxes.mle", "type Box<'v> = | Full(value: 'v) | Empty\n"),
         ],
     );
     let project = scratch.load().unwrap_or_else(|e| panic!("{}", e.render()));
@@ -524,7 +524,7 @@ fn cross_module_generics_check() {
     assert!(
         diags[0]
             .message
-            .contains("expected Boxes.Box<Float>, got Boxes.Box<String>"),
+            .contains("expected Boxes.Box<float>, got Boxes.Box<string>"),
         "unexpected diagnostic: {}",
         diags[0].message
     );
@@ -541,7 +541,7 @@ fn stray_sibling_type_does_not_capture_bare_literals() {
         &[
             (
                 "game.mle",
-                "type Position = { x: Float, y: Float }
+                "type Position = { x: float, y: float }
                  let p = { x: 1.0, y: 2.0 }
 let main = () => p.x
 ",
@@ -549,7 +549,7 @@ let main = () => p.x
             // Same field shape, never referenced, never opened.
             (
                 "extra.mle",
-                "type Point = { x: Float, y: Float }
+                "type Point = { x: float, y: float }
 ",
             ),
         ],
@@ -578,7 +578,7 @@ let bad = f() + 1.0
             ),
             (
                 "vec.mle",
-                "type V2 = { x: Float, y: Float }
+                "type V2 = { x: float, y: float }
 ",
             ),
         ],
@@ -608,7 +608,7 @@ let bad = f() + 1.0
             ),
             (
                 "vec.mle",
-                "type V2 = { x: Float, y: Float }
+                "type V2 = { x: float, y: float }
 ",
             ),
         ],
@@ -629,8 +629,8 @@ fn single_file_project_adds_only_the_builtin_net_module() {
     // A project always includes the built-in `Net` prelude module (so any
     // game can `match ev with | Net.Connected(id) => …`), so its merged IR
     // is plain lowering's defs/types PLUS Net's — nothing else changes.
-    let src = "type Shape = | Circle(radius: Float) | Point\n\
-               let area = (s: Shape): Float =>\n\
+    let src = "type Shape = | Circle(radius: float) | Point\n\
+               let area = (s: Shape): float =>\n\
                match s with | Circle(r) => 3.14 * r * r | Point => 0.0\n\
                let main = () => area(Circle(2.0))\n";
     let project = load("single-file", &[("game.mle", src)]);
@@ -775,20 +775,20 @@ fn project_typed_check_infers_across_files() {
         &[
             // Entry calls Utils.double with no annotations anywhere.
             ("game.mle", "let apply = (n) => Utils.double(n)\n"),
-            ("utils.mle", "let double = (x: Float): Float => x * 2.0\n"),
+            ("utils.mle", "let double = (x: float): float => x * 2.0\n"),
         ],
     );
     let (diags, types) = project.check_with_types();
     assert!(diags.is_empty(), "clean: {diags:?}");
 
-    // The entry's `apply` is inferred `(Float) => Float` across the file
-    // boundary (Utils.double is annotated Float→Float).
+    // The entry's `apply` is inferred `(float) => float` across the file
+    // boundary (Utils.double is annotated float→float).
     let sigs: Vec<String> = mle::codelens::signatures(&project.module, &types)
         .into_iter()
         .map(|s| s.title)
         .collect();
     assert!(
-        sigs.contains(&"apply : (Float) => Float".to_string()),
+        sigs.contains(&"apply : (float) => float".to_string()),
         "signatures: {sigs:?}"
     );
 
@@ -817,7 +817,7 @@ fn overrides_replace_a_sibling_buffer() {
         &[
             ("game.mle", "let apply = (n) => Utils.tripled(n)\n"),
             // On disk `utils.mle` has no `tripled` — loading from disk fails.
-            ("utils.mle", "let double = (x: Float): Float => x * 2.0\n"),
+            ("utils.mle", "let double = (x: float): float => x * 2.0\n"),
         ],
     );
     // Disk-only load: `Utils.tripled` is unresolved (load or check fails).
@@ -831,7 +831,7 @@ fn overrides_replace_a_sibling_buffer() {
     let mut overrides = std::collections::HashMap::new();
     overrides.insert(
         scratch.dir.join("utils.mle"),
-        "let tripled = (x: Float): Float => x * 3.0\n".to_string(),
+        "let tripled = (x: float): float => x * 3.0\n".to_string(),
     );
     let project = mle::project::load_with_overrides(&scratch.entry, &overrides)
         .unwrap_or_else(|e| panic!("override load: {}", e.render()));
@@ -879,13 +879,13 @@ fn interface_file_types_externals() {
             (
                 "game.mle",
                 "let build = (): Widget.Handle => Widget.make()\n\
-                 let area = (h: Widget.Handle): Float => Widget.size(h)",
+                 let area = (h: Widget.Handle): float => Widget.size(h)",
             ),
             (
                 "widget.mlei",
                 "type Handle\n\
                  let make : () => Handle\n\
-                 let size : (Handle) => Float",
+                 let size : (Handle) => float",
             ),
         ],
     );
@@ -900,10 +900,10 @@ fn interface_signature_mismatch_is_flagged() {
     let project = load(
         "mlei-mismatch",
         &[
-            ("game.mle", "let bad = (): Float => Widget.size(3.0)"),
+            ("game.mle", "let bad = (): float => Widget.size(3.0)"),
             (
                 "widget.mlei",
-                "type Handle\nlet size : (Handle) => Float",
+                "type Handle\nlet size : (Handle) => float",
             ),
         ],
     );
@@ -922,12 +922,12 @@ fn open_brings_interface_signatures() {
     let project = load(
         "mlei-open",
         &[
-            ("game.mle", "open Widget\nlet f = (): Float => size(make())"),
+            ("game.mle", "open Widget\nlet f = (): float => size(make())"),
             (
                 "widget.mlei",
                 "type Handle\n\
                  let make : () => Handle\n\
-                 let size : (Handle) => Float",
+                 let size : (Handle) => float",
             ),
         ],
     );
@@ -943,7 +943,7 @@ fn body_in_interface_file_is_rejected() {
         "mlei-body",
         &[
             ("game.mle", "let main = () => 1.0"),
-            ("widget.mlei", "let make : Float = 3.0"),
+            ("widget.mlei", "let make : float = 3.0"),
         ],
     );
     assert!(
@@ -962,7 +962,7 @@ fn interface_signature_may_reference_a_consumer_type() {
         &[
             (
                 "game.mle",
-                "type Model = { n: Float }\n\
+                "type Model = { n: float }\n\
                  let sc = (m: Model): Widget.Handle => Widget.render(m)",
             ),
             (
@@ -1012,7 +1012,7 @@ fn injected_prelude_types_host_externals() {
         "Scene".to_string(),
         "type Node\n\
          let cube : () => Node\n\
-         let color : (Float, Float, Float, Node) => Node"
+         let color : (float, float, float, Node) => Node"
             .to_string(),
     )];
     let project =

--- a/mle/tests/rebind.rs
+++ b/mle/tests/rebind.rs
@@ -70,7 +70,7 @@ fn stored_closure_adopts_edited_body_and_keeps_env() {
 fn closures_rebind_inside_containers() {
     let src = |body: &str| {
         format!(
-            "{APPLY}type Slot = | Held(f: Float)\n\
+            "{APPLY}type Slot = | Held(f: float)\n\
              let mul = (k) => (x) => {body}\n\
              let main = () => {{ fns: [mul(2.0)], slot: Held(mul(10.0)) }}"
         )

--- a/mle/tests/run.rs
+++ b/mle/tests/run.rs
@@ -571,7 +571,7 @@ fn text_fixed_formats_fixed_decimals() {
 
 // --- Variants + match (B5 part 1) ---
 
-const SHAPE: &str = "type Shape = | Circle(r: Float) | Rect(w: Float, h: Float) | Point\n";
+const SHAPE: &str = "type Shape = | Circle(r: float) | Rect(w: float, h: float) | Point\n";
 
 /// First matching arm wins, top to bottom — a catch-all above a more
 /// specific arm shadows it.
@@ -702,7 +702,7 @@ fn error_calling_a_nullary_ctor() {
     assert_eq!(message, "cannot call a variant");
 }
 
-/// Bool-literal matches are the language's first conditional.
+/// bool-literal matches are the language's first conditional.
 #[test]
 fn bool_match_is_a_conditional() {
     assert_eq!(
@@ -768,7 +768,7 @@ fn destructuring_let_arity_mismatch_fails_loud() {
 fn generic_adts_run_type_erased() {
     assert_eq!(
         main_result(
-            "type Box<v> = | Full(value: v) | Empty\n\
+            "type Box<'v> = | Full(value: 'v) | Empty\n\
              let orElse = (b, d) => match b with | Full(v) => v | Empty => d\n\
              let main = () => (orElse(Full(1.0), 0.0), orElse(Full(\"s\"), \"\"), orElse(Empty, 9.0))"
         ),

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "clean": "git clean -fdX",
     "build:cli": "wasm-pack build runtime/functor-runtime-web --target=web && cargo build --bin functor",
+    "build:lsp": "cargo install --path tools/mle-lsp --force && (pkill -x mle-lsp || true)",
     "build:oculus": "ANDROID_HOME=${ANDROID_HOME:-/opt/homebrew/share/android-sdk} CARGO_TARGET_DIR=target-android cargo ndk -t arm64-v8a build --manifest-path runtime/functor-runtime-oculus/Cargo.toml",
     "build:oculus:apk": "ANDROID_HOME=${ANDROID_HOME:-/opt/homebrew/share/android-sdk} ANDROID_NDK_ROOT=${ANDROID_NDK_ROOT:-/opt/homebrew/share/android-sdk/ndk/24.0.8215888} CARGO_TARGET_DIR=$PWD/target-android cargo apk build --manifest-path runtime/functor-runtime-oculus/Cargo.toml",
     "bench": "cargo run -q --release -p mle -- bench --all",

--- a/runtime/functor-runtime-common/tests/prelude_typecheck.rs
+++ b/runtime/functor-runtime-common/tests/prelude_typecheck.rs
@@ -50,11 +50,11 @@ fn real_tuple_mismatch_still_errors() {
 /// Host calls carry real types from the prelude `.mlei`, across namespaces.
 #[test]
 fn host_calls_have_real_types() {
-    let diags = check("let bad : Float = Camera.lookAt(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)");
-    assert!(diags.iter().any(|m| m.contains("Camera.T")), "{diags:?}");
+    let diags = check("let bad : float = Camera.lookAt(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)");
+    assert!(diags.iter().any(|m| m.contains("Camera.t")), "{diags:?}");
     let diags = check(
-        "let bad : Float =\n\
+        "let bad : float =\n\
          Frame.create(Camera.lookAt(0.0, 0.0, 0.0, 0.0, 0.0, 0.0), Scene.cube())",
     );
-    assert!(diags.iter().any(|m| m.contains("Frame.T")), "{diags:?}");
+    assert!(diags.iter().any(|m| m.contains("Frame.t")), "{diags:?}");
 }

--- a/site/examples/hero.mle
+++ b/site/examples/hero.mle
@@ -9,7 +9,7 @@ let gridRows = 10.0
 let spacing = 2.0
 
 // The rolling wave: a diagonal sine marching toward the camera.
-let waveY = (t: Float, ix: Float, iz: Float): Float =>
+let waveY = (t: float, ix: float, iz: float): float =>
   Math.sin(iz * 0.8 - t * 2.2 + ix * 0.3) * 0.55
 
 // One glowing grid dot. Near rows burn hot magenta; far rows cool toward
@@ -56,9 +56,9 @@ let ground = () =>
 
 let init = { t: 0.0 }
 
-let tick = (model, dt: Float, tts: Float) => { model with t: model.t + dt }
+let tick = (model, dt: float, tts: float) => { model with t: model.t + dt }
 
-let draw = (model, tts: Float) =>
+let draw = (model, tts: float) =>
   Frame.create(
     Camera.lookAt(0.0, 3.4, -13.0, 0.0, 1.8, 12.0),
     Scene.group([sky(), ground(), sun(model.t), grid(model.t)]))

--- a/tools/mle-lsp/Cargo.toml
+++ b/tools/mle-lsp/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 # only dependency besides the language crate itself.
 [dependencies]
 mle = { path = "../../mle" }
+functor-prelude = { path = "../../functor-prelude" }
 serde_json = "1.0"
 
 [[bin]]

--- a/tools/mle-lsp/src/main.rs
+++ b/tools/mle-lsp/src/main.rs
@@ -213,7 +213,12 @@ fn publish_diagnostics(writer: &mut impl Write, uri: &str, text: &str) {
 /// leak in). `None` on a non-`file:` URI or a load failure.
 fn load_project(uri: &str, documents: &HashMap<String, String>) -> Option<mle::project::Project> {
     let path = uri_to_path(uri)?;
-    let single_file = || mle::project::load_single_file(&path, documents.get(uri)?).ok();
+    // The engine prelude (`Scene.*`, `Camera.*`, …) as a check-time overlay, so
+    // the editor shows real host types (`Scene.cube() : Scene.t`) instead of
+    // `Unknown`. This is what makes the LSP host-aware; the runtime injects the
+    // same set (mlei 2e).
+    let prelude = functor_prelude::modules();
+    let single_file = || mle::project::load_single_file(&path, documents.get(uri)?, &prelude).ok();
     match discover_entry(&path) {
         Some(entry) => {
             let overrides: HashMap<PathBuf, String> = documents
@@ -224,7 +229,7 @@ fn load_project(uri: &str, documents: &HashMap<String, String>) -> Option<mle::p
             // file. A nearest `functor.json` whose entry lives in another dir,
             // or a broken sibling that fails the load, must not strip the open
             // buffer of all features — fall back to a single-file view.
-            match mle::project::load_with_overrides(&entry, &overrides) {
+            match mle::project::load_with_prelude(&entry, &overrides, &prelude) {
                 Ok(project) if project.sources.file_by_path(&path).is_some() => Some(project),
                 _ => single_file(),
             }

--- a/tools/mle-lsp/tests/e2e.rs
+++ b/tools/mle-lsp/tests/e2e.rs
@@ -145,7 +145,7 @@ fn diagnostics_over_real_stdio() {
     let response = server.recv();
     assert_eq!(response["id"], 3);
     assert_eq!(
-        response["result"]["contents"]["value"], "```mle\nx : Float\n```",
+        response["result"]["contents"]["value"], "```mle\nx : float\n```",
         "hover response: {response}"
     );
 
@@ -155,7 +155,7 @@ fn diagnostics_over_real_stdio() {
         "params": {
             "textDocument": { "uri": URI, "version": 3 },
             "contentChanges": [ { "text":
-                "let double = (x: Float): Float => x * 2.0\nlet main = () => double(2.0)" } ],
+                "let double = (x: float): float => x * 2.0\nlet main = () => double(2.0)" } ],
         },
     }));
     assert_eq!(server.recv()["params"]["diagnostics"], json!([]));
@@ -205,7 +205,7 @@ fn diagnostics_over_real_stdio() {
     }));
     assert_eq!(server.recv()["params"]["diagnostics"], json!([]));
 
-    // Inlay hints over line 0 → one `: Float` type hint right after the `x`
+    // Inlay hints over line 0 → one `: float` type hint right after the `x`
     // param (byte 10 = line 0 char 10).
     server.send(json!({
         "jsonrpc": "2.0", "id": 6, "method": "textDocument/inlayHint",
@@ -223,7 +223,7 @@ fn diagnostics_over_real_stdio() {
         response["result"],
         json!([{
             "position": { "line": 0, "character": 10 },
-            "label": ": Float",
+            "label": ": float",
             "kind": 1,
             "paddingLeft": false,
             "paddingRight": false,
@@ -246,7 +246,7 @@ fn diagnostics_over_real_stdio() {
                 "start": { "line": 0, "character": 0 },
                 "end": { "line": 0, "character": 22 },
             },
-            "command": { "title": "f : (Float) => Float", "command": "" },
+            "command": { "title": "f : (float) => float", "command": "" },
         }]),
         "codeLens response: {response}"
     );
@@ -278,7 +278,7 @@ fn project_aware_hover_and_cross_file_definition() {
     std::fs::write(dir.join("game.mle"), game).unwrap();
     std::fs::write(
         dir.join("utils.mle"),
-        "let double = (x: Float): Float => x * 2.0\n",
+        "let double = (x: float): float => x * 2.0\n",
     )
     .unwrap();
     let game_uri = format!("file://{}/game.mle", dir.display());
@@ -311,7 +311,7 @@ fn project_aware_hover_and_cross_file_definition() {
     let response = server.recv();
     assert_eq!(
         response["result"]["contents"]["value"],
-        "```mle\nUtils.double : (Float) => Float\n```",
+        "```mle\nUtils.double : (float) => float\n```",
         "cross-file hover: {response}"
     );
 

--- a/tools/mle-lsp/tests/e2e.rs
+++ b/tools/mle-lsp/tests/e2e.rs
@@ -359,3 +359,45 @@ fn vscode_extension_assets_are_well_formed() {
     let program = mle::parse(&sample).expect("sample.mle parses");
     mle::lower(program).expect("sample.mle lowers");
 }
+
+/// The engine prelude is injected as a check-time overlay (mlei 2e-iii), so a
+/// host call hovers with its real type — `Scene.cube : () => Scene.t` — not
+/// `Unknown`. Single-file (no functor.json) still gets the prelude.
+#[test]
+fn prelude_gives_host_calls_real_types() {
+    let mut server = Server::spawn();
+    server.send(json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": { "capabilities": {} },
+    }));
+    server.recv();
+    server.send(json!({ "jsonrpc": "2.0", "method": "initialized", "params": {} }));
+    let text = "let s = () => Scene.cube()\n";
+    server.send(json!({
+        "jsonrpc": "2.0", "method": "textDocument/didOpen",
+        "params": { "textDocument": {
+            "uri": URI, "languageId": "mle", "version": 1, "text": text,
+        } },
+    }));
+    server.recv(); // publishDiagnostics (clean — Scene.cube is known)
+
+    // Hover on `Scene.cube` (char 13 = the `c` of cube).
+    let col = text.find("Scene.cube").unwrap() as i64 + 6;
+    server.send(json!({
+        "jsonrpc": "2.0", "id": 2, "method": "textDocument/hover",
+        "params": {
+            "textDocument": { "uri": URI },
+            "position": { "line": 0, "character": col },
+        },
+    }));
+    let response = server.recv();
+    assert_eq!(
+        response["result"]["contents"]["value"],
+        "```mle\nScene.cube : () => Scene.t\n```",
+        "prelude hover: {response}"
+    );
+
+    server.send(json!({ "jsonrpc": "2.0", "id": 3, "method": "shutdown" }));
+    server.recv();
+    server.send(json!({ "jsonrpc": "2.0", "method": "exit" }));
+    server.child.wait().expect("wait for exit");
+}

--- a/tools/mle-vscode/syntaxes/mle.tmLanguage.json
+++ b/tools/mle-vscode/syntaxes/mle.tmLanguage.json
@@ -8,6 +8,8 @@
     { "include": "#keyword" },
     { "include": "#boolean" },
     { "include": "#number" },
+    { "include": "#type-variable" },
+    { "include": "#primitive-type" },
     { "include": "#qualified-name" },
     { "include": "#type-name" },
     { "include": "#operator" },
@@ -60,8 +62,18 @@
         "3": { "name": "support.function.mle" }
       }
     },
+    "type-variable": {
+      "comment": "Apostrophe-prefixed type variable in type position (`'a`, `'msg`)",
+      "name": "entity.name.type.parameter.mle",
+      "match": "'[a-zA-Z][A-Za-z0-9_]*\\b"
+    },
+    "primitive-type": {
+      "comment": "The lowercase primitive types (F#/OCaml convention)",
+      "name": "support.type.primitive.mle",
+      "match": "\\b(float|bool|string)\\b"
+    },
     "type-name": {
-      "comment": "Any other uppercase identifier is a type: `type` decl names, annotations after `:`, and generic arguments (`List<Float>`)",
+      "comment": "Any other uppercase identifier is a type: `type` decl names, annotations after `:`, and generic arguments (`List<float>`)",
       "name": "entity.name.type.mle",
       "match": "\\b[A-Z][A-Za-z0-9_]*\\b"
     },

--- a/tools/mle-vscode/test/sample.mle
+++ b/tools/mle-vscode/test/sample.mle
@@ -3,8 +3,8 @@
 // test in tools/mle-lsp/tests/e2e.rs.
 
 // Type declarations: record types, generic annotations.
-type Position = { x: Float, y: Float }
-type Player = { name: String, scores: List<Float> }
+type Position = { x: float, y: float }
+type Player = { name: string, scores: List<float> }
 
 // Literals: numbers, booleans, strings with escapes.
 let debug = false
@@ -14,7 +14,7 @@ let pi = 3.14
 let banner = "scores:\n\t\"final\" \\ report"
 
 // Lambdas with and without annotations; arithmetic and unary minus.
-let add = (a: Float, b: Float): Float => a + b
+let add = (a: float, b: float): float => a + b
 let average = (a, b) => (a + b) / 2.0
 let negate = (n) => -n
 let scaled = (n) => n * 100.0 - threshold
@@ -22,12 +22,12 @@ let scaled = (n) => n * 100.0 - threshold
 // Records, field access, comparisons.
 let origin = { x: 0.0, y: 0.0 }
 let mirror = (p: Position): Position => { x: -p.x, y: p.y }
-let isOrigin = (p: Position): Bool => p.x == 0.0
-let isHigh = (score: Float): Bool => score > threshold
-let isLow = (score: Float): Bool => score < threshold
+let isOrigin = (p: Position): bool => p.x == 0.0
+let isHigh = (score: float): bool => score > threshold
+let isLow = (score: float): bool => score < threshold
 
 // Pipelines and qualified names (trailing commas allowed in lists/records).
-let total = (p: Player): Float => p.scores |> List.fold(add, 0.0)
+let total = (p: Player): float => p.scores |> List.fold(add, 0.0)
 let normalized = (score) => score / 100.0 |> Math.clamp01
 let report = (scores) =>
   scores


### PR DESCRIPTION
Switches MLE's type syntax to the **F#/OCaml/ReasonML lowercase convention** — `float`/`bool`/`string`, apostrophe type variables `'a`, and `Module.t` for opaque host types. MLE is F#-inspired, and F# uses exactly this; the old `Float`/`Bool`/`String` + bare-lowercase type vars were the outlier.

```mle
let update = (m: 'a, msg: Msg): 'a => …          // 'a type variable
let clamp = (v: float, lo: float): float => …    // lowercase primitives
let scene = (): Scene.t => Scene.cube()          // Module.t opaque types
```

## Core language change (mle crate) — reviewed line-by-line
- **Lexer**: new `TokenKind::TypeVar` — `'` + ident (`'a`, `'msg`); a bare `'` or `'`-at-EOF is a clean lex error. Stores the apostrophe so token text = source.
- **Parser**: `type_atom` intercepts a `TypeVar` → a type-variable `TypeName`; generic decl params are now `type Box<'a>`. The old "bare lowercase in type position = type variable" special-casing is **fully removed** — the apostrophe is the only type-var signal.
- **Checker**: `resolve_type` recognizes `float`/`bool`/`string` as primitives and keys the type-var path on the `'`-prefix (was `is_lowercase`); `Display` renders `float`/`bool`/`string` (type vars already showed `'a`). A bare unknown name (upper or lower) stays gradual `Unknown` — consistent.

## Rename (mechanical, ~80 files)
Every `.mle` example + prelude `.mlei` (primitives + `Module.T`→`Module.t`, `Scene.Node`→`Scene.t`, Physics `shape`/`body`/`world` + record types, `Ui.view`/`anchor`, taggers `msg`→`'msg`); Rust test source strings (inside string literals only — Rust's own `String`/`Bool` preserved) + diagnostic-message assertions; `.ast`/`.ir`/`.check` goldens regenerated; the `mle-language` skill + `docs/` + the VSCode grammar (new `'a` / primitive highlight rules).

## Verification
- `cargo test -p mle -p functor-prelude -p functor_runtime_common -p mle-lsp` green (incl. drift + prelude-typecheck regression). No new warnings.
- Behavioral sanity I re-ran: `let x: float = 3.0` checks; `let x: bool = 3.0` → `expected bool, got float`; `let id = (x: 'a): 'a => x` checks; `type Box<'a>` + `(f: (float) => bool)` parse; old `Float`/typos degrade gracefully to gradual `Unknown`.
- All example games check clean under the prelude.

Delegated agent implementation; **I reviewed the lexer/parser/checker/Display core myself** (the delicate part) + behavioral probes. `/xreview` (Claude engine; Codex rate-limited) — clean, no findings.

## One open UX question (not blocking)
A bare *lowercase* unknown type (a typo like `flaot`) now silently degrades to `Unknown`, same as an unknown *uppercase* host type. Since lowercase is no longer type-vars, an unknown lowercase name is almost always a typo — so a future tightening could **error** on it (while keeping uppercase gradual for host types). Left gradual/uniform for now; easy follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)