### PR TITLE
feat(ui): Ui.button — the first interactive widget, with examples/counter

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -439,6 +439,25 @@ AudioSource.at(key, sound, x, y, z)                        //   / positioned emi
 source |> AudioSource.gain(g)                              // source-last: linear gain (1.0=full)
 AudioScene.create([source, …]) / AudioScene.empty()       // what `soundScape` returns
 
+Ui.text("line") / Ui.textColor(r, g, b, "line")            // HUD text (monospace, 14pt)
+Ui.column([view, …])                                       // stack top-to-bottom
+view |> Ui.panel(Ui.topLeft())                             // pin to a corner (view-LAST: pipes;
+                                                           //   only topLeft exists so far)
+Ui.button("label", msg)                                    // INTERACTIVE (docs/ui-interaction.md):
+                                                           //   a click delivers msg VERBATIM
+                                                           //   through `update` (the Sub.every
+                                                           //   message shape; requires update).
+                                                           //   Interactive widgets are numbered
+                                                           //   by SLOT in construction order —
+                                                           //   the debug server clicks them
+                                                           //   headlessly: POST /input
+                                                           //   {"type":"ui_event","slot":0,
+                                                           //    "kind":"Clicked"}. Like
+                                                           //   Sub.every's msg, the msg↔update
+                                                           //   type link is a runtime check.
+                                                           //   `examples/counter` is the
+                                                           //   reference
+
 Physics.box(w, h, d) / sphere(r) / capsule(halfH, r)       // -> Shape (box = FULL extents)
 Physics.dynamic("tag", shape)                              // simulated body
 Physics.kinematic("tag", shape) / Physics.fixed("tag", shape)
@@ -533,6 +552,9 @@ let update = (model, msg) => model'         // OPTIONAL; msgs are ADT variants
 let subscriptions = (model) => Sub.every(Time.seconds(1.0), Beat)
                                             // OPTIONAL, but requires update
 let physics = (model) => Physics.scene(0.0, -9.81, 0.0, [body, …])  // OPTIONAL
+let ui = (model) => Ui.column([…]) |> Ui.panel(Ui.topLeft())  // OPTIONAL; the 2D HUD,
+                                            // drawn over the frame. Ui.button clicks
+                                            // arrive as msgs through `update`
 let soundScape = (model) => AudioScene.create([source, …])  // OPTIONAL; continuous
                                             // looping voices, reconciled by key each
                                             // frame (needs no `update`)

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -108,10 +108,13 @@ iteration" item below (T6, trajectory preview).
 
 - [ ] T1: model as a `Simulatable` (snapshot = `Value` clone, command = frame
       inputs) + a unified frame clock seeking model and physics together; goldens.
-- [ ] T2: pointer/click input plumbing (real `RawInput` to egui; deliver mouse
-      buttons to the runtime) — unblocks the scrubber and interactive UI.
+- [x] T2: pointer/click input plumbing (real `RawInput` to egui; deliver mouse
+      buttons to the runtime) — shipped across docs/ui-interaction.md U1–U3
+      (`PointerBridge`, both shells' pointer wiring).
 - [ ] T3: shell-owned egui scrubber overlay; `~` toggle (native), default-on (web/VSCode).
-- [ ] T4: interactive Functor Lang `View` (`Button { label, onClick }`, storable closure).
+- [x] T4: interactive Functor Lang `View` — shipped as `Ui.button(label, msg)` (a verbatim
+      msg through `update`, not a stored closure; docs/ui-interaction.md), with
+      `examples/counter`. Sliders/text inputs follow (U4).
 - [ ] T5: forked timelines + ~50%-opacity render composite.
 - [ ] T6: trajectory preview (deterministic forward-sim + trail draw) — the
       *Inventing on Principle* demo.

--- a/examples/counter/functor.json
+++ b/examples/counter/functor.json
@@ -1,0 +1,4 @@
+{
+  "language": "functor-lang",
+  "entry": "game.fun"
+}

--- a/examples/counter/game.fun
+++ b/examples/counter/game.fun
@@ -1,0 +1,37 @@
+// counter — the interactive-UI hello world (docs/ui-interaction.md U3).
+//
+// A `Ui.button` click delivers its msg (Inc) verbatim through `update`; the
+// HUD echoes the count and the cube turns 15° per click, so the whole
+// UI → msg → model → view loop is visible. Drive it headlessly with the
+// debug server: POST /input {"type":"ui_event","slot":0,"kind":"Clicked"}
+// (the button is slot 0 — the tree's first interactive widget), then read
+// the count back from GET /state.
+
+type Model = { count: float }
+type Msg = | Inc
+
+let init = { count: 0.0 }
+
+let update = (m: Model, msg: Msg) =>
+  match msg with
+  | Inc => { m with count: m.count + 1.0 }
+
+let tick = (m: Model, dt, tts) => m
+
+let draw = (m: Model, tts) =>
+  Frame.createLit(
+    Camera.lookAt(0.0, 1.5, -4.0, 0.0, 0.0, 0.0),
+    Scene.cube()
+      |> Scene.lit(0.3, 0.65, 0.9)
+      |> Scene.rotateY(Angle.degrees(m.count * 15.0)),
+    [
+      Light.ambient(0.25, 0.25, 0.25),
+      Light.directional(-0.5, -1.0, 0.4, 1.0, 1.0, 1.0, 0.9),
+    ],
+  )
+
+let ui = (m: Model) =>
+  Ui.column([
+    Ui.text(Text.concat("count: ", Text.fixed(m.count, 0.0))),
+    Ui.button("+1", Inc),
+  ]) |> Ui.panel(Ui.topLeft())

--- a/functor-prelude/prelude/ui.funi
+++ b/functor-prelude/prelude/ui.funi
@@ -15,3 +15,7 @@ let column : (List<view>) => view
 // view LAST (subject-last), so it pipes: `Ui.column([…]) |> Ui.panel(Ui.topLeft())`.
 let panel : (anchor, view) => view
 let topLeft : () => anchor
+// Interactive: a click delivers `msg` verbatim through `update`
+// (docs/ui-interaction.md). Like Sub.every's msg, 'msg is erased by the
+// opaque `view` — the msg↔update link is checked at runtime.
+let button : (string, 'msg) => view

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -60,10 +60,13 @@
 //! Ui.column([view, …])                                      -> View
 //! Ui.panel(anchor, view)                                    -> View
 //! Ui.topLeft()                                              -> Anchor
+//! Ui.button(label, msg)                                     -> View
 //!   (the optional `ui = (model) => …` hook's tree — hello's HUD shape:
 //!    text lines stacked in a column, pinned to a screen corner. Only the
 //!    corner the port needed exists; the rest arrive with a port that
-//!    needs them. `Ui.panel` takes the view LAST, so it pipes.)
+//!    needs them. `Ui.panel` takes the view LAST, so it pipes. `Ui.button`
+//!    is interactive: a click delivers `msg` verbatim through `update` —
+//!    docs/ui-interaction.md.)
 //! Skybox.files(px, nx, py, ny, pz, nz)                       -> Skybox
 //! Frame.withSkybox(sky, frame)                               -> Frame
 //!   (a cubemap sky drawn behind everything; while the six faces load the
@@ -897,6 +900,7 @@ const PATHS: &[&str] = &[
     "Ui.column",
     "Ui.panel",
     "Ui.topLeft",
+    "Ui.button",
     "Time.seconds",
     "Time.millis",
     "Sub.none",
@@ -2086,6 +2090,21 @@ paths (+X, -X, +Y, -Y, +Z, -Z)",
             "Ui.topLeft" => match args.as_slice() {
                 [] => Ok(host(FunctorLangUiAnchor(ui::Anchor::TopLeft))),
                 _ => usage("Ui.topLeft()"),
+            },
+            // The first interactive widget (docs/ui-interaction.md U3). The
+            // msg is any Functor Lang value (typically an ADT variant), registered in
+            // the frame's handler table and delivered VERBATIM through
+            // `update` when the shell reports a click on the stamped slot —
+            // the `Sub.every` message shape.
+            "Ui.button" => match args.as_slice() {
+                [Value::String(label), msg] => {
+                    let slot = push_ui_handler(UiHandler::Msg(msg.clone()));
+                    Ok(host(FunctorLangView(View::Button {
+                        slot,
+                        label: label.to_string(),
+                    })))
+                }
+                _ => usage("Ui.button(\"label\", msg) — msg is delivered to update on click"),
             },
             "Time.seconds" => match args.as_slice() {
                 [n] => Ok(host(FunctorLangDuration(num(n, span)?))),
@@ -4968,6 +4987,37 @@ the game dir"
         // And it round-trips (the wasm boundary ships Views as JSON).
         let back: View = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(serde_json::to_string(&back).unwrap(), json);
+    }
+
+    // Ui.button (docs/ui-interaction.md U3): each button registers its msg in
+    // the frame's handler table and the node carries the slot, in
+    // construction order — the serializable tree never holds the msg itself.
+    #[test]
+    fn ui_button_registers_its_msg_and_stamps_the_slot() {
+        let _ = take_ui_handlers(); // isolate from other tests on this thread
+        let value = eval(
+            "type Msg = | Inc | Reset\n\
+             let main = () =>\n\
+             Ui.column([\n\
+               Ui.button(\"+1\", Inc),\n\
+               Ui.button(\"Reset\", Reset),\n\
+             ])",
+        );
+        let view = view_value(&value).expect("main should return a View");
+        assert_eq!(
+            serde_json::to_string(view).unwrap(),
+            r#"{"Column":[{"Button":{"slot":0,"label":"+1"}},{"Button":{"slot":1,"label":"Reset"}}]}"#
+        );
+        let handlers = take_ui_handlers();
+        assert_eq!(handlers.len(), 2);
+        // Construction order: slot 0 carries Inc, slot 1 carries Reset.
+        match (&handlers[0], &handlers[1]) {
+            (UiHandler::Msg(inc), UiHandler::Msg(reset)) => {
+                assert_eq!(inc.to_string(), "Inc");
+                assert_eq!(reset.to_string(), "Reset");
+            }
+            _ => panic!("both handlers should be verbatim msgs"),
+        }
     }
 
     // --- Networking (Sub.connect/listen, Effect.send, NetEvent) ---

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -588,5 +588,16 @@ mod tests {
         let legacy: View =
             serde_json::from_str(r#"{"Text":{"text":"hi","color":[1,2,3]}}"#).unwrap();
         assert_json_stable(&legacy);
+
+        // The interactive button (docs/ui-interaction.md U3): slot-stamped,
+        // handler kept producer-side so the tree stays serializable.
+        let button = View::Button {
+            slot: 0,
+            label: "Reset".to_string(),
+        };
+        let expected = r#"{"Button":{"slot":0,"label":"Reset"}}"#;
+        assert_eq!(serde_json::to_string(&button).unwrap(), expected);
+        let back: View = serde_json::from_str(expected).unwrap();
+        assert_eq!(serde_json::to_string(&back).unwrap(), expected);
     }
 }

--- a/runtime/functor-runtime-common/src/ui.rs
+++ b/runtime/functor-runtime-common/src/ui.rs
@@ -80,6 +80,12 @@ pub enum View {
     Row(Vec<View>),
     /// Pin a subtree to a screen corner.
     Panel { anchor: Anchor, child: Box<View> },
+    /// An interactive button (docs/ui-interaction.md U3). `slot` indexes the
+    /// per-frame handler table the producer kept from this tree's `ui(model)`
+    /// evaluation — a click comes back as `UiEvent { slot, Clicked }`. The
+    /// handler itself (a msg `Value`) never crosses: the tree stays
+    /// serializable.
+    Button { slot: u32, label: String },
 }
 
 /// 0..1 float components -> 8-bit color, clamped. Shared by the F#-facing
@@ -126,10 +132,23 @@ const UI_FONT_SIZE: f32 = 14.0;
 /// Inset of an anchored panel from the screen edge, in points.
 const MARGIN: f32 = 10.0;
 
+/// Whether the subtree holds any interactive widget — a Panel's egui `Area`
+/// is interactable only then, so a pure-text HUD keeps letting clicks
+/// through (a click over it still recaptures the cursor for free-look).
+fn contains_interactive(view: &View) -> bool {
+    match view {
+        View::Empty | View::Text { .. } => false,
+        View::Column(items) | View::Row(items) => items.iter().any(contains_interactive),
+        View::Panel { child, .. } => contains_interactive(child),
+        View::Button { .. } => true,
+    }
+}
+
 /// Render a declarative [`View`] into `ui` using egui's own layout (vertical /
 /// horizontal / anchored `Area`), so line height and spacing come from the font
-/// being rendered — no manual metrics, and lines never overlap.
-fn render_view(ui: &mut egui::Ui, view: &View) {
+/// being rendered — no manual metrics, and lines never overlap. Interactions
+/// egui detects on the view's widgets land in `events`, slot-stamped.
+fn render_view(ui: &mut egui::Ui, view: &View, events: &mut Vec<UiEvent>) {
     match view {
         View::Empty => {}
         View::Text { text, color, .. } => {
@@ -143,14 +162,14 @@ fn render_view(ui: &mut egui::Ui, view: &View) {
         View::Column(items) => {
             ui.vertical(|ui| {
                 for item in items {
-                    render_view(ui, item);
+                    render_view(ui, item, events);
                 }
             });
         }
         View::Row(items) => {
             ui.horizontal(|ui| {
                 for item in items {
-                    render_view(ui, item);
+                    render_view(ui, item, events);
                 }
             });
         }
@@ -159,8 +178,19 @@ fn render_view(ui: &mut egui::Ui, view: &View) {
             let ctx = ui.ctx().clone();
             egui::Area::new(egui::Id::new(("functor_ui_panel", anchor_id(*anchor))))
                 .anchor(align, offset)
-                .interactable(false)
-                .show(&ctx, |ui| render_view(ui, child));
+                .interactable(contains_interactive(child))
+                .show(&ctx, |ui| render_view(ui, child, events));
+        }
+        View::Button { slot, label } => {
+            let clicked = ui
+                .button(egui::RichText::new(label).font(egui::FontId::monospace(UI_FONT_SIZE)))
+                .clicked();
+            if clicked {
+                events.push(UiEvent {
+                    slot: *slot,
+                    kind: UiEventKind::Clicked,
+                });
+            }
         }
     }
 }
@@ -202,10 +232,22 @@ fn restore_gl_after_egui(gl: &glow::Context) {
     }
 }
 
+/// The game-UI pass's output for one frame (docs/ui-interaction.md U3).
+#[derive(Default)]
+pub struct UiOutput {
+    /// Interactions egui detected on the view's widgets, slot-stamped — the
+    /// shell forwards each to `GameProducer::ui_event`.
+    pub events: Vec<UiEvent>,
+    /// egui is using the pointer (hovering/clicking a widget), so the shell
+    /// must NOT treat a click as a free-look recapture (the scrubber rule).
+    pub wants_pointer: bool,
+}
+
 pub struct TextOverlay {
     ctx: egui::Context,
     painter: egui_glow::Painter,
     gl: Arc<glow::Context>,
+    pointer: PointerBridge,
 }
 
 impl TextOverlay {
@@ -219,6 +261,7 @@ impl TextOverlay {
             ctx: egui::Context::default(),
             painter,
             gl,
+            pointer: PointerBridge::default(),
         }
     }
 
@@ -230,7 +273,8 @@ impl TextOverlay {
         if labels.is_empty() {
             return;
         }
-        self.run_and_paint(width, height, pixels_per_point, |ui| {
+        // Label overlays (netsim, the F# path) are display-only: no pointer.
+        self.run_and_paint(width, height, pixels_per_point, Vec::new(), |ui| {
             // Labels are floating, Context-attached Areas rather than children of
             // the root Ui, so pull the context back out of the supplied `ui`.
             let ctx = ui.ctx().clone();
@@ -254,22 +298,48 @@ impl TextOverlay {
 
     /// Paint a declarative [`View`], laid out with egui's own containers so line
     /// height and spacing come from the rendered font (no manual metrics, no
-    /// overlap). `width`/`height` are physical framebuffer pixels.
-    pub fn draw_view(&mut self, width: u32, height: u32, pixels_per_point: f32, view: &View) {
+    /// overlap). `width`/`height` are physical framebuffer pixels. `pointer`
+    /// drives the view's interactive widgets ([`PointerState::default`] for a
+    /// display-only pass); interactions come back slot-stamped in the
+    /// [`UiOutput`] for the shell to forward to `GameProducer::ui_event`.
+    pub fn draw_view(
+        &mut self,
+        width: u32,
+        height: u32,
+        pixels_per_point: f32,
+        pointer: PointerState,
+        view: &View,
+    ) -> UiOutput {
+        // Tick the bridge even when nothing draws, so button edges spanning
+        // an Empty frame don't replay as phantom clicks later.
+        let pointer_events = self.pointer.events(pointer, pixels_per_point);
         if matches!(view, View::Empty) {
-            return;
+            // Still feed egui any release/PointerGone the bridge synthesized:
+            // a view hidden mid-press must not leave the context holding a
+            // stuck press for the view's return. [xreview]
+            if !pointer_events.is_empty() {
+                self.run_and_paint(width, height, pixels_per_point, pointer_events, |_| {});
+            }
+            return UiOutput::default();
         }
-        self.run_and_paint(width, height, pixels_per_point, |ui| match view {
-            // A panel anchors itself; a bare root sits at the top-left with a margin.
-            View::Panel { .. } => render_view(ui, view),
-            other => {
-                let ctx = ui.ctx().clone();
-                egui::Area::new(egui::Id::new("functor_ui_root"))
-                    .anchor(egui::Align2::LEFT_TOP, egui::vec2(MARGIN, MARGIN))
-                    .interactable(false)
-                    .show(&ctx, |ui| render_view(ui, other));
+        let mut events = Vec::new();
+        self.run_and_paint(width, height, pixels_per_point, pointer_events, |ui| {
+            match view {
+                // A panel anchors itself; a bare root sits at the top-left with a margin.
+                View::Panel { .. } => render_view(ui, view, &mut events),
+                other => {
+                    let ctx = ui.ctx().clone();
+                    egui::Area::new(egui::Id::new("functor_ui_root"))
+                        .anchor(egui::Align2::LEFT_TOP, egui::vec2(MARGIN, MARGIN))
+                        .interactable(contains_interactive(other))
+                        .show(&ctx, |ui| render_view(ui, other, &mut events));
+                }
             }
         });
+        UiOutput {
+            events,
+            wants_pointer: self.ctx.egui_wants_pointer_input(),
+        }
     }
 
     /// Run one egui frame (building the UI with `build`), tessellate, paint to the
@@ -280,6 +350,7 @@ impl TextOverlay {
         width: u32,
         height: u32,
         pixels_per_point: f32,
+        events: Vec<egui::Event>,
         build: impl FnMut(&mut egui::Ui),
     ) {
         if width == 0 || height == 0 {
@@ -292,6 +363,7 @@ impl TextOverlay {
         );
         let raw_input = egui::RawInput {
             screen_rect: Some(egui::Rect::from_min_size(egui::Pos2::ZERO, screen_points)),
+            events,
             ..Default::default()
         };
 
@@ -326,33 +398,54 @@ pub struct PointerState {
 /// whenever the pointer is on the overlay, and a primary-button event on the
 /// press/release EDGE (egui needs both edges to register a click). One bridge
 /// per egui context — it holds the previous button state to find the edges, so
-/// every interactive pass (the scrubber today, the game UI next) synthesizes
-/// identical input from the same shell state.
+/// every interactive pass (the scrubber, the game UI) synthesizes identical
+/// input from the same shell state.
 #[derive(Default)]
 pub struct PointerBridge {
     last_primary_down: bool,
+    /// Last on-overlay position (points) — where a press is released if the
+    /// pointer leaves the overlay while held.
+    last_pos: Option<egui::Pos2>,
 }
 
 impl PointerBridge {
     /// This frame's egui events. `pixels_per_point` maps the snapshot's
     /// physical-pixel position into egui's point space. While `pos` is `None`
-    /// (cursor captured) no events are emitted, but button state is still
-    /// tracked — a press begun off-overlay is swallowed, never replayed (its
-    /// release, if it lands on-overlay, is delivered unmatched, which egui
-    /// tolerates; symmetrically, a release that happens off-overlay is never
-    /// delivered, so egui holds the press until the next on-overlay edge).
+    /// (cursor captured / off-canvas) button state is still tracked — a press
+    /// begun off-overlay is swallowed, never replayed. On the transition OFF
+    /// the overlay, a press still held from on-overlay is RELEASED at its
+    /// last position (egui must not hold a stuck press), followed by
+    /// `PointerGone` so hover state clears.
     pub fn events(&mut self, pointer: PointerState, pixels_per_point: f32) -> Vec<egui::Event> {
         let mut events = Vec::new();
-        if let Some((px, py)) = pointer.pos {
-            let pos = egui::pos2(px / pixels_per_point, py / pixels_per_point);
-            events.push(egui::Event::PointerMoved(pos));
-            if pointer.primary_down != self.last_primary_down {
-                events.push(egui::Event::PointerButton {
-                    pos,
-                    button: egui::PointerButton::Primary,
-                    pressed: pointer.primary_down,
-                    modifiers: egui::Modifiers::default(),
-                });
+        match pointer.pos {
+            Some((px, py)) => {
+                let pos = egui::pos2(px / pixels_per_point, py / pixels_per_point);
+                events.push(egui::Event::PointerMoved(pos));
+                if pointer.primary_down != self.last_primary_down {
+                    events.push(egui::Event::PointerButton {
+                        pos,
+                        button: egui::PointerButton::Primary,
+                        pressed: pointer.primary_down,
+                        modifiers: egui::Modifiers::default(),
+                    });
+                }
+                self.last_pos = Some(pos);
+            }
+            None => {
+                if let Some(pos) = self.last_pos.take() {
+                    // Leaving the overlay: flush a held press, then the
+                    // pointer is gone.
+                    if self.last_primary_down {
+                        events.push(egui::Event::PointerButton {
+                            pos,
+                            button: egui::PointerButton::Primary,
+                            pressed: false,
+                            modifiers: egui::Modifiers::default(),
+                        });
+                    }
+                    events.push(egui::Event::PointerGone);
+                }
             }
         }
         self.last_primary_down = pointer.primary_down;
@@ -622,6 +715,27 @@ mod tests {
             release[1],
             egui::Event::PointerButton { pressed: false, .. }
         ));
+    }
+
+    #[test]
+    fn leaving_the_overlay_mid_press_releases_at_the_last_position() {
+        let mut bridge = PointerBridge::default();
+        bridge.events(on(5.0, 5.0, true), 1.0); // press on-overlay
+
+        // Pointer leaves (cursor captured / off-canvas) while still held:
+        // egui must not keep a stuck press — release where it last was,
+        // then the pointer is gone.
+        let leave = bridge.events(off(true), 1.0);
+        assert_eq!(leave.len(), 2);
+        assert!(matches!(
+            leave[0],
+            egui::Event::PointerButton { pressed: false, pos, .. } if pos == egui::pos2(5.0, 5.0)
+        ));
+        assert!(matches!(leave[1], egui::Event::PointerGone));
+
+        // Staying off-overlay emits nothing further.
+        assert!(bridge.events(off(true), 1.0).is_empty());
+        assert!(bridge.events(off(false), 1.0).is_empty());
     }
 
     #[test]

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -805,7 +805,17 @@ pub fn run(args: Args) {
         // the pointer last frame (so a click on a control doesn't recapture the
         // cursor for free-look).
         let mut mouse_primary_down = false;
+        // Press-latch for the frame's pointer SAMPLE: a click whose press and
+        // release both land in one poll batch (a fast tap, a slow frame)
+        // leaves `mouse_primary_down` false by sample time — the latch keeps
+        // the sampled level true for that frame so egui still sees the press
+        // edge (the release follows next frame). Cleared after each sample.
+        let mut mouse_primary_clicked = false;
         let mut scrubber_wants_pointer = false;
+        // Whether the game UI's egui pass wanted the pointer last frame — a
+        // click on a `Ui.button` must drive the widget, not recapture the
+        // cursor for free-look (the scrubber rule, docs/ui-interaction.md).
+        let mut ui_wants_pointer = false;
         // The time-travel console (`~`): HIDDEN by default in the native game
         // (it's a dev tool you summon with `~`, which also frees the cursor so
         // you can scrub right away). The wasm/vscode preview shows it always.
@@ -993,8 +1003,12 @@ Escape again to quit"
                     {
                         match action {
                             Action::Press => {
-                                if scrubber_wants_pointer {
+                                // Either overlay wanting the pointer — the
+                                // scrubber or the game UI's widgets — means
+                                // the click is for it, not a recapture.
+                                if scrubber_wants_pointer || ui_wants_pointer {
                                     mouse_primary_down = true;
+                                    mouse_primary_clicked = true;
                                 } else {
                                     window.set_cursor_mode(glfw::CursorMode::Disabled);
                                     cursor_captured = true;
@@ -1049,6 +1063,7 @@ Escape again to quit"
                         // (alt-tab), which would leave egui holding a stuck
                         // press — clear it so the scrubber stays live. [xreview]
                         mouse_primary_down = false;
+                        mouse_primary_clicked = false;
                     }
                     _ if ignore_user_input => {}
                     glfw::WindowEvent::Key(key, _, Action::Press | Action::Repeat, _) => {
@@ -1337,37 +1352,75 @@ Escape again to quit"
                 }
             }
 
-            // 2D UI overlay: the game's declarative `ui model` View, lowered to a
-            // text overlay on top of the 3D frame. Drawn before capture so it
-            // appears in --capture-frame PNGs.
-            let ui_view = game.ui();
-            text_overlay.draw_view(fb_width as u32, fb_height as u32, 1.0, &ui_view);
-
-            // The shell-owned time-travel scrubber (docs/time-travel.md T3),
-            // drawn over the frame (so it shows in captures) and interactive
-            // when the cursor is released.
-            // The cursor (GLFW window/logical coords) must be scaled to
-            // framebuffer pixels to line up with egui's layout space (which we
-            // drive in physical pixels, ppp = 1.0) — otherwise the panel is
-            // unclickable on a HiDPI/retina display (fb = 2× window). [xreview]
+            // The pointer, in framebuffer pixels, for BOTH interactive egui
+            // passes (the game UI and the scrubber). The cursor (GLFW window/
+            // logical coords) must be scaled to framebuffer pixels to line up
+            // with egui's layout space (which we drive in physical pixels,
+            // ppp = 1.0) — otherwise widgets are unclickable on a HiDPI/
+            // retina display (fb = 2× window). [xreview] `pos` is None while
+            // the cursor is captured for free-look (you're not pointing at
+            // the overlay).
             let (win_w, _) = window.get_size();
             let dpi_scale = if win_w > 0 {
                 fb_width as f32 / win_w as f32
             } else {
                 1.0
             };
+            let pointer = functor_runtime_common::ui::PointerState {
+                pos: (!cursor_captured && !hidden).then_some((
+                    mouse_pos.0 as f32 * dpi_scale,
+                    mouse_pos.1 as f32 * dpi_scale,
+                )),
+                // `|| clicked`: a press+release inside one poll batch still
+                // samples as down this frame (see the latch's declaration).
+                primary_down: mouse_primary_down || mouse_primary_clicked,
+            };
+            mouse_primary_clicked = false;
+
+            // 2D UI overlay: the game's declarative `ui model` View, lowered to a
+            // text overlay on top of the 3D frame. Drawn before capture so it
+            // appears in --capture-frame PNGs. Widget interactions come back
+            // slot-stamped and fold through the game's `update` — except while
+            // the clock is pinned, when window input must not reach the model
+            // (the `ignore_user_input` rule; injected `/input` still applies).
+            // The scrubber draws ON TOP of the game UI, so while it wants the
+            // pointer the game UI must not see it — otherwise one click over
+            // an overlapping region fires a game button AND a scrubber
+            // control (each pass is its own egui context; there is no shared
+            // hit-test). `pos: None` makes the game UI's bridge release any
+            // held press and clear hover. [xreview]
+            let ui_pointer = if scrubber_visible && scrubber_wants_pointer {
+                functor_runtime_common::ui::PointerState {
+                    pos: None,
+                    primary_down: pointer.primary_down,
+                }
+            } else {
+                pointer
+            };
+            let ui_view = game.ui();
+            let ui_out = text_overlay.draw_view(
+                fb_width as u32,
+                fb_height as u32,
+                1.0,
+                ui_pointer,
+                &ui_view,
+            );
+            ui_wants_pointer = ui_out.wants_pointer;
+            if !ignore_user_input {
+                for event in ui_out.events {
+                    game.ui_event(event);
+                }
+            }
+
+            // The shell-owned time-travel scrubber (docs/time-travel.md T3),
+            // drawn over the frame (so it shows in captures) and interactive
+            // when the cursor is released.
             let scrubber_out = if scrubber_visible {
                 scrubber.draw(
                     fb_width as u32,
                     fb_height as u32,
                     1.0,
-                    functor_runtime_common::ui::PointerState {
-                        pos: (!cursor_captured && !hidden).then_some((
-                            mouse_pos.0 as f32 * dpi_scale,
-                            mouse_pos.1 as f32 * dpi_scale,
-                        )),
-                        primary_down: mouse_primary_down,
-                    },
+                    pointer,
                     functor_runtime_common::ui::ScrubberState {
                         frame: game.current_scene_frame().unwrap_or(0),
                         range: game.scene_frame_range(),

--- a/runtime/functor-runtime-web/index-functor-lang.html
+++ b/runtime/functor-runtime-web/index-functor-lang.html
@@ -74,6 +74,8 @@
         functor_lang_key_event,
         functor_lang_mouse_move,
         functor_lang_mouse_wheel,
+        functor_lang_ui_pointer,
+        functor_lang_ui_pointer_leave,
         functor_lang_is_running,
         functor_lang_set_source,
         functor_lang_scene_frame,
@@ -162,6 +164,34 @@
         canvas.addEventListener("wheel", (e) => {
           e.preventDefault();
           functor_lang_mouse_wheel(Math.sign(e.deltaY));
+        });
+
+        // Interactive game UI (docs/ui-interaction.md U3): while the pointer
+        // is FREE (not look mode), its canvas position + primary button drive
+        // the game's `Ui.*` widgets. CSS px — the runtime scales by the
+        // device pixel ratio. Pointer lock engaging counts as leaving.
+        let uiButtonDown = false;
+        const uiPointer = (e) => {
+          if (document.pointerLockElement === canvas) return;
+          functor_lang_ui_pointer(e.offsetX, e.offsetY, uiButtonDown);
+        };
+        canvas.addEventListener("mousemove", uiPointer);
+        canvas.addEventListener("mousedown", (e) => {
+          if (e.button !== 0) return;
+          uiButtonDown = true;
+          uiPointer(e);
+        });
+        canvas.addEventListener("mouseup", (e) => {
+          if (e.button !== 0) return;
+          uiButtonDown = false;
+          uiPointer(e);
+        });
+        canvas.addEventListener("mouseleave", () => {
+          uiButtonDown = false;
+          functor_lang_ui_pointer_leave();
+        });
+        document.addEventListener("pointerlockchange", () => {
+          if (document.pointerLockElement === canvas) functor_lang_ui_pointer_leave();
         });
       };
 

--- a/runtime/functor-runtime-web/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-web/src/functor_lang_game.rs
@@ -847,6 +847,63 @@ pub fn functor_lang_mouse_wheel(delta: i32) {
     push_input(InputEvent::MouseWheel { delta });
 }
 
+thread_local! {
+    /// The page's UNLOCKED pointer over the canvas — `(pos in CSS px,
+    /// primary button down, press latched since last sample)` — for the
+    /// interactive game-UI overlay (docs/ui-interaction.md U3). Separate from
+    /// the pointer-lock mouse-look path above: while locked there is no
+    /// cursor to point at widgets with (`pos` is `None`). Level state plus a
+    /// press LATCH: a mousedown+mouseup landing between two rAF frames would
+    /// otherwise sample as never-pressed and the click would be lost — the
+    /// latch keeps the sampled level down for one frame so egui sees the
+    /// press edge (the release follows next frame).
+    static UI_POINTER: std::cell::Cell<(Option<(f32, f32)>, bool, bool)> =
+        const { std::cell::Cell::new((None, false, false)) };
+}
+
+/// Deliver the unlocked pointer's canvas position (CSS px, e.g. `offsetX/Y`)
+/// and primary-button state. Called by the page's mousemove/mousedown/mouseup
+/// handlers while pointer lock is NOT engaged.
+#[wasm_bindgen]
+pub fn functor_lang_ui_pointer(x: f32, y: f32, primary_down: bool) {
+    UI_POINTER.with(|p| {
+        let (_, was_down, clicked) = p.get();
+        // Latch the press EDGE (not the held level) so a sub-frame click
+        // survives to the next sample without pinning held state forever.
+        p.set((
+            Some((x, y)),
+            primary_down,
+            clicked || (primary_down && !was_down),
+        ));
+    });
+}
+
+/// The pointer left the canvas (or pointer lock engaged). The page clears its
+/// own button state on leave, so mirror it — a press begun off-canvas must
+/// not replay as a click on re-entry (the bridge's swallow rule; a press held
+/// across the leave is released by the bridge at its last position).
+#[wasm_bindgen]
+pub fn functor_lang_ui_pointer_leave() {
+    UI_POINTER.with(|p| {
+        let (_, _, clicked) = p.get();
+        p.set((None, false, clicked));
+    });
+}
+
+/// This frame's pointer for the overlay pass, scaled from the page's CSS px
+/// to framebuffer px (`dpr` — the overlay runs at the device pixel ratio).
+/// Consumes the press latch: a latched sub-frame click samples as down once.
+pub fn ui_pointer_state(dpr: f32) -> functor_runtime_common::ui::PointerState {
+    UI_POINTER.with(|p| {
+        let (pos, primary_down, clicked) = p.get();
+        p.set((pos, primary_down, false));
+        functor_runtime_common::ui::PointerState {
+            pos: pos.map(|(x, y)| (x * dpr, y * dpr)),
+            primary_down: primary_down || clicked,
+        }
+    })
+}
+
 /// Drain the queued page input into the producer, in arrival order. Called by
 /// the frame loop before `tick`. Empty (and free) on the F# path — its page
 /// never calls the `functor_lang_*` exports.

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -1120,10 +1120,12 @@ async fn run_async() -> Result<(), JsValue> {
 
             // Deliver page input queued since the last frame (the Functor Lang path's
             // `functor_lang_*` exports), once per rendered frame before this frame's steps.
-            // While paused, drain-and-discard: no input may reach the model on a
-            // paused frame (the input log would otherwise diverge replay), and
+            // While PINNED (paused or ?fixed-time — the desktop `ignore_user_input`
+            // rule), drain-and-discard: no input may reach the model on a pinned
+            // frame (a paused frame's input would diverge the replay log; a
+            // fixed-time frame must stay deterministic for captures), and
             // draining stops the queue bursting on resume.
-            functor_lang_game::drain_input(&mut **game, !clock.is_paused());
+            functor_lang_game::drain_input(&mut **game, !clock.is_pinned());
 
             for sub in &sub_frames {
                 game.tick(sub.clone());
@@ -1221,11 +1223,28 @@ async fn run_async() -> Result<(), JsValue> {
             }
 
             // 2D UI overlay: the game's declarative `ui model` View, lowered to a
-            // text overlay on top of the frame (HiDPI-aware via the device ratio).
+            // text overlay on top of the frame (HiDPI-aware via the device
+            // ratio). The page's unlocked-pointer canvas listeners feed the
+            // pointer (CSS px, scaled to framebuffer px here); widget
+            // interactions come back slot-stamped and fold through the game's
+            // `update` — except while paused, matching `drain_input`'s gate
+            // (no input may reach the model on a paused frame).
             let view: functor_runtime_common::ui::View = game.ui();
             let dpr = web_sys::window().unwrap().device_pixel_ratio() as f32;
             let dpr = dpr.max(1.0);
-            text_overlay.draw_view(canvas.width(), canvas.height(), dpr, &view);
+            let ui_pointer = functor_lang_game::ui_pointer_state(dpr);
+            let ui_out = text_overlay.draw_view(
+                canvas.width(),
+                canvas.height(),
+                dpr,
+                ui_pointer,
+                &view,
+            );
+            if !clock.is_pinned() {
+                for event in ui_out.events {
+                    game.ui_event(event);
+                }
+            }
 
             // Publish the scrubber state for the DOM slider to poll (the UI
             // itself is native HTML in index-functor-lang.html, outside the canvas).


### PR DESCRIPTION
## What

U3 of the interactive-UI plan (design doc #289; seam merged in #291; closes todo **T2** and **T4**). The Elm loop is now user-visible: a `Ui.button` click becomes a msg through `update`.

```
let ui = (m: Model) =>
  Ui.column([
    Ui.text(Text.concat("count: ", Text.fixed(m.count, 0.0))),
    Ui.button("+1", Inc),
  ]) |> Ui.panel(Ui.topLeft())
```

- **`View::Button { slot, label }`** (wire pinned) + prelude **`Ui.button(label, msg)`**: registers the msg in the frame's handler table (the `Sub.every` verbatim-msg shape) and stamps the node with its slot — tested from real `.fun` source.
- **`TextOverlay` is now the interactive game-UI pass**: owns a `PointerBridge`, `draw_view` takes the shell's pointer and returns `UiOutput { events, wants_pointer }`; buttons render as egui buttons; panels are interactable only when their subtree holds a widget, so a pure-text HUD still lets a click recapture free-look.
- **Desktop shell**: one pointer snapshot feeds both egui passes; widget events fold through `update` (gated off while the clock is pinned — the window-input rule; debug-injected events still apply); `ui_wants_pointer` joins the click-recapture decision; the scrubber, drawn on top, gets pointer priority so an overlapping click can't double-fire.
- **Web shell**: unlocked-pointer canvas listeners → `functor_lang_ui_pointer` exports; the frame loop scales CSS px by the device ratio and delivers events unless pinned. (Drive-by, doc-backed: web's input gate moves from `is_paused` to `is_pinned`, matching desktop's `ignore_user_input` rule — `?fixed-time` captures were open to stray input.)
- **`examples/counter`**: the interactive hello world — +1 button, HUD count, cube turns 15°/click. Headlessly drivable end to end.
- **functor-lang skill** gains the previously-missing `Ui` vocabulary + the `ui` entry point; `ui.funi` gains the `button` signature.

## Review (cross-engine, both ran)

Three findings fixed and re-validated:
- **[AGREED Claude+Codex] sub-frame click loss** — both shells sampled the button as a per-frame level, so a fast tap (press+release inside one event batch) never produced a press edge. Fixed with a press LATCH on both shells (a press seen since the last sample keeps that sample down for one frame).
- **[AGREED] overlap double-delivery** — the scrubber and game UI are separate egui contexts fed the same pointer; the scrubber (on top) now takes pointer priority.
- **`View::Empty` mid-press** — a view hidden while a button was held left egui with a stuck press; the bridge's synthesized release now flushes through an empty egui frame.

Assessed and accepted (both engines aware): a click while paused visually depresses the button but is dropped (matches the window-input policy); the first-click-after-Escape theoretical race (a hover frame always intervenes in practice).

## Verification

- 244 + 163 tests (new: press-latch behavior via bridge tests, leave-mid-press release, `Ui.button` slot registration from `.fun` source, `Button` wire pin).
- All targets build (desktop, CLI, web/wasm); golden images **byte-stable**.
- Live e2e: debug-server clicks take `examples/counter` from `{ count: 0 }` to `{ count: 3 }`; unknown slots report and drop.

Visuals follow in a comment (pr-visuals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Demo

![Ui.button counter demo](https://gist.githubusercontent.com/tommy-xr/39aaba417aec5e2acb87c4df9a95406b/raw/counter-demo.gif)

<sub>examples/counter: three headless debug-server clicks on the `Ui.button` — the msg folds through `update`, the HUD count and cube rotation follow. Captured via POST /capture, deterministic under `--fixed-time`.</sub>

![count: 3 still](https://gist.githubusercontent.com/tommy-xr/39aaba417aec5e2acb87c4df9a95406b/raw/counter-still.png)
