### PR TITLE
feat(lsp): live-value inlay hints + execution picker from paused traces

### DIFF
--- a/tools/functor-lang-lsp/src/inspector.rs
+++ b/tools/functor-lang-lsp/src/inspector.rs
@@ -1,0 +1,553 @@
+//! The pure half of the paused-scene inspector: a trace document (the wire
+//! contract in `docs`/`visual-debugger-implementation.md`) plus a file's source
+//! text turned into **live-value inlay hints** and a **CodeLens execution
+//! picker**. Like [`functor_lang::inlay`] / [`functor_lang::codelens`], this
+//! module decides *content* (offsets, spans, labels) and the editor server
+//! (`main.rs`) speaks the protocol — so it is unit-testable without an editor,
+//! window, or GPU.
+//!
+//! It lives in the LSP tool crate, not the `functor-lang` crate: the trace is
+//! JSON and the source-hash gate needs SHA-256, and the language crate is
+//! zero-dependency by design (its `Cargo.toml` says so). The only thing it
+//! borrows from `functor-lang` is [`functor_lang::Span`], a plain byte range.
+//!
+//! **Source-hash gate.** Every live hint and picker lens is withheld unless the
+//! trace's recorded SHA-256 for that file matches the SHA-256 of the source the
+//! server currently holds (open buffer, else disk). This is the "never wrong
+//! values on wrong lines" invariant — an edited buffer silently shows no live
+//! data (type hints are unaffected; they come from a different path).
+//!
+//! **Offset convention (a contract note).** The wire contract's binding
+//! `start`/`end` are byte offsets **into that one file's text** (per-file
+//! local), whereas the LSP's project loader works in project-wide offsets
+//! (`file.base + local`). Live-hint offsets returned here are therefore already
+//! file-local and the server renders them with no `base` adjustment; picker
+//! spans, which come from the parsed module, stay project-wide and the server
+//! localizes them with its existing machinery.
+
+use std::collections::HashSet;
+
+use functor_lang::Span;
+use serde_json::Value;
+
+/// One trace document — the last real frame's recorded entry-point
+/// invocations, plus the per-file source hashes that gate them.
+pub struct TraceDoc {
+    pub sources: Vec<SourceHash>,
+    pub invocations: Vec<Invocation>,
+}
+
+/// The SHA-256 (hex) of one project file's text as the runtime loaded it.
+pub struct SourceHash {
+    pub file: String,
+    pub hash: String,
+}
+
+/// One recorded call of an entry point (`update`, `tick`, …) within the frame.
+pub struct Invocation {
+    pub entry: String,
+    /// 0-based order within the frame for this entry name.
+    pub index: usize,
+    /// Total invocations of this entry this frame.
+    pub count: usize,
+    /// Human display string of *why* it ran (opaque to us).
+    pub provenance: String,
+    /// True for `--ghost` forward-projection dry-runs; excluded from display.
+    pub ghost: bool,
+    pub bindings: Vec<Binding>,
+}
+
+/// One binding site's last recorded value.
+pub struct Binding {
+    pub name: String,
+    /// Trace-relative file name (e.g. `game.fun`).
+    pub file: String,
+    /// Byte offsets **into that file's own text** (per-file local).
+    pub start: usize,
+    pub end: usize,
+    /// `Display` text of the (last) bound value.
+    pub value: String,
+    /// Times this site bound during the invocation (loops > 1); `value` is last.
+    pub count: usize,
+}
+
+impl TraceDoc {
+    /// Parse a trace document from the wire-contract JSON. `None` if the shape
+    /// is unrecognizable (missing `sources`/`invocations` arrays); individual
+    /// malformed entries are skipped rather than failing the whole doc.
+    pub fn from_json(v: &Value) -> Option<TraceDoc> {
+        let sources = v["sources"]
+            .as_array()?
+            .iter()
+            .filter_map(|s| {
+                Some(SourceHash {
+                    file: s["file"].as_str()?.to_string(),
+                    hash: s["hash"].as_str()?.to_string(),
+                })
+            })
+            .collect();
+        let invocations = v["invocations"]
+            .as_array()?
+            .iter()
+            .filter_map(Invocation::from_json)
+            .collect();
+        Some(TraceDoc {
+            sources,
+            invocations,
+        })
+    }
+}
+
+impl Invocation {
+    fn from_json(v: &Value) -> Option<Invocation> {
+        let bindings = v["bindings"]
+            .as_array()
+            .map(|arr| arr.iter().filter_map(Binding::from_json).collect())
+            .unwrap_or_default();
+        Some(Invocation {
+            entry: v["entry"].as_str()?.to_string(),
+            index: v["index"].as_u64().unwrap_or(0) as usize,
+            count: v["count"].as_u64().unwrap_or(1).max(1) as usize,
+            provenance: v["provenance"].as_str().unwrap_or("").to_string(),
+            ghost: v["ghost"].as_bool().unwrap_or(false),
+            bindings,
+        })
+    }
+}
+
+impl Binding {
+    fn from_json(v: &Value) -> Option<Binding> {
+        Some(Binding {
+            name: v["name"].as_str()?.to_string(),
+            file: v["file"].as_str()?.to_string(),
+            start: v["start"].as_u64()? as usize,
+            end: v["end"].as_u64()? as usize,
+            value: v["value"].as_str().unwrap_or("").to_string(),
+            count: v["count"].as_u64().unwrap_or(1).max(1) as usize,
+        })
+    }
+}
+
+/// One live-value hint: render `label` (a leading `= …` string) at byte
+/// `offset`, which is **file-local** (see the module offset note).
+pub struct LiveHint {
+    pub offset: usize,
+    pub label: String,
+}
+
+/// One execution-picker lens on an entry-point def. `span` is the def's span in
+/// whatever coordinate space the caller passed (the server passes project-wide
+/// module spans and localizes them itself). The cycle command carries
+/// `[file, entry, current_index]`.
+pub struct PickerLens {
+    pub span: Span,
+    pub title: String,
+    pub entry: String,
+    pub file: String,
+    /// 0-based selected execution, already reduced mod `count`.
+    pub current_index: usize,
+}
+
+/// Whether the server's `source` for `file_name` matches the trace's recorded
+/// hash — the gate for showing any live data. A file with no recorded hash
+/// fails closed (we can't verify, so we show nothing).
+pub fn source_matches(trace: &TraceDoc, file_name: &str, source: &str) -> bool {
+    match trace.sources.iter().find(|s| s.file == file_name) {
+        Some(sh) => sha256_hex(source.as_bytes()) == sh.hash,
+        None => false,
+    }
+}
+
+/// The selected invocation for `entry`: `(invocation, selected_index, count)`.
+/// `count` is the trace-reported total; the raw selection is reduced mod
+/// `count`, and the invocation whose `index` equals that selection is chosen
+/// (falling back to the first). Ghost invocations are excluded. `None` when the
+/// entry has no non-ghost invocations.
+fn selected_invocation<'a>(
+    trace: &'a TraceDoc,
+    entry: &str,
+    selected: &dyn Fn(&str) -> usize,
+) -> Option<(&'a Invocation, usize, usize)> {
+    let group: Vec<&Invocation> = trace
+        .invocations
+        .iter()
+        .filter(|i| i.entry == entry && !i.ghost)
+        .collect();
+    let first = *group.first()?;
+    let count = group.iter().map(|i| i.count).max().unwrap_or(1).max(1);
+    let sel = selected(entry) % count;
+    let inv = group.iter().find(|i| i.index == sel).copied().unwrap_or(first);
+    Some((inv, sel, count))
+}
+
+/// Live-value inlay hints for `file_name`'s `source`, from the selected
+/// execution of each entry point. Empty (silently) when the source hash does
+/// not match the trace. Hints are deduplicated by offset so a helper shared
+/// across two selected invocations doesn't double up.
+pub fn live_hints(
+    trace: &TraceDoc,
+    file_name: &str,
+    source: &str,
+    selected: &dyn Fn(&str) -> usize,
+) -> Vec<LiveHint> {
+    if !source_matches(trace, file_name, source) {
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    for entry in distinct_entries(trace) {
+        let Some((inv, _, _)) = selected_invocation(trace, &entry, selected) else {
+            continue;
+        };
+        for b in &inv.bindings {
+            let offset = hint_offset(source, b);
+            if b.file != file_name || !seen.insert(offset) {
+                continue;
+            }
+            let label = if b.count > 1 {
+                format!("= {} (×{})", b.value, b.count)
+            } else {
+                format!("= {}", b.value)
+            };
+            out.push(LiveHint { offset, label });
+        }
+    }
+    out
+}
+
+/// Execution-picker lenses for the entry-point defs in `file_name`. `entry_defs`
+/// is `(def_name, def_span)` for the file's top-level defs (the server pulls
+/// these from the parsed module); a def gets a lens iff the trace has an
+/// invocation for its name. Empty (silently) on a source-hash mismatch.
+pub fn picker_lenses(
+    trace: &TraceDoc,
+    file_name: &str,
+    source: &str,
+    entry_defs: &[(String, Span)],
+    selected: &dyn Fn(&str) -> usize,
+) -> Vec<PickerLens> {
+    if !source_matches(trace, file_name, source) {
+        return Vec::new();
+    }
+    entry_defs
+        .iter()
+        .filter_map(|(name, span)| {
+            let (inv, sel, count) = selected_invocation(trace, name, selected)?;
+            let title = if count == 1 {
+                format!("{name} — 1 execution")
+            } else {
+                format!("{name} — execution {}/{} ▸ [{}]", sel + 1, count, inv.provenance)
+            };
+            Some(PickerLens {
+                span: *span,
+                title,
+                entry: name.clone(),
+                file: file_name.to_string(),
+                current_index: sel,
+            })
+        })
+        .collect()
+}
+
+/// Where to render a binding's `= value` hint: **just after the binder name**.
+///
+/// Per the PR1 contract, a binding's span is name-precise only for lambda/match
+/// binders; a `let` binder's span is the whole `let [mut] name =` **region**, so
+/// its `end` sits after the `=`, not after the name. We therefore locate the
+/// `name` text within the span (`rfind`, so the binder — not a `let`/`mut`
+/// keyword — wins) and place the hint right after it, falling back to the span
+/// end when the source slice is unusable or the name isn't found.
+fn hint_offset(source: &str, b: &Binding) -> usize {
+    match source.get(b.start..b.end) {
+        Some(region) => match region.rfind(&b.name) {
+            Some(i) => b.start + i + b.name.len(),
+            None => b.end,
+        },
+        None => b.end,
+    }
+}
+
+/// Distinct entry names in first-seen order.
+fn distinct_entries(trace: &TraceDoc) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut out = Vec::new();
+    for inv in &trace.invocations {
+        if !inv.ghost && seen.insert(inv.entry.clone()) {
+            out.push(inv.entry.clone());
+        }
+    }
+    out
+}
+
+/// The number of executions the trace holds for `entry` (its reported `count`),
+/// or 0 if the entry is absent. Used by the server to cycle the picker index.
+pub fn execution_count(trace: &TraceDoc, entry: &str) -> usize {
+    trace
+        .invocations
+        .iter()
+        .filter(|i| i.entry == entry && !i.ghost)
+        .map(|i| i.count)
+        .max()
+        .unwrap_or(0)
+}
+
+/// SHA-256 of `bytes` as lowercase hex. Hand-rolled (FIPS 180-4) to keep the
+/// LSP crate's dependency set at `serde_json` only — matching the crate's
+/// "deliberately tiny" charter. Verified against the standard `"abc"` vector in
+/// tests.
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    const K: [u32; 64] = [
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4,
+        0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe,
+        0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f,
+        0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+        0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
+        0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+        0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116,
+        0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7,
+        0xc67178f2,
+    ];
+    let mut h: [u32; 8] = [
+        0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab,
+        0x5be0cd19,
+    ];
+
+    // Pad: append 0x80, then zeros to 56 mod 64, then the 64-bit bit length.
+    let mut msg = bytes.to_vec();
+    let bit_len = (bytes.len() as u64).wrapping_mul(8);
+    msg.push(0x80);
+    while msg.len() % 64 != 56 {
+        msg.push(0);
+    }
+    msg.extend_from_slice(&bit_len.to_be_bytes());
+
+    for chunk in msg.chunks_exact(64) {
+        let mut w = [0u32; 64];
+        for (i, word) in w.iter_mut().enumerate().take(16) {
+            let j = i * 4;
+            *word = u32::from_be_bytes([chunk[j], chunk[j + 1], chunk[j + 2], chunk[j + 3]]);
+        }
+        for i in 16..64 {
+            let s0 = w[i - 15].rotate_right(7) ^ w[i - 15].rotate_right(18) ^ (w[i - 15] >> 3);
+            let s1 = w[i - 2].rotate_right(17) ^ w[i - 2].rotate_right(19) ^ (w[i - 2] >> 10);
+            w[i] = w[i - 16]
+                .wrapping_add(s0)
+                .wrapping_add(w[i - 7])
+                .wrapping_add(s1);
+        }
+        let mut v = h;
+        for i in 0..64 {
+            let s1 = v[4].rotate_right(6) ^ v[4].rotate_right(11) ^ v[4].rotate_right(25);
+            let ch = (v[4] & v[5]) ^ (!v[4] & v[6]);
+            let t1 = v[7]
+                .wrapping_add(s1)
+                .wrapping_add(ch)
+                .wrapping_add(K[i])
+                .wrapping_add(w[i]);
+            let s0 = v[0].rotate_right(2) ^ v[0].rotate_right(13) ^ v[0].rotate_right(22);
+            let maj = (v[0] & v[1]) ^ (v[0] & v[2]) ^ (v[1] & v[2]);
+            let t2 = s0.wrapping_add(maj);
+            v[7] = v[6];
+            v[6] = v[5];
+            v[5] = v[4];
+            v[4] = v[3].wrapping_add(t1);
+            v[3] = v[2];
+            v[2] = v[1];
+            v[1] = v[0];
+            v[0] = t1.wrapping_add(t2);
+        }
+        for (hi, vi) in h.iter_mut().zip(v.iter()) {
+            *hi = hi.wrapping_add(*vi);
+        }
+    }
+
+    let mut hex = String::with_capacity(64);
+    for word in h {
+        hex.push_str(&format!("{word:08x}"));
+    }
+    hex
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // A trace whose one file's hash matches SHA-256("<source>").
+    fn trace_for(source: &str, invocations: Value) -> TraceDoc {
+        let doc = json!({
+            "paused": true,
+            "sources": [ { "file": "game.fun", "hash": sha256_hex(source.as_bytes()) } ],
+            "invocations": invocations,
+        });
+        TraceDoc::from_json(&doc).expect("parse trace")
+    }
+
+    fn no_selection() -> impl Fn(&str) -> usize {
+        |_| 0
+    }
+
+    #[test]
+    fn sha256_matches_the_standard_abc_vector() {
+        assert_eq!(
+            sha256_hex(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+        assert_eq!(
+            sha256_hex(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn live_hints_render_value_at_binding_end() {
+        let src = "let update = (model, msg) =>\n  let velocity = model in\n  velocity\n";
+        let start = src.find("velocity").unwrap();
+        let end = start + "velocity".len();
+        let trace = trace_for(
+            src,
+            json!([{
+                "entry": "update", "index": 0, "count": 1, "provenance": "tick dt=0.016",
+                "ghost": false, "result": "0",
+                "bindings": [{
+                    "name": "velocity", "file": "game.fun",
+                    "start": start, "end": end,
+                    "value": "{ x = 0.0, y = -9.8 }", "count": 1
+                }]
+            }]),
+        );
+        let hints = live_hints(&trace, "game.fun", src, &no_selection());
+        assert_eq!(hints.len(), 1);
+        assert_eq!(hints[0].offset, end);
+        assert_eq!(hints[0].label, "= { x = 0.0, y = -9.8 }");
+    }
+
+    #[test]
+    fn live_hints_place_after_name_for_a_region_shaped_span() {
+        // PR1's `let` binder spans cover the `let name =` REGION, not just the
+        // name. The hint must still land right after the binder name.
+        let src = "let update = (model, msg) =>\n  let velocity = model in\n  velocity\n";
+        let region_start = src.match_indices("let").nth(1).unwrap().0; // inner `let`
+        let name_pos = region_start + src[region_start..].find("velocity").unwrap();
+        let value_pos = name_pos + src[name_pos..].find("model").unwrap(); // `= model`
+        let expected = name_pos + "velocity".len();
+        let trace = trace_for(
+            src,
+            json!([{
+                "entry": "update", "index": 0, "count": 1, "provenance": "p",
+                "ghost": false, "result": "0",
+                "bindings": [{
+                    "name": "velocity", "file": "game.fun",
+                    "start": region_start, "end": value_pos,
+                    "value": "{ x = 0.0, y = -9.8 }", "count": 1
+                }]
+            }]),
+        );
+        let hints = live_hints(&trace, "game.fun", src, &no_selection());
+        assert_eq!(hints.len(), 1);
+        assert_eq!(hints[0].offset, expected);
+        assert_eq!(&src[..hints[0].offset].chars().rev().take(8).collect::<String>(), "yticolev");
+    }
+
+    #[test]
+    fn live_hints_show_loop_count_when_greater_than_one() {
+        let src = "let tick = (m, dt, tts) =>\n  let acc = m in\n  acc\n";
+        let start = src.find("acc").unwrap();
+        let end = start + "acc".len();
+        let trace = trace_for(
+            src,
+            json!([{
+                "entry": "tick", "index": 0, "count": 1, "provenance": "tick dt=0.016",
+                "ghost": false, "result": "0",
+                "bindings": [{
+                    "name": "acc", "file": "game.fun", "start": start, "end": end,
+                    "value": "42", "count": 8
+                }]
+            }]),
+        );
+        let hints = live_hints(&trace, "game.fun", src, &no_selection());
+        assert_eq!(hints.len(), 1);
+        assert_eq!(hints[0].label, "= 42 (×8)");
+    }
+
+    #[test]
+    fn source_hash_mismatch_yields_no_live_data() {
+        let src = "let update = (model, msg) =>\n  let velocity = model in\n  velocity\n";
+        let start = src.find("velocity").unwrap();
+        let end = start + "velocity".len();
+        let mut trace = trace_for(
+            src,
+            json!([{
+                "entry": "update", "index": 0, "count": 1, "provenance": "p",
+                "ghost": false, "result": "0",
+                "bindings": [{ "name":"velocity","file":"game.fun","start":start,"end":end,"value":"1","count":1 }]
+            }]),
+        );
+        // Corrupt the recorded hash so the gate closes.
+        trace.sources[0].hash = "deadbeef".to_string();
+        assert!(live_hints(&trace, "game.fun", src, &no_selection()).is_empty());
+        let defs = vec![("update".to_string(), Span::new(4, 10))];
+        assert!(picker_lenses(&trace, "game.fun", src, &defs, &no_selection()).is_empty());
+    }
+
+    #[test]
+    fn picker_lens_multi_execution_shows_index_and_provenance() {
+        let src = "let update = (model, msg) => model\n";
+        let invs = json!([
+            { "entry":"update","index":0,"count":3,"provenance":"subscription: Tick","ghost":false,"result":"0","bindings":[] },
+            { "entry":"update","index":1,"count":3,"provenance":"effect result: Pong","ghost":false,"result":"0","bindings":[] },
+            { "entry":"update","index":2,"count":3,"provenance":"input: Space down","ghost":false,"result":"0","bindings":[] }
+        ]);
+        let trace = trace_for(src, invs);
+        let defs = vec![("update".to_string(), Span::new(0, 34))];
+        // Select execution index 1.
+        let selected = |e: &str| if e == "update" { 1 } else { 0 };
+        let lenses = picker_lenses(&trace, "game.fun", src, &defs, &selected);
+        assert_eq!(lenses.len(), 1);
+        assert_eq!(lenses[0].title, "update — execution 2/3 ▸ [effect result: Pong]");
+        assert_eq!(lenses[0].current_index, 1);
+        assert_eq!(lenses[0].entry, "update");
+    }
+
+    #[test]
+    fn picker_lens_single_execution_reads_one_execution() {
+        let src = "let tick = (m, dt, tts) => m\n";
+        let trace = trace_for(
+            src,
+            json!([{ "entry":"tick","index":0,"count":1,"provenance":"tick dt=0.016","ghost":false,"result":"0","bindings":[] }]),
+        );
+        let defs = vec![("tick".to_string(), Span::new(0, 28))];
+        let lenses = picker_lenses(&trace, "game.fun", src, &defs, &no_selection());
+        assert_eq!(lenses.len(), 1);
+        assert_eq!(lenses[0].title, "tick — 1 execution");
+    }
+
+    #[test]
+    fn selection_beyond_count_wraps_modulo() {
+        let src = "let update = (model, msg) => model\n";
+        let invs = json!([
+            { "entry":"update","index":0,"count":2,"provenance":"a","ghost":false,"result":"0","bindings":[] },
+            { "entry":"update","index":1,"count":2,"provenance":"b","ghost":false,"result":"0","bindings":[] }
+        ]);
+        let trace = trace_for(src, invs);
+        let defs = vec![("update".to_string(), Span::new(0, 34))];
+        // Raw index 5 % 2 == 1 → the "b" execution.
+        let selected = |_: &str| 5usize;
+        let lenses = picker_lenses(&trace, "game.fun", src, &defs, &selected);
+        assert_eq!(lenses[0].title, "update — execution 2/2 ▸ [b]");
+        assert_eq!(lenses[0].current_index, 1);
+    }
+
+    #[test]
+    fn ghost_invocations_are_ignored() {
+        let src = "let update = (model, msg) => model\n";
+        let trace = trace_for(
+            src,
+            json!([{ "entry":"update","index":0,"count":1,"provenance":"ghost","ghost":true,"result":"0","bindings":[] }]),
+        );
+        let defs = vec![("update".to_string(), Span::new(0, 34))];
+        assert!(picker_lenses(&trace, "game.fun", src, &defs, &no_selection()).is_empty());
+        assert_eq!(execution_count(&trace, "update"), 0);
+    }
+}

--- a/tools/functor-lang-lsp/src/main.rs
+++ b/tools/functor-lang-lsp/src/main.rs
@@ -18,22 +18,71 @@
 //! `functor_lang::inlay`), and `textDocument/codeLens` (each top-level def's inferred
 //! signature above it, via `functor_lang::codelens`). Diagnostics cover parse,
 //! lowering, and every `functor_lang::check` type diagnostic.
+//!
+//! On top of that it hosts the **paused-scene inspector** (see [`inspector`]):
+//! it ingests a runtime trace document — pushed via the custom notification
+//! `functor/inspector/trace`, or pulled by polling `GET /trace` after
+//! `functor/inspector/attach {port}` — and overlays live binding values as
+//! inlay hints plus a click-to-cycle execution-picker code lens (command
+//! `functor.inspector.cycleExecution`), gated on a per-file source-hash match so
+//! stale buffers never show values on the wrong lines. Any trace or selection
+//! change triggers server-initiated `workspace/inlayHint/refresh` and
+//! `workspace/codeLens/refresh` requests.
+
+mod inspector;
 
 use std::collections::HashMap;
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::Sender;
+use std::sync::Arc;
 
 use serde_json::{json, Value};
+
+use inspector::TraceDoc;
 
 /// JSON-RPC "method not found" (LSP inherits JSON-RPC 2.0 error codes).
 const METHOD_NOT_FOUND: i64 = -32601;
 /// JSON-RPC "invalid request" — requests after `shutdown`.
 const INVALID_REQUEST: i64 = -32600;
 
+/// A message arriving on the multiplexed channel: a framed message (from stdin
+/// or an attach-poll thread), or the stdin reader hitting EOF. `Eof` ends the
+/// loop even though attach-poll senders (which never close on their own) keep
+/// the channel otherwise alive.
+enum Incoming {
+    Msg(Value),
+    Eof,
+}
+
 fn main() {
-    let stdin = std::io::stdin();
+    // Multiplex two message sources into one queue: stdin (the LSP client) and
+    // background attach-poll threads (which inject `functor/inspector/trace`
+    // notifications). A dedicated thread reads framed stdin messages so the main
+    // loop can block on the shared channel.
+    let (tx, rx) = std::sync::mpsc::channel::<Incoming>();
+    let stdin_tx = tx.clone();
+    std::thread::spawn(move || {
+        let stdin = std::io::stdin();
+        let mut reader = BufReader::new(stdin.lock());
+        while let Some(message) = read_message(&mut reader) {
+            if stdin_tx.send(Incoming::Msg(message)).is_err() {
+                return;
+            }
+        }
+        let _ = stdin_tx.send(Incoming::Eof); // client vanished — stop the loop
+    });
     let stdout = std::io::stdout();
-    let code = serve(&mut BufReader::new(stdin.lock()), &mut stdout.lock());
+    let mut writer = stdout.lock();
+    let code = run(
+        &mut || match rx.recv() {
+            Ok(Incoming::Msg(message)) => Some(message),
+            Ok(Incoming::Eof) | Err(_) => None,
+        },
+        &mut writer,
+        tx,
+    );
     std::process::exit(code);
 }
 
@@ -41,7 +90,25 @@ fn main() {
 /// requests (messages with an `id`) and notifications. Returns the process
 /// exit code: per the LSP spec, `exit` after `shutdown` is 0, `exit` without
 /// it is 1 (EOF — the client vanished — is a quiet 0).
+#[cfg(test)]
 fn serve(reader: &mut impl BufRead, writer: &mut impl Write) -> i32 {
+    // The synchronous single-source loop used by the tests: stdin only. Attach
+    // polling is a `main`-only concern (its trace notifications arrive on the
+    // channel `main` drains), so the receiver is dropped here.
+    let (trace_tx, _trace_rx) = std::sync::mpsc::channel::<Incoming>();
+    run(&mut || read_message(reader), writer, trace_tx)
+}
+
+/// The server core: pull messages from `next` (stdin in tests; a stdin+attach
+/// multiplexed channel in `main`) and dispatch them, writing replies and
+/// server-initiated requests to `writer`. `trace_tx` is handed to attach-poll
+/// threads so a fetched trace re-enters here as a `functor/inspector/trace`
+/// notification.
+fn run(
+    next: &mut dyn FnMut() -> Option<Value>,
+    writer: &mut impl Write,
+    trace_tx: Sender<Incoming>,
+) -> i32 {
     let mut shutdown_seen = false;
     let mut documents: HashMap<String, String> = HashMap::new();
     // The last-good parsed project per URI, for completion. Completion fires on
@@ -49,7 +116,22 @@ fn serve(reader: &mut impl BufRead, writer: &mut impl Write) -> i32 {
     // `None`; keeping the previous good load lets us still answer. A failed
     // refresh retains the previous entry — that IS "last good".
     let mut projects: HashMap<String, functor_lang::project::Project> = HashMap::new();
-    while let Some(message) = read_message(reader) {
+    // Inspector overlay state: the latest trace (parsed + its raw params, for
+    // change detection), the per-entry selected execution index (raw; reduced
+    // mod count at display), a monotonic id for server→client requests, and
+    // the live attach poller's cancel flag.
+    let mut trace: Option<TraceDoc> = None;
+    let mut last_trace_params: Option<Value> = None;
+    let mut selected: HashMap<String, usize> = HashMap::new();
+    let mut next_request_id: i64 = 1;
+    let mut attach_stop: Option<Arc<AtomicBool>> = None;
+    while let Some(message) = next() {
+        // A message with an `id` but no `method` is the client's response to one
+        // of our server-initiated refresh requests: fire-and-forget, so tolerate
+        // the reply arriving whenever and never try to "answer" it.
+        if message.get("method").is_none() {
+            continue;
+        }
         let method = message["method"].as_str().unwrap_or("").to_string();
         let id = message.get("id").cloned();
         let params = &message["params"];
@@ -79,6 +161,9 @@ fn serve(reader: &mut impl BufRead, writer: &mut impl Write) -> i32 {
                         "inlayHintProvider": true,
                         "codeLensProvider": { "resolveProvider": false },
                         "completionProvider": { "triggerCharacters": ["."] },
+                        "executeCommandProvider": {
+                            "commands": ["functor.inspector.cycleExecution"],
+                        },
                     },
                     "serverInfo": { "name": "functor-lang-lsp" },
                 });
@@ -120,26 +205,55 @@ fn serve(reader: &mut impl BufRead, writer: &mut impl Write) -> i32 {
             }
             ("textDocument/inlayHint", Some(id)) => {
                 let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
-                let result = documents
+                // Type hints (project-derived) merged with live-value hints
+                // (trace-derived, hash-gated) — the two are independent so live
+                // values still show even when the buffer fails to check.
+                let mut hints = documents
                     .contains_key(uri)
                     .then(|| inlay_hints(uri, &documents, &params["range"]))
                     .flatten()
-                    .unwrap_or_else(|| json!([]));
+                    .and_then(|v| v.as_array().cloned())
+                    .unwrap_or_default();
+                hints.extend(live_inlay_hints(
+                    uri,
+                    &documents,
+                    trace.as_ref(),
+                    &selected,
+                    &params["range"],
+                ));
                 write_message(
                     writer,
-                    &json!({ "jsonrpc": "2.0", "id": id, "result": result }),
+                    &json!({ "jsonrpc": "2.0", "id": id, "result": Value::Array(hints) }),
                 );
             }
             ("textDocument/codeLens", Some(id)) => {
                 let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
-                let result = documents
+                // Signature lenses merged with the execution-picker lens.
+                let mut lenses = documents
                     .contains_key(uri)
                     .then(|| code_lenses(uri, &documents))
                     .flatten()
-                    .unwrap_or_else(|| json!([]));
+                    .and_then(|v| v.as_array().cloned())
+                    .unwrap_or_default();
+                lenses.extend(picker_code_lenses(
+                    uri,
+                    &documents,
+                    trace.as_ref(),
+                    &selected,
+                ));
                 write_message(
                     writer,
-                    &json!({ "jsonrpc": "2.0", "id": id, "result": result }),
+                    &json!({ "jsonrpc": "2.0", "id": id, "result": Value::Array(lenses) }),
+                );
+            }
+            ("workspace/executeCommand", Some(id)) => {
+                if params["command"].as_str() == Some("functor.inspector.cycleExecution") {
+                    cycle_execution(&params["arguments"], trace.as_ref(), &mut selected);
+                    refresh_overlays(writer, &mut next_request_id);
+                }
+                write_message(
+                    writer,
+                    &json!({ "jsonrpc": "2.0", "id": id, "result": Value::Null }),
                 );
             }
             ("textDocument/completion", Some(id)) => {
@@ -200,6 +314,34 @@ fn serve(reader: &mut impl BufRead, writer: &mut impl Write) -> i32 {
                 projects.remove(uri);
                 // Clear stale squiggles for the closed file.
                 write_diagnostics(writer, uri, vec![]);
+            }
+            // A pushed trace (extension relay, wasm postMessage, tests, or the
+            // attach poller re-entering): replace the overlay and refresh.
+            // Refresh is event-driven — a document identical to the last one
+            // (e.g. an idle unpaused poll returning the same tiny `paused:false`
+            // JSON) causes no rebuild and no refresh.
+            ("functor/inspector/trace", None) => {
+                if last_trace_params.as_ref() == Some(params) {
+                    continue;
+                }
+                if let Some(doc) = TraceDoc::from_json(params) {
+                    last_trace_params = Some(params.clone());
+                    trace = Some(doc);
+                    refresh_overlays(writer, &mut next_request_id);
+                }
+            }
+            // Native refresh: poll `GET /trace` on a background thread. Attach
+            // persists until `{"port": null}` (or any non-number) detaches.
+            ("functor/inspector/attach", None) => {
+                if let Some(stop) = attach_stop.take() {
+                    stop.store(true, Ordering::SeqCst);
+                }
+                if let Some(port) = params["port"].as_u64() {
+                    let stop = Arc::new(AtomicBool::new(false));
+                    attach_stop = Some(stop.clone());
+                    let tx = trace_tx.clone();
+                    std::thread::spawn(move || poll_attached(port as u16, tx, stop));
+                }
             }
             // initialized, $/… and any other notification: deliberately ignored.
             (_, None) => {}
@@ -325,6 +467,227 @@ fn code_lenses(uri: &str, documents: &HashMap<String, String>) -> Option<Value> 
         })
         .collect();
     Some(Value::Array(lenses))
+}
+
+/// The live-value inlay hints for `uri` as LSP hints. Independent of the
+/// project load — it needs only the open-buffer (or on-disk) source text and
+/// the hash-gated trace — so live values still show when the buffer fails to
+/// check. Merged with the type hints by the caller.
+fn live_inlay_hints(
+    uri: &str,
+    documents: &HashMap<String, String>,
+    trace: Option<&TraceDoc>,
+    selected: &HashMap<String, usize>,
+    range: &Value,
+) -> Vec<Value> {
+    let Some(trace) = trace else {
+        return Vec::new();
+    };
+    let Some(path) = uri_to_path(uri) else {
+        return Vec::new();
+    };
+    let Some(file_name) = match_trace_file(trace, &path) else {
+        return Vec::new();
+    };
+    let source = source_text(uri, documents, &path);
+    let select = |entry: &str| selected.get(entry).copied().unwrap_or(0);
+    // The client's range is local to the file; live-hint offsets are already
+    // file-local trace byte offsets, so both compare directly (no `base`).
+    let start = position_to_offset(&source, &range["start"]);
+    let end = position_to_offset(&source, &range["end"]);
+    let in_range = |offset: usize| match (start, end) {
+        (Some(s), Some(e)) => s <= offset && offset < e,
+        _ => true,
+    };
+    inspector::live_hints(trace, &file_name, &source, &select)
+        .into_iter()
+        .filter(|hint| in_range(hint.offset))
+        .map(|hint| {
+            json!({
+                "position": lsp_position(&source, hint.offset),
+                "label": hint.label,
+                "paddingLeft": true,
+                "paddingRight": false,
+            })
+        })
+        .collect()
+}
+
+/// The execution-picker lenses for `uri`: one clickable lens per entry-point
+/// def whose name the trace recorded, cycling executions via
+/// `functor.inspector.cycleExecution`. The source-hash gate lives in the pure
+/// half; on a mismatch (or no trace) this is empty.
+fn picker_code_lenses(
+    uri: &str,
+    documents: &HashMap<String, String>,
+    trace: Option<&TraceDoc>,
+    selected: &HashMap<String, usize>,
+) -> Vec<Value> {
+    let Some(trace) = trace else {
+        return Vec::new();
+    };
+    let Some(project) = load_project(uri, documents) else {
+        return Vec::new();
+    };
+    let Some(path) = uri_to_path(uri) else {
+        return Vec::new();
+    };
+    let Some(file) = project.sources.file_by_path(&path) else {
+        return Vec::new();
+    };
+    let Some(file_name) = match_trace_file(trace, &path) else {
+        return Vec::new();
+    };
+    // Every top-level def in this file (project-wide span); the pure half keeps
+    // only those the trace has an invocation for.
+    let entry_defs: Vec<(String, functor_lang::Span)> = project
+        .module
+        .defs
+        .iter()
+        .filter(|def| owns(file, def.span.start))
+        .map(|def| (def.name.clone(), def.span))
+        .collect();
+    let select = |entry: &str| selected.get(entry).copied().unwrap_or(0);
+    inspector::picker_lenses(trace, &file_name, &file.src, &entry_defs, &select)
+        .into_iter()
+        .map(|lens| {
+            json!({
+                "range": local_range(file, lens.span),
+                "command": {
+                    "title": lens.title,
+                    "command": "functor.inspector.cycleExecution",
+                    "arguments": [lens.file, lens.entry, lens.current_index],
+                },
+            })
+        })
+        .collect()
+}
+
+/// Advance the selected execution for a `cycleExecution` command by one (mod
+/// the entry's execution count). Args are `[file, entry, currentIndex]`; the
+/// clicked lens's `currentIndex` is authoritative.
+fn cycle_execution(
+    arguments: &Value,
+    trace: Option<&TraceDoc>,
+    selected: &mut HashMap<String, usize>,
+) {
+    let Some(args) = arguments.as_array() else {
+        return;
+    };
+    let Some(entry) = args.get(1).and_then(|v| v.as_str()) else {
+        return;
+    };
+    let current = args.get(2).and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+    let count = trace
+        .map(|t| inspector::execution_count(t, entry))
+        .unwrap_or(0);
+    if count > 0 {
+        selected.insert(entry.to_string(), (current + 1) % count);
+    }
+}
+
+/// Ask the client to re-pull inlay hints and code lenses — server-initiated
+/// requests with ids from the server counter. Fire-and-forget: the client's
+/// responses are tolerated whenever (and ignored on arrival).
+fn refresh_overlays(writer: &mut impl Write, next_request_id: &mut i64) {
+    for method in ["workspace/inlayHint/refresh", "workspace/codeLens/refresh"] {
+        let id = *next_request_id;
+        *next_request_id += 1;
+        write_message(
+            writer,
+            &json!({ "jsonrpc": "2.0", "id": id, "method": method }),
+        );
+    }
+}
+
+/// The server's current text for a file: the open buffer wins over disk, so
+/// unsaved edits participate in the source-hash gate.
+fn source_text(uri: &str, documents: &HashMap<String, String>, path: &Path) -> String {
+    documents
+        .get(uri)
+        .cloned()
+        .unwrap_or_else(|| std::fs::read_to_string(path).unwrap_or_default())
+}
+
+/// The trace-relative file name (e.g. `game.fun`) whose path suffix matches
+/// `path`. The wire contract keys sources/bindings by project-relative name;
+/// the LSP holds absolute paths, so we match on a `/`-boundary suffix.
+fn match_trace_file(trace: &TraceDoc, path: &Path) -> Option<String> {
+    let path = path.to_string_lossy();
+    trace
+        .sources
+        .iter()
+        .find(|source| {
+            let file = source.file.as_str();
+            path == file || path.ends_with(&format!("/{file}"))
+        })
+        .map(|source| source.file.clone())
+}
+
+/// Fetch and parse `GET http://<addr>/trace`. Hand-rolled HTTP/1.1 over TCP
+/// (`Connection: close`, so read-to-EOF yields the whole body) to avoid an
+/// HTTP-client dependency — the endpoint is always the localhost debug server,
+/// whose tiny_http responses always carry a Content-Length body (never
+/// chunked), so the bytes after the header block are the JSON. `None` on any
+/// connection/read/parse failure.
+fn fetch_trace(addr: &str) -> Option<Value> {
+    let mut stream = std::net::TcpStream::connect(addr).ok()?;
+    stream
+        .set_read_timeout(Some(std::time::Duration::from_secs(2)))
+        .ok()?;
+    let request = format!("GET /trace HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n");
+    stream.write_all(request.as_bytes()).ok()?;
+    let mut response = Vec::new();
+    stream.read_to_end(&mut response).ok()?;
+    let split = find_subslice(&response, b"\r\n\r\n")?;
+    serde_json::from_slice(&response[split + 4..]).ok()
+}
+
+/// The index of the first occurrence of `needle` in `haystack`.
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+/// Poll `GET /trace` on `127.0.0.1:<port>`, re-injecting each *changed* trace
+/// as a `functor/inspector/trace` notification on `tx`. Attach **persists
+/// until explicit detach** (`stop`, or a dropped receiver): it fetches once on
+/// attach, polls ~2Hz while the last response said `paused: true`, and idles
+/// ~1Hz when unpaused (or unreachable) — never self-stopping, so a fresh pause
+/// is discovered without any extension-side signal. Event-driven-ness governs
+/// *refresh*, not discovery: a response identical to the last one is not
+/// re-sent (and the trace handler dedupes again for the push path), so an idle
+/// unpaused poll of the tiny `paused:false` JSON causes no downstream work.
+fn poll_attached(port: u16, tx: Sender<Incoming>, stop: Arc<AtomicBool>) {
+    let addr = format!("127.0.0.1:{port}");
+    let mut paused = false;
+    let mut last_sent: Option<Value> = None;
+    loop {
+        if stop.load(Ordering::SeqCst) {
+            return;
+        }
+        if let Some(doc) = fetch_trace(&addr) {
+            paused = doc["paused"].as_bool().unwrap_or(false);
+            if last_sent.as_ref() != Some(&doc) {
+                let message = json!({
+                    "jsonrpc": "2.0",
+                    "method": "functor/inspector/trace",
+                    "params": doc.clone(),
+                });
+                if tx.send(Incoming::Msg(message)).is_err() {
+                    return;
+                }
+                last_sent = Some(doc);
+            }
+        }
+        // ~2Hz paused, ~1Hz idle; wake promptly on detach.
+        let ticks = if paused { 5 } else { 10 };
+        for _ in 0..ticks {
+            if stop.load(Ordering::SeqCst) {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+    }
 }
 
 /// Answer an inlay-hint request: load the project and return an inferred-type
@@ -741,5 +1104,332 @@ mod codex_review_tests {
         let out = String::from_utf8(out).unwrap();
         assert!(!out.contains("publishDiagnostics"), "out: {out}");
         assert!(out.contains("-32600"), "out: {out}");
+    }
+}
+
+#[cfg(test)]
+mod inspector_server_tests {
+    use super::*;
+    use std::collections::VecDeque;
+    use std::net::TcpListener;
+    use std::time::Duration;
+
+    // The entry-point fixture: a `let` binder inside `update` whose recorded
+    // value the inspector renders inline.
+    const FIXTURE: &str = "let update = (model, msg) =>\n  let velocity = model in\n  velocity\n";
+    const URI: &str = "file:///tmp/functor_lsp_inspector_test_xyz/game.fun";
+
+    // Drive `run` to completion over a fixed message queue, returning every
+    // message the server wrote (responses, notifications, and its own
+    // server→client requests), in order.
+    fn drive(messages: Vec<Value>) -> Vec<Value> {
+        let mut queue: VecDeque<Value> = messages.into();
+        let mut out: Vec<u8> = Vec::new();
+        let (trace_tx, _rx) = std::sync::mpsc::channel::<Incoming>();
+        run(&mut || queue.pop_front(), &mut out, trace_tx);
+        let mut reader: &[u8] = &out;
+        let mut parsed = Vec::new();
+        while let Some(message) = read_message(&mut reader) {
+            parsed.push(message);
+        }
+        parsed
+    }
+
+    // The `velocity` let-binder as a REGION span (start of the inner `let`
+    // through the value expr's start) — the PR1 convention.
+    fn velocity_region() -> (usize, usize, usize) {
+        let region_start = FIXTURE.match_indices("let").nth(1).unwrap().0;
+        let name_pos = region_start + FIXTURE[region_start..].find("velocity").unwrap();
+        let value_pos = name_pos + FIXTURE[name_pos..].find("model").unwrap();
+        (region_start, value_pos, name_pos + "velocity".len())
+    }
+
+    // A 5-execution `update` trace whose hash matches `text`; execution 0 binds
+    // `velocity`, the rest carry only distinct provenance for the picker.
+    fn trace_message(text: &str) -> Value {
+        let (start, end, _) = velocity_region();
+        let mut invocations = vec![json!({
+            "entry": "update", "index": 0, "count": 5, "provenance": "subscription: Tick",
+            "ghost": false, "result": "0",
+            "bindings": [{
+                "name": "velocity", "file": "game.fun",
+                "start": start, "end": end,
+                "value": "{ x = 0.0, y = -9.8 }", "count": 1
+            }]
+        })];
+        for (i, prov) in ["effect result: Pong", "input: Space down", "mouseMove", "collision: ground"]
+            .iter()
+            .enumerate()
+        {
+            invocations.push(json!({
+                "entry": "update", "index": i + 1, "count": 5, "provenance": prov,
+                "ghost": false, "result": "0", "bindings": []
+            }));
+        }
+        json!({
+            "jsonrpc": "2.0", "method": "functor/inspector/trace",
+            "params": {
+                "paused": true,
+                "sources": [ { "file": "game.fun", "hash": inspector::sha256_hex(text.as_bytes()) } ],
+                "invocations": invocations,
+            }
+        })
+    }
+
+    fn open(uri: &str, text: &str) -> Value {
+        json!({
+            "jsonrpc": "2.0", "method": "textDocument/didOpen",
+            "params": { "textDocument": { "uri": uri, "languageId": "functor-lang", "version": 1, "text": text } }
+        })
+    }
+
+    fn change(uri: &str, version: i64, text: &str) -> Value {
+        json!({
+            "jsonrpc": "2.0", "method": "textDocument/didChange",
+            "params": {
+                "textDocument": { "uri": uri, "version": version },
+                "contentChanges": [ { "text": text } ]
+            }
+        })
+    }
+
+    fn inlay_req(id: i64, uri: &str) -> Value {
+        json!({
+            "jsonrpc": "2.0", "id": id, "method": "textDocument/inlayHint",
+            "params": {
+                "textDocument": { "uri": uri },
+                "range": { "start": { "line": 0, "character": 0 }, "end": { "line": 100, "character": 0 } }
+            }
+        })
+    }
+
+    fn codelens_req(id: i64, uri: &str) -> Value {
+        json!({
+            "jsonrpc": "2.0", "id": id, "method": "textDocument/codeLens",
+            "params": { "textDocument": { "uri": uri } }
+        })
+    }
+
+    fn response(messages: &[Value], id: i64) -> Value {
+        messages
+            .iter()
+            .find(|m| m["id"] == json!(id) && m.get("result").is_some())
+            .unwrap_or_else(|| panic!("no response for id {id} in {messages:#?}"))
+            .clone()
+    }
+
+    // Does a code-lens result carry a picker lens with this execution string?
+    fn has_picker(result: &Value, needle: &str) -> bool {
+        result.as_array().is_some_and(|lenses| {
+            lenses.iter().any(|lens| {
+                lens["command"]["command"] == json!("functor.inspector.cycleExecution")
+                    && lens["command"]["title"].as_str().is_some_and(|t| t.contains(needle))
+            })
+        })
+    }
+
+    fn has_live_value(result: &Value) -> bool {
+        result.as_array().is_some_and(|hints| {
+            hints
+                .iter()
+                .any(|h| h["label"].as_str().is_some_and(|l| l.starts_with("= ")))
+        })
+    }
+
+    #[test]
+    fn initialize_advertises_the_cycle_command() {
+        let out = drive(vec![json!({
+            "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": { "capabilities": {} }
+        })]);
+        assert_eq!(
+            response(&out, 1)["result"]["capabilities"]["executeCommandProvider"]["commands"],
+            json!(["functor.inspector.cycleExecution"])
+        );
+    }
+
+    #[test]
+    fn trace_yields_live_hints_and_a_picker_that_cycles_and_gates_on_edit() {
+        let mutated = format!("{FIXTURE}\n"); // hash-breaking edit
+        let out = drive(vec![
+            json!({ "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {} }),
+            open(URI, FIXTURE),
+            trace_message(FIXTURE),
+            inlay_req(2, URI),
+            codelens_req(3, URI),
+            // Cycle update's execution 0 → 1.
+            json!({
+                "jsonrpc": "2.0", "id": 4, "method": "workspace/executeCommand",
+                "params": { "command": "functor.inspector.cycleExecution", "arguments": ["game.fun", "update", 0] }
+            }),
+            codelens_req(5, URI),
+            change(URI, 2, &mutated),
+            inlay_req(6, URI),
+            codelens_req(7, URI),
+        ]);
+
+        // Live value hint appears at the binder name, hash-gated open.
+        let inlay2 = response(&out, 2)["result"].clone();
+        assert!(has_live_value(&inlay2), "expected a live value hint: {inlay2}");
+        let (_, _, name_end) = velocity_region();
+        let hit = inlay2
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|h| h["label"] == json!("= { x = 0.0, y = -9.8 }"))
+            .expect("velocity hint");
+        assert_eq!(hit["position"], lsp_position(FIXTURE, name_end));
+
+        // Picker lens starts at execution 1/5 with execution 0's provenance.
+        assert!(
+            has_picker(&response(&out, 3)["result"], "update — execution 1/5 ▸ [subscription: Tick]"),
+            "codeLens id 3: {:?}", response(&out, 3)["result"]
+        );
+
+        // After the cycle, the lens advances to 2/5 with execution 1's provenance.
+        assert!(
+            has_picker(&response(&out, 5)["result"], "update — execution 2/5 ▸ [effect result: Pong]"),
+            "codeLens id 5: {:?}", response(&out, 5)["result"]
+        );
+
+        // A trace change AND the executeCommand each pushed a codeLens refresh.
+        let refreshes = out
+            .iter()
+            .filter(|m| m["method"] == json!("workspace/codeLens/refresh"))
+            .count();
+        assert!(refreshes >= 2, "expected >=2 codeLens refreshes, got {refreshes}");
+        assert!(
+            out.iter().any(|m| m["method"] == json!("workspace/inlayHint/refresh")),
+            "expected an inlayHint refresh"
+        );
+
+        // The hash-breaking edit closes the gate: no live hints, no picker.
+        assert!(!has_live_value(&response(&out, 6)["result"]), "live hints must vanish on edit");
+        assert!(
+            !has_picker(&response(&out, 7)["result"], "execution"),
+            "picker must vanish on edit"
+        );
+    }
+
+    #[test]
+    fn client_response_to_a_refresh_is_tolerated() {
+        // A message with an `id` but no `method` is the client's reply to our
+        // refresh request; it must be ignored, not answered with an error.
+        let out = drive(vec![
+            json!({ "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {} }),
+            json!({ "jsonrpc": "2.0", "id": 42, "result": null }),
+        ]);
+        assert!(
+            !out.iter().any(|m| m["id"] == json!(42)),
+            "a client response must not be answered: {out:#?}"
+        );
+    }
+
+    // A minimal one-shot HTTP server that replies with `body` and closes.
+    fn stub_server(body: String) -> (String, std::thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        let handle = std::thread::spawn(move || {
+            let (mut sock, _) = listener.accept().unwrap();
+            let mut scratch = [0u8; 1024];
+            let _ = sock.read(&mut scratch);
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            sock.write_all(response.as_bytes()).unwrap();
+        });
+        (addr, handle)
+    }
+
+    #[test]
+    fn fetch_trace_reads_and_parses_a_stub_server() {
+        let (addr, handle) = stub_server(
+            r#"{"paused":true,"sources":[],"invocations":[]}"#.to_string(),
+        );
+        let trace = fetch_trace(&addr).expect("fetch");
+        assert_eq!(trace["paused"], json!(true));
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn poll_attached_idles_slowly_while_unpaused_and_discovers_the_next_pause() {
+        // A server that answers unpaused, unpaused (identical — must be
+        // deduplicated, not re-delivered), then paused; then it goes away
+        // (the poller must survive that too — attach persists until detach).
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = std::thread::spawn(move || {
+            for paused in ["false", "false", "true"] {
+                let (mut sock, _) = listener.accept().unwrap();
+                let mut scratch = [0u8; 512];
+                let _ = sock.read(&mut scratch);
+                let body = format!(r#"{{"paused":{paused},"sources":[],"invocations":[]}}"#);
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                sock.write_all(response.as_bytes()).unwrap();
+            }
+        });
+
+        let (tx, rx) = std::sync::mpsc::channel::<Incoming>();
+        let stop = Arc::new(AtomicBool::new(false));
+        let poller_stop = stop.clone();
+        let poller = std::thread::spawn(move || poll_attached(port, tx, poller_stop));
+        let recv_msg = |rx: &std::sync::mpsc::Receiver<Incoming>, secs: u64| match rx
+            .recv_timeout(Duration::from_secs(secs))
+        {
+            Ok(Incoming::Msg(v)) => Some(v),
+            _ => None,
+        };
+
+        // Fetch-once-on-attach delivers the unpaused doc.
+        let started = std::time::Instant::now();
+        let first = recv_msg(&rx, 3).expect("first trace");
+        assert_eq!(first["method"], json!("functor/inspector/trace"));
+        assert_eq!(first["params"]["paused"], json!(false));
+        // The identical second response is deduplicated; the NEXT delivery is
+        // the discovered pause — after two ~1s idle waits, never self-stopped.
+        let second = recv_msg(&rx, 6).expect("the discovered pause");
+        assert_eq!(second["params"]["paused"], json!(true));
+        assert!(
+            started.elapsed() >= Duration::from_millis(1500),
+            "unpaused polling must idle ~1Hz, got {:?}",
+            started.elapsed()
+        );
+
+        // Only explicit detach ends the poller (the server is already gone).
+        stop.store(true, Ordering::SeqCst);
+        poller.join().unwrap();
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn unchanged_trace_emits_no_refresh() {
+        // Event-driven refresh: a repeated identical trace document (the idle
+        // unpaused poll case) must cause no refresh; a changed one must.
+        let unpaused = json!({
+            "jsonrpc": "2.0", "method": "functor/inspector/trace",
+            "params": { "paused": false, "sources": [], "invocations": [] }
+        });
+        let out = drive(vec![
+            json!({ "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {} }),
+            unpaused.clone(),
+            unpaused.clone(), // identical — no refresh, no work
+            trace_message(FIXTURE), // changed — refresh again
+        ]);
+        let count = |method: &str| {
+            out.iter()
+                .filter(|m| m["method"] == json!(method))
+                .count()
+        };
+        assert_eq!(
+            count("workspace/inlayHint/refresh"),
+            2,
+            "one refresh per CHANGED trace: {out:#?}"
+        );
+        assert_eq!(count("workspace/codeLens/refresh"), 2);
     }
 }


### PR DESCRIPTION
Part 3 of the paused-scene inspector: the LSP server turns runtime traces into a LightTable-style editor experience — live values inline, and a clickable picker for the N executions of an entry point within a frame. Independent of the runtime PRs; built against the pinned wire contract.

## What

- **Live-value inlay hints**: `= value` after each binding site of the selected invocation (`(×N)` when a loop re-bound it), merged with the existing type hints. `let` binder names are located inside the region-shaped spans; params/match binders are name-precise.
- **Execution picker CodeLens** on entry-point defs: `update — execution 2/5 ▸ [subscription: Tick]` — clicking cycles via `workspace/executeCommand` (`functor.inspector.cycleExecution`, new `executeCommandProvider` capability). Single execution reads `update — 1 execution`.
- **Two ingestion paths**: notification `functor/inspector/trace` (push — the future wasm relay), and `functor/inspector/attach {port}` — the server polls `GET /trace` ~2Hz while paused, idles ~1Hz while unpaused, survives a vanished server, and stops only on explicit detach.
- **Refresh is event-driven**: the server emits `workspace/inlayHint/refresh` + `workspace/codeLens/refresh` (its first server-initiated requests) only when the pause state or trace content actually changes — identical responses are deduplicated at both the poller and handler, so an idle unpaused poll does zero downstream work.
- **Source-hash gate**: per-file sha256 from the trace vs the buffer the server sees (open document wins over disk). Any mismatch (unsaved edit, pre-hot-reload) silently drops live data for that file — values are never shown against drifted text. Live hints deliberately bypass the project loader, so values still display while a buffer transiently fails to typecheck.

The pure half lives in `tools/functor-lang-lsp/src/inspector.rs` (JSON + a hand-rolled sha256 stay out of the zero-dependency language crate).

## Verification (headless)

`cargo test -p functor-lang-lsp` — 35 green: 9 pure-half unit tests (placement incl. region spans, loop counts, hash gate, ghost filtering, modulo cycling, sha256 vectors) and serve-loop/poll tests covering the full flow — initialize → didOpen → trace → live hints → cycle → `2/5` + refresh emitted → didChange closes the gate — plus poller pacing/pause-discovery against a stub HTTP server and a no-refresh-on-unchanged-trace assertion.

## Stack

Pairs with #339 → #340 (the runtime side producing `/trace`) and #342 (attach commands + relay). Mergeable independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)