### PR TITLE
refactor(examples): asteroids on the new language/engine features [STACKED on #326 #327 #328 #330 #332 #334 #337]

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -509,6 +509,8 @@ Ui.text("line") / Ui.textColor(r, g, b, "line")            // HUD text (monospac
 Ui.column([view, …]) / Ui.row([view, …])                   // stack top-to-bottom / left-to-right
 view |> Ui.panel(Ui.topLeft())                             // pin to a corner (view-LAST: pipes);
 Ui.topLeft() / topRight() / bottomLeft() / bottomRight()   //   Anchor VALUES (the Angle rule)
+Ui.center()                                                //   center anchor (menus): pins a
+                                                           //   panel to the middle of the screen
 Ui.button("label", msg)                                    // INTERACTIVE (docs/ui-interaction.md):
                                                            //   a click delivers msg VERBATIM
                                                            //   through `update` (the Sub.every

--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -54,7 +54,7 @@ let shapes = [c, Rect(3.0, 4.0), Point]       // bare Point IS the value
 let area = (s: Shape): float =>
   match s with                                // match: | pattern => full-expression body
   | Circle(r) => 3.14 * r * r                 // ctor patterns bind positionally
-  | Rect(w, _) => w * w                       // sub-patterns: names or _ ONLY (no nesting)
+  | Rect(w, _) => w * w                       // sub-patterns: names, _, or literals (no deeper nesting)
   | Point => 0.0                              // exhaustiveness checked when s's type is known
 
 let sizeOf = (s: Shape): string =>
@@ -273,9 +273,17 @@ open Widget                                              // …or open, bringing
   pattern vars can't (they are forced lowercase).
 - **Patterns are minimal**: `Ctor(x, _)` / `Ctor` / `(x, _)` (tuple) /
   bare name / `_` / literals (`true`, `false`, numbers incl. negative,
-  strings — equality match). Ctor and tuple sub-patterns are names or `_`
-  only — no nesting, no literals inside. A tuple pattern matches by EXACT
-  arity (mismatch = non-match, like ctors).
+  strings — equality match). Ctor and tuple sub-patterns are names, `_`, or a
+  LITERAL (`| ("Enter", true) =>`, `| Circle(0.0) =>` — number incl. negative,
+  string, bool) — but still no deeper nesting (no ctor/tuple/list inside).
+  A literal sub-pattern is REFUTABLE, so a tuple/ctor arm with one no longer
+  counts toward exhaustiveness (`| ("Enter", true) =>` needs a catch-all; a
+  lone `| Circle(0.0) =>` still leaves `Circle` "missing"). This is
+  conservative — even a nominally-total set like `(true, _) | (false, _)`
+  still wants a catch-all (nested products aren't split into cases). LIST
+  element/tail sub-patterns stay names/`_` only (no literals — list
+  exhaustiveness is length-based). A tuple pattern matches by EXACT arity
+  (mismatch = non-match, like ctors).
   Pattern vars are immutable bindings; lambdas may capture them. First
   matching arm wins; no arm matching is a spanned runtime error. Unapplied
   ctors are first-class (`xs |> List.map(Circle)`); the runtime checks ctor

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -27,7 +27,7 @@ bug found in the same exercise was fixed on the spot
 - [x] Literals inside tuple/ctor patterns (`| ("Enter", true) =>`) for
       input mapping.
 - [x] `Frame.withClearColor` (today: distant-fog trick doubles as clear color).
-- [ ] `Ui.center()` anchor (+ eventually font size / spacer) for menus.
+- [x] `Ui.center()` anchor (+ eventually font size / spacer) for menus.
 - [x] Soundscape missing-asset error should warn once, not every frame.
 - [x] Project loader/watcher: ignore non-identifier / dot-prefixed `*.fun`
       stems (editor temp files fail hot reload today).

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -24,7 +24,7 @@ bug found in the same exercise was fixed on the spot
 - [x] List builtins: `length`, `append`, `flatten`, `any`/`all`, `reverse`,
       `isEmpty` — naive recursive versions blow the eval-depth cap at n≈60;
       the depth error should name the cap and hint at `List.fold`.
-- [ ] Literals inside tuple/ctor patterns (`| ("Enter", true) =>`) for
+- [x] Literals inside tuple/ctor patterns (`| ("Enter", true) =>`) for
       input mapping.
 - [x] `Frame.withClearColor` (today: distant-fog trick doubles as clear color).
 - [ ] `Ui.center()` anchor (+ eventually font size / spacer) for menus.

--- a/examples/asteroids/font.fun
+++ b/examples/asteroids/font.fun
@@ -45,13 +45,13 @@ let glyphCubes = (gx, gz, s, rows) =>
 
 // A word centered on (cx, cz): glyphs are 3 cells + 1 gap wide (4*s pitch).
 let word = (s, cx, cz, glyphs) =>
-  let count = Lib.length(glyphs) in
+  let count = List.length(glyphs) in
   let width = count * 4.0 * s - s in
   // startX/row origin are CELL CENTERS, hence the half-cell offsets.
   let startX = cx - width * 0.5 + s * 0.5 in
   let folded = glyphs |> List.fold((acc, g) =>
     let (gx, out) = acc in
-    (gx + 4.0 * s, Lib.append(glyphCubes(gx, cz - 2.0 * s, s, g), out)),
+    (gx + 4.0 * s, glyphCubes(gx, cz - 2.0 * s, s, g) |> List.append(out)),
     (startX, [])) in
   let (ignored, cubes) = folded in
   Scene.group(cubes)

--- a/examples/asteroids/game.fun
+++ b/examples/asteroids/game.fun
@@ -14,8 +14,6 @@
 // The playfield is the XZ plane (Y-up, camera overhead); positions wrap
 // at the field edges like the arcade original.
 
-open Lib
-
 // ---------- tuning ----------
 let worldX = 21.0        // half-extent of the playfield in x
 let worldZ = 15.0        // half-extent in z
@@ -27,6 +25,7 @@ let bulletLife = 1.0     // seconds
 let shipRadius = 0.7
 let respawnShield = 2.5  // seconds of invulnerability after (re)spawn
 let finalWave = 3.0
+let tau = Math.pi * 2.0
 
 type Phase =
   | Menu
@@ -38,12 +37,6 @@ type Msg =
   | Seeded(r: float)     // Effect.random result: begin a fresh run
   | StartClicked
   | RestartClicked
-
-// ---------- deterministic "randomness" ----------
-// Math has no floor/frac/random, so scaled-sin noise stands in: a
-// deterministic value in roughly [0,1] from a seed and a stream index.
-let noise = (seed, n) =>
-  Math.sin(seed * 127.1 + n * 311.7) * 0.5 + 0.5
 
 // ---------- spawning ----------
 let radiusOf = (size) =>
@@ -61,22 +54,38 @@ let pointsFor = (size) =>
 let waveRocks = (wave) => 2.0 + wave
 
 // A large rock on a ring around the center (never on the ship), drifting
-// in a noise-picked direction with a noise-picked spin.
-let spawnRock = (seed, n) =>
-  let ang = noise(seed, n) * 6.28318 in
-  let ring = 8.0 + noise(seed, n + 17.0) * 6.0 in
-  let dir = noise(seed, n + 31.0) * 6.28318 in
-  let speed = 1.5 + noise(seed, n + 47.0) * 2.0 in
-  { x: Math.sin(ang) * ring,
-    z: Math.cos(ang) * ring,
-    vx: Math.sin(dir) * speed,
-    vz: Math.cos(dir) * speed,
-    size: 3.0,
-    spin: noise(seed, n + 5.0) * 3.0 - 1.5,
-    seed: noise(seed, n + 3.0) }
+// in a randomly-picked direction with a random spin. Threads the seed:
+// returns (rock, nextSeed).
+let spawnRock = (seed) =>
+  let (u1, s1) = Random.step(seed) in
+  let (ring, s2) = Random.range(8.0, 14.0, s1) in
+  let (u3, s3) = Random.step(s2) in
+  let (speed, s4) = Random.range(1.5, 3.5, s3) in
+  let (spin, s5) = Random.range(0.0 - 1.5, 1.5, s4) in
+  // Store an INTEGER PRNG state as the rock's stable seed (s5 is a next-state,
+  // always a large integer). A fractional [0,1) VALUE would truncate to
+  // counter 0 in Random.step and reseed every rock identically. Thread one
+  // step past it so the next rock's stream is disjoint.
+  let (ignored, s6) = Random.step(s5) in
+  let ang = u1 * tau in
+  let dir = u3 * tau in
+  ({ x: Math.sin(ang) * ring,
+     z: Math.cos(ang) * ring,
+     vx: Math.sin(dir) * speed,
+     vz: Math.cos(dir) * speed,
+     size: 3.0,
+     spin: spin,
+     seed: s5 }, s6)
 
+// Spawn `count` rocks, threading one PRNG stream through them all — no
+// correlated streams (the sin-hash bug the findings log flagged). Returns
+// (rocks, nextSeed) so the caller can advance the wave's stream.
 let spawnWave = (seed, count) =>
-  List.range(count) |> List.map((n) => spawnRock(seed, n))
+  List.range(count) |> List.fold((acc, _) =>
+    let (rocks, s) = acc in
+    let (rock, s2) = spawnRock(s) in
+    ([rock, ..rocks], s2),
+    ([], seed))
 
 let newShip = {
   pos: { x: 0.0, z: 0.0 },
@@ -84,19 +93,19 @@ let newShip = {
   heading: 0.0,
 }
 
-let init = {
-  phase: Menu,
-  ship: newShip,
-  bullets: [],
-  asteroids: spawnWave(0.42, 5.0),   // the menu's drifting backdrop
-  score: 0.0,
-  lives: 3.0,
-  wave: 1.0,
-  held: { left: false, right: false, thrust: false },
-  fireHeld: false,
-  shield: 0.0,
-  seed: 0.42,
-}
+let init =
+  let (backdrop, ignored) = spawnWave(0.42, 5.0) in   // the menu's drifting backdrop
+  { phase: Menu,
+    ship: newShip,
+    bullets: [],
+    asteroids: backdrop,
+    score: 0.0,
+    lives: 3.0,
+    wave: 1.0,
+    held: { left: false, right: false, thrust: false },
+    fireHeld: false,
+    shield: 0.0,
+    seed: 0.42 }
 
 // ---------- geometry helpers ----------
 let wrap = (v, limit) =>
@@ -134,29 +143,39 @@ let bulletHitsRock = (a, b) =>
 let assignHits = (bullets, rocks) =>
   rocks |> List.fold((acc, a) =>
     let (bs, kept, struck) = acc in
-    (match bs |> Lib.any((b) => bulletHitsRock(a, b)) with
+    (match bs |> List.any((b) => bulletHitsRock(a, b)) with
      | true => (Lib.removeFirst((b) => bulletHitsRock(a, b), bs), kept, [a, ..struck])
      | false => (bs, [a, ..kept], struck)),
     (bullets, [], []))
 
 // ---------- splitting ----------
 // A destroyed rock (sizes 3/2) splits into two children of the next size
-// down, flung off the parent's course by opposite noise-picked angles.
-let childRock = (a, ang, salt) =>
+// down, flung off the parent's course by opposite random angles. Each
+// child draws its spin + seed from the parent's seed stream.
+let childRock = (a, ang, seed) =>
   let v = rotVec(a.vx * 1.35, a.vz * 1.35, ang) in
-  { x: a.x,
-    z: a.z,
-    vx: v.x,
-    vz: v.z,
-    size: a.size - 1.0,
-    spin: noise(a.seed, salt + 9.0) * 4.0 - 2.0,
-    seed: noise(a.seed, salt) }
+  let (spin, s1) = Random.range(0.0 - 2.0, 2.0, seed) in
+  // Store an integer seed for the child (see spawnRock); thread one step on.
+  let (ignored, s2) = Random.step(s1) in
+  ({ x: a.x,
+     z: a.z,
+     vx: v.x,
+     vz: v.z,
+     size: a.size - 1.0,
+     spin: spin,
+     seed: s1 }, s2)
 
 let splitRock = (a) =>
   match a.size with
   | 1.0 => []
-  | _ => [childRock(a, 0.7 + noise(a.seed, 7.0), 1.7),
-          childRock(a, 0.0 - (0.7 + noise(a.seed, 8.0)), 2.3)]
+  | _ =>
+    // Draw split angles from a sub-stream distinct from rockScene's (which
+    // reads a.seed directly), so a rock's shape and its split stay independent.
+    let (ang1, s1) = Random.range(0.7, 1.7, a.seed + 1.0) in
+    let (ang2, s2) = Random.range(0.7, 1.7, s1) in
+    let (c1, s3) = childRock(a, ang1, s2) in
+    let (c2, ignored) = childRock(a, 0.0 - ang2, s3) in
+    [c1, c2]
 
 // ---------- effects ----------
 let fxOf = (list) =>
@@ -166,18 +185,19 @@ let fxOf = (list) =>
 
 // ---------- a fresh run ----------
 let freshRun = (model, seed) =>
+  let (rocks, seed2) = spawnWave(seed, waveRocks(1.0)) in
   { model with
       phase: Playing,
       ship: newShip,
       bullets: [],
-      asteroids: spawnWave(seed, waveRocks(1.0)),
+      asteroids: rocks,
       score: 0.0,
       lives: 3.0,
       wave: 1.0,
       held: { left: false, right: false, thrust: false },
       fireHeld: false,
       shield: respawnShield,
-      seed: seed }
+      seed: seed2 }
 
 let update = (model, msg) =>
   match msg with
@@ -196,12 +216,6 @@ let setHeld = (held, key, isDown) =>
   | "W" => { held with thrust: isDown }
   | _ => held
 
-let startPressed = (key, isDown) =>
-  Lib.and(isDown, Lib.or(key == "Enter", key == "Space"))
-
-let restartPressed = (key, isDown) =>
-  Lib.and(isDown, Lib.or(key == "Enter", key == "R"))
-
 // Spawn a bullet at the ship's nose, inheriting the ship's velocity.
 let fire = (model) =>
   let s = model.ship in
@@ -214,30 +228,30 @@ let fire = (model) =>
    Effect.play("laser.ogg"))
 
 // GLFW key repeats arrive as isDown = true, so firing latches on the
-// rising edge (fireHeld clears on release).
+// rising edge (fireHeld clears on release). Literal tuple patterns map
+// (key, isDown) directly.
 let inputPlaying = (model, key, isDown) =>
   let m = { model with held: setHeld(model.held, key, isDown) } in
-  match key with
-  | "Space" =>
-    (match isDown with
-     | true => (match m.fireHeld with | true => m | false => fire(m))
-     | false => { m with fireHeld: false })
-  | "M" => (match isDown with | true => { m with phase: Menu } | false => m)
-  | _ => m
+  match (key, isDown) with
+  | ("Space", true) => (match m.fireHeld with | true => m | false => fire(m))
+  | ("Space", false) => { m with fireHeld: false }
+  | ("M", true) => { m with phase: Menu }
+  | (_, _) => m
 
 let input = (model, key, isDown) =>
   match model.phase with
   | Menu =>
-    (match startPressed(key, isDown) with
-     | true => (model, Effect.random(Seeded))
-     | false => model)
+    (match (key, isDown) with
+     | ("Enter", true) => (model, Effect.random(Seeded))
+     | ("Space", true) => (model, Effect.random(Seeded))
+     | (_, _) => model)
   | Playing => inputPlaying(model, key, isDown)
   | _ =>
-    (match restartPressed(key, isDown) with
-     | true => (model, Effect.random(Seeded))
-     | false => (match Lib.and(key == "M", isDown) with
-                 | true => { model with phase: Menu }
-                 | false => model))
+    (match (key, isDown) with
+     | ("Enter", true) => (model, Effect.random(Seeded))
+     | ("R", true) => (model, Effect.random(Seeded))
+     | ("M", true) => { model with phase: Menu }
+     | (_, _) => model)
 
 // ---------- simulation ----------
 let axis = (neg, pos) =>
@@ -248,7 +262,7 @@ let stepShip = (ship, held, dt) =>
   let heading = ship.heading + axis(held.left, held.right) * turnSpeed * dt in
   let acc = (match held.thrust with | true => thrustAccel | false => 0.0) in
   // Floored at 0 so a pathological frame (dt > 2s) can't reverse velocity.
-  let keep = Lib.floorAt(0.0, 1.0 - drag * dt) in
+  let keep = Math.max(0.0, 1.0 - drag * dt) in
   let vx = (ship.vel.x + Math.sin(heading) * acc * dt) * keep in
   let vz = (ship.vel.z + Math.cos(heading) * acc * dt) * keep in
   { pos: { x: wrap(ship.pos.x + vx * dt, worldX),
@@ -277,15 +291,15 @@ let tickPlaying = (model, dt, tts) =>
   let movedA = moveRocks(model.asteroids, dt) in
   let hits = assignHits(movedB, movedA) in
   let (keptB, kept, struck) = hits in
-  let rocks = Lib.append(kept, struck |> List.map(splitRock) |> Lib.flatten) in
+  let children = struck |> List.map(splitRock) |> List.flatten in
+  let rocks = kept |> List.append(children) in
   let gained = struck |> List.fold((acc, a) => acc + pointsFor(a.size), 0.0) in
-  let anyKill = (match struck with | [] => false | _ => true) in
+  let anyKill = not (List.isEmpty(struck)) in
   let killFx = (match anyKill with
                 | true => [Effect.play("explosion.ogg")]
                 | false => []) in
-  let shield = Lib.floorAt(0.0, model.shield - dt) in
-  let shipHit = Lib.and(shield == 0.0,
-                        rocks |> Lib.any((a) => rockHitsShip(ship, a))) in
+  let shield = Math.max(0.0, model.shield - dt) in
+  let shipHit = shield == 0.0 && (rocks |> List.any((a) => rockHitsShip(ship, a))) in
   let base = { model with
                  ship: ship,
                  bullets: keptB,
@@ -297,22 +311,22 @@ let tickPlaying = (model, dt, tts) =>
     (let lives = model.lives - 1.0 in
      match lives < 1.0 with
      | true => ({ base with lives: 0.0, phase: Lost },
-                fxOf(Lib.append(killFx, [Effect.play("ship-explosion.ogg")])))
+                fxOf(killFx |> List.append([Effect.play("ship-explosion.ogg")])))
      | false => ({ base with lives: lives, ship: newShip, shield: respawnShield },
-                 fxOf(Lib.append(killFx, [Effect.play("ship-explosion.ogg")]))))
+                 fxOf(killFx |> List.append([Effect.play("ship-explosion.ogg")]))))
   | false =>
-    (match rocks with
-     | [] =>
+    (match List.isEmpty(rocks) with
+     | true =>
        (match model.wave < finalWave with
         | true =>
-          (let nextSeed = noise(model.seed, tts) in
+          (let (next, nextSeed) = spawnWave(model.seed, waveRocks(model.wave + 1.0)) in
            ({ base with wave: model.wave + 1.0,
                         seed: nextSeed,
-                        shield: Lib.floorAt(1.5, shield),
-                        asteroids: spawnWave(nextSeed, waveRocks(model.wave + 1.0)) },
+                        shield: Math.max(1.5, shield),
+                        asteroids: next },
             fxOf(killFx)))
         | false => ({ base with phase: Won }, fxOf(killFx)))
-     | _ => (base, fxOf(killFx)))
+     | false => (base, fxOf(killFx)))
 
 let tick = (model, dt, tts) =>
   match model.phase with
@@ -324,25 +338,30 @@ let tick = (model, dt, tts) =>
 
 // ---------- rendering ----------
 // Stars as tiny upward-facing planes (spheres this small render as
-// speckle clusters from overhead). Brightness varies by noise.
+// speckle clusters from overhead). One PRNG stream threads all 60 stars,
+// so brightness/size/position are independent (no closed-curve clumping).
 let starfield = () =>
-  List.range(60.0) |> List.map((n) =>
-    let glow = 0.45 + noise(9.1, n) * 0.55 in
-    Scene.plane()
-      |> Scene.scale(0.14 + noise(7.7, n) * 0.14)
-      |> Scene.emissive(glow, glow, glow * 1.08)
-      // Decorrelated index scales — the same n-step in both axes walks a
-      // closed curve and the stars visibly clump.
-      |> Scene.translate((noise(3.1, n) * 2.0 - 1.0) * (worldX + 8.0),
-                         0.0 - 4.0,
-                         (noise(5.3, n * 1.37 + 11.0) * 2.0 - 1.0) * (worldZ + 8.0)))
+  let (stars, ignored) = List.range(60.0) |> List.fold((acc, _) =>
+    let (out, seed) = acc in
+    let (glow, s1) = Random.range(0.45, 1.0, seed) in
+    let (scale, s2) = Random.range(0.14, 0.28, s1) in
+    let (fx, s3) = Random.range(0.0 - 1.0, 1.0, s2) in
+    let (fz, s4) = Random.range(0.0 - 1.0, 1.0, s3) in
+    ([Scene.plane()
+        |> Scene.scale(scale)
+        |> Scene.emissive(glow, glow, glow * 1.08)
+        |> Scene.translate(fx * (worldX + 8.0), 0.0 - 4.0, fz * (worldZ + 8.0)), ..out],
+     s4),
+    ([], 7.7)) in
+  stars
 
 let rockScene = (a, tts) =>
   let r = radiusOf(a.size) in
+  let (sx, s1) = Random.range(0.75, 1.25, a.seed) in
+  let (sy, s2) = Random.range(0.75, 1.25, s1) in
+  let (sz, ignored) = Random.range(0.75, 1.25, s2) in
   Scene.sphere()
-    |> Scene.scaleXYZ(r * (0.75 + noise(a.seed, 1.0) * 0.5),
-                      r * (0.75 + noise(a.seed, 2.0) * 0.5),
-                      r * (0.75 + noise(a.seed, 3.0) * 0.5))
+    |> Scene.scaleXYZ(r * sx, r * sy, r * sz)
     |> Scene.rotateY(Angle.radians(tts * a.spin))
     |> Scene.lit(0.62, 0.55, 0.47)
     |> Scene.translate(a.x, 0.0, a.z)
@@ -364,7 +383,7 @@ let shipBody = (thrusting) =>
                   |> Scene.translate(0.0, 0.0, 0.0 - 0.85)
                   |> Scene.emissive(1.0, 0.55, 0.1)]
      | false => []) in
-  Scene.group(Lib.append([
+  Scene.group([
     // Kenney crafts model nose-toward--Z; flip to face our +Z forward.
     // The glb's craft_racer node carries a baked [2, 0, 1.5] placement
     // translation (kit-scene leftover) — counter it first or the body
@@ -373,21 +392,20 @@ let shipBody = (thrusting) =>
       |> Scene.translate(0.0 - 2.0, 0.0, 0.0 - 1.5)
       |> Scene.rotateY(Angle.degrees(180.0))
       |> Scene.scale(1.5),
-  ], flame))
+  ] |> List.append(flame))
 
 // Hidden entirely on Menu/Lost; blinks while the respawn shield runs.
 let shipScenes = (model, tts) =>
-  let visible = Lib.or(model.shield < 0.001, Math.sin(tts * 18.0) > 0.0) in
+  let visible = model.shield < 0.001 || Math.sin(tts * 18.0) > 0.0 in
   match visible with
   | false => []
   | true =>
-    [shipBody(Lib.and(model.held.thrust, model.phase == Playing))
+    [shipBody(model.held.thrust && model.phase == Playing)
        |> Scene.rotateY(Angle.radians(model.ship.heading))
        |> Scene.translate(model.ship.pos.x, 0.0, model.ship.pos.z)]
 
 // Centered arcade-style screens, built from Font's emissive cube glyphs
-// in scene space (Ui panels only anchor to corners — docs/todo.md). They
-// vanish the frame the phase changes.
+// in scene space. They vanish the frame the phase changes.
 let pressEnter = (tts, z) =>
   match Math.sin(tts * 4.0) > 0.0 - 0.3 with   // arcade blink, mostly on
   | true => [Font.word(0.3, 0.0, z,
@@ -434,10 +452,8 @@ let draw = (model, tts) =>
                  Scene.group(titleScenes(model, tts))]),
     [Light.ambient(0.3, 0.3, 0.38),
      Light.directional(-0.45, -1.0, -0.3, 1.0, 0.97, 0.9, 1.1)])
-    // Distance fog starting past the whole scene: nothing in play is
-    // fogged, but the pass's clear color becomes deep space (there is no
-    // Frame.clearColor — see the findings log).
-    |> Frame.withFog(Fog.linear(80.0, 160.0, 0.01, 0.012, 0.035))
+    // Deep-space background: an explicit clear color (no fog trick needed).
+    |> Frame.withClearColor(0.01, 0.012, 0.035)
 
 // ---------- sound ----------
 // One-shots (laser/explosions) fire as Effects above; the thrust loop is
@@ -461,7 +477,7 @@ let hudUi = (model) =>
     Ui.text(Text.concat("WAVE   ", Text.concat(f0(model.wave), Text.concat(" / ", f0(finalWave))))),
   ]) |> Ui.panel(Ui.topLeft())
 
-// The big centered title/prompt is scene-space (titleScenes); this corner
+// The big arcade title/prompt is scene-space (titleScenes); this centered
 // panel carries the controls reference and a clickable Start.
 let menuUi = (model) =>
   Ui.column([
@@ -469,7 +485,7 @@ let menuUi = (model) =>
     Ui.text("Up or W            thrust"),
     Ui.text("Space              fire"),
     Ui.button("Start", StartClicked),
-  ]) |> Ui.panel(Ui.bottomLeft())
+  ]) |> Ui.panel(Ui.center())
 
 let endUi = (title, model) =>
   Ui.column([
@@ -478,7 +494,7 @@ let endUi = (title, model) =>
     Ui.text(""),
     Ui.text("R or Enter to play again, M for menu"),
     Ui.button("Play again", RestartClicked),
-  ]) |> Ui.panel(Ui.topLeft())
+  ]) |> Ui.panel(Ui.center())
 
 let ui = (model) =>
   match model.phase with

--- a/examples/asteroids/lib.fun
+++ b/examples/asteroids/lib.fun
@@ -1,38 +1,6 @@
-// lib.fun — module Lib: tiny helpers Asteroids needs that the builtin
-// registry doesn't cover today (no List.length/append/flatten/any, and no
-// boolean &&/||/! operators — see the exercise's findings log).
-
-let length = (xs) =>
-  xs |> List.fold((acc, x) => acc + 1.0, 0.0)
-
-let and = (a, b) =>
-  match a with
-  | true => b
-  | false => false
-
-let or = (a, b) =>
-  match a with
-  | true => true
-  | false => b
-
-// True when any element satisfies pred. Subject-LAST so it pipes:
-// `rocks |> Lib.any(pred)`.
-let any = (pred, xs) =>
-  xs |> List.fold((acc, x) => (match acc with | true => true | false => pred(x)), false)
-
-// NOTE: a naive recursive append hits the interpreter's evaluation-depth
-// cap (~200 frames) at list lengths well under 100, so these are built on
-// the iterative List.fold instead (findings log: no builtin
-// List.reverse/append/flatten).
-let reverse = (xs) =>
-  xs |> List.fold((acc, x) => [x, ..acc], [])
-
-// a ++ b: prepend a's elements onto b, walking a back to front.
-let append = (a, b) =>
-  reverse(a) |> List.fold((acc, x) => [x, ..acc], b)
-
-let flatten = (xss) =>
-  reverse(xss) |> List.fold((acc, xs) => append(xs, acc), [])
+// lib.fun — module Lib: the one helper Asteroids still needs beyond the
+// builtin registry. Everything else (length/append/flatten/any, &&/||/not,
+// Math.max) is now a builtin — see the exercise's findings log.
 
 // Remove the FIRST element satisfying pred (if any), preserving order.
 let removeFirst = (pred, xs) =>
@@ -45,10 +13,4 @@ let removeFirst = (pred, xs) =>
                  | false => ([x, ..out], false))),
     ([], false)) in
   let (out, _) = folded in
-  reverse(out)
-
-// Clamp v to at least lo (no Math.max builtin).
-let floorAt = (lo, v) =>
-  match v < lo with
-  | true => lo
-  | false => v
+  List.reverse(out)

--- a/functor-lang/src/parser.rs
+++ b/functor-lang/src/parser.rs
@@ -792,10 +792,10 @@ and an `else` branch)",
         while self.peek_kind() != &TokenKind::RBracket {
             if self.peek_kind() == &TokenKind::DotDot {
                 self.bump();
-                tail = Some(Box::new(self.sub_pattern()?));
+                tail = Some(Box::new(self.list_element_pattern()?));
                 break;
             }
-            items.push(self.sub_pattern()?);
+            items.push(self.list_element_pattern()?);
             if self.peek_kind() == &TokenKind::Comma {
                 self.bump();
             } else {
@@ -874,7 +874,70 @@ and an `else` branch)",
         })
     }
 
+    /// A sub-pattern of a tuple or constructor pattern: a variable binding,
+    /// `_`, or a LITERAL (number — negative included — string, or bool). These
+    /// stay non-nesting: a nested constructor/tuple/list sub-pattern is still
+    /// refused, so `(Circle(r), _)` does not parse — only the leaves may be
+    /// literals (`("Enter", true)`).
     fn sub_pattern(&mut self) -> Result<Pattern, ParseError> {
+        // A leading `-` folds into a negative number literal (as in the
+        // top-level `pattern`).
+        if self.peek_kind() == &TokenKind::Minus {
+            if let TokenKind::Number(n) = self.nth_kind(1) {
+                let n = *n;
+                let minus = self.bump();
+                let number = self.bump();
+                return Ok(Pattern {
+                    kind: PatternKind::Number(-n),
+                    span: minus.span.to(number.span),
+                });
+            }
+        }
+        let span = self.peek().span;
+        let kind = match self.peek_kind() {
+            TokenKind::Number(n) => {
+                let n = *n;
+                self.bump();
+                PatternKind::Number(n)
+            }
+            TokenKind::Str(s) => {
+                let s = s.clone();
+                self.bump();
+                PatternKind::String(s)
+            }
+            TokenKind::True => {
+                self.bump();
+                PatternKind::Bool(true)
+            }
+            TokenKind::False => {
+                self.bump();
+                PatternKind::Bool(false)
+            }
+            TokenKind::Ident(name) if name == "_" => {
+                self.bump();
+                PatternKind::Wildcard
+            }
+            TokenKind::Ident(name) if !starts_uppercase(name) => {
+                let name = name.clone();
+                self.bump();
+                PatternKind::Var(name)
+            }
+            _ => {
+                return self.error(
+                    "a binding name, `_`, or a literal (constructor/tuple patterns do not nest)",
+                )
+            }
+        };
+        Ok(Pattern { kind, span })
+    }
+
+    /// A list element / tail sub-pattern: a variable binding or `_` only.
+    /// Unlike tuple/ctor sub-patterns, list elements may NOT be literals —
+    /// list exhaustiveness is length-based (it assumes every element is
+    /// irrefutable), so a literal element (`[true, ..rest]`) would silently
+    /// break it. Keeping the restriction here scopes the literal widening to
+    /// tuple/ctor patterns, where exhaustiveness accounts for it.
+    fn list_element_pattern(&mut self) -> Result<Pattern, ParseError> {
         let span = self.peek().span;
         let kind = match self.peek_kind() {
             TokenKind::Ident(name) if name == "_" => {
@@ -886,7 +949,7 @@ and an `else` branch)",
                 self.bump();
                 PatternKind::Var(name)
             }
-            _ => return self.error("a binding name or `_` (constructor patterns do not nest)"),
+            _ => return self.error("a binding name or `_` (list patterns do not nest)"),
         };
         Ok(Pattern { kind, span })
     }

--- a/functor-lang/src/types.rs
+++ b/functor-lang/src/types.rs
@@ -244,6 +244,17 @@ fn pattern_var_bindings(pattern: &Pattern, f: &mut impl FnMut(u32)) {
     }
 }
 
+/// Is `pattern` (a tuple/ctor sub-pattern) irrefutable — matching any value of
+/// the right type? Names and `_` are; a literal sub-pattern is not. Used by
+/// exhaustiveness: a tuple/ctor arm only counts as a catch-all / as covering
+/// its constructor when every sub-pattern is irrefutable.
+fn sub_pattern_irrefutable(pattern: &Pattern) -> bool {
+    matches!(
+        pattern.kind,
+        PatternKind::Wildcard | PatternKind::Var { .. }
+    )
+}
+
 /// Substitute declaration parameter placeholders (`Var(i)`, i < args.len())
 /// with concrete type arguments — how generic record/variant field types
 /// meet their use sites. Non-generic declarations contain no placeholders,
@@ -1939,15 +1950,26 @@ missing {missing}. Did you forget an argument?"
                         list_exact.push(items.len());
                     }
                 }
-                // Sub-patterns are irrefutable (names/`_`), so a tuple arm
-                // catches every tuple of its arity — but only if that arity
-                // CAN match the scrutinee (the mismatch itself is diagnosed
-                // in check_pattern; it must not also count as exhaustive).
-                PatternKind::Tuple(args) => match &self.zonk(&scrutinee_ty) {
-                    Type::Tuple(elems) if elems.len() != args.len() => {}
-                    _ => has_catch_all = true,
-                },
-                PatternKind::Ctor { name, .. } => covered_ctors.push(name),
+                // A tuple arm catches every tuple of its arity only when all
+                // its sub-patterns are irrefutable (names/`_`); a literal
+                // sub-pattern (`("Enter", true)`) makes it refutable, so it no
+                // longer counts as a catch-all. And the arity must be able to
+                // match the scrutinee (a mismatch is diagnosed in
+                // check_pattern; it must not also count as exhaustive).
+                PatternKind::Tuple(args) if args.iter().all(sub_pattern_irrefutable) => {
+                    match &self.zonk(&scrutinee_ty) {
+                        Type::Tuple(elems) if elems.len() != args.len() => {}
+                        _ => has_catch_all = true,
+                    }
+                }
+                PatternKind::Tuple(_) => {}
+                // A ctor arm fully covers that constructor only when all its
+                // sub-patterns are irrefutable; `Circle(0.0)` matches some
+                // `Circle`s, not all, so it doesn't count toward coverage.
+                PatternKind::Ctor { name, args } if args.iter().all(sub_pattern_irrefutable) => {
+                    covered_ctors.push(name)
+                }
+                PatternKind::Ctor { .. } => {}
                 PatternKind::Bool(true) => saw_true = true,
                 PatternKind::Bool(false) => saw_false = true,
                 PatternKind::Number(_) | PatternKind::String(_) => {}
@@ -2033,17 +2055,22 @@ a catch-all arm (`_` or a name)"
                         );
                     }
                 }
-                // A known product with no arity-matching arm can never be
-                // handled (the per-arm mismatch diags say why each arm
-                // fails; this says the MATCH as a whole is uncovered).
+                // A known product left uncovered. Either no arm matches the
+                // arity at all, or some do but are all refutable (a literal
+                // sub-pattern) with no catch-all — distinguish the two so the
+                // message fits the feature's primary use (input mapping).
                 Type::Tuple(elems) => {
+                    let arity_matched = arms.iter().any(|arm| {
+                        matches!(&arm.pattern.kind, PatternKind::Tuple(args) if args.len() == elems.len())
+                    });
+                    let detail = if arity_matched {
+                        "its arms are refutable — add a catch-all (`_` or a name)".to_string()
+                    } else {
+                        format!("no arm matches a {}-element tuple", elems.len())
+                    };
                     self.diag(
                         expr.span,
-                        format!(
-                            "match on {scrutinee_ty} is not exhaustive: no arm matches a \
-{}-element tuple",
-                            elems.len()
-                        ),
+                        format!("match on {scrutinee_ty} is not exhaustive: {detail}"),
                     );
                 }
                 // Unknown stays gradual; List/Record/Fn scrutinees already

--- a/functor-lang/tests/check.rs
+++ b/functor-lang/tests/check.rs
@@ -1479,6 +1479,18 @@ fn bool_operators_check_clean() {
     );
 }
 
+// --- Literals inside tuple / constructor patterns ---
+
+#[test]
+fn tuple_literal_patterns_check_clean() {
+    assert_clean(
+        "let f = (key: string, down: bool) =>\n\
+         \x20 match (key, down) with\n\
+         \x20 | (\"Enter\", true) => 1.0\n\
+         \x20 | (_, _) => 0.0",
+    );
+}
+
 #[test]
 fn logical_operand_must_be_bool() {
     let (message, line, _) = single_diag("let f = () => 1.0 && true");
@@ -1517,6 +1529,18 @@ fn if_else_checks_clean() {
 }
 
 #[test]
+fn ctor_literal_patterns_check_clean() {
+    assert_clean(
+        "type Shape = | Circle(r: float) | Rect(w: float, h: float)\n\
+         let f = (s: Shape) =>\n\
+         \x20 match s with\n\
+         \x20 | Circle(0.0) => \"pt\"\n\
+         \x20 | Circle(r) => \"c\"\n\
+         \x20 | Rect(w, h) => \"r\"",
+    );
+}
+
+#[test]
 fn if_condition_must_be_bool() {
     // A genuinely-non-bool condition (a float literal) — an unannotated param
     // would simply be inferred to bool instead.
@@ -1531,6 +1555,24 @@ fn if_branches_must_unify() {
     assert_eq!(
         message,
         "`if` branches have incompatible types float and string"
+    );
+}
+
+#[test]
+fn tuple_literal_sub_pattern_is_not_a_catch_all() {
+    // `("Enter", true)` is refutable, so without a catch-all the match is
+    // not exhaustive.
+    let (message, _, _) = single_diag(
+        "let f = (a: string, b: bool) =>\n\
+         \x20 match (a, b) with\n\
+         \x20 | (\"Enter\", true) => 1.0",
+    );
+    // The arm matches the arity but is refutable — the message must point at
+    // the missing catch-all, not claim no arm matches the arity.
+    assert_eq!(
+        message,
+        "match on (string, bool) is not exhaustive: its arms are refutable — \
+         add a catch-all (`_` or a name)"
     );
 }
 
@@ -1576,4 +1618,37 @@ fn nested_if_keeps_its_own_type() {
     );
     let inner = types.expr(else_branch.id).expect("inner if type recorded");
     assert_eq!(inner.to_string(), "float");
+}
+
+#[test]
+fn ctor_literal_sub_pattern_does_not_cover_the_ctor() {
+    // `Circle(0.0)` matches some circles, not all — `Circle` is still missing.
+    let diags = check_src(
+        "type Shape = | Circle(r: float) | Rect(w: float, h: float)\n\
+         let f = (s: Shape) =>\n\
+         \x20 match s with\n\
+         \x20 | Circle(0.0) => \"pt\"\n\
+         \x20 | Rect(w, h) => \"r\"",
+    );
+    assert!(
+        diags
+            .iter()
+            .any(|(m, _, _)| m.contains("not exhaustive") && m.contains("Circle")),
+        "expected a 'missing Circle' diagnostic, got {diags:?}"
+    );
+}
+
+#[test]
+fn literal_sub_pattern_type_mismatch_is_diagnosed() {
+    // A string literal where the tuple element is a float.
+    let (message, _, _) = single_diag(
+        "let f = (a: float, b: bool) =>\n\
+         \x20 match (a, b) with\n\
+         \x20 | (\"x\", true) => 1.0\n\
+         \x20 | (_, _) => 0.0",
+    );
+    assert!(
+        message.contains("string") && message.contains("float"),
+        "unexpected: {message}"
+    );
 }

--- a/functor-lang/tests/parser.rs
+++ b/functor-lang/tests/parser.rs
@@ -306,17 +306,92 @@ fn error_match_requires_leading_bar() {
     );
 }
 
-/// Sub-patterns are bindings or `_` only — constructor patterns don't nest.
+/// Sub-patterns are bindings, `_`, or literals — constructor patterns don't
+/// nest another constructor/tuple.
 #[test]
 fn error_nested_constructor_pattern() {
     assert_eq!(
         parse_err("let f = (s) => match s with | Circle(Point) => 1.0 | _ => 0.0"),
         (
-            "expected a binding name or `_` (constructor patterns do not nest), found `Point`"
+            "expected a binding name, `_`, or a literal (constructor/tuple patterns do not nest), \
+             found `Point`"
                 .to_string(),
             1,
             38
         )
+    );
+}
+
+/// Literals ARE allowed as tuple/ctor sub-patterns (`("Enter", true)`) — the
+/// input-mapping shape. String, number (incl. negative), and bool leaves.
+#[test]
+fn tuple_pattern_allows_literal_sub_patterns() {
+    use functor_lang::ast::PatternKind;
+    let src = "let f = (p) => match p with | (\"Enter\", true) => 1.0 | (-1.0, x) => x | _ => 0.0";
+    let program = functor_lang::parse(src).unwrap();
+    let Item::Let(decl) = &program.items[0] else {
+        panic!("expected a let declaration");
+    };
+    let ExprKind::Lambda { body, .. } = &decl.value.kind else {
+        panic!("expected a lambda");
+    };
+    let ExprKind::Match { arms, .. } = &body.kind else {
+        panic!("expected a match");
+    };
+    let PatternKind::Tuple(first) = &arms[0].pattern.kind else {
+        panic!("expected a tuple pattern");
+    };
+    assert!(matches!(first[0].kind, PatternKind::String(ref s) if s == "Enter"));
+    assert!(matches!(first[1].kind, PatternKind::Bool(true)));
+    let PatternKind::Tuple(second) = &arms[1].pattern.kind else {
+        panic!("expected a tuple pattern");
+    };
+    assert!(matches!(second[0].kind, PatternKind::Number(n) if n == -1.0));
+    assert!(matches!(second[1].kind, PatternKind::Var(ref n) if n == "x"));
+}
+
+/// A literal inside a constructor pattern (`Circle(0.0)`) parses.
+#[test]
+fn ctor_pattern_allows_literal_sub_pattern() {
+    use functor_lang::ast::PatternKind;
+    let src = "let f = (s) => match s with | Circle(0.0) => 1.0 | _ => 0.0";
+    let program = functor_lang::parse(src).unwrap();
+    let Item::Let(decl) = &program.items[0] else {
+        panic!("expected a let declaration");
+    };
+    let ExprKind::Lambda { body, .. } = &decl.value.kind else {
+        panic!("expected a lambda");
+    };
+    let ExprKind::Match { arms, .. } = &body.kind else {
+        panic!("expected a match");
+    };
+    let PatternKind::Ctor { args, .. } = &arms[0].pattern.kind else {
+        panic!("expected a ctor pattern");
+    };
+    assert!(matches!(args[0].kind, PatternKind::Number(n) if n == 0.0));
+}
+
+/// A nested tuple sub-pattern is still refused (only literal leaves, no
+/// deeper structure).
+#[test]
+fn error_nested_tuple_sub_pattern() {
+    let (message, _, _) = parse_err("let f = (p) => match p with | ((a, b), c) => a | _ => 0.0");
+    assert_eq!(
+        message,
+        "expected a binding name, `_`, or a literal (constructor/tuple patterns do not nest), \
+         found `(`"
+    );
+}
+
+/// Literals are NOT allowed in LIST element/tail patterns — list
+/// exhaustiveness is length-based and would silently break. The widening is
+/// scoped to tuple/ctor patterns.
+#[test]
+fn error_literal_in_list_pattern() {
+    let (message, _, _) = parse_err("let f = (xs) => match xs with | [] => 0.0 | [true, ..r] => 1.0");
+    assert_eq!(
+        message,
+        "expected a binding name or `_` (list patterns do not nest), found `true`"
     );
 }
 

--- a/functor-lang/tests/run.rs
+++ b/functor-lang/tests/run.rs
@@ -1299,3 +1299,40 @@ fn if_condition_on_non_bool_errors() {
     );
     assert_eq!(message, "`if` condition needs a bool, got a number");
 }
+
+// --- Literals inside tuple / constructor patterns ---
+
+#[test]
+fn tuple_literal_patterns_match_by_value() {
+    // The input-mapping shape: match on (key, isDown).
+    let src = "let classify = (key, down) =>\n\
+               \x20 match (key, down) with\n\
+               \x20 | (\"Enter\", true) => \"start\"\n\
+               \x20 | (\"Escape\", true) => \"quit\"\n\
+               \x20 | (_, false) => \"release\"\n\
+               \x20 | (_, _) => \"other\"\n\
+               let main = () => [classify(\"Enter\", true), classify(\"W\", false), classify(\"W\", true)]";
+    assert_eq!(main_result(src), "[\"start\", \"release\", \"other\"]");
+}
+
+#[test]
+fn ctor_literal_patterns_match_by_value() {
+    let src = "type Shape = | Circle(r: float) | Rect(w: float, h: float)\n\
+               let describe = (s: Shape) =>\n\
+               \x20 match s with\n\
+               \x20 | Circle(0.0) => \"point\"\n\
+               \x20 | Circle(r) => \"circle\"\n\
+               \x20 | Rect(w, h) => \"rect\"\n\
+               let main = () => [describe(Circle(0.0)), describe(Circle(2.0)), describe(Rect(1.0, 2.0))]";
+    assert_eq!(main_result(src), "[\"point\", \"circle\", \"rect\"]");
+}
+
+#[test]
+fn negative_number_sub_pattern() {
+    let src = "let sign = (p) =>\n\
+               \x20 match p with\n\
+               \x20 | (-1.0, y) => \"neg\"\n\
+               \x20 | (_, _) => \"other\"\n\
+               let main = () => [sign((-1.0, 5.0)), sign((2.0, 5.0))]";
+    assert_eq!(main_result(src), "[\"neg\", \"other\"]");
+}

--- a/functor-prelude/prelude/ui.funi
+++ b/functor-prelude/prelude/ui.funi
@@ -19,6 +19,8 @@ let topLeft : () => anchor
 let topRight : () => anchor
 let bottomLeft : () => anchor
 let bottomRight : () => anchor
+// Pins a panel to the screen center — e.g. `menuColumn |> Ui.panel(Ui.center())`.
+let center : () => anchor
 // Interactive widgets (docs/ui-interaction.md); like Sub.every's msg, 'msg is
 // erased by the opaque `view` — the msg↔update link is checked at runtime.
 // A click delivers `msg` verbatim through `update`.

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -63,6 +63,8 @@
 //! Ui.column([view, …]) / Ui.row([view, …])                  -> View
 //! Ui.panel(anchor, view)                                    -> View
 //! Ui.topLeft() / topRight() / bottomLeft() / bottomRight()  -> Anchor
+//! Ui.center()                                               -> Anchor
+//!   (pins a panel to the screen center — e.g. a menu column)
 //! Ui.button(label, msg)                                     -> View
 //! Ui.slider(min, max, value, tagger)                        -> View
 //! Ui.textInput(value, tagger)                               -> View
@@ -909,6 +911,7 @@ const PATHS: &[&str] = &[
     "Ui.topRight",
     "Ui.bottomLeft",
     "Ui.bottomRight",
+    "Ui.center",
     "Ui.button",
     "Ui.slider",
     "Ui.textInput",
@@ -2132,6 +2135,10 @@ paths (+X, -X, +Y, -Y, +Z, -Z)",
             "Ui.bottomRight" => match args.as_slice() {
                 [] => Ok(host(FunctorLangUiAnchor(ui::Anchor::BottomRight))),
                 _ => usage("Ui.bottomRight()"),
+            },
+            "Ui.center" => match args.as_slice() {
+                [] => Ok(host(FunctorLangUiAnchor(ui::Anchor::Center))),
+                _ => usage("Ui.center()"),
             },
             "Ui.row" => match args.as_slice() {
                 [Value::List(items)] => {
@@ -5139,6 +5146,28 @@ the game dir"
             r#"{"Panel":{"anchor":"TopLeft","child":{"Column":[{"Text":{"text":"functor · hello","color":[255,255,255],"font":null}},{"Text":{"text":"eye  0.0 0.0 -5.0","color":[255,217,102],"font":null}}]}}}"#
         );
         // And it round-trips (the wasm boundary ships Views as JSON).
+        let back: View = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(serde_json::to_string(&back).unwrap(), json);
+    }
+
+    // Ui.center() pins a panel to the screen center — the menu anchor. It
+    // lowers to a Panel with the Center anchor and round-trips over the wire.
+    #[test]
+    fn ui_center_anchors_a_panel_to_the_middle() {
+        let value = eval(
+            "let main = () =>\n\
+             Ui.column([Ui.text(\"Play\"), Ui.text(\"Quit\")]) |> Ui.panel(Ui.center())",
+        );
+        let view = view_value(&value).expect("main should return a View");
+        assert!(matches!(
+            view,
+            View::Panel {
+                anchor: ui::Anchor::Center,
+                ..
+            }
+        ));
+        let json = serde_json::to_string(view).expect("serialize");
+        assert!(json.contains(r#""anchor":"Center""#), "json: {json}");
         let back: View = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(serde_json::to_string(&back).unwrap(), json);
     }

--- a/runtime/functor-runtime-common/src/ui.rs
+++ b/runtime/functor-runtime-common/src/ui.rs
@@ -51,13 +51,15 @@ pub struct FontRef {
     pub size: f32,
 }
 
-/// Which screen corner a [`View::Panel`] pins its subtree to.
+/// Which screen position a [`View::Panel`] pins its subtree to — the four
+/// corners, or the screen center (for menus).
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum Anchor {
     TopLeft,
     TopRight,
     BottomLeft,
     BottomRight,
+    Center,
 }
 
 /// A declarative, serializable 2D UI tree — the lowering target for the F# `Ui`
@@ -376,23 +378,26 @@ fn render_view(ui: &mut egui::Ui, view: &View, state: &mut UiFrameState) {
     }
 }
 
-/// egui corner alignment + inset offset for an [`Anchor`].
+/// egui alignment + inset offset for an [`Anchor`]. Center pins to the middle
+/// with no edge inset (the margin is meaningless there).
 fn anchor_align(anchor: Anchor) -> (egui::Align2, egui::Vec2) {
     match anchor {
         Anchor::TopLeft => (egui::Align2::LEFT_TOP, egui::vec2(MARGIN, MARGIN)),
         Anchor::TopRight => (egui::Align2::RIGHT_TOP, egui::vec2(-MARGIN, MARGIN)),
         Anchor::BottomLeft => (egui::Align2::LEFT_BOTTOM, egui::vec2(MARGIN, -MARGIN)),
         Anchor::BottomRight => (egui::Align2::RIGHT_BOTTOM, egui::vec2(-MARGIN, -MARGIN)),
+        Anchor::Center => (egui::Align2::CENTER_CENTER, egui::vec2(0.0, 0.0)),
     }
 }
 
-/// A stable per-corner id so distinct panels get distinct egui `Area` ids.
+/// A stable per-anchor id so distinct panels get distinct egui `Area` ids.
 fn anchor_id(anchor: Anchor) -> u8 {
     match anchor {
         Anchor::TopLeft => 0,
         Anchor::TopRight => 1,
         Anchor::BottomLeft => 2,
         Anchor::BottomRight => 3,
+        Anchor::Center => 4,
     }
 }
 
@@ -1051,6 +1056,23 @@ mod tests {
             pos: None,
             primary_down: down,
         }
+    }
+
+    #[test]
+    fn center_anchor_maps_to_the_middle_with_a_unique_id() {
+        let (align, offset) = anchor_align(Anchor::Center);
+        assert_eq!(align, egui::Align2::CENTER_CENTER);
+        assert_eq!(offset, egui::vec2(0.0, 0.0));
+        // A distinct id from every corner so a centered panel gets its own Area.
+        let ids = [
+            anchor_id(Anchor::TopLeft),
+            anchor_id(Anchor::TopRight),
+            anchor_id(Anchor::BottomLeft),
+            anchor_id(Anchor::BottomRight),
+            anchor_id(Anchor::Center),
+        ];
+        let unique: std::collections::HashSet<_> = ids.iter().collect();
+        assert_eq!(unique.len(), ids.len(), "anchor ids must be unique");
     }
 
     #[test]


### PR DESCRIPTION
## Stacked PR — merge AFTER the seven feature branches below

`examples/asteroids` shipped in #324 **before** the ten language/engine gaps its
findings log flagged were fixed. This rewrites the game to use those new
capabilities, now open as PRs. **It must merge after all of them** and will be
rebased onto `main` once they land (this branch currently *contains* their
commits so it builds/tests on its own).

### Depends on (merge these first)
- #326 — List builtins (`length`/`append`/`flatten`/`any`/`all`/`reverse`/`isEmpty`)
- #327 — Math builtins (`sqrt`/`atan2`/`abs`/`floor`/`mod`/`min`/`max`/`pi`/`pow`)
- #328 — pure seeded PRNG (`Random.step` / `Random.range`)
- #330 — short-circuit `&&` / `||` / prefix `not`
- #332 — `Frame.withClearColor`
- #334 — literals in tuple/ctor patterns (`| ("Enter", true) =>`)
- #337 — `Ui.center()` anchor

### What changed in the game (workarounds → new features)
- **sin-hash noise → `Random.step` / `Random.range`**, one PRNG stream threaded
  through spawns, splits, and the starfield. This fixes the original's
  correlated-streams bug (the starfield clumped on a closed curve) *and* gives
  each asteroid a distinct shape/spin from a per-rock integer seed.
- **`Lib.and/or/not` → `&&` / `||` / `not`**.
- **`Lib.length/append/flatten/any/reverse` → `List.*` builtins** — `lib.fun`
  shrinks from 59 to 16 lines (only `removeFirst` has no builtin equivalent).
- **`Lib.floorAt` → `Math.max`; `6.28318` → `Math.pi * 2`**.
- **input-mapping match-pyramids → literal `(key, isDown)` tuple patterns**
  (dropped the `startPressed`/`restartPressed` helpers).
- **distant-fog clear-color trick → `Frame.withClearColor`** (fog dropped — the
  scene never wanted fog, only a background color).
- **corner-anchored menu/end dialogs → `Ui.center()`**.

Gameplay is identical (state machine, scoring, wave/win/lose, all input paths
verified headlessly via the debug server); only the RNG is now decorrelated.

### API friction found
- `Random.step`/`Random.range` return `(value, nextSeed)` where `value ∈ [0,1)`
  is a **float** but `nextSeed` is a large **integer** counter, and
  `random_step` **truncates a fractional seed to counter 0**. Storing the
  `value` as a per-entity seed (an easy mistake — it *looks* like a seed)
  silently collapses every entity to the same stream. A `Random.seed`-branded
  type, or folding fractional seeds distinctly instead of truncating, would make
  this misuse a type/behavior error instead of a silent correlation bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Before → after

Rendered headlessly via `--capture-frame` / `--fixed-time` (deterministic). Left is `main` (#324, commit `aee4872`); right is this branch.

![asteroids menu — before vs after](https://gist.githubusercontent.com/tommy-xr/fa06afaa8d02608a620c3d99567aedfb/raw/ast-beforeafter.png)

<sub>BEFORE: corner-anchored controls, correlated starfield, near-uniform asteroids. AFTER: `Ui.center()` menu panel with a Start button, decorrelated `Random` starfield, and per-rock distinct shapes/spins.</sub>

![asteroids menu drifting asteroids](https://gist.githubusercontent.com/tommy-xr/fa06afaa8d02608a620c3d99567aedfb/raw/ast-menu.gif)

<sub>The menu's asteroids drift over time (decorrelated PRNG stream).</sub>
