### PR TITLE
fix(project): refuse a non-identifier entry stem on disk even with no siblings

### DIFF
--- a/functor-lang/src/project.rs
+++ b/functor-lang/src/project.rs
@@ -337,6 +337,13 @@ pub fn load_with_prelude(
         );
     }
 
+    // The ENTRY is always loaded, so its stem must name a valid module even
+    // when it has no siblings — an on-disk one-file project must NOT take the
+    // single-source `Main` fallback in `load_sources_with_prelude`, which
+    // exists for the inline wasm/docs single-entry case where the path is
+    // only a label.
+    module_name(entry_path).map_err(|message| at(entry_path, message))?;
+
     // Read every project file (entry first), honoring the in-memory overrides,
     // then hand the (path, source) pairs to the shared linker.
     let mut sources: Vec<(PathBuf, String)> = Vec::new();


### PR DESCRIPTION
Fixes a semantic conflict between two independently-green PRs that merged in close succession:

- #343 added a **single-source `Main` fallback** in `load_sources_with_prelude` for the inline wasm/docs single-entry case (the path is only a label there).
- #333 added the rule (and test `non_identifier_entry_stem_is_refused`) that an **on-disk entry** must always name a valid module, even though bad-stem *siblings* are now skipped.

Together: a one-file on-disk project hits `sources.len() == 1`, takes the `Main` fallback, and loads silently instead of erroring — so `non_identifier_entry_stem_is_refused` fails on `main` right now.

**Fix:** `load_with_prelude` (the on-disk path) validates the entry's module name loudly before linking. The in-memory single-source fallback (wasm sandbox / docs try-it / LSP single-buffer) is untouched.

The regression test already exists — it's the one this un-breaks. `cargo test -p functor-lang` fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)