### PR TITLE
feat(functor-lang): List.length/append/flatten/any/all/reverse/isEmpty + clearer depth-cap error

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -260,7 +260,11 @@ open Widget                                              // …or open, bringing
   `let Foo` may coexist, but constructors share the value namespace with
   `let`s), record fields (literal and update), lambda params, pattern
   variables within one pattern.
-- Recursion depth is capped (~200); deep iteration belongs in `List.*`.
+- Recursion depth is capped (128 eval levels); deep iteration belongs in the
+  iterative `List.*` builtins (`List.fold`/`map`/`filter`/`any`/`all`/`length`/…),
+  which loop in the interpreter and consume no evaluation depth. A hand-rolled
+  recursive list walk trips the cap around n≈60; the depth error names the cap
+  value (128) and points at `List.fold`.
 
 ## Builtins (the whole registry)
 
@@ -272,7 +276,12 @@ thread through `|>` (which appends): `list |> List.map(fn)` == `List.map(fn, lis
 `List.grid(fn, rows, cols)` (→ `List<List<'a>>`; calls `fn(row, col)`, both
 0-based, per cell — the engine-loop form of a procedural heightmap, e.g.
 `Scene.heightmap(List.grid(height, r, c))`) ·
-`List.maximum(list)` · `Text.concat(a, b)` · `Text.fromFloat(n)` ·
+`List.maximum(list)` · `List.length(list)` (→ Float) · `List.isEmpty(list)` ·
+`List.reverse(list)` · `List.flatten(list)` (`List<List<'a>>` → `List<'a>`, one
+level) · `List.append(other, list)` (subject-LAST: `xs |> List.append(ys)` is
+`xs` followed by `ys`) · `List.any(fn, list)` / `List.all(fn, list)` (predicate
+first, list last — `xs |> List.any(pred)`; empty list is vacuously all-true /
+any-false) · `Text.concat(a, b)` · `Text.fromFloat(n)` ·
 `Text.fixed(n, decimals)` (fixed-decimal; `Text.fixed(42.0, 0.0)` = `"42"`, the
 `%d` shape) · `Text.toBullets(list)` · `Text.split(sep, s)` (→ `List<string>`;
 empty `sep` is an error; `Text.split(sep, "")` = `[""]`) · `Text.join(sep, list)`

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -19,7 +19,7 @@ bug found in the same exercise was fixed on the spot
       sin-hash noise, whose correlated streams caused a real visual bug.
 - [ ] Boolean operators `&&` / `||` / `not` (compound predicates are
       match-pyramids / hand-rolled helpers today).
-- [ ] List builtins: `length`, `append`, `flatten`, `any`/`all`, `reverse`,
+- [x] List builtins: `length`, `append`, `flatten`, `any`/`all`, `reverse`,
       `isEmpty` — naive recursive versions blow the eval-depth cap at n≈60;
       the depth error should name the cap and hint at `List.fold`.
 - [ ] Literals inside tuple/ctor patterns (`| ("Enter", true) =>`) for

--- a/functor-lang/src/complete.rs
+++ b/functor-lang/src/complete.rs
@@ -64,14 +64,21 @@ pub enum CompletionKind {
 }
 
 /// The complete builtin registry. Hand-listed because [`Builtin`] is not
-/// iterable — keep in sync with `eval::Builtin` (17 variants).
-const BUILTINS: [Builtin; 17] = [
+/// iterable — keep in sync with `eval::Builtin` (24 variants).
+const BUILTINS: [Builtin; 24] = [
     Builtin::ListMap,
     Builtin::ListFilter,
     Builtin::ListFold,
     Builtin::ListRange,
     Builtin::ListGrid,
     Builtin::ListMaximum,
+    Builtin::ListLength,
+    Builtin::ListAppend,
+    Builtin::ListFlatten,
+    Builtin::ListAny,
+    Builtin::ListAll,
+    Builtin::ListReverse,
+    Builtin::ListIsEmpty,
     Builtin::MathSin,
     Builtin::MathCos,
     Builtin::TextConcat,
@@ -1384,6 +1391,13 @@ mod tests {
                 | Builtin::ListRange
                 | Builtin::ListGrid
                 | Builtin::ListMaximum
+                | Builtin::ListLength
+                | Builtin::ListAppend
+                | Builtin::ListFlatten
+                | Builtin::ListAny
+                | Builtin::ListAll
+                | Builtin::ListReverse
+                | Builtin::ListIsEmpty
                 | Builtin::MathSin
                 | Builtin::MathCos
                 | Builtin::MathClamp01
@@ -1397,7 +1411,7 @@ mod tests {
                 | Builtin::DebugLog => {}
             }
         }
-        assert_eq!(BUILTINS.len(), 17, "BUILTINS must list every Builtin");
+        assert_eq!(BUILTINS.len(), 24, "BUILTINS must list every Builtin");
     }
 
     // 19. A full keyword typed (`let`, cursor at end) still offers `let`.

--- a/functor-lang/src/eval.rs
+++ b/functor-lang/src/eval.rs
@@ -309,9 +309,12 @@ impl Interp<'_> {
         if self.depth > MAX_EVAL_DEPTH {
             self.depth -= 1;
             return Err(RunError {
-                message:
-                    "evaluation nested too deeply (deep recursion, or deeply nested expressions)"
-                        .to_string(),
+                message: format!(
+                    "evaluation nested too deeply (exceeded the depth cap of {MAX_EVAL_DEPTH}): \
+deep recursion, or deeply nested expressions. Deep list iteration belongs in the builtin list \
+functions (List.fold/map/filter/any/all/length/…), which loop in the interpreter and consume no \
+evaluation depth."
+                ),
                 span: expr.span,
             });
         }
@@ -955,6 +958,109 @@ most 1000000 cells"
                 }
                 _ => err("List.maximum(list) expects one list".to_string()),
             },
+            // The iterative list helpers a game reaches for — hand-rolling
+            // these recursively blows the eval-depth cap around n≈60, so they
+            // loop in Rust and consume no evaluation depth (see MAX_EVAL_DEPTH).
+            Builtin::ListLength => match args.as_slice() {
+                [Value::List(items)] => Ok(Value::Number(items.len() as f64)),
+                _ => err("List.length(list) expects one list".to_string()),
+            },
+            // Subject-LAST — `xs |> List.append(ys)` is `List.append(ys, xs)`
+            // and yields `xs` followed by `ys` (the piped list stays the head).
+            Builtin::ListAppend => match args.as_slice() {
+                [Value::List(other), Value::List(items)] => {
+                    let mut out = Vec::with_capacity(items.len() + other.len());
+                    out.extend(items.iter().cloned());
+                    out.extend(other.iter().cloned());
+                    Ok(Value::List(Rc::new(out)))
+                }
+                _ => err("List.append(other, list) expects two lists".to_string()),
+            },
+            // Concatenate a list of lists one level deep (`List<List<'a>>` ->
+            // `List<'a>`). A non-list element is an error, not a silent no-op.
+            Builtin::ListFlatten => match args.as_slice() {
+                [Value::List(items)] => {
+                    let mut out = Vec::new();
+                    for item in items.iter() {
+                        match item {
+                            Value::List(inner) => out.extend(inner.iter().cloned()),
+                            other => {
+                                return err(format!(
+                                    "List.flatten expects a list of lists, got {}",
+                                    other.kind_name()
+                                ))
+                            }
+                        }
+                    }
+                    Ok(Value::List(Rc::new(out)))
+                }
+                _ => err("List.flatten(list) expects one list of lists".to_string()),
+            },
+            // Subject-LAST — `xs |> List.any(pred)`. True when the predicate
+            // holds for at least one element; short-circuits on the first hit.
+            Builtin::ListAny => match args.as_slice() {
+                [f, Value::List(items)] => {
+                    for (i, item) in items.iter().enumerate() {
+                        match self.call(
+                            f.clone(),
+                            vec![item.clone()],
+                            element_label(b, i),
+                            span,
+                            Some(builtin_name(b)),
+                        )? {
+                            Value::Bool(true) => return Ok(Value::Bool(true)),
+                            Value::Bool(false) => {}
+                            other => {
+                                return err(format!(
+                                    "List.any predicate must return a bool, got {}",
+                                    other.kind_name()
+                                ))
+                            }
+                        }
+                    }
+                    Ok(Value::Bool(false))
+                }
+                _ => err("List.any(fn, list) expects a function and a list".to_string()),
+            },
+            // Subject-LAST — `xs |> List.all(pred)`. True when the predicate
+            // holds for every element; short-circuits on the first miss (an
+            // empty list is vacuously true).
+            Builtin::ListAll => match args.as_slice() {
+                [f, Value::List(items)] => {
+                    for (i, item) in items.iter().enumerate() {
+                        match self.call(
+                            f.clone(),
+                            vec![item.clone()],
+                            element_label(b, i),
+                            span,
+                            Some(builtin_name(b)),
+                        )? {
+                            Value::Bool(true) => {}
+                            Value::Bool(false) => return Ok(Value::Bool(false)),
+                            other => {
+                                return err(format!(
+                                    "List.all predicate must return a bool, got {}",
+                                    other.kind_name()
+                                ))
+                            }
+                        }
+                    }
+                    Ok(Value::Bool(true))
+                }
+                _ => err("List.all(fn, list) expects a function and a list".to_string()),
+            },
+            Builtin::ListReverse => match args.as_slice() {
+                [Value::List(items)] => {
+                    let mut out: Vec<Value> = items.iter().cloned().collect();
+                    out.reverse();
+                    Ok(Value::List(Rc::new(out)))
+                }
+                _ => err("List.reverse(list) expects one list".to_string()),
+            },
+            Builtin::ListIsEmpty => match args.as_slice() {
+                [Value::List(items)] => Ok(Value::Bool(items.is_empty())),
+                _ => err("List.isEmpty(list) expects one list".to_string()),
+            },
             Builtin::TextConcat => match args.as_slice() {
                 [Value::String(a), Value::String(b)] => {
                     Ok(Value::String(Rc::from(format!("{a}{b}").as_str())))
@@ -1294,6 +1400,9 @@ pub fn builtin_arity(b: Builtin) -> usize {
         Builtin::ListFold | Builtin::ListGrid => 3,
         Builtin::ListMap
         | Builtin::ListFilter
+        | Builtin::ListAppend
+        | Builtin::ListAny
+        | Builtin::ListAll
         | Builtin::TextConcat
         | Builtin::TextFixed
         | Builtin::TextSplit
@@ -1301,6 +1410,10 @@ pub fn builtin_arity(b: Builtin) -> usize {
         | Builtin::DebugLog => 2,
         Builtin::ListRange
         | Builtin::ListMaximum
+        | Builtin::ListLength
+        | Builtin::ListFlatten
+        | Builtin::ListReverse
+        | Builtin::ListIsEmpty
         | Builtin::TextFromFloat
         | Builtin::TextToBullets
         | Builtin::TextParseFloat
@@ -1320,6 +1433,13 @@ pub enum Builtin {
     MathSin,
     MathCos,
     ListMaximum,
+    ListLength,
+    ListAppend,
+    ListFlatten,
+    ListAny,
+    ListAll,
+    ListReverse,
+    ListIsEmpty,
     TextConcat,
     TextFromFloat,
     TextFixed,
@@ -1341,6 +1461,13 @@ pub fn builtin(path: &[String]) -> Option<Builtin> {
         "List.range" => Builtin::ListRange,
         "List.grid" => Builtin::ListGrid,
         "List.maximum" => Builtin::ListMaximum,
+        "List.length" => Builtin::ListLength,
+        "List.append" => Builtin::ListAppend,
+        "List.flatten" => Builtin::ListFlatten,
+        "List.any" => Builtin::ListAny,
+        "List.all" => Builtin::ListAll,
+        "List.reverse" => Builtin::ListReverse,
+        "List.isEmpty" => Builtin::ListIsEmpty,
         "Text.concat" => Builtin::TextConcat,
         "Text.fromFloat" => Builtin::TextFromFloat,
         "Text.fixed" => Builtin::TextFixed,
@@ -1365,6 +1492,13 @@ pub fn builtin_name(b: Builtin) -> &'static str {
         Builtin::ListRange => "List.range",
         Builtin::ListGrid => "List.grid",
         Builtin::ListMaximum => "List.maximum",
+        Builtin::ListLength => "List.length",
+        Builtin::ListAppend => "List.append",
+        Builtin::ListFlatten => "List.flatten",
+        Builtin::ListAny => "List.any",
+        Builtin::ListAll => "List.all",
+        Builtin::ListReverse => "List.reverse",
+        Builtin::ListIsEmpty => "List.isEmpty",
         Builtin::TextConcat => "Text.concat",
         Builtin::TextFromFloat => "Text.fromFloat",
         Builtin::TextFixed => "Text.fixed",

--- a/functor-lang/src/types.rs
+++ b/functor-lang/src/types.rs
@@ -369,6 +369,27 @@ pub fn builtin_signature(b: Builtin) -> Type {
         ),
         // List.maximum : (List<Float>) => Float
         Builtin::ListMaximum => func(vec![List(Box::new(Float))], Float),
+        // List.length : (List<'a>) => Float
+        Builtin::ListLength => func(vec![List(Box::new(Var(0)))], Float),
+        // Subject-LAST. List.append : (List<'a>, List<'a>) => List<'a> — (other, list)
+        Builtin::ListAppend => func(
+            vec![List(Box::new(Var(0))), List(Box::new(Var(0)))],
+            List(Box::new(Var(0))),
+        ),
+        // List.flatten : (List<List<'a>>) => List<'a>
+        Builtin::ListFlatten => func(
+            vec![List(Box::new(List(Box::new(Var(0)))))],
+            List(Box::new(Var(0))),
+        ),
+        // Subject-LAST. List.any / List.all : (('a) => Bool, List<'a>) => Bool
+        Builtin::ListAny | Builtin::ListAll => func(
+            vec![func(vec![Var(0)], Bool), List(Box::new(Var(0)))],
+            Bool,
+        ),
+        // List.reverse : (List<'a>) => List<'a>
+        Builtin::ListReverse => func(vec![List(Box::new(Var(0)))], List(Box::new(Var(0)))),
+        // List.isEmpty : (List<'a>) => Bool
+        Builtin::ListIsEmpty => func(vec![List(Box::new(Var(0)))], Bool),
         // Text.concat : (String, String) => String
         Builtin::TextConcat => func(vec![String, String], String),
         // Text.fromFloat : (Float) => String

--- a/functor-lang/tests/run.rs
+++ b/functor-lang/tests/run.rs
@@ -281,9 +281,11 @@ fn error_infinite_recursion_is_a_clean_error() {
         "let spin = (n) => spin(n + 1.0)\n\
          let main = () => spin(0.0)",
     );
-    assert_eq!(
-        message,
-        "evaluation nested too deeply (deep recursion, or deeply nested expressions)"
+    // The improved cap error names the numeric cap and points at the
+    // iterative builtins (List.fold), which don't consume evaluation depth.
+    assert!(
+        message.contains("128") && message.contains("List.fold"),
+        "got: {message}"
     );
 }
 
@@ -314,6 +316,83 @@ fn builtins_evaluate() {
     assert_eq!(
         main_result("let main = () => [1.0, 2.0, 3.0] |> List.fold((acc, x) => acc + x, 0.0)"),
         "6"
+    );
+}
+
+#[test]
+fn list_length_isempty_reverse() {
+    assert_eq!(main_result("let main = () => List.length([7.0, 8.0, 9.0])"), "3");
+    assert_eq!(main_result("let main = () => List.length([])"), "0");
+    assert_eq!(main_result("let main = () => List.isEmpty([])"), "true");
+    assert_eq!(main_result("let main = () => List.isEmpty([1.0])"), "false");
+    assert_eq!(
+        main_result("let main = () => List.reverse([1.0, 2.0, 3.0])"),
+        "[3, 2, 1]"
+    );
+    assert_eq!(main_result("let main = () => List.reverse([])"), "[]");
+}
+
+#[test]
+fn list_append_threads_last() {
+    // Subject-LAST: `xs |> List.append(ys)` yields xs followed by ys.
+    assert_eq!(
+        main_result("let main = () => [1.0, 2.0] |> List.append([3.0, 4.0])"),
+        "[1, 2, 3, 4]"
+    );
+    assert_eq!(
+        main_result("let main = () => List.append([3.0], [1.0, 2.0])"),
+        "[1, 2, 3]"
+    );
+    assert_eq!(main_result("let main = () => List.append([], [])"), "[]");
+}
+
+#[test]
+fn list_flatten_one_level() {
+    assert_eq!(
+        main_result("let main = () => List.flatten([[1.0, 2.0], [3.0], []])"),
+        "[1, 2, 3]"
+    );
+    assert_eq!(main_result("let main = () => List.flatten([])"), "[]");
+    let (message, _, _) = run_err("let main = () => List.flatten([1.0])");
+    assert!(message.contains("list of lists"), "got: {message}");
+}
+
+#[test]
+fn list_any_all_predicates() {
+    assert_eq!(
+        main_result("let main = () => [1.0, 2.0, 3.0] |> List.any((x) => x > 2.0)"),
+        "true"
+    );
+    assert_eq!(
+        main_result("let main = () => [1.0, 2.0, 3.0] |> List.any((x) => x > 5.0)"),
+        "false"
+    );
+    assert_eq!(
+        main_result("let main = () => [2.0, 3.0] |> List.all((x) => x > 1.0)"),
+        "true"
+    );
+    assert_eq!(
+        main_result("let main = () => [2.0, 3.0] |> List.all((x) => x > 2.0)"),
+        "false"
+    );
+    // Vacuous truth / falsity on the empty list.
+    assert_eq!(main_result("let main = () => List.all((x) => x > 0.0, [])"), "true");
+    assert_eq!(main_result("let main = () => List.any((x) => x > 0.0, [])"), "false");
+    let (message, _, _) = run_err("let main = () => List.any((x) => x, [1.0])");
+    assert!(message.contains("must return a bool"), "got: {message}");
+}
+
+// The builtins loop in Rust, so folding/iterating a large list never trips
+// the eval-depth cap that a hand-rolled recursion hits around n≈60.
+#[test]
+fn list_builtins_do_not_consume_eval_depth() {
+    assert_eq!(
+        main_result("let main = () => List.length(List.range(1000.0))"),
+        "1000"
+    );
+    assert_eq!(
+        main_result("let main = () => List.isEmpty(List.reverse(List.range(1000.0)))"),
+        "false"
     );
 }
 

--- a/functor-lang/tests/run.rs
+++ b/functor-lang/tests/run.rs
@@ -394,6 +394,14 @@ fn list_builtins_do_not_consume_eval_depth() {
         main_result("let main = () => List.isEmpty(List.reverse(List.range(1000.0)))"),
         "false"
     );
+    assert_eq!(
+        main_result("let main = () => List.range(1000.0) |> List.any((x) => x > 900.0)"),
+        "true"
+    );
+    assert_eq!(
+        main_result("let main = () => List.range(1000.0) |> List.all((x) => x < 1000.0)"),
+        "true"
+    );
 }
 
 // NaN follows f64::max (IEEE maximumNumber): ignored unless all-NaN.


### PR DESCRIPTION
## What

Adds seven iterative `List` builtins to Functor Lang and improves the eval-depth-cap error, closing the `docs/todo.md` gap found building `examples/asteroids` (naive recursive list helpers blow the eval-depth cap around n≈60).

### New builtins (all subject-LAST, loop in the interpreter, consume no eval depth)

| Builtin | Signature |
| --- | --- |
| `List.length(list)` | `(List<'a>) => Float` |
| `List.isEmpty(list)` | `(List<'a>) => Bool` |
| `List.reverse(list)` | `(List<'a>) => List<'a>` |
| `List.flatten(list)` | `(List<List<'a>>) => List<'a>` (one level; non-list element errors) |
| `List.append(other, list)` | `(List<'a>, List<'a>) => List<'a>` — `xs \|> List.append(ys)` yields `xs` followed by `ys` |
| `List.any(fn, list)` | `(('a) => Bool, List<'a>) => Bool` — predicate first, list last; short-circuits; empty is vacuously false |
| `List.all(fn, list)` | `(('a) => Bool, List<'a>) => Bool` — predicate first, list last; short-circuits; empty is vacuously true |

### Depth-cap error

Before: `evaluation nested too deeply (deep recursion, or deeply nested expressions)`

After: `evaluation nested too deeply (exceeded the depth cap of 128): deep recursion, or deeply nested expressions. Deep list iteration belongs in the builtin list functions (List.fold/map/filter/any/all/length/…), which loop in the interpreter and consume no evaluation depth.`

## Changes

- `functor-lang/src/eval.rs` — `Builtin` variants, name map, `builtin_name`, `builtin_arity`, `call_builtin` impl arms; the improved depth message.
- `functor-lang/src/types.rs` — `builtin_signature` entries (generic over element type).
- `functor-lang/src/complete.rs` — completion registry (17 → 24).
- `functor-lang/tests/run.rs` — unit tests per builtin, an empty-list/vacuous-truth case, a large-list no-eval-depth guard, and the updated depth-error assertion (names `128` + `List.fold`).
- `.claude/skills/functor-lang/SKILL.md` — documented the new prelude surface and the sharper depth-cap note.
- `docs/todo.md` — ticked the item.

## Verification

- `cargo test -p functor-lang` — all pass.
- Headless scratch `.fun`: `(List.length, List.isEmpty, List.reverse, List.flatten, List.any, List.all)` → `(103, true, [3, 2, 1], [1, 2, 3], true, true)`; a 500-deep recursion prints the new depth-cap error.
- `/xreview` (Claude + Codex): no Critical/High. One Codex Medium (predicate not pre-validated on an empty list) is consistent with the existing `List.map`/`filter`/`fold` convention and caught by the typechecker; left as-is for registry consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)