### PR TITLE
fix: keep time-travel history stable across hot reloads

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -702,9 +702,16 @@ plain data (the usual constant-tweak case), so old frames are immediately
 rewindable under the new program. These are old data snapshots interpreted by
 new code, not a retroactive replay: draw-only tweaks affect every retained
 frame, while `tick` changes affect evolution after resume. A history containing
-a callable or opaque host value starts a new seekable generation at the same
-frame instead; older frames remain visible as unavailable rather than silently
-implying they are safe to restore.
+a callable or opaque host value makes the selected frame a reload boundary. An
+unsafe discarded future is dropped while a remaining plain-data prefix stays
+seekable; if the retained prefix is also unsafe, a new one-frame generation
+starts at the selected frame. Unavailable frames remain visible as stripes
+rather than silently implying they are safe to restore.
+When the retained history and authoritative live model are entirely reload-safe
+plain data, pausing on an earlier frame and reloading keeps the selected cursor
+and the entire recorded future. Resume remains the explicit branch point: it
+discards that future, while the scrubber holds its prior visual span until the
+new branch fills it.
 Closures **stored in the model** rebind too: they adopt the edited code
 with their captured values carried over (matched by the enclosing def's
 name; a closure whose def was renamed/deleted keeps its old body with a

--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -697,10 +697,19 @@ The model shows live at the
 debug server's `GET /state`. **Hot reload is on by default**: saving the
 `.fun` file reloads it in ~1 frame with the model preserved (a broken edit
 keeps the old program running; an edited `init` takes effect on restart).
+The time-travel history also survives the reload when every retained model is
+plain data (the usual constant-tweak case), so old frames are immediately
+rewindable under the new program. These are old data snapshots interpreted by
+new code, not a retroactive replay: draw-only tweaks affect every retained
+frame, while `tick` changes affect evolution after resume. A history containing
+a callable or opaque host value starts a new seekable generation at the same
+frame instead; older frames remain visible as unavailable rather than silently
+implying they are safe to restore.
 Closures **stored in the model** rebind too: they adopt the edited code
 with their captured values carried over (matched by the enclosing def's
 name; a closure whose def was renamed/deleted keeps its old body with a
-loud `[functor-lang] reload:` warning).
+loud `[functor-lang] reload:` warning). First-class variant constructors
+stored in the model likewise adopt the edited declaration's arity.
 
 Transforms wrap in Group nodes: the **outer call applies last in world
 space** — `s |> Scene.rotateY(r) |> Scene.translate(x, 0.0, 0.0)` rotates in

--- a/docs/time-travel.md
+++ b/docs/time-travel.md
@@ -45,13 +45,20 @@ on both the desktop runner and the web/VSCode preview. Exercised by
 - **Reload is conditionally a history boundary.** Plain-data model snapshots
   carry no module IR, so their coupled model/physics/time history remains
   seekable under the new program — the common constant-tweak workflow keeps its
-  full rewind window. If any retained model contains a callable or opaque host
-  value, the old generation cannot safely cross the edit: the rebound live scene
-  seeds a new seekable generation at the same frame and the UI marks older
-  frames as unavailable. Preserved snapshots are **new code over old data**, not
+  full rewind window. Before swapping code, a scrubbed reload whose history
+  contains a callable or opaque host value commits the selected frame as a
+  conservative boundary. If the unsafe values existed only in the discarded
+  future, the remaining plain-data prefix stays seekable; if an unsafe value
+  remains at or before the selected frame, the rebound live scene seeds a new
+  one-frame generation there and the UI marks the rest unavailable. Preserved
+  snapshots are **new code over old data**, not
   a replay: a draw-only constant changes the whole retained past immediately,
   while a constant used by `tick` changes state evolution only after playback
-  resumes.
+  resumes. When the retained history and authoritative live model are entirely
+  reload-safe plain data, reloading while scrubbed is non-destructive: the
+  selected frame and recorded future both remain seekable. Resume is still the
+  explicit branch point that discards that future, while the slider keeps its
+  prior visual span as the new branch fills it.
   "Rewind shows the earlier *code* version" (the harder frontier
   where code-bearing snapshots retain or replay old code) remains deferred.
 - **`tts` is a game clock, not a wall clock.** Both shells own a shared
@@ -324,6 +331,45 @@ them with weights. Fork+overlay is K=2 at (0.5, 0.5) from two branches; ghosting
 is K=N at `1/N` from one branch stepped forward. Build the compositor once and
 both land; the old polyline/trail primitive becomes an optional later "precise
 single-path read," not a prerequisite.
+
+## Deferred follow-ups: keep and reconstruct the old future
+
+Today's stripe after Resume has a specific meaning: the selected frame became a
+branch point, so the old suffix is no longer part of the authoritative run. The
+slider keeps its old scale while new cyan history replaces that suffix, but the
+old suffix itself is discarded. Two follow-ups can turn that honest placeholder
+into a more powerful authoring tool:
+
+1. **Persistent forks / ghost history (T5).** Instead of truncating the old
+   suffix, retain it as an immutable alternative branch identified by its fork
+   frame and code generation. Keep one branch authoritative, render alternatives
+   dimmed or as ghosts, and let the user inspect, compare, switch to, or delete a
+   branch explicitly. The ordinary linear scrubber should remain simple; branch
+   controls appear only after a fork exists.
+2. **Full event and effect record/replay (T7–T8).** Extend the frame log beyond
+   keyboard/pointer input to include every non-reproducible inbound value and
+   every outbound effect: subscription deliveries, HTTP/WebSocket requests and
+   responses, audio commands/completions, random/time results, and physics query
+   results. Replay supplies recorded inbound results and suppresses real outbound
+   work, so scrubbing or rebuilding history never repeats a purchase, request,
+   message, or sound.
+
+Together these enable **reconstruction under edited code**: restore a keyframe
+(or `init`), replay recorded inputs and effect results through the new program,
+and retain the former run as a comparison branch. Same-code replay can consume
+results positionally. Replay after an edit must match effects by stable identity
+and place a visible divergence marker when the new program asks for a result the
+log cannot supply; it must never silently fall back to performing the live
+effect. Replaying literally from frame zero additionally requires retaining the
+initial model/code revision and all environmental inputs, so keyframe-based
+reconstruction is the incremental first step.
+
+The functional core should expose branch/event-log transitions as pure data and
+tests; shells own persistence, actual effect execution, branch selection, and
+the overlay/compositor. Required headless tests are: no duplicate side effects,
+byte-identical same-code replay, deterministic branch reconstruction from a
+keyframe, explicit divergence under a changed effect stream, and bounded branch
+retention.
 
 ## LLM-native angle
 

--- a/docs/time-travel.md
+++ b/docs/time-travel.md
@@ -42,11 +42,18 @@ on both the desktop runner and the web/VSCode preview. Exercised by
   `world_frame_history` maps each rendered frame to the fixed frame the world
   ended at. The master clock is the **rendered frame** (every game has one, even
   with no physics hook).
-- **Reload is a history boundary.** Snapshots can hold closures bound to the old
-  module, so the rings reset on hot-reload (the live model is rebound; snapshots
-  are not). "Rewind shows the earlier *code* version" (the hard frontier from the
-  prior-art notes) is deferred — the interpreter *could* do it by keeping old
-  modules alive, but that's future work.
+- **Reload is conditionally a history boundary.** Plain-data model snapshots
+  carry no module IR, so their coupled model/physics/time history remains
+  seekable under the new program — the common constant-tweak workflow keeps its
+  full rewind window. If any retained model contains a callable or opaque host
+  value, the old generation cannot safely cross the edit: the rebound live scene
+  seeds a new seekable generation at the same frame and the UI marks older
+  frames as unavailable. Preserved snapshots are **new code over old data**, not
+  a replay: a draw-only constant changes the whole retained past immediately,
+  while a constant used by `tick` changes state evolution only after playback
+  resumes.
+  "Rewind shows the earlier *code* version" (the harder frontier
+  where code-bearing snapshots retain or replay old code) remains deferred.
 - **`tts` is a game clock, not a wall clock.** Both shells own a shared
   `GameClock` (`functor_runtime_common::game_clock`) that produces each frame's
   `FrameTime`. Live, it ACCUMULATES the real frame delta (`game_time += dts`);
@@ -248,7 +255,7 @@ Seeding RNG is what moves it from the record column to the recompute column (the
 seed becomes one more plain-data timeline entry). **Direction is the whole rule:**
 inputs and effect *responses* are inbound and get replayed; effects are outbound
 and get suppressed. Because the log is plain data it **survives a hot reload**,
-even though the model snapshots (old-module closures) do not — which is exactly
+even though code-bearing model snapshots do not — which is exactly
 what lets "tweak a constant, replay my recorded inputs, see if the jump now
 clears the chasm" work.
 

--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -670,19 +670,23 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
     branchMarkersAreAuthoritative
   );
 
-  // A successful reload while scrubbed keeps the selected frame as the visible
-  // boundary. This plain-data model retains its pre-reload branch history.
+  // A safe reload while scrubbed is non-destructive: it keeps the selected
+  // cursor AND the complete recorded future. Step/Resume branches later.
   await player.waitForFunction(() => !window.__scrub.paused(), { timeout: 3000 });
   await player.waitForFunction(() => {
     const range = window.__scrub.range();
     return range.length === 2 && range[1] - range[0] >= 4;
   });
-  const reloadWhileScrubbed = await player.evaluate(() => ({
-    hi: window.__scrub.range()[1],
-    lastId: Math.max(-1, ...window.__scrub.events().map((event) => event.id)),
-  }));
   await player.evaluate(() => window.__scrub.togglePause());
   await player.waitForFunction(() => window.__scrub.paused(), { timeout: 3000 });
+  // Capture the domain only after Pause has taken effect. Frames can still be
+  // published between the earlier running-state probe and this boundary.
+  const reloadWhileScrubbed = await player.evaluate(() => ({
+    hi: window.__scrub.range()[1],
+    viewportHi: window.__scrub.view().viewport.hi,
+    hadUnavailableHistory: window.__scrub.view().hasUnavailableHistory,
+    lastId: Math.max(-1, ...window.__scrub.events().map((event) => event.id)),
+  }));
   await player.evaluate((hi) => window.__scrub.seek(hi - 2), reloadWhileScrubbed.hi);
   await player.waitForFunction(
     (hi) => window.__scrub.frame() === hi - 2,
@@ -720,12 +724,12 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
   check("reload boundary keeps the visible Step/Resume transport", reloadTransportIsVisible);
   const safeReloadView = await player.evaluate(() => window.__scrub.view());
   check(
-    "paused plain-data reload keeps its selected frame and retained past",
+    "paused plain-data reload keeps its selected frame and complete future",
     safeReloadView.selectedFrame === selectedBeforeReload &&
       safeReloadView.recorded.lo < selectedBeforeReload &&
-      safeReloadView.recorded.hi === selectedBeforeReload &&
-      safeReloadView.unavailableEndUnit === 0 &&
-      safeReloadView.unavailableAfterStartUnit < 1,
+      safeReloadView.recorded.hi === reloadWhileScrubbed.hi &&
+      safeReloadView.viewport.hi === reloadWhileScrubbed.viewportHi &&
+      safeReloadView.hasUnavailableHistory === reloadWhileScrubbed.hadUnavailableHistory,
     JSON.stringify(safeReloadView)
   );
   await player.locator("#scrub-step").click();
@@ -734,12 +738,15 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
     paused: window.__scrub.paused(),
     frame: window.__scrub.frame(),
     range: window.__scrub.range(),
+    view: window.__scrub.view(),
   }));
   check(
-    "stepping after a scrubbed reload records its boundary",
-    postReloadStep.range.length === 2 &&
-      postReloadStep.range[0] <= scrubbedReloadMarker.frame &&
-      scrubbedReloadMarker.frame <= postReloadStep.range[1],
+    "stepping after a safe reload branches without shrinking the visual total",
+      postReloadStep.range.length === 2 &&
+      postReloadStep.range[1] === selectedBeforeReload + 1 &&
+      postReloadStep.view.viewport.hi === reloadWhileScrubbed.viewportHi &&
+      postReloadStep.view.hasUnavailableHistory &&
+      postReloadStep.view.unavailableAfterStartUnit < 1,
     JSON.stringify({ postReloadStep, scrubConsole: scrubConsole.slice(-8) })
   );
   const preservedRailStartsAtHistoryFloor = await player.evaluate(
@@ -750,7 +757,7 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
     preservedRailStartsAtHistoryFloor
   );
   check(
-    "reload while scrubbed branches from the selected frame",
+    "reload while scrubbed marks the selected frame without branching",
     scrubbedReloadMarker.frame === selectedBeforeReload,
     JSON.stringify({ reloadWhileScrubbed, scrubbedReloadMarker })
   );

--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -52,6 +52,18 @@ let draw = (model, tts: Float) =>
     Scene.cube() |> Scene.rotateY(Angle.radians(model.spin)) |> Scene.emissive(1.0, 0.2, 0.8))
 `;
 
+// A model that deliberately retains a module-bound closure. Its old snapshots
+// must not cross a hot reload, but the timeline should keep its frame/viewport
+// and show the unavailable prefix rather than collapsing or disappearing.
+const CLOSURE_HISTORY = `let offset = (k) => (x) => x + k
+let init = { t: 0.0, behavior: offset(1.0) }
+let tick = (model, dt: Float, tts: Float) => { model with t: model.t + dt }
+let draw = (model, tts: Float) =>
+  Frame.create(
+    Camera.lookAt(0.0, 0.0, -6.0, 0.0, 0.0, 0.0),
+    Scene.cube() |> Scene.rotateY(Angle.radians(model.t)) |> Scene.emissive(0.2, 0.8, 1.0))
+`;
+
 // A float-model program for the language-intelligence checks: every top-level
 // def has a knowable type (no record-typed `init` — a record's type stays
 // Unknown and earns no lens), so all four defs get a signature codelens; the
@@ -456,6 +468,7 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
     accessibleInputMarkers > 0
   );
 
+  const rangeBeforeSafeReload = await player.evaluate(() => window.__scrub.range());
   await page.evaluate(() =>
     window.__sandbox.setSource(`${window.__sandbox.getSource()}\n// timeline reload marker`)
   );
@@ -467,6 +480,13 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
     () => !!document.querySelector("#scrub-events .scrub-event.reload")
   );
   check("timeline renders successful hot-reload boundaries", reloadMarker);
+  const rangeAfterSafeReload = await player.evaluate(() => window.__scrub.range());
+  check(
+    "plain-data history remains seekable across a hot reload",
+    rangeAfterSafeReload[0] === rangeBeforeSafeReload[0] &&
+      rangeAfterSafeReload[1] >= rangeBeforeSafeReload[1],
+    `${rangeBeforeSafeReload} -> ${rangeAfterSafeReload}`
+  );
   await player.waitForFunction(
     () => {
       const range = window.__scrub.range();
@@ -650,9 +670,8 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
     branchMarkersAreAuthoritative
   );
 
-  // A successful reload while scrubbed still resumes at the recorder's next
-  // monotonic frame, so its boundary marker must not be anchored to the older
-  // selected frame and then pruned from the new history.
+  // A successful reload while scrubbed keeps the selected frame as the visible
+  // boundary. This plain-data model retains its pre-reload branch history.
   await player.waitForFunction(() => !window.__scrub.paused(), { timeout: 3000 });
   await player.waitForFunction(() => {
     const range = window.__scrub.range();
@@ -670,6 +689,7 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
     reloadWhileScrubbed.hi,
     { timeout: 3000 }
   );
+  const selectedBeforeReload = reloadWhileScrubbed.hi - 2;
   await page.evaluate(() =>
     window.__sandbox.setSource(`${window.__sandbox.getSource()}\n// reload while scrubbed marker`)
   );
@@ -698,6 +718,16 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
     );
   });
   check("reload boundary keeps the visible Step/Resume transport", reloadTransportIsVisible);
+  const safeReloadView = await player.evaluate(() => window.__scrub.view());
+  check(
+    "paused plain-data reload keeps its selected frame and retained past",
+    safeReloadView.selectedFrame === selectedBeforeReload &&
+      safeReloadView.recorded.lo < selectedBeforeReload &&
+      safeReloadView.recorded.hi === selectedBeforeReload &&
+      safeReloadView.unavailableEndUnit === 0 &&
+      safeReloadView.unavailableAfterStartUnit < 1,
+    JSON.stringify(safeReloadView)
+  );
   await player.locator("#scrub-step").click();
   await sleep(500);
   const postReloadStep = await player.evaluate(() => ({
@@ -712,23 +742,121 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
       scrubbedReloadMarker.frame <= postReloadStep.range[1],
     JSON.stringify({ postReloadStep, scrubConsole: scrubConsole.slice(-8) })
   );
-  const playedRailStartsAtRecordedBoundary = await player.evaluate(
-    () => Number(document.getElementById("scrub-played").getAttribute("x")) > 0
+  const preservedRailStartsAtHistoryFloor = await player.evaluate(
+    () => Number(document.getElementById("scrub-played").getAttribute("x")) === 0
   );
   check(
-    "played rail does not paint history before the reload boundary",
-    playedRailStartsAtRecordedBoundary
+    "preserved history keeps its cyan rail before the reload boundary",
+    preservedRailStartsAtHistoryFloor
   );
   check(
     "reload while scrubbed branches from the selected frame",
-    scrubbedReloadMarker.frame === reloadWhileScrubbed.hi - 1,
+    scrubbedReloadMarker.frame === selectedBeforeReload,
     JSON.stringify({ reloadWhileScrubbed, scrubbedReloadMarker })
   );
 
   await page.close();
 }
 
-// --- 10. The editor language-intelligence wasm analyzes source in-browser. -----
+// --- 10. Closure-bearing reloads retain UI continuity at a safe boundary. ---
+{
+  const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+  const b64u = Buffer.from(CLOSURE_HISTORY).toString("base64url");
+  await page.goto(`${BASE}/sandbox.html#src=${b64u}`);
+  await page.waitForFunction(
+    () => window.__sandbox && window.__sandbox.status().state === "live",
+    { timeout: 30000 }
+  );
+  const player = playerFrame(page);
+  await player.waitForFunction(
+    () => window.__scrub?.range().length === 2 && window.__scrub.range()[1] >= 30,
+    { timeout: 10000 }
+  );
+  await player.evaluate(() => window.__scrub.togglePause());
+  await player.waitForFunction(() => window.__scrub.paused(), { timeout: 3000 });
+  await player.evaluate(() => window.__scrub.setPreview({ enabled: true, seconds: 2 }));
+  const reloadTarget = await player.evaluate(() => {
+    const [lo, hi] = window.__scrub.range();
+    return Math.round(lo + (hi - lo) * 0.4);
+  });
+  await player.evaluate((frame) => window.__scrub.seek(frame), reloadTarget);
+  await player.waitForFunction(
+    (frame) => window.__scrub.frame() === frame,
+    reloadTarget,
+    { timeout: 3000 }
+  );
+  const beforeReload = await player.evaluate(() => ({
+    frame: window.__scrub.frame(),
+    view: window.__scrub.view(),
+    lastId: Math.max(-1, ...window.__scrub.events().map((event) => event.id)),
+  }));
+
+  await page.evaluate(() =>
+    window.__sandbox.setSource(`${window.__sandbox.getSource()}\n// closure history boundary`)
+  );
+  await player.waitForFunction(
+    (lastId) =>
+      window.__scrub.events().some(
+        (event) => event.id > lastId && event.kind === "reload-ok"
+      ),
+    beforeReload.lastId,
+    { timeout: 5000 }
+  );
+  const afterReload = await player.evaluate(() => {
+    const view = window.__scrub.view();
+    return {
+      frame: window.__scrub.frame(),
+      range: window.__scrub.range(),
+      view,
+      stripeWidth: Number(document.getElementById("scrub-unavailable").getAttribute("width")),
+      stripeAfterWidth: Number(
+        document.getElementById("scrub-unavailable-after").getAttribute("width")
+      ),
+      playheadVisible: getComputedStyle(document.getElementById("scrub-playhead")).display,
+      previewVisible: getComputedStyle(document.getElementById("scrub-preview-handle")).display,
+      label: document.getElementById("scrub-count").textContent,
+      reloadFrame: window.__scrub.events().findLast((event) => event.kind === "reload-ok").frame,
+    };
+  });
+  check(
+    "closure reload keeps the paused frame and frozen viewport",
+    afterReload.frame === beforeReload.frame &&
+      afterReload.view.selectedFrame === beforeReload.view.selectedFrame &&
+      afterReload.view.viewport.lo === beforeReload.view.viewport.lo &&
+      afterReload.view.viewport.hi === beforeReload.view.viewport.hi,
+    JSON.stringify({ beforeReload, afterReload })
+  );
+  check(
+    "closure reload seeds a one-frame seekable generation at the boundary",
+    afterReload.range[0] === beforeReload.frame &&
+      afterReload.range[1] === beforeReload.frame &&
+      afterReload.reloadFrame === beforeReload.frame,
+    JSON.stringify(afterReload)
+  );
+  check(
+    "unavailable history is striped while both handles remain visible",
+    afterReload.view.hasUnavailableHistory &&
+      afterReload.stripeWidth > 0 &&
+      afterReload.stripeAfterWidth > 0 &&
+      afterReload.playheadVisible === "block" &&
+      afterReload.previewVisible === "block" &&
+      afterReload.label.includes(String(beforeReload.frame)) &&
+      afterReload.label.includes("reload boundary"),
+    JSON.stringify(afterReload)
+  );
+
+  await player.evaluate((frame) => window.__scrub.seek(frame), beforeReload.view.viewport.lo);
+  await sleep(150);
+  const refusedOldSeek = await player.evaluate(() => window.__scrub.frame());
+  check(
+    "striped pre-reload frames are not seekable",
+    refusedOldSeek === beforeReload.frame,
+    `${beforeReload.view.viewport.lo} -> ${refusedOldSeek}`
+  );
+  await page.close();
+}
+
+// --- 11. The editor language-intelligence wasm analyzes source in-browser. -----
 // Commits 7-8 wire this into the CodeMirror editor (diagnostics/hover); here we
 // just smoke-test the bundle loads and `functor_lang_analyze` reports errors on
 // a bad source and none on a clean one.

--- a/functor-lang/src/rebind.rs
+++ b/functor-lang/src/rebind.rs
@@ -93,6 +93,8 @@ struct ModuleIndex {
     by_stable: HashMap<String, LambdaInfo>,
     stable_by_expr: HashMap<u32, String>,
     binder_kinds: HashMap<u32, BinderKind>,
+    /// Canonical constructor name to the arity declared by this module.
+    ctors: HashMap<String, usize>,
 }
 
 /// Rebind every closure reachable from `value`: closures created by
@@ -111,12 +113,12 @@ fn walk(value: &Value, old: &ModuleIndex, new: &ModuleIndex, report: &mut Rebind
         Value::Number(_)
         | Value::String(_)
         | Value::Bool(_)
-        | Value::Ctor { .. }
         | Value::Builtin(_)
         | Value::HostFn(_)
         // Host values are opaque to the language; they cannot hold Functor Lang
         // closures.
         | Value::HostData(_) => value.clone(),
+        Value::Ctor { name, arity } => rebind_ctor(name, *arity, old, new, report),
         Value::List(items) => Value::List(Rc::new(
             items.iter().map(|v| walk(v, old, new, report)).collect(),
         )),
@@ -134,18 +136,119 @@ fn walk(value: &Value, old: &ModuleIndex, new: &ModuleIndex, report: &mut Rebind
             args: Rc::new(args.iter().map(|v| walk(v, old, new, report)).collect()),
         },
         Value::Closure(closure) => rebind_closure(closure, old, new, report),
-        // Rebind the captured callee and the already-applied args. (The count
-        // still needed is derived from the rebound callee's arity at display
-        // time, so a hot-reload that changes it can never leave a stale count.)
-        Value::Partial(partial) => Value::Partial(Rc::new(crate::value::Partial {
-            callee: walk(&partial.callee, old, new, report),
-            applied: partial
-                .applied
-                .iter()
-                .map(|v| walk(v, old, new, report))
-                .collect(),
-        })),
+        Value::Partial(partial) => rebind_partial(partial, old, new, report),
     }
+}
+
+fn rebind_ctor(
+    name: &Rc<str>,
+    arity: usize,
+    old: &ModuleIndex,
+    new: &ModuleIndex,
+    report: &mut RebindReport,
+) -> Value {
+    // As with closures, only identify a value that agrees with the module we
+    // are actually replacing. This prevents a constructor kept across an
+    // earlier reload from being silently matched to a later declaration that
+    // happens to reuse its name.
+    if old.ctors.get(name.as_ref()) != Some(&arity) {
+        report.warnings.push(format!(
+            "stored constructor `{name}` predates the previous reload; keeping its old arity"
+        ));
+        return Value::Ctor {
+            name: name.clone(),
+            arity,
+        };
+    }
+
+    let Some(&new_arity) = new.ctors.get(name.as_ref()) else {
+        report.warnings.push(format!(
+            "stored constructor `{name}` has no match after the edit; keeping its old arity"
+        ));
+        return Value::Ctor {
+            name: name.clone(),
+            arity,
+        };
+    };
+
+    if new_arity == 0 {
+        Value::Variant {
+            ctor: name.clone(),
+            args: Rc::new(Vec::new()),
+        }
+    } else {
+        Value::Ctor {
+            name: name.clone(),
+            arity: new_arity,
+        }
+    }
+}
+
+fn rebind_partial(
+    partial: &Rc<crate::value::Partial>,
+    old: &ModuleIndex,
+    new: &ModuleIndex,
+    report: &mut RebindReport,
+) -> Value {
+    let callee = walk(&partial.callee, old, new, report);
+
+    let constructor_fallback = if let Value::Ctor { name, arity } = &callee {
+        (partial.applied.len() > *arity).then(|| {
+            format!(
+                "stored partial constructor `{name}` has {} applied argument(s), but the edited constructor takes {arity}; keeping its old arity",
+                partial.applied.len()
+            )
+        })
+    } else if let (Value::Ctor { name, .. }, Value::Variant { ctor, args }) =
+        (&partial.callee, &callee)
+    {
+        (!args.is_empty() || !partial.applied.is_empty()).then(|| {
+            format!(
+                "stored partial constructor `{name}` has {} applied argument(s), but the edited constructor `{ctor}` is nullary; keeping its old arity",
+                partial.applied.len()
+            )
+        })
+    } else {
+        None
+    };
+
+    let applied: Vec<Value> = partial
+        .applied
+        .iter()
+        .map(|value| walk(value, old, new, report))
+        .collect();
+
+    if let Some(warning) = constructor_fallback {
+        report.warnings.push(warning);
+        return Value::Partial(Rc::new(crate::value::Partial {
+            callee: partial.callee.clone(),
+            applied,
+        }));
+    }
+    if matches!(
+        (&partial.callee, &callee),
+        (Value::Ctor { .. }, Value::Variant { args, .. }) if args.is_empty()
+    ) {
+        return callee;
+    }
+
+    // Constructor arity is part of edited source. Normalize to the same value
+    // shape evaluation would have produced under the new declaration rather
+    // than manufacturing a zero-arity Ctor or a saturated Partial.
+    if let Value::Ctor { name, arity } = &callee {
+        return match applied.len().cmp(arity) {
+            std::cmp::Ordering::Less => {
+                Value::Partial(Rc::new(crate::value::Partial { callee, applied }))
+            }
+            std::cmp::Ordering::Equal => Value::Variant {
+                ctor: name.clone(),
+                args: Rc::new(applied),
+            },
+            std::cmp::Ordering::Greater => unreachable!("constructor shrink handled above"),
+        };
+    }
+
+    Value::Partial(Rc::new(crate::value::Partial { callee, applied }))
 }
 
 fn rebind_closure(
@@ -256,7 +359,17 @@ fn index_module(module: &Module) -> ModuleIndex {
         by_stable: HashMap::new(),
         stable_by_expr: HashMap::new(),
         binder_kinds: HashMap::new(),
+        ctors: HashMap::new(),
     };
+    for ty in &module.types {
+        if let crate::ast::TypeBody::Variants(variants) = &ty.body {
+            for variant in variants {
+                index
+                    .ctors
+                    .insert(variant.name.clone(), variant.fields.len());
+            }
+        }
+    }
     for def in &module.defs {
         let mut path: Vec<String> = Vec::new();
         collect(&def.value, &def.name, &mut path, &mut index);

--- a/functor-lang/src/value.rs
+++ b/functor-lang/src/value.rs
@@ -60,6 +60,13 @@ pub trait HostData {
     /// Shown as `<{type_name}>` in run/trace output and error messages.
     fn type_name(&self) -> &'static str;
     fn as_any(&self) -> &dyn std::any::Any;
+    /// Whether this opaque value is safe to retain in a model snapshot across
+    /// a module reload. Conservative by default: host values such as effects,
+    /// subscriptions, and UI trees may contain Functor Lang taggers/messages
+    /// that the generic value walker cannot inspect.
+    fn is_reload_safe_snapshot(&self) -> bool {
+        false
+    }
 }
 
 /// A lambda value: its IR params/body (shared with the [`crate::ir::Module`])
@@ -194,7 +201,11 @@ impl fmt::Display for Value {
                     Value::Builtin(b) => crate::eval::builtin_arity(*b),
                     _ => p.applied.len(),
                 };
-                write!(f, "<partial {} more>", arity.saturating_sub(p.applied.len()))
+                write!(
+                    f,
+                    "<partial {} more>",
+                    arity.saturating_sub(p.applied.len())
+                )
             }
             Value::Builtin(b) => write!(f, "<builtin {}>", builtin_name(*b)),
             Value::HostFn(path) => write!(f, "<host {path}>"),
@@ -204,6 +215,33 @@ impl fmt::Display for Value {
 }
 
 impl Value {
+    /// Whether a retained snapshot is independent of a loaded Functor module.
+    ///
+    /// Closures (including a partially-applied closure) hold `Rc`s into the
+    /// module IR that created them. First-class constructors also carry the
+    /// arity declared by that module. Plain immutable data is safe; callable
+    /// values are conservatively excluded, and opaque host values decide
+    /// through [`HostData`].
+    pub fn is_reload_safe_snapshot(&self) -> bool {
+        match self {
+            Value::List(items) | Value::Tuple(items) => {
+                items.iter().all(Value::is_reload_safe_snapshot)
+            }
+            Value::Record(fields) => fields
+                .iter()
+                .all(|(_, value)| value.is_reload_safe_snapshot()),
+            Value::Variant { args, .. } => args.iter().all(Value::is_reload_safe_snapshot),
+            Value::Closure(_) => false,
+            Value::Partial(partial) => {
+                partial.callee.is_reload_safe_snapshot()
+                    && partial.applied.iter().all(Value::is_reload_safe_snapshot)
+            }
+            Value::Number(_) | Value::String(_) | Value::Bool(_) => true,
+            Value::Ctor { .. } | Value::Builtin(_) | Value::HostFn(_) => false,
+            Value::HostData(data) => data.is_reload_safe_snapshot(),
+        }
+    }
+
     /// What kind of value this is, for error messages ("cannot call a number").
     pub fn kind_name(&self) -> &'static str {
         match self {

--- a/functor-lang/tests/rebind.rs
+++ b/functor-lang/tests/rebind.rs
@@ -6,7 +6,8 @@
 //! through B's session.
 
 use functor_lang::ir::Module;
-use functor_lang::{rebind_value, NoHost, RunOutcome, Session, Tracing, Value};
+use functor_lang::{rebind_value, HostData, NoHost, RunOutcome, Session, Tracing, Value};
+use std::rc::Rc;
 
 fn module(src: &str) -> Module {
     functor_lang::lower(functor_lang::parse(src).expect("parse")).expect("lower")
@@ -194,6 +195,82 @@ fn plain_data_is_preserved() {
     assert_eq!(report.rebound, 0);
     assert!(report.warnings.is_empty());
     assert_eq!(rebound.to_string(), stored.to_string());
+    assert!(stored.is_reload_safe_snapshot());
+}
+
+#[test]
+fn stored_closures_make_a_snapshot_reload_unsafe() {
+    let module = module(&format!(
+        "{APPLY}let mul = (k) => (x) => x * k\nlet main = () => {{ nested: [mul(3.0)] }}"
+    ));
+    let stored = main_value(&module);
+    assert!(!stored.is_reload_safe_snapshot());
+}
+
+#[test]
+fn first_class_constructors_rebind_arity_and_make_snapshots_unsafe() {
+    let a = module("type Pair = | Pair(left: float)\nlet main = () => Pair");
+    let b = module("type Pair = | Pair(left: float, right: float)\nlet main = () => Pair");
+    let stored = main_value(&a);
+    assert!(!stored.is_reload_safe_snapshot());
+    assert!(matches!(&stored, Value::Ctor { arity: 1, .. }));
+
+    let (rebound, report) = rebind_value(&stored, &a, &b);
+    assert!(report.warnings.is_empty());
+    assert!(matches!(rebound, Value::Ctor { arity: 2, .. }));
+}
+
+#[test]
+fn constructor_rebind_normalizes_nullary_and_saturated_values() {
+    let unary = module("type Slot = | Slot(value: float)\nlet main = () => Slot");
+    let nullary = module("type Slot = | Slot\nlet main = () => Slot");
+    let (rebound, report) = rebind_value(&main_value(&unary), &unary, &nullary);
+    assert!(report.warnings.is_empty());
+    assert!(matches!(rebound, Value::Variant { ref args, .. } if args.is_empty()));
+
+    let pair = module("type Pair = | Pair(left: float, right: float)\nlet main = () => Pair(1.0)");
+    let single = module("type Pair = | Pair(left: float)\nlet main = () => Pair(1.0)");
+    let (rebound, report) = rebind_value(&main_value(&pair), &pair, &single);
+    assert!(report.warnings.is_empty());
+    assert!(matches!(rebound, Value::Variant { ref args, .. } if args.len() == 1));
+}
+
+#[test]
+fn constructor_rebind_keeps_an_over_applied_partial_with_a_warning() {
+    let src = |body: &str, fields: &str| {
+        format!(
+            "{APPLY}type Triple = | Triple(f: (float) => float, {fields})\n\
+             let behavior = (x) => {body}\n\
+             let main = () => Triple(behavior, 2.0)"
+        )
+    };
+    let triple = module(&src("x + 1.0", "b: float, c: float"));
+    let single = module(&src("x + 10.0", ""));
+    let stored = main_value(&triple);
+    let (rebound, report) = rebind_value(&stored, &triple, &single);
+    assert_eq!(report.rebound, 1, "applied closure should still rebind");
+    assert_eq!(report.warnings.len(), 1, "warnings: {:?}", report.warnings);
+    assert!(report.warnings[0].contains("2 applied argument(s)"));
+    let Value::Partial(partial) = rebound else {
+        panic!("expected retained partial")
+    };
+    assert!(matches!(partial.callee, Value::Ctor { arity: 3, .. }));
+    assert_eq!(num(&apply(&single, partial.applied[0].clone(), 1.0)), 11.0);
+}
+
+#[test]
+fn opaque_host_values_are_reload_unsafe_unless_the_host_opts_in() {
+    struct Opaque;
+    impl HostData for Opaque {
+        fn type_name(&self) -> &'static str {
+            "Opaque"
+        }
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    assert!(!Value::HostData(Rc::new(Opaque)).is_reload_safe_snapshot());
 }
 
 // --- Review-driven cases (Codex + Claude adversarial probes) ---

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -145,12 +145,6 @@ pub trait GameProducer {
         0
     }
 
-    /// Rendered frame that the producer will record next, including after a
-    /// scrubbed reload commits a branch.
-    fn next_scene_frame(&self) -> Option<u64> {
-        None
-    }
-
     /// The recorded `tts` of the frame the scene currently sits on (the scrubbed
     /// frame while dragging, else the newest recorded frame). Shells read this to
     /// REBASE their [`crate::GameClock`] when a time-travel branch resumes — on a

--- a/runtime/functor-runtime-common/src/timetravel.rs
+++ b/runtime/functor-runtime-common/src/timetravel.rs
@@ -265,18 +265,15 @@ impl SceneRecorder {
         &mut self,
         rebound_model: &Value,
         physics_fixed_frame: u64,
+        live_model_was_safe: bool,
     ) -> ReloadHistory {
         let current_frame = self.current_scene_frame();
-        self.scrub_pos = None;
-        if self
-            .model_history
-            .snapshots
-            .iter()
-            .all(Value::is_reload_safe_snapshot)
-        {
+        if live_model_was_safe && self.reload_history_is_safe() {
             // Input can update the live model while paused, without producing
             // a new recorded frame. Make the snapshot at the visible cursor
             // match that authoritative live state before retaining history.
+            // Keep `scrub_pos`: reload is non-destructive, and Resume remains
+            // the operation that branches away the recorded future.
             if let Some(frame) = current_frame {
                 self.model_history.replace(frame, rebound_model);
                 self.world_frame_history
@@ -285,6 +282,7 @@ impl SceneRecorder {
             return ReloadHistory::Preserved;
         }
 
+        self.scrub_pos = None;
         let Some((frame, tts)) = current_frame.map(|frame| {
             let tts = *self.tts_history.seek(frame);
             (frame, tts)
@@ -304,15 +302,51 @@ impl SceneRecorder {
         ReloadHistory::RestartedAt(frame)
     }
 
+    /// Whether every retained model snapshot is independent of the loaded
+    /// module and can therefore remain seekable across a hot reload.
+    pub fn reload_history_is_safe(&self) -> bool {
+        self.model_history
+            .snapshots
+            .iter()
+            .all(Value::is_reload_safe_snapshot)
+    }
+
+    /// Classify and, when necessary, branch the coupled timeline before the
+    /// producer rebinds its authoritative live model. The live model may have
+    /// changed without a recorded frame while paused, so it participates in
+    /// the safety decision independently of the snapshot ring.
+    ///
+    /// Branching normally restores the selected snapshot into `model`; retain
+    /// and restore the authoritative live value around that operation so a
+    /// paused update is not silently lost. The returned live-model flag must be
+    /// passed to [`Self::finish_reload`] after rebinding.
+    pub fn prepare_reload(
+        &mut self,
+        model: &mut Value,
+        physics: &mut SteppedPhysics,
+        physics_frame: &mut u64,
+        has_physics: bool,
+    ) -> bool {
+        let live_model_is_safe = model.is_reload_safe_snapshot();
+        if !self.reload_history_is_safe() || !live_model_is_safe {
+            let authoritative_model = model.clone();
+            self.commit_scrub_before_reload(model, physics, physics_frame, has_physics);
+            *model = authoritative_model;
+        }
+        live_model_is_safe
+    }
+
     /// Monotonic revision for destructive branch/reload boundaries.
     pub fn generation(&self) -> u64 {
         self.generation
     }
 
-    /// Commit a non-destructive scrub before a reload evaluates whether the
-    /// snapshot rings can survive. This preserves the state the user is
-    /// inspecting and, critically, branches the physics timeline in lockstep
-    /// before `scrub_pos` disappears.
+    /// Commit a non-destructive scrub before an UNSAFE reload replaces the
+    /// snapshot generation. Safe plain-data reloads must not call this: they
+    /// retain both the selected cursor and its recorded future until Resume.
+    /// For an unsafe reload this preserves the state the user is inspecting
+    /// and branches the physics timeline in lockstep before `scrub_pos`
+    /// disappears.
     pub fn commit_scrub_before_reload(
         &mut self,
         model: &mut Value,
@@ -713,7 +747,7 @@ mod tests {
     }
 
     #[test]
-    fn plain_data_reload_while_scrubbed_preserves_the_branched_history() {
+    fn plain_data_reload_while_scrubbed_preserves_the_full_future_until_resume() {
         let mut rec = SceneRecorder::new();
         for frame in 0..5u64 {
             rec.record(&Value::Number(frame as f64), 0, frame as f64);
@@ -724,21 +758,22 @@ mod tests {
         rec.seek_scene_to(2, &mut model, &mut physics, &mut physics_frame, false)
             .expect("seek");
 
-        rec.commit_scrub_before_reload(&mut model, &mut physics, &mut physics_frame, false);
-        assert_eq!(rec.scene_frame_range(), Some((0, 2)));
-        assert_eq!(rec.next_frame(), 3);
         let generation = rec.generation();
+        assert!(rec.reload_history_is_safe());
         assert_eq!(
-            rec.finish_reload(&model, physics_frame),
+            rec.finish_reload(&model, physics_frame, true),
             ReloadHistory::Preserved
         );
-        assert_eq!(rec.scene_frame_range(), Some((0, 2)));
+        assert_eq!(rec.scene_frame_range(), Some((0, 4)));
+        assert_eq!(rec.current_scene_frame(), Some(2));
+        assert_eq!(rec.scrub_render_tts(), Some(2.0));
         assert_eq!(rec.generation(), generation);
-        assert_eq!(
-            rec.next_frame(),
-            3,
-            "reload resumes after the selected branch"
-        );
+        assert_eq!(rec.next_frame(), 5, "reload must not branch the future");
+
+        assert!(rec.commit_scrub_if_resuming(&mut model, &mut physics, &mut physics_frame, false));
+        assert_eq!(rec.scene_frame_range(), Some((0, 2)));
+        assert_eq!(rec.next_frame(), 3);
+        assert_ne!(rec.generation(), generation, "Resume commits the branch");
     }
 
     #[test]
@@ -749,7 +784,10 @@ mod tests {
         // Paused input may update the live model without advancing/recording a
         // frame. Reload must not leave frame 0 pointing at the stale value.
         let live_model = Value::Number(99.0);
-        assert_eq!(rec.finish_reload(&live_model, 0), ReloadHistory::Preserved);
+        assert_eq!(
+            rec.finish_reload(&live_model, 0, true),
+            ReloadHistory::Preserved
+        );
 
         let mut restored = Value::Number(0.0);
         let mut physics = SteppedPhysics::new();
@@ -771,11 +809,12 @@ mod tests {
         let mut physics_frame = 0;
         rec.seek_scene_to(2, &mut model, &mut physics, &mut physics_frame, false)
             .expect("seek");
+        assert!(!rec.reload_history_is_safe());
         rec.commit_scrub_before_reload(&mut model, &mut physics, &mut physics_frame, false);
         let generation = rec.generation();
 
         assert_eq!(
-            rec.finish_reload(&model, physics_frame),
+            rec.finish_reload(&model, physics_frame, false),
             ReloadHistory::RestartedAt(2)
         );
         assert_eq!(rec.scene_frame_range(), Some((2, 2)));
@@ -794,6 +833,69 @@ mod tests {
     }
 
     #[test]
+    fn unsafe_values_only_in_the_discarded_future_keep_the_safe_prefix() {
+        let stored_closure = closure_model();
+        let mut rec = SceneRecorder::new();
+        for frame in 0..3u64 {
+            rec.record(&Value::Number(frame as f64), 0, frame as f64);
+        }
+        for frame in 3..5u64 {
+            rec.record(&stored_closure, 0, frame as f64);
+        }
+        let mut model = Value::Number(0.0);
+        let mut physics = SteppedPhysics::new();
+        let mut physics_frame = 0;
+        rec.seek_scene_to(2, &mut model, &mut physics, &mut physics_frame, false)
+            .expect("seek");
+
+        assert!(!rec.reload_history_is_safe());
+        rec.commit_scrub_before_reload(&mut model, &mut physics, &mut physics_frame, false);
+        assert_eq!(rec.scene_frame_range(), Some((0, 2)));
+        assert!(rec.reload_history_is_safe());
+
+        assert_eq!(
+            rec.finish_reload(&model, physics_frame, true),
+            ReloadHistory::Preserved
+        );
+        assert_eq!(rec.scene_frame_range(), Some((0, 2)));
+        assert_eq!(rec.current_scene_frame(), Some(2));
+    }
+
+    #[test]
+    fn unsafe_authoritative_live_model_forces_a_boundary_without_losing_it() {
+        let mut rec = SceneRecorder::new();
+        for frame in 0..5u64 {
+            rec.record(&Value::Number(frame as f64), 0, frame as f64);
+        }
+        let mut model = Value::Number(0.0);
+        let mut physics = SteppedPhysics::new();
+        let mut physics_frame = 0;
+        rec.seek_scene_to(2, &mut model, &mut physics, &mut physics_frame, false)
+            .expect("seek");
+
+        // Simulate a paused update that changed the authoritative model without
+        // recording another frame. Preparing the reload may branch history,
+        // but must not overwrite this live value with frame 2's snapshot.
+        model = closure_model();
+        let live_before = model.to_string();
+        let live_model_was_safe = rec.prepare_reload(
+            &mut model,
+            &mut physics,
+            &mut physics_frame,
+            false,
+        );
+        assert!(!live_model_was_safe);
+        assert_eq!(model.to_string(), live_before);
+        assert_eq!(rec.scene_frame_range(), Some((0, 2)));
+
+        assert_eq!(
+            rec.finish_reload(&model, physics_frame, live_model_was_safe),
+            ReloadHistory::RestartedAt(2)
+        );
+        assert_eq!(rec.scene_frame_range(), Some((2, 2)));
+    }
+
+    #[test]
     fn first_class_constructor_history_starts_a_new_generation() {
         let constructor = Value::Ctor {
             name: Rc::from("Pair"),
@@ -804,7 +906,7 @@ mod tests {
         let generation = rec.generation();
 
         assert_eq!(
-            rec.finish_reload(&constructor, 0),
+            rec.finish_reload(&constructor, 0, false),
             ReloadHistory::RestartedAt(0)
         );
         assert_ne!(rec.generation(), generation);
@@ -851,7 +953,7 @@ mod tests {
         // A hot reload keeps both the plain-data model ring and input log.
         let generation = rec.generation();
         assert_eq!(
-            rec.finish_reload(&Value::Number(0.0), 0),
+            rec.finish_reload(&Value::Number(0.0), 0, true),
             ReloadHistory::Preserved
         );
         assert_eq!(rec.generation(), generation);

--- a/runtime/functor-runtime-common/src/timetravel.rs
+++ b/runtime/functor-runtime-common/src/timetravel.rs
@@ -39,6 +39,17 @@ use crate::physics::SteppedPhysics;
 /// [`crate::physics::timeline::Frame`].
 pub type Frame = u64;
 
+/// What a successful code reload did to the seekable scene history.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReloadHistory {
+    /// Every retained model was plain data, so the coupled history remains
+    /// seekable under the new program.
+    Preserved,
+    /// Code-bearing/callable model values required a new history generation.
+    /// The rebound live scene was seeded as its first safe snapshot.
+    RestartedAt(Frame),
+}
+
 /// Default rendered-frame retention (~15s at 60fps) — the window both game
 /// shells size their model `History` to, matching the physics recorder. Shared
 /// so the two shells can't silently diverge (docs/time-travel.md T1).
@@ -96,10 +107,7 @@ impl<T: Clone> History<T> {
     pub fn record(&mut self, frame: Frame, state: &T) {
         match self.next {
             None => self.base = frame,
-            Some(next) => assert_eq!(
-                frame, next,
-                "history frames must be recorded consecutively"
-            ),
+            Some(next) => assert_eq!(frame, next, "history frames must be recorded consecutively"),
         }
         self.snapshots.push_back(state.clone());
         if let Some(cap) = self.capacity {
@@ -120,6 +128,18 @@ impl<T: Clone> History<T> {
             "seek({frame}) outside recorded history [{oldest}, {newest}]"
         );
         &self.snapshots[(frame - self.base) as usize]
+    }
+
+    /// Replace one retained snapshot without changing the window or its next
+    /// frame. Reload uses this to make the current snapshot authoritative when
+    /// paused input changed the live model between recorded frames.
+    pub fn replace(&mut self, frame: Frame, state: &T) {
+        let (oldest, newest) = self.recorded_range().expect("replace in an empty history");
+        assert!(
+            frame >= oldest && frame <= newest,
+            "replace({frame}) outside recorded history [{oldest}, {newest}]"
+        );
+        self.snapshots[(frame - self.base) as usize] = state.clone();
     }
 
     /// The most recently recorded state, or `None` if nothing is recorded yet.
@@ -230,19 +250,58 @@ impl SceneRecorder {
         }
     }
 
-    /// Hot-reload boundary: drop the snapshot rings (they can hold old-module
-    /// closures) but keep `rendered_frame` monotonic so recording resumes
-    /// consecutively, and clear any scrub. The `input_history` is deliberately
-    /// NOT dropped: it is plain data (`RecordedInput`), so the input log SURVIVES
-    /// a reload (docs/time-travel.md, "The event log") — the one difference from
-    /// the closure-holding model/world/tts rings. It stays aligned because it too
-    /// keys off the single monotonic `rendered_frame`.
-    pub fn reset_on_reload(&mut self) {
+    /// Finish a successful hot reload after the producer has rebound its live
+    /// model to the new module.
+    ///
+    /// Plain-data model snapshots carry no module IR, so their coupled model /
+    /// world / time history remains valid and seekable under the new program.
+    /// If any retained snapshot contains a callable or opaque host value, the
+    /// old generation cannot cross the reload safely. In that case the rings are
+    /// reset and immediately seeded at the current frame with the REBOUND live
+    /// model, current world frame, and recorded game time. That anchor keeps the
+    /// frame counter and transport stable while honestly making older frames
+    /// unavailable. The plain-data input log always survives.
+    pub fn finish_reload(
+        &mut self,
+        rebound_model: &Value,
+        physics_fixed_frame: u64,
+    ) -> ReloadHistory {
+        let current_frame = self.current_scene_frame();
+        self.scrub_pos = None;
+        if self
+            .model_history
+            .snapshots
+            .iter()
+            .all(Value::is_reload_safe_snapshot)
+        {
+            // Input can update the live model while paused, without producing
+            // a new recorded frame. Make the snapshot at the visible cursor
+            // match that authoritative live state before retaining history.
+            if let Some(frame) = current_frame {
+                self.model_history.replace(frame, rebound_model);
+                self.world_frame_history
+                    .replace(frame, &physics_fixed_frame);
+            }
+            return ReloadHistory::Preserved;
+        }
+
+        let Some((frame, tts)) = current_frame.map(|frame| {
+            let tts = *self.tts_history.seek(frame);
+            (frame, tts)
+        }) else {
+            // An unsafe snapshot implies a non-empty history, so this is only a
+            // defensive fallback if that invariant changes later.
+            return ReloadHistory::Preserved;
+        };
         self.model_history = History::bounded(DEFAULT_HISTORY_FRAMES);
         self.world_frame_history = History::bounded(DEFAULT_HISTORY_FRAMES);
         self.tts_history = History::bounded(DEFAULT_HISTORY_FRAMES);
         self.generation = self.generation.wrapping_add(1);
-        self.scrub_pos = None;
+
+        self.model_history.record(frame, rebound_model);
+        self.world_frame_history.record(frame, &physics_fixed_frame);
+        self.tts_history.record(frame, &tts);
+        ReloadHistory::RestartedAt(frame)
     }
 
     /// Monotonic revision for destructive branch/reload boundaries.
@@ -250,9 +309,10 @@ impl SceneRecorder {
         self.generation
     }
 
-    /// Commit a non-destructive scrub before a reload discards the snapshot
-    /// rings. This preserves the state the user is inspecting and, critically,
-    /// branches the physics timeline in lockstep before `scrub_pos` disappears.
+    /// Commit a non-destructive scrub before a reload evaluates whether the
+    /// snapshot rings can survive. This preserves the state the user is
+    /// inspecting and, critically, branches the physics timeline in lockstep
+    /// before `scrub_pos` disappears.
     pub fn commit_scrub_before_reload(
         &mut self,
         model: &mut Value,
@@ -338,7 +398,8 @@ impl SceneRecorder {
     /// `scrub_pos` has been cleared — it then reports the newest frame's `tts`
     /// (the rewind target). `None` before anything is recorded.
     pub fn current_scene_frame_tts(&self) -> Option<f64> {
-        self.current_scene_frame().map(|f| *self.tts_history.seek(f))
+        self.current_scene_frame()
+            .map(|f| *self.tts_history.seek(f))
     }
 
     /// The seekable window `(oldest, newest)` — the draggable range.
@@ -467,7 +528,23 @@ impl SceneRecorder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use functor_lang::{RunOutcome, Tracing};
     use std::rc::Rc;
+
+    fn closure_model() -> Value {
+        let module = functor_lang::lower(
+            functor_lang::parse("let main = () => (x) => x + 1.0").expect("parse closure"),
+        )
+        .expect("lower closure");
+        let record = match functor_lang::run(&module, Tracing::Off) {
+            Ok(record) => record,
+            Err(failure) => panic!("run closure: {}", failure.error.message),
+        };
+        match record.outcome {
+            RunOutcome::Main(value) => value,
+            _ => panic!("expected main value"),
+        }
+    }
 
     // --- the generic ring, exercised over a trivial Clone state ---
 
@@ -577,9 +654,7 @@ mod tests {
 
     fn field<'a>(v: &'a Value, name: &str) -> &'a Value {
         match v {
-            Value::Record(fields) => {
-                &fields.iter().find(|(k, _)| k == name).expect("field").1
-            }
+            Value::Record(fields) => &fields.iter().find(|(k, _)| k == name).expect("field").1,
             _ => panic!("not a record"),
         }
     }
@@ -638,7 +713,7 @@ mod tests {
     }
 
     #[test]
-    fn reload_while_scrubbed_branches_before_resetting_snapshots() {
+    fn plain_data_reload_while_scrubbed_preserves_the_branched_history() {
         let mut rec = SceneRecorder::new();
         for frame in 0..5u64 {
             rec.record(&Value::Number(frame as f64), 0, frame as f64);
@@ -652,9 +727,88 @@ mod tests {
         rec.commit_scrub_before_reload(&mut model, &mut physics, &mut physics_frame, false);
         assert_eq!(rec.scene_frame_range(), Some((0, 2)));
         assert_eq!(rec.next_frame(), 3);
-        rec.reset_on_reload();
-        assert_eq!(rec.scene_frame_range(), None);
-        assert_eq!(rec.next_frame(), 3, "reload resumes after the selected branch");
+        let generation = rec.generation();
+        assert_eq!(
+            rec.finish_reload(&model, physics_frame),
+            ReloadHistory::Preserved
+        );
+        assert_eq!(rec.scene_frame_range(), Some((0, 2)));
+        assert_eq!(rec.generation(), generation);
+        assert_eq!(
+            rec.next_frame(),
+            3,
+            "reload resumes after the selected branch"
+        );
+    }
+
+    #[test]
+    fn preserved_reload_refreshes_the_current_snapshot_from_the_live_model() {
+        let mut rec = SceneRecorder::new();
+        rec.record(&Value::Number(1.0), 0, 0.0);
+
+        // Paused input may update the live model without advancing/recording a
+        // frame. Reload must not leave frame 0 pointing at the stale value.
+        let live_model = Value::Number(99.0);
+        assert_eq!(rec.finish_reload(&live_model, 0), ReloadHistory::Preserved);
+
+        let mut restored = Value::Number(0.0);
+        let mut physics = SteppedPhysics::new();
+        let mut physics_frame = 0;
+        rec.seek_scene_to(0, &mut restored, &mut physics, &mut physics_frame, false)
+            .expect("seek");
+        assert_eq!(restored.to_string(), live_model.to_string());
+    }
+
+    #[test]
+    fn closure_history_restarts_at_the_rebound_current_frame() {
+        let stored_closure = closure_model();
+        let mut rec = SceneRecorder::new();
+        for frame in 0..5u64 {
+            rec.record(&stored_closure, 0, frame as f64);
+        }
+        let mut model = Value::Number(0.0);
+        let mut physics = SteppedPhysics::new();
+        let mut physics_frame = 0;
+        rec.seek_scene_to(2, &mut model, &mut physics, &mut physics_frame, false)
+            .expect("seek");
+        rec.commit_scrub_before_reload(&mut model, &mut physics, &mut physics_frame, false);
+        let generation = rec.generation();
+
+        assert_eq!(
+            rec.finish_reload(&model, physics_frame),
+            ReloadHistory::RestartedAt(2)
+        );
+        assert_eq!(rec.scene_frame_range(), Some((2, 2)));
+        assert_eq!(rec.current_scene_frame(), Some(2));
+        assert_eq!(rec.current_scene_frame_tts(), Some(2.0));
+        assert_eq!(rec.next_frame(), 3);
+        assert_ne!(rec.generation(), generation);
+        assert!(rec
+            .seek_scene_to(1, &mut model, &mut physics, &mut physics_frame, false)
+            .is_ok());
+        assert_eq!(
+            rec.current_scene_frame(),
+            Some(2),
+            "seek clamps to the new boundary"
+        );
+    }
+
+    #[test]
+    fn first_class_constructor_history_starts_a_new_generation() {
+        let constructor = Value::Ctor {
+            name: Rc::from("Pair"),
+            arity: 1,
+        };
+        let mut rec = SceneRecorder::new();
+        rec.record(&constructor, 0, 0.0);
+        let generation = rec.generation();
+
+        assert_eq!(
+            rec.finish_reload(&constructor, 0),
+            ReloadHistory::RestartedAt(0)
+        );
+        assert_ne!(rec.generation(), generation);
+        assert_eq!(rec.scene_frame_range(), Some((0, 0)));
     }
 
     // --- the input log: record → read back, and survive a reload (T6b) ---
@@ -664,7 +818,10 @@ mod tests {
         let mut rec = SceneRecorder::new();
         // Record three frames, keying inputs in lockstep with the model (the
         // order the producer's `record_frame` uses: inputs first, then model).
-        let f0 = vec![RecordedInput::Key { code: 30, is_down: true }];
+        let f0 = vec![RecordedInput::Key {
+            code: 30,
+            is_down: true,
+        }];
         let f1: Vec<RecordedInput> = vec![];
         let f2 = vec![
             RecordedInput::MouseMove { x: 5, y: 7 },
@@ -679,7 +836,10 @@ mod tests {
         assert_eq!(rec.inputs_at(0).len(), 1);
         assert!(matches!(
             rec.inputs_at(0)[0],
-            RecordedInput::Key { code: 30, is_down: true }
+            RecordedInput::Key {
+                code: 30,
+                is_down: true
+            }
         ));
         assert!(rec.inputs_at(1).is_empty());
         assert_eq!(rec.inputs_at(2).len(), 2);
@@ -688,12 +848,14 @@ mod tests {
         // `inputs_from` is contiguous from the start frame.
         assert_eq!(rec.inputs_from(1).len(), 2); // frames 1 and 2
 
-        // A hot reload drops the model ring but KEEPS the input log (plain data
-        // survives reload, docs/time-travel.md).
+        // A hot reload keeps both the plain-data model ring and input log.
         let generation = rec.generation();
-        rec.reset_on_reload();
-        assert_ne!(rec.generation(), generation, "reload bumps the generation");
-        assert_eq!(rec.scene_frame_range(), None, "model ring reset on reload");
+        assert_eq!(
+            rec.finish_reload(&Value::Number(0.0), 0),
+            ReloadHistory::Preserved
+        );
+        assert_eq!(rec.generation(), generation);
+        assert_eq!(rec.scene_frame_range(), Some((0, 2)));
         assert_eq!(rec.inputs_at(0).len(), 1, "input log survives the reload");
         assert_eq!(rec.inputs_at(2).len(), 2, "input log survives the reload");
     }

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -29,12 +29,14 @@
 
 use std::time::Instant;
 
+use functor_lang::project::SourceMap;
+use functor_lang::{Session, Value};
+use functor_runtime_common::events::{self, RuntimeEvent};
 use functor_runtime_common::functor_lang_prelude::{
     audio_scene_of, clear_audio_completions, clear_http_taggers, frame_value, take_ui_handlers,
     view_value, EffectLog, EffectRunner, EffectTree, FunctorHost, NetEventKind, RealEffects,
     UiHandler,
 };
-use functor_runtime_common::events::{self, RuntimeEvent};
 use functor_runtime_common::functor_lang_producer::{
     journal_arm, journal_push, journal_swap, FrameCtx, JournalEntry, Provenance, Reporter,
     SpanSource,
@@ -44,8 +46,6 @@ use functor_runtime_common::physics;
 use functor_runtime_common::timetravel::SceneRecorder;
 use functor_runtime_common::ui::View;
 use functor_runtime_common::{Frame, FrameTime};
-use functor_lang::project::SourceMap;
-use functor_lang::{Session, Value};
 use std::path::PathBuf;
 use std::time::SystemTime;
 
@@ -223,8 +223,9 @@ fn load_project(path: &str, entry_src: Option<String>) -> Result<Loaded, String>
     // Inject the host prelude `.funi` interfaces so `Scene.*` (etc.) typecheck
     // against real types (docs/functor-lang-interfaces.md). Check-time only — the FunctorHost still
     // provides the actual runtime values.
-    let project = functor_lang::project::load_with_prelude(entry, &overrides, &functor_prelude::modules())
-        .map_err(|e| format!("cannot load {}", e.render()))?;
+    let project =
+        functor_lang::project::load_with_prelude(entry, &overrides, &functor_prelude::modules())
+            .map_err(|e| format!("cannot load {}", e.render()))?;
     // Type diagnostics are advisory in the dev loop: print, keep going.
     for diag in project.check() {
         eprintln!(
@@ -340,7 +341,8 @@ fn entry_mtime(stamp: &[(PathBuf, SystemTime)]) -> Option<SystemTime> {
 }
 
 fn project_stamp(path: &str) -> Vec<(PathBuf, SystemTime)> {
-    let files = functor_lang::project::project_files(std::path::Path::new(path)).unwrap_or_default();
+    let files =
+        functor_lang::project::project_files(std::path::Path::new(path)).unwrap_or_default();
     files
         .into_iter()
         .map(|file| {
@@ -453,7 +455,7 @@ impl FunctorLangGame {
     /// tick right through a reload. Returns the number of stored closures
     /// rebound, for the status line.
     fn swap_in(&mut self, loaded: Loaded) -> usize {
-        self.recorder.commit_scrub_before_reload(
+        let live_model_was_safe = self.recorder.prepare_reload(
             &mut self.model,
             &mut self.physics_rt,
             &mut self.physics_frame,
@@ -471,7 +473,8 @@ impl FunctorLangGame {
         self.last_frame_journal.clear();
         self.cached_trace = None;
         journal_swap(); // discard any partial current-frame journal
-        self.reporter.set_source(SpanSource::Project(loaded.sources));
+        self.reporter
+            .set_source(SpanSource::Project(loaded.sources));
         self.module = loaded.module;
         self.session = loaded.session;
         self.has_input = loaded.has_input;
@@ -512,7 +515,8 @@ impl FunctorLangGame {
         // Plain-data snapshots remain seekable under the new program. A model
         // history containing callable or opaque host values instead starts a new
         // generation anchored at this rebound live frame.
-        self.recorder.finish_reload(&self.model, self.physics_frame);
+        self.recorder
+            .finish_reload(&self.model, self.physics_frame, live_model_was_safe);
         report.rebound
     }
 
@@ -549,7 +553,6 @@ impl FunctorLangGame {
             self.swap_ns = 0;
         }
     }
-
 }
 
 impl Game for FunctorLangGame {
@@ -1005,20 +1008,22 @@ AudioScene.empty), got {}",
         functor_runtime_common::net::drain_commands_json()
     }
     fn net_push_http_response(&mut self, token: i32, status: i32, body: String) {
-        self.ctx().deliver_http_result(functor_runtime_common::net::HttpResult {
-            token: token as u64,
-            status: status as u16,
-            body: body.into_bytes(),
-            error: None,
-        });
+        self.ctx()
+            .deliver_http_result(functor_runtime_common::net::HttpResult {
+                token: token as u64,
+                status: status as u16,
+                body: body.into_bytes(),
+                error: None,
+            });
     }
     fn net_push_http_error(&mut self, token: i32, message: String) {
-        self.ctx().deliver_http_result(functor_runtime_common::net::HttpResult {
-            token: token as u64,
-            status: 0,
-            body: Vec::new(),
-            error: Some(message),
-        });
+        self.ctx()
+            .deliver_http_result(functor_runtime_common::net::HttpResult {
+                token: token as u64,
+                status: 0,
+                body: Vec::new(),
+                error: Some(message),
+            });
     }
     fn audio_drain_commands(&self) -> String {
         // One-shot commands (Effect.play/playAt/playThen), performed by the
@@ -1035,16 +1040,20 @@ AudioScene.empty), got {}",
         functor_runtime_common::net::drain_conn_commands_json()
     }
     fn net_push_connected(&mut self, key: String, conn: i32) {
-        self.ctx().deliver_net_event(key, NetEventKind::Connected, conn, String::new());
+        self.ctx()
+            .deliver_net_event(key, NetEventKind::Connected, conn, String::new());
     }
     fn net_push_conn_message(&mut self, key: String, conn: i32, text: String) {
-        self.ctx().deliver_net_event(key, NetEventKind::Message, conn, text);
+        self.ctx()
+            .deliver_net_event(key, NetEventKind::Message, conn, text);
     }
     fn net_push_disconnected(&mut self, key: String, conn: i32) {
-        self.ctx().deliver_net_event(key, NetEventKind::Disconnected, conn, String::new());
+        self.ctx()
+            .deliver_net_event(key, NetEventKind::Disconnected, conn, String::new());
     }
     fn net_push_conn_error(&mut self, key: String, conn: i32, message: String) {
-        self.ctx().deliver_net_event(key, NetEventKind::Error, conn, message);
+        self.ctx()
+            .deliver_net_event(key, NetEventKind::Error, conn, message);
     }
     fn audio_push_finished(&mut self, token: i32) {
         self.ctx().deliver_audio_completion(token as u64);
@@ -1179,7 +1188,8 @@ mod tests {
         let _guard = NET_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         use functor_runtime_common::net::{drain_conn_commands, ConnCommand};
         const BIND: &str = "127.0.0.1:9001";
-        let dir = std::env::temp_dir().join(format!("functor-lang-net-server-{}", std::process::id()));
+        let dir =
+            std::env::temp_dir().join(format!("functor-lang-net-server-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(
@@ -1246,7 +1256,10 @@ mod tests {
     /// a whole project since B8 — a shared temp dir would drag stray `.fun`
     /// files in as sibling modules) and return `load_game`'s error.
     fn load_err(name: &str, src: &str) -> String {
-        let dir = std::env::temp_dir().join(format!("functor-lang-game-test-{}-{name}", std::process::id()));
+        let dir = std::env::temp_dir().join(format!(
+            "functor-lang-game-test-{}-{name}",
+            std::process::id()
+        ));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).expect("create temp project dir");
         let path = dir.join("game.fun");
@@ -1299,7 +1312,10 @@ mod tests {
     /// per file). [Codex Medium — B8 review]
     #[test]
     fn pushed_entry_survives_sibling_reloads() {
-        let dir = std::env::temp_dir().join(format!("functor-lang-game-test-{}-push", std::process::id()));
+        let dir = std::env::temp_dir().join(format!(
+            "functor-lang-game-test-{}-push",
+            std::process::id()
+        ));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).expect("create temp project dir");
         let entry = dir.join("game.fun");
@@ -1392,8 +1408,10 @@ mod tests {
             }
         }
 
-        let dir =
-            std::env::temp_dir().join(format!("functor-lang-game-test-{}-history", std::process::id()));
+        let dir = std::env::temp_dir().join(format!(
+            "functor-lang-game-test-{}-history",
+            std::process::id()
+        ));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).expect("create temp project dir");
         std::fs::write(
@@ -1409,7 +1427,10 @@ mod tests {
         assert_eq!(game.recorder.scene_frame_range(), None);
 
         for _ in 0..5 {
-            game.tick(FrameTime { tts: 0.0, dts: 0.016 });
+            game.tick(FrameTime {
+                tts: 0.0,
+                dts: 0.016,
+            });
         }
 
         // Five rendered frames, indexed 0..4; recording left the live model
@@ -1425,12 +1446,15 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// Plain-data model history carries no module IR, so it remains seekable
-    /// across a hot reload and recording resumes consecutively.
+    /// Plain-data model history carries no module IR, so a reload while
+    /// scrubbed keeps the selected cursor and full future. Resume—not reload—
+    /// commits the branch and recording continues consecutively.
     #[test]
-    fn hot_reload_preserves_plain_data_history_and_recording_resumes() {
-        let dir = std::env::temp_dir()
-            .join(format!("functor-lang-game-test-{}-history-reload", std::process::id()));
+    fn hot_reload_preserves_a_plain_data_scrub_and_future_until_resume() {
+        let dir = std::env::temp_dir().join(format!(
+            "functor-lang-game-test-{}-history-reload",
+            std::process::id()
+        ));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).expect("create temp project dir");
         let src = "let init = { n: 0.0 }\n\
@@ -1440,24 +1464,30 @@ mod tests {
         let mut game = FunctorLangGame::create(dir.join("game.fun").to_str().expect("utf-8 path"));
 
         for _ in 0..3 {
-            game.tick(FrameTime { tts: 0.0, dts: 0.016 });
+            game.tick(FrameTime {
+                tts: 0.0,
+                dts: 0.016,
+            });
         }
         assert_eq!(game.recorder.scene_frame_range(), Some((0, 2)));
+        game.seek_scene_to(0).expect("scrub before reload");
 
         // Push a fresh source: the model is rebound and the plain-data history
-        // remains available under the new program.
+        // remains available under the new program without moving the cursor.
         game.reload_source(src).expect("reload should succeed");
         assert_eq!(
             game.recorder.scene_frame_range(),
             Some((0, 2)),
             "plain-data history should survive the reload"
         );
-        game.seek_scene_to(0).expect("old frame remains seekable");
+        assert_eq!(game.current_scene_frame(), Some(0));
 
-        // Return to the live tail, then recording continues monotonically.
-        game.seek_scene_to(2).expect("seek live tail");
-        game.tick(FrameTime { tts: 0.0, dts: 0.016 });
-        assert_eq!(game.recorder.scene_frame_range(), Some((0, 3)));
+        // Resume commits the branch from frame 0, then records frame 1.
+        game.tick(FrameTime {
+            tts: 0.0,
+            dts: 0.016,
+        });
+        assert_eq!(game.recorder.scene_frame_range(), Some((0, 1)));
 
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -1488,8 +1518,10 @@ mod tests {
         // Isolate the physics world from any prior test on this thread.
         physics::remove_world(physics::DEFAULT_WORLD);
 
-        let dir = std::env::temp_dir()
-            .join(format!("functor-lang-game-test-{}-coupled", std::process::id()));
+        let dir = std::env::temp_dir().join(format!(
+            "functor-lang-game-test-{}-coupled",
+            std::process::id()
+        ));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).expect("create temp project dir");
         std::fs::write(
@@ -1504,7 +1536,10 @@ mod tests {
         .expect("write game");
         let mut game = FunctorLangGame::create(dir.join("game.fun").to_str().expect("utf-8 path"));
 
-        let dt = FrameTime { tts: 0.0, dts: physics::FIXED_DT };
+        let dt = FrameTime {
+            tts: 0.0,
+            dts: physics::FIXED_DT,
+        };
         // Frames 0..3 (4 ticks): the ball falls under gravity, n counts up.
         for _ in 0..4 {
             game.tick(dt.clone());
@@ -1516,7 +1551,10 @@ mod tests {
         }
         let y_at_9 = ball_y();
         assert_eq!(n_of(&game.model), 10.0);
-        assert!(y_at_3 > y_at_9, "ball should have fallen further by frame 9");
+        assert!(
+            y_at_3 > y_at_9,
+            "ball should have fallen further by frame 9"
+        );
 
         // Rewind the WHOLE scene to rendered frame 3.
         let status = game.rewind_scene_to(3).expect("rewind should succeed");
@@ -1575,14 +1613,20 @@ mod tests {
         assert_eq!(game.scene_frame_range(), Some((0, 4)));
 
         // Live (not scrubbing): render draws at the real clock — eye.x == 42.0.
-        let live = game.render(FrameTime { tts: 42.0, dts: 1.0 });
+        let live = game.render(FrameTime {
+            tts: 42.0,
+            dts: 1.0,
+        });
         assert_eq!(live.camera.eye[0], 42.0, "live render uses the real clock");
 
         // Scrub back to frame 1 (recorded tts = 2.0). Even though render is
         // handed a bogus live tts, `draw` must run at the RECORDED tts, so the
         // tts-driven camera rewinds to eye.x == 2.0 — the bug this fixes.
         game.seek_scene_to(1).expect("seek 1");
-        let scrubbed = game.render(FrameTime { tts: 99.0, dts: 0.0 });
+        let scrubbed = game.render(FrameTime {
+            tts: 99.0,
+            dts: 0.0,
+        });
         assert_eq!(
             scrubbed.camera.eye[0], 2.0,
             "scrubbed frame must render at its recorded tts, not the live clock"
@@ -1608,7 +1652,10 @@ mod tests {
             }
         }
         physics::remove_world(physics::DEFAULT_WORLD);
-        let dir = std::env::temp_dir().join(format!("functor-lang-game-test-{}-scrub", std::process::id()));
+        let dir = std::env::temp_dir().join(format!(
+            "functor-lang-game-test-{}-scrub",
+            std::process::id()
+        ));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).expect("create temp project dir");
         std::fs::write(
@@ -1622,7 +1669,10 @@ mod tests {
         .expect("write game");
         let mut game = FunctorLangGame::create(dir.join("game.fun").to_str().expect("utf-8 path"));
 
-        let dt = FrameTime { tts: 0.0, dts: physics::FIXED_DT };
+        let dt = FrameTime {
+            tts: 0.0,
+            dts: physics::FIXED_DT,
+        };
         for _ in 0..10 {
             game.tick(dt.clone());
         }
@@ -1633,9 +1683,17 @@ mod tests {
         game.seek_scene_to(3).expect("seek 3");
         assert_eq!(n_of(&game.model), 4.0);
         assert_eq!(game.current_scene_frame(), Some(3));
-        assert_eq!(game.scene_frame_range(), Some((0, 9)), "seek must not truncate");
+        assert_eq!(
+            game.scene_frame_range(),
+            Some((0, 9)),
+            "seek must not truncate"
+        );
         game.seek_scene_to(7).expect("seek 7");
-        assert_eq!(n_of(&game.model), 8.0, "can scrub FORWARD again (non-destructive)");
+        assert_eq!(
+            n_of(&game.model),
+            8.0,
+            "can scrub FORWARD again (non-destructive)"
+        );
         assert_eq!(game.scene_frame_range(), Some((0, 9)));
         game.seek_scene_to(2).expect("seek 2");
         assert_eq!(n_of(&game.model), 3.0);
@@ -1644,8 +1702,16 @@ mod tests {
         // is discarded, and recording continues at frame 3.
         game.tick(dt.clone());
         assert_eq!(game.current_scene_frame(), Some(3), "no longer scrubbing");
-        assert_eq!(game.scene_frame_range(), Some((0, 3)), "future branched away");
-        assert_eq!(n_of(&game.model), 4.0, "model advanced from the scrubbed frame");
+        assert_eq!(
+            game.scene_frame_range(),
+            Some((0, 3)),
+            "future branched away"
+        );
+        assert_eq!(
+            n_of(&game.model),
+            4.0,
+            "model advanced from the scrubbed frame"
+        );
 
         physics::remove_world(physics::DEFAULT_WORLD);
         let _ = std::fs::remove_dir_all(&dir);
@@ -1667,8 +1733,10 @@ mod tests {
         }
 
         physics::remove_world(physics::DEFAULT_WORLD);
-        let dir =
-            std::env::temp_dir().join(format!("functor-lang-game-test-{}-latest", std::process::id()));
+        let dir = std::env::temp_dir().join(format!(
+            "functor-lang-game-test-{}-latest",
+            std::process::id()
+        ));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).expect("create temp project dir");
         std::fs::write(
@@ -1682,17 +1750,25 @@ mod tests {
         .expect("write game");
         let mut game = FunctorLangGame::create(dir.join("game.fun").to_str().expect("utf-8 path"));
 
-        let dt = FrameTime { tts: 0.0, dts: physics::FIXED_DT };
+        let dt = FrameTime {
+            tts: 0.0,
+            dts: physics::FIXED_DT,
+        };
         for _ in 0..8 {
             game.tick(dt.clone());
         }
         let y_before = ball_y();
 
         // Latest recorded frame is 7 (0..7).
-        let status = game.rewind_scene_to(7).expect("rewind to latest should succeed");
+        let status = game
+            .rewind_scene_to(7)
+            .expect("rewind to latest should succeed");
         assert!(status.contains("frame 7"), "unexpected status: {status}");
         // World untouched (no physics seek), model still current.
-        assert!((ball_y() - y_before).abs() < 1e-6, "latest-frame rewind moved the world");
+        assert!(
+            (ball_y() - y_before).abs() < 1e-6,
+            "latest-frame rewind moved the world"
+        );
         assert_eq!(game.recorder.scene_frame_range(), Some((0, 7)));
 
         physics::remove_world(physics::DEFAULT_WORLD);
@@ -1717,7 +1793,8 @@ mod tests {
         // physics test on this thread — start from an empty world.
         physics::remove_world(physics::DEFAULT_WORLD);
 
-        let dir = std::env::temp_dir().join(format!("functor-lang-fwd-step-{}", std::process::id()));
+        let dir =
+            std::env::temp_dir().join(format!("functor-lang-fwd-step-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).expect("create temp project dir");
         std::fs::write(
@@ -1800,7 +1877,11 @@ mod tests {
         assert_eq!(forward.len(), DIVISIONS, "division count");
         // The scene genuinely evolves: the world moves across the window and the
         // ball lands (a Contact folds `hits` up through `update`).
-        assert_ne!(live[0].1, live[N - 1].1, "world should move over the window");
+        assert_ne!(
+            live[0].1,
+            live[N - 1].1,
+            "world should move over the window"
+        );
         assert!(
             game.model.to_string().contains("hits: ")
                 && !game.model.to_string().contains("hits: 0"),
@@ -1812,7 +1893,11 @@ mod tests {
         for (div, (fwd_m, fwd_w)) in forward.iter().enumerate() {
             let live_idx = (div + 1) * STEPS_PER_DIV - 1;
             let (live_m, live_w) = &live[live_idx];
-            assert_eq!(fwd_m.to_string(), *live_m, "model diverged at division {div}");
+            assert_eq!(
+                fwd_m.to_string(),
+                *live_m,
+                "model diverged at division {div}"
+            );
             assert_eq!(fwd_w, live_w, "world diverged at division {div}");
         }
 
@@ -1872,7 +1957,10 @@ mod tests {
         let fork_tts = tts;
         // The fork is pre-jump: grounded, running, still well left of the chasm.
         assert_eq!(field(&fork_model, "grounded"), 1.0, "fork must be grounded");
-        assert!(field(&fork_model, "x") < -3.0, "fork must be left of the edge");
+        assert!(
+            field(&fork_model, "x") < -3.0,
+            "fork must be left of the edge"
+        );
 
         // Phase 2: the live continuation — run to the edge and JUMP at the last
         // grounded frame before walking off (the optimal launch), then land. This
@@ -1904,8 +1992,10 @@ mod tests {
         let up_events: usize = inputs
             .iter()
             .flatten()
-            .filter(|e| matches!(e, functor_runtime_common::RecordedInput::Key { code, is_down }
-                if *code == Key::Up as i32 && *is_down))
+            .filter(|e| {
+                matches!(e, functor_runtime_common::RecordedInput::Key { code, is_down }
+                if *code == Key::Up as i32 && *is_down)
+            })
             .count();
         assert_eq!(up_events, 1, "exactly one recorded jump");
 
@@ -2018,7 +2108,11 @@ mod tests {
             (field(&game.model, "x") - recorded[S as usize].0).abs() < 1e-9,
             "scrubbed model must be the recorded frame S"
         );
-        assert_eq!(field(&game.model, "grounded"), 1.0, "S is pre-jump / grounded");
+        assert_eq!(
+            field(&game.model, "grounded"),
+            1.0,
+            "S is pre-jump / grounded"
+        );
 
         // Resolve the fork EXACTLY as `ghost_frames(script_inputs = None)` does.
         let k = game.current_scene_frame().unwrap();
@@ -2063,7 +2157,10 @@ mod tests {
             );
         }
         // The strobe visibly shows the JUMP: some division rose above the ground.
-        assert!(peak_y > 0.5, "the ghost should show the jump arc, peak y = {peak_y}");
+        assert!(
+            peak_y > 0.5,
+            "the ghost should show the jump arc, peak y = {peak_y}"
+        );
     }
 
     /// Regression (xreview): under the fixed-timestep loop a live input can be
@@ -2211,7 +2308,10 @@ mod tests {
         assert_eq!(kicked.len(), DIVISIONS);
         let coast_x = ghosts.last().unwrap().0.scene.xform.w.x;
         let kicked_x = kicked.last().unwrap().0.scene.xform.w.x;
-        assert!(coast_x.abs() < 1e-3, "coast ghost stays centered: {coast_x}");
+        assert!(
+            coast_x.abs() < 1e-3,
+            "coast ghost stays centered: {coast_x}"
+        );
         assert!(
             kicked_x > 1.0,
             "the replayed kick must move the projected ball: {kicked_x}"
@@ -2333,10 +2433,8 @@ mod tests {
     /// does NOT leak into the resume frame's journal as a phantom.
     #[test]
     fn paused_injected_input_folds_into_the_trace_not_the_resume_frame() {
-        let dir = std::env::temp_dir().join(format!(
-            "functor-inspector-input-{}",
-            std::process::id()
-        ));
+        let dir =
+            std::env::temp_dir().join(format!("functor-inspector-input-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("game.fun"), INSPECTOR_GAME).unwrap();
@@ -2369,8 +2467,7 @@ mod tests {
         // Resume (a real frame runs): the new frame's journal replaces
         // everything — no phantom input carried over from the paused injection.
         game.tick(FrameTime { dts: 0.1, tts: 0.6 });
-        let resumed: serde_json::Value =
-            serde_json::from_str(&game.inspector_trace(true)).unwrap();
+        let resumed: serde_json::Value = serde_json::from_str(&game.inspector_trace(true)).unwrap();
         let entries: Vec<&str> = resumed["invocations"]
             .as_array()
             .unwrap()

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -509,13 +509,10 @@ impl FunctorLangGame {
         // the next render's `ui(model)` rebuilds it against the new one. A
         // click landing in the gap resolves an unknown slot and is dropped.
         self.ui_handlers.clear();
-        // Reload is a model-history BOUNDARY: the retained snapshots can hold
-        // closures bound to the old module, so — unlike the live model, which
-        // `rebind_value` migrates above — they can't safely cross a reload. The
-        // recorder keeps its rendered-frame clock monotonic so recording resumes
-        // consecutively. (Rebinding snapshots to preserve rewind ACROSS an edit
-        // is deferred to when that feature is built — docs/time-travel.md.)
-        self.recorder.reset_on_reload();
+        // Plain-data snapshots remain seekable under the new program. A model
+        // history containing callable or opaque host values instead starts a new
+        // generation anchored at this rebound live frame.
+        self.recorder.finish_reload(&self.model, self.physics_frame);
         report.rebound
     }
 
@@ -1428,12 +1425,10 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// Hot reload is a model-history boundary (xreview): the ring is reset so
-    /// it never retains old-module snapshots, while `rendered_frame` stays
-    /// monotonic so recording resumes CONSECUTIVELY after the reload (a stale
-    /// non-consecutive record would panic in `History::record`).
+    /// Plain-data model history carries no module IR, so it remains seekable
+    /// across a hot reload and recording resumes consecutively.
     #[test]
-    fn hot_reload_resets_history_and_recording_resumes() {
+    fn hot_reload_preserves_plain_data_history_and_recording_resumes() {
         let dir = std::env::temp_dir()
             .join(format!("functor-lang-game-test-{}-history-reload", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
@@ -1449,19 +1444,20 @@ mod tests {
         }
         assert_eq!(game.recorder.scene_frame_range(), Some((0, 2)));
 
-        // Push a fresh (compatible) source: the model is rebound and KEPT, but
-        // the history ring is reset.
+        // Push a fresh source: the model is rebound and the plain-data history
+        // remains available under the new program.
         game.reload_source(src).expect("reload should succeed");
         assert_eq!(
             game.recorder.scene_frame_range(),
-            None,
-            "reload must reset the model history"
+            Some((0, 2)),
+            "plain-data history should survive the reload"
         );
+        game.seek_scene_to(0).expect("old frame remains seekable");
 
-        // Recording resumes at the current (monotonic) rendered frame — the
-        // fresh ring re-bases there, so no non-consecutive panic.
+        // Return to the live tail, then recording continues monotonically.
+        game.seek_scene_to(2).expect("seek live tail");
         game.tick(FrameTime { tts: 0.0, dts: 0.016 });
-        assert_eq!(game.recorder.scene_frame_range(), Some((3, 3)));
+        assert_eq!(game.recorder.scene_frame_range(), Some((0, 3)));
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/runtime/functor-runtime-web/scrubber.js
+++ b/runtime/functor-runtime-web/scrubber.js
@@ -4,6 +4,7 @@
 
 import {
   functor_lang_scene_frame,
+  functor_lang_scene_generation,
   functor_lang_scene_range,
   functor_lang_seek_scene,
   functor_lang_scrub_seek_result,
@@ -59,6 +60,7 @@ const STYLE = `
 }
 #scrub-timeline { position: absolute; inset: 0; width: 100%; height: 100%; overflow: visible; }
 #scrub-track-bg { fill: rgba(155, 148, 179, 0.18); }
+.scrub-unavailable { fill: url(#scrub-unavailable-pattern); }
 #scrub-recorded { fill: rgba(65, 216, 230, 0.30); }
 #scrub-played { fill: var(--sb-accent); opacity: 0.62; }
 #scrub-future { fill: var(--sb-future); opacity: 0.9; }
@@ -139,7 +141,16 @@ const HTML = `
   <span id="scrub-rail" aria-label="Time-travel timeline" title="Drag to seek">
     <svg id="scrub-timeline" viewBox="0 0 1000 30" preserveAspectRatio="none"
       role="group" aria-label="Timeline event markers">
+      <defs>
+        <pattern id="scrub-unavailable-pattern" width="12" height="12"
+          patternUnits="userSpaceOnUse" patternTransform="rotate(20)">
+          <rect width="12" height="12" fill="rgba(8, 7, 14, 0.72)" />
+          <rect width="4" height="12" fill="rgba(155, 148, 179, 0.30)" />
+        </pattern>
+      </defs>
       <rect id="scrub-track-bg" x="0" y="12" width="1000" height="6" rx="3" aria-hidden="true" />
+      <rect id="scrub-unavailable" class="scrub-unavailable" x="0" y="12" width="0" height="6" rx="3" aria-hidden="true" />
+      <rect id="scrub-unavailable-after" class="scrub-unavailable" x="1000" y="12" width="0" height="6" rx="3" aria-hidden="true" />
       <rect id="scrub-recorded" x="0" y="12" width="1000" height="6" rx="3" aria-hidden="true" />
       <rect id="scrub-played" x="0" y="12" width="0" height="6" rx="3" aria-hidden="true" />
       <rect id="scrub-future" x="0" y="11" width="0" height="8" rx="3" aria-hidden="true" />
@@ -186,6 +197,8 @@ export function mountScrubber() {
   const pause = $("scrub-pause");
   const step = $("scrub-step");
   const label = $("scrub-count");
+  const unavailable = $("scrub-unavailable");
+  const unavailableAfter = $("scrub-unavailable-after");
   const recorded = $("scrub-recorded");
   const played = $("scrub-played");
   const future = $("scrub-future");
@@ -345,11 +358,23 @@ export function mountScrubber() {
     const playheadPct = current.playheadUnit * 100;
     const previewPct = current.previewEndUnit * 100;
     const futureWidth = Math.max(previewPct - playheadPct, 0);
-    const previewVisible =
-      state.preview.enabled && current.paused && current.recordingAvailable;
+    const previewVisible = state.preview.enabled && current.paused;
 
     playhead.style.left = `${playheadPct}%`;
-    playhead.style.display = current.recordingAvailable ? "block" : "none";
+    playhead.style.display = "block";
+    unavailable.setAttribute(
+      "width",
+      String(current.hasUnavailableHistory ? current.unavailableEndUnit * 1000 : 0)
+    );
+    unavailableAfter.setAttribute("x", String(current.unavailableAfterStartUnit * 1000));
+    unavailableAfter.setAttribute(
+      "width",
+      String(
+        current.hasUnavailableHistory
+          ? Math.max(1 - current.unavailableAfterStartUnit, 0) * 1000
+          : 0
+      )
+    );
     recorded.setAttribute("x", String(current.recordedStartUnit * 1000));
     recorded.setAttribute(
       "width",
@@ -382,10 +407,10 @@ export function mountScrubber() {
     overflow.style.display = previewVisible && current.previewClippedFrames > 0 ? "block" : "none";
     overflow.textContent = `+${current.previewClippedFrames}`;
 
-    playhead.setAttribute("aria-valuemin", String(current.viewport.lo));
+    playhead.setAttribute("aria-valuemin", String(current.recorded.lo));
     playhead.setAttribute(
       "aria-valuemax",
-      String(Math.max(current.viewport.hi, current.selectedFrame))
+      String(Math.max(current.recorded.hi, current.selectedFrame))
     );
     playhead.setAttribute("aria-valuenow", String(current.selectedFrame));
     playhead.setAttribute(
@@ -411,14 +436,14 @@ export function mountScrubber() {
         (current.previewClippedFrames ? `, ${current.previewClippedFrames} frames clipped` : "")
     );
 
-    label.innerHTML = current.recordingAvailable
-      ? `${current.selectedFrame}` +
-        (current.playheadClippedBefore || current.playheadClippedAfter
-          ? ` <span class="out">outside</span>`
-          : "") +
-        (state.preview.enabled ? ` <span class="fut">+${current.previewFrames}</span>` : "") +
-        ` / ${Math.round(current.viewport.hi)}`
-      : "reload boundary · Step or Resume";
+    label.innerHTML =
+      `${current.selectedFrame}` +
+      (current.playheadClippedBefore || current.playheadClippedAfter
+        ? ` <span class="out">outside</span>`
+        : "") +
+      (state.preview.enabled ? ` <span class="fut">+${current.previewFrames}</span>` : "") +
+      ` / ${Math.round(current.viewport.hi)}` +
+      (current.hasUnavailableHistory ? ` <span class="out">· reload boundary</span>` : "");
     pause.textContent = current.paused ? "▶" : "⏸";
     pause.setAttribute("aria-label", current.paused ? "Resume" : "Pause");
     extrapolate.classList.toggle("on", state.preview.enabled);
@@ -486,8 +511,8 @@ export function mountScrubber() {
       ArrowUp: current.selectedFrame + steps,
       PageDown: current.selectedFrame - TIMELINE_FPS,
       PageUp: current.selectedFrame + TIMELINE_FPS,
-      Home: current.viewport.lo,
-      End: current.viewport.hi,
+      Home: current.recorded.lo,
+      End: current.recorded.hi,
     };
     if (!(event.key in targets)) return;
     event.preventDefault();
@@ -593,8 +618,11 @@ export function mountScrubber() {
         lo: range[0],
         hi: range[1],
         paused: functor_lang_scrub_paused(),
+        generation: functor_lang_scene_generation(),
       };
-      const snapshotKey = `${snapshot.frame}:${snapshot.lo}:${snapshot.hi}:${snapshot.paused}`;
+      const snapshotKey =
+        `${snapshot.frame}:${snapshot.lo}:${snapshot.hi}:` +
+        `${snapshot.paused}:${snapshot.generation}`;
       if (snapshotKey !== lastRuntimeSnapshotKey) {
         lastRuntimeSnapshotKey = snapshotKey;
         dispatch({ type: "runtime-published", snapshot });

--- a/runtime/functor-runtime-web/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-web/src/functor_lang_game.rs
@@ -396,11 +396,10 @@ impl FunctorLangWebGame {
         // The widget handler table holds msgs/taggers into the OLD session;
         // the next render's `ui(model)` rebuilds it against the new one.
         self.ui_handlers.clear();
-        // Reload is a model-history BOUNDARY (see the desktop producer): the
-        // retained snapshots can hold old-module closures, so they can't cross
-        // a reload; the recorder keeps its rendered-frame clock monotonic so
-        // recording resumes consecutively.
-        self.recorder.reset_on_reload();
+        // Plain-data snapshots remain seekable under the new program. A model
+        // history containing callable or opaque host values instead starts a new
+        // generation anchored at this rebound live frame.
+        self.recorder.finish_reload(&self.model, self.physics_frame);
         self.has_ui = loaded.has_ui;
         if !self.has_ui {
             // Deleting the `ui` hook drops the HUD (the physics-world rule).
@@ -582,10 +581,6 @@ impl GameProducer for FunctorLangWebGame {
 
     fn scene_timeline_generation(&self) -> u64 {
         self.recorder.generation()
-    }
-
-    fn next_scene_frame(&self) -> Option<u64> {
-        Some(self.recorder.next_frame())
     }
 
     fn current_scene_tts(&self) -> Option<f64> {
@@ -1160,10 +1155,11 @@ pub enum ScrubControl {
 
 thread_local! {
     static SCRUB_CONTROLS: RefCell<Vec<ScrubControl>> = const { RefCell::new(Vec::new()) };
-    /// Published each frame for the page's slider: `(frame, lo, hi, paused)`.
+    /// Published each frame for the page's slider:
+    /// `(frame, lo, hi, paused, history generation)`.
     /// `frame`/`lo`/`hi` are `-1.0` when nothing is recorded yet.
-    static SCRUB_VIEW: RefCell<(f64, f64, f64, bool)> =
-        const { RefCell::new((-1.0, -1.0, -1.0, false)) };
+    static SCRUB_VIEW: RefCell<(f64, f64, f64, bool, u64)> =
+        const { RefCell::new((-1.0, -1.0, -1.0, false, 0)) };
     /// Latest completed seek as `(request id, authoritative applied frame)`.
     /// The DOM uses this acknowledgement to retire optimistic handle state even
     /// when the runtime clamps or refuses a request.
@@ -1333,9 +1329,8 @@ pub fn publish_timeline_inputs(game: &dyn GameProducer) {
     });
 }
 
-/// Record a reload boundary. Successful reloads reset model snapshots, so the
-/// marker belongs to the next monotonic frame; failures mark the attempted
-/// boundary without changing the running program.
+/// Record a reload boundary at the scene frame that remained current through
+/// the swap. Failures mark the attempted boundary without changing the program.
 pub fn publish_timeline_reload(frame: u64, ok: bool, message: &str) {
     TIMELINE_LOG.with(|log| {
         log.borrow_mut().push(
@@ -1379,12 +1374,17 @@ pub fn take_scrub_controls() -> Vec<ScrubControl> {
 }
 
 /// Publish this frame's scrubber state for the page to poll.
-pub fn publish_scrub_view(frame: Option<u64>, range: Option<(u64, u64)>, paused: bool) {
+pub fn publish_scrub_view(
+    frame: Option<u64>,
+    range: Option<(u64, u64)>,
+    paused: bool,
+    generation: u64,
+) {
     let f = frame.map(|f| f as f64).unwrap_or(-1.0);
     let (lo, hi) = range
         .map(|(l, h)| (l as f64, h as f64))
         .unwrap_or((-1.0, -1.0));
-    SCRUB_VIEW.with(|v| *v.borrow_mut() = (f, lo, hi, paused));
+    SCRUB_VIEW.with(|v| *v.borrow_mut() = (f, lo, hi, paused, generation));
 }
 
 /// Page → runtime: toggle pause (pin/unpin the clock).
@@ -1454,7 +1454,7 @@ pub fn functor_lang_scene_frame() -> f64 {
 /// Runtime → page: the seekable window as `[lo, hi]`, or `[]` if empty.
 #[wasm_bindgen]
 pub fn functor_lang_scene_range() -> Vec<f64> {
-    let (_, lo, hi, _) = SCRUB_VIEW.with(|v| *v.borrow());
+    let (_, lo, hi, _, _) = SCRUB_VIEW.with(|v| *v.borrow());
     if lo < 0.0 {
         vec![]
     } else {
@@ -1466,6 +1466,12 @@ pub fn functor_lang_scene_range() -> Vec<f64> {
 #[wasm_bindgen]
 pub fn functor_lang_scrub_paused() -> bool {
     SCRUB_VIEW.with(|v| v.borrow().3)
+}
+
+/// Runtime → page: current seekable-history generation.
+#[wasm_bindgen]
+pub fn functor_lang_scene_generation() -> f64 {
+    SCRUB_VIEW.with(|v| v.borrow().4 as f64)
 }
 
 // --- Paused-scene inspector ↔ DOM bridge (visual-debugger PR2b) --------------

--- a/runtime/functor-runtime-web/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-web/src/functor_lang_game.rs
@@ -21,6 +21,8 @@
 
 use std::cell::RefCell;
 
+use functor_lang::project::SourceMap;
+use functor_lang::{Session, Value};
 use functor_runtime_common::functor_lang_prelude::{
     audio_scene_of, clear_audio_completions, clear_http_taggers, contains_effect, frame_value,
     take_ui_handlers, view_value, EffectLog, EffectRunner, EffectTree, FunctorHost, NetEventKind,
@@ -35,8 +37,6 @@ use functor_runtime_common::protocol::GameProducer;
 use functor_runtime_common::timetravel::SceneRecorder;
 use functor_runtime_common::ui::View;
 use functor_runtime_common::{Frame, FrameTime};
-use functor_lang::project::SourceMap;
-use functor_lang::{Session, Value};
 use wasm_bindgen::prelude::*;
 
 pub struct FunctorLangWebGame {
@@ -175,8 +175,9 @@ fn load_source(sources: &[(String, String)]) -> Result<Loaded, String> {
     // interfaces so `Scene.*` (etc.) typecheck against real types — the exact
     // path the desktop producer runs (docs/functor-lang-interfaces.md). Check-time only; the
     // FunctorHost still provides the actual runtime values.
-    let project = functor_lang::project::load_sources_with_prelude(pairs, &functor_prelude::modules())
-        .map_err(|e| format!("cannot load {}", e.render()))?;
+    let project =
+        functor_lang::project::load_sources_with_prelude(pairs, &functor_prelude::modules())
+            .map_err(|e| format!("cannot load {}", e.render()))?;
     let module = project.module;
     let source_map = project.sources;
     // Type diagnostics are advisory in the dev loop: warn, keep going
@@ -184,11 +185,19 @@ fn load_source(sources: &[(String, String)]) -> Result<Loaded, String> {
     // project file they land in.
     for diag in functor_lang::check(&module) {
         web_sys::console::warn_1(
-            &format!("warning: {}", source_map.render(diag.span.start, &diag.message)).into(),
+            &format!(
+                "warning: {}",
+                source_map.render(diag.span.start, &diag.message)
+            )
+            .into(),
         );
     }
-    let session = Session::load(&module, &mut FunctorHost)
-        .map_err(|f| format!("cannot load {}", source_map.render(f.error.span.start, &f.error.message)))?;
+    let session = Session::load(&module, &mut FunctorHost).map_err(|f| {
+        format!(
+            "cannot load {}",
+            source_map.render(f.error.span.start, &f.error.message)
+        )
+    })?;
     // The producer contract is knowable at load — fail here, not once per
     // frame: `init` must be a model VALUE, `tick`/`draw` functions of the
     // right arity.
@@ -351,7 +360,7 @@ impl FunctorLangWebGame {
     /// right through a reload. Returns the number of stored closures rebound,
     /// for the status line.
     fn swap_in(&mut self, loaded: Loaded) -> usize {
-        self.recorder.commit_scrub_before_reload(
+        let live_model_was_safe = self.recorder.prepare_reload(
             &mut self.model,
             &mut self.physics_rt,
             &mut self.physics_frame,
@@ -369,7 +378,8 @@ impl FunctorLangWebGame {
         self.last_frame_journal.clear();
         self.cached_trace = None;
         journal_swap(); // discard any partial current-frame journal
-        self.reporter.set_source(SpanSource::Project(loaded.sources));
+        self.reporter
+            .set_source(SpanSource::Project(loaded.sources));
         self.module = loaded.module;
         self.session = loaded.session;
         self.has_input = loaded.has_input;
@@ -399,7 +409,8 @@ impl FunctorLangWebGame {
         // Plain-data snapshots remain seekable under the new program. A model
         // history containing callable or opaque host values instead starts a new
         // generation anchored at this rebound live frame.
-        self.recorder.finish_reload(&self.model, self.physics_frame);
+        self.recorder
+            .finish_reload(&self.model, self.physics_frame, live_model_was_safe);
         self.has_ui = loaded.has_ui;
         if !self.has_ui {
             // Deleting the `ui` hook drops the HUD (the physics-world rule).
@@ -832,20 +843,22 @@ AudioScene.empty), got {}",
         functor_runtime_common::net::drain_commands_json()
     }
     fn net_push_http_response(&mut self, token: i32, status: i32, body: String) {
-        self.ctx().deliver_http_result(functor_runtime_common::net::HttpResult {
-            token: token as u64,
-            status: status as u16,
-            body: body.into_bytes(),
-            error: None,
-        });
+        self.ctx()
+            .deliver_http_result(functor_runtime_common::net::HttpResult {
+                token: token as u64,
+                status: status as u16,
+                body: body.into_bytes(),
+                error: None,
+            });
     }
     fn net_push_http_error(&mut self, token: i32, message: String) {
-        self.ctx().deliver_http_result(functor_runtime_common::net::HttpResult {
-            token: token as u64,
-            status: 0,
-            body: Vec::new(),
-            error: Some(message),
-        });
+        self.ctx()
+            .deliver_http_result(functor_runtime_common::net::HttpResult {
+                token: token as u64,
+                status: 0,
+                body: Vec::new(),
+                error: Some(message),
+            });
     }
     fn audio_drain_commands(&self) -> String {
         // One-shot commands (Effect.play/playAt/playThen); the page's Web Audio
@@ -862,16 +875,20 @@ AudioScene.empty), got {}",
         functor_runtime_common::net::drain_conn_commands_json()
     }
     fn net_push_connected(&mut self, key: String, conn: i32) {
-        self.ctx().deliver_net_event(key, NetEventKind::Connected, conn, String::new());
+        self.ctx()
+            .deliver_net_event(key, NetEventKind::Connected, conn, String::new());
     }
     fn net_push_conn_message(&mut self, key: String, conn: i32, text: String) {
-        self.ctx().deliver_net_event(key, NetEventKind::Message, conn, text);
+        self.ctx()
+            .deliver_net_event(key, NetEventKind::Message, conn, text);
     }
     fn net_push_disconnected(&mut self, key: String, conn: i32) {
-        self.ctx().deliver_net_event(key, NetEventKind::Disconnected, conn, String::new());
+        self.ctx()
+            .deliver_net_event(key, NetEventKind::Disconnected, conn, String::new());
     }
     fn net_push_conn_error(&mut self, key: String, conn: i32, message: String) {
-        self.ctx().deliver_net_event(key, NetEventKind::Error, conn, message);
+        self.ctx()
+            .deliver_net_event(key, NetEventKind::Error, conn, message);
     }
     fn audio_push_finished(&mut self, token: i32) {
         self.ctx().deliver_audio_completion(token as u64);
@@ -1150,7 +1167,10 @@ pub enum ScrubControl {
     SetPreview(u32),
     /// The ⚙ popover's shared forward window (seconds) + samples-per-second
     /// rate, pushed by the DOM inputs on change.
-    SetPreviewConfig { window: f32, rate: usize },
+    SetPreviewConfig {
+        window: f32,
+        rate: usize,
+    },
 }
 
 thread_local! {
@@ -1227,7 +1247,8 @@ impl TimelineLog {
 
     fn reset_inputs(&mut self) {
         let old_len = self.markers.len();
-        self.markers.retain(|marker| marker.kind.starts_with("reload-"));
+        self.markers
+            .retain(|marker| marker.kind.starts_with("reload-"));
         if self.markers.len() != old_len {
             self.changed();
         }

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -288,10 +288,11 @@ fn apply_pending_reload(game: &mut dyn GameProducer) {
     };
     match outcome {
         Ok(status) => {
-            let next_recorded_frame = game
-                .next_scene_frame()
-                .unwrap_or_else(|| selected_frame.saturating_add(1));
-            functor_lang_game::publish_timeline_reload(next_recorded_frame, true, &status);
+            // The live scene remains on the selected/current frame across the
+            // swap. Mark that exact boundary; using the next frame makes a
+            // paused marker sit outside the seekable range and get pruned.
+            let reload_frame = game.current_scene_frame().unwrap_or(selected_frame);
+            functor_lang_game::publish_timeline_reload(reload_frame, true, &status);
             hide_error_overlay();
             post_reload_result(true, &status, id);
         }
@@ -1491,6 +1492,7 @@ async fn run_async() -> Result<(), JsValue> {
                 game.current_scene_frame(),
                 game.scene_frame_range(),
                 clock.is_paused(),
+                game.scene_timeline_generation(),
             );
 
             // Publish the paused-inspector trace for the page's poll loop

--- a/runtime/functor-runtime-web/timeline-model.js
+++ b/runtime/functor-runtime-web/timeline-model.js
@@ -84,7 +84,10 @@ export function reduceTimeline(state, action) {
         const span = Math.max(continuity.span, recorded.hi - recorded.lo);
         const hi = Math.max(continuity.anchorHi, recorded.hi);
         viewport = { lo: hi - span, hi };
-        if (recorded.lo <= viewport.lo) {
+        // A middle branch may leave unavailable history on BOTH sides. Keep
+        // the old visual span until the new recording covers the whole window;
+        // clearing as soon as the prefix is covered collapses 0–200 to 0–76.
+        if (recorded.lo <= viewport.lo && recorded.hi >= viewport.hi) {
           continuity = null;
           viewport = recorded;
         }

--- a/runtime/functor-runtime-web/timeline-model.js
+++ b/runtime/functor-runtime-web/timeline-model.js
@@ -32,6 +32,7 @@ export function createTimelineState(preview = {}) {
     runtime: null,
     recordingAvailable: false,
     viewport: null,
+    continuity: null,
     selectedFrame: null,
     requestedFrame: null,
     requestedSeekId: null,
@@ -49,26 +50,44 @@ const validSnapshot = (snapshot) =>
   Number.isFinite(snapshot.hi) &&
   snapshot.hi >= snapshot.lo;
 
-const rangesOverlap = (a, b) => a && b && a.hi >= b.lo && b.hi >= a.lo;
-
 export function reduceTimeline(state, action) {
   switch (action.type) {
     case "runtime-published": {
       const snapshot = action.snapshot;
       if (!validSnapshot(snapshot)) return state;
 
-      const recorded = { lo: snapshot.lo, hi: snapshot.hi };
+      const runtime = {
+        ...snapshot,
+        generation: finiteOr(snapshot.generation, state.runtime?.generation ?? 0),
+      };
+      const recorded = { lo: runtime.lo, hi: runtime.hi };
       let viewport = state.viewport;
+      let continuity = state.continuity;
+      const generationChanged =
+        state.runtime !== null && runtime.generation !== state.runtime.generation;
 
-      // A reload resets the seekable model-history window around a new monotonic
-      // frame. If the old viewport no longer intersects it, the new recording is
-      // the only honest domain.
-      if (!rangesOverlap(viewport, recorded)) viewport = recorded;
+      if (!viewport) viewport = recorded;
+      if (generationChanged) {
+        // Keep the visual scale continuous while a new seekable generation
+        // replaces the old one. As new frames arrive, the old-width window
+        // advances normally and its unavailable striped prefix rolls away.
+        continuity = {
+          span: Math.max(viewport.hi - viewport.lo, recorded.hi - recorded.lo),
+          anchorHi: viewport.hi,
+        };
+      }
 
-      if (snapshot.paused) {
+      if (runtime.paused) {
         // Pause captures the viewport exactly once. Subsequent history/config /
         // selection updates cannot resize it.
-        if (!viewport) viewport = recorded;
+      } else if (continuity) {
+        const span = Math.max(continuity.span, recorded.hi - recorded.lo);
+        const hi = Math.max(continuity.anchorHi, recorded.hi);
+        viewport = { lo: hi - span, hi };
+        if (recorded.lo <= viewport.lo) {
+          continuity = null;
+          viewport = recorded;
+        }
       } else {
         viewport = recorded;
       }
@@ -81,9 +100,10 @@ export function reduceTimeline(state, action) {
 
       return {
         ...state,
-        runtime: snapshot,
+        runtime,
         recordingAvailable: true,
         viewport,
+        continuity,
         requestedFrame,
         requestedSeekId,
         selectedFrame,
@@ -202,6 +222,13 @@ export function deriveTimelineView(state) {
   const recordedEndFrame = state.recordingAvailable
     ? clamp(state.runtime.hi, state.viewport.lo, state.viewport.hi)
     : state.viewport.lo;
+  const unavailableEndFrame = state.recordingAvailable
+    ? clamp(state.runtime.lo, state.viewport.lo, state.viewport.hi)
+    : state.viewport.hi;
+  const unavailableAfterStartFrame =
+    state.recordingAvailable && state.continuity
+      ? clamp(state.runtime.hi, state.viewport.lo, state.viewport.hi)
+      : state.viewport.hi;
   const activeEventId = state.hoveredEventId ?? state.selectedEventId;
   const activeEvent = eventMarkers.find((marker) => marker.id === activeEventId) ?? null;
 
@@ -211,6 +238,12 @@ export function deriveTimelineView(state) {
     recordingAvailable: state.recordingAvailable,
     recordedStartUnit: frameToUnit(recordedStartFrame, state.viewport),
     recordedEndUnit: frameToUnit(recordedEndFrame, state.viewport),
+    unavailableEndUnit: frameToUnit(unavailableEndFrame, state.viewport),
+    unavailableAfterStartUnit: frameToUnit(unavailableAfterStartFrame, state.viewport),
+    hasUnavailableHistory:
+      !state.recordingAvailable ||
+      state.runtime.lo > state.viewport.lo ||
+      (state.continuity !== null && state.runtime.hi < state.viewport.hi),
     paused: state.runtime.paused,
     selectedFrame,
     visibleSelectedFrame,

--- a/runtime/functor-runtime-web/timeline-model.test.js
+++ b/runtime/functor-runtime-web/timeline-model.test.js
@@ -8,10 +8,10 @@ import {
   reduceTimeline,
 } from "./timeline-model.js";
 
-const publish = (state, frame, hi, paused, lo = 0) =>
+const publish = (state, frame, hi, paused, lo = 0, generation = 0) =>
   reduceTimeline(state, {
     type: "runtime-published",
-    snapshot: { frame, lo, hi, paused },
+    snapshot: { frame, lo, hi, paused, generation },
   });
 
 test("live playback keeps the selected frame at the recorded endpoint", () => {
@@ -137,7 +137,66 @@ test("clearing recording keeps the frozen transport view but disables seeking", 
   assert.equal(view.recordingAvailable, false);
   assert.equal(view.recordedStartUnit, 0);
   assert.equal(view.recordedEndUnit, 0);
+  assert.equal(view.unavailableEndUnit, 1);
+  assert.equal(view.hasUnavailableHistory, true);
   assert.equal(state.requestedFrame, null);
+});
+
+test("a paused reload keeps its frame and viewport while marking old history unavailable", () => {
+  let state = publish(createTimelineState({ enabled: true }), 300, 300, true);
+  state = publish(state, 300, 300, true, 300, 1);
+  const view = deriveTimelineView(state);
+  assert.equal(view.selectedFrame, 300);
+  assert.deepEqual(view.viewport, { lo: 0, hi: 300 });
+  assert.equal(view.recordedStartUnit, 1);
+  assert.equal(view.recordedEndUnit, 1);
+  assert.equal(view.unavailableEndUnit, 1);
+  assert.equal(view.unavailableAfterStartUnit, 1);
+  assert.equal(view.hasUnavailableHistory, true);
+  assert.equal(view.previewFrames, 120);
+});
+
+test("an unsafe reload in the middle stripes both discarded sides", () => {
+  let state = publish(createTimelineState(), 300, 300, true);
+  state = reduceTimeline(state, { type: "seek-requested", id: 1, frame: 120 });
+  state = reduceTimeline(state, { type: "seek-resolved", id: 1, frame: 120 });
+  state = publish(state, 120, 120, true, 120, 1);
+
+  const view = deriveTimelineView(state);
+  assert.deepEqual(view.viewport, { lo: 0, hi: 300 });
+  assert.equal(view.recordedStartUnit, 0.4);
+  assert.equal(view.recordedEndUnit, 0.4);
+  assert.equal(view.unavailableEndUnit, 0.4);
+  assert.equal(view.unavailableAfterStartUnit, 0.4);
+  assert.equal(view.hasUnavailableHistory, true);
+});
+
+test("live frames replace a reload stripe without collapsing the visual scale", () => {
+  let state = publish(createTimelineState(), 300, 300, false);
+  state = publish(state, 300, 300, false, 300, 1);
+  assert.deepEqual(deriveTimelineView(state).viewport, { lo: 0, hi: 300 });
+
+  state = publish(state, 301, 301, false, 300, 1);
+  let view = deriveTimelineView(state);
+  assert.deepEqual(view.viewport, { lo: 1, hi: 301 });
+  assert.equal(view.unavailableEndUnit, 299 / 300);
+  assert.equal(view.unavailableAfterStartUnit, 1);
+
+  state = publish(state, 600, 600, false, 300, 1);
+  view = deriveTimelineView(state);
+  assert.deepEqual(view.viewport, { lo: 300, hi: 600 });
+  assert.equal(view.hasUnavailableHistory, false);
+  assert.equal(state.continuity, null);
+});
+
+test("a safe reload generation leaves the full seekable history unchanged", () => {
+  let state = publish(createTimelineState(), 300, 300, true, 0, 4);
+  state = publish(state, 300, 300, true, 0, 4);
+  const view = deriveTimelineView(state);
+  assert.deepEqual(view.viewport, { lo: 0, hi: 300 });
+  assert.equal(view.recordedStartUnit, 0);
+  assert.equal(view.recordedEndUnit, 1);
+  assert.equal(view.hasUnavailableHistory, false);
 });
 
 test("hover takes precedence over persistent marker selection", () => {

--- a/runtime/functor-runtime-web/timeline-model.test.js
+++ b/runtime/functor-runtime-web/timeline-model.test.js
@@ -171,6 +171,23 @@ test("an unsafe reload in the middle stripes both discarded sides", () => {
   assert.equal(view.hasUnavailableHistory, true);
 });
 
+test("a resumed middle branch keeps the old total until it is refilled", () => {
+  let state = publish(createTimelineState(), 75, 200, true);
+  state = publish(state, 76, 76, false, 0, 1);
+
+  let view = deriveTimelineView(state);
+  assert.deepEqual(view.viewport, { lo: 0, hi: 200 });
+  assert.equal(view.recordedEndUnit, 76 / 200);
+  assert.equal(view.unavailableAfterStartUnit, 76 / 200);
+  assert.equal(view.hasUnavailableHistory, true);
+
+  state = publish(state, 200, 200, false, 0, 1);
+  view = deriveTimelineView(state);
+  assert.deepEqual(view.viewport, { lo: 0, hi: 200 });
+  assert.equal(view.hasUnavailableHistory, false);
+  assert.equal(state.continuity, null);
+});
+
 test("live frames replace a reload stripe without collapsing the visual scale", () => {
   let state = publish(createTimelineState(), 300, 300, false);
   state = publish(state, 300, 300, false, 300, 1);


### PR DESCRIPTION
## Summary

- preserve the full coupled model/physics/time history when every retained model is reload-independent plain data
- keep paused frame, viewport, handles, and extrapolation stable when code-bearing state requires a new history generation
- render unreachable history as striped regions on either side of the new seekable boundary
- rebind first-class constructors safely across arity edits, including nullary and partially applied transitions

## Behavior

The common constant-tweak loop now keeps old frames seekable under the edited program. This is deliberately **new code over old data**, not retroactive replay: a draw-only constant affects all retained frames immediately, while a tick constant affects evolution after resume.

If a retained model contains a closure, callable, or opaque host value, restoring it under the new module is not safe. In that case the runtime anchors a new one-frame generation at the current paused frame. The timeline does not collapse: unavailable past/discarded future remain visible as a grey stripe, and the cyan/pink handles stay present.

A complete replay-from-start path remains separate work because the current event log is bounded and does not yet capture every effect response/coeffect needed to reconstruct arbitrary sessions deterministically.

## Tests

- `cargo test -p functor-lang -p functor_runtime_common -p functor-runtime-desktop`
- `npm run test:scrubber`
- `npm run build:cli`
- `npm run test:site`

The site suite skips the optional editor-language wasm checks when that separate package is not built; all timeline/runtime checks pass.


## Visuals

### Safe reload → explicit branch

![Safe reload preserves the future until Step branches](https://gist.githubusercontent.com/tommy-xr/4a43f3c10d85233199580e877f701dec/raw/before-after.png)

<sub>Same exact 0–200 viewport. Reloading plain-data state at frame 75 keeps the complete cyan future seekable with no new stripe. The following Step to frame 76 is the explicit branch point: `/200` stays fixed while the discarded suffix becomes striped.</sub>

### Reload safety states

![Safe reload, stepped branch, and unsafe closure boundary](https://gist.githubusercontent.com/tommy-xr/4a43f3c10d85233199580e877f701dec/raw/reload-states.png)

<sub>Top: safe reload at `75 / 200`, full cyan and no unavailable region. Middle: Step branches at `76 / 200`. Bottom: closure-bearing state conservatively anchors one frame at 75 with both handles and stripes on both sides.</sub>

### Interaction

![Safe future preservation, branching, refill, and unsafe reload](https://gist.githubusercontent.com/tommy-xr/4a43f3c10d85233199580e877f701dec/raw/hot-reload-timeline.gif)

<sub>The safe reload preserves 0–200; Step creates the branch; resumed playback visibly refills the frozen striped suffix with cyan through `189 / 200`; the final state shows the unchanged unsafe closure boundary. Captured with Playwright because the timeline is DOM/SVG.</sub>

### Unsafe closure boundary

![Unsafe closure-bearing reload keeps an honest one-frame boundary](https://gist.githubusercontent.com/tommy-xr/4a43f3c10d85233199580e877f701dec/raw/unsafe-boundary.png)

<sub>At `75 +30 / 200`, the seekable range is exactly `[75,75]`; the 0–200 viewport and both cyan/pink handles stay fixed while unavailable history is striped on both sides.</sub>