### PR TITLE
feat(lang): brand colors as an opaque Color value

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -190,9 +190,9 @@ let grab = (s) =>
   that creates no cycle.
 - **Protected namespaces**: a file whose module name collides with a
   builtin/prelude namespace (Net, Key, Random, List, Text, Math, Debug, Scene,
-  Anim, Camera, Frame, Light, Fog, Skybox, Angle, Texture, Time, Sub, Effect,
-  Physics, RenderTarget, Ui, AudioSource, AudioScene) is a load error —
-  rename the file.
+  Anim, Camera, Frame, Light, Fog, Color, Skybox, Angle, Texture, Time, Sub,
+  Effect, Physics, RenderTarget, Ui, AudioSource, AudioScene) is a load
+  error — rename the file.
 - **`Net` is a built-in module**, always in scope: `type NetEvent =
   | Connected(id: float) | Message(id: float, text: string) |
   Disconnected(id: float) | Error(id: float, text: string)`. A `Sub.connect`/
@@ -383,14 +383,18 @@ Scene.model("shark.glb")                                   // glTF by path, rela
                                                            //   game dir; missing file =
                                                            //   logged error + empty fallback
 Scene.group([scene, …])
-scene |> Scene.color(r, g, b)                              // scene-last: pipes
-scene |> Scene.lit(r, g, b)                                // diffuse+specular
-scene |> Scene.litNormalMapped(r, g, b, normalTex)         // + tangent-space
+Color.rgb(r, g, b)                                         // Color VALUES only (the
+                                                           //   Angle rule): every color
+                                                           //   parameter below takes one —
+                                                           //   never three bare floats
+scene |> Scene.color(color)                                // scene-last: pipes
+scene |> Scene.lit(color)                                  // diffuse+specular
+scene |> Scene.litNormalMapped(color, normalTex)           // + tangent-space
                                                            //   normal map (a
                                                            //   Texture value):
                                                            //   bumps catch the
                                                            //   lights/specular
-scene |> Scene.emissive(r, g, b)                           // unlit glow
+scene |> Scene.emissive(color)                             // unlit glow
 scene |> Scene.translate(x, y, z)
 scene |> Scene.rotateX(angle) / rotateY / rotateZ          // Angle VALUES only:
 Angle.degrees(60.0) / Angle.radians(1.57)                  //   never bare numbers
@@ -454,9 +458,9 @@ anim |> Anim.rotate("jointName", ax, ay, az)               // additive local XYZ
                                                            //   enclosing mask still can)
 Camera.lookAt(ex, ey, ez, tx, ty, tz)                      // up=+Y, fov 45°
 Camera.firstPerson(ex, ey, ez, yaw, pitch, fov)           // all three: Angles
-Light.ambient(r, g, b) / Light.point(px, py, pz, r, g, b, intensity, range)
-Light.directional(dx, dy, dz, r, g, b, intensity) |> Light.castShadows
-Light.spot(px, py, pz, dx, dy, dz, r, g, b, intensity, range, coneAngle)
+Light.ambient(color) / Light.point(px, py, pz, color, intensity, range)
+Light.directional(dx, dy, dz, color, intensity) |> Light.castShadows
+Light.spot(px, py, pz, dx, dy, dz, color, intensity, range, coneAngle)
                                                            // cone from pos
                                                            //   along dir;
                                                            //   coneAngle is an
@@ -485,18 +489,18 @@ scene |> Scene.screen(target)                              // reader: emissive s
                                                            //   is +Z — rotate the monitor
                                                            //   to face the viewer or the
                                                            //   feed shows mirrored
-Fog.linear(near, far, r, g, b)                             // Fog VALUES only (the Angle
-Fog.exp(density, r, g, b)                                  //   rule); near >= 0, far >
+Fog.linear(near, far, color)                               // Fog VALUES only (the Angle
+Fog.exp(density, color)                                    //   rule); near >= 0, far >
                                                            //   near, density > 0 enforced
                                                            //   with teaching errors
 frame |> Frame.withFog(fog)                                // distance fog on all forward
                                                            //   materials incl. emissive;
                                                            //   the fog color is also the
                                                            //   pass's clear color
-frame |> Frame.withClearColor(r, g, b)                     // explicit background clear color
-                                                           //   (r,g,b in 0..1), overriding the
-                                                           //   fog-color default; paints the
-                                                           //   background only, not fog blending
+frame |> Frame.withClearColor(color)                       // explicit background clear color,
+                                                           //   overriding the fog-color
+                                                           //   default; paints the background
+                                                           //   only, not fog blending
 Skybox.files(px, nx, py, ny, pz, nz)                       // Skybox VALUES only: six face
 frame |> Frame.withSkybox(sky)                             //   paths (+X..-Z). Faces are
                                                            //   fetched assets (not checked
@@ -523,7 +527,7 @@ AudioSource.at(key, sound, x, y, z)                        //   / positioned emi
 source |> AudioSource.gain(g)                              // source-last: linear gain (1.0=full)
 AudioScene.create([source, …]) / AudioScene.empty()       // what `soundScape` returns
 
-Ui.text("line") / Ui.textColor(r, g, b, "line")            // HUD text (monospace, 14pt)
+Ui.text("line") / Ui.textColor(color, "line")              // HUD text (monospace, 14pt)
 Ui.column([view, …]) / Ui.row([view, …])                   // stack top-to-bottom / left-to-right
 view |> Ui.panel(Ui.topLeft())                             // pin to a corner (view-LAST: pipes);
 Ui.topLeft() / topRight() / bottomLeft() / bottomRight()   //   Anchor VALUES (the Angle rule)

--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -570,19 +570,28 @@ Ui.textInput(value, tagger)                                // INTERACTIVE contro
                                                            //   `examples/ui` showcases every
                                                            //   widget in one panel
 
+Physics.tag("name")                                        // BRANDED body identity (the
+                                                           //   RenderTarget rule): declare
+                                                           //   once, use the VALUE at every
+                                                           //   site. Check-time only — at
+                                                           //   runtime a tag IS its string
+                                                           //   (plain data; == with event
+                                                           //   tags works). A bare string
+                                                           //   where a tag goes is a check
+                                                           //   error
 Physics.box(w, h, d) / sphere(r) / capsule(halfH, r)       // -> Shape (box = FULL extents)
-Physics.dynamic("tag", shape)                              // simulated body
-Physics.kinematic("tag", shape) / Physics.fixed("tag", shape)
+Physics.dynamic(tag, shape)                                // simulated body
+Physics.kinematic(tag, shape) / Physics.fixed(tag, shape)
 body |> Physics.at(x, y, z)                                // body-last: pipes
 body |> Physics.velocity(vx, vy, vz)
 body |> Physics.mass(m) / Physics.friction(f) / Physics.restitution(r)
 body |> Physics.sensor                                     // overlap-only, no forces
 Physics.scene(gx, gy, gz, [body, …])                       // what `physics` returns
-Physics.position("tag")                                    // {x, y, z} of the LIVE body
-scene |> Physics.transformed("tag")                        // scene at the body's live pose
-Physics.applyImpulse("tag", x, y, z)                       // -> Effect (fire-and-forget)
-Physics.applyForce("tag", x, y, z)                         //   force lasts ONE stepped frame
-Physics.setVelocity("tag", x, y, z) / Physics.teleport("tag", x, y, z)
+Physics.position(tag)                                      // {x, y, z} of the LIVE body
+scene |> Physics.transformed(tag)                          // scene at the body's live pose
+Physics.applyImpulse(tag, x, y, z)                         // -> Effect (fire-and-forget)
+Physics.applyForce(tag, x, y, z)                           //   force lasts ONE stepped frame
+Physics.setVelocity(tag, x, y, z) / Physics.teleport(tag, x, y, z)
 Physics.raycast(ox, oy, oz, dx, dy, dz, maxDist, tagger)   // -> Effect (QUERY): tagger gets
                                                            //   {hit, x, y, z, nx, ny, nz,
                                                            //    distance, tag} — hit: false
@@ -601,7 +610,7 @@ Re-declaring an *unchanged* body leaves the simulation alone; *changing*
 its declared position teleports it (the divergence rule, docs/physics.md).
 
 Physics **command effects** are returned beside the model like any effect
-— `(model, Physics.applyImpulse("ball", 0.0, 5.0, 0.0))` — but carry no
+— `(model, Physics.applyImpulse(ballTag, 0.0, 5.0, 0.0))` — but carry no
 tagger: nothing folds back through `update`; observe outcomes via the
 physics reads. Commands queue at perform time and apply at the next
 stepped frame's first substep, **after reconcile** — so declaring a body
@@ -628,9 +637,10 @@ testable with no world at all.
 
 `Physics.events` is a **Sub** (return it from `subscriptions`, alone or in
 `Sub.batch`; it requires `update`). Every contact begin/end from this
-frame's physics step arrives post-step as `{started: bool, a: Text,
-b: Text, sensor: bool}` — `a`/`b` are the pair's tags in rapier's
-(deterministic) order, so check both; `sensor: true` marks an overlap with
+frame's physics step arrives post-step as `{started: bool, a: Physics.tag,
+b: Physics.tag, sensor: bool}` — `a`/`b` are the pair's tags in rapier's
+(deterministic) order, so check both (compare against your declared tag
+VALUES: `e.a == ballTag` — tags are strings underneath, so `==` works); `sensor: true` marks an overlap with
 a `Physics.sensor` body (no contact forces). Events for a pair whose body
 was despawned this frame are dropped (there is nothing left to name), and
 a frame's undelivered events never carry over.

--- a/cli/templates/3d/game.fun
+++ b/cli/templates/3d/game.fun
@@ -14,18 +14,18 @@ let draw = (model, tts) =>
     Scene.group([
       Scene.plane()
         |> Scene.scale(20.0)
-        |> Scene.lit(0.35, 0.38, 0.42),
+        |> Scene.lit(Color.rgb(0.35, 0.38, 0.42)),
       Scene.cube()
         |> Scene.rotateY(Angle.radians(tts * 0.5))
         |> Scene.translate(0.0, 0.75, 0.0)
-        |> Scene.lit(0.25, 0.65, 1.0),
+        |> Scene.lit(Color.rgb(0.25, 0.65, 1.0)),
       Scene.sphere()
         |> Scene.scale(0.55)
         |> Scene.translate(-2.0, 0.55, 1.0)
-        |> Scene.lit(1.0, 0.35, 0.25),
+        |> Scene.lit(Color.rgb(1.0, 0.35, 0.25)),
     ]),
     [
-      Light.ambient(0.12, 0.12, 0.16),
-      Light.directional(0.5, -1.0, 0.35, 1.0, 0.96, 0.9, 1.0)
+      Light.ambient(Color.rgb(0.12, 0.12, 0.16)),
+      Light.directional(0.5, -1.0, 0.35, Color.rgb(1.0, 0.96, 0.9), 1.0)
         |> Light.castShadows,
     ])

--- a/cli/templates/fps/game.fun
+++ b/cli/templates/fps/game.fun
@@ -62,7 +62,7 @@ let tick = (model, dt, tts) =>
 let target = (x, z, r, g, b) =>
   Scene.cube()
     |> Scene.translate(x, 0.75, z)
-    |> Scene.lit(r, g, b)
+    |> Scene.lit(Color.rgb(r, g, b))
 
 let draw = (model, tts) =>
   Frame.createLit(
@@ -70,14 +70,14 @@ let draw = (model, tts) =>
       model.eye.x, model.eye.y, model.eye.z,
       Angle.radians(model.yaw), Angle.radians(model.pitch), Angle.degrees(70.0)),
     Scene.group([
-      Scene.plane() |> Scene.scale(40.0) |> Scene.lit(0.32, 0.34, 0.38),
+      Scene.plane() |> Scene.scale(40.0) |> Scene.lit(Color.rgb(0.32, 0.34, 0.38)),
       target(-2.5, 2.0, 1.0, 0.3, 0.25),
       target(0.0, 5.0, 0.25, 0.7, 1.0),
       target(3.0, 8.0, 0.75, 0.35, 1.0),
     ]),
     [
-      Light.ambient(0.12, 0.12, 0.16),
-      Light.directional(0.5, -1.0, 0.35, 1.0, 0.96, 0.9, 1.0)
+      Light.ambient(Color.rgb(0.12, 0.12, 0.16)),
+      Light.directional(0.5, -1.0, 0.35, Color.rgb(1.0, 0.96, 0.9), 1.0)
         |> Light.castShadows,
     ])
 

--- a/docs/functor-lang.md
+++ b/docs/functor-lang.md
@@ -282,6 +282,17 @@ snapshots — no GPU, fully agent-verifiable.
       server's wire format (`{"type":"key","key":"w"}`) is unchanged.
       Key values are plain data (nullary variants), so a key stored in the
       model snapshots and hot-reloads like any field.
+- [x] **Branded `Color` values** (2026-07-16; strong-typing track). The Angle
+      rule applied to color: `Color.rgb(r, g, b)` makes an opaque `Color.t`,
+      and every color parameter — `Scene.color`/`lit`/`emissive`/
+      `litNormalMapped`, all four `Light.*` constructors, `Fog.linear`/`exp`,
+      `Frame.withClearColor`, `Ui.textColor` — takes a Color VALUE, never
+      three bare floats, so channel swaps and argument miscounts are
+      unrepresentable. A bare number gets a teaching error ("wrap the
+      channels: Color.rgb(r, g, b)"); the pre-Color three-float spelling
+      gets the new usage line. Colors are first-class: name a palette once
+      (`let neonPink = Color.rgb(…)`) and reuse it across materials, lights,
+      fog, and UI.
 - [x] **B7. Hindley–Milner inference** (done 2026-07-04; decided 2026-07-02; **after effects
       land** — B6 + the `effect[...]` header checking, so type inference and
       effect rows are designed against each other, not retrofitted). Upgrade
@@ -335,7 +346,8 @@ snapshots — no GPU, fully agent-verifiable.
       (`List.map(fn, list)`, `List.fold(fn, init, list)`, `Text.split(sep, s)`,
       `Text.join(sep, list)`, `List.grid(fn, rows, cols)`, and every scene/body/
       frame/target/source transform — `scene |> Scene.color(r,g,b)` now resolves
-      to `Scene.color(r, g, b, scene)`). Pipes and signatures flip together, so
+      to `Scene.color(r, g, b, scene)`; colors have since been branded —
+      see the strong-typing track's `Color` entry). Pipes and signatures flip together, so
       existing piped code is untouched: the visually-rich pipe-heavy examples
       (`lighting`, `synthwave`, `primitives`, `physics`) render **byte-identical**
       before/after (`--fixed-time` PNG `cmp`), and the `functor-lang bench` saturated +
@@ -523,7 +535,7 @@ Starts once A2 + B3 exist.
       - [x] **C4b-4. Fog** (done 2026-07-04): prelude grows the
         distance-fog surface over the engine feature — branded
         `Fog.linear(near, far, r, g, b)` / `Fog.exp(density, r, g, b)`
-        values (degenerate parameters — near < 0, far <= near,
+        (the color channels since branded as a `Color.t`) values (degenerate parameters — near < 0, far <= near,
         density <= 0 — are teaching errors at construction) and
         `Frame.withFog(frame, fog)`. Fog applies to every forward
         material including emissive (fog occludes glow) and drives the

--- a/docs/functor-lang.md
+++ b/docs/functor-lang.md
@@ -293,6 +293,21 @@ snapshots — no GPU, fully agent-verifiable.
       gets the new usage line. Colors are first-class: name a palette once
       (`let neonPink = Color.rgb(…)`) and reuse it across materials, lights,
       fog, and UI.
+- [x] **Branded physics tags (`Physics.tag`)** (2026-07-16; strong-typing
+      track). The RenderTarget rule applied to physics identity:
+      `Physics.tag("name")` makes an abstract `Physics.tag`, and every tag
+      site — `dynamic`/`kinematic`/`fixed` declarations, `position`/
+      `transformed` reads, the four command effects, and the tags inside
+      `rayHit`/`collisionEvent` records — carries the brand, so a bare
+      string is a check-time error. Like `Random.Seed` the brand is erased:
+      at runtime a tag IS its string (identity constructor), so tags stored
+      in the model stay plain data, `/state`/journal display is unchanged,
+      and event-tag equality (`e.a == ballTag`) keeps working structurally.
+      The declare-once idiom (`let ballTag = Physics.tag("ball")`) makes the
+      declaration/read/command sites share one value. Runtime semantics are
+      untouched (reads still error loud on unknown tags; commands still warn
+      quietly, since a body may legitimately despawn with a command in
+      flight — the brand retires the TYPO class at build time instead).
 - [x] **B7. Hindley–Milner inference** (done 2026-07-04; decided 2026-07-02; **after effects
       land** — B6 + the `effect[...]` header checking, so type inference and
       effect rows are designed against each other, not retrofitted). Upgrade

--- a/docs/physics.md
+++ b/docs/physics.md
@@ -136,7 +136,7 @@ let physics = (model) =>                       // OPTIONAL game hook
 
 let draw = (model, tts) =>
   Frame.create(camera,
-    Scene.cube() |> Scene.lit(0.8, 0.5, 0.2) |> Physics.transformed("crate"))
+    Scene.cube() |> Scene.lit(Color.rgb(0.8, 0.5, 0.2)) |> Physics.transformed("crate"))
 ```
 
 Functor Lang dissolves the read-back boundary problem outright: the interpreter runs in

--- a/docs/physics.md
+++ b/docs/physics.md
@@ -128,15 +128,18 @@ commands, subs — but the shipping vocabulary is the Functor Lang prelude
 skill):
 
 ```functor
+let crateTag = Physics.tag("crate")            // branded identity: declared once,
+                                               // the VALUE used at every site
+
 let physics = (model) =>                       // OPTIONAL game hook
   Physics.scene(0.0, -9.81, 0.0, [
-    Physics.fixed("ground", Physics.box(20.0, 0.2, 20.0)),
-    Physics.dynamic("crate", Physics.box(1.0, 1.0, 1.0)) |> Physics.at(0.0, 5.0, 0.0),
+    Physics.fixed(Physics.tag("ground"), Physics.box(20.0, 0.2, 20.0)),
+    Physics.dynamic(crateTag, Physics.box(1.0, 1.0, 1.0)) |> Physics.at(0.0, 5.0, 0.0),
   ])
 
 let draw = (model, tts) =>
   Frame.create(camera,
-    Scene.cube() |> Scene.lit(Color.rgb(0.8, 0.5, 0.2)) |> Physics.transformed("crate"))
+    Scene.cube() |> Scene.lit(Color.rgb(0.8, 0.5, 0.2)) |> Physics.transformed(crateTag))
 ```
 
 Functor Lang dissolves the read-back boundary problem outright: the interpreter runs in
@@ -202,7 +205,8 @@ module PhysicsScene =
 ```
 
 **Commands — plain-data effects.** *Shipped (Phase 3) on the Functor Lang surface as B6
-effect variants* — `Physics.applyImpulse("tag", x, y, z)` etc., returned beside
+effect variants* — `Physics.applyImpulse(tag, x, y, z)` etc. (tags are branded
+`Physics.tag("name")` values), returned beside
 the model; tagger-less (outcomes are observed via the physics reads). Commands
 queue at perform time and apply **after the frame's reconcile, before its first
 substep** (so same-frame declare+command works); `applyForce` lasts exactly one

--- a/e2e/functor-lang-preview-reload.mjs
+++ b/e2e/functor-lang-preview-reload.mjs
@@ -39,7 +39,7 @@ const TICK = `let tick = (model, dt: Float, tts: Float) => { model with spin: mo
 const GREEN_DRAW = `let draw = (model, tts: Float) =>
   Frame.create(
     Camera.lookAt(0.0, 0.0, -6.0, 0.0, 0.0, 0.0),
-    Scene.sphere() |> Scene.emissive(0.1, 1.0, 0.2) |> Scene.scale(2.0))`;
+    Scene.sphere() |> Scene.emissive(Color.rgb(0.1, 1.0, 0.2)) |> Scene.scale(2.0))`;
 
 const V_GREEN = `let init = { spin: 0.0, beat: 0.0 }
 ${TICK}

--- a/e2e/ide-page.mjs
+++ b/e2e/ide-page.mjs
@@ -275,7 +275,7 @@ try {
     await page.evaluate(() => window.__ide.openFile("game.fun"));
     await page.evaluate(
       (src) => window.__ide.setActiveSource(src),
-      `${gameSource}let tinted = (s) => s |> Scene.emissive(0.1, 0.2, Colors.bad)\n`
+      `${gameSource}let tinted = (s) => s |> Scene.emissive(Color.rgb(0.1, 0.2, Colors.bad))\n`
     );
     const flagged = await poll(() => page.locator(".cm-lintRange-error").count(), (n) => n > 0);
     if (flagged > 0) console.log("wrong-typed sibling constant underlines in the entry ✓");

--- a/e2e/ide-project.mjs
+++ b/e2e/ide-project.mjs
@@ -36,7 +36,7 @@ let tick = (model, dt: Float, tts: Float) => { model with t: model.t + dt * Piec
 let draw = (model, tts: Float) =>
   Frame.create(
     Camera.lookAt(0.0, 0.0, -6.0, 0.0, 0.0, 0.0),
-    Scene.sphere() |> Scene.emissive(0.1, 1.0, Pieces.glow) |> Scene.scale(2.0))
+    Scene.sphere() |> Scene.emissive(Color.rgb(0.1, 1.0, Pieces.glow)) |> Scene.scale(2.0))
 `;
 
 const project = (pieces) => [

--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -38,7 +38,7 @@ let tick = (model, dt: Float, tts: Float) => { model with t: model.t + dt }
 let draw = (model, tts: Float) =>
   Frame.create(
     Camera.lookAt(0.0, 0.0, -6.0, 0.0, 0.0, 0.0),
-    Scene.sphere() |> Scene.emissive(0.1, 1.0, 0.2) |> Scene.scale(2.0))
+    Scene.sphere() |> Scene.emissive(Color.rgb(0.1, 1.0, 0.2)) |> Scene.scale(2.0))
 `;
 const BROKEN = "let init = {\n";
 
@@ -50,7 +50,7 @@ let tick = (model, dt: Float, tts: Float) => { model with spin: model.spin + dt 
 let draw = (model, tts: Float) =>
   Frame.create(
     Camera.lookAt(0.0, 0.0, -6.0, 0.0, 0.0, 0.0),
-    Scene.cube() |> Scene.rotateY(Angle.radians(model.spin)) |> Scene.emissive(1.0, 0.2, 0.8))
+    Scene.cube() |> Scene.rotateY(Angle.radians(model.spin)) |> Scene.emissive(Color.rgb(1.0, 0.2, 0.8)))
 `;
 
 // A model that deliberately retains a module-bound closure. Its old snapshots
@@ -62,7 +62,7 @@ let tick = (model, dt: Float, tts: Float) => { model with t: model.t + dt }
 let draw = (model, tts: Float) =>
   Frame.create(
     Camera.lookAt(0.0, 0.0, -6.0, 0.0, 0.0, 0.0),
-    Scene.cube() |> Scene.rotateY(Angle.radians(model.t)) |> Scene.emissive(0.2, 0.8, 1.0))
+    Scene.cube() |> Scene.rotateY(Angle.radians(model.t)) |> Scene.emissive(Color.rgb(0.2, 0.8, 1.0)))
 `;
 
 // A float-model program for the language-intelligence checks: every top-level
@@ -77,7 +77,7 @@ let tick = (model, dt: Float, tts: Float) => model + dt
 let draw = (model, tts: Float) =>
   Frame.create(
     Camera.lookAt(0.0, 0.0, -6.0, 0.0, 0.0, 0.0),
-    Scene.sphere() |> Scene.emissive(0.1, 1.0, 0.2)
+    Scene.sphere() |> Scene.emissive(Color.rgb(0.1, 1.0, 0.2))
       |> Scene.rotateY(Angle.radians(model)) |> Scene.scale(speed))
 `;
 
@@ -242,8 +242,8 @@ const playerFrame = (page) => {
   // A green edit: recolor the dots' emissive to pure green. The scene must
   // hot-swap with the model preserved (the wave keeps rolling) — no reload.
   const greenRegion = region.replace(
-    /Scene\.emissive\([^)]*\)/,
-    "Scene.emissive(0.1, 1.0, 0.2)"
+    /Scene\.emissive\(Color\.rgb\([^)]*\)\)/,
+    "Scene.emissive(Color.rgb(0.1, 1.0, 0.2))"
   );
   await page.evaluate((s) => window.__hero.setRegion(s), greenRegion);
   await page.waitForFunction(

--- a/examples/animation/game.fun
+++ b/examples/animation/game.fun
@@ -88,7 +88,7 @@ let draw = (model, tts) =>
   Frame.createLit(
     Camera.lookAt(0.0, 1.4, -3.2, 0.0, 0.9, 0.0),
     Scene.group([
-      Scene.plane() |> Scene.scale(10.0) |> Scene.lit(0.42, 0.47, 0.55),
+      Scene.plane() |> Scene.scale(10.0) |> Scene.lit(Color.rgb(0.42, 0.47, 0.55)),
       // Xbot stands ~1.8 units tall, Y-up, at authored scale; glTF forward
       // is +Z, so turn it to face the camera.
       Scene.model("Xbot.glb")
@@ -96,8 +96,8 @@ let draw = (model, tts) =>
         |> Scene.rotateY(Angle.degrees(180.0)),
     ]),
     [
-      Light.ambient(0.25, 0.25, 0.3),
-      Light.directional(-0.5, -1.0, 0.4, 1.0, 0.96, 0.88, 1.0) |> Light.castShadows,
+      Light.ambient(Color.rgb(0.25, 0.25, 0.3)),
+      Light.directional(-0.5, -1.0, 0.4, Color.rgb(1.0, 0.96, 0.88), 1.0) |> Light.castShadows,
     ])
 
 let ui = (model) =>

--- a/examples/asteroids/game.fun
+++ b/examples/asteroids/game.fun
@@ -345,7 +345,7 @@ let starfield = () =>
     let glow = 0.45 + glow01 * 0.55 in
     Scene.plane()
       |> Scene.scale(0.14 + size01 * 0.14)
-      |> Scene.emissive(glow, glow, glow * 1.08)
+      |> Scene.emissive(Color.rgb(glow, glow, glow * 1.08))
       |> Scene.translate((x01 * 2.0 - 1.0) * (worldX + 8.0),
                          0.0 - 4.0,
                          (z01 * 2.0 - 1.0) * (worldZ + 8.0)))
@@ -362,13 +362,13 @@ let rockScene = (a, tts) =>
                       r * (0.75 + w2 * 0.5),
                       r * (0.75 + w3 * 0.5))
     |> Scene.rotateY(Angle.radians(tts * a.spin))
-    |> Scene.lit(0.62, 0.55, 0.47)
+    |> Scene.lit(Color.rgb(0.62, 0.55, 0.47))
     |> Scene.translate(a.x, 0.0, a.z)
 
 let bulletScene = (b) =>
   Scene.sphere()
     |> Scene.scale(0.14)
-    |> Scene.emissive(1.0, 0.9, 0.3)
+    |> Scene.emissive(Color.rgb(1.0, 0.9, 0.3))
     |> Scene.translate(b.x, 0.0, b.z)
 
 // The ship: Kenney's craft_racer (CC0, see ASSETS.md; fetched, not checked
@@ -380,7 +380,7 @@ let shipBody = (thrusting) =>
      | true => [Scene.cube()
                   |> Scene.scaleXYZ(0.16, 0.16, 0.6)
                   |> Scene.translate(0.0, 0.0, 0.0 - 0.85)
-                  |> Scene.emissive(1.0, 0.55, 0.1)]
+                  |> Scene.emissive(Color.rgb(1.0, 0.55, 0.1))]
      | false => []) in
   Scene.group(Lib.append([
     // Kenney crafts model nose-toward--Z; flip to face our +Z forward.
@@ -411,7 +411,7 @@ let pressEnter = (tts, z) =>
   | true => [Font.word(0.3, 0.0, z,
                [Font.gP, Font.gR, Font.gE, Font.gS, Font.gS, Font.gSpace,
                 Font.gE, Font.gN, Font.gT, Font.gE, Font.gR])
-               |> Scene.emissive(0.92, 0.92, 0.92)]
+               |> Scene.emissive(Color.rgb(0.92, 0.92, 0.92))]
   | false => []
 
 // Titles float at y=2.5, above the rock plane, so a drifting rock passes
@@ -423,17 +423,17 @@ let titleScenes = (model, tts) =>
      | Menu =>
        [Font.word(0.72, 0.0, 0.0 - 6.0,
           [Font.gA, Font.gS, Font.gT, Font.gE, Font.gR, Font.gO, Font.gI, Font.gD, Font.gS])
-          |> Scene.emissive(0.55, 1.0, 0.65),
+          |> Scene.emissive(Color.rgb(0.55, 1.0, 0.65)),
         ..pressEnter(tts, 0.0 - 1.5)]
      | Won =>
        [Font.word(0.55, 0.0, 0.0 - 5.0,
           [Font.gY, Font.gO, Font.gU, Font.gSpace, Font.gW, Font.gI, Font.gN])
-          |> Scene.emissive(0.55, 1.0, 0.65),
+          |> Scene.emissive(Color.rgb(0.55, 1.0, 0.65)),
         ..pressEnter(tts, 0.0 - 1.5)]
      | Lost =>
        [Font.word(0.55, 0.0, 0.0 - 5.0,
           [Font.gG, Font.gA, Font.gM, Font.gE, Font.gSpace, Font.gO, Font.gV, Font.gE, Font.gR])
-          |> Scene.emissive(1.0, 0.45, 0.35),
+          |> Scene.emissive(Color.rgb(1.0, 0.45, 0.35)),
         ..pressEnter(tts, 0.0 - 1.5)]) in
   screens |> List.map((s) => s |> Scene.translate(0.0, 2.5, 0.0))
 
@@ -450,12 +450,12 @@ let draw = (model, tts) =>
     Scene.group([Scene.group(starfield()), Scene.group(rocks),
                  Scene.group(bullets), Scene.group(ship),
                  Scene.group(titleScenes(model, tts))]),
-    [Light.ambient(0.3, 0.3, 0.38),
-     Light.directional(-0.45, -1.0, -0.3, 1.0, 0.97, 0.9, 1.1)])
+    [Light.ambient(Color.rgb(0.3, 0.3, 0.38)),
+     Light.directional(-0.45, -1.0, -0.3, Color.rgb(1.0, 0.97, 0.9), 1.1)])
     // Distance fog starting past the whole scene: nothing in play is
     // fogged, but the pass's clear color becomes deep space (there is no
     // Frame.clearColor — see the findings log).
-    |> Frame.withFog(Fog.linear(80.0, 160.0, 0.01, 0.012, 0.035))
+    |> Frame.withFog(Fog.linear(80.0, 160.0, Color.rgb(0.01, 0.012, 0.035)))
 
 // ---------- sound ----------
 // One-shots (laser/explosions) fire as Effects above; the thrust loop is
@@ -474,7 +474,7 @@ let f0 = (n) => Text.fixed(n, 0.0)
 
 let hudUi = (model) =>
   Ui.column([
-    Ui.textColor(1.0, 0.9, 0.3, Text.concat("SCORE  ", f0(model.score))),
+    Ui.textColor(Color.rgb(1.0, 0.9, 0.3), Text.concat("SCORE  ", f0(model.score))),
     Ui.text(Text.concat("LIVES  ", f0(model.lives))),
     Ui.text(Text.concat("WAVE   ", Text.concat(f0(model.wave), Text.concat(" / ", f0(finalWave))))),
   ]) |> Ui.panel(Ui.topLeft())
@@ -491,7 +491,7 @@ let menuUi = (model) =>
 
 let endUi = (title, model) =>
   Ui.column([
-    Ui.textColor(1.0, 0.5, 0.4, title),
+    Ui.textColor(Color.rgb(1.0, 0.5, 0.4), title),
     Ui.text(Text.concat("Final score  ", f0(model.score))),
     Ui.text(""),
     Ui.text("R or Enter to play again, M for menu"),

--- a/examples/atmosphere/game.fun
+++ b/examples/atmosphere/game.fun
@@ -11,7 +11,7 @@
 // The skybox faces are not checked in — run `npm run fetch:assets` first.
 // While they load, the fog color shows in place of the sky.
 
-let fog = Fog.linear(6.0, 26.0, 0.93, 0.95, 0.96)
+let fog = Fog.linear(6.0, 26.0, Color.rgb(0.93, 0.95, 0.96))
 
 let sky = Skybox.files(
   "TropicalSunnyDay_px.jpg", "TropicalSunnyDay_nx.jpg",
@@ -21,19 +21,19 @@ let sky = Skybox.files(
 // One pillar at depth i (world z = i * 3), staggered left/right.
 let pillar = (i: float) =>
   Scene.cube()
-    |> Scene.lit(0.75, 0.55, 0.4)
+    |> Scene.lit(Color.rgb(0.75, 0.55, 0.4))
     |> Scene.translate(Math.sin(i * 1.7) * 4.0, 0.5, i * 3.0)
 
 // An emissive glow weaving through the colonnade.
 let drifter = (tts: float) =>
   Scene.sphere()
     |> Scene.scale(0.5)
-    |> Scene.emissive(1.0, 0.6, 0.2)
+    |> Scene.emissive(Color.rgb(1.0, 0.6, 0.2))
     |> Scene.translate(Math.cos(tts * 0.6) * 3.0, 1.4, 8.0 + Math.sin(tts * 0.6) * 7.0)
 
 let lights = () => [
-  Light.ambient(0.16, 0.17, 0.2),
-  Light.directional(0.4, -1.0, 0.3, 1.0, 0.96, 0.88, 0.85) |> Light.castShadows,
+  Light.ambient(Color.rgb(0.16, 0.17, 0.2)),
+  Light.directional(0.4, -1.0, 0.3, Color.rgb(1.0, 0.96, 0.88), 0.85) |> Light.castShadows,
 ]
 
 let init = {}
@@ -43,7 +43,7 @@ let draw = (m, tts: float) =>
   Frame.createLit(
     Camera.lookAt(0.0, 2.4, -6.0, 0.0, 1.0, 8.0),
     Scene.group([
-      Scene.plane() |> Scene.scale(70.0) |> Scene.lit(0.5, 0.55, 0.52),
+      Scene.plane() |> Scene.scale(70.0) |> Scene.lit(Color.rgb(0.5, 0.55, 0.52)),
       Scene.group([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0] |> List.map(pillar)),
       drifter(tts),
     ]),

--- a/examples/counter/game.fun
+++ b/examples/counter/game.fun
@@ -22,11 +22,11 @@ let draw = (m: Model, tts) =>
   Frame.createLit(
     Camera.lookAt(0.0, 1.5, -4.0, 0.0, 0.0, 0.0),
     Scene.cube()
-      |> Scene.lit(0.3, 0.65, 0.9)
+      |> Scene.lit(Color.rgb(0.3, 0.65, 0.9))
       |> Scene.rotateY(Angle.degrees(m.count * 15.0)),
     [
-      Light.ambient(0.25, 0.25, 0.25),
-      Light.directional(-0.5, -1.0, 0.4, 1.0, 1.0, 1.0, 0.9),
+      Light.ambient(Color.rgb(0.25, 0.25, 0.25)),
+      Light.directional(-0.5, -1.0, 0.4, Color.rgb(1.0, 1.0, 1.0), 0.9),
     ],
   )
 

--- a/examples/crossfade/game.fun
+++ b/examples/crossfade/game.fun
@@ -81,14 +81,14 @@ let draw = (model, tts) =>
   Frame.createLit(
     Camera.lookAt(0.0, 1.5, -4.4, 0.0, 0.9, 0.0),
     Scene.group([
-      Scene.plane() |> Scene.scale(12.0) |> Scene.lit(0.42, 0.47, 0.55),
+      Scene.plane() |> Scene.scale(12.0) |> Scene.lit(Color.rgb(0.42, 0.47, 0.55)),
       // Camera looks down +Z, so world +X is screen LEFT.
       figure(Anim.clip(model.anim.current, tts - model.anim.since), 1.2),
       figure(Animator.pose(model.anim, 0.5, tts), -1.2),
     ]),
     [
-      Light.ambient(0.25, 0.25, 0.3),
-      Light.directional(-0.5, -1.0, 0.4, 1.0, 0.96, 0.88, 1.0) |> Light.castShadows,
+      Light.ambient(Color.rgb(0.25, 0.25, 0.3)),
+      Light.directional(-0.5, -1.0, 0.4, Color.rgb(1.0, 0.96, 0.88), 1.0) |> Light.castShadows,
     ])
 
 let ui = (model) =>

--- a/examples/glove/game.fun
+++ b/examples/glove/game.fun
@@ -95,7 +95,7 @@ let draw = (model, tts) =>
     Camera.lookAt(0.0, 0.25, -0.65, 0.0, 0.1, 0.0),
     Scene.group([
       Scene.plane() |> Scene.scale(6.0) |> Scene.translate(0.0, -0.25, 0.0)
-        |> Scene.lit(0.42, 0.47, 0.55),
+        |> Scene.lit(Color.rgb(0.42, 0.47, 0.55)),
       // The glove renders at its authored size (~0.2 units — a real hand):
       // authored palm-down with the fingers along +Z, so tip it up to show
       // the back of the hand (and the finger curls) to the camera.
@@ -104,8 +104,8 @@ let draw = (model, tts) =>
         |> Scene.rotateX(Angle.degrees(-70.0)),
     ]),
     [
-      Light.ambient(0.45, 0.45, 0.5),
-      Light.directional(-0.4, -0.8, 0.6, 1.0, 0.96, 0.9, 1.1) |> Light.castShadows,
+      Light.ambient(Color.rgb(0.45, 0.45, 0.5)),
+      Light.directional(-0.4, -0.8, 0.6, Color.rgb(1.0, 0.96, 0.9), 1.1) |> Light.castShadows,
     ])
 
 let ui = (model) =>

--- a/examples/hello-cubes/pieces.fun
+++ b/examples/hello-cubes/pieces.fun
@@ -9,7 +9,7 @@ let tau = 6.2831853
 // One gradient cube on the ring at index `i`, given the current `spin`.
 let ringCube = (spin: float, i: float) =>
   Scene.cube()
-    |> Scene.color(0.25 + 0.75 * (i / count), 0.35, 0.95 - 0.65 * (i / count))
+    |> Scene.color(Color.rgb(0.25 + 0.75 * (i / count), 0.35, 0.95 - 0.65 * (i / count)))
     |> Scene.rotateY(Angle.radians(i * 0.7 + spin * 2.0))
     |> Scene.translate(4.0, Math.sin(i + spin * 3.0) * 0.6, 0.0)
     |> Scene.rotateY(Angle.radians(i * tau / count + spin))
@@ -17,5 +17,5 @@ let ringCube = (spin: float, i: float) =>
 // The pulsing sphere at the center of the ring.
 let centerpiece = (spin: float, beat: float) =>
   Scene.sphere()
-    |> Scene.color(1.0, 0.5 + 0.5 * Math.cos(beat * 2.1), 0.5 + 0.5 * Math.sin(beat * 1.3))
+    |> Scene.color(Color.rgb(1.0, 0.5 + 0.5 * Math.cos(beat * 2.1), 0.5 + 0.5 * Math.sin(beat * 1.3)))
     |> Scene.scale(1.1 + 0.25 * Math.sin(spin * 4.0))

--- a/examples/hello/game.fun
+++ b/examples/hello/game.fun
@@ -170,7 +170,7 @@ let litRow = () =>
     Scene.cylinder() |> Scene.translate(0.0, -2.5, 0.0),
     Scene.sphere() |> Scene.scale(0.7) |> Scene.translate(-2.0, 1.0, 2.0),
     Scene.cube() |> Scene.translate(2.0, 1.0, 2.0),
-  ]) |> Scene.lit(0.85, 0.85, 0.9)
+  ]) |> Scene.lit(Color.rgb(0.85, 0.85, 0.9))
 
 let draw = (model, tts) =>
   Frame.createLit(
@@ -183,7 +183,7 @@ let draw = (model, tts) =>
       litRow(),
       // Self-lit neon sphere, rendered fullbright (emissive material).
       Scene.sphere() |> Scene.scale(0.5) |> Scene.translate(0.0, 2.3, 2.0)
-        |> Scene.emissive(1.0, 0.2, 0.8),
+        |> Scene.emissive(Color.rgb(1.0, 0.2, 0.8)),
       // The glowing grid-texture sign quad (emissive texture, fullbright).
       Scene.quad() |> Scene.scale(1.2) |> Scene.translate(0.0, 0.3, 1.5)
         |> Scene.emissiveTexture(gridTexture),
@@ -192,8 +192,8 @@ let draw = (model, tts) =>
     // A low blue-ish ambient plus a warm "sun" angled down from the upper
     // right; lit surfaces shade by orientation, emissive ones stay bright.
     [
-      Light.ambient(0.2, 0.2, 0.28),
-      Light.directional(-0.5, -1.0, -0.35, 1.0, 0.96, 0.85, 1.1) |> Light.castShadows,
+      Light.ambient(Color.rgb(0.2, 0.2, 0.28)),
+      Light.directional(-0.5, -1.0, -0.35, Color.rgb(1.0, 0.96, 0.85), 1.1) |> Light.castShadows,
     ])
 
 let join = (parts) => parts |> List.fold((acc, s) => Text.concat(acc, s), "")
@@ -205,7 +205,7 @@ let f0 = (n) => Text.fixed(n, 0.0)
 let ui = (model) =>
   Ui.column([
     Ui.text("functor · hello"),
-    Ui.textColor(1.0, 0.85, 0.4,
+    Ui.textColor(Color.rgb(1.0, 0.85, 0.4),
       join(["eye  ", f1(model.eye.x), " ", f1(model.eye.y), " ", f1(model.eye.z)])),
     Ui.text(join(["look  yaw ", f0(model.yaw), "  pitch ", f0(model.pitch)])),
     Ui.text(Text.concat("frame ", f0(model.counter))),

--- a/examples/lighting/game.fun
+++ b/examples/lighting/game.fun
@@ -165,30 +165,30 @@ let markers = (tts: float) =>
     Scene.sphere()
       |> Scene.scale(0.12)
       |> Scene.translate(p.x, p.y, p.z)
-      |> Scene.emissive(r, g, b))
+      |> Scene.emissive(Color.rgb(r, g, b)))
 
 let pointLights = (tts: float) =>
   List.range(3.0) |> List.map((i) =>
     let p = pointPos(i, tts) in
     let (r, g, b) = pointColor(i) in
-    Light.point(p.x, p.y, p.z, r, g, b, 1.4, 4.0))
+    Light.point(p.x, p.y, p.z, Color.rgb(r, g, b), 1.4, 4.0))
 
 let draw = (model, tts: float) =>
   // Ground + a few lit objects sitting on it (each centered at y = its
   // half-height so it rests on y = 0). Near-white so the colored lights tint
   // them; the ground is a neutral grey.
   let ground =
-    Scene.plane() |> Scene.scale(24.0) |> Scene.lit(0.6, 0.6, 0.62) in
+    Scene.plane() |> Scene.scale(24.0) |> Scene.lit(Color.rgb(0.6, 0.6, 0.62)) in
   let litShapes =
     Scene.group([
       Scene.sphere() |> Scene.scale(0.8) |> Scene.translate(0.0 - 2.5, 0.8, 0.0),
       Scene.cylinder() |> Scene.translate(0.0, 0.5, 2.5),
-    ]) |> Scene.lit(0.9, 0.9, 0.9) in
+    ]) |> Scene.lit(Color.rgb(0.9, 0.9, 0.9)) in
   // The cube is normal-mapped, so its flat faces show the bumps.
   let cube =
     Scene.cube()
       |> Scene.translate(2.5, 0.5, 0.0)
-      |> Scene.litNormalMapped(0.9, 0.9, 0.92, bumpsTexture) in
+      |> Scene.litNormalMapped(Color.rgb(0.9, 0.9, 0.92), bumpsTexture) in
   let objects = Scene.group([ground, litShapes, cube]) in
 
   // An animated (skinned) shark swimming above the ground — it casts a
@@ -208,12 +208,12 @@ let draw = (model, tts: float) =>
     Scene.cylinder()
       |> Scene.scaleXYZ(1.4, 0.5, 1.4)
       |> Scene.translate(0.0, 0.25, 0.0)
-      |> Scene.lit(0.9, 0.9, 0.9) in
+      |> Scene.lit(Color.rgb(0.9, 0.9, 0.9)) in
   let water =
     Scene.sphere()
       |> Scene.scaleXYZ(0.55, 0.22, 0.55)
       |> Scene.translate(0.0, 0.6 + bob, 0.0)
-      |> Scene.emissive(0.3, 0.65, 1.0) in
+      |> Scene.emissive(Color.rgb(0.3, 0.65, 1.0)) in
   let fountain =
     Scene.group([basin, water])
       |> Scene.translate(fountainPos.x, 0.0, fountainPos.z) in
@@ -233,7 +233,7 @@ let draw = (model, tts: float) =>
     Light.spot(
       0.0, 7.0, 5.0,
       sweepX - 0.0, 0.3 - 7.0, 0.0 - 5.0,
-      1.0, 1.0, 0.95, 5.0, 18.0, Angle.radians(0.5))
+      Color.rgb(1.0, 1.0, 0.95), 5.0, 18.0, Angle.radians(0.5))
     |> Light.castShadows in
 
   Frame.createLit(
@@ -245,8 +245,8 @@ let draw = (model, tts: float) =>
     // spot sits before it — lighting is additive and the single shadow caster is
     // unambiguous, so the render is identical.)
     [
-      Light.ambient(0.08, 0.08, 0.11),
-      Light.directional(0.4, 0.0 - 1.0, 0.3, 0.9, 0.92, 1.0, 0.25),
+      Light.ambient(Color.rgb(0.08, 0.08, 0.11)),
+      Light.directional(0.4, 0.0 - 1.0, 0.3, Color.rgb(0.9, 0.92, 1.0), 0.25),
       spot,
       ..pointLights(tts)
     ])

--- a/examples/mario/game.fun
+++ b/examples/mario/game.fun
@@ -119,13 +119,13 @@ let tick = (model, dt, tts) =>
 let platform = (cx, width) =>
   Scene.cube()
     |> Scene.scaleXYZ(width, 2.0, 4.0)
-    |> Scene.lit(0.30, 0.68, 0.36)
+    |> Scene.lit(Color.rgb(0.30, 0.68, 0.36))
     |> Scene.translate(cx, groundTop - 1.0, 0.0)
 
 let character = (model) =>
   Scene.cube()
     |> Scene.scaleXYZ(0.8, 1.2, 0.8)
-    |> Scene.lit(0.95, 0.35, 0.25)
+    |> Scene.lit(Color.rgb(0.95, 0.35, 0.25))
     |> Scene.translate(model.x, model.y + charHalfH, 0.0)
 
 let draw = (model, tts) =>
@@ -138,6 +138,6 @@ let draw = (model, tts) =>
       character(model),
     ]),
     [
-      Light.ambient(0.18, 0.18, 0.22),
-      Light.directional(-0.4, -1.0, -0.5, 1.0, 0.98, 0.92, 0.9) |> Light.castShadows,
+      Light.ambient(Color.rgb(0.18, 0.18, 0.22)),
+      Light.directional(-0.4, -1.0, -0.5, Color.rgb(1.0, 0.98, 0.92), 0.9) |> Light.castShadows,
     ])

--- a/examples/monitor/game.fun
+++ b/examples/monitor/game.fun
@@ -21,37 +21,37 @@ let pan = (tts: float) => Math.sin(tts * 0.5) * 0.5
 let orbiter = (tts: float) =>
   Scene.sphere()
     |> Scene.scale(0.45)
-    |> Scene.emissive(1.0, 0.55, 0.15)
+    |> Scene.emissive(Color.rgb(1.0, 0.55, 0.15))
     |> Scene.translate(Math.cos(tts * 0.8) * 3.0, 0.6, 3.0 + Math.sin(tts * 0.8) * 2.0)
 
 // The courtyard both cameras film.
 let courtyard = (tts: float) =>
   Scene.group([
-    Scene.plane() |> Scene.scale(22.0) |> Scene.lit(0.55, 0.6, 0.55),
-    Scene.cube() |> Scene.lit(0.85, 0.3, 0.25) |> Scene.translate(-2.4, 0.5, 2.0),
+    Scene.plane() |> Scene.scale(22.0) |> Scene.lit(Color.rgb(0.55, 0.6, 0.55)),
+    Scene.cube() |> Scene.lit(Color.rgb(0.85, 0.3, 0.25)) |> Scene.translate(-2.4, 0.5, 2.0),
     Scene.cube()
       |> Scene.scale(0.7)
       |> Scene.rotateY(Angle.degrees(30.0))
-      |> Scene.lit(0.3, 0.5, 0.9)
+      |> Scene.lit(Color.rgb(0.3, 0.5, 0.9))
       |> Scene.translate(2.2, 0.35, 3.4),
-    Scene.cylinder() |> Scene.lit(0.9, 0.8, 0.3) |> Scene.translate(0.5, 0.5, 5.2),
+    Scene.cylinder() |> Scene.lit(Color.rgb(0.9, 0.8, 0.3)) |> Scene.translate(0.5, 0.5, 5.2),
     orbiter(tts),
   ])
 
 let lights = () => [
-  Light.ambient(0.12, 0.12, 0.15),
-  Light.directional(0.4, -1.0, 0.3, 1.0, 0.97, 0.9, 0.9) |> Light.castShadows,
+  Light.ambient(Color.rgb(0.12, 0.12, 0.15)),
+  Light.directional(0.4, -1.0, 0.3, Color.rgb(1.0, 0.97, 0.9), 0.9) |> Light.castShadows,
 ]
 
 // The visible camera prop: a head with a lens (a cylinder's axis is Y;
 // rotateX aims it along +Z), yawed by the SAME pan driving the feed camera.
 let cameraGadget = (tts: float) =>
   Scene.group([
-    Scene.cube() |> Scene.scale(0.45) |> Scene.lit(0.25, 0.25, 0.28),
+    Scene.cube() |> Scene.scale(0.45) |> Scene.lit(Color.rgb(0.25, 0.25, 0.28)),
     Scene.cylinder()
       |> Scene.scale(0.2)
       |> Scene.rotateX(Angle.degrees(90.0))
-      |> Scene.lit(0.1, 0.1, 0.1)
+      |> Scene.lit(Color.rgb(0.1, 0.1, 0.1))
       |> Scene.translate(0.0, 0.0, 0.35),
   ])
     |> Scene.rotateY(Angle.radians(pan(tts)))
@@ -75,7 +75,7 @@ let feedFrame = (tts: float) =>
 // a mirrored feed.
 let monitor = () =>
   Scene.group([
-    Scene.cube() |> Scene.scale(2.4) |> Scene.lit(0.08, 0.08, 0.09),
+    Scene.cube() |> Scene.scale(2.4) |> Scene.lit(Color.rgb(0.08, 0.08, 0.09)),
     Scene.quad()
       |> Scene.screen(feed)
       |> Scene.rotateY(Angle.degrees(180.0))

--- a/examples/mpclient/game.fun
+++ b/examples/mpclient/game.fun
@@ -109,9 +109,9 @@ let draw = (m: Model, tts: float) =>
       Scene.cube()
       |> Scene.scale(0.6)
       |> Scene.translate(p.x, 0.0, p.z)
-      |> Scene.lit(r, g, b)) in
+      |> Scene.lit(Color.rgb(r, g, b))) in
   let ground =
-    Scene.plane() |> Scene.scale(8.0) |> Scene.lit(0.18, 0.2, 0.28) in
+    Scene.plane() |> Scene.scale(8.0) |> Scene.lit(Color.rgb(0.18, 0.2, 0.28)) in
   let scene = Scene.group([ground, ..playerNodes]) in
   let camera =
     Camera.firstPerson(
@@ -119,5 +119,5 @@ let draw = (m: Model, tts: float) =>
       Angle.radians(0.0), Angle.radians(-1.2), Angle.degrees(70.0)) in
   Frame.createLit(
     camera, scene,
-    [ Light.ambient(0.35, 0.35, 0.42),
-      Light.directional(-0.4, -1.0, -0.35, 1.0, 0.95, 0.85, 1.1) ])
+    [ Light.ambient(Color.rgb(0.35, 0.35, 0.42)),
+      Light.directional(-0.4, -1.0, -0.35, Color.rgb(1.0, 0.95, 0.85), 1.1) ])

--- a/examples/mpserver/game.fun
+++ b/examples/mpserver/game.fun
@@ -126,9 +126,9 @@ let draw = (m: Model, tts: float) =>
       Scene.cube()
       |> Scene.scale(0.6)
       |> Scene.translate(p.x, 0.0, p.z)
-      |> Scene.lit(r, g, b)) in
+      |> Scene.lit(Color.rgb(r, g, b))) in
   let ground =
-    Scene.plane() |> Scene.scale(2.0 * arena) |> Scene.lit(0.18, 0.2, 0.28) in
+    Scene.plane() |> Scene.scale(2.0 * arena) |> Scene.lit(Color.rgb(0.18, 0.2, 0.28)) in
   let scene = Scene.group([ground, ..playerNodes]) in
   // Top-down-ish view so player movement stays on screen.
   let camera =
@@ -137,5 +137,5 @@ let draw = (m: Model, tts: float) =>
       Angle.radians(0.0), Angle.radians(-1.2), Angle.degrees(70.0)) in
   Frame.createLit(
     camera, scene,
-    [ Light.ambient(0.35, 0.35, 0.42),
-      Light.directional(-0.4, -1.0, -0.35, 1.0, 0.95, 0.85, 1.1) ])
+    [ Light.ambient(Color.rgb(0.35, 0.35, 0.42)),
+      Light.directional(-0.4, -1.0, -0.35, Color.rgb(1.0, 0.95, 0.85), 1.1) ])

--- a/examples/netdemo/game.fun
+++ b/examples/netdemo/game.fun
@@ -52,4 +52,4 @@ let draw = (m: Model, tts: float) =>
     Camera.firstPerson(
       0.0, 0.0, -5.0,
       Angle.radians(0.0), Angle.radians(0.0), Angle.degrees(60.0)),
-    Scene.cube() |> Scene.emissive(0.2, 0.9, 0.6))
+    Scene.cube() |> Scene.emissive(Color.rgb(0.2, 0.9, 0.6)))

--- a/examples/physics/game.fun
+++ b/examples/physics/game.fun
@@ -29,7 +29,13 @@ let crateCount = 5.0
 let scatterX = (drop, i) => Math.sin(i * 12.9898 + drop * 3.7) * 1.6
 let scatterZ = (drop, i) => Math.cos(i * 78.2330 + drop * 1.3) * 1.6
 
-let crateTag = (i) => Text.concat("crate-", Text.fromFloat(i))
+// Branded body identities — declared once, used as the VALUE at every site
+// (declaration, reads, commands, event comparisons). noTag is the "ball not
+// involved" sentinel matching the engine's zeroed-miss convention.
+let groundTag = Physics.tag("ground")
+let ballTag = Physics.tag("ball")
+let noTag = Physics.tag("")
+let crateTag = (i) => Physics.tag(Text.concat("crate-", Text.fromFloat(i)))
 
 let crateBody = (drop, i) =>
   Physics.dynamic(crateTag(i), Physics.box(1.0, 1.0, 1.0))
@@ -44,11 +50,11 @@ let crateBody = (drop, i) =>
 // resting bodies.
 let bodyAt = (drop, i) =>
   match i with
-  | 0.0 => Physics.fixed("ground", Physics.box(24.0, 0.4, 24.0)) |> Physics.at(0.0, -0.2, 0.0)
+  | 0.0 => Physics.fixed(groundTag, Physics.box(24.0, 0.4, 24.0)) |> Physics.at(0.0, -0.2, 0.0)
   | 1.0 =>
     // Nearly-vertical drop beside the crates (the small drop-dependent wobble
     // keeps SPACE's re-drop teleport firing), so the ball settles in frame.
-    (Physics.dynamic("ball", Physics.sphere(0.6))
+    (Physics.dynamic(ballTag, Physics.sphere(0.6))
       |> Physics.at(3.2 + scatterX(drop, 9.0) * 0.2, 5.5, 0.5 + scatterZ(drop, 9.0) * 0.2)
       |> Physics.restitution(0.55))
   | n => crateBody(drop, n - 2.0)
@@ -73,7 +79,7 @@ type Msg<'h, 'e> =
   | GotHit(hit: 'h)
   | Contact(ev: 'e)
 
-let init = { drop: 0.0, spaceHeld: false, hot: "" }
+let init = { drop: 0.0, spaceHeld: false, hot: noTag }
 
 let tick = (model, dt, tts) => model
 
@@ -93,7 +99,7 @@ let input = (model, key, isDown) =>
   | Key.K =>
     (match isDown with
      | true => model
-     | false => (model, Physics.applyImpulse("ball", -2.6, 5.0, -0.4)))
+     | false => (model, Physics.applyImpulse(ballTag, -2.6, 5.0, -0.4)))
   | Key.R =>
     (match isDown with
      | true => model
@@ -107,14 +113,14 @@ let input = (model, key, isDown) =>
   | _ => model
 
 // Contact events name both tags in rapier's pair order — find the ball's
-// partner (or "" when the ball isn't involved).
+// partner (or noTag when the ball isn't involved).
 let otherOf = (e) =>
-  match e.a == "ball" with
+  match e.a == ballTag with
   | true => e.b
   | false =>
-    (match e.b == "ball" with
+    (match e.b == ballTag with
      | true => e.a
-     | false => "")
+     | false => noTag)
 
 let subscriptions = (model) => Physics.events(Contact)
 
@@ -128,7 +134,7 @@ let update = (model, msg) =>
     (match hit.hit with
      | false => model
      | true =>
-       (match hit.tag == "ground" with
+       (match hit.tag == groundTag with
         | true => model
         | false => (model, Physics.applyImpulse(hit.tag, 0.0, 6.0, 0.0))))
   | Contact(e) =>
@@ -136,11 +142,11 @@ let update = (model, msg) =>
      | false => model
      | true =>
        let other = otherOf(e) in
-       (match other == "" with
+       (match other == noTag with
         | true => model
         | false =>
           // Touching the slab isn't interesting — only crates glow.
-          (match other == "ground" with
+          (match other == groundTag with
            | true => model
            | false => { model with hot: other })))
 
@@ -149,7 +155,7 @@ let draw = (model, tts) =>
     Camera.lookAt(10.5, 7.5, -10.5, 0.0, 0.8, 0.0),
     Scene.group([
       Scene.plane() |> Scene.scale(24.0) |> Scene.lit(Color.rgb(0.55, 0.58, 0.62)),
-      Scene.sphere() |> Scene.scale(0.6) |> Scene.lit(Color.rgb(0.95, 0.35, 0.25)) |> Physics.transformed("ball"),
+      Scene.sphere() |> Scene.scale(0.6) |> Scene.lit(Color.rgb(0.95, 0.35, 0.25)) |> Physics.transformed(ballTag),
       Scene.group(List.range(crateCount) |> List.map((i) => crateVisual(model, i))),
     ]),
     [

--- a/examples/physics/game.fun
+++ b/examples/physics/game.fun
@@ -61,10 +61,10 @@ let physics = (model) =>
 // latest touch glows (a Physics.events Contact set `hot`).
 let crateVisual = (model, i) =>
   (match crateTag(i) == model.hot with
-   | true => Scene.cube() |> Scene.emissive(1.0, 0.45, 0.15)
+   | true => Scene.cube() |> Scene.emissive(Color.rgb(1.0, 0.45, 0.15))
    | false =>
      Scene.cube()
-       |> Scene.lit(Math.clamp01(0.55 + 0.09 * i), Math.clamp01(0.42 - 0.04 * i), 0.28))
+       |> Scene.lit(Color.rgb(Math.clamp01(0.55 + 0.09 * i), Math.clamp01(0.42 - 0.04 * i), 0.28)))
     |> Physics.transformed(crateTag(i))
 
 // The message ADT: ctor taggers wrap each async result in its own arm —
@@ -148,11 +148,11 @@ let draw = (model, tts) =>
   Frame.createLit(
     Camera.lookAt(10.5, 7.5, -10.5, 0.0, 0.8, 0.0),
     Scene.group([
-      Scene.plane() |> Scene.scale(24.0) |> Scene.lit(0.55, 0.58, 0.62),
-      Scene.sphere() |> Scene.scale(0.6) |> Scene.lit(0.95, 0.35, 0.25) |> Physics.transformed("ball"),
+      Scene.plane() |> Scene.scale(24.0) |> Scene.lit(Color.rgb(0.55, 0.58, 0.62)),
+      Scene.sphere() |> Scene.scale(0.6) |> Scene.lit(Color.rgb(0.95, 0.35, 0.25)) |> Physics.transformed("ball"),
       Scene.group(List.range(crateCount) |> List.map((i) => crateVisual(model, i))),
     ]),
     [
-      Light.ambient(0.12, 0.12, 0.15),
-      Light.directional(0.5, -1.0, 0.35, 1.0, 0.98, 0.95, 0.9) |> Light.castShadows,
+      Light.ambient(Color.rgb(0.12, 0.12, 0.15)),
+      Light.directional(0.5, -1.0, 0.35, Color.rgb(1.0, 0.98, 0.95), 0.9) |> Light.castShadows,
     ])

--- a/examples/primitives/game.fun
+++ b/examples/primitives/game.fun
@@ -22,19 +22,19 @@ let whiteShapes = () =>
     Scene.sphere() |> Scene.scale(0.8) |> Scene.translate(-2.2, 0.8, 0.0),
     Scene.cube() |> Scene.translate(2.2, 0.5, 0.0),
     Scene.cylinder() |> Scene.translate(0.0, 0.5, 2.2),
-  ]) |> Scene.lit(0.9, 0.9, 0.9)
+  ]) |> Scene.lit(Color.rgb(0.9, 0.9, 0.9))
 
 // An emissive marker sphere at a point light's position.
 let marker = (i: float, tts: float, r: float, g: float, b: float) =>
   let p = pointPos(i, tts) in
   Scene.sphere()
     |> Scene.scale(0.15)
-    |> Scene.emissive(r, g, b)
+    |> Scene.emissive(Color.rgb(r, g, b))
     |> Scene.translate(p.x, p.y, p.z)
 
 let pointLight = (i: float, tts: float, r: float, g: float, b: float) =>
   let p = pointPos(i, tts) in
-  Light.point(p.x, p.y, p.z, r, g, b, 1.4, 4.0)
+  Light.point(p.x, p.y, p.z, Color.rgb(r, g, b), 1.4, 4.0)
 
 let init = {}
 
@@ -46,14 +46,14 @@ let draw = (m, tts: float) =>
       0.0, 3.5, -8.0,
       Angle.radians(0.0), Angle.radians(-0.3), Angle.degrees(60.0)),
     Scene.group([
-      Scene.plane() |> Scene.scale(24.0) |> Scene.lit(0.6, 0.6, 0.62),
+      Scene.plane() |> Scene.scale(24.0) |> Scene.lit(Color.rgb(0.6, 0.6, 0.62)),
       whiteShapes(),
       marker(0.0, tts, 1.0, 0.3, 0.25),
       marker(1.0, tts, 0.35, 0.5, 1.0),
     ]),
     [
-      Light.ambient(0.1, 0.1, 0.13),
-      Light.directional(0.5, -1.0, 0.35, 1.0, 0.98, 0.95, 0.85) |> Light.castShadows,
+      Light.ambient(Color.rgb(0.1, 0.1, 0.13)),
+      Light.directional(0.5, -1.0, 0.35, Color.rgb(1.0, 0.98, 0.95), 0.85) |> Light.castShadows,
       pointLight(0.0, tts, 1.0, 0.3, 0.25),
       pointLight(1.0, tts, 0.35, 0.5, 1.0),
     ])

--- a/examples/synthwave/game.fun
+++ b/examples/synthwave/game.fun
@@ -82,7 +82,7 @@ let draw = (m: float, tts: float) =>
     Scene.sphere()
     |> Scene.scale(16.0)
     |> Scene.translate(0.0, 9.0, 78.0)
-    |> Scene.emissive(1.0, 0.82, 0.6) in
+    |> Scene.emissive(Color.rgb(1.0, 0.82, 0.6)) in
   // A gradient sky backdrop (dark indigo up top -> warm magenta at the horizon)
   // on a large emissive quad just behind the sun. The quad lies in the XY plane
   // facing the camera; emissive so it ignores scene lighting.

--- a/examples/toss/game.fun
+++ b/examples/toss/game.fun
@@ -67,13 +67,13 @@ let tick = (model, dt, tts) =>
 let ballView = (b) =>
   Scene.sphere()
     |> Scene.scale(0.3)
-    |> Scene.lit(1.0, 0.45, 0.2)
+    |> Scene.lit(Color.rgb(1.0, 0.45, 0.2))
     |> Scene.translate(b.pos.x, b.pos.y, b.pos.z)
 
 let ground =
   Scene.plane()
     |> Scene.scale(24.0)
-    |> Scene.lit(0.14, 0.15, 0.2)
+    |> Scene.lit(Color.rgb(0.14, 0.15, 0.2))
 
 let draw = (model, tts) =>
   let cam = Camera.lookAt(0.0, 6.0, 15.0, 0.0, 3.0, 0.0) in
@@ -82,6 +82,6 @@ let draw = (model, tts) =>
     model.balls |> List.map(ballView) |> Scene.group
   ]) in
   Frame.createLit(cam, scene, [
-    Light.ambient(0.3, 0.3, 0.35),
-    Light.directional(-0.4, -1.0, -0.3, 1.0, 1.0, 1.0, 1.0)
+    Light.ambient(Color.rgb(0.3, 0.3, 0.35)),
+    Light.directional(-0.4, -1.0, -0.3, Color.rgb(1.0, 1.0, 1.0), 1.0)
   ])

--- a/examples/trajectory/game.fun
+++ b/examples/trajectory/game.fun
@@ -104,7 +104,7 @@ let moving = (b) => speedSq(b) > 0.05
 let ghost = (b) =>
   Scene.sphere()
     |> Scene.scale(0.07)
-    |> Scene.emissive(0.25, 0.85, 1.0)
+    |> Scene.emissive(Color.rgb(0.25, 0.85, 1.0))
     |> Scene.translate(b.pos.x, b.pos.y, b.pos.z)
 
 // The moving balls of one future model, as a group of ghost dots.
@@ -120,13 +120,13 @@ let trail = (model) =>
 let ballView = (b) =>
   Scene.sphere()
     |> Scene.scale(0.3)
-    |> Scene.lit(1.0, 0.45, 0.2)
+    |> Scene.lit(Color.rgb(1.0, 0.45, 0.2))
     |> Scene.translate(b.pos.x, b.pos.y, b.pos.z)
 
 let ground =
   Scene.plane()
     |> Scene.scale(24.0)
-    |> Scene.lit(0.14, 0.15, 0.2)
+    |> Scene.lit(Color.rgb(0.14, 0.15, 0.2))
 
 let draw = (model, tts) =>
   let cam = Camera.lookAt(0.0, 6.0, 15.0, 0.0, 3.0, 0.0) in
@@ -136,6 +136,6 @@ let draw = (model, tts) =>
     trail(model)
   ]) in
   Frame.createLit(cam, scene, [
-    Light.ambient(0.3, 0.3, 0.35),
-    Light.directional(-0.4, -1.0, -0.3, 1.0, 1.0, 1.0, 1.0)
+    Light.ambient(Color.rgb(0.3, 0.3, 0.35)),
+    Light.directional(-0.4, -1.0, -0.3, Color.rgb(1.0, 1.0, 1.0), 1.0)
   ])

--- a/examples/ui/game.fun
+++ b/examples/ui/game.fun
@@ -63,7 +63,7 @@ let nameRow = (m: Model) =>
 // other anchors and colored text.
 let echoPanel = (m: Model) =>
   Ui.textColor(
-    1.0, 0.85, 0.4,
+    Color.rgb(1.0, 0.85, 0.4),
     Text.join("", [
       "model = { count: ", Text.fixed(m.count, 0.0),
       ", speed: ", Text.fixed(m.speed, 1.0),

--- a/examples/wsdemo/game.fun
+++ b/examples/wsdemo/game.fun
@@ -43,4 +43,4 @@ let draw = (m: Model, tts: float) =>
     Camera.firstPerson(
       0.0, 0.0, -5.0,
       Angle.radians(0.0), Angle.radians(0.0), Angle.degrees(60.0)),
-    Scene.cube() |> Scene.emissive(0.6, 0.4, 0.9))
+    Scene.cube() |> Scene.emissive(Color.rgb(0.6, 0.4, 0.9)))

--- a/examples/wsserverdemo/game.fun
+++ b/examples/wsserverdemo/game.fun
@@ -44,4 +44,4 @@ let draw = (m: Model, tts: float) =>
     Camera.firstPerson(
       0.0, 0.0, -5.0,
       Angle.radians(0.0), Angle.radians(0.0), Angle.degrees(60.0)),
-    Scene.cube() |> Scene.emissive(0.3, 0.6, 0.4))
+    Scene.cube() |> Scene.emissive(Color.rgb(0.3, 0.6, 0.4)))

--- a/functor-lang/src/project.rs
+++ b/functor-lang/src/project.rs
@@ -55,6 +55,7 @@ const PROTECTED_NAMESPACES: &[&str] = &[
     "Frame",
     "Light",
     "Fog",
+    "Color",
     "Skybox",
     "Angle",
     "Texture",

--- a/functor-prelude/prelude/color.funi
+++ b/functor-prelude/prelude/color.funi
@@ -1,0 +1,11 @@
+// color.funi — the `Color` host module (interface only; implemented in Rust by
+// FunctorHost in functor_runtime_common::functor_lang_prelude). See docs/functor-lang-interfaces.md.
+
+// The opaque color handle (`Color.t` from game code): an RGB color with
+// channels normally in 0..1 (emissive/HDR uses may exceed 1). The Angle rule
+// applied to color — every material/light/fog/UI color parameter takes a
+// Color VALUE, never three bare floats, so channel swaps and argument
+// miscounts are unrepresentable.
+type t
+
+let rgb : (float, float, float) => t

--- a/functor-prelude/prelude/fog.funi
+++ b/functor-prelude/prelude/fog.funi
@@ -4,5 +4,6 @@
 // The opaque fog handle (`Fog.t` from game code).
 type t
 
-let linear : (float, float, float, float, float) => t
-let exp : (float, float, float, float) => t
+// near, far, color / density, color.
+let linear : (float, float, Color.t) => t
+let exp : (float, Color.t) => t

--- a/functor-prelude/prelude/frame.funi
+++ b/functor-prelude/prelude/frame.funi
@@ -13,5 +13,6 @@ let withRenderTarget : (RenderTarget.t, t, t) => t
 let withFog : (Fog.t, t) => t
 let withSkybox : (Skybox.t, t) => t
 // Explicit background clear color (r, g, b in 0..1), overriding the fog-color
-// default. Frame LAST, so it pipes: `frame |> Frame.withClearColor(0.1, 0.0, 0.2)`.
-let withClearColor : (float, float, float, t) => t
+// default. Frame LAST, so it pipes:
+// `frame |> Frame.withClearColor(Color.rgb(0.1, 0.0, 0.2))`.
+let withClearColor : (Color.t, t) => t

--- a/functor-prelude/prelude/light.funi
+++ b/functor-prelude/prelude/light.funi
@@ -4,10 +4,12 @@
 // The opaque light handle (`Light.t` from game code).
 type t
 
-let ambient : (float, float, float) => t
-let directional : (float, float, float, float, float, float, float) => t
-let point : (float, float, float, float, float, float, float, float) => t
-// px, py, pz, dx, dy, dz, r, g, b, intensity, range, coneAngle.
-let spot : (float, float, float, float, float, float, float, float, float, float, float, Angle.t) => t
+let ambient : (Color.t) => t
+// dx, dy, dz, color, intensity.
+let directional : (float, float, float, Color.t, float) => t
+// px, py, pz, color, intensity, range.
+let point : (float, float, float, Color.t, float, float) => t
+// px, py, pz, dx, dy, dz, color, intensity, range, coneAngle.
+let spot : (float, float, float, float, float, float, Color.t, float, float, Angle.t) => t
 // Light first, so it pipes: `Light.directional(…) |> Light.castShadows`.
 let castShadows : (t) => t

--- a/functor-prelude/prelude/physics.funi
+++ b/functor-prelude/prelude/physics.funi
@@ -11,6 +11,13 @@
 type shape
 type body
 type world
+// The branded body identity — the RenderTarget rule applied to physics
+// identity. Made ONCE by `Physics.tag("name")` and used as the VALUE at
+// every site: declaration, reads, commands, and the tags inside `rayHit` /
+// `collisionEvent`. At runtime a tag is still the plain string (plain data:
+// journal, /state, and structural equality with event tags all unchanged) —
+// the brand is check-time only, like `Random.Seed`.
+type tag
 
 // The record `Physics.position` returns — the live pose of a body.
 type position = { x: float, y: float, z: float }
@@ -21,10 +28,14 @@ type rayHit = {
   x: float, y: float, z: float,
   nx: float, ny: float, nz: float,
   distance: float,
-  tag: string
+  tag: tag
 }
 // The record a `Physics.events` tagger receives, one per contact begin/end.
-type collisionEvent = { started: bool, a: string, b: string, sensor: bool }
+type collisionEvent = { started: bool, a: tag, b: tag, sensor: bool }
+
+// The tag constructor (identity at runtime; the empty tag is the zeroed
+// rayHit-miss / "no body" sentinel).
+let tag : (string) => tag
 
 // Shapes.
 let box : (float, float, float) => shape
@@ -32,12 +43,12 @@ let sphere : (float) => shape
 let capsule : (float, float) => shape
 
 // Bodies (tag, shape).
-let dynamic : (string, shape) => body
-let kinematic : (string, shape) => body
-let fixed : (string, shape) => body
+let dynamic : (tag, shape) => body
+let kinematic : (tag, shape) => body
+let fixed : (tag, shape) => body
 
 // body LAST (subject-last), so they pipe:
-// `Physics.dynamic("crate", Physics.box(1.0, 1.0, 1.0)) |> Physics.at(0.0, 5.0, 0.0)`.
+// `Physics.dynamic(crateTag, Physics.box(1.0, 1.0, 1.0)) |> Physics.at(0.0, 5.0, 0.0)`.
 let at : (float, float, float, body) => body
 let velocity : (float, float, float, body) => body
 let mass : (float, body) => body
@@ -49,17 +60,17 @@ let sensor : (body) => body
 let scene : (float, float, float, List<body>) => world
 
 // Reads of the LIVE stepped world (in-process, no boundary).
-let position : (string) => position
+let position : (tag) => position
 
 // world LAST (subject-last), so it pipes: place a visual at a body's live pose —
-// `Scene.cube() |> Physics.transformed("crate-1")`.
-let transformed : (string, Scene.t) => Scene.t
+// `Scene.cube() |> Physics.transformed(crateTag)`.
+let transformed : (tag, Scene.t) => Scene.t
 
 // Command EFFECTS (tag, x, y, z).
-let applyImpulse : (string, float, float, float) => Effect.t
-let applyForce : (string, float, float, float) => Effect.t
-let setVelocity : (string, float, float, float) => Effect.t
-let teleport : (string, float, float, float) => Effect.t
+let applyImpulse : (tag, float, float, float) => Effect.t
+let applyForce : (tag, float, float, float) => Effect.t
+let setVelocity : (tag, float, float, float) => Effect.t
+let teleport : (tag, float, float, float) => Effect.t
 
 // Query EFFECT: ox, oy, oz, dx, dy, dz, maxDist, tagger.
 let raycast : (float, float, float, float, float, float, float, (rayHit) => 'msg) => Effect.t

--- a/functor-prelude/prelude/scene.funi
+++ b/functor-prelude/prelude/scene.funi
@@ -5,7 +5,7 @@
 // interface-only module is a CLOSED module: a reference to a member it does not
 // declare is a load error, so a partial Scene would break real games.
 //
-// Branded argument types (`Angle.t`, `Texture.t`, `RenderTarget.t`) name types
+// Branded argument types (`Angle.t`, `Color.t`, `Texture.t`, `RenderTarget.t`) name types
 // owned by the sibling host modules authored in 2e-ii, so they resolve to those
 // real opaque types.
 
@@ -27,13 +27,14 @@ let heightmap : (List<List<float>>) => t
 // Composition.
 let group : (List<t>) => t
 
-// Materials (subject-last, so they pipe: `Scene.cube() |> Scene.color(r,g,b)`).
-let color : (float, float, float, t) => t
-let lit : (float, float, float, t) => t
-let emissive : (float, float, float, t) => t
+// Materials (subject-last, so they pipe:
+// `Scene.cube() |> Scene.color(Color.rgb(r, g, b))`).
+let color : (Color.t, t) => t
+let lit : (Color.t, t) => t
+let emissive : (Color.t, t) => t
 let litTexture : (Texture.t, t) => t
 let emissiveTexture : (Texture.t, t) => t
-let litNormalMapped : (float, float, float, Texture.t, t) => t
+let litNormalMapped : (Color.t, Texture.t, t) => t
 let screen : (RenderTarget.t, t) => t
 
 // Animation (subject-last): attach an Anim expression to the Model node(s)

--- a/functor-prelude/prelude/ui.funi
+++ b/functor-prelude/prelude/ui.funi
@@ -10,7 +10,7 @@ type view
 type anchor
 
 let text : (string) => view
-let textColor : (float, float, float, string) => view
+let textColor : (Color.t, string) => view
 let column : (List<view>) => view
 let row : (List<view>) => view
 // view LAST (subject-last), so it pipes: `Ui.column([…]) |> Ui.panel(Ui.topLeft())`.

--- a/functor-prelude/src/lib.rs
+++ b/functor-prelude/src/lib.rs
@@ -19,6 +19,7 @@ pub fn modules() -> Vec<(String, String)> {
         module("Scene", include_str!("../prelude/scene.funi")),
         module("Anim", include_str!("../prelude/anim.funi")),
         module("Angle", include_str!("../prelude/angle.funi")),
+        module("Color", include_str!("../prelude/color.funi")),
         module("Camera", include_str!("../prelude/camera.funi")),
         module("Frame", include_str!("../prelude/frame.funi")),
         module("Light", include_str!("../prelude/light.funi")),

--- a/runtime/functor-runtime-common/examples/frame_bench.rs
+++ b/runtime/functor-runtime-common/examples/frame_bench.rs
@@ -146,7 +146,7 @@ let draw = (m: float, tts: float) =>
     Scene.sphere()
     |> Scene.scale(16.0)
     |> Scene.translate(0.0, 9.0, 78.0)
-    |> Scene.emissive(1.0, 0.82, 0.6) in
+    |> Scene.emissive(Color.rgb(1.0, 0.82, 0.6)) in
   let sky =
     Scene.quad()
     |> Scene.scaleXYZ(500.0, 280.0, 1.0)

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -22,7 +22,7 @@
 //!    List builtins: List.range(rows) |> List.map((r) => List.range(cols)
 //!    |> List.map((c) => f(r, c))) — F#'s `heightmapFn`, in user space)
 //! Scene.group([scene, …])                                   -> Scene
-//! Scene.color(r, g, b, scene)                               -> Scene
+//! Scene.color(color, scene)                                 -> Scene
 //! Scene.translate(x, y, z, scene)                           -> Scene
 //! Scene.rotateX/rotateY/rotateZ(angle, scene)               -> Scene
 //! Angle.degrees(n) / Angle.radians(n)                       -> Angle
@@ -52,14 +52,14 @@
 //! Scene.screen(target, scene)                               -> Scene
 //!   (the reader: an emissive "screen" surface showing the target's texture;
 //!    an id no frame declares shows magenta and warns once)
-//! Fog.linear(near, far, r, g, b) / Fog.exp(density, r, g, b) -> Fog
+//! Fog.linear(near, far, color) / Fog.exp(density, color)    -> Fog
 //! Frame.withFog(fog, frame)                                  -> Frame
 //!   (frame-level distance fog on every forward material, emissive included —
 //!    fog occludes glow; the fog color is also the pass's clear color)
-//! Frame.withClearColor(r, g, b, frame)                       -> Frame
+//! Frame.withClearColor(color, frame)                         -> Frame
 //!   (explicit background clear color, overriding the fog-color default; it
 //!    only paints the background, not fog blending)
-//! Ui.text(s) / Ui.textColor(r, g, b, s)                     -> View
+//! Ui.text(s) / Ui.textColor(color, s)                       -> View
 //! Ui.column([view, …]) / Ui.row([view, …])                  -> View
 //! Ui.panel(anchor, view)                                    -> View
 //! Ui.topLeft() / topRight() / bottomLeft() / bottomRight()  -> Anchor
@@ -112,7 +112,7 @@
 //!
 //! Scene-consuming functions take the scene LAST, so they compose with
 //! `|>` (the piped value is appended — thread-last; see `functor_lang`'s lowering docs):
-//! `Scene.cube() |> Scene.color(1.0, 0.0, 0.0) |> Scene.translate(2.0, 0.0, 0.0)`.
+//! `Scene.cube() |> Scene.color(Color.rgb(1.0, 0.0, 0.0)) |> Scene.translate(2.0, 0.0, 0.0)`.
 //!
 //! # Transform semantics (deliberate — see the Milestone-0 quirks)
 //!
@@ -585,6 +585,12 @@ impl HostData for FunctorLangAnim {
 /// discipline, carried across the boundary).
 pub struct FunctorLangAngle(pub Angle);
 
+/// An RGB color as an opaque Functor Lang value — made by `Color.rgb(r, g, b)`.
+/// Material/light/fog/UI color parameters accept ONLY this, never three bare
+/// floats, so channel swaps and argument miscounts are unrepresentable (the
+/// Angle rule, applied to color).
+pub struct FunctorLangColor(pub (f32, f32, f32));
+
 /// A [`RenderTargetDescriptor`] as an opaque Functor Lang value — declared once via
 /// `RenderTarget.named` and used at both sites: the writer
 /// (`Frame.withRenderTarget`) and the reader (`Scene.screen`). Both accept
@@ -693,6 +699,22 @@ impl HostData for FunctorLangEffect {
     }
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+}
+
+impl HostData for FunctorLangColor {
+    fn type_name(&self) -> &'static str {
+        "Color"
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+    // Three module-independent f32s — no taggers, no closures. A Color
+    // stored in the model must not invalidate hot-reload time-travel
+    // history (colors were plain floats before the brand; this preserves
+    // that reload behavior and keeps "name a palette once" model-friendly).
+    fn is_reload_safe_snapshot(&self) -> bool {
+        true
     }
 }
 
@@ -883,6 +905,7 @@ const PATHS: &[&str] = &[
     "Texture.file",
     "Angle.degrees",
     "Angle.radians",
+    "Color.rgb",
     "Camera.lookAt",
     "Camera.firstPerson",
     "Light.ambient",
@@ -1224,16 +1247,13 @@ least 2 rows, each an equal-length list of at least 2 numbers",
                 }
                 _ => usage("Scene.group([scene, …])"),
             },
-            // Scene LAST (subject-last), so they pipe: `Scene.cube() |> Scene.lit(r, g, b)`.
+            // Scene LAST (subject-last), so they pipe:
+            // `Scene.cube() |> Scene.lit(Color.rgb(r, g, b))`.
             "Scene.lit" | "Scene.emissive" => match args.as_slice() {
-                [r, g, b, scene] => {
-                    let (r, g, b) = (
-                        num(r, span)? as f32,
-                        num(g, span)? as f32,
-                        num(b, span)? as f32,
-                    );
+                [color, scene] => {
+                    let (r, g, b) = color_of(color, path, span)?;
                     let Some(scene) = scene_of(scene) else {
-                        return usage(&format!("{path}(r, g, b, scene)"));
+                        return usage(&format!("{path}(color, scene)"));
                     };
                     let material = if path == "Scene.lit" {
                         MaterialDescription::lit(r, g, b, 1.0)
@@ -1245,7 +1265,7 @@ least 2 rows, each an equal-length list of at least 2 numbers",
                         xform: Matrix4::from_scale(1.0),
                     })
                 }
-                _ => usage(&format!("{path}(r, g, b, scene)")),
+                _ => usage(&format!("{path}(color, scene)")),
             },
             // An image texture by file path (relative to the game dir), the
             // Functor Lang face of F#'s `Texture.file`. Loading is the shells' asset
@@ -1288,43 +1308,39 @@ the game dir",
             // and specular play across the bumps. `(r, g, b)` is the albedo
             // tint; the normal map is a Texture value (alpha fixed at 1.0).
             "Scene.litNormalMapped" => match args.as_slice() {
-                [r, g, b, normal, scene] => {
+                [color, normal, scene] => {
                     let Some(scene) = scene_of(scene) else {
-                        return usage("Scene.litNormalMapped(r, g, b, normalMap, scene)");
+                        return usage("Scene.litNormalMapped(color, normalMap, scene)");
                     };
+                    let (r, g, b) = color_of(color, path, span)?;
                     let normal = texture_of(normal, path, span)?;
                     scene_value(Scene3D {
                         obj: SceneObject::Material(
-                            MaterialDescription::lit_normal_mapped(
-                                num(r, span)? as f32,
-                                num(g, span)? as f32,
-                                num(b, span)? as f32,
-                                1.0,
-                                normal.clone(),
-                            ),
+                            MaterialDescription::lit_normal_mapped(r, g, b, 1.0, normal.clone()),
                             vec![scene.clone()],
                         ),
                         xform: Matrix4::from_scale(1.0),
                     })
                 }
-                _ => usage("Scene.litNormalMapped(r, g, b, normalMap, scene)"),
+                _ => usage("Scene.litNormalMapped(color, normalMap, scene)"),
             },
-            // Scene LAST (subject-last), so it pipes: `Scene.cube() |> Scene.color(r, g, b)`.
+            // Scene LAST (subject-last), so it pipes:
+            // `Scene.cube() |> Scene.color(Color.rgb(r, g, b))`.
             "Scene.color" => match args.as_slice() {
-                [r, g, b, scene] => {
-                    let (r, g, b) = (num(r, span)?, num(g, span)?, num(b, span)?);
+                [color, scene] => {
+                    let (r, g, b) = color_of(color, path, span)?;
                     let Some(scene) = scene_of(scene) else {
-                        return usage("Scene.color(r, g, b, scene)");
+                        return usage("Scene.color(color, scene)");
                     };
                     scene_value(Scene3D {
                         obj: SceneObject::Material(
-                            MaterialDescription::color(r as f32, g as f32, b as f32, 1.0),
+                            MaterialDescription::color(r, g, b, 1.0),
                             vec![scene.clone()],
                         ),
                         xform: Matrix4::from_scale(1.0),
                     })
                 }
-                _ => usage("Scene.color(r, g, b, scene)"),
+                _ => usage("Scene.color(color, scene)"),
             },
             "Scene.translate" => match args.as_slice() {
                 [x, y, z, scene] => {
@@ -1336,6 +1352,16 @@ the game dir",
                     wrap_transform(scene, xform, "Scene.translate(x, y, z, scene)", span)
                 }
                 _ => usage("Scene.translate(x, y, z, scene)"),
+            },
+            // An opaque RGB color (channels normally 0..1; emissive/HDR uses
+            // may exceed 1). Every color-taking parameter requires one.
+            "Color.rgb" => match args.as_slice() {
+                [r, g, b] => Ok(host(FunctorLangColor((
+                    num(r, span)? as f32,
+                    num(g, span)? as f32,
+                    num(b, span)? as f32,
+                )))),
+                _ => usage("Color.rgb(r, g, b)"),
             },
             "Angle.degrees" => match args.as_slice() {
                 [n] => Ok(host(FunctorLangAngle(Angle::from_degrees(num(n, span)? as f32)))),
@@ -1412,44 +1438,50 @@ the game dir",
                 ),
             },
             "Light.ambient" => match args.as_slice() {
-                [r, g, b] => Ok(host(FunctorLangLight(Light::ambient(
-                    num(r, span)? as f32,
-                    num(g, span)? as f32,
-                    num(b, span)? as f32,
-                )))),
-                _ => usage("Light.ambient(r, g, b)"),
+                [color] => {
+                    let (r, g, b) = color_of(color, path, span)?;
+                    Ok(host(FunctorLangLight(Light::ambient(r, g, b))))
+                }
+                _ => usage("Light.ambient(color)"),
             },
             "Light.directional" => match args.as_slice() {
-                [dx, dy, dz, r, g, b, intensity] => Ok(host(FunctorLangLight(Light::directional(
-                    num(dx, span)? as f32,
-                    num(dy, span)? as f32,
-                    num(dz, span)? as f32,
-                    num(r, span)? as f32,
-                    num(g, span)? as f32,
-                    num(b, span)? as f32,
-                    num(intensity, span)? as f32,
-                )))),
-                _ => usage("Light.directional(dx, dy, dz, r, g, b, intensity)"),
+                [dx, dy, dz, color, intensity] => {
+                    let (r, g, b) = color_of(color, path, span)?;
+                    Ok(host(FunctorLangLight(Light::directional(
+                        num(dx, span)? as f32,
+                        num(dy, span)? as f32,
+                        num(dz, span)? as f32,
+                        r,
+                        g,
+                        b,
+                        num(intensity, span)? as f32,
+                    ))))
+                }
+                _ => usage("Light.directional(dx, dy, dz, color, intensity)"),
             },
             "Light.point" => match args.as_slice() {
-                [px, py, pz, r, g, b, intensity, range] => Ok(host(FunctorLangLight(Light::point(
-                    num(px, span)? as f32,
-                    num(py, span)? as f32,
-                    num(pz, span)? as f32,
-                    num(r, span)? as f32,
-                    num(g, span)? as f32,
-                    num(b, span)? as f32,
-                    num(intensity, span)? as f32,
-                    num(range, span)? as f32,
-                )))),
-                _ => usage("Light.point(px, py, pz, r, g, b, intensity, range)"),
+                [px, py, pz, color, intensity, range] => {
+                    let (r, g, b) = color_of(color, path, span)?;
+                    Ok(host(FunctorLangLight(Light::point(
+                        num(px, span)? as f32,
+                        num(py, span)? as f32,
+                        num(pz, span)? as f32,
+                        r,
+                        g,
+                        b,
+                        num(intensity, span)? as f32,
+                        num(range, span)? as f32,
+                    ))))
+                }
+                _ => usage("Light.point(px, py, pz, color, intensity, range)"),
             },
             // A cone of light from (px,py,pz) aimed along (dx,dy,dz), soft-edged
             // at `coneAngle` (an Angle from the axis) with falloff to `range`.
             // Shadow-casting when piped through `Light.castShadows`.
             "Light.spot" => match args.as_slice() {
-                [px, py, pz, dx, dy, dz, r, g, b, intensity, range, cone] => {
+                [px, py, pz, dx, dy, dz, color, intensity, range, cone] => {
                     let cone: cgmath::Rad<f32> = angle_of(cone, path, span)?.into();
+                    let (r, g, b) = color_of(color, path, span)?;
                     Ok(host(FunctorLangLight(Light::spot(
                         num(px, span)? as f32,
                         num(py, span)? as f32,
@@ -1457,16 +1489,16 @@ the game dir",
                         num(dx, span)? as f32,
                         num(dy, span)? as f32,
                         num(dz, span)? as f32,
-                        num(r, span)? as f32,
-                        num(g, span)? as f32,
-                        num(b, span)? as f32,
+                        r,
+                        g,
+                        b,
                         num(intensity, span)? as f32,
                         num(range, span)? as f32,
                         cone.0,
                     ))))
                 }
                 _ => usage(
-                    "Light.spot(px, py, pz, dx, dy, dz, r, g, b, intensity, range, coneAngle)",
+                    "Light.spot(px, py, pz, dx, dy, dz, color, intensity, range, coneAngle)",
                 ),
             },
             // Light first, so it pipes: `Light.directional(…) |> Light.castShadows`.
@@ -1943,7 +1975,7 @@ frame's main pass",
                 _ => usage("Frame.withRenderTarget(target, targetFrame, frame)"),
             },
             "Fog.linear" => match args.as_slice() {
-                [near, far, r, g, b] => {
+                [near, far, color] => {
                     let near = non_negative_num(near, span, "Fog.linear near")?;
                     let far = positive_num(far, span, "Fog.linear far")?;
                     if far <= near {
@@ -1951,24 +1983,22 @@ frame's main pass",
                             "Fog.linear: far ({far}) must be greater than near ({near})"
                         ));
                     }
-                    Ok(host(FunctorLangFog(Fog::linear(
-                        near as f32,
-                        far as f32,
-                        num(r, span)? as f32,
-                        num(g, span)? as f32,
-                        num(b, span)? as f32,
-                    ))))
+                    let (r, g, b) = color_of(color, path, span)?;
+                    Ok(host(FunctorLangFog(Fog::linear(near as f32, far as f32, r, g, b))))
                 }
-                _ => usage("Fog.linear(near, far, r, g, b)"),
+                _ => usage("Fog.linear(near, far, color)"),
             },
             "Fog.exp" => match args.as_slice() {
-                [density, r, g, b] => Ok(host(FunctorLangFog(Fog::exp(
-                    positive_num(density, span, "Fog.exp density")? as f32,
-                    num(r, span)? as f32,
-                    num(g, span)? as f32,
-                    num(b, span)? as f32,
-                )))),
-                _ => usage("Fog.exp(density, r, g, b)"),
+                [density, color] => {
+                    let (r, g, b) = color_of(color, path, span)?;
+                    Ok(host(FunctorLangFog(Fog::exp(
+                        positive_num(density, span, "Fog.exp density")? as f32,
+                        r,
+                        g,
+                        b,
+                    ))))
+                }
+                _ => usage("Fog.exp(density, color)"),
             },
             // Frame LAST (subject-last), so it pipes: `Frame.createLit(…) |> Frame.withFog(fog)`.
             "Frame.withFog" => match args.as_slice() {
@@ -2014,19 +2044,19 @@ paths (+X, -X, +Y, -Y, +Z, -Z)",
             // `frame |> Frame.withClearColor(r, g, b)`. Sets the background
             // clear color explicitly, overriding the fog-color default.
             "Frame.withClearColor" => match args.as_slice() {
-                [r, g, b, frame] => {
-                    let (r, g, b) = (num(r, span)?, num(g, span)?, num(b, span)?);
+                [color, frame] => {
+                    let (r, g, b) = color_of(color, path, span)?;
                     let Some(inner) = frame_value(frame) else {
-                        return usage("Frame.withClearColor(r, g, b, frame)");
+                        return usage("Frame.withClearColor(color, frame)");
                     };
                     Ok(host(FunctorLangFrame(Frame::with_clear_color(
                         inner.clone(),
-                        r as f32,
-                        g as f32,
-                        b as f32,
+                        r,
+                        g,
+                        b,
                     ))))
                 }
-                _ => usage("Frame.withClearColor(r, g, b, frame)"),
+                _ => usage("Frame.withClearColor(color, frame)"),
             },
             // Scene LAST (subject-last), so it pipes: `Scene.quad() |> Scene.screen(feed)` —
             // an emissive (fullbright, screens glow) surface showing the
@@ -2074,16 +2104,15 @@ paths (+X, -X, +Y, -Y, +Z, -Z)",
                 _ => usage("Ui.text(\"…\")"),
             },
             "Ui.textColor" => match args.as_slice() {
-                [r, g, b, Value::String(s)] => Ok(host(FunctorLangView(View::Text {
-                    text: s.to_string(),
-                    color: ui::rgb_u8(
-                        num(r, span)? as f32,
-                        num(g, span)? as f32,
-                        num(b, span)? as f32,
-                    ),
-                    font: None,
-                }))),
-                _ => usage("Ui.textColor(r, g, b, \"…\")"),
+                [color, Value::String(s)] => {
+                    let (r, g, b) = color_of(color, path, span)?;
+                    Ok(host(FunctorLangView(View::Text {
+                        text: s.to_string(),
+                        color: ui::rgb_u8(r, g, b),
+                        font: None,
+                    })))
+                }
+                _ => usage("Ui.textColor(color, \"…\")"),
             },
             "Ui.column" => match args.as_slice() {
                 [Value::List(items)] => {
@@ -2345,6 +2374,33 @@ Angle.degrees(…) or Angle.radians(…)"
         }),
         other => Err(RunError {
             message: format!("{what}: expected an Angle, got {}", other.kind_name()),
+            span,
+        }),
+    }
+}
+
+/// Extract an RGB color — color-taking functions accept ONLY Color values,
+/// so bare numbers get a teaching error instead of a silent channel guess
+/// (the [`angle_of`] rule, applied to color).
+fn color_of(value: &Value, what: &str, span: Span) -> Result<(f32, f32, f32), RunError> {
+    match value {
+        Value::HostData(data) => data
+            .as_any()
+            .downcast_ref::<FunctorLangColor>()
+            .map(|c| c.0)
+            .ok_or_else(|| RunError {
+                message: format!("{what}: expected a Color, got {}", value.kind_name()),
+                span,
+            }),
+        Value::Number(_) => Err(RunError {
+            message: format!(
+                "{what}: expected a Color, got a bare number — wrap the channels: \
+Color.rgb(r, g, b)"
+            ),
+            span,
+        }),
+        other => Err(RunError {
+            message: format!("{what}: expected a Color, got {}", other.kind_name()),
             span,
         }),
     }
@@ -3330,7 +3386,7 @@ fn fog_of<'a>(value: &'a Value, what: &str, span: Span) -> Result<&'a Fog, RunEr
         Value::Number(_) => Err(RunError {
             message: format!(
                 "{what}: expected a Fog, got a bare number — build one with \
-Fog.linear(near, far, r, g, b) or Fog.exp(density, r, g, b)"
+Fog.linear(near, far, color) or Fog.exp(density, color)"
             ),
             span,
         }),
@@ -3496,7 +3552,7 @@ module is CLOSED, so games referencing these break at load: {missing:?}"
             "let main = () =>\n\
              Frame.create(\n\
                Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0),\n\
-               Scene.cube() |> Scene.color(1.0, 0.0, 0.0) |> Scene.translate(2.0, 0.0, 0.0))",
+               Scene.cube() |> Scene.color(Color.rgb(1.0, 0.0, 0.0)) |> Scene.translate(2.0, 0.0, 0.0))",
         );
         // Outermost node: a Group carrying the translation…
         let SceneObject::Group(children) = &frame.scene.obj else {
@@ -3556,7 +3612,7 @@ module is CLOSED, so games referencing these break at load: {missing:?}"
     #[test]
     fn mapped_group_builds_n_children() {
         let frame = frame_of(
-            "let cubeAt = (i) => Scene.cube() |> Scene.color(1.0, 0.5, 0.2) |> Scene.translate(i, 0.0, 0.0)\n\
+            "let cubeAt = (i) => Scene.cube() |> Scene.color(Color.rgb(1.0, 0.5, 0.2)) |> Scene.translate(i, 0.0, 0.0)\n\
              let main = () =>\n\
              Frame.create(\n\
                Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0),\n\
@@ -3633,13 +3689,13 @@ the game dir"
              Frame.createLit(
                Camera.firstPerson(0.0, 3.5, -8.0, Angle.radians(0.0), Angle.radians(-0.3), Angle.degrees(60.0)),
                Scene.group([
-                 Scene.plane() |> Scene.scale(24.0) |> Scene.lit(0.6, 0.6, 0.62),
-                 Scene.sphere() |> Scene.emissive(1.0, 0.3, 0.25),
+                 Scene.plane() |> Scene.scale(24.0) |> Scene.lit(Color.rgb(0.6, 0.6, 0.62)),
+                 Scene.sphere() |> Scene.emissive(Color.rgb(1.0, 0.3, 0.25)),
                ]),
                [
-                 Light.ambient(0.1, 0.1, 0.13),
-                 Light.directional(0.5, -1.0, 0.35, 1.0, 0.98, 0.95, 0.85) |> Light.castShadows,
-                 Light.point(1.0, 2.2, 0.0, 1.0, 0.3, 0.25, 1.4, 4.0),
+                 Light.ambient(Color.rgb(0.1, 0.1, 0.13)),
+                 Light.directional(0.5, -1.0, 0.35, Color.rgb(1.0, 0.98, 0.95), 0.85) |> Light.castShadows,
+                 Light.point(1.0, 2.2, 0.0, Color.rgb(1.0, 0.3, 0.25), 1.4, 4.0),
                ])",
         );
         assert_eq!(frame.lights.len(), 3);
@@ -3660,9 +3716,9 @@ the game dir"
              let main = () =>\n\
              Frame.createLit(\n\
                Camera.firstPerson(0.0, 3.0, -8.0, Angle.radians(0.0), Angle.radians(-0.25), Angle.degrees(60.0)),\n\
-               Scene.cube() |> Scene.litNormalMapped(0.9, 0.9, 0.92, bumps),\n\
+               Scene.cube() |> Scene.litNormalMapped(Color.rgb(0.9, 0.9, 0.92), bumps),\n\
                [\n\
-                 Light.spot(0.0, 7.0, 5.0, 0.0, -1.0, -0.5, 1.0, 1.0, 0.95, 5.0, 18.0, Angle.radians(0.5))\n\
+                 Light.spot(0.0, 7.0, 5.0, 0.0, -1.0, -0.5, Color.rgb(1.0, 1.0, 0.95), 5.0, 18.0, Angle.radians(0.5))\n\
                    |> Light.castShadows,\n\
                ])",
         );
@@ -3691,7 +3747,8 @@ the game dir"
     #[test]
     fn prelude_errors_are_spanned() {
         let module = functor_lang::lower(
-            functor_lang::parse("let main = () => Scene.color(1.0, \"x\", 0.0, Scene.cube())").unwrap(),
+            functor_lang::parse("let main = () => Scene.color(Color.rgb(1.0, \"x\", 0.0), Scene.cube())")
+                .unwrap(),
         )
         .unwrap();
         let failure = functor_lang::run_with_host(&module, Tracing::Off, &mut FunctorHost)
@@ -3715,6 +3772,57 @@ the game dir"
             "Scene.rotateY: expected an Angle, got a bare number — say which unit: \
 Angle.degrees(…) or Angle.radians(…)"
         );
+    }
+
+    // [strong-typing track] color parameters refuse bare numbers with a
+    // teaching error — channel swaps and arg miscounts are unrepresentable
+    // (the Angle rule, applied to color).
+    #[test]
+    fn bare_numbers_are_not_colors() {
+        let fail = |src: &str| {
+            let module = functor_lang::lower(functor_lang::parse(src).unwrap()).unwrap();
+            functor_lang::run_with_host(&module, Tracing::Off, &mut FunctorHost)
+                .err()
+                .expect("should fail")
+                .error
+                .message
+        };
+        // A bare number where the Color goes gets the teaching error…
+        assert_eq!(
+            fail("let main = () => Scene.cube() |> Scene.lit(0.5)"),
+            "Scene.lit: expected a Color, got a bare number — wrap the channels: \
+Color.rgb(r, g, b)"
+        );
+        assert_eq!(
+            fail("let main = () => Light.ambient(0.1)"),
+            "Light.ambient: expected a Color, got a bare number — wrap the channels: \
+Color.rgb(r, g, b)"
+        );
+        // …and the pre-Color three-float spelling teaches the new shape.
+        assert_eq!(
+            fail("let main = () => Scene.cube() |> Scene.lit(0.5, 0.5, 0.5)"),
+            "usage: Scene.lit(color, scene)"
+        );
+        // Color.rgb itself still validates its channels.
+        assert_eq!(
+            fail("let main = () => Color.rgb(1.0, \"x\", 0.0)"),
+            "expected a number, got a string"
+        );
+    }
+
+    // A Color stored in the model is plain enough to survive hot reload —
+    // colors were bare floats before the brand, and a palette field must not
+    // invalidate the time-travel history (unlike taggers-carrying host
+    // values, which stay conservatively unsafe).
+    #[test]
+    fn colors_are_reload_safe_snapshots() {
+        let color = eval("let main = () => Color.rgb(0.1, 0.2, 0.3)");
+        assert!(color.is_reload_safe_snapshot());
+        let in_model = eval("let main = () => { tint: Color.rgb(0.1, 0.2, 0.3), hp: 3.0 }");
+        assert!(in_model.is_reload_safe_snapshot());
+        // The conservative default still holds for tagger-carrying values.
+        let sub = eval("let main = () => Sub.every(Time.seconds(1.0), 3.0)");
+        assert!(!sub.is_reload_safe_snapshot());
     }
 
     // Scene.animate pipes after Scene.model and lands the expression on the
@@ -3937,14 +4045,14 @@ Scene.cube() |> Scene.rotateY(Angle.radians(1.5707964)))",
              Frame.createLit(\n\
                Camera.lookAt(0.0, 2.0, -8.0, 0.0, 1.0, 0.0),\n\
                Scene.group([\n\
-                 Scene.plane() |> Scene.lit(0.6, 0.6, 0.6),\n\
+                 Scene.plane() |> Scene.lit(Color.rgb(0.6, 0.6, 0.6)),\n\
                  Scene.quad() |> Scene.screen(feed),\n\
                ]),\n\
-               [Light.ambient(0.1, 0.1, 0.1)])\n\
+               [Light.ambient(Color.rgb(0.1, 0.1, 0.1))])\n\
              |> Frame.withRenderTarget(feed, Frame.createLit(\n\
                   Camera.lookAt(0.0, 4.0, -6.0, 0.0, 0.5, 0.0),\n\
-                  Scene.cube() |> Scene.lit(0.8, 0.2, 0.2),\n\
-                  [Light.ambient(0.2, 0.2, 0.2)]))",
+                  Scene.cube() |> Scene.lit(Color.rgb(0.8, 0.2, 0.2)),\n\
+                  [Light.ambient(Color.rgb(0.2, 0.2, 0.2))]))",
         );
         assert_eq!(frame.render_targets.len(), 1);
         let pass = &frame.render_targets[0];
@@ -4027,7 +4135,7 @@ piped through RenderTarget.sized"
         let frame = frame_of(
             "let main = () =>\n\
              Frame.create(Camera.lookAt(0.0, 2.0, -8.0, 0.0, 1.0, 0.0), Scene.cube())\n\
-             |> Frame.withFog(Fog.linear(4.0, 30.0, 0.5, 0.6, 0.7))",
+             |> Frame.withFog(Fog.linear(4.0, 30.0, Color.rgb(0.5, 0.6, 0.7)))",
         );
         assert_eq!(frame.fog, Some(Fog::linear(4.0, 30.0, 0.5, 0.6, 0.7)));
         let json = serde_json::to_string(&frame).expect("serialize");
@@ -4043,7 +4151,7 @@ piped through RenderTarget.sized"
         let frame = frame_of(
             "let main = () =>\n\
              Frame.create(Camera.lookAt(0.0, 2.0, -8.0, 0.0, 1.0, 0.0), Scene.cube())\n\
-             |> Frame.withClearColor(0.2, 0.4, 0.6)",
+             |> Frame.withClearColor(Color.rgb(0.2, 0.4, 0.6))",
         );
         assert_eq!(frame.clear_color, Some([0.2, 0.4, 0.6]));
         assert_eq!(frame.resolved_clear_color(), [0.2, 0.4, 0.6]);
@@ -4060,8 +4168,8 @@ piped through RenderTarget.sized"
         let both = frame_of(
             "let main = () => \
              Frame.create(Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0), Scene.cube()) \
-             |> Frame.withFog(Fog.linear(4.0, 30.0, 0.5, 0.6, 0.7)) \
-             |> Frame.withClearColor(0.0, 0.0, 0.0)",
+             |> Frame.withFog(Fog.linear(4.0, 30.0, Color.rgb(0.5, 0.6, 0.7))) \
+             |> Frame.withClearColor(Color.rgb(0.0, 0.0, 0.0))",
         );
         assert_eq!(both.resolved_clear_color(), [0.0, 0.0, 0.0]);
     }
@@ -4084,16 +4192,16 @@ piped through RenderTarget.sized"
 Scene.cube()) |> Frame.withFog(0.5)"
             ),
             "Frame.withFog: expected a Fog, got a bare number — build one with \
-Fog.linear(near, far, r, g, b) or Fog.exp(density, r, g, b)"
+Fog.linear(near, far, color) or Fog.exp(density, color)"
         );
         // Degenerate parameters are teaching errors at construction, not
         // silent bad renders.
         assert_eq!(
-            fail("let main = () => Fog.linear(10.0, 5.0, 0.5, 0.5, 0.5)"),
+            fail("let main = () => Fog.linear(10.0, 5.0, Color.rgb(0.5, 0.5, 0.5))"),
             "Fog.linear: far (5) must be greater than near (10)"
         );
         assert_eq!(
-            fail("let main = () => Fog.exp(-1.0, 0.5, 0.5, 0.5)"),
+            fail("let main = () => Fog.exp(-1.0, Color.rgb(0.5, 0.5, 0.5))"),
             "Fog.exp density must be positive, got -1"
         );
     }
@@ -5136,7 +5244,7 @@ the game dir"
             "let main = () =>\n\
              Ui.column([\n\
                Ui.text(\"functor · hello\"),\n\
-               Ui.textColor(1.0, 0.85, 0.4, \"eye  0.0 0.0 -5.0\"),\n\
+               Ui.textColor(Color.rgb(1.0, 0.85, 0.4), \"eye  0.0 0.0 -5.0\"),\n\
              ]) |> Ui.panel(Ui.topLeft())",
         );
         let view = view_value(&value).expect("main should return a View");
@@ -5916,8 +6024,13 @@ the new text, got a number"
 with Ui.topLeft()"
         );
         assert_eq!(
-            run_fail("let main = () => Ui.textColor(1.0, \"x\", 0.0, \"a\")"),
+            run_fail("let main = () => Ui.textColor(Color.rgb(1.0, \"x\", 0.0), \"a\")"),
             "expected a number, got a string"
+        );
+        // The pre-Color four-float spelling teaches the new shape.
+        assert_eq!(
+            run_fail("let main = () => Ui.textColor(1.0, 0.85, 0.4, \"a\")"),
+            "usage: Ui.textColor(color, \"…\")"
         );
     }
 

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -947,6 +947,7 @@ const PATHS: &[&str] = &[
     "Effect.now",
     "Effect.random",
     "Effect.batch",
+    "Physics.tag",
     "Physics.box",
     "Physics.sphere",
     "Physics.capsule",
@@ -1545,6 +1546,17 @@ the game dir",
             // Shapes are values, bodies are tag + shape + piped attributes,
             // and the optional game hook `physics = (model) => Physics.scene(…)`
             // declares the world each frame.
+            //
+            // `Physics.tag` is the branded body identity — check-time only
+            // (physics.funi types it as the abstract `Physics.tag`), so at
+            // runtime a tag IS its string: identity here, plain data in the
+            // model/journal, and structurally comparable with the tags inside
+            // rayHit/collisionEvent records. The empty tag is the zeroed
+            // rayHit-miss / "no body" sentinel, so no non-empty validation.
+            "Physics.tag" => match args.as_slice() {
+                [Value::String(_)] => Ok(args[0].clone()),
+                _ => usage("Physics.tag(\"name\")"),
+            },
             "Physics.box" => match args.as_slice() {
                 [w, h, d] => Ok(host(FunctorLangShape(physics::Shape::Cuboid {
                     extents: [
@@ -1585,7 +1597,7 @@ the game dir",
                 _ => usage(&format!("{path}(tag, shape)")),
             },
             // Body LAST (subject-last), so they pipe:
-            // `Physics.dynamic("crate", Physics.box(1.0, 1.0, 1.0)) |> Physics.at(0.0, 5.0, 0.0)`.
+            // `Physics.dynamic(crateTag, Physics.box(1.0, 1.0, 1.0)) |> Physics.at(0.0, 5.0, 0.0)`.
             "Physics.at" | "Physics.velocity" => match args.as_slice() {
                 [x, y, z, body] => match body_of(body) {
                     Some(inner) => {
@@ -1672,11 +1684,11 @@ the game dir",
                 _ => usage("Physics.position(tag)"),
             },
             // Scene LAST (subject-last), so it pipes: the way Functor Lang draws a physics body —
-            // `Scene.cube() |> Scene.lit(…) |> Physics.transformed("crate-1")`
+            // `Scene.cube() |> Scene.lit(…) |> Physics.transformed(crateTag)`
             // places the visual at the body's live pose (position + rotation).
             // Command EFFECTS (docs/physics.md Phase 3): fire-and-forget,
             // returned beside the model like any effect —
-            // `(model, Physics.applyImpulse("ball", 0.0, 5.0, 0.0))`.
+            // `(model, Physics.applyImpulse(ballTag, 0.0, 5.0, 0.0))`.
             // Performing one queues it on the singleton world; it applies at
             // the next stepped frame's first substep, AFTER reconcile — so a
             // body declared and commanded in the same frame works.
@@ -3808,6 +3820,38 @@ Color.rgb(r, g, b)"
             fail("let main = () => Color.rgb(1.0, \"x\", 0.0)"),
             "expected a number, got a string"
         );
+    }
+
+    // [strong-typing track] the physics tag brand has teeth at CHECK time:
+    // physics.funi types every tag parameter as the abstract `Physics.tag`,
+    // so a bare string is a build error. Runtime stays erased — a tag IS its
+    // string — so /state, the journal, and event-tag equality are unchanged.
+    #[test]
+    fn bare_strings_are_not_physics_tags() {
+        let dir =
+            std::env::temp_dir().join(format!("functor-physics-tag-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("game.fun"),
+            "let bad = () => Physics.position(\"ball\")\n\
+             let good = () => Physics.position(Physics.tag(\"ball\"))\n",
+        )
+        .unwrap();
+        let project = functor_lang::project::load_with_prelude(
+            &dir.join("game.fun"),
+            &Default::default(),
+            &functor_prelude::modules(),
+        )
+        .unwrap_or_else(|e| panic!("loads: {}", e.render()));
+        let diags: Vec<String> = project.check().into_iter().map(|d| d.message).collect();
+        assert_eq!(
+            diags,
+            vec![
+                "argument 1 of `Physics.position`: expected Physics.tag, got string".to_string()
+            ]
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     // A Color stored in the model is plain enough to survive hot reload —

--- a/site/docs.html
+++ b/site/docs.html
@@ -66,7 +66,7 @@ let draw = (m, tts: Float) =>
   Frame.create(
     Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0),
     Scene.cube()
-      |> Scene.emissive(1.0, 0.2, 0.8)
+      |> Scene.emissive(Color.rgb(1.0, 0.2, 0.8))
       |> Scene.rotateY(Angle.radians(tts)))</pre>
           <p>Run it:</p>
           <pre class="shell">functor -d . run native      # desktop window
@@ -108,7 +108,7 @@ let draw = (model, tts: Float) =>
   Frame.create(
     Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0),
     Scene.sphere()
-      |> Scene.emissive(1.0, 0.3, 0.8)
+      |> Scene.emissive(Color.rgb(1.0, 0.3, 0.8))
       |> Scene.scale(1.0 + 0.2 * Math.sin(model.spin * 4.0)))</pre>
           <p>
             Input is another pure function — slide the cube with A and D (click the preview
@@ -131,7 +131,7 @@ let draw = (model, tts) =>
   Frame.create(
     Camera.lookAt(0.0, 2.0, -8.0, 0.0, 0.0, 0.0),
     Scene.cube()
-      |> Scene.emissive(0.2, 0.9, 1.0)
+      |> Scene.emissive(Color.rgb(0.2, 0.9, 1.0))
       |> Scene.translate(model.x, 0.0, 0.0))</pre>
           <p>
             And physics is declarative — describe the bodies each frame; the runtime reconciles
@@ -153,15 +153,15 @@ let draw = (m, tts) =>
   Frame.createLit(
     Camera.lookAt(0.0, 3.0, -8.0, 0.0, 1.0, 0.0),
     Scene.group([
-      Scene.plane() |> Scene.scale(20.0) |> Scene.lit(0.4, 0.45, 0.55),
+      Scene.plane() |> Scene.scale(20.0) |> Scene.lit(Color.rgb(0.4, 0.45, 0.55)),
       Scene.sphere()
         |> Scene.scale(0.5)
-        |> Scene.lit(1.0, 0.4, 0.6)
+        |> Scene.lit(Color.rgb(1.0, 0.4, 0.6))
         |> Physics.transformed("ball"),
     ]),
     [
-      Light.ambient(0.15, 0.15, 0.2),
-      Light.directional(0.4, -1.0, 0.3, 1.0, 0.95, 0.9, 0.9) |> Light.castShadows,
+      Light.ambient(Color.rgb(0.15, 0.15, 0.2)),
+      Light.directional(0.4, -1.0, 0.3, Color.rgb(1.0, 0.95, 0.9), 0.9) |> Light.castShadows,
     ])</pre>
         </section>
 
@@ -326,9 +326,9 @@ let span = (a, b) =>
             <tbody>
               <tr><td><code>Scene.cube() / sphere() / cylinder() / quad() / plane()</code></td><td>primitives (zero args, enforced); <code>plane</code> lies in XZ (ground), <code>quad</code> in XY — a quad's front is +Z</td></tr>
               <tr><td><code>Scene.group([scene, …])</code></td><td>compose</td></tr>
-              <tr><td><code>scene |> Scene.color(r, g, b)</code></td><td>flat unlit color</td></tr>
-              <tr><td><code>scene |> Scene.lit(r, g, b)</code></td><td>diffuse + specular (needs lights)</td></tr>
-              <tr><td><code>scene |> Scene.emissive(r, g, b)</code></td><td>unlit glow</td></tr>
+              <tr><td><code>scene |> Scene.color(Color.rgb(r, g, b))</code></td><td>flat unlit color</td></tr>
+              <tr><td><code>scene |> Scene.lit(Color.rgb(r, g, b))</code></td><td>diffuse + specular (needs lights)</td></tr>
+              <tr><td><code>scene |> Scene.emissive(Color.rgb(r, g, b))</code></td><td>unlit glow</td></tr>
               <tr><td><code>scene |> Scene.translate(x, y, z)</code></td><td rowspan="3">transforms wrap outward: the <em>outer</em> call applies last in world space — <code>s |> rotateY(r) |> translate(x, 0.0, 0.0)</code> rotates in place, then moves</td></tr>
               <tr><td><code>scene |> Scene.rotateX/Y/Z(angle)</code></td></tr>
               <tr><td><code>scene |> Scene.scale(k)</code></td></tr>
@@ -345,9 +345,9 @@ let span = (a, b) =>
             <tbody>
               <tr><td><code>Camera.lookAt(ex, ey, ez, tx, ty, tz)</code></td><td>up = +Y, fov 45°</td></tr>
               <tr><td><code>Camera.firstPerson(ex, ey, ez, yaw, pitch, fov)</code></td><td>all three are Angles; yaw 0 / pitch 0 looks down +Z</td></tr>
-              <tr><td><code>Light.ambient(r, g, b)</code></td><td></td></tr>
-              <tr><td><code>Light.directional(dx, dy, dz, r, g, b, intensity)</code></td><td><code>|> Light.castShadows</code> for a shadowed key light</td></tr>
-              <tr><td><code>Light.point(px, py, pz, r, g, b, intensity, range)</code></td><td></td></tr>
+              <tr><td><code>Light.ambient(Color.rgb(r, g, b))</code></td><td></td></tr>
+              <tr><td><code>Light.directional(dx, dy, dz, Color.rgb(r, g, b), intensity)</code></td><td><code>|> Light.castShadows</code> for a shadowed key light</td></tr>
+              <tr><td><code>Light.point(px, py, pz, Color.rgb(r, g, b), intensity, range)</code></td><td></td></tr>
               <tr><td><code>Frame.create(camera, scene)</code></td><td>what <code>draw</code> returns</td></tr>
               <tr><td><code>Frame.createLit(camera, scene, [light, …])</code></td><td>lit + shadowed</td></tr>
             </tbody>

--- a/site/docs.html
+++ b/site/docs.html
@@ -140,11 +140,13 @@ let draw = (model, tts) =>
           <pre class="functor-lang runnable">let init = {}
 let tick = (m, dt, tts) => m
 
+let ballTag = Physics.tag("ball")
+
 let physics = (m) =>
   Physics.scene(0.0, -9.81, 0.0, [
-    Physics.fixed("ground", Physics.box(20.0, 0.4, 20.0))
+    Physics.fixed(Physics.tag("ground"), Physics.box(20.0, 0.4, 20.0))
       |> Physics.at(0.0, -0.2, 0.0),
-    Physics.dynamic("ball", Physics.sphere(0.5))
+    Physics.dynamic(ballTag, Physics.sphere(0.5))
       |> Physics.at(0.3, 4.0, 0.0)
       |> Physics.restitution(0.8),
   ])
@@ -157,7 +159,7 @@ let draw = (m, tts) =>
       Scene.sphere()
         |> Scene.scale(0.5)
         |> Scene.lit(Color.rgb(1.0, 0.4, 0.6))
-        |> Physics.transformed("ball"),
+        |> Physics.transformed(ballTag),
     ]),
     [
       Light.ambient(Color.rgb(0.15, 0.15, 0.2)),
@@ -382,11 +384,11 @@ let span = (a, b) =>
           <table>
             <tbody>
               <tr><td><code>Physics.box(w, h, d) / sphere(r) / capsule(halfH, r)</code></td><td>shapes; box takes <em>full</em> extents</td></tr>
-              <tr><td><code>Physics.dynamic("tag", shape)</code></td><td>simulated; also <code>kinematic</code> / <code>fixed</code></td></tr>
+              <tr><td><code>Physics.dynamic(tag, shape)</code></td><td>simulated; also <code>kinematic</code> / <code>fixed</code>; tags are <code>Physics.tag("name")</code> values</td></tr>
               <tr><td><code>body |> Physics.at(x, y, z)</code></td><td>spawn pose; also <code>velocity</code>, <code>mass</code>, <code>friction</code>, <code>restitution</code>, <code>sensor</code></td></tr>
               <tr><td><code>Physics.scene(gx, gy, gz, [body, …])</code></td><td>what the <code>physics</code> hook returns</td></tr>
-              <tr><td><code>Physics.position("tag")</code></td><td><code>{x, y, z}</code> of the live body</td></tr>
-              <tr><td><code>scene |> Physics.transformed("tag")</code></td><td>draw a scene at the body's live pose</td></tr>
+              <tr><td><code>Physics.position(tag)</code></td><td><code>{x, y, z}</code> of the live body</td></tr>
+              <tr><td><code>scene |> Physics.transformed(tag)</code></td><td>draw a scene at the body's live pose</td></tr>
             </tbody>
           </table>
           <p>

--- a/site/examples/hero.fun
+++ b/site/examples/hero.fun
@@ -20,7 +20,7 @@ let waveY = (t: float, ix: float, iz: float): float =>
 let dot = (t, ix, iz) =>
   let depth = iz / gridRows in
   Scene.cube()
-    |> Scene.emissive(1.0 - 0.4 * depth, 0.15 + 0.1 * depth, 0.85 - 0.2 * depth)
+    |> Scene.emissive(Color.rgb(1.0 - 0.4 * depth, 0.15 + 0.1 * depth, 0.85 - 0.2 * depth))
     |> Scene.rotateY(Angle.radians(t * 0.7 + ix + iz))
     |> Scene.scale(0.21 + 0.07 * Math.sin(t * 3.0 + ix * 0.9 + iz * 0.6))
     |> Scene.translate(
@@ -38,7 +38,7 @@ let grid = (t) =>
 // The retro sun, low over the horizon, breathing slowly.
 let sun = (t) =>
   Scene.sphere()
-    |> Scene.emissive(1.0, 0.36 + 0.08 * Math.sin(t * 1.7), 0.5)
+    |> Scene.emissive(Color.rgb(1.0, 0.36 + 0.08 * Math.sin(t * 1.7), 0.5))
     |> Scene.scale(6.5)
     |> Scene.translate(0.0, 3.2, 40.0)
 
@@ -47,14 +47,14 @@ let sun = (t) =>
 // +Z and the camera looks down +Z, so rotate it to face the viewer.
 let sky = () =>
   Scene.quad()
-    |> Scene.emissive(0.06, 0.015, 0.14)
+    |> Scene.emissive(Color.rgb(0.06, 0.015, 0.14))
     |> Scene.rotateY(Angle.degrees(180.0))
     |> Scene.scale(130.0)
     |> Scene.translate(0.0, 0.0, 55.0)
 
 let ground = () =>
   Scene.plane()
-    |> Scene.color(0.045, 0.01, 0.1)
+    |> Scene.color(Color.rgb(0.045, 0.01, 0.1))
     |> Scene.scale(90.0)
     |> Scene.translate(0.0, -0.9, 20.0)
 

--- a/site/src/ide.js
+++ b/site/src/ide.js
@@ -44,8 +44,8 @@ let draw = (model, tts: Float) =>
   Frame.create(
     Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.5, 0.0),
     Scene.group([
-      Scene.sphere() |> Scene.emissive(0.15, 1.0, Palette.glow) |> Scene.scale(1.4),
-      Scene.plane() |> Scene.scale(12.0) |> Scene.lit(Palette.sky, 0.12, 0.35),
+      Scene.sphere() |> Scene.emissive(Color.rgb(0.15, 1.0, Palette.glow)) |> Scene.scale(1.4),
+      Scene.plane() |> Scene.scale(12.0) |> Scene.lit(Color.rgb(Palette.sky, 0.12, 0.35)),
     ]))
 `,
     },

--- a/tools/functor-lang-wasm/src/lib.rs
+++ b/tools/functor-lang-wasm/src/lib.rs
@@ -637,7 +637,7 @@ mod tests {
     // resolves it — the reason the `_project` API exists.
     const GAME: &str = "let draw = (model, tts: Float) =>\n  \
         Frame.create(Camera.lookAt(0.0, 0.0, -6.0, 0.0, 0.0, 0.0), \
-        Scene.sphere() |> Scene.emissive(0.15, 1.0, Palette.glow))\n";
+        Scene.sphere() |> Scene.emissive(Color.rgb(0.15, 1.0, Palette.glow)))\n";
     const PALETTE: &str = "let glow = 0.85\nlet sky = 0.18\n";
 
     fn files_json(files: &[(&str, &str)]) -> String {

--- a/tools/functor-sdk/test/functor-lang-perf.e2e.test.ts
+++ b/tools/functor-sdk/test/functor-lang-perf.e2e.test.ts
@@ -69,12 +69,12 @@ let marker = (i: Float, tts: Float, r: Float, g: Float, b: Float) =>
   let p = pointPos(i, tts) in
   Scene.sphere()
     |> Scene.scale(0.15)
-    |> Scene.emissive(r, g, b)
+    |> Scene.emissive(Color.rgb(r, g, b))
     |> Scene.translate(p.x, p.y, p.z)
 
 let pointLight = (i: Float, tts: Float, r: Float, g: Float, b: Float) =>
   let p = pointPos(i, tts) in
-  Light.point(p.x, p.y, p.z, r, g, b, 1.4, 6.0)
+  Light.point(p.x, p.y, p.z, Color.rgb(r, g, b), 1.4, 6.0)
 
 // Spiral placement: radius and angle both derive from the index (no
 // mod/floor in the language yet); spin and bob derive from the phase.
@@ -92,14 +92,14 @@ let draw = (m, tts: Float) =>
       0.0, 9.0, -16.0,
       Angle.radians(0.0), Angle.radians(-0.5), Angle.degrees(60.0)),
     Scene.group([
-      Scene.plane() |> Scene.scale(30.0) |> Scene.lit(0.6, 0.6, 0.62),
-      m.entities |> List.map(shapeFor) |> Scene.group |> Scene.lit(0.9, 0.9, 0.9),
+      Scene.plane() |> Scene.scale(30.0) |> Scene.lit(Color.rgb(0.6, 0.6, 0.62)),
+      m.entities |> List.map(shapeFor) |> Scene.group |> Scene.lit(Color.rgb(0.9, 0.9, 0.9)),
       marker(0.0, tts, 1.0, 0.3, 0.25),
       marker(1.0, tts, 0.35, 0.5, 1.0),
     ]),
     [
-      Light.ambient(0.1, 0.1, 0.13),
-      Light.directional(0.5, -1.0, 0.35, 1.0, 0.98, 0.95, 0.85) |> Light.castShadows,
+      Light.ambient(Color.rgb(0.1, 0.1, 0.13)),
+      Light.directional(0.5, -1.0, 0.35, Color.rgb(1.0, 0.98, 0.95), 0.85) |> Light.castShadows,
       pointLight(0.0, tts, 1.0, 0.3, 0.25),
       pointLight(1.0, tts, 0.35, 0.5, 1.0),
     ])


### PR DESCRIPTION
## Summary

Third slice of the strong-typing track (stacked on #366): the Angle rule applied to color. `Color.rgb(r, g, b)` makes an opaque `Color.t`, and every color parameter — `Scene.color`/`lit`/`emissive`/`litNormalMapped`, all four `Light.*` constructors, `Fog.linear`/`exp`, `Frame.withClearColor`, `Ui.textColor` — takes a Color **value**, never three bare floats. Channel swaps and argument miscounts become unrepresentable, and colors become first-class: name a palette once (`let neonPink = Color.rgb(…)`) and reuse it across materials, lights, fog, and UI.

## Design

- `FunctorLangColor` follows the `Angle` HostData pattern exactly (newtype + `color_of` extractor). A bare number gets the teaching error ("wrap the channels: `Color.rgb(r, g, b)`"); the pre-Color three-float spelling gets the new usage line.
- **Reload-safe by design:** unlike the tagger-carrying host values, a Color is three module-independent floats, so it overrides `is_reload_safe_snapshot() → true` — a palette stored in the model does **not** invalidate hot-reload time-travel history (colors were plain floats before the brand; this preserves that behavior).
- New `color.funi` + PATHS entry (covered by the existing interface↔host drift test); `Color` joins the protected namespaces.

## Migration

All 22 examples, both CLI templates, the site's runnable examples and API-reference tables, the live-IDE hero snippet, the SDK perf fixture, the browser e2e fixtures (including the sandbox's edit-regex), and the `frame_bench` example — ~130 call sites.

## Validation

- **Golden-image test: 0 / 1,920,000 differing pixels per scenario** — the migration is proven render-identical.
- All crates green (`functor-lang`, `functor_runtime_common`, `functor-runtime-desktop`, `functor-cli`); web compiles for wasm32; every example passes `functor build`; `npm run test:site` passes; `frame_bench` runs.
- New tests: bare-number teaching error, old-spelling usage line, `Color.rgb` channel validation, and Color-in-model reload safety.
- Cross-engine adversarial review (Claude + Codex) ran; all findings addressed (e2e fixtures + edit-regex, frame_bench, the reload-safety regression, historical doc annotations) and re-validated.

The `functor-lang` skill and `docs/functor-lang.md` are updated in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)