### PR TITLE
feat(ui): the UI-event seam — slot-addressed widget events fold through update

### DIFF
--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -74,7 +74,17 @@ JSON is tagged by `type`. Unknown keys/shapes return **400** with a message.
 {"type":"key","key":"w","down":true}      // key press / release
 {"type":"mouse_move","x":10,"y":20}       // absolute cursor position
 {"type":"mouse_wheel","delta":1}          // scroll
+{"type":"ui_event","slot":0,"kind":"Clicked"}                  // click widget slot 0
+{"type":"ui_event","slot":1,"kind":{"SliderChanged":0.5}}      // drag slider slot 1
+{"type":"ui_event","slot":2,"kind":{"TextChanged":"hi"}}       // edit text input slot 2
 ```
+
+`ui_event` drives the game's interactive UI widgets without pixels or
+hit-testing (docs/ui-interaction.md): `slot` is the widget's index in the
+frame's `ui(model)` tree, in construction order over the interactive widgets.
+An event for a slot the current view doesn't have is dropped (with a one-line
+runtime report), and the endpoint still returns 200 — delivery, not handling,
+is what's acknowledged.
 
 ### `POST /time` — frame-loop control
 

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -2397,6 +2397,47 @@ pub fn clear_audio_completions() {
     PENDING_AUDIO.with(|m| m.borrow_mut().clear());
 }
 
+/// What an interactive UI widget delivers when the shell reports an
+/// interaction on it (docs/ui-interaction.md): either a message VALUE handed
+/// to `update` verbatim (a button — the `Sub.every` shape) or a TAGGER applied
+/// to the event's payload first (a slider / text input — the `Effect.now`
+/// shape).
+pub enum UiHandler {
+    Msg(Value),
+    Tagger(Value),
+}
+
+thread_local! {
+    /// The handler table for the `ui(model)` evaluation in progress: each
+    /// interactive `Ui.*` constructor pushes its handler and stamps the node
+    /// with the returned slot index (construction order). The producer drains
+    /// it with [`take_ui_handlers`] right after the evaluation and keeps it
+    /// beside the frame's cached `View`, so an event the shell reports later
+    /// resolves against the exact table that produced the tree it saw. Unlike
+    /// [`PENDING_HTTP`] this never spans frames — it is rebuilt every `ui`
+    /// evaluation — so hot reload needs no clearing here (the producer drops
+    /// its own kept copy instead).
+    static UI_HANDLERS: std::cell::RefCell<Vec<UiHandler>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
+/// Register a widget's handler for the `ui(model)` evaluation in progress and
+/// return its slot index (see [`UI_HANDLERS`]).
+pub fn push_ui_handler(handler: UiHandler) -> u32 {
+    UI_HANDLERS.with(|h| {
+        let mut handlers = h.borrow_mut();
+        handlers.push(handler);
+        (handlers.len() - 1) as u32
+    })
+}
+
+/// Drain the handlers the just-finished `ui(model)` evaluation registered.
+/// Call it after EVERY evaluation — including a failed one, whose partial
+/// table must not leak into the next frame's slots.
+pub fn take_ui_handlers() -> Vec<UiHandler> {
+    UI_HANDLERS.with(|h| std::mem::take(&mut *h.borrow_mut()))
+}
+
 #[derive(Clone, Copy)]
 pub enum NetEventKind {
     Connected,

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -33,7 +33,8 @@ use crate::functor_lang_prelude::{
     contains_effect, deliver_physics_events, drain_effects, frame_value, http_response_value,
     needs_update, net_conn_subs, net_event_value, perform_deferred_queries, physics_event_taggers,
     physics_scene_value, split_model_effect, sub_messages_for_frame, take_audio_completion,
-    take_http_tagger, DryRunEffects, EffectLog, EffectRunner, EffectTree, FunctorHost, NetEventKind,
+    take_http_tagger, take_ui_handlers, DryRunEffects, EffectLog, EffectRunner, EffectTree,
+    FunctorHost, NetEventKind, UiHandler,
 };
 use crate::input::{Key, RecordedInput};
 use crate::net::{push_conn_command, ConnCommand, HttpResult};
@@ -360,8 +361,19 @@ impl FrameCtx<'_> {
                 // so the model absorbs them exactly as the live frame did (coast
                 // when the log has no entry for this step).
                 if let Some(events) = inputs.get(step) {
+                    // A recorded UiEvent resolved against the LAST RENDER's
+                    // handler table live — the tree the user saw, built from
+                    // the settled model BEFORE this step's inputs. Rebuild
+                    // that table once here, at the step top, so a step with
+                    // several inputs can't resolve later UiEvents against a
+                    // tree an earlier input already re-shaped (xreview).
+                    let ui_handlers = events
+                        .iter()
+                        .any(|e| matches!(e, RecordedInput::UiEvent(_)))
+                        .then(|| self.eval_ui_handlers())
+                        .unwrap_or_default();
                     for event in events {
-                        self.replay_input(*event);
+                        self.replay_input(event.clone(), &ui_handlers);
                     }
                 }
                 let frame_time = FrameTime {
@@ -385,6 +397,26 @@ impl FrameCtx<'_> {
         out
     }
 
+    /// Evaluate `ui(model)` for its HANDLER TABLE only (the view is discarded)
+    /// — how the replay path reconstructs the table a recorded frame's
+    /// `UiEvent`s resolved against. A failed evaluation reports (silenced under
+    /// the dry-run reporter) and yields an empty table, so the events drop as
+    /// unknown slots.
+    fn eval_ui_handlers(&mut self) -> Vec<UiHandler> {
+        match self
+            .session
+            .call("ui", vec![self.model.clone()], &mut FunctorHost)
+        {
+            Ok(_) => take_ui_handlers(),
+            Err(err) => {
+                // A failed evaluation must not leak a partial table.
+                let _ = take_ui_handlers();
+                self.reporter.frame_error("ui", &err);
+                Vec::new()
+            }
+        }
+    }
+
     /// Replay one recorded input event during the forward-step, mirroring the
     /// LIVE path (`key_event`/`mouse_move`/`mouse_wheel`): call the game's
     /// `input`/`mouseMove`/`mouseWheel` entry point with the SAME reconstructed
@@ -392,8 +424,10 @@ impl FrameCtx<'_> {
     /// so nothing escapes). A `Key` re-runs `Key::from_i32` on the raw code just
     /// as the live path does; an unknown code is dropped, like live. An entry
     /// point the game doesn't define resolves to an interpreter error, reported
-    /// (and silenced) through the dry-run reporter.
-    fn replay_input(&mut self, event: RecordedInput) {
+    /// (and silenced) through the dry-run reporter. A `UiEvent` resolves against
+    /// `ui_handlers` — the step-top table the caller rebuilt (the live frame's
+    /// last-render contract).
+    fn replay_input(&mut self, event: RecordedInput, ui_handlers: &[UiHandler]) {
         let (entry, args) = match event {
             RecordedInput::Key { code, is_down } => {
                 let Some(key) = Key::from_i32(code) else {
@@ -418,6 +452,10 @@ impl FrameCtx<'_> {
             ),
             RecordedInput::MouseWheel { delta } => {
                 ("mouseWheel", vec![self.model.clone(), Value::Number(delta as f64)])
+            }
+            RecordedInput::UiEvent(event) => {
+                self.deliver_ui_event(ui_handlers, &event);
+                return;
             }
         };
         match self.session.call(entry, args, &mut FunctorHost) {
@@ -663,6 +701,73 @@ to receive their messages; dropping them"
         {
             Ok(msg) => msg,
             Err(err) => return self.reporter.frame_error("http response", &err),
+        };
+        match self
+            .session
+            .call("update", vec![self.model.clone(), msg], &mut FunctorHost)
+        {
+            Ok(returned) => self.absorb(returned),
+            Err(err) => self.reporter.frame_error("update", &err),
+        }
+    }
+
+    /// Route an interaction the shell detected on an interactive UI widget to
+    /// its handler and fold the resulting message through `update`
+    /// (docs/ui-interaction.md U2). `handlers` is the table the producer kept
+    /// from the `ui(model)` evaluation that built the tree the shell rendered
+    /// — slots resolve against exactly what the user saw. A verbatim-msg
+    /// handler (a button) ignores the event's payload; a tagger handler is
+    /// applied to it (a slider's new value, a text input's new text).
+    pub fn deliver_ui_event(&mut self, handlers: &[UiHandler], event: &crate::ui::UiEvent) {
+        use crate::ui::UiEventKind;
+        // Check the receiver exists before doing any work (the `absorb` rule)
+        // — a game with widgets but no `update` gets the teaching error, not
+        // a wasted tagger application.
+        if self.session.global("update").is_none() {
+            return self.reporter.report_once(
+                "[functor-lang] a ui widget produced a message but there is no \
+`let update = (model, msg) => …` to receive it; dropping it"
+                    .to_string(),
+            );
+        }
+        let Some(handler) = handlers.get(event.slot as usize) else {
+            return self.reporter.report_once(format!(
+                "[functor-lang] ui event for unknown widget slot {} (the view registered {}) — dropped",
+                event.slot,
+                handlers.len()
+            ));
+        };
+        let msg = match (handler, &event.kind) {
+            (UiHandler::Msg(msg), _) => msg.clone(),
+            (UiHandler::Tagger(tagger), UiEventKind::SliderChanged(value)) => {
+                match self.session.apply(
+                    tagger.clone(),
+                    vec![Value::Number(*value)],
+                    "ui event tagger",
+                    &mut FunctorHost,
+                ) {
+                    Ok(msg) => msg,
+                    Err(err) => return self.reporter.frame_error("ui event tagger", &err),
+                }
+            }
+            (UiHandler::Tagger(tagger), UiEventKind::TextChanged(text)) => {
+                match self.session.apply(
+                    tagger.clone(),
+                    vec![Value::String(std::rc::Rc::from(text.as_str()))],
+                    "ui event tagger",
+                    &mut FunctorHost,
+                ) {
+                    Ok(msg) => msg,
+                    Err(err) => return self.reporter.frame_error("ui event tagger", &err),
+                }
+            }
+            (UiHandler::Tagger(_), UiEventKind::Clicked) => {
+                return self.reporter.report_once(format!(
+                    "[functor-lang] ui click for slot {} reached a tagger handler — a click \
+carries no payload to tag; dropped",
+                    event.slot
+                ));
+            }
         };
         match self
             .session
@@ -931,4 +1036,171 @@ pub fn ghost_frames(
         }
     }
     frames
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::functor_lang_prelude::UiHandler;
+    use crate::ui::{UiEvent, UiEventKind};
+
+    /// A minimal MVU game with one message per widget shape: a verbatim msg
+    /// (the button contract) and taggers over a number / a string (the
+    /// slider / text-input contracts). The `expect*` globals are the models
+    /// the tests assert against (compared via `Display`, so the expectation
+    /// is built by the same evaluator as the result).
+    const SRC: &str = "\
+        type Msg = | Inc | SetN(n: Float) | SetS(s: String)\n\
+        type Model = { count: Float, n: Float, s: String }\n\
+        let init = { count: 0.0, n: 0.0, s: \"\" }\n\
+        let update = (m: Model, msg: Msg) =>\n\
+          match msg with\n\
+          | Inc => { m with count: m.count + 1.0 }\n\
+          | SetN(n) => { m with n: n }\n\
+          | SetS(s) => { m with s: s }\n\
+        let incMsg = Inc\n\
+        let setN = (v) => SetN(v)\n\
+        let setS = (v) => SetS(v)\n\
+        let expectInc = { count: 1.0, n: 0.0, s: \"\" }\n\
+        let expectSlider = { count: 0.0, n: 0.7, s: \"\" }\n\
+        let expectText = { count: 0.0, n: 0.0, s: \"hi\" }\n";
+
+    fn load_session() -> (Session, Value) {
+        let project = functor_lang::project::load_single_source("game", SRC)
+            .unwrap_or_else(|e| panic!("load: {}", e.render()));
+        let session = Session::load(&project.module, &mut FunctorHost)
+            .unwrap_or_else(|f| panic!("session: {}", f.error.message));
+        let model = session.global("init").expect("init");
+        (session, model)
+    }
+
+    /// Drive one `deliver_ui_event` through a throwaway [`FrameCtx`] (the
+    /// dry-run construction of `forward_step_scene`, minus physics).
+    fn deliver(session: &Session, model: &mut Value, handlers: &[UiHandler], event: &UiEvent) {
+        let mut physics_rt = SteppedPhysics::new();
+        let mut physics_frame = 0u64;
+        let mut recorder = SceneRecorder::new();
+        let mut effect_runner = DryRunEffects::new();
+        let mut effect_log = EffectLog::new();
+        let mut deferred_queries: Vec<EffectTree> = Vec::new();
+        let mut pending_events: Vec<PhysicsEvent> = Vec::new();
+        let mut live_conn_keys: HashSet<String> = HashSet::new();
+        let mut prev_tts: Option<f64> = None;
+        let mut input_buf: Vec<RecordedInput> = Vec::new();
+        let mut reporter = Reporter::new(
+            SpanSource::Single {
+                src: String::new(),
+                path: String::new(),
+            },
+            silent_emit,
+        );
+        let mut ctx = FrameCtx {
+            session,
+            model,
+            physics_rt: &mut physics_rt,
+            physics_frame: &mut physics_frame,
+            recorder: &mut recorder,
+            effect_runner: &mut effect_runner as &mut dyn EffectRunner,
+            effect_log: &mut effect_log,
+            deferred_queries: &mut deferred_queries,
+            pending_events: &mut pending_events,
+            live_conn_keys: &mut live_conn_keys,
+            prev_tts: &mut prev_tts,
+            input_buf: &mut input_buf,
+            has_physics: false,
+            has_subscriptions: false,
+            suppress_outbound: false,
+            reporter: &mut reporter,
+        };
+        ctx.deliver_ui_event(handlers, event);
+    }
+
+    fn assert_model(session: &Session, model: &Value, expected_global: &str) {
+        let expected = session.global(expected_global).expect(expected_global);
+        assert_eq!(model.to_string(), expected.to_string());
+    }
+
+    #[test]
+    fn ui_click_delivers_the_msg_through_update() {
+        let (session, mut model) = load_session();
+        let handlers = vec![UiHandler::Msg(session.global("incMsg").unwrap())];
+        deliver(
+            &session,
+            &mut model,
+            &handlers,
+            &UiEvent {
+                slot: 0,
+                kind: UiEventKind::Clicked,
+            },
+        );
+        assert_model(&session, &model, "expectInc");
+    }
+
+    #[test]
+    fn ui_slider_applies_the_tagger_to_the_new_value() {
+        let (session, mut model) = load_session();
+        // Slot 1: also proves slot addressing picks the right handler.
+        let handlers = vec![
+            UiHandler::Msg(session.global("incMsg").unwrap()),
+            UiHandler::Tagger(session.global("setN").unwrap()),
+        ];
+        deliver(
+            &session,
+            &mut model,
+            &handlers,
+            &UiEvent {
+                slot: 1,
+                kind: UiEventKind::SliderChanged(0.7),
+            },
+        );
+        assert_model(&session, &model, "expectSlider");
+    }
+
+    #[test]
+    fn ui_text_change_applies_the_tagger_to_the_new_text() {
+        let (session, mut model) = load_session();
+        let handlers = vec![UiHandler::Tagger(session.global("setS").unwrap())];
+        deliver(
+            &session,
+            &mut model,
+            &handlers,
+            &UiEvent {
+                slot: 0,
+                kind: UiEventKind::TextChanged("hi".to_string()),
+            },
+        );
+        assert_model(&session, &model, "expectText");
+    }
+
+    #[test]
+    fn ui_event_for_an_unknown_slot_is_dropped() {
+        let (session, mut model) = load_session();
+        let handlers = vec![UiHandler::Msg(session.global("incMsg").unwrap())];
+        deliver(
+            &session,
+            &mut model,
+            &handlers,
+            &UiEvent {
+                slot: 9,
+                kind: UiEventKind::Clicked,
+            },
+        );
+        assert_model(&session, &model, "init"); // unchanged
+    }
+
+    #[test]
+    fn ui_click_on_a_tagger_handler_is_dropped() {
+        let (session, mut model) = load_session();
+        let handlers = vec![UiHandler::Tagger(session.global("setN").unwrap())];
+        deliver(
+            &session,
+            &mut model,
+            &handlers,
+            &UiEvent {
+                slot: 0,
+                kind: UiEventKind::Clicked,
+            },
+        );
+        assert_model(&session, &model, "init"); // unchanged
+    }
 }

--- a/runtime/functor-runtime-common/src/input.rs
+++ b/runtime/functor-runtime-common/src/input.rs
@@ -54,7 +54,8 @@ pub enum Key {
 /// `key_event`/`mouse_move`/`mouse_wheel` and flush a frame's worth into the
 /// recorder; the forward-step replays them. (`Serialize`/`Deserialize` are for
 /// the future on-disk/wire event log, T7 — unused by the in-session replay.)
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+/// (Not `Copy`: `UiEvent` can carry a text payload.)
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum RecordedInput {
     /// A keyboard event carrying the raw `Key as i32` code (not the resolved
     /// `Key`), so replay re-runs `Key::from_i32` exactly as the live path does.
@@ -63,6 +64,10 @@ pub enum RecordedInput {
     MouseMove { x: i32, y: i32 },
     /// A wheel notch (±1 per notch).
     MouseWheel { delta: i32 },
+    /// An interaction on an interactive UI widget (slot-addressed — see
+    /// [`crate::ui::UiEvent`]). Replay rebuilds the frame's handler table from
+    /// `ui(model)` and re-delivers, so UI-driven model changes replay too.
+    UiEvent(crate::ui::UiEvent),
 }
 
 impl Key {

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -17,6 +17,9 @@
 //!   **`i32` discriminants** are the wire representation on both sides
 //!   (mirrored by F# `Input.ofKeyCode`) — inserting a variant mid-enum is a
 //!   protocol break even though serde names don't change.
+//! - [`crate::ui::UiEvent`] — an interaction on an interactive UI widget
+//!   (slot-addressed; see docs/ui-interaction.md), delivered like the input
+//!   scalars above.
 //!
 //! # Per-frame, logic → runtime
 //!
@@ -178,6 +181,12 @@ pub trait GameProducer {
 
     /// Deliver a mouse-wheel event (vertical scroll offset).
     fn mouse_wheel(&mut self, delta: i32);
+
+    /// Deliver an interaction on an interactive UI widget
+    /// ([`crate::ui::UiEvent`], slot-addressed — docs/ui-interaction.md). The
+    /// default drops it: the honest no-op for producers with no interactive
+    /// UI (replays, producers whose games define no `ui`).
+    fn ui_event(&mut self, _event: crate::ui::UiEvent) {}
 
     fn render(&mut self, frame_time: crate::FrameTime) -> crate::Frame;
 
@@ -522,6 +531,36 @@ mod tests {
         // The exact hop the runtimes use (audio_scene_json).
         let back: AudioScene = serde_json::from_str(&crate::audio::scene_to_json(&scene)).unwrap();
         assert_eq!(scene, back);
+    }
+
+    // The UI-interaction event (docs/ui-interaction.md U2): slot-addressed,
+    // one variant per widget kind. Crosses the debug-server wire and the
+    // recorder's event log.
+    #[test]
+    fn ui_event_is_pinned() {
+        use crate::ui::{UiEvent, UiEventKind};
+
+        assert_wire(
+            &UiEvent {
+                slot: 0,
+                kind: UiEventKind::Clicked,
+            },
+            r#"{"slot":0,"kind":"Clicked"}"#,
+        );
+        assert_wire(
+            &UiEvent {
+                slot: 2,
+                kind: UiEventKind::SliderChanged(0.5),
+            },
+            r#"{"slot":2,"kind":{"SliderChanged":0.5}}"#,
+        );
+        assert_wire(
+            &UiEvent {
+                slot: 1,
+                kind: UiEventKind::TextChanged("hi".to_string()),
+            },
+            r#"{"slot":1,"kind":{"TextChanged":"hi"}}"#,
+        );
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/ui.rs
+++ b/runtime/functor-runtime-common/src/ui.rs
@@ -98,6 +98,29 @@ impl View {
     }
 }
 
+/// An interaction the shell detected on an interactive [`View`] widget,
+/// delivered to the producer via `GameProducer::ui_event` and folded through
+/// the game's `update` (docs/ui-interaction.md U2). `slot` addresses the
+/// widget: interactive `Ui.*` constructors register their handler (a msg or a
+/// tagger) in a per-frame table during `ui(model)` evaluation, in construction
+/// order, and stamp the node with the index. Serializable — it crosses the
+/// debug-server wire (`POST /input`) and is recorded for replay.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct UiEvent {
+    pub slot: u32,
+    pub kind: UiEventKind,
+}
+
+/// What happened to the widget. `Clicked` pairs with a verbatim-msg handler
+/// (a button); the payload-carrying kinds pair with a tagger applied to the
+/// new value (a slider / text input).
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum UiEventKind {
+    Clicked,
+    SliderChanged(f64),
+    TextChanged(String),
+}
+
 /// Point size of the overlay's monospace text.
 const UI_FONT_SIZE: f32 = 14.0;
 /// Inset of an anchored panel from the screen edge, in points.

--- a/runtime/functor-runtime-desktop/src/debug_server.rs
+++ b/runtime/functor-runtime-desktop/src/debug_server.rs
@@ -61,13 +61,21 @@ impl RuntimeState {
 /// An input event to inject via `POST /input`. JSON is tagged by `type`:
 /// `{"type":"key","key":"w","down":true}`,
 /// `{"type":"mouse_move","x":10,"y":20}`,
-/// `{"type":"mouse_wheel","delta":1}`.
+/// `{"type":"mouse_wheel","delta":1}`,
+/// `{"type":"ui_event","slot":0,"kind":"Clicked"}` (kind also
+/// `{"SliderChanged":0.5}` / `{"TextChanged":"hi"}` — the
+/// [`functor_runtime_common::ui::UiEventKind`] wire shape), so an agent can
+/// drive interactive UI widgets headlessly (docs/ui-interaction.md U2).
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum InputCommand {
     Key { key: String, down: bool },
     MouseMove { x: i32, y: i32 },
     MouseWheel { delta: i32 },
+    UiEvent {
+        slot: u32,
+        kind: functor_runtime_common::ui::UiEventKind,
+    },
 }
 
 /// A clock command via `POST /time`: `{"type":"set","tts":2.0}` pins the frame
@@ -403,7 +411,7 @@ pub fn spawn(bind: &str, port: u16) -> Receiver<DebugRequest> {
                             "POST /capture": "PNG (image/png) of the next rendered frame",
                             "GET /state": "runtime state JSON: frame, tts, viewport, input (held_keys + mouse), model (Debug text)",
                             "GET /scene": "current frame as JSON: camera + scene + lights",
-                            "POST /input": "inject input — {\"type\":\"key\",\"key\":\"w\",\"down\":true} | {\"type\":\"mouse_move\",\"x\":0,\"y\":0} | {\"type\":\"mouse_wheel\",\"delta\":1}",
+                            "POST /input": "inject input — {\"type\":\"key\",\"key\":\"w\",\"down\":true} | {\"type\":\"mouse_move\",\"x\":0,\"y\":0} | {\"type\":\"mouse_wheel\",\"delta\":1} | {\"type\":\"ui_event\",\"slot\":0,\"kind\":\"Clicked\"}",
                             "POST /time": "clock control — {\"type\":\"set\",\"tts\":2.0} (pause) | {\"type\":\"advance\",\"dts\":0.016} (step one frame) | {\"type\":\"resume\"}",
                             "POST /reload-source": "swap game logic from the request body (raw .fun source), model preserved — 400 with the load error on a broken push",
                             "POST /rewind": "coupled scene rewind — {\"frame\":42} restores model + physics to that rendered frame (pin the clock first); 400 if unrecorded/pruned"

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -30,8 +30,9 @@
 use std::time::Instant;
 
 use functor_runtime_common::functor_lang_prelude::{
-    audio_scene_of, clear_audio_completions, clear_http_taggers, frame_value, view_value,
-    EffectLog, EffectRunner, EffectTree, FunctorHost, NetEventKind, RealEffects,
+    audio_scene_of, clear_audio_completions, clear_http_taggers, frame_value, take_ui_handlers,
+    view_value, EffectLog, EffectRunner, EffectTree, FunctorHost, NetEventKind, RealEffects,
+    UiHandler,
 };
 use functor_runtime_common::events::{self, RuntimeEvent};
 use functor_runtime_common::functor_lang_producer::{FrameCtx, Reporter, SpanSource};
@@ -86,6 +87,12 @@ pub struct FunctorLangGame {
     /// keeps the last good view (the `last_frame` rule); a reload that drops
     /// the hook clears it.
     last_view: View,
+    /// The interactive-widget handler table registered by the `ui(model)`
+    /// evaluation that built `last_view` (docs/ui-interaction.md U2): a
+    /// `UiEvent` the shell reports resolves its slot here. Kept in lockstep
+    /// with `last_view` (updated only on a successful evaluation) and cleared
+    /// on reload — its values may close over the old session.
+    ui_handlers: Vec<UiHandler>,
     /// The last serialized soundscape (`soundScape model` → JSON), cached
     /// because `audio_scene_json` is a `&self` accessor — evaluated beside
     /// `draw` each frame so errors can `&mut`-dedupe. A bad frame keeps the
@@ -356,6 +363,7 @@ impl FunctorLangGame {
             has_soundscape: loaded.has_soundscape,
             has_ui: loaded.has_ui,
             last_view: View::Empty,
+            ui_handlers: Vec::new(),
             last_soundscape_json: empty_soundscape_json(),
             effect_runner: RealEffects::new(),
             effect_log: EffectLog::new(),
@@ -451,6 +459,10 @@ impl FunctorLangGame {
         // too — drop them alongside the HTTP taggers (a late finish for a
         // dropped token arrives orphaned and is ignored).
         clear_audio_completions();
+        // The widget handler table holds msgs/taggers into the OLD session;
+        // the next render's `ui(model)` rebuilds it against the new one. A
+        // click landing in the gap resolves an unknown slot and is dropped.
+        self.ui_handlers.clear();
         // Reload is a model-history BOUNDARY: the retained snapshots can hold
         // closures bound to the old module, so — unlike the live model, which
         // `rebind_value` migrates above — they can't safely cross a reload. The
@@ -748,6 +760,23 @@ impl Game for FunctorLangGame {
             .push(functor_runtime_common::RecordedInput::MouseWheel { delta });
     }
 
+    fn ui_event(&mut self, event: functor_runtime_common::ui::UiEvent) {
+        // No `ui` hook → no widgets to have interacted with; drop silently
+        // (mirrors the has_input gates above).
+        if !self.has_ui {
+            return;
+        }
+        // The table is moved out for the call — `ctx()` borrows every other
+        // producer field mutably — and restored after.
+        let handlers = std::mem::take(&mut self.ui_handlers);
+        self.ctx().deliver_ui_event(&handlers, &event);
+        self.ui_handlers = handlers;
+        // Buffer for the frame-indexed input log (T6b), like key events, so a
+        // replay re-delivers the interaction.
+        self.input_buf
+            .push(functor_runtime_common::RecordedInput::UiEvent(event));
+    }
+
     fn render(&mut self, frame_time: FrameTime) -> Frame {
         let started = Instant::now();
         // While scrubbing, draw at the scrubbed frame's recorded `tts` so
@@ -777,13 +806,26 @@ impl Game for FunctorLangGame {
                 .call("ui", vec![self.model.clone()], &mut FunctorHost)
             {
                 Ok(value) => match view_value(&value) {
-                    Some(view) => self.last_view = view.clone(),
-                    None => self.reporter.report_once(format!(
-                        "[functor-lang] ui must return a View (Ui.text / Ui.column / Ui.panel), got {}",
-                        value.kind_name()
-                    )),
+                    Some(view) => {
+                        self.last_view = view.clone();
+                        // The evaluation registered this tree's widget handlers
+                        // — adopt them in lockstep with the view they address.
+                        self.ui_handlers = take_ui_handlers();
+                    }
+                    None => {
+                        let _ = take_ui_handlers();
+                        self.reporter.report_once(format!(
+                            "[functor-lang] ui must return a View (Ui.text / Ui.column / Ui.panel), got {}",
+                            value.kind_name()
+                        ))
+                    }
                 },
-                Err(err) => self.reporter.frame_error("ui", &err),
+                Err(err) => {
+                    // A failed evaluation keeps the last good view AND its
+                    // handlers; drop the partial table it registered.
+                    let _ = take_ui_handlers();
+                    self.reporter.frame_error("ui", &err)
+                }
             }
         }
         // The optional soundscape, evaluated beside `draw` (same settled model)

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -562,6 +562,10 @@ fn service_debug_request(
                     game.mouse_wheel(delta);
                     Ok(())
                 }
+                debug_server::InputCommand::UiEvent { slot, kind } => {
+                    game.ui_event(functor_runtime_common::ui::UiEvent { slot, kind });
+                    Ok(())
+                }
             };
             let _ = resp.send(result);
         }

--- a/runtime/functor-runtime-web/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-web/src/functor_lang_game.rs
@@ -23,7 +23,8 @@ use std::cell::RefCell;
 
 use functor_runtime_common::functor_lang_prelude::{
     audio_scene_of, clear_audio_completions, clear_http_taggers, contains_effect, frame_value,
-    view_value, EffectLog, EffectRunner, EffectTree, FunctorHost, NetEventKind, RealEffects,
+    take_ui_handlers, view_value, EffectLog, EffectRunner, EffectTree, FunctorHost, NetEventKind,
+    RealEffects, UiHandler,
 };
 use functor_runtime_common::functor_lang_producer::{FrameCtx, Reporter, SpanSource};
 use functor_runtime_common::physics;
@@ -73,6 +74,10 @@ pub struct FunctorLangWebGame {
     /// `&self` accessor — evaluated beside `draw` each frame (the desktop
     /// producer's rule: a bad `ui` keeps the last good view).
     last_view: View,
+    /// The interactive-widget handler table registered by the `ui(model)`
+    /// evaluation that built `last_view` (docs/ui-interaction.md U2), kept in
+    /// lockstep with it — same rules as the desktop producer.
+    ui_handlers: Vec<UiHandler>,
     /// Performs `Effect.*` commands (B6). `RealEffects` is wasm-safe: its
     /// clock is `Date.now()` on this target.
     effect_runner: RealEffects,
@@ -304,6 +309,7 @@ impl FunctorLangWebGame {
             last_soundscape_json: empty_soundscape_json(),
             has_ui: loaded.has_ui,
             last_view: View::Empty,
+            ui_handlers: Vec::new(),
             last_frame: empty_frame(),
         })
     }
@@ -348,6 +354,9 @@ impl FunctorLangWebGame {
         self.pending_events.clear();
         clear_http_taggers();
         clear_audio_completions();
+        // The widget handler table holds msgs/taggers into the OLD session;
+        // the next render's `ui(model)` rebuilds it against the new one.
+        self.ui_handlers.clear();
         // Reload is a model-history BOUNDARY (see the desktop producer): the
         // retained snapshots can hold old-module closures, so they can't cross
         // a reload; the recorder keeps its rendered-frame clock monotonic so
@@ -580,6 +589,23 @@ impl GameProducer for FunctorLangWebGame {
             .push(functor_runtime_common::RecordedInput::MouseWheel { delta });
     }
 
+    fn ui_event(&mut self, event: functor_runtime_common::ui::UiEvent) {
+        // No `ui` hook → no widgets to have interacted with; drop silently
+        // (mirrors the has_input gates above).
+        if !self.has_ui {
+            return;
+        }
+        // The table is moved out for the call — `ctx()` borrows every other
+        // producer field mutably — and restored after.
+        let handlers = std::mem::take(&mut self.ui_handlers);
+        self.ctx().deliver_ui_event(&handlers, &event);
+        self.ui_handlers = handlers;
+        // Buffer for the frame-indexed input log (T6b), like key events, so a
+        // replay re-delivers the interaction.
+        self.input_buf
+            .push(functor_runtime_common::RecordedInput::UiEvent(event));
+    }
+
     fn render(&mut self, frame_time: FrameTime) -> Frame {
         // While scrubbing, draw at the scrubbed frame's recorded `tts` so
         // `tts`-driven visuals (orbiting lights, `sin(tts)` motion) rewind with
@@ -621,13 +647,26 @@ impl GameProducer for FunctorLangWebGame {
                 .call("ui", vec![self.model.clone()], &mut FunctorHost)
             {
                 Ok(value) => match view_value(&value) {
-                    Some(view) => self.last_view = view.clone(),
-                    None => self.reporter.report_once(format!(
-                        "[functor-lang] ui must return a View (Ui.text / Ui.column / Ui.panel), got {}",
-                        value.kind_name()
-                    )),
+                    Some(view) => {
+                        self.last_view = view.clone();
+                        // The evaluation registered this tree's widget handlers
+                        // — adopt them in lockstep with the view they address.
+                        self.ui_handlers = take_ui_handlers();
+                    }
+                    None => {
+                        let _ = take_ui_handlers();
+                        self.reporter.report_once(format!(
+                            "[functor-lang] ui must return a View (Ui.text / Ui.column / Ui.panel), got {}",
+                            value.kind_name()
+                        ))
+                    }
                 },
-                Err(err) => self.reporter.frame_error("ui", &err),
+                Err(err) => {
+                    // A failed evaluation keeps the last good view AND its
+                    // handlers; drop the partial table it registered.
+                    let _ = take_ui_handlers();
+                    self.reporter.frame_error("ui", &err)
+                }
             }
         }
         // The optional soundscape, evaluated beside `draw` (same settled model)
@@ -827,6 +866,7 @@ pub fn drain_input(game: &mut dyn GameProducer, deliver: bool) {
             InputEvent::Key { code, is_down } => game.key_event(code, is_down),
             InputEvent::MouseMove { x, y } => game.mouse_move(x, y),
             InputEvent::MouseWheel { delta } => game.mouse_wheel(delta),
+            InputEvent::UiEvent(event) => game.ui_event(event),
         }
     }
 }


### PR DESCRIPTION
## What

U2 of the interactive-UI plan (design doc: #289; U1 was #288). This is the **machinery PR** — no widget renders yet, but the full event path from wire to `update` exists and is tested end to end:

- **`ui::UiEvent { slot, kind: Clicked | SliderChanged(f64) | TextChanged(String) }`** — serializable, wire shape pinned in the protocol tests.
- **`UiHandler` (Msg | Tagger)** in the prelude — the two established message shapes (`Sub.every`'s verbatim msg for buttons, `Effect.now`'s tagger for sliders/text) — plus the per-frame handler table interactive `Ui.*` constructors will register into during `ui(model)` evaluation (`push_ui_handler`/`take_ui_handlers`). Both producers keep the drained table in lockstep with `last_view` (adopted only on a successful evaluation, dropped on reload).
- **`FrameCtx::deliver_ui_event`**, modeled on `deliver_net_event`: resolve the slot, apply the tagger to the payload (or take the msg verbatim), fold through `update` + `absorb`. Unknown slots, clicks on tagger handlers, and missing-`update` games drop with a one-line teaching report.
- **`GameProducer::ui_event`** (default no-op), implemented by both producers, which also buffer **`RecordedInput::UiEvent`** so time-travel replay re-delivers interactions. Replay rebuilds the handler table **once per fine step, before the step's inputs** — matching the live contract that an event resolves against the last render's tree (the one the user saw). `RecordedInput` loses `Copy` for the future text payload.
- **Debug server:** `POST /input {"type":"ui_event","slot":0,"kind":"Clicked"}` (also `{"SliderChanged":0.5}` / `{"TextChanged":"hi"}`) injects widget events headlessly — an agent can drive UI without pixels or hit-testing. Documented in docs/debug-runtime.md.

## Verification

- 5 new headless producer tests drive `deliver_ui_event` through a real interpreter session: msg click, tagger slider, tagger text, unknown-slot drop, click-on-tagger drop (`cargo test -p functor_runtime_common` — 234 passed).
- All targets compile: desktop, CLI, web on `wasm32-unknown-unknown`.
- Live e2e: `functor run native --headless --debug-port …` + `curl` — valid events return 200 and surface the expected `[functor-lang]` drop report; malformed kinds 400 with the serde message.
- Cross-engine review: Claude reviewer's replay-divergence finding (multiple tree-shaping inputs in one frame could resolve later UiEvents against a re-shaped tree) fixed by the step-top table rebuild above; re-validated. Codex was unavailable this round (usage limit).

Next up: **U3** — `Ui.button` + pointer input to the game-UI egui pass + a counter example, making this seam user-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)