### PR TITLE
ci: release pipeline — changelog, tag, GitHub release with platform binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,130 @@
+name: Release
+
+# The release pipeline (manually dispatched, main only). Given a version
+# X.Y.Z it:
+#
+#   1. validates the version and that the tag vX.Y.Z is free
+#   2. generates release notes from the conventional commits since the last
+#      release tag (git-cliff, config in cliff.toml)
+#   3. builds + sanity-checks the `functor` binary for every supported
+#      platform (release-binaries.yml, reused via workflow_call)
+#   4. creates the vX.Y.Z tag and a PRE-RELEASE GitHub release (Functor is
+#      pre-alpha) with the notes and all platform archives attached
+#   5. dispatches Deploy Site, so the deployed site header picks up the new
+#      tag (a GITHUB_TOKEN-created tag does not fire push-triggered workflows
+#      on its own — explicit workflow_dispatch is the sanctioned exception)
+#
+# The tag is the single source of truth for the version: nothing in-repo is
+# bumped. The binaries bake the version via FUNCTOR_RELEASE_VERSION (the CLI
+# crate stays 0.0.0-dev), and the site stamps its header badge from the
+# latest reachable tag at build time.
+#
+# `inputs.version` is user-controlled text: every job reads it through an
+# env var (never `${{ }}`-interpolated into a `run:` script), so it cannot
+# inject shell into a write-capable job.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release, without the leading v (e.g. 0.1.0)"
+        required: true
+        type: string
+
+concurrency:
+  group: release # never two releases at once; a second dispatch queues
+  cancel-in-progress: false
+
+# Only the jobs that need write access get it (see their `permissions`).
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      VERSION: ${{ inputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Full history + tags: git-cliff walks last-tag..HEAD, and the
+          # tag-free check needs the existing tags.
+          fetch-depth: 0
+
+      - name: Validate version and ref
+        run: |
+          [[ "$GITHUB_REF" == "refs/heads/main" ]] \
+            || { echo "::error::releases are cut from main, not $GITHUB_REF"; exit 1; }
+          [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+            || { echo "::error::version '$VERSION' is not of the form X.Y.Z"; exit 1; }
+          if git rev-parse -q --verify "refs/tags/v$VERSION" >/dev/null; then
+            echo "::error::tag v$VERSION already exists"
+            exit 1
+          fi
+
+      - name: Install git-cliff
+        uses: taiki-e/install-action@v2
+        with:
+          tool: git-cliff@2.13.1
+
+      - name: Generate release notes
+        run: |
+          git-cliff --unreleased --tag "v$VERSION" -o release-notes.md
+          cat release-notes.md
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-notes
+          path: release-notes.md
+          retention-days: 14
+
+  binaries:
+    needs: prepare
+    uses: ./.github/workflows/release-binaries.yml
+    with:
+      version: ${{ inputs.version }}
+
+  publish:
+    needs: [prepare, binaries]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write # create the tag + release
+    env:
+      VERSION: ${{ inputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+
+      # Flattens every artifact (release-notes + the per-platform archives
+      # from release-binaries.yml) into assets/.
+      - uses: actions/download-artifact@v4
+        with:
+          path: assets
+          merge-multiple: true
+
+      - name: Create tag + pre-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ls -l assets
+          gh release create "v$VERSION" \
+            --target "$GITHUB_SHA" \
+            --title "v$VERSION" \
+            --prerelease \
+            --notes-file assets/release-notes.md \
+            assets/functor-*.tar.gz assets/functor-*.zip
+
+  # A separate job so a failed dispatch can be rerun without tripping over
+  # the already-created release in `publish`.
+  deploy-site:
+    needs: publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write # dispatch Deploy Site
+    steps:
+      - name: Deploy the site (stamps the new version into the header)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run deploy-site.yml --ref main --repo "$GITHUB_REPOSITORY"

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,44 @@
+# git-cliff configuration — generates the release notes for the release
+# pipeline (.github/workflows/release.yml) from conventional commits.
+#
+# Preview locally:  npx git-cliff --unreleased --tag v0.1.0
+
+[changelog]
+header = ""
+# Groups carry an HTML-comment ordering prefix (a git-cliff idiom: groups sort
+# by name, the comment is invisible in rendered markdown).
+body = """
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | striptags | trim }}
+{% for commit in commits %}
+- {% if commit.breaking %}**BREAKING** {% endif %}{{ commit.message | split(pat="\n") | first }}
+{%- endfor %}
+{% endfor %}
+"""
+footer = ""
+trim = true
+
+[git]
+conventional_commits = true
+# Keep non-conventional commits (grouped under Other) rather than dropping
+# them silently — the log is clean enough that this is a rare fallback.
+filter_unconventional = false
+commit_parsers = [
+  # `type!:`-marked breaking changes group first, whatever their type — this
+  # also keeps a breaking build/ci/chore/test commit out of the skip rule
+  # below (a footer-only "BREAKING CHANGE:" in a skipped type is still kept
+  # by protect_breaking_commits, but lands ungrouped — mark breakage with `!`).
+  { message = "^[a-z]+(\\(.+\\))?!:", group = "<!-- 0 -->Breaking" },
+  { message = "^feat", group = "<!-- 1 -->Features" },
+  { message = "^fix", group = "<!-- 2 -->Fixes" },
+  { message = "^perf", group = "<!-- 3 -->Performance" },
+  { message = "^docs", group = "<!-- 4 -->Docs" },
+  { message = "^refactor", group = "<!-- 5 -->Refactoring" },
+  { message = "^(build|ci|chore|test)", skip = true },
+  { message = ".*", group = "<!-- 6 -->Other" },
+]
+# A breaking change must never be dropped by a skip rule above.
+protect_breaking_commits = true
+filter_commits = false
+tag_pattern = "^v[0-9]+\\.[0-9]+\\.[0-9]+$"
+sort_commits = "newest"


### PR DESCRIPTION
Second slice of the release-management work (follows #392): the manually dispatched pipeline that cuts a release.

## What

`.github/workflows/release.yml` — dispatch with a version `X.Y.Z` (main only) and it:

1. **Validates**: main-only, `X.Y.Z` shape, tag `vX.Y.Z` free.
2. **Release notes**: git-cliff over the conventional commits since the last release tag (`cliff.toml`: Breaking/Features/Fixes/Performance/Docs/Refactoring grouped; `build`/`ci`/`chore`/`test` skipped; breaking commits protected and grouped first).
3. **Binaries**: calls the existing `release-binaries.yml` via `workflow_call` — its interface was built for exactly this — building + sanity-checking all four platform archives with the version baked in.
4. **Publishes**: creates the tag and a **pre-release** GitHub release with notes + all archives attached.
5. **Redeploys the site** (separate job, rerunnable) via explicit `workflow_dispatch`, since a `GITHUB_TOKEN`-created tag fires no push-triggered workflows — this is what stamps the new version into the site header from #392.

The tag stays the single source of truth: nothing in-repo is bumped per release.

## Hardening (from cross-review)

- `inputs.version` is user-controlled text — every job reads it via an `env:` var, never `${{ }}`-interpolated into a `run:` script (script-injection guard).
- Workflow-level permissions are `contents: read`; only `publish` gets `contents: write` and only `deploy-site` gets `actions: write`, so the four binary-build jobs never hold a write token.
- Releases are refused off non-main refs; the site dispatch lives in its own job so a late failure can be rerun without tripping on the already-created release.
- `cliff.toml`'s `tag_pattern` is anchored to `^v\d+\.\d+\.\d+$` so a stray non-release tag can't become a changelog boundary.

## Verification

- `actionlint` passes on the workflow.
- `npx git-cliff --unreleased --tag v0.1.0` against the real history renders correctly grouped notes (336 entries for the full-history first release — trimmable on the release page after publishing).
- /xreview (Claude + Codex): the `${{ inputs.version }}` injection was flagged by both engines; the permissions scoping, main-only guard, idempotency split, and tag-pattern anchor are Codex findings — all applied above. End-to-end proof will be the real `v0.1.0` dispatch once this merges.

Next (stacked): making `version` optional with an automatic semver calculation from the conventional commits + a language-surface (`.funi`) diff escalator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)