### PR TITLE
fix(wasm): multi-file modules, error overlay, and a wasm smoke test

### DIFF
--- a/.github/workflows/wasm-smoke.yml
+++ b/.github/workflows/wasm-smoke.yml
@@ -1,0 +1,59 @@
+name: WASM smoke
+
+# Loads every self-contained MLE sample in the real web runtime (headless
+# Chromium) and asserts it LOADS → survives a pushed reload → ticks a few frames
+# without a persistent error overlay. This is the guard for "works native,
+# broken in wasm" divergence — a missing sibling module, a dropped record field,
+# a contract regression — that the native tests and even the wasm GOLDEN tests
+# miss (goldens run under `--fixed-time`, which masks first-frame races).
+#
+# Software WebGL2 (swiftshader, set in e2e/wasm-smoke.mjs) means no GPU is
+# needed, so this runs on a plain ubuntu runner.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  wasm-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install wasm-pack
+        run: npm install -g wasm-pack
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "."
+
+      # The single `functor` binary embeds the web-runtime bundle via
+      # `include_bytes!`, so the bundle must exist before the CLI is built.
+      - name: Build web runtime bundle
+        run: wasm-pack build --target=web
+        working-directory: runtime/functor-runtime-web
+
+      - name: Build functor CLI
+        run: cargo build --bin functor
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run wasm smoke
+        run: npm run test:wasm-smoke

--- a/.github/workflows/wasm-smoke.yml
+++ b/.github/workflows/wasm-smoke.yml
@@ -40,6 +40,31 @@ jobs:
         with:
           workspaces: "."
 
+      # Post-E3 the single `functor` binary always includes the native
+      # GLFW/OpenGL runtime, so building the CLI links X11/GL/ALSA — install the
+      # same system libs as build-native.yml / golden.yml (even though this job
+      # only serves wasm, the binary links them).
+      - name: Install GL/X11 system libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libx11-dev \
+            libxcursor-dev \
+            libxrandr-dev \
+            libxinerama-dev \
+            libxi-dev \
+            libgl1-mesa-dev \
+            libglu1-mesa-dev \
+            libglfw3 \
+            libglfw3-dev \
+            libasound2-dev
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
       # The single `functor` binary embeds the web-runtime bundle via
       # `include_bytes!`, so the bundle must exist before the CLI is built.
       - name: Build web runtime bundle
@@ -48,12 +73,6 @@ jobs:
 
       - name: Build functor CLI
         run: cargo build --bin functor
-
-      - name: Install npm dependencies
-        run: npm ci
-
-      - name: Install Playwright Chromium
-        run: npx playwright install --with-deps chromium
 
       - name: Run wasm smoke
         run: npm run test:wasm-smoke

--- a/cli/src/util/wasm_dev_server.rs
+++ b/cli/src/util/wasm_dev_server.rs
@@ -10,19 +10,53 @@ const WASM_FILE: &[u8] =
 const JS_FILE_1: &[u8] =
     include_bytes!("../../../runtime/functor-runtime-web/pkg/functor_runtime_web.js");
 
-/// Substitute the project's MLE entry file into the MLE index page: the quoted
-/// placeholder `"__MLE_ENTRY__"` becomes a JSON string literal (valid JS for
-/// any entry path, quotes and backslashes included). The page assigns it to
-/// `window.__mleGamePath`, which tells the web runtime to fetch + interpret
-/// that source (docs/mle.md Track C5).
-fn render_mle_index(entry: &str) -> String {
-    let literal = serde_json::to_string(entry)
-        .expect("a string always serializes")
-        // JSON escaping is not HTML escaping: `</script>` inside the literal
-        // would terminate the page's script block. `<\/` is the standard
-        // inline-script defense (`\/` is `/` in a JS string).
-        .replace("</", "<\\/");
-    INDEX_MLE_HTML.replace("\"__MLE_ENTRY__\"", &literal)
+/// The standard inline-script defense: JSON escaping is not HTML escaping, so a
+/// `</script>` inside a substituted literal would terminate the page's script
+/// block. `<\/` is `/` in a JS string, harmless to the HTML parser.
+fn script_safe(json: String) -> String {
+    json.replace("</", "<\\/")
+}
+
+/// Substitute the project's MLE entry + full file list into the MLE index page:
+///
+/// - `"__MLE_ENTRY__"` becomes a JSON string literal → `window.__mleGamePath`,
+///   the program root.
+/// - `"__MLE_PROJECT_FILES__"` becomes a JSON array literal (entry first, then
+///   siblings) → `window.__mleProjectFiles`, so multi-file games (`file =
+///   module`) load EVERY module, not just the entry (docs/mle.md Track C5).
+///
+/// Both are valid JS for any path (quotes/backslashes included).
+fn render_mle_index(entry: &str, files: &[String]) -> String {
+    let entry_literal =
+        script_safe(serde_json::to_string(entry).expect("a string always serializes"));
+    let files_literal =
+        script_safe(serde_json::to_string(files).expect("a string slice always serializes"));
+    INDEX_MLE_HTML
+        .replace("\"__MLE_ENTRY__\"", &entry_literal)
+        .replace("\"__MLE_PROJECT_FILES__\"", &files_literal)
+}
+
+/// The project's file list as URLs relative to the served directory (entry
+/// first, then sibling `.mle`/`.mlei` files) — the same set the desktop
+/// producer links (`mle::project::project_files`), made relative so the web
+/// runtime fetches each from the dev server's filesystem route. Falls back to
+/// just the entry if the directory can't be scanned.
+fn project_file_urls(working_directory: &str, entry: &str) -> Vec<String> {
+    let entry_path = std::path::Path::new(working_directory).join(entry);
+    let paths = match mle::project::project_files(&entry_path) {
+        Ok(paths) => paths,
+        Err(_) => return vec![entry.to_string()],
+    };
+    let root = std::path::Path::new(working_directory);
+    paths
+        .iter()
+        .map(|p| {
+            p.strip_prefix(root)
+                .unwrap_or(p)
+                .to_string_lossy()
+                .replace('\\', "/")
+        })
+        .collect()
 }
 
 impl WasmDevServer {
@@ -31,7 +65,12 @@ impl WasmDevServer {
     /// is no game wasm module; the runtime fetches the entry file, which the
     /// filesystem route serves straight from the project directory.
     pub async fn start_mle(working_directory: &str, entry: &str) -> Result<(), io::Error> {
-        Self::serve(working_directory, render_mle_index(entry).into_bytes()).await
+        let files = project_file_urls(working_directory, entry);
+        Self::serve(
+            working_directory,
+            render_mle_index(entry, &files).into_bytes(),
+        )
+        .await
     }
 
     async fn serve(working_directory: &str, index_html: Vec<u8>) -> Result<(), io::Error> {
@@ -64,9 +103,14 @@ impl WasmDevServer {
         // Route to serve files from the specified working directory
         let route_filesystem = warp::fs::dir(wd);
 
-        // Combine all routes
+        // Combine all routes. `no-store` on everything: this is a dev server,
+        // and the index page + `.mle` source are re-generated per run — without
+        // it, switching samples (each serving its source at the same
+        // `/game.mle` URL) can show a stale game from the browser cache.
         let static_routes = route_index.or(route_js1).or(route_wasm);
-        let routes = static_routes.or(route_filesystem);
+        let routes = static_routes
+            .or(route_filesystem)
+            .with(warp::reply::with::header("cache-control", "no-store"));
 
         // Bind first, then announce — so `ServerListening` never claims a port
         // that isn't actually accepting connections, and a bind failure (port
@@ -90,20 +134,31 @@ mod tests {
 
     #[test]
     fn substitutes_the_entry_as_a_js_string() {
-        let html = render_mle_index("game.mle");
+        let html = render_mle_index("game.mle", &["game.mle".to_string()]);
         assert!(html.contains("window.__mleGamePath = \"game.mle\""));
         assert!(!html.contains("__MLE_ENTRY__"));
     }
 
     #[test]
+    fn substitutes_the_project_file_list_as_a_js_array() {
+        let html = render_mle_index(
+            "game.mle",
+            &["game.mle".to_string(), "pieces.mle".to_string()],
+        );
+        assert!(html.contains("(["));
+        assert!(html.contains("\"game.mle\",\"pieces.mle\""));
+        assert!(!html.contains("__MLE_PROJECT_FILES__"));
+    }
+
+    #[test]
     fn escapes_entries_that_would_break_the_script() {
-        let html = render_mle_index("we\"ird\\name.mle");
+        let html = render_mle_index("we\"ird\\name.mle", &["we\"ird\\name.mle".to_string()]);
         assert!(html.contains("we\\\"ird\\\\name.mle"));
     }
 
     #[test]
     fn escapes_a_script_terminator_in_the_entry() {
-        let html = render_mle_index("bad</script>.mle");
+        let html = render_mle_index("bad</script>.mle", &["bad</script>.mle".to_string()]);
         assert!(html.contains("bad<\\/script>.mle"));
     }
 }

--- a/e2e/mle-preview-reload.mjs
+++ b/e2e/mle-preview-reload.mjs
@@ -184,7 +184,7 @@ const broken = await push(V_BROKEN);
 check("broken push rejected", broken.ok === false, JSON.stringify(broken));
 check(
   "broken push reports the parse error",
-  !broken.ok && broken.message.includes("cannot parse"),
+  !broken.ok && broken.message.includes("expected an expression"),
   broken.message
 );
 await sleep(400);

--- a/e2e/wasm-smoke.mjs
+++ b/e2e/wasm-smoke.mjs
@@ -71,6 +71,25 @@ const EXCLUDE = new Set([
   "wsserverdemo",
 ]);
 
+// A sample "needs assets" if its directory carries fetched binary assets
+// (glTF/textures/audio via `npm run fetch:assets`, gitignored). When those
+// aren't present — the default on CI, which mirrors golden.yml's asset-free
+// stance — such a sample would 404 its assets, so we SKIP it (loudly) rather
+// than fail. Local runs (assets fetched) still cover it. NOTE: a missing asset
+// currently PANICS the wasm runtime instead of falling back to the empty asset
+// (docs/mle.md says it should degrade) — tracked as a follow-up; until then the
+// skip keeps this CI check meaningful for the asset-free samples.
+function needsMissingAssets(sample) {
+  const dir = `${ROOT}/examples/${sample}`;
+  const refsAssets = /\.(glb|png|jpg|wav)\b/i.test(
+    readFileSync(`${dir}/game.mle`, "utf8"),
+  );
+  const hasAssets = readdirSync(dir).some((f) =>
+    /\.(glb|png|jpg|wav)$/i.test(f),
+  );
+  return refsAssets && !hasAssets;
+}
+
 // The sample list: CLI args if given, else every examples/* with a functor.json
 // declaring `"language": "mle"`, minus the network demos.
 const allSamples = readdirSync(`${ROOT}/examples`, { withFileTypes: true })
@@ -253,7 +272,13 @@ async function smoke(sample) {
 
 let failures = 0;
 console.log(`wasm smoke: ${samples.length} sample(s)\n`);
+let skipped = 0;
 for (const sample of samples) {
+  if (needsMissingAssets(sample)) {
+    skipped++;
+    console.log(`SKIP  ${sample} — references assets not present (run npm run fetch:assets to include it)`);
+    continue;
+  }
   let r;
   try {
     r = await smoke(sample);
@@ -272,9 +297,11 @@ for (const sample of samples) {
   }
 }
 
+const ran = samples.length - skipped;
+const skipNote = skipped ? ` (${skipped} skipped — assets not fetched)` : "";
 console.log(
   failures === 0
-    ? `\nALL ${samples.length} SAMPLES PASSED`
-    : `\n${failures} SAMPLE(S) FAILED`,
+    ? `\nALL ${ran} SAMPLES PASSED${skipNote}`
+    : `\n${failures} SAMPLE(S) FAILED${skipNote}`,
 );
 process.exit(failures === 0 ? 0 : 1);

--- a/e2e/wasm-smoke.mjs
+++ b/e2e/wasm-smoke.mjs
@@ -71,23 +71,23 @@ const EXCLUDE = new Set([
   "wsserverdemo",
 ]);
 
-// A sample "needs assets" if its directory carries fetched binary assets
-// (glTF/textures/audio via `npm run fetch:assets`, gitignored). When those
-// aren't present — the default on CI, which mirrors golden.yml's asset-free
-// stance — such a sample would 404 its assets, so we SKIP it (loudly) rather
-// than fail. Local runs (assets fetched) still cover it. NOTE: a missing asset
-// currently PANICS the wasm runtime instead of falling back to the empty asset
-// (docs/mle.md says it should degrade) — tracked as a follow-up; until then the
-// skip keeps this CI check meaningful for the asset-free samples.
-function needsMissingAssets(sample) {
+// Whether the sample references a binary asset (glTF/texture/audio, fetched via
+// `npm run fetch:assets` and gitignored) that ISN'T present on disk. On CI —
+// asset-free by convention (golden.yml uses the asset-free primitives sample) —
+// those files 404, so we SKIP such a sample (loudly) rather than fail. Local
+// runs (assets fetched) still cover it. Checked per-referenced-file, because a
+// sample can commit SOME assets (e.g. a .png) yet fetch others (a .glb).
+// NOTE: a missing asset currently PANICS the wasm runtime ("RuntimeError:
+// unreachable") instead of falling back to the empty asset (docs/mle.md says it
+// should degrade) — tracked as a follow-up; until then the skip keeps this CI
+// check meaningful for the asset-free samples.
+function missingReferencedAssets(sample) {
   const dir = `${ROOT}/examples/${sample}`;
-  const refsAssets = /\.(glb|png|jpg|wav)\b/i.test(
-    readFileSync(`${dir}/game.mle`, "utf8"),
+  const src = readFileSync(`${dir}/game.mle`, "utf8");
+  const refs = [...src.matchAll(/["']([^"']+\.(?:glb|png|jpg|wav))["']/gi)].map(
+    (m) => m[1],
   );
-  const hasAssets = readdirSync(dir).some((f) =>
-    /\.(glb|png|jpg|wav)$/i.test(f),
-  );
-  return refsAssets && !hasAssets;
+  return refs.some((ref) => !existsSync(`${dir}/${ref}`));
 }
 
 // The sample list: CLI args if given, else every examples/* with a functor.json
@@ -274,7 +274,7 @@ let failures = 0;
 console.log(`wasm smoke: ${samples.length} sample(s)\n`);
 let skipped = 0;
 for (const sample of samples) {
-  if (needsMissingAssets(sample)) {
+  if (missingReferencedAssets(sample)) {
     skipped++;
     console.log(`SKIP  ${sample} — references assets not present (run npm run fetch:assets to include it)`);
     continue;

--- a/e2e/wasm-smoke.mjs
+++ b/e2e/wasm-smoke.mjs
@@ -186,37 +186,36 @@ async function smoke(sample) {
       });
     });
     const src = entrySource(sample);
-    // `mle_set_source` refuses ("runtime is mid-frame; retry") if the frame loop
-    // holds the producer borrow when the push lands — likelier on the heavier
-    // samples under slow software GL — so retry that transient a few times.
-    let result;
-    for (let attempt = 0; attempt < 15; attempt++) {
-      const before = await page.evaluate(() => window.__smokeResults.length);
-      await page.evaluate(
-        (s) => window.postMessage({ type: "mle-set-source", source: s }, "*"),
-        src,
-      );
-      await page
-        .waitForFunction((n) => window.__smokeResults.length > n, before, {
-          timeout: 10000,
-        })
-        .catch(() => {});
-      result = await page.evaluate(
-        () => window.__smokeResults[window.__smokeResults.length - 1],
-      );
-      if (result && result.ok === true) break;
-      const msg = (result && result.message) || "";
-      if (result && result.ok === false && /mid-frame|not running/.test(msg)) {
-        await sleep(200);
-        continue;
-      }
-      break; // a real reload error (or no result) — stop and report it
-    }
+    // The runtime QUEUES the pushed source and applies it at the top of a frame
+    // (never mid-frame), then posts `mle-set-source-result`. On a heavy sample
+    // under software GL a frame can take several seconds, so wait generously.
+    const before = await page.evaluate(() => window.__smokeResults.length);
+    const pushStart = Date.now();
+    await page.evaluate(
+      (s) => window.postMessage({ type: "mle-set-source", source: s }, "*"),
+      src,
+    );
+    await page
+      .waitForFunction((n) => window.__smokeResults.length > n, before, {
+        timeout: 30000,
+      })
+      .catch(() => {});
+    const result = await page.evaluate(
+      () => window.__smokeResults[window.__smokeResults.length - 1],
+    );
     if (!result || result.ok !== true) {
+      const waited = ((Date.now() - pushStart) / 1000).toFixed(1);
+      // Did the runtime log that it applied the reload? (Distinguishes a frame
+      // loop that never got to it from a result that wasn't delivered.)
+      const applied = log.filter((m) => /\[mle\] (reloaded|reload error)/.test(m));
+      const tail = log.slice(-8).map((m) => m.replace(/\s+/g, " ").slice(0, 100));
       return {
         sample,
         ok: false,
-        reason: `reload push failed: ${result ? result.message : "no result (timed out)"}`,
+        reason:
+          `reload push failed after ${waited}s: ${result ? result.message : "no mle-set-source-result received"}` +
+          ` | runtime applied-reload log: ${applied.length ? applied.join(" ; ") : "NONE"}` +
+          ` | last console: ${tail.join(" | ")}`,
         mleErrors,
         log,
       };

--- a/e2e/wasm-smoke.mjs
+++ b/e2e/wasm-smoke.mjs
@@ -28,11 +28,38 @@
 //   node e2e/wasm-smoke.mjs  # all samples, or: node e2e/wasm-smoke.mjs lighting hello-cubes
 import { spawn } from "node:child_process";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
+import net from "node:net";
 import { fileURLToPath } from "node:url";
 import { chromium } from "@playwright/test";
 
 const ROOT = fileURLToPath(new URL("..", import.meta.url));
 const BASE = "http://127.0.0.1:8080";
+const PORT = 8080;
+
+// Is :PORT accepting connections? Used to serialize the per-sample servers: a
+// lingering dev server from a previous sample would make the next one connect to
+// the WRONG project (the stale-:8080 hazard that produces phantom errors), so we
+// wait for the port to be FREE before spawning and after killing.
+function portInUse() {
+  return new Promise((resolve) => {
+    const sock = net
+      .connect(PORT, "127.0.0.1")
+      .on("connect", () => {
+        sock.destroy();
+        resolve(true);
+      })
+      .on("error", () => resolve(false));
+  });
+}
+
+async function waitPortFree(timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!(await portInUse())) return true;
+    await sleep(200);
+  }
+  return false;
+}
 
 // Samples that stand alone (no companion network server). The multiplayer /
 // websocket demos need a running server to do anything, so they're out of a
@@ -73,6 +100,16 @@ function entrySource(sample) {
 }
 
 async function smoke(sample) {
+  // A previous sample's dev server must have fully released :8080, or this
+  // sample would connect to the wrong project (stale-server false results).
+  if (!(await waitPortFree(15000))) {
+    return {
+      sample,
+      ok: false,
+      reason: `:${PORT} still in use by a previous server — cannot serve this sample cleanly`,
+      mleErrors: [],
+    };
+  }
   const server = spawn(
     "./target/debug/functor",
     ["-d", `examples/${sample}`, "run", "wasm", "--no-open"],
@@ -116,6 +153,25 @@ async function smoke(sample) {
       await sleep(250);
     }
 
+    // Guard against a stale server: the entry the page fetched must match this
+    // sample's entry on disk. A mismatch means we connected to a leftover dev
+    // server for a different project — fail loud instead of reporting phantom
+    // errors from the wrong game.
+    const served = await page.evaluate(async () => {
+      const path = window.__mleGamePath;
+      const res = await fetch(path, { cache: "no-store" });
+      return res.text();
+    });
+    if (served.trim() !== entrySource(sample).trim()) {
+      return {
+        sample,
+        ok: false,
+        reason: "served entry source does not match this sample (stale/wrong dev server?)",
+        mleErrors,
+        log,
+      };
+    }
+
     // Run a few frames.
     await sleep(1500);
 
@@ -130,24 +186,37 @@ async function smoke(sample) {
       });
     });
     const src = entrySource(sample);
-    const before = await page.evaluate(() => window.__smokeResults.length);
-    await page.evaluate(
-      (s) => window.postMessage({ type: "mle-set-source", source: s }, "*"),
-      src,
-    );
-    await page
-      .waitForFunction((n) => window.__smokeResults.length > n, before, {
-        timeout: 5000,
-      })
-      .catch(() => {});
-    const result = await page.evaluate(
-      () => window.__smokeResults[window.__smokeResults.length - 1],
-    );
+    // `mle_set_source` refuses ("runtime is mid-frame; retry") if the frame loop
+    // holds the producer borrow when the push lands — likelier on the heavier
+    // samples under slow software GL — so retry that transient a few times.
+    let result;
+    for (let attempt = 0; attempt < 15; attempt++) {
+      const before = await page.evaluate(() => window.__smokeResults.length);
+      await page.evaluate(
+        (s) => window.postMessage({ type: "mle-set-source", source: s }, "*"),
+        src,
+      );
+      await page
+        .waitForFunction((n) => window.__smokeResults.length > n, before, {
+          timeout: 10000,
+        })
+        .catch(() => {});
+      result = await page.evaluate(
+        () => window.__smokeResults[window.__smokeResults.length - 1],
+      );
+      if (result && result.ok === true) break;
+      const msg = (result && result.message) || "";
+      if (result && result.ok === false && /mid-frame|not running/.test(msg)) {
+        await sleep(200);
+        continue;
+      }
+      break; // a real reload error (or no result) — stop and report it
+    }
     if (!result || result.ok !== true) {
       return {
         sample,
         ok: false,
-        reason: `reload push failed: ${result ? result.error : "no result"}`,
+        reason: `reload push failed: ${result ? result.message : "no result (timed out)"}`,
         mleErrors,
         log,
       };
@@ -176,8 +245,10 @@ async function smoke(sample) {
     return { sample, ok: true, mleErrors };
   } finally {
     await browser.close();
-    server.kill();
-    await sleep(400);
+    server.kill("SIGKILL");
+    // Wait for :PORT to actually release before the next sample spawns, so the
+    // next one can't connect to this server.
+    await waitPortFree(10000);
   }
 }
 

--- a/e2e/wasm-smoke.mjs
+++ b/e2e/wasm-smoke.mjs
@@ -1,0 +1,210 @@
+// wasm smoke test: every MLE sample must LOAD → UPDATE (a pushed reload) → run
+// several frames in the browser wasm runtime WITHOUT a persistent error.
+//
+// This is the guard for the whole class of "works native, broken in wasm" bugs
+// — a missing sibling module (hello-cubes's `Pieces.*`), a stale interpreter
+// dropping record fields, a contract regression — that a native-only test can't
+// see. Each sample:
+//
+//   1. serves with the built CLI (`functor run wasm`) and loads in headless
+//      Chromium (asserts the game reached "[mle] loaded");
+//   2. runs a few frames, then PUSHES its own entry source back through the
+//      `mle-set-source` seam (the VSCode live-preview / hot-reload path) and
+//      asserts the reload succeeds — for a multi-file game this re-links the
+//      siblings kept from the initial fetch;
+//   3. runs a few more frames and asserts the red DRAW-error overlay is NOT
+//      showing (a persistent broken `draw` — the blank-screen symptom — leaves
+//      it up; a benign first-frame transient auto-clears and passes).
+//
+// A visible overlay or a failed load/push fails that sample. Per-frame `[mle]`
+// error console lines are printed as info (they may be benign transients) but
+// don't by themselves fail the run.
+//
+// Run manually (owns its own server on :8080, one sample at a time — not part
+// of `playwright test`):
+//
+//   npm run build:cli        # once, so target/debug/functor embeds the runtime
+//   npm run fetch:assets     # glTF/textures some samples load (optional)
+//   node e2e/wasm-smoke.mjs  # all samples, or: node e2e/wasm-smoke.mjs lighting hello-cubes
+import { spawn } from "node:child_process";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { chromium } from "@playwright/test";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const BASE = "http://127.0.0.1:8080";
+
+// Samples that stand alone (no companion network server). The multiplayer /
+// websocket demos need a running server to do anything, so they're out of a
+// pure client smoke.
+const EXCLUDE = new Set([
+  "mpclient",
+  "mpserver",
+  "wsdemo",
+  "wsserverdemo",
+]);
+
+// The sample list: CLI args if given, else every examples/* with a functor.json
+// declaring `"language": "mle"`, minus the network demos.
+const allSamples = readdirSync(`${ROOT}/examples`, { withFileTypes: true })
+  .filter((d) => d.isDirectory())
+  .map((d) => d.name)
+  .filter((name) => {
+    const cfg = `${ROOT}/examples/${name}/functor.json`;
+    return (
+      existsSync(cfg) &&
+      JSON.parse(readFileSync(cfg, "utf8")).language === "mle" &&
+      !EXCLUDE.has(name)
+    );
+  })
+  .sort();
+const samples = process.argv.slice(2).length ? process.argv.slice(2) : allSamples;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Read the sample's entry source, so we can push it back through the reload seam
+// (the "update" step) exactly as an editor would.
+function entrySource(sample) {
+  const cfg = JSON.parse(
+    readFileSync(`${ROOT}/examples/${sample}/functor.json`, "utf8"),
+  );
+  const entry = cfg.entry || "game.mle";
+  return readFileSync(`${ROOT}/examples/${sample}/${entry}`, "utf8");
+}
+
+async function smoke(sample) {
+  const server = spawn(
+    "./target/debug/functor",
+    ["-d", `examples/${sample}`, "run", "wasm", "--no-open"],
+    { cwd: ROOT, stdio: "ignore" },
+  );
+  // Software WebGL2 (swiftshader) so the runtime's GL context comes up on any
+  // runner — headless CI included — without a real GPU. Same flags as the wasm
+  // golden config; a smoke run compares no pixels, so software rendering is fine.
+  const browser = await chromium.launch({
+    args: [
+      "--use-gl=angle",
+      "--use-angle=swiftshader",
+      "--enable-unsafe-swiftshader",
+      "--ignore-gpu-blocklist",
+    ],
+  });
+  const mleErrors = [];
+  try {
+    const page = await browser.newPage({ viewport: { width: 640, height: 480 } });
+    const log = [];
+    page.on("console", (m) => {
+      const line = `${m.type()}: ${m.text()}`;
+      log.push(line);
+      if (/\[mle\].*error/.test(m.text())) mleErrors.push(m.text());
+    });
+    page.on("pageerror", (e) => log.push(`pageerror: ${e}`));
+
+    // Wait for the dev server, then the game to load.
+    for (let i = 0; i < 120; i++) {
+      try {
+        await page.goto(BASE);
+        break;
+      } catch {
+        await sleep(500);
+      }
+    }
+    for (let i = 0; !log.some((m) => m.includes("[mle] loaded")); i++) {
+      if (i > 60) {
+        return { sample, ok: false, reason: "never loaded", mleErrors, log };
+      }
+      await sleep(250);
+    }
+
+    // Run a few frames.
+    await sleep(1500);
+
+    // UPDATE: push the entry source back through the reload seam and await its
+    // result (the VSCode hot-reload path). Multi-file games re-link the siblings
+    // kept from the initial fetch.
+    await page.evaluate(() => {
+      window.__smokeResults = [];
+      window.addEventListener("message", (e) => {
+        if (e.data && e.data.type === "mle-set-source-result")
+          window.__smokeResults.push(e.data);
+      });
+    });
+    const src = entrySource(sample);
+    const before = await page.evaluate(() => window.__smokeResults.length);
+    await page.evaluate(
+      (s) => window.postMessage({ type: "mle-set-source", source: s }, "*"),
+      src,
+    );
+    await page
+      .waitForFunction((n) => window.__smokeResults.length > n, before, {
+        timeout: 5000,
+      })
+      .catch(() => {});
+    const result = await page.evaluate(
+      () => window.__smokeResults[window.__smokeResults.length - 1],
+    );
+    if (!result || result.ok !== true) {
+      return {
+        sample,
+        ok: false,
+        reason: `reload push failed: ${result ? result.error : "no result"}`,
+        mleErrors,
+        log,
+      };
+    }
+
+    // Run a few more frames, then read the draw-error overlay state.
+    await sleep(1500);
+    const overlay = await page.evaluate(() => {
+      const el = document.getElementById("mle-error");
+      if (!el) return { visible: false, text: "" };
+      return {
+        visible: getComputedStyle(el).display !== "none",
+        text: el.textContent || "",
+      };
+    });
+    if (overlay.visible) {
+      return {
+        sample,
+        ok: false,
+        reason: `draw-error overlay visible: ${overlay.text.replace(/\s+/g, " ").trim()}`,
+        mleErrors,
+        log,
+      };
+    }
+
+    return { sample, ok: true, mleErrors };
+  } finally {
+    await browser.close();
+    server.kill();
+    await sleep(400);
+  }
+}
+
+let failures = 0;
+console.log(`wasm smoke: ${samples.length} sample(s)\n`);
+for (const sample of samples) {
+  let r;
+  try {
+    r = await smoke(sample);
+  } catch (e) {
+    r = { sample, ok: false, reason: `harness error: ${e}`, mleErrors: [] };
+  }
+  const note = r.mleErrors?.length
+    ? ` (${r.mleErrors.length} transient [mle] error line(s))`
+    : "";
+  if (r.ok) {
+    console.log(`PASS  ${sample}${note}`);
+  } else {
+    failures++;
+    console.log(`FAIL  ${sample} — ${r.reason}${note}`);
+    for (const e of (r.mleErrors || []).slice(0, 3)) console.log(`        ${e}`);
+  }
+}
+
+console.log(
+  failures === 0
+    ? `\nALL ${samples.length} SAMPLES PASSED`
+    : `\n${failures} SAMPLE(S) FAILED`,
+);
+process.exit(failures === 0 ? 0 : 1);

--- a/mle/src/project.rs
+++ b/mle/src/project.rs
@@ -288,10 +288,42 @@ pub fn load_with_prelude(
         )
     })?;
 
-    // Derive and validate module names; read sources; assign span bases.
+    // Read every project file (entry first), honoring the in-memory overrides,
+    // then hand the (path, source) pairs to the shared linker.
+    let mut sources: Vec<(PathBuf, String)> = Vec::new();
+    for path in paths.iter() {
+        let src = match override_for(path, overrides) {
+            Some(src) => src.clone(),
+            None => std::fs::read_to_string(path)
+                .map_err(|e| at(path, format!("cannot read {}: {e}", path.display())))?,
+        };
+        sources.push((path.clone(), src));
+    }
+    load_sources_with_prelude(sources, prelude)
+}
+
+/// Link an already-read set of project sources (entry FIRST, then siblings —
+/// each a `(path, source)` pair) plus the injected prelude modules. The
+/// in-memory core shared by the on-disk [`load_with_prelude`] and the wasm
+/// producer, which fetches each project file over HTTP rather than reading the
+/// directory — so native and web run ONE link path (module-name derivation,
+/// the protected-namespace guard, span bases, prelude injection). The paths are
+/// only labels here (module names + error rendering); nothing is read from disk.
+pub fn load_sources_with_prelude(
+    sources: Vec<(PathBuf, String)>,
+    prelude: &[(String, String)],
+) -> Result<Project, ProjectError> {
+    let at = |path: &Path, message: String| ProjectError {
+        path: path.to_path_buf(),
+        line: 1,
+        col: 1,
+        message,
+    };
+
+    // Derive and validate module names; assign span bases.
     let mut files: Vec<SourceFile> = Vec::new();
     let mut base = 0usize;
-    for path in paths.iter() {
+    for (path, src) in sources.iter() {
         let module = module_name(path).map_err(|message| at(path, message))?;
         if PROTECTED_NAMESPACES.contains(&module.as_str()) {
             return Err(at(
@@ -314,17 +346,12 @@ come from file names, capitalized",
                 ),
             ));
         }
-        let src = match override_for(path, overrides) {
-            Some(src) => src.clone(),
-            None => std::fs::read_to_string(path)
-                .map_err(|e| at(path, format!("cannot read {}: {e}", path.display())))?,
-        };
         let len = src.len();
         files.push(SourceFile {
             interface: is_interface(path),
             path: path.clone(),
             module,
-            src,
+            src: src.clone(),
             base,
         });
         // +1 gap: a span at one file's very end never collides with the

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:golden": "npm run fetch:assets && npm run build:cli && cargo test -p functor-runtime-desktop --test golden -- --ignored --nocapture",
     "test:wasm-golden": "playwright test",
     "test:wasm-golden:update": "playwright test --update-snapshots",
+    "test:wasm-smoke": "node e2e/wasm-smoke.mjs",
     "site:build": "node site/build.mjs",
     "site:serve": "node site/serve.mjs",
     "test:site": "node e2e/site-sandbox.mjs"

--- a/runtime/functor-runtime-common/src/mle_producer.rs
+++ b/runtime/functor-runtime-common/src/mle_producer.rs
@@ -106,11 +106,18 @@ impl Reporter {
     /// The span identifies the file too (project-wide spans), so an error in a
     /// sibling module names that module's file.
     pub fn frame_error(&mut self, stage: &str, err: &RunError) {
-        let rendered = format!(
+        self.report_once(self.render_frame_error(stage, err));
+    }
+
+    /// Render a per-frame `RunError` to its `[mle] {stage} error at
+    /// path:line:col: message` form WITHOUT reporting it — for a caller (the web
+    /// error overlay) that also surfaces the text elsewhere, so it can report
+    /// once and display the same string without re-deriving the position.
+    pub fn render_frame_error(&self, stage: &str, err: &RunError) -> String {
+        format!(
             "[mle] {stage} error at {}",
             self.source.render(err.span, &err.message)
-        );
-        self.report_once(rendered);
+        )
     }
 }
 

--- a/runtime/functor-runtime-web/Cargo.toml
+++ b/runtime/functor-runtime-web/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 functor_runtime_common = { path = "./../functor-runtime-common" }
+functor-prelude = { path = "../../functor-prelude" }
 # The MLE language, for the in-runtime interpreter producer (docs/mle.md C5).
 mle = { path = "../../mle" }
 glow = "0.17"
@@ -20,7 +21,7 @@ serde_json = "1.0"
 
 [dependencies.web-sys]
 version = "0.3.4"
-features = ['Blob', 'HtmlCanvasElement', 'WebGl2RenderingContext', 'console', 'Window', 'Location', 'Performance', 'PerformanceTiming', 'Document', 'Element', 'Request', 'RequestInit', 'Response', 'Headers', 'AudioContext', 'BaseAudioContext', 'AudioBuffer', 'AudioBufferSourceNode', 'AudioDestinationNode', 'AudioNode', 'AudioParam', 'GainNode', 'StereoPannerNode', 'WebSocket', 'MessageEvent', 'CloseEvent', 'ErrorEvent']
+features = ['Blob', 'HtmlCanvasElement', 'WebGl2RenderingContext', 'console', 'Window', 'Location', 'Performance', 'PerformanceTiming', 'Document', 'Element', 'Node', 'HtmlElement', 'Request', 'RequestInit', 'RequestCache', 'Response', 'Headers', 'AudioContext', 'BaseAudioContext', 'AudioBuffer', 'AudioBufferSourceNode', 'AudioDestinationNode', 'AudioNode', 'AudioParam', 'GainNode', 'StereoPannerNode', 'WebSocket', 'MessageEvent', 'CloseEvent', 'ErrorEvent']
 
 [profile.release]
 codegen-units = 1

--- a/runtime/functor-runtime-web/index-mle.html
+++ b/runtime/functor-runtime-web/index-mle.html
@@ -93,6 +93,13 @@
       window.__mleGamePath = "__MLE_ENTRY__"
         .split("/").map(encodeURIComponent).join("/");
 
+      // The project's full file list (entry first, then siblings) — file =
+      // module, so a game split across game.mle + pieces.mle loads all its
+      // modules. The CLI substitutes this JSON array (see wasm_dev_server.rs);
+      // each path is URL-encoded per segment like the entry above.
+      window.__mleProjectFiles = ("__MLE_PROJECT_FILES__")
+        .map((p) => p.split("/").map(encodeURIComponent).join("/"));
+
       // Map a browser KeyboardEvent.code to the canonical key code expected by
       // the game (functor_runtime_common::Key as i32 — the same mapping as
       // index.html). Keep in sync with that enum: A=1..Z=26, then the entries

--- a/runtime/functor-runtime-web/index-mle.html
+++ b/runtime/functor-runtime-web/index-mle.html
@@ -232,22 +232,10 @@
           if (event.source !== window.parent) return;
           const data = event.data;
           if (!data || data.type !== "mle-set-source" || typeof data.source !== "string") return;
-          let ok = true;
-          let message = "";
-          try {
-            message = mle_set_source(data.source);
-          } catch (e) {
-            // A broken push: the wasm export throws the rendered load error
-            // and the old program keeps running.
-            ok = false;
-            message = String(e);
-          }
-          if (event.source) {
-            event.source.postMessage(
-              { type: "mle-set-source-result", ok, message },
-              event.origin || "*"
-            );
-          }
+          // Queue the source; the wasm frame loop applies it at a safe point
+          // (never mid-frame) and posts back an `mle-set-source-result` message
+          // with the outcome — so a broken push keeps the old program running.
+          mle_set_source(data.source);
         });
         // Tell the hosting frame the push seam is live — the editor panel
         // flushes the current buffer on this (edits made while the server

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -186,36 +186,71 @@ pub fn mle_is_running() -> bool {
     GAME.with(|g| g.borrow().is_some())
 }
 
-/// Hot-swap the running game's logic from pushed `.mle` source — the wasm
-/// counterpart of the desktop runner's `POST /reload-source` (docs/mle.md
-/// D4). Same semantics: the model is preserved (`mle::rebind_value`), a
-/// broken push keeps the old program running. `Ok` carries a short status
-/// line; `Err` (a JS throw) the rendered load error.
-#[wasm_bindgen]
-pub fn mle_set_source(source: String) -> Result<String, String> {
-    let game = GAME.with(|g| g.borrow().clone());
-    let Some(game) = game else {
-        return Err("game is not running yet (still loading, or the load failed)".to_string());
+thread_local! {
+    /// Source pushed via `mle_set_source`, waiting to be applied at a SAFE point
+    /// (the top of the frame loop, where the loop already holds the producer
+    /// borrow). Deferring — rather than reloading straight from the message
+    /// handler — is what keeps a push from ever colliding with the frame's
+    /// borrow ("runtime is mid-frame"); it also coalesces a burst of edits to
+    /// the last one. Mirrors the desktop runner, which applies reloads between
+    /// frames.
+    static PENDING_RELOAD: RefCell<Option<String>> = const { RefCell::new(None) };
+}
+
+/// Post a `mle-set-source-result` back to the page (the reload's outcome). The
+/// pusher — the VSCode live preview, the site sandbox, a test harness — listens
+/// for this. Because the reload is applied asynchronously (next frame), the
+/// result is delivered here rather than returned from `mle_set_source`.
+fn post_reload_result(ok: bool, message: &str) {
+    let obj = js_sys::Object::new();
+    let set = |k: &str, v: &JsValue| {
+        let _ = js_sys::Reflect::set(&obj, &JsValue::from_str(k), v);
     };
-    // JS is single-threaded and postMessage handlers never run mid-frame, so
-    // this borrow can't collide with the frame loop's — but a panic here
-    // would poison the page, so refuse instead of unwrapping.
-    let Ok(mut game) = game.try_borrow_mut() else {
-        return Err("runtime is mid-frame; retry".to_string());
+    set("type", &JsValue::from_str("mle-set-source-result"));
+    set("ok", &JsValue::from_bool(ok));
+    set("message", &JsValue::from_str(message));
+    // Deliver to the PARENT — the push's original sender (the VSCode preview
+    // host, the site sandbox frame). When the page is top-level, `parent` is the
+    // window itself, so a standalone page / test harness listening on `window`
+    // still receives it.
+    let target = window().parent().ok().flatten().unwrap_or_else(window);
+    let _ = target.post_message(&obj, "*");
+}
+
+/// Apply a pending pushed source, if any — called at the top of each frame while
+/// the frame loop holds the producer borrow, so it never collides with a frame.
+/// A good push clears the error overlay; a broken one shows it; either way the
+/// outcome is posted back to the page.
+fn apply_pending_reload(game: &mut dyn GameProducer) {
+    let Some(source) = PENDING_RELOAD.with(|p| p.borrow_mut().take()) else {
+        return;
     };
-    // A good push clears any lingering error overlay; a broken one shows it
-    // (and still returns the rendered error to the pusher — e.g. the VSCode
-    // editor — as before).
     match game.reload_source(&source) {
         Ok(status) => {
             hide_error_overlay();
-            Ok(status)
+            post_reload_result(true, &status);
         }
         Err(message) => {
             show_error_overlay(&format!("[mle] reload error: {message}"));
-            Err(message)
+            post_reload_result(false, &message);
         }
     }
+}
+
+/// Hot-swap the running game's logic from pushed `.mle` source — the wasm
+/// counterpart of the desktop runner's `POST /reload-source` (docs/mle.md D4).
+/// The source is QUEUED and applied at the top of the next frame (see
+/// [`apply_pending_reload`]); the outcome is delivered asynchronously as a
+/// `mle-set-source-result` message, not returned here. Model preserved
+/// (`mle::rebind_value`); a broken push keeps the old program running.
+#[wasm_bindgen]
+pub fn mle_set_source(source: String) {
+    if !mle_is_running() {
+        post_reload_result(false, "game is not running yet (still loading, or the load failed)");
+        return;
+    }
+    // Last edit wins: a burst of pushes before the next frame coalesces.
+    PENDING_RELOAD.with(|p| *p.borrow_mut() = Some(source));
 }
 
 /// Route a socket event to the LIVE producer via the shared `GAME` handle (the
@@ -1021,11 +1056,13 @@ async fn run_async() -> Result<(), JsValue> {
         let mut ghost_window: f32 = 2.0;
 
         *g.borrow_mut() = Some(Closure::new(move || {
-            // The frame's exclusive borrow of the shared producer. Cannot
-            // collide with `mle_set_source`: JS is single-threaded, and
-            // message handlers only run between rAF callbacks.
+            // The frame's exclusive borrow of the shared producer.
             let mut game = game.borrow_mut();
             let now = performance.now() as f32;
+
+            // Apply a pushed source (`mle_set_source`) here, at a safe point that
+            // already holds the borrow — so a push never collides with a frame.
+            apply_pending_reload(&mut **game);
 
             // Apply scrubber controls from the DOM (pause / step / seek), which
             // drive the shared game clock BEFORE this frame's time is computed.

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -30,6 +30,50 @@ fn window() -> web_sys::Window {
     web_sys::window().expect("no global `window` exists")
 }
 
+/// The red error overlay's inline style — a fixed panel pinned to the top of
+/// the page, above the canvas, scrollable if the message is long. Kept as one
+/// string so `show`/`hide` toggle the same element.
+const ERROR_OVERLAY_STYLE: &str = "position:fixed;top:0;left:0;right:0;max-height:60%;\
+overflow:auto;z-index:2147483647;margin:0;padding:12px 16px;background:#2b0a0a;color:#ffb3b3;\
+border-bottom:2px solid #ff5555;font:13px/1.5 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;\
+white-space:pre-wrap;box-shadow:0 2px 12px rgba(0,0,0,.5)";
+
+/// Show (or update) a red error overlay in the page — the web runtime's take on
+/// React's hot-reload error screen, so a failed load or a broken edit shows the
+/// message instead of a blank canvas (the desktop runner prints to stderr; the
+/// browser has no console the user is watching). Idempotent: reuses one
+/// `#mle-error` element. Best-effort — a missing document just no-ops.
+fn show_error_overlay(message: &str) {
+    let Some(doc) = window().document() else {
+        return;
+    };
+    let el = match doc.get_element_by_id("mle-error") {
+        Some(el) => el,
+        None => {
+            let Ok(el) = doc.create_element("div") else {
+                return;
+            };
+            el.set_id("mle-error");
+            if let Some(body) = doc.body() {
+                let _ = body.append_child(&el);
+            }
+            el
+        }
+    };
+    let _ = el.set_attribute("style", ERROR_OVERLAY_STYLE);
+    el.set_text_content(Some(&format!("⛔ MLE error\n\n{message}")));
+}
+
+/// Hide the error overlay if present — called after a successful (re)load so a
+/// fixed edit clears the panel.
+fn hide_error_overlay() {
+    if let Some(doc) = window().document() {
+        if let Some(el) = doc.get_element_by_id("mle-error") {
+            let _ = el.set_attribute("style", "display:none");
+        }
+    }
+}
+
 fn request_animation_frame(f: &Closure<dyn FnMut()>) {
     window()
         .request_animation_frame(f.as_ref().unchecked_ref())
@@ -88,17 +132,42 @@ fn mle_game_path() -> Option<String> {
         .and_then(|v| v.as_string())
 }
 
-/// Fetch the `.mle` source and build the interpreter producer. Failures are
-/// rendered strings (fetch status, parse/load position, contract violation)
-/// for `run_async` to fail loud with.
-async fn create_mle_game(path: &str) -> Result<mle_game::MleWebGame, String> {
-    let (status, src) = perform_fetch(HttpMethod::Get, path, &[], &[])
-        .await
-        .map_err(|e| format!("cannot fetch {path}: {e}"))?;
-    if status != 200 {
-        return Err(format!("cannot fetch {path}: HTTP {status}"));
+/// The project's full file list (entry FIRST, then siblings), as the CLI's MLE
+/// index page injects it (`window.__mleProjectFiles`, mirroring `__mleGamePath`
+/// — see `wasm_dev_server.rs`). Absent (a page that only set the single entry,
+/// e.g. the site sandbox) → `None`, and the caller falls back to the entry
+/// alone.
+fn mle_project_files() -> Option<Vec<String>> {
+    use wasm_bindgen::JsCast;
+    let value = js_sys::Reflect::get(&window(), &JsValue::from_str("__mleProjectFiles")).ok()?;
+    let array = value.dyn_into::<js_sys::Array>().ok()?;
+    let files: Vec<String> = array.iter().filter_map(|v| v.as_string()).collect();
+    (!files.is_empty()).then_some(files)
+}
+
+/// Fetch every project `.mle`/`.mlei` source (entry first, then siblings) and
+/// build the interpreter producer. `file = module`, so a game split across
+/// `game.mle` + `pieces.mle` links exactly as it does natively. Failures are
+/// rendered strings (fetch status, parse/load position, contract violation) for
+/// `run_async` to fail loud with.
+async fn create_mle_game(entry: &str) -> Result<mle_game::MleWebGame, String> {
+    // The CLI injects the whole project file list; a page that set only the
+    // entry (or none) falls back to loading the entry alone.
+    let paths = mle_project_files().unwrap_or_else(|| vec![entry.to_string()]);
+    let mut sources: Vec<(String, String)> = Vec::with_capacity(paths.len());
+    for path in &paths {
+        // `no_store`: never serve project source from the browser cache — the
+        // dev server reuses `/game.mle` across samples, so a cached response
+        // would keep showing the previous game after switching projects.
+        let (status, src) = perform_fetch(HttpMethod::Get, path, &[], &[], true)
+            .await
+            .map_err(|e| format!("cannot fetch {path}: {e}"))?;
+        if status != 200 {
+            return Err(format!("cannot fetch {path}: HTTP {status}"));
+        }
+        sources.push((path.clone(), src));
     }
-    mle_game::MleWebGame::create(path, src)
+    mle_game::MleWebGame::create(sources)
 }
 
 thread_local! {
@@ -134,7 +203,19 @@ pub fn mle_set_source(source: String) -> Result<String, String> {
     let Ok(mut game) = game.try_borrow_mut() else {
         return Err("runtime is mid-frame; retry".to_string());
     };
-    game.reload_source(&source)
+    // A good push clears any lingering error overlay; a broken one shows it
+    // (and still returns the rendered error to the pusher — e.g. the VSCode
+    // editor — as before).
+    match game.reload_source(&source) {
+        Ok(status) => {
+            hide_error_overlay();
+            Ok(status)
+        }
+        Err(message) => {
+            show_error_overlay(&format!("[mle] reload error: {message}"));
+            Err(message)
+        }
+    }
 }
 
 /// Route a socket event to the LIVE producer via the shared `GAME` handle (the
@@ -195,7 +276,7 @@ async fn perform_and_push(cmd: NetCommand) {
         body,
     } = cmd;
     let token = token as i32;
-    let result = perform_fetch(method, &url, &headers, &body).await;
+    let result = perform_fetch(method, &url, &headers, &body, false).await;
     // Route the completion to the LIVE producer via the shared GAME handle —
     // the MLE page's MleWebGame, which folds the response through `update`.
     // This runs as a fetch microtask, never mid-frame, so the borrow can't
@@ -218,12 +299,16 @@ async fn perform_fetch(
     url: &str,
     headers: &[(String, String)],
     body: &[u8],
+    no_store: bool,
 ) -> Result<(i32, String), String> {
     use wasm_bindgen::JsCast;
-    use web_sys::{Request, RequestInit, Response};
+    use web_sys::{Request, RequestCache, RequestInit, Response};
 
     let mut opts = RequestInit::new();
     opts.method(http_method_str(method));
+    if no_store {
+        opts.cache(RequestCache::NoStore);
+    }
     if !body.is_empty() {
         let text = String::from_utf8_lossy(body).to_string();
         opts.body(Some(&JsValue::from_str(&text)));
@@ -769,6 +854,7 @@ async fn run_async() -> Result<(), JsValue> {
     let Some(path) = mle_game_path() else {
         let rendered = "[mle] error: no game entry — window.__mleGamePath is not set".to_string();
         web_sys::console::error_1(&rendered.as_str().into());
+        show_error_overlay(&rendered);
         return Err(JsValue::from_str(&rendered));
     };
     let game: Box<dyn GameProducer> = match create_mle_game(&path).await {
@@ -776,6 +862,7 @@ async fn run_async() -> Result<(), JsValue> {
         Err(message) => {
             let rendered = format!("[mle] error: {message}");
             web_sys::console::error_1(&rendered.as_str().into());
+            show_error_overlay(&rendered);
             return Err(JsValue::from_str(&rendered));
         }
     };

--- a/runtime/functor-runtime-web/src/mle_game.rs
+++ b/runtime/functor-runtime-web/src/mle_game.rs
@@ -31,11 +31,17 @@ use functor_runtime_common::protocol::GameProducer;
 use functor_runtime_common::timetravel::SceneRecorder;
 use functor_runtime_common::ui::View;
 use functor_runtime_common::{Frame, FrameTime};
+use mle::project::SourceMap;
 use mle::{Session, Value};
 use wasm_bindgen::prelude::*;
 
 pub struct MleWebGame {
     path: String,
+    /// The project's fetched source files (entry FIRST, then siblings) as
+    /// `(path, source)` — the web's stand-in for the on-disk directory the
+    /// desktop producer re-reads on reload. A push (`reload_source`) replaces
+    /// only the ENTRY buffer; siblings keep their last-fetched text.
+    sources: Vec<(String, String)>,
     /// The lowered module the current session came from — kept (like the
     /// desktop producer) so a pushed reload can rebind model-stored closures
     /// (old module × new module).
@@ -104,12 +110,17 @@ pub struct MleWebGame {
     /// span rendering) — shared with the desktop producer
     /// (`mle_producer::Reporter`).
     reporter: Reporter,
+    /// The DRAW error currently shown on the page's red overlay, if any (the
+    /// web-only "blank screen" guard — a broken `draw` shows the message instead
+    /// of a frozen canvas, React-HMR style). Tracked so the DOM is touched only
+    /// on a transition (draw breaks / recovers), not every frame.
+    overlay_error: Option<String>,
 }
 
 /// A successfully loaded, contract-validated game module (the desktop
 /// producer's `Loaded`, verbatim minus the file-shaped fields).
 struct Loaded {
-    src: String,
+    sources: SourceMap,
     module: mle::ir::Module,
     session: Session,
     init: Value,
@@ -122,30 +133,39 @@ struct Loaded {
     has_ui: bool,
 }
 
-/// Load, check, and contract-validate game source — the web counterpart of
-/// the desktop `load_source`, shared by the page-load path (`create`) and
-/// the editor push path (`reload_source`). Errors come back as fully
-/// rendered strings (`path:line:col: message`); `path` is only a label for
-/// error rendering.
-fn load_source(path: &str, src: String) -> Result<Loaded, String> {
-    let render = |stage: &str, span: mle::Span, message: &str| {
-        let (line, col) = mle::line_col(&src, span.start);
-        format!("cannot {stage} {path}:{line}:{col}: {message}")
-    };
-    // Load through the single-source project path so the built-in `Net`
-    // module is in scope (the web fetches ONE file — no siblings — but the
-    // Net ADT must still resolve). Spans render against the entry source.
-    let project = mle::project::load_single_source("Game", &src)
-        .map_err(|e| format!("cannot load {path}:{}:{}: {}", e.line, e.col, e.message))?;
+/// Load, check, and contract-validate a game PROJECT — the web counterpart of
+/// the desktop `load_source`, shared by the page-load path (`create`) and the
+/// editor push path (`reload_source`). `sources` is every fetched project file
+/// as `(path, source)`, the ENTRY first, then siblings (`file = module`, so
+/// `pieces.mle` is module `Pieces`). Errors come back as fully rendered strings
+/// (`path:line:col: message`).
+fn load_source(sources: &[(String, String)]) -> Result<Loaded, String> {
+    let path = sources
+        .first()
+        .map(|(p, _)| p.clone())
+        .unwrap_or_else(|| "game.mle".to_string());
+    let pairs: Vec<(std::path::PathBuf, String)> = sources
+        .iter()
+        .map(|(p, s)| (std::path::PathBuf::from(p), s.clone()))
+        .collect();
+    // Link the entry with its siblings, injecting the host prelude `.mlei`
+    // interfaces so `Scene.*` (etc.) typecheck against real types — the exact
+    // path the desktop producer runs (docs/mlei.md). Check-time only; the
+    // FunctorHost still provides the actual runtime values.
+    let project = mle::project::load_sources_with_prelude(pairs, &functor_prelude::modules())
+        .map_err(|e| format!("cannot load {}", e.render()))?;
     let module = project.module;
+    let source_map = project.sources;
     // Type diagnostics are advisory in the dev loop: warn, keep going
-    // (the CLI's `build` is the strict gate).
+    // (the CLI's `build` is the strict gate). Spans render against whichever
+    // project file they land in.
     for diag in mle::check(&module) {
-        let (line, col) = mle::line_col(&src, diag.span.start);
-        web_sys::console::warn_1(&format!("warning: {path}:{line}:{col}: {}", diag.message).into());
+        web_sys::console::warn_1(
+            &format!("warning: {}", source_map.render(diag.span.start, &diag.message)).into(),
+        );
     }
     let session = Session::load(&module, &mut FunctorHost)
-        .map_err(|f| render("load", f.error.span, &f.error.message))?;
+        .map_err(|f| format!("cannot load {}", source_map.render(f.error.span.start, &f.error.message)))?;
     // The producer contract is knowable at load — fail here, not once per
     // frame: `init` must be a model VALUE, `tick`/`draw` functions of the
     // right arity.
@@ -166,30 +186,30 @@ fn load_source(path: &str, src: String) -> Result<Loaded, String> {
 return them beside the model as `(model, effect)`"
         ));
     }
-    require_function(path, &session, "tick", 3)?;
-    require_function(path, &session, "draw", 2)?;
+    require_function(&path, &session, "tick", 3)?;
+    require_function(&path, &session, "draw", 2)?;
     // `input` is optional (many games are non-interactive), but when
     // present it must honor the contract: (model, key, isDown) => model.
     let has_input = session.global("input").is_some();
     if has_input {
-        require_function(path, &session, "input", 3)?;
+        require_function(&path, &session, "input", 3)?;
     }
     // Same deal for the mouse: `mouseMove(model, x, y)` in window pixels,
     // `mouseWheel(model, delta)`.
     let has_mouse_move = session.global("mouseMove").is_some();
     if has_mouse_move {
-        require_function(path, &session, "mouseMove", 3)?;
+        require_function(&path, &session, "mouseMove", 3)?;
     }
     let has_mouse_wheel = session.global("mouseWheel").is_some();
     if has_mouse_wheel {
-        require_function(path, &session, "mouseWheel", 2)?;
+        require_function(&path, &session, "mouseWheel", 2)?;
     }
     // The MVU pair: `subscriptions(model)` declares timers whose fired
     // messages fold through `update(model, msg)` — so subscriptions
     // without an update have nowhere to deliver.
     let has_subscriptions = session.global("subscriptions").is_some();
     if has_subscriptions {
-        require_function(path, &session, "subscriptions", 1)?;
+        require_function(&path, &session, "subscriptions", 1)?;
         if session.global("update").is_none() {
             return Err(format!(
                 "{path}: `subscriptions` produces messages but there is no \
@@ -198,7 +218,7 @@ return them beside the model as `(model, effect)`"
         }
     }
     if session.global("update").is_some() {
-        require_function(path, &session, "update", 2)?;
+        require_function(&path, &session, "update", 2)?;
     }
     // Optional physics: `physics(model) => Physics.scene(…)` declares the
     // bodies that should exist; the host reconciles + fixed-steps the
@@ -206,23 +226,23 @@ return them beside the model as `(model, effect)`"
     // the world runs in the browser exactly as it does natively.
     let has_physics = session.global("physics").is_some();
     if has_physics {
-        require_function(path, &session, "physics", 1)?;
+        require_function(&path, &session, "physics", 1)?;
     }
     // Optional soundscape: `soundScape(model)` returns an AudioScene (the
     // continuous, reconciled half of audio). No `update` requirement — the
     // scene is reconciled by the shell, not folded back as a message.
     let has_soundscape = session.global("soundScape").is_some();
     if has_soundscape {
-        require_function(path, &session, "soundScape", 1)?;
+        require_function(&path, &session, "soundScape", 1)?;
     }
     // Optional HUD: `ui(model)` returns a View (Ui.text / Ui.column /
     // Ui.panel), lowered to the shared text overlay — the F# `ui` hook.
     let has_ui = session.global("ui").is_some();
     if has_ui {
-        require_function(path, &session, "ui", 1)?;
+        require_function(&path, &session, "ui", 1)?;
     }
     Ok(Loaded {
-        src,
+        sources: source_map,
         module,
         session,
         init,
@@ -237,10 +257,11 @@ return them beside the model as `(model, effect)`"
 }
 
 impl MleWebGame {
-    /// Build the producer from fetched game source. Errors come back fully
-    /// rendered for `run_async` to fail loud with (there is no keep-running
-    /// fallback: a page load either gets a valid game or a console error).
-    pub fn create(path: &str, src: String) -> Result<MleWebGame, String> {
+    /// Build the producer from the fetched project sources (entry FIRST, then
+    /// siblings). Errors come back fully rendered for `run_async` to fail loud
+    /// with (there is no keep-running fallback: a page load either gets a valid
+    /// game or a console error).
+    pub fn create(sources: Vec<(String, String)>) -> Result<MleWebGame, String> {
         // Route MLE `Debug.log` traces to the browser console (once per process;
         // the process-global sink survives hot-reload). The web runtime has no
         // CLI event stream, so — unlike native, which forwards into the
@@ -249,17 +270,17 @@ impl MleWebGame {
         mle::set_trace_sink(Box::new(|message| {
             web_sys::console::log_1(&JsValue::from_str(&message));
         }));
-        let loaded = load_source(path, src)?;
+        let path = sources
+            .first()
+            .map(|(p, _)| p.clone())
+            .unwrap_or_else(|| "game.mle".to_string());
+        let loaded = load_source(&sources)?;
         web_sys::console::log_1(&format!("[mle] loaded {path}").into());
         Ok(MleWebGame {
-            reporter: Reporter::new(
-                SpanSource::Single {
-                    src: loaded.src,
-                    path: path.to_string(),
-                },
-                report_to_console,
-            ),
-            path: path.to_string(),
+            reporter: Reporter::new(SpanSource::Project(loaded.sources), report_to_console),
+            overlay_error: None,
+            sources,
+            path,
             module: loaded.module,
             session: loaded.session,
             model: loaded.init,
@@ -302,10 +323,7 @@ impl MleWebGame {
         for warning in &report.warnings {
             web_sys::console::warn_1(&format!("[mle] reload: {warning}").into());
         }
-        self.reporter.set_source(SpanSource::Single {
-            src: loaded.src,
-            path: self.path.clone(),
-        });
+        self.reporter.set_source(SpanSource::Project(loaded.sources));
         self.module = loaded.module;
         self.session = loaded.session;
         self.has_input = loaded.has_input;
@@ -340,7 +358,25 @@ impl MleWebGame {
             self.last_view = View::Empty;
         }
         self.reporter.reset();
+        // The push path (`mle_set_source`) already hid the overlay in the DOM;
+        // clear our shadow so the reloaded program's first draw re-shows it if
+        // that program's `draw` still errors.
+        self.overlay_error = None;
         report.rebound
+    }
+
+    /// Toggle the page's red draw-error overlay, touching the DOM only when the
+    /// state actually changes (draw breaks with a new message, or recovers) so a
+    /// persistent error doesn't rewrite the overlay every frame.
+    fn set_draw_overlay(&mut self, error: Option<String>) {
+        if self.overlay_error == error {
+            return;
+        }
+        match &error {
+            Some(message) => crate::show_error_overlay(message),
+            None => crate::hide_error_overlay(),
+        }
+        self.overlay_error = error;
     }
 
     /// Bundle this producer's per-frame state into the shared [`FrameCtx`]
@@ -381,7 +417,17 @@ impl GameProducer for MleWebGame {
         // who is looking at the source that caused it). No mtime bookkeeping
         // — the browser has no file watcher; pushes are the only reload.
         let started = js_sys::Date::now();
-        let loaded = load_source(&self.path, source.to_string())?;
+        // The push replaces the ENTRY buffer; siblings keep their last-fetched
+        // text (the web has no filesystem to re-read, unlike the desktop
+        // producer). A load failure leaves `self.sources` untouched.
+        let mut sources = self.sources.clone();
+        if let Some(entry) = sources.first_mut() {
+            entry.1 = source.to_string();
+        } else {
+            sources.push((self.path.clone(), source.to_string()));
+        }
+        let loaded = load_source(&sources)?;
+        self.sources = sources;
         let rebound = self.swap_in(loaded);
         let stored = if rebound > 0 {
             format!("; {rebound} stored closure(s) rebound")
@@ -544,16 +590,26 @@ impl GameProducer for MleWebGame {
         let args = vec![self.model.clone(), Value::Number(tts)];
         match self.session.call("draw", args, &mut FunctorHost) {
             Ok(value) => match frame_value(&value) {
-                Some(frame) => self.last_frame = frame.clone(),
+                Some(frame) => {
+                    self.last_frame = frame.clone();
+                    // A live draw clears the blank-screen overlay: the canvas is
+                    // rendering again (a transient/first-frame error recovers).
+                    self.set_draw_overlay(None);
+                }
                 None => {
                     let rendered = format!(
                         "[mle] draw must return Frame.create(camera, scene), got {}",
                         value.kind_name()
                     );
-                    self.reporter.report_once(rendered);
+                    self.reporter.report_once(rendered.clone());
+                    self.set_draw_overlay(Some(rendered));
                 }
             },
-            Err(err) => self.reporter.frame_error("draw", &err),
+            Err(err) => {
+                let rendered = self.reporter.render_frame_error("draw", &err);
+                self.reporter.report_once(rendered.clone());
+                self.set_draw_overlay(Some(rendered));
+            }
         }
         // The optional HUD, evaluated beside `draw` (same settled model) and
         // cached — `ui()` is a `&self` accessor, and errors need `&mut`

--- a/site/player.html
+++ b/site/player.html
@@ -106,22 +106,10 @@
           if (event.source !== window.parent) return;
           const data = event.data;
           if (!data || data.type !== "mle-set-source" || typeof data.source !== "string") return;
-          let ok = true;
-          let message = "";
-          try {
-            message = mle_set_source(data.source);
-          } catch (e) {
-            // A broken push: the wasm export throws the rendered load error
-            // and the old program keeps running.
-            ok = false;
-            message = String(e);
-          }
-          if (event.source) {
-            event.source.postMessage(
-              { type: "mle-set-source-result", ok, message },
-              event.origin || "*"
-            );
-          }
+          // Queue the source; the wasm frame loop applies it at a safe point
+          // (never mid-frame) and posts an `mle-set-source-result` back to the
+          // hosting frame with the outcome (a broken push keeps the old program).
+          mle_set_source(data.source);
         });
         // Announce once the PRODUCER is installed (not just the wasm module):
         // run_async still has to fetch the source, so poll mle_is_running().

--- a/tools/mle-vscode/client/extension.js
+++ b/tools/mle-vscode/client/extension.js
@@ -14,12 +14,16 @@ let client;
 // The open preview panel, if any. A singleton: the dev server owns a fixed
 // port, so a second panel would race the first for it — and closing either
 // panel would kill the server out from under the other. Re-running the
-// command reveals the existing panel instead.
+// command for the SAME project reveals the existing panel; for a DIFFERENT
+// project it tears this one down first (see openLivePreview).
 let previewPanel;
 // The preview's dev-server child process — module-scoped so deactivate()
 // can kill it even if the panel outlives the command's closure (extension
 // reload/disable with the panel open must not orphan the server).
 let previewChild;
+// Project dir the open preview is serving — used to tell "reveal the existing
+// panel" (same project) apart from "restart for a different sample".
+let previewProjectDir;
 
 // Where `functor run wasm` serves the game — fixed by the CLI's dev server.
 const PREVIEW_URL = "http://127.0.0.1:8080";
@@ -105,18 +109,42 @@ function waitForServer(timeoutMs) {
 // `functor run wasm` and host the running game in a webview panel that
 // hot-reloads from the LIVE buffer (unsaved included), model preserved.
 async function openLivePreview() {
-  if (previewPanel) {
-    previewPanel.reveal();
-    return;
-  }
   const editor = vscode.window.activeTextEditor;
+  const project =
+    editor && editor.document.fileName.endsWith(".mle")
+      ? findMleProject(editor.document.fileName)
+      : null;
+
+  if (previewPanel) {
+    // Same project (or no new project resolvable from the active editor) →
+    // just focus the running preview.
+    if (!project || project.dir === previewProjectDir) {
+      previewPanel.reveal();
+      return;
+    }
+    // Switching samples: dispose the old panel (its onDidDispose kills the
+    // dev-server child) and wait for that child to actually exit, so port 8080
+    // is free before the new server tries to bind it.
+    const dying = previewChild;
+    previewPanel.dispose();
+    const running = dying && dying.exitCode === null && dying.signalCode === null;
+    if (running) {
+      await new Promise((resolve) => {
+        const t = setTimeout(resolve, 3000); // fail-safe: never hang the command
+        dying.once("exit", () => {
+          clearTimeout(t);
+          resolve();
+        });
+      });
+    }
+  }
+
   if (!editor || !editor.document.fileName.endsWith(".mle")) {
     vscode.window.showErrorMessage(
       "MLE: open the project's .mle file first — the preview serves the project it belongs to."
     );
     return;
   }
-  const project = findMleProject(editor.document.fileName);
   if (!project) {
     vscode.window.showErrorMessage(
       `MLE: no functor.json with "language": "mle" found in any directory above ` +
@@ -145,6 +173,7 @@ async function openLivePreview() {
     cwd: project.dir,
   });
   previewChild = child;
+  previewProjectDir = project.dir;
   child.stdout.on("data", (d) => log(d.toString()));
   child.stderr.on("data", (d) => log(d.toString()));
   child.on("error", (e) => {
@@ -220,6 +249,7 @@ async function openLivePreview() {
     disposed = true;
     previewPanel = undefined;
     previewChild = undefined;
+    previewProjectDir = undefined;
     clearTimeout(debounce);
     clearTimeout(readyTimeout);
     changeSub.dispose();


### PR DESCRIPTION
## Problem

Recent type-system / language work runs great on **native** but several samples were broken in **wasm**. Two distinct issues:

1. **Multi-file modules didn't load in wasm.** The web runtime fetched only the game's *entry* file (`load_single_source`), so a game split across sibling modules (`file = module`, e.g. `hello-cubes`'s `game.mle` + `pieces.mle`) failed at draw time with `unknown external Pieces.centerpiece`. Native worked because it directory-scans the project.
2. **The lighting `record has no field eye/held` errors were a stale running server**, not a code bug — a `functor` dev server bound to `:8080` was serving a *different* project, and VSCode reuses whatever's already on `:8080`. Verified: current source handles lighting through every load path, and the rebuilt bundle is byte-identical.

## What this does

- **`mle`:** extract `load_sources_with_prelude`, the in-memory multi-source linker now shared by native (`load_with_prelude` delegates to it) and web — so both link identically (module names, span bases, protected-namespace + duplicate checks, prelude injection).
- **CLI + web:** the dev server injects the full project file list as `window.__mleProjectFiles`; the web runtime fetches every module and links them with the host prelude `.mlei` (matching native). A push-reload replaces only the entry buffer, keeping siblings.
- **Red DOM error overlay:** a broken load/push or a persistently-erroring `draw` now shows a red overlay with the exact `file:line:col` (React hot-reload style) instead of a blank canvas — and it **auto-clears** when `draw` recovers.
- **`npm run test:wasm-smoke` + CI:** loads every self-contained sample → pushes a reload → ticks frames → asserts no error overlay. Runs on software WebGL2 (`.github/workflows/wasm-smoke.yml`). This guards the whole native/wasm-divergence class the golden tests miss (goldens run under `--fixed-time`).
- **VSCode:** tear down the live preview when the active project changes, so it stops reusing a dev server bound to a different sample.

## Verification

- `cargo test -p mle -p functor_runtime_common` — green (added a `render_mle_index` array test).
- Strict native build (`cargo build --features=strict` in the desktop crate) — clean.
- `npm run test:wasm-smoke` — **10/10 samples pass**.
- Proven to be a real guard: hiding `pieces.mle` makes the smoke FAIL with the exact `unknown external Pieces.centerpiece`; restoring it passes.
- Cross-engine review (`/xreview`): no Critical/High/Medium findings.

## Follow-up (separate PR)

`examples/physics` flashes a one-frame `draw error: no body tagged "ball"` on load in free-running web: frame 1 yields zero fixed sub-frames (`accumulator < FIXED_DT`), so physics never reconciles before the first draw. Planned fix: have `GameClock::fixed_frames` emit one bootstrap `{dts:0}` frame on its first call. The smoke test tolerates it as a transient (recovers by frame 2), so CI stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)