### PR TITLE
feat(site): a browser IDE — multi-file editing, live preview, project download

### DIFF
--- a/e2e/ide-page.mjs
+++ b/e2e/ide-page.mjs
@@ -1,0 +1,140 @@
+// IDE-page e2e: the browser IDE (site/ide.html) end-to-end, headless. Drives
+// the `window.__ide` test seam (no synthesized DOM events) through:
+//
+//   1. the page boots the multi-file starter to "live" (preview loaded);
+//   2. the sidebar lists game.fun + palette.fun (the entry + a sibling module);
+//   3. editing the SIBLING (palette.fun) hot-swaps and stays "live" — the
+//      multi-file loop the single-buffer sandbox can't do;
+//   4. a broken edit reports the error and the old program keeps running;
+//   5. a good edit recovers to "live";
+//   6. a new file adds a module and the preview stays live;
+//   7. Download builds a real .zip (valid EOCD signature, one entry per file).
+//
+// Run manually (needs the wasm bundle):
+//   wasm-pack build runtime/functor-runtime-web --target=web   # once
+//   node e2e/ide-page.mjs
+import { spawn, spawnSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { chromium } from "@playwright/test";
+
+const PORT = 8126;
+const BASE = `http://127.0.0.1:${PORT}`;
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const fail = (m) => {
+  console.error(`FAIL: ${m}`);
+  process.exitCode = 1;
+};
+
+const GOOD_PALETTE = `let glow = 0.3
+let sky = 0.7
+`;
+const BROKEN_PALETTE = `let glow =
+`;
+
+const built = spawnSync("node", ["site/build.mjs"], { cwd: ROOT, stdio: "inherit" });
+if (built.status !== 0) {
+  console.error("FAIL: site build failed");
+  process.exit(1);
+}
+
+const server = spawn("node", ["site/serve.mjs", "--port", String(PORT)], { cwd: ROOT, stdio: "ignore" });
+const browser = await chromium.launch({
+  args: ["--use-gl=angle", "--use-angle=swiftshader", "--enable-unsafe-swiftshader", "--ignore-gpu-blocklist"],
+});
+
+try {
+  const page = await browser.newPage({ viewport: { width: 1100, height: 640 } });
+  const log = [];
+  page.on("console", (m) => log.push(m.text()));
+  // Start from a clean slate so a stale localStorage project can't mask the
+  // starter (the page persists edits across reloads by design).
+  await page.addInitScript(() => {
+    try {
+      localStorage.removeItem("functor-ide-project-v1");
+    } catch {}
+  });
+
+  for (let i = 0; i < 60; i++) {
+    try {
+      await page.goto(`${BASE}/ide.html`);
+      break;
+    } catch {
+      await sleep(500);
+    }
+  }
+
+  const status = () => page.evaluate(() => window.__ide.status());
+  const waitStatus = async (state, what, timeoutMs = 20000) => {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if ((await status()).state === state) return true;
+      await sleep(150);
+    }
+    fail(`timed out waiting for status "${state}" (${what}); last = ${JSON.stringify(await status())}`);
+    return false;
+  };
+
+  // 1. Boot to live.
+  await waitStatus("live", "initial boot");
+  if (log.some((l) => l.includes("[functor-lang] loaded game.fun"))) {
+    console.log("boots the starter to live ✓");
+  } else {
+    fail(`no "[functor-lang] loaded game.fun":\n${log.join("\n")}`);
+  }
+
+  // 2. Sidebar lists the two starter files.
+  const files = await page.evaluate(() => window.__ide.files().map((f) => f.path));
+  if (JSON.stringify(files) === JSON.stringify(["game.fun", "palette.fun"])) {
+    console.log("file list = game.fun + palette.fun ✓");
+  } else {
+    fail(`unexpected file list: ${JSON.stringify(files)}`);
+  }
+
+  // 3. Edit the SIBLING module → hot-swap, stays live.
+  await page.evaluate(() => window.__ide.openFile("palette.fun"));
+  await page.evaluate((src) => window.__ide.setActiveSource(src), GOOD_PALETTE);
+  if (await waitStatus("live", "sibling hot-swap")) console.log("sibling-module hot-swap stays live ✓");
+
+  // 4. A broken sibling → error, old program keeps running.
+  await page.evaluate((src) => window.__ide.setActiveSource(src), BROKEN_PALETTE);
+  if (await waitStatus("error", "broken sibling")) console.log("broken sibling shows error ✓");
+
+  // 5. Recover.
+  await page.evaluate((src) => window.__ide.setActiveSource(src), GOOD_PALETTE);
+  if (await waitStatus("live", "recovery")) console.log("recovery back to live ✓");
+
+  // 6. New module keeps the preview live.
+  await page.evaluate(() => window.__ide.newFile("enemy.fun", "let hp = 3.0\n"));
+  const withEnemy = await page.evaluate(() => window.__ide.files().map((f) => f.path));
+  if (!withEnemy.includes("enemy.fun")) fail("new file not added");
+  if (await waitStatus("live", "after new file")) console.log("new module added, stays live ✓");
+
+  // 7. Download builds a real zip.
+  const [download] = await Promise.all([
+    page.waitForEvent("download"),
+    page.click("#download"),
+  ]);
+  const path = await download.path();
+  const bytes = await readFile(path);
+  const hasEOCD = bytes.includes(Buffer.from([0x50, 0x4b, 0x05, 0x06])); // end-of-central-dir
+  // EOCD is the last 22 bytes (no comment); "total entries" sits at its
+  // offset 10, i.e. length - 12.
+  const entryCount = bytes.readUInt16LE(bytes.length - 12);
+  const text = bytes.toString("latin1");
+  const hasManifest = text.includes("functor.json"); // must ship so `build wasm` works
+  const hasEntry = text.includes("game.fun");
+  // functor.json + game.fun + palette.fun + enemy.fun
+  if (hasEOCD && entryCount === 4 && hasManifest && hasEntry) {
+    console.log(`download is a valid zip with ${entryCount} entries incl. functor.json ✓`);
+  } else {
+    fail(`bad zip: EOCD=${hasEOCD} entries=${entryCount} manifest=${hasManifest} entry=${hasEntry}`);
+  }
+
+  console.log(process.exitCode ? "RESULT: FAIL" : "RESULT: PASS");
+} finally {
+  await browser.close();
+  server.kill();
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "site:build": "node site/build.mjs",
     "site:serve": "node site/serve.mjs",
     "test:site": "node e2e/site-sandbox.mjs",
-    "test:ide": "node e2e/ide-project.mjs"
+    "test:ide": "node e2e/ide-project.mjs",
+    "test:ide-page": "node e2e/ide-page.mjs"
   },
   "devDependencies": {
     "@codemirror/autocomplete": "^6.20.3",

--- a/site/README.md
+++ b/site/README.md
@@ -1,23 +1,33 @@
-# site/ — functor's website + Functor Lang sandbox
+# site/ — functor's website + Functor Lang sandbox + IDE
 
 A fully static site: landing page (whose hero background is `examples/hero.fun`
-interpreted live by the wasm runtime) and an interactive Functor Lang sandbox — a
-CodeMirror editor pushing edits into the running game over the same
+interpreted live by the wasm runtime), a single-file Functor Lang **sandbox**,
+and a multi-file **IDE**. Both editors push edits into the running game over the
 postMessage seam the VSCode live-preview panel uses, hot-reloading with the
 model preserved.
 
 ```sh
 wasm-pack build runtime/functor-runtime-web --target=web   # once (or npm run build:cli)
-npm run site:build     # bundle editor + copy runtime/examples into site/dist
-npm run site:serve     # http://127.0.0.1:8123
-npm run test:site      # headless e2e (e2e/site-sandbox.mjs)
+npm run site:build       # bundle editors + copy runtime/examples into site/dist
+npm run site:serve       # http://127.0.0.1:8123
+npm run test:site        # headless e2e — sandbox (e2e/site-sandbox.mjs)
+npm run test:ide         # headless e2e — the set-project seam (e2e/ide-project.mjs)
+npm run test:ide-page    # headless e2e — the IDE page (e2e/ide-page.mjs)
 ```
 
 - `player.html` — the runtime host page; the sibling of the CLI dev server's
-  `index-functor-lang.html`, but the `.fun` entry comes from `?game=`. Keep its input
-  mapping and set-source seam in sync with that page.
-- `src/sandbox.js` / `src/functor-lang.js` — the editor page and the Functor Lang
-  CodeMirror language + synthwave theme.
+  `index-functor-lang.html`, but the `.fun` entry comes from `?game=` (one file) or
+  `?project=inline` (the IDE pushes the whole file set by postMessage). Keep its
+  input mapping and set-source/set-project seam in sync with that page.
+- `sandbox.html` / `src/sandbox.js` — the single-buffer editor over a served
+  example (pushes `functor-lang-set-source`).
+- `ide.html` / `src/ide.js` — the multi-file IDE: a file sidebar, per-file
+  editing, a live preview fed the whole project via `functor-lang-set-project`
+  (`src/project-bridge.js`), localStorage persistence, and project download as a
+  `.zip` (`src/zip.js`, a store-only writer). Asset (`.glb`/audio) management is a
+  follow-up.
+- `src/functor-lang.js` — the Functor Lang CodeMirror language + synthwave theme,
+  shared by both editors.
 - `build.mjs` copies selected repo examples' `game.fun` sources (see the map in `build.mjs`)
-  at build time, so the dropdown always matches what ships in the repo.
+  at build time, so the sandbox dropdown always matches what ships in the repo.
 - Deploy: publish `site/dist` to any static host.

--- a/site/build.mjs
+++ b/site/build.mjs
@@ -16,7 +16,7 @@ const site = fileURLToPath(new URL(".", import.meta.url));
 const root = fileURLToPath(new URL("..", import.meta.url));
 const dist = `${site}dist`;
 
-const PAGES = ["index.html", "sandbox.html", "player.html", "docs.html", "styles.css"];
+const PAGES = ["index.html", "sandbox.html", "ide.html", "player.html", "docs.html", "styles.css"];
 
 const PKG = `${root}runtime/functor-runtime-web/pkg`;
 const PKG_FILES = ["functor_runtime_web.js", "functor_runtime_web_bg.wasm"];
@@ -80,7 +80,7 @@ if (langPkgPresent) {
 }
 
 await esbuild.build({
-  entryPoints: [`${site}src/sandbox.js`, `${site}src/docs.js`, `${site}src/hero.js`],
+  entryPoints: [`${site}src/sandbox.js`, `${site}src/ide.js`, `${site}src/docs.js`, `${site}src/hero.js`],
   bundle: true,
   minify: true,
   format: "esm",

--- a/site/ide.html
+++ b/site/ide.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>functor IDE — build a Functor Lang game in the browser</title>
+    <meta
+      name="description"
+      content="A browser IDE for Functor Lang: multi-file editing, a live-reloading preview, and download your project as a zip."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Orbitron:wght@600;800&family=JetBrains+Mono:ital,wght@0,400;0,600;1,400&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body class="ide-page">
+    <header class="site-header">
+      <a class="wordmark" href="./">FUNCTOR<span class="wordmark-accent">//IDE</span></a>
+      <div class="sandbox-controls">
+        <button id="download" type="button" title="Download the project as a .zip">
+          ↓ project.zip
+        </button>
+        <button id="restart" type="button" title="Reload the preview with a fresh model">
+          ↻ restart
+        </button>
+        <span id="status" class="status-pill" data-state="busy">◌ loading…</span>
+      </div>
+      <nav class="site-nav">
+        <a href="sandbox.html">Sandbox</a>
+        <a href="ide.html" aria-current="page">IDE</a>
+        <a href="docs.html">Docs</a>
+        <a href="https://github.com/tommy-xr/functor">GitHub ↗</a>
+      </nav>
+    </header>
+
+    <main class="ide-split">
+      <aside class="file-pane">
+        <div class="file-pane-head">
+          <span class="file-pane-title">Files</span>
+          <button id="new-file" type="button" title="New .fun file">+</button>
+        </div>
+        <div id="file-list" class="file-list"></div>
+        <p class="file-pane-note">
+          Every <code>.fun</code> is a module (<code>file = module</code>).
+          <code>game.fun</code> is the entry.
+        </p>
+      </aside>
+      <section class="editor-pane">
+        <div class="editor-tab"><span id="active-file">game.fun</span></div>
+        <div id="editor"></div>
+        <pre id="status-log" hidden></pre>
+      </section>
+      <section class="preview-pane">
+        <iframe id="player" title="live game preview" allow="pointer-lock"></iframe>
+      </section>
+    </main>
+
+    <script type="module" src="assets/ide.js"></script>
+  </body>
+</html>

--- a/site/sandbox.html
+++ b/site/sandbox.html
@@ -29,6 +29,7 @@
       </div>
       <nav class="site-nav">
         <a href="sandbox.html" aria-current="page">Sandbox</a>
+        <a href="ide.html">IDE</a>
         <a href="docs.html">Docs</a>
         <a href="https://github.com/tommy-xr/functor">GitHub ↗</a>
       </nav>

--- a/site/src/ide.js
+++ b/site/src/ide.js
@@ -1,0 +1,319 @@
+// The web IDE: a file sidebar + multi-file Functor Lang editor + live preview.
+// The IDE holds the WHOLE project in memory (nothing is served) and pushes it
+// over the `functor-lang-set-project` seam to a `player.html?project=inline`
+// iframe (see project-bridge.js): the preview boots from memory and hot-swaps
+// on every edit, model preserved. Work is persisted to localStorage; the
+// project downloads as a .zip that drops into `functor -d <dir> build wasm`.
+
+import { basicSetup } from "codemirror";
+import { EditorView, keymap } from "@codemirror/view";
+import { indentWithTab } from "@codemirror/commands";
+import { functorLangLanguage, synthwaveEditorTheme } from "./functor-lang.js";
+import { ProjectBridge } from "./project-bridge.js";
+import { zipFiles } from "./zip.js";
+
+const STORAGE_KEY = "functor-ide-project-v1";
+const ENTRY = "game.fun"; // the program root; every other .fun is a sibling module
+// A valid project file: a bare module name + `.fun` (the project is a flat
+// module space — no path separators). Enforced on BOTH created and loaded
+// files, so a hand-edited/corrupt localStorage can't smuggle in a `../x.fun`
+// (which would be a zip-slip entry on download and a bad module at load).
+const MODULE_FILE = /^[A-Za-z][A-Za-z0-9_]*\.fun$/;
+
+// A two-file starter: game.fun draws using constants from palette.fun (a
+// sibling module — file = module, so palette.fun is module `Palette`), to show
+// the multi-file loop the sandbox can't.
+const STARTER = {
+  active: ENTRY,
+  files: [
+    {
+      path: ENTRY,
+      source: `// A multi-file starter. palette.fun is a sibling module (file = module,
+// so it is \`Palette\`). Edit either file — the preview hot-reloads with the
+// model preserved. Add files with + in the sidebar; download the project as
+// a .zip to run it with \`functor -d <dir> build wasm\`.
+let init = { t: 0.0 }
+
+let tick = (model, dt: Float, tts: Float) => { model with t: model.t + dt }
+
+let draw = (model, tts: Float) =>
+  Frame.create(
+    Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.5, 0.0),
+    Scene.group([
+      Scene.sphere() |> Scene.emissive(0.15, 1.0, Palette.glow) |> Scene.scale(1.4),
+      Scene.plane() |> Scene.scale(12.0) |> Scene.lit(Palette.sky, 0.12, 0.35),
+    ]))
+`,
+    },
+    {
+      path: "palette.fun",
+      source: `// Constants for the scene, edited on their own. Try changing these — the
+// sphere and ground recolor live.
+let glow = 0.85
+let sky = 0.18
+`,
+    },
+  ],
+};
+
+const els = {
+  fileList: document.getElementById("file-list"),
+  newFile: document.getElementById("new-file"),
+  download: document.getElementById("download"),
+  restart: document.getElementById("restart"),
+  status: document.getElementById("status"),
+  statusLog: document.getElementById("status-log"),
+  activeName: document.getElementById("active-file"),
+  editorHost: document.getElementById("editor"),
+  player: document.getElementById("player"),
+};
+
+// ---------------------------------------------------------------- project
+
+let project = loadProject();
+
+function loadProject() {
+  try {
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY));
+    const seen = new Set();
+    const valid =
+      stored &&
+      Array.isArray(stored.files) &&
+      stored.files.length > 0 &&
+      stored.files.every((f) => {
+        if (!f || typeof f.path !== "string" || typeof f.source !== "string") return false;
+        if (!MODULE_FILE.test(f.path)) return false; // same rule as created files
+        const key = f.path.toLowerCase();
+        if (seen.has(key)) return false; // no case-insensitive duplicates (one entry)
+        seen.add(key);
+        return true;
+      }) &&
+      stored.files.some((f) => f.path === ENTRY);
+    if (valid) {
+      const active = stored.files.some((f) => f.path === stored.active) ? stored.active : ENTRY;
+      return { files: stored.files, active };
+    }
+  } catch {
+    // fall through to the starter
+  }
+  return structuredClone(STARTER);
+}
+
+const saveProject = () => {
+  // Best-effort: a disabled/full localStorage (private mode, quota) must not
+  // break editing or the live preview — persistence is a convenience.
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(project));
+  } catch {
+    /* not persisted this session */
+  }
+};
+const activeFile = () => project.files.find((f) => f.path === project.active);
+
+// ---------------------------------------------------------------- status
+
+const setStatus = (state, text, detail = "") => {
+  els.status.dataset.state = state;
+  els.status.textContent = text;
+  els.status.title = "";
+  els.statusLog.textContent = detail;
+  els.statusLog.hidden = detail === "";
+};
+
+// ---------------------------------------------------------------- editor
+
+let programmaticEdit = false;
+
+const view = new EditorView({
+  parent: els.editorHost,
+  extensions: [
+    basicSetup,
+    keymap.of([indentWithTab]),
+    functorLangLanguage,
+    synthwaveEditorTheme,
+    EditorView.updateListener.of((update) => {
+      if (update.docChanged && !programmaticEdit) {
+        // Mirror the buffer into the active file and push the whole project.
+        const file = activeFile();
+        if (file) file.source = view.state.doc.toString();
+        schedulePush();
+      }
+    }),
+  ],
+});
+
+const setDoc = (source) => {
+  programmaticEdit = true;
+  view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: source } });
+  programmaticEdit = false;
+};
+
+// ---------------------------------------------------------------- preview
+
+const bridge = new ProjectBridge(els.player, {
+  onReloading: () => setStatus("busy", "◌ reloading…"),
+  onLive: () => setStatus("live", "● live"),
+  onResult: (ok, message) => {
+    if (ok) {
+      setStatus("live", "● live");
+      els.status.title = message; // the runtime's "model preserved" note, on hover
+    } else {
+      setStatus("error", "✖ error", message);
+    }
+  },
+});
+
+// Persist + push the current file set (the bridge debounces the actual send).
+const schedulePush = () => {
+  saveProject();
+  bridge.setProject(project.files);
+};
+
+// ---------------------------------------------------------------- sidebar
+
+const renderFileList = () => {
+  els.fileList.textContent = "";
+  for (const file of project.files) {
+    const row = document.createElement("div");
+    row.className = "file-row" + (file.path === project.active ? " active" : "");
+
+    const name = document.createElement("button");
+    name.className = "file-name";
+    name.textContent = file.path;
+    name.title = file.path === ENTRY ? "game.fun — the program entry" : file.path;
+    name.addEventListener("click", () => openFile(file.path));
+    row.appendChild(name);
+
+    // Every file but the entry can be deleted (the entry is the program root).
+    if (file.path !== ENTRY) {
+      const del = document.createElement("button");
+      del.className = "file-delete";
+      del.textContent = "×";
+      del.title = `Delete ${file.path}`;
+      del.addEventListener("click", (e) => {
+        e.stopPropagation();
+        deleteFile(file.path);
+      });
+      row.appendChild(del);
+    }
+    els.fileList.appendChild(row);
+  }
+  els.activeName.textContent = project.active;
+};
+
+const openFile = (path) => {
+  if (path === project.active) return;
+  // Save the live buffer into the outgoing file before switching.
+  const current = activeFile();
+  if (current) current.source = view.state.doc.toString();
+  project.active = path;
+  const next = activeFile();
+  setDoc(next ? next.source : "");
+  renderFileList();
+  saveProject();
+};
+
+// A valid sibling filename: `<name>.fun`, a bare module stem (no path
+// separators — the project is a flat module space), and not already taken.
+const validName = (raw) => {
+  const path = raw.trim();
+  if (!MODULE_FILE.test(path)) {
+    return { error: "name must be a bare module like `enemy.fun` (letters, digits, _)" };
+  }
+  if (project.files.some((f) => f.path.toLowerCase() === path.toLowerCase())) {
+    return { error: `${path} already exists` };
+  }
+  return { path };
+};
+
+const newFile = () => {
+  const raw = window.prompt("New file name (e.g. enemy.fun):", "");
+  if (raw === null) return;
+  const { path, error } = validName(raw);
+  if (error) {
+    setStatus("error", "✖ error", error);
+    return;
+  }
+  project.files.push({ path, source: `// ${path}\n` });
+  openFile(path);
+  schedulePush(); // a new empty module can't break the build; keep the preview in sync
+};
+
+const deleteFile = (path) => {
+  if (path === ENTRY) return;
+  if (!window.confirm(`Delete ${path}? This can't be undone.`)) return;
+  project.files = project.files.filter((f) => f.path !== path);
+  if (project.active === path) {
+    project.active = ENTRY;
+    setDoc(activeFile().source);
+  }
+  renderFileList();
+  schedulePush();
+};
+
+// ---------------------------------------------------------------- toolbar
+
+const download = () => {
+  // Include the functor.json the CLI needs to recognise the project, so the
+  // zip drops straight into `functor -d <dir> build wasm` (per the README).
+  const manifest = {
+    path: "functor.json",
+    source: JSON.stringify({ language: "functor-lang", entry: ENTRY }, null, 2) + "\n",
+  };
+  const blob = zipFiles([manifest, ...project.files]);
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "functor-project.zip";
+  a.click();
+  // Revoke after the click's synchronous download kickoff has settled (a
+  // same-tick revoke is the known-fragile pattern on some browsers).
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+};
+
+// Reload the preview from scratch — a fresh model (init runs again) with the
+// current files. The iframe re-announces project-waiting; the bridge reboots.
+const restart = () => {
+  bridge.reset();
+  setStatus("busy", "◌ loading…");
+  els.player.src = "player.html?project=inline";
+  bridge.setProject(project.files);
+};
+
+// ---------------------------------------------------------------- boot
+
+els.newFile.addEventListener("click", newFile);
+els.download.addEventListener("click", download);
+els.restart.addEventListener("click", restart);
+
+renderFileList();
+setDoc(activeFile().source);
+setStatus("busy", "◌ loading…");
+// Store the file set BEFORE the iframe loads, so the bridge can flush it the
+// moment the player announces it's ready (no lost first push).
+bridge.setProject(project.files);
+els.player.src = "player.html?project=inline";
+
+// Test seam for the headless e2e (e2e/ide-page.mjs): drive files without
+// synthesizing DOM events, and read status.
+window.__ide = {
+  setActiveSource(source) {
+    setDoc(source);
+    const file = activeFile();
+    if (file) file.source = source;
+    schedulePush();
+  },
+  openFile,
+  newFile: (path, source = `// ${path}\n`) => {
+    project.files.push({ path, source });
+    openFile(path);
+    schedulePush();
+  },
+  files: () => project.files.map((f) => ({ ...f })),
+  status: () => ({
+    state: els.status.dataset.state,
+    text: els.status.textContent,
+    message: els.status.title,
+    detail: els.statusLog.textContent,
+  }),
+};

--- a/site/src/project-bridge.js
+++ b/site/src/project-bridge.js
@@ -1,0 +1,91 @@
+// The multi-file editor ↔ player bridge — the whole-project sibling of
+// player-bridge.js (which pushes a single source buffer). The IDE owns every
+// .fun in memory, so it pushes the full file set over `functor-lang-set-project`
+// to a `player.html?project=inline` iframe: the player boots from memory (no
+// fetch) on the first push, then hot-swaps (model preserved) on each edit.
+//
+// The boot handshake: the player announces `functor-lang-project-waiting` when
+// its listener is armed; only then may we push. It replies
+// `functor-lang-preview-ready` once the producer is live, and
+// `functor-lang-set-source-result` (with our echoed id) for every hot-swap.
+
+const PUSH_DEBOUNCE_MS = 300;
+
+export class ProjectBridge {
+  // iframe: the player element. Callbacks map protocol events to UI:
+  //   onReloading()          — a push was sent (busy)
+  //   onLive()               — the player booted / is ready
+  //   onResult(ok, message)  — a hot-swap reply came back
+  constructor(iframe, { onReloading, onLive, onResult, debounceMs = PUSH_DEBOUNCE_MS }) {
+    this.iframe = iframe;
+    this.onReloading = onReloading;
+    this.onLive = onLive;
+    this.onResult = onResult;
+    this.debounceMs = debounceMs;
+
+    this.waiting = false; // player announced project-waiting (safe to push)
+    this.files = null; // latest full file set
+    this.pushTimer = null;
+    // Correlates results with pushes: each push gets a fresh id, the runtime
+    // echoes it, and a result for anything but the LATEST push is stale.
+    this.pushId = 0;
+
+    window.addEventListener("message", (event) => this.#onMessage(event));
+  }
+
+  // Debounced whole-project push: swap in the file set once edits settle.
+  setProject(files) {
+    this.files = files;
+    clearTimeout(this.pushTimer);
+    this.pushTimer = setTimeout(() => this.#send(), this.debounceMs);
+  }
+
+  // Reset for a fresh iframe (a new project=inline load): drop the handshake
+  // state until the next `functor-lang-project-waiting`.
+  reset() {
+    clearTimeout(this.pushTimer);
+    this.waiting = false;
+  }
+
+  #send() {
+    clearTimeout(this.pushTimer); // an early flush cancels the pending timer
+    if (!this.iframe.contentWindow || !this.files) return;
+    // The player drops anything sent before it announces `project-waiting`;
+    // hold the push and flush it on that signal (below).
+    if (!this.waiting) return;
+    this.onReloading();
+    this.pushId += 1;
+    this.iframe.contentWindow.postMessage(
+      { type: "functor-lang-set-project", files: this.files, id: this.pushId },
+      "*"
+    );
+  }
+
+  #onMessage(event) {
+    if (event.source !== this.iframe.contentWindow) return;
+    const data = event.data;
+    if (!data) return;
+    if (data.type === "functor-lang-project-waiting") {
+      // The player is armed: flush the initial (or any held) project to boot it.
+      this.waiting = true;
+      if (this.files) this.#send();
+    } else if (data.type === "functor-lang-preview-ready") {
+      // Ignore a ready/result from the OUTGOING document — an iframe keeps its
+      // WindowProxy (so `event.source` still matches) across a restart's src
+      // swap, and a late reply from the old player would flash over the new
+      // one's "loading…". `reset()` drops `waiting`; only the fresh
+      // project-waiting handshake re-arms us. (Mirrors PlayerBridge's
+      // previewReady guard.)
+      if (!this.waiting) return;
+      // The boot push carries an id but the boot path sends no result — the
+      // ready signal is the boot's "ok". Later edits get result messages.
+      this.onLive();
+    } else if (data.type === "functor-lang-set-source-result") {
+      if (!this.waiting) return;
+      // A result whose id isn't the latest push's is stale — a newer push is
+      // already in flight; its reply supersedes this one.
+      if (data.id !== undefined && data.id !== this.pushId) return;
+      this.onResult(data.ok, data.message);
+    }
+  }
+}

--- a/site/src/zip.js
+++ b/site/src/zip.js
@@ -1,0 +1,81 @@
+// Minimal STORE-only (uncompressed) ZIP writer — enough to download a Functor
+// project (a handful of small .fun text files) as a .zip, with no dependency.
+// Deflate isn't worth the code for a few KB of source; a store-only archive
+// unzips everywhere and drops straight into `functor -d <dir> build wasm`.
+
+const CRC_TABLE = (() => {
+  const t = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    t[n] = c >>> 0;
+  }
+  return t;
+})();
+
+const crc32 = (bytes) => {
+  let c = 0xffffffff;
+  for (let i = 0; i < bytes.length; i++) c = CRC_TABLE[(c ^ bytes[i]) & 0xff] ^ (c >>> 8);
+  return (c ^ 0xffffffff) >>> 0;
+};
+
+const u16 = (v) => new Uint8Array([v & 0xff, (v >>> 8) & 0xff]);
+const u32 = (v) =>
+  new Uint8Array([v & 0xff, (v >>> 8) & 0xff, (v >>> 16) & 0xff, (v >>> 24) & 0xff]);
+
+const concat = (arrs) => {
+  let len = 0;
+  for (const a of arrs) len += a.length;
+  const out = new Uint8Array(len);
+  let o = 0;
+  for (const a of arrs) {
+    out.set(a, o);
+    o += a.length;
+  }
+  return out;
+};
+
+// files: [{ path, source }] (source a string). Returns a Blob (application/zip).
+// Timestamps are pinned (1980-01-01) so identical inputs yield identical bytes.
+export function zipFiles(files) {
+  const enc = new TextEncoder();
+  const parts = [];
+  const central = [];
+  let offset = 0;
+
+  for (const f of files) {
+    const name = enc.encode(f.path);
+    const data = enc.encode(f.source);
+    const crc = crc32(data);
+    const local = concat([
+      u32(0x04034b50), u16(20), u16(0), u16(0), // sig, version, flags, method=store
+      u16(0), u16(0x21), // mod time 0, mod date 1980-01-01
+      u32(crc), u32(data.length), u32(data.length),
+      u16(name.length), u16(0),
+      name,
+    ]);
+    const localOffset = offset;
+    parts.push(local, data);
+    offset += local.length + data.length;
+    central.push(
+      concat([
+        u32(0x02014b50), u16(20), u16(20), u16(0), u16(0), // sig, made-by, need, flags, method
+        u16(0), u16(0x21),
+        u32(crc), u32(data.length), u32(data.length),
+        u16(name.length), u16(0), u16(0), u16(0), u16(0),
+        u32(0), u32(localOffset),
+        name,
+      ])
+    );
+  }
+
+  const centralStart = offset;
+  let centralSize = 0;
+  for (const c of central) centralSize += c.length;
+  const end = concat([
+    u32(0x06054b50), u16(0), u16(0),
+    u16(files.length), u16(files.length),
+    u32(centralSize), u32(centralStart), u16(0),
+  ]);
+  return new Blob([...parts, ...central, end], { type: "application/zip" });
+}

--- a/site/styles.css
+++ b/site/styles.css
@@ -444,7 +444,8 @@ a:hover {
 
 /* ---------------------------------------------------------------- sandbox */
 
-.sandbox-page {
+.sandbox-page,
+.ide-page {
   height: 100vh;
   display: flex;
   flex-direction: column;
@@ -482,7 +483,9 @@ a:hover {
 }
 
 #example-picker,
-#reset {
+#reset,
+#download,
+#restart {
   font-family: var(--font-mono);
   font-size: 0.85rem;
   color: var(--text);
@@ -492,11 +495,15 @@ a:hover {
   padding: 6px 10px;
 }
 
-#reset {
+#reset,
+#download,
+#restart {
   cursor: pointer;
 }
 
-#reset:hover {
+#reset:hover,
+#download:hover,
+#restart:hover {
   border-color: var(--cyan);
   color: var(--cyan);
 }
@@ -598,6 +605,149 @@ a:hover {
   .editor-pane {
     border-right: none;
     border-bottom: 1px solid var(--line);
+  }
+}
+
+/* --------------------------------------------------------------------- ide */
+
+/* Three panes: file sidebar | editor | preview. Reuses .editor-pane,
+   #editor, .preview-pane, #player, #status-log, .status-pill from the
+   sandbox rules above. */
+.ide-split {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 200px minmax(300px, 40%) 1fr;
+  min-height: 0;
+}
+
+.file-pane {
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--line);
+  background: var(--bg-panel);
+  min-height: 0;
+}
+
+.file-pane-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--line);
+}
+
+.file-pane-title {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-dim);
+}
+
+#new-file {
+  font-family: var(--font-mono);
+  font-size: 1rem;
+  line-height: 1;
+  color: var(--text);
+  background: var(--bg-raised);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  width: 24px;
+  height: 24px;
+  cursor: pointer;
+}
+
+#new-file:hover {
+  border-color: var(--cyan);
+  color: var(--cyan);
+}
+
+.file-list {
+  flex: 1;
+  overflow: auto;
+  min-height: 0;
+}
+
+.file-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 8px 0 12px;
+}
+
+.file-row.active {
+  background: var(--bg-raised);
+  box-shadow: inset 2px 0 0 var(--pink);
+}
+
+.file-name {
+  flex: 1;
+  text-align: left;
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  color: var(--text);
+  background: none;
+  border: 0;
+  padding: 8px 0;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-row.active .file-name {
+  color: var(--cyan);
+}
+
+.file-delete {
+  font-family: var(--font-mono);
+  font-size: 0.95rem;
+  line-height: 1;
+  color: var(--text-dim);
+  background: none;
+  border: 0;
+  padding: 2px 6px;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.file-delete:hover {
+  color: var(--red);
+}
+
+.file-pane-note {
+  margin: 0;
+  padding: 10px 12px;
+  border-top: 1px solid var(--line);
+  font-size: 0.68rem;
+  line-height: 1.5;
+  color: var(--text-dim);
+}
+
+.file-pane-note code {
+  font-family: var(--font-mono);
+  color: var(--text);
+}
+
+.editor-tab {
+  padding: 7px 14px;
+  border-bottom: 1px solid var(--line);
+  background: var(--bg-panel);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--cyan);
+}
+
+@media (max-width: 900px) {
+  .ide-split {
+    grid-template-columns: 150px 1fr;
+    grid-template-rows: 1fr 300px;
+  }
+  .file-pane {
+    grid-row: span 2;
+  }
+  .preview-pane {
+    border-top: 1px solid var(--line);
   }
 }
 


### PR DESCRIPTION
Stacked on #348 (the `functor_lang_set_project` seam).

The second slice of the web IDE (ide/dev.functor.games): the **page**. A three-pane browser IDE — file sidebar · editor · live preview — that does the multi-file loop the single-buffer sandbox can't.

![functor IDE](https://gist.githubusercontent.com/tommy-xr/59d05636f5aaf21cbd3e4b7792e31283/raw/ide-web.png)

## What

The IDE holds the **whole project in memory** and pushes the full file set to a `player.html?project=inline` iframe over the parent PR's seam — so editing a **sibling module** (`palette.fun`) hot-swaps the preview with the model preserved, which `functor-lang-set-source` (entry-only) can't do.

- **`src/ide.js`** — file list (open / add / delete; `game.fun` is the undeletable entry), one CodeMirror buffer swapped per file, localStorage persistence, restart (fresh model), download.
- **`src/project-bridge.js`** — the whole-project sibling of `player-bridge.js`: debounced `set-project` pushes, the `project-waiting → boot → preview-ready` handshake, id-correlated results (stale/outgoing-iframe replies dropped).
- **`src/zip.js`** — a dependency-free store-only ZIP writer (pinned timestamps, correct CRC-32). **Download** ships `functor.json` + every `.fun`, so the archive drops straight into `functor -d <dir> build wasm`.
- `ide.html` + IDE layout CSS + build wiring; a Sandbox↔IDE nav link. Asset (`.glb`/audio) management is the next slice (IDE-2).

## Verification

- `npm run test:ide-page` (new `e2e/ide-page.mjs`, headless Chromium): boot to live, sidebar lists entry + sibling, **sibling-module hot-swap** stays live, broken edit shows the error with the old program running, recovery, new module stays live, and Download yields a valid 4-entry zip (`functor.json` + 3 modules).
- **End-to-end**: unzipped a downloaded project and ran `functor build wasm` on it — checks + exports clean, proving the `functor.json` fix.
- `npm run test:site` (sandbox) stays green.

## Review

Cross-engine (Claude + Codex). Fixed: **download omits `functor.json`** so the zip couldn't build (Codex High — now verified buildable); the bridge **ignores ready/results until a fresh handshake** so a stale reply from the outgoing iframe can't flash over a restart (both engines); `loadProject` **validates persisted paths** with the same module-name rule as created files, rejecting zip-slip/invalid names from a corrupt localStorage (both engines); `saveProject` tolerates a disabled/full localStorage; download revokes its object URL off-tick. The reviewers' one simplicity note — `project-bridge.js` shares ~90% with `player-bridge.js` — is left as-is deliberately (the boot handshakes genuinely differ; a shared base is a possible follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)