### PR TITLE
feat(frame): Frame.withClearColor — explicit background clear color

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -413,6 +413,10 @@ frame |> Frame.withFog(fog)                                // distance fog on al
                                                            //   materials incl. emissive;
                                                            //   the fog color is also the
                                                            //   pass's clear color
+frame |> Frame.withClearColor(r, g, b)                     // explicit background clear color
+                                                           //   (r,g,b in 0..1), overriding the
+                                                           //   fog-color default; paints the
+                                                           //   background only, not fog blending
 Skybox.files(px, nx, py, ny, pz, nz)                       // Skybox VALUES only: six face
 frame |> Frame.withSkybox(sky)                             //   paths (+X..-Z). Faces are
                                                            //   fetched assets (not checked

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -24,7 +24,7 @@ bug found in the same exercise was fixed on the spot
       the depth error should name the cap and hint at `List.fold`.
 - [ ] Literals inside tuple/ctor patterns (`| ("Enter", true) =>`) for
       input mapping.
-- [ ] `Frame.withClearColor` (today: distant-fog trick doubles as clear color).
+- [x] `Frame.withClearColor` (today: distant-fog trick doubles as clear color).
 - [ ] `Ui.center()` anchor (+ eventually font size / spacer) for menus.
 - [ ] Soundscape missing-asset error should warn once, not every frame.
 - [ ] Project loader/watcher: ignore non-identifier / dot-prefixed `*.fun`

--- a/functor-prelude/prelude/frame.funi
+++ b/functor-prelude/prelude/frame.funi
@@ -12,3 +12,6 @@ let createLit : (Camera.t, Scene.t, List<Light.t>) => t
 let withRenderTarget : (RenderTarget.t, t, t) => t
 let withFog : (Fog.t, t) => t
 let withSkybox : (Skybox.t, t) => t
+// Explicit background clear color (r, g, b in 0..1), overriding the fog-color
+// default. Frame LAST, so it pipes: `frame |> Frame.withClearColor(0.1, 0.0, 0.2)`.
+let withClearColor : (float, float, float, t) => t

--- a/runtime/functor-runtime-common/src/frame.rs
+++ b/runtime/functor-runtime-common/src/frame.rs
@@ -33,6 +33,12 @@ pub struct Frame {
     /// A cubemap skybox drawn behind everything (fog does not apply to it).
     #[serde(default)]
     pub skybox: Option<SkyboxDescription>,
+    /// Explicit background clear color (`Frame.withClearColor`). When set it
+    /// wins over the fog-color-as-clear-color default; when `None` the clear
+    /// color falls back to the fog color, else the engine default. It only
+    /// paints the background — it does not affect fog blending.
+    #[serde(default)]
+    pub clear_color: Option<[f32; 3]>,
 }
 
 impl Frame {
@@ -46,7 +52,16 @@ impl Frame {
             render_targets: vec![],
             fog: None,
             skybox: None,
+            clear_color: None,
         }
+    }
+
+    /// The background clear color for this frame's pass: the explicit
+    /// `Frame.withClearColor` override when set, otherwise the fog color, else
+    /// the engine default (`fog::clear_color`).
+    pub fn resolved_clear_color(&self) -> [f32; 3] {
+        self.clear_color
+            .unwrap_or_else(|| crate::fog::clear_color(self.fog.as_ref()))
     }
 
     /// Render `target_frame` into `target` each frame, before this frame's main
@@ -78,5 +93,42 @@ impl Frame {
     pub fn with_skybox(mut frame: Frame, skybox: SkyboxDescription) -> Frame {
         frame.skybox = Some(skybox);
         frame
+    }
+
+    /// Explicit background clear color, overriding the fog-color default.
+    /// Subject-last so it pipes (`frame |> Frame.withClearColor(r, g, b)`).
+    pub fn with_clear_color(mut frame: Frame, r: f32, g: f32, b: f32) -> Frame {
+        frame.clear_color = Some([r, g, b]);
+        frame
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{fog::Fog, Scene3D};
+
+    fn bare() -> Frame {
+        Frame::new(Camera::default(), Scene3D::cube())
+    }
+
+    #[test]
+    fn resolved_clear_color_defaults_to_engine_default() {
+        assert_eq!(bare().resolved_clear_color(), [0.1, 0.2, 0.3]);
+    }
+
+    #[test]
+    fn resolved_clear_color_falls_back_to_fog_color() {
+        let frame = Frame::with_fog(bare(), Fog::linear(4.0, 30.0, 0.5, 0.6, 0.7));
+        assert_eq!(frame.resolved_clear_color(), [0.5, 0.6, 0.7]);
+    }
+
+    #[test]
+    fn explicit_clear_color_wins_over_fog() {
+        let frame = Frame::with_fog(bare(), Fog::linear(4.0, 30.0, 0.5, 0.6, 0.7));
+        let frame = Frame::with_clear_color(frame, 0.0, 0.0, 0.0);
+        assert_eq!(frame.resolved_clear_color(), [0.0, 0.0, 0.0]);
+        // The fog itself is untouched — only the background clear changed.
+        assert!(frame.fog.is_some());
     }
 }

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -56,6 +56,9 @@
 //! Frame.withFog(fog, frame)                                  -> Frame
 //!   (frame-level distance fog on every forward material, emissive included —
 //!    fog occludes glow; the fog color is also the pass's clear color)
+//! Frame.withClearColor(r, g, b, frame)                       -> Frame
+//!   (explicit background clear color, overriding the fog-color default; it
+//!    only paints the background, not fog blending)
 //! Ui.text(s) / Ui.textColor(r, g, b, s)                     -> View
 //! Ui.column([view, …]) / Ui.row([view, …])                  -> View
 //! Ui.panel(anchor, view)                                    -> View
@@ -892,6 +895,7 @@ const PATHS: &[&str] = &[
     "Fog.linear",
     "Fog.exp",
     "Frame.withSkybox",
+    "Frame.withClearColor",
     "Skybox.files",
     "RenderTarget.named",
     "RenderTarget.sized",
@@ -1497,6 +1501,7 @@ the game dir",
                         render_targets: vec![],
                         fog: None,
                         skybox: None,
+                        clear_color: None,
                     })))
                 }
                 _ => usage("Frame.createLit(camera, scene, [light, …])"),
@@ -2001,6 +2006,24 @@ paths (+X, -X, +Y, -Y, +Z, -Z)",
                     Ok(host(FunctorLangFrame(Frame::with_skybox(inner.clone(), sky.clone()))))
                 }
                 _ => usage("Frame.withSkybox(skybox, frame)"),
+            },
+            // Frame LAST (subject-last), so it pipes:
+            // `frame |> Frame.withClearColor(r, g, b)`. Sets the background
+            // clear color explicitly, overriding the fog-color default.
+            "Frame.withClearColor" => match args.as_slice() {
+                [r, g, b, frame] => {
+                    let (r, g, b) = (num(r, span)?, num(g, span)?, num(b, span)?);
+                    let Some(inner) = frame_value(frame) else {
+                        return usage("Frame.withClearColor(r, g, b, frame)");
+                    };
+                    Ok(host(FunctorLangFrame(Frame::with_clear_color(
+                        inner.clone(),
+                        r as f32,
+                        g as f32,
+                        b as f32,
+                    ))))
+                }
+                _ => usage("Frame.withClearColor(r, g, b, frame)"),
             },
             // Scene LAST (subject-last), so it pipes: `Scene.quad() |> Scene.screen(feed)` —
             // an emissive (fullbright, screens glow) surface showing the
@@ -3986,6 +4009,36 @@ piped through RenderTarget.sized"
         assert!(json.contains(r#""Linear""#), "json: {json}");
         let back: Frame = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(serde_json::to_string(&back).unwrap(), json);
+    }
+
+    // Frame.withClearColor sets the frame's explicit clear color, and it wins
+    // over the fog color as the resolved background (fog blending unchanged).
+    #[test]
+    fn functor_lang_snippet_declares_clear_color() {
+        let frame = frame_of(
+            "let main = () =>\n\
+             Frame.create(Camera.lookAt(0.0, 2.0, -8.0, 0.0, 1.0, 0.0), Scene.cube())\n\
+             |> Frame.withClearColor(0.2, 0.4, 0.6)",
+        );
+        assert_eq!(frame.clear_color, Some([0.2, 0.4, 0.6]));
+        assert_eq!(frame.resolved_clear_color(), [0.2, 0.4, 0.6]);
+
+        // Without the override, the resolved clear color is the engine default;
+        // with fog it's the fog color; withClearColor overrides even that.
+        let plain = frame_of(
+            "let main = () => \
+             Frame.create(Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0), Scene.cube())",
+        );
+        assert_eq!(plain.clear_color, None);
+        assert_eq!(plain.resolved_clear_color(), [0.1, 0.2, 0.3]);
+
+        let both = frame_of(
+            "let main = () => \
+             Frame.create(Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0), Scene.cube()) \
+             |> Frame.withFog(Fog.linear(4.0, 30.0, 0.5, 0.6, 0.7)) \
+             |> Frame.withClearColor(0.0, 0.0, 0.0)",
+        );
+        assert_eq!(both.resolved_clear_color(), [0.0, 0.0, 0.0]);
     }
 
     // [units, tier 1 — the Angle rule] Frame.withFog accepts ONLY the branded

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -354,6 +354,7 @@ mod tests {
             skybox: Some(crate::skybox::SkyboxDescription::new(
                 "px.jpg", "nx.jpg", "py.jpg", "ny.jpg", "pz.jpg", "nz.jpg",
             )),
+            clear_color: Some([0.2, 0.4, 0.6]),
         };
         assert_json_stable(&frame);
 
@@ -368,6 +369,7 @@ mod tests {
         assert!(legacy.render_targets.is_empty());
         assert!(legacy.fog.is_none());
         assert!(legacy.skybox.is_none());
+        assert!(legacy.clear_color.is_none());
     }
 
     // The render-target wire vocabulary: the reader (a texture by target id)

--- a/runtime/functor-runtime-common/src/renderer.rs
+++ b/runtime/functor-runtime-common/src/renderer.rs
@@ -62,7 +62,7 @@ pub fn render_frame(
             scene_context.ensure_render_target(
                 gl,
                 &pass.target,
-                crate::fog::clear_color(pass.frame.fog.as_ref()),
+                pass.frame.resolved_clear_color(),
             );
         } else {
             scene_context.warn_once(
@@ -115,7 +115,7 @@ target frame are ignored (depth 1 only)",
             // The FBO owns the whole texture — no scissoring wanted (the main
             // pass re-enables it, clipped to its viewport pane).
             gl.disable(glow::SCISSOR_TEST);
-            let [r, g, b] = crate::fog::clear_color(pass.frame.fog.as_ref());
+            let [r, g, b] = pass.frame.resolved_clear_color();
             gl.clear_color(r, g, b, 1.0);
             gl.clear(glow::COLOR_BUFFER_BIT | glow::DEPTH_BUFFER_BIT);
         }
@@ -170,7 +170,7 @@ target frame are ignored (depth 1 only)",
             viewport.height as i32,
         );
         gl.enable(glow::SCISSOR_TEST);
-        let [r, g, b] = crate::fog::clear_color(frame.fog.as_ref());
+        let [r, g, b] = frame.resolved_clear_color();
         gl.clear_color(r, g, b, 1.0);
         gl.clear(glow::COLOR_BUFFER_BIT | glow::DEPTH_BUFFER_BIT);
     }
@@ -235,7 +235,7 @@ pub fn render_composited_frames(
     let mut textures: Vec<glow::Texture> = Vec::with_capacity(n);
     for (i, (frame, frame_time)) in frames[..n].iter().enumerate() {
         let id = format!("__composite_{i}");
-        let clear = crate::fog::clear_color(frame.fog.as_ref());
+        let clear = frame.resolved_clear_color();
         let desc = RenderTargetDescriptor {
             id: id.clone(),
             width: viewport.width,


### PR DESCRIPTION
## What

Adds `Frame.withClearColor(r, g, b, frame)` so games can set the background
clear color directly instead of relying on the distant-fog trick (the only way
to change the background today). Thread-last, so it pipes:

```
draw = (m, tts) =>
  Frame.create(camera, scene)
  |> Frame.withClearColor(0.8, 0.1, 0.6)
```

Colors are bare `r, g, b` floats in 0..1, matching the existing color surfaces
(`Scene.color`, `Ui.textColor`, `Fog.linear`) — there is no branded `Color`
type in the prelude.

## How

- `Frame` gains `clear_color: Option<[f32; 3]>` (`#[serde(default)]`, wire
  back-compat). `Frame::resolved_clear_color()` centralizes precedence:
  explicit override → fog color → engine default. The renderer's clear sites
  (main pass, render-target passes, compositor inputs) all go through it.
- Wired once in the shared prelude (`FunctorHost`) + frame protocol, so **both**
  producers get it: desktop and web share `render_frame` /
  `render_composited_frames`.
- `.funi` signature + `functor-lang` skill doc updated in the same PR.

## Default behavior unchanged

When the combinator isn't called, `resolved_clear_color()` returns exactly the
prior value (fog color, else the engine default `[0.1, 0.2, 0.3]`), so existing
examples and golden images are byte-identical.

## Tests

`cargo test -p functor_runtime_common` (264 passing) — new unit tests for the
precedence resolver (`frame.rs`), a prelude round-trip that declares the color
and checks it wins over fog (`functor_lang_prelude.rs`), protocol serde
round-trip + legacy decode (`protocol.rs`), and the `.funi`↔host bijection guard.

## Visual verification

Captured headlessly (`--capture-frame --fixed-time 1`) on a scene calling
`Frame.withClearColor(0.8, 0.1, 0.6)`: the background clears to magenta, clearly
distinct from the default teal. GIF + PNG below.

![Frame.withClearColor demo](https://gist.githubusercontent.com/tommy-xr/fc3975fa5e3b079fa85760cce09736bf/raw/clearcolor-demo.gif)

<sub>Magenta (0.8, 0.1, 0.6) background via `Frame.withClearColor`, lit cube rotating one full turn. Rendered headlessly via `--capture-frame` / `--fixed-time`.</sub>

![still t=1.2](https://gist.githubusercontent.com/tommy-xr/fc3975fa5e3b079fa85760cce09736bf/raw/clearcolor-t0.png)
![still t=3.0](https://gist.githubusercontent.com/tommy-xr/fc3975fa5e3b079fa85760cce09736bf/raw/clearcolor-t2.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
