### PR TITLE
perf: GPU resource counters in frame telemetry (leak tripwire)

### DIFF
--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -119,6 +119,22 @@ pub enum Event {
         #[serde(skip_serializing_if = "Option::is_none")]
         budget_pct: Option<f64>,
         over_n_frames: u32,
+        /// GPU-resource counters (native only): instantaneous live counts, plus
+        /// per-window upload bytes/frame and heightmap-cache hit/miss totals. A
+        /// leak shows as a climbing `gpu_live_*`. `None` on paths that don't
+        /// carry them (none today; reserved for a non-native emitter).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        gpu_live_vaos: Option<u64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        gpu_live_buffers: Option<u64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        gpu_live_textures: Option<u64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        gpu_bytes_per_frame: Option<f64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        gpu_cache_hits: Option<u64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        gpu_cache_misses: Option<u64>,
     },
     /// A `--capture-frame` PNG was written.
     CaptureWritten { path: String },
@@ -155,6 +171,12 @@ impl From<functor_runtime_common::events::RuntimeEvent> for Event {
                 frame_us,
                 budget_pct,
                 over_n_frames,
+                gpu_live_vaos,
+                gpu_live_buffers,
+                gpu_live_textures,
+                gpu_bytes_per_frame,
+                gpu_cache_hits,
+                gpu_cache_misses,
             } => Event::FrameStats {
                 tick_us,
                 draw_us,
@@ -163,6 +185,12 @@ impl From<functor_runtime_common::events::RuntimeEvent> for Event {
                 frame_us: Some(frame_us),
                 budget_pct: Some(budget_pct),
                 over_n_frames,
+                gpu_live_vaos: Some(gpu_live_vaos),
+                gpu_live_buffers: Some(gpu_live_buffers),
+                gpu_live_textures: Some(gpu_live_textures),
+                gpu_bytes_per_frame: Some(gpu_bytes_per_frame),
+                gpu_cache_hits: Some(gpu_cache_hits),
+                gpu_cache_misses: Some(gpu_cache_misses),
             },
             R::CaptureWritten { path } => Event::CaptureWritten { path },
             R::HotReload { ok, message } => Event::HotReload { ok, message },
@@ -324,6 +352,12 @@ impl PlainRenderer {
                 frame_us,
                 budget_pct,
                 over_n_frames,
+                gpu_live_vaos,
+                gpu_live_buffers,
+                gpu_live_textures,
+                gpu_bytes_per_frame,
+                gpu_cache_hits,
+                gpu_cache_misses,
             } => {
                 let mut s = format!("tick {tick_us:.1}µs, draw {draw_us:.1}µs");
                 if let Some(render_us) = render_us {
@@ -337,6 +371,19 @@ impl PlainRenderer {
                 }
                 if let Some(budget_pct) = budget_pct {
                     s.push_str(&format!(" ({budget_pct:.1}% of 60fps)"));
+                }
+                if let (Some(vaos), Some(buffers), Some(textures)) =
+                    (gpu_live_vaos, gpu_live_buffers, gpu_live_textures)
+                {
+                    s.push_str(&format!(
+                        ", gpu vao {vaos}/buf {buffers}/tex {textures}"
+                    ));
+                }
+                if let Some(bytes) = gpu_bytes_per_frame {
+                    s.push_str(&format!(", up {bytes:.0}B/frame"));
+                }
+                if let (Some(hits), Some(misses)) = (gpu_cache_hits, gpu_cache_misses) {
+                    s.push_str(&format!(", cache {hits}hit/{misses}miss"));
                 }
                 vec![format!(
                     "{} {}",

--- a/cli/src/output/live.rs
+++ b/cli/src/output/live.rs
@@ -39,6 +39,11 @@ struct Stats {
     swap_us: Option<f64>,
     frame_us: Option<f64>,
     budget_pct: Option<f64>,
+    /// GPU-resource counters (native): (live vaos, buffers, textures). A leak
+    /// shows as these climbing across samples.
+    gpu_live: Option<(u64, u64, u64)>,
+    gpu_bytes_per_frame: Option<f64>,
+    gpu_cache: Option<(u64, u64)>,
 }
 
 /// The sticky `run native` telemetry panel.
@@ -80,6 +85,27 @@ impl Panel {
                 lines.push(row);
                 if let Some(pct) = s.budget_pct {
                     lines.push(format!("  {}", budget_bar(pct)));
+                }
+                if let Some((vaos, buffers, textures)) = s.gpu_live {
+                    let mut gpu = format!(
+                        "  gpu vao {} · buf {} · tex {}",
+                        format!("{vaos}").cyan(),
+                        format!("{buffers}").cyan(),
+                        format!("{textures}").cyan(),
+                    );
+                    if let Some(bytes) = s.gpu_bytes_per_frame {
+                        gpu.push_str(&format!(
+                            " · up {}",
+                            format!("{bytes:.0}B/f").cyan()
+                        ));
+                    }
+                    if let Some((hits, misses)) = s.gpu_cache {
+                        gpu.push_str(&format!(
+                            " · cache {}",
+                            format!("{hits}/{}", hits + misses).cyan()
+                        ));
+                    }
+                    lines.push(gpu);
                 }
             }
             None => lines.push(format!("  {}", "warming up…".dimmed())),
@@ -222,6 +248,12 @@ impl Renderer for LiveRenderer {
                 frame_us,
                 budget_pct,
                 over_n_frames,
+                gpu_live_vaos,
+                gpu_live_buffers,
+                gpu_live_textures,
+                gpu_bytes_per_frame,
+                gpu_cache_hits,
+                gpu_cache_misses,
             } => {
                 if let Some(panel) = inner.panel.as_mut() {
                     let now = Instant::now();
@@ -232,6 +264,14 @@ impl Renderer for LiveRenderer {
                         }
                     }
                     panel.last_stats_at = Some(now);
+                    let gpu_live = match (gpu_live_vaos, gpu_live_buffers, gpu_live_textures) {
+                        (Some(v), Some(b), Some(t)) => Some((*v, *b, *t)),
+                        _ => None,
+                    };
+                    let gpu_cache = match (gpu_cache_hits, gpu_cache_misses) {
+                        (Some(h), Some(m)) => Some((*h, *m)),
+                        _ => None,
+                    };
                     panel.stats = Some(Stats {
                         tick_us: *tick_us,
                         draw_us: *draw_us,
@@ -239,6 +279,9 @@ impl Renderer for LiveRenderer {
                         swap_us: *swap_us,
                         frame_us: *frame_us,
                         budget_pct: *budget_pct,
+                        gpu_live,
+                        gpu_bytes_per_frame: *gpu_bytes_per_frame,
+                        gpu_cache,
                     });
                     panel.refresh();
                 } else {

--- a/docs/cli-output.md
+++ b/docs/cli-output.md
@@ -211,7 +211,7 @@ used to `println!` directly. PR-2a routes them through the runtime event sink (b
 | `type`            | Fields                                                                           | Emitted when |
 | ----------------- | -------------------------------------------------------------------------------- | ------------ |
 | `runtime_ready`   | —                                                                                | the runtime loaded and is about to render |
-| `frame_stats`     | `tick_us`, `draw_us`, `render_us`?, `swap_us`?, `frame_us`?, `budget_pct`?, `over_n_frames` | every `over_n_frames` frames (300) |
+| `frame_stats`     | `tick_us`, `draw_us`, `render_us`?, `swap_us`?, `frame_us`?, `budget_pct`?, `over_n_frames`, `gpu_live_vaos`?, `gpu_live_buffers`?, `gpu_live_textures`?, `gpu_bytes_per_frame`?, `gpu_cache_hits`?, `gpu_cache_misses`? | every `over_n_frames` frames (300) |
 | `capture_written` | `path` (string)                                                                  | a `--capture-frame` PNG was written |
 | `hot_reload`      | `ok` (bool), `message` (string)                                                  | a hot-reload settled (`ok:false` = rejected edit; old program kept) |
 | `asset_error`     | `path` (string?), `message` (string)                                             | an asset failed to load (fallback served) |
@@ -228,11 +228,20 @@ All are rounded to one decimal. `render_us`/`swap_us` come from the native GL sh
 window (300). This is a per-window,
 **not** per-frame, emission — see the cadence note below.
 
+The `gpu_*` fields (native only) are the GPU-resource counters (`functor_runtime_common::gpu_counters`),
+a leak tripwire: since GL objects have no `Drop`, a resource created every frame and never freed is
+otherwise invisible. `gpu_live_vaos` / `gpu_live_buffers` / `gpu_live_textures` are the **instantaneous**
+live counts (bumped at every `create_*` site, decremented at each explicit `delete`) — a leak class
+(e.g. a per-frame mesh) shows up as one of these climbing sample over sample; they stay flat when
+nothing leaks. `gpu_bytes_per_frame` is the average bytes uploaded per frame over the window
+(`buffer_data`/`buffer_sub_data`/`tex_image` payloads); `gpu_cache_hits`/`gpu_cache_misses` are the
+heightmap-mesh cache's window totals (a healthy animated heightmap is ~all hits after the first frame).
+
 Example tail of `functor -d examples/lighting run native --json` (frame stats + capture):
 
 ```json
 {"type":"runtime_ready"}
-{"type":"frame_stats","tick_us":16.4,"draw_us":163.8,"render_us":210.5,"swap_us":15980.2,"frame_us":180.3,"budget_pct":1.1,"over_n_frames":300}
+{"type":"frame_stats","tick_us":16.4,"draw_us":163.8,"render_us":210.5,"swap_us":15980.2,"frame_us":180.3,"budget_pct":1.1,"over_n_frames":300,"gpu_live_vaos":6,"gpu_live_buffers":11,"gpu_live_textures":4,"gpu_bytes_per_frame":101376.0,"gpu_cache_hits":300,"gpu_cache_misses":0}
 {"type":"capture_written","path":"/tmp/frame.png"}
 ```
 

--- a/runtime/functor-runtime-common/src/events.rs
+++ b/runtime/functor-runtime-common/src/events.rs
@@ -34,6 +34,12 @@ pub enum RuntimeEvent {
     /// blocking) — reported alongside `draw_us` so interpreter cost and GL cost
     /// can be told apart. They are not folded into `frame_us` (swap's vsync block
     /// would peg `budget_pct`).
+    ///
+    /// The `gpu_*` fields are the GPU-resource counters (`gpu_counters`): the
+    /// `gpu_live_*` counts are instantaneous (latest snapshot) and stay flat when
+    /// nothing leaks; `gpu_bytes_per_frame` is the average bytes uploaded per
+    /// frame over the window; `gpu_cache_hits`/`gpu_cache_misses` are the
+    /// heightmap-mesh cache's window totals.
     FrameStats {
         tick_us: f64,
         draw_us: f64,
@@ -42,6 +48,12 @@ pub enum RuntimeEvent {
         frame_us: f64,
         budget_pct: f64,
         over_n_frames: u32,
+        gpu_live_vaos: u64,
+        gpu_live_buffers: u64,
+        gpu_live_textures: u64,
+        gpu_bytes_per_frame: f64,
+        gpu_cache_hits: u64,
+        gpu_cache_misses: u64,
     },
     /// A `--capture-frame` PNG was written to `path`.
     CaptureWritten { path: String },

--- a/runtime/functor-runtime-common/src/geometry/heightmap.rs
+++ b/runtime/functor-runtime-common/src/geometry/heightmap.rs
@@ -54,21 +54,24 @@ impl HeightmapMesh {
                 indices.as_ptr() as *const u8,
                 indices.len() * core::mem::size_of::<u32>(),
             );
+            let counters = crate::gpu_counters::gpu_counters();
             let ebo = gl.create_buffer().unwrap();
+            counters.buffer_created();
             gl.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, Some(ebo));
             gl.buffer_data_u8_slice(glow::ELEMENT_ARRAY_BUFFER, indices_u8, glow::STATIC_DRAW);
+            counters.uploaded(indices_u8.len());
 
             // DYNAMIC_DRAW: the vertex buffer is re-uploaded in place whenever the
             // heights change (see `update`).
             let vbo = gl.create_buffer().unwrap();
+            counters.buffer_created();
             gl.bind_buffer(glow::ARRAY_BUFFER, Some(vbo));
-            gl.buffer_data_u8_slice(
-                glow::ARRAY_BUFFER,
-                vertices_bytes(&vertices),
-                glow::DYNAMIC_DRAW,
-            );
+            let vertices_u8 = vertices_bytes(&vertices);
+            gl.buffer_data_u8_slice(glow::ARRAY_BUFFER, vertices_u8, glow::DYNAMIC_DRAW);
+            counters.uploaded(vertices_u8.len());
 
             let vao = gl.create_vertex_array().unwrap();
+            counters.vao_created();
             gl.bind_vertex_array(Some(vao));
 
             let attributes = <VertexPositionTexture>::get_vertex_attributes();
@@ -116,9 +119,11 @@ impl HeightmapMesh {
         let rows = self.vertices.len() / self.cols;
         fill_vertices(&mut self.vertices, rows, self.cols, heights, &self.indices);
         unsafe {
+            let vertices_u8 = vertices_bytes(&self.vertices);
             gl.bind_buffer(glow::ARRAY_BUFFER, Some(self.vbo));
-            gl.buffer_sub_data_u8_slice(glow::ARRAY_BUFFER, 0, vertices_bytes(&self.vertices));
+            gl.buffer_sub_data_u8_slice(glow::ARRAY_BUFFER, 0, vertices_u8);
             gl.bind_buffer(glow::ARRAY_BUFFER, None);
+            crate::gpu_counters::gpu_counters().uploaded(vertices_u8.len());
         }
         self.heights_hash = hash;
     }

--- a/runtime/functor-runtime-common/src/geometry/indexed_mesh.rs
+++ b/runtime/functor-runtime-common/src/geometry/indexed_mesh.rs
@@ -47,15 +47,21 @@ impl<T: Vertex> RenderableAsset for IndexedMeshData<T> {
                 self.indices.as_ptr() as *const u8,
                 self.indices.len() * core::mem::size_of::<u32>(),
             );
+            let counters = crate::gpu_counters::gpu_counters();
             let ebo = gl.create_buffer().unwrap();
+            counters.buffer_created();
             gl.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, Some(ebo));
             gl.buffer_data_u8_slice(glow::ELEMENT_ARRAY_BUFFER, indices_u8, glow::STATIC_DRAW);
+            counters.uploaded(indices_u8.len());
 
             let vbo = gl.create_buffer().unwrap();
+            counters.buffer_created();
             gl.bind_buffer(glow::ARRAY_BUFFER, Some(vbo));
             gl.buffer_data_u8_slice(glow::ARRAY_BUFFER, vertices_u8, glow::STATIC_DRAW);
+            counters.uploaded(vertices_u8.len());
 
             let vao = gl.create_vertex_array().unwrap();
+            counters.vao_created();
             gl.bind_vertex_array(Some(vao));
 
             let attributes = <T>::get_vertex_attributes();

--- a/runtime/functor-runtime-common/src/gpu_counters.rs
+++ b/runtime/functor-runtime-common/src/gpu_counters.rs
@@ -1,0 +1,121 @@
+//! Process-wide GPU-resource counters — a leak tripwire.
+//!
+//! There are no `Drop` impls for GL resources in this crate (the context isn't
+//! available at drop time); frees happen through explicit `delete(gl)` methods.
+//! A leak — a resource created every frame and never freed — is therefore
+//! invisible to ordinary instrumentation. These counters make it a visibly
+//! climbing number: every `create_*` site bumps a live count, every explicit
+//! delete decrements it, so a leak class shows up as a monotonically rising
+//! `live_buffers`/`live_vaos`/`live_textures` in the frame-stats stream.
+//!
+//! It is a global (a single `static` of atomics), not a struct threaded through
+//! the create sites, because those sites are scattered across trait impls
+//! (`RenderableAsset::hydrate`, `Geometry::draw`, `RenderTargetBuffers`, …) with
+//! no shared owner to thread through, and the native runtime is a single process
+//! with a single GL context. Bumping a `Relaxed` atomic is the entire cost at
+//! each site — no signature churn, matching "don't refactor create sites beyond
+//! adding the increment".
+//!
+//! Native-only reads it (the desktop `FrameStats` reporter drains it each stats
+//! window); the shared create sites still bump it on wasm, harmlessly unread.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// The counters. `live_*` persist across frames (current count of alive GL
+/// objects); the rest are per-window accumulators the reporter drains with
+/// [`take_window`](GpuCounters::take_window).
+pub struct GpuCounters {
+    live_vaos: AtomicU64,
+    live_buffers: AtomicU64,
+    live_textures: AtomicU64,
+    bytes_uploaded: AtomicU64,
+    cache_hits: AtomicU64,
+    cache_misses: AtomicU64,
+}
+
+static COUNTERS: GpuCounters = GpuCounters::new();
+
+/// The process-wide counters.
+pub fn gpu_counters() -> &'static GpuCounters {
+    &COUNTERS
+}
+
+/// A snapshot of the live counts — instantaneous, so reported as the latest.
+#[derive(Debug, Clone, Copy)]
+pub struct GpuLive {
+    pub vaos: u64,
+    pub buffers: u64,
+    pub textures: u64,
+}
+
+/// The per-window accumulators, as drained by [`GpuCounters::take_window`].
+#[derive(Debug, Clone, Copy)]
+pub struct GpuWindow {
+    pub bytes_uploaded: u64,
+    pub cache_hits: u64,
+    pub cache_misses: u64,
+}
+
+impl GpuCounters {
+    const fn new() -> Self {
+        GpuCounters {
+            live_vaos: AtomicU64::new(0),
+            live_buffers: AtomicU64::new(0),
+            live_textures: AtomicU64::new(0),
+            bytes_uploaded: AtomicU64::new(0),
+            cache_hits: AtomicU64::new(0),
+            cache_misses: AtomicU64::new(0),
+        }
+    }
+
+    pub fn vao_created(&self) {
+        self.live_vaos.fetch_add(1, Ordering::Relaxed);
+    }
+    pub fn vao_deleted(&self) {
+        self.live_vaos.fetch_sub(1, Ordering::Relaxed);
+    }
+    pub fn buffer_created(&self) {
+        self.live_buffers.fetch_add(1, Ordering::Relaxed);
+    }
+    pub fn buffer_deleted(&self) {
+        self.live_buffers.fetch_sub(1, Ordering::Relaxed);
+    }
+    pub fn texture_created(&self) {
+        self.live_textures.fetch_add(1, Ordering::Relaxed);
+    }
+    pub fn texture_deleted(&self) {
+        self.live_textures.fetch_sub(1, Ordering::Relaxed);
+    }
+
+    /// Record `bytes` uploaded to the GPU this frame (a `buffer_data` /
+    /// `buffer_sub_data` / `tex_image` payload).
+    pub fn uploaded(&self, bytes: usize) {
+        self.bytes_uploaded.fetch_add(bytes as u64, Ordering::Relaxed);
+    }
+
+    pub fn cache_hit(&self) {
+        self.cache_hits.fetch_add(1, Ordering::Relaxed);
+    }
+    pub fn cache_miss(&self) {
+        self.cache_misses.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// The current live counts.
+    pub fn live(&self) -> GpuLive {
+        GpuLive {
+            vaos: self.live_vaos.load(Ordering::Relaxed),
+            buffers: self.live_buffers.load(Ordering::Relaxed),
+            textures: self.live_textures.load(Ordering::Relaxed),
+        }
+    }
+
+    /// Read and zero the per-window accumulators. Called once per stats window,
+    /// so the returned totals cover exactly the frames since the last drain.
+    pub fn take_window(&self) -> GpuWindow {
+        GpuWindow {
+            bytes_uploaded: self.bytes_uploaded.swap(0, Ordering::Relaxed),
+            cache_hits: self.cache_hits.swap(0, Ordering::Relaxed),
+            cache_misses: self.cache_misses.swap(0, Ordering::Relaxed),
+        }
+    }
+}

--- a/runtime/functor-runtime-common/src/lib.rs
+++ b/runtime/functor-runtime-common/src/lib.rs
@@ -56,6 +56,7 @@ mod camera;
 pub mod composite;
 pub mod events;
 pub mod fog;
+pub mod gpu_counters;
 mod frame;
 mod frame_time;
 pub mod game_clock;

--- a/runtime/functor-runtime-common/src/render_target.rs
+++ b/runtime/functor-runtime-common/src/render_target.rs
@@ -75,6 +75,7 @@ impl RenderTargetBuffers {
             let mut textures = [None; 2];
             for i in 0..2 {
                 let texture = gl.create_texture().expect("render target texture");
+                crate::gpu_counters::gpu_counters().texture_created();
                 gl.bind_texture(glow::TEXTURE_2D, Some(texture));
                 gl.tex_image_2d(
                     glow::TEXTURE_2D,
@@ -177,6 +178,7 @@ impl RenderTargetBuffers {
             }
             for texture in self.textures {
                 gl.delete_texture(texture);
+                crate::gpu_counters::gpu_counters().texture_deleted();
             }
             gl.delete_renderbuffer(self.depth_rbo);
         }

--- a/runtime/functor-runtime-common/src/renderer.rs
+++ b/runtime/functor-runtime-common/src/renderer.rs
@@ -512,9 +512,12 @@ pub fn render_debug_lines(
             mvp_raw,
         );
 
+        let counters = crate::gpu_counters::gpu_counters();
         let vao = gl.create_vertex_array().expect("create debug line vao");
+        counters.vao_created();
         gl.bind_vertex_array(Some(vao));
         let vbo = gl.create_buffer().expect("create debug line vbo");
+        counters.buffer_created();
         gl.bind_buffer(glow::ARRAY_BUFFER, Some(vbo));
         // Same raw-bytes view the mesh upload path uses (indexed_mesh.rs).
         let vertices_u8: &[u8] = core::slice::from_raw_parts(
@@ -522,6 +525,7 @@ pub fn render_debug_lines(
             std::mem::size_of_val(vertices.as_slice()),
         );
         gl.buffer_data_u8_slice(glow::ARRAY_BUFFER, vertices_u8, glow::STREAM_DRAW);
+        counters.uploaded(vertices_u8.len());
         let stride = (7 * std::mem::size_of::<f32>()) as i32;
         gl.enable_vertex_attrib_array(0);
         gl.vertex_attrib_pointer_f32(0, 3, glow::FLOAT, false, stride, 0);
@@ -539,7 +543,9 @@ pub fn render_debug_lines(
         gl.bind_buffer(glow::ARRAY_BUFFER, None);
         gl.use_program(None);
         gl.delete_buffer(vbo);
+        counters.buffer_deleted();
         gl.delete_vertex_array(vao);
+        counters.vao_deleted();
         gl.delete_program(program);
     }
 }

--- a/runtime/functor-runtime-common/src/scene3d/mod.rs
+++ b/runtime/functor-runtime-common/src/scene3d/mod.rs
@@ -160,6 +160,7 @@ impl SceneContext {
         let mut fallback = self.fallback_texture.borrow_mut();
         *fallback.get_or_insert_with(|| unsafe {
             let texture = gl.create_texture().expect("fallback texture");
+            crate::gpu_counters::gpu_counters().texture_created();
             gl.bind_texture(glow::TEXTURE_2D, Some(texture));
             gl.tex_image_2d(
                 glow::TEXTURE_2D,
@@ -172,6 +173,7 @@ impl SceneContext {
                 glow::UNSIGNED_BYTE,
                 glow::PixelUnpackData::Slice(Some(&[255, 0, 255, 255])),
             );
+            crate::gpu_counters::gpu_counters().uploaded(4);
             gl.tex_parameter_i32(
                 glow::TEXTURE_2D,
                 glow::TEXTURE_MIN_FILTER,
@@ -266,6 +268,7 @@ skybox disabled for this set",
                 }
                 let texture = unsafe {
                     let texture = gl.create_texture().expect("skybox cubemap");
+                    crate::gpu_counters::gpu_counters().texture_created();
                     gl.bind_texture(glow::TEXTURE_CUBE_MAP, Some(texture));
                     for (i, face) in faces.iter().enumerate() {
                         gl.tex_image_2d(
@@ -279,6 +282,7 @@ skybox disabled for this set",
                             glow::UNSIGNED_BYTE,
                             glow::PixelUnpackData::Slice(Some(&face.bytes)),
                         );
+                        crate::gpu_counters::gpu_counters().uploaded(face.bytes.len());
                     }
                     gl.tex_parameter_i32(
                         glow::TEXTURE_CUBE_MAP,
@@ -930,14 +934,22 @@ named \"{name}\" — {hint}"
                 // then re-upload its vertices in place only when the heights change
                 // (a no-op for static terrain). No per-frame VAO/VBO/EBO churn.
                 let mut heightmaps = scene_context.heightmaps.borrow_mut();
-                let mesh = heightmaps.entry((*rows, *cols)).or_insert_with(|| {
-                    geometry::HeightmapMesh::create(
-                        &render_context.gl,
-                        *rows as usize,
-                        *cols as usize,
-                        heights,
-                    )
-                });
+                let counters = crate::gpu_counters::gpu_counters();
+                let mesh = match heightmaps.entry((*rows, *cols)) {
+                    std::collections::hash_map::Entry::Occupied(e) => {
+                        counters.cache_hit();
+                        e.into_mut()
+                    }
+                    std::collections::hash_map::Entry::Vacant(e) => {
+                        counters.cache_miss();
+                        e.insert(geometry::HeightmapMesh::create(
+                            &render_context.gl,
+                            *rows as usize,
+                            *cols as usize,
+                            heights,
+                        ))
+                    }
+                };
                 mesh.update(&render_context.gl, heights);
                 mesh.draw(&render_context.gl);
             }

--- a/runtime/functor-runtime-common/src/shadow.rs
+++ b/runtime/functor-runtime-common/src/shadow.rs
@@ -24,6 +24,7 @@ impl ShadowMap {
     pub fn new(gl: &glow::Context, size: u32) -> ShadowMap {
         unsafe {
             let depth_texture = gl.create_texture().expect("shadow depth texture");
+            crate::gpu_counters::gpu_counters().texture_created();
             gl.bind_texture(glow::TEXTURE_2D, Some(depth_texture));
             gl.tex_image_2d(
                 glow::TEXTURE_2D,

--- a/runtime/functor-runtime-common/src/texture/texture_2d.rs
+++ b/runtime/functor-runtime-common/src/texture/texture_2d.rs
@@ -48,6 +48,7 @@ impl RenderableAsset for TextureData {
         unsafe {
             let gl = gl_context;
             let texture = gl.create_texture().expect("Texture to be created");
+            crate::gpu_counters::gpu_counters().texture_created();
             gl.bind_texture(glow::TEXTURE_2D, Some(texture));
 
             // Set texture parameters
@@ -84,6 +85,7 @@ impl RenderableAsset for TextureData {
                 glow::UNSIGNED_BYTE,
                 glow::PixelUnpackData::Slice(Some(&self.bytes)),
             );
+            crate::gpu_counters::gpu_counters().uploaded(self.bytes.len());
 
             gl.bind_texture(glow::TEXTURE_2D, None);
             texture

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -487,6 +487,9 @@ impl FunctorLangGame {
             let render_us = self.render_ns as f64 / STATS_EVERY as f64 / 1000.0;
             let swap_us = self.swap_ns as f64 / STATS_EVERY as f64 / 1000.0;
             let frame_us = tick_us + physics_us + draw_us;
+            let counters = functor_runtime_common::gpu_counters::gpu_counters();
+            let live = counters.live();
+            let window = counters.take_window();
             events::emit(RuntimeEvent::FrameStats {
                 tick_us: round1(tick_us),
                 draw_us: round1(draw_us),
@@ -495,6 +498,12 @@ impl FunctorLangGame {
                 frame_us: round1(frame_us),
                 budget_pct: round1(frame_us / 16_666.0 * 100.0),
                 over_n_frames: STATS_EVERY as u32,
+                gpu_live_vaos: live.vaos,
+                gpu_live_buffers: live.buffers,
+                gpu_live_textures: live.textures,
+                gpu_bytes_per_frame: round1(window.bytes_uploaded as f64 / STATS_EVERY as f64),
+                gpu_cache_hits: window.cache_hits,
+                gpu_cache_misses: window.cache_misses,
             });
             self.tick_ns = 0;
             self.physics_ns = 0;


### PR DESCRIPTION
**Stacked on #317** (`perf/heightmap-mesh-leak`) — base that PR into `main` first, or this PR's diff will include #317's commit. Opened against `perf/heightmap-mesh-leak` per the stacked-PR workflow.

## What

Adds GPU-resource counters to the frame telemetry so resource leaks show up as a **visibly climbing number**. #317 fixed one instance of a fresh VAO/VBO/EBO created and orphaned every frame — a leak that was invisible to all existing instrumentation because there are **no `Drop` impls for GL objects** (the context isn't available at drop; frees go through explicit `delete(gl)` methods). This is the measurement follow-up: make that leak *class* observable.

New `functor_runtime_common::gpu_counters` — a process-wide `static` of `Relaxed` atomics:

- **live counts** — VAOs, buffers (VBO/EBO), textures. Incremented at every `create_*` site in the runtime (geometry `hydrate`, heightmap mesh, texture upload, render targets, skybox, shadow map, fallback texture, debug lines), decremented at the explicit delete sites (render-target recreate, debug-line teardown).
- **bytes uploaded per frame** — sum of `buffer_data`/`buffer_sub_data`/`tex_image` payloads, averaged over the window.
- **heightmap-mesh cache hits vs misses** — the per-frame cache in `scene3d/mod.rs`.

Surfaced in the existing `FrameStats` pipeline (native only, following the `tick_us`/`draw_us` pattern — 300-frame window; live counts reported as the latest snapshot, per-window accumulators averaged/totaled): `RuntimeEvent::FrameStats`, the ndjson `--json` stream, the live panel, and the plain renderer. `docs/cli-output.md` updated.

### Design

A global `static` rather than a struct threaded through the create sites: those sites are scattered across trait impls (`RenderableAsset::hydrate`, `Geometry::draw`, `RenderTargetBuffers`, …) with no shared owner to thread through, and the native runtime is a single process with a single GL context. Bumping an atomic is the entire cost at each site — no signature churn, matching "don't refactor create sites beyond adding the increment." The plumbing lives in `functor-runtime-common`, so `cargo check -p functor_runtime_common --target wasm32-unknown-unknown` stays clean (the shared create sites still bump on wasm, harmlessly unread).

## Verification

`./target/debug/functor --json -d examples/synthwave run native --capture-frame … --capture-time 14`, two 300-frame windows (early + late):

```json
{"type":"frame_stats", … ,"gpu_live_vaos":3,"gpu_live_buffers":6,"gpu_live_textures":3,"gpu_bytes_per_frame":75925.9,"gpu_cache_hits":446,"gpu_cache_misses":1}
{"type":"frame_stats", … ,"gpu_live_vaos":3,"gpu_live_buffers":6,"gpu_live_textures":3,"gpu_bytes_per_frame":76544.0,"gpu_cache_hits":456,"gpu_cache_misses":0}
```

Post-#317: **live counts FLAT** (vaos 3 / buffers 6 / textures 3 across both windows), bytes-uploaded-per-frame steady at ~76 KB (the heightmap vertex buffer, re-uploaded in place each frame), heightmap cache hit rate ≈ 100% after the first frame (1 miss total, then 0).

### Leak-class validation (the whole point)

Temporarily keyed the heightmap cache by a per-frame counter (simulating the pre-#317 leak — a fresh GL mesh every frame), rebuilt, re-ran, then restored:

```json
{"type":"frame_stats", … ,"gpu_live_vaos":430,"gpu_live_buffers":860, … ,"gpu_cache_hits":0,"gpu_cache_misses":428}
{"type":"frame_stats", … ,"gpu_live_vaos":864,"gpu_live_buffers":1728, … ,"gpu_cache_hits":0,"gpu_cache_misses":434}
```

`gpu_live_vaos` 430→864 (+~1/frame), `gpu_live_buffers` 860→1728 (+~2/frame), cache all-misses — the leak is a loudly climbing number. Restored to the cached path (diff verified clean).

## Tests

- `cargo test -p functor_runtime_common` — 252 passed, 0 failed.
- `cargo check -p functor_runtime_common` (native) and `--target wasm32-unknown-unknown` — both clean.
- `npm run build:cli` — builds.

## Review

Ran cross-engine adversarial review (Claude + Codex). No Critical/High findings on the change. Claude verified windowing correctness, no counter underflow, correct cache hit/miss accounting, and that counting persistent one-time resources (primitives, shadow/fallback textures) is intended. Codex's findings were all pre-existing base-branch (#317) code (cache eviction TODO, height hash, index rebuild, soak test), out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)