### PR TITLE
perf: request a lean WebGL2 context (no MSAA, opaque, high-performance)

### DIFF
--- a/runtime/functor-runtime-web/Cargo.toml
+++ b/runtime/functor-runtime-web/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = "1.0"
 
 [dependencies.web-sys]
 version = "0.3.4"
-features = ['Blob', 'HtmlCanvasElement', 'WebGl2RenderingContext', 'console', 'Window', 'Location', 'Performance', 'PerformanceTiming', 'Document', 'Element', 'Node', 'HtmlElement', 'Request', 'RequestInit', 'RequestCache', 'Response', 'Headers', 'AudioContext', 'BaseAudioContext', 'AudioBuffer', 'AudioBufferSourceNode', 'AudioDestinationNode', 'AudioNode', 'AudioParam', 'GainNode', 'StereoPannerNode', 'WebSocket', 'MessageEvent', 'CloseEvent', 'ErrorEvent']
+features = ['Blob', 'HtmlCanvasElement', 'WebGl2RenderingContext', 'WebGlContextAttributes', 'WebGlPowerPreference', 'console', 'Window', 'Location', 'Performance', 'PerformanceTiming', 'Document', 'Element', 'Node', 'HtmlElement', 'Request', 'RequestInit', 'RequestCache', 'Response', 'Headers', 'AudioContext', 'BaseAudioContext', 'AudioBuffer', 'AudioBufferSourceNode', 'AudioDestinationNode', 'AudioNode', 'AudioParam', 'GainNode', 'StereoPannerNode', 'WebSocket', 'MessageEvent', 'CloseEvent', 'ErrorEvent']
 
 [profile.release]
 codegen-units = 1

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -919,8 +919,16 @@ async fn run_async() -> Result<(), JsValue> {
                 .unwrap()
                 .dyn_into::<web_sys::HtmlCanvasElement>()
                 .unwrap();
+            // Ask for a lean context: no MSAA (the canvas is sized to CSS px x
+            // devicePixelRatio, so on retina 4x multisampling a ~2880x1800
+            // backbuffer every frame is a GPU burner), an opaque backbuffer (no
+            // alpha compositing with the page), and the discrete GPU.
+            let attrs = web_sys::WebGlContextAttributes::new();
+            attrs.set_antialias(false);
+            attrs.set_alpha(false);
+            attrs.set_power_preference(web_sys::WebGlPowerPreference::HighPerformance);
             let webgl2_context = canvas
-                .get_context("webgl2")
+                .get_context_with_context_options("webgl2", &attrs)
                 .unwrap()
                 .unwrap()
                 .dyn_into::<web_sys::WebGl2RenderingContext>()


### PR DESCRIPTION
## What

The wasm runtime created its WebGL2 context with `get_context("webgl2")` and **no attributes**, so it inherited the browser defaults:

- `antialias: true` — 4x MSAA
- `alpha: true` — alpha compositing with the page
- default `powerPreference`

The canvas is sized to CSS px × `devicePixelRatio`, so on a retina display this multisamples a ~2880×1800 backbuffer every frame — a classic GPU burner.

## Change

Create the context with explicit options via `get_context_with_context_options("webgl2", …)`:

- `antialias: false`
- `alpha: false`
- `powerPreference: "high-performance"`

Adds the minimal `web-sys` features required (`WebGlContextAttributes`, `WebGlPowerPreference`). Left `desynchronized` out to keep the change minimal (the audit only said "consider").

## Tradeoff

`antialias: false` may slightly change edge appearance on the wasm target (aliased polygon edges instead of MSAA-smoothed). This is an accepted tradeoff from the performance audit — the retina MSAA cost outweighs the edge smoothing.

## Verification

- `npm run build:cli` succeeds (builds the wasm bundle via wasm-pack, then the CLI) — exit 0.
- `./target/debug/functor -d examples/synthwave run wasm` serves without error; `curl http://127.0.0.1:8080` returns HTTP 200 (index served).

🤖 Generated with [Claude Code](https://claude.com/claude-code)