### PR TITLE
feat(runtime): journal ring + per-frame execution coverage on the trace

### DIFF
--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -62,7 +62,7 @@ screenshot run has no reason to grab your mouse.
 | `POST /capture` | PNG (`image/png`) of the next rendered frame |
 | `GET /state` | runtime state JSON: `frame`, `tts`, `viewport`, `input` (structured `held_keys` + `mouse`), `model` (Rust `Debug` text) |
 | `GET /scene` | current frame as JSON: `camera` + `scene` + `lights` |
-| `GET /trace` | paused-inspector trace: the last real frame's entry-point invocations plus a synthesized `draw` pass, replayed while paused. Each site (binders AND variable reads, `site`) carries the full `value`, a depth-limited `preview`, and `kind` (primitive/composite — the editor's inline-vs-hover policy); `{ "paused": false, "invocations": [] }` while playing |
+| `GET /trace` | paused-inspector trace: the last real frame's entry-point invocations plus a synthesized `draw` pass, replayed while paused. Each site (binders AND variable reads, `site`) carries the full `value`, a depth-limited `preview`, and `kind` (primitive/composite — the editor's inline-vs-hover policy); `{ "paused": false, "invocations": [] }` while playing. Paused docs also carry `coverage` (per-file span starts with the frame OFFSETS they executed on, over a ±120-frame journal ring — positive offsets appear when scrubbed behind the live head) and `runnable` (the static could-run set) — the recency gutter's data |
 | `POST /input` | inject input (see below) |
 | `POST /time` | control the frame clock (see below) |
 | `POST /reload-source` | swap game logic from the request body (see below) |

--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -1287,6 +1287,98 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
   await page.close();
 }
 
+// --- 12d. The execution-recency gutter. ----------------------------------------
+// A parity-conditional program makes every gutter state deterministic: the
+// even/odd arms alternate per frame, and a never-true branch stays dark.
+// Pausing shows green (ran this frame) vs cyan (ran a frame before); scrubbing
+// BACK one frame swaps the arms' colors and turns pink on (ran after).
+{
+  // A frame-counter threshold: the EARLY arm runs on frames n<60, the LATE
+  // arm after; `never` requires hp < 0 — unreachable (statically runnable →
+  // dark). Unique arm texts so line lookup can't collide with init.
+  const PARITY = `let init = { n: 0.0, hp: 1.0 }
+let tick = (model, dt: Float, tts: Float) =>
+  match model.hp < 0.0 with
+  | true => { n: model.n, hp: 0.0 }
+  | false =>
+    match model.n < 60.0 with
+    | true => { n: model.n + 1.0, hp: 1.0 }
+    | false => { n: model.n + 1.0, hp: 2.0 }
+let draw = (model, tts: Float) =>
+  Frame.create(
+    Camera.lookAt(0.0, 0.0, -6.0, 0.0, 0.0, 0.0),
+    Scene.sphere() |> Scene.emissive(Color.rgb(0.1, 1.0, 0.2)))
+`;
+  const b64u = Buffer.from(PARITY).toString("base64url");
+  const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+  await page.goto(`${BASE}/sandbox.html#src=${b64u}`);
+  await page.waitForFunction(
+    () => window.__sandbox && window.__sandbox.status().state === "live",
+    { timeout: 30000 }
+  );
+  await page.waitForFunction(() => window.__lang && window.__lang.ready, { timeout: 15000 });
+
+  const waitFor = async (fn, pred, timeout = 10000) => {
+    const t0 = Date.now();
+    for (;;) {
+      const v = await fn();
+      if (pred(v)) return v;
+      if (Date.now() - t0 > timeout) return v;
+      await sleep(150);
+    }
+  };
+  const lineOf = (needle) => PARITY.slice(0, PARITY.indexOf(needle)).split("\n").length;
+  const earlyLine = lineOf("{ n: model.n + 1.0, hp: 1.0 }"); // frames n<60
+  const lateLine = lineOf("{ n: model.n + 1.0, hp: 2.0 }"); // frames n>=60
+  const neverLine = lineOf("{ n: model.n, hp: 0.0 }");
+
+  // Run past the threshold, then pause: the late arm is CURRENT (green),
+  // the early arm history (cyan), the unreachable arm dark.
+  const player = playerFrame(page);
+  await player.waitForFunction(
+    () => window.__scrub && window.__scrub.range().length === 2 && window.__scrub.range()[1] > 80,
+    { timeout: 30000 }
+  );
+  await player.evaluate(() => document.getElementById("scrub-pause")?.click());
+  const cov = await waitFor(
+    () => page.evaluate(() => window.__lang.coverage()),
+    (c) => c[lateLine] === "now"
+  );
+  check("current arm is green", cov[lateLine] === "now", JSON.stringify(cov));
+  check("pre-threshold arm is cyan (ran before)", cov[earlyLine] === "before", JSON.stringify(cov));
+  check("never-taken branch is dark", cov[neverLine] === "dark", JSON.stringify(cov));
+  // Gutter markers are real DOM (the viewport shows them all here).
+  const domStates = await page.evaluate(() =>
+    [...document.querySelectorAll(".cm-cov")].map((el) => el.className)
+  );
+  check(
+    "gutter renders now/before/dark markers",
+    ["now", "before", "dark"].every((s) => domStates.some((c) => c.includes(`cm-cov-${s}`))),
+    JSON.stringify(domStates.slice(0, 6))
+  );
+
+  // Scrub back BEFORE the threshold (frame 10): the early arm becomes this
+  // frame's (green — its coverage comes from the ring, the scrubbed-frame
+  // path) and the late arm ran only in frames AFTER the paused one → pink.
+  await player.evaluate(() => window.__scrub.seek(10));
+  const scrubbed = await waitFor(
+    () => page.evaluate(() => window.__lang.coverage()),
+    (c) => c[earlyLine] === "now"
+  );
+  check(
+    "scrubbed back: the early arm is green from the ring",
+    scrubbed[earlyLine] === "now",
+    JSON.stringify(scrubbed)
+  );
+  check(
+    "scrubbed back: the post-threshold arm is pink (ran after)",
+    scrubbed[lateLine] === "after",
+    JSON.stringify(scrubbed)
+  );
+
+  await page.close();
+}
+
 // --- 13. Scope-aware autocomplete in the editor (commit 8b). ------------------
 // The completion source is backed by the wasm's scope-aware `complete`, driven
 // through the __sandbox.triggerComplete seam (insert text + set cursor + open

--- a/functor-lang/src/coverage.rs
+++ b/functor-lang/src/coverage.rs
@@ -1,0 +1,76 @@
+//! Static execution-coverage support: the set of RUNNABLE positions.
+//!
+//! The paused inspector's recency gutter colors lines by when they last ran
+//! (this frame / an earlier frame / a later frame). The fourth state —
+//! "runnable but did NOT run in the window" (the un-taken match arm, the
+//! false branch) — can't come from runtime coverage alone: a never-executed
+//! expression appears in no frame's set. This walk enumerates every
+//! expression span start in the module, statically, so the consumer knows
+//! which positions COULD run. Mirrors the inlay/hover walk (Lambda bodies
+//! and Match arms special-cased, everything else through
+//! [`crate::hover::children`]) so the three walks stay in lockstep.
+
+use crate::ir::{Expr, ExprKind, Module};
+
+/// Every expression span start in the module's defs, sorted and deduped —
+/// the static "could run" set the runtime pairs with per-frame coverage.
+pub fn runnable_offsets(module: &Module) -> Vec<usize> {
+    let mut out = Vec::new();
+    for def in &module.defs {
+        visit(&def.value, &mut out);
+    }
+    out.sort_unstable();
+    out.dedup();
+    out
+}
+
+fn visit(expr: &Expr, out: &mut Vec<usize>) {
+    out.push(expr.span.start);
+    match &expr.kind {
+        ExprKind::Lambda { body, .. } => visit(body, out),
+        ExprKind::Match { scrutinee, arms } => {
+            visit(scrutinee, out);
+            for arm in arms {
+                visit(&arm.body, out);
+            }
+        }
+        _ => {
+            for child in crate::hover::children(expr) {
+                visit(child, out);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Both match arms are runnable, statically — even though any single run
+    // takes only one. The un-taken arm is exactly what the gutter's "dark"
+    // state needs.
+    #[test]
+    fn match_arms_are_all_runnable() {
+        let src = "let pick = (b) =>\n  match b with\n  | true => 1.0\n  | false => 2.0";
+        let program = crate::parse(src).expect("parse");
+        let module = crate::lower(program).expect("lower");
+        let offsets = runnable_offsets(&module);
+
+        let one = src.find("1.0").unwrap();
+        let two = src.find("2.0").unwrap();
+        assert!(offsets.contains(&one), "taken-arm body is runnable");
+        assert!(offsets.contains(&two), "un-taken-arm body is runnable too");
+        // Sorted + deduped.
+        assert!(offsets.windows(2).all(|w| w[0] < w[1]));
+    }
+
+    // Lambda bodies (the walk's special case) are included.
+    #[test]
+    fn lambda_bodies_are_runnable() {
+        let src = "let f = (x) => x + 1.0";
+        let program = crate::parse(src).expect("parse");
+        let module = crate::lower(program).expect("lower");
+        let offsets = runnable_offsets(&module);
+        assert!(offsets.contains(&src.find("x + 1.0").unwrap()));
+    }
+}

--- a/functor-lang/src/eval.rs
+++ b/functor-lang/src/eval.rs
@@ -124,6 +124,9 @@ pub struct RecordedInvocation {
     pub result_preview: String,
     /// One entry per distinct binding site reached, in first-seen order.
     pub bindings: Vec<RecordedBinding>,
+    /// Sorted span starts of every expression evaluated during the call —
+    /// the execution-coverage set (which lines / match arms / branches ran).
+    pub coverage: Vec<usize>,
     /// The recorder hit a cap during this call — `bindings` is partial (but
     /// `result` is exact; recording never changes evaluation).
     pub truncated: bool,
@@ -202,10 +205,19 @@ struct Recorder {
     ref_sites: usize,
     events: usize,
     truncated: bool,
+    /// Span starts of every expression evaluated under this recorder — the
+    /// execution-coverage set (which lines/arms actually ran). Distinct
+    /// starts are static program positions, so the set is bounded by program
+    /// size; [`MAX_RECORDED_BINDINGS`] caps it defensively anyway.
+    coverage: std::collections::HashSet<usize>,
+    /// When false, only coverage collects — the values pass (Display
+    /// rendering, site bookkeeping) is skipped entirely. The cheap mode for
+    /// replaying a whole window of frames just to know what ran.
+    record_values: bool,
 }
 
 impl Recorder {
-    fn new() -> Recorder {
+    fn new(record_values: bool) -> Recorder {
         Recorder {
             bindings: Vec::new(),
             index: HashMap::new(),
@@ -213,14 +225,34 @@ impl Recorder {
             ref_sites: 0,
             events: 0,
             truncated: false,
+            coverage: std::collections::HashSet::new(),
+            record_values,
         }
+    }
+
+    /// Note an expression evaluation at `start` (its span start).
+    fn cover(&mut self, start: usize) {
+        if self.coverage.len() < MAX_RECORDED_BINDINGS {
+            self.coverage.insert(start);
+        }
+    }
+
+    /// The sorted coverage set.
+    fn coverage_sorted(&self) -> Vec<usize> {
+        let mut out: Vec<usize> = self.coverage.iter().copied().collect();
+        out.sort_unstable();
+        out
     }
 
     /// Record a value observed at a site. The event cap is a hard stop; a
     /// site-class cap only refuses NEW sites of that class — existing sites
     /// keep updating and the other class keeps recording, so a
-    /// reference-heavy body can't starve the binder record.
+    /// reference-heavy body can't starve the binder record. A no-op in
+    /// coverage-only mode.
     fn record(&mut self, key: SiteKey, site: RecordedSite, name: &str, span: Span, value: &Value) {
+        if !self.record_values {
+            return;
+        }
         if self.events >= MAX_RECORDED_BINDINGS {
             self.truncated = true;
             return;
@@ -439,21 +471,53 @@ impl Session {
             mut_slots: HashMap::new(),
             trace: Vec::new(),
             tracing: Tracing::Off,
-            recorder: Some(Recorder::new()),
+            recorder: Some(Recorder::new(true)),
             depth: 0,
             call_depth: 0,
             host,
         };
         let result = interp.call(callee, args, name.to_string(), Span::new(0, 0), None)?;
         let recorder = interp.recorder.expect("armed above");
+        let coverage = recorder.coverage_sorted();
         let invocation = RecordedInvocation {
             entry: name.to_string(),
             result: result.to_string(),
             result_preview: result.preview(),
             bindings: recorder.bindings,
+            coverage,
             truncated: recorder.truncated,
         };
         Ok((result, invocation))
+    }
+
+    /// Like [`Self::call_recorded`] but COVERAGE-ONLY: returns the sorted
+    /// span starts of every expression the call evaluated, skipping the
+    /// values pass entirely (no Display rendering, no site bookkeeping) —
+    /// the cheap mode for replaying a whole window of frames just to learn
+    /// which lines/arms ran.
+    pub fn call_covered(
+        &self,
+        name: &str,
+        args: Vec<Value>,
+        host: &mut dyn Host,
+    ) -> Result<(Value, Vec<usize>), RunError> {
+        let callee = self.globals.get(name).cloned().ok_or_else(|| RunError {
+            message: format!("no top-level `let {name}` in the module"),
+            span: Span::new(0, 0),
+        })?;
+        let mut interp = Interp {
+            globals: self.globals.clone(),
+            mut_slots: HashMap::new(),
+            trace: Vec::new(),
+            tracing: Tracing::Off,
+            recorder: Some(Recorder::new(false)),
+            depth: 0,
+            call_depth: 0,
+            host,
+        };
+        let result = interp.call(callee, args, name.to_string(), Span::new(0, 0), None)?;
+        let recorder = interp.recorder.expect("armed above");
+        Ok((result, recorder.coverage_sorted()))
     }
 }
 
@@ -528,6 +592,11 @@ evaluation depth."
                 ),
                 span: expr.span,
             });
+        }
+        // Coverage: one armed-check per evaluation (a `None` test when off —
+        // the same hot-path cost class as the binding-site hook).
+        if let Some(recorder) = &mut self.recorder {
+            recorder.cover(expr.span.start);
         }
         let result = self.eval_inner(expr, env);
         self.depth -= 1;

--- a/functor-lang/src/lib.rs
+++ b/functor-lang/src/lib.rs
@@ -14,6 +14,7 @@ pub mod complete;
 pub mod eval;
 pub mod goto;
 pub mod hover;
+pub mod coverage;
 pub mod inlay;
 pub mod ir;
 // Public for consumers that need raw string literals without evaluating

--- a/functor-lang/tests/recorder.rs
+++ b/functor-lang/tests/recorder.rs
@@ -337,6 +337,31 @@ fn empty_collections_are_primitive() {
 }
 
 #[test]
+fn coverage_records_the_taken_arm_only() {
+    // Runtime coverage is the recency gutter's data: the TAKEN match arm's
+    // span is covered, the un-taken arm's is not (statically both are
+    // runnable — see functor_lang::coverage::runnable_offsets).
+    let src = "let pick = (b) =>\n  match b with\n  | true => 1.0\n  | false => 2.0";
+    let session = session(src);
+    let taken = src.find("1.0").unwrap();
+    let untaken = src.find("2.0").unwrap();
+
+    let (_, inv) = session
+        .call_recorded("pick", vec![Value::Bool(true)], &mut NoHost)
+        .expect("call_recorded");
+    assert!(inv.coverage.contains(&taken), "taken arm covered: {:?}", inv.coverage);
+    assert!(!inv.coverage.contains(&untaken), "un-taken arm NOT covered");
+    assert!(inv.coverage.windows(2).all(|w| w[0] < w[1]), "sorted + deduped");
+
+    // The coverage-only mode agrees and still returns the exact result.
+    let (result, cov) = session
+        .call_covered("pick", vec![Value::Bool(true)], &mut NoHost)
+        .expect("call_covered");
+    assert_eq!(result.to_string(), "1");
+    assert_eq!(cov, inv.coverage);
+}
+
+#[test]
 fn cap_breach_truncates_but_result_is_exact() {
     // 60_000 elements × 2 closure params = 120_000 binding events, past the
     // 100_000 event cap — recording stops, `truncated` is set, and the fold

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -64,6 +64,7 @@ use crate::{Frame, FrameTime};
 /// lightweight provenance tag. The provenance STRING (the wire vocabulary) is
 /// derived from the tag + args only at trace-build time — never during play, so
 /// journaling renders no Display text.
+#[derive(Clone)]
 pub struct JournalEntry {
     /// The entry-point name — `tick` | `input` | `mouseMove` | `mouseWheel` |
     /// `update` (the wire contract's `entry`).

--- a/runtime/functor-runtime-common/src/inspector.rs
+++ b/runtime/functor-runtime-common/src/inspector.rs
@@ -102,7 +102,7 @@ fn build_invocations(
     draw_args: Option<&[Value]>,
     sources: &[InspectorSource],
     session: &Session,
-) -> Vec<serde_json::Value> {
+) -> (Vec<serde_json::Value>, Vec<usize>) {
     use std::collections::HashMap;
     // Replay FIRST, then frame: `index`/`count` are computed over the
     // invocations actually EMITTED, so the array is always consistent with its
@@ -176,7 +176,15 @@ fn build_invocations(
             "bindings": bindings,
         }));
     }
-    out
+    // The paused frame's coverage rides along free (every values replay
+    // collected it, draw included) — merged and deduped for coverage_json.
+    let mut frame_coverage: Vec<usize> = replayed
+        .iter()
+        .flat_map(|(_, _, inv)| inv.coverage.iter().copied())
+        .collect();
+    frame_coverage.sort_unstable();
+    frame_coverage.dedup();
+    (out, frame_coverage)
 }
 
 /// The wire strings for the recorder's site/kind enums.
@@ -211,6 +219,39 @@ pub fn build_trace_doc(
     draw_args: Option<&[Value]>,
     session: &Session,
 ) -> String {
+    build_trace_doc_with_coverage(
+        paused, frame, tts, sources, journal, draw_args, &[], &[], session,
+    )
+}
+
+/// [`build_trace_doc`] plus the recency-gutter data (visual-debugger v2 PR4):
+///
+/// - `ring` is a window of recent frames' journals `(frame, entries)` — the
+///   coverage source. Each ringed frame replays COVERAGE-ONLY
+///   (`Session::call_covered`: no Display rendering), yielding
+///   `"coverage": { file: [ { "start": N, "frames": [-2, 0, 3] } ] }` —
+///   per-file span starts with the sorted frame OFFSETS (ringFrame − frame)
+///   they executed on. Offsets can be positive when the paused frame is
+///   scrubbed behind the live head (the gutter's "ran in a frame after").
+///   The paused frame's own coverage comes free from the values replay
+///   (including draw); other frames' draw passes are not replayed (their
+///   models aren't journaled).
+/// - `runnable` is the static could-run set
+///   (`functor_lang::coverage::runnable_offsets`, project-wide starts),
+///   emitted per file as `"runnable": { file: [starts] }` — how a consumer
+///   tells "runnable but never ran" (dark) from "not code at all".
+#[allow(clippy::too_many_arguments)]
+pub fn build_trace_doc_with_coverage(
+    paused: bool,
+    frame: u64,
+    tts: f64,
+    sources: &[InspectorSource],
+    journal: &[JournalEntry],
+    draw_args: Option<&[Value]>,
+    ring: &[(u64, Vec<JournalEntry>)],
+    runnable: &[usize],
+    session: &Session,
+) -> String {
     if !paused {
         return serde_json::json!({
             "paused": false,
@@ -219,14 +260,88 @@ pub fn build_trace_doc(
         })
         .to_string();
     }
+    let (invocations, paused_coverage) = build_invocations(journal, draw_args, sources, session);
     serde_json::json!({
         "frame": frame,
         "tts": tts,
         "paused": true,
         "sources": sources_json(sources),
-        "invocations": build_invocations(journal, draw_args, sources, session),
+        "invocations": invocations,
+        "coverage": coverage_json(frame, paused_coverage, ring, sources, session),
+        "runnable": runnable_json(runnable, sources),
     })
     .to_string()
+}
+
+/// How many recent frames' journals the shells retain for coverage (the
+/// recency gutter's ±window). Entries hold Rc-cloned args, so a frame costs
+/// little; replay is lazy (pause-time only) and coverage-only per frame.
+pub const COVERAGE_RING_FRAMES: usize = 120;
+
+/// Merge the paused frame's coverage (already collected by the values
+/// replay) with coverage-only replays of every OTHER ringed frame, grouped
+/// per file with frame offsets relative to `frame`.
+fn coverage_json(
+    frame: u64,
+    paused_coverage: Vec<usize>,
+    ring: &[(u64, Vec<JournalEntry>)],
+    sources: &[InspectorSource],
+    session: &Session,
+) -> serde_json::Value {
+    use std::collections::{BTreeMap, BTreeSet};
+    // The same observation-only bracket as the values replay: a windowful of
+    // frames with a Debug.log in tick would otherwise re-emit ~120× per
+    // trace build, and a Ui.* call would leak handlers into the next real
+    // ui pass. (Sequential with build_invocations' own bracket, not nested.)
+    let _mute = functor_lang::suppress_trace();
+    let saved_handlers = crate::functor_lang_prelude::take_ui_handlers();
+    // start (project-wide) → the frame offsets it executed on.
+    let mut hits: BTreeMap<usize, BTreeSet<i64>> = BTreeMap::new();
+    for start in paused_coverage {
+        hits.entry(start).or_default().insert(0);
+    }
+    for (ring_frame, entries) in ring {
+        let offset = *ring_frame as i64 - frame as i64;
+        // offset == 0 is NOT skipped: when scrubbed to frame K, the values
+        // replay saw an empty journal (seek clears it) and covered only draw
+        // — the ring's (K, journal) entry is the sole source of the paused
+        // frame's tick/update coverage. Unscrubbed, the union with
+        // paused_coverage is identical (BTreeSet dedups), so always
+        // processing is strictly safe for one cheap extra replay.
+        for e in entries {
+            if let Ok((_discard, cov)) = session.call_covered(e.entry, e.args.clone(), &mut FunctorHost)
+            {
+                for start in cov {
+                    hits.entry(start).or_default().insert(offset);
+                }
+            }
+        }
+    }
+    let _replay_pushed = crate::functor_lang_prelude::take_ui_handlers();
+    crate::functor_lang_prelude::restore_ui_handlers(saved_handlers);
+    // Group per file, in file-local offsets.
+    let mut per_file: BTreeMap<String, Vec<serde_json::Value>> = BTreeMap::new();
+    for (start, offsets) in hits {
+        if let Some((file, local, _)) = span_to_file(sources, Span::new(start, start)) {
+            per_file.entry(file).or_default().push(serde_json::json!({
+                "start": local,
+                "frames": offsets.iter().collect::<Vec<_>>(),
+            }));
+        }
+    }
+    serde_json::json!(per_file)
+}
+
+/// The static could-run set, per file in local offsets.
+fn runnable_json(runnable: &[usize], sources: &[InspectorSource]) -> serde_json::Value {
+    use std::collections::BTreeMap;
+    let mut per_file: BTreeMap<String, Vec<usize>> = BTreeMap::new();
+    for &start in runnable {
+        if let Some((file, local, _)) = span_to_file(sources, Span::new(start, start)) {
+            per_file.entry(file).or_default().push(local);
+        }
+    }
+    serde_json::json!(per_file)
 }
 
 #[cfg(test)]
@@ -455,6 +570,78 @@ mod tests {
         let handlers = take_ui_handlers();
         assert_eq!(handlers.len(), 1, "replay pushes must not linger in the UI table");
         assert!(matches!(handlers[0], UiHandler::Msg(Value::Number(n)) if n == 9.0));
+    }
+
+    #[test]
+    fn coverage_window_and_runnable_pin_the_gutter_states() {
+        // The recency gutter's exact scenario: a branch whose arm depends on
+        // the model. Frame 5 (paused) and 6 take the true arm; frame 4 took
+        // the false arm; a third arm never runs in the window but is
+        // statically runnable.
+        let src = "\
+            let init = { n: 0.0 }\n\
+            let tick = (m, dt: Float, tts: Float) =>\n\
+              match m.n < 1.0 with\n\
+              | true => { n: m.n + 1.0 }\n\
+              | false => { n: 0.0 }\n";
+        let project =
+            load_single_source("game", src).unwrap_or_else(|e| panic!("load: {}", e.render()));
+        let session = Session::load(&project.module, &mut FunctorHost)
+            .unwrap_or_else(|f| panic!("session: {}", f.error.message));
+        let sources = inspector_sources(&project.sources);
+        let runnable = functor_lang::coverage::runnable_offsets(&project.module);
+
+        let model = |n: f64| {
+            Value::Record(Rc::new(vec![("n".to_string(), Value::Number(n))]))
+        };
+        let tick = |n: f64| JournalEntry {
+            entry: "tick",
+            args: vec![model(n), Value::Number(0.1), Value::Number(0.1)],
+            provenance: Provenance::Tick,
+        };
+        // Paused frame 5 takes true (n=0); frame 4 took false (n=2); frame 6
+        // takes true again (n=0.2).
+        let journal = vec![tick(0.0)];
+        let ring = vec![
+            (4u64, vec![tick(2.0)]),
+            (5u64, vec![tick(0.0)]),
+            (6u64, vec![tick(0.2)]),
+        ];
+        let doc: serde_json::Value = serde_json::from_str(&build_trace_doc_with_coverage(
+            true,
+            5,
+            0.5,
+            &sources,
+            &journal,
+            None,
+            &ring,
+            &runnable,
+            &session,
+        ))
+        .unwrap();
+
+        let true_arm = src.find("{ n: m.n + 1.0 }").unwrap();
+        // rfind: `init` is the SAME text as the false arm — the arm is last.
+        let false_arm = src.rfind("{ n: 0.0 }").unwrap();
+        let cov = doc["coverage"]["game.fun"].as_array().expect("coverage for game.fun");
+        let frames_at = |start: usize| {
+            cov.iter()
+                .find(|c| c["start"] == serde_json::json!(start))
+                .map(|c| c["frames"].as_array().unwrap().iter().map(|f| f.as_i64().unwrap()).collect::<Vec<_>>())
+        };
+        // The true arm ran on the paused frame (0) and the frame after (+1),
+        // never the frame before.
+        assert_eq!(frames_at(true_arm), Some(vec![0, 1]), "{cov:#?}");
+        // The false arm ran ONLY the frame before (−1) — the cyan case.
+        assert_eq!(frames_at(false_arm), Some(vec![-1]), "{cov:#?}");
+        // Both arms are statically runnable (the dark state's baseline).
+        let runnable_local: Vec<usize> = doc["runnable"]["game.fun"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_u64().unwrap() as usize)
+            .collect();
+        assert!(runnable_local.contains(&true_arm) && runnable_local.contains(&false_arm));
     }
 
     #[test]

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -151,6 +151,17 @@ pub struct FunctorLangGame {
     /// — the inspector reads the last real frame. `GET /trace` replays each
     /// entry through `Session::call_recorded` while paused.
     last_frame_journal: Vec<JournalEntry>,
+    /// A window of recent frames' journals `(frame, entries)` — the recency
+    /// gutter's coverage source (functor_runtime_common::inspector). Survives
+    /// rewind/seek (that's what makes "ran in a frame AFTER" observable when
+    /// scrubbed back); cleared on hot-reload (old program's spans). A
+    /// resume-from-scrub BRANCH can briefly leave both timelines' entries for
+    /// a reused frame number — the merged coverage is approximate there and
+    /// ages out within the window.
+    journal_ring: std::collections::VecDeque<(u64, Vec<JournalEntry>)>,
+    /// The static could-run set (functor_lang::coverage::runnable_offsets),
+    /// recomputed on load/reload.
+    runnable: Vec<usize>,
     /// The lazily built + cached `/trace` JSON for the current paused frame.
     /// Invalidated when the frame advances (`tick`), the paused frame changes
     /// (rewind/seek), or the program reloads.
@@ -377,6 +388,7 @@ impl FunctorLangGame {
         // `None` check. See `functor_lang_producer`.
         journal_arm();
         let source_hashes = inspector_sources(&loaded.sources);
+        let runnable = functor_lang::coverage::runnable_offsets(&loaded.module);
         FunctorLangGame {
             path: path.to_string(),
             stamp,
@@ -407,6 +419,8 @@ impl FunctorLangGame {
             last_frame: empty_frame(),
             reporter: Reporter::new(SpanSource::Project(loaded.sources), report_to_stderr),
             last_frame_journal: Vec::new(),
+            journal_ring: std::collections::VecDeque::new(),
+            runnable,
             cached_trace: None,
             source_hashes,
             frames: 0,
@@ -471,6 +485,8 @@ impl FunctorLangGame {
         // execution (visual-debugger PR2 — hot-reload clears both).
         self.source_hashes = inspector_sources(&loaded.sources);
         self.last_frame_journal.clear();
+        self.journal_ring.clear(); // old program's spans
+        self.runnable = functor_lang::coverage::runnable_offsets(&loaded.module);
         self.cached_trace = None;
         journal_swap(); // discard any partial current-frame journal
         self.reporter
@@ -777,6 +793,13 @@ impl Game for FunctorLangGame {
         // a fresh armed journal) and drop the cached trace (the frame advanced).
         // A paused frame never reaches here, so its last real frame is kept.
         if let Some(journal) = journal_swap() {
+            // The ring shares the frame's entries (Rc-cloned args — cheap);
+            // coverage replays them lazily at pause time.
+            let frame = self.recorder.current_scene_frame().unwrap_or(0);
+            self.journal_ring.push_back((frame, journal.clone()));
+            while self.journal_ring.len() > functor_runtime_common::inspector::COVERAGE_RING_FRAMES {
+                self.journal_ring.pop_front();
+            }
             self.last_frame_journal = journal;
         }
         self.cached_trace = None;
@@ -973,13 +996,16 @@ AudioScene.empty), got {}",
         // Draw is pure and never journaled; the builder replays it once
         // against the frozen model so the render pass is inspectable too.
         let draw_args = vec![self.model.clone(), Value::Number(tts)];
-        let json = build_trace_doc(
+        let ring: Vec<(u64, Vec<JournalEntry>)> = self.journal_ring.iter().cloned().collect();
+        let json = functor_runtime_common::inspector::build_trace_doc_with_coverage(
             true,
             frame,
             tts,
             &self.source_hashes,
             &self.last_frame_journal,
             Some(&draw_args),
+            &ring,
+            &self.runnable,
             &self.session,
         );
         self.cached_trace = Some(json.clone());

--- a/runtime/functor-runtime-web/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-web/src/functor_lang_game.rs
@@ -130,6 +130,13 @@ pub struct FunctorLangWebGame {
     /// the inspector reads the last real frame. Replayed through
     /// `Session::call_recorded` while paused. Mirrors the desktop producer.
     last_frame_journal: Vec<JournalEntry>,
+    /// A window of recent frames' journals `(frame, entries)` — the recency
+    /// gutter's coverage source. Survives rewind/seek (that's what makes
+    /// "ran in a frame AFTER" observable when scrubbed back); cleared on
+    /// hot-reload (old program's spans). Mirrors the desktop producer.
+    journal_ring: std::collections::VecDeque<(u64, Vec<JournalEntry>)>,
+    /// The static could-run set, recomputed on load/reload.
+    runnable: Vec<usize>,
     /// The lazily built + cached inspector-trace JSON for the current paused
     /// frame. Invalidated when the frame advances (`tick`), the paused frame
     /// changes (rewind/seek), or the program reloads.
@@ -349,10 +356,13 @@ impl FunctorLangWebGame {
         // trace is built lazily only when paused (visual-debugger PR2b).
         journal_arm();
         let source_hashes = inspector_sources(&loaded.sources);
+        let runnable = functor_lang::coverage::runnable_offsets(&loaded.module);
         Ok(FunctorLangWebGame {
             reporter: Reporter::new(SpanSource::Project(loaded.sources), report_to_console),
             overlay_error: None,
             last_frame_journal: Vec::new(),
+            journal_ring: std::collections::VecDeque::new(),
+            runnable,
             cached_trace: None,
             source_hashes,
             sources,
@@ -411,6 +421,8 @@ impl FunctorLangWebGame {
         // execution (visual-debugger PR2b — reload clears both, like desktop).
         self.source_hashes = inspector_sources(&loaded.sources);
         self.last_frame_journal.clear();
+        self.journal_ring.clear(); // old program's spans
+        self.runnable = functor_lang::coverage::runnable_offsets(&loaded.module);
         self.cached_trace = None;
         journal_swap(); // discard any partial current-frame journal
         self.reporter
@@ -669,6 +681,13 @@ impl GameProducer for FunctorLangWebGame {
         // A paused frame never reaches here, so its last real frame is kept
         // (visual-debugger PR2b — mirrors the desktop producer).
         if let Some(journal) = journal_swap() {
+            // The ring shares the frame's entries (Rc-cloned args — cheap);
+            // coverage replays them lazily at pause time.
+            let frame = self.recorder.current_scene_frame().unwrap_or(0);
+            self.journal_ring.push_back((frame, journal.clone()));
+            while self.journal_ring.len() > functor_runtime_common::inspector::COVERAGE_RING_FRAMES {
+                self.journal_ring.pop_front();
+            }
             self.last_frame_journal = journal;
         }
         self.cached_trace = None;
@@ -859,13 +878,16 @@ AudioScene.empty), got {}",
         // Draw is pure and never journaled; the builder replays it once
         // against the frozen model so the render pass is inspectable too.
         let draw_args = vec![self.model.clone(), Value::Number(tts)];
-        let json = build_trace_doc(
+        let ring: Vec<(u64, Vec<JournalEntry>)> = self.journal_ring.iter().cloned().collect();
+        let json = functor_runtime_common::inspector::build_trace_doc_with_coverage(
             true,
             frame,
             tts,
             &self.source_hashes,
             &self.last_frame_journal,
             Some(&draw_args),
+            &ring,
+            &self.runnable,
             &self.session,
         );
         self.cached_trace = Some(json.clone());

--- a/site/src/lang-intel.js
+++ b/site/src/lang-intel.js
@@ -17,8 +17,16 @@
 // and cheaper than a second scheduler) instead of re-analyzing on every key.
 
 import { forceLinting, linter } from "@codemirror/lint";
-import { Decoration, EditorView, ViewPlugin, WidgetType, hoverTooltip } from "@codemirror/view";
-import { StateEffect, StateField } from "@codemirror/state";
+import {
+  Decoration,
+  EditorView,
+  GutterMarker,
+  ViewPlugin,
+  WidgetType,
+  gutter,
+  hoverTooltip,
+} from "@codemirror/view";
+import { RangeSet, StateEffect, StateField } from "@codemirror/state";
 import { functorLangLanguage } from "./functor-lang.js";
 
 // The runtime import specifier resolves to the glue esbuild leaves external
@@ -601,11 +609,115 @@ const sha256Hex = async (text) => {
   return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
 };
 
+// --- Recency gutter -----------------------------------------------------------
+// Colors each line by when it last EXECUTED, from the trace's coverage window
+// (a ±120-frame journal ring the runtime replays coverage-only at pause):
+//   now    (green) — ran on the paused frame
+//   before (cyan)  — ran only on earlier frames in the window
+//   after  (pink)  — ran on later frames (visible when scrubbed back)
+//   dark           — runnable (an expression starts there) but never ran
+// Lines with no runnable position (comments, blanks) stay unmarked. A line
+// that ran both before and after (never now) takes the NEAREST frame's color,
+// tie → before.
+
+class CovMarker extends GutterMarker {
+  constructor(state) {
+    super();
+    this.state = state;
+  }
+  eq(other) {
+    return other.state === this.state;
+  }
+  toDOM() {
+    const el = document.createElement("div");
+    el.className = `cm-cov cm-cov-${this.state}`;
+    return el;
+  }
+}
+
+const COV_MARKERS = {
+  now: new CovMarker("now"),
+  before: new CovMarker("before"),
+  after: new CovMarker("after"),
+  dark: new CovMarker("dark"),
+};
+
+const setCoverage = StateEffect.define();
+
+const coverageField = StateField.define({
+  create: () => RangeSet.empty,
+  update(value, tr) {
+    // Same honesty rule as the value overlay: any edit clears wholesale.
+    if (tr.docChanged) return RangeSet.empty;
+    for (const effect of tr.effects) {
+      if (effect.is(setCoverage)) return effect.value;
+      if (effect.is(clearDecorations)) return RangeSet.empty;
+    }
+    return value;
+  },
+});
+
+const coverageGutter = gutter({
+  class: "cm-cov-gutter",
+  markers: (view) => view.state.field(coverageField, false) || RangeSet.empty,
+});
+
+// The per-line recency state for the current buffer, as a marker RangeSet.
+// Coverage/runnable starts are UTF-8 byte offsets (the wire) — converted
+// through the same byte→UTF-16 map as the value overlay before line lookup.
+const coverageSetFor = (fileName, source, doc) => {
+  const conv = byteToUtf16(source);
+  const at = (byte) => {
+    const off = conv ? conv[byte] ?? source.length : byte;
+    return Math.min(off, doc.length);
+  };
+  // line number → { now, before: minDistance, after: minDistance, runnable }
+  const lines = new Map();
+  const lineState = (offset) => {
+    const line = doc.lineAt(offset).number;
+    let s = lines.get(line);
+    if (!s) {
+      s = { now: false, before: 0, after: 0, runnable: false };
+      lines.set(line, s);
+    }
+    return s;
+  };
+  for (const start of (liveTrace.runnable || {})[fileName] || []) {
+    lineState(at(start)).runnable = true;
+  }
+  for (const site of (liveTrace.coverage || {})[fileName] || []) {
+    const s = lineState(at(site.start));
+    for (const frame of site.frames || []) {
+      if (frame === 0) s.now = true;
+      else if (frame < 0) s.before = s.before ? Math.max(s.before, frame) : frame;
+      else s.after = s.after ? Math.min(s.after, frame) : frame;
+    }
+  }
+  const ranges = [];
+  for (const [line, s] of lines) {
+    const state = s.now
+      ? "now"
+      : s.before && s.after
+        ? (-s.before <= s.after ? "before" : "after")
+        : s.before
+          ? "before"
+          : s.after
+            ? "after"
+            : s.runnable
+              ? "dark"
+              : null;
+    if (state) ranges.push(COV_MARKERS[state].range(doc.line(line).from));
+  }
+  ranges.sort((a, z) => a.from - z.from);
+  return RangeSet.of(ranges);
+};
+
 // Rebuild the overlay for the current buffer: async (the hash check), token-
 // guarded so a stale completion can't clobber a newer state.
 const refreshLive = async (view) => {
   const token = ++liveRefreshToken;
-  const clear = () => view.dispatch({ effects: setLiveOverlay.of([]) });
+  const clear = () =>
+    view.dispatch({ effects: [setLiveOverlay.of([]), setCoverage.of(RangeSet.empty)] });
   if (!liveTrace || !liveTrace.paused) {
     clear();
     return;
@@ -625,7 +737,12 @@ const refreshLive = async (view) => {
   }
   const sites = liveSitesFor(fileName, source);
   liveSites = sites;
-  view.dispatch({ effects: setLiveOverlay.of(liveHintsFor(sites, source)) });
+  view.dispatch({
+    effects: [
+      setLiveOverlay.of(liveHintsFor(sites, source)),
+      setCoverage.of(coverageSetFor(fileName, source, view.state.doc)),
+    ],
+  });
 };
 
 // Host seams -------------------------------------------------------------------
@@ -642,6 +759,20 @@ export const setLiveTrace = (view, trace) => {
 // hint's [nameStart, nameEnd) must slice to exactly its name in the doc,
 // which fails loudly if byte offsets ever leak through unconverted).
 export const currentLiveHints = () => liveHints;
+
+// The rendered gutter states as `{ lineNumber: state }` — the e2e seam (DOM
+// gutter elements only exist for the viewport; this reads the full set).
+export const currentCoverage = (view) => {
+  const set = view.state.field(coverageField, false);
+  const out = {};
+  if (!set) return out;
+  const iter = set.iter();
+  while (iter.value) {
+    out[view.state.doc.lineAt(iter.from).number] = iter.value.state;
+    iter.next();
+  }
+  return out;
+};
 
 // The frame's executions in order, for the host's picker UI:
 // `[{ entry, index, count, provenance, selected }]`. Empty while playing.
@@ -744,6 +875,21 @@ const intelTheme = EditorView.theme({
   ".cm-hover-live": {
     color: "#41d8e6",
   },
+  // The recency gutter: a slim execution-state bar per line. Colors match
+  // the calm theme (green live / cyan accent / pink future — the scrubber's
+  // own recency language).
+  ".cm-cov-gutter": {
+    width: "4px",
+  },
+  ".cm-cov": {
+    width: "4px",
+    height: "100%",
+    borderRadius: "1px",
+  },
+  ".cm-cov-now": { background: "#6fdc92" },
+  ".cm-cov-before": { background: "rgba(65, 216, 230, 0.55)" },
+  ".cm-cov-after": { background: "rgba(232, 88, 184, 0.55)" },
+  ".cm-cov-dark": { background: "rgba(233, 230, 242, 0.14)" },
   // Codelenses: a dimmed signature line above the def.
   ".cm-lens": {
     fontFamily: mono,
@@ -821,6 +967,8 @@ export const setupLangIntel = async () => {
     hoverTypes,
     decorationField,
     liveField,
+    coverageField,
+    coverageGutter,
     initialRefresh,
     // Register the completion source on the language's data facet — basicSetup's
     // autocompletion() picks it up via languageDataAt (no second popup).

--- a/site/src/sandbox.js
+++ b/site/src/sandbox.js
@@ -18,6 +18,7 @@ import {
   onDiagnostics,
   wireLiveTrace,
   currentLiveHints,
+  currentCoverage,
 } from "./lang-intel.js";
 import { PlayerBridge } from "./player-bridge.js";
 import { createStatusBar } from "./status-bar.js";
@@ -137,6 +138,7 @@ window.__lang = {
   analyze: (source) => analyzeCached(source),
   complete: (source, offset) => completeAt(source, offset),
   liveHints: () => currentLiveHints(),
+  coverage: () => currentCoverage(view),
 };
 
 const setDoc = (source) => {


### PR DESCRIPTION
## Why

Inspector v2 part 4 of 5 — the recency gutter's runtime half. The gutter (next PR) colors lines by when they last ran: green = this frame, cyan = a frame before, pink = a frame after (visible when scrubbed back), dark = runnable but never ran (the un-taken match arm). That needs per-frame execution coverage over a window — which nothing recorded.

## What

**Interpreter (`functor-lang`):** the recorder collects the span start of every evaluated expression (one armed-check per eval; `None`-test cost when off — verified no new clones on the unarmed path). `RecordedInvocation.coverage` + the coverage-only `Session::call_covered` (skips the values pass — no Display rendering). New `coverage::runnable_offsets` walks the module statically for the dark state's baseline (mirrors the inlay/hover walks).

**Runtime (both shells, symmetric):** a ±120-frame journal ring (`COVERAGE_RING_FRAMES`; Rc-shared args, so a frame costs pointer bumps) that **survives rewind/seek** — that's exactly what makes 'ran in a frame after' observable — and clears on hot-reload. Nothing replays during play. The paused trace gains `coverage` (per-file span starts × sorted frame offsets) and `runnable` (per-file could-run sets); the paused frame's coverage rides free on the values replay, other ringed frames replay coverage-only.

### Review-driven fixes (cross-engine)
- Coverage replays are inside the same **observation-only bracket** as the values replay — without it a `Debug.log` in tick re-emitted ~120 frames of lines per trace build, straight into the new Output panel.
- The ring's paused-frame entry is **not skipped**: when scrubbed to frame K, seek cleared the journal, so the ring is the only source of K's tick/update coverage (the headline gutter state was draw-only without this).

## Testing

- `cargo test`: functor-lang 501 (coverage arm-taken/not-taken + `call_covered` agreement + static runnable walks), common 298 (the parity-branch fixture pins green `[0,1]` / cyan `[-1]` / runnable baseline), desktop 49, lsp 41; wasm-pack build clean.
- Live headless curl (`examples/inspector`, `--headless --debug-port`): 28 covered sites over offsets −119…0, 41 runnable positions, **coverage ⊆ runnable**, 13 dark candidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)