### PR TITLE
feat(runtime): typed external registry for the Functor <-> Rust bridge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,10 @@ externals that make `Scene.*` / `Camera.*` / `Frame.*` / `Light.*` / `Physics.*`
 `Sub.*` resolve to real protocol values. Both producers implement the shared
 `functor_runtime_common::protocol::GameProducer` trait the runtime loop consumes; the versioned
 logic↔runtime boundary is enumerated in `functor_runtime_common::protocol`. When you add or change
-a prelude surface, the real implementation lives in `functor_lang_prelude.rs` and both producers must wire it.
+a prelude surface, the real implementation lives in `functor_lang_prelude.rs` and both producers must wire it —
+prefer REGISTERING it in the typed external registry (`host_registry.rs` + `register_*` in
+`functor_lang_prelude.rs`: one typed closure, arity/usage/conversion errors derived) over adding a
+legacy `match path` arm; a drift test pins `.funi` signatures ≡ (registry ∪ legacy `PATHS`).
 
 **Hot-reload and state persistence.** Functor Lang hot-reload is built into the producer: it polls the
 project files' mtime each frame and on change reparses → rechecks → builds a new `Session` with

--- a/docs/functor-lang.md
+++ b/docs/functor-lang.md
@@ -324,6 +324,24 @@ snapshots — no GPU, fully agent-verifiable.
       velocities stored in the model survive hot-reload time travel.
       Component accessors and vector math (`Vec3.add`/`scale`/`length`, and
       Vec2/Vec4) are deliberately deferred until an API returns a Vec3.
+- [x] **Typed external registry** (2026-07-16; prelude-infra track, PR 1).
+      The generalized Functor Lang ↔ Rust bridge: hosts REGISTER externals as
+      typed closures (`host_registry.rs`) instead of hand-writing `match
+      path` arms — arity/usage errors derive from the registered signature,
+      argument conversion (and each branded type's teaching error) lives
+      once on the type via `FromArg`, and returns convert via
+      `IntoHostResult` (incl. `Result<_, String>` domain validation, span
+      attached). Dispatch consults the registry FIRST and falls back to the
+      legacy match, so externals migrate arm-by-arm with no flag day; the
+      drift test now asserts `.funi` signatures ≡ (registry ∪ legacy PATHS),
+      disjoint. First migrated module: the ten branded-value constructors
+      (Angle/Time/Color/Vec3/Physics.tag/RenderTarget.named/Fog). One
+      deliberate behavior unification: a wrong-TYPE argument now always gets
+      the precise conversion error ("expected a string, got a number") where
+      string-pattern arms used to fall through to the usage line; arity
+      mistakes still teach usage. Golden-verified behavior-neutral
+      otherwise. This is the seam future third-party/native extension
+      modules plug into (a `.funi` + a set of registered host functions).
 - [x] **B7. Hindley–Milner inference** (done 2026-07-04; decided 2026-07-02; **after effects
       land** — B6 + the `effect[...]` header checking, so type inference and
       effect rows are designed against each other, not retrofitted). Upgrade

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -930,10 +930,6 @@ const PATHS: &[&str] = &[
     "Anim.mask",
     "Anim.rotate",
     "Texture.file",
-    "Angle.degrees",
-    "Angle.radians",
-    "Color.rgb",
-    "Vec3.make",
     "Camera.lookAt",
     "Camera.firstPerson",
     "Light.ambient",
@@ -945,12 +941,9 @@ const PATHS: &[&str] = &[
     "Frame.createLit",
     "Frame.withRenderTarget",
     "Frame.withFog",
-    "Fog.linear",
-    "Fog.exp",
     "Frame.withSkybox",
     "Frame.withClearColor",
     "Skybox.files",
-    "RenderTarget.named",
     "RenderTarget.sized",
     "Scene.screen",
     "Ui.text",
@@ -958,16 +951,9 @@ const PATHS: &[&str] = &[
     "Ui.column",
     "Ui.row",
     "Ui.panel",
-    "Ui.topLeft",
-    "Ui.topRight",
-    "Ui.bottomLeft",
-    "Ui.bottomRight",
-    "Ui.center",
     "Ui.button",
     "Ui.slider",
     "Ui.textInput",
-    "Time.seconds",
-    "Time.millis",
     "Sub.none",
     "Sub.every",
     "Sub.batch",
@@ -976,7 +962,6 @@ const PATHS: &[&str] = &[
     "Effect.now",
     "Effect.random",
     "Effect.batch",
-    "Physics.tag",
     "Physics.box",
     "Physics.sphere",
     "Physics.capsule",
@@ -1013,9 +998,122 @@ const PATHS: &[&str] = &[
     "AudioScene.empty",
 ];
 
+/// The typed external registry (see [`crate::host_registry`]) — consulted
+/// BEFORE the legacy `match path` below, so externals migrate arm-by-arm.
+/// New externals should be registered here, not added as match arms; the
+/// drift test asserts `.funi` signatures ≡ (registry ∪ legacy `PATHS`).
+pub(crate) fn registry() -> &'static crate::host_registry::Registry {
+    static REGISTRY: std::sync::OnceLock<crate::host_registry::Registry> =
+        std::sync::OnceLock::new();
+    REGISTRY.get_or_init(|| {
+        let mut reg = crate::host_registry::Registry::default();
+        register_branded_constructors(&mut reg);
+        register_ui_anchors(&mut reg);
+        reg
+    })
+}
+
+/// The branded-value constructors — the first module migrated off the legacy
+/// match (the registry proof). Each is one registration: arity/usage errors
+/// and argument conversion (with the per-type teaching errors) are derived.
+fn register_branded_constructors(reg: &mut crate::host_registry::Registry) {
+    reg.fn1("Angle.degrees", "Angle.degrees(n)", |n: f64| {
+        FunctorLangAngle(Angle::from_degrees(n as f32))
+    });
+    reg.fn1("Angle.radians", "Angle.radians(n)", |n: f64| {
+        FunctorLangAngle(Angle::from_radians(n as f32))
+    });
+    reg.fn1("Time.seconds", "Time.seconds(n)", FunctorLangDuration);
+    reg.fn1("Time.millis", "Time.millis(n)", |n: f64| {
+        FunctorLangDuration(n / 1000.0)
+    });
+    reg.fn3("Color.rgb", "Color.rgb(r, g, b)", |r: f64, g: f64, b: f64| {
+        FunctorLangColor((r as f32, g as f32, b as f32))
+    });
+    reg.fn3("Vec3.make", "Vec3.make(x, y, z)", |x: f64, y: f64, z: f64| {
+        FunctorLangVec3((x as f32, y as f32, z as f32))
+    });
+    // Identity at runtime — the tag brand is check-time only (physics.funi).
+    // Rc<str> in and out: allocation-neutral in a per-frame physics hook.
+    reg.fn1("Physics.tag", "Physics.tag(\"name\")", |name: std::rc::Rc<str>| {
+        Value::String(name)
+    });
+    const RT_NAMED: &str = "RenderTarget.named(\"id\") — a non-empty name; 512x512 unless \
+piped through RenderTarget.sized";
+    reg.fn1("RenderTarget.named", RT_NAMED, |name: String| {
+        if name.is_empty() {
+            Err(format!("usage: {RT_NAMED}"))
+        } else {
+            Ok(FunctorLangRenderTarget(RenderTargetDescriptor::new(name)))
+        }
+    });
+    reg.fn3(
+        "Fog.linear",
+        "Fog.linear(near, far, color)",
+        |near: f64, far: f64, color: FunctorLangColor| {
+            if near < 0.0 {
+                return Err(format!("Fog.linear near must not be negative, got {near}"));
+            }
+            if far <= 0.0 {
+                return Err(format!("Fog.linear far must be positive, got {far}"));
+            }
+            if far <= near {
+                return Err(format!(
+                    "Fog.linear: far ({far}) must be greater than near ({near})"
+                ));
+            }
+            let (r, g, b) = color.0;
+            Ok(FunctorLangFog(Fog::linear(near as f32, far as f32, r, g, b)))
+        },
+    );
+    reg.fn2(
+        "Fog.exp",
+        "Fog.exp(density, color)",
+        |density: f64, color: FunctorLangColor| {
+            if density <= 0.0 {
+                return Err(format!("Fog.exp density must be positive, got {density}"));
+            }
+            let (r, g, b) = color.0;
+            Ok(FunctorLangFog(Fog::exp(density as f32, r, g, b)))
+        },
+    );
+}
+
+crate::host_returnable!(
+    FunctorLangAngle,
+    FunctorLangDuration,
+    FunctorLangColor,
+    FunctorLangVec3,
+    FunctorLangRenderTarget,
+    FunctorLangFog,
+    FunctorLangUiAnchor,
+);
+
+fn register_ui_anchors(reg: &mut crate::host_registry::Registry) {
+    reg.fn0("Ui.topLeft", "Ui.topLeft()", || FunctorLangUiAnchor(ui::Anchor::TopLeft));
+    reg.fn0("Ui.topRight", "Ui.topRight()", || {
+        FunctorLangUiAnchor(ui::Anchor::TopRight)
+    });
+    reg.fn0("Ui.bottomLeft", "Ui.bottomLeft()", || {
+        FunctorLangUiAnchor(ui::Anchor::BottomLeft)
+    });
+    reg.fn0("Ui.bottomRight", "Ui.bottomRight()", || {
+        FunctorLangUiAnchor(ui::Anchor::BottomRight)
+    });
+    reg.fn0("Ui.center", "Ui.center()", || FunctorLangUiAnchor(ui::Anchor::Center));
+}
+
+/// Colors convert through the registry with the same teaching error the
+/// legacy `color_of` extractor gives — written once, on the type.
+impl crate::host_registry::FromArg for FunctorLangColor {
+    fn from_arg(value: &Value, path: &str, span: Span) -> Result<Self, RunError> {
+        color_of(value, path, span).map(FunctorLangColor)
+    }
+}
+
 impl Host for FunctorHost {
     fn provides(&self, path: &str) -> bool {
-        PATHS.contains(&path)
+        registry().provides(path) || PATHS.contains(&path)
     }
 
     fn call(&mut self, path: &str, args: Vec<Value>, span: Span) -> Result<Value, RunError> {
@@ -1026,6 +1124,11 @@ impl Host for FunctorHost {
                 span,
             })
         };
+        // The typed external registry dispatches first; the match below is
+        // the not-yet-migrated remainder (see crate::host_registry).
+        if let Some(result) = registry().call(path, &args, span) {
+            return result;
+        }
         match path {
             // Constructors take no arguments — reject any, so a guessed
             // `Scene.cube(size)` fails loud instead of silently ignoring it.
@@ -1380,34 +1483,6 @@ the game dir",
                 }
                 _ => usage("Scene.translate(v, scene)"),
             },
-            // An opaque 3-vector. Every position/direction parameter
-            // requires one — never three bare floats.
-            "Vec3.make" => match args.as_slice() {
-                [x, y, z] => Ok(host(FunctorLangVec3((
-                    num(x, span)? as f32,
-                    num(y, span)? as f32,
-                    num(z, span)? as f32,
-                )))),
-                _ => usage("Vec3.make(x, y, z)"),
-            },
-            // An opaque RGB color (channels normally 0..1; emissive/HDR uses
-            // may exceed 1). Every color-taking parameter requires one.
-            "Color.rgb" => match args.as_slice() {
-                [r, g, b] => Ok(host(FunctorLangColor((
-                    num(r, span)? as f32,
-                    num(g, span)? as f32,
-                    num(b, span)? as f32,
-                )))),
-                _ => usage("Color.rgb(r, g, b)"),
-            },
-            "Angle.degrees" => match args.as_slice() {
-                [n] => Ok(host(FunctorLangAngle(Angle::from_degrees(num(n, span)? as f32)))),
-                _ => usage("Angle.degrees(n)"),
-            },
-            "Angle.radians" => match args.as_slice() {
-                [n] => Ok(host(FunctorLangAngle(Angle::from_radians(num(n, span)? as f32)))),
-                _ => usage("Angle.radians(n)"),
-            },
             "Scene.rotateX" | "Scene.rotateY" | "Scene.rotateZ" => match args.as_slice() {
                 [angle, scene] => {
                     let angle: cgmath::Rad<f32> = angle_of(angle, path, span)?.into();
@@ -1586,10 +1661,6 @@ the game dir",
             // model/journal, and structurally comparable with the tags inside
             // rayHit/collisionEvent records. The empty tag is the zeroed
             // rayHit-miss / "no body" sentinel, so no non-empty validation.
-            "Physics.tag" => match args.as_slice() {
-                [Value::String(_)] => Ok(args[0].clone()),
-                _ => usage("Physics.tag(\"name\")"),
-            },
             "Physics.box" => match args.as_slice() {
                 [w, h, d] => Ok(host(FunctorLangShape(physics::Shape::Cuboid {
                     extents: [
@@ -1959,15 +2030,6 @@ the Net.HttpResponse, got {}",
                 }
                 _ => usage("Physics.transformed(tag, scene)"),
             },
-            "RenderTarget.named" => match args.as_slice() {
-                [Value::String(name)] if !name.is_empty() => Ok(host(FunctorLangRenderTarget(
-                    RenderTargetDescriptor::new(name.to_string()),
-                ))),
-                _ => usage(
-                    "RenderTarget.named(\"id\") — a non-empty name; 512x512 unless \
-piped through RenderTarget.sized",
-                ),
-            },
             // Target LAST (subject-last), so it pipes:
             // `RenderTarget.named("x") |> RenderTarget.sized(256.0, 256.0)`.
             "RenderTarget.sized" => match args.as_slice() {
@@ -2002,32 +2064,6 @@ frame's main pass",
                     ))))
                 }
                 _ => usage("Frame.withRenderTarget(target, targetFrame, frame)"),
-            },
-            "Fog.linear" => match args.as_slice() {
-                [near, far, color] => {
-                    let near = non_negative_num(near, span, "Fog.linear near")?;
-                    let far = positive_num(far, span, "Fog.linear far")?;
-                    if far <= near {
-                        return err(format!(
-                            "Fog.linear: far ({far}) must be greater than near ({near})"
-                        ));
-                    }
-                    let (r, g, b) = color_of(color, path, span)?;
-                    Ok(host(FunctorLangFog(Fog::linear(near as f32, far as f32, r, g, b))))
-                }
-                _ => usage("Fog.linear(near, far, color)"),
-            },
-            "Fog.exp" => match args.as_slice() {
-                [density, color] => {
-                    let (r, g, b) = color_of(color, path, span)?;
-                    Ok(host(FunctorLangFog(Fog::exp(
-                        positive_num(density, span, "Fog.exp density")? as f32,
-                        r,
-                        g,
-                        b,
-                    ))))
-                }
-                _ => usage("Fog.exp(density, color)"),
             },
             // Frame LAST (subject-last), so it pipes: `Frame.createLit(…) |> Frame.withFog(fog)`.
             "Frame.withFog" => match args.as_slice() {
@@ -2178,26 +2214,6 @@ paths (+X, -X, +Y, -Y, +Z, -Z)",
                 }
                 _ => usage("Ui.panel(anchor, view)"),
             },
-            "Ui.topLeft" => match args.as_slice() {
-                [] => Ok(host(FunctorLangUiAnchor(ui::Anchor::TopLeft))),
-                _ => usage("Ui.topLeft()"),
-            },
-            "Ui.topRight" => match args.as_slice() {
-                [] => Ok(host(FunctorLangUiAnchor(ui::Anchor::TopRight))),
-                _ => usage("Ui.topRight()"),
-            },
-            "Ui.bottomLeft" => match args.as_slice() {
-                [] => Ok(host(FunctorLangUiAnchor(ui::Anchor::BottomLeft))),
-                _ => usage("Ui.bottomLeft()"),
-            },
-            "Ui.bottomRight" => match args.as_slice() {
-                [] => Ok(host(FunctorLangUiAnchor(ui::Anchor::BottomRight))),
-                _ => usage("Ui.bottomRight()"),
-            },
-            "Ui.center" => match args.as_slice() {
-                [] => Ok(host(FunctorLangUiAnchor(ui::Anchor::Center))),
-                _ => usage("Ui.center()"),
-            },
             "Ui.row" => match args.as_slice() {
                 [Value::List(items)] => {
                     let mut views = Vec::with_capacity(items.len());
@@ -2276,14 +2292,6 @@ the new text, got {}",
                     other.kind_name()
                 )),
                 _ => usage("Ui.textInput(value, tagger) — tagger: (newText) => msg"),
-            },
-            "Time.seconds" => match args.as_slice() {
-                [n] => Ok(host(FunctorLangDuration(num(n, span)?))),
-                _ => usage("Time.seconds(n)"),
-            },
-            "Time.millis" => match args.as_slice() {
-                [n] => Ok(host(FunctorLangDuration(num(n, span)? / 1000.0))),
-                _ => usage("Time.millis(n)"),
             },
             "Sub.none" => match args.as_slice() {
                 [] => Ok(host(FunctorLangSub(SubTree::None))),
@@ -3646,7 +3654,16 @@ mod tests {
             }
         }
 
-        let paths: BTreeSet<String> = PATHS.iter().map(|p| p.to_string()).collect();
+        let legacy: BTreeSet<String> = PATHS.iter().map(|p| p.to_string()).collect();
+        let registered: BTreeSet<String> =
+            registry().paths().map(|p| p.to_string()).collect();
+        let overlap: Vec<&String> = legacy.intersection(&registered).collect();
+        assert!(
+            overlap.is_empty(),
+            "externals both registered and in the legacy PATHS (remove the \
+legacy entry): {overlap:?}"
+        );
+        let paths: BTreeSet<String> = legacy.union(&registered).cloned().collect();
 
         let phantom: Vec<&String> = signatures.difference(&paths).collect();
         assert!(
@@ -3661,6 +3678,33 @@ mod tests {
             "host externals in PATHS with no `.funi` signature — an interface-only \
 module is CLOSED, so games referencing these break at load: {missing:?}"
         );
+
+        // Registered arities must match the `.funi` signatures' parameter
+        // counts — the registry's usage text and the interface cannot teach
+        // different shapes. (A `.funi` function type parses as the reserved
+        // name `=>` with params + return as args.)
+        let mut funi_arity: std::collections::HashMap<String, usize> =
+            std::collections::HashMap::new();
+        for (module, src) in functor_prelude::modules() {
+            let program = functor_lang::parse_interface(&src).expect("parsed above");
+            for item in &program.items {
+                if let functor_lang::ast::Item::Sig(sig) = item {
+                    let arity = if sig.ty.name == "=>" {
+                        sig.ty.args.len() - 1
+                    } else {
+                        0
+                    };
+                    funi_arity.insert(format!("{module}.{}", sig.name), arity);
+                }
+            }
+        }
+        for (path, arity) in registry().arities() {
+            assert_eq!(
+                funi_arity.get(path),
+                Some(&arity),
+                "registered arity for `{path}` must match its .funi signature"
+            );
+        }
     }
 
     // The C1 verify criterion (docs/functor-lang.md): an .fun snippet emits exactly
@@ -4339,8 +4383,20 @@ it once with RenderTarget.named(\"…\") and pass that value at both sites"
             fail("let main = () => RenderTarget.named(\"x\") |> RenderTarget.sized(-1.0, 4.0)"),
             "RenderTarget.sized width must be positive, got -1"
         );
+        // A wrong-TYPE argument gets the precise conversion error (the
+        // registry rule — matching how number-taking arms always behaved);
+        // arity mistakes and empty names still teach the full usage line.
         assert_eq!(
             fail("let main = () => RenderTarget.named(3.0)"),
+            "expected a string, got a number"
+        );
+        assert_eq!(
+            fail("let main = () => RenderTarget.named(\"a\", \"b\")"),
+            "usage: RenderTarget.named(\"id\") — a non-empty name; 512x512 unless \
+piped through RenderTarget.sized"
+        );
+        assert_eq!(
+            fail("let main = () => RenderTarget.named(\"\")"),
             "usage: RenderTarget.named(\"id\") — a non-empty name; 512x512 unless \
 piped through RenderTarget.sized"
         );

--- a/runtime/functor-runtime-common/src/host_registry.rs
+++ b/runtime/functor-runtime-common/src/host_registry.rs
@@ -1,0 +1,399 @@
+//! The typed external registry — the generalized Functor Lang ↔ Rust bridge.
+//!
+//! The prelude's contract has two halves: the `.funi` interface (types, in
+//! `functor-prelude/prelude/*.funi`) and the host implementation. Historically
+//! the implementation half was one hand-written `match path` arm per external
+//! in [`crate::functor_lang_prelude`], each destructuring its `&[Value]` slice,
+//! calling extractors, and hand-writing a usage string — three places to keep
+//! in sync per API (`.funi`, `PATHS`, the arm), guarded only by a drift test.
+//!
+//! This module replaces that with REGISTRATION: the host declares each
+//! external once, as a typed Rust closure —
+//!
+//! ```ignore
+//! reg.fn3("Color.rgb", "Color.rgb(r, g, b)", |r: f64, g: f64, b: f64| {
+//!     FunctorLangColor((r as f32, g as f32, b as f32))
+//! });
+//! ```
+//!
+//! and the registry derives everything the arm used to hand-roll:
+//!
+//! - **Arity errors** become `usage: <sig>` from the registered signature, so
+//!   the usage text cannot drift from the actual parameter count.
+//! - **Argument conversion** comes from [`FromArg`] — implemented once per
+//!   Rust-side type, which is where the per-type TEACHING ERRORS live
+//!   ("expected a Color, got a bare number — wrap the channels: …"), instead
+//!   of being re-plumbed at every consuming arm.
+//! - **Returns** convert through [`IntoHostResult`] (a [`HostData`] newtype
+//!   wraps itself via [`host_returnable!`]), and a closure may return
+//!   `Result<_, String>` for domain-validation errors — the registry
+//!   attaches the call span.
+//!
+//! [`FunctorHost::call`] consults the registry FIRST and falls back to the
+//! legacy match, so externals migrate arm-by-arm with no flag day. The drift
+//! test asserts `.funi` signatures ≡ (registry keys ∪ legacy `PATHS`), keys
+//! disjoint.
+//!
+//! [`FunctorHost::call`]: crate::functor_lang_prelude::FunctorHost
+//! [`HostData`]: functor_lang::HostData
+
+use std::collections::HashMap;
+
+use functor_lang::value::Value;
+use functor_lang::{RunError, Span};
+
+/// Convert one call argument into a typed Rust value. Implementations own the
+/// error text for a mismatched argument — including the branded types'
+/// teaching errors — so the message is written once per TYPE, not once per
+/// consuming external. `path` is the external being called (`"Fog.linear"`),
+/// for `{path}: expected …`-shaped messages.
+pub trait FromArg: Sized {
+    fn from_arg(value: &Value, path: &str, span: Span) -> Result<Self, RunError>;
+}
+
+/// A float at the engine boundary: finite (as f32) or a spanned error — the
+/// same contract as the legacy `num()` extractor, byte-identical messages.
+impl FromArg for f64 {
+    fn from_arg(value: &Value, _path: &str, span: Span) -> Result<Self, RunError> {
+        match value {
+            Value::Number(n) if (*n as f32).is_finite() => Ok(*n),
+            Value::Number(n) => Err(RunError {
+                message: format!("expected a finite number, got {n}"),
+                span,
+            }),
+            other => Err(RunError {
+                message: format!("expected a number, got {}", other.kind_name()),
+                span,
+            }),
+        }
+    }
+}
+
+impl FromArg for String {
+    fn from_arg(value: &Value, _path: &str, span: Span) -> Result<Self, RunError> {
+        match value {
+            Value::String(s) => Ok(s.to_string()),
+            other => Err(RunError {
+                message: format!("expected a string, got {}", other.kind_name()),
+                span,
+            }),
+        }
+    }
+}
+
+/// An `Rc<str>` argument — allocation-neutral for identity-shaped externals
+/// (`Physics.tag`) that hand the string straight back.
+impl FromArg for std::rc::Rc<str> {
+    fn from_arg(value: &Value, _path: &str, span: Span) -> Result<Self, RunError> {
+        match value {
+            Value::String(s) => Ok(s.clone()),
+            other => Err(RunError {
+                message: format!("expected a string, got {}", other.kind_name()),
+                span,
+            }),
+        }
+    }
+}
+
+impl FromArg for bool {
+    fn from_arg(value: &Value, _path: &str, span: Span) -> Result<Self, RunError> {
+        match value {
+            Value::Bool(b) => Ok(*b),
+            other => Err(RunError {
+                message: format!("expected a bool, got {}", other.kind_name()),
+                span,
+            }),
+        }
+    }
+}
+
+/// The raw value, unconverted — for externals that accept several shapes
+/// (taggers, subject-last handles) and dispatch themselves.
+impl FromArg for Value {
+    fn from_arg(value: &Value, _path: &str, _span: Span) -> Result<Self, RunError> {
+        Ok(value.clone())
+    }
+}
+
+/// What a registered closure may return: a value (a [`HostData`] newtype
+/// wraps itself opaquely; [`Value`] passes through for plain data), or
+/// `Result<value, String>` for domain validation (`far must be greater than
+/// near`) — the registry attaches the call span to the message.
+///
+/// Blanket impls over [`HostData`] fall foul of coherence (a foreign type
+/// could implement it), so host-data newtypes opt in explicitly with
+/// [`host_returnable!`] — one line per migrated type.
+pub trait IntoHostResult {
+    fn into_host_result(self, span: Span) -> Result<Value, RunError>;
+}
+
+impl IntoHostResult for Value {
+    fn into_host_result(self, _span: Span) -> Result<Value, RunError> {
+        Ok(self)
+    }
+}
+
+impl IntoHostResult for Result<Value, String> {
+    fn into_host_result(self, span: Span) -> Result<Value, RunError> {
+        self.map_err(|message| RunError { message, span })
+    }
+}
+
+/// Opt a [`HostData`] newtype into being returned from registered externals,
+/// bare or as `Result<T, String>`.
+#[macro_export]
+macro_rules! host_returnable {
+    ($($ty:ty),+ $(,)?) => {$(
+        impl $crate::host_registry::IntoHostResult for $ty {
+            fn into_host_result(
+                self,
+                _span: functor_lang::Span,
+            ) -> Result<functor_lang::value::Value, functor_lang::RunError> {
+                Ok(functor_lang::value::Value::HostData(std::rc::Rc::new(self)))
+            }
+        }
+        impl $crate::host_registry::IntoHostResult for Result<$ty, String> {
+            fn into_host_result(
+                self,
+                span: functor_lang::Span,
+            ) -> Result<functor_lang::value::Value, functor_lang::RunError> {
+                match self {
+                    Ok(value) => {
+                        Ok(functor_lang::value::Value::HostData(std::rc::Rc::new(value)))
+                    }
+                    Err(message) => Err(functor_lang::RunError { message, span }),
+                }
+            }
+        }
+    )+};
+}
+
+/// One registered external: its dispatch closure plus the human signature its
+/// arity error teaches (`usage: Angle.degrees(n)`).
+struct External {
+    sig: &'static str,
+    /// The registered parameter count — asserted against the `.funi`
+    /// signature's arity by the drift test, so the usage text and the
+    /// interface cannot teach different shapes.
+    arity: usize,
+    call: Box<dyn Fn(&str, &[Value], Span) -> Result<Value, RunError> + Send + Sync>,
+}
+
+/// The registry: external path → typed implementation. Built once at startup
+/// ([`crate::functor_lang_prelude::registry`]) and consulted before the legacy match.
+#[derive(Default)]
+pub struct Registry {
+    fns: HashMap<&'static str, External>,
+}
+
+/// Implements `fn1`/`fn2`/… — one registration method per arity. Each checks
+/// the argument count (else the `usage:` error), converts each argument with
+/// [`FromArg`] left to right, and converts the return with [`IntoHostResult`].
+///
+/// NOTE: when several arguments are malformed at once, the error reported is
+/// the LEFTMOST conversion failure — and all conversions run before the
+/// closure's own domain validation. Legacy match arms interleaved those
+/// checks in ad-hoc orders, so multi-error calls may report a different
+/// (equally legitimate) error than the arm they replaced.
+macro_rules! register_arity {
+    ($method:ident, $count:literal, $($arg:ident : $ty:ident),+) => {
+        pub fn $method<$($ty: FromArg + 'static,)+ R: IntoHostResult + 'static>(
+            &mut self,
+            path: &'static str,
+            sig: &'static str,
+            f: impl Fn($($ty),+) -> R + Send + Sync + 'static,
+        ) {
+            self.register(path, sig, $count, move |path, args, span| {
+                let [$($arg),+] = args else {
+                    return Err(RunError {
+                        message: format!("usage: {sig}"),
+                        span,
+                    });
+                };
+                f($($ty::from_arg($arg, path, span)?),+).into_host_result(span)
+            });
+        }
+    };
+}
+
+impl Registry {
+    /// A zero-argument external (`Ui.topLeft()`): any argument is rejected
+    /// with the usage error, like the legacy constructor arms.
+    pub fn fn0<R: IntoHostResult + 'static>(
+        &mut self,
+        path: &'static str,
+        sig: &'static str,
+        f: impl Fn() -> R + Send + Sync + 'static,
+    ) {
+        self.register(path, sig, 0, move |_path, args, span| {
+            if !args.is_empty() {
+                return Err(RunError {
+                    message: format!("usage: {sig}"),
+                    span,
+                });
+            }
+            f().into_host_result(span)
+        });
+    }
+
+    register_arity!(fn1, 1, a: A);
+    register_arity!(fn2, 2, a: A, b: B);
+    register_arity!(fn3, 3, a: A, b: B, c: C);
+    register_arity!(fn4, 4, a: A, b: B, c: C, d: D);
+    register_arity!(fn5, 5, a: A, b: B, c: C, d: D, e: E);
+    register_arity!(fn6, 6, a: A, b: B, c: C, d: D, e: E, f_: F);
+
+    fn register(
+        &mut self,
+        path: &'static str,
+        sig: &'static str,
+        arity: usize,
+        call: impl Fn(&str, &[Value], Span) -> Result<Value, RunError> + Send + Sync + 'static,
+    ) {
+        assert!(
+            sig.starts_with(path),
+            "external `{path}`: its usage signature must start with the path, got `{sig}`"
+        );
+        let previous = self.fns.insert(
+            path,
+            External {
+                sig,
+                arity,
+                call: Box::new(call),
+            },
+        );
+        assert!(previous.is_none(), "external `{path}` registered twice");
+    }
+
+    /// Whether `path` is a registered external.
+    pub fn provides(&self, path: &str) -> bool {
+        self.fns.contains_key(path)
+    }
+
+    /// Dispatch a call if `path` is registered; `None` falls through to the
+    /// legacy match.
+    pub fn call(&self, path: &str, args: &[Value], span: Span) -> Option<Result<Value, RunError>> {
+        self.fns.get(path).map(|ext| (ext.call)(path, args, span))
+    }
+
+    /// The registered paths, for the `.funi` drift test.
+    pub fn paths(&self) -> impl Iterator<Item = &'static str> + '_ {
+        self.fns.keys().copied()
+    }
+
+    /// `(path, registered arity)` pairs — the drift test asserts each against
+    /// the `.funi` signature's parameter count.
+    pub fn arities(&self) -> impl Iterator<Item = (&'static str, usize)> + '_ {
+        self.fns.iter().map(|(path, ext)| (*path, ext.arity))
+    }
+
+    /// The registered signature for `path`, for tests.
+    pub fn sig(&self, path: &str) -> Option<&'static str> {
+        self.fns.get(path).map(|ext| ext.sig)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use functor_lang::HostData;
+
+    struct Marker(f64);
+    impl HostData for Marker {
+        fn type_name(&self) -> &'static str {
+            "Marker"
+        }
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    fn span() -> Span {
+        Span { start: 3, end: 9 }
+    }
+
+    crate::host_returnable!(Marker);
+
+    fn unwrap_err(result: Result<Value, RunError>) -> RunError {
+        match result {
+            Err(e) => e,
+            Ok(v) => panic!("expected an error, got {v}"),
+        }
+    }
+
+    fn registry() -> Registry {
+        let mut reg = Registry::default();
+        reg.fn1("T.wrap", "T.wrap(n)", Marker);
+        reg.fn2("T.ratio", "T.ratio(num, denom)", |n: f64, d: f64| {
+            if d == 0.0 {
+                Err("T.ratio: denom must not be zero".to_string())
+            } else {
+                Ok(Marker(n / d))
+            }
+        });
+        reg
+    }
+
+    #[test]
+    fn arity_mismatch_teaches_the_registered_signature() {
+        let err = unwrap_err(registry().call("T.wrap", &[], span()).expect("registered"));
+        assert_eq!(err.message, "usage: T.wrap(n)");
+        assert_eq!(err.span, span());
+    }
+
+    #[test]
+    fn arguments_convert_left_to_right_with_typed_errors() {
+        let err = unwrap_err(
+            registry()
+                .call(
+                    "T.ratio",
+                    &[Value::Number(1.0), Value::String("x".into())],
+                    span(),
+                )
+                .expect("registered"),
+        );
+        assert_eq!(err.message, "expected a number, got a string");
+        // Non-finite floats are rejected at the boundary, like the legacy num().
+        let err = unwrap_err(
+            registry()
+                .call("T.wrap", &[Value::Number(f64::INFINITY)], span())
+                .expect("registered"),
+        );
+        assert_eq!(err.message, "expected a finite number, got inf");
+    }
+
+    #[test]
+    fn domain_validation_errors_carry_the_call_span() {
+        let err = unwrap_err(
+            registry()
+                .call("T.ratio", &[Value::Number(1.0), Value::Number(0.0)], span())
+                .expect("registered"),
+        );
+        assert_eq!(err.message, "T.ratio: denom must not be zero");
+        assert_eq!(err.span, span());
+    }
+
+    #[test]
+    fn success_wraps_host_data_and_unknown_paths_fall_through() {
+        let reg = registry();
+        let value = reg
+            .call("T.ratio", &[Value::Number(9.0), Value::Number(3.0)], span())
+            .expect("registered")
+            .expect("ok");
+        match value {
+            Value::HostData(data) => {
+                assert_eq!(data.as_any().downcast_ref::<Marker>().unwrap().0, 3.0)
+            }
+            other => panic!("expected host data, got {other}"),
+        }
+        assert!(reg.call("T.unknown", &[], span()).is_none());
+        assert!(!reg.provides("T.unknown") && reg.provides("T.wrap"));
+    }
+
+    #[test]
+    #[should_panic(expected = "registered twice")]
+    fn double_registration_panics() {
+        let mut reg = registry();
+        reg.fn1("T.wrap", "T.wrap(n)", Marker);
+    }
+}

--- a/runtime/functor-runtime-common/src/lib.rs
+++ b/runtime/functor-runtime-common/src/lib.rs
@@ -69,6 +69,7 @@ mod light;
 pub mod material;
 pub mod math;
 pub mod functor_lang_prelude;
+pub mod host_registry;
 pub mod functor_lang_producer;
 pub mod model;
 pub mod net;


### PR DESCRIPTION
## Summary

PR 1 of the prelude-infra track (stacked on #372): the generalized Functor Lang ↔ Rust bridge. The prelude's interface half was already declarative (`.funi`); this makes the implementation half match. Hosts now **register** externals as typed Rust closures instead of adding hand-written `match path` arms:

```rust
reg.fn3("Color.rgb", "Color.rgb(r, g, b)", |r: f64, g: f64, b: f64| {
    FunctorLangColor((r as f32, g as f32, b as f32))
});
```

The registry derives what each arm used to hand-roll:
- **Arity errors** become `usage: <registered sig>`, and the registered arity is **asserted against the `.funi` signature's parameter count** by the drift test — the usage text, the implementation, and the interface cannot teach different shapes.
- **Argument conversion** comes from `FromArg`, implemented once per type (`f64` with the legacy `num()` semantics, `String`, `Rc<str>` for allocation-neutral identity externals, `bool`, `Value` passthrough, and branded types like `FunctorLangColor`) — which is where the branded teaching errors now live, instead of being re-plumbed per consuming arm.
- **Returns** convert via `IntoHostResult` (`host_returnable!` opts HostData newtypes in; `Result<_, String>` carries domain validation with the call span attached).

Dispatch consults the registry **first** and falls back to the legacy match, so externals migrate arm-by-arm with no flag day. The drift test asserts `.funi` signatures ≡ (registry ∪ legacy `PATHS`), disjoint, with per-path arity agreement.

## Proof migration (15 externals)

The branded-value constructors — `Angle.degrees/radians`, `Time.seconds/millis`, `Color.rgb`, `Vec3.make`, `Physics.tag` (Rc-identity), `RenderTarget.named` (non-empty validation), `Fog.linear/exp` (domain validation + a branded `Color` argument) — plus the five zero-arg `Ui` anchors.

**One deliberate, test-pinned unification:** a wrong-**type** argument now always gets the precise conversion error ("expected a string, got a number") where string-pattern arms used to fall through to the usage line; arity mistakes still teach usage. (Number-taking arms already behaved this way — the registry makes it uniform.) Multi-error calls report the leftmost conversion failure; documented on the registry.

## Validation

- All crates green (`functor_runtime_common` 301 incl. new registry unit tests + the arity drift check, `functor-lang`, `functor-runtime-desktop`, `functor-lang-wasm`, `functor-cli`); web compiles for wasm32 (the registry is a `OnceLock` global — verified for the single-threaded target).
- Every example passes `functor build`; **golden-image test: 0 differing pixels across all 7 scenarios** (synthwave exercises Fog/RenderTarget/Angle/Color/Vec3 through the registry).
- Live CLI demo: a scene using five registry constructors renders; swapping `Fog.linear`'s near/far yields the spanned teaching error at the exact call site.
- Cross-engine adversarial review (Claude + Codex): no Critical/High; all findings applied (the arity↔`.funi` invariant, `Rc<str>` allocation-neutral `Physics.tag`, `fn0` + the Ui-anchor migration proving it, and the conversion-order doc note).

CLAUDE.md and `docs/functor-lang.md` document the registry as the preferred way to add prelude surfaces. Follow-up PRs migrate the remaining arms module-by-module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)