### PR TITLE
feat(functor-lang): per-call binding-site recorder for the paused inspector

### DIFF
--- a/functor-lang/src/eval.rs
+++ b/functor-lang/src/eval.rs
@@ -58,6 +58,13 @@ const MAX_EVAL_DEPTH: usize = 128;
 /// Trace-event cap; see the module doc.
 pub const MAX_TRACE_EVENTS: usize = 10_000;
 
+/// Recorder caps (see [`Recorder`] / [`Session::call_recorded`]). Distinct
+/// binding *sites* per armed invocation, and total binding *events* (a loop
+/// re-binding one site counts each time). A breach stops recording and flags
+/// `truncated`; evaluation itself is never affected.
+pub const MAX_RECORDED_SITES: usize = 1024;
+pub const MAX_RECORDED_BINDINGS: usize = 100_000;
+
 #[derive(Clone, Copy, PartialEq)]
 pub enum Tracing {
     Off,
@@ -97,6 +104,94 @@ pub struct RunRecord {
 pub struct RunFailure {
     pub error: RunError,
     pub trace: Vec<TraceEvent>,
+}
+
+/// The record of one armed entry-point call (see [`Session::call_recorded`]):
+/// the call's result and every binding-site value observed while it ran, as
+/// pre-rendered `Display` text (the record owns no `Value`s). Framing above a
+/// single invocation — entry provenance, ghost, index/count within a frame —
+/// is the producer's job; this is one call's raw record.
+pub struct RecordedInvocation {
+    /// The called top-level name (`update`, `tick`, …).
+    pub entry: String,
+    /// `Display` of the returned value.
+    pub result: String,
+    /// One entry per distinct binding site reached, in first-seen order.
+    pub bindings: Vec<RecordedBinding>,
+    /// The recorder hit a cap during this call — `bindings` is partial (but
+    /// `result` is exact; recording never changes evaluation).
+    pub truncated: bool,
+}
+
+/// One binding site's last observed value. A site is a `let` binding, a
+/// lambda/function parameter, or a match-pattern variable; nested calls' sites
+/// appear here too (flat — spans disambiguate them). `value` is the LAST
+/// value bound at the site and `count` how many times it bound (a loop, e.g.
+/// `List.fold`, re-binds a site each iteration).
+pub struct RecordedBinding {
+    pub name: String,
+    /// Byte range into the loaded source. NOTE: [`Span`] carries no file — a
+    /// multi-file project loads as one concatenated source, so mapping this
+    /// range back to (file, offset) is the producer's job (see the visual-
+    /// debugger wire contract). For a `let` this is the `let [mut] name =`
+    /// region (as `goto`/`hover` report binder names); for a param or match
+    /// var it is the name's own span.
+    pub span: Span,
+    /// `Display` of the last value bound here.
+    pub value: String,
+    pub count: u32,
+}
+
+/// The per-call binding-site recorder — armed by [`Session::call_recorded`],
+/// mirroring the [`Tracing`] mode: an `Option<Recorder>` on the interpreter,
+/// checked cheaply at binding sites only (a `None` test when off). Keyed by
+/// [`BindingId`] (unique per site in a module; a loop re-enters the same
+/// site's id), it keeps the last value + hit count per site. On a cap breach
+/// it sets `truncated` and stops recording — evaluation continues untouched.
+struct Recorder {
+    bindings: Vec<RecordedBinding>,
+    /// `BindingId` raw → index into `bindings`.
+    index: HashMap<u32, usize>,
+    events: usize,
+    truncated: bool,
+}
+
+impl Recorder {
+    fn new() -> Recorder {
+        Recorder {
+            bindings: Vec::new(),
+            index: HashMap::new(),
+            events: 0,
+            truncated: false,
+        }
+    }
+
+    /// Record a value bound at `binding`'s site. Once `truncated`, a no-op.
+    fn record(&mut self, binding: u32, name: &str, span: Span, value: &Value) {
+        if self.truncated {
+            return;
+        }
+        self.events += 1;
+        if self.events > MAX_RECORDED_BINDINGS {
+            self.truncated = true;
+            return;
+        }
+        if let Some(&idx) = self.index.get(&binding) {
+            let slot = &mut self.bindings[idx];
+            slot.value = value.to_string();
+            slot.count += 1;
+        } else if self.bindings.len() >= MAX_RECORDED_SITES {
+            self.truncated = true;
+        } else {
+            self.index.insert(binding, self.bindings.len());
+            self.bindings.push(RecordedBinding {
+                name: name.to_string(),
+                span,
+                value: value.to_string(),
+                count: 1,
+            });
+        }
+    }
 }
 
 /// Host-provided externals: the embedding runtime (e.g. Functor's shells)
@@ -146,6 +241,7 @@ pub fn run_with_host(
         mut_slots: HashMap::new(),
         trace: Vec::new(),
         tracing,
+        recorder: None,
         depth: 0,
         call_depth: 0,
         host,
@@ -182,6 +278,7 @@ impl Session {
             mut_slots: HashMap::new(),
             trace: Vec::new(),
             tracing: Tracing::Off,
+            recorder: None,
             depth: 0,
             call_depth: 0,
             host,
@@ -219,6 +316,7 @@ impl Session {
             mut_slots: HashMap::new(),
             trace: Vec::new(),
             tracing: Tracing::Off,
+            recorder: None,
             depth: 0,
             call_depth: 0,
             host,
@@ -241,11 +339,50 @@ impl Session {
             mut_slots: HashMap::new(),
             trace: Vec::new(),
             tracing: Tracing::Off,
+            recorder: None,
             depth: 0,
             call_depth: 0,
             host,
         };
         interp.call(callee, args, label.to_string(), Span::new(0, 0), None)
+    }
+
+    /// Like [`Self::call`], but with the binding-site recorder armed: returns
+    /// the call's result plus a [`RecordedInvocation`] of every `let` /
+    /// parameter / match-variable value bound while it ran (including nested
+    /// user calls). Recording is bounded (see [`MAX_RECORDED_SITES`] /
+    /// [`MAX_RECORDED_BINDINGS`]) and never changes evaluation — the result is
+    /// identical to [`Self::call`]; only observation is added. The seam the
+    /// paused visual-debugger replays entry points through.
+    pub fn call_recorded(
+        &self,
+        name: &str,
+        args: Vec<Value>,
+        host: &mut dyn Host,
+    ) -> Result<(Value, RecordedInvocation), RunError> {
+        let callee = self.globals.get(name).cloned().ok_or_else(|| RunError {
+            message: format!("no top-level `let {name}` in the module"),
+            span: Span::new(0, 0),
+        })?;
+        let mut interp = Interp {
+            globals: self.globals.clone(),
+            mut_slots: HashMap::new(),
+            trace: Vec::new(),
+            tracing: Tracing::Off,
+            recorder: Some(Recorder::new()),
+            depth: 0,
+            call_depth: 0,
+            host,
+        };
+        let result = interp.call(callee, args, name.to_string(), Span::new(0, 0), None)?;
+        let recorder = interp.recorder.expect("armed above");
+        let invocation = RecordedInvocation {
+            entry: name.to_string(),
+            result: result.to_string(),
+            bindings: recorder.bindings,
+            truncated: recorder.truncated,
+        };
+        Ok((result, invocation))
     }
 }
 
@@ -258,6 +395,9 @@ struct Interp<'h> {
     mut_slots: HashMap<u32, Vec<Value>>,
     trace: Vec<TraceEvent>,
     tracing: Tracing,
+    /// The binding-site recorder, armed only by [`Session::call_recorded`];
+    /// `None` (the norm) means zero recording cost on the hot path.
+    recorder: Option<Recorder>,
     depth: usize,
     call_depth: usize,
     host: &'h mut dyn Host,
@@ -318,6 +458,15 @@ impl Interp<'_> {
         let result = self.eval_inner(expr, env);
         self.depth -= 1;
         result
+    }
+
+    /// Record a value bound at `binding`'s site, when the recorder is armed —
+    /// a cheap `None` check otherwise (the binding-site hot-path cost). See
+    /// [`Recorder`].
+    fn record_binding(&mut self, binding: BindingId, name: &str, span: Span, value: &Value) {
+        if let Some(recorder) = &mut self.recorder {
+            recorder.record(binding.0, name, span, value);
+        }
     }
 
     fn eval_inner(&mut self, expr: &Expr, env: &Env) -> Result<Value, RunError> {
@@ -430,12 +579,16 @@ impl Interp<'_> {
                 }),
             ExprKind::Let {
                 binding,
+                name,
                 mutable,
                 value,
                 body,
                 ..
             } => {
+                // The `let [mut] name =` region, as goto/hover report binders.
+                let binder_span = Span::new(expr.span.start, value.span.start);
                 let value = self.eval(value, env)?;
+                self.record_binding(*binding, name, binder_span, &value);
                 if *mutable {
                     self.mut_slots.entry(binding.0).or_default().push(value);
                     let result = self.eval(body, env);
@@ -554,6 +707,17 @@ impl Interp<'_> {
                 for arm in arms {
                     let mut vars = Vec::new();
                     if match_pattern(&arm.pattern, &value, &mut vars) {
+                        if self.recorder.is_some() {
+                            let mut sites = Vec::new();
+                            pattern_binder_sites(&arm.pattern, &mut sites);
+                            for (binding, bound) in &vars {
+                                if let Some(&(_, name, span)) =
+                                    sites.iter().find(|(b, _, _)| b == binding)
+                                {
+                                    self.record_binding(*binding, name, span, bound);
+                                }
+                            }
+                        }
                         let child = env.child(vars);
                         return self.eval(&arm.body, &child);
                     }
@@ -678,7 +842,13 @@ impl Interp<'_> {
                         span,
                     })
                 } else {
-                    let vars = closure.params.iter().map(|p| p.binding).zip(args).collect();
+                    let vars: Vec<(BindingId, Value)> =
+                        closure.params.iter().map(|p| p.binding).zip(args).collect();
+                    if self.recorder.is_some() {
+                        for (param, (_, value)) in closure.params.iter().zip(vars.iter()) {
+                            self.record_binding(param.binding, &param.name, param.span, value);
+                        }
+                    }
                     let env = closure.env.child(vars);
                     let body = closure.body.clone();
                     self.eval(&body, &env)
@@ -1151,6 +1321,32 @@ fn match_pattern(pattern: &Pattern, value: &Value, vars: &mut Vec<(BindingId, Va
         PatternKind::Number(n) => matches!(value, Value::Number(v) if v == n),
         PatternKind::Bool(b) => matches!(value, Value::Bool(v) if v == b),
         PatternKind::String(s) => matches!(value, Value::String(v) if v.as_ref() == s),
+    }
+}
+
+/// Each pattern variable's `(binding, name, span)` — the recorder's per-site
+/// key/label/location for match binders (the `Var` pattern's own span is the
+/// name's span), mirroring `goto::pattern_binders`'s traversal.
+fn pattern_binder_sites<'a>(pattern: &'a Pattern, out: &mut Vec<(BindingId, &'a str, Span)>) {
+    match &pattern.kind {
+        PatternKind::Var { binding, name } => out.push((*binding, name, pattern.span)),
+        PatternKind::Ctor { args, .. } | PatternKind::Tuple(args) => {
+            for arg in args {
+                pattern_binder_sites(arg, out);
+            }
+        }
+        PatternKind::List { items, tail } => {
+            for item in items {
+                pattern_binder_sites(item, out);
+            }
+            if let Some(tail) = tail {
+                pattern_binder_sites(tail, out);
+            }
+        }
+        PatternKind::Wildcard
+        | PatternKind::Number(_)
+        | PatternKind::Bool(_)
+        | PatternKind::String(_) => {}
     }
 }
 

--- a/functor-lang/src/lib.rs
+++ b/functor-lang/src/lib.rs
@@ -27,8 +27,8 @@ pub mod types;
 pub mod value;
 
 pub use eval::{
-    render_trace, run, run_with_host, Host, NoHost, RunFailure, RunOutcome, RunRecord, Session,
-    Tracing,
+    render_trace, run, run_with_host, Host, NoHost, RecordedBinding, RecordedInvocation, RunFailure,
+    RunOutcome, RunRecord, Session, Tracing,
 };
 pub use lower::lower;
 pub use parser::{parse, parse_interface};

--- a/functor-lang/tests/recorder.rs
+++ b/functor-lang/tests/recorder.rs
@@ -1,0 +1,136 @@
+//! Binding-site recorder verification (the paused visual-debugger's PR1 seam,
+//! `Session::call_recorded`): a bounded, per-call-armed record of every `let` /
+//! parameter / match-variable value, with last-value + hit-count per site and a
+//! `truncated` cap flag — and NO effect on evaluation itself.
+
+use functor_lang::value::Value;
+use functor_lang::{NoHost, RecordedBinding, RecordedInvocation, Session};
+use std::rc::Rc;
+
+/// Parse + lower + load `src` into a session, panicking with a rendered
+/// position on failure.
+fn session(src: &str) -> Session {
+    let program = functor_lang::parse(src).expect("source should parse");
+    let module = functor_lang::lower(program).expect("source should lower");
+    match Session::load(&module, &mut NoHost) {
+        Ok(session) => session,
+        Err(failure) => {
+            let (line, col) = functor_lang::line_col(src, failure.error.span.start);
+            panic!("{line}:{col}: load error: {}", failure.error.message);
+        }
+    }
+}
+
+/// The recorded binding named `name` (panics if absent).
+fn binding<'a>(inv: &'a RecordedInvocation, name: &str) -> &'a RecordedBinding {
+    inv.bindings
+        .iter()
+        .find(|b| b.name == name)
+        .unwrap_or_else(|| panic!("no recorded binding `{name}`"))
+}
+
+/// The exact source text the binding's span points at (proves spans are real
+/// byte offsets into the loaded source).
+fn spanned<'a>(src: &'a str, b: &RecordedBinding) -> &'a str {
+    &src[b.span.start..b.span.end]
+}
+
+#[test]
+fn records_let_bindings_and_params_and_result() {
+    let src = "let update = (model) =>\n  let doubled = model + 1.0 in\n  doubled + 10.0";
+    let session = session(src);
+    let (result, inv) = session
+        .call_recorded("update", vec![Value::Number(5.0)], &mut NoHost)
+        .expect("call_recorded");
+
+    assert_eq!(result.to_string(), "16");
+    assert_eq!(inv.entry, "update");
+    assert_eq!(inv.result, "16");
+    assert!(!inv.truncated);
+
+    let model = binding(&inv, "model");
+    assert_eq!(model.value, "5");
+    assert_eq!(model.count, 1);
+    assert_eq!(spanned(src, model), "model");
+
+    let doubled = binding(&inv, "doubled");
+    assert_eq!(doubled.value, "6");
+    assert_eq!(doubled.count, 1);
+    // A `let`'s span is the `let name =` binder region (goto/hover convention).
+    assert!(spanned(src, doubled).contains("doubled"));
+}
+
+#[test]
+fn records_match_binders() {
+    let src = "type Shape = | Circle(radius: Float) | Square(side: Float)\n\
+               let area = (shape) =>\n  \
+               match shape with\n  \
+               | Circle(r) => r + 1.0\n  \
+               | Square(s) => s + 2.0";
+    let session = session(src);
+    let circle = Value::Variant {
+        ctor: Rc::from("Circle"),
+        args: Rc::new(vec![Value::Number(3.0)]),
+    };
+    let (result, inv) = session
+        .call_recorded("area", vec![circle], &mut NoHost)
+        .expect("call_recorded");
+
+    assert_eq!(result.to_string(), "4");
+    // The scrutinee parameter renders as the whole variant.
+    assert_eq!(binding(&inv, "shape").value, "Circle(3)");
+    // The winning arm's binder is recorded; the losing arm's `s` is not.
+    let r = binding(&inv, "r");
+    assert_eq!(r.value, "3");
+    assert_eq!(r.count, 1);
+    assert_eq!(spanned(src, r), "r");
+    assert!(inv.bindings.iter().all(|b| b.name != "s"));
+}
+
+#[test]
+fn loop_site_keeps_last_value_and_counts_hits() {
+    let src = "let sum = (xs) => List.fold((acc, x) => acc + x, 0.0, xs)";
+    let session = session(src);
+    let xs = Value::List(Rc::new(vec![
+        Value::Number(1.0),
+        Value::Number(2.0),
+        Value::Number(3.0),
+    ]));
+    let (result, inv) = session
+        .call_recorded("sum", vec![xs], &mut NoHost)
+        .expect("call_recorded");
+
+    assert_eq!(result.to_string(), "6");
+    assert!(!inv.truncated);
+
+    // The fold closure's params re-bind once per element: last value wins,
+    // count is the element count.
+    let acc = binding(&inv, "acc");
+    assert_eq!(acc.count, 3);
+    assert_eq!(acc.value, "3"); // acc going into the final `acc + x` (1 + 2)
+    let x = binding(&inv, "x");
+    assert_eq!(x.count, 3);
+    assert_eq!(x.value, "3"); // the last element
+    assert_eq!(binding(&inv, "xs").count, 1);
+}
+
+#[test]
+fn cap_breach_truncates_but_result_is_exact() {
+    // 60_000 elements × 2 closure params = 120_000 binding events, past the
+    // 100_000 event cap — recording stops, `truncated` is set, and the fold
+    // still returns the exact sum (recording never changes evaluation).
+    let src = "let sum = (xs) => List.fold((acc, x) => acc + x, 0.0, xs)\n\
+               let total = (n) => sum(List.range(n))";
+    let session = session(src);
+
+    let (recorded, inv) = session
+        .call_recorded("total", vec![Value::Number(60_000.0)], &mut NoHost)
+        .expect("call_recorded");
+    assert!(inv.truncated);
+
+    // Same call with the recorder OFF must yield the identical value.
+    let plain = session
+        .call("total", vec![Value::Number(60_000.0)], &mut NoHost)
+        .expect("call");
+    assert_eq!(recorded.to_string(), plain.to_string());
+}


### PR DESCRIPTION
Part 1 of the paused-scene inspector ("LightTable" experience): when a game is paused, the editor shows live variable values inline via LSP inlay hints, with a CodeLens picker for the N executions of an entry point within a frame. This PR is the language-crate half: a bounded, per-call recorder.

## What

- `Session::call_recorded(name, args, host)` — same semantics as the existing entry-point call, plus a `RecordedInvocation`: the result (as `Display` text) and every **binding site** that bound during the call (`let` bindings, lambda/function params, match binders) with the last value's `Display` text + a hit count per site.
- Implemented as an `Option<Recorder>` on the interpreter mirroring the existing trace mode: when not armed (all normal execution), the cost is a `None` check at binding sites; nothing else changes.
- Bounded: 1024 distinct sites / 100k binding events per invocation. A cap breach sets `truncated`, stops recording, and the call finishes normally — recording can never affect evaluation semantics.
- Sites are keyed by `BindingId`; loops re-binding a site keep the last value and increment the count. `let` binder spans use the existing goto/hover binder-region convention (`let name =`); params and match binders are name-precise.

## Why record binding sites (not every expression)

Inlay hints display `name = value` where names are bound — recording every subexpression would be unbounded and useless for display. Values render to `Display` text at record time, so no `Value` graphs are retained.

## Verification (headless)

`cargo test -p functor-lang` — 485 tests green, including 4 new: let-in/param/result recording with span checks, match-binder recording (losing arm absent), fold-loop last-value + count, and cap-breach → `truncated` with a result identical to the recorder-off call.

## Stack

- **This PR** — recorder (language crate only)
- #340 — replay journal + `GET /trace` (stacked on this)
- #341 (LSP overlay), #342 (extension) — independent editor-side PRs

Design/plan: the paused-inspector investigation (LSP-inlay display channel, event-driven refresh, zero perf impact unless paused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)