### PR TITLE
feat(assets): hot-reload asset files on the desktop runtime

### DIFF
--- a/runtime/functor-runtime-common/src/asset/asset_cache.rs
+++ b/runtime/functor-runtime-common/src/asset/asset_cache.rs
@@ -18,6 +18,19 @@ impl AssetCache {
         }
     }
 
+    /// Every asset path with loaded bytes — the set the asset hot-reload
+    /// watcher stats each frame.
+    pub fn loaded_paths(&self) -> Vec<String> {
+        self.bytes_cache.lock().unwrap().keys().cloned().collect()
+    }
+
+    /// Forget the cached bytes for `path` so the next load re-reads the file
+    /// (asset hot-reload). Pipelines cache decoded handles separately — evict
+    /// there too (`SceneContext::evict_asset` does both).
+    pub fn evict(&self, path: &str) {
+        self.bytes_cache.lock().unwrap().remove(path);
+    }
+
     pub fn load_asset_with_pipeline<T: 'static>(
         self: &Arc<Self>,
         pipeline: Arc<BuiltAssetPipeline<T>>,

--- a/runtime/functor-runtime-common/src/asset/asset_pipeline.rs
+++ b/runtime/functor-runtime-common/src/asset/asset_pipeline.rs
@@ -38,6 +38,14 @@ impl<TRuntimeAsset> BuiltAssetPipeline<TRuntimeAsset> {
             .borrow_mut()
             .insert(asset_name.to_owned(), asset.clone());
     }
+
+    /// Drop the cached handle for `asset_name` so the next lookup rebuilds it
+    /// from (re-read) bytes — asset hot-reload. Scenes still holding the old
+    /// handle keep rendering the old decode until their next draw resolves the
+    /// path again (the very next frame, in practice).
+    pub fn evict(&self, asset_name: &str) {
+        self.asset_cache.borrow_mut().remove(asset_name);
+    }
 }
 
 impl<TRuntimeAsset> AssetPipeline<TRuntimeAsset> for BuiltAssetPipeline<TRuntimeAsset> {

--- a/runtime/functor-runtime-common/src/asset/pipelines/model_pipeline.rs
+++ b/runtime/functor-runtime-common/src/asset/pipelines/model_pipeline.rs
@@ -22,10 +22,20 @@ impl AssetPipeline<Model> for ModelPipeline {
         &self,
         bytes: Vec<u8>,
         _asset_cache: &AssetCache,
-        _context: crate::asset::AssetPipelineContext,
+        context: crate::asset::AssetPipelineContext,
     ) -> Model {
         let cursor = Cursor::new(bytes);
-        let gltf = gltf::Gltf::from_slice(cursor.get_ref()).unwrap();
+        // Unparseable bytes fall back to the empty model, never a panic:
+        // asset hot-reload can catch a file mid-write, and the render thread
+        // polls asset futures (a panic aborts the runtime). The next save
+        // reloads it again.
+        let gltf = match gltf::Gltf::from_slice(cursor.get_ref()) {
+            Ok(gltf) => gltf,
+            Err(e) => {
+                eprintln!("[model] cannot parse glTF: {e}");
+                return self.unloaded_asset(context);
+            }
+        };
         let document = gltf.document;
         let blob = gltf.blob;
 
@@ -386,4 +396,23 @@ fn process_animations(document: &gltf::Document, buffers: &[gltf::buffer::Data])
     }
     // panic!("animations");
     animations
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::asset::AssetPipelineContext;
+
+    // Unparseable bytes must become the empty model, not a panic (asset
+    // hot-reload can catch a .glb mid-write; the render thread polls asset
+    // futures — a panic aborts the runtime).
+    #[test]
+    fn corrupt_glb_falls_back_instead_of_panicking() {
+        let model = ModelPipeline.process(
+            b"<html>not a model</html>".to_vec(),
+            &AssetCache::new(),
+            AssetPipelineContext {},
+        );
+        assert!(model.meshes.is_empty());
+    }
 }

--- a/runtime/functor-runtime-common/src/asset/pipelines/texture_pipeline.rs
+++ b/runtime/functor-runtime-common/src/asset/pipelines/texture_pipeline.rs
@@ -12,18 +12,24 @@ impl AssetPipeline<Texture2D> for TexturePipeline {
         &self,
         bytes: Vec<u8>,
         _asset_cache: &AssetCache,
-        _context: crate::asset::AssetPipelineContext,
+        context: crate::asset::AssetPipelineContext,
     ) -> Texture2D {
-        let guessed_format = image::guess_format(&bytes);
-
-        let format_loader = match guessed_format {
-            Ok(ImageFormat::Png) => PNG,
-            Ok(ImageFormat::Jpeg) => JPEG,
-            // TODO: Replace with placeholder texture
-            _ => panic!("Unhandled format: {:?}", guessed_format),
+        // Unhandled formats and corrupt bytes both fall back to the
+        // checkerboard, never a panic: asset hot-reload can catch a file
+        // mid-write, and the render thread polls asset futures (a panic
+        // aborts the runtime). The next save reloads it again.
+        let decoded = match image::guess_format(&bytes) {
+            Ok(ImageFormat::Png) => PNG.load(&bytes),
+            Ok(ImageFormat::Jpeg) => JPEG.load(&bytes),
+            other => Err(format!("unhandled format: {:?}", other)),
         };
-
-        let texture_data = format_loader.load(&bytes);
+        let texture_data = match decoded {
+            Ok(data) => data,
+            Err(e) => {
+                eprintln!("[texture] cannot decode image: {e}");
+                return self.unloaded_asset(context);
+            }
+        };
         Texture2D::init_from_data(
             texture_data,
             // Default to `wrap: true` so that model textures load correctly
@@ -38,5 +44,30 @@ impl AssetPipeline<Texture2D> for TexturePipeline {
     fn unloaded_asset(&self, _context: crate::asset::AssetPipelineContext) -> Texture2D {
         let texture_data = TextureData::checkerboard_pattern(8, 8, [0, 255, 0, 255]);
         Texture2D::init_from_data(texture_data, TextureOptions::default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::asset::AssetPipelineContext;
+
+    // Corrupt/unknown bytes must become the fallback checkerboard, not a
+    // panic (asset hot-reload can catch a file mid-write; the render thread
+    // polls asset futures — a panic aborts the runtime).
+    #[test]
+    fn corrupt_png_falls_back_instead_of_panicking() {
+        // Valid PNG magic, truncated body.
+        let corrupt = vec![0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 0, 0];
+        let _ = TexturePipeline.process(corrupt, &AssetCache::new(), AssetPipelineContext {});
+    }
+
+    #[test]
+    fn unknown_format_falls_back_instead_of_panicking() {
+        let _ = TexturePipeline.process(
+            b"<html>not an image</html>".to_vec(),
+            &AssetCache::new(),
+            AssetPipelineContext {},
+        );
     }
 }

--- a/runtime/functor-runtime-common/src/scene3d/mod.rs
+++ b/runtime/functor-runtime-common/src/scene3d/mod.rs
@@ -92,6 +92,21 @@ struct CompositeUniforms {
 }
 
 impl SceneContext {
+    /// Drop every cached decode of `path` so the next draw reloads it from
+    /// disk — asset hot-reload (pair with `AssetCache::evict` for the bytes).
+    /// A skybox using the path as a face rebuilds too (its cache key is the
+    /// six face paths joined with '\n'). GPU objects hydrated from the old
+    /// decode are not freed (renderables have no Drop yet) — a dev-loop leak
+    /// bounded by save count, the same class as the render-target TODO above.
+    pub fn evict_asset(&self, path: &str) {
+        self.model_pipeline.evict(path);
+        self.texture_pipeline.evict(path);
+        self.raw_image_pipeline.evict(path);
+        self.skyboxes
+            .borrow_mut()
+            .retain(|faces, _| !faces.split('\n').any(|face| face == path));
+    }
+
     pub fn new() -> SceneContext {
         SceneContext {
             cube: RefCell::new(geometry::Cube::create()),

--- a/runtime/functor-runtime-common/src/texture/texture_format.rs
+++ b/runtime/functor-runtime-common/src/texture/texture_format.rs
@@ -7,7 +7,10 @@ pub enum PixelFormat {
 }
 
 pub trait TextureFormat {
-    fn load(&self, buffer: &std::vec::Vec<u8>) -> TextureData;
+    /// Decode, or explain why not. Corrupt bytes are an Err, never a panic —
+    /// asset hot-reload can catch a file mid-write, and the render thread
+    /// polls asset futures (a panic aborts the runtime).
+    fn load(&self, buffer: &std::vec::Vec<u8>) -> Result<TextureData, String>;
 }
 
 pub struct FormatUsingImageCrate {
@@ -15,18 +18,18 @@ pub struct FormatUsingImageCrate {
 }
 
 impl TextureFormat for FormatUsingImageCrate {
-    fn load(&self, buffer: &std::vec::Vec<u8>) -> TextureData {
+    fn load(&self, buffer: &std::vec::Vec<u8>) -> Result<TextureData, String> {
         let img = image::load_from_memory_with_format(buffer, self.image_format)
-            .expect("Failed to load texture");
+            .map_err(|e| e.to_string())?;
         let mut data = img.to_rgba8().into_raw();
         apply_color_key(&mut data, img.width(), img.height());
 
-        TextureData {
+        Ok(TextureData {
             bytes: data,
             width: img.width(),
             height: img.height(),
             format: PixelFormat::RGBA,
-        }
+        })
     }
 }
 

--- a/runtime/functor-runtime-desktop/src/asset_watch.rs
+++ b/runtime/functor-runtime-desktop/src/asset_watch.rs
@@ -1,0 +1,120 @@
+//! Asset hot-reload: stat every loaded asset file each frame — the same
+//! mtime-polling scheme the Functor Lang project watcher uses for `.fun` files — and
+//! report the ones that changed on disk so the run loop can evict them from
+//! the caches. The next draw then re-reads and re-decodes the file: save a
+//! `.glb`/`.png` in your editor and the running scene updates in ~1 frame.
+
+use std::{collections::HashMap, time::SystemTime};
+
+pub struct AssetWatcher {
+    stamps: HashMap<String, SystemTime>,
+    /// Changed-but-not-yet-stable mtimes. A save is not atomic — reloading on
+    /// the FIRST new mtime reads a half-written file (a torn PNG/glb, which
+    /// must not reach the parsers) — so a change is only reported once the
+    /// mtime holds still across two consecutive polls (i.e. the writer went
+    /// quiet for at least a frame; a long export keeps bumping it and waits).
+    pending: HashMap<String, SystemTime>,
+}
+
+impl AssetWatcher {
+    pub fn new() -> AssetWatcher {
+        AssetWatcher {
+            stamps: HashMap::new(),
+            pending: HashMap::new(),
+        }
+    }
+
+    /// The subset of `loaded` whose file changed on disk since last seen and
+    /// has settled (see `pending`). A path seen for the first time only
+    /// records its stamp (loading it was the freshest read possible — nothing
+    /// to reload). A path that can't be stat'd is left alone: deleted-mid-save
+    /// files come back a moment later, and non-file paths (URLs) never match.
+    pub fn changed(&mut self, loaded: impl IntoIterator<Item = String>) -> Vec<String> {
+        let mut out = Vec::new();
+        for path in loaded {
+            let Ok(mtime) = std::fs::metadata(&path).and_then(|md| md.modified()) else {
+                continue;
+            };
+            match self.stamps.get(&path) {
+                Some(prev) if *prev != mtime => match self.pending.get(&path) {
+                    // Same mtime two polls in a row: the writer is done.
+                    Some(pending) if *pending == mtime => {
+                        self.pending.remove(&path);
+                        self.stamps.insert(path.clone(), mtime);
+                        out.push(path);
+                    }
+                    // First sighting of this mtime (or still being written):
+                    // hold until it stabilizes.
+                    _ => {
+                        self.pending.insert(path, mtime);
+                    }
+                },
+                Some(_) => {
+                    self.pending.remove(&path);
+                }
+                None => {
+                    self.stamps.insert(path, mtime);
+                }
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_file(name: &str, contents: &[u8]) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "functor-asset-watch-{}-{}",
+            std::process::id(),
+            name
+        ));
+        std::fs::write(&path, contents).unwrap();
+        path
+    }
+
+    #[test]
+    fn first_sighting_records_then_change_reports_once() {
+        let file = temp_file("a.png", b"v1");
+        let path = file.to_string_lossy().to_string();
+        let mut watcher = AssetWatcher::new();
+
+        // First sighting: stamp only, no reload.
+        assert!(watcher.changed([path.clone()]).is_empty());
+        // Unchanged: quiet.
+        assert!(watcher.changed([path.clone()]).is_empty());
+
+        // Bump the mtime explicitly (rewriting can land in the same clock tick).
+        let bump = |secs: u64| {
+            let f = std::fs::File::options().write(true).open(&file).unwrap();
+            f.set_modified(SystemTime::now() + std::time::Duration::from_secs(secs))
+                .unwrap();
+        };
+        bump(2);
+
+        // Poll 1 sees the new mtime: held as pending (the writer may still be
+        // mid-save). Poll 2 sees it stable: reported. Poll 3: quiet.
+        assert!(watcher.changed([path.clone()]).is_empty());
+        assert_eq!(watcher.changed([path.clone()]), vec![path.clone()]);
+        assert!(watcher.changed([path.clone()]).is_empty());
+
+        // A write that keeps changing (a slow export) stays held until it
+        // settles.
+        bump(4);
+        assert!(watcher.changed([path.clone()]).is_empty()); // pending @4
+        bump(6);
+        assert!(watcher.changed([path.clone()]).is_empty()); // still moving: pending @6
+        assert_eq!(watcher.changed([path.clone()]), vec![path.clone()]); // settled
+        let _ = std::fs::remove_file(&file);
+    }
+
+    #[test]
+    fn unstattable_paths_are_ignored() {
+        let mut watcher = AssetWatcher::new();
+        let gone = "definitely/not/a/file.glb".to_string();
+        let url = "https://example.test/remote.glb".to_string();
+        assert!(watcher.changed([gone, url]).is_empty());
+    }
+}

--- a/runtime/functor-runtime-desktop/src/lib.rs
+++ b/runtime/functor-runtime-desktop/src/lib.rs
@@ -19,6 +19,8 @@ pub mod functor_lang_game;
 // `cfg(not(wasm32))` target section, so they are gated to native builds. The
 // wasm-visible surface stays exactly `game` + `functor_lang_game` (the producers).
 #[cfg(not(target_arch = "wasm32"))]
+mod asset_watch;
+#[cfg(not(target_arch = "wasm32"))]
 mod audio;
 #[cfg(not(target_arch = "wasm32"))]
 mod debug_server;

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -20,7 +20,9 @@ use glfw::{Action, Key};
 use glow::*;
 
 use crate::game::Game;
-use crate::{audio, debug_server, functor_lang_game, net_dispatch, replay_game, ws_host, xreal};
+use crate::{
+    asset_watch, audio, debug_server, functor_lang_game, net_dispatch, replay_game, ws_host, xreal,
+};
 
 const SCR_WIDTH: u32 = 800;
 const SCR_HEIGHT: u32 = 600;
@@ -957,6 +959,10 @@ pub fn run(args: Args) {
         use glfw::Context;
 
         let asset_cache = Arc::new(AssetCache::new());
+        // Asset hot-reload state: mtime stamps for every loaded asset file
+        // (see the check next to `check_hot_reload` in the frame loop).
+        let mut asset_watcher = asset_watch::AssetWatcher::new();
+        let mut last_asset_poll = Instant::now();
 
         let scene_context = SceneContext::new();
 
@@ -1055,6 +1061,20 @@ pub fn run(args: Args) {
             }
 
             game.check_hot_reload(time.clone());
+
+            // Asset hot-reload, the twin of the .fun check above: a model/
+            // texture saved on disk is evicted from the caches so the next
+            // draw re-reads and re-decodes it. Throttled: unlike the handful
+            // of .fun files, the asset set is unbounded (a stat per asset per
+            // poll), and 4Hz is plenty for a save-and-look loop.
+            if last_asset_poll.elapsed().as_millis() >= 250 {
+                last_asset_poll = Instant::now();
+                for path in asset_watcher.changed(asset_cache.loaded_paths()) {
+                    log::info!("asset '{}' changed on disk; reloading", path);
+                    asset_cache.evict(&path);
+                    scene_context.evict_asset(&path);
+                }
+            }
 
             glfw.poll_events();
             // When time is pinned (`--fixed-time` or the debug server's /time),


### PR DESCRIPTION
## What

Asset hot-reload — the asset twin of `.fun` hot-reload, and probably the highest delight-per-line item in the asset-handling plan: **save a `.glb`/`.png` in your editor and the running scene updates in about a frame**, no restart. (Previously the `AssetCache` was never invalidated: any asset edit meant killing and relaunching the runtime.)

- **`AssetWatcher`** (`functor-runtime-desktop/src/asset_watch.rs`): polls the mtime of every loaded asset file in the frame loop, next to `check_hot_reload`, throttled to 4Hz (unlike the handful of project `.fun` files, the asset set is unbounded — one stat per asset per poll). Paths that can't be stat'd are left alone (deleted-mid-save files come back; URLs never match).
- **Eviction** (`functor-runtime-common`): `AssetCache::evict` (bytes) + `BuiltAssetPipeline::evict` (decoded handles) + `SceneContext::evict_asset` (all three pipelines, plus any skybox whose face list contains the file). The next draw re-resolves the path and re-decodes from disk.

## The torn-write hazard (found by live testing, fixed here)

A save is not atomic. The first live run of this feature read a **half-written PNG** and hit the texture pipeline's pre-existing `panic!("Unhandled format")` — hot-reload makes that panic trivially reachable by every editor. Two-layer fix:

1. **Debounce**: a change is only reported once its mtime holds still across two consecutive polls — a writer mid-save keeps bumping the mtime, so slow exports (Blender writing a big glb) naturally wait until done.
2. **Panic-free decode pipelines**: `TextureFormat::load` returns `Result` now; unhandled/corrupt textures fall back to the checkerboard, unparseable glTF to the empty model, each with a warning — mirroring the raw-image pipeline's existing graceful behavior (which already had tests asserting exactly this). The next save reloads again. Side effect worth noting: a *genuinely* broken checked-in asset now renders as a visible fallback instead of aborting the runtime — a deliberate semantic choice, consistent with "a broken `.fun` edit keeps the old program running."

## Verification

- Live end-to-end (agent-verifiable, no human): run under `--hidden --debug-port`, `POST /capture`, overwrite the texture on disk, `/capture` again — center pixel flips red `(220,40,40)` → blue `(40,80,220)` in the same process. Verified before and after the throttle was added.
- Unit tests: watcher debounce state machine (first-sighting, stable-change-reports-once, slow-export-held-until-settled, unstattable ignored); torn/corrupt bytes fall back without panicking in both pipelines.
- Full suites green: 286 (common) + 46 (desktop lib); wasm target checks clean (the watcher is native-only, `cfg`-gated like the rest of the shell).

## Known limitations (follow-ups in the asset-handling plan)

- GPU objects hydrated from the old decode are not freed (renderables have no `Drop` yet) — a dev-loop leak bounded by save count, same class as the existing render-target TODO.
- An asset that was *missing* at first reference stays failed until restart (its handle caches `Failed` and there's no file to watch) — recovering those needs the failed-path set watched too.
- Sounds don't flow through the asset cache natively (rodio re-decodes per play — one-shots already pick up edits; looping soundscape voices don't).

🤖 Generated with [Claude Code](https://claude.com/claude-code)