### PR TITLE
feat(ui): Ui.slider + Ui.row + the remaining anchors

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -440,9 +440,9 @@ source |> AudioSource.gain(g)                              // source-last: linea
 AudioScene.create([source, …]) / AudioScene.empty()       // what `soundScape` returns
 
 Ui.text("line") / Ui.textColor(r, g, b, "line")            // HUD text (monospace, 14pt)
-Ui.column([view, …])                                       // stack top-to-bottom
-view |> Ui.panel(Ui.topLeft())                             // pin to a corner (view-LAST: pipes;
-                                                           //   only topLeft exists so far)
+Ui.column([view, …]) / Ui.row([view, …])                   // stack top-to-bottom / left-to-right
+view |> Ui.panel(Ui.topLeft())                             // pin to a corner (view-LAST: pipes);
+Ui.topLeft() / topRight() / bottomLeft() / bottomRight()   //   Anchor VALUES (the Angle rule)
 Ui.button("label", msg)                                    // INTERACTIVE (docs/ui-interaction.md):
                                                            //   a click delivers msg VERBATIM
                                                            //   through `update` (the Sub.every
@@ -457,6 +457,14 @@ Ui.button("label", msg)                                    // INTERACTIVE (docs/
                                                            //   type link is a runtime check.
                                                            //   `examples/counter` is the
                                                            //   reference
+Ui.slider(min, max, value, tagger)                         // INTERACTIVE controlled slider:
+                                                           //   shows the MODEL's value; a drag
+                                                           //   applies tagger to the new value
+                                                           //   (the Effect.now tagger shape) and
+                                                           //   the msg folds through `update`.
+                                                           //   max must exceed min; tagger must
+                                                           //   be a function/ctor. Headless:
+                                                           //   {"kind":{"SliderChanged":0.5}}
 
 Physics.box(w, h, d) / sphere(r) / capsule(halfH, r)       // -> Shape (box = FULL extents)
 Physics.dynamic("tag", shape)                              // simulated body

--- a/functor-prelude/prelude/ui.funi
+++ b/functor-prelude/prelude/ui.funi
@@ -12,10 +12,19 @@ type anchor
 let text : (string) => view
 let textColor : (float, float, float, string) => view
 let column : (List<view>) => view
+let row : (List<view>) => view
 // view LAST (subject-last), so it pipes: `Ui.column([…]) |> Ui.panel(Ui.topLeft())`.
 let panel : (anchor, view) => view
 let topLeft : () => anchor
-// Interactive: a click delivers `msg` verbatim through `update`
-// (docs/ui-interaction.md). Like Sub.every's msg, 'msg is erased by the
-// opaque `view` — the msg↔update link is checked at runtime.
+let topRight : () => anchor
+let bottomLeft : () => anchor
+let bottomRight : () => anchor
+// Interactive widgets (docs/ui-interaction.md); like Sub.every's msg, 'msg is
+// erased by the opaque `view` — the msg↔update link is checked at runtime.
+// A click delivers `msg` verbatim through `update`.
 let button : (string, 'msg) => view
+// A controlled slider: shows `value` (from the model); a drag applies the
+// tagger to the new value and the message folds through `update`.
+// (Function-typed params can't be written in signatures yet, so the tagger
+// is typed by inference at the call site.)
+let slider : (float, float, float, 'tagger) => view

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -57,16 +57,16 @@
 //!   (frame-level distance fog on every forward material, emissive included —
 //!    fog occludes glow; the fog color is also the pass's clear color)
 //! Ui.text(s) / Ui.textColor(r, g, b, s)                     -> View
-//! Ui.column([view, …])                                      -> View
+//! Ui.column([view, …]) / Ui.row([view, …])                  -> View
 //! Ui.panel(anchor, view)                                    -> View
-//! Ui.topLeft()                                              -> Anchor
+//! Ui.topLeft() / topRight() / bottomLeft() / bottomRight()  -> Anchor
 //! Ui.button(label, msg)                                     -> View
-//!   (the optional `ui = (model) => …` hook's tree — hello's HUD shape:
-//!    text lines stacked in a column, pinned to a screen corner. Only the
-//!    corner the port needed exists; the rest arrive with a port that
-//!    needs them. `Ui.panel` takes the view LAST, so it pipes. `Ui.button`
-//!    is interactive: a click delivers `msg` verbatim through `update` —
-//!    docs/ui-interaction.md.)
+//! Ui.slider(min, max, value, tagger)                        -> View
+//!   (the optional `ui = (model) => …` hook's tree. `Ui.panel` takes the
+//!    view LAST, so it pipes. The interactive widgets fold through
+//!    `update` — docs/ui-interaction.md: a button click delivers `msg`
+//!    verbatim (the Sub.every shape); a slider drag applies `tagger` to
+//!    the new value (the Effect.now shape).)
 //! Skybox.files(px, nx, py, ny, pz, nz)                       -> Skybox
 //! Frame.withSkybox(sky, frame)                               -> Frame
 //!   (a cubemap sky drawn behind everything; while the six faces load the
@@ -898,9 +898,14 @@ const PATHS: &[&str] = &[
     "Ui.text",
     "Ui.textColor",
     "Ui.column",
+    "Ui.row",
     "Ui.panel",
     "Ui.topLeft",
+    "Ui.topRight",
+    "Ui.bottomLeft",
+    "Ui.bottomRight",
     "Ui.button",
+    "Ui.slider",
     "Time.seconds",
     "Time.millis",
     "Sub.none",
@@ -2091,6 +2096,36 @@ paths (+X, -X, +Y, -Y, +Z, -Z)",
                 [] => Ok(host(FunctorLangUiAnchor(ui::Anchor::TopLeft))),
                 _ => usage("Ui.topLeft()"),
             },
+            "Ui.topRight" => match args.as_slice() {
+                [] => Ok(host(FunctorLangUiAnchor(ui::Anchor::TopRight))),
+                _ => usage("Ui.topRight()"),
+            },
+            "Ui.bottomLeft" => match args.as_slice() {
+                [] => Ok(host(FunctorLangUiAnchor(ui::Anchor::BottomLeft))),
+                _ => usage("Ui.bottomLeft()"),
+            },
+            "Ui.bottomRight" => match args.as_slice() {
+                [] => Ok(host(FunctorLangUiAnchor(ui::Anchor::BottomRight))),
+                _ => usage("Ui.bottomRight()"),
+            },
+            "Ui.row" => match args.as_slice() {
+                [Value::List(items)] => {
+                    let mut views = Vec::with_capacity(items.len());
+                    for item in items.iter() {
+                        match view_value(item) {
+                            Some(view) => views.push(view.clone()),
+                            None => {
+                                return err(format!(
+                                    "Ui.row items must be Views, got {}",
+                                    item.kind_name()
+                                ))
+                            }
+                        }
+                    }
+                    Ok(host(FunctorLangView(View::Row(views))))
+                }
+                _ => usage("Ui.row([view, …])"),
+            },
             // The first interactive widget (docs/ui-interaction.md U3). The
             // msg is any Functor Lang value (typically an ADT variant), registered in
             // the frame's handler table and delivered VERBATIM through
@@ -2105,6 +2140,34 @@ paths (+X, -X, +Y, -Y, +Z, -Z)",
                     })))
                 }
                 _ => usage("Ui.button(\"label\", msg) — msg is delivered to update on click"),
+            },
+            // A slider over min..=max showing the MODEL's value (a controlled
+            // widget, docs/ui-interaction.md U4). The tagger is applied to
+            // the dragged value and the message folds through `update` — the
+            // `Effect.now` tagger shape.
+            "Ui.slider" => match args.as_slice() {
+                [min, max, value, tagger @ (Value::Closure(_) | Value::Ctor { .. })] => {
+                    let min = num(min, span)?;
+                    let max = num(max, span)?;
+                    if max <= min {
+                        return err(format!(
+                            "Ui.slider: max ({max}) must be greater than min ({min})"
+                        ));
+                    }
+                    let slot = push_ui_handler(UiHandler::Tagger(tagger.clone()));
+                    Ok(host(FunctorLangView(View::Slider {
+                        slot,
+                        min,
+                        max,
+                        value: num(value, span)?,
+                    })))
+                }
+                [_, _, _, other] => err(format!(
+                    "Ui.slider(min, max, value, tagger): the tagger must be a function of \
+the new value, got {}",
+                    other.kind_name()
+                )),
+                _ => usage("Ui.slider(min, max, value, tagger) — tagger: (newValue) => msg"),
             },
             "Time.seconds" => match args.as_slice() {
                 [n] => Ok(host(FunctorLangDuration(num(n, span)?))),
@@ -5018,6 +5081,41 @@ the game dir"
             }
             _ => panic!("both handlers should be verbatim msgs"),
         }
+    }
+
+    // Ui.slider (docs/ui-interaction.md U4): registers its tagger (the
+    // Effect.now shape), carries min/max/value in the node, and rejects a
+    // non-function tagger and an empty range with teaching errors.
+    #[test]
+    fn ui_slider_registers_its_tagger_and_validates() {
+        let _ = take_ui_handlers();
+        let value = eval(
+            "type Msg = | SetSpeed(v: Float)\n\
+             let main = () => Ui.row([\n\
+               Ui.slider(0.0, 10.0, 2.5, SetSpeed),\n\
+             ])",
+        );
+        let view = view_value(&value).expect("main should return a View");
+        assert_eq!(
+            serde_json::to_string(view).unwrap(),
+            r#"{"Row":[{"Slider":{"slot":0,"min":0.0,"max":10.0,"value":2.5}}]}"#
+        );
+        let handlers = take_ui_handlers();
+        assert_eq!(handlers.len(), 1);
+        assert!(matches!(&handlers[0], UiHandler::Tagger(_)));
+
+        assert_eq!(
+            run_fail("let main = () => Ui.slider(0.0, 10.0, 2.5, 42.0)"),
+            "Ui.slider(min, max, value, tagger): the tagger must be a function of \
+the new value, got a number"
+        );
+        let _ = take_ui_handlers();
+
+        assert_eq!(
+            run_fail("let main = () => Ui.slider(5.0, 5.0, 5.0, (v) => v)"),
+            "Ui.slider: max (5) must be greater than min (5)"
+        );
+        let _ = take_ui_handlers();
     }
 
     // --- Networking (Sub.connect/listen, Effect.send, NetEvent) ---

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -589,14 +589,25 @@ mod tests {
             serde_json::from_str(r#"{"Text":{"text":"hi","color":[1,2,3]}}"#).unwrap();
         assert_json_stable(&legacy);
 
-        // The interactive button (docs/ui-interaction.md U3): slot-stamped,
-        // handler kept producer-side so the tree stays serializable.
+        // The interactive widgets (docs/ui-interaction.md U3/U4): slot-stamped,
+        // handlers kept producer-side so the tree stays serializable.
         let button = View::Button {
             slot: 0,
             label: "Reset".to_string(),
         };
         let expected = r#"{"Button":{"slot":0,"label":"Reset"}}"#;
         assert_eq!(serde_json::to_string(&button).unwrap(), expected);
+        let back: View = serde_json::from_str(expected).unwrap();
+        assert_eq!(serde_json::to_string(&back).unwrap(), expected);
+
+        let slider = View::Slider {
+            slot: 1,
+            min: 0.0,
+            max: 10.0,
+            value: 2.5,
+        };
+        let expected = r#"{"Slider":{"slot":1,"min":0.0,"max":10.0,"value":2.5}}"#;
+        assert_eq!(serde_json::to_string(&slider).unwrap(), expected);
         let back: View = serde_json::from_str(expected).unwrap();
         assert_eq!(serde_json::to_string(&back).unwrap(), expected);
     }

--- a/runtime/functor-runtime-common/src/ui.rs
+++ b/runtime/functor-runtime-common/src/ui.rs
@@ -86,6 +86,17 @@ pub enum View {
     /// handler itself (a msg `Value`) never crosses: the tree stays
     /// serializable.
     Button { slot: u32, label: String },
+    /// An interactive slider over `min..=max` (docs/ui-interaction.md U4).
+    /// `value` is the model's CONTROLLED value; a drag comes back as
+    /// `UiEvent { slot, SliderChanged(v) }` per change, and the overlay keeps
+    /// a small per-slot buffer so the one-frame model echo never rubber-bands
+    /// the handle (see `SliderBuffer`).
+    Slider {
+        slot: u32,
+        min: f64,
+        max: f64,
+        value: f64,
+    },
 }
 
 /// 0..1 float components -> 8-bit color, clamped. Shared by the F#-facing
@@ -140,15 +151,40 @@ fn contains_interactive(view: &View) -> bool {
         View::Empty | View::Text { .. } => false,
         View::Column(items) | View::Row(items) => items.iter().any(contains_interactive),
         View::Panel { child, .. } => contains_interactive(child),
-        View::Button { .. } => true,
+        View::Button { .. } | View::Slider { .. } => true,
     }
+}
+
+/// Per-slot slider reconciliation (docs/ui-interaction.md U4): `live` is the
+/// value egui's handle edits; `last_emitted` is the last value sent up as a
+/// `SliderChanged` msg. The model's incoming value overwrites `live` only
+/// when it differs from `last_emitted`: our own edit echoing back one frame
+/// late leaves the handle alone (no rubber-banding mid-drag), while a change
+/// we did NOT cause — game logic, a Reset button, an `update` that clamps —
+/// is programmatic and snaps the handle to it. (Corollary: an `update` that
+/// clamps NARROWER than the slider's own range churns per frame while a drag
+/// is held past the cap — the snap and the pointer fight. Prefer matching
+/// the slider's min/max to the accepted range.)
+struct SliderBuffer {
+    live: f64,
+    last_emitted: f64,
+}
+
+/// The mutable per-frame state a [`View`] render threads through the tree:
+/// the slot-stamped interactions egui detected, plus the stateful widgets'
+/// reconciliation buffers (owned by [`TextOverlay`], keyed by slot; `seen`
+/// collects this frame's live slots so stale buffers drop after the pass).
+struct UiFrameState<'a> {
+    events: &'a mut Vec<UiEvent>,
+    sliders: &'a mut std::collections::HashMap<u32, SliderBuffer>,
+    seen_sliders: &'a mut std::collections::HashSet<u32>,
 }
 
 /// Render a declarative [`View`] into `ui` using egui's own layout (vertical /
 /// horizontal / anchored `Area`), so line height and spacing come from the font
 /// being rendered — no manual metrics, and lines never overlap. Interactions
-/// egui detects on the view's widgets land in `events`, slot-stamped.
-fn render_view(ui: &mut egui::Ui, view: &View, events: &mut Vec<UiEvent>) {
+/// egui detects on the view's widgets land in `state.events`, slot-stamped.
+fn render_view(ui: &mut egui::Ui, view: &View, state: &mut UiFrameState) {
     match view {
         View::Empty => {}
         View::Text { text, color, .. } => {
@@ -162,14 +198,14 @@ fn render_view(ui: &mut egui::Ui, view: &View, events: &mut Vec<UiEvent>) {
         View::Column(items) => {
             ui.vertical(|ui| {
                 for item in items {
-                    render_view(ui, item, events);
+                    render_view(ui, item, state);
                 }
             });
         }
         View::Row(items) => {
             ui.horizontal(|ui| {
                 for item in items {
-                    render_view(ui, item, events);
+                    render_view(ui, item, state);
                 }
             });
         }
@@ -179,16 +215,45 @@ fn render_view(ui: &mut egui::Ui, view: &View, events: &mut Vec<UiEvent>) {
             egui::Area::new(egui::Id::new(("functor_ui_panel", anchor_id(*anchor))))
                 .anchor(align, offset)
                 .interactable(contains_interactive(child))
-                .show(&ctx, |ui| render_view(ui, child, events));
+                .show(&ctx, |ui| render_view(ui, child, state));
         }
         View::Button { slot, label } => {
             let clicked = ui
                 .button(egui::RichText::new(label).font(egui::FontId::monospace(UI_FONT_SIZE)))
                 .clicked();
             if clicked {
-                events.push(UiEvent {
+                state.events.push(UiEvent {
                     slot: *slot,
                     kind: UiEventKind::Clicked,
+                });
+            }
+        }
+        View::Slider {
+            slot,
+            min,
+            max,
+            value,
+        } => {
+            state.seen_sliders.insert(*slot);
+            let buf = state.sliders.entry(*slot).or_insert(SliderBuffer {
+                live: *value,
+                last_emitted: *value,
+            });
+            // Echo vs programmatic: see `SliderBuffer`. (Exact f64 equality
+            // is right here — the echo is the emitted value round-tripped
+            // through the interpreter unchanged.)
+            if *value != buf.last_emitted {
+                buf.live = *value;
+                buf.last_emitted = *value;
+            }
+            let mut v = buf.live;
+            let changed = ui.add(egui::Slider::new(&mut v, *min..=*max)).changed();
+            buf.live = v;
+            if changed {
+                buf.last_emitted = v;
+                state.events.push(UiEvent {
+                    slot: *slot,
+                    kind: UiEventKind::SliderChanged(v),
                 });
             }
         }
@@ -248,6 +313,9 @@ pub struct TextOverlay {
     painter: egui_glow::Painter,
     gl: Arc<glow::Context>,
     pointer: PointerBridge,
+    /// Per-slot slider reconciliation state, kept across frames (see
+    /// [`SliderBuffer`]); entries whose slot leaves the view are dropped.
+    sliders: std::collections::HashMap<u32, SliderBuffer>,
 }
 
 impl TextOverlay {
@@ -262,6 +330,7 @@ impl TextOverlay {
             painter,
             gl,
             pointer: PointerBridge::default(),
+            sliders: std::collections::HashMap::new(),
         }
     }
 
@@ -322,20 +391,38 @@ impl TextOverlay {
             }
             return UiOutput::default();
         }
+        // A zero-size frame never runs the build (`run_and_paint` bails), so
+        // bail BEFORE the buffer sweep below — a minimized window must not
+        // wipe every slider buffer via an all-unseen retain. [xreview]
+        if width == 0 || height == 0 {
+            return UiOutput::default();
+        }
         let mut events = Vec::new();
+        let mut seen_sliders = std::collections::HashSet::new();
+        // Moved out for the pass — `run_and_paint` borrows self mutably too.
+        let mut sliders = std::mem::take(&mut self.sliders);
         self.run_and_paint(width, height, pixels_per_point, pointer_events, |ui| {
+            let mut state = UiFrameState {
+                events: &mut events,
+                sliders: &mut sliders,
+                seen_sliders: &mut seen_sliders,
+            };
             match view {
                 // A panel anchors itself; a bare root sits at the top-left with a margin.
-                View::Panel { .. } => render_view(ui, view, &mut events),
+                View::Panel { .. } => render_view(ui, view, &mut state),
                 other => {
                     let ctx = ui.ctx().clone();
                     egui::Area::new(egui::Id::new("functor_ui_root"))
                         .anchor(egui::Align2::LEFT_TOP, egui::vec2(MARGIN, MARGIN))
                         .interactable(contains_interactive(other))
-                        .show(&ctx, |ui| render_view(ui, other, &mut events));
+                        .show(&ctx, |ui| render_view(ui, other, &mut state));
                 }
             }
         });
+        // A slot that left the view is a different widget if it ever returns
+        // (positional identity) — drop its buffer rather than resurrect it.
+        sliders.retain(|slot, _| seen_sliders.contains(slot));
+        self.sliders = sliders;
         UiOutput {
             events,
             wants_pointer: self.ctx.egui_wants_pointer_input(),

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -1402,8 +1402,13 @@ Escape again to quit"
             // an overlapping region fires a game button AND a scrubber
             // control (each pass is its own egui context; there is no shared
             // hit-test). `pos: None` makes the game UI's bridge release any
-            // held press and clear hover. [xreview]
-            let ui_pointer = if scrubber_visible && scrubber_wants_pointer {
+            // held press and clear hover. Same while the clock is pinned:
+            // the events would be dropped anyway (the window-input rule), so
+            // don't let egui process the interaction at all — a paused
+            // button must not visually depress, and a paused slider drag
+            // must not fight its own reconciliation. [xreview]
+            let ui_pointer = if (scrubber_visible && scrubber_wants_pointer) || ignore_user_input
+            {
                 functor_runtime_common::ui::PointerState {
                     pos: None,
                     primary_down: pointer.primary_down,

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -1232,7 +1232,14 @@ async fn run_async() -> Result<(), JsValue> {
             let view: functor_runtime_common::ui::View = game.ui();
             let dpr = web_sys::window().unwrap().device_pixel_ratio() as f32;
             let dpr = dpr.max(1.0);
-            let ui_pointer = functor_lang_game::ui_pointer_state(dpr);
+            // While the clock is pinned, events would be dropped anyway (the
+            // window-input rule) — hide the pointer from egui entirely so a
+            // paused interaction can't visually engage widgets or fight the
+            // slider reconciliation (the desktop rule). [xreview]
+            let mut ui_pointer = functor_lang_game::ui_pointer_state(dpr);
+            if clock.is_pinned() {
+                ui_pointer.pos = None;
+            }
             let ui_out = text_overlay.draw_view(
                 canvas.width(),
                 canvas.height(),


### PR DESCRIPTION
## What

U4a of the interactive-UI plan (design doc #289; the pointer-only half of U4 — `Ui.textInput` and its keyboard plumbing follow separately). The tagger message shape is now live end to end:

```
Ui.slider(0.0, 3.0, m.speed, SetSpeed)   // a drag applies SetSpeed to the new
                                         // value; the msg folds through update
```

- **`View::Slider { slot, min, max, value }`** (wire pinned) + prelude **`Ui.slider(min, max, value, tagger)`**: registers the tagger (the `Effect.now` shape), with teaching errors for a non-function tagger and an empty range.
- **The design doc's controlled-slider reconciliation**, implemented in the overlay: a per-slot `SliderBuffer { live, last_emitted }` — the model's incoming value moves the handle only when it differs from `last_emitted`, so our own one-frame-late echo never rubber-bands a drag, while a programmatic change (game logic, an `update` that clamps) snaps the handle. Buffers drop when their slot leaves the view (positional identity).
- **`Ui.row`** (the `View::Row` ctor gap) and **`Ui.topRight`/`bottomLeft`/`bottomRight`**.
- funi + skill updated in the same PR (the language rule). No shell input changes needed — the U3 pointer path drives sliders as-is.

## Review (cross-engine, both ran)

- **[AGREED] zero-size-frame buffer wipe** — a minimized window ran the retain sweep with nothing seen, dropping every buffer; fixed (bail before the sweep).
- **Pinned-clock interaction** (Codex): while input is gated the overlay now hides the pointer from egui entirely (both shells) — a paused drag can't fight the reconciliation, and (fixing a U3 cosmetic) a paused button no longer visually depresses.
- **Clamp-churn** (both engines, severity disputed): an `update` clamping *narrower than the slider's range* churns snap-vs-pointer while a drag is held past the cap. Claude traced it as the documented controlled-widget semantics; Codex's drag-cancel would kill legitimate drags on programmatic changes. Kept as documented behavior with a doc-comment corollary: match the slider's range to the accepted range.
- **Not taken** (Codex speculation contradicted by source): "egui clamping an out-of-range model value emits a spurious `SliderChanged`" — the Claude reviewer verified in vendored egui 0.34 that clamping happens before the change-check, so no event fires; NaN can't reach the node either (`num` rejects non-finite).

## Verification

- 246 tests (new: slider ctor registration + validation from `.fun` source, `Slider` wire pin); goldens byte-stable; all targets build.
- Live e2e: debug-server `{"kind":{"SliderChanged":2.4}}` on a scratch slider game moves the model `{ speed: 1 }` → `{ speed: 2.4 }`; a `Clicked` on the tagger slot drops with the teaching report.

Visuals follow in the body (pr-visuals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Demo

![Ui.slider demo](https://gist.githubusercontent.com/tommy-xr/dcbdefe8edaa7ebbc0f74f8f342eb615/raw/slider-demo.gif)

<sub>Ui.slider driven headlessly: six debug-server SliderChanged events sweep speed 1.0 → 3.0 — the tagger msg folds through update, the cube scale, HUD text, and handle follow. Captured via POST /capture under `--fixed-time`.</sub>

![Ui.slider still at speed 3.0](https://gist.githubusercontent.com/tommy-xr/dcbdefe8edaa7ebbc0f74f8f342eb615/raw/slider-still.png)
