### PR TITLE
feat(functor-lang): literals inside tuple/ctor patterns

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -54,7 +54,7 @@ let shapes = [c, Rect(3.0, 4.0), Point]       // bare Point IS the value
 let area = (s: Shape): float =>
   match s with                                // match: | pattern => full-expression body
   | Circle(r) => 3.14 * r * r                 // ctor patterns bind positionally
-  | Rect(w, _) => w * w                       // sub-patterns: names or _ ONLY (no nesting)
+  | Rect(w, _) => w * w                       // sub-patterns: names, _, or literals (no deeper nesting)
   | Point => 0.0                              // exhaustiveness checked when s's type is known
 
 let sizeOf = (s: Shape): string =>
@@ -273,9 +273,17 @@ open Widget                                              // …or open, bringing
   pattern vars can't (they are forced lowercase).
 - **Patterns are minimal**: `Ctor(x, _)` / `Ctor` / `(x, _)` (tuple) /
   bare name / `_` / literals (`true`, `false`, numbers incl. negative,
-  strings — equality match). Ctor and tuple sub-patterns are names or `_`
-  only — no nesting, no literals inside. A tuple pattern matches by EXACT
-  arity (mismatch = non-match, like ctors).
+  strings — equality match). Ctor and tuple sub-patterns are names, `_`, or a
+  LITERAL (`| ("Enter", true) =>`, `| Circle(0.0) =>` — number incl. negative,
+  string, bool) — but still no deeper nesting (no ctor/tuple/list inside).
+  A literal sub-pattern is REFUTABLE, so a tuple/ctor arm with one no longer
+  counts toward exhaustiveness (`| ("Enter", true) =>` needs a catch-all; a
+  lone `| Circle(0.0) =>` still leaves `Circle` "missing"). This is
+  conservative — even a nominally-total set like `(true, _) | (false, _)`
+  still wants a catch-all (nested products aren't split into cases). LIST
+  element/tail sub-patterns stay names/`_` only (no literals — list
+  exhaustiveness is length-based). A tuple pattern matches by EXACT arity
+  (mismatch = non-match, like ctors).
   Pattern vars are immutable bindings; lambdas may capture them. First
   matching arm wins; no arm matching is a spanned runtime error. Unapplied
   ctors are first-class (`xs |> List.map(Circle)`); the runtime checks ctor

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -24,7 +24,7 @@ bug found in the same exercise was fixed on the spot
 - [x] List builtins: `length`, `append`, `flatten`, `any`/`all`, `reverse`,
       `isEmpty` — naive recursive versions blow the eval-depth cap at n≈60;
       the depth error should name the cap and hint at `List.fold`.
-- [ ] Literals inside tuple/ctor patterns (`| ("Enter", true) =>`) for
+- [x] Literals inside tuple/ctor patterns (`| ("Enter", true) =>`) for
       input mapping.
 - [x] `Frame.withClearColor` (today: distant-fog trick doubles as clear color).
 - [ ] `Ui.center()` anchor (+ eventually font size / spacer) for menus.

--- a/functor-lang/src/parser.rs
+++ b/functor-lang/src/parser.rs
@@ -792,10 +792,10 @@ and an `else` branch)",
         while self.peek_kind() != &TokenKind::RBracket {
             if self.peek_kind() == &TokenKind::DotDot {
                 self.bump();
-                tail = Some(Box::new(self.sub_pattern()?));
+                tail = Some(Box::new(self.list_element_pattern()?));
                 break;
             }
-            items.push(self.sub_pattern()?);
+            items.push(self.list_element_pattern()?);
             if self.peek_kind() == &TokenKind::Comma {
                 self.bump();
             } else {
@@ -874,7 +874,70 @@ and an `else` branch)",
         })
     }
 
+    /// A sub-pattern of a tuple or constructor pattern: a variable binding,
+    /// `_`, or a LITERAL (number — negative included — string, or bool). These
+    /// stay non-nesting: a nested constructor/tuple/list sub-pattern is still
+    /// refused, so `(Circle(r), _)` does not parse — only the leaves may be
+    /// literals (`("Enter", true)`).
     fn sub_pattern(&mut self) -> Result<Pattern, ParseError> {
+        // A leading `-` folds into a negative number literal (as in the
+        // top-level `pattern`).
+        if self.peek_kind() == &TokenKind::Minus {
+            if let TokenKind::Number(n) = self.nth_kind(1) {
+                let n = *n;
+                let minus = self.bump();
+                let number = self.bump();
+                return Ok(Pattern {
+                    kind: PatternKind::Number(-n),
+                    span: minus.span.to(number.span),
+                });
+            }
+        }
+        let span = self.peek().span;
+        let kind = match self.peek_kind() {
+            TokenKind::Number(n) => {
+                let n = *n;
+                self.bump();
+                PatternKind::Number(n)
+            }
+            TokenKind::Str(s) => {
+                let s = s.clone();
+                self.bump();
+                PatternKind::String(s)
+            }
+            TokenKind::True => {
+                self.bump();
+                PatternKind::Bool(true)
+            }
+            TokenKind::False => {
+                self.bump();
+                PatternKind::Bool(false)
+            }
+            TokenKind::Ident(name) if name == "_" => {
+                self.bump();
+                PatternKind::Wildcard
+            }
+            TokenKind::Ident(name) if !starts_uppercase(name) => {
+                let name = name.clone();
+                self.bump();
+                PatternKind::Var(name)
+            }
+            _ => {
+                return self.error(
+                    "a binding name, `_`, or a literal (constructor/tuple patterns do not nest)",
+                )
+            }
+        };
+        Ok(Pattern { kind, span })
+    }
+
+    /// A list element / tail sub-pattern: a variable binding or `_` only.
+    /// Unlike tuple/ctor sub-patterns, list elements may NOT be literals —
+    /// list exhaustiveness is length-based (it assumes every element is
+    /// irrefutable), so a literal element (`[true, ..rest]`) would silently
+    /// break it. Keeping the restriction here scopes the literal widening to
+    /// tuple/ctor patterns, where exhaustiveness accounts for it.
+    fn list_element_pattern(&mut self) -> Result<Pattern, ParseError> {
         let span = self.peek().span;
         let kind = match self.peek_kind() {
             TokenKind::Ident(name) if name == "_" => {
@@ -886,7 +949,7 @@ and an `else` branch)",
                 self.bump();
                 PatternKind::Var(name)
             }
-            _ => return self.error("a binding name or `_` (constructor patterns do not nest)"),
+            _ => return self.error("a binding name or `_` (list patterns do not nest)"),
         };
         Ok(Pattern { kind, span })
     }

--- a/functor-lang/src/types.rs
+++ b/functor-lang/src/types.rs
@@ -244,6 +244,17 @@ fn pattern_var_bindings(pattern: &Pattern, f: &mut impl FnMut(u32)) {
     }
 }
 
+/// Is `pattern` (a tuple/ctor sub-pattern) irrefutable — matching any value of
+/// the right type? Names and `_` are; a literal sub-pattern is not. Used by
+/// exhaustiveness: a tuple/ctor arm only counts as a catch-all / as covering
+/// its constructor when every sub-pattern is irrefutable.
+fn sub_pattern_irrefutable(pattern: &Pattern) -> bool {
+    matches!(
+        pattern.kind,
+        PatternKind::Wildcard | PatternKind::Var { .. }
+    )
+}
+
 /// Substitute declaration parameter placeholders (`Var(i)`, i < args.len())
 /// with concrete type arguments — how generic record/variant field types
 /// meet their use sites. Non-generic declarations contain no placeholders,
@@ -1939,15 +1950,26 @@ missing {missing}. Did you forget an argument?"
                         list_exact.push(items.len());
                     }
                 }
-                // Sub-patterns are irrefutable (names/`_`), so a tuple arm
-                // catches every tuple of its arity — but only if that arity
-                // CAN match the scrutinee (the mismatch itself is diagnosed
-                // in check_pattern; it must not also count as exhaustive).
-                PatternKind::Tuple(args) => match &self.zonk(&scrutinee_ty) {
-                    Type::Tuple(elems) if elems.len() != args.len() => {}
-                    _ => has_catch_all = true,
-                },
-                PatternKind::Ctor { name, .. } => covered_ctors.push(name),
+                // A tuple arm catches every tuple of its arity only when all
+                // its sub-patterns are irrefutable (names/`_`); a literal
+                // sub-pattern (`("Enter", true)`) makes it refutable, so it no
+                // longer counts as a catch-all. And the arity must be able to
+                // match the scrutinee (a mismatch is diagnosed in
+                // check_pattern; it must not also count as exhaustive).
+                PatternKind::Tuple(args) if args.iter().all(sub_pattern_irrefutable) => {
+                    match &self.zonk(&scrutinee_ty) {
+                        Type::Tuple(elems) if elems.len() != args.len() => {}
+                        _ => has_catch_all = true,
+                    }
+                }
+                PatternKind::Tuple(_) => {}
+                // A ctor arm fully covers that constructor only when all its
+                // sub-patterns are irrefutable; `Circle(0.0)` matches some
+                // `Circle`s, not all, so it doesn't count toward coverage.
+                PatternKind::Ctor { name, args } if args.iter().all(sub_pattern_irrefutable) => {
+                    covered_ctors.push(name)
+                }
+                PatternKind::Ctor { .. } => {}
                 PatternKind::Bool(true) => saw_true = true,
                 PatternKind::Bool(false) => saw_false = true,
                 PatternKind::Number(_) | PatternKind::String(_) => {}
@@ -2033,17 +2055,22 @@ a catch-all arm (`_` or a name)"
                         );
                     }
                 }
-                // A known product with no arity-matching arm can never be
-                // handled (the per-arm mismatch diags say why each arm
-                // fails; this says the MATCH as a whole is uncovered).
+                // A known product left uncovered. Either no arm matches the
+                // arity at all, or some do but are all refutable (a literal
+                // sub-pattern) with no catch-all — distinguish the two so the
+                // message fits the feature's primary use (input mapping).
                 Type::Tuple(elems) => {
+                    let arity_matched = arms.iter().any(|arm| {
+                        matches!(&arm.pattern.kind, PatternKind::Tuple(args) if args.len() == elems.len())
+                    });
+                    let detail = if arity_matched {
+                        "its arms are refutable — add a catch-all (`_` or a name)".to_string()
+                    } else {
+                        format!("no arm matches a {}-element tuple", elems.len())
+                    };
                     self.diag(
                         expr.span,
-                        format!(
-                            "match on {scrutinee_ty} is not exhaustive: no arm matches a \
-{}-element tuple",
-                            elems.len()
-                        ),
+                        format!("match on {scrutinee_ty} is not exhaustive: {detail}"),
                     );
                 }
                 // Unknown stays gradual; List/Record/Fn scrutinees already

--- a/functor-lang/tests/check.rs
+++ b/functor-lang/tests/check.rs
@@ -1479,6 +1479,18 @@ fn bool_operators_check_clean() {
     );
 }
 
+// --- Literals inside tuple / constructor patterns ---
+
+#[test]
+fn tuple_literal_patterns_check_clean() {
+    assert_clean(
+        "let f = (key: string, down: bool) =>\n\
+         \x20 match (key, down) with\n\
+         \x20 | (\"Enter\", true) => 1.0\n\
+         \x20 | (_, _) => 0.0",
+    );
+}
+
 #[test]
 fn logical_operand_must_be_bool() {
     let (message, line, _) = single_diag("let f = () => 1.0 && true");
@@ -1517,6 +1529,18 @@ fn if_else_checks_clean() {
 }
 
 #[test]
+fn ctor_literal_patterns_check_clean() {
+    assert_clean(
+        "type Shape = | Circle(r: float) | Rect(w: float, h: float)\n\
+         let f = (s: Shape) =>\n\
+         \x20 match s with\n\
+         \x20 | Circle(0.0) => \"pt\"\n\
+         \x20 | Circle(r) => \"c\"\n\
+         \x20 | Rect(w, h) => \"r\"",
+    );
+}
+
+#[test]
 fn if_condition_must_be_bool() {
     // A genuinely-non-bool condition (a float literal) — an unannotated param
     // would simply be inferred to bool instead.
@@ -1531,6 +1555,24 @@ fn if_branches_must_unify() {
     assert_eq!(
         message,
         "`if` branches have incompatible types float and string"
+    );
+}
+
+#[test]
+fn tuple_literal_sub_pattern_is_not_a_catch_all() {
+    // `("Enter", true)` is refutable, so without a catch-all the match is
+    // not exhaustive.
+    let (message, _, _) = single_diag(
+        "let f = (a: string, b: bool) =>\n\
+         \x20 match (a, b) with\n\
+         \x20 | (\"Enter\", true) => 1.0",
+    );
+    // The arm matches the arity but is refutable — the message must point at
+    // the missing catch-all, not claim no arm matches the arity.
+    assert_eq!(
+        message,
+        "match on (string, bool) is not exhaustive: its arms are refutable — \
+         add a catch-all (`_` or a name)"
     );
 }
 
@@ -1576,4 +1618,37 @@ fn nested_if_keeps_its_own_type() {
     );
     let inner = types.expr(else_branch.id).expect("inner if type recorded");
     assert_eq!(inner.to_string(), "float");
+}
+
+#[test]
+fn ctor_literal_sub_pattern_does_not_cover_the_ctor() {
+    // `Circle(0.0)` matches some circles, not all — `Circle` is still missing.
+    let diags = check_src(
+        "type Shape = | Circle(r: float) | Rect(w: float, h: float)\n\
+         let f = (s: Shape) =>\n\
+         \x20 match s with\n\
+         \x20 | Circle(0.0) => \"pt\"\n\
+         \x20 | Rect(w, h) => \"r\"",
+    );
+    assert!(
+        diags
+            .iter()
+            .any(|(m, _, _)| m.contains("not exhaustive") && m.contains("Circle")),
+        "expected a 'missing Circle' diagnostic, got {diags:?}"
+    );
+}
+
+#[test]
+fn literal_sub_pattern_type_mismatch_is_diagnosed() {
+    // A string literal where the tuple element is a float.
+    let (message, _, _) = single_diag(
+        "let f = (a: float, b: bool) =>\n\
+         \x20 match (a, b) with\n\
+         \x20 | (\"x\", true) => 1.0\n\
+         \x20 | (_, _) => 0.0",
+    );
+    assert!(
+        message.contains("string") && message.contains("float"),
+        "unexpected: {message}"
+    );
 }

--- a/functor-lang/tests/parser.rs
+++ b/functor-lang/tests/parser.rs
@@ -306,17 +306,92 @@ fn error_match_requires_leading_bar() {
     );
 }
 
-/// Sub-patterns are bindings or `_` only — constructor patterns don't nest.
+/// Sub-patterns are bindings, `_`, or literals — constructor patterns don't
+/// nest another constructor/tuple.
 #[test]
 fn error_nested_constructor_pattern() {
     assert_eq!(
         parse_err("let f = (s) => match s with | Circle(Point) => 1.0 | _ => 0.0"),
         (
-            "expected a binding name or `_` (constructor patterns do not nest), found `Point`"
+            "expected a binding name, `_`, or a literal (constructor/tuple patterns do not nest), \
+             found `Point`"
                 .to_string(),
             1,
             38
         )
+    );
+}
+
+/// Literals ARE allowed as tuple/ctor sub-patterns (`("Enter", true)`) — the
+/// input-mapping shape. String, number (incl. negative), and bool leaves.
+#[test]
+fn tuple_pattern_allows_literal_sub_patterns() {
+    use functor_lang::ast::PatternKind;
+    let src = "let f = (p) => match p with | (\"Enter\", true) => 1.0 | (-1.0, x) => x | _ => 0.0";
+    let program = functor_lang::parse(src).unwrap();
+    let Item::Let(decl) = &program.items[0] else {
+        panic!("expected a let declaration");
+    };
+    let ExprKind::Lambda { body, .. } = &decl.value.kind else {
+        panic!("expected a lambda");
+    };
+    let ExprKind::Match { arms, .. } = &body.kind else {
+        panic!("expected a match");
+    };
+    let PatternKind::Tuple(first) = &arms[0].pattern.kind else {
+        panic!("expected a tuple pattern");
+    };
+    assert!(matches!(first[0].kind, PatternKind::String(ref s) if s == "Enter"));
+    assert!(matches!(first[1].kind, PatternKind::Bool(true)));
+    let PatternKind::Tuple(second) = &arms[1].pattern.kind else {
+        panic!("expected a tuple pattern");
+    };
+    assert!(matches!(second[0].kind, PatternKind::Number(n) if n == -1.0));
+    assert!(matches!(second[1].kind, PatternKind::Var(ref n) if n == "x"));
+}
+
+/// A literal inside a constructor pattern (`Circle(0.0)`) parses.
+#[test]
+fn ctor_pattern_allows_literal_sub_pattern() {
+    use functor_lang::ast::PatternKind;
+    let src = "let f = (s) => match s with | Circle(0.0) => 1.0 | _ => 0.0";
+    let program = functor_lang::parse(src).unwrap();
+    let Item::Let(decl) = &program.items[0] else {
+        panic!("expected a let declaration");
+    };
+    let ExprKind::Lambda { body, .. } = &decl.value.kind else {
+        panic!("expected a lambda");
+    };
+    let ExprKind::Match { arms, .. } = &body.kind else {
+        panic!("expected a match");
+    };
+    let PatternKind::Ctor { args, .. } = &arms[0].pattern.kind else {
+        panic!("expected a ctor pattern");
+    };
+    assert!(matches!(args[0].kind, PatternKind::Number(n) if n == 0.0));
+}
+
+/// A nested tuple sub-pattern is still refused (only literal leaves, no
+/// deeper structure).
+#[test]
+fn error_nested_tuple_sub_pattern() {
+    let (message, _, _) = parse_err("let f = (p) => match p with | ((a, b), c) => a | _ => 0.0");
+    assert_eq!(
+        message,
+        "expected a binding name, `_`, or a literal (constructor/tuple patterns do not nest), \
+         found `(`"
+    );
+}
+
+/// Literals are NOT allowed in LIST element/tail patterns — list
+/// exhaustiveness is length-based and would silently break. The widening is
+/// scoped to tuple/ctor patterns.
+#[test]
+fn error_literal_in_list_pattern() {
+    let (message, _, _) = parse_err("let f = (xs) => match xs with | [] => 0.0 | [true, ..r] => 1.0");
+    assert_eq!(
+        message,
+        "expected a binding name or `_` (list patterns do not nest), found `true`"
     );
 }
 

--- a/functor-lang/tests/run.rs
+++ b/functor-lang/tests/run.rs
@@ -1299,3 +1299,40 @@ fn if_condition_on_non_bool_errors() {
     );
     assert_eq!(message, "`if` condition needs a bool, got a number");
 }
+
+// --- Literals inside tuple / constructor patterns ---
+
+#[test]
+fn tuple_literal_patterns_match_by_value() {
+    // The input-mapping shape: match on (key, isDown).
+    let src = "let classify = (key, down) =>\n\
+               \x20 match (key, down) with\n\
+               \x20 | (\"Enter\", true) => \"start\"\n\
+               \x20 | (\"Escape\", true) => \"quit\"\n\
+               \x20 | (_, false) => \"release\"\n\
+               \x20 | (_, _) => \"other\"\n\
+               let main = () => [classify(\"Enter\", true), classify(\"W\", false), classify(\"W\", true)]";
+    assert_eq!(main_result(src), "[\"start\", \"release\", \"other\"]");
+}
+
+#[test]
+fn ctor_literal_patterns_match_by_value() {
+    let src = "type Shape = | Circle(r: float) | Rect(w: float, h: float)\n\
+               let describe = (s: Shape) =>\n\
+               \x20 match s with\n\
+               \x20 | Circle(0.0) => \"point\"\n\
+               \x20 | Circle(r) => \"circle\"\n\
+               \x20 | Rect(w, h) => \"rect\"\n\
+               let main = () => [describe(Circle(0.0)), describe(Circle(2.0)), describe(Rect(1.0, 2.0))]";
+    assert_eq!(main_result(src), "[\"point\", \"circle\", \"rect\"]");
+}
+
+#[test]
+fn negative_number_sub_pattern() {
+    let src = "let sign = (p) =>\n\
+               \x20 match p with\n\
+               \x20 | (-1.0, y) => \"neg\"\n\
+               \x20 | (_, _) => \"other\"\n\
+               let main = () => [sign((-1.0, 5.0)), sign((2.0, 5.0))]";
+    assert_eq!(main_result(src), "[\"neg\", \"other\"]");
+}


### PR DESCRIPTION
## What

Allows **literal sub-patterns** inside tuple and constructor patterns:

```functor
input = (model, key, isDown) =>
  match (key, isDown) with
  | ("Enter", true)  => start(model)
  | ("Escape", true) => quit(model)
  | (_, _)           => model
```

Numbers (negative included), strings, and bools may now appear as tuple/ctor sub-patterns (`| Circle(0.0) =>`, `| (-1.0, y) =>`). Before, a tuple/ctor sub-pattern could only be a name or `_`. Needed for input mapping — a gap found building `examples/asteroids` (`docs/todo.md`).

## Why the change is small

The AST/IR/eval (`match_pattern`)/lower/typecheck (`check_pattern`) layers **already** handled literal patterns at any depth — top-level `| true =>` already worked, and they recurse uniformly. So the change is just:

- **parser `sub_pattern`:** accept literals (mirroring the top-level `pattern` literal handling, incl. the negative-number fold) in addition to names/`_`. Deeper nesting (a ctor/tuple/list *inside* a sub-pattern) is still refused — only literal leaves.
- **types exhaustiveness:** a literal sub-pattern is **refutable**, so a tuple/ctor arm carrying one no longer counts as a catch-all / as covering its constructor. `| ("Enter", true) =>` now needs a catch-all; a lone `| Circle(0.0) =>` still reports `Circle` missing. New `sub_pattern_irrefutable` helper gates both.

Literal type-mismatch inside a tuple/ctor (`("x", true)` vs `(float, bool)`) is already caught by the existing per-element check.

## Scope & conservatism

- **List patterns keep the names/`_`-only rule** (`list_element_pattern`). List exhaustiveness is length-based and assumes irrefutable elements, so a literal element (`[true, ..rest]`) would silently defeat it — the widening is deliberately scoped to tuple/ctor. (This soundness hole was caught in review before it shipped.)
- Exhaustiveness is **conservative**: even a nominally-total nested product like `(true, _) | (false, _)` still wants a catch-all (no product-of-finite-domains reasoning — that would be real scope creep). Documented in the skill.
- The tuple non-exhaustive message distinguishes "no arm matches the arity" from "arms are refutable — add a catch-all", so the feature's primary use case gets an accurate hint.

## Tests

`cargo test -p functor-lang` passes. Added:
- **parser:** tuple/ctor literal sub-patterns parse (string/number/negative/bool leaves); nested ctor/tuple sub-pattern still refused; literal in a **list** pattern refused.
- **eval:** input-mapping tuple match; ctor-literal match; negative-number sub-pattern.
- **check:** clean exhaustive tuple/ctor-literal matches; refutable tuple arm needs a catch-all (asserts the exact message); ctor-literal arm doesn't cover its ctor; literal type-mismatch inside a tuple.

Verified headlessly with scratch `.fun` via `cargo run -p functor-lang -- run/check`.

## Docs

Updated the `functor-lang` skill pattern section. Ticked the `docs/todo.md` item.

## Review

Ran `/xreview` (Claude + Codex). Both independently flagged the list-pattern soundness hole (now closed by restricting list elements). Also fixed the misleading tuple non-exhaustive message; documented the finite-product conservatism. Re-ran tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)