### PR TITLE
feat(lang): type input keys as the built-in Key variant

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -189,14 +189,22 @@ let grab = (s) =>
   (they evaluate first); siblings may reference the entry (`Game.foo`) if
   that creates no cycle.
 - **Protected namespaces**: a file whose module name collides with a
-  builtin/prelude namespace (Net, List, Text, Math, Debug, Scene, Anim, Camera,
-  Frame, Light, Fog, Skybox, Angle, Texture, Time, Sub, Effect, Physics,
-  RenderTarget, Ui, AudioSource, AudioScene) is a load error — rename the file.
+  builtin/prelude namespace (Net, Key, Random, List, Text, Math, Debug, Scene,
+  Anim, Camera, Frame, Light, Fog, Skybox, Angle, Texture, Time, Sub, Effect,
+  Physics, RenderTarget, Ui, AudioSource, AudioScene) is a load error —
+  rename the file.
 - **`Net` is a built-in module**, always in scope: `type NetEvent =
   | Connected(id: float) | Message(id: float, text: string) |
   Disconnected(id: float) | Error(id: float, text: string)`. A `Sub.connect`/
   `Sub.listen` tagger receives these — `match ev with | Net.Connected(id)
   => …` — with no declaration needed.
+- **`Key` is a built-in module**: `Key.t`, the variant the `input` hook's
+  `key` parameter carries — `Key.A`..`Key.Z`, `Key.Up`/`Down`/`Left`/`Right`,
+  `Key.Space`/`Enter`/`Escape`, and the digit row as `Key.Num0`..`Key.Num9`
+  (NOT bare digits). Match constructors (`| Key.W =>`) or compare
+  (`key == Key.Enter`); a typo (`Key.Enterr`) is a load-time error — the
+  reason keys stopped being strings. `Random` is likewise built-in (the
+  abstract `Random.Seed` — see the Random builtins above).
 - Constructor names must be unique per MODULE (not per project); values
   from a non-entry module display with their canonical tag
   (`Utils.Circle(2)` in run/trace/`/state` output). The entry's own names
@@ -642,7 +650,9 @@ A runner-hosted game (`functor -d <project-dir> run native`, with
 let init = { … }                       // the initial model (a value)
 let tick = (model, dt, tts) => model'  // per-frame step
 let draw = (model, tts) => Frame.create(camera, scene)
-let input = (model, key, isDown) => model'  // OPTIONAL; key = "W"/"Up"/"Space"/"0".."9"
+let input = (model, key, isDown) => model'  // OPTIONAL; key: Key.t — match
+                                            // | Key.W / Key.Up / Key.Space /
+                                            // Key.Num0..Num9 (never strings)
 let mouseMove = (model, x, y) => model'     // OPTIONAL; window pixels
 let mouseWheel = (model, delta) => model'   // OPTIONAL
 let update = (model, msg) => model'         // OPTIONAL; msgs are ADT variants

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,8 +48,9 @@ Prefix every PR title with a Conventional Commits-style type, optionally followe
 name (contract in the `functor-lang` skill; reference: `examples/hello/game.fun`):
 
 - `init` — the initial model, a plain Functor Lang value
-- `input = (model, key, isDown) => model'` — OPTIONAL; keyboard events, keys as canonical names
-  ("W", "Up", "Space", "0".."9"). `mouseMove`/`mouseWheel` are the analogous optional entry points
+- `input = (model, key, isDown) => model'` — OPTIONAL; keyboard events, keys as the built-in
+  `Key` module's variants (`Key.W`, `Key.Up`, `Key.Space`, `Key.Num0`..`Key.Num9`).
+  `mouseMove`/`mouseWheel` are the analogous optional entry points
 - `tick = (model, dt, tts) => model'` — per-frame simulation step
 - `update = (model, msg) => model'` — OPTIONAL; handles messages (ADT variants) from subscriptions/effects
 - `subscriptions = (model) => Sub.every(...)` — OPTIONAL declarative timers, polled each frame (requires `update`)

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ defines these top-level Functor Lang bindings:
 let init = { … }                        // the initial model (a value)
 let tick = (model, dt, tts) => model'   // per-frame step
 let draw = (model, tts) => Frame.create(camera, scene)
-let input = (model, key, isDown) => model'         // OPTIONAL; key = "W"/"Up"/"Space"
+let input = (model, key, isDown) => model'         // OPTIONAL; key: Key.t (Key.W, Key.Up, …)
 let update = (model, msg) => model'                // OPTIONAL; msgs are ADT variants
 let subscriptions = (model) => Sub.every(Time.seconds(1.0), Beat)  // OPTIONAL timers
 let physics = (model) => Physics.scene(0.0, -9.81, 0.0, [body, …]) // OPTIONAL

--- a/cli/templates/fps/game.fun
+++ b/cli/templates/fps/game.fun
@@ -19,14 +19,14 @@ let init = {
 
 let setHeld = (held, key, isDown) =>
   match key with
-  | "W" => { held with forward: isDown }
-  | "Up" => { held with forward: isDown }
-  | "S" => { held with back: isDown }
-  | "Down" => { held with back: isDown }
-  | "A" => { held with left: isDown }
-  | "Left" => { held with left: isDown }
-  | "D" => { held with right: isDown }
-  | "Right" => { held with right: isDown }
+  | Key.W => { held with forward: isDown }
+  | Key.Up => { held with forward: isDown }
+  | Key.S => { held with back: isDown }
+  | Key.Down => { held with back: isDown }
+  | Key.A => { held with left: isDown }
+  | Key.Left => { held with left: isDown }
+  | Key.D => { held with right: isDown }
+  | Key.Right => { held with right: isDown }
   | _ => held
 
 let input = (model, key, isDown) =>

--- a/docs/functor-lang.md
+++ b/docs/functor-lang.md
@@ -270,6 +270,18 @@ snapshots — no GPU, fully agent-verifiable.
       checker's External seam an interface signature now takes precedence
       over a builtin scheme — the injected `.funi` is what brands the
       builtins.
+- [x] **Typed input keys (`Key.t`)** (2026-07-16; strong-typing track). The
+      `input` hook's `key` parameter is the built-in `Key` module's variant
+      (`<builtin>/Key.fun`, injected beside `Net`): `Key.A`..`Key.Z`,
+      arrows, `Space`/`Enter`/`Escape`, and the digit row as
+      `Key.Num0`..`Key.Num9` — a key typo is a load/check-time error where
+      the old string spelling silently never matched. All three producers
+      (desktop, web, and the shared replay path in `functor_lang_producer`)
+      build the same `Key.*` variant from the raw i32 code, so live input,
+      the time-travel forward-step, and the journal agree; the debug
+      server's wire format (`{"type":"key","key":"w"}`) is unchanged.
+      Key values are plain data (nullary variants), so a key stored in the
+      model snapshots and hot-reloads like any field.
 - [x] **B7. Hindley–Milner inference** (done 2026-07-04; decided 2026-07-02; **after effects
       land** — B6 + the `effect[...]` header checking, so type inference and
       effect rows are designed against each other, not retrofitted). Upgrade
@@ -457,7 +469,8 @@ Starts once A2 + B3 exist.
       rendering.
       - [x] **C4a. Input + CLI wiring.** Optional `input` entry point —
         `(model, key, isDown) => model`, keys as canonical names ("W",
-        "Up") — validated at load when present, reload-aware. And
+        "Up"; since typed as the `Key.t` variant — see the strong-typing
+        track entry) — validated at load when present, reload-aware. And
         `functor.json` grows `"language": "functor-lang"` (+ optional `entry`,
         default `game.fun`): `functor build` = parse+lower+**check as
         errors** (the strict gate; the runner keeps them warnings),

--- a/examples/animation/game.fun
+++ b/examples/animation/game.fun
@@ -25,10 +25,10 @@ let input = (model, key, isDown) =>
   | false => model
   | true =>
     match key with
-    | "1" => { model with target: 0.0, auto: false }
-    | "2" => { model with target: 0.5, auto: false }
-    | "3" => { model with target: 1.0, auto: false }
-    | "0" => { model with auto: true, pointerDrivesHead: false }
+    | Key.Num1 => { model with target: 0.0, auto: false }
+    | Key.Num2 => { model with target: 0.5, auto: false }
+    | Key.Num3 => { model with target: 1.0, auto: false }
+    | Key.Num0 => { model with auto: true, pointerDrivesHead: false }
     | _ => model
 
 // Pointer position (window pixels) -> head aim: the pointer's offset from

--- a/examples/asteroids/game.fun
+++ b/examples/asteroids/game.fun
@@ -196,19 +196,19 @@ let update = (model, msg) =>
 // ---------- input ----------
 let setHeld = (held, key, isDown) =>
   match key with
-  | "Left" => { held with left: isDown }
-  | "A" => { held with left: isDown }
-  | "Right" => { held with right: isDown }
-  | "D" => { held with right: isDown }
-  | "Up" => { held with thrust: isDown }
-  | "W" => { held with thrust: isDown }
+  | Key.Left => { held with left: isDown }
+  | Key.A => { held with left: isDown }
+  | Key.Right => { held with right: isDown }
+  | Key.D => { held with right: isDown }
+  | Key.Up => { held with thrust: isDown }
+  | Key.W => { held with thrust: isDown }
   | _ => held
 
 let startPressed = (key, isDown) =>
-  Lib.and(isDown, Lib.or(key == "Enter", key == "Space"))
+  Lib.and(isDown, Lib.or(key == Key.Enter, key == Key.Space))
 
 let restartPressed = (key, isDown) =>
-  Lib.and(isDown, Lib.or(key == "Enter", key == "R"))
+  Lib.and(isDown, Lib.or(key == Key.Enter, key == Key.R))
 
 // Spawn a bullet at the ship's nose, inheriting the ship's velocity.
 let fire = (model) =>
@@ -226,11 +226,11 @@ let fire = (model) =>
 let inputPlaying = (model, key, isDown) =>
   let m = { model with held: setHeld(model.held, key, isDown) } in
   match key with
-  | "Space" =>
+  | Key.Space =>
     (match isDown with
      | true => (match m.fireHeld with | true => m | false => fire(m))
      | false => { m with fireHeld: false })
-  | "M" => (match isDown with | true => { m with phase: Menu } | false => m)
+  | Key.M => (match isDown with | true => { m with phase: Menu } | false => m)
   | _ => m
 
 let input = (model, key, isDown) =>
@@ -243,7 +243,7 @@ let input = (model, key, isDown) =>
   | _ =>
     (match restartPressed(key, isDown) with
      | true => (model, Effect.random(Seeded))
-     | false => (match Lib.and(key == "M", isDown) with
+     | false => (match Lib.and(key == Key.M, isDown) with
                  | true => { model with phase: Menu }
                  | false => model))
 

--- a/examples/crossfade/game.fun
+++ b/examples/crossfade/game.fun
@@ -42,12 +42,12 @@ let input = (model, key, isDown) =>
   | false => model
   | true =>
     match key with
-    | "0" => { model with auto: true, timer: 2.5 }
-    | "1" => trigger(model, "idle")
-    | "2" => trigger(model, "agree")
-    | "3" => trigger(model, "headShake")
-    | "4" => trigger(model, "sneak_pose")
-    | "5" => trigger(model, "run")
+    | Key.Num0 => { model with auto: true, timer: 2.5 }
+    | Key.Num1 => trigger(model, "idle")
+    | Key.Num2 => trigger(model, "agree")
+    | Key.Num3 => trigger(model, "headShake")
+    | Key.Num4 => trigger(model, "sneak_pose")
+    | Key.Num5 => trigger(model, "run")
     | _ => model
 
 let tick = (model, dt, tts) =>

--- a/examples/glove/game.fun
+++ b/examples/glove/game.fun
@@ -26,12 +26,12 @@ let input = (model, key, isDown) =>
   | false => model
   | true =>
     match key with
-    | "1" => preset(model, 0.0, 0.0, 0.0, 0.0, 0.0)   // open
-    | "2" => preset(model, 1.0, 1.0, 1.0, 1.0, 1.0)   // fist
-    | "3" => preset(model, 0.9, 0.0, 1.0, 1.0, 1.0)   // point
-    | "4" => preset(model, 0.0, 1.0, 1.0, 1.0, 1.0)   // thumbs-up
-    | "5" => preset(model, 0.55, 0.6, 0.0, 0.0, 0.0)  // pinch
-    | "0" => { model with auto: true }
+    | Key.Num1 => preset(model, 0.0, 0.0, 0.0, 0.0, 0.0)   // open
+    | Key.Num2 => preset(model, 1.0, 1.0, 1.0, 1.0, 1.0)   // fist
+    | Key.Num3 => preset(model, 0.9, 0.0, 1.0, 1.0, 1.0)   // point
+    | Key.Num4 => preset(model, 0.0, 1.0, 1.0, 1.0, 1.0)   // thumbs-up
+    | Key.Num5 => preset(model, 0.55, 0.6, 0.0, 0.0, 0.0)  // pinch
+    | Key.Num0 => { model with auto: true }
     | _ => model
 
 // Auto mode: a staggered wave rippling across the fingers.

--- a/examples/hello/game.fun
+++ b/examples/hello/game.fun
@@ -71,14 +71,14 @@ let init = {
 // key-ups flow through here; repeats just re-set the same flag.
 let setHeld = (held, key, isDown) =>
   match key with
-  | "W" => { held with up: isDown }
-  | "Up" => { held with up: isDown }
-  | "S" => { held with down: isDown }
-  | "Down" => { held with down: isDown }
-  | "A" => { held with left: isDown }
-  | "Left" => { held with left: isDown }
-  | "D" => { held with right: isDown }
-  | "Right" => { held with right: isDown }
+  | Key.W => { held with up: isDown }
+  | Key.Up => { held with up: isDown }
+  | Key.S => { held with down: isDown }
+  | Key.Down => { held with down: isDown }
+  | Key.A => { held with left: isDown }
+  | Key.Left => { held with left: isDown }
+  | Key.D => { held with right: isDown }
+  | Key.Right => { held with right: isDown }
   | _ => held
 
 let input = (model, key, isDown) =>

--- a/examples/lighting/game.fun
+++ b/examples/lighting/game.fun
@@ -61,14 +61,14 @@ let init = {
 // key-ups flow through here; repeats just re-set the same flag.
 let setHeld = (held, key, isDown) =>
   match key with
-  | "W" => { held with up: isDown }
-  | "Up" => { held with up: isDown }
-  | "S" => { held with down: isDown }
-  | "Down" => { held with down: isDown }
-  | "A" => { held with left: isDown }
-  | "Left" => { held with left: isDown }
-  | "D" => { held with right: isDown }
-  | "Right" => { held with right: isDown }
+  | Key.W => { held with up: isDown }
+  | Key.Up => { held with up: isDown }
+  | Key.S => { held with down: isDown }
+  | Key.Down => { held with down: isDown }
+  | Key.A => { held with left: isDown }
+  | Key.Left => { held with left: isDown }
+  | Key.D => { held with right: isDown }
+  | Key.Right => { held with right: isDown }
   | _ => held
 
 // Spacebar fires a one-shot sound, with a message delivered when it ends. Only
@@ -104,8 +104,8 @@ let fireBang = (model, isDown) =>
 
 let input = (model, key, isDown) =>
   match key with
-  | "Space" => fireGun(model, isDown)
-  | "B" => fireBang(model, isDown)
+  | Key.Space => fireGun(model, isDown)
+  | Key.B => fireBang(model, isDown)
   | _ => { model with held: setHeld(model.held, key, isDown) }
 
 let clamp = (v, lo, hi) =>

--- a/examples/mario/game.fun
+++ b/examples/mario/game.fun
@@ -90,13 +90,13 @@ let jump = (model, isDown) =>
 
 let input = (model, key, isDown) =>
   match key with
-  | "Left" => { model with leftHeld: isDown }
-  | "A" => { model with leftHeld: isDown }
-  | "Right" => { model with rightHeld: isDown }
-  | "D" => { model with rightHeld: isDown }
-  | "Up" => jump(model, isDown)
-  | "W" => jump(model, isDown)
-  | "Space" => jump(model, isDown)
+  | Key.Left => { model with leftHeld: isDown }
+  | Key.A => { model with leftHeld: isDown }
+  | Key.Right => { model with rightHeld: isDown }
+  | Key.D => { model with rightHeld: isDown }
+  | Key.Up => jump(model, isDown)
+  | Key.W => jump(model, isDown)
+  | Key.Space => jump(model, isDown)
   | _ => model
 
 let tick = (model, dt, tts) =>

--- a/examples/mpclient/game.fun
+++ b/examples/mpclient/game.fun
@@ -65,17 +65,17 @@ let subscriptions = (m: Model) => Sub.connect(serverUrl, toMsg)
 let tick = (m: Model, dt: float, tts: float) => m
 
 // WASD -> a velocity string the server understands; other keys send nothing.
-let velocityFor = (key: string): string =>
+let velocityFor = (key: Key.t): string =>
   match key with
-  | "W" => "0 1"
-  | "S" => "0 -1"
-  | "A" => "-1 0"
-  | "D" => "1 0"
+  | Key.W => "0 1"
+  | Key.S => "0 -1"
+  | Key.A => "-1 0"
+  | Key.D => "1 0"
   | _ => ""
 
 // Key down sends the direction; key release sends a stop. Both need the live
 // connection id, so nothing is sent until the socket has opened.
-let input = (m: Model, key: string, isDown: bool) =>
+let input = (m: Model, key: Key.t, isDown: bool) =>
   match m.conn with
   | Offline => m
   | Online(id) =>

--- a/examples/physics/game.fun
+++ b/examples/physics/game.fun
@@ -83,18 +83,18 @@ let tick = (model, dt, tts) => model
 // is needed; arms mix plain-model and (model, effect) returns freely.
 let input = (model, key, isDown) =>
   match key with
-  | "Space" =>
+  | Key.Space =>
     (match isDown with
      | false => { model with spaceHeld: false }
      | true =>
        (match model.spaceHeld with
         | true => model
         | false => { model with drop: model.drop + 1.0, spaceHeld: true }))
-  | "K" =>
+  | Key.K =>
     (match isDown with
      | true => model
      | false => (model, Physics.applyImpulse("ball", -2.6, 5.0, -0.4)))
-  | "R" =>
+  | Key.R =>
     (match isDown with
      | true => model
      | false =>

--- a/functor-lang/src/project.rs
+++ b/functor-lang/src/project.rs
@@ -44,6 +44,7 @@ use crate::CheckError;
 /// colliding with one is a load-time error.
 const PROTECTED_NAMESPACES: &[&str] = &[
     "Net",
+    "Key",
     "List",
     "Text",
     "Math",
@@ -127,6 +128,21 @@ const RANDOM_MODULE_SRC: &str = "type Seed\n\
      let step : (Seed) => (float, Seed)\n\
      let range : (float, float, Seed) => (float, Seed)\n\
      let fork : (float, Seed) => Seed\n";
+
+/// The built-in `Key` module (injected beside `Net` in [`link`]): the variant
+/// the `input` hook's `key` parameter carries — `Key.W`, `Key.Up`,
+/// `Key.Num0` … — so a key typo is a check-time unknown-constructor error
+/// instead of a silently dead string arm. The shells build matching
+/// `Key.*` values (`functor_runtime_common::Key::ctor_tag`); `Unknown` is
+/// filtered before dispatch and deliberately has no constructor here. Keep in
+/// sync with the `Key` enum in `functor_runtime_common::input` (the digit row
+/// is `Num0`..`Num9` — constructor names must be identifiers).
+const KEY_MODULE_SRC: &str = "type t =\n\
+     | A | B | C | D | E | F | G | H | I | J | K | L | M\n\
+     | N | O | P | Q | R | S | T | U | V | W | X | Y | Z\n\
+     | Up | Down | Left | Right\n\
+     | Space | Enter | Escape\n\
+     | Num0 | Num1 | Num2 | Num3 | Num4 | Num5 | Num6 | Num7 | Num8 | Num9\n";
 
 pub struct SourceFile {
     pub path: PathBuf,
@@ -483,6 +499,17 @@ fn link(mut files: Vec<SourceFile>) -> Result<Project, ProjectError> {
         path: PathBuf::from("<builtin>/Random.funi"),
         module: "Random".to_string(),
         src: RANDOM_MODULE_SRC.to_string(),
+        base,
+    });
+
+    // The built-in `Key` module — the `input` hook's key variant (see
+    // KEY_MODULE_SRC).
+    let base = files.last().map_or(0, |f| f.base + f.src.len() + 1);
+    files.push(SourceFile {
+        interface: false,
+        path: PathBuf::from("<builtin>/Key.fun"),
+        module: "Key".to_string(),
+        src: KEY_MODULE_SRC.to_string(),
         base,
     });
 

--- a/functor-lang/tests/project.rs
+++ b/functor-lang/tests/project.rs
@@ -812,7 +812,8 @@ fn single_file_project_adds_only_the_builtin_modules() {
         assert!(proj_types.contains(&ty.name.as_str()));
     }
     // The ONLY additions are the built-in modules': Net's canonicalized
-    // `Net.NetEvent` / `Net.HttpResponse` and Random's abstract `Random.Seed`.
+    // `Net.NetEvent` / `Net.HttpResponse`, Random's abstract `Random.Seed`,
+    // and the input-key variant `Key.t`.
     assert!(
         proj_types.contains(&"Net.NetEvent") && proj_types.contains(&"Net.HttpResponse"),
         "the built-in Net module must be injected: {proj_types:?}"
@@ -821,10 +822,46 @@ fn single_file_project_adds_only_the_builtin_modules() {
         proj_types.contains(&"Random.Seed"),
         "the built-in Random module must be injected: {proj_types:?}"
     );
+    assert!(
+        proj_types.contains(&"Key.t"),
+        "the built-in Key module must be injected: {proj_types:?}"
+    );
     assert_eq!(
         proj_types.len(),
-        plain.types.len() + 3,
-        "no types beyond the entry's + Net's two + Random.Seed"
+        plain.types.len() + 4,
+        "no types beyond the entry's + Net's two + Random.Seed + Key.t"
+    );
+}
+
+/// The built-in `Key` module: the `input` hook's key variant. Qualified
+/// constructors work in patterns and expressions, keys compare structurally,
+/// and a typo (`Key.Enterr`) is a load-time unknown-member error — the whole
+/// point of retiring the string spelling.
+#[test]
+fn builtin_key_module_is_matchable() {
+    let src = "let dir = (k: Key.t): float =>\n\
+               match k with\n\
+               | Key.Left => 0.0 - 1.0\n\
+               | Key.Right => 1.0\n\
+               | Key.Num0 => 0.5\n\
+               | _ => 0.0\n\
+               let main = () => (dir(Key.Left), dir(Key.Num0), Key.Space == Key.Space)\n";
+    let project = load("key-module", &[("game.fun", src)]);
+    assert!(project.check().is_empty(), "checks clean");
+    let record = functor_lang::run(&project.module, Tracing::Off)
+        .unwrap_or_else(|f| panic!("runs: {}", f.error.message));
+    match record.outcome {
+        RunOutcome::Main(value) => assert_eq!(value.to_string(), "(-1, 0.5, true)"),
+        RunOutcome::Bindings(_) => panic!("expected main's value"),
+    }
+
+    let err = load_err(
+        "key-module-typo",
+        &[("game.fun", "let f = (k) => match k with | Key.Enterr => 1.0 | _ => 0.0\n")],
+    );
+    assert!(
+        err.contains("module `Key` has no constructor `Enterr`"),
+        "a key typo is a load error: {err}"
     );
 }
 

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -5830,7 +5830,12 @@ the new text, got a number"
                 .collect()
         }
         let event = |kind, id: u64, text: &str| net_event_value(kind, id, text).to_functor_lang();
-        let key = |k: &str| Value::String(std::rc::Rc::from(k));
+        // Keys are the built-in `Key` module's variants (`Key.W`), as the
+        // producers deliver them.
+        let key = |k: &str| Value::Variant {
+            ctor: std::rc::Rc::from(format!("Key.{k}").as_str()),
+            args: std::rc::Rc::new(Vec::new()),
+        };
 
         // subscriptions declares an OUTBOUND connection (not a listener).
         let subs = call(&session, "subscriptions", vec![session.global("init").unwrap()]);

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -36,7 +36,7 @@ use crate::functor_lang_prelude::{
     take_http_tagger, take_ui_handlers, DryRunEffects, EffectLog, EffectRunner, EffectTree,
     FunctorHost, NetEventKind, UiHandler,
 };
-use crate::input::{Key, RecordedInput};
+use crate::input::RecordedInput;
 use crate::net::{push_conn_command, ConnCommand, HttpResult};
 use crate::physics::{self, PhysicsEvent, SteppedPhysics};
 use crate::timetravel::SceneRecorder;
@@ -111,7 +111,9 @@ impl Provenance {
             }
             Provenance::Input => {
                 let key = match args.get(1) {
-                    Some(Value::String(s)) => s.to_string(),
+                    // The `Key.*` variant the producers deliver (displays as
+                    // its canonical tag, `Key.W`).
+                    Some(v @ Value::Variant { .. }) => v.to_string(),
                     _ => String::new(),
                 };
                 let dir = match args.get(2) {
@@ -594,16 +596,12 @@ impl FrameCtx<'_> {
     fn replay_input(&mut self, event: RecordedInput, ui_handlers: &[UiHandler]) {
         let (entry, args) = match event {
             RecordedInput::Key { code, is_down } => {
-                let Some(key) = Key::from_i32(code) else {
-                    return;
+                let Some(key_value) = crate::key_input_value(code) else {
+                    return; // unrecognized code / Key::Unknown — dropped, like live.
                 };
                 (
                     "input",
-                    vec![
-                        self.model.clone(),
-                        Value::String(std::rc::Rc::from(key.name().as_str())),
-                        Value::Bool(is_down),
-                    ],
+                    vec![self.model.clone(), key_value, Value::Bool(is_down)],
                 )
             }
             RecordedInput::MouseMove { x, y } => (

--- a/runtime/functor-runtime-common/src/input.rs
+++ b/runtime/functor-runtime-common/src/input.rs
@@ -103,8 +103,10 @@ impl Key {
         Key::ALL.into_iter().find(|k| *k as i32 == value)
     }
 
-    /// The canonical name a game's `input` hook receives: `"W"`, `"Up"`,
-    /// `"Space"` — and bare digits (`"1"`, not `"Num1"`) for the digit row.
+    /// The key's short display name — `"W"`, `"Up"`, `"Space"`, bare digits
+    /// (`"1"`, not `"Num1"`) — for human-facing labels like the web timeline's
+    /// input markers. Games no longer see this: the `input` hook receives the
+    /// built-in `Key` module's variant (see [`Key::ctor_tag`]).
     pub fn name(self) -> String {
         let digit = self as i32 - Key::Num0 as i32;
         if (0..=9).contains(&digit) {
@@ -113,6 +115,31 @@ impl Key {
             format!("{self:?}")
         }
     }
+
+    /// The built-in `Key` module's constructor tag for this key (`"Key.W"`,
+    /// `"Key.Num0"`) — the `Value::Variant` ctor the producers hand a game's
+    /// `input` hook. `None` for `Unknown`, which is never delivered. Keep in
+    /// sync with `KEY_MODULE_SRC` in `functor_lang::project` (guarded by that
+    /// crate's tests and `ctor_tags_cover_the_module` here).
+    pub fn ctor_tag(self) -> Option<String> {
+        match self {
+            Key::Unknown => None,
+            _ => Some(format!("Key.{self:?}")),
+        }
+    }
+}
+
+/// The `Value` a game's `input` hook receives for a raw key code: the built-in
+/// `Key` module's variant (`Key.W`). `None` for an unrecognized code or
+/// `Key::Unknown` — the event is dropped, never delivered. The ONE conversion
+/// every delivery path shares (desktop, web, and the time-travel replay in
+/// `functor_lang_producer`), so live input and replay cannot drift.
+pub fn key_input_value(code: i32) -> Option<functor_lang::Value> {
+    let tag = Key::from_i32(code)?.ctor_tag()?;
+    Some(functor_lang::Value::Variant {
+        ctor: std::rc::Rc::from(tag.as_str()),
+        args: std::rc::Rc::new(Vec::new()),
+    })
 }
 
 #[cfg(test)]
@@ -127,6 +154,45 @@ mod tests {
         // Digits are bare — the name a game's `input` hook matches on.
         assert_eq!(Key::Num0.name(), "0");
         assert_eq!(Key::Num9.name(), "9");
+    }
+
+    #[test]
+    fn ctor_tags_are_canonical() {
+        assert_eq!(Key::W.ctor_tag().as_deref(), Some("Key.W"));
+        assert_eq!(Key::Up.ctor_tag().as_deref(), Some("Key.Up"));
+        // Digits keep the identifier spelling (ctor names can't be bare digits).
+        assert_eq!(Key::Num0.ctor_tag().as_deref(), Some("Key.Num0"));
+        // Unknown is filtered before dispatch — no constructor exists for it.
+        assert_eq!(Key::Unknown.ctor_tag(), None);
+        // Every deliverable key has a tag.
+        for key in Key::ALL.into_iter().skip(1) {
+            assert!(key.ctor_tag().is_some());
+        }
+    }
+
+    /// Drift guard: every deliverable `Key` maps to a constructor the
+    /// built-in `Key` module actually declares, and the module declares
+    /// nothing else — this enum and `KEY_MODULE_SRC` (functor_lang::project)
+    /// must move together.
+    #[test]
+    fn ctor_tags_cover_the_module() {
+        let project = functor_lang::project::load_single_source("game", "let x = 0.0\n")
+            .unwrap_or_else(|e| panic!("empty project loads: {}", e.render()));
+        let key_ty = project
+            .module
+            .types
+            .iter()
+            .find(|t| t.name == "Key.t")
+            .expect("the built-in Key module is injected");
+        let declared: std::collections::BTreeSet<String> = match &key_ty.body {
+            functor_lang::ast::TypeBody::Variants(variants) => {
+                variants.iter().map(|v| v.name.clone()).collect()
+            }
+            _ => panic!("Key.t must be a variant type"),
+        };
+        let expected: std::collections::BTreeSet<String> =
+            Key::ALL.into_iter().filter_map(|k| k.ctor_tag()).collect();
+        assert_eq!(declared, expected, "Key enum and KEY_MODULE_SRC drifted");
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/inspector.rs
+++ b/runtime/functor-runtime-common/src/inspector.rs
@@ -207,7 +207,7 @@ mod tests {
         let tick = (m: Model, dt: Float, tts: Float) =>\n\
           let bumped = m.n + dt in\n\
           { n: bumped }\n\
-        let input = (m: Model, key: String, isDown: Bool) =>\n\
+        let input = (m: Model, key: Key.t, isDown: Bool) =>\n\
           let step = 1.0 in\n\
           { n: m.n + step }\n";
 
@@ -257,7 +257,14 @@ mod tests {
             },
             JournalEntry {
                 entry: "input",
-                args: vec![model.clone(), Value::String(Rc::from("W")), Value::Bool(true)],
+                args: vec![
+                    model.clone(),
+                    Value::Variant {
+                        ctor: Rc::from("Key.W"),
+                        args: Rc::new(Vec::new()),
+                    },
+                    Value::Bool(true),
+                ],
                 provenance: Provenance::Input,
             },
         ];
@@ -306,7 +313,7 @@ mod tests {
         let input = invs.iter().find(|i| i["entry"] == "input").unwrap();
         assert_eq!(input["index"], serde_json::json!(0));
         assert_eq!(input["count"], serde_json::json!(1));
-        assert_eq!(input["provenance"], serde_json::json!("input: W down"));
+        assert_eq!(input["provenance"], serde_json::json!("input: Key.W down"));
         assert!(!input["bindings"].as_array().unwrap().is_empty());
     }
 }

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -786,19 +786,15 @@ impl Game for FunctorLangGame {
 
     fn key_event(&mut self, code: i32, is_down: bool) {
         // The optional `input` entry point: (model, key, isDown) => model.
-        // Keys cross as their canonical names ("W", "Up", "Space") — the same
-        // spelling the debug server and SDK use.
+        // Keys cross as the built-in `Key` module's variants (`Key.W`,
+        // `Key.Up`, `Key.Num0`), so games match constructors, not strings.
         if !self.has_input {
             return;
         }
-        let Some(key) = functor_runtime_common::Key::from_i32(code) else {
-            return;
+        let Some(key_value) = functor_runtime_common::key_input_value(code) else {
+            return; // unrecognized code / Key::Unknown — never delivered.
         };
-        let args = vec![
-            self.model.clone(),
-            Value::String(std::rc::Rc::from(key.name().as_str())),
-            Value::Bool(is_down),
-        ];
+        let args = vec![self.model.clone(), key_value, Value::Bool(is_down)];
         journal_push("input", &args, Provenance::Input);
         match self.session.call("input", args, &mut FunctorHost) {
             Ok(returned) => self.ctx().absorb(returned),
@@ -2226,7 +2222,7 @@ mod tests {
              let tick = (m, dt, tts) => m\n\
              let input = (m, key, isDown) =>\n\
                match key with\n\
-               | \"K\" =>\n\
+               | Key.K =>\n\
                  (match isDown with\n\
                   | true => (m, Physics.applyImpulse(\"ball\", 6.0, 0.0, 0.0))\n\
                   | false => m)\n\
@@ -2347,7 +2343,7 @@ mod tests {
           | Tick => ({ m with ticks: m.ticks + 1.0 }, Effect.now((t) => GotTime(t)))\n\
           | GotTime(t) => { m with lastTime: t }\n\
         let subscriptions = (m: Model) => Sub.every(Time.seconds(1.0), Tick)\n\
-        let input = (m: Model, key: String, isDown: Bool) => { m with ticks: m.ticks + 100.0 }\n\
+        let input = (m: Model, key: Key.t, isDown: Bool) => { m with ticks: m.ticks + 100.0 }\n\
         let tick = (m: Model, dt: Float, tts: Float) => m\n\
         let draw = (m: Model, tts: Float) =>\n\
           Frame.create(Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0), Scene.cube())\n";
@@ -2460,7 +2456,7 @@ mod tests {
             .iter()
             .find(|i| i["entry"] == "input")
             .expect("injected input invocation");
-        assert_eq!(input["provenance"], serde_json::json!("input: W down"));
+        assert_eq!(input["provenance"], serde_json::json!("input: Key.W down"));
         assert_eq!(input["count"], serde_json::json!(1));
         assert!(!input["bindings"].as_array().unwrap().is_empty());
 

--- a/runtime/functor-runtime-web/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-web/src/functor_lang_game.rs
@@ -641,19 +641,15 @@ impl GameProducer for FunctorLangWebGame {
 
     fn key_event(&mut self, code: i32, is_down: bool) {
         // The optional `input` entry point: (model, key, isDown) => model.
-        // Keys cross as their canonical names ("W", "Up", "Space") — the same
-        // spelling the desktop producer and SDK use.
+        // Keys cross as the built-in `Key` module's variants (`Key.W`,
+        // `Key.Up`, `Key.Num0`) — mirrors the desktop producer.
         if !self.has_input {
             return;
         }
-        let Some(key) = functor_runtime_common::Key::from_i32(code) else {
-            return;
+        let Some(key_value) = functor_runtime_common::key_input_value(code) else {
+            return; // unrecognized code / Key::Unknown — never delivered.
         };
-        let args = vec![
-            self.model.clone(),
-            Value::String(std::rc::Rc::from(key.name().as_str())),
-            Value::Bool(is_down),
-        ];
+        let args = vec![self.model.clone(), key_value, Value::Bool(is_down)];
         match self.session.call("input", args, &mut FunctorHost) {
             Ok(returned) => self.ctx().absorb(returned),
             Err(err) => self.reporter.frame_error("input", &err),

--- a/site/docs.html
+++ b/site/docs.html
@@ -121,8 +121,8 @@ let input = (model, key, isDown) =>
   | false => model
   | true =>
     (match key with
-     | "A" => { model with x: model.x - 0.5 }
-     | "D" => { model with x: model.x + 0.5 }
+     | Key.A => { model with x: model.x - 0.5 }
+     | Key.D => { model with x: model.x + 0.5 }
      | _ => model)
 
 let tick = (model, dt, tts) => model

--- a/tools/functor-sdk/test/functor-lang-input.e2e.test.ts
+++ b/tools/functor-sdk/test/functor-lang-input.e2e.test.ts
@@ -7,7 +7,8 @@ import { test } from "node:test";
 import { findRepoRoot, FunctorRunner } from "../src/index.js";
 
 // C4: key events reach the Functor Lang model through the optional `input` entry
-// point — (model, key, isDown) => model, keys as canonical names.
+// point — (model, key, isDown) => model, keys as the built-in `Key` module's
+// variants (Key.Up, Key.W, …).
 const e2eEnabled = process.env.FUNCTOR_E2E === "1";
 const headless = process.env.FUNCTOR_E2E_HEADLESS === "1";
 
@@ -41,12 +42,12 @@ test(
     const model = async () => (await runner.state()).model;
     assert.match(await model(), /presses: 0/, "no input yet");
 
-    // A press+release is two events; the key crosses as its canonical name.
+    // A press+release is two events; the key crosses as its `Key.*` variant.
     await runner.keyDown("up");
     await runner.keyUp("up");
     await runner.step();
     const after = await model();
     assert.match(after, /presses: 2/, `expected two events in: ${after}`);
-    assert.match(after, /last: "Up"/, `expected canonical key name in: ${after}`);
+    assert.match(after, /last: Key.Up/, `expected the Key variant in: ${after}`);
   },
 );


### PR DESCRIPTION
## Summary

Second slice of the strong-typing track (stacked on #364): the `input` hook's `key` parameter is now a real variant instead of a string. A built-in `Key` module (`<builtin>/Key.fun`, injected beside `Net`) declares `type t` with 43 nullary constructors — `Key.A`..`Key.Z`, the arrows, `Key.Space`/`Enter`/`Escape`, and the digit row as `Key.Num0`..`Key.Num9`. A key typo (`Key.Enterr`, or matching a string) is a **load/check-time error** where the old string spelling silently never matched.

## Design

- **One conversion, three consumers.** `key_input_value(code)` in `functor-runtime-common` is the single raw-i32 → `Key.*` variant conversion, shared by the desktop producer, the web producer, and the time-travel replay path — live input, the forward-step replay, and the journal cannot drift. `Key::Unknown` is filtered and deliberately has no constructor.
- **Two drift guards.** `ctor_tags_cover_the_module` pins the Rust `Key` enum against the injected module's constructor set (cross-crate); the existing `from_i32_round_trips` covers the wire codes.
- **Plain data.** Key values are nullary variants, so a key stored in the model snapshots, hot-reloads, and time-travels like any field.
- **Wire formats unchanged.** The debug server still takes `{"type":"key","key":"w"}` and the recorded-input log still stores raw i32 codes; only the game-facing value changed.

## Migration

All examples (hello, mario, lighting, asteroids, physics, animation, glove, crossfade, mpclient), the fps init template, the site's runnable docs example, README, the SDK e2e fixture, and the desktop/inspector test games move from string arms to `Key.*` arms. Journal provenance renders the variant (`input: Key.W down`).

## Validation

- All crates green: `functor-lang`, `functor_runtime_common`, `functor-runtime-desktop`, `functor-cli`; web runtime compiles for `wasm32-unknown-unknown`.
- Every example typechecks via `functor build`.
- Live end-to-end: a headless debug-server session POSTs `key w` down/up and `examples/hello`'s `held.up` flips true/false through the `| Key.W =>` arm.
- Cross-engine adversarial review (Claude + Codex) ran; all findings addressed (desktop/inspector test games, SDK fixture, site example, README, stale `Key::name()` doc, and the conversion centralized) and re-validated.

The `functor-lang` skill, CLAUDE.md, and `docs/functor-lang.md` are updated in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)