### PR TITLE
feat(web-runtime): functor_lang_set_project — multi-file hot-swap seam for the web IDE

### DIFF
--- a/e2e/ide-project.mjs
+++ b/e2e/ide-project.mjs
@@ -1,0 +1,194 @@
+// IDE project-seam e2e: the multi-file postMessage protocol, headless — the
+// seam the site IDE builds on (player.html?project=inline +
+// functor_lang_set_project), with no IDE UI involved:
+//
+//   1. player.html?project=inline announces `functor-lang-project-waiting`
+//      and boots nothing until files arrive;
+//   2. a pushed two-file project (game.fun referencing Pieces.*) boots from
+//      MEMORY — no .fun is fetched — and reports `functor-lang-preview-ready`;
+//   3. a `functor-lang-set-project` push editing the SIBLING module hot-swaps
+//      (the thing `functor-lang-set-source` cannot do) and echoes the push id;
+//   4. a broken sibling push reports the error and keeps the old program;
+//   5. a good push after the broken one recovers and clears the overlay.
+//
+// Run manually (needs the wasm bundle):
+//
+//   wasm-pack build runtime/functor-runtime-web --target=web   # once
+//   node e2e/ide-project.mjs
+import { spawn, spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { chromium } from "@playwright/test";
+
+const PORT = 8124;
+const BASE = `http://127.0.0.1:${PORT}`;
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+
+const PIECES_V1 = `let speed = 1.0
+let glow = 0.2
+`;
+const PIECES_V2 = `let speed = 3.0
+let glow = 0.9
+`;
+const PIECES_BROKEN = `let speed =
+`;
+const GAME = `let init = { t: 0.0 }
+let tick = (model, dt: Float, tts: Float) => { model with t: model.t + dt * Pieces.speed }
+let draw = (model, tts: Float) =>
+  Frame.create(
+    Camera.lookAt(0.0, 0.0, -6.0, 0.0, 0.0, 0.0),
+    Scene.sphere() |> Scene.emissive(0.1, 1.0, Pieces.glow) |> Scene.scale(2.0))
+`;
+
+const project = (pieces) => [
+  { path: "game.fun", source: GAME },
+  { path: "pieces.fun", source: pieces },
+];
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const fail = (message) => {
+  console.error(`FAIL: ${message}`);
+  process.exitCode = 1;
+};
+
+// Build the site fresh so dist matches the working tree.
+const built = spawnSync("node", ["site/build.mjs"], { cwd: ROOT, stdio: "inherit" });
+if (built.status !== 0) {
+  console.error("FAIL: site build failed");
+  process.exit(1);
+}
+
+const server = spawn("node", ["site/serve.mjs", "--port", String(PORT)], {
+  cwd: ROOT,
+  stdio: "ignore",
+});
+const browser = await chromium.launch({
+  args: [
+    "--use-gl=angle",
+    "--use-angle=swiftshader",
+    "--enable-unsafe-swiftshader",
+    "--ignore-gpu-blocklist",
+  ],
+});
+
+try {
+  const page = await browser.newPage({ viewport: { width: 640, height: 480 } });
+  const log = [];
+  page.on("console", (m) => log.push(m.text()));
+  // Load the player in an IFRAME on a same-origin host — exactly how the IDE
+  // hosts it. The player posts its announcements/results to `window.parent`
+  // (the top frame), where the init-script listener collects them; our pushes
+  // go the other way, to the iframe's contentWindow, arriving with
+  // event.source === window.parent as the player's handler requires.
+  await page.addInitScript(() => {
+    window.__msgs = [];
+    window.addEventListener("message", (e) => {
+      if (e.data && typeof e.data.type === "string") window.__msgs.push(e.data);
+    });
+  });
+
+  // A CLEAN same-origin host (not the landing page — its live hero player
+  // emits the very protocol messages we assert on, which would pollute the
+  // top-window collection). Route a blank document so only our iframe speaks.
+  await page.route(`${BASE}/__ide_host`, (route) =>
+    route.fulfill({ contentType: "text/html", body: "<!doctype html><title>ide host</title>" })
+  );
+  // Wait for the dev server, then mount the host page + player iframe.
+  for (let i = 0; i < 60; i++) {
+    try {
+      await page.goto(`${BASE}/__ide_host`);
+      break;
+    } catch {
+      await sleep(500);
+    }
+  }
+  await page.evaluate((base) => {
+    const f = document.createElement("iframe");
+    f.id = "player";
+    f.style.cssText = "width:640px;height:480px;border:0";
+    f.src = `${base}/player.html?project=inline`;
+    document.body.appendChild(f);
+  }, BASE);
+  const post = (msg) =>
+    page.evaluate(
+      (m) => document.getElementById("player").contentWindow.postMessage(m, "*"),
+      msg
+    );
+
+  const waitForMsg = async (predicate, what, timeoutMs = 20000) => {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const found = await page.evaluate(
+        (pred) => window.__msgs.find((m) => new Function("m", `return ${pred}`)(m)) ?? null,
+        predicate
+      );
+      if (found) return found;
+      await sleep(100);
+    }
+    fail(`timed out waiting for ${what}`);
+    return null;
+  };
+
+  // 1. The inline player waits — it must announce, and must NOT have booted.
+  if (!(await waitForMsg(`m.type === "functor-lang-project-waiting"`, "project-waiting"))) {
+    throw new Error("no waiting announcement");
+  }
+  if (log.some((l) => l.includes("[functor-lang] loaded"))) {
+    fail("player booted before any project was pushed");
+  }
+
+  // 1b. A MALFORMED first push is rejected but must NOT consume the boot
+  // handshake — a subsequent valid push still boots (a broken editor state
+  // shouldn't wedge the preview forever).
+  await post({ type: "functor-lang-set-project", files: [{}], id: 1 });
+  const rejected = await waitForMsg(
+    `m.type === "functor-lang-set-source-result" && m.id === 1`,
+    "malformed-first-push rejection"
+  );
+  if (rejected?.ok) fail("a malformed first project push was accepted");
+  else if (rejected) console.log("malformed first push rejected, handshake kept ✓");
+  if (log.some((l) => l.includes("[functor-lang] loaded"))) {
+    fail("player booted from a malformed first push");
+  }
+
+  // 2. Push the two-file project; it boots from memory.
+  await post({ type: "functor-lang-set-project", files: project(PIECES_V1) });
+  await waitForMsg(`m.type === "functor-lang-preview-ready"`, "preview-ready");
+  if (!log.some((l) => l.includes("[functor-lang] loaded game.fun"))) {
+    fail(`no "[functor-lang] loaded game.fun" in console:\n${log.join("\n")}`);
+  } else {
+    console.log("boot from pushed project ✓");
+  }
+
+  const pushProject = async (pieces, id) => {
+    await post({ type: "functor-lang-set-project", files: project(pieces), id });
+    return waitForMsg(`m.type === "functor-lang-set-source-result" && m.id === ${id}`, `result #${id}`);
+  };
+
+  // 3. Hot-swap the SIBLING module (set-source can't do this) — id echoed.
+  const swap = await pushProject(PIECES_V2, 2);
+  if (swap && !swap.ok) fail(`sibling hot-swap rejected: ${swap.message}`);
+  if (swap?.ok && !/2 file/.test(swap.message)) {
+    fail(`expected a 2-file project reload status, got: ${swap.message}`);
+  }
+  if (swap?.ok) console.log(`sibling hot-swap ✓ (${swap.message})`);
+
+  // 4. A broken sibling keeps the old program (result not ok).
+  const broken = await pushProject(PIECES_BROKEN, 3);
+  if (broken?.ok) fail("a broken sibling push was accepted");
+  else if (broken) console.log(`broken push rejected ✓ (${broken.message.slice(0, 60)}…)`);
+
+  // 5. Recovery clears the overlay.
+  const recovered = await pushProject(PIECES_V1, 4);
+  if (recovered && !recovered.ok) fail(`recovery push rejected: ${recovered.message}`);
+  await sleep(500);
+  // The error overlay lives inside the player iframe, so probe its document.
+  const overlayVisible = await page.frameLocator("#player").locator("#functor-lang-error").isVisible().catch(() => false);
+  if (overlayVisible) fail("error overlay still visible after recovery");
+  else if (recovered?.ok) console.log("recovery ✓ (overlay cleared)");
+
+  console.log(process.exitCode ? "RESULT: FAIL" : "RESULT: PASS");
+} finally {
+  await browser.close();
+  server.kill();
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "test:inspector-emit": "node e2e/inspector-emit.mjs",
     "site:build": "node site/build.mjs",
     "site:serve": "node site/serve.mjs",
-    "test:site": "node e2e/site-sandbox.mjs"
+    "test:site": "node e2e/site-sandbox.mjs",
+    "test:ide": "node e2e/ide-project.mjs"
   },
   "devDependencies": {
     "@codemirror/autocomplete": "^6.20.3",

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -99,6 +99,16 @@ pub trait GameProducer {
         Err("this producer does not support source reload (not an .fun game)".to_string())
     }
 
+    /// Replace the game's logic from a full pushed FILE SET — `(path, source)`
+    /// pairs, the entry first, then siblings (`file = module`). The multi-file
+    /// sibling of [`GameProducer::reload_source`], for pushers that hold the
+    /// whole project in memory (the web IDE) rather than editing one buffer
+    /// over served files. Same semantics: model preserved, a broken push
+    /// keeps the old program running.
+    fn reload_project(&mut self, _files: &[(String, String)]) -> Result<String, String> {
+        Err("this producer does not support project reload (not an .fun game)".to_string())
+    }
+
     /// Rewind the whole scene — model AND physics world — to an earlier
     /// RENDERED frame, restoring both to the state they had at the end of that
     /// frame and branching the recorded future from there (docs/time-travel.md

--- a/runtime/functor-runtime-web/index-functor-lang.html
+++ b/runtime/functor-runtime-web/index-functor-lang.html
@@ -141,6 +141,7 @@
         functor_lang_ui_wants_keyboard,
         functor_lang_is_running,
         functor_lang_set_source,
+        functor_lang_set_project,
         functor_lang_scene_frame,
         functor_lang_scene_range,
         functor_lang_seek_scene,
@@ -445,11 +446,19 @@
         window.addEventListener("message", (event) => {
           if (event.source !== window.parent) return;
           const data = event.data;
-          if (!data || data.type !== "functor-lang-set-source" || typeof data.source !== "string") return;
-          // Queue the source; the wasm frame loop applies it at a safe point
+          if (!data) return;
+          // Queue the push; the wasm frame loop applies it at a safe point
           // (never mid-frame) and posts back an `functor-lang-set-source-result` message
           // with the outcome — so a broken push keeps the old program running.
-          functor_lang_set_source(data.source);
+          if (data.type === "functor-lang-set-source" && typeof data.source === "string") {
+            functor_lang_set_source(data.source);
+          } else if (data.type === "functor-lang-set-project" && Array.isArray(data.files)) {
+            // The multi-file sibling (a host that owns every file, e.g. the
+            // site IDE): whole file set replaced, same result message. Forward
+            // the optional correlation id so stale-result matching works (the
+            // Rust side validates the array shape and rejects a malformed set).
+            functor_lang_set_project(data.files, typeof data.id === "number" ? data.id : undefined);
+          }
         });
         // Tell the hosting frame the push seam is live — the editor panel
         // flushes the current buffer on this (edits made while the server

--- a/runtime/functor-runtime-web/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-web/src/functor_lang_game.rs
@@ -486,6 +486,35 @@ impl GameProducer for FunctorLangWebGame {
         Ok(status)
     }
 
+    fn reload_project(&mut self, files: &[(String, String)]) -> Result<String, String> {
+        // The multi-file push path (the web IDE): the pusher owns the WHOLE
+        // file set, so — unlike `reload_source`, which swaps the entry and
+        // keeps the last-fetched siblings — this replaces every module.
+        // Entry first, then siblings; same keep-old-program-on-failure
+        // semantics.
+        if files.is_empty() {
+            return Err("a pushed project needs at least the entry file".to_string());
+        }
+        let started = js_sys::Date::now();
+        let loaded = load_source(files)?;
+        self.sources = files.to_vec();
+        self.path = files[0].0.clone();
+        let rebound = self.swap_in(loaded);
+        let stored = if rebound > 0 {
+            format!("; {rebound} stored closure(s) rebound")
+        } else {
+            String::new()
+        };
+        let status = format!(
+            "reloaded {} ({} file(s)) from pushed project in {:.2}ms (model preserved{stored})",
+            self.path,
+            files.len(),
+            js_sys::Date::now() - started
+        );
+        web_sys::console::log_1(&format!("[functor-lang] {status}").into());
+        Ok(status)
+    }
+
     /// Coupled scene rewind — delegated to the shared [`SceneRecorder`]
     /// (docs/time-travel.md T1), identical to the desktop producer.
     fn rewind_scene_to(&mut self, target: u64) -> Result<String, String> {

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -145,12 +145,49 @@ fn functor_lang_project_files() -> Option<Vec<String>> {
     (!files.is_empty()).then_some(files)
 }
 
+/// In-memory project sources (`window.__functorLangProjectSources`, an array of
+/// `{path, source}` objects, entry FIRST) — set by a page that holds the
+/// whole project in memory instead of serving it (the IDE's inline boot,
+/// see `player.html?project=inline`). Absent or malformed → `None`, and the
+/// caller uses the fetch path.
+fn functor_lang_project_sources() -> Option<Vec<(String, String)>> {
+    let value =
+        js_sys::Reflect::get(&window(), &JsValue::from_str("__functorLangProjectSources")).ok()?;
+    parse_project_files(&value)
+}
+
+/// Parse an array of `{path, source}` objects (both strings) into the
+/// producer's `(path, source)` pairs — shared by the inline-boot global
+/// above and the `functor_lang_set_project` push below. `None` when the value
+/// isn't that shape (including an empty array).
+fn parse_project_files(value: &JsValue) -> Option<Vec<(String, String)>> {
+    use wasm_bindgen::JsCast;
+    let array = value.dyn_ref::<js_sys::Array>()?;
+    let mut files = Vec::with_capacity(array.length() as usize);
+    for item in array.iter() {
+        let path = js_sys::Reflect::get(&item, &JsValue::from_str("path"))
+            .ok()?
+            .as_string()?;
+        let source = js_sys::Reflect::get(&item, &JsValue::from_str("source"))
+            .ok()?
+            .as_string()?;
+        files.push((path, source));
+    }
+    (!files.is_empty()).then_some(files)
+}
+
 /// Fetch every project `.fun`/`.funi` source (entry first, then siblings) and
 /// build the interpreter producer. `file = module`, so a game split across
 /// `game.fun` + `pieces.fun` links exactly as it does natively. Failures are
 /// rendered strings (fetch status, parse/load position, contract violation) for
 /// `run_async` to fail loud with.
 async fn create_functor_lang_game(entry: &str) -> Result<functor_lang_game::FunctorLangWebGame, String> {
+    // A page that already holds every source in memory (the IDE's
+    // `?project=inline` boot) injects them directly — nothing to fetch, and
+    // module names come from the given paths exactly as in the fetch path.
+    if let Some(sources) = functor_lang_project_sources() {
+        return functor_lang_game::FunctorLangWebGame::create(sources);
+    }
     // The CLI injects the whole project file list; a page that set only the
     // entry (or none) falls back to loading the entry alone.
     let paths = functor_lang_project_files().unwrap_or_else(|| vec![entry.to_string()]);
@@ -186,16 +223,25 @@ pub fn functor_lang_is_running() -> bool {
     GAME.with(|g| g.borrow().is_some())
 }
 
+/// A queued push: the classic single-buffer text push (the sandbox / VSCode
+/// preview editing the entry over served siblings), or the whole-project
+/// push (the IDE, which owns every file in memory).
+enum PendingPush {
+    Source(String),
+    Project(Vec<(String, String)>),
+}
+
 thread_local! {
-    /// Source pushed via `functor_lang_set_source` (with the pusher's optional
-    /// correlation id), waiting to be applied at a SAFE point
-    /// (the top of the frame loop, where the loop already holds the producer
-    /// borrow). Deferring — rather than reloading straight from the message
-    /// handler — is what keeps a push from ever colliding with the frame's
-    /// borrow ("runtime is mid-frame"); it also coalesces a burst of edits to
-    /// the last one. Mirrors the desktop runner, which applies reloads between
-    /// frames.
-    static PENDING_RELOAD: RefCell<Option<(String, Option<f64>)>> = const { RefCell::new(None) };
+    /// The push queued via `functor_lang_set_source` / `functor_lang_set_project` (with
+    /// the pusher's optional correlation id), waiting to be applied at a SAFE
+    /// point (the top of the frame loop, where the loop already holds the
+    /// producer borrow). Deferring — rather than reloading straight from the
+    /// message handler — is what keeps a push from ever colliding with the
+    /// frame's borrow ("runtime is mid-frame"); it also coalesces a burst of
+    /// edits to the last one (across BOTH push kinds: last push wins).
+    /// Mirrors the desktop runner, which applies reloads between frames.
+    static PENDING_RELOAD: RefCell<Option<(PendingPush, Option<f64>)>> =
+        const { RefCell::new(None) };
 }
 
 /// Post a `functor-lang-set-source-result` back to the page (the reload's outcome). The
@@ -229,10 +275,14 @@ fn post_reload_result(ok: bool, message: &str, id: Option<f64>) {
 /// A good push clears the error overlay; a broken one shows it; either way the
 /// outcome is posted back to the page.
 fn apply_pending_reload(game: &mut dyn GameProducer) {
-    let Some((source, id)) = PENDING_RELOAD.with(|p| p.borrow_mut().take()) else {
+    let Some((push, id)) = PENDING_RELOAD.with(|p| p.borrow_mut().take()) else {
         return;
     };
-    match game.reload_source(&source) {
+    let outcome = match push {
+        PendingPush::Source(source) => game.reload_source(&source),
+        PendingPush::Project(files) => game.reload_project(&files),
+    };
+    match outcome {
         Ok(status) => {
             hide_error_overlay();
             post_reload_result(true, &status, id);
@@ -261,7 +311,34 @@ pub fn functor_lang_set_source(source: String, id: Option<f64>) {
         return;
     }
     // Last edit wins: a burst of pushes before the next frame coalesces.
-    PENDING_RELOAD.with(|p| *p.borrow_mut() = Some((source, id)));
+    PENDING_RELOAD.with(|p| *p.borrow_mut() = Some((PendingPush::Source(source), id)));
+}
+
+/// The multi-file sibling of [`functor_lang_set_source`]: hot-swap the running
+/// game from a pushed FILE SET — an array of `{path, source}` objects, the
+/// entry first, then siblings (`file = module`). For pushers that own the
+/// whole project in memory (the web IDE); a single-buffer editor over served
+/// files keeps using `functor_lang_set_source`. Same queue, same result message,
+/// same model-preserving semantics.
+#[wasm_bindgen]
+pub fn functor_lang_set_project(files: JsValue, id: Option<f64>) {
+    if !functor_lang_is_running() {
+        post_reload_result(
+            false,
+            "game is not running yet (still loading, or the load failed)",
+            id,
+        );
+        return;
+    }
+    let Some(parsed) = parse_project_files(&files) else {
+        post_reload_result(
+            false,
+            "malformed project push: expected a non-empty array of {path, source} objects",
+            id,
+        );
+        return;
+    };
+    PENDING_RELOAD.with(|p| *p.borrow_mut() = Some((PendingPush::Project(parsed), id)));
 }
 
 /// Route a socket event to the LIVE producer via the shared `GAME` handle (the

--- a/site/player.html
+++ b/site/player.html
@@ -84,6 +84,7 @@
         functor_lang_mouse_wheel,
         functor_lang_is_running,
         functor_lang_set_source,
+        functor_lang_set_project,
         functor_lang_scene_frame,
         functor_lang_scene_range,
         functor_lang_seek_scene,
@@ -103,15 +104,22 @@
       // push, which deliberately preserves the running model.
       const src = params.get("src");
       const requested = params.get("game");
+      // ?project=inline: the HOSTING page owns the whole file set (the IDE)
+      // and delivers it by postMessage — nothing is fetched. The boot is
+      // deferred until the first `functor-lang-set-project` arrives (see the
+      // bottom of this script), so no game path is set here.
+      const inlineProject = params.get("project") === "inline";
       // Same-origin relative paths only: reject absolute/protocol-relative
       // URLs so the page can't be pointed at a third-party source.
       const game =
         requested && !requested.startsWith("/") && !requested.includes(":")
           ? requested
           : "examples/hero.fun";
-      window.__functorLangGamePath = src
-        ? "data:text/plain;base64," + src.replace(/-/g, "+").replace(/_/g, "/")
-        : game.split("/").map(encodeURIComponent).join("/");
+      if (!inlineProject) {
+        window.__functorLangGamePath = src
+          ? "data:text/plain;base64," + src.replace(/-/g, "+").replace(/_/g, "/")
+          : game.split("/").map(encodeURIComponent).join("/");
+      }
 
       // Map a browser KeyboardEvent.code to the canonical key code expected by
       // the game (functor_runtime_common::Key as i32). Keep in sync with
@@ -230,47 +238,109 @@
         requestAnimationFrame(update);
       };
 
-      // The live-edit seam: the hosting page (the sandbox) posts the full
-      // .fun source and the runtime hot-swaps it, model preserved. Pushes are
-      // accepted only from the HOSTING frame; replies go only to the sender.
-      const setupSetSource = () => {
-        window.addEventListener("message", (event) => {
-          if (event.source !== window.parent) return;
-          const data = event.data;
-          if (!data) return;
-          // Handshake: a `functor-lang-preview-hello` from the hosting bridge asks
-          // us to re-announce readiness (its listener may have attached after our
-          // one-shot ready fired). Reply only once we're actually live; before
-          // that, the one-shot announce below covers this direction.
-          if (data.type === "functor-lang-preview-hello") {
-            if (functor_lang_is_running()) {
-              window.parent.postMessage({ type: "functor-lang-preview-ready" }, "*");
-            }
+      // The live-edit seam: the hosting page (the sandbox / the IDE) posts
+      // .fun source (`functor-lang-set-source`) or a whole file set
+      // (`functor-lang-set-project`, the IDE) and the runtime hot-swaps it,
+      // model preserved. ONE listener, installed synchronously below, so no
+      // push is lost in the async init() → producer-ready window (a
+      // fast-typing IDE pushes exactly there); pushes that arrive before the
+      // producer runs are queued and replayed once it does. Pushes are
+      // accepted only from the HOSTING frame; replies go to the sender.
+      //
+      // Trust model: we gate on `event.source === window.parent` but not
+      // `event.origin` — the same model as the long-standing set-source seam.
+      // A framing page can push arbitrary Functor Lang, but it runs only in the
+      // sandboxed interpreter (no JS eval), so inline set-project is no more
+      // powerful than set-source. An origin allowlist, if ever added, must
+      // cover both.
+      const validFiles = (files) =>
+        Array.isArray(files) && files.length > 0 &&
+        files.every((f) => f && typeof f.path === "string" && f.path && typeof f.source === "string");
+
+      const postResult = (id, ok, message) =>
+        window.parent.postMessage(
+          { type: "functor-lang-set-source-result", ok, message, ...(id !== undefined ? { id } : {}) },
+          "*"
+        );
+
+      // Route a push to the wasm export. The frame loop applies it at a safe
+      // point (never mid-frame) and posts a `functor-lang-set-source-result`
+      // back with the outcome (a broken push keeps the old program); the
+      // optional correlation id is echoed so the sender can drop stale replies.
+      const applyPush = (data) => {
+        const id = typeof data.id === "number" ? data.id : undefined;
+        if (data.type === "functor-lang-set-source" && typeof data.source === "string") {
+          functor_lang_set_source(data.source, id);
+        } else if (data.type === "functor-lang-set-project") {
+          if (!validFiles(data.files)) {
+            postResult(id, false, "malformed project push: expected a non-empty array of {path, source}");
             return;
           }
-          if (data.type !== "functor-lang-set-source" || typeof data.source !== "string") return;
-          // Queue the source; the wasm frame loop applies it at a safe point
-          // (never mid-frame) and posts an `functor-lang-set-source-result` back to the
-          // hosting frame with the outcome (a broken push keeps the old program).
-          // The push's optional correlation id is echoed in the result so the
-          // sender can discard stale replies; id-less pushes work as before.
-          functor_lang_set_source(data.source, typeof data.id === "number" ? data.id : undefined);
-        });
-        // Announce once the PRODUCER is installed (not just the wasm module):
-        // run_async still has to fetch the source, so poll functor_lang_is_running().
-        if (window.parent !== window) {
-          const announce = () => {
-            if (functor_lang_is_running()) {
-              window.parent.postMessage({ type: "functor-lang-preview-ready" }, "*");
-            } else {
-              setTimeout(announce, 50);
-            }
-          };
-          announce();
+          functor_lang_set_project(data.files, id);
         }
       };
 
-      init().then(() => {
+      const pushQueue = [];
+      let booted = false; // inline: has the first valid project kicked off boot()?
+
+      window.addEventListener("message", (event) => {
+        if (event.source !== window.parent) return;
+        const data = event.data;
+        if (!data) return;
+        // Handshake: a `functor-lang-preview-hello` from the hosting bridge asks
+        // us to re-announce readiness (its listener may have attached after our
+        // one-shot ready fired). Reply only once we're actually live.
+        if (data.type === "functor-lang-preview-hello") {
+          if (functor_lang_is_running()) {
+            window.parent.postMessage({ type: "functor-lang-preview-ready" }, "*");
+          }
+          return;
+        }
+        if (data.type !== "functor-lang-set-source" && data.type !== "functor-lang-set-project") return;
+
+        // Inline mode: the FIRST valid project boots the player from memory
+        // (the runtime reads __functorLangProjectSources instead of fetching).
+        // A malformed first push is rejected but keeps the handshake open, so
+        // the host can retry — it does NOT consume the boot.
+        if (inlineProject && !booted) {
+          if (data.type !== "functor-lang-set-project") return; // wait for a project
+          if (!validFiles(data.files)) {
+            postResult(
+              typeof data.id === "number" ? data.id : undefined,
+              false,
+              "malformed project push: expected a non-empty array of {path, source}"
+            );
+            return;
+          }
+          booted = true;
+          window.__functorLangProjectSources = data.files;
+          // Only to satisfy run_async's entry guard; the sources come from
+          // __functorLangProjectSources above, so this path is never fetched.
+          window.__functorLangGamePath = String(data.files[0].path);
+          boot();
+          return; // the initial project IS the boot, not a hot-swap push
+        }
+
+        // Producer already up → apply now; else queue for replay after it boots.
+        if (functor_lang_is_running()) applyPush(data);
+        else pushQueue.push(data);
+      });
+
+      // Announce readiness once the PRODUCER is installed (init() resolving
+      // only means the wasm module loaded; run_async still has to build the
+      // producer), then replay anything queued during that window.
+      const announceWhenReady = () => {
+        if (!functor_lang_is_running()) {
+          setTimeout(announceWhenReady, 50);
+          return;
+        }
+        if (window.parent !== window) {
+          window.parent.postMessage({ type: "functor-lang-preview-ready" }, "*");
+        }
+        while (pushQueue.length) applyPush(pushQueue.shift());
+      };
+
+      const boot = () => init().then(() => {
         // In a deterministic capture (?fixed-time), don't wire up input — a
         // stray mouse move would turn the camera — and skip the scrubber
         // entirely, so its chrome never appears in a golden capture. Hide the
@@ -285,8 +355,17 @@
           setupInput();
           if (!scrubberOff) setupScrubber();
         }
-        setupSetSource();
+        announceWhenReady();
       });
+
+      if (inlineProject) {
+        // Tell the host the listener is armed — it then pushes the initial
+        // project, which boots the player. (A message sent while the page was
+        // still parsing would be lost, so the host waits for this.)
+        window.parent.postMessage({ type: "functor-lang-project-waiting" }, "*");
+      } else {
+        boot();
+      }
     </script>
   </body>
 </html>


### PR DESCRIPTION
First slice of the web IDE (ide/dev.functor.games): the **runtime seam** a browser IDE needs, with no UI yet. The IDE page (file sidebar → editor → preview, project download) stacks on top of this.

## Why

The web runtime's live-reload push (`functor_lang_set_source`) swaps only the **entry** buffer, keeping the last-fetched siblings — right for a single-buffer editor over served files (the sandbox, the VSCode preview). A multi-file IDE owns **every** `.fun` in memory (nothing is served), so it needs to replace the whole set and to boot the player from memory.

## What

- **`GameProducer::reload_project(&[(path, source)])`** — the multi-file sibling of `reload_source` (default: the same honest refusal). The web producer replaces every module, entry first, model preserved; `load_source` runs before any mutation so a broken push keeps the old program (identical semantics to `reload_source`).
- **`functor_lang_set_project(files, id)`** wasm export + a `PendingPush { Source | Project }` enum so both push kinds share the one deferred-apply slot (applied at the top of a frame, never mid-frame; last-push-wins across both).
- **`player.html?project=inline`** boot mode — the host delivers the file set by `postMessage` (`window.__functorLangProjectSources`) instead of the runtime fetching it. One persistent listener runs the whole lifecycle so a fast-typing IDE never loses a push in the `init()` → producer-ready window (early pushes queue and replay); the first **valid** project boots, and a malformed first push is rejected but keeps the handshake open.
- `index-functor-lang.html` gets the same `set-project` routing (id forwarded), per its keep-in-sync contract.

## Verification

- `npm run test:ide` (new `e2e/ide-project.mjs`, headless Chromium): inline boot from a pushed 2-file project (nothing fetched), a malformed first push rejected without wedging the boot, **sibling-module hot-swap** (which `set-source` cannot do), broken-sibling rejection keeping the old program, and recovery clearing the overlay.
- `npm run test:site` still green — the classic `set-source` path is unregressed.
- `cargo check -p functor-runtime-web --target wasm32-unknown-unknown` clean; `cargo test -p functor_runtime_common` (269) passes.

## Review

Cross-engine (Claude + Codex). Both flagged the inline-boot handshake — fixed (persistent listener + queue/replay; validate-before-consume). Both noted the `event.source`/`event.origin` trust model: it's the **pre-existing** set-source model (blast radius is the sandboxed interpreter — no JS eval — so set-project is no more powerful than set-source), documented in `player.html`; an origin allowlist is deferred as a separate policy decision covering both seams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)