### PR TITLE
feat: `build native` — a runnable native bundle (dist/native/<os>-<arch>)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,11 @@ Under the hood: `build` typechecks the whole `.fun` project (diagnostics are err
 then also exports a **self-contained static web bundle** to `<project>/dist/web` — the rendered
 host page + the embedded web runtime + a copy of the project directory (hidden files and `dist/`
 excluded), with a warn-only lint for string-literal asset references that won't be in the bundle.
-Zip that folder for itch.io (HTML5) or serve it from any static host. `run native`
+Zip that folder for itch.io (HTML5) or serve it from any static host — `--zip` writes
+`dist/<project>-web.zip` (itch layout) for you. `build native` exports a **runnable native
+bundle** to `<project>/dist/native/<os>-<arch>/`: a copy of the running `functor` binary renamed
+after the project + the same staged file set; launching that binary bare (or with runner flags
+like `--capture-frame`) boots the game from its own directory. `run native`
 drives the built-in desktop runtime in-process from the game dir; it **interprets** the
 `.fun` each frame — nothing compiles. `run wasm` serves the project directory: the `.fun` ships as
 text and is interpreted by the embedded web runtime. `develop` is `run` (hot-reload is built in; on

--- a/cli/src/commands/functor_lang_project.rs
+++ b/cli/src/commands/functor_lang_project.rs
@@ -21,10 +21,11 @@ use std::path::{Path, PathBuf};
 use clap::Parser;
 
 use crate::output::{emit, Event, Severity};
-// `util` (the shell-command runner + wasm dev server) is only used by the
-// `web`-gated `run wasm` path.
+use crate::util;
+// The shell-command runner + wasm dev server are only used by the
+// `web`-gated `run wasm` path; the bundle/native exporters are ungated.
 #[cfg(feature = "web")]
-use crate::util::{self, ShellCommand, WasmDevServer};
+use crate::util::{ShellCommand, WasmDevServer};
 use crate::Environment;
 
 /// The Functor Lang project settings read from `functor.json`.
@@ -282,58 +283,21 @@ with --debug-port (and --debug-bind 0.0.0.0 if remote)?"
         }
         #[cfg(feature = "web")]
         {
-            self.entry_path(working_directory)?;
-            // Same constraint as `run wasm`: the bundle carries the project
-            // directory, so the entry must live inside it.
-            if entry_escapes_project(&self.entry) {
-                return Err(Error::other(format!(
-                    "functor-lang on wasm ships the project directory, so `entry` must be a \
-relative path inside it (got {})",
-                    self.entry
-                )));
-            }
+            self.bundle_entry_path(working_directory)?;
             let export = util::export_functor_lang_wasm(working_directory, &self.entry)?;
-            for name in &export.shadowed {
-                emit(Event::Warning {
-                    message: format!(
-                        "project file `{name}` was not copied — that name is reserved for the \
-bundle's runtime files"
-                    ),
-                });
-            }
-            for link in &export.skipped_symlinks {
-                emit(Event::Warning {
-                    message: format!(
-                        "symlinked directory `{link}` was not copied into the bundle \
-(following it could recurse or pull in files outside the project)"
-                    ),
-                });
-            }
-            for asset in &export.missing_assets {
-                emit(Event::Warning {
-                    message: format!(
-                        "asset \"{asset}\" is referenced in the source but won't be in the bundle \
-(missing from the project dir, or an absolute/`..` path) — it would load as the empty fallback"
-                    ),
-                });
-            }
+            emit_staging_warnings(&export.staged);
             emit(Event::Info {
                 message: format!(
                     "exported static web bundle to {} ({} project files, {:.1} MB + {:.1} MB runtime) \
 — zip the folder for itch.io (HTML5), or serve it from any static host",
                     export.out_dir.display(),
-                    export.file_count,
-                    export.project_bytes as f64 / 1e6,
+                    export.staged.file_count,
+                    export.staged.project_bytes as f64 / 1e6,
                     export.runtime_bytes as f64 / 1e6,
                 ),
             });
             if zip {
-                // Name the archive after the project directory; `-d .` and
-                // friends need the canonical path to have a file name.
-                let name = std::fs::canonicalize(working_directory)?
-                    .file_name()
-                    .map(|n| n.to_string_lossy().into_owned())
-                    .unwrap_or_else(|| "game".to_string());
+                let name = crate::util::bundle::project_name(Path::new(working_directory));
                 let zip_path = Path::new(working_directory)
                     .join("dist")
                     .join(format!("{name}-web.zip"));
@@ -349,6 +313,51 @@ HTML5 game (set \"This file will be played in the browser\")",
             }
             Ok(())
         }
+    }
+
+    /// `build native`, after the typecheck gate: write a runnable native
+    /// bundle in `dist/native/<os>-<arch>/` — a copy of THIS `functor`
+    /// binary renamed after the project (the desktop runtime is built in;
+    /// launched bare next to its `functor.json` it boots the game — see
+    /// `bundled_invocation` in main.rs) plus the same staged project file
+    /// set the web export ships. Zip the folder to share a playable build
+    /// for this platform.
+    pub fn export_native(&self, working_directory: &str) -> Result<(), Error> {
+        self.bundle_entry_path(working_directory)?;
+        let exe = std::env::current_exe()?;
+        let export = util::export_functor_lang_native(working_directory, &self.entry, &exe)?;
+        emit_staging_warnings(&export.staged);
+        emit(Event::Info {
+            message: format!(
+                "exported native bundle to {} ({} project files, {:.1} MB + the {:.1} MB `{}` \
+binary) — run it, or zip the folder to share (this platform only)",
+                export.out_dir.display(),
+                export.staged.file_count,
+                export.staged.project_bytes as f64 / 1e6,
+                export.binary_bytes as f64 / 1e6,
+                export
+                    .binary_path
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy(),
+            ),
+        });
+        Ok(())
+    }
+
+    /// The entry, validated for bundling: it must exist AND live inside the
+    /// project directory — every bundle (and the wasm dev server) carries
+    /// exactly the project dir, so an escaping entry can never ship.
+    fn bundle_entry_path(&self, working_directory: &str) -> Result<PathBuf, Error> {
+        let path = self.entry_path(working_directory)?;
+        if entry_escapes_project(&self.entry) {
+            return Err(Error::other(format!(
+                "a bundle ships the project directory, so `entry` must be a relative path \
+inside it (got {})",
+                self.entry
+            )));
+        }
+        Ok(path)
     }
 
     /// Serve the project at 127.0.0.1:8080 with the Functor Lang index page (docs/
@@ -429,6 +438,35 @@ relative path inside it (got {})",
     }
 }
 
+/// The user-facing warnings for everything the staging copy skipped or
+/// couldn't find — shared verbatim by the wasm and native exports.
+fn emit_staging_warnings(staged: &crate::util::bundle::StagedBundle) {
+    for name in &staged.shadowed {
+        emit(Event::Warning {
+            message: format!(
+                "project file `{name}` was not copied — that name is reserved for the \
+bundle's own files"
+            ),
+        });
+    }
+    for link in &staged.skipped_symlinks {
+        emit(Event::Warning {
+            message: format!(
+                "symlinked directory `{link}` was not copied into the bundle \
+(following it could recurse or pull in files outside the project)"
+            ),
+        });
+    }
+    for asset in &staged.missing_assets {
+        emit(Event::Warning {
+            message: format!(
+                "asset \"{asset}\" is referenced in the source but won't be in the bundle \
+(missing from the project dir, or an absolute/`..` path) — it would load as the empty fallback"
+            ),
+        });
+    }
+}
+
 /// Minimal HTTP POST over std::net — one dependency-free request to the
 /// runner's tiny_http server. Returns (status, body). `Connection: close`
 /// keeps the read side trivial (read to EOF, split headers off).
@@ -476,16 +514,15 @@ fn nth_line(src: &str, line: usize) -> Option<String> {
         .map(str::to_string)
 }
 
-/// True when `entry` can't be served by the wasm dev server, which roots at
-/// the project directory: absolute paths and any `..` component escape it.
-#[cfg(feature = "web")]
+/// True when `entry` escapes the project directory — which the wasm dev
+/// server serves and every bundle ships, so such an entry can't be served
+/// or exported: absolute paths and any `..` component escape it.
 fn entry_escapes_project(entry: &str) -> bool {
     Path::new(entry).is_absolute() || entry.split(['/', '\\']).any(|seg| seg == "..")
 }
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "web")]
     use super::entry_escapes_project;
     use super::nth_line;
 
@@ -504,14 +541,12 @@ mod tests {
         assert_eq!(nth_line("", 1), None);
     }
 
-    #[cfg(feature = "web")]
     #[test]
     fn entries_inside_the_project_are_servable() {
         assert!(!entry_escapes_project("game.fun"));
         assert!(!entry_escapes_project("src/game.fun"));
     }
 
-    #[cfg(feature = "web")]
     #[test]
     fn escaping_entries_are_rejected() {
         assert!(entry_escapes_project("../shared/game.fun"));

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -83,8 +83,10 @@ enum Command {
     },
     /// Typecheck the Functor Lang project (the strict build gate — diagnostics are
     /// errors). `build wasm` also exports a self-contained static web bundle
-    /// to `dist/web/` (zip it for itch.io, or serve from any static host).
-    /// E.g. `functor -d examples/primitives build`.
+    /// to `dist/web/` (zip it for itch.io, or serve from any static host);
+    /// `build native` exports a runnable bundle to `dist/native/<os>-<arch>/`
+    /// (this binary named after the project + the game — launching it bare
+    /// starts the game). E.g. `functor -d examples/primitives build`.
     Build {
         #[arg(value_enum)]
         environment: Option<Environment>,
@@ -179,7 +181,18 @@ enum InspectTarget {
 #[tokio::main]
 async fn main() -> tokio::io::Result<()> {
     let started = Instant::now();
-    let args = Args::parse();
+    // Anything that parses as a CLI invocation IS one — even next to a
+    // bundle's functor.json (`./game --verbose build native` stays CLI).
+    // Only when clap rejects the args (a bare double-click, or runner flags
+    // like `--capture-frame`) does the bundled-game boot get a look; with
+    // no bundle context, the clap error/help prints as usual.
+    let args = match Args::try_parse() {
+        Ok(args) => args,
+        Err(clap_error) => match bundled_invocation() {
+            Some(bundled) => bundled,
+            None => clap_error.exit(),
+        },
+    };
 
     output::init(
         args.json,
@@ -294,7 +307,10 @@ async fn run(args: &Args) -> io::Result<()> {
                     Some(Environment::Wasm) => {
                         project.export_wasm(&working_directory_str, *zip)
                     }
-                    _ => Ok(()),
+                    Some(Environment::Native) => {
+                        project.export_native(&working_directory_str)
+                    }
+                    None => Ok(()),
                 }
             }
             Command::Run {
@@ -349,6 +365,49 @@ async fn run(args: &Args) -> io::Result<()> {
         Command::Inspect { .. } => unreachable!(),
         // Handled earlier (right after functor.json validation).
         Command::Import => unreachable!(),
+    }
+}
+
+/// The bundled-game boot (`build native` output): when THIS binary sits
+/// next to a `functor.json` — the layout the native export writes — and
+/// clap rejected the invocation as CLI args, a bare launch (a double-click)
+/// or one that starts with a `-`/`--` flag (runner args like
+/// `--capture-frame`) synthesizes `run native` on the binary's own
+/// directory, forwarding those flags to the runtime. `--help`/`--version`
+/// keep their CLI meaning even inside a bundle. Returns None for every
+/// non-bundle context (a dev `target/debug/functor` has no adjacent
+/// functor.json).
+fn bundled_invocation() -> Option<Args> {
+    let raw: Vec<String> = env::args().skip(1).collect();
+    if !is_bundled_launch(&raw) {
+        return None;
+    }
+    let exe = env::current_exe().ok()?;
+    let exe_dir = exe.parent()?;
+    if !exe_dir.join("functor.json").is_file() {
+        return None;
+    }
+    Some(Args {
+        dir: Some(exe_dir.to_path_buf()),
+        json: false,
+        quiet: false,
+        no_color: false,
+        ascii: false,
+        verbose: false,
+        command: Command::Run {
+            environment: Some(Environment::Native),
+            runner_args: raw,
+        },
+    })
+}
+
+/// Bare, or flags only — and not a CLI meta-flag.
+fn is_bundled_launch(raw: &[String]) -> bool {
+    match raw.first() {
+        None => true,
+        Some(first) => {
+            first.starts_with('-') && !matches!(first.as_str(), "--help" | "-h" | "--version" | "-V")
+        }
     }
 }
 
@@ -449,9 +508,28 @@ fn get_working_directory(args: &Args) -> PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use super::{run, Args};
+    use super::{is_bundled_launch, run, Args};
     use clap::Parser;
     use std::fs;
+
+    fn strings(args: &[&str]) -> Vec<String> {
+        args.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn bare_and_flag_only_launches_are_bundled() {
+        assert!(is_bundled_launch(&[]));
+        assert!(is_bundled_launch(&strings(&["--capture-frame", "f.png"])));
+        assert!(is_bundled_launch(&strings(&["--fixed-time", "2"])));
+    }
+
+    #[test]
+    fn subcommands_and_cli_meta_flags_stay_cli() {
+        assert!(!is_bundled_launch(&strings(&["run", "native"])));
+        assert!(!is_bundled_launch(&strings(&["build", "wasm"])));
+        assert!(!is_bundled_launch(&strings(&["--help"])));
+        assert!(!is_bundled_launch(&strings(&["-V"])));
+    }
 
     #[tokio::test]
     async fn init_dispatches_before_metadata_validation_and_defaults_to_3d() {

--- a/cli/src/util/bundle.rs
+++ b/cli/src/util/bundle.rs
@@ -1,0 +1,282 @@
+//! The shared bundle-staging machinery behind `build wasm` and
+//! `build native`: both exports are "the project directory, copied under
+//! `dist/`, plus a runtime" — this module owns the copy and its rules, the
+//! pre-wipe validation, and the missing-asset lint, so the two targets can
+//! never drift on what a bundle contains.
+//!
+//! The whole project directory is copied (minus hidden entries and the
+//! reserved output names below) rather than a statically discovered file
+//! set: asset paths are runtime strings (`Scene.model("shark.glb")`, or
+//! computed), and a non-embedded `.gltf` references external `.bin`/texture
+//! files from *inside* the glTF — no source scan can see either, and a
+//! missing asset degrades to the invisible fallback, the worst failure mode
+//! for a published game. Copy-everything is the only rule that keeps the
+//! run ↔ export invariant. A best-effort lint (below) still catches the
+//! common case of literal-referenced assets that were never fetched.
+
+use std::collections::BTreeSet;
+use std::io::Error;
+use std::path::Path;
+
+/// Names at the project root the WEB exporter owns in the bundle: the
+/// output dir and the runtime files it writes. Project files with these
+/// names are skipped (and reported via [`StagedBundle::shadowed`]) rather
+/// than merged — merging a project `pkg/` with the runtime's would leave
+/// stray files beside the wasm bundle. Reservations are per-target (the
+/// native export reserves only `dist` + its own binary name), so a native
+/// game with a root `pkg/` asset dir still ships it.
+pub const WEB_RESERVED: &[&str] = &["dist", "index.html", "pkg"];
+
+/// Extensions the runtime fetches at runtime: models (plus the external
+/// buffers/images a non-embedded `.gltf` references), audio, textures.
+const ASSET_EXTENSIONS: &[&str] = &[
+    "glb", "gltf", "bin", "wav", "ogg", "mp3", "png", "jpg", "jpeg", "hdr",
+];
+
+/// The result of [`stage_bundle`]: the copied project plus everything the
+/// caller should report to the user.
+#[derive(Debug)]
+pub struct StagedBundle {
+    /// Project files copied into the bundle (excludes any runtime files the
+    /// caller adds afterwards).
+    pub file_count: usize,
+    /// Total bytes of those project files.
+    pub project_bytes: u64,
+    /// String-literal asset references that will NOT be in the bundle
+    /// (missing from the project dir, or absolute/`..`/hidden/reserved
+    /// paths).
+    pub missing_assets: Vec<String>,
+    /// Root-level project entries skipped because their names are reserved.
+    pub shadowed: Vec<String>,
+    /// Symlinked directories (or broken links) skipped by the copy.
+    pub skipped_symlinks: Vec<String>,
+}
+
+/// The project's file list as URLs relative to the project dir (entry
+/// first, then sibling `.fun`/`.funi` files) — the set the runners link.
+/// Falls back to just the entry if the directory can't be scanned.
+pub fn project_file_urls(working_directory: &str, entry: &str) -> Vec<String> {
+    let entry_path = Path::new(working_directory).join(entry);
+    let paths = match functor_lang::project::project_files(&entry_path) {
+        Ok(paths) => paths,
+        Err(_) => return vec![entry.to_string()],
+    };
+    let root = Path::new(working_directory);
+    paths
+        .iter()
+        .map(|p| {
+            p.strip_prefix(root)
+                .unwrap_or(p)
+                .to_string_lossy()
+                .replace('\\', "/")
+        })
+        .collect()
+}
+
+/// The project's name for artifacts (the bundle binary, the zip): its
+/// directory's file name — canonicalized, so `-d .` resolves to a real name.
+pub fn project_name(root: &Path) -> String {
+    std::fs::canonicalize(root)
+        .ok()
+        .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+        .unwrap_or_else(|| "game".to_string())
+}
+
+/// Validate, wipe, and copy the project into `out` (which must live under
+/// `<root>/dist`). The shared front half of every bundle export:
+///
+/// 1. every module in `files` must satisfy the copy rules — a
+///    listed-but-uncopied module is a broken bundle, so this fails loud
+///    BEFORE the destructive wipe;
+/// 2. refuse to wipe through a symlink anywhere on `dist/…/out` —
+///    `remove_dir_all` follows intermediate symlinks and would delete the
+///    link TARGET's contents, potentially outside the project;
+/// 3. wipe `out` so a file deleted from the project can't linger, then
+///    copy the project in.
+pub fn stage_bundle(
+    root: &Path,
+    out: &Path,
+    entry: &str,
+    files: &[String],
+    reserved: &[&str],
+) -> Result<StagedBundle, Error> {
+    let unbundleable: Vec<&str> = files
+        .iter()
+        .filter(|f| !in_bundle(root, f, reserved))
+        .map(|f| f.as_str())
+        .collect();
+    if !unbundleable.is_empty() {
+        return Err(Error::other(format!(
+            "module(s) that can't ship in the bundle (hidden path segment, or a reserved \
+name {reserved:?} at the project root): {} — rename or move them",
+            unbundleable.join(", ")
+        )));
+    }
+
+    // Walk dist → out checking each component (dist and out included).
+    // (`dist/.`-style joins would resolve THROUGH a symlink, hiding it, so
+    // each path is checked as-is.)
+    let dist = root.join("dist");
+    let below_dist = out
+        .strip_prefix(&dist)
+        .map_err(|_| Error::other("bundle output must live under the project's dist/"))?
+        .to_path_buf();
+    let mut guard = dist.clone();
+    let mut to_check = vec![dist];
+    for component in below_dist.iter() {
+        guard = guard.join(component);
+        to_check.push(guard.clone());
+    }
+    for path in to_check {
+        let is_symlink = path
+            .symlink_metadata()
+            .is_ok_and(|m| m.file_type().is_symlink());
+        if is_symlink {
+            return Err(Error::other(format!(
+                "{} is a symlink — refusing to wipe and export through it",
+                path.display()
+            )));
+        }
+    }
+    if out.exists() {
+        std::fs::remove_dir_all(out)?;
+    }
+
+    let shadowed: Vec<String> = reserved
+        .iter()
+        .filter(|name| root.join(name).exists() && **name != "dist")
+        .map(|name| name.to_string())
+        .collect();
+
+    let mut stats = CopyStats::default();
+    copy_project(root, out, reserved, true, &mut stats)?;
+
+    Ok(StagedBundle {
+        file_count: stats.files,
+        project_bytes: stats.bytes,
+        missing_assets: missing_asset_references(root, entry, reserved),
+        shadowed,
+        skipped_symlinks: stats.skipped_symlinks,
+    })
+}
+
+#[derive(Default)]
+struct CopyStats {
+    files: usize,
+    bytes: u64,
+    skipped_symlinks: Vec<String>,
+}
+
+/// Recursive project copy: skips hidden entries everywhere (`.git`,
+/// `.DS_Store`) and the reserved names at the root only. Symlinked FILES
+/// copy through (`fs::copy` reads the target — a linked shared asset is a
+/// real workflow), but symlinked DIRECTORIES are skipped and reported:
+/// following one can recurse forever (a link to an ancestor) or vacuum an
+/// external tree into the bundle.
+fn copy_project(
+    src: &Path,
+    dst: &Path,
+    reserved: &[&str],
+    is_root: bool,
+    stats: &mut CopyStats,
+) -> Result<(), Error> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        if name_str.starts_with('.') {
+            continue;
+        }
+        if is_root && reserved.contains(&name_str.as_ref()) {
+            continue;
+        }
+        let from = entry.path();
+        let to = dst.join(&name);
+        // no-follow, so symlinks are decided here and never recursed into
+        let file_type = entry.file_type()?;
+        if file_type.is_symlink() {
+            match std::fs::metadata(&from) {
+                Ok(m) if m.is_file() => {
+                    stats.bytes += std::fs::copy(&from, &to)?;
+                    stats.files += 1;
+                }
+                // A symlinked dir or a broken link: skip + report.
+                _ => stats.skipped_symlinks.push(from.display().to_string()),
+            }
+        } else if file_type.is_dir() {
+            copy_project(&from, &to, reserved, false, stats)?;
+        } else {
+            stats.bytes += std::fs::copy(&from, &to)?;
+            stats.files += 1;
+        }
+    }
+    Ok(())
+}
+
+/// Best-effort missing-asset lint: every string literal in the project's
+/// `.fun`/`.funi` sources that looks like an asset path should resolve to a
+/// file the bundle carries (both runners resolve asset paths relative to
+/// the project dir). Absolute or `..` paths may work in a dev checkout but
+/// can never be in the bundle, so they're flagged even when the file
+/// exists. Computed paths (`"fish" ++ ".glb"`) are invisible to this scan —
+/// hence warn-only, never a gate — but it catches the common case:
+/// gitignored models that were never fetched, producing a bundle that
+/// silently renders fallbacks.
+pub fn missing_asset_references(root: &Path, entry: &str, reserved: &[&str]) -> Vec<String> {
+    let Ok(files) = functor_lang::project::project_files(&root.join(entry)) else {
+        return Vec::new();
+    };
+    let mut missing = BTreeSet::new();
+    for path in files {
+        let Ok(src) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        // A lex failure just skips the file: the build's typecheck gate
+        // already ran, so this only happens for sources it also rejected.
+        let Ok(tokens) = functor_lang::lexer::lex(&src, 0) else {
+            continue;
+        };
+        for token in tokens {
+            if let functor_lang::lexer::TokenKind::Str(s) = token.kind {
+                if is_asset_path(&s) && !in_bundle(root, &s, reserved) {
+                    missing.insert(s);
+                }
+            }
+        }
+    }
+    missing.into_iter().collect()
+}
+
+fn is_asset_path(s: &str) -> bool {
+    // A URL ("https://cdn/x.png") is fetched remotely, not from the bundle.
+    !s.contains("://")
+        && Path::new(s)
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|ext| ASSET_EXTENSIONS.iter().any(|a| ext.eq_ignore_ascii_case(a)))
+}
+
+/// Will the path `s` be present in the exported bundle at the path the
+/// runtime resolves? Mirrors the copy rules: relative, inside the project,
+/// no hidden segments, not under a reserved root name.
+fn in_bundle(root: &Path, s: &str, reserved: &[&str]) -> bool {
+    let path = Path::new(s);
+    if path.is_absolute() {
+        return false;
+    }
+    if s.split(['/', '\\'])
+        .next()
+        .is_some_and(|first| reserved.contains(&first))
+    {
+        return false;
+    }
+    // A `.`-prefixed segment is excluded by the copy's hidden-file rule,
+    // and `..` (also caught here) escapes the project.
+    if s.split(['/', '\\'])
+        .any(|seg| seg != "." && seg.starts_with('.'))
+    {
+        return false;
+    }
+    root.join(path).is_file()
+}

--- a/cli/src/util/mod.rs
+++ b/cli/src/util/mod.rs
@@ -1,12 +1,17 @@
+// The staging rules shared by both bundle exporters, and the native
+// exporter itself — ungated: `build native` works without the web bundle.
+pub mod bundle;
+mod native_export;
 mod shell_command;
-// The wasm dev server `include_bytes!`s the web bundle, so it (and its bundle
-// dependency) only exist under the `web` feature. The static `build wasm`
-// exporter writes those same embedded files, so it's gated too.
+// The wasm dev server `include_bytes!`s the web bundle, so it (and its
+// exporter, which writes those same embedded files) only exist under the
+// `web` feature.
 #[cfg(feature = "web")]
 mod wasm_dev_server;
 #[cfg(feature = "web")]
 mod wasm_export;
 
+pub use native_export::*;
 pub use shell_command::*;
 #[cfg(feature = "web")]
 pub use wasm_dev_server::*;

--- a/cli/src/util/native_export.rs
+++ b/cli/src/util/native_export.rs
@@ -1,0 +1,208 @@
+//! `build native`: write the project as a runnable native bundle in
+//! `dist/native/<os>-<arch>/` — a copy of the RUNNING `functor` binary
+//! (the desktop runtime is built in), renamed after the project, next to
+//! the same staged project file set the web export ships (see
+//! `util::bundle`). Launching that binary bare boots the game: it finds
+//! the adjacent `functor.json` (see `bundled_invocation` in main.rs).
+//! Zip the folder to share a playable build for this platform.
+
+use std::io::Error;
+use std::path::{Path, PathBuf};
+
+use super::bundle::{project_file_urls, project_name, stage_bundle, StagedBundle};
+
+#[derive(Debug)]
+pub struct NativeExport {
+    /// The bundle directory: `<project>/dist/native/<os>-<arch>`.
+    pub out_dir: PathBuf,
+    /// The game binary inside it, named after the project.
+    pub binary_path: PathBuf,
+    /// Bytes of that binary.
+    pub binary_bytes: u64,
+    pub staged: StagedBundle,
+}
+
+/// Export the project as a native bundle for the platform this CLI runs
+/// on. `exe` is the binary to ship — the caller passes
+/// `std::env::current_exe()` — so bundling needs no download and no
+/// compile; a release-built `functor` produces a release-grade bundle.
+pub fn export_functor_lang_native(
+    working_directory: &str,
+    entry: &str,
+    exe: &Path,
+) -> Result<NativeExport, Error> {
+    let root = Path::new(working_directory);
+    let target = format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH);
+    let out = root.join("dist").join("native").join(&target);
+
+    // Rebuilding THROUGH a bundled binary (`./dist/native/<t>/game build
+    // native`) would wipe the running executable out from under the copy
+    // below (and can't delete it at all on Windows). Refuse up front.
+    let exe_canonical = std::fs::canonicalize(exe).unwrap_or_else(|_| exe.to_path_buf());
+    if let Ok(root_canonical) = std::fs::canonicalize(root) {
+        if exe_canonical.starts_with(root_canonical.join("dist")) {
+            return Err(Error::other(format!(
+                "{} lives inside the output directory — rebuild with a functor binary \
+outside dist/ (the bundle would wipe the running executable)",
+                exe.display()
+            )));
+        }
+    }
+
+    // Native reserves only the output dir and its own binary name — the
+    // web-only names (index.html, pkg) ship normally in a native bundle.
+    // Reserving the binary name keeps a same-named project file from being
+    // silently clobbered by the copy below (it's skipped + reported).
+    let name = format!("{}{}", project_name(root), std::env::consts::EXE_SUFFIX);
+    let reserved = ["dist", name.as_str()];
+
+    let files = project_file_urls(working_directory, entry);
+    let staged = stage_bundle(root, &out, entry, &files, &reserved)?;
+
+    // The binary goes in last (like the web runtime files) so nothing in
+    // the project can shadow it. `fs::copy` preserves the exec bit.
+    let binary_path = out.join(&name);
+    let binary_bytes = std::fs::copy(exe, &binary_path)?;
+
+    Ok(NativeExport {
+        out_dir: out,
+        binary_path,
+        binary_bytes,
+        staged,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    static NEXT_DIR: AtomicU32 = AtomicU32::new(0);
+
+    struct TestDir(PathBuf);
+
+    impl TestDir {
+        fn new(name: &str) -> Self {
+            let suffix = NEXT_DIR.fetch_add(1, Ordering::Relaxed);
+            let dir = std::env::temp_dir().join(format!(
+                "functor-native-{name}-{}-{suffix}",
+                std::process::id()
+            ));
+            fs::create_dir_all(&dir).unwrap();
+            Self(dir)
+        }
+
+        fn write(&self, rel: &str, content: &str) {
+            let path = self.0.join(rel);
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(path, content).unwrap();
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn exports_binary_plus_project_under_a_target_dir() {
+        let dir = TestDir::new("layout");
+        dir.write("functor.json", r#"{"language":"functor-lang","entry":"game.fun"}"#);
+        dir.write("game.fun", "let init = 0");
+        dir.write("laser.ogg", "ogg-bytes");
+        dir.write("dist/native/stale-target/old", "wiped? no — sibling target");
+        let fake_exe = dir.0.join(".fake-functor"); // hidden: not copied as project data
+        fs::write(&fake_exe, "binary-bytes").unwrap();
+
+        let wd = dir.0.to_string_lossy().to_string();
+        let export = export_functor_lang_native(&wd, "game.fun", &fake_exe).unwrap();
+
+        let target = format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH);
+        assert!(export.out_dir.ends_with(Path::new("dist/native").join(&target)));
+        // The binary is named after the project dir and carries the exe bytes.
+        let expected_name = format!(
+            "{}{}",
+            dir.0.file_name().unwrap().to_string_lossy(),
+            std::env::consts::EXE_SUFFIX
+        );
+        assert_eq!(
+            export.binary_path.file_name().unwrap().to_string_lossy(),
+            expected_name
+        );
+        assert_eq!(fs::read(&export.binary_path).unwrap(), b"binary-bytes");
+        // The game rides along — functor.json included, so the binary can
+        // find its game at launch.
+        assert!(export.out_dir.join("functor.json").is_file());
+        assert!(export.out_dir.join("game.fun").is_file());
+        assert!(export.out_dir.join("laser.ogg").is_file());
+        // Only THIS target's dir is wiped; a sibling target's bundle stays.
+        assert!(dir.0.join("dist/native/stale-target/old").is_file());
+    }
+
+    #[test]
+    fn native_ships_web_reserved_names_but_not_its_own_binary_name() {
+        let dir = TestDir::new("reserved");
+        dir.write("functor.json", r#"{"language":"functor-lang","entry":"game.fun"}"#);
+        dir.write("game.fun", "let init = 0");
+        // Web-only reserved names are REAL project data for a native bundle.
+        dir.write("index.html", "native games may ship one");
+        dir.write("pkg/model.glb", "glb-bytes");
+        // A project file named exactly like the generated binary would be
+        // clobbered by the copy — reserved instead (skipped + reported).
+        let binary_name = format!(
+            "{}{}",
+            dir.0.file_name().unwrap().to_string_lossy(),
+            std::env::consts::EXE_SUFFIX
+        );
+        dir.write(&binary_name, "project data, not the binary");
+        let fake_exe = dir.0.join(".fake-functor");
+        fs::write(&fake_exe, "binary-bytes").unwrap();
+
+        let wd = dir.0.to_string_lossy().to_string();
+        let export = export_functor_lang_native(&wd, "game.fun", &fake_exe).unwrap();
+
+        assert!(export.out_dir.join("index.html").is_file());
+        assert!(export.out_dir.join("pkg/model.glb").is_file());
+        assert_eq!(
+            fs::read(&export.binary_path).unwrap(),
+            b"binary-bytes",
+            "the binary wins its name"
+        );
+        assert_eq!(export.staged.shadowed, vec![binary_name]);
+    }
+
+    #[test]
+    fn refuses_to_rebuild_through_a_bundled_binary() {
+        let dir = TestDir::new("self-wipe");
+        dir.write("functor.json", r#"{"language":"functor-lang","entry":"game.fun"}"#);
+        dir.write("game.fun", "let init = 0");
+        // The running exe living inside dist/ is exactly the
+        // `./dist/native/<t>/game build native` self-wipe scenario.
+        dir.write("dist/native/some-target/game", "the running binary");
+        let exe_in_dist = dir.0.join("dist/native/some-target/game");
+
+        let wd = dir.0.to_string_lossy().to_string();
+        let err = export_functor_lang_native(&wd, "game.fun", &exe_in_dist).unwrap_err();
+        assert!(err.to_string().contains("output directory"), "{err}");
+        assert!(exe_in_dist.is_file(), "nothing was wiped");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn the_copied_binary_keeps_its_exec_bit() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = TestDir::new("execbit");
+        dir.write("functor.json", r#"{"language":"functor-lang","entry":"game.fun"}"#);
+        dir.write("game.fun", "let init = 0");
+        let fake_exe = dir.0.join(".fake-functor");
+        fs::write(&fake_exe, "binary-bytes").unwrap();
+        fs::set_permissions(&fake_exe, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let wd = dir.0.to_string_lossy().to_string();
+        let export = export_functor_lang_native(&wd, "game.fun", &fake_exe).unwrap();
+        let mode = fs::metadata(&export.binary_path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o111, 0o111, "exec bits survive the copy");
+    }
+}

--- a/cli/src/util/wasm_dev_server.rs
+++ b/cli/src/util/wasm_dev_server.rs
@@ -2,6 +2,8 @@ use std::io;
 
 use warp::{http::Response, Filter};
 
+use super::bundle::project_file_urls;
+
 pub struct WasmDevServer;
 
 // pub(crate): the static `build wasm` exporter (util::wasm_export) writes
@@ -37,29 +39,6 @@ pub(crate) fn render_functor_lang_index(entry: &str, files: &[String]) -> String
     INDEX_FUNCTOR_LANG_HTML
         .replace("\"__FUNCTOR_LANG_ENTRY__\"", &entry_literal)
         .replace("\"__FUNCTOR_LANG_PROJECT_FILES__\"", &files_literal)
-}
-
-/// The project's file list as URLs relative to the served directory (entry
-/// first, then sibling `.fun`/`.funi` files) — the same set the desktop
-/// producer links (`functor_lang::project::project_files`), made relative so the web
-/// runtime fetches each from the dev server's filesystem route. Falls back to
-/// just the entry if the directory can't be scanned.
-pub(crate) fn project_file_urls(working_directory: &str, entry: &str) -> Vec<String> {
-    let entry_path = std::path::Path::new(working_directory).join(entry);
-    let paths = match functor_lang::project::project_files(&entry_path) {
-        Ok(paths) => paths,
-        Err(_) => return vec![entry.to_string()],
-    };
-    let root = std::path::Path::new(working_directory);
-    paths
-        .iter()
-        .map(|p| {
-            p.strip_prefix(root)
-                .unwrap_or(p)
-                .to_string_lossy()
-                .replace('\\', "/")
-        })
-        .collect()
 }
 
 impl WasmDevServer {

--- a/cli/src/util/wasm_export.rs
+++ b/cli/src/util/wasm_export.rs
@@ -8,103 +8,33 @@
 //! silently broken bundle. The folder works on any static host: zip it for
 //! itch.io (HTML5), push it to GitHub Pages, `python -m http.server` it.
 //!
-//! The whole project directory is copied (minus hidden entries and the
-//! reserved output names below) rather than a statically discovered file
-//! set: asset paths are runtime strings (`Scene.model("shark.glb")`, or
-//! computed), and a non-embedded `.gltf` references external `.bin`/texture
-//! files from *inside* the glTF — no source scan can see either, and a
-//! missing asset degrades to the invisible fallback, the worst failure mode
-//! for a published game. Copy-everything is the only rule that keeps the
-//! run-wasm ↔ export invariant. A best-effort lint (below) still catches the
-//! common case of literal-referenced assets that were never fetched.
+//! The staging rules (copy-everything, reserved names, symlink handling,
+//! the missing-asset lint) live in `util::bundle`, shared with the native
+//! export.
 
-use std::collections::BTreeSet;
 use std::io::Error;
 use std::path::{Path, PathBuf};
 
-use super::wasm_dev_server::{project_file_urls, render_functor_lang_index, JS_FILE_1, WASM_FILE};
-
-/// Names at the project root the exporter owns in the bundle: its output dir
-/// and the runtime files it writes. Project files with these names are
-/// skipped (and reported via [`WasmExport::shadowed`]) rather than merged —
-/// merging a project `pkg/` with the runtime's would leave stray files
-/// beside the wasm bundle.
-const RESERVED_ROOT: &[&str] = &["dist", "index.html", "pkg"];
-
-/// Extensions the runtime fetches at runtime: models (plus the external
-/// buffers/images a non-embedded `.gltf` references), audio, textures.
-const ASSET_EXTENSIONS: &[&str] = &[
-    "glb", "gltf", "bin", "wav", "ogg", "mp3", "png", "jpg", "jpeg", "hdr",
-];
+use super::bundle::{project_file_urls, stage_bundle, StagedBundle, WEB_RESERVED};
+use super::wasm_dev_server::{render_functor_lang_index, JS_FILE_1, WASM_FILE};
 
 #[derive(Debug)]
 pub struct WasmExport {
     /// The bundle directory: `<project>/dist/web`.
     pub out_dir: PathBuf,
-    /// Project files copied into the bundle (excludes the runtime files).
-    pub file_count: usize,
-    /// Total bytes of those project files.
-    pub project_bytes: u64,
-    /// Bytes of the embedded runtime files written alongside them.
+    /// Bytes of the embedded runtime files written alongside the project.
     pub runtime_bytes: u64,
-    /// String-literal asset references that will NOT be in the bundle
-    /// (missing from the project dir, or absolute/`..`/hidden paths).
-    pub missing_assets: Vec<String>,
-    /// Root-level project entries skipped because their names are reserved.
-    pub shadowed: Vec<String>,
-    /// Symlinked directories (or broken links) skipped by the copy.
-    pub skipped_symlinks: Vec<String>,
+    pub staged: StagedBundle,
 }
 
-/// Export the project as a static web bundle. `dist/web` is wiped first so a
-/// file deleted from the project can't linger in the bundle.
+/// Export the project as a static web bundle (see `util::bundle` for the
+/// staging rules).
 pub fn export_functor_lang_wasm(working_directory: &str, entry: &str) -> Result<WasmExport, Error> {
     let root = Path::new(working_directory);
-
-    // Every module baked into the index's file list must be fetchable from
-    // the bundle — a listed-but-uncopied module 404s at load time, a broken
-    // bundle. Validate BEFORE the destructive wipe below, and fail loud.
-    let files = project_file_urls(working_directory, entry);
-    let unbundleable: Vec<&str> = files
-        .iter()
-        .filter(|f| !in_bundle(root, f))
-        .map(|f| f.as_str())
-        .collect();
-    if !unbundleable.is_empty() {
-        return Err(Error::other(format!(
-            "module(s) that can't ship in the bundle (hidden path segment, or a reserved \
-name {RESERVED_ROOT:?} at the project root): {} — rename or move them",
-            unbundleable.join(", ")
-        )));
-    }
-
     let out = root.join("dist").join("web");
-    // Refuse to wipe through a symlink: `remove_dir_all` follows an
-    // intermediate `dist` symlink and would delete the link TARGET's
-    // contents — potentially outside the project.
-    for link in [root.join("dist"), out.clone()] {
-        let is_symlink = link
-            .symlink_metadata()
-            .is_ok_and(|m| m.file_type().is_symlink());
-        if is_symlink {
-            return Err(Error::other(format!(
-                "{} is a symlink — refusing to wipe and export through it",
-                link.display()
-            )));
-        }
-    }
-    if out.exists() {
-        std::fs::remove_dir_all(&out)?;
-    }
 
-    let shadowed: Vec<String> = RESERVED_ROOT
-        .iter()
-        .filter(|name| root.join(name).exists() && **name != "dist")
-        .map(|name| name.to_string())
-        .collect();
-
-    let mut stats = CopyStats::default();
-    copy_project(root, &out, true, &mut stats)?;
+    let files = project_file_urls(working_directory, entry);
+    let staged = stage_bundle(root, &out, entry, &files, WEB_RESERVED)?;
 
     // The runtime files go in last so nothing in the project can shadow them.
     std::fs::write(out.join("index.html"), render_functor_lang_index(entry, &files))?;
@@ -115,12 +45,8 @@ name {RESERVED_ROOT:?} at the project root): {} — rename or move them",
 
     Ok(WasmExport {
         out_dir: out,
-        file_count: stats.files,
-        project_bytes: stats.bytes,
         runtime_bytes: (JS_FILE_1.len() + WASM_FILE.len()) as u64,
-        missing_assets: missing_asset_references(root, entry),
-        shadowed,
-        skipped_symlinks: stats.skipped_symlinks,
+        staged,
     })
 }
 
@@ -167,125 +93,10 @@ fn collect_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), Error> {
     Ok(())
 }
 
-#[derive(Default)]
-struct CopyStats {
-    files: usize,
-    bytes: u64,
-    skipped_symlinks: Vec<String>,
-}
-
-/// Recursive project copy: skips hidden entries everywhere (`.git`,
-/// `.DS_Store`) and the reserved names at the root only. Symlinked FILES
-/// copy through (`fs::copy` reads the target — a linked shared asset is a
-/// real workflow), but symlinked DIRECTORIES are skipped and reported:
-/// following one can recurse forever (a link to an ancestor) or vacuum an
-/// external tree into the bundle.
-fn copy_project(src: &Path, dst: &Path, is_root: bool, stats: &mut CopyStats) -> Result<(), Error> {
-    std::fs::create_dir_all(dst)?;
-    for entry in std::fs::read_dir(src)? {
-        let entry = entry?;
-        let name = entry.file_name();
-        let name_str = name.to_string_lossy();
-        if name_str.starts_with('.') {
-            continue;
-        }
-        if is_root && RESERVED_ROOT.contains(&name_str.as_ref()) {
-            continue;
-        }
-        let from = entry.path();
-        let to = dst.join(&name);
-        // no-follow, so symlinks are decided here and never recursed into
-        let file_type = entry.file_type()?;
-        if file_type.is_symlink() {
-            match std::fs::metadata(&from) {
-                Ok(m) if m.is_file() => {
-                    stats.bytes += std::fs::copy(&from, &to)?;
-                    stats.files += 1;
-                }
-                // A symlinked dir or a broken link: skip + report.
-                _ => stats.skipped_symlinks.push(from.display().to_string()),
-            }
-        } else if file_type.is_dir() {
-            copy_project(&from, &to, false, stats)?;
-        } else {
-            stats.bytes += std::fs::copy(&from, &to)?;
-            stats.files += 1;
-        }
-    }
-    Ok(())
-}
-
-/// Best-effort missing-asset lint: every string literal in the project's
-/// `.fun`/`.funi` sources that looks like an asset path should resolve to a
-/// file the bundle carries (wasm fetches asset paths as URLs relative to the
-/// page, i.e. relative to the project dir). Absolute or `..` paths work
-/// natively but can never be in the bundle, so they're flagged even when the
-/// file exists. Computed paths (`"fish" ++ ".glb"`) are invisible to this
-/// scan — hence warn-only, never a gate — but it catches the common case:
-/// gitignored models that were never fetched, producing a bundle that
-/// silently renders fallbacks.
-fn missing_asset_references(root: &Path, entry: &str) -> Vec<String> {
-    let Ok(files) = functor_lang::project::project_files(&root.join(entry)) else {
-        return Vec::new();
-    };
-    let mut missing = BTreeSet::new();
-    for path in files {
-        let Ok(src) = std::fs::read_to_string(&path) else {
-            continue;
-        };
-        // A lex failure just skips the file: the build's typecheck gate
-        // already ran, so this only happens for sources it also rejected.
-        let Ok(tokens) = functor_lang::lexer::lex(&src, 0) else {
-            continue;
-        };
-        for token in tokens {
-            if let functor_lang::lexer::TokenKind::Str(s) = token.kind {
-                if is_asset_path(&s) && !in_bundle(root, &s) {
-                    missing.insert(s);
-                }
-            }
-        }
-    }
-    missing.into_iter().collect()
-}
-
-fn is_asset_path(s: &str) -> bool {
-    // A URL ("https://cdn/x.png") is fetched remotely, not from the bundle.
-    !s.contains("://")
-        && Path::new(s)
-            .extension()
-            .and_then(|e| e.to_str())
-            .is_some_and(|ext| ASSET_EXTENSIONS.iter().any(|a| ext.eq_ignore_ascii_case(a)))
-}
-
-/// Will the path `s` be present in the exported bundle at the URL the
-/// runtime fetches? Mirrors the copy rules: relative, inside the project,
-/// no hidden segments, not under a reserved root name.
-fn in_bundle(root: &Path, s: &str) -> bool {
-    let path = Path::new(s);
-    if path.is_absolute() {
-        return false;
-    }
-    let mut segments = s.split(['/', '\\']);
-    if segments
-        .next()
-        .is_some_and(|first| RESERVED_ROOT.contains(&first))
-    {
-        return false;
-    }
-    // A `.`-prefixed segment is excluded by the copy's hidden-file rule,
-    // and `..` (also caught here) escapes the project.
-    if s.split(['/', '\\'])
-        .any(|seg| seg != "." && seg.starts_with('.'))
-    {
-        return false;
-    }
-    root.join(path).is_file()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::util::bundle::{missing_asset_references, WEB_RESERVED};
     use std::fs;
     use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -350,8 +161,8 @@ mod tests {
         assert!(!out.join("stale.txt").exists(), "stale output is wiped, not carried over");
         assert!(!out.join("dist").exists(), "the output dir is never copied into itself");
         // game.fun + pieces.fun + model.glb + tex/wall.png
-        assert_eq!(export.file_count, 4);
-        assert!(export.shadowed.is_empty());
+        assert_eq!(export.staged.file_count, 4);
+        assert!(export.staged.shadowed.is_empty());
     }
 
     #[test]
@@ -368,7 +179,7 @@ mod tests {
         let index = fs::read_to_string(out.join("index.html")).unwrap();
         assert!(index.contains("__functorLangGamePath"), "the bundle's index wins");
         assert!(!out.join("pkg/junk.js").exists(), "no merge into the runtime pkg/");
-        assert_eq!(export.shadowed, vec!["index.html", "pkg"]);
+        assert_eq!(export.staged.shadowed, vec!["index.html", "pkg"]);
     }
 
     #[test]
@@ -390,7 +201,7 @@ let g = "pkg/tex.png"
 "#,
         );
 
-        let missing = missing_asset_references(dir.path(), "game.fun");
+        let missing = missing_asset_references(dir.path(), "game.fun", WEB_RESERVED);
         assert_eq!(
             missing,
             vec!["../outside.png", "/abs/path.jpg", "missing.glb", "pkg/tex.png"],
@@ -453,7 +264,7 @@ let g = "pkg/tex.png"
 
         let wd = dir.path().to_string_lossy().to_string();
         let export = export_functor_lang_wasm(&wd, "game.fun").unwrap();
-        assert_eq!(export.file_count, 1, "only game.fun ships");
+        assert_eq!(export.staged.file_count, 1, "only game.fun ships");
         assert!(!export.out_dir.join(".hidden.fun").exists(), "hidden sibling not bundled");
     }
 
@@ -496,7 +307,7 @@ let g = "pkg/tex.png"
             "a symlinked file copies through"
         );
         assert!(!export.out_dir.join("loop").exists());
-        assert_eq!(export.skipped_symlinks.len(), 1);
-        assert!(export.skipped_symlinks[0].ends_with("loop"));
+        assert_eq!(export.staged.skipped_symlinks.len(), 1);
+        assert!(export.staged.skipped_symlinks[0].ends_with("loop"));
     }
 }


### PR DESCRIPTION
Stacked on #331 (which stacks on #325).

## What

`functor -d <game> build native` exports a **shareable, runnable folder bundle**:

```
dist/native/macos-aarch64/
  asteroids            # this functor binary, renamed — desktop runtime built in
  functor.json
  game.fun (+ siblings)
  ship.glb, *.ogg, …   # same staged file set as the web export
```

**Double-clicking the binary starts the game.** Launch arbitration: clap parses first — anything that parses as a CLI invocation is one (`./asteroids --verbose build native`, `--help`, subcommands); only a clap-rejected invocation (bare launch, or runner flags like `--capture-frame`) next to an adjacent `functor.json` boots the game from the binary's own directory. A dev `target/debug/functor` is unaffected (no adjacent manifest). Because the shipped binary IS the CLI, a bundle is also a full dev environment — `./asteroids run wasm` etc. all work.

No cross-compilation or downloads: bundling is a file copy of the running binary, so a release-built `functor` produces a release-grade bundle (the CI release binaries slot in directly; cross-platform bundling can later fetch those artifacts).

## Design

- **Staging rules unified**: the copy-everything machinery, symlink guards, missing-asset lint, and pre-wipe module validation moved from the web-gated `wasm_export` into ungated `util::bundle`, consumed by both exporters — `build native` works in `--no-default-features` builds.
- **Per-target reserved names** (from cross-engine review): web reserves `dist`/`index.html`/`pkg` (its own outputs); native reserves only `dist` + its binary name. A native game with a root `index.html` or `pkg/` asset dir ships it intact; a project file named like the binary is skipped + reported, not silently clobbered.
- **Self-wipe guard**: rebuilding through a bundled binary (`./dist/native/<t>/game build native`) is refused up front — staging would otherwise delete the running executable before copying it.

## Verification

- 36 CLI tests pass (new: bundle layout, exec-bit preservation, per-target reservations, binary-name shadowing, self-wipe refusal, launch-arbitration predicate).
- End-to-end: exported `examples/asteroids`, launched the bundled `asteroids` binary from an unrelated cwd with `--capture-frame`/`--fixed-time` — the menu renders in the captured frame. `--help`, `--verbose build native`, and the bare dev binary all route to the CLI.
- Cross-engine review (Claude + Codex): no Critical/High; both Mediums fixed (per-target reservations, self-wipe guard) plus the arbitration and clobber findings. Justified skip: the bundled boot re-runs the typecheck each launch (~ms for real games, and it turns a tampered bundle into a clear error instead of a crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)