### PR TITLE
feat(vscode): inspector attach/detach commands + trace relay

### DIFF
--- a/tools/functor-lang-vscode/client/extension.js
+++ b/tools/functor-lang-vscode/client/extension.js
@@ -9,8 +9,19 @@ const http = require("node:http");
 const path = require("node:path");
 const { spawn } = require("node:child_process");
 const { LanguageClient } = require("vscode-languageclient/node");
+// All inspector decision logic (relay filter, attach/detach state, port
+// parsing, status bar text) lives in this plain module so it is testable with
+// `node --test` (client/inspector.test.js) — extension.js keeps only the thin
+// VS Code wiring around it.
+const inspector = require("./inspector.js");
 
 let client;
+// The paused-scene inspector's attach state + its status bar item. Attach
+// persists server-side until detach, so this is per-session UI state; the
+// last-used port is persisted across sessions in globalState.
+let inspectorState;
+let inspectorStatus;
+const INSPECTOR_PORT_KEY = "functor-lang.inspector.port";
 // The open preview panel, if any. A singleton: the dev server owns a fixed
 // port, so a second panel would race the first for it — and closing either
 // panel would kill the server out from under the other. Re-running the
@@ -46,6 +57,46 @@ function activate(context) {
 
   context.subscriptions.push(
     vscode.commands.registerCommand("functor-lang.openLivePreview", openLivePreview)
+  );
+
+  // --- Paused-scene inspector: attach/detach + status bar -----------------
+  inspectorState = inspector.initialState(context.globalState.get(INSPECTOR_PORT_KEY));
+  inspectorStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
+  const renderInspectorStatus = () => {
+    const bar = inspector.statusBar(inspectorState);
+    inspectorStatus.text = bar.text;
+    inspectorStatus.tooltip = bar.tooltip;
+    inspectorStatus.command = bar.command;
+    inspectorStatus.show();
+  };
+  renderInspectorStatus();
+
+  const attachInspector = async () => {
+    const input = await vscode.window.showInputBox({
+      prompt: "Functor Lang inspector: debug-server port to attach to",
+      value: inspector.promptDefault(inspectorState),
+      validateInput: (v) => inspector.parsePort(v).error,
+    });
+    if (input === undefined) return; // cancelled
+    const parsed = inspector.parsePort(input);
+    if (parsed.error) return; // validateInput blocks this, but be defensive
+    inspectorState = inspector.reduce(inspectorState, { type: "attach", port: parsed.port });
+    context.globalState.update(INSPECTOR_PORT_KEY, parsed.port);
+    const n = inspector.attachNotification(parsed.port);
+    if (client) client.sendNotification(n.notification, n.params);
+    renderInspectorStatus();
+  };
+  const detachInspector = () => {
+    inspectorState = inspector.reduce(inspectorState, { type: "detach" });
+    const n = inspector.detachNotification();
+    if (client) client.sendNotification(n.notification, n.params);
+    renderInspectorStatus();
+  };
+
+  context.subscriptions.push(
+    inspectorStatus,
+    vscode.commands.registerCommand(inspector.ATTACH_COMMAND, attachInspector),
+    vscode.commands.registerCommand(inspector.DETACH_COMMAND, detachInspector)
   );
 }
 
@@ -214,6 +265,15 @@ async function openLivePreview() {
   };
   panel.webview.onDidReceiveMessage((msg) => {
     if (!msg) return;
+    // Inspector trace relay (wasm push path, PR2b): the game iframe posts a
+    // `functor-inspector-trace` message that the webview forwards here; hand
+    // the wire-contract payload to the LSP. Inert until the wasm runtime emits
+    // these; unrelated messages fall through to relayTrace → null.
+    const relayed = inspector.relayTrace(msg);
+    if (relayed) {
+      if (client) client.sendNotification(relayed.notification, relayed.params);
+      return;
+    }
     if (msg.type === "functor-lang-preview-ready") {
       if (ready) return;
       ready = true;
@@ -314,10 +374,15 @@ function previewHtml() {
           // Extension → game page (the page only accepts pushes from its
           // parent — us).
           if (frame.contentWindow) frame.contentWindow.postMessage(data, "*");
-        } else if (data.type === "functor-lang-set-source-result" || data.type === "functor-lang-preview-ready") {
-          // Game page → extension. Only trust the page we framed: anything
-          // else on that port (or the game code itself) must not spoof
-          // results or readiness.
+        } else if (
+          data.type === "functor-lang-set-source-result" ||
+          data.type === "functor-lang-preview-ready" ||
+          data.type === "functor-inspector-trace"
+        ) {
+          // Game page → extension: reload results, readiness, and inspector
+          // trace pushes (the wasm path, PR2b — inert until the runtime emits
+          // them). Only trust the page we framed: anything else on that port
+          // (or the game code itself) must not spoof these.
           if (event.source !== frame.contentWindow) return;
           if (event.origin && event.origin !== "${PREVIEW_ORIGIN}") return;
           vscode.postMessage(data);

--- a/tools/functor-lang-vscode/client/inspector.js
+++ b/tools/functor-lang-vscode/client/inspector.js
@@ -1,0 +1,113 @@
+// Pure decision logic for the visual-debugger (paused-scene inspector) glue in
+// extension.js. Everything that *decides* anything lives here so it can be
+// exercised headlessly with `node --test` (see inspector.test.js) — no VS Code
+// host, no LSP server. extension.js keeps only the thin wiring: command
+// registration, the actual client.sendNotification calls, the status bar item,
+// and the webview hookup.
+//
+// The two custom LSP notifications (server contract, see the LSP crate):
+//   functor/inspector/attach  { port: N }    attach the poller to GET :N/trace
+//   functor/inspector/attach  { port: null } detach
+//   functor/inspector/trace   <wire JSON>    push a trace doc (wasm relay path)
+// Attach persists server-side until detach, so one attach per run session is
+// enough — no re-attach machinery here.
+
+const ATTACH = "functor/inspector/attach";
+const TRACE = "functor/inspector/trace";
+
+// The port the runtime's debug server listens on by default (`--debug-port`).
+const DEFAULT_PORT = 8077;
+
+// Command ids (kept in sync with package.json's contributes.commands and the
+// registrations in extension.js). Prefixed `functor-lang.` to match the
+// existing `functor-lang.openLivePreview` convention.
+const ATTACH_COMMAND = "functor-lang.inspector.attach";
+const DETACH_COMMAND = "functor-lang.inspector.detach";
+
+// --- webview relay --------------------------------------------------------
+// The preview webview forwards `functor-inspector-trace` window messages (from
+// the game iframe — the future wasm push path, PR2b) to the extension. Turn
+// such a message into the LSP notification to send, or null for anything else
+// (unrelated messages must be ignored). The message shape is
+//   { type: "functor-inspector-trace", trace: <wire-contract JSON> }
+function relayTrace(msg) {
+  if (!msg || msg.type !== "functor-inspector-trace") return null;
+  return { notification: TRACE, params: msg.trace };
+}
+
+// --- attach / detach notifications ---------------------------------------
+function attachNotification(port) {
+  return { notification: ATTACH, params: { port } };
+}
+
+function detachNotification() {
+  return { notification: ATTACH, params: { port: null } };
+}
+
+// --- port validation / persistence ---------------------------------------
+// Parse a user-entered port string. Returns { port } on success or { error }
+// with a human message (the error doubles as VS Code's validateInput return).
+function parsePort(input) {
+  const trimmed = String(input == null ? "" : input).trim();
+  if (!/^\d+$/.test(trimmed)) return { error: "Enter a port number (1–65535)." };
+  const port = Number(trimmed);
+  if (port < 1 || port > 65535) return { error: "Port must be between 1 and 65535." };
+  return { port };
+}
+
+// --- attach state + status bar derivation --------------------------------
+// State is { attached, port }: `port` is the last-used port (remembered across
+// attach/detach and, via the host's globalState, across sessions).
+function initialState(lastPort) {
+  const parsed = parsePort(lastPort);
+  return { attached: false, port: parsed.error ? DEFAULT_PORT : parsed.port };
+}
+
+function reduce(state, action) {
+  switch (action && action.type) {
+    case "attach":
+      return { attached: true, port: action.port };
+    case "detach":
+      return { attached: false, port: state.port };
+    default:
+      return state;
+  }
+}
+
+// The value to pre-fill the attach prompt with (the remembered port).
+function promptDefault(state) {
+  return String(state.port);
+}
+
+// Status bar item derivation: text, tooltip, and the command a click runs —
+// attach when detached, detach when attached (so clicking toggles sensibly).
+function statusBar(state) {
+  if (state.attached) {
+    return {
+      text: `$(debug) inspector :${state.port}`,
+      tooltip: `Functor Lang inspector attached to :${state.port} — click to detach`,
+      command: DETACH_COMMAND,
+    };
+  }
+  return {
+    text: "$(debug-disconnect) inspector",
+    tooltip: "Functor Lang inspector detached — click to attach",
+    command: ATTACH_COMMAND,
+  };
+}
+
+module.exports = {
+  ATTACH,
+  TRACE,
+  DEFAULT_PORT,
+  ATTACH_COMMAND,
+  DETACH_COMMAND,
+  relayTrace,
+  attachNotification,
+  detachNotification,
+  parsePort,
+  initialState,
+  reduce,
+  promptDefault,
+  statusBar,
+};

--- a/tools/functor-lang-vscode/client/inspector.test.js
+++ b/tools/functor-lang-vscode/client/inspector.test.js
@@ -1,0 +1,86 @@
+// Headless tests for the inspector decision logic (client/inspector.js).
+// Runs under `node --test` — no VS Code host, no LSP server, no new deps.
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const inspector = require("./inspector.js");
+
+test("relayTrace forwards a functor-inspector-trace message", () => {
+  const trace = { frame: 7, paused: true, invocations: [] };
+  assert.deepEqual(inspector.relayTrace({ type: "functor-inspector-trace", trace }), {
+    notification: "functor/inspector/trace",
+    params: trace,
+  });
+});
+
+test("relayTrace ignores unrelated / malformed messages", () => {
+  assert.equal(inspector.relayTrace(null), null);
+  assert.equal(inspector.relayTrace(undefined), null);
+  assert.equal(inspector.relayTrace({}), null);
+  assert.equal(inspector.relayTrace({ type: "functor-lang-set-source" }), null);
+  assert.equal(inspector.relayTrace({ type: "functor-lang-preview-ready" }), null);
+});
+
+test("attach / detach notifications carry the right params", () => {
+  assert.deepEqual(inspector.attachNotification(8077), {
+    notification: "functor/inspector/attach",
+    params: { port: 8077 },
+  });
+  assert.deepEqual(inspector.detachNotification(), {
+    notification: "functor/inspector/attach",
+    params: { port: null },
+  });
+});
+
+test("parsePort accepts valid ports", () => {
+  assert.deepEqual(inspector.parsePort("8077"), { port: 8077 });
+  assert.deepEqual(inspector.parsePort("  8077 "), { port: 8077 });
+  assert.deepEqual(inspector.parsePort("1"), { port: 1 });
+  assert.deepEqual(inspector.parsePort("65535"), { port: 65535 });
+});
+
+test("parsePort rejects out-of-range and non-numeric input", () => {
+  assert.ok(inspector.parsePort("0").error);
+  assert.ok(inspector.parsePort("65536").error);
+  assert.ok(inspector.parsePort("").error);
+  assert.ok(inspector.parsePort("abc").error);
+  assert.ok(inspector.parsePort("80a").error);
+  assert.ok(inspector.parsePort(null).error);
+});
+
+test("initialState remembers a valid last port, else the default", () => {
+  assert.deepEqual(inspector.initialState(9000), { attached: false, port: 9000 });
+  assert.deepEqual(inspector.initialState("9000"), { attached: false, port: 9000 });
+  assert.deepEqual(inspector.initialState(undefined), {
+    attached: false,
+    port: inspector.DEFAULT_PORT,
+  });
+  assert.deepEqual(inspector.initialState("garbage"), {
+    attached: false,
+    port: inspector.DEFAULT_PORT,
+  });
+});
+
+test("reduce transitions attach/detach and keeps the port on detach", () => {
+  const s0 = inspector.initialState(undefined);
+  const s1 = inspector.reduce(s0, { type: "attach", port: 9001 });
+  assert.deepEqual(s1, { attached: true, port: 9001 });
+  const s2 = inspector.reduce(s1, { type: "detach" });
+  assert.deepEqual(s2, { attached: false, port: 9001 });
+  // Unknown actions are a no-op.
+  assert.equal(inspector.reduce(s2, { type: "nope" }), s2);
+});
+
+test("promptDefault reflects the remembered port", () => {
+  assert.equal(inspector.promptDefault({ attached: false, port: 8077 }), "8077");
+  assert.equal(inspector.promptDefault({ attached: true, port: 9001 }), "9001");
+});
+
+test("statusBar derives text + toggle command from attach state", () => {
+  const detached = inspector.statusBar({ attached: false, port: 8077 });
+  assert.match(detached.text, /inspector/);
+  assert.equal(detached.command, inspector.ATTACH_COMMAND);
+
+  const attached = inspector.statusBar({ attached: true, port: 8077 });
+  assert.equal(attached.text, "$(debug) inspector :8077");
+  assert.equal(attached.command, inspector.DETACH_COMMAND);
+});

--- a/tools/functor-lang-vscode/package.json
+++ b/tools/functor-lang-vscode/package.json
@@ -21,6 +21,14 @@
       {
         "command": "functor-lang.openLivePreview",
         "title": "Functor Lang: Open Live Preview"
+      },
+      {
+        "command": "functor-lang.inspector.attach",
+        "title": "Functor Lang: Attach Inspector"
+      },
+      {
+        "command": "functor-lang.inspector.detach",
+        "title": "Functor Lang: Detach Inspector"
       }
     ],
     "configuration": {
@@ -60,6 +68,7 @@
     ]
   },
   "scripts": {
+    "test": "node --test client/inspector.test.js",
     "package:vsix": "npx --yes @vscode/vsce@3.9.2 package --out functor-lang-vscode.vsix",
     "install:vsix": "npm run package:vsix && code --install-extension functor-lang-vscode.vsix --force"
   },


### PR DESCRIPTION
Part 4 (final) of the paused-scene inspector: thin VS Code wiring so the LSP inspector can be attached to a running game.

## What

- Commands `functor-lang.inspector.attach` / `functor-lang.inspector.detach`: attach prompts for the game's `--debug-port` (default 8077, last-used remembered in `globalState`, validated) and sends the `functor/inspector/attach` LSP notification; attach persists server-side until detach.
- Status bar item: `$(debug-disconnect) inspector` ↔ `$(debug) inspector :8077`, click toggles attach/detach.
- Preview-webview relay (inert until the wasm runtime emits trace events): iframe messages of type `functor-inspector-trace` are whitelisted with the same origin/source guards as the existing preview messages and forwarded as `functor/inspector/trace` notifications — the future no-HTTP push path for the web runtime.

All decision logic (message filtering, attach state transitions, status-bar text, port validation) lives in a pure `client/inspector.js`; `extension.js` keeps only command registration, `sendNotification` calls, and the webview hookup.

## Verification (headless)

`npm test` in the extension → `node --test client/inspector.test.js`: 9 tests green (relay filtering incl. unrelated-message rejection, notification payloads, port validation edges, state transitions, status-bar derivation). No VS Code host needed.

## Stack

Pairs with #341 (the server consuming these notifications) and the runtime PRs #339 → #340. Mergeable independently; the commands are inert without the updated LSP server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)