### PR TITLE
ci: build the language analysis wasm for site deploys and e2e

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -46,6 +46,12 @@ jobs:
         run: wasm-pack build --target=web
         working-directory: runtime/functor-runtime-web
 
+      # The editor's language intelligence (diagnostics/hover/completion).
+      # site:build treats a missing pkg as optional and skips it, so without
+      # this step the deployed editor silently ships with no language services.
+      - name: Build language analysis wasm
+        run: npm run build:lang-wasm
+
       - name: Build site
         run: npm run site:build
 

--- a/.github/workflows/wasm-smoke.yml
+++ b/.github/workflows/wasm-smoke.yml
@@ -71,6 +71,12 @@ jobs:
         run: wasm-pack build --target=web
         working-directory: runtime/functor-runtime-web
 
+      # The editor's language intelligence — without it, test:site silently
+      # SKIPs every lang-intel check (lint/hover/completion) instead of
+      # exercising them.
+      - name: Build language analysis wasm
+        run: npm run build:lang-wasm
+
       - name: Build functor CLI
         run: cargo build --bin functor
 


### PR DESCRIPTION
## Why

Language services (completion, hover, diagnostics) were missing from the sandbox/IDE editor — including on the deployed site. Root cause: nothing in CI ever runs `npm run build:lang-wasm`, and every layer downstream degrades **silently**:

- `site/build.mjs` treats a missing `tools/functor-lang-wasm/pkg` as optional (a note, not an error) and skips copying it to `dist/pkg/`
- `lang-intel.js` catches the failed dynamic import and returns no extensions (one `console.info` line)
- the e2e lang-intel checks in `e2e/site-sandbox.mjs` SKIP when the pkg is absent

So `deploy-site` shipped a degraded editor and `wasm-smoke` stayed green while doing it.

## What

Add a `Build language analysis wasm` step to both workflows, before the site build / site tests. With the pkg present, all previously-skipped lang-intel e2e checks run (verified locally: lint underlines, hover, inlays, codelens, and completion all PASS).

Follow-ups (separate PRs): make the e2e checks required rather than skippable, and wire language intel into `ide.js` (today only `sandbox.js` loads it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)