### PR TITLE
feat(site): live values in the sandbox and web IDE while paused

### DIFF
--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -1204,6 +1204,89 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
   await page.close();
 }
 
+// --- 12c. Live values while paused (the inspector overlay). --------------------
+// Pausing via the player's scrubber relays the trace to the page; the editor
+// grows cyan `= value` live inlays next to binders AND variable reads, the
+// executions tab lists the frame's entry-point runs (tick + the synthesized
+// draw), and any edit clears the overlay instantly (hash gate).
+{
+  const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+  await page.goto(`${BASE}/sandbox.html`);
+  await page.waitForFunction(
+    () => window.__sandbox && window.__sandbox.status().state === "live",
+    { timeout: 30000 }
+  );
+  await page.waitForFunction(() => window.__lang && window.__lang.ready, { timeout: 15000 });
+
+  const waitFor = async (fn, pred, timeout = 10000) => {
+    const t0 = Date.now();
+    for (;;) {
+      const v = await fn();
+      if (pred(v)) return v;
+      if (Date.now() - t0 > timeout) return v;
+      await sleep(150);
+    }
+  };
+
+  // Let a few frames run, then pause via the real scrubber button.
+  await sleep(800);
+  await playerFrame(page).evaluate(() => document.getElementById("scrub-pause")?.click());
+
+  // Live inlays appear (the relay → setLiveTrace → hash gate → overlay path).
+  const liveCount = await waitFor(() => page.locator(".cm-live-value").count(), (n) => n > 0);
+  check("pausing shows live-value inlays in the editor", liveCount > 0, `count=${liveCount}`);
+  const liveTexts = await page.locator(".cm-live-value").allTextContents();
+  check(
+    "live inlays carry `= value` previews",
+    liveTexts.every((t) => t.startsWith("= ")) && liveTexts.length > 0,
+    JSON.stringify(liveTexts.slice(0, 4))
+  );
+
+  // Position invariant: every hint's name span slices to exactly its name.
+  // hero.fun's comments contain multibyte characters (em dashes) BEFORE the
+  // bindings, so this fails loudly if the trace's UTF-8 byte offsets ever
+  // reach the editor unconverted.
+  const misplaced = await page.evaluate(() => {
+    const doc = window.__sandbox.source();
+    return window.__lang
+      .liveHints()
+      .filter((h) => doc.slice(h.nameStart, h.nameEnd) !== h.name)
+      .map((h) => `${h.name}@${h.nameStart}=${JSON.stringify(doc.slice(h.nameStart, h.nameEnd))}`);
+  });
+  check("live hints sit exactly on their names (byte→UTF-16)", misplaced.length === 0, JSON.stringify(misplaced));
+
+  // The executions picker lists the frame's runs, draw included.
+  const execTab = page.locator('.statusbar-tab[data-tab="executions"]');
+  const tabText = ((await execTab.textContent()) || "").trim();
+  check("executions tab counts the paused frame's runs", /⏸ \d+ executions/.test(tabText), tabText);
+  await execTab.click();
+  const rows = await waitFor(
+    () => page.locator(".exec-row").allTextContents(),
+    (rs) => rs.some((r) => r.startsWith("draw"))
+  );
+  check(
+    "executions list includes tick and the synthesized draw",
+    rows.some((r) => r.startsWith("tick")) && rows.some((r) => r.startsWith("draw")),
+    JSON.stringify(rows)
+  );
+
+  // Resuming play clears the overlay (the runtime's unpaused stub bumps the
+  // trace generation; stale inlays over a running game would be lies).
+  await playerFrame(page).evaluate(() => document.getElementById("scrub-pause")?.click());
+  const resumed = await waitFor(() => page.locator(".cm-live-value").count(), (n) => n === 0, 6000);
+  check("resuming clears the live overlay", resumed === 0, `count=${resumed}`);
+
+  // Pause again: the overlay returns, then an edit clears it instantly —
+  // stale values must never drift over moved text (hash gate).
+  await playerFrame(page).evaluate(() => document.getElementById("scrub-pause")?.click());
+  await waitFor(() => page.locator(".cm-live-value").count(), (n) => n > 0);
+  await page.evaluate((s) => window.__sandbox.setSource(s), `${GREEN}// paused edit\n`);
+  const cleared = await waitFor(() => page.locator(".cm-live-value").count(), (n) => n === 0, 4000);
+  check("editing clears the live overlay (hash gate)", cleared === 0, `count=${cleared}`);
+
+  await page.close();
+}
+
 // --- 13. Scope-aware autocomplete in the editor (commit 8b). ------------------
 // The completion source is backed by the wasm's scope-aware `complete`, driven
 // through the __sandbox.triggerComplete seam (insert text + set cursor + open

--- a/site/player.html
+++ b/site/player.html
@@ -102,6 +102,8 @@
         functor_lang_mouse_wheel,
         functor_lang_is_running,
         functor_lang_scene_frame,
+        functor_lang_inspector_trace,
+        functor_lang_inspector_trace_gen,
         functor_lang_set_source,
         functor_lang_set_project,
       } from "./pkg/functor_runtime_web.js";
@@ -316,8 +318,37 @@
           setupInput();
           if (!scrubberOff) mountScrubber();
         }
+        setupInspectorRelay();
         announceWhenReady();
       });
+
+      // Relay the paused-inspector trace to the embedding sandbox/IDE page
+      // (live values in the editor). The runtime bumps a generation counter
+      // only when the trace CONTENT changes (pause, paused-frame change);
+      // poll it once per frame and post the doc on change. Same-origin
+      // parents only — like the console relay above, this carries
+      // game-visible data outward.
+      const setupInspectorRelay = () => {
+        if (!sameOriginParent) return;
+        let lastTraceGen = -1;
+        const poll = () => {
+          const traceGen = functor_lang_inspector_trace_gen();
+          if (traceGen !== lastTraceGen) {
+            lastTraceGen = traceGen;
+            try {
+              const trace = JSON.parse(functor_lang_inspector_trace());
+              window.parent.postMessage(
+                { type: "functor-inspector-trace", trace },
+                window.location.origin
+              );
+            } catch {
+              // A malformed doc (shouldn't happen) must not kill the poll loop.
+            }
+          }
+          requestAnimationFrame(poll);
+        };
+        requestAnimationFrame(poll);
+      };
 
       if (inlineProject) {
         // Tell the host the listener is armed — it then pushes the initial

--- a/site/sandbox.html
+++ b/site/sandbox.html
@@ -47,15 +47,6 @@
 
     <div id="statusbar"></div>
 
-    <footer class="sandbox-footer">
-      <p>
-        Edits hot-reload the running game <em>with the model preserved</em> — the wave keeps
-        rolling while you retune it. A broken edit keeps the old program running. Press
-        <em>mouse look</em> to steer the camera (Esc to release), and scrub the timeline
-        along the bottom to travel through time.
-      </p>
-    </footer>
-
     <script type="module" src="assets/sandbox.js"></script>
   </body>
 </html>

--- a/site/src/ide.js
+++ b/site/src/ide.js
@@ -11,7 +11,15 @@ import { indentWithTab } from "@codemirror/commands";
 import { acceptCompletion, closeCompletion, startCompletion } from "@codemirror/autocomplete";
 import { StateEffect } from "@codemirror/state";
 import { functorLangLanguage, synthwaveEditorTheme } from "./functor-lang.js";
-import { setupLangIntel, setLangContext, resetIntel, refreshIntel, onDiagnostics } from "./lang-intel.js";
+import {
+  setupLangIntel,
+  setLangContext,
+  resetIntel,
+  refreshIntel,
+  onDiagnostics,
+  wireLiveTrace,
+  refreshLiveValues,
+} from "./lang-intel.js";
 import { ProjectBridge } from "./project-bridge.js";
 import { createStatusBar } from "./status-bar.js";
 import { zipFiles } from "./zip.js";
@@ -203,6 +211,12 @@ window.addEventListener("message", (event) => {
   statusBar.appendOutput(data.level, data.message, data.frame ?? null);
 });
 
+// The paused-inspector trace (live values in the editor + the executions
+// picker), relayed by the player on pause / paused-frame change. A file
+// switch keeps the trace — refreshLiveValues re-gates against the newly
+// opened buffer's hash (openFile below calls it after setDoc).
+wireLiveTrace(view, statusBar, els.player, langReady);
+
 const setDoc = (source) => {
   programmaticEdit = true;
   view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: source } });
@@ -285,6 +299,9 @@ const openFile = (path) => {
   setDoc(next ? next.source : "");
   renderFileList();
   saveProject();
+  // The paused trace carries per-file hashes: re-gate the live overlay
+  // against the newly opened buffer (the doc swap just cleared it).
+  refreshLiveValues(view);
 };
 
 // A valid sibling filename: `<name>.fun`, a bare module stem (no path

--- a/site/src/lang-intel.js
+++ b/site/src/lang-intel.js
@@ -145,6 +145,12 @@ const toDiagnostics = (view) => {
 // and render it monospace in a small calm-theme tooltip.
 const hoverTypes = hoverTooltip((view, pos) => {
   if (!hoverFn) return null;
+  // The live value first (the paused inspector's inline-vs-hover policy:
+  // previews render inline, the FULL value lives here). ALL recorded sites
+  // answer — including reads the inline dedup suppressed. Half-open bounds —
+  // the character AT nameEnd is the operator/space after the name.
+  const hit = liveSites.find((s) => pos >= s.nameStart && pos < s.nameEnd);
+  const live = hit ? { name: hit.b.name, value: hit.b.value, count: hit.b.count || 1, nameStart: hit.nameStart, nameEnd: hit.nameEnd } : null;
   let info;
   try {
     const doc = view.state.doc.toString();
@@ -153,21 +159,36 @@ const hoverTypes = hoverTooltip((view, pos) => {
       (args ? hoverProjectFn(args.filesJson, args.active, pos) : hoverFn(doc, pos)) || ""
     );
   } catch {
-    return null;
+    info = null;
   }
-  if (!info || !info.text) return null;
+  if (!live && (!info || !info.text)) return null;
   // Clamp to the current doc, exactly like toDiagnostics/buildDecorations: the
   // wasm offsets can lag the live buffer by a keystroke.
   const len = view.state.doc.length;
-  const from = Math.max(0, Math.min(info.from | 0, len));
-  const to = Math.max(from, Math.min(info.to | 0, len));
+  const from = live
+    ? live.nameStart
+    : Math.max(0, Math.min(info.from | 0, len));
+  const to = live ? live.nameEnd : Math.max(from, Math.min(info.to | 0, len));
   return {
     pos: from,
     end: to,
     create: () => {
       const dom = document.createElement("div");
       dom.className = "cm-hover-type";
-      dom.textContent = info.text;
+      if (live) {
+        const line = document.createElement("div");
+        line.className = "cm-hover-live";
+        line.textContent =
+          live.count > 1
+            ? `${live.name} = ${live.value} (×${live.count})`
+            : `${live.name} = ${live.value}`;
+        dom.appendChild(line);
+      }
+      if (info && info.text) {
+        const line = document.createElement("div");
+        line.textContent = info.text;
+        dom.appendChild(line);
+      }
       return { dom };
     },
   };
@@ -360,6 +381,325 @@ const decorationField = StateField.define({
   provide: (f) => EditorView.decorations.from(f),
 });
 
+// --- Live values (paused-inspector overlay) ------------------------------------
+// The player relays the paused trace (`functor-inspector-trace` postMessage,
+// see site/player.html); the host page hands it to `setLiveTrace`. While the
+// game is paused and the buffer matches the trace's source hash, every
+// recorded site renders an inline `= preview` next to its name — binders and
+// variable reads — and hovering a name shows the FULL value. Any edit clears
+// the overlay instantly (the hash no longer matches; the IDE's push loop
+// delivers a fresh trace after the hot reload).
+
+class LiveValueWidget extends WidgetType {
+  constructor(label) {
+    super();
+    this.label = label;
+  }
+  eq(other) {
+    return other.label === this.label;
+  }
+  toDOM() {
+    const span = document.createElement("span");
+    span.className = "cm-live-value";
+    span.textContent = this.label;
+    return span;
+  }
+  ignoreEvent() {
+    return true;
+  }
+}
+
+const setLiveOverlay = StateEffect.define();
+
+// The current overlay's hint data, kept in lockstep with the decoration
+// field below — plus ALL recorded sites for the buffer (hover searches every
+// site, not just the per-line dedup winners: the second `x` in `x + x` still
+// hovers to its value).
+let liveHints = [];
+let liveSites = [];
+
+const liveField = StateField.define({
+  create: () => Decoration.none,
+  update(value, tr) {
+    // Any edit invalidates the overlay wholesale — the trace's source hash no
+    // longer matches, and honest absence beats drifted values. A fresh trace
+    // re-populates after the reload round-trips.
+    if (tr.docChanged) {
+      liveHints = [];
+      liveSites = [];
+      return Decoration.none;
+    }
+    for (const effect of tr.effects) {
+      if (effect.is(setLiveOverlay)) {
+        liveHints = effect.value;
+        return Decoration.set(
+          effect.value.map((h) =>
+            Decoration.widget({ widget: new LiveValueWidget(h.label), side: 1 }).range(h.offset)
+          ),
+          true
+        );
+      }
+      if (effect.is(clearDecorations)) {
+        liveHints = [];
+        liveSites = [];
+        return Decoration.none;
+      }
+    }
+    return value;
+  },
+  provide: (f) => EditorView.decorations.from(f),
+});
+
+// The trace + selection state, module-level like the analysis caches.
+let liveTrace = null; // the last paused trace doc (null while playing)
+let selectedExec = new Map(); // entry name → selected execution index
+let liveRefreshToken = 0; // supersedes in-flight async hash checks
+
+// The 0-based line of `offset` in `source`.
+const lineOf = (source, offset) => {
+  let line = 0;
+  for (let i = 0; i < offset && i < source.length; i++) {
+    if (source.charCodeAt(i) === 10) line += 1;
+  }
+  return line;
+};
+
+// Trace spans are UTF-8 BYTE offsets into the file text; JS strings and
+// CodeMirror positions count UTF-16 code units. Returns a byte→UTF-16 lookup
+// array, or null for pure-ASCII sources (identity — the common case).
+const byteToUtf16 = (source) => {
+  let ascii = true;
+  for (let i = 0; i < source.length; i++) {
+    if (source.charCodeAt(i) > 127) {
+      ascii = false;
+      break;
+    }
+  }
+  if (ascii) return null;
+  const map = [];
+  let bytes = 0;
+  let units = 0;
+  for (const ch of source) {
+    const cp = ch.codePointAt(0);
+    const width = cp <= 0x7f ? 1 : cp <= 0x7ff ? 2 : cp <= 0xffff ? 3 : 4;
+    for (let k = 0; k < width; k++) map[bytes + k] = units;
+    bytes += width;
+    units += ch.length;
+  }
+  map[bytes] = units;
+  return map;
+};
+
+// Locate the binder name inside its recorded span (the LSP's rule): spans are
+// name-precise except `let [mut] name =` regions, where we scan FORWARD past
+// the keywords (a type annotation or comment inside the region can contain
+// the name too). Returns the offset just after the name, or span end.
+const hintOffset = (source, b) => {
+  const region = source.slice(b.start, b.end);
+  const atName = (i) => {
+    if (!region.startsWith(b.name, i)) return false;
+    const next = region[i + b.name.length];
+    return !(next && /[A-Za-z0-9_]/.test(next));
+  };
+  if (atName(0)) return b.start + b.name.length;
+  let i = 0;
+  for (const keyword of ["let", "mut"]) {
+    if (region.startsWith(keyword, i)) {
+      i += keyword.length;
+      while (i < region.length && /\s/.test(region[i])) i += 1;
+      if (atName(i)) return b.start + i + b.name.length;
+    }
+  }
+  const found = region.lastIndexOf(b.name);
+  return found >= 0 ? b.start + found + b.name.length : b.end;
+};
+
+// The wire's file name for the buffer being edited: the active path in
+// project mode (the IDE), else the trace's single user file (the sandbox
+// serves examples under their own names — `hero.fun`, not `game.fun`).
+// SINGLE-FILE ASSUMPTION: a sandbox program that ever loads sibling modules
+// would yield multiple sources here and the overlay stays hidden — the
+// sandbox is a one-buffer editor by design, so there is nothing to overlay
+// the siblings on anyway.
+const liveFileName = (docString) => {
+  const args = projectArgs(docString);
+  if (args) return args.active;
+  const sources = liveTrace?.sources || [];
+  return sources.length === 1 ? sources[0].file : null;
+};
+
+// The selected executions' recorded sites for `fileName`, with spans
+// CONVERTED to UTF-16 (`byteToUtf16`) and name-located (`hintOffset`) —
+// `[{ b, offset, nameStart, nameEnd }]` for every site (hover searches all
+// of them; the inline dedup happens in liveHintsFor).
+const liveSitesFor = (fileName, source) => {
+  const conv = byteToUtf16(source);
+  const invs = (liveTrace.invocations || []).filter((i) => !i.ghost);
+  const sites = [];
+  for (const entry of new Set(invs.map((i) => i.entry))) {
+    const group = invs.filter((i) => i.entry === entry);
+    const count = Math.max(1, ...group.map((i) => i.count || 1));
+    const sel = (selectedExec.get(entry) || 0) % count;
+    const inv = group.find((i) => i.index === sel) || group[0];
+    for (const b of inv.bindings || []) {
+      if (b.file !== fileName) continue;
+      const start = conv ? conv[b.start] ?? source.length : b.start;
+      const end = conv ? conv[b.end] ?? source.length : b.end;
+      const offset = hintOffset(source, { ...b, start, end });
+      sites.push({ b, offset, nameStart: offset - b.name.length, nameEnd: offset });
+    }
+  }
+  return sites;
+};
+
+// Compute the overlay hints for the CURRENT buffer from the selected
+// execution of each entry — the LSP's policy, ported: previews inline, one
+// hint per (line, name), a binder site beats a reference, earliest read wins.
+const liveHintsFor = (sites, source) => {
+  const chosen = new Map(); // `${line}\x00${name}` → { b, offset, … }
+  for (const site of sites) {
+    const key = `${lineOf(source, site.offset)}\x00${site.b.name}`;
+    const cur = chosen.get(key);
+    const wins =
+      !cur ||
+      (site.b.site === "binder" && cur.b.site === "ref") ||
+      (!(site.b.site === "ref" && cur.b.site === "binder") && site.offset < cur.offset);
+    if (wins) chosen.set(key, site);
+  }
+  return [...chosen.values()]
+    .map(({ b, offset, nameStart, nameEnd }) => {
+      const preview = shortNumbers(b.preview ?? b.value);
+      return {
+        offset,
+        label: b.count > 1 ? `= ${preview} (×${b.count})` : `= ${preview}`,
+        name: b.name,
+        value: b.value,
+        count: b.count || 1,
+        nameStart,
+        nameEnd,
+      };
+    })
+    .sort((a, z) => a.offset - z.offset);
+};
+
+// Inline labels shorten long floats (0.15000000782310963 → 0.15) — full-
+// precision noise makes dense lines unreadable; hover keeps the exact value.
+// Quoted segments pass through untouched: a STRING value containing
+// number-like text ("lat: 37.7749295") must never be rewritten.
+const shortNumbers = (text) =>
+  String(text ?? "")
+    .split(/("(?:[^"\\]|\\.)*")/)
+    .map((part, i) =>
+      i % 2
+        ? part
+        : part.replace(/-?\d+\.\d{6,}(?:e-?\d+)?/g, (m) => String(Number(Number(m).toPrecision(5))))
+    )
+    .join("");
+
+const sha256Hex = async (text) => {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
+};
+
+// Rebuild the overlay for the current buffer: async (the hash check), token-
+// guarded so a stale completion can't clobber a newer state.
+const refreshLive = async (view) => {
+  const token = ++liveRefreshToken;
+  const clear = () => view.dispatch({ effects: setLiveOverlay.of([]) });
+  if (!liveTrace || !liveTrace.paused) {
+    clear();
+    return;
+  }
+  const source = view.state.doc.toString();
+  const fileName = liveFileName(source);
+  const traceHash = (liveTrace.sources || []).find((s) => s.file === fileName)?.hash;
+  if (!fileName || !traceHash) {
+    clear();
+    return;
+  }
+  const hash = await sha256Hex(source);
+  if (token !== liveRefreshToken) return; // superseded
+  if (hash !== traceHash || source !== view.state.doc.toString()) {
+    clear();
+    return;
+  }
+  const sites = liveSitesFor(fileName, source);
+  liveSites = sites;
+  view.dispatch({ effects: setLiveOverlay.of(liveHintsFor(sites, source)) });
+};
+
+// Host seams -------------------------------------------------------------------
+
+// A new trace arrived (or the game resumed: pass an unpaused doc/null).
+// Resets the execution selection — the frame changed under it.
+export const setLiveTrace = (view, trace) => {
+  liveTrace = trace && trace.paused ? trace : null;
+  selectedExec = new Map();
+  refreshLive(view);
+};
+
+// The current overlay's hints — the e2e position-invariant seam (every
+// hint's [nameStart, nameEnd) must slice to exactly its name in the doc,
+// which fails loudly if byte offsets ever leak through unconverted).
+export const currentLiveHints = () => liveHints;
+
+// The frame's executions in order, for the host's picker UI:
+// `[{ entry, index, count, provenance, selected }]`. Empty while playing.
+export const liveExecutions = () => {
+  if (!liveTrace) return [];
+  return (liveTrace.invocations || [])
+    .filter((i) => !i.ghost)
+    .map((i) => ({
+      entry: i.entry,
+      index: i.index || 0,
+      count: i.count || 1,
+      provenance: i.provenance || "",
+      selected: ((selectedExec.get(i.entry) || 0) % (i.count || 1)) === (i.index || 0),
+    }));
+};
+
+// Select which execution of `entry` overlays (the picker's click).
+export const selectExecution = (view, entry, index) => {
+  selectedExec.set(entry, index);
+  refreshLive(view);
+};
+
+// Re-verify the overlay after a context change the doc didn't see (the IDE's
+// file switch re-uses setDoc, whose doc change already clears; this is for
+// hosts that need an explicit nudge, e.g. after a reload result).
+export const refreshLiveValues = (view) => refreshLive(view);
+
+// The whole host-side wiring, shared by the sandbox and the IDE: listen for
+// the player's `functor-inspector-trace` relay (guarded to OUR iframe),
+// hand traces to the overlay, and keep the status bar's executions picker in
+// sync (rows select which execution's values render).
+export const wireLiveTrace = (view, statusBar, playerIframe, ready) => {
+  const renderExecutions = () => {
+    statusBar.setExecutions(
+      liveExecutions().map((e) => ({
+        label: `${e.entry} ${e.index + 1}/${e.count} — ${e.provenance}`,
+        selected: e.selected,
+        onPick: () => {
+          selectExecution(view, e.entry, e.index);
+          renderExecutions();
+        },
+      }))
+    );
+  };
+  window.addEventListener("message", (event) => {
+    const data = event.data;
+    if (!data || data.type !== "functor-inspector-trace") return;
+    if (event.source !== playerIframe.contentWindow) return;
+    setLiveTrace(view, data.trace);
+    renderExecutions();
+  });
+  // A trace can beat the async extension install (the runtime pauses before
+  // setupLangIntel resolves): the overlay effect would land on an
+  // unconfigured field and the generation never re-fires for an unchanged
+  // doc. Replay once the extensions are in.
+  if (ready) ready.then(() => refreshLive(view));
+};
+
 // --- Theme (editor chrome) ----------------------------------------------------
 // Recolor lint's wavy underline to the calm theme's red (--red: #f2637f)
 // instead of its default bright #f11. Mirrors @codemirror/lint's own helper.
@@ -392,6 +732,17 @@ const intelTheme = EditorView.theme({
     color: "#6c6685",
     fontSize: "0.85em",
     padding: "0 1px",
+  },
+  // Live values (the paused inspector): cyan-tinted so runtime data reads
+  // apart from the static type inlays.
+  ".cm-live-value": {
+    color: "#41d8e6",
+    fontSize: "0.85em",
+    padding: "0 2px",
+    opacity: "0.85",
+  },
+  ".cm-hover-live": {
+    color: "#41d8e6",
   },
   // Codelenses: a dimmed signature line above the def.
   ".cm-lens": {
@@ -469,6 +820,7 @@ export const setupLangIntel = async () => {
     linter(toDiagnostics, { delay: 300, needsRefresh: contextChanged }),
     hoverTypes,
     decorationField,
+    liveField,
     initialRefresh,
     // Register the completion source on the language's data facet — basicSetup's
     // autocompletion() picks it up via languageDataAt (no second popup).

--- a/site/src/sandbox.js
+++ b/site/src/sandbox.js
@@ -10,7 +10,15 @@ import { StateEffect } from "@codemirror/state";
 import { indentWithTab } from "@codemirror/commands";
 import { startCompletion, acceptCompletion, closeCompletion } from "@codemirror/autocomplete";
 import { functorLangLanguage, synthwaveEditorTheme } from "./functor-lang.js";
-import { setupLangIntel, analyzeCached, completeAt, resetIntel, onDiagnostics } from "./lang-intel.js";
+import {
+  setupLangIntel,
+  analyzeCached,
+  completeAt,
+  resetIntel,
+  onDiagnostics,
+  wireLiveTrace,
+  currentLiveHints,
+} from "./lang-intel.js";
 import { PlayerBridge } from "./player-bridge.js";
 import { createStatusBar } from "./status-bar.js";
 
@@ -67,6 +75,7 @@ window.addEventListener("message", (event) => {
   statusBar.appendOutput(data.level, data.message, data.frame ?? null);
 });
 
+
 // Set while loadExample replaces the buffer programmatically: that content is
 // exactly what the fresh iframe is about to fetch, so pushing it back would
 // be a redundant reload (and would mislabel a fresh load as a hot reload).
@@ -94,6 +103,10 @@ const langReady = setupLangIntel().then((extensions) => {
   if (extensions.length) view.dispatch({ effects: StateEffect.appendConfig.of(extensions) });
   return extensions.length > 0;
 });
+
+// The paused-inspector trace (live values in the editor + the executions
+// picker), relayed by the player on pause / paused-frame change.
+wireLiveTrace(view, statusBar, frame, langReady);
 
 // Each lint pass refreshes the Problems panel; clicking a problem jumps the
 // editor to it. Positions re-clamp at click time (the doc may have moved on).
@@ -123,6 +136,7 @@ window.__lang = {
   ready: langReady,
   analyze: (source) => analyzeCached(source),
   complete: (source, offset) => completeAt(source, offset),
+  liveHints: () => currentLiveHints(),
 };
 
 const setDoc = (source) => {
@@ -231,6 +245,7 @@ window.__sandbox = {
   setSource(source) {
     view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: source } });
   },
+  source: () => view.state.doc.toString(),
   status: () => ({
     state: statusPill.dataset.state,
     text: statusPill.textContent,

--- a/site/src/status-bar.js
+++ b/site/src/status-bar.js
@@ -24,6 +24,8 @@ export const createStatusBar = ({ host }) => {
   problemsList.className = "statusbar-list problems-list";
   const outputList = document.createElement("div");
   outputList.className = "statusbar-list output-list";
+  const executionsList = document.createElement("div");
+  executionsList.className = "statusbar-list executions-list";
 
   const strip = document.createElement("div");
   strip.className = "statusbar-strip";
@@ -36,6 +38,7 @@ export const createStatusBar = ({ host }) => {
     panel.hidden = open === null;
     problemsList.style.display = open === "problems" ? "" : "none";
     outputList.style.display = open === "output" ? "" : "none";
+    executionsList.style.display = open === "executions" ? "" : "none";
     for (const [tabName, button] of Object.entries(tabs)) {
       button.classList.toggle("active", tabName === open);
     }
@@ -58,9 +61,11 @@ export const createStatusBar = ({ host }) => {
 
   const problemsTab = makeTab("problems", "✓ 0 problems");
   makeTab("output", "output");
+  const executionsTab = makeTab("executions", "executions");
 
   panel.appendChild(problemsList);
   panel.appendChild(outputList);
+  panel.appendChild(executionsList);
   host.appendChild(panel);
   host.appendChild(strip);
 
@@ -155,5 +160,29 @@ export const createStatusBar = ({ host }) => {
     }
   };
 
-  return { setProblems, appendOutput };
+  // The paused frame's entry-point executions (the inspector's picker):
+  // `items` is `[{ label, selected, onPick }]` in frame order. Empty while
+  // the game plays.
+  const setExecutions = (items) => {
+    executionsTab.textContent = items.length ? `⏸ ${items.length} executions` : "executions";
+    executionsList.textContent = "";
+    if (items.length === 0) {
+      const empty = document.createElement("div");
+      empty.className = "statusbar-empty";
+      empty.textContent = "Pause the game to inspect the frame's executions.";
+      executionsList.appendChild(empty);
+      return;
+    }
+    for (const item of items) {
+      const row = document.createElement("button");
+      row.type = "button";
+      row.className = "exec-row" + (item.selected ? " selected" : "");
+      row.textContent = item.label;
+      if (item.onPick) row.addEventListener("click", item.onPick);
+      executionsList.appendChild(row);
+    }
+  };
+  setExecutions([]);
+
+  return { setProblems, appendOutput, setExecutions };
 };

--- a/site/styles.css
+++ b/site/styles.css
@@ -1004,3 +1004,26 @@ a:hover {
 .output-line.output-info {
   color: var(--text);
 }
+
+.exec-row {
+  appearance: none;
+  border: none;
+  background: none;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 2px 4px;
+  cursor: pointer;
+  border-radius: 3px;
+}
+
+.exec-row:hover {
+  background: var(--bg-raised);
+}
+
+.exec-row.selected {
+  color: var(--cyan);
+}

--- a/site/styles.css
+++ b/site/styles.css
@@ -926,6 +926,13 @@ a:hover {
   display: flex;
 }
 
+/* The author display:flex above would override the `hidden` attribute's UA
+   display:none — without this, the closed panel still eats 180px and the
+   editor/preview never get the full height back. */
+.statusbar-panel[hidden] {
+  display: none;
+}
+
 .statusbar-list {
   flex: 1;
   overflow-y: auto;


### PR DESCRIPTION
## Why

Part 3 of the inspector v2 arc (#373 ← #374 ← this). The paused trace was VS Code-only; the web IDE — the surface you actually demo in — showed nothing. This is the LightTable moment: pause the game, read your program's actual values in place.

## What

- **`site/player.html`** polls the trace generation once per frame and relays `functor-inspector-trace` to **same-origin parents** (the security posture of the console forwarder).
- **`lang-intel.js` live overlay**: on pause, every recorded site — binders *and* variable reads — renders a cyan inline `= preview` (long floats shortened for readability, quoted strings untouched; the **exact** value on hover, which answers on every site including reads the per-line dedup suppressed). Gated on a `crypto.subtle` sha256 match; **any edit clears the overlay instantly**, and the IDE re-gates per file on switch.
- **Executions tab** in the status bar: the frame's runs in order (`tick 1/1 — tick dt=0.0167`, `update k/N — subscription: …`, `draw 1/1 — draw`), click to choose which execution's values overlay.

### Review-driven hardening (cross-engine /xreview)
- **Byte→UTF-16 conversion on ingestion** — trace spans are UTF-8 byte offsets; hero.fun's em-dash comments visibly shifted every hint before. An e2e invariant now asserts each hint slices to exactly its name.
- A trace arriving before the async extension install **replays once ready** (the generation never re-fires for an unchanged doc).
- `shortNumbers` skips quoted segments (a string value `"lat: 37.7749295"` must never be rewritten).
- One shared `wireLiveTrace` seam replaces byte-identical wiring in both hosts.

![live values](https://gist.github.com/tommy-xr/d854579e69c31c23fdc1a30ea9d13dba/raw/live-values.png)

## Testing

`npm run test:site` → ALL CHECKS PASSED — the new block drives the **real** pause path: scrubber pause → inlays appear with `= value` previews → position invariant (byte→UTF-16) → executions tab lists tick + the synthesized draw → **resume clears** → pause again → **edit clears** (hash gate). `npm run test:ide-page` → RESULT: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)