### PR TITLE
site: trim the landing page's language-bullets list

### DIFF
--- a/cli/src/util/wasm_dev_server.rs
+++ b/cli/src/util/wasm_dev_server.rs
@@ -12,6 +12,10 @@ pub(crate) const WASM_FILE: &[u8] =
     include_bytes!("../../../runtime/functor-runtime-web/pkg/functor_runtime_web_bg.wasm");
 pub(crate) const JS_FILE_1: &[u8] =
     include_bytes!("../../../runtime/functor-runtime-web/pkg/functor_runtime_web.js");
+// The shared time-travel scrubber component, imported by the served index page
+// (and by the site's player.html). Served at /scrubber.js next to pkg/.
+pub(crate) const SCRUBBER_JS: &[u8] =
+    include_bytes!("../../../runtime/functor-runtime-web/scrubber.js");
 
 /// The standard inline-script defense: JSON escaping is not HTML escaping, so a
 /// `</script>` inside a substituted literal would terminate the page's script
@@ -102,6 +106,13 @@ impl WasmDevServer {
                     .body(WASM_FILE.to_vec())
             })
             .boxed();
+        let route_scrubber = warp::path!("scrubber.js")
+            .map(|| {
+                Response::builder()
+                    .header("Content-Type", "application/javascript")
+                    .body(SCRUBBER_JS.to_vec())
+            })
+            .boxed();
 
         // Route to serve files from the specified working directory
         let route_filesystem = warp::fs::dir(wd);
@@ -110,7 +121,7 @@ impl WasmDevServer {
         // and the index page + `.fun` source are re-generated per run — without
         // it, switching samples (each serving its source at the same
         // `/game.fun` URL) can show a stale game from the browser cache.
-        let static_routes = route_index.or(route_js1).or(route_wasm);
+        let static_routes = route_index.or(route_js1).or(route_wasm).or(route_scrubber);
         let routes = static_routes
             .or(route_filesystem)
             .with(warp::reply::with::header("cache-control", "no-store"));

--- a/cli/src/util/wasm_export.rs
+++ b/cli/src/util/wasm_export.rs
@@ -22,14 +22,17 @@ use std::collections::BTreeSet;
 use std::io::Error;
 use std::path::{Path, PathBuf};
 
-use super::wasm_dev_server::{project_file_urls, render_functor_lang_index, JS_FILE_1, WASM_FILE};
+use super::wasm_dev_server::{
+    project_file_urls, render_functor_lang_index, JS_FILE_1, SCRUBBER_JS, WASM_FILE,
+};
 
 /// Names at the project root the exporter owns in the bundle: its output dir
-/// and the runtime files it writes. Project files with these names are
+/// and the runtime files it writes (the index page, the `pkg/` wasm bundle,
+/// and the shared `scrubber.js` component). Project files with these names are
 /// skipped (and reported via [`WasmExport::shadowed`]) rather than merged —
 /// merging a project `pkg/` with the runtime's would leave stray files
 /// beside the wasm bundle.
-const RESERVED_ROOT: &[&str] = &["dist", "index.html", "pkg"];
+const RESERVED_ROOT: &[&str] = &["dist", "index.html", "pkg", "scrubber.js"];
 
 /// Extensions the runtime fetches at runtime: models (plus the external
 /// buffers/images a non-embedded `.gltf` references), audio, textures.
@@ -108,6 +111,7 @@ name {RESERVED_ROOT:?} at the project root): {} — rename or move them",
 
     // The runtime files go in last so nothing in the project can shadow them.
     std::fs::write(out.join("index.html"), render_functor_lang_index(entry, &files))?;
+    std::fs::write(out.join("scrubber.js"), SCRUBBER_JS)?;
     let pkg = out.join("pkg");
     std::fs::create_dir_all(&pkg)?;
     std::fs::write(pkg.join("functor_runtime_web.js"), JS_FILE_1)?;
@@ -117,7 +121,7 @@ name {RESERVED_ROOT:?} at the project root): {} — rename or move them",
         out_dir: out,
         file_count: stats.files,
         project_bytes: stats.bytes,
-        runtime_bytes: (JS_FILE_1.len() + WASM_FILE.len()) as u64,
+        runtime_bytes: (JS_FILE_1.len() + WASM_FILE.len() + SCRUBBER_JS.len()) as u64,
         missing_assets: missing_asset_references(root, entry),
         shadowed,
         skipped_symlinks: stats.skipped_symlinks,
@@ -299,6 +303,10 @@ mod tests {
         assert!(index.contains("\"pieces.fun\""), "sibling module in the file list");
         assert!(!fs::read(out.join("pkg/functor_runtime_web_bg.wasm")).unwrap().is_empty());
         assert!(!fs::read(out.join("pkg/functor_runtime_web.js")).unwrap().is_empty());
+        assert!(
+            fs::read_to_string(out.join("scrubber.js")).unwrap().contains("mountScrubber"),
+            "the shared scrubber component ships with the bundle"
+        );
         assert!(out.join("game.fun").is_file());
         assert!(out.join("pieces.fun").is_file());
         assert!(out.join("model.glb").is_file());
@@ -356,17 +364,19 @@ let g = "pkg/tex.png"
     }
 
     #[test]
-    fn hidden_sibling_modules_fail_the_export() {
+    fn hidden_sibling_modules_are_skipped_not_bundled() {
         let dir = TestDir::new("hidden-module");
         dir.write("game.fun", "let init = 0");
-        // Listed by project_files (it's a sibling *.fun) but excluded by the
-        // copy's hidden rule — exporting would bake a 404 into the index.
+        // A dot-prefixed sibling (an editor temp file like `.#game.fun`) is
+        // filtered by project loading (functor_lang::project skips non-loadable
+        // stems), so it's neither listed in the index nor copied. The export
+        // succeeds with only the entry — the hidden file never reaches it.
         dir.write(".hidden.fun", "let ghost = 1");
 
         let wd = dir.path().to_string_lossy().to_string();
-        let err = export_functor_lang_wasm(&wd, "game.fun").unwrap_err();
-        assert!(err.to_string().contains(".hidden.fun"), "{err}");
-        assert!(!dir.path().join("dist").exists(), "failed before any write");
+        let export = export_functor_lang_wasm(&wd, "game.fun").unwrap();
+        assert_eq!(export.file_count, 1, "only game.fun ships");
+        assert!(!export.out_dir.join(".hidden.fun").exists(), "hidden sibling not bundled");
     }
 
     #[cfg(unix)]

--- a/e2e/ide-page.mjs
+++ b/e2e/ide-page.mjs
@@ -1,0 +1,140 @@
+// IDE-page e2e: the browser IDE (site/ide.html) end-to-end, headless. Drives
+// the `window.__ide` test seam (no synthesized DOM events) through:
+//
+//   1. the page boots the multi-file starter to "live" (preview loaded);
+//   2. the sidebar lists game.fun + palette.fun (the entry + a sibling module);
+//   3. editing the SIBLING (palette.fun) hot-swaps and stays "live" — the
+//      multi-file loop the single-buffer sandbox can't do;
+//   4. a broken edit reports the error and the old program keeps running;
+//   5. a good edit recovers to "live";
+//   6. a new file adds a module and the preview stays live;
+//   7. Download builds a real .zip (valid EOCD signature, one entry per file).
+//
+// Run manually (needs the wasm bundle):
+//   wasm-pack build runtime/functor-runtime-web --target=web   # once
+//   node e2e/ide-page.mjs
+import { spawn, spawnSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { chromium } from "@playwright/test";
+
+const PORT = 8126;
+const BASE = `http://127.0.0.1:${PORT}`;
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const fail = (m) => {
+  console.error(`FAIL: ${m}`);
+  process.exitCode = 1;
+};
+
+const GOOD_PALETTE = `let glow = 0.3
+let sky = 0.7
+`;
+const BROKEN_PALETTE = `let glow =
+`;
+
+const built = spawnSync("node", ["site/build.mjs"], { cwd: ROOT, stdio: "inherit" });
+if (built.status !== 0) {
+  console.error("FAIL: site build failed");
+  process.exit(1);
+}
+
+const server = spawn("node", ["site/serve.mjs", "--port", String(PORT)], { cwd: ROOT, stdio: "ignore" });
+const browser = await chromium.launch({
+  args: ["--use-gl=angle", "--use-angle=swiftshader", "--enable-unsafe-swiftshader", "--ignore-gpu-blocklist"],
+});
+
+try {
+  const page = await browser.newPage({ viewport: { width: 1100, height: 640 } });
+  const log = [];
+  page.on("console", (m) => log.push(m.text()));
+  // Start from a clean slate so a stale localStorage project can't mask the
+  // starter (the page persists edits across reloads by design).
+  await page.addInitScript(() => {
+    try {
+      localStorage.removeItem("functor-ide-project-v1");
+    } catch {}
+  });
+
+  for (let i = 0; i < 60; i++) {
+    try {
+      await page.goto(`${BASE}/ide.html`);
+      break;
+    } catch {
+      await sleep(500);
+    }
+  }
+
+  const status = () => page.evaluate(() => window.__ide.status());
+  const waitStatus = async (state, what, timeoutMs = 20000) => {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if ((await status()).state === state) return true;
+      await sleep(150);
+    }
+    fail(`timed out waiting for status "${state}" (${what}); last = ${JSON.stringify(await status())}`);
+    return false;
+  };
+
+  // 1. Boot to live.
+  await waitStatus("live", "initial boot");
+  if (log.some((l) => l.includes("[functor-lang] loaded game.fun"))) {
+    console.log("boots the starter to live ✓");
+  } else {
+    fail(`no "[functor-lang] loaded game.fun":\n${log.join("\n")}`);
+  }
+
+  // 2. Sidebar lists the two starter files.
+  const files = await page.evaluate(() => window.__ide.files().map((f) => f.path));
+  if (JSON.stringify(files) === JSON.stringify(["game.fun", "palette.fun"])) {
+    console.log("file list = game.fun + palette.fun ✓");
+  } else {
+    fail(`unexpected file list: ${JSON.stringify(files)}`);
+  }
+
+  // 3. Edit the SIBLING module → hot-swap, stays live.
+  await page.evaluate(() => window.__ide.openFile("palette.fun"));
+  await page.evaluate((src) => window.__ide.setActiveSource(src), GOOD_PALETTE);
+  if (await waitStatus("live", "sibling hot-swap")) console.log("sibling-module hot-swap stays live ✓");
+
+  // 4. A broken sibling → error, old program keeps running.
+  await page.evaluate((src) => window.__ide.setActiveSource(src), BROKEN_PALETTE);
+  if (await waitStatus("error", "broken sibling")) console.log("broken sibling shows error ✓");
+
+  // 5. Recover.
+  await page.evaluate((src) => window.__ide.setActiveSource(src), GOOD_PALETTE);
+  if (await waitStatus("live", "recovery")) console.log("recovery back to live ✓");
+
+  // 6. New module keeps the preview live.
+  await page.evaluate(() => window.__ide.newFile("enemy.fun", "let hp = 3.0\n"));
+  const withEnemy = await page.evaluate(() => window.__ide.files().map((f) => f.path));
+  if (!withEnemy.includes("enemy.fun")) fail("new file not added");
+  if (await waitStatus("live", "after new file")) console.log("new module added, stays live ✓");
+
+  // 7. Download builds a real zip.
+  const [download] = await Promise.all([
+    page.waitForEvent("download"),
+    page.click("#download"),
+  ]);
+  const path = await download.path();
+  const bytes = await readFile(path);
+  const hasEOCD = bytes.includes(Buffer.from([0x50, 0x4b, 0x05, 0x06])); // end-of-central-dir
+  // EOCD is the last 22 bytes (no comment); "total entries" sits at its
+  // offset 10, i.e. length - 12.
+  const entryCount = bytes.readUInt16LE(bytes.length - 12);
+  const text = bytes.toString("latin1");
+  const hasManifest = text.includes("functor.json"); // must ship so `build wasm` works
+  const hasEntry = text.includes("game.fun");
+  // functor.json + game.fun + palette.fun + enemy.fun
+  if (hasEOCD && entryCount === 4 && hasManifest && hasEntry) {
+    console.log(`download is a valid zip with ${entryCount} entries incl. functor.json ✓`);
+  } else {
+    fail(`bad zip: EOCD=${hasEOCD} entries=${entryCount} manifest=${hasManifest} entry=${hasEntry}`);
+  }
+
+  console.log(process.exitCode ? "RESULT: FAIL" : "RESULT: PASS");
+} finally {
+  await browser.close();
+  server.kill();
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "site:build": "node site/build.mjs",
     "site:serve": "node site/serve.mjs",
     "test:site": "node e2e/site-sandbox.mjs",
-    "test:ide": "node e2e/ide-project.mjs"
+    "test:ide": "node e2e/ide-project.mjs",
+    "test:ide-page": "node e2e/ide-page.mjs"
   },
   "devDependencies": {
     "@codemirror/autocomplete": "^6.20.3",

--- a/runtime/functor-runtime-web/index-functor-lang.html
+++ b/runtime/functor-runtime-web/index-functor-lang.html
@@ -19,116 +19,20 @@
         font: 12px/1 monospace; padding: 6px 10px; cursor: pointer;
         color: #ddd; background: rgba(20,20,24,0.72);
         border: 1px solid rgba(255,255,255,0.15); border-radius: 6px;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35); /* depth — matches the scrubber buttons */
+        transition: box-shadow 0.12s ease, background 0.12s ease, transform 0.12s ease;
       }
-      #mouselook:hover { background: rgba(40,40,48,0.85); }
-      /* The time-travel scrubber — native DOM OUTSIDE the canvas, so its
-         controls never fight the game's pointer handling (docs/time-travel.md
-         T3). Hidden until the runtime has recorded some history. */
-      #scrubber {
-        position: fixed; left: 50%; bottom: 14px; transform: translateX(-50%);
-        z-index: 10; display: none; align-items: center; gap: 10px;
-        font: 12px/1 monospace; color: #eee; padding: 8px 12px 16px;
-        background: rgba(20,20,24,0.82); border-radius: 8px;
-        border: 1px solid rgba(255,255,255,0.14);
+      #mouselook:hover {
+        background: rgba(40,40,48,0.85);
+        box-shadow: 0 3px 10px rgba(0, 0, 0, 0.5); transform: translateY(-1px);
       }
-      #scrubber button {
-        font: 12px/1 monospace; color: #eee; cursor: pointer;
-        background: rgba(80,80,90,0.6); border: 1px solid rgba(255,255,255,0.15);
-        border-radius: 5px; padding: 5px 9px;
-      }
-      #scrubber button:hover { background: rgba(110,110,125,0.7); }
-      /* Frame counter: tiny, faded, tucked right under the timeline rail and
-         centered on IT (not the panel) — positioned, so digit growth never
-         reflows the controls. */
-      #scrub-label {
-        position: absolute; top: calc(100% + 1px); left: 50%;
-        transform: translateX(-50%);
-        opacity: 0.5; font-size: 9px; white-space: nowrap; pointer-events: none;
-      }
-      /* The timeline rail: the range input spans the RECORDED part; the
-         translucent strip marks [handle, handle + preview window] — the rail's
-         domain extends past the recorded end while a preview is on. */
-      #scrub-rail { position: relative; display: flex; align-items: center; width: 340px; }
-      #scrub-slider { width: 100%; accent-color: #e0803a; }
-      #scrub-future {
-        position: absolute; height: 5px; top: 50%; transform: translateY(-50%);
-        border-radius: 2px; background: rgba(64,217,255,0.8);
-        pointer-events: none; display: none;
-      }
-      /* The future segment's end cap: drag to resize the forward window in
-         place. Hangs BELOW the track so it never fights the seek thumb. */
-      #scrub-future-cap {
-        position: absolute; width: 8px; height: 14px; top: 50%;
-        transform: translateY(-50%);
-        border-radius: 2px; background: rgba(64,217,255,0.95);
-        cursor: ew-resize; display: none; touch-action: none;
-      }
-      #scrub-future-cap:hover { background: rgba(150,236,255,1); }
-      #scrub-label .fut { color: rgba(64,217,255,0.85); }
-      #scrubber label { display: flex; align-items: center; gap: 4px; }
-      #scrubber input[type="number"] {
-        width: 42px; font: 12px/1 monospace; color: #eee;
-        background: rgba(80,80,90,0.6); border: 1px solid rgba(255,255,255,0.15);
-        border-radius: 5px; padding: 4px 5px;
-      }
-      /* Future preview (docs/time-travel.md T6/T6d): mode selector; the shared
-         window/samples knobs live in the ⚙ popover. */
-      #scrub-preview {
-        font: 12px/1 monospace; color: #eee;
-        background: rgba(80,80,90,0.6); border: 1px solid rgba(255,255,255,0.15);
-        border-radius: 5px; padding: 4px 5px;
-      }
-      #scrub-adv { position: relative; }
-      #scrub-adv > summary {
-        list-style: none; cursor: pointer; font-size: 14px; padding: 4px 6px;
-        background: rgba(80,80,90,0.6); border: 1px solid rgba(255,255,255,0.15);
-        border-radius: 5px; user-select: none;
-      }
-      #scrub-adv > summary::-webkit-details-marker { display: none; }
-      #scrub-adv[open] > summary { background: rgba(110,110,125,0.7); }
-      #scrub-adv-pop {
-        position: absolute; bottom: 130%; right: 0; z-index: 11;
-        display: flex; flex-direction: column; gap: 8px; padding: 10px 12px;
-        background: rgba(20,20,24,0.92); border-radius: 8px;
-        border: 1px solid rgba(255,255,255,0.14); white-space: nowrap;
-      }
+      /* The time-travel scrubber is the shared component (scrubber.js); it
+         injects its own styles (the calm site theme). */
     </style>
   </head>
   <body>
     <canvas id="canvas"></canvas>
     <button id="mouselook" title="Control the camera with the mouse; Esc to release">🖱 mouse look</button>
-    <div id="scrubber">
-      <button id="scrub-pause">Pause</button>
-      <span id="scrub-rail">
-        <input id="scrub-slider" type="range" min="0" max="0" value="0" step="1" />
-        <span id="scrub-future"></span>
-        <span id="scrub-future-cap" title="Drag to resize the preview window"></span>
-        <span id="scrub-label">time-travel</span>
-      </span>
-      <button id="scrub-step">Step ▸</button>
-      <label title="Extrapolate the future while paused: forward-simulate the game and overlay where everything is headed (docs/time-travel.md T6)">
-        <input id="scrub-extrapolate" type="checkbox" checked />extrapolate
-      </label>
-      <details id="scrub-adv">
-        <summary title="Extrapolation settings">⚙</summary>
-        <div id="scrub-adv-pop">
-          <label title="What the extrapolation shows: trail dots, scene-space strobe copies, both, or the screen-space ghost compositor">show
-            <select id="scrub-mode">
-              <option value="1">trail</option>
-              <option value="2">strobe</option>
-              <option value="3" selected>both</option>
-              <option value="4">ghost</option>
-            </select>
-          </label>
-          <label title="How far ahead the preview projects">window
-            <input id="scrub-win" type="number" step="0.5" min="0.5" max="5" value="2" />s
-          </label>
-          <label title="Strobe copies per second — the trail samples finer; density holds as the window resizes (ghost composites at most 8 total)">rate
-            <input id="scrub-rate" type="number" min="1" max="30" value="5" />/s
-          </label>
-        </div>
-      </details>
-    </div>
     <script type="module">
 
       import init, {
@@ -142,17 +46,13 @@
         functor_lang_is_running,
         functor_lang_set_source,
         functor_lang_set_project,
-        functor_lang_scene_frame,
-        functor_lang_scene_range,
-        functor_lang_seek_scene,
-        functor_lang_scrub_toggle_pause,
-        functor_lang_scrub_step,
-        functor_lang_scrub_paused,
-        functor_lang_scrub_set_preview,
-        functor_lang_scrub_set_preview_config,
         functor_lang_inspector_trace_gen,
         functor_lang_inspector_trace,
       } from "./pkg/functor_runtime_web.js";
+      // The time-travel scrubber is the shared component, served next to pkg/
+      // by the dev server (see runtime/functor-runtime-web/scrubber.js). It
+      // wires the functor_lang_scrub_* exports itself.
+      import { mountScrubber } from "./scrubber.js";
 
       // The Functor Lang entry file, substituted in by the CLI's dev server (see
       // cli/src/util/wasm_dev_server.rs). Must be set before init(): the
@@ -286,88 +186,18 @@
         });
       };
 
-      // The time-travel scrubber (docs/time-travel.md T3). Native DOM controls
-      // drive the runtime through the `functor_lang_scrub_*` exports and poll the
-      // published view state each frame to track the handle. Coalesce drags to
-      // one seek per frame, and don't fight the user's drag by writing the
-      // slider value while they hold it.
-      const setupScrubber = () => {
-        const el = document.getElementById("scrubber");
-        const label = document.getElementById("scrub-label");
-        const pause = document.getElementById("scrub-pause");
-        const slider = document.getElementById("scrub-slider");
-        const step = document.getElementById("scrub-step");
-        const future = document.getElementById("scrub-future");
-        const futureCap = document.getElementById("scrub-future-cap");
-
-        let scrubbing = false;
-        let pendingSeek = null;
-        // Paused-scene inspector (visual-debugger PR2b): the runtime bumps a
-        // generation counter only when the trace CONTENT changes (on pause, or
-        // when the paused frame changes). We poll it in the same per-frame loop
-        // and relay each change to the hosting frame — the VS Code live-preview
-        // webview, which forwards it to the LSP as `functor/inspector/trace`.
+      // Relay a changed paused-scene inspector trace to the hosting frame — the
+      // VS Code live-preview webview, which forwards it to the LSP as
+      // `functor/inspector/trace` (visual-debugger PR2b). The runtime bumps a
+      // generation counter only when the trace CONTENT changes (on pause, or
+      // when the paused frame changes); we poll it once per frame. This lives
+      // on the runtime page only — the site player has no inspector to feed.
+      // Posting to `window.parent` is harmless when not embedded (it resolves
+      // to this window, which has no production listener). Kept OUT of the
+      // shared scrubber component (scrubber.js), which the site also uses.
+      const setupInspectorRelay = () => {
         let lastTraceGen = -1;
-        slider.addEventListener("pointerdown", () => (scrubbing = true));
-        window.addEventListener("pointerup", () => (scrubbing = false));
-        slider.addEventListener("input", () => (pendingSeek = Number(slider.value)));
-        pause.addEventListener("click", () => functor_lang_scrub_toggle_pause());
-        step.addEventListener("click", () => functor_lang_scrub_step());
-
-        // Future extrapolation (docs/time-travel.md T6/T6d): ONE switch on the
-        // bar (default ON — pausing shows trail+strobe out of the box); the
-        // mode / window / rate live in the ⚙ popover. JS owns the UI state and
-        // pushes the EFFECTIVE mode (0 while unchecked). Pushed once at setup
-        // too: the browser may restore form state across a reload while the
-        // fresh runtime starts at the defaults.
-        const extrapolate = document.getElementById("scrub-extrapolate");
-        const mode = document.getElementById("scrub-mode");
-        const win = document.getElementById("scrub-win");
-        const rate = document.getElementById("scrub-rate");
-        const pushPreview = () =>
-          functor_lang_scrub_set_preview(extrapolate.checked ? +mode.value : 0);
-        const pushConfig = () =>
-          functor_lang_scrub_set_preview_config(+win.value, +rate.value);
-        extrapolate.addEventListener("change", pushPreview);
-        mode.addEventListener("change", pushPreview);
-        win.addEventListener("input", pushConfig);
-        rate.addEventListener("input", pushConfig);
-        pushPreview();
-        pushConfig();
-
-        // Drag the cyan segment's end cap to resize the forward window in
-        // place — the ⚙ window input's direct-manipulation twin.
-        let capDrag = null; // { x: pointerdown clientX, w: window at start }
-        futureCap.addEventListener("pointerdown", (e) => {
-          e.preventDefault();
-          futureCap.setPointerCapture(e.pointerId);
-          capDrag = { x: e.clientX, w: +win.value };
-        });
-        futureCap.addEventListener("pointermove", (e) => {
-          if (!capDrag) return;
-          const inset = 7;
-          const travel = slider.offsetWidth - 2 * inset;
-          const domain = +slider.max - +slider.min;
-          if (travel <= 0 || domain <= 0) return;
-          const framesPerPx = domain / travel;
-          const w = Math.min(
-            5,
-            Math.max(0.5, capDrag.w + ((e.clientX - capDrag.x) * framesPerPx) / 60)
-          );
-          win.value = w.toFixed(1);
-          pushConfig();
-        });
-        futureCap.addEventListener("pointerup", () => (capDrag = null));
-
-        const update = () => {
-          if (pendingSeek !== null) {
-            functor_lang_seek_scene(pendingSeek);
-            pendingSeek = null;
-          }
-          // Relay a changed inspector trace to the hosting frame. Posting to
-          // `window.parent` is harmless when not embedded (it resolves to this
-          // window, which has no production listener); the VS Code webview
-          // whitelists `functor-inspector-trace` and forwards it to the LSP.
+        const poll = () => {
           const traceGen = functor_lang_inspector_trace_gen();
           if (traceGen !== lastTraceGen) {
             lastTraceGen = traceGen;
@@ -378,61 +208,9 @@
               // A malformed doc (shouldn't happen) must not kill the poll loop.
             }
           }
-          const range = functor_lang_scene_range(); // [] or [lo, hi]
-          if (range.length === 2) {
-            el.style.display = "flex";
-            const lo = range[0], hi = range[1];
-            slider.min = lo;
-            slider.max = hi;
-            const frame = functor_lang_scene_frame();
-            if (!scrubbing) slider.value = frame; // don't tug the handle mid-drag
-            // The rail's domain includes the preview window: the handle can be
-            // dragged INTO the cyan segment — a seek beyond the recorded end
-            // steps the game forward, input-free (the runtime animates the
-            // catch-up). The counter's cyan `+N` is the numeric twin.
-            const span = hi - lo;
-            const futureFrames = extrapolate.checked
-              ? Math.round(+win.value * 60)
-              : 0;
-            slider.max = hi + futureFrames;
-            // The predicted-frames count sits WITH the current frame:
-            // `227 +120 / 227`.
-            label.innerHTML =
-              `${frame | 0}` +
-              (futureFrames > 0 ? ` <span class="fut">+${futureFrames}</span>` : "") +
-              ` / ${hi | 0}`;
-            pause.textContent = functor_lang_scrub_paused() ? "Resume" : "Pause";
-            if (futureFrames > 0 && span > 0) {
-              // The cyan segment [handle, handle + window] plus its draggable
-              // end cap. Anchored to the THUMB (the visual handle, including
-              // mid-drag) and starting at its right edge, so the cyan never
-              // paints over the orange traversed track or the thumb itself.
-              const inset = 7;
-              const travel = slider.offsetWidth - 2 * inset;
-              const domain = hi + futureFrames - lo;
-              const thumb = +slider.value;
-              const thumbPx = inset + ((thumb - lo) / domain) * travel;
-              const leftPx = thumbPx + inset;
-              const endPx = Math.min(
-                thumbPx + (futureFrames / domain) * travel,
-                inset + travel
-              );
-              const widthPx = Math.max(endPx - leftPx, 0);
-              future.style.left = `${leftPx}px`;
-              future.style.width = `${widthPx}px`;
-              future.style.display = "block";
-              futureCap.style.left = `${endPx - 4}px`;
-              futureCap.style.display = "block";
-            } else {
-              future.style.display = "none";
-              futureCap.style.display = "none";
-            }
-          } else {
-            el.style.display = "none"; // nothing recorded yet
-          }
-          requestAnimationFrame(update);
+          requestAnimationFrame(poll);
         };
-        requestAnimationFrame(update);
+        requestAnimationFrame(poll);
       };
 
       // Editor live-preview bridge (docs/functor-lang.md D4): a hosting page (the
@@ -485,7 +263,8 @@
         const deterministic = new URLSearchParams(window.location.search).has("fixed-time");
         if (!deterministic) {
           setupInput();
-          setupScrubber();
+          mountScrubber();
+          setupInspectorRelay();
         }
         setupSetSource();
       });

--- a/runtime/functor-runtime-web/scrubber.js
+++ b/runtime/functor-runtime-web/scrubber.js
@@ -1,0 +1,317 @@
+// The shared time-travel scrubber — ONE component for every wasm-preview
+// surface: the site's sandbox/IDE (site/player.html) and the CLI dev server /
+// VSCode live-preview (index-functor-lang.html, served by `functor run wasm`).
+// Both pages `import { mountScrubber }` from here instead of hand-rolling the
+// controls, so the two can't drift (they used to — different themes AND
+// different feature sets).
+//
+// It's a dependency-free ES module (no framework): the codebase is Rust +
+// vanilla JS, and neither host page is bundled, so a plain module that both
+// pages import — exactly like they already import ./pkg — is the natural fit.
+// It's served alongside pkg/ (the CLI embeds + serves it; the site build copies
+// it; `build wasm` writes it into dist/web).
+//
+// Look: the site's calm violet/cyan theme, everywhere. Styles are injected here
+// (self-contained) using `var(--scrub-*, <calm default>)`, so a host that sets
+// those vars (player.html, for its mouselook button) matches, and one that
+// doesn't (the runtime page) still renders the same calm look via the fallbacks.
+//
+// Features: the full time-travel UI — pause/resume, a seek slider whose rail
+// extends into a cyan FUTURE bar with a draggable end-cap (resize the forward
+// window in place), step, an extrapolate toggle (🔮), and a ⚙ popover for the
+// extrapolation mode / window / rate (docs/time-travel.md T3/T6/T6d).
+
+import {
+  functor_lang_scene_frame,
+  functor_lang_scene_range,
+  functor_lang_seek_scene,
+  functor_lang_scrub_toggle_pause,
+  functor_lang_scrub_step,
+  functor_lang_scrub_paused,
+  functor_lang_scrub_set_preview,
+  functor_lang_scrub_set_preview_config,
+} from "./pkg/functor_runtime_web.js";
+
+// Calm site theme (site/styles.css :root) as the DEFAULTS, so the runtime page
+// — which sets no vars — renders identically to the site.
+const STYLE = `
+#scrubber {
+  --sb-bg: var(--scrub-bg, rgba(30, 24, 51, 0.92));
+  --sb-line: var(--scrub-line, #2b2542);
+  --sb-text: var(--scrub-text, #e9e6f2);
+  --sb-dim: var(--scrub-dim, #9b94b3);
+  --sb-accent: var(--scrub-accent, #41d8e6);
+  /* The extrapolated-future color — synthwave pink, distinct from the cyan
+     accent of the timeline you actually scrub, and matching the 🔮 toggle. */
+  --sb-future: var(--scrub-future, #e858b8);
+  --sb-font: var(--scrub-font, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+  position: fixed; left: 0; right: 0; bottom: 0; z-index: 10;
+  display: none; align-items: center; gap: 8px; flex-wrap: nowrap;
+  font: 12px/1 var(--sb-font); color: var(--sb-text);
+  /* Extra bottom padding leaves room for the frame counter, which hangs
+     centered UNDER the rail. */
+  padding: 8px 12px 18px; background: var(--sb-bg);
+  border-top: 1px solid var(--sb-line);
+  box-shadow: 0 -3px 16px rgba(0, 0, 0, 0.35); /* depth: lift off the canvas */
+}
+/* Buttons + the ⚙ summary share one raised, tactile treatment — a resting
+   drop shadow, a lift on hover, a press on active. */
+#scrubber button, #scrub-adv > summary {
+  font: 14px/1 var(--sb-font); color: var(--sb-text); cursor: pointer;
+  background: rgba(65, 216, 230, 0.10);
+  border: 1px solid var(--sb-line); border-radius: 6px; padding: 6px 9px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
+  transition: box-shadow 0.12s ease, border-color 0.12s ease, transform 0.12s ease;
+}
+#scrubber button:hover, #scrub-adv > summary:hover {
+  border-color: var(--sb-accent); box-shadow: 0 3px 10px rgba(0, 0, 0, 0.5); transform: translateY(-1px);
+}
+#scrubber button:active, #scrub-adv > summary:active {
+  transform: translateY(0); box-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+}
+/* The timeline rail: the range input spans the recorded part; a translucent
+   cyan strip marks [handle, handle + preview window] — the rail's domain
+   extends past the recorded end while a preview is on. */
+#scrub-rail { position: relative; display: flex; align-items: center; flex: 1; min-width: 60px; }
+#scrub-slider { width: 100%; accent-color: var(--sb-accent); }
+#scrub-future {
+  position: absolute; height: 5px; top: 50%; transform: translateY(-50%);
+  border-radius: 2px; background: var(--sb-future); opacity: 0.85;
+  pointer-events: none; display: none;
+}
+/* The future segment's end cap: drag to resize the forward window in place.
+   Hangs level with the track but is grabbable (the seek thumb owns the middle). */
+#scrub-future-cap {
+  position: absolute; width: 8px; height: 14px; top: 50%; transform: translateY(-50%);
+  border-radius: 2px; background: var(--sb-future);
+  cursor: ew-resize; display: none; touch-action: none;
+}
+#scrub-future-cap:hover { filter: brightness(1.3); }
+/* Frame counter: tiny, faded, centered UNDER the rail — positioned, so digit
+   growth never reflows the controls. */
+#scrub-label {
+  position: absolute; top: calc(100% + 4px); left: 50%; transform: translateX(-50%);
+  color: var(--sb-dim); opacity: 0.7; font-size: 9px; white-space: nowrap; pointer-events: none;
+}
+#scrub-label .fut { color: var(--sb-future); }
+/* Extrapolate toggle: a normal (clearly-clickable) button when OFF, LIT in the
+   future's pink when on — never a greyed-out "disabled" look. */
+#scrub-extrapolate.on {
+  border-color: var(--sb-future);
+  box-shadow: 0 0 0 1px var(--sb-future), 0 2px 10px rgba(232, 88, 184, 0.4);
+}
+#scrub-adv { position: relative; }
+#scrub-adv > summary { list-style: none; user-select: none; }
+#scrub-adv > summary::-webkit-details-marker { display: none; }
+#scrub-adv[open] > summary { border-color: var(--sb-accent); }
+#scrub-adv-pop {
+  position: absolute; bottom: calc(100% + 10px); right: 0; z-index: 11;
+  display: flex; flex-direction: column; gap: 8px; padding: 10px 12px;
+  background: var(--sb-bg); border-radius: 8px; border: 1px solid var(--sb-line);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.5); /* depth: floats above the strip */
+  white-space: nowrap;
+}
+#scrub-adv-pop label { display: flex; align-items: center; gap: 6px; justify-content: space-between; }
+#scrub-adv-pop select, #scrub-adv-pop input[type="number"] {
+  font: 12px/1 var(--sb-font); color: var(--sb-text);
+  background: rgba(65, 216, 230, 0.10); border: 1px solid var(--sb-line);
+  border-radius: 5px; padding: 4px 5px;
+}
+#scrub-adv-pop input[type="number"] { width: 46px; }
+/* Responsive: narrow iframes (the hero card, a phone). This page is an iframe,
+   so the parent's media queries can't reach in — these run against the iframe's
+   own viewport. Tighten gaps/padding and let the rail flex smaller so the whole
+   strip fits without clipping. */
+@media (max-width: 520px) {
+  #scrubber { gap: 6px; padding: 7px 8px 17px; }
+  #scrubber button, #scrub-adv > summary { padding: 6px 7px; }
+  #scrub-rail { min-width: 36px; }
+}
+@media (max-width: 380px) {
+  #scrubber { gap: 4px; }
+  #scrubber button, #scrub-adv > summary { padding: 6px 5px; font-size: 13px; }
+}`;
+
+const HTML = `
+  <button id="scrub-pause" title="Pause / resume">⏸</button>
+  <button id="scrub-step" title="Step one frame forward">⏭</button>
+  <span id="scrub-rail">
+    <input id="scrub-slider" type="range" min="0" max="0" value="0" step="1" />
+    <span id="scrub-future"></span>
+    <span id="scrub-future-cap" title="Drag to resize the preview window"></span>
+    <span id="scrub-label"><span id="scrub-count"></span></span>
+  </span>
+  <button id="scrub-extrapolate" title="Extrapolate: forward-simulate the paused game and overlay where everything is headed (docs/time-travel.md T6)">🔮</button>
+  <details id="scrub-adv">
+    <summary title="Extrapolation settings — what it shows, how far ahead, how densely">⚙</summary>
+    <div id="scrub-adv-pop">
+      <label title="What the extrapolation shows: trail dots, scene-space strobe copies, both, or the screen-space ghost compositor">show
+        <select id="scrub-mode">
+          <option value="1">trail</option>
+          <option value="2">strobe</option>
+          <option value="3" selected>both</option>
+          <option value="4">ghost</option>
+        </select>
+      </label>
+      <label title="How far ahead the preview projects">window
+        <input id="scrub-win" type="number" step="0.5" min="0.5" max="5" value="2" />s
+      </label>
+      <label title="Strobe copies per second — the trail samples finer; density holds as the window resizes (ghost composites at most 8 total)">rate
+        <input id="scrub-rate" type="number" min="1" max="30" value="5" />/s
+      </label>
+    </div>
+  </details>`;
+
+// Mount the scrubber into the page (creates a fixed bottom strip on document.body,
+// hidden until history is recorded). Returns a handle with destroy().
+export function mountScrubber() {
+  if (!document.getElementById("functor-scrubber-style")) {
+    const style = document.createElement("style");
+    style.id = "functor-scrubber-style";
+    style.textContent = STYLE;
+    document.head.appendChild(style);
+  }
+
+  const el = document.createElement("div");
+  el.id = "scrubber";
+  el.innerHTML = HTML;
+  document.body.appendChild(el);
+
+  const $ = (id) => el.querySelector(`#${id}`);
+  const label = $("scrub-count");
+  const pause = $("scrub-pause");
+  const slider = $("scrub-slider");
+  const step = $("scrub-step");
+  const future = $("scrub-future");
+  const futureCap = $("scrub-future-cap");
+  const extrapolate = $("scrub-extrapolate");
+  const mode = $("scrub-mode");
+  const win = $("scrub-win");
+  const rate = $("scrub-rate");
+
+  let scrubbing = false;
+  let pendingSeek = null;
+  // Hoisted so destroy() can remove it — it's a WINDOW listener, not on `el`.
+  const onPointerUp = () => (scrubbing = false);
+  slider.addEventListener("pointerdown", () => (scrubbing = true));
+  window.addEventListener("pointerup", onPointerUp);
+  slider.addEventListener("input", () => (pendingSeek = Number(slider.value)));
+  pause.addEventListener("click", () => functor_lang_scrub_toggle_pause());
+  step.addEventListener("click", () => functor_lang_scrub_step());
+
+  // Future extrapolation (docs/time-travel.md T6/T6d): ONE toggle on the bar
+  // (default OFF — opt in to see where things are headed); the mode / window /
+  // rate live in the ⚙ popover. JS owns the UI state and pushes the EFFECTIVE
+  // mode (0 while off). Pushed once at setup too, since a fresh runtime starts
+  // at its own defaults.
+  let extrapolating = false;
+  const syncExtrapolateIcon = () => extrapolate.classList.toggle("on", extrapolating);
+  const pushPreview = () => functor_lang_scrub_set_preview(extrapolating ? +mode.value : 0);
+  const pushConfig = () => functor_lang_scrub_set_preview_config(+win.value, +rate.value);
+  extrapolate.addEventListener("click", () => {
+    extrapolating = !extrapolating;
+    syncExtrapolateIcon();
+    pushPreview();
+  });
+  mode.addEventListener("change", pushPreview);
+  win.addEventListener("input", pushConfig);
+  rate.addEventListener("input", pushConfig);
+  syncExtrapolateIcon();
+  pushPreview();
+  pushConfig();
+
+  // Drag the cyan segment's end cap to resize the forward window in place —
+  // the ⚙ window input's direct-manipulation twin.
+  let capDrag = null; // { x: pointerdown clientX, w: window at start }
+  futureCap.addEventListener("pointerdown", (e) => {
+    e.preventDefault();
+    futureCap.setPointerCapture(e.pointerId);
+    capDrag = { x: e.clientX, w: +win.value };
+  });
+  futureCap.addEventListener("pointermove", (e) => {
+    if (!capDrag) return;
+    const inset = 7;
+    const travel = slider.offsetWidth - 2 * inset;
+    const domain = +slider.max - +slider.min;
+    if (travel <= 0 || domain <= 0) return;
+    const framesPerPx = domain / travel;
+    const w = Math.min(5, Math.max(0.5, capDrag.w + ((e.clientX - capDrag.x) * framesPerPx) / 60));
+    win.value = w.toFixed(1);
+    pushConfig();
+  });
+  futureCap.addEventListener("pointerup", () => (capDrag = null));
+
+  // Headless test seam (e2e/site-sandbox.mjs): drive/observe without the DOM.
+  const seam = {
+    paused: () => functor_lang_scrub_paused(),
+    frame: () => functor_lang_scene_frame(),
+    range: () => functor_lang_scene_range(),
+    seek: (f) => functor_lang_seek_scene(f),
+    togglePause: () => functor_lang_scrub_toggle_pause(),
+    step: () => functor_lang_scrub_step(),
+  };
+  window.__scrub = seam;
+
+  let raf = 0;
+  const update = () => {
+    if (pendingSeek !== null) {
+      functor_lang_seek_scene(pendingSeek);
+      pendingSeek = null;
+    }
+    const range = functor_lang_scene_range(); // [] or [lo, hi]
+    if (range.length === 2) {
+      el.style.display = "flex";
+      const lo = range[0];
+      const hi = range[1];
+      slider.min = lo;
+      const frame = functor_lang_scene_frame();
+      if (!scrubbing) slider.value = frame; // don't tug the handle mid-drag
+      // The rail's domain includes the preview window: the handle can be
+      // dragged INTO the cyan segment — a seek beyond the recorded end steps
+      // the game forward, input-free (the runtime animates the catch-up).
+      const span = hi - lo;
+      const futureFrames = extrapolating ? Math.round(+win.value * 60) : 0;
+      slider.max = hi + futureFrames;
+      // `227 +120 / 227` — the predicted-frames count sits with the frame.
+      label.innerHTML =
+        `${frame | 0}` +
+        (futureFrames > 0 ? ` <span class="fut">+${futureFrames}</span>` : "") +
+        ` / ${hi | 0}`;
+      pause.textContent = functor_lang_scrub_paused() ? "▶" : "⏸";
+      if (futureFrames > 0 && span > 0) {
+        // The cyan segment [handle, handle + window] plus its draggable end
+        // cap, anchored to the thumb (including mid-drag) and starting at its
+        // right edge, so the cyan never paints over the traversed track.
+        const inset = 7;
+        const travel = slider.offsetWidth - 2 * inset;
+        const domain = hi + futureFrames - lo;
+        const thumb = +slider.value;
+        const thumbPx = inset + ((thumb - lo) / domain) * travel;
+        const leftPx = thumbPx + inset;
+        const endPx = Math.min(thumbPx + (futureFrames / domain) * travel, inset + travel);
+        const widthPx = Math.max(endPx - leftPx, 0);
+        future.style.left = `${leftPx}px`;
+        future.style.width = `${widthPx}px`;
+        future.style.display = "block";
+        futureCap.style.left = `${endPx - 4}px`;
+        futureCap.style.display = "block";
+      } else {
+        future.style.display = "none";
+        futureCap.style.display = "none";
+      }
+    } else {
+      el.style.display = "none"; // nothing recorded yet
+    }
+    raf = requestAnimationFrame(update);
+  };
+  raf = requestAnimationFrame(update);
+
+  return {
+    destroy() {
+      cancelAnimationFrame(raf);
+      window.removeEventListener("pointerup", onPointerUp);
+      el.remove();
+      if (window.__scrub === seam) delete window.__scrub;
+    },
+  };
+}

--- a/site/README.md
+++ b/site/README.md
@@ -1,23 +1,33 @@
-# site/ — functor's website + Functor Lang sandbox
+# site/ — functor's website + Functor Lang sandbox + IDE
 
 A fully static site: landing page (whose hero background is `examples/hero.fun`
-interpreted live by the wasm runtime) and an interactive Functor Lang sandbox — a
-CodeMirror editor pushing edits into the running game over the same
+interpreted live by the wasm runtime), a single-file Functor Lang **sandbox**,
+and a multi-file **IDE**. Both editors push edits into the running game over the
 postMessage seam the VSCode live-preview panel uses, hot-reloading with the
 model preserved.
 
 ```sh
 wasm-pack build runtime/functor-runtime-web --target=web   # once (or npm run build:cli)
-npm run site:build     # bundle editor + copy runtime/examples into site/dist
-npm run site:serve     # http://127.0.0.1:8123
-npm run test:site      # headless e2e (e2e/site-sandbox.mjs)
+npm run site:build       # bundle editors + copy runtime/examples into site/dist
+npm run site:serve       # http://127.0.0.1:8123
+npm run test:site        # headless e2e — sandbox (e2e/site-sandbox.mjs)
+npm run test:ide         # headless e2e — the set-project seam (e2e/ide-project.mjs)
+npm run test:ide-page    # headless e2e — the IDE page (e2e/ide-page.mjs)
 ```
 
 - `player.html` — the runtime host page; the sibling of the CLI dev server's
-  `index-functor-lang.html`, but the `.fun` entry comes from `?game=`. Keep its input
-  mapping and set-source seam in sync with that page.
-- `src/sandbox.js` / `src/functor-lang.js` — the editor page and the Functor Lang
-  CodeMirror language + synthwave theme.
+  `index-functor-lang.html`, but the `.fun` entry comes from `?game=` (one file) or
+  `?project=inline` (the IDE pushes the whole file set by postMessage). Keep its
+  input mapping and set-source/set-project seam in sync with that page.
+- `sandbox.html` / `src/sandbox.js` — the single-buffer editor over a served
+  example (pushes `functor-lang-set-source`).
+- `ide.html` / `src/ide.js` — the multi-file IDE: a file sidebar, per-file
+  editing, a live preview fed the whole project via `functor-lang-set-project`
+  (`src/project-bridge.js`), localStorage persistence, and project download as a
+  `.zip` (`src/zip.js`, a store-only writer). Asset (`.glb`/audio) management is a
+  follow-up.
+- `src/functor-lang.js` — the Functor Lang CodeMirror language + synthwave theme,
+  shared by both editors.
 - `build.mjs` copies selected repo examples' `game.fun` sources (see the map in `build.mjs`)
-  at build time, so the dropdown always matches what ships in the repo.
+  at build time, so the sandbox dropdown always matches what ships in the repo.
 - Deploy: publish `site/dist` to any static host.

--- a/site/build.mjs
+++ b/site/build.mjs
@@ -20,6 +20,9 @@ const PAGES = ["index.html", "sandbox.html", "ide.html", "player.html", "docs.ht
 
 const PKG = `${root}runtime/functor-runtime-web/pkg`;
 const PKG_FILES = ["functor_runtime_web.js", "functor_runtime_web_bg.wasm"];
+// The shared time-travel scrubber, imported by player.html (served next to it,
+// like pkg/). Single source in the runtime crate — copied, never duplicated.
+const SCRUBBER = `${root}runtime/functor-runtime-web/scrubber.js`;
 
 // The editor's in-browser language intelligence (diagnostics/hover), a separate
 // small wasm bundle built by `npm run build:lang-wasm`. Optional: the site must
@@ -58,6 +61,7 @@ for (const page of PAGES) {
 for (const file of PKG_FILES) {
   await cp(`${PKG}/${file}`, `${dist}/pkg/${file}`);
 }
+await cp(SCRUBBER, `${dist}/scrubber.js`);
 for (const [name, path] of Object.entries(EXAMPLES)) {
   await cp(path, `${dist}/examples/${name}.fun`);
 }

--- a/site/build.mjs
+++ b/site/build.mjs
@@ -16,7 +16,7 @@ const site = fileURLToPath(new URL(".", import.meta.url));
 const root = fileURLToPath(new URL("..", import.meta.url));
 const dist = `${site}dist`;
 
-const PAGES = ["index.html", "sandbox.html", "player.html", "docs.html", "styles.css"];
+const PAGES = ["index.html", "sandbox.html", "ide.html", "player.html", "docs.html", "styles.css"];
 
 const PKG = `${root}runtime/functor-runtime-web/pkg`;
 const PKG_FILES = ["functor_runtime_web.js", "functor_runtime_web_bg.wasm"];
@@ -80,7 +80,7 @@ if (langPkgPresent) {
 }
 
 await esbuild.build({
-  entryPoints: [`${site}src/sandbox.js`, `${site}src/docs.js`, `${site}src/hero.js`],
+  entryPoints: [`${site}src/sandbox.js`, `${site}src/ide.js`, `${site}src/docs.js`, `${site}src/hero.js`],
   bundle: true,
   minify: true,
   format: "esm",

--- a/site/ide.html
+++ b/site/ide.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>functor IDE — build a Functor Lang game in the browser</title>
+    <meta
+      name="description"
+      content="A browser IDE for Functor Lang: multi-file editing, a live-reloading preview, and download your project as a zip."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Orbitron:wght@600;800&family=JetBrains+Mono:ital,wght@0,400;0,600;1,400&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body class="ide-page">
+    <header class="site-header">
+      <a class="wordmark" href="./">FUNCTOR<span class="wordmark-accent">//IDE</span></a>
+      <div class="sandbox-controls">
+        <button id="download" type="button" title="Download the project as a .zip">
+          ↓ project.zip
+        </button>
+        <button id="restart" type="button" title="Reload the preview with a fresh model">
+          ↻ restart
+        </button>
+        <span id="status" class="status-pill" data-state="busy">◌ loading…</span>
+      </div>
+      <nav class="site-nav">
+        <a href="sandbox.html">Sandbox</a>
+        <a href="ide.html" aria-current="page">IDE</a>
+        <a href="docs.html">Docs</a>
+        <a href="https://github.com/tommy-xr/functor">GitHub ↗</a>
+      </nav>
+    </header>
+
+    <main class="ide-split">
+      <aside class="file-pane">
+        <div class="file-pane-head">
+          <span class="file-pane-title">Files</span>
+          <button id="new-file" type="button" title="New .fun file">+</button>
+        </div>
+        <div id="file-list" class="file-list"></div>
+        <p class="file-pane-note">
+          Every <code>.fun</code> is a module (<code>file = module</code>).
+          <code>game.fun</code> is the entry.
+        </p>
+      </aside>
+      <section class="editor-pane">
+        <div class="editor-tab"><span id="active-file">game.fun</span></div>
+        <div id="editor"></div>
+        <pre id="status-log" hidden></pre>
+      </section>
+      <section class="preview-pane">
+        <iframe id="player" title="live game preview" allow="pointer-lock"></iframe>
+      </section>
+    </main>
+
+    <script type="module" src="assets/ide.js"></script>
+  </body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -91,24 +91,6 @@
         title="Open this program live in the sandbox"
         target="_blank"
         >▶ try it</a></pre>
-      <ul class="lang-bullets">
-        <li>
-          There is no <code>if</code>/<code>else</code> — the conditional is a bool-literal
-          <code>match</code> on <code>true</code>/<code>false</code>.
-        </li>
-        <li>
-          Pipelines thread last: <code>x |> f(a)</code> is <code>f(a, x)</code>, so every prelude
-          function takes its subject last.
-        </li>
-        <li>
-          File = module: every sibling <code>.fun</code> is a module, and a <code>.funi</code>
-          interface file types the host's values.
-        </li>
-        <li>
-          Gradual Hindley–Milner types: real inference with let-polymorphism, annotations
-          optional and diagnostics on demand.
-        </li>
-      </ul>
     </section>
 
     <section class="differentiators">
@@ -133,8 +115,7 @@
           <h2>Pure MVU + honest effects</h2>
           <p>
             A game is pure Model–View–Update. Effects are values too — randomness, time, network —
-            performed by the shell and folded back through <code>update</code>, so a fake runner
-            makes every run deterministic.
+            performed by the shell and folded back through <code>update</code>.
           </p>
         </div>
         <div class="feature">

--- a/site/player.html
+++ b/site/player.html
@@ -18,6 +18,7 @@
         --scrub-text: #e9e6f2;
         --scrub-dim: #9b94b3;
         --scrub-accent: #41d8e6;
+        --scrub-future: #e858b8; /* pink #e858b8 — the extrapolated-future accent */
         --scrub-font: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
       }
       html, body { margin: 0; height: 100%; overflow: hidden; background: #0d0221; }
@@ -33,49 +34,21 @@
         font: 12px/1 var(--scrub-font); padding: 6px 10px; cursor: pointer;
         color: var(--scrub-text); background: var(--scrub-bg);
         border: 1px solid var(--scrub-line); border-radius: 6px;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35); /* depth — matches the scrubber buttons */
+        transition: box-shadow 0.12s ease, border-color 0.12s ease, transform 0.12s ease;
       }
-      #mouselook:hover { border-color: var(--scrub-accent); }
-      /* The time-travel scrubber — a slim bottom strip of native DOM OUTSIDE
-         the canvas, so its controls never fight the game's pointer handling.
-         Hidden until the runtime has recorded some history. */
-      #scrubber {
-        position: fixed; left: 0; right: 0; bottom: 0; z-index: 10;
-        display: none; align-items: center; gap: 10px;
-        font: 12px/1 var(--scrub-font); color: var(--scrub-text);
-        padding: 8px 12px; background: var(--scrub-bg);
-        border-top: 1px solid var(--scrub-line);
+      #mouselook:hover {
+        border-color: var(--scrub-accent);
+        box-shadow: 0 3px 10px rgba(0, 0, 0, 0.5); transform: translateY(-1px);
       }
-      #scrubber button {
-        font: 12px/1 var(--scrub-font); color: var(--scrub-text); cursor: pointer;
-        background: rgba(65, 216, 230, 0.10);
-        border: 1px solid var(--scrub-line); border-radius: 5px; padding: 5px 9px;
-      }
-      #scrubber button:hover { border-color: var(--scrub-accent); }
-      #scrub-slider { flex: 1; min-width: 80px; accent-color: var(--scrub-accent); }
-      #scrub-label { color: var(--scrub-dim); min-width: 118px; text-align: right; }
-      /* Narrow hosts (the ~350px hero card on a phone). This page is an
-         iframe, so the parent's media queries can't reach in — this query runs
-         against the iframe's own viewport. Drop the "time-travel · " prefix,
-         tighten gaps/padding, and let the slider flex smaller so the whole
-         strip (buttons + slider + counter) fits without clipping. */
-      @media (max-width: 480px) {
-        #scrubber { gap: 6px; padding: 6px 8px; }
-        #scrubber button { padding: 5px 7px; }
-        #scrub-prefix { display: none; }
-        #scrub-label { min-width: 0; }
-        #scrub-slider { min-width: 40px; }
-      }
+      /* The time-travel scrubber is the shared component (scrubber.js); it
+         injects its own styles, reading the --scrub-* vars above so it matches
+         this page's calm theme. */
     </style>
   </head>
   <body>
     <canvas id="canvas"></canvas>
     <button id="mouselook" title="Control the camera with the mouse; Esc to release">🖱 mouse look</button>
-    <div id="scrubber">
-      <button id="scrub-pause">Pause</button>
-      <button id="scrub-step">Step ▸</button>
-      <input id="scrub-slider" type="range" min="0" max="0" value="0" step="1" />
-      <span id="scrub-label"><span id="scrub-prefix">time-travel · </span><span id="scrub-count"></span></span>
-    </div>
     <script type="module">
 
       import init, {
@@ -85,13 +58,11 @@
         functor_lang_is_running,
         functor_lang_set_source,
         functor_lang_set_project,
-        functor_lang_scene_frame,
-        functor_lang_scene_range,
-        functor_lang_seek_scene,
-        functor_lang_scrub_toggle_pause,
-        functor_lang_scrub_step,
-        functor_lang_scrub_paused,
       } from "./pkg/functor_runtime_web.js";
+      // The time-travel scrubber is the shared component, served next to
+      // pkg/ (see runtime/functor-runtime-web/scrubber.js). It wires the
+      // functor_lang_scrub_* exports itself.
+      import { mountScrubber } from "./scrubber.js";
 
       // The Functor Lang entry, from `?game=<path>` (a path relative to this page).
       // Must be set before init(): the runtime reads it at start to choose the
@@ -180,62 +151,6 @@
           e.preventDefault();
           functor_lang_mouse_wheel(Math.sign(e.deltaY));
         });
-      };
-
-      // The time-travel scrubber. Native DOM controls drive the runtime through
-      // the `functor_lang_scrub_*` exports and poll the published view state each
-      // frame to track the handle. Coalesce drags to one seek per frame, and
-      // don't fight the user's drag by writing the slider value while they hold
-      // it. (Ghost controls are deliberately out of scope here.)
-      const setupScrubber = () => {
-        const el = document.getElementById("scrubber");
-        const count = document.getElementById("scrub-count");
-        const pause = document.getElementById("scrub-pause");
-        const slider = document.getElementById("scrub-slider");
-        const step = document.getElementById("scrub-step");
-
-        let scrubbing = false;
-        let pendingSeek = null;
-        slider.addEventListener("pointerdown", () => (scrubbing = true));
-        window.addEventListener("pointerup", () => (scrubbing = false));
-        slider.addEventListener("input", () => (pendingSeek = Number(slider.value)));
-        pause.addEventListener("click", () => functor_lang_scrub_toggle_pause());
-        step.addEventListener("click", () => functor_lang_scrub_step());
-
-        // Headless test seam: drive/observe the scrubber without the DOM
-        // controls (e2e/site-sandbox.mjs). Thin wrappers over the same exports.
-        window.__scrub = {
-          paused: () => functor_lang_scrub_paused(),
-          frame: () => functor_lang_scene_frame(),
-          range: () => functor_lang_scene_range(),
-          seek: (f) => functor_lang_seek_scene(f),
-          togglePause: () => functor_lang_scrub_toggle_pause(),
-          step: () => functor_lang_scrub_step(),
-        };
-
-        const update = () => {
-          if (pendingSeek !== null) {
-            functor_lang_seek_scene(pendingSeek);
-            pendingSeek = null;
-          }
-          const range = functor_lang_scene_range(); // [] or [lo, hi]
-          if (range.length === 2) {
-            el.style.display = "flex";
-            const lo = range[0], hi = range[1];
-            slider.min = lo;
-            slider.max = hi;
-            const frame = functor_lang_scene_frame();
-            if (!scrubbing) slider.value = frame; // don't tug the handle mid-drag
-            // The "time-travel · " prefix is static markup (#scrub-prefix),
-            // hidden on narrow viewports; only the counter updates here.
-            count.textContent = `${frame | 0} / ${hi | 0}`;
-            pause.textContent = functor_lang_scrub_paused() ? "Resume" : "Pause";
-          } else {
-            el.style.display = "none"; // nothing recorded yet
-          }
-          requestAnimationFrame(update);
-        };
-        requestAnimationFrame(update);
       };
 
       // The live-edit seam: the hosting page (the sandbox / the IDE) posts
@@ -353,7 +268,7 @@
           document.getElementById("mouselook").style.display = "none";
         } else {
           setupInput();
-          if (!scrubberOff) setupScrubber();
+          if (!scrubberOff) mountScrubber();
         }
         announceWhenReady();
       });

--- a/site/sandbox.html
+++ b/site/sandbox.html
@@ -29,6 +29,7 @@
       </div>
       <nav class="site-nav">
         <a href="sandbox.html" aria-current="page">Sandbox</a>
+        <a href="ide.html">IDE</a>
         <a href="docs.html">Docs</a>
         <a href="https://github.com/tommy-xr/functor">GitHub ↗</a>
       </nav>

--- a/site/src/ide.js
+++ b/site/src/ide.js
@@ -1,0 +1,319 @@
+// The web IDE: a file sidebar + multi-file Functor Lang editor + live preview.
+// The IDE holds the WHOLE project in memory (nothing is served) and pushes it
+// over the `functor-lang-set-project` seam to a `player.html?project=inline`
+// iframe (see project-bridge.js): the preview boots from memory and hot-swaps
+// on every edit, model preserved. Work is persisted to localStorage; the
+// project downloads as a .zip that drops into `functor -d <dir> build wasm`.
+
+import { basicSetup } from "codemirror";
+import { EditorView, keymap } from "@codemirror/view";
+import { indentWithTab } from "@codemirror/commands";
+import { functorLangLanguage, synthwaveEditorTheme } from "./functor-lang.js";
+import { ProjectBridge } from "./project-bridge.js";
+import { zipFiles } from "./zip.js";
+
+const STORAGE_KEY = "functor-ide-project-v1";
+const ENTRY = "game.fun"; // the program root; every other .fun is a sibling module
+// A valid project file: a bare module name + `.fun` (the project is a flat
+// module space — no path separators). Enforced on BOTH created and loaded
+// files, so a hand-edited/corrupt localStorage can't smuggle in a `../x.fun`
+// (which would be a zip-slip entry on download and a bad module at load).
+const MODULE_FILE = /^[A-Za-z][A-Za-z0-9_]*\.fun$/;
+
+// A two-file starter: game.fun draws using constants from palette.fun (a
+// sibling module — file = module, so palette.fun is module `Palette`), to show
+// the multi-file loop the sandbox can't.
+const STARTER = {
+  active: ENTRY,
+  files: [
+    {
+      path: ENTRY,
+      source: `// A multi-file starter. palette.fun is a sibling module (file = module,
+// so it is \`Palette\`). Edit either file — the preview hot-reloads with the
+// model preserved. Add files with + in the sidebar; download the project as
+// a .zip to run it with \`functor -d <dir> build wasm\`.
+let init = { t: 0.0 }
+
+let tick = (model, dt: Float, tts: Float) => { model with t: model.t + dt }
+
+let draw = (model, tts: Float) =>
+  Frame.create(
+    Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.5, 0.0),
+    Scene.group([
+      Scene.sphere() |> Scene.emissive(0.15, 1.0, Palette.glow) |> Scene.scale(1.4),
+      Scene.plane() |> Scene.scale(12.0) |> Scene.lit(Palette.sky, 0.12, 0.35),
+    ]))
+`,
+    },
+    {
+      path: "palette.fun",
+      source: `// Constants for the scene, edited on their own. Try changing these — the
+// sphere and ground recolor live.
+let glow = 0.85
+let sky = 0.18
+`,
+    },
+  ],
+};
+
+const els = {
+  fileList: document.getElementById("file-list"),
+  newFile: document.getElementById("new-file"),
+  download: document.getElementById("download"),
+  restart: document.getElementById("restart"),
+  status: document.getElementById("status"),
+  statusLog: document.getElementById("status-log"),
+  activeName: document.getElementById("active-file"),
+  editorHost: document.getElementById("editor"),
+  player: document.getElementById("player"),
+};
+
+// ---------------------------------------------------------------- project
+
+let project = loadProject();
+
+function loadProject() {
+  try {
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY));
+    const seen = new Set();
+    const valid =
+      stored &&
+      Array.isArray(stored.files) &&
+      stored.files.length > 0 &&
+      stored.files.every((f) => {
+        if (!f || typeof f.path !== "string" || typeof f.source !== "string") return false;
+        if (!MODULE_FILE.test(f.path)) return false; // same rule as created files
+        const key = f.path.toLowerCase();
+        if (seen.has(key)) return false; // no case-insensitive duplicates (one entry)
+        seen.add(key);
+        return true;
+      }) &&
+      stored.files.some((f) => f.path === ENTRY);
+    if (valid) {
+      const active = stored.files.some((f) => f.path === stored.active) ? stored.active : ENTRY;
+      return { files: stored.files, active };
+    }
+  } catch {
+    // fall through to the starter
+  }
+  return structuredClone(STARTER);
+}
+
+const saveProject = () => {
+  // Best-effort: a disabled/full localStorage (private mode, quota) must not
+  // break editing or the live preview — persistence is a convenience.
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(project));
+  } catch {
+    /* not persisted this session */
+  }
+};
+const activeFile = () => project.files.find((f) => f.path === project.active);
+
+// ---------------------------------------------------------------- status
+
+const setStatus = (state, text, detail = "") => {
+  els.status.dataset.state = state;
+  els.status.textContent = text;
+  els.status.title = "";
+  els.statusLog.textContent = detail;
+  els.statusLog.hidden = detail === "";
+};
+
+// ---------------------------------------------------------------- editor
+
+let programmaticEdit = false;
+
+const view = new EditorView({
+  parent: els.editorHost,
+  extensions: [
+    basicSetup,
+    keymap.of([indentWithTab]),
+    functorLangLanguage,
+    synthwaveEditorTheme,
+    EditorView.updateListener.of((update) => {
+      if (update.docChanged && !programmaticEdit) {
+        // Mirror the buffer into the active file and push the whole project.
+        const file = activeFile();
+        if (file) file.source = view.state.doc.toString();
+        schedulePush();
+      }
+    }),
+  ],
+});
+
+const setDoc = (source) => {
+  programmaticEdit = true;
+  view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: source } });
+  programmaticEdit = false;
+};
+
+// ---------------------------------------------------------------- preview
+
+const bridge = new ProjectBridge(els.player, {
+  onReloading: () => setStatus("busy", "◌ reloading…"),
+  onLive: () => setStatus("live", "● live"),
+  onResult: (ok, message) => {
+    if (ok) {
+      setStatus("live", "● live");
+      els.status.title = message; // the runtime's "model preserved" note, on hover
+    } else {
+      setStatus("error", "✖ error", message);
+    }
+  },
+});
+
+// Persist + push the current file set (the bridge debounces the actual send).
+const schedulePush = () => {
+  saveProject();
+  bridge.setProject(project.files);
+};
+
+// ---------------------------------------------------------------- sidebar
+
+const renderFileList = () => {
+  els.fileList.textContent = "";
+  for (const file of project.files) {
+    const row = document.createElement("div");
+    row.className = "file-row" + (file.path === project.active ? " active" : "");
+
+    const name = document.createElement("button");
+    name.className = "file-name";
+    name.textContent = file.path;
+    name.title = file.path === ENTRY ? "game.fun — the program entry" : file.path;
+    name.addEventListener("click", () => openFile(file.path));
+    row.appendChild(name);
+
+    // Every file but the entry can be deleted (the entry is the program root).
+    if (file.path !== ENTRY) {
+      const del = document.createElement("button");
+      del.className = "file-delete";
+      del.textContent = "×";
+      del.title = `Delete ${file.path}`;
+      del.addEventListener("click", (e) => {
+        e.stopPropagation();
+        deleteFile(file.path);
+      });
+      row.appendChild(del);
+    }
+    els.fileList.appendChild(row);
+  }
+  els.activeName.textContent = project.active;
+};
+
+const openFile = (path) => {
+  if (path === project.active) return;
+  // Save the live buffer into the outgoing file before switching.
+  const current = activeFile();
+  if (current) current.source = view.state.doc.toString();
+  project.active = path;
+  const next = activeFile();
+  setDoc(next ? next.source : "");
+  renderFileList();
+  saveProject();
+};
+
+// A valid sibling filename: `<name>.fun`, a bare module stem (no path
+// separators — the project is a flat module space), and not already taken.
+const validName = (raw) => {
+  const path = raw.trim();
+  if (!MODULE_FILE.test(path)) {
+    return { error: "name must be a bare module like `enemy.fun` (letters, digits, _)" };
+  }
+  if (project.files.some((f) => f.path.toLowerCase() === path.toLowerCase())) {
+    return { error: `${path} already exists` };
+  }
+  return { path };
+};
+
+const newFile = () => {
+  const raw = window.prompt("New file name (e.g. enemy.fun):", "");
+  if (raw === null) return;
+  const { path, error } = validName(raw);
+  if (error) {
+    setStatus("error", "✖ error", error);
+    return;
+  }
+  project.files.push({ path, source: `// ${path}\n` });
+  openFile(path);
+  schedulePush(); // a new empty module can't break the build; keep the preview in sync
+};
+
+const deleteFile = (path) => {
+  if (path === ENTRY) return;
+  if (!window.confirm(`Delete ${path}? This can't be undone.`)) return;
+  project.files = project.files.filter((f) => f.path !== path);
+  if (project.active === path) {
+    project.active = ENTRY;
+    setDoc(activeFile().source);
+  }
+  renderFileList();
+  schedulePush();
+};
+
+// ---------------------------------------------------------------- toolbar
+
+const download = () => {
+  // Include the functor.json the CLI needs to recognise the project, so the
+  // zip drops straight into `functor -d <dir> build wasm` (per the README).
+  const manifest = {
+    path: "functor.json",
+    source: JSON.stringify({ language: "functor-lang", entry: ENTRY }, null, 2) + "\n",
+  };
+  const blob = zipFiles([manifest, ...project.files]);
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "functor-project.zip";
+  a.click();
+  // Revoke after the click's synchronous download kickoff has settled (a
+  // same-tick revoke is the known-fragile pattern on some browsers).
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+};
+
+// Reload the preview from scratch — a fresh model (init runs again) with the
+// current files. The iframe re-announces project-waiting; the bridge reboots.
+const restart = () => {
+  bridge.reset();
+  setStatus("busy", "◌ loading…");
+  els.player.src = "player.html?project=inline";
+  bridge.setProject(project.files);
+};
+
+// ---------------------------------------------------------------- boot
+
+els.newFile.addEventListener("click", newFile);
+els.download.addEventListener("click", download);
+els.restart.addEventListener("click", restart);
+
+renderFileList();
+setDoc(activeFile().source);
+setStatus("busy", "◌ loading…");
+// Store the file set BEFORE the iframe loads, so the bridge can flush it the
+// moment the player announces it's ready (no lost first push).
+bridge.setProject(project.files);
+els.player.src = "player.html?project=inline";
+
+// Test seam for the headless e2e (e2e/ide-page.mjs): drive files without
+// synthesizing DOM events, and read status.
+window.__ide = {
+  setActiveSource(source) {
+    setDoc(source);
+    const file = activeFile();
+    if (file) file.source = source;
+    schedulePush();
+  },
+  openFile,
+  newFile: (path, source = `// ${path}\n`) => {
+    project.files.push({ path, source });
+    openFile(path);
+    schedulePush();
+  },
+  files: () => project.files.map((f) => ({ ...f })),
+  status: () => ({
+    state: els.status.dataset.state,
+    text: els.status.textContent,
+    message: els.status.title,
+    detail: els.statusLog.textContent,
+  }),
+};

--- a/site/src/project-bridge.js
+++ b/site/src/project-bridge.js
@@ -1,0 +1,91 @@
+// The multi-file editor ↔ player bridge — the whole-project sibling of
+// player-bridge.js (which pushes a single source buffer). The IDE owns every
+// .fun in memory, so it pushes the full file set over `functor-lang-set-project`
+// to a `player.html?project=inline` iframe: the player boots from memory (no
+// fetch) on the first push, then hot-swaps (model preserved) on each edit.
+//
+// The boot handshake: the player announces `functor-lang-project-waiting` when
+// its listener is armed; only then may we push. It replies
+// `functor-lang-preview-ready` once the producer is live, and
+// `functor-lang-set-source-result` (with our echoed id) for every hot-swap.
+
+const PUSH_DEBOUNCE_MS = 300;
+
+export class ProjectBridge {
+  // iframe: the player element. Callbacks map protocol events to UI:
+  //   onReloading()          — a push was sent (busy)
+  //   onLive()               — the player booted / is ready
+  //   onResult(ok, message)  — a hot-swap reply came back
+  constructor(iframe, { onReloading, onLive, onResult, debounceMs = PUSH_DEBOUNCE_MS }) {
+    this.iframe = iframe;
+    this.onReloading = onReloading;
+    this.onLive = onLive;
+    this.onResult = onResult;
+    this.debounceMs = debounceMs;
+
+    this.waiting = false; // player announced project-waiting (safe to push)
+    this.files = null; // latest full file set
+    this.pushTimer = null;
+    // Correlates results with pushes: each push gets a fresh id, the runtime
+    // echoes it, and a result for anything but the LATEST push is stale.
+    this.pushId = 0;
+
+    window.addEventListener("message", (event) => this.#onMessage(event));
+  }
+
+  // Debounced whole-project push: swap in the file set once edits settle.
+  setProject(files) {
+    this.files = files;
+    clearTimeout(this.pushTimer);
+    this.pushTimer = setTimeout(() => this.#send(), this.debounceMs);
+  }
+
+  // Reset for a fresh iframe (a new project=inline load): drop the handshake
+  // state until the next `functor-lang-project-waiting`.
+  reset() {
+    clearTimeout(this.pushTimer);
+    this.waiting = false;
+  }
+
+  #send() {
+    clearTimeout(this.pushTimer); // an early flush cancels the pending timer
+    if (!this.iframe.contentWindow || !this.files) return;
+    // The player drops anything sent before it announces `project-waiting`;
+    // hold the push and flush it on that signal (below).
+    if (!this.waiting) return;
+    this.onReloading();
+    this.pushId += 1;
+    this.iframe.contentWindow.postMessage(
+      { type: "functor-lang-set-project", files: this.files, id: this.pushId },
+      "*"
+    );
+  }
+
+  #onMessage(event) {
+    if (event.source !== this.iframe.contentWindow) return;
+    const data = event.data;
+    if (!data) return;
+    if (data.type === "functor-lang-project-waiting") {
+      // The player is armed: flush the initial (or any held) project to boot it.
+      this.waiting = true;
+      if (this.files) this.#send();
+    } else if (data.type === "functor-lang-preview-ready") {
+      // Ignore a ready/result from the OUTGOING document — an iframe keeps its
+      // WindowProxy (so `event.source` still matches) across a restart's src
+      // swap, and a late reply from the old player would flash over the new
+      // one's "loading…". `reset()` drops `waiting`; only the fresh
+      // project-waiting handshake re-arms us. (Mirrors PlayerBridge's
+      // previewReady guard.)
+      if (!this.waiting) return;
+      // The boot push carries an id but the boot path sends no result — the
+      // ready signal is the boot's "ok". Later edits get result messages.
+      this.onLive();
+    } else if (data.type === "functor-lang-set-source-result") {
+      if (!this.waiting) return;
+      // A result whose id isn't the latest push's is stale — a newer push is
+      // already in flight; its reply supersedes this one.
+      if (data.id !== undefined && data.id !== this.pushId) return;
+      this.onResult(data.ok, data.message);
+    }
+  }
+}

--- a/site/src/zip.js
+++ b/site/src/zip.js
@@ -1,0 +1,81 @@
+// Minimal STORE-only (uncompressed) ZIP writer — enough to download a Functor
+// project (a handful of small .fun text files) as a .zip, with no dependency.
+// Deflate isn't worth the code for a few KB of source; a store-only archive
+// unzips everywhere and drops straight into `functor -d <dir> build wasm`.
+
+const CRC_TABLE = (() => {
+  const t = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    t[n] = c >>> 0;
+  }
+  return t;
+})();
+
+const crc32 = (bytes) => {
+  let c = 0xffffffff;
+  for (let i = 0; i < bytes.length; i++) c = CRC_TABLE[(c ^ bytes[i]) & 0xff] ^ (c >>> 8);
+  return (c ^ 0xffffffff) >>> 0;
+};
+
+const u16 = (v) => new Uint8Array([v & 0xff, (v >>> 8) & 0xff]);
+const u32 = (v) =>
+  new Uint8Array([v & 0xff, (v >>> 8) & 0xff, (v >>> 16) & 0xff, (v >>> 24) & 0xff]);
+
+const concat = (arrs) => {
+  let len = 0;
+  for (const a of arrs) len += a.length;
+  const out = new Uint8Array(len);
+  let o = 0;
+  for (const a of arrs) {
+    out.set(a, o);
+    o += a.length;
+  }
+  return out;
+};
+
+// files: [{ path, source }] (source a string). Returns a Blob (application/zip).
+// Timestamps are pinned (1980-01-01) so identical inputs yield identical bytes.
+export function zipFiles(files) {
+  const enc = new TextEncoder();
+  const parts = [];
+  const central = [];
+  let offset = 0;
+
+  for (const f of files) {
+    const name = enc.encode(f.path);
+    const data = enc.encode(f.source);
+    const crc = crc32(data);
+    const local = concat([
+      u32(0x04034b50), u16(20), u16(0), u16(0), // sig, version, flags, method=store
+      u16(0), u16(0x21), // mod time 0, mod date 1980-01-01
+      u32(crc), u32(data.length), u32(data.length),
+      u16(name.length), u16(0),
+      name,
+    ]);
+    const localOffset = offset;
+    parts.push(local, data);
+    offset += local.length + data.length;
+    central.push(
+      concat([
+        u32(0x02014b50), u16(20), u16(20), u16(0), u16(0), // sig, made-by, need, flags, method
+        u16(0), u16(0x21),
+        u32(crc), u32(data.length), u32(data.length),
+        u16(name.length), u16(0), u16(0), u16(0), u16(0),
+        u32(0), u32(localOffset),
+        name,
+      ])
+    );
+  }
+
+  const centralStart = offset;
+  let centralSize = 0;
+  for (const c of central) centralSize += c.length;
+  const end = concat([
+    u32(0x06054b50), u16(0), u16(0),
+    u16(files.length), u16(files.length),
+    u32(centralSize), u32(centralStart), u16(0),
+  ]);
+  return new Blob([...parts, ...central, end], { type: "application/zip" });
+}

--- a/site/styles.css
+++ b/site/styles.css
@@ -340,35 +340,6 @@ a:hover {
   font-size: 0.85rem;
 }
 
-/* Language bullets under the sample. */
-.lang-bullets {
-  list-style: none;
-  padding: 0;
-  margin: 28px 0 0;
-  display: grid;
-  gap: 14px;
-}
-
-.lang-bullets li {
-  position: relative;
-  padding-left: 22px;
-  color: var(--text-dim);
-  font-size: 0.9rem;
-}
-
-.lang-bullets li::before {
-  content: "›";
-  position: absolute;
-  left: 0;
-  color: var(--cyan);
-  font-weight: 600;
-}
-
-.lang-bullets code {
-  color: var(--green);
-  font-size: 0.9em;
-}
-
 /* The one-line LLM-native banner under the differentiators. */
 .llm-banner {
   max-width: 1180px;

--- a/site/styles.css
+++ b/site/styles.css
@@ -444,7 +444,8 @@ a:hover {
 
 /* ---------------------------------------------------------------- sandbox */
 
-.sandbox-page {
+.sandbox-page,
+.ide-page {
   height: 100vh;
   display: flex;
   flex-direction: column;
@@ -482,7 +483,9 @@ a:hover {
 }
 
 #example-picker,
-#reset {
+#reset,
+#download,
+#restart {
   font-family: var(--font-mono);
   font-size: 0.85rem;
   color: var(--text);
@@ -492,11 +495,15 @@ a:hover {
   padding: 6px 10px;
 }
 
-#reset {
+#reset,
+#download,
+#restart {
   cursor: pointer;
 }
 
-#reset:hover {
+#reset:hover,
+#download:hover,
+#restart:hover {
   border-color: var(--cyan);
   color: var(--cyan);
 }
@@ -598,6 +605,149 @@ a:hover {
   .editor-pane {
     border-right: none;
     border-bottom: 1px solid var(--line);
+  }
+}
+
+/* --------------------------------------------------------------------- ide */
+
+/* Three panes: file sidebar | editor | preview. Reuses .editor-pane,
+   #editor, .preview-pane, #player, #status-log, .status-pill from the
+   sandbox rules above. */
+.ide-split {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 200px minmax(300px, 40%) 1fr;
+  min-height: 0;
+}
+
+.file-pane {
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--line);
+  background: var(--bg-panel);
+  min-height: 0;
+}
+
+.file-pane-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--line);
+}
+
+.file-pane-title {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-dim);
+}
+
+#new-file {
+  font-family: var(--font-mono);
+  font-size: 1rem;
+  line-height: 1;
+  color: var(--text);
+  background: var(--bg-raised);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  width: 24px;
+  height: 24px;
+  cursor: pointer;
+}
+
+#new-file:hover {
+  border-color: var(--cyan);
+  color: var(--cyan);
+}
+
+.file-list {
+  flex: 1;
+  overflow: auto;
+  min-height: 0;
+}
+
+.file-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 8px 0 12px;
+}
+
+.file-row.active {
+  background: var(--bg-raised);
+  box-shadow: inset 2px 0 0 var(--pink);
+}
+
+.file-name {
+  flex: 1;
+  text-align: left;
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  color: var(--text);
+  background: none;
+  border: 0;
+  padding: 8px 0;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-row.active .file-name {
+  color: var(--cyan);
+}
+
+.file-delete {
+  font-family: var(--font-mono);
+  font-size: 0.95rem;
+  line-height: 1;
+  color: var(--text-dim);
+  background: none;
+  border: 0;
+  padding: 2px 6px;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.file-delete:hover {
+  color: var(--red);
+}
+
+.file-pane-note {
+  margin: 0;
+  padding: 10px 12px;
+  border-top: 1px solid var(--line);
+  font-size: 0.68rem;
+  line-height: 1.5;
+  color: var(--text-dim);
+}
+
+.file-pane-note code {
+  font-family: var(--font-mono);
+  color: var(--text);
+}
+
+.editor-tab {
+  padding: 7px 14px;
+  border-bottom: 1px solid var(--line);
+  background: var(--bg-panel);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--cyan);
+}
+
+@media (max-width: 900px) {
+  .ide-split {
+    grid-template-columns: 150px 1fr;
+    grid-template-rows: 1fr 300px;
+  }
+  .file-pane {
+    grid-row: span 2;
+  }
+  .preview-pane {
+    border-top: 1px solid var(--line);
   }
 }
 


### PR DESCRIPTION
Stacked on the scrubber PR (all site work).

Small landing-page copy trim on `site/index.html`:
- Removes the four **"The language"** bullets under the code sample (no `if`/`else`, thread-last pipelines, `file = module`, gradual Hindley–Milner). The live "▶ try it" sample already demonstrates the language; the bullets read as spec trivia on a landing page.
- Drops the trailing "so a fake runner makes every run deterministic" clause from the **Pure MVU + honest effects** card — an implementation detail, not a pitch.
- Removes the now-orphaned `.lang-bullets` CSS.

Content-only; the "The language" section keeps its heading, intro, and live code sample.

🤖 Generated with [Claude Code](https://claude.com/claude-code)