### PR TITLE
feat(ide): wire project-aware language intel into the IDE editor

### DIFF
--- a/.github/workflows/wasm-smoke.yml
+++ b/.github/workflows/wasm-smoke.yml
@@ -88,3 +88,6 @@ jobs:
 
       - name: Run site sandbox browser tests
         run: npm run test:site
+
+      - name: Run IDE page browser tests
+        run: npm run test:ide-page

--- a/e2e/ide-page.mjs
+++ b/e2e/ide-page.mjs
@@ -8,13 +8,17 @@
 //   4. a broken edit reports the error and the old program keeps running;
 //   5. a good edit recovers to "live";
 //   6. a new file adds a module and the preview stays live;
-//   7. Download builds a real .zip (valid EOCD signature, one entry per file).
+//   7. Download builds a real .zip (valid EOCD signature, one entry per file);
+//   8. project-aware language intelligence: the starter's cross-module
+//      references earn lenses, `Palette.` completes to the sibling's members,
+//      and a type error underlines then clears.
 //
-// Run manually (needs the wasm bundle):
+// Run manually (needs both wasm bundles):
 //   wasm-pack build runtime/functor-runtime-web --target=web   # once
+//   npm run build:lang-wasm                                    # once
 //   node e2e/ide-page.mjs
 import { spawn, spawnSync } from "node:child_process";
-import { readFile } from "node:fs/promises";
+import { access, readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { chromium } from "@playwright/test";
 
@@ -37,6 +41,17 @@ const BROKEN_PALETTE = `let glow =
 const built = spawnSync("node", ["site/build.mjs"], { cwd: ROOT, stdio: "inherit" });
 if (built.status !== 0) {
   console.error("FAIL: site build failed");
+  process.exit(1);
+}
+
+// The language-intel pkg is REQUIRED by this suite (same rule as
+// site-sandbox.mjs): the checks in section 8 must not silently skip.
+try {
+  await access(`${ROOT}site/dist/pkg/functor_lang_wasm.js`);
+} catch {
+  console.error(
+    "FAIL: site/dist/pkg/functor_lang_wasm.js missing — build it first: npm run build:lang-wasm"
+  );
   process.exit(1);
 }
 
@@ -131,6 +146,131 @@ try {
     console.log(`download is a valid zip with ${entryCount} entries incl. functor.json ✓`);
   } else {
     fail(`bad zip: EOCD=${hasEOCD} entries=${entryCount} manifest=${hasManifest} entry=${hasEntry}`);
+  }
+
+  // 8. Project-aware language intelligence. `__lang.ready` resolves once the
+  // analysis wasm is up; the pkg is guaranteed present (startup check), so
+  // not-ready is a failure, never a skip.
+  const langReady = await page.evaluate(() => window.__lang && window.__lang.ready);
+  if (!langReady) {
+    fail("language analysis not ready (__lang.ready is false)");
+  } else {
+    const poll = async (fn, pred, timeout = 8000) => {
+      const deadline = Date.now() + timeout;
+      for (;;) {
+        const v = await fn();
+        if (pred(v)) return v;
+        if (Date.now() > deadline) return v;
+        await sleep(150);
+      }
+    };
+
+    // (a) The entry's cross-module program earns ITS signature lenses — the
+    // analysis ran project-wide (a single-file pass has no sibling Palette).
+    // Assert content, not mere presence: a stale lens mapped over from another
+    // buffer would count but not read `draw`.
+    await page.evaluate(() => window.__ide.openFile("game.fun"));
+    const gameSource = await page.evaluate(
+      () => window.__ide.files().find((f) => f.path === "game.fun").source
+    );
+    const lensTexts = await poll(
+      () => page.locator(".cm-lens").allTextContents(),
+      (ts) => ts.some((t) => t.startsWith("draw"))
+    );
+    if (lensTexts.some((t) => t.startsWith("draw"))) {
+      console.log("entry file shows draw's signature lens ✓");
+    } else {
+      fail(`no draw lens on game.fun: ${JSON.stringify(lensTexts)}`);
+    }
+
+    // (b) Dot-completion on the SIBLING module offers its members — the
+    // capability the project-aware wasm API adds. Open-and-wait with retries
+    // (the sandbox's pattern: a popup open can be swallowed by a lagging
+    // transaction, so a single-shot trigger flakes).
+    const openCompletion = async (source, cursor, pred) => {
+      for (let attempt = 0; attempt < 4; attempt++) {
+        await page.evaluate(
+          ({ s, c }) => window.__ide.triggerComplete(s, c),
+          { s: source, c: cursor }
+        );
+        const t0 = Date.now();
+        while (Date.now() - t0 < 2500) {
+          const labels = await page.evaluate(() =>
+            [...document.querySelectorAll(".cm-tooltip-autocomplete .cm-completionLabel")].map(
+              (el) => el.textContent
+            )
+          );
+          if (pred(labels)) return labels;
+          await sleep(150);
+        }
+      }
+      return [];
+    };
+
+    // Prime the wasm last-good cache: an explicit completion on the CLEAN
+    // buffer loads the project (file switches reset the cache). Waiting for
+    // its popup proves the query actually ran. The probe is then a broken
+    // buffer (trailing dot) answered from that cache — the offset contract,
+    // same as real typing.
+    const primed = await openCompletion(gameSource, gameSource.length, (ls) => ls.length > 0);
+    if (!primed.length) fail("prime completion never opened on the clean buffer");
+    const probe = `${gameSource}let probe = Palette.`;
+    const labels = await openCompletion(probe, probe.length, (ls) => ls.includes("glow"));
+    if (labels.includes("glow") && labels.includes("sky")) {
+      console.log("Palette. completes to the sibling's members (glow, sky) ✓");
+    } else {
+      fail(`sibling members not offered: ${JSON.stringify(labels)}`);
+    }
+
+    // (c) A type error in the active file underlines, and fixing it clears —
+    // the lint loop works against the project-wide pass. Restore the clean
+    // buffer first (the completion probe left a broken one, which would
+    // underline on its own and mask this check).
+    await page.evaluate((src) => window.__ide.setActiveSource(src), gameSource);
+    await poll(() => page.locator(".cm-lintRange-error").count(), (n) => n === 0);
+    await page.evaluate(
+      (src) => window.__ide.setActiveSource(src),
+      `${gameSource}let oops = (x: Float) => x + "type error"\n`
+    );
+    const underlined = await poll(() => page.locator(".cm-lintRange-error").count(), (n) => n > 0);
+    if (underlined > 0) console.log("type error draws a lint underline ✓");
+    else fail("no lint underline for a type error");
+
+    await page.evaluate((src) => window.__ide.setActiveSource(src), gameSource);
+    const cleared = await poll(() => page.locator(".cm-lintRange-error").count(), (n) => n === 0);
+    if (cleared === 0) console.log("fixing the type error clears the underline ✓");
+    else fail(`underline did not clear (count=${cleared})`);
+
+    if (await waitStatus("live", "after intel checks")) {
+      console.log("language intelligence keeps the preview live ✓");
+    }
+
+    // (d) Deleting a referenced sibling re-analyzes the OPEN file without an
+    // edit (the forced lint pass on a topology change — without it the linter
+    // never reruns): a sibling constant of the wrong type errors inside an
+    // UNCALLED function in game.fun (uncalled so the preview stays live —
+    // type diagnostics are advisory); deleting the sibling makes the module
+    // Unknown (tolerated) and the underline must clear, no edit involved.
+    await page.evaluate(() => window.__ide.newFile("colors.fun", 'let bad = "nope"\n'));
+    await page.evaluate(() => window.__ide.openFile("game.fun"));
+    await page.evaluate(
+      (src) => window.__ide.setActiveSource(src),
+      `${gameSource}let tinted = (s) => s |> Scene.emissive(0.1, 0.2, Colors.bad)\n`
+    );
+    const flagged = await poll(() => page.locator(".cm-lintRange-error").count(), (n) => n > 0);
+    if (flagged > 0) console.log("wrong-typed sibling constant underlines in the entry ✓");
+    else fail("no underline for a wrong-typed sibling reference");
+
+    page.on("dialog", (d) => d.accept());
+    await page.click('.file-delete[title="Delete colors.fun"]');
+    const afterDelete = await poll(() => page.locator(".cm-lintRange-error").count(), (n) => n === 0);
+    if (afterDelete === 0) console.log("deleting the sibling re-analyzes and clears the underline ✓");
+    else fail(`underline survived the sibling delete (count=${afterDelete})`);
+
+    await page.evaluate((src) => window.__ide.setActiveSource(src), gameSource);
+    if (await waitStatus("live", "after delete-sibling checks")) {
+      console.log("delete-sibling checks keep the preview live ✓");
+    }
   }
 
   console.log(process.exitCode ? "RESULT: FAIL" : "RESULT: PASS");

--- a/site/src/ide.js
+++ b/site/src/ide.js
@@ -8,7 +8,10 @@
 import { basicSetup } from "codemirror";
 import { EditorView, keymap } from "@codemirror/view";
 import { indentWithTab } from "@codemirror/commands";
+import { acceptCompletion, closeCompletion, startCompletion } from "@codemirror/autocomplete";
+import { StateEffect } from "@codemirror/state";
 import { functorLangLanguage, synthwaveEditorTheme } from "./functor-lang.js";
+import { setupLangIntel, setLangContext, resetIntel, refreshIntel } from "./lang-intel.js";
 import { ProjectBridge } from "./project-bridge.js";
 import { zipFiles } from "./zip.js";
 
@@ -91,7 +94,14 @@ function loadProject() {
       stored.files.some((f) => f.path === ENTRY);
     if (valid) {
       const active = stored.files.some((f) => f.path === stored.active) ? stored.active : ENTRY;
-      return { files: stored.files, active };
+      // The loader's contract (preview AND language analysis): the ENTRY is
+      // files[0] — its module is the program root. Every mutation here keeps
+      // that order, but a hand-edited localStorage could reorder.
+      const files = [
+        ...stored.files.filter((f) => f.path === ENTRY),
+        ...stored.files.filter((f) => f.path !== ENTRY),
+      ];
+      return { files, active };
     }
   } catch {
     // fall through to the starter
@@ -142,10 +152,26 @@ const view = new EditorView({
   ],
 });
 
+// Live language intelligence (diagnostics/hover/completion/inlays), shared
+// with the sandbox but project-aware here: the context provider hands the
+// whole file set + the active path, so sibling modules resolve (Palette.glow
+// from palette.fun). Degrades silently when the pkg is absent.
+setLangContext(() => ({ active: project.active, files: project.files }));
+const langReady = setupLangIntel().then((extensions) => {
+  if (extensions.length) view.dispatch({ effects: StateEffect.appendConfig.of(extensions) });
+  return extensions.length > 0;
+});
+
 const setDoc = (source) => {
   programmaticEdit = true;
   view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: source } });
   programmaticEdit = false;
+  // Wholesale document replacement (file switch, delete, e2e seam): the
+  // outgoing file's decorations are meaningless on this buffer — drop them now
+  // and force a fresh pass rather than waiting out the lint debounce. The wasm
+  // completion cache is NOT cleared: it holds the same project, and completion
+  // passes the active module per call.
+  refreshIntel(view);
 };
 
 // ---------------------------------------------------------------- preview
@@ -243,9 +269,16 @@ const deleteFile = (path) => {
   if (path === ENTRY) return;
   if (!window.confirm(`Delete ${path}? This can't be undone.`)) return;
   project.files = project.files.filter((f) => f.path !== path);
+  // The deleted module must leave the completion candidates (the wasm
+  // last-good cache still holds it until the next clean load).
+  resetIntel();
   if (project.active === path) {
     project.active = ENTRY;
     setDoc(activeFile().source);
+  } else {
+    // Topology changed under an unchanged buffer: without a doc change the
+    // linter never reruns, leaving diagnostics/inlays/lenses stale forever.
+    refreshIntel(view);
   }
   renderFileList();
   schedulePush();
@@ -316,4 +349,23 @@ window.__ide = {
     message: els.status.title,
     detail: els.statusLog.textContent,
   }),
+  // Replace the active buffer, place the cursor, and open the completion popup
+  // (explicit trigger) — the sandbox's seam, minus any push (programmaticEdit
+  // suppresses the mirror-and-push listener).
+  triggerComplete(source, cursor) {
+    closeCompletion(view);
+    programmaticEdit = true;
+    view.dispatch({
+      changes: { from: 0, to: view.state.doc.length, insert: source },
+      selection: { anchor: cursor },
+    });
+    programmaticEdit = false;
+    view.focus();
+    startCompletion(view);
+  },
+  acceptCompletion: () => acceptCompletion(view),
 };
+
+// Whether language analysis is available (false = degraded, pkg absent) — the
+// same readiness seam the sandbox exposes for e2e.
+window.__lang = { ready: langReady };

--- a/site/src/lang-intel.js
+++ b/site/src/lang-intel.js
@@ -1,7 +1,10 @@
-// Live language intelligence for the sandbox editor: loads the small
+// Live language intelligence for the sandbox and IDE editors: loads the small
 // functor-lang analysis wasm (built by `npm run build:lang-wasm`, copied to
 // dist/pkg/ by build.mjs) and turns its type diagnostics into CodeMirror lint
-// underlines, plus hover types, inlay hints, and signature codelenses.
+// underlines, plus hover types, inlay hints, and signature codelenses. The
+// sandbox analyzes its single buffer; the IDE registers a context provider
+// (setLangContext) so every pass runs over the whole file set with sibling
+// modules resolved.
 // Optional by design — if the pkg is absent or fails to init, the setup
 // resolves to [] and the editor works exactly as before (no analysis, no
 // console spam beyond one info line).
@@ -13,7 +16,7 @@
 // has filled it, so inlays/lenses lag the doc by the lint debounce (acceptable
 // and cheaper than a second scheduler) instead of re-analyzing on every key.
 
-import { linter } from "@codemirror/lint";
+import { forceLinting, linter } from "@codemirror/lint";
 import { Decoration, EditorView, ViewPlugin, WidgetType, hoverTooltip } from "@codemirror/view";
 import { StateEffect, StateField } from "@codemirror/state";
 import { functorLangLanguage } from "./functor-lang.js";
@@ -25,9 +28,41 @@ const PKG_URL = "/pkg/functor_lang_wasm.js";
 let analyzeFn = null; // (src) => JSON string, set once the wasm is ready
 let hoverFn = null; // (src, offset) => JSON string ("" when nothing to show)
 let completeFn = null; // (src, offset) => JSON string, set once the wasm is ready
+let analyzeProjectFn = null; // (filesJson, active) => JSON string
+let hoverProjectFn = null; // (filesJson, active, offset) => JSON string
+let completeProjectFn = null; // (filesJson, active, offset) => JSON string
 let resetFn = null; // () => void, clears the wasm completion cache
-let lastDoc = null;
+let lastKey = null;
 let lastResult = null;
+
+// The multi-file seam (the IDE): the host registers a provider returning the
+// whole file set (`[{ path, source }]`, entry first) plus the active path;
+// every analysis then runs project-wide — sibling modules resolve — with the
+// active file's source swapped for the live editor doc. Null (the sandbox
+// default) keeps the single-file calls.
+let contextFn = null;
+
+export const setLangContext = (fn) => {
+  contextFn = fn;
+};
+
+// The `*_project` call args for the live `docString`, or null in single-file
+// mode (no provider, or a provider mid-teardown returning junk).
+const projectArgs = (docString) => {
+  if (!contextFn) return null;
+  const { active, files } = contextFn() ?? {};
+  if (!active || !Array.isArray(files)) return null;
+  const withLive = files.map((f) => ({
+    path: f.path,
+    source: f.path === active ? docString : f.source,
+  }));
+  return { filesJson: JSON.stringify(withLive), active };
+};
+
+// The memo key covers everything an analysis depends on: in project mode the
+// serialized file set + active path (so a file switch or sibling edit is a
+// fresh analysis), in single-file mode just the doc.
+const cacheKey = (docString, args) => (args ? `${args.active}\x00${args.filesJson}` : docString);
 
 // Clear the wasm completion last-good cache — called by the sandbox when the
 // editor document is wholly replaced (example switch, inline load, reset) so
@@ -37,18 +72,22 @@ export const resetIntel = () => {
   if (resetFn) resetFn();
 };
 
-// Run analyze at most once per distinct doc string. Returns the parsed
+// Run analyze at most once per distinct (doc, context) key. Returns the parsed
 // `{ diagnostics, inlays, lenses }`, or null when the wasm isn't loaded.
 export const analyzeCached = (docString) => {
   if (!analyzeFn) return null;
-  if (docString === lastDoc) return lastResult;
+  const args = projectArgs(docString);
+  const key = cacheKey(docString, args);
+  if (key === lastKey) return lastResult;
   let result;
   try {
-    result = JSON.parse(analyzeFn(docString));
+    result = JSON.parse(
+      args ? analyzeProjectFn(args.filesJson, args.active) : analyzeFn(docString)
+    );
   } catch {
     result = { diagnostics: [], inlays: [], lenses: [] };
   }
-  lastDoc = docString;
+  lastKey = key;
   lastResult = result;
   return result;
 };
@@ -70,7 +109,7 @@ export const completeAt = (src, offset) => {
 // it never triggers an analyze of its own (the lint source is the sole caller
 // that fills the cache).
 const peekCached = (docString) =>
-  analyzeFn && docString === lastDoc ? lastResult : null;
+  analyzeFn && cacheKey(docString, projectArgs(docString)) === lastKey ? lastResult : null;
 
 // analyze offsets are whole-document UTF-16 — CodeMirror's native unit — so
 // they map straight across; clamp defensively to the current doc length.
@@ -97,7 +136,11 @@ const hoverTypes = hoverTooltip((view, pos) => {
   if (!hoverFn) return null;
   let info;
   try {
-    info = JSON.parse(hoverFn(view.state.doc.toString(), pos) || "");
+    const doc = view.state.doc.toString();
+    const args = projectArgs(doc);
+    info = JSON.parse(
+      (args ? hoverProjectFn(args.filesJson, args.active, pos) : hoverFn(doc, pos)) || ""
+    );
   } catch {
     return null;
   }
@@ -146,7 +189,13 @@ const functorCompletions = (context) => {
   if (!context.explicit && !afterDot && !word) return null;
   let items;
   try {
-    items = JSON.parse(completeFn(context.state.doc.toString(), context.pos)).items;
+    const doc = context.state.doc.toString();
+    const args = projectArgs(doc);
+    items = JSON.parse(
+      args
+        ? completeProjectFn(args.filesJson, args.active, context.pos)
+        : completeFn(doc, context.pos)
+    ).items;
   } catch {
     return null;
   }
@@ -238,6 +287,28 @@ const buildDecorations = (state) => {
 // A signal to re-derive decorations from the (freshly filled) cache.
 const refreshDecorations = StateEffect.define();
 
+// A signal to drop all decorations NOW (file switch / topology change): the
+// current set belongs to the outgoing context, and the keep-on-stale rule
+// below would otherwise show it against the incoming doc until the debounced
+// lint pass lands.
+const clearDecorations = StateEffect.define();
+
+// The editor now shows a different document or file-set shape (IDE file
+// switch, file create/delete): drop the outgoing decorations immediately and
+// force a fresh lint pass — a topology change alone doesn't change the doc,
+// so the linter would otherwise never rerun. The effect trips the linter's
+// `needsRefresh` (forceLinting alone only flushes an already-pending query);
+// safe before setup resolves (the effect is simply unhandled without it).
+export const refreshIntel = (view) => {
+  view.dispatch({ effects: clearDecorations.of(null) });
+  forceLinting(view);
+};
+
+// True when a transaction carries the clear signal — the linter must re-query
+// even though the doc is unchanged (the analysis context changed under it).
+const contextChanged = (update) =>
+  update.transactions.some((tr) => tr.effects.some((e) => e.is(clearDecorations)));
+
 // Fired from the lint source after it fills the cache; a rAF avoids dispatching
 // mid-update. Only refreshes when the cache is current, so a keystroke landing
 // in the same frame doesn't clear the decorations.
@@ -271,6 +342,7 @@ const decorationField = StateField.define({
         const built = buildDecorations(tr.state);
         if (built) decos = built; // null == stale cache: keep the mapped set
       }
+      if (effect.is(clearDecorations)) decos = Decoration.none;
     }
     return decos;
   },
@@ -361,13 +433,19 @@ export const setupLangIntel = async () => {
     if (
       typeof mod.functor_lang_analyze !== "function" ||
       typeof mod.functor_lang_hover !== "function" ||
-      typeof mod.functor_lang_complete !== "function"
+      typeof mod.functor_lang_complete !== "function" ||
+      typeof mod.functor_lang_analyze_project !== "function" ||
+      typeof mod.functor_lang_hover_project !== "function" ||
+      typeof mod.functor_lang_complete_project !== "function"
     ) {
       throw new Error("functor-lang-wasm is missing an expected export");
     }
     analyzeFn = mod.functor_lang_analyze;
     hoverFn = mod.functor_lang_hover;
     completeFn = mod.functor_lang_complete;
+    analyzeProjectFn = mod.functor_lang_analyze_project;
+    hoverProjectFn = mod.functor_lang_hover_project;
+    completeProjectFn = mod.functor_lang_complete_project;
     // reset is optional — an older bundle without it just skips cache clearing.
     resetFn = typeof mod.functor_lang_reset === "function" ? mod.functor_lang_reset : null;
   } catch {
@@ -377,7 +455,7 @@ export const setupLangIntel = async () => {
     return [];
   }
   return [
-    linter(toDiagnostics, { delay: 300 }),
+    linter(toDiagnostics, { delay: 300, needsRefresh: contextChanged }),
     hoverTypes,
     decorationField,
     initialRefresh,


### PR DESCRIPTION
## Why

Stacked on #361 (top of the #359 ← #360 ← #361 stack). The IDE page had **no language services at all** — only the sandbox loaded `setupLangIntel`. And the IDE is multi-file, so the single-file wasm calls would type sibling references (`Palette.glow`) as Unknown and offer no sibling completions.

## What

- `lang-intel.js` gains a context provider (`setLangContext`): the IDE hands the whole file set + active path, and analysis/hover/completion route through the `*_project` wasm exports with the active file's source swapped for the live doc. The memo key is the serialized file set + active path. The sandbox registers no provider and stays byte-identical on the single-file calls.
- `ide.js` wires the extensions in, plus the sandbox's `triggerComplete`/`acceptCompletion` e2e seam and `__lang.ready`.
- **Review-driven hardening** (cross-engine /xreview, findings addressed):
  - a file switch keeps the wasm completion cache (same project) but drops the outgoing file's decorations immediately instead of flashing them over the new buffer for the lint-debounce window;
  - deleting a file re-analyzes the open buffer via the linter's `needsRefresh` — a topology change alone never reruns the lint query (`forceLinting` only flushes a pending one);
  - `loadProject` enforces the loader's entry-first contract against hand-edited localStorage.
- `e2e/ide-page.mjs` requires the analysis pkg (same rule as site-sandbox) and adds: lens asserted by content, cross-module `Palette.` completion, the underline draw/clear cycle, and delete-a-referenced-sibling clearing an underline with no edit. wasm-smoke CI now runs `test:ide-page`.

## Testing

- `npm run test:ide-page` → RESULT: PASS (16 checks, all lang-intel checks exercised)
- `npm run test:site` → ALL CHECKS PASSED (sandbox unregressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)