### PR TITLE
feat(lang): brand Random seeds as an abstract Random.Seed type

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -326,18 +326,28 @@ positively: `Math.mod(-1.0, 8.0)` == `7.0`, the wraparound games want;
 `b == 0.0` → NaN) ·
 `Math.min(a, b)` · `Math.max(a, b)` · `Math.pow(base, exp)` (`base ^ exp`) ·
 `Math.pi` (a constant `float` VALUE, not a call — write `Math.pi`, never
-`Math.pi()`) · `Debug.log(label, value)` — `(string, 'a) => 'a`: an Elm-style trace. Logs
+`Math.pi()`) ·
+`Random.seed(n)` → `Seed` — make a seed. Seeds are **`Random.Seed`**, an
+abstract BRANDED type (annotate as `Random.Seed`): a bare number where a
+`Seed` is expected (`Random.step(42.0)`) and seed arithmetic (`seed + i`)
+are check-time errors. `Random.seed` hashes the float's BITS, so any finite
+float — `Random.seed(0.42)` from an `Effect.random` result as much as
+`Random.seed(42.0)` — is a valid, distinct starting point. At runtime a
+seed is still plain data (a number), so it snapshots, hot-reloads, and
+time-travels like any model field ·
 `Random.step(seed)` → `(value, nextSeed)` — pure seeded PRNG: `value` in
 `[0, 1)`, deterministic (same seed → same stream), no effect round-trip.
-Thread `nextSeed` through the model to advance the stream
+Thread `nextSeed` (itself a `Seed`) through the model to advance the stream
 (`let (v, s2) = Random.step(model.seed) in …`). Seed the stream once at
-init via `Effect.random`/`Effect.now` (or a fixed constant for a
-reproducible run). Because it's a builtin it also runs under plain
-`functor-lang run`. Adjacent seeds give **decorrelated** streams with no
-short-prefix overlap (a splitmix64 avalanche over a Weyl counter — this is the
-fix for the sin-hash noise whose correlated streams were a visual bug), so
-`baseSeed + i` per entity is safe. Seeds fold mod 2^52, so any finite seed
-(including negatives) is a valid distinct starting point.
+init via `Effect.random`/`Effect.now` + `Random.seed(r)` (or a fixed
+`Random.seed(42.0)` for a reproducible run). Because it's a builtin it also
+runs under plain `functor-lang run`. Distinct seeds give **decorrelated**
+streams with no short-prefix overlap (a splitmix64 avalanche over a Weyl
+counter — the fix for the sin-hash noise whose correlated streams were a
+visual bug) ·
+`Random.fork(i, seed)` → `Seed` — the seed of decorrelated child stream `i`
+(per-entity streams: `model.seed |> Random.fork(i)`; subject-LAST, any
+float index). The typed successor of the old `baseSeed + i` arithmetic ·
 `Random.range(lo, hi, seed)` → `(value, nextSeed)` is the one convenience:
 one draw rescaled into `[lo, hi)` (for `lo <= hi`) · `Debug.log(label, value)` —
 `(string, 'a) => 'a`: an Elm-style trace. Logs

--- a/docs/functor-lang.md
+++ b/docs/functor-lang.md
@@ -256,6 +256,20 @@ snapshots — no GPU, fully agent-verifiable.
       REFUSE bare numbers with a teaching error — degree/radian confusion
       is unrepresentable, matching the F# side's `Math.Angle` discipline.
       Tier 2 (F#-style units of measure with unit algebra) rides on B7.
+- [x] **Branded `Random.Seed`** (2026-07-16; the strong-typing track's first
+      slice). A built-in `Random` interface module (`<builtin>/Random.funi`,
+      injected beside `Net`) declares an abstract `Seed`: `Random.seed(n)`
+      makes one (hashing the float's BITS, so `Effect.random`'s fractional
+      [0, 1) output no longer collapses every run onto counter 0),
+      `Random.fork(i, seed)` derives per-entity child streams (the typed
+      successor of `baseSeed + i`), and `step`/`range` take and return
+      `Seed`s. Enforcement is CHECK-TIME only — at runtime a seed stays a
+      plain number, so seeds remain plain data for time-travel snapshots,
+      hot-reload preservation, and `/state` (docs/time-travel.md's "the seed
+      is one more plain-data timeline entry" invariant holds). At the
+      checker's External seam an interface signature now takes precedence
+      over a builtin scheme — the injected `.funi` is what brands the
+      builtins.
 - [x] **B7. Hindley–Milner inference** (done 2026-07-04; decided 2026-07-02; **after effects
       land** — B6 + the `effect[...]` header checking, so type inference and
       effect rows are designed against each other, not retrofitted). Upgrade

--- a/examples/asteroids/game.fun
+++ b/examples/asteroids/game.fun
@@ -39,11 +39,10 @@ type Msg =
   | StartClicked
   | RestartClicked
 
-// ---------- deterministic "randomness" ----------
-// Math has no floor/frac/random, so scaled-sin noise stands in: a
-// deterministic value in roughly [0,1] from a seed and a stream index.
-let noise = (seed, n) =>
-  Math.sin(seed * 127.1 + n * 311.7) * 0.5 + 0.5
+// ---------- deterministic randomness ----------
+// The model carries a Random.Seed; per-entity streams fork off it
+// (`seed |> Random.fork(i)`) and draws thread the returned nextSeed, so
+// every run seeded by the same Effect.random result replays exactly.
 
 // ---------- spawning ----------
 let radiusOf = (size) =>
@@ -61,19 +60,23 @@ let pointsFor = (size) =>
 let waveRocks = (wave) => 2.0 + wave
 
 // A large rock on a ring around the center (never on the ship), drifting
-// in a noise-picked direction with a noise-picked spin.
+// in a randomly-picked direction with a random spin. Rock n draws from its
+// own forked stream, and the last nextSeed becomes the rock's OWN seed
+// (its shape wobble and, on destruction, its children derive from it).
 let spawnRock = (seed, n) =>
-  let ang = noise(seed, n) * 6.28318 in
-  let ring = 8.0 + noise(seed, n + 17.0) * 6.0 in
-  let dir = noise(seed, n + 31.0) * 6.28318 in
-  let speed = 1.5 + noise(seed, n + 47.0) * 2.0 in
+  let s0 = seed |> Random.fork(n) in
+  let (ang, s1) = Random.range(0.0, 6.28318, s0) in
+  let (ring, s2) = Random.range(8.0, 14.0, s1) in
+  let (dir, s3) = Random.range(0.0, 6.28318, s2) in
+  let (speed, s4) = Random.range(1.5, 3.5, s3) in
+  let (spin, s5) = Random.range(0.0 - 1.5, 1.5, s4) in
   { x: Math.sin(ang) * ring,
     z: Math.cos(ang) * ring,
     vx: Math.sin(dir) * speed,
     vz: Math.cos(dir) * speed,
     size: 3.0,
-    spin: noise(seed, n + 5.0) * 3.0 - 1.5,
-    seed: noise(seed, n + 3.0) }
+    spin: spin,
+    seed: s5 }
 
 let spawnWave = (seed, count) =>
   List.range(count) |> List.map((n) => spawnRock(seed, n))
@@ -88,14 +91,14 @@ let init = {
   phase: Menu,
   ship: newShip,
   bullets: [],
-  asteroids: spawnWave(0.42, 5.0),   // the menu's drifting backdrop
+  asteroids: spawnWave(Random.seed(0.42), 5.0),   // the menu's drifting backdrop
   score: 0.0,
   lives: 3.0,
   wave: 1.0,
   held: { left: false, right: false, thrust: false },
   fireHeld: false,
   shield: 0.0,
-  seed: 0.42,
+  seed: Random.seed(0.42),
 }
 
 // ---------- geometry helpers ----------
@@ -141,22 +144,27 @@ let assignHits = (bullets, rocks) =>
 
 // ---------- splitting ----------
 // A destroyed rock (sizes 3/2) splits into two children of the next size
-// down, flung off the parent's course by opposite noise-picked angles.
+// down, flung off the parent's course by opposite randomly-kicked angles.
+// Each child forks its own stream off the parent's seed by salt.
 let childRock = (a, ang, salt) =>
   let v = rotVec(a.vx * 1.35, a.vz * 1.35, ang) in
+  let (spin, childSeed) = Random.range(0.0 - 2.0, 2.0, a.seed |> Random.fork(salt)) in
   { x: a.x,
     z: a.z,
     vx: v.x,
     vz: v.z,
     size: a.size - 1.0,
-    spin: noise(a.seed, salt + 9.0) * 4.0 - 2.0,
-    seed: noise(a.seed, salt) }
+    spin: spin,
+    seed: childSeed }
 
 let splitRock = (a) =>
   match a.size with
   | 1.0 => []
-  | _ => [childRock(a, 0.7 + noise(a.seed, 7.0), 1.7),
-          childRock(a, 0.0 - (0.7 + noise(a.seed, 8.0)), 2.3)]
+  | _ =>
+    let (kickA, ks) = Random.step(a.seed |> Random.fork(7.0)) in
+    let (kickB, _) = Random.step(ks) in
+    [childRock(a, 0.7 + kickA, 1.7),
+     childRock(a, 0.0 - (0.7 + kickB), 2.3)]
 
 // ---------- effects ----------
 let fxOf = (list) =>
@@ -181,7 +189,7 @@ let freshRun = (model, seed) =>
 
 let update = (model, msg) =>
   match msg with
-  | Seeded(r) => freshRun(model, r)
+  | Seeded(r) => freshRun(model, Random.seed(r))
   | StartClicked => (model, Effect.random(Seeded))
   | RestartClicked => (model, Effect.random(Seeded))
 
@@ -305,7 +313,7 @@ let tickPlaying = (model, dt, tts) =>
      | [] =>
        (match model.wave < finalWave with
         | true =>
-          (let nextSeed = noise(model.seed, tts) in
+          (let (_, nextSeed) = Random.step(model.seed) in
            ({ base with wave: model.wave + 1.0,
                         seed: nextSeed,
                         shield: Lib.floorAt(1.5, shield),
@@ -324,25 +332,35 @@ let tick = (model, dt, tts) =>
 
 // ---------- rendering ----------
 // Stars as tiny upward-facing planes (spheres this small render as
-// speckle clusters from overhead). Brightness varies by noise.
+// speckle clusters from overhead). Star n draws glow, size, and position
+// from its own forked stream — decorrelated by construction, no clumping.
+let starSeed = Random.seed(9.1)
+
 let starfield = () =>
   List.range(60.0) |> List.map((n) =>
-    let glow = 0.45 + noise(9.1, n) * 0.55 in
+    let (glow01, s1) = Random.step(starSeed |> Random.fork(n)) in
+    let (size01, s2) = Random.step(s1) in
+    let (x01, s3) = Random.step(s2) in
+    let (z01, _) = Random.step(s3) in
+    let glow = 0.45 + glow01 * 0.55 in
     Scene.plane()
-      |> Scene.scale(0.14 + noise(7.7, n) * 0.14)
+      |> Scene.scale(0.14 + size01 * 0.14)
       |> Scene.emissive(glow, glow, glow * 1.08)
-      // Decorrelated index scales — the same n-step in both axes walks a
-      // closed curve and the stars visibly clump.
-      |> Scene.translate((noise(3.1, n) * 2.0 - 1.0) * (worldX + 8.0),
+      |> Scene.translate((x01 * 2.0 - 1.0) * (worldX + 8.0),
                          0.0 - 4.0,
-                         (noise(5.3, n * 1.37 + 11.0) * 2.0 - 1.0) * (worldZ + 8.0)))
+                         (z01 * 2.0 - 1.0) * (worldZ + 8.0)))
 
+// The rock's shape wobble draws from its own seed — pure, so the shape is
+// stable frame to frame.
 let rockScene = (a, tts) =>
   let r = radiusOf(a.size) in
+  let (w1, s1) = Random.step(a.seed) in
+  let (w2, s2) = Random.step(s1) in
+  let (w3, _) = Random.step(s2) in
   Scene.sphere()
-    |> Scene.scaleXYZ(r * (0.75 + noise(a.seed, 1.0) * 0.5),
-                      r * (0.75 + noise(a.seed, 2.0) * 0.5),
-                      r * (0.75 + noise(a.seed, 3.0) * 0.5))
+    |> Scene.scaleXYZ(r * (0.75 + w1 * 0.5),
+                      r * (0.75 + w2 * 0.5),
+                      r * (0.75 + w3 * 0.5))
     |> Scene.rotateY(Angle.radians(tts * a.spin))
     |> Scene.lit(0.62, 0.55, 0.47)
     |> Scene.translate(a.x, 0.0, a.z)

--- a/functor-lang/src/complete.rs
+++ b/functor-lang/src/complete.rs
@@ -65,7 +65,7 @@ pub enum CompletionKind {
 
 /// The complete builtin registry. Hand-listed because [`Builtin`] is not
 /// iterable — keep in sync with `eval::Builtin` (35 variants).
-const BUILTINS: [Builtin; 35] = [
+const BUILTINS: [Builtin; 37] = [
     Builtin::ListMap,
     Builtin::ListFilter,
     Builtin::ListFold,
@@ -98,8 +98,10 @@ const BUILTINS: [Builtin; 35] = [
     Builtin::TextJoin,
     Builtin::TextParseFloat,
     Builtin::MathClamp01,
+    Builtin::RandomSeed,
     Builtin::RandomStep,
     Builtin::RandomRange,
+    Builtin::RandomFork,
     Builtin::DebugLog,
 ];
 
@@ -1439,12 +1441,14 @@ mod tests {
                 | Builtin::TextSplit
                 | Builtin::TextJoin
                 | Builtin::TextParseFloat
+                | Builtin::RandomSeed
                 | Builtin::RandomStep
                 | Builtin::RandomRange
+                | Builtin::RandomFork
                 | Builtin::DebugLog => {}
             }
         }
-        assert_eq!(BUILTINS.len(), 35, "BUILTINS must list every Builtin");
+        assert_eq!(BUILTINS.len(), 37, "BUILTINS must list every Builtin");
     }
 
     // 19. A full keyword typed (`let`, cursor at end) still offers `let`.

--- a/functor-lang/src/eval.rs
+++ b/functor-lang/src/eval.rs
@@ -1460,6 +1460,24 @@ most 1000000 cells"
                 }
                 _ => err("Random.step(seed) expects one finite number".to_string()),
             },
+            // `Random.seed(n)` — make a Seed from any finite number by
+            // hashing its BITS (see `seed_counter`); the branded entry point
+            // to the PRNG. At runtime a Seed is a plain number (the brand is
+            // check-time only), which keeps seeds plain data for time-travel
+            // snapshots, hot-reload preservation, and `/state`.
+            Builtin::RandomSeed => match args.as_slice() {
+                [Value::Number(n)] if n.is_finite() => Ok(Value::Number(seed_counter(*n) as f64)),
+                _ => err("Random.seed(n) expects one finite number".to_string()),
+            },
+            // `Random.fork(i, seed)` — the seed of decorrelated child stream
+            // `i`: the typed form of the old `baseSeed + i` per-entity idiom.
+            // Subject-LAST, so it pipes: `model.seed |> Random.fork(i)`.
+            Builtin::RandomFork => match args.as_slice() {
+                [Value::Number(i), Value::Number(seed)] if i.is_finite() && seed.is_finite() => {
+                    Ok(Value::Number(fork_seed(*i, *seed)))
+                }
+                _ => err("Random.fork(i, seed) expects two finite numbers".to_string()),
+            },
             // Convenience: `Random.range(lo, hi, seed) => (value, nextSeed)`
             // with value in [lo, hi) for lo <= hi (one `Random.step` draw
             // rescaled).
@@ -1765,6 +1783,7 @@ pub fn builtin_arity(b: Builtin) -> usize {
         | Builtin::MathMin
         | Builtin::MathMax
         | Builtin::MathPow
+        | Builtin::RandomFork
         | Builtin::DebugLog => 2,
         Builtin::ListRange
         | Builtin::ListMaximum
@@ -1784,7 +1803,7 @@ pub fn builtin_arity(b: Builtin) -> usize {
         // `Math.pi` resolves straight to a number in `eval` (it's a constant,
         // never a callable value), so this arity is never consulted.
         Builtin::MathPi => 0,
-        | Builtin::RandomStep => 1,
+        Builtin::RandomSeed | Builtin::RandomStep => 1,
     }
 }
 
@@ -1822,8 +1841,10 @@ pub enum Builtin {
     TextJoin,
     TextParseFloat,
     MathClamp01,
+    RandomSeed,
     RandomStep,
     RandomRange,
+    RandomFork,
     DebugLog,
 }
 
@@ -1844,8 +1865,6 @@ pub enum Builtin {
 ///
 /// Returns `(value, nextSeed)` with `value` in `[0, 1)`.
 fn random_step(seed: f64) -> (f64, f64) {
-    const MASK52: u64 = (1u64 << 52) - 1;
-    const TWO52: f64 = 4_503_599_627_370_496.0; // 2^52
     // Odd 52-bit golden-ratio gamma — a large stride with full period 2^52.
     const GAMMA: u64 = 0x9E37_79B9_7F4A_7;
 
@@ -1858,15 +1877,48 @@ fn random_step(seed: f64) -> (f64, f64) {
     let counter = seed.rem_euclid(TWO52) as u64 & MASK52;
     let next = counter.wrapping_add(GAMMA) & MASK52;
 
-    // The splitmix64 finalizer avalanches the (52-bit) Weyl state into 64 bits.
-    let mut z = next;
-    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
-    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
-    z ^= z >> 31;
+    // The finalizer avalanches the (52-bit) Weyl state into 64 bits.
+    let z = mix64(next);
 
     // Top 53 bits → a double in [0, 1) (the standard splitmix64→f64 mapping).
     let value = (z >> 11) as f64 * (1.0 / 9_007_199_254_740_992.0); // 2^53
     (value, next as f64)
+}
+
+const MASK52: u64 = (1u64 << 52) - 1;
+const TWO52: f64 = 4_503_599_627_370_496.0; // 2^52
+
+/// The splitmix64 finalizer — shared by [`random_step`], [`seed_counter`],
+/// and [`fork_seed`].
+fn mix64(mut z: u64) -> u64 {
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
+/// `Random.seed(n)` — fold any finite f64 into a counter by hashing its BIT
+/// PATTERN, not its integer value. `random_step`'s raw fold truncates
+/// fractional seeds, so every seed in `[0, 1)` — exactly what the documented
+/// `Effect.random` seeding idiom delivers — collapsed to counter 0 (the same
+/// stream every run). Hashing the bits gives every distinct float a
+/// decorrelated starting point.
+fn seed_counter(n: f64) -> u64 {
+    // `+ 0.0` normalizes -0.0 to +0.0 so the two equal zeros seed alike.
+    mix64((n + 0.0).to_bits()) & MASK52
+}
+
+/// `Random.fork(i, seed)` — the seed of child stream `i`, hash-combined so
+/// ANY float index names a distinct decorrelated stream (no truncation edge
+/// cases). The typed replacement for the old `baseSeed + i` arithmetic,
+/// which an opaque seed no longer permits.
+fn fork_seed(i: f64, seed: f64) -> f64 {
+    // Offsetting the index bits domain-separates the combine: mix64(0) == 0,
+    // so without it the all-zero corner `Random.fork(0.0, Random.seed(0.0))`
+    // would fix-point back to the parent seed.
+    const FORK_GAMMA: u64 = 0x9E37_79B9_7F4A_7C15;
+    let counter = seed.rem_euclid(TWO52) as u64 & MASK52;
+    let index = mix64((i + 0.0).to_bits().wrapping_add(FORK_GAMMA));
+    (mix64(counter ^ index) & MASK52) as f64
 }
 
 /// Resolve an [`ExprKind::External`] path against the registry.
@@ -1905,8 +1957,10 @@ pub fn builtin(path: &[String]) -> Option<Builtin> {
         "Math.max" => Builtin::MathMax,
         "Math.pow" => Builtin::MathPow,
         "Math.pi" => Builtin::MathPi,
+        "Random.seed" => Builtin::RandomSeed,
         "Random.step" => Builtin::RandomStep,
         "Random.range" => Builtin::RandomRange,
+        "Random.fork" => Builtin::RandomFork,
         "Debug.log" => Builtin::DebugLog,
         _ => return None,
     })
@@ -1947,8 +2001,10 @@ pub fn builtin_name(b: Builtin) -> &'static str {
         Builtin::MathMax => "Math.max",
         Builtin::MathPow => "Math.pow",
         Builtin::MathPi => "Math.pi",
+        Builtin::RandomSeed => "Random.seed",
         Builtin::RandomStep => "Random.step",
         Builtin::RandomRange => "Random.range",
+        Builtin::RandomFork => "Random.fork",
         Builtin::DebugLog => "Debug.log",
     }
 }
@@ -2086,6 +2142,56 @@ mod random_tests {
                     i + 1
                 );
             }
+        }
+    }
+
+    /// `Random.seed` hashes the float's BITS: fractional seeds — notably the
+    /// `Effect.random` idiom's [0, 1) output, which the raw counter fold
+    /// truncates to 0 — must land on distinct counters.
+    #[test]
+    fn seed_counter_spreads_fractional_seeds() {
+        let seeds = [0.0, 0.42, 0.84, 0.999, 1.0, 5.0, -0.42, -5.0];
+        let counters: Vec<u64> = seeds.iter().map(|&s| super::seed_counter(s)).collect();
+        let mut sorted = counters.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted.len(), seeds.len(), "seed counters collapsed: {counters:?}");
+        // -0.0 == +0.0, so the two equal zeros must seed alike…
+        assert_eq!(super::seed_counter(-0.0), super::seed_counter(0.0));
+        // …and every counter round-trips exactly through the language's f64s.
+        for &c in &counters {
+            assert_eq!(c as f64 as u64, c);
+            assert!(c < 1u64 << 52);
+        }
+    }
+
+    /// The all-zero corner: `mix64(0) == 0`, so `Random.seed(0.0)` is counter
+    /// 0 — and an undecorated hash-combine would make `fork(0.0, that)`
+    /// fix-point back to the parent. The FORK_GAMMA offset breaks the cycle.
+    #[test]
+    fn fork_of_zero_seed_leaves_the_parent() {
+        let zero = super::seed_counter(0.0) as f64;
+        let child = super::fork_seed(0.0, zero);
+        assert_ne!(child, zero, "fork(0, seed(0)) must not echo the parent");
+        // And the child's stream diverges from the parent's.
+        assert_ne!(random_step(child).0, random_step(zero).0);
+    }
+
+    /// `Random.fork(i, seed)` — distinct, deterministic, in-range child seeds
+    /// for distinct stream indices (including fractional ones — no
+    /// truncation collisions like `fork(0.5) == fork(0.0)`).
+    #[test]
+    fn fork_names_distinct_child_streams() {
+        let seed = super::seed_counter(5.0) as f64;
+        let indices: Vec<f64> = (0..64).map(|i| i as f64).chain([0.5, 1.5, -1.0]).collect();
+        let children: Vec<f64> = indices.iter().map(|&i| super::fork_seed(i, seed)).collect();
+        let mut sorted = children.clone();
+        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        sorted.dedup();
+        assert_eq!(sorted.len(), children.len(), "fork child seeds collided");
+        for (&i, &c) in indices.iter().zip(&children) {
+            assert_eq!(c, super::fork_seed(i, seed), "fork is deterministic");
+            assert!(c >= 0.0 && c < (1u64 << 52) as f64 && c == c.trunc());
         }
     }
 

--- a/functor-lang/src/project.rs
+++ b/functor-lang/src/project.rs
@@ -115,6 +115,19 @@ const NET_MODULE_SRC: &str = "type NetEvent =\n\
      | Response(status: Float, body: String)\n\
      | Failure(error: String)\n";
 
+/// The built-in `Random` interface module (injected beside `Net` in [`link`]).
+/// `Seed` is an abstract type — the brand that keeps PRNG seeds out of
+/// arithmetic — while at runtime a seed stays a plain number (plain data for
+/// time-travel snapshots and hot-reload). The values are builtins
+/// ([`crate::eval::Builtin`]); these signatures both type them (the checker
+/// prefers a signature over a builtin scheme) and keep the qualified names
+/// resolving now that a `Random` module exists.
+const RANDOM_MODULE_SRC: &str = "type Seed\n\
+     let seed : (float) => Seed\n\
+     let step : (Seed) => (float, Seed)\n\
+     let range : (float, float, Seed) => (float, Seed)\n\
+     let fork : (float, Seed) => Seed\n";
+
 pub struct SourceFile {
     pub path: PathBuf,
     /// The module name derived from the file name.
@@ -459,6 +472,17 @@ fn link(mut files: Vec<SourceFile>) -> Result<Project, ProjectError> {
         path: PathBuf::from("<builtin>/Net.fun"),
         module: "Net".to_string(),
         src: NET_MODULE_SRC.to_string(),
+        base,
+    });
+
+    // The built-in `Random` interface module — the abstract `Seed` type and
+    // the signatures that brand the Random builtins (see RANDOM_MODULE_SRC).
+    let base = files.last().map_or(0, |f| f.base + f.src.len() + 1);
+    files.push(SourceFile {
+        interface: true,
+        path: PathBuf::from("<builtin>/Random.funi"),
+        module: "Random".to_string(),
+        src: RANDOM_MODULE_SRC.to_string(),
         base,
     });
 

--- a/functor-lang/src/types.rs
+++ b/functor-lang/src/types.rs
@@ -349,6 +349,9 @@ pub fn builtin_signature(b: Builtin) -> Type {
     fn func(params: Vec<Type>, ret: Type) -> Type {
         Fn(params, Box::new(ret))
     }
+    fn seed() -> Type {
+        Variant("Random.Seed".to_string(), Vec::new())
+    }
     match b {
         // Generic slots are Var(0)/Var(1); every use site instantiates
         // them fresh (B7), so element types genuinely flow through.
@@ -430,10 +433,19 @@ pub fn builtin_signature(b: Builtin) -> Type {
         | Builtin::MathPow => func(vec![Float, Float], Float),
         // Math.pi : Float — a constant, not a function.
         Builtin::MathPi => Float,
-        // Random.step : (Float) => (Float, Float) — (value in [0,1), nextSeed)
-        Builtin::RandomStep => func(vec![Float], Tuple(vec![Float, Float])),
-        // Random.range : (Float, Float, Float) => (Float, Float) — (value in [lo,hi), nextSeed)
-        Builtin::RandomRange => func(vec![Float, Float, Float], Tuple(vec![Float, Float])),
+        // Random.* — seeds are BRANDED: `Random.Seed` is the injected
+        // `Random` interface module's abstract type (see
+        // `crate::project::RANDOM_MODULE_SRC`). These schemes are the
+        // fallback behind those injected signatures (a signature wins at the
+        // External seam) — keep the two in sync.
+        // Random.seed : (Float) => Seed
+        Builtin::RandomSeed => func(vec![Float], seed()),
+        // Random.step : (Seed) => (Float, Seed) — (value in [0,1), nextSeed)
+        Builtin::RandomStep => func(vec![seed()], Tuple(vec![Float, seed()])),
+        // Random.range : (Float, Float, Seed) => (Float, Seed) — (value in [lo,hi), nextSeed)
+        Builtin::RandomRange => func(vec![Float, Float, seed()], Tuple(vec![Float, seed()])),
+        // Subject-LAST. Random.fork : (Float, Seed) => Seed — child stream i
+        Builtin::RandomFork => func(vec![Float, seed()], seed()),
         // Subject-LAST. Debug.log : (String, 'a) => 'a — label first, subject
         // last; logs `label: subject` and returns the subject unchanged (Var(0)
         // is generic, so it's transparent in a pipe).
@@ -1491,19 +1503,20 @@ missing {missing}. Did you forget an argument?"
                 // letrec rule).
                 None => self.globals.get(name).cloned().unwrap_or(Type::Unknown),
             },
-            // An unregistered external is a runtime concern (the module set
-            // may grow); the checker only knows the builtins' signatures.
-            ExprKind::External(path) => match builtin(path) {
-                Some(b) => {
-                    let sig = builtin_signature(b);
-                    let mut vars = Vec::new();
-                    free_vars_of(&sig, &mut vars);
-                    self.instantiate(&Scheme { vars, ty: sig })
-                }
-                // An interface (`.funi`) signature gives a host external a real
-                // type; otherwise it stays the gradual seam (`Unknown`).
-                None => match self.signatures.get(&path.join(".")).cloned() {
-                    Some(scheme) => self.instantiate(&scheme),
+            // An interface (`.funi`) signature is authoritative when present
+            // (the injected `Random` module types its builtins this way);
+            // otherwise a builtin's own scheme applies, and an external
+            // neither declares is the gradual seam (`Unknown` — the module
+            // set may grow at runtime).
+            ExprKind::External(path) => match self.signatures.get(&path.join(".")).cloned() {
+                Some(scheme) => self.instantiate(&scheme),
+                None => match builtin(path) {
+                    Some(b) => {
+                        let sig = builtin_signature(b);
+                        let mut vars = Vec::new();
+                        free_vars_of(&sig, &mut vars);
+                        self.instantiate(&Scheme { vars, ty: sig })
+                    }
                     None => Type::Unknown,
                 },
             },

--- a/functor-lang/tests/check.rs
+++ b/functor-lang/tests/check.rs
@@ -229,12 +229,32 @@ fn math_builtins_check() {
     assert_eq!(message, "argument 2 of `Math.mod`: expected float, got string");
 }
 
-// `Random.step`/`Random.range` are typed builtins: the seed is a float and the
-// result is a `(float, float)` tuple, so a destructuring `let` checks cleanly.
+// `Random.step`/`Random.range` are typed builtins whose seed is the injected
+// `Random` module's abstract `Random.Seed`: made by `Random.seed`/`Random.fork`
+// and threaded back out of `step`/`range` — never a bare number.
 #[test]
 fn random_step_typechecks() {
-    assert_clean("let x = () => let (v, s) = Random.step(1.0) in v + s");
-    assert_clean("let x = () => let (v, s) = Random.range(0.0, 10.0, 1.0) in v + s");
+    assert_clean("let x = () => let (v, s) = Random.step(Random.seed(1.0)) in (v + 1.0, s)");
+    assert_clean(
+        "let x = () => let (v, _) = Random.range(0.0, 10.0, Random.seed(1.0)) in v + 1.0",
+    );
+    // The threaded nextSeed is itself a Seed…
+    assert_clean("let x = () => let (_, s) = Random.step(Random.seed(1.0)) in Random.step(s)");
+    // …and so is a per-entity fork (subject-LAST, so it pipes).
+    assert_clean("let x = (i: float) => Random.seed(9.0) |> Random.fork(i) |> Random.step");
+}
+
+// The brand cuts both ways: a bare number is not a Seed, and a Seed is not a
+// number (the old `baseSeed + i` arithmetic now points at `Random.fork`).
+#[test]
+fn random_seed_is_branded() {
+    let (message, _, _) = single_diag("let x = () => Random.step(1.0)");
+    assert_eq!(
+        message,
+        "argument 1 of `Random.step`: expected Random.Seed, got float"
+    );
+    let (message, _, _) = single_diag("let x = () => Random.seed(1.0) + 1.0");
+    assert_eq!(message, "`+` needs float operands, got Random.Seed");
 }
 
 #[test]
@@ -242,7 +262,7 @@ fn random_step_rejects_non_float_seed() {
     let (message, _, _) = single_diag("let x = () => Random.step(\"s\")");
     assert_eq!(
         message,
-        "argument 1 of `Random.step`: expected float, got string"
+        "argument 1 of `Random.step`: expected Random.Seed, got string"
     );
 }
 

--- a/functor-lang/tests/project.rs
+++ b/functor-lang/tests/project.rs
@@ -787,10 +787,11 @@ let bad = f() + 1.0
 /// lowering (the backward-compatibility pin: bare names, IDs from zero,
 /// spans from zero).
 #[test]
-fn single_file_project_adds_only_the_builtin_net_module() {
-    // A project always includes the built-in `Net` prelude module (so any
-    // game can `match ev with | Net.Connected(id) => …`), so its merged IR
-    // is plain lowering's defs/types PLUS Net's — nothing else changes.
+fn single_file_project_adds_only_the_builtin_modules() {
+    // A project always includes the built-in `Net` and `Random` prelude
+    // modules (so any game can `match ev with | Net.Connected(id) => …` and
+    // seed the PRNG), so its merged IR is plain lowering's defs/types PLUS
+    // theirs — nothing else changes.
     let src = "type Shape = | Circle(radius: float) | Point\n\
                let area = (s: Shape): float =>\n\
                match s with | Circle(r) => 3.14 * r * r | Point => 0.0\n\
@@ -810,16 +811,57 @@ fn single_file_project_adds_only_the_builtin_net_module() {
     for ty in &plain.types {
         assert!(proj_types.contains(&ty.name.as_str()));
     }
-    // The ONLY additions are the Net module's (canonicalized `Net.NetEvent`
-    // and `Net.HttpResponse`).
+    // The ONLY additions are the built-in modules': Net's canonicalized
+    // `Net.NetEvent` / `Net.HttpResponse` and Random's abstract `Random.Seed`.
     assert!(
         proj_types.contains(&"Net.NetEvent") && proj_types.contains(&"Net.HttpResponse"),
         "the built-in Net module must be injected: {proj_types:?}"
     );
+    assert!(
+        proj_types.contains(&"Random.Seed"),
+        "the built-in Random module must be injected: {proj_types:?}"
+    );
     assert_eq!(
         proj_types.len(),
-        plain.types.len() + 2,
-        "no types beyond the entry's + Net.NetEvent + Net.HttpResponse"
+        plain.types.len() + 3,
+        "no types beyond the entry's + Net's two + Random.Seed"
+    );
+}
+
+/// The four `Random.*` builtins are typed from two places that must not
+/// drift: the injected interface module's signatures (project loads — the
+/// authoritative path) and `builtin_signature` (the fallback for bare
+/// single-file checks with no project env). The same correct use must be
+/// clean through both, and the same misuse must produce the SAME diagnostic.
+#[test]
+fn random_signatures_agree_between_interface_and_builtin_fallback() {
+    let ok = "let ok = () =>\n\
+              let (v, s) = Random.step(Random.seed(1.0)) in\n\
+              let (w, s2) = Random.range(0.0, 1.0, s |> Random.fork(2.0)) in\n\
+              (v + w, s2)\n";
+    let bad = "let bad = () => Random.step(1.0)\n";
+
+    // Signature path: a loaded project injects `<builtin>/Random.funi`.
+    let via_project = |name: &str, src: &str| -> Vec<String> {
+        load(name, &[("game.fun", src)])
+            .check()
+            .into_iter()
+            .map(|d| d.message)
+            .collect()
+    };
+    // Builtin-scheme path: bare parse + lower + check, no project env.
+    let via_builtin = |src: &str| -> Vec<String> {
+        let module = functor_lang::lower(functor_lang::parse(src).expect("parses")).expect("lowers");
+        functor_lang::check(&module).into_iter().map(|d| d.message).collect()
+    };
+
+    assert_eq!(via_project("rand-parity-ok", ok), Vec::<String>::new());
+    assert_eq!(via_builtin(ok), Vec::<String>::new());
+    let project_diag = via_project("rand-parity-bad", bad);
+    assert_eq!(project_diag, via_builtin(bad));
+    assert_eq!(
+        project_diag,
+        vec!["argument 1 of `Random.step`: expected Random.Seed, got float".to_string()]
     );
 }
 

--- a/functor-lang/tests/run.rs
+++ b/functor-lang/tests/run.rs
@@ -665,7 +665,7 @@ fn new_builtins_evaluate() {
 #[test]
 fn random_step_is_pure_and_deterministic() {
     let src = "let main = () =>\n  \
-        let (a, s1) = Random.step(42.0) in\n  \
+        let (a, s1) = Random.step(Random.seed(42.0)) in\n  \
         let (b, _) = Random.step(s1) in\n  \
         (a == a, a < 1.0, a == b)";
     // Same seed → same value (a==a), value in [0,1), a fresh draw differs.
@@ -679,8 +679,9 @@ fn random_range_rescales_step_draw() {
     // range(0,10,seed) == step(seed).value * 10 — the rescale relationship,
     // checked deterministically without hardcoding a float.
     let src = "let main = () =>\n  \
-        let (u, _) = Random.step(7.0) in\n  \
-        let (v, _) = Random.range(0.0, 10.0, 7.0) in\n  \
+        let s = Random.seed(7.0) in\n  \
+        let (u, _) = Random.step(s) in\n  \
+        let (v, _) = Random.range(0.0, 10.0, s) in\n  \
         (v == u * 10.0, u < 1.0)";
     assert_eq!(main_result(src), "(true, true)");
 }
@@ -691,13 +692,15 @@ fn random_range_rescales_step_draw() {
 fn random_range_edge_bounds() {
     // lo == hi → exactly lo (lerp lo*(1-u)+lo*u == lo).
     assert_eq!(
-        main_result("let main = () => let (v, _) = Random.range(5.0, 5.0, 1.0) in v == 5.0"),
+        main_result(
+            "let main = () => let (v, _) = Random.range(5.0, 5.0, Random.seed(1.0)) in v == 5.0"
+        ),
         "true",
     );
     // Negative bounds stay inside [-2, -1) — v < hi is the tight guarantee;
     // the loose lower bound just confirms no inf/NaN leak.
     let neg = "let main = () =>\n  \
-        let (v, _) = Random.range(-2.0, -1.0, 3.0) in\n  \
+        let (v, _) = Random.range(-2.0, -1.0, Random.seed(3.0)) in\n  \
         (-2.5 < v, v < -1.0)";
     assert_eq!(main_result(neg), "(true, true)");
 }
@@ -706,6 +709,23 @@ fn random_range_edge_bounds() {
 fn random_step_rejects_non_number() {
     let (message, _, _) = run_err("let main = () => Random.step(\"x\")");
     assert!(message.starts_with("Random.step(seed) expects"));
+}
+
+/// `Random.seed` hashes the float's BITS, so fractional seeds — what the
+/// `Effect.random` seeding idiom delivers, all in [0, 1) — give distinct
+/// streams (the raw counter fold truncates them all to 0), and
+/// `Random.fork(i, seed)` names decorrelated per-entity child streams.
+#[test]
+fn random_seed_and_fork_give_distinct_streams() {
+    let src = "let main = () =>\n  \
+        let (a, _) = Random.step(Random.seed(0.42)) in\n  \
+        let (b, _) = Random.step(Random.seed(0.84)) in\n  \
+        let (c, _) = Random.step(Random.seed(0.0)) in\n  \
+        let s = Random.seed(5.0) in\n  \
+        let (f0, _) = Random.step(Random.fork(0.0, s)) in\n  \
+        let (f1, _) = Random.step(s |> Random.fork(1.0)) in\n  \
+        (a == b, a == c, b == c, f0 == f1)";
+    assert_eq!(main_result(src), "(false, false, false, false)");
 }
 
 /// `Text.fixed(n, decimals)` — the F# `sprintf "%.1f"` shape (HUD text):


### PR DESCRIPTION
## Summary

First slice of the strong-typing track: PRNG seeds become an abstract, branded `Random.Seed` — a bare number where a seed is expected (`Random.step(42.0)`) or seed arithmetic (`seed + 1.0`) is now a **check-time error** with a nominal-type diagnostic (`expected Random.Seed, got float`).

- A built-in `Random` interface module (`<builtin>/Random.funi`, injected in `link()` beside `Net`) declares `type Seed` plus signatures for `seed`/`step`/`range`/`fork`.
- **The brand is check-time only.** At runtime a seed stays a plain number, so seeds remain plain data for time-travel snapshots, hot-reload preservation, and `/state` — the `docs/time-travel.md` "the seed is one more plain-data timeline entry" invariant holds untouched.
- The checker's External seam now prefers a `.funi` signature over a builtin scheme (no overlap existed before; a parity test pins the injected signatures and the fallback schemes together so they can't drift).

## New API

- `Random.seed(n) => Seed` — constructs a seed by hashing the float's **bits**. This fixes a latent bug: the raw counter fold truncates fractional seeds, so every seed in `[0, 1)` — exactly what the documented `Effect.random` seeding idiom delivers — collapsed to counter 0 and produced the identical stream every run.
- `Random.fork(i, seed) => Seed` — decorrelated per-entity child streams (`model.seed |> Random.fork(i)`), the typed replacement for the now-untypeable `baseSeed + i` idiom. The index hash is domain-separated (`mix64(0) == 0`, so the all-zero corner `fork(0.0, seed(0.0))` would otherwise echo the parent — regression-tested).
- `Random.step` / `Random.range` take and return `Seed`s; shapes otherwise unchanged.

## Validation

- `examples/asteroids` migrated off its hand-rolled sin-hash noise onto the branded API (per-rock/per-star forked streams, threaded wave reseeding); typechecks under the full engine prelude via `functor build`, and a headless `--capture-frame` run renders the expected scene. The menu backdrop's exact rock layout differs (new draws from a better PRNG); the visual style is unchanged.
- New tests: brand errors both directions, seed threading/fork typing, fractional-seed spreading, fork zero-corner regression, interface↔builtin signature parity.
- `cargo test -p functor-lang`, `-p functor_runtime_common`, `-p functor-cli` all green.
- Cross-engine adversarial review (Claude + Codex) ran; both findings (fork zero corner, signature-drift risk) addressed and re-validated.

The `functor-lang` skill and `docs/functor-lang.md` are updated in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)