### PR TITLE
feat(ui): Ui.center() anchor — pin a panel to the screen center

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -509,6 +509,8 @@ Ui.text("line") / Ui.textColor(r, g, b, "line")            // HUD text (monospac
 Ui.column([view, …]) / Ui.row([view, …])                   // stack top-to-bottom / left-to-right
 view |> Ui.panel(Ui.topLeft())                             // pin to a corner (view-LAST: pipes);
 Ui.topLeft() / topRight() / bottomLeft() / bottomRight()   //   Anchor VALUES (the Angle rule)
+Ui.center()                                                //   center anchor (menus): pins a
+                                                           //   panel to the middle of the screen
 Ui.button("label", msg)                                    // INTERACTIVE (docs/ui-interaction.md):
                                                            //   a click delivers msg VERBATIM
                                                            //   through `update` (the Sub.every

--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -54,7 +54,7 @@ let shapes = [c, Rect(3.0, 4.0), Point]       // bare Point IS the value
 let area = (s: Shape): float =>
   match s with                                // match: | pattern => full-expression body
   | Circle(r) => 3.14 * r * r                 // ctor patterns bind positionally
-  | Rect(w, _) => w * w                       // sub-patterns: names or _ ONLY (no nesting)
+  | Rect(w, _) => w * w                       // sub-patterns: names, _, or literals (no deeper nesting)
   | Point => 0.0                              // exhaustiveness checked when s's type is known
 
 let sizeOf = (s: Shape): string =>
@@ -273,9 +273,17 @@ open Widget                                              // …or open, bringing
   pattern vars can't (they are forced lowercase).
 - **Patterns are minimal**: `Ctor(x, _)` / `Ctor` / `(x, _)` (tuple) /
   bare name / `_` / literals (`true`, `false`, numbers incl. negative,
-  strings — equality match). Ctor and tuple sub-patterns are names or `_`
-  only — no nesting, no literals inside. A tuple pattern matches by EXACT
-  arity (mismatch = non-match, like ctors).
+  strings — equality match). Ctor and tuple sub-patterns are names, `_`, or a
+  LITERAL (`| ("Enter", true) =>`, `| Circle(0.0) =>` — number incl. negative,
+  string, bool) — but still no deeper nesting (no ctor/tuple/list inside).
+  A literal sub-pattern is REFUTABLE, so a tuple/ctor arm with one no longer
+  counts toward exhaustiveness (`| ("Enter", true) =>` needs a catch-all; a
+  lone `| Circle(0.0) =>` still leaves `Circle` "missing"). This is
+  conservative — even a nominally-total set like `(true, _) | (false, _)`
+  still wants a catch-all (nested products aren't split into cases). LIST
+  element/tail sub-patterns stay names/`_` only (no literals — list
+  exhaustiveness is length-based). A tuple pattern matches by EXACT arity
+  (mismatch = non-match, like ctors).
   Pattern vars are immutable bindings; lambdas may capture them. First
   matching arm wins; no arm matching is a spanned runtime error. Unapplied
   ctors are first-class (`xs |> List.map(Circle)`); the runtime checks ctor

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -27,7 +27,7 @@ bug found in the same exercise was fixed on the spot
 - [x] Literals inside tuple/ctor patterns (`| ("Enter", true) =>`) for
       input mapping.
 - [x] `Frame.withClearColor` (today: distant-fog trick doubles as clear color).
-- [ ] `Ui.center()` anchor (+ eventually font size / spacer) for menus.
+- [x] `Ui.center()` anchor (+ eventually font size / spacer) for menus.
 - [x] Soundscape missing-asset error should warn once, not every frame.
 - [x] Project loader/watcher: ignore non-identifier / dot-prefixed `*.fun`
       stems (editor temp files fail hot reload today).

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -24,7 +24,7 @@ bug found in the same exercise was fixed on the spot
 - [x] List builtins: `length`, `append`, `flatten`, `any`/`all`, `reverse`,
       `isEmpty` — naive recursive versions blow the eval-depth cap at n≈60;
       the depth error should name the cap and hint at `List.fold`.
-- [ ] Literals inside tuple/ctor patterns (`| ("Enter", true) =>`) for
+- [x] Literals inside tuple/ctor patterns (`| ("Enter", true) =>`) for
       input mapping.
 - [x] `Frame.withClearColor` (today: distant-fog trick doubles as clear color).
 - [ ] `Ui.center()` anchor (+ eventually font size / spacer) for menus.

--- a/functor-lang/src/parser.rs
+++ b/functor-lang/src/parser.rs
@@ -792,10 +792,10 @@ and an `else` branch)",
         while self.peek_kind() != &TokenKind::RBracket {
             if self.peek_kind() == &TokenKind::DotDot {
                 self.bump();
-                tail = Some(Box::new(self.sub_pattern()?));
+                tail = Some(Box::new(self.list_element_pattern()?));
                 break;
             }
-            items.push(self.sub_pattern()?);
+            items.push(self.list_element_pattern()?);
             if self.peek_kind() == &TokenKind::Comma {
                 self.bump();
             } else {
@@ -874,7 +874,70 @@ and an `else` branch)",
         })
     }
 
+    /// A sub-pattern of a tuple or constructor pattern: a variable binding,
+    /// `_`, or a LITERAL (number — negative included — string, or bool). These
+    /// stay non-nesting: a nested constructor/tuple/list sub-pattern is still
+    /// refused, so `(Circle(r), _)` does not parse — only the leaves may be
+    /// literals (`("Enter", true)`).
     fn sub_pattern(&mut self) -> Result<Pattern, ParseError> {
+        // A leading `-` folds into a negative number literal (as in the
+        // top-level `pattern`).
+        if self.peek_kind() == &TokenKind::Minus {
+            if let TokenKind::Number(n) = self.nth_kind(1) {
+                let n = *n;
+                let minus = self.bump();
+                let number = self.bump();
+                return Ok(Pattern {
+                    kind: PatternKind::Number(-n),
+                    span: minus.span.to(number.span),
+                });
+            }
+        }
+        let span = self.peek().span;
+        let kind = match self.peek_kind() {
+            TokenKind::Number(n) => {
+                let n = *n;
+                self.bump();
+                PatternKind::Number(n)
+            }
+            TokenKind::Str(s) => {
+                let s = s.clone();
+                self.bump();
+                PatternKind::String(s)
+            }
+            TokenKind::True => {
+                self.bump();
+                PatternKind::Bool(true)
+            }
+            TokenKind::False => {
+                self.bump();
+                PatternKind::Bool(false)
+            }
+            TokenKind::Ident(name) if name == "_" => {
+                self.bump();
+                PatternKind::Wildcard
+            }
+            TokenKind::Ident(name) if !starts_uppercase(name) => {
+                let name = name.clone();
+                self.bump();
+                PatternKind::Var(name)
+            }
+            _ => {
+                return self.error(
+                    "a binding name, `_`, or a literal (constructor/tuple patterns do not nest)",
+                )
+            }
+        };
+        Ok(Pattern { kind, span })
+    }
+
+    /// A list element / tail sub-pattern: a variable binding or `_` only.
+    /// Unlike tuple/ctor sub-patterns, list elements may NOT be literals —
+    /// list exhaustiveness is length-based (it assumes every element is
+    /// irrefutable), so a literal element (`[true, ..rest]`) would silently
+    /// break it. Keeping the restriction here scopes the literal widening to
+    /// tuple/ctor patterns, where exhaustiveness accounts for it.
+    fn list_element_pattern(&mut self) -> Result<Pattern, ParseError> {
         let span = self.peek().span;
         let kind = match self.peek_kind() {
             TokenKind::Ident(name) if name == "_" => {
@@ -886,7 +949,7 @@ and an `else` branch)",
                 self.bump();
                 PatternKind::Var(name)
             }
-            _ => return self.error("a binding name or `_` (constructor patterns do not nest)"),
+            _ => return self.error("a binding name or `_` (list patterns do not nest)"),
         };
         Ok(Pattern { kind, span })
     }

--- a/functor-lang/src/types.rs
+++ b/functor-lang/src/types.rs
@@ -244,6 +244,17 @@ fn pattern_var_bindings(pattern: &Pattern, f: &mut impl FnMut(u32)) {
     }
 }
 
+/// Is `pattern` (a tuple/ctor sub-pattern) irrefutable — matching any value of
+/// the right type? Names and `_` are; a literal sub-pattern is not. Used by
+/// exhaustiveness: a tuple/ctor arm only counts as a catch-all / as covering
+/// its constructor when every sub-pattern is irrefutable.
+fn sub_pattern_irrefutable(pattern: &Pattern) -> bool {
+    matches!(
+        pattern.kind,
+        PatternKind::Wildcard | PatternKind::Var { .. }
+    )
+}
+
 /// Substitute declaration parameter placeholders (`Var(i)`, i < args.len())
 /// with concrete type arguments — how generic record/variant field types
 /// meet their use sites. Non-generic declarations contain no placeholders,
@@ -1939,15 +1950,26 @@ missing {missing}. Did you forget an argument?"
                         list_exact.push(items.len());
                     }
                 }
-                // Sub-patterns are irrefutable (names/`_`), so a tuple arm
-                // catches every tuple of its arity — but only if that arity
-                // CAN match the scrutinee (the mismatch itself is diagnosed
-                // in check_pattern; it must not also count as exhaustive).
-                PatternKind::Tuple(args) => match &self.zonk(&scrutinee_ty) {
-                    Type::Tuple(elems) if elems.len() != args.len() => {}
-                    _ => has_catch_all = true,
-                },
-                PatternKind::Ctor { name, .. } => covered_ctors.push(name),
+                // A tuple arm catches every tuple of its arity only when all
+                // its sub-patterns are irrefutable (names/`_`); a literal
+                // sub-pattern (`("Enter", true)`) makes it refutable, so it no
+                // longer counts as a catch-all. And the arity must be able to
+                // match the scrutinee (a mismatch is diagnosed in
+                // check_pattern; it must not also count as exhaustive).
+                PatternKind::Tuple(args) if args.iter().all(sub_pattern_irrefutable) => {
+                    match &self.zonk(&scrutinee_ty) {
+                        Type::Tuple(elems) if elems.len() != args.len() => {}
+                        _ => has_catch_all = true,
+                    }
+                }
+                PatternKind::Tuple(_) => {}
+                // A ctor arm fully covers that constructor only when all its
+                // sub-patterns are irrefutable; `Circle(0.0)` matches some
+                // `Circle`s, not all, so it doesn't count toward coverage.
+                PatternKind::Ctor { name, args } if args.iter().all(sub_pattern_irrefutable) => {
+                    covered_ctors.push(name)
+                }
+                PatternKind::Ctor { .. } => {}
                 PatternKind::Bool(true) => saw_true = true,
                 PatternKind::Bool(false) => saw_false = true,
                 PatternKind::Number(_) | PatternKind::String(_) => {}
@@ -2033,17 +2055,22 @@ a catch-all arm (`_` or a name)"
                         );
                     }
                 }
-                // A known product with no arity-matching arm can never be
-                // handled (the per-arm mismatch diags say why each arm
-                // fails; this says the MATCH as a whole is uncovered).
+                // A known product left uncovered. Either no arm matches the
+                // arity at all, or some do but are all refutable (a literal
+                // sub-pattern) with no catch-all — distinguish the two so the
+                // message fits the feature's primary use (input mapping).
                 Type::Tuple(elems) => {
+                    let arity_matched = arms.iter().any(|arm| {
+                        matches!(&arm.pattern.kind, PatternKind::Tuple(args) if args.len() == elems.len())
+                    });
+                    let detail = if arity_matched {
+                        "its arms are refutable — add a catch-all (`_` or a name)".to_string()
+                    } else {
+                        format!("no arm matches a {}-element tuple", elems.len())
+                    };
                     self.diag(
                         expr.span,
-                        format!(
-                            "match on {scrutinee_ty} is not exhaustive: no arm matches a \
-{}-element tuple",
-                            elems.len()
-                        ),
+                        format!("match on {scrutinee_ty} is not exhaustive: {detail}"),
                     );
                 }
                 // Unknown stays gradual; List/Record/Fn scrutinees already

--- a/functor-lang/tests/check.rs
+++ b/functor-lang/tests/check.rs
@@ -1479,6 +1479,18 @@ fn bool_operators_check_clean() {
     );
 }
 
+// --- Literals inside tuple / constructor patterns ---
+
+#[test]
+fn tuple_literal_patterns_check_clean() {
+    assert_clean(
+        "let f = (key: string, down: bool) =>\n\
+         \x20 match (key, down) with\n\
+         \x20 | (\"Enter\", true) => 1.0\n\
+         \x20 | (_, _) => 0.0",
+    );
+}
+
 #[test]
 fn logical_operand_must_be_bool() {
     let (message, line, _) = single_diag("let f = () => 1.0 && true");
@@ -1517,6 +1529,18 @@ fn if_else_checks_clean() {
 }
 
 #[test]
+fn ctor_literal_patterns_check_clean() {
+    assert_clean(
+        "type Shape = | Circle(r: float) | Rect(w: float, h: float)\n\
+         let f = (s: Shape) =>\n\
+         \x20 match s with\n\
+         \x20 | Circle(0.0) => \"pt\"\n\
+         \x20 | Circle(r) => \"c\"\n\
+         \x20 | Rect(w, h) => \"r\"",
+    );
+}
+
+#[test]
 fn if_condition_must_be_bool() {
     // A genuinely-non-bool condition (a float literal) — an unannotated param
     // would simply be inferred to bool instead.
@@ -1531,6 +1555,24 @@ fn if_branches_must_unify() {
     assert_eq!(
         message,
         "`if` branches have incompatible types float and string"
+    );
+}
+
+#[test]
+fn tuple_literal_sub_pattern_is_not_a_catch_all() {
+    // `("Enter", true)` is refutable, so without a catch-all the match is
+    // not exhaustive.
+    let (message, _, _) = single_diag(
+        "let f = (a: string, b: bool) =>\n\
+         \x20 match (a, b) with\n\
+         \x20 | (\"Enter\", true) => 1.0",
+    );
+    // The arm matches the arity but is refutable — the message must point at
+    // the missing catch-all, not claim no arm matches the arity.
+    assert_eq!(
+        message,
+        "match on (string, bool) is not exhaustive: its arms are refutable — \
+         add a catch-all (`_` or a name)"
     );
 }
 
@@ -1576,4 +1618,37 @@ fn nested_if_keeps_its_own_type() {
     );
     let inner = types.expr(else_branch.id).expect("inner if type recorded");
     assert_eq!(inner.to_string(), "float");
+}
+
+#[test]
+fn ctor_literal_sub_pattern_does_not_cover_the_ctor() {
+    // `Circle(0.0)` matches some circles, not all — `Circle` is still missing.
+    let diags = check_src(
+        "type Shape = | Circle(r: float) | Rect(w: float, h: float)\n\
+         let f = (s: Shape) =>\n\
+         \x20 match s with\n\
+         \x20 | Circle(0.0) => \"pt\"\n\
+         \x20 | Rect(w, h) => \"r\"",
+    );
+    assert!(
+        diags
+            .iter()
+            .any(|(m, _, _)| m.contains("not exhaustive") && m.contains("Circle")),
+        "expected a 'missing Circle' diagnostic, got {diags:?}"
+    );
+}
+
+#[test]
+fn literal_sub_pattern_type_mismatch_is_diagnosed() {
+    // A string literal where the tuple element is a float.
+    let (message, _, _) = single_diag(
+        "let f = (a: float, b: bool) =>\n\
+         \x20 match (a, b) with\n\
+         \x20 | (\"x\", true) => 1.0\n\
+         \x20 | (_, _) => 0.0",
+    );
+    assert!(
+        message.contains("string") && message.contains("float"),
+        "unexpected: {message}"
+    );
 }

--- a/functor-lang/tests/parser.rs
+++ b/functor-lang/tests/parser.rs
@@ -306,17 +306,92 @@ fn error_match_requires_leading_bar() {
     );
 }
 
-/// Sub-patterns are bindings or `_` only — constructor patterns don't nest.
+/// Sub-patterns are bindings, `_`, or literals — constructor patterns don't
+/// nest another constructor/tuple.
 #[test]
 fn error_nested_constructor_pattern() {
     assert_eq!(
         parse_err("let f = (s) => match s with | Circle(Point) => 1.0 | _ => 0.0"),
         (
-            "expected a binding name or `_` (constructor patterns do not nest), found `Point`"
+            "expected a binding name, `_`, or a literal (constructor/tuple patterns do not nest), \
+             found `Point`"
                 .to_string(),
             1,
             38
         )
+    );
+}
+
+/// Literals ARE allowed as tuple/ctor sub-patterns (`("Enter", true)`) — the
+/// input-mapping shape. String, number (incl. negative), and bool leaves.
+#[test]
+fn tuple_pattern_allows_literal_sub_patterns() {
+    use functor_lang::ast::PatternKind;
+    let src = "let f = (p) => match p with | (\"Enter\", true) => 1.0 | (-1.0, x) => x | _ => 0.0";
+    let program = functor_lang::parse(src).unwrap();
+    let Item::Let(decl) = &program.items[0] else {
+        panic!("expected a let declaration");
+    };
+    let ExprKind::Lambda { body, .. } = &decl.value.kind else {
+        panic!("expected a lambda");
+    };
+    let ExprKind::Match { arms, .. } = &body.kind else {
+        panic!("expected a match");
+    };
+    let PatternKind::Tuple(first) = &arms[0].pattern.kind else {
+        panic!("expected a tuple pattern");
+    };
+    assert!(matches!(first[0].kind, PatternKind::String(ref s) if s == "Enter"));
+    assert!(matches!(first[1].kind, PatternKind::Bool(true)));
+    let PatternKind::Tuple(second) = &arms[1].pattern.kind else {
+        panic!("expected a tuple pattern");
+    };
+    assert!(matches!(second[0].kind, PatternKind::Number(n) if n == -1.0));
+    assert!(matches!(second[1].kind, PatternKind::Var(ref n) if n == "x"));
+}
+
+/// A literal inside a constructor pattern (`Circle(0.0)`) parses.
+#[test]
+fn ctor_pattern_allows_literal_sub_pattern() {
+    use functor_lang::ast::PatternKind;
+    let src = "let f = (s) => match s with | Circle(0.0) => 1.0 | _ => 0.0";
+    let program = functor_lang::parse(src).unwrap();
+    let Item::Let(decl) = &program.items[0] else {
+        panic!("expected a let declaration");
+    };
+    let ExprKind::Lambda { body, .. } = &decl.value.kind else {
+        panic!("expected a lambda");
+    };
+    let ExprKind::Match { arms, .. } = &body.kind else {
+        panic!("expected a match");
+    };
+    let PatternKind::Ctor { args, .. } = &arms[0].pattern.kind else {
+        panic!("expected a ctor pattern");
+    };
+    assert!(matches!(args[0].kind, PatternKind::Number(n) if n == 0.0));
+}
+
+/// A nested tuple sub-pattern is still refused (only literal leaves, no
+/// deeper structure).
+#[test]
+fn error_nested_tuple_sub_pattern() {
+    let (message, _, _) = parse_err("let f = (p) => match p with | ((a, b), c) => a | _ => 0.0");
+    assert_eq!(
+        message,
+        "expected a binding name, `_`, or a literal (constructor/tuple patterns do not nest), \
+         found `(`"
+    );
+}
+
+/// Literals are NOT allowed in LIST element/tail patterns — list
+/// exhaustiveness is length-based and would silently break. The widening is
+/// scoped to tuple/ctor patterns.
+#[test]
+fn error_literal_in_list_pattern() {
+    let (message, _, _) = parse_err("let f = (xs) => match xs with | [] => 0.0 | [true, ..r] => 1.0");
+    assert_eq!(
+        message,
+        "expected a binding name or `_` (list patterns do not nest), found `true`"
     );
 }
 

--- a/functor-lang/tests/run.rs
+++ b/functor-lang/tests/run.rs
@@ -1299,3 +1299,40 @@ fn if_condition_on_non_bool_errors() {
     );
     assert_eq!(message, "`if` condition needs a bool, got a number");
 }
+
+// --- Literals inside tuple / constructor patterns ---
+
+#[test]
+fn tuple_literal_patterns_match_by_value() {
+    // The input-mapping shape: match on (key, isDown).
+    let src = "let classify = (key, down) =>\n\
+               \x20 match (key, down) with\n\
+               \x20 | (\"Enter\", true) => \"start\"\n\
+               \x20 | (\"Escape\", true) => \"quit\"\n\
+               \x20 | (_, false) => \"release\"\n\
+               \x20 | (_, _) => \"other\"\n\
+               let main = () => [classify(\"Enter\", true), classify(\"W\", false), classify(\"W\", true)]";
+    assert_eq!(main_result(src), "[\"start\", \"release\", \"other\"]");
+}
+
+#[test]
+fn ctor_literal_patterns_match_by_value() {
+    let src = "type Shape = | Circle(r: float) | Rect(w: float, h: float)\n\
+               let describe = (s: Shape) =>\n\
+               \x20 match s with\n\
+               \x20 | Circle(0.0) => \"point\"\n\
+               \x20 | Circle(r) => \"circle\"\n\
+               \x20 | Rect(w, h) => \"rect\"\n\
+               let main = () => [describe(Circle(0.0)), describe(Circle(2.0)), describe(Rect(1.0, 2.0))]";
+    assert_eq!(main_result(src), "[\"point\", \"circle\", \"rect\"]");
+}
+
+#[test]
+fn negative_number_sub_pattern() {
+    let src = "let sign = (p) =>\n\
+               \x20 match p with\n\
+               \x20 | (-1.0, y) => \"neg\"\n\
+               \x20 | (_, _) => \"other\"\n\
+               let main = () => [sign((-1.0, 5.0)), sign((2.0, 5.0))]";
+    assert_eq!(main_result(src), "[\"neg\", \"other\"]");
+}

--- a/functor-prelude/prelude/ui.funi
+++ b/functor-prelude/prelude/ui.funi
@@ -19,6 +19,8 @@ let topLeft : () => anchor
 let topRight : () => anchor
 let bottomLeft : () => anchor
 let bottomRight : () => anchor
+// Pins a panel to the screen center — e.g. `menuColumn |> Ui.panel(Ui.center())`.
+let center : () => anchor
 // Interactive widgets (docs/ui-interaction.md); like Sub.every's msg, 'msg is
 // erased by the opaque `view` — the msg↔update link is checked at runtime.
 // A click delivers `msg` verbatim through `update`.

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -63,6 +63,8 @@
 //! Ui.column([view, …]) / Ui.row([view, …])                  -> View
 //! Ui.panel(anchor, view)                                    -> View
 //! Ui.topLeft() / topRight() / bottomLeft() / bottomRight()  -> Anchor
+//! Ui.center()                                               -> Anchor
+//!   (pins a panel to the screen center — e.g. a menu column)
 //! Ui.button(label, msg)                                     -> View
 //! Ui.slider(min, max, value, tagger)                        -> View
 //! Ui.textInput(value, tagger)                               -> View
@@ -909,6 +911,7 @@ const PATHS: &[&str] = &[
     "Ui.topRight",
     "Ui.bottomLeft",
     "Ui.bottomRight",
+    "Ui.center",
     "Ui.button",
     "Ui.slider",
     "Ui.textInput",
@@ -2132,6 +2135,10 @@ paths (+X, -X, +Y, -Y, +Z, -Z)",
             "Ui.bottomRight" => match args.as_slice() {
                 [] => Ok(host(FunctorLangUiAnchor(ui::Anchor::BottomRight))),
                 _ => usage("Ui.bottomRight()"),
+            },
+            "Ui.center" => match args.as_slice() {
+                [] => Ok(host(FunctorLangUiAnchor(ui::Anchor::Center))),
+                _ => usage("Ui.center()"),
             },
             "Ui.row" => match args.as_slice() {
                 [Value::List(items)] => {
@@ -5139,6 +5146,28 @@ the game dir"
             r#"{"Panel":{"anchor":"TopLeft","child":{"Column":[{"Text":{"text":"functor · hello","color":[255,255,255],"font":null}},{"Text":{"text":"eye  0.0 0.0 -5.0","color":[255,217,102],"font":null}}]}}}"#
         );
         // And it round-trips (the wasm boundary ships Views as JSON).
+        let back: View = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(serde_json::to_string(&back).unwrap(), json);
+    }
+
+    // Ui.center() pins a panel to the screen center — the menu anchor. It
+    // lowers to a Panel with the Center anchor and round-trips over the wire.
+    #[test]
+    fn ui_center_anchors_a_panel_to_the_middle() {
+        let value = eval(
+            "let main = () =>\n\
+             Ui.column([Ui.text(\"Play\"), Ui.text(\"Quit\")]) |> Ui.panel(Ui.center())",
+        );
+        let view = view_value(&value).expect("main should return a View");
+        assert!(matches!(
+            view,
+            View::Panel {
+                anchor: ui::Anchor::Center,
+                ..
+            }
+        ));
+        let json = serde_json::to_string(view).expect("serialize");
+        assert!(json.contains(r#""anchor":"Center""#), "json: {json}");
         let back: View = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(serde_json::to_string(&back).unwrap(), json);
     }

--- a/runtime/functor-runtime-common/src/ui.rs
+++ b/runtime/functor-runtime-common/src/ui.rs
@@ -51,13 +51,15 @@ pub struct FontRef {
     pub size: f32,
 }
 
-/// Which screen corner a [`View::Panel`] pins its subtree to.
+/// Which screen position a [`View::Panel`] pins its subtree to — the four
+/// corners, or the screen center (for menus).
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum Anchor {
     TopLeft,
     TopRight,
     BottomLeft,
     BottomRight,
+    Center,
 }
 
 /// A declarative, serializable 2D UI tree — the lowering target for the F# `Ui`
@@ -376,23 +378,26 @@ fn render_view(ui: &mut egui::Ui, view: &View, state: &mut UiFrameState) {
     }
 }
 
-/// egui corner alignment + inset offset for an [`Anchor`].
+/// egui alignment + inset offset for an [`Anchor`]. Center pins to the middle
+/// with no edge inset (the margin is meaningless there).
 fn anchor_align(anchor: Anchor) -> (egui::Align2, egui::Vec2) {
     match anchor {
         Anchor::TopLeft => (egui::Align2::LEFT_TOP, egui::vec2(MARGIN, MARGIN)),
         Anchor::TopRight => (egui::Align2::RIGHT_TOP, egui::vec2(-MARGIN, MARGIN)),
         Anchor::BottomLeft => (egui::Align2::LEFT_BOTTOM, egui::vec2(MARGIN, -MARGIN)),
         Anchor::BottomRight => (egui::Align2::RIGHT_BOTTOM, egui::vec2(-MARGIN, -MARGIN)),
+        Anchor::Center => (egui::Align2::CENTER_CENTER, egui::vec2(0.0, 0.0)),
     }
 }
 
-/// A stable per-corner id so distinct panels get distinct egui `Area` ids.
+/// A stable per-anchor id so distinct panels get distinct egui `Area` ids.
 fn anchor_id(anchor: Anchor) -> u8 {
     match anchor {
         Anchor::TopLeft => 0,
         Anchor::TopRight => 1,
         Anchor::BottomLeft => 2,
         Anchor::BottomRight => 3,
+        Anchor::Center => 4,
     }
 }
 
@@ -1051,6 +1056,23 @@ mod tests {
             pos: None,
             primary_down: down,
         }
+    }
+
+    #[test]
+    fn center_anchor_maps_to_the_middle_with_a_unique_id() {
+        let (align, offset) = anchor_align(Anchor::Center);
+        assert_eq!(align, egui::Align2::CENTER_CENTER);
+        assert_eq!(offset, egui::vec2(0.0, 0.0));
+        // A distinct id from every corner so a centered panel gets its own Area.
+        let ids = [
+            anchor_id(Anchor::TopLeft),
+            anchor_id(Anchor::TopRight),
+            anchor_id(Anchor::BottomLeft),
+            anchor_id(Anchor::BottomRight),
+            anchor_id(Anchor::Center),
+        ];
+        let unique: std::collections::HashSet<_> = ids.iter().collect();
+        assert_eq!(unique.len(), ids.len(), "anchor ids must be unique");
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds `Ui.center()` — a screen-center anchor for the Elm-style UI panel system,
alongside the existing four corners. Menus need it:

```
let menu = () =>
  Ui.column([
    Ui.text("Play"),
    Ui.text("Options"),
    Ui.text("Quit"),
  ]) |> Ui.panel(Ui.center())
```

(Centering only — the todo's "eventually font size / spacer" is left for later.)

## How

- New `Anchor::Center` variant in the shared `ui.rs`, lowering to egui
  `CENTER_CENTER` with no edge inset (the margin is meaningless at the center),
  plus a unique `anchor_id` so a centered panel gets its own egui `Area`.
- `Ui.center()` wired in the shared prelude (`FunctorHost`) + `.funi` signature,
  so **both** shells get it — the desktop and web runtimes lower `View` through
  the same `TextOverlay`.
- `functor-lang` skill doc updated in the same PR.

## Tests

`cargo test -p functor_runtime_common` (262 passing) — a `ui.rs` unit test that
`Center` maps to `CENTER_CENTER` with a unique id, and a prelude round-trip that
`Ui.center()` lowers to a `Panel { anchor: Center }` and survives the JSON wire.
The `.funi`↔host bijection guard covers the new signature.

## Visual verification

Captured headlessly: a menu column pinned with `Ui.panel(Ui.center())` sits in
the middle of the screen, distinct from a `topLeft` panel shown for contrast.
GIF + PNG below.

![Ui.center() demo](https://gist.githubusercontent.com/tommy-xr/7d8cfd8d2429e5b1957891a609d0fc94/raw/uicenter-demo.gif)

<sub>The centered menu column stays anchored to mid-screen while the background cube rotates a full turn; a top-left "corner: topLeft" panel is shown for contrast. Rendered headlessly via `--capture-frame` / `--fixed-time`.</sub>

![still](https://gist.githubusercontent.com/tommy-xr/7d8cfd8d2429e5b1957891a609d0fc94/raw/uicenter-t0.png)


🤖 Generated with [Claude Code](https://claude.com/claude-code)
