### PR TITLE
chore: reword pre-alpha to alpha

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ name: Release
 #   3. builds + sanity-checks the `functor` binary for every supported
 #      platform (release-binaries.yml, reused via workflow_call)
 #   4. creates the vX.Y.Z tag and a PRE-RELEASE GitHub release (Functor is
-#      pre-alpha) with the notes and all platform archives attached
+#      alpha) with the notes and all platform archives attached
 #   5. dispatches Deploy Site, so the deployed site header picks up the new
 #      tag (a GITHUB_TOKEN-created tag does not fire push-triggered workflows
 #      on its own — explicit workflow_dispatch is the sanctioned exception)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ for game logic** — the Rust runtime *interprets* the `.fun` directly, with
 state-preserving hot reload as you save, whole-game time travel over the running model,
 and the same source running on **native and wasm**.
 
-> **Status: pre-alpha.** Functor is early software under active development — the
+> **Status: alpha.** Functor is early software under active development — the
 > language, the prelude, and file formats can all change between releases without a
 > deprecation path. Binaries and changelogs are published on the
 > [releases page](https://github.com/tommy-xr/functor/releases).

--- a/site/build.mjs
+++ b/site/build.mjs
@@ -56,7 +56,7 @@ await mkdir(`${dist}/examples`, { recursive: true });
 // The latest release tag (vX.Y.Z), stamped into each page's header
 // version-badge so the deployed site names the release it accompanies. No
 // reachable tag (fresh history, shallow checkout) → the badge stays the
-// source's plain "pre-alpha".
+// source's plain "alpha".
 let version = "";
 try {
   const tag = execSync("git describe --tags --abbrev=0 --match 'v[0-9]*'", {
@@ -75,7 +75,7 @@ for (const page of PAGES) {
       `${dist}/${page}`,
       html.replace(
         /(<span class="version-badge"[^>]*>)[^<]*(<\/span>)/,
-        `$1${version} · pre-alpha$2`
+        `$1${version} · alpha$2`
       )
     );
   } else {

--- a/site/docs.html
+++ b/site/docs.html
@@ -23,7 +23,7 @@
   <body class="docs-page">
     <header class="site-header">
       <a class="wordmark" href="./"><svg class="wordmark-mark" viewBox="366 163 385 690" fill="currentColor" aria-hidden="true"><path d="M382 341 545 179H735L615 300H548L382 466Z"/><path d="M382 493 497 380V748L382 837Z"/><path d="M518 426H693L597 522H518Z"/></svg>FUNCTOR<span class="wordmark-accent">//DOCS</span></a>
-      <span class="version-badge" title="Functor is pre-alpha software — everything may change between releases">pre-alpha</span>
+      <span class="version-badge" title="Functor is alpha software — everything may change between releases">alpha</span>
       <nav class="site-nav">
         <a href="sandbox.html">Sandbox</a>
         <a href="docs.html" aria-current="page">Docs</a>

--- a/site/ide.html
+++ b/site/ide.html
@@ -23,7 +23,7 @@
   <body class="ide-page">
     <header class="site-header">
       <a class="wordmark" href="./"><svg class="wordmark-mark" viewBox="366 163 385 690" fill="currentColor" aria-hidden="true"><path d="M382 341 545 179H735L615 300H548L382 466Z"/><path d="M382 493 497 380V748L382 837Z"/><path d="M518 426H693L597 522H518Z"/></svg>FUNCTOR<span class="wordmark-accent">//IDE</span></a>
-      <span class="version-badge" title="Functor is pre-alpha software — everything may change between releases">pre-alpha</span>
+      <span class="version-badge" title="Functor is alpha software — everything may change between releases">alpha</span>
       <div class="sandbox-controls">
         <button id="download" type="button" title="Download the project as a .zip">
           ↓ project.zip

--- a/site/index.html
+++ b/site/index.html
@@ -23,7 +23,7 @@
   <body class="landing-page">
     <header class="site-header">
       <a class="wordmark" href="./"><svg class="wordmark-mark" viewBox="366 163 385 690" fill="currentColor" aria-hidden="true"><path d="M382 341 545 179H735L615 300H548L382 466Z"/><path d="M382 493 497 380V748L382 837Z"/><path d="M518 426H693L597 522H518Z"/></svg>FUNCTOR</a>
-      <span class="version-badge" title="Functor is pre-alpha software — everything may change between releases">pre-alpha</span>
+      <span class="version-badge" title="Functor is alpha software — everything may change between releases">alpha</span>
       <nav class="site-nav">
         <a href="sandbox.html">Sandbox</a>
         <a href="docs.html">Docs</a>

--- a/site/sandbox.html
+++ b/site/sandbox.html
@@ -23,7 +23,7 @@
   <body class="sandbox-page">
     <header class="site-header">
       <a class="wordmark" href="./"><svg class="wordmark-mark" viewBox="366 163 385 690" fill="currentColor" aria-hidden="true"><path d="M382 341 545 179H735L615 300H548L382 466Z"/><path d="M382 493 497 380V748L382 837Z"/><path d="M518 426H693L597 522H518Z"/></svg>FUNCTOR<span class="wordmark-accent">//SANDBOX</span></a>
-      <span class="version-badge" title="Functor is pre-alpha software — everything may change between releases">pre-alpha</span>
+      <span class="version-badge" title="Functor is alpha software — everything may change between releases">alpha</span>
       <div class="sandbox-controls">
         <label class="picker-label" for="example-picker">scene</label>
         <select id="example-picker"></select>

--- a/site/styles.css
+++ b/site/styles.css
@@ -460,7 +460,7 @@ a:hover {
   color: var(--pink);
 }
 
-/* The release badge next to the wordmark. The HTML ships "pre-alpha"; the site
+/* The release badge next to the wordmark. The HTML ships "alpha"; the site
    build stamps in the latest release tag (see build.mjs). */
 .version-badge {
   font-size: 0.68rem;


### PR DESCRIPTION
Mechanical wording sweep: the status badge, README notice, and workflow comment now say **alpha** instead of pre-alpha. Verified the site build stamps `v0.1.0 · alpha` with a simulated tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)