### PR TITLE
feat(site): version + pre-alpha badge in the site header

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -22,6 +22,12 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Full history + tags: site:build stamps the latest vX.Y.Z into the
+          # header version-badge via `git describe`, which has to walk from
+          # HEAD back to the tagged commit — a shallow checkout (even with
+          # fetch-tags) only finds a tag sitting exactly on HEAD.
+          fetch-depth: 0
 
       - uses: actions/setup-node@v6
         with:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ for game logic** — the Rust runtime *interprets* the `.fun` directly, with
 state-preserving hot reload as you save, whole-game time travel over the running model,
 and the same source running on **native and wasm**.
 
+> **Status: pre-alpha.** Functor is early software under active development — the
+> language, the prelude, and file formats can all change between releases without a
+> deprecation path. Binaries and changelogs are published on the
+> [releases page](https://github.com/tommy-xr/functor/releases).
+
 ## Try it in the browser
 
 No install needed:

--- a/site/build.mjs
+++ b/site/build.mjs
@@ -8,8 +8,9 @@
 //
 // The output is fully static — deploy site/dist to any static host.
 
-import { cp, mkdir, rm, access } from "node:fs/promises";
+import { cp, mkdir, rm, access, readFile, writeFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
+import { execSync } from "node:child_process";
 import esbuild from "esbuild";
 import { EXAMPLES } from "./src/examples.js";
 
@@ -52,8 +53,34 @@ await rm(dist, { recursive: true, force: true });
 await mkdir(`${dist}/pkg`, { recursive: true });
 await mkdir(`${dist}/examples`, { recursive: true });
 
+// The latest release tag (vX.Y.Z), stamped into each page's header
+// version-badge so the deployed site names the release it accompanies. No
+// reachable tag (fresh history, shallow checkout) → the badge stays the
+// source's plain "pre-alpha".
+let version = "";
+try {
+  const tag = execSync("git describe --tags --abbrev=0 --match 'v[0-9]*'", {
+    cwd: root,
+    stdio: ["ignore", "pipe", "ignore"],
+  })
+    .toString()
+    .trim();
+  if (/^v\d+\.\d+\.\d+$/.test(tag)) version = tag;
+} catch {}
+
 for (const page of PAGES) {
-  await cp(`${site}${page}`, `${dist}/${page}`);
+  if (version && page.endsWith(".html")) {
+    const html = await readFile(`${site}${page}`, "utf8");
+    await writeFile(
+      `${dist}/${page}`,
+      html.replace(
+        /(<span class="version-badge"[^>]*>)[^<]*(<\/span>)/,
+        `$1${version} · pre-alpha$2`
+      )
+    );
+  } else {
+    await cp(`${site}${page}`, `${dist}/${page}`);
+  }
 }
 for (const icon of ICONS) {
   try {

--- a/site/docs.html
+++ b/site/docs.html
@@ -23,6 +23,7 @@
   <body class="docs-page">
     <header class="site-header">
       <a class="wordmark" href="./"><svg class="wordmark-mark" viewBox="366 163 385 690" fill="currentColor" aria-hidden="true"><path d="M382 341 545 179H735L615 300H548L382 466Z"/><path d="M382 493 497 380V748L382 837Z"/><path d="M518 426H693L597 522H518Z"/></svg>FUNCTOR<span class="wordmark-accent">//DOCS</span></a>
+      <span class="version-badge" title="Functor is pre-alpha software — everything may change between releases">pre-alpha</span>
       <nav class="site-nav">
         <a href="sandbox.html">Sandbox</a>
         <a href="docs.html" aria-current="page">Docs</a>

--- a/site/ide.html
+++ b/site/ide.html
@@ -23,6 +23,7 @@
   <body class="ide-page">
     <header class="site-header">
       <a class="wordmark" href="./"><svg class="wordmark-mark" viewBox="366 163 385 690" fill="currentColor" aria-hidden="true"><path d="M382 341 545 179H735L615 300H548L382 466Z"/><path d="M382 493 497 380V748L382 837Z"/><path d="M518 426H693L597 522H518Z"/></svg>FUNCTOR<span class="wordmark-accent">//IDE</span></a>
+      <span class="version-badge" title="Functor is pre-alpha software — everything may change between releases">pre-alpha</span>
       <div class="sandbox-controls">
         <button id="download" type="button" title="Download the project as a .zip">
           ↓ project.zip

--- a/site/index.html
+++ b/site/index.html
@@ -23,6 +23,7 @@
   <body class="landing-page">
     <header class="site-header">
       <a class="wordmark" href="./"><svg class="wordmark-mark" viewBox="366 163 385 690" fill="currentColor" aria-hidden="true"><path d="M382 341 545 179H735L615 300H548L382 466Z"/><path d="M382 493 497 380V748L382 837Z"/><path d="M518 426H693L597 522H518Z"/></svg>FUNCTOR</a>
+      <span class="version-badge" title="Functor is pre-alpha software — everything may change between releases">pre-alpha</span>
       <nav class="site-nav">
         <a href="sandbox.html">Sandbox</a>
         <a href="docs.html">Docs</a>

--- a/site/sandbox.html
+++ b/site/sandbox.html
@@ -23,6 +23,7 @@
   <body class="sandbox-page">
     <header class="site-header">
       <a class="wordmark" href="./"><svg class="wordmark-mark" viewBox="366 163 385 690" fill="currentColor" aria-hidden="true"><path d="M382 341 545 179H735L615 300H548L382 466Z"/><path d="M382 493 497 380V748L382 837Z"/><path d="M518 426H693L597 522H518Z"/></svg>FUNCTOR<span class="wordmark-accent">//SANDBOX</span></a>
+      <span class="version-badge" title="Functor is pre-alpha software — everything may change between releases">pre-alpha</span>
       <div class="sandbox-controls">
         <label class="picker-label" for="example-picker">scene</label>
         <select id="example-picker"></select>

--- a/site/styles.css
+++ b/site/styles.css
@@ -460,6 +460,19 @@ a:hover {
   color: var(--pink);
 }
 
+/* The release badge next to the wordmark. The HTML ships "pre-alpha"; the site
+   build stamps in the latest release tag (see build.mjs). */
+.version-badge {
+  font-size: 0.68rem;
+  letter-spacing: 0.06em;
+  color: var(--text-dim);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 2px 9px;
+  white-space: nowrap;
+  cursor: default;
+}
+
 .sandbox-controls {
   display: flex;
   align-items: center;


### PR DESCRIPTION
First slice of the release-management work: make the pre-alpha status and the released version visible.

## What

- A small **version badge** in the `site-header` of the landing, sandbox, IDE, and docs pages. The HTML ships a plain `pre-alpha` pill; `site:build` stamps in the latest release tag so the deployed site reads **`v0.1.0 · pre-alpha`** once tags exist.
- `build.mjs` resolves the version with `git describe --tags --abbrev=0 --match 'v[0-9]*'`, validated against `^v\d+\.\d+\.\d+$`; no reachable tag (fresh history, local dev) degrades to the plain pill.
- `deploy-site.yml` checks out with `fetch-depth: 0` — `git describe` must walk from HEAD back to the tagged commit, which a shallow checkout can't (even with `fetch-tags`).
- A **pre-alpha status notice** at the top of the README.

## Design note: where the version lives

Nowhere in the repo — the git tag `vX.Y.Z` is the single source of truth. The CLI already bakes `FUNCTOR_RELEASE_VERSION` at release build (crate stays `0.0.0-dev`), and the site now derives from the same tag, so cutting a release is *just* creating the tag. The release pipeline that creates those tags (changelog, semver calc, binaries) follows in the next PRs; it will also dispatch a site deploy after tagging, since a `GITHUB_TOKEN`-created tag doesn't fire push-triggered workflows.

## Verification

- `node site/build.mjs` with no tag → all four pages carry the plain `pre-alpha` badge.
- With a local `v0.1.0` tag → all four pages stamp `v0.1.0 · pre-alpha`; `player.html` (no header) untouched.
- `npm run test:site` — all 104 e2e checks pass.
- /xreview (Claude + Codex): both flagged the shallow-checkout/`git describe` interaction (fixed with `fetch-depth: 0`); Codex's note that tagging alone doesn't redeploy the site is handled in the release-pipeline PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)