### PR TITLE
fix(lang): canonicalize binding annotations in non-entry modules

### DIFF
--- a/functor-lang/src/lower.rs
+++ b/functor-lang/src/lower.rs
@@ -398,7 +398,7 @@ qualify uses (`{prev}.{name}` / `{}.{name}`)",
                 defs.push(Def {
                     id,
                     name: lowerer.self_qualify(&decl.name),
-                    ty: decl.ty,
+                    ty: decl.ty.map(|ty| lowerer.canon_type(ty)).transpose()?,
                     value: lowerer.expr(decl.value)?,
                     span: decl.span,
                 });
@@ -719,6 +719,7 @@ impl Lowerer<'_> {
             } => {
                 // The value is evaluated outside the binding's scope
                 // (`let x = x in …` refers to the outer `x`).
+                let ty = ty.map(|ty| self.canon_type(ty)).transpose()?;
                 let value = Box::new(self.expr(*value)?);
                 let binding = BindingId(self.next_binding);
                 self.next_binding += 1;

--- a/functor-lang/tests/project.rs
+++ b/functor-lang/tests/project.rs
@@ -535,6 +535,137 @@ fn cross_module_generics_check() {
     );
 }
 
+/// Binding annotations in a NON-ENTRY module are canonicalized like the
+/// entry's: the sibling's own bare type name resolves nominally, so a wrong
+/// value is a real diagnostic (it used to silently resolve to Unknown), on
+/// both top-level `let name: Type = …` and expression `let … in`.
+#[test]
+fn sibling_binding_annotations_are_enforced() {
+    let scratch = Scratch::new(
+        "sibling-binding-annot",
+        &[
+            ("game.fun", "let main = () => 0.0\n"),
+            (
+                "utils.fun",
+                "type Shape = | Circle(radius: float) | Point\n\
+                 let bad: Shape = 3.0\n\
+                 let letIn = () =>\n\
+                 let x: Shape = 4.0 in\n\
+                 x\n",
+            ),
+        ],
+    );
+    let project = scratch.load().unwrap_or_else(|e| panic!("{}", e.render()));
+    let diags = project.check();
+    assert_eq!(diags.len(), 2, "expected two diagnostics, got {diags:?}");
+    for diag in &diags {
+        assert!(
+            diag.message.contains("expected Utils.Shape, got float"),
+            "unexpected diagnostic: {}",
+            diag.message
+        );
+    }
+}
+
+/// Qualified cross-module type names in a sibling's binding annotation
+/// resolve too: a good value checks clean, a bad one is flagged with the
+/// canonical name.
+#[test]
+fn qualified_types_in_sibling_binding_annotations() {
+    let files: &[(&str, &str)] = &[
+        ("game.fun", "let main = () => 0.0\n"),
+        ("shapes.fun", "type Shape = | Circle(radius: float) | Point\n"),
+        (
+            "consumer.fun",
+            "let good: Shapes.Shape = Shapes.Circle(1.0)\n\
+             let bad: Shapes.Shape = 3.0\n",
+        ),
+    ];
+    let scratch = Scratch::new("sibling-qualified-annot", files);
+    let project = scratch.load().unwrap_or_else(|e| panic!("{}", e.render()));
+    let diags = project.check();
+    assert_eq!(diags.len(), 1, "expected one diagnostic, got {diags:?}");
+    assert!(
+        diags[0]
+            .message
+            .contains("expected Shapes.Shape, got float"),
+        "unexpected diagnostic: {}",
+        diags[0].message
+    );
+}
+
+/// `open`ed type names in binding annotations resolve to their module's
+/// canonical type (this held for params; binding annotations skipped it).
+#[test]
+fn opened_types_in_binding_annotations_are_enforced() {
+    let scratch = Scratch::new(
+        "opened-binding-annot",
+        &[
+            (
+                "game.fun",
+                "open Shapes\nlet bad: Shape = 3.0\nlet main = () => 0.0\n",
+            ),
+            ("shapes.fun", "type Shape = | Circle(radius: float) | Point\n"),
+        ],
+    );
+    let project = scratch.load().unwrap_or_else(|e| panic!("{}", e.render()));
+    let diags = project.check();
+    assert_eq!(diags.len(), 1, "expected one diagnostic, got {diags:?}");
+    assert!(
+        diags[0]
+            .message
+            .contains("expected Shapes.Shape, got float"),
+        "unexpected diagnostic: {}",
+        diags[0].message
+    );
+}
+
+/// Interface (`.funi`) types — the prelude's `Anim.t` shape — are enforced in
+/// a SIBLING module's binding annotations: a host-made value checks clean, a
+/// bare number is flagged.
+#[test]
+fn interface_types_in_sibling_binding_annotations() {
+    let scratch = Scratch::new(
+        "sibling-funi-annot",
+        &[
+            ("game.fun", "let main = () => 0.0\n"),
+            (
+                "widget.funi",
+                "type Handle\nlet make : () => Handle\n",
+            ),
+            (
+                "util.fun",
+                "let good: Widget.Handle = Widget.make()\n\
+                 let bad: Widget.Handle = 3.0\n",
+            ),
+        ],
+    );
+    let project = scratch.load().unwrap_or_else(|e| panic!("{}", e.render()));
+    let diags = project.check();
+    assert_eq!(diags.len(), 1, "expected one diagnostic, got {diags:?}");
+    assert!(
+        diags[0]
+            .message
+            .contains("expected Widget.Handle, got float"),
+        "unexpected diagnostic: {}",
+        diags[0].message
+    );
+}
+
+/// Binding annotations get the same lowering-time validation as param
+/// annotations: an unknown member of a KNOWN module is a load error.
+#[test]
+fn unknown_member_type_in_binding_annotation_is_a_load_error() {
+    let err = load_err(
+        "unknown-binding-annot-type",
+        &[
+            ("game.fun", "let x: Util.Nope = 1.0\n"),
+            ("util.fun", "let x = 1.0\n"),
+        ],
+    );
+    assert_eq!(err, "game.fun:1:8: module `Util` has no type `Nope`");
+}
+
 /// An UNREFERENCED sibling declaring a same-shaped record type must not
 /// capture (or make ambiguous) a bare record literal elsewhere — literal
 /// resolution is scoped to types visible unqualified where the literal is


### PR DESCRIPTION
## Bug

A top-level binding annotation (`let x: Shape = …`) — and the expression-level `let x: Shape = … in` — skipped the `canon_type` name-canonicalization pass in lowering (`functor-lang/src/lower.rs`, `Item::Let` / `ExprKind::Let`), while param/return annotations, `.funi` signatures, and type-decl bodies all get it. In the **entry** module this was invisible (the entry's canonical names are bare, so the un-canonicalized name matched anyway), but in a **non-entry** module the annotation kept its bare/wrongly-qualified name, missed the checker's nominal lookup, and silently resolved to `Unknown` — the annotation was unenforced.

Reported while building #295; `examples/crossfade/animator.fun` was the trail — its **return-position** annotation (`: Anim.t`) turned out fine (lambda param/return annotations already canonicalize); only *binding* annotations were affected.

## Repro (kept as regression tests)

```text
// utils.fun (sibling)                      // entry.fun
type Shape = | Circle(radius: float) | Point
let bad: Shape = 3.0        // ← no error before this fix; entry equivalent errored
let letIn = () =>
  let x: Shape = 4.0 in x   // ← same bug on let-in
```

`functor-lang check entry.fun` reported nothing for `utils.fun`; the identical annotations in the entry module errored.

## Fix

Route both binding-annotation sites through `canon_type`, the same `.map(...).transpose()?` idiom the param sites use (2 lines). That also restores the behaviors documented to hang off canonicalization, now consistent with param annotations:

- an annotation-only cross-module reference is a **dependency edge** (cycles refused with the path);
- an unknown type member of a known module (`let x: Util.Nope = …`) is a **load error** instead of silently `Unknown`.

Single-file projects and `.ir` goldens are byte-identical (`canon_type` is the identity outside a project and allocates no IDs).

## What the stricter checking exposed

Nothing — all 18 examples still typecheck clean (`npm run verify`), so no latent annotation errors were hiding in the tree. The `functor-lang` skill already documented binding annotations as checked (no sibling caveat), so no skill update is needed — the fix makes the documented behavior true.

## Tests

New regression tests in `functor-lang/tests/project.rs`:
- sibling own-type binding annotation + let-in annotation enforced (`expected Utils.Shape, got float`)
- qualified cross-module type in a sibling annotation (`Shapes.Shape`): good value clean, bad value flagged
- `open`ed type names in binding annotations enforced
- interface (`.funi`) types — the prelude `Anim.t` shape — in sibling binding annotations: host-made value clean, bare number flagged
- unknown member type in a binding annotation is a load error (matches the param-annotation test)

`cargo test -p functor-lang` (353 tests) and `cargo test -p functor_runtime_common` (251 tests) green; `npm run verify` passes. Cross-engine review run (Claude reviewer: clean, no findings; Codex unavailable — usage limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)