### PR TITLE
fix: simplify the timeline frame counter

### DIFF
--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -821,6 +821,7 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
       ),
       playheadVisible: getComputedStyle(document.getElementById("scrub-playhead")).display,
       previewVisible: getComputedStyle(document.getElementById("scrub-preview-handle")).display,
+      playheadValueText: document.getElementById("scrub-playhead").getAttribute("aria-valuetext"),
       label: document.getElementById("scrub-count").textContent,
       reloadFrame: window.__scrub.events().findLast((event) => event.kind === "reload-ok").frame,
     };
@@ -841,14 +842,19 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
     JSON.stringify(afterReload)
   );
   check(
-    "unavailable history is striped while both handles remain visible",
+    "unavailable history stays striped without cluttering the frame counter",
     afterReload.view.hasUnavailableHistory &&
       afterReload.stripeWidth > 0 &&
       afterReload.stripeAfterWidth > 0 &&
       afterReload.playheadVisible === "block" &&
       afterReload.previewVisible === "block" &&
+      afterReload.playheadValueText.includes(
+        `recorded frames ${beforeReload.frame} to ${beforeReload.frame}`
+      ) &&
+      afterReload.playheadValueText.includes("striped history") &&
+      afterReload.playheadValueText.includes("unavailable") &&
       afterReload.label.includes(String(beforeReload.frame)) &&
-      afterReload.label.includes("reload boundary"),
+      !afterReload.label.includes("reload boundary"),
     JSON.stringify(afterReload)
   );
 

--- a/runtime/functor-runtime-web/scrubber.js
+++ b/runtime/functor-runtime-web/scrubber.js
@@ -21,6 +21,7 @@ import {
   PREVIEW_SECONDS_MIN,
   TIMELINE_FPS,
   createTimelineState,
+  describeRecordedAvailability,
   deriveTimelineView,
   reduceTimeline,
   unitToFrame,
@@ -413,12 +414,14 @@ export function mountScrubber() {
       String(Math.max(current.recorded.hi, current.selectedFrame))
     );
     playhead.setAttribute("aria-valuenow", String(current.selectedFrame));
+    const availability = describeRecordedAvailability(current);
     playhead.setAttribute(
       "aria-valuetext",
       `frame ${current.selectedFrame}` +
         (current.playheadClippedBefore || current.playheadClippedAfter
           ? `, outside the frozen viewport ${current.viewport.lo} to ${current.viewport.hi}`
-          : "")
+          : "") +
+        (availability ? `, ${availability}` : "")
     );
 
     previewHandle.setAttribute(
@@ -442,8 +445,7 @@ export function mountScrubber() {
         ? ` <span class="out">outside</span>`
         : "") +
       (state.preview.enabled ? ` <span class="fut">+${current.previewFrames}</span>` : "") +
-      ` / ${Math.round(current.viewport.hi)}` +
-      (current.hasUnavailableHistory ? ` <span class="out">· reload boundary</span>` : "");
+      ` / ${Math.round(current.viewport.hi)}`;
     pause.textContent = current.paused ? "▶" : "⏸";
     pause.setAttribute("aria-label", current.paused ? "Resume" : "Pause");
     extrapolate.classList.toggle("on", state.preview.enabled);

--- a/runtime/functor-runtime-web/timeline-model.js
+++ b/runtime/functor-runtime-web/timeline-model.js
@@ -266,6 +266,12 @@ export function deriveTimelineView(state) {
   };
 }
 
+export function describeRecordedAvailability(view) {
+  if (!view?.recordingAvailable) return "no recorded history is currently available";
+  if (!view.hasUnavailableHistory) return "";
+  return `recorded frames ${Math.round(view.recorded.lo)} to ${Math.round(view.recorded.hi)}; striped history outside that range is unavailable`;
+}
+
 export function clusterTimelineEvents(events, viewport, bucketCount = 250) {
   if (!viewport || viewport.hi < viewport.lo) return [];
   const buckets = new Map();

--- a/runtime/functor-runtime-web/timeline-model.test.js
+++ b/runtime/functor-runtime-web/timeline-model.test.js
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   clusterTimelineEvents,
   createTimelineState,
+  describeRecordedAvailability,
   deriveTimelineView,
   normalizePreviewConfig,
   reduceTimeline,
@@ -140,6 +141,10 @@ test("clearing recording keeps the frozen transport view but disables seeking", 
   assert.equal(view.unavailableEndUnit, 1);
   assert.equal(view.hasUnavailableHistory, true);
   assert.equal(state.requestedFrame, null);
+  assert.equal(
+    describeRecordedAvailability(view),
+    "no recorded history is currently available"
+  );
 });
 
 test("a paused reload keeps its frame and viewport while marking old history unavailable", () => {
@@ -169,6 +174,10 @@ test("an unsafe reload in the middle stripes both discarded sides", () => {
   assert.equal(view.unavailableEndUnit, 0.4);
   assert.equal(view.unavailableAfterStartUnit, 0.4);
   assert.equal(view.hasUnavailableHistory, true);
+  assert.equal(
+    describeRecordedAvailability(view),
+    "recorded frames 120 to 120; striped history outside that range is unavailable"
+  );
 });
 
 test("a resumed middle branch keeps the old total until it is refilled", () => {


### PR DESCRIPTION
## Summary

- remove the redundant `reload boundary` suffix from the frame counter
- keep reload markers and their contextual detail unchanged
- preserve the history-availability cue for screen readers by announcing recorded/striped ranges or the no-recording state through the playhead's `aria-valuetext`
- cover the concise counter and accessibility announcement in the browser end-to-end scenario

## Test plan

- `npm run test:site`

## Visuals

![Reload marker contextual detail remains available](https://gist.githubusercontent.com/tommy-xr/4034ea85188deeb6c51dcbea4f0ba0bc/raw/37a3e3e66608e7996a6c871671402aeccb26083d/pr356-reload-marker.gif)

<sub>The concise counter remains uncluttered; focusing the reload marker reveals its contextual detail. Captured in headless Chromium.</sub>

### Before → after

![Before and after timeline frame counter](https://gist.githubusercontent.com/tommy-xr/4034ea85188deeb6c51dcbea4f0ba0bc/raw/37a3e3e66608e7996a6c871671402aeccb26083d/pr356-before-after.png)

<sub>Both captures show the identical unsafe reload state: frame 30, frozen viewport 0–72, striped unavailable history, and the reload marker. The playhead now announces recorded/striped ranges or explicitly reports when no recorded history is available.</sub>
