### PR TITLE
fix(time-travel): restore extrapolation while playing

### DIFF
--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -446,6 +446,36 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
   const r1 = await player.evaluate(() => window.__scrub.range());
   check("scrubber range grows while running", r1[1] > r0[1], `${r0} -> ${r1}`);
 
+  // Extrapolation is a live mode: its second handle follows the advancing tail
+  // by a fixed logical window. Pausing freezes the anchor; it does not enable
+  // the control or the renderer.
+  await player.evaluate(() => window.__scrub.setPreview({ enabled: true, seconds: 2 }));
+  await player.waitForFunction(
+    () => getComputedStyle(document.getElementById("scrub-preview-handle")).display === "block",
+    { timeout: 3000 }
+  );
+  const livePreview0 = await player.evaluate(() => window.__scrub.view());
+  await sleep(300);
+  const livePreview1 = await player.evaluate(() => ({
+    view: window.__scrub.view(),
+    handleVisible:
+      getComputedStyle(document.getElementById("scrub-preview-handle")).display === "block",
+    endpointClipped: document
+      .getElementById("scrub-preview-handle")
+      .classList.contains("fully-clipped"),
+  }));
+  check(
+    "live extrapolation keeps its pink endpoint tracking the live tail",
+    !livePreview0.paused &&
+      !livePreview1.view.paused &&
+      livePreview1.handleVisible &&
+      livePreview1.endpointClipped &&
+      livePreview1.view.selectedFrame > livePreview0.selectedFrame &&
+      livePreview0.previewEndFrame - livePreview0.selectedFrame === 120 &&
+      livePreview1.view.previewEndFrame - livePreview1.view.selectedFrame === 120,
+    JSON.stringify({ livePreview0, livePreview1 })
+  );
+
   // Markers come from the authoritative runtime log: a real recorded key edge,
   // followed by a real hot-reload boundary from the editor bridge.
   await player.evaluate(() => {

--- a/runtime/functor-runtime-common/src/lib.rs
+++ b/runtime/functor-runtime-common/src/lib.rs
@@ -102,8 +102,8 @@ pub use renderer::*;
 pub use skybox::SkyboxDescription;
 pub use scene3d::*;
 pub use trajectory::{
-    overlay, scene_preview, trajectory_trail, PreviewMode, PreviewOptions, ScenePreview,
-    StrobeOptions,
+    interactive_preview, overlay, scene_preview, trajectory_trail, InteractivePreview,
+    PreviewMode, PreviewOptions, ScenePreview, StrobeOptions,
 };
 pub use viewport::*;
 

--- a/runtime/functor-runtime-common/src/trajectory.rs
+++ b/runtime/functor-runtime-common/src/trajectory.rs
@@ -489,6 +489,32 @@ impl PreviewMode {
     }
 }
 
+/// The render work selected by an interactive extrapolation control. Pause is
+/// deliberately not an input: playing advances the projection anchor while
+/// pausing freezes it. Catch-up seeks suppress the expensive dry run until the
+/// requested frame arrives.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct InteractivePreview {
+    pub trail: bool,
+    pub strobe: bool,
+    pub ghost: bool,
+}
+
+pub fn interactive_preview(
+    mode: PreviewMode,
+    enabled: bool,
+    catching_up: bool,
+) -> InteractivePreview {
+    if !enabled || catching_up {
+        return InteractivePreview::default();
+    }
+    InteractivePreview {
+        trail: mode.wants_trail(),
+        strobe: mode.wants_strobe(),
+        ghost: mode.wants_ghost(),
+    }
+}
+
 /// What [`scene_preview`] should compute.
 pub struct PreviewOptions {
     /// Forward-sim divisions (samples). Not bound by the screen-space
@@ -554,6 +580,34 @@ mod tests {
 
     fn ball_at(x: f32, y: f32) -> Scene3D {
         Scene3D::sphere().transform(Matrix4::from_translation(vec3(x, y, 0.0)))
+    }
+
+    #[test]
+    fn interactive_preview_is_enabled_by_the_toggle_not_by_pause() {
+        assert_eq!(
+            interactive_preview(PreviewMode::Both, true, false),
+            InteractivePreview {
+                trail: true,
+                strobe: true,
+                ghost: false,
+            }
+        );
+        assert_eq!(
+            interactive_preview(PreviewMode::Ghost, true, false),
+            InteractivePreview {
+                trail: false,
+                strobe: false,
+                ghost: true,
+            }
+        );
+        assert_eq!(
+            interactive_preview(PreviewMode::Both, false, false),
+            InteractivePreview::default()
+        );
+        assert_eq!(
+            interactive_preview(PreviewMode::Both, true, true),
+            InteractivePreview::default()
+        );
     }
 
     // A group holding a mover (sphere 0) and a static sphere (sphere 1).

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -893,8 +893,8 @@ pub fn run(args: Args) {
         let mut scrubber_visible = args.scrubber;
         // Future-preview (docs/time-travel.md T6/T6d) state, driven
         // interactively from the scrubber's "extrapolate" switch and ⚙ popover
-        // (mode / window / rate). Extrapolation defaults ON — pausing shows
-        // trail+strobe out of the box (the demo default) — and the launch
+        // (mode / window / rate). Extrapolation defaults ON with trail+strobe
+        // out of the box (the demo default), and the launch
         // flags pick the mode; they stay authoritative while the overlay is
         // hidden (the headless-capture escape hatch), where they may also
         // COMBINE (--ghost --trajectory composes the trail into the strobe).
@@ -912,16 +912,24 @@ pub fn run(args: Args) {
         // --trajectory/--strobe preview cache. The 32-division forward-sim is
         // the expensive part, and while PAUSED its anchor (scene frame + tts) is
         // frozen — so reuse the computed preview while the anchor key matches,
-        // but still refresh every TRAIL_REFRESH_FRAMES so a hot-reload's edited
-        // code re-projects within ~half a second (the anchor can't see a code
-        // edit). Live play changes the key every frame, so it recomputes like
-        // --ghost does.
-        const TRAIL_REFRESH_FRAMES: u32 = 30;
+        // but still refresh after a bounded number of frames so a hot-reload's
+        // edited code re-projects within ~half a second (the anchor can't see a
+        // code edit). While live, the last projection remains visible between
+        // wall-clock refreshes so continuous extrapolation bounds repeated work.
+        const PAUSED_PREVIEW_REUSE_FRAMES: u32 = 30;
+        const LIVE_PREVIEW_INTERVAL_SECONDS: f32 = 0.1;
         let mut trail_cache: Option<(
-            (Option<u64>, u32, bool, bool, usize, u32),
+            (Option<u64>, u32, bool, bool, bool, usize, u32),
             functor_runtime_common::ScenePreview,
         )> = None;
         let mut trail_refresh: u32 = 0;
+        let mut next_live_trail_refresh: f32 = 0.0;
+        let mut ghost_cache: Option<(
+            (Option<u64>, u32, bool, usize, u32),
+            Vec<(Frame, FrameTime)>,
+        )> = None;
+        let mut ghost_refresh: u32 = 0;
+        let mut next_live_ghost_refresh: f32 = 0.0;
 
         gl.clear_color(0.1, 0.2, 0.3, 1.0);
 
@@ -1299,31 +1307,23 @@ Escape again to quit"
             // Drive the ghost from the interactive toggle when the overlay is up,
             // and from the `--ghost` launch flag when it's hidden (the headless
             // capture path — F2 demo, goldens, tests — is byte-for-byte
-            // unchanged). Interactive ghost only renders while PAUSED: the
-            // strobe is a preview of a frozen frame's future, and
-            // forward-stepping the scene N times every LIVE frame tanks the
-            // framerate (the "can't move with the scrubber open" bug).
-            // `is_paused()` is false under --fixed-time, so the headless
-            // `args.ghost` capture branch is unaffected. Computed HERE, above
-            // the scene-diff preview, because the preview's gating reads it.
+            // unchanged). Computed HERE, above the scene-diff preview, because
+            // the preview's gating reads it.
             // One wanted-set drives every future preview (docs/time-travel.md
             // T6/T6d): the scene-diff trail/strobe overlays AND the
             // screen-space ghost compositor. With the overlay up, the
-            // scrubber's selector picks ONE mode, and only while PAUSED
-            // (forward-stepping every LIVE frame tanks the framerate); with the
-            // overlay hidden the launch flags drive it — several may combine
+            // scrubber's selector picks ONE mode. Its anchor follows the live
+            // tail while playing and freezes when paused. With the overlay
+            // hidden the launch flags drive it — several may combine
             // there (--ghost --trajectory composes the trail into the strobe) —
             // so headless captures are byte-for-byte unchanged.
             let (trail_wanted, strobe_wanted, ghost_active) = if scrubber_visible {
-                if clock.is_paused() && extrapolate_on {
-                    (
-                        preview_mode.wants_trail(),
-                        preview_mode.wants_strobe(),
-                        preview_mode.wants_ghost(),
-                    )
-                } else {
-                    (false, false, false)
-                }
+                let selected = functor_runtime_common::interactive_preview(
+                    preview_mode,
+                    extrapolate_on,
+                    clock.pending_frames() > 0,
+                );
+                (selected.trail, selected.strobe, selected.ghost)
             } else {
                 (args.trajectory, args.strobe, args.ghost)
             };
@@ -1365,15 +1365,30 @@ Escape again to quit"
                 let key = (
                     game.current_scene_frame(),
                     time.tts.to_bits(),
+                    clock.is_paused(),
                     trail_wanted,
                     strobe_wanted,
                     divisions,
                     window.to_bits(),
                 );
-                let cache_hit = trail_refresh > 0
-                    && trail_cache.as_ref().is_some_and(|(k, _)| *k == key);
+                let interactive_live = scrubber_visible && !clock.is_paused();
+                let cache_hit = trail_cache.as_ref().is_some_and(|(k, _)| {
+                    if interactive_live {
+                        elapsed_time < next_live_trail_refresh
+                            && trail_refresh == 0
+                            && !k.2
+                            && k.3 == key.3
+                            && k.4 == key.4
+                            && k.5 == key.5
+                            && k.6 == key.6
+                    } else {
+                        trail_refresh > 0 && *k == key
+                    }
+                });
                 if cache_hit {
-                    trail_refresh -= 1;
+                    if !interactive_live {
+                        trail_refresh -= 1;
+                    }
                     trail_cache.as_ref().map(|(_, p)| p.clone())
                 } else {
                     // Under --input-script the live loop keeps consuming the
@@ -1432,12 +1447,19 @@ Escape again to quit"
                             }),
                         },
                     );
-                    trail_refresh = TRAIL_REFRESH_FRAMES;
+                    if interactive_live {
+                        trail_refresh = 0;
+                        next_live_trail_refresh =
+                            start_time.elapsed().as_secs_f32() + LIVE_PREVIEW_INTERVAL_SECONDS;
+                    } else {
+                        trail_refresh = PAUSED_PREVIEW_REUSE_FRAMES;
+                    }
                     trail_cache = Some((key, p.clone()));
                     Some(p)
                 }
             } else {
                 trail_cache = None;
+                next_live_trail_refresh = 0.0;
                 None
             };
 
@@ -1489,8 +1511,57 @@ Escape again to quit"
                             .map(|f| script.get(&f).cloned().unwrap_or_default())
                             .collect()
                     });
-                game.ghost_frames(divisions, dt, time.tts as f64, script_slice.as_deref())
+                if scrubber_visible {
+                    let key = (
+                        game.current_scene_frame(),
+                        time.tts.to_bits(),
+                        clock.is_paused(),
+                        divisions,
+                        ghost_window.to_bits(),
+                    );
+                    let cache_hit = ghost_cache.as_ref().is_some_and(|(k, _)| {
+                        if clock.is_paused() {
+                            ghost_refresh > 0 && *k == key
+                        } else {
+                            elapsed_time < next_live_ghost_refresh
+                                && !k.2
+                                && k.3 == key.3
+                                && k.4 == key.4
+                        }
+                    });
+                    if cache_hit {
+                        if clock.is_paused() {
+                            ghost_refresh -= 1;
+                        }
+                        ghost_cache
+                            .as_ref()
+                            .map(|(_, frames)| frames.clone())
+                            .unwrap_or_default()
+                    } else {
+                        let frames = game.ghost_frames(
+                            divisions,
+                            dt,
+                            time.tts as f64,
+                            script_slice.as_deref(),
+                        );
+                        if clock.is_paused() {
+                            ghost_refresh = PAUSED_PREVIEW_REUSE_FRAMES;
+                        } else {
+                            ghost_refresh = 0;
+                            next_live_ghost_refresh =
+                                start_time.elapsed().as_secs_f32() + LIVE_PREVIEW_INTERVAL_SECONDS;
+                        }
+                        ghost_cache = Some((key, frames.clone()));
+                        frames
+                    }
+                } else {
+                    ghost_cache = None;
+                    next_live_ghost_refresh = 0.0;
+                    game.ghost_frames(divisions, dt, time.tts as f64, script_slice.as_deref())
+                }
             } else {
+                ghost_cache = None;
+                next_live_ghost_refresh = 0.0;
                 Vec::new()
             };
             // The trail composes with --ghost's screen-space strobe by riding IN

--- a/runtime/functor-runtime-web/scrubber.js
+++ b/runtime/functor-runtime-web/scrubber.js
@@ -165,7 +165,7 @@ const HTML = `
     <span id="scrub-event-detail" role="status"></span>
     <span id="scrub-label"><span id="scrub-count"></span></span>
   </span>
-  <button id="scrub-extrapolate" title="Extrapolate the paused game into the future">🔮</button>
+  <button id="scrub-extrapolate" title="Extrapolate the game into the future">🔮</button>
   <details id="scrub-adv">
     <summary title="Extrapolation settings">⚙</summary>
     <div id="scrub-adv-pop">
@@ -359,7 +359,7 @@ export function mountScrubber() {
     const playheadPct = current.playheadUnit * 100;
     const previewPct = current.previewEndUnit * 100;
     const futureWidth = Math.max(previewPct - playheadPct, 0);
-    const previewVisible = state.preview.enabled && current.paused;
+    const previewVisible = state.preview.enabled;
 
     playhead.style.left = `${playheadPct}%`;
     playhead.style.display = "block";

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -1164,16 +1164,25 @@ async fn run_async() -> Result<(), JsValue> {
         // from the ⚙ popover. Same anchor cache as the desktop shell: while
         // paused the anchor (scene frame + tts) is frozen, so reuse the
         // computed preview; the refresh bound re-projects a pushed source edit
-        // within ~half a second.
+        // within ~half a second. Live projections remain painted every frame
+        // but refresh on a wall-clock cadence that bounds repeated dry runs.
         let mut preview_mode = functor_runtime_common::PreviewMode::Off;
         let mut preview_window: f32 = 2.0;
         let mut preview_rate: usize = 5;
-        const PREVIEW_REFRESH_FRAMES: u32 = 30;
+        const PAUSED_PREVIEW_REUSE_FRAMES: u32 = 30;
+        const LIVE_PREVIEW_INTERVAL_MS: f32 = 100.0;
         let mut preview_cache: Option<(
-            (Option<u64>, u32, bool, bool, usize, u32),
+            (Option<u64>, u32, bool, bool, bool, usize, u32),
             functor_runtime_common::ScenePreview,
         )> = None;
         let mut preview_refresh: u32 = 0;
+        let mut next_live_preview_refresh: f32 = 0.0;
+        let mut ghost_cache: Option<(
+            (Option<u64>, u32, bool, usize, u32),
+            Vec<(Frame, FrameTime)>,
+        )> = None;
+        let mut ghost_refresh: u32 = 0;
+        let mut next_live_ghost_refresh: f32 = 0.0;
 
         *g.borrow_mut() = Some(Closure::new(move || {
             // The frame's exclusive borrow of the shared producer.
@@ -1290,33 +1299,49 @@ async fn run_async() -> Result<(), JsValue> {
 
             // Scene-diff preview (docs/time-travel.md T6): the DOM preview
             // <select>'s trail/strobe overlays, from ONE shared forward-sim —
-            // `scene_preview`, the same step the desktop shell runs. The web
-            // scrubber is always visible, so like the ghost it renders only
-            // while PAUSED. Script inputs are `None`: web has no --input-script.
+            // `scene_preview`, the same step the desktop shell runs. While live,
+            // its anchor follows the newest frame; pausing freezes that anchor
+            // instead of enabling the preview. Script inputs are `None`: web has
+            // no --input-script.
             // While a drag-into-the-future catch-up is draining, skip preview
             // and ghost recomputes (the anchor moves every frame — a full
             // forward-sim per frame would throttle the catch-up to a crawl);
             // they snap back in on arrival.
             let catching_up = clock.pending_frames() > 0;
-            let paused = clock.is_paused() && !catching_up;
-            let trail_wanted = preview_mode.wants_trail() && paused;
+            let selected =
+                functor_runtime_common::interactive_preview(preview_mode, true, catching_up);
+            let trail_wanted = selected.trail;
             // The selector is single-valued, so a strobe mode and the ghost
             // compositor can never be on together (the double-ghost hazard the
             // desktop flag path still guards against).
-            let strobe_wanted = preview_mode.wants_strobe() && paused;
+            let strobe_wanted = selected.strobe;
             let preview = if trail_wanted || strobe_wanted {
                 let key = (
                     game.current_scene_frame(),
                     frame_time.tts.to_bits(),
+                    clock.is_paused(),
                     trail_wanted,
                     strobe_wanted,
                     preview_rate,
                     preview_window.to_bits(),
                 );
-                let cache_hit = preview_refresh > 0
-                    && preview_cache.as_ref().is_some_and(|(k, _)| *k == key);
+                let cache_hit = preview_cache.as_ref().is_some_and(|(k, _)| {
+                    if clock.is_paused() {
+                        preview_refresh > 0 && *k == key
+                    } else {
+                        now < next_live_preview_refresh
+                            && preview_refresh == 0
+                            && !k.2
+                            && k.3 == key.3
+                            && k.4 == key.4
+                            && k.5 == key.5
+                            && k.6 == key.6
+                    }
+                });
                 if cache_hit {
-                    preview_refresh -= 1;
+                    if clock.is_paused() {
+                        preview_refresh -= 1;
+                    }
                     preview_cache.as_ref().map(|(_, p)| p.clone())
                 } else {
                     // The SIM samples fine (~20/s — the trail's smooth-arc
@@ -1349,12 +1374,19 @@ async fn run_async() -> Result<(), JsValue> {
                             }),
                         },
                     );
-                    preview_refresh = PREVIEW_REFRESH_FRAMES;
+                    if clock.is_paused() {
+                        preview_refresh = PAUSED_PREVIEW_REUSE_FRAMES;
+                    } else {
+                        preview_refresh = 0;
+                        next_live_preview_refresh =
+                            performance.now() as f32 + LIVE_PREVIEW_INTERVAL_MS;
+                    }
                     preview_cache = Some((key, p.clone()));
                     Some(p)
                 }
             } else {
                 preview_cache = None;
+                next_live_preview_refresh = 0.0;
                 None
             };
 
@@ -1383,26 +1415,60 @@ async fn run_async() -> Result<(), JsValue> {
             let viewport = functor_runtime_common::Viewport::new(canvas.width(), canvas.height());
 
             // Forward-ghosting (docs/time-travel.md T6d): when the preview
-            // selector is on `ghost` AND the clock is paused, forward-step the
-            // scene over the ⚙ popover's window in up to 8 slices and composite
-            // them at equal weight, so moving elements strobe across their
-            // future and static geometry stays solid. `None` = the
-            // recorded-log/coast path (web has no --input-script). Empty
-            // (→ this arm skipped) leaves live rendering unchanged.
-            //
-            // Gated on `is_paused()` to match the desktop shell: the strobe is a
-            // preview of a FROZEN frame's future, and forward-stepping the scene N
-            // times every LIVE rAF frame would starve the wasm render loop (the
-            // interpreter forward-step is costly on WebGL2). Pause via the DOM
-            // scrubber to see it.
-            let ghosts = if preview_mode.wants_ghost() && clock.is_paused() && !catching_up {
+            // selector is on `ghost`, forward-step the scene over the ⚙
+            // popover's window in up to 8 slices and composite them at equal
+            // weight, so moving elements strobe across their future and static
+            // geometry stays solid. While live the anchor advances each frame;
+            // pausing freezes it. `None` = the recorded-log/coast path (web has
+            // no --input-script). Empty (→ this arm skipped) leaves live
+            // rendering unchanged.
+            let ghosts = if selected.ghost {
                 // The ⚙ popover's rate × window, clamped to the compositor's
                 // 8-target cap.
                 let divisions = ((preview_rate as f32 * preview_window).round() as usize)
                     .clamp(1, 8);
                 let dt = preview_window / divisions as f32;
-                game.ghost_frames(divisions, dt, frame_time.tts as f64, None)
+                let key = (
+                    game.current_scene_frame(),
+                    frame_time.tts.to_bits(),
+                    clock.is_paused(),
+                    divisions,
+                    preview_window.to_bits(),
+                );
+                let cache_hit = ghost_cache.as_ref().is_some_and(|(k, _)| {
+                    if clock.is_paused() {
+                        ghost_refresh > 0 && *k == key
+                    } else {
+                        now < next_live_ghost_refresh
+                            && ghost_refresh == 0
+                            && !k.2
+                            && k.3 == key.3
+                            && k.4 == key.4
+                    }
+                });
+                if cache_hit {
+                    if clock.is_paused() {
+                        ghost_refresh -= 1;
+                    }
+                    ghost_cache
+                        .as_ref()
+                        .map(|(_, frames)| frames.clone())
+                        .unwrap_or_default()
+                } else {
+                    let frames = game.ghost_frames(divisions, dt, frame_time.tts as f64, None);
+                    if clock.is_paused() {
+                        ghost_refresh = PAUSED_PREVIEW_REUSE_FRAMES;
+                    } else {
+                        ghost_refresh = 0;
+                        next_live_ghost_refresh =
+                            performance.now() as f32 + LIVE_PREVIEW_INTERVAL_MS;
+                    }
+                    ghost_cache = Some((key, frames.clone()));
+                    frames
+                }
             } else {
+                ghost_cache = None;
+                next_live_ghost_refresh = 0.0;
                 Vec::new()
             };
 

--- a/runtime/functor-runtime-web/timeline-model.test.js
+++ b/runtime/functor-runtime-web/timeline-model.test.js
@@ -24,6 +24,16 @@ test("live playback keeps the selected frame at the recorded endpoint", () => {
   assert.equal(view.playheadUnit, 1);
 });
 
+test("live extrapolation follows the recorded endpoint by a fixed window", () => {
+  let state = publish(createTimelineState({ enabled: true, seconds: 2 }), 10, 10, false);
+  state = publish(state, 11, 11, false);
+  const view = deriveTimelineView(state);
+  assert.equal(view.selectedFrame, 11);
+  assert.equal(view.previewEndFrame, 131);
+  assert.equal(view.previewEndUnit, 1);
+  assert.equal(view.previewClippedFrames, 120);
+});
+
 test("pausing captures a viewport that preview changes cannot resize", () => {
   let state = publish(createTimelineState(), 300, 300, false);
   state = publish(state, 300, 300, true);


### PR DESCRIPTION
## Summary

- keep the pink extrapolation endpoint visible and following the live tail while playing
- render trail, strobe, and ghost previews during live playback; pausing freezes the projection anchor instead of enabling it
- share the interactive preview policy between native and web, while suppressing projection work during future-seek catch-up
- keep the projection painted continuously but refresh expensive live forward simulation on a 100 ms wall-clock cadence

## Behavior

Extrapolation is now controlled only by the extrapolation toggle. While playing, its endpoint advances with the recorded tail and its forward preview updates in real time. Pausing preserves the existing frozen timeline domain and clips the logical future at the rail edge.

The live projection cache distinguishes paused and playing anchors, so resume cannot reuse a frozen paused projection. The refresh deadline is measured after projection work completes, guaranteeing a reuse interval even when a forward simulation is expensive.

## Verification

- `npm run test:scrubber` (19 tests)
- `cargo test -p functor_runtime_common trajectory::tests::interactive_preview_is_enabled_by_the_toggle_not_by_pause`
- `cargo check -p functor-runtime-desktop`
- `npm run build:cli`
- `npm run test:site` (all checks passed; language-WASM checks skipped because that optional package was not built)
- cross-engine adversarial review, with pause/resume cache invalidation and live cadence findings addressed

## Visual verification

### Playing with extrapolation enabled

![Live extrapolation while the physics pile keeps playing](https://gist.githubusercontent.com/tommy-xr/b6cd48f11a6da5f95931c2782b250345/raw/live-extrapolation.gif)

<sub>The running physics pile keeps updating its cyan trajectory dots and strobe copies; the solid pink endpoint remains at the advancing live edge. Captured headlessly in Chromium from exact commit `5c614bc`.</sub>

### Before → after

![Before and after comparison of extrapolation while playing](https://gist.githubusercontent.com/tommy-xr/b6cd48f11a6da5f95931c2782b250345/raw/before-after-live-extrapolation.png)

<sub>Both captures have extrapolation enabled and remain unpaused. Base `1227c42` hides the endpoint and forward rendering; this branch exposes the pink endpoint and live projection.</sub>

### Motion checkpoints

<img src="https://gist.githubusercontent.com/tommy-xr/b6cd48f11a6da5f95931c2782b250345/raw/after-live-frame-a.png" width="49%" alt="Live extrapolation early in the falling physics scene"> <img src="https://gist.githubusercontent.com/tommy-xr/b6cd48f11a6da5f95931c2782b250345/raw/2758029d4c56acec1ce95b677357e18e2f3eb56d/after-live-frame-b.png" width="49%" alt="Live extrapolation at a later frame of the physics scene">

<sub>Two distinct live frames verify that the projected scene and recorded endpoint continue advancing rather than freezing.</sub>