### PR TITLE
refactor(site): single source of truth for sandbox examples (+CDN loading example)

### DIFF
--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -340,7 +340,26 @@ const playerFrame = (page) => {
 }
 
 // --- 6. Every example loads and ticks cleanly. ---------------------------------
-for (const example of ["hero", "primitives", "bounce", "monitor"]) {
+// Derived from the live picker (not a hardcoded list) so a newly-added example
+// is covered automatically — this is the guard that a repo example still runs
+// on wasm once it's wired into the sandbox dropdown.
+const examples = await (async () => {
+  const page = await browser.newPage();
+  await page.goto(`${BASE}/sandbox.html`);
+  await page.waitForFunction(() => document.getElementById("example-picker")?.options.length > 0);
+  const ids = await page.evaluate(() =>
+    Array.from(document.getElementById("example-picker").options)
+      .map((o) => o.value)
+      .filter((v) => v !== "__inline")
+  );
+  await page.close();
+  return ids;
+})();
+check("picker exposes the expanded example set", examples.length >= 10, examples.join(", "));
+// Duplicate ids would silently overwrite each other's dist/examples/<id>.fun and
+// under-test the set — a unique-count mismatch is a real drift bug, not a nit.
+check("picker example ids are unique", new Set(examples).size === examples.length, examples.join(", "));
+for (const example of examples) {
   const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
   const consoleLog = [];
   page.on("console", (m) => consoleLog.push(m.text()));

--- a/site/README.md
+++ b/site/README.md
@@ -28,6 +28,8 @@ npm run test:ide-page    # headless e2e — the IDE page (e2e/ide-page.mjs)
   follow-up.
 - `src/functor-lang.js` — the Functor Lang CodeMirror language + synthwave theme,
   shared by both editors.
-- `build.mjs` copies selected repo examples' `game.fun` sources (see the map in `build.mjs`)
-  at build time, so the sandbox dropdown always matches what ships in the repo.
+- `src/examples.js` is the single source of truth for the sandbox's example set
+  (id + dropdown label + repo source path). `build.mjs` copies each entry's
+  `game.fun` at build time and `src/sandbox.js` builds the dropdown from the same
+  list, so the sandbox dropdown always matches what ships in the repo.
 - Deploy: publish `site/dist` to any static host.

--- a/site/build.mjs
+++ b/site/build.mjs
@@ -11,6 +11,7 @@
 import { cp, mkdir, rm, access } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import esbuild from "esbuild";
+import { EXAMPLES } from "./src/examples.js";
 
 const site = fileURLToPath(new URL(".", import.meta.url));
 const root = fileURLToPath(new URL("..", import.meta.url));
@@ -31,16 +32,6 @@ const TIMELINE_MODEL = `${root}runtime/functor-runtime-web/timeline-model.js`;
 // pkg is a note, not an error.
 const LANG_PKG = `${root}tools/functor-lang-wasm/pkg`;
 const LANG_PKG_FILES = ["functor_lang_wasm.js", "functor_lang_wasm_bg.wasm"];
-
-// dist/examples/<name>.fun — site-local plus the repo's Functor Lang examples.
-const EXAMPLES = {
-  hero: `${site}examples/hero.fun`,
-  primitives: `${root}examples/primitives/game.fun`,
-  // Named `bounce` (not `physics`): the flat copy makes `file = module`, and a
-  // module literally named `Physics` collides with the builtin/prelude namespace.
-  bounce: `${root}examples/physics/game.fun`,
-  monitor: `${root}examples/monitor/game.fun`,
-};
 
 try {
   await access(`${PKG}/${PKG_FILES[0]}`);
@@ -64,8 +55,8 @@ for (const file of PKG_FILES) {
 }
 await cp(SCRUBBER, `${dist}/scrubber.js`);
 await cp(TIMELINE_MODEL, `${dist}/timeline-model.js`);
-for (const [name, path] of Object.entries(EXAMPLES)) {
-  await cp(path, `${dist}/examples/${name}.fun`);
+for (const { id, source } of EXAMPLES) {
+  await cp(`${root}${source}`, `${dist}/examples/${id}.fun`);
 }
 
 // The language-intelligence wasm, if it has been built. Absent → skip (build on).

--- a/site/src/examples.js
+++ b/site/src/examples.js
@@ -1,0 +1,31 @@
+// The single source of truth for the sandbox's example set. Two consumers read
+// this one list, so it can't drift:
+//   - build.mjs (Node)   uses `id` + `source` to copy the .fun into
+//     dist/examples/<id>.fun at build time;
+//   - sandbox.js (browser) uses `id` + `label` to build the scene dropdown.
+// The site e2e derives its per-example smoke test from the rendered picker, so
+// it tracks this list automatically too.
+//
+// `source` is a path relative to the repo root. Every entry must be a SINGLE
+// .fun (the sandbox is a one-buffer editor — no sibling modules ship) and must
+// be either asset-free or reference its assets by absolute CDN URL (the wasm
+// runtime fetch()es those cross-origin; local asset files are NOT bundled). See
+// build.mjs / README for the classification.
+export const EXAMPLES = [
+  { id: "hero", label: "Neon grid", source: "site/examples/hero.fun" },
+  { id: "counter", label: "Counter", source: "examples/counter/game.fun" },
+  { id: "primitives", label: "Primitives", source: "examples/primitives/game.fun" },
+  { id: "ui", label: "UI widgets", source: "examples/ui/game.fun" },
+  { id: "inspector", label: "Inspector", source: "examples/inspector/game.fun" },
+  // Named `bounce` (not `physics`): the flat copy makes `file = module`, and a
+  // module literally named `Physics` collides with the builtin/prelude namespace.
+  { id: "bounce", label: "Physics", source: "examples/physics/game.fun" },
+  { id: "toss", label: "Bouncing balls", source: "examples/toss/game.fun" },
+  { id: "trajectory", label: "Trajectory", source: "examples/trajectory/game.fun" },
+  { id: "mario", label: "Platformer", source: "examples/mario/game.fun" },
+  // Single-file, and every model is an absolute Babylon CDN URL — the wasm
+  // runtime fetch()es those cross-origin (CORS-permitting), so unlike the
+  // local-asset examples this one runs in the single-buffer sandbox.
+  { id: "loading", label: "CDN assets", source: "examples/loading/game.fun" },
+  { id: "monitor", label: "Render targets", source: "examples/monitor/game.fun" },
+];

--- a/site/src/sandbox.js
+++ b/site/src/sandbox.js
@@ -22,13 +22,7 @@ import {
 } from "./lang-intel.js";
 import { PlayerBridge } from "./player-bridge.js";
 import { createStatusBar } from "./status-bar.js";
-
-const EXAMPLES = [
-  { id: "hero", label: "Neon grid" },
-  { id: "primitives", label: "Primitives" },
-  { id: "bounce", label: "Physics" },
-  { id: "monitor", label: "Render targets" },
-];
+import { EXAMPLES } from "./examples.js";
 
 const frame = document.getElementById("player");
 const statusPill = document.getElementById("status");


### PR DESCRIPTION
## Why

The sandbox's example set lived in **three** places that had drifted apart:
- a copy map in `site/build.mjs`,
- a dropdown array in `site/src/sandbox.js`,
- a stale hardcoded loop in `e2e/site-sandbox.mjs` (whose comment claimed "every example in the picker" but only tested the original 4).

Result: the sandbox showed **4 of 24** repo examples, and the e2e only smoke-tested those 4.

## What

- **Single source of truth** — new `site/src/examples.js` (`[{ id, label, source }]`). `build.mjs` copies each `source` → `dist/examples/<id>.fun`; `sandbox.js` builds the dropdown from `label`; the e2e derives its per-example smoke test from the **rendered picker** (no fourth list). Adding an example is now a one-line edit.
- **Sandbox 4 → 11 curated scenes**: `hero, counter, primitives, ui, inspector, bounce, toss, trajectory, mario, loading, monitor`.
- **CDN assets in the sandbox** — included `loading`, whose models are absolute Babylon CDN URLs. The wasm runtime `fetch()`es them cross-origin; verified `200` in a real headless-browser load (CDN sends `access-control-allow-origin: *`).
- **Hardened e2e** — asserts the picker set is non-trivial and its ids are unique (guards a duplicate id silently clobbering a `dist` file).

### Deliberately excluded
Classes the single-buffer, no-asset-bundle sandbox structurally can't run:
- **multi-file**: animation, lighting, hello-cubes, crossfade, asteroids, replay
- **local-asset**: hello, synthwave, glove, atmosphere (local skybox jpgs)
- **networked**: mp*/ws*/netdemo

(The multi-file IDE page is the eventual home for the multi-file/local-asset ones.)

## Review

Ran `/xreview` (Claude Opus + Codex) — **no Critical/High** from either engine.
- Claude caught `atmosphere` degrading to fog-only in the sandbox (local skybox, not CDN) → **dropped it** before this PR.
- Codex flagged the e2e assertion being too loose → **added the uniqueness check**.

## Verification

`npm run test:site` → **ALL CHECKS PASSED**: all 11 examples load live on wasm; ids unique; `loading`'s CDN models fetch `200` cross-origin in-page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)