### PR TITLE
feat(lang): brand spatial vectors as an opaque Vec3 value

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -190,7 +190,7 @@ let grab = (s) =>
   that creates no cycle.
 - **Protected namespaces**: a file whose module name collides with a
   builtin/prelude namespace (Net, Key, Random, List, Text, Math, Debug, Scene,
-  Anim, Camera, Frame, Light, Fog, Color, Skybox, Angle, Texture, Time, Sub,
+  Anim, Camera, Frame, Light, Fog, Color, Vec3, Skybox, Angle, Texture, Time, Sub,
   Effect, Physics, RenderTarget, Ui, AudioSource, AudioScene) is a load
   error — rename the file.
 - **`Net` is a built-in module**, always in scope: `type NetEvent =
@@ -387,6 +387,12 @@ Color.rgb(r, g, b)                                         // Color VALUES only 
                                                            //   Angle rule): every color
                                                            //   parameter below takes one —
                                                            //   never three bare floats
+Vec3.make(x, y, z)                                         // Vec3 VALUES only: every
+                                                           //   position/direction/velocity/
+                                                           //   gravity parameter below takes
+                                                           //   one. Reads (Physics.position,
+                                                           //   rayHit) still hand back plain
+                                                           //   {x, y, z} records
 scene |> Scene.color(color)                                // scene-last: pipes
 scene |> Scene.lit(color)                                  // diffuse+specular
 scene |> Scene.litNormalMapped(color, normalTex)           // + tangent-space
@@ -395,7 +401,7 @@ scene |> Scene.litNormalMapped(color, normalTex)           // + tangent-space
                                                            //   bumps catch the
                                                            //   lights/specular
 scene |> Scene.emissive(color)                             // unlit glow
-scene |> Scene.translate(x, y, z)
+scene |> Scene.translate(v)
 scene |> Scene.rotateX(angle) / rotateY / rotateZ          // Angle VALUES only:
 Angle.degrees(60.0) / Angle.radians(1.57)                  //   never bare numbers
 scene |> Scene.scale(k)                                    // uniform
@@ -456,11 +462,11 @@ anim |> Anim.rotate("jointName", ax, ay, az)               // additive local XYZ
                                                            //   fully driven (masks BENEATH
                                                            //   this node can't drop it; an
                                                            //   enclosing mask still can)
-Camera.lookAt(ex, ey, ez, tx, ty, tz)                      // up=+Y, fov 45°
-Camera.firstPerson(ex, ey, ez, yaw, pitch, fov)           // all three: Angles
-Light.ambient(color) / Light.point(px, py, pz, color, intensity, range)
-Light.directional(dx, dy, dz, color, intensity) |> Light.castShadows
-Light.spot(px, py, pz, dx, dy, dz, color, intensity, range, coneAngle)
+Camera.lookAt(eye, target)                                 // two Vec3s; up=+Y, fov 45°
+Camera.firstPerson(eye, yaw, pitch, fov)                   // Vec3 eye; Angles for the rest
+Light.ambient(color) / Light.point(pos, color, intensity, range)
+Light.directional(dir, color, intensity) |> Light.castShadows
+Light.spot(pos, dir, color, intensity, range, coneAngle)
                                                            // cone from pos
                                                            //   along dir;
                                                            //   coneAngle is an
@@ -517,12 +523,12 @@ Effect.send(connId, text)                                  // send on an open co
 Effect.none() / Effect.batch([fx, …])                      //   random: [0,1); now: epoch secs
 
 Effect.play(sound)                                         // one-shot: fire-and-forget,
-Effect.playAt(sound, x, y, z)                              //   non-spatial / positioned
+Effect.playAt(sound, pos)                                  //   non-spatial / positioned
 Effect.playThen(sound, msg)                                // one-shot; delivers msg (a VALUE,
                                                            //   not a tagger) through `update`
                                                            //   when the sound FINISHES
 AudioSource.ambient(key, sound)                            // soundScape voice: non-spatial bed
-AudioSource.at(key, sound, x, y, z)                        //   / positioned emitter (key =
+AudioSource.at(key, sound, pos)                            //   / positioned emitter (key =
                                                            //   cross-frame identity)
 source |> AudioSource.gain(g)                              // source-last: linear gain (1.0=full)
 AudioScene.create([source, …]) / AudioScene.empty()       // what `soundScape` returns
@@ -582,17 +588,17 @@ Physics.tag("name")                                        // BRANDED body ident
 Physics.box(w, h, d) / sphere(r) / capsule(halfH, r)       // -> Shape (box = FULL extents)
 Physics.dynamic(tag, shape)                                // simulated body
 Physics.kinematic(tag, shape) / Physics.fixed(tag, shape)
-body |> Physics.at(x, y, z)                                // body-last: pipes
-body |> Physics.velocity(vx, vy, vz)
+body |> Physics.at(v)                                      // body-last: pipes
+body |> Physics.velocity(v)
 body |> Physics.mass(m) / Physics.friction(f) / Physics.restitution(r)
 body |> Physics.sensor                                     // overlap-only, no forces
-Physics.scene(gx, gy, gz, [body, …])                       // what `physics` returns
+Physics.scene(gravity, [body, …])                          // what `physics` returns
 Physics.position(tag)                                      // {x, y, z} of the LIVE body
 scene |> Physics.transformed(tag)                          // scene at the body's live pose
-Physics.applyImpulse(tag, x, y, z)                         // -> Effect (fire-and-forget)
-Physics.applyForce(tag, x, y, z)                           //   force lasts ONE stepped frame
-Physics.setVelocity(tag, x, y, z) / Physics.teleport(tag, x, y, z)
-Physics.raycast(ox, oy, oz, dx, dy, dz, maxDist, tagger)   // -> Effect (QUERY): tagger gets
+Physics.applyImpulse(tag, v)                               // -> Effect (fire-and-forget)
+Physics.applyForce(tag, v)                                 //   force lasts ONE stepped frame
+Physics.setVelocity(tag, v) / Physics.teleport(tag, v)
+Physics.raycast(origin, dir, maxDist, tagger)              // -> Effect (QUERY): tagger gets
                                                            //   {hit, x, y, z, nx, ny, nz,
                                                            //    distance, tag} — hit: false
                                                            //   (zeroed) for a miss
@@ -610,7 +616,7 @@ Re-declaring an *unchanged* body leaves the simulation alone; *changing*
 its declared position teleports it (the divergence rule, docs/physics.md).
 
 Physics **command effects** are returned beside the model like any effect
-— `(model, Physics.applyImpulse(ballTag, 0.0, 5.0, 0.0))` — but carry no
+— `(model, Physics.applyImpulse(ballTag, Vec3.make(0.0, 5.0, 0.0)))` — but carry no
 tagger: nothing folds back through `update`; observe outcomes via the
 physics reads. Commands queue at perform time and apply at the next
 stepped frame's first substep, **after reconcile** — so declaring a body
@@ -675,7 +681,7 @@ let update = (model, msg) => model'         // OPTIONAL; msgs are ADT variants
                                             // second element is an Effect value
 let subscriptions = (model) => Sub.every(Time.seconds(1.0), Beat)
                                             // OPTIONAL, but requires update
-let physics = (model) => Physics.scene(0.0, -9.81, 0.0, [body, …])  // OPTIONAL
+let physics = (model) => Physics.scene(Vec3.make(0.0, -9.81, 0.0), [body, …])  // OPTIONAL
 let ui = (model) => Ui.column([…]) |> Ui.panel(Ui.topLeft())  // OPTIONAL; the 2D HUD,
                                             // drawn over the frame. Ui.button clicks
                                             // arrive as msgs through `update`
@@ -753,7 +759,7 @@ loud `[functor-lang] reload:` warning). First-class variant constructors
 stored in the model likewise adopt the edited declaration's arity.
 
 Transforms wrap in Group nodes: the **outer call applies last in world
-space** — `s |> Scene.rotateY(r) |> Scene.translate(x, 0.0, 0.0)` rotates in
+space** — `s |> Scene.rotateY(r) |> Scene.translate(Vec3.make(x, 0.0, 0.0))` rotates in
 place, then moves (the order the source reads). Engine values (`<Scene>`,
 `<Camera>`, `<Frame>`) are opaque: they can be passed around but not
 inspected, compared, or serialized.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ let draw = (model, tts) => Frame.create(camera, scene)
 let input = (model, key, isDown) => model'         // OPTIONAL; key: Key.t (Key.W, Key.Up, …)
 let update = (model, msg) => model'                // OPTIONAL; msgs are ADT variants
 let subscriptions = (model) => Sub.every(Time.seconds(1.0), Beat)  // OPTIONAL timers
-let physics = (model) => Physics.scene(0.0, -9.81, 0.0, [body, …]) // OPTIONAL
+let physics = (model) => Physics.scene(Vec3.make(0.0, -9.81, 0.0), [body, …]) // OPTIONAL
 let soundScape = (model) => AudioScene.create([source, …])         // OPTIONAL looping audio
 ```
 

--- a/cli/templates/3d/game.fun
+++ b/cli/templates/3d/game.fun
@@ -10,22 +10,22 @@ let tick = (model, dt, tts) => model
 
 let draw = (model, tts) =>
   Frame.createLit(
-    Camera.lookAt(6.0, 4.0, -8.0, 0.0, 0.5, 0.0),
+    Camera.lookAt(Vec3.make(6.0, 4.0, -8.0), Vec3.make(0.0, 0.5, 0.0)),
     Scene.group([
       Scene.plane()
         |> Scene.scale(20.0)
         |> Scene.lit(Color.rgb(0.35, 0.38, 0.42)),
       Scene.cube()
         |> Scene.rotateY(Angle.radians(tts * 0.5))
-        |> Scene.translate(0.0, 0.75, 0.0)
+        |> Scene.translate(Vec3.make(0.0, 0.75, 0.0))
         |> Scene.lit(Color.rgb(0.25, 0.65, 1.0)),
       Scene.sphere()
         |> Scene.scale(0.55)
-        |> Scene.translate(-2.0, 0.55, 1.0)
+        |> Scene.translate(Vec3.make(-2.0, 0.55, 1.0))
         |> Scene.lit(Color.rgb(1.0, 0.35, 0.25)),
     ]),
     [
       Light.ambient(Color.rgb(0.12, 0.12, 0.16)),
-      Light.directional(0.5, -1.0, 0.35, Color.rgb(1.0, 0.96, 0.9), 1.0)
+      Light.directional(Vec3.make(0.5, -1.0, 0.35), Color.rgb(1.0, 0.96, 0.9), 1.0)
         |> Light.castShadows,
     ])

--- a/cli/templates/fps/game.fun
+++ b/cli/templates/fps/game.fun
@@ -61,13 +61,13 @@ let tick = (model, dt, tts) =>
 
 let target = (x, z, r, g, b) =>
   Scene.cube()
-    |> Scene.translate(x, 0.75, z)
+    |> Scene.translate(Vec3.make(x, 0.75, z))
     |> Scene.lit(Color.rgb(r, g, b))
 
 let draw = (model, tts) =>
   Frame.createLit(
     Camera.firstPerson(
-      model.eye.x, model.eye.y, model.eye.z,
+      Vec3.make(model.eye.x, model.eye.y, model.eye.z),
       Angle.radians(model.yaw), Angle.radians(model.pitch), Angle.degrees(70.0)),
     Scene.group([
       Scene.plane() |> Scene.scale(40.0) |> Scene.lit(Color.rgb(0.32, 0.34, 0.38)),
@@ -77,7 +77,7 @@ let draw = (model, tts) =>
     ]),
     [
       Light.ambient(Color.rgb(0.12, 0.12, 0.16)),
-      Light.directional(0.5, -1.0, 0.35, Color.rgb(1.0, 0.96, 0.9), 1.0)
+      Light.directional(Vec3.make(0.5, -1.0, 0.35), Color.rgb(1.0, 0.96, 0.9), 1.0)
         |> Light.castShadows,
     ])
 

--- a/docs/functor-lang.md
+++ b/docs/functor-lang.md
@@ -308,6 +308,22 @@ snapshots — no GPU, fully agent-verifiable.
       untouched (reads still error loud on unknown tags; commands still warn
       quietly, since a body may legitimately despawn with a command in
       flight — the brand retires the TYPO class at build time instead).
+- [x] **Branded `Vec3` values** (2026-07-16; strong-typing track). The Angle
+      rule applied to space: `Vec3.make(x, y, z)` makes an opaque `Vec3.t`,
+      and every position/direction/velocity/gravity parameter takes one —
+      `Scene.translate`, `Camera.lookAt(eye, target)` (6 floats → 2 Vec3s —
+      arity slips and float interleaving become unrepresentable, though the
+      two Vec3s themselves remain swappable) and
+      `Camera.firstPerson`, `Light.directional`/`point`/`spot`,
+      `Physics.at`/`velocity`/`scene`/the command effects/`raycast(origin,
+      dir, …)`, `Effect.playAt`, and `AudioSource.at`. Reads that hand
+      vectors BACK (`Physics.position`, `rayHit`) stay plain `{x, y, z}`
+      records so components remain accessible for game math; `Scene.scaleXYZ`
+      keeps floats (scale factors, not a spatial vector). Like Color, a Vec3
+      is reload-safe (three module-independent f32s), so spawn points and
+      velocities stored in the model survive hot-reload time travel.
+      Component accessors and vector math (`Vec3.add`/`scale`/`length`, and
+      Vec2/Vec4) are deliberately deferred until an API returns a Vec3.
 - [x] **B7. Hindley–Milner inference** (done 2026-07-04; decided 2026-07-02; **after effects
       land** — B6 + the `effect[...]` header checking, so type inference and
       effect rows are designed against each other, not retrofitted). Upgrade

--- a/docs/physics.md
+++ b/docs/physics.md
@@ -132,9 +132,9 @@ let crateTag = Physics.tag("crate")            // branded identity: declared onc
                                                // the VALUE used at every site
 
 let physics = (model) =>                       // OPTIONAL game hook
-  Physics.scene(0.0, -9.81, 0.0, [
+  Physics.scene(Vec3.make(0.0, -9.81, 0.0), [
     Physics.fixed(Physics.tag("ground"), Physics.box(20.0, 0.2, 20.0)),
-    Physics.dynamic(crateTag, Physics.box(1.0, 1.0, 1.0)) |> Physics.at(0.0, 5.0, 0.0),
+    Physics.dynamic(crateTag, Physics.box(1.0, 1.0, 1.0)) |> Physics.at(Vec3.make(0.0, 5.0, 0.0)),
   ])
 
 let draw = (model, tts) =>
@@ -205,7 +205,7 @@ module PhysicsScene =
 ```
 
 **Commands — plain-data effects.** *Shipped (Phase 3) on the Functor Lang surface as B6
-effect variants* — `Physics.applyImpulse(tag, x, y, z)` etc. (tags are branded
+effect variants* — `Physics.applyImpulse(tag, Vec3.make(x, y, z))` etc. (tags are branded
 `Physics.tag("name")` values), returned beside
 the model; tagger-less (outcomes are observed via the physics reads). Commands
 queue at perform time and apply **after the frame's reconcile, before its first
@@ -223,7 +223,7 @@ module Physics =
 ```
 
 **Queries — tagger effects.** *Shipped (Phase 4) on the Functor Lang surface*:
-`Physics.raycast(ox, oy, oz, dx, dy, dz, maxDist, tagger)` — the tagger
+`Physics.raycast(Vec3.make(ox, oy, oz), Vec3.make(dx, dy, dz), maxDist, tagger)` — the tagger
 receives `{hit: Bool, x, y, z, nx, ny, nz, distance, tag}`. Queries are
 **deferred**: held through the frame's pre-step effect drains and performed
 right after the physics step, their messages folding through a second

--- a/e2e/functor-lang-preview-reload.mjs
+++ b/e2e/functor-lang-preview-reload.mjs
@@ -38,7 +38,7 @@ const TICK = `let tick = (model, dt: Float, tts: Float) => { model with spin: mo
 // assertion can't be confused by animation phase.
 const GREEN_DRAW = `let draw = (model, tts: Float) =>
   Frame.create(
-    Camera.lookAt(0.0, 0.0, -6.0, 0.0, 0.0, 0.0),
+    Camera.lookAt(Vec3.make(0.0, 0.0, -6.0), Vec3.make(0.0, 0.0, 0.0)),
     Scene.sphere() |> Scene.emissive(Color.rgb(0.1, 1.0, 0.2)) |> Scene.scale(2.0))`;
 
 const V_GREEN = `let init = { spin: 0.0, beat: 0.0 }

--- a/e2e/ide-project.mjs
+++ b/e2e/ide-project.mjs
@@ -35,7 +35,7 @@ const GAME = `let init = { t: 0.0 }
 let tick = (model, dt: Float, tts: Float) => { model with t: model.t + dt * Pieces.speed }
 let draw = (model, tts: Float) =>
   Frame.create(
-    Camera.lookAt(0.0, 0.0, -6.0, 0.0, 0.0, 0.0),
+    Camera.lookAt(Vec3.make(0.0, 0.0, -6.0), Vec3.make(0.0, 0.0, 0.0)),
     Scene.sphere() |> Scene.emissive(Color.rgb(0.1, 1.0, Pieces.glow)) |> Scene.scale(2.0))
 `;
 

--- a/e2e/remote-assets.mjs
+++ b/e2e/remote-assets.mjs
@@ -155,7 +155,7 @@ function buildBundle(goodUrl, badUrl, softUrl) {
     JSON.stringify({ language: "functor-lang", entry: "game.fun" }, null, 2),
   );
   const soft = softUrl
-    ? `\n      Scene.model("${softUrl}") |> Scene.translate(0.0 - 3.0, 0.0, 0.0),`
+    ? `\n      Scene.model("${softUrl}") |> Scene.translate(Vec3.make(0.0 - 3.0, 0.0, 0.0)),`
     : "";
   writeFileSync(
     join(dir, "game.fun"),
@@ -166,10 +166,10 @@ let tick = (model, dt, tts) => { model with frame: model.frame + 1.0 }
 
 let draw = (model, tts) =>
   Frame.create(
-    Camera.lookAt(0.0, 2.0, 0.0 - 6.0, 0.0, 0.0, 0.0),
+    Camera.lookAt(Vec3.make(0.0, 2.0, 0.0 - 6.0), Vec3.make(0.0, 0.0, 0.0)),
     Scene.group([
       Scene.model("${goodUrl}"),
-      Scene.model("${badUrl}") |> Scene.translate(3.0, 0.0, 0.0),${soft}
+      Scene.model("${badUrl}") |> Scene.translate(Vec3.make(3.0, 0.0, 0.0)),${soft}
     ]))
 `,
   );

--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -37,7 +37,7 @@ const GREEN = `let init = { t: 0.0 }
 let tick = (model, dt: Float, tts: Float) => { model with t: model.t + dt }
 let draw = (model, tts: Float) =>
   Frame.create(
-    Camera.lookAt(0.0, 0.0, -6.0, 0.0, 0.0, 0.0),
+    Camera.lookAt(Vec3.make(0.0, 0.0, -6.0), Vec3.make(0.0, 0.0, 0.0)),
     Scene.sphere() |> Scene.emissive(Color.rgb(0.1, 1.0, 0.2)) |> Scene.scale(2.0))
 `;
 const BROKEN = "let init = {\n";
@@ -49,7 +49,7 @@ const INLINE_SPIN = `let init = { spin: 0.0 }
 let tick = (model, dt: Float, tts: Float) => { model with spin: model.spin + dt }
 let draw = (model, tts: Float) =>
   Frame.create(
-    Camera.lookAt(0.0, 0.0, -6.0, 0.0, 0.0, 0.0),
+    Camera.lookAt(Vec3.make(0.0, 0.0, -6.0), Vec3.make(0.0, 0.0, 0.0)),
     Scene.cube() |> Scene.rotateY(Angle.radians(model.spin)) |> Scene.emissive(Color.rgb(1.0, 0.2, 0.8)))
 `;
 
@@ -61,7 +61,7 @@ let init = { t: 0.0, behavior: offset(1.0) }
 let tick = (model, dt: Float, tts: Float) => { model with t: model.t + dt }
 let draw = (model, tts: Float) =>
   Frame.create(
-    Camera.lookAt(0.0, 0.0, -6.0, 0.0, 0.0, 0.0),
+    Camera.lookAt(Vec3.make(0.0, 0.0, -6.0), Vec3.make(0.0, 0.0, 0.0)),
     Scene.cube() |> Scene.rotateY(Angle.radians(model.t)) |> Scene.emissive(Color.rgb(0.2, 0.8, 1.0)))
 `;
 
@@ -76,7 +76,7 @@ let init = 0.0
 let tick = (model, dt: Float, tts: Float) => model + dt
 let draw = (model, tts: Float) =>
   Frame.create(
-    Camera.lookAt(0.0, 0.0, -6.0, 0.0, 0.0, 0.0),
+    Camera.lookAt(Vec3.make(0.0, 0.0, -6.0), Vec3.make(0.0, 0.0, 0.0)),
     Scene.sphere() |> Scene.emissive(Color.rgb(0.1, 1.0, 0.2))
       |> Scene.rotateY(Angle.radians(model)) |> Scene.scale(speed))
 `;
@@ -934,7 +934,7 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
     const clean = JSON.parse(
       mod.functor_lang_analyze(
         "let draw = (model, tts: Float) =>\n" +
-          "  Frame.create(Camera.lookAt(0.0, 0.0, -6.0, 0.0, 0.0, 0.0), Scene.cube())\n"
+          "  Frame.create(Camera.lookAt(Vec3.make(0.0, 0.0, -6.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n"
       )
     );
     return { bad, clean };

--- a/examples/animation/game.fun
+++ b/examples/animation/game.fun
@@ -86,7 +86,7 @@ let pose = (model, tts) =>
 
 let draw = (model, tts) =>
   Frame.createLit(
-    Camera.lookAt(0.0, 1.4, -3.2, 0.0, 0.9, 0.0),
+    Camera.lookAt(Vec3.make(0.0, 1.4, -3.2), Vec3.make(0.0, 0.9, 0.0)),
     Scene.group([
       Scene.plane() |> Scene.scale(10.0) |> Scene.lit(Color.rgb(0.42, 0.47, 0.55)),
       // Xbot stands ~1.8 units tall, Y-up, at authored scale; glTF forward
@@ -97,7 +97,7 @@ let draw = (model, tts) =>
     ]),
     [
       Light.ambient(Color.rgb(0.25, 0.25, 0.3)),
-      Light.directional(-0.5, -1.0, 0.4, Color.rgb(1.0, 0.96, 0.88), 1.0) |> Light.castShadows,
+      Light.directional(Vec3.make(-0.5, -1.0, 0.4), Color.rgb(1.0, 0.96, 0.88), 1.0) |> Light.castShadows,
     ])
 
 let ui = (model) =>

--- a/examples/asteroids/font.fun
+++ b/examples/asteroids/font.fun
@@ -34,7 +34,7 @@ let glyphCubes = (gx, gz, s, rows) =>
       let (cx, out2) = acc2 in
       (cx + s,
        (match c > 0.5 with
-        | true => [Scene.cube() |> Scene.scale(s * 0.9) |> Scene.translate(cx, 0.0, rz), ..out2]
+        | true => [Scene.cube() |> Scene.scale(s * 0.9) |> Scene.translate(Vec3.make(cx, 0.0, rz)), ..out2]
         | false => out2)),
       (gx, out)) in
     let (ignored, out3) = rowFolded in

--- a/examples/asteroids/game.fun
+++ b/examples/asteroids/game.fun
@@ -346,9 +346,9 @@ let starfield = () =>
     Scene.plane()
       |> Scene.scale(0.14 + size01 * 0.14)
       |> Scene.emissive(Color.rgb(glow, glow, glow * 1.08))
-      |> Scene.translate((x01 * 2.0 - 1.0) * (worldX + 8.0),
+      |> Scene.translate(Vec3.make((x01 * 2.0 - 1.0) * (worldX + 8.0),
                          0.0 - 4.0,
-                         (z01 * 2.0 - 1.0) * (worldZ + 8.0)))
+                         (z01 * 2.0 - 1.0) * (worldZ + 8.0))))
 
 // The rock's shape wobble draws from its own seed — pure, so the shape is
 // stable frame to frame.
@@ -363,13 +363,13 @@ let rockScene = (a, tts) =>
                       r * (0.75 + w3 * 0.5))
     |> Scene.rotateY(Angle.radians(tts * a.spin))
     |> Scene.lit(Color.rgb(0.62, 0.55, 0.47))
-    |> Scene.translate(a.x, 0.0, a.z)
+    |> Scene.translate(Vec3.make(a.x, 0.0, a.z))
 
 let bulletScene = (b) =>
   Scene.sphere()
     |> Scene.scale(0.14)
     |> Scene.emissive(Color.rgb(1.0, 0.9, 0.3))
-    |> Scene.translate(b.x, 0.0, b.z)
+    |> Scene.translate(Vec3.make(b.x, 0.0, b.z))
 
 // The ship: Kenney's craft_racer (CC0, see ASSETS.md; fetched, not checked
 // in) with an emissive flame while thrusting. The group faces +Z at
@@ -379,7 +379,7 @@ let shipBody = (thrusting) =>
     (match thrusting with
      | true => [Scene.cube()
                   |> Scene.scaleXYZ(0.16, 0.16, 0.6)
-                  |> Scene.translate(0.0, 0.0, 0.0 - 0.85)
+                  |> Scene.translate(Vec3.make(0.0, 0.0, 0.0 - 0.85))
                   |> Scene.emissive(Color.rgb(1.0, 0.55, 0.1))]
      | false => []) in
   Scene.group(Lib.append([
@@ -388,7 +388,7 @@ let shipBody = (thrusting) =>
     // translation (kit-scene leftover) — counter it first or the body
     // renders displaced from the ship's true position.
     Scene.model("ship.glb")
-      |> Scene.translate(0.0 - 2.0, 0.0, 0.0 - 1.5)
+      |> Scene.translate(Vec3.make(0.0 - 2.0, 0.0, 0.0 - 1.5))
       |> Scene.rotateY(Angle.degrees(180.0))
       |> Scene.scale(1.5),
   ], flame))
@@ -401,7 +401,7 @@ let shipScenes = (model, tts) =>
   | true =>
     [shipBody(Lib.and(model.held.thrust, model.phase == Playing))
        |> Scene.rotateY(Angle.radians(model.ship.heading))
-       |> Scene.translate(model.ship.pos.x, 0.0, model.ship.pos.z)]
+       |> Scene.translate(Vec3.make(model.ship.pos.x, 0.0, model.ship.pos.z))]
 
 // Centered arcade-style screens, built from Font's emissive cube glyphs
 // in scene space (Ui panels only anchor to corners — docs/todo.md). They
@@ -435,7 +435,7 @@ let titleScenes = (model, tts) =>
           [Font.gG, Font.gA, Font.gM, Font.gE, Font.gSpace, Font.gO, Font.gV, Font.gE, Font.gR])
           |> Scene.emissive(Color.rgb(1.0, 0.45, 0.35)),
         ..pressEnter(tts, 0.0 - 1.5)]) in
-  screens |> List.map((s) => s |> Scene.translate(0.0, 2.5, 0.0))
+  screens |> List.map((s) => s |> Scene.translate(Vec3.make(0.0, 2.5, 0.0)))
 
 let draw = (model, tts) =>
   let rocks = model.asteroids |> List.map((a) => rockScene(a, tts)) in
@@ -446,12 +446,12 @@ let draw = (model, tts) =>
      | Lost => []
      | _ => shipScenes(model, tts)) in
   Frame.createLit(
-    Camera.lookAt(0.0, 46.0, 10.0, 0.0, 0.0, 0.0),
+    Camera.lookAt(Vec3.make(0.0, 46.0, 10.0), Vec3.make(0.0, 0.0, 0.0)),
     Scene.group([Scene.group(starfield()), Scene.group(rocks),
                  Scene.group(bullets), Scene.group(ship),
                  Scene.group(titleScenes(model, tts))]),
     [Light.ambient(Color.rgb(0.3, 0.3, 0.38)),
-     Light.directional(-0.45, -1.0, -0.3, Color.rgb(1.0, 0.97, 0.9), 1.1)])
+     Light.directional(Vec3.make(-0.45, -1.0, -0.3), Color.rgb(1.0, 0.97, 0.9), 1.1)])
     // Distance fog starting past the whole scene: nothing in play is
     // fogged, but the pass's clear color becomes deep space (there is no
     // Frame.clearColor — see the findings log).

--- a/examples/atmosphere/game.fun
+++ b/examples/atmosphere/game.fun
@@ -22,18 +22,18 @@ let sky = Skybox.files(
 let pillar = (i: float) =>
   Scene.cube()
     |> Scene.lit(Color.rgb(0.75, 0.55, 0.4))
-    |> Scene.translate(Math.sin(i * 1.7) * 4.0, 0.5, i * 3.0)
+    |> Scene.translate(Vec3.make(Math.sin(i * 1.7) * 4.0, 0.5, i * 3.0))
 
 // An emissive glow weaving through the colonnade.
 let drifter = (tts: float) =>
   Scene.sphere()
     |> Scene.scale(0.5)
     |> Scene.emissive(Color.rgb(1.0, 0.6, 0.2))
-    |> Scene.translate(Math.cos(tts * 0.6) * 3.0, 1.4, 8.0 + Math.sin(tts * 0.6) * 7.0)
+    |> Scene.translate(Vec3.make(Math.cos(tts * 0.6) * 3.0, 1.4, 8.0 + Math.sin(tts * 0.6) * 7.0))
 
 let lights = () => [
   Light.ambient(Color.rgb(0.16, 0.17, 0.2)),
-  Light.directional(0.4, -1.0, 0.3, Color.rgb(1.0, 0.96, 0.88), 0.85) |> Light.castShadows,
+  Light.directional(Vec3.make(0.4, -1.0, 0.3), Color.rgb(1.0, 0.96, 0.88), 0.85) |> Light.castShadows,
 ]
 
 let init = {}
@@ -41,7 +41,7 @@ let tick = (m, dt, tts) => m
 
 let draw = (m, tts: float) =>
   Frame.createLit(
-    Camera.lookAt(0.0, 2.4, -6.0, 0.0, 1.0, 8.0),
+    Camera.lookAt(Vec3.make(0.0, 2.4, -6.0), Vec3.make(0.0, 1.0, 8.0)),
     Scene.group([
       Scene.plane() |> Scene.scale(70.0) |> Scene.lit(Color.rgb(0.5, 0.55, 0.52)),
       Scene.group([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0] |> List.map(pillar)),

--- a/examples/counter/game.fun
+++ b/examples/counter/game.fun
@@ -20,13 +20,13 @@ let tick = (m: Model, dt, tts) => m
 
 let draw = (m: Model, tts) =>
   Frame.createLit(
-    Camera.lookAt(0.0, 1.5, -4.0, 0.0, 0.0, 0.0),
+    Camera.lookAt(Vec3.make(0.0, 1.5, -4.0), Vec3.make(0.0, 0.0, 0.0)),
     Scene.cube()
       |> Scene.lit(Color.rgb(0.3, 0.65, 0.9))
       |> Scene.rotateY(Angle.degrees(m.count * 15.0)),
     [
       Light.ambient(Color.rgb(0.25, 0.25, 0.25)),
-      Light.directional(-0.5, -1.0, 0.4, Color.rgb(1.0, 1.0, 1.0), 0.9),
+      Light.directional(Vec3.make(-0.5, -1.0, 0.4), Color.rgb(1.0, 1.0, 1.0), 0.9),
     ],
   )
 

--- a/examples/crossfade/game.fun
+++ b/examples/crossfade/game.fun
@@ -75,11 +75,11 @@ let figure = (anim: Anim.t, x: float): Scene.t =>
   Scene.model("Xbot.glb")
     |> Scene.animate(anim)
     |> Scene.rotateY(Angle.degrees(180.0))
-    |> Scene.translate(x, 0.0, 0.0)
+    |> Scene.translate(Vec3.make(x, 0.0, 0.0))
 
 let draw = (model, tts) =>
   Frame.createLit(
-    Camera.lookAt(0.0, 1.5, -4.4, 0.0, 0.9, 0.0),
+    Camera.lookAt(Vec3.make(0.0, 1.5, -4.4), Vec3.make(0.0, 0.9, 0.0)),
     Scene.group([
       Scene.plane() |> Scene.scale(12.0) |> Scene.lit(Color.rgb(0.42, 0.47, 0.55)),
       // Camera looks down +Z, so world +X is screen LEFT.
@@ -88,7 +88,7 @@ let draw = (model, tts) =>
     ]),
     [
       Light.ambient(Color.rgb(0.25, 0.25, 0.3)),
-      Light.directional(-0.5, -1.0, 0.4, Color.rgb(1.0, 0.96, 0.88), 1.0) |> Light.castShadows,
+      Light.directional(Vec3.make(-0.5, -1.0, 0.4), Color.rgb(1.0, 0.96, 0.88), 1.0) |> Light.castShadows,
     ])
 
 let ui = (model) =>

--- a/examples/glove/game.fun
+++ b/examples/glove/game.fun
@@ -92,9 +92,9 @@ let handPose = (c) =>
 
 let draw = (model, tts) =>
   Frame.createLit(
-    Camera.lookAt(0.0, 0.25, -0.65, 0.0, 0.1, 0.0),
+    Camera.lookAt(Vec3.make(0.0, 0.25, -0.65), Vec3.make(0.0, 0.1, 0.0)),
     Scene.group([
-      Scene.plane() |> Scene.scale(6.0) |> Scene.translate(0.0, -0.25, 0.0)
+      Scene.plane() |> Scene.scale(6.0) |> Scene.translate(Vec3.make(0.0, -0.25, 0.0))
         |> Scene.lit(Color.rgb(0.42, 0.47, 0.55)),
       // The glove renders at its authored size (~0.2 units — a real hand):
       // authored palm-down with the fingers along +Z, so tip it up to show
@@ -105,7 +105,7 @@ let draw = (model, tts) =>
     ]),
     [
       Light.ambient(Color.rgb(0.45, 0.45, 0.5)),
-      Light.directional(-0.4, -0.8, 0.6, Color.rgb(1.0, 0.96, 0.9), 1.1) |> Light.castShadows,
+      Light.directional(Vec3.make(-0.4, -0.8, 0.6), Color.rgb(1.0, 0.96, 0.9), 1.1) |> Light.castShadows,
     ])
 
 let ui = (model) =>

--- a/examples/hello-cubes/game.fun
+++ b/examples/hello-cubes/game.fun
@@ -28,7 +28,7 @@ let subscriptions = (model) => Sub.every(Time.seconds(1.0), Beat)
 
 let draw = (model, tts: float) =>
   Frame.create(
-    Camera.lookAt(0.0, 3.5, -9.0, 0.0, 0.0, 0.0),
+    Camera.lookAt(Vec3.make(0.0, 3.5, -9.0), Vec3.make(0.0, 0.0, 0.0)),
     Scene.group([
       Pieces.centerpiece(model.spin, model.beat),
       Scene.group(List.range(Pieces.count) |> List.map((i) => Pieces.ringCube(model.spin, i))),

--- a/examples/hello-cubes/pieces.fun
+++ b/examples/hello-cubes/pieces.fun
@@ -11,7 +11,7 @@ let ringCube = (spin: float, i: float) =>
   Scene.cube()
     |> Scene.color(Color.rgb(0.25 + 0.75 * (i / count), 0.35, 0.95 - 0.65 * (i / count)))
     |> Scene.rotateY(Angle.radians(i * 0.7 + spin * 2.0))
-    |> Scene.translate(4.0, Math.sin(i + spin * 3.0) * 0.6, 0.0)
+    |> Scene.translate(Vec3.make(4.0, Math.sin(i + spin * 3.0) * 0.6, 0.0))
     |> Scene.rotateY(Angle.radians(i * tau / count + spin))
 
 // The pulsing sphere at the center of the ring.

--- a/examples/hello/game.fun
+++ b/examples/hello/game.fun
@@ -138,7 +138,7 @@ let terrain = () =>
     List.range(32.0) |> List.map((r) =>
       List.range(32.0) |> List.map((c) => ripple(r, c))))
     |> Scene.scale(30.0)
-    |> Scene.translate(0.0, -2.5, 4.0)
+    |> Scene.translate(Vec3.make(0.0, -2.5, 4.0))
     |> Scene.litTexture(dirtTexture)
 
 // A lineup of glTF samples from BabylonJS/Assets exercising the model
@@ -151,41 +151,41 @@ let models = () =>
     Scene.model("shark.glb")
       |> Scene.scale(0.2)
       |> Scene.rotateY(Angle.degrees(180.0))
-      |> Scene.translate(3.0, 1.0, 3.0),
+      |> Scene.translate(Vec3.make(3.0, 1.0, 3.0)),
     Scene.model("fish.glb")
       |> Scene.scale(0.06)
-      |> Scene.translate(-4.5, 0.8, 4.0),
+      |> Scene.translate(Vec3.make(-4.5, 0.8, 4.0)),
     Scene.model("Xbot.glb")
       |> Scene.rotateY(Angle.degrees(180.0))
-      |> Scene.translate(0.9, -0.2, 3.0),
+      |> Scene.translate(Vec3.make(0.9, -0.2, 3.0)),
     Scene.model("ExplodingBarrel.glb")
       |> Scene.scale(0.02)
-      |> Scene.translate(0.0, -1.5, 3.0),
+      |> Scene.translate(Vec3.make(0.0, -1.5, 3.0)),
   ])
 
 // A row of lit primitives in front of the lineup — Lambert shading reads
 // clearly on the sphere (and the cube's faces).
 let litRow = () =>
   Scene.group([
-    Scene.cylinder() |> Scene.translate(0.0, -2.5, 0.0),
-    Scene.sphere() |> Scene.scale(0.7) |> Scene.translate(-2.0, 1.0, 2.0),
-    Scene.cube() |> Scene.translate(2.0, 1.0, 2.0),
+    Scene.cylinder() |> Scene.translate(Vec3.make(0.0, -2.5, 0.0)),
+    Scene.sphere() |> Scene.scale(0.7) |> Scene.translate(Vec3.make(-2.0, 1.0, 2.0)),
+    Scene.cube() |> Scene.translate(Vec3.make(2.0, 1.0, 2.0)),
   ]) |> Scene.lit(Color.rgb(0.85, 0.85, 0.9))
 
 let draw = (model, tts) =>
   Frame.createLit(
     // First-person camera: WASD moves the eye, the mouse turns yaw/pitch.
     Camera.firstPerson(
-      model.eye.x, model.eye.y, model.eye.z,
+      Vec3.make(model.eye.x, model.eye.y, model.eye.z),
       Angle.radians(model.yaw), Angle.radians(model.pitch), Angle.degrees(60.0)),
     Scene.group([
       terrain(),
       litRow(),
       // Self-lit neon sphere, rendered fullbright (emissive material).
-      Scene.sphere() |> Scene.scale(0.5) |> Scene.translate(0.0, 2.3, 2.0)
+      Scene.sphere() |> Scene.scale(0.5) |> Scene.translate(Vec3.make(0.0, 2.3, 2.0))
         |> Scene.emissive(Color.rgb(1.0, 0.2, 0.8)),
       // The glowing grid-texture sign quad (emissive texture, fullbright).
-      Scene.quad() |> Scene.scale(1.2) |> Scene.translate(0.0, 0.3, 1.5)
+      Scene.quad() |> Scene.scale(1.2) |> Scene.translate(Vec3.make(0.0, 0.3, 1.5))
         |> Scene.emissiveTexture(gridTexture),
       models(),
     ]),
@@ -193,7 +193,7 @@ let draw = (model, tts) =>
     // right; lit surfaces shade by orientation, emissive ones stay bright.
     [
       Light.ambient(Color.rgb(0.2, 0.2, 0.28)),
-      Light.directional(-0.5, -1.0, -0.35, Color.rgb(1.0, 0.96, 0.85), 1.1) |> Light.castShadows,
+      Light.directional(Vec3.make(-0.5, -1.0, -0.35), Color.rgb(1.0, 0.96, 0.85), 1.1) |> Light.castShadows,
     ])
 
 let join = (parts) => parts |> List.fold((acc, s) => Text.concat(acc, s), "")

--- a/examples/inspector/game.fun
+++ b/examples/inspector/game.fun
@@ -35,6 +35,6 @@ let tick = (model: Model, dt: Float, tts: Float) => model
 
 let draw = (model: Model, tts: Float) =>
   Frame.create(
-    Camera.lookAt(0.0, 1.5, -4.0, 0.0, 0.0, 0.0),
+    Camera.lookAt(Vec3.make(0.0, 1.5, -4.0), Vec3.make(0.0, 0.0, 0.0)),
     Scene.cube() |> Scene.rotateY(Angle.radians(tts)),
   )

--- a/examples/lighting/game.fun
+++ b/examples/lighting/game.fun
@@ -100,7 +100,7 @@ let fireBang = (model, isDown) =>
        let py = model.eye.y in
        let pz = model.eye.z + side * rz in
        let flipped = (match model.bangRight with | true => false | false => true) in
-       ({ model with bangRight: flipped, bHeld: true }, Effect.playAt("gunshot.wav", px, py, pz)))
+       ({ model with bangRight: flipped, bHeld: true }, Effect.playAt("gunshot.wav", Vec3.make(px, py, pz))))
 
 let input = (model, key, isDown) =>
   match key with
@@ -164,14 +164,14 @@ let markers = (tts: float) =>
     let (r, g, b) = pointColor(i) in
     Scene.sphere()
       |> Scene.scale(0.12)
-      |> Scene.translate(p.x, p.y, p.z)
+      |> Scene.translate(Vec3.make(p.x, p.y, p.z))
       |> Scene.emissive(Color.rgb(r, g, b)))
 
 let pointLights = (tts: float) =>
   List.range(3.0) |> List.map((i) =>
     let p = pointPos(i, tts) in
     let (r, g, b) = pointColor(i) in
-    Light.point(p.x, p.y, p.z, Color.rgb(r, g, b), 1.4, 4.0))
+    Light.point(Vec3.make(p.x, p.y, p.z), Color.rgb(r, g, b), 1.4, 4.0))
 
 let draw = (model, tts: float) =>
   // Ground + a few lit objects sitting on it (each centered at y = its
@@ -181,13 +181,13 @@ let draw = (model, tts: float) =>
     Scene.plane() |> Scene.scale(24.0) |> Scene.lit(Color.rgb(0.6, 0.6, 0.62)) in
   let litShapes =
     Scene.group([
-      Scene.sphere() |> Scene.scale(0.8) |> Scene.translate(0.0 - 2.5, 0.8, 0.0),
-      Scene.cylinder() |> Scene.translate(0.0, 0.5, 2.5),
+      Scene.sphere() |> Scene.scale(0.8) |> Scene.translate(Vec3.make(0.0 - 2.5, 0.8, 0.0)),
+      Scene.cylinder() |> Scene.translate(Vec3.make(0.0, 0.5, 2.5)),
     ]) |> Scene.lit(Color.rgb(0.9, 0.9, 0.9)) in
   // The cube is normal-mapped, so its flat faces show the bumps.
   let cube =
     Scene.cube()
-      |> Scene.translate(2.5, 0.5, 0.0)
+      |> Scene.translate(Vec3.make(2.5, 0.5, 0.0))
       |> Scene.litNormalMapped(Color.rgb(0.9, 0.9, 0.92), bumpsTexture) in
   let objects = Scene.group([ground, litShapes, cube]) in
 
@@ -197,7 +197,7 @@ let draw = (model, tts: float) =>
     Scene.model("shark.glb")
       |> Scene.scale(0.18)
       |> Scene.rotateY(Angle.degrees(90.0))
-      |> Scene.translate(1.5, 1.8, 0.5) in
+      |> Scene.translate(Vec3.make(1.5, 1.8, 0.5)) in
 
   // The fountain: a stone basin with a glowing pool of water at `fountainPos` —
   // the source of the positioned water-loop you hear pan as you walk around it.
@@ -207,22 +207,22 @@ let draw = (model, tts: float) =>
   let basin =
     Scene.cylinder()
       |> Scene.scaleXYZ(1.4, 0.5, 1.4)
-      |> Scene.translate(0.0, 0.25, 0.0)
+      |> Scene.translate(Vec3.make(0.0, 0.25, 0.0))
       |> Scene.lit(Color.rgb(0.9, 0.9, 0.9)) in
   let water =
     Scene.sphere()
       |> Scene.scaleXYZ(0.55, 0.22, 0.55)
-      |> Scene.translate(0.0, 0.6 + bob, 0.0)
+      |> Scene.translate(Vec3.make(0.0, 0.6 + bob, 0.0))
       |> Scene.emissive(Color.rgb(0.3, 0.65, 1.0)) in
   let fountain =
     Scene.group([basin, water])
-      |> Scene.translate(fountainPos.x, 0.0, fountainPos.z) in
+      |> Scene.translate(Vec3.make(fountainPos.x, 0.0, fountainPos.z)) in
 
   let scene = Scene.group([objects, shark, fountain, ..markers(tts)]) in
 
   let camera =
     Camera.firstPerson(
-      model.eye.x, model.eye.y, model.eye.z,
+      Vec3.make(model.eye.x, model.eye.y, model.eye.z),
       Angle.radians(model.yaw), Angle.radians(model.pitch), Angle.degrees(60.0)) in
 
   // A "searchlight" spot high above, slowly sweeping across the objects — this
@@ -231,8 +231,8 @@ let draw = (model, tts: float) =>
   let sweepX = Math.sin(tts * 0.5) * 3.0 in
   let spot =
     Light.spot(
-      0.0, 7.0, 5.0,
-      sweepX - 0.0, 0.3 - 7.0, 0.0 - 5.0,
+      Vec3.make(0.0, 7.0, 5.0),
+      Vec3.make(sweepX - 0.0, 0.3 - 7.0, 0.0 - 5.0),
       Color.rgb(1.0, 1.0, 0.95), 5.0, 18.0, Angle.radians(0.5))
     |> Light.castShadows in
 
@@ -246,7 +246,7 @@ let draw = (model, tts: float) =>
     // unambiguous, so the render is identical.)
     [
       Light.ambient(Color.rgb(0.08, 0.08, 0.11)),
-      Light.directional(0.4, 0.0 - 1.0, 0.3, Color.rgb(0.9, 0.92, 1.0), 0.25),
+      Light.directional(Vec3.make(0.4, 0.0 - 1.0, 0.3), Color.rgb(0.9, 0.92, 1.0), 0.25),
       spot,
       ..pointLights(tts)
     ])
@@ -257,6 +257,6 @@ let draw = (model, tts: float) =>
 let soundScape = (model) =>
   AudioScene.create([
     AudioSource.ambient("wind", "wind-loop.wav") |> AudioSource.gain(0.35),
-    AudioSource.at("fountain", "water-loop.wav", fountainPos.x, fountainPos.y, fountainPos.z)
+    AudioSource.at("fountain", "water-loop.wav", Vec3.make(fountainPos.x, fountainPos.y, fountainPos.z))
       |> AudioSource.gain(0.8),
   ])

--- a/examples/mario/game.fun
+++ b/examples/mario/game.fun
@@ -120,17 +120,17 @@ let platform = (cx, width) =>
   Scene.cube()
     |> Scene.scaleXYZ(width, 2.0, 4.0)
     |> Scene.lit(Color.rgb(0.30, 0.68, 0.36))
-    |> Scene.translate(cx, groundTop - 1.0, 0.0)
+    |> Scene.translate(Vec3.make(cx, groundTop - 1.0, 0.0))
 
 let character = (model) =>
   Scene.cube()
     |> Scene.scaleXYZ(0.8, 1.2, 0.8)
     |> Scene.lit(Color.rgb(0.95, 0.35, 0.25))
-    |> Scene.translate(model.x, model.y + charHalfH, 0.0)
+    |> Scene.translate(Vec3.make(model.x, model.y + charHalfH, 0.0))
 
 let draw = (model, tts) =>
   Frame.createLit(
-    Camera.lookAt(0.0, 3.0, 20.0, 0.0, 1.0, 0.0),
+    Camera.lookAt(Vec3.make(0.0, 3.0, 20.0), Vec3.make(0.0, 1.0, 0.0)),
     Scene.group([
       // Left platform: x in [leftEdge, -chasmHalf]; right: [chasmHalf, rightEdge].
       platform((leftEdge - chasmHalf) / 2.0, -chasmHalf - leftEdge),
@@ -139,5 +139,5 @@ let draw = (model, tts) =>
     ]),
     [
       Light.ambient(Color.rgb(0.18, 0.18, 0.22)),
-      Light.directional(-0.4, -1.0, -0.5, Color.rgb(1.0, 0.98, 0.92), 0.9) |> Light.castShadows,
+      Light.directional(Vec3.make(-0.4, -1.0, -0.5), Color.rgb(1.0, 0.98, 0.92), 0.9) |> Light.castShadows,
     ])

--- a/examples/monitor/game.fun
+++ b/examples/monitor/game.fun
@@ -22,25 +22,25 @@ let orbiter = (tts: float) =>
   Scene.sphere()
     |> Scene.scale(0.45)
     |> Scene.emissive(Color.rgb(1.0, 0.55, 0.15))
-    |> Scene.translate(Math.cos(tts * 0.8) * 3.0, 0.6, 3.0 + Math.sin(tts * 0.8) * 2.0)
+    |> Scene.translate(Vec3.make(Math.cos(tts * 0.8) * 3.0, 0.6, 3.0 + Math.sin(tts * 0.8) * 2.0))
 
 // The courtyard both cameras film.
 let courtyard = (tts: float) =>
   Scene.group([
     Scene.plane() |> Scene.scale(22.0) |> Scene.lit(Color.rgb(0.55, 0.6, 0.55)),
-    Scene.cube() |> Scene.lit(Color.rgb(0.85, 0.3, 0.25)) |> Scene.translate(-2.4, 0.5, 2.0),
+    Scene.cube() |> Scene.lit(Color.rgb(0.85, 0.3, 0.25)) |> Scene.translate(Vec3.make(-2.4, 0.5, 2.0)),
     Scene.cube()
       |> Scene.scale(0.7)
       |> Scene.rotateY(Angle.degrees(30.0))
       |> Scene.lit(Color.rgb(0.3, 0.5, 0.9))
-      |> Scene.translate(2.2, 0.35, 3.4),
-    Scene.cylinder() |> Scene.lit(Color.rgb(0.9, 0.8, 0.3)) |> Scene.translate(0.5, 0.5, 5.2),
+      |> Scene.translate(Vec3.make(2.2, 0.35, 3.4)),
+    Scene.cylinder() |> Scene.lit(Color.rgb(0.9, 0.8, 0.3)) |> Scene.translate(Vec3.make(0.5, 0.5, 5.2)),
     orbiter(tts),
   ])
 
 let lights = () => [
   Light.ambient(Color.rgb(0.12, 0.12, 0.15)),
-  Light.directional(0.4, -1.0, 0.3, Color.rgb(1.0, 0.97, 0.9), 0.9) |> Light.castShadows,
+  Light.directional(Vec3.make(0.4, -1.0, 0.3), Color.rgb(1.0, 0.97, 0.9), 0.9) |> Light.castShadows,
 ]
 
 // The visible camera prop: a head with a lens (a cylinder's axis is Y;
@@ -52,11 +52,11 @@ let cameraGadget = (tts: float) =>
       |> Scene.scale(0.2)
       |> Scene.rotateX(Angle.degrees(90.0))
       |> Scene.lit(Color.rgb(0.1, 0.1, 0.1))
-      |> Scene.translate(0.0, 0.0, 0.35),
+      |> Scene.translate(Vec3.make(0.0, 0.0, 0.35)),
   ])
     |> Scene.rotateY(Angle.radians(pan(tts)))
     |> Scene.scale(0.8)
-    |> Scene.translate(0.0, 3.2, -5.0)
+    |> Scene.translate(Vec3.make(0.0, 3.2, -5.0))
 
 // What the security camera sees: its own full frame — the courtyard from the
 // gadget's mount, looking where the gadget points. (The feed deliberately
@@ -64,8 +64,8 @@ let cameraGadget = (tts: float) =>
 let feedFrame = (tts: float) =>
   Frame.createLit(
     Camera.lookAt(
-      0.0, 3.2, -5.0,
-      Math.sin(pan(tts)) * 8.0, 0.5, -5.0 + Math.cos(pan(tts)) * 8.0),
+      Vec3.make(0.0, 3.2, -5.0),
+      Vec3.make(Math.sin(pan(tts)) * 8.0, 0.5, -5.0 + Math.cos(pan(tts)) * 8.0)),
     courtyard(tts),
     lights())
 
@@ -80,17 +80,17 @@ let monitor = () =>
       |> Scene.screen(feed)
       |> Scene.rotateY(Angle.degrees(180.0))
       |> Scene.scale(2.0)
-      |> Scene.translate(0.0, 0.0, -1.25),
+      |> Scene.translate(Vec3.make(0.0, 0.0, -1.25)),
   ])
     |> Scene.rotateY(Angle.degrees(25.0))
-    |> Scene.translate(3.1, 1.5, -0.6)
+    |> Scene.translate(Vec3.make(3.1, 1.5, -0.6))
 
 let init = {}
 let tick = (m, dt, tts) => m
 
 let draw = (m, tts: float) =>
   Frame.createLit(
-    Camera.lookAt(0.0, 2.6, -9.5, 0.0, 1.2, 0.0),
+    Camera.lookAt(Vec3.make(0.0, 2.6, -9.5), Vec3.make(0.0, 1.2, 0.0)),
     Scene.group([courtyard(tts), cameraGadget(tts), monitor()]),
     lights())
   |> Frame.withRenderTarget(feed, feedFrame(tts))

--- a/examples/mpclient/game.fun
+++ b/examples/mpclient/game.fun
@@ -108,16 +108,16 @@ let draw = (m: Model, tts: float) =>
       let (r, g, b) = colorFor(p.pid) in
       Scene.cube()
       |> Scene.scale(0.6)
-      |> Scene.translate(p.x, 0.0, p.z)
+      |> Scene.translate(Vec3.make(p.x, 0.0, p.z))
       |> Scene.lit(Color.rgb(r, g, b))) in
   let ground =
     Scene.plane() |> Scene.scale(8.0) |> Scene.lit(Color.rgb(0.18, 0.2, 0.28)) in
   let scene = Scene.group([ground, ..playerNodes]) in
   let camera =
     Camera.firstPerson(
-      0.0, 9.0, -2.0,
+      Vec3.make(0.0, 9.0, -2.0),
       Angle.radians(0.0), Angle.radians(-1.2), Angle.degrees(70.0)) in
   Frame.createLit(
     camera, scene,
     [ Light.ambient(Color.rgb(0.35, 0.35, 0.42)),
-      Light.directional(-0.4, -1.0, -0.35, Color.rgb(1.0, 0.95, 0.85), 1.1) ])
+      Light.directional(Vec3.make(-0.4, -1.0, -0.35), Color.rgb(1.0, 0.95, 0.85), 1.1) ])

--- a/examples/mpserver/game.fun
+++ b/examples/mpserver/game.fun
@@ -125,7 +125,7 @@ let draw = (m: Model, tts: float) =>
       let (r, g, b) = colorFor(p.pid) in
       Scene.cube()
       |> Scene.scale(0.6)
-      |> Scene.translate(p.x, 0.0, p.z)
+      |> Scene.translate(Vec3.make(p.x, 0.0, p.z))
       |> Scene.lit(Color.rgb(r, g, b))) in
   let ground =
     Scene.plane() |> Scene.scale(2.0 * arena) |> Scene.lit(Color.rgb(0.18, 0.2, 0.28)) in
@@ -133,9 +133,9 @@ let draw = (m: Model, tts: float) =>
   // Top-down-ish view so player movement stays on screen.
   let camera =
     Camera.firstPerson(
-      0.0, 9.0, -2.0,
+      Vec3.make(0.0, 9.0, -2.0),
       Angle.radians(0.0), Angle.radians(-1.2), Angle.degrees(70.0)) in
   Frame.createLit(
     camera, scene,
     [ Light.ambient(Color.rgb(0.35, 0.35, 0.42)),
-      Light.directional(-0.4, -1.0, -0.35, Color.rgb(1.0, 0.95, 0.85), 1.1) ])
+      Light.directional(Vec3.make(-0.4, -1.0, -0.35), Color.rgb(1.0, 0.95, 0.85), 1.1) ])

--- a/examples/netdemo/game.fun
+++ b/examples/netdemo/game.fun
@@ -50,6 +50,6 @@ let draw = (m: Model, tts: float) =>
   // state is the textual phase, inspected via /state.
   Frame.create(
     Camera.firstPerson(
-      0.0, 0.0, -5.0,
+      Vec3.make(0.0, 0.0, -5.0),
       Angle.radians(0.0), Angle.radians(0.0), Angle.degrees(60.0)),
     Scene.cube() |> Scene.emissive(Color.rgb(0.2, 0.9, 0.6)))

--- a/examples/physics/game.fun
+++ b/examples/physics/game.fun
@@ -39,7 +39,7 @@ let crateTag = (i) => Physics.tag(Text.concat("crate-", Text.fromFloat(i)))
 
 let crateBody = (drop, i) =>
   Physics.dynamic(crateTag(i), Physics.box(1.0, 1.0, 1.0))
-    |> Physics.at(scatterX(drop, i), 3.0 + i * 1.3, scatterZ(drop, i))
+    |> Physics.at(Vec3.make(scatterX(drop, i), 3.0 + i * 1.3, scatterZ(drop, i)))
     |> Physics.friction(0.6)
     |> Physics.restitution(0.2)
 
@@ -50,17 +50,17 @@ let crateBody = (drop, i) =>
 // resting bodies.
 let bodyAt = (drop, i) =>
   match i with
-  | 0.0 => Physics.fixed(groundTag, Physics.box(24.0, 0.4, 24.0)) |> Physics.at(0.0, -0.2, 0.0)
+  | 0.0 => Physics.fixed(groundTag, Physics.box(24.0, 0.4, 24.0)) |> Physics.at(Vec3.make(0.0, -0.2, 0.0))
   | 1.0 =>
     // Nearly-vertical drop beside the crates (the small drop-dependent wobble
     // keeps SPACE's re-drop teleport firing), so the ball settles in frame.
     (Physics.dynamic(ballTag, Physics.sphere(0.6))
-      |> Physics.at(3.2 + scatterX(drop, 9.0) * 0.2, 5.5, 0.5 + scatterZ(drop, 9.0) * 0.2)
+      |> Physics.at(Vec3.make(3.2 + scatterX(drop, 9.0) * 0.2, 5.5, 0.5 + scatterZ(drop, 9.0) * 0.2))
       |> Physics.restitution(0.55))
   | n => crateBody(drop, n - 2.0)
 
 let physics = (model) =>
-  Physics.scene(0.0, -9.81, 0.0,
+  Physics.scene(Vec3.make(0.0, -9.81, 0.0),
     List.range(crateCount + 2.0) |> List.map((i) => bodyAt(model.drop, i)))
 
 // Tints stay in 0..1 for any crateCount thanks to clamp01; the ball's
@@ -99,7 +99,7 @@ let input = (model, key, isDown) =>
   | Key.K =>
     (match isDown with
      | true => model
-     | false => (model, Physics.applyImpulse(ballTag, -2.6, 5.0, -0.4)))
+     | false => (model, Physics.applyImpulse(ballTag, Vec3.make(-2.6, 5.0, -0.4))))
   | Key.R =>
     (match isDown with
      | true => model
@@ -108,8 +108,8 @@ let input = (model, key, isDown) =>
        // arguments are ordinary expressions of the model. The tagger is the
        // GotHit constructor: the result record arrives wrapped in Msg.
        (model,
-        Physics.raycast(scatterX(model.drop, 0.0), 8.0, scatterZ(model.drop, 0.0),
-                        0.0, -1.0, 0.0, 20.0, GotHit)))
+        Physics.raycast(Vec3.make(scatterX(model.drop, 0.0), 8.0, scatterZ(model.drop, 0.0)),
+                        Vec3.make(0.0, -1.0, 0.0), 20.0, GotHit)))
   | _ => model
 
 // Contact events name both tags in rapier's pair order — find the ball's
@@ -136,7 +136,7 @@ let update = (model, msg) =>
      | true =>
        (match hit.tag == groundTag with
         | true => model
-        | false => (model, Physics.applyImpulse(hit.tag, 0.0, 6.0, 0.0))))
+        | false => (model, Physics.applyImpulse(hit.tag, Vec3.make(0.0, 6.0, 0.0)))))
   | Contact(e) =>
     (match e.started with
      | false => model
@@ -152,7 +152,7 @@ let update = (model, msg) =>
 
 let draw = (model, tts) =>
   Frame.createLit(
-    Camera.lookAt(10.5, 7.5, -10.5, 0.0, 0.8, 0.0),
+    Camera.lookAt(Vec3.make(10.5, 7.5, -10.5), Vec3.make(0.0, 0.8, 0.0)),
     Scene.group([
       Scene.plane() |> Scene.scale(24.0) |> Scene.lit(Color.rgb(0.55, 0.58, 0.62)),
       Scene.sphere() |> Scene.scale(0.6) |> Scene.lit(Color.rgb(0.95, 0.35, 0.25)) |> Physics.transformed(ballTag),
@@ -160,5 +160,5 @@ let draw = (model, tts) =>
     ]),
     [
       Light.ambient(Color.rgb(0.12, 0.12, 0.15)),
-      Light.directional(0.5, -1.0, 0.35, Color.rgb(1.0, 0.98, 0.95), 0.9) |> Light.castShadows,
+      Light.directional(Vec3.make(0.5, -1.0, 0.35), Color.rgb(1.0, 0.98, 0.95), 0.9) |> Light.castShadows,
     ])

--- a/examples/primitives/game.fun
+++ b/examples/primitives/game.fun
@@ -19,9 +19,9 @@ let pointPos = (i: float, tts: float) =>
 // Near-white lit surfaces so the colored point lights tint them.
 let whiteShapes = () =>
   Scene.group([
-    Scene.sphere() |> Scene.scale(0.8) |> Scene.translate(-2.2, 0.8, 0.0),
-    Scene.cube() |> Scene.translate(2.2, 0.5, 0.0),
-    Scene.cylinder() |> Scene.translate(0.0, 0.5, 2.2),
+    Scene.sphere() |> Scene.scale(0.8) |> Scene.translate(Vec3.make(-2.2, 0.8, 0.0)),
+    Scene.cube() |> Scene.translate(Vec3.make(2.2, 0.5, 0.0)),
+    Scene.cylinder() |> Scene.translate(Vec3.make(0.0, 0.5, 2.2)),
   ]) |> Scene.lit(Color.rgb(0.9, 0.9, 0.9))
 
 // An emissive marker sphere at a point light's position.
@@ -30,11 +30,11 @@ let marker = (i: float, tts: float, r: float, g: float, b: float) =>
   Scene.sphere()
     |> Scene.scale(0.15)
     |> Scene.emissive(Color.rgb(r, g, b))
-    |> Scene.translate(p.x, p.y, p.z)
+    |> Scene.translate(Vec3.make(p.x, p.y, p.z))
 
 let pointLight = (i: float, tts: float, r: float, g: float, b: float) =>
   let p = pointPos(i, tts) in
-  Light.point(p.x, p.y, p.z, Color.rgb(r, g, b), 1.4, 4.0)
+  Light.point(Vec3.make(p.x, p.y, p.z), Color.rgb(r, g, b), 1.4, 4.0)
 
 let init = {}
 
@@ -43,7 +43,7 @@ let tick = (m, dt, tts) => m
 let draw = (m, tts: float) =>
   Frame.createLit(
     Camera.firstPerson(
-      0.0, 3.5, -8.0,
+      Vec3.make(0.0, 3.5, -8.0),
       Angle.radians(0.0), Angle.radians(-0.3), Angle.degrees(60.0)),
     Scene.group([
       Scene.plane() |> Scene.scale(24.0) |> Scene.lit(Color.rgb(0.6, 0.6, 0.62)),
@@ -53,7 +53,7 @@ let draw = (m, tts: float) =>
     ]),
     [
       Light.ambient(Color.rgb(0.1, 0.1, 0.13)),
-      Light.directional(0.5, -1.0, 0.35, Color.rgb(1.0, 0.98, 0.95), 0.85) |> Light.castShadows,
+      Light.directional(Vec3.make(0.5, -1.0, 0.35), Color.rgb(1.0, 0.98, 0.95), 0.85) |> Light.castShadows,
       pointLight(0.0, tts, 1.0, 0.3, 0.25),
       pointLight(1.0, tts, 0.35, 0.5, 1.0),
     ])

--- a/examples/synthwave/game.fun
+++ b/examples/synthwave/game.fun
@@ -74,14 +74,14 @@ let draw = (m: float, tts: float) =>
   let terrain =
     Scene.heightmap(List.grid((r, c) => terrainHeight(phase, r, c), rows, cols))
     |> Scene.scaleXYZ(terrainSize, 1.0, terrainSize)
-    |> Scene.translate(0.0, -2.0, 0.0)
+    |> Scene.translate(Vec3.make(0.0, -2.0, 0.0))
     |> Scene.emissiveTexture(gridTexture) in
   // The glowing sun, low on the horizon down +Z — a bright, warm emissive
   // sphere that pops against the warm horizon glow of the sky behind it.
   let sun =
     Scene.sphere()
     |> Scene.scale(16.0)
-    |> Scene.translate(0.0, 9.0, 78.0)
+    |> Scene.translate(Vec3.make(0.0, 9.0, 78.0))
     |> Scene.emissive(Color.rgb(1.0, 0.82, 0.6)) in
   // A gradient sky backdrop (dark indigo up top -> warm magenta at the horizon)
   // on a large emissive quad just behind the sun. The quad lies in the XY plane
@@ -89,13 +89,13 @@ let draw = (m: float, tts: float) =>
   let sky =
     Scene.quad()
     |> Scene.scaleXYZ(500.0, 280.0, 1.0)
-    |> Scene.translate(0.0, 60.0, 84.0)
+    |> Scene.translate(Vec3.make(0.0, 60.0, 84.0))
     |> Scene.emissiveTexture(skyTexture) in
   let scene = Scene.group([sky, sun, terrain]) in
   // Low camera near the front edge, looking down +Z across the hills to the sun
   // on the horizon. A hair of downward pitch frames the grid.
   Frame.create(
     Camera.firstPerson(
-      0.0, 5.0, -12.0,
+      Vec3.make(0.0, 5.0, -12.0),
       Angle.radians(0.0), Angle.radians(-0.05), Angle.degrees(70.0)),
     scene)

--- a/examples/toss/game.fun
+++ b/examples/toss/game.fun
@@ -68,7 +68,7 @@ let ballView = (b) =>
   Scene.sphere()
     |> Scene.scale(0.3)
     |> Scene.lit(Color.rgb(1.0, 0.45, 0.2))
-    |> Scene.translate(b.pos.x, b.pos.y, b.pos.z)
+    |> Scene.translate(Vec3.make(b.pos.x, b.pos.y, b.pos.z))
 
 let ground =
   Scene.plane()
@@ -76,12 +76,12 @@ let ground =
     |> Scene.lit(Color.rgb(0.14, 0.15, 0.2))
 
 let draw = (model, tts) =>
-  let cam = Camera.lookAt(0.0, 6.0, 15.0, 0.0, 3.0, 0.0) in
+  let cam = Camera.lookAt(Vec3.make(0.0, 6.0, 15.0), Vec3.make(0.0, 3.0, 0.0)) in
   let scene = Scene.group([
     ground,
     model.balls |> List.map(ballView) |> Scene.group
   ]) in
   Frame.createLit(cam, scene, [
     Light.ambient(Color.rgb(0.3, 0.3, 0.35)),
-    Light.directional(-0.4, -1.0, -0.3, Color.rgb(1.0, 1.0, 1.0), 1.0)
+    Light.directional(Vec3.make(-0.4, -1.0, -0.3), Color.rgb(1.0, 1.0, 1.0), 1.0)
   ])

--- a/examples/trajectory/game.fun
+++ b/examples/trajectory/game.fun
@@ -105,7 +105,7 @@ let ghost = (b) =>
   Scene.sphere()
     |> Scene.scale(0.07)
     |> Scene.emissive(Color.rgb(0.25, 0.85, 1.0))
-    |> Scene.translate(b.pos.x, b.pos.y, b.pos.z)
+    |> Scene.translate(Vec3.make(b.pos.x, b.pos.y, b.pos.z))
 
 // The moving balls of one future model, as a group of ghost dots.
 let ghostsOf = (m) =>
@@ -121,7 +121,7 @@ let ballView = (b) =>
   Scene.sphere()
     |> Scene.scale(0.3)
     |> Scene.lit(Color.rgb(1.0, 0.45, 0.2))
-    |> Scene.translate(b.pos.x, b.pos.y, b.pos.z)
+    |> Scene.translate(Vec3.make(b.pos.x, b.pos.y, b.pos.z))
 
 let ground =
   Scene.plane()
@@ -129,7 +129,7 @@ let ground =
     |> Scene.lit(Color.rgb(0.14, 0.15, 0.2))
 
 let draw = (model, tts) =>
-  let cam = Camera.lookAt(0.0, 6.0, 15.0, 0.0, 3.0, 0.0) in
+  let cam = Camera.lookAt(Vec3.make(0.0, 6.0, 15.0), Vec3.make(0.0, 3.0, 0.0)) in
   let scene = Scene.group([
     ground,
     model.balls |> List.map(ballView) |> Scene.group,
@@ -137,5 +137,5 @@ let draw = (model, tts) =>
   ]) in
   Frame.createLit(cam, scene, [
     Light.ambient(Color.rgb(0.3, 0.3, 0.35)),
-    Light.directional(-0.4, -1.0, -0.3, Color.rgb(1.0, 1.0, 1.0), 1.0)
+    Light.directional(Vec3.make(-0.4, -1.0, -0.3), Color.rgb(1.0, 1.0, 1.0), 1.0)
   ])

--- a/examples/ui/game.fun
+++ b/examples/ui/game.fun
@@ -36,7 +36,7 @@ let tick = (m: Model, dt, tts) => m
 // frame source, so give it a camera over an empty group.
 let draw = (m: Model, tts) =>
   Frame.create(
-    Camera.lookAt(0.0, 1.5, -4.0, 0.0, 0.0, 0.0),
+    Camera.lookAt(Vec3.make(0.0, 1.5, -4.0), Vec3.make(0.0, 0.0, 0.0)),
     Scene.group([])
   )
 

--- a/examples/wsdemo/game.fun
+++ b/examples/wsdemo/game.fun
@@ -41,6 +41,6 @@ let tick = (m: Model, dt: float, tts: float) => m
 let draw = (m: Model, tts: float) =>
   Frame.create(
     Camera.firstPerson(
-      0.0, 0.0, -5.0,
+      Vec3.make(0.0, 0.0, -5.0),
       Angle.radians(0.0), Angle.radians(0.0), Angle.degrees(60.0)),
     Scene.cube() |> Scene.emissive(Color.rgb(0.6, 0.4, 0.9)))

--- a/examples/wsserverdemo/game.fun
+++ b/examples/wsserverdemo/game.fun
@@ -42,6 +42,6 @@ let tick = (m: Model, dt: float, tts: float) => m
 let draw = (m: Model, tts: float) =>
   Frame.create(
     Camera.firstPerson(
-      0.0, 0.0, -5.0,
+      Vec3.make(0.0, 0.0, -5.0),
       Angle.radians(0.0), Angle.radians(0.0), Angle.degrees(60.0)),
     Scene.cube() |> Scene.emissive(Color.rgb(0.3, 0.6, 0.4)))

--- a/functor-lang/src/project.rs
+++ b/functor-lang/src/project.rs
@@ -56,6 +56,7 @@ const PROTECTED_NAMESPACES: &[&str] = &[
     "Light",
     "Fog",
     "Color",
+    "Vec3",
     "Skybox",
     "Angle",
     "Texture",

--- a/functor-prelude/prelude/audio_source.funi
+++ b/functor-prelude/prelude/audio_source.funi
@@ -9,7 +9,7 @@ type t
 
 // key, sound.
 let ambient : (string, string) => t
-// key, sound, x, y, z.
-let at : (string, string, float, float, float) => t
+// key, sound, pos.
+let at : (string, string, Vec3.t) => t
 // Source LAST (subject-last), so it pipes: `AudioSource.ambient(…) |> AudioSource.gain(0.35)`.
 let gain : (float, t) => t

--- a/functor-prelude/prelude/camera.funi
+++ b/functor-prelude/prelude/camera.funi
@@ -5,6 +5,7 @@
 type t
 
 // Eye + target (Y-up, right-handed), a fixed 45° fov.
-let lookAt : (float, float, float, float, float, float) => t
+// eye, target (Vec3 values — the 6-float form is retired).
+let lookAt : (Vec3.t, Vec3.t) => t
 // Eye + yaw/pitch/fov Angles: yaw = 0 / pitch = 0 looks down +Z.
-let firstPerson : (float, float, float, Angle.t, Angle.t, Angle.t) => t
+let firstPerson : (Vec3.t, Angle.t, Angle.t, Angle.t) => t

--- a/functor-prelude/prelude/effect.funi
+++ b/functor-prelude/prelude/effect.funi
@@ -19,6 +19,6 @@ let httpGet : (string, (Net.HttpResponse) => 'msg) => t
 let httpPost : (string, string, (Net.HttpResponse) => 'msg) => t
 // Fire-and-forget audio one-shots. `play` is non-spatial; `playAt` positioned.
 let play : (string) => t
-let playAt : (string, float, float, float) => t
+let playAt : (string, Vec3.t) => t
 // Play once and deliver `'msg` (a message VALUE, not a tagger) when it finishes.
 let playThen : (string, 'msg) => t

--- a/functor-prelude/prelude/light.funi
+++ b/functor-prelude/prelude/light.funi
@@ -5,11 +5,11 @@
 type t
 
 let ambient : (Color.t) => t
-// dx, dy, dz, color, intensity.
-let directional : (float, float, float, Color.t, float) => t
-// px, py, pz, color, intensity, range.
-let point : (float, float, float, Color.t, float, float) => t
-// px, py, pz, dx, dy, dz, color, intensity, range, coneAngle.
-let spot : (float, float, float, float, float, float, Color.t, float, float, Angle.t) => t
+// dir, color, intensity.
+let directional : (Vec3.t, Color.t, float) => t
+// pos, color, intensity, range.
+let point : (Vec3.t, Color.t, float, float) => t
+// pos, dir, color, intensity, range, coneAngle.
+let spot : (Vec3.t, Vec3.t, Color.t, float, float, Angle.t) => t
 // Light first, so it pipes: `Light.directional(…) |> Light.castShadows`.
 let castShadows : (t) => t

--- a/functor-prelude/prelude/physics.funi
+++ b/functor-prelude/prelude/physics.funi
@@ -48,16 +48,16 @@ let kinematic : (tag, shape) => body
 let fixed : (tag, shape) => body
 
 // body LAST (subject-last), so they pipe:
-// `Physics.dynamic(crateTag, Physics.box(1.0, 1.0, 1.0)) |> Physics.at(0.0, 5.0, 0.0)`.
-let at : (float, float, float, body) => body
-let velocity : (float, float, float, body) => body
+// `Physics.dynamic(crateTag, Physics.box(1.0, 1.0, 1.0)) |> Physics.at(Vec3.make(0.0, 5.0, 0.0))`.
+let at : (Vec3.t, body) => body
+let velocity : (Vec3.t, body) => body
 let mass : (float, body) => body
 let friction : (float, body) => body
 let restitution : (float, body) => body
 let sensor : (body) => body
 
-// The world (gx, gy, gz, bodies).
-let scene : (float, float, float, List<body>) => world
+// The world (gravity, bodies).
+let scene : (Vec3.t, List<body>) => world
 
 // Reads of the LIVE stepped world (in-process, no boundary).
 let position : (tag) => position
@@ -66,14 +66,14 @@ let position : (tag) => position
 // `Scene.cube() |> Physics.transformed(crateTag)`.
 let transformed : (tag, Scene.t) => Scene.t
 
-// Command EFFECTS (tag, x, y, z).
-let applyImpulse : (tag, float, float, float) => Effect.t
-let applyForce : (tag, float, float, float) => Effect.t
-let setVelocity : (tag, float, float, float) => Effect.t
-let teleport : (tag, float, float, float) => Effect.t
+// Command EFFECTS (tag, v).
+let applyImpulse : (tag, Vec3.t) => Effect.t
+let applyForce : (tag, Vec3.t) => Effect.t
+let setVelocity : (tag, Vec3.t) => Effect.t
+let teleport : (tag, Vec3.t) => Effect.t
 
-// Query EFFECT: ox, oy, oz, dx, dy, dz, maxDist, tagger.
-let raycast : (float, float, float, float, float, float, float, (rayHit) => 'msg) => Effect.t
+// Query EFFECT: origin, dir, maxDist, tagger.
+let raycast : (Vec3.t, Vec3.t, float, (rayHit) => 'msg) => Effect.t
 
 // Collision-event SUB (what `subscriptions` returns).
 let events : ((collisionEvent) => 'msg) => Sub.t

--- a/functor-prelude/prelude/scene.funi
+++ b/functor-prelude/prelude/scene.funi
@@ -42,7 +42,7 @@ let screen : (RenderTarget.t, t) => t
 let animate : (Anim.t, t) => t
 
 // Transforms.
-let translate : (float, float, float, t) => t
+let translate : (Vec3.t, t) => t
 let scale : (float, t) => t
 let scaleXYZ : (float, float, float, t) => t
 let rotateX : (Angle.t, t) => t

--- a/functor-prelude/prelude/vec3.funi
+++ b/functor-prelude/prelude/vec3.funi
@@ -1,0 +1,13 @@
+// vec3.funi — the `Vec3` host module (interface only; implemented in Rust by
+// FunctorHost in functor_runtime_common::functor_lang_prelude). See docs/functor-lang-interfaces.md.
+
+// The opaque 3-vector handle (`Vec3.t` from game code): a position, direction,
+// velocity, or gravity. The Angle rule applied to space — every spatial
+// parameter takes a Vec3 VALUE, never three bare floats, so arity slips and
+// float interleaving mistakes (a color channel absorbed into a position)
+// are unrepresentable. Reads that hand
+// vectors BACK to the game (`Physics.position`, `rayHit`) stay plain
+// `{x, y, z}` records, so components remain accessible for game math.
+type t
+
+let make : (float, float, float) => t

--- a/functor-prelude/src/lib.rs
+++ b/functor-prelude/src/lib.rs
@@ -20,6 +20,7 @@ pub fn modules() -> Vec<(String, String)> {
         module("Anim", include_str!("../prelude/anim.funi")),
         module("Angle", include_str!("../prelude/angle.funi")),
         module("Color", include_str!("../prelude/color.funi")),
+        module("Vec3", include_str!("../prelude/vec3.funi")),
         module("Camera", include_str!("../prelude/camera.funi")),
         module("Frame", include_str!("../prelude/frame.funi")),
         module("Light", include_str!("../prelude/light.funi")),

--- a/runtime/functor-runtime-common/examples/frame_bench.rs
+++ b/runtime/functor-runtime-common/examples/frame_bench.rs
@@ -140,22 +140,22 @@ let draw = (m: float, tts: float) =>
   let terrain =
     Scene.heightmap(List.grid((r, c) => terrainHeight(phase, r, c), rows, cols))
     |> Scene.scaleXYZ(terrainSize, 1.0, terrainSize)
-    |> Scene.translate(0.0, -2.0, 0.0)
+    |> Scene.translate(Vec3.make(0.0, -2.0, 0.0))
     |> Scene.emissiveTexture(gridTexture) in
   let sun =
     Scene.sphere()
     |> Scene.scale(16.0)
-    |> Scene.translate(0.0, 9.0, 78.0)
+    |> Scene.translate(Vec3.make(0.0, 9.0, 78.0))
     |> Scene.emissive(Color.rgb(1.0, 0.82, 0.6)) in
   let sky =
     Scene.quad()
     |> Scene.scaleXYZ(500.0, 280.0, 1.0)
-    |> Scene.translate(0.0, 60.0, 84.0)
+    |> Scene.translate(Vec3.make(0.0, 60.0, 84.0))
     |> Scene.emissiveTexture(skyTexture) in
   let scene = Scene.group([sky, sun, terrain]) in
   Frame.create(
     Camera.firstPerson(
-      0.0, 5.0, -12.0,
+      Vec3.make(0.0, 5.0, -12.0),
       Angle.radians(0.0), Angle.radians(-0.05), Angle.degrees(70.0)),
     scene)
 "#

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -23,7 +23,7 @@
 //!    |> List.map((c) => f(r, c))) — F#'s `heightmapFn`, in user space)
 //! Scene.group([scene, …])                                   -> Scene
 //! Scene.color(color, scene)                                 -> Scene
-//! Scene.translate(x, y, z, scene)                           -> Scene
+//! Scene.translate(Vec3.make(x, y, z), scene)                           -> Scene
 //! Scene.rotateX/rotateY/rotateZ(angle, scene)               -> Scene
 //! Angle.degrees(n) / Angle.radians(n)                       -> Angle
 //!   (rotations and camera angles take Angle VALUES, never bare numbers —
@@ -37,7 +37,7 @@
 //!   (a diffuse-lit textured surface — F#'s `Material.litTexture`)
 //! Scene.emissiveTexture(texture, scene)                     -> Scene
 //!   (a self-lit textured surface, fullbright — F#'s `Material.emissiveTexture`)
-//! Camera.lookAt(ex, ey, ez, tx, ty, tz)                     -> Camera
+//! Camera.lookAt(Vec3.make(ex, ey, ez), Vec3.make(tx, ty, tz))                     -> Camera
 //!   (up is +Y; vertical fov pinned at 45°, near/far at protocol defaults)
 //! Frame.create(camera, scene)                               -> Frame
 //! RenderTarget.named(id)                                    -> RenderTarget
@@ -94,13 +94,13 @@
 //!
 //! Physics.box(w, h, d) / sphere(r) / capsule(hh, r)         -> Shape
 //! Physics.dynamic/kinematic/fixed(tag, shape)               -> Body
-//! Physics.at/velocity(x, y, z, body)                        -> Body
+//! Physics.at/velocity(v, body)                        -> Body
 //! Physics.mass/friction/restitution(n, body)                -> Body
 //! Physics.sensor(body)                                      -> Body
-//! Physics.scene(gx, gy, gz, [body, …])                      -> PhysicsScene
+//! Physics.scene(Vec3.make(gx, gy, gz), [body, …])                      -> PhysicsScene
 //! Physics.position(tag)                                     -> {x, y, z}
 //! Physics.transformed(tag, scene)                           -> Scene
-//! Physics.applyImpulse/applyForce/setVelocity/teleport(tag, x, y, z)
+//! Physics.applyImpulse/applyForce/setVelocity/teleport(tag, v)
 //!                                                           -> Effect
 //! ```
 //!
@@ -112,7 +112,7 @@
 //!
 //! Scene-consuming functions take the scene LAST, so they compose with
 //! `|>` (the piped value is appended — thread-last; see `functor_lang`'s lowering docs):
-//! `Scene.cube() |> Scene.color(Color.rgb(1.0, 0.0, 0.0)) |> Scene.translate(2.0, 0.0, 0.0)`.
+//! `Scene.cube() |> Scene.color(Color.rgb(1.0, 0.0, 0.0)) |> Scene.translate(Vec3.make(2.0, 0.0, 0.0))`.
 //!
 //! # Transform semantics (deliberate — see the Milestone-0 quirks)
 //!
@@ -127,7 +127,7 @@
 //! - `Scene3D::transform` right-multiplies (`self.xform * xform`), making
 //!   `translate(rotateY(x))` apply the translation *first*. Wrapping makes
 //!   each transform a parent node instead, so the outer call is applied last
-//!   in world space: `s |> Scene.rotateY(r) |> Scene.translate(x, 0, 0)` rotates in
+//!   in world space: `s |> Scene.rotateY(r) |> Scene.translate(Vec3.make(x, 0, 0))` rotates in
 //!   place, *then* moves — the order the source reads.
 
 use cgmath::Matrix4;
@@ -591,6 +591,12 @@ pub struct FunctorLangAngle(pub Angle);
 /// Angle rule, applied to color).
 pub struct FunctorLangColor(pub (f32, f32, f32));
 
+/// A 3-component vector as an opaque Functor Lang value — made by
+/// `Vec3.make(x, y, z)`. Position/direction parameters accept ONLY this,
+/// never three bare floats, so arity slips and float-interleaving mistakes
+/// are unrepresentable (the Angle rule, applied to space).
+pub struct FunctorLangVec3(pub (f32, f32, f32));
+
 /// A [`RenderTargetDescriptor`] as an opaque Functor Lang value — declared once via
 /// `RenderTarget.named` and used at both sites: the writer
 /// (`Frame.withRenderTarget`) and the reader (`Scene.screen`). Both accept
@@ -713,6 +719,20 @@ impl HostData for FunctorLangColor {
     // stored in the model must not invalidate hot-reload time-travel
     // history (colors were plain floats before the brand; this preserves
     // that reload behavior and keeps "name a palette once" model-friendly).
+    fn is_reload_safe_snapshot(&self) -> bool {
+        true
+    }
+}
+
+impl HostData for FunctorLangVec3 {
+    fn type_name(&self) -> &'static str {
+        "Vec3"
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+    // Same plain-f32 reasoning as Color: a spawn point or velocity stored
+    // in the model must not invalidate hot-reload time-travel history.
     fn is_reload_safe_snapshot(&self) -> bool {
         true
     }
@@ -906,6 +926,7 @@ const PATHS: &[&str] = &[
     "Angle.degrees",
     "Angle.radians",
     "Color.rgb",
+    "Vec3.make",
     "Camera.lookAt",
     "Camera.firstPerson",
     "Light.ambient",
@@ -1344,15 +1365,22 @@ the game dir",
                 _ => usage("Scene.color(color, scene)"),
             },
             "Scene.translate" => match args.as_slice() {
-                [x, y, z, scene] => {
-                    let xform = Matrix4::from_translation(cgmath::vec3(
-                        num(x, span)? as f32,
-                        num(y, span)? as f32,
-                        num(z, span)? as f32,
-                    ));
-                    wrap_transform(scene, xform, "Scene.translate(x, y, z, scene)", span)
+                [v, scene] => {
+                    let (x, y, z) = vec3_of(v, path, span)?;
+                    let xform = Matrix4::from_translation(cgmath::vec3(x, y, z));
+                    wrap_transform(scene, xform, "Scene.translate(v, scene)", span)
                 }
-                _ => usage("Scene.translate(x, y, z, scene)"),
+                _ => usage("Scene.translate(v, scene)"),
+            },
+            // An opaque 3-vector. Every position/direction parameter
+            // requires one — never three bare floats.
+            "Vec3.make" => match args.as_slice() {
+                [x, y, z] => Ok(host(FunctorLangVec3((
+                    num(x, span)? as f32,
+                    num(y, span)? as f32,
+                    num(z, span)? as f32,
+                )))),
+                _ => usage("Vec3.make(x, y, z)"),
             },
             // An opaque RGB color (channels normally 0..1; emissive/HDR uses
             // may exceed 1). Every color-taking parameter requires one.
@@ -1406,35 +1434,30 @@ the game dir",
                 _ => usage("Scene.scaleXYZ(x, y, z, scene)"),
             },
             "Camera.lookAt" => match args.as_slice() {
-                [ex, ey, ez, tx, ty, tz] => Ok(host(FunctorLangCamera(Camera::look_at(
-                    [
-                        num(ex, span)? as f32,
-                        num(ey, span)? as f32,
-                        num(ez, span)? as f32,
-                    ],
-                    [
-                        num(tx, span)? as f32,
-                        num(ty, span)? as f32,
-                        num(tz, span)? as f32,
-                    ],
-                    [0.0, 1.0, 0.0],
-                    Angle::from_degrees(45.0),
-                )))),
-                _ => usage("Camera.lookAt(ex, ey, ez, tx, ty, tz)"),
+                [eye, target] => {
+                    let (ex, ey, ez) = vec3_of(eye, "Camera.lookAt eye", span)?;
+                    let (tx, ty, tz) = vec3_of(target, "Camera.lookAt target", span)?;
+                    Ok(host(FunctorLangCamera(Camera::look_at(
+                        [ex, ey, ez],
+                        [tx, ty, tz],
+                        [0.0, 1.0, 0.0],
+                        Angle::from_degrees(45.0),
+                    ))))
+                }
+                _ => usage("Camera.lookAt(eye, target) — Vec3 values (Vec3.make)"),
             },
             "Camera.firstPerson" => match args.as_slice() {
-                [ex, ey, ez, yaw, pitch, fov] => Ok(host(FunctorLangCamera(Camera::first_person(
-                    [
-                        num(ex, span)? as f32,
-                        num(ey, span)? as f32,
-                        num(ez, span)? as f32,
-                    ],
-                    angle_of(yaw, "Camera.firstPerson yaw", span)?,
-                    angle_of(pitch, "Camera.firstPerson pitch", span)?,
-                    angle_of(fov, "Camera.firstPerson fov", span)?,
-                )))),
+                [eye, yaw, pitch, fov] => {
+                    let (ex, ey, ez) = vec3_of(eye, "Camera.firstPerson eye", span)?;
+                    Ok(host(FunctorLangCamera(Camera::first_person(
+                        [ex, ey, ez],
+                        angle_of(yaw, "Camera.firstPerson yaw", span)?,
+                        angle_of(pitch, "Camera.firstPerson pitch", span)?,
+                        angle_of(fov, "Camera.firstPerson fov", span)?,
+                    ))))
+                }
                 _ => usage(
-                    "Camera.firstPerson(ex, ey, ez, yaw, pitch, fov) — Angle values \
+                    "Camera.firstPerson(eye, yaw, pitch, fov) — a Vec3 eye and Angle values \
 (Angle.degrees/Angle.radians)",
                 ),
             },
@@ -1446,27 +1469,29 @@ the game dir",
                 _ => usage("Light.ambient(color)"),
             },
             "Light.directional" => match args.as_slice() {
-                [dx, dy, dz, color, intensity] => {
+                [dir, color, intensity] => {
+                    let (dx, dy, dz) = vec3_of(dir, path, span)?;
                     let (r, g, b) = color_of(color, path, span)?;
                     Ok(host(FunctorLangLight(Light::directional(
-                        num(dx, span)? as f32,
-                        num(dy, span)? as f32,
-                        num(dz, span)? as f32,
+                        dx,
+                        dy,
+                        dz,
                         r,
                         g,
                         b,
                         num(intensity, span)? as f32,
                     ))))
                 }
-                _ => usage("Light.directional(dx, dy, dz, color, intensity)"),
+                _ => usage("Light.directional(dir, color, intensity)"),
             },
             "Light.point" => match args.as_slice() {
-                [px, py, pz, color, intensity, range] => {
+                [pos, color, intensity, range] => {
+                    let (px, py, pz) = vec3_of(pos, path, span)?;
                     let (r, g, b) = color_of(color, path, span)?;
                     Ok(host(FunctorLangLight(Light::point(
-                        num(px, span)? as f32,
-                        num(py, span)? as f32,
-                        num(pz, span)? as f32,
+                        px,
+                        py,
+                        pz,
                         r,
                         g,
                         b,
@@ -1474,22 +1499,24 @@ the game dir",
                         num(range, span)? as f32,
                     ))))
                 }
-                _ => usage("Light.point(px, py, pz, color, intensity, range)"),
+                _ => usage("Light.point(pos, color, intensity, range)"),
             },
             // A cone of light from (px,py,pz) aimed along (dx,dy,dz), soft-edged
             // at `coneAngle` (an Angle from the axis) with falloff to `range`.
             // Shadow-casting when piped through `Light.castShadows`.
             "Light.spot" => match args.as_slice() {
-                [px, py, pz, dx, dy, dz, color, intensity, range, cone] => {
+                [pos, dir, color, intensity, range, cone] => {
                     let cone: cgmath::Rad<f32> = angle_of(cone, path, span)?.into();
+                    let (px, py, pz) = vec3_of(pos, "Light.spot position", span)?;
+                    let (dx, dy, dz) = vec3_of(dir, "Light.spot direction", span)?;
                     let (r, g, b) = color_of(color, path, span)?;
                     Ok(host(FunctorLangLight(Light::spot(
-                        num(px, span)? as f32,
-                        num(py, span)? as f32,
-                        num(pz, span)? as f32,
-                        num(dx, span)? as f32,
-                        num(dy, span)? as f32,
-                        num(dz, span)? as f32,
+                        px,
+                        py,
+                        pz,
+                        dx,
+                        dy,
+                        dz,
                         r,
                         g,
                         b,
@@ -1498,9 +1525,7 @@ the game dir",
                         cone.0,
                     ))))
                 }
-                _ => usage(
-                    "Light.spot(px, py, pz, dx, dy, dz, color, intensity, range, coneAngle)",
-                ),
+                _ => usage("Light.spot(pos, dir, color, intensity, range, coneAngle)"),
             },
             // Light first, so it pipes: `Light.directional(…) |> Light.castShadows`.
             "Light.castShadows" => match args.as_slice() {
@@ -1597,24 +1622,21 @@ the game dir",
                 _ => usage(&format!("{path}(tag, shape)")),
             },
             // Body LAST (subject-last), so they pipe:
-            // `Physics.dynamic(crateTag, Physics.box(1.0, 1.0, 1.0)) |> Physics.at(0.0, 5.0, 0.0)`.
+            // `Physics.dynamic(crateTag, Physics.box(1.0, 1.0, 1.0)) |> Physics.at(Vec3.make(0.0, 5.0, 0.0))`.
             "Physics.at" | "Physics.velocity" => match args.as_slice() {
-                [x, y, z, body] => match body_of(body) {
+                [vec, body] => match body_of(body) {
                     Some(inner) => {
-                        let v = [
-                            num(x, span)? as f32,
-                            num(y, span)? as f32,
-                            num(z, span)? as f32,
-                        ];
+                        let (x, y, z) = vec3_of(vec, path, span)?;
+                        let v = [x, y, z];
                         Ok(host(FunctorLangBody(if path == "Physics.at" {
                             inner.clone().at(v)
                         } else {
                             inner.clone().with_velocity(v)
                         })))
                     }
-                    None => usage(&format!("{path}(x, y, z, body)")),
+                    None => usage(&format!("{path}(v, body)")),
                 },
-                _ => usage(&format!("{path}(x, y, z, body)")),
+                _ => usage(&format!("{path}(v, body)")),
             },
             "Physics.mass" | "Physics.friction" | "Physics.restitution" => match args.as_slice() {
                 [n, body] => match body_of(body) {
@@ -1641,12 +1663,9 @@ the game dir",
                 _ => usage("Physics.sensor(body)"),
             },
             "Physics.scene" => match args.as_slice() {
-                [gx, gy, gz, Value::List(items)] => {
-                    let gravity = [
-                        num(gx, span)? as f32,
-                        num(gy, span)? as f32,
-                        num(gz, span)? as f32,
-                    ];
+                [g, Value::List(items)] => {
+                    let (gx, gy, gz) = vec3_of(g, "Physics.scene gravity", span)?;
+                    let gravity = [gx, gy, gz];
                     let mut bodies = Vec::with_capacity(items.len());
                     for item in items.iter() {
                         match body_of(item) {
@@ -1663,7 +1682,7 @@ the game dir",
                         gravity, bodies,
                     ))))
                 }
-                _ => usage("Physics.scene(gx, gy, gz, [body, …])"),
+                _ => usage("Physics.scene(Vec3.make(gx, gy, gz), [body, …])"),
             },
             // Reads of the LIVE stepped world (the singleton, world 0). Functor Lang
             // runs in the same process as the world the shell steps, so these
@@ -1688,19 +1707,16 @@ the game dir",
             // places the visual at the body's live pose (position + rotation).
             // Command EFFECTS (docs/physics.md Phase 3): fire-and-forget,
             // returned beside the model like any effect —
-            // `(model, Physics.applyImpulse(ballTag, 0.0, 5.0, 0.0))`.
+            // `(model, Physics.applyImpulse(ballTag, Vec3.make(0.0, 5.0, 0.0)))`.
             // Performing one queues it on the singleton world; it applies at
             // the next stepped frame's first substep, AFTER reconcile — so a
             // body declared and commanded in the same frame works.
             "Physics.applyImpulse" | "Physics.applyForce" | "Physics.setVelocity"
             | "Physics.teleport" => match args.as_slice() {
-                [Value::String(tag), x, y, z] => {
+                [Value::String(tag), vec] => {
                     let tag = tag.to_string();
-                    let v = [
-                        num(x, span)? as f32,
-                        num(y, span)? as f32,
-                        num(z, span)? as f32,
-                    ];
+                    let (x, y, z) = vec3_of(vec, path, span)?;
+                    let v = [x, y, z];
                     let command = match path {
                         "Physics.applyImpulse" => {
                             physics::PhysicsCommand::ApplyImpulse { tag, impulse: v }
@@ -1715,25 +1731,18 @@ the game dir",
                     };
                     Ok(host(FunctorLangEffect(EffectTree::Physics(command))))
                 }
-                _ => usage(&format!("{path}(tag, x, y, z)")),
+                _ => usage(&format!("{path}(tag, v)")),
             },
             // Query EFFECT (docs/physics.md Phase 4): deferred until after
             // the frame's physics step, then the tagger receives the result
             // record `{hit, x, y, z, nx, ny, nz, distance, tag}` (hit: false
             // with zeroed fields for a miss) — fresh, same-frame.
             "Physics.raycast" => match args.as_slice() {
-                [ox, oy, oz, dx, dy, dz, max_dist, tagger @ (Value::Closure(_) | Value::Ctor { .. })] =>
-                {
-                    let origin = [
-                        num(ox, span)? as f32,
-                        num(oy, span)? as f32,
-                        num(oz, span)? as f32,
-                    ];
-                    let dir = [
-                        num(dx, span)? as f32,
-                        num(dy, span)? as f32,
-                        num(dz, span)? as f32,
-                    ];
+                [o, d, max_dist, tagger @ (Value::Closure(_) | Value::Ctor { .. })] => {
+                    let (ox, oy, oz) = vec3_of(o, "Physics.raycast origin", span)?;
+                    let (dx, dy, dz) = vec3_of(d, "Physics.raycast direction", span)?;
+                    let origin = [ox, oy, oz];
+                    let dir = [dx, dy, dz];
                     if dir == [0.0, 0.0, 0.0] {
                         return err("Physics.raycast: the direction must not be zero".to_string());
                     }
@@ -1746,12 +1755,12 @@ the game dir",
                         tagger: tagger.clone(),
                     })))
                 }
-                [_, _, _, _, _, _, _, other] => err(format!(
-                    "Physics.raycast(ox, oy, oz, dx, dy, dz, maxDist, tagger): the tagger \
+                [_, _, _, other] => err(format!(
+                    "Physics.raycast(origin, dir, maxDist, tagger): the tagger \
                      must be a function of the result record, got {}",
                     other.kind_name()
                 )),
-                _ => usage("Physics.raycast(ox, oy, oz, dx, dy, dz, maxDist, tagger)"),
+                _ => usage("Physics.raycast(origin, dir, maxDist, tagger)"),
             },
             // Collision-event SUB (docs/physics.md Phase 5): what
             // `subscriptions` returns (alone or in Sub.batch). The tagger
@@ -1852,15 +1861,14 @@ the Net.HttpResponse, got {}",
                 _ => usage("Effect.play(sound)"),
             },
             "Effect.playAt" => match args.as_slice() {
-                [Value::String(sound), x, y, z] => Ok(host(FunctorLangEffect(EffectTree::PlayAudio {
-                    sound: sound.to_string(),
-                    position: Some([
-                        num(x, span)? as f32,
-                        num(y, span)? as f32,
-                        num(z, span)? as f32,
-                    ]),
-                }))),
-                _ => usage("Effect.playAt(sound, x, y, z)"),
+                [Value::String(sound), v] => {
+                    let (x, y, z) = vec3_of(v, path, span)?;
+                    Ok(host(FunctorLangEffect(EffectTree::PlayAudio {
+                        sound: sound.to_string(),
+                        position: Some([x, y, z]),
+                    })))
+                }
+                _ => usage("Effect.playAt(sound, v)"),
             },
             // Play once and deliver `msg` (a message VALUE, not a tagger) when
             // the sound finishes — see EffectTree::PlayAudioThen. Any value is a
@@ -1882,16 +1890,17 @@ the Net.HttpResponse, got {}",
                 _ => usage("AudioSource.ambient(key, sound)"),
             },
             "AudioSource.at" => match args.as_slice() {
-                [Value::String(key), Value::String(sound), x, y, z] => {
+                [Value::String(key), Value::String(sound), v] => {
+                    let (x, y, z) = vec3_of(v, path, span)?;
                     Ok(host(FunctorLangAudioSource(crate::audio::AudioSource::at(
                         key.to_string(),
                         sound.to_string(),
-                        num(x, span)? as f32,
-                        num(y, span)? as f32,
-                        num(z, span)? as f32,
+                        x,
+                        y,
+                        z,
                     ))))
                 }
-                _ => usage("AudioSource.at(key, sound, x, y, z)"),
+                _ => usage("AudioSource.at(key, sound, v)"),
             },
             // Source LAST (subject-last) so it pipes: `AudioSource.ambient(…) |> AudioSource.gain(0.35)`.
             "AudioSource.gain" => match args.as_slice() {
@@ -2413,6 +2422,33 @@ Color.rgb(r, g, b)"
         }),
         other => Err(RunError {
             message: format!("{what}: expected a Color, got {}", other.kind_name()),
+            span,
+        }),
+    }
+}
+
+/// Extract a 3-vector — position/direction parameters accept ONLY Vec3
+/// values, so bare numbers get a teaching error instead of a silent axis
+/// guess (the [`angle_of`] rule, applied to space).
+fn vec3_of(value: &Value, what: &str, span: Span) -> Result<(f32, f32, f32), RunError> {
+    match value {
+        Value::HostData(data) => data
+            .as_any()
+            .downcast_ref::<FunctorLangVec3>()
+            .map(|v| v.0)
+            .ok_or_else(|| RunError {
+                message: format!("{what}: expected a Vec3, got {}", value.kind_name()),
+                span,
+            }),
+        Value::Number(_) => Err(RunError {
+            message: format!(
+                "{what}: expected a Vec3, got a bare number — wrap the components: \
+Vec3.make(x, y, z)"
+            ),
+            span,
+        }),
+        other => Err(RunError {
+            message: format!("{what}: expected a Vec3, got {}", other.kind_name()),
             span,
         }),
     }
@@ -3549,7 +3585,7 @@ module is CLOSED, so games referencing these break at load: {missing:?}"
     fn functor_lang_snippet_emits_protocol_frame() {
         let frame = frame_of(
             "let main = () =>\n\
-             Frame.create(Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0), Scene.cube())",
+             Frame.create(Camera.lookAt(Vec3.make(0.0, 2.0, -6.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube())",
         );
         let json = serde_json::to_string(&frame).expect("serialize");
         // Camera: eye/target as given, up +Y, 45° fov, protocol defaults.
@@ -3571,8 +3607,8 @@ module is CLOSED, so games referencing these break at load: {missing:?}"
         let frame = frame_of(
             "let main = () =>\n\
              Frame.create(\n\
-               Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0),\n\
-               Scene.cube() |> Scene.color(Color.rgb(1.0, 0.0, 0.0)) |> Scene.translate(2.0, 0.0, 0.0))",
+               Camera.lookAt(Vec3.make(0.0, 0.0, -5.0), Vec3.make(0.0, 0.0, 0.0)),\n\
+               Scene.cube() |> Scene.color(Color.rgb(1.0, 0.0, 0.0)) |> Scene.translate(Vec3.make(2.0, 0.0, 0.0)))",
         );
         // Outermost node: a Group carrying the translation…
         let SceneObject::Group(children) = &frame.scene.obj else {
@@ -3594,8 +3630,8 @@ module is CLOSED, so games referencing these break at load: {missing:?}"
         let frame = frame_of(
             "let main = () =>\n\
              Frame.create(\n\
-               Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0),\n\
-               Scene.cube() |> Scene.rotateY(Angle.degrees(90.0)) |> Scene.translate(3.0, 0.0, 0.0))",
+               Camera.lookAt(Vec3.make(0.0, 0.0, -5.0), Vec3.make(0.0, 0.0, 0.0)),\n\
+               Scene.cube() |> Scene.rotateY(Angle.degrees(90.0)) |> Scene.translate(Vec3.make(3.0, 0.0, 0.0)))",
         );
         // World composition for nested Groups is parent-first:
         // world = T * R, so a cube corner rotates about the cube's own origin
@@ -3619,7 +3655,7 @@ module is CLOSED, so games referencing these break at load: {missing:?}"
         let frame = frame_of(
             "let main = () =>\n\
              Frame.create(\n\
-               Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0),\n\
+               Camera.lookAt(Vec3.make(0.0, 0.0, -5.0), Vec3.make(0.0, 0.0, 0.0)),\n\
                Scene.cube() |> Scene.scaleXYZ(2.0, 3.0, 4.0))",
         );
         // The wrapper Group carries a non-uniform scale on its diagonal — the
@@ -3632,10 +3668,10 @@ module is CLOSED, so games referencing these break at load: {missing:?}"
     #[test]
     fn mapped_group_builds_n_children() {
         let frame = frame_of(
-            "let cubeAt = (i) => Scene.cube() |> Scene.color(Color.rgb(1.0, 0.5, 0.2)) |> Scene.translate(i, 0.0, 0.0)\n\
+            "let cubeAt = (i) => Scene.cube() |> Scene.color(Color.rgb(1.0, 0.5, 0.2)) |> Scene.translate(Vec3.make(i, 0.0, 0.0))\n\
              let main = () =>\n\
              Frame.create(\n\
-               Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0),\n\
+               Camera.lookAt(Vec3.make(0.0, 0.0, -5.0), Vec3.make(0.0, 0.0, 0.0)),\n\
                Scene.group([0.0, 1.0, 2.0] |> List.map(cubeAt)))",
         );
         let SceneObject::Group(children) = &frame.scene.obj else {
@@ -3656,8 +3692,8 @@ module is CLOSED, so games referencing these break at load: {missing:?}"
         let frame = frame_of(
             "let main = () =>\n\
              Frame.create(\n\
-               Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0),\n\
-               Scene.model(\"shark.glb\") |> Scene.scale(0.002) |> Scene.translate(3.0, 1.0, 3.0))",
+               Camera.lookAt(Vec3.make(0.0, 0.0, -5.0), Vec3.make(0.0, 0.0, 0.0)),\n\
+               Scene.model(\"shark.glb\") |> Scene.scale(0.002) |> Scene.translate(Vec3.make(3.0, 1.0, 3.0)))",
         );
         // Outermost: the translate wrapper; inside it, the scale wrapper;
         // inside that, the Model node itself.
@@ -3707,15 +3743,15 @@ the game dir"
         let frame = frame_of(
             "let main = () =>
              Frame.createLit(
-               Camera.firstPerson(0.0, 3.5, -8.0, Angle.radians(0.0), Angle.radians(-0.3), Angle.degrees(60.0)),
+               Camera.firstPerson(Vec3.make(0.0, 3.5, -8.0), Angle.radians(0.0), Angle.radians(-0.3), Angle.degrees(60.0)),
                Scene.group([
                  Scene.plane() |> Scene.scale(24.0) |> Scene.lit(Color.rgb(0.6, 0.6, 0.62)),
                  Scene.sphere() |> Scene.emissive(Color.rgb(1.0, 0.3, 0.25)),
                ]),
                [
                  Light.ambient(Color.rgb(0.1, 0.1, 0.13)),
-                 Light.directional(0.5, -1.0, 0.35, Color.rgb(1.0, 0.98, 0.95), 0.85) |> Light.castShadows,
-                 Light.point(1.0, 2.2, 0.0, Color.rgb(1.0, 0.3, 0.25), 1.4, 4.0),
+                 Light.directional(Vec3.make(0.5, -1.0, 0.35), Color.rgb(1.0, 0.98, 0.95), 0.85) |> Light.castShadows,
+                 Light.point(Vec3.make(1.0, 2.2, 0.0), Color.rgb(1.0, 0.3, 0.25), 1.4, 4.0),
                ])",
         );
         assert_eq!(frame.lights.len(), 3);
@@ -3735,10 +3771,10 @@ the game dir"
             "let bumps = Texture.file(\"bumps-normal.png\")\n\
              let main = () =>\n\
              Frame.createLit(\n\
-               Camera.firstPerson(0.0, 3.0, -8.0, Angle.radians(0.0), Angle.radians(-0.25), Angle.degrees(60.0)),\n\
+               Camera.firstPerson(Vec3.make(0.0, 3.0, -8.0), Angle.radians(0.0), Angle.radians(-0.25), Angle.degrees(60.0)),\n\
                Scene.cube() |> Scene.litNormalMapped(Color.rgb(0.9, 0.9, 0.92), bumps),\n\
                [\n\
-                 Light.spot(0.0, 7.0, 5.0, 0.0, -1.0, -0.5, Color.rgb(1.0, 1.0, 0.95), 5.0, 18.0, Angle.radians(0.5))\n\
+                 Light.spot(Vec3.make(0.0, 7.0, 5.0), Vec3.make(0.0, -1.0, -0.5), Color.rgb(1.0, 1.0, 0.95), 5.0, 18.0, Angle.radians(0.5))\n\
                    |> Light.castShadows,\n\
                ])",
         );
@@ -3860,6 +3896,51 @@ Color.rgb(r, g, b)"
             ]
         );
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // [strong-typing track] spatial parameters refuse bare numbers with a
+    // teaching error — axis transposition and eye/target swaps are
+    // unrepresentable (the Angle rule, applied to space).
+    #[test]
+    fn bare_numbers_are_not_vec3s() {
+        let fail = |src: &str| {
+            let module = functor_lang::lower(functor_lang::parse(src).unwrap()).unwrap();
+            functor_lang::run_with_host(&module, Tracing::Off, &mut FunctorHost)
+                .err()
+                .expect("should fail")
+                .error
+                .message
+        };
+        assert_eq!(
+            fail("let main = () => Scene.cube() |> Scene.translate(1.0)"),
+            "Scene.translate: expected a Vec3, got a bare number — wrap the components: \
+Vec3.make(x, y, z)"
+        );
+        // The pre-Vec3 spelling teaches the new shape.
+        assert_eq!(
+            fail("let main = () => Scene.cube() |> Scene.translate(1.0, 2.0, 3.0)"),
+            "usage: Scene.translate(v, scene)"
+        );
+        assert_eq!(
+            fail(
+                "let main = () => Camera.lookAt(Vec3.make(0.0, 2.0, -6.0), 0.0)"
+            ),
+            "Camera.lookAt target: expected a Vec3, got a bare number — wrap the components: \
+Vec3.make(x, y, z)"
+        );
+        // Vec3.make itself still validates its components.
+        assert_eq!(
+            fail("let main = () => Vec3.make(1.0, \"x\", 0.0)"),
+            "expected a number, got a string"
+        );
+    }
+
+    // A Vec3 stored in the model (a spawn point, a velocity) survives hot
+    // reload, like Color.
+    #[test]
+    fn vec3s_are_reload_safe_snapshots() {
+        let v = eval("let main = () => Vec3.make(0.1, 0.2, 0.3)");
+        assert!(v.is_reload_safe_snapshot());
     }
 
     // A Color stored in the model is plain enough to survive hot reload —
@@ -4045,11 +4126,11 @@ Anim.clip(\"walk\", tts)"
     #[test]
     fn degrees_and_radians_agree() {
         let deg = frame_of(
-            "let main = () => Frame.create(Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0), \
+            "let main = () => Frame.create(Camera.lookAt(Vec3.make(0.0, 0.0, -5.0), Vec3.make(0.0, 0.0, 0.0)), \
 Scene.cube() |> Scene.rotateY(Angle.degrees(90.0)))",
         );
         let rad = frame_of(
-            "let main = () => Frame.create(Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0), \
+            "let main = () => Frame.create(Camera.lookAt(Vec3.make(0.0, 0.0, -5.0), Vec3.make(0.0, 0.0, 0.0)), \
 Scene.cube() |> Scene.rotateY(Angle.radians(1.5707964)))",
         );
         assert_eq!(
@@ -4095,14 +4176,14 @@ Scene.cube() |> Scene.rotateY(Angle.radians(1.5707964)))",
             "let feed = RenderTarget.named(\"security\") |> RenderTarget.sized(256.0, 128.0)\n\
              let main = () =>\n\
              Frame.createLit(\n\
-               Camera.lookAt(0.0, 2.0, -8.0, 0.0, 1.0, 0.0),\n\
+               Camera.lookAt(Vec3.make(0.0, 2.0, -8.0), Vec3.make(0.0, 1.0, 0.0)),\n\
                Scene.group([\n\
                  Scene.plane() |> Scene.lit(Color.rgb(0.6, 0.6, 0.6)),\n\
                  Scene.quad() |> Scene.screen(feed),\n\
                ]),\n\
                [Light.ambient(Color.rgb(0.1, 0.1, 0.1))])\n\
              |> Frame.withRenderTarget(feed, Frame.createLit(\n\
-                  Camera.lookAt(0.0, 4.0, -6.0, 0.0, 0.5, 0.0),\n\
+                  Camera.lookAt(Vec3.make(0.0, 4.0, -6.0), Vec3.make(0.0, 0.5, 0.0)),\n\
                   Scene.cube() |> Scene.lit(Color.rgb(0.8, 0.2, 0.2)),\n\
                   [Light.ambient(Color.rgb(0.2, 0.2, 0.2))]))",
         );
@@ -4130,7 +4211,7 @@ Scene.cube() |> Scene.rotateY(Angle.radians(1.5707964)))",
         let frame = frame_of(
             "let main = () =>\n\
              Frame.create(\n\
-               Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0),\n\
+               Camera.lookAt(Vec3.make(0.0, 0.0, -5.0), Vec3.make(0.0, 0.0, 0.0)),\n\
                Scene.quad() |> Scene.screen(RenderTarget.named(\"feed\")))",
         );
         let json = serde_json::to_string(&frame.scene).expect("serialize");
@@ -4162,9 +4243,9 @@ with RenderTarget.named(\"…\") and pass that value at both sites"
         );
         assert_eq!(
             fail(
-                "let main = () => Frame.create(Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0), \
+                "let main = () => Frame.create(Camera.lookAt(Vec3.make(0.0, 0.0, -5.0), Vec3.make(0.0, 0.0, 0.0)), \
 Scene.cube()) |> Frame.withRenderTarget(\"feed\", Frame.create(\
-Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0), Scene.cube()))"
+Camera.lookAt(Vec3.make(0.0, 0.0, -5.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube()))"
             ),
             "Frame.withRenderTarget: expected a RenderTarget, got a bare string — declare \
 it once with RenderTarget.named(\"…\") and pass that value at both sites"
@@ -4186,7 +4267,7 @@ piped through RenderTarget.sized"
     fn functor_lang_snippet_declares_fog() {
         let frame = frame_of(
             "let main = () =>\n\
-             Frame.create(Camera.lookAt(0.0, 2.0, -8.0, 0.0, 1.0, 0.0), Scene.cube())\n\
+             Frame.create(Camera.lookAt(Vec3.make(0.0, 2.0, -8.0), Vec3.make(0.0, 1.0, 0.0)), Scene.cube())\n\
              |> Frame.withFog(Fog.linear(4.0, 30.0, Color.rgb(0.5, 0.6, 0.7)))",
         );
         assert_eq!(frame.fog, Some(Fog::linear(4.0, 30.0, 0.5, 0.6, 0.7)));
@@ -4202,7 +4283,7 @@ piped through RenderTarget.sized"
     fn functor_lang_snippet_declares_clear_color() {
         let frame = frame_of(
             "let main = () =>\n\
-             Frame.create(Camera.lookAt(0.0, 2.0, -8.0, 0.0, 1.0, 0.0), Scene.cube())\n\
+             Frame.create(Camera.lookAt(Vec3.make(0.0, 2.0, -8.0), Vec3.make(0.0, 1.0, 0.0)), Scene.cube())\n\
              |> Frame.withClearColor(Color.rgb(0.2, 0.4, 0.6))",
         );
         assert_eq!(frame.clear_color, Some([0.2, 0.4, 0.6]));
@@ -4212,14 +4293,14 @@ piped through RenderTarget.sized"
         // with fog it's the fog color; withClearColor overrides even that.
         let plain = frame_of(
             "let main = () => \
-             Frame.create(Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0), Scene.cube())",
+             Frame.create(Camera.lookAt(Vec3.make(0.0, 0.0, -5.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube())",
         );
         assert_eq!(plain.clear_color, None);
         assert_eq!(plain.resolved_clear_color(), [0.1, 0.2, 0.3]);
 
         let both = frame_of(
             "let main = () => \
-             Frame.create(Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0), Scene.cube()) \
+             Frame.create(Camera.lookAt(Vec3.make(0.0, 0.0, -5.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube()) \
              |> Frame.withFog(Fog.linear(4.0, 30.0, Color.rgb(0.5, 0.6, 0.7))) \
              |> Frame.withClearColor(Color.rgb(0.0, 0.0, 0.0))",
         );
@@ -4240,7 +4321,7 @@ piped through RenderTarget.sized"
         };
         assert_eq!(
             fail(
-                "let main = () => Frame.create(Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0), \
+                "let main = () => Frame.create(Camera.lookAt(Vec3.make(0.0, 0.0, -5.0), Vec3.make(0.0, 0.0, 0.0)), \
 Scene.cube()) |> Frame.withFog(0.5)"
             ),
             "Frame.withFog: expected a Fog, got a bare number — build one with \
@@ -4266,7 +4347,7 @@ Fog.linear(near, far, color) or Fog.exp(density, color)"
             "let sky = Skybox.files(\"px.jpg\", \"nx.jpg\", \"py.jpg\", \"ny.jpg\", \
 \"pz.jpg\", \"nz.jpg\")\n\
              let main = () =>\n\
-             Frame.create(Camera.lookAt(0.0, 2.0, -8.0, 0.0, 1.0, 0.0), Scene.cube())\n\
+             Frame.create(Camera.lookAt(Vec3.make(0.0, 2.0, -8.0), Vec3.make(0.0, 1.0, 0.0)), Scene.cube())\n\
              |> Frame.withSkybox(sky)",
         );
         let sky = frame.skybox.as_ref().expect("skybox set");
@@ -4294,7 +4375,7 @@ Fog.linear(near, far, color) or Fog.exp(density, color)"
         };
         assert_eq!(
             fail(
-                "let main = () => Frame.create(Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0), \
+                "let main = () => Frame.create(Camera.lookAt(Vec3.make(0.0, 0.0, -5.0), Vec3.make(0.0, 0.0, 0.0)), \
 Scene.cube()) |> Frame.withSkybox(\"sky.jpg\")"
             ),
             "Frame.withSkybox: expected a Skybox, got a bare string — build one with \
@@ -4316,11 +4397,11 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
     fn functor_lang_snippet_declares_a_physics_scene() {
         let value = eval(
             "let crate1 = Physics.dynamic(\"crate-1\", Physics.box(1.0, 1.0, 1.0))\n\
-             |> Physics.at(0.0, 5.0, 0.0)\n\
-             |> Physics.velocity(1.0, 0.0, 0.0)\n\
+             |> Physics.at(Vec3.make(0.0, 5.0, 0.0))\n\
+             |> Physics.velocity(Vec3.make(1.0, 0.0, 0.0))\n\
              |> Physics.mass(2.0)\n\
              |> Physics.restitution(0.5)\n\
-             let main = () => Physics.scene(0.0, -9.81, 0.0, [\n\
+             let main = () => Physics.scene(Vec3.make(0.0, -9.81, 0.0), [\n\
                Physics.fixed(\"ground\", Physics.box(20.0, 0.2, 20.0)),\n\
                crate1,\n\
                Physics.kinematic(\"door\", Physics.capsule(1.0, 0.3)) |> Physics.sensor,\n\
@@ -4344,8 +4425,8 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
     fn physics_reads_see_the_stepped_world() {
         crate::physics::remove_world(crate::physics::DEFAULT_WORLD);
         let declare = eval(
-            "let main = () => Physics.scene(0.0, -9.81, 0.0, [\n\
-               Physics.dynamic(\"ball\", Physics.sphere(0.5)) |> Physics.at(0.0, 5.0, 0.0)])",
+            "let main = () => Physics.scene(Vec3.make(0.0, -9.81, 0.0), [\n\
+               Physics.dynamic(\"ball\", Physics.sphere(0.5)) |> Physics.at(Vec3.make(0.0, 5.0, 0.0))])",
         );
         let scene = physics_scene_value(&declare)
             .expect("a PhysicsScene")
@@ -4415,7 +4496,7 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
 
             // A suppressed drain (the dry-run forward-step) under the scope
             // queues the command on the SCOPED world…
-            let effect = eval("let main = () => Physics.applyImpulse(\"ball\", 2.0, 0.0, 0.0)");
+            let effect = eval("let main = () => Physics.applyImpulse(\"ball\", Vec3.make(2.0, 0.0, 0.0))");
             let Value::HostData(data) = &effect else {
                 panic!("expected an Effect");
             };
@@ -4499,7 +4580,7 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
     #[test]
     fn physics_command_effects_queue_and_apply() {
         crate::physics::remove_world(crate::physics::DEFAULT_WORLD);
-        let effect = eval("let main = () => Physics.applyImpulse(\"ball\", 2.0, 0.0, 0.0)");
+        let effect = eval("let main = () => Physics.applyImpulse(\"ball\", Vec3.make(2.0, 0.0, 0.0))");
         let Value::HostData(data) = &effect else {
             panic!("expected an Effect");
         };
@@ -4580,7 +4661,7 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
     #[test]
     fn non_finite_numbers_are_rejected_at_the_boundary() {
         let module = functor_lang::lower(
-            functor_lang::parse("let main = () => Scene.translate(1.0 / 0.0, 0.0, 0.0, Scene.cube())")
+            functor_lang::parse("let main = () => Scene.translate(Vec3.make(1.0 / 0.0, 0.0, 0.0), Scene.cube())")
                 .unwrap(),
         )
         .unwrap();
@@ -4751,7 +4832,7 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
         // `update` swaps the model for the hit record (tagger = a closure, so
         // the record itself is the message).
         let src = "let update = (m, msg) => msg\n\
-                   let main = () => Physics.raycast(0.0, 5.0, 0.0, 0.0, -1.0, 0.0, 100.0, (hit) => hit)";
+                   let main = () => Physics.raycast(Vec3.make(0.0, 5.0, 0.0), Vec3.make(0.0, -1.0, 0.0), 100.0, (hit) => hit)";
         let module = functor_lang::lower(functor_lang::parse(src).unwrap()).unwrap();
         let session = functor_lang::Session::load(&module, &mut FunctorHost)
             .unwrap_or_else(|f| panic!("load failed: {}", f.error.message));
@@ -5155,7 +5236,7 @@ Time.seconds(…) or Time.millis(…)"
         let frame = frame_of(
             "let main = () =>\n\
              Frame.create(\n\
-               Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0),\n\
+               Camera.lookAt(Vec3.make(0.0, 2.0, -6.0), Vec3.make(0.0, 0.0, 0.0)),\n\
                Scene.heightmap([[0.0, 1.0], [2.0, 3.0], [4.0, 5.0]]))",
         );
         let SceneObject::Geometry(Shape::Heightmap {
@@ -5183,7 +5264,7 @@ Time.seconds(…) or Time.millis(…)"
             "let ripple = (r, c) => 0.05 * (Math.sin(c * 0.5) + Math.cos(r * 0.5))\n\
              let main = () =>\n\
              Frame.create(\n\
-               Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0),\n\
+               Camera.lookAt(Vec3.make(0.0, 2.0, -6.0), Vec3.make(0.0, 0.0, 0.0)),\n\
                Scene.heightmap(\n\
                  List.range(4.0) |> List.map((r) =>\n\
                    List.range(4.0) |> List.map((c) => ripple(r, c)))))",
@@ -5242,7 +5323,7 @@ row 1 has 3"
              let grid = Texture.file(\"grid.png\")\n\
              let main = () =>\n\
              Frame.create(\n\
-               Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0),\n\
+               Camera.lookAt(Vec3.make(0.0, 2.0, -6.0), Vec3.make(0.0, 0.0, 0.0)),\n\
                Scene.group([\n\
                  Scene.plane() |> Scene.litTexture(dirt),\n\
                  Scene.quad() |> Scene.emissiveTexture(grid),\n\
@@ -5663,7 +5744,7 @@ the new text, got a number"
         let src = "\
             let init = 0.0\n\
             let shoot = Effect.play(\"gunshot.wav\")\n\
-            let blast = Effect.playAt(\"explosion.wav\", 5.0, 0.5, -2.0)\n";
+            let blast = Effect.playAt(\"explosion.wav\", Vec3.make(5.0, 0.5, -2.0))\n";
         let project = functor_lang::project::load_single_source("game", src)
             .unwrap_or_else(|e| panic!("load: {}", e.render()));
         let session = functor_lang::Session::load(&project.module, &mut FunctorHost)
@@ -5801,7 +5882,7 @@ the new text, got a number"
             let soundScape = (m) =>\n\
               AudioScene.create([\n\
                 AudioSource.ambient(\"wind\", \"wind-loop.wav\") |> AudioSource.gain(0.35),\n\
-                AudioSource.at(\"fountain\", \"water.wav\", 5.0, 0.5, 0.0)\n\
+                AudioSource.at(\"fountain\", \"water.wav\", Vec3.make(5.0, 0.5, 0.0))\n\
               ])\n";
         let project = functor_lang::project::load_single_source("game", src)
             .unwrap_or_else(|e| panic!("load: {}", e.render()));

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -750,7 +750,7 @@ to receive their messages; dropping them"
                     return steps;
                 }
                 None => self.reporter.report_once(format!(
-                    "[functor-lang] physics must return Physics.scene(gx, gy, gz, [body, …]), got {}",
+                    "[functor-lang] physics must return Physics.scene(gravity, [body, …]), got {}",
                     value.kind_name()
                 )),
             },
@@ -1390,7 +1390,7 @@ mod tests {
         let subscriptions = (m: Model) => Sub.every(Time.seconds(1.0), Tick)\n\
         let tick = (m: Model, dt: Float, tts: Float) => m\n\
         let draw = (m: Model, tts: Float) =>\n\
-          Frame.create(Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0), Scene.cube())\n";
+          Frame.create(Camera.lookAt(Vec3.make(0.0, 0.0, -5.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n";
 
     fn inspector_session() -> (Session, Value) {
         let project = functor_lang::project::load_single_source("game", INSPECTOR_SRC)

--- a/runtime/functor-runtime-common/tests/prelude_typecheck.rs
+++ b/runtime/functor-runtime-common/tests/prelude_typecheck.rs
@@ -50,11 +50,11 @@ fn real_tuple_mismatch_still_errors() {
 /// Host calls carry real types from the prelude `.funi`, across namespaces.
 #[test]
 fn host_calls_have_real_types() {
-    let diags = check("let bad : float = Camera.lookAt(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)");
+    let diags = check("let bad : float = Camera.lookAt(Vec3.make(0.0, 0.0, 0.0), Vec3.make(0.0, 0.0, 0.0))");
     assert!(diags.iter().any(|m| m.contains("Camera.t")), "{diags:?}");
     let diags = check(
         "let bad : float =\n\
-         Frame.create(Camera.lookAt(0.0, 0.0, 0.0, 0.0, 0.0, 0.0), Scene.cube())",
+         Frame.create(Camera.lookAt(Vec3.make(0.0, 0.0, 0.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube())",
     );
     assert!(diags.iter().any(|m| m.contains("Frame.t")), "{diags:?}");
 }

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -13,7 +13,7 @@
 //! // optional MVU pair (C4b-2) — timer messages fold through update:
 //! let update = (model, msg) => model'
 //! let subscriptions = (model) => Sub.every(Time.seconds(1.0), Msg)
-//! let physics = (model) => Physics.scene(gx, gy, gz, [body, …])  // OPTIONAL
+//! let physics = (model) => Physics.scene(Vec3.make(gx, gy, gz), [body, …])  // OPTIONAL
 //! let ui = (model) => Ui.column([…]) |> Ui.panel(Ui.topLeft())   // OPTIONAL HUD
 //! ```
 //!
@@ -1141,7 +1141,7 @@ mod tests {
              let subscriptions = (m: Model) => Sub.connect(\"ws://127.0.0.1:9001/echo\", Ws)\n\
              let tick = (m: Model, dt: Float, tts: Float) => m\n\
              let draw = (m: Model, tts: Float) =>\n\
-               Frame.create(Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0), Scene.cube())\n",
+               Frame.create(Camera.lookAt(Vec3.make(0.0, 0.0, -5.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n",
         )
         .unwrap();
         let _ = drain_conn_commands(); // clear the shared queue
@@ -1211,7 +1211,7 @@ mod tests {
              let subscriptions = (m: Model) => Sub.listen(\"127.0.0.1:9001\", toMsg)\n\
              let tick = (m: Model, dt: Float, tts: Float) => m\n\
              let draw = (m: Model, tts: Float) =>\n\
-               Frame.create(Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0), Scene.cube())\n",
+               Frame.create(Camera.lookAt(Vec3.make(0.0, 0.0, -5.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n",
         )
         .unwrap();
         let _ = drain_conn_commands();
@@ -1273,7 +1273,7 @@ mod tests {
 
     const BASE: &str = "let init = { n: 0.0 }\n\
          let tick = (m, dt, tts) => m\n\
-         let draw = (m, tts) => Frame.create(Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0), Scene.cube())\n";
+         let draw = (m, tts) => Frame.create(Camera.lookAt(Vec3.make(0.0, 2.0, -6.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n";
 
     /// Subscriptions produce messages; without an `update` they have nowhere
     /// to go — a load error, not a per-frame one.
@@ -1297,7 +1297,7 @@ mod tests {
             "init-effect",
             "let init = (0.0, Effect.none())
              let tick = (m, dt, tts) => m
-             let draw = (m, tts) => Frame.create(Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0), Scene.cube())
+             let draw = (m, tts) => Frame.create(Camera.lookAt(Vec3.make(0.0, 2.0, -6.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube())
 ",
         );
         assert!(
@@ -1418,7 +1418,7 @@ mod tests {
             dir.join("game.fun"),
             "let init = { n: 0.0 }\n\
              let tick = (m, dt, tts) => { m with n: m.n + 1.0 }\n\
-             let draw = (m, tts) => Frame.create(Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0), Scene.cube())\n",
+             let draw = (m, tts) => Frame.create(Camera.lookAt(Vec3.make(0.0, 2.0, -6.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n",
         )
         .expect("write game");
         let mut game = FunctorLangGame::create(dir.join("game.fun").to_str().expect("utf-8 path"));
@@ -1459,7 +1459,7 @@ mod tests {
         std::fs::create_dir_all(&dir).expect("create temp project dir");
         let src = "let init = { n: 0.0 }\n\
              let tick = (m, dt, tts) => { m with n: m.n + 1.0 }\n\
-             let draw = (m, tts) => Frame.create(Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0), Scene.cube())\n";
+             let draw = (m, tts) => Frame.create(Camera.lookAt(Vec3.make(0.0, 2.0, -6.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n";
         std::fs::write(dir.join("game.fun"), src).expect("write game");
         let mut game = FunctorLangGame::create(dir.join("game.fun").to_str().expect("utf-8 path"));
 
@@ -1528,10 +1528,10 @@ mod tests {
             dir.join("game.fun"),
             "let init = { n: 0.0 }\n\
              let tick = (m, dt, tts) => { m with n: m.n + 1.0 }\n\
-             let physics = (m) => Physics.scene(0.0, -9.81, 0.0, [\n\
-             \x20 Physics.fixed(\"ground\", Physics.box(20.0, 0.4, 20.0)) |> Physics.at(0.0, -0.2, 0.0),\n\
-             \x20 Physics.dynamic(\"ball\", Physics.sphere(0.5)) |> Physics.at(0.0, 8.0, 0.0)])\n\
-             let draw = (m, tts) => Frame.create(Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0), Scene.cube())\n",
+             let physics = (m) => Physics.scene(Vec3.make(0.0, -9.81, 0.0), [\n\
+             \x20 Physics.fixed(\"ground\", Physics.box(20.0, 0.4, 20.0)) |> Physics.at(Vec3.make(0.0, -0.2, 0.0)),\n\
+             \x20 Physics.dynamic(\"ball\", Physics.sphere(0.5)) |> Physics.at(Vec3.make(0.0, 8.0, 0.0))])\n\
+             let draw = (m, tts) => Frame.create(Camera.lookAt(Vec3.make(0.0, 2.0, -6.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n",
         )
         .expect("write game");
         let mut game = FunctorLangGame::create(dir.join("game.fun").to_str().expect("utf-8 path"));
@@ -1598,7 +1598,7 @@ mod tests {
             dir.join("game.fun"),
             "let init = { n: 0.0 }\n\
              let tick = (m, dt, tts) => { m with n: m.n + 1.0 }\n\
-             let draw = (m, tts) => Frame.create(Camera.lookAt(tts, 2.0, -6.0, 0.0, 0.0, 0.0), Scene.cube())\n",
+             let draw = (m, tts) => Frame.create(Camera.lookAt(Vec3.make(tts, 2.0, -6.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n",
         )
         .expect("write game");
         let mut game = FunctorLangGame::create(dir.join("game.fun").to_str().expect("utf-8 path"));
@@ -1662,9 +1662,9 @@ mod tests {
             dir.join("game.fun"),
             "let init = { n: 0.0 }\n\
              let tick = (m, dt, tts) => { m with n: m.n + 1.0 }\n\
-             let physics = (m) => Physics.scene(0.0, -9.81, 0.0, [\n\
-             \x20 Physics.dynamic(\"ball\", Physics.sphere(0.5)) |> Physics.at(0.0, 8.0, 0.0)])\n\
-             let draw = (m, tts) => Frame.create(Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0), Scene.cube())\n",
+             let physics = (m) => Physics.scene(Vec3.make(0.0, -9.81, 0.0), [\n\
+             \x20 Physics.dynamic(\"ball\", Physics.sphere(0.5)) |> Physics.at(Vec3.make(0.0, 8.0, 0.0))])\n\
+             let draw = (m, tts) => Frame.create(Camera.lookAt(Vec3.make(0.0, 2.0, -6.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n",
         )
         .expect("write game");
         let mut game = FunctorLangGame::create(dir.join("game.fun").to_str().expect("utf-8 path"));
@@ -1743,9 +1743,9 @@ mod tests {
             dir.join("game.fun"),
             "let init = { n: 0.0 }\n\
              let tick = (m, dt, tts) => { m with n: m.n + 1.0 }\n\
-             let physics = (m) => Physics.scene(0.0, -9.81, 0.0, [\n\
-             \x20 Physics.dynamic(\"ball\", Physics.sphere(0.5)) |> Physics.at(0.0, 8.0, 0.0)])\n\
-             let draw = (m, tts) => Frame.create(Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0), Scene.cube())\n",
+             let physics = (m) => Physics.scene(Vec3.make(0.0, -9.81, 0.0), [\n\
+             \x20 Physics.dynamic(\"ball\", Physics.sphere(0.5)) |> Physics.at(Vec3.make(0.0, 8.0, 0.0))])\n\
+             let draw = (m, tts) => Frame.create(Camera.lookAt(Vec3.make(0.0, 2.0, -6.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n",
         )
         .expect("write game");
         let mut game = FunctorLangGame::create(dir.join("game.fun").to_str().expect("utf-8 path"));
@@ -1802,14 +1802,14 @@ mod tests {
             "type Msg = | Contact(ev: e)\n\
              let init = { n: 0.0, hits: 0.0 }\n\
              let tick = (m, dt, tts) => { m with n: m.n + 1.0 }\n\
-             let physics = (m) => Physics.scene(0.0, -9.81, 0.0, [\n\
-             \x20 Physics.fixed(\"ground\", Physics.box(10.0, 0.4, 10.0)) |> Physics.at(0.0, -0.2, 0.0),\n\
-             \x20 Physics.dynamic(\"ball\", Physics.sphere(0.5)) |> Physics.at(0.0, 4.0, 0.0)])\n\
+             let physics = (m) => Physics.scene(Vec3.make(0.0, -9.81, 0.0), [\n\
+             \x20 Physics.fixed(\"ground\", Physics.box(10.0, 0.4, 10.0)) |> Physics.at(Vec3.make(0.0, -0.2, 0.0)),\n\
+             \x20 Physics.dynamic(\"ball\", Physics.sphere(0.5)) |> Physics.at(Vec3.make(0.0, 4.0, 0.0))])\n\
              let subscriptions = (m) => Physics.events(Contact)\n\
              let update = (m, msg) =>\n\
                match msg with\n\
                | Contact(e) => (match e.started with | true => { m with hits: m.hits + 1.0 } | false => m)\n\
-             let draw = (m, tts) => Frame.create(Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0), Scene.cube())\n",
+             let draw = (m, tts) => Frame.create(Camera.lookAt(Vec3.make(0.0, 2.0, -6.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n",
         )
         .expect("write game");
         let mut game = FunctorLangGame::create(dir.join("game.fun").to_str().expect("utf-8 path"));
@@ -2228,14 +2228,14 @@ mod tests {
                match key with\n\
                | Key.K =>\n\
                  (match isDown with\n\
-                  | true => (m, Physics.applyImpulse(\"ball\", 6.0, 0.0, 0.0))\n\
+                  | true => (m, Physics.applyImpulse(\"ball\", Vec3.make(6.0, 0.0, 0.0)))\n\
                   | false => m)\n\
                | _ => m\n\
-             let physics = (m) => Physics.scene(0.0, -9.81, 0.0, [\n\
-             \x20 Physics.fixed(\"ground\", Physics.box(10.0, 0.4, 10.0)) |> Physics.at(0.0, -0.2, 0.0),\n\
-             \x20 Physics.dynamic(\"ball\", Physics.sphere(0.5)) |> Physics.at(0.0, 4.0, 0.0)])\n\
+             let physics = (m) => Physics.scene(Vec3.make(0.0, -9.81, 0.0), [\n\
+             \x20 Physics.fixed(\"ground\", Physics.box(10.0, 0.4, 10.0)) |> Physics.at(Vec3.make(0.0, -0.2, 0.0)),\n\
+             \x20 Physics.dynamic(\"ball\", Physics.sphere(0.5)) |> Physics.at(Vec3.make(0.0, 4.0, 0.0))])\n\
              let draw = (m, tts) => Frame.create(\n\
-               Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0),\n\
+               Camera.lookAt(Vec3.make(0.0, 2.0, -6.0), Vec3.make(0.0, 0.0, 0.0)),\n\
                Scene.sphere() |> Physics.transformed(\"ball\"))\n",
         )
         .expect("write game");
@@ -2350,7 +2350,7 @@ mod tests {
         let input = (m: Model, key: Key.t, isDown: Bool) => { m with ticks: m.ticks + 100.0 }\n\
         let tick = (m: Model, dt: Float, tts: Float) => m\n\
         let draw = (m: Model, tts: Float) =>\n\
-          Frame.create(Camera.lookAt(0.0, 0.0, -5.0, 0.0, 0.0, 0.0), Scene.cube())\n";
+          Frame.create(Camera.lookAt(Vec3.make(0.0, 0.0, -5.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n";
 
     #[test]
     fn inspector_trace_replays_the_paused_frame_and_is_empty_while_playing() {

--- a/site/docs.html
+++ b/site/docs.html
@@ -64,7 +64,7 @@ npm run build:cli                    # builds the functor CLI + runtimes</pre>
 let tick = (m, dt, tts) => m
 let draw = (m, tts: Float) =>
   Frame.create(
-    Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0),
+    Camera.lookAt(Vec3.make(0.0, 2.0, -6.0), Vec3.make(0.0, 0.0, 0.0)),
     Scene.cube()
       |> Scene.emissive(Color.rgb(1.0, 0.2, 0.8))
       |> Scene.rotateY(Angle.radians(tts)))</pre>
@@ -106,7 +106,7 @@ let subscriptions = (model) => Sub.every(Time.seconds(1.0), Beat)
 
 let draw = (model, tts: Float) =>
   Frame.create(
-    Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0),
+    Camera.lookAt(Vec3.make(0.0, 2.0, -6.0), Vec3.make(0.0, 0.0, 0.0)),
     Scene.sphere()
       |> Scene.emissive(Color.rgb(1.0, 0.3, 0.8))
       |> Scene.scale(1.0 + 0.2 * Math.sin(model.spin * 4.0)))</pre>
@@ -129,10 +129,10 @@ let tick = (model, dt, tts) => model
 
 let draw = (model, tts) =>
   Frame.create(
-    Camera.lookAt(0.0, 2.0, -8.0, 0.0, 0.0, 0.0),
+    Camera.lookAt(Vec3.make(0.0, 2.0, -8.0), Vec3.make(0.0, 0.0, 0.0)),
     Scene.cube()
       |> Scene.emissive(Color.rgb(0.2, 0.9, 1.0))
-      |> Scene.translate(model.x, 0.0, 0.0))</pre>
+      |> Scene.translate(Vec3.make(model.x, 0.0, 0.0)))</pre>
           <p>
             And physics is declarative — describe the bodies each frame; the runtime reconciles
             and steps the world:
@@ -143,17 +143,17 @@ let tick = (m, dt, tts) => m
 let ballTag = Physics.tag("ball")
 
 let physics = (m) =>
-  Physics.scene(0.0, -9.81, 0.0, [
+  Physics.scene(Vec3.make(0.0, -9.81, 0.0), [
     Physics.fixed(Physics.tag("ground"), Physics.box(20.0, 0.4, 20.0))
-      |> Physics.at(0.0, -0.2, 0.0),
+      |> Physics.at(Vec3.make(0.0, -0.2, 0.0)),
     Physics.dynamic(ballTag, Physics.sphere(0.5))
-      |> Physics.at(0.3, 4.0, 0.0)
+      |> Physics.at(Vec3.make(0.3, 4.0, 0.0))
       |> Physics.restitution(0.8),
   ])
 
 let draw = (m, tts) =>
   Frame.createLit(
-    Camera.lookAt(0.0, 3.0, -8.0, 0.0, 1.0, 0.0),
+    Camera.lookAt(Vec3.make(0.0, 3.0, -8.0), Vec3.make(0.0, 1.0, 0.0)),
     Scene.group([
       Scene.plane() |> Scene.scale(20.0) |> Scene.lit(Color.rgb(0.4, 0.45, 0.55)),
       Scene.sphere()
@@ -163,7 +163,7 @@ let draw = (m, tts) =>
     ]),
     [
       Light.ambient(Color.rgb(0.15, 0.15, 0.2)),
-      Light.directional(0.4, -1.0, 0.3, Color.rgb(1.0, 0.95, 0.9), 0.9) |> Light.castShadows,
+      Light.directional(Vec3.make(0.4, -1.0, 0.3), Color.rgb(1.0, 0.95, 0.9), 0.9) |> Light.castShadows,
     ])</pre>
         </section>
 
@@ -331,7 +331,7 @@ let span = (a, b) =>
               <tr><td><code>scene |> Scene.color(Color.rgb(r, g, b))</code></td><td>flat unlit color</td></tr>
               <tr><td><code>scene |> Scene.lit(Color.rgb(r, g, b))</code></td><td>diffuse + specular (needs lights)</td></tr>
               <tr><td><code>scene |> Scene.emissive(Color.rgb(r, g, b))</code></td><td>unlit glow</td></tr>
-              <tr><td><code>scene |> Scene.translate(x, y, z)</code></td><td rowspan="3">transforms wrap outward: the <em>outer</em> call applies last in world space — <code>s |> rotateY(r) |> translate(x, 0.0, 0.0)</code> rotates in place, then moves</td></tr>
+              <tr><td><code>scene |> Scene.translate(Vec3.make(x, y, z))</code></td><td rowspan="3">transforms wrap outward: the <em>outer</em> call applies last in world space — <code>s |> rotateY(r) |> translate(Vec3.make(x, 0.0, 0.0))</code> rotates in place, then moves</td></tr>
               <tr><td><code>scene |> Scene.rotateX/Y/Z(angle)</code></td></tr>
               <tr><td><code>scene |> Scene.scale(k)</code></td></tr>
             </tbody>
@@ -345,11 +345,11 @@ let span = (a, b) =>
           <h3>Camera, lights, frames</h3>
           <table>
             <tbody>
-              <tr><td><code>Camera.lookAt(ex, ey, ez, tx, ty, tz)</code></td><td>up = +Y, fov 45°</td></tr>
-              <tr><td><code>Camera.firstPerson(ex, ey, ez, yaw, pitch, fov)</code></td><td>all three are Angles; yaw 0 / pitch 0 looks down +Z</td></tr>
+              <tr><td><code>Camera.lookAt(Vec3.make(ex, ey, ez), Vec3.make(tx, ty, tz))</code></td><td>up = +Y, fov 45°</td></tr>
+              <tr><td><code>Camera.firstPerson(Vec3.make(ex, ey, ez), yaw, pitch, fov)</code></td><td>all three are Angles; yaw 0 / pitch 0 looks down +Z</td></tr>
               <tr><td><code>Light.ambient(Color.rgb(r, g, b))</code></td><td></td></tr>
-              <tr><td><code>Light.directional(dx, dy, dz, Color.rgb(r, g, b), intensity)</code></td><td><code>|> Light.castShadows</code> for a shadowed key light</td></tr>
-              <tr><td><code>Light.point(px, py, pz, Color.rgb(r, g, b), intensity, range)</code></td><td></td></tr>
+              <tr><td><code>Light.directional(Vec3.make(dx, dy, dz), Color.rgb(r, g, b), intensity)</code></td><td><code>|> Light.castShadows</code> for a shadowed key light</td></tr>
+              <tr><td><code>Light.point(Vec3.make(px, py, pz), Color.rgb(r, g, b), intensity, range)</code></td><td></td></tr>
               <tr><td><code>Frame.create(camera, scene)</code></td><td>what <code>draw</code> returns</td></tr>
               <tr><td><code>Frame.createLit(camera, scene, [light, …])</code></td><td>lit + shadowed</td></tr>
             </tbody>
@@ -385,8 +385,8 @@ let span = (a, b) =>
             <tbody>
               <tr><td><code>Physics.box(w, h, d) / sphere(r) / capsule(halfH, r)</code></td><td>shapes; box takes <em>full</em> extents</td></tr>
               <tr><td><code>Physics.dynamic(tag, shape)</code></td><td>simulated; also <code>kinematic</code> / <code>fixed</code>; tags are <code>Physics.tag("name")</code> values</td></tr>
-              <tr><td><code>body |> Physics.at(x, y, z)</code></td><td>spawn pose; also <code>velocity</code>, <code>mass</code>, <code>friction</code>, <code>restitution</code>, <code>sensor</code></td></tr>
-              <tr><td><code>Physics.scene(gx, gy, gz, [body, …])</code></td><td>what the <code>physics</code> hook returns</td></tr>
+              <tr><td><code>body |> Physics.at(Vec3.make(x, y, z))</code></td><td>spawn pose; also <code>velocity</code>, <code>mass</code>, <code>friction</code>, <code>restitution</code>, <code>sensor</code></td></tr>
+              <tr><td><code>Physics.scene(Vec3.make(gx, gy, gz), [body, …])</code></td><td>what the <code>physics</code> hook returns</td></tr>
               <tr><td><code>Physics.position(tag)</code></td><td><code>{x, y, z}</code> of the live body</td></tr>
               <tr><td><code>scene |> Physics.transformed(tag)</code></td><td>draw a scene at the body's live pose</td></tr>
             </tbody>

--- a/site/examples/hero.fun
+++ b/site/examples/hero.fun
@@ -24,9 +24,9 @@ let dot = (t, ix, iz) =>
     |> Scene.rotateY(Angle.radians(t * 0.7 + ix + iz))
     |> Scene.scale(0.21 + 0.07 * Math.sin(t * 3.0 + ix * 0.9 + iz * 0.6))
     |> Scene.translate(
-         (ix - (gridCols - 1.0) / 2.0) * spacing,
+         Vec3.make((ix - (gridCols - 1.0) / 2.0) * spacing,
          waveY(t, ix, iz),
-         iz * spacing)
+         iz * spacing))
 // </editable>
 
 let row = (t, iz) =>
@@ -40,7 +40,7 @@ let sun = (t) =>
   Scene.sphere()
     |> Scene.emissive(Color.rgb(1.0, 0.36 + 0.08 * Math.sin(t * 1.7), 0.5))
     |> Scene.scale(6.5)
-    |> Scene.translate(0.0, 3.2, 40.0)
+    |> Scene.translate(Vec3.make(0.0, 3.2, 40.0))
 
 // A flat backdrop quad well behind the sun: it fills the frame with the
 // night-sky violet (the renderer has no clear-color hook). A quad's front is
@@ -50,13 +50,13 @@ let sky = () =>
     |> Scene.emissive(Color.rgb(0.06, 0.015, 0.14))
     |> Scene.rotateY(Angle.degrees(180.0))
     |> Scene.scale(130.0)
-    |> Scene.translate(0.0, 0.0, 55.0)
+    |> Scene.translate(Vec3.make(0.0, 0.0, 55.0))
 
 let ground = () =>
   Scene.plane()
     |> Scene.color(Color.rgb(0.045, 0.01, 0.1))
     |> Scene.scale(90.0)
-    |> Scene.translate(0.0, -0.9, 20.0)
+    |> Scene.translate(Vec3.make(0.0, -0.9, 20.0))
 
 let init = { t: 0.0 }
 
@@ -64,5 +64,5 @@ let tick = (model, dt: float, tts: float) => { model with t: model.t + dt }
 
 let draw = (model, tts: float) =>
   Frame.create(
-    Camera.lookAt(0.0, 3.4, -13.0, 0.0, 1.8, 12.0),
+    Camera.lookAt(Vec3.make(0.0, 3.4, -13.0), Vec3.make(0.0, 1.8, 12.0)),
     Scene.group([sky(), ground(), sun(model.t), grid(model.t)]))

--- a/site/src/ide.js
+++ b/site/src/ide.js
@@ -50,7 +50,7 @@ let tick = (model, dt: Float, tts: Float) => { model with t: model.t + dt }
 
 let draw = (model, tts: Float) =>
   Frame.create(
-    Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.5, 0.0),
+    Camera.lookAt(Vec3.make(0.0, 2.0, -6.0), Vec3.make(0.0, 0.5, 0.0)),
     Scene.group([
       Scene.sphere() |> Scene.emissive(Color.rgb(0.15, 1.0, Palette.glow)) |> Scene.scale(1.4),
       Scene.plane() |> Scene.scale(12.0) |> Scene.lit(Color.rgb(Palette.sky, 0.12, 0.35)),

--- a/tools/functor-lang-wasm/src/lib.rs
+++ b/tools/functor-lang-wasm/src/lib.rs
@@ -438,7 +438,7 @@ mod tests {
     #[test]
     fn valid_program_with_prelude_is_clean() {
         let src = "let draw = (model, tts: Float) =>\n  \
-            Frame.create(Camera.lookAt(0.0, 0.0, -6.0, 0.0, 0.0, 0.0), Scene.cube())\n";
+            Frame.create(Camera.lookAt(Vec3.make(0.0, 0.0, -6.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n";
         let out = parse(&analyze_json(src));
         assert_eq!(out["diagnostics"].as_array().unwrap().len(), 0, "{out}");
         // Inlays/lenses come only from the user file — never from the injected
@@ -667,7 +667,7 @@ mod tests {
     // Single-file analyze errors on the unknown `Palette`; the project variant
     // resolves it — the reason the `_project` API exists.
     const GAME: &str = "let draw = (model, tts: Float) =>\n  \
-        Frame.create(Camera.lookAt(0.0, 0.0, -6.0, 0.0, 0.0, 0.0), \
+        Frame.create(Camera.lookAt(Vec3.make(0.0, 0.0, -6.0), Vec3.make(0.0, 0.0, 0.0)), \
         Scene.sphere() |> Scene.emissive(Color.rgb(0.15, 1.0, Palette.glow)))\n";
     const PALETTE: &str = "let glow = 0.85\nlet sky = 0.18\n";
 

--- a/tools/functor-sdk/test/functor-lang-closure-rebind.e2e.test.ts
+++ b/tools/functor-sdk/test/functor-lang-closure-rebind.e2e.test.ts
@@ -21,7 +21,7 @@ const game = (body: string) => `let makeSpin = (k) => (dt) => ${body}
 let init = { vel: makeSpin(2.0), x: 0.0 }
 let tick = (m, dt, tts) => { m with x: m.x + m.vel(dt) }
 let draw = (m, tts) =>
-  Frame.create(Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0), Scene.cube())
+  Frame.create(Camera.lookAt(Vec3.make(0.0, 2.0, -6.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube())
 `;
 
 function xOf(model: string): number {

--- a/tools/functor-sdk/test/functor-lang-effects.e2e.test.ts
+++ b/tools/functor-sdk/test/functor-lang-effects.e2e.test.ts
@@ -31,7 +31,7 @@ let input = (m, key, isDown) =>
   | true => (m, Effect.random(Rolled))
   | false => m
 let draw = (m, tts) =>
-  Frame.create(Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0), Scene.cube())
+  Frame.create(Camera.lookAt(Vec3.make(0.0, 2.0, -6.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube())
 `;
 
 function fieldOf(model: string, name: string): number {

--- a/tools/functor-sdk/test/functor-lang-hot-reload.e2e.test.ts
+++ b/tools/functor-sdk/test/functor-lang-hot-reload.e2e.test.ts
@@ -19,7 +19,7 @@ const game = (speed: string) => `let speed = ${speed}
 let init = { spin: 0.0 }
 let tick = (m, dt, tts) => { m with spin: m.spin + dt * speed }
 let draw = (m, tts) =>
-  Frame.create(Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0), Scene.cube())
+  Frame.create(Camera.lookAt(Vec3.make(0.0, 2.0, -6.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube())
 `;
 
 /** The spin field of the runner's `/state` model (Functor Lang Value display). */

--- a/tools/functor-sdk/test/functor-lang-input.e2e.test.ts
+++ b/tools/functor-sdk/test/functor-lang-input.e2e.test.ts
@@ -16,7 +16,7 @@ const GAME = `let init = { presses: 0.0, last: "none" }
 let input = (m, key, isDown) => { m with presses: m.presses + 1.0, last: key }
 let tick = (m, dt, tts) => m
 let draw = (m, tts) =>
-  Frame.create(Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0), Scene.cube())
+  Frame.create(Camera.lookAt(Vec3.make(0.0, 2.0, -6.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube())
 `;
 
 test(

--- a/tools/functor-sdk/test/functor-lang-modules-hot-reload.e2e.test.ts
+++ b/tools/functor-sdk/test/functor-lang-modules-hot-reload.e2e.test.ts
@@ -22,7 +22,7 @@ const headless = process.env.FUNCTOR_E2E_HEADLESS === "1";
 const game = `let init = { spin: 0.0 }
 let tick = (m, dt, tts) => { m with spin: m.spin + dt * Config.speed }
 let draw = (m, tts) =>
-  Frame.create(Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0), Scene.cube())
+  Frame.create(Camera.lookAt(Vec3.make(0.0, 2.0, -6.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube())
 `;
 
 const config = (speed: string) => `let speed = ${speed}

--- a/tools/functor-sdk/test/functor-lang-perf.e2e.test.ts
+++ b/tools/functor-sdk/test/functor-lang-perf.e2e.test.ts
@@ -70,11 +70,11 @@ let marker = (i: Float, tts: Float, r: Float, g: Float, b: Float) =>
   Scene.sphere()
     |> Scene.scale(0.15)
     |> Scene.emissive(Color.rgb(r, g, b))
-    |> Scene.translate(p.x, p.y, p.z)
+    |> Scene.translate(Vec3.make(p.x, p.y, p.z))
 
 let pointLight = (i: Float, tts: Float, r: Float, g: Float, b: Float) =>
   let p = pointPos(i, tts) in
-  Light.point(p.x, p.y, p.z, Color.rgb(r, g, b), 1.4, 6.0)
+  Light.point(Vec3.make(p.x, p.y, p.z), Color.rgb(r, g, b), 1.4, 6.0)
 
 // Spiral placement: radius and angle both derive from the index (no
 // mod/floor in the language yet); spin and bob derive from the phase.
@@ -84,12 +84,12 @@ let shapeFor = (e) =>
   Scene.cube()
     |> Scene.scale(0.3)
     |> Scene.rotateY(Angle.radians(e.phase))
-    |> Scene.translate(Math.cos(a) * r, 0.4 + Math.sin(e.phase) * 0.2, Math.sin(a) * r)
+    |> Scene.translate(Vec3.make(Math.cos(a) * r, 0.4 + Math.sin(e.phase) * 0.2, Math.sin(a) * r))
 
 let draw = (m, tts: Float) =>
   Frame.createLit(
     Camera.firstPerson(
-      0.0, 9.0, -16.0,
+      Vec3.make(0.0, 9.0, -16.0),
       Angle.radians(0.0), Angle.radians(-0.5), Angle.degrees(60.0)),
     Scene.group([
       Scene.plane() |> Scene.scale(30.0) |> Scene.lit(Color.rgb(0.6, 0.6, 0.62)),
@@ -99,7 +99,7 @@ let draw = (m, tts: Float) =>
     ]),
     [
       Light.ambient(Color.rgb(0.1, 0.1, 0.13)),
-      Light.directional(0.5, -1.0, 0.35, Color.rgb(1.0, 0.98, 0.95), 0.85) |> Light.castShadows,
+      Light.directional(Vec3.make(0.5, -1.0, 0.35), Color.rgb(1.0, 0.98, 0.95), 0.85) |> Light.castShadows,
       pointLight(0.0, tts, 1.0, 0.3, 0.25),
       pointLight(1.0, tts, 0.35, 0.5, 1.0),
     ])

--- a/tools/functor-sdk/test/functor-lang-subscriptions.e2e.test.ts
+++ b/tools/functor-sdk/test/functor-lang-subscriptions.e2e.test.ts
@@ -37,14 +37,14 @@ let subscriptions = (m) => Sub.batch([
   Sub.every(Time.millis(1000.0), Echo),
 ])
 let draw = (m, tts) =>
-  Frame.create(Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0), Scene.cube())
+  Frame.create(Camera.lookAt(Vec3.make(0.0, 2.0, -6.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube())
 `;
 
 // The same game with no subscriptions/update — the reload starting point.
 const unsubscribed = `let init = { beats: 0.0, echoes: 0.0 }
 let tick = (m, dt, tts) => m
 let draw = (m, tts) =>
-  Frame.create(Camera.lookAt(0.0, 2.0, -6.0, 0.0, 0.0, 0.0), Scene.cube())
+  Frame.create(Camera.lookAt(Vec3.make(0.0, 2.0, -6.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube())
 `;
 
 /** A named Float field of the runner's `/state` model (Functor Lang Value display). */


### PR DESCRIPTION
## Summary

Fifth slice of the strong-typing track (stacked on #371): the Angle rule applied to space. `Vec3.make(x, y, z)` makes an opaque `Vec3.t`, and every position/direction/velocity/gravity parameter takes one:

- `Scene.translate(v)` · `Camera.lookAt(eye, target)` (6 floats → 2 Vec3s) · `Camera.firstPerson(eye, …)`
- `Light.directional(dir, …)` / `point(pos, …)` / `spot(pos, dir, …)`
- `Physics.at`/`velocity`/`scene(gravity, …)` / the four command effects (`applyImpulse(tag, v)`) / `raycast(origin, dir, maxDist, tagger)`
- `Effect.playAt(sound, pos)` · `AudioSource.at(key, sound, pos)`

Arity slips and float-interleaving mistakes become unrepresentable; a bare number gets the teaching error ("wrap the components: `Vec3.make(x, y, z)`") and the pre-Vec3 spelling gets the new usage line.

## Deliberate boundaries

- **Reads stay records.** `Physics.position` and `rayHit` keep returning plain `{x, y, z}` so components stay accessible for game math (a Vec3 is opaque). Component accessors and vector math (`Vec3.add`/`scale`/`length`, Vec2/Vec4) are deferred until an API hands a Vec3 back.
- `Scene.scaleXYZ` keeps floats — scale factors, not a spatial vector.
- Reload-safe like Color: spawn points/velocities stored in the model survive hot-reload time travel.

## Migration & validation

~230 call sites across all examples, both templates, the site's runnable examples/API tables, e2e + SDK fixtures, embedded Rust test games, and the wasm-tooling fixtures.

- **Golden-image test: 0 differing pixels across all 7 scenarios** — render-identical.
- All crates green, including `functor-lang-wasm` (whose fixture suite was previously outside the validation set — now included); every example passes `functor build`; `examples/physics` renders correctly headlessly; web compiles for wasm32.
- Cross-engine adversarial review (Claude + Codex): no Critical correctness findings; all findings applied (wasm-tooling fixtures, inspector fixture, stale usage/error strings, skill/interface doc snippets, and narrowing an overclaimed "transposition unrepresentable" doc line — the two Vec3s of `lookAt` remain swappable).

The `functor-lang` skill and `docs/functor-lang.md` are updated in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)