### PR TITLE
feat(runtime): wasm emits inspector traces — the VS Code preview auto-connects

### DIFF
--- a/e2e/inspector-emit.mjs
+++ b/e2e/inspector-emit.mjs
@@ -1,0 +1,187 @@
+// Inspector-emit E2E (visual-debugger PR2b): the wasm runtime must EMIT the
+// paused-scene inspector trace over postMessage, so the VS Code live-preview
+// auto-connects the inspector with no explicit gesture.
+//
+// Modeled on e2e/wasm-smoke.mjs (same server-spawn + headless Chromium). It:
+//
+//   1. serves `examples/inspector` with the built CLI (`functor run wasm`) and
+//      loads it in headless Chromium (asserts "[functor-lang] loaded");
+//   2. installs a `window` message listener capturing `functor-inspector-trace`
+//      messages (the page posts to `window.parent`, which resolves to the page
+//      itself when loaded top-level — so a top-level listener captures them);
+//   3. runs a few frames, then PAUSES via the real DOM scrubber pause button
+//      (`#scrub-pause`), falling back to the `functor_lang_scrub_toggle_pause`
+//      export if the button isn't hit;
+//   4. asserts a `functor-inspector-trace` arrived with `paused: true` and at
+//      least one invocation whose bindings carry real (string) values.
+//
+// Run manually (owns its own server on :8080):
+//
+//   npm run build:cli            # so target/debug/functor embeds the runtime
+//   node e2e/inspector-emit.mjs
+import { spawn } from "node:child_process";
+import net from "node:net";
+import { fileURLToPath } from "node:url";
+import { chromium } from "@playwright/test";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const BASE = "http://127.0.0.1:8080";
+const PORT = 8080;
+const SAMPLE = "inspector";
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Serialize against a lingering dev server on :PORT (see wasm-smoke.mjs).
+function portInUse() {
+  return new Promise((resolve) => {
+    const sock = net
+      .connect(PORT, "127.0.0.1")
+      .on("connect", () => {
+        sock.destroy();
+        resolve(true);
+      })
+      .on("error", () => resolve(false));
+  });
+}
+
+async function waitPortFree(timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!(await portInUse())) return true;
+    await sleep(200);
+  }
+  return false;
+}
+
+async function run() {
+  if (!(await waitPortFree(15000))) {
+    return { ok: false, reason: `:${PORT} still in use by a previous server` };
+  }
+  const server = spawn(
+    "./target/debug/functor",
+    ["-d", `examples/${SAMPLE}`, "run", "wasm", "--no-open"],
+    { cwd: ROOT, stdio: "ignore" },
+  );
+  const browser = await chromium.launch({
+    args: [
+      "--use-gl=angle",
+      "--use-angle=swiftshader",
+      "--enable-unsafe-swiftshader",
+      "--ignore-gpu-blocklist",
+    ],
+  });
+  try {
+    const page = await browser.newPage({ viewport: { width: 640, height: 480 } });
+    const log = [];
+    page.on("console", (m) => log.push(`${m.type()}: ${m.text()}`));
+    page.on("pageerror", (e) => log.push(`pageerror: ${e}`));
+
+    // Wait for the dev server to come up, then the game to load.
+    for (let i = 0; i < 120; i++) {
+      try {
+        await page.goto(BASE);
+        break;
+      } catch {
+        await sleep(500);
+      }
+    }
+    for (let i = 0; !log.some((m) => m.includes("[functor-lang] loaded")); i++) {
+      if (i > 60) return { ok: false, reason: "never loaded", log };
+      await sleep(250);
+    }
+
+    // Capture every `functor-inspector-trace` the runtime emits (the page posts
+    // to window.parent; top-level, that is this same window).
+    await page.evaluate(() => {
+      window.__traces = [];
+      window.addEventListener("message", (e) => {
+        if (e.data && e.data.type === "functor-inspector-trace")
+          window.__traces.push(e.data.trace);
+      });
+    });
+
+    // Run a few frames of real play (crosses at least one tick).
+    await sleep(1800);
+
+    // PAUSE via the real DOM scrubber button; fall back to the export if the
+    // click somehow didn't land.
+    const clicked = await page.evaluate(() => {
+      const btn = document.getElementById("scrub-pause");
+      if (btn) {
+        btn.click();
+        return true;
+      }
+      return false;
+    });
+    if (!clicked) {
+      await page.evaluate(() => window.functor_lang_scrub_toggle_pause?.());
+    }
+
+    // Let the poll loop observe the pause, build the paused trace, and post it.
+    await sleep(1200);
+
+    const traces = await page.evaluate(() => window.__traces);
+    const paused = (traces || []).filter((t) => t && t.paused === true);
+    if (paused.length === 0) {
+      return {
+        ok: false,
+        reason: `no paused functor-inspector-trace received (got ${traces ? traces.length : 0} trace message(s), clickedButton=${clicked})`,
+        log: log.slice(-12),
+      };
+    }
+
+    // The paused doc must replay the last real frame into >=1 invocation whose
+    // bindings carry real values (the recorder captured live binding-site data).
+    const doc = paused[paused.length - 1];
+    const invs = Array.isArray(doc.invocations) ? doc.invocations : [];
+    const withRealBindings = invs.find(
+      (i) =>
+        Array.isArray(i.bindings) &&
+        i.bindings.length > 0 &&
+        i.bindings.every((b) => typeof b.value === "string" && b.value.length > 0),
+    );
+    if (!withRealBindings) {
+      return {
+        ok: false,
+        reason: `paused trace has no invocation with real-valued bindings: ${JSON.stringify(doc).slice(0, 400)}`,
+      };
+    }
+
+    // Sources hash present (the LSP's span/version gate).
+    const hashOk =
+      Array.isArray(doc.sources) &&
+      doc.sources.length > 0 &&
+      typeof doc.sources[0].hash === "string" &&
+      doc.sources[0].hash.length === 64;
+
+    return {
+      ok: hashOk,
+      reason: hashOk ? "" : "sources hash missing/malformed",
+      summary: {
+        pausedMessages: paused.length,
+        invocations: invs.length,
+        entries: invs.map((i) => i.entry),
+        sampleBinding: withRealBindings.bindings[0],
+      },
+    };
+  } finally {
+    await browser.close();
+    server.kill("SIGKILL");
+    await waitPortFree(10000);
+  }
+}
+
+let r;
+try {
+  r = await run();
+} catch (e) {
+  r = { ok: false, reason: `harness error: ${e}` };
+}
+if (r.ok) {
+  console.log("PASS  inspector-emit");
+  console.log(`      ${JSON.stringify(r.summary)}`);
+} else {
+  console.log(`FAIL  inspector-emit — ${r.reason}`);
+  if (r.log) for (const line of r.log) console.log(`        ${line}`);
+}
+process.exit(r.ok ? 0 : 1);

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:wasm-golden": "playwright test",
     "test:wasm-golden:update": "playwright test --update-snapshots",
     "test:wasm-smoke": "node e2e/wasm-smoke.mjs",
+    "test:inspector-emit": "node e2e/inspector-emit.mjs",
     "site:build": "node site/build.mjs",
     "site:serve": "node site/serve.mjs",
     "test:site": "node e2e/site-sandbox.mjs"

--- a/runtime/functor-runtime-common/Cargo.toml
+++ b/runtime/functor-runtime-common/Cargo.toml
@@ -33,6 +33,10 @@ once_cell = "1.19.0"
 rapier3d = { version = "0.33", features = ["serde-serialize", "debug-render"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+# sha256 of each loaded `.fun` file's text — the paused-inspector wire
+# contract's `sources` hash the LSP gates its live-value overlay on
+# (visual-debugger PR2/2b). Shared by both shells' producers.
+sha2 = "0.10"
 futures = "0.3.30"
 async-trait = "0.1.80"
 # The `log` facade for free-form runtime diagnostics (e.g. asset-load debug

--- a/runtime/functor-runtime-common/src/inspector.rs
+++ b/runtime/functor-runtime-common/src/inspector.rs
@@ -1,0 +1,312 @@
+//! The paused-scene inspector's wire-contract trace builder (visual-debugger
+//! PR2/2b) — shared by both shells' producers.
+//!
+//! During normal play a producer records nothing and renders no Display text
+//! (the hard perf requirement); it only keeps a cheap replay journal of the
+//! model-updating calls (`functor_lang_producer::JournalEntry`). On pause it
+//! hands that journal, the loaded source hashes, and the live `Session` to
+//! [`build_trace_doc`], which replays each call through
+//! `Session::call_recorded` (the PR1 recorder) and assembles the wire JSON the
+//! LSP consumes (`docs/visual-debugger`). Entry points are pure functions of
+//! their args and effects are plain data (only the drain performs), so replay
+//! is exact and side-effect-free.
+//!
+//! The desktop producer serves this over `GET /trace`; the web producer
+//! publishes it through the `functor_lang_inspector_trace*` wasm exports for the
+//! VS Code live-preview to relay. Keeping the assembly here means one tested
+//! copy and a wire contract that cannot drift between the two shells.
+
+use functor_lang::project::SourceMap;
+use functor_lang::{Session, Span};
+
+use crate::functor_lang_prelude::FunctorHost;
+use crate::functor_lang_producer::JournalEntry;
+
+/// One project source file's inspector metadata: its wire name, its base offset
+/// in the project-wide span space, its length, and the sha256 of the text the
+/// runtime loaded. Computed once per load (not per frame), so a binding span
+/// maps to `(file, local offset)` and the wire `sources` gates on a content
+/// hash without re-reading files.
+pub struct InspectorSource {
+    pub file: String,
+    pub base: usize,
+    pub len: usize,
+    pub hash: String,
+}
+
+/// Build the per-file inspector metadata from a loaded [`SourceMap`]: the REAL
+/// project `.fun` files only (skip the injected prelude `.funi` interfaces and
+/// the `<builtin>/Net.fun` module — a game binding never lands in them, and they
+/// aren't editor documents the LSP gates on).
+pub fn inspector_sources(sources: &SourceMap) -> Vec<InspectorSource> {
+    use sha2::{Digest, Sha256};
+    sources
+        .files()
+        .iter()
+        .filter(|f| !f.interface && !f.path.to_string_lossy().starts_with('<'))
+        .map(|f| {
+            let file = f
+                .path
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_else(|| f.path.to_string_lossy().into_owned());
+            let hash = format!("{:x}", Sha256::digest(f.src.as_bytes()));
+            InspectorSource {
+                file,
+                base: f.base,
+                len: f.src.len(),
+                hash,
+            }
+        })
+        .collect()
+}
+
+/// Map a project-wide binding span to `(file, local start, local end)` for the
+/// wire contract, using the per-file base offsets. `None` if the span falls
+/// outside a real project file (a prelude/builtin span — a game binding never
+/// does).
+fn span_to_file(sources: &[InspectorSource], span: Span) -> Option<(String, usize, usize)> {
+    let src = sources
+        .iter()
+        .filter(|s| s.base <= span.start)
+        .max_by_key(|s| s.base)?;
+    if span.start > src.base + src.len {
+        return None;
+    }
+    Some((
+        src.file.clone(),
+        span.start - src.base,
+        span.end.saturating_sub(src.base),
+    ))
+}
+
+/// The wire `sources` array — `{ file, hash }` per loaded project file.
+fn sources_json(sources: &[InspectorSource]) -> Vec<serde_json::Value> {
+    sources
+        .iter()
+        .map(|s| serde_json::json!({ "file": s.file, "hash": s.hash }))
+        .collect()
+}
+
+/// Replay the last real frame's journal into the wire-contract `invocations`.
+/// Each journaled call is re-run through `Session::call_recorded` — entry points
+/// are pure functions of their args, so the record is exact, and effects are
+/// plain data (nothing performs), so replay is side-effect-free. `index`/`count`
+/// frame each call within its entry name; binding spans map to `(file, local
+/// offsets)`.
+fn build_invocations(
+    journal: &[JournalEntry],
+    sources: &[InspectorSource],
+    session: &Session,
+) -> Vec<serde_json::Value> {
+    use std::collections::HashMap;
+    // Replay FIRST, then frame: `index`/`count` are computed over the
+    // invocations actually EMITTED, so the array is always consistent with its
+    // own counts (the LSP picker mod-cycles on `count`). A call that succeeded
+    // live, replayed pure, should not fail — skip one defensively rather than
+    // abort the whole trace if it somehow does.
+    let mut replayed = Vec::with_capacity(journal.len());
+    for e in journal {
+        if let Ok((_discard, inv)) = session.call_recorded(e.entry, e.args.clone(), &mut FunctorHost)
+        {
+            replayed.push((e, inv));
+        }
+    }
+    let mut counts: HashMap<&str, usize> = HashMap::new();
+    for (e, _) in &replayed {
+        *counts.entry(e.entry).or_default() += 1;
+    }
+    let mut seen: HashMap<&str, usize> = HashMap::new();
+    let mut out = Vec::with_capacity(replayed.len());
+    for (e, inv) in &replayed {
+        let index = {
+            let c = seen.entry(e.entry).or_default();
+            let i = *c;
+            *c += 1;
+            i
+        };
+        let bindings: Vec<serde_json::Value> = inv
+            .bindings
+            .iter()
+            .filter_map(|b| {
+                span_to_file(sources, b.span).map(|(file, start, end)| {
+                    serde_json::json!({
+                        "name": b.name,
+                        "file": file,
+                        "start": start,
+                        "end": end,
+                        "value": b.value,
+                        "count": b.count,
+                    })
+                })
+            })
+            .collect();
+        out.push(serde_json::json!({
+            "entry": e.entry,
+            "index": index,
+            "count": counts[e.entry],
+            "provenance": e.provenance.render(&e.args),
+            "ghost": false,
+            "result": inv.result,
+            "truncated": inv.truncated,
+            "bindings": bindings,
+        }));
+    }
+    out
+}
+
+/// Assemble the wire-contract trace document (`docs/visual-debugger`).
+///
+/// When NOT paused this is the byte-stable stub `{"paused":false,"sources":[…],
+/// "invocations":[]}` — no `frame`/`tts` (they change every frame, and the LSP's
+/// idle poll dedups on the doc bytes, so the unpaused doc must stay identical
+/// while the sources are unchanged). When paused it carries `frame`/`tts` and
+/// replays the journal into `invocations`. The caller owns any caching (building
+/// only on a pause-state or paused-frame change) — this function is pure.
+pub fn build_trace_doc(
+    paused: bool,
+    frame: u64,
+    tts: f64,
+    sources: &[InspectorSource],
+    journal: &[JournalEntry],
+    session: &Session,
+) -> String {
+    if !paused {
+        return serde_json::json!({
+            "paused": false,
+            "sources": sources_json(sources),
+            "invocations": [],
+        })
+        .to_string();
+    }
+    serde_json::json!({
+        "frame": frame,
+        "tts": tts,
+        "paused": true,
+        "sources": sources_json(sources),
+        "invocations": build_invocations(journal, sources, session),
+    })
+    .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::functor_lang_producer::Provenance;
+    use functor_lang::project::load_single_source;
+    use functor_lang::Value;
+    use std::rc::Rc;
+
+    // Two entry points with param binders + a `let` binder each — no engine
+    // prelude needed (we never call `draw`), so this builds and replays under
+    // the plain host. `input`'s primitive args let us construct the journal
+    // directly (no ADT message value to synthesize).
+    const SRC: &str = "\
+        type Model = { n: Float }\n\
+        let init = { n: 0.0 }\n\
+        let tick = (m: Model, dt: Float, tts: Float) =>\n\
+          let bumped = m.n + dt in\n\
+          { n: bumped }\n\
+        let input = (m: Model, key: String, isDown: Bool) =>\n\
+          let step = 1.0 in\n\
+          { n: m.n + step }\n";
+
+    fn session_and_sources() -> (Session, Value, Vec<InspectorSource>) {
+        let project =
+            load_single_source("game", SRC).unwrap_or_else(|e| panic!("load: {}", e.render()));
+        let session = Session::load(&project.module, &mut FunctorHost)
+            .unwrap_or_else(|f| panic!("session: {}", f.error.message));
+        let model = session.global("init").expect("init");
+        let sources = inspector_sources(&project.sources);
+        (session, model, sources)
+    }
+
+    #[test]
+    fn unpaused_doc_is_the_byte_stable_stub() {
+        let (session, _model, sources) = session_and_sources();
+        // Byte-identical regardless of the frame/tts args — the M1 contract: the
+        // LSP dedups idle polls on the doc bytes, so the unpaused doc must not
+        // carry per-frame fields.
+        let a = build_trace_doc(false, 0, 0.0, &sources, &[], &session);
+        let b = build_trace_doc(false, 7, 4.5, &sources, &[], &session);
+        assert_eq!(a, b);
+        let doc: serde_json::Value = serde_json::from_str(&a).unwrap();
+        assert_eq!(doc["paused"], serde_json::json!(false));
+        assert_eq!(doc["invocations"].as_array().unwrap().len(), 0);
+        assert!(doc.get("frame").is_none(), "no frame while playing");
+        assert!(doc.get("tts").is_none(), "no tts while playing");
+        assert_eq!(doc["sources"][0]["file"], serde_json::json!("game.fun"));
+        assert_eq!(doc["sources"][0]["hash"].as_str().unwrap().len(), 64);
+    }
+
+    #[test]
+    fn paused_doc_replays_journal_into_wire_contract_invocations() {
+        let (session, model, sources) = session_and_sources();
+        // Two ticks + one input: proves index/count framing and both provenance
+        // kinds, with real args that replay to real binding values.
+        let journal = vec![
+            JournalEntry {
+                entry: "tick",
+                args: vec![model.clone(), Value::Number(0.2), Value::Number(1.1)],
+                provenance: Provenance::Tick,
+            },
+            JournalEntry {
+                entry: "tick",
+                args: vec![model.clone(), Value::Number(0.5), Value::Number(1.6)],
+                provenance: Provenance::Tick,
+            },
+            JournalEntry {
+                entry: "input",
+                args: vec![model.clone(), Value::String(Rc::from("W")), Value::Bool(true)],
+                provenance: Provenance::Input,
+            },
+        ];
+        let doc: serde_json::Value =
+            serde_json::from_str(&build_trace_doc(true, 3, 1.6, &sources, &journal, &session))
+                .unwrap();
+
+        assert_eq!(doc["paused"], serde_json::json!(true));
+        assert_eq!(doc["frame"], serde_json::json!(3));
+        assert_eq!(doc["tts"], serde_json::json!(1.6));
+        assert_eq!(doc["sources"][0]["file"], serde_json::json!("game.fun"));
+        assert_eq!(doc["sources"][0]["hash"].as_str().unwrap().len(), 64);
+
+        let invs = doc["invocations"].as_array().unwrap();
+        assert_eq!(invs.len(), 3);
+
+        // The two ticks: 0-based index within the entry, shared count, dt-tagged
+        // provenance rendered at f32 precision.
+        let ticks: Vec<_> = invs.iter().filter(|i| i["entry"] == "tick").collect();
+        assert_eq!(ticks.len(), 2);
+        assert_eq!(ticks[0]["index"], serde_json::json!(0));
+        assert_eq!(ticks[1]["index"], serde_json::json!(1));
+        assert!(ticks.iter().all(|t| t["count"] == serde_json::json!(2)));
+        assert_eq!(ticks[0]["provenance"], serde_json::json!("tick dt=0.2"));
+        assert_eq!(ticks[0]["ghost"], serde_json::json!(false));
+
+        // Bindings: the params + the `let bumped` site, in game.fun, at LOCAL
+        // byte offsets into the file text, carrying the replayed values.
+        let binds = ticks[0]["bindings"].as_array().unwrap();
+        assert!(
+            binds.iter().any(|b| b["name"] == "bumped"),
+            "the let binder is recorded: {binds:#?}"
+        );
+        assert!(binds.iter().all(|b| b["file"] == "game.fun"));
+        for b in binds {
+            let start = b["start"].as_u64().unwrap() as usize;
+            let end = b["end"].as_u64().unwrap() as usize;
+            assert!(start <= end && end <= SRC.len(), "LOCAL offset into the file");
+            assert!(b["value"].is_string());
+        }
+        // `dt` binds to the exact arg we passed — a real value.
+        let dt = binds.iter().find(|b| b["name"] == "dt").expect("dt binding");
+        assert_eq!(dt["value"], serde_json::json!("0.2"));
+
+        // The input invocation: its own count, key/down provenance, real bindings.
+        let input = invs.iter().find(|i| i["entry"] == "input").unwrap();
+        assert_eq!(input["index"], serde_json::json!(0));
+        assert_eq!(input["count"], serde_json::json!(1));
+        assert_eq!(input["provenance"], serde_json::json!("input: W down"));
+        assert!(!input["bindings"].as_array().unwrap().is_empty());
+    }
+}

--- a/runtime/functor-runtime-common/src/lib.rs
+++ b/runtime/functor-runtime-common/src/lib.rs
@@ -63,6 +63,7 @@ pub mod game_clock;
 pub mod geometry;
 mod input;
 pub mod inspect;
+pub mod inspector;
 pub mod io;
 mod light;
 pub mod material;

--- a/runtime/functor-runtime-desktop/Cargo.toml
+++ b/runtime/functor-runtime-desktop/Cargo.toml
@@ -26,9 +26,6 @@ cgmath = "0.18.0"
 image = "0.25"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-# Per-file source hashing for the paused-inspector wire contract (visual-debugger
-# PR2): the `sources` array's sha256 gates the LSP's live-value overlay.
-sha2 = "0.10"
 notify = "6.1.1"
 notify-debouncer-full = "0.3.1"
 tempfile = "3.10.1"

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -39,12 +39,13 @@ use functor_runtime_common::functor_lang_producer::{
     journal_arm, journal_push, journal_swap, FrameCtx, JournalEntry, Provenance, Reporter,
     SpanSource,
 };
+use functor_runtime_common::inspector::{build_trace_doc, inspector_sources, InspectorSource};
 use functor_runtime_common::physics;
 use functor_runtime_common::timetravel::SceneRecorder;
 use functor_runtime_common::ui::View;
 use functor_runtime_common::{Frame, FrameTime};
 use functor_lang::project::SourceMap;
-use functor_lang::{Session, Span, Value};
+use functor_lang::{Session, Value};
 use std::path::PathBuf;
 use std::time::SystemTime;
 
@@ -194,45 +195,6 @@ struct Loaded {
     has_physics: bool,
     has_soundscape: bool,
     has_ui: bool,
-}
-
-/// One project source file's inspector metadata (visual-debugger PR2): its
-/// wire name, its base offset in the project-wide span space, its length, and
-/// the sha256 of the text the runtime loaded. Computed once per load, so a
-/// binding span maps to `(file, local offset)` and the wire `sources` gates on
-/// a content hash without re-reading files.
-struct InspectorSource {
-    file: String,
-    base: usize,
-    len: usize,
-    hash: String,
-}
-
-/// Build the per-file inspector metadata from a loaded [`SourceMap`]: the REAL
-/// project `.fun` files only (skip the injected prelude `.funi` interfaces and
-/// the `<builtin>/Net.fun` module — a game binding never lands in them, and
-/// they aren't editor documents the LSP gates on).
-fn inspector_sources(sources: &SourceMap) -> Vec<InspectorSource> {
-    use sha2::{Digest, Sha256};
-    sources
-        .files()
-        .iter()
-        .filter(|f| !f.interface && !f.path.to_string_lossy().starts_with('<'))
-        .map(|f| {
-            let file = f
-                .path
-                .file_name()
-                .map(|n| n.to_string_lossy().into_owned())
-                .unwrap_or_else(|| f.path.to_string_lossy().into_owned());
-            let hash = format!("{:x}", Sha256::digest(f.src.as_bytes()));
-            InspectorSource {
-                file,
-                base: f.base,
-                len: f.src.len(),
-                hash,
-            }
-        })
-        .collect()
 }
 
 /// Load, check, and contract-validate a game project (B8: the entry plus
@@ -585,98 +547,6 @@ impl FunctorLangGame {
         }
     }
 
-    /// Map a project-wide binding span to `(file, local start, local end)` for
-    /// the wire contract, using the per-file base offsets (visual-debugger PR2).
-    /// `None` if the span falls outside a real project file (a prelude/builtin
-    /// span — a game binding never does).
-    fn span_to_file(&self, span: Span) -> Option<(String, usize, usize)> {
-        let src = self
-            .source_hashes
-            .iter()
-            .filter(|s| s.base <= span.start)
-            .max_by_key(|s| s.base)?;
-        if span.start > src.base + src.len {
-            return None;
-        }
-        Some((
-            src.file.clone(),
-            span.start - src.base,
-            span.end.saturating_sub(src.base),
-        ))
-    }
-
-    /// Replay the last real frame's journal into the wire-contract
-    /// `invocations` (visual-debugger PR2). Each journaled call is re-run through
-    /// `Session::call_recorded` — entry points are pure functions of their args,
-    /// so the record is exact, and effects are plain data (nothing performs), so
-    /// replay is side-effect-free. `index`/`count` frame each call within its
-    /// entry name; binding spans map to `(file, local offsets)`.
-    fn build_invocations(&self) -> Vec<serde_json::Value> {
-        use std::collections::HashMap;
-        // Replay FIRST, then frame: `index`/`count` are computed over the
-        // invocations actually EMITTED, so the array is always consistent with
-        // its own counts (the LSP picker mod-cycles on `count`). A call that
-        // succeeded live, replayed pure, should not fail — skip one
-        // defensively rather than abort the whole trace if it somehow does.
-        let mut replayed = Vec::with_capacity(self.last_frame_journal.len());
-        for e in &self.last_frame_journal {
-            if let Ok((_discard, inv)) =
-                self.session
-                    .call_recorded(e.entry, e.args.clone(), &mut FunctorHost)
-            {
-                replayed.push((e, inv));
-            }
-        }
-        let mut counts: HashMap<&str, usize> = HashMap::new();
-        for (e, _) in &replayed {
-            *counts.entry(e.entry).or_default() += 1;
-        }
-        let mut seen: HashMap<&str, usize> = HashMap::new();
-        let mut out = Vec::with_capacity(replayed.len());
-        for (e, inv) in &replayed {
-            let index = {
-                let c = seen.entry(e.entry).or_default();
-                let i = *c;
-                *c += 1;
-                i
-            };
-            let bindings: Vec<serde_json::Value> = inv
-                .bindings
-                .iter()
-                .filter_map(|b| {
-                    self.span_to_file(b.span).map(|(file, start, end)| {
-                        serde_json::json!({
-                            "name": b.name,
-                            "file": file,
-                            "start": start,
-                            "end": end,
-                            "value": b.value,
-                            "count": b.count,
-                        })
-                    })
-                })
-                .collect();
-            out.push(serde_json::json!({
-                "entry": e.entry,
-                "index": index,
-                "count": counts[e.entry],
-                "provenance": e.provenance.render(&e.args),
-                "ghost": false,
-                "result": inv.result,
-                "truncated": inv.truncated,
-                "bindings": bindings,
-            }));
-        }
-        out
-    }
-
-    /// The wire `sources` array — `{ file, hash }` per loaded project file.
-    fn sources_json(&self) -> Vec<serde_json::Value> {
-        self.source_hashes
-            .iter()
-            .map(|s| serde_json::json!({ "file": s.file, "hash": s.hash }))
-            .collect()
-    }
 }
 
 impl Game for FunctorLangGame {
@@ -1091,26 +961,21 @@ AudioScene.empty), got {}",
     /// (`GameClock::is_paused`).
     fn inspector_trace(&mut self, paused: bool) -> String {
         if !paused {
-            return serde_json::json!({
-                "paused": false,
-                "sources": self.sources_json(),
-                "invocations": [],
-            })
-            .to_string();
+            return build_trace_doc(false, 0, 0.0, &self.source_hashes, &[], &self.session);
         }
-        let frame = self.recorder.current_scene_frame().unwrap_or(0);
-        let tts = self.recorder.current_scene_frame_tts().unwrap_or(0.0);
         if let Some(cached) = &self.cached_trace {
             return cached.clone();
         }
-        let json = serde_json::json!({
-            "frame": frame,
-            "tts": tts,
-            "paused": true,
-            "sources": self.sources_json(),
-            "invocations": self.build_invocations(),
-        })
-        .to_string();
+        let frame = self.recorder.current_scene_frame().unwrap_or(0);
+        let tts = self.recorder.current_scene_frame_tts().unwrap_or(0.0);
+        let json = build_trace_doc(
+            true,
+            frame,
+            tts,
+            &self.source_hashes,
+            &self.last_frame_journal,
+            &self.session,
+        );
         self.cached_trace = Some(json.clone());
         json
     }

--- a/runtime/functor-runtime-web/index-functor-lang.html
+++ b/runtime/functor-runtime-web/index-functor-lang.html
@@ -149,6 +149,8 @@
         functor_lang_scrub_paused,
         functor_lang_scrub_set_preview,
         functor_lang_scrub_set_preview_config,
+        functor_lang_inspector_trace_gen,
+        functor_lang_inspector_trace,
       } from "./pkg/functor_runtime_web.js";
 
       // The Functor Lang entry file, substituted in by the CLI's dev server (see
@@ -299,6 +301,12 @@
 
         let scrubbing = false;
         let pendingSeek = null;
+        // Paused-scene inspector (visual-debugger PR2b): the runtime bumps a
+        // generation counter only when the trace CONTENT changes (on pause, or
+        // when the paused frame changes). We poll it in the same per-frame loop
+        // and relay each change to the hosting frame — the VS Code live-preview
+        // webview, which forwards it to the LSP as `functor/inspector/trace`.
+        let lastTraceGen = -1;
         slider.addEventListener("pointerdown", () => (scrubbing = true));
         window.addEventListener("pointerup", () => (scrubbing = false));
         slider.addEventListener("input", () => (pendingSeek = Number(slider.value)));
@@ -354,6 +362,20 @@
           if (pendingSeek !== null) {
             functor_lang_seek_scene(pendingSeek);
             pendingSeek = null;
+          }
+          // Relay a changed inspector trace to the hosting frame. Posting to
+          // `window.parent` is harmless when not embedded (it resolves to this
+          // window, which has no production listener); the VS Code webview
+          // whitelists `functor-inspector-trace` and forwards it to the LSP.
+          const traceGen = functor_lang_inspector_trace_gen();
+          if (traceGen !== lastTraceGen) {
+            lastTraceGen = traceGen;
+            try {
+              const trace = JSON.parse(functor_lang_inspector_trace());
+              window.parent.postMessage({ type: "functor-inspector-trace", trace }, "*");
+            } catch (e) {
+              // A malformed doc (shouldn't happen) must not kill the poll loop.
+            }
           }
           const range = functor_lang_scene_range(); // [] or [lo, hi]
           if (range.length === 2) {

--- a/runtime/functor-runtime-web/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-web/src/functor_lang_game.rs
@@ -26,7 +26,10 @@ use functor_runtime_common::functor_lang_prelude::{
     take_ui_handlers, view_value, EffectLog, EffectRunner, EffectTree, FunctorHost, NetEventKind,
     RealEffects, UiHandler,
 };
-use functor_runtime_common::functor_lang_producer::{FrameCtx, Reporter, SpanSource};
+use functor_runtime_common::functor_lang_producer::{
+    journal_arm, journal_swap, FrameCtx, JournalEntry, Reporter, SpanSource,
+};
+use functor_runtime_common::inspector::{build_trace_doc, inspector_sources, InspectorSource};
 use functor_runtime_common::physics;
 use functor_runtime_common::protocol::GameProducer;
 use functor_runtime_common::timetravel::SceneRecorder;
@@ -121,6 +124,20 @@ pub struct FunctorLangWebGame {
     /// of a frozen canvas, React-HMR style). Tracked so the DOM is touched only
     /// on a transition (draw breaks / recovers), not every frame.
     overlay_error: Option<String>,
+    /// The last real frame's replay journal (visual-debugger PR2b): one entry
+    /// per model-updating call, swapped in from the thread-local journal at the
+    /// end of each `tick`. A paused frame runs no `tick`, so this is preserved —
+    /// the inspector reads the last real frame. Replayed through
+    /// `Session::call_recorded` while paused. Mirrors the desktop producer.
+    last_frame_journal: Vec<JournalEntry>,
+    /// The lazily built + cached inspector-trace JSON for the current paused
+    /// frame. Invalidated when the frame advances (`tick`), the paused frame
+    /// changes (rewind/seek), or the program reloads.
+    cached_trace: Option<String>,
+    /// Per-file sha256 of the loaded `.fun` source, computed at load / reload
+    /// (not per frame) — the wire contract's `sources`, and the per-file
+    /// base→(file, local offset) map for binding spans.
+    source_hashes: Vec<InspectorSource>,
 }
 
 /// A successfully loaded, contract-validated game module (the desktop
@@ -282,9 +299,18 @@ impl FunctorLangWebGame {
             .unwrap_or_else(|| "game.fun".to_string());
         let loaded = load_source(&sources)?;
         web_sys::console::log_1(&format!("[functor-lang] loaded {path}").into());
+        // Arm the paused-inspector journal on this (the only) wasm thread: from
+        // now on every live model-updating call is journaled (a cheap Rc-clone
+        // push). During play we NEVER arm the recorder or render Display — the
+        // trace is built lazily only when paused (visual-debugger PR2b).
+        journal_arm();
+        let source_hashes = inspector_sources(&loaded.sources);
         Ok(FunctorLangWebGame {
             reporter: Reporter::new(SpanSource::Project(loaded.sources), report_to_console),
             overlay_error: None,
+            last_frame_journal: Vec::new(),
+            cached_trace: None,
+            source_hashes,
             sources,
             path,
             module: loaded.module,
@@ -330,6 +356,13 @@ impl FunctorLangWebGame {
         for warning in &report.warnings {
             web_sys::console::warn_1(&format!("[functor-lang] reload: {warning}").into());
         }
+        // Recompute the inspector source hashes for the edited files, and drop
+        // the journal + cached trace: they refer to the OLD program's spans and
+        // execution (visual-debugger PR2b — reload clears both, like desktop).
+        self.source_hashes = inspector_sources(&loaded.sources);
+        self.last_frame_journal.clear();
+        self.cached_trace = None;
+        journal_swap(); // discard any partial current-frame journal
         self.reporter.set_source(SpanSource::Project(loaded.sources));
         self.module = loaded.module;
         self.session = loaded.session;
@@ -469,6 +502,10 @@ impl GameProducer for FunctorLangWebGame {
             // Model restored to `target`; drop orphaned buffered input so it can't
             // record into the branch (fixed-timestep 0-substep buffering, xreview).
             self.input_buf.clear();
+            // The scrubbed frame is a historical one whose journal we didn't keep
+            // — report it honestly as empty invocations (visual-debugger PR2b).
+            self.last_frame_journal.clear();
+            self.cached_trace = None;
         }
         result
     }
@@ -485,6 +522,10 @@ impl GameProducer for FunctorLangWebGame {
             // Same as rewind: the model was restored, so buffered input since the
             // last recorded frame is orphaned and must not enter the branch.
             self.input_buf.clear();
+            // The paused frame changed — clear the last-frame journal and cache
+            // so the trace reflects the scrubbed frame (visual-debugger PR2b).
+            self.last_frame_journal.clear();
+            self.cached_trace = None;
         }
         result
     }
@@ -532,6 +573,14 @@ impl GameProducer for FunctorLangWebGame {
         // (docs/time-travel.md T6a). Web runs it as one call — unlike native it
         // has no per-frame perf timing to split it at the physics boundary.
         self.ctx().run_frame(frame_time);
+        // A real frame ran: swap its journal into `last_frame_journal` (leaving
+        // a fresh armed journal) and drop the cached trace (the frame advanced).
+        // A paused frame never reaches here, so its last real frame is kept
+        // (visual-debugger PR2b — mirrors the desktop producer).
+        if let Some(journal) = journal_swap() {
+            self.last_frame_journal = journal;
+        }
+        self.cached_trace = None;
     }
 
     fn key_event(&mut self, code: i32, is_down: bool) {
@@ -702,6 +751,34 @@ AudioScene.empty), got {}",
 
     fn state_debug(&self) -> String {
         self.model.to_string()
+    }
+
+    /// The paused-inspector trace (visual-debugger PR2b), same contract and
+    /// caching as the desktop producer: the byte-stable stub while playing
+    /// (no `frame`/`tts`), and a lazily built + cached full doc while paused —
+    /// built only once per pause / paused-frame change (the cache is dropped on
+    /// tick / rewind / seek / reload). Published to the page's poll loop via
+    /// [`publish_inspector_trace`] each frame; the page relays a CHANGE to the
+    /// VS Code live-preview as a `functor-inspector-trace` postMessage.
+    fn inspector_trace(&mut self, paused: bool) -> String {
+        if !paused {
+            return build_trace_doc(false, 0, 0.0, &self.source_hashes, &[], &self.session);
+        }
+        if let Some(cached) = &self.cached_trace {
+            return cached.clone();
+        }
+        let frame = self.recorder.current_scene_frame().unwrap_or(0);
+        let tts = self.recorder.current_scene_frame_tts().unwrap_or(0.0);
+        let json = build_trace_doc(
+            true,
+            frame,
+            tts,
+            &self.source_hashes,
+            &self.last_frame_journal,
+            &self.session,
+        );
+        self.cached_trace = Some(json.clone());
+        json
     }
 
     fn net_drain_commands(&self) -> String {
@@ -1118,4 +1195,52 @@ pub fn functor_lang_scene_range() -> Vec<f64> {
 #[wasm_bindgen]
 pub fn functor_lang_scrub_paused() -> bool {
     SCRUB_VIEW.with(|v| v.borrow().3)
+}
+
+// --- Paused-scene inspector ↔ DOM bridge (visual-debugger PR2b) --------------
+//
+// The desktop shell serves the inspector trace over `GET /trace`; the web shell
+// has no debug HTTP server, so it uses the SAME poll pattern as the scrubber
+// above. Each frame the loop publishes the current trace doc via
+// [`publish_inspector_trace`]; a GENERATION counter bumps only when the doc
+// CONTENT changes — which, given the producer's caching, happens only on a
+// pause-state change or a paused-frame change (step/seek), never generally
+// during play. The page polls the counter and, on a change, reads the doc and
+// relays it to the VS Code live-preview as a `functor-inspector-trace`
+// postMessage (which the extension already forwards to the LSP).
+
+thread_local! {
+    /// `(generation, doc json)` — published each frame by the loop, read by the
+    /// page's poll exports. The generation increments ONLY when the doc bytes
+    /// change, so the page posts a trace on pause / paused-frame change, not
+    /// every frame.
+    static INSPECTOR_TRACE: RefCell<(u32, String)> = const { RefCell::new((0, String::new())) };
+}
+
+/// Publish this frame's inspector trace for the page to poll. Cheap: the doc is
+/// the producer's cached string while paused (rebuilt only on a pause/frame
+/// change) and the byte-stable stub while playing, so the equality check here
+/// is a plain string compare — the generation bumps only on a real change.
+pub fn publish_inspector_trace(doc: String) {
+    INSPECTOR_TRACE.with(|t| {
+        let mut t = t.borrow_mut();
+        if t.1 != doc {
+            t.0 = t.0.wrapping_add(1);
+            t.1 = doc;
+        }
+    });
+}
+
+/// Runtime → page: the inspector-trace generation. The page polls this each
+/// frame and reads [`functor_lang_inspector_trace`] only when it changes.
+#[wasm_bindgen]
+pub fn functor_lang_inspector_trace_gen() -> u32 {
+    INSPECTOR_TRACE.with(|t| t.borrow().0)
+}
+
+/// Runtime → page: the current inspector-trace wire JSON (the paused full doc,
+/// or the byte-stable playing stub).
+#[wasm_bindgen]
+pub fn functor_lang_inspector_trace() -> String {
+    INSPECTOR_TRACE.with(|t| t.borrow().1.clone())
 }

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -1395,6 +1395,13 @@ async fn run_async() -> Result<(), JsValue> {
                 clock.is_paused(),
             );
 
+            // Publish the paused-inspector trace for the page's poll loop
+            // (visual-debugger PR2b). Cheap: while playing this is the byte-stable
+            // stub; while paused the producer serves its cached doc (rebuilt only
+            // on a pause / paused-frame change). The page relays a CHANGE to the
+            // VS Code live-preview as a `functor-inspector-trace` postMessage.
+            functor_lang_game::publish_inspector_trace(game.inspector_trace(clock.is_paused()));
+
             // Schedule the next frame. In deterministic mode (?fixed-time, the
             // golden) render a short warm-up (shader compile, first-frame
             // settling) then stop, so the page is perfectly static: the golden


### PR DESCRIPTION
Follow-up to the paused-scene inspector (#339–#342): the **WASM runtime now emits inspector traces**, so the VS Code live preview auto-connects the inspector — pause the preview and live values appear inline, with no explicit attach gesture.

## Why

The native inspector path uses `GET /trace` over the debug server (an explicit `attach` to a `--debug-port`). The VS Code preview is the *wasm* runtime in a webview, which has no HTTP debug transport — so it needs the push path. The extension's `functor-inspector-trace` → `functor/inspector/trace` relay already merged in #342; this PR supplies the missing sender.

## What

- **Shared trace-builder.** Lifted the trace-doc assembler out of the desktop crate into `functor_runtime_common::inspector` (`build_trace_doc`, `inspector_sources`, `InspectorSource`; `sha2` moved to common). Desktop's `inspector_trace` is now a thin caller and stays **byte-identical** — the byte-stable unpaused stub `{"paused":false,"sources":[…],"invocations":[]}` (the M1 fix) is preserved.
- **Web producer emission.** Arms the journal and swaps it per frame; builds the trace **lazily, only when paused** — no recorder arming or `Display` rendering during play, matching the inspector's zero-cost-while-playing constraint. New wasm exports `functor_lang_inspector_trace()` and `functor_lang_inspector_trace_gen()` (the gen counter bumps only on content change — pause-state or paused-frame change).
- **Page glue.** The existing per-frame poll loop posts `{type:"functor-inspector-trace", trace}` to `window.parent` when the gen counter changes.

## Verification (headless)

- `cargo test -p functor_runtime_common` (274, +2 new for the shared builder) and `-p functor-runtime-desktop` (44, unchanged) green; strict build clean.
- **Playwright E2E** (`e2e/inspector-emit.mjs`, `npm run test:inspector-emit`): serves `examples/inspector` as wasm, clicks the real `#scrub-pause` DOM button, and asserts a `functor-inspector-trace` message arrives with `paused:true` and a real-valued binding:
  ```
  PASS  inspector-emit
    {"pausedMessages":1,"invocations":1,"entries":["tick"],
     "sampleBinding":{"name":"model","value":"{ ticks: 1, lastTime: … }", ...}}
  ```

## Reviewed

Adversarial review: no Critical/High. Confirmed the desktop refactor is byte-identical, the web journal lifecycle clears correctly on hot-reload/rewind/seek, and the gen-counter (keyed on full doc-byte equality) can neither miss a change nor churn. Documented non-blocking nits: the page posts with `targetOrigin: "*"` (the webview re-checks `event.source`/origin on receipt, so scoping the sender risks breaking that path), and playing frames still serialize the tiny stub each frame (stub-only, no replay/hashing; gen-compare prevents any postMessage churn).

## Merge note

Both this and the VS Code E2E harness PR add an npm script at the same spot in `package.json` — whichever merges second hits a one-line conflict; resolution is keep both lines.

## Follow-ups

SSE `GET /events` to replace native idle polling; optionally skip the per-frame stub serialize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
