### PR TITLE
feat(examples): the ui widget showcase — every interactive widget in one panel

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -477,6 +477,8 @@ Ui.textInput(value, tagger)                                // INTERACTIVE contro
                                                            //   resets the cursor to the end.
                                                            //   Headless:
                                                            //   {"kind":{"TextChanged":"hi"}}
+                                                           //   `examples/ui` showcases every
+                                                           //   widget in one panel
 
 Physics.box(w, h, d) / sphere(r) / capsule(halfH, r)       // -> Shape (box = FULL extents)
 Physics.dynamic("tag", shape)                              // simulated body

--- a/docs/ui-interaction.md
+++ b/docs/ui-interaction.md
@@ -1,16 +1,14 @@
 # Interactive UI (Elm-style)
 
-Status: **design — nothing shipped.** Today `ui = (model) => View` renders a
-text-only HUD (`Ui.text`/`column`/`panel`) that egui paints with every area
-`.interactable(false)`; mouse buttons never reach game logic at all (the
-desktop shell consumes them for cursor recapture and the scrubber). This doc
-is the design for making UI *interactive* — buttons, sliders, text inputs that
-produce messages folded through `update` — targeting **parity with React and
-Elm**. It absorbs `docs/todo.md` time-travel items T2 (pointer/click plumbing)
-and T4 (interactive `View`), but the UI system itself is independent of the
-scrubber — the scrubber shows up only as U1's verification target, being the
-one interactive egui widget that exists today. The culmination is
-`examples/ui`, a widget showcase.
+Status: **SHIPPED** (U1–U5, 2026-07-10). `ui = (model) => View` is
+interactive: `Ui.button` / `Ui.slider` / `Ui.textInput` produce messages
+folded through `update` — Elm/React-parity controlled widgets — drivable
+headlessly through the debug server (`POST /input {"type":"ui_event",…}`).
+This doc is the design record and the map of the machinery; the reference
+example is **`examples/ui`** (the widget showcase; `examples/counter` is the
+button-only hello world). It absorbed `docs/todo.md` time-travel items T2
+(pointer/click plumbing) and T4 (interactive `View`); the UI system is
+independent of the scrubber.
 
 ## The shape
 
@@ -114,29 +112,30 @@ game's perspective this is fully Elm-controlled.
 
 ## Roadmap
 
-- [ ] **U1 — pointer plumbing (= todo T2).** Extract the scrubber's
-      hand-rolled `PointerState` → egui-event synthesis into a shared,
-      unit-tested `PointerBridge` — the piece the interactive game-UI pass
-      reuses. Desktop-only: the web shell has no egui input consumer yet, so
-      its pointer wiring lands with U3 where it's observable. No game-facing
-      change. *Verify:* bridge unit tests; the scrubber behaves identically
-      through the shared path.
-- [ ] **U2 — the seam.** `UiEvent`, `GameProducer::ui_event`, the slot table,
-      `FrameCtx::deliver_ui_event`, the `RecordedInput` variant, debug-server
-      injection. *Verify:* headless unit tests (inject event → `update` ran),
-      before any widget renders.
-- [ ] **U3 — `Ui.button` (= todo T4) + counter example.** Prelude ctor,
-      interactable egui rendering (the `TextOverlay` pass gains pointer input
-      via the U1 bridge, on both shells — web adds its unlocked-pointer canvas
-      listeners here), click → msg. *Verify:* debug-server e2e clicks the
-      button and reads the count; functor-lang skill updated.
-- [ ] **U4 — `Ui.slider` + `Ui.textInput`.** Tagger-carrying, with the
-      reconciliation algorithm above and the keyboard-focus gate; plus the
-      missing basics (`Ui.row`, remaining anchors). *Verify:* typing-fast and
-      programmatic-reset cases as producer tests; validate the egui
-      `TextEdit` buffer integration first — it's the riskiest piece.
-- [ ] **U5 — `examples/ui`.** A widget showcase: one panel exercising every
-      interactive widget (buttons, slider, text input) plus the display
-      vocabulary (`row`/`column`/anchors), each wired to model state echoed
-      back as text — the full UI → msg → model → view loop, no 3D scene or
-      scrubber involvement required. GIF/PNG via pr-visuals.
+- [x] **U1 — pointer plumbing (= todo T2)** (#288). The scrubber's
+      hand-rolled `PointerState` → egui-event synthesis extracted into the
+      shared, unit-tested `PointerBridge` the game-UI pass reuses.
+- [x] **U2 — the seam** (#291). `UiEvent`, `GameProducer::ui_event`, the slot
+      table, `FrameCtx::deliver_ui_event`, the `RecordedInput` variant,
+      debug-server injection — all headlessly tested before any widget
+      rendered. Replay rebuilds the handler table once per fine step, before
+      the step's inputs (the live last-render contract).
+- [x] **U3 — `Ui.button` (= todo T4) + `examples/counter`** (#293). The
+      interactive `TextOverlay` pass (pointer via the U1 bridge, both
+      shells), click → msg. Review catches now baked in: a press LATCH so
+      sub-frame clicks aren't level-sampled away; scrubber pointer priority
+      over an overlapping game widget; Empty-view frames still flush bridge
+      events so egui can't hold a stuck press.
+- [x] **U4 — `Ui.slider` (#294) + `Ui.textInput` (#297)** plus `Ui.row` and
+      the remaining anchors. Both reconciliation algorithms above shipped
+      as specified (per-slot buffers keyed by slot, dropped when the slot
+      leaves the view); the keyboard focus gate suppresses the game's
+      `input` hook — including releases whose press was swallowed — and the
+      pinned clock hides the pointer from the pass entirely. The egui
+      `TextEdit` integration is unit-tested headlessly (egui runs without
+      GL; input hit-tests against the previous frame's rects, so click
+      tests need a warmup frame).
+- [x] **U5 — `examples/ui`.** The widget showcase: one panel exercising
+      every interactive widget plus the display vocabulary, each wired to
+      model state echoed back as text — the full UI → msg → model → view
+      loop, no 3D scene or scrubber involvement.

--- a/examples/ui/functor.json
+++ b/examples/ui/functor.json
@@ -1,0 +1,4 @@
+{
+  "language": "functor-lang",
+  "entry": "game.fun"
+}

--- a/examples/ui/game.fun
+++ b/examples/ui/game.fun
@@ -1,0 +1,83 @@
+// ui — the widget showcase (docs/ui-interaction.md U5).
+//
+// Every interactive widget in one panel — buttons, a slider, a text input —
+// each wired to model state that is echoed straight back as text, so the
+// whole UI → msg → model → view loop is visible with no 3D scene in the way.
+// The display vocabulary (row/column, corner anchors, colored text) frames
+// it; a second panel pinned to the opposite corner echoes the full model.
+//
+// Drive it headlessly (docs/debug-runtime.md): interactive widgets number by
+// SLOT in construction order — here 0 = "+1", 1 = "Reset", 2 = the slider,
+// 3 = the text input:
+//   POST /input {"type":"ui_event","slot":0,"kind":"Clicked"}
+//   POST /input {"type":"ui_event","slot":2,"kind":{"SliderChanged":7.5}}
+//   POST /input {"type":"ui_event","slot":3,"kind":{"TextChanged":"shark"}}
+// then read the model back from GET /state.
+
+type Model = { count: float, speed: float, name: string }
+type Msg =
+  | Inc
+  | Reset
+  | SetSpeed(v: float)
+  | SetName(s: string)
+
+let init = { count: 0.0, speed: 1.0, name: "functor" }
+
+let update = (m: Model, msg: Msg) =>
+  match msg with
+  | Inc => { m with count: m.count + 1.0 }
+  | Reset => init
+  | SetSpeed(v) => { m with speed: v }
+  | SetName(s) => { m with name: s }
+
+let tick = (m: Model, dt, tts) => m
+
+// No scene — the showcase is the UI itself. `draw` is still the required
+// frame source, so give it a camera over an empty group.
+let draw = (m: Model, tts) =>
+  Frame.create(
+    Camera.lookAt(0.0, 1.5, -4.0, 0.0, 0.0, 0.0),
+    Scene.group([])
+  )
+
+let counterRow = (m: Model) =>
+  Ui.row([
+    Ui.button("+1", Inc),
+    Ui.button("Reset", Reset),
+    Ui.text(Text.concat("count: ", Text.fixed(m.count, 0.0))),
+  ])
+
+let speedRow = (m: Model) =>
+  Ui.row([
+    Ui.slider(0.0, 10.0, m.speed, SetSpeed),
+    Ui.text(Text.concat("speed: ", Text.fixed(m.speed, 1.0))),
+  ])
+
+let nameRow = (m: Model) =>
+  Ui.row([
+    Ui.textInput(m.name, SetName),
+    Ui.text(Text.concat("name: ", m.name)),
+  ])
+
+// The full model echoed in one line, pinned to the opposite corner — the
+// other anchors and colored text.
+let echoPanel = (m: Model) =>
+  Ui.textColor(
+    1.0, 0.85, 0.4,
+    Text.join("", [
+      "model = { count: ", Text.fixed(m.count, 0.0),
+      ", speed: ", Text.fixed(m.speed, 1.0),
+      ", name: \"", m.name, "\" }",
+    ])
+  ) |> Ui.panel(Ui.bottomRight())
+
+let ui = (m: Model) =>
+  Ui.column([
+    Ui.column([
+      Ui.text("functor · ui showcase"),
+      counterRow(m),
+      speedRow(m),
+      nameRow(m),
+    ]) |> Ui.panel(Ui.topLeft()),
+    echoPanel(m),
+  ])

--- a/runtime/functor-runtime-common/src/ui.rs
+++ b/runtime/functor-runtime-common/src/ui.rs
@@ -273,10 +273,17 @@ fn render_view(ui: &mut egui::Ui, view: &View, state: &mut UiFrameState) {
         View::Empty => {}
         View::Text { text, color, .. } => {
             let [r, g, b] = *color;
-            ui.label(
-                egui::RichText::new(text)
-                    .font(egui::FontId::monospace(UI_FONT_SIZE))
-                    .color(egui::Color32::from_rgb(r, g, b)),
+            // Extend, never soft-wrap: a corner Area remembers its width, so
+            // dynamic text that shrinks then grows back would wrap at the
+            // STALE narrower constraint (e.g. an echo line after a model
+            // reset). HUD text is one line unless the author breaks it.
+            ui.add(
+                egui::Label::new(
+                    egui::RichText::new(text)
+                        .font(egui::FontId::monospace(UI_FONT_SIZE))
+                        .color(egui::Color32::from_rgb(r, g, b)),
+                )
+                .wrap_mode(egui::TextWrapMode::Extend),
             );
         }
         View::Column(items) => {


### PR DESCRIPTION
## What

**U5 — the last step of the interactive-UI plan** (#289; machinery shipped across #288 → #291 → #293 → #294 → #297). Example + docs, plus one one-line overlay fix the showcase exposed: HUD `Text` now renders with `TextWrapMode::Extend` — a corner Area remembers its width, so dynamic text that shrank then grew back (the echo line after Reset) soft-wrapped at the stale narrower constraint.

`examples/ui` puts the whole widget vocabulary in one place: **+1 / Reset buttons**, a **slider**, and a **text input** in a top-left panel, each echoing its model state back as text, with the full model mirrored in a gold bottom-right panel — the complete **UI → msg → model → view** loop with no 3D scene or scrubber framing.

```
let ui = (m: Model) =>
  Ui.column([
    Ui.column([
      Ui.text("functor · ui showcase"),
      Ui.row([Ui.button("+1", Inc), Ui.button("Reset", Reset), …count…]),
      Ui.row([Ui.slider(0.0, 10.0, m.speed, SetSpeed), …speed…]),
      Ui.row([Ui.textInput(m.name, SetName), …name…]),
    ]) |> Ui.panel(Ui.topLeft()),
    echoPanel(m),   // the model, one line, bottom-right, gold
  ])
```

The file header documents the slot map (0=+1, 1=Reset, 2=slider, 3=textInput) so an agent can drive it blind through the debug server.

Also: `docs/ui-interaction.md` status flipped to **SHIPPED** with the U1–U5 roadmap checked off (PR numbers + the review catches that got baked in), and the functor-lang skill points here as the widget reference.

## Verification

- Typecheck clean; e2e via the debug server exercises **every widget**: two clicks + `SliderChanged(7.5)` + `TextChanged("shark")` → `{ count: 2, speed: 7.5, name: "shark" }`; **Reset** restores init exactly.
- Capture confirms both panels render as specced.
- The wrap fix is pinned by the goldens (byte-stable — nothing wrapped before) and a shrink-then-grow capture repro; behavior otherwise fully e2e- and visually verified. No cross-engine review this round (example + docs + a one-liner).

Demo below (pr-visuals).

## Demo

![examples/ui demo](https://gist.githubusercontent.com/tommy-xr/c4a90ac2d525f6f2e0a251a1a4edd940/raw/ui-demo.gif)

<sub>examples/ui driven headlessly end to end: two button clicks, a slider drag, a text edit, then Reset — every msg folds through update and both panels re-render from the model. Captured via POST /capture under `--fixed-time`.</sub>

![examples/ui still — count 2, speed 6.5, name shark](https://gist.githubusercontent.com/tommy-xr/c4a90ac2d525f6f2e0a251a1a4edd940/raw/ui-still.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

