### PR TITLE
ci: deploy the site to functor.games (Workers static assets)

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,0 +1,57 @@
+name: Deploy Site
+
+# Builds the static site (site/dist) and deploys it to the `functor` Worker
+# (static assets) at functor.games. Unlike the other CI workflows this never
+# builds the GL-linked `functor` binary — it only needs the wasm bundle
+# (wasm-pack) and the static site build, so no X11/GL system libs.
+#
+# Requires two repo secrets: CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:            # one deploy at a time; a newer push supersedes
+  group: deploy-site
+  cancel-in-progress: true
+
+jobs:
+  deploy-site:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Install wasm-pack
+        run: npm install -g wasm-pack
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "."
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Build web runtime bundle
+        run: wasm-pack build --target=web
+        working-directory: runtime/functor-runtime-web
+
+      - name: Build site
+        run: npm run site:build
+
+      - name: Deploy to Cloudflare
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,11 @@
+{
+  // Static-assets-only Worker that serves the built site (site/dist) at
+  // functor.games. There is no Worker script — `assets.directory` alone makes
+  // Cloudflare serve the prebuilt files directly. Build the site first:
+  //   npm run build:cli   (or: wasm-pack build runtime/functor-runtime-web --target=web)
+  //   npm run site:build  -> site/dist
+  // Deploy: `npx wrangler deploy` (CI does this on push to main).
+  "name": "functor",
+  "compatibility_date": "2026-07-11",
+  "assets": { "directory": "./site/dist" }
+}


### PR DESCRIPTION
## What

Adds a **Deploy Site** GitHub Action that, on every push to `main`, builds the
wasm bundle + static site (`site/dist`) and deploys it to the `functor` Worker
(static assets) via `wrangler deploy`. This is the first slice of the release
pipeline: getting functor.games live.

- `.github/workflows/deploy-site.yml` — build → deploy (no GL/X11 libs; only the
  wasm bundle + `npm run site:build` are needed).
- `wrangler.jsonc` — an **assets-only** Worker (no server script) serving `site/dist`.

## Why Workers static assets (not Pages)

Same edge CDN → identical user-facing performance for a static site, but Workers
is Cloudflare's actively-developed path and lets us add dynamic bits later
(share links, an API) in the same project without migrating.

## Verified

Ran the full chain manually (`wasm-pack build` → `npm run site:build` →
`npx wrangler deploy`). Live at https://functor.games:

| Path | Result |
| --- | --- |
| `/` | 200 · `text/html` · correct title |
| `/pkg/*_bg.wasm` | 200 · `application/wasm` (CF sets it automatically) |
| `/assets/sandbox.js` | 200 · 396 KB bundle |
| `/styles.css`, `/examples/*.fun` | 200 |

## Before this can deploy from CI

- [ ] Repo secrets `CLOUDFLARE_API_TOKEN` (Edit Cloudflare Workers) + `CLOUDFLARE_ACCOUNT_ID`
- [ ] Attach custom domain `functor.games` to the `functor` Worker
- [ ] Merge — the `on: push: main` trigger takes over

🤖 Generated with [Claude Code](https://claude.com/claude-code)