### PR TITLE
ci: pin wrangler v4 in the site deploy

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -52,6 +52,10 @@ jobs:
       - name: Deploy to Cloudflare
         uses: cloudflare/wrangler-action@v3
         with:
+          # wrangler-action's default (v3.90.0) predates static-assets-only
+          # Workers and demands a `main` entry-point; pin v4, which serves our
+          # assets-only wrangler.jsonc (no server script).
+          wranglerVersion: "4.110.0"
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: deploy


### PR DESCRIPTION
The `Deploy Site` run on #303's merge [failed](https://github.com/tommy-xr/functor/actions/runs/29134233373) at the `wrangler deploy` step:

```
✘ [ERROR] Missing entry-point: ... the `main` config field.
```

**Not a secrets issue** — `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` were passed correctly. The cause: `cloudflare/wrangler-action@v3` installs **wrangler 3.90.0** by default, which predates static-assets-only Workers and requires a `main` entry-point. Our `wrangler.jsonc` is assets-only (no server script), which only wrangler **v4** understands.

Fix: pin `wranglerVersion: "4.110.0"` on the action — the exact version verified working via the manual deploy that put the site live at https://functor.games.

🤖 Generated with [Claude Code](https://claude.com/claude-code)