### PR TITLE
fix(web): surface asset errors in the browser console + wasm soft-404 guard

### DIFF
--- a/e2e/remote-assets.mjs
+++ b/e2e/remote-assets.mjs
@@ -31,17 +31,20 @@
 //   - the browser issued a GET to the good URL and got 200 (URL passthrough +
 //     CORS + the fetch really fired inside the wasm runtime);
 //   - the browser issued a GET to the 404 URL and got 404;
-//   - the draw-error overlay is NOT showing afterward — the 404 degraded to the
-//     fallback asset; it did not hang the loop or panic the glTF pipeline.
+//   - (hermetic case) a "soft 404" — HTTP 200 whose body is an HTML error
+//     page — FAILS the load: the magic-byte guard refuses to feed HTML to the
+//     glTF parser (wasm parity with the native guard);
+//   - each failed asset shows up as a console.error — the web runtime's
+//     RuntimeEvent sink (a failed asset used to fall back to `eprintln!`,
+//     which goes nowhere in a browser: totally invisible);
+//   - the draw-error overlay is NOT showing afterward — failures degraded to
+//     the fallback asset; nothing hung the loop or panicked the glTF pipeline.
 //
-// Why observe the network rather than an in-page "loaded" signal: on wasm a
-// failed asset load emits a RuntimeEvent::AssetError that currently falls back
-// to `eprintln!` (events.rs) — which goes NOWHERE in a browser. So there is no
-// console signal for load success/failure today; the real fetch, seen by
-// Playwright, IS the ground truth (see the report for that observability gap).
-// This is intentionally an end-to-end NETWORK test, not a glTF-decode test:
-// decoding of local assets is already covered by the wasm golden suite; what
-// was untested is the remote URL round-trip in a real browser.
+// Network observation (Playwright response events) remains the ground truth
+// for "the fetch really happened"; the console signal is the ground truth for
+// "and a human/agent can SEE what failed". This is intentionally an
+// end-to-end NETWORK test, not a glTF-decode test: decoding of local assets
+// is already covered by the wasm golden suite.
 //
 // Optional live-CDN case: with FUNCTOR_REMOTE_E2E_NETWORK=1, also loads a real
 // asset from https://assets.babylonjs.com. OFF by default (needs the internet
@@ -81,9 +84,11 @@ function minimalGlb() {
   return Buffer.concat([header, chunkHeader, json]);
 }
 
-// A permissive-CORS "CDN": /model.glb serves a real glb; everything else 404s.
-// Every response carries Access-Control-Allow-Origin: * so the game page (a
-// different origin) can fetch cross-origin, and a 404 is CORS-visible too.
+// A permissive-CORS "CDN": /model.glb serves a real glb, /soft404.glb serves
+// the classic CDN failure — HTTP 200 with an HTML error page — and everything
+// else 404s. Every response carries Access-Control-Allow-Origin: * so the game
+// page (a different origin) can fetch cross-origin, and failures are
+// CORS-visible too.
 function startAssetServer() {
   const glb = minimalGlb();
   const server = http.createServer((req, res) => {
@@ -91,6 +96,9 @@ function startAssetServer() {
     if (req.url === "/model.glb") {
       res.writeHead(200, { "Content-Type": "model/gltf-binary" });
       res.end(glb);
+    } else if (req.url === "/soft404.glb") {
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.end("<html><body>totally not a model</body></html>");
     } else {
       res.writeHead(404, { "Content-Type": "text/plain" });
       res.end("not found");
@@ -136,18 +144,22 @@ function startBundleServer(dir) {
   });
 }
 
-// A temp Functor Lang project whose draw loads a good URL and a 404 URL, built into a
-// self-contained wasm bundle. Both assets fetch once (the asset handle is
-// cached), so the browser makes exactly one request per URL.
-function buildBundle(goodUrl, badUrl) {
+// A temp Functor Lang project whose draw loads a good URL, a 404 URL, and (when the
+// case provides one) a soft-404 URL, built into a self-contained wasm bundle.
+// Each asset fetches once (the asset handle is cached), so the browser makes
+// exactly one request per URL.
+function buildBundle(goodUrl, badUrl, softUrl) {
   const dir = mkdtempSync(join(tmpdir(), "functor-remote-e2e-"));
   writeFileSync(
     join(dir, "functor.json"),
     JSON.stringify({ language: "functor-lang", entry: "game.fun" }, null, 2),
   );
+  const soft = softUrl
+    ? `\n      Scene.model("${softUrl}") |> Scene.translate(0.0 - 3.0, 0.0, 0.0),`
+    : "";
   writeFileSync(
     join(dir, "game.fun"),
-    `// Generated e2e fixture: load one URL model that resolves and one that 404s.
+    `// Generated e2e fixture: URL models that resolve, 404, and soft-404.
 let init = { frame: 0.0 }
 
 let tick = (model, dt, tts) => { model with frame: model.frame + 1.0 }
@@ -157,7 +169,7 @@ let draw = (model, tts) =>
     Camera.lookAt(0.0, 2.0, 0.0 - 6.0, 0.0, 0.0, 0.0),
     Scene.group([
       Scene.model("${goodUrl}"),
-      Scene.model("${badUrl}") |> Scene.translate(3.0, 0.0, 0.0),
+      Scene.model("${badUrl}") |> Scene.translate(3.0, 0.0, 0.0),${soft}
     ]))
 `,
   );
@@ -171,8 +183,8 @@ let draw = (model, tts) =>
   return { dir, webDir: join(dir, "dist", "web") };
 }
 
-async function runCase({ goodUrl, badUrl, label }) {
-  const { dir, webDir } = buildBundle(goodUrl, badUrl);
+async function runCase({ goodUrl, badUrl, softUrl, label }) {
+  const { dir, webDir } = buildBundle(goodUrl, badUrl, softUrl);
   const { server: bundleServer, port: bundlePort } = await startBundleServer(webDir);
   const base = `http://127.0.0.1:${bundlePort}`;
   const browser = await chromium.launch({
@@ -194,7 +206,7 @@ async function runCase({ goodUrl, badUrl, label }) {
     // The ground truth: every response the browser actually received for a URL
     // the game asked for.
     page.on("response", (r) => {
-      if (r.url() === goodUrl || r.url() === badUrl) {
+      if (r.url() === goodUrl || r.url() === badUrl || r.url() === softUrl) {
         responses.push({ url: r.url(), status: r.status() });
       }
     });
@@ -231,6 +243,47 @@ async function runCase({ goodUrl, badUrl, label }) {
       throw new Error(`[${label}] 404 URL returned ${bad.status}, expected 404`);
     }
 
+    // Failed assets must be VISIBLE: the web runtime's RuntimeEvent sink turns
+    // each AssetError into a console.error naming the asset. (Before the sink,
+    // failures fell back to eprintln! — nothing in a browser.)
+    const assetError = (url) =>
+      log.some(
+        (m) => m.startsWith("error:") && m.includes(url) && m.includes("failed to load"),
+      );
+    if (!assetError(badUrl)) {
+      throw new Error(
+        `[${label}] no console.error for the 404 asset ${badUrl}. Log tail: ${log
+          .slice(-8)
+          .join(" | ")}`,
+      );
+    }
+
+    if (softUrl) {
+      const soft = responses.find((r) => r.url === softUrl);
+      if (!soft || soft.status !== 200) {
+        throw new Error(
+          `[${label}] soft-404 URL should have returned 200 (got ${soft?.status}) — the case needs a 200-with-HTML body`,
+        );
+      }
+      // The magic-byte guard must fail the load (HTML never reaches the glTF
+      // parser) and say so in the console.
+      if (!assetError(softUrl)) {
+        throw new Error(
+          `[${label}] no console.error for the soft-404 asset ${softUrl} — the wasm magic-byte guard did not reject the HTML body. Log tail: ${log
+            .slice(-8)
+            .join(" | ")}`,
+        );
+      }
+    }
+
+    // Nothing may have thrown uncaught in the page — a wasm panic surfaces as
+    // a pageerror, and a dead frame loop would otherwise pass the checks below
+    // silently.
+    const pageErrors = log.filter((m) => m.startsWith("pageerror:"));
+    if (pageErrors.length > 0) {
+      throw new Error(`[${label}] uncaught page error(s): ${pageErrors.join(" | ")}`);
+    }
+
     // The 404 must have degraded to the fallback asset — NOT crashed the frame
     // loop or the glTF pipeline. A persistent draw error leaves the red overlay
     // up; check it's hidden.
@@ -251,7 +304,9 @@ async function runCase({ goodUrl, badUrl, label }) {
     }
 
     console.log(
-      `PASS  ${label} — good ${good.status} (${goodUrl}), bad ${bad.status} (${badUrl}), overlay hidden`,
+      `PASS  ${label} — good ${good.status} (${goodUrl}), bad ${bad.status} (${badUrl})${
+        softUrl ? ", soft-404 rejected by magic guard" : ""
+      }, console errors present, overlay hidden`,
     );
   } finally {
     await browser.close();
@@ -271,6 +326,7 @@ async function main() {
       label: "hermetic (localhost CORS server)",
       goodUrl: `${origin}/model.glb`,
       badUrl: `${origin}/missing.glb`,
+      softUrl: `${origin}/soft404.glb`,
     });
   } catch (e) {
     failures++;

--- a/runtime/functor-runtime-common/src/io/mod.rs
+++ b/runtime/functor-runtime-common/src/io/mod.rs
@@ -55,10 +55,21 @@ pub async fn load_bytes_async2(path: String) -> Result<Vec<u8>, String> {
     #[cfg(target_arch = "wasm32")]
     {
         // fetch() takes relative paths (bundle-served files) and absolute
-        // http(s) URLs (CDN assets, CORS permitting) alike — no branch needed.
-        load_bytes_async(&path)
+        // http(s) URLs (CDN assets, CORS permitting) alike — no branch needed
+        // for the transfer itself...
+        let bytes = load_bytes_async(&path)
             .await
-            .map_err(|e| format!("{}: {}", path, e))
+            .map_err(|e| format!("{}: {}", path, e))?;
+        // ...but remote responses get the same soft-404 guard as native: a
+        // CDN answering HTTP 200 with an HTML error page must not reach the
+        // glTF/PNG parsers (they panic on garbage) — it fails the load, which
+        // routes to the fallback asset + an AssetError event instead. Local
+        // bundle files skip this (the pipelines sniff content, not extension,
+        // so a mislabeled-but-valid local file keeps working).
+        if is_remote_path(&path) {
+            verify_magic(&path, &bytes).map_err(|e| format!("{}: {}", path, e))?;
+        }
+        Ok(bytes)
     }
     #[cfg(not(target_arch = "wasm32"))]
     {
@@ -85,6 +96,60 @@ pub fn is_remote_path(path: &str) -> bool {
     path.starts_with("http://") || path.starts_with("https://")
 }
 
+/// Cheap magic-byte verification for the formats whose URLs we can recognize
+/// by extension, applied to every REMOTE asset body on both targets (natively
+/// in `remote::fetch`, on wasm after the browser fetch). Unknown extensions
+/// pass — this is a poisoning/soft-404 guard, not a general validator.
+fn verify_magic(url: &str, bytes: &[u8]) -> Result<(), String> {
+    // HTML is never a valid asset of ANY type, so an HTML body — the classic
+    // CDN error page — is rejected regardless of extension. This covers
+    // extensionless/API-style asset URLs the per-format checks below can't.
+    let stripped = bytes.strip_prefix(&[0xEF, 0xBB, 0xBF]).unwrap_or(bytes);
+    let body = stripped
+        .iter()
+        .position(|b| !b.is_ascii_whitespace())
+        .map(|start| &stripped[start..])
+        .unwrap_or(&[]);
+    let html = [&b"<!doctype"[..], &b"<html"[..]]
+        .iter()
+        .any(|prefix| body.len() >= prefix.len() && body[..prefix.len()].eq_ignore_ascii_case(prefix));
+    if html {
+        return Err("response body is an HTML page, not an asset — is the URL an error page?"
+            .to_string());
+    }
+    let path_part = url.split(['?', '#']).next().unwrap_or(url);
+    let ext = std::path::Path::new(path_part)
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    let ok = match ext.as_str() {
+        "glb" => bytes.starts_with(b"glTF"),
+        // A .gltf is JSON: first non-whitespace byte is '{' (some exporters
+        // prefix a UTF-8 BOM — skip it, it's still JSON).
+        "gltf" => bytes
+            .strip_prefix(&[0xEF, 0xBB, 0xBF])
+            .unwrap_or(bytes)
+            .iter()
+            .find(|b| !b.is_ascii_whitespace())
+            .map(|b| *b == b'{')
+            .unwrap_or(false),
+        "png" => bytes.starts_with(&[0x89, b'P', b'N', b'G']),
+        "jpg" | "jpeg" => bytes.starts_with(&[0xFF, 0xD8]),
+        _ => true,
+    };
+    if ok {
+        Ok(())
+    } else {
+        let head: Vec<u8> = bytes.iter().take(12).copied().collect();
+        Err(format!(
+            "response body is not {} (starts with {:?}) — is the URL an error page?",
+            ext,
+            String::from_utf8_lossy(&head)
+        ))
+    }
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 pub use remote::{set_remote_fetcher, RemoteFetchResult, RemoteFetchSender};
 
@@ -104,6 +169,8 @@ mod remote {
         path::{Path, PathBuf},
         sync::RwLock,
     };
+
+    use super::verify_magic;
 
     pub type RemoteFetchResult = Result<Vec<u8>, String>;
     pub type RemoteFetchSender = futures::channel::oneshot::Sender<RemoteFetchResult>;
@@ -148,40 +215,6 @@ mod remote {
         verify_magic(url, &bytes)?;
         cache_write(url, &bytes);
         Ok(bytes)
-    }
-
-    /// Cheap magic-byte verification for the formats whose URLs we can
-    /// recognize by extension. Unknown extensions pass — this is a poisoning
-    /// guard, not a general validator.
-    fn verify_magic(url: &str, bytes: &[u8]) -> Result<(), String> {
-        let path_part = url.split(['?', '#']).next().unwrap_or(url);
-        let ext = Path::new(path_part)
-            .extension()
-            .and_then(|e| e.to_str())
-            .unwrap_or("")
-            .to_ascii_lowercase();
-        let ok = match ext.as_str() {
-            "glb" => bytes.starts_with(b"glTF"),
-            // A .gltf is JSON: first non-whitespace byte is '{'.
-            "gltf" => bytes
-                .iter()
-                .find(|b| !b.is_ascii_whitespace())
-                .map(|b| *b == b'{')
-                .unwrap_or(false),
-            "png" => bytes.starts_with(&[0x89, b'P', b'N', b'G']),
-            "jpg" | "jpeg" => bytes.starts_with(&[0xFF, 0xD8]),
-            _ => true,
-        };
-        if ok {
-            Ok(())
-        } else {
-            let head: Vec<u8> = bytes.iter().take(12).copied().collect();
-            Err(format!(
-                "response body is not {} (starts with {:?}) — is the URL an error page?",
-                ext,
-                String::from_utf8_lossy(&head)
-            ))
-        }
     }
 
     fn cache_dir() -> Option<PathBuf> {
@@ -302,7 +335,9 @@ mod remote {
             let tx = stash.lock().unwrap().take().unwrap();
             tx.send(Ok(b"<html>not found</html>".to_vec())).unwrap();
             match poll_once(&mut fut3) {
-                Poll::Ready(Err(e)) => assert!(e.contains("not glb"), "error was: {e}"),
+                // The extension-independent HTML rejection fires before the
+                // per-format glb check for this body.
+                Poll::Ready(Err(e)) => assert!(e.contains("HTML page"), "error was: {e}"),
                 _ => panic!("expected Ready(Err(..)) for an HTML body"),
             }
             // Nothing new cached: only the good asset's entry exists.
@@ -317,13 +352,20 @@ mod remote {
             assert!(verify_magic("https://x/a.glb?v=2", GLB).is_ok());
             assert!(verify_magic("https://x/a.glb", b"<html>").is_err());
             assert!(verify_magic("https://x/a.gltf", b"  {\"asset\":{}}").is_ok());
+            // A UTF-8 BOM before the JSON is still a valid .gltf.
+            assert!(verify_magic("https://x/a.gltf", b"\xEF\xBB\xBF{\"asset\":{}}").is_ok());
             assert!(verify_magic("https://x/a.gltf", b"<html>").is_err());
             assert!(verify_magic("https://x/a.png", &[0x89, b'P', b'N', b'G', 1]).is_ok());
             assert!(verify_magic("https://x/a.png", b"nope").is_err());
             assert!(verify_magic("https://x/a.jpg", &[0xFF, 0xD8, 0xFF]).is_ok());
-            // Unknown extensions pass through unverified.
+            // Unknown extensions pass through unverified...
             assert!(verify_magic("https://x/a.bin", b"anything").is_ok());
             assert!(verify_magic("https://x/noext", b"anything").is_ok());
+            // ...EXCEPT an HTML body, which is never a valid asset of any
+            // type — extensionless/API-style URLs get soft-404 protection too.
+            assert!(verify_magic("https://x/api/asset/123", b"<!DOCTYPE html><html>").is_err());
+            assert!(verify_magic("https://x/noext", b"\n  <html><body>err</body>").is_err());
+            assert!(verify_magic("https://x/noext", b"\xEF\xBB\xBF<HTML>").is_err());
         }
     }
 }

--- a/runtime/functor-runtime-web/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-web/src/functor_lang_game.rs
@@ -302,6 +302,41 @@ impl FunctorLangWebGame {
         functor_lang::set_trace_sink(Box::new(|message| {
             web_sys::console::log_1(&JsValue::from_str(&message));
         }));
+        // Route runtime events to the browser console too. Without a sink they
+        // fall back to eprintln!, which goes nowhere in a browser — a failed
+        // asset was completely invisible (it just rendered as the fallback).
+        // AssetError is the load-bearing case: `Scene.model` on a missing or
+        // bad URL now says so in the console, where a dev (or a headless test)
+        // can see it.
+        functor_runtime_common::events::set_sink(Box::new(|event| {
+            use functor_runtime_common::events::RuntimeEvent as R;
+            match event {
+                R::AssetError { path, message } => {
+                    let line = match path {
+                        Some(path) => format!(
+                            "[functor] asset '{path}' failed to load; using fallback: {message}"
+                        ),
+                        None => {
+                            format!("[functor] asset failed to load; using fallback: {message}")
+                        }
+                    };
+                    web_sys::console::error_1(&JsValue::from_str(&line));
+                }
+                R::HotReload { ok, message } => {
+                    let line = format!("[functor] hot-reload: {message}");
+                    if ok {
+                        web_sys::console::log_1(&JsValue::from_str(&line));
+                    } else {
+                        web_sys::console::error_1(&JsValue::from_str(&line));
+                    }
+                }
+                R::FunctorLangTrace { message } => {
+                    web_sys::console::log_1(&JsValue::from_str(&message));
+                }
+                // CLI-stream concerns; quiet in the browser.
+                R::Ready | R::FrameStats { .. } | R::CaptureWritten { .. } => {}
+            }
+        }));
         let path = sources
             .first()
             .map(|(p, _)| p.clone())


### PR DESCRIPTION
## What

Closes both wasm gaps the browser e2e (#367) documented — a failed asset in the browser was **completely invisible**, and a CDN "soft 404" could feed HTML to the glTF parser:

- **Browser console sink for runtime events.** `RuntimeEvent` had no sink on wasm, so `AssetError` fell back to `eprintln!` (which goes nowhere in a browser) — a missing/bad URL asset just silently rendered as the fallback. The web producer now installs an events sink beside its existing `Debug.log` trace sink: asset failures and rejected hot-reloads are `console.error`, successful reloads and traces `console.log`, CLI-stream concerns (frame stats, capture notices) stay quiet.
- **Soft-404 magic-byte guard, wasm parity.** `verify_magic` (from the native remote path in #365) hoists to `io` scope and the wasm fetch arm applies it to **remote (URL) bodies**: HTTP 200 with an HTML error page now fails the load — fallback asset + a now-visible `AssetError` — instead of reaching the glTF parser's `.unwrap()`. Local bundle files are exempt: the pipelines sniff content rather than trusting extensions, so a mislabeled-but-valid local file keeps working exactly as before.

## Verification

The Playwright e2e grows a **soft-404 case** (localhost "CDN" serves `/soft404.glb` as 200-with-HTML) and **console assertions**: the run fails unless each failed asset produces a `console.error` naming it, the soft-404 is rejected before the parser, and the draw-error overlay stays hidden. Full run passes in headless Chromium:

```
PASS  hermetic (localhost CORS server) — good 200, bad 404, soft-404 rejected by magic guard, console errors present, overlay hidden
```

Also green: common io tests (magic verification, remote fetch flow), wasm target checks for both `functor_runtime_common` and `functor-runtime-web`.

Stacked on #367 (which is stacked on the merged #365).

🤖 Generated with [Claude Code](https://claude.com/claude-code)