### PR TITLE
docs: release version badge at the top of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Native](https://github.com/tommy-xr/functor/actions/workflows/build-native.yml/badge.svg)](https://github.com/tommy-xr/functor/actions/workflows/build-native.yml) [![Build WebAssembly](https://github.com/tommy-xr/functor/actions/workflows/build-wasm.yml/badge.svg)](https://github.com/tommy-xr/functor/actions/workflows/build-wasm.yml)
+[![Release](https://img.shields.io/github/v/release/tommy-xr/functor?include_prereleases&label=release&color=41d8e6)](https://github.com/tommy-xr/functor/releases) [![Build Native](https://github.com/tommy-xr/functor/actions/workflows/build-native.yml/badge.svg)](https://github.com/tommy-xr/functor/actions/workflows/build-native.yml) [![Build WebAssembly](https://github.com/tommy-xr/functor/actions/workflows/build-wasm.yml/badge.svg)](https://github.com/tommy-xr/functor/actions/workflows/build-wasm.yml)
 
 # functor
 


### PR DESCRIPTION
Adds a shields.io release badge (reads the latest tag from the GitHub API, `include_prereleases`, cyan to match the site accent) ahead of the build badges, linking to the releases page. It shows `v0.1.0` now and auto-updates on every release — no README edit per release, consistent with the tag being the single source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)