### PR TITLE
feat(project): skip non-identifier / dot-prefixed .fun siblings

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -27,7 +27,7 @@ bug found in the same exercise was fixed on the spot
 - [x] `Frame.withClearColor` (today: distant-fog trick doubles as clear color).
 - [ ] `Ui.center()` anchor (+ eventually font size / spacer) for menus.
 - [x] Soundscape missing-asset error should warn once, not every frame.
-- [ ] Project loader/watcher: ignore non-identifier / dot-prefixed `*.fun`
+- [x] Project loader/watcher: ignore non-identifier / dot-prefixed `*.fun`
       stems (editor temp files fail hot reload today).
 - [x] Asset introspection: `functor inspect` should print per-node
       translations + bbox (Kenney glbs carry baked placement offsets that

--- a/functor-lang/src/project.rs
+++ b/functor-lang/src/project.rs
@@ -205,9 +205,24 @@ impl ProjectError {
 }
 
 /// The `.fun` files of the project rooted at `entry_path`: the entry first,
-/// then its sibling `.fun` files in name order. (Subdirectories are not
-/// scanned — a directory is one flat module space.)
+/// then its loadable sibling `.fun` files in name order. (Subdirectories are not
+/// scanned — a directory is one flat module space.) Siblings whose stem isn't a
+/// valid module identifier — editor temp files like `.#game.fun`, or `2d.fun` —
+/// are skipped (see [`scan_project_dir`]); the watcher and dev server both go
+/// through here, so they ignore those files too.
 pub fn project_files(entry_path: &Path) -> std::io::Result<Vec<PathBuf>> {
+    scan_project_dir(entry_path).map(|(kept, _skipped)| kept)
+}
+
+/// Scan the entry's directory, partitioning sibling `.fun`/`.funi` files into
+/// **kept** (the entry first, then loadable siblings whose stem is a valid module
+/// identifier — [`is_module_stem`]) and **skipped** (files that match the
+/// extension but whose stem can't be a module: editor temp files like
+/// `.#game.fun`, or non-identifier stems like `2d.fun`). Skipping them here — vs
+/// letting [`module_name`] fail the whole load — is what keeps a stray editor
+/// temp file next to `game.fun` from breaking hot reload. Both lists are sorted;
+/// the entry is always kept regardless of its own stem.
+fn scan_project_dir(entry_path: &Path) -> std::io::Result<(Vec<PathBuf>, Vec<PathBuf>)> {
     // A bare relative entry ("game.fun") has an EMPTY parent — that still
     // means the current directory, not "no siblings".
     let dir = match entry_path.parent() {
@@ -227,9 +242,31 @@ pub fn project_files(entry_path: &Path) -> std::io::Result<Vec<PathBuf>> {
         })
         .collect();
     siblings.sort();
-    let mut files = vec![entry_path.to_path_buf()];
-    files.extend(siblings);
-    Ok(files)
+
+    let (kept_siblings, skipped): (Vec<PathBuf>, Vec<PathBuf>) =
+        siblings.into_iter().partition(|path| is_loadable_stem(path));
+
+    let mut kept = vec![entry_path.to_path_buf()];
+    kept.extend(kept_siblings);
+    Ok((kept, skipped))
+}
+
+/// Whether a path's file stem is a valid module identifier (so it can load as a
+/// module — see [`is_module_stem`]). A dot-prefixed stem (`.#game`) or a
+/// non-identifier stem (`2d`) returns false.
+fn is_loadable_stem(path: &Path) -> bool {
+    path.file_stem()
+        .and_then(|s| s.to_str())
+        .is_some_and(is_module_stem)
+}
+
+/// Whether `stem` is a valid module identifier: non-empty, starts with an ASCII
+/// letter, and is otherwise ASCII alphanumeric or `_`. This is the same rule
+/// [`module_name`] enforces — a file whose stem fails it cannot name a module.
+fn is_module_stem(stem: &str) -> bool {
+    !stem.is_empty()
+        && stem.chars().next().is_some_and(|c| c.is_ascii_alphabetic())
+        && stem.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
 /// Load the multi-file project rooted at `entry_path` (see the module doc).
@@ -282,12 +319,22 @@ pub fn load_with_prelude(
         message,
     };
 
-    let paths = project_files(entry_path).map_err(|e| {
+    let (paths, skipped) = scan_project_dir(entry_path).map_err(|e| {
         at(
             entry_path,
             format!("cannot read the project directory: {e}"),
         )
     })?;
+
+    // Tell the user (once, at load — not per frame) about `.fun` siblings we
+    // ignored, so a temp file or misnamed module isn't a silent no-load.
+    for path in &skipped {
+        eprintln!(
+            "[functor-lang] ignoring {} — its file stem is not a valid module identifier \
+(editor temp file?); rename it to load it as a module",
+            file_name(path)
+        );
+    }
 
     // Read every project file (entry first), honoring the in-memory overrides,
     // then hand the (path, source) pairs to the shared linker.
@@ -588,10 +635,7 @@ fn module_name(path: &Path) -> Result<String, String> {
         .file_stem()
         .and_then(|s| s.to_str())
         .unwrap_or_default();
-    let valid = !stem.is_empty()
-        && stem.chars().next().is_some_and(|c| c.is_ascii_alphabetic())
-        && stem.chars().all(|c| c.is_ascii_alphanumeric() || c == '_');
-    if !valid {
+    if !is_module_stem(stem) {
         return Err(format!(
             "cannot derive a module name from `{}` — file stems must be identifiers \
 (letters, digits, `_`; starting with a letter), like `utils.fun` → `Utils`",
@@ -695,4 +739,37 @@ fn dependency_order(
         }
     }
     Ok(order)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn module_stem_accepts_identifiers_and_rejects_the_rest() {
+        // Valid module identifiers.
+        assert!(is_module_stem("game"));
+        assert!(is_module_stem("Utils"));
+        assert!(is_module_stem("enemy_ai"));
+        assert!(is_module_stem("a1"));
+
+        // Rejected: empty, non-letter start, and non-identifier characters —
+        // the exact stems that would otherwise fail `module_name` (or, for a
+        // dot-prefixed stem, name an editor temp file).
+        assert!(!is_module_stem(""));
+        assert!(!is_module_stem("2d")); // starts with a digit
+        assert!(!is_module_stem(".#game")); // emacs lock file stem
+        assert!(!is_module_stem("#game")); // starts with `#`
+        assert!(!is_module_stem("my-game")); // contains `-`
+        assert!(!is_module_stem("game.old")); // contains `.`
+    }
+
+    #[test]
+    fn loadable_stem_reads_the_file_stem() {
+        // `.fun` files whose stem is / isn't a valid module identifier.
+        assert!(is_loadable_stem(Path::new("game.fun")));
+        assert!(is_loadable_stem(Path::new("dir/utils.funi")));
+        assert!(!is_loadable_stem(Path::new(".#game.fun"))); // stem `.#game`
+        assert!(!is_loadable_stem(Path::new("2d.fun"))); // stem `2d`
+    }
 }

--- a/functor-lang/tests/project.rs
+++ b/functor-lang/tests/project.rs
@@ -449,14 +449,11 @@ namespace `Debug` — rename the file"
 }
 
 #[test]
-fn non_identifier_file_stems_are_refused() {
-    let err = load_err(
-        "bad-stem",
-        &[
-            ("game.fun", "let main = () => 0.0\n"),
-            ("my-utils.fun", "let x = 1.0\n"),
-        ],
-    );
+fn non_identifier_entry_stem_is_refused() {
+    // A non-identifier SIBLING is now skipped (see
+    // `non_identifier_fun_siblings_are_skipped`), but the ENTRY file — which is
+    // always loaded — must still name a valid module.
+    let err = load_err("bad-entry-stem", &[("my-utils.fun", "let x = 1.0\n")]);
     assert!(
         err.contains("cannot derive a module name from `my-utils.fun`"),
         "unexpected error: {err}"
@@ -1162,4 +1159,47 @@ fn injected_prelude_types_host_externals() {
         "unexpected: {}",
         diags[0].message
     );
+}
+
+/// Editor temp files and other non-identifier `.fun` stems (`.#game.fun`,
+/// `2d.fun`) are ignored by the loader, not treated as modules — so a stray
+/// temp file next to `game.fun` can't break the load (or hot reload). Their
+/// (deliberately broken) contents are never parsed.
+#[test]
+fn non_identifier_fun_siblings_are_skipped() {
+    let project = load(
+        "skip-temp-siblings",
+        &[
+            ("game.fun", "let main = 1.0\n"),
+            (".#game.fun", "$$ not valid functor-lang $$\n"),
+            ("2d.fun", "also completely broken !!!\n"),
+        ],
+    );
+    let names: Vec<String> = project
+        .sources
+        .files()
+        .iter()
+        .filter_map(|f| f.path.file_name())
+        .map(|n| n.to_string_lossy().into_owned())
+        .collect();
+    // The entry loads; the built-in Net module is always injected.
+    assert!(names.contains(&"game.fun".to_string()), "{names:?}");
+    // Neither skipped sibling contributes a module.
+    assert!(!names.iter().any(|n| n == ".#game.fun"), "{names:?}");
+    assert!(!names.iter().any(|n| n == "2d.fun"), "{names:?}");
+}
+
+/// A well-named sibling still loads normally alongside a skipped temp file —
+/// the filter drops only the non-identifier stems, not real modules.
+#[test]
+fn valid_sibling_loads_beside_a_skipped_temp_file() {
+    let value = run_main(
+        "valid-sibling-beside-temp",
+        &[
+            ("game.fun", "let main = Utils.answer\n"),
+            ("utils.fun", "let answer = 42.0\n"),
+            (".#utils.fun", "garbage that must be ignored\n"),
+        ],
+    );
+    assert_eq!(number(&value), 42.0);
 }


### PR DESCRIPTION
## What

In Functor's `file = module` model, every sibling `.fun` file in the entry's directory loads with the project. Editor temp files (`.#game.fun`) and other non-identifier stems (`2d.fun`) previously **failed the whole load** — `module_name` errored — so a stray emacs lock file next to `game.fun` broke hot reload. Hit while building `examples/asteroids` (docs/todo.md).

## Fix

`project_files` (the single seam used by the loader, the native hot-reload watcher, and the wasm dev server) now delegates to a new `scan_project_dir`, which partitions sibling `.fun`/`.funi` files into:
- **kept** — the entry first, then siblings whose stem is a valid module identifier (`is_module_stem`, the same rule `module_name` enforces);
- **skipped** — non-identifier / dot-prefixed stems.

`load_with_prelude` logs a one-line `[functor-lang] ignoring …` notice per skipped file **at load** (not per frame — the watcher's `project_files` path stays silent, and skipped files aren't in the mtime stamp). The entry file is always kept regardless of its stem, so a bad-stem *entry* still errors via `module_name`.

Because the loader and watcher share `scan_project_dir`, their file sets can't diverge — hot-reload stamps stay consistent.

## Tests

- `module_stem_accepts_identifiers_and_rejects_the_rest`, `loadable_stem_reads_the_file_stem` — the predicates (incl. `.#game`, `2d`, `my-game`, `game.old`).
- `non_identifier_fun_siblings_are_skipped` — `.#game.fun` + `2d.fun` siblings; project loads, neither becomes a module.
- `valid_sibling_loads_beside_a_skipped_temp_file` — a real `utils.fun` still loads next to `.#utils.fun`.
- `non_identifier_entry_stem_is_refused` — repurposed from the old "refused sibling" test to cover the still-erroring bad-stem **entry** case.
- `cargo test -p functor-lang` passes (85+ tests).

## End-to-end

`functor run native --capture-frame` on a scratch project containing a `.#game.fun` temp sibling now loads cleanly, prints:
```
[functor-lang] ignoring .#game.fun — its file stem is not a valid module identifier (editor temp file?); rename it to load it as a module
```
and renders (capture exit 0) — where it previously failed to load.

## Review

`/xreview` (Claude opus + Codex) both returned **no Critical/High findings**: watcher/loader file sets provably match, entry always loads, kept siblings can never fail `module_name`, protected-namespace/duplicate checks still fire, and the log is once-per-load. Two Low nits (notice re-emits per reload; a redundant `!stem.is_empty()` guard carried verbatim from the original `module_name`) were judged defensible and left to keep the diff surgical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)