### PR TITLE
feat(vscode): execution-recency gutter — parity with the web editors

### DIFF
--- a/tools/functor-lang-lsp/src/inspector.rs
+++ b/tools/functor-lang-lsp/src/inspector.rs
@@ -35,6 +35,17 @@ use serde_json::Value;
 pub struct TraceDoc {
     pub sources: Vec<SourceHash>,
     pub invocations: Vec<Invocation>,
+    /// Execution coverage per file: byte-start → the frame OFFSETS (relative
+    /// to the paused frame) it executed on. Trace v2's recency-gutter data.
+    pub coverage: Vec<(String, Vec<CoverageSite>)>,
+    /// The static could-run set per file (byte starts) — the "dark" baseline.
+    pub runnable: Vec<(String, Vec<usize>)>,
+}
+
+/// One covered position: a byte start and the frame offsets it ran on.
+pub struct CoverageSite {
+    pub start: usize,
+    pub frames: Vec<i64>,
 }
 
 /// The SHA-256 (hex) of one project file's text as the runtime loaded it.
@@ -100,9 +111,51 @@ impl TraceDoc {
             .iter()
             .filter_map(Invocation::from_json)
             .collect();
+        let obj_entries = |key: &str| -> Vec<(String, Vec<Value>)> {
+            v[key]
+                .as_object()
+                .map(|m| {
+                    m.iter()
+                        .map(|(file, arr)| {
+                            (file.clone(), arr.as_array().cloned().unwrap_or_default())
+                        })
+                        .collect()
+                })
+                .unwrap_or_default()
+        };
+        let coverage = obj_entries("coverage")
+            .into_iter()
+            .map(|(file, sites)| {
+                let sites = sites
+                    .iter()
+                    .filter_map(|site| {
+                        Some(CoverageSite {
+                            start: site["start"].as_u64()? as usize,
+                            frames: site["frames"]
+                                .as_array()?
+                                .iter()
+                                .filter_map(|f| f.as_i64())
+                                .collect(),
+                        })
+                    })
+                    .collect();
+                (file, sites)
+            })
+            .collect();
+        let runnable = obj_entries("runnable")
+            .into_iter()
+            .map(|(file, starts)| {
+                (
+                    file,
+                    starts.iter().filter_map(|x| x.as_u64().map(|n| n as usize)).collect(),
+                )
+            })
+            .collect();
         Some(TraceDoc {
             sources,
             invocations,
+            coverage,
+            runnable,
         })
     }
 }
@@ -430,6 +483,83 @@ pub fn execution_count(trace: &TraceDoc, entry: &str) -> usize {
         .unwrap_or(0)
 }
 
+/// The per-line recency-gutter states for `file_name`'s `source` — the same
+/// policy as the web editors' CodeMirror gutter (site/src/lang-intel.js):
+/// `now` (green) ran on the paused frame; `before`/`after` ran only on
+/// earlier/later frames of the window (a line that ran both sides takes the
+/// NEAREST frame, tie → before); `dark` is statically runnable but never ran.
+/// Lines with no runnable position are unmarked. 0-based lines, hash-gated
+/// like every live overlay.
+pub fn coverage_lines(
+    trace: &TraceDoc,
+    file_name: &str,
+    source: &str,
+) -> Vec<(usize, &'static str)> {
+    if !source_matches(trace, file_name, source) {
+        return Vec::new();
+    }
+    #[derive(Default, Clone)]
+    struct LineAcc {
+        now: bool,
+        // Nearest distances (positive numbers), 0 = none seen.
+        before: i64,
+        after: i64,
+        runnable: bool,
+    }
+    let line_of = |byte: usize| {
+        source.as_bytes()[..byte.min(source.len())]
+            .iter()
+            .filter(|&&b| b == b'\n')
+            .count()
+    };
+    let mut lines: std::collections::BTreeMap<usize, LineAcc> = std::collections::BTreeMap::new();
+    for (file, starts) in &trace.runnable {
+        if file != file_name {
+            continue;
+        }
+        for &start in starts {
+            lines.entry(line_of(start)).or_default().runnable = true;
+        }
+    }
+    for (file, sites) in &trace.coverage {
+        if file != file_name {
+            continue;
+        }
+        for site in sites {
+            let acc = lines.entry(line_of(site.start)).or_default();
+            for &frame in &site.frames {
+                if frame == 0 {
+                    acc.now = true;
+                } else if frame < 0 {
+                    let d = -frame;
+                    acc.before = if acc.before == 0 { d } else { acc.before.min(d) };
+                } else {
+                    acc.after = if acc.after == 0 { frame } else { acc.after.min(frame) };
+                }
+            }
+        }
+    }
+    lines
+        .into_iter()
+        .filter_map(|(line, acc)| {
+            let state = if acc.now {
+                "now"
+            } else if acc.before > 0 && acc.after > 0 {
+                if acc.before <= acc.after { "before" } else { "after" }
+            } else if acc.before > 0 {
+                "before"
+            } else if acc.after > 0 {
+                "after"
+            } else if acc.runnable {
+                "dark"
+            } else {
+                return None;
+            };
+            Some((line, state))
+        })
+        .collect()
+}
+
 /// A multi-hit numeric site's `min…max` label, `None` when the range is
 /// absent or degenerate (min == max — the plain value reads better).
 fn range_label(b: &Binding) -> Option<String> {
@@ -666,6 +796,33 @@ mod tests {
         let hints = live_hints(&trace, "game.fun", src, &no_selection());
         assert_eq!(hints.len(), 1);
         assert_eq!(hints[0].offset, region_start + "let t".len());
+    }
+
+    #[test]
+    fn coverage_lines_map_the_four_gutter_states() {
+        // Four lines: ran-now, ran-before-only, ran-after-only, runnable-dark.
+        let src = "let a = 1.0\nlet b = 2.0\nlet c = 3.0\nlet d = 4.0\n";
+        let l = |n: usize| src.split('\n').take(n).map(|x| x.len() + 1).sum::<usize>();
+        let doc = json!({
+            "paused": true,
+            "sources": [ { "file": "game.fun", "hash": sha256_hex(src.as_bytes()) } ],
+            "invocations": [],
+            "coverage": { "game.fun": [
+                { "start": l(0) + 4, "frames": [-3, 0] },
+                { "start": l(1) + 4, "frames": [-2, -7] },
+                { "start": l(2) + 4, "frames": [1, 5, -4] },
+            ]},
+            "runnable": { "game.fun": [l(0) + 4, l(1) + 4, l(2) + 4, l(3) + 4] },
+        });
+        let trace = TraceDoc::from_json(&doc).unwrap();
+        let lines = coverage_lines(&trace, "game.fun", src);
+        // Line 2 ran at -4 and +1: the NEAREST frame wins → after.
+        assert_eq!(
+            lines,
+            vec![(0, "now"), (1, "before"), (2, "after"), (3, "dark")]
+        );
+        // Hash gate: an edited buffer gets nothing.
+        assert!(coverage_lines(&trace, "game.fun", &format!("{src} ")).is_empty());
     }
 
     #[test]

--- a/tools/functor-lang-lsp/src/main.rs
+++ b/tools/functor-lang-lsp/src/main.rs
@@ -303,6 +303,8 @@ fn run(
                 if let Some(project) = load_project(uri, &documents) {
                     projects.insert(uri.to_string(), project);
                 }
+                // A just-opened matching document gets the current coverage.
+                push_coverage(writer, trace.as_ref(), &documents);
             }
             ("textDocument/didChange", None) => {
                 let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
@@ -317,6 +319,9 @@ fn run(
                     if let Some(project) = load_project(uri, &documents) {
                         projects.insert(uri.to_string(), project);
                     }
+                    // The edit changed the hash: the gate re-evaluates (and
+                    // the client's gutter clears via the empty push).
+                    push_coverage(writer, trace.as_ref(), &documents);
                 }
             }
             ("textDocument/didClose", None) => {
@@ -339,6 +344,7 @@ fn run(
                     last_trace_params = Some(params.clone());
                     trace = Some(doc);
                     refresh_overlays(writer, &mut next_request_id);
+                    push_coverage(writer, trace.as_ref(), &documents);
                 }
             }
             // Native refresh: poll `GET /trace` on a background thread. Attach
@@ -654,6 +660,46 @@ fn refresh_overlays(writer: &mut impl Write, next_request_id: &mut i64) {
         write_message(
             writer,
             &json!({ "jsonrpc": "2.0", "id": id, "method": method }),
+        );
+    }
+}
+
+/// Push the recency-gutter coverage to the client — a custom NOTIFICATION
+/// (`functor/inspector/coverage`, no id: fire-and-forget) with per-line
+/// states for every OPEN document the trace covers. Hash-gated per file by
+/// the pure half; a document that no longer matches gets an explicit empty
+/// list so the client clears its gutter (never stale colors on wrong lines).
+fn push_coverage(
+    writer: &mut impl Write,
+    trace: Option<&TraceDoc>,
+    documents: &HashMap<String, String>,
+) {
+    // No trace yet → nothing to draw OR clear (the client starts empty), and
+    // pushing would inject notifications into sessions that never touch the
+    // inspector (the stdio e2e reads the stream in strict order).
+    if trace.is_none() {
+        return;
+    }
+    for (uri, text) in documents {
+        let lines: Vec<Value> = trace
+            .and_then(|t| {
+                let path = uri_to_path(uri)?;
+                let file_name = match_trace_file(t, &path)?;
+                Some(
+                    inspector::coverage_lines(t, &file_name, text)
+                        .into_iter()
+                        .map(|(line, state)| json!({ "line": line, "state": state }))
+                        .collect(),
+                )
+            })
+            .unwrap_or_default();
+        write_message(
+            writer,
+            &json!({
+                "jsonrpc": "2.0",
+                "method": "functor/inspector/coverage",
+                "params": { "uri": uri, "lines": lines },
+            }),
         );
     }
 }

--- a/tools/functor-lang-vscode/client/extension.js
+++ b/tools/functor-lang-vscode/client/extension.js
@@ -70,8 +70,49 @@ function activate(context) {
     { command: "functor-lang-lsp" },
     { documentSelector: [{ language: "functor-lang" }] }
   );
+  // --- Recency gutter (inspector coverage) --------------------------------
+  // Four decoration types, one per state; the LSP pushes per-line states and
+  // we repaint every visible editor for that document. All decision logic is
+  // in inspector.groupCoverage (pure, node-tested); this is thin wiring.
+  const covDecorations = {};
+  for (const state of inspector.COVERAGE_STATES) {
+    covDecorations[state] = vscode.window.createTextEditorDecorationType({
+      gutterIconPath: vscode.Uri.file(
+        path.join(context.extensionPath, "media", `cov-${state}.svg`)
+      ),
+      gutterIconSize: "contain",
+    });
+    context.subscriptions.push(covDecorations[state]);
+  }
+  // uri (string) → grouped line lists, so an editor that becomes visible
+  // later (split, tab switch) repaints from the latest push.
+  const covByUri = new Map();
+  const paintCoverage = (editor) => {
+    const grouped = covByUri.get(editor.document.uri.toString());
+    for (const state of inspector.COVERAGE_STATES) {
+      const lines = (grouped && grouped.groups[state]) || [];
+      editor.setDecorations(
+        covDecorations[state],
+        lines.map((line) => new vscode.Range(line, 0, line, 0))
+      );
+    }
+  };
+  context.subscriptions.push(
+    vscode.window.onDidChangeVisibleTextEditors((editors) => editors.forEach(paintCoverage))
+  );
+
   clientStarted = client.start().then(
-    () => elog("language server started (functor-lang-lsp)"),
+    () => {
+      elog("language server started (functor-lang-lsp)");
+      client.onNotification(inspector.COVERAGE, (params) => {
+        const grouped = inspector.groupCoverage(params);
+        if (!grouped) return;
+        covByUri.set(vscode.Uri.parse(grouped.uri).toString(), grouped);
+        const total = Object.values(grouped.groups).reduce((n, l) => n + l.length, 0);
+        elog(`inspector coverage: ${total} gutter lines for ${grouped.uri}`);
+        vscode.window.visibleTextEditors.forEach(paintCoverage);
+      });
+    },
     (e) => elog(`language server FAILED to start: ${e && e.message ? e.message : e}`)
   );
 

--- a/tools/functor-lang-vscode/client/inspector.js
+++ b/tools/functor-lang-vscode/client/inspector.js
@@ -35,6 +35,27 @@ function relayTrace(msg) {
   return { notification: TRACE, params: msg.trace };
 }
 
+// --- recency-gutter coverage ----------------------------------------------
+// The LSP pushes `functor/inspector/coverage` with per-line recency states
+// (`{ uri, lines: [{line, state}] }`). Group into per-state line lists for
+// the extension to hand to its four decoration types; unknown states are
+// dropped (a newer server must not break an older extension). Pure — the
+// tested half; extension.js does the vscode.Range/setDecorations wiring.
+const COVERAGE = "functor/inspector/coverage";
+const COVERAGE_STATES = ["now", "before", "after", "dark"];
+
+function groupCoverage(params) {
+  const groups = { now: [], before: [], after: [], dark: [] };
+  if (!params || typeof params.uri !== "string" || !Array.isArray(params.lines)) {
+    return null;
+  }
+  for (const entry of params.lines) {
+    if (!entry || typeof entry.line !== "number") continue;
+    if (COVERAGE_STATES.includes(entry.state)) groups[entry.state].push(entry.line);
+  }
+  return { uri: params.uri, groups };
+}
+
 // --- attach / detach notifications ---------------------------------------
 function attachNotification(port) {
   return { notification: ATTACH, params: { port } };
@@ -103,6 +124,9 @@ module.exports = {
   ATTACH_COMMAND,
   DETACH_COMMAND,
   relayTrace,
+  groupCoverage,
+  COVERAGE,
+  COVERAGE_STATES,
   attachNotification,
   detachNotification,
   parsePort,

--- a/tools/functor-lang-vscode/client/inspector.test.js
+++ b/tools/functor-lang-vscode/client/inspector.test.js
@@ -84,3 +84,24 @@ test("statusBar derives text + toggle command from attach state", () => {
   assert.equal(attached.text, "$(debug) inspector :8077");
   assert.equal(attached.command, inspector.DETACH_COMMAND);
 });
+
+test("groupCoverage buckets lines by state and rejects junk", () => {
+  const grouped = inspector.groupCoverage({
+    uri: "file:///g.fun",
+    lines: [
+      { line: 0, state: "now" },
+      { line: 2, state: "before" },
+      { line: 3, state: "after" },
+      { line: 5, state: "dark" },
+      { line: 6, state: "mystery" }, // unknown state → dropped
+      { state: "now" }, // no line → dropped
+    ],
+  });
+  assert.deepStrictEqual(grouped, {
+    uri: "file:///g.fun",
+    groups: { now: [0], before: [2], after: [3], dark: [5] },
+  });
+  assert.strictEqual(inspector.groupCoverage(null), null);
+  assert.strictEqual(inspector.groupCoverage({ uri: 1, lines: [] }), null);
+  assert.strictEqual(inspector.groupCoverage({ uri: "u" }), null);
+});

--- a/tools/functor-lang-vscode/media/cov-after.svg
+++ b/tools/functor-lang-vscode/media/cov-after.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><rect x="6" y="1" width="3" height="14" rx="1" fill="#e858b8" fill-opacity="0.55"/></svg>

--- a/tools/functor-lang-vscode/media/cov-before.svg
+++ b/tools/functor-lang-vscode/media/cov-before.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><rect x="6" y="1" width="3" height="14" rx="1" fill="#41d8e6" fill-opacity="0.55"/></svg>

--- a/tools/functor-lang-vscode/media/cov-dark.svg
+++ b/tools/functor-lang-vscode/media/cov-dark.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><rect x="6" y="1" width="3" height="14" rx="1" fill="#e9e6f2" fill-opacity="0.14"/></svg>

--- a/tools/functor-lang-vscode/media/cov-now.svg
+++ b/tools/functor-lang-vscode/media/cov-now.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><rect x="6" y="1" width="3" height="14" rx="1" fill="#6fdc92" fill-opacity="1.0"/></svg>

--- a/tools/functor-lang-vscode/tests-integration/inspector-inlay.spec.mjs
+++ b/tools/functor-lang-vscode/tests-integration/inspector-inlay.spec.mjs
@@ -42,6 +42,28 @@ test("a paused trace makes a live-value inlay hint appear in the editor", async 
     editor.getByText(EXPECTED_RANGE_HINT, { exact: false }).first()
   ).toBeVisible({ timeout: 15_000 });
 
+  // The recency gutter: the trace's coverage section becomes four gutter
+  // decorations (now/before/after/dark — one per def line in the canned
+  // coverage). Monaco renders gutterIconPath decorations as glyph-margin
+  // elements with our SVGs as background images.
+  const gutterCount = await workbox
+    .locator(".glyph-margin-widgets > div, .margin-view-overlays .cgmr")
+    .filter({ has: workbox.locator(":scope") })
+    .count()
+    .catch(() => 0);
+  const gutterStyles = await workbox.evaluate(() =>
+    [...document.querySelectorAll("[class*='TextEditorDecorationType']")]
+      .map((el) => getComputedStyle(el).backgroundImage)
+      .filter((s) => s.includes("cov-"))
+  );
+  expect(
+    gutterStyles.filter((s) => s.includes("cov-")).length,
+    `gutter decorations rendered: ${JSON.stringify(gutterStyles)} (count probe: ${gutterCount})`
+  ).toBeGreaterThanOrEqual(4);
+
+  // Artifact: hints + gutter in one frame.
+  await workbox.screenshot({ path: test.info().outputPath("vscode-gutter.png") });
+
   // The hash gate: mutate the buffer so its text no longer hashes to the
   // trace's recorded source hash, and the live hint must disappear ("never wrong
   // values on wrong lines"). Any edit changes the whole-file hash.

--- a/tools/functor-lang-vscode/tests-integration/trace.mjs
+++ b/tools/functor-lang-vscode/tests-integration/trace.mjs
@@ -24,17 +24,24 @@ export const EXPECTED_HINT = `= ${CANNED_VALUE}`;
 export const RANGE_BINDING_NAME = "bumped";
 export const EXPECTED_RANGE_HINT = "= 0.1…0.61667 (×120)";
 
+// Wire offsets are BYTES into the file text, not JS string indices — the
+// fixture's header comment contains em-dashes (3 UTF-8 bytes, 1 UTF-16 unit),
+// so a bare indexOf lands hints/gutter lines visibly early. Anchor by
+// characters, convert to bytes.
+const byteAt = (source, index) => Buffer.byteLength(source.slice(0, index), "utf8");
+
 // Build the trace doc for a given game.fun source text. Places the binding at
 // the FIRST occurrence of `model` (the `update` parameter, near the top of the
 // file so its inlay hint is inside the default viewport).
 // The numeric-range binding at update's `bumped` let binder (region-shaped
 // span, `let bumped =`, per the recorder's binder-span convention).
 function rangeBinding(source) {
-  const start = source.indexOf("let bumped");
-  if (start < 0) {
+  const idx = source.indexOf("let bumped");
+  if (idx < 0) {
     throw new Error("binding 'bumped' not found in game.fun");
   }
-  const end = start + source.slice(start).indexOf("=") + 1;
+  const start = byteAt(source, idx);
+  const end = byteAt(source, idx + source.slice(idx).indexOf("=") + 1);
   return {
     name: RANGE_BINDING_NAME,
     file: "game.fun",
@@ -48,12 +55,32 @@ function rangeBinding(source) {
 }
 
 export function buildTrace(source) {
-  const start = source.indexOf(BINDING_NAME);
-  if (start < 0) {
+  const idx = source.indexOf(BINDING_NAME);
+  if (idx < 0) {
     throw new Error(`binding '${BINDING_NAME}' not found in game.fun`);
   }
+  const start = byteAt(source, idx);
   const hash = createHash("sha256").update(Buffer.from(source, "utf8")).digest("hex");
+  // Recency-gutter coverage: distinct states on four def lines. Starts are
+  // byte offsets of each def's body-ish position; the LSP folds them to lines.
+  const at = (needle) => {
+    const i = source.indexOf(needle);
+    if (i < 0) throw new Error(`coverage anchor '${needle}' not found`);
+    return byteAt(source, i);
+  };
+  const coverage = {
+    "game.fun": [
+      { start: at("let update"), frames: [0, -2] },        // now (green)
+      { start: at("let tick"), frames: [-1, -9] },          // before (cyan)
+      { start: at("let draw"), frames: [3] },               // after (pink)
+    ],
+  };
+  const runnable = {
+    "game.fun": [at("let update"), at("let tick"), at("let draw"), at("let subscriptions")],
+  }; // subscriptions never ran → dark
   return {
+    coverage,
+    runnable,
     frame: 1,
     tts: 1.0,
     paused: true,


### PR DESCRIPTION
## Why

The final piece of the inspector v2 arc: the web IDE got the green/cyan/pink/dark recency gutter; VS Code didn't — gutters aren't expressible in pure LSP.

## What

Thin-client split, per the repo's rule:

- **LSP** (`coverage_lines`, node… er, cargo-tested): computes per-line states from the trace it already holds — the CodeMirror gutter's policy ported exactly (now/before/after by nearest frame, tie → before; dark = statically runnable but never ran; hash-gated per file). Pushes a `functor/inspector/coverage` notification on trace change / didOpen / didChange; an edited buffer gets an explicit empty list — never stale colors on moved lines.
- **Extension**: four `gutterIconPath` decoration types (`media/cov-*.svg`), repainted across visible editors; the decision logic lives in the node-tested `groupCoverage`.
- **Harness regression** with a screenshot artifact: the canned trace carries coverage anchored on four defs, asserted as ≥4 rendered gutter decorations in Monaco.

The gutter also **exposed a latent fixture bug**: the canned trace computed offsets with JS `indexOf` (UTF-16 units) where the wire is BYTES — the fixture's em-dash comments shifted every hint and gutter line two lines up (visible in the first capture). Anchors now convert through `Buffer.byteLength`; the real runtime always sent bytes.

All four states on their exact lines — `update` green (ran this frame, `= 42` inline), `tick` cyan, `draw` pink, `subscriptions` dark, with the `= 0.1…0.61667 (×120)` range hint alongside:

![vscode gutter](https://gist.github.com/tommy-xr/d854579e69c31c23fdc1a30ea9d13dba/raw/vscode-gutter-parity.png)

## Testing

- `cargo test -p functor-lang-lsp` — 43 (new: `coverage_lines` pins all four states incl. the nearest-frame tie-break + the hash gate)
- extension `npm test` — 10 (new: `groupCoverage` bucketing + junk rejection)
- `npm run test:vscode-e2e` — 2 passed, gutter decorations asserted in the live Monaco DOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)