### PR TITLE
fix(runtime): route ghost physics through an active-world scope

### DIFF
--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -313,6 +313,16 @@ pub fn ray_result_value(hit: Option<physics::RayHit>) -> EffectValue {
     ])
 }
 
+/// A raycast against the ACTIVE world (a world read, not an environment read)
+/// — shared by the live and dry-run runners, so both answer against whatever
+/// world is scoped (the live singleton, or a forward-step's throwaway world).
+fn active_world_raycast(origin: [f32; 3], dir: [f32; 3], max_dist: f32) -> EffectValue {
+    ray_result_value(
+        physics::with_world(physics::active_world(), |w| w.raycast(origin, dir, max_dist))
+            .flatten(),
+    )
+}
+
 /// The structured effect log keeps this many most-recent records — enforced
 /// INSIDE the drain, so the bound holds even mid-frame.
 pub const EFFECT_LOG_CAP: usize = 256;
@@ -413,10 +423,7 @@ impl EffectRunner for RealEffects {
         epoch_seconds()
     }
     fn raycast(&mut self, origin: [f32; 3], dir: [f32; 3], max_dist: f32) -> EffectValue {
-        ray_result_value(
-            physics::with_world(physics::DEFAULT_WORLD, |w| w.raycast(origin, dir, max_dist))
-                .flatten(),
-        )
+        active_world_raycast(origin, dir, max_dist)
     }
     fn random(&mut self) -> f64 {
         // xorshift64*; map the top 53 bits into [0, 1).
@@ -474,6 +481,32 @@ impl EffectRunner for FakeEffects {
         let v = self.ray_hits[self.next_ray % self.ray_hits.len()].clone();
         self.next_ray += 1;
         v
+    }
+}
+
+/// The dry-run forward-step's runner (docs/time-travel.md T6b): ENVIRONMENT
+/// reads (`now`/`random`) are deterministic — the projection must not depend
+/// on wall clock or entropy — but a raycast is a WORLD read, not an
+/// environment read, so it answers against the ACTIVE world (the forward-step
+/// scopes that to its throwaway projected world) exactly like the live runner.
+pub struct DryRunEffects(FakeEffects);
+
+impl DryRunEffects {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> DryRunEffects {
+        DryRunEffects(FakeEffects::new(0.0, vec![0.0]))
+    }
+}
+
+impl EffectRunner for DryRunEffects {
+    fn now(&mut self) -> f64 {
+        self.0.now()
+    }
+    fn random(&mut self) -> f64 {
+        self.0.random()
+    }
+    fn raycast(&mut self, origin: [f32; 3], dir: [f32; 3], max_dist: f32) -> EffectValue {
+        active_world_raycast(origin, dir, max_dist)
     }
 }
 
@@ -1534,7 +1567,7 @@ the game dir",
             // (reads like Physics.position — the live world, in-process).
             "Physics.timelineFrame" => match args.as_slice() {
                 [] => {
-                    let frame = physics::with_world(physics::DEFAULT_WORLD, |w| w.frame())
+                    let frame = physics::with_world(physics::active_world(), |w| w.frame())
                         .unwrap_or(0);
                     Ok(Value::Number(frame as f64))
                 }
@@ -2627,8 +2660,13 @@ dropping the rest"
                     physics::PhysicsCommand::Teleport { .. } => "physics.teleport",
                 };
                 let tag = command.tag_and_kind().0.to_string();
-                if !suppress_outbound {
-                    physics::with_world(physics::DEFAULT_WORLD, |w| w.queue_command(command));
+                // Outbound suppression protects the LIVE world (a dry run must
+                // not kick real bodies) — but a dry-run world SCOPE routes
+                // commands to its own throwaway world, which is exactly where a
+                // replayed kick belongs (docs/time-travel.md T6b).
+                let target = physics::active_world();
+                if !suppress_outbound || target != physics::DEFAULT_WORLD {
+                    physics::with_world(target, |w| w.queue_command(command));
                 }
                 log.push(EffectRecord {
                     kind,
@@ -3000,10 +3038,12 @@ fn body_of(value: &Value) -> Option<&physics::Body> {
     }
 }
 
-/// Live pose of a body in the singleton world (the world the shell steps —
-/// same process, same crate statics as this prelude).
+/// Live pose of a body in the ACTIVE world (normally the singleton world the
+/// shell steps — same process, same crate statics as this prelude; under a
+/// dry-run forward-step scope, the throwaway projected world, so ghost draws
+/// read the stepped poses — docs/time-travel.md T6b).
 fn live_transform(tag: &str) -> Option<([f32; 3], [f32; 4])> {
-    physics::with_world(physics::DEFAULT_WORLD, |w| w.body_transform(tag)).flatten()
+    physics::with_world(physics::active_world(), |w| w.body_transform(tag)).flatten()
 }
 
 fn no_body(tag: &str) -> String {
@@ -3666,6 +3706,84 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
         let scene3d = scene_of(&drawn).expect("a Scene");
         assert!((scene3d.xform.w.y as f64 - y).abs() < 1e-6);
 
+        crate::physics::remove_world(crate::physics::DEFAULT_WORLD);
+    }
+
+    // The dry-run world scope (docs/time-travel.md T6b): under an
+    // ActiveWorldScope, game-code physics readback answers against the SCOPED world
+    // (the ghost's projected world), and a suppressed-outbound drain routes
+    // commands to it — a replayed kick belongs to the throwaway world. Outside
+    // the scope everything resolves to the default world, and a suppressed
+    // drain with NO scope still queues nothing
+    // (`suppress_outbound_logs_but_queues_nothing`).
+    #[test]
+    fn physics_reads_and_commands_follow_the_active_world_scope() {
+        crate::physics::remove_world(crate::physics::DEFAULT_WORLD);
+        let ball_at = |y: f32| {
+            crate::physics::PhysicsScene::create(
+                [0.0, 0.0, 0.0],
+                vec![crate::physics::Body::dynamic(
+                    "ball".to_string(),
+                    crate::physics::Shape::Sphere { radius: 0.5 },
+                )
+                .at([0.0, y, 0.0])],
+            )
+        };
+        crate::physics::with_world(crate::physics::DEFAULT_WORLD, |w| w.reconcile(&ball_at(5.0)));
+        let scoped = crate::physics::create_world([0.0, 0.0, 0.0]);
+        crate::physics::with_world(scoped, |w| w.reconcile(&ball_at(9.0)));
+
+        let ball_y = || {
+            let drawn = eval("let main = () => Scene.sphere() |> Physics.transformed(\"ball\")");
+            scene_of(&drawn).expect("a Scene").xform.w.y
+        };
+        assert!((ball_y() - 5.0).abs() < 1e-6, "unscoped read = default world");
+        {
+            let _scope = crate::physics::ActiveWorldScope::enter(scoped);
+            assert!((ball_y() - 9.0).abs() < 1e-6, "scoped read = scoped world");
+
+            // A suppressed drain (the dry-run forward-step) under the scope
+            // queues the command on the SCOPED world…
+            let effect = eval("let main = () => Physics.applyImpulse(\"ball\", 2.0, 0.0, 0.0)");
+            let Value::HostData(data) = &effect else {
+                panic!("expected an Effect");
+            };
+            let tree = &data
+                .as_any()
+                .downcast_ref::<FunctorLangEffect>()
+                .expect("Effect")
+                .0;
+            let module =
+                functor_lang::lower(functor_lang::parse("let update = (m, msg) => m").unwrap())
+                    .unwrap();
+            let session = functor_lang::Session::load(&module, &mut FunctorHost)
+                .unwrap_or_else(|f| panic!("load failed: {}", f.error.message));
+            let mut model = Value::Number(0.0);
+            let mut log = EffectLog::new();
+            let mut runner = FakeEffects::new(0.0, vec![]);
+            let deferred = drain_effects(
+                &session,
+                &mut model,
+                tree.clone(),
+                &mut runner,
+                &mut log,
+                &mut |m| panic!("unexpected report: {m}"),
+                true, // suppress_outbound
+            );
+            assert!(deferred.is_empty(), "nothing should defer here");
+        }
+        crate::physics::with_world(scoped, |w| {
+            w.step_frame(1.0 / 60.0);
+            let v = w.body_velocity("ball").unwrap();
+            assert!(v[0] > 0.0, "impulse should land on the scoped world: {v:?}");
+        });
+        // …and the DEFAULT world got nothing.
+        crate::physics::with_world(crate::physics::DEFAULT_WORLD, |w| {
+            w.step_frame(1.0 / 60.0);
+            let v = w.body_velocity("ball").unwrap();
+            assert_eq!(v[0], 0.0, "default world must be untouched: {v:?}");
+        });
+        crate::physics::remove_world(scoped);
         crate::physics::remove_world(crate::physics::DEFAULT_WORLD);
     }
 

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -33,7 +33,7 @@ use crate::functor_lang_prelude::{
     contains_effect, deliver_physics_events, drain_effects, frame_value, http_response_value,
     needs_update, net_conn_subs, net_event_value, perform_deferred_queries, physics_event_taggers,
     physics_scene_value, split_model_effect, sub_messages_for_frame, take_audio_completion,
-    take_http_tagger, EffectLog, EffectRunner, EffectTree, FakeEffects, FunctorHost, NetEventKind,
+    take_http_tagger, DryRunEffects, EffectLog, EffectRunner, EffectTree, FunctorHost, NetEventKind,
 };
 use crate::input::{Key, RecordedInput};
 use crate::net::{push_conn_command, ConnCommand, HttpResult};
@@ -325,20 +325,16 @@ impl FrameCtx<'_> {
     ///
     /// The determinism boundary — where the projected model diverges from a
     /// live continuation (the physics WORLD snapshot is always exact):
-    /// - wall-clock `Now` / unseeded `Random` reads (the runner is deterministic
-    ///   here, so a game reading real time/entropy in the frame body won't
-    ///   match); a `tts`-driven / seeded game DOES match, since `tts` is
-    ///   supplied and the runner is deterministic.
-    /// - physics READBACK in the frame body (`Physics.position` /
-    ///   `Physics.transformed` / `Physics.raycast` / `Physics.timelineFrame`)
-    ///   resolves against the LIVE `DEFAULT_WORLD`, not this throwaway world, and
-    ///   physics COMMANDS (`applyImpulse` / `teleport` / …) are suppressed rather
-    ///   than applied to the throwaway world — so a game that reads physics state
-    ///   or issues physics commands from `tick` / `update` / `subscriptions`
-    ///   projects only approximately. Closing this needs a world-scoped host
-    ///   (follow-up, alongside the input log). The coast case the T6b test covers
-    ///   — a frame body that neither reads physics nor commands it — matches
-    ///   exactly, model AND world.
+    /// wall-clock `Now` / unseeded `Random` reads (the runner is deterministic
+    /// here, so a game reading real time/entropy in the frame body won't
+    /// match); a `tts`-driven / seeded game DOES match, since `tts` is
+    /// supplied and the runner is deterministic. Physics is NOT a boundary:
+    /// the caller scopes the throwaway world active
+    /// ([`physics::ActiveWorldScope`]), so readback in the frame body
+    /// (`Physics.position` / `Physics.transformed` / `Physics.raycast`)
+    /// answers against the projected world and physics COMMANDS
+    /// (`applyImpulse` / `teleport` / …) apply to it — a replayed kick kicks
+    /// the ghost.
     ///
     /// `inputs` is the recorded input log, now indexed per FINE step (not per
     /// division): index `s` = fine step `s`'s events, i.e. fork frame
@@ -716,13 +712,15 @@ impl Drop for DryWorld {
 /// The producer entry the shell / T6d call to run a deterministic headless
 /// forward-step (docs/time-travel.md T6b, forward-ghosting). It assembles a
 /// DRY-RUN [`FrameCtx`] over entirely THROWAWAY state — a cloned model, a
-/// silencing reporter, fresh logs/queues, a deterministic [`FakeEffects`]
+/// silencing reporter, fresh logs/queues, a deterministic [`DryRunEffects`]
 /// runner, `suppress_outbound = true`, and (when the game has physics) a
 /// throwaway physics world seeded from a snapshot of the live
-/// [`physics::DEFAULT_WORLD`] driven by a fresh [`SteppedPhysics::for_world`]
-/// — then steps the scene forward at the fine `sub_dt` (`steps_per_division`
-/// sub-ticks per snapshot), returning the stepped `(model, world-snapshot)` at
-/// each of the `divisions` division boundaries.
+/// [`physics::DEFAULT_WORLD`], driven by a fresh [`SteppedPhysics::for_world`]
+/// and scoped ACTIVE ([`physics::ActiveWorldScope`]) so game-code physics
+/// readback and commands resolve against it — then steps the scene forward at
+/// the fine `sub_dt` (`steps_per_division` sub-ticks per snapshot), returning
+/// the stepped `(model, world-snapshot)` at each of the `divisions` division
+/// boundaries.
 ///
 /// The live producer state (model, world, recorder, clock, and the global
 /// effect / net / audio queues) is COMPLETELY untouched: the throwaway world
@@ -765,11 +763,18 @@ pub fn forward_step_scene(
         Some(dry) => SteppedPhysics::for_world(dry.0),
         None => SteppedPhysics::new(),
     };
+    // Scope game-code physics to the throwaway world for the whole step:
+    // readbacks (`Physics.position` / `Physics.transformed` / `Physics.raycast`)
+    // in the stepped frame bodies answer against the PROJECTED world, and
+    // replayed commands (a recorded kick) apply to it — never the live world.
+    let _world_scope = dry_world
+        .as_ref()
+        .map(|dry| physics::ActiveWorldScope::enter(dry.0));
 
     let mut model = model.clone();
     let mut physics_status = (0u64, false, 0u64);
     let mut recorder = SceneRecorder::new();
-    let mut effect_runner = FakeEffects::new(0.0, vec![0.0]);
+    let mut effect_runner = DryRunEffects::new();
     let mut effect_log = EffectLog::new();
     let mut deferred_queries: Vec<EffectTree> = Vec::new();
     let mut pending_events: Vec<PhysicsEvent> = Vec::new();
@@ -808,9 +813,9 @@ pub fn forward_step_scene(
         ctx.step_scene_forward(divisions, steps_per_division, sub_dt, start_tts, inputs)
     };
 
-    // `dry_world`'s `Drop` removes the throwaway world here (and on any unwind
-    // from the step above), leaving the registry as found.
-    drop(dry_world);
+    // Natural drop order (declaration-reverse, also on unwind) restores the
+    // world scope FIRST, then `dry_world`'s `Drop` removes the throwaway world
+    // — so `active_world()` never points at a removed world.
     result
 }
 
@@ -818,8 +823,10 @@ pub fn forward_step_scene(
 /// both shells' `GameProducer::ghost_frames`. Step the scene forward over a
 /// window of `divisions` divisions, each `dt` wide, from `start_tts` (a dry run
 /// over throwaway state via [`forward_step_scene`] — the live producer is
-/// untouched), then `draw` each stepped model at its division-boundary time and
-/// return the frames for the shell to composite. To keep velocity-integrated
+/// untouched), then `draw` each stepped model at its division-boundary time —
+/// with that division's stepped WORLD snapshot scoped active, so
+/// `Physics.transformed` / `Physics.position` in `draw` render the projected
+/// poses — and return the frames for the shell to composite. To keep velocity-integrated
 /// motion (mario's jump) faithful, each division is advanced in FINE
 /// `sub_dt = 1/60` sub-steps (`steps_per_division ≈ dt / sub_dt`) and sampled
 /// only at the boundary, so the strobe still has `divisions` frames but each is
@@ -883,8 +890,28 @@ pub fn ghost_frames(
         steps_per_division,
         inputs,
     );
+    // Ghost draws must read the PROJECTED world: `Physics.transformed` /
+    // `Physics.position` in `draw` resolve against the active world, so each
+    // division's stepped world snapshot is restored into a throwaway world
+    // scoped active for that division's draw — otherwise every ghost frame
+    // would render physics bodies at the paused LIVE pose. One throwaway world
+    // is reused across divisions (each restore overwrites it); the `DryWorld`
+    // guard removes it on every exit path.
+    let draw_world = stepped
+        .iter()
+        .any(|(_, w)| w.is_some())
+        .then(|| DryWorld(physics::create_world([0.0, -9.81, 0.0])));
     let mut frames = Vec::with_capacity(stepped.len());
-    for (i, (model_i, _world)) in stepped.iter().enumerate() {
+    for (i, (model_i, world_i)) in stepped.iter().enumerate() {
+        let _world_scope = match (&draw_world, world_i) {
+            (Some(dry), Some(bytes)) => {
+                physics::with_world(dry.0, |w| {
+                    let _ = w.restore(bytes);
+                });
+                Some(physics::ActiveWorldScope::enter(dry.0))
+            }
+            _ => None,
+        };
         // Match forward_step_scene's f32 division-boundary tts exactly, so
         // each redrawn frame's tts equals the tts its model was stepped at.
         let tts = (start_tts as f32 + (i as f32 + 1.0) * steps_per_division as f32 * sub_dt) as f64;

--- a/runtime/functor-runtime-common/src/physics/registry.rs
+++ b/runtime/functor-runtime-common/src/physics/registry.rs
@@ -24,6 +24,38 @@ pub const DEFAULT_WORLD: WorldId = 0;
 thread_local! {
     static WORLDS: RefCell<BTreeMap<WorldId, World>> = const { RefCell::new(BTreeMap::new()) };
     static NEXT_ID: Cell<WorldId> = const { Cell::new(1) };
+    static ACTIVE_WORLD: Cell<WorldId> = const { Cell::new(DEFAULT_WORLD) };
+}
+
+/// The world game-code physics currently resolves against: readbacks
+/// (`Physics.position` / `Physics.transformed` / `Physics.raycast` /
+/// `Physics.timelineFrame`) and queued commands (`Physics.applyImpulse`, …) in
+/// the Functor Lang prelude target this world, not [`DEFAULT_WORLD`] directly. Live
+/// frames leave it at the default; the dry-run forward-step
+/// (docs/time-travel.md T6b) scopes it to a throwaway world via
+/// [`ActiveWorldScope`] so ghost frames read and command the projected world.
+pub fn active_world() -> WorldId {
+    ACTIVE_WORLD.with(|c| c.get())
+}
+
+/// RAII scope routing [`active_world`] to `id` until dropped. Nests: the guard
+/// restores whatever was active when it was entered (drop order must mirror
+/// entry order, which Rust scoping gives for free).
+pub struct ActiveWorldScope {
+    prev: WorldId,
+}
+
+impl ActiveWorldScope {
+    pub fn enter(id: WorldId) -> ActiveWorldScope {
+        let prev = ACTIVE_WORLD.with(|c| c.replace(id));
+        ActiveWorldScope { prev }
+    }
+}
+
+impl Drop for ActiveWorldScope {
+    fn drop(&mut self) {
+        ACTIVE_WORLD.with(|c| c.set(self.prev));
+    }
 }
 
 /// Create an explicit world with its own gravity, returning its id.
@@ -99,6 +131,25 @@ mod tests {
 
         remove_world(a);
         assert_eq!(with_world(a, |w| w.frame()), None);
+        remove_world(b);
+    }
+
+    #[test]
+    fn active_world_defaults_and_scopes_with_nesting() {
+        assert_eq!(active_world(), DEFAULT_WORLD);
+        let a = create_world([0.0, -9.81, 0.0]);
+        let b = create_world([0.0, 0.0, 0.0]);
+        {
+            let _outer = ActiveWorldScope::enter(a);
+            assert_eq!(active_world(), a);
+            {
+                let _inner = ActiveWorldScope::enter(b);
+                assert_eq!(active_world(), b);
+            }
+            assert_eq!(active_world(), a, "inner scope must restore the outer");
+        }
+        assert_eq!(active_world(), DEFAULT_WORLD, "scope must restore default");
+        remove_world(a);
         remove_world(b);
     }
 }

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -1946,4 +1946,119 @@ mod tests {
             "seek must drop input orphaned by the model restore"
         );
     }
+
+    /// Ghosting a PHYSICS game end-to-end (the world-scoped host,
+    /// docs/time-travel.md T6b): the ghost's `draw` calls resolve
+    /// `Physics.transformed` against each division's PROJECTED world — the
+    /// strobe shows the ball falling through its future poses, not N copies of
+    /// the paused pose — and a scripted input whose handler issues a physics
+    /// COMMAND (`Physics.applyImpulse`) kicks the projected ball, altering the
+    /// ghost trajectory. The live world stays byte-identical throughout.
+    #[test]
+    fn ghost_frames_project_physics_poses_and_replay_commands() {
+        use functor_runtime_common::{Key, RecordedInput};
+
+        physics::remove_world(physics::DEFAULT_WORLD);
+
+        let dir =
+            std::env::temp_dir().join(format!("functor-lang-ghost-phys-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create temp project dir");
+        std::fs::write(
+            dir.join("game.fun"),
+            "let init = { n: 0.0 }\n\
+             let tick = (m, dt, tts) => m\n\
+             let input = (m, key, isDown) =>\n\
+               match key with\n\
+               | \"K\" =>\n\
+                 (match isDown with\n\
+                  | true => (m, Physics.applyImpulse(\"ball\", 6.0, 0.0, 0.0))\n\
+                  | false => m)\n\
+               | _ => m\n\
+             let physics = (m) => Physics.scene(0.0, -9.81, 0.0, [\n\
+             \x20 Physics.fixed(\"ground\", Physics.box(10.0, 0.4, 10.0)) |> Physics.at(0.0, -0.2, 0.0),\n\
+             \x20 Physics.dynamic(\"ball\", Physics.sphere(0.5)) |> Physics.at(0.0, 4.0, 0.0)])\n\
+             let draw = (m, tts) => Frame.create(\n\
+               Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0),\n\
+               Scene.sphere() |> Physics.transformed(\"ball\"))\n",
+        )
+        .expect("write game");
+        let mut game = FunctorLangGame::create(dir.join("game.fun").to_str().expect("utf-8 path"));
+
+        // Drive to a fork point mid-fall (ticks record history; render seeds
+        // `last_frame`, whose camera the ghost freezes to).
+        const SUB_DT: f32 = 1.0 / 60.0;
+        const K: usize = 10;
+        let mut tts = 0.0f32;
+        for _ in 0..K {
+            tts += SUB_DT;
+            game.tick(FrameTime { tts, dts: SUB_DT });
+            game.render(FrameTime { tts, dts: SUB_DT });
+        }
+        let paused_y = game.last_frame.scene.xform.w.y;
+        assert!(
+            paused_y < 4.0 && paused_y > 3.0,
+            "fork mid-fall, y = {paused_y}"
+        );
+        let live_world_before = physics::with_world(physics::DEFAULT_WORLD, |w| w.snapshot());
+
+        // The strobe over ~1s in 4 divisions: each ghost frame's draw must
+        // read that division's projected world — falling, then resting.
+        const DIVISIONS: usize = 4;
+        const DT: f32 = 0.25;
+        let ghosts = game.ghost_frames(DIVISIONS, DT, tts as f64, None);
+        assert_eq!(ghosts.len(), DIVISIONS, "one frame per division");
+        let ys: Vec<f32> = ghosts.iter().map(|f| f.scene.xform.w.y).collect();
+        assert!(
+            ys[0] < paused_y - 0.5,
+            "division 0 must have fallen past the paused pose: {ys:?} vs {paused_y}"
+        );
+        for pair in ys.windows(2) {
+            // Allow a small settle-bounce near the slab (restitution), but the
+            // strobe must never show the ball climbing back up.
+            assert!(
+                pair[1] <= pair[0] + 0.1,
+                "the ghost ball must keep falling/settling: {ys:?}"
+            );
+        }
+        let rest_y = *ys.last().unwrap();
+        assert!(
+            (0.3..0.7).contains(&rest_y),
+            "the ghost ball should come to rest on the slab: {ys:?}"
+        );
+
+        // A scripted kick (K down at the first fine step) must alter the ghost:
+        // its handler returns Physics.applyImpulse, which applies to the
+        // PROJECTED world — the kicked ghost drifts in +x, the coast ghost
+        // stays on the fall line.
+        let steps = DIVISIONS * ((DT / SUB_DT).round() as usize).max(1);
+        let mut script: Vec<Vec<RecordedInput>> = vec![Vec::new(); steps];
+        script[0].push(RecordedInput::Key {
+            code: Key::K as i32,
+            is_down: true,
+        });
+        let kicked = game.ghost_frames(DIVISIONS, DT, tts as f64, Some(&script));
+        assert_eq!(kicked.len(), DIVISIONS);
+        let coast_x = ghosts.last().unwrap().scene.xform.w.x;
+        let kicked_x = kicked.last().unwrap().scene.xform.w.x;
+        assert!(coast_x.abs() < 1e-3, "coast ghost stays centered: {coast_x}");
+        assert!(
+            kicked_x > 1.0,
+            "the replayed kick must move the projected ball: {kicked_x}"
+        );
+
+        // The live producer and world are untouched by all of the above.
+        assert_eq!(
+            physics::with_world(physics::DEFAULT_WORLD, |w| w.snapshot()),
+            live_world_before,
+            "live world untouched by ghosting"
+        );
+        assert!(
+            (game.last_frame.scene.xform.w.y - paused_y).abs() < 1e-6,
+            "live frame untouched by ghosting"
+        );
+
+        physics::remove_world(physics::DEFAULT_WORLD);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }


### PR DESCRIPTION
Forward-ghosting (docs/time-travel.md T6d) stepped a throwaway copy of the physics world correctly, but every game-code read of physics still hit the LIVE world: `Physics.position`/`transformed`/`raycast` in the stepped frame bodies and in the ghost draws resolved against `DEFAULT_WORLD`, and physics commands were suppressed outright — so ghost frames rendered every body at the paused pose (the stepped world snapshots were computed and then discarded) and a replayed kick did nothing. This closes the "world-scoped host" follow-up documented on the T6b forward-step.

- `physics::active_world()` + `ActiveWorldScope` (registry): the world game-code physics resolves against; live frames leave it at the default.
- The prelude follows the scope: `live_transform`, raycasts (shared `active_world_raycast` helper), `Physics.timelineFrame`, and the command drain — a suppressed drain under a non-default scope queues commands to the scoped throwaway world (where a replayed kick belongs) instead of dropping them.
- `forward_step_scene` scopes its throwaway world for the whole step and runs the new `DryRunEffects` runner (deterministic now/random; raycasts answer against the active world — a world read, not an environment read).
- `ghost_frames` restores each division's stepped world snapshot into a throwaway world scoped active for that division's draw, so `Physics.transformed` in draw renders the projected poses.

**Tests:** an end-to-end desktop ghost test (the strobe shows the ball falling and settling; a scripted kick moves the projected ball; the live world stays byte-identical), a prelude scope test (reads + suppressed command routing), and a registry scope-nesting test.

**Verified visually** (headless `--ghost --fixed-time 1.0 --capture-frame` on `examples/physics`): the strobe now shows the ball and crates falling through their future poses down to rest on the slab; before this fix the ghost was indistinguishable from the paused frame.

Part 1/3 of the ghosting-reliability stack (physics scope → per-division frame time → timeline-API removal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Visuals

![Forward-ghost physics demo](https://gist.githubusercontent.com/tommy-xr/85e0a1715c9aa2fef5f04e5314bae437/raw/ghost-demo.gif)

<sub>`examples/physics` running live with `--ghost`: the solid bodies (ball + crates) fall and settle while the translucent ghost strobe precedes them into the future (~2s window, 8 divisions). 16 frames captured headlessly via `--capture-frame`, sweeping `--capture-time` 0.2s → 3.2s.</sub>

### Paused frame → ghost strobe

![Paused frame vs ghost strobe](https://gist.githubusercontent.com/tommy-xr/85e0a1715c9aa2fef5f04e5314bae437/raw/ghost-beforeafter.png)

<sub>Both captured at `--fixed-time 1.0`. Left: the frame with no ghost — bodies frozen mid-fall. Right: `--ghost` on — the strobe projects the bodies through their future poses down to rest. Before this fix, the ghost render of physics bodies was **identical to the left image** (every division drew the paused pose), so this composite doubles as an honest before/after without a cold rebuild of `main`.</sub>

![Ghost strobe still](https://gist.githubusercontent.com/tommy-xr/85e0a1715c9aa2fef5f04e5314bae437/raw/physics-ghost.png)
