### PR TITLE
site: in-browser language intelligence in the sandbox (stack 2/3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ perf*
 # shared target/ corrupts cross-compile fingerprints)
 target-android/
 runtime/functor-runtime-web/pkg
+tools/functor-lang-wasm/pkg

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "runtime/functor-runtime-desktop",
     "runtime/functor-runtime-web",
     "tools/functor-lang-lsp",
+    "tools/functor-lang-wasm",
 ]
 
 # Debug info dominated target/ size (it was repeatedly filling the disk during

--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -443,6 +443,42 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
   await page.close();
 }
 
+// --- 10. The editor language-intelligence wasm analyzes source in-browser. -----
+// Commits 7-8 wire this into the CodeMirror editor (diagnostics/hover); here we
+// just smoke-test the bundle loads and `functor_lang_analyze` reports errors on
+// a bad source and none on a clean one.
+{
+  const page = await browser.newPage({ viewport: { width: 800, height: 600 } });
+  await page.goto(BASE); // any same-origin page; we only need /pkg/ reachable
+  const result = await page.evaluate(async () => {
+    const mod = await import("/pkg/functor_lang_wasm.js");
+    await mod.default(); // init the wasm
+    // A type error: adding a string to a float.
+    const bad = JSON.parse(mod.functor_lang_analyze('let bad = 1.0 + "x"\n'));
+    // A clean program using prelude names.
+    const clean = JSON.parse(
+      mod.functor_lang_analyze(
+        "let draw = (model, tts: Float) =>\n" +
+          "  Frame.create(Camera.lookAt(0.0, 0.0, -6.0, 0.0, 0.0, 0.0), Scene.cube())\n"
+      )
+    );
+    return { bad, clean };
+  });
+  const d = result.bad.diagnostics;
+  const sane =
+    Array.isArray(d) &&
+    d.length >= 1 &&
+    Number.isInteger(d[0].from) &&
+    Number.isInteger(d[0].to) &&
+    d[0].from < d[0].to;
+  check(
+    "language wasm analyzes source in-browser (error on bad, none on clean)",
+    sane && result.clean.diagnostics.length === 0,
+    `bad=${JSON.stringify(d)} clean=${result.clean.diagnostics.length}`
+  );
+  await page.close();
+}
+
 await browser.close();
 server.kill();
 console.log(failures === 0 ? "\nALL CHECKS PASSED" : `\n${failures} CHECK(S) FAILED`);

--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -650,6 +650,118 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
   }
 }
 
+// --- 13. Scope-aware autocomplete in the editor (commit 8b). ------------------
+// The completion source is backed by the wasm's scope-aware `complete`, driven
+// through the __sandbox.triggerComplete seam (insert text + set cursor + open
+// the popup). That seam is guarded to NOT push, so the status pill stays live
+// throughout. SKIPs (like the lint/hover blocks) when the analysis pkg is absent.
+{
+  const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+  await page.goto(`${BASE}/sandbox.html`);
+  await page.waitForFunction(
+    () => window.__sandbox && window.__sandbox.status().state === "live",
+    { timeout: 30000 }
+  );
+
+  const langAvailable = await page.evaluate(() => window.__lang && window.__lang.ready);
+  if (!langAvailable) {
+    console.log("SKIP: autocomplete — language analysis pkg not built (__lang not ready)");
+    await page.close();
+  } else {
+    // Prime the wasm last-good cache with a valid program (via the __lang seam —
+    // no doc change, no push), so dot-completion works even while the live
+    // buffer is mid-edit.
+    await page.evaluate((s) => window.__lang.complete(s, 0), GREEN);
+
+    // Open the popup and wait until its option labels satisfy `pred`; retries
+    // the trigger — under load a popup open can be swallowed by a lagging
+    // transaction (a lint pass landing mid-open), so a single-shot wait flakes.
+    const openCompletion = async (source, cursor, pred) => {
+      for (let attempt = 0; attempt < 4; attempt++) {
+        await page.evaluate(
+          ({ s, c }) => window.__sandbox.triggerComplete(s, c),
+          { s: source, c: cursor }
+        );
+        const t0 = Date.now();
+        while (Date.now() - t0 < 2500) {
+          const labels = await page.evaluate(() =>
+            [...document.querySelectorAll(".cm-tooltip-autocomplete .cm-completionLabel")].map(
+              (el) => el.textContent
+            )
+          );
+          if (pred(labels)) return labels;
+          await sleep(150);
+        }
+      }
+      return [];
+    };
+
+    // A) Member popup: cursor right after `Scene.` (empty partial) surfaces many
+    // members. `triggerComplete` is guarded (no push), so status stays live.
+    const memberCursor = GREEN.indexOf("Scene.") + "Scene.".length;
+    const opts = await openCompletion(
+      GREEN,
+      memberCursor,
+      (labels) => labels.length > 3 && labels.includes("sphere")
+    );
+    check(
+      "Scene. opens the completion popup with >3 members",
+      opts.length > 3,
+      `options=${JSON.stringify(opts.slice(0, 8))}`
+    );
+    check(
+      "completion offers a known Scene member (sphere)",
+      opts.includes("sphere"),
+      JSON.stringify(opts.slice(0, 8))
+    );
+
+    // B) Applying a completion inserts its label: a typo'd member `spher` offers
+    // the sole `sphere`; accepting it fixes the program (still valid → the push
+    // keeps the loop live), and the label is now in the doc.
+    const GREEN_TYPO = GREEN.replace("Scene.sphere()", "Scene.spher()");
+    const typoCursor = GREEN_TYPO.indexOf("Scene.spher") + "Scene.spher".length;
+    const typoOpts = await openCompletion(
+      GREEN_TYPO,
+      typoCursor,
+      (labels) => labels[0] === "sphere"
+    );
+    // Accept via the editor's own apply path (deterministic — no key focus).
+    const accepted = await page.evaluate(() => window.__sandbox.acceptCompletion());
+    await sleep(150);
+    const afterAccept = await page.evaluate(() => window.__sandbox.getSource());
+    check(
+      "applying a completion inserts its label",
+      afterAccept.includes("Scene.sphere()"),
+      `accepted=${accepted}, popup=${JSON.stringify(typoOpts)}, line=${JSON.stringify(
+        afterAccept.split("\n").find((l) => l.includes("Scene.")) || afterAccept.slice(0, 60)
+      )}`
+    );
+    // The accept pushed the fixed (valid) program. Wait for the push RESULT
+    // (not just state === "live": the pill is already live before the debounced
+    // push fires, so that would pass early and the final live check below could
+    // catch the transient "reloading").
+    await page.waitForFunction(
+      () => window.__sandbox.status().message.includes("model preserved"),
+      { timeout: 8000 }
+    );
+
+    // C) Top-level partial `le` → the `let` keyword (guarded — no push).
+    const topOpts = await openCompletion("le", 2, (labels) => labels.includes("let"));
+    check(
+      "top-level `le` offers the `let` keyword",
+      topOpts.includes("let"),
+      JSON.stringify(topOpts.slice(0, 8))
+    );
+
+    check(
+      "autocomplete keeps the sandbox live",
+      (await page.evaluate(() => window.__sandbox.status().state)) === "live"
+    );
+
+    await page.close();
+  }
+}
+
 await browser.close();
 server.kill();
 console.log(failures === 0 ? "\nALL CHECKS PASSED" : `\n${failures} CHECK(S) FAILED`);

--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -52,6 +52,22 @@ let draw = (model, tts: Float) =>
     Scene.cube() |> Scene.rotateY(Angle.radians(model.spin)) |> Scene.emissive(1.0, 0.2, 0.8))
 `;
 
+// A float-model program for the language-intelligence checks: every top-level
+// def has a knowable type (no record-typed `init` — a record's type stays
+// Unknown and earns no lens), so all four defs get a signature codelens; the
+// two unannotated `model` params get inlay hints; and `speed` hovers to its
+// type. Loaded via #src= so it fresh-inits (its float model runs cleanly —
+// a hot-swap onto the record-model default would throw at draw).
+const INTEL_SRC = `let speed = 2.0
+let init = 0.0
+let tick = (model, dt: Float, tts: Float) => model + dt
+let draw = (model, tts: Float) =>
+  Frame.create(
+    Camera.lookAt(0.0, 0.0, -6.0, 0.0, 0.0, 0.0),
+    Scene.sphere() |> Scene.emissive(0.1, 1.0, 0.2)
+      |> Scene.rotateY(Angle.radians(model)) |> Scene.scale(speed))
+`;
+
 let failures = 0;
 const check = (name, ok, detail = "") => {
   console.log(`${ok ? "PASS" : "FAIL"}: ${name}${ok || !detail ? "" : ` — ${detail}`}`);
@@ -540,6 +556,93 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
     check("fixing the type error clears the underline", cleared, `count=${await lintCount()}`);
     check(
       "sandbox returns/stays live after the fix",
+      (await page.evaluate(() => window.__sandbox.status().state)) === "live"
+    );
+
+    await page.close();
+  }
+}
+
+// --- 12. Hover types + inlay hints + codelens (commit 8). ---------------------
+// The intel program loads fresh via #src=; once the analysis pkg is ready the
+// editor grows inline `: float` inlays, a signature codelens above each def,
+// and a hover tooltip — all while the push loop keeps the status pill live.
+// SKIPs (like the lint block) when the analysis pkg isn't built.
+{
+  const b64u = Buffer.from(INTEL_SRC).toString("base64url");
+  const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+  await page.goto(`${BASE}/sandbox.html#src=${b64u}`);
+  await page.waitForFunction(
+    () => window.__sandbox && window.__sandbox.status().state === "live",
+    { timeout: 30000 }
+  );
+
+  const langAvailable = await page.evaluate(() => window.__lang && window.__lang.ready);
+  if (!langAvailable) {
+    console.log("SKIP: hover/inlay/codelens — language analysis pkg not built (__lang not ready)");
+    await page.close();
+  } else {
+    // The signature lens appears once per top-level def; count them in the source.
+    const topDefs = INTEL_SRC.split("\n").filter((l) => l.startsWith("let ")).length;
+
+    // Inlays and lenses lag the doc by the lint debounce (they read the cache
+    // the lint pass fills), so poll rather than sampling once.
+    const poll = async (fn, pred, timeout = 8000) => {
+      const t0 = Date.now();
+      for (;;) {
+        const v = await fn();
+        if (pred(v)) return v;
+        if (Date.now() - t0 > timeout) return v;
+        await sleep(150);
+      }
+    };
+
+    const inlays = await poll(() => page.locator(".cm-inlay").count(), (n) => n > 0);
+    check("inlay hints decorate unannotated params", inlays > 0, `count=${inlays}`);
+
+    const lenses = await poll(() => page.locator(".cm-lens").count(), (n) => n >= topDefs);
+    check(
+      "codelens shows a signature above every top-level def",
+      lenses >= topDefs,
+      `lenses=${lenses}, defs=${topDefs}`
+    );
+
+    // Hover a REAL code token (skip the lens/inlay widget text) and rest the
+    // mouse over it — a jiggle would keep resetting the hover timer.
+    const coord = await page.evaluate(() => {
+      const content = document.querySelector(".cm-content");
+      const walker = document.createTreeWalker(content, NodeFilter.SHOW_TEXT);
+      let node;
+      while ((node = walker.nextNode())) {
+        if (node.parentElement.closest(".cm-lens, .cm-inlay")) continue; // widget text
+        const idx = node.textContent.indexOf("speed");
+        if (idx >= 0) {
+          const range = document.createRange();
+          range.setStart(node, idx);
+          range.setEnd(node, idx + 5);
+          const r = range.getBoundingClientRect();
+          return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
+        }
+      }
+      return null;
+    });
+    check("found a hoverable token in the editor", !!coord, JSON.stringify(coord));
+    if (coord) {
+      await page.mouse.move(coord.x - 40, coord.y);
+      await sleep(100);
+      await page.mouse.move(coord.x, coord.y);
+      const tip = await poll(
+        async () => {
+          const el = page.locator(".cm-tooltip-hover");
+          return (await el.count()) ? (await el.first().textContent()) || "" : "";
+        },
+        (t) => t.includes(":")
+      );
+      check("hover shows a type tooltip", tip.includes(":"), `tooltip=${JSON.stringify(tip)}`);
+    }
+
+    check(
+      "language intelligence keeps the sandbox live",
       (await page.evaluate(() => window.__sandbox.status().state)) === "live"
     );
 

--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -546,6 +546,15 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
     await page.evaluate((s) => window.__sandbox.setSource(s), TYPE_ERROR);
     const gotError = await waitLint((n) => n > 0);
     check("type error draws a lint underline", gotError, `count=${await lintCount()}`);
+    // Await the hot-swap RESULT before reading liveness: the debounced push
+    // (busy → live) can be mid-flight right when the underline appears, so a
+    // bare status() read would intermittently catch the transient "reloading".
+    // TYPE_ERROR still loads and runs (type diagnostics are advisory), so the
+    // push reports "model preserved".
+    await page.waitForFunction(
+      () => window.__sandbox.status().message.includes("model preserved"),
+      { timeout: 8000 }
+    );
     check(
       "diagnostics keep the sandbox live",
       (await page.evaluate(() => window.__sandbox.status().state)) === "live"
@@ -554,6 +563,11 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
     await page.evaluate((s) => window.__sandbox.setSource(s), CLEAN);
     const cleared = await waitLint((n) => n === 0);
     check("fixing the type error clears the underline", cleared, `count=${await lintCount()}`);
+    // Same as above: wait for the fix's push to round-trip before asserting live.
+    await page.waitForFunction(
+      () => window.__sandbox.status().message.includes("model preserved"),
+      { timeout: 8000 }
+    );
     check(
       "sandbox returns/stays live after the fix",
       (await page.evaluate(() => window.__sandbox.status().state)) === "live"

--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -451,7 +451,12 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
   const page = await browser.newPage({ viewport: { width: 800, height: 600 } });
   await page.goto(BASE); // any same-origin page; we only need /pkg/ reachable
   const result = await page.evaluate(async () => {
-    const mod = await import("/pkg/functor_lang_wasm.js");
+    let mod;
+    try {
+      mod = await import("/pkg/functor_lang_wasm.js");
+    } catch {
+      return null; // pkg not built — degraded config, skip below
+    }
     await mod.default(); // init the wasm
     // A type error: adding a string to a float.
     const bad = JSON.parse(mod.functor_lang_analyze('let bad = 1.0 + "x"\n'));
@@ -464,6 +469,11 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
     );
     return { bad, clean };
   });
+  if (!result) {
+    console.log("SKIP: language wasm analyzes source in-browser — pkg not built");
+    await page.close();
+    // Nothing further to assert in the degraded config.
+  } else {
   const d = result.bad.diagnostics;
   const sane =
     Array.isArray(d) &&
@@ -477,6 +487,64 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
     `bad=${JSON.stringify(d)} clean=${result.clean.diagnostics.length}`
   );
   await page.close();
+  }
+}
+
+// --- 11. Live diagnostics: the linter underlines a type error, clears on fix. --
+// A valid MVU program (loads & runs live — type diagnostics are advisory in the
+// dev loop) with ONE unused function whose body is a type error the checker
+// flags. The `.cm-lintRange-error` underline must appear, then clear when the
+// bad def is removed — all while the push loop keeps the status pill live.
+{
+  const CLEAN = GREEN;
+  const TYPE_ERROR = `${GREEN}let oops = (x: Float) => x + "type error"\n`;
+
+  const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+  await page.goto(`${BASE}/sandbox.html`);
+  await page.waitForFunction(
+    () => window.__sandbox && window.__sandbox.status().state === "live",
+    { timeout: 30000 }
+  );
+
+  // Await the analysis wasm's readiness (resolves to false when the pkg is
+  // absent — then the whole lint block is skipped so the suite stays green in
+  // both configurations).
+  const langAvailable = await page.evaluate(
+    () => window.__lang && window.__lang.ready
+  );
+  if (!langAvailable) {
+    console.log("SKIP: live diagnostics — language analysis pkg not built (__lang not ready)");
+    await page.close();
+  } else {
+    const lintCount = () => page.locator(".cm-lintRange-error").count();
+    // Poll for the count to reach a predicate (covers the 300ms lint delay).
+    const waitLint = async (pred, timeout = 6000) => {
+      const t0 = Date.now();
+      for (;;) {
+        if (pred(await lintCount())) return true;
+        if (Date.now() - t0 > timeout) return false;
+        await sleep(150);
+      }
+    };
+
+    await page.evaluate((s) => window.__sandbox.setSource(s), TYPE_ERROR);
+    const gotError = await waitLint((n) => n > 0);
+    check("type error draws a lint underline", gotError, `count=${await lintCount()}`);
+    check(
+      "diagnostics keep the sandbox live",
+      (await page.evaluate(() => window.__sandbox.status().state)) === "live"
+    );
+
+    await page.evaluate((s) => window.__sandbox.setSource(s), CLEAN);
+    const cleared = await waitLint((n) => n === 0);
+    check("fixing the type error clears the underline", cleared, `count=${await lintCount()}`);
+    check(
+      "sandbox returns/stays live after the fix",
+      (await page.evaluate(() => window.__sandbox.status().state)) === "live"
+    );
+
+    await page.close();
+  }
 }
 
 await browser.close();

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "devDependencies": {
         "@codemirror/commands": "^6.10.4",
         "@codemirror/language": "^6.12.4",
+        "@codemirror/lint": "^6.9.7",
         "@codemirror/view": "^6.43.5",
         "@lezer/highlight": "^1.2.3",
         "@playwright/test": "^1.61.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "devDependencies": {
+        "@codemirror/autocomplete": "^6.20.3",
         "@codemirror/commands": "^6.10.4",
         "@codemirror/language": "^6.12.4",
         "@codemirror/lint": "^6.9.7",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "clean": "git clean -fdX",
     "build:cli": "wasm-pack build runtime/functor-runtime-web --target=web && cargo build --bin functor",
+    "build:lang-wasm": "wasm-pack build tools/functor-lang-wasm --target=web",
     "build:lsp": "cargo install --path tools/functor-lang-lsp --force && (pkill -x functor-lang-lsp || true)",
     "install:vsix": "npm run install:vsix --prefix tools/functor-lang-vscode",
     "build:oculus": "ANDROID_HOME=${ANDROID_HOME:-/opt/homebrew/share/android-sdk} CARGO_TARGET_DIR=target-android cargo ndk -t arm64-v8a build --manifest-path runtime/functor-runtime-oculus/Cargo.toml",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:site": "node e2e/site-sandbox.mjs"
   },
   "devDependencies": {
+    "@codemirror/autocomplete": "^6.20.3",
     "@codemirror/commands": "^6.10.4",
     "@codemirror/language": "^6.12.4",
     "@codemirror/lint": "^6.9.7",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@codemirror/commands": "^6.10.4",
     "@codemirror/language": "^6.12.4",
+    "@codemirror/lint": "^6.9.7",
     "@codemirror/view": "^6.43.5",
     "@lezer/highlight": "^1.2.3",
     "@playwright/test": "^1.61.0",

--- a/site/build.mjs
+++ b/site/build.mjs
@@ -21,6 +21,13 @@ const PAGES = ["index.html", "sandbox.html", "player.html", "docs.html", "styles
 const PKG = `${root}runtime/functor-runtime-web/pkg`;
 const PKG_FILES = ["functor_runtime_web.js", "functor_runtime_web_bg.wasm"];
 
+// The editor's in-browser language intelligence (diagnostics/hover), a separate
+// small wasm bundle built by `npm run build:lang-wasm`. Optional: the site must
+// still build without it (the editor just loses live analysis), so a missing
+// pkg is a note, not an error.
+const LANG_PKG = `${root}tools/functor-lang-wasm/pkg`;
+const LANG_PKG_FILES = ["functor_lang_wasm.js", "functor_lang_wasm_bg.wasm"];
+
 // dist/examples/<name>.fun — site-local plus the repo's Functor Lang examples.
 const EXAMPLES = {
   hero: `${site}examples/hero.fun`,
@@ -55,11 +62,31 @@ for (const [name, path] of Object.entries(EXAMPLES)) {
   await cp(path, `${dist}/examples/${name}.fun`);
 }
 
+// The language-intelligence wasm, if it has been built. Absent → skip (build on).
+let langPkgPresent = false;
+try {
+  await access(`${LANG_PKG}/${LANG_PKG_FILES[0]}`);
+  langPkgPresent = true;
+} catch {
+  console.log(
+    `note: ${LANG_PKG_FILES[0]} not found — skipping the editor language pkg ` +
+      `(build it with \`npm run build:lang-wasm\`)`
+  );
+}
+if (langPkgPresent) {
+  for (const file of LANG_PKG_FILES) {
+    await cp(`${LANG_PKG}/${file}`, `${dist}/pkg/${file}`);
+  }
+}
+
 await esbuild.build({
   entryPoints: [`${site}src/sandbox.js`, `${site}src/docs.js`, `${site}src/hero.js`],
   bundle: true,
   minify: true,
   format: "esm",
+  // The editor dynamic-imports the language wasm glue at runtime from /pkg/;
+  // esbuild must not try to bundle that path (it's copied in above, or absent).
+  external: ["/pkg/functor_lang_wasm.js"],
   outdir: `${dist}/assets`,
   logLevel: "info",
 });

--- a/site/player.html
+++ b/site/player.html
@@ -237,7 +237,18 @@
         window.addEventListener("message", (event) => {
           if (event.source !== window.parent) return;
           const data = event.data;
-          if (!data || data.type !== "functor-lang-set-source" || typeof data.source !== "string") return;
+          if (!data) return;
+          // Handshake: a `functor-lang-preview-hello` from the hosting bridge asks
+          // us to re-announce readiness (its listener may have attached after our
+          // one-shot ready fired). Reply only once we're actually live; before
+          // that, the one-shot announce below covers this direction.
+          if (data.type === "functor-lang-preview-hello") {
+            if (functor_lang_is_running()) {
+              window.parent.postMessage({ type: "functor-lang-preview-ready" }, "*");
+            }
+            return;
+          }
+          if (data.type !== "functor-lang-set-source" || typeof data.source !== "string") return;
           // Queue the source; the wasm frame loop applies it at a safe point
           // (never mid-frame) and posts an `functor-lang-set-source-result` back to the
           // hosting frame with the outcome (a broken push keeps the old program).

--- a/site/src/lang-intel.js
+++ b/site/src/lang-intel.js
@@ -16,6 +16,7 @@
 import { linter } from "@codemirror/lint";
 import { Decoration, EditorView, ViewPlugin, WidgetType, hoverTooltip } from "@codemirror/view";
 import { StateEffect, StateField } from "@codemirror/state";
+import { functorLangLanguage } from "./functor-lang.js";
 
 // The runtime import specifier resolves to the glue esbuild leaves external
 // (see build.mjs `external`), copied to /pkg/ at build time — NOT bundled.
@@ -23,6 +24,7 @@ const PKG_URL = "/pkg/functor_lang_wasm.js";
 
 let analyzeFn = null; // (src) => JSON string, set once the wasm is ready
 let hoverFn = null; // (src, offset) => JSON string ("" when nothing to show)
+let completeFn = null; // (src, offset) => JSON string, set once the wasm is ready
 let lastDoc = null;
 let lastResult = null;
 
@@ -40,6 +42,18 @@ export const analyzeCached = (docString) => {
   lastDoc = docString;
   lastResult = result;
   return result;
+};
+
+// Raw completion at a UTF-16 offset — the test/introspection seam
+// (window.__lang.complete). Returns the parsed `{ items }`, or null when the
+// wasm isn't loaded.
+export const completeAt = (src, offset) => {
+  if (!completeFn) return null;
+  try {
+    return JSON.parse(completeFn(src, offset));
+  } catch {
+    return null;
+  }
 };
 
 // Read the memoized result WITHOUT running analyze: returns it only when it is
@@ -90,6 +104,49 @@ const hoverTypes = hoverTooltip((view, pos) => {
     },
   };
 });
+
+// --- Autocomplete -------------------------------------------------------------
+// A CodeMirror completion source backed by the wasm's scope-aware `complete`.
+// Registered via the language's `data` facet (below), so basicSetup's
+// `autocompletion()` picks it up through `languageDataAt("autocomplete")` — no
+// second popup, and in degraded mode (no wasm) it is simply never registered.
+
+// Map the wasm's completion kind to a CodeMirror `type`, so the built-in icons
+// render (function/variable/namespace/keyword/enum/property all have glyphs).
+const KIND_TO_TYPE = {
+  function: "function",
+  value: "variable",
+  module: "namespace",
+  keyword: "keyword",
+  constructor: "enum",
+  field: "property",
+};
+
+// Fires on explicit trigger (Ctrl-Space), after a `.`, or while typing a word.
+// Returns `validFor` so CodeMirror filters the list client-side as more word
+// chars are typed — one wasm call per token, not per keystroke.
+const functorCompletions = (context) => {
+  if (!completeFn) return null;
+  const word = context.matchBefore(/[A-Za-z_]\w*/);
+  const afterDot = context.pos > 0 && context.state.sliceDoc(context.pos - 1, context.pos) === ".";
+  if (!context.explicit && !afterDot && !word) return null;
+  let items;
+  try {
+    items = JSON.parse(completeFn(context.state.doc.toString(), context.pos)).items;
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(items) || items.length === 0) return null;
+  return {
+    from: word ? word.from : context.pos,
+    options: items.map((it) => ({
+      label: it.label,
+      type: KIND_TO_TYPE[it.kind],
+      detail: it.detail || undefined,
+    })),
+    validFor: /^\w*$/,
+  };
+};
 
 // --- Inlay hints + codelenses (one StateField) --------------------------------
 // Block decorations (the codelenses) MUST come from a StateField, not a
@@ -247,6 +304,36 @@ const intelTheme = EditorView.theme({
     fontStyle: "italic",
     lineHeight: "1.5",
   },
+  // Autocomplete popup: the same calm dark panel as the hover tooltip.
+  ".cm-tooltip.cm-tooltip-autocomplete": {
+    backgroundColor: "#1e1833",
+    border: "1px solid #2b2542",
+    borderRadius: "5px",
+  },
+  ".cm-tooltip-autocomplete > ul": {
+    fontFamily: mono,
+    fontSize: "12.5px",
+    maxHeight: "16em",
+  },
+  ".cm-tooltip-autocomplete > ul > li": {
+    color: "#e9e6f2",
+    padding: "2px 6px",
+  },
+  ".cm-tooltip-autocomplete ul li[aria-selected]": {
+    backgroundColor: "#0e3b46",
+    color: "#c7f2f7",
+  },
+  // The detail (type signature) trailing each option, dimmed.
+  ".cm-completionDetail": {
+    color: "#6c6685",
+    fontStyle: "italic",
+  },
+  // The kind icon, tinted to the cyan accent so glyphs read on the dark panel.
+  ".cm-completionIcon": {
+    color: "#9b94b3",
+    opacity: "0.9",
+    marginRight: "0.4em",
+  },
 });
 
 // Async setup: resolve to the full intel extension set, or [] on any failure so
@@ -257,6 +344,7 @@ export const setupLangIntel = async () => {
     await mod.default(); // init the wasm
     analyzeFn = mod.functor_lang_analyze;
     hoverFn = mod.functor_lang_hover;
+    completeFn = mod.functor_lang_complete;
   } catch {
     console.info(
       "[lang-intel] language analysis unavailable (pkg not built) — editor runs without diagnostics"
@@ -268,6 +356,9 @@ export const setupLangIntel = async () => {
     hoverTypes,
     decorationField,
     initialRefresh,
+    // Register the completion source on the language's data facet — basicSetup's
+    // autocompletion() picks it up via languageDataAt (no second popup).
+    functorLangLanguage.data.of({ autocomplete: functorCompletions }),
     intelTheme,
   ];
 };

--- a/site/src/lang-intel.js
+++ b/site/src/lang-intel.js
@@ -1,0 +1,79 @@
+// Live language intelligence for the sandbox editor: loads the small
+// functor-lang analysis wasm (built by `npm run build:lang-wasm`, copied to
+// dist/pkg/ by build.mjs) and turns its type diagnostics into CodeMirror lint
+// underlines. Optional by design — if the pkg is absent or fails to init, the
+// setup resolves to [] and the editor works exactly as before (no analysis,
+// no console spam beyond one info line).
+//
+// The parsed analyze result is memoized per doc string (analyzeCached) so the
+// same pass backs both the linter and commit 8's inlays/lenses.
+
+import { linter } from "@codemirror/lint";
+import { EditorView } from "@codemirror/view";
+
+// The runtime import specifier resolves to the glue esbuild leaves external
+// (see build.mjs `external`), copied to /pkg/ at build time — NOT bundled.
+const PKG_URL = "/pkg/functor_lang_wasm.js";
+
+let analyzeFn = null; // (src) => JSON string, set once the wasm is ready
+let lastDoc = null;
+let lastResult = null;
+
+// Run analyze at most once per distinct doc string. Returns the parsed
+// `{ diagnostics, inlays, lenses }`, or null when the wasm isn't loaded.
+export const analyzeCached = (docString) => {
+  if (!analyzeFn) return null;
+  if (docString === lastDoc) return lastResult;
+  let result;
+  try {
+    result = JSON.parse(analyzeFn(docString));
+  } catch {
+    result = { diagnostics: [], inlays: [], lenses: [] };
+  }
+  lastDoc = docString;
+  lastResult = result;
+  return result;
+};
+
+// analyze offsets are whole-document UTF-16 — CodeMirror's native unit — so
+// they map straight across; clamp defensively to the current doc length.
+const toDiagnostics = (view) => {
+  const doc = view.state.doc;
+  const result = analyzeCached(doc.toString());
+  if (!result || !Array.isArray(result.diagnostics)) return [];
+  const len = doc.length;
+  return result.diagnostics.map((d) => {
+    const from = Math.max(0, Math.min(d.from | 0, len));
+    let to = Math.max(from, Math.min(d.to | 0, len));
+    return { from, to, severity: d.severity || "error", message: d.message || "" };
+  });
+};
+
+// Recolor lint's wavy underline to the calm theme's red (--red: #f2637f)
+// instead of its default bright #f11. Mirrors @codemirror/lint's own helper.
+const wavyUnderline = (color) =>
+  `url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="6" height="3">` +
+  encodeURIComponent(
+    `<path d="m0 2.5 l2 -1.5 l1 0 l2 1.5 l1 0" stroke="${color}" fill="none" stroke-width=".7"/>`
+  ) +
+  `</svg>')`;
+
+const lintTheme = EditorView.theme({
+  ".cm-lintRange-error": { backgroundImage: wavyUnderline("#f2637f") },
+});
+
+// Async setup: resolve to the lint extensions, or [] on any failure so the
+// editor degrades to no-analysis silently.
+export const setupLangIntel = async () => {
+  try {
+    const mod = await import(PKG_URL);
+    await mod.default(); // init the wasm
+    analyzeFn = mod.functor_lang_analyze;
+  } catch {
+    console.info(
+      "[lang-intel] language analysis unavailable (pkg not built) — editor runs without diagnostics"
+    );
+    return [];
+  }
+  return [linter(toDiagnostics, { delay: 300 }), lintTheme];
+};

--- a/site/src/lang-intel.js
+++ b/site/src/lang-intel.js
@@ -1,21 +1,28 @@
 // Live language intelligence for the sandbox editor: loads the small
 // functor-lang analysis wasm (built by `npm run build:lang-wasm`, copied to
 // dist/pkg/ by build.mjs) and turns its type diagnostics into CodeMirror lint
-// underlines. Optional by design — if the pkg is absent or fails to init, the
-// setup resolves to [] and the editor works exactly as before (no analysis,
-// no console spam beyond one info line).
+// underlines, plus hover types, inlay hints, and signature codelenses.
+// Optional by design — if the pkg is absent or fails to init, the setup
+// resolves to [] and the editor works exactly as before (no analysis, no
+// console spam beyond one info line).
 //
 // The parsed analyze result is memoized per doc string (analyzeCached) so the
-// same pass backs both the linter and commit 8's inlays/lenses.
+// SAME pass backs the linter, the inlays, and the lenses — one analyze per doc
+// version, never a second. The lint source runs the analyze (debounced); the
+// decoration StateField only PEEKS the cache and refreshes when the lint pass
+// has filled it, so inlays/lenses lag the doc by the lint debounce (acceptable
+// and cheaper than a second scheduler) instead of re-analyzing on every key.
 
 import { linter } from "@codemirror/lint";
-import { EditorView } from "@codemirror/view";
+import { Decoration, EditorView, ViewPlugin, WidgetType, hoverTooltip } from "@codemirror/view";
+import { StateEffect, StateField } from "@codemirror/state";
 
 // The runtime import specifier resolves to the glue esbuild leaves external
 // (see build.mjs `external`), copied to /pkg/ at build time — NOT bundled.
 const PKG_URL = "/pkg/functor_lang_wasm.js";
 
 let analyzeFn = null; // (src) => JSON string, set once the wasm is ready
+let hoverFn = null; // (src, offset) => JSON string ("" when nothing to show)
 let lastDoc = null;
 let lastResult = null;
 
@@ -35,11 +42,22 @@ export const analyzeCached = (docString) => {
   return result;
 };
 
+// Read the memoized result WITHOUT running analyze: returns it only when it is
+// already current for `docString`, else null. The decoration field uses this so
+// it never triggers an analyze of its own (the lint source is the sole caller
+// that fills the cache).
+const peekCached = (docString) =>
+  analyzeFn && docString === lastDoc ? lastResult : null;
+
 // analyze offsets are whole-document UTF-16 — CodeMirror's native unit — so
 // they map straight across; clamp defensively to the current doc length.
 const toDiagnostics = (view) => {
   const doc = view.state.doc;
   const result = analyzeCached(doc.toString());
+  // The lint pass just refreshed the cache for this doc; nudge the decoration
+  // field to re-read it (the initial doc lands here too, so inlays/lenses show
+  // on load — not only after the first edit).
+  scheduleRefresh(view);
   if (!result || !Array.isArray(result.diagnostics)) return [];
   const len = doc.length;
   return result.diagnostics.map((d) => {
@@ -49,6 +67,146 @@ const toDiagnostics = (view) => {
   });
 };
 
+// --- Hover types --------------------------------------------------------------
+// Ask the wasm for the type under the cursor (UTF-16 offset == CodeMirror pos)
+// and render it monospace in a small calm-theme tooltip.
+const hoverTypes = hoverTooltip((view, pos) => {
+  if (!hoverFn) return null;
+  let info;
+  try {
+    info = JSON.parse(hoverFn(view.state.doc.toString(), pos) || "");
+  } catch {
+    return null;
+  }
+  if (!info || !info.text) return null;
+  return {
+    pos: info.from | 0,
+    end: info.to | 0,
+    create: () => {
+      const dom = document.createElement("div");
+      dom.className = "cm-hover-type";
+      dom.textContent = info.text;
+      return { dom };
+    },
+  };
+});
+
+// --- Inlay hints + codelenses (one StateField) --------------------------------
+// Block decorations (the codelenses) MUST come from a StateField, not a
+// ViewPlugin — CodeMirror rejects block decorations from plugins. Inlays ride
+// along in the same field so both share the one cache-driven refresh.
+
+class InlayWidget extends WidgetType {
+  constructor(label) {
+    super();
+    this.label = label;
+  }
+  eq(other) {
+    return other.label === this.label;
+  }
+  toDOM() {
+    const span = document.createElement("span");
+    span.className = "cm-inlay";
+    span.textContent = this.label;
+    return span;
+  }
+  ignoreEvent() {
+    return true;
+  }
+}
+
+class LensWidget extends WidgetType {
+  constructor(text, indent) {
+    super();
+    this.text = text;
+    this.indent = indent;
+  }
+  eq(other) {
+    return other.text === this.text && other.indent === this.indent;
+  }
+  toDOM() {
+    const div = document.createElement("div");
+    div.className = "cm-lens";
+    div.textContent = this.text;
+    if (this.indent) div.style.paddingLeft = `${this.indent}ch`;
+    return div;
+  }
+  ignoreEvent() {
+    return true;
+  }
+}
+
+// Build the combined decoration set from the CACHED analysis for this doc, or
+// null when the cache is stale/empty (the field then keeps what it has).
+const buildDecorations = (state) => {
+  const result = peekCached(state.doc.toString());
+  if (!result) return null;
+  const doc = state.doc;
+  const len = doc.length;
+  const ranges = [];
+  for (const it of result.inlays || []) {
+    const pos = Math.max(0, Math.min(it.pos | 0, len));
+    ranges.push(
+      Decoration.widget({ widget: new InlayWidget(String(it.label ?? "")), side: 1 }).range(pos)
+    );
+  }
+  for (const it of result.lenses || []) {
+    const from = Math.max(0, Math.min(it.from | 0, len));
+    const line = doc.lineAt(from);
+    ranges.push(
+      Decoration.widget({
+        widget: new LensWidget(String(it.text ?? ""), from - line.from),
+        block: true,
+        side: -1,
+      }).range(line.from)
+    );
+  }
+  return Decoration.set(ranges, true);
+};
+
+// A signal to re-derive decorations from the (freshly filled) cache.
+const refreshDecorations = StateEffect.define();
+
+// Fired from the lint source after it fills the cache; a rAF avoids dispatching
+// mid-update. Only refreshes when the cache is current, so a keystroke landing
+// in the same frame doesn't clear the decorations.
+const scheduleRefresh = (view) =>
+  requestAnimationFrame(() => view.dispatch({ effects: refreshDecorations.of(null) }));
+
+// Decorate the INITIAL doc once, without waiting for an edit: the linter's
+// first pass isn't guaranteed to fire on load, so this one-shot analyzes the
+// starting buffer and refreshes. Ongoing edits are covered by the lint pass
+// (scheduleRefresh), so this fires exactly once.
+const initialRefresh = ViewPlugin.fromClass(
+  class {
+    constructor(view) {
+      requestAnimationFrame(() => {
+        analyzeCached(view.state.doc.toString());
+        view.dispatch({ effects: refreshDecorations.of(null) });
+      });
+    }
+  }
+);
+
+const decorationField = StateField.define({
+  create: (state) => buildDecorations(state) || Decoration.none,
+  update(value, tr) {
+    let decos = value;
+    // Keep decorations glued to their text between refreshes (no jitter under a
+    // keystroke storm) — they only re-derive when the lint pass refreshes.
+    if (tr.docChanged) decos = decos.map(tr.changes);
+    for (const effect of tr.effects) {
+      if (effect.is(refreshDecorations)) {
+        const built = buildDecorations(tr.state);
+        if (built) decos = built; // null == stale cache: keep the mapped set
+      }
+    }
+    return decos;
+  },
+  provide: (f) => EditorView.decorations.from(f),
+});
+
+// --- Theme (editor chrome) ----------------------------------------------------
 // Recolor lint's wavy underline to the calm theme's red (--red: #f2637f)
 // instead of its default bright #f11. Mirrors @codemirror/lint's own helper.
 const wavyUnderline = (color) =>
@@ -58,22 +216,58 @@ const wavyUnderline = (color) =>
   ) +
   `</svg>')`;
 
-const lintTheme = EditorView.theme({
+const mono = "'JetBrains Mono', 'Fira Code', ui-monospace, monospace";
+
+const intelTheme = EditorView.theme({
   ".cm-lintRange-error": { backgroundImage: wavyUnderline("#f2637f") },
+  // Hover: a small dark panel consistent with the editor chrome.
+  ".cm-tooltip.cm-tooltip-hover": {
+    backgroundColor: "#1e1833",
+    border: "1px solid #2b2542",
+    borderRadius: "5px",
+  },
+  ".cm-hover-type": {
+    fontFamily: mono,
+    fontSize: "12.5px",
+    color: "#e9e6f2",
+    padding: "3px 8px",
+    whiteSpace: "pre",
+  },
+  // Inlay hints: dimmed, slightly smaller, non-intrusive.
+  ".cm-inlay": {
+    color: "#6c6685",
+    fontSize: "0.85em",
+    padding: "0 1px",
+  },
+  // Codelenses: a dimmed signature line above the def.
+  ".cm-lens": {
+    fontFamily: mono,
+    fontSize: "0.82em",
+    color: "#6c6685",
+    fontStyle: "italic",
+    lineHeight: "1.5",
+  },
 });
 
-// Async setup: resolve to the lint extensions, or [] on any failure so the
-// editor degrades to no-analysis silently.
+// Async setup: resolve to the full intel extension set, or [] on any failure so
+// the editor degrades to no-analysis silently.
 export const setupLangIntel = async () => {
   try {
     const mod = await import(PKG_URL);
     await mod.default(); // init the wasm
     analyzeFn = mod.functor_lang_analyze;
+    hoverFn = mod.functor_lang_hover;
   } catch {
     console.info(
       "[lang-intel] language analysis unavailable (pkg not built) — editor runs without diagnostics"
     );
     return [];
   }
-  return [linter(toDiagnostics, { delay: 300 }), lintTheme];
+  return [
+    linter(toDiagnostics, { delay: 300 }),
+    hoverTypes,
+    decorationField,
+    initialRefresh,
+    intelTheme,
+  ];
 };

--- a/site/src/lang-intel.js
+++ b/site/src/lang-intel.js
@@ -25,8 +25,17 @@ const PKG_URL = "/pkg/functor_lang_wasm.js";
 let analyzeFn = null; // (src) => JSON string, set once the wasm is ready
 let hoverFn = null; // (src, offset) => JSON string ("" when nothing to show)
 let completeFn = null; // (src, offset) => JSON string, set once the wasm is ready
+let resetFn = null; // () => void, clears the wasm completion cache
 let lastDoc = null;
 let lastResult = null;
+
+// Clear the wasm completion last-good cache — called by the sandbox when the
+// editor document is wholly replaced (example switch, inline load, reset) so
+// stale candidates from the previous program can't leak into the new one. A
+// no-op when analysis is degraded/unavailable.
+export const resetIntel = () => {
+  if (resetFn) resetFn();
+};
 
 // Run analyze at most once per distinct doc string. Returns the parsed
 // `{ diagnostics, inlays, lenses }`, or null when the wasm isn't loaded.
@@ -93,9 +102,14 @@ const hoverTypes = hoverTooltip((view, pos) => {
     return null;
   }
   if (!info || !info.text) return null;
+  // Clamp to the current doc, exactly like toDiagnostics/buildDecorations: the
+  // wasm offsets can lag the live buffer by a keystroke.
+  const len = view.state.doc.length;
+  const from = Math.max(0, Math.min(info.from | 0, len));
+  const to = Math.max(from, Math.min(info.to | 0, len));
   return {
-    pos: info.from | 0,
-    end: info.to | 0,
+    pos: from,
+    end: to,
     create: () => {
       const dom = document.createElement("div");
       dom.className = "cm-hover-type";
@@ -342,9 +356,20 @@ export const setupLangIntel = async () => {
   try {
     const mod = await import(PKG_URL);
     await mod.default(); // init the wasm
+    // A partial/mismatched bundle (missing an expected export) degrades fully
+    // rather than installing half the intel — the catch below is the one seam.
+    if (
+      typeof mod.functor_lang_analyze !== "function" ||
+      typeof mod.functor_lang_hover !== "function" ||
+      typeof mod.functor_lang_complete !== "function"
+    ) {
+      throw new Error("functor-lang-wasm is missing an expected export");
+    }
     analyzeFn = mod.functor_lang_analyze;
     hoverFn = mod.functor_lang_hover;
     completeFn = mod.functor_lang_complete;
+    // reset is optional — an older bundle without it just skips cache clearing.
+    resetFn = typeof mod.functor_lang_reset === "function" ? mod.functor_lang_reset : null;
   } catch {
     console.info(
       "[lang-intel] language analysis unavailable (pkg not built) — editor runs without diagnostics"

--- a/site/src/player-bridge.js
+++ b/site/src/player-bridge.js
@@ -36,6 +36,21 @@ export class PlayerBridge {
     // Replies and readiness from the player iframe. Only trust the iframe we
     // created (same-origin, but be explicit about the source anyway).
     window.addEventListener("message", (event) => this.#onMessage(event));
+
+    // Handshake: the player posts a one-shot `functor-lang-preview-ready` when it
+    // boots, but under load that can fire before this bridge exists (its message
+    // listener isn't attached yet), leaving the status stuck "busy". So also
+    // greet the player: post `functor-lang-preview-hello` into the iframe now and
+    // on every load — an already-live player replies with the ready message.
+    this.#hello();
+    this.iframe.addEventListener("load", () => this.#hello());
+  }
+
+  // Greet the player so an already-live one re-announces readiness. Harmless if
+  // the player isn't up yet: it ignores the hello and its one-shot ready (now
+  // reaching our attached listener) covers that direction.
+  #hello() {
+    this.iframe.contentWindow?.postMessage({ type: "functor-lang-preview-hello" }, "*");
   }
 
   // Debounced live edit: swap in `source` once the buffer settles.
@@ -72,6 +87,9 @@ export class PlayerBridge {
     const data = event.data;
     if (!data) return;
     if (data.type === "functor-lang-preview-ready") {
+      // Idempotent: the one-shot ready and a hello-ack ready can both arrive for
+      // one live session — honor only the first (reset() re-arms this on reload).
+      if (this.previewReady) return;
       this.previewReady = true;
       // Flush edits made while the runtime was still starting.
       if (this.dirty) this.#post();

--- a/site/src/sandbox.js
+++ b/site/src/sandbox.js
@@ -10,7 +10,7 @@ import { StateEffect } from "@codemirror/state";
 import { indentWithTab } from "@codemirror/commands";
 import { startCompletion, acceptCompletion, closeCompletion } from "@codemirror/autocomplete";
 import { functorLangLanguage, synthwaveEditorTheme } from "./functor-lang.js";
-import { setupLangIntel, analyzeCached, completeAt } from "./lang-intel.js";
+import { setupLangIntel, analyzeCached, completeAt, resetIntel } from "./lang-intel.js";
 import { PlayerBridge } from "./player-bridge.js";
 
 const EXAMPLES = [
@@ -87,6 +87,9 @@ window.__lang = {
 
 const setDoc = (source) => {
   bridge.reset();
+  // Wholesale document replacement (example switch, inline load, reset): drop
+  // the wasm completion cache so the previous program's candidates can't leak.
+  resetIntel();
   programmaticEdit = true;
   view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: source } });
   programmaticEdit = false;

--- a/site/src/sandbox.js
+++ b/site/src/sandbox.js
@@ -8,8 +8,9 @@ import { basicSetup } from "codemirror";
 import { EditorView, keymap } from "@codemirror/view";
 import { StateEffect } from "@codemirror/state";
 import { indentWithTab } from "@codemirror/commands";
+import { startCompletion, acceptCompletion, closeCompletion } from "@codemirror/autocomplete";
 import { functorLangLanguage, synthwaveEditorTheme } from "./functor-lang.js";
-import { setupLangIntel, analyzeCached } from "./lang-intel.js";
+import { setupLangIntel, analyzeCached, completeAt } from "./lang-intel.js";
 import { PlayerBridge } from "./player-bridge.js";
 
 const EXAMPLES = [
@@ -81,6 +82,7 @@ const langReady = setupLangIntel().then((extensions) => {
 window.__lang = {
   ready: langReady,
   analyze: (source) => analyzeCached(source),
+  complete: (source, offset) => completeAt(source, offset),
 };
 
 const setDoc = (source) => {
@@ -192,4 +194,23 @@ window.__sandbox = {
     message: statusPill.title,
     detail: statusLog.textContent,
   }),
+  getSource: () => view.state.doc.toString(),
+  // Replace the buffer, place the cursor, and open the completion popup
+  // (explicit trigger). Guarded so it does NOT push to the runtime — completion
+  // is an editor-only concern that must not disturb the live loop. Any open
+  // popup is closed first so the fresh trigger reflects the new buffer.
+  triggerComplete(source, cursor) {
+    closeCompletion(view);
+    programmaticEdit = true;
+    view.dispatch({
+      changes: { from: 0, to: view.state.doc.length, insert: source },
+      selection: { anchor: cursor },
+    });
+    programmaticEdit = false;
+    view.focus();
+    startCompletion(view);
+  },
+  // Accept the selected completion (the editor's normal apply path — this DOES
+  // push, exactly as a real accept would). Returns whether one was applied.
+  acceptCompletion: () => acceptCompletion(view),
 };

--- a/site/src/sandbox.js
+++ b/site/src/sandbox.js
@@ -6,8 +6,10 @@
 
 import { basicSetup } from "codemirror";
 import { EditorView, keymap } from "@codemirror/view";
+import { StateEffect } from "@codemirror/state";
 import { indentWithTab } from "@codemirror/commands";
 import { functorLangLanguage, synthwaveEditorTheme } from "./functor-lang.js";
+import { setupLangIntel, analyzeCached } from "./lang-intel.js";
 import { PlayerBridge } from "./player-bridge.js";
 
 const EXAMPLES = [
@@ -65,6 +67,21 @@ const view = new EditorView({
     }),
   ],
 });
+
+// Live type diagnostics: load the analysis wasm lazily and, once ready, append
+// the CodeMirror linter to the already-constructed editor. Degrades silently —
+// if the pkg is absent the promise resolves to no extensions and the sandbox is
+// unchanged. `ready` resolves to whether analysis is available so e2e can await
+// it; `analyze` exposes the same cached pass the linter uses.
+const langReady = setupLangIntel().then((extensions) => {
+  if (extensions.length) view.dispatch({ effects: StateEffect.appendConfig.of(extensions) });
+  return extensions.length > 0;
+});
+
+window.__lang = {
+  ready: langReady,
+  analyze: (source) => analyzeCached(source),
+};
 
 const setDoc = (source) => {
   bridge.reset();

--- a/tools/functor-lang-wasm/Cargo.toml
+++ b/tools/functor-lang-wasm/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "functor-lang-wasm"
+version = "0.1.0"
+edition = "2021"
+
+# The in-browser language intelligence for the sandbox editor: the same
+# functor-lang analysis the LSP runs (diagnostics + inlay hints + code lenses +
+# hover), compiled to a small wasm module the editor imports directly. It is
+# SEPARATE from the engine wasm (functor-runtime-web): the editor lives in the
+# parent page, the engine in an iframe, so this stays a few hundred KB.
+[lib]
+# `cdylib` for the wasm-pack bundle, `rlib` so `cargo test` runs the pure
+# `*_json` functions natively (no wasm toolchain needed).
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+# functor-lang stays zero-dep; the wasm glue lives here, not in it.
+functor-lang = { path = "../../functor-lang" }
+functor-prelude = { path = "../../functor-prelude" }
+wasm-bindgen = "0.2"
+serde_json = "1"

--- a/tools/functor-lang-wasm/src/lib.rs
+++ b/tools/functor-lang-wasm/src/lib.rs
@@ -20,8 +20,10 @@
 //! `#[wasm_bindgen]` wrappers, so `cargo test -p functor-lang-wasm` exercises it
 //! natively.
 
+use std::cell::RefCell;
 use std::path::{Path, PathBuf};
 
+use functor_lang::complete::{CompletionItem, CompletionKind};
 use functor_lang::project::{self, Project, SourceFile};
 use serde_json::{json, Value};
 use wasm_bindgen::prelude::*;
@@ -55,6 +57,14 @@ pub fn functor_lang_analyze(src: &str) -> String {
 #[wasm_bindgen]
 pub fn functor_lang_hover(src: &str, offset: f64) -> String {
     hover_json(src, offset.max(0.0) as usize)
+}
+
+/// Completion candidates at `offset` (a UTF-16 code-unit position). Returns a
+/// JSON string `{"items": [{"label", "detail" (string|null), "kind"}]}` — the
+/// `kind` a lowercase string (`"function"`, `"module"`, …). Never throws.
+#[wasm_bindgen]
+pub fn functor_lang_complete(src: &str, offset: f64) -> String {
+    complete_json(src, offset.max(0.0) as usize)
 }
 
 /// See [`functor_lang_analyze`]. Pure — the tested seam.
@@ -126,6 +136,72 @@ pub fn hover_json(src: &str, offset: usize) -> String {
         "text": text,
     })
     .to_string()
+}
+
+// The last project that loaded cleanly — dot-completion keeps answering off
+// this while the live buffer is mid-edit or broken (the offset contract:
+// context comes from the live `src`, candidates from a possibly-stale
+// project). Refreshed on every clean load. Per-wasm-instance, single-threaded.
+thread_local! {
+    static LAST_GOOD: RefCell<Option<Project>> = const { RefCell::new(None) };
+}
+
+/// The most completion items to encode — bounds the JSON for a huge namespace.
+const MAX_ITEMS: usize = 200;
+
+/// See [`functor_lang_complete`]. Pure — the tested seam. `offset` is UTF-16.
+///
+/// Refreshes the last-good cache when `src` loads cleanly, then completes
+/// against it (falling back to the previous cache when the live buffer is
+/// broken; empty items when nothing has loaded yet). The byte offset the
+/// language crate wants is LOCAL to `src`, so it converts straight from UTF-16
+/// with no `file.base`.
+pub fn complete_json(src: &str, offset: usize) -> String {
+    let byte = from_u16(src, offset);
+    if let Ok(project) = load(src) {
+        LAST_GOOD.with(|cell| *cell.borrow_mut() = Some(project));
+    }
+    LAST_GOOD.with(|cell| {
+        let borrow = cell.borrow();
+        let Some(project) = borrow.as_ref() else {
+            return empty_completion();
+        };
+        let items = functor_lang::complete::complete(project, &project.entry, src, byte);
+        completion_json(&items)
+    })
+}
+
+/// Encode completion items as `{"items": [...]}`, capped at [`MAX_ITEMS`].
+fn completion_json(items: &[CompletionItem]) -> String {
+    let items: Vec<Value> = items
+        .iter()
+        .take(MAX_ITEMS)
+        .map(|item| {
+            json!({
+                "label": item.label,
+                "detail": item.detail,
+                "kind": kind_str(item.kind),
+            })
+        })
+        .collect();
+    json!({ "items": items }).to_string()
+}
+
+fn empty_completion() -> String {
+    json!({ "items": [] }).to_string()
+}
+
+/// A completion kind as a lowercase string, matching the CodeMirror `type` the
+/// editor maps to a built-in icon.
+fn kind_str(kind: CompletionKind) -> &'static str {
+    match kind {
+        CompletionKind::Function => "function",
+        CompletionKind::Value => "value",
+        CompletionKind::Module => "module",
+        CompletionKind::Keyword => "keyword",
+        CompletionKind::Constructor => "constructor",
+        CompletionKind::Field => "field",
+    }
 }
 
 /// Load `src` as a single-file project with the host prelude injected (so
@@ -296,6 +372,89 @@ mod tests {
         // The flagged token is the `"x"` string literal (wrong type for `+`).
         assert!(src[byte_from..].starts_with("\"x\""), "flagged {:?}: {out}", &src[byte_from..]);
         assert!(to > from && to <= utf16_len(src));
+    }
+
+    // Prime the last-good cache with a clean buffer, then complete `live` at its
+    // end (UTF-16). Returns the parsed `{ items }` — the same one/two-step the
+    // editor does (a valid doc parses, then the user types a `.`).
+    fn complete_after(prime_src: &str, live: &str) -> Value {
+        complete_json(prime_src, 0); // load cleanly → refresh the cache
+        parse(&complete_json(live, utf16_len(live)))
+    }
+
+    fn labels(items: &Value) -> Vec<String> {
+        items["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|i| i["label"].as_str().unwrap().to_string())
+            .collect()
+    }
+
+    fn item<'a>(items: &'a Value, label: &str) -> &'a Value {
+        items["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|i| i["label"] == label)
+            .unwrap_or_else(|| panic!("no `{label}` in {:?}", labels(items)))
+    }
+
+    // (a) `Scene.` member completion offers prelude members with kind
+    // "function". The buffer is a complete, valid program (`Scene.cube()`) with
+    // the cursor right after the dot — the fresh path.
+    #[test]
+    fn scene_member_completion() {
+        let src = "let d = () => Scene.cube()";
+        let offset = utf16_len(&src[..src.find("Scene.").unwrap() + "Scene.".len()]);
+        let out = parse(&complete_json(src, offset));
+        let names = labels(&out);
+        assert!(names.contains(&"cube".to_string()), "{names:?}");
+        assert!(names.len() > 3, "expected many Scene members: {names:?}");
+        assert_eq!(item(&out, "cube")["kind"], "function");
+        assert!(item(&out, "cube")["detail"].is_string(), "{out}");
+    }
+
+    // (b) A BROKEN live buffer (trailing `.`) still completes via the last-good
+    // cache — the cache was primed by a clean, unrelated buffer.
+    #[test]
+    fn broken_buffer_completes_from_cache() {
+        let out = complete_after("let main = () => 1.0", "let x = 1.0\nlet s = Scene.");
+        let names = labels(&out);
+        assert!(names.contains(&"cube".to_string()), "{names:?}");
+        assert_eq!(item(&out, "cube")["kind"], "function");
+    }
+
+    // (c) UTF-16 offset conversion: a non-ASCII prefix pushes byte offsets past
+    // their UTF-16 counterparts, so a raw UTF-16-as-bytes offset would miss the
+    // dot. The correct conversion lands member completion (`cube` present).
+    #[test]
+    fn completion_offset_is_utf16() {
+        // 'é' (2 bytes) and '→' (3 bytes) before the completion point.
+        let src = "let label = \"café→\"\nlet d = () => Scene.cube()";
+        let dot = src.find("Scene.").unwrap() + "Scene.".len();
+        let offset = utf16_len(&src[..dot]);
+        // The byte offset must exceed the UTF-16 offset — proving conversion is
+        // needed (a raw offset would land short of the dot).
+        assert!(dot > offset, "expected multibyte prefix: byte {dot} vs utf16 {offset}");
+        let out = parse(&complete_json(src, offset));
+        assert!(labels(&out).contains(&"cube".to_string()), "{:?}", labels(&out));
+    }
+
+    // (d) A top-level partial `le` includes the keyword `let`.
+    #[test]
+    fn top_level_partial_offers_keyword() {
+        let out = complete_after("let main = () => 1.0", "le");
+        assert!(labels(&out).contains(&"let".to_string()), "{:?}", labels(&out));
+        assert_eq!(item(&out, "let")["kind"], "keyword");
+    }
+
+    // An empty cache (nothing ever loaded) answers with empty items, never an
+    // error, on a broken buffer.
+    #[test]
+    fn empty_cache_is_empty_items() {
+        let out = parse(&complete_json("let s = Scene.", utf16_len("let s = Scene.")));
+        assert!(out["items"].as_array().unwrap().is_empty(), "{out}");
     }
 
     // Hover round-trips on a non-ASCII line: the returned span's UTF-16 offsets

--- a/tools/functor-lang-wasm/src/lib.rs
+++ b/tools/functor-lang-wasm/src/lib.rs
@@ -1,0 +1,319 @@
+//! In-browser Functor Lang language intelligence for the sandbox editor.
+//!
+//! The same front-end the LSP runs (`tools/functor-lang-lsp`) — diagnostics,
+//! inlay hints, code lenses, and hover — compiled to a small wasm module the
+//! CodeMirror editor imports directly. The editor lives in the sandbox's
+//! PARENT page (the engine runs in an iframe), so this is its own tiny bundle
+//! rather than a slice of the multi-MB engine wasm.
+//!
+//! Two exports, both returning JSON strings so the JS side needs no schema:
+//!
+//! - [`functor_lang_analyze`] runs ONE load/check pass and reports all three of
+//!   diagnostics, inlay hints, and code lenses.
+//! - [`functor_lang_hover`] answers a single hover at an offset.
+//!
+//! **Positions are UTF-16 code units**, matching CodeMirror (and JS string)
+//! indexing: byte offsets from the parser are converted here in Rust, exactly
+//! as the LSP converts them to LSP `character` counts.
+//!
+//! All logic lives in plain `pub fn`s (`analyze_json` / `hover_json`) with thin
+//! `#[wasm_bindgen]` wrappers, so `cargo test -p functor-lang-wasm` exercises it
+//! natively.
+
+use std::path::{Path, PathBuf};
+
+use functor_lang::project::{self, Project, SourceFile};
+use serde_json::{json, Value};
+use wasm_bindgen::prelude::*;
+
+/// The single user file's name. The sandbox is a one-file program; the loader
+/// puts it first, so its span base is 0 and its project-wide offsets ARE byte
+/// offsets into `src`.
+const USER_FILE: &str = "game.fun";
+
+/// Analyze `src`: one load/check pass producing diagnostics, inlay hints, and
+/// code lenses. Returns a JSON string:
+///
+/// ```json
+/// {
+///   "diagnostics": [{ "from": u16, "to": u16, "message": str, "severity": "error" }],
+///   "inlays":      [{ "pos": u16, "label": str }],
+///   "lenses":      [{ "line": u32, "from": u16, "text": str }]
+/// }
+/// ```
+///
+/// `from`/`to`/`pos` are whole-document UTF-16 offsets; `line` is 0-based.
+/// A load-level failure (parse/link error) comes back as a single diagnostic —
+/// never an exception. Prelude spans are filtered out.
+#[wasm_bindgen]
+pub fn functor_lang_analyze(src: &str) -> String {
+    analyze_json(src)
+}
+
+/// Hover at `offset` (a UTF-16 code-unit position). Returns `{"from","to","text"}`
+/// (both UTF-16 offsets) or `""` when there is nothing to show.
+#[wasm_bindgen]
+pub fn functor_lang_hover(src: &str, offset: f64) -> String {
+    hover_json(src, offset.max(0.0) as usize)
+}
+
+/// See [`functor_lang_analyze`]. Pure — the tested seam.
+pub fn analyze_json(src: &str) -> String {
+    let project = match load(src) {
+        Ok(project) => project,
+        // A parse/link failure surfaces as one diagnostic at the reported
+        // point, not an error.
+        Err(err) => return load_error_json(src, err),
+    };
+    let Some(file) = project.sources.file_by_path(Path::new(USER_FILE)) else {
+        return empty_analysis();
+    };
+    let (diags, types) = project.check_with_types();
+
+    let diagnostics: Vec<Value> = diags
+        .into_iter()
+        .filter(|d| owns(file, d.span.start))
+        .map(|d| {
+            json!({
+                "from": to_u16(file, d.span.start),
+                "to": to_u16(file, d.span.end),
+                "message": d.message,
+                "severity": "error",
+            })
+        })
+        .collect();
+
+    let inlays: Vec<Value> = functor_lang::inlay::inlay_hints(&project.module, &types)
+        .into_iter()
+        .filter(|h| owns(file, h.offset))
+        .map(|h| json!({ "pos": to_u16(file, h.offset), "label": h.label }))
+        .collect();
+
+    let lenses: Vec<Value> = functor_lang::codelens::signatures(&project.module, &types)
+        .into_iter()
+        .filter(|l| owns(file, l.span.start))
+        .map(|l| {
+            json!({
+                "line": line_of(file, l.span.start),
+                "from": to_u16(file, l.span.start),
+                "text": l.title,
+            })
+        })
+        .collect();
+
+    json!({ "diagnostics": diagnostics, "inlays": inlays, "lenses": lenses }).to_string()
+}
+
+/// See [`functor_lang_hover`]. Pure — the tested seam. `offset` is UTF-16.
+pub fn hover_json(src: &str, offset: usize) -> String {
+    let Ok(project) = load(src) else {
+        return String::new();
+    };
+    let Some(file) = project.sources.file_by_path(Path::new(USER_FILE)) else {
+        return String::new();
+    };
+    let byte = file.base + from_u16(&file.src, offset);
+    let (_, types) = project.check_with_types();
+    let Some((span, text)) = functor_lang::hover::hover_text(&project.module, &types, byte) else {
+        return String::new();
+    };
+    if !owns(file, span.start) {
+        return String::new();
+    }
+    json!({
+        "from": to_u16(file, span.start),
+        "to": to_u16(file, span.end),
+        "text": text,
+    })
+    .to_string()
+}
+
+/// Load `src` as a single-file project with the host prelude injected (so
+/// `Scene.*` / `Camera.*` / … typecheck), mirroring the LSP.
+fn load(src: &str) -> Result<Project, project::ProjectError> {
+    project::load_sources_with_prelude(
+        vec![(PathBuf::from(USER_FILE), src.to_string())],
+        &functor_prelude::modules(),
+    )
+}
+
+/// A load failure → one diagnostic at its reported point. The `ProjectError`
+/// gives a 1-based (line, col) in the user file (base 0); convert it to a
+/// zero-width UTF-16 offset.
+fn load_error_json(src: &str, err: project::ProjectError) -> String {
+    let byte = line_col_to_byte(src, err.line, err.col);
+    let at = utf16_len(&src[..byte.min(src.len())]);
+    json!({
+        "diagnostics": [{ "from": at, "to": at, "message": err.message, "severity": "error" }],
+        "inlays": [],
+        "lenses": [],
+    })
+    .to_string()
+}
+
+fn empty_analysis() -> String {
+    json!({ "diagnostics": [], "inlays": [], "lenses": [] }).to_string()
+}
+
+/// Whether a project-wide `offset` falls in `file` (its half-open base range) —
+/// the LSP's `owns`, which keeps prelude/builtin spans from leaking.
+fn owns(file: &SourceFile, offset: usize) -> bool {
+    file.base <= offset && offset <= file.base + file.src.len()
+}
+
+/// A project-wide byte offset → a whole-document UTF-16 offset within `file`.
+fn to_u16(file: &SourceFile, offset: usize) -> usize {
+    let local = offset.saturating_sub(file.base).min(file.src.len());
+    utf16_len(&file.src[..local])
+}
+
+/// The 0-based line a project-wide byte offset sits on within `file`.
+fn line_of(file: &SourceFile, offset: usize) -> usize {
+    let local = offset.saturating_sub(file.base).min(file.src.len());
+    file.src[..local].matches('\n').count()
+}
+
+/// UTF-16 code-unit length of `s` (what CodeMirror/JS counts).
+fn utf16_len(s: &str) -> usize {
+    s.encode_utf16().count()
+}
+
+/// A whole-document UTF-16 offset → a byte offset into `src`. Clamps past the
+/// end. Inverse of [`utf16_len`] over a prefix.
+fn from_u16(src: &str, units: usize) -> usize {
+    let mut seen = 0;
+    for (byte, ch) in src.char_indices() {
+        if seen >= units {
+            return byte;
+        }
+        seen += ch.len_utf16();
+    }
+    src.len()
+}
+
+/// A 1-based (line, col) — `col` counting characters from the line start, as
+/// `functor_lang::line_col` reports — back to a byte offset into `src`.
+fn line_col_to_byte(src: &str, line: usize, col: usize) -> usize {
+    let mut cur_line = 1;
+    let mut cur_col = 1;
+    for (byte, ch) in src.char_indices() {
+        if cur_line == line && cur_col == col {
+            return byte;
+        }
+        if ch == '\n' {
+            cur_line += 1;
+            cur_col = 1;
+        } else {
+            cur_col += 1;
+        }
+    }
+    src.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(json: &str) -> Value {
+        serde_json::from_str(json).unwrap()
+    }
+
+    // A valid program using prelude names typechecks: no diagnostics, and the
+    // prelude's own files leak nothing into inlays/lenses (only the user file's
+    // one def is reported).
+    #[test]
+    fn valid_program_with_prelude_is_clean() {
+        let src = "let draw = (model, tts: Float) =>\n  \
+            Frame.create(Camera.lookAt(0.0, 0.0, -6.0, 0.0, 0.0, 0.0), Scene.cube())\n";
+        let out = parse(&analyze_json(src));
+        assert_eq!(out["diagnostics"].as_array().unwrap().len(), 0, "{out}");
+        // Inlays/lenses come only from the user file — never from the injected
+        // prelude `.funi` modules.
+        for lens in out["lenses"].as_array().unwrap() {
+            let from = lens["from"].as_u64().unwrap() as usize;
+            assert!(from <= utf16_len(src), "lens leaked past user file: {lens}");
+        }
+        for inlay in out["inlays"].as_array().unwrap() {
+            let pos = inlay["pos"].as_u64().unwrap() as usize;
+            assert!(pos <= utf16_len(src), "inlay leaked past user file: {inlay}");
+        }
+        // The one top-level def gets a signature lens on line 0.
+        let lenses = out["lenses"].as_array().unwrap();
+        assert!(
+            lenses.iter().any(|l| l["line"] == 0),
+            "expected a lens for `draw` on line 0: {out}"
+        );
+    }
+
+    // A type error → exactly one diagnostic, with correct ASCII UTF-16 offsets
+    // (here byte == UTF-16, since the source is ASCII) spanning the offending
+    // sub-expression.
+    #[test]
+    fn type_error_reports_one_diagnostic() {
+        // `1.0 + "x"`: adding a string to a float is a type error.
+        let src = "let bad = 1.0 + \"x\"\n";
+        let out = parse(&analyze_json(src));
+        let diags = out["diagnostics"].as_array().unwrap();
+        assert_eq!(diags.len(), 1, "{out}");
+        let d = &diags[0];
+        let from = d["from"].as_u64().unwrap() as usize;
+        let to = d["to"].as_u64().unwrap() as usize;
+        assert!(from < to && to <= utf16_len(src), "span {from}..{to}: {out}");
+        assert_eq!(d["severity"], "error");
+    }
+
+    // A parse failure comes back as a single diagnostic (never an exception),
+    // at the reported point.
+    #[test]
+    fn parse_error_is_a_single_diagnostic() {
+        let out = parse(&analyze_json("let init = {\n"));
+        let diags = out["diagnostics"].as_array().unwrap();
+        assert_eq!(diags.len(), 1, "{out}");
+        assert_eq!(diags[0]["severity"], "error");
+    }
+
+    // Non-ASCII before an error proves the UTF-8 byte offset is converted to a
+    // UTF-16 code-unit offset: the multi-byte characters make the byte offset
+    // strictly larger than the UTF-16 offset.
+    #[test]
+    fn non_ascii_offsets_are_utf16() {
+        // "héllo→" — 'é' is 2 bytes, '→' is 3 bytes — sits before the error.
+        let src = "let s = \"héllo→\"\nlet bad = 1.0 + \"x\"\n";
+        let out = parse(&analyze_json(src));
+        let diags = out["diagnostics"].as_array().unwrap();
+        assert_eq!(diags.len(), 1, "{out}");
+        let from = diags[0]["from"].as_u64().unwrap() as usize;
+        let to = diags[0]["to"].as_u64().unwrap() as usize;
+        // The multi-byte chars on line 1 push every byte offset on line 2 ahead
+        // of its UTF-16 offset: the flagged token's byte position must be
+        // STRICTLY greater than the reported UTF-16 offset — proving conversion
+        // happened (a raw byte offset would be equal).
+        let byte_from = from_u16(src, from);
+        assert!(
+            byte_from > from,
+            "byte from ({byte_from}) should exceed UTF-16 from ({from}) — conversion applied: {out}"
+        );
+        // The flagged token is the `"x"` string literal (wrong type for `+`).
+        assert!(src[byte_from..].starts_with("\"x\""), "flagged {:?}: {out}", &src[byte_from..]);
+        assert!(to > from && to <= utf16_len(src));
+    }
+
+    // Hover round-trips on a non-ASCII line: the returned span's UTF-16 offsets
+    // map back to the identifier's bytes.
+    #[test]
+    fn hover_round_trips_on_non_ascii_line() {
+        // `spin` is used after a non-ASCII string literal; hover over it.
+        let src = "let label = \"café→\"\nlet spin = 3.0\nlet twice = spin + spin\n";
+        // Offset (UTF-16) of the first `spin` in `twice`'s body.
+        let byte = src.rfind("spin + spin").unwrap();
+        let offset = utf16_len(&src[..byte]);
+        let out = hover_json(src, offset);
+        assert!(!out.is_empty(), "expected a hover result");
+        let v = parse(&out);
+        let from = v["from"].as_u64().unwrap() as usize;
+        let to = v["to"].as_u64().unwrap() as usize;
+        assert_eq!(from_u16(src, from), byte, "hover from maps back to bytes");
+        assert_eq!(&src[from_u16(src, from)..from_u16(src, to)], "spin");
+        assert!(v["text"].as_str().unwrap().contains("float"), "{out}");
+    }
+}

--- a/tools/functor-lang-wasm/src/lib.rs
+++ b/tools/functor-lang-wasm/src/lib.rs
@@ -40,11 +40,11 @@ const USER_FILE: &str = "game.fun";
 /// {
 ///   "diagnostics": [{ "from": u16, "to": u16, "message": str, "severity": "error" }],
 ///   "inlays":      [{ "pos": u16, "label": str }],
-///   "lenses":      [{ "line": u32, "from": u16, "text": str }]
+///   "lenses":      [{ "from": u16, "text": str }]
 /// }
 /// ```
 ///
-/// `from`/`to`/`pos` are whole-document UTF-16 offsets; `line` is 0-based.
+/// `from`/`to`/`pos` are whole-document UTF-16 offsets.
 /// A load-level failure (parse/link error) comes back as a single diagnostic —
 /// never an exception. Prelude spans are filtered out.
 #[wasm_bindgen]
@@ -65,6 +65,14 @@ pub fn functor_lang_hover(src: &str, offset: f64) -> String {
 #[wasm_bindgen]
 pub fn functor_lang_complete(src: &str, offset: f64) -> String {
     complete_json(src, offset.max(0.0) as usize)
+}
+
+/// Clear the completion last-good cache. The sandbox calls this whenever the
+/// editor document is wholly replaced (example switch, inline `#src=` load,
+/// reset) so candidates from the previous program can't leak into the new one.
+#[wasm_bindgen]
+pub fn functor_lang_reset() {
+    reset_cache();
 }
 
 /// See [`functor_lang_analyze`]. Pure — the tested seam.
@@ -104,7 +112,6 @@ pub fn analyze_json(src: &str) -> String {
         .filter(|l| owns(file, l.span.start))
         .map(|l| {
             json!({
-                "line": line_of(file, l.span.start),
                 "from": to_u16(file, l.span.start),
                 "text": l.title,
             })
@@ -169,6 +176,13 @@ pub fn complete_json(src: &str, offset: usize) -> String {
         let items = functor_lang::complete::complete(project, &project.entry, src, byte);
         completion_json(&items)
     })
+}
+
+/// See [`functor_lang_reset`]. Pure — the tested seam. Drops the last-good
+/// project so the next completion starts from a blank cache (no candidates from
+/// a previously-loaded, now-replaced document).
+pub fn reset_cache() {
+    LAST_GOOD.with(|cell| *cell.borrow_mut() = None);
 }
 
 /// Encode completion items as `{"items": [...]}`, capped at [`MAX_ITEMS`].
@@ -243,12 +257,6 @@ fn to_u16(file: &SourceFile, offset: usize) -> usize {
     utf16_len(&file.src[..local])
 }
 
-/// The 0-based line a project-wide byte offset sits on within `file`.
-fn line_of(file: &SourceFile, offset: usize) -> usize {
-    let local = offset.saturating_sub(file.base).min(file.src.len());
-    file.src[..local].matches('\n').count()
-}
-
 /// UTF-16 code-unit length of `s` (what CodeMirror/JS counts).
 fn utf16_len(s: &str) -> usize {
     s.encode_utf16().count()
@@ -313,11 +321,13 @@ mod tests {
             let pos = inlay["pos"].as_u64().unwrap() as usize;
             assert!(pos <= utf16_len(src), "inlay leaked past user file: {inlay}");
         }
-        // The one top-level def gets a signature lens on line 0.
+        // The one top-level def gets a signature lens titled `draw : …`.
         let lenses = out["lenses"].as_array().unwrap();
         assert!(
-            lenses.iter().any(|l| l["line"] == 0),
-            "expected a lens for `draw` on line 0: {out}"
+            lenses
+                .iter()
+                .any(|l| l["text"].as_str().unwrap().starts_with("draw ")),
+            "expected a signature lens for `draw`: {out}"
         );
     }
 
@@ -455,6 +465,47 @@ mod tests {
     fn empty_cache_is_empty_items() {
         let out = parse(&complete_json("let s = Scene.", utf16_len("let s = Scene.")));
         assert!(out["items"].as_array().unwrap().is_empty(), "{out}");
+    }
+
+    // Resetting the cache clears the last-good project: a broken buffer for a
+    // DIFFERENT program, completed after a reset, does NOT offer the previous
+    // program's globals — the fix for switching sandbox examples and then
+    // dot-completing a broken buffer. Without the reset the stale cache is
+    // deliberately reused (the offset contract: candidates from a
+    // possibly-stale project), which this test also documents.
+    #[test]
+    fn reset_clears_completion_cache() {
+        // Program A defines a distinctive global `alpha`.
+        let a = "let alpha = 1.0\nlet main = () => alpha";
+        // A DIFFERENT, broken program (a bare top-level word `al` never parses),
+        // so it can't refresh the cache — completion falls back to whatever the
+        // cache holds. `al` is a top-level partial that matches A's `alpha`.
+        let broken_b = "let beta = 2.0\nal";
+        let at = utf16_len(broken_b);
+
+        // Without reset: A's `alpha` leaks into the broken B buffer.
+        complete_json(a, 0); // load A cleanly → cache A
+        let leaked = parse(&complete_json(broken_b, at));
+        assert!(
+            labels(&leaked).contains(&"alpha".to_string()),
+            "expected stale reuse of A's globals: {:?}",
+            labels(&leaked)
+        );
+
+        // With reset: the cache is cleared, so A's globals are gone and the
+        // broken buffer completes to nothing (empty cache → empty items).
+        complete_json(a, 0); // re-cache A
+        reset_cache();
+        let cleared = parse(&complete_json(broken_b, at));
+        assert!(
+            !labels(&cleared).contains(&"alpha".to_string()),
+            "cache not cleared — A's globals still offered: {:?}",
+            labels(&cleared)
+        );
+        assert!(
+            cleared["items"].as_array().unwrap().is_empty(),
+            "empty cache → empty items: {cleared}"
+        );
     }
 
     // Hover round-trips on a non-ASCII line: the returned span's UTF-16 offsets


### PR DESCRIPTION
Stack 2 of the site redesign, on top of #343: the sandbox editor gets full language intelligence, entirely in the browser — no server round-trips, and the landing page stays light (none of this loads there).

## What's here (6 commits)

- **`feat(tools)`: `tools/functor-lang-wasm`** — a new workspace crate compiling the same functor-lang analysis the LSP uses to a **~500 KB** wasm module (vs the multi-MB engine): `functor_lang_analyze` (diagnostics + inlay hints + codelens in one pass), `functor_lang_hover`, `functor_lang_complete`, `functor_lang_reset` — all JSON with **UTF-16 offsets converted in Rust** (non-ASCII unit tests prove byte ≠ UTF-16). Prelude injected via `functor_prelude::modules()`, spans filtered to the user file, `functor-lang` itself stays zero-dep. `npm run build:lang-wasm`; `site/build.mjs` copies the pkg when present and the site **degrades silently when it's absent** (verified: the e2e runs green in both configurations).
- **`feat(site)`: live type diagnostics** — `@codemirror/lint` squiggles at 300ms, themed to the calm palette; one memoized analyze pass per document.
- **`feat(site)`: hover types, inlay hints, codelens** — `hoverTooltip` + inline widgets + line-above signature widgets (block decorations from a `StateField`, per the CM constraint), all reading the cached lint pass; decorations map through edits between passes.
- **`feat(site)`: scope-aware autocomplete** — dot-completion + locals + keywords from the newly-merged `complete.rs`, with kind icons, dim signature details, and a last-good project cache so completion keeps working mid-edit on a broken buffer (the LSP's design). Registered via the StreamLanguage's `languageData`; themed popup.
- **`fix(site)`: close-out** — review fixes (cache reset on whole-document switches, hover clamp parity, degraded mode on partial exports, dead-code removal) plus two root-caused e2e flakes (the one-shot `preview-ready` handshake race → hello/ack in the player bridge; premature status reads in the diagnostics checks).

| Diagnostics | Hover + inlays + codelens | Autocomplete |
|---|---|---|
| ![red squiggle under a type error while the game stays live](https://gist.githubusercontent.com/tommy-xr/d00c54b7467246e1253ab4110fbd7865/raw/commit7-squiggle.png) | ![hover tooltip, dimmed : float inlays, signature lines above defs](https://gist.githubusercontent.com/tommy-xr/d00c54b7467246e1253ab4110fbd7865/raw/commit8-intel.png) | ![completion popup after Scene. with kind icons and signatures](https://gist.githubusercontent.com/tommy-xr/d00c54b7467246e1253ab4110fbd7865/raw/commit8b-complete.png) |

## Verification

- `cargo test -p functor-lang-wasm` — 11 tests (JSON shapes, prelude-span filtering, UTF-16 round-trips, last-good cache semantics incl. reset).
- `npm run test:site` — 42 checks, green **3× consecutively** (the close-out fixed the two flakes), and green with the lang pkg absent (features SKIP, sandbox unaffected).
- Two-engine adversarial review (Claude + Codex): no Critical/High; both Mediums addressed (one fixed, one accepted-by-design with rationale — decorations map through edits until the debounced pass settles, as in VS Code).

A type error squiggles **while the game keeps running** — the web runtime treats check diagnostics as advisory, so the sandbox stays live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
