### PR TITLE
feat(functor-lang): value previews, kind, and reference-site recording

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -161,6 +161,11 @@ multi-file.
       [const-tweaker](https://github.com/tversteeg/const-tweaker). (Functor Lang hot-reload
       already rebinds edited top-level values live; this is the finer-grained,
       no-reload knob.)
+- [ ] IDE status bar: project-wide Problems. The panel currently mirrors the
+      per-document lint pass (active file only), so a type error in a
+      non-active sibling is invisible while the preview is red. Collect by
+      running `functor_lang_analyze_project` once per file (the export's documented
+      contract) on the same debounce.
 
 ## Audio
 

--- a/e2e/ide-page.mjs
+++ b/e2e/ide-page.mjs
@@ -236,6 +236,26 @@ try {
     if (underlined > 0) console.log("type error draws a lint underline ✓");
     else fail("no lint underline for a type error");
 
+    // The status bar's Problems tab mirrors the same pass, naming the file.
+    const problemsTab = page.locator('.statusbar-tab[data-tab="problems"]');
+    const flaggedTab = await poll(
+      async () => ((await problemsTab.textContent()) || "").trim(),
+      (t) => t.includes("1 problem")
+    );
+    if (flaggedTab.includes("1 problem")) console.log("problems tab counts the type error ✓");
+    else fail(`problems tab out of sync: ${flaggedTab}`);
+    await problemsTab.click();
+    const rowText = await poll(
+      async () => {
+        const row = page.locator(".problem-row");
+        return (await row.count()) ? (await row.first().textContent()) || "" : "";
+      },
+      (t) => t.includes("game.fun")
+    );
+    if (rowText.includes("game.fun")) console.log("problems row names the active file ✓");
+    else fail(`problem row missing the file: ${rowText}`);
+    await problemsTab.click(); // close the panel again
+
     await page.evaluate((src) => window.__ide.setActiveSource(src), gameSource);
     const cleared = await poll(() => page.locator(".cm-lintRange-error").count(), (n) => n === 0);
     if (cleared === 0) console.log("fixing the type error clears the underline ✓");

--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -1116,6 +1116,86 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
   }
 }
 
+// --- 12b. Status bar: Problems + Output. ---------------------------------------
+// The bottom strip's Problems tab mirrors the lint pass (count + clickable
+// rows that jump the editor), and the Output panel receives runtime console
+// traces (`Debug.log`, forwarded from the player iframe) plus reload results.
+{
+  const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+  await page.goto(`${BASE}/sandbox.html`);
+  await page.waitForFunction(
+    () => window.__sandbox && window.__sandbox.status().state === "live",
+    { timeout: 30000 }
+  );
+
+  const problemsTab = page.locator('.statusbar-tab[data-tab="problems"]');
+  const outputTab = page.locator('.statusbar-tab[data-tab="output"]');
+  const tabText = async (tab) => ((await tab.textContent()) || "").trim();
+  const waitFor = async (fn, pred, timeout = 8000) => {
+    const t0 = Date.now();
+    for (;;) {
+      const v = await fn();
+      if (pred(v)) return v;
+      if (Date.now() - t0 > timeout) return v;
+      await sleep(150);
+    }
+  };
+
+  // A type error fills the Problems tab and panel.
+  const BAD = `${GREEN}let oops = (x: Float) => x + "status bar"\n`;
+  await page.evaluate((s) => window.__sandbox.setSource(s), BAD);
+  const flagged = await waitFor(() => tabText(problemsTab), (t) => t.includes("1 problem"));
+  check("problems tab counts the type error", flagged.includes("1 problem"), flagged);
+
+  await problemsTab.click();
+  const row = page.locator(".problem-row");
+  const rowText = await waitFor(
+    async () => ((await row.count()) ? await row.first().textContent() : ""),
+    (t) => t.includes("game.fun")
+  );
+  check(
+    "problems panel lists the diagnostic with its location",
+    rowText.includes("float") && rowText.includes("game.fun"),
+    rowText
+  );
+
+  // Clicking the row jumps + focuses the editor.
+  await row.first().click();
+  const focused = await page.evaluate(() =>
+    document.activeElement ? document.activeElement.classList.contains("cm-content") : false
+  );
+  check("clicking a problem focuses the editor", focused);
+
+  // Fixing the error empties the tab back out.
+  await page.evaluate((s) => window.__sandbox.setSource(s), GREEN);
+  const cleared = await waitFor(() => tabText(problemsTab), (t) => t.includes("0 problems"));
+  check("fixing the error resets the problems tab", cleared.includes("0 problems"), cleared);
+
+  // A top-level Debug.log fires on the hot-swap and lands in Output (the
+  // player forwards its console), alongside the reload-result lines.
+  await page.evaluate(
+    (s) => window.__sandbox.setSource(s),
+    `${GREEN}let boot = Debug.log("status-probe", 42.0)\n`
+  );
+  await outputTab.click();
+  const outputLines = await waitFor(
+    () => page.locator(".output-line").allTextContents(),
+    (lines) => lines.some((l) => l.includes("status-probe"))
+  );
+  check(
+    "Debug.log reaches the Output panel",
+    outputLines.some((l) => l.includes("status-probe")),
+    JSON.stringify(outputLines.slice(-4))
+  );
+  check(
+    "reload results reach the Output panel",
+    outputLines.some((l) => l.includes("model preserved")),
+    JSON.stringify(outputLines.slice(-4))
+  );
+
+  await page.close();
+}
+
 // --- 13. Scope-aware autocomplete in the editor (commit 8b). ------------------
 // The completion source is backed by the wasm's scope-aware `complete`, driven
 // through the __sandbox.triggerComplete seam (insert text + set cursor + open

--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -1192,6 +1192,14 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
     outputLines.some((l) => l.includes("model preserved")),
     JSON.stringify(outputLines.slice(-4))
   );
+  // Runtime lines carry a `[Frame N | HH:MM:SS]` preamble (the game was
+  // already running when the hot-swap re-evaluated the Debug.log).
+  const probeLine = outputLines.find((l) => l.includes("status-probe")) || "";
+  check(
+    "output lines carry a [Frame N | time] preamble",
+    /^\[Frame \d+ \| \d{2}:\d{2}:\d{2}\]/.test(probeLine),
+    probeLine
+  );
 
   await page.close();
 }

--- a/functor-lang/src/eval.rs
+++ b/functor-lang/src/eval.rs
@@ -59,9 +59,12 @@ const MAX_EVAL_DEPTH: usize = 128;
 pub const MAX_TRACE_EVENTS: usize = 10_000;
 
 /// Recorder caps (see [`Recorder`] / [`Session::call_recorded`]). Distinct
-/// binding *sites* per armed invocation, and total binding *events* (a loop
-/// re-binding one site counts each time). A breach stops recording and flags
-/// `truncated`; evaluation itself is never affected.
+/// *sites* per armed invocation — PER SITE CLASS (binders and references
+/// budget separately, so a reference-heavy body can't starve the binder
+/// record) — and total *events* (a loop re-hitting one site counts each
+/// time). A site-class breach stops NEW sites of that class only; the event
+/// breach stops recording entirely. Both flag `truncated`; evaluation itself
+/// is never affected.
 pub const MAX_RECORDED_SITES: usize = 1024;
 pub const MAX_RECORDED_BINDINGS: usize = 100_000;
 
@@ -116,6 +119,9 @@ pub struct RecordedInvocation {
     pub entry: String,
     /// `Display` of the returned value.
     pub result: String,
+    /// Depth-limited one-line preview of the returned value
+    /// ([`Value::preview`]) — what an editor shows inline.
+    pub result_preview: String,
     /// One entry per distinct binding site reached, in first-seen order.
     pub bindings: Vec<RecordedBinding>,
     /// The recorder hit a cap during this call — `bindings` is partial (but
@@ -123,35 +129,77 @@ pub struct RecordedInvocation {
     pub truncated: bool,
 }
 
-/// One binding site's last observed value. A site is a `let` binding, a
-/// lambda/function parameter, or a match-pattern variable; nested calls' sites
-/// appear here too (flat — spans disambiguate them). `value` is the LAST
-/// value bound at the site and `count` how many times it bound (a loop, e.g.
-/// `List.fold`, re-binds a site each iteration).
+/// How a recorded value renders in an editor: a `Primitive` is short and
+/// complete (its preview IS its full rendering — show inline as-is); a
+/// `Composite` has structure (show the depth-limited preview inline and the
+/// full `value` on hover). See [`Value::is_primitive`].
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum RecordedKind {
+    Primitive,
+    Composite,
+}
+
+/// What kind of site observed the value: a `Binder` (a `let` binding, a
+/// lambda/function parameter, or a match-pattern variable) or a `Ref` — a
+/// READ of a local or module-level name, so every line that *uses* a
+/// variable carries its value too. Reference sites skip callable values (a
+/// call's callee name is not data worth overlaying).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum RecordedSite {
+    Binder,
+    Ref,
+}
+
+/// One site's last observed value: `Binder` sites (a `let` binding, a
+/// lambda/function parameter, a match-pattern variable) plus `Ref` sites
+/// (variable reads); nested calls' sites appear here too (flat — spans
+/// disambiguate them). `value` is the LAST value seen at the site and
+/// `count` how many times it was seen (a loop, e.g. `List.fold`, re-binds
+/// and re-reads a site each iteration).
 pub struct RecordedBinding {
     pub name: String,
     /// Byte range into the loaded source. NOTE: [`Span`] carries no file — a
     /// multi-file project loads as one concatenated source, so mapping this
     /// range back to (file, offset) is the producer's job (see the visual-
     /// debugger wire contract). For a `let` this is the `let [mut] name =`
-    /// region (as `goto`/`hover` report binder names); for a param or match
-    /// var it is the name's own span.
+    /// region (as `goto`/`hover` report binder names); for a param, match
+    /// var, or reference it is the name's own span.
     pub span: Span,
-    /// `Display` of the last value bound here.
+    /// `Display` of the last value seen here.
     pub value: String,
+    /// Depth-limited one-line preview of that value ([`Value::preview`]);
+    /// equals `value` when `kind` is `Primitive`.
+    pub preview: String,
+    /// Whether `value` is short/complete or structured — the editor's
+    /// inline-vs-hover policy input.
+    pub kind: RecordedKind,
+    /// Binder or reference — see [`RecordedSite`].
+    pub site: RecordedSite,
     pub count: u32,
 }
 
-/// The per-call binding-site recorder — armed by [`Session::call_recorded`],
+/// A recorder site key. Binder sites key by [`BindingId`] (unique per site
+/// in a module; a loop re-enters the same site's id); reference sites key by
+/// the reference expression's start offset — unique among references, since
+/// no two name reads start at the same byte.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+enum SiteKey {
+    Binding(u32),
+    Ref(usize),
+}
+
+/// The per-call site recorder — armed by [`Session::call_recorded`],
 /// mirroring the [`Tracing`] mode: an `Option<Recorder>` on the interpreter,
-/// checked cheaply at binding sites only (a `None` test when off). Keyed by
-/// [`BindingId`] (unique per site in a module; a loop re-enters the same
-/// site's id), it keeps the last value + hit count per site. On a cap breach
-/// it sets `truncated` and stops recording — evaluation continues untouched.
+/// checked cheaply at binding and reference sites only (a `None` test when
+/// off). It keeps the last value + hit count per site. On a cap breach it
+/// sets `truncated` and stops recording — evaluation continues untouched.
 struct Recorder {
     bindings: Vec<RecordedBinding>,
-    /// `BindingId` raw → index into `bindings`.
-    index: HashMap<u32, usize>,
+    /// Site key → index into `bindings`.
+    index: HashMap<SiteKey, usize>,
+    /// Distinct sites so far, per class (see [`MAX_RECORDED_SITES`]).
+    binder_sites: usize,
+    ref_sites: usize,
     events: usize,
     truncated: bool,
 }
@@ -161,36 +209,58 @@ impl Recorder {
         Recorder {
             bindings: Vec::new(),
             index: HashMap::new(),
+            binder_sites: 0,
+            ref_sites: 0,
             events: 0,
             truncated: false,
         }
     }
 
-    /// Record a value bound at `binding`'s site. Once `truncated`, a no-op.
-    fn record(&mut self, binding: u32, name: &str, span: Span, value: &Value) {
-        if self.truncated {
+    /// Record a value observed at a site. The event cap is a hard stop; a
+    /// site-class cap only refuses NEW sites of that class — existing sites
+    /// keep updating and the other class keeps recording, so a
+    /// reference-heavy body can't starve the binder record.
+    fn record(&mut self, key: SiteKey, site: RecordedSite, name: &str, span: Span, value: &Value) {
+        if self.events >= MAX_RECORDED_BINDINGS {
+            self.truncated = true;
             return;
         }
         self.events += 1;
-        if self.events > MAX_RECORDED_BINDINGS {
+        if let Some(&idx) = self.index.get(&key) {
+            let slot = &mut self.bindings[idx];
+            slot.value = value.to_string();
+            slot.preview = value.preview();
+            slot.kind = recorded_kind(value);
+            slot.count += 1;
+            return;
+        }
+        let sites = match site {
+            RecordedSite::Binder => &mut self.binder_sites,
+            RecordedSite::Ref => &mut self.ref_sites,
+        };
+        if *sites >= MAX_RECORDED_SITES {
             self.truncated = true;
             return;
         }
-        if let Some(&idx) = self.index.get(&binding) {
-            let slot = &mut self.bindings[idx];
-            slot.value = value.to_string();
-            slot.count += 1;
-        } else if self.bindings.len() >= MAX_RECORDED_SITES {
-            self.truncated = true;
-        } else {
-            self.index.insert(binding, self.bindings.len());
-            self.bindings.push(RecordedBinding {
-                name: name.to_string(),
-                span,
-                value: value.to_string(),
-                count: 1,
-            });
-        }
+        *sites += 1;
+        self.index.insert(key, self.bindings.len());
+        self.bindings.push(RecordedBinding {
+            name: name.to_string(),
+            span,
+            value: value.to_string(),
+            preview: value.preview(),
+            kind: recorded_kind(value),
+            site,
+            count: 1,
+        });
+    }
+}
+
+fn recorded_kind(value: &Value) -> RecordedKind {
+    if value.is_primitive() {
+        RecordedKind::Primitive
+    } else {
+        RecordedKind::Composite
     }
 }
 
@@ -379,6 +449,7 @@ impl Session {
         let invocation = RecordedInvocation {
             entry: name.to_string(),
             result: result.to_string(),
+            result_preview: result.preview(),
             bindings: recorder.bindings,
             truncated: recorder.truncated,
         };
@@ -468,7 +539,28 @@ evaluation depth."
     /// [`Recorder`].
     fn record_binding(&mut self, binding: BindingId, name: &str, span: Span, value: &Value) {
         if let Some(recorder) = &mut self.recorder {
-            recorder.record(binding.0, name, span, value);
+            recorder.record(SiteKey::Binding(binding.0), RecordedSite::Binder, name, span, value);
+        }
+    }
+
+    /// Record a value READ at a reference site (a `Local`/`Global` name use),
+    /// when the recorder is armed — the same cheap `None` check otherwise.
+    /// Callable values are skipped: a call's callee name (`helper(m)`,
+    /// `xs |> sum`) is not data worth overlaying, and skipping it halves the
+    /// noise at the source.
+    fn record_ref(&mut self, name: &str, span: Span, value: &Value) {
+        if let Some(recorder) = &mut self.recorder {
+            if matches!(
+                value,
+                Value::Closure(_)
+                    | Value::Ctor { .. }
+                    | Value::Partial(_)
+                    | Value::Builtin(_)
+                    | Value::HostFn(_)
+            ) {
+                return;
+            }
+            recorder.record(SiteKey::Ref(span.start), RecordedSite::Ref, name, span, value);
         }
     }
 
@@ -477,15 +569,23 @@ evaluation depth."
             ExprKind::Number(n) => Ok(Value::Number(*n)),
             ExprKind::String(s) => Ok(Value::String(Rc::from(s.as_str()))),
             ExprKind::Bool(b) => Ok(Value::Bool(*b)),
-            ExprKind::Local { binding, name } => env.lookup(*binding).ok_or_else(|| RunError {
-                // Unreachable if lowering is correct; fail loud rather than UB.
-                message: format!("internal: unbound local `{name}`"),
-                span: expr.span,
-            }),
-            ExprKind::Global(name) => self.globals.get(name).cloned().ok_or_else(|| RunError {
-                message: format!("global `{name}` used before its definition"),
-                span: expr.span,
-            }),
+            ExprKind::Local { binding, name } => {
+                let value = env.lookup(*binding).ok_or_else(|| RunError {
+                    // Unreachable if lowering is correct; fail loud rather than UB.
+                    message: format!("internal: unbound local `{name}`"),
+                    span: expr.span,
+                })?;
+                self.record_ref(name, expr.span, &value);
+                Ok(value)
+            }
+            ExprKind::Global(name) => {
+                let value = self.globals.get(name).cloned().ok_or_else(|| RunError {
+                    message: format!("global `{name}` used before its definition"),
+                    span: expr.span,
+                })?;
+                self.record_ref(name, expr.span, &value);
+                Ok(value)
+            }
             ExprKind::External(path) => {
                 let joined = path.join(".");
                 match builtin(path) {
@@ -573,16 +673,20 @@ evaluation depth."
                 }
                 Ok(Value::Record(Rc::new(out)))
             }
-            ExprKind::LocalMut { binding, name } => self
-                .mut_slots
-                .get(&binding.0)
-                .and_then(|stack| stack.last())
-                .cloned()
-                .ok_or_else(|| RunError {
-                    // Unreachable if lowering is correct; fail loud.
-                    message: format!("internal: dead mut slot `{name}`"),
-                    span: expr.span,
-                }),
+            ExprKind::LocalMut { binding, name } => {
+                let value = self
+                    .mut_slots
+                    .get(&binding.0)
+                    .and_then(|stack| stack.last())
+                    .cloned()
+                    .ok_or_else(|| RunError {
+                        // Unreachable if lowering is correct; fail loud.
+                        message: format!("internal: dead mut slot `{name}`"),
+                        span: expr.span,
+                    })?;
+                self.record_ref(name, expr.span, &value);
+                Ok(value)
+            }
             ExprKind::Let {
                 binding,
                 name,

--- a/functor-lang/src/lib.rs
+++ b/functor-lang/src/lib.rs
@@ -29,8 +29,8 @@ pub mod types;
 pub mod value;
 
 pub use eval::{
-    render_trace, run, run_with_host, Host, NoHost, RecordedBinding, RecordedInvocation, RunFailure,
-    RunOutcome, RunRecord, Session, Tracing,
+    render_trace, run, run_with_host, Host, NoHost, RecordedBinding, RecordedInvocation,
+    RecordedKind, RecordedSite, RunFailure, RunOutcome, RunRecord, Session, Tracing,
 };
 pub use lower::lower;
 pub use parser::{parse, parse_interface};

--- a/functor-lang/src/value.rs
+++ b/functor-lang/src/value.rs
@@ -130,6 +130,109 @@ impl Env {
     }
 }
 
+/// Preview caps (see [`Value::preview`]): the longest string shown unelided,
+/// and how many list/tuple elements and record fields render before `…`.
+const MAX_PREVIEW_STRING: usize = 40;
+const MAX_PREVIEW_ITEMS: usize = 4;
+const MAX_PREVIEW_FIELDS: usize = 6;
+
+impl Value {
+    /// Whether this value renders short and complete on one line — the
+    /// editor shows primitives inline in full, while composites get the
+    /// depth-limited [`Value::preview`] inline and the full `Display` on
+    /// hover. Callables and host data count as primitive: their `Display` is
+    /// already a short opaque tag (`<fn(x)>`, `<ctor Circle>`). Empty
+    /// collections are primitive too (`[]` is complete).
+    pub fn is_primitive(&self) -> bool {
+        match self {
+            Value::Number(_) | Value::Bool(_) => true,
+            // The cap is CHARACTERS; `take(N+1)` bounds the count work.
+            Value::String(s) => s.chars().take(MAX_PREVIEW_STRING + 1).count() <= MAX_PREVIEW_STRING,
+            Value::Variant { args, .. } => args.is_empty(),
+            Value::List(items) => items.is_empty(),
+            Value::Record(fields) => fields.is_empty(),
+            Value::Tuple(_) => false, // never empty (two elements minimum)
+            Value::Ctor { .. }
+            | Value::Closure(_)
+            | Value::Partial(_)
+            | Value::Builtin(_)
+            | Value::HostFn(_)
+            | Value::HostData(_) => true,
+        }
+    }
+
+    /// A one-line, depth-limited preview: scalars in full (long strings
+    /// capped), ONE level of structure with nested composites elided to `…`,
+    /// and long collections elided after a few items. The full rendering is
+    /// `Display`; a primitive's preview equals it.
+    pub fn preview(&self) -> String {
+        self.preview_at(0)
+    }
+
+    fn preview_at(&self, depth: usize) -> String {
+        // Below the top level, only scalar-shaped values still render —
+        // nested structure elides.
+        if depth >= 1 && !self.is_primitive() {
+            return "…".to_string();
+        }
+        match self {
+            Value::String(s) if !self.is_primitive() => {
+                // Cap at MAX_PREVIEW_STRING CHARACTERS; the trailing ellipsis
+                // (inside the quotes) marks the cut. Pop exactly the closing
+                // delimiter — a trim would also eat an escaped quote at the cut.
+                let cut = s
+                    .char_indices()
+                    .nth(MAX_PREVIEW_STRING)
+                    .map(|(i, _)| i)
+                    .unwrap_or(s.len());
+                let mut out = format!("{:?}", &s[..cut]);
+                out.pop();
+                out.push('…');
+                out.push('"');
+                out
+            }
+            Value::List(items) => {
+                let shown: Vec<String> = items
+                    .iter()
+                    .take(MAX_PREVIEW_ITEMS)
+                    .map(|v| v.preview_at(depth + 1))
+                    .collect();
+                let tail = if items.len() > MAX_PREVIEW_ITEMS { ", …" } else { "" };
+                format!("[{}{tail}]", shown.join(", "))
+            }
+            Value::Tuple(items) => {
+                let shown: Vec<String> = items
+                    .iter()
+                    .take(MAX_PREVIEW_ITEMS)
+                    .map(|v| v.preview_at(depth + 1))
+                    .collect();
+                let tail = if items.len() > MAX_PREVIEW_ITEMS { ", …" } else { "" };
+                format!("({}{tail})", shown.join(", "))
+            }
+            Value::Record(fields) => {
+                let shown: Vec<String> = fields
+                    .iter()
+                    .take(MAX_PREVIEW_FIELDS)
+                    .map(|(name, value)| format!("{name}: {}", value.preview_at(depth + 1)))
+                    .collect();
+                let tail = if fields.len() > MAX_PREVIEW_FIELDS { ", …" } else { "" };
+                format!("{{ {}{tail} }}", shown.join(", "))
+            }
+            Value::Variant { ctor, args } if !args.is_empty() => {
+                let shown: Vec<String> = args
+                    .iter()
+                    .take(MAX_PREVIEW_ITEMS)
+                    .map(|v| v.preview_at(depth + 1))
+                    .collect();
+                let tail = if args.len() > MAX_PREVIEW_ITEMS { ", …" } else { "" };
+                format!("{ctor}({}{tail})", shown.join(", "))
+            }
+            // Every remaining shape is primitive: `Display` is already short.
+            other => other.to_string(),
+        }
+    }
+}
+
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/functor-lang/tests/recorder.rs
+++ b/functor-lang/tests/recorder.rs
@@ -1,10 +1,13 @@
 //! Binding-site recorder verification (the paused visual-debugger's PR1 seam,
 //! `Session::call_recorded`): a bounded, per-call-armed record of every `let` /
-//! parameter / match-variable value, with last-value + hit-count per site and a
+//! parameter / match-variable value AND every variable-reference read, with
+//! last-value + hit-count per site, kind/preview rendering policy, and a
 //! `truncated` cap flag — and NO effect on evaluation itself.
 
 use functor_lang::value::Value;
-use functor_lang::{NoHost, RecordedBinding, RecordedInvocation, Session};
+use functor_lang::{
+    NoHost, RecordedBinding, RecordedInvocation, RecordedKind, RecordedSite, Session,
+};
 use std::rc::Rc;
 
 /// Parse + lower + load `src` into a session, panicking with a rendered
@@ -112,6 +115,225 @@ fn loop_site_keeps_last_value_and_counts_hits() {
     assert_eq!(x.count, 3);
     assert_eq!(x.value, "3"); // the last element
     assert_eq!(binding(&inv, "xs").count, 1);
+}
+
+#[test]
+fn records_reference_sites_per_use() {
+    // `model` is READ twice on the body line — each read is its own site
+    // (distinct span), name-precise, tagged Ref; the param binder is Binder.
+    let src = "let update = (model) => model + model";
+    let session = session(src);
+    let (_, inv) = session
+        .call_recorded("update", vec![Value::Number(2.0)], &mut NoHost)
+        .expect("call_recorded");
+
+    let refs: Vec<&RecordedBinding> = inv
+        .bindings
+        .iter()
+        .filter(|b| b.name == "model" && b.site == RecordedSite::Ref)
+        .collect();
+    assert_eq!(refs.len(), 2, "each read is its own site");
+    for r in &refs {
+        assert_eq!(spanned(src, r), "model");
+        assert_eq!(r.value, "2");
+        assert_eq!(r.count, 1);
+    }
+    assert_ne!(refs[0].span.start, refs[1].span.start);
+    assert_eq!(binding(&inv, "model").site, RecordedSite::Binder);
+}
+
+#[test]
+fn callee_references_are_not_recorded() {
+    // Reading `helper` to CALL it is not data worth overlaying — only `m`'s
+    // read records.
+    let src = "let helper = (x) => x + 1.0\nlet update = (m) => helper(m)";
+    let session = session(src);
+    let (_, inv) = session
+        .call_recorded("update", vec![Value::Number(4.0)], &mut NoHost)
+        .expect("call_recorded");
+
+    assert!(
+        inv.bindings
+            .iter()
+            .all(|b| !(b.name == "helper" && b.site == RecordedSite::Ref)),
+        "callable reference leaked into the record"
+    );
+    // The nested call's param binder still records (flat map).
+    assert_eq!(binding(&inv, "x").value, "4");
+}
+
+#[test]
+fn kind_and_preview_follow_the_inline_vs_hover_policy() {
+    // A composite model previews one level deep (nested records elide to …);
+    // a primitive's preview IS its value.
+    let src = "let update = (model) =>\n  let hp = model.hp in\n  hp";
+    let session = session(src);
+    let model = Value::Record(Rc::new(vec![
+        (
+            "pos".to_string(),
+            Value::Record(Rc::new(vec![
+                ("x".to_string(), Value::Number(1.0)),
+                ("y".to_string(), Value::Number(2.0)),
+            ])),
+        ),
+        ("hp".to_string(), Value::Number(3.0)),
+    ]));
+    let (_, inv) = session
+        .call_recorded("update", vec![model], &mut NoHost)
+        .expect("call_recorded");
+
+    let m = binding(&inv, "model");
+    assert_eq!(m.kind, RecordedKind::Composite);
+    assert_eq!(m.preview, "{ pos: …, hp: 3 }");
+    assert_eq!(m.value, "{ pos: { x: 1, y: 2 }, hp: 3 }");
+
+    let hp = binding(&inv, "hp");
+    assert_eq!(hp.kind, RecordedKind::Primitive);
+    assert_eq!(hp.preview, hp.value);
+    assert_eq!(hp.value, "3");
+
+    // The invocation result carries a preview too.
+    assert_eq!(inv.result_preview, "3");
+}
+
+#[test]
+fn long_values_elide_in_previews() {
+    let src = "let idText = (s) => s\nlet firstOf = (xs) => xs";
+    let session = session(src);
+
+    // A long string caps at 40 chars with a marked tail.
+    let long = "x".repeat(60);
+    let (_, inv) = session
+        .call_recorded("idText", vec![Value::String(Rc::from(long.as_str()))], &mut NoHost)
+        .expect("call_recorded");
+    let s = binding(&inv, "s");
+    assert_eq!(s.kind, RecordedKind::Composite, "a long string is not inline-complete");
+    assert_eq!(s.preview, format!("\"{}…\"", "x".repeat(40)));
+
+    // A long list elides after 4 items.
+    let xs = Value::List(Rc::new((0..10).map(|i| Value::Number(i as f64)).collect()));
+    let (_, inv) = session
+        .call_recorded("firstOf", vec![xs], &mut NoHost)
+        .expect("call_recorded");
+    assert_eq!(binding(&inv, "xs").preview, "[0, 1, 2, 3, …]");
+}
+
+#[test]
+fn loop_reference_sites_count_reads() {
+    // Inside the fold closure, `acc`'s READ site is hit once per element.
+    let src = "let sum = (xs) => List.fold((acc, x) => acc + x, 0.0, xs)";
+    let session = session(src);
+    let xs = Value::List(Rc::new(vec![
+        Value::Number(1.0),
+        Value::Number(2.0),
+        Value::Number(3.0),
+    ]));
+    let (_, inv) = session
+        .call_recorded("sum", vec![xs], &mut NoHost)
+        .expect("call_recorded");
+
+    let acc_ref = inv
+        .bindings
+        .iter()
+        .find(|b| b.name == "acc" && b.site == RecordedSite::Ref)
+        .expect("acc read site");
+    assert_eq!(acc_ref.count, 3);
+    assert_eq!(acc_ref.value, "3"); // the read feeding the final `acc + x`
+}
+
+#[test]
+fn mut_reads_record_current_values() {
+    // A `let mut` READ goes through its own eval arm (LocalMut) — the read
+    // after the assignment must record the post-assign value.
+    let src = "let update = (n) => let mut c = n in c := c + 1.0; c";
+    let session = session(src);
+    let (result, inv) = session
+        .call_recorded("update", vec![Value::Number(4.0)], &mut NoHost)
+        .expect("call_recorded");
+
+    assert_eq!(result.to_string(), "5");
+    let c_refs: Vec<&RecordedBinding> = inv
+        .bindings
+        .iter()
+        .filter(|b| b.name == "c" && b.site == RecordedSite::Ref)
+        .collect();
+    // Two read sites: the assignment's RHS (pre-assign, 4) and the final
+    // read (post-assign, 5).
+    assert!(
+        c_refs.iter().any(|r| r.value == "4") && c_refs.iter().any(|r| r.value == "5"),
+        "mut reads missing or stale: {:?}",
+        c_refs.iter().map(|r| r.value.as_str()).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn reference_sites_cannot_starve_binders() {
+    // More distinct reference sites than the per-class cap, followed by a
+    // binder: the ref budget breaches (truncated), but the binder — the more
+    // valuable record — still lands.
+    let reads = vec!["x"; 1030].join(" + ");
+    let src = format!("let update = (x) => let z = {reads} in z");
+    let session = session(&src);
+    let (_, inv) = session
+        .call_recorded("update", vec![Value::Number(1.0)], &mut NoHost)
+        .expect("call_recorded");
+
+    assert!(inv.truncated, "1030 ref sites must breach the 1024 ref budget");
+    let z = binding(&inv, "z");
+    assert_eq!(z.site, RecordedSite::Binder);
+    assert_eq!(z.value, "1030");
+}
+
+#[test]
+fn string_previews_cap_by_characters_not_bytes() {
+    let src = "let idText = (s) => s";
+    let session = session(src);
+
+    // 39 multibyte chars: primitive (the cap counts characters).
+    let short = "é".repeat(39);
+    let (_, inv) = session
+        .call_recorded("idText", vec![Value::String(Rc::from(short.as_str()))], &mut NoHost)
+        .expect("call_recorded");
+    assert_eq!(binding(&inv, "s").kind, RecordedKind::Primitive);
+
+    // 45 multibyte chars: composite, capped at 40 CHARACTERS.
+    let long = "é".repeat(45);
+    let (_, inv) = session
+        .call_recorded("idText", vec![Value::String(Rc::from(long.as_str()))], &mut NoHost)
+        .expect("call_recorded");
+    let s = binding(&inv, "s");
+    assert_eq!(s.kind, RecordedKind::Composite);
+    assert_eq!(s.preview, format!("\"{}…\"", "é".repeat(40)));
+}
+
+#[test]
+fn preview_cut_on_a_quote_stays_well_formed() {
+    // The 40th character is a `"`: the escaped quote must survive the cut
+    // (a trim would eat it along with the closing delimiter).
+    let long = format!("{}\"{}", "x".repeat(39), "y".repeat(20));
+    let src = "let idText = (s) => s";
+    let session = session(src);
+    let (_, inv) = session
+        .call_recorded("idText", vec![Value::String(Rc::from(long.as_str()))], &mut NoHost)
+        .expect("call_recorded");
+    let preview = &binding(&inv, "s").preview;
+    assert!(
+        preview.ends_with("\\\"…\""),
+        "escaped quote at the cut must survive: {preview}"
+    );
+}
+
+#[test]
+fn empty_collections_are_primitive() {
+    let src = "let firstOf = (xs) => xs";
+    let session = session(src);
+    let (_, inv) = session
+        .call_recorded("firstOf", vec![Value::List(Rc::new(vec![]))], &mut NoHost)
+        .expect("call_recorded");
+    let xs = binding(&inv, "xs");
+    assert_eq!(xs.kind, RecordedKind::Primitive);
+    assert_eq!(xs.preview, "[]");
+    assert_eq!(xs.preview, xs.value);
 }
 
 #[test]

--- a/runtime/functor-runtime-common/src/inspector.rs
+++ b/runtime/functor-runtime-common/src/inspector.rs
@@ -128,6 +128,12 @@ fn build_invocations(
         let bindings: Vec<serde_json::Value> = inv
             .bindings
             .iter()
+            // Binder sites only for now: the recorder also captures reference
+            // sites (RecordedSite::Ref), but shipping them without the wire's
+            // site/preview fields would flood the editor with undifferentiated
+            // full-value overlays. Trace v2 (the next inspector PR) serializes
+            // site/kind/preview and lifts this filter.
+            .filter(|b| b.site == functor_lang::RecordedSite::Binder)
             .filter_map(|b| {
                 span_to_file(sources, b.span).map(|(file, start, end)| {
                     serde_json::json!({

--- a/site/ide.html
+++ b/site/ide.html
@@ -58,6 +58,8 @@
       </section>
     </main>
 
+    <div id="statusbar"></div>
+
     <script type="module" src="assets/ide.js"></script>
   </body>
 </html>

--- a/site/player.html
+++ b/site/player.html
@@ -51,6 +51,39 @@
     <button id="mouselook" title="Control the camera with the mouse; Esc to release">🖱 mouse look</button>
     <script type="module">
 
+      // Forward console traces to the embedding page's Output panel. Functor Lang
+      // `Debug.log` routes to console.log INSIDE this iframe (see the web
+      // runtime's trace sink) — invisible unless devtools are open on the
+      // frame. Installed before the wasm loads so boot-time logs are caught.
+      // SAME-ORIGIN parents only (the sandbox/IDE): unlike the inbound
+      // protocol, this channel carries game-visible data outward, and a
+      // third-party page framing the player must not receive it — so the
+      // guard, and location.origin (never "*") as the target.
+      const sameOriginParent = (() => {
+        if (window.parent === window) return false;
+        try {
+          return window.parent.location.origin === window.location.origin;
+        } catch {
+          return false; // cross-origin parent: reading its location throws
+        }
+      })();
+      if (sameOriginParent) {
+        for (const level of ["log", "warn", "error"]) {
+          const original = console[level].bind(console);
+          console[level] = (...args) => {
+            original(...args);
+            try {
+              window.parent.postMessage(
+                { type: "functor-lang-console", level, message: args.map(String).join(" ") },
+                window.location.origin
+              );
+            } catch {
+              /* an unclonable edge must never break logging */
+            }
+          };
+        }
+      }
+
       import init, {
         functor_lang_key_event,
         functor_lang_mouse_move,

--- a/site/player.html
+++ b/site/player.html
@@ -73,8 +73,20 @@
           console[level] = (...args) => {
             original(...args);
             try {
+              // Stamp the game frame the line was emitted on. Throws before
+              // init() (no wasm yet) and reads -1 before anything is
+              // recorded — both become null (the panel then shows time only).
+              // Safe mid-tick: the export is a one-shot read of a small cell
+              // the runtime only writes in a non-held assignment.
+              let frame = null;
+              try {
+                const f = functor_lang_scene_frame();
+                if (f >= 0) frame = f;
+              } catch {
+                /* pre-init */
+              }
               window.parent.postMessage(
-                { type: "functor-lang-console", level, message: args.map(String).join(" ") },
+                { type: "functor-lang-console", level, message: args.map(String).join(" "), frame },
                 window.location.origin
               );
             } catch {
@@ -89,6 +101,7 @@
         functor_lang_mouse_move,
         functor_lang_mouse_wheel,
         functor_lang_is_running,
+        functor_lang_scene_frame,
         functor_lang_set_source,
         functor_lang_set_project,
       } from "./pkg/functor_runtime_web.js";

--- a/site/sandbox.html
+++ b/site/sandbox.html
@@ -45,6 +45,8 @@
       </section>
     </main>
 
+    <div id="statusbar"></div>
+
     <footer class="sandbox-footer">
       <p>
         Edits hot-reload the running game <em>with the model preserved</em> — the wave keeps

--- a/site/src/ide.js
+++ b/site/src/ide.js
@@ -11,8 +11,9 @@ import { indentWithTab } from "@codemirror/commands";
 import { acceptCompletion, closeCompletion, startCompletion } from "@codemirror/autocomplete";
 import { StateEffect } from "@codemirror/state";
 import { functorLangLanguage, synthwaveEditorTheme } from "./functor-lang.js";
-import { setupLangIntel, setLangContext, resetIntel, refreshIntel } from "./lang-intel.js";
+import { setupLangIntel, setLangContext, resetIntel, refreshIntel, onDiagnostics } from "./lang-intel.js";
 import { ProjectBridge } from "./project-bridge.js";
+import { createStatusBar } from "./status-bar.js";
 import { zipFiles } from "./zip.js";
 
 const STORAGE_KEY = "functor-ide-project-v1";
@@ -162,6 +163,46 @@ const langReady = setupLangIntel().then((extensions) => {
   return extensions.length > 0;
 });
 
+const statusBar = createStatusBar({ host: document.getElementById("statusbar") });
+
+// Each lint pass (of the ACTIVE file — the per-document model) refreshes the
+// Problems panel; clicking a problem jumps the editor to it. Positions
+// re-clamp at click time (the doc may have moved on).
+onDiagnostics((diags) => {
+  const file = project.active;
+  statusBar.setProblems(
+    diags.map((d) => {
+      const line = view.state.doc.lineAt(Math.min(d.from, view.state.doc.length));
+      return {
+        severity: d.severity,
+        message: d.message,
+        loc: `${file} ${line.number}:${d.from - line.from + 1}`,
+        jump: () => {
+          // A row can outlive its file (delete + the debounce window).
+          if (!project.files.some((f) => f.path === file)) return;
+          if (project.active !== file) openFile(file);
+          const len = view.state.doc.length;
+          const from = Math.min(d.from, len);
+          view.dispatch({
+            selection: { anchor: from, head: Math.max(from, Math.min(d.to, len)) },
+            scrollIntoView: true,
+          });
+          view.focus();
+        },
+      };
+    })
+  );
+});
+
+// Runtime console traces (Functor Lang `Debug.log` and friends), forwarded by the
+// player page — see the console hook in player.html. Guarded to OUR iframe.
+window.addEventListener("message", (event) => {
+  const data = event.data;
+  if (!data || data.type !== "functor-lang-console") return;
+  if (event.source !== els.player.contentWindow) return;
+  statusBar.appendOutput(data.level, data.message);
+});
+
 const setDoc = (source) => {
   programmaticEdit = true;
   view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: source } });
@@ -186,6 +227,10 @@ const bridge = new ProjectBridge(els.player, {
     } else {
       setStatus("error", "✖ error", message);
     }
+    // Failed reloads also land in the Output panel — the pill is transient,
+    // the panel keeps the history. (Successes already arrive there via the
+    // runtime's own "[functor-lang] reloaded …" console line.)
+    if (!ok) statusBar.appendOutput("error", message);
   },
 });
 
@@ -229,6 +274,9 @@ const renderFileList = () => {
 
 const openFile = (path) => {
   if (path === project.active) return;
+  // A stale caller (e.g. a problem row outliving a delete) must not point
+  // `active` at a file that no longer exists.
+  if (!project.files.some((f) => f.path === path)) return;
   // Save the live buffer into the outgoing file before switching.
   const current = activeFile();
   if (current) current.source = view.state.doc.toString();

--- a/site/src/ide.js
+++ b/site/src/ide.js
@@ -200,7 +200,7 @@ window.addEventListener("message", (event) => {
   const data = event.data;
   if (!data || data.type !== "functor-lang-console") return;
   if (event.source !== els.player.contentWindow) return;
-  statusBar.appendOutput(data.level, data.message);
+  statusBar.appendOutput(data.level, data.message, data.frame ?? null);
 });
 
 const setDoc = (source) => {

--- a/site/src/lang-intel.js
+++ b/site/src/lang-intel.js
@@ -111,6 +111,13 @@ export const completeAt = (src, offset) => {
 const peekCached = (docString) =>
   analyzeFn && cacheKey(docString, projectArgs(docString)) === lastKey ? lastResult : null;
 
+// The host page can observe each lint pass's diagnostics (the status bar's
+// Problems panel) — called with the same clamped list the linter gets.
+let diagnosticsListener = null;
+export const onDiagnostics = (fn) => {
+  diagnosticsListener = fn;
+};
+
 // analyze offsets are whole-document UTF-16 — CodeMirror's native unit — so
 // they map straight across; clamp defensively to the current doc length.
 const toDiagnostics = (view) => {
@@ -120,13 +127,17 @@ const toDiagnostics = (view) => {
   // field to re-read it (the initial doc lands here too, so inlays/lenses show
   // on load — not only after the first edit).
   scheduleRefresh(view);
-  if (!result || !Array.isArray(result.diagnostics)) return [];
   const len = doc.length;
-  return result.diagnostics.map((d) => {
-    const from = Math.max(0, Math.min(d.from | 0, len));
-    let to = Math.max(from, Math.min(d.to | 0, len));
-    return { from, to, severity: d.severity || "error", message: d.message || "" };
-  });
+  const diagnostics =
+    !result || !Array.isArray(result.diagnostics)
+      ? []
+      : result.diagnostics.map((d) => {
+          const from = Math.max(0, Math.min(d.from | 0, len));
+          const to = Math.max(from, Math.min(d.to | 0, len));
+          return { from, to, severity: d.severity || "error", message: d.message || "" };
+        });
+  if (diagnosticsListener) diagnosticsListener(diagnostics);
+  return diagnostics;
 };
 
 // --- Hover types --------------------------------------------------------------

--- a/site/src/sandbox.js
+++ b/site/src/sandbox.js
@@ -10,8 +10,9 @@ import { StateEffect } from "@codemirror/state";
 import { indentWithTab } from "@codemirror/commands";
 import { startCompletion, acceptCompletion, closeCompletion } from "@codemirror/autocomplete";
 import { functorLangLanguage, synthwaveEditorTheme } from "./functor-lang.js";
-import { setupLangIntel, analyzeCached, completeAt, resetIntel } from "./lang-intel.js";
+import { setupLangIntel, analyzeCached, completeAt, resetIntel, onDiagnostics } from "./lang-intel.js";
 import { PlayerBridge } from "./player-bridge.js";
+import { createStatusBar } from "./status-bar.js";
 
 const EXAMPLES = [
   { id: "hero", label: "Neon grid" },
@@ -36,6 +37,8 @@ const setStatus = (state, text, detail = "") => {
   statusLog.hidden = detail === "";
 };
 
+const statusBar = createStatusBar({ host: document.getElementById("statusbar") });
+
 const bridge = new PlayerBridge(frame, {
   onReloading: () => setStatus("busy", "◌ reloading…"),
   onLive: () => setStatus("live", "● live"),
@@ -48,7 +51,20 @@ const bridge = new PlayerBridge(frame, {
     } else {
       setStatus("error", "✖ error", message);
     }
+    // Failed reloads also land in the Output panel — the pill is transient,
+    // the panel keeps the history. (Successes already arrive there via the
+    // runtime's own "[functor-lang] reloaded …" console line.)
+    if (!ok) statusBar.appendOutput("error", message);
   },
+});
+
+// Runtime console traces (Functor Lang `Debug.log` and friends), forwarded by the
+// player page — see the console hook in player.html. Guarded to OUR iframe.
+window.addEventListener("message", (event) => {
+  const data = event.data;
+  if (!data || data.type !== "functor-lang-console") return;
+  if (event.source !== frame.contentWindow) return;
+  statusBar.appendOutput(data.level, data.message);
 });
 
 // Set while loadExample replaces the buffer programmatically: that content is
@@ -77,6 +93,30 @@ const view = new EditorView({
 const langReady = setupLangIntel().then((extensions) => {
   if (extensions.length) view.dispatch({ effects: StateEffect.appendConfig.of(extensions) });
   return extensions.length > 0;
+});
+
+// Each lint pass refreshes the Problems panel; clicking a problem jumps the
+// editor to it. Positions re-clamp at click time (the doc may have moved on).
+onDiagnostics((diags) => {
+  statusBar.setProblems(
+    diags.map((d) => {
+      const line = view.state.doc.lineAt(Math.min(d.from, view.state.doc.length));
+      return {
+        severity: d.severity,
+        message: d.message,
+        loc: `game.fun ${line.number}:${d.from - line.from + 1}`,
+        jump: () => {
+          const len = view.state.doc.length;
+          const from = Math.min(d.from, len);
+          view.dispatch({
+            selection: { anchor: from, head: Math.max(from, Math.min(d.to, len)) },
+            scrollIntoView: true,
+          });
+          view.focus();
+        },
+      };
+    })
+  );
 });
 
 window.__lang = {

--- a/site/src/sandbox.js
+++ b/site/src/sandbox.js
@@ -64,7 +64,7 @@ window.addEventListener("message", (event) => {
   const data = event.data;
   if (!data || data.type !== "functor-lang-console") return;
   if (event.source !== frame.contentWindow) return;
-  statusBar.appendOutput(data.level, data.message);
+  statusBar.appendOutput(data.level, data.message, data.frame ?? null);
 });
 
 // Set while loadExample replaces the buffer programmatically: that content is

--- a/site/src/status-bar.js
+++ b/site/src/status-bar.js
@@ -1,0 +1,142 @@
+// A VSCode-style bottom status bar for the sandbox and IDE pages: a slim
+// strip with two toggleable panels — Problems (live type diagnostics from the
+// language analysis) and Output (runtime console traces + reload results).
+// Plain DOM, no framework. The host page owns placement (an empty container)
+// and feeds the returned handle:
+//
+//   const bar = createStatusBar({ host });
+//   bar.setProblems([{ severity, message, loc, jump }]);   // whole list, each pass
+//   bar.appendOutput(level, text);                          // one line at a time
+//
+// Problems entries carry their own `jump` (the host closes over its editor),
+// so the component stays editor-agnostic.
+
+const MAX_OUTPUT_LINES = 500;
+
+export const createStatusBar = ({ host }) => {
+  host.className = "statusbar";
+
+  const panel = document.createElement("div");
+  panel.className = "statusbar-panel";
+  panel.hidden = true;
+
+  const problemsList = document.createElement("div");
+  problemsList.className = "statusbar-list problems-list";
+  const outputList = document.createElement("div");
+  outputList.className = "statusbar-list output-list";
+
+  const strip = document.createElement("div");
+  strip.className = "statusbar-strip";
+
+  const tabs = {};
+  let open = null; // "problems" | "output" | null
+
+  const show = (name) => {
+    open = name;
+    panel.hidden = open === null;
+    problemsList.style.display = open === "problems" ? "" : "none";
+    outputList.style.display = open === "output" ? "" : "none";
+    for (const [tabName, button] of Object.entries(tabs)) {
+      button.classList.toggle("active", tabName === open);
+    }
+    // Lines appended while the panel was hidden couldn't stick to the bottom
+    // (a display:none subtree measures 0) — land on the newest, not the oldest.
+    if (open === "output") outputList.scrollTop = outputList.scrollHeight;
+  };
+
+  const makeTab = (name, label) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "statusbar-tab";
+    button.dataset.tab = name;
+    button.textContent = label;
+    button.addEventListener("click", () => show(open === name ? null : name));
+    tabs[name] = button;
+    strip.appendChild(button);
+    return button;
+  };
+
+  const problemsTab = makeTab("problems", "✓ 0 problems");
+  makeTab("output", "output");
+
+  panel.appendChild(problemsList);
+  panel.appendChild(outputList);
+  host.appendChild(panel);
+  host.appendChild(strip);
+
+  const setProblems = (items) => {
+    // The tab goes loud (red ✖) only for errors — a warnings-only file keeps
+    // the calm glyph.
+    const errors = items.filter((item) => (item.severity || "error") === "error").length;
+    problemsTab.textContent =
+      items.length === 0
+        ? "✓ 0 problems"
+        : `${errors > 0 ? "✖" : "⚠"} ${items.length} problem${items.length === 1 ? "" : "s"}`;
+    problemsTab.classList.toggle("has-problems", errors > 0);
+    problemsList.textContent = "";
+    if (items.length === 0) {
+      const empty = document.createElement("div");
+      empty.className = "statusbar-empty";
+      empty.textContent = "No problems detected.";
+      problemsList.appendChild(empty);
+      return;
+    }
+    for (const item of items) {
+      const row = document.createElement("button");
+      row.type = "button";
+      row.className = "problem-row";
+      const icon = document.createElement("span");
+      const severity = item.severity || "error";
+      icon.className = `problem-icon severity-${severity}`;
+      icon.textContent = severity === "error" ? "✖" : "⚠";
+      const message = document.createElement("span");
+      message.className = "problem-message";
+      message.textContent = item.message;
+      const loc = document.createElement("span");
+      loc.className = "problem-loc";
+      loc.textContent = item.loc;
+      row.append(icon, message, loc);
+      if (item.jump) row.addEventListener("click", item.jump);
+      problemsList.appendChild(row);
+    }
+  };
+  setProblems([]);
+
+  // Appends are rAF-coalesced: a per-frame `Debug.log` in tick/draw arrives
+  // ~60/sec, and appending each line individually would force a layout read
+  // (scrollHeight) per message while the panel is open. One DOM flush per
+  // frame keeps the panel usable under a logging loop.
+  let pending = [];
+  let flushScheduled = false;
+
+  const flushOutput = () => {
+    flushScheduled = false;
+    if (pending.length === 0) return;
+    // Stick to the bottom only if the user is already there (don't yank the
+    // scroll out from under them mid-read).
+    const atBottom = outputList.scrollTop + outputList.clientHeight >= outputList.scrollHeight - 4;
+    // A burst larger than the cap only ever shows its tail — skip the rest.
+    const lines = pending.slice(-MAX_OUTPUT_LINES);
+    pending = [];
+    for (const { level, text } of lines) {
+      const line = document.createElement("div");
+      line.className = `output-line output-${level}`;
+      line.textContent = text;
+      outputList.appendChild(line);
+    }
+    while (outputList.childElementCount > MAX_OUTPUT_LINES) {
+      outputList.firstElementChild.remove();
+    }
+    if (atBottom) outputList.scrollTop = outputList.scrollHeight;
+  };
+
+  const appendOutput = (level, text) => {
+    pending.push({ level, text });
+    if (!flushScheduled) {
+      flushScheduled = true;
+      requestAnimationFrame(flushOutput);
+    }
+  };
+
+  return { setProblems, appendOutput };
+};

--- a/site/src/status-bar.js
+++ b/site/src/status-bar.js
@@ -102,6 +102,17 @@ export const createStatusBar = ({ host }) => {
   };
   setProblems([]);
 
+  // Each line carries a `[Frame N | HH:MM:SS]` preamble — the game frame it
+  // was emitted on (when the runtime had one) and the wall clock. The clock is
+  // stamped at append time, not at the rAF flush, so a coalesced burst keeps
+  // each line's true arrival time.
+  const clock = (date) => {
+    const two = (n) => String(n).padStart(2, "0");
+    return `${two(date.getHours())}:${two(date.getMinutes())}:${two(date.getSeconds())}`;
+  };
+  const preamble = (frame, time) =>
+    frame == null ? `[${time}]` : `[Frame ${frame} | ${time}]`;
+
   // Appends are rAF-coalesced: a per-frame `Debug.log` in tick/draw arrives
   // ~60/sec, and appending each line individually would force a layout read
   // (scrollHeight) per message while the panel is open. One DOM flush per
@@ -118,10 +129,14 @@ export const createStatusBar = ({ host }) => {
     // A burst larger than the cap only ever shows its tail — skip the rest.
     const lines = pending.slice(-MAX_OUTPUT_LINES);
     pending = [];
-    for (const { level, text } of lines) {
+    for (const { level, text, frame, time } of lines) {
       const line = document.createElement("div");
       line.className = `output-line output-${level}`;
-      line.textContent = text;
+      const stamp = document.createElement("span");
+      stamp.className = "output-preamble";
+      stamp.textContent = preamble(frame, time);
+      line.appendChild(stamp);
+      line.appendChild(document.createTextNode(` ${text}`));
       outputList.appendChild(line);
     }
     while (outputList.childElementCount > MAX_OUTPUT_LINES) {
@@ -130,8 +145,10 @@ export const createStatusBar = ({ host }) => {
     if (atBottom) outputList.scrollTop = outputList.scrollHeight;
   };
 
-  const appendOutput = (level, text) => {
-    pending.push({ level, text });
+  // `frame` is the game frame the line belongs to (null when the runtime had
+  // none to offer — boot lines, host-side reload errors).
+  const appendOutput = (level, text, frame = null) => {
+    pending.push({ level, text, frame, time: clock(new Date()) });
     if (!flushScheduled) {
       flushScheduled = true;
       requestAnimationFrame(flushOutput);

--- a/site/styles.css
+++ b/site/styles.css
@@ -872,3 +872,130 @@ a:hover {
     gap: 12px;
   }
 }
+
+/* ---- Status bar (sandbox + IDE): Problems / Output panels ---------------- */
+
+.statusbar {
+  display: flex;
+  flex-direction: column;
+  border-top: 1px solid var(--line);
+  background: var(--bg-panel);
+  font-family: var(--font-mono);
+}
+
+.statusbar-strip {
+  display: flex;
+  gap: 2px;
+  padding: 0 8px;
+}
+
+.statusbar-tab {
+  appearance: none;
+  border: none;
+  background: none;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  padding: 4px 10px;
+  cursor: pointer;
+}
+
+.statusbar-tab:hover {
+  color: var(--text);
+}
+
+.statusbar-tab.active {
+  color: var(--cyan);
+  box-shadow: inset 0 2px 0 var(--cyan);
+}
+
+.statusbar-tab.has-problems {
+  color: var(--red);
+}
+
+.statusbar-tab.has-problems.active {
+  color: var(--red);
+  box-shadow: inset 0 2px 0 var(--red);
+}
+
+.statusbar-panel {
+  height: 180px;
+  border-bottom: 1px solid var(--line);
+  overflow: hidden;
+  display: flex;
+}
+
+.statusbar-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 6px 8px;
+  font-size: 0.78rem;
+  line-height: 1.5;
+}
+
+.statusbar-empty {
+  color: var(--text-dim);
+  font-style: italic;
+}
+
+.problem-row {
+  appearance: none;
+  border: none;
+  background: none;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  width: 100%;
+  text-align: left;
+  padding: 2px 4px;
+  cursor: pointer;
+  border-radius: 3px;
+}
+
+.problem-row:hover {
+  background: var(--bg-raised);
+}
+
+.problem-icon.severity-error {
+  color: var(--red);
+}
+
+.problem-icon.severity-warning {
+  color: var(--amber);
+}
+
+.problem-message {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.problem-loc {
+  color: var(--text-dim);
+  font-size: 0.72rem;
+  white-space: nowrap;
+}
+
+.output-line {
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--text-dim);
+}
+
+.output-line.output-warn {
+  color: var(--amber);
+}
+
+.output-line.output-error {
+  color: var(--red);
+}
+
+.output-line.output-info {
+  color: var(--text);
+}

--- a/site/styles.css
+++ b/site/styles.css
@@ -988,6 +988,11 @@ a:hover {
   color: var(--text-dim);
 }
 
+.output-preamble {
+  color: #6c6685;
+  font-size: 0.9em;
+}
+
 .output-line.output-warn {
   color: var(--amber);
 }


### PR DESCRIPTION
## Why

First PR of the paused-inspector v2 arc (plan: visual-debugger notes, Evolution v2). Today the inspector shows "one giant value for tick and nothing else": values render as full untruncated `Display` text (the whole model inline), and only binder sites (let/param/match) are captured — variable uses, `let mut` reads, and intermediates never appear.

## What

- **`Value::preview()`** — one-line, depth-limited preview: one level of structure, nested composites elide to `…`, lists/tuples cap at 4 items, records at 6 fields, strings at 40 characters (multibyte-safe, escape-safe cut). **`Value::is_primitive()`** is the inline-vs-hover policy seam: a primitive's preview IS its full rendering (empty collections included).
- **`RecordedBinding`** gains `preview`, `kind` (Primitive|Composite), `site` (Binder|Ref); `RecordedInvocation` gains `result_preview`.
- **Reference-site recording** — reads of `Local`/`LocalMut`/`Global` names record (span, value), so every line that *uses* a variable carries its value. Callables are skipped at ref sites (a callee name isn't data). Per-class site budgets (1024 each) keep reference-heavy bodies from starving the binder record. Recording still only happens under `call_recorded` (pause-time replay) — the unarmed hot path stays a `None` check, no new clones.
- The runtime wire builder **filters to binder sites for now**: refs ship to editors in trace v2 (next PR), which serializes `site`/`kind`/`preview` — until then the existing LSP behavior is byte-identical.

## Testing

`cargo test -p functor-lang` 497 (14 recorder tests, 10 new: ref sites per use, callee skipping, kind/preview policy, character-counted caps, quote-at-cut escapes, mut reads, ref-vs-binder budget, empty collections). Downstream unchanged: functor_runtime_common 289, desktop 47, functor-lang-lsp 35.

Reviewed with /xreview (Claude + Codex); all High/Medium findings fixed (LocalMut reads, byte-vs-char caps, quote-cut trim bug, budget starvation, premature ref exposure on the wire).

🤖 Generated with [Claude Code](https://claude.com/claude-code)