### PR TITLE
perf: add GL render/swap timing to frame-stats telemetry

### DIFF
--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -111,6 +111,10 @@ pub enum Event {
         tick_us: f64,
         draw_us: f64,
         #[serde(skip_serializing_if = "Option::is_none")]
+        render_us: Option<f64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        swap_us: Option<f64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         frame_us: Option<f64>,
         #[serde(skip_serializing_if = "Option::is_none")]
         budget_pct: Option<f64>,
@@ -146,12 +150,16 @@ impl From<functor_runtime_common::events::RuntimeEvent> for Event {
             R::FrameStats {
                 tick_us,
                 draw_us,
+                render_us,
+                swap_us,
                 frame_us,
                 budget_pct,
                 over_n_frames,
             } => Event::FrameStats {
                 tick_us,
                 draw_us,
+                render_us: Some(render_us),
+                swap_us: Some(swap_us),
                 frame_us: Some(frame_us),
                 budget_pct: Some(budget_pct),
                 over_n_frames,
@@ -311,11 +319,19 @@ impl PlainRenderer {
             Event::FrameStats {
                 tick_us,
                 draw_us,
+                render_us,
+                swap_us,
                 frame_us,
                 budget_pct,
                 over_n_frames,
             } => {
                 let mut s = format!("tick {tick_us:.1}µs, draw {draw_us:.1}µs");
+                if let Some(render_us) = render_us {
+                    s.push_str(&format!(", render {render_us:.1}µs"));
+                }
+                if let Some(swap_us) = swap_us {
+                    s.push_str(&format!(", swap {swap_us:.1}µs"));
+                }
                 if let Some(frame_us) = frame_us {
                     s.push_str(&format!(", frame {frame_us:.1}µs"));
                 }

--- a/cli/src/output/live.rs
+++ b/cli/src/output/live.rs
@@ -35,6 +35,8 @@ use super::{Event, PlainRenderer, Renderer};
 struct Stats {
     tick_us: f64,
     draw_us: f64,
+    render_us: Option<f64>,
+    swap_us: Option<f64>,
     frame_us: Option<f64>,
     budget_pct: Option<f64>,
 }
@@ -66,6 +68,12 @@ impl Panel {
                     format!("{:.0}µs", s.tick_us).cyan(),
                     format!("{:.0}µs", s.draw_us).cyan(),
                 );
+                if let Some(render_us) = s.render_us {
+                    row.push_str(&format!(" · render {}", format!("{render_us:.0}µs").cyan()));
+                }
+                if let Some(swap_us) = s.swap_us {
+                    row.push_str(&format!(" · swap {}", format!("{swap_us:.0}µs").cyan()));
+                }
                 if let Some(frame_us) = s.frame_us {
                     row.push_str(&format!(" · frame {}", format!("{frame_us:.0}µs").cyan()));
                 }
@@ -209,6 +217,8 @@ impl Renderer for LiveRenderer {
             Event::FrameStats {
                 tick_us,
                 draw_us,
+                render_us,
+                swap_us,
                 frame_us,
                 budget_pct,
                 over_n_frames,
@@ -225,6 +235,8 @@ impl Renderer for LiveRenderer {
                     panel.stats = Some(Stats {
                         tick_us: *tick_us,
                         draw_us: *draw_us,
+                        render_us: *render_us,
+                        swap_us: *swap_us,
                         frame_us: *frame_us,
                         budget_pct: *budget_pct,
                     });

--- a/docs/cli-output.md
+++ b/docs/cli-output.md
@@ -211,23 +211,28 @@ used to `println!` directly. PR-2a routes them through the runtime event sink (b
 | `type`            | Fields                                                                           | Emitted when |
 | ----------------- | -------------------------------------------------------------------------------- | ------------ |
 | `runtime_ready`   | —                                                                                | the runtime loaded and is about to render |
-| `frame_stats`     | `tick_us`, `draw_us`, `frame_us`?, `budget_pct`?, `over_n_frames`                | every `over_n_frames` frames (300) |
+| `frame_stats`     | `tick_us`, `draw_us`, `render_us`?, `swap_us`?, `frame_us`?, `budget_pct`?, `over_n_frames` | every `over_n_frames` frames (300) |
 | `capture_written` | `path` (string)                                                                  | a `--capture-frame` PNG was written |
 | `hot_reload`      | `ok` (bool), `message` (string)                                                  | a hot-reload settled (`ok:false` = rejected edit; old program kept) |
 | `asset_error`     | `path` (string?), `message` (string)                                             | an asset failed to load (fallback served) |
 | `reload`          | —                                                                                | reserved for the wasm dev-server page reload (not emitted natively yet) |
 
-`frame_stats` folds the runtime's per-frame `tick`/`physics`/`draw` cost into three numbers:
-`tick_us` and `draw_us` are the tick and draw averages; `frame_us` is the **total** (tick +
-physics + draw), and `budget_pct` is that total against a 60 fps (16.666 ms) budget. All are
-rounded to one decimal. `over_n_frames` is the averaging window (300). This is a per-window,
+`frame_stats` folds the runtime's per-frame cost into averaged numbers: `tick_us` and `draw_us`
+are the interpreter's tick and draw (frame-description) averages; `render_us` and `swap_us` are the
+shell-measured GL cost — the scene render pass and the buffer swap (which blocks on vsync). Splitting
+them out lets you tell interpreter cost from GL cost. `frame_us` is the **total** (tick + physics +
+draw) and `budget_pct` is that against a 60 fps (16.666 ms) budget; `render_us`/`swap_us` are
+reported alongside but **not** folded into `frame_us` (swap's vsync block would peg `budget_pct`).
+All are rounded to one decimal. `render_us`/`swap_us` come from the native GL shell; under
+`--headless` there is no GL pass to measure, so they read `0.0`. `over_n_frames` is the averaging
+window (300). This is a per-window,
 **not** per-frame, emission — see the cadence note below.
 
 Example tail of `functor -d examples/lighting run native --json` (frame stats + capture):
 
 ```json
 {"type":"runtime_ready"}
-{"type":"frame_stats","tick_us":16.4,"draw_us":163.8,"frame_us":180.3,"budget_pct":1.1,"over_n_frames":300}
+{"type":"frame_stats","tick_us":16.4,"draw_us":163.8,"render_us":210.5,"swap_us":15980.2,"frame_us":180.3,"budget_pct":1.1,"over_n_frames":300}
 {"type":"capture_written","path":"/tmp/frame.png"}
 ```
 

--- a/runtime/functor-runtime-common/src/events.rs
+++ b/runtime/functor-runtime-common/src/events.rs
@@ -29,10 +29,16 @@ pub enum RuntimeEvent {
     Ready,
     /// A periodic frame-cost sample, averaged over `over_n_frames` frames.
     /// `frame_us` is the total (`tick + physics + draw`); `budget_pct` is that
-    /// total against a 60 fps (16.666 ms) budget.
+    /// total against a 60 fps (16.666 ms) budget. `render_us` / `swap_us` are the
+    /// shell-measured GL cost — the scene render pass and the buffer swap (vsync
+    /// blocking) — reported alongside `draw_us` so interpreter cost and GL cost
+    /// can be told apart. They are not folded into `frame_us` (swap's vsync block
+    /// would peg `budget_pct`).
     FrameStats {
         tick_us: f64,
         draw_us: f64,
+        render_us: f64,
+        swap_us: f64,
         frame_us: f64,
         budget_pct: f64,
         over_n_frames: u32,

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -190,6 +190,18 @@ pub trait GameProducer {
 
     fn render(&mut self, frame_time: crate::FrameTime) -> crate::Frame;
 
+    /// Record the shell-measured GL cost of the frame just presented — the wall
+    /// time of the scene render pass (`render_ns`, interpreter → GL submission)
+    /// and of the buffer swap (`swap_ns`, which captures vsync blocking). Unlike
+    /// `tick`/`draw` (interpreter cost the producer times itself), these are
+    /// measured in the imperative shell around the GL calls, so the shell folds
+    /// them back here once per windowed frame after `swap_buffers`; the producer
+    /// averages them into its rolling frame-stats window. The default drops them
+    /// — the honest no-op for producers with no GL shell (replays, web). The
+    /// headless desktop loop uses the same producer but never calls this (no
+    /// GL), so its `render_us`/`swap_us` stay 0.
+    fn record_gl_timing(&mut self, _render_ns: u64, _swap_ns: u64) {}
+
     /// The game's declarative UI tree (`ui model`), lowered by the shell to a
     /// text overlay drawn on top of the frame.
     fn ui(&self) -> crate::ui::View;

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -149,6 +149,10 @@ pub struct FunctorLangGame {
     tick_ns: u64,
     physics_ns: u64,
     draw_ns: u64,
+    // GL cost the shell measures around its render/swap calls and folds back via
+    // `record_gl_timing` — the render pass and the vsync-blocking buffer swap.
+    render_ns: u64,
+    swap_ns: u64,
 }
 
 const STATS_EVERY: u64 = 300;
@@ -380,6 +384,8 @@ impl FunctorLangGame {
             tick_ns: 0,
             physics_ns: 0,
             draw_ns: 0,
+            render_ns: 0,
+            swap_ns: 0,
         }
     }
 
@@ -478,10 +484,14 @@ impl FunctorLangGame {
             let tick_us = self.tick_ns as f64 / STATS_EVERY as f64 / 1000.0;
             let physics_us = self.physics_ns as f64 / STATS_EVERY as f64 / 1000.0;
             let draw_us = self.draw_ns as f64 / STATS_EVERY as f64 / 1000.0;
+            let render_us = self.render_ns as f64 / STATS_EVERY as f64 / 1000.0;
+            let swap_us = self.swap_ns as f64 / STATS_EVERY as f64 / 1000.0;
             let frame_us = tick_us + physics_us + draw_us;
             events::emit(RuntimeEvent::FrameStats {
                 tick_us: round1(tick_us),
                 draw_us: round1(draw_us),
+                render_us: round1(render_us),
+                swap_us: round1(swap_us),
                 frame_us: round1(frame_us),
                 budget_pct: round1(frame_us / 16_666.0 * 100.0),
                 over_n_frames: STATS_EVERY as u32,
@@ -489,6 +499,8 @@ impl FunctorLangGame {
             self.tick_ns = 0;
             self.physics_ns = 0;
             self.draw_ns = 0;
+            self.render_ns = 0;
+            self.swap_ns = 0;
         }
     }
 
@@ -855,6 +867,15 @@ AudioScene.empty), got {}",
         // On failure this is the last good frame — a bad draw must not blank
         // the screen.
         self.last_frame.clone()
+    }
+
+    fn record_gl_timing(&mut self, render_ns: u64, swap_ns: u64) {
+        // The shell measured this frame's GL render + swap (it owns the GL
+        // calls); fold them into the same rolling window `report_stats` averages
+        // — same one-frame lag as `draw_ns`, which is likewise accumulated after
+        // `tick` runs `report_stats`.
+        self.render_ns += render_ns;
+        self.swap_ns += swap_ns;
     }
 
     fn ui(&self) -> View {

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -1332,6 +1332,9 @@ Escape again to quit"
             // half of the window. (The shadow pass runs per eye; it must start
             // unscissored, so scissor is reset before each call — same contract
             // as the netsim viewer's panes.)
+            // Time the whole scene render (all arms) for FrameStats.render_us —
+            // the GL-submission cost, distinct from the interpreter's draw cost.
+            let render_started = Instant::now();
             if args.stereo_sbs {
                 let (left_cam, right_cam) = view_camera.stereo_eyes(args.stereo_ipd);
                 // Odd widths: the right eye absorbs the extra column, so the
@@ -1436,6 +1439,7 @@ Escape again to quit"
                     );
                 }
             }
+            let render_ns = render_started.elapsed().as_nanos() as u64;
 
             // The pointer, in framebuffer pixels, for BOTH interactive egui
             // passes (the game UI and the scrubber). The cursor (GLFW window/
@@ -1636,7 +1640,15 @@ Escape again to quit"
                 }
             }
 
+            // Time the buffer swap separately: it blocks on vsync, so
+            // FrameStats.swap_us captures presentation/vsync cost, not GL work.
+            let swap_started = Instant::now();
             window.swap_buffers();
+            let swap_ns = swap_started.elapsed().as_nanos() as u64;
+
+            // Hand this frame's shell-measured GL cost to the producer, which
+            // folds it into the same rolling window it averages tick/draw over.
+            game.record_gl_timing(render_ns, swap_ns);
         }
     }
 


### PR DESCRIPTION
## Why

A performance audit found a **GPU-side leak that was invisible to existing instrumentation**. `FrameStats.draw_us` times only `session.call("draw")` in the Functor Lang producer — i.e. the interpreter cost to *produce* the frame description. The actual GL render pass and buffer swap were **untimed**, so in the `--json` ndjson stream and the live panel you could not tell interpreter cost from GL cost, and a leak that grew GL-pass time stayed hidden.

## What

Two shell-measured `*_us` fields, reported alongside `draw_us`:

- **`render_us`** — wall time of the scene render pass (from handing the frame description to the renderer through GL submission), measured around **all** render arms (stereo / composite / ghost / normal) in the desktop shell loop.
- **`swap_us`** — wall time of `swap_buffers` (captures vsync blocking), timed separately.

The desktop shell folds these back to the producer via a new `GameProducer::record_gl_timing(render_ns, swap_ns)` hook (default no-op for replay / web; the headless loop has no GL so its values stay 0). The producer averages them into the **same 300-frame window** it already uses for `tick`/`draw`, with the **same reset and one-frame lag as `draw_ns`** (both accumulate after `tick` runs `report_stats`). Wired through the ndjson output, the plain renderer, and the live stats panel.

`render_us`/`swap_us` are reported next to `frame_us` but **not folded into it** — swap's vsync block would peg `budget_pct`, so `frame_us`/`budget_pct` keep their existing tick+physics+draw meaning. The debug server does not surface `FrameStats`, so nothing to change there. Native-only (as the audit noted `FrameStats` is); wasm telemetry parity is a separate backlog item.

## Sample ndjson

From `functor --json -d examples/synthwave run native --capture-frame … --capture-time 7`:

```json
{"type":"frame_stats","tick_us":26.6,"draw_us":12293.4,"render_us":1162.0,"swap_us":2706.9,"frame_us":12321.5,"budget_pct":73.9,"over_n_frames":300}
```

`draw_us` (interpreter producing the frame) and `render_us` (GL submission) are now distinct — exactly the split the audit needed.

## Verification

- `npm run build:cli` succeeds.
- `cargo test -p functor_runtime_common` passes (3 passed, 0 failed).
- Ran the synthwave capture above; ndjson now carries plausible `render_us`/`swap_us`.
- Cross-engine review (Claude + Codex): both confirmed the averaging is consistent with the existing `draw_us` (same divisor, reset, one-frame lag) and the render-region/swap placement is correct. The one agreed finding — a doc claiming these were "omitted under --headless" when the code reports `0.0` — is fixed in the doc and the trait comment. (Both engines noted the per-tick-vs-per-presentation divisor caveat is inherited *identically* from the pre-existing `draw_us`; kept consistent by design rather than diverging.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)