### PR TITLE
feat(lang): brand physics body tags as Physics.tag

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -570,19 +570,28 @@ Ui.textInput(value, tagger)                                // INTERACTIVE contro
                                                            //   `examples/ui` showcases every
                                                            //   widget in one panel
 
+Physics.tag("name")                                        // BRANDED body identity (the
+                                                           //   RenderTarget rule): declare
+                                                           //   once, use the VALUE at every
+                                                           //   site. Check-time only — at
+                                                           //   runtime a tag IS its string
+                                                           //   (plain data; == with event
+                                                           //   tags works). A bare string
+                                                           //   where a tag goes is a check
+                                                           //   error
 Physics.box(w, h, d) / sphere(r) / capsule(halfH, r)       // -> Shape (box = FULL extents)
-Physics.dynamic("tag", shape)                              // simulated body
-Physics.kinematic("tag", shape) / Physics.fixed("tag", shape)
+Physics.dynamic(tag, shape)                                // simulated body
+Physics.kinematic(tag, shape) / Physics.fixed(tag, shape)
 body |> Physics.at(x, y, z)                                // body-last: pipes
 body |> Physics.velocity(vx, vy, vz)
 body |> Physics.mass(m) / Physics.friction(f) / Physics.restitution(r)
 body |> Physics.sensor                                     // overlap-only, no forces
 Physics.scene(gx, gy, gz, [body, …])                       // what `physics` returns
-Physics.position("tag")                                    // {x, y, z} of the LIVE body
-scene |> Physics.transformed("tag")                        // scene at the body's live pose
-Physics.applyImpulse("tag", x, y, z)                       // -> Effect (fire-and-forget)
-Physics.applyForce("tag", x, y, z)                         //   force lasts ONE stepped frame
-Physics.setVelocity("tag", x, y, z) / Physics.teleport("tag", x, y, z)
+Physics.position(tag)                                      // {x, y, z} of the LIVE body
+scene |> Physics.transformed(tag)                          // scene at the body's live pose
+Physics.applyImpulse(tag, x, y, z)                         // -> Effect (fire-and-forget)
+Physics.applyForce(tag, x, y, z)                           //   force lasts ONE stepped frame
+Physics.setVelocity(tag, x, y, z) / Physics.teleport(tag, x, y, z)
 Physics.raycast(ox, oy, oz, dx, dy, dz, maxDist, tagger)   // -> Effect (QUERY): tagger gets
                                                            //   {hit, x, y, z, nx, ny, nz,
                                                            //    distance, tag} — hit: false
@@ -601,7 +610,7 @@ Re-declaring an *unchanged* body leaves the simulation alone; *changing*
 its declared position teleports it (the divergence rule, docs/physics.md).
 
 Physics **command effects** are returned beside the model like any effect
-— `(model, Physics.applyImpulse("ball", 0.0, 5.0, 0.0))` — but carry no
+— `(model, Physics.applyImpulse(ballTag, 0.0, 5.0, 0.0))` — but carry no
 tagger: nothing folds back through `update`; observe outcomes via the
 physics reads. Commands queue at perform time and apply at the next
 stepped frame's first substep, **after reconcile** — so declaring a body
@@ -628,9 +637,10 @@ testable with no world at all.
 
 `Physics.events` is a **Sub** (return it from `subscriptions`, alone or in
 `Sub.batch`; it requires `update`). Every contact begin/end from this
-frame's physics step arrives post-step as `{started: bool, a: Text,
-b: Text, sensor: bool}` — `a`/`b` are the pair's tags in rapier's
-(deterministic) order, so check both; `sensor: true` marks an overlap with
+frame's physics step arrives post-step as `{started: bool, a: Physics.tag,
+b: Physics.tag, sensor: bool}` — `a`/`b` are the pair's tags in rapier's
+(deterministic) order, so check both (compare against your declared tag
+VALUES: `e.a == ballTag` — tags are strings underneath, so `==` works); `sensor: true` marks an overlap with
 a `Physics.sensor` body (no contact forces). Events for a pair whose body
 was despawned this frame are dropped (there is nothing left to name), and
 a frame's undelivered events never carry over.

--- a/docs/functor-lang.md
+++ b/docs/functor-lang.md
@@ -293,6 +293,21 @@ snapshots — no GPU, fully agent-verifiable.
       gets the new usage line. Colors are first-class: name a palette once
       (`let neonPink = Color.rgb(…)`) and reuse it across materials, lights,
       fog, and UI.
+- [x] **Branded physics tags (`Physics.tag`)** (2026-07-16; strong-typing
+      track). The RenderTarget rule applied to physics identity:
+      `Physics.tag("name")` makes an abstract `Physics.tag`, and every tag
+      site — `dynamic`/`kinematic`/`fixed` declarations, `position`/
+      `transformed` reads, the four command effects, and the tags inside
+      `rayHit`/`collisionEvent` records — carries the brand, so a bare
+      string is a check-time error. Like `Random.Seed` the brand is erased:
+      at runtime a tag IS its string (identity constructor), so tags stored
+      in the model stay plain data, `/state`/journal display is unchanged,
+      and event-tag equality (`e.a == ballTag`) keeps working structurally.
+      The declare-once idiom (`let ballTag = Physics.tag("ball")`) makes the
+      declaration/read/command sites share one value. Runtime semantics are
+      untouched (reads still error loud on unknown tags; commands still warn
+      quietly, since a body may legitimately despawn with a command in
+      flight — the brand retires the TYPO class at build time instead).
 - [x] **B7. Hindley–Milner inference** (done 2026-07-04; decided 2026-07-02; **after effects
       land** — B6 + the `effect[...]` header checking, so type inference and
       effect rows are designed against each other, not retrofitted). Upgrade

--- a/docs/physics.md
+++ b/docs/physics.md
@@ -128,15 +128,18 @@ commands, subs — but the shipping vocabulary is the Functor Lang prelude
 skill):
 
 ```functor
+let crateTag = Physics.tag("crate")            // branded identity: declared once,
+                                               // the VALUE used at every site
+
 let physics = (model) =>                       // OPTIONAL game hook
   Physics.scene(0.0, -9.81, 0.0, [
-    Physics.fixed("ground", Physics.box(20.0, 0.2, 20.0)),
-    Physics.dynamic("crate", Physics.box(1.0, 1.0, 1.0)) |> Physics.at(0.0, 5.0, 0.0),
+    Physics.fixed(Physics.tag("ground"), Physics.box(20.0, 0.2, 20.0)),
+    Physics.dynamic(crateTag, Physics.box(1.0, 1.0, 1.0)) |> Physics.at(0.0, 5.0, 0.0),
   ])
 
 let draw = (model, tts) =>
   Frame.create(camera,
-    Scene.cube() |> Scene.lit(Color.rgb(0.8, 0.5, 0.2)) |> Physics.transformed("crate"))
+    Scene.cube() |> Scene.lit(Color.rgb(0.8, 0.5, 0.2)) |> Physics.transformed(crateTag))
 ```
 
 Functor Lang dissolves the read-back boundary problem outright: the interpreter runs in
@@ -202,7 +205,8 @@ module PhysicsScene =
 ```
 
 **Commands — plain-data effects.** *Shipped (Phase 3) on the Functor Lang surface as B6
-effect variants* — `Physics.applyImpulse("tag", x, y, z)` etc., returned beside
+effect variants* — `Physics.applyImpulse(tag, x, y, z)` etc. (tags are branded
+`Physics.tag("name")` values), returned beside
 the model; tagger-less (outcomes are observed via the physics reads). Commands
 queue at perform time and apply **after the frame's reconcile, before its first
 substep** (so same-frame declare+command works); `applyForce` lasts exactly one

--- a/examples/physics/game.fun
+++ b/examples/physics/game.fun
@@ -29,7 +29,13 @@ let crateCount = 5.0
 let scatterX = (drop, i) => Math.sin(i * 12.9898 + drop * 3.7) * 1.6
 let scatterZ = (drop, i) => Math.cos(i * 78.2330 + drop * 1.3) * 1.6
 
-let crateTag = (i) => Text.concat("crate-", Text.fromFloat(i))
+// Branded body identities — declared once, used as the VALUE at every site
+// (declaration, reads, commands, event comparisons). noTag is the "ball not
+// involved" sentinel matching the engine's zeroed-miss convention.
+let groundTag = Physics.tag("ground")
+let ballTag = Physics.tag("ball")
+let noTag = Physics.tag("")
+let crateTag = (i) => Physics.tag(Text.concat("crate-", Text.fromFloat(i)))
 
 let crateBody = (drop, i) =>
   Physics.dynamic(crateTag(i), Physics.box(1.0, 1.0, 1.0))
@@ -44,11 +50,11 @@ let crateBody = (drop, i) =>
 // resting bodies.
 let bodyAt = (drop, i) =>
   match i with
-  | 0.0 => Physics.fixed("ground", Physics.box(24.0, 0.4, 24.0)) |> Physics.at(0.0, -0.2, 0.0)
+  | 0.0 => Physics.fixed(groundTag, Physics.box(24.0, 0.4, 24.0)) |> Physics.at(0.0, -0.2, 0.0)
   | 1.0 =>
     // Nearly-vertical drop beside the crates (the small drop-dependent wobble
     // keeps SPACE's re-drop teleport firing), so the ball settles in frame.
-    (Physics.dynamic("ball", Physics.sphere(0.6))
+    (Physics.dynamic(ballTag, Physics.sphere(0.6))
       |> Physics.at(3.2 + scatterX(drop, 9.0) * 0.2, 5.5, 0.5 + scatterZ(drop, 9.0) * 0.2)
       |> Physics.restitution(0.55))
   | n => crateBody(drop, n - 2.0)
@@ -73,7 +79,7 @@ type Msg<'h, 'e> =
   | GotHit(hit: 'h)
   | Contact(ev: 'e)
 
-let init = { drop: 0.0, spaceHeld: false, hot: "" }
+let init = { drop: 0.0, spaceHeld: false, hot: noTag }
 
 let tick = (model, dt, tts) => model
 
@@ -93,7 +99,7 @@ let input = (model, key, isDown) =>
   | Key.K =>
     (match isDown with
      | true => model
-     | false => (model, Physics.applyImpulse("ball", -2.6, 5.0, -0.4)))
+     | false => (model, Physics.applyImpulse(ballTag, -2.6, 5.0, -0.4)))
   | Key.R =>
     (match isDown with
      | true => model
@@ -107,14 +113,14 @@ let input = (model, key, isDown) =>
   | _ => model
 
 // Contact events name both tags in rapier's pair order — find the ball's
-// partner (or "" when the ball isn't involved).
+// partner (or noTag when the ball isn't involved).
 let otherOf = (e) =>
-  match e.a == "ball" with
+  match e.a == ballTag with
   | true => e.b
   | false =>
-    (match e.b == "ball" with
+    (match e.b == ballTag with
      | true => e.a
-     | false => "")
+     | false => noTag)
 
 let subscriptions = (model) => Physics.events(Contact)
 
@@ -128,7 +134,7 @@ let update = (model, msg) =>
     (match hit.hit with
      | false => model
      | true =>
-       (match hit.tag == "ground" with
+       (match hit.tag == groundTag with
         | true => model
         | false => (model, Physics.applyImpulse(hit.tag, 0.0, 6.0, 0.0))))
   | Contact(e) =>
@@ -136,11 +142,11 @@ let update = (model, msg) =>
      | false => model
      | true =>
        let other = otherOf(e) in
-       (match other == "" with
+       (match other == noTag with
         | true => model
         | false =>
           // Touching the slab isn't interesting — only crates glow.
-          (match other == "ground" with
+          (match other == groundTag with
            | true => model
            | false => { model with hot: other })))
 
@@ -149,7 +155,7 @@ let draw = (model, tts) =>
     Camera.lookAt(10.5, 7.5, -10.5, 0.0, 0.8, 0.0),
     Scene.group([
       Scene.plane() |> Scene.scale(24.0) |> Scene.lit(Color.rgb(0.55, 0.58, 0.62)),
-      Scene.sphere() |> Scene.scale(0.6) |> Scene.lit(Color.rgb(0.95, 0.35, 0.25)) |> Physics.transformed("ball"),
+      Scene.sphere() |> Scene.scale(0.6) |> Scene.lit(Color.rgb(0.95, 0.35, 0.25)) |> Physics.transformed(ballTag),
       Scene.group(List.range(crateCount) |> List.map((i) => crateVisual(model, i))),
     ]),
     [

--- a/functor-prelude/prelude/physics.funi
+++ b/functor-prelude/prelude/physics.funi
@@ -11,6 +11,13 @@
 type shape
 type body
 type world
+// The branded body identity — the RenderTarget rule applied to physics
+// identity. Made ONCE by `Physics.tag("name")` and used as the VALUE at
+// every site: declaration, reads, commands, and the tags inside `rayHit` /
+// `collisionEvent`. At runtime a tag is still the plain string (plain data:
+// journal, /state, and structural equality with event tags all unchanged) —
+// the brand is check-time only, like `Random.Seed`.
+type tag
 
 // The record `Physics.position` returns — the live pose of a body.
 type position = { x: float, y: float, z: float }
@@ -21,10 +28,14 @@ type rayHit = {
   x: float, y: float, z: float,
   nx: float, ny: float, nz: float,
   distance: float,
-  tag: string
+  tag: tag
 }
 // The record a `Physics.events` tagger receives, one per contact begin/end.
-type collisionEvent = { started: bool, a: string, b: string, sensor: bool }
+type collisionEvent = { started: bool, a: tag, b: tag, sensor: bool }
+
+// The tag constructor (identity at runtime; the empty tag is the zeroed
+// rayHit-miss / "no body" sentinel).
+let tag : (string) => tag
 
 // Shapes.
 let box : (float, float, float) => shape
@@ -32,12 +43,12 @@ let sphere : (float) => shape
 let capsule : (float, float) => shape
 
 // Bodies (tag, shape).
-let dynamic : (string, shape) => body
-let kinematic : (string, shape) => body
-let fixed : (string, shape) => body
+let dynamic : (tag, shape) => body
+let kinematic : (tag, shape) => body
+let fixed : (tag, shape) => body
 
 // body LAST (subject-last), so they pipe:
-// `Physics.dynamic("crate", Physics.box(1.0, 1.0, 1.0)) |> Physics.at(0.0, 5.0, 0.0)`.
+// `Physics.dynamic(crateTag, Physics.box(1.0, 1.0, 1.0)) |> Physics.at(0.0, 5.0, 0.0)`.
 let at : (float, float, float, body) => body
 let velocity : (float, float, float, body) => body
 let mass : (float, body) => body
@@ -49,17 +60,17 @@ let sensor : (body) => body
 let scene : (float, float, float, List<body>) => world
 
 // Reads of the LIVE stepped world (in-process, no boundary).
-let position : (string) => position
+let position : (tag) => position
 
 // world LAST (subject-last), so it pipes: place a visual at a body's live pose —
-// `Scene.cube() |> Physics.transformed("crate-1")`.
-let transformed : (string, Scene.t) => Scene.t
+// `Scene.cube() |> Physics.transformed(crateTag)`.
+let transformed : (tag, Scene.t) => Scene.t
 
 // Command EFFECTS (tag, x, y, z).
-let applyImpulse : (string, float, float, float) => Effect.t
-let applyForce : (string, float, float, float) => Effect.t
-let setVelocity : (string, float, float, float) => Effect.t
-let teleport : (string, float, float, float) => Effect.t
+let applyImpulse : (tag, float, float, float) => Effect.t
+let applyForce : (tag, float, float, float) => Effect.t
+let setVelocity : (tag, float, float, float) => Effect.t
+let teleport : (tag, float, float, float) => Effect.t
 
 // Query EFFECT: ox, oy, oz, dx, dy, dz, maxDist, tagger.
 let raycast : (float, float, float, float, float, float, float, (rayHit) => 'msg) => Effect.t

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -947,6 +947,7 @@ const PATHS: &[&str] = &[
     "Effect.now",
     "Effect.random",
     "Effect.batch",
+    "Physics.tag",
     "Physics.box",
     "Physics.sphere",
     "Physics.capsule",
@@ -1545,6 +1546,17 @@ the game dir",
             // Shapes are values, bodies are tag + shape + piped attributes,
             // and the optional game hook `physics = (model) => Physics.scene(…)`
             // declares the world each frame.
+            //
+            // `Physics.tag` is the branded body identity — check-time only
+            // (physics.funi types it as the abstract `Physics.tag`), so at
+            // runtime a tag IS its string: identity here, plain data in the
+            // model/journal, and structurally comparable with the tags inside
+            // rayHit/collisionEvent records. The empty tag is the zeroed
+            // rayHit-miss / "no body" sentinel, so no non-empty validation.
+            "Physics.tag" => match args.as_slice() {
+                [Value::String(_)] => Ok(args[0].clone()),
+                _ => usage("Physics.tag(\"name\")"),
+            },
             "Physics.box" => match args.as_slice() {
                 [w, h, d] => Ok(host(FunctorLangShape(physics::Shape::Cuboid {
                     extents: [
@@ -1585,7 +1597,7 @@ the game dir",
                 _ => usage(&format!("{path}(tag, shape)")),
             },
             // Body LAST (subject-last), so they pipe:
-            // `Physics.dynamic("crate", Physics.box(1.0, 1.0, 1.0)) |> Physics.at(0.0, 5.0, 0.0)`.
+            // `Physics.dynamic(crateTag, Physics.box(1.0, 1.0, 1.0)) |> Physics.at(0.0, 5.0, 0.0)`.
             "Physics.at" | "Physics.velocity" => match args.as_slice() {
                 [x, y, z, body] => match body_of(body) {
                     Some(inner) => {
@@ -1672,11 +1684,11 @@ the game dir",
                 _ => usage("Physics.position(tag)"),
             },
             // Scene LAST (subject-last), so it pipes: the way Functor Lang draws a physics body —
-            // `Scene.cube() |> Scene.lit(…) |> Physics.transformed("crate-1")`
+            // `Scene.cube() |> Scene.lit(…) |> Physics.transformed(crateTag)`
             // places the visual at the body's live pose (position + rotation).
             // Command EFFECTS (docs/physics.md Phase 3): fire-and-forget,
             // returned beside the model like any effect —
-            // `(model, Physics.applyImpulse("ball", 0.0, 5.0, 0.0))`.
+            // `(model, Physics.applyImpulse(ballTag, 0.0, 5.0, 0.0))`.
             // Performing one queues it on the singleton world; it applies at
             // the next stepped frame's first substep, AFTER reconcile — so a
             // body declared and commanded in the same frame works.
@@ -3808,6 +3820,38 @@ Color.rgb(r, g, b)"
             fail("let main = () => Color.rgb(1.0, \"x\", 0.0)"),
             "expected a number, got a string"
         );
+    }
+
+    // [strong-typing track] the physics tag brand has teeth at CHECK time:
+    // physics.funi types every tag parameter as the abstract `Physics.tag`,
+    // so a bare string is a build error. Runtime stays erased — a tag IS its
+    // string — so /state, the journal, and event-tag equality are unchanged.
+    #[test]
+    fn bare_strings_are_not_physics_tags() {
+        let dir =
+            std::env::temp_dir().join(format!("functor-physics-tag-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("game.fun"),
+            "let bad = () => Physics.position(\"ball\")\n\
+             let good = () => Physics.position(Physics.tag(\"ball\"))\n",
+        )
+        .unwrap();
+        let project = functor_lang::project::load_with_prelude(
+            &dir.join("game.fun"),
+            &Default::default(),
+            &functor_prelude::modules(),
+        )
+        .unwrap_or_else(|e| panic!("loads: {}", e.render()));
+        let diags: Vec<String> = project.check().into_iter().map(|d| d.message).collect();
+        assert_eq!(
+            diags,
+            vec![
+                "argument 1 of `Physics.position`: expected Physics.tag, got string".to_string()
+            ]
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     // A Color stored in the model is plain enough to survive hot reload —

--- a/site/docs.html
+++ b/site/docs.html
@@ -140,11 +140,13 @@ let draw = (model, tts) =>
           <pre class="functor-lang runnable">let init = {}
 let tick = (m, dt, tts) => m
 
+let ballTag = Physics.tag("ball")
+
 let physics = (m) =>
   Physics.scene(0.0, -9.81, 0.0, [
-    Physics.fixed("ground", Physics.box(20.0, 0.4, 20.0))
+    Physics.fixed(Physics.tag("ground"), Physics.box(20.0, 0.4, 20.0))
       |> Physics.at(0.0, -0.2, 0.0),
-    Physics.dynamic("ball", Physics.sphere(0.5))
+    Physics.dynamic(ballTag, Physics.sphere(0.5))
       |> Physics.at(0.3, 4.0, 0.0)
       |> Physics.restitution(0.8),
   ])
@@ -157,7 +159,7 @@ let draw = (m, tts) =>
       Scene.sphere()
         |> Scene.scale(0.5)
         |> Scene.lit(Color.rgb(1.0, 0.4, 0.6))
-        |> Physics.transformed("ball"),
+        |> Physics.transformed(ballTag),
     ]),
     [
       Light.ambient(Color.rgb(0.15, 0.15, 0.2)),
@@ -382,11 +384,11 @@ let span = (a, b) =>
           <table>
             <tbody>
               <tr><td><code>Physics.box(w, h, d) / sphere(r) / capsule(halfH, r)</code></td><td>shapes; box takes <em>full</em> extents</td></tr>
-              <tr><td><code>Physics.dynamic("tag", shape)</code></td><td>simulated; also <code>kinematic</code> / <code>fixed</code></td></tr>
+              <tr><td><code>Physics.dynamic(tag, shape)</code></td><td>simulated; also <code>kinematic</code> / <code>fixed</code>; tags are <code>Physics.tag("name")</code> values</td></tr>
               <tr><td><code>body |> Physics.at(x, y, z)</code></td><td>spawn pose; also <code>velocity</code>, <code>mass</code>, <code>friction</code>, <code>restitution</code>, <code>sensor</code></td></tr>
               <tr><td><code>Physics.scene(gx, gy, gz, [body, …])</code></td><td>what the <code>physics</code> hook returns</td></tr>
-              <tr><td><code>Physics.position("tag")</code></td><td><code>{x, y, z}</code> of the live body</td></tr>
-              <tr><td><code>scene |> Physics.transformed("tag")</code></td><td>draw a scene at the body's live pose</td></tr>
+              <tr><td><code>Physics.position(tag)</code></td><td><code>{x, y, z}</code> of the live body</td></tr>
+              <tr><td><code>scene |> Physics.transformed(tag)</code></td><td>draw a scene at the body's live pose</td></tr>
             </tbody>
           </table>
           <p>


### PR DESCRIPTION
## Summary

Fourth slice of the strong-typing track (stacked on #369): the RenderTarget rule applied to physics identity. `Physics.tag("name")` makes an abstract `Physics.tag`, and every tag site — `dynamic`/`kinematic`/`fixed` declarations, `position`/`transformed` reads, the four command effects, and the tags inside the `rayHit` / `collisionEvent` records — carries the brand, so a bare string where a tag goes is a **check-time error**. The declare-once idiom makes declaration, reads, commands, and event comparisons share one value: `let ballTag = Physics.tag("ball")`.

## Design

- **Erased brand (the `Random.Seed` pattern), deliberately not HostData.** At runtime a tag IS its string — the constructor is identity, one new host arm. That keeps tags stored in the model plain data for time-travel snapshots and hot-reload, keeps `/state`/journal display unchanged, and keeps event-tag equality (`e.a == ballTag`) working structurally. The empty tag remains the zeroed rayHit-miss / "no body" sentinel, so there is no non-empty validation.
- **Runtime semantics untouched.** Reads still error loud on an unknown tag; commands still warn quietly (a body may legitimately despawn with a command in flight). The brand retires the typo class at build time instead of changing the runtime's failure model.
- Record fields are branded too, so `hit.tag == "ground"` (a string literal) is now a check error — compare against your declared tag values instead.

## Migration

`examples/physics` (including its `""` sentinel → `noTag`, and the dynamic `crateTag(i)` builder wrapping its `Text.concat`) and the site's runnable physics example + API table.

## Validation

- New test loads the real prelude and asserts the check-time diagnostic (`argument 1 of \`Physics.position\`: expected Physics.tag, got string`); the `.funi`↔PATHS drift test covers the new entry.
- `functor-lang` + `functor_runtime_common` suites green; `examples/physics` passes `functor build` and renders correctly via headless capture.
- Cross-engine adversarial review (Claude + Codex): **no correctness defects**; both engines' doc-comment findings applied.

The `functor-lang` skill, `docs/physics.md`, and `docs/functor-lang.md` are updated in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)