### PR TITLE
feat(functor-lang): short-circuiting boolean operators && / || / not

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -107,8 +107,13 @@ let main = () => report([12.0, 3.5, 40.0])    // zero-param main is run's entry 
 ```
 
 Operators: `+ - * /` `< > ==` (conventional precedence; pipelines bind
-loosest), unary `-`. There is **no** if/else, loops, or string-concatenation
-operator — iteration is `List.map/filter/fold`,
+loosest), unary `-`, and the **short-circuiting booleans** `&&` / `||` plus
+prefix `not`. Precedence (tightest→loosest): comparisons > `not` > `&&` > `||`
+> pipelines. So `not a == b` is `not (a == b)`, `a || b && c` is
+`a || (b && c)`, and all three operands are checked as `bool`. `&&`/`||`
+short-circuit — `false && e` / `true || e` never evaluate `e` (so
+`isReady && risky()` is safe). There is **no** if/else, loops, or
+string-concatenation operator — iteration is `List.map/filter/fold`,
 and the conditional is a **bool-literal match**
 (`match x > 3.0 with | true => a | false => b`). Tuples are structural:
 `(1.0, "a") == (1.0, "a")`; tuple types annotate as `(float, string)` and

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -17,7 +17,7 @@ bug found in the same exercise was fixed on the spot
 - [ ] Pure seeded randomness (`Random.step(seed) -> (value, seed)` or
       `Effect.randomList`) — `Effect.random`'s one-float-per-update forces
       sin-hash noise, whose correlated streams caused a real visual bug.
-- [ ] Boolean operators `&&` / `||` / `not` (compound predicates are
+- [x] Boolean operators `&&` / `||` / `not` (compound predicates are
       match-pyramids / hand-rolled helpers today).
 - [ ] List builtins: `length`, `append`, `flatten`, `any`/`all`, `reverse`,
       `isEmpty` — naive recursive versions blow the eval-depth cap at n≈60;

--- a/examples/asteroids/lib.fun
+++ b/examples/asteroids/lib.fun
@@ -5,11 +5,6 @@
 let length = (xs) =>
   xs |> List.fold((acc, x) => acc + 1.0, 0.0)
 
-let not = (b) =>
-  match b with
-  | true => false
-  | false => true
-
 let and = (a, b) =>
   match a with
   | true => b

--- a/functor-lang/src/ast.rs
+++ b/functor-lang/src/ast.rs
@@ -191,8 +191,19 @@ pub enum ExprKind {
         lhs: Box<Expr>,
         rhs: Box<Expr>,
     },
+    /// `a && b` / `a || b` — short-circuiting boolean operators. Kept distinct
+    /// from [`Self::Binary`] because the right operand is evaluated lazily
+    /// (only when the left doesn't already decide the result), so they can't
+    /// ride the eager left-assoc binary spine.
+    Logical {
+        op: LogicalOp,
+        lhs: Box<Expr>,
+        rhs: Box<Expr>,
+    },
     /// Unary minus.
     Neg(Box<Expr>),
+    /// `not e` — boolean negation (prefix operator).
+    Not(Box<Expr>),
     /// `match expr with | pattern => expr | …` — first matching arm wins,
     /// top to bottom. Arm bodies are full expressions, so a nested `match`
     /// inside an arm greedily consumes the following `|` arms — parenthesize
@@ -273,4 +284,12 @@ pub enum BinOp {
     Lt,
     Gt,
     Eq,
+}
+
+/// The short-circuiting boolean operators. `And` binds tighter than `Or`;
+/// both are looser than comparisons and `not` (see [`crate::parser`]).
+#[derive(Debug, Clone, Copy)]
+pub enum LogicalOp {
+    And,
+    Or,
 }

--- a/functor-lang/src/eval.rs
+++ b/functor-lang/src/eval.rs
@@ -526,6 +526,34 @@ impl Interp<'_> {
                 }
                 Ok(acc)
             }
+            // Short-circuit: an operand is evaluated only when the accumulator
+            // so far doesn't already decide the result (`false && _` is false,
+            // `true || _` is true). Both operands must be bools. Left-assoc
+            // chains nest down the lhs and the parser builds them iteratively
+            // (no depth guard), so walk the spine iteratively too — like the
+            // Binary arm above, a flat `a && b && …` chain must not consume
+            // host stack per term. Each spine node carries its own op, so a
+            // mixed `a && b || c` folds correctly.
+            ExprKind::Logical { .. } => {
+                use crate::ast::LogicalOp;
+                let mut spine = Vec::new();
+                let mut leaf = expr;
+                while let ExprKind::Logical { op, lhs, rhs } = &leaf.kind {
+                    spine.push((*op, rhs.as_ref()));
+                    leaf = lhs;
+                }
+                let mut acc = as_bool(&self.eval(leaf, env)?, leaf.span)?;
+                for (op, rhs) in spine.into_iter().rev() {
+                    let decided = match op {
+                        LogicalOp::And => !acc,
+                        LogicalOp::Or => acc,
+                    };
+                    if !decided {
+                        acc = as_bool(&self.eval(rhs, env)?, rhs.span)?;
+                    }
+                }
+                Ok(Value::Bool(acc))
+            }
             ExprKind::Neg(inner) => match self.eval(inner, env)? {
                 Value::Number(n) => Ok(Value::Number(-n)),
                 other => Err(RunError {
@@ -533,6 +561,9 @@ impl Interp<'_> {
                     span: expr.span,
                 }),
             },
+            ExprKind::Not(inner) => {
+                Ok(Value::Bool(!as_bool(&self.eval(inner, env)?, inner.span)?))
+            }
             // A nullary constructor used bare IS the variant value; a
             // parameterful one is a callable constructor (so `List.map(xs,
             // Circle)` works like any function argument).
@@ -1080,6 +1111,18 @@ most 1000000 cells"
                 ),
             },
         }
+    }
+}
+
+/// Coerce a value to a bool for the boolean operators (`&&`, `||`, `not`),
+/// erroring at `span` on anything else.
+fn as_bool(value: &Value, span: Span) -> Result<bool, RunError> {
+    match value {
+        Value::Bool(b) => Ok(*b),
+        other => Err(RunError {
+            message: format!("boolean operator needs a bool, got {}", other.kind_name()),
+            span,
+        }),
     }
 }
 

--- a/functor-lang/src/hover.rs
+++ b/functor-lang/src/hover.rs
@@ -159,7 +159,9 @@ pub(crate) fn children(expr: &Expr) -> Vec<&Expr> {
             .chain(args.iter())
             .collect(),
         ExprKind::Binary { lhs, rhs, .. } => vec![lhs, rhs],
+        ExprKind::Logical { lhs, rhs, .. } => vec![lhs, rhs],
         ExprKind::Neg(inner) => vec![inner],
+        ExprKind::Not(inner) => vec![inner],
         ExprKind::Let { value, body, .. } => vec![value, body],
         ExprKind::Assign { value, rest, .. } => vec![value, rest],
         // Match is caller-handled (see the doc comment): `visit` must walk

--- a/functor-lang/src/ir.rs
+++ b/functor-lang/src/ir.rs
@@ -17,7 +17,7 @@
 //! - **Type annotations stay symbolic** ([`TypeName`] carried through
 //!   verbatim) — no inference or checking until B4.
 
-use crate::ast::{BinOp, TypeBody, TypeName};
+use crate::ast::{BinOp, LogicalOp, TypeBody, TypeName};
 use crate::span::Span;
 use std::fmt;
 use std::rc::Rc;
@@ -198,7 +198,16 @@ pub enum ExprKind {
         lhs: Box<Expr>,
         rhs: Box<Expr>,
     },
+    /// `a && b` / `a || b` — short-circuiting; the right operand is evaluated
+    /// only when the left doesn't decide the result (see [`crate::eval`]).
+    Logical {
+        op: LogicalOp,
+        lhs: Box<Expr>,
+        rhs: Box<Expr>,
+    },
     Neg(Box<Expr>),
+    /// `not e` — boolean negation.
+    Not(Box<Expr>),
     /// Reference to a declared variant constructor (an uppercase identifier
     /// that resolved against the module's constructors — see
     /// [`crate::lower`]). `arity` is the declared field count, carried here

--- a/functor-lang/src/lexer.rs
+++ b/functor-lang/src/lexer.rs
@@ -21,6 +21,7 @@ pub enum TokenKind {
     With,
     In,
     Match,
+    Not,
     LParen,
     RParen,
     LBrace,
@@ -37,7 +38,9 @@ pub enum TokenKind {
     EqEq,
     FatArrow,
     PipeGt,
+    PipePipe,
     Pipe,
+    AmpAmp,
     Plus,
     Minus,
     Star,
@@ -69,6 +72,7 @@ pub fn describe(kind: &TokenKind) -> String {
         With => "`with`".to_string(),
         In => "`in`".to_string(),
         Match => "`match`".to_string(),
+        Not => "`not`".to_string(),
         LParen => "`(`".to_string(),
         RParen => "`)`".to_string(),
         LBrace => "`{`".to_string(),
@@ -85,7 +89,9 @@ pub fn describe(kind: &TokenKind) -> String {
         EqEq => "`==`".to_string(),
         FatArrow => "`=>`".to_string(),
         PipeGt => "`|>`".to_string(),
+        PipePipe => "`||`".to_string(),
         Pipe => "`|`".to_string(),
+        AmpAmp => "`&&`".to_string(),
         Plus => "`+`".to_string(),
         Minus => "`-`".to_string(),
         Star => "`*`".to_string(),
@@ -215,12 +221,21 @@ pub fn lex(src: &str, base: usize) -> Result<Vec<Token>, ParseError> {
                     i += 2;
                     TokenKind::PipeGt
                 }
+                Some(b'|') => {
+                    i += 2;
+                    TokenKind::PipePipe
+                }
                 // Bare `|` begins a variant alternative or a match arm.
                 _ => {
                     i += 1;
                     TokenKind::Pipe
                 }
             },
+            // `&&` is the only use of `&` — a bare `&` is a lex error.
+            b'&' if bytes.get(i + 1) == Some(&b'&') => {
+                i += 2;
+                TokenKind::AmpAmp
+            }
             b'"' => {
                 let (kind, next) = lex_string(src, i, base)?;
                 i = next;
@@ -267,6 +282,7 @@ pub fn lex(src: &str, base: usize) -> Result<Vec<Token>, ParseError> {
                     "with" => TokenKind::With,
                     "in" => TokenKind::In,
                     "match" => TokenKind::Match,
+                    "not" => TokenKind::Not,
                     name => TokenKind::Ident(name.to_string()),
                 }
             }

--- a/functor-lang/src/lower.rs
+++ b/functor-lang/src/lower.rs
@@ -821,7 +821,33 @@ impl Lowerer<'_> {
                     args: lowered,
                 }
             }
+            // Like the Binary spine above: left-assoc `&&`/`||` chains nest
+            // down the lhs, so lower them iteratively — a flat chain must not
+            // grow the host stack per term.
+            ast::ExprKind::Logical { .. } => {
+                let mut spine = Vec::new();
+                let mut leaf = expr;
+                while let ast::ExprKind::Logical { op, lhs, rhs } = leaf.kind {
+                    spine.push((op, *rhs, leaf.span));
+                    leaf = *lhs;
+                }
+                let mut acc = self.expr(leaf)?;
+                for (op, rhs, node_span) in spine.into_iter().rev() {
+                    let rhs = self.expr(rhs)?;
+                    acc = Expr {
+                        id: self.expr_id(),
+                        kind: ExprKind::Logical {
+                            op,
+                            lhs: Box::new(acc),
+                            rhs: Box::new(rhs),
+                        },
+                        span: node_span,
+                    };
+                }
+                return Ok(acc);
+            }
             ast::ExprKind::Neg(inner) => ExprKind::Neg(Box::new(self.expr(*inner)?)),
+            ast::ExprKind::Not(inner) => ExprKind::Not(Box::new(self.expr(*inner)?)),
             ast::ExprKind::Match { scrutinee, arms } => {
                 // The scrutinee is evaluated outside any arm's scope.
                 let scrutinee = Box::new(self.expr(*scrutinee)?);

--- a/functor-lang/src/parser.rs
+++ b/functor-lang/src/parser.rs
@@ -92,9 +92,11 @@ fn parse_impl(src: &str, base: usize, interface: bool) -> Result<Program, ParseE
 
 /// Nesting cap for the recursive entry points: pathological input
 /// (`((((…))))`) must fail as a clean spanned error, not a stack overflow —
-/// Functor Lang sources may be machine-generated. Each nesting level costs ~10 debug
-/// frames, so the cap must fit a 2 MiB test-thread stack with margin.
-const MAX_DEPTH: usize = 100;
+/// Functor Lang sources may be machine-generated. Each nesting level costs ~13 debug
+/// frames (the operator-precedence descent — pipeline → `||` → `&&` → `not` →
+/// comparison → … → primary), so the cap must fit a 2 MiB test-thread stack
+/// with margin.
+const MAX_DEPTH: usize = 76;
 
 struct Parser {
     tokens: Vec<Token>,
@@ -840,14 +842,14 @@ rebind surface); `mut` is for `let mut … in …` inside a function"
     }
 
     fn pipeline(&mut self) -> Result<Expr, ParseError> {
-        let head = self.comparison()?;
+        let head = self.logic_or()?;
         if self.peek_kind() != &TokenKind::PipeGt {
             return Ok(head);
         }
         let mut stages = Vec::new();
         while self.peek_kind() == &TokenKind::PipeGt {
             self.bump();
-            stages.push(self.comparison()?);
+            stages.push(self.logic_or()?);
         }
         let span = head
             .span
@@ -859,6 +861,66 @@ rebind surface); `mut` is for `let mut … in …` inside a function"
             },
             span,
         })
+    }
+
+    /// `a || b` — left-assoc, looser than `&&`. Short-circuit semantics live
+    /// in eval; the parser only records the tree. The loop is inlined (rather
+    /// than a shared helper) to keep the per-level frame cost — which the
+    /// `MAX_DEPTH` guard is calibrated against — small.
+    fn logic_or(&mut self) -> Result<Expr, ParseError> {
+        let mut lhs = self.logic_and()?;
+        while self.peek_kind() == &TokenKind::PipePipe {
+            self.bump();
+            let rhs = self.logic_and()?;
+            let span = lhs.span.to(rhs.span);
+            lhs = Expr {
+                kind: ExprKind::Logical {
+                    op: LogicalOp::Or,
+                    lhs: Box::new(lhs),
+                    rhs: Box::new(rhs),
+                },
+                span,
+            };
+        }
+        Ok(lhs)
+    }
+
+    /// `a && b` — left-assoc, tighter than `||`, looser than `not`/comparison.
+    fn logic_and(&mut self) -> Result<Expr, ParseError> {
+        let mut lhs = self.logic_not()?;
+        while self.peek_kind() == &TokenKind::AmpAmp {
+            self.bump();
+            let rhs = self.logic_not()?;
+            let span = lhs.span.to(rhs.span);
+            lhs = Expr {
+                kind: ExprKind::Logical {
+                    op: LogicalOp::And,
+                    lhs: Box::new(lhs),
+                    rhs: Box::new(rhs),
+                },
+                span,
+            };
+        }
+        Ok(lhs)
+    }
+
+    /// `not e` — prefix boolean negation, binding looser than comparison (so
+    /// `not a == b` is `not (a == b)`) but tighter than `&&`. Iterative so a
+    /// `not not not …` chain can't grow the host stack past the depth guard.
+    fn logic_not(&mut self) -> Result<Expr, ParseError> {
+        let mut not_spans = Vec::new();
+        while self.peek_kind() == &TokenKind::Not {
+            not_spans.push(self.bump().span);
+        }
+        let mut expr = self.comparison()?;
+        for not_span in not_spans.into_iter().rev() {
+            let span = not_span.to(expr.span);
+            expr = Expr {
+                kind: ExprKind::Not(Box::new(expr)),
+                span,
+            };
+        }
+        Ok(expr)
     }
 
     fn comparison(&mut self) -> Result<Expr, ParseError> {

--- a/functor-lang/src/rebind.rs
+++ b/functor-lang/src/rebind.rs
@@ -353,7 +353,7 @@ fn collect(expr: &Expr, def: &str, path: &mut Vec<String>, index: &mut ModuleInd
                 seg(arg, format!(":{i}"), path, index);
             }
         }
-        ExprKind::Binary { lhs, rhs, .. } => {
+        ExprKind::Binary { lhs, rhs, .. } | ExprKind::Logical { lhs, rhs, .. } => {
             seg(lhs, "lhs".to_string(), path, index);
             seg(rhs, "rhs".to_string(), path, index);
         }
@@ -368,7 +368,7 @@ fn collect(expr: &Expr, def: &str, path: &mut Vec<String>, index: &mut ModuleInd
         }
         // Single-child edges are transparent: uniqueness is preserved, and
         // e.g. negating or field-accessing around a lambda keeps its id.
-        ExprKind::Neg(inner) => collect(inner, def, path, index),
+        ExprKind::Neg(inner) | ExprKind::Not(inner) => collect(inner, def, path, index),
         ExprKind::FieldAccess { object, .. } => collect(object, def, path, index),
         ExprKind::Number(_)
         | ExprKind::String(_)
@@ -502,11 +502,11 @@ pub(crate) fn each_child<'a>(expr: &'a Expr, f: &mut impl FnMut(&'a Expr)) {
                 f(arg);
             }
         }
-        ExprKind::Binary { lhs, rhs, .. } => {
+        ExprKind::Binary { lhs, rhs, .. } | ExprKind::Logical { lhs, rhs, .. } => {
             f(lhs);
             f(rhs);
         }
-        ExprKind::Neg(inner) => f(inner),
+        ExprKind::Neg(inner) | ExprKind::Not(inner) => f(inner),
         ExprKind::Match { scrutinee, arms } => {
             f(scrutinee);
             for arm in arms {

--- a/functor-lang/src/types.rs
+++ b/functor-lang/src/types.rs
@@ -1774,6 +1774,27 @@ missing {missing}. Did you forget an argument?"
                 }
                 acc
             }
+            ExprKind::Logical { .. } => {
+                // Left-assoc chains nest down the lhs with no parser depth
+                // guard — walk the spine iteratively, like the Binary arm.
+                // Every operand (and every node) is Bool.
+                let mut spine = Vec::new();
+                let mut leaf = expr;
+                while let ExprKind::Logical { lhs, rhs, .. } = &leaf.kind {
+                    spine.push((rhs.as_ref(), leaf.id));
+                    leaf = lhs;
+                }
+                let leaf_ty = self.infer(leaf);
+                self.require_bool(&leaf_ty, leaf.span, "`&&`/`||`");
+                for (rhs, node_id) in spine.into_iter().rev() {
+                    let rhs_ty = self.infer(rhs);
+                    self.require_bool(&rhs_ty, rhs.span, "`&&`/`||`");
+                    // Spine nodes never pass through the recording `infer`
+                    // wrapper (the walk is iterative) — record each here.
+                    self.expr_types.insert(node_id.raw(), Type::Bool);
+                }
+                Type::Bool
+            }
             ExprKind::Neg(inner) => {
                 let ty = self.infer(inner);
                 let ty = self.zonk(&ty);
@@ -1786,6 +1807,11 @@ missing {missing}. Did you forget an argument?"
                     );
                 }
                 Type::Float
+            }
+            ExprKind::Not(inner) => {
+                let ty = self.infer(inner);
+                self.require_bool(&ty, inner.span, "`not`");
+                Type::Bool
             }
             // A constructor reference: nullary is the variant value itself,
             // parameterful is a function from its declared field types.
@@ -2283,6 +2309,19 @@ is {other}"
                 span,
                 format!("`{}` needs float operands, got {ty}", op_str(op)),
             );
+        }
+    }
+
+    /// Constrain an operand of a boolean operator (`&&`, `||`, `not`) to
+    /// `Bool` — unifying an unsolved variable, erroring on a known non-bool.
+    fn require_bool(&mut self, ty: &Type, span: Span, op: &str) {
+        let ty = self.zonk(ty);
+        if let Type::Var(_) = ty {
+            self.unify(&ty, &Type::Bool, span, "boolean operand");
+            return;
+        }
+        if !compatible(&ty, &Type::Bool) {
+            self.diag(span, format!("{op} needs bool operands, got {ty}"));
         }
     }
 }

--- a/functor-lang/tests/check.rs
+++ b/functor-lang/tests/check.rs
@@ -1440,3 +1440,39 @@ fn forgotten_type_equals_is_diagnosed() {
         );
     }
 }
+
+// --- Boolean operators typecheck as Bool ---
+
+#[test]
+fn bool_operators_check_clean() {
+    assert_clean(
+        "let f = (a: bool, b: bool): bool => a && b || not a\n\
+         let g = (x: float): bool => x > 0.0 && not (x == 1.0)",
+    );
+}
+
+#[test]
+fn logical_operand_must_be_bool() {
+    let (message, line, _) = single_diag("let f = () => 1.0 && true");
+    assert_eq!(message, "`&&`/`||` needs bool operands, got float");
+    assert_eq!(line, 1);
+}
+
+#[test]
+fn not_operand_must_be_bool() {
+    let (message, _, _) = single_diag("let f = () => not 3.0");
+    assert_eq!(message, "`not` needs bool operands, got float");
+}
+
+#[test]
+fn logical_result_is_bool() {
+    // The `&&` result feeds a float context — the mismatch proves it typed
+    // as Bool, not gradual Unknown.
+    let (message, _, _) = single_diag(
+        "let f = (a: bool, b: bool): float => a && b",
+    );
+    assert!(
+        message.contains("bool") && message.contains("float"),
+        "unexpected: {message}"
+    );
+}

--- a/functor-lang/tests/parser.rs
+++ b/functor-lang/tests/parser.rs
@@ -437,3 +437,64 @@ fn error_spread_needs_a_leading_element() {
         )
     );
 }
+
+// --- Boolean operators `&&` / `||` / `not` ---
+
+/// Parse `let v = <expr>` and hand back the expression's kind.
+fn parsed_value(src: &str) -> ExprKind {
+    let program = functor_lang::parse(src).unwrap();
+    let Item::Let(decl) = program.items.into_iter().next().unwrap() else {
+        panic!("expected a let declaration");
+    };
+    decl.value.kind
+}
+
+#[test]
+fn and_binds_tighter_than_or() {
+    // `a || b && c` parses as `a || (b && c)`.
+    use functor_lang::ast::LogicalOp;
+    let ExprKind::Logical { op: LogicalOp::Or, rhs, .. } = parsed_value("let v = a || b && c")
+    else {
+        panic!("expected an `||` at the root");
+    };
+    assert!(
+        matches!(rhs.kind, ExprKind::Logical { op: LogicalOp::And, .. }),
+        "expected `&&` on the right of `||`, got {:?}",
+        rhs.kind
+    );
+}
+
+#[test]
+fn logical_is_looser_than_comparison() {
+    // `a > b && c > d` parses as `(a > b) && (c > d)`.
+    use functor_lang::ast::LogicalOp;
+    let ExprKind::Logical { op: LogicalOp::And, lhs, .. } =
+        parsed_value("let v = a > b && c > d")
+    else {
+        panic!("expected an `&&` at the root");
+    };
+    assert!(
+        matches!(lhs.kind, ExprKind::Binary { .. }),
+        "expected a comparison on the left of `&&`, got {:?}",
+        lhs.kind
+    );
+}
+
+#[test]
+fn not_is_looser_than_comparison() {
+    // `not a == b` parses as `not (a == b)`, so the child is the comparison.
+    let ExprKind::Not(inner) = parsed_value("let v = not a == b") else {
+        panic!("expected a `not` at the root");
+    };
+    assert!(
+        matches!(inner.kind, ExprKind::Binary { .. }),
+        "expected a comparison under `not`, got {:?}",
+        inner.kind
+    );
+}
+
+#[test]
+fn bare_ampersand_is_a_lex_error() {
+    let (message, _, _) = parse_err("let v = a & b");
+    assert_eq!(message, "unexpected character `&`");
+}

--- a/functor-lang/tests/run.rs
+++ b/functor-lang/tests/run.rs
@@ -948,3 +948,99 @@ fn thread_last_pipe_appends() {
         "[2, 4, 6]"
     );
 }
+
+// --- Boolean operators `&&` / `||` / `not` ---
+
+#[test]
+fn bool_operators_evaluate() {
+    assert_eq!(main_result("let main = () => true && false"), "false");
+    assert_eq!(main_result("let main = () => true && true"), "true");
+    assert_eq!(main_result("let main = () => false || true"), "true");
+    assert_eq!(main_result("let main = () => false || false"), "false");
+    assert_eq!(main_result("let main = () => not true"), "false");
+    assert_eq!(main_result("let main = () => not false"), "true");
+}
+
+#[test]
+fn bool_operator_precedence() {
+    // `&&` binds tighter than `||`: `false || true && false` is
+    // `false || (true && false)` == false.
+    assert_eq!(
+        main_result("let main = () => false || true && false"),
+        "false"
+    );
+    // Both are looser than comparison: `3.0 > 2.0 && 2.0 > 1.0` is
+    // `(3.0 > 2.0) && (2.0 > 1.0)` == true.
+    assert_eq!(
+        main_result("let main = () => 3.0 > 2.0 && 2.0 > 1.0"),
+        "true"
+    );
+    // `not` is looser than comparison: `not 1.0 == 2.0` is `not (1.0 == 2.0)`.
+    assert_eq!(main_result("let main = () => not 1.0 == 2.0"), "true");
+}
+
+#[test]
+fn logical_and_short_circuits() {
+    // `boom(0.0)` would fail at runtime (no matching arm); `false && _`
+    // must not evaluate it.
+    assert_eq!(
+        main_result(
+            "let boom = (x) => match x with | 99.0 => true\n\
+             let main = () => false && boom(0.0)"
+        ),
+        "false"
+    );
+}
+
+#[test]
+fn logical_or_short_circuits() {
+    assert_eq!(
+        main_result(
+            "let boom = (x) => match x with | 99.0 => true\n\
+             let main = () => true || boom(0.0)"
+        ),
+        "true"
+    );
+}
+
+#[test]
+fn logical_and_evaluates_rhs_when_needed() {
+    // The complement: `true && _` DOES evaluate the right side, so the
+    // failing call surfaces.
+    let (message, _, _) = run_err(
+        "let boom = (x) => match x with | 99.0 => true\n\
+         let main = () => true && boom(0.0)",
+    );
+    assert_eq!(message, "no pattern matched 0");
+}
+
+#[test]
+fn long_logical_chain_does_not_overflow() {
+    // Left-assoc `&&`/`||` chains parse iteratively (no depth guard), so eval
+    // must walk their spine iteratively too — a flat 2000-term chain must not
+    // consume host stack per term. `true && … && true && false` == false.
+    let chain = std::iter::repeat("true")
+        .take(2000)
+        .collect::<Vec<_>>()
+        .join(" && ");
+    assert_eq!(
+        main_result(&format!("let main = () => {chain} && false")),
+        "false"
+    );
+    let ors = std::iter::repeat("false")
+        .take(2000)
+        .collect::<Vec<_>>()
+        .join(" || ");
+    assert_eq!(
+        main_result(&format!("let main = () => {ors} || true")),
+        "true"
+    );
+}
+
+#[test]
+fn bool_operator_on_non_bool_errors() {
+    // A non-bool operand is a runtime error (the checker also rejects it,
+    // but `run` does not typecheck).
+    let (message, _, _) = run_err("let main = () => not 3.0");
+    assert_eq!(message, "boolean operator needs a bool, got a number");
+}


### PR DESCRIPTION
## What

Adds the short-circuiting boolean operators `&&` and `||` and the prefix `not` operator to Functor Lang. Compound predicates no longer require match-pyramids or hand-rolled helpers — a gap found building `examples/asteroids` (`docs/todo.md`).

```functor
let canFire = (m) => m.alive && not m.reloading || m.cheat
let atRest = (v) => v.x == 0.0 && v.y == 0.0
```

## Syntax & semantics

- **Precedence (tightest→loosest):** comparisons > `not` > `&&` > `||` > pipelines. So `not a == b` is `not (a == b)`, and `a || b && c` is `a || (b && c)`.
- **Short-circuit:** `false && e` and `true || e` never evaluate `e`. Proven by a test where the RHS would fail at runtime if evaluated.
- **Typecheck:** all three operands are checked as `bool`; the result is `bool`.

## Design decisions

- **`not` is a prefix operator, not a builtin.** Functor Lang has no bare-name builtin convention (every builtin is namespaced: `List.*`, `Math.*`, …), and the language already has a prefix unary operator (`-`/`Neg`). A prefix `not` is the minimal, consistent grammar addition. It is a reserved word.
- **`&&`/`||` are a distinct `Logical` IR node**, not `BinOp` variants — the lazy right operand can't ride the eager left-associative `Binary` eval spine.
- **`Logical` is walked iteratively** in eval / lower / types (mirroring the existing `Binary` spine), so a flat `a && b && …` chain — which the parser builds with no depth cost — can't overflow the host stack. `not`/`Not` mirrors `Neg` (recursive). A 2000-term chain test guards this.
- **`MAX_DEPTH` lowered 100→76.** The deeper precedence descent (pipeline → `||` → `&&` → `not` → comparison → …) costs more host-stack frames per nesting level, so the parser's nesting cap is recalibrated to keep pathological `((((…))))` input failing as a clean spanned error within the 2 MiB test-thread stack. This narrows the max valid nesting depth from 100 to 76; a Pratt-parser refactor could restore 100 but is out of scope here.

## Example fix

Removed the now-dead `let not` helper from `examples/asteroids/lib.fun`: it is unreferenced, and with `not` reserved it no longer parses. `Lib.and`/`Lib.or` are untouched.

## Tests

`cargo test -p functor-lang` passes. Added:
- **parser:** `&&` tighter than `||`; both looser than comparison; `not` looser than comparison; bare `&` is a lex error.
- **eval:** truth tables; precedence; `&&`/`||` short-circuit (RHS not evaluated); the complement (RHS *is* evaluated when needed); non-bool runtime error; 2000-term chain doesn't overflow.
- **check:** clean well-typed use; non-bool operand errors for `&&`/`||` and `not`; result types as `bool`.

Verified headlessly with scratch `.fun` via `cargo run -p functor-lang -- run/check`.

## Docs

Updated the `functor-lang` skill operators section. Ticked the `docs/todo.md` item.

## Review

Ran `/xreview` (Claude + Codex). Fixed the Critical (asteroids `not` collision), the agreed High (iterative `Logical` for flat chains), and a doc-comment nit; re-ran tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)