### PR TITLE
feat(assets): load assets from URLs natively, with a verified disk cache

### DIFF
--- a/runtime/functor-runtime-common/src/io/mod.rs
+++ b/runtime/functor-runtime-common/src/io/mod.rs
@@ -54,18 +54,290 @@ pub async fn load_bytes_async(path: &str) -> Result<Vec<u8>, String> {
 pub async fn load_bytes_async2(path: String) -> Result<Vec<u8>, String> {
     #[cfg(target_arch = "wasm32")]
     {
+        // fetch() takes relative paths (bundle-served files) and absolute
+        // http(s) URLs (CDN assets, CORS permitting) alike — no branch needed.
         load_bytes_async(&path)
             .await
             .map_err(|e| format!("{}: {}", path, e))
     }
-    // AssetHandle polls asset futures manually with a noop waker, once per
-    // frame on the render thread. A chunked tokio::fs read only advances one
-    // chunk per poll under that scheme, so large assets took minutes to load
-    // natively (a 47MB glb ≈ thousands of frames). Until assets are driven by
-    // a real executor (see docs/todo.md "async inbox"), read synchronously:
-    // one frame hitch instead of a minutes-long stall.
     #[cfg(not(target_arch = "wasm32"))]
     {
+        // Remote (URL) assets download off-thread through the shell's installed
+        // fetcher and land over a channel — the future stays Pending until the
+        // download completes, so a CDN transfer never stalls the render thread.
+        if is_remote_path(&path) {
+            return remote::fetch(&path).await.map_err(|e| format!("{}: {}", path, e));
+        }
+        // AssetHandle polls asset futures manually with a noop waker, once per
+        // frame on the render thread. A chunked tokio::fs read only advances one
+        // chunk per poll under that scheme, so large assets took minutes to load
+        // natively (a 47MB glb ≈ thousands of frames). Until assets are driven by
+        // a real executor (see docs/todo.md "async inbox"), read synchronously:
+        // one frame hitch instead of a minutes-long stall.
         std::fs::read(&path).map_err(|e| format!("{}: {}", path, e))
+    }
+}
+
+/// True when an asset path names a remote resource (an absolute http/https URL)
+/// rather than a file in the project directory. Mirrors the `://` rule the wasm
+/// bundle-export lint uses to classify a reference as remote.
+pub fn is_remote_path(path: &str) -> bool {
+    path.starts_with("http://") || path.starts_with("https://")
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use remote::{set_remote_fetcher, RemoteFetchResult, RemoteFetchSender};
+
+/// Remote (URL) asset fetching for the native runtime.
+///
+/// The shell installs a fetcher via [`set_remote_fetcher`] (desktop: reqwest on
+/// its tokio runtime); the download itself runs off-thread and lands over a
+/// oneshot channel. Verified bytes go to a disk cache (`~/.functor/cache`,
+/// overridable with `FUNCTOR_ASSET_CACHE`) so a CDN asset downloads once per
+/// machine, not once per run. Cache reads/writes are synchronous on the polling
+/// thread — the same accepted one-frame hitch as local file reads (see the
+/// load_bytes_async2 comment); the network transfer is what must never stall a
+/// frame, and doesn't.
+#[cfg(not(target_arch = "wasm32"))]
+mod remote {
+    use std::{
+        path::{Path, PathBuf},
+        sync::RwLock,
+    };
+
+    pub type RemoteFetchResult = Result<Vec<u8>, String>;
+    pub type RemoteFetchSender = futures::channel::oneshot::Sender<RemoteFetchResult>;
+
+    type Fetcher = Box<dyn Fn(String, RemoteFetchSender) + Send + Sync>;
+
+    static FETCHER: RwLock<Option<Fetcher>> = RwLock::new(None);
+
+    /// Install the host's remote fetcher: called with a URL and a oneshot
+    /// sender, it must (eventually, from any thread) send exactly one result.
+    /// Installing replaces any previous fetcher — each runner entry point
+    /// installs its own, so a later run in the same process never holds a
+    /// handle onto a torn-down runtime.
+    pub fn set_remote_fetcher(f: impl Fn(String, RemoteFetchSender) + Send + Sync + 'static) {
+        *FETCHER.write().unwrap() = Some(Box::new(f));
+    }
+
+    pub async fn fetch(url: &str) -> RemoteFetchResult {
+        if let Some(bytes) = cache_read(url) {
+            // A cached entry that fails the magic check (poisoned by a pre-fix
+            // build, or corrupted) is treated as a miss and refetched.
+            if verify_magic(url, &bytes).is_ok() {
+                log::debug!("remote asset '{}' served from disk cache", url);
+                return Ok(bytes);
+            }
+            log::debug!("remote asset '{}' cache entry invalid; refetching", url);
+        }
+        let (tx, rx) = futures::channel::oneshot::channel();
+        {
+            let fetcher = FETCHER.read().unwrap();
+            let Some(fetcher) = fetcher.as_ref() else {
+                return Err("remote assets are not supported in this host".to_string());
+            };
+            fetcher(url.to_string(), tx);
+        }
+        let bytes = rx
+            .await
+            .map_err(|_| "remote fetch worker disappeared".to_string())??;
+        // Refuse to parse OR cache a body that isn't the format the URL claims
+        // (a CDN "soft 404" — HTTP 200 with an HTML error page — would panic
+        // the glTF pipeline this run and, if cached, on every later run too).
+        verify_magic(url, &bytes)?;
+        cache_write(url, &bytes);
+        Ok(bytes)
+    }
+
+    /// Cheap magic-byte verification for the formats whose URLs we can
+    /// recognize by extension. Unknown extensions pass — this is a poisoning
+    /// guard, not a general validator.
+    fn verify_magic(url: &str, bytes: &[u8]) -> Result<(), String> {
+        let path_part = url.split(['?', '#']).next().unwrap_or(url);
+        let ext = Path::new(path_part)
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("")
+            .to_ascii_lowercase();
+        let ok = match ext.as_str() {
+            "glb" => bytes.starts_with(b"glTF"),
+            // A .gltf is JSON: first non-whitespace byte is '{'.
+            "gltf" => bytes
+                .iter()
+                .find(|b| !b.is_ascii_whitespace())
+                .map(|b| *b == b'{')
+                .unwrap_or(false),
+            "png" => bytes.starts_with(&[0x89, b'P', b'N', b'G']),
+            "jpg" | "jpeg" => bytes.starts_with(&[0xFF, 0xD8]),
+            _ => true,
+        };
+        if ok {
+            Ok(())
+        } else {
+            let head: Vec<u8> = bytes.iter().take(12).copied().collect();
+            Err(format!(
+                "response body is not {} (starts with {:?}) — is the URL an error page?",
+                ext,
+                String::from_utf8_lossy(&head)
+            ))
+        }
+    }
+
+    fn cache_dir() -> Option<PathBuf> {
+        if let Ok(dir) = std::env::var("FUNCTOR_ASSET_CACHE") {
+            if !dir.is_empty() {
+                return Some(PathBuf::from(dir));
+            }
+        }
+        let home = std::env::var("HOME")
+            .or_else(|_| std::env::var("USERPROFILE"))
+            .ok()?;
+        Some(Path::new(&home).join(".functor").join("cache"))
+    }
+
+    /// Cache file for a URL: hex sha256 of the URL itself (we key by locator,
+    /// not content — the content hash isn't known until after the download).
+    fn cache_path(url: &str) -> Option<PathBuf> {
+        use sha2::{Digest, Sha256};
+        let hash = Sha256::digest(url.as_bytes());
+        Some(cache_dir()?.join(format!("{:x}", hash)))
+    }
+
+    fn cache_read(url: &str) -> Option<Vec<u8>> {
+        std::fs::read(cache_path(url)?).ok()
+    }
+
+    /// Best-effort: a cache-write failure must never fail the load. Temp-file +
+    /// rename so a concurrent reader never sees a torn file.
+    fn cache_write(url: &str, bytes: &[u8]) {
+        let Some(path) = cache_path(url) else { return };
+        let Some(dir) = path.parent() else { return };
+        if std::fs::create_dir_all(dir).is_err() {
+            return;
+        }
+        // Per-process temp name: two functor processes fetching the same new
+        // URL must not interleave writes into one shared temp file.
+        let tmp = path.with_extension(format!("part-{}", std::process::id()));
+        if std::fs::write(&tmp, bytes).is_ok() {
+            let _ = std::fs::rename(&tmp, &path);
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use std::{
+            future::Future,
+            pin::Pin,
+            task::{Context, Poll},
+        };
+
+        fn poll_once<T>(fut: &mut Pin<Box<dyn Future<Output = T>>>) -> Poll<T> {
+            let waker = futures::task::noop_waker();
+            let mut cx = Context::from_waker(&waker);
+            fut.as_mut().poll(&mut cx)
+        }
+
+        // glb magic + enough padding that the head-of-body error path (if hit)
+        // is readable.
+        const GLB: &[u8] = b"glTF2000fake-binary-payload";
+
+        /// One test drives the whole flow (install → pending → resolve → disk
+        /// cache hit) because the fetcher is process-global state and the cache
+        /// dir comes from an env var — splitting it would race siblings.
+        #[test]
+        fn fetch_downloads_then_serves_from_disk_cache() {
+            let cache = std::env::temp_dir().join(format!(
+                "functor-remote-cache-test-{}",
+                std::process::id()
+            ));
+            let _ = std::fs::remove_dir_all(&cache);
+            std::env::set_var("FUNCTOR_ASSET_CACHE", &cache);
+
+            // The fetcher stashes the sender instead of answering, so the test
+            // controls exactly when the "download" completes.
+            let stash: std::sync::Arc<std::sync::Mutex<Option<RemoteFetchSender>>> =
+                Default::default();
+            let fetch_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+            {
+                let stash = stash.clone();
+                let fetch_count = fetch_count.clone();
+                set_remote_fetcher(move |_url, tx| {
+                    fetch_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    *stash.lock().unwrap() = Some(tx);
+                });
+            }
+
+            let url = "https://example.test/model.glb";
+            let mut fut: Pin<Box<dyn Future<Output = RemoteFetchResult>>> =
+                Box::pin(fetch(url));
+            // Download in flight: the future parks without blocking.
+            assert!(matches!(poll_once(&mut fut), Poll::Pending));
+            assert!(matches!(poll_once(&mut fut), Poll::Pending));
+
+            let tx = stash.lock().unwrap().take().unwrap();
+            tx.send(Ok(GLB.to_vec())).unwrap();
+            match poll_once(&mut fut) {
+                Poll::Ready(Ok(bytes)) => assert_eq!(bytes, GLB),
+                Poll::Ready(Err(e)) => panic!("expected Ok, got Err({e})"),
+                Poll::Pending => panic!("expected Ready after send"),
+            }
+
+            // Second fetch: served from the disk cache, fetcher not called again.
+            let mut fut2: Pin<Box<dyn Future<Output = RemoteFetchResult>>> =
+                Box::pin(fetch(url));
+            match poll_once(&mut fut2) {
+                Poll::Ready(Ok(bytes)) => assert_eq!(bytes, GLB),
+                _ => panic!("expected cached Ready(Ok(..))"),
+            }
+            assert_eq!(fetch_count.load(std::sync::atomic::Ordering::SeqCst), 1);
+
+            // A body that isn't what the URL claims (CDN soft-404 HTML) is an
+            // error and must NOT be cached.
+            let url2 = "https://example.test/other.glb";
+            let mut fut3: Pin<Box<dyn Future<Output = RemoteFetchResult>>> =
+                Box::pin(fetch(url2));
+            assert!(matches!(poll_once(&mut fut3), Poll::Pending));
+            let tx = stash.lock().unwrap().take().unwrap();
+            tx.send(Ok(b"<html>not found</html>".to_vec())).unwrap();
+            match poll_once(&mut fut3) {
+                Poll::Ready(Err(e)) => assert!(e.contains("not glb"), "error was: {e}"),
+                _ => panic!("expected Ready(Err(..)) for an HTML body"),
+            }
+            // Nothing new cached: only the good asset's entry exists.
+            assert_eq!(std::fs::read_dir(&cache).unwrap().count(), 1);
+
+            let _ = std::fs::remove_dir_all(&cache);
+        }
+
+        #[test]
+        fn magic_verification_by_extension() {
+            assert!(verify_magic("https://x/a.glb", GLB).is_ok());
+            assert!(verify_magic("https://x/a.glb?v=2", GLB).is_ok());
+            assert!(verify_magic("https://x/a.glb", b"<html>").is_err());
+            assert!(verify_magic("https://x/a.gltf", b"  {\"asset\":{}}").is_ok());
+            assert!(verify_magic("https://x/a.gltf", b"<html>").is_err());
+            assert!(verify_magic("https://x/a.png", &[0x89, b'P', b'N', b'G', 1]).is_ok());
+            assert!(verify_magic("https://x/a.png", b"nope").is_err());
+            assert!(verify_magic("https://x/a.jpg", &[0xFF, 0xD8, 0xFF]).is_ok());
+            // Unknown extensions pass through unverified.
+            assert!(verify_magic("https://x/a.bin", b"anything").is_ok());
+            assert!(verify_magic("https://x/noext", b"anything").is_ok());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remote_paths_are_urls_only() {
+        assert!(is_remote_path("https://assets.babylonjs.com/meshes/fish.glb"));
+        assert!(is_remote_path("http://localhost:8080/crate.png"));
+        assert!(!is_remote_path("crate.png"));
+        assert!(!is_remote_path("models/fish.glb"));
+        assert!(!is_remote_path("httpx://not-a-scheme.glb"));
     }
 }

--- a/runtime/functor-runtime-desktop/src/lib.rs
+++ b/runtime/functor-runtime-desktop/src/lib.rs
@@ -35,3 +35,8 @@ mod xreal;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use run::{run, Args};
+
+// The remote-asset fetcher install, re-exported for the end-to-end test in
+// tests/remote_assets.rs (the run loops install it themselves).
+#[cfg(not(target_arch = "wasm32"))]
+pub use net_dispatch::install_remote_asset_fetcher;

--- a/runtime/functor-runtime-desktop/src/net_dispatch.rs
+++ b/runtime/functor-runtime-desktop/src/net_dispatch.rs
@@ -23,6 +23,44 @@ pub enum NetResult {
     },
 }
 
+/// Install the desktop remote-asset fetcher: URL asset paths (`Scene.model` /
+/// `Texture.file` on an http(s) locator) download through this client on tokio
+/// tasks, landing in the asset system's channel-backed future. Must be called
+/// from inside the tokio runtime — the handle is captured here so fetches can
+/// be spawned from whichever thread polls assets.
+pub fn install_remote_asset_fetcher(client: reqwest::Client) {
+    let handle = tokio::runtime::Handle::current();
+    functor_runtime_common::io::set_remote_fetcher(move |url, tx| {
+        let client = client.clone();
+        handle.spawn(async move {
+            let _ = tx.send(fetch_asset_bytes(&client, &url).await);
+        });
+    });
+}
+
+/// GET one remote asset. Mirrors the wasm fetch rule: an HTTP error status is a
+/// FAILED load — the 404 page's body must not reach the glTF/PNG parser — so
+/// the asset system serves the fallback instead.
+async fn fetch_asset_bytes(client: &reqwest::Client, url: &str) -> Result<Vec<u8>, String> {
+    // Generous total timeout: big assets on slow links are legitimate, but a
+    // stalled endpoint must not leave the asset Loading (fallback) forever
+    // with no error event.
+    let resp = client
+        .get(url)
+        .timeout(std::time::Duration::from_secs(300))
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+    let status = resp.status();
+    if !status.is_success() {
+        return Err(format!("HTTP {}", status.as_u16()));
+    }
+    resp.bytes()
+        .await
+        .map(|b| b.to_vec())
+        .map_err(|e| format!("reading body: {e}"))
+}
+
 fn to_method(method: HttpMethod) -> reqwest::Method {
     match method {
         HttpMethod::Get => reqwest::Method::GET,
@@ -121,6 +159,41 @@ mod tests {
             }
             NetResult::Error { message, .. } => panic!("unexpected error: {message}"),
         }
+    }
+
+    /// A server that answers every request with the given status and body.
+    fn spawn_status_server(status: u16, body: &'static str) -> u16 {
+        let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+        let port = server.server_addr().to_ip().unwrap().port();
+        std::thread::spawn(move || {
+            for req in server.incoming_requests() {
+                let _ =
+                    req.respond(tiny_http::Response::from_string(body).with_status_code(status));
+            }
+        });
+        port
+    }
+
+    #[tokio::test]
+    async fn asset_fetch_returns_body_bytes() {
+        let port = spawn_status_server(200, "glb-bytes");
+        let client = reqwest::Client::new();
+        let bytes = fetch_asset_bytes(&client, &format!("http://127.0.0.1:{port}/a.glb"))
+            .await
+            .expect("fetch should succeed");
+        assert_eq!(bytes, b"glb-bytes");
+    }
+
+    #[tokio::test]
+    async fn asset_fetch_fails_on_http_error_status() {
+        // The 404 body must NOT come back as asset bytes (it would be fed to
+        // the glTF parser); an error routes to the fallback asset instead.
+        let port = spawn_status_server(404, "<html>not found</html>");
+        let client = reqwest::Client::new();
+        let err = fetch_asset_bytes(&client, &format!("http://127.0.0.1:{port}/a.glb"))
+            .await
+            .expect_err("404 must fail the load");
+        assert!(err.contains("404"), "error was: {err}");
     }
 
     #[tokio::test]

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -658,6 +658,7 @@ fn run_headless(
     // games is the whole point of a headless runner. Audio is omitted (no device
     // context), but queued audio commands are still drained so they don't pile up.
     let http_client = reqwest::Client::new();
+    net_dispatch::install_remote_asset_fetcher(http_client.clone());
     let (net_tx, net_rx) = std::sync::mpsc::channel::<net_dispatch::NetResult>();
     let (ws_tx, ws_rx) = std::sync::mpsc::channel::<ws_host::HostNetEvent>();
     let mut ws_manager = ws_host::WsManager::new(ws_tx);
@@ -984,6 +985,9 @@ pub fn run(args: Args) {
         // returns over this channel and is pushed back into the game on the main
         // thread, keeping all dylib calls on one thread.
         let http_client = reqwest::Client::new();
+        // Remote (URL) asset paths download through the same client (see
+        // net_dispatch::install_remote_asset_fetcher).
+        net_dispatch::install_remote_asset_fetcher(http_client.clone());
         let (net_tx, net_rx) = std::sync::mpsc::channel::<net_dispatch::NetResult>();
 
         // WebSocket connections. Commands (connect/send/close) are drained each

--- a/runtime/functor-runtime-desktop/tests/remote_assets.rs
+++ b/runtime/functor-runtime-desktop/tests/remote_assets.rs
@@ -1,0 +1,119 @@
+//! End-to-end remote asset loading, natively: a real localhost HTTP server, the
+//! real desktop fetcher (reqwest on tokio), the real byte loader + disk cache,
+//! and the real glTF model pipeline — everything except a GPU (hydration is
+//! lazy, so decoding needs no GL). Hermetic: no external network.
+//!
+//! The wasm side of the same seam (fetch() with a URL) has no in-repo harness
+//! yet — browser e2e is tracked as follow-up in the asset-handling plan.
+
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use functor_runtime_common::asset::{
+    build_pipeline, pipelines::ModelPipeline, AssetCache, AssetPollState,
+};
+
+/// The smallest valid .glb: header + a JSON chunk declaring an empty glTF 2.0
+/// asset. Decodes to a Model with no meshes — the point is that the pipeline
+/// PARSES it (reaching AssetPollState::Loaded), which garbage bytes would not.
+fn minimal_glb() -> Vec<u8> {
+    let mut json = br#"{"asset":{"version":"2.0"}}"#.to_vec();
+    while json.len() % 4 != 0 {
+        json.push(b' ');
+    }
+    let mut out = Vec::new();
+    out.extend_from_slice(b"glTF");
+    out.extend_from_slice(&2u32.to_le_bytes());
+    out.extend_from_slice(&(12 + 8 + json.len() as u32).to_le_bytes());
+    out.extend_from_slice(&(json.len() as u32).to_le_bytes());
+    out.extend_from_slice(b"JSON");
+    out.extend_from_slice(&json);
+    out
+}
+
+/// Serves /model.glb (a valid glb), /poison.glb (HTTP 200 but an HTML body —
+/// the CDN "soft 404"), and 404 for everything else.
+fn spawn_asset_server() -> u16 {
+    let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+    let port = server.server_addr().to_ip().unwrap().port();
+    std::thread::spawn(move || {
+        for req in server.incoming_requests() {
+            let _ = match req.url() {
+                "/model.glb" => req.respond(tiny_http::Response::from_data(minimal_glb())),
+                "/poison.glb" => {
+                    req.respond(tiny_http::Response::from_string("<html>oops</html>"))
+                }
+                _ => req.respond(
+                    tiny_http::Response::from_string("not found").with_status_code(404),
+                ),
+            };
+        }
+    });
+    port
+}
+
+/// Drive an AssetHandle the way the render loop does — repeated manual polls —
+/// until it settles or the deadline passes.
+async fn settle<T>(
+    handle: &functor_runtime_common::asset::AssetHandle<T>,
+) -> AssetPollState<T> {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        match handle.poll_state() {
+            AssetPollState::Loading => {
+                assert!(Instant::now() < deadline, "asset did not settle in 10s");
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+            settled => return settled,
+        }
+    }
+}
+
+/// One test drives all three cases (loads / 404 / poison) because the fetcher
+/// and the FUNCTOR_ASSET_CACHE env var are process-global — parallel test fns
+/// would race them.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn remote_glb_loads_end_to_end() {
+    let cache_dir = std::env::temp_dir().join(format!(
+        "functor-remote-e2e-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&cache_dir);
+    std::env::set_var("FUNCTOR_ASSET_CACHE", &cache_dir);
+
+    let port = spawn_asset_server();
+    functor_runtime_desktop::install_remote_asset_fetcher(reqwest::Client::new());
+
+    let asset_cache = Arc::new(AssetCache::new());
+    let pipeline = build_pipeline(Box::new(ModelPipeline));
+
+    // A real glb over real HTTP decodes to Loaded.
+    let url = format!("http://127.0.0.1:{port}/model.glb");
+    let handle = asset_cache.load_asset_with_pipeline(pipeline.clone(), &url);
+    match settle(&handle).await {
+        AssetPollState::Loaded(_) => {}
+        _ => panic!("expected the remote glb to load"),
+    }
+    // ...and its verified bytes landed in the disk cache.
+    assert_eq!(std::fs::read_dir(&cache_dir).unwrap().count(), 1);
+
+    // A missing asset fails (fallback), it does not hang or panic.
+    let handle = asset_cache.load_asset_with_pipeline(
+        pipeline.clone(),
+        &format!("http://127.0.0.1:{port}/missing.glb"),
+    );
+    assert!(matches!(settle(&handle).await, AssetPollState::Failed));
+
+    // A 200-with-HTML body fails BEFORE the glTF parser (which would panic on
+    // it) and is not cached.
+    let handle = asset_cache.load_asset_with_pipeline(
+        pipeline.clone(),
+        &format!("http://127.0.0.1:{port}/poison.glb"),
+    );
+    assert!(matches!(settle(&handle).await, AssetPollState::Failed));
+    assert_eq!(std::fs::read_dir(&cache_dir).unwrap().count(), 1);
+
+    let _ = std::fs::remove_dir_all(&cache_dir);
+}


### PR DESCRIPTION
## What

`Scene.model("https://assets.babylonjs.com/meshes/ExplodingBarrel.glb")` now works on the **native** runtime — the first clickstop of the asset-handling revamp (remote/CDN assets). The wasm runtime already accepted URLs through `fetch()`; this PR changes zero wasm lines.

- **`functor-runtime-common`**: `is_remote_path` (`http://`/`https://`, mirroring the wasm-export lint's `://` rule); an injectable remote-fetcher seam (`io::set_remote_fetcher`, replace-on-install so a fetcher never outlives its runtime); the download lands over a `futures::oneshot` channel so the future stays `Pending` (fallback renders) until the transfer completes — a CDN download never stalls the render thread.
- **Verified disk cache**: bytes are cached at `~/.functor/cache/<sha256(url)>` (`FUNCTOR_ASSET_CACHE` overrides), so an asset downloads once per machine and later runs are instant. **Magic-byte verification** (glb/gltf/png/jpg) runs before both parsing and caching: a CDN "soft 404" (HTTP 200 with an HTML error body) fails the load — routing to the fallback asset — instead of hitting the glTF pipeline's `.unwrap()`, and can never poison the cache. Cache reads re-verify, so a corrupted/poisoned entry self-heals by refetching.
- **`functor-runtime-desktop`**: installs the fetcher (reqwest on the existing tokio runtime, same pattern as `Effect.http*` dispatch) at both loop entry points; an HTTP error status is a failed load (the wasm rule); 300s request timeout so a stalled endpoint can't leave an asset silently `Loading` forever.

## Verification

- **New e2e test** `runtime/functor-runtime-desktop/tests/remote_assets.rs` — hermetic (localhost `tiny_http`, no GPU, no external network), drives the real fetcher → loader → disk cache → glTF pipeline through the render loop's polling scheme. Cases: a real glb loads to `Loaded` + lands in the cache; a 404 settles to `Failed` (no hang/panic); a soft-404 HTML body fails **before** the parser and is **not** cached.
- Unit tests: URL classification, download→pending→resolve→cache-hit flow, magic verification per extension (`cargo test -p functor_runtime_common`), fetcher status handling (`cargo test -p functor-runtime-desktop`).
- Live: the BabylonJS CDN barrel renders natively with no local asset files (capture below); second run serves from the disk cache. Wasm target checks clean.

## Notes / follow-ups (tracked in the asset-handling plan)

- Sounds don't go through the asset cache natively (rodio decodes from file paths) — URL sounds are a follow-up.
- Cache is append-only (no eviction) and cache I/O is synchronous on the polling thread — the same accepted one-frame tradeoff as local file reads until the async-inbox work lands.
- Wasm browser e2e harness (no `wasm-bindgen-test` infra exists yet) — being investigated separately.

## Demo

![Remote asset streaming demo](https://gist.githubusercontent.com/tommy-xr/963957e4f2376f88b23b3daf3cb3c8d3/raw/remote-asset-demo.gif)

<sub>ExplodingBarrel.glb streamed straight from the BabylonJS CDN by the native runtime — no local asset files; second run serves from `~/.functor/cache`. Rendered headlessly via `--capture-frame` / `--fixed-time`.</sub>

![still](https://gist.githubusercontent.com/tommy-xr/963957e4f2376f88b23b3daf3cb3c8d3/raw/still-t1.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
