### PR TITLE
fix(wasm): fall back on a missing asset instead of panicking

### DIFF
--- a/e2e/wasm-smoke.mjs
+++ b/e2e/wasm-smoke.mjs
@@ -70,25 +70,12 @@ const EXCLUDE = new Set([
   "wsdemo",
   "wsserverdemo",
 ]);
-
-// Whether the sample references a binary asset (glTF/texture/audio, fetched via
-// `npm run fetch:assets` and gitignored) that ISN'T present on disk. On CI —
-// asset-free by convention (golden.yml uses the asset-free primitives sample) —
-// those files 404, so we SKIP such a sample (loudly) rather than fail. Local
-// runs (assets fetched) still cover it. Checked per-referenced-file, because a
-// sample can commit SOME assets (e.g. a .png) yet fetch others (a .glb).
-// NOTE: a missing asset currently PANICS the wasm runtime ("RuntimeError:
-// unreachable") instead of falling back to the empty asset (docs/mle.md says it
-// should degrade) — tracked as a follow-up; until then the skip keeps this CI
-// check meaningful for the asset-free samples.
-function missingReferencedAssets(sample) {
-  const dir = `${ROOT}/examples/${sample}`;
-  const src = readFileSync(`${dir}/game.mle`, "utf8");
-  const refs = [...src.matchAll(/["']([^"']+\.(?:glb|png|jpg|wav))["']/gi)].map(
-    (m) => m[1],
-  );
-  return refs.some((ref) => !existsSync(`${dir}/${ref}`));
-}
+// A sample that references binary assets (glTF/texture/audio, fetched via
+// `npm run fetch:assets` and gitignored) runs fine WITHOUT them: a missing/404
+// asset degrades to the empty fallback (matching native — see
+// functor_runtime_common::io::load_bytes_async), so the sample still loads,
+// reloads, and ticks without an MLE error. So every sample runs on CI even
+// asset-free; the missing-asset path is itself worth exercising here.
 
 // The sample list: CLI args if given, else every examples/* with a functor.json
 // declaring `"language": "mle"`, minus the network demos.
@@ -272,13 +259,7 @@ async function smoke(sample) {
 
 let failures = 0;
 console.log(`wasm smoke: ${samples.length} sample(s)\n`);
-let skipped = 0;
 for (const sample of samples) {
-  if (missingReferencedAssets(sample)) {
-    skipped++;
-    console.log(`SKIP  ${sample} — references assets not present (run npm run fetch:assets to include it)`);
-    continue;
-  }
   let r;
   try {
     r = await smoke(sample);
@@ -297,11 +278,9 @@ for (const sample of samples) {
   }
 }
 
-const ran = samples.length - skipped;
-const skipNote = skipped ? ` (${skipped} skipped — assets not fetched)` : "";
 console.log(
   failures === 0
-    ? `\nALL ${ran} SAMPLES PASSED${skipNote}`
-    : `\n${failures} SAMPLE(S) FAILED${skipNote}`,
+    ? `\nALL ${samples.length} SAMPLES PASSED`
+    : `\n${failures} SAMPLE(S) FAILED`,
 );
 process.exit(failures === 0 ? 0 : 1);

--- a/runtime/functor-runtime-common/src/io/mod.rs
+++ b/runtime/functor-runtime-common/src/io/mod.rs
@@ -19,6 +19,14 @@ pub async fn load_bytes_async(path: &str) -> Result<Vec<u8>, String> {
             .dyn_into()
             .map_err(|_| "Failed to cast to Response")?;
 
+        // A missing asset must FAIL (like the native `File::open` path), not
+        // return the 404 page's body as if it were the asset — otherwise the
+        // glTF/PNG parser downstream chokes on that HTML and panics. Returning
+        // Err here routes into the asset system's fallback (empty) asset instead.
+        if !response.ok() {
+            return Err(format!("{}: HTTP {}", path, response.status()));
+        }
+
         let array_buffer = JsFuture::from(
             response
                 .array_buffer()


### PR DESCRIPTION
## Problem

On the **web** runtime, loading a game whose asset (glTF `.glb`, texture, audio)
**404s** crashed the whole wasm instance with `RuntimeError: unreachable`. The
frame loop then died — nothing rendered, and a pushed reload never applied.

Root cause: `io::load_bytes_async` (wasm) **never checked the HTTP status**, so a
404 returned the *error page's bytes* as if they were the asset, and the
glTF/PNG parser downstream panicked on that HTML. Native degrades gracefully
(its `File::open` returns `Err` on a missing file, which routes into the asset
system's empty fallback), so this was a native/wasm divergence — `docs/mle.md`
says a missing asset should render the fallback.

Surfaced by the wasm smoke test (#278): `hello`/`lighting` need fetched assets,
which CI doesn't have, so they 404'd and panicked.

## Fix

Check `response.ok()` and return `Err` on a non-2xx — **matching native** — so
the existing fallback machinery (`AssetHandle`'s `fallback_asset` on a failed
load, propagated via `?` in `asset_cache`) takes over instead of feeding garbage
to the parser. The audio path already handled the Err/garbage case (a bad decode
cleanly rejects); only the model/texture parse panicked.

With missing assets now safe, this also **drops the wasm-smoke skip** that
avoided the panic: every sample now runs on CI even without fetched assets
(rendering fallbacks), which exercises the missing-asset path as a regression
guard.

## Verification

- Hiding `examples/hello/*.glb` → the game now `loaded=true panicked=false`
  (before: `RuntimeError: unreachable`); renders fallback models.
- With `hello` + `lighting` assets hidden, both **pass the full smoke** (load →
  reload → tick → no error overlay).
- `npm run test:wasm-smoke`: all 10 samples pass (none skipped).
- `cargo test -p functor_runtime_common` green; strict native build clean
  (the change is in the wasm-only `cfg` block; native path unchanged).

Follow-up to #278 (surfaced by its wasm smoke test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)