### PR TITLE
feat(time-travel): scene-diff preview in the scrubber, both shells (T6)

### DIFF
--- a/runtime/functor-runtime-common/src/lib.rs
+++ b/runtime/functor-runtime-common/src/lib.rs
@@ -100,7 +100,8 @@ pub use renderer::*;
 pub use skybox::SkyboxDescription;
 pub use scene3d::*;
 pub use trajectory::{
-    overlay, scene_preview, trajectory_trail, PreviewOptions, ScenePreview, StrobeOptions,
+    overlay, scene_preview, trajectory_trail, PreviewMode, PreviewOptions, ScenePreview,
+    StrobeOptions,
 };
 pub use viewport::*;
 

--- a/runtime/functor-runtime-common/src/trajectory.rs
+++ b/runtime/functor-runtime-common/src/trajectory.rs
@@ -414,6 +414,54 @@ pub fn overlay(scene: &mut Scene3D, trail: Scene3D) {
     };
 }
 
+/// The interactive scene-diff preview mode — what the scrubber's selector (and
+/// the `--trajectory`/`--strobe` launch flags, which seed it) ask the shell to
+/// overlay. Shared by both shells so the wire encoding and cycle order match.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum PreviewMode {
+    #[default]
+    Off,
+    Trail,
+    Strobe,
+    Both,
+}
+
+impl PreviewMode {
+    pub fn wants_trail(self) -> bool {
+        matches!(self, PreviewMode::Trail | PreviewMode::Both)
+    }
+    pub fn wants_strobe(self) -> bool {
+        matches!(self, PreviewMode::Strobe | PreviewMode::Both)
+    }
+    /// Cycle order for a one-button UI: off → trail → strobe → both → off.
+    pub fn next(self) -> PreviewMode {
+        match self {
+            PreviewMode::Off => PreviewMode::Trail,
+            PreviewMode::Trail => PreviewMode::Strobe,
+            PreviewMode::Strobe => PreviewMode::Both,
+            PreviewMode::Both => PreviewMode::Off,
+        }
+    }
+    pub fn label(self) -> &'static str {
+        match self {
+            PreviewMode::Off => "off",
+            PreviewMode::Trail => "trail",
+            PreviewMode::Strobe => "strobe",
+            PreviewMode::Both => "both",
+        }
+    }
+    /// Stable wire encoding for the wasm scrubber bridge (the DOM `<select>`
+    /// values); anything unknown is `Off`.
+    pub fn from_index(i: u32) -> PreviewMode {
+        match i {
+            1 => PreviewMode::Trail,
+            2 => PreviewMode::Strobe,
+            3 => PreviewMode::Both,
+            _ => PreviewMode::Off,
+        }
+    }
+}
+
 /// What [`scene_preview`] should compute.
 pub struct PreviewOptions {
     /// Forward-sim divisions (samples). Not bound by the screen-space

--- a/runtime/functor-runtime-common/src/ui.rs
+++ b/runtime/functor-runtime-common/src/ui.rs
@@ -692,6 +692,10 @@ pub struct ScrubberState {
     pub ghost_divisions: usize,
     /// The forward window in seconds; `dt = ghost_window / ghost_divisions`.
     pub ghost_window: f32,
+    /// Scene-diff preview mode (docs/time-travel.md T6): trail dots and/or
+    /// scene-space strobe copies. Interactive companion to the
+    /// `--trajectory`/`--strobe` launch flags.
+    pub preview_mode: crate::trajectory::PreviewMode,
 }
 
 /// A control the user activated in the scrubber this frame.
@@ -708,6 +712,8 @@ pub enum ScrubberAction {
     SetGhostDivisions(usize),
     /// Set the ghost's forward window in seconds.
     SetGhostWindow(f32),
+    /// Set the scene-diff preview mode (the `preview:` cycle button).
+    SetPreviewMode(crate::trajectory::PreviewMode),
 }
 
 /// The scrubber's output for one frame.
@@ -843,6 +849,20 @@ impl Scrubber {
                                 .changed()
                             {
                                 action = Some(ScrubberAction::SetGhostWindow(window));
+                            }
+
+                            // Scene-diff preview (docs/time-travel.md T6): a
+                            // compact cycle button (off → trail → strobe → both)
+                            // — one widget until the scrubber declutter pass
+                            // gives previews a proper popover.
+                            ui.separator();
+                            if ui
+                                .button(format!("preview: {}", state.preview_mode.label()))
+                                .clicked()
+                            {
+                                action = Some(ScrubberAction::SetPreviewMode(
+                                    state.preview_mode.next(),
+                                ));
                             }
                         });
                     });

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -877,6 +877,18 @@ pub fn run(args: Args) {
         let mut ghost_on = args.ghost;
         let mut ghost_divisions = args.ghost_divisions;
         let mut ghost_window: f32 = 2.0;
+        // Scene-diff preview (docs/time-travel.md T6) state, driven
+        // interactively from the scrubber's `preview:` cycle button. Seeded
+        // from the launch flags so `--trajectory`/`--strobe` (the
+        // headless-capture escape hatch, overlay hidden) are unchanged; when
+        // the overlay is up, this var takes over (the `active_preview` gate).
+        let args_preview = match (args.trajectory, args.strobe) {
+            (true, true) => functor_runtime_common::PreviewMode::Both,
+            (true, false) => functor_runtime_common::PreviewMode::Trail,
+            (false, true) => functor_runtime_common::PreviewMode::Strobe,
+            (false, false) => functor_runtime_common::PreviewMode::Off,
+        };
+        let mut preview_mode = args_preview;
         // --trajectory/--strobe preview cache. The 32-division forward-sim is
         // the expensive part, and while PAUSED its anchor (scene frame + tts) is
         // frozen — so reuse the computed preview while the anchor key matches,
@@ -886,7 +898,7 @@ pub fn run(args: Args) {
         // --ghost does.
         const TRAIL_REFRESH_FRAMES: u32 = 30;
         let mut trail_cache: Option<(
-            (Option<u64>, u32, bool),
+            (Option<u64>, u32, bool, bool),
             functor_runtime_common::ScenePreview,
         )> = None;
         let mut trail_refresh: u32 = 0;
@@ -1288,23 +1300,40 @@ Escape again to quit"
             // from ONE forward-sim. Same gating as ghost (interactive only while
             // the scrubber is paused; headless via the flags, so it's
             // deterministically capturable).
-            let trail_wanted = args.trajectory;
+            // Interactive preview follows the ghost rule: with the overlay up
+            // it renders only while PAUSED (forward-stepping every LIVE frame
+            // tanks the framerate); with the overlay hidden the launch flags
+            // drive it, so headless captures are byte-for-byte unchanged.
+            let active_preview = if scrubber_visible {
+                if clock.is_paused() {
+                    preview_mode
+                } else {
+                    functor_runtime_common::PreviewMode::Off
+                }
+            } else {
+                args_preview
+            };
+            let trail_wanted = active_preview.wants_trail();
             // Under the screen-space ghost compositor the scene-space strobe
             // would double-ghost — and the compositor arm never draws the
             // display frame — so while the ghost is active the strobe is off
             // (the trail still shows: it rides IN the composited frames), and
             // it must not silently burn a forward-sim it can't display.
-            let strobe_wanted = args.strobe && !ghost_active;
+            let strobe_wanted = active_preview.wants_strobe() && !ghost_active;
             let preview_active = (trail_wanted || strobe_wanted)
-                && args.composite_demo == CompositeDemoArg::Off
-                && (!scrubber_visible || clock.is_paused());
+                && args.composite_demo == CompositeDemoArg::Off;
             let preview: Option<functor_runtime_common::ScenePreview> = if preview_active {
                 // Not bound by the 8-target compositor cap — this only reads node
                 // transforms — so sample finely for a smooth arc.
                 let divisions = 32usize;
                 let window = 1.6f32;
                 let dt = window / divisions as f32;
-                let key = (game.current_scene_frame(), time.tts.to_bits(), strobe_wanted);
+                let key = (
+                    game.current_scene_frame(),
+                    time.tts.to_bits(),
+                    trail_wanted,
+                    strobe_wanted,
+                );
                 let cache_hit = trail_refresh > 0
                     && trail_cache.as_ref().is_some_and(|(k, _)| *k == key);
                 if cache_hit {
@@ -1690,6 +1719,7 @@ Escape again to quit"
                         ghost_on,
                         ghost_divisions,
                         ghost_window,
+                        preview_mode,
                     },
                 )
             } else {
@@ -1758,6 +1788,12 @@ Escape again to quit"
                 }
                 Some(functor_runtime_common::ui::ScrubberAction::SetGhostWindow(w)) => {
                     ghost_window = w.clamp(0.5, 5.0);
+                }
+                Some(functor_runtime_common::ui::ScrubberAction::SetPreviewMode(m)) => {
+                    if args.debug_clock {
+                        eprintln!("[clock] preview {}", m.label());
+                    }
+                    preview_mode = m;
                 }
                 None => {}
             }

--- a/runtime/functor-runtime-web/index-functor-lang.html
+++ b/runtime/functor-runtime-web/index-functor-lang.html
@@ -48,6 +48,12 @@
         border-radius: 5px; padding: 4px 5px;
       }
       #scrub-ghost { accent-color: #e0803a; }
+      /* Scene-diff preview (docs/time-travel.md T6): trail / strobe selector. */
+      #scrub-preview {
+        font: 12px/1 monospace; color: #eee;
+        background: rgba(80,80,90,0.6); border: 1px solid rgba(255,255,255,0.15);
+        border-radius: 5px; padding: 4px 5px;
+      }
     </style>
   </head>
   <body>
@@ -66,6 +72,14 @@
       </label>
       <label title="Ghost window (seconds)">
         <input id="scrub-ghost-win" type="number" step="0.5" value="2" />s
+      </label>
+      <label title="Scene-diff preview while paused: dotted trail and/or scene-space strobe copies of whatever moves (docs/time-travel.md T6)">
+        <select id="scrub-preview">
+          <option value="0" selected>preview: off</option>
+          <option value="1">preview: trail</option>
+          <option value="2">preview: strobe</option>
+          <option value="3">preview: both</option>
+        </select>
       </label>
     </div>
     <script type="module">
@@ -87,6 +101,7 @@
         functor_lang_scrub_step,
         functor_lang_scrub_paused,
         functor_lang_scrub_set_ghost,
+        functor_lang_scrub_set_preview,
       } from "./pkg/functor_runtime_web.js";
 
       // The Functor Lang entry file, substituted in by the CLI's dev server (see
@@ -252,6 +267,16 @@
         ghost.addEventListener("change", pushGhost);
         ghostDiv.addEventListener("input", pushGhost);
         ghostWin.addEventListener("input", pushGhost);
+
+        // Scene-diff preview (docs/time-travel.md T6): JS owns the selector
+        // state and pushes the mode index (0 off / 1 trail / 2 strobe / 3 both)
+        // on change; the frame loop overlays while paused. Pushed once at setup
+        // too: the browser may restore the select's value across a reload while
+        // the fresh runtime starts at Off.
+        const preview = document.getElementById("scrub-preview");
+        const pushPreview = () => functor_lang_scrub_set_preview(+preview.value);
+        preview.addEventListener("change", pushPreview);
+        pushPreview();
 
         const update = () => {
           if (pendingSeek !== null) {

--- a/runtime/functor-runtime-web/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-web/src/functor_lang_game.rs
@@ -1026,6 +1026,10 @@ pub enum ScrubControl {
         divisions: usize,
         window: f32,
     },
+    /// Scene-diff preview mode (docs/time-travel.md T6), pushed by the DOM
+    /// preview `<select>` (PreviewMode wire index: 0 off / 1 trail / 2 strobe /
+    /// 3 both). The frame loop owns the preview state.
+    SetPreview(u32),
 }
 
 thread_local! {
@@ -1083,6 +1087,13 @@ pub fn functor_lang_scrub_set_ghost(on: bool, divisions: usize, window: f32) {
         divisions,
         window,
     });
+}
+
+/// Page → runtime: set the scene-diff preview mode (the DOM preview `<select>`;
+/// 0 off / 1 trail / 2 strobe / 3 both — `PreviewMode::from_index`).
+#[wasm_bindgen]
+pub fn functor_lang_scrub_set_preview(mode: u32) {
+    push_scrub(ScrubControl::SetPreview(mode));
 }
 
 /// Page → runtime: non-destructively scrub to a rendered frame (slider drag).

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -1063,6 +1063,19 @@ async fn run_async() -> Result<(), JsValue> {
         let mut ghost_divisions: usize = 8;
         let mut ghost_window: f32 = 2.0;
 
+        // Scene-diff preview (docs/time-travel.md T6): trail dots and/or
+        // scene-space strobe copies, driven by the DOM preview <select>. Same
+        // anchor cache as the desktop shell: while paused the anchor (scene
+        // frame + tts) is frozen, so reuse the computed preview; the refresh
+        // bound re-projects a pushed source edit within ~half a second.
+        let mut preview_mode = functor_runtime_common::PreviewMode::Off;
+        const PREVIEW_REFRESH_FRAMES: u32 = 30;
+        let mut preview_cache: Option<(
+            (Option<u64>, u32, bool, bool),
+            functor_runtime_common::ScenePreview,
+        )> = None;
+        let mut preview_refresh: u32 = 0;
+
         *g.borrow_mut() = Some(Closure::new(move || {
             // The frame's exclusive borrow of the shared producer.
             let mut game = game.borrow_mut();
@@ -1098,6 +1111,9 @@ async fn run_async() -> Result<(), JsValue> {
                         ghost_on = on;
                         ghost_divisions = divisions;
                         ghost_window = window;
+                    }
+                    functor_lang_game::ScrubControl::SetPreview(mode) => {
+                        preview_mode = functor_runtime_common::PreviewMode::from_index(mode);
                     }
                     functor_lang_game::ScrubControl::SeekTo(f) => {
                         let _ = game.seek_scene_to(f);
@@ -1148,11 +1164,62 @@ async fn run_async() -> Result<(), JsValue> {
             dispatch_audio_commands(&**game);
             dispatch_conn_commands(&**game, &ws_state);
 
-            let frame: Frame = game.render(frame_time.clone());
+            let mut frame: Frame = game.render(frame_time.clone());
 
             // Soundscape: aim the listener from this frame's camera, then
             // reconcile the desired looping voices against the live ones.
             update_soundscape(&**game, &frame.camera);
+
+            // Scene-diff preview (docs/time-travel.md T6): the DOM preview
+            // <select>'s trail/strobe overlays, from ONE shared forward-sim —
+            // `scene_preview`, the same step the desktop shell runs. The web
+            // scrubber is always visible, so like the ghost it renders only
+            // while PAUSED. Script inputs are `None`: web has no --input-script.
+            let paused = clock.is_paused();
+            let trail_wanted = preview_mode.wants_trail() && paused;
+            // Under the screen-space ghost compositor the scene-space strobe
+            // would double-ghost — and the compositor arm never draws this
+            // frame — so the strobe yields to the ghost (the trail still shows:
+            // it rides IN the composited frames below).
+            let strobe_wanted = preview_mode.wants_strobe() && paused && !ghost_on;
+            let preview = if trail_wanted || strobe_wanted {
+                let key = (
+                    game.current_scene_frame(),
+                    frame_time.tts.to_bits(),
+                    trail_wanted,
+                    strobe_wanted,
+                );
+                let cache_hit = preview_refresh > 0
+                    && preview_cache.as_ref().is_some_and(|(k, _)| *k == key);
+                if cache_hit {
+                    preview_refresh -= 1;
+                    preview_cache.as_ref().map(|(_, p)| p.clone())
+                } else {
+                    let p = functor_runtime_common::scene_preview(
+                        &**game,
+                        &frame.scene,
+                        frame_time.tts as f64,
+                        None,
+                        &functor_runtime_common::PreviewOptions {
+                            divisions: 32,
+                            window: 1.6,
+                            // eps 0.04: ignore sub-mm jitter. max_step 3.0: cut
+                            // respawn teleports.
+                            eps: 0.04,
+                            max_step: 3.0,
+                            trail: trail_wanted,
+                            strobe: strobe_wanted
+                                .then(functor_runtime_common::StrobeOptions::default),
+                        },
+                    );
+                    preview_refresh = PREVIEW_REFRESH_FRAMES;
+                    preview_cache = Some((key, p.clone()));
+                    Some(p)
+                }
+            } else {
+                preview_cache = None;
+                None
+            };
 
             // Match the drawable buffer to the canvas's displayed (CSS) size,
             // scaled for HiDPI, so the view follows browser/window resizes. In
@@ -1198,6 +1265,27 @@ async fn run_async() -> Result<(), JsValue> {
             } else {
                 Vec::new()
             };
+
+            // The trail composes with the ghost strobe by riding IN each
+            // composited frame (identical opaque geometry at identical world
+            // positions reconstructs at full intensity under the equal-weight
+            // average); otherwise the preview overlays go on the live frame.
+            let mut ghosts = ghosts;
+            if let Some(t) = preview.as_ref().and_then(|p| p.trail.as_ref()) {
+                for (f, _) in ghosts.iter_mut() {
+                    functor_runtime_common::overlay(&mut f.scene, t.clone());
+                }
+            }
+            if ghosts.is_empty() {
+                if let Some(p) = &preview {
+                    if let Some(t) = &p.trail {
+                        functor_runtime_common::overlay(&mut frame.scene, t.clone());
+                    }
+                    if let Some(s) = &p.strobe {
+                        functor_runtime_common::overlay(&mut frame.scene, s.clone());
+                    }
+                }
+            }
 
             // Shadow + forward passes, shared with the desktop runtime. Each
             // ghost frame renders at ITS OWN division-boundary time, so


### PR DESCRIPTION
## Scene-diff preview in the scrubber — both shells (T6)

Builds on #318 (merged). Promotes `--trajectory`/`--strobe` from launch flags to an
interactive scrubber control, and brings the preview to the **web shell for the
first time** (it becomes a small consumer of #318's shared `scene_preview`).

- **Shared `PreviewMode`** (off / trail / strobe / both) in
  `functor-runtime-common` — selector semantics, cycle order, and the wasm wire
  encoding in one place.
- **Desktop**: a compact `preview: <mode>` cycle button in the egui scrubber,
  seeded from the launch flags. Gating follows the ghost rule exactly
  (interactive only while paused; flags drive the headless path — captures
  verified **byte-identical** pre/post).
- **Web**: a `preview` `<select>` in the DOM scrubber →
  `functor_lang_scrub_set_preview` → the frame loop runs the shared `scene_preview`
  with the same anchor cache; the trail rides in composited ghost frames;
  otherwise trail/strobe overlay the live frame. The select's value is pushed
  once at setup (browsers restore form state across reloads while the runtime
  starts at Off — xreview finding).

### Verified

- 260 common-crate tests; strict native checks + `wasm32` check; wasm bundle +
  CLI rebuilt.
- Flag-path captures byte-identical to the pre-change captures (the promotion
  is purely additive).
- **End-to-end Playwright run** driving the real DOM scrubber: pause → select
  trail / strobe / both / off, asserting cyan trail pixels appear, the strobe
  changes the frame, and off restores the paused frame **byte-identically**.
- Cross-engine review (Claude + Codex): clean; one Low fixed (setup-time select
  push).

### Notes

- With the overlay hidden on desktop, the launch flags drive the preview (the
  ghost rule) — so cycling to `off` interactively and then hiding the scrubber
  resurrects a flag-enabled preview. Documented behavior, inherited from ghost;
  the scrubber redesign PR revisits both together.
- Next (PR 4): faded out-of-flow frame counter, a translucent "future window"
  segment on the timeline while a preview is active, and ghost folded into the
  mode selector with a ⚙ advanced popover for duration/intervals.

## Demo

Driven end-to-end in headless Chromium through the real DOM scrubber (the same
run that asserts the pixels):

| `preview: trail` | `preview: both` |
| --- | --- |
| ![trail](https://gist.githubusercontent.com/tommy-xr/e3c1d5162b43d25453b85b3a45914a85/raw/web-paused-trail.png) | ![both](https://gist.githubusercontent.com/tommy-xr/e3c1d5162b43d25453b85b3a45914a85/raw/web-paused-both.png) |

![off restores the paused frame](https://gist.githubusercontent.com/tommy-xr/e3c1d5162b43d25453b85b3a45914a85/raw/web-paused-off2.png)

<sub>Back to `preview: off` — the overlay is fully removed; the paused frame is byte-identical to before the preview was enabled.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
