### PR TITLE
chore(physics): remove the game-facing timeline-control API

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -410,9 +410,6 @@ Physics.raycast(ox, oy, oz, dx, dy, dz, maxDist, tagger)   // -> Effect (QUERY):
 Physics.events(tagger)                                     // -> Sub (from `subscriptions`):
                                                            //   tagger gets {started, a, b,
                                                            //   sensor} per contact begin/end
-Physics.pause() / Physics.resume() / Physics.stepOnce()   // -> Effect: recorder controls
-Physics.rewindTo(frame)                                    // -> Effect: seek (resume = branch)
-Physics.timelineFrame()                                    // -> float: current fixed frame
 ```
 
 `Physics.position` / `Physics.transformed` read the live stepped world
@@ -458,15 +455,16 @@ a `Physics.sensor` body (no contact forces). Events for a pair whose body
 was despawned this frame are dropped (there is nothing left to name), and
 a frame's undelivered events never carry over.
 
-The physics drive is **recorded** (docs/physics.md, the culmination):
-`Physics.pause()`/`resume()`/`stepOnce()` freeze and single-step the
-simulation; `Physics.rewindTo(frame)` seeks the recorded timeline and
-`Physics.timelineFrame()` reads the current fixed frame (for scrub math,
-e.g. `rewindTo(timelineFrame() - 10.0)`). These are fire-and-forget
-effects (no tagger). Resuming after a rewind **branches** — the old future
-is discarded, so a different input replays a different timeline. History is
-bounded (~15s at 60Hz); rewind clamps to it. Everything is deterministic:
-replaying identical inputs from a rewind reproduces the run byte-for-byte.
+The physics drive is **recorded** (docs/physics.md), but time travel is the
+SHELL's tool, not a game API: the runner's scrubber overlay (`~` on desktop,
+the DOM scrubber on web) pauses, scrubs, and rewinds the whole scene — the
+MVU model and the physics world together (docs/time-travel.md). Resuming
+from a scrubbed frame **branches** — the old future is discarded. History
+is bounded (~15s at 60Hz). Everything is deterministic: replaying identical
+inputs from a rewind reproduces the run byte-for-byte. (The game-authored
+timeline effects — `Physics.pause`/`resume`/`stepOnce`/`rewindTo`/
+`timelineFrame` — were removed when the whole-game scrubber superseded
+them.)
 
 
 A runner-hosted game (`functor -d <project-dir> run native`, with

--- a/docs/physics.md
+++ b/docs/physics.md
@@ -15,14 +15,19 @@ roadmap table; the highlights:
 
 - **Declarative bodies** (`Physics.scene`/`dynamic`/`kinematic`/`fixed` + the
   divergence rule), **live reads** (`Physics.position`/`transformed`),
-  **commands** (impulse/force/velocity/teleport), **raycast queries**,
-  **collision events** (`Physics.events`), and **pause/rewind/replay**
-  (`Physics.pause`/`resume`/`stepOnce`/`rewindTo`) — all on the Functor Lang prelude,
+  **commands** (impulse/force/velocity/teleport), **raycast queries**, and
+  **collision events** (`Physics.events`) — all on the Functor Lang prelude,
   native + wasm.
 - **Determinism goldens**, the `Simulatable`/`Timeline` rewind seam, and a
   `--debug-render physics` collider-wireframe overlay (native).
-- `examples/physics` exercises the whole surface (K kick, R raycast, P/Left/
-  Right/G timeline scrub, contact-flash).
+- **Pause/rewind/replay is shell-owned**: the recorded drive powers the
+  whole-game scrubber (docs/time-travel.md), which restores model + world
+  together. The game-authored timeline effects this doc originally sketched
+  (`Physics.pause`/`resume`/`stepOnce`/`rewindTo`/`timelineFrame`) shipped in
+  Phase 6 and were later REMOVED once the scrubber superseded them — the
+  F#-era sketches below are the archival design, not the live surface.
+- `examples/physics` exercises the whole surface (K kick, R raycast,
+  contact-flash; scrub time with the shell scrubber overlay).
 
 **Not yet built:** the model-layer `Entities`/`Archetype` abstraction (5b),
 networked physics (7a/7b — the `mpserver`/`mpclient` demo), and cross-target
@@ -575,28 +580,19 @@ through `TimelineLog`: each substep is recorded with exactly the `Command`s
 that produce it (the frame's `DeclareScene` + any queued `PhysicsCommand`s),
 then run through `Simulatable::step` — the **same path a `seek` replays**, so
 live and replayed frames are byte-identical by construction (the recorder
-tests assert this). Controls arrive as tagger-less effects queued for the
-recorder (the world's command-queue pattern, one level up).
+tests assert this).
 
-The `examples/physics` bindings:
-
-- **P** -> `Physics.pause()` / `Physics.resume()` (toggle). Paused, real time
-  doesn't accumulate — resuming never fast-forwards.
-- **Left / Right** -> `Physics.rewindTo(Physics.timelineFrame() - 10.0)` /
-  `Physics.stepOnce()`. Scrub backward (10 fixed frames per key-repeat) and
-  single-step forward; `draw` reads the rewound world live
-  (`Physics.transformed`), so the scene visibly moves.
-- **G** -> `rewindTo(0)` + `resume` — deterministic **replay** from the oldest
-  recorded frame; pressing **K** mid-replay applies a fresh impulse and
-  **branches** the timeline (`TimelineLog::truncate_from` discards the old
-  future), demonstrating determinism-and-divergence live.
-
-The status overlay (`View`, the existing 2D text layer) shows **read-only
-status** — current fixed frame, history depth, the scrub keys — while paused;
-all *control* is via the keyboard, since egui input isn't wired. History is
-bounded (~15s at 60Hz, pruned each frame); `rewindTo` clamps to it. Frame 0's
-pre-step state is the empty world, so the rewind floor is frame 1 (the world's
-first stepped state) — reads never hit an empty world.
+**Control is shell-owned** (this changed after Phase 6 shipped): the recorder
+is driven by the whole-game scrubber (docs/time-travel.md) through
+`SteppedPhysics::rewind_to_frame` / `seek_to_frame`, which restore the world
+together with the MVU model. The original game-facing control effects
+(`Physics.pause`/`resume`/`stepOnce`/`rewindTo`/`timelineFrame`) and
+`examples/physics`'s P/Left/Right/G bindings were removed once the scrubber
+superseded them — a game no longer scripts its own timeline. Rewind-then-
+resume still **branches** (`TimelineLog::truncate_from` discards the old
+future). History is bounded (~15s at 60Hz, pruned each frame); rewind clamps
+to it. Frame 0's pre-step state is the empty world, so the rewind floor is
+frame 1 (the world's first stepped state) — reads never hit an empty world.
 
 ## Debug visualization (wireframes via Rapier's debug renderer)
 
@@ -687,7 +683,7 @@ It's worth building in two steps, because they exercise different machinery:
 | **4. Queries** | `Physics.raycast` as a deferred tagger effect over the B6.5 structured-payload broker (`EffectValue`); performed post-step for same-frame freshness; fake/replay runners can raycasts. `shapeCast` deferred until a game needs it. **Shipped (Functor Lang).** | native+wasm (Functor Lang) |
 | **5. Collision events** | `Physics.events(tagger)` sub: contact begin/end as `{started, a, b, sensor}` records, collected per fixed substep (rapier `ActiveEvents::COLLISION_EVENTS` on every collider), delivered post-step through `update`; `Simulatable::step` now returns the frame's events (the doc's original seam). **Shipped (Functor Lang).** | native+wasm (Functor Lang) |
 | **5b. Entity abstraction** | `Entities<'e>` + `Archetype` model-layer library, `Scene3D.instances` primitive, reconcile bail-out + tag interning, despawn-on-collision; `physics` grows a bullet/debris archetype. | both |
-| **6. Pause/rewind/replay** | `SteppedPhysics` recorder over the 1b `Timeline`: `Physics.pause`/`resume`/`stepOnce`/`rewindTo` control effects, `timelineFrame` read, per-fixed-frame recording (byte-identical to replay by construction), rewind-then-branch via `TimelineLog::truncate_from`, bounded history, read-only status overlay + keyboard scrub in `physics`. **Shipped (Functor Lang).** | native+wasm (Functor Lang) |
+| **6. Pause/rewind/replay** | `SteppedPhysics` recorder over the 1b `Timeline`: per-fixed-frame recording (byte-identical to replay by construction), rewind-then-branch via `TimelineLog::truncate_from`, bounded history. **Shipped**; the game-facing control effects (`Physics.pause`/`resume`/`stepOnce`/`rewindTo`/`timelineFrame`) and the example's keyboard scrub shipped here too but were later **removed** — the recorder now drives the shell-owned whole-game scrubber (docs/time-travel.md) via `rewind_to_frame`/`seek_to_frame`. | native+wasm (Functor Lang) |
 | **7a. Networked physics (state-sync)** | `Authority`, `mpserver`/`mpclient` grown to client-owned balls + server-owned objects, kinematic `Remote` + interpolation. No prediction. | both |
 | **7b. Prediction + reconciliation** | Server-authoritative ball, client input + prediction, structural `server`/`client` collections (network snapshot = `server`; reconcile = field swap), `Timeline` reconcile, `netsim_viz` ghosts + divergence metrics, latency-sweep convergence tests. | both |
 

--- a/docs/time-travel.md
+++ b/docs/time-travel.md
@@ -192,7 +192,7 @@ the overlay defaults to visible.
         │  TimelineLog<FrameTimeline>  (keyframe + input log, bounded) │
         │  one frame clock  ·  seek(N) restores model AND world       │
         │                                                             │
-        │  egui scrubber overlay  ── drives ──►  TimelineControl      │
+        │  egui scrubber overlay ── drives ─► rewind/seek_to_frame    │
         │   (shell-owned; `~` toggle; default-on web/VSCode)          │
         └─────────────────────────────────────────────────────────────┘
             native: functor (in-process)  │   wasm: web-runtime (= VSCode preview)

--- a/examples/physics/game.fun
+++ b/examples/physics/game.fun
@@ -8,11 +8,10 @@
 // record folds through `update`, which kicks whatever the ray hit — a query
 // chaining into a command, answered against this frame's stepped world.
 // Collision events (Physics.events) flash whatever the ball touches: the
-// touched crate glows until the ball's next contact. And the TIMELINE
-// (docs/physics.md, the culmination): P pauses (the overlay shows the
-// frame), Left scrubs BACKWARD through recorded history, Right steps one
-// fixed frame forward, G rewinds to the oldest recorded frame and resumes
-// — a live replay; kick differently this time and the timeline branches.
+// touched crate glows until the ball's next contact. Time travel is the
+// SHELL's job, not the game's: open the scrubber overlay (`~` on the
+// desktop runner) to pause, scrub, and rewind the whole scene — model and
+// physics world together (docs/time-travel.md).
 // Run with:
 //
 //   functor -d examples/physics run native
@@ -74,7 +73,7 @@ type Msg<'h, 'e> =
   | GotHit(hit: 'h)
   | Contact(ev: 'e)
 
-let init = { drop: 0.0, spaceHeld: false, hot: "", paused: false, pHeld: false }
+let init = { drop: 0.0, spaceHeld: false, hot: "" }
 
 let tick = (model, dt, tts) => model
 
@@ -105,33 +104,6 @@ let input = (model, key, isDown) =>
        (model,
         Physics.raycast(scatterX(model.drop, 0.0), 8.0, scatterZ(model.drop, 0.0),
                         0.0, -1.0, 0.0, 20.0, GotHit)))
-  | "P" =>
-    (match isDown with
-     | false => { model with pHeld: false }
-     | true =>
-       (match model.pHeld with
-        | true => model
-        | false =>
-          (match model.paused with
-           | false => ({ model with paused: true, pHeld: true }, Physics.pause())
-           | true => ({ model with paused: false, pHeld: true }, Physics.resume()))))
-  | "Left" =>
-    // Scrub: 10 fixed frames per press/repeat (key repeats make this a
-    // smooth reverse). The clamp to recorded history is the recorder's job.
-    (match isDown with
-     | false => model
-     | true => (model, Physics.rewindTo(Physics.timelineFrame() - 10.0)))
-  | "Right" =>
-    // One fixed frame forward (only meaningful while paused).
-    (match isDown with
-     | false => model
-     | true => (model, Physics.stepOnce()))
-  | "G" =>
-    // Replay: back to the oldest recorded frame, playing. Press K mid-replay
-    // and the timeline BRANCHES from that point.
-    (match isDown with
-     | false => model
-     | true => ({ model with paused: false }, Effect.batch([Physics.rewindTo(0.0), Physics.resume()])))
   | _ => model
 
 // Contact events name both tags in rapier's pair order — find the ball's

--- a/functor-prelude/prelude/physics.funi
+++ b/functor-prelude/prelude/physics.funi
@@ -50,7 +50,6 @@ let scene : (float, float, float, List<body>) => world
 
 // Reads of the LIVE stepped world (in-process, no boundary).
 let position : (string) => position
-let timelineFrame : () => float
 
 // world LAST (subject-last), so it pipes: place a visual at a body's live pose —
 // `Scene.cube() |> Physics.transformed("crate-1")`.
@@ -67,9 +66,3 @@ let raycast : (float, float, float, float, float, float, float, (rayHit) => 'msg
 
 // Collision-event SUB (what `subscriptions` returns).
 let events : ((collisionEvent) => 'msg) => Sub.t
-
-// Timeline-control EFFECTS.
-let pause : () => Effect.t
-let resume : () => Effect.t
-let stepOnce : () => Effect.t
-let rewindTo : (float) => Effect.t

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -221,10 +221,6 @@ pub enum EffectTree {
     /// The game observes the outcome through the physics reads, not a
     /// message.
     Physics(physics::PhysicsCommand),
-    /// A timeline control (docs/physics.md Phase 6): tagger-less, queued
-    /// for the recorder ([`physics::SteppedPhysics`]) like commands queue
-    /// for the world.
-    Timeline(physics::TimelineControl),
     /// Send text on an open connection (`Effect.send(id, text)`). Tagger-less
     /// like a physics command: performing it queues a `ConnCommand::Send` for
     /// the shell's connection manager.
@@ -908,11 +904,6 @@ const PATHS: &[&str] = &[
     "Physics.teleport",
     "Physics.raycast",
     "Physics.events",
-    "Physics.pause",
-    "Physics.resume",
-    "Physics.stepOnce",
-    "Physics.rewindTo",
-    "Physics.timelineFrame",
     "Sub.connect",
     "Sub.listen",
     "Effect.send",
@@ -1534,44 +1525,6 @@ the game dir",
                     other.kind_name()
                 )),
                 _ => usage("Physics.raycast(ox, oy, oz, dx, dy, dz, maxDist, tagger)"),
-            },
-            // Timeline-control EFFECTS (docs/physics.md Phase 6): pause /
-            // resume / stepOnce freeze and single-step the recorded physics
-            // drive; rewindTo(frame) seeks the timeline (resuming from there
-            // BRANCHES — the old future is discarded). Fire-and-forget.
-            "Physics.pause" | "Physics.resume" | "Physics.stepOnce" => match args.as_slice() {
-                [] => {
-                    let control = match path {
-                        "Physics.pause" => physics::TimelineControl::Pause,
-                        "Physics.resume" => physics::TimelineControl::Resume,
-                        _ => physics::TimelineControl::StepOnce,
-                    };
-                    Ok(host(FunctorLangEffect(EffectTree::Timeline(control))))
-                }
-                _ => usage(&format!("{path}()")),
-            },
-            "Physics.rewindTo" => match args.as_slice() {
-                [frame] => {
-                    // Clamping to the recorded range is the RECORDER's job, so
-                    // any finite frame is accepted here — in particular a
-                    // negative `timelineFrame() - 10.0` early on floors to 0,
-                    // rather than erroring before it reaches the clamp.
-                    let frame = num(frame, span)?.max(0.0) as u64;
-                    Ok(host(FunctorLangEffect(EffectTree::Timeline(
-                        physics::TimelineControl::RewindTo(frame),
-                    ))))
-                }
-                _ => usage("Physics.rewindTo(frame)"),
-            },
-            // The recorder's clock, for rewind math: the CURRENT fixed frame
-            // (reads like Physics.position — the live world, in-process).
-            "Physics.timelineFrame" => match args.as_slice() {
-                [] => {
-                    let frame = physics::with_world(physics::active_world(), |w| w.frame())
-                        .unwrap_or(0);
-                    Ok(Value::Number(frame as f64))
-                }
-                _ => usage("Physics.timelineFrame()"),
             },
             // Collision-event SUB (docs/physics.md Phase 5): what
             // `subscriptions` returns (alone or in Sub.batch). The tagger
@@ -2555,7 +2508,6 @@ pub fn needs_update(tree: &EffectTree) -> bool {
     match tree {
         EffectTree::None
         | EffectTree::Physics(_)
-        | EffectTree::Timeline(_)
         | EffectTree::Send { .. }
         // The request is fire-and-forget; its RESPONSE needs `update`, but
         // that arrives frames later through the producer's HTTP pump.
@@ -2672,26 +2624,6 @@ dropping the rest"
                     kind,
                     value: EffectValue::Text(tag),
                 });
-                if log.len() > EFFECT_LOG_CAP {
-                    log.remove(0);
-                }
-                continue;
-            }
-            EffectTree::Timeline(control) => {
-                let kind = match control {
-                    physics::TimelineControl::Pause => "physics.pause",
-                    physics::TimelineControl::Resume => "physics.resume",
-                    physics::TimelineControl::StepOnce => "physics.stepOnce",
-                    physics::TimelineControl::RewindTo(_) => "physics.rewindTo",
-                };
-                let value = match control {
-                    physics::TimelineControl::RewindTo(f) => EffectValue::Number(f as f64),
-                    _ => EffectValue::Bool(true),
-                };
-                if !suppress_outbound {
-                    physics::queue_timeline_control(control);
-                }
-                log.push(EffectRecord { kind, value });
                 if log.len() > EFFECT_LOG_CAP {
                     log.remove(0);
                 }

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -129,7 +129,9 @@ pub struct FrameCtx<'a> {
     pub session: &'a Session,
     pub model: &'a mut Value,
     pub physics_rt: &'a mut SteppedPhysics,
-    pub physics_status: &'a mut (u64, bool, u64),
+    /// The physics world's current fixed frame (what the coupled scene
+    /// recorder stores per rendered frame).
+    pub physics_frame: &'a mut u64,
     pub recorder: &'a mut SceneRecorder,
     pub effect_runner: &'a mut dyn EffectRunner,
     pub effect_log: &'a mut EffectLog,
@@ -175,7 +177,7 @@ impl FrameCtx<'_> {
             && self.recorder.commit_scrub_if_resuming(
                 self.model,
                 self.physics_rt,
-                self.physics_status,
+                self.physics_frame,
                 self.has_physics,
             )
         {
@@ -221,7 +223,7 @@ impl FrameCtx<'_> {
         // frame's steps, but also while PAUSED (frozen mid-flight, frame > 0)
         // and on a short zero-substep frame — so a raycast fired while paused
         // answers against the frozen world instead of deferring forever.
-        let world_ready = physics_steps > 0 || !self.has_physics || self.physics_status.0 > 0;
+        let world_ready = physics_steps > 0 || !self.has_physics || *self.physics_frame > 0;
         if world_ready && !self.deferred_queries.is_empty() {
             let deferred = std::mem::take(self.deferred_queries);
             let mut reports: Vec<String> = Vec::new();
@@ -274,8 +276,7 @@ impl FrameCtx<'_> {
 
     /// Record the settled model of this rendered frame (docs/time-travel.md T1)
     /// plus the physics fixed-frame the world reached, in lockstep, so a coupled
-    /// rewind can restore both. `physics_status.0` is the world's current fixed
-    /// frame.
+    /// rewind can restore both.
     ///
     /// Skip a PAUSED frame (`dts == 0`, i.e. the clock pinned): the sim hasn't
     /// advanced, so recording would only pile up frozen duplicates — inflating
@@ -289,7 +290,7 @@ impl FrameCtx<'_> {
             // both must land on the same frame (docs/time-travel.md T6b).
             self.recorder.record_inputs(std::mem::take(self.input_buf));
             self.recorder
-                .record(self.model, self.physics_status.0, frame_time.tts as f64);
+                .record(self.model, *self.physics_frame, frame_time.tts as f64);
         } else {
             // Paused frame (`dts == 0`): drain-and-drop the buffer. Paused frames
             // aren't part of the played timeline, so their buffered inputs must
@@ -534,7 +535,7 @@ to receive their messages; dropping them"
                     // through the Timeline, so pause/rewind/replay work.
                     let advanced = self.physics_rt.advance(scene, dts);
                     *self.pending_events = advanced.events;
-                    *self.physics_status = advanced.status;
+                    *self.physics_frame = advanced.frame;
                     let steps = advanced.steps;
                     let warnings = advanced.warnings;
                     // Command effects apply asynchronously (queued at perform
@@ -772,7 +773,7 @@ pub fn forward_step_scene(
         .map(|dry| physics::ActiveWorldScope::enter(dry.0));
 
     let mut model = model.clone();
-    let mut physics_status = (0u64, false, 0u64);
+    let mut physics_frame = 0u64;
     let mut recorder = SceneRecorder::new();
     let mut effect_runner = DryRunEffects::new();
     let mut effect_log = EffectLog::new();
@@ -796,7 +797,7 @@ pub fn forward_step_scene(
             session,
             model: &mut model,
             physics_rt: &mut physics_rt,
-            physics_status: &mut physics_status,
+            physics_frame: &mut physics_frame,
             recorder: &mut recorder,
             effect_runner: &mut effect_runner as &mut dyn EffectRunner,
             effect_log: &mut effect_log,

--- a/runtime/functor-runtime-common/src/physics/driver.rs
+++ b/runtime/functor-runtime-common/src/physics/driver.rs
@@ -1,5 +1,6 @@
-//! The recorded physics drive (docs/physics.md, Phase 6 — the culmination):
-//! pause / rewind / step / replay over the 1b `Timeline` seam.
+//! The recorded physics drive (docs/physics.md, Phase 6): per-fixed-frame
+//! recording over the 1b `Timeline` seam, powering the shell-owned scene
+//! rewind/seek (docs/time-travel.md T1/T3).
 //!
 //! [`SteppedPhysics`] replaces the drivers' direct `reconcile + step_frame`
 //! call with per-fixed-frame recording: each substep is recorded through
@@ -10,12 +11,11 @@
 //! byte-identical by construction (the strategy-equivalence goldens' claim,
 //! now load-bearing at runtime).
 //!
-//! Timeline CONTROLS (pause / resume / stepOnce / rewindTo) arrive as
-//! tagger-less effects, queued on a shell-side control queue (like physics
-//! commands, but targeting the recorder rather than the world) and applied
-//! at the next [`SteppedPhysics::advance`].
-
-use std::cell::RefCell;
+//! Rewind/seek is driven by the SHELL (the scrubber's coupled scene restore,
+//! via [`SteppedPhysics::rewind_to_frame`] / [`SteppedPhysics::seek_to_frame`]),
+//! not by game code — the game-authored timeline-control effects
+//! (`Physics.pause`/`rewindTo`/…) were removed when the whole-game scrubber
+//! superseded them.
 
 use super::{
     with_world, Command, PhysicsEvent, PhysicsScene, Simulatable, Timeline, TimelineLog, World,
@@ -30,78 +30,35 @@ const KEYFRAME_INTERVAL: u64 = 30;
 /// frame, so memory is bounded no matter how long the game runs.
 const HISTORY_FRAMES: u64 = 900;
 
-/// A control against the recorder (docs/physics.md Phase 6): plain data,
-/// queued by the `Physics.pause`/`resume`/`stepOnce`/`rewindTo` effects.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum TimelineControl {
-    Pause,
-    Resume,
-    /// Advance exactly one fixed frame while paused.
-    StepOnce,
-    /// Restore the pre-step state of this fixed frame and truncate the
-    /// recorded future (resuming from here BRANCHES the timeline).
-    RewindTo(u64),
-}
-
-thread_local! {
-    /// Pending timeline controls (the recorder's analogue of the world's
-    /// command queue). Bounded: a game without a physics drive must not leak.
-    static CONTROLS: RefCell<Vec<TimelineControl>> = const { RefCell::new(Vec::new()) };
-}
-
-const MAX_PENDING_CONTROLS: usize = 64;
-
-/// Queue a control for the next [`SteppedPhysics::advance`] (called by the
-/// effect drain, in-process — same seam as `World::queue_command`).
-pub fn queue_timeline_control(control: TimelineControl) {
-    CONTROLS.with(|c| {
-        let mut controls = c.borrow_mut();
-        if controls.len() < MAX_PENDING_CONTROLS {
-            controls.push(control);
-        }
-    });
-}
-
-fn take_timeline_controls() -> Vec<TimelineControl> {
-    CONTROLS.with(|c| std::mem::take(&mut *c.borrow_mut()))
-}
-
 /// What one [`SteppedPhysics::advance`] did, for the driver to surface.
 pub struct Advanced {
-    /// Fixed substeps simulated this frame (0 while paused or when the
-    /// accumulator hasn't reached a full step).
+    /// Fixed substeps simulated this frame (0 when the accumulator hasn't
+    /// reached a full step).
     pub steps: u32,
-    /// The frame's contact transitions (empty while paused).
+    /// The frame's contact transitions.
     pub events: Vec<PhysicsEvent>,
-    /// Command/control problems to report (deduped by the driver).
+    /// Command problems to report (deduped by the driver).
     pub warnings: Vec<String>,
-    /// The recorder's state after this frame, for status overlays:
-    /// `(current_fixed_frame, paused, recorded_history_len)`.
-    pub status: (u64, bool, u64),
+    /// The world's current fixed frame after this advance (what the coupled
+    /// scene recorder stores per rendered frame).
+    pub frame: u64,
 }
 
-/// The per-driver recorded physics drive. Owns the pause flag, the fixed-step
-/// accumulator, and the `TimelineLog` — the `World` itself stays in the
-/// registry (shared with reads, wireframes, and hot reload).
+/// The per-driver recorded physics drive. Owns the fixed-step accumulator and
+/// the `TimelineLog` — the `World` itself stays in the registry (shared with
+/// reads, wireframes, and hot reload).
 pub struct SteppedPhysics {
     world: WorldId,
     timeline: TimelineLog<World>,
-    paused: bool,
     accumulator: f32,
-    /// Whether any frame has simulated yet. The first non-paused advance is
-    /// floored to one step, so the world is reconciled+stepped before the
-    /// first draw even when the first frame's dt is short — otherwise
-    /// draw-time reads (`Physics.position`/`transformed`) would find an empty
-    /// world. (Reconcile lives INSIDE the recorded step so replay reproduces
-    /// it byte-exact, so we can't reconcile eagerly for draw — we step once
+    /// Whether any frame has simulated yet. The first advance is floored to
+    /// one step, so the world is reconciled+stepped before the first draw
+    /// even when the first frame's dt is short — otherwise draw-time reads
+    /// (`Physics.position`/`transformed`) would find an empty world.
+    /// (Reconcile lives INSIDE the recorded step so replay reproduces it
+    /// byte-exact, so we can't reconcile eagerly for draw — we step once
     /// instead.)
     started: bool,
-    /// A throwaway dry-run driver ([`Self::for_world`], docs/time-travel.md
-    /// T6b): it must NOT touch the process-global timeline-control queue that
-    /// [`advance`](Self::advance) otherwise drains, or a forward-step would eat
-    /// a live-pending `pause`/`rewind` and the live driver would miss it. Live
-    /// drivers set this false and consume controls as usual.
-    dry_run: bool,
 }
 
 impl Default for SteppedPhysics {
@@ -115,10 +72,8 @@ impl SteppedPhysics {
         SteppedPhysics {
             world: DEFAULT_WORLD,
             timeline: TimelineLog::keyframes(KEYFRAME_INTERVAL),
-            paused: false,
             accumulator: 0.0,
             started: false,
-            dry_run: false,
         }
     }
 
@@ -126,24 +81,21 @@ impl SteppedPhysics {
     /// fresh `TimelineLog` — the dry-run forward-step (docs/time-travel.md T6b)
     /// points this at a throwaway world (a restored snapshot of
     /// [`DEFAULT_WORLD`]) so it can step the scene forward WITHOUT touching the
-    /// live world/driver/timeline or the global control queue (`dry_run`).
+    /// live world/driver/timeline.
     ///
     /// The live driver's sub-frame state is deliberately NOT forked: `started`
     /// is false (so the first division floors to one fixed step — the `new`
-    /// bootstrap), `accumulator` is 0, and `paused` is false. So the projection
-    /// matches a live continuation exactly only for an UNPAUSED fork driven at a
-    /// full `FIXED_DT` with no accumulator residue (the coast case the T6b test
-    /// covers). Forking a paused scene, a sub-`FIXED_DT` accumulator phase, or
-    /// carrying timeline history for `rewindTo` is follow-up work (alongside the
-    /// input log).
+    /// bootstrap) and `accumulator` is 0. So the projection matches a live
+    /// continuation exactly only for a fork driven at a full `FIXED_DT` with no
+    /// accumulator residue (the case the T6b test covers). Forking a
+    /// sub-`FIXED_DT` accumulator phase, or carrying timeline history so the
+    /// projection itself could be scrubbed, is follow-up work.
     pub fn for_world(world: WorldId) -> SteppedPhysics {
         SteppedPhysics {
             world,
             timeline: TimelineLog::keyframes(KEYFRAME_INTERVAL),
-            paused: false,
             accumulator: 0.0,
             started: false,
-            dry_run: true,
         }
     }
 
@@ -154,73 +106,40 @@ impl SteppedPhysics {
         with_world(self.world, |w| w.snapshot())
     }
 
-    /// One rendered frame's worth of recorded physics: apply queued controls,
-    /// then simulate whole fixed substeps from `real_dt` (unless paused),
-    /// recording each through the Timeline. The declared `scene` reconciles
-    /// on the frame's first recorded substep — identical semantics to
-    /// `World::step_frame`, but every fixed frame is now seekable.
+    /// One rendered frame's worth of recorded physics: simulate whole fixed
+    /// substeps from `real_dt`, recording each through the Timeline. The
+    /// declared `scene` reconciles on the frame's first recorded substep —
+    /// identical semantics to `World::step_frame`, but every fixed frame is
+    /// now seekable.
     pub fn advance(&mut self, scene: &PhysicsScene, real_dt: f32) -> Advanced {
         let mut out = Advanced {
             steps: 0,
             events: Vec::new(),
             warnings: Vec::new(),
-            status: (0, self.paused, 0),
+            frame: 0,
         };
 
-        // Controls first, so a pause/rewind issued last frame takes effect
-        // before this frame simulates. A dry-run driver must NOT drain the
-        // process-global queue (it would steal a live-pending control); the
-        // forward-step suppresses timeline effects anyway, so it has none.
-        let mut step_once = false;
-        let controls = if self.dry_run {
-            Vec::new()
-        } else {
-            take_timeline_controls()
-        };
-        for control in controls {
-            match control {
-                TimelineControl::Pause => self.paused = true,
-                TimelineControl::Resume => self.paused = false,
-                TimelineControl::StepOnce => step_once = true,
-                TimelineControl::RewindTo(frame) => {
-                    self.rewind_to(frame, &mut out.warnings);
-                }
-            }
+        self.accumulator += real_dt.max(0.0);
+        // Bootstrap: guarantee the very first frame simulates one step so
+        // the world exists for the first draw. Floors, never adds — a
+        // full-dt first frame (the tests) still yields exactly one step.
+        if !self.started {
+            self.accumulator = self.accumulator.max(FIXED_DT);
         }
-
-        let simulate = if self.paused {
-            // Paused: real time doesn't accumulate (resuming later must not
-            // fast-forward), but an explicit stepOnce advances one frame.
-            self.accumulator = 0.0;
-            step_once
-        } else {
-            self.accumulator += real_dt.max(0.0);
-            // Bootstrap: guarantee the very first frame simulates one step so
-            // the world exists for the first draw. Floors, never adds — a
-            // full-dt first frame (the tests) still yields exactly one step.
-            if !self.started {
-                self.accumulator = self.accumulator.max(FIXED_DT);
-            }
-            self.accumulator >= FIXED_DT
-        };
+        let simulate = self.accumulator >= FIXED_DT;
         if simulate {
             self.started = true;
         }
 
         if simulate {
-            let steps = if self.paused {
-                1
-            } else {
-                let whole = (self.accumulator / FIXED_DT) as u32;
-                let steps = whole.min(MAX_SUBSTEPS_PER_FRAME);
-                self.accumulator -= steps as f32 * FIXED_DT;
-                if whole > MAX_SUBSTEPS_PER_FRAME {
-                    // Hitch: drop the whole-step backlog, keep the phase
-                    // (the same discipline as World::step_frame).
-                    self.accumulator %= FIXED_DT;
-                }
-                steps
-            };
+            let whole = (self.accumulator / FIXED_DT) as u32;
+            let steps = whole.min(MAX_SUBSTEPS_PER_FRAME);
+            self.accumulator -= steps as f32 * FIXED_DT;
+            if whole > MAX_SUBSTEPS_PER_FRAME {
+                // Hitch: drop the whole-step backlog, keep the phase
+                // (the same discipline as World::step_frame).
+                self.accumulator %= FIXED_DT;
+            }
             let (events, warnings) = with_world(self.world, |w| {
                 let mut events = Vec::new();
                 for i in 0..steps {
@@ -248,16 +167,15 @@ impl SteppedPhysics {
                 .prune(self.current_frame().saturating_sub(HISTORY_FRAMES));
         }
 
-        out.status = (self.current_frame(), self.paused, self.history_len());
+        out.frame = self.current_frame();
         out
     }
 
-    /// Rewind the recorded world to a fixed frame directly (the coupled
-    /// scene-rewind path, docs/time-travel.md T1) — the same seek the
-    /// `RewindTo` control performs, but callable in-process by the shell
-    /// rather than only through the effect-queued control. Returns any
-    /// clamp/range warnings. The coupled caller checks [`Self::seekable_range`]
-    /// first so this only ever runs on an exactly-restorable frame.
+    /// Rewind the recorded world to a fixed frame — the coupled scene-rewind
+    /// path (docs/time-travel.md T1), called in-process by the shell when a
+    /// time-travel branch commits. Returns any clamp/range warnings. The
+    /// coupled caller checks [`Self::seekable_range`] first so this only ever
+    /// runs on an exactly-restorable frame.
     pub fn rewind_to_frame(&mut self, frame: u64) -> Vec<String> {
         let mut warnings = Vec::new();
         self.rewind_to(frame, &mut warnings);
@@ -317,7 +235,7 @@ impl SteppedPhysics {
         let (lo, hi) = match self.recorded_range() {
             Some(range) => range,
             None => {
-                warnings.push("physics rewindTo: nothing recorded yet".to_string());
+                warnings.push("physics rewind: nothing recorded yet".to_string());
                 return;
             }
         };
@@ -325,7 +243,7 @@ impl SteppedPhysics {
             // Only the empty frame-0 exists — nothing meaningful to seek to
             // (frame 0's pre-step state is the empty world, before any
             // reconcile, which draw-reads can't use).
-            warnings.push("physics rewindTo: no stepped frame recorded yet".to_string());
+            warnings.push("physics rewind: no stepped frame recorded yet".to_string());
             return;
         }
         // Pre-step of fixed frame 0 is the empty world, so the practical floor
@@ -353,10 +271,6 @@ impl SteppedPhysics {
 
     fn current_frame(&self) -> u64 {
         with_world(self.world, |w| w.frame()).unwrap_or(0)
-    }
-
-    fn history_len(&self) -> u64 {
-        self.recorded_range().map(|(lo, hi)| hi - lo + 1).unwrap_or(0)
     }
 
     /// The seekable fixed-frame range `(oldest, newest)`, if anything has
@@ -398,63 +312,7 @@ mod tests {
 
     fn fresh() -> SteppedPhysics {
         remove_world(DEFAULT_WORLD);
-        let _ = take_timeline_controls(); // hygiene: prior test leftovers
         SteppedPhysics::new()
-    }
-
-    /// A dry-run driver (docs/time-travel.md T6b, the forward-step) must NOT
-    /// drain the process-global timeline-control queue: a live-pending
-    /// `pause`/`rewind` has to survive the forward-step for the live driver to
-    /// apply it. Without the `dry_run` guard the dry `advance` would steal it.
-    #[test]
-    fn dry_run_advance_leaves_global_controls_for_the_live_driver() {
-        let mut live = fresh();
-        live.advance(&scene_at(0), FIXED_DT); // seed a world to snapshot
-        let bytes = snapshot();
-
-        // A live-pending control, queued before the forward-step runs.
-        queue_timeline_control(TimelineControl::Pause);
-
-        // A dry-run driver over a throwaway world restored from the snapshot.
-        let dry_id = crate::physics::create_world([0.0, -9.81, 0.0]);
-        with_world(dry_id, |w| {
-            let _ = w.restore(&bytes);
-        });
-        let mut dry = SteppedPhysics::for_world(dry_id);
-        dry.advance(&scene_at(1), FIXED_DT);
-
-        // The control is untouched — still pending for the live driver.
-        assert_eq!(
-            take_timeline_controls(),
-            vec![TimelineControl::Pause],
-            "dry-run advance stole a live-pending timeline control"
-        );
-        remove_world(dry_id);
-        remove_world(DEFAULT_WORLD);
-    }
-
-    #[test]
-    fn pause_freezes_and_step_once_advances_exactly_one() {
-        let mut sp = fresh();
-        for t in 0..10 {
-            sp.advance(&scene_at(t), FIXED_DT);
-        }
-        let before = snapshot();
-        queue_timeline_control(TimelineControl::Pause);
-        let out = sp.advance(&scene_at(10), FIXED_DT);
-        assert_eq!(out.steps, 0);
-        assert!(out.status.1, "should report paused");
-        assert!(snapshot() == before, "paused frame must not simulate");
-        // Wall-clock passing while paused must not fast-forward on resume.
-        for t in 11..20 {
-            sp.advance(&scene_at(t), FIXED_DT * 3.0);
-        }
-        assert!(snapshot() == before);
-        // stepOnce advances exactly one fixed frame.
-        queue_timeline_control(TimelineControl::StepOnce);
-        let out = sp.advance(&scene_at(20), FIXED_DT);
-        assert_eq!(out.steps, 1);
-        assert!(snapshot() != before);
     }
 
     #[test]
@@ -472,19 +330,17 @@ mod tests {
         let end_a = snapshot();
 
         // Rewind to fixed frame 20 (pre-step state of 20 == post-step of 19
-        // == what we snapshotted before advancing frame 20).
-        queue_timeline_control(TimelineControl::Pause);
-        queue_timeline_control(TimelineControl::RewindTo(20));
-        let out = sp.advance(&scene_at(40), FIXED_DT);
-        assert!(out.warnings.is_empty(), "{:?}", out.warnings);
+        // == what we snapshotted before advancing frame 20) — the shell's
+        // coupled scene-rewind path.
+        let warnings = sp.rewind_to_frame(20);
+        assert!(warnings.is_empty(), "{warnings:?}");
         assert!(
             snapshot() == snap_20,
             "rewind must restore the recorded frame byte-exact"
         );
 
-        // Resume and replay the same declared scenes: local determinism makes
-        // the branch land byte-identical to run A.
-        queue_timeline_control(TimelineControl::Resume);
+        // Replay the same declared scenes: local determinism makes the branch
+        // land byte-identical to run A.
         for t in 20..40 {
             sp.advance(&scene_at(t), FIXED_DT);
         }
@@ -498,9 +354,8 @@ mod tests {
     fn rewind_clamps_to_recorded_history() {
         let mut sp = fresh();
         // Nothing recorded yet: rewind warns instead of panicking.
-        queue_timeline_control(TimelineControl::RewindTo(3));
-        let out = sp.advance(&scene_at(0), 0.0);
-        assert_eq!(out.warnings.len(), 1, "{:?}", out.warnings);
+        let warnings = sp.rewind_to_frame(3);
+        assert_eq!(warnings.len(), 1, "{warnings:?}");
 
         for t in 0..5 {
             sp.advance(&scene_at(t), FIXED_DT);
@@ -508,12 +363,12 @@ mod tests {
         // Past the newest end: clamped, no warning. (Rewinding to the OLDEST
         // frame truncates the entire history — by design: the future is
         // discarded — so the far-future clamp is tested first.)
-        queue_timeline_control(TimelineControl::RewindTo(9_999));
-        let out = sp.advance(&scene_at(5), 0.0);
-        assert!(out.warnings.is_empty(), "{:?}", out.warnings);
-        queue_timeline_control(TimelineControl::RewindTo(0));
-        let out = sp.advance(&scene_at(5), 0.0);
-        assert!(out.warnings.is_empty(), "{:?}", out.warnings);
+        let warnings = sp.rewind_to_frame(9_999);
+        assert!(warnings.is_empty(), "{warnings:?}");
+        // Below the recorded floor: clamped to it, no warning, no panic.
+        let warnings = sp.rewind_to_frame(0);
+        assert!(warnings.is_empty(), "{warnings:?}");
+        remove_world(DEFAULT_WORLD);
     }
 
     #[test]
@@ -522,40 +377,22 @@ mod tests {
         for t in 0..20 {
             sp.advance(&scene_at(t), FIXED_DT);
         }
-        // Same frame: rewind to 10 AND queue an impulse. The impulse must
+        // Same frame: queue an impulse, then rewind to 10. The impulse must
         // survive the seek and apply at the branch's first step.
-        queue_timeline_control(TimelineControl::RewindTo(10));
         with_world(DEFAULT_WORLD, |w| {
             w.queue_command(crate::physics::PhysicsCommand::ApplyImpulse {
                 tag: "a".to_string(),
                 impulse: [5.0, 0.0, 0.0],
             })
         });
+        let warnings = sp.rewind_to_frame(10);
+        assert!(warnings.is_empty(), "{warnings:?}");
         let out = sp.advance(&scene_at(20), FIXED_DT);
         assert!(out.warnings.is_empty(), "{:?}", out.warnings);
         // The branch's first step applied the +x impulse.
         let vx = with_world(DEFAULT_WORLD, |w| w.body_velocity("a").unwrap()[0]).unwrap();
         assert!(vx > 0.0, "the same-frame impulse was dropped by the rewind: vx={vx}");
-    }
-
-    #[test]
-    fn scrub_below_zero_clamps_without_erroring() {
-        // The example's `rewindTo(timelineFrame() - 10.0)` goes negative in
-        // the first 10 frames; the prelude floors it to 0 and the recorder
-        // clamps to the floor — no error, no panic.
-        let mut sp = fresh();
-        for t in 0..5 {
-            sp.advance(&scene_at(t), FIXED_DT);
-        }
-        queue_timeline_control(TimelineControl::Pause);
-        queue_timeline_control(TimelineControl::RewindTo(0)); // the floored negative
-        let out = sp.advance(&scene_at(5), 0.0);
-        assert!(out.warnings.is_empty(), "{:?}", out.warnings);
-        // And a rewind before ANY step warns rather than seeking the empty world.
-        let mut sp2 = fresh();
-        queue_timeline_control(TimelineControl::RewindTo(0));
-        let out = sp2.advance(&scene_at(0), 0.0);
-        assert_eq!(out.warnings.len(), 1, "{:?}", out.warnings);
+        remove_world(DEFAULT_WORLD);
     }
 
     #[test]
@@ -582,13 +419,12 @@ mod tests {
         // byte-identical proves commands replay. (Post-rewind the future is
         // truncated — a resumed run is a BRANCH and only re-runs what the
         // game issues again; that is the design, not a loss.)
-        queue_timeline_control(TimelineControl::Pause);
-        queue_timeline_control(TimelineControl::RewindTo(20));
-        let out = sp.advance(&scene_at(30), 0.0);
-        assert!(out.warnings.is_empty(), "{:?}", out.warnings);
+        let warnings = sp.rewind_to_frame(20);
+        assert!(warnings.is_empty(), "{warnings:?}");
         assert!(
             snapshot() == snap_20,
             "seek must re-apply recorded commands to land byte-exact"
         );
+        remove_world(DEFAULT_WORLD);
     }
 }

--- a/runtime/functor-runtime-common/src/physics/registry.rs
+++ b/runtime/functor-runtime-common/src/physics/registry.rs
@@ -28,8 +28,8 @@ thread_local! {
 }
 
 /// The world game-code physics currently resolves against: readbacks
-/// (`Physics.position` / `Physics.transformed` / `Physics.raycast` /
-/// `Physics.timelineFrame`) and queued commands (`Physics.applyImpulse`, …) in
+/// (`Physics.position` / `Physics.transformed` / `Physics.raycast`) and queued
+/// commands (`Physics.applyImpulse`, …) in
 /// the Functor Lang prelude target this world, not [`DEFAULT_WORLD`] directly. Live
 /// frames leave it at the default; the dry-run forward-step
 /// (docs/time-travel.md T6b) scopes it to a throwaway world via

--- a/runtime/functor-runtime-common/src/timetravel.rs
+++ b/runtime/functor-runtime-common/src/timetravel.rs
@@ -323,11 +323,11 @@ impl SceneRecorder {
         &mut self,
         model: &mut Value,
         physics: &mut SteppedPhysics,
-        physics_status: &mut (u64, bool, u64),
+        physics_frame: &mut u64,
         has_physics: bool,
     ) -> bool {
         if let Some(k) = self.scrub_pos.take() {
-            let _ = self.rewind_scene_to(k, model, physics, physics_status, has_physics);
+            let _ = self.rewind_scene_to(k, model, physics, physics_frame, has_physics);
             true
         } else {
             false
@@ -342,7 +342,7 @@ impl SceneRecorder {
         target: u64,
         model: &mut Value,
         physics: &mut SteppedPhysics,
-        physics_status: &mut (u64, bool, u64),
+        physics_frame: &mut u64,
         has_physics: bool,
     ) -> Result<String, String> {
         let (lo, hi) = self
@@ -356,7 +356,7 @@ impl SceneRecorder {
             // Warnings are empty on every reachable coupled seek: `physics_seek_
             // target` already validated `fixed` against the seekable range.
             let _ = physics.seek_to_frame(fixed);
-            physics_status.0 = physics.current_fixed_frame();
+            *physics_frame = physics.current_fixed_frame();
         }
         self.scrub_pos = Some(frame);
         Ok(format!("scrubbed to rendered frame {frame}"))
@@ -371,7 +371,7 @@ impl SceneRecorder {
         target: u64,
         model: &mut Value,
         physics: &mut SteppedPhysics,
-        physics_status: &mut (u64, bool, u64),
+        physics_frame: &mut u64,
         has_physics: bool,
     ) -> Result<String, String> {
         let (lo, hi) = self
@@ -383,7 +383,7 @@ impl SceneRecorder {
         *model = self.model_history.seek(frame).clone();
         if let Some(fixed) = physics_target {
             let _ = physics.rewind_to_frame(fixed);
-            physics_status.0 = physics.current_fixed_frame();
+            *physics_frame = physics.current_fixed_frame();
         }
         self.model_history.truncate_from(frame + 1);
         self.world_frame_history.truncate_from(frame + 1);
@@ -589,9 +589,9 @@ mod tests {
 
         let mut model = Value::Number(0.0);
         let mut physics = SteppedPhysics::new();
-        let mut status = (0u64, false, 0u64);
+        let mut frame = 0u64;
         // Non-destructively scrub back to frame 2 (has_physics = false).
-        rec.seek_scene_to(2, &mut model, &mut physics, &mut status, false)
+        rec.seek_scene_to(2, &mut model, &mut physics, &mut frame, false)
             .expect("seek");
         // A scrubbed frame draws at its recorded tts (2 * 10.0), and the model
         // restored in lockstep.
@@ -599,7 +599,7 @@ mod tests {
         assert_eq!(model.to_string(), Value::Number(2.0).to_string());
 
         // Scrub forward to frame 4: the override tracks the handle.
-        rec.seek_scene_to(4, &mut model, &mut physics, &mut status, false)
+        rec.seek_scene_to(4, &mut model, &mut physics, &mut frame, false)
             .expect("seek");
         assert_eq!(rec.scrub_render_tts(), Some(40.0));
     }

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -106,11 +106,12 @@ pub struct FunctorLangGame {
     /// `Physics.events` taggers of the current `subscriptions(model)`.
     pending_events: Vec<functor_runtime_common::physics::PhysicsEvent>,
     /// The recorded physics drive (docs/physics.md Phase 6): the Timeline
-    /// recorder + pause flag + fixed-step accumulator. The World stays in
-    /// the registry; this owns the rewind machinery over it.
+    /// recorder + fixed-step accumulator. The World stays in the registry;
+    /// this owns the rewind machinery over it (driven by the shell scrubber).
     physics_rt: physics::SteppedPhysics,
-    /// Latest recorder status for the overlay: (fixed frame, paused, history).
-    physics_status: (u64, bool, u64),
+    /// The physics world's fixed frame after the latest advance — what the
+    /// coupled scene recorder stores per rendered frame.
+    physics_frame: u64,
     /// The coupled time-travel recorder (docs/time-travel.md T1–T3): records the
     /// settled `model` + physics fixed-frame each rendered frame and seeks/
     /// rewinds them together. Shared with the web producer (one tested impl).
@@ -361,7 +362,7 @@ impl FunctorLangGame {
             deferred_queries: Vec::new(),
             pending_events: Vec::new(),
             physics_rt: physics::SteppedPhysics::new(),
-            physics_status: (0, false, 0),
+            physics_frame: 0,
             recorder: SceneRecorder::new(),
             input_buf: Vec::new(),
             live_conn_keys: std::collections::HashSet::new(),
@@ -383,7 +384,7 @@ impl FunctorLangGame {
             session: &self.session,
             model: &mut self.model,
             physics_rt: &mut self.physics_rt,
-            physics_status: &mut self.physics_status,
+            physics_frame: &mut self.physics_frame,
             recorder: &mut self.recorder,
             effect_runner: &mut self.effect_runner as &mut dyn EffectRunner,
             effect_log: &mut self.effect_log,
@@ -581,7 +582,7 @@ impl Game for FunctorLangGame {
             target,
             &mut self.model,
             &mut self.physics_rt,
-            &mut self.physics_status,
+            &mut self.physics_frame,
             self.has_physics,
         );
         if result.is_ok() {
@@ -665,7 +666,7 @@ impl Game for FunctorLangGame {
             target,
             &mut self.model,
             &mut self.physics_rt,
-            &mut self.physics_status,
+            &mut self.physics_frame,
             self.has_physics,
         );
         if result.is_ok() {
@@ -815,24 +816,7 @@ AudioScene.empty), got {}",
     }
 
     fn ui(&self) -> View {
-        // The game's own `ui` view, plus a read-only recorder status line
-        // while paused (docs/physics.md, the culmination) — shown only when
-        // paused so live play stays clean. All physics CONTROL is via the
-        // game's keyboard bindings (egui input isn't wired). Composing via a
-        // column keeps both: an `Empty` game view (e.g. physics has no
-        // `ui` hook) renders nothing, leaving just the status.
-        let (frame, paused, history) = self.physics_status;
-        if !paused {
-            return self.last_view.clone();
-        }
-        let status = View::Text {
-            text: format!(
-                "physics ⏸ frame {frame} · {history} recorded · Left/Right scrub · Space resume"
-            ),
-            color: [255, 255, 255],
-            font: None,
-        };
-        View::Column(vec![self.last_view.clone(), status])
+        self.last_view.clone()
     }
 
     fn state_debug(&self) -> String {
@@ -1599,7 +1583,7 @@ mod tests {
         let fork_tts = tts;
         let live_model_before = game.model.to_string();
         let live_world_before = physics::with_world(physics::DEFAULT_WORLD, |w| w.snapshot());
-        let live_frame_before = game.physics_status.0;
+        let live_frame_before = game.physics_frame;
 
         // Forward-step DIVISIONS divisions (STEPS_PER_DIV fine ticks each) from
         // the fork — a dry run over throwaway state.
@@ -1624,7 +1608,7 @@ mod tests {
             "live world untouched"
         );
         assert_eq!(
-            game.physics_status.0, live_frame_before,
+            game.physics_frame, live_frame_before,
             "live fixed frame untouched"
         );
 

--- a/runtime/functor-runtime-web/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-web/src/functor_lang_game.rs
@@ -86,11 +86,12 @@ pub struct FunctorLangWebGame {
     /// `Physics.events` taggers of the current `subscriptions(model)`.
     pending_events: Vec<functor_runtime_common::physics::PhysicsEvent>,
     /// The recorded physics drive (docs/physics.md Phase 6): the Timeline
-    /// recorder + pause flag + fixed-step accumulator. The World stays in
-    /// the registry; this owns the rewind machinery over it.
+    /// recorder + fixed-step accumulator. The World stays in the registry;
+    /// this owns the rewind machinery over it (driven by the shell scrubber).
     physics_rt: physics::SteppedPhysics,
-    /// Latest recorder status for the overlay: (fixed frame, paused, history).
-    physics_status: (u64, bool, u64),
+    /// The physics world's fixed frame after the latest advance — what the
+    /// coupled scene recorder stores per rendered frame.
+    physics_frame: u64,
     /// The coupled time-travel recorder (docs/time-travel.md T1–T3), shared with
     /// the desktop producer (one tested impl): records the settled `model` +
     /// physics fixed-frame each rendered frame and seeks/rewinds them together.
@@ -294,7 +295,7 @@ impl FunctorLangWebGame {
             deferred_queries: Vec::new(),
             pending_events: Vec::new(),
             physics_rt: physics::SteppedPhysics::new(),
-            physics_status: (0, false, 0),
+            physics_frame: 0,
             recorder: SceneRecorder::new(),
             input_buf: Vec::new(),
             live_conn_keys: std::collections::HashSet::new(),
@@ -388,7 +389,7 @@ impl FunctorLangWebGame {
             session: &self.session,
             model: &mut self.model,
             physics_rt: &mut self.physics_rt,
-            physics_status: &mut self.physics_status,
+            physics_frame: &mut self.physics_frame,
             recorder: &mut self.recorder,
             effect_runner: &mut self.effect_runner as &mut dyn EffectRunner,
             effect_log: &mut self.effect_log,
@@ -450,7 +451,7 @@ impl GameProducer for FunctorLangWebGame {
             target,
             &mut self.model,
             &mut self.physics_rt,
-            &mut self.physics_status,
+            &mut self.physics_frame,
             self.has_physics,
         );
         if result.is_ok() {
@@ -468,7 +469,7 @@ impl GameProducer for FunctorLangWebGame {
             target,
             &mut self.model,
             &mut self.physics_rt,
-            &mut self.physics_status,
+            &mut self.physics_frame,
             self.has_physics,
         );
         if result.is_ok() {


### PR DESCRIPTION
The whole-game scrubber (docs/time-travel.md T1–T3) restores model + world together and superseded the game-authored physics timeline: the effects (`Physics.pause`/`resume`/`stepOnce`/`rewindTo`), the `Physics.timelineFrame` read, the `TimelineControl` queue, and the driver's pause/step-once machinery had one consumer left — `examples/physics`'s P/Left/Right/G keys — and a game-authored `Physics.pause` actively confused the shell clock and the ghost's dry-run driver, which know nothing about it.

- **Prelude:** drop the five builtins, the `EffectTree::Timeline` variant/arm, and the `physics.funi` signatures.
- **Driver:** drop `TimelineControl`, the control queue/drain, the paused/step-once branches, and the `dry_run` guard (it existed only to protect the queue); `Advanced.status` `(frame, paused, history)` collapses to the one element anything read — `frame`. The recorded `TimelineLog` and the shell's `rewind_to_frame`/`seek_to_frame`/`seekable_range` stay: they power the scrubber. Driver tests now exercise rewind through `rewind_to_frame`.
- **Producer/shells:** `physics_status (u64, bool, u64)` collapses to `physics_frame: u64`; the desktop `ui()` overlay that advertised the removed keys is gone.
- **examples/physics:** the P/Left/Right/G handlers and `paused`/`pHeld` model fields removed; the header now points at the shell scrubber.
- **Docs/skill:** docs/physics.md's summary, Phase-6 roadmap row, and rewind narrative now record the ship-then-remove history; the functor-lang skill documents the removal; docs/time-travel.md's diagram points at `rewind/seek_to_frame`.

Net −500 lines. Cross-engine review (Claude + Codex) found no Critical/High issues on the stack; all findings (doc staleness, a drop-order wart, a duplicated raycast body) are addressed in the stack.

Part 3/3 of the ghosting-reliability stack. Stacked on #285.

🤖 Generated with [Claude Code](https://claude.com/claude-code)