### PR TITLE
feat(web): make the time-travel timeline stable and extensible

### DIFF
--- a/.github/workflows/wasm-smoke.yml
+++ b/.github/workflows/wasm-smoke.yml
@@ -76,3 +76,9 @@ jobs:
 
       - name: Run wasm smoke
         run: npm run test:wasm-smoke
+
+      - name: Run scrubber model tests
+        run: npm run test:scrubber
+
+      - name: Run site sandbox browser tests
+        run: npm run test:site

--- a/cli/src/util/wasm_dev_server.rs
+++ b/cli/src/util/wasm_dev_server.rs
@@ -16,6 +16,8 @@ pub(crate) const JS_FILE_1: &[u8] =
 // (and by the site's player.html). Served at /scrubber.js next to pkg/.
 pub(crate) const SCRUBBER_JS: &[u8] =
     include_bytes!("../../../runtime/functor-runtime-web/scrubber.js");
+pub(crate) const TIMELINE_MODEL_JS: &[u8] =
+    include_bytes!("../../../runtime/functor-runtime-web/timeline-model.js");
 
 /// The standard inline-script defense: JSON escaping is not HTML escaping, so a
 /// `</script>` inside a substituted literal would terminate the page's script
@@ -113,6 +115,13 @@ impl WasmDevServer {
                     .body(SCRUBBER_JS.to_vec())
             })
             .boxed();
+        let route_timeline_model = warp::path!("timeline-model.js")
+            .map(|| {
+                Response::builder()
+                    .header("Content-Type", "application/javascript")
+                    .body(TIMELINE_MODEL_JS.to_vec())
+            })
+            .boxed();
 
         // Route to serve files from the specified working directory
         let route_filesystem = warp::fs::dir(wd);
@@ -121,7 +130,11 @@ impl WasmDevServer {
         // and the index page + `.fun` source are re-generated per run — without
         // it, switching samples (each serving its source at the same
         // `/game.fun` URL) can show a stale game from the browser cache.
-        let static_routes = route_index.or(route_js1).or(route_wasm).or(route_scrubber);
+        let static_routes = route_index
+            .or(route_js1)
+            .or(route_wasm)
+            .or(route_scrubber)
+            .or(route_timeline_model);
         let routes = static_routes
             .or(route_filesystem)
             .with(warp::reply::with::header("cache-control", "no-store"));

--- a/cli/src/util/wasm_export.rs
+++ b/cli/src/util/wasm_export.rs
@@ -23,7 +23,8 @@ use std::io::Error;
 use std::path::{Path, PathBuf};
 
 use super::wasm_dev_server::{
-    project_file_urls, render_functor_lang_index, JS_FILE_1, SCRUBBER_JS, WASM_FILE,
+    project_file_urls, render_functor_lang_index, JS_FILE_1, SCRUBBER_JS, TIMELINE_MODEL_JS,
+    WASM_FILE,
 };
 
 /// Names at the project root the exporter owns in the bundle: its output dir
@@ -32,7 +33,13 @@ use super::wasm_dev_server::{
 /// skipped (and reported via [`WasmExport::shadowed`]) rather than merged —
 /// merging a project `pkg/` with the runtime's would leave stray files
 /// beside the wasm bundle.
-const RESERVED_ROOT: &[&str] = &["dist", "index.html", "pkg", "scrubber.js"];
+const RESERVED_ROOT: &[&str] = &[
+    "dist",
+    "index.html",
+    "pkg",
+    "scrubber.js",
+    "timeline-model.js",
+];
 
 /// Extensions the runtime fetches at runtime: models (plus the external
 /// buffers/images a non-embedded `.gltf` references), audio, textures.
@@ -112,6 +119,7 @@ name {RESERVED_ROOT:?} at the project root): {} — rename or move them",
     // The runtime files go in last so nothing in the project can shadow them.
     std::fs::write(out.join("index.html"), render_functor_lang_index(entry, &files))?;
     std::fs::write(out.join("scrubber.js"), SCRUBBER_JS)?;
+    std::fs::write(out.join("timeline-model.js"), TIMELINE_MODEL_JS)?;
     let pkg = out.join("pkg");
     std::fs::create_dir_all(&pkg)?;
     std::fs::write(pkg.join("functor_runtime_web.js"), JS_FILE_1)?;
@@ -121,7 +129,10 @@ name {RESERVED_ROOT:?} at the project root): {} — rename or move them",
         out_dir: out,
         file_count: stats.files,
         project_bytes: stats.bytes,
-        runtime_bytes: (JS_FILE_1.len() + WASM_FILE.len() + SCRUBBER_JS.len()) as u64,
+        runtime_bytes: (JS_FILE_1.len()
+            + WASM_FILE.len()
+            + SCRUBBER_JS.len()
+            + TIMELINE_MODEL_JS.len()) as u64,
         missing_assets: missing_asset_references(root, entry),
         shadowed,
         skipped_symlinks: stats.skipped_symlinks,
@@ -306,6 +317,12 @@ mod tests {
         assert!(
             fs::read_to_string(out.join("scrubber.js")).unwrap().contains("mountScrubber"),
             "the shared scrubber component ships with the bundle"
+        );
+        assert!(
+            fs::read_to_string(out.join("timeline-model.js"))
+                .unwrap()
+                .contains("deriveTimelineView"),
+            "the scrubber's functional core ships with the bundle"
         );
         assert!(out.join("game.fun").is_file());
         assert!(out.join("pieces.fun").is_file());

--- a/docs/time-travel.md
+++ b/docs/time-travel.md
@@ -7,7 +7,7 @@ scrub, rewind, replay, branch — plus the authoring experiences those unlock. I
 generalizes the physics `Timeline` (`docs/physics.md` Phase 6 / #215) from the
 Rapier world to the entire MVU model.
 
-## What shipped (as of 2026-07-05)
+## What shipped (as of 2026-07-13)
 
 You can pause a running Functor Lang game and **drag a timeline scrubber to any recorded
 frame** — the whole scene (MVU `model` *and* physics world) restores together —
@@ -27,8 +27,8 @@ on both the desktop runner and the web/VSCode preview. Exercised by
   you drag back *and* forth; the future is branched only when play resumes.
 - **Live triggers.** Desktop debug server `POST /rewind {"frame":N}` (#225); an
   egui scrubber overlay on desktop (`~` console toggle, hidden by default); a
-  **native DOM** scrubber on web (index-functor-lang.html, outside the canvas — see the
-  design note below).
+  custom DOM/SVG timeline on web (index-functor-lang.html, outside the canvas —
+  see the design note below).
 - **PRs:** `History` primitive #218, per-frame model recording #219, coupled
   seek #222, `POST /rewind` #225, the scrubber + web parity #226.
 
@@ -62,9 +62,13 @@ on both the desktop runner and the web/VSCode preview. Exercised by
   accumulation, pause, and rebase — the deterministic golden-capture path.
 - **Shared logic, platform-native UI.** The `SceneRecorder` (the hard part) is
   shared; the *UI surface* is per-platform: egui-in-canvas on desktop (no DOM
-  there), **native DOM on web** (`functor_lang_scrub_*` wasm exports drive it). The web
-  DOM scrubber sits *outside* the game canvas, so its widgets never fight the
-  canvas's pointer-lock — a cleaner fit than mirroring desktop's egui onto web.
+  there), a custom SVG timeline with accessible DOM handles on web
+  (`functor_lang_scrub_*` wasm exports drive it). The web scrubber sits *outside*
+  the game canvas, so its widgets never fight the canvas's pointer-lock.
+- **Viewport is not history extent.** Web keeps recorded extent, visible
+  viewport, selected frame, and extrapolation endpoint as separate values. A
+  pause freezes the viewport; moving either handle never resizes it. A logical
+  future beyond the viewport is clipped at the edge and reported as overflow.
 
 It builds directly on three existing threads and should be read alongside them:
 `docs/physics.md` (the `Simulatable`/`Timeline` seam this generalizes),
@@ -157,13 +161,11 @@ overlay out of Functor's own UI primitives (dogfooding the interactive-UI
 feature), but that couples shipping the tool to shipping a general UI-actions
 capability. Instead:
 
-- **The scrubber is a shell-side egui panel** — a timeline bar, transport
-  (play/pause/step), a scrub handle, a frame counter — that drives the generic
-  `Timeline` directly. It renders in **both** shells because egui already runs in
-  both, needs **no game-facing API**, and requires no game to opt in. "Always
-  exposed in the browser / VSCode plugin" comes for free: the VSCode live preview
-  is just `functor run wasm` in a webview, so a shell-owned overlay in the web
-  runtime *is* the VSCode overlay — one implementation, both surfaces.
+- **The scrubber is shell-owned** — an egui panel on desktop and the shared
+  DOM/SVG timeline on web. Both drive the generic `Timeline` directly, need no
+  game-facing API, and require no game to opt in. "Always exposed in the browser
+  / VSCode plugin" comes for free: the VSCode live preview is `functor run wasm`
+  in a webview, so the shared web component serves both surfaces.
 - **Interactive Functor Lang UI (buttons with actions) is a separate feature.** Functor Lang
   closures are storable, so a `Button { label, onClick }` `View` variant is
   natural; it needs egui fed real pointer input and a return channel into
@@ -333,11 +335,11 @@ the project's "design for agent verifiability" rule.
 | --- | --- | --- |
 | **T1. Coupled model+world recorder** | `History<T>` snapshot ring + `SceneRecorder`; per-frame model + physics-fixed-frame recording; `rewind_scene_to`/`seek_scene_to` exact-or-refused; live `POST /rewind`. Landed as a snapshot-ring + shared rendered-frame clock rather than a single frame `Simulatable` (see the design note). Headless integration tests. | **Shipped** (#218/#219/#222/#225) |
 | **T2. Pointer/click input plumbing** | Feed real pointer `RawInput` to egui (desktop); DOM mouse for the web scrubber. `.interactable(false)` dropped for the scrubber panel. | **Shipped** (#226) |
-| **T3. Scrubber overlay** | Draggable timeline (non-destructive scrub + branch-on-resume) + Pause/Step. **Desktop:** egui-in-canvas, `~` console toggle (hidden by default). **Web:** native DOM outside the canvas + "🖱 mouse look" button. | **Shipped** (#226) |
+| **T3. Scrubber overlay** | Draggable timeline (non-destructive scrub + branch-on-resume) + Pause/Step. **Desktop:** egui-in-canvas, `~` console toggle (hidden by default). **Web:** custom DOM/SVG timeline with two accessible handles, a frozen paused viewport, input/reload markers, and the "🖱 mouse look" button. | **Shipped** (#226 + follow-up) |
 | **T4. Interactive Functor Lang `View`** | `View` gains an action-carrying node (`Button { label, onClick }`, storable Functor Lang closure); egui hit-tests and dispatches back into `update`. Independent of the scrubber (which is shell-owned) — a general game-UI capability. | Not started |
 | **T5. Fork + overlay** | Keep-the-branch instead of truncate; hold two model+world states; a **screen-space compositor** (new fullscreen average pass at the tail of `render_frame`, reusing the double-buffered `RenderTargetBuffers`) renders each scene to its own target and averages them (K=2, weights 0.5/0.5). Shares its whole implementation with T6. | Not started |
 | **T6. Forward-ghosting (trajectory preview)** | A frame-indexed **input log** in the recorder (plain data, survives reload) + a headless deterministic forward-step (replay inputs, suppress effects) + the T5 compositor at K=N, `1/N` weights; wire to hot-reload for the tweak-a-constant loop; slider once T4 lands. The *Inventing on Principle* demo — no trail primitive needed. | Not started |
-| **T7. Event timeline** | Record inputs *and* effects as one plain-data event log keyed by frame (inputs in / effects out); render them as markers on the scrubber; use the log to suppress-on-replay. The event-sourcing spine the earlier phases already imply. | Not started |
+| **T7. Event timeline** | Record inputs *and* effects as one plain-data event log keyed by frame (inputs in / effects out); render them as markers on the scrubber; use the log to suppress-on-replay. Web now renders recorded inputs and reload boundaries; effect/coeffect markers and a unified cross-shell protocol remain. | **In progress** |
 | **T8. Coeffect record/replay** | Record & replay effect *responses* (http/ws) so a recorded window re-runs faithfully. Pure replay is positional/exact; replay-under-a-tweak needs identity-matching + a visible **divergence marker** when a changed model asks for an un-recorded response (never fire live). | Later |
 
 T1–T3 (the whole-game scrubber) are shipped. T5–T6 are the showstopper authoring

--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -389,6 +389,9 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
 // --- 9. Time-travel scrubber drives/observes the player via __scrub. ----------
 {
   const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+  const scrubConsole = [];
+  page.on("console", (message) => scrubConsole.push(message.text()));
+  page.on("pageerror", (error) => scrubConsole.push(`pageerror: ${error.message}`));
   await page.goto(`${BASE}/sandbox.html?example=bounce`);
   await page.waitForFunction(
     () => window.__sandbox && window.__sandbox.status().state === "live",
@@ -410,6 +413,16 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
     })
   );
   check("scrubber exposes two keyboard-focusable slider handles", customHandles);
+  const handleColors = await player.evaluate(() => ({
+    playhead: getComputedStyle(document.getElementById("scrub-playhead")).backgroundColor,
+    preview: getComputedStyle(document.getElementById("scrub-preview-handle")).backgroundColor,
+  }));
+  check(
+    "scrubber handles keep their solid cyan and pink fills",
+    handleColors.playhead === "rgb(65, 216, 230)" &&
+      handleColors.preview === "rgb(232, 88, 184)",
+    JSON.stringify(handleColors)
+  );
 
   await player.waitForFunction(() => window.__scrub.range().length === 2, {
     timeout: 10000,
@@ -435,6 +448,13 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
     () => !!document.querySelector("#scrub-events .scrub-event.input")
   );
   check("timeline renders recorded input markers", inputMarker);
+  const accessibleInputMarkers = await player
+    .getByRole("button", { name: /frame \d+, Space down/ })
+    .count();
+  check(
+    "timeline markers are present in the accessibility tree",
+    accessibleInputMarkers > 0
+  );
 
   await page.evaluate(() =>
     window.__sandbox.setSource(`${window.__sandbox.getSource()}\n// timeline reload marker`)
@@ -447,7 +467,13 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
     () => !!document.querySelector("#scrub-events .scrub-event.reload")
   );
   check("timeline renders successful hot-reload boundaries", reloadMarker);
-  await player.waitForFunction(() => window.__scrub.range().length === 2, { timeout: 3000 });
+  await player.waitForFunction(
+    () => {
+      const range = window.__scrub.range();
+      return range.length === 2 && range[1] - range[0] >= 30;
+    },
+    { timeout: 3000 }
+  );
 
   // Pause freezes both the frame counter AND the pixels.
   await player.evaluate(() => window.__scrub.togglePause());
@@ -476,6 +502,66 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
     previewAfter.previewEndFrame > previewAfter.viewport.hi && previewAfter.previewClippedFrames > 0,
     JSON.stringify(previewAfter)
   );
+  const transportAccessibility = await player.evaluate(() => ({
+    pause: document.getElementById("scrub-pause").getAttribute("aria-label"),
+    extrapolating: document.getElementById("scrub-extrapolate").getAttribute("aria-pressed"),
+  }));
+  check(
+    "transport and extrapolation expose their current state accessibly",
+    transportAccessibility.pause === "Resume" && transportAccessibility.extrapolating === "true",
+    JSON.stringify(transportAccessibility)
+  );
+  const clippedHandlesRemainIndependent = await player.evaluate(() => {
+    const playhead = document.getElementById("scrub-playhead");
+    const preview = document.getElementById("scrub-preview-handle");
+    const rect = playhead.getBoundingClientRect();
+    return (
+      preview.classList.contains("fully-clipped") &&
+      document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2) === playhead
+    );
+  });
+  check(
+    "a fully clipped preview endpoint does not cover the playhead",
+    clippedHandlesRemainIndependent
+  );
+
+  const frozenBeforeStep = await player.evaluate(() => window.__scrub.view());
+  await player.evaluate(() => window.__scrub.step());
+  await player.waitForFunction(
+    (frame) => window.__scrub.frame() === frame + 1,
+    frozenBeforeStep.selectedFrame,
+    { timeout: 3000 }
+  );
+  const frozenAfterStep = await player.evaluate(() => window.__scrub.view());
+  check(
+    "step advances logically without moving the frozen paused endpoint",
+    frozenAfterStep.selectedFrame === frozenBeforeStep.selectedFrame + 1 &&
+      frozenAfterStep.viewport.hi === frozenBeforeStep.viewport.hi &&
+      frozenAfterStep.playheadClippedAfter,
+    JSON.stringify(frozenAfterStep)
+  );
+
+  // Markers have generous invisible hit targets, expose hover detail, and seek
+  // when selected.
+  const markerDetail = await player.evaluate(() => {
+    const marker = document.querySelector("#scrub-events .scrub-event-hit");
+    marker.dispatchEvent(new MouseEvent("mouseenter"));
+    return document.getElementById("scrub-event-detail").textContent;
+  });
+  check("hovering a marker exposes its frame and label", markerDetail.includes("frame"), markerDetail);
+  const selectedMarkerFrame = await player.evaluate(() => {
+    const marker = document.querySelector("#scrub-events .scrub-event-hit");
+    marker.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    return window.__scrub.model().selectedEventId !== null
+      ? Number(marker.getAttribute("aria-label").match(/frame (\d+)/)[1])
+      : -1;
+  });
+  await player.waitForFunction(
+    (frame) => Math.abs(window.__scrub.frame() - frame) <= 1,
+    selectedMarkerFrame,
+    { timeout: 3000 }
+  );
+  check("selecting a marker seeks to its frame", selectedMarkerFrame >= 0);
 
   // Seek snaps to a frame within the range.
   const rng = await player.evaluate(() => window.__scrub.range());
@@ -494,19 +580,150 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
   await player.evaluate(() => window.__scrub.step());
   await sleep(150);
   const after = await player.evaluate(() => window.__scrub.frame());
+  const afterStepView = await player.evaluate(() => window.__scrub.view());
   check(
     "step advances the frame by exactly 1 while paused",
     after === before + 1,
     `${before} -> ${after}`
   );
+  check(
+    "stepping from history marks the discarded future as unrecorded",
+    afterStepView.recordedEndUnit < 1,
+    JSON.stringify(afterStepView)
+  );
 
   // Resume: frames advance again.
   await player.evaluate(() => window.__scrub.togglePause());
-  await player.waitForFunction(() => !window.__scrub.paused(), { timeout: 3000 });
   const rf0 = await player.evaluate(() => window.__scrub.frame());
   await sleep(400);
   const rf1 = await player.evaluate(() => window.__scrub.frame());
   check("resume advances frames again", rf1 > rf0, `${rf0} -> ${rf1}`);
+
+  // Rewinding and resuming replaces the first frame of the discarded future.
+  // Its markers must be rebuilt from the new branch, not retained from the old
+  // history or skipped by the publication cursor.
+  await player.evaluate(() => {
+    window.dispatchEvent(new KeyboardEvent("keydown", { code: "Space" }));
+  });
+  await player.waitForFunction(
+    () => window.__scrub.events().some((event) => event.label === "Space down"),
+    { timeout: 3000 }
+  );
+  const oldBranchFrame = await player.evaluate(
+    () => window.__scrub.events().findLast((event) => event.label === "Space down").frame
+  );
+  await player.waitForFunction(
+    (frame) => window.__scrub.range()[1] >= frame + 4,
+    oldBranchFrame,
+    { timeout: 3000 }
+  );
+  await player.evaluate(() => window.__scrub.togglePause());
+  await player.waitForFunction(() => window.__scrub.paused(), { timeout: 3000 });
+  await player.evaluate((frame) => window.__scrub.seek(frame - 1), oldBranchFrame);
+  await player.waitForFunction(
+    (frame) => window.__scrub.frame() === frame - 1,
+    oldBranchFrame,
+    { timeout: 3000 }
+  );
+  await player.evaluate(() => {
+    window.__scrub.togglePause();
+    window.dispatchEvent(new KeyboardEvent("keyup", { code: "Space" }));
+  });
+  await player.waitForFunction(
+    (frame) =>
+      window.__scrub.events().some((event) => event.frame === frame && event.label === "Space up"),
+    oldBranchFrame,
+    { timeout: 3000 }
+  );
+  const branchMarkersAreAuthoritative = await player.evaluate(
+    (frame) => {
+      const atBranch = window.__scrub.events().filter((event) => event.frame === frame);
+      return (
+        atBranch.some((event) => event.label === "Space up") &&
+        !atBranch.some((event) => event.label === "Space down")
+      );
+    },
+    oldBranchFrame
+  );
+  check(
+    "branching replaces discarded-future markers with authoritative inputs",
+    branchMarkersAreAuthoritative
+  );
+
+  // A successful reload while scrubbed still resumes at the recorder's next
+  // monotonic frame, so its boundary marker must not be anchored to the older
+  // selected frame and then pruned from the new history.
+  await player.waitForFunction(() => !window.__scrub.paused(), { timeout: 3000 });
+  await player.waitForFunction(() => {
+    const range = window.__scrub.range();
+    return range.length === 2 && range[1] - range[0] >= 4;
+  });
+  const reloadWhileScrubbed = await player.evaluate(() => ({
+    hi: window.__scrub.range()[1],
+    lastId: Math.max(-1, ...window.__scrub.events().map((event) => event.id)),
+  }));
+  await player.evaluate(() => window.__scrub.togglePause());
+  await player.waitForFunction(() => window.__scrub.paused(), { timeout: 3000 });
+  await player.evaluate((hi) => window.__scrub.seek(hi - 2), reloadWhileScrubbed.hi);
+  await player.waitForFunction(
+    (hi) => window.__scrub.frame() === hi - 2,
+    reloadWhileScrubbed.hi,
+    { timeout: 3000 }
+  );
+  await page.evaluate(() =>
+    window.__sandbox.setSource(`${window.__sandbox.getSource()}\n// reload while scrubbed marker`)
+  );
+  await player.waitForFunction(
+    (lastId) =>
+      window.__scrub
+        .events()
+        .some((event) => event.id > lastId && event.kind === "reload-ok"),
+    reloadWhileScrubbed.lastId,
+    { timeout: 5000 }
+  );
+  const scrubbedReloadMarker = await player.evaluate(
+    (lastId) =>
+      window.__scrub
+        .events()
+        .find((event) => event.id > lastId && event.kind === "reload-ok"),
+    reloadWhileScrubbed.lastId
+  );
+  const reloadTransportIsVisible = await player.evaluate(() => {
+    const scrubber = document.getElementById("scrubber");
+    const step = document.getElementById("scrub-step");
+    return (
+      getComputedStyle(scrubber).display === "flex" &&
+      getComputedStyle(step).visibility !== "hidden" &&
+      !step.disabled
+    );
+  });
+  check("reload boundary keeps the visible Step/Resume transport", reloadTransportIsVisible);
+  await player.locator("#scrub-step").click();
+  await sleep(500);
+  const postReloadStep = await player.evaluate(() => ({
+    paused: window.__scrub.paused(),
+    frame: window.__scrub.frame(),
+    range: window.__scrub.range(),
+  }));
+  check(
+    "stepping after a scrubbed reload records its boundary",
+    postReloadStep.range.length === 2 &&
+      postReloadStep.range[0] <= scrubbedReloadMarker.frame &&
+      scrubbedReloadMarker.frame <= postReloadStep.range[1],
+    JSON.stringify({ postReloadStep, scrubConsole: scrubConsole.slice(-8) })
+  );
+  const playedRailStartsAtRecordedBoundary = await player.evaluate(
+    () => Number(document.getElementById("scrub-played").getAttribute("x")) > 0
+  );
+  check(
+    "played rail does not paint history before the reload boundary",
+    playedRailStartsAtRecordedBoundary
+  );
+  check(
+    "reload while scrubbed branches from the selected frame",
+    scrubbedReloadMarker.frame === reloadWhileScrubbed.hi - 1,
+    JSON.stringify({ reloadWhileScrubbed, scrubbedReloadMarker })
+  );
 
   await page.close();
 }

--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -403,6 +403,13 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
     () => !!document.getElementById("scrubber")
   );
   check("sandbox player has the scrubber element", sandboxHasScrubber);
+  const customHandles = await player.evaluate(() =>
+    ["scrub-playhead", "scrub-preview-handle"].every((id) => {
+      const handle = document.getElementById(id);
+      return handle?.getAttribute("role") === "slider" && handle.tabIndex === 0;
+    })
+  );
+  check("scrubber exposes two keyboard-focusable slider handles", customHandles);
 
   await player.waitForFunction(() => window.__scrub.range().length === 2, {
     timeout: 10000,
@@ -424,6 +431,23 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
   const h1 = await regionHash(player);
   check("pause freezes the frame counter", f0 === f1, `${f0} -> ${f1}`);
   check("pause freezes the pixels", h0 === h1, `hash ${h0} -> ${h1}`);
+
+  // Preview duration changes the logical second endpoint, but never the paused
+  // viewport. At the live tail the endpoint is clipped and advertised as such.
+  const previewBefore = await player.evaluate(() => window.__scrub.view());
+  await player.evaluate(() => window.__scrub.setPreview({ enabled: true, seconds: 5 }));
+  const previewAfter = await player.evaluate(() => window.__scrub.view());
+  check(
+    "preview changes keep the paused timeline domain fixed",
+    previewBefore.viewport.lo === previewAfter.viewport.lo &&
+      previewBefore.viewport.hi === previewAfter.viewport.hi,
+    `${JSON.stringify(previewBefore.viewport)} -> ${JSON.stringify(previewAfter.viewport)}`
+  );
+  check(
+    "off-rail extrapolation is clipped without shortening the logical preview",
+    previewAfter.previewEndFrame > previewAfter.viewport.hi && previewAfter.previewClippedFrames > 0,
+    JSON.stringify(previewAfter)
+  );
 
   // Seek snaps to a frame within the range.
   const rng = await player.evaluate(() => window.__scrub.range());

--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -389,7 +389,7 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
 // --- 9. Time-travel scrubber drives/observes the player via __scrub. ----------
 {
   const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
-  await page.goto(`${BASE}/sandbox.html`);
+  await page.goto(`${BASE}/sandbox.html?example=bounce`);
   await page.waitForFunction(
     () => window.__sandbox && window.__sandbox.status().state === "live",
     { timeout: 30000 }
@@ -420,6 +420,34 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
   await sleep(500);
   const r1 = await player.evaluate(() => window.__scrub.range());
   check("scrubber range grows while running", r1[1] > r0[1], `${r0} -> ${r1}`);
+
+  // Markers come from the authoritative runtime log: a real recorded key edge,
+  // followed by a real hot-reload boundary from the editor bridge.
+  await player.evaluate(() => {
+    window.dispatchEvent(new KeyboardEvent("keydown", { code: "Space" }));
+    window.dispatchEvent(new KeyboardEvent("keyup", { code: "Space" }));
+  });
+  await player.waitForFunction(
+    () => window.__scrub.events().some((event) => event.kind === "key-down"),
+    { timeout: 3000 }
+  );
+  const inputMarker = await player.evaluate(
+    () => !!document.querySelector("#scrub-events .scrub-event.input")
+  );
+  check("timeline renders recorded input markers", inputMarker);
+
+  await page.evaluate(() =>
+    window.__sandbox.setSource(`${window.__sandbox.getSource()}\n// timeline reload marker`)
+  );
+  await player.waitForFunction(
+    () => window.__scrub.events().some((event) => event.kind === "reload-ok"),
+    { timeout: 5000 }
+  );
+  const reloadMarker = await player.evaluate(
+    () => !!document.querySelector("#scrub-events .scrub-event.reload")
+  );
+  check("timeline renders successful hot-reload boundaries", reloadMarker);
+  await player.waitForFunction(() => window.__scrub.range().length === 2, { timeout: 3000 });
 
   // Pause freezes both the frame counter AND the pixels.
   await player.evaluate(() => window.__scrub.togglePause());

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:wasm-golden:update": "playwright test --update-snapshots",
     "test:wasm-smoke": "node e2e/wasm-smoke.mjs",
     "test:inspector-emit": "node e2e/inspector-emit.mjs",
+    "test:scrubber": "node --test runtime/functor-runtime-web/timeline-model.test.js",
     "site:build": "node site/build.mjs",
     "site:serve": "node site/serve.mjs",
     "test:site": "node e2e/site-sandbox.mjs",

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -139,6 +139,18 @@ pub trait GameProducer {
         Vec::new()
     }
 
+    /// Revision of the authoritative recording generation. It changes when a
+    /// destructive branch or reload can replace frame-indexed timeline data.
+    fn scene_timeline_generation(&self) -> u64 {
+        0
+    }
+
+    /// Rendered frame that the producer will record next, including after a
+    /// scrubbed reload commits a branch.
+    fn next_scene_frame(&self) -> Option<u64> {
+        None
+    }
+
     /// The recorded `tts` of the frame the scene currently sits on (the scrubbed
     /// frame while dragging, else the newest recorded frame). Shells read this to
     /// REBASE their [`crate::GameClock`] when a time-travel branch resumes — on a

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -132,6 +132,13 @@ pub trait GameProducer {
         None
     }
 
+    /// Plain-data inputs recorded on one rendered frame. Timeline UIs use this
+    /// to draw authoritative event markers from the replay log rather than from
+    /// raw shell events that may have been discarded while paused.
+    fn recorded_inputs_at(&self, _rendered_frame: u64) -> Vec<crate::RecordedInput> {
+        Vec::new()
+    }
+
     /// The recorded `tts` of the frame the scene currently sits on (the scrubbed
     /// frame while dragging, else the newest recorded frame). Shells read this to
     /// REBASE their [`crate::GameClock`] when a time-travel branch resumes — on a

--- a/runtime/functor-runtime-common/src/timetravel.rs
+++ b/runtime/functor-runtime-common/src/timetravel.rs
@@ -201,6 +201,11 @@ pub struct SceneRecorder {
     input_history: History<Vec<RecordedInput>>,
     /// The rendered-frame index the next snapshot records at; monotonic.
     rendered_frame: u64,
+    /// Bumps whenever existing recorded frames may have been replaced or a
+    /// reload starts a new snapshot generation. Timeline marker consumers use
+    /// this to rebuild from authoritative input history instead of guessing a
+    /// branch from range movement.
+    generation: u64,
     /// While dragging: the frame the scrubber has non-destructively seeked to.
     /// `Some` = "scrubbing" (future intact); committed on resume.
     scrub_pos: Option<u64>,
@@ -220,6 +225,7 @@ impl SceneRecorder {
             tts_history: History::bounded(DEFAULT_HISTORY_FRAMES),
             input_history: History::bounded(DEFAULT_HISTORY_FRAMES),
             rendered_frame: 0,
+            generation: 0,
             scrub_pos: None,
         }
     }
@@ -235,7 +241,33 @@ impl SceneRecorder {
         self.model_history = History::bounded(DEFAULT_HISTORY_FRAMES);
         self.world_frame_history = History::bounded(DEFAULT_HISTORY_FRAMES);
         self.tts_history = History::bounded(DEFAULT_HISTORY_FRAMES);
+        self.generation = self.generation.wrapping_add(1);
         self.scrub_pos = None;
+    }
+
+    /// Monotonic revision for destructive branch/reload boundaries.
+    pub fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    /// Commit a non-destructive scrub before a reload discards the snapshot
+    /// rings. This preserves the state the user is inspecting and, critically,
+    /// branches the physics timeline in lockstep before `scrub_pos` disappears.
+    pub fn commit_scrub_before_reload(
+        &mut self,
+        model: &mut Value,
+        physics: &mut SteppedPhysics,
+        physics_frame: &mut u64,
+        has_physics: bool,
+    ) {
+        if let Some(frame) = self.scrub_pos {
+            let _ = self.rewind_scene_to(frame, model, physics, physics_frame, has_physics);
+        }
+    }
+
+    /// Rendered frame at which the next settled model will be recorded.
+    pub fn next_frame(&self) -> u64 {
+        self.rendered_frame
     }
 
     /// Record the settled `model`, the world's current fixed frame, and the
@@ -392,6 +424,7 @@ impl SceneRecorder {
         // future consistently across all four rings (docs/time-travel.md T6b).
         self.input_history.truncate_from(frame + 1);
         self.rendered_frame = frame + 1;
+        self.generation = self.generation.wrapping_add(1);
         self.scrub_pos = None;
         let clamped = if frame == target {
             String::new()
@@ -604,6 +637,26 @@ mod tests {
         assert_eq!(rec.scrub_render_tts(), Some(40.0));
     }
 
+    #[test]
+    fn reload_while_scrubbed_branches_before_resetting_snapshots() {
+        let mut rec = SceneRecorder::new();
+        for frame in 0..5u64 {
+            rec.record(&Value::Number(frame as f64), 0, frame as f64);
+        }
+        let mut model = Value::Number(0.0);
+        let mut physics = SteppedPhysics::new();
+        let mut physics_frame = 0;
+        rec.seek_scene_to(2, &mut model, &mut physics, &mut physics_frame, false)
+            .expect("seek");
+
+        rec.commit_scrub_before_reload(&mut model, &mut physics, &mut physics_frame, false);
+        assert_eq!(rec.scene_frame_range(), Some((0, 2)));
+        assert_eq!(rec.next_frame(), 3);
+        rec.reset_on_reload();
+        assert_eq!(rec.scene_frame_range(), None);
+        assert_eq!(rec.next_frame(), 3, "reload resumes after the selected branch");
+    }
+
     // --- the input log: record → read back, and survive a reload (T6b) ---
 
     #[test]
@@ -637,7 +690,9 @@ mod tests {
 
         // A hot reload drops the model ring but KEEPS the input log (plain data
         // survives reload, docs/time-travel.md).
+        let generation = rec.generation();
         rec.reset_on_reload();
+        assert_ne!(rec.generation(), generation, "reload bumps the generation");
         assert_eq!(rec.scene_frame_range(), None, "model ring reset on reload");
         assert_eq!(rec.inputs_at(0).len(), 1, "input log survives the reload");
         assert_eq!(rec.inputs_at(2).len(), 2, "input log survives the reload");

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -453,6 +453,12 @@ impl FunctorLangGame {
     /// tick right through a reload. Returns the number of stored closures
     /// rebound, for the status line.
     fn swap_in(&mut self, loaded: Loaded) -> usize {
+        self.recorder.commit_scrub_before_reload(
+            &mut self.model,
+            &mut self.physics_rt,
+            &mut self.physics_frame,
+            self.has_physics,
+        );
         let (model, report) = functor_lang::rebind_value(&self.model, &self.module, &loaded.module);
         self.model = model;
         for warning in &report.warnings {

--- a/runtime/functor-runtime-web/scrubber.js
+++ b/runtime/functor-runtime-web/scrubber.js
@@ -11,6 +11,7 @@ import {
   functor_lang_scrub_paused,
   functor_lang_scrub_set_preview,
   functor_lang_scrub_set_preview_config,
+  functor_lang_timeline_events,
 } from "./pkg/functor_runtime_web.js";
 import {
   PREVIEW_SECONDS_MAX,
@@ -59,6 +60,10 @@ const STYLE = `
 #scrub-recorded { fill: rgba(65, 216, 230, 0.30); }
 #scrub-played { fill: var(--sb-accent); opacity: 0.62; }
 #scrub-future { fill: var(--sb-future); opacity: 0.9; }
+.scrub-event { pointer-events: none; }
+.scrub-event.input { fill: #ffd166; }
+.scrub-event.reload { fill: #b994ff; }
+.scrub-event.reload-error { fill: #ff6b7d; }
 .scrub-handle {
   position: absolute; top: 15px; z-index: 3; width: 14px; height: 20px;
   box-sizing: border-box; padding: 0 !important; transform: translate(-50%, -50%) !important;
@@ -119,6 +124,7 @@ const HTML = `
       <rect id="scrub-recorded" x="0" y="12" width="1000" height="6" rx="3" />
       <rect id="scrub-played" x="0" y="12" width="0" height="6" rx="3" />
       <rect id="scrub-future" x="0" y="11" width="0" height="8" rx="3" />
+      <g id="scrub-events"></g>
     </svg>
     <button id="scrub-playhead" class="scrub-handle" role="slider"
       aria-label="Selected frame" aria-orientation="horizontal"></button>
@@ -165,6 +171,7 @@ export function mountScrubber() {
   const playhead = $("scrub-playhead");
   const previewHandle = $("scrub-preview-handle");
   const overflow = $("scrub-overflow");
+  const eventLayer = $("scrub-events");
   const extrapolate = $("scrub-extrapolate");
   const mode = $("scrub-mode");
   const win = $("scrub-win");
@@ -172,6 +179,8 @@ export function mountScrubber() {
 
   let state = createTimelineState();
   let pendingSeek = null;
+  let lastEventsJson = "";
+  let markerRenderKey = "";
   let raf = 0;
 
   const dispatch = (action) => {
@@ -203,6 +212,36 @@ export function mountScrubber() {
     const rect = rail.getBoundingClientRect();
     const unit = rect.width > 0 ? (event.clientX - rect.left) / rect.width : 0;
     return unitToFrame(unit, current.viewport);
+  };
+
+  const renderMarkers = (current) => {
+    const key =
+      `${current.viewport.lo}:${current.viewport.hi}:` +
+      current.eventMarkers.map((marker) => `${marker.id}:${marker.count}`).join(",");
+    if (key === markerRenderKey) return;
+    markerRenderKey = key;
+    eventLayer.replaceChildren();
+    const ns = "http://www.w3.org/2000/svg";
+    for (const marker of current.eventMarkers) {
+      const tick = document.createElementNS(ns, "rect");
+      const x = marker.unit * 1000;
+      const reload = marker.category === "reload";
+      tick.setAttribute("x", String(x - (reload ? 3 : 2)));
+      tick.setAttribute("y", reload ? "1" : "21");
+      tick.setAttribute("width", reload ? "6" : "4");
+      tick.setAttribute("height", reload ? "9" : "7");
+      tick.setAttribute("rx", reload ? "2" : "1");
+      tick.setAttribute(
+        "class",
+        `scrub-event ${marker.category}${marker.kind === "reload-error" ? " reload-error" : ""}`
+      );
+      tick.dataset.eventId = String(marker.id);
+      const title = document.createElementNS(ns, "title");
+      const suffix = marker.count > 1 ? ` (+${marker.count - 1} nearby)` : "";
+      title.textContent = `frame ${marker.frame}: ${marker.labels[0]}${suffix}`;
+      tick.appendChild(title);
+      eventLayer.appendChild(tick);
+    }
   };
 
   const render = () => {
@@ -251,6 +290,7 @@ export function mountScrubber() {
       ` / ${current.viewport.hi}`;
     pause.textContent = current.paused ? "▶" : "⏸";
     extrapolate.classList.toggle("on", state.preview.enabled);
+    renderMarkers(current);
   };
 
   const beginAbsoluteDrag = (handle, move) => {
@@ -382,6 +422,7 @@ export function mountScrubber() {
     step: () => functor_lang_scrub_step(),
     model: () => state,
     view,
+    events: () => state.events,
     setPreview: (preview) => {
       dispatch({ type: "preview-changed", preview });
       syncInputs();
@@ -395,6 +436,15 @@ export function mountScrubber() {
     if (pendingSeek !== null) {
       functor_lang_seek_scene(pendingSeek);
       pendingSeek = null;
+    }
+    const eventsJson = functor_lang_timeline_events();
+    if (eventsJson !== lastEventsJson) {
+      lastEventsJson = eventsJson;
+      try {
+        dispatch({ type: "events-published", events: JSON.parse(eventsJson) });
+      } catch {
+        // A malformed marker payload must not stop the runtime poll loop.
+      }
     }
     const range = functor_lang_scene_range();
     if (range.length === 2) {

--- a/runtime/functor-runtime-web/scrubber.js
+++ b/runtime/functor-runtime-web/scrubber.js
@@ -1,25 +1,6 @@
-// The shared time-travel scrubber — ONE component for every wasm-preview
-// surface: the site's sandbox/IDE (site/player.html) and the CLI dev server /
-// VSCode live-preview (index-functor-lang.html, served by `functor run wasm`).
-// Both pages `import { mountScrubber }` from here instead of hand-rolling the
-// controls, so the two can't drift (they used to — different themes AND
-// different feature sets).
-//
-// It's a dependency-free ES module (no framework): the codebase is Rust +
-// vanilla JS, and neither host page is bundled, so a plain module that both
-// pages import — exactly like they already import ./pkg — is the natural fit.
-// It's served alongside pkg/ (the CLI embeds + serves it; the site build copies
-// it; `build wasm` writes it into dist/web).
-//
-// Look: the site's calm violet/cyan theme, everywhere. Styles are injected here
-// (self-contained) using `var(--scrub-*, <calm default>)`, so a host that sets
-// those vars (player.html, for its mouselook button) matches, and one that
-// doesn't (the runtime page) still renders the same calm look via the fallbacks.
-//
-// Features: the full time-travel UI — pause/resume, a seek slider whose rail
-// extends into a cyan FUTURE bar with a draggable end-cap (resize the forward
-// window in place), step, an extrapolate toggle (🔮), and a ⚙ popover for the
-// extrapolation mode / window / rate (docs/time-travel.md T3/T6/T6d).
+// Shared web time-travel timeline for the site player, browser IDE, CLI wasm
+// server, and VS Code preview. Semantics live in timeline-model.js; this module
+// is the imperative DOM/WASM shell.
 
 import {
   functor_lang_scene_frame,
@@ -31,9 +12,16 @@ import {
   functor_lang_scrub_set_preview,
   functor_lang_scrub_set_preview_config,
 } from "./pkg/functor_runtime_web.js";
+import {
+  PREVIEW_SECONDS_MAX,
+  PREVIEW_SECONDS_MIN,
+  TIMELINE_FPS,
+  createTimelineState,
+  deriveTimelineView,
+  reduceTimeline,
+  unitToFrame,
+} from "./timeline-model.js";
 
-// Calm site theme (site/styles.css :root) as the DEFAULTS, so the runtime page
-// — which sets no vars — renders identically to the site.
 const STYLE = `
 #scrubber {
   --sb-bg: var(--scrub-bg, rgba(30, 24, 51, 0.92));
@@ -41,61 +29,57 @@ const STYLE = `
   --sb-text: var(--scrub-text, #e9e6f2);
   --sb-dim: var(--scrub-dim, #9b94b3);
   --sb-accent: var(--scrub-accent, #41d8e6);
-  /* The extrapolated-future color — synthwave pink, distinct from the cyan
-     accent of the timeline you actually scrub, and matching the 🔮 toggle. */
   --sb-future: var(--scrub-future, #e858b8);
   --sb-font: var(--scrub-font, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
   position: fixed; left: 0; right: 0; bottom: 0; z-index: 10;
   display: none; align-items: center; gap: 8px; flex-wrap: nowrap;
-  font: 12px/1 var(--sb-font); color: var(--sb-text);
-  /* Extra bottom padding leaves room for the frame counter, which hangs
-     centered UNDER the rail. */
-  padding: 8px 12px 18px; background: var(--sb-bg);
-  border-top: 1px solid var(--sb-line);
-  box-shadow: 0 -3px 16px rgba(0, 0, 0, 0.35); /* depth: lift off the canvas */
+  padding: 8px 12px 18px; color: var(--sb-text); background: var(--sb-bg);
+  border-top: 1px solid var(--sb-line); box-shadow: 0 -3px 16px rgba(0, 0, 0, 0.35);
+  font: 12px/1 var(--sb-font);
 }
-/* Buttons + the ⚙ summary share one raised, tactile treatment — a resting
-   drop shadow, a lift on hover, a press on active. */
 #scrubber button, #scrub-adv > summary {
   font: 14px/1 var(--sb-font); color: var(--sb-text); cursor: pointer;
-  background: rgba(65, 216, 230, 0.10);
-  border: 1px solid var(--sb-line); border-radius: 6px; padding: 6px 9px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
+  background: rgba(65, 216, 230, 0.10); border: 1px solid var(--sb-line);
+  border-radius: 6px; padding: 6px 9px; box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
   transition: box-shadow 0.12s ease, border-color 0.12s ease, transform 0.12s ease;
 }
 #scrubber button:hover, #scrub-adv > summary:hover {
-  border-color: var(--sb-accent); box-shadow: 0 3px 10px rgba(0, 0, 0, 0.5); transform: translateY(-1px);
+  border-color: var(--sb-accent); box-shadow: 0 3px 10px rgba(0, 0, 0, 0.5);
+  transform: translateY(-1px);
 }
 #scrubber button:active, #scrub-adv > summary:active {
   transform: translateY(0); box-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
 }
-/* The timeline rail: the range input spans the recorded part; a translucent
-   cyan strip marks [handle, handle + preview window] — the rail's domain
-   extends past the recorded end while a preview is on. */
-#scrub-rail { position: relative; display: flex; align-items: center; flex: 1; min-width: 60px; }
-#scrub-slider { width: 100%; accent-color: var(--sb-accent); }
-#scrub-future {
-  position: absolute; height: 5px; top: 50%; transform: translateY(-50%);
-  border-radius: 2px; background: var(--sb-future); opacity: 0.85;
-  pointer-events: none; display: none;
+#scrub-rail {
+  position: relative; flex: 1; min-width: 80px; height: 30px; cursor: ew-resize;
+  touch-action: none; user-select: none;
 }
-/* The future segment's end cap: drag to resize the forward window in place.
-   Hangs level with the track but is grabbable (the seek thumb owns the middle). */
-#scrub-future-cap {
-  position: absolute; width: 8px; height: 14px; top: 50%; transform: translateY(-50%);
-  border-radius: 2px; background: var(--sb-future);
-  cursor: ew-resize; display: none; touch-action: none;
+#scrub-timeline { position: absolute; inset: 0; width: 100%; height: 100%; overflow: visible; }
+#scrub-track-bg { fill: rgba(155, 148, 179, 0.18); }
+#scrub-recorded { fill: rgba(65, 216, 230, 0.30); }
+#scrub-played { fill: var(--sb-accent); opacity: 0.62; }
+#scrub-future { fill: var(--sb-future); opacity: 0.9; }
+.scrub-handle {
+  position: absolute; top: 15px; z-index: 3; width: 14px; height: 20px;
+  box-sizing: border-box; padding: 0 !important; transform: translate(-50%, -50%) !important;
+  border-radius: 4px !important; touch-action: none; cursor: ew-resize !important;
 }
-#scrub-future-cap:hover { filter: brightness(1.3); }
-/* Frame counter: tiny, faded, centered UNDER the rail — positioned, so digit
-   growth never reflows the controls. */
+.scrub-handle:focus-visible { outline: 2px solid white; outline-offset: 2px; }
+#scrub-playhead { background: var(--sb-accent); border-color: #b9f8ff; }
+#scrub-preview-handle { background: var(--sb-future); border-color: #ffd0ee; }
+#scrub-preview-handle.clipped { border-radius: 3px 0 0 3px !important; }
+#scrub-overflow {
+  position: absolute; right: 0; top: -5px; z-index: 4; display: none;
+  padding: 2px 4px; border: 1px solid var(--sb-future); border-radius: 5px;
+  color: #ffd0ee; background: rgba(30, 24, 51, 0.96); font-size: 9px;
+  pointer-events: none;
+}
 #scrub-label {
-  position: absolute; top: calc(100% + 4px); left: 50%; transform: translateX(-50%);
-  color: var(--sb-dim); opacity: 0.7; font-size: 9px; white-space: nowrap; pointer-events: none;
+  position: absolute; top: calc(100% + 2px); left: 50%; transform: translateX(-50%);
+  color: var(--sb-dim); opacity: 0.78; font-size: 9px; white-space: nowrap;
+  pointer-events: none;
 }
 #scrub-label .fut { color: var(--sb-future); }
-/* Extrapolate toggle: a normal (clearly-clickable) button when OFF, LIT in the
-   future's pink when on — never a greyed-out "disabled" look. */
 #scrub-extrapolate.on {
   border-color: var(--sb-future);
   box-shadow: 0 0 0 1px var(--sb-future), 0 2px 10px rgba(232, 88, 184, 0.4);
@@ -108,24 +92,18 @@ const STYLE = `
   position: absolute; bottom: calc(100% + 10px); right: 0; z-index: 11;
   display: flex; flex-direction: column; gap: 8px; padding: 10px 12px;
   background: var(--sb-bg); border-radius: 8px; border: 1px solid var(--sb-line);
-  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.5); /* depth: floats above the strip */
-  white-space: nowrap;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.5); white-space: nowrap;
 }
 #scrub-adv-pop label { display: flex; align-items: center; gap: 6px; justify-content: space-between; }
 #scrub-adv-pop select, #scrub-adv-pop input[type="number"] {
-  font: 12px/1 var(--sb-font); color: var(--sb-text);
-  background: rgba(65, 216, 230, 0.10); border: 1px solid var(--sb-line);
-  border-radius: 5px; padding: 4px 5px;
+  font: 12px/1 var(--sb-font); color: var(--sb-text); background: rgba(65, 216, 230, 0.10);
+  border: 1px solid var(--sb-line); border-radius: 5px; padding: 4px 5px;
 }
 #scrub-adv-pop input[type="number"] { width: 46px; }
-/* Responsive: narrow iframes (the hero card, a phone). This page is an iframe,
-   so the parent's media queries can't reach in — these run against the iframe's
-   own viewport. Tighten gaps/padding and let the rail flex smaller so the whole
-   strip fits without clipping. */
 @media (max-width: 520px) {
   #scrubber { gap: 6px; padding: 7px 8px 17px; }
   #scrubber button, #scrub-adv > summary { padding: 6px 7px; }
-  #scrub-rail { min-width: 36px; }
+  #scrub-rail { min-width: 48px; }
 }
 @media (max-width: 380px) {
   #scrubber { gap: 4px; }
@@ -135,35 +113,35 @@ const STYLE = `
 const HTML = `
   <button id="scrub-pause" title="Pause / resume">⏸</button>
   <button id="scrub-step" title="Step one frame forward">⏭</button>
-  <span id="scrub-rail">
-    <input id="scrub-slider" type="range" min="0" max="0" value="0" step="1" />
-    <span id="scrub-future"></span>
-    <span id="scrub-future-cap" title="Drag to resize the preview window"></span>
+  <span id="scrub-rail" aria-label="Time-travel timeline">
+    <svg id="scrub-timeline" viewBox="0 0 1000 30" preserveAspectRatio="none" aria-hidden="true">
+      <rect id="scrub-track-bg" x="0" y="12" width="1000" height="6" rx="3" />
+      <rect id="scrub-recorded" x="0" y="12" width="1000" height="6" rx="3" />
+      <rect id="scrub-played" x="0" y="12" width="0" height="6" rx="3" />
+      <rect id="scrub-future" x="0" y="11" width="0" height="8" rx="3" />
+    </svg>
+    <button id="scrub-playhead" class="scrub-handle" role="slider"
+      aria-label="Selected frame" aria-orientation="horizontal"></button>
+    <button id="scrub-preview-handle" class="scrub-handle" role="slider"
+      aria-label="Extrapolation endpoint" aria-orientation="horizontal"></button>
+    <span id="scrub-overflow"></span>
     <span id="scrub-label"><span id="scrub-count"></span></span>
   </span>
-  <button id="scrub-extrapolate" title="Extrapolate: forward-simulate the paused game and overlay where everything is headed (docs/time-travel.md T6)">🔮</button>
+  <button id="scrub-extrapolate" title="Extrapolate the paused game into the future">🔮</button>
   <details id="scrub-adv">
-    <summary title="Extrapolation settings — what it shows, how far ahead, how densely">⚙</summary>
+    <summary title="Extrapolation settings">⚙</summary>
     <div id="scrub-adv-pop">
-      <label title="What the extrapolation shows: trail dots, scene-space strobe copies, both, or the screen-space ghost compositor">show
+      <label>show
         <select id="scrub-mode">
-          <option value="1">trail</option>
-          <option value="2">strobe</option>
-          <option value="3" selected>both</option>
-          <option value="4">ghost</option>
+          <option value="1">trail</option><option value="2">strobe</option>
+          <option value="3" selected>both</option><option value="4">ghost</option>
         </select>
       </label>
-      <label title="How far ahead the preview projects">window
-        <input id="scrub-win" type="number" step="0.5" min="0.5" max="5" value="2" />s
-      </label>
-      <label title="Strobe copies per second — the trail samples finer; density holds as the window resizes (ghost composites at most 8 total)">rate
-        <input id="scrub-rate" type="number" min="1" max="30" value="5" />/s
-      </label>
+      <label>window <input id="scrub-win" type="number" step="0.5" min="0.5" max="5" value="2" />s</label>
+      <label>rate <input id="scrub-rate" type="number" min="1" max="30" value="5" />/s</label>
     </div>
   </details>`;
 
-// Mount the scrubber into the page (creates a fixed bottom strip on document.body,
-// hidden until history is recorded). Returns a handle with destroy().
 export function mountScrubber() {
   if (!document.getElementById("functor-scrubber-style")) {
     const style = document.createElement("style");
@@ -178,129 +156,260 @@ export function mountScrubber() {
   document.body.appendChild(el);
 
   const $ = (id) => el.querySelector(`#${id}`);
-  const label = $("scrub-count");
+  const rail = $("scrub-rail");
   const pause = $("scrub-pause");
-  const slider = $("scrub-slider");
   const step = $("scrub-step");
+  const label = $("scrub-count");
+  const played = $("scrub-played");
   const future = $("scrub-future");
-  const futureCap = $("scrub-future-cap");
+  const playhead = $("scrub-playhead");
+  const previewHandle = $("scrub-preview-handle");
+  const overflow = $("scrub-overflow");
   const extrapolate = $("scrub-extrapolate");
   const mode = $("scrub-mode");
   const win = $("scrub-win");
   const rate = $("scrub-rate");
 
-  let scrubbing = false;
+  let state = createTimelineState();
   let pendingSeek = null;
-  // Hoisted so destroy() can remove it — it's a WINDOW listener, not on `el`.
-  const onPointerUp = () => (scrubbing = false);
-  slider.addEventListener("pointerdown", () => (scrubbing = true));
-  window.addEventListener("pointerup", onPointerUp);
-  slider.addEventListener("input", () => (pendingSeek = Number(slider.value)));
+  let raf = 0;
+
+  const dispatch = (action) => {
+    state = reduceTimeline(state, action);
+    render();
+  };
+
+  const view = () => deriveTimelineView(state);
+  const canonicalConfig = () => state.preview;
+  const pushPreview = () =>
+    functor_lang_scrub_set_preview(state.preview.enabled ? Number(mode.value) : 0);
+  const pushConfig = () => {
+    const config = canonicalConfig();
+    functor_lang_scrub_set_preview_config(config.seconds, config.rate);
+  };
+  const syncInputs = () => {
+    win.value = String(state.preview.seconds);
+    rate.value = String(state.preview.rate);
+  };
+
+  const requestSeek = (frame) => {
+    dispatch({ type: "seek-requested", frame });
+    pendingSeek = state.requestedFrame;
+  };
+
+  const frameAtPointer = (event) => {
+    const current = view();
+    if (!current) return 0;
+    const rect = rail.getBoundingClientRect();
+    const unit = rect.width > 0 ? (event.clientX - rect.left) / rect.width : 0;
+    return unitToFrame(unit, current.viewport);
+  };
+
+  const render = () => {
+    const current = view();
+    if (!current) return;
+
+    const playheadPct = current.playheadUnit * 100;
+    const previewPct = current.previewEndUnit * 100;
+    const futureWidth = Math.max(previewPct - playheadPct, 0);
+    const previewVisible = state.preview.enabled && current.paused;
+
+    playhead.style.left = `${playheadPct}%`;
+    played.setAttribute("width", String(current.playheadUnit * 1000));
+    future.setAttribute("x", String(current.playheadUnit * 1000));
+    future.setAttribute("width", String(previewVisible ? futureWidth * 10 : 0));
+    previewHandle.style.left = `${previewPct}%`;
+    previewHandle.style.display = previewVisible ? "block" : "none";
+    previewHandle.classList.toggle("clipped", current.previewClippedFrames > 0);
+
+    overflow.style.display = previewVisible && current.previewClippedFrames > 0 ? "block" : "none";
+    overflow.textContent = `+${current.previewClippedFrames}`;
+
+    playhead.setAttribute("aria-valuemin", String(current.viewport.lo));
+    playhead.setAttribute("aria-valuemax", String(current.viewport.hi));
+    playhead.setAttribute("aria-valuenow", String(current.selectedFrame));
+    playhead.setAttribute("aria-valuetext", `frame ${current.selectedFrame}`);
+
+    previewHandle.setAttribute(
+      "aria-valuemin",
+      String(current.selectedFrame + Math.round(PREVIEW_SECONDS_MIN * TIMELINE_FPS))
+    );
+    previewHandle.setAttribute(
+      "aria-valuemax",
+      String(current.selectedFrame + Math.round(PREVIEW_SECONDS_MAX * TIMELINE_FPS))
+    );
+    previewHandle.setAttribute("aria-valuenow", String(current.previewEndFrame));
+    previewHandle.setAttribute(
+      "aria-valuetext",
+      `${state.preview.seconds} seconds ahead` +
+        (current.previewClippedFrames ? `, ${current.previewClippedFrames} frames clipped` : "")
+    );
+
+    label.innerHTML =
+      `${current.selectedFrame}` +
+      (state.preview.enabled ? ` <span class="fut">+${current.previewFrames}</span>` : "") +
+      ` / ${current.viewport.hi}`;
+    pause.textContent = current.paused ? "▶" : "⏸";
+    extrapolate.classList.toggle("on", state.preview.enabled);
+  };
+
+  const beginAbsoluteDrag = (handle, move) => {
+    handle.addEventListener("pointerdown", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      handle.setPointerCapture(event.pointerId);
+      move(event, true);
+    });
+    handle.addEventListener("pointermove", (event) => {
+      if (handle.hasPointerCapture(event.pointerId)) move(event, false);
+    });
+  };
+
+  beginAbsoluteDrag(playhead, (event) => requestSeek(frameAtPointer(event)));
+
+  let previewDrag = null;
+  previewHandle.addEventListener("pointerdown", (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    previewHandle.setPointerCapture(event.pointerId);
+    previewDrag = { x: event.clientX, seconds: state.preview.seconds };
+  });
+  previewHandle.addEventListener("pointermove", (event) => {
+    if (!previewDrag || !previewHandle.hasPointerCapture(event.pointerId)) return;
+    const current = view();
+    const width = rail.getBoundingClientRect().width;
+    const span = current ? current.viewport.hi - current.viewport.lo : 0;
+    if (width <= 0 || span <= 0) return;
+    const deltaFrames = ((event.clientX - previewDrag.x) / width) * span;
+    dispatch({
+      type: "preview-changed",
+      preview: { seconds: previewDrag.seconds + deltaFrames / TIMELINE_FPS },
+    });
+    syncInputs();
+    pushConfig();
+  });
+  const endPreviewDrag = () => (previewDrag = null);
+  previewHandle.addEventListener("pointerup", endPreviewDrag);
+  previewHandle.addEventListener("pointercancel", endPreviewDrag);
+  previewHandle.addEventListener("lostpointercapture", endPreviewDrag);
+
+  rail.addEventListener("pointerdown", (event) => {
+    if (event.target.closest(".scrub-handle")) return;
+    event.preventDefault();
+    rail.setPointerCapture(event.pointerId);
+    requestSeek(frameAtPointer(event));
+  });
+  rail.addEventListener("pointermove", (event) => {
+    if (rail.hasPointerCapture(event.pointerId)) requestSeek(frameAtPointer(event));
+  });
+
+  const seekKey = (event) => {
+    const current = view();
+    if (!current) return;
+    const steps = event.shiftKey ? 10 : 1;
+    const targets = {
+      ArrowLeft: current.selectedFrame - steps,
+      ArrowDown: current.selectedFrame - steps,
+      ArrowRight: current.selectedFrame + steps,
+      ArrowUp: current.selectedFrame + steps,
+      PageDown: current.selectedFrame - TIMELINE_FPS,
+      PageUp: current.selectedFrame + TIMELINE_FPS,
+      Home: current.viewport.lo,
+      End: current.viewport.hi,
+    };
+    if (!(event.key in targets)) return;
+    event.preventDefault();
+    requestSeek(targets[event.key]);
+  };
+  playhead.addEventListener("keydown", seekKey);
+
+  previewHandle.addEventListener("keydown", (event) => {
+    const steps = event.shiftKey ? TIMELINE_FPS : Math.round(TIMELINE_FPS / 2);
+    const deltas = {
+      ArrowLeft: -steps,
+      ArrowDown: -steps,
+      ArrowRight: steps,
+      ArrowUp: steps,
+      PageDown: -TIMELINE_FPS,
+      PageUp: TIMELINE_FPS,
+    };
+    if (event.key === "Home" || event.key === "End") {
+      event.preventDefault();
+      dispatch({
+        type: "preview-changed",
+        preview: { seconds: event.key === "Home" ? PREVIEW_SECONDS_MIN : PREVIEW_SECONDS_MAX },
+      });
+    } else if (event.key in deltas) {
+      event.preventDefault();
+      dispatch({ type: "preview-delta-requested", frames: deltas[event.key] });
+    } else {
+      return;
+    }
+    syncInputs();
+    pushConfig();
+  });
+
   pause.addEventListener("click", () => functor_lang_scrub_toggle_pause());
   step.addEventListener("click", () => functor_lang_scrub_step());
-
-  // Future extrapolation (docs/time-travel.md T6/T6d): ONE toggle on the bar
-  // (default OFF — opt in to see where things are headed); the mode / window /
-  // rate live in the ⚙ popover. JS owns the UI state and pushes the EFFECTIVE
-  // mode (0 while off). Pushed once at setup too, since a fresh runtime starts
-  // at its own defaults.
-  let extrapolating = false;
-  const syncExtrapolateIcon = () => extrapolate.classList.toggle("on", extrapolating);
-  const pushPreview = () => functor_lang_scrub_set_preview(extrapolating ? +mode.value : 0);
-  const pushConfig = () => functor_lang_scrub_set_preview_config(+win.value, +rate.value);
   extrapolate.addEventListener("click", () => {
-    extrapolating = !extrapolating;
-    syncExtrapolateIcon();
+    dispatch({ type: "preview-changed", preview: { enabled: !state.preview.enabled } });
     pushPreview();
   });
   mode.addEventListener("change", pushPreview);
-  win.addEventListener("input", pushConfig);
-  rate.addEventListener("input", pushConfig);
-  syncExtrapolateIcon();
+
+  const updateConfigFromInputs = () => {
+    const seconds = win.valueAsNumber;
+    const nextRate = rate.valueAsNumber;
+    if (!win.validity.valid || !rate.validity.valid) return;
+    dispatch({ type: "preview-changed", preview: { seconds, rate: nextRate } });
+    pushConfig();
+  };
+  win.addEventListener("input", updateConfigFromInputs);
+  rate.addEventListener("input", updateConfigFromInputs);
+  win.addEventListener("change", syncInputs);
+  rate.addEventListener("change", syncInputs);
+
+  syncInputs();
   pushPreview();
   pushConfig();
 
-  // Drag the cyan segment's end cap to resize the forward window in place —
-  // the ⚙ window input's direct-manipulation twin.
-  let capDrag = null; // { x: pointerdown clientX, w: window at start }
-  futureCap.addEventListener("pointerdown", (e) => {
-    e.preventDefault();
-    futureCap.setPointerCapture(e.pointerId);
-    capDrag = { x: e.clientX, w: +win.value };
-  });
-  futureCap.addEventListener("pointermove", (e) => {
-    if (!capDrag) return;
-    const inset = 7;
-    const travel = slider.offsetWidth - 2 * inset;
-    const domain = +slider.max - +slider.min;
-    if (travel <= 0 || domain <= 0) return;
-    const framesPerPx = domain / travel;
-    const w = Math.min(5, Math.max(0.5, capDrag.w + ((e.clientX - capDrag.x) * framesPerPx) / 60));
-    win.value = w.toFixed(1);
-    pushConfig();
-  });
-  futureCap.addEventListener("pointerup", () => (capDrag = null));
-
-  // Headless test seam (e2e/site-sandbox.mjs): drive/observe without the DOM.
   const seam = {
     paused: () => functor_lang_scrub_paused(),
     frame: () => functor_lang_scene_frame(),
     range: () => functor_lang_scene_range(),
-    seek: (f) => functor_lang_seek_scene(f),
+    seek: requestSeek,
     togglePause: () => functor_lang_scrub_toggle_pause(),
     step: () => functor_lang_scrub_step(),
+    model: () => state,
+    view,
+    setPreview: (preview) => {
+      dispatch({ type: "preview-changed", preview });
+      syncInputs();
+      pushPreview();
+      pushConfig();
+    },
   };
   window.__scrub = seam;
 
-  let raf = 0;
   const update = () => {
     if (pendingSeek !== null) {
       functor_lang_seek_scene(pendingSeek);
       pendingSeek = null;
     }
-    const range = functor_lang_scene_range(); // [] or [lo, hi]
+    const range = functor_lang_scene_range();
     if (range.length === 2) {
       el.style.display = "flex";
-      const lo = range[0];
-      const hi = range[1];
-      slider.min = lo;
-      const frame = functor_lang_scene_frame();
-      if (!scrubbing) slider.value = frame; // don't tug the handle mid-drag
-      // The rail's domain includes the preview window: the handle can be
-      // dragged INTO the cyan segment — a seek beyond the recorded end steps
-      // the game forward, input-free (the runtime animates the catch-up).
-      const span = hi - lo;
-      const futureFrames = extrapolating ? Math.round(+win.value * 60) : 0;
-      slider.max = hi + futureFrames;
-      // `227 +120 / 227` — the predicted-frames count sits with the frame.
-      label.innerHTML =
-        `${frame | 0}` +
-        (futureFrames > 0 ? ` <span class="fut">+${futureFrames}</span>` : "") +
-        ` / ${hi | 0}`;
-      pause.textContent = functor_lang_scrub_paused() ? "▶" : "⏸";
-      if (futureFrames > 0 && span > 0) {
-        // The cyan segment [handle, handle + window] plus its draggable end
-        // cap, anchored to the thumb (including mid-drag) and starting at its
-        // right edge, so the cyan never paints over the traversed track.
-        const inset = 7;
-        const travel = slider.offsetWidth - 2 * inset;
-        const domain = hi + futureFrames - lo;
-        const thumb = +slider.value;
-        const thumbPx = inset + ((thumb - lo) / domain) * travel;
-        const leftPx = thumbPx + inset;
-        const endPx = Math.min(thumbPx + (futureFrames / domain) * travel, inset + travel);
-        const widthPx = Math.max(endPx - leftPx, 0);
-        future.style.left = `${leftPx}px`;
-        future.style.width = `${widthPx}px`;
-        future.style.display = "block";
-        futureCap.style.left = `${endPx - 4}px`;
-        futureCap.style.display = "block";
-      } else {
-        future.style.display = "none";
-        futureCap.style.display = "none";
-      }
+      dispatch({
+        type: "runtime-published",
+        snapshot: {
+          frame: functor_lang_scene_frame(),
+          lo: range[0],
+          hi: range[1],
+          paused: functor_lang_scrub_paused(),
+        },
+      });
     } else {
-      el.style.display = "none"; // nothing recorded yet
+      el.style.display = "none";
     }
     raf = requestAnimationFrame(update);
   };
@@ -309,7 +418,6 @@ export function mountScrubber() {
   return {
     destroy() {
       cancelAnimationFrame(raf);
-      window.removeEventListener("pointerup", onPointerUp);
       el.remove();
       if (window.__scrub === seam) delete window.__scrub;
     },

--- a/runtime/functor-runtime-web/scrubber.js
+++ b/runtime/functor-runtime-web/scrubber.js
@@ -6,12 +6,14 @@ import {
   functor_lang_scene_frame,
   functor_lang_scene_range,
   functor_lang_seek_scene,
+  functor_lang_scrub_seek_result,
   functor_lang_scrub_toggle_pause,
   functor_lang_scrub_step,
   functor_lang_scrub_paused,
   functor_lang_scrub_set_preview,
   functor_lang_scrub_set_preview_config,
   functor_lang_timeline_events,
+  functor_lang_timeline_events_gen,
 } from "./pkg/functor_runtime_web.js";
 import {
   PREVIEW_SECONDS_MAX,
@@ -64,20 +66,35 @@ const STYLE = `
 .scrub-event.input { fill: #ffd166; }
 .scrub-event.reload { fill: #b994ff; }
 .scrub-event.reload-error { fill: #ff6b7d; }
+.scrub-event-hit { cursor: pointer; outline: none; }
+.scrub-event-hit.active .scrub-event,
+.scrub-event-hit:focus .scrub-event { stroke: white; stroke-width: 2; }
 .scrub-handle {
   position: absolute; top: 15px; z-index: 3; width: 14px; height: 20px;
   box-sizing: border-box; padding: 0 !important; transform: translate(-50%, -50%) !important;
   border-radius: 4px !important; touch-action: none; cursor: ew-resize !important;
 }
 .scrub-handle:focus-visible { outline: 2px solid white; outline-offset: 2px; }
-#scrub-playhead { background: var(--sb-accent); border-color: #b9f8ff; }
-#scrub-preview-handle { background: var(--sb-future); border-color: #ffd0ee; }
+#scrubber #scrub-playhead { background: var(--sb-accent); border-color: #b9f8ff; }
+#scrubber #scrub-preview-handle { background: var(--sb-future); border-color: #ffd0ee; }
 #scrub-preview-handle.clipped { border-radius: 3px 0 0 3px !important; }
+#scrub-preview-handle.fully-clipped {
+  top: 0; z-index: 5; height: 12px;
+}
+#scrub-playhead.outside { box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.55); }
 #scrub-overflow {
   position: absolute; right: 0; top: -5px; z-index: 4; display: none;
   padding: 2px 4px; border: 1px solid var(--sb-future); border-radius: 5px;
   color: #ffd0ee; background: rgba(30, 24, 51, 0.96); font-size: 9px;
   pointer-events: none;
+}
+#scrub-event-detail {
+  position: absolute; z-index: 5; bottom: calc(100% + 7px); display: none;
+  max-width: min(280px, 80vw); padding: 5px 7px; transform: translateX(-50%);
+  border: 1px solid var(--sb-line); border-radius: 6px; color: var(--sb-text);
+  background: rgba(30, 24, 51, 0.98); box-shadow: 0 4px 16px rgba(0, 0, 0, 0.45);
+  font-size: 10px; line-height: 1.3; white-space: nowrap; overflow: hidden;
+  text-overflow: ellipsis; pointer-events: none;
 }
 #scrub-label {
   position: absolute; top: calc(100% + 2px); left: 50%; transform: translateX(-50%);
@@ -85,6 +102,7 @@ const STYLE = `
   pointer-events: none;
 }
 #scrub-label .fut { color: var(--sb-future); }
+#scrub-label .out { color: #ffd166; }
 #scrub-extrapolate.on {
   border-color: var(--sb-future);
   box-shadow: 0 0 0 1px var(--sb-future), 0 2px 10px rgba(232, 88, 184, 0.4);
@@ -118,19 +136,21 @@ const STYLE = `
 const HTML = `
   <button id="scrub-pause" title="Pause / resume">⏸</button>
   <button id="scrub-step" title="Step one frame forward">⏭</button>
-  <span id="scrub-rail" aria-label="Time-travel timeline">
-    <svg id="scrub-timeline" viewBox="0 0 1000 30" preserveAspectRatio="none" aria-hidden="true">
-      <rect id="scrub-track-bg" x="0" y="12" width="1000" height="6" rx="3" />
-      <rect id="scrub-recorded" x="0" y="12" width="1000" height="6" rx="3" />
-      <rect id="scrub-played" x="0" y="12" width="0" height="6" rx="3" />
-      <rect id="scrub-future" x="0" y="11" width="0" height="8" rx="3" />
-      <g id="scrub-events"></g>
+  <span id="scrub-rail" aria-label="Time-travel timeline" title="Drag to seek">
+    <svg id="scrub-timeline" viewBox="0 0 1000 30" preserveAspectRatio="none"
+      role="group" aria-label="Timeline event markers">
+      <rect id="scrub-track-bg" x="0" y="12" width="1000" height="6" rx="3" aria-hidden="true" />
+      <rect id="scrub-recorded" x="0" y="12" width="1000" height="6" rx="3" aria-hidden="true" />
+      <rect id="scrub-played" x="0" y="12" width="0" height="6" rx="3" aria-hidden="true" />
+      <rect id="scrub-future" x="0" y="11" width="0" height="8" rx="3" aria-hidden="true" />
+      <g id="scrub-events" aria-label="Recorded events"></g>
     </svg>
     <button id="scrub-playhead" class="scrub-handle" role="slider"
       aria-label="Selected frame" aria-orientation="horizontal"></button>
     <button id="scrub-preview-handle" class="scrub-handle" role="slider"
       aria-label="Extrapolation endpoint" aria-orientation="horizontal"></button>
     <span id="scrub-overflow"></span>
+    <span id="scrub-event-detail" role="status"></span>
     <span id="scrub-label"><span id="scrub-count"></span></span>
   </span>
   <button id="scrub-extrapolate" title="Extrapolate the paused game into the future">🔮</button>
@@ -166,11 +186,13 @@ export function mountScrubber() {
   const pause = $("scrub-pause");
   const step = $("scrub-step");
   const label = $("scrub-count");
+  const recorded = $("scrub-recorded");
   const played = $("scrub-played");
   const future = $("scrub-future");
   const playhead = $("scrub-playhead");
   const previewHandle = $("scrub-preview-handle");
   const overflow = $("scrub-overflow");
+  const eventDetail = $("scrub-event-detail");
   const eventLayer = $("scrub-events");
   const extrapolate = $("scrub-extrapolate");
   const mode = $("scrub-mode");
@@ -179,9 +201,12 @@ export function mountScrubber() {
 
   let state = createTimelineState();
   let pendingSeek = null;
-  let lastEventsJson = "";
-  let markerRenderKey = "";
+  let nextSeekId = 1;
+  let lastSeekResultId = null;
+  let lastEventsGeneration = null;
+  let lastRuntimeSnapshotKey = "";
   let raf = 0;
+  const markerNodes = new Map();
 
   const dispatch = (action) => {
     state = reduceTimeline(state, action);
@@ -202,8 +227,11 @@ export function mountScrubber() {
   };
 
   const requestSeek = (frame) => {
-    dispatch({ type: "seek-requested", frame });
-    pendingSeek = state.requestedFrame;
+    const id = nextSeekId++;
+    dispatch({ type: "seek-requested", id, frame });
+    if (state.requestedSeekId === id) {
+      pendingSeek = { id, frame: state.requestedFrame };
+    }
   };
 
   const frameAtPointer = (event) => {
@@ -215,32 +243,98 @@ export function mountScrubber() {
   };
 
   const renderMarkers = (current) => {
-    const key =
-      `${current.viewport.lo}:${current.viewport.hi}:` +
-      current.eventMarkers.map((marker) => `${marker.id}:${marker.count}`).join(",");
-    if (key === markerRenderKey) return;
-    markerRenderKey = key;
-    eventLayer.replaceChildren();
     const ns = "http://www.w3.org/2000/svg";
+    const desiredIds = new Set(current.eventMarkers.map((marker) => marker.id));
+    for (const [id, group] of markerNodes) {
+      if (!desiredIds.has(id)) {
+        group.remove();
+        markerNodes.delete(id);
+      }
+    }
+
+    let nextChild = eventLayer.firstElementChild;
     for (const marker of current.eventMarkers) {
-      const tick = document.createElementNS(ns, "rect");
-      const x = marker.unit * 1000;
-      const reload = marker.category === "reload";
-      tick.setAttribute("x", String(x - (reload ? 3 : 2)));
-      tick.setAttribute("y", reload ? "1" : "21");
-      tick.setAttribute("width", reload ? "6" : "4");
-      tick.setAttribute("height", reload ? "9" : "7");
-      tick.setAttribute("rx", reload ? "2" : "1");
-      tick.setAttribute(
-        "class",
-        `scrub-event ${marker.category}${marker.kind === "reload-error" ? " reload-error" : ""}`
+      let group = markerNodes.get(marker.id);
+      if (!group) {
+        group = document.createElementNS(ns, "g");
+        const tick = document.createElementNS(ns, "rect");
+        const hit = document.createElementNS(ns, "rect");
+        const reload = marker.category === "reload";
+
+        group.setAttribute("class", "scrub-event-hit");
+        group.setAttribute("role", "button");
+        group.setAttribute("tabindex", "0");
+        group.dataset.eventId = String(marker.id);
+
+        hit.setAttribute("x", "-9");
+        hit.setAttribute("y", "0");
+        hit.setAttribute("width", "18");
+        hit.setAttribute("height", "30");
+        hit.setAttribute("fill", "transparent");
+
+        tick.setAttribute("x", String(-(reload ? 3 : 2)));
+        tick.setAttribute("y", reload ? "1" : "21");
+        tick.setAttribute("width", reload ? "6" : "4");
+        tick.setAttribute("height", reload ? "9" : "7");
+        tick.setAttribute("rx", reload ? "2" : "1");
+        tick.setAttribute(
+          "class",
+          `scrub-event ${marker.category}${marker.kind === "reload-error" ? " reload-error" : ""}`
+        );
+
+        const activate = () => {
+          dispatch({ type: "event-selected", id: marker.id });
+          requestSeek(marker.frame);
+        };
+        group.addEventListener("mouseenter", () => dispatch({ type: "event-hovered", id: marker.id }));
+        group.addEventListener("mouseleave", () => dispatch({ type: "event-hovered", id: null }));
+        group.addEventListener("focus", () => dispatch({ type: "event-hovered", id: marker.id }));
+        group.addEventListener("blur", () => dispatch({ type: "event-hovered", id: null }));
+        group.addEventListener("pointerdown", (event) => event.stopPropagation());
+        group.addEventListener("click", (event) => {
+          event.stopPropagation();
+          activate();
+        });
+        group.addEventListener("keydown", (event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            activate();
+          } else if (event.key === "Escape") {
+            dispatch({ type: "event-selected", id: null });
+          }
+        });
+        group.append(hit, tick);
+        markerNodes.set(marker.id, group);
+      }
+
+      const suffix = marker.count > 1 ? `, ${marker.count} nearby events` : "";
+      group.setAttribute("aria-label", `frame ${marker.frame}, ${marker.labels[0]}${suffix}`);
+      group.setAttribute("transform", `translate(${marker.unit * 1000} 0)`);
+      // Retain nodes/listeners and touch the DOM only when clustering changes
+      // their chronological keyboard-navigation order.
+      if (group === nextChild) {
+        nextChild = nextChild.nextElementSibling;
+      } else {
+        eventLayer.insertBefore(group, nextChild);
+      }
+    }
+
+    for (const group of eventLayer.querySelectorAll(".scrub-event-hit")) {
+      const id = Number(group.dataset.eventId);
+      group.classList.toggle(
+        "active",
+        id === current.selectedEventId || id === current.hoveredEventId
       );
-      tick.dataset.eventId = String(marker.id);
-      const title = document.createElementNS(ns, "title");
-      const suffix = marker.count > 1 ? ` (+${marker.count - 1} nearby)` : "";
-      title.textContent = `frame ${marker.frame}: ${marker.labels[0]}${suffix}`;
-      tick.appendChild(title);
-      eventLayer.appendChild(tick);
+    }
+
+    if (current.activeEvent) {
+      eventDetail.style.display = "block";
+      eventDetail.style.left = `${Math.min(95, Math.max(5, current.activeEvent.unit * 100))}%`;
+      const count = current.activeEvent.count > 1 ? ` · ${current.activeEvent.count} events` : "";
+      const detail = `frame ${current.activeEvent.frame} · ${current.activeEvent.labels[0]}${count}`;
+      if (eventDetail.textContent !== detail) eventDetail.textContent = detail;
+    } else {
+      eventDetail.style.display = "none";
     }
   };
 
@@ -251,23 +345,56 @@ export function mountScrubber() {
     const playheadPct = current.playheadUnit * 100;
     const previewPct = current.previewEndUnit * 100;
     const futureWidth = Math.max(previewPct - playheadPct, 0);
-    const previewVisible = state.preview.enabled && current.paused;
+    const previewVisible =
+      state.preview.enabled && current.paused && current.recordingAvailable;
 
     playhead.style.left = `${playheadPct}%`;
-    played.setAttribute("width", String(current.playheadUnit * 1000));
+    playhead.style.display = current.recordingAvailable ? "block" : "none";
+    recorded.setAttribute("x", String(current.recordedStartUnit * 1000));
+    recorded.setAttribute(
+      "width",
+      String(Math.max(current.recordedEndUnit - current.recordedStartUnit, 0) * 1000)
+    );
+    played.setAttribute("x", String(current.recordedStartUnit * 1000));
+    played.setAttribute(
+      "width",
+      String(
+        Math.max(
+          Math.min(current.playheadUnit, current.recordedEndUnit) - current.recordedStartUnit,
+          0
+        ) * 1000
+      )
+    );
     future.setAttribute("x", String(current.playheadUnit * 1000));
     future.setAttribute("width", String(previewVisible ? futureWidth * 10 : 0));
     previewHandle.style.left = `${previewPct}%`;
     previewHandle.style.display = previewVisible ? "block" : "none";
     previewHandle.classList.toggle("clipped", current.previewClippedFrames > 0);
+    previewHandle.classList.toggle(
+      "fully-clipped",
+      previewVisible && current.previewFrames > 0 && previewPct <= playheadPct
+    );
+    playhead.classList.toggle(
+      "outside",
+      current.playheadClippedBefore || current.playheadClippedAfter
+    );
 
     overflow.style.display = previewVisible && current.previewClippedFrames > 0 ? "block" : "none";
     overflow.textContent = `+${current.previewClippedFrames}`;
 
     playhead.setAttribute("aria-valuemin", String(current.viewport.lo));
-    playhead.setAttribute("aria-valuemax", String(current.viewport.hi));
+    playhead.setAttribute(
+      "aria-valuemax",
+      String(Math.max(current.viewport.hi, current.selectedFrame))
+    );
     playhead.setAttribute("aria-valuenow", String(current.selectedFrame));
-    playhead.setAttribute("aria-valuetext", `frame ${current.selectedFrame}`);
+    playhead.setAttribute(
+      "aria-valuetext",
+      `frame ${current.selectedFrame}` +
+        (current.playheadClippedBefore || current.playheadClippedAfter
+          ? `, outside the frozen viewport ${current.viewport.lo} to ${current.viewport.hi}`
+          : "")
+    );
 
     previewHandle.setAttribute(
       "aria-valuemin",
@@ -284,12 +411,18 @@ export function mountScrubber() {
         (current.previewClippedFrames ? `, ${current.previewClippedFrames} frames clipped` : "")
     );
 
-    label.innerHTML =
-      `${current.selectedFrame}` +
-      (state.preview.enabled ? ` <span class="fut">+${current.previewFrames}</span>` : "") +
-      ` / ${current.viewport.hi}`;
+    label.innerHTML = current.recordingAvailable
+      ? `${current.selectedFrame}` +
+        (current.playheadClippedBefore || current.playheadClippedAfter
+          ? ` <span class="out">outside</span>`
+          : "") +
+        (state.preview.enabled ? ` <span class="fut">+${current.previewFrames}</span>` : "") +
+        ` / ${Math.round(current.viewport.hi)}`
+      : "reload boundary · Step or Resume";
     pause.textContent = current.paused ? "▶" : "⏸";
+    pause.setAttribute("aria-label", current.paused ? "Resume" : "Pause");
     extrapolate.classList.toggle("on", state.preview.enabled);
+    extrapolate.setAttribute("aria-pressed", String(state.preview.enabled));
     renderMarkers(current);
   };
 
@@ -342,7 +475,6 @@ export function mountScrubber() {
   rail.addEventListener("pointermove", (event) => {
     if (rail.hasPointerCapture(event.pointerId)) requestSeek(frameAtPointer(event));
   });
-
   const seekKey = (event) => {
     const current = view();
     if (!current) return;
@@ -423,6 +555,7 @@ export function mountScrubber() {
     model: () => state,
     view,
     events: () => state.events,
+    selectEvent: (id) => dispatch({ type: "event-selected", id }),
     setPreview: (preview) => {
       dispatch({ type: "preview-changed", preview });
       syncInputs();
@@ -434,12 +567,18 @@ export function mountScrubber() {
 
   const update = () => {
     if (pendingSeek !== null) {
-      functor_lang_seek_scene(pendingSeek);
+      functor_lang_seek_scene(pendingSeek.frame, pendingSeek.id);
       pendingSeek = null;
     }
-    const eventsJson = functor_lang_timeline_events();
-    if (eventsJson !== lastEventsJson) {
-      lastEventsJson = eventsJson;
+    const seekResult = functor_lang_scrub_seek_result();
+    if (seekResult.length === 2 && seekResult[0] !== lastSeekResultId) {
+      lastSeekResultId = seekResult[0];
+      dispatch({ type: "seek-resolved", id: seekResult[0], frame: seekResult[1] });
+    }
+    const eventsGeneration = functor_lang_timeline_events_gen();
+    if (eventsGeneration !== lastEventsGeneration) {
+      lastEventsGeneration = eventsGeneration;
+      const eventsJson = functor_lang_timeline_events();
       try {
         dispatch({ type: "events-published", events: JSON.parse(eventsJson) });
       } catch {
@@ -449,17 +588,26 @@ export function mountScrubber() {
     const range = functor_lang_scene_range();
     if (range.length === 2) {
       el.style.display = "flex";
-      dispatch({
-        type: "runtime-published",
-        snapshot: {
-          frame: functor_lang_scene_frame(),
-          lo: range[0],
-          hi: range[1],
-          paused: functor_lang_scrub_paused(),
-        },
-      });
+      const snapshot = {
+        frame: functor_lang_scene_frame(),
+        lo: range[0],
+        hi: range[1],
+        paused: functor_lang_scrub_paused(),
+      };
+      const snapshotKey = `${snapshot.frame}:${snapshot.lo}:${snapshot.hi}:${snapshot.paused}`;
+      if (snapshotKey !== lastRuntimeSnapshotKey) {
+        lastRuntimeSnapshotKey = snapshotKey;
+        dispatch({ type: "runtime-published", snapshot });
+      }
     } else {
-      el.style.display = "none";
+      const paused = functor_lang_scrub_paused();
+      if (paused && state.runtime) {
+        el.style.display = "flex";
+        if (state.recordingAvailable) dispatch({ type: "recording-cleared" });
+      } else {
+        el.style.display = "none";
+      }
+      lastRuntimeSnapshotKey = "";
     }
     raf = requestAnimationFrame(update);
   };

--- a/runtime/functor-runtime-web/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-web/src/functor_lang_game.rs
@@ -351,6 +351,12 @@ impl FunctorLangWebGame {
     /// right through a reload. Returns the number of stored closures rebound,
     /// for the status line.
     fn swap_in(&mut self, loaded: Loaded) -> usize {
+        self.recorder.commit_scrub_before_reload(
+            &mut self.model,
+            &mut self.physics_rt,
+            &mut self.physics_frame,
+            self.has_physics,
+        );
         let (model, report) = functor_lang::rebind_value(&self.model, &self.module, &loaded.module);
         self.model = model;
         for warning in &report.warnings {
@@ -572,6 +578,14 @@ impl GameProducer for FunctorLangWebGame {
         rendered_frame: u64,
     ) -> Vec<functor_runtime_common::RecordedInput> {
         self.recorder.inputs_at(rendered_frame).to_vec()
+    }
+
+    fn scene_timeline_generation(&self) -> u64 {
+        self.recorder.generation()
+    }
+
+    fn next_scene_frame(&self) -> Option<u64> {
+        Some(self.recorder.next_frame())
     }
 
     fn current_scene_tts(&self) -> Option<f64> {
@@ -1131,7 +1145,10 @@ pub fn drain_input(game: &mut dyn GameProducer, deliver: bool) {
 pub enum ScrubControl {
     TogglePause,
     Step,
-    SeekTo(u64),
+    SeekTo {
+        frame: u64,
+        request_id: u32,
+    },
     /// Future-preview mode (docs/time-travel.md T6/T6d), pushed by the DOM
     /// preview `<select>` (PreviewMode wire index: 0 off / 1 trail / 2 strobe /
     /// 3 both / 4 ghost). The frame loop owns the preview state.
@@ -1147,6 +1164,10 @@ thread_local! {
     /// `frame`/`lo`/`hi` are `-1.0` when nothing is recorded yet.
     static SCRUB_VIEW: RefCell<(f64, f64, f64, bool)> =
         const { RefCell::new((-1.0, -1.0, -1.0, false)) };
+    /// Latest completed seek as `(request id, authoritative applied frame)`.
+    /// The DOM uses this acknowledgement to retire optimistic handle state even
+    /// when the runtime clamps or refuses a request.
+    static SCRUB_SEEK_RESULT: RefCell<Option<(u32, f64)>> = const { RefCell::new(None) };
 }
 
 const SCRUB_CONTROLS_CAP: usize = 256;
@@ -1164,11 +1185,18 @@ struct TimelineLog {
     markers: Vec<TimelineMarker>,
     next_id: u64,
     input_cursor: Option<u64>,
+    input_generation: Option<u64>,
     cached_json: String,
     dirty: bool,
+    revision: u32,
 }
 
 impl TimelineLog {
+    fn changed(&mut self) {
+        self.dirty = true;
+        self.revision = self.revision.wrapping_add(1);
+    }
+
     fn push(&mut self, frame: u64, kind: &'static str, label: String) {
         self.markers.push(TimelineMarker {
             id: self.next_id,
@@ -1181,14 +1209,33 @@ impl TimelineLog {
         if self.markers.len() > CAP {
             self.markers.drain(..self.markers.len() - CAP);
         }
-        self.dirty = true;
+        self.changed();
     }
 
     fn retain_range(&mut self, lo: u64, hi: u64) {
         let old_len = self.markers.len();
         self.markers
             .retain(|marker| marker.frame >= lo && marker.frame <= hi);
-        self.dirty |= self.markers.len() != old_len;
+        if self.markers.len() != old_len {
+            self.changed();
+        }
+    }
+
+    fn truncate_from(&mut self, frame: u64) {
+        let old_len = self.markers.len();
+        self.markers.retain(|marker| marker.frame < frame);
+        if self.markers.len() != old_len {
+            self.changed();
+        }
+    }
+
+    fn reset_inputs(&mut self) {
+        let old_len = self.markers.len();
+        self.markers.retain(|marker| marker.kind.starts_with("reload-"));
+        if self.markers.len() != old_len {
+            self.changed();
+        }
+        self.input_cursor = None;
     }
 
     fn json(&mut self) -> &str {
@@ -1243,16 +1290,39 @@ pub fn publish_timeline_inputs(game: &dyn GameProducer) {
     };
     TIMELINE_LOG.with(|log| {
         let mut log = log.borrow_mut();
+        let generation = game.scene_timeline_generation();
+        if log.input_generation != Some(generation) {
+            // A branch can replace frames without making `hi` move backward
+            // (for example, one frame from the old tail). Rebuild input markers
+            // from the authoritative recorder instead of inferring from range.
+            log.reset_inputs();
+            log.input_generation = Some(generation);
+        }
         if log.input_cursor.is_some_and(|cursor| cursor > hi) {
-            // A resumed scrub branched away the old future.
-            log.input_cursor = Some(hi);
+            // A resumed scrub rewrote `hi`, the first frame on the new branch.
+            // Drop the discarded branch including its stale marker at `hi`,
+            // then rescan that authoritative replacement frame below.
+            log.truncate_from(hi);
+            log.input_cursor = hi.checked_sub(1);
         }
         let start = log
             .input_cursor
             .map_or(lo, |cursor| cursor.saturating_add(1).max(lo));
         if start <= hi {
             for frame in start..=hi {
+                let mut last_mouse_move = None;
                 for input in game.recorded_inputs_at(frame) {
+                    if matches!(&input, InputEvent::MouseMove { .. }) {
+                        // Pointer-lock mouselook can emit several moves per
+                        // rendered frame. One marker still says "input here"
+                        // without multiplying bridge payload and DOM hits.
+                        last_mouse_move = Some(input);
+                        continue;
+                    }
+                    let (kind, label) = input_marker(&input);
+                    log.push(frame, kind, label);
+                }
+                if let Some(input) = last_mouse_move {
                     let (kind, label) = input_marker(&input);
                     log.push(frame, kind, label);
                 }
@@ -1284,6 +1354,13 @@ pub fn publish_timeline_reload(frame: u64, ok: bool, message: &str) {
 #[wasm_bindgen]
 pub fn functor_lang_timeline_events() -> String {
     TIMELINE_LOG.with(|log| log.borrow_mut().json().to_string())
+}
+
+/// Runtime → page: cheap marker-log revision. The DOM fetches the JSON only
+/// when this changes instead of cloning it over the WASM boundary every rAF.
+#[wasm_bindgen]
+pub fn functor_lang_timeline_events_gen() -> u32 {
+    TIMELINE_LOG.with(|log| log.borrow().revision)
 }
 
 fn push_scrub(control: ScrubControl) {
@@ -1339,10 +1416,33 @@ pub fn functor_lang_scrub_set_preview_config(window: f32, rate: usize) {
 
 /// Page → runtime: non-destructively scrub to a rendered frame (slider drag).
 #[wasm_bindgen]
-pub fn functor_lang_seek_scene(frame: f64) {
+pub fn functor_lang_seek_scene(frame: f64, request_id: u32) {
     if frame >= 0.0 {
-        push_scrub(ScrubControl::SeekTo(frame as u64));
+        push_scrub(ScrubControl::SeekTo {
+            frame: frame as u64,
+            request_id,
+        });
     }
+}
+
+/// Publish a completed seek's authoritative frame for the DOM's optimistic
+/// state reconciler. Kept separate from [`SCRUB_VIEW`] so ordinary playback
+/// publications do not masquerade as seek acknowledgements.
+pub fn publish_scrub_seek_result(request_id: u32, frame: Option<u64>) {
+    SCRUB_SEEK_RESULT.with(|result| {
+        *result.borrow_mut() = Some((request_id, frame.map_or(-1.0, |frame| frame as f64)));
+    });
+}
+
+/// Runtime → page: latest `[requestId, appliedFrame]`, or `[]` before any seek.
+#[wasm_bindgen]
+pub fn functor_lang_scrub_seek_result() -> Vec<f64> {
+    SCRUB_SEEK_RESULT.with(|result| {
+        result
+            .borrow()
+            .map(|(request_id, frame)| vec![request_id as f64, frame])
+            .unwrap_or_default()
+    })
 }
 
 /// Runtime → page: the current handle frame (`-1` if nothing recorded).

--- a/runtime/functor-runtime-web/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-web/src/functor_lang_game.rs
@@ -567,6 +567,13 @@ impl GameProducer for FunctorLangWebGame {
         self.recorder.scene_frame_range()
     }
 
+    fn recorded_inputs_at(
+        &self,
+        rendered_frame: u64,
+    ) -> Vec<functor_runtime_common::RecordedInput> {
+        self.recorder.inputs_at(rendered_frame).to_vec()
+    }
+
     fn current_scene_tts(&self) -> Option<f64> {
         self.recorder.current_scene_frame_tts()
     }
@@ -1143,6 +1150,141 @@ thread_local! {
 }
 
 const SCRUB_CONTROLS_CAP: usize = 256;
+
+#[derive(Clone)]
+struct TimelineMarker {
+    id: u64,
+    frame: u64,
+    kind: &'static str,
+    label: String,
+}
+
+#[derive(Default)]
+struct TimelineLog {
+    markers: Vec<TimelineMarker>,
+    next_id: u64,
+    input_cursor: Option<u64>,
+    cached_json: String,
+    dirty: bool,
+}
+
+impl TimelineLog {
+    fn push(&mut self, frame: u64, kind: &'static str, label: String) {
+        self.markers.push(TimelineMarker {
+            id: self.next_id,
+            frame,
+            kind,
+            label,
+        });
+        self.next_id += 1;
+        const CAP: usize = 4096;
+        if self.markers.len() > CAP {
+            self.markers.drain(..self.markers.len() - CAP);
+        }
+        self.dirty = true;
+    }
+
+    fn retain_range(&mut self, lo: u64, hi: u64) {
+        let old_len = self.markers.len();
+        self.markers
+            .retain(|marker| marker.frame >= lo && marker.frame <= hi);
+        self.dirty |= self.markers.len() != old_len;
+    }
+
+    fn json(&mut self) -> &str {
+        if self.dirty || self.cached_json.is_empty() {
+            let markers: Vec<_> = self
+                .markers
+                .iter()
+                .map(|marker| {
+                    serde_json::json!({
+                        "id": marker.id,
+                        "frame": marker.frame,
+                        "kind": marker.kind,
+                        "label": marker.label,
+                    })
+                })
+                .collect();
+            self.cached_json = serde_json::to_string(&markers).unwrap_or_else(|_| "[]".to_string());
+            self.dirty = false;
+        }
+        &self.cached_json
+    }
+}
+
+thread_local! {
+    static TIMELINE_LOG: RefCell<TimelineLog> = RefCell::new(TimelineLog::default());
+}
+
+fn input_marker(input: &InputEvent) -> (&'static str, String) {
+    match input {
+        InputEvent::Key { code, is_down } => {
+            let name = functor_runtime_common::Key::from_i32(*code)
+                .map(|key| key.name())
+                .unwrap_or_else(|| format!("key {code}"));
+            let edge = if *is_down { "down" } else { "up" };
+            (
+                if *is_down { "key-down" } else { "key-up" },
+                format!("{name} {edge}"),
+            )
+        }
+        InputEvent::MouseMove { x, y } => ("mouse-move", format!("mouse move ({x}, {y})")),
+        InputEvent::MouseWheel { delta } => ("mouse-wheel", format!("mouse wheel {delta:+}")),
+        InputEvent::UiEvent(event) => ("ui-input", format!("UI {event:?}")),
+    }
+}
+
+/// Copy newly recorded inputs into the DOM timeline's compact marker log. The
+/// producer's recorder is authoritative: inputs discarded while paused never
+/// appear, and replayable inputs land on their exact rendered frame.
+pub fn publish_timeline_inputs(game: &dyn GameProducer) {
+    let Some((lo, hi)) = game.scene_frame_range() else {
+        return;
+    };
+    TIMELINE_LOG.with(|log| {
+        let mut log = log.borrow_mut();
+        if log.input_cursor.is_some_and(|cursor| cursor > hi) {
+            // A resumed scrub branched away the old future.
+            log.input_cursor = Some(hi);
+        }
+        let start = log
+            .input_cursor
+            .map_or(lo, |cursor| cursor.saturating_add(1).max(lo));
+        if start <= hi {
+            for frame in start..=hi {
+                for input in game.recorded_inputs_at(frame) {
+                    let (kind, label) = input_marker(&input);
+                    log.push(frame, kind, label);
+                }
+            }
+        }
+        log.input_cursor = Some(hi);
+        log.retain_range(lo, hi);
+    });
+}
+
+/// Record a reload boundary. Successful reloads reset model snapshots, so the
+/// marker belongs to the next monotonic frame; failures mark the attempted
+/// boundary without changing the running program.
+pub fn publish_timeline_reload(frame: u64, ok: bool, message: &str) {
+    TIMELINE_LOG.with(|log| {
+        log.borrow_mut().push(
+            frame,
+            if ok { "reload-ok" } else { "reload-error" },
+            if ok {
+                "hot reload".to_string()
+            } else {
+                format!("reload failed: {message}")
+            },
+        );
+    });
+}
+
+/// Runtime → page: JSON array of `{id, frame, kind, label}` markers.
+#[wasm_bindgen]
+pub fn functor_lang_timeline_events() -> String {
+    TIMELINE_LOG.with(|log| log.borrow_mut().json().to_string())
+}
 
 fn push_scrub(control: ScrubControl) {
     SCRUB_CONTROLS.with(|c| {

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -278,24 +278,26 @@ fn apply_pending_reload(game: &mut dyn GameProducer) {
     let Some((push, id)) = PENDING_RELOAD.with(|p| p.borrow_mut().take()) else {
         return;
     };
-    let marker_frame = game
+    let selected_frame = game
         .current_scene_frame()
         .or_else(|| game.scene_frame_range().map(|(_, hi)| hi))
-        .unwrap_or(0)
-        .saturating_add(1);
+        .unwrap_or(0);
     let outcome = match push {
         PendingPush::Source(source) => game.reload_source(&source),
         PendingPush::Project(files) => game.reload_project(&files),
     };
     match outcome {
         Ok(status) => {
-            functor_lang_game::publish_timeline_reload(marker_frame, true, &status);
+            let next_recorded_frame = game
+                .next_scene_frame()
+                .unwrap_or_else(|| selected_frame.saturating_add(1));
+            functor_lang_game::publish_timeline_reload(next_recorded_frame, true, &status);
             hide_error_overlay();
             post_reload_result(true, &status, id);
         }
         Err(message) => {
             functor_lang_game::publish_timeline_reload(
-                marker_frame.saturating_sub(1),
+                selected_frame,
                 false,
                 &message,
             );
@@ -1206,7 +1208,10 @@ async fn run_async() -> Result<(), JsValue> {
                         preview_window = window.clamp(0.5, 5.0);
                         preview_rate = rate.clamp(1, 30);
                     }
-                    functor_lang_game::ScrubControl::SeekTo(f) => {
+                    functor_lang_game::ScrubControl::SeekTo {
+                        frame: f,
+                        request_id,
+                    } => {
                         let newest = game.scene_frame_range().map(|(_, h)| h);
                         match newest {
                             Some(h) if f > h => {
@@ -1231,6 +1236,10 @@ async fn run_async() -> Result<(), JsValue> {
                                 clock.pause();
                             }
                         }
+                        functor_lang_game::publish_scrub_seek_result(
+                            request_id,
+                            game.current_scene_frame(),
+                        );
                     }
                 }
             }

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -278,16 +278,27 @@ fn apply_pending_reload(game: &mut dyn GameProducer) {
     let Some((push, id)) = PENDING_RELOAD.with(|p| p.borrow_mut().take()) else {
         return;
     };
+    let marker_frame = game
+        .current_scene_frame()
+        .or_else(|| game.scene_frame_range().map(|(_, hi)| hi))
+        .unwrap_or(0)
+        .saturating_add(1);
     let outcome = match push {
         PendingPush::Source(source) => game.reload_source(&source),
         PendingPush::Project(files) => game.reload_project(&files),
     };
     match outcome {
         Ok(status) => {
+            functor_lang_game::publish_timeline_reload(marker_frame, true, &status);
             hide_error_overlay();
             post_reload_result(true, &status, id);
         }
         Err(message) => {
+            functor_lang_game::publish_timeline_reload(
+                marker_frame.saturating_sub(1),
+                false,
+                &message,
+            );
             show_error_overlay(&format!("[functor-lang] reload error: {message}"));
             post_reload_result(false, &message, id);
         }
@@ -1466,6 +1477,7 @@ async fn run_async() -> Result<(), JsValue> {
 
             // Publish the scrubber state for the DOM slider to poll (the UI
             // itself is native HTML in index-functor-lang.html, outside the canvas).
+            functor_lang_game::publish_timeline_inputs(&**game);
             functor_lang_game::publish_scrub_view(
                 game.current_scene_frame(),
                 game.scene_frame_range(),

--- a/runtime/functor-runtime-web/timeline-model.js
+++ b/runtime/functor-runtime-web/timeline-model.js
@@ -30,12 +30,15 @@ export function normalizePreviewConfig(next = {}, previous = { seconds: 2, rate:
 export function createTimelineState(preview = {}) {
   return {
     runtime: null,
+    recordingAvailable: false,
     viewport: null,
     selectedFrame: null,
     requestedFrame: null,
-    followLive: true,
+    requestedSeekId: null,
     preview: normalizePreviewConfig(preview),
     events: [],
+    hoveredEventId: null,
+    selectedEventId: null,
   };
 }
 
@@ -54,7 +57,6 @@ export function reduceTimeline(state, action) {
       const snapshot = action.snapshot;
       if (!validSnapshot(snapshot)) return state;
 
-      const previousPaused = state.runtime?.paused ?? false;
       const recorded = { lo: snapshot.lo, hi: snapshot.hi };
       let viewport = state.viewport;
 
@@ -66,30 +68,65 @@ export function reduceTimeline(state, action) {
       if (snapshot.paused) {
         // Pause captures the viewport exactly once. Subsequent history/config /
         // selection updates cannot resize it.
-        if (!previousPaused || !viewport) viewport = recorded;
-      } else if (state.followLive || !viewport) {
+        if (!viewport) viewport = recorded;
+      } else {
         viewport = recorded;
       }
 
       const acknowledged =
         state.requestedFrame !== null && snapshot.frame === state.requestedFrame;
       const requestedFrame = acknowledged ? null : state.requestedFrame;
+      const requestedSeekId = acknowledged ? null : state.requestedSeekId;
       const selectedFrame = requestedFrame ?? snapshot.frame;
 
       return {
         ...state,
         runtime: snapshot,
+        recordingAvailable: true,
         viewport,
         requestedFrame,
+        requestedSeekId,
         selectedFrame,
       };
     }
 
     case "seek-requested": {
-      if (!state.viewport || !Number.isFinite(action.frame)) return state;
-      const frame = Math.round(clamp(action.frame, state.viewport.lo, state.viewport.hi));
-      return { ...state, selectedFrame: frame, requestedFrame: frame };
+      if (
+        !state.recordingAvailable ||
+        !state.viewport ||
+        !state.runtime ||
+        !Number.isFinite(action.frame)
+      ) {
+        return state;
+      }
+      const lo = Math.max(state.viewport.lo, state.runtime.lo);
+      const hi = Math.min(state.viewport.hi, state.runtime.hi);
+      if (hi < lo) return state;
+      const frame = Math.round(clamp(action.frame, lo, hi));
+      return {
+        ...state,
+        selectedFrame: frame,
+        requestedFrame: frame,
+        requestedSeekId: action.id ?? null,
+      };
     }
+
+    case "seek-resolved":
+      if (
+        state.requestedSeekId === null ||
+        action.id !== state.requestedSeekId
+      ) {
+        return state;
+      }
+      return {
+        ...state,
+        selectedFrame: finiteOr(action.frame, state.runtime?.frame ?? state.selectedFrame),
+        requestedFrame: null,
+        requestedSeekId: null,
+      };
+
+    case "recording-cleared":
+      return state.runtime ? { ...state, recordingAvailable: false } : state;
 
     case "preview-changed":
       return {
@@ -102,6 +139,12 @@ export function reduceTimeline(state, action) {
         ...state,
         events: Array.isArray(action.events) ? action.events : state.events,
       };
+
+    case "event-hovered":
+      return { ...state, hoveredEventId: action.id ?? null };
+
+    case "event-selected":
+      return { ...state, selectedEventId: action.id ?? null };
 
     case "preview-end-requested": {
       if (state.selectedFrame === null || !Number.isFinite(action.frame)) return state;
@@ -118,18 +161,6 @@ export function reduceTimeline(state, action) {
       return {
         ...state,
         preview: normalizePreviewConfig({ seconds }, state.preview),
-      };
-    }
-
-    case "follow-live-changed":
-      return { ...state, followLive: Boolean(action.enabled) };
-
-    case "viewport-changed": {
-      if (!validSnapshot({ frame: action.lo, lo: action.lo, hi: action.hi })) return state;
-      return {
-        ...state,
-        viewport: { lo: action.lo, hi: action.hi },
-        followLive: false,
       };
     }
 
@@ -151,29 +182,51 @@ export function unitToFrame(unit, viewport) {
 export function deriveTimelineView(state) {
   if (!state.runtime || !state.viewport || state.selectedFrame === null) return null;
 
-  const selectedFrame = Math.round(
-    clamp(state.selectedFrame, state.viewport.lo, state.viewport.hi)
-  );
+  // The logical frame may move beyond a deliberately frozen paused viewport
+  // after Step. Keep that truth in labels/ARIA and clamp only its coordinate.
+  const selectedFrame = Math.round(state.selectedFrame);
+  const visibleSelectedFrame = clamp(selectedFrame, state.viewport.lo, state.viewport.hi);
   const previewFrames = state.preview.enabled
     ? Math.round(state.preview.seconds * TIMELINE_FPS)
     : 0;
   const previewEndFrame = selectedFrame + previewFrames;
-  const visiblePreviewEndFrame = Math.min(previewEndFrame, state.viewport.hi);
+  const visiblePreviewEndFrame = clamp(
+    previewEndFrame,
+    state.viewport.lo,
+    state.viewport.hi
+  );
   const eventMarkers = clusterTimelineEvents(state.events, state.viewport);
+  const recordedStartFrame = state.recordingAvailable
+    ? clamp(state.runtime.lo, state.viewport.lo, state.viewport.hi)
+    : state.viewport.lo;
+  const recordedEndFrame = state.recordingAvailable
+    ? clamp(state.runtime.hi, state.viewport.lo, state.viewport.hi)
+    : state.viewport.lo;
+  const activeEventId = state.hoveredEventId ?? state.selectedEventId;
+  const activeEvent = eventMarkers.find((marker) => marker.id === activeEventId) ?? null;
 
   return {
     viewport: state.viewport,
     recorded: { lo: state.runtime.lo, hi: state.runtime.hi },
+    recordingAvailable: state.recordingAvailable,
+    recordedStartUnit: frameToUnit(recordedStartFrame, state.viewport),
+    recordedEndUnit: frameToUnit(recordedEndFrame, state.viewport),
     paused: state.runtime.paused,
     selectedFrame,
+    visibleSelectedFrame,
     requestedFrame: state.requestedFrame,
     playheadUnit: frameToUnit(selectedFrame, state.viewport),
+    playheadClippedBefore: selectedFrame < state.viewport.lo,
+    playheadClippedAfter: selectedFrame > state.viewport.hi,
     previewFrames,
     previewEndFrame,
     visiblePreviewEndFrame,
     previewEndUnit: frameToUnit(visiblePreviewEndFrame, state.viewport),
     previewClippedFrames: Math.max(previewEndFrame - state.viewport.hi, 0),
     eventMarkers,
+    activeEvent,
+    selectedEventId: state.selectedEventId,
+    hoveredEventId: state.hoveredEventId,
   };
 }
 

--- a/runtime/functor-runtime-web/timeline-model.js
+++ b/runtime/functor-runtime-web/timeline-model.js
@@ -35,6 +35,7 @@ export function createTimelineState(preview = {}) {
     requestedFrame: null,
     followLive: true,
     preview: normalizePreviewConfig(preview),
+    events: [],
   };
 }
 
@@ -96,6 +97,12 @@ export function reduceTimeline(state, action) {
         preview: normalizePreviewConfig(action.preview, state.preview),
       };
 
+    case "events-published":
+      return {
+        ...state,
+        events: Array.isArray(action.events) ? action.events : state.events,
+      };
+
     case "preview-end-requested": {
       if (state.selectedFrame === null || !Number.isFinite(action.frame)) return state;
       const seconds = (action.frame - state.selectedFrame) / TIMELINE_FPS;
@@ -152,6 +159,7 @@ export function deriveTimelineView(state) {
     : 0;
   const previewEndFrame = selectedFrame + previewFrames;
   const visiblePreviewEndFrame = Math.min(previewEndFrame, state.viewport.hi);
+  const eventMarkers = clusterTimelineEvents(state.events, state.viewport);
 
   return {
     viewport: state.viewport,
@@ -165,5 +173,37 @@ export function deriveTimelineView(state) {
     visiblePreviewEndFrame,
     previewEndUnit: frameToUnit(visiblePreviewEndFrame, state.viewport),
     previewClippedFrames: Math.max(previewEndFrame - state.viewport.hi, 0),
+    eventMarkers,
   };
+}
+
+export function clusterTimelineEvents(events, viewport, bucketCount = 250) {
+  if (!viewport || viewport.hi < viewport.lo) return [];
+  const buckets = new Map();
+  for (const event of events) {
+    if (!event || !Number.isFinite(event.frame)) continue;
+    if (event.frame < viewport.lo || event.frame > viewport.hi) continue;
+    const category = String(event.kind).startsWith("reload") ? "reload" : "input";
+    const unit = frameToUnit(event.frame, viewport);
+    const bucket = Math.round(unit * bucketCount);
+    const key = `${category}:${bucket}`;
+    const existing = buckets.get(key);
+    if (existing) {
+      existing.count += 1;
+      existing.lastFrame = event.frame;
+      existing.labels.push(event.label);
+    } else {
+      buckets.set(key, {
+        id: event.id,
+        frame: event.frame,
+        lastFrame: event.frame,
+        kind: event.kind,
+        category,
+        count: 1,
+        labels: [event.label],
+        unit,
+      });
+    }
+  }
+  return [...buckets.values()].sort((a, b) => a.frame - b.frame);
 }

--- a/runtime/functor-runtime-web/timeline-model.js
+++ b/runtime/functor-runtime-web/timeline-model.js
@@ -1,0 +1,169 @@
+// Pure state and geometry for the web time-travel timeline. The DOM component
+// dispatches semantic actions and renders the derived view; it never owns the
+// timeline policy itself. Keeping this file browser-free makes the pause/seek /
+// extrapolation invariants cheap to test under Node.
+
+export const TIMELINE_FPS = 60;
+export const PREVIEW_SECONDS_MIN = 0.5;
+export const PREVIEW_SECONDS_MAX = 5;
+export const PREVIEW_RATE_MIN = 1;
+export const PREVIEW_RATE_MAX = 30;
+
+const clamp = (value, lo, hi) => Math.min(hi, Math.max(lo, value));
+const finiteOr = (value, fallback) =>
+  typeof value === "number" && Number.isFinite(value) ? value : fallback;
+
+export function normalizePreviewConfig(next = {}, previous = { seconds: 2, rate: 5 }) {
+  return {
+    enabled: next.enabled ?? previous.enabled ?? false,
+    seconds: clamp(
+      finiteOr(next.seconds, previous.seconds),
+      PREVIEW_SECONDS_MIN,
+      PREVIEW_SECONDS_MAX
+    ),
+    rate: Math.round(
+      clamp(finiteOr(next.rate, previous.rate), PREVIEW_RATE_MIN, PREVIEW_RATE_MAX)
+    ),
+  };
+}
+
+export function createTimelineState(preview = {}) {
+  return {
+    runtime: null,
+    viewport: null,
+    selectedFrame: null,
+    requestedFrame: null,
+    followLive: true,
+    preview: normalizePreviewConfig(preview),
+  };
+}
+
+const validSnapshot = (snapshot) =>
+  snapshot &&
+  Number.isFinite(snapshot.frame) &&
+  Number.isFinite(snapshot.lo) &&
+  Number.isFinite(snapshot.hi) &&
+  snapshot.hi >= snapshot.lo;
+
+const rangesOverlap = (a, b) => a && b && a.hi >= b.lo && b.hi >= a.lo;
+
+export function reduceTimeline(state, action) {
+  switch (action.type) {
+    case "runtime-published": {
+      const snapshot = action.snapshot;
+      if (!validSnapshot(snapshot)) return state;
+
+      const previousPaused = state.runtime?.paused ?? false;
+      const recorded = { lo: snapshot.lo, hi: snapshot.hi };
+      let viewport = state.viewport;
+
+      // A reload resets the seekable model-history window around a new monotonic
+      // frame. If the old viewport no longer intersects it, the new recording is
+      // the only honest domain.
+      if (!rangesOverlap(viewport, recorded)) viewport = recorded;
+
+      if (snapshot.paused) {
+        // Pause captures the viewport exactly once. Subsequent history/config /
+        // selection updates cannot resize it.
+        if (!previousPaused || !viewport) viewport = recorded;
+      } else if (state.followLive || !viewport) {
+        viewport = recorded;
+      }
+
+      const acknowledged =
+        state.requestedFrame !== null && snapshot.frame === state.requestedFrame;
+      const requestedFrame = acknowledged ? null : state.requestedFrame;
+      const selectedFrame = requestedFrame ?? snapshot.frame;
+
+      return {
+        ...state,
+        runtime: snapshot,
+        viewport,
+        requestedFrame,
+        selectedFrame,
+      };
+    }
+
+    case "seek-requested": {
+      if (!state.viewport || !Number.isFinite(action.frame)) return state;
+      const frame = Math.round(clamp(action.frame, state.viewport.lo, state.viewport.hi));
+      return { ...state, selectedFrame: frame, requestedFrame: frame };
+    }
+
+    case "preview-changed":
+      return {
+        ...state,
+        preview: normalizePreviewConfig(action.preview, state.preview),
+      };
+
+    case "preview-end-requested": {
+      if (state.selectedFrame === null || !Number.isFinite(action.frame)) return state;
+      const seconds = (action.frame - state.selectedFrame) / TIMELINE_FPS;
+      return {
+        ...state,
+        preview: normalizePreviewConfig({ seconds }, state.preview),
+      };
+    }
+
+    case "preview-delta-requested": {
+      if (!Number.isFinite(action.frames)) return state;
+      const seconds = state.preview.seconds + action.frames / TIMELINE_FPS;
+      return {
+        ...state,
+        preview: normalizePreviewConfig({ seconds }, state.preview),
+      };
+    }
+
+    case "follow-live-changed":
+      return { ...state, followLive: Boolean(action.enabled) };
+
+    case "viewport-changed": {
+      if (!validSnapshot({ frame: action.lo, lo: action.lo, hi: action.hi })) return state;
+      return {
+        ...state,
+        viewport: { lo: action.lo, hi: action.hi },
+        followLive: false,
+      };
+    }
+
+    default:
+      return state;
+  }
+}
+
+export function frameToUnit(frame, viewport) {
+  if (!viewport || viewport.hi <= viewport.lo) return 0;
+  return clamp((frame - viewport.lo) / (viewport.hi - viewport.lo), 0, 1);
+}
+
+export function unitToFrame(unit, viewport) {
+  if (!viewport) return 0;
+  return Math.round(viewport.lo + clamp(unit, 0, 1) * (viewport.hi - viewport.lo));
+}
+
+export function deriveTimelineView(state) {
+  if (!state.runtime || !state.viewport || state.selectedFrame === null) return null;
+
+  const selectedFrame = Math.round(
+    clamp(state.selectedFrame, state.viewport.lo, state.viewport.hi)
+  );
+  const previewFrames = state.preview.enabled
+    ? Math.round(state.preview.seconds * TIMELINE_FPS)
+    : 0;
+  const previewEndFrame = selectedFrame + previewFrames;
+  const visiblePreviewEndFrame = Math.min(previewEndFrame, state.viewport.hi);
+
+  return {
+    viewport: state.viewport,
+    recorded: { lo: state.runtime.lo, hi: state.runtime.hi },
+    paused: state.runtime.paused,
+    selectedFrame,
+    requestedFrame: state.requestedFrame,
+    playheadUnit: frameToUnit(selectedFrame, state.viewport),
+    previewFrames,
+    previewEndFrame,
+    visiblePreviewEndFrame,
+    previewEndUnit: frameToUnit(visiblePreviewEndFrame, state.viewport),
+    previewClippedFrames: Math.max(previewEndFrame - state.viewport.hi, 0),
+  };
+}

--- a/runtime/functor-runtime-web/timeline-model.test.js
+++ b/runtime/functor-runtime-web/timeline-model.test.js
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  createTimelineState,
+  deriveTimelineView,
+  normalizePreviewConfig,
+  reduceTimeline,
+} from "./timeline-model.js";
+
+const publish = (state, frame, hi, paused, lo = 0) =>
+  reduceTimeline(state, {
+    type: "runtime-published",
+    snapshot: { frame, lo, hi, paused },
+  });
+
+test("live playback keeps the selected frame at the recorded endpoint", () => {
+  let state = publish(createTimelineState(), 10, 10, false);
+  state = publish(state, 11, 11, false);
+  const view = deriveTimelineView(state);
+  assert.equal(view.selectedFrame, 11);
+  assert.equal(view.viewport.hi, 11);
+  assert.equal(view.playheadUnit, 1);
+});
+
+test("pausing captures a viewport that preview changes cannot resize", () => {
+  let state = publish(createTimelineState(), 300, 300, false);
+  state = publish(state, 300, 300, true);
+  state = reduceTimeline(state, {
+    type: "preview-changed",
+    preview: { enabled: true, seconds: 5 },
+  });
+  state = publish(state, 301, 301, true);
+  assert.deepEqual(deriveTimelineView(state).viewport, { lo: 0, hi: 300 });
+});
+
+test("seeking changes selection without changing the paused viewport", () => {
+  let state = publish(createTimelineState({ enabled: true, seconds: 2 }), 300, 300, true);
+  state = reduceTimeline(state, { type: "seek-requested", frame: 250 });
+  const view = deriveTimelineView(state);
+  assert.equal(view.selectedFrame, 250);
+  assert.deepEqual(view.viewport, { lo: 0, hi: 300 });
+});
+
+test("the logical preview remains full length while its rendering clips", () => {
+  let state = publish(createTimelineState({ enabled: true, seconds: 2 }), 300, 300, true);
+  state = reduceTimeline(state, { type: "seek-requested", frame: 250 });
+  const view = deriveTimelineView(state);
+  assert.equal(view.previewFrames, 120);
+  assert.equal(view.previewEndFrame, 370);
+  assert.equal(view.visiblePreviewEndFrame, 300);
+  assert.equal(view.previewClippedFrames, 70);
+});
+
+test("an optimistic seek is held until the runtime acknowledges it", () => {
+  let state = publish(createTimelineState(), 100, 200, true);
+  state = reduceTimeline(state, { type: "seek-requested", frame: 150 });
+  state = publish(state, 100, 200, true);
+  assert.equal(deriveTimelineView(state).selectedFrame, 150);
+  state = publish(state, 150, 200, true);
+  assert.equal(state.requestedFrame, null);
+  assert.equal(deriveTimelineView(state).selectedFrame, 150);
+});
+
+test("invalid preview edits retain the previous canonical configuration", () => {
+  const previous = { enabled: true, seconds: 2, rate: 5 };
+  assert.deepEqual(normalizePreviewConfig({ seconds: NaN, rate: NaN }, previous), previous);
+  assert.deepEqual(normalizePreviewConfig({ seconds: 99, rate: -4 }, previous), {
+    enabled: true,
+    seconds: 5,
+    rate: 1,
+  });
+});
+
+test("resuming returns the viewport to the live recorded extent", () => {
+  let state = publish(createTimelineState(), 200, 200, true);
+  state = publish(state, 200, 240, true);
+  assert.equal(deriveTimelineView(state).viewport.hi, 200);
+  state = publish(state, 241, 241, false);
+  assert.equal(deriveTimelineView(state).viewport.hi, 241);
+});

--- a/runtime/functor-runtime-web/timeline-model.test.js
+++ b/runtime/functor-runtime-web/timeline-model.test.js
@@ -54,12 +54,23 @@ test("the logical preview remains full length while its rendering clips", () => 
 
 test("an optimistic seek is held until the runtime acknowledges it", () => {
   let state = publish(createTimelineState(), 100, 200, true);
-  state = reduceTimeline(state, { type: "seek-requested", frame: 150 });
+  state = reduceTimeline(state, { type: "seek-requested", id: 1, frame: 150 });
   state = publish(state, 100, 200, true);
   assert.equal(deriveTimelineView(state).selectedFrame, 150);
   state = publish(state, 150, 200, true);
   assert.equal(state.requestedFrame, null);
+  assert.equal(state.requestedSeekId, null);
   assert.equal(deriveTimelineView(state).selectedFrame, 150);
+});
+
+test("a resolved seek reconciles a clamped or refused optimistic target", () => {
+  let state = publish(createTimelineState(), 100, 200, true);
+  state = reduceTimeline(state, { type: "seek-requested", id: 7, frame: 150 });
+  state = reduceTimeline(state, { type: "seek-resolved", id: 6, frame: 100 });
+  assert.equal(deriveTimelineView(state).selectedFrame, 150, "ignore an older result");
+  state = reduceTimeline(state, { type: "seek-resolved", id: 7, frame: 100 });
+  assert.equal(state.requestedFrame, null);
+  assert.equal(deriveTimelineView(state).selectedFrame, 100);
 });
 
 test("invalid preview edits retain the previous canonical configuration", () => {
@@ -94,4 +105,54 @@ test("timeline events are filtered and clustered within the viewport", () => {
   assert.equal(markers[0].category, "input");
   assert.equal(markers[0].count, 2);
   assert.equal(markers[1].category, "reload");
+});
+
+test("stepping past a frozen paused endpoint preserves the logical selected frame", () => {
+  let state = publish(createTimelineState(), 300, 300, false);
+  state = publish(state, 300, 300, true);
+  state = publish(state, 301, 301, true);
+  const view = deriveTimelineView(state);
+  assert.deepEqual(view.viewport, { lo: 0, hi: 300 });
+  assert.equal(view.selectedFrame, 301);
+  assert.equal(view.playheadUnit, 1);
+  assert.equal(view.playheadClippedAfter, true);
+});
+
+test("a shortened branch paints only the still-recorded part of a frozen viewport", () => {
+  let state = publish(createTimelineState(), 300, 300, true);
+  state = reduceTimeline(state, { type: "seek-requested", id: 1, frame: 150 });
+  state = reduceTimeline(state, { type: "seek-resolved", id: 1, frame: 150 });
+  state = publish(state, 151, 151, true);
+  const view = deriveTimelineView(state);
+  assert.deepEqual(view.viewport, { lo: 0, hi: 300 });
+  assert.equal(view.recordedStartUnit, 0);
+  assert.equal(view.recordedEndUnit, 151 / 300);
+});
+
+test("clearing recording keeps the frozen transport view but disables seeking", () => {
+  let state = publish(createTimelineState(), 300, 300, true);
+  state = reduceTimeline(state, { type: "recording-cleared" });
+  state = reduceTimeline(state, { type: "seek-requested", id: 1, frame: 100 });
+  const view = deriveTimelineView(state);
+  assert.equal(view.recordingAvailable, false);
+  assert.equal(view.recordedStartUnit, 0);
+  assert.equal(view.recordedEndUnit, 0);
+  assert.equal(state.requestedFrame, null);
+});
+
+test("hover takes precedence over persistent marker selection", () => {
+  let state = publish(createTimelineState(), 100, 100, true);
+  state = reduceTimeline(state, {
+    type: "events-published",
+    events: [
+      { id: 1, frame: 20, kind: "key-down", label: "Space down" },
+      { id: 2, frame: 80, kind: "reload-ok", label: "hot reload" },
+    ],
+  });
+  state = reduceTimeline(state, { type: "event-selected", id: 1 });
+  assert.equal(deriveTimelineView(state).activeEvent.id, 1);
+  state = reduceTimeline(state, { type: "event-hovered", id: 2 });
+  assert.equal(deriveTimelineView(state).activeEvent.id, 2);
+  state = reduceTimeline(state, { type: "event-hovered", id: null });
+  assert.equal(deriveTimelineView(state).activeEvent.id, 1);
 });

--- a/runtime/functor-runtime-web/timeline-model.test.js
+++ b/runtime/functor-runtime-web/timeline-model.test.js
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  clusterTimelineEvents,
   createTimelineState,
   deriveTimelineView,
   normalizePreviewConfig,
@@ -77,4 +78,20 @@ test("resuming returns the viewport to the live recorded extent", () => {
   assert.equal(deriveTimelineView(state).viewport.hi, 200);
   state = publish(state, 241, 241, false);
   assert.equal(deriveTimelineView(state).viewport.hi, 241);
+});
+
+test("timeline events are filtered and clustered within the viewport", () => {
+  const markers = clusterTimelineEvents(
+    [
+      { id: 1, frame: 9, kind: "key-down", label: "Space down" },
+      { id: 2, frame: 20, kind: "key-down", label: "W down" },
+      { id: 3, frame: 20, kind: "key-up", label: "W up" },
+      { id: 4, frame: 80, kind: "reload-ok", label: "hot reload" },
+    ],
+    { lo: 10, hi: 100 }
+  );
+  assert.equal(markers.length, 2);
+  assert.equal(markers[0].category, "input");
+  assert.equal(markers[0].count, 2);
+  assert.equal(markers[1].category, "reload");
 });

--- a/site/build.mjs
+++ b/site/build.mjs
@@ -23,6 +23,7 @@ const PKG_FILES = ["functor_runtime_web.js", "functor_runtime_web_bg.wasm"];
 // The shared time-travel scrubber, imported by player.html (served next to it,
 // like pkg/). Single source in the runtime crate — copied, never duplicated.
 const SCRUBBER = `${root}runtime/functor-runtime-web/scrubber.js`;
+const TIMELINE_MODEL = `${root}runtime/functor-runtime-web/timeline-model.js`;
 
 // The editor's in-browser language intelligence (diagnostics/hover), a separate
 // small wasm bundle built by `npm run build:lang-wasm`. Optional: the site must
@@ -62,6 +63,7 @@ for (const file of PKG_FILES) {
   await cp(`${PKG}/${file}`, `${dist}/pkg/${file}`);
 }
 await cp(SCRUBBER, `${dist}/scrubber.js`);
+await cp(TIMELINE_MODEL, `${dist}/timeline-model.js`);
 for (const [name, path] of Object.entries(EXAMPLES)) {
   await cp(path, `${dist}/examples/${name}.fun`);
 }


### PR DESCRIPTION
## Summary

Reworks the web time-travel scrubber around a small functional state/geometry core and a custom, accessible two-handle timeline.

- keeps the live playhead pinned cleanly to the recorded endpoint
- freezes the paused viewport/end frame while selection, stepping, and extrapolation continue logically
- clips off-viewport extrapolation without changing the configured preview window
- preserves independent playhead and extrapolation endpoint handles, including when the endpoint is fully clipped
- renders recorded input and hot-reload markers with hover, keyboard selection, and seek
- uses explicit seek acknowledgements and revision-gated marker transfer across the WASM bridge

The custom SVG/DOM control also gives us a straightforward path for richer timeline rendering without rebuilding state policy inside event handlers.

## Commit stack

1. `refactor(web): extract timeline state and geometry core`
2. `feat(web): replace scrubber with accessible two-handle timeline`
3. `feat(web): render recorded input and reload markers`
4. `feat(web): add timeline inspection and viewport controls`

## Verification

- `npm run test:scrubber` (13 functional-core tests)
- `npm run test:site` (full browser sandbox suite; optional language-WASM checks skipped when that package is absent)
- `npm run build:cli`
- `cargo test -p functor_runtime_common`
- `cargo test -p functor-cli`
- `git diff --check main...HEAD`

## Visuals

### Before → after

![Before and after timeline scrubber comparison](https://gist.githubusercontent.com/tommy-xr/03751e5dc304e366e64521a21ddd38c0/raw/before-after.png)

<sub>Same 1200×700 headless-browser viewport and comparable recorded span. The new control keeps the paused domain fixed, separates the solid cyan playhead from the pink extrapolation endpoint, clips the logical future at the rail edge, and exposes real reload/input markers with hover detail.</sub>

### Interaction

![Custom timeline seek, preview endpoint, and marker interaction](https://gist.githubusercontent.com/tommy-xr/03751e5dc304e366e64521a21ddd38c0/raw/timeline-interaction.gif)

<sub>Paused seek and preview-window resizing over a frozen domain, followed by marker inspection. Captured with Playwright because the timeline is DOM/SVG rather than part of the native framebuffer.</sub>
