### PR TITLE
perf: stop per-frame GPU mesh leak in animated heightmaps

### DIFF
--- a/runtime/functor-runtime-common/src/geometry/heightmap.rs
+++ b/runtime/functor-runtime-common/src/geometry/heightmap.rs
@@ -1,64 +1,219 @@
 use cgmath::{vec2, vec3, InnerSpace};
+use glow::{Buffer, HasContext, VertexArray};
 
+use crate::render::vertex::{Vertex, VertexAttributeType};
 use crate::render::VertexPositionTexture;
 
-use super::{Geometry, IndexedMesh};
+use super::compute_tangents;
 
 /// A subdivided grid in the XZ plane (Y-up), centered on the origin and spanning
 /// the unit square (-0.5..0.5); size it with `Transform.scale`. Each vertex's Y
 /// comes from `heights` (row-major, length `rows * cols`). UVs tile one full
 /// texture cell per grid quad (textures load with REPEAT wrap).
-pub struct Heightmap;
+///
+/// Unlike the static primitives, a heightmap is usually **animated** — its
+/// `heights` change every frame. So the scene keeps one persistent
+/// `HeightmapMesh` per `(rows, cols)` and re-uploads its vertex buffer in place
+/// (`buffer_sub_data`) only when the heights actually change; the index buffer is
+/// fixed for a given grid size and never re-uploaded. This avoids allocating a
+/// fresh VAO/VBO/EBO every frame (which, with the never-evicted cache, leaked a
+/// full GPU mesh per frame).
+///
+/// Like the primitive meshes (`Cube`/`Plane`/…), a `HeightmapMesh` is persistent
+/// for the scene's lifetime — one per grid size, never evicted — so its GL
+/// objects have no `Drop` (the GL context isn't available there) and are freed
+/// with the context at teardown.
+pub struct HeightmapMesh {
+    cols: usize,
+    /// Reused CPU-side vertex scratch, recomputed in place when heights change.
+    vertices: Vec<VertexPositionTexture>,
+    /// Triangle indices — constant for the grid size, so built once and kept for
+    /// re-tangenting on each vertex update (never re-uploaded after `create`).
+    indices: Vec<u32>,
+    vao: VertexArray,
+    vbo: Buffer,
+    ebo: Buffer,
+    /// Hash of the heights currently uploaded to the VBO; re-upload is skipped
+    /// when the incoming heights match (static terrain uploads exactly once).
+    heights_hash: u64,
+}
 
-impl Heightmap {
-    pub fn create(rows: usize, cols: usize, heights: &[f32]) -> Box<dyn Geometry> {
+impl HeightmapMesh {
+    /// Build the grid mesh for `(rows, cols)` and upload it, seeded with `heights`.
+    pub fn create(gl: &glow::Context, rows: usize, cols: usize, heights: &[f32]) -> HeightmapMesh {
         // Need at least a 2x2 grid to form a quad.
         let rows = rows.max(2);
         let cols = cols.max(2);
-        let height_at = |r: usize, c: usize| heights.get(r * cols + c).copied().unwrap_or(0.0);
 
-        // World spacing between adjacent grid samples (the grid spans 1 unit).
-        let cell_dx = 1.0 / (cols - 1) as f32;
-        let cell_dz = 1.0 / (rows - 1) as f32;
-
+        let indices = build_indices(rows, cols);
         let mut vertices = Vec::with_capacity(rows * cols);
-        for r in 0..rows {
-            for c in 0..cols {
-                let x = c as f32 / (cols - 1) as f32 - 0.5;
-                let z = r as f32 / (rows - 1) as f32 - 0.5;
+        fill_vertices(&mut vertices, rows, cols, heights, &indices);
 
-                // Normal from central differences of the height field, clamped
-                // to one-sided differences at the edges.
-                let (left, right) = (c.saturating_sub(1), (c + 1).min(cols - 1));
-                let (up, down) = (r.saturating_sub(1), (r + 1).min(rows - 1));
-                let dhdx = (height_at(r, right) - height_at(r, left))
-                    / ((right - left) as f32 * cell_dx);
-                let dhdz = (height_at(down, c) - height_at(up, c))
-                    / ((down - up) as f32 * cell_dz);
-                let normal = vec3(-dhdx, 1.0, -dhdz).normalize();
+        unsafe {
+            let indices_u8: &[u8] = core::slice::from_raw_parts(
+                indices.as_ptr() as *const u8,
+                indices.len() * core::mem::size_of::<u32>(),
+            );
+            let ebo = gl.create_buffer().unwrap();
+            gl.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, Some(ebo));
+            gl.buffer_data_u8_slice(glow::ELEMENT_ARRAY_BUFFER, indices_u8, glow::STATIC_DRAW);
 
-                vertices.push(VertexPositionTexture::new(
-                    vec3(x, height_at(r, c), z),
-                    vec2(c as f32, r as f32),
-                    normal,
-                ));
+            // DYNAMIC_DRAW: the vertex buffer is re-uploaded in place whenever the
+            // heights change (see `update`).
+            let vbo = gl.create_buffer().unwrap();
+            gl.bind_buffer(glow::ARRAY_BUFFER, Some(vbo));
+            gl.buffer_data_u8_slice(
+                glow::ARRAY_BUFFER,
+                vertices_bytes(&vertices),
+                glow::DYNAMIC_DRAW,
+            );
+
+            let vao = gl.create_vertex_array().unwrap();
+            gl.bind_vertex_array(Some(vao));
+
+            let attributes = <VertexPositionTexture>::get_vertex_attributes();
+            let total_size = <VertexPositionTexture>::get_total_size() as i32;
+            for (i, attribute) in attributes.iter().enumerate() {
+                let i = i as u32;
+                gl.enable_vertex_attrib_array(i);
+                match attribute.attribute_type {
+                    VertexAttributeType::Float => {
+                        gl.vertex_attrib_pointer_f32(
+                            i,
+                            attribute.size as i32,
+                            glow::FLOAT,
+                            false,
+                            total_size,
+                            attribute.offset as i32,
+                        );
+                    }
+                }
+            }
+
+            gl.bind_buffer(glow::ARRAY_BUFFER, None);
+            gl.bind_vertex_array(None);
+
+            HeightmapMesh {
+                cols,
+                vertices,
+                indices,
+                vao,
+                vbo,
+                ebo,
+                heights_hash: hash_heights(heights),
             }
         }
+    }
 
-        let mut indices = Vec::with_capacity((rows - 1) * (cols - 1) * 6);
-        for r in 0..rows - 1 {
-            for c in 0..cols - 1 {
-                let i = (r * cols + c) as u32;
-                let right = i + 1;
-                let down = i + cols as u32;
-                let down_right = down + 1;
-                // Two triangles per cell. (Backface culling is off, so winding
-                // only matters if it's enabled later.)
-                indices.extend_from_slice(&[i, down, down_right, i, down_right, right]);
-            }
+    /// Re-upload the vertex buffer if `heights` changed since the last upload.
+    /// `heights.len()` must equal the mesh's `rows * cols` — guaranteed by the
+    /// caller, which keys the mesh by `(rows, cols)`.
+    pub fn update(&mut self, gl: &glow::Context, heights: &[f32]) {
+        let hash = hash_heights(heights);
+        if hash == self.heights_hash {
+            return;
         }
+        let rows = self.vertices.len() / self.cols;
+        fill_vertices(&mut self.vertices, rows, self.cols, heights, &self.indices);
+        unsafe {
+            gl.bind_buffer(glow::ARRAY_BUFFER, Some(self.vbo));
+            gl.buffer_sub_data_u8_slice(glow::ARRAY_BUFFER, 0, vertices_bytes(&self.vertices));
+            gl.bind_buffer(glow::ARRAY_BUFFER, None);
+        }
+        self.heights_hash = hash;
+    }
 
-        super::compute_tangents(&mut vertices, &indices);
-        Box::new(IndexedMesh::create(vertices, indices))
+    pub fn draw(&self, gl: &glow::Context) {
+        unsafe {
+            gl.bind_vertex_array(Some(self.vao));
+            gl.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, Some(self.ebo));
+            gl.draw_elements(
+                glow::TRIANGLES,
+                self.indices.len() as i32,
+                glow::UNSIGNED_INT,
+                0,
+            );
+        }
+    }
+}
+
+/// Triangle indices for a `rows × cols` grid — a function of the grid size only,
+/// so it's built once per mesh and never re-uploaded.
+fn build_indices(rows: usize, cols: usize) -> Vec<u32> {
+    let mut indices = Vec::with_capacity((rows - 1) * (cols - 1) * 6);
+    for r in 0..rows - 1 {
+        for c in 0..cols - 1 {
+            let i = (r * cols + c) as u32;
+            let right = i + 1;
+            let down = i + cols as u32;
+            let down_right = down + 1;
+            // Two triangles per cell. (Backface culling is off, so winding
+            // only matters if it's enabled later.)
+            indices.extend_from_slice(&[i, down, down_right, i, down_right, right]);
+        }
+    }
+    indices
+}
+
+/// (Re)compute the grid's vertices from `heights` into `vertices`, reusing its
+/// allocation. Positions, normals (central differences of the height field) and
+/// tangents are all derived from `heights`, so this runs whenever the heights
+/// change; `indices` (constant for the grid size) drive the tangent pass.
+/// Produces byte-identical output to the previous per-frame rebuild.
+fn fill_vertices(
+    vertices: &mut Vec<VertexPositionTexture>,
+    rows: usize,
+    cols: usize,
+    heights: &[f32],
+    indices: &[u32],
+) {
+    let height_at = |r: usize, c: usize| heights.get(r * cols + c).copied().unwrap_or(0.0);
+
+    // World spacing between adjacent grid samples (the grid spans 1 unit).
+    let cell_dx = 1.0 / (cols - 1) as f32;
+    let cell_dz = 1.0 / (rows - 1) as f32;
+
+    vertices.clear();
+    for r in 0..rows {
+        for c in 0..cols {
+            let x = c as f32 / (cols - 1) as f32 - 0.5;
+            let z = r as f32 / (rows - 1) as f32 - 0.5;
+
+            // Normal from central differences of the height field, clamped
+            // to one-sided differences at the edges.
+            let (left, right) = (c.saturating_sub(1), (c + 1).min(cols - 1));
+            let (up, down) = (r.saturating_sub(1), (r + 1).min(rows - 1));
+            let dhdx =
+                (height_at(r, right) - height_at(r, left)) / ((right - left) as f32 * cell_dx);
+            let dhdz = (height_at(down, c) - height_at(up, c)) / ((down - up) as f32 * cell_dz);
+            let normal = vec3(-dhdx, 1.0, -dhdz).normalize();
+
+            vertices.push(VertexPositionTexture::new(
+                vec3(x, height_at(r, c), z),
+                vec2(c as f32, r as f32),
+                normal,
+            ));
+        }
+    }
+
+    compute_tangents(vertices, indices);
+}
+
+/// Content hash of a heightmap's `heights`, to skip re-uploading unchanged terrain.
+fn hash_heights(heights: &[f32]) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    for h in heights {
+        h.to_bits().hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
+fn vertices_bytes(vertices: &[VertexPositionTexture]) -> &[u8] {
+    unsafe {
+        core::slice::from_raw_parts(
+            vertices.as_ptr() as *const u8,
+            std::mem::size_of_val(vertices),
+        )
     }
 }

--- a/runtime/functor-runtime-common/src/scene3d/mod.rs
+++ b/runtime/functor-runtime-common/src/scene3d/mod.rs
@@ -47,9 +47,11 @@ pub struct SceneContext {
     sphere: RefCell<Box<dyn Geometry>>,
     quad: RefCell<Box<dyn Geometry>>,
     plane: RefCell<Box<dyn Geometry>>,
-    // Heightmaps are parameterized, so they're cached by a content hash (rows,
-    // cols, heights) — static terrain builds its GL mesh once and reuses it.
-    heightmaps: RefCell<HashMap<u64, Box<dyn Geometry>>>,
+    // One persistent mesh per grid size. Animated terrain (heights change every
+    // frame) re-uploads its vertex buffer in place instead of rebuilding a fresh
+    // GL mesh each frame; static terrain uploads exactly once. Keyed by
+    // (rows, cols) — the stable identity of the mesh across frames.
+    heightmaps: RefCell<HashMap<(u32, u32), geometry::HeightmapMesh>>,
     // Render targets persist across frames/hot reloads, keyed by the target's
     // string id (the cross-frame identity). Buffers for ids a game stops
     // declaring are kept until exit — TODO: evict.
@@ -924,32 +926,23 @@ named \"{name}\" — {hint}"
                     &xform,
                     &skinning_data,
                 );
-                // Build the grid mesh once per unique (rows, cols, heights) and
-                // cache it; static terrain reuses the same GL buffers each frame.
-                let key = heightmap_key(*rows, *cols, heights);
-                scene_context
-                    .heightmaps
-                    .borrow_mut()
-                    .entry(key)
-                    .or_insert_with(|| {
-                        geometry::Heightmap::create(*rows as usize, *cols as usize, heights)
-                    });
-                scene_context.heightmaps.borrow()[&key].draw(&render_context.gl);
+                // One persistent GL mesh per (rows, cols): build it on first sight,
+                // then re-upload its vertices in place only when the heights change
+                // (a no-op for static terrain). No per-frame VAO/VBO/EBO churn.
+                let mut heightmaps = scene_context.heightmaps.borrow_mut();
+                let mesh = heightmaps.entry((*rows, *cols)).or_insert_with(|| {
+                    geometry::HeightmapMesh::create(
+                        &render_context.gl,
+                        *rows as usize,
+                        *cols as usize,
+                        heights,
+                    )
+                });
+                mesh.update(&render_context.gl, heights);
+                mesh.draw(&render_context.gl);
             }
         }
     }
-}
-
-/// Content hash of a heightmap's parameters, used to cache its built GL mesh.
-fn heightmap_key(rows: u32, cols: u32, heights: &[f32]) -> u64 {
-    use std::hash::{Hash, Hasher};
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    rows.hash(&mut hasher);
-    cols.hash(&mut hasher);
-    for h in heights {
-        h.to_bits().hash(&mut hasher);
-    }
-    hasher.finish()
 }
 
 fn serialize_matrix<S>(matrix: &Matrix4<f32>, serializer: S) -> Result<S::Ok, S::Error>

--- a/runtime/functor-runtime-desktop/tests/soak.rs
+++ b/runtime/functor-runtime-desktop/tests/soak.rs
@@ -1,0 +1,168 @@
+//! Memory soak regression test.
+//!
+//! Runs the `synthwave` sample headless for ~20s and asserts its resident-set
+//! size (RSS) does not trend upward — a guard against per-frame GPU/CPU leaks
+//! like the heightmap-mesh leak (a fresh VAO/VBO/EBO built and cached, never
+//! evicted, every frame — the terrain animates, so the cache key changed each
+//! frame). `synthwave` is the worst case: its heightmap is a pure function of
+//! time, so every frame reuploads the terrain.
+//!
+//! The fix gives each `(rows, cols)` a single persistent mesh, re-uploaded in
+//! place, so RSS is flat. Before the fix, RSS grew ~linearly (measured ~8 MB/s
+//! on Linux). This test fails if the slope of a least-squares fit over the
+//! sampled RSS exceeds [`MAX_SLOPE_MB_PER_S`].
+//!
+//! Ignored by default: it needs a GL display and runs for ~20s. Run it with:
+//!
+//! ```sh
+//! cargo test -p functor-runtime-desktop --test soak -- --ignored --nocapture
+//! ```
+//!
+//! Note: some GL drivers (notably Apple's legacy GL-over-Metal) periodically
+//! reclaim orphaned buffers, so a *leaking* build shows a large RSS sawtooth
+//! rather than a clean ramp there; the least-squares slope still stays well
+//! under the threshold once the leak is fixed (the per-frame GPU-buffer growth is
+//! gone — only bounded, immediately-freed CPU scratch remains). The threshold is
+//! set to catch the ~MB/s-class linear leak this test guards.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::thread::sleep;
+use std::time::Duration;
+
+/// Fail if RSS trends upward faster than this. The leak this guards against was
+/// ~8 MB/s; a fixed build is flat (measured ~0.02 MB/s of allocator jitter).
+const MAX_SLOPE_MB_PER_S: f64 = 0.5;
+
+/// Total wall-clock the sample runs headless before capturing its final frame
+/// and exiting.
+const RUN_SECS: u64 = 22;
+/// Skip the first few seconds (asset load, first-frame hydration) before sampling.
+const WARMUP_SECS: u64 = 3;
+/// RSS sample period.
+const SAMPLE_MS: u64 = 500;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("resolve repo root")
+}
+
+/// Path to the `functor` CLI binary, next to this test binary
+/// (`target/<profile>/functor`). Build it first (`cargo build --bin functor`).
+fn functor_bin() -> PathBuf {
+    let exe = std::env::current_exe().expect("locate test binary");
+    let target_dir = exe
+        .parent()
+        .and_then(|deps| deps.parent())
+        .expect("target/<profile> dir");
+    let name = if cfg!(windows) { "functor.exe" } else { "functor" };
+    let bin = target_dir.join(name);
+    assert!(
+        bin.exists(),
+        "functor CLI not found at {} — build it first (`cargo build --bin functor`)",
+        bin.display()
+    );
+    bin
+}
+
+/// Resident-set size of `pid` in KB via `ps`, or `None` if the process is gone.
+fn rss_kb(pid: u32) -> Option<u64> {
+    let out = Command::new("ps")
+        .args(["-o", "rss=", "-p", &pid.to_string()])
+        .output()
+        .ok()?;
+    let text = String::from_utf8_lossy(&out.stdout);
+    text.trim().parse::<u64>().ok()
+}
+
+/// Least-squares slope of `(t_seconds, rss_mb)` samples, in MB/s.
+fn slope_mb_per_s(samples: &[(f64, f64)]) -> f64 {
+    let n = samples.len() as f64;
+    let sx: f64 = samples.iter().map(|(x, _)| x).sum();
+    let sy: f64 = samples.iter().map(|(_, y)| y).sum();
+    let sxx: f64 = samples.iter().map(|(x, _)| x * x).sum();
+    let sxy: f64 = samples.iter().map(|(x, y)| x * y).sum();
+    (n * sxy - sx * sy) / (n * sxx - sx * sx)
+}
+
+#[test]
+#[ignore = "needs a GL display; runs ~20s. Run with --ignored"]
+fn synthwave_rss_is_flat() {
+    let sample_dir = repo_root().join("examples").join("synthwave");
+    let out = std::env::temp_dir().join("functor-soak-synthwave.png");
+    let _ = std::fs::remove_file(&out);
+
+    // Headless run (`--capture-frame` implies `--hidden`), captured/exited at RUN_SECS.
+    let mut child = Command::new(functor_bin())
+        .args([
+            "-d",
+            sample_dir.to_str().unwrap(),
+            "run",
+            "native",
+            "--",
+            "--capture-frame",
+            out.to_str().unwrap(),
+            "--capture-time",
+            &RUN_SECS.to_string(),
+        ])
+        .spawn()
+        .expect("spawn functor");
+    let pid = child.id();
+
+    sleep(Duration::from_secs(WARMUP_SECS));
+
+    let mut samples: Vec<(f64, f64)> = Vec::new();
+    let sample_count = ((RUN_SECS - WARMUP_SECS - 1) * 1000 / SAMPLE_MS) as usize;
+    let mut exited_early = false;
+    for i in 0..sample_count {
+        match rss_kb(pid) {
+            Some(kb) => {
+                let t = WARMUP_SECS as f64 + (i as f64) * (SAMPLE_MS as f64 / 1000.0);
+                samples.push((t, kb as f64 / 1024.0));
+            }
+            None => {
+                exited_early = true; // process gone before the window ended — a crash
+                break;
+            }
+        }
+        sleep(Duration::from_millis(SAMPLE_MS));
+    }
+
+    let status = child.wait().expect("wait for functor");
+
+    // Trust the slope only if the process ran the whole window and exited cleanly
+    // with the expected capture — otherwise a crash could masquerade as "flat".
+    assert!(
+        !exited_early,
+        "functor exited before the {RUN_SECS}s window ended ({} samples) — treat as a failure, not flat RSS",
+        samples.len()
+    );
+    assert!(status.success(), "functor exited with {status}");
+    assert!(
+        out.exists(),
+        "capture {} was not written — the run did not complete normally",
+        out.display()
+    );
+    assert!(
+        samples.len() >= sample_count - 1,
+        "too few RSS samples ({} of {sample_count})",
+        samples.len()
+    );
+
+    let slope = slope_mb_per_s(&samples);
+    let first = samples.first().unwrap().1;
+    let last = samples.last().unwrap().1;
+    let peak = samples.iter().map(|(_, y)| *y).fold(0.0_f64, f64::max);
+    println!(
+        "soak: {} samples, first={first:.1}MB last={last:.1}MB peak={peak:.1}MB slope={slope:.3} MB/s",
+        samples.len()
+    );
+
+    assert!(
+        slope < MAX_SLOPE_MB_PER_S,
+        "RSS trends up at {slope:.3} MB/s (max {MAX_SLOPE_MB_PER_S} MB/s) — a per-frame leak may have regressed \
+         (first={first:.1}MB last={last:.1}MB peak={peak:.1}MB)"
+    );
+}


### PR DESCRIPTION
## The leak

Heightmap meshes were cached in a **never-evicted** `HashMap` keyed by a hash over `(rows, cols, and every height sample)` (`scene3d/mod.rs`, old `heightmap_key`). `examples/synthwave`'s terrain is a pure function of time, so the key changed **every frame** → the cache missed every frame → a fresh VAO/VBO/EBO (~111 KB) was created, uploaded, inserted into the map, and **never drawn again or freed**.

Compounding it: `IndexedMeshRuntimeData` never stored/deleted its VBO, so even eviction couldn't have freed the GL objects. The result was a full GPU mesh leaked per frame.

## The fix

Give animated heightmaps a **stable identity**: one persistent `HeightmapMesh` per `(rows, cols)`, keyed on grid size alone.

- Its **vertex buffer is re-uploaded in place** with `glBufferSubData` (`buffer_sub_data_u8_slice`, `DYNAMIC_DRAW`) only when the heights actually change; a cheap per-slot content hash skips the upload (and the CPU rebuild) entirely for static terrain.
- The **index buffer is fixed** for a grid size — built and uploaded once, then reused for the per-update tangent pass (no per-frame index allocation).
- The mesh owns its GL objects; like the primitive meshes (`Cube`/`Plane`/…) it is persistent for the scene's lifetime and never evicted, so there is **no `Drop`** (no GL context is available there — matching `RenderTargetBuffers`).

`IndexedMesh` (used by glTF models and the primitives) is left untouched — the fix is confined to the heightmap path.

**Rendering is byte-identical**: `synthwave` captures at fixed-time 0 and 2 are `cmp`-identical before/after, and the committed `synthwave` goldens pass at 0.000% drift. No visual change, so no GIF/PNG is attached.

## Before / after (native, macOS)

Headless `synthwave` soak, sampling process RSS:

| | peak RSS | trend |
| --- | --- | --- |
| **before** | **~291 MB** | climbs ~102→291 MB over the first ~40 s (~4.6 MB/s here; the perf audit measured ~8 MB/s on a non-reclaiming driver), then the legacy GL driver periodically reclaims the orphaned buffers → large sawtooth |
| **after** | **~85 MB** | flat: min 74 MB, slope **−0.155 MB/s** over 90 s |

`draw_us`/frame is unchanged (~13.5–14.2 ms both — the fix removes per-frame GL-buffer *creation*, which wasn't the draw-time bottleneck but was the leak).

## Regression test

Adds an `#[ignore]`d soak test (`runtime/functor-runtime-desktop/tests/soak.rs`): runs `synthwave` headless ~20 s, samples RSS, and fails if the least-squares slope exceeds **0.5 MB/s** (fixed build measures ~0.01 MB/s). It also requires the run to complete the full window and exit cleanly with its capture, so a crash can't masquerade as "flat". Run with:

```sh
cargo test -p functor-runtime-desktop --test soak -- --ignored --nocapture
```

## Verification

- `cargo test -p functor_runtime_common` — 252 passed
- `cargo check -p functor_runtime_common --target wasm32-unknown-unknown` — clean (shared code, so the WebGL2 web runtime is covered)
- soak test — passes (slope 0.007 MB/s)
- `synthwave` golden — 0.000% drift; capture byte-identical before/after

Reviewed with cross-engine adversarial review (Claude + Codex); the agreed finding (per-update index re-allocation) is fixed in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)