### PR TITLE
feat(lang): Asset.model/texture/sound — branded asset locators (B.1)

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -190,9 +190,10 @@ let grab = (s) =>
   that creates no cycle.
 - **Protected namespaces**: a file whose module name collides with a
   builtin/prelude namespace (Net, Key, Random, List, Text, Math, Debug, Scene,
-  Anim, Camera, Frame, Light, Fog, Color, Vec3, Skybox, Angle, Texture, Time, Sub,
-  Effect, Physics, RenderTarget, Ui, AudioSource, AudioScene) is a load
-  error — rename the file.
+  Anim, Asset, Camera, Frame, Light, Fog, Color, Vec3, Skybox, Angle, Texture,
+  Time, Sub, Effect, Physics, RenderTarget, Ui, AudioSource, AudioScene) is a
+  load error — rename the file. (`assets.fun` → `Assets` — the generated
+  manifest — is fine; only the exact name collides.)
 - **`Net` is a built-in module**, always in scope: `type NetEvent =
   | Connected(id: float) | Message(id: float, text: string) |
   Disconnected(id: float) | Error(id: float, text: string)`. A `Sub.connect`/
@@ -243,13 +244,13 @@ open Widget                                              // …or open, bringing
 - **Runtime is unchanged**: an interface member stays an `External` (the host
   provides its value at run time), so `.funi` is a pure check-time overlay.
 - This is how the **engine prelude's types are declared**: the `functor-prelude`
-  crate ships a `.funi` for every host namespace (`Scene`, `Camera`, `Frame`,
-  `Light`, `Fog`, `Skybox`, `RenderTarget`, `Texture`, `Angle`, `Time`, `Sub`,
-  `Effect`, `Physics`, `Ui`, `AudioSource`, `AudioScene`), loaded by the runner
-  so engine calls carry real types (no longer `Unknown`). Each module's primary
-  opaque handle is `Mod.t` (`Camera.t`, `Frame.t`, `Effect.t`, …); modules that
-  own several name each (`Scene.t`; `Physics.shape`/`body`/`world`;
-  `Ui.view`/`anchor`). Physics query/event results are records
+  crate ships a `.funi` for every host namespace (`Scene`, `Asset`, `Camera`,
+  `Frame`, `Light`, `Fog`, `Skybox`, `RenderTarget`, `Texture`, `Angle`, `Time`,
+  `Sub`, `Effect`, `Physics`, `Ui`, `AudioSource`, `AudioScene`), loaded by the
+  runner so engine calls carry real types (no longer `Unknown`). Each module's
+  primary opaque handle is `Mod.t` (`Camera.t`, `Frame.t`, `Effect.t`, …);
+  modules that own several name each (`Scene.t`; `Physics.shape`/`body`/`world`;
+  `Ui.view`/`anchor`; `Asset.Model`/`Texture`/`Sound`). Physics query/event results are records
   (`Physics.position`, `Physics.rayHit`, `Physics.collisionEvent`).
 
 ## Semantics rules that WILL bite you
@@ -382,6 +383,32 @@ Scene.cube() / sphere() / cylinder() / quad() / plane()   // zero args, enforced
 Scene.model("shark.glb")                                   // glTF by path, relative to the
                                                            //   game dir; missing file =
                                                            //   logged error + empty fallback
+Asset.model("shark.glb") / Asset.texture("wood.png")       // typed asset locators, branded
+Asset.sound("boom.ogg")                                    //   per KIND (types Asset.Model /
+                                                           //   Asset.Texture / Asset.Sound).
+                                                           //   Scene.model, Effect.play/
+                                                           //   playAt/playThen, and
+                                                           //   AudioSource.ambient/at accept
+                                                           //   the matching kind alongside
+                                                           //   the pre-manifest bare path
+                                                           //   string (deprecated, retired
+                                                           //   at the flag day; the
+                                                           //   AudioSource KEY stays a
+                                                           //   string). The texture
+                                                           //   materials accept
+                                                           //   Asset.Texture alongside a
+                                                           //   Texture.t VALUE — they never
+                                                           //   took bare strings. A WRONG-
+                                                           //   kind asset (a sound into
+                                                           //   Scene.model) is a teaching
+                                                           //   error naming the right
+                                                           //   constructor. Check-time: the
+                                                           //   consumers' asset params are
+                                                           //   gradually typed (no union
+                                                           //   type) until the flag day
+                                                           //   tightens them to the Asset
+                                                           //   kinds; the constructors are
+                                                           //   fully typed now
 Scene.group([scene, …])
 Color.rgb(r, g, b)                                         // Color VALUES only (the
                                                            //   Angle rule): every color

--- a/functor-lang/src/project.rs
+++ b/functor-lang/src/project.rs
@@ -51,6 +51,7 @@ const PROTECTED_NAMESPACES: &[&str] = &[
     "Random",
     "Scene",
     "Anim",
+    "Asset",
     "Camera",
     "Frame",
     "Light",

--- a/functor-prelude/prelude/asset.funi
+++ b/functor-prelude/prelude/asset.funi
@@ -1,0 +1,19 @@
+// asset.funi — the `Asset` host module (interface only; implemented in Rust by
+// FunctorHost in functor_runtime_common::functor_lang_prelude). See docs/functor-lang-interfaces.md.
+//
+// Typed asset locators (the typed-manifest front door): one branded value per
+// asset KIND, so a wrong-kind asset (a sound where a model belongs) is a
+// teaching error instead of a silent fallback at draw. These per-kind
+// constructors are the PERMANENT dynamic escape hatch — the typed manifest
+// `functor import` grows into (Track B.2) will call the same ones; bare
+// strings live only at data boundaries.
+
+// The branded locator types, one per kind (`Asset.Model` from game code).
+type Model
+type Texture
+type Sound
+
+// Construct a locator from a non-empty path (relative to the game dir).
+let model : (string) => Model
+let texture : (string) => Texture
+let sound : (string) => Sound

--- a/functor-prelude/prelude/audio_source.funi
+++ b/functor-prelude/prelude/audio_source.funi
@@ -7,9 +7,12 @@
 // The opaque audio-source handle (`AudioSource.t` from game code).
 type t
 
-// key, sound.
-let ambient : (string, string) => t
+// key, sound. The sound parameter accepts a path string OR an `Asset.Sound`
+// during the typed-asset migration (gradually typed — no union type); the
+// flag day tightens it. The KEY stays a string (cross-frame identity, not
+// an asset).
+let ambient : (string, 'sound) => t
 // key, sound, pos.
-let at : (string, string, Vec3.t) => t
+let at : (string, 'sound, Vec3.t) => t
 // Source LAST (subject-last), so it pipes: `AudioSource.ambient(…) |> AudioSource.gain(0.35)`.
 let gain : (float, t) => t

--- a/functor-prelude/prelude/effect.funi
+++ b/functor-prelude/prelude/effect.funi
@@ -18,7 +18,10 @@ let send : (float, string) => t
 let httpGet : (string, (Net.HttpResponse) => 'msg) => t
 let httpPost : (string, string, (Net.HttpResponse) => 'msg) => t
 // Fire-and-forget audio one-shots. `play` is non-spatial; `playAt` positioned.
-let play : (string) => t
-let playAt : (string, Vec3.t) => t
+// The sound parameter accepts a path string OR an `Asset.Sound` during the
+// typed-asset migration (gradually typed — no union type); the flag day
+// tightens it, and the host teaches wrong-kind assets at runtime.
+let play : ('sound) => t
+let playAt : ('sound, Vec3.t) => t
 // Play once and deliver `'msg` (a message VALUE, not a tagger) when it finishes.
-let playThen : (string, 'msg) => t
+let playThen : ('sound, 'msg) => t

--- a/functor-prelude/prelude/scene.funi
+++ b/functor-prelude/prelude/scene.funi
@@ -20,8 +20,11 @@ let cylinder : () => t
 let quad : () => t
 let plane : () => t
 
-// Assets and generated surfaces.
-let model : (string) => t
+// Assets and generated surfaces. During the typed-asset migration, `model`
+// accepts a path string OR an `Asset.Model` value (there is no union type, so
+// the parameter is gradually typed); the flag day tightens it to
+// `(Asset.Model) => t`, and the host teaches wrong-kind assets at runtime.
+let model : ('asset) => t
 let heightmap : (List<List<float>>) => t
 
 // Composition.
@@ -32,9 +35,12 @@ let group : (List<t>) => t
 let color : (Color.t, t) => t
 let lit : (Color.t, t) => t
 let emissive : (Color.t, t) => t
-let litTexture : (Texture.t, t) => t
-let emissiveTexture : (Texture.t, t) => t
-let litNormalMapped : (Color.t, Texture.t, t) => t
+// Texture parameters accept a `Texture.t` OR an `Asset.Texture` during the
+// typed-asset migration (gradually typed — no union type); the flag day
+// tightens them, and the host teaches bare strings / wrong kinds at runtime.
+let litTexture : ('texture, t) => t
+let emissiveTexture : ('texture, t) => t
+let litNormalMapped : (Color.t, 'texture, t) => t
 let screen : (RenderTarget.t, t) => t
 
 // Animation (subject-last): attach an Anim expression to the Model node(s)

--- a/functor-prelude/src/lib.rs
+++ b/functor-prelude/src/lib.rs
@@ -18,6 +18,7 @@ pub fn modules() -> Vec<(String, String)> {
     vec![
         module("Scene", include_str!("../prelude/scene.funi")),
         module("Anim", include_str!("../prelude/anim.funi")),
+        module("Asset", include_str!("../prelude/asset.funi")),
         module("Angle", include_str!("../prelude/angle.funi")),
         module("Color", include_str!("../prelude/color.funi")),
         module("Vec3", include_str!("../prelude/vec3.funi")),

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -635,6 +635,71 @@ impl HostData for FunctorLangTexture {
     }
 }
 
+/// Which asset family a branded [`FunctorLangAsset`] locates. Consumers check
+/// it, so a sound asset can't slip into `Scene.model` (the Angle rule,
+/// applied per asset kind).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum AssetKind {
+    Model,
+    Texture,
+    Sound,
+}
+
+impl AssetKind {
+    /// How errors name the kind: "a model asset".
+    fn noun(self) -> &'static str {
+        match self {
+            AssetKind::Model => "model",
+            AssetKind::Texture => "texture",
+            AssetKind::Sound => "sound",
+        }
+    }
+
+    /// The constructor a teaching error points at.
+    fn constructor(self) -> &'static str {
+        match self {
+            AssetKind::Model => "Asset.model(…)",
+            AssetKind::Texture => "Asset.texture(…)",
+            AssetKind::Sound => "Asset.sound(…)",
+        }
+    }
+
+    /// The example path in the constructor's usage message.
+    fn example(self) -> &'static str {
+        match self {
+            AssetKind::Model => "file.glb",
+            AssetKind::Texture => "file.png",
+            AssetKind::Sound => "file.ogg",
+        }
+    }
+}
+
+/// A typed asset locator as an opaque Functor Lang value — made by
+/// `Asset.model` / `Asset.texture` / `Asset.sound` (the typed-manifest front
+/// door). Asset-consuming functions accept it alongside the bare path string
+/// (the pre-manifest form, deprecated at B.6) and check the KIND, so a
+/// wrong-kind asset is a teaching error at the call instead of a silent
+/// fallback at draw.
+struct FunctorLangAsset {
+    kind: AssetKind,
+    path: String,
+}
+
+impl HostData for FunctorLangAsset {
+    fn type_name(&self) -> &'static str {
+        "Asset"
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+    // A kind tag + a path string — plain data, like Color/Vec3. Manifests
+    // get stored in models (`init = { mesh: Assets.barrel }`), and that must
+    // not invalidate hot-reload time-travel history.
+    fn is_reload_safe_snapshot(&self) -> bool {
+        true
+    }
+}
+
 /// A [`View`] as an opaque Functor Lang value — what the optional `ui(model)` entry
 /// point returns (`Ui.text` / `Ui.column` / `Ui.panel`). The shells lower it
 /// to the shared egui text overlay, exactly as the F# `ui` hook's tree.
@@ -929,6 +994,9 @@ const PATHS: &[&str] = &[
     "Anim.add",
     "Anim.mask",
     "Anim.rotate",
+    "Asset.model",
+    "Asset.texture",
+    "Asset.sound",
     "Texture.file",
     "Angle.degrees",
     "Angle.radians",
@@ -1053,11 +1121,44 @@ impl Host for FunctorHost {
                         animation: None,
                     }))
                 }
+                [v] if asset_of(v).is_some() => {
+                    let path = asset_path(v, AssetKind::Model, "Scene.model", span)?;
+                    scene_value(Scene3D::model(ModelDescription {
+                        handle: ModelHandle::File(path),
+                        overrides: Vec::new(),
+                        animation: None,
+                    }))
+                }
                 _ => usage(
                     "Scene.model(\"file.glb\") — a non-empty glTF path relative to \
 the game dir",
                 ),
             },
+            // Typed asset locators (the typed-manifest front door): a branded
+            // value naming an asset by path, constructed per KIND so a
+            // wrong-kind asset is a teaching error at the consumer instead of
+            // a silent fallback at draw. These are the PERMANENT dynamic
+            // constructors — the typed manifest `functor import` grows into
+            // (Track B.2) will call the same ones; strings live only at data
+            // boundaries.
+            "Asset.model" | "Asset.texture" | "Asset.sound" => {
+                let kind = match path {
+                    "Asset.model" => AssetKind::Model,
+                    "Asset.texture" => AssetKind::Texture,
+                    _ => AssetKind::Sound,
+                };
+                match args.as_slice() {
+                    [Value::String(p)] if !p.is_empty() => Ok(host(FunctorLangAsset {
+                        kind,
+                        path: p.to_string(),
+                    })),
+                    _ => usage(&format!(
+                        "{path}(\"{}\") — a non-empty {} path relative to the game dir",
+                        kind.example(),
+                        kind.noun(),
+                    )),
+                }
+            }
             // Attach an animation expression to the Model node(s) in a scene
             // (scene-last, so it pipes right after `Scene.model`). Without it
             // a skinned model keeps the zero-config default: its first clip
@@ -1322,9 +1423,9 @@ the game dir",
                     };
                     let texture = texture_of(texture, path, span)?;
                     let material = if path == "Scene.litTexture" {
-                        MaterialDescription::lit_texture(texture.clone())
+                        MaterialDescription::lit_texture(texture)
                     } else {
-                        MaterialDescription::emissive_texture(texture.clone())
+                        MaterialDescription::emissive_texture(texture)
                     };
                     scene_value(Scene3D {
                         obj: SceneObject::Material(material, vec![scene.clone()]),
@@ -1346,7 +1447,7 @@ the game dir",
                     let normal = texture_of(normal, path, span)?;
                     scene_value(Scene3D {
                         obj: SceneObject::Material(
-                            MaterialDescription::lit_normal_mapped(r, g, b, 1.0, normal.clone()),
+                            MaterialDescription::lit_normal_mapped(r, g, b, 1.0, normal),
                             vec![scene.clone()],
                         ),
                         xform: Matrix4::from_scale(1.0),
@@ -1866,6 +1967,13 @@ the Net.HttpResponse, got {}",
                     sound: sound.to_string(),
                     position: None,
                 }))),
+                [v] if asset_of(v).is_some() => {
+                    let sound = asset_path(v, AssetKind::Sound, "Effect.play", span)?;
+                    Ok(host(FunctorLangEffect(EffectTree::PlayAudio {
+                        sound,
+                        position: None,
+                    })))
+                }
                 _ => usage("Effect.play(sound)"),
             },
             "Effect.playAt" => match args.as_slice() {
@@ -1873,6 +1981,14 @@ the Net.HttpResponse, got {}",
                     let (x, y, z) = vec3_of(v, path, span)?;
                     Ok(host(FunctorLangEffect(EffectTree::PlayAudio {
                         sound: sound.to_string(),
+                        position: Some([x, y, z]),
+                    })))
+                }
+                [a, v] if asset_of(a).is_some() => {
+                    let sound = asset_path(a, AssetKind::Sound, "Effect.playAt", span)?;
+                    let (x, y, z) = vec3_of(v, path, span)?;
+                    Ok(host(FunctorLangEffect(EffectTree::PlayAudio {
+                        sound,
                         position: Some([x, y, z]),
                     })))
                 }
@@ -1886,6 +2002,13 @@ the Net.HttpResponse, got {}",
                     sound: sound.to_string(),
                     message: msg.clone(),
                 }))),
+                [a, msg] if asset_of(a).is_some() => {
+                    let sound = asset_path(a, AssetKind::Sound, "Effect.playThen", span)?;
+                    Ok(host(FunctorLangEffect(EffectTree::PlayAudioThen {
+                        sound,
+                        message: msg.clone(),
+                    })))
+                }
                 _ => usage("Effect.playThen(sound, msg)"),
             },
             // Soundscape voices (the continuous, reconciled half of audio).
@@ -1895,6 +2018,12 @@ the Net.HttpResponse, got {}",
                 [Value::String(key), Value::String(sound)] => Ok(host(FunctorLangAudioSource(
                     crate::audio::AudioSource::ambient(key.to_string(), sound.to_string()),
                 ))),
+                [Value::String(key), a] if asset_of(a).is_some() => {
+                    let sound = asset_path(a, AssetKind::Sound, "AudioSource.ambient", span)?;
+                    Ok(host(FunctorLangAudioSource(
+                        crate::audio::AudioSource::ambient(key.to_string(), sound),
+                    )))
+                }
                 _ => usage("AudioSource.ambient(key, sound)"),
             },
             "AudioSource.at" => match args.as_slice() {
@@ -1903,6 +2032,17 @@ the Net.HttpResponse, got {}",
                     Ok(host(FunctorLangAudioSource(crate::audio::AudioSource::at(
                         key.to_string(),
                         sound.to_string(),
+                        x,
+                        y,
+                        z,
+                    ))))
+                }
+                [Value::String(key), a, v] if asset_of(a).is_some() => {
+                    let sound = asset_path(a, AssetKind::Sound, "AudioSource.at", span)?;
+                    let (x, y, z) = vec3_of(v, path, span)?;
+                    Ok(host(FunctorLangAudioSource(crate::audio::AudioSource::at(
+                        key.to_string(),
+                        sound,
                         x,
                         y,
                         z,
@@ -3479,24 +3619,27 @@ with Ui.topLeft()"
     }
 }
 
-/// Extract a [`TextureDescription`] — texture materials accept ONLY the
-/// branded value, so the predictable mistake (a bare path string) gets a
-/// teaching error pointing at `Texture.file` (the [`angle_of`] rule, applied
-/// to assets).
-fn texture_of<'a>(
-    value: &'a Value,
-    what: &str,
-    span: Span,
-) -> Result<&'a TextureDescription, RunError> {
+/// Extract a [`TextureDescription`] — texture materials accept the branded
+/// `Texture.file` value or a texture Asset (`Asset.texture`), never a bare
+/// path string: that predictable mistake gets a teaching error pointing at
+/// the constructors (the [`angle_of`] rule, applied to assets).
+fn texture_of(value: &Value, what: &str, span: Span) -> Result<TextureDescription, RunError> {
     match value {
-        Value::HostData(data) => data
-            .as_any()
-            .downcast_ref::<FunctorLangTexture>()
-            .map(|t| &t.0)
-            .ok_or_else(|| RunError {
+        Value::HostData(data) => {
+            if let Some(t) = data.as_any().downcast_ref::<FunctorLangTexture>() {
+                return Ok(t.0.clone());
+            }
+            if asset_of(value).is_some() {
+                // A texture asset carries a file path; a wrong-kind asset is
+                // a teaching error from asset_path.
+                return asset_path(value, AssetKind::Texture, what, span)
+                    .map(TextureDescription::File);
+            }
+            Err(RunError {
                 message: format!("{what}: expected a Texture, got {}", value.kind_name()),
                 span,
-            }),
+            })
+        }
         Value::String(_) => Err(RunError {
             message: format!(
                 "{what}: expected a Texture, got a bare string — build one with \
@@ -3508,6 +3651,35 @@ Texture.file(\"…\") and pass that value"
             message: format!("{what}: expected a Texture, got {}", other.kind_name()),
             span,
         }),
+    }
+}
+
+/// Downcast to the branded Asset locator, if the value is one.
+fn asset_of(value: &Value) -> Option<&FunctorLangAsset> {
+    match value {
+        Value::HostData(data) => data.as_any().downcast_ref::<FunctorLangAsset>(),
+        _ => None,
+    }
+}
+
+/// The path inside an Asset argument, enforcing the KIND: a sound asset
+/// where a model asset belongs is a teaching error naming the right
+/// constructor. Callers guard with [`asset_of`] first.
+fn asset_path(value: &Value, kind: AssetKind, what: &str, span: Span) -> Result<String, RunError> {
+    let asset = asset_of(value).expect("asset_path callers guard with asset_of");
+    if asset.kind == kind {
+        Ok(asset.path.clone())
+    } else {
+        Err(RunError {
+            message: format!(
+                "{what}: expected a {} asset, got a {} asset (\"{}\") — construct it with {}",
+                kind.noun(),
+                asset.kind.noun(),
+                asset.path,
+                kind.constructor(),
+            ),
+            span,
+        })
     }
 }
 
@@ -3818,6 +3990,198 @@ module is CLOSED, so games referencing these break at load: {missing:?}"
                 "usage: Scene.model(\"file.glb\") — a non-empty glTF path relative to \
 the game dir"
             );
+        }
+    }
+
+    // --- typed assets (Track B.1) ---
+
+    /// A run failure's message, for teaching-error assertions.
+    fn fail_message(src: &str) -> String {
+        let module = functor_lang::lower(functor_lang::parse(src).unwrap()).unwrap();
+        functor_lang::run_with_host(&module, Tracing::Off, &mut FunctorHost)
+            .err()
+            .expect("should fail")
+            .error
+            .message
+    }
+
+    /// `Asset.model` flows into `Scene.model` exactly like the (deprecated)
+    /// bare path string — byte-identical protocol frames.
+    #[test]
+    fn asset_model_matches_string_form() {
+        let camera = "Camera.lookAt(Vec3.make(0.0, 1.0, -3.0), Vec3.make(0.0, 0.0, 0.0))";
+        let by_string =
+            frame_of(&format!("let main = () => Frame.create({camera}, Scene.model(\"shark.glb\"))"));
+        let by_asset = frame_of(&format!(
+            "let main = () => Frame.create({camera}, Scene.model(Asset.model(\"shark.glb\")))"
+        ));
+        assert_eq!(
+            serde_json::to_string(&by_string).unwrap(),
+            serde_json::to_string(&by_asset).unwrap()
+        );
+    }
+
+    /// `Asset.texture` feeds the texture materials exactly like a
+    /// `Texture.file` value (both lit and the normal-map slot).
+    #[test]
+    fn asset_texture_matches_texture_file_form() {
+        let camera = "Camera.lookAt(Vec3.make(0.0, 1.0, -3.0), Vec3.make(0.0, 0.0, 0.0))";
+        for (by_texture, by_asset) in [
+            (
+                "Scene.plane() |> Scene.litTexture(Texture.file(\"wood.png\"))",
+                "Scene.plane() |> Scene.litTexture(Asset.texture(\"wood.png\"))",
+            ),
+            (
+                "Scene.plane() |> Scene.litNormalMapped(Color.rgb(1.0, 1.0, 1.0), Texture.file(\"n.png\"))",
+                "Scene.plane() |> Scene.litNormalMapped(Color.rgb(1.0, 1.0, 1.0), Asset.texture(\"n.png\"))",
+            ),
+        ] {
+            let a = frame_of(&format!("let main = () => Frame.create({camera}, {by_texture})"));
+            let b = frame_of(&format!("let main = () => Frame.create({camera}, {by_asset})"));
+            assert_eq!(
+                serde_json::to_string(&a).unwrap(),
+                serde_json::to_string(&b).unwrap()
+            );
+        }
+    }
+
+    /// `Asset.sound` feeds the soundscape voices exactly like a bare path
+    /// (the key stays a string — identity, not an asset).
+    #[test]
+    fn asset_sound_matches_string_form_in_soundscape() {
+        let by_string = eval("let main = () => AudioSource.ambient(\"bed\", \"wind.ogg\")");
+        let by_asset =
+            eval("let main = () => AudioSource.ambient(\"bed\", Asset.sound(\"wind.ogg\"))");
+        assert_eq!(
+            audio_source_of(&by_string).unwrap(),
+            audio_source_of(&by_asset).unwrap()
+        );
+        let by_string = eval(
+            "let main = () => AudioSource.at(\"fire\", \"crackle.ogg\", Vec3.make(1.0, 0.0, 2.0))",
+        );
+        let by_asset = eval(
+            "let main = () => AudioSource.at(\"fire\", Asset.sound(\"crackle.ogg\"), Vec3.make(1.0, 0.0, 2.0))",
+        );
+        assert_eq!(
+            audio_source_of(&by_string).unwrap(),
+            audio_source_of(&by_asset).unwrap()
+        );
+    }
+
+    /// `Asset.sound` in the one-shot effects queues the same AudioCommands
+    /// as the bare-path form.
+    #[test]
+    fn asset_sound_matches_string_form_in_one_shots() {
+        let _guard = crate::audio::OUTBOUND_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let _ = crate::audio::drain_commands(); // clear the shared queue
+        let src = "\
+            let init = 0.0\n\
+            let shoot = Effect.play(Asset.sound(\"gunshot.wav\"))\n\
+            let blast = Effect.playAt(Asset.sound(\"explosion.wav\"), Vec3.make(5.0, 0.5, -2.0))\n";
+        let project = functor_lang::project::load_single_source("game", src)
+            .unwrap_or_else(|e| panic!("load: {}", e.render()));
+        let session = functor_lang::Session::load(&project.module, &mut FunctorHost)
+            .unwrap_or_else(|f| panic!("session: {}", f.error.message));
+        let mut model = session.global("init").unwrap();
+        let mut log = EffectLog::new();
+        for name in ["shoot", "blast"] {
+            let effect = effect_of(&session.global(name).unwrap()).unwrap().0.clone();
+            let _ = drain_effects(
+                &session,
+                &mut model,
+                effect,
+                &mut FakeEffects::new(0.0, vec![]),
+                &mut log,
+                &mut |m| panic!("unexpected report: {m}"),
+                false,
+            );
+        }
+        assert_eq!(
+            crate::audio::drain_commands(),
+            vec![
+                crate::audio::AudioCommand::PlayOneShot {
+                    token: None,
+                    sound: "gunshot.wav".to_string(),
+                    gain: 1.0,
+                    position: None,
+                },
+                crate::audio::AudioCommand::PlayOneShot {
+                    token: None,
+                    sound: "explosion.wav".to_string(),
+                    gain: 1.0,
+                    position: Some([5.0, 0.5, -2.0]),
+                },
+            ]
+        );
+    }
+
+    /// The Asset constructors teach their usage: a bare number or an empty
+    /// path is a spanned error naming the kind's example file.
+    #[test]
+    fn asset_constructors_teach_usage() {
+        for (src, want) in [
+            (
+                "let main = () => Asset.model(42.0)",
+                "usage: Asset.model(\"file.glb\") — a non-empty model path relative to the game dir",
+            ),
+            (
+                "let main = () => Asset.model(\"\")",
+                "usage: Asset.model(\"file.glb\") — a non-empty model path relative to the game dir",
+            ),
+            (
+                "let main = () => Asset.texture(42.0)",
+                "usage: Asset.texture(\"file.png\") — a non-empty texture path relative to the game dir",
+            ),
+            (
+                "let main = () => Asset.sound()",
+                "usage: Asset.sound(\"file.ogg\") — a non-empty sound path relative to the game dir",
+            ),
+        ] {
+            assert_eq!(fail_message(src), want, "for {src}");
+        }
+    }
+
+    /// A wrong-kind asset at a consumer is a teaching error naming the value,
+    /// its actual kind, and the constructor that fits — never a silent
+    /// fallback at draw.
+    #[test]
+    fn wrong_kind_assets_are_teaching_errors() {
+        for (src, want) in [
+            (
+                "let main = () => Scene.model(Asset.sound(\"boom.ogg\"))",
+                "Scene.model: expected a model asset, got a sound asset (\"boom.ogg\") — \
+construct it with Asset.model(…)",
+            ),
+            (
+                "let main = () => Scene.plane() |> Scene.litTexture(Asset.model(\"shark.glb\"))",
+                "Scene.litTexture: expected a texture asset, got a model asset (\"shark.glb\") — \
+construct it with Asset.texture(…)",
+            ),
+            (
+                "let main = () => Effect.play(Asset.texture(\"wood.png\"))",
+                "Effect.play: expected a sound asset, got a texture asset (\"wood.png\") — \
+construct it with Asset.sound(…)",
+            ),
+            (
+                "let main = () => AudioSource.ambient(\"bed\", Asset.model(\"shark.glb\"))",
+                "AudioSource.ambient: expected a sound asset, got a model asset (\"shark.glb\") — \
+construct it with Asset.sound(…)",
+            ),
+        ] {
+            assert_eq!(fail_message(src), want, "for {src}");
+        }
+    }
+
+    /// An Asset is plain data (kind + path), so storing one in the model must
+    /// not invalidate hot-reload time-travel history.
+    #[test]
+    fn assets_are_reload_safe_snapshots() {
+        let value = eval("let main = () => Asset.model(\"shark.glb\")");
+        match &value {
+            Value::HostData(data) => assert!(data.is_reload_safe_snapshot()),
+            other => panic!("expected a HostData asset, got {}", other.kind_name()),
         }
     }
 

--- a/runtime/functor-runtime-common/tests/prelude_typecheck.rs
+++ b/runtime/functor-runtime-common/tests/prelude_typecheck.rs
@@ -58,3 +58,41 @@ fn host_calls_have_real_types() {
     );
     assert!(diags.iter().any(|m| m.contains("Frame.t")), "{diags:?}");
 }
+
+// --- typed assets (Track B.1) ---
+
+/// The `Asset` constructors are fully typed: a non-string argument is a
+/// check-time diagnostic, and each kind's annotation holds.
+#[test]
+fn asset_constructors_are_typed() {
+    let diags = check("let a = Asset.model(42.0)");
+    assert!(!diags.is_empty(), "Asset.model(42.0) must be a check error");
+
+    let diags = check("let a : Asset.Model = Asset.model(\"barrel.glb\")");
+    assert!(diags.is_empty(), "kind annotation should hold: {diags:?}");
+
+    // A kind mismatch is a check-time error — the whole point of the brand.
+    let diags = check("let a : Asset.Sound = Asset.model(\"barrel.glb\")");
+    assert!(
+        diags.iter().any(|m| m.contains("Model")),
+        "Asset.Model vs Asset.Sound must error: {diags:?}"
+    );
+}
+
+/// During the typed-asset migration, asset-consuming functions accept BOTH
+/// the bare path string (deprecated at the flag day) and the branded Asset
+/// value — their asset parameter is gradually typed, so both forms check
+/// clean; the host enforces kinds at runtime.
+#[test]
+fn asset_consumers_accept_both_forms() {
+    let diags = check(
+        "let byString = Scene.model(\"shark.glb\")\n\
+         let byAsset = Scene.model(Asset.model(\"shark.glb\"))\n\
+         let tex = Scene.plane() |> Scene.litTexture(Asset.texture(\"wood.png\"))\n\
+         let texFile = Scene.plane() |> Scene.litTexture(Texture.file(\"wood.png\"))\n\
+         let sfx = Effect.play(Asset.sound(\"boom.ogg\"))\n\
+         let sfxString = Effect.play(\"boom.ogg\")\n\
+         let bed = AudioSource.ambient(\"bed\", Asset.sound(\"wind.ogg\"))",
+    );
+    assert!(diags.is_empty(), "both forms should check clean: {diags:?}");
+}


### PR DESCRIPTION
Track B.1 of the [asset-handling revamp]: typed asset locators, the typed-manifest front door. `Asset.model` / `Asset.texture` / `Asset.sound` construct branded per-kind values (`Asset.Model` / `Asset.Texture` / `Asset.Sound`), and the asset-consuming functions accept them alongside their existing forms — so a wrong-kind asset is a **teaching error naming the right constructor** instead of a silent fallback at draw.

## What changed

- **Runtime** (`functor_lang_prelude.rs`): `FunctorLangAsset` brand (kind + path; reload-safe plain data, so manifests stored in the model don't invalidate time-travel history). Constructors with per-kind usage errors. Consumer acceptance in `Scene.model`, the texture materials (`litTexture` / `emissiveTexture` / `litNormalMapped`, via `texture_of`), `Effect.play` / `playAt` / `playThen`, and `AudioSource.ambient` / `at` (the key stays a string). **Existing string forms are byte-for-byte unchanged** — every pre-existing match arm and error message is preserved.
- **Check-time**: new `asset.funi` with the three opaque kinds and fully typed constructors (`Asset.model : (string) => Model`); `Asset` added to the protected namespaces (the generated `assets.fun` → `Assets` module is unaffected).
- **Skill**: functor-lang SKILL.md updated in the same PR (prelude surface, namespaces, funi list).

## Design note: consumer signatures are gradually typed for the migration window

The checker has no union types, so a consumer typed `(string) => t` cannot also accept `Asset.Model`. Since strings must keep working until the B.6 flag day (settled decision), the asset-accepting parameters loosen to type variables for the window, with the runtime carrying enforcement (wrong kinds and bare-string-into-texture-material both get teaching errors). B.6 tightens them to the Asset kinds — at which point check-time is *stronger* than today. The tradeoff is documented at each loosened signature.

## Verification

- `cargo test -p functor_runtime_common` (309, incl. 7 new: string↔Asset parity on protocol frames and AudioCommands, teaching errors, usage errors, reload-safety) and `-p functor-lang` — green; the funi↔PATHS drift test covers the new module.
- 5 check-time tests in `prelude_typecheck.rs`: constructors typed, kind annotations hold, kind mismatch errors, both consumer forms check clean.
- All examples build with the rebuilt CLI. (`examples/loading` fails identically on main — pre-existing: #372's Vec3/Color branding missed it; will fix separately.)
- Fixed-time captures of `Scene.model("shark.glb")` vs `Scene.model(Asset.model("shark.glb"))` are **byte-identical PNGs**.

## xreview disposition (two-engine review: Claude + Codex)

- **[AGREED] texture-materials/string asymmetry** — with `litTexture`'s param loosened, a bare string *typechecks* but fails at runtime (teaching error pointing at `Texture.file`). Codex proposed accepting strings there; **rejected**: texture materials never accepted strings (pre-existing Angle rule), and widening the string surface now adds exactly what B.6 must remove. Claude's angle (SKILL.md overclaimed strings work there) — **fixed**.
- **Codex Low** (comments claimed the generated manifest already calls `Asset.*` — that's B.2) — **fixed**, softened to future tense.
- **Claude Low observation** (pre-existing: `FunctorLangTexture` is not reload-safe while `Asset.texture` is) — noted, out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)