### PR TITLE
fix(runtime): render each ghost frame at its own division time

### DIFF
--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -826,7 +826,10 @@ pub fn forward_step_scene(
 /// untouched), then `draw` each stepped model at its division-boundary time —
 /// with that division's stepped WORLD snapshot scoped active, so
 /// `Physics.transformed` / `Physics.position` in `draw` render the projected
-/// poses — and return the frames for the shell to composite. To keep velocity-integrated
+/// poses — and return the frames, each PAIRED with the division-boundary
+/// [`FrameTime`] it was drawn at (`dts = 0`: a still of the future), for the
+/// shell to composite — each at its own time, so render-time animation (the
+/// skinned-skeleton pose) advances through the strobe. To keep velocity-integrated
 /// motion (mario's jump) faithful, each division is advanced in FINE
 /// `sub_dt = 1/60` sub-steps (`steps_per_division ≈ dt / sub_dt`) and sampled
 /// only at the boundary, so the strobe still has `divisions` frames but each is
@@ -855,7 +858,7 @@ pub fn ghost_frames(
     dt: f32,
     start_tts: f64,
     script_inputs: Option<&[Vec<RecordedInput>]>,
-) -> Vec<Frame> {
+) -> Vec<(Frame, FrameTime)> {
     // Replay the recorded inputs for the frames AFTER the fork point K, so a
     // recorded jump/run ghosts (docs/time-travel.md T6b). The input log is
     // per-rendered-frame = per-fine-step (both 1/60), so it feeds the fine
@@ -914,15 +917,15 @@ pub fn ghost_frames(
         };
         // Match forward_step_scene's f32 division-boundary tts exactly, so
         // each redrawn frame's tts equals the tts its model was stepped at.
-        let tts = (start_tts as f32 + (i as f32 + 1.0) * steps_per_division as f32 * sub_dt) as f64;
-        let args = vec![model_i.clone(), Value::Number(tts)];
+        let tts = start_tts as f32 + (i as f32 + 1.0) * steps_per_division as f32 * sub_dt;
+        let args = vec![model_i.clone(), Value::Number(tts as f64)];
         // A draw error or non-Frame return for a division is skipped, not fatal.
         if let Ok(value) = session.call("draw", args, &mut FunctorHost) {
             if let Some(frame) = frame_value(&value) {
                 let mut frame = frame.clone();
                 // Freeze the view: composite only world motion, not the camera.
                 frame.camera = last_frame.camera.clone();
-                frames.push(frame);
+                frames.push((frame, FrameTime { dts: 0.0, tts }));
             }
         }
     }

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -131,10 +131,14 @@ pub trait GameProducer {
     }
 
     /// Forward-step the scene `divisions` fixed frames of `dt` seconds from
-    /// `start_tts` and return the drawn [`crate::Frame`] for each — the
+    /// `start_tts` and return the drawn [`crate::Frame`] for each, PAIRED with
+    /// the division-boundary [`crate::FrameTime`] the frame was drawn at — the
     /// forward-ghosting trajectory preview (docs/time-travel.md T6d). The shell
     /// composites the returned frames into one image (chronophotography), so
-    /// moving elements smear into a strobe of their future positions. Each frame
+    /// moving elements smear into a strobe of their future positions, and must
+    /// render EACH frame at ITS paired time so render-time animation (the
+    /// skinned-skeleton pose, sampled from the render pass's `tts`) advances
+    /// through the strobe instead of freezing at the paused pose. Each frame
     /// carries the *paused* camera so only world motion smears, not the view.
     ///
     /// `script_inputs` is the F2 forward-ghost-a-script mode (docs/time-travel.md
@@ -151,7 +155,7 @@ pub trait GameProducer {
         _dt: f32,
         _start_tts: f64,
         _script_inputs: Option<&[Vec<crate::RecordedInput>]>,
-    ) -> Vec<crate::Frame> {
+    ) -> Vec<(crate::Frame, crate::FrameTime)> {
         Vec::new()
     }
 

--- a/runtime/functor-runtime-common/src/renderer.rs
+++ b/runtime/functor-runtime-common/src/renderer.rs
@@ -196,11 +196,15 @@ target frame are ignored (depth 1 only)",
 /// framebuffer as a weighted average — the screen-space compositor (T5, the
 /// shared foundation for fork+overlay and forward-ghosting, docs/time-travel.md).
 ///
-/// Each frame renders through the same shadow + forward path as a normal frame,
-/// into its own full-viewport-sized RGBA8 target (keyed `__composite_{i}`, reused
-/// across frames), then `SceneContext::draw_composite` sums them in-shader. The
-/// composite lands in the default framebuffer *after* the forward work and before
-/// any UI overlay, so it shows up in `--capture-frame` PNGs.
+/// Each frame renders through the same shadow + forward path as a normal frame
+/// AT ITS OWN paired [`FrameTime`], into its own full-viewport-sized RGBA8
+/// target (keyed `__composite_{i}`, reused across frames), then
+/// `SceneContext::draw_composite` sums them in-shader. Per-frame time is what
+/// lets render-time animation (the skinned-skeleton pose, sampled from the
+/// render pass's `tts`) advance across a ghost strobe instead of freezing every
+/// division at the paused pose. The composite lands in the default framebuffer
+/// *after* the forward work and before any UI overlay, so it shows up in
+/// `--capture-frame` PNGs.
 ///
 /// Inputs beyond `MAX_COMPOSITE` are dropped; `weights` is truncated/normalized
 /// to the retained count (so equal weights average). Nested render targets inside
@@ -212,9 +216,8 @@ pub fn render_composited_frames(
     asset_cache: Arc<AssetCache>,
     scene_context: &SceneContext,
     shadow_map: &ShadowMap,
-    frames: &[Frame],
+    frames: &[(Frame, FrameTime)],
     weights: &[f32],
-    frame_time: FrameTime,
     viewport: Viewport,
     debug_render_mode: DebugRenderMode,
 ) {
@@ -227,9 +230,10 @@ pub fn render_composited_frames(
     }
     let weights = normalize_weights(&weights[..n]);
 
-    // 1. Render each input frame into its own full-viewport offscreen target.
+    // 1. Render each input frame into its own full-viewport offscreen target,
+    //    at its own frame time.
     let mut textures: Vec<glow::Texture> = Vec::with_capacity(n);
-    for (i, frame) in frames[..n].iter().enumerate() {
+    for (i, (frame, frame_time)) in frames[..n].iter().enumerate() {
         let id = format!("__composite_{i}");
         let clear = crate::fog::clear_color(frame.fog.as_ref());
         let desc = RenderTargetDescriptor {

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -639,7 +639,7 @@ impl Game for FunctorLangGame {
         dt: f32,
         start_tts: f64,
         script_inputs: Option<&[Vec<functor_runtime_common::RecordedInput>]>,
-    ) -> Vec<Frame> {
+    ) -> Vec<(Frame, FrameTime)> {
         // The body is shared (`functor_lang_producer::ghost_frames`) so both shells ghost
         // through one impl; this just hands it the producer's state.
         functor_runtime_common::functor_lang_producer::ghost_frames(
@@ -2008,7 +2008,18 @@ mod tests {
         const DT: f32 = 0.25;
         let ghosts = game.ghost_frames(DIVISIONS, DT, tts as f64, None);
         assert_eq!(ghosts.len(), DIVISIONS, "one frame per division");
-        let ys: Vec<f32> = ghosts.iter().map(|f| f.scene.xform.w.y).collect();
+        // Each frame is paired with its division-boundary time (the compositor
+        // renders it at that time, so render-time animation advances).
+        for (i, (_, ft)) in ghosts.iter().enumerate() {
+            let expected = tts + (i as f32 + 1.0) * DT;
+            assert!(
+                (ft.tts - expected).abs() < 1e-4,
+                "division {i} time: {} vs {expected}",
+                ft.tts
+            );
+            assert_eq!(ft.dts, 0.0, "a ghost frame is a still of the future");
+        }
+        let ys: Vec<f32> = ghosts.iter().map(|(f, _)| f.scene.xform.w.y).collect();
         assert!(
             ys[0] < paused_y - 0.5,
             "division 0 must have fallen past the paused pose: {ys:?} vs {paused_y}"
@@ -2039,8 +2050,8 @@ mod tests {
         });
         let kicked = game.ghost_frames(DIVISIONS, DT, tts as f64, Some(&script));
         assert_eq!(kicked.len(), DIVISIONS);
-        let coast_x = ghosts.last().unwrap().scene.xform.w.x;
-        let kicked_x = kicked.last().unwrap().scene.xform.w.x;
+        let coast_x = ghosts.last().unwrap().0.scene.xform.w.x;
+        let kicked_x = kicked.last().unwrap().0.scene.xform.w.x;
         assert!(coast_x.abs() < 1e-3, "coast ghost stays centered: {coast_x}");
         assert!(
             kicked_x > 1.0,

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -1274,7 +1274,10 @@ Escape again to quit"
                         xform: cgmath::Matrix4::from_translation(cgmath::vec3(6.0, 0.0, 0.0)),
                     };
                 }
-                let frames = [frame.clone(), frame_b];
+                let frames = [
+                    (frame.clone(), time.clone()),
+                    (frame_b, time.clone()),
+                ];
                 functor_runtime_common::render_composited_frames(
                     &gl,
                     shader_version,
@@ -1283,7 +1286,6 @@ Escape again to quit"
                     &shadow_map,
                     &frames,
                     &[0.5, 0.5],
-                    time.clone(),
                     viewport,
                     args.debug_render.into(),
                 );
@@ -1291,7 +1293,9 @@ Escape again to quit"
                 // Forward-ghosting (docs/time-travel.md T6d): composite the ~2s
                 // forward-stepped frames (computed above) at equal weight so moving
                 // elements strobe across their future and static geometry stays
-                // solid. Empty (→ this arm skipped) when --ghost is off or the
+                // solid. Each frame renders at ITS OWN division-boundary time, so
+                // render-time animation (the skinned pose) advances through the
+                // strobe. Empty (→ this arm skipped) when --ghost is off or the
                 // producer yields no frames, so live rendering is unchanged.
                 let weights = vec![1.0f32; ghost_frames.len()];
                 functor_runtime_common::render_composited_frames(
@@ -1302,7 +1306,6 @@ Escape again to quit"
                     &shadow_map,
                     &ghost_frames,
                     &weights,
-                    time.clone(),
                     viewport,
                     args.debug_render.into(),
                 );

--- a/runtime/functor-runtime-web/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-web/src/functor_lang_game.rs
@@ -501,7 +501,7 @@ impl GameProducer for FunctorLangWebGame {
         dt: f32,
         start_tts: f64,
         script_inputs: Option<&[Vec<functor_runtime_common::RecordedInput>]>,
-    ) -> Vec<Frame> {
+    ) -> Vec<(Frame, FrameTime)> {
         functor_runtime_common::functor_lang_producer::ghost_frames(
             &self.session,
             &self.model,

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -1189,7 +1189,10 @@ async fn run_async() -> Result<(), JsValue> {
                 Vec::new()
             };
 
-            // Shadow + forward passes, shared with the desktop runtime.
+            // Shadow + forward passes, shared with the desktop runtime. Each
+            // ghost frame renders at ITS OWN division-boundary time, so
+            // render-time animation (the skinned pose) advances through the
+            // strobe instead of freezing at the paused pose.
             if !ghosts.is_empty() {
                 functor_runtime_common::render_composited_frames(
                     &gl,
@@ -1199,7 +1202,6 @@ async fn run_async() -> Result<(), JsValue> {
                     &shadow_map,
                     &ghosts,
                     &vec![1.0f32; ghosts.len()],
-                    frame_time.clone(),
                     viewport,
                     debug_render_mode,
                 );


### PR DESCRIPTION
The compositor rendered every ghost division with the single paused `FrameTime`, but the skinned-skeleton pose is sampled at render time from the render pass's `tts` — so an animated model strobed across its future positions frozen in the paused pose. `ghost_frames` computed each division's boundary tts for `draw` and then dropped it.

- `mle_producer::ghost_frames` (and `GameProducer::ghost_frames`) now return each `Frame` paired with the `FrameTime` it was drawn at (`dts = 0`, a still of the future).
- `render_composited_frames` takes per-frame times (`&[(Frame, FrameTime)]`) and runs the shadow + forward passes for each input at its own time, so render-time animation advances through the strobe.
- Both shells pass the paired times through; the T5 composite demo pairs both copies with the live time (unchanged behavior).

**Tests:** the desktop ghost test asserts each returned frame carries its division-boundary time.

**Verified visually** (headless `--ghost --fixed-time 1.0 --capture-frame` on `examples/hello`): the skinned fish models now strobe through visibly different swim poses across the divisions instead of N copies of one frozen pose.

Part 2/3 of the ghosting-reliability stack. Stacked on #284.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Visuals

![ghost strobe demo — animated fish with per-division poses](https://gist.githubusercontent.com/tommy-xr/42763c363095e133a87139bb868f28fb/raw/ghost-demo.gif)

<sub>`examples/hello` with `--ghost --ghost-divisions 4`, sweeping `--fixed-time` 0→3s. Each ghost division now renders at its own future division time, so the skinned fish strobe through visibly different swim poses along the trajectory preview. Rendered headlessly via `--capture-frame` / `--fixed-time`.</sub>

![live frame vs ghost strobe at fixed-time 1.0](https://gist.githubusercontent.com/tommy-xr/42763c363095e133a87139bb868f28fb/raw/live-vs-ghost.png)

<sub>Left: the live frame (no `--ghost`) at `--fixed-time 1.0`. Right: the ghost strobe at the same time — note the differing fin/body poses across the overlapped copies. Before this fix, every ghost division rendered the identical paused pose, so the strobe was N copies of the frozen left-hand fish.</sub>

![ghost strobe still, fixed-time 1.0](https://gist.githubusercontent.com/tommy-xr/42763c363095e133a87139bb868f28fb/raw/hello-ghost.png)
