### PR TITLE
feat(lsp): textDocument/completion — dot-completion off the last-good parse

### DIFF
--- a/functor-lang/src/complete.rs
+++ b/functor-lang/src/complete.rs
@@ -1,0 +1,866 @@
+//! Code completion: what to offer at a byte offset in a (possibly broken)
+//! live buffer — the language-aware half of the LSP's
+//! `textDocument/completion`. Like [`crate::hover`] and [`crate::goto`], the
+//! editor server converts positions and speaks the protocol; this module
+//! decides the candidates, so it is unit-testable without an editor.
+//!
+//! Completion fires on code that does not parse (`let s = Scene.`), so the
+//! two halves of the answer come from different places:
+//!
+//! - **Context** — am I after `Ident.` (a member access) or typing a bare
+//!   word (a top-level position)? — is derived **textually** from the live
+//!   buffer by lexing the prefix up to the cursor.
+//! - **Candidates** come from a **loaded [`Project`]** (the LSP's last-good
+//!   parse): its `.funi` prelude signatures, sibling defs, ADT constructors,
+//!   the builtin registry, keywords, and module names.
+//!
+//! v1 non-goals (PR 2): locals/parameters, typed record fields (`pos.`),
+//! chained members (`a.b.`), type-position members (`Scene.t` /
+//! `Pieces.Shape` in annotations), and `open`ed modules' exports offered
+//! bare (the merged module does not retain `open` metadata). Each of the
+//! testable ones is pinned as an empty result by a boundary test below so
+//! PR 2 flips assertions rather than discovering surprises.
+
+use std::collections::BTreeSet;
+
+use crate::ast::{TypeBody, VariantDecl};
+use crate::eval::{builtin_name, Builtin};
+use crate::hover::type_name_text;
+use crate::lexer::{Token, TokenKind};
+use crate::project::Project;
+use crate::types::{builtin_signature, Type};
+
+/// One completion candidate: the inserted `label`, an optional hover-style
+/// `detail` (`name : Type`), and its editor `kind`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompletionItem {
+    pub label: String,
+    pub detail: Option<String>,
+    pub kind: CompletionKind,
+}
+
+/// What a candidate is — the editor renders each with its own icon.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompletionKind {
+    Function,
+    Value,
+    Module,
+    Keyword,
+    Constructor,
+}
+
+/// The complete builtin registry. Hand-listed because [`Builtin`] is not
+/// iterable — keep in sync with `eval::Builtin` (17 variants).
+const BUILTINS: [Builtin; 17] = [
+    Builtin::ListMap,
+    Builtin::ListFilter,
+    Builtin::ListFold,
+    Builtin::ListRange,
+    Builtin::ListGrid,
+    Builtin::ListMaximum,
+    Builtin::MathSin,
+    Builtin::MathCos,
+    Builtin::TextConcat,
+    Builtin::TextFromFloat,
+    Builtin::TextFixed,
+    Builtin::TextToBullets,
+    Builtin::TextSplit,
+    Builtin::TextJoin,
+    Builtin::TextParseFloat,
+    Builtin::MathClamp01,
+    Builtin::DebugLog,
+];
+
+/// The keywords offered at a top-level position: the 8 lexer keywords plus
+/// the contextual `open` (`lexer.rs`).
+const KEYWORDS: [&str; 9] = [
+    "let", "type", "open", "mut", "with", "in", "match", "true", "false",
+];
+
+/// OFFSET CONTRACT: `offset` is LOCAL to `live_text` (the live buffer), NOT
+/// project-wide. Context comes purely from `live_text`; candidates purely from
+/// `project` (possibly a stale last-good load). The two span spaces never mix.
+pub fn complete(
+    project: &Project,
+    current_module: &str,
+    live_text: &str,
+    offset: usize,
+) -> Vec<CompletionItem> {
+    match context_at(live_text, offset) {
+        Context::None => Vec::new(),
+        Context::Member { qualifier, partial } => member_candidates(project, &qualifier, &partial),
+        Context::TopLevel { partial } => top_level_candidates(project, current_module, &partial),
+    }
+}
+
+/// The cursor's completion context, derived textually from the prefix.
+enum Context {
+    /// After `Qualifier.` — offer that module's members filtered by `partial`.
+    Member { qualifier: String, partial: String },
+    /// A bare word (or fresh position) — offer keywords, globals, modules.
+    TopLevel { partial: String },
+    /// No completion here (inside a string/comment, after a literal, …).
+    None,
+}
+
+/// Classify the cursor by lexing the prefix `live_text[..offset]`. Lexing is
+/// not parsing: a buffer broken only at the parse level (`let s = Scene.`)
+/// still lexes cleanly. A genuine lex error (an unterminated string, a bare
+/// `'`) honestly means "no completions".
+fn context_at(live_text: &str, offset: usize) -> Context {
+    if offset > live_text.len() || !live_text.is_char_boundary(offset) {
+        return Context::None;
+    }
+    let prefix = &live_text[..offset];
+    let Ok(mut tokens) = crate::lexer::lex(prefix, 0) else {
+        return Context::None;
+    };
+    tokens.pop(); // drop the Eof sentinel the lexer always appends
+
+    // The cursor sits in a line comment when a `//` lies between the last
+    // token and the cursor on the CURSOR'S line: the lexer skips comments, so
+    // it emits no token for the tail the cursor is inside. A comment on an
+    // earlier line (a newline follows it) leaves a fresh top-level position.
+    let last_end = tokens.last().map_or(0, |t| t.span.end);
+    let gap = &prefix[last_end..];
+    if gap[gap.rfind('\n').map_or(0, |i| i + 1)..].contains("//") {
+        return Context::None;
+    }
+
+    let n = tokens.len();
+    if n == 0 {
+        return Context::TopLevel {
+            partial: String::new(),
+        };
+    }
+    let last = &tokens[n - 1];
+    let touches = last.span.end == offset;
+
+    match &last.kind {
+        // `Qualifier.` — a member access with no partial yet. Same-line
+        // whitespace before the cursor keeps the member context; a line break
+        // ends it (the cursor is on a fresh line, not finishing the access).
+        TokenKind::Dot if !prefix[last.span.end..].contains('\n') => {
+            if n >= 2 {
+                if let TokenKind::Ident(_) = tokens[n - 2].kind {
+                    return Context::Member {
+                        qualifier: qualifier_chain(&tokens, n - 2),
+                        partial: String::new(),
+                    };
+                }
+            }
+            // `1.`, `).`, a bare `.` — not a module member (expression-member
+            // completion is PR 2).
+            Context::None
+        }
+        // A word touching the cursor: `Qualifier.partial` or a top-level
+        // partial. (A word NOT touching the cursor has whitespace after it —
+        // it falls through to a fresh top-level position.)
+        TokenKind::Ident(partial) if touches => {
+            if n >= 2 && tokens[n - 2].kind == TokenKind::Dot {
+                if n >= 3 {
+                    if let TokenKind::Ident(_) = tokens[n - 3].kind {
+                        return Context::Member {
+                            qualifier: qualifier_chain(&tokens, n - 3),
+                            partial: partial.clone(),
+                        };
+                    }
+                }
+                // `1.cu` — the qualifier head is not an identifier.
+                return Context::None;
+            }
+            Context::TopLevel {
+                partial: partial.clone(),
+            }
+        }
+        // A full keyword touching the cursor still wants the popup (the user
+        // is mid-typing `let`): treat it as a top-level partial of its own
+        // text.
+        kind if touches && is_keyword(kind) => Context::TopLevel {
+            partial: prefix[last.span.start..last.span.end].to_string(),
+        },
+        // A literal / range touching the cursor offers nothing — there is no
+        // member completion off a number or string in v1.
+        TokenKind::Number(_) | TokenKind::Str(_) | TokenKind::DotDot | TokenKind::TypeVar(_)
+            if touches =>
+        {
+            Context::None
+        }
+        // Anywhere else — after an operator, a delimiter, or whitespace — is a
+        // fresh top-level position.
+        _ => Context::TopLevel {
+            partial: String::new(),
+        },
+    }
+}
+
+/// The dotted qualifier ending at `tokens[end]` (an `Ident`): walk back over an
+/// `Ident (Dot Ident)*` chain so `a.b.` yields `"a.b"`. A multi-segment
+/// qualifier matches no module in v1 (its candidates come back empty — the
+/// chained-member boundary).
+fn qualifier_chain(tokens: &[Token], end: usize) -> String {
+    let mut names = Vec::new();
+    let mut i = end;
+    while let TokenKind::Ident(name) = &tokens[i].kind {
+        names.push(name.clone());
+        if i >= 2 && tokens[i - 1].kind == TokenKind::Dot {
+            if let TokenKind::Ident(_) = tokens[i - 2].kind {
+                i -= 2;
+                continue;
+            }
+        }
+        break;
+    }
+    names.reverse();
+    names.join(".")
+}
+
+fn is_keyword(kind: &TokenKind) -> bool {
+    matches!(
+        kind,
+        TokenKind::Let
+            | TokenKind::Type
+            | TokenKind::True
+            | TokenKind::False
+            | TokenKind::Mut
+            | TokenKind::With
+            | TokenKind::In
+            | TokenKind::Match
+    )
+}
+
+/// Candidates for `Qualifier.partial`: the module's `.funi` signatures, its
+/// sibling defs, its ADT constructors, and the builtins in its namespace.
+fn member_candidates(project: &Project, qualifier: &str, partial: &str) -> Vec<CompletionItem> {
+    let module = &project.module;
+    let prefix = format!("{qualifier}.");
+    // Lazy: only checked now that a context matched (defs need the checker's
+    // types for their details). The check is on `project` (last-good), never
+    // on the live buffer.
+    let (_, types) = project.check_with_types();
+    let mut items = Vec::new();
+
+    // Host-provided values (`Scene.cube : () => Scene.t`).
+    for sig in &module.signatures {
+        if let Some(label) = sig.name.strip_prefix(&prefix) {
+            let kind = if sig.ty.name == "=>" {
+                CompletionKind::Function
+            } else {
+                CompletionKind::Value
+            };
+            items.push(CompletionItem {
+                label: label.to_string(),
+                detail: Some(format!("{} : {}", sig.name, type_name_text(&sig.ty))),
+                kind,
+            });
+        }
+    }
+
+    // Sibling/user-module defs (detail from the checker, hover-identical).
+    for def in &module.defs {
+        if let Some(label) = def.name.strip_prefix(&prefix) {
+            let ty = types.expr(def.value.id).cloned().unwrap_or(Type::Unknown);
+            items.push(CompletionItem {
+                label: label.to_string(),
+                detail: Some(format!("{} : {ty}", def.name)),
+                kind: value_kind(&ty),
+            });
+        }
+    }
+
+    // ADT constructors (value namespace; symbolic detail from the decl).
+    for ty in &module.types {
+        if let TypeBody::Variants(decls) = &ty.body {
+            let ret = ctor_return(ty);
+            for variant in decls {
+                if let Some(label) = variant.name.strip_prefix(&prefix) {
+                    items.push(CompletionItem {
+                        label: label.to_string(),
+                        detail: Some(ctor_detail(variant, &ret)),
+                        kind: CompletionKind::Constructor,
+                    });
+                }
+            }
+        }
+    }
+
+    // Builtins whose namespace is the qualifier (`List.map`, …).
+    for &b in &BUILTINS {
+        let name = builtin_name(b);
+        if let Some(label) = name.strip_prefix(&prefix) {
+            items.push(CompletionItem {
+                label: label.to_string(),
+                detail: Some(format!("{name} : {}", builtin_signature(b))),
+                kind: CompletionKind::Function,
+            });
+        }
+    }
+
+    finish(items, partial)
+}
+
+/// Candidates at a top-level position: keywords, the current module's own
+/// defs and constructors (bare), and the visible module names.
+fn top_level_candidates(
+    project: &Project,
+    current_module: &str,
+    partial: &str,
+) -> Vec<CompletionItem> {
+    let module = &project.module;
+    let entry = &project.entry;
+    let (_, types) = project.check_with_types();
+    let mut items = Vec::new();
+
+    for kw in KEYWORDS {
+        items.push(CompletionItem {
+            label: kw.to_string(),
+            detail: None,
+            kind: CompletionKind::Keyword,
+        });
+    }
+
+    // This module's own defs, referenced bare in source. (Entry defs are
+    // already bare; a sibling's are `Module.name` — the same strip either way.)
+    for def in &module.defs {
+        if owning_module(&def.name, entry) == current_module {
+            let ty = types.expr(def.value.id).cloned().unwrap_or(Type::Unknown);
+            items.push(CompletionItem {
+                label: bare_name(&def.name).to_string(),
+                detail: Some(format!("{} : {ty}", def.name)),
+                kind: value_kind(&ty),
+            });
+        }
+    }
+
+    // This module's own constructors, also bare.
+    for ty in &module.types {
+        if let TypeBody::Variants(decls) = &ty.body {
+            let ret = ctor_return(ty);
+            for variant in decls {
+                if owning_module(&variant.name, entry) == current_module {
+                    items.push(CompletionItem {
+                        label: bare_name(&variant.name).to_string(),
+                        detail: Some(ctor_detail(variant, &ret)),
+                        kind: CompletionKind::Constructor,
+                    });
+                }
+            }
+        }
+    }
+
+    // Module names: the first segment of every dotted signature/def/ctor name,
+    // plus the builtin namespaces, minus the current module (you don't qualify
+    // your own defs).
+    let mut modules: BTreeSet<String> = BTreeSet::new();
+    for sig in &module.signatures {
+        module_segment(&sig.name, &mut modules);
+    }
+    for def in &module.defs {
+        module_segment(&def.name, &mut modules);
+    }
+    for ty in &module.types {
+        if let TypeBody::Variants(decls) = &ty.body {
+            for variant in decls {
+                module_segment(&variant.name, &mut modules);
+            }
+        }
+    }
+    for &b in &BUILTINS {
+        module_segment(builtin_name(b), &mut modules);
+    }
+    modules.remove(current_module);
+    for name in modules {
+        items.push(CompletionItem {
+            label: name,
+            detail: None,
+            kind: CompletionKind::Module,
+        });
+    }
+
+    finish(items, partial)
+}
+
+/// A constructor's return type as declared: the owning type's bare name with
+/// its type parameters (`Shape`, `Option<'a>`).
+fn ctor_return(ty: &crate::ir::TypeDef) -> String {
+    let name = bare_name(&ty.name);
+    if ty.params.is_empty() {
+        name.to_string()
+    } else {
+        format!("{name}<{}>", ty.params.join(", "))
+    }
+}
+
+/// Symbolic constructor detail from its declaration: nullary `Point : Shape`,
+/// fielded `Circle : (float) => Shape` (field types via [`type_name_text`],
+/// `ret` = the owning type's declared return, see [`ctor_return`]).
+fn ctor_detail(variant: &VariantDecl, ret: &str) -> String {
+    if variant.fields.is_empty() {
+        format!("{} : {ret}", variant.name)
+    } else {
+        let params: Vec<String> = variant
+            .fields
+            .iter()
+            .map(|f| type_name_text(&f.ty))
+            .collect();
+        format!("{} : ({}) => {ret}", variant.name, params.join(", "))
+    }
+}
+
+/// A value's kind: [`CompletionKind::Function`] when its type is a function,
+/// else [`CompletionKind::Value`].
+fn value_kind(ty: &Type) -> CompletionKind {
+    if matches!(ty, Type::Fn(..)) {
+        CompletionKind::Function
+    } else {
+        CompletionKind::Value
+    }
+}
+
+/// The module a canonical name belongs to: the segment before its first `.`,
+/// or the entry (whose members are bare).
+fn owning_module<'a>(name: &'a str, entry: &'a str) -> &'a str {
+    name.split_once('.').map_or(entry, |(module, _)| module)
+}
+
+/// A canonical name stripped of its module qualifier (`Utils.clamp` →
+/// `clamp`; a bare name is unchanged).
+fn bare_name(name: &str) -> &str {
+    name.split_once('.').map_or(name, |(_, member)| member)
+}
+
+/// Record `name`'s module qualifier (its first dotted segment), if any.
+fn module_segment(name: &str, out: &mut BTreeSet<String>) {
+    if let Some((module, _)) = name.split_once('.') {
+        out.insert(module.to_string());
+    }
+}
+
+/// Keep only candidates matching `partial`, then sort and dedup by label for a
+/// deterministic, popup-ready list.
+fn finish(mut items: Vec<CompletionItem>, partial: &str) -> Vec<CompletionItem> {
+    items.retain(|item| item.label.starts_with(partial));
+    items.sort_by(|a, b| a.label.cmp(&b.label));
+    items.dedup_by(|a, b| a.label == b.label);
+    items
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::project::load_sources_with_prelude;
+    use std::path::PathBuf;
+
+    /// A minimal, valid single-file project — the last-good parse the broken
+    /// live buffers complete against.
+    const STUB: &str = "let main = () => 1.0";
+
+    /// The inline `Scene` prelude used by the A-layer tests: only `cube` and
+    /// `sphere`, so exact-label assertions stay small. (`type t` canonicalizes
+    /// to `Scene.t`, matching how the real `scene.funi` renders.)
+    const SCENE: &str = "type t\nlet cube : () => t\nlet sphere : () => t";
+
+    fn project_of(sources: &[(&str, &str)], prelude: &[(&str, &str)]) -> Project {
+        let sources = sources
+            .iter()
+            .map(|(name, src)| (PathBuf::from(name), src.to_string()))
+            .collect();
+        let prelude: Vec<(String, String)> = prelude
+            .iter()
+            .map(|(module, src)| (module.to_string(), src.to_string()))
+            .collect();
+        load_sources_with_prelude(sources, &prelude)
+            .unwrap_or_else(|e| panic!("project loads: {}", e.render()))
+    }
+
+    /// Complete in module `Game`, cursor at the END of `live`, with candidates
+    /// from a valid single-file project (`project_src`) plus `prelude`. `live`
+    /// deliberately differs from `project_src` — that IS the live-vs-last-good
+    /// seam.
+    fn game(project_src: &str, prelude: &[(&str, &str)], live: &str) -> Vec<CompletionItem> {
+        let project = project_of(&[("game.fun", project_src)], prelude);
+        complete(&project, "Game", live, live.len())
+    }
+
+    fn labels(items: &[CompletionItem]) -> Vec<String> {
+        items.iter().map(|i| i.label.clone()).collect()
+    }
+
+    fn find<'a>(items: &'a [CompletionItem], label: &str) -> &'a CompletionItem {
+        items
+            .iter()
+            .find(|i| i.label == label)
+            .unwrap_or_else(|| panic!("no `{label}` in {:?}", labels(items)))
+    }
+
+    fn has(items: &[CompletionItem], label: &str) -> bool {
+        items.iter().any(|i| i.label == label)
+    }
+
+    // 1 (+20). Prelude dot-completion — exact sorted Vec, kinds, details.
+    #[test]
+    fn prelude_member_completion() {
+        let items = game(STUB, &[("Scene", SCENE)], "let s = Scene.");
+        assert_eq!(
+            items,
+            vec![
+                CompletionItem {
+                    label: "cube".to_string(),
+                    detail: Some("Scene.cube : () => Scene.t".to_string()),
+                    kind: CompletionKind::Function,
+                },
+                CompletionItem {
+                    label: "sphere".to_string(),
+                    detail: Some("Scene.sphere : () => Scene.t".to_string()),
+                    kind: CompletionKind::Function,
+                },
+            ]
+        );
+    }
+
+    // 2. Builtin module `List.` — members present, nothing from `Text.`; pins
+    // the `List.range` detail and the `'a`/`'b` Var rendering via `List.map`.
+    #[test]
+    fn builtin_member_completion() {
+        let items = game(STUB, &[], "let s = List.");
+        for member in ["map", "filter", "fold", "range", "grid", "maximum"] {
+            assert!(
+                has(&items, member),
+                "missing {member} in {:?}",
+                labels(&items)
+            );
+        }
+        assert!(!has(&items, "concat"), "Text builtin leaked into List.");
+        assert_eq!(
+            find(&items, "range").detail.as_deref(),
+            Some("List.range : (float) => List<float>")
+        );
+        assert_eq!(
+            find(&items, "map").detail.as_deref(),
+            Some("List.map : (('a) => 'b, List<'a>) => List<'b>")
+        );
+        assert_eq!(find(&items, "map").kind, CompletionKind::Function);
+    }
+
+    // 3 (+20). Sibling module `Utils.` from `game.fun` — exact Vec, kinds.
+    #[test]
+    fn sibling_member_completion() {
+        let project = project_of(
+            &[
+                ("game.fun", STUB),
+                (
+                    "utils.fun",
+                    "let clamp = (lo: float, hi: float, x: float): float => x\n\
+                     let version = 3.0",
+                ),
+            ],
+            &[],
+        );
+        let live = "let s = Utils.";
+        let items = complete(&project, "Game", live, live.len());
+        assert_eq!(
+            items,
+            vec![
+                CompletionItem {
+                    label: "clamp".to_string(),
+                    detail: Some("Utils.clamp : (float, float, float) => float".to_string()),
+                    kind: CompletionKind::Function,
+                },
+                CompletionItem {
+                    label: "version".to_string(),
+                    detail: Some("Utils.version : float".to_string()),
+                    kind: CompletionKind::Value,
+                },
+            ]
+        );
+    }
+
+    // 3b. Sibling ADT constructors `Pieces.` — ctors ∪ defs, sorted, kinds,
+    // symbolic details.
+    #[test]
+    fn sibling_constructor_completion() {
+        let project = project_of(
+            &[
+                ("game.fun", STUB),
+                (
+                    "pieces.fun",
+                    "type Shape = | Circle(r: float) | Point\nlet count = 12.0",
+                ),
+            ],
+            &[],
+        );
+        let live = "let s = Pieces.";
+        let items = complete(&project, "Game", live, live.len());
+        assert_eq!(labels(&items), ["Circle", "Point", "count"]);
+        assert_eq!(find(&items, "Circle").kind, CompletionKind::Constructor);
+        assert_eq!(
+            find(&items, "Circle").detail.as_deref(),
+            Some("Pieces.Circle : (float) => Shape")
+        );
+        assert_eq!(find(&items, "Point").kind, CompletionKind::Constructor);
+        assert_eq!(
+            find(&items, "Point").detail.as_deref(),
+            Some("Pieces.Point : Shape")
+        );
+        assert_eq!(find(&items, "count").kind, CompletionKind::Value);
+    }
+
+    // 3c. Own-module bare constructors at the top level — for the entry, and
+    // for the sibling that owns the ADT (via `current_module`).
+    #[test]
+    fn own_module_bare_constructors() {
+        let entry = project_of(
+            &[(
+                "game.fun",
+                "type Dir = | Left | Right\nlet main = () => 1.0",
+            )],
+            &[],
+        );
+        let items = complete(&entry, "Game", "let x = ", "let x = ".len());
+        assert!(has(&items, "Left"));
+        assert!(has(&items, "Right"));
+        assert_eq!(find(&items, "Left").kind, CompletionKind::Constructor);
+
+        let sibling = project_of(
+            &[
+                ("game.fun", STUB),
+                ("pieces.fun", "type Shape = | Circle(r: float) | Point"),
+            ],
+            &[],
+        );
+        let items = complete(&sibling, "Pieces", "let x = ", "let x = ".len());
+        assert!(
+            has(&items, "Circle"),
+            "own ctor bare in {:?}",
+            labels(&items)
+        );
+        assert!(has(&items, "Point"));
+        assert_eq!(find(&items, "Circle").kind, CompletionKind::Constructor);
+    }
+
+    // 4. Top-level: keywords + own globals + modules; NOT qualified labels, NOT
+    // the entry name.
+    #[test]
+    fn top_level_completion() {
+        let project = project_of(
+            &[
+                ("game.fun", STUB),
+                (
+                    "utils.fun",
+                    "let clamp = (lo: float, hi: float, x: float): float => x",
+                ),
+            ],
+            &[("Scene", SCENE)],
+        );
+        let live = "let x = ";
+        let items = complete(&project, "Game", live, live.len());
+        assert_eq!(find(&items, "let").kind, CompletionKind::Keyword);
+        assert!(has(&items, "main"), "own def bare in {:?}", labels(&items));
+        assert_eq!(find(&items, "Utils").kind, CompletionKind::Module);
+        assert_eq!(find(&items, "Scene").kind, CompletionKind::Module);
+        assert_eq!(find(&items, "List").kind, CompletionKind::Module);
+        assert!(!has(&items, "Utils.clamp"), "qualified label leaked");
+        assert!(!has(&items, "Game"), "entry name offered as a module");
+    }
+
+    // 5. Editing a sibling: its own defs are bare; its own name is not in the
+    // module list.
+    #[test]
+    fn editing_a_sibling_offers_own_defs_bare() {
+        let project = project_of(
+            &[
+                ("game.fun", STUB),
+                (
+                    "utils.fun",
+                    "let clamp = (lo: float, hi: float, x: float): float => x\n\
+                     let version = 3.0",
+                ),
+            ],
+            &[("Scene", SCENE)],
+        );
+        let live = "let y = ";
+        let items = complete(&project, "Utils", live, live.len());
+        assert!(has(&items, "clamp"), "own def bare in {:?}", labels(&items));
+        assert!(has(&items, "Scene"));
+        assert!(!has(&items, "Utils"), "own module offered to itself");
+    }
+
+    // 6. Partial member `Scene.cu` → `cube` only.
+    #[test]
+    fn partial_member_filters() {
+        let items = game(STUB, &[("Scene", SCENE)], "let s = Scene.cu");
+        assert_eq!(labels(&items), ["cube"]);
+    }
+
+    // 7. Broken/last-good: candidates come from the loaded project even though
+    // the live buffer does not parse.
+    #[test]
+    fn broken_buffer_uses_last_good_project() {
+        // Project loaded from a good buffer that never mentions Scene; the
+        // prelude gives it the signatures.
+        let items = game(
+            "let x = 1.0",
+            &[("Scene", SCENE)],
+            "let x = 1.0\nlet s = Scene.",
+        );
+        assert!(has(&items, "cube"));
+        assert!(has(&items, "sphere"));
+    }
+
+    // 8. Broken elsewhere than the cursor line — the whole buffer lexes but
+    // does not parse; members are still offered.
+    #[test]
+    fn broken_earlier_line_still_completes() {
+        let items = game(
+            "let x = 1.0",
+            &[("Scene", SCENE)],
+            "let broken =\nlet s = Scene.",
+        );
+        assert!(has(&items, "cube"));
+    }
+
+    // 9. Unknown module → empty.
+    #[test]
+    fn unknown_module_is_empty() {
+        let items = game(STUB, &[("Scene", SCENE)], "let s = Nope.");
+        assert!(items.is_empty(), "{:?}", labels(&items));
+    }
+
+    // 10. Lowercase qualifier `pos.` (a record field) — empty today. PR 2:
+    // typed record-field completion flips this.
+    #[test]
+    fn record_field_qualifier_is_empty_pr2_boundary() {
+        let items = game(STUB, &[("Scene", SCENE)], "let x = pos.");
+        assert!(items.is_empty(), "{:?}", labels(&items));
+    }
+
+    // 11. Locals are not offered at the top level. PR 2: locals/params flip
+    // this.
+    #[test]
+    fn locals_not_offered_pr2_boundary() {
+        let items = game("let f = (score) => score", &[], "let f = (score) => sc");
+        assert!(!has(&items, "score"), "local leaked into completion");
+    }
+
+    // 12. Partial top-level `Sc` → `Scene`, not `let`, not `List`.
+    #[test]
+    fn partial_top_level_filters() {
+        let items = game(STUB, &[("Scene", SCENE)], "let x = Sc");
+        assert!(has(&items, "Scene"));
+        assert!(!has(&items, "let"));
+        assert!(!has(&items, "List"));
+    }
+
+    // 14. Offset 0 / empty buffer — top-level set, no panic.
+    #[test]
+    fn empty_buffer_offers_top_level() {
+        let project = project_of(&[("game.fun", STUB)], &[]);
+        let items = complete(&project, "Game", "", 0);
+        assert!(has(&items, "let"));
+    }
+
+    // 15. `.` after a number → empty (the token before `Dot` is a Number).
+    #[test]
+    fn dot_after_number_is_empty() {
+        assert!(game(STUB, &[], "let x = 1.").is_empty());
+        assert!(game(STUB, &[], "let x = 1.5.").is_empty());
+    }
+
+    // 16. Chained `a.b.` → empty (a multi-segment qualifier matches no
+    // module). PR 2: chained members flip this.
+    #[test]
+    fn chained_member_is_empty_pr2_boundary() {
+        let items = game(STUB, &[("Scene", SCENE)], "let x = a.b.");
+        assert!(items.is_empty(), "{:?}", labels(&items));
+    }
+
+    // 17. Cursor inside a string → empty (the prefix lexes as an unterminated
+    // string).
+    #[test]
+    fn cursor_in_string_is_empty() {
+        let live = "let s = \"Scene.";
+        let items = game(STUB, &[("Scene", SCENE)], live);
+        assert!(items.is_empty(), "{:?}", labels(&items));
+    }
+
+    // 18. Cursor in a line comment → empty (the gap contains `//`).
+    #[test]
+    fn cursor_in_comment_is_empty() {
+        let items = game(STUB, &[("Scene", SCENE)], "let x = 1.0 // Scene.");
+        assert!(items.is_empty(), "{:?}", labels(&items));
+    }
+
+    // 18b. A fresh line AFTER a trailing comment is a normal top-level
+    // position — only a comment on the cursor's own line swallows it.
+    #[test]
+    fn fresh_line_after_comment_offers_top_level() {
+        let items = game(STUB, &[], "let x = 1.0 // note\n");
+        assert!(has(&items, "let"), "{:?}", labels(&items));
+    }
+
+    // 18c. A line break after `Ident.` ends the member context — the cursor is
+    // on a fresh line, not finishing the access.
+    #[test]
+    fn newline_after_dot_is_top_level() {
+        let items = game(STUB, &[("Scene", SCENE)], "let x = Scene.\n");
+        assert!(!has(&items, "cube"), "{:?}", labels(&items));
+        assert!(has(&items, "let"));
+    }
+
+    // A generic type's constructors carry its parameters in the detail.
+    #[test]
+    fn generic_constructor_detail_keeps_type_params() {
+        let project = project_of(
+            &[
+                ("game.fun", STUB),
+                ("pieces.fun", "type Box<'a> = | Full(value: 'a) | Empty"),
+            ],
+            &[],
+        );
+        let live = "let s = Pieces.";
+        let items = complete(&project, "Game", live, live.len());
+        assert_eq!(
+            find(&items, "Full").detail.as_deref(),
+            Some("Pieces.Full : ('a) => Box<'a>")
+        );
+        assert_eq!(
+            find(&items, "Empty").detail.as_deref(),
+            Some("Pieces.Empty : Box<'a>")
+        );
+    }
+
+    // Drift guard: this match is exhaustive over `Builtin`, so adding a
+    // variant fails to compile here until BUILTINS (above) offers it too.
+    #[test]
+    fn builtins_list_is_exhaustive() {
+        for &b in &BUILTINS {
+            match b {
+                Builtin::ListMap
+                | Builtin::ListFilter
+                | Builtin::ListFold
+                | Builtin::ListRange
+                | Builtin::ListGrid
+                | Builtin::ListMaximum
+                | Builtin::MathSin
+                | Builtin::MathCos
+                | Builtin::MathClamp01
+                | Builtin::TextConcat
+                | Builtin::TextFromFloat
+                | Builtin::TextFixed
+                | Builtin::TextToBullets
+                | Builtin::TextSplit
+                | Builtin::TextJoin
+                | Builtin::TextParseFloat
+                | Builtin::DebugLog => {}
+            }
+        }
+        assert_eq!(BUILTINS.len(), 17, "BUILTINS must list every Builtin");
+    }
+
+    // 19. A full keyword typed (`let`, cursor at end) still offers `let`.
+    #[test]
+    fn full_keyword_still_offered() {
+        let items = game(STUB, &[], "let");
+        assert!(has(&items, "let"));
+    }
+}

--- a/functor-lang/src/hover.rs
+++ b/functor-lang/src/hover.rs
@@ -179,7 +179,7 @@ pub(crate) fn children(expr: &Expr) -> Vec<&Expr> {
 
 /// Render a surface annotation (`List<Float>`) for param hovers, which have
 /// no expression node of their own.
-fn type_name_text(ty: &TypeName) -> String {
+pub(crate) fn type_name_text(ty: &TypeName) -> String {
     if ty.args.is_empty() {
         return ty.name.clone();
     }

--- a/functor-lang/src/lib.rs
+++ b/functor-lang/src/lib.rs
@@ -10,6 +10,7 @@
 
 pub mod ast;
 pub mod codelens;
+pub mod complete;
 pub mod eval;
 pub mod goto;
 pub mod hover;

--- a/tools/functor-lang-lsp/src/main.rs
+++ b/tools/functor-lang-lsp/src/main.rs
@@ -44,6 +44,11 @@ fn main() {
 fn serve(reader: &mut impl BufRead, writer: &mut impl Write) -> i32 {
     let mut shutdown_seen = false;
     let mut documents: HashMap<String, String> = HashMap::new();
+    // The last-good parsed project per URI, for completion. Completion fires on
+    // code that does not parse (`let s = Scene.`), where `load_project` returns
+    // `None`; keeping the previous good load lets us still answer. A failed
+    // refresh retains the previous entry — that IS "last good".
+    let mut projects: HashMap<String, functor_lang::project::Project> = HashMap::new();
     while let Some(message) = read_message(reader) {
         let method = message["method"].as_str().unwrap_or("").to_string();
         let id = message.get("id").cloned();
@@ -73,6 +78,7 @@ fn serve(reader: &mut impl BufRead, writer: &mut impl Write) -> i32 {
                         "definitionProvider": true,
                         "inlayHintProvider": true,
                         "codeLensProvider": { "resolveProvider": false },
+                        "completionProvider": { "triggerCharacters": ["."] },
                     },
                     "serverInfo": { "name": "functor-lang-lsp" },
                 });
@@ -136,6 +142,22 @@ fn serve(reader: &mut impl BufRead, writer: &mut impl Write) -> i32 {
                     &json!({ "jsonrpc": "2.0", "id": id, "result": result }),
                 );
             }
+            ("textDocument/completion", Some(id)) => {
+                let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
+                // No reload here: didOpen/didChange already refreshed the cache
+                // from this same `documents` state, so it is as fresh as the
+                // live buffer allows — a parseable buffer refreshed it, a
+                // broken one kept the last good load. Completion is the hot
+                // keystroke path; don't reparse the project a second time.
+                let result = projects
+                    .get(uri)
+                    .and_then(|project| completion(project, uri, &documents, &params["position"]))
+                    .unwrap_or_else(|| json!([]));
+                write_message(
+                    writer,
+                    &json!({ "jsonrpc": "2.0", "id": id, "result": result }),
+                );
+            }
             (_, Some(id)) => {
                 let error = json!({
                     "code": METHOD_NOT_FOUND,
@@ -153,6 +175,9 @@ fn serve(reader: &mut impl BufRead, writer: &mut impl Write) -> i32 {
                 let text = params["textDocument"]["text"].as_str().unwrap_or("");
                 publish_diagnostics(writer, uri, text);
                 documents.insert(uri.to_string(), text.to_string());
+                if let Some(project) = load_project(uri, &documents) {
+                    projects.insert(uri.to_string(), project);
+                }
             }
             ("textDocument/didChange", None) => {
                 let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
@@ -164,11 +189,15 @@ fn serve(reader: &mut impl BufRead, writer: &mut impl Write) -> i32 {
                 {
                     publish_diagnostics(writer, uri, text);
                     documents.insert(uri.to_string(), text.to_string());
+                    if let Some(project) = load_project(uri, &documents) {
+                        projects.insert(uri.to_string(), project);
+                    }
                 }
             }
             ("textDocument/didClose", None) => {
                 let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
                 documents.remove(uri);
+                projects.remove(uri);
                 // Clear stale squiggles for the closed file.
                 write_diagnostics(writer, uri, vec![]);
             }
@@ -328,6 +357,57 @@ fn inlay_hints(uri: &str, documents: &HashMap<String, String>, range: &Value) ->
         })
         .collect();
     Some(Value::Array(hints))
+}
+
+/// Answer a completion request. Unlike hover/definition, the offset stays
+/// **local** to the live buffer (no `file.base +`): `functor_lang::complete`
+/// derives context textually from that buffer, while candidates come from the
+/// (possibly stale) last-good `project`. `current_module` is the open file's
+/// module (a sibling's own defs are referenced bare), falling back to the
+/// project entry.
+fn completion(
+    project: &functor_lang::project::Project,
+    uri: &str,
+    documents: &HashMap<String, String>,
+    position: &Value,
+) -> Option<Value> {
+    let text = documents.get(uri)?;
+    let offset = position_to_offset(text, position)?;
+    let current_module = uri_to_path(uri)
+        .and_then(|path| {
+            project
+                .sources
+                .file_by_path(&path)
+                .map(|file| file.module.clone())
+        })
+        .unwrap_or_else(|| project.entry.clone());
+    let items = functor_lang::complete::complete(project, &current_module, text, offset);
+    if items.is_empty() {
+        return None;
+    }
+    let items: Vec<Value> = items
+        .into_iter()
+        .map(|item| {
+            json!({
+                "label": item.label,
+                "kind": kind_code(item.kind),
+                "detail": item.detail,
+            })
+        })
+        .collect();
+    Some(Value::Array(items))
+}
+
+/// The LSP `CompletionItemKind` code for a completion kind.
+fn kind_code(kind: functor_lang::complete::CompletionKind) -> i64 {
+    use functor_lang::complete::CompletionKind;
+    match kind {
+        CompletionKind::Function => 3,
+        CompletionKind::Constructor => 4,
+        CompletionKind::Module => 9,
+        CompletionKind::Value => 12,
+        CompletionKind::Keyword => 14,
+    }
 }
 
 /// Whether project-wide `offset` falls in `file` (its half-open base range).

--- a/tools/functor-lang-lsp/tests/completion.rs
+++ b/tools/functor-lang-lsp/tests/completion.rs
@@ -1,0 +1,63 @@
+//! B-layer completion tests: drive `functor_lang::complete::complete` directly
+//! against the **real** engine prelude (`functor_prelude::modules()`) — no
+//! server spawn, no framed stdio. The A-layer unit tests in `complete.rs` use
+//! inline throwaway preludes for exact-label assertions; here we pin the real
+//! `scene.funi` surface so drift in the shipped prelude is caught.
+
+use std::path::PathBuf;
+
+use functor_lang::complete::{complete, CompletionKind};
+use functor_lang::project::{load_sources_with_prelude, Project};
+
+/// A minimal, valid single-file project — the last-good parse the broken live
+/// buffers complete against. The real prelude gives it `Scene.*`.
+const STUB: &str = "let main = () => 1.0";
+
+fn project() -> Project {
+    let sources = vec![(PathBuf::from("game.fun"), STUB.to_string())];
+    let prelude = functor_prelude::modules();
+    load_sources_with_prelude(sources, &prelude)
+        .unwrap_or_else(|e| panic!("project loads: {}", e.render()))
+}
+
+fn labels(items: &[functor_lang::complete::CompletionItem]) -> Vec<String> {
+    items.iter().map(|i| i.label.clone()).collect()
+}
+
+fn find<'a>(
+    items: &'a [functor_lang::complete::CompletionItem],
+    label: &str,
+) -> &'a functor_lang::complete::CompletionItem {
+    items
+        .iter()
+        .find(|i| i.label == label)
+        .unwrap_or_else(|| panic!("no `{label}` in {:?}", labels(items)))
+}
+
+// Row 1. Real prelude dot-completion `Scene.` — cube/sphere/group present, and
+// the exact detail the real `scene.funi` renders for `cube`.
+#[test]
+fn real_prelude_scene_member_completion() {
+    let project = project();
+    let live = "let s = Scene.";
+    let items = complete(&project, "Game", live, live.len());
+    let names = labels(&items);
+    for member in ["cube", "sphere", "group"] {
+        assert!(
+            names.contains(&member.to_string()),
+            "missing {member} in {names:?}"
+        );
+    }
+    let cube = find(&items, "cube");
+    assert_eq!(cube.detail.as_deref(), Some("Scene.cube : () => Scene.t"));
+    assert_eq!(cube.kind, CompletionKind::Function);
+}
+
+// Row 6. Partial member `Scene.cu` → `cube` only, from the real prelude.
+#[test]
+fn real_prelude_partial_member_filters() {
+    let project = project();
+    let live = "let s = Scene.cu";
+    let items = complete(&project, "Game", live, live.len());
+    assert_eq!(labels(&items), ["cube"]);
+}

--- a/tools/functor-lang-lsp/tests/e2e.rs
+++ b/tools/functor-lang-lsp/tests/e2e.rs
@@ -82,6 +82,10 @@ fn diagnostics_over_real_stdio() {
         response["result"]["capabilities"]["codeLensProvider"]["resolveProvider"],
         false
     );
+    assert_eq!(
+        response["result"]["capabilities"]["completionProvider"]["triggerCharacters"],
+        json!(["."])
+    );
 
     server.send(json!({ "jsonrpc": "2.0", "method": "initialized", "params": {} }));
 
@@ -266,7 +270,10 @@ fn diagnostics_over_real_stdio() {
 #[test]
 fn project_aware_hover_and_cross_file_definition() {
     // A scratch project: game.fun (entry) calls Utils.double from utils.fun.
-    let dir = std::env::temp_dir().join(format!("functor-lang-lsp-e2e-project-{}", std::process::id()));
+    let dir = std::env::temp_dir().join(format!(
+        "functor-lang-lsp-e2e-project-{}",
+        std::process::id()
+    ));
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).expect("scratch dir");
     std::fs::write(
@@ -310,8 +317,7 @@ fn project_aware_hover_and_cross_file_definition() {
     }));
     let response = server.recv();
     assert_eq!(
-        response["result"]["contents"]["value"],
-        "```functor\nUtils.double : (float) => float\n```",
+        response["result"]["contents"]["value"], "```functor\nUtils.double : (float) => float\n```",
         "cross-file hover: {response}"
     );
 
@@ -325,17 +331,170 @@ fn project_aware_hover_and_cross_file_definition() {
         },
     }));
     let response = server.recv();
-    assert_eq!(response["result"]["uri"], utils_uri, "cross-file goto: {response}");
+    assert_eq!(
+        response["result"]["uri"], utils_uri,
+        "cross-file goto: {response}"
+    );
     assert_eq!(
         response["result"]["range"]["start"]["line"], 0,
         "double is on line 0 of utils.fun: {response}"
     );
+
+    // Row 23: cross-file completion. Edit game.fun to an (unparseable) buffer
+    // ending in `Utils.` — completion still answers from the last-good project,
+    // offering the sibling's `double` with its inferred signature.
+    let broken = "let apply = (n) => Utils.";
+    server.send(json!({
+        "jsonrpc": "2.0", "method": "textDocument/didChange",
+        "params": {
+            "textDocument": { "uri": game_uri, "version": 2 },
+            "contentChanges": [ { "text": broken } ],
+        },
+    }));
+    server.recv(); // publishDiagnostics (a parse error on the broken buffer)
+    server.send(json!({
+        "jsonrpc": "2.0", "id": 10, "method": "textDocument/completion",
+        "params": {
+            "textDocument": { "uri": game_uri },
+            "position": { "line": 0, "character": broken.encode_utf16().count() as i64 },
+        },
+    }));
+    let response = server.recv();
+    let items = response["result"].as_array().expect("completion array");
+    let double = items
+        .iter()
+        .find(|item| item["label"] == "double")
+        .unwrap_or_else(|| panic!("no `double` in completion: {response}"));
+    assert_eq!(double["detail"], "Utils.double : (float) => float");
 
     server.send(json!({ "jsonrpc": "2.0", "id": 4, "method": "shutdown" }));
     server.recv();
     server.send(json!({ "jsonrpc": "2.0", "method": "exit" }));
     server.child.wait().expect("wait for exit");
     let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Completion over the real binary (matrix rows 7, 8, 9, 13, 22): a broken
+/// live buffer still completes prelude members from the last-good project, with
+/// LSP kind codes over the wire and UTF-16 positions. Single-file (no
+/// functor.json) still gets the injected prelude.
+#[test]
+fn completion_over_real_stdio() {
+    let mut server = Server::spawn();
+    server.send(json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": { "capabilities": {} },
+    }));
+    server.recv();
+    server.send(json!({ "jsonrpc": "2.0", "method": "initialized", "params": {} }));
+
+    // A valid buffer opens first, seeding the last-good project cache.
+    server.send(json!({
+        "jsonrpc": "2.0", "method": "textDocument/didOpen",
+        "params": { "textDocument": {
+            "uri": URI, "languageId": "functor-lang", "version": 1, "text": "let s = () => 1.0\n",
+        } },
+    }));
+    server.recv(); // publishDiagnostics (clean)
+
+    // A helper: replace the whole buffer, drain its diagnostics, then ask for
+    // completion at (line, character) — character in UTF-16 code units.
+    let complete_at = |server: &mut Server, version: i64, text: &str, line: i64, character: i64| {
+        server.send(json!({
+            "jsonrpc": "2.0", "method": "textDocument/didChange",
+            "params": {
+                "textDocument": { "uri": URI, "version": version },
+                "contentChanges": [ { "text": text } ],
+            },
+        }));
+        server.recv(); // publishDiagnostics
+        server.send(json!({
+            "jsonrpc": "2.0", "id": 100 + version, "method": "textDocument/completion",
+            "params": {
+                "textDocument": { "uri": URI },
+                "position": { "line": line, "character": character },
+            },
+        }));
+        server.recv()["result"].clone()
+    };
+
+    // Row 7: didChange to a broken buffer ending `Scene.` → completion still
+    // answers `cube` with the real detail and kind 3 (Function), from cache.
+    let broken = "let s = Scene.";
+    let result = complete_at(
+        &mut server,
+        2,
+        broken,
+        0,
+        broken.encode_utf16().count() as i64,
+    );
+    let items = result.as_array().expect("completion array");
+    let cube = items
+        .iter()
+        .find(|item| item["label"] == "cube")
+        .unwrap_or_else(|| panic!("no `cube` in {result}"));
+    assert_eq!(cube["detail"], "Scene.cube : () => Scene.t");
+    assert_eq!(cube["kind"], 3);
+
+    // Row 8: broken ELSEWHERE than the cursor line (line 0 never parses) — the
+    // members are still offered on the completion line.
+    let elsewhere = "let broken =\nlet s = Scene.";
+    let line1 = "let s = Scene.";
+    let result = complete_at(
+        &mut server,
+        3,
+        elsewhere,
+        1,
+        line1.encode_utf16().count() as i64,
+    );
+    let items = result.as_array().expect("completion array");
+    assert!(
+        items.iter().any(|item| item["label"] == "cube"),
+        "row 8 expected cube: {result}"
+    );
+
+    // Row 9: an unknown module `Nope.` → an empty array (not null).
+    let nope = "let s = Nope.";
+    let result = complete_at(&mut server, 4, nope, 0, nope.encode_utf16().count() as i64);
+    assert_eq!(result, json!([]), "row 9 expected []: {result}");
+
+    // Row 13: an emoji earlier on the completion line — the character must be
+    // counted in UTF-16 code units (the emoji is 2), or the offset lands wrong.
+    let utf16 = "let s = { a: \"\u{1F642}\", b: Scene. }";
+    let cursor = utf16.find("Scene.").unwrap() + "Scene.".len();
+    let character = utf16[..cursor].encode_utf16().count() as i64;
+    let result = complete_at(&mut server, 5, utf16, 0, character);
+    let items = result.as_array().expect("completion array");
+    assert!(
+        items.iter().any(|item| item["label"] == "cube"),
+        "row 13 expected cube with UTF-16 offset: {result}"
+    );
+
+    // Row 22: a top-level request shows the JSON kind codes over the wire —
+    // `let` is a Keyword (14) and `Scene` is a Module (9).
+    let top = "let x = 1.0\nlet y = ";
+    let result = complete_at(
+        &mut server,
+        6,
+        top,
+        1,
+        "let y = ".encode_utf16().count() as i64,
+    );
+    let items = result.as_array().expect("completion array");
+    let kw = items
+        .iter()
+        .find(|item| item["label"] == "let")
+        .unwrap_or_else(|| panic!("no `let` at top level: {result}"));
+    assert_eq!(kw["kind"], 14);
+    let module = items
+        .iter()
+        .find(|item| item["label"] == "Scene")
+        .unwrap_or_else(|| panic!("no `Scene` module at top level: {result}"));
+    assert_eq!(module["kind"], 9);
+
+    server.send(json!({ "jsonrpc": "2.0", "id": 9, "method": "shutdown" }));
+    server.recv();
+    server.send(json!({ "jsonrpc": "2.0", "method": "exit" }));
+    server.child.wait().expect("wait for exit");
 }
 
 /// The VSCode extension's grammar and manifests must at least be valid JSON
@@ -391,8 +550,7 @@ fn prelude_gives_host_calls_real_types() {
     }));
     let response = server.recv();
     assert_eq!(
-        response["result"]["contents"]["value"],
-        "```functor\nScene.cube : () => Scene.t\n```",
+        response["result"]["contents"]["value"], "```functor\nScene.cube : () => Scene.t\n```",
         "prelude hover: {response}"
     );
 


### PR DESCRIPTION
Implements PR 1 of the LSP completion plan: `textDocument/completion` in `functor-lang-lsp`, targeting prelude/module dot-completion — the highest-value case for a game author (`Scene.` → `cube`, `sphere`, … with real `name : Type` details).

## Design

Completion fires on code that does not parse (`let s = Scene.`), where `load_project` returns `None`. The two halves of the answer therefore come from different places:

- **Context** (am I after `Ident.`? partial word?) is derived **textually** from the live buffer by lexing the prefix up to the cursor. Lexing ≠ parsing: a buffer broken only at the parse level still lexes cleanly.
- **Candidates** come from the **last-good parsed project**, cached per URI and refreshed on didOpen/didChange (a failed refresh retains the previous good load).

The pure module `functor_lang::complete` follows the hover/goto per-feature pattern. Offsets stay **local** to the live buffer — unlike hover's project-wide `file.base +` offsets; the two span spaces never mix (documented contract).

Candidates: prelude `.funi` signatures, sibling-module defs (`Pieces.ringCube`), **ADT constructors** (`Pieces.Circle : (float) => Shape`, generics keep their params: `Box<'a>`), builtins, keywords, and module names. No VS Code client changes — `vscode-languageclient` routes completion once the server advertises it.

v1 non-goals, each pinned by a boundary test so PR 2 flips assertions rather than discovering surprises: locals/params, typed record fields (`pos.`), chained members (`a.b.`), type-position members, `open`ed modules' bare exports.

## Tests

- **Unit** (24, in `complete.rs`): member/top-level/partial completion, sibling defs + constructors, broken-buffer/last-good behavior, strings/comments/numbers/newline edge cases, a `BUILTINS` drift guard (exhaustive match), PR-2 boundary pins. Inline throwaway preludes — `functor-lang` stays zero-dependency.
- **Real prelude** (`tools/functor-lang-lsp/tests/completion.rs`): `Scene.` against the actual `scene.funi`.
- **e2e over stdio** (`tests/e2e.rs`): capability advertisement, broken-buffer round-trip served from the cache, UTF-16 (emoji) offsets, LSP kind codes, cross-file `Utils.` completion in a real project.

Reviewed with /xreview (Claude + Codex, adversarial): no Critical/High; all four actionable findings fixed (hot-path double reparse removed, generic ctor details, drift guard, newline-after-dot context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)