### PR TITLE
feat(ui): Ui.textInput — controlled text editing with the keyboard focus gate

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -465,6 +465,18 @@ Ui.slider(min, max, value, tagger)                         // INTERACTIVE contro
                                                            //   max must exceed min; tagger must
                                                            //   be a function/ctor. Headless:
                                                            //   {"kind":{"SliderChanged":0.5}}
+Ui.textInput(value, tagger)                                // INTERACTIVE controlled single-line
+                                                           //   text input: shows the MODEL's
+                                                           //   text; each edit applies tagger to
+                                                           //   the new text. While a field is
+                                                           //   FOCUSED the game's `input` hook
+                                                           //   is suppressed (keys type into the
+                                                           //   field; Escape defocuses first,
+                                                           //   releases the cursor second). An
+                                                           //   `update` that transforms the text
+                                                           //   resets the cursor to the end.
+                                                           //   Headless:
+                                                           //   {"kind":{"TextChanged":"hi"}}
 
 Physics.box(w, h, d) / sphere(r) / capsule(halfH, r)       // -> Shape (box = FULL extents)
 Physics.dynamic("tag", shape)                              // simulated body

--- a/functor-prelude/prelude/ui.funi
+++ b/functor-prelude/prelude/ui.funi
@@ -28,3 +28,6 @@ let button : (string, 'msg) => view
 // (Function-typed params can't be written in signatures yet, so the tagger
 // is typed by inference at the call site.)
 let slider : (float, float, float, 'tagger) => view
+// A controlled single-line text input: shows `value` (from the model); an
+// edit applies the tagger to the new text.
+let textInput : (string, 'tagger) => view

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -62,11 +62,12 @@
 //! Ui.topLeft() / topRight() / bottomLeft() / bottomRight()  -> Anchor
 //! Ui.button(label, msg)                                     -> View
 //! Ui.slider(min, max, value, tagger)                        -> View
+//! Ui.textInput(value, tagger)                               -> View
 //!   (the optional `ui = (model) => …` hook's tree. `Ui.panel` takes the
 //!    view LAST, so it pipes. The interactive widgets fold through
 //!    `update` — docs/ui-interaction.md: a button click delivers `msg`
-//!    verbatim (the Sub.every shape); a slider drag applies `tagger` to
-//!    the new value (the Effect.now shape).)
+//!    verbatim (the Sub.every shape); a slider drag / text edit applies
+//!    `tagger` to the new value (the Effect.now shape).)
 //! Skybox.files(px, nx, py, ny, pz, nz)                       -> Skybox
 //! Frame.withSkybox(sky, frame)                               -> Frame
 //!   (a cubemap sky drawn behind everything; while the six faces load the
@@ -906,6 +907,7 @@ const PATHS: &[&str] = &[
     "Ui.bottomRight",
     "Ui.button",
     "Ui.slider",
+    "Ui.textInput",
     "Time.seconds",
     "Time.millis",
     "Sub.none",
@@ -2168,6 +2170,24 @@ the new value, got {}",
                     other.kind_name()
                 )),
                 _ => usage("Ui.slider(min, max, value, tagger) — tagger: (newValue) => msg"),
+            },
+            // A single-line text input showing the MODEL's text (controlled,
+            // docs/ui-interaction.md U4). The tagger is applied to the new
+            // text on each edit — the `Effect.now` tagger shape.
+            "Ui.textInput" => match args.as_slice() {
+                [Value::String(value), tagger @ (Value::Closure(_) | Value::Ctor { .. })] => {
+                    let slot = push_ui_handler(UiHandler::Tagger(tagger.clone()));
+                    Ok(host(FunctorLangView(View::TextInput {
+                        slot,
+                        value: value.to_string(),
+                    })))
+                }
+                [_, other] => err(format!(
+                    "Ui.textInput(value, tagger): the tagger must be a function of \
+the new text, got {}",
+                    other.kind_name()
+                )),
+                _ => usage("Ui.textInput(value, tagger) — tagger: (newText) => msg"),
             },
             "Time.seconds" => match args.as_slice() {
                 [n] => Ok(host(FunctorLangDuration(num(n, span)?))),
@@ -5114,6 +5134,33 @@ the new value, got a number"
         assert_eq!(
             run_fail("let main = () => Ui.slider(5.0, 5.0, 5.0, (v) => v)"),
             "Ui.slider: max (5) must be greater than min (5)"
+        );
+        let _ = take_ui_handlers();
+    }
+
+    // Ui.textInput (docs/ui-interaction.md U4): the text sibling of the
+    // slider — registers its tagger, carries the model's value, rejects a
+    // non-function tagger.
+    #[test]
+    fn ui_text_input_registers_its_tagger_and_validates() {
+        let _ = take_ui_handlers();
+        let value = eval(
+            "type Msg = | SetName(s: String)\n\
+             let main = () => Ui.textInput(\"functor\", SetName)",
+        );
+        let view = view_value(&value).expect("main should return a View");
+        assert_eq!(
+            serde_json::to_string(view).unwrap(),
+            r#"{"TextInput":{"slot":0,"value":"functor"}}"#
+        );
+        let handlers = take_ui_handlers();
+        assert_eq!(handlers.len(), 1);
+        assert!(matches!(&handlers[0], UiHandler::Tagger(_)));
+
+        assert_eq!(
+            run_fail("let main = () => Ui.textInput(\"x\", 42.0)"),
+            "Ui.textInput(value, tagger): the tagger must be a function of \
+the new text, got a number"
         );
         let _ = take_ui_handlers();
     }

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -610,5 +610,14 @@ mod tests {
         assert_eq!(serde_json::to_string(&slider).unwrap(), expected);
         let back: View = serde_json::from_str(expected).unwrap();
         assert_eq!(serde_json::to_string(&back).unwrap(), expected);
+
+        let text_input = View::TextInput {
+            slot: 2,
+            value: "hi".to_string(),
+        };
+        let expected = r#"{"TextInput":{"slot":2,"value":"hi"}}"#;
+        assert_eq!(serde_json::to_string(&text_input).unwrap(), expected);
+        let back: View = serde_json::from_str(expected).unwrap();
+        assert_eq!(serde_json::to_string(&back).unwrap(), expected);
     }
 }

--- a/runtime/functor-runtime-common/src/ui.rs
+++ b/runtime/functor-runtime-common/src/ui.rs
@@ -97,6 +97,12 @@ pub enum View {
         max: f64,
         value: f64,
     },
+    /// An interactive single-line text input (docs/ui-interaction.md U4).
+    /// `value` is the model's CONTROLLED text; an edit comes back as
+    /// `UiEvent { slot, TextChanged(s) }` per change. The overlay keeps the
+    /// live editing buffer (see `TextBuffer`) — egui owns cursor/selection
+    /// state, the model owns the canonical text.
+    TextInput { slot: u32, value: String },
 }
 
 /// 0..1 float components -> 8-bit color, clamped. Shared by the F#-facing
@@ -151,7 +157,70 @@ fn contains_interactive(view: &View) -> bool {
         View::Empty | View::Text { .. } => false,
         View::Column(items) | View::Row(items) => items.iter().any(contains_interactive),
         View::Panel { child, .. } => contains_interactive(child),
-        View::Button { .. } | View::Slider { .. } => true,
+        View::Button { .. } | View::Slider { .. } | View::TextInput { .. } => true,
+    }
+}
+
+/// A keyboard event for the game-UI pass, in shell-neutral vocabulary — the
+/// shells collect these while egui wants the keyboard (a text input is
+/// focused) and [`TextOverlay::draw_view`] lowers them to egui events. `Char`
+/// is printable input (desktop: GLFW char events; web: single-char `e.key`);
+/// `Edit` is the editing-key subset egui's `TextEdit` needs. No modifier
+/// combos yet (no shift-selection / cmd-shortcuts) — v1 is basic editing.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum UiKeyboardEvent {
+    Char(char),
+    Edit(UiEditKey),
+}
+
+/// The editing keys a focused text input consumes (see [`UiKeyboardEvent`]).
+/// `Escape` releases focus (egui's built-in behavior) — shells route Escape
+/// here INSTEAD of their own Escape handling while a field is focused.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum UiEditKey {
+    Backspace,
+    Delete,
+    Left,
+    Right,
+    Home,
+    End,
+    Enter,
+    Escape,
+}
+
+/// Lower a [`UiKeyboardEvent`] to the egui event(s) it means. An edit key
+/// arrives as a full press+release pair so egui's key-repeat bookkeeping
+/// stays consistent frame to frame.
+fn keyboard_to_egui(event: UiKeyboardEvent, out: &mut Vec<egui::Event>) {
+    match event {
+        UiKeyboardEvent::Char(c) => {
+            // egui ignores control characters in Text events; filter the
+            // obvious ones so a stray '\r' from a shell can't sneak in.
+            if !c.is_control() {
+                out.push(egui::Event::Text(c.to_string()));
+            }
+        }
+        UiKeyboardEvent::Edit(key) => {
+            let key = match key {
+                UiEditKey::Backspace => egui::Key::Backspace,
+                UiEditKey::Delete => egui::Key::Delete,
+                UiEditKey::Left => egui::Key::ArrowLeft,
+                UiEditKey::Right => egui::Key::ArrowRight,
+                UiEditKey::Home => egui::Key::Home,
+                UiEditKey::End => egui::Key::End,
+                UiEditKey::Enter => egui::Key::Enter,
+                UiEditKey::Escape => egui::Key::Escape,
+            };
+            for pressed in [true, false] {
+                out.push(egui::Event::Key {
+                    key,
+                    physical_key: None,
+                    pressed,
+                    repeat: false,
+                    modifiers: egui::Modifiers::default(),
+                });
+            }
+        }
     }
 }
 
@@ -170,6 +239,19 @@ struct SliderBuffer {
     last_emitted: f64,
 }
 
+/// Per-slot text-input reconciliation (docs/ui-interaction.md U4) — the
+/// text analogue of [`SliderBuffer`], with the same echo rule: the model's
+/// incoming value overwrites the live editing buffer only when it differs
+/// from `last_emitted`. Comparing against the BUFFER instead would clobber
+/// every keystroke (the model echo is one frame behind while typing) — the
+/// comparison target is load-bearing. A transform in `update` (uppercase,
+/// clamp-length) reads as programmatic: the field resets to it with the
+/// cursor moved to the end — the React-parity wart, accepted.
+struct TextBuffer {
+    live: String,
+    last_emitted: String,
+}
+
 /// The mutable per-frame state a [`View`] render threads through the tree:
 /// the slot-stamped interactions egui detected, plus the stateful widgets'
 /// reconciliation buffers (owned by [`TextOverlay`], keyed by slot; `seen`
@@ -178,6 +260,8 @@ struct UiFrameState<'a> {
     events: &'a mut Vec<UiEvent>,
     sliders: &'a mut std::collections::HashMap<u32, SliderBuffer>,
     seen_sliders: &'a mut std::collections::HashSet<u32>,
+    texts: &'a mut std::collections::HashMap<u32, TextBuffer>,
+    seen_texts: &'a mut std::collections::HashSet<u32>,
 }
 
 /// Render a declarative [`View`] into `ui` using egui's own layout (vertical /
@@ -257,6 +341,31 @@ fn render_view(ui: &mut egui::Ui, view: &View, state: &mut UiFrameState) {
                 });
             }
         }
+        View::TextInput { slot, value } => {
+            state.seen_texts.insert(*slot);
+            let buf = state.texts.entry(*slot).or_insert_with(|| TextBuffer {
+                live: value.clone(),
+                last_emitted: value.clone(),
+            });
+            // Echo vs programmatic: see `TextBuffer`.
+            if *value != buf.last_emitted {
+                buf.live = value.clone();
+                buf.last_emitted = value.clone();
+            }
+            let changed = ui
+                .add(
+                    egui::TextEdit::singleline(&mut buf.live)
+                        .font(egui::FontId::monospace(UI_FONT_SIZE)),
+                )
+                .changed();
+            if changed {
+                buf.last_emitted = buf.live.clone();
+                state.events.push(UiEvent {
+                    slot: *slot,
+                    kind: UiEventKind::TextChanged(buf.live.clone()),
+                });
+            }
+        }
     }
 }
 
@@ -306,6 +415,10 @@ pub struct UiOutput {
     /// egui is using the pointer (hovering/clicking a widget), so the shell
     /// must NOT treat a click as a free-look recapture (the scrubber rule).
     pub wants_pointer: bool,
+    /// egui wants the keyboard (a text input is focused): the shell routes
+    /// keys to the overlay as [`UiKeyboardEvent`]s and suppresses the game's
+    /// `input` hook (docs/ui-interaction.md U4).
+    pub wants_keyboard: bool,
 }
 
 pub struct TextOverlay {
@@ -316,6 +429,8 @@ pub struct TextOverlay {
     /// Per-slot slider reconciliation state, kept across frames (see
     /// [`SliderBuffer`]); entries whose slot leaves the view are dropped.
     sliders: std::collections::HashMap<u32, SliderBuffer>,
+    /// Per-slot text-input editing buffers (see [`TextBuffer`]), same rules.
+    texts: std::collections::HashMap<u32, TextBuffer>,
 }
 
 impl TextOverlay {
@@ -331,6 +446,7 @@ impl TextOverlay {
             gl,
             pointer: PointerBridge::default(),
             sliders: std::collections::HashMap::new(),
+            texts: std::collections::HashMap::new(),
         }
     }
 
@@ -369,43 +485,53 @@ impl TextOverlay {
     /// height and spacing come from the rendered font (no manual metrics, no
     /// overlap). `width`/`height` are physical framebuffer pixels. `pointer`
     /// drives the view's interactive widgets ([`PointerState::default`] for a
-    /// display-only pass); interactions come back slot-stamped in the
-    /// [`UiOutput`] for the shell to forward to `GameProducer::ui_event`.
+    /// display-only pass) and `keyboard` feeds a focused text input (empty
+    /// unless the shell saw `wants_keyboard` last frame); interactions come
+    /// back slot-stamped in the [`UiOutput`] for the shell to forward to
+    /// `GameProducer::ui_event`.
     pub fn draw_view(
         &mut self,
         width: u32,
         height: u32,
         pixels_per_point: f32,
         pointer: PointerState,
+        keyboard: &[UiKeyboardEvent],
         view: &View,
     ) -> UiOutput {
         // Tick the bridge even when nothing draws, so button edges spanning
         // an Empty frame don't replay as phantom clicks later.
-        let pointer_events = self.pointer.events(pointer, pixels_per_point);
+        let mut input_events = self.pointer.events(pointer, pixels_per_point);
+        for event in keyboard {
+            keyboard_to_egui(*event, &mut input_events);
+        }
         if matches!(view, View::Empty) {
             // Still feed egui any release/PointerGone the bridge synthesized:
             // a view hidden mid-press must not leave the context holding a
             // stuck press for the view's return. [xreview]
-            if !pointer_events.is_empty() {
-                self.run_and_paint(width, height, pixels_per_point, pointer_events, |_| {});
+            if !input_events.is_empty() {
+                self.run_and_paint(width, height, pixels_per_point, input_events, |_| {});
             }
             return UiOutput::default();
         }
         // A zero-size frame never runs the build (`run_and_paint` bails), so
         // bail BEFORE the buffer sweep below — a minimized window must not
-        // wipe every slider buffer via an all-unseen retain. [xreview]
+        // wipe every widget buffer via an all-unseen retain. [xreview]
         if width == 0 || height == 0 {
             return UiOutput::default();
         }
         let mut events = Vec::new();
         let mut seen_sliders = std::collections::HashSet::new();
+        let mut seen_texts = std::collections::HashSet::new();
         // Moved out for the pass — `run_and_paint` borrows self mutably too.
         let mut sliders = std::mem::take(&mut self.sliders);
-        self.run_and_paint(width, height, pixels_per_point, pointer_events, |ui| {
+        let mut texts = std::mem::take(&mut self.texts);
+        self.run_and_paint(width, height, pixels_per_point, input_events, |ui| {
             let mut state = UiFrameState {
                 events: &mut events,
                 sliders: &mut sliders,
                 seen_sliders: &mut seen_sliders,
+                texts: &mut texts,
+                seen_texts: &mut seen_texts,
             };
             match view {
                 // A panel anchors itself; a bare root sits at the top-left with a margin.
@@ -422,10 +548,13 @@ impl TextOverlay {
         // A slot that left the view is a different widget if it ever returns
         // (positional identity) — drop its buffer rather than resurrect it.
         sliders.retain(|slot, _| seen_sliders.contains(slot));
+        texts.retain(|slot, _| seen_texts.contains(slot));
         self.sliders = sliders;
+        self.texts = texts;
         UiOutput {
             events,
             wants_pointer: self.ctx.egui_wants_pointer_input(),
+            wants_keyboard: self.ctx.egui_wants_keyboard_input(),
         }
     }
 
@@ -831,4 +960,144 @@ mod tests {
         let events = bridge.events(on(200.0, 100.0, false), 2.0);
         assert!(matches!(events[0], egui::Event::PointerMoved(p) if p == egui::pos2(100.0, 50.0)));
     }
+
+    /// Run one HEADLESS egui frame (no painter/GL — only painting needs a
+    /// context) over a view, returning the widget events it produced.
+    fn run_widget_frame(
+        ctx: &egui::Context,
+        input: Vec<egui::Event>,
+        texts: &mut std::collections::HashMap<u32, TextBuffer>,
+        view: &View,
+    ) -> Vec<UiEvent> {
+        let mut events = Vec::new();
+        let mut sliders = std::collections::HashMap::new();
+        let mut seen_sliders = std::collections::HashSet::new();
+        let mut seen_texts = std::collections::HashSet::new();
+        let raw = egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(
+                egui::Pos2::ZERO,
+                egui::vec2(800.0, 600.0),
+            )),
+            events: input,
+            ..Default::default()
+        };
+        let _ = ctx.run_ui(raw, |ui| {
+            let mut state = UiFrameState {
+                events: &mut events,
+                sliders: &mut sliders,
+                seen_sliders: &mut seen_sliders,
+                texts,
+                seen_texts: &mut seen_texts,
+            };
+            render_view(ui, view, &mut state);
+        });
+        events
+    }
+
+    /// The risky U4 path, exercised headlessly end to end: click to focus the
+    /// field, type through egui's `TextEdit`, and check both reconciliation
+    /// rules — the emitted echo leaves the buffer alone, a programmatic model
+    /// change resets it.
+    #[test]
+    fn typing_into_a_focused_text_input_emits_and_reconciles() {
+        let ctx = egui::Context::default();
+        let mut texts = std::collections::HashMap::new();
+        let view = |value: &str| View::TextInput {
+            slot: 0,
+            value: value.to_string(),
+        };
+
+        // Warmup: egui hit-tests input against the PREVIOUS frame's widget
+        // rects, so the field must exist for a frame before a click can land.
+        assert!(run_widget_frame(&ctx, Vec::new(), &mut texts, &view("cube")).is_empty());
+
+        // Then click inside the field (it renders at the top-left of the
+        // root Ui, rect ~280x19) to focus it. egui needs both button edges.
+        let click_pos = egui::pos2(30.0, 12.0);
+        let press = vec![
+            egui::Event::PointerMoved(click_pos),
+            egui::Event::PointerButton {
+                pos: click_pos,
+                button: egui::PointerButton::Primary,
+                pressed: true,
+                modifiers: egui::Modifiers::default(),
+            },
+        ];
+        assert!(run_widget_frame(&ctx, press, &mut texts, &view("cube")).is_empty());
+        let release = vec![egui::Event::PointerButton {
+            pos: click_pos,
+            button: egui::PointerButton::Primary,
+            pressed: false,
+            modifiers: egui::Modifiers::default(),
+        }];
+        assert!(run_widget_frame(&ctx, release, &mut texts, &view("cube")).is_empty());
+        assert!(ctx.egui_wants_keyboard_input(), "click should focus the field");
+
+        // Frame 3: a typed character (the shell's Char event, lowered the
+        // same way draw_view lowers it) must emit exactly one TextChanged.
+        let mut typed = Vec::new();
+        keyboard_to_egui(UiKeyboardEvent::Char('s'), &mut typed);
+        let events = run_widget_frame(&ctx, typed, &mut texts, &view("cube"));
+        assert_eq!(events.len(), 1);
+        let UiEventKind::TextChanged(new_text) = &events[0].kind else {
+            panic!("expected TextChanged, got {:?}", events[0].kind);
+        };
+        assert!(new_text.contains('s'), "typed char should land: {new_text:?}");
+        let emitted = new_text.clone();
+
+        // Frame 4 — the ECHO: the model comes back equal to what we emitted;
+        // the buffer must be left alone and nothing re-emitted.
+        assert!(run_widget_frame(&ctx, Vec::new(), &mut texts, &view(&emitted)).is_empty());
+        assert_eq!(texts.get(&0).unwrap().live, emitted);
+
+        // Frame 5 — PROGRAMMATIC: a model value that isn't our echo (a game
+        // reset) snaps the buffer to it.
+        assert!(run_widget_frame(&ctx, Vec::new(), &mut texts, &view("reset")).is_empty());
+        assert_eq!(texts.get(&0).unwrap().live, "reset");
+        assert_eq!(texts.get(&0).unwrap().last_emitted, "reset");
+    }
+
+    /// Backspace through the synthesized edit-key pair deletes in a focused
+    /// field — the editing-key half of the keyboard path.
+    #[test]
+    fn backspace_edits_a_focused_text_input() {
+        let ctx = egui::Context::default();
+        let mut texts = std::collections::HashMap::new();
+        let view = View::TextInput {
+            slot: 0,
+            value: "ab".to_string(),
+        };
+
+        // Warmup so the click can hit (see the sibling test), then focus
+        // with a click; End pins the cursor after the last char.
+        let _ = run_widget_frame(&ctx, Vec::new(), &mut texts, &view);
+        let click_pos = egui::pos2(30.0, 12.0);
+        let mut input = vec![
+            egui::Event::PointerMoved(click_pos),
+            egui::Event::PointerButton {
+                pos: click_pos,
+                button: egui::PointerButton::Primary,
+                pressed: true,
+                modifiers: egui::Modifiers::default(),
+            },
+            egui::Event::PointerButton {
+                pos: click_pos,
+                button: egui::PointerButton::Primary,
+                pressed: false,
+                modifiers: egui::Modifiers::default(),
+            },
+        ];
+        keyboard_to_egui(UiKeyboardEvent::Edit(UiEditKey::End), &mut input);
+        let _ = run_widget_frame(&ctx, input, &mut texts, &view);
+
+        let mut backspace = Vec::new();
+        keyboard_to_egui(UiKeyboardEvent::Edit(UiEditKey::Backspace), &mut backspace);
+        let events = run_widget_frame(&ctx, backspace, &mut texts, &view);
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            &events[0].kind,
+            UiEventKind::TextChanged(s) if s == "a"
+        ));
+    }
+
 }

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -786,6 +786,10 @@ pub fn run(args: Args) {
 
             window.make_current();
             window.set_key_polling(true);
+            // Printable characters for a focused `Ui.textInput`
+            // (docs/ui-interaction.md U4) — GLFW delivers text as separate
+            // Char events beside the Key stream.
+            window.set_char_polling(true);
             window.set_cursor_pos_polling(true);
             window.set_scroll_polling(true);
             window.set_mouse_button_polling(true);
@@ -830,6 +834,11 @@ pub fn run(args: Args) {
         // click on a `Ui.button` must drive the widget, not recapture the
         // cursor for free-look (the scrubber rule, docs/ui-interaction.md).
         let mut ui_wants_pointer = false;
+        // Whether it wanted the KEYBOARD last frame (a `Ui.textInput` is
+        // focused): keys then route to the overlay instead of the game's
+        // `input` hook, and Escape defocuses the field instead of releasing
+        // the cursor (docs/ui-interaction.md U4).
+        let mut ui_wants_keyboard = false;
         // The time-travel console (`~`): HIDDEN by default in the native game
         // (it's a dev tool you summon with `~`, which also frees the cursor so
         // you can scrub right away). The wasm/vscode preview shows it always.
@@ -970,9 +979,34 @@ pub fn run(args: Args) {
             // capture can't turn the camera). Window close/escape and the debug
             // server's /input still work.
             let ignore_user_input = clock.is_pinned();
+            // Keyboard events for a focused `Ui.textInput` this frame,
+            // collected from the GLFW stream while the overlay wants the
+            // keyboard and handed to `draw_view` below. While the clock is
+            // pinned nothing is collected — typing is inert like all other
+            // window input.
+            let mut ui_keyboard: Vec<functor_runtime_common::ui::UiKeyboardEvent> = Vec::new();
             for (_, event) in glfw::flush_messages(&events) {
                 match event {
                     glfw::WindowEvent::Close => window.set_should_close(true),
+                    // Printable text for a focused field. Only meaningful
+                    // while the overlay wants the keyboard; otherwise Char
+                    // events are dropped (the game hears keys, not text).
+                    glfw::WindowEvent::Char(c)
+                        if ui_wants_keyboard && !ignore_user_input =>
+                    {
+                        ui_keyboard
+                            .push(functor_runtime_common::ui::UiKeyboardEvent::Char(c));
+                    }
+                    // While a field is focused, Escape DEFOCUSES it (egui's
+                    // built-in) instead of releasing the cursor — the next
+                    // Escape then falls through to the arm below.
+                    glfw::WindowEvent::Key(Key::Escape, _, Action::Press, _)
+                        if ui_wants_keyboard && !ignore_user_input =>
+                    {
+                        ui_keyboard.push(functor_runtime_common::ui::UiKeyboardEvent::Edit(
+                            functor_runtime_common::ui::UiEditKey::Escape,
+                        ));
+                    }
                     // First Escape releases the cursor (edit code while the
                     // game runs — the hot-reload workflow); Escape again while
                     // released quits, preserving the Esc-Esc exit.
@@ -992,8 +1026,12 @@ Escape again to quit"
                     // cursor (so you can scrub immediately); closing returns to
                     // free-look. Before the `ignore_user_input` catch-all so it
                     // works while the clock is pinned (paused). Never grabs the
-                    // pointer on a hidden window.
-                    glfw::WindowEvent::Key(Key::GraveAccent, _, Action::Press, _) => {
+                    // pointer on a hidden window. Guarded off while a text
+                    // field is focused — typing '`' must insert, not toggle
+                    // (the char arrives via the Char arm above).
+                    glfw::WindowEvent::Key(Key::GraveAccent, _, Action::Press, _)
+                        if !ui_wants_keyboard =>
+                    {
                         scrubber_visible = !scrubber_visible;
                         if !hidden {
                             if scrubber_visible {
@@ -1058,10 +1096,18 @@ Escape again to quit"
                     // !ignore_user_input while keeping held_keys/cursor bookkeeping.
                     glfw::WindowEvent::Key(key, _, Action::Release, _) => {
                         let k = map_key(key);
-                        if !ignore_user_input {
+                        // Deliver the release only if the game SAW the press
+                        // (it's in held_keys) — a press swallowed by a focused
+                        // text field must not leak a phantom release edge to
+                        // the game's `input` hook (xreview). Unknown keys are
+                        // never tracked; keep their pre-existing passthrough,
+                        // but not while a field is focused.
+                        let was_held = held_keys.remove(&k);
+                        if !ignore_user_input
+                            && (was_held || (k == InputKey::Unknown && !ui_wants_keyboard))
+                        {
                             game.key_event(k as i32, false);
                         }
-                        held_keys.remove(&k);
                     }
                     glfw::WindowEvent::Focus(false) => {
                         for k in std::mem::take(&mut held_keys) {
@@ -1080,6 +1126,31 @@ Escape again to quit"
                         mouse_primary_clicked = false;
                     }
                     _ if ignore_user_input => {}
+                    // While a field is focused, key presses drive the OVERLAY:
+                    // the editing subset maps across (press+release pairs are
+                    // synthesized by the lowering, so Repeat works), printable
+                    // keys arrive via the Char arm, and the game's `input`
+                    // hook hears none of it (the focus gate). Releases still
+                    // reach the game below — a key held from before focus
+                    // must not stick.
+                    glfw::WindowEvent::Key(key, _, Action::Press | Action::Repeat, _)
+                        if ui_wants_keyboard =>
+                    {
+                        use functor_runtime_common::ui::{UiEditKey, UiKeyboardEvent};
+                        let edit = match key {
+                            Key::Backspace => Some(UiEditKey::Backspace),
+                            Key::Delete => Some(UiEditKey::Delete),
+                            Key::Left => Some(UiEditKey::Left),
+                            Key::Right => Some(UiEditKey::Right),
+                            Key::Home => Some(UiEditKey::Home),
+                            Key::End => Some(UiEditKey::End),
+                            Key::Enter => Some(UiEditKey::Enter),
+                            _ => None,
+                        };
+                        if let Some(edit) = edit {
+                            ui_keyboard.push(UiKeyboardEvent::Edit(edit));
+                        }
+                    }
                     glfw::WindowEvent::Key(key, _, Action::Press | Action::Repeat, _) => {
                         let k = map_key(key);
                         game.key_event(k as i32, true);
@@ -1422,9 +1493,11 @@ Escape again to quit"
                 fb_height as u32,
                 1.0,
                 ui_pointer,
+                &ui_keyboard,
                 &ui_view,
             );
             ui_wants_pointer = ui_out.wants_pointer;
+            ui_wants_keyboard = ui_out.wants_keyboard;
             if !ignore_user_input {
                 for event in ui_out.events {
                     game.ui_event(event);

--- a/runtime/functor-runtime-web/index-functor-lang.html
+++ b/runtime/functor-runtime-web/index-functor-lang.html
@@ -76,6 +76,8 @@
         functor_lang_mouse_wheel,
         functor_lang_ui_pointer,
         functor_lang_ui_pointer_leave,
+        functor_lang_ui_key,
+        functor_lang_ui_wants_keyboard,
         functor_lang_is_running,
         functor_lang_set_source,
         functor_lang_scene_frame,
@@ -135,16 +137,33 @@
 
         // Keyboard. Ignore auto-repeat (the game tracks held state itself), and
         // swallow keys we handle so Space/arrows don't scroll the page.
+        // While a Ui.textInput is focused (the runtime reports it after each
+        // frame), keydowns route to the OVERLAY instead — the game's input
+        // hook is suppressed (docs/ui-interaction.md U4; repeats pass
+        // through so held backspace repeats). Modifier combos (Cmd+R,
+        // Ctrl+…) and unconsumed keys (F5) keep their browser behavior.
+        // `gameHeld` tracks the presses the GAME actually received, so a
+        // release whose press was swallowed by a focused field never leaks
+        // a phantom release edge.
+        const gameHeld = new Set();
         window.addEventListener("keydown", (e) => {
+          if (functor_lang_ui_wants_keyboard()) {
+            if (e.metaKey || e.ctrlKey || e.altKey) return;
+            if (functor_lang_ui_key(e.key)) e.preventDefault();
+            return;
+          }
           const code = keyCode(e.code);
           if (code === 0) return;
           e.preventDefault();
-          if (!e.repeat) functor_lang_key_event(code, true);
+          if (!e.repeat) {
+            functor_lang_key_event(code, true);
+            gameHeld.add(code);
+          }
         });
         window.addEventListener("keyup", (e) => {
           const code = keyCode(e.code);
           if (code === 0) return;
-          functor_lang_key_event(code, false);
+          if (gameHeld.delete(code)) functor_lang_key_event(code, false);
         });
 
         // Mouse free-look. Pointer Lock is the browser equivalent of the

--- a/runtime/functor-runtime-web/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-web/src/functor_lang_game.rs
@@ -904,6 +904,82 @@ pub fn ui_pointer_state(dpr: f32) -> functor_runtime_common::ui::PointerState {
     })
 }
 
+thread_local! {
+    /// Keyboard events queued for a focused `Ui.textInput`
+    /// (docs/ui-interaction.md U4). The page routes keydowns here (instead
+    /// of the game key path) while [`functor_lang_ui_wants_keyboard`] reports
+    /// true; the frame loop drains it into the overlay pass. Same cap
+    /// rationale as [`INPUT_QUEUE`].
+    static UI_KEY_QUEUE: RefCell<Vec<functor_runtime_common::ui::UiKeyboardEvent>> =
+        const { RefCell::new(Vec::new()) };
+    /// Whether the overlay wanted the keyboard after the LAST frame's pass —
+    /// what the page's keydown handler polls to pick a route.
+    static UI_WANTS_KEYBOARD: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// Deliver a keydown for a focused text field. `key` is the DOM
+/// `KeyboardEvent.key`: a single-char string is printable text; the named
+/// editing keys map across; anything else is dropped (F-keys, media keys).
+/// Returns whether the key was CONSUMED — the page only `preventDefault()`s
+/// then, so browser chrome (F5, DevTools) keeps working while typing.
+#[wasm_bindgen]
+pub fn functor_lang_ui_key(key: &str) -> bool {
+    use functor_runtime_common::ui::{UiEditKey, UiKeyboardEvent};
+    let mut chars = key.chars();
+    let event = match (chars.next(), chars.next()) {
+        // Exactly one char → printable text ("a", "3", "`", …).
+        (Some(c), None) => Some(UiKeyboardEvent::Char(c)),
+        _ => match key {
+            "Backspace" => Some(UiKeyboardEvent::Edit(UiEditKey::Backspace)),
+            "Delete" => Some(UiKeyboardEvent::Edit(UiEditKey::Delete)),
+            "ArrowLeft" => Some(UiKeyboardEvent::Edit(UiEditKey::Left)),
+            "ArrowRight" => Some(UiKeyboardEvent::Edit(UiEditKey::Right)),
+            "Home" => Some(UiKeyboardEvent::Edit(UiEditKey::Home)),
+            "End" => Some(UiKeyboardEvent::Edit(UiEditKey::End)),
+            "Enter" => Some(UiKeyboardEvent::Edit(UiEditKey::Enter)),
+            "Escape" => Some(UiKeyboardEvent::Edit(UiEditKey::Escape)),
+            _ => None,
+        },
+    };
+    match event {
+        Some(event) => {
+            UI_KEY_QUEUE.with(|q| {
+                let mut q = q.borrow_mut();
+                if q.len() < INPUT_QUEUE_CAP {
+                    q.push(event);
+                }
+            });
+            true
+        }
+        None => false,
+    }
+}
+
+/// Whether a `Ui.textInput` is focused — the page's keydown handler routes
+/// keys to [`functor_lang_ui_key`] while this is true, and to the game's
+/// key path otherwise (the focus gate, docs/ui-interaction.md U4).
+#[wasm_bindgen]
+pub fn functor_lang_ui_wants_keyboard() -> bool {
+    UI_WANTS_KEYBOARD.with(|w| w.get())
+}
+
+/// Drain the focused-field key queue (the frame loop, before the overlay
+/// pass). `deliver: false` (pinned clock) discards — typing is inert while
+/// pinned, like all other window input.
+pub fn drain_ui_keys(deliver: bool) -> Vec<functor_runtime_common::ui::UiKeyboardEvent> {
+    let events = UI_KEY_QUEUE.with(|q| std::mem::take(&mut *q.borrow_mut()));
+    if deliver {
+        events
+    } else {
+        Vec::new()
+    }
+}
+
+/// Publish this frame's `wants_keyboard` for the page's keydown routing.
+pub fn set_ui_wants_keyboard(wants: bool) {
+    UI_WANTS_KEYBOARD.with(|w| w.set(wants));
+}
+
 /// Drain the queued page input into the producer, in arrival order. Called by
 /// the frame loop before `tick`. Empty (and free) on the F# path — its page
 /// never calls the `functor_lang_*` exports.

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -1235,18 +1235,22 @@ async fn run_async() -> Result<(), JsValue> {
             // While the clock is pinned, events would be dropped anyway (the
             // window-input rule) — hide the pointer from egui entirely so a
             // paused interaction can't visually engage widgets or fight the
-            // slider reconciliation (the desktop rule). [xreview]
+            // slider reconciliation (the desktop rule), and discard queued
+            // focused-field keys the same way. [xreview]
             let mut ui_pointer = functor_lang_game::ui_pointer_state(dpr);
             if clock.is_pinned() {
                 ui_pointer.pos = None;
             }
+            let ui_keys = functor_lang_game::drain_ui_keys(!clock.is_pinned());
             let ui_out = text_overlay.draw_view(
                 canvas.width(),
                 canvas.height(),
                 dpr,
                 ui_pointer,
+                &ui_keys,
                 &view,
             );
+            functor_lang_game::set_ui_wants_keyboard(ui_out.wants_keyboard);
             if !clock.is_pinned() {
                 for event in ui_out.events {
                     game.ui_event(event);


### PR DESCRIPTION
## What

U4b of the interactive-UI plan (design doc #289) — the last widget before the U5 showcase. `Ui.textInput(value, tagger)`: a controlled single-line field; each edit applies the tagger to the new text and the msg folds through `update`.

- **The design doc's text reconciliation**, implemented: per-slot `TextBuffer { live, last_emitted }` — the model's value overwrites the live editing buffer only when it differs from `last_emitted`. Comparing against the buffer instead would clobber every keystroke (the model echo is one frame behind while typing) — the comparison target is load-bearing. A transform in `update` resets the field with the cursor at the end (the React-parity wart, documented).
- **A shell-neutral keyboard path**: `UiKeyboardEvent` (`Char` + the editing-key subset) lowered to egui events in the overlay; `UiOutput.wants_keyboard` is the focus gate.
- **Desktop**: GLFW char polling; while a field is focused, keys drive the overlay and the game's `input` hook is suppressed; Escape defocuses first / releases the cursor second; `~` types instead of toggling the scrubber; typing is inert while the clock is pinned.
- **Web**: keydowns route through `functor_lang_ui_wants_keyboard()` to a key queue; modifier combos and unconsumed keys (F5, Cmd+R) keep their browser behavior.
- IME/composition + shift-selection are out of scope for v1 (documented).

## The risky piece is tested headlessly

egui contexts run without GL (only painting needs it), so unit tests click-to-focus a real `TextEdit`, type through the same event lowering the shells use, and pin all three reconciliation rules — emit, echo-leaves-the-buffer-alone, programmatic-snap — plus backspace editing. (One egui subtlety encoded in the tests: input hit-tests against the previous frame's rects, so a click needs a warmup frame.)

## Review

Claude reviewer (Codex hit its usage limit this round — single-engine): two real findings, both fixed and re-validated:
- **Phantom release leak**: the focus gate suppressed presses but not releases, so typing Space/Enter in a field fired release-edge game actions. Both shells now deliver a release only if the game saw its press (desktop: the `held_keys` gate; web: a `gameHeld` set).
- **Web `preventDefault` over-swallow**: every keydown while focused blocked browser chrome (F5, Cmd+R — with the 'r' also typed into the field). `functor_lang_ui_key` now returns whether it consumed the key; modifiers pass through untouched.

Accepted (Low, recoverable): a focused field removed from the view can strand the keyboard for a frame until Escape/click — noted for U5's dynamic-view testing.

## Verification

- 249 tests (new: headless click-to-focus + typing + echo/programmatic reconciliation + backspace); goldens byte-stable; all targets build.
- Live e2e: debug-server `{"kind":{"TextChanged":"shark"}}` moves a scratch game's model from `{ name: "cube" }` to `{ name: "shark" }`.

Visuals follow in the body (pr-visuals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Demo

![Ui.textInput demo](https://gist.githubusercontent.com/tommy-xr/28dc6422069a45c14d0dae331d72e5dd/raw/textinput.gif)

<sub>Ui.textInput driven headlessly: progressive TextChanged injections spell out 'shark' — each folds through update and the controlled field re-renders the model's text. Captured via POST /capture under `--fixed-time`.</sub>

![still](https://gist.githubusercontent.com/tommy-xr/28dc6422069a45c14d0dae331d72e5dd/raw/textinput-still.png)
