### PR TITLE
build(cli): optional web feature + npm run verify — fast native/check loop

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -8,6 +8,14 @@ edition = "2021"
 name = "functor"
 path = "src/main.rs"
 
+[features]
+# `web` embeds the WebGL2 runtime bundle (`include_bytes!`) for `run wasm`, so it
+# requires `npm run build:cli` first. ON by default; disable it
+# (`--no-default-features`) for a FAST native + typecheck build that needs no
+# wasm bundle — `run wasm` then errors with a rebuild hint.
+default = ["web"]
+web = []
+
 [dependencies]
 # The MLE language, for `language: "mle"` projects (docs/mle.md Track C4).
 mle = { path = "../mle" }

--- a/cli/src/commands/mle_project.rs
+++ b/cli/src/commands/mle_project.rs
@@ -21,6 +21,9 @@ use std::path::{Path, PathBuf};
 use clap::Parser;
 
 use crate::output::{emit, Event, Severity};
+// `util` (the shell-command runner + wasm dev server) is only used by the
+// `web`-gated `run wasm` path.
+#[cfg(feature = "web")]
 use crate::util::{self, ShellCommand, WasmDevServer};
 use crate::Environment;
 
@@ -274,59 +277,70 @@ with --debug-port (and --debug-bind 0.0.0.0 if remote)?"
         runner_args: &[String],
         develop: bool,
     ) -> Result<(), Error> {
-        self.entry_path(working_directory)?; // fail before serving, not per fetch
-
-        // The dev server can only serve files INSIDE the project dir — an
-        // entry that escapes it (absolute, or `..`) is readable natively but
-        // unfetchable by the page. Fail loud here, not as a browser 404.
-        if entry_escapes_project(&self.entry) {
-            return Err(Error::other(format!(
-                "mle on wasm serves the project directory over HTTP, so `entry` must be a \
-relative path inside it (got {})",
-                self.entry
-            )));
+        #[cfg(not(feature = "web"))]
+        {
+            let _ = (working_directory, runner_args, develop);
+            return Err(Error::other(
+                "the web runtime is not bundled in this build — rebuild with the `web` feature \
+                 (`npm run build:cli`) to `run wasm`",
+            ));
         }
-        if develop {
-            emit(Event::Info {
+        #[cfg(feature = "web")]
+        {
+            self.entry_path(working_directory)?; // fail before serving, not per fetch
+
+            // The dev server can only serve files INSIDE the project dir — an
+            // entry that escapes it (absolute, or `..`) is readable natively but
+            // unfetchable by the page. Fail loud here, not as a browser 404.
+            if entry_escapes_project(&self.entry) {
+                return Err(Error::other(format!(
+                    "mle on wasm serves the project directory over HTTP, so `entry` must be a \
+relative path inside it (got {})",
+                    self.entry
+                )));
+            }
+            if develop {
+                emit(Event::Info {
                 message: "develop (wasm): hot reload is native-only — reload the page to pick up edits".to_string(),
             });
-        }
-        let no_open = runner_args.iter().any(|a| a == "--no-open");
-        let ignored: Vec<&str> = runner_args
-            .iter()
-            .filter(|a| a.as_str() != "--no-open")
-            .map(|s| s.as_str())
-            .collect();
-        if !ignored.is_empty() {
-            emit(Event::Warning {
-                message: format!(
-                    "ignoring runner args (not supported for wasm): {}",
-                    ignored.join(" ")
-                ),
-            });
-        }
+            }
+            let no_open = runner_args.iter().any(|a| a == "--no-open");
+            let ignored: Vec<&str> = runner_args
+                .iter()
+                .filter(|a| a.as_str() != "--no-open")
+                .map(|s| s.as_str())
+                .collect();
+            if !ignored.is_empty() {
+                emit(Event::Warning {
+                    message: format!(
+                        "ignoring runner args (not supported for wasm): {}",
+                        ignored.join(" ")
+                    ),
+                });
+            }
 
-        let wasm_server_start = WasmDevServer::start_mle(working_directory, &self.entry);
-        if no_open {
-            emit(Event::Info {
-                message: "--no-open: skipping browser launch".to_string(),
-            });
-        } else {
-            let cmd = if std::env::consts::OS == "windows" {
-                "start"
+            let wasm_server_start = WasmDevServer::start_mle(working_directory, &self.entry);
+            if no_open {
+                emit(Event::Info {
+                    message: "--no-open: skipping browser launch".to_string(),
+                });
             } else {
-                "open"
-            };
-            let commands = vec![ShellCommand {
-                prefix: "[Open Browser]",
-                cmd,
-                cwd: working_directory,
-                env: vec![],
-                args: vec!["http://127.0.0.1:8080"],
-            }];
-            util::ShellCommand::run_sequential(commands).await?;
+                let cmd = if std::env::consts::OS == "windows" {
+                    "start"
+                } else {
+                    "open"
+                };
+                let commands = vec![ShellCommand {
+                    prefix: "[Open Browser]",
+                    cmd,
+                    cwd: working_directory,
+                    env: vec![],
+                    args: vec!["http://127.0.0.1:8080"],
+                }];
+                util::ShellCommand::run_sequential(commands).await?;
+            }
+            wasm_server_start.await
         }
-        wasm_server_start.await
     }
 }
 
@@ -379,6 +393,7 @@ fn nth_line(src: &str, line: usize) -> Option<String> {
 
 /// True when `entry` can't be served by the wasm dev server, which roots at
 /// the project directory: absolute paths and any `..` component escape it.
+#[cfg(feature = "web")]
 fn entry_escapes_project(entry: &str) -> bool {
     Path::new(entry).is_absolute() || entry.split(['/', '\\']).any(|seg| seg == "..")
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -159,7 +159,13 @@ async fn main() -> tokio::io::Result<()> {
     let started = Instant::now();
     let args = Args::parse();
 
-    output::init(args.json, args.quiet, args.no_color, args.ascii, args.verbose);
+    output::init(
+        args.json,
+        args.quiet,
+        args.no_color,
+        args.ascii,
+        args.verbose,
+    );
 
     // When the live (ink-style) renderer is up, a Ctrl-C would otherwise kill
     // the process mid-draw and leave the sticky live region stranded on screen.
@@ -186,13 +192,8 @@ async fn main() -> tokio::io::Result<()> {
                 animation,
                 format,
             } => {
-                commands::inspect::execute_model(
-                    path,
-                    *time,
-                    animation.as_deref(),
-                    format.clone(),
-                )
-                .await
+                commands::inspect::execute_model(path, *time, animation.as_deref(), format.clone())
+                    .await
             }
         };
         return finish_inspect(res);

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -90,6 +90,7 @@ pub enum Event {
         source_line: Option<String>,
     },
     /// The wasm dev server bound and is serving.
+    #[cfg(feature = "web")]
     ServerListening { url: String },
     /// Neutral status (a hot-reload hint, a push acknowledgement, …).
     Info { message: String },
@@ -291,6 +292,7 @@ impl PlainRenderer {
                 }
                 out
             }
+            #[cfg(feature = "web")]
             Event::ServerListening { url } => {
                 vec![format!("{} serving {}", g_serve().cyan(), url.underline())]
             }
@@ -428,6 +430,7 @@ pub(crate) fn g_fail() -> &'static str {
         "✗"
     }
 }
+#[cfg(feature = "web")]
 pub(crate) fn g_serve() -> &'static str {
     if ascii() {
         "::"

--- a/cli/src/output/live.rs
+++ b/cli/src/output/live.rs
@@ -87,8 +87,14 @@ impl Panel {
 /// Green under budget, yellow tight, red over.
 fn budget_bar(pct: f64) -> String {
     const CELLS: usize = 20;
-    let filled = ((pct / 100.0) * CELLS as f64).round().clamp(0.0, CELLS as f64) as usize;
-    let (full, empty) = if super::ascii() { ("#", "-") } else { ("█", "░") };
+    let filled = ((pct / 100.0) * CELLS as f64)
+        .round()
+        .clamp(0.0, CELLS as f64) as usize;
+    let (full, empty) = if super::ascii() {
+        ("#", "-")
+    } else {
+        ("█", "░")
+    };
     let bar = format!("{}{}", full.repeat(filled), empty.repeat(CELLS - filled));
     let bar = if pct >= 100.0 {
         bar.red()

--- a/cli/src/util/mod.rs
+++ b/cli/src/util/mod.rs
@@ -1,5 +1,9 @@
 mod shell_command;
+// The wasm dev server `include_bytes!`s the web bundle, so it (and its bundle
+// dependency) only exist under the `web` feature.
+#[cfg(feature = "web")]
 mod wasm_dev_server;
 
 pub use shell_command::*;
+#[cfg(feature = "web")]
 pub use wasm_dev_server::*;

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build:oculus": "ANDROID_HOME=${ANDROID_HOME:-/opt/homebrew/share/android-sdk} CARGO_TARGET_DIR=target-android cargo ndk -t arm64-v8a build --manifest-path runtime/functor-runtime-oculus/Cargo.toml",
     "build:oculus:apk": "ANDROID_HOME=${ANDROID_HOME:-/opt/homebrew/share/android-sdk} ANDROID_NDK_ROOT=${ANDROID_NDK_ROOT:-/opt/homebrew/share/android-sdk/ndk/24.0.8215888} CARGO_TARGET_DIR=$PWD/target-android cargo apk build --manifest-path runtime/functor-runtime-oculus/Cargo.toml",
     "bench": "cargo run -q --release -p mle -- bench --all",
+    "verify": "node scripts/verify.mjs",
     "fetch:assets": "node scripts/fetch-assets.mjs",
     "generate:audio": "node scripts/generate-audio.mjs",
     "test:golden": "npm run fetch:assets && npm run build:cli && cargo test -p functor-runtime-desktop --test golden -- --ignored --nocapture",

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -1,0 +1,71 @@
+// verify — a fast, GPU-optional smoke check of a runtime-facing change.
+//
+//   npm run verify
+//
+// Builds the CLI WITHOUT the wasm bundle (`--no-default-features`, seconds, no
+// `npm run build:cli` needed), then:
+//   1. typechecks every `examples/*/game.mle` under the host prelude (catches
+//      load / type breaks — no GPU, no assets),
+//   2. captures a frame from a couple of procedural (asset-free) scenes
+//      (catches render breaks — needs a GL display; skip with `--no-render`).
+//
+// Exits non-zero on any failure, listing what broke.
+
+import { execSync, spawnSync } from "node:child_process";
+import { readdirSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+const render = !process.argv.includes("--no-render");
+const bin = "target/debug/functor";
+const failed = [];
+
+console.log("▸ building native-only CLI (no wasm bundle)…");
+execSync("cargo build -q -p functor-cli --no-default-features", { stdio: "inherit" });
+
+const examples = readdirSync("examples", { withFileTypes: true })
+  .filter((d) => d.isDirectory() && existsSync(`examples/${d.name}/game.mle`))
+  .map((d) => d.name)
+  .sort();
+
+console.log(`\n▸ typechecking ${examples.length} examples…`);
+for (const ex of examples) {
+  const r = spawnSync(bin, ["-d", `examples/${ex}`, "build", "native"], {
+    encoding: "utf8",
+  });
+  const ok = r.status === 0;
+  console.log(`  ${ok ? "✓" : "✗"} ${ex}`);
+  if (!ok) {
+    failed.push(ex);
+    process.stdout.write((r.stdout || "") + (r.stderr || ""));
+  }
+}
+
+if (render) {
+  console.log("\n▸ rendering procedural scenes (needs a GL display)…");
+  for (const ex of ["hello-cubes", "primitives"].filter((e) =>
+    examples.includes(e),
+  )) {
+    // `run` chdir's into the game dir, so the capture path must be absolute.
+    const out = resolve(`target/verify-${ex}.png`);
+    const r = spawnSync(
+      bin,
+      [
+        "-d", `examples/${ex}`, "run", "native",
+        "--capture-frame", out, "--capture-time", "1", "--fixed-time", "1",
+      ],
+      { encoding: "utf8" },
+    );
+    const ok = r.status === 0 && existsSync(out);
+    console.log(`  ${ok ? "✓" : "✗"} render ${ex} → ${out}`);
+    if (!ok) {
+      failed.push(`render:${ex}`);
+      process.stdout.write((r.stdout || "") + (r.stderr || ""));
+    }
+  }
+}
+
+if (failed.length) {
+  console.error(`\n✗ verify failed: ${failed.join(", ")}`);
+  process.exit(1);
+}
+console.log("\n✓ verify passed");


### PR DESCRIPTION
The CLI `include_bytes!`s the WebGL2 bundle at compile time, so the `functor` binary couldn't build *at all* without `npm run build:cli` (wasm-pack) first — even for `run native` / `build` / `check`, which never touch wasm. This is the queued dev-loop improvement.

## `web` cargo feature (default ON)
Gates the bundle embed (`cli/src/util/wasm_dev_server.rs`) + the `run wasm` serve path.

```sh
cargo build -p functor-cli --no-default-features   # native + typecheck CLI, seconds, NO wasm bundle
```

`run wasm` on such a build errors with a clear hint: *"the web runtime is not bundled — rebuild with the `web` feature (`npm run build:cli`)"*. The default build and CI are unchanged.

## `npm run verify`
A fast, GPU-optional smoke check: native-only build → typecheck every `examples/*/game.mle` under the host prelude → capture a frame from two procedural scenes (`--no-render` skips the GL step). Exits non-zero listing what broke. Rounds out the self-serve loop alongside `npm run build:lsp`.

## The tiered verify story this enables
| Change touches | Cheapest tool | Speed |
|---|---|---|
| Game logic (`.mle`) | prebuilt native CLI + `--capture-frame` | instant |
| Language (`mle` crate) | `mle check` + `cargo test -p mle` | fast |
| Runtime crates | `--no-default-features` build + capture | **fast now** (was blocked on the bundle) |
| Web/wasm path | full `npm run build:cli` | slow, rare |

## Verification
Native-only `build native` runs in ~7ms with no bundle; `run wasm` gives the hint; the default build + `run wasm` still serve; `npm run verify` passes (14 examples typecheck, 2 render). No new warnings in *either* feature config; `cargo test -p functor-cli` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)