### PR TITLE
feat(inspector): numeric loop sites show their min…max range inline

### DIFF
--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -1241,6 +1241,13 @@ for (const example of ["hero", "primitives", "bounce", "monitor"]) {
     liveTexts.every((t) => t.startsWith("= ")) && liveTexts.length > 0,
     JSON.stringify(liveTexts.slice(0, 4))
   );
+  // The hero's dot-grid loop sites (×120) sweep numerically — a multi-hit
+  // numeric site renders its RANGE, not the last sample: `= 0…11 (×120)`.
+  check(
+    "numeric loop sites render min…max ranges",
+    liveTexts.some((t) => /^= -?[\d.]+…-?[\d.]+ \(×\d+\)$/.test(t)),
+    JSON.stringify(liveTexts.filter((t) => t.includes("×")).slice(0, 4))
+  );
 
   // Position invariant: every hint's name span slices to exactly its name.
   // hero.fun's comments contain multibyte characters (em dashes) BEFORE the

--- a/functor-lang/src/eval.rs
+++ b/functor-lang/src/eval.rs
@@ -179,6 +179,11 @@ pub struct RecordedBinding {
     /// Binder or reference — see [`RecordedSite`].
     pub site: RecordedSite,
     pub count: u32,
+    /// For NUMERIC sites hit more than once (a loop), the observed range —
+    /// the editor renders `= min…max (×N)` instead of just the last value.
+    /// `None` for non-numeric values or single hits.
+    pub min: Option<f64>,
+    pub max: Option<f64>,
 }
 
 /// A recorder site key. Binder sites key by [`BindingId`] (unique per site
@@ -264,6 +269,15 @@ impl Recorder {
             slot.preview = value.preview();
             slot.kind = recorded_kind(value);
             slot.count += 1;
+            // Numeric loop sites fold their range; a non-numeric value at a
+            // previously-numeric site (a union-typed binder) drops it.
+            if let Value::Number(n) = value {
+                slot.min = Some(slot.min.map_or(*n, |m| m.min(*n)));
+                slot.max = Some(slot.max.map_or(*n, |m| m.max(*n)));
+            } else {
+                slot.min = None;
+                slot.max = None;
+            }
             return;
         }
         let sites = match site {
@@ -276,6 +290,10 @@ impl Recorder {
         }
         *sites += 1;
         self.index.insert(key, self.bindings.len());
+        let n = match value {
+            Value::Number(n) => Some(*n),
+            _ => None,
+        };
         self.bindings.push(RecordedBinding {
             name: name.to_string(),
             span,
@@ -284,6 +302,8 @@ impl Recorder {
             kind: recorded_kind(value),
             site,
             count: 1,
+            min: n,
+            max: n,
         });
     }
 }

--- a/functor-lang/tests/recorder.rs
+++ b/functor-lang/tests/recorder.rs
@@ -107,14 +107,19 @@ fn loop_site_keeps_last_value_and_counts_hits() {
     assert!(!inv.truncated);
 
     // The fold closure's params re-bind once per element: last value wins,
-    // count is the element count.
+    // count is the element count, and numeric sites fold their RANGE.
     let acc = binding(&inv, "acc");
     assert_eq!(acc.count, 3);
     assert_eq!(acc.value, "3"); // acc going into the final `acc + x` (1 + 2)
+    assert_eq!((acc.min, acc.max), (Some(0.0), Some(3.0)));
     let x = binding(&inv, "x");
     assert_eq!(x.count, 3);
     assert_eq!(x.value, "3"); // the last element
+    assert_eq!((x.min, x.max), (Some(1.0), Some(3.0)));
+    // A single-hit numeric site still carries its (degenerate) range; a
+    // non-numeric one carries none.
     assert_eq!(binding(&inv, "xs").count, 1);
+    assert_eq!(binding(&inv, "xs").min, None);
 }
 
 #[test]

--- a/runtime/functor-runtime-common/src/inspector.rs
+++ b/runtime/functor-runtime-common/src/inspector.rs
@@ -150,7 +150,7 @@ fn build_invocations(
             .iter()
             .filter_map(|b| {
                 span_to_file(sources, b.span).map(|(file, start, end)| {
-                    serde_json::json!({
+                    let mut o = serde_json::json!({
                         "name": b.name,
                         "file": file,
                         "start": start,
@@ -160,7 +160,14 @@ fn build_invocations(
                         "kind": kind_str(b.kind),
                         "site": site_str(b.site),
                         "count": b.count,
-                    })
+                    });
+                    // Numeric loop sites carry their observed range — the
+                    // editors render `= min…max (×N)` for multi-hit sites.
+                    if let (Some(min), Some(max)) = (b.min, b.max) {
+                        o["min"] = serde_json::json!(min);
+                        o["max"] = serde_json::json!(max);
+                    }
+                    o
                 })
             })
             .collect();

--- a/site/src/lang-intel.js
+++ b/site/src/lang-intel.js
@@ -158,7 +158,22 @@ const hoverTypes = hoverTooltip((view, pos) => {
   // answer — including reads the inline dedup suppressed. Half-open bounds —
   // the character AT nameEnd is the operator/space after the name.
   const hit = liveSites.find((s) => pos >= s.nameStart && pos < s.nameEnd);
-  const live = hit ? { name: hit.b.name, value: hit.b.value, count: hit.b.count || 1, nameStart: hit.nameStart, nameEnd: hit.nameEnd } : null;
+  const live = hit
+    ? {
+        name: hit.b.name,
+        value: hit.b.value,
+        count: hit.b.count || 1,
+        range:
+          (hit.b.count || 1) > 1 &&
+          typeof hit.b.min === "number" &&
+          typeof hit.b.max === "number" &&
+          hit.b.min < hit.b.max
+            ? `${shortNumbers(String(hit.b.min))}…${shortNumbers(String(hit.b.max))}`
+            : null,
+        nameStart: hit.nameStart,
+        nameEnd: hit.nameEnd,
+      }
+    : null;
   let info;
   try {
     const doc = view.state.doc.toString();
@@ -188,7 +203,7 @@ const hoverTypes = hoverTooltip((view, pos) => {
         line.className = "cm-hover-live";
         line.textContent =
           live.count > 1
-            ? `${live.name} = ${live.value} (×${live.count})`
+            ? `${live.name} = ${live.value} (×${live.count}${live.range ? `, range ${live.range}` : ""})`
             : `${live.name} = ${live.value}`;
         dom.appendChild(line);
       }
@@ -576,13 +591,21 @@ const liveHintsFor = (sites, source) => {
   }
   return [...chosen.values()]
     .map(({ b, offset, nameStart, nameEnd }) => {
-      const preview = shortNumbers(b.preview ?? b.value);
+      // A multi-hit NUMERIC site reads as its swept range (`= 0.1…0.61
+      // (×120)`) — far more informative than the last sample; hover keeps
+      // the exact value. Degenerate ranges (a loop-constant) stay a value.
+      const range =
+        b.count > 1 && typeof b.min === "number" && typeof b.max === "number" && b.min < b.max
+          ? `${shortNumbers(String(b.min))}…${shortNumbers(String(b.max))}`
+          : null;
+      const preview = range ?? shortNumbers(b.preview ?? b.value);
       return {
         offset,
         label: b.count > 1 ? `= ${preview} (×${b.count})` : `= ${preview}`,
         name: b.name,
         value: b.value,
         count: b.count || 1,
+        range,
         nameStart,
         nameEnd,
       };

--- a/tools/functor-lang-lsp/src/inspector.rs
+++ b/tools/functor-lang-lsp/src/inspector.rs
@@ -75,6 +75,9 @@ pub struct Binding {
     pub site: String,
     /// Times this site was seen during the invocation (loops > 1); `value` is last.
     pub count: usize,
+    /// A numeric loop site's observed range (absent for non-numeric values).
+    pub min: Option<f64>,
+    pub max: Option<f64>,
 }
 
 impl TraceDoc {
@@ -136,6 +139,8 @@ impl Binding {
             preview,
             site: v["site"].as_str().unwrap_or("binder").to_string(),
             count: v["count"].as_u64().unwrap_or(1).max(1) as usize,
+            min: v["min"].as_f64(),
+            max: v["max"].as_f64(),
         })
     }
 }
@@ -244,10 +249,12 @@ pub fn live_hints(
     let mut out: Vec<LiveHint> = chosen
         .into_values()
         .map(|(b, offset)| {
-            let label = if b.count > 1 {
-                format!("= {} (×{})", b.preview, b.count)
-            } else {
-                format!("= {}", b.preview)
+            let label = match (b.count > 1, range_label(b)) {
+                // A numeric loop site reads as its swept range, not the last
+                // sample: `= 0.1…0.61 (×120)`.
+                (true, Some(range)) => format!("= {} (×{})", range, b.count),
+                (true, None) => format!("= {} (×{})", b.preview, b.count),
+                _ => format!("= {}", b.preview),
             };
             LiveHint { offset, label }
         })
@@ -298,8 +305,9 @@ pub fn live_hover(
         }
     }
     best.map(|(b, _)| {
+        let range = range_label(b).map(|r| format!(", range {r}")).unwrap_or_default();
         if b.count > 1 {
-            format!("{} = {} (×{})", b.name, b.value, b.count)
+            format!("{} = {} (×{}{})", b.name, b.value, b.count, range)
         } else {
             format!("{} = {}", b.name, b.value)
         }
@@ -420,6 +428,30 @@ pub fn execution_count(trace: &TraceDoc, entry: &str) -> usize {
         .map(|i| i.count)
         .max()
         .unwrap_or(0)
+}
+
+/// A multi-hit numeric site's `min…max` label, `None` when the range is
+/// absent or degenerate (min == max — the plain value reads better).
+fn range_label(b: &Binding) -> Option<String> {
+    match (b.min, b.max) {
+        (Some(min), Some(max)) if min < max => Some(format!("{}…{}", short(min), short(max))),
+        _ => None,
+    }
+}
+
+/// A short numeric rendering for inline labels: ~5 significant digits, no
+/// trailing zeros — full precision stays on the last value / hover.
+fn short(x: f64) -> String {
+    if x == 0.0 || !x.is_finite() {
+        return format!("{x}");
+    }
+    let digits = (4.0 - x.abs().log10().floor()).clamp(0.0, 12.0) as usize;
+    let s = format!("{x:.digits$}");
+    if s.contains('.') {
+        s.trim_end_matches('0').trim_end_matches('.').to_string()
+    } else {
+        s
+    }
 }
 
 /// SHA-256 of `bytes` as lowercase hex. Hand-rolled (FIPS 180-4) to keep the
@@ -634,6 +666,48 @@ mod tests {
         let hints = live_hints(&trace, "game.fun", src, &no_selection());
         assert_eq!(hints.len(), 1);
         assert_eq!(hints[0].offset, region_start + "let t".len());
+    }
+
+    #[test]
+    fn numeric_loop_sites_render_their_range() {
+        let src = "let tick = (m, dt, tts) =>\n  m\n";
+        let start = src.find('m').unwrap();
+        let trace = trace_for(
+            src,
+            json!([{
+                "entry": "tick", "index": 0, "count": 1, "provenance": "p",
+                "ghost": false, "result": "0",
+                "bindings": [{
+                    "name": "m", "file": "game.fun", "start": start, "end": start + 1,
+                    "value": "0.6166666666666667", "preview": "0.6166666666666667",
+                    "kind": "primitive", "site": "binder", "count": 120,
+                    "min": 0.1, "max": 0.6166666666666667
+                }]
+            }]),
+        );
+        let hints = live_hints(&trace, "game.fun", src, &no_selection());
+        assert_eq!(hints.len(), 1);
+        // The swept range replaces the last-sample preview inline…
+        assert_eq!(hints[0].label, "= 0.1…0.61667 (×120)");
+        // …and hover keeps the exact last value plus the range.
+        let hover = live_hover(&trace, "game.fun", src, start, &no_selection()).unwrap();
+        assert_eq!(hover, "m = 0.6166666666666667 (×120, range 0.1…0.61667)");
+
+        // A DEGENERATE range (a constant re-bound in a loop) stays a value.
+        let constant = trace_for(
+            src,
+            json!([{
+                "entry": "tick", "index": 0, "count": 1, "provenance": "p",
+                "ghost": false, "result": "0",
+                "bindings": [{
+                    "name": "m", "file": "game.fun", "start": start, "end": start + 1,
+                    "value": "2", "preview": "2", "kind": "primitive",
+                    "site": "binder", "count": 8, "min": 2.0, "max": 2.0
+                }]
+            }]),
+        );
+        let hints = live_hints(&constant, "game.fun", src, &no_selection());
+        assert_eq!(hints[0].label, "= 2 (×8)");
     }
 
     #[test]

--- a/tools/functor-lang-vscode/tests-integration/baseTest.mjs
+++ b/tools/functor-lang-vscode/tests-integration/baseTest.mjs
@@ -45,8 +45,17 @@ export const test = base.extend({
     const tracePath = path.join(tmp, "trace.json");
     writeFileSync(tracePath, JSON.stringify(buildTrace(source)));
 
+    // FUNCTOR_E2E_VIDEO=1 records the whole session as .webm into the test's
+    // output dir — raw material for PR descriptions (convert to GIF for
+    // GitHub embedding, per the repo's pr-visuals convention). Off by default:
+    // recording costs a compositor thread and disk.
+    const recordVideo =
+      process.env.FUNCTOR_E2E_VIDEO === "1"
+        ? { dir: testInfo.outputPath("video"), size: { width: 1440, height: 900 } }
+        : undefined;
     const electronApp = await _electron.launch({
       executablePath: vscodePath,
+      recordVideo,
       args: [
         "--no-sandbox",
         "--disable-gpu-sandbox",

--- a/tools/functor-lang-vscode/tests-integration/inspector-inlay.spec.mjs
+++ b/tools/functor-lang-vscode/tests-integration/inspector-inlay.spec.mjs
@@ -9,7 +9,7 @@
 //   inject command relays the wire-contract trace → LSP inlay-hint provider
 //   (hash-gated) → Monaco renders "= 42" next to the `model` binder.
 import { test, expect, openFile, runCommand } from "./baseTest.mjs";
-import { EXPECTED_HINT } from "./trace.mjs";
+import { EXPECTED_HINT, EXPECTED_RANGE_HINT } from "./trace.mjs";
 
 // The palette title of the guarded inject command (see extension.js).
 const INJECT_COMMAND = "Functor Lang: [test] Inject Inspector Trace";
@@ -35,6 +35,12 @@ test("a paused trace makes a live-value inlay hint appear in the editor", async 
   await expect(
     editor.getByText(EXPECTED_HINT, { exact: false }).first()
   ).toBeVisible({ timeout: 30_000 });
+
+  // The numeric-range rendering: the same trace carries a 120-hit numeric
+  // site — its hint reads as the swept range, not the last sample.
+  await expect(
+    editor.getByText(EXPECTED_RANGE_HINT, { exact: false }).first()
+  ).toBeVisible({ timeout: 15_000 });
 
   // The hash gate: mutate the buffer so its text no longer hashes to the
   // trace's recorded source hash, and the live hint must disappear ("never wrong

--- a/tools/functor-lang-vscode/tests-integration/trace.mjs
+++ b/tools/functor-lang-vscode/tests-integration/trace.mjs
@@ -17,10 +17,36 @@ export const BINDING_NAME = "model";
 export const CANNED_VALUE = "42";
 // What the resulting inlay hint's text is (LSP renders live hints as "= value").
 export const EXPECTED_HINT = `= ${CANNED_VALUE}`;
+// A second binding on the SAME trace exercises the numeric-range rendering: a
+// multi-hit numeric site renders `= min…max (×N)` instead of the last sample.
+// Placed at `bumped` (update's let binder). The expected label pins the LSP's
+// ~5-significant-digit shortening.
+export const RANGE_BINDING_NAME = "bumped";
+export const EXPECTED_RANGE_HINT = "= 0.1…0.61667 (×120)";
 
 // Build the trace doc for a given game.fun source text. Places the binding at
 // the FIRST occurrence of `model` (the `update` parameter, near the top of the
 // file so its inlay hint is inside the default viewport).
+// The numeric-range binding at update's `bumped` let binder (region-shaped
+// span, `let bumped =`, per the recorder's binder-span convention).
+function rangeBinding(source) {
+  const start = source.indexOf("let bumped");
+  if (start < 0) {
+    throw new Error("binding 'bumped' not found in game.fun");
+  }
+  const end = start + source.slice(start).indexOf("=") + 1;
+  return {
+    name: RANGE_BINDING_NAME,
+    file: "game.fun",
+    start,
+    end,
+    value: "0.6166666666666667",
+    count: 120,
+    min: 0.1,
+    max: 0.6166666666666667,
+  };
+}
+
 export function buildTrace(source) {
   const start = source.indexOf(BINDING_NAME);
   if (start < 0) {
@@ -50,6 +76,7 @@ export function buildTrace(source) {
             value: CANNED_VALUE,
             count: 1,
           },
+          rangeBinding(source),
         ],
       },
     ],


### PR DESCRIPTION
## Why

A `(×120)` loop site showed only its LAST sample — `t = 0.61667 (×120)` tells you nothing about the sweep. The committed follow-up from the recency-gutter arc.

## What

- **Recorder**: numeric sites fold `min`/`max` per hit (two `f64`s; non-numeric or single-hit sites carry none; a non-numeric value landing on a previously-numeric site — a union-typed binder — drops the range).
- **Wire**: `min`/`max` as raw JSON numbers when present; absent otherwise (v1/v2 consumers unaffected).
- **LSP**: inline hints read `= 0.1…0.61667 (×120)` (~5-significant-digit shortening); hover keeps the exact last value plus `, range …`. Degenerate ranges (loop-constants) stay a plain value.
- **Web editors**: same policy via the existing `shortNumbers`; hover appends the range.
- **VSCode harness regression** (the revived #351 doing its job): the canned trace carries a 120-hit range binding asserted in Monaco — `= 0.1…0.61667 (×120)` — alongside the existing hints. Plus `FUNCTOR_E2E_VIDEO=1` records harness sessions as `.webm` for PR visuals.

A recorded harness session (the live preview booting, pausing on a real frame, live hints appearing):

![vscode session](https://gist.github.com/tommy-xr/d854579e69c31c23fdc1a30ea9d13dba/raw/vscode-range-session.gif)

## Testing

- `cargo test`: functor-lang 501 (fold ranges pinned: acc 0…3, x 1…3, non-numeric none), functor_runtime_common 310, desktop 49, functor-lang-lsp 42 (range + degenerate + hover labels pinned exactly)
- `npm run test:site` → ALL CHECKS PASSED (new check: the hero's ×120 sites render `min…max` ranges in the editor)
- `npm run test:vscode-e2e` → 2 passed (range hint asserted in Monaco)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
