### PR TITLE
fix(site): sync player.html input bridges with the runtime host page

### DIFF
--- a/site/player.html
+++ b/site/player.html
@@ -103,6 +103,10 @@
         functor_lang_key_event,
         functor_lang_mouse_move,
         functor_lang_mouse_wheel,
+        functor_lang_ui_pointer,
+        functor_lang_ui_pointer_leave,
+        functor_lang_ui_wants_keyboard,
+        functor_lang_ui_key,
         functor_lang_is_running,
         functor_lang_scene_frame,
         functor_lang_inspector_trace,
@@ -150,6 +154,13 @@
         if (code.length === 4 && code.startsWith("Key")) {
           return code.charCodeAt(3) - 64;
         }
+        // "Digit0".."Digit9" / "Numpad0".."Numpad9" -> Num0=34..Num9=43.
+        if (code.startsWith("Digit") && code.length === 6) {
+          return code.charCodeAt(5) - 48 + 34;
+        }
+        if (code.startsWith("Numpad") && code.length === 7) {
+          return code.charCodeAt(6) - 48 + 34;
+        }
         switch (code) {
           case "ArrowUp": return 27;
           case "ArrowDown": return 28;
@@ -165,16 +176,32 @@
       const setupInput = () => {
         const canvas = document.getElementById("canvas");
 
+        // While a Ui.textInput is focused (the runtime reports it after each
+        // frame), keydowns route to the OVERLAY instead — the game's input
+        // hook is suppressed (docs/ui-interaction.md U4; repeats pass through
+        // so held backspace repeats). `gameHeld` tracks the presses the GAME
+        // actually received, so a release whose press was swallowed by a
+        // focused field never leaks a phantom release edge. Kept in sync with
+        // index-functor-lang.html.
+        const gameHeld = new Set();
         window.addEventListener("keydown", (e) => {
+          if (functor_lang_ui_wants_keyboard()) {
+            if (e.metaKey || e.ctrlKey || e.altKey) return;
+            if (functor_lang_ui_key(e.key)) e.preventDefault();
+            return;
+          }
           const code = keyCode(e.code);
           if (code === 0) return;
           e.preventDefault();
-          if (!e.repeat) functor_lang_key_event(code, true);
+          if (!e.repeat) {
+            functor_lang_key_event(code, true);
+            gameHeld.add(code);
+          }
         });
         window.addEventListener("keyup", (e) => {
           const code = keyCode(e.code);
           if (code === 0) return;
-          functor_lang_key_event(code, false);
+          if (gameHeld.delete(code)) functor_lang_key_event(code, false);
         });
 
         // Mouse free-look. Pointer Lock is the browser equivalent of the
@@ -201,6 +228,35 @@
         canvas.addEventListener("wheel", (e) => {
           e.preventDefault();
           functor_lang_mouse_wheel(Math.sign(e.deltaY));
+        });
+
+        // Interactive game UI (docs/ui-interaction.md U3): while the pointer
+        // is FREE (not look mode), its canvas position + primary button drive
+        // the game's `Ui.*` widgets. CSS px — the runtime scales by the
+        // device pixel ratio. Pointer lock engaging counts as leaving. Kept
+        // in sync with index-functor-lang.html.
+        let uiButtonDown = false;
+        const uiPointer = (e) => {
+          if (document.pointerLockElement === canvas) return;
+          functor_lang_ui_pointer(e.offsetX, e.offsetY, uiButtonDown);
+        };
+        canvas.addEventListener("mousemove", uiPointer);
+        canvas.addEventListener("mousedown", (e) => {
+          if (e.button !== 0) return;
+          uiButtonDown = true;
+          uiPointer(e);
+        });
+        canvas.addEventListener("mouseup", (e) => {
+          if (e.button !== 0) return;
+          uiButtonDown = false;
+          uiPointer(e);
+        });
+        canvas.addEventListener("mouseleave", () => {
+          uiButtonDown = false;
+          functor_lang_ui_pointer_leave();
+        });
+        document.addEventListener("pointerlockchange", () => {
+          if (document.pointerLockElement === canvas) functor_lang_ui_pointer_leave();
         });
       };
 


### PR DESCRIPTION
## What

The site player (`site/player.html`) is a hand-maintained copy of the runtime's host page (`index-functor-lang.html`) and had silently drifted behind it. This ports the missing input blocks verbatim:

- **the egui ui-pointer bridge** — canvas `mousemove/mousedown/mouseup` → `functor_lang_ui_pointer(offsetX, offsetY, primaryDown)`, `mouseleave` / pointer-lock-engage → `functor_lang_ui_pointer_leave()`. Without it, every interactive `Ui.*` widget (`Ui.button` / `Ui.slider` / `Ui.textInput`) **rendered but was click-dead on the website** — while working on native and on `functor run wasm`'s own page — ever since the bridge shipped in #293.
- **the `Ui.textInput` keyboard route** — the `functor_lang_ui_wants_keyboard()` gate + `functor_lang_ui_key()`, with the `gameHeld` set so a press swallowed by a focused field never leaks a phantom release edge to the game's `input` hook.
- **`Key.Num0`–`Num9`** — the Digit/Numpad rows were missing from the site's `keyCode` map.

## How it was diagnosed

User report: "UI works in the native window and at 127.0.0.1:8080, but not on the website." Bisected conclusively with Playwright against the built site: the stock page registered **0** of 42 grid clicks on `examples/counter`'s `+1` button; the same page + wasm instance with the runtime page's listener block injected via `page.evaluate` registered clicks immediately (count reached 8). Not a coordinate/dpr bug, not a stale pkg bundle (the exports were present — the *page* was stale).

## Verification

Playwright against `site:serve` on the rebuilt `dist`: a `Debug.log`-instrumented `examples/counter` (via `?src=`) logs `clicked: 1 / 2 / 3` for 3/3 button clicks.

## Follow-up

The root cause is the duplication itself — two hand-copied host pages. Tracked in #402 (extract the shared page glue into a module like `scrubber.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)