### PR TITLE
spike: scene-diff trajectory preview (T6)

### DIFF
--- a/examples/toss/functor.json
+++ b/examples/toss/functor.json
@@ -1,0 +1,4 @@
+{
+  "language": "functor-lang",
+  "entry": "game.fun"
+}

--- a/examples/toss/game.fun
+++ b/examples/toss/game.fun
@@ -1,0 +1,60 @@
+// examples/toss — bouncing balls under gravity. NOTE: this game has NO
+// trajectory / trail logic at all. `draw` renders only the balls at their
+// CURRENT positions. The predicted arcs come entirely from the runtime's
+// scene-diff trajectory preview (`functor -d examples/toss run native
+// --trajectory`), which forward-simulates the model and traces the scene
+// nodes that move — proving the runtime derives the trails, not the game.
+//
+//   functor -d examples/toss run native --trajectory \
+//     --capture-frame /tmp/toss.png --fixed-time 0.0 --capture-time 0.5
+
+type Vec3 = { x: float, y: float, z: float }
+type Ball = { pos: Vec3, vel: Vec3 }
+
+let gravity = 14.0
+let bounce = 0.55
+
+let init = {
+  balls: [
+    { pos: { x: -4.0, y: 0.5, z: 0.0 }, vel: { x: 3.2, y: 9.0, z: 0.0 } },
+    { pos: { x: -1.5, y: 0.5, z: 1.5 }, vel: { x: 2.6, y: 11.5, z: -0.7 } },
+    { pos: { x: 1.5, y: 0.5, z: -1.0 }, vel: { x: -1.8, y: 8.0, z: 0.4 } },
+    // Already at rest on the ground (y = 0, zero velocity) — it never moves in
+    // the forward-sim, so the runtime gives it NO trail.
+    { pos: { x: 4.0, y: 0.0, z: 0.0 }, vel: { x: 0.0, y: 0.0, z: 0.0 } }
+  ]
+}
+
+let stepBall = (dt, b) =>
+  let nx = b.pos.x + b.vel.x * dt in
+  let ny = b.pos.y + b.vel.y * dt in
+  let nz = b.pos.z + b.vel.z * dt in
+  let nvy = b.vel.y - gravity * dt in
+  match ny < 0.0 with
+  | true => { pos: { x: nx, y: 0.0, z: nz }, vel: { x: b.vel.x, y: 0.0 - nvy * bounce, z: b.vel.z } }
+  | false => { pos: { x: nx, y: ny, z: nz }, vel: { x: b.vel.x, y: nvy, z: b.vel.z } }
+
+let tick = (model, dt, tts) =>
+  { model with balls: model.balls |> List.map((b) => stepBall(dt, b)) }
+
+let ballView = (b) =>
+  Scene.sphere()
+    |> Scene.scale(0.3)
+    |> Scene.lit(1.0, 0.45, 0.2)
+    |> Scene.translate(b.pos.x, b.pos.y, b.pos.z)
+
+let ground =
+  Scene.plane()
+    |> Scene.scale(24.0)
+    |> Scene.lit(0.14, 0.15, 0.2)
+
+let draw = (model, tts) =>
+  let cam = Camera.lookAt(0.0, 6.0, 15.0, 0.0, 3.0, 0.0) in
+  let scene = Scene.group([
+    ground,
+    model.balls |> List.map(ballView) |> Scene.group
+  ]) in
+  Frame.createLit(cam, scene, [
+    Light.ambient(0.3, 0.3, 0.35),
+    Light.directional(-0.4, -1.0, -0.3, 1.0, 1.0, 1.0, 1.0)
+  ])

--- a/examples/toss/game.fun
+++ b/examples/toss/game.fun
@@ -13,26 +13,53 @@ type Ball = { pos: Vec3, vel: Vec3 }
 
 let gravity = 14.0
 let bounce = 0.55
+let restVel = 0.5    // a bounce reflecting slower than this lands as at-rest
 
 let init = {
   balls: [
     { pos: { x: -4.0, y: 0.5, z: 0.0 }, vel: { x: 3.2, y: 9.0, z: 0.0 } },
     { pos: { x: -1.5, y: 0.5, z: 1.5 }, vel: { x: 2.6, y: 11.5, z: -0.7 } },
     { pos: { x: 1.5, y: 0.5, z: -1.0 }, vel: { x: -1.8, y: 8.0, z: 0.4 } },
-    // Already at rest on the ground (y = 0, zero velocity) — it never moves in
-    // the forward-sim, so the runtime gives it NO trail.
+    // At rest on the ground (y = 0, zero velocity). `stepBall` holds a resting
+    // ball exactly still, so it never moves in the forward-sim and the runtime
+    // gives it NO trail.
     { pos: { x: 4.0, y: 0.0, z: 0.0 }, vel: { x: 0.0, y: 0.0, z: 0.0 } }
   ]
 }
 
+// A ball exactly at rest on the ground stays at rest. Without this, gravity
+// accumulates for a step, the discrete bounce reflects it, and a "resting"
+// ball pumps a tiny perpetual hop — enough motion to earn the trail it is
+// here to prove it must NOT get.
+let atRest = (b) =>
+  match b.pos.y == 0.0 with
+  | false => false
+  | true =>
+    match b.vel.x == 0.0 with
+    | false => false
+    | true =>
+      match b.vel.y == 0.0 with
+      | false => false
+      | true => b.vel.z == 0.0
+
+// One Euler step; bounce off the ground at y = 0. A bounce that would reflect
+// slower than restVel PARKS the ball (all velocity zeroed — crude friction), so
+// every ball converges to atRest and its trail ends when its motion does.
 let stepBall = (dt, b) =>
-  let nx = b.pos.x + b.vel.x * dt in
-  let ny = b.pos.y + b.vel.y * dt in
-  let nz = b.pos.z + b.vel.z * dt in
-  let nvy = b.vel.y - gravity * dt in
-  match ny < 0.0 with
-  | true => { pos: { x: nx, y: 0.0, z: nz }, vel: { x: b.vel.x, y: 0.0 - nvy * bounce, z: b.vel.z } }
-  | false => { pos: { x: nx, y: ny, z: nz }, vel: { x: b.vel.x, y: nvy, z: b.vel.z } }
+  match atRest(b) with
+  | true => b
+  | false =>
+    let nx = b.pos.x + b.vel.x * dt in
+    let ny = b.pos.y + b.vel.y * dt in
+    let nz = b.pos.z + b.vel.z * dt in
+    let nvy = b.vel.y - gravity * dt in
+    match ny < 0.0 with
+    | true =>
+      let ry = 0.0 - nvy * bounce in
+      (match ry < restVel with
+       | true => { pos: { x: nx, y: 0.0, z: nz }, vel: { x: 0.0, y: 0.0, z: 0.0 } }
+       | false => { pos: { x: nx, y: 0.0, z: nz }, vel: { x: b.vel.x, y: ry, z: b.vel.z } })
+    | false => { pos: { x: nx, y: ny, z: nz }, vel: { x: b.vel.x, y: nvy, z: b.vel.z } }
 
 let tick = (model, dt, tts) =>
   { model with balls: model.balls |> List.map((b) => stepBall(dt, b)) }

--- a/examples/trajectory/functor.json
+++ b/examples/trajectory/functor.json
@@ -1,0 +1,4 @@
+{
+  "language": "functor-lang",
+  "entry": "game.fun"
+}

--- a/examples/trajectory/game.fun
+++ b/examples/trajectory/game.fun
@@ -1,0 +1,114 @@
+// examples/trajectory — trajectory-preview spike (docs/time-travel.md T6, the
+// "Inventing on Principle" demo).
+//
+// A handful of balls launched under gravity. Each frame `draw` FORWARD-SIMULATES
+// the model — it re-runs the exact same pure step the live sim uses, N times,
+// to get the balls' future states — and draws a dim ghost dot at every future
+// position. You see where each ball WILL go before it gets there.
+//
+// The trick is only possible because the sim step is a PURE function of the
+// model (no side effects): holding a model, anyone can roll it forward. No
+// engine changes — this is all in-language.
+//
+// "Smart" trails: only balls that are actually MOVING contribute ghost dots
+// (see `moving`), so a resting ball leaves the scene clean — trails appear
+// exactly where something is in motion.
+//
+// Run:   functor -d examples/trajectory run native
+// Live:  edit `gravity` / a ball's launch `vel` and save — hot reload keeps the
+//        model and the predicted arcs update instantly (the Bret Victor moment).
+//
+// Deterministic still (arcs fully drawn; --fixed-time pins dt=0 so the live
+// balls hold at their launch point while the preview still projects forward):
+//   functor -d examples/trajectory run native \
+//     --capture-frame /tmp/trajectory.png --fixed-time 0.0 --capture-time 0.5
+
+type Vec3 = { x: float, y: float, z: float }
+type Ball = { pos: Vec3, vel: Vec3 }
+
+// --- Tunables (edit while running; the arcs re-project live on save) ---
+let gravity = 14.0        // downward accel, units/s^2
+let bounce = 0.55         // restitution when a ball hits the ground (y = 0)
+let previewSteps = 48.0   // how many steps into the future to project
+let previewDt = 0.03      // seconds per preview step (~arc resolution)
+
+let init = {
+  balls: [
+    { pos: { x: -4.0, y: 0.5, z: 0.0 }, vel: { x: 3.2, y: 9.0, z: 0.0 } },
+    { pos: { x: -1.5, y: 0.5, z: 1.5 }, vel: { x: 2.6, y: 11.5, z: -0.7 } },
+    { pos: { x: 1.5, y: 0.5, z: -1.0 }, vel: { x: -1.8, y: 8.0, z: 0.4 } },
+    // A ball at rest: velocity ~0, so it earns NO trail (the "smart" filter).
+    { pos: { x: 4.0, y: 0.3, z: 0.0 }, vel: { x: 0.0, y: 0.0, z: 0.0 } }
+  ]
+}
+
+// The ONE pure step. Euler integrate; bounce off the ground plane at y = 0.
+// Both the live `tick` and the forward-sim preview call this — the ghost trail
+// is, by construction, exactly the future the game itself will produce.
+let stepBall = (dt, b) =>
+  let nx = b.pos.x + b.vel.x * dt in
+  let ny = b.pos.y + b.vel.y * dt in
+  let nz = b.pos.z + b.vel.z * dt in
+  let nvy = b.vel.y - gravity * dt in
+  match ny < 0.0 with
+  | true => { pos: { x: nx, y: 0.0, z: nz }, vel: { x: b.vel.x, y: 0.0 - nvy * bounce, z: b.vel.z } }
+  | false => { pos: { x: nx, y: ny, z: nz }, vel: { x: b.vel.x, y: nvy, z: b.vel.z } }
+
+let stepModel = (dt, m) =>
+  { m with balls: m.balls |> List.map((b) => stepBall(dt, b)) }
+
+let tick = (model, dt, tts) => stepModel(dt, model)
+
+// --- Forward simulation: roll the model forward, collecting future states ---
+// (List.fold, not recursion — the interpreter caps manual recursion depth.)
+let futures = (m) =>
+  List.range(previewSteps)
+    |> List.fold(
+         (acc, _) =>
+           let next = stepModel(previewDt, acc.cur) in
+           { cur: next, seq: [next, ..acc.seq] },
+         { cur: m, seq: [] })
+
+// --- The "smart" filter: only moving balls get a ghost trail ---
+let speedSq = (b) => b.vel.x * b.vel.x + b.vel.y * b.vel.y + b.vel.z * b.vel.z
+let moving = (b) => speedSq(b) > 0.05
+
+// A dim ghost marker at a ball's (future) position.
+let ghost = (b) =>
+  Scene.sphere()
+    |> Scene.scale(0.07)
+    |> Scene.emissive(0.25, 0.85, 1.0)
+    |> Scene.translate(b.pos.x, b.pos.y, b.pos.z)
+
+// The moving balls of one future model, as a group of ghost dots.
+let ghostsOf = (m) =>
+  m.balls |> List.filter(moving) |> List.map(ghost) |> Scene.group
+
+// All ghost dots across the whole projected future.
+let trail = (model) =>
+  let fs = futures(model) in
+  fs.seq |> List.map(ghostsOf) |> Scene.group
+
+// A solid, lit ball at its CURRENT position.
+let ballView = (b) =>
+  Scene.sphere()
+    |> Scene.scale(0.3)
+    |> Scene.lit(1.0, 0.45, 0.2)
+    |> Scene.translate(b.pos.x, b.pos.y, b.pos.z)
+
+let ground =
+  Scene.plane()
+    |> Scene.scale(24.0)
+    |> Scene.lit(0.14, 0.15, 0.2)
+
+let draw = (model, tts) =>
+  let cam = Camera.lookAt(0.0, 6.0, 15.0, 0.0, 3.0, 0.0) in
+  let scene = Scene.group([
+    ground,
+    model.balls |> List.map(ballView) |> Scene.group,
+    trail(model)
+  ]) in
+  Frame.createLit(cam, scene, [
+    Light.ambient(0.3, 0.3, 0.35),
+    Light.directional(-0.4, -1.0, -0.3, 1.0, 1.0, 1.0, 1.0)
+  ])

--- a/examples/trajectory/game.fun
+++ b/examples/trajectory/game.fun
@@ -29,6 +29,7 @@ type Ball = { pos: Vec3, vel: Vec3 }
 // --- Tunables (edit while running; the arcs re-project live on save) ---
 let gravity = 14.0        // downward accel, units/s^2
 let bounce = 0.55         // restitution when a ball hits the ground (y = 0)
+let restVel = 0.5         // a bounce reflecting slower than this lands as at-rest
 let previewSteps = 48.0   // how many steps into the future to project
 let previewDt = 0.03      // seconds per preview step (~arc resolution)
 
@@ -37,22 +38,48 @@ let init = {
     { pos: { x: -4.0, y: 0.5, z: 0.0 }, vel: { x: 3.2, y: 9.0, z: 0.0 } },
     { pos: { x: -1.5, y: 0.5, z: 1.5 }, vel: { x: 2.6, y: 11.5, z: -0.7 } },
     { pos: { x: 1.5, y: 0.5, z: -1.0 }, vel: { x: -1.8, y: 8.0, z: 0.4 } },
-    // A ball at rest: velocity ~0, so it earns NO trail (the "smart" filter).
-    { pos: { x: 4.0, y: 0.3, z: 0.0 }, vel: { x: 0.0, y: 0.0, z: 0.0 } }
+    // A ball at rest on the ground: `stepBall` holds it exactly still, so its
+    // velocity stays zero and it earns NO trail (the "smart" filter).
+    { pos: { x: 4.0, y: 0.0, z: 0.0 }, vel: { x: 0.0, y: 0.0, z: 0.0 } }
   ]
 }
 
-// The ONE pure step. Euler integrate; bounce off the ground plane at y = 0.
-// Both the live `tick` and the forward-sim preview call this — the ghost trail
-// is, by construction, exactly the future the game itself will produce.
+// A ball exactly at rest on the ground stays at rest. Without this, gravity
+// accumulates for a step, the discrete bounce reflects it, and a "resting"
+// ball pumps a tiny perpetual hop — enough velocity to defeat the `moving`
+// filter below and earn a trail it must not have.
+let atRest = (b) =>
+  match b.pos.y == 0.0 with
+  | false => false
+  | true =>
+    match b.vel.x == 0.0 with
+    | false => false
+    | true =>
+      match b.vel.y == 0.0 with
+      | false => false
+      | true => b.vel.z == 0.0
+
+// The ONE pure step. Euler integrate; bounce off the ground plane at y = 0 (a
+// bounce reflecting slower than restVel PARKS the ball — all velocity zeroed,
+// crude friction — so every ball converges to atRest and its trail ends when
+// its motion does). Both the live `tick` and the forward-sim preview call
+// this — the ghost trail is, by construction, exactly the future the game
+// itself will produce.
 let stepBall = (dt, b) =>
-  let nx = b.pos.x + b.vel.x * dt in
-  let ny = b.pos.y + b.vel.y * dt in
-  let nz = b.pos.z + b.vel.z * dt in
-  let nvy = b.vel.y - gravity * dt in
-  match ny < 0.0 with
-  | true => { pos: { x: nx, y: 0.0, z: nz }, vel: { x: b.vel.x, y: 0.0 - nvy * bounce, z: b.vel.z } }
-  | false => { pos: { x: nx, y: ny, z: nz }, vel: { x: b.vel.x, y: nvy, z: b.vel.z } }
+  match atRest(b) with
+  | true => b
+  | false =>
+    let nx = b.pos.x + b.vel.x * dt in
+    let ny = b.pos.y + b.vel.y * dt in
+    let nz = b.pos.z + b.vel.z * dt in
+    let nvy = b.vel.y - gravity * dt in
+    match ny < 0.0 with
+    | true =>
+      let ry = 0.0 - nvy * bounce in
+      (match ry < restVel with
+       | true => { pos: { x: nx, y: 0.0, z: nz }, vel: { x: 0.0, y: 0.0, z: 0.0 } }
+       | false => { pos: { x: nx, y: 0.0, z: nz }, vel: { x: b.vel.x, y: ry, z: b.vel.z } })
+    | false => { pos: { x: nx, y: ny, z: nz }, vel: { x: b.vel.x, y: nvy, z: b.vel.z } }
 
 let stepModel = (dt, m) =>
   { m with balls: m.balls |> List.map((b) => stepBall(dt, b)) }

--- a/runtime/functor-runtime-common/src/lib.rs
+++ b/runtime/functor-runtime-common/src/lib.rs
@@ -83,6 +83,7 @@ pub mod skybox;
 mod shader_program;
 pub mod texture;
 pub mod timetravel;
+pub mod trajectory;
 pub mod ui;
 mod viewport;
 
@@ -98,6 +99,7 @@ pub use render_target::RenderTargetDescriptor;
 pub use renderer::*;
 pub use skybox::SkyboxDescription;
 pub use scene3d::*;
+pub use trajectory::{overlay, trajectory_trail};
 pub use viewport::*;
 
 #[cfg(test)]

--- a/runtime/functor-runtime-common/src/trajectory.rs
+++ b/runtime/functor-runtime-common/src/trajectory.rs
@@ -1,0 +1,222 @@
+//! Scene-diff trajectory preview (docs/time-travel.md T6, the scene-diff
+//! variant). Given a game's live frame plus its forward-simulated future frames,
+//! find the scene nodes whose WORLD position changes across the sequence and
+//! emit a trail of dots tracing each mover's path.
+//!
+//! The point is that this needs NO game cooperation: the runtime derives the
+//! trajectory purely from what `draw` already renders. It diffs the rendered
+//! *scene* (which carries concrete world transforms), not the opaque model — so
+//! "which numbers are positions" is unambiguous (a node's world translation) and
+//! "what moved" falls out of comparing those across the forward-sim.
+//!
+//! Pure and testable — no GPU, no interpreter needed (see the unit tests).
+
+use std::collections::HashMap;
+
+use cgmath::{InnerSpace, Matrix4, SquareMatrix, Vector3};
+
+use crate::{MaterialDescription, Scene3D, SceneObject};
+
+/// Walk `scene`, accumulating world transforms, and record each LEAF node's
+/// world-space position keyed by its child-index path from the root. Node
+/// identity across frames = this path — stable while `draw` keeps the same tree
+/// shape (the common case, where only transforms vary frame to frame). A game
+/// that conditionally changes the tree structure between frames will simply not
+/// match those nodes across frames (they fall out of the trail), which is safe.
+fn collect_positions(
+    scene: &Scene3D,
+    world: Matrix4<f32>,
+    path: &mut Vec<usize>,
+    out: &mut Vec<(Vec<usize>, Vector3<f32>)>,
+) {
+    let w = world * scene.xform;
+    match &scene.obj {
+        SceneObject::Group(children) | SceneObject::Material(_, children) => {
+            for (i, child) in children.iter().enumerate() {
+                path.push(i);
+                collect_positions(child, w, path, out);
+                path.pop();
+            }
+        }
+        SceneObject::Geometry(_) | SceneObject::Model(_) => {
+            // The 4th column of the accumulated matrix is the node origin's
+            // world position.
+            out.push((path.clone(), w.w.truncate()));
+        }
+    }
+}
+
+fn positions_by_path(scene: &Scene3D) -> HashMap<Vec<usize>, Vector3<f32>> {
+    let mut out = Vec::new();
+    let mut path = Vec::new();
+    collect_positions(scene, Matrix4::identity(), &mut path, &mut out);
+    out.into_iter().collect()
+}
+
+/// A single dim emissive marker at a world position. The renderer applies a
+/// node's `xform` on `Group`/`Geometry` but NOT on `Material` (the prelude only
+/// ever puts transforms on Groups), so the world translation goes on an
+/// enclosing Group — the size lives on the geometry leaf.
+fn trail_dot(p: Vector3<f32>) -> Scene3D {
+    let sphere = Scene3D::sphere().transform(Matrix4::from_scale(0.07));
+    let material = Scene3D {
+        obj: SceneObject::Material(
+            MaterialDescription::emissive(0.25, 0.85, 1.0, 1.0),
+            vec![sphere],
+        ),
+        xform: Matrix4::identity(),
+    };
+    Scene3D {
+        obj: SceneObject::Group(vec![material]),
+        xform: Matrix4::from_translation(p),
+    }
+}
+
+/// Build a trail scene from a sequence of scenes (index 0 = current, the rest =
+/// forward-simulated futures). A node earns a trail only if its world position
+/// varies by more than `eps` across the sequence — so static geometry stays
+/// clean and only movers get ghost dots. Returns `None` when nothing moved.
+///
+/// `max_step` guards against TELEPORTS: a forward-sim can reset/respawn a node
+/// (e.g. a platformer character falling off the level snaps back to spawn), and
+/// that discontinuity is not a trajectory. Each polyline is cut at the first
+/// per-sample jump larger than `max_step`, so the preview traces the smooth path
+/// up to the reset instead of drawing a straight streak across the snap-back.
+pub fn trajectory_trail(scenes: &[&Scene3D], eps: f32, max_step: f32) -> Option<Scene3D> {
+    if scenes.len() < 2 {
+        return None;
+    }
+    let per_scene: Vec<_> = scenes.iter().map(|s| positions_by_path(s)).collect();
+    let eps2 = eps * eps;
+    let mut dots = Vec::new();
+    // Identity set = the paths present in the current (index 0) scene.
+    for (path, p0) in &per_scene[0] {
+        let mut poly = vec![*p0];
+        let mut present_everywhere = true;
+        for m in &per_scene[1..] {
+            match m.get(path) {
+                Some(p) => poly.push(*p),
+                None => {
+                    present_everywhere = false;
+                    break;
+                }
+            }
+        }
+        if !present_everywhere {
+            continue;
+        }
+        // Cut at the first teleport (respawn/reset) — a trajectory is continuous.
+        if let Some(cut) = (1..poly.len()).find(|&i| (poly[i] - poly[i - 1]).magnitude() > max_step)
+        {
+            poly.truncate(cut);
+        }
+        let moved = poly.iter().any(|p| (p - poly[0]).magnitude2() > eps2);
+        if !moved {
+            continue;
+        }
+        if std::env::var("TRAJ_DEBUG").is_ok() {
+            let last = poly.len() - 1;
+            let span = poly.iter().map(|p| (p - poly[0]).magnitude()).fold(0.0f32, f32::max);
+            eprintln!(
+                "[traj] path={:?} span={:.2} p0=({:.2},{:.2},{:.2}) plast=({:.2},{:.2},{:.2})",
+                path, span,
+                poly[0].x, poly[0].y, poly[0].z,
+                poly[last].x, poly[last].y, poly[last].z,
+            );
+        }
+        for p in &poly {
+            dots.push(trail_dot(*p));
+        }
+    }
+    if dots.is_empty() {
+        None
+    } else {
+        Some(Scene3D {
+            obj: SceneObject::Group(dots),
+            xform: Matrix4::identity(),
+        })
+    }
+}
+
+/// Composite a derived trail onto a scene (the runtime's trajectory overlay).
+pub fn overlay(scene: Scene3D, trail: Scene3D) -> Scene3D {
+    Scene3D {
+        obj: SceneObject::Group(vec![scene, trail]),
+        xform: Matrix4::identity(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgmath::vec3;
+
+    fn ball_at(x: f32, y: f32) -> Scene3D {
+        Scene3D::sphere().transform(Matrix4::from_translation(vec3(x, y, 0.0)))
+    }
+
+    // A group holding a mover (sphere 0) and a static sphere (sphere 1).
+    fn frame(x: f32, y: f32) -> Scene3D {
+        Scene3D {
+            obj: SceneObject::Group(vec![ball_at(x, y), ball_at(5.0, 0.0)]),
+            xform: Matrix4::identity(),
+        }
+    }
+
+    #[test]
+    fn moving_node_gets_a_trail_static_does_not() {
+        let f0 = frame(0.0, 0.0);
+        let f1 = frame(1.0, 1.0);
+        let f2 = frame(2.0, 1.5);
+        let trail = trajectory_trail(&[&f0, &f1, &f2], 0.05, 3.0).expect("a trail");
+        // Only the mover contributes dots — one per frame (3); the static ball none.
+        match trail.obj {
+            SceneObject::Group(dots) => assert_eq!(dots.len(), 3),
+            _ => panic!("expected a group of dots"),
+        }
+    }
+
+    #[test]
+    fn nothing_moving_yields_no_trail() {
+        let s = frame(1.0, 1.0);
+        assert!(trajectory_trail(&[&s, &s, &s], 0.05, 3.0).is_none());
+    }
+
+    #[test]
+    fn dot_lands_at_the_movers_world_position() {
+        // A mover nested under a translated group: world position must fold in
+        // the parent transform (2 + 3 = 5 on x).
+        let nested = |x: f32| Scene3D {
+            obj: SceneObject::Group(vec![ball_at(x, 0.0)]),
+            xform: Matrix4::from_translation(vec3(2.0, 0.0, 0.0)),
+        };
+        let a = nested(0.0);
+        let b = nested(3.0);
+        let trail = trajectory_trail(&[&a, &b], 0.05, 3.0).expect("a trail");
+        let dots = match trail.obj {
+            SceneObject::Group(d) => d,
+            _ => panic!(),
+        };
+        // Second dot is the mover at frame b: world x = 2 (group) + 3 (local) = 5.
+        let x = dots[1].xform.w.x;
+        assert!((x - 5.0).abs() < 1e-4, "expected world x=5, got {x}");
+    }
+
+    #[test]
+    fn trail_stops_at_a_teleport() {
+        // A node steps smoothly (0 → 0.5 → 1.0) then RESPAWNS to a far position
+        // (a mario-style reset). The trail must cover the smooth run only — 3
+        // dots — and NOT draw the snap-back streak.
+        let step = |x: f32| Scene3D {
+            obj: SceneObject::Group(vec![ball_at(x, 0.0)]),
+            xform: Matrix4::identity(),
+        };
+        let frames = [step(0.0), step(0.5), step(1.0), step(-6.0)];
+        let refs: Vec<&Scene3D> = frames.iter().collect();
+        let trail = trajectory_trail(&refs, 0.05, 3.0).expect("a trail");
+        match trail.obj {
+            SceneObject::Group(dots) => assert_eq!(dots.len(), 3, "teleport sample dropped"),
+            _ => panic!(),
+        }
+    }
+}

--- a/runtime/functor-runtime-common/src/trajectory.rs
+++ b/runtime/functor-runtime-common/src/trajectory.rs
@@ -11,29 +11,39 @@
 //!
 //! Pure and testable — no GPU, no interpreter needed (see the unit tests).
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use cgmath::{InnerSpace, Matrix4, SquareMatrix, Vector3};
 
 use crate::{MaterialDescription, Scene3D, SceneObject};
 
+/// One step of a node path: (child index, sibling count). Node identity across
+/// frames = the path of these segments from the root. Including the sibling
+/// count means a structural change that alters a group's SIZE (a child spawning
+/// or despawning mid-window) changes every sibling's key in that frame, so a
+/// current-frame path stops matching there instead of silently resolving to a
+/// shifted neighbor — a plain despawn TRUNCATES a trail rather than cross-wiring
+/// it onto a different entity. Positional identity still can't distinguish
+/// size-preserving changes (a removal plus an insertion within one sample
+/// interval, or two siblings swapping list positions) — those can alias, and
+/// the real fix is stable node ids, a known limit.
+type PathSeg = (usize, usize);
+
 /// Walk `scene`, accumulating world transforms, and record each LEAF node's
-/// world-space position keyed by its child-index path from the root. Node
-/// identity across frames = this path — stable while `draw` keeps the same tree
-/// shape (the common case, where only transforms vary frame to frame). A game
-/// that conditionally changes the tree structure between frames will simply not
-/// match those nodes across frames (they fall out of the trail), which is safe.
+/// world-space position keyed by its path from the root. A `BTreeMap` so
+/// iteration (and thus trail-dot order in the emitted scene) is deterministic.
 fn collect_positions(
     scene: &Scene3D,
     world: Matrix4<f32>,
-    path: &mut Vec<usize>,
-    out: &mut Vec<(Vec<usize>, Vector3<f32>)>,
+    path: &mut Vec<PathSeg>,
+    out: &mut BTreeMap<Vec<PathSeg>, Vector3<f32>>,
 ) {
     let w = world * scene.xform;
     match &scene.obj {
         SceneObject::Group(children) | SceneObject::Material(_, children) => {
+            let count = children.len();
             for (i, child) in children.iter().enumerate() {
-                path.push(i);
+                path.push((i, count));
                 collect_positions(child, w, path, out);
                 path.pop();
             }
@@ -41,16 +51,16 @@ fn collect_positions(
         SceneObject::Geometry(_) | SceneObject::Model(_) => {
             // The 4th column of the accumulated matrix is the node origin's
             // world position.
-            out.push((path.clone(), w.w.truncate()));
+            out.insert(path.clone(), w.w.truncate());
         }
     }
 }
 
-fn positions_by_path(scene: &Scene3D) -> HashMap<Vec<usize>, Vector3<f32>> {
-    let mut out = Vec::new();
+fn positions_by_path(scene: &Scene3D) -> BTreeMap<Vec<PathSeg>, Vector3<f32>> {
+    let mut out = BTreeMap::new();
     let mut path = Vec::new();
     collect_positions(scene, Matrix4::identity(), &mut path, &mut out);
-    out.into_iter().collect()
+    out
 }
 
 /// A single dim emissive marker at a world position. The renderer applies a
@@ -89,21 +99,16 @@ pub fn trajectory_trail(scenes: &[&Scene3D], eps: f32, max_step: f32) -> Option<
     let per_scene: Vec<_> = scenes.iter().map(|s| positions_by_path(s)).collect();
     let eps2 = eps * eps;
     let mut dots = Vec::new();
-    // Identity set = the paths present in the current (index 0) scene.
+    // Identity set = the paths present in the current (index 0) scene. A node
+    // whose path stops matching mid-window (despawn, or its group changed
+    // shape — see `PathSeg`) keeps its trail up to that sample.
     for (path, p0) in &per_scene[0] {
         let mut poly = vec![*p0];
-        let mut present_everywhere = true;
         for m in &per_scene[1..] {
             match m.get(path) {
                 Some(p) => poly.push(*p),
-                None => {
-                    present_everywhere = false;
-                    break;
-                }
+                None => break,
             }
-        }
-        if !present_everywhere {
-            continue;
         }
         // Cut at the first teleport (respawn/reset) — a trajectory is continuous.
         if let Some(cut) = (1..poly.len()).find(|&i| (poly[i] - poly[i - 1]).magnitude() > max_step)
@@ -113,16 +118,6 @@ pub fn trajectory_trail(scenes: &[&Scene3D], eps: f32, max_step: f32) -> Option<
         let moved = poly.iter().any(|p| (p - poly[0]).magnitude2() > eps2);
         if !moved {
             continue;
-        }
-        if std::env::var("TRAJ_DEBUG").is_ok() {
-            let last = poly.len() - 1;
-            let span = poly.iter().map(|p| (p - poly[0]).magnitude()).fold(0.0f32, f32::max);
-            eprintln!(
-                "[traj] path={:?} span={:.2} p0=({:.2},{:.2},{:.2}) plast=({:.2},{:.2},{:.2})",
-                path, span,
-                poly[0].x, poly[0].y, poly[0].z,
-                poly[last].x, poly[last].y, poly[last].z,
-            );
         }
         for p in &poly {
             dots.push(trail_dot(*p));
@@ -138,12 +133,21 @@ pub fn trajectory_trail(scenes: &[&Scene3D], eps: f32, max_step: f32) -> Option<
     }
 }
 
-/// Composite a derived trail onto a scene (the runtime's trajectory overlay).
-pub fn overlay(scene: Scene3D, trail: Scene3D) -> Scene3D {
-    Scene3D {
-        obj: SceneObject::Group(vec![scene, trail]),
+/// Composite a derived trail onto a scene in place (the runtime's trajectory
+/// overlay). In-place so callers overlaying every frame don't deep-clone the
+/// scene tree just to regroup it.
+pub fn overlay(scene: &mut Scene3D, trail: Scene3D) {
+    let prev = std::mem::replace(
+        scene,
+        Scene3D {
+            obj: SceneObject::Group(Vec::new()),
+            xform: Matrix4::identity(),
+        },
+    );
+    *scene = Scene3D {
+        obj: SceneObject::Group(vec![prev, trail]),
         xform: Matrix4::identity(),
-    }
+    };
 }
 
 #[cfg(test)]
@@ -200,6 +204,35 @@ mod tests {
         // Second dot is the mover at frame b: world x = 2 (group) + 3 (local) = 5.
         let x = dots[1].xform.w.x;
         assert!((x - 5.0).abs() < 1e-4, "expected world x=5, got {x}");
+    }
+
+    #[test]
+    fn mid_list_despawn_truncates_and_never_cross_wires() {
+        // Group [mover, staticA, staticB]; in the last frame the mover
+        // despawns, shifting the statics down one list slot. With bare-index
+        // paths the statics' old paths would resolve to their neighbors and
+        // fabricate a phantom trail between two objects that never moved; with
+        // sibling counts in the key the changed group stops matching, so the
+        // mover keeps its trail up to the despawn and the statics get nothing.
+        let f = |x: f32| Scene3D {
+            obj: SceneObject::Group(vec![
+                ball_at(x, 0.0),
+                ball_at(1.0, 0.0),
+                ball_at(2.0, 0.0),
+            ]),
+            xform: Matrix4::identity(),
+        };
+        let last = Scene3D {
+            obj: SceneObject::Group(vec![ball_at(1.0, 0.0), ball_at(2.0, 0.0)]),
+            xform: Matrix4::identity(),
+        };
+        let trail = trajectory_trail(&[&f(0.0), &f(0.5), &last], 0.05, 3.0).expect("a trail");
+        match trail.obj {
+            // Two dots: the mover's frames before the despawn. Anything more
+            // means a static sibling was aliased onto a neighbor's position.
+            SceneObject::Group(dots) => assert_eq!(dots.len(), 2, "expected only the mover's pre-despawn dots"),
+            _ => panic!("expected a group of dots"),
+        }
     }
 
     #[test]

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -858,6 +858,18 @@ pub fn run(args: Args) {
         let mut ghost_on = args.ghost;
         let mut ghost_divisions = args.ghost_divisions;
         let mut ghost_window: f32 = 2.0;
+        // --trajectory trail cache. The 32-division forward-sim is the expensive
+        // part, and while PAUSED its anchor (scene frame + tts) is frozen — so
+        // reuse the trail while the anchor key matches, but still refresh every
+        // TRAIL_REFRESH_FRAMES so a hot-reload's edited code re-projects within
+        // ~half a second (the anchor can't see a code edit). Live play changes
+        // the key every frame, so it recomputes like --ghost does.
+        const TRAIL_REFRESH_FRAMES: u32 = 30;
+        let mut trail_cache: Option<(
+            (Option<u64>, u32),
+            Option<functor_runtime_common::Scene3D>,
+        )> = None;
+        let mut trail_refresh: u32 = 0;
 
         gl.clear_color(0.1, 0.2, 0.3, 1.0);
 
@@ -1227,40 +1239,86 @@ Escape again to quit"
             let viewport = functor_runtime_common::Viewport::new(fb_width as u32, fb_height as u32);
 
             // The game supplies the camera/scene/lights as part of its frame.
-            let mut frame = game.render(time.clone());
+            // Kept PRISTINE: the debug server's GET /scene serves this frame, and
+            // it must reflect exactly what the game's `draw` produced — the
+            // trajectory overlay goes on a render-only copy below.
+            let frame = game.render(time.clone());
 
             // Scene-diff trajectory preview (docs/time-travel.md T6, scene-diff
             // variant): forward-simulate the model (physics included, via the
             // shared ghost_frames) and diff the rendered scenes' node world
-            // positions, then overlay a dotted trail on just the movers — the
-            // clean-lines COMPLEMENT to --ghost's whole-scene strobe. Same gating
-            // as ghost (interactive only while the scrubber is paused; headless
-            // via the flag, so it's deterministically capturable). Renders on the
-            // normal path — the trail is ordinary emissive geometry, no
-            // compositor.
-            let trajectory_active = if scrubber_visible {
-                args.trajectory && clock.is_paused()
-            } else {
-                args.trajectory
-            };
-            if trajectory_active {
+            // positions into a dotted trail on just the movers — the clean-lines
+            // COMPLEMENT to --ghost's whole-scene strobe. Same gating as ghost
+            // (interactive only while the scrubber is paused; headless via the
+            // flag, so it's deterministically capturable). Renders on the normal
+            // path — the trail is ordinary emissive geometry, no compositor.
+            let trajectory_active = args.trajectory
+                && args.composite_demo == CompositeDemoArg::Off
+                && (!scrubber_visible || clock.is_paused());
+            let trail: Option<functor_runtime_common::Scene3D> = if trajectory_active {
                 // Not bound by the 8-target compositor cap — this only reads node
                 // positions — so sample finely for a smooth arc.
                 let divisions = 32usize;
                 let window = 1.6f32;
                 let dt = window / divisions as f32;
-                let futures = game.ghost_frames(divisions, dt, time.tts as f64, None);
-                let trail = {
-                    let mut scenes: Vec<&functor_runtime_common::Scene3D> = vec![&frame.scene];
-                    scenes.extend(futures.iter().map(|(f, _)| &f.scene));
-                    // eps 0.04: ignore sub-mm jitter. max_step 3.0: cut respawn
-                    // teleports (a reset covers many units in one sample).
-                    functor_runtime_common::trajectory_trail(&scenes, 0.04, 3.0)
-                };
-                if let Some(trail) = trail {
-                    frame.scene = functor_runtime_common::overlay(frame.scene.clone(), trail);
+                let key = (game.current_scene_frame(), time.tts.to_bits());
+                let cache_hit = trail_refresh > 0
+                    && trail_cache.as_ref().is_some_and(|(k, _)| *k == key);
+                if cache_hit {
+                    trail_refresh -= 1;
+                    trail_cache.as_ref().and_then(|(_, t)| t.clone())
+                } else {
+                    // Under --input-script the live loop keeps consuming the
+                    // script (its gate is `!args.ghost`), so the forward-sim must
+                    // replay the SAME upcoming slice — with `None` it would
+                    // replay the recorder's (empty-at-head) log and predict an
+                    // input-free future the game won't play. The slice anchors at
+                    // the fine step after the newest recorded frame, mirroring
+                    // the `inputs_from(k + 1)` anchor of the recorded-log path.
+                    let script_slice: Option<Vec<Vec<RecordedInput>>> =
+                        input_script.as_ref().map(|script| {
+                            let sub_dt = 1.0f32 / 60.0;
+                            let steps_per_division =
+                                ((dt / sub_dt).round() as usize).max(1);
+                            let total = (divisions * steps_per_division) as u64;
+                            // Under --ghost the live loop does NOT consume the
+                            // script (the model holds at the init anchor while
+                            // the recorder still advances), and the ghost slice
+                            // below replays from frame 0 — anchor the trail the
+                            // same way or the two projections diverge. Live
+                            // playback consumes the script, so there the next
+                            // unconsumed frame (k + 1) is the right anchor.
+                            let base = if args.ghost {
+                                0
+                            } else {
+                                game.current_scene_frame().map_or(0, |k| k + 1)
+                            };
+                            (0..total)
+                                .map(|j| script.get(&(base + j)).cloned().unwrap_or_default())
+                                .collect()
+                        });
+                    let futures = game.ghost_frames(
+                        divisions,
+                        dt,
+                        time.tts as f64,
+                        script_slice.as_deref(),
+                    );
+                    let t = {
+                        let mut scenes: Vec<&functor_runtime_common::Scene3D> =
+                            vec![&frame.scene];
+                        scenes.extend(futures.iter().map(|(f, _)| &f.scene));
+                        // eps 0.04: ignore sub-mm jitter. max_step 3.0: cut respawn
+                        // teleports (a reset covers many units in one sample).
+                        functor_runtime_common::trajectory_trail(&scenes, 0.04, 3.0)
+                    };
+                    trail_refresh = TRAIL_REFRESH_FRAMES;
+                    trail_cache = Some((key, t.clone()));
+                    t
                 }
-            }
+            } else {
+                trail_cache = None;
+                None
+            };
 
             // Forward-ghosting (docs/time-travel.md T6d): when --ghost is on, step
             // the scene forward over a ~2s window and collect a Frame per division
@@ -1314,6 +1372,18 @@ Escape again to quit"
             } else {
                 Vec::new()
             };
+            // The trail composes with the strobe by riding IN each composited
+            // frame: the dots are identical opaque geometry at identical world
+            // positions in every input, so the equal-weight average reconstructs
+            // them at full intensity (unlike movers, which appear in only one
+            // frame each). Without this the ghost render arm draws only
+            // `ghost_frames` and the trail would silently vanish.
+            let mut ghost_frames = ghost_frames;
+            if let Some(trail) = &trail {
+                for (f, _) in ghost_frames.iter_mut() {
+                    functor_runtime_common::overlay(&mut f.scene, trail.clone());
+                }
+            }
 
             // The camera actually viewed/heard: the game's camera, rotated by
             // the head orientation when Xreal tracking is on.
@@ -1368,6 +1438,20 @@ Escape again to quit"
                 })
                 .flatten();
 
+            // The frame the render ladder draws: the game frame plus the
+            // trajectory overlay (`frame` itself stays pristine for GET /scene).
+            // Skipped when the ghost arm will draw instead — the trail already
+            // rides inside `ghost_frames`.
+            let display_frame = match (&trail, ghost_frames.is_empty()) {
+                (Some(t), true) => {
+                    let mut f = frame.clone();
+                    functor_runtime_common::overlay(&mut f.scene, t.clone());
+                    Some(f)
+                }
+                _ => None,
+            };
+            let drawn_frame = display_frame.as_ref().unwrap_or(&frame);
+
             // Shadow + forward passes, shared with the web runtime. In stereo
             // mode, render the same frame twice — once per eye camera into each
             // half of the window. (The shadow pass runs per eye; it must start
@@ -1391,7 +1475,7 @@ Escape again to quit"
                         asset_cache.clone(),
                         &scene_context,
                         &shadow_map,
-                        &frame,
+                        drawn_frame,
                         camera,
                         time.clone(),
                         *eye_viewport,
@@ -1461,7 +1545,7 @@ Escape again to quit"
                     asset_cache.clone(),
                     &scene_context,
                     &shadow_map,
-                    &frame,
+                    drawn_frame,
                     &view_camera,
                     time.clone(),
                     viewport,

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -312,6 +312,14 @@ pub struct Args {
     #[arg(long, default_value_t = 8)]
     ghost_divisions: usize,
 
+    /// Scene-diff trajectory preview (docs/time-travel.md T6, scene-diff
+    /// variant): forward-simulate the model and draw a clean dotted trail
+    /// tracing ONLY the scene nodes that move — derived by the runtime from
+    /// `draw`, with no game logic. Unlike --ghost's whole-scene strobe, static
+    /// geometry contributes nothing. Capturable under --fixed-time.
+    #[arg(long)]
+    trajectory: bool,
+
     /// Narrate the game clock + time-travel seams to stderr: pause/resume/seek
     /// rebases (with the tts they land on), ghost on/off, and per-frame HITCH
     /// warnings when a rendered frame's dt blows past 33ms (the tell-tale of the
@@ -1219,7 +1227,40 @@ Escape again to quit"
             let viewport = functor_runtime_common::Viewport::new(fb_width as u32, fb_height as u32);
 
             // The game supplies the camera/scene/lights as part of its frame.
-            let frame = game.render(time.clone());
+            let mut frame = game.render(time.clone());
+
+            // Scene-diff trajectory preview (docs/time-travel.md T6, scene-diff
+            // variant): forward-simulate the model (physics included, via the
+            // shared ghost_frames) and diff the rendered scenes' node world
+            // positions, then overlay a dotted trail on just the movers — the
+            // clean-lines COMPLEMENT to --ghost's whole-scene strobe. Same gating
+            // as ghost (interactive only while the scrubber is paused; headless
+            // via the flag, so it's deterministically capturable). Renders on the
+            // normal path — the trail is ordinary emissive geometry, no
+            // compositor.
+            let trajectory_active = if scrubber_visible {
+                args.trajectory && clock.is_paused()
+            } else {
+                args.trajectory
+            };
+            if trajectory_active {
+                // Not bound by the 8-target compositor cap — this only reads node
+                // positions — so sample finely for a smooth arc.
+                let divisions = 32usize;
+                let window = 1.6f32;
+                let dt = window / divisions as f32;
+                let futures = game.ghost_frames(divisions, dt, time.tts as f64, None);
+                let trail = {
+                    let mut scenes: Vec<&functor_runtime_common::Scene3D> = vec![&frame.scene];
+                    scenes.extend(futures.iter().map(|(f, _)| &f.scene));
+                    // eps 0.04: ignore sub-mm jitter. max_step 3.0: cut respawn
+                    // teleports (a reset covers many units in one sample).
+                    functor_runtime_common::trajectory_trail(&scenes, 0.04, 3.0)
+                };
+                if let Some(trail) = trail {
+                    frame.scene = functor_runtime_common::overlay(frame.scene.clone(), trail);
+                }
+            }
 
             // Forward-ghosting (docs/time-travel.md T6d): when --ghost is on, step
             // the scene forward over a ~2s window and collect a Frame per division


### PR DESCRIPTION
## Scene-diff trajectory preview (spike) — docs/time-travel.md T6

A **spike** exploring the "Inventing on Principle" trajectory predictor as a
**shell-owned, zero-game-logic** feature: the runtime forward-simulates the
model and draws a clean predicted-path trail for whatever is moving — the game
writes nothing.

> **Status: spike, not production.** Opened to document the exploration and the
> code. See *Findings* and *Follow-ups* before merging.
>
> Commit ec420cd hardened the spike after a cross-engine review — findings
> addressed: mid-list despawn identity truncation (sibling-count path keys + a
> regression test), deterministic dot order (`BTreeMap`), a trail cache keyed on
> the (scene frame, tts) anchor (paused scrubbing no longer re-simulates every
> frame; hot-reload re-projects within ~0.5s), `--input-script` script-slice
> replay (base 0 under `--ghost` to match the strobe anchor), `GET /scene` stays
> pristine (the trail is a render-only overlay), the trail now composes INTO the
> `--ghost` strobe (previously it was silently hidden), `--composite-demo`
> gating, and the examples' resting balls are genuinely at rest (`atRest` /
> `restVel`; the trajectory example's resting ball moved y=0.3→0.0).

### How it works

The whole thing rides on `tick` being a **pure function of the model**, so the
shell can roll the model forward with no side effects. Rather than diff the
*opaque model* (where "which numbers are positions?" is unanswerable), it diffs
the **rendered scene**, which carries concrete world transforms:

1. Forward-simulate via the existing physics-aware `ghost_frames` (re-runs
   `tick` **and steps the rapier world**, in throwaway state).
2. Walk each future frame's scene graph, accumulating world transforms; key each
   leaf's world position by its **node path**.
3. Keep only nodes whose world position **changes** across the sequence (static
   geometry contributes nothing — "smart" trails).
4. Overlay a dotted trail on the movers, as ordinary emissive geometry on the
   normal render path (no compositor).

This is the clean-lines **complement to `--ghost`**: ghost composites the whole
scene into a translucent strobe ("no trail primitive needed"); this traces crisp
per-mover arcs instead. `--trajectory` is gated **identically to `--ghost`**
(interactive only while the scrubber is paused; headless via the flag, so it's
deterministically capturable).

### What's in the PR

| File | What |
| --- | --- |
| `runtime/functor-runtime-common/src/trajectory.rs` | Pure, unit-tested `trajectory_trail(scenes, eps, max_step)` — the walk + diff + teleport-cut + dot builder (4 tests). |
| `runtime/functor-runtime-desktop/src/run.rs` | `--trajectory` flag; ghost-parity gating; overlays the trail before the render ladder. |
| `runtime/functor-runtime-common/src/lib.rs` | Re-exports. |
| `examples/toss/` | **Zero-trail-logic** demo — bouncing balls; a resting ball gets no trail. The trails are entirely runtime-derived. |
| `examples/trajectory/` | The earlier **in-language** prototype — the game forward-sims in `draw` (no engine changes), for contrast. |

### Verified

- `functor -d examples/toss run native --trajectory` → clean bouncing arcs incl.
  ground bounces; the at-rest ball gets nothing.
- `functor -d examples/physics run native --trajectory` → automatic fall arcs on
  the crates + ball, **motion sourced from rapier**, zero game logic.
- `examples/mario` → run-off-edge-and-fall arc that **stops at the respawn** (no
  snap-back streak).
- `cargo test -p functor_runtime_common trajectory` → 4/4 green.
- Strict (deny-warnings) build of the changed crates is clean.

### Findings worth keeping

- **`Material` scene nodes ignore their own `xform`** (the renderer applies
  transforms only on `Group`/`Geometry`; the prelude always wraps transforms in
  Groups). Putting a translation on a Material node silently drops it — this
  collapsed every trail dot to the origin until fixed by wrapping in a Group.
- **Forward-sims teleport** (respawn/reset — e.g. mario falling in the chasm
  snaps back to spawn). A trajectory is continuous, so each polyline is cut at
  the first teleport-sized per-sample jump; bounces (continuous) are unaffected.

### Follow-ups (before this is "real")

- Exclude trail geometry from **shadow casting** (dots currently cast dotted
  floor shadows in the physics scene).
- Interactive **scrubber toggle** next to the ghost toggle (currently launch-flag
  only) — the true "complement" UX.
- Fold the scene-diff variant into docs/time-travel.md T6 (design record).

Done since the spike opened (ec420cd): strobe + trail now compose (`--ghost
--trajectory` shows both), the per-frame forward-sim cost is anchored-cached
while paused, and the `TRAJ_DEBUG` env logging was removed.


## Demo

![trajectory trails demo](https://gist.githubusercontent.com/tommy-xr/386166e7590e2279a0303208e05620b7/raw/toss-trajectory.gif)

<sub>Runtime-derived trajectory trails (`examples/toss`, `--trajectory`) — zero game logic; the resting ball gets no trail. Rendered headlessly via the deterministic `--input-script` / `--capture-at-frame` path.</sub>

![toss trajectory still](https://gist.githubusercontent.com/tommy-xr/386166e7590e2279a0303208e05620b7/raw/toss-trajectory-still.png)

![ghost + trajectory composed](https://gist.githubusercontent.com/tommy-xr/386166e7590e2279a0303208e05620b7/raw/toss-ghost-trajectory.png)

<sub>NEW — `--ghost --trajectory` composed: the translucent strobe copies AND the full-intensity trail dots in one frame (previously the ghost compositor silently hid the trail). Note the visibility contrast between the dim strobe and the crisp trail.</sub>

![in-language trajectory example](https://gist.githubusercontent.com/tommy-xr/386166e7590e2279a0303208e05620b7/raw/trajectory-example.png)

<sub>`examples/trajectory`, no flags — the in-language prototype for contrast: the game's own `draw` forward-sims and draws the dots; the resting ball is trail-free.</sub>

![physics trajectory still](https://gist.githubusercontent.com/tommy-xr/386166e7590e2279a0303208e05620b7/raw/physics-trajectory.png)

<sub>`examples/physics --trajectory` — rapier-sourced fall arcs on the crates + ball, zero game logic.</sub>
