### PR TITLE
perf(diagnostics): debounce error reporting, and one error location in the sandbox/IDE

### DIFF
--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -320,11 +320,12 @@ const playerFrame = (page) => {
 
   // Broken edit → error surfaced, old frame keeps rendering.
   await page.evaluate((s) => window.__sandbox.setSource(s), BROKEN);
+  // The preview holds an error back (~4s grace) before surfacing it.
   await page.waitForFunction(() => window.__sandbox.status().state === "error", {
-    timeout: 5000,
+    timeout: 8000,
   });
   const status = await page.evaluate(() => window.__sandbox.status());
-  check("broken edit surfaces the parse error", /cannot .*:\d+:\d+/.test(status.detail), status.detail);
+  check("broken edit surfaces the parse error", /cannot .*:\d+:\d+/.test(status.message), status.message);
   await sleep(400);
   const still = await centerPixel(playerFrame(page));
   check("old program keeps rendering after a broken edit", still[1] > 150 && still[0] < 100, `center = rgb(${still})`);

--- a/site/ide.html
+++ b/site/ide.html
@@ -47,15 +47,10 @@
           <button id="new-file" type="button" title="New .fun file">+</button>
         </div>
         <div id="file-list" class="file-list"></div>
-        <p class="file-pane-note">
-          Every <code>.fun</code> is a module (<code>file = module</code>).
-          <code>game.fun</code> is the entry.
-        </p>
       </aside>
       <section class="editor-pane">
         <div class="editor-tab"><span id="active-file">game.fun</span></div>
         <div id="editor"></div>
-        <pre id="status-log" hidden></pre>
       </section>
       <section class="preview-pane">
         <iframe id="player" title="live game preview" allow="pointer-lock"></iframe>

--- a/site/sandbox.html
+++ b/site/sandbox.html
@@ -42,7 +42,6 @@
     <main class="sandbox-split">
       <section class="editor-pane">
         <div id="editor"></div>
-        <pre id="status-log" hidden></pre>
       </section>
       <section class="preview-pane">
         <iframe id="player" title="live game preview" allow="pointer-lock"></iframe>

--- a/site/src/ide.js
+++ b/site/src/ide.js
@@ -82,7 +82,6 @@ const els = {
   download: document.getElementById("download"),
   restart: document.getElementById("restart"),
   status: document.getElementById("status"),
-  statusLog: document.getElementById("status-log"),
   activeName: document.getElementById("active-file"),
   editorHost: document.getElementById("editor"),
   player: document.getElementById("player"),
@@ -142,9 +141,10 @@ const activeFile = () => project.files.find((f) => f.path === project.active);
 const setStatus = (state, text, detail = "") => {
   els.status.dataset.state = state;
   els.status.textContent = text;
-  els.status.title = "";
-  els.statusLog.textContent = detail;
-  els.statusLog.hidden = detail === "";
+  // The detail (the reload note, or a parse error) lives in the pill's tooltip
+  // and — for errors — the Output panel. No separate error banner under the
+  // editor: the preview pill is the single live indicator.
+  els.status.title = detail;
 };
 
 // ---------------------------------------------------------------- editor
@@ -244,8 +244,8 @@ const bridge = new ProjectBridge(els.player, {
   onLive: () => setStatus("live", "● live"),
   onResult: (ok, message) => {
     if (ok) {
-      setStatus("live", "● live");
-      els.status.title = message; // the runtime's "model preserved" note, on hover
+      // the runtime's "model preserved" note, reachable on hover
+      setStatus("live", "● live", message);
     } else {
       setStatus("error", "✖ error", message);
     }
@@ -424,7 +424,6 @@ window.__ide = {
     state: els.status.dataset.state,
     text: els.status.textContent,
     message: els.status.title,
-    detail: els.statusLog.textContent,
   }),
   // Replace the active buffer, place the cursor, and open the completion popup
   // (explicit trigger) — the sandbox's seam, minus any push (programmaticEdit

--- a/site/src/player-bridge.js
+++ b/site/src/player-bridge.js
@@ -11,21 +11,37 @@
 // not to push a reload per keystroke.
 const PUSH_DEBOUNCE_MS = 300;
 
+// A rejected edit keeps the last good program running, so an error isn't urgent.
+// Hold it back this long before surfacing it — a fix within the window (the
+// common case while typing) clears it before it ever shows.
+const ERROR_GRACE_MS = 4000;
+
 export class PlayerBridge {
   // iframe: the player element. Callbacks map protocol events to UI:
   //   onReloading()          — a push was sent (busy)
   //   onLive()               — the player is ready with nothing pending
   //   onResult(ok, message)  — a hot-swap reply came back
-  constructor(iframe, { onReloading, onLive, onResult, debounceMs = PUSH_DEBOUNCE_MS }) {
+  constructor(
+    iframe,
+    {
+      onReloading,
+      onLive,
+      onResult,
+      debounceMs = PUSH_DEBOUNCE_MS,
+      errorGraceMs = ERROR_GRACE_MS,
+    }
+  ) {
     this.iframe = iframe;
     this.onReloading = onReloading;
     this.onLive = onLive;
     this.onResult = onResult;
     this.debounceMs = debounceMs;
+    this.errorGraceMs = errorGraceMs;
 
     this.previewReady = false;
     this.dirty = false;
     this.pushTimer = null;
+    this.errorTimer = null;
     this.lastSource = "";
     // Correlates results with pushes: each posted push gets a fresh id, the
     // runtime echoes it in the result, and a result for anything but the
@@ -64,8 +80,23 @@ export class PlayerBridge {
   // push and drops readiness until the next `functor-lang-preview-ready`.
   reset() {
     clearTimeout(this.pushTimer);
+    clearTimeout(this.errorTimer);
     this.previewReady = false;
     this.dirty = false;
+  }
+
+  // Surface a hot-swap result — but hold errors back. A rejected edit keeps the
+  // last good program running, so the preview IS still live; show that now and
+  // only surface the error if the program stays broken past the grace window.
+  // Any success (the usual next keystroke that re-parses) clears it instantly.
+  #deliverResult(ok, message) {
+    clearTimeout(this.errorTimer);
+    if (ok) {
+      this.onResult(true, message);
+    } else {
+      this.onLive();
+      this.errorTimer = setTimeout(() => this.onResult(false, message), this.errorGraceMs);
+    }
   }
 
   #post() {
@@ -101,7 +132,7 @@ export class PlayerBridge {
       // A result carrying an id that isn't the latest push's is stale — a
       // newer push is already in flight; its reply supersedes this one.
       if (data.id !== undefined && data.id !== this.pushId) return;
-      this.onResult(data.ok, data.message);
+      this.#deliverResult(data.ok, data.message);
     }
   }
 }

--- a/site/src/project-bridge.js
+++ b/site/src/project-bridge.js
@@ -11,21 +11,37 @@
 
 const PUSH_DEBOUNCE_MS = 300;
 
+// A rejected edit keeps the last good program running, so an error isn't urgent.
+// Hold it back this long before surfacing it — a fix within the window (the
+// common case while typing) clears it before it ever shows.
+const ERROR_GRACE_MS = 4000;
+
 export class ProjectBridge {
   // iframe: the player element. Callbacks map protocol events to UI:
   //   onReloading()          — a push was sent (busy)
   //   onLive()               — the player booted / is ready
   //   onResult(ok, message)  — a hot-swap reply came back
-  constructor(iframe, { onReloading, onLive, onResult, debounceMs = PUSH_DEBOUNCE_MS }) {
+  constructor(
+    iframe,
+    {
+      onReloading,
+      onLive,
+      onResult,
+      debounceMs = PUSH_DEBOUNCE_MS,
+      errorGraceMs = ERROR_GRACE_MS,
+    }
+  ) {
     this.iframe = iframe;
     this.onReloading = onReloading;
     this.onLive = onLive;
     this.onResult = onResult;
     this.debounceMs = debounceMs;
+    this.errorGraceMs = errorGraceMs;
 
     this.waiting = false; // player announced project-waiting (safe to push)
     this.files = null; // latest full file set
     this.pushTimer = null;
+    this.errorTimer = null;
     // Correlates results with pushes: each push gets a fresh id, the runtime
     // echoes it, and a result for anything but the LATEST push is stale.
     this.pushId = 0;
@@ -44,7 +60,22 @@ export class ProjectBridge {
   // state until the next `functor-lang-project-waiting`.
   reset() {
     clearTimeout(this.pushTimer);
+    clearTimeout(this.errorTimer);
     this.waiting = false;
+  }
+
+  // Surface a hot-swap result — but hold errors back. A rejected edit keeps the
+  // last good program running, so the preview IS still live; show that now and
+  // only surface the error if the program stays broken past the grace window.
+  // Any success (the usual next keystroke that re-parses) clears it instantly.
+  #deliverResult(ok, message) {
+    clearTimeout(this.errorTimer);
+    if (ok) {
+      this.onResult(true, message);
+    } else {
+      this.onLive();
+      this.errorTimer = setTimeout(() => this.onResult(false, message), this.errorGraceMs);
+    }
   }
 
   #send() {
@@ -85,7 +116,7 @@ export class ProjectBridge {
       // A result whose id isn't the latest push's is stale — a newer push is
       // already in flight; its reply supersedes this one.
       if (data.id !== undefined && data.id !== this.pushId) return;
-      this.onResult(data.ok, data.message);
+      this.#deliverResult(data.ok, data.message);
     }
   }
 }

--- a/site/src/sandbox.js
+++ b/site/src/sandbox.js
@@ -26,18 +26,16 @@ import { EXAMPLES } from "./examples.js";
 
 const frame = document.getElementById("player");
 const statusPill = document.getElementById("status");
-const statusLog = document.getElementById("status-log");
 const picker = document.getElementById("example-picker");
 const resetButton = document.getElementById("reset");
 
 const setStatus = (state, text, detail = "") => {
   statusPill.dataset.state = state;
   statusPill.textContent = text;
-  // Every transition clears the tooltip (the ok branch below re-sets it) so
-  // a stale "model preserved" can't contradict a later error or fresh load.
-  statusPill.title = "";
-  statusLog.textContent = detail;
-  statusLog.hidden = detail === "";
+  // The detail (the reload note, or a parse error) lives in the pill's tooltip
+  // and — for errors — the Output panel. No separate error banner under the
+  // editor: the preview pill is the single live indicator.
+  statusPill.title = detail;
 };
 
 const statusBar = createStatusBar({ host: document.getElementById("statusbar") });
@@ -47,10 +45,9 @@ const bridge = new PlayerBridge(frame, {
   onLive: () => setStatus("live", "● live"),
   onResult: (ok, message) => {
     if (ok) {
-      setStatus("live", "● live");
       // The runtime's status line ("reloaded … model preserved") stays
       // reachable — hover the pill, or the e2e's status() seam below.
-      statusPill.title = message;
+      setStatus("live", "● live", message);
     } else {
       setStatus("error", "✖ error", message);
     }
@@ -246,7 +243,6 @@ window.__sandbox = {
     state: statusPill.dataset.state,
     text: statusPill.textContent,
     message: statusPill.title,
-    detail: statusLog.textContent,
   }),
   getSource: () => view.state.doc.toString(),
   // Replace the buffer, place the cursor, and open the completion popup

--- a/site/styles.css
+++ b/site/styles.css
@@ -551,18 +551,6 @@ a:hover {
   height: 100%;
 }
 
-#status-log {
-  margin: 0;
-  padding: 10px 14px;
-  max-height: 30%;
-  overflow: auto;
-  font-size: 0.78rem;
-  color: var(--red);
-  background: #1a1220;
-  border-top: 1px solid rgba(242, 99, 127, 0.4);
-  white-space: pre-wrap;
-}
-
 .preview-pane {
   min-width: 0;
   min-height: 0;
@@ -603,8 +591,8 @@ a:hover {
 /* --------------------------------------------------------------------- ide */
 
 /* Three panes: file sidebar | editor | preview. Reuses .editor-pane,
-   #editor, .preview-pane, #player, #status-log, .status-pill from the
-   sandbox rules above. */
+   #editor, .preview-pane, #player, .status-pill from the sandbox rules
+   above. */
 .ide-split {
   flex: 1;
   display: grid;
@@ -719,20 +707,6 @@ a:hover {
 
 .file-delete:hover {
   color: var(--red);
-}
-
-.file-pane-note {
-  margin: 0;
-  padding: 10px 12px;
-  border-top: 1px solid var(--line);
-  font-size: 0.68rem;
-  line-height: 1.5;
-  color: var(--text-dim);
-}
-
-.file-pane-note code {
-  font-family: var(--font-mono);
-  color: var(--text);
 }
 
 .editor-tab {

--- a/tools/functor-lang-lsp/src/main.rs
+++ b/tools/functor-lang-lsp/src/main.rs
@@ -35,7 +35,7 @@ use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::Sender;
+use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender};
 use std::sync::Arc;
 
 use serde_json::{json, Value};
@@ -73,6 +73,26 @@ fn main() {
         }
         let _ = stdin_tx.send(Incoming::Eof); // client vanished — stop the loop
     });
+    // Debounced diagnostics: `didChange` signals this thread instead of
+    // publishing inline; after a quiet window it injects a `$/functorFlush`
+    // notification back onto the channel and the loop publishes the settled
+    // buffer. Tunable via FUNCTOR_LSP_DIAGNOSTICS_DEBOUNCE_MS (default 1000ms;
+    // 0 disables and publishes inline, per-keystroke).
+    let debounce_ms = std::env::var("FUNCTOR_LSP_DIAGNOSTICS_DEBOUNCE_MS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(1000);
+    let debounce = if debounce_ms > 0 {
+        let (change_tx, change_rx) = std::sync::mpsc::channel::<String>();
+        let flush_tx = tx.clone();
+        std::thread::spawn(move || {
+            debounce_publisher(change_rx, flush_tx, std::time::Duration::from_millis(debounce_ms));
+        });
+        Some(change_tx)
+    } else {
+        None
+    };
+
     let stdout = std::io::stdout();
     let mut writer = stdout.lock();
     let code = run(
@@ -82,8 +102,49 @@ fn main() {
         },
         &mut writer,
         tx,
+        debounce,
     );
     std::process::exit(code);
+}
+
+/// Coalesce rapid `didChange`s into one diagnostics publish. Each edit (re)arms
+/// a per-URI deadline; once a URI has been quiet for `delay`, inject a
+/// `$/functorFlush` notification back onto the server channel so the loop
+/// publishes the settled buffer's diagnostics. One thread serves every URI, and
+/// idles on a long recv when nothing is pending.
+fn debounce_publisher(rx: Receiver<String>, flush: Sender<Incoming>, delay: std::time::Duration) {
+    let mut deadlines: HashMap<String, std::time::Instant> = HashMap::new();
+    loop {
+        let now = std::time::Instant::now();
+        let due: Vec<String> = deadlines
+            .iter()
+            .filter(|(_, &deadline)| deadline <= now)
+            .map(|(uri, _)| uri.clone())
+            .collect();
+        for uri in due {
+            deadlines.remove(&uri);
+            let message = json!({
+                "jsonrpc": "2.0",
+                "method": "$/functorFlush",
+                "params": { "uri": uri },
+            });
+            if flush.send(Incoming::Msg(message)).is_err() {
+                return; // the server loop is gone
+            }
+        }
+        let timeout = deadlines
+            .values()
+            .min()
+            .map(|deadline| deadline.saturating_duration_since(std::time::Instant::now()))
+            .unwrap_or(std::time::Duration::from_secs(3600));
+        match rx.recv_timeout(timeout) {
+            Ok(uri) => {
+                deadlines.insert(uri, std::time::Instant::now() + delay);
+            }
+            Err(RecvTimeoutError::Timeout) => {}
+            Err(RecvTimeoutError::Disconnected) => return,
+        }
+    }
 }
 
 /// The server loop: read framed messages until `exit` (or EOF), dispatching
@@ -96,7 +157,7 @@ fn serve(reader: &mut impl BufRead, writer: &mut impl Write) -> i32 {
     // polling is a `main`-only concern (its trace notifications arrive on the
     // channel `main` drains), so the receiver is dropped here.
     let (trace_tx, _trace_rx) = std::sync::mpsc::channel::<Incoming>();
-    run(&mut || read_message(reader), writer, trace_tx)
+    run(&mut || read_message(reader), writer, trace_tx, None)
 }
 
 /// The server core: pull messages from `next` (stdin in tests; a stdin+attach
@@ -108,6 +169,7 @@ fn run(
     next: &mut dyn FnMut() -> Option<Value>,
     writer: &mut impl Write,
     trace_tx: Sender<Incoming>,
+    debounce: Option<Sender<String>>,
 ) -> i32 {
     let mut shutdown_seen = false;
     let mut documents: HashMap<String, String> = HashMap::new();
@@ -314,8 +376,16 @@ fn run(
                     .and_then(|changes| changes.last())
                     .and_then(|change| change["text"].as_str())
                 {
-                    publish_diagnostics(writer, uri, text);
                     documents.insert(uri.to_string(), text.to_string());
+                    // Diagnostics are debounced so typing doesn't flash squiggles:
+                    // signal the debounce thread, which flushes via `$/functorFlush`
+                    // once the buffer settles. With no debouncer (tests), publish now.
+                    match &debounce {
+                        Some(change_tx) => {
+                            let _ = change_tx.send(uri.to_string());
+                        }
+                        None => publish_diagnostics(writer, uri, text),
+                    }
                     if let Some(project) = load_project(uri, &documents) {
                         projects.insert(uri.to_string(), project);
                     }
@@ -330,6 +400,14 @@ fn run(
                 projects.remove(uri);
                 // Clear stale squiggles for the closed file.
                 write_diagnostics(writer, uri, vec![]);
+            }
+            // A debounce-thread flush: `uri`'s buffer has settled — publish its
+            // diagnostics from the latest stored document.
+            ("$/functorFlush", None) => {
+                let uri = params["uri"].as_str().unwrap_or("");
+                if let Some(text) = documents.get(uri) {
+                    publish_diagnostics(writer, uri, text);
+                }
             }
             // A pushed trace (extension relay, wasm postMessage, tests, or the
             // attach poller re-entering): replace the overlay and refresh.
@@ -1230,7 +1308,7 @@ mod inspector_server_tests {
         let mut queue: VecDeque<Value> = messages.into();
         let mut out: Vec<u8> = Vec::new();
         let (trace_tx, _rx) = std::sync::mpsc::channel::<Incoming>();
-        run(&mut || queue.pop_front(), &mut out, trace_tx);
+        run(&mut || queue.pop_front(), &mut out, trace_tx, None);
         let mut reader: &[u8] = &out;
         let mut parsed = Vec::new();
         while let Some(message) = read_message(&mut reader) {

--- a/tools/functor-lang-lsp/tests/e2e.rs
+++ b/tools/functor-lang-lsp/tests/e2e.rs
@@ -18,6 +18,9 @@ struct Server {
 impl Server {
     fn spawn() -> Server {
         let mut child = Command::new(env!("CARGO_BIN_EXE_functor-lang-lsp"))
+            // These tests assert diagnostic content, not typing cadence: disable
+            // the didChange debounce so publishes are immediate and deterministic.
+            .env("FUNCTOR_LSP_DIAGNOSTICS_DEBOUNCE_MS", "0")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .spawn()


### PR DESCRIPTION
Editing a `.fun` flashed errors on nearly every keystroke, and the sandbox/IDE showed each error in two places at once. This calms it down across all three surfaces (web sandbox, web IDE, VS Code).

## 1. Debounce error *reporting* (not the analysis)

**VS Code (LSP)** — `publish_diagnostics` ran on *every* `didChange` with no debounce (the worst offender). Now a per-URI **trailing debounce**: a `didChange` arms a deadline, and once the buffer has been quiet a background thread injects a `$/functorFlush` notification back onto the server channel so the loop publishes the settled buffer.
- Default **1000ms**, tunable via `FUNCTOR_LSP_DIAGNOSTICS_DEBOUNCE_MS` (`0` = publish inline).
- `didOpen` still publishes immediately.
- The real-stdio e2e spawns with the debounce disabled (it asserts content, not cadence) — stays fast and deterministic.

**Web (sandbox + IDE)** — a rejected hot-swap keeps the last good program running, so the preview is still live; flipping the pill to "✖ error" mid-word was pure noise. The bridges now **hold an error ~4000ms** and show the still-running program as *live* meanwhile; any success (the next keystroke that re-parses) clears the pending error instantly. Pushes are unchanged — only the surfacing is delayed.

## 2. One error location

The parse/reload error showed **twice** — the preview status pill *and* a red banner under the editor (`#status-log`). Dropped the under-editor banner: the pill is the single live indicator; the full message stays in its tooltip and the Output panel. Also removed the IDE file-pane note (“Every `.fun` is a module … `game.fun` is the entry”) and the CSS orphaned by both removals.

## Verify
- `cargo test -p functor-lang-lsp` — green.
- `npm run test:site` — all 33 checks pass, including broken-edit → error (now at the 4s grace) → recover, with the parse error read from the pill tooltip.
- IDE screenshotted: file pane clean, no under-editor banner.

## Tuning
The 1s / 4s values are UX-sensitive — easy to nudge. The VS Code value is env-var-only for now; the extension could expose a proper setting later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)