### PR TITLE
feat(site): VSCode-style status bar with Problems and Output panels

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -161,6 +161,11 @@ multi-file.
       [const-tweaker](https://github.com/tversteeg/const-tweaker). (Functor Lang hot-reload
       already rebinds edited top-level values live; this is the finer-grained,
       no-reload knob.)
+- [ ] IDE status bar: project-wide Problems. The panel currently mirrors the
+      per-document lint pass (active file only), so a type error in a
+      non-active sibling is invisible while the preview is red. Collect by
+      running `functor_lang_analyze_project` once per file (the export's documented
+      contract) on the same debounce.
 
 ## Audio
 

--- a/e2e/ide-page.mjs
+++ b/e2e/ide-page.mjs
@@ -236,6 +236,26 @@ try {
     if (underlined > 0) console.log("type error draws a lint underline ✓");
     else fail("no lint underline for a type error");
 
+    // The status bar's Problems tab mirrors the same pass, naming the file.
+    const problemsTab = page.locator('.statusbar-tab[data-tab="problems"]');
+    const flaggedTab = await poll(
+      async () => ((await problemsTab.textContent()) || "").trim(),
+      (t) => t.includes("1 problem")
+    );
+    if (flaggedTab.includes("1 problem")) console.log("problems tab counts the type error ✓");
+    else fail(`problems tab out of sync: ${flaggedTab}`);
+    await problemsTab.click();
+    const rowText = await poll(
+      async () => {
+        const row = page.locator(".problem-row");
+        return (await row.count()) ? (await row.first().textContent()) || "" : "";
+      },
+      (t) => t.includes("game.fun")
+    );
+    if (rowText.includes("game.fun")) console.log("problems row names the active file ✓");
+    else fail(`problem row missing the file: ${rowText}`);
+    await problemsTab.click(); // close the panel again
+
     await page.evaluate((src) => window.__ide.setActiveSource(src), gameSource);
     const cleared = await poll(() => page.locator(".cm-lintRange-error").count(), (n) => n === 0);
     if (cleared === 0) console.log("fixing the type error clears the underline ✓");

--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -1116,6 +1116,86 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
   }
 }
 
+// --- 12b. Status bar: Problems + Output. ---------------------------------------
+// The bottom strip's Problems tab mirrors the lint pass (count + clickable
+// rows that jump the editor), and the Output panel receives runtime console
+// traces (`Debug.log`, forwarded from the player iframe) plus reload results.
+{
+  const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+  await page.goto(`${BASE}/sandbox.html`);
+  await page.waitForFunction(
+    () => window.__sandbox && window.__sandbox.status().state === "live",
+    { timeout: 30000 }
+  );
+
+  const problemsTab = page.locator('.statusbar-tab[data-tab="problems"]');
+  const outputTab = page.locator('.statusbar-tab[data-tab="output"]');
+  const tabText = async (tab) => ((await tab.textContent()) || "").trim();
+  const waitFor = async (fn, pred, timeout = 8000) => {
+    const t0 = Date.now();
+    for (;;) {
+      const v = await fn();
+      if (pred(v)) return v;
+      if (Date.now() - t0 > timeout) return v;
+      await sleep(150);
+    }
+  };
+
+  // A type error fills the Problems tab and panel.
+  const BAD = `${GREEN}let oops = (x: Float) => x + "status bar"\n`;
+  await page.evaluate((s) => window.__sandbox.setSource(s), BAD);
+  const flagged = await waitFor(() => tabText(problemsTab), (t) => t.includes("1 problem"));
+  check("problems tab counts the type error", flagged.includes("1 problem"), flagged);
+
+  await problemsTab.click();
+  const row = page.locator(".problem-row");
+  const rowText = await waitFor(
+    async () => ((await row.count()) ? await row.first().textContent() : ""),
+    (t) => t.includes("game.fun")
+  );
+  check(
+    "problems panel lists the diagnostic with its location",
+    rowText.includes("float") && rowText.includes("game.fun"),
+    rowText
+  );
+
+  // Clicking the row jumps + focuses the editor.
+  await row.first().click();
+  const focused = await page.evaluate(() =>
+    document.activeElement ? document.activeElement.classList.contains("cm-content") : false
+  );
+  check("clicking a problem focuses the editor", focused);
+
+  // Fixing the error empties the tab back out.
+  await page.evaluate((s) => window.__sandbox.setSource(s), GREEN);
+  const cleared = await waitFor(() => tabText(problemsTab), (t) => t.includes("0 problems"));
+  check("fixing the error resets the problems tab", cleared.includes("0 problems"), cleared);
+
+  // A top-level Debug.log fires on the hot-swap and lands in Output (the
+  // player forwards its console), alongside the reload-result lines.
+  await page.evaluate(
+    (s) => window.__sandbox.setSource(s),
+    `${GREEN}let boot = Debug.log("status-probe", 42.0)\n`
+  );
+  await outputTab.click();
+  const outputLines = await waitFor(
+    () => page.locator(".output-line").allTextContents(),
+    (lines) => lines.some((l) => l.includes("status-probe"))
+  );
+  check(
+    "Debug.log reaches the Output panel",
+    outputLines.some((l) => l.includes("status-probe")),
+    JSON.stringify(outputLines.slice(-4))
+  );
+  check(
+    "reload results reach the Output panel",
+    outputLines.some((l) => l.includes("model preserved")),
+    JSON.stringify(outputLines.slice(-4))
+  );
+
+  await page.close();
+}
+
 // --- 13. Scope-aware autocomplete in the editor (commit 8b). ------------------
 // The completion source is backed by the wasm's scope-aware `complete`, driven
 // through the __sandbox.triggerComplete seam (insert text + set cursor + open

--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -1192,6 +1192,14 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
     outputLines.some((l) => l.includes("model preserved")),
     JSON.stringify(outputLines.slice(-4))
   );
+  // Runtime lines carry a `[Frame N | HH:MM:SS]` preamble (the game was
+  // already running when the hot-swap re-evaluated the Debug.log).
+  const probeLine = outputLines.find((l) => l.includes("status-probe")) || "";
+  check(
+    "output lines carry a [Frame N | time] preamble",
+    /^\[Frame \d+ \| \d{2}:\d{2}:\d{2}\]/.test(probeLine),
+    probeLine
+  );
 
   await page.close();
 }

--- a/site/ide.html
+++ b/site/ide.html
@@ -58,6 +58,8 @@
       </section>
     </main>
 
+    <div id="statusbar"></div>
+
     <script type="module" src="assets/ide.js"></script>
   </body>
 </html>

--- a/site/player.html
+++ b/site/player.html
@@ -51,6 +51,39 @@
     <button id="mouselook" title="Control the camera with the mouse; Esc to release">🖱 mouse look</button>
     <script type="module">
 
+      // Forward console traces to the embedding page's Output panel. Functor Lang
+      // `Debug.log` routes to console.log INSIDE this iframe (see the web
+      // runtime's trace sink) — invisible unless devtools are open on the
+      // frame. Installed before the wasm loads so boot-time logs are caught.
+      // SAME-ORIGIN parents only (the sandbox/IDE): unlike the inbound
+      // protocol, this channel carries game-visible data outward, and a
+      // third-party page framing the player must not receive it — so the
+      // guard, and location.origin (never "*") as the target.
+      const sameOriginParent = (() => {
+        if (window.parent === window) return false;
+        try {
+          return window.parent.location.origin === window.location.origin;
+        } catch {
+          return false; // cross-origin parent: reading its location throws
+        }
+      })();
+      if (sameOriginParent) {
+        for (const level of ["log", "warn", "error"]) {
+          const original = console[level].bind(console);
+          console[level] = (...args) => {
+            original(...args);
+            try {
+              window.parent.postMessage(
+                { type: "functor-lang-console", level, message: args.map(String).join(" ") },
+                window.location.origin
+              );
+            } catch {
+              /* an unclonable edge must never break logging */
+            }
+          };
+        }
+      }
+
       import init, {
         functor_lang_key_event,
         functor_lang_mouse_move,

--- a/site/player.html
+++ b/site/player.html
@@ -73,8 +73,20 @@
           console[level] = (...args) => {
             original(...args);
             try {
+              // Stamp the game frame the line was emitted on. Throws before
+              // init() (no wasm yet) and reads -1 before anything is
+              // recorded — both become null (the panel then shows time only).
+              // Safe mid-tick: the export is a one-shot read of a small cell
+              // the runtime only writes in a non-held assignment.
+              let frame = null;
+              try {
+                const f = functor_lang_scene_frame();
+                if (f >= 0) frame = f;
+              } catch {
+                /* pre-init */
+              }
               window.parent.postMessage(
-                { type: "functor-lang-console", level, message: args.map(String).join(" ") },
+                { type: "functor-lang-console", level, message: args.map(String).join(" "), frame },
                 window.location.origin
               );
             } catch {
@@ -89,6 +101,7 @@
         functor_lang_mouse_move,
         functor_lang_mouse_wheel,
         functor_lang_is_running,
+        functor_lang_scene_frame,
         functor_lang_set_source,
         functor_lang_set_project,
       } from "./pkg/functor_runtime_web.js";

--- a/site/sandbox.html
+++ b/site/sandbox.html
@@ -45,6 +45,8 @@
       </section>
     </main>
 
+    <div id="statusbar"></div>
+
     <footer class="sandbox-footer">
       <p>
         Edits hot-reload the running game <em>with the model preserved</em> — the wave keeps

--- a/site/src/ide.js
+++ b/site/src/ide.js
@@ -11,8 +11,9 @@ import { indentWithTab } from "@codemirror/commands";
 import { acceptCompletion, closeCompletion, startCompletion } from "@codemirror/autocomplete";
 import { StateEffect } from "@codemirror/state";
 import { functorLangLanguage, synthwaveEditorTheme } from "./functor-lang.js";
-import { setupLangIntel, setLangContext, resetIntel, refreshIntel } from "./lang-intel.js";
+import { setupLangIntel, setLangContext, resetIntel, refreshIntel, onDiagnostics } from "./lang-intel.js";
 import { ProjectBridge } from "./project-bridge.js";
+import { createStatusBar } from "./status-bar.js";
 import { zipFiles } from "./zip.js";
 
 const STORAGE_KEY = "functor-ide-project-v1";
@@ -162,6 +163,46 @@ const langReady = setupLangIntel().then((extensions) => {
   return extensions.length > 0;
 });
 
+const statusBar = createStatusBar({ host: document.getElementById("statusbar") });
+
+// Each lint pass (of the ACTIVE file — the per-document model) refreshes the
+// Problems panel; clicking a problem jumps the editor to it. Positions
+// re-clamp at click time (the doc may have moved on).
+onDiagnostics((diags) => {
+  const file = project.active;
+  statusBar.setProblems(
+    diags.map((d) => {
+      const line = view.state.doc.lineAt(Math.min(d.from, view.state.doc.length));
+      return {
+        severity: d.severity,
+        message: d.message,
+        loc: `${file} ${line.number}:${d.from - line.from + 1}`,
+        jump: () => {
+          // A row can outlive its file (delete + the debounce window).
+          if (!project.files.some((f) => f.path === file)) return;
+          if (project.active !== file) openFile(file);
+          const len = view.state.doc.length;
+          const from = Math.min(d.from, len);
+          view.dispatch({
+            selection: { anchor: from, head: Math.max(from, Math.min(d.to, len)) },
+            scrollIntoView: true,
+          });
+          view.focus();
+        },
+      };
+    })
+  );
+});
+
+// Runtime console traces (Functor Lang `Debug.log` and friends), forwarded by the
+// player page — see the console hook in player.html. Guarded to OUR iframe.
+window.addEventListener("message", (event) => {
+  const data = event.data;
+  if (!data || data.type !== "functor-lang-console") return;
+  if (event.source !== els.player.contentWindow) return;
+  statusBar.appendOutput(data.level, data.message);
+});
+
 const setDoc = (source) => {
   programmaticEdit = true;
   view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: source } });
@@ -186,6 +227,10 @@ const bridge = new ProjectBridge(els.player, {
     } else {
       setStatus("error", "✖ error", message);
     }
+    // Failed reloads also land in the Output panel — the pill is transient,
+    // the panel keeps the history. (Successes already arrive there via the
+    // runtime's own "[functor-lang] reloaded …" console line.)
+    if (!ok) statusBar.appendOutput("error", message);
   },
 });
 
@@ -229,6 +274,9 @@ const renderFileList = () => {
 
 const openFile = (path) => {
   if (path === project.active) return;
+  // A stale caller (e.g. a problem row outliving a delete) must not point
+  // `active` at a file that no longer exists.
+  if (!project.files.some((f) => f.path === path)) return;
   // Save the live buffer into the outgoing file before switching.
   const current = activeFile();
   if (current) current.source = view.state.doc.toString();

--- a/site/src/ide.js
+++ b/site/src/ide.js
@@ -200,7 +200,7 @@ window.addEventListener("message", (event) => {
   const data = event.data;
   if (!data || data.type !== "functor-lang-console") return;
   if (event.source !== els.player.contentWindow) return;
-  statusBar.appendOutput(data.level, data.message);
+  statusBar.appendOutput(data.level, data.message, data.frame ?? null);
 });
 
 const setDoc = (source) => {

--- a/site/src/lang-intel.js
+++ b/site/src/lang-intel.js
@@ -111,6 +111,13 @@ export const completeAt = (src, offset) => {
 const peekCached = (docString) =>
   analyzeFn && cacheKey(docString, projectArgs(docString)) === lastKey ? lastResult : null;
 
+// The host page can observe each lint pass's diagnostics (the status bar's
+// Problems panel) — called with the same clamped list the linter gets.
+let diagnosticsListener = null;
+export const onDiagnostics = (fn) => {
+  diagnosticsListener = fn;
+};
+
 // analyze offsets are whole-document UTF-16 — CodeMirror's native unit — so
 // they map straight across; clamp defensively to the current doc length.
 const toDiagnostics = (view) => {
@@ -120,13 +127,17 @@ const toDiagnostics = (view) => {
   // field to re-read it (the initial doc lands here too, so inlays/lenses show
   // on load — not only after the first edit).
   scheduleRefresh(view);
-  if (!result || !Array.isArray(result.diagnostics)) return [];
   const len = doc.length;
-  return result.diagnostics.map((d) => {
-    const from = Math.max(0, Math.min(d.from | 0, len));
-    let to = Math.max(from, Math.min(d.to | 0, len));
-    return { from, to, severity: d.severity || "error", message: d.message || "" };
-  });
+  const diagnostics =
+    !result || !Array.isArray(result.diagnostics)
+      ? []
+      : result.diagnostics.map((d) => {
+          const from = Math.max(0, Math.min(d.from | 0, len));
+          const to = Math.max(from, Math.min(d.to | 0, len));
+          return { from, to, severity: d.severity || "error", message: d.message || "" };
+        });
+  if (diagnosticsListener) diagnosticsListener(diagnostics);
+  return diagnostics;
 };
 
 // --- Hover types --------------------------------------------------------------

--- a/site/src/sandbox.js
+++ b/site/src/sandbox.js
@@ -10,8 +10,9 @@ import { StateEffect } from "@codemirror/state";
 import { indentWithTab } from "@codemirror/commands";
 import { startCompletion, acceptCompletion, closeCompletion } from "@codemirror/autocomplete";
 import { functorLangLanguage, synthwaveEditorTheme } from "./functor-lang.js";
-import { setupLangIntel, analyzeCached, completeAt, resetIntel } from "./lang-intel.js";
+import { setupLangIntel, analyzeCached, completeAt, resetIntel, onDiagnostics } from "./lang-intel.js";
 import { PlayerBridge } from "./player-bridge.js";
+import { createStatusBar } from "./status-bar.js";
 
 const EXAMPLES = [
   { id: "hero", label: "Neon grid" },
@@ -36,6 +37,8 @@ const setStatus = (state, text, detail = "") => {
   statusLog.hidden = detail === "";
 };
 
+const statusBar = createStatusBar({ host: document.getElementById("statusbar") });
+
 const bridge = new PlayerBridge(frame, {
   onReloading: () => setStatus("busy", "◌ reloading…"),
   onLive: () => setStatus("live", "● live"),
@@ -48,7 +51,20 @@ const bridge = new PlayerBridge(frame, {
     } else {
       setStatus("error", "✖ error", message);
     }
+    // Failed reloads also land in the Output panel — the pill is transient,
+    // the panel keeps the history. (Successes already arrive there via the
+    // runtime's own "[functor-lang] reloaded …" console line.)
+    if (!ok) statusBar.appendOutput("error", message);
   },
+});
+
+// Runtime console traces (Functor Lang `Debug.log` and friends), forwarded by the
+// player page — see the console hook in player.html. Guarded to OUR iframe.
+window.addEventListener("message", (event) => {
+  const data = event.data;
+  if (!data || data.type !== "functor-lang-console") return;
+  if (event.source !== frame.contentWindow) return;
+  statusBar.appendOutput(data.level, data.message);
 });
 
 // Set while loadExample replaces the buffer programmatically: that content is
@@ -77,6 +93,30 @@ const view = new EditorView({
 const langReady = setupLangIntel().then((extensions) => {
   if (extensions.length) view.dispatch({ effects: StateEffect.appendConfig.of(extensions) });
   return extensions.length > 0;
+});
+
+// Each lint pass refreshes the Problems panel; clicking a problem jumps the
+// editor to it. Positions re-clamp at click time (the doc may have moved on).
+onDiagnostics((diags) => {
+  statusBar.setProblems(
+    diags.map((d) => {
+      const line = view.state.doc.lineAt(Math.min(d.from, view.state.doc.length));
+      return {
+        severity: d.severity,
+        message: d.message,
+        loc: `game.fun ${line.number}:${d.from - line.from + 1}`,
+        jump: () => {
+          const len = view.state.doc.length;
+          const from = Math.min(d.from, len);
+          view.dispatch({
+            selection: { anchor: from, head: Math.max(from, Math.min(d.to, len)) },
+            scrollIntoView: true,
+          });
+          view.focus();
+        },
+      };
+    })
+  );
 });
 
 window.__lang = {

--- a/site/src/sandbox.js
+++ b/site/src/sandbox.js
@@ -64,7 +64,7 @@ window.addEventListener("message", (event) => {
   const data = event.data;
   if (!data || data.type !== "functor-lang-console") return;
   if (event.source !== frame.contentWindow) return;
-  statusBar.appendOutput(data.level, data.message);
+  statusBar.appendOutput(data.level, data.message, data.frame ?? null);
 });
 
 // Set while loadExample replaces the buffer programmatically: that content is

--- a/site/src/status-bar.js
+++ b/site/src/status-bar.js
@@ -1,0 +1,142 @@
+// A VSCode-style bottom status bar for the sandbox and IDE pages: a slim
+// strip with two toggleable panels — Problems (live type diagnostics from the
+// language analysis) and Output (runtime console traces + reload results).
+// Plain DOM, no framework. The host page owns placement (an empty container)
+// and feeds the returned handle:
+//
+//   const bar = createStatusBar({ host });
+//   bar.setProblems([{ severity, message, loc, jump }]);   // whole list, each pass
+//   bar.appendOutput(level, text);                          // one line at a time
+//
+// Problems entries carry their own `jump` (the host closes over its editor),
+// so the component stays editor-agnostic.
+
+const MAX_OUTPUT_LINES = 500;
+
+export const createStatusBar = ({ host }) => {
+  host.className = "statusbar";
+
+  const panel = document.createElement("div");
+  panel.className = "statusbar-panel";
+  panel.hidden = true;
+
+  const problemsList = document.createElement("div");
+  problemsList.className = "statusbar-list problems-list";
+  const outputList = document.createElement("div");
+  outputList.className = "statusbar-list output-list";
+
+  const strip = document.createElement("div");
+  strip.className = "statusbar-strip";
+
+  const tabs = {};
+  let open = null; // "problems" | "output" | null
+
+  const show = (name) => {
+    open = name;
+    panel.hidden = open === null;
+    problemsList.style.display = open === "problems" ? "" : "none";
+    outputList.style.display = open === "output" ? "" : "none";
+    for (const [tabName, button] of Object.entries(tabs)) {
+      button.classList.toggle("active", tabName === open);
+    }
+    // Lines appended while the panel was hidden couldn't stick to the bottom
+    // (a display:none subtree measures 0) — land on the newest, not the oldest.
+    if (open === "output") outputList.scrollTop = outputList.scrollHeight;
+  };
+
+  const makeTab = (name, label) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "statusbar-tab";
+    button.dataset.tab = name;
+    button.textContent = label;
+    button.addEventListener("click", () => show(open === name ? null : name));
+    tabs[name] = button;
+    strip.appendChild(button);
+    return button;
+  };
+
+  const problemsTab = makeTab("problems", "✓ 0 problems");
+  makeTab("output", "output");
+
+  panel.appendChild(problemsList);
+  panel.appendChild(outputList);
+  host.appendChild(panel);
+  host.appendChild(strip);
+
+  const setProblems = (items) => {
+    // The tab goes loud (red ✖) only for errors — a warnings-only file keeps
+    // the calm glyph.
+    const errors = items.filter((item) => (item.severity || "error") === "error").length;
+    problemsTab.textContent =
+      items.length === 0
+        ? "✓ 0 problems"
+        : `${errors > 0 ? "✖" : "⚠"} ${items.length} problem${items.length === 1 ? "" : "s"}`;
+    problemsTab.classList.toggle("has-problems", errors > 0);
+    problemsList.textContent = "";
+    if (items.length === 0) {
+      const empty = document.createElement("div");
+      empty.className = "statusbar-empty";
+      empty.textContent = "No problems detected.";
+      problemsList.appendChild(empty);
+      return;
+    }
+    for (const item of items) {
+      const row = document.createElement("button");
+      row.type = "button";
+      row.className = "problem-row";
+      const icon = document.createElement("span");
+      const severity = item.severity || "error";
+      icon.className = `problem-icon severity-${severity}`;
+      icon.textContent = severity === "error" ? "✖" : "⚠";
+      const message = document.createElement("span");
+      message.className = "problem-message";
+      message.textContent = item.message;
+      const loc = document.createElement("span");
+      loc.className = "problem-loc";
+      loc.textContent = item.loc;
+      row.append(icon, message, loc);
+      if (item.jump) row.addEventListener("click", item.jump);
+      problemsList.appendChild(row);
+    }
+  };
+  setProblems([]);
+
+  // Appends are rAF-coalesced: a per-frame `Debug.log` in tick/draw arrives
+  // ~60/sec, and appending each line individually would force a layout read
+  // (scrollHeight) per message while the panel is open. One DOM flush per
+  // frame keeps the panel usable under a logging loop.
+  let pending = [];
+  let flushScheduled = false;
+
+  const flushOutput = () => {
+    flushScheduled = false;
+    if (pending.length === 0) return;
+    // Stick to the bottom only if the user is already there (don't yank the
+    // scroll out from under them mid-read).
+    const atBottom = outputList.scrollTop + outputList.clientHeight >= outputList.scrollHeight - 4;
+    // A burst larger than the cap only ever shows its tail — skip the rest.
+    const lines = pending.slice(-MAX_OUTPUT_LINES);
+    pending = [];
+    for (const { level, text } of lines) {
+      const line = document.createElement("div");
+      line.className = `output-line output-${level}`;
+      line.textContent = text;
+      outputList.appendChild(line);
+    }
+    while (outputList.childElementCount > MAX_OUTPUT_LINES) {
+      outputList.firstElementChild.remove();
+    }
+    if (atBottom) outputList.scrollTop = outputList.scrollHeight;
+  };
+
+  const appendOutput = (level, text) => {
+    pending.push({ level, text });
+    if (!flushScheduled) {
+      flushScheduled = true;
+      requestAnimationFrame(flushOutput);
+    }
+  };
+
+  return { setProblems, appendOutput };
+};

--- a/site/src/status-bar.js
+++ b/site/src/status-bar.js
@@ -102,6 +102,17 @@ export const createStatusBar = ({ host }) => {
   };
   setProblems([]);
 
+  // Each line carries a `[Frame N | HH:MM:SS]` preamble — the game frame it
+  // was emitted on (when the runtime had one) and the wall clock. The clock is
+  // stamped at append time, not at the rAF flush, so a coalesced burst keeps
+  // each line's true arrival time.
+  const clock = (date) => {
+    const two = (n) => String(n).padStart(2, "0");
+    return `${two(date.getHours())}:${two(date.getMinutes())}:${two(date.getSeconds())}`;
+  };
+  const preamble = (frame, time) =>
+    frame == null ? `[${time}]` : `[Frame ${frame} | ${time}]`;
+
   // Appends are rAF-coalesced: a per-frame `Debug.log` in tick/draw arrives
   // ~60/sec, and appending each line individually would force a layout read
   // (scrollHeight) per message while the panel is open. One DOM flush per
@@ -118,10 +129,14 @@ export const createStatusBar = ({ host }) => {
     // A burst larger than the cap only ever shows its tail — skip the rest.
     const lines = pending.slice(-MAX_OUTPUT_LINES);
     pending = [];
-    for (const { level, text } of lines) {
+    for (const { level, text, frame, time } of lines) {
       const line = document.createElement("div");
       line.className = `output-line output-${level}`;
-      line.textContent = text;
+      const stamp = document.createElement("span");
+      stamp.className = "output-preamble";
+      stamp.textContent = preamble(frame, time);
+      line.appendChild(stamp);
+      line.appendChild(document.createTextNode(` ${text}`));
       outputList.appendChild(line);
     }
     while (outputList.childElementCount > MAX_OUTPUT_LINES) {
@@ -130,8 +145,10 @@ export const createStatusBar = ({ host }) => {
     if (atBottom) outputList.scrollTop = outputList.scrollHeight;
   };
 
-  const appendOutput = (level, text) => {
-    pending.push({ level, text });
+  // `frame` is the game frame the line belongs to (null when the runtime had
+  // none to offer — boot lines, host-side reload errors).
+  const appendOutput = (level, text, frame = null) => {
+    pending.push({ level, text, frame, time: clock(new Date()) });
     if (!flushScheduled) {
       flushScheduled = true;
       requestAnimationFrame(flushOutput);

--- a/site/styles.css
+++ b/site/styles.css
@@ -872,3 +872,130 @@ a:hover {
     gap: 12px;
   }
 }
+
+/* ---- Status bar (sandbox + IDE): Problems / Output panels ---------------- */
+
+.statusbar {
+  display: flex;
+  flex-direction: column;
+  border-top: 1px solid var(--line);
+  background: var(--bg-panel);
+  font-family: var(--font-mono);
+}
+
+.statusbar-strip {
+  display: flex;
+  gap: 2px;
+  padding: 0 8px;
+}
+
+.statusbar-tab {
+  appearance: none;
+  border: none;
+  background: none;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  padding: 4px 10px;
+  cursor: pointer;
+}
+
+.statusbar-tab:hover {
+  color: var(--text);
+}
+
+.statusbar-tab.active {
+  color: var(--cyan);
+  box-shadow: inset 0 2px 0 var(--cyan);
+}
+
+.statusbar-tab.has-problems {
+  color: var(--red);
+}
+
+.statusbar-tab.has-problems.active {
+  color: var(--red);
+  box-shadow: inset 0 2px 0 var(--red);
+}
+
+.statusbar-panel {
+  height: 180px;
+  border-bottom: 1px solid var(--line);
+  overflow: hidden;
+  display: flex;
+}
+
+.statusbar-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 6px 8px;
+  font-size: 0.78rem;
+  line-height: 1.5;
+}
+
+.statusbar-empty {
+  color: var(--text-dim);
+  font-style: italic;
+}
+
+.problem-row {
+  appearance: none;
+  border: none;
+  background: none;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  width: 100%;
+  text-align: left;
+  padding: 2px 4px;
+  cursor: pointer;
+  border-radius: 3px;
+}
+
+.problem-row:hover {
+  background: var(--bg-raised);
+}
+
+.problem-icon.severity-error {
+  color: var(--red);
+}
+
+.problem-icon.severity-warning {
+  color: var(--amber);
+}
+
+.problem-message {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.problem-loc {
+  color: var(--text-dim);
+  font-size: 0.72rem;
+  white-space: nowrap;
+}
+
+.output-line {
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--text-dim);
+}
+
+.output-line.output-warn {
+  color: var(--amber);
+}
+
+.output-line.output-error {
+  color: var(--red);
+}
+
+.output-line.output-info {
+  color: var(--text);
+}

--- a/site/styles.css
+++ b/site/styles.css
@@ -988,6 +988,11 @@ a:hover {
   color: var(--text-dim);
 }
 
+.output-preamble {
+  color: #6c6685;
+  font-size: 0.9em;
+}
+
 .output-line.output-warn {
   color: var(--amber);
 }


### PR DESCRIPTION
## Why

Top of the stack (#359 ← #360 ← #361 ← #362). Two gaps in the sandbox/IDE dev loop: type diagnostics only existed as editor underlines (no overview, nothing clickable), and **runtime debug logs went nowhere** — Functor Lang `Debug.log` routes to `console.log` inside the player iframe, invisible unless you had devtools open on the frame.

## What

A VSCode-style bottom status bar on both pages (shared `site/src/status-bar.js`, plain DOM):

- **Problems** — fed each lint pass via a new `onDiagnostics` seam in `lang-intel.js`; the tab counts errors (`✖ 1 problem`, calm `⚠` for warnings-only), rows show message + `file line:col` and jump the editor to the range on click (IDE rows re-check the file still exists and can switch files).
- **Output** — `player.html` wraps `console.log/warn/error` and forwards lines to the embedding page; `Debug.log` traces, `[functor-lang]` load/reload lines, and failed reload results all land there (capped at 500 lines, rAF-coalesced so a per-frame `Debug.log` at ~60/sec doesn't jank the panel, auto-follow unless you've scrolled up).

### Security note (from cross-engine review)
Console forwarding only activates for a **same-origin parent** and targets `location.origin`, never `"*"` — unlike the inbound push protocol, this channel carries game-visible data *outward*, and a third-party page framing the player must not receive it.

Known scope (in `docs/todo.md`): the IDE's Problems panel mirrors the per-document pass, so a non-active file's type error isn't listed (the preview pill still goes red); project-wide collection is a follow-up.

## Screenshots

**Problems** — a type error counted in the tab, listed with location, underlined in the editor:

![problems](https://gist.github.com/tommy-xr/d854579e69c31c23fdc1a30ea9d13dba/raw/statusbar-problems.png)

**Output** — `Debug.log("boot model", 42.0)` forwarded from the player, alongside the runtime's load/reload lines:

![output](https://gist.github.com/tommy-xr/d854579e69c31c23fdc1a30ea9d13dba/raw/statusbar-output.png)

## Testing

- `npm run test:site` → ALL CHECKS PASSED (new block: problems count/row/jump/clear + Debug.log and reload lines reaching Output)
- `npm run test:ide-page` → RESULT: PASS (problems tab syncs with the underline cycle, row names the active file)

Reviewed with /xreview (Claude + Codex); all Critical/High/Medium findings addressed or explicitly scoped (stale-offset drift within the 300ms lint debounce is clamped + self-healing; deemed not worth transaction-mapping complexity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)