### PR TITLE
feat(runtime): replay journal + GET /trace — the paused-scene inspector data path

### DIFF
--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -62,6 +62,7 @@ screenshot run has no reason to grab your mouse.
 | `POST /capture` | PNG (`image/png`) of the next rendered frame |
 | `GET /state` | runtime state JSON: `frame`, `tts`, `viewport`, `input` (structured `held_keys` + `mouse`), `model` (Rust `Debug` text) |
 | `GET /scene` | current frame as JSON: `camera` + `scene` + `lights` |
+| `GET /trace` | paused-inspector trace: the last real frame's entry-point invocations (per-binding-site values + result) replayed while paused; `{ "paused": false, "invocations": [] }` while playing |
 | `POST /input` | inject input (see below) |
 | `POST /time` | control the frame clock (see below) |
 | `POST /reload-source` | swap game logic from the request body (see below) |

--- a/examples/inspector/functor.json
+++ b/examples/inspector/functor.json
@@ -1,0 +1,4 @@
+{
+  "language": "functor-lang",
+  "entry": "game.fun"
+}

--- a/examples/inspector/game.fun
+++ b/examples/inspector/game.fun
@@ -1,0 +1,40 @@
+// examples/inspector — a tiny MVU game for the paused visual-debugger
+// (docs/visual-debugger). A per-second `Sub.every` timer fires a `Tick`
+// message; its `update` returns an `Effect.now` command, so ONE timer firing
+// drives TWO `update` calls in a single frame — the timer message, then the
+// effect result — plus the per-frame `tick`. Pausing on such a frame
+// (`POST /time set` past a 1s boundary, or `advance` across one) makes
+// `GET /trace` show `update` with count 2 and both provenance kinds:
+//
+//   functor -d examples/inspector run native --headless --debug-port 8077
+//   curl -s -XPOST localhost:8077/time -d '{"type":"set","tts":0.9}'
+//   curl -s -XPOST localhost:8077/time -d '{"type":"advance","dts":0.2}'
+//   curl -s localhost:8077/trace | jq
+
+type Msg =
+  | Tick
+  | GotTime(t: Float)
+
+type Model = {
+  ticks: Float,
+  lastTime: Float,
+}
+
+let init = { ticks: 0.0, lastTime: 0.0 }
+
+let update = (model: Model, msg: Msg) =>
+  match msg with
+  | Tick =>
+    let bumped = model.ticks + 1.0 in
+    ({ model with ticks: bumped }, Effect.now((t) => GotTime(t)))
+  | GotTime(t) => { model with lastTime: t }
+
+let subscriptions = (model: Model) => Sub.every(Time.seconds(1.0), Tick)
+
+let tick = (model: Model, dt: Float, tts: Float) => model
+
+let draw = (model: Model, tts: Float) =>
+  Frame.create(
+    Camera.lookAt(0.0, 1.5, -4.0, 0.0, 0.0, 0.0),
+    Scene.cube() |> Scene.rotateY(Angle.radians(tts)),
+  )

--- a/functor-lang/src/eval.rs
+++ b/functor-lang/src/eval.rs
@@ -58,6 +58,13 @@ const MAX_EVAL_DEPTH: usize = 128;
 /// Trace-event cap; see the module doc.
 pub const MAX_TRACE_EVENTS: usize = 10_000;
 
+/// Recorder caps (see [`Recorder`] / [`Session::call_recorded`]). Distinct
+/// binding *sites* per armed invocation, and total binding *events* (a loop
+/// re-binding one site counts each time). A breach stops recording and flags
+/// `truncated`; evaluation itself is never affected.
+pub const MAX_RECORDED_SITES: usize = 1024;
+pub const MAX_RECORDED_BINDINGS: usize = 100_000;
+
 #[derive(Clone, Copy, PartialEq)]
 pub enum Tracing {
     Off,
@@ -97,6 +104,94 @@ pub struct RunRecord {
 pub struct RunFailure {
     pub error: RunError,
     pub trace: Vec<TraceEvent>,
+}
+
+/// The record of one armed entry-point call (see [`Session::call_recorded`]):
+/// the call's result and every binding-site value observed while it ran, as
+/// pre-rendered `Display` text (the record owns no `Value`s). Framing above a
+/// single invocation — entry provenance, ghost, index/count within a frame —
+/// is the producer's job; this is one call's raw record.
+pub struct RecordedInvocation {
+    /// The called top-level name (`update`, `tick`, …).
+    pub entry: String,
+    /// `Display` of the returned value.
+    pub result: String,
+    /// One entry per distinct binding site reached, in first-seen order.
+    pub bindings: Vec<RecordedBinding>,
+    /// The recorder hit a cap during this call — `bindings` is partial (but
+    /// `result` is exact; recording never changes evaluation).
+    pub truncated: bool,
+}
+
+/// One binding site's last observed value. A site is a `let` binding, a
+/// lambda/function parameter, or a match-pattern variable; nested calls' sites
+/// appear here too (flat — spans disambiguate them). `value` is the LAST
+/// value bound at the site and `count` how many times it bound (a loop, e.g.
+/// `List.fold`, re-binds a site each iteration).
+pub struct RecordedBinding {
+    pub name: String,
+    /// Byte range into the loaded source. NOTE: [`Span`] carries no file — a
+    /// multi-file project loads as one concatenated source, so mapping this
+    /// range back to (file, offset) is the producer's job (see the visual-
+    /// debugger wire contract). For a `let` this is the `let [mut] name =`
+    /// region (as `goto`/`hover` report binder names); for a param or match
+    /// var it is the name's own span.
+    pub span: Span,
+    /// `Display` of the last value bound here.
+    pub value: String,
+    pub count: u32,
+}
+
+/// The per-call binding-site recorder — armed by [`Session::call_recorded`],
+/// mirroring the [`Tracing`] mode: an `Option<Recorder>` on the interpreter,
+/// checked cheaply at binding sites only (a `None` test when off). Keyed by
+/// [`BindingId`] (unique per site in a module; a loop re-enters the same
+/// site's id), it keeps the last value + hit count per site. On a cap breach
+/// it sets `truncated` and stops recording — evaluation continues untouched.
+struct Recorder {
+    bindings: Vec<RecordedBinding>,
+    /// `BindingId` raw → index into `bindings`.
+    index: HashMap<u32, usize>,
+    events: usize,
+    truncated: bool,
+}
+
+impl Recorder {
+    fn new() -> Recorder {
+        Recorder {
+            bindings: Vec::new(),
+            index: HashMap::new(),
+            events: 0,
+            truncated: false,
+        }
+    }
+
+    /// Record a value bound at `binding`'s site. Once `truncated`, a no-op.
+    fn record(&mut self, binding: u32, name: &str, span: Span, value: &Value) {
+        if self.truncated {
+            return;
+        }
+        self.events += 1;
+        if self.events > MAX_RECORDED_BINDINGS {
+            self.truncated = true;
+            return;
+        }
+        if let Some(&idx) = self.index.get(&binding) {
+            let slot = &mut self.bindings[idx];
+            slot.value = value.to_string();
+            slot.count += 1;
+        } else if self.bindings.len() >= MAX_RECORDED_SITES {
+            self.truncated = true;
+        } else {
+            self.index.insert(binding, self.bindings.len());
+            self.bindings.push(RecordedBinding {
+                name: name.to_string(),
+                span,
+                value: value.to_string(),
+                count: 1,
+            });
+        }
+    }
 }
 
 /// Host-provided externals: the embedding runtime (e.g. Functor's shells)
@@ -146,6 +241,7 @@ pub fn run_with_host(
         mut_slots: HashMap::new(),
         trace: Vec::new(),
         tracing,
+        recorder: None,
         depth: 0,
         call_depth: 0,
         host,
@@ -182,6 +278,7 @@ impl Session {
             mut_slots: HashMap::new(),
             trace: Vec::new(),
             tracing: Tracing::Off,
+            recorder: None,
             depth: 0,
             call_depth: 0,
             host,
@@ -219,6 +316,7 @@ impl Session {
             mut_slots: HashMap::new(),
             trace: Vec::new(),
             tracing: Tracing::Off,
+            recorder: None,
             depth: 0,
             call_depth: 0,
             host,
@@ -241,11 +339,50 @@ impl Session {
             mut_slots: HashMap::new(),
             trace: Vec::new(),
             tracing: Tracing::Off,
+            recorder: None,
             depth: 0,
             call_depth: 0,
             host,
         };
         interp.call(callee, args, label.to_string(), Span::new(0, 0), None)
+    }
+
+    /// Like [`Self::call`], but with the binding-site recorder armed: returns
+    /// the call's result plus a [`RecordedInvocation`] of every `let` /
+    /// parameter / match-variable value bound while it ran (including nested
+    /// user calls). Recording is bounded (see [`MAX_RECORDED_SITES`] /
+    /// [`MAX_RECORDED_BINDINGS`]) and never changes evaluation — the result is
+    /// identical to [`Self::call`]; only observation is added. The seam the
+    /// paused visual-debugger replays entry points through.
+    pub fn call_recorded(
+        &self,
+        name: &str,
+        args: Vec<Value>,
+        host: &mut dyn Host,
+    ) -> Result<(Value, RecordedInvocation), RunError> {
+        let callee = self.globals.get(name).cloned().ok_or_else(|| RunError {
+            message: format!("no top-level `let {name}` in the module"),
+            span: Span::new(0, 0),
+        })?;
+        let mut interp = Interp {
+            globals: self.globals.clone(),
+            mut_slots: HashMap::new(),
+            trace: Vec::new(),
+            tracing: Tracing::Off,
+            recorder: Some(Recorder::new()),
+            depth: 0,
+            call_depth: 0,
+            host,
+        };
+        let result = interp.call(callee, args, name.to_string(), Span::new(0, 0), None)?;
+        let recorder = interp.recorder.expect("armed above");
+        let invocation = RecordedInvocation {
+            entry: name.to_string(),
+            result: result.to_string(),
+            bindings: recorder.bindings,
+            truncated: recorder.truncated,
+        };
+        Ok((result, invocation))
     }
 }
 
@@ -258,6 +395,9 @@ struct Interp<'h> {
     mut_slots: HashMap<u32, Vec<Value>>,
     trace: Vec<TraceEvent>,
     tracing: Tracing,
+    /// The binding-site recorder, armed only by [`Session::call_recorded`];
+    /// `None` (the norm) means zero recording cost on the hot path.
+    recorder: Option<Recorder>,
     depth: usize,
     call_depth: usize,
     host: &'h mut dyn Host,
@@ -318,6 +458,15 @@ impl Interp<'_> {
         let result = self.eval_inner(expr, env);
         self.depth -= 1;
         result
+    }
+
+    /// Record a value bound at `binding`'s site, when the recorder is armed —
+    /// a cheap `None` check otherwise (the binding-site hot-path cost). See
+    /// [`Recorder`].
+    fn record_binding(&mut self, binding: BindingId, name: &str, span: Span, value: &Value) {
+        if let Some(recorder) = &mut self.recorder {
+            recorder.record(binding.0, name, span, value);
+        }
     }
 
     fn eval_inner(&mut self, expr: &Expr, env: &Env) -> Result<Value, RunError> {
@@ -430,12 +579,16 @@ impl Interp<'_> {
                 }),
             ExprKind::Let {
                 binding,
+                name,
                 mutable,
                 value,
                 body,
                 ..
             } => {
+                // The `let [mut] name =` region, as goto/hover report binders.
+                let binder_span = Span::new(expr.span.start, value.span.start);
                 let value = self.eval(value, env)?;
+                self.record_binding(*binding, name, binder_span, &value);
                 if *mutable {
                     self.mut_slots.entry(binding.0).or_default().push(value);
                     let result = self.eval(body, env);
@@ -554,6 +707,17 @@ impl Interp<'_> {
                 for arm in arms {
                     let mut vars = Vec::new();
                     if match_pattern(&arm.pattern, &value, &mut vars) {
+                        if self.recorder.is_some() {
+                            let mut sites = Vec::new();
+                            pattern_binder_sites(&arm.pattern, &mut sites);
+                            for (binding, bound) in &vars {
+                                if let Some(&(_, name, span)) =
+                                    sites.iter().find(|(b, _, _)| b == binding)
+                                {
+                                    self.record_binding(*binding, name, span, bound);
+                                }
+                            }
+                        }
                         let child = env.child(vars);
                         return self.eval(&arm.body, &child);
                     }
@@ -678,7 +842,13 @@ impl Interp<'_> {
                         span,
                     })
                 } else {
-                    let vars = closure.params.iter().map(|p| p.binding).zip(args).collect();
+                    let vars: Vec<(BindingId, Value)> =
+                        closure.params.iter().map(|p| p.binding).zip(args).collect();
+                    if self.recorder.is_some() {
+                        for (param, (_, value)) in closure.params.iter().zip(vars.iter()) {
+                            self.record_binding(param.binding, &param.name, param.span, value);
+                        }
+                    }
                     let env = closure.env.child(vars);
                     let body = closure.body.clone();
                     self.eval(&body, &env)
@@ -1151,6 +1321,32 @@ fn match_pattern(pattern: &Pattern, value: &Value, vars: &mut Vec<(BindingId, Va
         PatternKind::Number(n) => matches!(value, Value::Number(v) if v == n),
         PatternKind::Bool(b) => matches!(value, Value::Bool(v) if v == b),
         PatternKind::String(s) => matches!(value, Value::String(v) if v.as_ref() == s),
+    }
+}
+
+/// Each pattern variable's `(binding, name, span)` — the recorder's per-site
+/// key/label/location for match binders (the `Var` pattern's own span is the
+/// name's span), mirroring `goto::pattern_binders`'s traversal.
+fn pattern_binder_sites<'a>(pattern: &'a Pattern, out: &mut Vec<(BindingId, &'a str, Span)>) {
+    match &pattern.kind {
+        PatternKind::Var { binding, name } => out.push((*binding, name, pattern.span)),
+        PatternKind::Ctor { args, .. } | PatternKind::Tuple(args) => {
+            for arg in args {
+                pattern_binder_sites(arg, out);
+            }
+        }
+        PatternKind::List { items, tail } => {
+            for item in items {
+                pattern_binder_sites(item, out);
+            }
+            if let Some(tail) = tail {
+                pattern_binder_sites(tail, out);
+            }
+        }
+        PatternKind::Wildcard
+        | PatternKind::Number(_)
+        | PatternKind::Bool(_)
+        | PatternKind::String(_) => {}
     }
 }
 

--- a/functor-lang/src/lib.rs
+++ b/functor-lang/src/lib.rs
@@ -27,8 +27,8 @@ pub mod types;
 pub mod value;
 
 pub use eval::{
-    render_trace, run, run_with_host, Host, NoHost, RunFailure, RunOutcome, RunRecord, Session,
-    Tracing,
+    render_trace, run, run_with_host, Host, NoHost, RecordedBinding, RecordedInvocation, RunFailure,
+    RunOutcome, RunRecord, Session, Tracing,
 };
 pub use lower::lower;
 pub use parser::{parse, parse_interface};

--- a/functor-lang/tests/recorder.rs
+++ b/functor-lang/tests/recorder.rs
@@ -1,0 +1,136 @@
+//! Binding-site recorder verification (the paused visual-debugger's PR1 seam,
+//! `Session::call_recorded`): a bounded, per-call-armed record of every `let` /
+//! parameter / match-variable value, with last-value + hit-count per site and a
+//! `truncated` cap flag — and NO effect on evaluation itself.
+
+use functor_lang::value::Value;
+use functor_lang::{NoHost, RecordedBinding, RecordedInvocation, Session};
+use std::rc::Rc;
+
+/// Parse + lower + load `src` into a session, panicking with a rendered
+/// position on failure.
+fn session(src: &str) -> Session {
+    let program = functor_lang::parse(src).expect("source should parse");
+    let module = functor_lang::lower(program).expect("source should lower");
+    match Session::load(&module, &mut NoHost) {
+        Ok(session) => session,
+        Err(failure) => {
+            let (line, col) = functor_lang::line_col(src, failure.error.span.start);
+            panic!("{line}:{col}: load error: {}", failure.error.message);
+        }
+    }
+}
+
+/// The recorded binding named `name` (panics if absent).
+fn binding<'a>(inv: &'a RecordedInvocation, name: &str) -> &'a RecordedBinding {
+    inv.bindings
+        .iter()
+        .find(|b| b.name == name)
+        .unwrap_or_else(|| panic!("no recorded binding `{name}`"))
+}
+
+/// The exact source text the binding's span points at (proves spans are real
+/// byte offsets into the loaded source).
+fn spanned<'a>(src: &'a str, b: &RecordedBinding) -> &'a str {
+    &src[b.span.start..b.span.end]
+}
+
+#[test]
+fn records_let_bindings_and_params_and_result() {
+    let src = "let update = (model) =>\n  let doubled = model + 1.0 in\n  doubled + 10.0";
+    let session = session(src);
+    let (result, inv) = session
+        .call_recorded("update", vec![Value::Number(5.0)], &mut NoHost)
+        .expect("call_recorded");
+
+    assert_eq!(result.to_string(), "16");
+    assert_eq!(inv.entry, "update");
+    assert_eq!(inv.result, "16");
+    assert!(!inv.truncated);
+
+    let model = binding(&inv, "model");
+    assert_eq!(model.value, "5");
+    assert_eq!(model.count, 1);
+    assert_eq!(spanned(src, model), "model");
+
+    let doubled = binding(&inv, "doubled");
+    assert_eq!(doubled.value, "6");
+    assert_eq!(doubled.count, 1);
+    // A `let`'s span is the `let name =` binder region (goto/hover convention).
+    assert!(spanned(src, doubled).contains("doubled"));
+}
+
+#[test]
+fn records_match_binders() {
+    let src = "type Shape = | Circle(radius: Float) | Square(side: Float)\n\
+               let area = (shape) =>\n  \
+               match shape with\n  \
+               | Circle(r) => r + 1.0\n  \
+               | Square(s) => s + 2.0";
+    let session = session(src);
+    let circle = Value::Variant {
+        ctor: Rc::from("Circle"),
+        args: Rc::new(vec![Value::Number(3.0)]),
+    };
+    let (result, inv) = session
+        .call_recorded("area", vec![circle], &mut NoHost)
+        .expect("call_recorded");
+
+    assert_eq!(result.to_string(), "4");
+    // The scrutinee parameter renders as the whole variant.
+    assert_eq!(binding(&inv, "shape").value, "Circle(3)");
+    // The winning arm's binder is recorded; the losing arm's `s` is not.
+    let r = binding(&inv, "r");
+    assert_eq!(r.value, "3");
+    assert_eq!(r.count, 1);
+    assert_eq!(spanned(src, r), "r");
+    assert!(inv.bindings.iter().all(|b| b.name != "s"));
+}
+
+#[test]
+fn loop_site_keeps_last_value_and_counts_hits() {
+    let src = "let sum = (xs) => List.fold((acc, x) => acc + x, 0.0, xs)";
+    let session = session(src);
+    let xs = Value::List(Rc::new(vec![
+        Value::Number(1.0),
+        Value::Number(2.0),
+        Value::Number(3.0),
+    ]));
+    let (result, inv) = session
+        .call_recorded("sum", vec![xs], &mut NoHost)
+        .expect("call_recorded");
+
+    assert_eq!(result.to_string(), "6");
+    assert!(!inv.truncated);
+
+    // The fold closure's params re-bind once per element: last value wins,
+    // count is the element count.
+    let acc = binding(&inv, "acc");
+    assert_eq!(acc.count, 3);
+    assert_eq!(acc.value, "3"); // acc going into the final `acc + x` (1 + 2)
+    let x = binding(&inv, "x");
+    assert_eq!(x.count, 3);
+    assert_eq!(x.value, "3"); // the last element
+    assert_eq!(binding(&inv, "xs").count, 1);
+}
+
+#[test]
+fn cap_breach_truncates_but_result_is_exact() {
+    // 60_000 elements × 2 closure params = 120_000 binding events, past the
+    // 100_000 event cap — recording stops, `truncated` is set, and the fold
+    // still returns the exact sum (recording never changes evaluation).
+    let src = "let sum = (xs) => List.fold((acc, x) => acc + x, 0.0, xs)\n\
+               let total = (n) => sum(List.range(n))";
+    let session = session(src);
+
+    let (recorded, inv) = session
+        .call_recorded("total", vec![Value::Number(60_000.0)], &mut NoHost)
+        .expect("call_recorded");
+    assert!(inv.truncated);
+
+    // Same call with the recorder OFF must yield the identical value.
+    let plain = session
+        .call("total", vec![Value::Number(60_000.0)], &mut NoHost)
+        .expect("call");
+    assert_eq!(recorded.to_string(), plain.to_string());
+}

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -2677,7 +2677,15 @@ pub fn deliver_physics_events(
                     continue;
                 }
             };
-            match session.call("update", vec![model.clone(), msg], &mut FunctorHost) {
+            // Journal this collision-driven `update` for the paused inspector
+            // (PR2); a no-op unless journaling is armed.
+            let args = vec![model.clone(), msg];
+            crate::functor_lang_producer::journal_push(
+                "update",
+                &args,
+                crate::functor_lang_producer::Provenance::Collision,
+            );
+            match session.call("update", args, &mut FunctorHost) {
                 Ok(returned) => {
                     let (next_model, more) = split_model_effect(returned);
                     *model = next_model;
@@ -3072,7 +3080,17 @@ dropping the rest"
                 continue;
             }
         };
-        match session.call("update", vec![model.clone(), msg], &mut FunctorHost) {
+        // Journal this effect-result `update` for the paused inspector (PR2): a
+        // raycast result is a physics QUERY, everything else an effect result.
+        // A no-op unless journaling is armed (the live desktop frame only).
+        let args = vec![model.clone(), msg];
+        let provenance = if kind == "physics.raycast" {
+            crate::functor_lang_producer::Provenance::PhysicsQuery
+        } else {
+            crate::functor_lang_producer::Provenance::EffectResult
+        };
+        crate::functor_lang_producer::journal_push("update", &args, provenance);
+        match session.call("update", args, &mut FunctorHost) {
             Ok(returned) => {
                 let (next_model, more) = split_model_effect(returned);
                 *model = next_model;

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -42,6 +42,169 @@ use crate::physics::{self, PhysicsEvent, SteppedPhysics};
 use crate::timetravel::SceneRecorder;
 use crate::{Frame, FrameTime};
 
+// ---------------------------------------------------------------------------
+// The paused-inspector replay journal (visual-debugger PR2).
+//
+// During normal play the producer records nothing and renders no Display text —
+// the hard perf requirement. Instead each model-updating entry-point call site
+// pushes a cheap `(entry, Rc-cloned args, provenance tag)` into a thread-local
+// journal. On pause the desktop producer replays each journaled call through
+// `Session::call_recorded` (the PR1 recorder) to build the trace; entry points
+// are pure functions of their args (the input model is `args[0]`), so replay is
+// exact and — effects being plain data that only the drain performs — free of
+// side effects.
+//
+// A THREAD-LOCAL sink (rather than a `FrameCtx` field) keeps this off the web
+// producer entirely (it never arms it → the pushes are a `None` check) and off
+// the shared effect machinery's signatures. The dry-run forward-step pauses it
+// ([`JournalPause`]) so `--ghost` calls are never journaled.
+// ---------------------------------------------------------------------------
+
+/// One journaled model-updating call: the entry name, its Rc-cloned args, and a
+/// lightweight provenance tag. The provenance STRING (the wire vocabulary) is
+/// derived from the tag + args only at trace-build time — never during play, so
+/// journaling renders no Display text.
+pub struct JournalEntry {
+    /// The entry-point name — `tick` | `input` | `mouseMove` | `mouseWheel` |
+    /// `update` (the wire contract's `entry`).
+    pub entry: &'static str,
+    /// The call's arguments (Rc-cloned). `args[0]` is the input model; for a
+    /// message-bearing call `args[1]` is the message.
+    pub args: Vec<Value>,
+    pub provenance: Provenance,
+}
+
+/// Why a model-updating call ran — the source that drove it. Rendered to the
+/// wire provenance string by [`Provenance::render`].
+#[derive(Clone, Copy)]
+pub enum Provenance {
+    Tick,
+    Input,
+    MouseMove,
+    MouseWheel,
+    Subscription,
+    EffectResult,
+    PhysicsQuery,
+    Collision,
+    NetEvent,
+    HttpResponse,
+    AudioFinished,
+    UiEvent,
+}
+
+impl Provenance {
+    /// The wire provenance string, from the tag + the call's args. The
+    /// message-bearing variants render `args[1]` (the message); `tick` renders
+    /// its `dt` (`args[1]`); `input` reads the key name (`args[1]`, unquoted)
+    /// and the down flag (`args[2]`). Built here at trace time, not during play.
+    pub fn render(&self, args: &[Value]) -> String {
+        let msg = || args.get(1).map(|v| v.to_string()).unwrap_or_default();
+        match self {
+            // `dt` is f32-sourced (the protocol's FrameTime), so render it at
+            // f32 precision — the f64 Value would show cast noise (…0.2000000029).
+            Provenance::Tick => {
+                let dt = match args.get(1) {
+                    Some(Value::Number(n)) => (*n as f32).to_string(),
+                    _ => String::new(),
+                };
+                format!("tick dt={dt}")
+            }
+            Provenance::Input => {
+                let key = match args.get(1) {
+                    Some(Value::String(s)) => s.to_string(),
+                    _ => String::new(),
+                };
+                let dir = match args.get(2) {
+                    Some(Value::Bool(false)) => "up",
+                    _ => "down",
+                };
+                format!("input: {key} {dir}")
+            }
+            Provenance::MouseMove => "mouseMove".to_string(),
+            Provenance::MouseWheel => "mouseWheel".to_string(),
+            Provenance::Subscription => format!("subscription: {}", msg()),
+            Provenance::EffectResult => format!("effect result: {}", msg()),
+            Provenance::PhysicsQuery => format!("physics query: {}", msg()),
+            Provenance::Collision => format!("collision: {}", msg()),
+            Provenance::NetEvent => format!("net event: {}", msg()),
+            Provenance::HttpResponse => format!("http response: {}", msg()),
+            Provenance::AudioFinished => format!("audio finished: {}", msg()),
+            Provenance::UiEvent => format!("ui event: {}", msg()),
+        }
+    }
+}
+
+thread_local! {
+    /// The current frame's journal, `Some` only while the desktop producer is
+    /// driving live frames (armed once in `FunctorLangGame::create`). `None`
+    /// everywhere else — the web producer, the dry-run forward-step, tests —
+    /// so [`journal_push`] is a cheap `None` check with zero allocation.
+    static JOURNAL: std::cell::RefCell<Option<Vec<JournalEntry>>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// Push a journal entry if journaling is armed on this thread — otherwise a
+/// no-op (one thread-local borrow). Called at every model-updating entry-point
+/// call site; `args` is cloned (Rc-shared, cheap).
+pub fn journal_push(entry: &'static str, args: &[Value], provenance: Provenance) {
+    JOURNAL.with(|j| {
+        if let Some(v) = j.borrow_mut().as_mut() {
+            v.push(JournalEntry {
+                entry,
+                args: args.to_vec(),
+                provenance,
+            });
+        }
+    });
+}
+
+/// Arm journaling for this thread (idempotent). The desktop producer calls this
+/// once at startup; the web producer never does, so its shared frame body pays
+/// only the `None` check.
+pub fn journal_arm() {
+    JOURNAL.with(|j| {
+        let mut b = j.borrow_mut();
+        if b.is_none() {
+            *b = Some(Vec::new());
+        }
+    });
+}
+
+/// Swap out the current frame's collected entries, leaving a fresh empty
+/// journal armed — called at the end of each real frame (`tick`). `None` when
+/// journaling isn't armed (web / tests).
+pub fn journal_swap() -> Option<Vec<JournalEntry>> {
+    JOURNAL.with(|j| {
+        j.borrow_mut()
+            .as_mut()
+            .map(|v| std::mem::replace(v, Vec::new()))
+    })
+}
+
+/// Disarm journaling on this thread, dropping any collected entries — for tests
+/// that armed it (so a reused test thread starts clean).
+pub fn journal_disarm() {
+    JOURNAL.with(|j| *j.borrow_mut() = None);
+}
+
+/// RAII guard that PAUSES journaling for its lifetime: takes the current
+/// journal out (leaving `None`, so nested pushes no-op) and restores it on
+/// drop. Wraps the dry-run forward-step so `--ghost` forward-projection calls
+/// never land in the journal, even on an unwind from stepped game code.
+struct JournalPause(Option<Vec<JournalEntry>>);
+
+impl JournalPause {
+    fn enter() -> JournalPause {
+        JournalPause(JOURNAL.with(|j| j.borrow_mut().take()))
+    }
+}
+
+impl Drop for JournalPause {
+    fn drop(&mut self) {
+        JOURNAL.with(|j| *j.borrow_mut() = self.0.take());
+    }
+}
+
 /// Where a producer resolves per-frame error spans to `path:line:col: message`.
 /// The two shells hold their source differently (a multi-file project map on
 /// desktop; the single fetched entry source on web), so this captures both.
@@ -201,6 +364,7 @@ impl FrameCtx<'_> {
             Value::Number(frame_time.dts as f64),
             Value::Number(frame_time.tts as f64),
         ];
+        journal_push("tick", &args, Provenance::Tick);
         match self.session.call("tick", args, &mut FunctorHost) {
             Ok(returned) => self.absorb(returned),
             Err(err) => self.reporter.frame_error("tick", &err),
@@ -544,10 +708,9 @@ to receive their messages; dropping them"
             Err(message) => return self.reporter.report_once(format!("[functor-lang] {message}")),
         };
         for msg in msgs {
-            match self
-                .session
-                .call("update", vec![self.model.clone(), msg], &mut FunctorHost)
-            {
+            let args = vec![self.model.clone(), msg];
+            journal_push("update", &args, Provenance::Subscription);
+            match self.session.call("update", args, &mut FunctorHost) {
                 Ok(returned) => self.absorb(returned),
                 Err(err) => self.reporter.frame_error("update", &err),
             }
@@ -677,10 +840,9 @@ to receive their messages; dropping them"
             Ok(msg) => msg,
             Err(err) => return self.reporter.frame_error("net event", &err),
         };
-        match self
-            .session
-            .call("update", vec![self.model.clone(), msg], &mut FunctorHost)
-        {
+        let args = vec![self.model.clone(), msg];
+        journal_push("update", &args, Provenance::NetEvent);
+        match self.session.call("update", args, &mut FunctorHost) {
             Ok(returned) => self.absorb(returned),
             Err(err) => self.reporter.frame_error("update", &err),
         }
@@ -702,10 +864,9 @@ to receive their messages; dropping them"
             Ok(msg) => msg,
             Err(err) => return self.reporter.frame_error("http response", &err),
         };
-        match self
-            .session
-            .call("update", vec![self.model.clone(), msg], &mut FunctorHost)
-        {
+        let args = vec![self.model.clone(), msg];
+        journal_push("update", &args, Provenance::HttpResponse);
+        match self.session.call("update", args, &mut FunctorHost) {
             Ok(returned) => self.absorb(returned),
             Err(err) => self.reporter.frame_error("update", &err),
         }
@@ -769,10 +930,9 @@ carries no payload to tag; dropped",
                 ));
             }
         };
-        match self
-            .session
-            .call("update", vec![self.model.clone(), msg], &mut FunctorHost)
-        {
+        let args = vec![self.model.clone(), msg];
+        journal_push("update", &args, Provenance::UiEvent);
+        match self.session.call("update", args, &mut FunctorHost) {
             Ok(returned) => self.absorb(returned),
             Err(err) => self.reporter.frame_error("update", &err),
         }
@@ -787,10 +947,9 @@ carries no payload to tag; dropped",
         let Some(message) = take_audio_completion(token) else {
             return;
         };
-        match self
-            .session
-            .call("update", vec![self.model.clone(), message], &mut FunctorHost)
-        {
+        let args = vec![self.model.clone(), message];
+        journal_push("update", &args, Provenance::AudioFinished);
+        match self.session.call("update", args, &mut FunctorHost) {
             Ok(returned) => self.absorb(returned),
             Err(err) => self.reporter.frame_error("update", &err),
         }
@@ -846,6 +1005,12 @@ pub fn forward_step_scene(
     steps_per_division: usize,
     inputs: &[Vec<RecordedInput>],
 ) -> Vec<(Value, Option<Vec<u8>>)> {
+    // Pause the paused-inspector journal for the whole dry run: `--ghost`
+    // forward-projection replays `tick`/`update` over throwaway state, and those
+    // calls must NOT land in the live frame's journal (they are not real frame
+    // executions). Restored on drop, including on an unwind from stepped game
+    // code.
+    let _journal_pause = JournalPause::enter();
     // Dry-run physics: snapshot the live world and restore it into a fresh
     // throwaway world, so stepping forward never touches the live world,
     // driver, or timeline. The `DryWorld` guard removes it on drop — including on
@@ -1202,5 +1367,178 @@ mod tests {
             },
         );
         assert_model(&session, &model, "init"); // unchanged
+    }
+
+    // ---- Paused-inspector replay journal (visual-debugger PR2) --------------
+
+    use crate::functor_lang_prelude::FakeEffects;
+
+    /// A game with a per-second subscription whose `update` returns an
+    /// `Effect.now` — one subscription firing drives TWO `update` calls in a
+    /// frame (the timer message, then its effect result), so the journal proves
+    /// count > 1 and both provenance kinds.
+    const INSPECTOR_SRC: &str = "\
+        type Msg = | Tick | GotTime(t: Float)\n\
+        type Model = { ticks: Float, lastTime: Float }\n\
+        let init = { ticks: 0.0, lastTime: 0.0 }\n\
+        let update = (m: Model, msg: Msg) =>\n\
+          match msg with\n\
+          | Tick => ({ m with ticks: m.ticks + 1.0 }, Effect.now((t) => GotTime(t)))\n\
+          | GotTime(t) => { m with lastTime: t }\n\
+        let subscriptions = (m: Model) => Sub.every(Time.seconds(1.0), Tick)\n\
+        let tick = (m: Model, dt: Float, tts: Float) => m\n\
+        let draw = (m: Model, tts: Float) =>\n\
+          Frame.create(Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0), Scene.cube())\n";
+
+    fn inspector_session() -> (Session, Value) {
+        let project = functor_lang::project::load_single_source("game", INSPECTOR_SRC)
+            .unwrap_or_else(|e| panic!("load: {}", e.render()));
+        let session = Session::load(&project.module, &mut FunctorHost)
+            .unwrap_or_else(|f| panic!("session: {}", f.error.message));
+        let model = session.global("init").expect("init");
+        (session, model)
+    }
+
+    /// Run one live frame (subscriptions + tick) with the journal armed, driving
+    /// the model with `FakeEffects` so `Effect.now` is deterministic.
+    fn run_inspector_frame(session: &Session, model: &mut Value) {
+        let mut physics_rt = SteppedPhysics::new();
+        let mut physics_frame = 0u64;
+        let mut recorder = SceneRecorder::new();
+        let mut effect_runner = FakeEffects::new(42.0, vec![0.0]);
+        let mut effect_log = EffectLog::new();
+        let mut deferred_queries: Vec<EffectTree> = Vec::new();
+        let mut pending_events: Vec<PhysicsEvent> = Vec::new();
+        let mut live_conn_keys: HashSet<String> = HashSet::new();
+        // prev_tts just below a period boundary so this frame crosses 1.0s and
+        // fires the `Sub.every` timer.
+        let mut prev_tts: Option<f64> = Some(0.9);
+        let mut input_buf: Vec<RecordedInput> = Vec::new();
+        let mut reporter = Reporter::new(
+            SpanSource::Single {
+                src: INSPECTOR_SRC.to_string(),
+                path: "game".to_string(),
+            },
+            silent_emit,
+        );
+        let mut ctx = FrameCtx {
+            session,
+            model,
+            physics_rt: &mut physics_rt,
+            physics_frame: &mut physics_frame,
+            recorder: &mut recorder,
+            effect_runner: &mut effect_runner as &mut dyn EffectRunner,
+            effect_log: &mut effect_log,
+            deferred_queries: &mut deferred_queries,
+            pending_events: &mut pending_events,
+            live_conn_keys: &mut live_conn_keys,
+            prev_tts: &mut prev_tts,
+            input_buf: &mut input_buf,
+            has_physics: false,
+            has_subscriptions: true,
+            suppress_outbound: false,
+            reporter: &mut reporter,
+        };
+        ctx.before_physics(FrameTime {
+            dts: 0.2,
+            tts: 1.1,
+        });
+    }
+
+    #[test]
+    fn journal_records_a_frame_with_provenance_and_replay_matches() {
+        journal_disarm(); // this thread may be reused across tests
+        journal_arm();
+        let (session, model) = inspector_session();
+
+        let mut m = model.clone();
+        run_inspector_frame(&session, &mut m);
+        let journal = journal_swap().expect("journaling armed");
+
+        // Subscription `update` (Tick), its effect-result `update` (GotTime),
+        // then `tick` — the frame's model-updating calls, in order.
+        assert_eq!(journal.len(), 3, "tick + two updates");
+        assert_eq!(journal[0].entry, "update");
+        assert_eq!(
+            journal[0].provenance.render(&journal[0].args),
+            "subscription: Tick"
+        );
+        assert_eq!(journal[1].entry, "update");
+        assert_eq!(
+            journal[1].provenance.render(&journal[1].args),
+            "effect result: GotTime(42)"
+        );
+        assert_eq!(journal[2].entry, "tick");
+        assert_eq!(journal[2].provenance.render(&journal[2].args), "tick dt=0.2");
+
+        // Replaying each journaled call through the PR1 recorder reproduces the
+        // exact result of a direct `call` (entry points are pure), and records
+        // binding sites (the seam the desktop trace serializes).
+        for e in &journal {
+            let direct = session
+                .call(e.entry, e.args.clone(), &mut FunctorHost)
+                .expect("direct call");
+            let (replayed, inv) = session
+                .call_recorded(e.entry, e.args.clone(), &mut FunctorHost)
+                .expect("recorded call");
+            assert_eq!(replayed.to_string(), direct.to_string());
+            assert_eq!(inv.result, direct.to_string());
+            // Each call binds its params (`m`, `msg`/`dt`/`tts`) — non-empty.
+            assert!(!inv.bindings.is_empty(), "recorded some binding sites");
+        }
+
+        journal_disarm();
+    }
+
+    #[test]
+    fn journal_survives_a_paused_frame_and_excludes_ghost_calls() {
+        journal_disarm();
+        journal_arm();
+        let (session, model) = inspector_session();
+
+        // A real frame fills the journal; swap it out (the producer's frame-end
+        // move into `last_frame_journal`).
+        let mut m = model.clone();
+        run_inspector_frame(&session, &mut m);
+        let last_frame = journal_swap().expect("armed");
+        assert_eq!(last_frame.len(), 3);
+
+        // A dry-run forward-step (the `--ghost` projection) calls tick/update
+        // over throwaway state — and must NOT touch the live journal. After it,
+        // the freshly-armed journal is still empty (ghost calls excluded).
+        let _ = forward_step_scene(
+            &session,
+            &m,
+            false, // has_physics
+            true,  // has_subscriptions
+            Some(0.9),
+            1.1,
+            1.0 / 60.0,
+            3, // divisions
+            1, // steps per division
+            &[],
+        );
+        let after_ghost = journal_swap().expect("still armed");
+        assert!(
+            after_ghost.is_empty(),
+            "ghost forward-projection calls must not be journaled, got {}",
+            after_ghost.len()
+        );
+
+        journal_disarm();
+    }
+
+    #[test]
+    fn journaling_off_by_default_is_a_noop() {
+        // With no `journal_arm` (the web / plain-frame path), running a frame
+        // journals nothing — the perf gate: no collection, no Display rendering.
+        journal_disarm();
+        let (session, model) = inspector_session();
+        let mut m = model.clone();
+        run_inspector_frame(&session, &mut m);
+        assert!(
+            journal_swap().is_none(),
+            "journaling must stay off until explicitly armed"
+        );
     }
 }

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -214,11 +214,21 @@ pub trait GameProducer {
     /// The paused-inspector trace (visual-debugger PR2): the wire-contract JSON
     /// for the last real frame's entry-point invocations, replayed on demand
     /// while paused (the debug server's `GET /trace`). `paused` is the shell's
-    /// clock state. The default is an inert doc — only the interpreter producer
-    /// keeps a replay journal (a compiled/replay producer has no source to trace).
+    /// clock state. The unpaused doc carries no `frame`/`tts` (it must stay
+    /// byte-identical across idle polls — the LSP dedups on the doc bytes).
+    /// The default is an inert doc — only the interpreter producer keeps a
+    /// replay journal (a compiled/replay producer has no source to trace).
     fn inspector_trace(&mut self, _paused: bool) -> String {
-        "{\"frame\":0,\"tts\":0.0,\"paused\":false,\"sources\":[],\"invocations\":[]}".to_string()
+        "{\"paused\":false,\"sources\":[],\"invocations\":[]}".to_string()
     }
+
+    /// The shell delivered debug-injected input (`POST /input`) while the clock
+    /// is PAUSED (visual-debugger PR2): no `tick` will run to sweep the
+    /// journaled entry-point calls into the last-frame journal, so the producer
+    /// folds them in now — the injection becomes a first-class invocation in
+    /// `GET /trace` instead of a phantom on the resume frame's journal.
+    /// Default: no-op (producers without a replay journal have nothing to fold).
+    fn absorb_paused_input(&mut self) {}
 
     /// Take the networking commands the game queued this frame (a JSON array
     /// of [`crate::net::NetCommand`]). The shell performs the I/O and reports

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -211,6 +211,15 @@ pub trait GameProducer {
     /// debug text — see the module doc; consumers must not parse it.
     fn state_debug(&self) -> String;
 
+    /// The paused-inspector trace (visual-debugger PR2): the wire-contract JSON
+    /// for the last real frame's entry-point invocations, replayed on demand
+    /// while paused (the debug server's `GET /trace`). `paused` is the shell's
+    /// clock state. The default is an inert doc — only the interpreter producer
+    /// keeps a replay journal (a compiled/replay producer has no source to trace).
+    fn inspector_trace(&mut self, _paused: bool) -> String {
+        "{\"frame\":0,\"tts\":0.0,\"paused\":false,\"sources\":[],\"invocations\":[]}".to_string()
+    }
+
     /// Take the networking commands the game queued this frame (a JSON array
     /// of [`crate::net::NetCommand`]). The shell performs the I/O and reports
     /// results back with `net_push_http_response` / `net_push_http_error`.

--- a/runtime/functor-runtime-desktop/Cargo.toml
+++ b/runtime/functor-runtime-desktop/Cargo.toml
@@ -26,6 +26,9 @@ cgmath = "0.18.0"
 image = "0.25"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# Per-file source hashing for the paused-inspector wire contract (visual-debugger
+# PR2): the `sources` array's sha256 gates the LSP's live-value overlay.
+sha2 = "0.10"
 notify = "6.1.1"
 notify-debouncer-full = "0.3.1"
 tempfile = "3.10.1"

--- a/runtime/functor-runtime-desktop/src/debug_server.rs
+++ b/runtime/functor-runtime-desktop/src/debug_server.rs
@@ -11,8 +11,8 @@
 //! only read on the main thread.
 //!
 //! Endpoints: `GET /` (index), `POST /capture`, `GET /state`, `GET /scene`,
-//! `POST /input`, `POST /time`. See `docs/debug-runtime.md` for usage and the
-//! observe-vs-drive workflows.
+//! `GET /trace`, `POST /input`, `POST /time`. See `docs/debug-runtime.md` for
+//! usage and the observe-vs-drive workflows.
 
 use std::io::Read;
 use std::sync::mpsc::{self, Receiver, Sender};
@@ -117,6 +117,10 @@ pub enum DebugRequest {
     State(Sender<RuntimeState>),
     /// `GET /scene` — reply with the current frame (camera + scene) as JSON.
     Scene(Sender<String>),
+    /// `GET /trace` — reply with the paused-inspector trace JSON (visual-
+    /// debugger PR2): the last real frame's entry-point invocations, replayed
+    /// while paused. The GL loop fills in the paused state from its clock.
+    Trace(Sender<String>),
     /// `POST /input` — inject a key/mouse event; reply Ok or an error message.
     Input(InputCommand, Sender<Result<(), String>>),
     /// `POST /time` — set/advance/resume the clock; reply once applied.
@@ -232,6 +236,28 @@ pub fn spawn(bind: &str, port: u16) -> Receiver<DebugRequest> {
                         Err(_) => {
                             let _ = request.respond(
                                 Response::from_string("scene failed").with_status_code(500),
+                            );
+                        }
+                    }
+                }
+                (Method::Get, "/trace") => {
+                    let (resp_tx, resp_rx) = mpsc::channel::<String>();
+                    if tx.send(DebugRequest::Trace(resp_tx)).is_err() {
+                        let _ = request
+                            .respond(Response::from_string("runtime gone").with_status_code(503));
+                        continue;
+                    }
+                    match resp_rx.recv() {
+                        Ok(json) => {
+                            let header =
+                                Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..])
+                                    .unwrap();
+                            let resp = Response::from_string(json).with_header(header);
+                            let _ = request.respond(resp);
+                        }
+                        Err(_) => {
+                            let _ = request.respond(
+                                Response::from_string("trace failed").with_status_code(500),
                             );
                         }
                     }
@@ -411,6 +437,7 @@ pub fn spawn(bind: &str, port: u16) -> Receiver<DebugRequest> {
                             "POST /capture": "PNG (image/png) of the next rendered frame",
                             "GET /state": "runtime state JSON: frame, tts, viewport, input (held_keys + mouse), model (Debug text)",
                             "GET /scene": "current frame as JSON: camera + scene + lights",
+                            "GET /trace": "paused-inspector trace: last real frame's entry-point invocations (bindings + result) replayed while paused; {paused:false, invocations:[]} while playing",
                             "POST /input": "inject input — {\"type\":\"key\",\"key\":\"w\",\"down\":true} | {\"type\":\"mouse_move\",\"x\":0,\"y\":0} | {\"type\":\"mouse_wheel\",\"delta\":1} | {\"type\":\"ui_event\",\"slot\":0,\"kind\":\"Clicked\"}",
                             "POST /time": "clock control — {\"type\":\"set\",\"tts\":2.0} (pause) | {\"type\":\"advance\",\"dts\":0.016} (step one frame) | {\"type\":\"resume\"}",
                             "POST /reload-source": "swap game logic from the request body (raw .fun source), model preserved — 400 with the load error on a broken push",

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -35,13 +35,16 @@ use functor_runtime_common::functor_lang_prelude::{
     UiHandler,
 };
 use functor_runtime_common::events::{self, RuntimeEvent};
-use functor_runtime_common::functor_lang_producer::{FrameCtx, Reporter, SpanSource};
+use functor_runtime_common::functor_lang_producer::{
+    journal_arm, journal_push, journal_swap, FrameCtx, JournalEntry, Provenance, Reporter,
+    SpanSource,
+};
 use functor_runtime_common::physics;
 use functor_runtime_common::timetravel::SceneRecorder;
 use functor_runtime_common::ui::View;
 use functor_runtime_common::{Frame, FrameTime};
 use functor_lang::project::SourceMap;
-use functor_lang::{Session, Value};
+use functor_lang::{Session, Span, Value};
 use std::path::PathBuf;
 use std::time::SystemTime;
 
@@ -141,6 +144,20 @@ pub struct FunctorLangGame {
     /// Per-frame error reporting (dedupe + stderr sink + project-span
     /// rendering) — shared with the web producer (`functor_lang_producer::Reporter`).
     reporter: Reporter,
+    /// The last real frame's replay journal (visual-debugger PR2): one entry
+    /// per model-updating call, swapped in from the thread-local journal at the
+    /// end of each `tick`. A paused frame runs no `tick`, so this is preserved
+    /// — the inspector reads the last real frame. `GET /trace` replays each
+    /// entry through `Session::call_recorded` while paused.
+    last_frame_journal: Vec<JournalEntry>,
+    /// The lazily built + cached `/trace` JSON for the current paused frame.
+    /// Invalidated when the frame advances (`tick`), the paused frame changes
+    /// (rewind/seek), or the program reloads.
+    cached_trace: Option<String>,
+    /// Per-file sha256 of the loaded `.fun` source, computed at load /
+    /// hot-reload (not per frame) — the wire contract's `sources`, and the
+    /// per-file base→(file, local offset) map for binding spans.
+    source_hashes: Vec<InspectorSource>,
     // rolling per-frame eval cost, printed every STATS_EVERY frames (the C6
     // perf gate watches these). Physics is engine cost, not Functor Lang eval cost, so
     // it gets its own counter — a heavy scene must not read as an interpreter
@@ -177,6 +194,45 @@ struct Loaded {
     has_physics: bool,
     has_soundscape: bool,
     has_ui: bool,
+}
+
+/// One project source file's inspector metadata (visual-debugger PR2): its
+/// wire name, its base offset in the project-wide span space, its length, and
+/// the sha256 of the text the runtime loaded. Computed once per load, so a
+/// binding span maps to `(file, local offset)` and the wire `sources` gates on
+/// a content hash without re-reading files.
+struct InspectorSource {
+    file: String,
+    base: usize,
+    len: usize,
+    hash: String,
+}
+
+/// Build the per-file inspector metadata from a loaded [`SourceMap`]: the REAL
+/// project `.fun` files only (skip the injected prelude `.funi` interfaces and
+/// the `<builtin>/Net.fun` module — a game binding never lands in them, and
+/// they aren't editor documents the LSP gates on).
+fn inspector_sources(sources: &SourceMap) -> Vec<InspectorSource> {
+    use sha2::{Digest, Sha256};
+    sources
+        .files()
+        .iter()
+        .filter(|f| !f.interface && !f.path.to_string_lossy().starts_with('<'))
+        .map(|f| {
+            let file = f
+                .path
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_else(|| f.path.to_string_lossy().into_owned());
+            let hash = format!("{:x}", Sha256::digest(f.src.as_bytes()));
+            InspectorSource {
+                file,
+                base: f.base,
+                len: f.src.len(),
+                hash,
+            }
+        })
+        .collect()
 }
 
 /// Load, check, and contract-validate a game project (B8: the entry plus
@@ -351,6 +407,12 @@ impl FunctorLangGame {
                 std::process::exit(1);
             }
         };
+        // Arm the paused-inspector journal on this (the render) thread: from now
+        // on every live model-updating call is journaled (a cheap Rc-clone push).
+        // The web producer never arms it — its shared frame body pays only a
+        // `None` check. See `functor_lang_producer`.
+        journal_arm();
+        let source_hashes = inspector_sources(&loaded.sources);
         FunctorLangGame {
             path: path.to_string(),
             stamp,
@@ -380,6 +442,9 @@ impl FunctorLangGame {
             live_conn_keys: std::collections::HashSet::new(),
             last_frame: empty_frame(),
             reporter: Reporter::new(SpanSource::Project(loaded.sources), report_to_stderr),
+            last_frame_journal: Vec::new(),
+            cached_trace: None,
+            source_hashes,
             frames: 0,
             tick_ns: 0,
             physics_ns: 0,
@@ -431,6 +496,13 @@ impl FunctorLangGame {
         for warning in &report.warnings {
             eprintln!("[functor-lang] reload: {warning}");
         }
+        // Recompute the inspector source hashes for the edited files, and drop
+        // the journal + cached trace: they refer to the OLD program's spans and
+        // execution (visual-debugger PR2 — hot-reload clears both).
+        self.source_hashes = inspector_sources(&loaded.sources);
+        self.last_frame_journal.clear();
+        self.cached_trace = None;
+        journal_swap(); // discard any partial current-frame journal
         self.reporter.set_source(SpanSource::Project(loaded.sources));
         self.module = loaded.module;
         self.session = loaded.session;
@@ -513,6 +585,94 @@ impl FunctorLangGame {
         }
     }
 
+    /// Map a project-wide binding span to `(file, local start, local end)` for
+    /// the wire contract, using the per-file base offsets (visual-debugger PR2).
+    /// `None` if the span falls outside a real project file (a prelude/builtin
+    /// span — a game binding never does).
+    fn span_to_file(&self, span: Span) -> Option<(String, usize, usize)> {
+        let src = self
+            .source_hashes
+            .iter()
+            .filter(|s| s.base <= span.start)
+            .max_by_key(|s| s.base)?;
+        if span.start > src.base + src.len {
+            return None;
+        }
+        Some((
+            src.file.clone(),
+            span.start - src.base,
+            span.end.saturating_sub(src.base),
+        ))
+    }
+
+    /// Replay the last real frame's journal into the wire-contract
+    /// `invocations` (visual-debugger PR2). Each journaled call is re-run through
+    /// `Session::call_recorded` — entry points are pure functions of their args,
+    /// so the record is exact, and effects are plain data (nothing performs), so
+    /// replay is side-effect-free. `index`/`count` frame each call within its
+    /// entry name; binding spans map to `(file, local offsets)`.
+    fn build_invocations(&self) -> Vec<serde_json::Value> {
+        use std::collections::HashMap;
+        let mut counts: HashMap<&str, usize> = HashMap::new();
+        for e in &self.last_frame_journal {
+            *counts.entry(e.entry).or_default() += 1;
+        }
+        let mut seen: HashMap<&str, usize> = HashMap::new();
+        let mut out = Vec::with_capacity(self.last_frame_journal.len());
+        for e in &self.last_frame_journal {
+            let index = {
+                let c = seen.entry(e.entry).or_default();
+                let i = *c;
+                *c += 1;
+                i
+            };
+            // A call that succeeded live, replayed pure, should not fail — skip
+            // it defensively rather than abort the whole trace if it somehow does.
+            let (_discard, inv) =
+                match self
+                    .session
+                    .call_recorded(e.entry, e.args.clone(), &mut FunctorHost)
+                {
+                    Ok(pair) => pair,
+                    Err(_) => continue,
+                };
+            let bindings: Vec<serde_json::Value> = inv
+                .bindings
+                .iter()
+                .filter_map(|b| {
+                    self.span_to_file(b.span).map(|(file, start, end)| {
+                        serde_json::json!({
+                            "name": b.name,
+                            "file": file,
+                            "start": start,
+                            "end": end,
+                            "value": b.value,
+                            "count": b.count,
+                        })
+                    })
+                })
+                .collect();
+            out.push(serde_json::json!({
+                "entry": e.entry,
+                "index": index,
+                "count": counts[e.entry],
+                "provenance": e.provenance.render(&e.args),
+                "ghost": false,
+                "result": inv.result,
+                "truncated": inv.truncated,
+                "bindings": bindings,
+            }));
+        }
+        out
+    }
+
+    /// The wire `sources` array — `{ file, hash }` per loaded project file.
+    fn sources_json(&self) -> Vec<serde_json::Value> {
+        self.source_hashes
+            .iter()
+            .map(|s| serde_json::json!({ "file": s.file, "hash": s.hash }))
+            .collect()
+    }
 }
 
 impl Game for FunctorLangGame {
@@ -625,6 +785,11 @@ impl Game for FunctorLangGame {
             self.pending_events.clear();
             clear_http_taggers();
             clear_audio_completions();
+            // The paused frame moved to `target`, for which we hold no journal
+            // (only the last real frame's) — drop the stale trace so the
+            // inspector reports the rewound frame with no invocations (PR2).
+            self.last_frame_journal.clear();
+            self.cached_trace = None;
             // Drop any input buffered since the last recorded frame: the model was
             // just restored to `target`, so a stray live event (e.g. one buffered
             // on a 0-substep frame under the fixed-timestep loop) is now orphaned
@@ -703,6 +868,11 @@ impl Game for FunctorLangGame {
             self.has_physics,
         );
         if result.is_ok() {
+            // The scrubbed frame changed: drop the stale journal + cached trace
+            // (we hold a journal only for the last real frame, not the scrubbed
+            // target) — PR2, like `rewind_scene_to`.
+            self.last_frame_journal.clear();
+            self.cached_trace = None;
             // The model was restored to `target`; drop any input buffered since
             // the last recorded frame so a stray live event (buffered on a
             // 0-substep frame under the fixed-timestep loop) can't be recorded
@@ -723,6 +893,13 @@ impl Game for FunctorLangGame {
         self.ctx().physics_phase(frame_time);
         self.physics_ns += physics_started.elapsed().as_nanos() as u64;
         self.ctx().record_frame(frame_time);
+        // A real frame ran: swap its journal into `last_frame_journal` (leaving
+        // a fresh armed journal) and drop the cached trace (the frame advanced).
+        // A paused frame never reaches here, so its last real frame is kept.
+        if let Some(journal) = journal_swap() {
+            self.last_frame_journal = journal;
+        }
+        self.cached_trace = None;
         self.frames += 1;
         self.report_stats();
     }
@@ -742,6 +919,7 @@ impl Game for FunctorLangGame {
             Value::String(std::rc::Rc::from(key.name().as_str())),
             Value::Bool(is_down),
         ];
+        journal_push("input", &args, Provenance::Input);
         match self.session.call("input", args, &mut FunctorHost) {
             Ok(returned) => self.ctx().absorb(returned),
             Err(err) => self.reporter.frame_error("input", &err),
@@ -760,6 +938,7 @@ impl Game for FunctorLangGame {
             Value::Number(x as f64),
             Value::Number(y as f64),
         ];
+        journal_push("mouseMove", &args, Provenance::MouseMove);
         match self.session.call("mouseMove", args, &mut FunctorHost) {
             Ok(returned) => self.ctx().absorb(returned),
             Err(err) => self.reporter.frame_error("mouseMove", &err),
@@ -773,6 +952,7 @@ impl Game for FunctorLangGame {
             return;
         }
         let args = vec![self.model.clone(), Value::Number(delta as f64)];
+        journal_push("mouseWheel", &args, Provenance::MouseWheel);
         match self.session.call("mouseWheel", args, &mut FunctorHost) {
             Ok(returned) => self.ctx().absorb(returned),
             Err(err) => self.reporter.frame_error("mouseWheel", &err),
@@ -893,6 +1073,40 @@ AudioScene.empty), got {}",
 
     fn state_debug(&self) -> String {
         self.model.to_string()
+    }
+
+    /// The paused-inspector trace (visual-debugger PR2). When NOT paused, a
+    /// cheap early-out: `paused: false` with empty invocations (frame/tts/
+    /// sources still filled). When paused, lazily replay the last real frame's
+    /// journal into the wire-contract `invocations` and CACHE the result until
+    /// the frame advances (`tick`), the scrubbed frame changes, or the program
+    /// reloads. `paused` is the shell's clock state (`GameClock::is_paused`).
+    fn inspector_trace(&mut self, paused: bool) -> String {
+        let frame = self.recorder.current_scene_frame().unwrap_or(0);
+        let tts = self.recorder.current_scene_frame_tts().unwrap_or(0.0);
+        if !paused {
+            return serde_json::json!({
+                "frame": frame,
+                "tts": tts,
+                "paused": false,
+                "sources": self.sources_json(),
+                "invocations": [],
+            })
+            .to_string();
+        }
+        if let Some(cached) = &self.cached_trace {
+            return cached.clone();
+        }
+        let json = serde_json::json!({
+            "frame": frame,
+            "tts": tts,
+            "paused": true,
+            "sources": self.sources_json(),
+            "invocations": self.build_invocations(),
+        })
+        .to_string();
+        self.cached_trace = Some(json.clone());
+        json
     }
 
     fn net_drain_commands(&self) -> String {
@@ -2126,6 +2340,86 @@ mod tests {
         );
 
         physics::remove_world(physics::DEFAULT_WORLD);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // ---- Paused-inspector trace (visual-debugger PR2) -----------------------
+
+    /// A per-second subscription whose `update` fires an `Effect.now` — one
+    /// timer firing drives TWO `update`s in a frame (the message + its effect
+    /// result), so the trace shows `update` count > 1.
+    const INSPECTOR_GAME: &str = "\
+        type Msg = | Tick | GotTime(t: Float)\n\
+        type Model = { ticks: Float, lastTime: Float }\n\
+        let init = { ticks: 0.0, lastTime: 0.0 }\n\
+        let update = (m: Model, msg: Msg) =>\n\
+          match msg with\n\
+          | Tick => ({ m with ticks: m.ticks + 1.0 }, Effect.now((t) => GotTime(t)))\n\
+          | GotTime(t) => { m with lastTime: t }\n\
+        let subscriptions = (m: Model) => Sub.every(Time.seconds(1.0), Tick)\n\
+        let tick = (m: Model, dt: Float, tts: Float) => m\n\
+        let draw = (m: Model, tts: Float) =>\n\
+          Frame.create(Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0), Scene.cube())\n";
+
+    #[test]
+    fn inspector_trace_replays_the_paused_frame_and_is_empty_while_playing() {
+        let dir = std::env::temp_dir().join(format!("functor-inspector-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("game.fun"), INSPECTOR_GAME).unwrap();
+        let mut game = FunctorLangGame::create(dir.join("game.fun").to_str().unwrap());
+
+        // Frame 1 seeds prev_tts (nothing fires on frame one); frame 2 crosses
+        // the 1s boundary → the timer fires.
+        game.tick(FrameTime { dts: 0.9, tts: 0.9 });
+        game.tick(FrameTime { dts: 0.2, tts: 1.1 });
+
+        // NOT paused: the cheap early-out — no replay, empty invocations, but
+        // frame/tts/sources still filled. (Proves the recorder is only armed on
+        // the paused path — `build_invocations` never runs here.)
+        let playing: serde_json::Value =
+            serde_json::from_str(&game.inspector_trace(false)).unwrap();
+        assert_eq!(playing["paused"], serde_json::json!(false));
+        assert_eq!(playing["invocations"].as_array().unwrap().len(), 0);
+        assert!(!playing["sources"].as_array().unwrap().is_empty());
+
+        // PAUSED: the last real frame replays into invocations.
+        let paused: serde_json::Value = serde_json::from_str(&game.inspector_trace(true)).unwrap();
+        assert_eq!(paused["paused"], serde_json::json!(true));
+        let invs = paused["invocations"].as_array().unwrap();
+        let updates: Vec<_> = invs.iter().filter(|i| i["entry"] == "update").collect();
+        assert_eq!(updates.len(), 2, "update count > 1: {invs:#?}");
+        assert_eq!(updates[0]["count"], serde_json::json!(2));
+        assert_eq!(updates[0]["index"], serde_json::json!(0));
+        assert_eq!(
+            updates[0]["provenance"],
+            serde_json::json!("subscription: Tick")
+        );
+        assert!(updates[1]["provenance"]
+            .as_str()
+            .unwrap()
+            .starts_with("effect result: GotTime("));
+        assert_eq!(updates[0]["ghost"], serde_json::json!(false));
+
+        // Bindings map to the entry file with LOCAL byte offsets + values.
+        let bindings = updates[0]["bindings"].as_array().unwrap();
+        assert!(!bindings.is_empty());
+        assert!(bindings.iter().all(|b| b["file"] == "game.fun"));
+        assert!(bindings
+            .iter()
+            .all(|b| b["start"].as_u64().is_some() && b["value"].is_string()));
+
+        // The `tick` invocation is present with its dt provenance.
+        let tick = invs.iter().find(|i| i["entry"] == "tick").unwrap();
+        assert_eq!(tick["provenance"], serde_json::json!("tick dt=0.2"));
+
+        // sources: one entry per project file, each a 64-hex sha256.
+        assert_eq!(paused["sources"][0]["file"], serde_json::json!("game.fun"));
+        assert_eq!(paused["sources"][0]["hash"].as_str().unwrap().len(), 64);
+
+        // A second /trace while still paused is served from cache (identical).
+        assert_eq!(game.inspector_trace(true), game.inspector_trace(true));
+
         let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -613,29 +613,33 @@ impl FunctorLangGame {
     /// entry name; binding spans map to `(file, local offsets)`.
     fn build_invocations(&self) -> Vec<serde_json::Value> {
         use std::collections::HashMap;
-        let mut counts: HashMap<&str, usize> = HashMap::new();
+        // Replay FIRST, then frame: `index`/`count` are computed over the
+        // invocations actually EMITTED, so the array is always consistent with
+        // its own counts (the LSP picker mod-cycles on `count`). A call that
+        // succeeded live, replayed pure, should not fail — skip one
+        // defensively rather than abort the whole trace if it somehow does.
+        let mut replayed = Vec::with_capacity(self.last_frame_journal.len());
         for e in &self.last_frame_journal {
+            if let Ok((_discard, inv)) =
+                self.session
+                    .call_recorded(e.entry, e.args.clone(), &mut FunctorHost)
+            {
+                replayed.push((e, inv));
+            }
+        }
+        let mut counts: HashMap<&str, usize> = HashMap::new();
+        for (e, _) in &replayed {
             *counts.entry(e.entry).or_default() += 1;
         }
         let mut seen: HashMap<&str, usize> = HashMap::new();
-        let mut out = Vec::with_capacity(self.last_frame_journal.len());
-        for e in &self.last_frame_journal {
+        let mut out = Vec::with_capacity(replayed.len());
+        for (e, inv) in &replayed {
             let index = {
                 let c = seen.entry(e.entry).or_default();
                 let i = *c;
                 *c += 1;
                 i
             };
-            // A call that succeeded live, replayed pure, should not fail — skip
-            // it defensively rather than abort the whole trace if it somehow does.
-            let (_discard, inv) =
-                match self
-                    .session
-                    .call_recorded(e.entry, e.args.clone(), &mut FunctorHost)
-                {
-                    Ok(pair) => pair,
-                    Err(_) => continue,
-                };
             let bindings: Vec<serde_json::Value> = inv
                 .bindings
                 .iter()
@@ -1076,24 +1080,26 @@ AudioScene.empty), got {}",
     }
 
     /// The paused-inspector trace (visual-debugger PR2). When NOT paused, a
-    /// cheap early-out: `paused: false` with empty invocations (frame/tts/
-    /// sources still filled). When paused, lazily replay the last real frame's
-    /// journal into the wire-contract `invocations` and CACHE the result until
-    /// the frame advances (`tick`), the scrubbed frame changes, or the program
-    /// reloads. `paused` is the shell's clock state (`GameClock::is_paused`).
+    /// cheap early-out: `paused: false` with empty invocations — and NO
+    /// `frame`/`tts`, which change every frame: the LSP's idle poll dedups on
+    /// the doc bytes, so the unpaused doc must stay byte-identical while the
+    /// sources are unchanged (otherwise every poll would churn a hint/lens
+    /// refresh in the editor). When paused, lazily replay the last real
+    /// frame's journal into the wire-contract `invocations` and CACHE the
+    /// result until the frame advances (`tick`), the scrubbed frame changes,
+    /// or the program reloads. `paused` is the shell's clock state
+    /// (`GameClock::is_paused`).
     fn inspector_trace(&mut self, paused: bool) -> String {
-        let frame = self.recorder.current_scene_frame().unwrap_or(0);
-        let tts = self.recorder.current_scene_frame_tts().unwrap_or(0.0);
         if !paused {
             return serde_json::json!({
-                "frame": frame,
-                "tts": tts,
                 "paused": false,
                 "sources": self.sources_json(),
                 "invocations": [],
             })
             .to_string();
         }
+        let frame = self.recorder.current_scene_frame().unwrap_or(0);
+        let tts = self.recorder.current_scene_frame_tts().unwrap_or(0.0);
         if let Some(cached) = &self.cached_trace {
             return cached.clone();
         }
@@ -1107,6 +1113,22 @@ AudioScene.empty), got {}",
         .to_string();
         self.cached_trace = Some(json.clone());
         json
+    }
+
+    /// Debug input delivered while PAUSED (`POST /input` with the clock
+    /// pinned) journaled its entry-point calls, but no `tick` runs to swap
+    /// them — fold them into the last real frame's journal now, so the
+    /// injection shows up in `GET /trace` as a first-class invocation (with
+    /// its bindings) instead of lingering and leaking into the RESUME frame's
+    /// journal as a phantom. The cached trace is dropped so the next `/trace`
+    /// rebuilds with the injected calls included.
+    fn absorb_paused_input(&mut self) {
+        if let Some(mut entries) = journal_swap() {
+            if !entries.is_empty() {
+                self.last_frame_journal.append(&mut entries);
+                self.cached_trace = None;
+            }
+        }
     }
 
     fn net_drain_commands(&self) -> String {
@@ -2347,7 +2369,8 @@ mod tests {
 
     /// A per-second subscription whose `update` fires an `Effect.now` — one
     /// timer firing drives TWO `update`s in a frame (the message + its effect
-    /// result), so the trace shows `update` count > 1.
+    /// result), so the trace shows `update` count > 1. The `input` hook exists
+    /// for the paused-injection test below.
     const INSPECTOR_GAME: &str = "\
         type Msg = | Tick | GotTime(t: Float)\n\
         type Model = { ticks: Float, lastTime: Float }\n\
@@ -2357,6 +2380,7 @@ mod tests {
           | Tick => ({ m with ticks: m.ticks + 1.0 }, Effect.now((t) => GotTime(t)))\n\
           | GotTime(t) => { m with lastTime: t }\n\
         let subscriptions = (m: Model) => Sub.every(Time.seconds(1.0), Tick)\n\
+        let input = (m: Model, key: String, isDown: Bool) => { m with ticks: m.ticks + 100.0 }\n\
         let tick = (m: Model, dt: Float, tts: Float) => m\n\
         let draw = (m: Model, tts: Float) =>\n\
           Frame.create(Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0), Scene.cube())\n";
@@ -2374,14 +2398,26 @@ mod tests {
         game.tick(FrameTime { dts: 0.9, tts: 0.9 });
         game.tick(FrameTime { dts: 0.2, tts: 1.1 });
 
-        // NOT paused: the cheap early-out — no replay, empty invocations, but
-        // frame/tts/sources still filled. (Proves the recorder is only armed on
+        // NOT paused: the cheap early-out — no replay, empty invocations, and
+        // NO frame/tts (they change every frame; the LSP's idle poll dedups on
+        // the doc bytes, so the unpaused doc must be byte-identical while the
+        // sources are unchanged). (Also proves the recorder is only armed on
         // the paused path — `build_invocations` never runs here.)
-        let playing: serde_json::Value =
-            serde_json::from_str(&game.inspector_trace(false)).unwrap();
+        let playing_doc = game.inspector_trace(false);
+        let playing: serde_json::Value = serde_json::from_str(&playing_doc).unwrap();
         assert_eq!(playing["paused"], serde_json::json!(false));
         assert_eq!(playing["invocations"].as_array().unwrap().len(), 0);
         assert!(!playing["sources"].as_array().unwrap().is_empty());
+        assert!(playing.get("frame").is_none(), "no frame while playing");
+        assert!(playing.get("tts").is_none(), "no tts while playing");
+        // Byte-identical across ticks (sources unchanged) — the dedup contract.
+        game.tick(FrameTime { dts: 0.1, tts: 1.2 });
+        assert_eq!(game.inspector_trace(false), playing_doc);
+        // Restore the frame state the paused assertions below expect (a fresh
+        // last real frame at tts 1.1's shape: tick-only would differ — so
+        // re-run the boundary-crossing frame).
+        game.tick(FrameTime { dts: 0.7, tts: 1.9 });
+        game.tick(FrameTime { dts: 0.2, tts: 2.1 });
 
         // PAUSED: the last real frame replays into invocations.
         let paused: serde_json::Value = serde_json::from_str(&game.inspector_trace(true)).unwrap();
@@ -2419,6 +2455,66 @@ mod tests {
 
         // A second /trace while still paused is served from cache (identical).
         assert_eq!(game.inspector_trace(true), game.inspector_trace(true));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The paused-injection contract (visual-debugger PR2): input delivered
+    /// while PAUSED (the debug server's `POST /input`, followed by the shell's
+    /// `absorb_paused_input` call) folds into the last-frame journal — so it
+    /// shows in `GET /trace` as a first-class invocation with bindings — and
+    /// does NOT leak into the resume frame's journal as a phantom.
+    #[test]
+    fn paused_injected_input_folds_into_the_trace_not_the_resume_frame() {
+        let dir = std::env::temp_dir().join(format!(
+            "functor-inspector-input-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("game.fun"), INSPECTOR_GAME).unwrap();
+        let mut game = FunctorLangGame::create(dir.join("game.fun").to_str().unwrap());
+
+        // One real frame (no timer boundary): the last-frame journal is [tick].
+        game.tick(FrameTime { dts: 0.5, tts: 0.5 });
+
+        // Pause: prime the cached trace, then inject a key (the POST /input
+        // path) and fold — exactly what the shell does while the clock is
+        // paused.
+        let before = game.inspector_trace(true);
+        game.key_event(functor_runtime_common::Key::W as i32, true);
+        game.absorb_paused_input();
+
+        // The cache was invalidated and the injection is now a first-class
+        // invocation with its bindings, appended after the frame's tick.
+        let after = game.inspector_trace(true);
+        assert_ne!(before, after, "cached trace must be invalidated");
+        let doc: serde_json::Value = serde_json::from_str(&after).unwrap();
+        let invs = doc["invocations"].as_array().unwrap();
+        let input = invs
+            .iter()
+            .find(|i| i["entry"] == "input")
+            .expect("injected input invocation");
+        assert_eq!(input["provenance"], serde_json::json!("input: W down"));
+        assert_eq!(input["count"], serde_json::json!(1));
+        assert!(!input["bindings"].as_array().unwrap().is_empty());
+
+        // Resume (a real frame runs): the new frame's journal replaces
+        // everything — no phantom input carried over from the paused injection.
+        game.tick(FrameTime { dts: 0.1, tts: 0.6 });
+        let resumed: serde_json::Value =
+            serde_json::from_str(&game.inspector_trace(true)).unwrap();
+        let entries: Vec<&str> = resumed["invocations"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|i| i["entry"].as_str().unwrap())
+            .collect();
+        assert_eq!(
+            entries,
+            vec!["tick"],
+            "only the resume frame's own entries survive"
+        );
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -613,6 +613,12 @@ fn service_debug_request(
                     Ok(())
                 }
             };
+            // Input injected while PAUSED journals entry-point calls no `tick`
+            // will sweep — fold them into the inspector's last-frame journal so
+            // they show in `GET /trace` now, not as phantoms on resume (PR2).
+            if clock.is_paused() {
+                game.absorb_paused_input();
+            }
             let _ = resp.send(result);
         }
         debug_server::DebugRequest::Time(cmd, resp) => {

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -563,6 +563,12 @@ fn service_debug_request(
                 .unwrap_or_else(|e| format!("{{\"error\":{:?}}}", e.to_string()));
             let _ = resp.send(json);
         }
+        debug_server::DebugRequest::Trace(resp) => {
+            // The paused-inspector trace (visual-debugger PR2). Paused-ness is a
+            // clock property: while paused the last real frame's journal is
+            // stable, so the producer replays it; otherwise it early-outs empty.
+            let _ = resp.send(game.inspector_trace(clock.is_paused()));
+        }
         debug_server::DebugRequest::ReloadSource(source, resp) => {
             let _ = resp.send(game.reload_source(&source));
         }


### PR DESCRIPTION
Part 2 of the paused-scene inspector, **stacked on `inspector-recorder`**: the runtime records what ran in the last real frame and serves it as JSON at `GET /trace` on the debug server.

## Design: zero cost unless paused

During normal play nothing renders `Display` text and the recorder is never armed. Instead the producer keeps a **replay journal**: per entry-point invocation, `(entry, Rc-cloned args, provenance tag)` — a few Rc bumps and a Vec push per frame. Args include the input model, and entry points are pure functions of their args, so on the first `GET /trace` **while paused** the journal is replayed via `call_recorded` to build the full binding-level trace (effects are plain data — replay constructs but never performs them). The trace is cached until the paused frame changes, and rewind/scrub honestly clears it (per-invocation data exists only for the last real frame).

## What's in the trace

Per invocation: entry (`update`/`tick`/`input`/…), `index`/`count` within the frame, **provenance** (why it ran: `subscription: Tick`, `effect result: GotTime(…)`, `tick dt=0.6`, `input: W down`, collision/physics-query/net/http/audio/ui variants), the result, and every binding site's name, file + local byte span, value, and loop count. Plus per-file sha256 of the loaded sources so the editor never overlays values on drifted text. `--ghost` forward-projection dry-runs are excluded. The unpaused doc is intentionally byte-stable (`paused:false`, empty invocations, no frame/tts) so pollers can dedup it.

Injected debug input while paused folds into the trace immediately (new `GameProducer::absorb_paused_input`, default no-op) — pause, `POST /input`, and `/trace` shows that input invocation with its bindings; nothing leaks into the resume frame.

## Verified end-to-end (headless)

`functor -d examples/inspector run native --headless --debug-port 8077`, pause across a timer boundary, `GET /trace`:

```json
{ "frame": 75, "paused": true, "tts": 1.1,
  "sources": [{ "file": "game.fun", "hash": "e2b394…" }],
  "invocations": [
    { "entry":"update","index":0,"count":2,"provenance":"subscription: Tick", "bindings":[…] },
    { "entry":"update","index":1,"count":2,"provenance":"effect result: GotTime(…)", "bindings":[…] },
    { "entry":"tick","index":0,"count":1,"provenance":"tick dt=0.6", "bindings":[…] } ] }
```

Tests: `functor_runtime_common` 268 green (journal provenance/replay-equivalence, paused-frame survival, ghost exclusion, off-is-a-noop), `functor-runtime-desktop` 43 green (trace replay, byte-stable unpaused doc, paused-input fold), strict build clean.

## New example

`examples/inspector` — a minimal `Sub.every` + `Effect.now` fixture whose timer deterministically drives `update` twice in one frame (used by the tests and the curl run above). It is a test fixture, not visual work — still frame for completeness:

![inspector example](https://gist.githubusercontent.com/tommy-xr/8e6a2b316604f0286044759b43417d61/raw/9457e327ce4bae646abd5bda0e4be9bcce1fe84e/inspector.png)

## Stack

- #339 — the recorder this builds on
- **This PR** — journal + `/trace`
- #341 (LSP overlay), #342 (extension) — the editor side (independent)

Follow-ups: wasm postMessage trace events (the web path needs no HTTP), SSE `GET /events` to replace idle polling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)