### PR TITLE
ci(release): compute the version from the commits when none is given

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,11 @@
 name: Release
 
-# The release pipeline (manually dispatched, main only). Given a version
-# X.Y.Z it:
+# The release pipeline (manually dispatched, main only). Dispatched with a
+# version X.Y.Z — or with none, in which case the version is computed from
+# the conventional commits since the last release tag plus a language-surface
+# check (scripts/next-version.mjs) — it:
 #
-#   1. validates the version and that the tag vX.Y.Z is free
+#   1. resolves + validates the version and that the tag vX.Y.Z is free
 #   2. generates release notes from the conventional commits since the last
 #      release tag (git-cliff, config in cliff.toml)
 #   3. builds + sanity-checks the `functor` binary for every supported
@@ -27,8 +29,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to release, without the leading v (e.g. 0.1.0)"
-        required: true
+        description: "Version to release, without the leading v (e.g. 0.1.0). Leave empty to compute it from the commits since the last release tag."
+        required: false
+        default: ""
         type: string
 
 concurrency:
@@ -43,25 +46,35 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    env:
-      VERSION: ${{ inputs.version }}
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v6
         with:
-          # Full history + tags: git-cliff walks last-tag..HEAD, and the
-          # tag-free check needs the existing tags.
+          # Full history + tags: the version calc and git-cliff walk
+          # last-tag..HEAD, and the tag-free check needs the existing tags.
           fetch-depth: 0
 
-      - name: Validate version and ref
+      - name: Resolve + validate version
+        id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           [[ "$GITHUB_REF" == "refs/heads/main" ]] \
             || { echo "::error::releases are cut from main, not $GITHUB_REF"; exit 1; }
+          if [[ -n "$INPUT_VERSION" ]]; then
+            VERSION="$INPUT_VERSION"
+          else
+            VERSION="$(node scripts/next-version.mjs)"
+          fi
           [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
             || { echo "::error::version '$VERSION' is not of the form X.Y.Z"; exit 1; }
           if git rev-parse -q --verify "refs/tags/v$VERSION" >/dev/null; then
             echo "::error::tag v$VERSION already exists"
             exit 1
           fi
+          echo "releasing v$VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Install git-cliff
         uses: taiki-e/install-action@v2
@@ -69,6 +82,8 @@ jobs:
           tool: git-cliff@2.13.1
 
       - name: Generate release notes
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           git-cliff --unreleased --tag "v$VERSION" -o release-notes.md
           cat release-notes.md
@@ -83,7 +98,7 @@ jobs:
     needs: prepare
     uses: ./.github/workflows/release-binaries.yml
     with:
-      version: ${{ inputs.version }}
+      version: ${{ needs.prepare.outputs.version }}
 
   publish:
     needs: [prepare, binaries]
@@ -92,7 +107,7 @@ jobs:
     permissions:
       contents: write # create the tag + release
     env:
-      VERSION: ${{ inputs.version }}
+      VERSION: ${{ needs.prepare.outputs.version }}
     steps:
       - uses: actions/checkout@v6
 

--- a/scripts/next-version.mjs
+++ b/scripts/next-version.mjs
@@ -1,0 +1,70 @@
+// Compute the next release version from the git history. Used by the release
+// pipeline (.github/workflows/release.yml) when a release is dispatched
+// without an explicit version; runnable locally the same way:
+//
+//   node scripts/next-version.mjs     # prints X.Y.Z on stdout, reasoning on stderr
+//
+// Rules (pre-1.0 semver — breaking changes bump the minor, everything else
+// the patch):
+//   - no release tag yet                                → 0.1.0
+//   - a breaking commit since the last release tag
+//     (`type!:` subject or a "BREAKING CHANGE:" body)   → minor bump
+//   - any change to the language/prelude surface
+//     (functor-prelude/prelude/*.funi) since the last
+//     tag, even if no commit message says so — the
+//     signatures are the honest record of that surface  → minor bump
+//   - anything else                                     → patch bump
+// From 1.0.0 on, the same signals map to major (breaking) and minor
+// (feat / surface change).
+
+import { execFileSync } from "node:child_process";
+
+const git = (...args) => execFileSync("git", args, { encoding: "utf8" }).trim();
+const explain = (msg) => process.stderr.write(`${msg}\n`);
+
+// Highest existing release tag (not nearest-ancestor: on a single main-only
+// release train they coincide, and version order is robust to clone depth).
+const tags = git("tag", "--list", "v*", "--sort=-v:refname")
+  .split("\n")
+  .filter((t) => /^v\d+\.\d+\.\d+$/.test(t));
+
+if (tags.length === 0) {
+  explain("no release tag yet → first release");
+  console.log("0.1.0");
+  process.exit(0);
+}
+
+const last = tags[0];
+const [major, minor, patch] = last.slice(1).split(".").map(Number);
+
+const subjects = git("log", `${last}..HEAD`, "--format=%s").split("\n").filter(Boolean);
+if (subjects.length === 0) {
+  console.error(`error: no commits since ${last} — nothing to release`);
+  process.exit(1);
+}
+
+const breaking =
+  subjects.some((s) => /^[a-z]+(\(.+\))?!:/.test(s)) ||
+  /BREAKING[ -]CHANGE:/.test(git("log", `${last}..HEAD`, "--format=%b"));
+const feature = subjects.some((s) => /^feat(\(.+\))?:/.test(s));
+const surface = git("diff", "--name-only", `${last}..HEAD`, "--", "functor-prelude/prelude/*.funi")
+  .split("\n")
+  .filter(Boolean);
+
+explain(`${subjects.length} commit(s) since ${last}`);
+if (breaking) explain("breaking commit (`type!:` / BREAKING CHANGE) → breaking bump");
+if (surface.length) explain(`language surface changed (${surface.join(", ")}) → at least a minor bump`);
+
+// A surface diff can be additive, so it never forces a major on its own —
+// only an explicitly breaking commit does.
+let next;
+if (breaking && major >= 1) {
+  next = `${major + 1}.0.0`;
+} else if (breaking || surface.length || (feature && major >= 1)) {
+  next = `${major}.${minor + 1}.0`;
+} else {
+  next = `${major}.${minor}.${patch + 1}`;
+}
+
+explain(`${last} → ${next}`);
+console.log(next);


### PR DESCRIPTION
Stacked on #394 (review only the last commit). Completes the binaries-first release milestone: dispatching **Release** with an empty version now computes it.

## What

`scripts/next-version.mjs` (locally runnable: `node scripts/next-version.mjs`) derives the next version from the git history:

- no release tag yet → **0.1.0**
- a breaking commit since the last tag (`type!:` subject or a `BREAKING CHANGE:`/`BREAKING-CHANGE:` body) → **minor** bump (pre-1.0 semver)
- any diff to the **language/prelude surface** (`functor-prelude/prelude/*.funi`) since the last tag → **minor** bump, even when no commit message admits it — the `.funi` signatures are the drift-tested record of that surface, so the bump can't be under-labeled
- anything else → **patch** bump
- from 1.0.0 on, the same signals map to major (breaking only — a surface diff can be additive) and minor (feat / surface)

`release.yml`'s `version` input becomes optional; `prepare` resolves it (input override still wins), validates as before, and exports it as a job output consumed by the `binaries` and `publish` jobs.

## Verification

- Exercised against real history with temporary tags: no tags → `0.1.0`; tag at HEAD → exit 1 "nothing to release"; tag at HEAD~20 (13 `.funi` files changed since) → `0.2.0`; `v1.0.0` at HEAD~20 → `1.1.0`; tag at HEAD~1 (perf commit, no surface change) → `0.1.1`. Breaking-subject regex unit-tested.
- `actionlint` passes.
- /xreview (Claude + Codex): no Critical/High/Medium findings on this slice; the `BREAKING-CHANGE:` hyphen-synonym Low is fixed, the >2^53 version-component Low is declined as not a real-world tag shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)