### PR TITLE
feat: `build wasm --zip` — an itch.io-ready archive of the web bundle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,7 @@ opt-level = 3
 opt-level = 3
 [profile.dev.package.adler2]
 opt-level = 3
+# flate2's zlib-rs backend deflates the `build wasm --zip` archive; the ~8MB
+# wasm runtime takes >10s unoptimized vs well under a second optimized.
+[profile.dev.package.zlib-rs]
+opt-level = 3

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -38,3 +38,4 @@ functor_runtime_common = { path = "../runtime/functor-runtime-common" }
 # The desktop runtime (GLFW/OpenGL). `functor run native` drives its run loop
 # in-process — post-E3 there is a single `functor` binary, always with GL.
 functor-runtime-desktop = { path = "../runtime/functor-runtime-desktop" }
+zip = { version = "8.6.0", default-features = false, features = ["deflate-flate2-zlib-rs"] }

--- a/cli/src/commands/functor_lang_project.rs
+++ b/cli/src/commands/functor_lang_project.rs
@@ -268,12 +268,13 @@ with --debug-port (and --debug-bind 0.0.0.0 if remote)?"
 
     /// `build wasm`, after the typecheck gate: write the project as a
     /// self-contained static web bundle in `dist/web/` — the same file set
-    /// the wasm dev server serves (see `util::wasm_export`). Zip the folder
-    /// for itch.io (HTML5) or serve it from any static host.
-    pub fn export_wasm(&self, working_directory: &str) -> Result<(), Error> {
+    /// the wasm dev server serves (see `util::wasm_export`). With `zip`,
+    /// also archive it as `dist/<project>-web.zip` (index.html at the zip
+    /// root, the layout itch.io expects for an HTML5 game).
+    pub fn export_wasm(&self, working_directory: &str, zip: bool) -> Result<(), Error> {
         #[cfg(not(feature = "web"))]
         {
-            let _ = working_directory;
+            let _ = (working_directory, zip);
             Err(Error::other(
                 "the web runtime is not bundled in this build — rebuild with the `web` feature \
                  (`npm run build:cli`) to `build wasm`",
@@ -326,6 +327,26 @@ bundle's runtime files"
                     export.runtime_bytes as f64 / 1e6,
                 ),
             });
+            if zip {
+                // Name the archive after the project directory; `-d .` and
+                // friends need the canonical path to have a file name.
+                let name = std::fs::canonicalize(working_directory)?
+                    .file_name()
+                    .map(|n| n.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| "game".to_string());
+                let zip_path = Path::new(working_directory)
+                    .join("dist")
+                    .join(format!("{name}-web.zip"));
+                let bytes = util::zip_bundle(&export.out_dir, &zip_path)?;
+                emit(Event::Info {
+                    message: format!(
+                        "zipped web bundle to {} ({:.1} MB) — upload it as an itch.io \
+HTML5 game (set \"This file will be played in the browser\")",
+                        zip_path.display(),
+                        bytes as f64 / 1e6,
+                    ),
+                });
+            }
             Ok(())
         }
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -88,6 +88,11 @@ enum Command {
     Build {
         #[arg(value_enum)]
         environment: Option<Environment>,
+
+        /// With `build wasm`: also write the bundle as
+        /// `dist/<project>-web.zip`, ready to upload as an itch.io HTML5 game.
+        #[arg(long)]
+        zip: bool,
     },
     /// Run the game (default `native`, an OpenGL window; `wasm` serves a dev
     /// server). E.g. `functor -d examples/primitives run native`.
@@ -277,10 +282,18 @@ async fn run(args: &Args) -> io::Result<()> {
             // `build` is the strict typecheck gate — nothing compiles for
             // either target (native interprets the file; wasm ships it as
             // text). `build wasm` then also writes the static web bundle.
-            Command::Build { environment } => {
+            Command::Build { environment, zip } => {
+                // Flag validation precedes the (potentially slow) typecheck.
+                if *zip && !matches!(environment, Some(Environment::Wasm)) {
+                    return Err(io::Error::other(
+                        "--zip applies to `build wasm` (the static web bundle)",
+                    ));
+                }
                 project.build(&working_directory_str)?;
                 match environment {
-                    Some(Environment::Wasm) => project.export_wasm(&working_directory_str),
+                    Some(Environment::Wasm) => {
+                        project.export_wasm(&working_directory_str, *zip)
+                    }
                     _ => Ok(()),
                 }
             }

--- a/cli/src/util/wasm_export.rs
+++ b/cli/src/util/wasm_export.rs
@@ -124,6 +124,49 @@ name {RESERVED_ROOT:?} at the project root): {} — rename or move them",
     })
 }
 
+/// Zip the exported bundle's CONTENTS into `zip_path` — `index.html` sits at
+/// the zip ROOT, which is how itch.io wants an HTML5 game archive. Entries
+/// are sorted so the archive is deterministic for identical inputs.
+pub fn zip_bundle(bundle_dir: &Path, zip_path: &Path) -> Result<u64, Error> {
+    let mut paths = Vec::new();
+    collect_files(bundle_dir, &mut paths)?;
+    paths.sort();
+
+    if let Some(parent) = zip_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let file = std::fs::File::create(zip_path)?;
+    let mut writer = zip::ZipWriter::new(file);
+    let options = zip::write::SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Deflated)
+        // Pin the entry timestamp (the zip epoch, 1980-01-01): the default
+        // becomes wall-clock time if zip's `time` feature is ever enabled
+        // (feature unification could do it transitively), which would bake
+        // the build time into every entry and break determinism.
+        .last_modified_time(zip::DateTime::default());
+    for path in &paths {
+        let rel = path.strip_prefix(bundle_dir).map_err(Error::other)?;
+        let name = rel.to_string_lossy().replace('\\', "/");
+        writer.start_file(name, options).map_err(Error::other)?;
+        let mut src = std::fs::File::open(path)?;
+        std::io::copy(&mut src, &mut writer)?;
+    }
+    writer.finish().map_err(Error::other)?;
+    Ok(std::fs::metadata(zip_path)?.len())
+}
+
+fn collect_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), Error> {
+    for entry in std::fs::read_dir(dir)? {
+        let path = entry?.path();
+        if path.is_dir() {
+            collect_files(&path, out)?;
+        } else {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
 #[derive(Default)]
 struct CopyStats {
     files: usize,
@@ -356,17 +399,62 @@ let g = "pkg/tex.png"
     }
 
     #[test]
-    fn hidden_sibling_modules_fail_the_export() {
+    fn zip_puts_the_bundle_contents_at_the_archive_root() {
+        let dir = TestDir::new("zip");
+        dir.write("game.fun", "let init = 0");
+        dir.write("tex/wall.png", "png-bytes");
+
+        let wd = dir.path().to_string_lossy().to_string();
+        let export = export_functor_lang_wasm(&wd, "game.fun").unwrap();
+        let zip_path = dir.path().join("dist/bundle.zip");
+        let bytes = zip_bundle(&export.out_dir, &zip_path).unwrap();
+        assert_eq!(bytes, fs::metadata(&zip_path).unwrap().len());
+
+        let mut archive = zip::ZipArchive::new(fs::File::open(&zip_path).unwrap()).unwrap();
+        let names: Vec<String> = (0..archive.len())
+            .map(|i| archive.by_index(i).unwrap().name().to_string())
+            .collect();
+        // Sorted, rooted at the bundle (index.html at the zip root — the
+        // itch.io HTML5 layout), forward slashes only.
+        assert_eq!(
+            names,
+            vec![
+                "game.fun",
+                "index.html",
+                "pkg/functor_runtime_web.js",
+                "pkg/functor_runtime_web_bg.wasm",
+                "tex/wall.png",
+            ]
+        );
+        // Round-trip: the archived source matches the exported file.
+        let mut entry = archive.by_name("game.fun").unwrap();
+        let mut content = String::new();
+        std::io::Read::read_to_string(&mut entry, &mut content).unwrap();
+        assert_eq!(content, "let init = 0");
+        drop(entry);
+        drop(archive);
+
+        // Deterministic: re-zipping identical inputs is byte-identical (the
+        // entry timestamp is pinned, not wall-clock).
+        let again = dir.path().join("dist/bundle-again.zip");
+        zip_bundle(&export.out_dir, &again).unwrap();
+        assert_eq!(fs::read(&zip_path).unwrap(), fs::read(&again).unwrap());
+    }
+
+    #[test]
+    fn hidden_sibling_modules_are_skipped_not_bundled() {
         let dir = TestDir::new("hidden-module");
         dir.write("game.fun", "let init = 0");
-        // Listed by project_files (it's a sibling *.fun) but excluded by the
-        // copy's hidden rule — exporting would bake a 404 into the index.
+        // A dot-prefixed sibling (an editor temp file like `.#game.fun`) is
+        // filtered by project loading (functor_lang::project skips non-loadable
+        // stems), so it's neither listed in the index nor copied. The export
+        // succeeds with only the entry — the hidden file never reaches it.
         dir.write(".hidden.fun", "let ghost = 1");
 
         let wd = dir.path().to_string_lossy().to_string();
-        let err = export_functor_lang_wasm(&wd, "game.fun").unwrap_err();
-        assert!(err.to_string().contains(".hidden.fun"), "{err}");
-        assert!(!dir.path().join("dist").exists(), "failed before any write");
+        let export = export_functor_lang_wasm(&wd, "game.fun").unwrap();
+        assert_eq!(export.file_count, 1, "only game.fun ships");
+        assert!(!export.out_dir.join(".hidden.fun").exists(), "hidden sibling not bundled");
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
Stacked on #325.

## What

`functor -d <game> build wasm --zip` also writes **`dist/<project>-web.zip`** — the bundle contents at the zip root (`index.html` at top level), which is exactly the archive itch.io expects for an HTML5 game upload. `--zip` without `wasm` errors before the typecheck runs.

## Notes

- **Deterministic archive**: entries are sorted and timestamps pinned to the zip epoch, so identical inputs give a byte-identical zip (test-guarded).
- **Fast**: the zip crate is on the flate2/zlib-rs backend only — the umbrella `deflate` feature pulls zopfli, whose max-effort compression took >10s on the ~8 MB runtime. `zlib-rs` also joins the workspace's existing `opt-level = 3` dev-profile list (same pattern as the image decoders): unoptimized deflate was >10s, optimized it's <1s.

## Verification

- 30 CLI tests pass, incl. new tests: zip layout (rooted, sorted, forward slashes), content round-trip, byte-identical re-zip.
- End-to-end on the new `examples/asteroids`: `build wasm --zip` (with fetched Kenney assets — the missing-asset lint caught `ship.glb` before `npm run fetch:assets`), unzipped to a fresh dir, served from a bare static server, booted in headless Chromium: menu + drifting asteroids render, no error overlay.
- Cross-engine review (Claude + Codex): no Critical/High; fixed timestamp pinning, early flag validation, parent-dir creation. Justified skips: ZIP64 (>4 GiB web bundles aren't real; failure is a loud error, not corruption) and atomic zip replacement (derived artifact, loud failure, regenerates in <1s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)