### PR TITLE
feat: Sub.assets — loading progress as a subscription, with examples/loading

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -512,13 +512,18 @@ Sub.assets(tagger)                                         // asset-loading prog
                                                            //   whenever the shell's snapshot
                                                            //   CHANGES (incl. the initial state
                                                            //   on frame one) — the loading-
-                                                           //   screen seam. loaded == total is
-                                                           //   "all settled"; failed lists
-                                                           //   {path, error} per failed
-                                                           //   byte-load (decode fallbacks
-                                                           //   count as loaded). Fires from
-                                                           //   snapshot changes, not the time
-                                                           //   grid; requires `update`
+                                                           //   screen seam. The settled gate is
+                                                           //   total > 0.0 && loaded +
+                                                           //   List.length(failed) == total
+                                                           //   (failures never join loaded, and
+                                                           //   frame one can deliver 0/0);
+                                                           //   failed lists {path, error} per
+                                                           //   failed byte-load (decode
+                                                           //   fallbacks count as loaded).
+                                                           //   Fires from snapshot changes, not
+                                                           //   the time grid; requires `update`.
+                                                           //   examples/loading is the
+                                                           //   reference
 Effect.random(tagger) / Effect.now(tagger)                 // one-shots; tagger: (float) => Msg
 Sub.connect(url, tagger) / Sub.listen(addr, tagger)        // persistent connections; tagger: (Net.NetEvent) => Msg
 Effect.send(connId, text)                                  // send on an open connection

--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -507,6 +507,18 @@ frame |> Frame.withSkybox(sky)                             //   paths (+X..-Z). 
                                                            //   Fog never fogs the sky
 Time.seconds(1.0) / Time.millis(500.0)                     // Duration VALUES only
 Sub.every(duration, msg) / Sub.none() / Sub.batch([sub,…]) // what subscriptions returns
+Sub.assets(tagger)                                         // asset-loading progress: the tagger
+                                                           //   receives {loaded, total, failed}
+                                                           //   whenever the shell's snapshot
+                                                           //   CHANGES (incl. the initial state
+                                                           //   on frame one) — the loading-
+                                                           //   screen seam. loaded == total is
+                                                           //   "all settled"; failed lists
+                                                           //   {path, error} per failed
+                                                           //   byte-load (decode fallbacks
+                                                           //   count as loaded). Fires from
+                                                           //   snapshot changes, not the time
+                                                           //   grid; requires `update`
 Effect.random(tagger) / Effect.now(tagger)                 // one-shots; tagger: (float) => Msg
 Sub.connect(url, tagger) / Sub.listen(addr, tagger)        // persistent connections; tagger: (Net.NetEvent) => Msg
 Effect.send(connId, text)                                  // send on an open connection

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -34,6 +34,12 @@ bug found in the same exercise was fixed on the spot
 - [x] Asset introspection: `functor inspect` should print per-node
       translations + bbox (Kenney glbs carry baked placement offsets that
       render displaced and look like renderer bugs).
+- [ ] `Sub.assets` under `--headless`: the headless loop has no asset cache,
+      so it never pushes a progress snapshot and the sub silently never fires
+      — a game gating on its loading screen can't be driven headless. Either
+      push an empty-cache snapshot (loading screens settle at 0/0 with the
+      documented `total > 0` guard… still gated) or give headless a real
+      byte-load path without GPU hydration.
 
 ## Validation tooling
 

--- a/e2e/wasm-smoke.mjs
+++ b/e2e/wasm-smoke.mjs
@@ -63,8 +63,13 @@ async function waitPortFree(timeoutMs) {
 
 // Samples that stand alone (no companion network server). The multiplayer /
 // websocket demos need a running server to do anything, so they're out of a
-// pure client smoke.
+// pure client smoke — and `loading` is out because it is the one sample that
+// streams from an EXTERNAL CDN (assets.babylonjs.com): a hermetic CI smoke
+// must not depend on third-party network. Its wasm remote-loading path is
+// covered hermetically by e2e/remote-assets.mjs, and its Sub.assets
+// lifecycle by the producer tests + native debug-server verification.
 const EXCLUDE = new Set([
+  "loading",
   "mpclient",
   "mpserver",
   "wsdemo",

--- a/examples/loading/functor.json
+++ b/examples/loading/functor.json
@@ -1,0 +1,1 @@
+{"language": "functor-lang", "entry": "game.fun"}

--- a/examples/loading/game.fun
+++ b/examples/loading/game.fun
@@ -1,0 +1,99 @@
+// examples/loading — a loading screen over `Sub.assets`: models stream from
+// the BabylonJS CDN while a progress bar tracks {loaded, total, failed}; when
+// everything settles the bar disappears. On a fast machine (or once the disk
+// cache is warm) loads are near-instant — simulate a slow network to actually
+// watch it (native only; the value is KB/s):
+//
+//   FUNCTOR_THROTTLE_ASSETS=200 functor -d examples/loading run native
+//
+// Remote assets disk-cache at ~/.functor/cache, so point FUNCTOR_ASSET_CACHE
+// at a scratch dir (or wipe the cache) to re-see the first-load experience.
+//
+// Loading is DECLARATIVE: an asset starts loading when `draw` references it.
+// So the scene is drawn from frame one — models pop in as they arrive — and
+// the bar overlays until `loaded + failed == total`. Failed loads (a bad URL)
+// count toward settling, and the HUD shows them: a loading screen must end
+// even when the CDN doesn't cooperate.
+
+let init = { loaded: 0.0, failed: 0.0, total: 0.0, done: false }
+
+let update = (model, p) =>
+  let failedCount = List.length(p.failed) in
+  { loaded: p.loaded,
+    failed: failedCount,
+    total: p.total,
+    done: p.total > 0.0 && p.loaded + failedCount == p.total }
+
+let subscriptions = (model) => Sub.assets((p) => p)
+
+let tick = (model, dt, tts) => model
+
+let fraction = (model) =>
+  if model.total == 0.0 then 0.0
+  else (model.loaded + model.failed) / model.total
+
+let models = () =>
+  Scene.group([
+    Scene.model("https://assets.babylonjs.com/meshes/ExplodingBarrel.glb")
+      |> Scene.scale(0.35)
+      |> Scene.translate(0.0, -1.2, 0.0),
+    Scene.model("https://assets.babylonjs.com/meshes/shark.glb")
+      |> Scene.scale(0.18)
+      |> Scene.rotateY(Angle.degrees(200.0))
+      |> Scene.translate(-2.2, 0.7, 0.0),
+    // Deliberately mixed sizes (2KB box, 2.9MB barrel, 15MB shark): assets
+    // settle in size order, so the staggered pop-in is visible.
+    Scene.model("https://assets.babylonjs.com/meshes/box.glb")
+      |> Scene.scale(0.8)
+      |> Scene.rotateY(Angle.degrees(30.0))
+      |> Scene.translate(2.4, 0.2, 0.0),
+  ])
+
+// A backdrop quad and a left-anchored fill quad (quads are centered, so the
+// fill shifts left by half its missing width). Quad fronts face +Z — toward
+// the camera below.
+let barWidth = 3.0
+
+let bar = (model) =>
+  let f = fraction(model) in
+  Scene.group([
+    Scene.quad()
+      |> Scene.scaleXYZ(barWidth + 0.15, 0.35, 1.0)
+      |> Scene.color(0.12, 0.12, 0.18),
+    Scene.quad()
+      |> Scene.scaleXYZ(barWidth * f, 0.22, 1.0)
+      |> Scene.translate(barWidth * (f - 1.0) * 0.5, 0.0, 0.05)
+      |> Scene.emissive(0.25, 0.9, 0.55),
+  ])
+    |> Scene.translate(0.0, -2.3, 0.0)
+
+let draw = (model, tts) =>
+  let scene =
+    if model.done then models()
+    else Scene.group([models(), bar(model)])
+  in
+  Frame.createLit(
+    Camera.lookAt(0.0, 0.8, 6.0, 0.0, -0.2, 0.0),
+    scene,
+    [
+      Light.ambient(0.4, 0.4, 0.45),
+      Light.directional(-0.4, -1.0, -0.5, 1.0, 0.95, 0.9, 1.1),
+    ])
+
+let ui = (model) =>
+  let status =
+    if model.done then "Ready!"
+    else
+      Text.concat(
+        "Loading ",
+        Text.concat(
+          Text.fixed(model.loaded + model.failed, 0.0),
+          Text.concat(
+            " / ",
+            Text.concat(
+              Text.fixed(model.total, 0.0),
+              if model.failed > 0.0
+              then Text.concat("  failed: ", Text.fixed(model.failed, 0.0))
+              else ""))))
+  in
+  Ui.column([Ui.text(status)]) |> Ui.panel(Ui.center())

--- a/examples/loading/game.fun
+++ b/examples/loading/game.fun
@@ -1,10 +1,11 @@
 // examples/loading — a loading screen over `Sub.assets`: models stream from
 // the BabylonJS CDN while a progress bar tracks {loaded, total, failed}; when
-// everything settles the bar disappears. On a fast machine (or once the disk
-// cache is warm) loads are near-instant — simulate a slow network to actually
-// watch it (native only; the value is KB/s):
+// everything settles the bar disappears. Press SPACE to request a SECOND
+// batch mid-game — the demo of late asset requests. On a fast machine (or a
+// warm disk cache) loads are near-instant — simulate a slow network to
+// actually watch it (native only; the value is KB/s):
 //
-//   FUNCTOR_THROTTLE_ASSETS=200 functor -d examples/loading run native
+//   FUNCTOR_THROTTLE_ASSETS=600 functor -d examples/loading run native
 //
 // Remote assets disk-cache at ~/.functor/cache, so point FUNCTOR_ASSET_CACHE
 // at a scratch dir (or wipe the cache) to re-see the first-load experience.
@@ -14,23 +15,61 @@
 // the bar overlays until `loaded + failed == total`. Failed loads (a bad URL)
 // count toward settling, and the HUD shows them: a loading screen must end
 // even when the CDN doesn't cooperate.
+//
+// The SPACE transition demonstrates the two late-request idioms:
+//   1. Progress is CUMULATIVE (total never resets), so a per-phase bar
+//      subtracts the baseline captured at the transition (baseLoaded /
+//      baseTotal below).
+//   2. The new assets only enter the snapshot on the frame AFTER draw first
+//      references them, so the keypress sets its own `transitioning` flag —
+//      the game knows it just asked — and clears it when the batch settles.
 
-let init = { loaded: 0.0, failed: 0.0, total: 0.0, done: false }
+let init = {
+  loaded: 0.0, failed: 0.0, total: 0.0, done: false,
+  phase: 1.0,
+  baseLoaded: 0.0, baseTotal: 0.0,
+  transitioning: false,
+}
 
 let update = (model, p) =>
   let failedCount = List.length(p.failed) in
-  { loaded: p.loaded,
-    failed: failedCount,
-    total: p.total,
-    done: p.total > 0.0 && p.loaded + failedCount == p.total }
+  let settledAll = p.total > 0.0 && p.loaded + failedCount == p.total in
+  { model with
+      loaded: p.loaded,
+      failed: failedCount,
+      total: p.total,
+      done: settledAll,
+      // Idiom 2: the flag clears once the phase-2 batch is both KNOWN
+      // (total grew past the baseline) and settled.
+      transitioning:
+        model.transitioning && not (settledAll && p.total > model.baseTotal) }
 
 let subscriptions = (model) => Sub.assets((p) => p)
 
+let input = (model, key, isDown) =>
+  match key with
+  | Key.Space =>
+    if isDown && model.phase == 1.0
+    then
+      // Idiom 1 + 2: capture the baseline for a fresh per-phase bar, and
+      // raise our own flag — the snapshot won't know about the new assets
+      // until the next frame's draw references them.
+      { model with
+          phase: 2.0,
+          transitioning: true,
+          baseLoaded: model.loaded + model.failed,
+          baseTotal: model.total }
+    else model
+  | _ => model
+
 let tick = (model, dt, tts) => model
 
+// Per-phase fraction (idiom 1): progress since the captured baseline.
 let fraction = (model) =>
-  if model.total == 0.0 then 0.0
-  else (model.loaded + model.failed) / model.total
+  if model.total == model.baseTotal then 0.0
+  else
+    (model.loaded + model.failed - model.baseLoaded)
+      / (model.total - model.baseTotal)
 
 let models = () =>
   Scene.group([
@@ -47,6 +86,24 @@ let models = () =>
       |> Scene.scale(0.8)
       |> Scene.rotateY(Angle.degrees(30.0))
       |> Scene.translate(2.4, 0.2, 0.0),
+  ])
+
+// The SPACE batch — another size ladder (1.1MB gull, 4.6MB plane, 11MB
+// boombox), placed above the phase-1 row.
+let phase2Models = () =>
+  Scene.group([
+    Scene.model("https://assets.babylonjs.com/meshes/seagulf.glb")
+      |> Scene.scale(0.001)
+      |> Scene.translate(-3.0, -1.6, 0.0),
+    Scene.model("https://assets.babylonjs.com/meshes/aerobatic_plane.glb")
+      |> Scene.scale(3.0)
+      |> Scene.rotateY(Angle.degrees(150.0))
+      |> Scene.translate(1.7, 2.0, 0.0),
+    // The glTF-sample BoomBox is authored at centimeter scale (~1cm tall).
+    Scene.model("https://assets.babylonjs.com/meshes/boombox.glb")
+      |> Scene.scale(22.0)
+      |> Scene.rotateY(Angle.degrees(180.0))
+      |> Scene.translate(0.0, 1.6, 0.0),
   ])
 
 // A backdrop quad and a left-anchored fill quad (quads are centered, so the
@@ -68,13 +125,19 @@ let bar = (model) =>
     |> Scene.translate(0.0, -2.3, 0.0)
 
 let draw = (model, tts) =>
+  let base = models() in
   let scene =
-    if model.done then models()
-    else Scene.group([models(), bar(model)])
+    if model.phase > 1.0 then Scene.group([base, phase2Models()])
+    else base
+  in
+  let withBar =
+    if model.transitioning || not model.done
+    then Scene.group([scene, bar(model)])
+    else scene
   in
   Frame.createLit(
-    Camera.lookAt(0.0, 0.8, 6.0, 0.0, -0.2, 0.0),
-    scene,
+    Camera.lookAt(0.0, 0.8, 6.0, 0.0, 0.2, 0.0),
+    withBar,
     [
       Light.ambient(0.4, 0.4, 0.45),
       Light.directional(-0.4, -1.0, -0.5, 1.0, 0.95, 0.9, 1.1),
@@ -82,18 +145,23 @@ let draw = (model, tts) =>
 
 let ui = (model) =>
   let status =
-    if model.done then "Ready!"
-    else
+    if model.transitioning && model.total == model.baseTotal
+    then "Requesting more assets..."
+    else if not model.done
+    then
       Text.concat(
         "Loading ",
         Text.concat(
-          Text.fixed(model.loaded + model.failed, 0.0),
+          Text.fixed(model.loaded + model.failed - model.baseLoaded, 0.0),
           Text.concat(
             " / ",
             Text.concat(
-              Text.fixed(model.total, 0.0),
+              Text.fixed(model.total - model.baseTotal, 0.0),
               if model.failed > 0.0
               then Text.concat("  failed: ", Text.fixed(model.failed, 0.0))
               else ""))))
+    else if model.phase == 1.0
+    then "Ready!  [Space: load more]"
+    else "Ready!"
   in
   Ui.column([Ui.text(status)]) |> Ui.panel(Ui.center())

--- a/functor-prelude/prelude/sub.funi
+++ b/functor-prelude/prelude/sub.funi
@@ -16,3 +16,13 @@ let batch : (List<t>) => t
 // `Net.NetEvent` values.
 let connect : (string, (Net.NetEvent) => 'msg) => t
 let listen : (string, (Net.NetEvent) => 'msg) => t
+
+// One failed asset byte-load (missing file, HTTP error, bad remote body).
+type AssetFailure = { path: string, error: string }
+// The loading snapshot: `loaded == total` is "all settled" — a loading
+// screen's gate. Decode fallbacks count as loaded; only byte-load failures
+// land in `failed`.
+type AssetProgress = { loaded: float, total: float, failed: List<AssetFailure> }
+// Asset-loading progress: the tagger receives the snapshot whenever it
+// changes (including the initial state on the first frame).
+let assets : ((AssetProgress) => 'msg) => t

--- a/functor-prelude/prelude/sub.funi
+++ b/functor-prelude/prelude/sub.funi
@@ -19,9 +19,11 @@ let listen : (string, (Net.NetEvent) => 'msg) => t
 
 // One failed asset byte-load (missing file, HTTP error, bad remote body).
 type AssetFailure = { path: string, error: string }
-// The loading snapshot: `loaded == total` is "all settled" — a loading
-// screen's gate. Decode fallbacks count as loaded; only byte-load failures
-// land in `failed`.
+// The loading snapshot. The "all settled" gate — a loading screen's dismiss
+// condition — is `total > 0.0 && loaded + List.length(failed) == total`:
+// failures never join `loaded`, and frame one can deliver 0/0 before any
+// asset is referenced. Decode fallbacks count as loaded; only byte-load
+// failures land in `failed`.
 type AssetProgress = { loaded: float, total: float, failed: List<AssetFailure> }
 // Asset-loading progress: the tagger receives the snapshot whenever it
 // changes (including the initial state on the first frame).

--- a/runtime/functor-runtime-common/src/asset/asset_cache.rs
+++ b/runtime/functor-runtime-common/src/asset/asset_cache.rs
@@ -9,9 +9,12 @@ use super::{AssetHandle, AssetPipeline, AssetPipelineContext, BuiltAssetPipeline
 
 /// A snapshot of asset loading, the data behind `Sub.assets`: how many
 /// distinct assets have been referenced, how many are decoded, and which
-/// byte-loads failed (missing file, HTTP error). `loaded == total` is "all
-/// settled" — a loading screen's gate. Decode failures are NOT here: the
-/// pipelines fall back (checkerboard / empty model) and count as loaded.
+/// byte-loads failed (missing file, HTTP error). The "all settled" gate — a
+/// loading screen's dismiss condition — is `total > 0 && loaded +
+/// failed.len() == total`: failures never join `loaded`, and frame one can
+/// deliver `0/0` before anything is referenced. Decode failures are NOT
+/// here: the pipelines fall back (checkerboard / empty model) and count as
+/// loaded.
 #[derive(Clone, Debug, PartialEq, Default)]
 pub struct AssetProgress {
     pub loaded: usize,

--- a/runtime/functor-runtime-common/src/asset/asset_cache.rs
+++ b/runtime/functor-runtime-common/src/asset/asset_cache.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap, HashSet},
     sync::{Arc, Mutex},
 };
 
@@ -7,14 +7,53 @@ use crate::io::load_bytes_async2;
 
 use super::{AssetHandle, AssetPipeline, AssetPipelineContext, BuiltAssetPipeline};
 
+/// A snapshot of asset loading, the data behind `Sub.assets`: how many
+/// distinct assets have been referenced, how many are decoded, and which
+/// byte-loads failed (missing file, HTTP error). `loaded == total` is "all
+/// settled" — a loading screen's gate. Decode failures are NOT here: the
+/// pipelines fall back (checkerboard / empty model) and count as loaded.
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct AssetProgress {
+    pub loaded: usize,
+    pub total: usize,
+    /// (path, error) per failed byte-load, in stable path order.
+    pub failed: Vec<(String, String)>,
+}
+
+#[derive(Default)]
+struct ProgressState {
+    /// Every path a load was ever started for (`total`).
+    started: HashSet<String>,
+    /// Paths whose bytes loaded AND decoded (`loaded`).
+    loaded: HashSet<String>,
+    /// Byte-load failures, keyed by path (BTreeMap for stable order).
+    failed: BTreeMap<String, String>,
+}
+
 pub struct AssetCache {
     bytes_cache: Arc<Mutex<HashMap<String, Vec<u8>>>>,
+    progress: Arc<Mutex<ProgressState>>,
 }
 
 impl AssetCache {
     pub fn new() -> AssetCache {
         AssetCache {
             bytes_cache: Arc::new(Mutex::new(HashMap::new())),
+            progress: Arc::new(Mutex::new(ProgressState::default())),
+        }
+    }
+
+    /// The current loading snapshot (see [`AssetProgress`]).
+    pub fn progress(&self) -> AssetProgress {
+        let state = self.progress.lock().unwrap();
+        AssetProgress {
+            loaded: state.loaded.len(),
+            total: state.started.len(),
+            failed: state
+                .failed
+                .iter()
+                .map(|(path, err)| (path.clone(), err.clone()))
+                .collect(),
         }
     }
 
@@ -26,9 +65,13 @@ impl AssetCache {
 
     /// Forget the cached bytes for `path` so the next load re-reads the file
     /// (asset hot-reload). Pipelines cache decoded handles separately — evict
-    /// there too (`SceneContext::evict_asset` does both).
+    /// there too (`SceneContext::evict_asset` does both). The path counts as
+    /// pending again in `progress()` until the reload settles.
     pub fn evict(&self, path: &str) {
         self.bytes_cache.lock().unwrap().remove(path);
+        let mut progress = self.progress.lock().unwrap();
+        progress.loaded.remove(path);
+        progress.failed.remove(path);
     }
 
     pub fn load_asset_with_pipeline<T: 'static>(
@@ -45,6 +88,12 @@ impl AssetCache {
         let bytes_cache = self.bytes_cache.clone();
 
         let self_arc = Arc::clone(self);
+        self.progress
+            .lock()
+            .unwrap()
+            .started
+            .insert(asset_path_owned.clone());
+        let progress = self.progress.clone();
 
         // Check cache
         if let Some(cached_bytes) = self.bytes_cache.lock().unwrap().get(&asset_path_owned) {
@@ -59,11 +108,9 @@ impl AssetCache {
             let pipeline = pipeline.clone();
             // If bytes are already cached, return a handle immediately
             let future = async move {
-                Ok(Arc::new(pipeline.process(
-                    bytes,
-                    self_arc.as_ref(),
-                    context,
-                )))
+                let decoded = Arc::new(pipeline.process(bytes, self_arc.as_ref(), context));
+                progress.lock().unwrap().loaded.insert(asset_path_owned);
+                Ok(decoded)
             };
             return Arc::new(AssetHandle::new(future, Arc::new(default_asset)));
         }
@@ -75,7 +122,17 @@ impl AssetCache {
         let outer_pipeline = pipeline.clone();
         // If not cached, load bytes asynchronously
         let bytes_future = async move {
-            let bytes = load_bytes_async2(asset_path_owned.clone()).await?;
+            let bytes = match load_bytes_async2(asset_path_owned.clone()).await {
+                Ok(bytes) => bytes,
+                Err(e) => {
+                    progress
+                        .lock()
+                        .unwrap()
+                        .failed
+                        .insert(asset_path_owned, e.clone());
+                    return Err(e);
+                }
+            };
             // Region-aware debug line (see docs/cli-output.md): under the CLI's
             // logger this becomes an `Event::Log` printed above the live panel;
             // silent unless `-v`/`RUST_LOG=debug`. Fires once per asset (on the
@@ -92,15 +149,89 @@ impl AssetCache {
 
             let pipeline = pipeline.clone();
             let context = AssetPipelineContext {};
-            Ok(Arc::new(pipeline.process(
-                bytes,
-                self_arc.as_ref(),
-                context,
-            )))
+            let decoded = Arc::new(pipeline.process(bytes, self_arc.as_ref(), context));
+            progress.lock().unwrap().loaded.insert(asset_path_owned);
+            Ok(decoded)
         };
 
         let handle = Arc::new(AssetHandle::new(bytes_future, Arc::new(default_asset)));
         outer_pipeline.cache(asset_path, handle.clone());
         handle
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::asset::AssetPollState;
+
+    struct BytesLen;
+    impl AssetPipeline<usize> for BytesLen {
+        fn process(&self, bytes: Vec<u8>, _: &AssetCache, _: AssetPipelineContext) -> usize {
+            bytes.len()
+        }
+        fn unloaded_asset(&self, _: AssetPipelineContext) -> usize {
+            0
+        }
+    }
+
+    fn temp_file(name: &str, contents: &[u8]) -> String {
+        let path = std::env::temp_dir().join(format!(
+            "functor-asset-progress-{}-{}",
+            std::process::id(),
+            name
+        ));
+        std::fs::write(&path, contents).unwrap();
+        path.to_string_lossy().to_string()
+    }
+
+    /// Drive a handle to settled the way the render loop does.
+    fn settle<T>(handle: &AssetHandle<T>) {
+        for _ in 0..100 {
+            match handle.poll_state() {
+                AssetPollState::Loading => {}
+                _ => return,
+            }
+        }
+        panic!("asset did not settle");
+    }
+
+    #[test]
+    fn progress_counts_loads_failures_and_evictions() {
+        let cache = Arc::new(AssetCache::new());
+        let pipeline = super::super::build_pipeline(Box::new(BytesLen));
+        assert_eq!(cache.progress(), AssetProgress::default());
+
+        // A real file loads: 1/1, no failures.
+        let good = temp_file("good.bin", b"12345");
+        settle(&cache.load_asset_with_pipeline(pipeline.clone(), &good));
+        let progress = cache.progress();
+        assert_eq!((progress.loaded, progress.total), (1, 1));
+        assert!(progress.failed.is_empty());
+
+        // A missing file fails: 1/2 with the path in `failed`.
+        let missing = "does/not/exist.bin";
+        settle(&cache.load_asset_with_pipeline(pipeline.clone(), missing));
+        let progress = cache.progress();
+        assert_eq!((progress.loaded, progress.total), (1, 2));
+        assert_eq!(progress.failed.len(), 1);
+        assert_eq!(progress.failed[0].0, missing);
+
+        // Re-requesting settled assets never double-counts.
+        settle(&cache.load_asset_with_pipeline(pipeline.clone(), &good));
+        let progress = cache.progress();
+        assert_eq!((progress.loaded, progress.total), (1, 2));
+
+        // Eviction (hot-reload) makes the path pending again...
+        cache.evict(&good);
+        pipeline.evict(&good);
+        let progress = cache.progress();
+        assert_eq!((progress.loaded, progress.total), (0, 2));
+        // ...until the reload settles.
+        settle(&cache.load_asset_with_pipeline(pipeline.clone(), &good));
+        let progress = cache.progress();
+        assert_eq!((progress.loaded, progress.total), (1, 2));
+
+        let _ = std::fs::remove_file(&good);
     }
 }

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -193,6 +193,13 @@ pub enum SubTree {
     PhysicsEvents {
         tagger: Value,
     },
+    /// Asset-loading progress (the loading-screen seam): the tagger receives
+    /// `{loaded, total, failed}` whenever the shell's snapshot changes,
+    /// delivered with the frame's subscription messages through `update`.
+    /// NOT fired on the time grid — the producer compares snapshots.
+    Assets {
+        tagger: Value,
+    },
     /// A persistent client connection (`Sub.connect`) or server listener
     /// (`Sub.listen`), keyed by its endpoint url/addr. NOT fired on the time
     /// grid — the producer reconciles declared keys against the live set
@@ -920,6 +927,7 @@ const PATHS: &[&str] = &[
     "Sub.none",
     "Sub.every",
     "Sub.batch",
+    "Sub.assets",
     "Effect.none",
     "Effect.now",
     "Effect.random",
@@ -2240,6 +2248,21 @@ the new text, got {}",
                 }))),
                 _ => usage("Sub.every(duration, msg)"),
             },
+            // Asset-loading progress SUB: the tagger receives
+            // `{loaded, total, failed}` whenever the loading snapshot changes
+            // (see functor_lang_producer's delivery). The loading-screen seam.
+            "Sub.assets" => match args.as_slice() {
+                [tagger @ (Value::Closure(_) | Value::Ctor { .. })] => Ok(host(FunctorLangSub(
+                    SubTree::Assets {
+                        tagger: tagger.clone(),
+                    },
+                ))),
+                [other] => err(format!(
+                    "Sub.assets(tagger): the tagger must be a function of the progress record, got {}",
+                    other.kind_name()
+                )),
+                _ => usage("Sub.assets(tagger)"),
+            },
             "Effect.none" => match args.as_slice() {
                 [] => Ok(host(FunctorLangEffect(EffectTree::None))),
                 _ => usage("Effect.none()"),
@@ -2423,6 +2446,9 @@ fn collect_fired(sub: &SubTree, prev_tts: f64, tts: f64, msgs: &mut Vec<Value>) 
         SubTree::PhysicsEvents { .. } => {}
         // Connections are reconciled + routed by the producer, not fired.
         SubTree::Connect { .. } => {}
+        // Progress subs fire on snapshot changes, not the time grid — the
+        // producer collects their taggers via `assets_taggers`.
+        SubTree::Assets { .. } => {}
     }
 }
 
@@ -2480,7 +2506,10 @@ fn collect_conn_subs(sub: &SubTree, out: &mut Vec<NetConnSub>) {
             listen: *listen,
             tagger: tagger.clone(),
         }),
-        SubTree::None | SubTree::Every { .. } | SubTree::PhysicsEvents { .. } => {}
+        SubTree::None
+        | SubTree::Every { .. }
+        | SubTree::PhysicsEvents { .. }
+        | SubTree::Assets { .. } => {}
     }
 }
 
@@ -2665,7 +2694,10 @@ pub enum NetEventKind {
 
 fn collect_event_taggers(sub: &SubTree, taggers: &mut Vec<Value>) {
     match sub {
-        SubTree::None | SubTree::Every { .. } | SubTree::Connect { .. } => {}
+        SubTree::None
+        | SubTree::Every { .. }
+        | SubTree::Connect { .. }
+        | SubTree::Assets { .. } => {}
         SubTree::Batch(items) => {
             for item in items.iter() {
                 collect_event_taggers(item, taggers);
@@ -2673,6 +2705,58 @@ fn collect_event_taggers(sub: &SubTree, taggers: &mut Vec<Value>) {
         }
         SubTree::PhysicsEvents { tagger } => taggers.push(tagger.clone()),
     }
+}
+
+/// The `Sub.assets` taggers in a subscription tree, in declaration order —
+/// the producer applies each to the progress record whenever the loading
+/// snapshot changes and folds the messages through `update`. A non-Sub value
+/// yields the same error `sub_messages_for_frame` reports.
+pub fn assets_taggers(subs: &Value) -> Result<Vec<Value>, String> {
+    let Some(sub) = sub_of(subs) else {
+        return Err(format!(
+            "subscriptions must return a Sub (Sub.every / Sub.none / Sub.batch), got {}",
+            subs.kind_name()
+        ));
+    };
+    let mut taggers = Vec::new();
+    collect_assets_taggers(&sub.0, &mut taggers);
+    Ok(taggers)
+}
+
+fn collect_assets_taggers(sub: &SubTree, taggers: &mut Vec<Value>) {
+    match sub {
+        SubTree::None
+        | SubTree::Every { .. }
+        | SubTree::PhysicsEvents { .. }
+        | SubTree::Connect { .. } => {}
+        SubTree::Batch(items) => {
+            for item in items.iter() {
+                collect_assets_taggers(item, taggers);
+            }
+        }
+        SubTree::Assets { tagger } => taggers.push(tagger.clone()),
+    }
+}
+
+/// The tagger-facing record for a `Sub.assets` progress snapshot:
+/// `{loaded, total, failed: [{path, error}, …]}`. `loaded == total` is "all
+/// settled" — a loading screen's gate.
+pub fn asset_progress_value(progress: &crate::asset::AssetProgress) -> Value {
+    let failed: Vec<Value> = progress
+        .failed
+        .iter()
+        .map(|(path, error)| {
+            Value::Record(Rc::new(vec![
+                ("path".to_string(), Value::String(Rc::from(path.as_str()))),
+                ("error".to_string(), Value::String(Rc::from(error.as_str()))),
+            ]))
+        })
+        .collect();
+    Value::Record(Rc::new(vec![
+        ("loaded".to_string(), Value::Number(progress.loaded as f64)),
+        ("total".to_string(), Value::Number(progress.total as f64)),
+        ("failed".to_string(), Value::List(Rc::new(failed))),
+    ]))
 }
 
 /// The tagger-facing record for one collision event.

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -2739,8 +2739,9 @@ fn collect_assets_taggers(sub: &SubTree, taggers: &mut Vec<Value>) {
 }
 
 /// The tagger-facing record for a `Sub.assets` progress snapshot:
-/// `{loaded, total, failed: [{path, error}, …]}`. `loaded == total` is "all
-/// settled" — a loading screen's gate.
+/// `{loaded, total, failed: [{path, error}, …]}`. The settled gate is
+/// `total > 0 && loaded + List.length(failed) == total` — failures never
+/// join `loaded`, and frame one can deliver 0/0 (see examples/loading).
 pub fn asset_progress_value(progress: &crate::asset::AssetProgress) -> Value {
     let failed: Vec<Value> = progress
         .failed

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -753,6 +753,7 @@ to receive their messages; dropping them"
             return;
         }
         let record = asset_progress_value(&progress);
+        let mut any_delivered = false;
         for tagger in taggers {
             let msg = match self.session.apply(
                 tagger,
@@ -766,6 +767,7 @@ to receive their messages; dropping them"
                     continue;
                 }
             };
+            any_delivered = true;
             let args = vec![self.model.clone(), msg];
             journal_push("update", &args, Provenance::Subscription);
             match self.session.call("update", args, &mut FunctorHost) {
@@ -773,7 +775,12 @@ to receive their messages; dropping them"
                 Err(err) => self.reporter.frame_error("update", &err),
             }
         }
-        *self.delivered_asset_progress = Some(progress);
+        // Only mark delivered when a tagger actually received it — an
+        // erroring tagger (usually a transient hot-reload state) must not
+        // permanently swallow the snapshot.
+        if any_delivered {
+            *self.delivered_asset_progress = Some(progress);
+        }
     }
 
     /// The frame's physics phase (docs/physics.md): ask the game what bodies

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -364,6 +364,12 @@ impl FrameCtx<'_> {
         {
             self.deferred_queries.clear();
             self.pending_events.clear();
+            // The restored model predates the current loading snapshot, so
+            // "what the game last saw" no longer holds — invalidate the
+            // marker so the branch's first frame redelivers current progress
+            // (a rewound loading screen must learn its assets already
+            // settled).
+            *self.delivered_asset_progress = None;
         }
         self.subscriptions_and_tick(frame_time);
     }
@@ -1529,7 +1535,8 @@ mod tests {
         let subscriptions = (m) => Sub.assets((p) => p)\n\
         let tick = (m, dt, tts) => m\n\
         let expectedFirst = { count: 1.0, loaded: 1.0, total: 3.0, failedCount: 1.0 }\n\
-        let expectedSettled = { count: 2.0, loaded: 3.0, total: 3.0, failedCount: 1.0 }\n";
+        let expectedSettled = { count: 2.0, loaded: 3.0, total: 3.0, failedCount: 1.0 }\n\
+        let expectedFirstSettled = { count: 1.0, loaded: 3.0, total: 3.0, failedCount: 1.0 }\n";
 
     /// Run one frame (subscriptions + tick) with the given shell snapshot,
     /// the way a shell drives the producer.
@@ -1610,8 +1617,17 @@ mod tests {
             total: 3,
             failed: vec![("a.glb".to_string(), "404".to_string())],
         };
-        run_assets_frame(&session, &mut model, Some(settled), &mut delivered, 1.3);
+        run_assets_frame(&session, &mut model, Some(settled.clone()), &mut delivered, 1.3);
         assert_model(&session, &model, "expectedSettled");
+
+        // A time-travel branch restores an older model and INVALIDATES the
+        // delivered marker (before_physics / rewind_scene_to): the next frame
+        // redelivers the unchanged current snapshot, so a rewound loading
+        // screen learns its assets already settled.
+        let mut rewound = session.global("init").expect("init");
+        delivered = None;
+        run_assets_frame(&session, &mut rewound, Some(settled), &mut delivered, 1.4);
+        assert_model(&session, &rewound, "expectedFirstSettled");
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -30,12 +30,14 @@ use std::collections::HashSet;
 use functor_lang::{line_col, project::SourceMap, RunError, Session, Span, Value};
 
 use crate::functor_lang_prelude::{
-    contains_effect, deliver_physics_events, drain_effects, frame_value, http_response_value,
+    asset_progress_value, assets_taggers, contains_effect, deliver_physics_events, drain_effects,
+    frame_value, http_response_value,
     needs_update, net_conn_subs, net_event_value, perform_deferred_queries, physics_event_taggers,
     physics_scene_value, split_model_effect, sub_messages_for_frame, take_audio_completion,
     take_http_tagger, take_ui_handlers, DryRunEffects, EffectLog, EffectRunner, EffectTree,
     FunctorHost, NetEventKind, UiHandler,
 };
+use crate::asset::AssetProgress;
 use crate::input::RecordedInput;
 use crate::net::{push_conn_command, ConnCommand, HttpResult};
 use crate::physics::{self, PhysicsEvent, SteppedPhysics};
@@ -317,6 +319,15 @@ pub struct FrameCtx<'a> {
     pub input_buf: &'a mut Vec<RecordedInput>,
     pub has_physics: bool,
     pub has_subscriptions: bool,
+    /// The shell's current asset-loading snapshot (`AssetCache::progress()`),
+    /// `None` when the driver doesn't track assets (dry-run forward-step,
+    /// headless tests). Compared against `delivered_asset_progress` each frame;
+    /// a change fires the `Sub.assets` taggers through `update`.
+    pub asset_progress: Option<AssetProgress>,
+    /// The snapshot the game last saw (shell-owned so it survives frames; only
+    /// advanced when a `Sub.assets` tagger actually received it, so a game
+    /// that ADDS the sub later — hot reload — still gets the current state).
+    pub delivered_asset_progress: &'a mut Option<AssetProgress>,
     /// Suppress OUTBOUND effects (physics command / timeline / send / http /
     /// audio) during a dry-run forward-step (docs/time-travel.md T6b): they
     /// still log and the model still evolves, but nothing escapes to the live
@@ -702,6 +713,9 @@ to receive their messages; dropping them"
         // Reconcile connections EVERY frame — including frame one (before the
         // timer window exists), so a declared connection opens immediately.
         self.reconcile_connections(&subs);
+        // Asset progress also delivers on frame one: a loading screen wants
+        // the initial snapshot, not the first change after it.
+        self.deliver_asset_progress(&subs);
         let Some(prev) = prev else {
             return;
         };
@@ -717,6 +731,49 @@ to receive their messages; dropping them"
                 Err(err) => self.reporter.frame_error("update", &err),
             }
         }
+    }
+
+    /// Fire the `Sub.assets` taggers when the shell's loading snapshot changed
+    /// since the game last saw it, folding `tagger({loaded, total, failed})`
+    /// through `update` — the loading-screen seam. No taggers subscribed
+    /// leaves `delivered` unmarked, so a game that adds `Sub.assets` later
+    /// (hot reload) still receives the current state on its first frame.
+    fn deliver_asset_progress(&mut self, subs: &Value) {
+        let Some(progress) = self.asset_progress.clone() else {
+            return;
+        };
+        if self.delivered_asset_progress.as_ref() == Some(&progress) {
+            return;
+        }
+        let taggers = match assets_taggers(subs) {
+            Ok(taggers) => taggers,
+            Err(message) => return self.reporter.report_once(format!("[functor-lang] {message}")),
+        };
+        if taggers.is_empty() {
+            return;
+        }
+        let record = asset_progress_value(&progress);
+        for tagger in taggers {
+            let msg = match self.session.apply(
+                tagger,
+                vec![record.clone()],
+                "Sub.assets tagger",
+                &mut FunctorHost,
+            ) {
+                Ok(msg) => msg,
+                Err(err) => {
+                    self.reporter.frame_error("Sub.assets tagger", &err);
+                    continue;
+                }
+            };
+            let args = vec![self.model.clone(), msg];
+            journal_push("update", &args, Provenance::Subscription);
+            match self.session.call("update", args, &mut FunctorHost) {
+                Ok(returned) => self.absorb(returned),
+                Err(err) => self.reporter.frame_error("update", &err),
+            }
+        }
+        *self.delivered_asset_progress = Some(progress);
     }
 
     /// The frame's physics phase (docs/physics.md): ask the game what bodies
@@ -1056,6 +1113,8 @@ pub fn forward_step_scene(
     // Throwaway input buffer: the forward-step replays `inputs` directly and
     // never records, so this stays empty — it just satisfies the borrow.
     let mut input_buf: Vec<RecordedInput> = Vec::new();
+    // The dry run never tracks assets: no snapshot, throwaway delivered slot.
+    let mut delivered_asset_progress: Option<AssetProgress> = None;
     let mut reporter = Reporter::new(
         SpanSource::Single {
             src: String::new(),
@@ -1080,6 +1139,8 @@ pub fn forward_step_scene(
             input_buf: &mut input_buf,
             has_physics,
             has_subscriptions,
+            asset_progress: None,
+            delivered_asset_progress: &mut delivered_asset_progress,
             suppress_outbound: true,
             reporter: &mut reporter,
         };
@@ -1254,6 +1315,7 @@ mod tests {
         let mut live_conn_keys: HashSet<String> = HashSet::new();
         let mut prev_tts: Option<f64> = None;
         let mut input_buf: Vec<RecordedInput> = Vec::new();
+        let mut delivered_asset_progress: Option<AssetProgress> = None;
         let mut reporter = Reporter::new(
             SpanSource::Single {
                 src: String::new(),
@@ -1276,6 +1338,8 @@ mod tests {
             input_buf: &mut input_buf,
             has_physics: false,
             has_subscriptions: false,
+            asset_progress: None,
+            delivered_asset_progress: &mut delivered_asset_progress,
             suppress_outbound: false,
             reporter: &mut reporter,
         };
@@ -1416,6 +1480,7 @@ mod tests {
         // fires the `Sub.every` timer.
         let mut prev_tts: Option<f64> = Some(0.9);
         let mut input_buf: Vec<RecordedInput> = Vec::new();
+        let mut delivered_asset_progress: Option<AssetProgress> = None;
         let mut reporter = Reporter::new(
             SpanSource::Single {
                 src: INSPECTOR_SRC.to_string(),
@@ -1438,6 +1503,8 @@ mod tests {
             input_buf: &mut input_buf,
             has_physics: false,
             has_subscriptions: true,
+            asset_progress: None,
+            delivered_asset_progress: &mut delivered_asset_progress,
             suppress_outbound: false,
             reporter: &mut reporter,
         };
@@ -1445,6 +1512,99 @@ mod tests {
             dts: 0.2,
             tts: 1.1,
         });
+    }
+
+    const ASSETS_SRC: &str = "\
+        let init = { count: 0.0, loaded: 99.0, total: 99.0, failedCount: 99.0 }\n\
+        let update = (m, p) =>\n\
+          { count: m.count + 1.0, loaded: p.loaded, total: p.total,\n\
+            failedCount: List.length(p.failed) }\n\
+        let subscriptions = (m) => Sub.assets((p) => p)\n\
+        let tick = (m, dt, tts) => m\n\
+        let expectedFirst = { count: 1.0, loaded: 1.0, total: 3.0, failedCount: 1.0 }\n\
+        let expectedSettled = { count: 2.0, loaded: 3.0, total: 3.0, failedCount: 1.0 }\n";
+
+    /// Run one frame (subscriptions + tick) with the given shell snapshot,
+    /// the way a shell drives the producer.
+    fn run_assets_frame(
+        session: &Session,
+        model: &mut Value,
+        progress: Option<AssetProgress>,
+        delivered: &mut Option<AssetProgress>,
+        tts: f64,
+    ) {
+        let mut physics_rt = SteppedPhysics::new();
+        let mut physics_frame = 0u64;
+        let mut recorder = SceneRecorder::new();
+        let mut effect_runner = DryRunEffects::new();
+        let mut effect_log = EffectLog::new();
+        let mut deferred_queries: Vec<EffectTree> = Vec::new();
+        let mut pending_events: Vec<PhysicsEvent> = Vec::new();
+        let mut live_conn_keys: HashSet<String> = HashSet::new();
+        let mut prev_tts: Option<f64> = Some(tts - 0.1);
+        let mut input_buf: Vec<RecordedInput> = Vec::new();
+        let mut reporter = Reporter::new(
+            SpanSource::Single {
+                src: ASSETS_SRC.to_string(),
+                path: "game".to_string(),
+            },
+            silent_emit,
+        );
+        let mut ctx = FrameCtx {
+            session,
+            model,
+            physics_rt: &mut physics_rt,
+            physics_frame: &mut physics_frame,
+            recorder: &mut recorder,
+            effect_runner: &mut effect_runner as &mut dyn EffectRunner,
+            effect_log: &mut effect_log,
+            deferred_queries: &mut deferred_queries,
+            pending_events: &mut pending_events,
+            live_conn_keys: &mut live_conn_keys,
+            prev_tts: &mut prev_tts,
+            input_buf: &mut input_buf,
+            has_physics: false,
+            has_subscriptions: true,
+            asset_progress: progress,
+            delivered_asset_progress: delivered,
+            suppress_outbound: false,
+            reporter: &mut reporter,
+        };
+        ctx.before_physics(FrameTime { dts: 0.1, tts: tts as f32 });
+    }
+
+    /// `Sub.assets` delivers the snapshot through `update` exactly when it
+    /// changes: on the first sighting, NOT on an identical frame, and again
+    /// when loading settles.
+    #[test]
+    fn asset_progress_flows_to_update_once_per_change() {
+        let project = functor_lang::project::load_single_source("game", ASSETS_SRC)
+            .unwrap_or_else(|e| panic!("load: {}", e.render()));
+        let session = Session::load(&project.module, &mut FunctorHost)
+            .unwrap_or_else(|f| panic!("session: {}", f.error.message));
+        let mut model = session.global("init").expect("init");
+        let mut delivered: Option<AssetProgress> = None;
+
+        let loading = AssetProgress {
+            loaded: 1,
+            total: 3,
+            failed: vec![("a.glb".to_string(), "404".to_string())],
+        };
+        run_assets_frame(&session, &mut model, Some(loading.clone()), &mut delivered, 1.1);
+        assert_model(&session, &model, "expectedFirst");
+
+        // Same snapshot: no redelivery (count stays 1).
+        run_assets_frame(&session, &mut model, Some(loading), &mut delivered, 1.2);
+        assert_model(&session, &model, "expectedFirst");
+
+        // Loading settles: the change delivers once more.
+        let settled = AssetProgress {
+            loaded: 3,
+            total: 3,
+            failed: vec![("a.glb".to_string(), "404".to_string())],
+        };
+        run_assets_frame(&session, &mut model, Some(settled), &mut delivered, 1.3);
+        assert_model(&session, &model, "expectedSettled");
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/io/mod.rs
+++ b/runtime/functor-runtime-common/src/io/mod.rs
@@ -73,19 +73,75 @@ pub async fn load_bytes_async2(path: String) -> Result<Vec<u8>, String> {
     }
     #[cfg(not(target_arch = "wasm32"))]
     {
-        // Remote (URL) assets download off-thread through the shell's installed
-        // fetcher and land over a channel — the future stays Pending until the
-        // download completes, so a CDN transfer never stalls the render thread.
-        if is_remote_path(&path) {
-            return remote::fetch(&path).await.map_err(|e| format!("{}: {}", path, e));
+        let bytes = if is_remote_path(&path) {
+            // Remote (URL) assets download off-thread through the shell's
+            // installed fetcher and land over a channel — the future stays
+            // Pending until the download completes, so a CDN transfer never
+            // stalls the render thread.
+            remote::fetch(&path)
+                .await
+                .map_err(|e| format!("{}: {}", path, e))?
+        } else {
+            // AssetHandle polls asset futures manually with a noop waker, once
+            // per frame on the render thread. A chunked tokio::fs read only
+            // advances one chunk per poll under that scheme, so large assets
+            // took minutes to load natively (a 47MB glb ≈ thousands of
+            // frames). Until assets are driven by a real executor (see
+            // docs/todo.md "async inbox"), read synchronously: one frame hitch
+            // instead of a minutes-long stall.
+            std::fs::read(&path).map_err(|e| format!("{}: {}", path, e))?
+        };
+        // Simulated slow network (dev): FUNCTOR_THROTTLE_ASSETS=<KB/s> holds
+        // the loaded bytes until size/rate has elapsed, so loading UX
+        // (Sub.assets progress bars, fallback placeholders) is actually
+        // visible on a machine where every load is otherwise instant.
+        if let Some(kbps) = throttle_kbps() {
+            let seconds = bytes.len() as f64 / (kbps * 1024.0);
+            throttle::DelayUntil {
+                deadline: std::time::Instant::now() + std::time::Duration::from_secs_f64(seconds),
+            }
+            .await;
         }
-        // AssetHandle polls asset futures manually with a noop waker, once per
-        // frame on the render thread. A chunked tokio::fs read only advances one
-        // chunk per poll under that scheme, so large assets took minutes to load
-        // natively (a 47MB glb ≈ thousands of frames). Until assets are driven by
-        // a real executor (see docs/todo.md "async inbox"), read synchronously:
-        // one frame hitch instead of a minutes-long stall.
-        std::fs::read(&path).map_err(|e| format!("{}: {}", path, e))
+        Ok(bytes)
+    }
+}
+
+/// See the FUNCTOR_THROTTLE_ASSETS comment in [`load_bytes_async2`].
+#[cfg(not(target_arch = "wasm32"))]
+fn throttle_kbps() -> Option<f64> {
+    std::env::var("FUNCTOR_THROTTLE_ASSETS")
+        .ok()?
+        .parse::<f64>()
+        .ok()
+        .filter(|kbps| *kbps > 0.0)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+mod throttle {
+    use std::{
+        future::Future,
+        pin::Pin,
+        task::{Context, Poll},
+        time::Instant,
+    };
+
+    /// Pending until the deadline passes. Never registers a waker — like the
+    /// asset futures it delays, it relies on the once-per-frame manual polling
+    /// in `AssetHandle::poll_load` (a parked executor would hang on it).
+    pub struct DelayUntil {
+        pub deadline: Instant,
+    }
+
+    impl Future for DelayUntil {
+        type Output = ();
+
+        fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+            if Instant::now() >= self.deadline {
+                Poll::Ready(())
+            } else {
+                Poll::Pending
+            }
+        }
     }
 }
 

--- a/runtime/functor-runtime-common/src/io/mod.rs
+++ b/runtime/functor-runtime-common/src/io/mod.rs
@@ -96,7 +96,10 @@ pub async fn load_bytes_async2(path: String) -> Result<Vec<u8>, String> {
         // (Sub.assets progress bars, fallback placeholders) is actually
         // visible on a machine where every load is otherwise instant.
         if let Some(kbps) = throttle_kbps() {
-            let seconds = bytes.len() as f64 / (kbps * 1024.0);
+            // Clamp to a day: an absurdly small rate must not overflow
+            // Duration (a panic on the render thread) — it just hangs the
+            // load, which is what the user asked for.
+            let seconds = (bytes.len() as f64 / (kbps * 1024.0)).min(24.0 * 3600.0);
             throttle::DelayUntil {
                 deadline: std::time::Instant::now() + std::time::Duration::from_secs_f64(seconds),
             }

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -264,6 +264,13 @@ pub trait GameProducer {
     /// Deliver a transport-level failure for a request into the async inbox.
     fn net_push_http_error(&mut self, token: i32, message: String);
 
+    /// Push the shell's current asset-loading snapshot
+    /// ([`crate::asset::AssetCache::progress`]); a change fires the game's
+    /// `Sub.assets` taggers with the frame's subscription messages. Default:
+    /// no-op (drivers without an asset cache — replay, netsim — have nothing
+    /// to report).
+    fn push_asset_progress(&mut self, _progress: crate::asset::AssetProgress) {}
+
     /// Take the audio commands the game queued this frame (a JSON array of
     /// [`crate::audio::AudioCommand`]). The shell plays them on its device.
     fn audio_drain_commands(&self) -> String;

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -78,6 +78,10 @@ pub struct FunctorLangGame {
     /// state, not model state: it survives a hot reload, and the stateless
     /// time-grid semantics of `Sub.every` do the rest.
     prev_tts: Option<f64>,
+    /// The shell's latest asset-loading snapshot (pushed each frame by the
+    /// run loop) and the one the game last saw — the `Sub.assets` seam.
+    asset_progress: Option<functor_runtime_common::asset::AssetProgress>,
+    delivered_asset_progress: Option<functor_runtime_common::asset::AssetProgress>,
     has_physics: bool,
     /// The game defines the optional `soundScape` entry point
     /// (`soundScape(model) -> AudioScene`, the continuous-audio hook). Absent =
@@ -404,6 +408,8 @@ impl FunctorLangGame {
             recorder: SceneRecorder::new(),
             input_buf: Vec::new(),
             live_conn_keys: std::collections::HashSet::new(),
+            asset_progress: None,
+            delivered_asset_progress: None,
             last_frame: empty_frame(),
             reporter: Reporter::new(SpanSource::Project(loaded.sources), report_to_stderr),
             last_frame_journal: Vec::new(),
@@ -438,6 +444,8 @@ impl FunctorLangGame {
             input_buf: &mut self.input_buf,
             has_physics: self.has_physics,
             has_subscriptions: self.has_subscriptions,
+            asset_progress: self.asset_progress.clone(),
+            delivered_asset_progress: &mut self.delivered_asset_progress,
             suppress_outbound: false,
             reporter: &mut self.reporter,
         }
@@ -1006,6 +1014,11 @@ AudioScene.empty), got {}",
         // HttpRequest commands (Effect.httpGet/httpPost), performed by the
         // shell's net_dispatch; the response returns via net_push_http_*.
         functor_runtime_common::net::drain_commands_json()
+    }
+    fn push_asset_progress(&mut self, progress: functor_runtime_common::asset::AssetProgress) {
+        // Stored, not delivered here: the producer compares it against what
+        // the game last saw during the frame's subscription phase.
+        self.asset_progress = Some(progress);
     }
     fn net_push_http_response(&mut self, token: i32, status: i32, body: String) {
         self.ctx()

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -671,6 +671,9 @@ impl Game for FunctorLangGame {
             // the reload discipline); between-frame callers have these empty.
             self.deferred_queries.clear();
             self.pending_events.clear();
+            // The restored model predates the current loading snapshot —
+            // redeliver it on the next frame (see before_physics).
+            self.delivered_asset_progress = None;
             clear_http_taggers();
             clear_audio_completions();
             // The paused frame moved to `target`, for which we hold no journal

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -1062,6 +1062,10 @@ pub fn run(args: Args) {
 
             game.check_hot_reload(time.clone());
 
+            // The loading snapshot for `Sub.assets`: pushed every frame, the
+            // producer only acts when it changed since the game last saw it.
+            game.push_asset_progress(asset_cache.progress());
+
             // Asset hot-reload, the twin of the .fun check above: a model/
             // texture saved on disk is evicted from the caches so the next
             // draw re-reads and re-decodes it. Throttled: unlike the handful

--- a/runtime/functor-runtime-web/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-web/src/functor_lang_game.rs
@@ -61,6 +61,10 @@ pub struct FunctorLangWebGame {
     /// (nothing fires on frame one — mirroring the F# executor and the
     /// desktop producer).
     prev_tts: Option<f64>,
+    /// The shell's latest asset-loading snapshot (pushed each frame by the
+    /// render loop) and the one the game last saw — the `Sub.assets` seam.
+    asset_progress: Option<functor_runtime_common::asset::AssetProgress>,
+    delivered_asset_progress: Option<functor_runtime_common::asset::AssetProgress>,
     has_physics: bool,
     /// The game defines the optional `soundScape` entry point
     /// (`soundScape(model) -> AudioScene`, the continuous-audio hook). Absent =
@@ -374,6 +378,8 @@ impl FunctorLangWebGame {
             recorder: SceneRecorder::new(),
             input_buf: Vec::new(),
             live_conn_keys: std::collections::HashSet::new(),
+            asset_progress: None,
+            delivered_asset_progress: None,
             has_physics: loaded.has_physics,
             has_soundscape: loaded.has_soundscape,
             last_soundscape_json: empty_soundscape_json(),
@@ -493,6 +499,8 @@ impl FunctorLangWebGame {
             input_buf: &mut self.input_buf,
             has_physics: self.has_physics,
             has_subscriptions: self.has_subscriptions,
+            asset_progress: self.asset_progress.clone(),
+            delivered_asset_progress: &mut self.delivered_asset_progress,
             suppress_outbound: false,
             reporter: &mut self.reporter,
         }
@@ -503,6 +511,12 @@ impl GameProducer for FunctorLangWebGame {
     // File-watch hot reload is native-only (docs/functor-lang.md C3) — there is no
     // filesystem here. The PUSH path below is the web's reload.
     fn check_hot_reload(&mut self, _frame_time: FrameTime) {}
+
+    fn push_asset_progress(&mut self, progress: functor_runtime_common::asset::AssetProgress) {
+        // Stored, not delivered here: the producer compares it against what
+        // the game last saw during the frame's subscription phase.
+        self.asset_progress = Some(progress);
+    }
 
     fn reload_source(&mut self, source: &str) -> Result<String, String> {
         // The editor push path (docs/functor-lang.md D4), same semantics as the

--- a/runtime/functor-runtime-web/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-web/src/functor_lang_game.rs
@@ -593,6 +593,9 @@ impl GameProducer for FunctorLangWebGame {
         if result.is_ok() {
             self.deferred_queries.clear();
             self.pending_events.clear();
+            // The restored model predates the current loading snapshot —
+            // redeliver it on the next frame (see before_physics).
+            self.delivered_asset_progress = None;
             // Model restored to `target`; drop orphaned buffered input so it can't
             // record into the branch (fixed-timestep 0-substep buffering, xreview).
             self.input_buf.clear();

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -1278,6 +1278,10 @@ async fn run_async() -> Result<(), JsValue> {
             // draining stops the queue bursting on resume.
             functor_lang_game::drain_input(&mut **game, !clock.is_pinned());
 
+            // The loading snapshot for `Sub.assets`: pushed every frame, the
+            // producer only acts when it changed since the game last saw it.
+            game.push_asset_progress(asset_cache.progress());
+
             for sub in &sub_frames {
                 game.tick(sub.clone());
             }


### PR DESCRIPTION
## What

Clickstop 2 of the asset-handling revamp: **game code can watch assets load, purely, as data** — and the loading-screen demo built on it.

```fun
subscriptions = (model) => Sub.assets((p) => p)
update = (model, p) =>
  { model with done: p.total > 0.0 && p.loaded + List.length(p.failed) == p.total }
draw = (model, tts) => if model.done then game(model) else loadingScreen(model)
```

Three commits + review fixes:

1. **`AssetCache::progress()`** — `{loaded, total, failed: [(path, error)]}` accounting at the load seams. Decode fallbacks count as loaded (the asset *settled*); only byte-load failures (missing file, HTTP error, bad remote body) are failures. Hot-reload eviction returns a path to pending until its reload settles.
2. **`Sub.assets(tagger)`** — a new `SubTree` variant beside the `PhysicsEvents` precedent. The shells push the snapshot across the `GameProducer` trait each frame (default no-op for replay/netsim drivers); the **shared** producer compares it against what the game last saw and folds `tagger({loaded, total, failed})` through `update` with the frame's subscription messages — so native and wasm behave identically. Delivers the *initial* snapshot on frame one (a loading screen wants current state, not the first change), and re-delivers current state to a game that adds the sub over hot reload. Journaled with `Provenance::Subscription` like physics/net events, so the paused inspector and replay see it; the ghost forward-step carries no snapshot and never fires it.
3. **`examples/loading` + `FUNCTOR_THROTTLE_ASSETS`** — three CDN models of deliberately mixed sizes (2KB box, 2.9MB barrel, 15MB shark) stream in while a progress bar + HUD count track them; failures count toward settling so the screen always ends. `FUNCTOR_THROTTLE_ASSETS=<KB/s>` (native) simulates a slow network — the backlog's missing mode, without which loading UX is invisible on a dev machine.

## Verification

- Producer test: three frames through the real delivery path — first sighting delivers, an identical frame doesn't, settling delivers again. The funi drift test pins the `Sub.assets` signature.
- 297 common + 48 desktop tests green; both wasm targets check clean; `functor build` typechecks the example.
- Live captures of the full lifecycle: `Loading 0 / 3` with an empty bar (cold cache, throttled) → `Loading 2 / 3` with the bar two-thirds green and models popped in → `Ready!` with the bar gone.

## Review dispositions (cross-engine, adversarial)

- **Fixed**: the documented settled-gate (`loaded == total`) contradicted the example and hangs on any failed asset — all four doc sites now teach `total > 0 && loaded + failed == total`; a tiny throttle rate overflowed `Duration` (render-thread panic) — clamped; a transient tagger error permanently swallowed a snapshot — the delivered marker now only advances on actual delivery.
- **Noted**: `Sub.assets` never fires under `--headless` (no asset cache there) — added to `docs/todo.md`; progress sets grow unboundedly over a long streaming session — same class as the planned cache-eviction work.

## Demo

![examples/loading demo](https://gist.githubusercontent.com/tommy-xr/f01b7a4ef035721f08b94dd28baa5ec6/raw/pr378-demo.gif)

<sub>examples/loading under `FUNCTOR_THROTTLE_ASSETS=600`: three CDN models settle in size order while the Sub.assets-driven bar fills; failures would count toward settling so the screen always ends. Captured from one continuous run via the debug server.</sub>

![settled Ready! state](https://gist.githubusercontent.com/tommy-xr/f01b7a4ef035721f08b94dd28baa5ec6/raw/pr378-ready.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
