### PR TITLE
feat(time-travel): scrubber redesign — future bar, ⚙ popover, ghost as a mode

### DIFF
--- a/runtime/functor-runtime-common/src/game_clock.rs
+++ b/runtime/functor-runtime-common/src/game_clock.rs
@@ -55,6 +55,12 @@ pub struct GameClock {
     /// A one-shot step (seconds) that advances `game_time` on the next frame,
     /// then holds. Set by Step / debug Advance (both imply pause).
     pending_step: Option<f32>,
+    /// Queued FIXED-frame steps (the scrubber's drag-into-the-future
+    /// catch-up): consumed up to [`MAX_SUBSTEPS`] whole `FIXED_DT` sub-frames
+    /// per rendered frame — never one fat tick, preserving the fixed-timestep
+    /// invariant (`FIXED_DT` == the forward-step `sub_dt`) that keeps the
+    /// recording/replay seams sound. Implies pause; holds when drained.
+    pending_frames: u32,
     /// Unconditional pin (`--fixed-time` / `?fixed-time`). When set, every frame
     /// is `{ dts: 0, tts: <const> }` — no accumulation, no pause, no rebase.
     fixed_time: Option<f32>,
@@ -77,6 +83,7 @@ impl GameClock {
             accumulator: 0.0,
             paused: false,
             pending_step: None,
+            pending_frames: 0,
             fixed_time,
             started: false,
         }
@@ -140,6 +147,22 @@ impl GameClock {
                 tts: self.game_time,
             }];
         }
+        if self.pending_frames > 0 {
+            // Catch-up: whole FIXED_DT sub-frames, at most MAX_SUBSTEPS per
+            // rendered frame, so a long drag into the future animates over a
+            // few frames instead of hitching one frame with a giant backlog.
+            let k = self.pending_frames.min(MAX_SUBSTEPS as u32);
+            self.pending_frames -= k;
+            let mut frames = Vec::with_capacity(k as usize);
+            for _ in 0..k {
+                self.game_time += FIXED_DT;
+                frames.push(FrameTime {
+                    dts: FIXED_DT,
+                    tts: self.game_time,
+                });
+            }
+            return frames;
+        }
         if self.paused {
             return Vec::new();
         }
@@ -198,6 +221,7 @@ impl GameClock {
     pub fn toggle_pause(&mut self) {
         self.paused = !self.paused;
         self.pending_step = None;
+        self.pending_frames = 0;
     }
 
     /// Engage the pause (idempotent), dropping any queued step. Used by the
@@ -205,6 +229,7 @@ impl GameClock {
     pub fn pause(&mut self) {
         self.paused = true;
         self.pending_step = None;
+        self.pending_frames = 0;
     }
 
     /// Return to live wall-clock accumulation, continuing from the current
@@ -212,6 +237,7 @@ impl GameClock {
     pub fn resume(&mut self) {
         self.paused = false;
         self.pending_step = None;
+        self.pending_frames = 0;
     }
 
     /// Pause and queue a one-frame step of `dt` seconds (Step / debug Advance).
@@ -220,10 +246,25 @@ impl GameClock {
         self.pending_step = Some(dt);
     }
 
+    /// Pause and queue `n` whole FIXED-frame steps — the scrubber's
+    /// drag-into-the-future catch-up. Consumed at most [`MAX_SUBSTEPS`] per
+    /// rendered frame (see [`Self::fixed_frames`]), so long drags animate.
+    /// Queuing again REPLACES the backlog (the newest drag wins).
+    pub fn step_frames(&mut self, n: u32) {
+        self.paused = true;
+        self.pending_frames = n;
+    }
+
+    /// Fixed-frame steps still queued from [`Self::step_frames`].
+    pub fn pending_frames(&self) -> u32 {
+        self.pending_frames
+    }
+
     /// Debug `POST /time` Set: pin the clock to `tts` (pause + rebase).
     pub fn set(&mut self, tts: f32) {
         self.paused = true;
         self.pending_step = None;
+        self.pending_frames = 0;
         self.game_time = tts;
     }
 
@@ -242,6 +283,23 @@ impl GameClock {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn step_frames_drains_in_fixed_chunks_and_holds() {
+        let mut clock = GameClock::new(None);
+        clock.step_frames(11);
+        let a = clock.fixed_frames(0.0);
+        assert_eq!(a.len(), MAX_SUBSTEPS, "first chunk capped at MAX_SUBSTEPS");
+        assert!(a.iter().all(|f| (f.dts - FIXED_DT).abs() < 1e-6));
+        let b = clock.fixed_frames(0.0);
+        assert_eq!(b.len(), 11 - MAX_SUBSTEPS, "remainder drains next frame");
+        assert!(clock.fixed_frames(0.0).is_empty(), "drained → holds paused");
+        assert!(clock.is_paused());
+        // Any pause-state transition clears the backlog.
+        clock.step_frames(5);
+        clock.toggle_pause();
+        assert_eq!(clock.pending_frames(), 0);
+    }
 
     #[test]
     fn live_accumulates_real_delta() {

--- a/runtime/functor-runtime-common/src/trajectory.rs
+++ b/runtime/functor-runtime-common/src/trajectory.rs
@@ -414,9 +414,13 @@ pub fn overlay(scene: &mut Scene3D, trail: Scene3D) {
     };
 }
 
-/// The interactive scene-diff preview mode — what the scrubber's selector (and
-/// the `--trajectory`/`--strobe` launch flags, which seed it) ask the shell to
-/// overlay. Shared by both shells so the wire encoding and cycle order match.
+/// The interactive future-preview mode — what the scrubber's selector (and the
+/// `--trajectory`/`--strobe`/`--ghost` launch flags, which seed it) ask the
+/// shell to overlay. One selector covers both preview families: the scene-diff
+/// overlays (trail / strobe / both — geometry on the normal render path) and
+/// `Ghost`, the screen-space compositor strobe (the only mode that can depict
+/// non-geometry motion such as animated lighting). Shared by both shells so
+/// the wire encoding and cycle order match.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
 pub enum PreviewMode {
     #[default]
@@ -424,6 +428,7 @@ pub enum PreviewMode {
     Trail,
     Strobe,
     Both,
+    Ghost,
 }
 
 impl PreviewMode {
@@ -433,13 +438,23 @@ impl PreviewMode {
     pub fn wants_strobe(self) -> bool {
         matches!(self, PreviewMode::Strobe | PreviewMode::Both)
     }
-    /// Cycle order for a one-button UI: off → trail → strobe → both → off.
+    /// The screen-space compositor strobe (docs/time-travel.md T6d).
+    pub fn wants_ghost(self) -> bool {
+        matches!(self, PreviewMode::Ghost)
+    }
+    /// Any mode that forward-simulates (i.e. everything but `Off`) — the
+    /// timeline's future pseudo-bar shows exactly when this is true.
+    pub fn is_on(self) -> bool {
+        self != PreviewMode::Off
+    }
+    /// Cycle order for a one-button UI: off → trail → strobe → both → ghost.
     pub fn next(self) -> PreviewMode {
         match self {
             PreviewMode::Off => PreviewMode::Trail,
             PreviewMode::Trail => PreviewMode::Strobe,
             PreviewMode::Strobe => PreviewMode::Both,
-            PreviewMode::Both => PreviewMode::Off,
+            PreviewMode::Both => PreviewMode::Ghost,
+            PreviewMode::Ghost => PreviewMode::Off,
         }
     }
     pub fn label(self) -> &'static str {
@@ -448,6 +463,7 @@ impl PreviewMode {
             PreviewMode::Trail => "trail",
             PreviewMode::Strobe => "strobe",
             PreviewMode::Both => "both",
+            PreviewMode::Ghost => "ghost",
         }
     }
     /// Stable wire encoding for the wasm scrubber bridge (the DOM `<select>`
@@ -457,6 +473,7 @@ impl PreviewMode {
             1 => PreviewMode::Trail,
             2 => PreviewMode::Strobe,
             3 => PreviewMode::Both,
+            4 => PreviewMode::Ghost,
             _ => PreviewMode::Off,
         }
     }

--- a/runtime/functor-runtime-common/src/trajectory.rs
+++ b/runtime/functor-runtime-common/src/trajectory.rs
@@ -238,7 +238,15 @@ fn trail_dot(p: Vector3<f32>) -> Scene3D {
     }
 }
 
-fn trail_from_tracks(tracks: &[MoverTrack]) -> Option<Scene3D> {
+/// The 1-based future-sample index the strobe's `c`-th copy stands on, for a
+/// track with `n_future` future samples and `count` copies: evenly spread,
+/// always including the window's end. Shared by the strobe (to place copies)
+/// and the trail (to stay OFF the strobe's cadence).
+fn strobe_idx(c: usize, count: usize, n_future: usize) -> usize {
+    (((c + 1) as f32 * n_future as f32 / count as f32).round() as usize).clamp(1, n_future)
+}
+
+fn trail_from_tracks(tracks: &[MoverTrack], strobe: Option<&StrobeOptions>) -> Option<Scene3D> {
     let mut dots = Vec::new();
     for track in tracks {
         // A pure in-place spinner has a track (for the strobe) but no path to
@@ -246,7 +254,20 @@ fn trail_from_tracks(tracks: &[MoverTrack]) -> Option<Scene3D> {
         if !track.translated {
             continue;
         }
-        for w in &track.worlds {
+        // Off-cadence with the strobe: skip the samples where a copy stands,
+        // so dots fill the gaps BETWEEN copies instead of hiding under them.
+        let n_future = track.worlds.len() - 1;
+        let skip: Vec<usize> = match strobe {
+            Some(s) if n_future > 0 && s.copies > 0 => {
+                let count = s.copies.min(n_future);
+                (0..count).map(|c| strobe_idx(c, count, n_future)).collect()
+            }
+            _ => Vec::new(),
+        };
+        for (i, w) in track.worlds.iter().enumerate() {
+            if skip.contains(&i) {
+                continue;
+            }
             dots.push(trail_dot(world_pos(w)));
         }
     }
@@ -263,7 +284,7 @@ fn trail_from_tracks(tracks: &[MoverTrack]) -> Option<Scene3D> {
 /// Build a dotted-trail scene from a scene sequence. Returns `None` when
 /// nothing moved. (The trail consumer of [`mover_tracks`].)
 pub fn trajectory_trail(scenes: &[&Scene3D], eps: f32, max_step: f32) -> Option<Scene3D> {
-    trail_from_tracks(&mover_tracks(scenes, eps, max_step))
+    trail_from_tracks(&mover_tracks(scenes, eps, max_step), None)
 }
 
 /// Scene-space strobe options.
@@ -373,8 +394,7 @@ pub fn strobe_overlay(tracks: &[MoverTrack], opts: &StrobeOptions) -> Option<Sce
         let count = opts.copies.min(n_future);
         for c in 0..count {
             // Evenly sample the future, always including the window's end.
-            let idx = ((c + 1) as f32 * n_future as f32 / count as f32).round() as usize;
-            let idx = idx.clamp(1, n_future);
+            let idx = strobe_idx(c, count, n_future);
             // Age by TIME along the track (not copy index), so sparse strobes
             // fade the same way dense ones do. Normalized over the inclusive
             // endpoints so the nearest possible future really gets `fade.0`; a
@@ -447,16 +467,6 @@ impl PreviewMode {
     pub fn is_on(self) -> bool {
         self != PreviewMode::Off
     }
-    /// Cycle order for a one-button UI: off → trail → strobe → both → ghost.
-    pub fn next(self) -> PreviewMode {
-        match self {
-            PreviewMode::Off => PreviewMode::Trail,
-            PreviewMode::Trail => PreviewMode::Strobe,
-            PreviewMode::Strobe => PreviewMode::Both,
-            PreviewMode::Both => PreviewMode::Ghost,
-            PreviewMode::Ghost => PreviewMode::Off,
-        }
-    }
     pub fn label(self) -> &'static str {
         match self {
             PreviewMode::Off => "off",
@@ -525,7 +535,8 @@ pub fn scene_preview(
     let tracks = mover_tracks(&scenes, opts.eps, opts.max_step);
     ScenePreview {
         trail: if opts.trail {
-            trail_from_tracks(&tracks)
+            // When the strobe draws too, the trail stays off its cadence.
+            trail_from_tracks(&tracks, opts.strobe.as_ref())
         } else {
             None
         },
@@ -697,6 +708,27 @@ mod tests {
     }
 
     #[test]
+    fn both_mode_dots_stay_off_the_strobe_cadence() {
+        // 4 future samples, 2 copies → copies stand on samples 2 and 4; the
+        // trail must drop those and keep the anchor plus samples 1 and 3, so
+        // dots fill the gaps between copies instead of hiding under them.
+        let frames: Vec<Scene3D> = (0..=4).map(|i| frame(i as f32, 0.0)).collect();
+        let refs: Vec<&Scene3D> = frames.iter().collect();
+        let tracks = mover_tracks(&refs, 0.05, 9.0);
+        let opts = StrobeOptions {
+            copies: 2,
+            ..Default::default()
+        };
+        let trail = trail_from_tracks(&tracks, Some(&opts)).expect("a trail");
+        match trail.obj {
+            SceneObject::Group(dots) => {
+                assert_eq!(dots.len(), 3, "anchor + the two non-copy samples")
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
     fn in_place_rotation_strobes_but_leaves_no_trail() {
         // A cube spinning in place: its world POSITION never changes, but its
         // basis vectors do. It must earn strobe copies (which can depict the
@@ -713,7 +745,10 @@ mod tests {
         assert_eq!(tracks.len(), 1, "a spinner is a mover");
         assert!(!tracks[0].translated);
         assert!(strobe_overlay(&tracks, &StrobeOptions::default()).is_some());
-        assert!(trail_from_tracks(&tracks).is_none(), "no dots for pure rotation");
+        assert!(
+            trail_from_tracks(&tracks, None).is_none(),
+            "no dots for pure rotation"
+        );
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/ui.rs
+++ b/runtime/functor-runtime-common/src/ui.rs
@@ -685,35 +685,34 @@ pub struct ScrubberState {
     /// until something is recorded (the slider is then hidden).
     pub range: Option<(u64, u64)>,
     pub paused: bool,
-    /// Forward-ghosting (docs/time-travel.md T6d) toggle: composite the ~window-s
-    /// future into a strobe. Interactive companion to the `--ghost` launch flag.
-    pub ghost_on: bool,
-    /// Divisions composited by the ghost (1..=8, the compositor `MAX_GHOST` cap).
-    pub ghost_divisions: usize,
-    /// The forward window in seconds; `dt = ghost_window / ghost_divisions`.
-    pub ghost_window: f32,
-    /// Scene-diff preview mode (docs/time-travel.md T6): trail dots and/or
-    /// scene-space strobe copies. Interactive companion to the
-    /// `--trajectory`/`--strobe` launch flags.
+    /// Future-preview mode (docs/time-travel.md T6/T6d): the scene-diff trail /
+    /// strobe overlays, or the screen-space ghost compositor — one selector,
+    /// with the per-family knobs collapsed into the ⚙ popover. Interactive
+    /// companion to the `--trajectory`/`--strobe`/`--ghost` launch flags.
     pub preview_mode: crate::trajectory::PreviewMode,
+    /// The forward window in seconds, shared by every preview mode; also sizes
+    /// the timeline's translucent future segment.
+    pub preview_window: f32,
+    /// Forward samples across the window (the ghost compositor clamps to its
+    /// 8-target cap at use).
+    pub preview_samples: usize,
 }
 
 /// A control the user activated in the scrubber this frame.
-// No `Eq`: `SetGhostWindow` carries an `f32`.
+// No `Eq`: `SetPreviewWindow` carries an `f32`.
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum ScrubberAction {
     TogglePause,
     /// Non-destructive scrub to a rendered frame (dragging the timeline).
     SeekTo(u64),
     Step,
-    /// Toggle forward-ghosting on/off (the `ghost` checkbox).
-    SetGhost(bool),
-    /// Set the ghost's forward divisions (clamped 1..=8 by the shell).
-    SetGhostDivisions(usize),
-    /// Set the ghost's forward window in seconds.
-    SetGhostWindow(f32),
-    /// Set the scene-diff preview mode (the `preview:` cycle button).
+    /// Set the future-preview mode (the `preview:` cycle button).
     SetPreviewMode(crate::trajectory::PreviewMode),
+    /// Set the preview's forward window in seconds (the ⚙ popover).
+    SetPreviewWindow(f32),
+    /// Set the preview's forward samples (the ⚙ popover; the ghost compositor
+    /// clamps to 8 at use).
+    SetPreviewSamples(usize),
 }
 
 /// The scrubber's output for one frame.
@@ -787,83 +786,149 @@ impl Scrubber {
                 .anchor(egui::Align2::CENTER_BOTTOM, egui::vec2(0.0, -MARGIN))
                 .show(&ctx, |ui| {
                     egui::Frame::popup(ui.style()).show(ui, |ui| {
-                        ui.horizontal(|ui| {
-                            let label = match state.range {
-                                Some((_, hi)) => format!("time-travel · {} / {hi}", state.frame),
-                                None => format!("time-travel · frame {}", state.frame),
-                            };
-                            ui.label(
-                                egui::RichText::new(label).font(egui::FontId::monospace(UI_FONT_SIZE)),
-                            );
-                            if ui.button(if state.paused { "Resume" } else { "Pause" }).clicked() {
-                                action = Some(ScrubberAction::TogglePause);
-                            }
-                            // The draggable timeline: drag anywhere in the
-                            // recorded window to scrub (non-destructive). Only
-                            // shown once there's a range to drag across.
-                            if let Some((lo, hi)) = state.range {
-                                if hi > lo {
-                                    let mut f = state.frame.clamp(lo, hi);
-                                    ui.spacing_mut().slider_width = 260.0;
-                                    let slider = ui.add(
-                                        egui::Slider::new(&mut f, lo..=hi)
-                                            .show_value(false)
-                                            .handle_shape(egui::style::HandleShape::Rect {
-                                                aspect_ratio: 0.5,
-                                            }),
-                                    );
-                                    if slider.changed() {
-                                        action = Some(ScrubberAction::SeekTo(f));
+                        ui.vertical(|ui| {
+                            ui.horizontal(|ui| {
+                                if ui
+                                    .button(if state.paused { "Resume" } else { "Pause" })
+                                    .clicked()
+                                {
+                                    action = Some(ScrubberAction::TogglePause);
+                                }
+                                // The draggable timeline: drag anywhere in the
+                                // recorded window to scrub (non-destructive).
+                                // Only shown once there's a range to drag
+                                // across. When a preview is on, the rail's
+                                // DOMAIN extends past the recorded end by the
+                                // preview window (60 fixed frames/sec): the
+                                // slider spans the recorded part and a
+                                // translucent strip marks [handle, handle +
+                                // window] — how far ahead the preview looks.
+                                if let Some((lo, hi)) = state.range {
+                                    if hi > lo {
+                                        const RAIL_W: f32 = 300.0;
+                                        let span = (hi - lo) as f32;
+                                        let future = if state.preview_mode.is_on() {
+                                            (state.preview_window * 60.0).max(0.0)
+                                        } else {
+                                            0.0
+                                        };
+                                        let px_per_frame = RAIL_W / (span + future);
+                                        let mut f = state.frame.clamp(lo, hi);
+                                        ui.spacing_mut().slider_width = px_per_frame * span;
+                                        let slider = ui.add(
+                                            egui::Slider::new(&mut f, lo..=hi)
+                                                .show_value(false)
+                                                .handle_shape(egui::style::HandleShape::Rect {
+                                                    aspect_ratio: 0.5,
+                                                }),
+                                        );
+                                        if slider.changed() {
+                                            action = Some(ScrubberAction::SeekTo(f));
+                                        }
+                                        if future > 0.0 {
+                                            // The future segment sits flush
+                                            // against the rail: drop the item
+                                            // gap only BETWEEN the slider and
+                                            // this allocation (set after the
+                                            // slider, so the Pause↔slider gap
+                                            // is untouched).
+                                            let old_spacing = ui.spacing().item_spacing;
+                                            ui.spacing_mut().item_spacing.x = 0.0;
+                                            let (ext, _) = ui.allocate_exact_size(
+                                                egui::vec2(
+                                                    px_per_frame * future,
+                                                    slider.rect.height(),
+                                                ),
+                                                egui::Sense::hover(),
+                                            );
+                                            ui.spacing_mut().item_spacing = old_spacing;
+                                            // Paint the strip just under the
+                                            // rail line, handle → window end.
+                                            // The handle's center travels an
+                                            // INSET range (≈ its half-size)
+                                            // inside the slider rect — start
+                                            // the strip from that, not the box
+                                            // edge, so it meets the handle.
+                                            let y = slider.rect.center().y;
+                                            let inset = slider.rect.height() * 0.5;
+                                            let travel =
+                                                (slider.rect.width() - 2.0 * inset).max(1.0);
+                                            let x0 = slider.rect.left()
+                                                + inset
+                                                + (f - lo) as f32 / span * travel;
+                                            let x1 = (x0 + px_per_frame * future)
+                                                .min(ext.right());
+                                            ui.painter().rect_filled(
+                                                egui::Rect::from_min_max(
+                                                    egui::pos2(x0, y + 6.0),
+                                                    egui::pos2(x1, y + 9.0),
+                                                ),
+                                                1.5,
+                                                egui::Color32::from_rgba_unmultiplied(
+                                                    224, 128, 58, 110,
+                                                ),
+                                            );
+                                        }
                                     }
                                 }
-                            }
-                            if ui.button("Step >").clicked() {
-                                action = Some(ScrubberAction::Step);
-                            }
+                                if ui.button("Step >").clicked() {
+                                    action = Some(ScrubberAction::Step);
+                                }
 
-                            // Forward-ghosting controls (docs/time-travel.md T6d):
-                            // an in-app companion to the `--ghost` launch flag.
-                            ui.separator();
-                            let mut ghost_on = state.ghost_on;
-                            if ui.checkbox(&mut ghost_on, "ghost").changed() {
-                                action = Some(ScrubberAction::SetGhost(ghost_on));
-                            }
-                            // Divisions (1..=8, the compositor MAX_GHOST cap) and
-                            // the forward window in seconds (dt = window / divisions).
-                            let mut divisions = state.ghost_divisions.clamp(1, 8);
-                            if ui
-                                .add(
-                                    egui::DragValue::new(&mut divisions)
-                                        .range(1..=8)
-                                        .prefix("÷"),
-                                )
-                                .changed()
-                            {
-                                action = Some(ScrubberAction::SetGhostDivisions(divisions));
-                            }
-                            let mut window = state.ghost_window;
-                            if ui
-                                .add(
-                                    egui::Slider::new(&mut window, 0.5..=5.0).suffix("s"),
-                                )
-                                .changed()
-                            {
-                                action = Some(ScrubberAction::SetGhostWindow(window));
-                            }
-
-                            // Scene-diff preview (docs/time-travel.md T6): a
-                            // compact cycle button (off → trail → strobe → both)
-                            // — one widget until the scrubber declutter pass
-                            // gives previews a proper popover.
-                            ui.separator();
-                            if ui
-                                .button(format!("preview: {}", state.preview_mode.label()))
-                                .clicked()
-                            {
-                                action = Some(ScrubberAction::SetPreviewMode(
-                                    state.preview_mode.next(),
-                                ));
-                            }
+                                // Future preview (docs/time-travel.md T6/T6d):
+                                // one cycle button for the mode; the shared
+                                // window/samples knobs live in the ⚙ popover.
+                                ui.separator();
+                                if ui
+                                    .button(format!("preview: {}", state.preview_mode.label()))
+                                    .clicked()
+                                {
+                                    action = Some(ScrubberAction::SetPreviewMode(
+                                        state.preview_mode.next(),
+                                    ));
+                                }
+                                ui.menu_button("⚙", |ui| {
+                                    ui.label("forward window");
+                                    let mut window = state.preview_window;
+                                    if ui
+                                        .add(egui::Slider::new(&mut window, 0.5..=5.0).suffix("s"))
+                                        .changed()
+                                    {
+                                        action = Some(ScrubberAction::SetPreviewWindow(window));
+                                    }
+                                    ui.label("samples");
+                                    let mut samples = state.preview_samples.clamp(1, 64);
+                                    if ui
+                                        .add(egui::DragValue::new(&mut samples).range(1..=64))
+                                        .changed()
+                                    {
+                                        action = Some(ScrubberAction::SetPreviewSamples(samples));
+                                    }
+                                    ui.label(
+                                        egui::RichText::new(
+                                            "ghost composites at most 8 samples",
+                                        )
+                                        .weak()
+                                        .size(10.0),
+                                    );
+                                });
+                            });
+                            // The frame counter: a small faded row BELOW the
+                            // controls, centered on the bar — digit growth
+                            // re-centers this text but never reflows the
+                            // control row above it (the controls row is the
+                            // wider one, so it fixes the panel's width).
+                            let label = match state.range {
+                                Some((_, hi)) => format!("{} / {hi}", state.frame),
+                                None => format!("frame {}", state.frame),
+                            };
+                            ui.vertical_centered(|ui| {
+                                ui.label(
+                                    egui::RichText::new(label)
+                                        .font(egui::FontId::monospace(UI_FONT_SIZE - 5.0))
+                                        .weak(),
+                                );
+                            });
                         });
                     });
                 });

--- a/runtime/functor-runtime-common/src/ui.rs
+++ b/runtime/functor-runtime-common/src/ui.rs
@@ -787,6 +787,11 @@ impl Scrubber {
                 .show(&ctx, |ui| {
                     egui::Frame::popup(ui.style()).show(ui, |ui| {
                         ui.vertical(|ui| {
+                            // The timeline rail's horizontal extent (slider +
+                            // future segment), captured from inside the row so
+                            // the frame counter below can center on the BAR
+                            // rather than the whole panel.
+                            let mut rail: Option<(f32, f32)> = None;
                             ui.horizontal(|ui| {
                                 if ui
                                     .button(if state.paused { "Resume" } else { "Pause" })
@@ -825,6 +830,7 @@ impl Scrubber {
                                         if slider.changed() {
                                             action = Some(ScrubberAction::SeekTo(f));
                                         }
+                                        rail = Some((slider.rect.left(), slider.rect.right()));
                                         if future > 0.0 {
                                             // The future segment sits flush
                                             // against the rail: drop the item
@@ -842,13 +848,16 @@ impl Scrubber {
                                                 egui::Sense::hover(),
                                             );
                                             ui.spacing_mut().item_spacing = old_spacing;
-                                            // Paint the strip just under the
-                                            // rail line, handle → window end.
-                                            // The handle's center travels an
-                                            // INSET range (≈ its half-size)
-                                            // inside the slider rect — start
-                                            // the strip from that, not the box
-                                            // edge, so it meets the handle.
+                                            rail = Some((slider.rect.left(), ext.right()));
+                                            // Paint the future segment ON the
+                                            // rail line at track height —
+                                            // trail-cyan, so it reads as "the
+                                            // preview's part of the bar", not
+                                            // a hint. The handle's center
+                                            // travels an INSET range (≈ its
+                                            // half-size) inside the slider
+                                            // rect — start from that, not the
+                                            // box edge, so it meets the handle.
                                             let y = slider.rect.center().y;
                                             let inset = slider.rect.height() * 0.5;
                                             let travel =
@@ -860,12 +869,12 @@ impl Scrubber {
                                                 .min(ext.right());
                                             ui.painter().rect_filled(
                                                 egui::Rect::from_min_max(
-                                                    egui::pos2(x0, y + 6.0),
-                                                    egui::pos2(x1, y + 9.0),
+                                                    egui::pos2(x0, y - 2.5),
+                                                    egui::pos2(x1, y + 2.5),
                                                 ),
-                                                1.5,
+                                                2.0,
                                                 egui::Color32::from_rgba_unmultiplied(
-                                                    224, 128, 58, 110,
+                                                    64, 217, 255, 200,
                                                 ),
                                             );
                                         }
@@ -913,22 +922,28 @@ impl Scrubber {
                                     );
                                 });
                             });
-                            // The frame counter: a small faded row BELOW the
-                            // controls, centered on the bar — digit growth
-                            // re-centers this text but never reflows the
-                            // control row above it (the controls row is the
-                            // wider one, so it fixes the panel's width).
+                            // The frame counter: tiny, faded, PAINTED just
+                            // under the timeline rail and centered on IT (not
+                            // the panel) — positioned text, so digit growth
+                            // never reflows anything.
                             let label = match state.range {
                                 Some((_, hi)) => format!("{} / {hi}", state.frame),
                                 None => format!("frame {}", state.frame),
                             };
-                            ui.vertical_centered(|ui| {
-                                ui.label(
-                                    egui::RichText::new(label)
-                                        .font(egui::FontId::monospace(UI_FONT_SIZE - 5.0))
-                                        .weak(),
-                                );
-                            });
+                            let (strip, _) = ui.allocate_exact_size(
+                                egui::vec2(ui.available_width().max(1.0), 8.0),
+                                egui::Sense::hover(),
+                            );
+                            let center_x = rail
+                                .map(|(l, r)| (l + r) * 0.5)
+                                .unwrap_or_else(|| strip.center().x);
+                            ui.painter().text(
+                                egui::pos2(center_x, strip.top() - 3.0),
+                                egui::Align2::CENTER_TOP,
+                                label,
+                                egui::FontId::monospace(UI_FONT_SIZE - 6.0),
+                                ui.visuals().weak_text_color(),
+                            );
                         });
                     });
                 });

--- a/runtime/functor-runtime-common/src/ui.rs
+++ b/runtime/functor-runtime-common/src/ui.rs
@@ -685,17 +685,21 @@ pub struct ScrubberState {
     /// until something is recorded (the slider is then hidden).
     pub range: Option<(u64, u64)>,
     pub paused: bool,
-    /// Future-preview mode (docs/time-travel.md T6/T6d): the scene-diff trail /
-    /// strobe overlays, or the screen-space ghost compositor — one selector,
-    /// with the per-family knobs collapsed into the ⚙ popover. Interactive
-    /// companion to the `--trajectory`/`--strobe`/`--ghost` launch flags.
+    /// The bar's single future-preview switch (docs/time-travel.md T6/T6d):
+    /// "extrapolate" on/off. What it SHOWS when on is `preview_mode`,
+    /// configured in the ⚙ popover. Interactive companion to the
+    /// `--trajectory`/`--strobe`/`--ghost` launch flags.
+    pub extrapolate: bool,
+    /// The preview family shown while extrapolating (never `Off` here — the
+    /// checkbox is the off switch): trail / strobe / both / ghost.
     pub preview_mode: crate::trajectory::PreviewMode,
     /// The forward window in seconds, shared by every preview mode; also sizes
     /// the timeline's translucent future segment.
     pub preview_window: f32,
-    /// Forward samples across the window (the ghost compositor clamps to its
-    /// 8-target cap at use).
-    pub preview_samples: usize,
+    /// Forward samples PER SECOND — density stays constant as the window is
+    /// resized (total samples = rate × window, clamped; the ghost compositor
+    /// further clamps to its 8-target cap at use).
+    pub preview_rate: usize,
 }
 
 /// A control the user activated in the scrubber this frame.
@@ -706,13 +710,14 @@ pub enum ScrubberAction {
     /// Non-destructive scrub to a rendered frame (dragging the timeline).
     SeekTo(u64),
     Step,
-    /// Set the future-preview mode (the `preview:` cycle button).
+    /// Toggle the bar's "extrapolate" switch.
+    SetExtrapolate(bool),
+    /// Set the preview family shown while extrapolating (the ⚙ popover).
     SetPreviewMode(crate::trajectory::PreviewMode),
     /// Set the preview's forward window in seconds (the ⚙ popover).
     SetPreviewWindow(f32),
-    /// Set the preview's forward samples (the ⚙ popover; the ghost compositor
-    /// clamps to 8 at use).
-    SetPreviewSamples(usize),
+    /// Set the preview's forward samples per second (the ⚙ popover).
+    SetPreviewRate(usize),
 }
 
 /// The scrubber's output for one frame.
@@ -793,7 +798,7 @@ impl Scrubber {
                             let mut rail: Option<(f32, f32)> = None;
                             // The preview window in fixed frames — sizes the
                             // rail's cyan segment and the counter's `+N`.
-                            let future_frames = if state.preview_mode.is_on() {
+                            let future_frames = if state.extrapolate {
                                 (state.preview_window * 60.0).round().max(0.0) as u64
                             } else {
                                 0
@@ -912,18 +917,31 @@ impl Scrubber {
                                 }
 
                                 // Future preview (docs/time-travel.md T6/T6d):
-                                // one cycle button for the mode; the shared
-                                // window/samples knobs live in the ⚙ popover.
+                                // ONE switch on the bar; the mode /
+                                // window / rate knobs live in the ⚙ popover.
                                 ui.separator();
-                                if ui
-                                    .button(format!("preview: {}", state.preview_mode.label()))
-                                    .clicked()
-                                {
-                                    action = Some(ScrubberAction::SetPreviewMode(
-                                        state.preview_mode.next(),
-                                    ));
+                                let mut on = state.extrapolate;
+                                if ui.checkbox(&mut on, "extrapolate").changed() {
+                                    action = Some(ScrubberAction::SetExtrapolate(on));
                                 }
                                 ui.menu_button("⚙", |ui| {
+                                    ui.label("show");
+                                    ui.horizontal(|ui| {
+                                        use crate::trajectory::PreviewMode as PM;
+                                        for mode in [PM::Trail, PM::Strobe, PM::Both, PM::Ghost]
+                                        {
+                                            if ui
+                                                .selectable_label(
+                                                    state.preview_mode == mode,
+                                                    mode.label(),
+                                                )
+                                                .clicked()
+                                            {
+                                                action =
+                                                    Some(ScrubberAction::SetPreviewMode(mode));
+                                            }
+                                        }
+                                    });
                                     ui.label("forward window");
                                     let mut window = state.preview_window;
                                     if ui
@@ -932,17 +950,21 @@ impl Scrubber {
                                     {
                                         action = Some(ScrubberAction::SetPreviewWindow(window));
                                     }
-                                    ui.label("samples");
-                                    let mut samples = state.preview_samples.clamp(1, 64);
+                                    ui.label("rate");
+                                    let mut rate = state.preview_rate.clamp(1, 30);
                                     if ui
-                                        .add(egui::DragValue::new(&mut samples).range(1..=64))
+                                        .add(
+                                            egui::DragValue::new(&mut rate)
+                                                .range(1..=30)
+                                                .suffix("/s"),
+                                        )
                                         .changed()
                                     {
-                                        action = Some(ScrubberAction::SetPreviewSamples(samples));
+                                        action = Some(ScrubberAction::SetPreviewRate(rate));
                                     }
                                     ui.label(
                                         egui::RichText::new(
-                                            "ghost composites at most 8 samples",
+                                            "strobe copies per second — the trail samples\nfiner; ghost composites ≤8 total",
                                         )
                                         .weak()
                                         .size(10.0),

--- a/runtime/functor-runtime-common/src/ui.rs
+++ b/runtime/functor-runtime-common/src/ui.rs
@@ -787,11 +787,17 @@ impl Scrubber {
                 .show(&ctx, |ui| {
                     egui::Frame::popup(ui.style()).show(ui, |ui| {
                         ui.vertical(|ui| {
-                            // The timeline rail's horizontal extent (slider +
-                            // future segment), captured from inside the row so
-                            // the frame counter below can center on the BAR
-                            // rather than the whole panel.
+                            // The timeline rail's horizontal extent, captured
+                            // from inside the row so the frame counter below
+                            // can center on the BAR rather than the panel.
                             let mut rail: Option<(f32, f32)> = None;
+                            // The preview window in fixed frames — sizes the
+                            // rail's cyan segment and the counter's `+N`.
+                            let future_frames = if state.preview_mode.is_on() {
+                                (state.preview_window * 60.0).round().max(0.0) as u64
+                            } else {
+                                0
+                            };
                             ui.horizontal(|ui| {
                                 if ui
                                     .button(if state.paused { "Resume" } else { "Pause" })
@@ -799,29 +805,24 @@ impl Scrubber {
                                 {
                                     action = Some(ScrubberAction::TogglePause);
                                 }
-                                // The draggable timeline: drag anywhere in the
-                                // recorded window to scrub (non-destructive).
-                                // Only shown once there's a range to drag
-                                // across. When a preview is on, the rail's
-                                // DOMAIN extends past the recorded end by the
-                                // preview window (60 fixed frames/sec): the
-                                // slider spans the recorded part and a
-                                // translucent strip marks [handle, handle +
-                                // window] — how far ahead the preview looks.
+                                // The draggable timeline. When a preview is
+                                // on, the rail's DOMAIN includes the preview
+                                // window (60 fixed frames/sec past the
+                                // recorded end): the cyan segment marks
+                                // [handle, handle + window], and the handle
+                                // can be dragged INTO it — a seek beyond the
+                                // recorded end steps the game forward,
+                                // input-free (the clock animates the
+                                // catch-up). The segment's end cap drags to
+                                // resize the window in place.
                                 if let Some((lo, hi)) = state.range {
                                     if hi > lo {
                                         const RAIL_W: f32 = 300.0;
-                                        let span = (hi - lo) as f32;
-                                        let future = if state.preview_mode.is_on() {
-                                            (state.preview_window * 60.0).max(0.0)
-                                        } else {
-                                            0.0
-                                        };
-                                        let px_per_frame = RAIL_W / (span + future);
+                                        let max = hi + future_frames;
                                         let mut f = state.frame.clamp(lo, hi);
-                                        ui.spacing_mut().slider_width = px_per_frame * span;
+                                        ui.spacing_mut().slider_width = RAIL_W;
                                         let slider = ui.add(
-                                            egui::Slider::new(&mut f, lo..=hi)
+                                            egui::Slider::new(&mut f, lo..=max)
                                                 .show_value(false)
                                                 .handle_shape(egui::style::HandleShape::Rect {
                                                     aspect_ratio: 0.5,
@@ -831,42 +832,30 @@ impl Scrubber {
                                             action = Some(ScrubberAction::SeekTo(f));
                                         }
                                         rail = Some((slider.rect.left(), slider.rect.right()));
-                                        if future > 0.0 {
-                                            // The future segment sits flush
-                                            // against the rail: drop the item
-                                            // gap only BETWEEN the slider and
-                                            // this allocation (set after the
-                                            // slider, so the Pause↔slider gap
-                                            // is untouched).
-                                            let old_spacing = ui.spacing().item_spacing;
-                                            ui.spacing_mut().item_spacing.x = 0.0;
-                                            let (ext, _) = ui.allocate_exact_size(
-                                                egui::vec2(
-                                                    px_per_frame * future,
-                                                    slider.rect.height(),
-                                                ),
-                                                egui::Sense::hover(),
-                                            );
-                                            ui.spacing_mut().item_spacing = old_spacing;
-                                            rail = Some((slider.rect.left(), ext.right()));
-                                            // Paint the future segment ON the
-                                            // rail line at track height —
-                                            // trail-cyan, so it reads as "the
-                                            // preview's part of the bar", not
-                                            // a hint. The handle's center
+                                        if future_frames > 0 {
+                                            // The cyan future segment, painted
+                                            // ON the rail at track height
+                                            // (trail-cyan: it IS the preview's
+                                            // future). The handle's center
                                             // travels an INSET range (≈ its
                                             // half-size) inside the slider
-                                            // rect — start from that, not the
-                                            // box edge, so it meets the handle.
+                                            // rect — map through that so the
+                                            // segment meets the handle.
                                             let y = slider.rect.center().y;
                                             let inset = slider.rect.height() * 0.5;
                                             let travel =
                                                 (slider.rect.width() - 2.0 * inset).max(1.0);
-                                            let x0 = slider.rect.left()
-                                                + inset
-                                                + (f - lo) as f32 / span * travel;
-                                            let x1 = (x0 + px_per_frame * future)
-                                                .min(ext.right());
+                                            let domain = (max - lo) as f32;
+                                            let x_of = |frame: u64| {
+                                                slider.rect.left()
+                                                    + inset
+                                                    + (frame - lo) as f32 / domain * travel
+                                            };
+                                            // Start at the handle's RIGHT edge
+                                            // so the cyan never paints over the
+                                            // handle or the traversed track.
+                                            let x0 = x_of(f) + 5.0;
+                                            let x1 = x_of((f + future_frames).min(max)).max(x0);
                                             ui.painter().rect_filled(
                                                 egui::Rect::from_min_max(
                                                     egui::pos2(x0, y - 2.5),
@@ -877,6 +866,44 @@ impl Scrubber {
                                                     64, 217, 255, 200,
                                                 ),
                                             );
+                                            // The segment's END CAP: a small
+                                            // grabber hanging under the window
+                                            // end — drag to resize the forward
+                                            // window in place (the ⚙ slider's
+                                            // direct-manipulation twin).
+                                            // Offset BELOW the track so it
+                                            // never fights the seek handle.
+                                            let cap = egui::Rect::from_min_max(
+                                                egui::pos2(x1 - 4.0, y + 3.0),
+                                                egui::pos2(x1 + 4.0, y + 11.0),
+                                            );
+                                            let cap_resp = ui.interact(
+                                                cap,
+                                                ui.id().with("preview_window_cap"),
+                                                egui::Sense::drag(),
+                                            );
+                                            let cap_color =
+                                                if cap_resp.hovered() || cap_resp.dragged() {
+                                                    egui::Color32::from_rgb(150, 236, 255)
+                                                } else {
+                                                    egui::Color32::from_rgba_unmultiplied(
+                                                        64, 217, 255, 230,
+                                                    )
+                                                };
+                                            ui.painter().rect_filled(cap, 1.5, cap_color);
+                                            if cap_resp.dragged() {
+                                                let frames_per_px = domain / travel;
+                                                let dw = cap_resp.drag_delta().x
+                                                    * frames_per_px
+                                                    / 60.0;
+                                                let w = (state.preview_window + dw)
+                                                    .clamp(0.5, 5.0);
+                                                if (w - state.preview_window).abs() > 1e-4 {
+                                                    action = Some(
+                                                        ScrubberAction::SetPreviewWindow(w),
+                                                    );
+                                                }
+                                            }
                                         }
                                     }
                                 }
@@ -925,11 +952,9 @@ impl Scrubber {
                             // The frame counter: tiny, faded, PAINTED just
                             // under the timeline rail and centered on IT (not
                             // the panel) — positioned text, so digit growth
-                            // never reflows anything.
-                            let label = match state.range {
-                                Some((_, hi)) => format!("{} / {hi}", state.frame),
-                                None => format!("frame {}", state.frame),
-                            };
+                            // never reflows anything. The predicted-frames
+                            // count (the rail's cyan segment, numerically)
+                            // sits WITH the current frame: `227 +120 / 227`.
                             let (strip, _) = ui.allocate_exact_size(
                                 egui::vec2(ui.available_width().max(1.0), 8.0),
                                 egui::Sense::hover(),
@@ -937,13 +962,35 @@ impl Scrubber {
                             let center_x = rail
                                 .map(|(l, r)| (l + r) * 0.5)
                                 .unwrap_or_else(|| strip.center().x);
-                            ui.painter().text(
-                                egui::pos2(center_x, strip.top() - 3.0),
-                                egui::Align2::CENTER_TOP,
-                                label,
-                                egui::FontId::monospace(UI_FONT_SIZE - 6.0),
-                                ui.visuals().weak_text_color(),
-                            );
+                            let font = egui::FontId::monospace(UI_FONT_SIZE - 6.0);
+                            let weak = ui.visuals().weak_text_color();
+                            let cyan =
+                                egui::Color32::from_rgba_unmultiplied(64, 217, 255, 190);
+                            let mut segments: Vec<(String, egui::Color32)> = Vec::new();
+                            match state.range {
+                                Some((_, hi)) => {
+                                    segments.push((format!("{}", state.frame), weak));
+                                    if future_frames > 0 {
+                                        segments.push((format!(" +{future_frames}"), cyan));
+                                    }
+                                    segments.push((format!(" / {hi}"), weak));
+                                }
+                                None => segments.push((format!("frame {}", state.frame), weak)),
+                            }
+                            let galleys: Vec<_> = segments
+                                .into_iter()
+                                .map(|(text, color)| {
+                                    ui.painter().layout_no_wrap(text, font.clone(), color)
+                                })
+                                .collect();
+                            let total: f32 = galleys.iter().map(|g| g.size().x).sum();
+                            let mut x = center_x - total * 0.5;
+                            for galley in galleys {
+                                let w = galley.size().x;
+                                ui.painter()
+                                    .galley(egui::pos2(x, strip.top() - 3.0), galley, weak);
+                                x += w;
+                            }
                         });
                     });
                 });

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -330,6 +330,14 @@ pub struct Args {
     #[arg(long)]
     strobe: bool,
 
+    /// Start with the time-travel scrubber overlay visible (it is otherwise
+    /// hidden until summoned with `~`). Useful for demos and captures of the
+    /// scrubber itself. NOTE: with the overlay up, previews follow the
+    /// interactive rule (paused only) — combine with --trajectory/--strobe/
+    /// --ghost WITHOUT --scrubber for headless overlay captures.
+    #[arg(long)]
+    scrubber: bool,
+
     /// Narrate the game clock + time-travel seams to stderr: pause/resume/seek
     /// rebases (with the tts they land on), ghost on/off, and per-frame HITCH
     /// warnings when a rendered frame's dt blows past 33ms (the tell-tale of the
@@ -868,27 +876,27 @@ pub fn run(args: Args) {
         let mut ui_wants_keyboard = false;
         // The time-travel console (`~`): HIDDEN by default in the native game
         // (it's a dev tool you summon with `~`, which also frees the cursor so
-        // you can scrub right away). The wasm/vscode preview shows it always.
-        let mut scrubber_visible = false;
-        // Forward-ghosting (docs/time-travel.md T6d) state, driven interactively
-        // from the scrubber overlay. Seeded from the launch flags so `--ghost`
-        // (the headless-capture escape hatch, overlay hidden) is unchanged; when
-        // the overlay is up, these vars take over (see the `ghost_active` gate).
-        let mut ghost_on = args.ghost;
-        let mut ghost_divisions = args.ghost_divisions;
-        let mut ghost_window: f32 = 2.0;
-        // Scene-diff preview (docs/time-travel.md T6) state, driven
-        // interactively from the scrubber's `preview:` cycle button. Seeded
-        // from the launch flags so `--trajectory`/`--strobe` (the
-        // headless-capture escape hatch, overlay hidden) are unchanged; when
-        // the overlay is up, this var takes over (the `active_preview` gate).
-        let args_preview = match (args.trajectory, args.strobe) {
-            (true, true) => functor_runtime_common::PreviewMode::Both,
-            (true, false) => functor_runtime_common::PreviewMode::Trail,
-            (false, true) => functor_runtime_common::PreviewMode::Strobe,
-            (false, false) => functor_runtime_common::PreviewMode::Off,
+        // you can scrub right away; --scrubber starts it open, e.g. for
+        // captures). The wasm/vscode preview shows it always.
+        let mut scrubber_visible = args.scrubber;
+        // Future-preview (docs/time-travel.md T6/T6d) state, driven
+        // interactively from the scrubber's `preview:` selector and ⚙ popover.
+        // Seeded from the launch flags — which stay authoritative while the
+        // overlay is hidden (the headless-capture escape hatch), where they may
+        // also COMBINE (--ghost --trajectory composes the trail into the
+        // strobe; the selector picks one mode at a time).
+        let mut preview_mode = match (args.ghost, args.trajectory, args.strobe) {
+            (true, _, _) => functor_runtime_common::PreviewMode::Ghost,
+            (false, true, true) => functor_runtime_common::PreviewMode::Both,
+            (false, true, false) => functor_runtime_common::PreviewMode::Trail,
+            (false, false, true) => functor_runtime_common::PreviewMode::Strobe,
+            (false, false, false) => functor_runtime_common::PreviewMode::Off,
         };
-        let mut preview_mode = args_preview;
+        // The ⚙ popover's shared forward window/samples. Ghost seeds samples
+        // from its historical flag so `--ghost --ghost-divisions N` still tunes
+        // the interactive strobe.
+        let mut preview_window: f32 = 2.0;
+        let mut preview_samples: usize = if args.ghost { args.ghost_divisions } else { 32 };
         // --trajectory/--strobe preview cache. The 32-division forward-sim is
         // the expensive part, and while PAUSED its anchor (scene frame + tts) is
         // frozen — so reuse the computed preview while the anchor key matches,
@@ -898,7 +906,7 @@ pub fn run(args: Args) {
         // --ghost does.
         const TRAIL_REFRESH_FRAMES: u32 = 30;
         let mut trail_cache: Option<(
-            (Option<u64>, u32, bool, bool),
+            (Option<u64>, u32, bool, bool, usize, u32),
             functor_runtime_common::ScenePreview,
         )> = None;
         let mut trail_refresh: u32 = 0;
@@ -1286,53 +1294,56 @@ Escape again to quit"
             // `is_paused()` is false under --fixed-time, so the headless
             // `args.ghost` capture branch is unaffected. Computed HERE, above
             // the scene-diff preview, because the preview's gating reads it.
-            let ghost_active = if scrubber_visible {
-                ghost_on && clock.is_paused()
-            } else {
-                args.ghost
-            };
-
-            // Scene-diff preview (docs/time-travel.md T6): forward-simulate the
-            // model (physics included, via the shared ghost_frames inside
-            // scene_preview) and diff the rendered scenes' node world transforms
-            // into --trajectory's dotted trail and/or --strobe's real-geometry
-            // future copies — both overlays on the normal render path, computed
-            // from ONE forward-sim. Same gating as ghost (interactive only while
-            // the scrubber is paused; headless via the flags, so it's
-            // deterministically capturable).
-            // Interactive preview follows the ghost rule: with the overlay up
-            // it renders only while PAUSED (forward-stepping every LIVE frame
-            // tanks the framerate); with the overlay hidden the launch flags
-            // drive it, so headless captures are byte-for-byte unchanged.
-            let active_preview = if scrubber_visible {
+            // One wanted-set drives every future preview (docs/time-travel.md
+            // T6/T6d): the scene-diff trail/strobe overlays AND the
+            // screen-space ghost compositor. With the overlay up, the
+            // scrubber's selector picks ONE mode, and only while PAUSED
+            // (forward-stepping every LIVE frame tanks the framerate); with the
+            // overlay hidden the launch flags drive it — several may combine
+            // there (--ghost --trajectory composes the trail into the strobe) —
+            // so headless captures are byte-for-byte unchanged.
+            let (trail_wanted, strobe_wanted, ghost_active) = if scrubber_visible {
                 if clock.is_paused() {
-                    preview_mode
+                    (
+                        preview_mode.wants_trail(),
+                        preview_mode.wants_strobe(),
+                        preview_mode.wants_ghost(),
+                    )
                 } else {
-                    functor_runtime_common::PreviewMode::Off
+                    (false, false, false)
                 }
             } else {
-                args_preview
+                (args.trajectory, args.strobe, args.ghost)
             };
-            let trail_wanted = active_preview.wants_trail();
             // Under the screen-space ghost compositor the scene-space strobe
             // would double-ghost — and the compositor arm never draws the
             // display frame — so while the ghost is active the strobe is off
             // (the trail still shows: it rides IN the composited frames), and
             // it must not silently burn a forward-sim it can't display.
-            let strobe_wanted = active_preview.wants_strobe() && !ghost_active;
+            let strobe_wanted = strobe_wanted && !ghost_active;
+            // Forward window/samples: the ⚙ popover's shared values
+            // interactively; the historical constants on the flag path (32
+            // samples over 1.6s), keeping captures byte-identical.
+            let (preview_divisions, preview_window_s) = if scrubber_visible {
+                (preview_samples.clamp(1, 64), preview_window)
+            } else {
+                (32usize, 1.6f32)
+            };
             let preview_active = (trail_wanted || strobe_wanted)
                 && args.composite_demo == CompositeDemoArg::Off;
             let preview: Option<functor_runtime_common::ScenePreview> = if preview_active {
                 // Not bound by the 8-target compositor cap — this only reads node
                 // transforms — so sample finely for a smooth arc.
-                let divisions = 32usize;
-                let window = 1.6f32;
+                let divisions = preview_divisions;
+                let window = preview_window_s;
                 let dt = window / divisions as f32;
                 let key = (
                     game.current_scene_frame(),
                     time.tts.to_bits(),
                     trail_wanted,
                     strobe_wanted,
+                    divisions,
+                    window.to_bits(),
                 );
                 let cache_hit = trail_refresh > 0
                     && trail_cache.as_ref().is_some_and(|(k, _)| *k == key);
@@ -1360,6 +1371,13 @@ Escape again to quit"
                             // same way or the two projections diverge. Live
                             // playback consumes the script, so there the next
                             // unconsumed frame (k + 1) is the right anchor.
+                            // Deliberately keyed on the LAUNCH FLAG, not the
+                            // interactive mode: `--ghost --input-script` is the
+                            // F2 session semantic (the script drives the
+                            // anchored future, never the live game), so
+                            // selecting trail/strobe there previews the SAME
+                            // scripted future — switching modes changes the
+                            // visualization, not the script routing.
                             let base = if args.ghost {
                                 0
                             } else {
@@ -1412,7 +1430,14 @@ Escape again to quit"
                 && args.composite_demo == CompositeDemoArg::Off
             {
                 const MAX_GHOST: usize = 8;
-                let divisions = ghost_divisions.clamp(1, MAX_GHOST);
+                // Interactive: the ⚙ popover's shared window/samples (clamped
+                // to the compositor's 8-target cap). Flag path: the historical
+                // --ghost-divisions over a 2s window, byte-identical captures.
+                let (divisions, ghost_window) = if scrubber_visible {
+                    (preview_samples.clamp(1, MAX_GHOST), preview_window)
+                } else {
+                    (args.ghost_divisions.clamp(1, MAX_GHOST), 2.0f32)
+                };
                 let dt = ghost_window / divisions as f32;
                 // F2 (docs/time-travel.md): when an --input-script is loaded, the
                 // ghost previews the SCRIPT's trajectory from the live anchor
@@ -1716,10 +1741,9 @@ Escape again to quit"
                         frame: game.current_scene_frame().unwrap_or(0),
                         range: game.scene_frame_range(),
                         paused: clock.is_paused(),
-                        ghost_on,
-                        ghost_divisions,
-                        ghost_window,
                         preview_mode,
+                        preview_window,
+                        preview_samples,
                     },
                 )
             } else {
@@ -1777,23 +1801,17 @@ Escape again to quit"
                     // Step implies pause: advance exactly one frame, then hold.
                     clock.step(1.0 / 60.0);
                 }
-                Some(functor_runtime_common::ui::ScrubberAction::SetGhost(on)) => {
-                    if args.debug_clock {
-                        eprintln!("[clock] ghost {}", if on { "on" } else { "off" });
-                    }
-                    ghost_on = on;
-                }
-                Some(functor_runtime_common::ui::ScrubberAction::SetGhostDivisions(n)) => {
-                    ghost_divisions = n.clamp(1, 8);
-                }
-                Some(functor_runtime_common::ui::ScrubberAction::SetGhostWindow(w)) => {
-                    ghost_window = w.clamp(0.5, 5.0);
-                }
                 Some(functor_runtime_common::ui::ScrubberAction::SetPreviewMode(m)) => {
                     if args.debug_clock {
                         eprintln!("[clock] preview {}", m.label());
                     }
                     preview_mode = m;
+                }
+                Some(functor_runtime_common::ui::ScrubberAction::SetPreviewWindow(w)) => {
+                    preview_window = w.clamp(0.5, 5.0);
+                }
+                Some(functor_runtime_common::ui::ScrubberAction::SetPreviewSamples(n)) => {
+                    preview_samples = n.clamp(1, 64);
                 }
                 None => {}
             }

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -880,23 +880,23 @@ pub fn run(args: Args) {
         // captures). The wasm/vscode preview shows it always.
         let mut scrubber_visible = args.scrubber;
         // Future-preview (docs/time-travel.md T6/T6d) state, driven
-        // interactively from the scrubber's `preview:` selector and ⚙ popover.
-        // Seeded from the launch flags — which stay authoritative while the
-        // overlay is hidden (the headless-capture escape hatch), where they may
-        // also COMBINE (--ghost --trajectory composes the trail into the
-        // strobe; the selector picks one mode at a time).
+        // interactively from the scrubber's "extrapolate" switch and ⚙ popover
+        // (mode / window / rate). Extrapolation defaults ON — pausing shows
+        // trail+strobe out of the box (the demo default) — and the launch
+        // flags pick the mode; they stay authoritative while the overlay is
+        // hidden (the headless-capture escape hatch), where they may also
+        // COMBINE (--ghost --trajectory composes the trail into the strobe).
+        let mut extrapolate_on = true;
         let mut preview_mode = match (args.ghost, args.trajectory, args.strobe) {
             (true, _, _) => functor_runtime_common::PreviewMode::Ghost,
-            (false, true, true) => functor_runtime_common::PreviewMode::Both,
             (false, true, false) => functor_runtime_common::PreviewMode::Trail,
             (false, false, true) => functor_runtime_common::PreviewMode::Strobe,
-            (false, false, false) => functor_runtime_common::PreviewMode::Off,
+            _ => functor_runtime_common::PreviewMode::Both,
         };
-        // The ⚙ popover's shared forward window/samples. Ghost seeds samples
-        // from its historical flag so `--ghost --ghost-divisions N` still tunes
-        // the interactive strobe.
+        // The ⚙ popover's shared forward window and samples-per-second rate
+        // (density holds as the window resizes: total samples = rate × window).
         let mut preview_window: f32 = 2.0;
-        let mut preview_samples: usize = if args.ghost { args.ghost_divisions } else { 32 };
+        let mut preview_rate: usize = 5;
         // --trajectory/--strobe preview cache. The 32-division forward-sim is
         // the expensive part, and while PAUSED its anchor (scene frame + tts) is
         // frozen — so reuse the computed preview while the anchor key matches,
@@ -1303,7 +1303,7 @@ Escape again to quit"
             // there (--ghost --trajectory composes the trail into the strobe) —
             // so headless captures are byte-for-byte unchanged.
             let (trail_wanted, strobe_wanted, ghost_active) = if scrubber_visible {
-                if clock.is_paused() {
+                if clock.is_paused() && extrapolate_on {
                     (
                         preview_mode.wants_trail(),
                         preview_mode.wants_strobe(),
@@ -1321,13 +1321,21 @@ Escape again to quit"
             // (the trail still shows: it rides IN the composited frames), and
             // it must not silently burn a forward-sim it can't display.
             let strobe_wanted = strobe_wanted && !ghost_active;
-            // Forward window/samples: the ⚙ popover's shared values
-            // interactively; the historical constants on the flag path (32
-            // samples over 1.6s), keeping captures byte-identical.
-            let (preview_divisions, preview_window_s) = if scrubber_visible {
-                (preview_samples.clamp(1, 64), preview_window)
+            // Forward window/densities. The SIM samples fine (~20/s — the
+            // trail's smooth-arc rate) while the ⚙ rate governs STROBE COPIES
+            // per second, so dots stay visible between copies and both hold
+            // their density as the window resizes. The flag path keeps its
+            // historical constants (32 samples over 1.6s, 8 copies), keeping
+            // captures byte-identical.
+            const TRAIL_RATE: f32 = 20.0;
+            let (preview_divisions, preview_window_s, strobe_copies) = if scrubber_visible {
+                let divisions =
+                    ((TRAIL_RATE * preview_window).round() as usize).clamp(1, 64);
+                let copies = ((preview_rate as f32 * preview_window).round() as usize)
+                    .clamp(1, divisions);
+                (divisions, preview_window, copies)
             } else {
-                (32usize, 1.6f32)
+                (32usize, 1.6f32, 8usize)
             };
             // While a drag-into-the-future catch-up is draining, skip the
             // preview recompute (the anchor moves every frame, so it would be
@@ -1406,8 +1414,10 @@ Escape again to quit"
                             eps: 0.04,
                             max_step: 3.0,
                             trail: trail_wanted,
-                            strobe: strobe_wanted
-                                .then(functor_runtime_common::StrobeOptions::default),
+                            strobe: strobe_wanted.then(|| functor_runtime_common::StrobeOptions {
+                                copies: strobe_copies,
+                                ..Default::default()
+                            }),
                         },
                     );
                     trail_refresh = TRAIL_REFRESH_FRAMES;
@@ -1437,11 +1447,15 @@ Escape again to quit"
                 && clock.pending_frames() == 0
             {
                 const MAX_GHOST: usize = 8;
-                // Interactive: the ⚙ popover's shared window/samples (clamped
-                // to the compositor's 8-target cap). Flag path: the historical
+                // Interactive: the ⚙ popover's rate × window (clamped to the
+                // compositor's 8-target cap). Flag path: the historical
                 // --ghost-divisions over a 2s window, byte-identical captures.
                 let (divisions, ghost_window) = if scrubber_visible {
-                    (preview_samples.clamp(1, MAX_GHOST), preview_window)
+                    (
+                        ((preview_rate as f32 * preview_window).round() as usize)
+                            .clamp(1, MAX_GHOST),
+                        preview_window,
+                    )
                 } else {
                     (args.ghost_divisions.clamp(1, MAX_GHOST), 2.0f32)
                 };
@@ -1748,9 +1762,10 @@ Escape again to quit"
                         frame: game.current_scene_frame().unwrap_or(0),
                         range: game.scene_frame_range(),
                         paused: clock.is_paused(),
+                        extrapolate: extrapolate_on,
                         preview_mode,
                         preview_window,
-                        preview_samples,
+                        preview_rate,
                     },
                 )
             } else {
@@ -1835,6 +1850,12 @@ Escape again to quit"
                     // Step implies pause: advance exactly one frame, then hold.
                     clock.step(1.0 / 60.0);
                 }
+                Some(functor_runtime_common::ui::ScrubberAction::SetExtrapolate(on)) => {
+                    if args.debug_clock {
+                        eprintln!("[clock] extrapolate {}", if on { "on" } else { "off" });
+                    }
+                    extrapolate_on = on;
+                }
                 Some(functor_runtime_common::ui::ScrubberAction::SetPreviewMode(m)) => {
                     if args.debug_clock {
                         eprintln!("[clock] preview {}", m.label());
@@ -1844,8 +1865,8 @@ Escape again to quit"
                 Some(functor_runtime_common::ui::ScrubberAction::SetPreviewWindow(w)) => {
                     preview_window = w.clamp(0.5, 5.0);
                 }
-                Some(functor_runtime_common::ui::ScrubberAction::SetPreviewSamples(n)) => {
-                    preview_samples = n.clamp(1, 64);
+                Some(functor_runtime_common::ui::ScrubberAction::SetPreviewRate(n)) => {
+                    preview_rate = n.clamp(1, 30);
                 }
                 None => {}
             }

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -1329,8 +1329,13 @@ Escape again to quit"
             } else {
                 (32usize, 1.6f32)
             };
+            // While a drag-into-the-future catch-up is draining, skip the
+            // preview recompute (the anchor moves every frame, so it would be
+            // a full forward-sim per frame and throttle the catch-up to a
+            // crawl) — it snaps back in on arrival.
             let preview_active = (trail_wanted || strobe_wanted)
-                && args.composite_demo == CompositeDemoArg::Off;
+                && args.composite_demo == CompositeDemoArg::Off
+                && clock.pending_frames() == 0;
             let preview: Option<functor_runtime_common::ScenePreview> = if preview_active {
                 // Not bound by the 8-target compositor cap — this only reads node
                 // transforms — so sample finely for a smooth arc.
@@ -1428,6 +1433,8 @@ Escape again to quit"
             let ghost_frames = if ghost_active
                 && !args.stereo_sbs
                 && args.composite_demo == CompositeDemoArg::Off
+                // Skipped during a catch-up drain, like the scene-diff preview.
+                && clock.pending_frames() == 0
             {
                 const MAX_GHOST: usize = 8;
                 // Interactive: the ⚙ popover's shared window/samples (clamped
@@ -1781,21 +1788,48 @@ Escape again to quit"
                     clock.toggle_pause();
                 }
                 Some(functor_runtime_common::ui::ScrubberAction::SeekTo(f)) => {
-                    // Dragging the timeline: non-destructive seek, and park the
-                    // clock on the scrubbed frame (resuming from there is what
-                    // commits the branch). Keep the clock's time aligned to the
-                    // scrubbed frame so a resume continues from it.
-                    match game.seek_scene_to(f) {
-                        Ok(_) => {}
-                        Err(e) => eprintln!("[scrubber] {e}"),
-                    }
-                    if let Some(tts) = game.current_scene_tts() {
-                        if args.debug_clock {
-                            eprintln!("[clock] seek frame={f}: rebase tts={tts:.3}");
+                    let newest = game.scene_frame_range().map(|(_, h)| h);
+                    match newest {
+                        Some(h) if f > h => {
+                            // Dragged INTO the rail's cyan future segment:
+                            // pass through the recorded end, then step the
+                            // game forward input-free — the clock animates
+                            // the catch-up (≤8 fixed frames per rendered
+                            // frame). Stepping from the newest frame commits
+                            // nothing away, so this is branch-safe.
+                            if args.debug_clock {
+                                eprintln!(
+                                    "[clock] seek frame={f}: {} beyond newest {h} — stepping forward",
+                                    f - h
+                                );
+                            }
+                            if let Err(e) = game.seek_scene_to(h) {
+                                eprintln!("[scrubber] {e}");
+                            }
+                            if let Some(tts) = game.current_scene_tts() {
+                                clock.rebase(tts as f32);
+                            }
+                            clock.step_frames((f - h) as u32);
                         }
-                        clock.rebase(tts as f32);
+                        _ => {
+                            // Dragging the recorded window: non-destructive
+                            // seek, and park the clock on the scrubbed frame
+                            // (resuming from there is what commits the
+                            // branch). Keep the clock's time aligned to the
+                            // scrubbed frame so a resume continues from it.
+                            match game.seek_scene_to(f) {
+                                Ok(_) => {}
+                                Err(e) => eprintln!("[scrubber] {e}"),
+                            }
+                            if let Some(tts) = game.current_scene_tts() {
+                                if args.debug_clock {
+                                    eprintln!("[clock] seek frame={f}: rebase tts={tts:.3}");
+                                }
+                                clock.rebase(tts as f32);
+                            }
+                            clock.pause();
+                        }
                     }
-                    clock.pause();
                 }
                 Some(functor_runtime_common::ui::ScrubberAction::Step) => {
                     // Step implies pause: advance exactly one frame, then hold.

--- a/runtime/functor-runtime-web/index-functor-lang.html
+++ b/runtime/functor-runtime-web/index-functor-lang.html
@@ -27,7 +27,7 @@
       #scrubber {
         position: fixed; left: 50%; bottom: 14px; transform: translateX(-50%);
         z-index: 10; display: none; align-items: center; gap: 10px;
-        font: 12px/1 monospace; color: #eee; padding: 8px 12px 20px;
+        font: 12px/1 monospace; color: #eee; padding: 8px 12px 16px;
         background: rgba(20,20,24,0.82); border-radius: 8px;
         border: 1px solid rgba(255,255,255,0.14);
       }
@@ -37,12 +37,13 @@
         border-radius: 5px; padding: 5px 9px;
       }
       #scrubber button:hover { background: rgba(110,110,125,0.7); }
-      /* Frame counter: a small faded row BELOW the controls, inside the panel
-         (the bar's extra bottom padding is its home), centered — positioned,
-         so digit growth never reflows the controls. */
+      /* Frame counter: tiny, faded, tucked right under the timeline rail and
+         centered on IT (not the panel) — positioned, so digit growth never
+         reflows the controls. */
       #scrub-label {
-        position: absolute; bottom: 5px; left: 50%; transform: translateX(-50%);
-        opacity: 0.5; font-size: 9.5px; white-space: nowrap; pointer-events: none;
+        position: absolute; top: calc(100% + 1px); left: 50%;
+        transform: translateX(-50%);
+        opacity: 0.5; font-size: 9px; white-space: nowrap; pointer-events: none;
       }
       /* The timeline rail: the range input spans the RECORDED part; the
          translucent strip marks [handle, handle + preview window] — the rail's
@@ -50,8 +51,9 @@
       #scrub-rail { position: relative; display: flex; align-items: center; width: 340px; }
       #scrub-slider { width: 100%; accent-color: #e0803a; }
       #scrub-future {
-        position: absolute; height: 3px; bottom: 5px; border-radius: 2px;
-        background: rgba(224,128,58,0.45); pointer-events: none; display: none;
+        position: absolute; height: 5px; top: 50%; transform: translateY(-50%);
+        border-radius: 2px; background: rgba(64,217,255,0.8);
+        pointer-events: none; display: none;
       }
       #scrubber label { display: flex; align-items: center; gap: 4px; }
       #scrubber input[type="number"] {
@@ -86,11 +88,11 @@
     <canvas id="canvas"></canvas>
     <button id="mouselook" title="Control the camera with the mouse; Esc to release">🖱 mouse look</button>
     <div id="scrubber">
-      <span id="scrub-label">time-travel</span>
       <button id="scrub-pause">Pause</button>
       <span id="scrub-rail">
         <input id="scrub-slider" type="range" min="0" max="0" value="0" step="1" />
         <span id="scrub-future"></span>
+        <span id="scrub-label">time-travel</span>
       </span>
       <button id="scrub-step">Step ▸</button>
       <label title="Future preview while paused: trail dots, scene-space strobe copies, or the screen-space ghost compositor (docs/time-travel.md T6)">

--- a/runtime/functor-runtime-web/index-functor-lang.html
+++ b/runtime/functor-runtime-web/index-functor-lang.html
@@ -55,6 +55,16 @@
         border-radius: 2px; background: rgba(64,217,255,0.8);
         pointer-events: none; display: none;
       }
+      /* The future segment's end cap: drag to resize the forward window in
+         place. Hangs BELOW the track so it never fights the seek thumb. */
+      #scrub-future-cap {
+        position: absolute; width: 8px; height: 14px; top: 50%;
+        transform: translateY(-50%);
+        border-radius: 2px; background: rgba(64,217,255,0.95);
+        cursor: ew-resize; display: none; touch-action: none;
+      }
+      #scrub-future-cap:hover { background: rgba(150,236,255,1); }
+      #scrub-label .fut { color: rgba(64,217,255,0.85); }
       #scrubber label { display: flex; align-items: center; gap: 4px; }
       #scrubber input[type="number"] {
         width: 42px; font: 12px/1 monospace; color: #eee;
@@ -92,6 +102,7 @@
       <span id="scrub-rail">
         <input id="scrub-slider" type="range" min="0" max="0" value="0" step="1" />
         <span id="scrub-future"></span>
+        <span id="scrub-future-cap" title="Drag to resize the preview window"></span>
         <span id="scrub-label">time-travel</span>
       </span>
       <button id="scrub-step">Step ▸</button>
@@ -282,6 +293,7 @@
         const slider = document.getElementById("scrub-slider");
         const step = document.getElementById("scrub-step");
         const future = document.getElementById("scrub-future");
+        const futureCap = document.getElementById("scrub-future-cap");
 
         let scrubbing = false;
         let pendingSeek = null;
@@ -308,6 +320,30 @@
         pushPreview();
         pushConfig();
 
+        // Drag the cyan segment's end cap to resize the forward window in
+        // place — the ⚙ window input's direct-manipulation twin.
+        let capDrag = null; // { x: pointerdown clientX, w: window at start }
+        futureCap.addEventListener("pointerdown", (e) => {
+          e.preventDefault();
+          futureCap.setPointerCapture(e.pointerId);
+          capDrag = { x: e.clientX, w: +win.value };
+        });
+        futureCap.addEventListener("pointermove", (e) => {
+          if (!capDrag) return;
+          const inset = 7;
+          const travel = slider.offsetWidth - 2 * inset;
+          const domain = +slider.max - +slider.min;
+          if (travel <= 0 || domain <= 0) return;
+          const framesPerPx = domain / travel;
+          const w = Math.min(
+            5,
+            Math.max(0.5, capDrag.w + ((e.clientX - capDrag.x) * framesPerPx) / 60)
+          );
+          win.value = w.toFixed(1);
+          pushConfig();
+        });
+        futureCap.addEventListener("pointerup", () => (capDrag = null));
+
         const update = () => {
           if (pendingSeek !== null) {
             functor_lang_seek_scene(pendingSeek);
@@ -321,35 +357,45 @@
             slider.max = hi;
             const frame = functor_lang_scene_frame();
             if (!scrubbing) slider.value = frame; // don't tug the handle mid-drag
-            label.textContent = `${frame | 0} / ${hi | 0}`;
-            pause.textContent = functor_lang_scrub_paused() ? "Resume" : "Pause";
-            // Future pseudo-bar: while a preview mode is on, the rail's domain
-            // extends past the recorded end by the preview window (60 fixed
-            // frames/sec) — the slider spans the recorded part and the strip
-            // marks [handle, handle + window], showing how far ahead the
-            // preview looks.
+            // The rail's domain includes the preview window: the handle can be
+            // dragged INTO the cyan segment — a seek beyond the recorded end
+            // steps the game forward, input-free (the runtime animates the
+            // catch-up). The counter's cyan `+N` is the numeric twin.
             const span = hi - lo;
-            const futureFrames = +preview.value !== 0 ? +win.value * 60 : 0;
+            const futureFrames =
+              +preview.value !== 0 ? Math.round(+win.value * 60) : 0;
+            slider.max = hi + futureFrames;
+            // The predicted-frames count sits WITH the current frame:
+            // `227 +120 / 227`.
+            label.innerHTML =
+              `${frame | 0}` +
+              (futureFrames > 0 ? ` <span class="fut">+${futureFrames}</span>` : "") +
+              ` / ${hi | 0}`;
+            pause.textContent = functor_lang_scrub_paused() ? "Resume" : "Pause";
             if (futureFrames > 0 && span > 0) {
-              const total = span + futureFrames;
-              slider.style.width = `${(span / total) * 100}%`;
-              // The thumb's CENTER travels an inset range inside the input
-              // (≈ half the thumb), so start the strip there — not at the
-              // input's box edge — to meet the handle.
-              const railW = slider.parentElement.offsetWidth;
+              // The cyan segment [handle, handle + window] plus its draggable
+              // end cap. Anchored to the THUMB (the visual handle, including
+              // mid-drag) and starting at its right edge, so the cyan never
+              // paints over the orange traversed track or the thumb itself.
               const inset = 7;
-              const leftPx =
-                inset + ((frame - lo) / span) * (slider.offsetWidth - 2 * inset);
-              const widthPx = Math.min(
-                (futureFrames / total) * railW,
-                railW - leftPx
+              const travel = slider.offsetWidth - 2 * inset;
+              const domain = hi + futureFrames - lo;
+              const thumb = +slider.value;
+              const thumbPx = inset + ((thumb - lo) / domain) * travel;
+              const leftPx = thumbPx + inset;
+              const endPx = Math.min(
+                thumbPx + (futureFrames / domain) * travel,
+                inset + travel
               );
+              const widthPx = Math.max(endPx - leftPx, 0);
               future.style.left = `${leftPx}px`;
               future.style.width = `${widthPx}px`;
               future.style.display = "block";
+              futureCap.style.left = `${endPx - 4}px`;
+              futureCap.style.display = "block";
             } else {
-              slider.style.width = "100%";
               future.style.display = "none";
+              futureCap.style.display = "none";
             }
           } else {
             el.style.display = "none"; // nothing recorded yet

--- a/runtime/functor-runtime-web/index-functor-lang.html
+++ b/runtime/functor-runtime-web/index-functor-lang.html
@@ -106,23 +106,25 @@
         <span id="scrub-label">time-travel</span>
       </span>
       <button id="scrub-step">Step ▸</button>
-      <label title="Future preview while paused: trail dots, scene-space strobe copies, or the screen-space ghost compositor (docs/time-travel.md T6)">
-        <select id="scrub-preview">
-          <option value="0" selected>preview: off</option>
-          <option value="1">preview: trail</option>
-          <option value="2">preview: strobe</option>
-          <option value="3">preview: both</option>
-          <option value="4">preview: ghost</option>
-        </select>
+      <label title="Extrapolate the future while paused: forward-simulate the game and overlay where everything is headed (docs/time-travel.md T6)">
+        <input id="scrub-extrapolate" type="checkbox" checked />extrapolate
       </label>
       <details id="scrub-adv">
-        <summary title="Preview settings">⚙</summary>
+        <summary title="Extrapolation settings">⚙</summary>
         <div id="scrub-adv-pop">
+          <label title="What the extrapolation shows: trail dots, scene-space strobe copies, both, or the screen-space ghost compositor">show
+            <select id="scrub-mode">
+              <option value="1">trail</option>
+              <option value="2">strobe</option>
+              <option value="3" selected>both</option>
+              <option value="4">ghost</option>
+            </select>
+          </label>
           <label title="How far ahead the preview projects">window
             <input id="scrub-win" type="number" step="0.5" min="0.5" max="5" value="2" />s
           </label>
-          <label title="Forward samples across the window (ghost composites at most 8)">samples
-            <input id="scrub-samples" type="number" min="1" max="64" value="32" />
+          <label title="Strobe copies per second — the trail samples finer; density holds as the window resizes (ghost composites at most 8 total)">rate
+            <input id="scrub-rate" type="number" min="1" max="30" value="5" />/s
           </label>
         </div>
       </details>
@@ -303,20 +305,24 @@
         pause.addEventListener("click", () => functor_lang_scrub_toggle_pause());
         step.addEventListener("click", () => functor_lang_scrub_step());
 
-        // Future preview (docs/time-travel.md T6/T6d): JS owns the selector +
-        // the ⚙ popover state and pushes on change; the frame loop overlays /
-        // composites while paused. Pushed once at setup too: the browser may
-        // restore form state across a reload while the fresh runtime starts at
-        // Off / the defaults.
-        const preview = document.getElementById("scrub-preview");
+        // Future extrapolation (docs/time-travel.md T6/T6d): ONE switch on the
+        // bar (default ON — pausing shows trail+strobe out of the box); the
+        // mode / window / rate live in the ⚙ popover. JS owns the UI state and
+        // pushes the EFFECTIVE mode (0 while unchecked). Pushed once at setup
+        // too: the browser may restore form state across a reload while the
+        // fresh runtime starts at the defaults.
+        const extrapolate = document.getElementById("scrub-extrapolate");
+        const mode = document.getElementById("scrub-mode");
         const win = document.getElementById("scrub-win");
-        const samples = document.getElementById("scrub-samples");
-        const pushPreview = () => functor_lang_scrub_set_preview(+preview.value);
+        const rate = document.getElementById("scrub-rate");
+        const pushPreview = () =>
+          functor_lang_scrub_set_preview(extrapolate.checked ? +mode.value : 0);
         const pushConfig = () =>
-          functor_lang_scrub_set_preview_config(+win.value, +samples.value);
-        preview.addEventListener("change", pushPreview);
+          functor_lang_scrub_set_preview_config(+win.value, +rate.value);
+        extrapolate.addEventListener("change", pushPreview);
+        mode.addEventListener("change", pushPreview);
         win.addEventListener("input", pushConfig);
-        samples.addEventListener("input", pushConfig);
+        rate.addEventListener("input", pushConfig);
         pushPreview();
         pushConfig();
 
@@ -362,8 +368,9 @@
             // steps the game forward, input-free (the runtime animates the
             // catch-up). The counter's cyan `+N` is the numeric twin.
             const span = hi - lo;
-            const futureFrames =
-              +preview.value !== 0 ? Math.round(+win.value * 60) : 0;
+            const futureFrames = extrapolate.checked
+              ? Math.round(+win.value * 60)
+              : 0;
             slider.max = hi + futureFrames;
             // The predicted-frames count sits WITH the current frame:
             // `227 +120 / 227`.

--- a/runtime/functor-runtime-web/index-functor-lang.html
+++ b/runtime/functor-runtime-web/index-functor-lang.html
@@ -27,7 +27,7 @@
       #scrubber {
         position: fixed; left: 50%; bottom: 14px; transform: translateX(-50%);
         z-index: 10; display: none; align-items: center; gap: 10px;
-        font: 12px/1 monospace; color: #eee; padding: 8px 12px;
+        font: 12px/1 monospace; color: #eee; padding: 8px 12px 20px;
         background: rgba(20,20,24,0.82); border-radius: 8px;
         border: 1px solid rgba(255,255,255,0.14);
       }
@@ -37,22 +37,48 @@
         border-radius: 5px; padding: 5px 9px;
       }
       #scrubber button:hover { background: rgba(110,110,125,0.7); }
-      #scrub-slider { width: 320px; accent-color: #e0803a; }
-      #scrub-label { min-width: 150px; }
-      /* Forward-ghosting controls (docs/time-travel.md T6d): toggle the ghost
-         and tune its divisions / window, alongside the transport. */
+      /* Frame counter: a small faded row BELOW the controls, inside the panel
+         (the bar's extra bottom padding is its home), centered — positioned,
+         so digit growth never reflows the controls. */
+      #scrub-label {
+        position: absolute; bottom: 5px; left: 50%; transform: translateX(-50%);
+        opacity: 0.5; font-size: 9.5px; white-space: nowrap; pointer-events: none;
+      }
+      /* The timeline rail: the range input spans the RECORDED part; the
+         translucent strip marks [handle, handle + preview window] — the rail's
+         domain extends past the recorded end while a preview is on. */
+      #scrub-rail { position: relative; display: flex; align-items: center; width: 340px; }
+      #scrub-slider { width: 100%; accent-color: #e0803a; }
+      #scrub-future {
+        position: absolute; height: 3px; bottom: 5px; border-radius: 2px;
+        background: rgba(224,128,58,0.45); pointer-events: none; display: none;
+      }
       #scrubber label { display: flex; align-items: center; gap: 4px; }
       #scrubber input[type="number"] {
         width: 42px; font: 12px/1 monospace; color: #eee;
         background: rgba(80,80,90,0.6); border: 1px solid rgba(255,255,255,0.15);
         border-radius: 5px; padding: 4px 5px;
       }
-      #scrub-ghost { accent-color: #e0803a; }
-      /* Scene-diff preview (docs/time-travel.md T6): trail / strobe selector. */
+      /* Future preview (docs/time-travel.md T6/T6d): mode selector; the shared
+         window/samples knobs live in the ⚙ popover. */
       #scrub-preview {
         font: 12px/1 monospace; color: #eee;
         background: rgba(80,80,90,0.6); border: 1px solid rgba(255,255,255,0.15);
         border-radius: 5px; padding: 4px 5px;
+      }
+      #scrub-adv { position: relative; }
+      #scrub-adv > summary {
+        list-style: none; cursor: pointer; font-size: 14px; padding: 4px 6px;
+        background: rgba(80,80,90,0.6); border: 1px solid rgba(255,255,255,0.15);
+        border-radius: 5px; user-select: none;
+      }
+      #scrub-adv > summary::-webkit-details-marker { display: none; }
+      #scrub-adv[open] > summary { background: rgba(110,110,125,0.7); }
+      #scrub-adv-pop {
+        position: absolute; bottom: 130%; right: 0; z-index: 11;
+        display: flex; flex-direction: column; gap: 8px; padding: 10px 12px;
+        background: rgba(20,20,24,0.92); border-radius: 8px;
+        border: 1px solid rgba(255,255,255,0.14); white-space: nowrap;
       }
     </style>
   </head>
@@ -62,25 +88,31 @@
     <div id="scrubber">
       <span id="scrub-label">time-travel</span>
       <button id="scrub-pause">Pause</button>
-      <input id="scrub-slider" type="range" min="0" max="0" value="0" step="1" />
+      <span id="scrub-rail">
+        <input id="scrub-slider" type="range" min="0" max="0" value="0" step="1" />
+        <span id="scrub-future"></span>
+      </span>
       <button id="scrub-step">Step ▸</button>
-      <label title="Forward-ghost the scene (docs/time-travel.md T6d)">
-        <input id="scrub-ghost" type="checkbox" />ghost
-      </label>
-      <label title="Number of ghost divisions">
-        <input id="scrub-ghost-div" type="number" min="1" max="8" value="8" />÷
-      </label>
-      <label title="Ghost window (seconds)">
-        <input id="scrub-ghost-win" type="number" step="0.5" value="2" />s
-      </label>
-      <label title="Scene-diff preview while paused: dotted trail and/or scene-space strobe copies of whatever moves (docs/time-travel.md T6)">
+      <label title="Future preview while paused: trail dots, scene-space strobe copies, or the screen-space ghost compositor (docs/time-travel.md T6)">
         <select id="scrub-preview">
           <option value="0" selected>preview: off</option>
           <option value="1">preview: trail</option>
           <option value="2">preview: strobe</option>
           <option value="3">preview: both</option>
+          <option value="4">preview: ghost</option>
         </select>
       </label>
+      <details id="scrub-adv">
+        <summary title="Preview settings">⚙</summary>
+        <div id="scrub-adv-pop">
+          <label title="How far ahead the preview projects">window
+            <input id="scrub-win" type="number" step="0.5" min="0.5" max="5" value="2" />s
+          </label>
+          <label title="Forward samples across the window (ghost composites at most 8)">samples
+            <input id="scrub-samples" type="number" min="1" max="64" value="32" />
+          </label>
+        </div>
+      </details>
     </div>
     <script type="module">
 
@@ -100,8 +132,8 @@
         functor_lang_scrub_toggle_pause,
         functor_lang_scrub_step,
         functor_lang_scrub_paused,
-        functor_lang_scrub_set_ghost,
         functor_lang_scrub_set_preview,
+        functor_lang_scrub_set_preview_config,
       } from "./pkg/functor_runtime_web.js";
 
       // The Functor Lang entry file, substituted in by the CLI's dev server (see
@@ -247,9 +279,7 @@
         const pause = document.getElementById("scrub-pause");
         const slider = document.getElementById("scrub-slider");
         const step = document.getElementById("scrub-step");
-        const ghost = document.getElementById("scrub-ghost");
-        const ghostDiv = document.getElementById("scrub-ghost-div");
-        const ghostWin = document.getElementById("scrub-ghost-win");
+        const future = document.getElementById("scrub-future");
 
         let scrubbing = false;
         let pendingSeek = null;
@@ -259,24 +289,22 @@
         pause.addEventListener("click", () => functor_lang_scrub_toggle_pause());
         step.addEventListener("click", () => functor_lang_scrub_step());
 
-        // Forward-ghosting (docs/time-travel.md T6d): JS owns the ghost UI state
-        // and pushes the whole set on any change; the frame loop composites when
-        // the toggle is on. The web scrubber is always visible, so no overlay gate.
-        const pushGhost = () =>
-          functor_lang_scrub_set_ghost(ghost.checked, +ghostDiv.value, +ghostWin.value);
-        ghost.addEventListener("change", pushGhost);
-        ghostDiv.addEventListener("input", pushGhost);
-        ghostWin.addEventListener("input", pushGhost);
-
-        // Scene-diff preview (docs/time-travel.md T6): JS owns the selector
-        // state and pushes the mode index (0 off / 1 trail / 2 strobe / 3 both)
-        // on change; the frame loop overlays while paused. Pushed once at setup
-        // too: the browser may restore the select's value across a reload while
-        // the fresh runtime starts at Off.
+        // Future preview (docs/time-travel.md T6/T6d): JS owns the selector +
+        // the ⚙ popover state and pushes on change; the frame loop overlays /
+        // composites while paused. Pushed once at setup too: the browser may
+        // restore form state across a reload while the fresh runtime starts at
+        // Off / the defaults.
         const preview = document.getElementById("scrub-preview");
+        const win = document.getElementById("scrub-win");
+        const samples = document.getElementById("scrub-samples");
         const pushPreview = () => functor_lang_scrub_set_preview(+preview.value);
+        const pushConfig = () =>
+          functor_lang_scrub_set_preview_config(+win.value, +samples.value);
         preview.addEventListener("change", pushPreview);
+        win.addEventListener("input", pushConfig);
+        samples.addEventListener("input", pushConfig);
         pushPreview();
+        pushConfig();
 
         const update = () => {
           if (pendingSeek !== null) {
@@ -291,8 +319,36 @@
             slider.max = hi;
             const frame = functor_lang_scene_frame();
             if (!scrubbing) slider.value = frame; // don't tug the handle mid-drag
-            label.textContent = `time-travel · ${frame | 0} / ${hi | 0}`;
+            label.textContent = `${frame | 0} / ${hi | 0}`;
             pause.textContent = functor_lang_scrub_paused() ? "Resume" : "Pause";
+            // Future pseudo-bar: while a preview mode is on, the rail's domain
+            // extends past the recorded end by the preview window (60 fixed
+            // frames/sec) — the slider spans the recorded part and the strip
+            // marks [handle, handle + window], showing how far ahead the
+            // preview looks.
+            const span = hi - lo;
+            const futureFrames = +preview.value !== 0 ? +win.value * 60 : 0;
+            if (futureFrames > 0 && span > 0) {
+              const total = span + futureFrames;
+              slider.style.width = `${(span / total) * 100}%`;
+              // The thumb's CENTER travels an inset range inside the input
+              // (≈ half the thumb), so start the strip there — not at the
+              // input's box edge — to meet the handle.
+              const railW = slider.parentElement.offsetWidth;
+              const inset = 7;
+              const leftPx =
+                inset + ((frame - lo) / span) * (slider.offsetWidth - 2 * inset);
+              const widthPx = Math.min(
+                (futureFrames / total) * railW,
+                railW - leftPx
+              );
+              future.style.left = `${leftPx}px`;
+              future.style.width = `${widthPx}px`;
+              future.style.display = "block";
+            } else {
+              slider.style.width = "100%";
+              future.style.display = "none";
+            }
           } else {
             el.style.display = "none"; // nothing recorded yet
           }

--- a/runtime/functor-runtime-web/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-web/src/functor_lang_game.rs
@@ -1023,9 +1023,9 @@ pub enum ScrubControl {
     /// preview `<select>` (PreviewMode wire index: 0 off / 1 trail / 2 strobe /
     /// 3 both / 4 ghost). The frame loop owns the preview state.
     SetPreview(u32),
-    /// The ⚙ popover's shared forward window (seconds) + samples, pushed by
-    /// the DOM inputs on change.
-    SetPreviewConfig { window: f32, samples: usize },
+    /// The ⚙ popover's shared forward window (seconds) + samples-per-second
+    /// rate, pushed by the DOM inputs on change.
+    SetPreviewConfig { window: f32, rate: usize },
 }
 
 thread_local! {
@@ -1082,10 +1082,11 @@ pub fn functor_lang_scrub_set_preview(mode: u32) {
 }
 
 /// Page → runtime: set the preview's shared forward window (seconds) and
-/// sample count (the ⚙ popover; JS owns the inputs and pushes on change).
+/// samples-per-second rate (the ⚙ popover; JS owns the inputs and pushes on
+/// change).
 #[wasm_bindgen]
-pub fn functor_lang_scrub_set_preview_config(window: f32, samples: usize) {
-    push_scrub(ScrubControl::SetPreviewConfig { window, samples });
+pub fn functor_lang_scrub_set_preview_config(window: f32, rate: usize) {
+    push_scrub(ScrubControl::SetPreviewConfig { window, rate });
 }
 
 /// Page → runtime: non-destructively scrub to a rendered frame (slider drag).

--- a/runtime/functor-runtime-web/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-web/src/functor_lang_game.rs
@@ -1019,17 +1019,13 @@ pub enum ScrubControl {
     TogglePause,
     Step,
     SeekTo(u64),
-    /// Forward-ghosting (docs/time-travel.md T6d): toggle + parameters, pushed by
-    /// the DOM ghost controls. The frame loop owns the ghost state.
-    SetGhost {
-        on: bool,
-        divisions: usize,
-        window: f32,
-    },
-    /// Scene-diff preview mode (docs/time-travel.md T6), pushed by the DOM
+    /// Future-preview mode (docs/time-travel.md T6/T6d), pushed by the DOM
     /// preview `<select>` (PreviewMode wire index: 0 off / 1 trail / 2 strobe /
-    /// 3 both). The frame loop owns the preview state.
+    /// 3 both / 4 ghost). The frame loop owns the preview state.
     SetPreview(u32),
+    /// The ⚙ popover's shared forward window (seconds) + samples, pushed by
+    /// the DOM inputs on change.
+    SetPreviewConfig { window: f32, samples: usize },
 }
 
 thread_local! {
@@ -1078,22 +1074,18 @@ pub fn functor_lang_scrub_step() {
     push_scrub(ScrubControl::Step);
 }
 
-/// Page → runtime: set forward-ghosting on/off and its parameters (JS owns the
-/// ghost UI state and pushes this on any change — docs/time-travel.md T6d).
-#[wasm_bindgen]
-pub fn functor_lang_scrub_set_ghost(on: bool, divisions: usize, window: f32) {
-    push_scrub(ScrubControl::SetGhost {
-        on,
-        divisions,
-        window,
-    });
-}
-
-/// Page → runtime: set the scene-diff preview mode (the DOM preview `<select>`;
-/// 0 off / 1 trail / 2 strobe / 3 both — `PreviewMode::from_index`).
+/// Page → runtime: set the future-preview mode (the DOM preview `<select>`;
+/// 0 off / 1 trail / 2 strobe / 3 both / 4 ghost — `PreviewMode::from_index`).
 #[wasm_bindgen]
 pub fn functor_lang_scrub_set_preview(mode: u32) {
     push_scrub(ScrubControl::SetPreview(mode));
+}
+
+/// Page → runtime: set the preview's shared forward window (seconds) and
+/// sample count (the ⚙ popover; JS owns the inputs and pushes on change).
+#[wasm_bindgen]
+pub fn functor_lang_scrub_set_preview_config(window: f32, samples: usize) {
+    push_scrub(ScrubControl::SetPreviewConfig { window, samples });
 }
 
 /// Page → runtime: non-destructively scrub to a rendered frame (slider drag).

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -1108,13 +1108,30 @@ async fn run_async() -> Result<(), JsValue> {
                         preview_samples = samples.clamp(1, 64);
                     }
                     functor_lang_game::ScrubControl::SeekTo(f) => {
-                        let _ = game.seek_scene_to(f);
-                        // Park on the scrubbed frame and keep the clock aligned to
-                        // its time, so resuming continues from there.
-                        if let Some(tts) = game.current_scene_tts() {
-                            clock.rebase(tts as f32);
+                        let newest = game.scene_frame_range().map(|(_, h)| h);
+                        match newest {
+                            Some(h) if f > h => {
+                                // Dragged INTO the rail's cyan future segment:
+                                // pass through the recorded end, then step the
+                                // game forward input-free (the clock animates
+                                // the catch-up — mirrors the desktop shell).
+                                let _ = game.seek_scene_to(h);
+                                if let Some(tts) = game.current_scene_tts() {
+                                    clock.rebase(tts as f32);
+                                }
+                                clock.step_frames((f - h) as u32);
+                            }
+                            _ => {
+                                let _ = game.seek_scene_to(f);
+                                // Park on the scrubbed frame and keep the clock
+                                // aligned to its time, so resuming continues
+                                // from there.
+                                if let Some(tts) = game.current_scene_tts() {
+                                    clock.rebase(tts as f32);
+                                }
+                                clock.pause();
+                            }
                         }
-                        clock.pause();
                     }
                 }
             }
@@ -1167,7 +1184,12 @@ async fn run_async() -> Result<(), JsValue> {
             // `scene_preview`, the same step the desktop shell runs. The web
             // scrubber is always visible, so like the ghost it renders only
             // while PAUSED. Script inputs are `None`: web has no --input-script.
-            let paused = clock.is_paused();
+            // While a drag-into-the-future catch-up is draining, skip preview
+            // and ghost recomputes (the anchor moves every frame — a full
+            // forward-sim per frame would throttle the catch-up to a crawl);
+            // they snap back in on arrival.
+            let catching_up = clock.pending_frames() > 0;
+            let paused = clock.is_paused() && !catching_up;
             let trail_wanted = preview_mode.wants_trail() && paused;
             // The selector is single-valued, so a strobe mode and the ghost
             // compositor can never be on together (the double-ghost hazard the
@@ -1251,7 +1273,7 @@ async fn run_async() -> Result<(), JsValue> {
             // times every LIVE rAF frame would starve the wasm render loop (the
             // interpreter forward-step is costly on WebGL2). Pause via the DOM
             // scrubber to see it.
-            let ghosts = if preview_mode.wants_ghost() && clock.is_paused() {
+            let ghosts = if preview_mode.wants_ghost() && clock.is_paused() && !catching_up {
                 // The ⚙ popover's shared window/samples, clamped to the
                 // compositor's 8-target cap.
                 let divisions = preview_samples.clamp(1, 8);

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -1065,7 +1065,7 @@ async fn run_async() -> Result<(), JsValue> {
         // within ~half a second.
         let mut preview_mode = functor_runtime_common::PreviewMode::Off;
         let mut preview_window: f32 = 2.0;
-        let mut preview_samples: usize = 32;
+        let mut preview_rate: usize = 5;
         const PREVIEW_REFRESH_FRAMES: u32 = 30;
         let mut preview_cache: Option<(
             (Option<u64>, u32, bool, bool, usize, u32),
@@ -1103,9 +1103,9 @@ async fn run_async() -> Result<(), JsValue> {
                     functor_lang_game::ScrubControl::SetPreview(mode) => {
                         preview_mode = functor_runtime_common::PreviewMode::from_index(mode);
                     }
-                    functor_lang_game::ScrubControl::SetPreviewConfig { window, samples } => {
+                    functor_lang_game::ScrubControl::SetPreviewConfig { window, rate } => {
                         preview_window = window.clamp(0.5, 5.0);
-                        preview_samples = samples.clamp(1, 64);
+                        preview_rate = rate.clamp(1, 30);
                     }
                     functor_lang_game::ScrubControl::SeekTo(f) => {
                         let newest = game.scene_frame_range().map(|(_, h)| h);
@@ -1201,7 +1201,7 @@ async fn run_async() -> Result<(), JsValue> {
                     frame_time.tts.to_bits(),
                     trail_wanted,
                     strobe_wanted,
-                    preview_samples,
+                    preview_rate,
                     preview_window.to_bits(),
                 );
                 let cache_hit = preview_refresh > 0
@@ -1210,21 +1210,34 @@ async fn run_async() -> Result<(), JsValue> {
                     preview_refresh -= 1;
                     preview_cache.as_ref().map(|(_, p)| p.clone())
                 } else {
+                    // The SIM samples fine (~20/s — the trail's smooth-arc
+                    // rate) while the ⚙ rate governs STROBE COPIES per second,
+                    // so dots stay visible between copies and both hold their
+                    // density as the window resizes.
+                    const TRAIL_RATE: f32 = 20.0;
+                    let divisions =
+                        ((TRAIL_RATE * preview_window).round() as usize).clamp(1, 64);
+                    let copies = ((preview_rate as f32 * preview_window).round() as usize)
+                        .clamp(1, divisions);
                     let p = functor_runtime_common::scene_preview(
                         &**game,
                         &frame.scene,
                         frame_time.tts as f64,
                         None,
                         &functor_runtime_common::PreviewOptions {
-                            divisions: preview_samples.clamp(1, 64),
+                            divisions,
                             window: preview_window,
                             // eps 0.04: ignore sub-mm jitter. max_step 3.0: cut
                             // respawn teleports.
                             eps: 0.04,
                             max_step: 3.0,
                             trail: trail_wanted,
-                            strobe: strobe_wanted
-                                .then(functor_runtime_common::StrobeOptions::default),
+                            strobe: strobe_wanted.then(|| {
+                                functor_runtime_common::StrobeOptions {
+                                    copies,
+                                    ..Default::default()
+                                }
+                            }),
                         },
                     );
                     preview_refresh = PREVIEW_REFRESH_FRAMES;
@@ -1274,9 +1287,10 @@ async fn run_async() -> Result<(), JsValue> {
             // interpreter forward-step is costly on WebGL2). Pause via the DOM
             // scrubber to see it.
             let ghosts = if preview_mode.wants_ghost() && clock.is_paused() && !catching_up {
-                // The ⚙ popover's shared window/samples, clamped to the
-                // compositor's 8-target cap.
-                let divisions = preview_samples.clamp(1, 8);
+                // The ⚙ popover's rate × window, clamped to the compositor's
+                // 8-target cap.
+                let divisions = ((preview_rate as f32 * preview_window).round() as usize)
+                    .clamp(1, 8);
                 let dt = preview_window / divisions as f32;
                 game.ghost_frames(divisions, dt, frame_time.tts as f64, None)
             } else {

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -1056,22 +1056,19 @@ async fn run_async() -> Result<(), JsValue> {
         // golden captures.
         let mut clock = GameClock::new(fixed_time);
 
-        // Forward-ghosting (docs/time-travel.md T6d). Unlike native (gated on the
-        // `~` overlay), the web DOM scrubber is always visible, so the ghost shows
-        // whenever `ghost_on`. JS owns this UI state and pushes `SetGhost` on change.
-        let mut ghost_on = false;
-        let mut ghost_divisions: usize = 8;
-        let mut ghost_window: f32 = 2.0;
-
-        // Scene-diff preview (docs/time-travel.md T6): trail dots and/or
-        // scene-space strobe copies, driven by the DOM preview <select>. Same
-        // anchor cache as the desktop shell: while paused the anchor (scene
-        // frame + tts) is frozen, so reuse the computed preview; the refresh
-        // bound re-projects a pushed source edit within ~half a second.
+        // Future preview (docs/time-travel.md T6/T6d): trail dots, scene-space
+        // strobe copies, or the screen-space ghost compositor — one mode, driven
+        // by the DOM preview <select>, with the shared forward window/samples
+        // from the ⚙ popover. Same anchor cache as the desktop shell: while
+        // paused the anchor (scene frame + tts) is frozen, so reuse the
+        // computed preview; the refresh bound re-projects a pushed source edit
+        // within ~half a second.
         let mut preview_mode = functor_runtime_common::PreviewMode::Off;
+        let mut preview_window: f32 = 2.0;
+        let mut preview_samples: usize = 32;
         const PREVIEW_REFRESH_FRAMES: u32 = 30;
         let mut preview_cache: Option<(
-            (Option<u64>, u32, bool, bool),
+            (Option<u64>, u32, bool, bool, usize, u32),
             functor_runtime_common::ScenePreview,
         )> = None;
         let mut preview_refresh: u32 = 0;
@@ -1103,17 +1100,12 @@ async fn run_async() -> Result<(), JsValue> {
                         clock.toggle_pause();
                     }
                     functor_lang_game::ScrubControl::Step => clock.step(1.0 / 60.0),
-                    functor_lang_game::ScrubControl::SetGhost {
-                        on,
-                        divisions,
-                        window,
-                    } => {
-                        ghost_on = on;
-                        ghost_divisions = divisions;
-                        ghost_window = window;
-                    }
                     functor_lang_game::ScrubControl::SetPreview(mode) => {
                         preview_mode = functor_runtime_common::PreviewMode::from_index(mode);
+                    }
+                    functor_lang_game::ScrubControl::SetPreviewConfig { window, samples } => {
+                        preview_window = window.clamp(0.5, 5.0);
+                        preview_samples = samples.clamp(1, 64);
                     }
                     functor_lang_game::ScrubControl::SeekTo(f) => {
                         let _ = game.seek_scene_to(f);
@@ -1177,17 +1169,18 @@ async fn run_async() -> Result<(), JsValue> {
             // while PAUSED. Script inputs are `None`: web has no --input-script.
             let paused = clock.is_paused();
             let trail_wanted = preview_mode.wants_trail() && paused;
-            // Under the screen-space ghost compositor the scene-space strobe
-            // would double-ghost — and the compositor arm never draws this
-            // frame — so the strobe yields to the ghost (the trail still shows:
-            // it rides IN the composited frames below).
-            let strobe_wanted = preview_mode.wants_strobe() && paused && !ghost_on;
+            // The selector is single-valued, so a strobe mode and the ghost
+            // compositor can never be on together (the double-ghost hazard the
+            // desktop flag path still guards against).
+            let strobe_wanted = preview_mode.wants_strobe() && paused;
             let preview = if trail_wanted || strobe_wanted {
                 let key = (
                     game.current_scene_frame(),
                     frame_time.tts.to_bits(),
                     trail_wanted,
                     strobe_wanted,
+                    preview_samples,
+                    preview_window.to_bits(),
                 );
                 let cache_hit = preview_refresh > 0
                     && preview_cache.as_ref().is_some_and(|(k, _)| *k == key);
@@ -1201,8 +1194,8 @@ async fn run_async() -> Result<(), JsValue> {
                         frame_time.tts as f64,
                         None,
                         &functor_runtime_common::PreviewOptions {
-                            divisions: 32,
-                            window: 1.6,
+                            divisions: preview_samples.clamp(1, 64),
+                            window: preview_window,
                             // eps 0.04: ignore sub-mm jitter. max_step 3.0: cut
                             // respawn teleports.
                             eps: 0.04,
@@ -1245,45 +1238,39 @@ async fn run_async() -> Result<(), JsValue> {
             }
             let viewport = functor_runtime_common::Viewport::new(canvas.width(), canvas.height());
 
-            // Forward-ghosting (docs/time-travel.md T6d): when the DOM ghost
-            // toggle is on AND the clock is paused, forward-step the scene over
-            // `ghost_window` seconds in `ghost_divisions` slices and composite them
-            // at equal weight, so moving elements strobe across their future and
-            // static geometry stays solid. `None` = the recorded-log/coast path
-            // (web has no --input-script). Empty (→ this arm skipped) leaves live
-            // rendering unchanged.
+            // Forward-ghosting (docs/time-travel.md T6d): when the preview
+            // selector is on `ghost` AND the clock is paused, forward-step the
+            // scene over the ⚙ popover's window in up to 8 slices and composite
+            // them at equal weight, so moving elements strobe across their
+            // future and static geometry stays solid. `None` = the
+            // recorded-log/coast path (web has no --input-script). Empty
+            // (→ this arm skipped) leaves live rendering unchanged.
             //
             // Gated on `is_paused()` to match the desktop shell: the strobe is a
             // preview of a FROZEN frame's future, and forward-stepping the scene N
             // times every LIVE rAF frame would starve the wasm render loop (the
             // interpreter forward-step is costly on WebGL2). Pause via the DOM
             // scrubber to see it.
-            let ghosts = if ghost_on && clock.is_paused() {
-                let divisions = ghost_divisions.clamp(1, 8);
-                let dt = ghost_window / divisions as f32;
+            let ghosts = if preview_mode.wants_ghost() && clock.is_paused() {
+                // The ⚙ popover's shared window/samples, clamped to the
+                // compositor's 8-target cap.
+                let divisions = preview_samples.clamp(1, 8);
+                let dt = preview_window / divisions as f32;
                 game.ghost_frames(divisions, dt, frame_time.tts as f64, None)
             } else {
                 Vec::new()
             };
 
-            // The trail composes with the ghost strobe by riding IN each
-            // composited frame (identical opaque geometry at identical world
-            // positions reconstructs at full intensity under the equal-weight
-            // average); otherwise the preview overlays go on the live frame.
-            let mut ghosts = ghosts;
-            if let Some(t) = preview.as_ref().and_then(|p| p.trail.as_ref()) {
-                for (f, _) in ghosts.iter_mut() {
-                    functor_runtime_common::overlay(&mut f.scene, t.clone());
+            // Preview overlays go on the live frame. (The single-valued mode
+            // selector means the scene-diff preview and the ghost compositor
+            // are never on together here — unlike the desktop flag path, where
+            // --ghost --trajectory composes the trail into the ghost frames.)
+            if let Some(p) = &preview {
+                if let Some(t) = &p.trail {
+                    functor_runtime_common::overlay(&mut frame.scene, t.clone());
                 }
-            }
-            if ghosts.is_empty() {
-                if let Some(p) = &preview {
-                    if let Some(t) = &p.trail {
-                        functor_runtime_common::overlay(&mut frame.scene, t.clone());
-                    }
-                    if let Some(s) = &p.strobe {
-                        functor_runtime_common::overlay(&mut frame.scene, s.clone());
-                    }
+                if let Some(s) = &p.strobe {
+                    functor_runtime_common::overlay(&mut frame.scene, s.clone());
                 }
             }
 


### PR DESCRIPTION
## Scrubber redesign — future bar, ⚙ popover, ghost as a mode

Builds on #321 (merged). The declutter pass, per design feedback: the bar collapses to
`Pause | timeline | Step | preview ▾ | ⚙`.

- **Frame counter out of the row**: a small faded line below the controls,
  centered in the panel. Digit growth never reflows the controls
  (Playwright-verified: bar width byte-stable while the count grows digits).
- **Future pseudo-bar**: while a preview is on, the timeline's domain extends
  past the recorded end by the forward window; the slider spans the recorded
  part and a translucent strip marks **[handle, handle + window]** — how far
  ahead the preview looks, widening live as the window is tuned (both shells
  inset-corrected to the handle's real travel).
- **Ghost folds into the selector** (`off / trail / strobe / both / ghost`) —
  it's still the only mode that can strobe *lighting* changes — and the ghost
  checkbox / ÷ / window widgets become a shared **⚙ popover** (window 0.5–5s,
  samples 1–64, ghost clamps to the compositor's 8).
- **Flags unchanged where it matters**: with the overlay hidden, the raw launch
  flags drive everything (they still combine — `--ghost --trajectory`
  composes) and headless captures are **byte-identical** to pre-redesign. New
  `--scrubber` starts the overlay visible for demos/captures.
- `--ghost --input-script` keeps its F2 session semantics: the selector
  changes the visualization, never the script routing (documented in place).

### Verified

260 common tests · strict native + wasm32 checks · wasm goldens untouched
(scrubber hidden under `?fixed-time`) · flag-path captures byte-identical ·
Playwright e2e drives the real DOM bar (counter placement + centering, width
stability across digit growth, strip show/hide per mode, strip widening 2s→4s
via the popover, ghost mode via the selector). Cross-engine review (Claude +
Codex): all actionable findings addressed; one declined as intended semantics
and documented.


### The cyan segment is interactive (second round of design feedback)

- **Drag the handle INTO the cyan** — the rail's domain includes the preview
  window, and a seek beyond the recorded end steps the game forward,
  input-free. The catch-up rides a new `GameClock::step_frames(n)` primitive:
  whole `FIXED_DT` sub-frames drained ≤`MAX_SUBSTEPS` per rendered frame (never
  one fat tick — the fixed-timestep invariant that keeps recording/replay sound
  holds), so long drags animate. Preview/ghost recomputes are skipped while the
  drain is in flight (a forward-sim per frame throttled the catch-up — caught
  by the e2e) and snap back in on arrival.
- **Drag the segment's end cap** to resize the forward window in place — the ⚙
  window input's direct-manipulation twin, both shells.
- **The counter shows the numeric twin** with the current frame:
  `277 +120 / 277`, the `+N` in segment-cyan. The segment anchors to the
  thumb's right edge (never over the orange traversed track) and the cap
  centers on the bar.

E2E additions: drag-to-max advances the game to exactly the target frame
(277 → 517 in the run), the counter suffix equals window×60, and off-mode
still restores the paused frame byte-identically. New clock unit test covers
the chunked drain, the hold at arrival, and backlog clearing on pause
transitions.


### Third round: one "extrapolate" switch, on by default

- The bar's preview control is now a single **`extrapolate` checkbox, DEFAULT
  ON with trail+strobe** — pausing shows the full future preview with zero
  interaction (the website-demo default). The mode (trail / strobe / both /
  ghost) joins window + rate in the ⚙ popover.
- **Per-second densities**: the sim samples ~20/s (smooth trail arcs) while the
  ⚙ `rate` sets **strobe copies per second** (default 5/s — distinct copies),
  both holding as the window resizes. **Off-cadence**: the trail skips the
  samples copies stand on, so dots fill the gaps between copies.
- Flag path untouched (historical constants; captures byte-identical).

## Demo

**Desktop** (`--scrubber --trajectory`): the counter tucked under the
controls; the orange strip is the rail's future segment — 2s of preview beyond
the 54 recorded frames:

![desktop](https://gist.githubusercontent.com/tommy-xr/5154fc7928005a7a891d483817b2644e/raw/desktop-scrubber-v3.png)

**Web** — `preview: trail` paused (strip after the handle), the new ghost
mode, and the ⚙ popover with a widened window:

| trail | ghost |
| --- | --- |
| ![trail](https://gist.githubusercontent.com/tommy-xr/5154fc7928005a7a891d483817b2644e/raw/web2-trail.png) | ![ghost](https://gist.githubusercontent.com/tommy-xr/5154fc7928005a7a891d483817b2644e/raw/web2-ghost.png) |

![popover](https://gist.githubusercontent.com/tommy-xr/5154fc7928005a7a891d483817b2644e/raw/web2-popover.png)

<sub>All states exercised headlessly by the Playwright run that asserts the
layout invariants. One follow-up left deliberately: a manual interactive check
of the desktop ⚙ popover (egui popup under the scrubber's pointer bridge —
reviewer-verified plumbing, untested by hand).</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


