### PR TITLE
feat(runtime): trace v2 — draw pass, previews, and reference sites on the wire

### DIFF
--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -62,7 +62,7 @@ screenshot run has no reason to grab your mouse.
 | `POST /capture` | PNG (`image/png`) of the next rendered frame |
 | `GET /state` | runtime state JSON: `frame`, `tts`, `viewport`, `input` (structured `held_keys` + `mouse`), `model` (Rust `Debug` text) |
 | `GET /scene` | current frame as JSON: `camera` + `scene` + `lights` |
-| `GET /trace` | paused-inspector trace: the last real frame's entry-point invocations (per-binding-site values + result) replayed while paused; `{ "paused": false, "invocations": [] }` while playing |
+| `GET /trace` | paused-inspector trace: the last real frame's entry-point invocations plus a synthesized `draw` pass, replayed while paused. Each site (binders AND variable reads, `site`) carries the full `value`, a depth-limited `preview`, and `kind` (primitive/composite — the editor's inline-vs-hover policy); `{ "paused": false, "invocations": [] }` while playing |
 | `POST /input` | inject input (see below) |
 | `POST /time` | control the frame clock (see below) |
 | `POST /reload-source` | swap game logic from the request body (see below) |

--- a/functor-lang/src/lib.rs
+++ b/functor-lang/src/lib.rs
@@ -36,7 +36,7 @@ pub use lower::lower;
 pub use parser::{parse, parse_interface};
 pub use rebind::{rebind_value, RebindReport};
 pub use span::{line_col, Span};
-pub use trace::set_trace_sink;
+pub use trace::{set_trace_sink, suppress as suppress_trace};
 pub use types::{check, check_with_scopes_and_types, check_with_types, ExprTypes};
 pub use value::{HostData, Value};
 

--- a/functor-lang/src/trace.rs
+++ b/functor-lang/src/trace.rs
@@ -33,10 +33,38 @@ pub fn set_trace_sink(sink: Sink) {
     *SINK.write().unwrap() = Some(sink);
 }
 
+thread_local! {
+    /// See [`suppress`] — true while a paused-inspector replay runs on this
+    /// thread.
+    static SUPPRESSED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// A scope with `Debug.log` emission suppressed on this thread — the paused
+/// inspector's replay seam: a journaled call re-runs to record values, and its
+/// `Debug.log` lines already emitted live at frame time, so re-emitting would
+/// duplicate every line on each trace build. RAII so an early return can't
+/// leave the thread muted.
+pub fn suppress() -> SuppressGuard {
+    SUPPRESSED.with(|s| s.set(true));
+    SuppressGuard
+}
+
+pub struct SuppressGuard;
+
+impl Drop for SuppressGuard {
+    fn drop(&mut self) {
+        SUPPRESSED.with(|s| s.set(false));
+    }
+}
+
 /// Emit one already-formatted `Debug.log` line (`"label: value"`). With a sink
 /// installed it routes there; otherwise — plain `functor-lang run`, tests, a bare
-/// interpreter — it prints to stdout, the interpreter's only renderer.
+/// interpreter — it prints to stdout, the interpreter's only renderer. Silent
+/// inside a [`suppress`] scope (inspector replay).
 pub fn emit(message: String) {
+    if SUPPRESSED.with(|s| s.get()) {
+        return;
+    }
     match SINK.read().unwrap().as_ref() {
         Some(sink) => sink(message),
         None => println!("{message}"),

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -2647,6 +2647,14 @@ pub fn take_ui_handlers() -> Vec<UiHandler> {
     UI_HANDLERS.with(|h| std::mem::take(&mut *h.borrow_mut()))
 }
 
+/// Put a saved handler table back — the inspector-replay bracket: replaying a
+/// journaled call (or draw) that evaluates `Ui.*` pushes handlers the NEXT
+/// real `ui` pass would take as its own, shifting every slot. The replay
+/// saves with [`take_ui_handlers`], runs, drops what it pushed, and restores.
+pub fn restore_ui_handlers(handlers: Vec<UiHandler>) {
+    UI_HANDLERS.with(|h| *h.borrow_mut() = handlers);
+}
+
 #[derive(Clone, Copy)]
 pub enum NetEventKind {
     Connected,

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -90,6 +90,9 @@ pub enum Provenance {
     HttpResponse,
     AudioFinished,
     UiEvent,
+    /// The frame's pure render pass — never journaled during play; the trace
+    /// builder synthesizes one draw invocation against the frozen model.
+    Draw,
 }
 
 impl Provenance {
@@ -132,6 +135,7 @@ impl Provenance {
             Provenance::HttpResponse => format!("http response: {}", msg()),
             Provenance::AudioFinished => format!("audio finished: {}", msg()),
             Provenance::UiEvent => format!("ui event: {}", msg()),
+            Provenance::Draw => "draw".to_string(),
         }
     }
 }

--- a/runtime/functor-runtime-common/src/inspector.rs
+++ b/runtime/functor-runtime-common/src/inspector.rs
@@ -17,10 +17,11 @@
 //! copy and a wire contract that cannot drift between the two shells.
 
 use functor_lang::project::SourceMap;
+use functor_lang::value::Value;
 use functor_lang::{Session, Span};
 
 use crate::functor_lang_prelude::FunctorHost;
-use crate::functor_lang_producer::JournalEntry;
+use crate::functor_lang_producer::{JournalEntry, Provenance};
 
 /// One project source file's inspector metadata: its wire name, its base offset
 /// in the project-wide span space, its length, and the sha256 of the text the
@@ -88,14 +89,17 @@ fn sources_json(sources: &[InspectorSource]) -> Vec<serde_json::Value> {
         .collect()
 }
 
-/// Replay the last real frame's journal into the wire-contract `invocations`.
-/// Each journaled call is re-run through `Session::call_recorded` — entry points
-/// are pure functions of their args, so the record is exact, and effects are
-/// plain data (nothing performs), so replay is side-effect-free. `index`/`count`
-/// frame each call within its entry name; binding spans map to `(file, local
-/// offsets)`.
+/// Replay the last real frame's journal into the wire-contract `invocations`,
+/// plus one synthesized `draw` invocation against the frozen model when the
+/// caller supplies its args (draw is pure and never journaled during play —
+/// replaying it once at trace-build time is exact and free). Each call is
+/// re-run through `Session::call_recorded` — entry points are pure functions
+/// of their args, so the record is exact, and effects are plain data (nothing
+/// performs), so replay is side-effect-free. `index`/`count` frame each call
+/// within its entry name; binding spans map to `(file, local offsets)`.
 fn build_invocations(
     journal: &[JournalEntry],
+    draw_args: Option<&[Value]>,
     sources: &[InspectorSource],
     session: &Session,
 ) -> Vec<serde_json::Value> {
@@ -104,23 +108,39 @@ fn build_invocations(
     // invocations actually EMITTED, so the array is always consistent with its
     // own counts (the LSP picker mod-cycles on `count`). A call that succeeded
     // live, replayed pure, should not fail — skip one defensively rather than
-    // abort the whole trace if it somehow does.
-    let mut replayed = Vec::with_capacity(journal.len());
+    // abort the whole trace if it somehow does. Draw comes last (the frame
+    // order: update → tick → draw); a program without a `draw` def just skips.
+    // Replay must be OBSERVATION-ONLY beyond effect inertness (effects are
+    // plain data; only the drain performs): suppress `Debug.log` re-emission
+    // (its lines already emitted live at frame time — re-emitting would
+    // duplicate them on every trace build) and bracket the UI handler table
+    // (a replayed `Ui.*` call would append handlers the next real `ui` pass
+    // takes as its own, shifting every slot).
+    let _mute = functor_lang::suppress_trace();
+    let saved_handlers = crate::functor_lang_prelude::take_ui_handlers();
+    let mut replayed = Vec::with_capacity(journal.len() + 1);
     for e in journal {
         if let Ok((_discard, inv)) = session.call_recorded(e.entry, e.args.clone(), &mut FunctorHost)
         {
-            replayed.push((e, inv));
+            replayed.push((e.entry, Provenance::render(&e.provenance, &e.args), inv));
         }
     }
+    if let Some(args) = draw_args {
+        if let Ok((_discard, inv)) = session.call_recorded("draw", args.to_vec(), &mut FunctorHost) {
+            replayed.push(("draw", Provenance::Draw.render(args), inv));
+        }
+    }
+    let _replay_pushed = crate::functor_lang_prelude::take_ui_handlers();
+    crate::functor_lang_prelude::restore_ui_handlers(saved_handlers);
     let mut counts: HashMap<&str, usize> = HashMap::new();
-    for (e, _) in &replayed {
-        *counts.entry(e.entry).or_default() += 1;
+    for (entry, _, _) in &replayed {
+        *counts.entry(entry).or_default() += 1;
     }
     let mut seen: HashMap<&str, usize> = HashMap::new();
     let mut out = Vec::with_capacity(replayed.len());
-    for (e, inv) in &replayed {
+    for (entry, provenance, inv) in &replayed {
         let index = {
-            let c = seen.entry(e.entry).or_default();
+            let c = seen.entry(entry).or_default();
             let i = *c;
             *c += 1;
             i
@@ -128,12 +148,6 @@ fn build_invocations(
         let bindings: Vec<serde_json::Value> = inv
             .bindings
             .iter()
-            // Binder sites only for now: the recorder also captures reference
-            // sites (RecordedSite::Ref), but shipping them without the wire's
-            // site/preview fields would flood the editor with undifferentiated
-            // full-value overlays. Trace v2 (the next inspector PR) serializes
-            // site/kind/preview and lifts this filter.
-            .filter(|b| b.site == functor_lang::RecordedSite::Binder)
             .filter_map(|b| {
                 span_to_file(sources, b.span).map(|(file, start, end)| {
                     serde_json::json!({
@@ -142,23 +156,42 @@ fn build_invocations(
                         "start": start,
                         "end": end,
                         "value": b.value,
+                        "preview": b.preview,
+                        "kind": kind_str(b.kind),
+                        "site": site_str(b.site),
                         "count": b.count,
                     })
                 })
             })
             .collect();
         out.push(serde_json::json!({
-            "entry": e.entry,
+            "entry": entry,
             "index": index,
-            "count": counts[e.entry],
-            "provenance": e.provenance.render(&e.args),
+            "count": counts[entry],
+            "provenance": provenance,
             "ghost": false,
             "result": inv.result,
+            "result_preview": inv.result_preview,
             "truncated": inv.truncated,
             "bindings": bindings,
         }));
     }
     out
+}
+
+/// The wire strings for the recorder's site/kind enums.
+fn kind_str(kind: functor_lang::RecordedKind) -> &'static str {
+    match kind {
+        functor_lang::RecordedKind::Primitive => "primitive",
+        functor_lang::RecordedKind::Composite => "composite",
+    }
+}
+
+fn site_str(site: functor_lang::RecordedSite) -> &'static str {
+    match site {
+        functor_lang::RecordedSite::Binder => "binder",
+        functor_lang::RecordedSite::Ref => "ref",
+    }
 }
 
 /// Assemble the wire-contract trace document (`docs/visual-debugger`).
@@ -175,6 +208,7 @@ pub fn build_trace_doc(
     tts: f64,
     sources: &[InspectorSource],
     journal: &[JournalEntry],
+    draw_args: Option<&[Value]>,
     session: &Session,
 ) -> String {
     if !paused {
@@ -190,7 +224,7 @@ pub fn build_trace_doc(
         "tts": tts,
         "paused": true,
         "sources": sources_json(sources),
-        "invocations": build_invocations(journal, sources, session),
+        "invocations": build_invocations(journal, draw_args, sources, session),
     })
     .to_string()
 }
@@ -233,8 +267,8 @@ mod tests {
         // Byte-identical regardless of the frame/tts args — the M1 contract: the
         // LSP dedups idle polls on the doc bytes, so the unpaused doc must not
         // carry per-frame fields.
-        let a = build_trace_doc(false, 0, 0.0, &sources, &[], &session);
-        let b = build_trace_doc(false, 7, 4.5, &sources, &[], &session);
+        let a = build_trace_doc(false, 0, 0.0, &sources, &[], None, &session);
+        let b = build_trace_doc(false, 7, 4.5, &sources, &[], None, &session);
         assert_eq!(a, b);
         let doc: serde_json::Value = serde_json::from_str(&a).unwrap();
         assert_eq!(doc["paused"], serde_json::json!(false));
@@ -274,9 +308,10 @@ mod tests {
                 provenance: Provenance::Input,
             },
         ];
-        let doc: serde_json::Value =
-            serde_json::from_str(&build_trace_doc(true, 3, 1.6, &sources, &journal, &session))
-                .unwrap();
+        let doc: serde_json::Value = serde_json::from_str(&build_trace_doc(
+            true, 3, 1.6, &sources, &journal, None, &session,
+        ))
+        .unwrap();
 
         assert_eq!(doc["paused"], serde_json::json!(true));
         assert_eq!(doc["frame"], serde_json::json!(3));
@@ -321,5 +356,161 @@ mod tests {
         assert_eq!(input["count"], serde_json::json!(1));
         assert_eq!(input["provenance"], serde_json::json!("input: Key.W down"));
         assert!(!input["bindings"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn wire_carries_v2_fields_and_reference_sites() {
+        let (session, model, sources) = session_and_sources();
+        let journal = vec![JournalEntry {
+            entry: "tick",
+            args: vec![model, Value::Number(0.2), Value::Number(1.1)],
+            provenance: Provenance::Tick,
+        }];
+        let doc: serde_json::Value = serde_json::from_str(&build_trace_doc(
+            true, 1, 0.2, &sources, &journal, None, &session,
+        ))
+        .unwrap();
+        let tick = &doc["invocations"][0];
+
+        // The invocation result carries its preview alongside the full text.
+        assert!(tick["result_preview"].is_string());
+
+        let binds = tick["bindings"].as_array().unwrap();
+        // Every binding carries preview/kind/site; the model param is a
+        // composite (preview elides) and `dt` a primitive (preview == value).
+        for b in binds {
+            assert!(b["preview"].is_string(), "{b}");
+            assert!(matches!(b["kind"].as_str(), Some("primitive" | "composite")), "{b}");
+            assert!(matches!(b["site"].as_str(), Some("binder" | "ref")), "{b}");
+        }
+        let m = binds.iter().find(|b| b["name"] == "m" && b["site"] == "binder").unwrap();
+        assert_eq!(m["kind"], serde_json::json!("composite"));
+        let dt = binds.iter().find(|b| b["name"] == "dt" && b["site"] == "binder").unwrap();
+        assert_eq!(dt["kind"], serde_json::json!("primitive"));
+        assert_eq!(dt["preview"], dt["value"]);
+
+        // Reference sites now ship: `m.n + dt` READS both names.
+        assert!(
+            binds.iter().any(|b| b["name"] == "m" && b["site"] == "ref"),
+            "reference sites reach the wire: {binds:#?}"
+        );
+        assert!(binds.iter().any(|b| b["name"] == "dt" && b["site"] == "ref"));
+    }
+
+    #[test]
+    fn replay_is_observation_only() {
+        use crate::functor_lang_prelude::{push_ui_handler, take_ui_handlers, UiHandler};
+
+        // A tick that BOTH traces (`Debug.log`) and registers a UI handler
+        // (`Ui.button`) — the two ambient channels a replay could perturb.
+        let src = "\
+            let init = { n: 0.0 }\n\
+            let tick = (m, dt: Float, tts: Float) =>\n\
+              let b = Ui.button(\"hi\", 1.0) in\n\
+              Debug.log(\"suppress-probe\", m)\n";
+        let project =
+            load_single_source("game", src).unwrap_or_else(|e| panic!("load: {}", e.render()));
+        let session = Session::load(&project.module, &mut FunctorHost)
+            .unwrap_or_else(|f| panic!("session: {}", f.error.message));
+        let model = session.global("init").expect("init");
+        let sources = inspector_sources(&project.sources);
+        let journal = vec![JournalEntry {
+            entry: "tick",
+            args: vec![model, Value::Number(0.1), Value::Number(0.1)],
+            provenance: Provenance::Tick,
+        }];
+
+        // A capturing sink (the process-wide test seam); the filter below
+        // keys on this test's unique label so parallel tests can't pollute.
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        let sink = captured.clone();
+        functor_lang::set_trace_sink(Box::new(move |line| sink.lock().unwrap().push(line)));
+
+        // A handler already registered mid-frame must survive the replay
+        // untouched, with none of the replay's own pushes appended after it.
+        let _ = take_ui_handlers();
+        push_ui_handler(UiHandler::Msg(Value::Number(9.0)));
+
+        let doc: serde_json::Value = serde_json::from_str(&build_trace_doc(
+            true, 1, 0.1, &sources, &journal, None, &session,
+        ))
+        .unwrap();
+        // The replay itself succeeded — the traced-and-widgeted tick recorded.
+        let tick = &doc["invocations"][0];
+        assert_eq!(tick["entry"], serde_json::json!("tick"));
+        assert!(
+            tick["bindings"].as_array().unwrap().iter().any(|b| b["name"] == "b"),
+            "the Ui.button binding recorded"
+        );
+
+        let leaked: Vec<String> = captured
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|l| l.contains("suppress-probe"))
+            .cloned()
+            .collect();
+        assert!(leaked.is_empty(), "replay re-emitted Debug.log: {leaked:?}");
+
+        let handlers = take_ui_handlers();
+        assert_eq!(handlers.len(), 1, "replay pushes must not linger in the UI table");
+        assert!(matches!(handlers[0], UiHandler::Msg(Value::Number(n)) if n == 9.0));
+    }
+
+    #[test]
+    fn draw_is_synthesized_against_the_frozen_model() {
+        // A `draw` that needs no engine prelude: it returns a number derived
+        // from the model, so the replay works under the plain host and the
+        // recorded bindings carry real values.
+        let src = "\
+            let init = { n: 4.0 }\n\
+            let tick = (m, dt: Float, tts: Float) => m\n\
+            let draw = (m, tts: Float) =>\n\
+              let shade = m.n + tts in\n\
+              shade\n";
+        let project =
+            load_single_source("game", src).unwrap_or_else(|e| panic!("load: {}", e.render()));
+        let session = Session::load(&project.module, &mut FunctorHost)
+            .unwrap_or_else(|f| panic!("session: {}", f.error.message));
+        let model = session.global("init").expect("init");
+        let sources = inspector_sources(&project.sources);
+
+        let draw_args = vec![model, Value::Number(1.5)];
+        let doc: serde_json::Value = serde_json::from_str(&build_trace_doc(
+            true,
+            2,
+            1.5,
+            &sources,
+            &[],
+            Some(&draw_args),
+            &session,
+        ))
+        .unwrap();
+
+        let invs = doc["invocations"].as_array().unwrap();
+        let draw = invs.iter().find(|i| i["entry"] == "draw").expect("draw invocation");
+        assert_eq!(draw["provenance"], serde_json::json!("draw"));
+        assert_eq!(draw["count"], serde_json::json!(1));
+        let binds = draw["bindings"].as_array().unwrap();
+        let shade = binds
+            .iter()
+            .find(|b| b["name"] == "shade" && b["site"] == "binder")
+            .expect("shade binder");
+        assert_eq!(shade["value"], serde_json::json!("5.5"));
+
+        // A program WITHOUT draw skips gracefully (no invocation, no error).
+        let (session2, model2, sources2) = session_and_sources();
+        let args2 = vec![model2, Value::Number(0.5)];
+        let doc2: serde_json::Value = serde_json::from_str(&build_trace_doc(
+            true,
+            2,
+            0.5,
+            &sources2,
+            &[],
+            Some(&args2),
+            &session2,
+        ))
+        .unwrap();
+        assert!(doc2["invocations"].as_array().unwrap().is_empty());
     }
 }

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -963,19 +963,23 @@ AudioScene.empty), got {}",
     /// (`GameClock::is_paused`).
     fn inspector_trace(&mut self, paused: bool) -> String {
         if !paused {
-            return build_trace_doc(false, 0, 0.0, &self.source_hashes, &[], &self.session);
+            return build_trace_doc(false, 0, 0.0, &self.source_hashes, &[], None, &self.session);
         }
         if let Some(cached) = &self.cached_trace {
             return cached.clone();
         }
         let frame = self.recorder.current_scene_frame().unwrap_or(0);
         let tts = self.recorder.current_scene_frame_tts().unwrap_or(0.0);
+        // Draw is pure and never journaled; the builder replays it once
+        // against the frozen model so the render pass is inspectable too.
+        let draw_args = vec![self.model.clone(), Value::Number(tts)];
         let json = build_trace_doc(
             true,
             frame,
             tts,
             &self.source_hashes,
             &self.last_frame_journal,
+            Some(&draw_args),
             &self.session,
         );
         self.cached_trace = Some(json.clone());
@@ -2470,9 +2474,11 @@ mod tests {
             .iter()
             .map(|i| i["entry"].as_str().unwrap())
             .collect();
+        // Only the resume frame's own entries survive (no phantom input),
+        // plus the trace-time synthesized draw pass (trace v2).
         assert_eq!(
             entries,
-            vec!["tick"],
+            vec!["tick", "draw"],
             "only the resume frame's own entries survive"
         );
 

--- a/runtime/functor-runtime-web/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-web/src/functor_lang_game.rs
@@ -814,19 +814,23 @@ AudioScene.empty), got {}",
     /// VS Code live-preview as a `functor-inspector-trace` postMessage.
     fn inspector_trace(&mut self, paused: bool) -> String {
         if !paused {
-            return build_trace_doc(false, 0, 0.0, &self.source_hashes, &[], &self.session);
+            return build_trace_doc(false, 0, 0.0, &self.source_hashes, &[], None, &self.session);
         }
         if let Some(cached) = &self.cached_trace {
             return cached.clone();
         }
         let frame = self.recorder.current_scene_frame().unwrap_or(0);
         let tts = self.recorder.current_scene_frame_tts().unwrap_or(0.0);
+        // Draw is pure and never journaled; the builder replays it once
+        // against the frozen model so the render pass is inspectable too.
+        let draw_args = vec![self.model.clone(), Value::Number(tts)];
         let json = build_trace_doc(
             true,
             frame,
             tts,
             &self.source_hashes,
             &self.last_frame_journal,
+            Some(&draw_args),
             &self.session,
         );
         self.cached_trace = Some(json.clone());

--- a/tools/functor-lang-lsp/src/inspector.rs
+++ b/tools/functor-lang-lsp/src/inspector.rs
@@ -57,7 +57,8 @@ pub struct Invocation {
     pub bindings: Vec<Binding>,
 }
 
-/// One binding site's last recorded value.
+/// One site's last recorded value — a binder (let/param/match) or a variable
+/// reference (trace v2).
 pub struct Binding {
     pub name: String,
     /// Trace-relative file name (e.g. `game.fun`).
@@ -65,9 +66,14 @@ pub struct Binding {
     /// Byte offsets **into that file's own text** (per-file local).
     pub start: usize,
     pub end: usize,
-    /// `Display` text of the (last) bound value.
+    /// `Display` text of the (last) value.
     pub value: String,
-    /// Times this site bound during the invocation (loops > 1); `value` is last.
+    /// Depth-limited one-line preview — what renders inline (`value` moves to
+    /// hover). Equals `value` on a v1 trace (no preview field) or a primitive.
+    pub preview: String,
+    /// `"binder"` or `"ref"` (v1 traces: `"binder"`).
+    pub site: String,
+    /// Times this site was seen during the invocation (loops > 1); `value` is last.
     pub count: usize,
 }
 
@@ -117,12 +123,18 @@ impl Invocation {
 
 impl Binding {
     fn from_json(v: &Value) -> Option<Binding> {
+        let value = v["value"].as_str().unwrap_or("").to_string();
+        // v1 traces carry no preview/site — default to the full value and
+        // binder, which reproduces the v1 rendering exactly.
+        let preview = v["preview"].as_str().map(str::to_string).unwrap_or_else(|| value.clone());
         Some(Binding {
             name: v["name"].as_str()?.to_string(),
             file: v["file"].as_str()?.to_string(),
             start: v["start"].as_u64()? as usize,
             end: v["end"].as_u64()? as usize,
-            value: v["value"].as_str().unwrap_or("").to_string(),
+            value,
+            preview,
+            site: v["site"].as_str().unwrap_or("binder").to_string(),
             count: v["count"].as_u64().unwrap_or(1).max(1) as usize,
         })
     }
@@ -182,8 +194,13 @@ fn selected_invocation<'a>(
 
 /// Live-value inlay hints for `file_name`'s `source`, from the selected
 /// execution of each entry point. Empty (silently) when the source hash does
-/// not match the trace. Hints are deduplicated by offset so a helper shared
-/// across two selected invocations doesn't double up.
+/// not match the trace.
+///
+/// Renders the depth-limited `preview` (the full `value` is hover's job) and
+/// keeps ONE hint per (line, name): a binder site beats a reference site,
+/// and among references the first in reading order wins — so `m + m` shows
+/// `m`'s value once, and a line that binds `x` doesn't also annotate its
+/// reads of `x`.
 pub fn live_hints(
     trace: &TraceDoc,
     file_name: &str,
@@ -193,26 +210,110 @@ pub fn live_hints(
     if !source_matches(trace, file_name, source) {
         return Vec::new();
     }
-    let mut out = Vec::new();
-    let mut seen = HashSet::new();
+    // (line, name) → the winning binding + its render offset.
+    let mut chosen: std::collections::HashMap<(usize, String), (&Binding, usize)> =
+        std::collections::HashMap::new();
     for entry in distinct_entries(trace) {
         let Some((inv, _, _)) = selected_invocation(trace, &entry, selected) else {
             continue;
         };
         for b in &inv.bindings {
-            let offset = hint_offset(source, b);
-            if b.file != file_name || !seen.insert(offset) {
+            if b.file != file_name {
                 continue;
             }
-            let label = if b.count > 1 {
-                format!("= {} (×{})", b.value, b.count)
-            } else {
-                format!("= {}", b.value)
-            };
-            out.push(LiveHint { offset, label });
+            let offset = hint_offset(source, b);
+            let line = line_of(source, offset);
+            match chosen.entry((line, b.name.clone())) {
+                std::collections::hash_map::Entry::Vacant(slot) => {
+                    slot.insert((b, offset));
+                }
+                std::collections::hash_map::Entry::Occupied(mut slot) => {
+                    let (cur, cur_offset) = *slot.get();
+                    let wins = match (b.site.as_str(), cur.site.as_str()) {
+                        ("binder", "ref") => true,
+                        ("ref", "binder") => false,
+                        _ => offset < cur_offset,
+                    };
+                    if wins {
+                        slot.insert((b, offset));
+                    }
+                }
+            }
         }
     }
+    let mut out: Vec<LiveHint> = chosen
+        .into_values()
+        .map(|(b, offset)| {
+            let label = if b.count > 1 {
+                format!("= {} (×{})", b.preview, b.count)
+            } else {
+                format!("= {}", b.preview)
+            };
+            LiveHint { offset, label }
+        })
+        .collect();
+    out.sort_by_key(|h| h.offset);
+    out.dedup_by_key(|h| h.offset);
     out
+}
+
+/// The live value under `offset` in `file_name` — the hover half of the
+/// inline-vs-hover policy: inline shows the elided `preview`, hover shows the
+/// FULL `value`. Picks the narrowest recorded site whose name span contains
+/// the offset, from the selected executions; `None` on a hash mismatch or
+/// when nothing recorded there.
+pub fn live_hover(
+    trace: &TraceDoc,
+    file_name: &str,
+    source: &str,
+    offset: usize,
+    selected: &dyn Fn(&str) -> usize,
+) -> Option<String> {
+    if !source_matches(trace, file_name, source) {
+        return None;
+    }
+    let mut best: Option<(&Binding, usize)> = None; // (binding, name-span width)
+    for entry in distinct_entries(trace) {
+        let Some((inv, _, _)) = selected_invocation(trace, &entry, selected) else {
+            continue;
+        };
+        for b in &inv.bindings {
+            if b.file != file_name {
+                continue;
+            }
+            // The name-precise span: a `let` binder's span is the whole
+            // `let name =` region, so locate the name inside it (as
+            // hint_offset does); refs/params are already name-precise.
+            // Half-open: hovering the character AT name_end (the operator or
+            // space after the name) is not hovering the name.
+            let name_end = hint_offset(source, b);
+            let name_start = name_end.saturating_sub(b.name.len());
+            if offset < name_start || offset >= name_end {
+                continue;
+            }
+            let width = name_end - name_start;
+            if best.map(|(_, w)| width < w).unwrap_or(true) {
+                best = Some((b, width));
+            }
+        }
+    }
+    best.map(|(b, _)| {
+        if b.count > 1 {
+            format!("{} = {} (×{})", b.name, b.value, b.count)
+        } else {
+            format!("{} = {}", b.name, b.value)
+        }
+    })
+}
+
+/// The 0-based line of `offset` in `source`.
+fn line_of(source: &str, offset: usize) -> usize {
+    source
+        .as_bytes()
+        .iter()
+        .take(offset.min(source.len()))
+        .filter(|&&b| b == b'\n')
+        .count()
 }
 
 /// Execution-picker lenses for the entry-point defs in `file_name`. `entry_defs`
@@ -251,20 +352,50 @@ pub fn picker_lenses(
 
 /// Where to render a binding's `= value` hint: **just after the binder name**.
 ///
-/// Per the PR1 contract, a binding's span is name-precise only for lambda/match
-/// binders; a `let` binder's span is the whole `let [mut] name =` **region**, so
-/// its `end` sits after the `=`, not after the name. We therefore locate the
-/// `name` text within the span (`rfind`, so the binder — not a `let`/`mut`
-/// keyword — wins) and place the hint right after it, falling back to the span
-/// end when the source slice is unusable or the name isn't found.
+/// Per the PR1 contract, a binding's span is name-precise only for lambda/
+/// match binders and references; a `let` binder's span is the whole
+/// `let [mut] name =` **region**, so its `end` sits after the `=`, not after
+/// the name. We locate the name by scanning FORWARD past the keywords (a
+/// comment inside the region can contain the name too — a backwards search
+/// would hit it), with `rfind` as the last-resort fallback, and place the
+/// hint right after it; span end when the source slice is unusable.
 fn hint_offset(source: &str, b: &Binding) -> usize {
     match source.get(b.start..b.end) {
-        Some(region) => match region.rfind(&b.name) {
+        Some(region) => match binder_name_at(region, &b.name) {
             Some(i) => b.start + i + b.name.len(),
             None => b.end,
         },
         None => b.end,
     }
+}
+
+/// The byte offset of the binder `name` within its recorded span text — 0 for
+/// a name-precise span, the post-keyword position for a `let [mut] name =`
+/// region (skipping `let`/`mut`/whitespace, never searching backwards past a
+/// comment), else a whole-region `rfind` as the defensive fallback.
+fn binder_name_at(region: &str, name: &str) -> Option<usize> {
+    let at_name = |i: usize| {
+        region[i..].starts_with(name)
+            && !region[i + name.len()..]
+                .chars()
+                .next()
+                .map(|c| c.is_alphanumeric() || c == '_')
+                .unwrap_or(false)
+    };
+    if at_name(0) {
+        return Some(0);
+    }
+    let mut i = 0;
+    for keyword in ["let", "mut"] {
+        if region[i..].starts_with(keyword) {
+            i += keyword.len();
+            i += region[i..].len() - region[i..].trim_start().len();
+            if at_name(i) {
+                return Some(i);
+            }
+        }
+    }
+    region.rfind(name)
 }
 
 /// Distinct entry names in first-seen order.
@@ -386,6 +517,164 @@ mod tests {
 
     fn no_selection() -> impl Fn(&str) -> usize {
         |_| 0
+    }
+
+    #[test]
+    fn v2_previews_render_inline_and_full_values_hover() {
+        let src = "let tick = (m, dt, tts) =>\n  m\n";
+        let start = src.find('m').unwrap();
+        let end = start + 1;
+        let trace = trace_for(
+            src,
+            json!([{
+                "entry": "tick", "index": 0, "count": 1, "provenance": "tick dt=0.016",
+                "ghost": false, "result": "0",
+                "bindings": [{
+                    "name": "m", "file": "game.fun", "start": start, "end": end,
+                    "value": "{ pos: { x: 1, y: 2 }, hp: 3 }",
+                    "preview": "{ pos: …, hp: 3 }",
+                    "kind": "composite", "site": "binder", "count": 1
+                }]
+            }]),
+        );
+        // Inline shows the elided preview…
+        let hints = live_hints(&trace, "game.fun", src, &no_selection());
+        assert_eq!(hints.len(), 1);
+        assert_eq!(hints[0].label, "= { pos: …, hp: 3 }");
+        // …and hover on the name shows the full value.
+        let hover = live_hover(&trace, "game.fun", src, start, &no_selection());
+        assert_eq!(hover.as_deref(), Some("m = { pos: { x: 1, y: 2 }, hp: 3 }"));
+        // Off the name: nothing. Half-open: the character AT name_end (the
+        // `,` after `m`) is not the name either.
+        assert!(live_hover(&trace, "game.fun", src, src.len() - 1, &no_selection()).is_none());
+        assert!(live_hover(&trace, "game.fun", src, end, &no_selection()).is_none());
+    }
+
+    #[test]
+    fn one_hint_per_line_and_name_binder_wins() {
+        // `x` appears three times on the body line: the binder plus two reads.
+        // Exactly one hint renders for it, at the binder.
+        let src = "let tick = (m, dt, tts) =>\n  let x = m in x\n";
+        let region_start = src.find("let x").unwrap();
+        let name_pos = region_start + "let ".len();
+        let value_pos = region_start + src[region_start..].find("m in").unwrap();
+        let read_pos = src.rfind('x').unwrap();
+        let trace = trace_for(
+            src,
+            json!([{
+                "entry": "tick", "index": 0, "count": 1, "provenance": "p",
+                "ghost": false, "result": "0",
+                "bindings": [
+                    { "name": "x", "file": "game.fun",
+                      "start": region_start, "end": value_pos,
+                      "value": "7", "preview": "7", "kind": "primitive",
+                      "site": "binder", "count": 1 },
+                    { "name": "x", "file": "game.fun",
+                      "start": read_pos, "end": read_pos + 1,
+                      "value": "7", "preview": "7", "kind": "primitive",
+                      "site": "ref", "count": 1 }
+                ]
+            }]),
+        );
+        let hints = live_hints(&trace, "game.fun", src, &no_selection());
+        assert_eq!(hints.len(), 1, "one hint per (line, name): {:?}",
+            hints.iter().map(|h| h.offset).collect::<Vec<_>>());
+        assert_eq!(hints[0].offset, name_pos + 1, "the binder wins");
+    }
+
+    #[test]
+    fn reference_sites_annotate_their_own_lines() {
+        // A read on a DIFFERENT line than its binder gets its own hint.
+        let src = "let tick = (m, dt, tts) =>\n  m\n";
+        let param_pos = src.find('m').unwrap();
+        let read_pos = src.rfind('m').unwrap();
+        let trace = trace_for(
+            src,
+            json!([{
+                "entry": "tick", "index": 0, "count": 1, "provenance": "p",
+                "ghost": false, "result": "0",
+                "bindings": [
+                    { "name": "m", "file": "game.fun",
+                      "start": param_pos, "end": param_pos + 1,
+                      "value": "5", "preview": "5", "kind": "primitive",
+                      "site": "binder", "count": 1 },
+                    { "name": "m", "file": "game.fun",
+                      "start": read_pos, "end": read_pos + 1,
+                      "value": "5", "preview": "5", "kind": "primitive",
+                      "site": "ref", "count": 1 }
+                ]
+            }]),
+        );
+        let hints = live_hints(&trace, "game.fun", src, &no_selection());
+        assert_eq!(hints.len(), 2, "binder line + read line");
+        assert!(hints.iter().any(|h| h.offset == read_pos + 1));
+    }
+
+    #[test]
+    fn hint_lands_on_the_binder_not_a_later_occurrence_in_the_region() {
+        // `let t: Float =` — the region text contains a later `t` (inside
+        // `Float`); a backwards search would land the hint there. The forward
+        // scan puts it after the BINDER name.
+        let src = "let tick = (m, dt, tts) =>\n  let t: Float = 1.0 in t\n";
+        let region_start = src.find("let t:").unwrap();
+        let value_pos = region_start + src[region_start..].find("1.0").unwrap();
+        let trace = trace_for(
+            src,
+            json!([{
+                "entry": "tick", "index": 0, "count": 1, "provenance": "p",
+                "ghost": false, "result": "1",
+                "bindings": [{
+                    "name": "t", "file": "game.fun",
+                    "start": region_start, "end": value_pos,
+                    "value": "1", "preview": "1", "kind": "primitive",
+                    "site": "binder", "count": 1
+                }]
+            }]),
+        );
+        let hints = live_hints(&trace, "game.fun", src, &no_selection());
+        assert_eq!(hints.len(), 1);
+        assert_eq!(hints[0].offset, region_start + "let t".len());
+    }
+
+    #[test]
+    fn v1_traces_without_preview_fields_still_render() {
+        // Back-compat: no preview/kind/site → preview defaults to the value,
+        // site to binder — byte-identical to the v1 rendering.
+        let src = "let tick = (m, dt, tts) =>\n  m\n";
+        let start = src.find('m').unwrap();
+        let trace = trace_for(
+            src,
+            json!([{
+                "entry": "tick", "index": 0, "count": 1, "provenance": "p",
+                "ghost": false, "result": "0",
+                "bindings": [{
+                    "name": "m", "file": "game.fun", "start": start, "end": start + 1,
+                    "value": "42", "count": 1
+                }]
+            }]),
+        );
+        let hints = live_hints(&trace, "game.fun", src, &no_selection());
+        assert_eq!(hints.len(), 1);
+        assert_eq!(hints[0].label, "= 42");
+    }
+
+    #[test]
+    fn live_hover_gates_on_the_source_hash() {
+        let src = "let tick = (m, dt, tts) =>\n  m\n";
+        let start = src.find('m').unwrap();
+        let trace = trace_for(
+            src,
+            json!([{
+                "entry": "tick", "index": 0, "count": 1, "provenance": "p",
+                "ghost": false, "result": "0",
+                "bindings": [{
+                    "name": "m", "file": "game.fun", "start": start, "end": start + 1,
+                    "value": "42", "count": 1
+                }]
+            }]),
+        );
+        let edited = format!("{src} ");
+        assert!(live_hover(&trace, "game.fun", &edited, start, &no_selection()).is_none());
     }
 
     #[test]

--- a/tools/functor-lang-lsp/src/main.rs
+++ b/tools/functor-lang-lsp/src/main.rs
@@ -181,9 +181,20 @@ fn run(
             }
             ("textDocument/hover", Some(id)) => {
                 let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
+                // The type hover merged with the live value under the cursor
+                // (trace v2's inline-vs-hover policy: previews render inline,
+                // the FULL value lives here).
                 let result = documents
                     .contains_key(uri)
-                    .then(|| hover(uri, &documents, &params["position"]))
+                    .then(|| {
+                        hover_with_live(
+                            uri,
+                            &documents,
+                            trace.as_ref(),
+                            &selected,
+                            &params["position"],
+                        )
+                    })
                     .flatten()
                     .unwrap_or(Value::Null);
                 write_message(
@@ -432,6 +443,53 @@ fn hover(uri: &str, documents: &HashMap<String, String>, position: &Value) -> Op
         "contents": { "kind": "markdown", "value": format!("```functor\n{hover_text}\n```") },
         "range": range,
     }))
+}
+
+/// The type hover merged with the live value under the cursor. Either half
+/// can be absent: a live value with no type hover still answers (values show
+/// even when the buffer doesn't check — the live-hint precedent), and vice
+/// versa. The live value renders FIRST (it's the immediate question when
+/// paused), the type after.
+fn hover_with_live(
+    uri: &str,
+    documents: &HashMap<String, String>,
+    trace: Option<&TraceDoc>,
+    selected: &HashMap<String, usize>,
+    position: &Value,
+) -> Option<Value> {
+    let type_hover = hover(uri, documents, position);
+    let live = live_hover_text(uri, documents, trace, selected, position);
+    match (type_hover, live) {
+        (Some(mut h), Some(live)) => {
+            let existing = h["contents"]["value"].as_str().unwrap_or("").to_string();
+            h["contents"]["value"] =
+                json!(format!("```functor\n{live}\n```\n\n{existing}"));
+            Some(h)
+        }
+        (h @ Some(_), None) => h,
+        (None, Some(live)) => Some(json!({
+            "contents": { "kind": "markdown", "value": format!("```functor\n{live}\n```") },
+        })),
+        (None, None) => None,
+    }
+}
+
+/// The live value under the cursor, from the trace (hash-gated, selected
+/// executions) — mirrors `live_inlay_hints`' file/offset mapping.
+fn live_hover_text(
+    uri: &str,
+    documents: &HashMap<String, String>,
+    trace: Option<&TraceDoc>,
+    selected: &HashMap<String, usize>,
+    position: &Value,
+) -> Option<String> {
+    let trace = trace?;
+    let path = uri_to_path(uri)?;
+    let file_name = match_trace_file(trace, &path)?;
+    let source = source_text(uri, documents, &path);
+    let offset = position_to_offset(&source, position)?;
+    let select = |entry: &str| selected.get(entry).copied().unwrap_or(0);
+    inspector::live_hover(trace, &file_name, &source, offset, &select)
 }
 
 /// Answer a definition request: load the project, resolve the reference at


### PR DESCRIPTION
## Why

Stacked on #373 (inspector v2, part 2 of 5 — plan in the visual-debugger notes). The paused trace only carried binder sites as full untruncated Display strings, and `draw` was invisible (never journaled) — so the editor showed one giant value for tick and nothing for the render pass.

## What

**Runtime (`functor_runtime_common::inspector`):**
- `build_trace_doc` gains `draw_args`: one synthesized **draw** invocation replayed against the frozen model (pure — draw already re-runs every paused frame; provenance `"draw"`). Programs without draw skip gracefully. Both shells wire it identically.
- Wire bindings carry `preview`/`kind`/`site`; invocations carry `result_preview`; the binder-only filter is lifted so **reference sites** ship.
- **Replay is observation-only** (review-driven): `Debug.log` re-emission is suppressed for the replay scope (RAII; its lines already emitted live — every trace build re-emitted them, straight into the new Output panel), and the UI handler table is save/restored (a replayed `Ui.*` would shift the next real `ui` pass's slots).

**LSP:**
- Inlay hints render the depth-limited **preview**; the **full value moves to hover** (`live_hover`, merged above the type hover — answers even when the buffer doesn't check).
- One hint per (line, name): a binder beats a reference, earliest read wins — `m + m` annotates once.
- The binder-name locator scans **forward** past `let`/`mut` (an annotation like `let t: Float =` contains a later `t` the old `rfind` landed on).
- v1 traces parse with back-compat defaults — rendering byte-identical to before.

## Testing

- functor_runtime_common 292 (5 inspector tests: draw synthesis + graceful skip, v2 fields + ref sites on the wire, observation-only replay with a traced-and-widgeted tick)
- functor-lang-lsp 41 (7 new: preview-inline/full-hover policy, per-line dedup binder-wins, ref lines annotate, v1 back-compat, hash gate, annotation-occurrence positioning, half-open hover bounds)
- desktop 47, functor-lang 497, wasm-pack build clean
- Live headless verification: `examples/inspector` under `--headless --debug-port` → pause/step → `GET /trace` shows `draw` (result_preview `<Frame>`), eliding composite previews, refs counted apart from binders.

Reviewed with /xreview (Claude + Codex); both Mediums fixed (replay side-channels, binder locator), half-open hover bound fixed, Lows accepted (same-line shadowing collapse is the intended dedup; `result_preview` lands its consumer in PR 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)