### PR TITLE
feat(time-travel): scene-space strobe — full-intensity future copies (T6)

### DIFF
--- a/runtime/functor-runtime-common/src/lib.rs
+++ b/runtime/functor-runtime-common/src/lib.rs
@@ -99,7 +99,9 @@ pub use render_target::RenderTargetDescriptor;
 pub use renderer::*;
 pub use skybox::SkyboxDescription;
 pub use scene3d::*;
-pub use trajectory::{overlay, trajectory_trail};
+pub use trajectory::{
+    overlay, scene_preview, trajectory_trail, PreviewOptions, ScenePreview, StrobeOptions,
+};
 pub use viewport::*;
 
 #[cfg(test)]

--- a/runtime/functor-runtime-common/src/trajectory.rs
+++ b/runtime/functor-runtime-common/src/trajectory.rs
@@ -1,21 +1,33 @@
-//! Scene-diff trajectory preview (docs/time-travel.md T6, the scene-diff
-//! variant). Given a game's live frame plus its forward-simulated future frames,
-//! find the scene nodes whose WORLD position changes across the sequence and
-//! emit a trail of dots tracing each mover's path.
+//! Scene-diff preview (docs/time-travel.md T6): given a game's live frame plus
+//! its forward-simulated future frames, find the scene nodes whose WORLD
+//! transform changes across the sequence ("movers") and render their future two
+//! ways:
 //!
-//! The point is that this needs NO game cooperation: the runtime derives the
-//! trajectory purely from what `draw` already renders. It diffs the rendered
+//! - a **trail** of dots tracing each mover's path (the clean-lines view), and
+//! - a **scene-space strobe**: real-geometry copies of each mover at its future
+//!   poses, color-faded by age (the chronophotography view). Unlike the
+//!   screen-space `--ghost` compositor — which averages N whole frames, pinning
+//!   every ghost copy at 1/N opacity — copies here are ordinary geometry on the
+//!   normal render path: full intensity, no division cap, and the camera stays
+//!   live. (The compositor remains the right tool for non-geometry motion such
+//!   as animated lighting, which no geometry copy can represent.)
+//!
+//! The point is that this needs NO game cooperation: the runtime derives
+//! everything purely from what `draw` already renders. It diffs the rendered
 //! *scene* (which carries concrete world transforms), not the opaque model — so
-//! "which numbers are positions" is unambiguous (a node's world translation) and
-//! "what moved" falls out of comparing those across the forward-sim.
+//! "which numbers are positions" is unambiguous and "what moved" falls out of
+//! comparing world transforms across the forward-sim.
 //!
-//! Pure and testable — no GPU, no interpreter needed (see the unit tests).
+//! Pure and testable — no GPU, no interpreter needed (see the unit tests). The
+//! one host-facing entry point is [`scene_preview`]: one forward-sim, both
+//! consumers.
 
 use std::collections::BTreeMap;
 
-use cgmath::{InnerSpace, Matrix4, SquareMatrix, Vector3};
+use cgmath::{vec4, InnerSpace, Matrix4, SquareMatrix, Vector3, Vector4};
 
-use crate::{MaterialDescription, Scene3D, SceneObject};
+use crate::protocol::GameProducer;
+use crate::{MaterialDescription, RecordedInput, Scene3D, SceneObject};
 
 /// One step of a node path: (child index, sibling count). Node identity across
 /// frames = the path of these segments from the root. Including the sibling
@@ -29,14 +41,23 @@ use crate::{MaterialDescription, Scene3D, SceneObject};
 /// the real fix is stable node ids, a known limit.
 type PathSeg = (usize, usize);
 
-/// Walk `scene`, accumulating world transforms, and record each LEAF node's
-/// world-space position keyed by its path from the root. A `BTreeMap` so
-/// iteration (and thus trail-dot order in the emitted scene) is deterministic.
-fn collect_positions(
+/// A LEAF node of the anchor scene: its world transform, the innermost
+/// enclosing material (what the renderer would shade it with), and the leaf
+/// object itself.
+struct AnchorLeaf {
+    world: Matrix4<f32>,
+    material: Option<MaterialDescription>,
+    leaf: SceneObject,
+}
+
+/// Walk `scene`, accumulating world transforms, and record each leaf's world
+/// matrix keyed by its path. A `BTreeMap` so iteration (and thus the emitted
+/// scene order) is deterministic.
+fn collect_transforms(
     scene: &Scene3D,
     world: Matrix4<f32>,
     path: &mut Vec<PathSeg>,
-    out: &mut BTreeMap<Vec<PathSeg>, Vector3<f32>>,
+    out: &mut BTreeMap<Vec<PathSeg>, Matrix4<f32>>,
 ) {
     let w = world * scene.xform;
     match &scene.obj {
@@ -44,23 +65,158 @@ fn collect_positions(
             let count = children.len();
             for (i, child) in children.iter().enumerate() {
                 path.push((i, count));
-                collect_positions(child, w, path, out);
+                collect_transforms(child, w, path, out);
                 path.pop();
             }
         }
         SceneObject::Geometry(_) | SceneObject::Model(_) => {
-            // The 4th column of the accumulated matrix is the node origin's
-            // world position.
-            out.insert(path.clone(), w.w.truncate());
+            out.insert(path.clone(), w);
         }
     }
 }
 
-fn positions_by_path(scene: &Scene3D) -> BTreeMap<Vec<PathSeg>, Vector3<f32>> {
+fn transforms_by_path(scene: &Scene3D) -> BTreeMap<Vec<PathSeg>, Matrix4<f32>> {
     let mut out = BTreeMap::new();
     let mut path = Vec::new();
-    collect_positions(scene, Matrix4::identity(), &mut path, &mut out);
+    collect_transforms(scene, Matrix4::identity(), &mut path, &mut out);
     out
+}
+
+/// The anchor-scene walk: like [`collect_transforms`] but also records each
+/// leaf's object and innermost enclosing material, which the strobe needs to
+/// build faithful copies. Run once per preview (on the anchor only).
+fn collect_anchor(
+    scene: &Scene3D,
+    world: Matrix4<f32>,
+    material: Option<&MaterialDescription>,
+    path: &mut Vec<PathSeg>,
+    out: &mut BTreeMap<Vec<PathSeg>, AnchorLeaf>,
+) {
+    let w = world * scene.xform;
+    match &scene.obj {
+        SceneObject::Group(children) => {
+            let count = children.len();
+            for (i, child) in children.iter().enumerate() {
+                path.push((i, count));
+                collect_anchor(child, w, material, path, out);
+                path.pop();
+            }
+        }
+        SceneObject::Material(mat, children) => {
+            let count = children.len();
+            for (i, child) in children.iter().enumerate() {
+                path.push((i, count));
+                collect_anchor(child, w, Some(mat), path, out);
+                path.pop();
+            }
+        }
+        SceneObject::Geometry(_) | SceneObject::Model(_) => {
+            out.insert(
+                path.clone(),
+                AnchorLeaf {
+                    world: w,
+                    material: material.cloned(),
+                    leaf: scene.obj.clone(),
+                },
+            );
+        }
+    }
+}
+
+fn anchor_leaves(scene: &Scene3D) -> BTreeMap<Vec<PathSeg>, AnchorLeaf> {
+    let mut out = BTreeMap::new();
+    let mut path = Vec::new();
+    collect_anchor(scene, Matrix4::identity(), None, &mut path, &mut out);
+    out
+}
+
+/// A mover identified by the scene diff: the leaf object, the material the
+/// renderer shades it with (from the anchor frame), and its world transform at
+/// each sampled frame — index 0 = the anchor, truncated at the first structural
+/// mismatch or teleport. `translated` distinguishes movers whose world POSITION
+/// changes from pure in-place spinners (rotation/scale only): the strobe
+/// depicts both, but a dotted trail of a spinner would just pile dots on one
+/// spot, so the trail consumer skips them.
+pub struct MoverTrack {
+    pub leaf: SceneObject,
+    pub material: Option<MaterialDescription>,
+    pub worlds: Vec<Matrix4<f32>>,
+    pub translated: bool,
+}
+
+fn world_pos(w: &Matrix4<f32>) -> Vector3<f32> {
+    // The 4th column of the accumulated matrix is the node origin's world
+    // position.
+    w.w.truncate()
+}
+
+/// Largest squared per-column delta between two transforms: the translation
+/// column plus the three (scaled) basis vectors, so rotation and scale changes
+/// register as movement too — for a unit-scale object, `eps` on a basis column
+/// is roughly the sine of the rotation angle.
+fn columns_delta2(a: &Matrix4<f32>, b: &Matrix4<f32>) -> f32 {
+    let dx = (a.x - b.x).magnitude2();
+    let dy = (a.y - b.y).magnitude2();
+    let dz = (a.z - b.z).magnitude2();
+    let dw = (a.w - b.w).magnitude2();
+    dx.max(dy).max(dz).max(dw)
+}
+
+/// Diff a scene sequence (index 0 = current, the rest = forward-simulated
+/// futures) into mover tracks — the shared core both the trail and the strobe
+/// consume. A node earns a track only if its world position varies by more than
+/// `eps` across the sequence, so static geometry contributes nothing.
+///
+/// `max_step` guards against TELEPORTS: a forward-sim can reset/respawn a node
+/// (a platformer character falling off the level snaps back to spawn), and that
+/// discontinuity is not a trajectory. Each track is cut at the first per-sample
+/// jump larger than `max_step`, so the preview traces the smooth path up to the
+/// reset instead of streaking across the snap-back. A path that stops matching
+/// mid-window (despawn, or its group changed shape — see [`PathSeg`]) keeps its
+/// track up to that sample.
+pub fn mover_tracks(scenes: &[&Scene3D], eps: f32, max_step: f32) -> Vec<MoverTrack> {
+    if scenes.len() < 2 {
+        return Vec::new();
+    }
+    let anchor = anchor_leaves(scenes[0]);
+    let futures: Vec<_> = scenes[1..].iter().map(|s| transforms_by_path(s)).collect();
+    let eps2 = eps * eps;
+    let mut tracks = Vec::new();
+    for (path, a) in &anchor {
+        let mut worlds = vec![a.world];
+        for m in &futures {
+            match m.get(path) {
+                Some(w) => worlds.push(*w),
+                None => break,
+            }
+        }
+        // Cut at the first teleport (respawn/reset) — a trajectory is continuous.
+        if let Some(cut) = (1..worlds.len())
+            .find(|&i| (world_pos(&worlds[i]) - world_pos(&worlds[i - 1])).magnitude() > max_step)
+        {
+            worlds.truncate(cut);
+        }
+        let p0 = world_pos(&worlds[0]);
+        let translated = worlds
+            .iter()
+            .any(|w| (world_pos(w) - p0).magnitude2() > eps2);
+        // A mover is anything whose world TRANSFORM changes — translation, or
+        // an in-place rotation/scale (which only the strobe can depict).
+        let moved = translated
+            || worlds
+                .iter()
+                .any(|w| columns_delta2(w, &worlds[0]) > eps2);
+        if !moved {
+            continue;
+        }
+        tracks.push(MoverTrack {
+            leaf: a.leaf.clone(),
+            material: a.material.clone(),
+            worlds,
+            translated,
+        });
+    }
+    tracks
 }
 
 /// A single dim emissive marker at a world position. The renderer applies a
@@ -82,45 +238,16 @@ fn trail_dot(p: Vector3<f32>) -> Scene3D {
     }
 }
 
-/// Build a trail scene from a sequence of scenes (index 0 = current, the rest =
-/// forward-simulated futures). A node earns a trail only if its world position
-/// varies by more than `eps` across the sequence — so static geometry stays
-/// clean and only movers get ghost dots. Returns `None` when nothing moved.
-///
-/// `max_step` guards against TELEPORTS: a forward-sim can reset/respawn a node
-/// (e.g. a platformer character falling off the level snaps back to spawn), and
-/// that discontinuity is not a trajectory. Each polyline is cut at the first
-/// per-sample jump larger than `max_step`, so the preview traces the smooth path
-/// up to the reset instead of drawing a straight streak across the snap-back.
-pub fn trajectory_trail(scenes: &[&Scene3D], eps: f32, max_step: f32) -> Option<Scene3D> {
-    if scenes.len() < 2 {
-        return None;
-    }
-    let per_scene: Vec<_> = scenes.iter().map(|s| positions_by_path(s)).collect();
-    let eps2 = eps * eps;
+fn trail_from_tracks(tracks: &[MoverTrack]) -> Option<Scene3D> {
     let mut dots = Vec::new();
-    // Identity set = the paths present in the current (index 0) scene. A node
-    // whose path stops matching mid-window (despawn, or its group changed
-    // shape — see `PathSeg`) keeps its trail up to that sample.
-    for (path, p0) in &per_scene[0] {
-        let mut poly = vec![*p0];
-        for m in &per_scene[1..] {
-            match m.get(path) {
-                Some(p) => poly.push(*p),
-                None => break,
-            }
-        }
-        // Cut at the first teleport (respawn/reset) — a trajectory is continuous.
-        if let Some(cut) = (1..poly.len()).find(|&i| (poly[i] - poly[i - 1]).magnitude() > max_step)
-        {
-            poly.truncate(cut);
-        }
-        let moved = poly.iter().any(|p| (p - poly[0]).magnitude2() > eps2);
-        if !moved {
+    for track in tracks {
+        // A pure in-place spinner has a track (for the strobe) but no path to
+        // dot — its dots would all land on one spot.
+        if !track.translated {
             continue;
         }
-        for p in &poly {
-            dots.push(trail_dot(*p));
+        for w in &track.worlds {
+            dots.push(trail_dot(world_pos(w)));
         }
     }
     if dots.is_empty() {
@@ -133,9 +260,146 @@ pub fn trajectory_trail(scenes: &[&Scene3D], eps: f32, max_step: f32) -> Option<
     }
 }
 
-/// Composite a derived trail onto a scene in place (the runtime's trajectory
-/// overlay). In-place so callers overlaying every frame don't deep-clone the
-/// scene tree just to regroup it.
+/// Build a dotted-trail scene from a scene sequence. Returns `None` when
+/// nothing moved. (The trail consumer of [`mover_tracks`].)
+pub fn trajectory_trail(scenes: &[&Scene3D], eps: f32, max_step: f32) -> Option<Scene3D> {
+    trail_from_tracks(&mover_tracks(scenes, eps, max_step))
+}
+
+/// Scene-space strobe options.
+pub struct StrobeOptions {
+    /// Ghost copies per mover across the window (evenly sampled from its track).
+    pub copies: usize,
+    /// The color ghosts fade toward with age — pick the scene's background so
+    /// far-future copies read as receding into it.
+    pub fade_to: [f32; 3],
+    /// Color retention at (nearest, farthest) future — e.g. `(0.8, 0.2)` draws
+    /// the next moment at 80% of the mover's own color and the window's end at
+    /// 20%.
+    pub fade: (f32, f32),
+}
+
+impl Default for StrobeOptions {
+    fn default() -> Self {
+        StrobeOptions {
+            copies: 8,
+            // The runtime's clear color (run.rs / web lib.rs) — overridden by
+            // hosts whose scene has its own backdrop.
+            fade_to: [0.1, 0.2, 0.3],
+            fade: (0.8, 0.2),
+        }
+    }
+}
+
+/// Lerp a material's color toward `to` keeping `k` of the original (k=1 → the
+/// original color, k=0 → fully `to`). Textures/normal maps are kept — the tint
+/// darkens them toward the background. A `Texture` material (no color channel)
+/// becomes an emissive-tinted texture so it can fade at all. `None` (a bare
+/// leaf with no enclosing material — typically a `Model`, which carries its own
+/// internal materials) stays `None`: the copy renders at full fidelity, and
+/// fading it needs a render-path tint (a known follow-up).
+fn faded_material(
+    material: Option<&MaterialDescription>,
+    to: [f32; 3],
+    k: f32,
+) -> Option<MaterialDescription> {
+    let lerp = |c: Vector4<f32>| {
+        vec4(
+            to[0] + (c.x - to[0]) * k,
+            to[1] + (c.y - to[1]) * k,
+            to[2] + (c.z - to[2]) * k,
+            c.w,
+        )
+    };
+    match material {
+        Some(MaterialDescription::Color(c)) => Some(MaterialDescription::Color(lerp(*c))),
+        Some(MaterialDescription::Emissive { color, texture }) => {
+            Some(MaterialDescription::Emissive {
+                color: lerp(*color),
+                texture: texture.clone(),
+            })
+        }
+        Some(MaterialDescription::Lit {
+            color,
+            texture,
+            normal_map,
+        }) => Some(MaterialDescription::Lit {
+            color: lerp(*color),
+            texture: texture.clone(),
+            normal_map: normal_map.clone(),
+        }),
+        Some(MaterialDescription::Texture(t)) => Some(MaterialDescription::Emissive {
+            color: lerp(vec4(1.0, 1.0, 1.0, 1.0)),
+            texture: Some(t.clone()),
+        }),
+        None => None,
+    }
+}
+
+/// One strobe copy: the mover's leaf at a future world pose, shaded by its
+/// (age-faded) material. Transforms go on a Group / the leaf itself — never on
+/// a Material node, which the renderer ignores (see [`trail_dot`]).
+fn strobe_copy(track: &MoverTrack, world: Matrix4<f32>, fade_to: [f32; 3], k: f32) -> Scene3D {
+    let leaf = Scene3D {
+        obj: track.leaf.clone(),
+        xform: Matrix4::identity(),
+    };
+    match faded_material(track.material.as_ref(), fade_to, k) {
+        Some(mat) => Scene3D {
+            obj: SceneObject::Group(vec![Scene3D {
+                obj: SceneObject::Material(mat, vec![leaf]),
+                xform: Matrix4::identity(),
+            }]),
+            xform: world,
+        },
+        None => Scene3D {
+            obj: leaf.obj,
+            xform: world,
+        },
+    }
+}
+
+/// Scene-space strobe: real-geometry copies of each mover at its future poses,
+/// color-faded by age. Returns `None` when nothing moved. (The strobe consumer
+/// of [`mover_tracks`].)
+pub fn strobe_overlay(tracks: &[MoverTrack], opts: &StrobeOptions) -> Option<Scene3D> {
+    let mut copies = Vec::new();
+    for track in tracks {
+        // Future poses only — the live mover is already in the frame.
+        let n_future = track.worlds.len() - 1;
+        if n_future == 0 || opts.copies == 0 {
+            continue;
+        }
+        let count = opts.copies.min(n_future);
+        for c in 0..count {
+            // Evenly sample the future, always including the window's end.
+            let idx = ((c + 1) as f32 * n_future as f32 / count as f32).round() as usize;
+            let idx = idx.clamp(1, n_future);
+            // Age by TIME along the track (not copy index), so sparse strobes
+            // fade the same way dense ones do. Normalized over the inclusive
+            // endpoints so the nearest possible future really gets `fade.0`; a
+            // single-sample track counts as near.
+            let age = if n_future <= 1 {
+                0.0
+            } else {
+                (idx - 1) as f32 / (n_future - 1) as f32
+            };
+            let k = opts.fade.0 + (opts.fade.1 - opts.fade.0) * age;
+            copies.push(strobe_copy(track, track.worlds[idx], opts.fade_to, k));
+        }
+    }
+    if copies.is_empty() {
+        None
+    } else {
+        Some(Scene3D {
+            obj: SceneObject::Group(copies),
+            xform: Matrix4::identity(),
+        })
+    }
+}
+
+/// Composite a derived overlay onto a scene in place. In-place so callers
+/// overlaying every frame don't deep-clone the scene tree just to regroup it.
 pub fn overlay(scene: &mut Scene3D, trail: Scene3D) {
     let prev = std::mem::replace(
         scene,
@@ -148,6 +412,63 @@ pub fn overlay(scene: &mut Scene3D, trail: Scene3D) {
         obj: SceneObject::Group(vec![prev, trail]),
         xform: Matrix4::identity(),
     };
+}
+
+/// What [`scene_preview`] should compute.
+pub struct PreviewOptions {
+    /// Forward-sim divisions (samples). Not bound by the screen-space
+    /// compositor's 8-target cap — this only reads scenes — so sample finely.
+    pub divisions: usize,
+    /// Seconds of future to project.
+    pub window: f32,
+    /// Movement threshold: ignore world-position jitter below this.
+    pub eps: f32,
+    /// Teleport threshold: cut a track at a per-sample jump beyond this.
+    pub max_step: f32,
+    /// Emit the dotted trail?
+    pub trail: bool,
+    /// Emit the scene-space strobe?
+    pub strobe: Option<StrobeOptions>,
+}
+
+/// A computed preview: overlays for the normal render path. Cheap to clone
+/// relative to recomputing (hosts cache it on the anchor).
+#[derive(Clone)]
+pub struct ScenePreview {
+    pub trail: Option<crate::Scene3D>,
+    pub strobe: Option<crate::Scene3D>,
+}
+
+/// The SHARED composition step both shells call (desktop `run.rs`; web
+/// `lib.rs`): run ONE forward-sim via the producer's `ghost_frames`, diff the
+/// scenes into mover tracks, and build whichever overlays `opts` asks for.
+/// `script_inputs` follows `ghost_frames`' contract (docs/time-travel.md F2) —
+/// the caller builds the slice, since only the shell knows its script and
+/// anchor convention.
+pub fn scene_preview(
+    game: &dyn GameProducer,
+    anchor_scene: &Scene3D,
+    start_tts: f64,
+    script_inputs: Option<&[Vec<RecordedInput>]>,
+    opts: &PreviewOptions,
+) -> ScenePreview {
+    let divisions = opts.divisions.max(1);
+    let dt = opts.window / divisions as f32;
+    let futures = game.ghost_frames(divisions, dt, start_tts, script_inputs);
+    let mut scenes: Vec<&Scene3D> = vec![anchor_scene];
+    scenes.extend(futures.iter().map(|(f, _)| &f.scene));
+    let tracks = mover_tracks(&scenes, opts.eps, opts.max_step);
+    ScenePreview {
+        trail: if opts.trail {
+            trail_from_tracks(&tracks)
+        } else {
+            None
+        },
+        strobe: opts
+            .strobe
+            .as_ref()
+            .and_then(|s| strobe_overlay(&tracks, s)),
+    }
 }
 
 #[cfg(test)]
@@ -250,6 +571,105 @@ mod tests {
         match trail.obj {
             SceneObject::Group(dots) => assert_eq!(dots.len(), 3, "teleport sample dropped"),
             _ => panic!(),
+        }
+    }
+
+    // --- strobe ---
+
+    // A mover wrapped in a Lit material under a translated group, so the strobe
+    // must fold the full parent chain into each copy AND carry the material.
+    fn lit_frame(x: f32) -> Scene3D {
+        Scene3D {
+            obj: SceneObject::Group(vec![Scene3D {
+                obj: SceneObject::Material(
+                    MaterialDescription::lit(1.0, 0.5, 0.0, 1.0),
+                    vec![ball_at(x, 0.0)],
+                ),
+                xform: Matrix4::identity(),
+            }]),
+            xform: Matrix4::from_translation(vec3(2.0, 0.0, 0.0)),
+        }
+    }
+
+    #[test]
+    fn strobe_copies_land_at_future_world_poses_with_faded_material() {
+        let frames = [lit_frame(0.0), lit_frame(1.0), lit_frame(2.0)];
+        let refs: Vec<&Scene3D> = frames.iter().collect();
+        let tracks = mover_tracks(&refs, 0.05, 9.0);
+        assert_eq!(tracks.len(), 1);
+        let strobe = strobe_overlay(
+            &tracks,
+            &StrobeOptions {
+                copies: 2,
+                fade_to: [0.0, 0.0, 0.0],
+                fade: (0.8, 0.2),
+            },
+        )
+        .expect("a strobe");
+        let copies = match strobe.obj {
+            SceneObject::Group(c) => c,
+            _ => panic!(),
+        };
+        assert_eq!(copies.len(), 2);
+        // Copies at the two future poses: world x = 2 (group) + local.
+        assert!((copies[0].xform.w.x - 3.0).abs() < 1e-4);
+        assert!((copies[1].xform.w.x - 4.0).abs() < 1e-4);
+        // Each copy: Group -> Material(faded Lit) -> leaf. The LAST copy fades
+        // hardest: k = 0.2 → red channel 1.0 * 0.2.
+        let mat = match &copies[1].obj {
+            SceneObject::Group(children) => match &children[0].obj {
+                SceneObject::Material(m, _) => m.clone(),
+                _ => panic!("expected a material wrapper"),
+            },
+            _ => panic!("expected a group"),
+        };
+        match mat {
+            MaterialDescription::Lit { color, .. } => {
+                assert!((color.x - 0.2).abs() < 1e-4, "expected faded red, got {}", color.x);
+            }
+            _ => panic!("expected a Lit material"),
+        }
+    }
+
+    #[test]
+    fn in_place_rotation_strobes_but_leaves_no_trail() {
+        // A cube spinning in place: its world POSITION never changes, but its
+        // basis vectors do. It must earn strobe copies (which can depict the
+        // spin) and no trail (whose dots would pile on one spot).
+        let spin = |angle: f32| Scene3D {
+            obj: SceneObject::Group(vec![
+                Scene3D::cube().transform(Matrix4::from_angle_y(cgmath::Rad(angle)))
+            ]),
+            xform: Matrix4::identity(),
+        };
+        let frames = [spin(0.0), spin(0.5), spin(1.0)];
+        let refs: Vec<&Scene3D> = frames.iter().collect();
+        let tracks = mover_tracks(&refs, 0.05, 3.0);
+        assert_eq!(tracks.len(), 1, "a spinner is a mover");
+        assert!(!tracks[0].translated);
+        assert!(strobe_overlay(&tracks, &StrobeOptions::default()).is_some());
+        assert!(trail_from_tracks(&tracks).is_none(), "no dots for pure rotation");
+    }
+
+    #[test]
+    fn strobe_skips_statics_and_material_less_leaves_render_bare() {
+        // Two nodes: a bare (no material) mover and a static. Only the mover
+        // strobes, and its copies carry no Material wrapper (full fidelity —
+        // the model/no-material case).
+        let f = |x: f32| frame(x, 0.0);
+        let frames = [f(0.0), f(1.0)];
+        let refs: Vec<&Scene3D> = frames.iter().collect();
+        let tracks = mover_tracks(&refs, 0.05, 9.0);
+        assert_eq!(tracks.len(), 1);
+        let strobe = strobe_overlay(&tracks, &StrobeOptions::default()).expect("a strobe");
+        let copies = match strobe.obj {
+            SceneObject::Group(c) => c,
+            _ => panic!(),
+        };
+        assert_eq!(copies.len(), 1, "one future sample → one copy");
+        match &copies[0].obj {
+            SceneObject::Geometry(_) => {}
+            other => panic!("expected a bare geometry copy, got {other:?}"),
         }
     }
 }

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -320,6 +320,16 @@ pub struct Args {
     #[arg(long)]
     trajectory: bool,
 
+    /// Scene-space strobe preview: forward-simulate the model and overlay
+    /// real-geometry copies of each MOVING scene node at its future poses,
+    /// color-faded by age — full-intensity chronophotography on the normal
+    /// render path. The geometry complement to --ghost's screen-space
+    /// compositor (which pins every copy at 1/N opacity and freezes the
+    /// camera); like --trajectory it's runtime-derived from `draw`, shares one
+    /// forward-sim with it, and is capturable under --fixed-time.
+    #[arg(long)]
+    strobe: bool,
+
     /// Narrate the game clock + time-travel seams to stderr: pause/resume/seek
     /// rebases (with the tts they land on), ghost on/off, and per-frame HITCH
     /// warnings when a rendered frame's dt blows past 33ms (the tell-tale of the
@@ -867,16 +877,17 @@ pub fn run(args: Args) {
         let mut ghost_on = args.ghost;
         let mut ghost_divisions = args.ghost_divisions;
         let mut ghost_window: f32 = 2.0;
-        // --trajectory trail cache. The 32-division forward-sim is the expensive
-        // part, and while PAUSED its anchor (scene frame + tts) is frozen — so
-        // reuse the trail while the anchor key matches, but still refresh every
-        // TRAIL_REFRESH_FRAMES so a hot-reload's edited code re-projects within
-        // ~half a second (the anchor can't see a code edit). Live play changes
-        // the key every frame, so it recomputes like --ghost does.
+        // --trajectory/--strobe preview cache. The 32-division forward-sim is
+        // the expensive part, and while PAUSED its anchor (scene frame + tts) is
+        // frozen — so reuse the computed preview while the anchor key matches,
+        // but still refresh every TRAIL_REFRESH_FRAMES so a hot-reload's edited
+        // code re-projects within ~half a second (the anchor can't see a code
+        // edit). Live play changes the key every frame, so it recomputes like
+        // --ghost does.
         const TRAIL_REFRESH_FRAMES: u32 = 30;
         let mut trail_cache: Option<(
-            (Option<u64>, u32),
-            Option<functor_runtime_common::Scene3D>,
+            (Option<u64>, u32, bool),
+            functor_runtime_common::ScenePreview,
         )> = None;
         let mut trail_refresh: u32 = 0;
 
@@ -1253,29 +1264,52 @@ Escape again to quit"
             // trajectory overlay goes on a render-only copy below.
             let frame = game.render(time.clone());
 
-            // Scene-diff trajectory preview (docs/time-travel.md T6, scene-diff
-            // variant): forward-simulate the model (physics included, via the
-            // shared ghost_frames) and diff the rendered scenes' node world
-            // positions into a dotted trail on just the movers — the clean-lines
-            // COMPLEMENT to --ghost's whole-scene strobe. Same gating as ghost
-            // (interactive only while the scrubber is paused; headless via the
-            // flag, so it's deterministically capturable). Renders on the normal
-            // path — the trail is ordinary emissive geometry, no compositor.
-            let trajectory_active = args.trajectory
+            // Drive the ghost from the interactive toggle when the overlay is up,
+            // and from the `--ghost` launch flag when it's hidden (the headless
+            // capture path — F2 demo, goldens, tests — is byte-for-byte
+            // unchanged). Interactive ghost only renders while PAUSED: the
+            // strobe is a preview of a frozen frame's future, and
+            // forward-stepping the scene N times every LIVE frame tanks the
+            // framerate (the "can't move with the scrubber open" bug).
+            // `is_paused()` is false under --fixed-time, so the headless
+            // `args.ghost` capture branch is unaffected. Computed HERE, above
+            // the scene-diff preview, because the preview's gating reads it.
+            let ghost_active = if scrubber_visible {
+                ghost_on && clock.is_paused()
+            } else {
+                args.ghost
+            };
+
+            // Scene-diff preview (docs/time-travel.md T6): forward-simulate the
+            // model (physics included, via the shared ghost_frames inside
+            // scene_preview) and diff the rendered scenes' node world transforms
+            // into --trajectory's dotted trail and/or --strobe's real-geometry
+            // future copies — both overlays on the normal render path, computed
+            // from ONE forward-sim. Same gating as ghost (interactive only while
+            // the scrubber is paused; headless via the flags, so it's
+            // deterministically capturable).
+            let trail_wanted = args.trajectory;
+            // Under the screen-space ghost compositor the scene-space strobe
+            // would double-ghost — and the compositor arm never draws the
+            // display frame — so while the ghost is active the strobe is off
+            // (the trail still shows: it rides IN the composited frames), and
+            // it must not silently burn a forward-sim it can't display.
+            let strobe_wanted = args.strobe && !ghost_active;
+            let preview_active = (trail_wanted || strobe_wanted)
                 && args.composite_demo == CompositeDemoArg::Off
                 && (!scrubber_visible || clock.is_paused());
-            let trail: Option<functor_runtime_common::Scene3D> = if trajectory_active {
+            let preview: Option<functor_runtime_common::ScenePreview> = if preview_active {
                 // Not bound by the 8-target compositor cap — this only reads node
-                // positions — so sample finely for a smooth arc.
+                // transforms — so sample finely for a smooth arc.
                 let divisions = 32usize;
                 let window = 1.6f32;
                 let dt = window / divisions as f32;
-                let key = (game.current_scene_frame(), time.tts.to_bits());
+                let key = (game.current_scene_frame(), time.tts.to_bits(), strobe_wanted);
                 let cache_hit = trail_refresh > 0
                     && trail_cache.as_ref().is_some_and(|(k, _)| *k == key);
                 if cache_hit {
                     trail_refresh -= 1;
-                    trail_cache.as_ref().and_then(|(_, t)| t.clone())
+                    trail_cache.as_ref().map(|(_, p)| p.clone())
                 } else {
                     // Under --input-script the live loop keeps consuming the
                     // script (its gate is `!args.ghost`), so the forward-sim must
@@ -1306,23 +1340,27 @@ Escape again to quit"
                                 .map(|j| script.get(&(base + j)).cloned().unwrap_or_default())
                                 .collect()
                         });
-                    let futures = game.ghost_frames(
-                        divisions,
-                        dt,
+                    let p = functor_runtime_common::scene_preview(
+                        &*game,
+                        &frame.scene,
                         time.tts as f64,
                         script_slice.as_deref(),
+                        &functor_runtime_common::PreviewOptions {
+                            divisions,
+                            window,
+                            // eps 0.04: ignore sub-mm jitter. max_step 3.0: cut
+                            // respawn teleports (a reset covers many units in
+                            // one sample).
+                            eps: 0.04,
+                            max_step: 3.0,
+                            trail: trail_wanted,
+                            strobe: strobe_wanted
+                                .then(functor_runtime_common::StrobeOptions::default),
+                        },
                     );
-                    let t = {
-                        let mut scenes: Vec<&functor_runtime_common::Scene3D> =
-                            vec![&frame.scene];
-                        scenes.extend(futures.iter().map(|(f, _)| &f.scene));
-                        // eps 0.04: ignore sub-mm jitter. max_step 3.0: cut respawn
-                        // teleports (a reset covers many units in one sample).
-                        functor_runtime_common::trajectory_trail(&scenes, 0.04, 3.0)
-                    };
                     trail_refresh = TRAIL_REFRESH_FRAMES;
-                    trail_cache = Some((key, t.clone()));
-                    t
+                    trail_cache = Some((key, p.clone()));
+                    Some(p)
                 }
             } else {
                 trail_cache = None;
@@ -1339,20 +1377,7 @@ Escape again to quit"
             // deterministically capturable under --fixed-time.
             // Gate on the full ladder condition so we don't pay the dry-run + N
             // draws only to have stereo / composite-demo outrank the ghost arm.
-            // Drive the ghost from the interactive toggle when the overlay is up,
-            // and from the `--ghost` launch flag when it's hidden (the headless
-            // capture path — F2 demo, goldens, tests — is byte-for-byte unchanged).
-            //
-            // Interactive ghost only renders while PAUSED: the strobe is a preview
-            // of a frozen frame's future, and forward-stepping the scene N times
-            // every LIVE frame tanks the framerate (the "can't move with the
-            // scrubber open" bug). `is_paused()` is false under --fixed-time, so
-            // the headless `args.ghost` capture branch is unaffected.
-            let ghost_active = if scrubber_visible {
-                ghost_on && clock.is_paused()
-            } else {
-                args.ghost
-            };
+            // (`ghost_active` is computed above the scene-diff preview block.)
             let ghost_frames = if ghost_active
                 && !args.stereo_sbs
                 && args.composite_demo == CompositeDemoArg::Off
@@ -1381,14 +1406,16 @@ Escape again to quit"
             } else {
                 Vec::new()
             };
-            // The trail composes with the strobe by riding IN each composited
-            // frame: the dots are identical opaque geometry at identical world
-            // positions in every input, so the equal-weight average reconstructs
-            // them at full intensity (unlike movers, which appear in only one
-            // frame each). Without this the ghost render arm draws only
-            // `ghost_frames` and the trail would silently vanish.
+            // The trail composes with --ghost's screen-space strobe by riding IN
+            // each composited frame: the dots are identical opaque geometry at
+            // identical world positions in every input, so the equal-weight
+            // average reconstructs them at full intensity (unlike movers, which
+            // appear in only one frame each). Without this the ghost render arm
+            // draws only `ghost_frames` and the trail would silently vanish.
+            // The scene-space strobe is deliberately NOT folded in — layering
+            // geometry copies under the compositor's strobe would double-ghost.
             let mut ghost_frames = ghost_frames;
-            if let Some(trail) = &trail {
+            if let Some(trail) = preview.as_ref().and_then(|p| p.trail.as_ref()) {
                 for (f, _) in ghost_frames.iter_mut() {
                     functor_runtime_common::overlay(&mut f.scene, trail.clone());
                 }
@@ -1448,13 +1475,18 @@ Escape again to quit"
                 .flatten();
 
             // The frame the render ladder draws: the game frame plus the
-            // trajectory overlay (`frame` itself stays pristine for GET /scene).
+            // preview overlays (`frame` itself stays pristine for GET /scene).
             // Skipped when the ghost arm will draw instead — the trail already
             // rides inside `ghost_frames`.
-            let display_frame = match (&trail, ghost_frames.is_empty()) {
-                (Some(t), true) => {
+            let display_frame = match (&preview, ghost_frames.is_empty()) {
+                (Some(p), true) if p.trail.is_some() || p.strobe.is_some() => {
                     let mut f = frame.clone();
-                    functor_runtime_common::overlay(&mut f.scene, t.clone());
+                    if let Some(t) = &p.trail {
+                        functor_runtime_common::overlay(&mut f.scene, t.clone());
+                    }
+                    if let Some(s) = &p.strobe {
+                        functor_runtime_common::overlay(&mut f.scene, s.clone());
+                    }
                     Some(f)
                 }
                 _ => None,


### PR DESCRIPTION
## Scene-space strobe — full-intensity future copies (T6)

Stacked on #312. The visibility fix for the ghost strobe, per the design discussion:
the screen-space compositor averages N whole frames, so a moving object's ghost copy
is pinned at **1/N opacity** (~12% at 8 divisions) — nearly invisible. The scene diff
(#312) already knows *which* nodes move and *where they'll be*, so this draws the
strobe as **real geometry** instead:

- **`mover_tracks`** — the shared scene-diff core now keeps **full world matrices**
  (rotation carries: falling crates tumble through their arcs), each leaf's innermost
  material, and the leaf object. The dotted trail becomes one consumer
  (behavior-identical; pure in-place spinners excluded — their dots would pile on one
  spot); the new **`strobe_overlay`** is the other: copies of each mover at evenly
  sampled future poses, **color-faded by age** toward the background (0.8 → 0.2,
  endpoint-normalized). Color/Emissive/Lit lerp their color; Texture becomes an
  emissive-tinted texture; material-less leaves (Models) render full-fidelity unfaded
  (fade needs a render-path tint — follow-up).
- **`scene_preview`** — the shared composition step: ONE `ghost_frames` forward-sim
  feeding trail + strobe. The web port becomes a small consumer of this function
  instead of a copy of the run.rs block.
- **`--strobe`** on desktop, riding `--trajectory`'s gating, anchor cache, and script
  slice. Under `--ghost` the strobe is off *and its forward-sim is skipped* (the
  compositor arm never draws the display frame; layering geometry copies under the
  screen-space strobe would double-ghost). The trail still rides in the composited
  ghost frames.

### Why scene-space

Full opacity for free (no averaging anywhere), no 8-division compositor cap, the
camera stays live while paused, and trail + strobe compose on one code path. The
screen-space compositor remains the right tool for non-geometry motion (animated
lighting), so `--ghost` is unchanged.

### Verified

- 259 common-crate tests (3 new: strobe poses/fade, bare-leaf copies, in-place
  rotation); strict deny-warnings builds of both crates.
- Captures: `toss --strobe` (fading copies along all three arcs; resting ball gets
  none), `toss --strobe --trajectory` (copies + dots composed),
  `physics --strobe` (rapier crates' copies visibly **rotated** at future poses).
- Cross-engine review (Claude + Codex): both engines' agreed findings fixed
  (in-place-rotation coverage, ghost/strobe gating), plus fade endpoint
  normalization and a divisions=0 guard.

### Known limits (follow-ups)

- Strobe copies cast shadows (same as trail dots — the shadow-exclusion follow-up).
- `fade_to` is the runtime clear color; scenes with bright floors read the fade as
  darkening (scene-derived background sampling later).
- Model copies don't fade (needs a render-path tint uniform).
- Scrubber-UI mode selector (off / trail / strobe) is the next PR.


## Demo

![toss --strobe demo](https://gist.githubusercontent.com/tommy-xr/2e6c23b557e19dad198a4f7b0c1b6bf4/raw/toss-strobe.gif)

<sub>`examples/toss` with `--strobe`: full-intensity copies of each ball at evenly sampled future poses, color-faded by age toward the background. Rendered headlessly via `--input-script` / `--capture-at-frame` / `--capture-frame`.</sub>

| `--strobe` (this PR — scene-space copies) | `--ghost` (existing 1/N-opacity compositor strobe) |
| --- | --- |
| ![toss strobe still](https://gist.githubusercontent.com/tommy-xr/2e6c23b557e19dad198a4f7b0c1b6bf4/raw/toss-strobe-t0.png) | ![toss ghost still](https://gist.githubusercontent.com/tommy-xr/2e6c23b557e19dad198a4f7b0c1b6bf4/raw/toss-ghost-t0.png) |

<sub>Left: `toss --strobe` at `--fixed-time 0.0` — full-intensity orange copies fading toward the background along all three arcs; the resting ball gets no copies. Right: the same scene under the existing screen-space `--ghost` compositor this PR complements — copies pinned at 1/N opacity (~12%), nearly invisible. Same fixed time.</sub>

![toss strobe + trajectory](https://gist.githubusercontent.com/tommy-xr/2e6c23b557e19dad198a4f7b0c1b6bf4/raw/toss-strobe-traj-t0.png)

<sub>`toss --strobe --trajectory` at `--fixed-time 0.0`: strobe copies and the cyan dotted trail compose on the one shared `ghost_frames` forward-sim.</sub>

![physics strobe](https://gist.githubusercontent.com/tommy-xr/2e6c23b557e19dad198a4f7b0c1b6bf4/raw/physics-strobe-t1.png)

<sub>`examples/physics --strobe` at `--fixed-time 1.0`: the rapier crates' copies are visibly **rotated** at their future poses — `mover_tracks` carries the full world matrix, so tumbling crates tumble through their arcs.</sub>
