### PR TITLE
feat(site): execution-recency gutter in the sandbox and web IDE

### DIFF
--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -1287,6 +1287,98 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
   await page.close();
 }
 
+// --- 12d. The execution-recency gutter. ----------------------------------------
+// A parity-conditional program makes every gutter state deterministic: the
+// even/odd arms alternate per frame, and a never-true branch stays dark.
+// Pausing shows green (ran this frame) vs cyan (ran a frame before); scrubbing
+// BACK one frame swaps the arms' colors and turns pink on (ran after).
+{
+  // A frame-counter threshold: the EARLY arm runs on frames n<60, the LATE
+  // arm after; `never` requires hp < 0 — unreachable (statically runnable →
+  // dark). Unique arm texts so line lookup can't collide with init.
+  const PARITY = `let init = { n: 0.0, hp: 1.0 }
+let tick = (model, dt: Float, tts: Float) =>
+  match model.hp < 0.0 with
+  | true => { n: model.n, hp: 0.0 }
+  | false =>
+    match model.n < 60.0 with
+    | true => { n: model.n + 1.0, hp: 1.0 }
+    | false => { n: model.n + 1.0, hp: 2.0 }
+let draw = (model, tts: Float) =>
+  Frame.create(
+    Camera.lookAt(0.0, 0.0, -6.0, 0.0, 0.0, 0.0),
+    Scene.sphere() |> Scene.emissive(Color.rgb(0.1, 1.0, 0.2)))
+`;
+  const b64u = Buffer.from(PARITY).toString("base64url");
+  const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+  await page.goto(`${BASE}/sandbox.html#src=${b64u}`);
+  await page.waitForFunction(
+    () => window.__sandbox && window.__sandbox.status().state === "live",
+    { timeout: 30000 }
+  );
+  await page.waitForFunction(() => window.__lang && window.__lang.ready, { timeout: 15000 });
+
+  const waitFor = async (fn, pred, timeout = 10000) => {
+    const t0 = Date.now();
+    for (;;) {
+      const v = await fn();
+      if (pred(v)) return v;
+      if (Date.now() - t0 > timeout) return v;
+      await sleep(150);
+    }
+  };
+  const lineOf = (needle) => PARITY.slice(0, PARITY.indexOf(needle)).split("\n").length;
+  const earlyLine = lineOf("{ n: model.n + 1.0, hp: 1.0 }"); // frames n<60
+  const lateLine = lineOf("{ n: model.n + 1.0, hp: 2.0 }"); // frames n>=60
+  const neverLine = lineOf("{ n: model.n, hp: 0.0 }");
+
+  // Run past the threshold, then pause: the late arm is CURRENT (green),
+  // the early arm history (cyan), the unreachable arm dark.
+  const player = playerFrame(page);
+  await player.waitForFunction(
+    () => window.__scrub && window.__scrub.range().length === 2 && window.__scrub.range()[1] > 80,
+    { timeout: 30000 }
+  );
+  await player.evaluate(() => document.getElementById("scrub-pause")?.click());
+  const cov = await waitFor(
+    () => page.evaluate(() => window.__lang.coverage()),
+    (c) => c[lateLine] === "now"
+  );
+  check("current arm is green", cov[lateLine] === "now", JSON.stringify(cov));
+  check("pre-threshold arm is cyan (ran before)", cov[earlyLine] === "before", JSON.stringify(cov));
+  check("never-taken branch is dark", cov[neverLine] === "dark", JSON.stringify(cov));
+  // Gutter markers are real DOM (the viewport shows them all here).
+  const domStates = await page.evaluate(() =>
+    [...document.querySelectorAll(".cm-cov")].map((el) => el.className)
+  );
+  check(
+    "gutter renders now/before/dark markers",
+    ["now", "before", "dark"].every((s) => domStates.some((c) => c.includes(`cm-cov-${s}`))),
+    JSON.stringify(domStates.slice(0, 6))
+  );
+
+  // Scrub back BEFORE the threshold (frame 10): the early arm becomes this
+  // frame's (green — its coverage comes from the ring, the scrubbed-frame
+  // path) and the late arm ran only in frames AFTER the paused one → pink.
+  await player.evaluate(() => window.__scrub.seek(10));
+  const scrubbed = await waitFor(
+    () => page.evaluate(() => window.__lang.coverage()),
+    (c) => c[earlyLine] === "now"
+  );
+  check(
+    "scrubbed back: the early arm is green from the ring",
+    scrubbed[earlyLine] === "now",
+    JSON.stringify(scrubbed)
+  );
+  check(
+    "scrubbed back: the post-threshold arm is pink (ran after)",
+    scrubbed[lateLine] === "after",
+    JSON.stringify(scrubbed)
+  );
+
+  await page.close();
+}
+
 // --- 13. Scope-aware autocomplete in the editor (commit 8b). ------------------
 // The completion source is backed by the wasm's scope-aware `complete`, driven
 // through the __sandbox.triggerComplete seam (insert text + set cursor + open

--- a/site/src/lang-intel.js
+++ b/site/src/lang-intel.js
@@ -17,8 +17,16 @@
 // and cheaper than a second scheduler) instead of re-analyzing on every key.
 
 import { forceLinting, linter } from "@codemirror/lint";
-import { Decoration, EditorView, ViewPlugin, WidgetType, hoverTooltip } from "@codemirror/view";
-import { StateEffect, StateField } from "@codemirror/state";
+import {
+  Decoration,
+  EditorView,
+  GutterMarker,
+  ViewPlugin,
+  WidgetType,
+  gutter,
+  hoverTooltip,
+} from "@codemirror/view";
+import { RangeSet, StateEffect, StateField } from "@codemirror/state";
 import { functorLangLanguage } from "./functor-lang.js";
 
 // The runtime import specifier resolves to the glue esbuild leaves external
@@ -601,11 +609,115 @@ const sha256Hex = async (text) => {
   return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
 };
 
+// --- Recency gutter -----------------------------------------------------------
+// Colors each line by when it last EXECUTED, from the trace's coverage window
+// (a ±120-frame journal ring the runtime replays coverage-only at pause):
+//   now    (green) — ran on the paused frame
+//   before (cyan)  — ran only on earlier frames in the window
+//   after  (pink)  — ran on later frames (visible when scrubbed back)
+//   dark           — runnable (an expression starts there) but never ran
+// Lines with no runnable position (comments, blanks) stay unmarked. A line
+// that ran both before and after (never now) takes the NEAREST frame's color,
+// tie → before.
+
+class CovMarker extends GutterMarker {
+  constructor(state) {
+    super();
+    this.state = state;
+  }
+  eq(other) {
+    return other.state === this.state;
+  }
+  toDOM() {
+    const el = document.createElement("div");
+    el.className = `cm-cov cm-cov-${this.state}`;
+    return el;
+  }
+}
+
+const COV_MARKERS = {
+  now: new CovMarker("now"),
+  before: new CovMarker("before"),
+  after: new CovMarker("after"),
+  dark: new CovMarker("dark"),
+};
+
+const setCoverage = StateEffect.define();
+
+const coverageField = StateField.define({
+  create: () => RangeSet.empty,
+  update(value, tr) {
+    // Same honesty rule as the value overlay: any edit clears wholesale.
+    if (tr.docChanged) return RangeSet.empty;
+    for (const effect of tr.effects) {
+      if (effect.is(setCoverage)) return effect.value;
+      if (effect.is(clearDecorations)) return RangeSet.empty;
+    }
+    return value;
+  },
+});
+
+const coverageGutter = gutter({
+  class: "cm-cov-gutter",
+  markers: (view) => view.state.field(coverageField, false) || RangeSet.empty,
+});
+
+// The per-line recency state for the current buffer, as a marker RangeSet.
+// Coverage/runnable starts are UTF-8 byte offsets (the wire) — converted
+// through the same byte→UTF-16 map as the value overlay before line lookup.
+const coverageSetFor = (fileName, source, doc) => {
+  const conv = byteToUtf16(source);
+  const at = (byte) => {
+    const off = conv ? conv[byte] ?? source.length : byte;
+    return Math.min(off, doc.length);
+  };
+  // line number → { now, before: minDistance, after: minDistance, runnable }
+  const lines = new Map();
+  const lineState = (offset) => {
+    const line = doc.lineAt(offset).number;
+    let s = lines.get(line);
+    if (!s) {
+      s = { now: false, before: 0, after: 0, runnable: false };
+      lines.set(line, s);
+    }
+    return s;
+  };
+  for (const start of (liveTrace.runnable || {})[fileName] || []) {
+    lineState(at(start)).runnable = true;
+  }
+  for (const site of (liveTrace.coverage || {})[fileName] || []) {
+    const s = lineState(at(site.start));
+    for (const frame of site.frames || []) {
+      if (frame === 0) s.now = true;
+      else if (frame < 0) s.before = s.before ? Math.max(s.before, frame) : frame;
+      else s.after = s.after ? Math.min(s.after, frame) : frame;
+    }
+  }
+  const ranges = [];
+  for (const [line, s] of lines) {
+    const state = s.now
+      ? "now"
+      : s.before && s.after
+        ? (-s.before <= s.after ? "before" : "after")
+        : s.before
+          ? "before"
+          : s.after
+            ? "after"
+            : s.runnable
+              ? "dark"
+              : null;
+    if (state) ranges.push(COV_MARKERS[state].range(doc.line(line).from));
+  }
+  ranges.sort((a, z) => a.from - z.from);
+  return RangeSet.of(ranges);
+};
+
 // Rebuild the overlay for the current buffer: async (the hash check), token-
 // guarded so a stale completion can't clobber a newer state.
 const refreshLive = async (view) => {
   const token = ++liveRefreshToken;
-  const clear = () => view.dispatch({ effects: setLiveOverlay.of([]) });
+  const clear = () =>
+    view.dispatch({ effects: [setLiveOverlay.of([]), setCoverage.of(RangeSet.empty)] });
   if (!liveTrace || !liveTrace.paused) {
     clear();
     return;
@@ -625,7 +737,12 @@ const refreshLive = async (view) => {
   }
   const sites = liveSitesFor(fileName, source);
   liveSites = sites;
-  view.dispatch({ effects: setLiveOverlay.of(liveHintsFor(sites, source)) });
+  view.dispatch({
+    effects: [
+      setLiveOverlay.of(liveHintsFor(sites, source)),
+      setCoverage.of(coverageSetFor(fileName, source, view.state.doc)),
+    ],
+  });
 };
 
 // Host seams -------------------------------------------------------------------
@@ -642,6 +759,20 @@ export const setLiveTrace = (view, trace) => {
 // hint's [nameStart, nameEnd) must slice to exactly its name in the doc,
 // which fails loudly if byte offsets ever leak through unconverted).
 export const currentLiveHints = () => liveHints;
+
+// The rendered gutter states as `{ lineNumber: state }` — the e2e seam (DOM
+// gutter elements only exist for the viewport; this reads the full set).
+export const currentCoverage = (view) => {
+  const set = view.state.field(coverageField, false);
+  const out = {};
+  if (!set) return out;
+  const iter = set.iter();
+  while (iter.value) {
+    out[view.state.doc.lineAt(iter.from).number] = iter.value.state;
+    iter.next();
+  }
+  return out;
+};
 
 // The frame's executions in order, for the host's picker UI:
 // `[{ entry, index, count, provenance, selected }]`. Empty while playing.
@@ -744,6 +875,21 @@ const intelTheme = EditorView.theme({
   ".cm-hover-live": {
     color: "#41d8e6",
   },
+  // The recency gutter: a slim execution-state bar per line. Colors match
+  // the calm theme (green live / cyan accent / pink future — the scrubber's
+  // own recency language).
+  ".cm-cov-gutter": {
+    width: "4px",
+  },
+  ".cm-cov": {
+    width: "4px",
+    height: "100%",
+    borderRadius: "1px",
+  },
+  ".cm-cov-now": { background: "#6fdc92" },
+  ".cm-cov-before": { background: "rgba(65, 216, 230, 0.55)" },
+  ".cm-cov-after": { background: "rgba(232, 88, 184, 0.55)" },
+  ".cm-cov-dark": { background: "rgba(233, 230, 242, 0.14)" },
   // Codelenses: a dimmed signature line above the def.
   ".cm-lens": {
     fontFamily: mono,
@@ -821,6 +967,8 @@ export const setupLangIntel = async () => {
     hoverTypes,
     decorationField,
     liveField,
+    coverageField,
+    coverageGutter,
     initialRefresh,
     // Register the completion source on the language's data facet — basicSetup's
     // autocompletion() picks it up via languageDataAt (no second popup).

--- a/site/src/sandbox.js
+++ b/site/src/sandbox.js
@@ -18,6 +18,7 @@ import {
   onDiagnostics,
   wireLiveTrace,
   currentLiveHints,
+  currentCoverage,
 } from "./lang-intel.js";
 import { PlayerBridge } from "./player-bridge.js";
 import { createStatusBar } from "./status-bar.js";
@@ -137,6 +138,7 @@ window.__lang = {
   analyze: (source) => analyzeCached(source),
   complete: (source, offset) => completeAt(source, offset),
   liveHints: () => currentLiveHints(),
+  coverage: () => currentCoverage(view),
 };
 
 const setDoc = (source) => {


### PR DESCRIPTION
## Why

Inspector v2, part 5 — the visualization #379's coverage data exists for: see at a glance which conditionals and match arms actually ran, and *when*.

## What

A slim per-line gutter while paused, driven by the trace's `coverage`/`runnable` sections:

- 🟩 **green** — ran on the paused frame
- 🟦 **cyan** — ran only in earlier frames of the ±120 window
- 🟪 **pink** — ran in *later* frames (appears when scrubbed back — the ring survives seek)
- ▪️ **dark** — statically runnable but never ran (the un-taken arm, the dead branch)

Comments/blanks stay unmarked; a line that ran on both sides of the paused frame takes the nearest frame's color. Same lifecycle as the live-value overlay: byte→UTF-16 conversion, sha256 hash gate, wholesale clear on edit.

**Paused past the threshold** — late arm green, early arm cyan, unreachable arm dark:

![paused](https://gist.github.com/tommy-xr/d854579e69c31c23fdc1a30ea9d13dba/raw/gutter-paused.png)

**Scrubbed back to frame 10/81** — the arms swap: early arm green (its coverage comes from the journal ring — the seek-cleared journal has nothing), the post-threshold arm **pink**, values showing `n: 11`:

![scrubbed](https://gist.github.com/tommy-xr/d854579e69c31c23fdc1a30ea9d13dba/raw/gutter-scrubbed.png)

## Testing

`npm run test:site` → ALL CHECKS PASSED — a threshold fixture driven through the **real** pause + `__scrub.seek` path pins all four states, including the scrubbed-frame green sourced from the ring (#379's H2 path). `npm run test:ide-page` → RESULT: PASS.

VSCode parity is the planned follow-up (extension gutter decorations fed by the LSP — gutters aren't expressible in pure LSP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)