### PR TITLE
fix(mle): lower MAX_EVAL_DEPTH to 128 so the cap fits a 2 MiB debug stack

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# MLE sources and the mle crate's golden files (.ast/.ir/.run/.trace/.check)
+# are byte-compared against LF-rendered output in tests — never CRLF-normalize
+# them on checkout, or the goldens diverge on Windows.
+*.mle text eol=lf
+*.ast text eol=lf
+*.check text eol=lf
+*.ir text eol=lf
+*.run text eol=lf
+*.trace text eol=lf

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -53,10 +53,10 @@ jobs:
 
       # Run the unit tests here (rather than a standalone job) to get coverage
       # across the whole OS matrix for free: this job already has the common
-      # runtime compiled. Scoped to functor_runtime_common, the only crate with
-      # tests.
+      # runtime compiled. The mle suite runs on the default test-thread stack —
+      # that is deliberate: it guards the MAX_EVAL_DEPTH-fits-2-MiB budget (#221).
       - name: Run tests
-        run: cargo test -p functor_runtime_common
+        run: cargo test -p functor_runtime_common -p mle
 
       # Building the web bundle is necessary for the CLI,
       # since the cli includes the web bundle for dev server

--- a/mle/src/eval.rs
+++ b/mle/src/eval.rs
@@ -43,15 +43,17 @@ use std::rc::Rc;
 /// host stack usage directly. Deep iteration belongs in the iterative builtins
 /// (`List.map`/`fold`), not user-level recursion.
 ///
-/// Kept at 200 through the currying migration (measured, debug build,
-/// Apple Silicon): 200 levels of the deepest recursion need ≈2.24 MiB of stack
-/// on this branch vs ≈2.18 MiB pre-currying — the call-site arity gate adds
-/// only ~320 bytes/level because the partial/over-application logic lives in an
-/// out-of-line `#[cold]` helper ([`Interp::call_curried`]), not `call`'s hot
-/// frame. Both already exceed a 2 MiB test-thread stack, so the suite runs with
-/// a bumped `RUST_MIN_STACK` regardless; the ~64 KiB currying delta is well
-/// within that and the 8 MiB release stack, so the cap need not drop.
-const MAX_EVAL_DEPTH: usize = 200;
+/// INVARIANT: the cap must trip *before* a default 2 MiB test-thread stack is
+/// exhausted in a debug build, so `cargo test -p mle` needs no `RUST_MIN_STACK`
+/// bump and the infinite-recursion test is a live guard on this budget
+/// (`error_infinite_recursion_is_a_clean_error` runs on the default stack; a
+/// per-frame regression shows up there as a stack overflow, not silently).
+///
+/// Measured 2026-07 (debug build, Apple Silicon): the deepest recursion costs
+/// ≈11.8 KiB of stack per eval level — 128 levels need ≈1.35 MiB, leaving ~50%
+/// frame-growth headroom under 2 MiB. 200 levels had grown past the budget
+/// (≈2.2 MiB), aborting the whole test binary on a clean tree (#221).
+const MAX_EVAL_DEPTH: usize = 128;
 
 /// Trace-event cap; see the module doc.
 pub const MAX_TRACE_EVENTS: usize = 10_000;

--- a/mle/tests/project.rs
+++ b/mle/tests/project.rs
@@ -32,6 +32,13 @@ impl Scratch {
     fn load(&self) -> Result<mle::project::Project, mle::project::ProjectError> {
         mle::project::load(&self.entry)
     }
+
+    /// Strip this scratch dir's prefix (with the platform's separator — `\`
+    /// on Windows) from a rendered `path:line:col` diagnostic.
+    fn strip_dir(&self, rendered: &str) -> String {
+        let prefix = format!("{}{}", self.dir.display(), std::path::MAIN_SEPARATOR);
+        rendered.replace(&prefix, "")
+    }
 }
 
 impl Drop for Scratch {
@@ -56,9 +63,7 @@ fn load_err(name: &str, files: &[(&str, &str)]) -> String {
         Err(err) => err,
         Ok(_) => panic!("project should fail to load"),
     };
-    let rendered = err.render();
-    let prefix = format!("{}/", scratch.dir.display());
-    rendered.replace(&prefix, "")
+    scratch.strip_dir(&err.render())
 }
 
 /// Run a scratch project's `main`.
@@ -493,7 +498,7 @@ fn unreferenced_sibling_diagnostics_surface_with_their_file() {
     let rendered = project
         .sources
         .render(diags[0].span.start, &diags[0].message);
-    let rendered = rendered.replace(&format!("{}/", scratch.dir.display()), "");
+    let rendered = scratch.strip_dir(&rendered);
     assert_eq!(err_line(&rendered), "util.mle:2:36");
 }
 


### PR DESCRIPTION
Fixes #221.

## Problem

On a clean `main`, `error_infinite_recursion_is_a_clean_error` overflowed the default 2 MiB test-thread stack before `MAX_EVAL_DEPTH = 200` could trip — a stack overflow aborts the whole `run` test binary (SIGABRT), so a stock debug `cargo test -p mle` was red and `UPDATE_GOLDENS=1` needed a `RUST_MIN_STACK` workaround. The cap's doc comment promised it fits a 2 MiB stack, but per-level debug frame size had grown past that budget.

## Fix

Option 1 from the issue — re-measure and lower the cap, keeping the "fits the default test stack" contract:

- Measured on this tree (debug, Apple Silicon): **cap 200 needs ~2.2 MiB** (threshold between 2176 and 2240 KiB); **cap 128 needs ~1.35 MiB** (threshold between 1280 and 1408 KiB) — ≈11.8 KiB per eval level, leaving ~50% frame-growth headroom under 2 MiB.
- Rewrote the constant's doc comment to state the invariant and record the measurement.
- No new test needed: `error_infinite_recursion_is_a_clean_error` now runs (and passes) on the default stack, so it *is* the live guard — future frame growth past the budget fails loudly there instead of only under a bumped `RUST_MIN_STACK`.
- **CI now runs the guard**: `build-native.yml` adds `-p mle` to the existing test step (the `mle` suite previously never ran in CI, which is how this regressed silently). It runs on the default test-thread stack deliberately, so the depth-cap budget is enforced across the ubuntu/windows/macos matrix.

## Windows fallout (pre-existing, surfaced by running the suite in CI)

Running the `mle` suite on the CI matrix for the first time exposed two latent Windows-only failures, fixed here so the new step lands green:

- **Golden CRLF**: the committed goldens (`.check`, and equally `.ast`/`.ir`/`.run`/`.trace`) are byte-compared against LF-rendered output, but Windows runners checked them out with CRLF via autocrlf. Fixed with a root `.gitattributes` pinning `.mle` sources and all golden extensions to `eol=lf`.
- **Path-separator stripping**: the project tests stripped the scratch temp dir from rendered diagnostics with a hard-coded `/`, so absolute `C:\...` paths leaked into 12 assertions. Fixed with a `Scratch::strip_dir` helper using `std::path::MAIN_SEPARATOR`.

Neither is related to the depth-cap change itself, which passed on all three OSes from the first run.

## Verification

- `cargo test -p mle` — 357 passed, 0 failed on a default stack (previously SIGABRT), debug build.
- `cargo test -p functor_runtime_common` — 215 passed, 0 failed (real game programs through the prelude, confirming nothing legitimate needs >128 levels; deep iteration goes through the iterative builtins by design).
- CI: the full check suite on this PR is green, including the new `mle` test step across ubuntu/windows/macos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
