### PR TITLE
fix(ci): create the release tag explicitly — gh release create --target 403s

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,13 +118,21 @@ jobs:
           path: assets
           merge-multiple: true
 
+      # The tag is created + pushed explicitly, then the release attaches to
+      # it: `gh release create --target <sha>` is rejected with a 403 for the
+      # Actions token even with contents: write (cli/cli#9514), while a plain
+      # tag push and a release onto an existing tag are both allowed. The
+      # explicit SHA pins the release to the commit the binaries were built
+      # from, even if main has moved since the dispatch.
       - name: Create tag + pre-release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           ls -l assets
+          git tag "v$VERSION" "$GITHUB_SHA"
+          git push origin "v$VERSION"
           gh release create "v$VERSION" \
-            --target "$GITHUB_SHA" \
+            --verify-tag \
             --title "v$VERSION" \
             --prerelease \
             --notes-file assets/release-notes.md \


### PR DESCRIPTION
The first `v0.1.0` dispatch ([run 29645928343](https://github.com/tommy-xr/functor/actions/runs/29645928343)) sailed through `prepare` (version resolved to 0.1.0, notes generated) and all four platform binaries, then failed in `publish`: `gh release create --target <sha>` returns **HTTP 403: Resource not accessible by integration** for the Actions token even though the job log confirms `Contents: write` was granted — a known gh/API restriction on `--target` ([cli/cli#9514](https://github.com/cli/cli/issues/9514)). Rulesets/tag-protection were ruled out (none configured).

Fix: create + push the tag explicitly (a plain tag push is permitted with `contents: write`), then attach the release to the existing tag with `--verify-tag`. The tag is still pinned to `$GITHUB_SHA`, so it matches the commit the binaries were built from even if main has moved since dispatch. The failed run created no tag or release, so a fresh dispatch after this merges will cleanly compute `0.1.0` again.

Verification: `actionlint` passes; the real proof is the re-dispatched release run, which I'll monitor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)