### PR TITLE
feat(ui): webview — HTML/CSS game UI via blitz (native) + a DOM overlay (wasm)

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -194,7 +194,7 @@ let grab = (s) =>
 - **Protected namespaces**: a file whose module name collides with a
   builtin/prelude namespace (Net, Key, Random, List, Text, Math, Debug, Scene,
   Anim, Asset, Camera, Frame, Light, Fog, Color, Vec3, Skybox, Angle, Texture,
-  Time, Sub, Effect, Physics, RenderTarget, Ui, AudioSource, AudioScene) is a
+  Time, Sub, Effect, Physics, RenderTarget, Ui, Html, Attr, AudioSource, AudioScene) is a
   load error — rename the file. (`assets.fun` → `Assets` — the generated
   manifest — is fine; only the exact name collides.)
 - **`Net` is a built-in module**, always in scope: `type NetEvent =
@@ -249,11 +249,12 @@ open Widget                                              // …or open, bringing
 - This is how the **engine prelude's types are declared**: the `functor-prelude`
   crate ships a `.funi` for every host namespace (`Scene`, `Asset`, `Camera`,
   `Frame`, `Light`, `Fog`, `Skybox`, `RenderTarget`, `Texture`, `Angle`, `Time`,
-  `Sub`, `Effect`, `Physics`, `Ui`, `AudioSource`, `AudioScene`), loaded by the
+  `Sub`, `Effect`, `Physics`, `Ui`, `Html`, `Attr`, `AudioSource`, `AudioScene`),
+  loaded by the
   runner so engine calls carry real types (no longer `Unknown`). Each module's
   primary opaque handle is `Mod.t` (`Camera.t`, `Frame.t`, `Effect.t`, …);
   modules that own several name each (`Scene.t`; `Physics.shape`/`body`/`world`;
-  `Ui.view`/`anchor`; `Asset.Model`/`Texture`/`Sound`). Physics query/event results are records
+  `Ui.view`/`anchor`; `Html.node`/`Attr.t`; `Asset.Model`/`Texture`/`Sound`). Physics query/event results are records
   (`Physics.position`, `Physics.rayHit`, `Physics.collisionEvent`).
 
 ## Semantics rules that WILL bite you
@@ -623,6 +624,41 @@ Ui.textInput(value, tagger)                                // INTERACTIVE contro
                                                            //   `examples/ui` showcases every
                                                            //   widget in one panel
 
+Html.text("…") / Html.style("css…")                        // the `webview` hook's vocabulary: an
+Html.element("tag", [attr, …], [node, …])                  //   Elm-style HTML tree styled with
+Html.div([attr, …], [node, …])                             //   REAL CSS (flexbox, gradients,
+Html.span(…) / Html.button(…) / Html.h1(…)                 //   :hover, transitions). Natively it
+Html.h2(…) / Html.p(…)                                     //   renders via blitz (Stylo + Taffy +
+Html.input([attr, …])                                      //   Parley) CPU-painted and composited
+                                                           //   over the frame; on wasm it is a
+                                                           //   REAL DOM overlay above the canvas.
+                                                           //   Html.style emits its CSS string
+                                                           //   verbatim in a <style> element;
+                                                           //   Html.text is escaped. Html.input
+                                                           //   is a void element (attrs only) —
+                                                           //   pair Attr.value + Attr.onInput.
+Attr.class("…") / Attr.style("…") / Attr.id("…")           // plain attributes; Attr.attr(name,
+Attr.value("…") / Attr.placeholder("…")                    //   value) for anything else
+Attr.attr("name", "value")
+Attr.onClick(msg)                                          // INTERACTIVE (the Ui.button shape):
+                                                           //   a click on the element (or a
+                                                           //   descendant — DOM bubbling)
+                                                           //   delivers msg VERBATIM through
+                                                           //   `update`. Handlers are numbered by
+                                                           //   SLOT in construction order across
+                                                           //   the whole webview tree; drive them
+                                                           //   headlessly via POST /input
+                                                           //   {"type":"webview_event","slot":0,
+                                                           //    "kind":"Clicked"}.
+Attr.onInput(tagger)                                       // INTERACTIVE (the Ui.textInput
+                                                           //   shape): each edit applies the
+                                                           //   tagger to the new text. NOTE: text
+                                                           //   inputs are wasm-complete; native
+                                                           //   focus/keyboard routing is still a
+                                                           //   prototype gap (clicks work
+                                                           //   everywhere). `examples/webview` is
+                                                           //   the reference
+
 Physics.tag("name")                                        // BRANDED body identity (the
                                                            //   RenderTarget rule): declare
                                                            //   once, use the VALUE at every
@@ -729,6 +765,10 @@ let update = (model, msg) => model'         // OPTIONAL; msgs are ADT variants
 let subscriptions = (model) => Sub.every(Time.seconds(1.0), Beat)
                                             // OPTIONAL, but requires update
 let physics = (model) => Physics.scene(Vec3.make(0.0, -9.81, 0.0), [body, …])  // OPTIONAL
+let webview = (model) => Html.div([…], […])  // OPTIONAL; the HTML/CSS overlay
+                                            // (blitz natively, a DOM overlay on
+                                            // wasm). Attr.onClick msgs arrive
+                                            // through `update`
 let ui = (model) => Ui.column([…]) |> Ui.panel(Ui.topLeft())  // OPTIONAL; the 2D HUD,
                                             // drawn over the frame. Ui.button clicks
                                             // arrive as msgs through `update`

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -40,7 +40,8 @@ jobs:
             libglu1-mesa-dev \
             libglfw3 \
             libglfw3-dev \
-            libasound2-dev
+            libasound2-dev \
+            libfontconfig-dev
 
       - name: Cache Rust build
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/golden.yml
+++ b/.github/workflows/golden.yml
@@ -69,7 +69,8 @@ jobs:
             libglu1-mesa-dev \
             libglfw3 \
             libglfw3-dev \
-            libasound2-dev
+            libasound2-dev \
+            libfontconfig-dev
 
       - name: Install npm dependencies
         run: npm install

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -90,7 +90,8 @@ jobs:
             libglu1-mesa-dev \
             libglfw3 \
             libglfw3-dev \
-            libasound2-dev
+            libasound2-dev \
+            libfontconfig-dev
 
       - name: Build web runtime bundle
         run: wasm-pack build --target=web

--- a/.github/workflows/wasm-smoke.yml
+++ b/.github/workflows/wasm-smoke.yml
@@ -57,7 +57,8 @@ jobs:
             libglu1-mesa-dev \
             libglfw3 \
             libglfw3-dev \
-            libasound2-dev
+            libasound2-dev \
+            libfontconfig-dev
 
       - name: Install npm dependencies
         run: npm ci

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,10 +128,17 @@ Functor Lang hot-reload is built into the runtime, so `develop` does not need it
 `include_bytes!`, so the wasm bundle must exist before the `functor` binary is built:
 
 ```sh
-npm run build:cli   # the wasm bundle, then the functor CLI
+npm run build:cli           # the wasm bundle, then the functor CLI (debug)
+npm run build:cli:release   # same, but target/release/functor
 ```
 
-Produces `target/debug/functor` — a single binary with the desktop runtime built in.
+Produces `target/debug/functor` (or `target/release/functor`) — a single binary with the
+desktop runtime built in. **Use the RELEASE binary for interactive native testing** — the
+debug build is fine for headless checks and captures, but its CPU-bound paths are unusably
+slow live: the webview overlay's CPU raster is ~200× slower (~0.6s per repaint at a retina
+window — feels like a hang), and rapier physics steps are similarly far off release speed.
+The wasm bundle is unaffected either way: `wasm-pack build` is release by default, so
+`run wasm` and the site always ship optimized wasm.
 
 **Scaffold a game.** `init` creates an embedded Functor Lang starter without overwriting an existing
 `functor.json` or `game.fun`; `3d` is the default template:
@@ -270,6 +277,18 @@ For language-only changes, `functor-lang/benches` (see its README) isolates
 interpreter micro-ops under the plain prelude — useful for pinpointing, but a
 frame_bench run is still the acceptance number: micro-derived estimates have
 misjudged real per-frame cost before.
+
+For changes to the **native webview overlay** (blitz parse/resolve/paint —
+`webview_overlay.rs` or its blitz dependency pins), the analogous number is:
+
+```sh
+cargo run -q --release -p functor-runtime-desktop --example webview_bench
+```
+
+It times per-re-render parse+resolve (shared FontContext — a fresh one
+re-scans system fonts, the ~30ms regression it exists to catch), per-repaint
+CPU raster at three framebuffer sizes, and the press-time hit-test. Same
+rules: release only, compare the **min** column.
 
 ## Gotchas
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -80,6 +80,33 @@ bug found in the same exercise was fixed on the spot
 - [ ] Camera middleware: FPSCamera, OrbitCamera.
 - [ ] In-built hands models.
 
+## Webview (HTML/CSS UI)
+
+Prototype landed 2026-07-18: `webview(model)` → `Html.*`/`Attr.*` tree, blitz
+(CPU-painted) natively, DOM overlay on wasm; clicks fold through `update`.
+Remaining, roughly in priority order:
+
+- [ ] Native text input: route focus/keyboard into blitz (`Ui.textInput`'s
+      wants-keyboard gate; blitz has `Input` events + form support). wasm
+      inputs already work.
+- [ ] Record webview events for replay — needs their own `RecordedInput`
+      variant (a `UiEvent` entry would replay against the wrong handler
+      table; TODO comments in both producers).
+- [ ] Reconcile the DOM instead of full reparse on change (also fixes
+      focus/caret loss in wasm controlled inputs, and native selection state).
+- [ ] Cache the serialized HTML in the producer (today: tree clone +
+      `to_html` per frame per shell — the `webview_bench` numbers).
+- [ ] Tick CSS animations/transitions: repaint-while-animating (native is
+      dirty-flag only; we own blitz's clock via `resolve(t)`).
+- [ ] Debug-build usability: dirty-region repaint or downscaled raster
+      (full-window CPU paint is ~200× release — interactive native testing
+      uses release builds meanwhile).
+- [ ] Keep `site/player.html` in sync with `index-functor-lang.html` — the
+      hand-copied page drifted three features behind (ui-pointer bridge,
+      textInput keyboard route, webview overlay; caught+fixed 2026-07-18).
+      Extract the shared page JS into a module like `scrubber.js`, or add a
+      sync-check test.
+
 ## Effects & subscriptions
 
 Build the shared machinery once when the first resource-backed sub/effect lands.

--- a/examples/webview/functor.json
+++ b/examples/webview/functor.json
@@ -1,0 +1,4 @@
+{
+  "language": "functor-lang",
+  "entry": "game.fun"
+}

--- a/examples/webview/game.fun
+++ b/examples/webview/game.fun
@@ -1,0 +1,66 @@
+// webview — the HTML/CSS overlay hello world.
+//
+// `webview(model)` returns an Elm-style `Html.*` tree styled with real CSS
+// (flexbox, gradients, border-radius, :hover). Natively it renders through
+// blitz (Stylo + Taffy + Parley) composited over the 3D frame; on wasm it is
+// a real DOM overlay above the canvas. An `Attr.onClick` click delivers its
+// msg verbatim through `update` — the `Ui.button` loop, with CSS styling.
+
+type Model = { count: float, spin: float }
+type Msg =
+  | Inc
+  | Dec
+  | Reset
+
+let init = { count: 0.0, spin: 0.0 }
+
+let update = (m: Model, msg: Msg) =>
+  match msg with
+  | Inc => { m with count: m.count + 1.0 }
+  | Dec => { m with count: m.count - 1.0 }
+  | Reset => { m with count: 0.0 }
+
+let tick = (m: Model, dt, tts) => { m with spin: m.spin + dt * 20.0 }
+
+let draw = (m: Model, tts) =>
+  Frame.createLit(
+    Camera.lookAt(Vec3.make(0.0, 1.5, -4.0), Vec3.make(0.0, 0.0, 0.0)),
+    Scene.cube()
+      |> Scene.lit(Color.rgb(0.35, 0.75, 0.55))
+      |> Scene.rotateY(Angle.degrees(m.spin + m.count * 15.0)),
+    [
+      Light.ambient(Color.rgb(0.25, 0.25, 0.25)),
+      Light.directional(Vec3.make(-0.5, -1.0, 0.4), Color.rgb(1.0, 1.0, 1.0), 0.9),
+    ],
+  )
+
+// The stylesheet is plain CSS in a string — themeable without touching the
+// tree. .hud is a fixed-width card pinned by its margin; buttons get :hover.
+let css = "
+  .hud { display: flex; flex-direction: column; gap: 12px; width: 300px;
+         margin: 24px; padding: 20px;
+         background: linear-gradient(135deg, rgba(24, 26, 44, 0.92), rgba(52, 24, 64, 0.92));
+         border: 2px solid #8be9fd; border-radius: 14px;
+         font-family: sans-serif; color: #f8f8f2; }
+  .hud h1 { margin: 0; font-size: 22px; color: #8be9fd; }
+  .count { font-size: 40px; font-weight: bold; text-align: center; }
+  .row { display: flex; gap: 10px; justify-content: center; }
+  button { padding: 8px 18px; font-size: 18px; font-weight: bold;
+           background: #50fa7b; color: #1e1e3c; border: none; border-radius: 8px; }
+  button:hover { background: #f1fa8c; }
+  button.ghost { background: transparent; color: #8be9fd; border: 1px solid #8be9fd; }
+"
+
+let webview = (m: Model) =>
+  Html.div([], [
+    Html.style(css),
+    Html.div([Attr.class("hud")], [
+      Html.h1([], [Html.text("Functor webview")]),
+      Html.div([Attr.class("count")], [Html.text(Text.fixed(m.count, 0.0))]),
+      Html.div([Attr.class("row")], [
+        Html.button([Attr.onClick(Dec)], [Html.text("-")]),
+        Html.button([Attr.onClick(Inc)], [Html.text("+")]),
+        Html.button([Attr.class("ghost"), Attr.onClick(Reset)], [Html.text("Reset")]),
+      ]),
+    ]),
+  ])

--- a/functor-lang/src/project.rs
+++ b/functor-lang/src/project.rs
@@ -67,6 +67,8 @@ const PROTECTED_NAMESPACES: &[&str] = &[
     "Physics",
     "RenderTarget",
     "Ui",
+    "Html",
+    "Attr",
     "AudioSource",
     "AudioScene",
     "Debug",

--- a/functor-prelude/prelude/attr.funi
+++ b/functor-prelude/prelude/attr.funi
@@ -1,0 +1,22 @@
+// attr.funi — the `Attr` host module (interface only; implemented in Rust by
+// FunctorHost in functor_runtime_common::functor_lang_prelude). See docs/functor-lang-interfaces.md.
+//
+// Attributes for `Html.*` elements — CSS classes, inline styles, and the
+// event handlers that route interactions back through `update`.
+
+// The opaque attribute handle.
+type t
+
+let class : (string) => t
+let style : (string) => t
+let id : (string) => t
+// Any attribute by name: `Attr.attr("placeholder", "Your name")`.
+let attr : (string, string) => t
+// The controlled value of an `Html.input`.
+let value : (string) => t
+let placeholder : (string) => t
+// Like Ui.button's msg: delivered VERBATIM through `update` when the element
+// is clicked ('msg is erased by the opaque t; checked at runtime).
+let onClick : ('msg) => t
+// Like Ui.textInput's tagger: applied to the new text on each edit.
+let onInput : ('tagger) => t

--- a/functor-prelude/prelude/html.funi
+++ b/functor-prelude/prelude/html.funi
@@ -1,0 +1,28 @@
+// html.funi — the `Html` host module (interface only; implemented in Rust by
+// FunctorHost in functor_runtime_common::functor_lang_prelude). See docs/functor-lang-interfaces.md.
+//
+// The optional `webview = (model) => …` hook's vocabulary: an Elm-style tree
+// of HTML elements styled with CSS. Native renders it via blitz (Stylo +
+// Taffy + Parley) composited over the 3D frame; wasm shows it as a real DOM
+// overlay above the canvas.
+
+// The opaque node handle (`Html.node` from game code).
+type node
+
+// A text node. Escaped — write markup with elements, not strings.
+let text : (string) => node
+// A generic element: `Html.element("section", [attrs], [children])`.
+let element : (string, List<Attr.t>, List<node>) => node
+// Common elements, all `(attrs, children)`.
+let div : (List<Attr.t>, List<node>) => node
+let span : (List<Attr.t>, List<node>) => node
+let button : (List<Attr.t>, List<node>) => node
+let h1 : (List<Attr.t>, List<node>) => node
+let h2 : (List<Attr.t>, List<node>) => node
+let p : (List<Attr.t>, List<node>) => node
+// A single-line text input (a void element — no children). Pair with
+// `Attr.value` (controlled) and `Attr.onInput`.
+let input : (List<Attr.t>) => node
+// A stylesheet: `Html.style(".hud { color: red; }")`. The CSS string is
+// emitted verbatim inside a <style> element.
+let style : (string) => node

--- a/functor-prelude/src/lib.rs
+++ b/functor-prelude/src/lib.rs
@@ -34,6 +34,8 @@ pub fn modules() -> Vec<(String, String)> {
         module("Effect", include_str!("../prelude/effect.funi")),
         module("Physics", include_str!("../prelude/physics.funi")),
         module("Ui", include_str!("../prelude/ui.funi")),
+        module("Html", include_str!("../prelude/html.funi")),
+        module("Attr", include_str!("../prelude/attr.funi")),
         module("AudioSource", include_str!("../prelude/audio_source.funi")),
         module("AudioScene", include_str!("../prelude/audio_scene.funi")),
     ]

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "clean": "git clean -fdX",
     "build:cli": "wasm-pack build runtime/functor-runtime-web --target=web && cargo build --bin functor",
+    "build:cli:release": "wasm-pack build runtime/functor-runtime-web --target=web && cargo build --release --bin functor",
     "build:lang-wasm": "wasm-pack build tools/functor-lang-wasm --target=web",
     "build:lsp": "cargo install --path tools/functor-lang-lsp --force && (pkill -x functor-lang-lsp || true)",
     "install:vsix": "npm run install:vsix --prefix tools/functor-lang-vscode",

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -143,6 +143,7 @@ use crate::render_target::RenderTargetDescriptor;
 use crate::scene3d::{MaterialDescription, ModelDescription, ModelHandle, TextureDescription};
 use crate::skybox::SkyboxDescription;
 use crate::ui::{self, View};
+use crate::webview::HtmlNode;
 use crate::{Camera, Frame, Light, Scene3D, SceneObject, Shape};
 
 /// A [`Scene3D`] as an opaque Functor Lang value.
@@ -727,6 +728,46 @@ impl HostData for FunctorLangUiAnchor {
     }
 }
 
+/// An [`HtmlNode`] as an opaque Functor Lang value — what the optional
+/// `webview(model)` entry point returns (`Html.div` / `Html.text` / …).
+/// The shells render it as HTML/CSS: blitz-composited natively, a real DOM
+/// overlay on wasm.
+pub struct FunctorLangHtmlNode(pub HtmlNode);
+
+impl HostData for FunctorLangHtmlNode {
+    fn type_name(&self) -> &'static str {
+        "Html"
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+/// One attribute of an `Html.*` element, before it is folded into the node.
+/// Interactive attributes registered their handler at construction time (the
+/// `Ui.button` shape) and carry only the slot.
+#[derive(Clone)]
+pub enum HtmlAttr {
+    /// A plain `name="value"` pair (`Attr.class` / `Attr.style` / `Attr.attr`).
+    Pair(String, String),
+    /// `Attr.onClick(msg)` — msg registered in the frame's handler table.
+    Click(u32),
+    /// `Attr.onInput(tagger)` — tagger registered in the frame's handler table.
+    Input(u32),
+}
+
+/// An [`HtmlAttr`] as an opaque Functor Lang value — `Attr.class(…)` / `Attr.onClick(msg)`.
+pub struct FunctorLangHtmlAttr(pub HtmlAttr);
+
+impl HostData for FunctorLangHtmlAttr {
+    fn type_name(&self) -> &'static str {
+        "Attr"
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
 /// A [`Fog`] as an opaque Functor Lang value — `Fog.linear(…)`/`Fog.exp(…)`.
 /// `Frame.withFog` accepts ONLY this (the Angle rule).
 pub struct FunctorLangFog(pub Fog);
@@ -936,6 +977,18 @@ pub fn view_value(value: &Value) -> Option<&View> {
     }
 }
 
+/// Extract the [`HtmlNode`] from a Functor Lang value (an `Html.*` result), for the
+/// shells' webview overlay — the `webview` hook's [`view_value`].
+pub fn html_node_value(value: &Value) -> Option<&HtmlNode> {
+    match value {
+        Value::HostData(data) => data
+            .as_any()
+            .downcast_ref::<FunctorLangHtmlNode>()
+            .map(|n| &n.0),
+        _ => None,
+    }
+}
+
 /// Extract the [`physics::PhysicsScene`] from a Functor Lang value (a `Physics.scene`
 /// result), for the shells' physics drive.
 pub fn physics_scene_value(value: &Value) -> Option<&physics::PhysicsScene> {
@@ -987,6 +1040,7 @@ pub(crate) fn registry() -> &'static crate::host_registry::Registry {
         register_effects(&mut reg);
         register_subs(&mut reg);
         register_ui_widgets(&mut reg);
+        register_html(&mut reg);
         register_audio(&mut reg);
         reg
     })
@@ -1080,6 +1134,8 @@ crate::host_returnable!(
     FunctorLangSub,
     FunctorLangAsset,
     FunctorLangView,
+    FunctorLangHtmlNode,
+    FunctorLangHtmlAttr,
     FunctorLangAudioSource,
     FunctorLangAudioScene,
 );
@@ -2193,6 +2249,162 @@ fn register_ui_widgets(reg: &mut crate::host_registry::Registry) {
     );
 }
 
+/// A simple identifier-ish name: letters, then letters/digits/dashes — the
+/// shape of every real tag and attribute name. Anything else could break out
+/// of the serialized HTML (names are emitted unescaped).
+fn valid_html_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    matches!(chars.next(), Some(c) if c.is_ascii_alphabetic())
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '-')
+}
+
+/// Tags that execute or reframe content — never legitimate game UI. The wasm
+/// overlay is a REAL DOM, so `Html.element("script", …)` would otherwise run
+/// code in the host page (game logic has no DOM access by design).
+fn forbidden_tag(tag: &str) -> bool {
+    matches!(
+        tag,
+        "script" | "iframe" | "object" | "embed" | "link" | "base" | "meta" | "frame" | "frameset"
+    )
+}
+
+/// Attribute names that execute code (`on*`), navigate (`href`, `action`,
+/// `formaction`), embed documents (`srcdoc`), or spoof the runtime's handler
+/// slots (`data-fn-*` — those come only from `Attr.onClick`/`Attr.onInput`).
+fn forbidden_attr(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    lower.starts_with("on")
+        || lower.starts_with("data-fn-")
+        || matches!(lower.as_str(), "href" | "srcdoc" | "action" | "formaction")
+}
+
+/// Fold typed `Html.*` builder arguments — attrs and child nodes — into an
+/// [`HtmlNode::Element`]. Type errors were already handled by the registry's
+/// argument conversion; this owns only the fold.
+fn build_html_element(
+    tag: &str,
+    attrs: Vec<FunctorLangHtmlAttr>,
+    children: Vec<FunctorLangHtmlNode>,
+) -> FunctorLangHtmlNode {
+    let mut pairs = Vec::new();
+    let mut click_slot = None;
+    let mut input_slot = None;
+    for FunctorLangHtmlAttr(attr) in attrs {
+        match attr {
+            HtmlAttr::Pair(name, value) => pairs.push((name, value)),
+            HtmlAttr::Click(slot) => click_slot = Some(slot),
+            HtmlAttr::Input(slot) => input_slot = Some(slot),
+        }
+    }
+    FunctorLangHtmlNode(HtmlNode::Element {
+        tag: tag.to_string(),
+        attrs: pairs,
+        click_slot,
+        input_slot,
+        children: children.into_iter().map(|n| n.0).collect(),
+    })
+}
+
+/// The webview vocabulary (the optional `webview = (model) => …` hook): an
+/// Elm-style HTML/CSS tree — `Html.div([Attr.class("hud")], […])`.
+/// Interactive attrs register their handler like Ui.button/textInput
+/// (docs/ui-interaction.md); the shells render the tree via blitz (native)
+/// or a DOM overlay (wasm).
+fn register_html(reg: &mut crate::host_registry::Registry) {
+    reg.fn1("Html.text", "Html.text(\"…\")", |text: String| {
+        FunctorLangHtmlNode(HtmlNode::Text(text))
+    });
+    // A stylesheet: the CSS string is emitted VERBATIM inside <style> (CSS
+    // needs `>` selectors etc.; `Html.text` is escaped).
+    reg.fn1("Html.style", "Html.style(\"css…\")", |css: String| {
+        FunctorLangHtmlNode(HtmlNode::Element {
+            tag: "style".to_string(),
+            attrs: vec![],
+            click_slot: None,
+            input_slot: None,
+            children: vec![HtmlNode::Text(css)],
+        })
+    });
+    // The generic element. Names are emitted unescaped and the wasm overlay
+    // is a REAL DOM — validate here so a script-capable tag is a
+    // construction-time teaching error, not an injection.
+    reg.fn3(
+        "Html.element",
+        "Html.element(\"tag\", [attr, …], [node, …])",
+        |tag: String,
+         attrs: Vec<FunctorLangHtmlAttr>,
+         children: Vec<FunctorLangHtmlNode>| {
+            if !valid_html_name(&tag) || forbidden_tag(&tag) {
+                return Err(format!(
+                    "Html.element: `{tag}` is not an allowed tag name \
+(letters/digits/dashes; script-capable tags are refused)"
+                ));
+            }
+            Ok(build_html_element(&tag, attrs, children))
+        },
+    );
+    for tag in ["div", "span", "button", "h1", "h2", "p"] {
+        reg.fn2(
+            format!("Html.{tag}").leak() as &'static str,
+            format!("Html.{tag}([attr, …], [node, …])").leak() as &'static str,
+            move |attrs: Vec<FunctorLangHtmlAttr>, children: Vec<FunctorLangHtmlNode>| {
+                build_html_element(tag, attrs, children)
+            },
+        );
+    }
+    // A void element: attrs only. Pair Attr.value (controlled) with
+    // Attr.onInput.
+    reg.fn1(
+        "Html.input",
+        "Html.input([attr, …])",
+        |attrs: Vec<FunctorLangHtmlAttr>| build_html_element("input", attrs, vec![]),
+    );
+    for name in ["class", "style", "id", "value", "placeholder"] {
+        reg.fn1(
+            format!("Attr.{name}").leak() as &'static str,
+            format!("Attr.{name}(\"…\")").leak() as &'static str,
+            move |value: String| FunctorLangHtmlAttr(HtmlAttr::Pair(name.to_string(), value)),
+        );
+    }
+    // The `Html.element` rule for attribute names: reject executable (`on*`),
+    // navigating (`href`/`action`), and handler-slot-spoofing (`data-fn-*`)
+    // names.
+    reg.fn2(
+        "Attr.attr",
+        "Attr.attr(\"name\", \"value\")",
+        |name: String, value: String| {
+            if !valid_html_name(&name) || forbidden_attr(&name) {
+                return Err(format!(
+                    "Attr.attr: `{name}` is not an allowed attribute name \
+(letters/digits/dashes; on*/href/data-fn-* are refused)"
+                ));
+            }
+            Ok(FunctorLangHtmlAttr(HtmlAttr::Pair(name, value)))
+        },
+    );
+    // The msg is any Functor Lang value (typically an ADT variant), registered in
+    // the frame's handler table and delivered VERBATIM through `update` when
+    // the shell reports a click — the Ui.button shape.
+    reg.fn1(
+        "Attr.onClick",
+        "Attr.onClick(msg) — msg is delivered to update on click",
+        |msg: Value| {
+            let slot = push_ui_handler(UiHandler::Msg(msg));
+            FunctorLangHtmlAttr(HtmlAttr::Click(slot))
+        },
+    );
+    // The tagger is applied to the new text on each edit — the Ui.textInput
+    // shape.
+    reg.fn1(
+        "Attr.onInput",
+        "Attr.onInput(tagger) — tagger: (newText) => msg",
+        |tagger: Tagger| {
+            let slot = push_ui_handler(UiHandler::Tagger(tagger.0));
+            FunctorLangHtmlAttr(HtmlAttr::Input(slot))
+        },
+    );
+}
+
 /// The audio vocabulary — soundscape voices (the continuous, reconciled half
 /// of audio; the one-shots live in `register_effects`). Voices are keyed for
 /// cross-frame identity so the shell keeps a live voice playing.
@@ -2348,6 +2560,8 @@ handle_arg!(
     FunctorLangEffect => "an Effect",
     FunctorLangSub => "a Sub",
     FunctorLangView => "a View",
+    FunctorLangHtmlNode => "an Html node",
+    FunctorLangHtmlAttr => "an Attr",
     FunctorLangAudioSource => "an AudioSource",
 );
 
@@ -4539,12 +4753,21 @@ Scene.cube() |> Scene.rotateY(Angle.radians(1.5707964)))",
         let mut host = FunctorHost;
         for path in registry().paths() {
             let result = host.call(path, vec![Value::Bool(true)], functor_lang::Span::new(0, 0));
-            let message = result.err().expect("garbage args should error").message;
-            assert!(
-                !message.starts_with("internal:"),
-                "`{path}` fell through to the internal fallback: {message}"
-            );
+            // Most paths reject the garbage `true` arg with a usage/type
+            // error; a path whose contract accepts ANY value
+            // (`Attr.onClick(msg)`) may legitimately succeed — an Ok proves
+            // dispatch just as well.
+            if let Err(error) = result {
+                assert!(
+                    !error.message.starts_with("internal:"),
+                    "`{path}` fell through to the internal fallback: {}",
+                    error.message
+                );
+            }
         }
+        // An any-msg path (Attr.onClick) registered a handler above — drop it
+        // so the table never leaks into other tests on this thread.
+        let _ = take_ui_handlers();
     }
 
     // The render-target vocabulary end to end: a branded target declared once
@@ -5907,6 +6130,103 @@ the game dir"
             run_fail("let main = () => Ui.textInput(\"x\", 42.0)"),
             "Ui.textInput: the tagger must be a function of the result record, got a number"
         );
+        let _ = take_ui_handlers();
+    }
+
+    // Html/Attr (the `webview` hook): the Elm-style HTML tree. Attrs fold
+    // into the element (class pairs, onClick slots), children must be nodes,
+    // and the serialized HTML carries the handler slots as data attributes —
+    // the exact string both shells render.
+    #[test]
+    fn html_builders_fold_attrs_and_stamp_handler_slots() {
+        let _ = take_ui_handlers(); // isolate from other tests on this thread
+        let value = eval(
+            "type Msg = | Inc | Dec\n\
+             let main = () =>\n\
+             Html.div([Attr.class(\"hud\")], [\n\
+               Html.button([Attr.onClick(Dec)], [Html.text(\"-\")]),\n\
+               Html.button([Attr.onClick(Inc)], [Html.text(\"+\")]),\n\
+               Html.input([Attr.value(\"hi\"), Attr.onInput((s) => s)]),\n\
+             ])",
+        );
+        let node = html_node_value(&value).expect("main should return an Html node");
+        assert_eq!(
+            node.to_html(),
+            r#"<div class="hud"><button data-fn-click="0">-</button><button data-fn-click="1">+</button><input value="hi" data-fn-input="2"></div>"#
+        );
+        let handlers = take_ui_handlers();
+        assert_eq!(handlers.len(), 3);
+        match (&handlers[0], &handlers[1], &handlers[2]) {
+            (UiHandler::Msg(dec), UiHandler::Msg(inc), UiHandler::Tagger(_)) => {
+                assert_eq!(dec.to_string(), "Dec");
+                assert_eq!(inc.to_string(), "Inc");
+            }
+            _ => panic!("onClick registers msgs, onInput a tagger"),
+        }
+    }
+
+    #[test]
+    fn html_builders_reject_wrong_shapes_with_teaching_errors() {
+        let _ = take_ui_handlers();
+        assert_eq!(
+            run_fail("let main = () => Html.div([42.0], [])"),
+            "Html.div: expected an Attr, got a number"
+        );
+        let _ = take_ui_handlers();
+        assert_eq!(
+            run_fail("let main = () => Html.div([], [1.0])"),
+            "Html.div: expected an Html node, got a number"
+        );
+        let _ = take_ui_handlers();
+        assert_eq!(
+            run_fail("let main = () => Attr.onInput(42.0)"),
+            "Attr.onInput: the tagger must be a function of the result record, got a number"
+        );
+        let _ = take_ui_handlers();
+    }
+
+    // The wasm overlay is a REAL DOM, so script-capable tags and executable/
+    // spoofing attribute names are refused at construction (game logic has no
+    // DOM access by design — the webview must not become the escape hatch).
+    #[test]
+    fn html_rejects_injection_shaped_names() {
+        let _ = take_ui_handlers();
+        assert_eq!(
+            run_fail("let main = () => Html.element(\"script\", [], [])"),
+            "Html.element: `script` is not an allowed tag name \
+(letters/digits/dashes; script-capable tags are refused)"
+        );
+        let _ = take_ui_handlers();
+        assert_eq!(
+            run_fail("let main = () => Html.element(\"div onload=x\", [], [])"),
+            "Html.element: `div onload=x` is not an allowed tag name \
+(letters/digits/dashes; script-capable tags are refused)"
+        );
+        let _ = take_ui_handlers();
+        for bad in ["onerror", "href", "data-fn-click", "srcdoc"] {
+            assert_eq!(
+                run_fail(&format!("let main = () => Attr.attr(\"{bad}\", \"x\")")),
+                format!(
+                    "Attr.attr: `{bad}` is not an allowed attribute name \
+(letters/digits/dashes; on*/href/data-fn-* are refused)"
+                )
+            );
+            let _ = take_ui_handlers();
+        }
+        // Ordinary names still pass.
+        let value =
+            eval("let main = () => Html.element(\"section\", [Attr.attr(\"title\", \"hi\")], [])");
+        let node = html_node_value(&value).expect("section node");
+        assert_eq!(node.to_html(), r#"<section title="hi"></section>"#);
+        let _ = take_ui_handlers();
+    }
+
+    #[test]
+    fn html_style_emits_raw_css() {
+        let _ = take_ui_handlers();
+        let value = eval("let main = () => Html.style(\".a > .b { color: red; }\")");
+        let node = html_node_value(&value).expect("style node");
+        assert_eq!(node.to_html(), "<style>.a > .b { color: red; }</style>");
         let _ = take_ui_handlers();
     }
 

--- a/runtime/functor-runtime-common/src/lib.rs
+++ b/runtime/functor-runtime-common/src/lib.rs
@@ -89,6 +89,7 @@ pub mod texture;
 pub mod timetravel;
 pub mod trajectory;
 pub mod ui;
+pub mod webview;
 mod viewport;
 
 pub use camera::*;

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -229,6 +229,20 @@ pub trait GameProducer {
     /// text overlay drawn on top of the frame.
     fn ui(&self) -> crate::ui::View;
 
+    /// The game's HTML/CSS webview tree (`webview model`), or `None` when the
+    /// game defines no `webview`. The shell renders it above the frame: blitz
+    /// composited as a GL texture natively, a real DOM overlay on wasm.
+    /// Interactions come back through [`GameProducer::webview_event`].
+    fn webview(&self) -> Option<crate::webview::HtmlNode> {
+        None
+    }
+
+    /// Deliver an interaction on an interactive webview element (slot-addressed
+    /// like [`GameProducer::ui_event`], against the webview's own handler
+    /// table). The default drops it: the honest no-op for producers whose
+    /// games define no `webview`.
+    fn webview_event(&mut self, _event: crate::ui::UiEvent) {}
+
     /// A pretty-printed (Rust `Debug`) view of the live game model, for
     /// introspection (the debug server's `GET /state` `model` field). Opaque
     /// debug text — see the module doc; consumers must not parse it.

--- a/runtime/functor-runtime-common/src/webview.rs
+++ b/runtime/functor-runtime-common/src/webview.rs
@@ -1,0 +1,207 @@
+//! The game-authored HTML/CSS webview overlay — the serializable tree behind
+//! the `webview : model => Html.node` entry point.
+//!
+//! Games build this tree with the `Html.*` / `Attr.*` prelude (Elm-style:
+//! `Html.div([Attr.class("hud")], [...])`); the shells render it:
+//!
+//! - **native** — serialized to an HTML string ([`HtmlNode::to_html`]) and fed
+//!   to blitz (Stylo + Taffy + Parley), CPU-painted to an RGBA buffer, and
+//!   composited as a GL texture over the 3D frame.
+//! - **wasm** — the same HTML string becomes `innerHTML` of a DOM overlay div
+//!   above the canvas; the browser is the renderer.
+//!
+//! Interaction mirrors the egui `ui` path exactly (see [`crate::ui`]):
+//! `Attr.onClick(msg)` / `Attr.onInput(tagger)` register their handler in the
+//! per-frame table during `webview(model)` evaluation and stamp the node with
+//! the slot index, serialized as a `data-fn-click="N"` / `data-fn-input="N"`
+//! attribute. The shell reports interactions as `UiEvent { slot, kind }` via
+//! `GameProducer::webview_event`; the handler `Value` itself never crosses,
+//! so the tree stays serializable/inspectable.
+
+use serde::{Deserialize, Serialize};
+
+/// A node in the webview tree. Only names, strings and slot indexes — never
+/// closures or bytes — so it round-trips as JSON and survives time travel.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum HtmlNode {
+    /// A text node. Escaped on serialization (except inside `<style>`).
+    Text(String),
+    Element {
+        /// Lowercase tag name (`div`, `button`, `style`, ...). Author-controlled;
+        /// the webview renders only what the game emits, there is no untrusted input.
+        tag: String,
+        /// Plain string attributes in emission order (`class`, `style`, `id`, ...).
+        attrs: Vec<(String, String)>,
+        /// Handler-table slot for a click on this element (`Attr.onClick`).
+        click_slot: Option<u32>,
+        /// Handler-table slot for an input edit on this element (`Attr.onInput`).
+        input_slot: Option<u32>,
+        children: Vec<HtmlNode>,
+    },
+}
+
+/// Void elements: serialized without children or a closing tag.
+fn is_void(tag: &str) -> bool {
+    matches!(tag, "input" | "br" | "hr" | "img")
+}
+
+fn escape_text(s: &str, out: &mut String) {
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            _ => out.push(c),
+        }
+    }
+}
+
+fn escape_attr(s: &str, out: &mut String) {
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '"' => out.push_str("&quot;"),
+            '<' => out.push_str("&lt;"),
+            _ => out.push(c),
+        }
+    }
+}
+
+impl HtmlNode {
+    /// Serialize the tree to an HTML string — the shared wire format for both
+    /// shells. Handler slots become `data-fn-click` / `data-fn-input`
+    /// attributes so events can be routed back by walking the bubble chain.
+    pub fn to_html(&self) -> String {
+        let mut out = String::new();
+        self.write_html(&mut out, false);
+        out
+    }
+
+    fn write_html(&self, out: &mut String, raw_text: bool) {
+        match self {
+            HtmlNode::Text(text) => {
+                if raw_text {
+                    // Inside <style>: CSS needs `>` selectors etc. verbatim.
+                    out.push_str(text);
+                } else {
+                    escape_text(text, out);
+                }
+            }
+            HtmlNode::Element {
+                tag,
+                attrs,
+                click_slot,
+                input_slot,
+                children,
+            } => {
+                out.push('<');
+                out.push_str(tag);
+                for (name, value) in attrs {
+                    out.push(' ');
+                    out.push_str(name);
+                    out.push_str("=\"");
+                    escape_attr(value, out);
+                    out.push('"');
+                }
+                if let Some(slot) = click_slot {
+                    out.push_str(&format!(" data-fn-click=\"{slot}\""));
+                }
+                if let Some(slot) = input_slot {
+                    out.push_str(&format!(" data-fn-input=\"{slot}\""));
+                }
+                out.push('>');
+                if is_void(tag) {
+                    return;
+                }
+                let raw = tag == "style";
+                for child in children {
+                    child.write_html(out, raw);
+                }
+                out.push_str("</");
+                out.push_str(tag);
+                out.push('>');
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn el(tag: &str, attrs: &[(&str, &str)], children: Vec<HtmlNode>) -> HtmlNode {
+        HtmlNode::Element {
+            tag: tag.to_string(),
+            attrs: attrs
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            click_slot: None,
+            input_slot: None,
+            children,
+        }
+    }
+
+    #[test]
+    fn serializes_nested_elements_with_attrs() {
+        let tree = el(
+            "div",
+            &[("class", "hud")],
+            vec![el("span", &[], vec![HtmlNode::Text("Score: 7".into())])],
+        );
+        assert_eq!(
+            tree.to_html(),
+            r#"<div class="hud"><span>Score: 7</span></div>"#
+        );
+    }
+
+    #[test]
+    fn escapes_text_and_attrs() {
+        let tree = el(
+            "div",
+            &[("title", "a\"b<c")],
+            vec![HtmlNode::Text("1 < 2 & 3".into())],
+        );
+        assert_eq!(
+            tree.to_html(),
+            r#"<div title="a&quot;b&lt;c">1 &lt; 2 &amp; 3</div>"#
+        );
+    }
+
+    #[test]
+    fn style_text_is_raw() {
+        let tree = el(
+            "style",
+            &[],
+            vec![HtmlNode::Text(".a > .b { color: red; }".into())],
+        );
+        assert_eq!(tree.to_html(), "<style>.a > .b { color: red; }</style>");
+    }
+
+    #[test]
+    fn handler_slots_become_data_attributes() {
+        let tree = HtmlNode::Element {
+            tag: "button".into(),
+            attrs: vec![("class".into(), "go".into())],
+            click_slot: Some(3),
+            input_slot: None,
+            children: vec![HtmlNode::Text("Go".into())],
+        };
+        assert_eq!(
+            tree.to_html(),
+            r#"<button class="go" data-fn-click="3">Go</button>"#
+        );
+    }
+
+    #[test]
+    fn void_elements_have_no_closing_tag() {
+        let tree = HtmlNode::Element {
+            tag: "input".into(),
+            attrs: vec![("value".into(), "hi".into())],
+            click_slot: None,
+            input_slot: Some(5),
+            children: vec![],
+        };
+        assert_eq!(tree.to_html(), r#"<input value="hi" data-fn-input="5">"#);
+    }
+}

--- a/runtime/functor-runtime-desktop/Cargo.toml
+++ b/runtime/functor-runtime-desktop/Cargo.toml
@@ -51,6 +51,17 @@ rodio = { version = "0.19", default-features = false, features = ["symphonia-wav
 symphonia = { version = "0.5", default-features = false, features = ["ogg"] }
 tokio-tungstenite = "0.21"
 futures-util = "0.3"
+# Webview overlay: game-authored HTML/CSS UI rendered headlessly by blitz
+# (Stylo + Taffy + Parley) and CPU-painted into an RGBA buffer we upload as a
+# GL texture. Native-only — the wasm runtime shows the same tree as a real DOM
+# overlay instead. Pre-1.0: pinned exactly, expect churn on upgrades.
+blitz-dom = "=0.3.0-beta.1"
+blitz-html = "=0.3.0-beta.1"
+blitz-paint = "=0.3.0-beta.1"
+blitz-traits = "=0.3.0-beta.1"
+anyrender = "=0.11.1"
+anyrender_vello_cpu = "=0.14.0"
+markup5ever = "0.39"
 
 [dev-dependencies]
 functor_runtime_common = { path = "./../functor-runtime-common" }

--- a/runtime/functor-runtime-desktop/Cargo.toml
+++ b/runtime/functor-runtime-desktop/Cargo.toml
@@ -54,7 +54,10 @@ futures-util = "0.3"
 # Webview overlay: game-authored HTML/CSS UI rendered headlessly by blitz
 # (Stylo + Taffy + Parley) and CPU-painted into an RGBA buffer we upload as a
 # GL texture. Native-only — the wasm runtime shows the same tree as a real DOM
-# overlay instead. Pre-1.0: pinned exactly, expect churn on upgrades.
+# overlay instead. Pre-1.0: pinned exactly, expect churn on upgrades. The font
+# stack (parley/fontique) needs fontconfig dev headers on Linux
+# (libfontconfig-dev) — installed in every CI job that builds this crate (the
+# cpal/ALSA rule).
 blitz-dom = "=0.3.0-beta.1"
 blitz-html = "=0.3.0-beta.1"
 blitz-paint = "=0.3.0-beta.1"

--- a/runtime/functor-runtime-desktop/examples/webview_bench.rs
+++ b/runtime/functor-runtime-desktop/examples/webview_bench.rs
@@ -1,0 +1,138 @@
+//! `webview_bench` — a headless benchmark of the native webview overlay's
+//! CPU costs: blitz parse/resolve (per model-driven re-render) and CPU paint
+//! (per repaint: hover transitions, presses, content changes).
+//!
+//! The `frame_bench` philosophy (see functor-runtime-common/examples): no GL,
+//! no window — the exact blitz calls `webview_overlay` makes, timed
+//! back-to-back; min + median over a FIXED sample count so both sides of an
+//! A/B draw from the same distribution. Report-only, no CI gate.
+//!
+//! The workload is a hermetic copy of `examples/webview`'s counter card
+//! (deliberately NOT the live example file — it can change under the bench),
+//! serialized exactly as `HtmlNode::to_html` emits it (data-fn-* slots
+//! included).
+//!
+//! Reference numbers (M-series Mac, release): parse+resolve ~1ms with the
+//! shared FontContext (~30ms with a fresh one — the regression this bench
+//! exists to catch), paint ~1ms at 800x600 and ~3ms at a 2048x1536 retina
+//! framebuffer. Debug paint is ~200x slower (~0.6s at retina size), which is
+//! why interactive native testing uses release builds.
+//!
+//! ```sh
+//! cargo run -q --release -p functor-runtime-desktop --example webview_bench
+//! ```
+
+use anyrender::ImageRenderer;
+use anyrender_vello_cpu::VelloCpuImageRenderer;
+use blitz_dom::{BaseDocument, DocumentConfig, FontContext};
+use blitz_html::HtmlDocument;
+use blitz_traits::shell::{ColorScheme, Viewport};
+use std::time::Instant;
+
+/// The counter card from examples/webview, as `HtmlNode::to_html` serializes
+/// it (handler slots as data attributes).
+const HTML: &str = r#"<div><style>
+  .hud { display: flex; flex-direction: column; gap: 12px; width: 300px;
+         margin: 24px; padding: 20px;
+         background: linear-gradient(135deg, rgba(24, 26, 44, 0.92), rgba(52, 24, 64, 0.92));
+         border: 2px solid #8be9fd; border-radius: 14px;
+         font-family: sans-serif; color: #f8f8f2; }
+  .hud h1 { margin: 0; font-size: 22px; color: #8be9fd; }
+  .count { font-size: 40px; font-weight: bold; text-align: center; }
+  .row { display: flex; gap: 10px; justify-content: center; }
+  button { padding: 8px 18px; font-size: 18px; font-weight: bold;
+           background: #50fa7b; color: #1e1e3c; border: none; border-radius: 8px; }
+  button:hover { background: #f1fa8c; }
+  button.ghost { background: transparent; color: #8be9fd; border: 1px solid #8be9fd; }
+</style><div class="hud"><h1>Functor webview</h1><div class="count">7</div><div class="row"><button data-fn-click="0">-</button><button data-fn-click="1">+</button><button class="ghost" data-fn-click="2">Reset</button></div></div></div>"#;
+
+/// (framebuffer size, hidpi scale) — a small window, a common 1x window, and
+/// a retina-sized framebuffer (the case that made debug builds unusable).
+const SIZES: &[(u32, u32, f32)] = &[
+    (800, 600, 1.0),
+    (1280, 720, 1.0),
+    (2048, 1536, 2.0),
+];
+
+const PARSE_SAMPLES: usize = 100;
+const PAINT_SAMPLES: usize = 40;
+const HIT_SAMPLES: usize = 2000;
+
+fn build_doc(w: u32, h: u32, scale: f32, font_ctx: &FontContext) -> BaseDocument {
+    let mut doc = HtmlDocument::from_html(
+        HTML,
+        DocumentConfig {
+            viewport: Some(Viewport::new(w, h, scale, ColorScheme::Dark)),
+            font_ctx: Some(font_ctx.clone()),
+            ..Default::default()
+        },
+    )
+    .into_inner();
+    doc.resolve(0.0);
+    doc
+}
+
+/// min + median of `samples` timed runs of `f`, in microseconds.
+fn time_us(samples: usize, mut f: impl FnMut()) -> (f64, f64) {
+    let mut us: Vec<f64> = (0..samples)
+        .map(|_| {
+            let t = Instant::now();
+            f();
+            t.elapsed().as_secs_f64() * 1e6
+        })
+        .collect();
+    us.sort_by(|a, b| a.total_cmp(b));
+    (us[0], us[samples / 2])
+}
+
+fn main() {
+    #[cfg(debug_assertions)]
+    eprintln!(
+        "warning: webview_bench in a DEBUG build — paint is ~200x release; \
+numbers are not comparable. Re-run with --release."
+    );
+
+    let font_ctx = FontContext::default();
+    // Warm the shared font context once (first parse pays font enumeration,
+    // like the overlay's first frame).
+    let _ = build_doc(800, 600, 1.0, &font_ctx);
+
+    println!(
+        "{:<18} {:>22} {:>22}",
+        "scenario", "min", "median"
+    );
+    for &(w, h, scale) in SIZES {
+        let label = format!("{w}x{h}@{scale}");
+
+        // Per re-render cost: parse + resolve with the SHARED font context
+        // (the shipping config — a fresh context re-scans system fonts).
+        let (min, med) = time_us(PARSE_SAMPLES, || {
+            let _ = build_doc(w, h, scale, &font_ctx);
+        });
+        println!("{label:<18} {:>14.0} us parse {:>14.0} us", min, med);
+
+        // Per repaint cost: rasterize the resolved doc (hover transitions,
+        // presses, and content changes each pay one of these).
+        let mut doc = build_doc(w, h, scale, &font_ctx);
+        let mut renderer = VelloCpuImageRenderer::new(w, h);
+        let mut buf = Vec::new();
+        let (min, med) = time_us(PAINT_SAMPLES, || {
+            renderer.render_to_vec(
+                |scene| {
+                    blitz_paint::paint_scene(scene, &mut doc, scale as f64, w, h, 0, 0)
+                },
+                &mut buf,
+            );
+        });
+        println!("{label:<18} {:>14.0} us paint {:>14.0} us", min, med);
+    }
+
+    // Per-press hit-test cost (the run loop's synchronous click arbitration).
+    let doc = build_doc(1280, 720, 1.0, &font_ctx);
+    let (min, med) = time_us(HIT_SAMPLES, || {
+        // Over the "+" button and over empty space.
+        std::hint::black_box(doc.hit(180.0, 180.0));
+        std::hint::black_box(doc.hit(900.0, 500.0));
+    });
+    println!("{:<18} {:>14.2} us hit   {:>14.2} us", "hit-test x2", min, med);
+}

--- a/runtime/functor-runtime-desktop/src/debug_server.rs
+++ b/runtime/functor-runtime-desktop/src/debug_server.rs
@@ -76,6 +76,12 @@ pub enum InputCommand {
         slot: u32,
         kind: functor_runtime_common::ui::UiEventKind,
     },
+    /// The webview's flavor of `ui_event`, addressed against the webview
+    /// handler table: `{"type":"webview_event","slot":0,"kind":"Clicked"}`.
+    WebviewEvent {
+        slot: u32,
+        kind: functor_runtime_common::ui::UiEventKind,
+    },
 }
 
 /// A clock command via `POST /time`: `{"type":"set","tts":2.0}` pins the frame
@@ -438,7 +444,7 @@ pub fn spawn(bind: &str, port: u16) -> Receiver<DebugRequest> {
                             "GET /state": "runtime state JSON: frame, tts, viewport, input (held_keys + mouse), model (Debug text)",
                             "GET /scene": "current frame as JSON: camera + scene + lights",
                             "GET /trace": "paused-inspector trace: last real frame's entry-point invocations (bindings + result) replayed while paused; {paused:false, invocations:[]} while playing",
-                            "POST /input": "inject input — {\"type\":\"key\",\"key\":\"w\",\"down\":true} | {\"type\":\"mouse_move\",\"x\":0,\"y\":0} | {\"type\":\"mouse_wheel\",\"delta\":1} | {\"type\":\"ui_event\",\"slot\":0,\"kind\":\"Clicked\"}",
+                            "POST /input": "inject input — {\"type\":\"key\",\"key\":\"w\",\"down\":true} | {\"type\":\"mouse_move\",\"x\":0,\"y\":0} | {\"type\":\"mouse_wheel\",\"delta\":1} | {\"type\":\"ui_event\",\"slot\":0,\"kind\":\"Clicked\"} | {\"type\":\"webview_event\",\"slot\":0,\"kind\":\"Clicked\"}",
                             "POST /time": "clock control — {\"type\":\"set\",\"tts\":2.0} (pause) | {\"type\":\"advance\",\"dts\":0.016} (step one frame) | {\"type\":\"resume\"}",
                             "POST /reload-source": "swap game logic from the request body (raw .fun source), model preserved — 400 with the load error on a broken push",
                             "POST /rewind": "coupled scene rewind — {\"frame\":42} restores model + physics to that rendered frame (pin the clock first); 400 if unrecorded/pruned"

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -33,9 +33,9 @@ use functor_lang::project::SourceMap;
 use functor_lang::{Session, Value};
 use functor_runtime_common::events::{self, RuntimeEvent};
 use functor_runtime_common::functor_lang_prelude::{
-    audio_scene_of, clear_audio_completions, clear_http_taggers, frame_value, take_ui_handlers,
-    view_value, EffectLog, EffectRunner, EffectTree, FunctorHost, NetEventKind, RealEffects,
-    UiHandler,
+    audio_scene_of, clear_audio_completions, clear_http_taggers, frame_value, html_node_value,
+    take_ui_handlers, view_value, EffectLog, EffectRunner, EffectTree, FunctorHost, NetEventKind,
+    RealEffects, UiHandler,
 };
 use functor_runtime_common::functor_lang_producer::{
     journal_arm, journal_push, journal_swap, FrameCtx, JournalEntry, Provenance, Reporter,
@@ -45,6 +45,7 @@ use functor_runtime_common::inspector::{build_trace_doc, inspector_sources, Insp
 use functor_runtime_common::physics;
 use functor_runtime_common::timetravel::SceneRecorder;
 use functor_runtime_common::ui::View;
+use functor_runtime_common::webview::HtmlNode;
 use functor_runtime_common::{Frame, FrameTime};
 use std::path::PathBuf;
 use std::time::SystemTime;
@@ -101,6 +102,17 @@ pub struct FunctorLangGame {
     /// with `last_view` (updated only on a successful evaluation) and cleared
     /// on reload — its values may close over the old session.
     ui_handlers: Vec<UiHandler>,
+    /// The game defines the optional `webview` entry point
+    /// (`webview(model) -> Html.node`, the HTML/CSS overlay hook).
+    has_webview: bool,
+    /// The last successfully built webview tree, cached like `last_view`.
+    /// `None` = no webview (hook absent, or its first evaluation hasn't
+    /// succeeded yet).
+    last_webview: Option<HtmlNode>,
+    /// The handler table for `last_webview` — the webview's own slot space,
+    /// separate from `ui_handlers` (each hook's evaluation drains the shared
+    /// per-eval table into its own copy). Same lockstep/reload rules.
+    webview_handlers: Vec<UiHandler>,
     /// The last serialized soundscape (`soundScape model` → JSON), cached
     /// because `audio_scene_json` is a `&self` accessor — evaluated beside
     /// `draw` each frame so errors can `&mut`-dedupe. A bad frame keeps the
@@ -210,6 +222,7 @@ struct Loaded {
     has_physics: bool,
     has_soundscape: bool,
     has_ui: bool,
+    has_webview: bool,
 }
 
 /// Load, check, and contract-validate a game project (B8: the entry plus
@@ -330,6 +343,12 @@ return them beside the model as `(model, effect)`"
     if has_ui {
         require_function(path, &session, "ui", 1)?;
     }
+    // Optional webview: `webview(model)` returns an Html node (Html.div /
+    // Html.text / …), rendered as an HTML/CSS overlay above the frame.
+    let has_webview = session.global("webview").is_some();
+    if has_webview {
+        require_function(path, &session, "webview", 1)?;
+    }
     Ok(Loaded {
         sources,
         module,
@@ -342,6 +361,7 @@ return them beside the model as `(model, effect)`"
         has_physics,
         has_soundscape,
         has_ui,
+        has_webview,
     })
 }
 
@@ -410,6 +430,9 @@ impl FunctorLangGame {
             has_ui: loaded.has_ui,
             last_view: View::Empty,
             ui_handlers: Vec::new(),
+            has_webview: loaded.has_webview,
+            last_webview: None,
+            webview_handlers: Vec::new(),
             last_soundscape_json: empty_soundscape_json(),
             effect_runner: RealEffects::new(),
             effect_log: EffectLog::new(),
@@ -521,6 +544,11 @@ impl FunctorLangGame {
             // Deleting the `ui` hook drops the HUD (the physics-world rule).
             self.last_view = View::Empty;
         }
+        self.has_webview = loaded.has_webview;
+        if !self.has_webview {
+            // Deleting the `webview` hook drops the overlay (the `ui` rule).
+            self.last_webview = None;
+        }
         self.reporter.reset();
         // A deferred query or in-flight HTTP request holds a tagger — a closure
         // into the OLD session; drop them rather than let them dangle. A late
@@ -536,6 +564,7 @@ impl FunctorLangGame {
         // the next render's `ui(model)` rebuilds it against the new one. A
         // click landing in the gap resolves an unknown slot and is dropped.
         self.ui_handlers.clear();
+        self.webview_handlers.clear();
         // Plain-data snapshots remain seekable under the new program. A model
         // history containing callable or opaque host values instead starts a new
         // generation anchored at this rebound live frame.
@@ -888,6 +917,19 @@ impl Game for FunctorLangGame {
             .push(functor_runtime_common::RecordedInput::UiEvent(event));
     }
 
+    fn webview_event(&mut self, event: functor_runtime_common::ui::UiEvent) {
+        // The `ui_event` shape, against the webview's own handler table.
+        if !self.has_webview {
+            return;
+        }
+        let handlers = std::mem::take(&mut self.webview_handlers);
+        self.ctx().deliver_ui_event(&handlers, &event);
+        self.webview_handlers = handlers;
+        // TODO(webview): record for replay once webview events get their own
+        // RecordedInput variant — a UiEvent entry would replay against the
+        // wrong (ui) handler table.
+    }
+
     fn render(&mut self, frame_time: FrameTime) -> Frame {
         let started = Instant::now();
         // While scrubbing, draw at the scrubbed frame's recorded `tts` so
@@ -939,6 +981,32 @@ impl Game for FunctorLangGame {
                 }
             }
         }
+        // The optional webview, evaluated beside `draw` like `ui` — same
+        // caching, same handler-adoption lockstep, its own handler table.
+        if self.has_webview {
+            match self
+                .session
+                .call("webview", vec![self.model.clone()], &mut FunctorHost)
+            {
+                Ok(value) => match html_node_value(&value) {
+                    Some(node) => {
+                        self.last_webview = Some(node.clone());
+                        self.webview_handlers = take_ui_handlers();
+                    }
+                    None => {
+                        let _ = take_ui_handlers();
+                        self.reporter.report_once(format!(
+                            "[functor-lang] webview must return an Html node (Html.div / Html.text / …), got {}",
+                            value.kind_name()
+                        ))
+                    }
+                },
+                Err(err) => {
+                    let _ = take_ui_handlers();
+                    self.reporter.frame_error("webview", &err)
+                }
+            }
+        }
         // The optional soundscape, evaluated beside `draw` (same settled model)
         // and cached — `audio_scene_json` is a `&self` accessor, and errors
         // need `&mut` dedupe. A bad frame keeps the last good scene (the
@@ -979,6 +1047,10 @@ AudioScene.empty), got {}",
 
     fn ui(&self) -> View {
         self.last_view.clone()
+    }
+
+    fn webview(&self) -> Option<HtmlNode> {
+        self.last_webview.clone()
     }
 
     fn state_debug(&self) -> String {

--- a/runtime/functor-runtime-desktop/src/lib.rs
+++ b/runtime/functor-runtime-desktop/src/lib.rs
@@ -30,6 +30,11 @@ mod net_dispatch;
 mod replay_game;
 #[cfg(not(target_arch = "wasm32"))]
 mod run;
+// The blitz-backed HTML/CSS webview overlay (native-only: the wasm runtime
+// renders the same tree as a real DOM overlay instead). `pub` for the
+// headless render test in tests/.
+#[cfg(not(target_arch = "wasm32"))]
+pub mod webview_overlay;
 #[cfg(not(target_arch = "wasm32"))]
 mod ws_host;
 #[cfg(not(target_arch = "wasm32"))]

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -614,6 +614,10 @@ fn service_debug_request(
                     game.ui_event(functor_runtime_common::ui::UiEvent { slot, kind });
                     Ok(())
                 }
+                debug_server::InputCommand::WebviewEvent { slot, kind } => {
+                    game.webview_event(functor_runtime_common::ui::UiEvent { slot, kind });
+                    Ok(())
+                }
             };
             // Input injected while PAUSED journals entry-point calls no `tick`
             // will sweep — fold them into the inspector's last-frame journal so
@@ -866,6 +870,10 @@ pub fn run(args: Args) {
         // rest of the runtime keeps using `&gl`, which derefs through the Arc.
         let gl = std::sync::Arc::new(gl);
         let mut text_overlay = functor_runtime_common::ui::TextOverlay::new(gl.clone());
+        // The game's HTML/CSS webview overlay (`webview model`), blitz-rendered
+        // to a texture and composited between the game UI and the scrubber.
+        let mut webview_overlay =
+            crate::webview_overlay::WebviewOverlay::new(gl.clone(), shader_version);
         // The shell-owned time-travel scrubber (docs/time-travel.md T3), drawn
         // over the frame; interactive when the cursor is released (Escape).
         let mut scrubber = functor_runtime_common::ui::Scrubber::new(gl.clone());
@@ -884,6 +892,9 @@ pub fn run(args: Args) {
         // click on a `Ui.button` must drive the widget, not recapture the
         // cursor for free-look (the scrubber rule, docs/ui-interaction.md).
         let mut ui_wants_pointer = false;
+        // Same latch for the webview overlay: the pointer is over an element
+        // with an `Attr.onClick`/`Attr.onInput` handler.
+        let mut webview_wants_pointer = false;
         // Whether it wanted the KEYBOARD last frame (a `Ui.textInput` is
         // focused): keys then route to the overlay instead of the game's
         // `input` hook, and Escape defocuses the field instead of releasing
@@ -1163,10 +1174,21 @@ Escape again to quit"
                     {
                         match action {
                             Action::Press => {
-                                // Either overlay wanting the pointer — the
-                                // scrubber or the game UI's widgets — means
-                                // the click is for it, not a recapture.
-                                if scrubber_wants_pointer || ui_wants_pointer {
+                                // Any overlay wanting the pointer — the
+                                // scrubber, the game UI's widgets, or the
+                                // webview — means the click is for it, not a
+                                // recapture. The webview is hit-tested LIVE
+                                // (mouse_pos is window points == CSS px): the
+                                // one-frame latch reads the OLD tree after a
+                                // model-driven re-render, and a stationary
+                                // repeat-click would recapture the cursor.
+                                if scrubber_wants_pointer
+                                    || ui_wants_pointer
+                                    || webview_overlay.hit_interactive_css(
+                                        mouse_pos.0 as f32,
+                                        mouse_pos.1 as f32,
+                                    )
+                                {
                                     mouse_primary_down = true;
                                     mouse_primary_clicked = true;
                                 } else {
@@ -1834,12 +1856,25 @@ Escape again to quit"
             // don't let egui process the interaction at all — a paused
             // button must not visually depress, and a paused slider drag
             // must not fight its own reconciliation. [xreview]
-            let ui_pointer = if (scrubber_visible && scrubber_wants_pointer) || ignore_user_input
-            {
-                functor_runtime_common::ui::PointerState {
-                    pos: None,
-                    primary_down: pointer.primary_down,
-                }
+            let overlay_suppressed =
+                (scrubber_visible && scrubber_wants_pointer) || ignore_user_input;
+            let suppressed_pointer = functor_runtime_common::ui::PointerState {
+                pos: None,
+                primary_down: pointer.primary_down,
+            };
+            // The webview draws ABOVE the game UI, so while the pointer is
+            // over one of its interactive elements the egui pass must not
+            // also hit-test the click (the scrubber-over-ui rule) — one click
+            // must never fire a `Ui.button` AND a webview button. The webview
+            // itself is gated only by the scrubber/pin (never by its own
+            // latch, which would oscillate). [xreview]
+            let webview_pointer = if overlay_suppressed {
+                suppressed_pointer
+            } else {
+                pointer
+            };
+            let ui_pointer = if overlay_suppressed || webview_wants_pointer {
+                suppressed_pointer
             } else {
                 pointer
             };
@@ -1857,6 +1892,28 @@ Escape again to quit"
             if !ignore_user_input {
                 for event in ui_out.events {
                     game.ui_event(event);
+                }
+            }
+
+            // The HTML/CSS webview overlay (`webview model`), blitz-rendered
+            // over the game UI and under the scrubber. Same pointer
+            // arbitration as the game UI (`ui_pointer`): suppressed while the
+            // scrubber wants the pointer or the clock is pinned.
+            // TODO(webview): `webview()` clones the tree and `to_html`
+            // reserializes every frame — cache the serialized string in the
+            // producer once the protocol shape settles (perf follow-up).
+            let webview_html = game.webview().map(|node| node.to_html());
+            let webview_out = webview_overlay.frame(
+                fb_width as u32,
+                fb_height as u32,
+                dpi_scale,
+                webview_html.as_deref(),
+                webview_pointer,
+            );
+            webview_wants_pointer = webview_out.wants_pointer;
+            if !ignore_user_input {
+                for event in webview_out.events {
+                    game.webview_event(event);
                 }
             }
 

--- a/runtime/functor-runtime-desktop/src/webview_overlay.rs
+++ b/runtime/functor-runtime-desktop/src/webview_overlay.rs
@@ -1,0 +1,500 @@
+//! The native webview overlay: renders the game's `webview(model)` HTML/CSS
+//! tree over the 3D frame, and routes pointer input back as slot-stamped
+//! [`UiEvent`]s (docs/ui-interaction.md, the webview flavor).
+//!
+//! Pipeline (see `~/notes` html-css-ui research → CLAUDE.md "webview"):
+//! the producer's [`HtmlNode`] tree is serialized to an HTML string, parsed by
+//! **blitz** (`blitz-dom`: Stylo styles + Taffy layout + Parley text), painted
+//! headlessly on the CPU (`anyrender_vello_cpu`) into a premultiplied-RGBA
+//! buffer, uploaded as a GL texture, and composited as a fullscreen quad with
+//! `(ONE, ONE_MINUS_SRC_ALPHA)` blending. No wgpu anywhere — the CPU painter
+//! keeps the whole path on the existing glow stack.
+//!
+//! Retained, not immediate: the DOM is rebuilt only when the serialized HTML
+//! actually changes, and re-rasterized only when something visible could have
+//! changed (new HTML, hover transitions, clicks, resize). An idle webview
+//! costs one string compare per frame.
+//!
+//! Interaction mirrors the egui overlay: pointer events feed blitz's
+//! `EventDriver`, which synthesizes DOM semantics (click = press+release on
+//! the same element, hover chains for `:hover` CSS). A DOM `click`/`input`
+//! event walks the bubble chain for the nearest `data-fn-click` /
+//! `data-fn-input` attribute — the handler slot the `Attr.onClick` /
+//! `Attr.onInput` builder stamped — and comes back as a [`UiEvent`] the shell
+//! folds through `GameProducer::webview_event`.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use anyrender::ImageRenderer;
+use anyrender_vello_cpu::VelloCpuImageRenderer;
+use blitz_dom::{BaseDocument, Document, DocumentConfig, EventDriver, EventHandler, FontContext};
+use blitz_html::HtmlDocument;
+use blitz_traits::events::{
+    BlitzPointerEvent, BlitzPointerId, DomEvent, DomEventData, EventState, MouseEventButton,
+    MouseEventButtons, PointerCoords, UiEvent as BlitzUiEvent,
+};
+use blitz_traits::shell::{ColorScheme, Viewport};
+use functor_runtime_common::ui::{PointerState, UiEvent, UiEventKind};
+use glow::HasContext;
+use markup5ever::LocalName;
+
+/// What one webview frame produced: interactions to fold through `update`,
+/// and whether the pointer is over an interactive element (the shell's
+/// click-arbitration latch, like `ui_wants_pointer`).
+pub struct WebviewOutput {
+    pub events: Vec<UiEvent>,
+    pub wants_pointer: bool,
+}
+
+impl WebviewOutput {
+    fn empty() -> Self {
+        WebviewOutput {
+            events: Vec::new(),
+            wants_pointer: false,
+        }
+    }
+}
+
+/// Collects DOM events out of blitz's event driver, resolving the bubble
+/// chain to handler slots (`data-fn-click` / `data-fn-input`).
+struct EventCollector {
+    events: Vec<UiEvent>,
+}
+
+impl EventHandler for &mut EventCollector {
+    fn handle_event(
+        &mut self,
+        chain: &[usize],
+        event: &mut DomEvent,
+        doc: &mut dyn Document,
+        _state: &mut EventState,
+    ) {
+        let doc = doc.inner();
+        let slot_on_chain = |attr: &str| {
+            chain.iter().find_map(|&node_id| {
+                doc.get_node(node_id)?
+                    .attr(LocalName::from(attr))?
+                    .parse::<u32>()
+                    .ok()
+            })
+        };
+        match &event.data {
+            DomEventData::Click(_) => {
+                if let Some(slot) = slot_on_chain("data-fn-click") {
+                    self.events.push(UiEvent {
+                        slot,
+                        kind: UiEventKind::Clicked,
+                    });
+                }
+            }
+            DomEventData::Input(input) => {
+                if let Some(slot) = slot_on_chain("data-fn-input") {
+                    self.events.push(UiEvent {
+                        slot,
+                        kind: UiEventKind::TextChanged(input.value.clone()),
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+pub struct WebviewOverlay {
+    gl: Arc<glow::Context>,
+    program: glow::Program,
+    vao: glow::VertexArray,
+    texture: glow::Texture,
+    /// The live DOM, rebuilt when `html` changes. `None` until the game's
+    /// first `webview` tree arrives.
+    doc: Option<BaseDocument>,
+    /// The serialized HTML the current `doc` was parsed from — the
+    /// change-detection key (a tree diff can replace this later).
+    html: String,
+    /// CPU rasterizer + its output buffer, recreated on resize.
+    renderer: Option<VelloCpuImageRenderer>,
+    buf: Vec<u8>,
+    tex_w: u32,
+    tex_h: u32,
+    /// Repaint latch: HTML changed, hover moved, a click landed, resized.
+    dirty: bool,
+    /// The animation clock blitz `resolve(t)` ticks on — ours, per the
+    /// headless embedding (the shell owns the loop).
+    start: Instant,
+    /// One font context shared across reparses. A fresh context per document
+    /// re-enumerates system fonts — ~55ms per model-driven re-render (~30ms
+    /// release), measured; sharing drops the reparse to single-digit ms.
+    font_ctx: FontContext,
+    /// Pointer state last frame, to synthesize press/release edges.
+    pointer_was_down: bool,
+    hover_pos: Option<(f32, f32)>,
+}
+
+const VERTEX_SRC: &str = r#"
+    out vec2 vUv;
+    void main() {
+        // A fullscreen strip from gl_VertexID — no VBO. v flipped: the CPU
+        // painter's buffer is top-down, GL's texture space bottom-up.
+        vec2 pos = vec2(float(gl_VertexID & 1), float(gl_VertexID >> 1));
+        vUv = vec2(pos.x, 1.0 - pos.y);
+        gl_Position = vec4(pos * 2.0 - 1.0, 0.0, 1.0);
+    }
+"#;
+
+const FRAGMENT_SRC: &str = r#"
+    in vec2 vUv;
+    out vec4 fragColor;
+    uniform sampler2D uTex;
+    void main() {
+        // Premultiplied alpha straight through; blend state does the rest.
+        fragColor = texture(uTex, vUv);
+    }
+"#;
+
+impl WebviewOverlay {
+    pub fn new(gl: Arc<glow::Context>, shader_version: &str) -> Self {
+        let (program, vao, texture) = unsafe {
+            let program = gl.create_program().expect("webview: create_program");
+            let compile = |kind, src: &str| {
+                let shader = gl.create_shader(kind).expect("webview: create_shader");
+                gl.shader_source(shader, &format!("{shader_version}\n{src}"));
+                gl.compile_shader(shader);
+                if !gl.get_shader_compile_status(shader) {
+                    panic!("webview shader: {}", gl.get_shader_info_log(shader));
+                }
+                gl.attach_shader(program, shader);
+                shader
+            };
+            let vs = compile(glow::VERTEX_SHADER, VERTEX_SRC);
+            let fs = compile(glow::FRAGMENT_SHADER, FRAGMENT_SRC);
+            gl.link_program(program);
+            if !gl.get_program_link_status(program) {
+                panic!("webview link: {}", gl.get_program_info_log(program));
+            }
+            gl.detach_shader(program, vs);
+            gl.detach_shader(program, fs);
+            gl.delete_shader(vs);
+            gl.delete_shader(fs);
+            let vao = gl.create_vertex_array().expect("webview: create_vao");
+            let texture = gl.create_texture().expect("webview: create_texture");
+            gl.bind_texture(glow::TEXTURE_2D, Some(texture));
+            gl.tex_parameter_i32(
+                glow::TEXTURE_2D,
+                glow::TEXTURE_MIN_FILTER,
+                glow::LINEAR as i32,
+            );
+            gl.tex_parameter_i32(
+                glow::TEXTURE_2D,
+                glow::TEXTURE_MAG_FILTER,
+                glow::LINEAR as i32,
+            );
+            gl.bind_texture(glow::TEXTURE_2D, None);
+            (program, vao, texture)
+        };
+        WebviewOverlay {
+            gl,
+            program,
+            vao,
+            texture,
+            doc: None,
+            html: String::new(),
+            renderer: None,
+            buf: Vec::new(),
+            tex_w: 0,
+            tex_h: 0,
+            dirty: false,
+            start: Instant::now(),
+            font_ctx: FontContext::default(),
+            pointer_was_down: false,
+            hover_pos: None,
+        }
+    }
+
+    /// Synchronous hit-test in CSS px (== window points): is the pointer over
+    /// an interactive element RIGHT NOW? The shell's press arbitration uses
+    /// this instead of the one-frame-stale `wants_pointer` latch — after a
+    /// model-driven re-render, a stationary click's latch still reads the OLD
+    /// tree, and the press would recapture the cursor instead of clicking.
+    pub fn hit_interactive_css(&self, x: f32, y: f32) -> bool {
+        let Some(doc) = &self.doc else {
+            return false;
+        };
+        doc.hit(x, y)
+            .map(|hit| chain_has_handler(doc, hit.node_id))
+            .unwrap_or(false)
+    }
+
+    /// Run one webview frame: reconcile the DOM against `html`, feed pointer
+    /// input, repaint if anything changed, and draw the overlay quad.
+    /// `pointer.pos` is in framebuffer pixels (the egui overlays' space);
+    /// blitz works in CSS px, so it is divided by `dpi_scale` here.
+    pub fn frame(
+        &mut self,
+        fb_width: u32,
+        fb_height: u32,
+        dpi_scale: f32,
+        html: Option<&str>,
+        pointer: PointerState,
+    ) -> WebviewOutput {
+        let Some(html) = html else {
+            // Hook absent (or nothing built yet): drop any retained DOM so a
+            // deleted `webview` clears the overlay (the `ui` reload rule).
+            self.doc = None;
+            self.html.clear();
+            self.pointer_was_down = false;
+            return WebviewOutput::empty();
+        };
+        if fb_width == 0 || fb_height == 0 {
+            return WebviewOutput::empty();
+        }
+
+        let scale = if dpi_scale > 0.0 { dpi_scale } else { 1.0 };
+        let viewport_changed = self.tex_w != fb_width || self.tex_h != fb_height;
+        let clock = self.start.elapsed().as_secs_f64();
+
+        // ── Reconcile the DOM (prototype: full reparse on change) ─────────
+        if html != self.html || self.doc.is_none() {
+            self.html.clear();
+            self.html.push_str(html);
+            let viewport = Viewport::new(fb_width, fb_height, scale, ColorScheme::Dark);
+            let mut doc = HtmlDocument::from_html(
+                html,
+                DocumentConfig {
+                    viewport: Some(viewport),
+                    // Shared across reparses — a fresh context re-enumerates
+                    // system fonts (tens of ms) on every re-render.
+                    font_ctx: Some(self.font_ctx.clone()),
+                    ..Default::default()
+                },
+            )
+            .into_inner();
+            // A fresh document has NO layout until resolved — the hover
+            // re-establishing move below would hit-test nothing, leaving
+            // `wants_pointer` false until the mouse physically moves, and the
+            // next stationary click would recapture the cursor instead of
+            // pressing the button (the repeated-click repro). Resolve now so
+            // same-frame events see real geometry.
+            doc.resolve(clock);
+            self.doc = Some(doc);
+            self.dirty = true;
+            // Re-establish hover on the fresh DOM: clearing `hover_pos` makes
+            // the next pointer sample look moved, so the move re-synthesizes
+            // below even for a stationary cursor (`:hover` and wants_pointer
+            // would otherwise go stale until the mouse physically moves).
+            // [xreview]
+            self.hover_pos = None;
+            self.pointer_was_down = false;
+        } else if viewport_changed {
+            if let Some(doc) = &mut self.doc {
+                doc.set_viewport(Viewport::new(fb_width, fb_height, scale, ColorScheme::Dark));
+                self.dirty = true;
+            }
+        }
+        let Some(doc) = &mut self.doc else {
+            return WebviewOutput::empty();
+        };
+
+        // ── Pointer input → blitz event driver ─────────────────────────────
+        let mut collector = EventCollector { events: Vec::new() };
+        let css_pos = pointer
+            .pos
+            .map(|(x, y)| (x / scale, y / scale));
+        let hover_before = doc.get_hover_node_id();
+        let mut press_edge = false;
+        {
+            let mut driver = EventDriver::new(doc as &mut dyn Document, &mut collector);
+            match css_pos {
+                Some((x, y)) => {
+                    if self.hover_pos != css_pos {
+                        // A hover move carries the CURRENT button level —
+                        // `Primary` on a plain move would read as a drag.
+                        // [xreview]
+                        driver.handle_ui_event(BlitzUiEvent::PointerMove(pointer_event(
+                            x,
+                            y,
+                            self.pointer_was_down,
+                        )));
+                    }
+                    if pointer.primary_down && !self.pointer_was_down {
+                        driver
+                            .handle_ui_event(BlitzUiEvent::PointerDown(pointer_event(x, y, true)));
+                        press_edge = true;
+                    } else if !pointer.primary_down && self.pointer_was_down {
+                        driver
+                            .handle_ui_event(BlitzUiEvent::PointerUp(pointer_event(x, y, false)));
+                        press_edge = true;
+                    }
+                }
+                None => {
+                    // Pointer left (captured for free-look / suppressed):
+                    // release any held press so a drag can't stick.
+                    if self.pointer_was_down {
+                        if let Some((x, y)) = self.hover_pos {
+                            driver.handle_ui_event(BlitzUiEvent::PointerUp(pointer_event(
+                                x, y, false,
+                            )));
+                            press_edge = true;
+                        }
+                    }
+                }
+            }
+        }
+        self.pointer_was_down = pointer.primary_down && css_pos.is_some();
+        self.hover_pos = css_pos;
+        if doc.get_hover_node_id() != hover_before || press_edge || !collector.events.is_empty() {
+            // Hover transitions restyle (`:hover`), press/release edges
+            // restyle (`:active`) [xreview], clicks re-render below anyway
+            // once the model folds — repaint on any of them.
+            self.dirty = true;
+        }
+
+        // Is the pointer over an interactive element? That click belongs to
+        // the webview, not to free-look recapture (the `ui_wants_pointer`
+        // rule). Text hit or not, walk up from the hovered node.
+        let wants_pointer = doc
+            .get_hover_node_id()
+            .map(|id| chain_has_handler(doc, id))
+            .unwrap_or(false);
+
+        // ── Layout/style resolution + CPU repaint (only when dirty) ────────
+        doc.resolve(clock);
+        if self.dirty || viewport_changed {
+            if self.renderer.is_none() || viewport_changed {
+                self.renderer = Some(VelloCpuImageRenderer::new(fb_width, fb_height));
+            }
+            let renderer = self.renderer.as_mut().expect("just created");
+            renderer.render_to_vec(
+                |scene| {
+                    blitz_paint::paint_scene(
+                        scene,
+                        doc,
+                        scale as f64,
+                        fb_width,
+                        fb_height,
+                        0,
+                        0,
+                    )
+                },
+                &mut self.buf,
+            );
+            unsafe {
+                let gl = &self.gl;
+                gl.bind_texture(glow::TEXTURE_2D, Some(self.texture));
+                gl.tex_image_2d(
+                    glow::TEXTURE_2D,
+                    0,
+                    glow::RGBA as i32,
+                    fb_width as i32,
+                    fb_height as i32,
+                    0,
+                    glow::RGBA,
+                    glow::UNSIGNED_BYTE,
+                    glow::PixelUnpackData::Slice(Some(&self.buf)),
+                );
+                gl.bind_texture(glow::TEXTURE_2D, None);
+            }
+            self.tex_w = fb_width;
+            self.tex_h = fb_height;
+            self.dirty = false;
+        }
+
+        // ── Composite the overlay quad ──────────────────────────────────────
+        if self.tex_w > 0 {
+            unsafe {
+                let gl = &self.gl;
+                gl.disable(glow::DEPTH_TEST);
+                gl.disable(glow::SCISSOR_TEST);
+                gl.enable(glow::BLEND);
+                // The CPU painter emits PREMULTIPLIED alpha.
+                gl.blend_func(glow::ONE, glow::ONE_MINUS_SRC_ALPHA);
+                gl.use_program(Some(self.program));
+                gl.active_texture(glow::TEXTURE0);
+                gl.bind_texture(glow::TEXTURE_2D, Some(self.texture));
+                gl.bind_vertex_array(Some(self.vao));
+                gl.draw_arrays(glow::TRIANGLE_STRIP, 0, 4);
+                gl.bind_vertex_array(None);
+                gl.bind_texture(glow::TEXTURE_2D, None);
+                gl.use_program(None);
+                // Restore the slate the 3D path expects (the
+                // `restore_gl_after_egui` convention).
+                gl.disable(glow::BLEND);
+                gl.enable(glow::DEPTH_TEST);
+            }
+        }
+
+        WebviewOutput {
+            events: collector.events,
+            wants_pointer,
+        }
+    }
+}
+
+/// Render an HTML string to a premultiplied-RGBA buffer, headlessly (no GL) —
+/// the GL-free core of [`WebviewOverlay::frame`], exposed for tests and
+/// tooling (an agent can verify webview rendering without a window).
+pub fn render_html_to_rgba(html: &str, width: u32, height: u32, scale: f32) -> Vec<u8> {
+    let viewport = Viewport::new(width, height, scale, ColorScheme::Dark);
+    let mut doc = HtmlDocument::from_html(
+        html,
+        DocumentConfig {
+            viewport: Some(viewport),
+            ..Default::default()
+        },
+    )
+    .into_inner();
+    doc.resolve(0.0);
+    let mut renderer = VelloCpuImageRenderer::new(width, height);
+    let mut buf = Vec::new();
+    renderer.render_to_vec(
+        |scene| blitz_paint::paint_scene(scene, &mut doc, scale as f64, width, height, 0, 0),
+        &mut buf,
+    );
+    buf
+}
+
+/// Whether `node_id` or any ancestor carries a webview handler attribute —
+/// the pointer-arbitration test (a click here is for the webview).
+fn chain_has_handler(doc: &BaseDocument, node_id: usize) -> bool {
+    let click = LocalName::from("data-fn-click");
+    let input = LocalName::from("data-fn-input");
+    let mut current = Some(node_id);
+    while let Some(id) = current {
+        let Some(node) = doc.get_node(id) else {
+            return false;
+        };
+        if node.attr(click.clone()).is_some() || node.attr(input.clone()).is_some() {
+            return true;
+        }
+        current = node.parent;
+    }
+    false
+}
+
+/// `primary_held` is the button LEVEL the event carries (`buttons` in DOM
+/// terms): true for a press and for moves while held, false for a release
+/// and plain hover moves — blitz reads a held-level move as a drag.
+fn pointer_event(x: f32, y: f32, primary_held: bool) -> BlitzPointerEvent {
+    BlitzPointerEvent {
+        id: BlitzPointerId::Mouse,
+        is_primary: true,
+        coords: PointerCoords {
+            page_x: x,
+            page_y: y,
+            screen_x: x,
+            screen_y: y,
+            client_x: x,
+            client_y: y,
+        },
+        button: MouseEventButton::Main,
+        buttons: if primary_held {
+            MouseEventButtons::Primary
+        } else {
+            MouseEventButtons::None
+        },
+        mods: Default::default(),
+        details: Default::default(),
+        element: Default::default(),
+        active_pointers: Default::default(),
+    }
+}

--- a/runtime/functor-runtime-desktop/tests/webview_render.rs
+++ b/runtime/functor-runtime-desktop/tests/webview_render.rs
@@ -1,0 +1,54 @@
+//! Headless webview-render test: the blitz pipeline (parse → Stylo/Taffy/
+//! Parley → CPU paint) turns a styled card into the expected pixels with NO
+//! GL context or window — the agent-verifiable core of the native webview
+//! overlay (`webview_overlay::render_html_to_rgba` is the exact code the
+//! GL path uploads as a texture).
+#![cfg(not(target_arch = "wasm32"))]
+
+use functor_runtime_desktop::webview_overlay::render_html_to_rgba;
+
+const HTML: &str = r#"
+<html><head><style>
+  html, body { margin: 0; background: transparent; }
+  .card { width: 200px; height: 100px; margin: 50px; background: rgb(255, 0, 0); }
+</style></head>
+<body><div class="card"></div></body></html>
+"#;
+
+fn px(buf: &[u8], w: u32, x: u32, y: u32) -> [u8; 4] {
+    let i = ((y * w + x) * 4) as usize;
+    [buf[i], buf[i + 1], buf[i + 2], buf[i + 3]]
+}
+
+#[test]
+fn styled_card_renders_to_expected_pixels() {
+    let (w, h) = (400, 300);
+    let buf = render_html_to_rgba(HTML, w, h, 1.0);
+    assert_eq!(buf.len(), (w * h * 4) as usize);
+
+    // Inside the card (50..250 x, 50..150 y): opaque red.
+    assert_eq!(px(&buf, w, 150, 100), [255, 0, 0, 255]);
+    // Outside the card: fully transparent — the 3D scene must show through.
+    assert_eq!(px(&buf, w, 350, 250), [0, 0, 0, 0]);
+    assert_eq!(px(&buf, w, 10, 10), [0, 0, 0, 0]);
+}
+
+#[test]
+fn webview_tree_serializes_and_renders() {
+    // End-to-end through the shared tree type: HtmlNode → to_html → pixels.
+    use functor_runtime_common::webview::HtmlNode;
+    let tree = HtmlNode::Element {
+        tag: "div".into(),
+        attrs: vec![(
+            "style".into(),
+            "width: 100px; height: 100px; background: rgb(0, 255, 0);".into(),
+        )],
+        click_slot: Some(0),
+        input_slot: None,
+        children: vec![],
+    };
+    let buf = render_html_to_rgba(&tree.to_html(), 200, 200, 1.0);
+    // Body default margin is 8px — sample well inside the square.
+    assert_eq!(px(&buf, 200, 50, 50), [0, 255, 0, 255]);
+    assert_eq!(px(&buf, 200, 150, 150), [0, 0, 0, 0]);
+}

--- a/runtime/functor-runtime-web/index-functor-lang.html
+++ b/runtime/functor-runtime-web/index-functor-lang.html
@@ -28,10 +28,18 @@
       }
       /* The time-travel scrubber is the shared component (scrubber.js); it
          injects its own styles (the calm site theme). */
+      /* The game's HTML/CSS webview overlay (`webview model`): a REAL DOM
+         layer above the canvas — the browser renders here what blitz renders
+         natively. The game's tree lives in a SHADOW ROOT so its stylesheet
+         (Html.style) can't restyle the host chrome — matching blitz's
+         isolated document on native. The interior pointer-events rules live
+         inside the shadow root (page CSS can't cross the boundary). */
+      #webview { position: fixed; inset: 0; z-index: 5; pointer-events: none; overflow: hidden; }
     </style>
   </head>
   <body>
     <canvas id="canvas"></canvas>
+    <div id="webview"></div>
     <button id="mouselook" title="Control the camera with the mouse; Esc to release">🖱 mouse look</button>
     <script type="module">
 
@@ -48,6 +56,10 @@
         functor_lang_set_project,
         functor_lang_inspector_trace_gen,
         functor_lang_inspector_trace,
+        functor_lang_webview_html,
+        functor_lang_webview_gen,
+        functor_lang_webview_click,
+        functor_lang_webview_input,
       } from "./pkg/functor_runtime_web.js";
       // The time-travel scrubber is the shared component, served next to pkg/
       // by the dev server (see runtime/functor-runtime-web/scrubber.js). It
@@ -257,6 +269,41 @@
         }
       };
 
+      // The webview overlay: poll the runtime's revision each frame and swap
+      // innerHTML only on change (the timeline-events pattern — no per-rAF
+      // string copies over the wasm boundary). The tree renders inside a
+      // SHADOW ROOT so the game's <style> can't leak onto the host chrome
+      // (mouselook button, scrubber) — the native blitz document is likewise
+      // isolated. Interactions route back by walking up from the event
+      // target to the nearest handler-stamped element, mirroring the native
+      // shell's bubble-chain walk (closest() stays within the shadow tree).
+      const setupWebview = () => {
+        const shadow = document.getElementById("webview").attachShadow({ mode: "open" });
+        // Only handler-carrying elements take pointer input; empty overlay
+        // space stays click-through to the canvas.
+        const baseCss =
+          "<style>[data-fn-click], [data-fn-input] { pointer-events: auto; }</style>";
+        let lastGen = -1;
+        const poll = () => {
+          const gen = functor_lang_webview_gen();
+          if (gen !== lastGen) {
+            lastGen = gen;
+            const html = functor_lang_webview_html();
+            shadow.innerHTML = html ? baseCss + html : "";
+          }
+          requestAnimationFrame(poll);
+        };
+        requestAnimationFrame(poll);
+        shadow.addEventListener("click", (e) => {
+          const el = e.target.closest("[data-fn-click]");
+          if (el) functor_lang_webview_click(Number(el.getAttribute("data-fn-click")));
+        });
+        shadow.addEventListener("input", (e) => {
+          const el = e.target.closest("[data-fn-input]");
+          if (el) functor_lang_webview_input(Number(el.getAttribute("data-fn-input")), e.target.value);
+        });
+      };
+
       init().then(() => {
         // In a deterministic capture (?fixed-time), don't wire up input — a
         // stray mouse move would turn the camera, like on native.
@@ -266,6 +313,10 @@
           mountScrubber();
           setupInspectorRelay();
         }
+        // The webview overlay renders even in deterministic captures (it is
+        // part of the frame's visual output); only its input wiring is inert
+        // then (paused clocks drop interactions runtime-side anyway).
+        setupWebview();
         setupSetSource();
       });
     </script>

--- a/runtime/functor-runtime-web/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-web/src/functor_lang_game.rs
@@ -25,8 +25,8 @@ use functor_lang::project::SourceMap;
 use functor_lang::{Session, Value};
 use functor_runtime_common::functor_lang_prelude::{
     audio_scene_of, clear_audio_completions, clear_http_taggers, contains_effect, frame_value,
-    take_ui_handlers, view_value, EffectLog, EffectRunner, EffectTree, FunctorHost, NetEventKind,
-    RealEffects, UiHandler,
+    html_node_value, take_ui_handlers, view_value, EffectLog, EffectRunner, EffectTree,
+    FunctorHost, NetEventKind, RealEffects, UiHandler,
 };
 use functor_runtime_common::functor_lang_producer::{
     journal_arm, journal_swap, FrameCtx, JournalEntry, Reporter, SpanSource,
@@ -36,6 +36,7 @@ use functor_runtime_common::physics;
 use functor_runtime_common::protocol::GameProducer;
 use functor_runtime_common::timetravel::SceneRecorder;
 use functor_runtime_common::ui::View;
+use functor_runtime_common::webview::HtmlNode;
 use functor_runtime_common::{Frame, FrameTime};
 use wasm_bindgen::prelude::*;
 
@@ -85,6 +86,14 @@ pub struct FunctorLangWebGame {
     /// evaluation that built `last_view` (docs/ui-interaction.md U2), kept in
     /// lockstep with it — same rules as the desktop producer.
     ui_handlers: Vec<UiHandler>,
+    /// The game defines the optional `webview` entry point
+    /// (`webview(model) -> Html.node`, the HTML/CSS overlay hook).
+    has_webview: bool,
+    /// The last successfully built webview tree, cached like `last_view`.
+    last_webview: Option<HtmlNode>,
+    /// The handler table for `last_webview` — the webview's own slot space,
+    /// separate from `ui_handlers`. Same lockstep/reload rules.
+    webview_handlers: Vec<UiHandler>,
     /// Performs `Effect.*` commands (B6). `RealEffects` is wasm-safe: its
     /// clock is `Date.now()` on this target.
     effect_runner: RealEffects,
@@ -165,6 +174,7 @@ struct Loaded {
     has_physics: bool,
     has_soundscape: bool,
     has_ui: bool,
+    has_webview: bool,
 }
 
 /// Load, check, and contract-validate a game PROJECT — the web counterpart of
@@ -284,6 +294,12 @@ return them beside the model as `(model, effect)`"
     if has_ui {
         require_function(&path, &session, "ui", 1)?;
     }
+    // Optional webview: `webview(model)` returns an Html node (Html.div /
+    // Html.text / …), rendered as a DOM overlay above the canvas.
+    let has_webview = session.global("webview").is_some();
+    if has_webview {
+        require_function(&path, &session, "webview", 1)?;
+    }
     Ok(Loaded {
         sources: source_map,
         module,
@@ -296,6 +312,7 @@ return them beside the model as `(model, effect)`"
         has_physics,
         has_soundscape,
         has_ui,
+        has_webview,
     })
 }
 
@@ -396,6 +413,9 @@ impl FunctorLangWebGame {
             has_ui: loaded.has_ui,
             last_view: View::Empty,
             ui_handlers: Vec::new(),
+            has_webview: loaded.has_webview,
+            last_webview: None,
+            webview_handlers: Vec::new(),
             last_frame: empty_frame(),
         })
     }
@@ -459,6 +479,7 @@ impl FunctorLangWebGame {
         // The widget handler table holds msgs/taggers into the OLD session;
         // the next render's `ui(model)` rebuilds it against the new one.
         self.ui_handlers.clear();
+        self.webview_handlers.clear();
         // Plain-data snapshots remain seekable under the new program. A model
         // history containing callable or opaque host values instead starts a new
         // generation anchored at this rebound live frame.
@@ -468,6 +489,11 @@ impl FunctorLangWebGame {
         if !self.has_ui {
             // Deleting the `ui` hook drops the HUD (the physics-world rule).
             self.last_view = View::Empty;
+        }
+        self.has_webview = loaded.has_webview;
+        if !self.has_webview {
+            // Deleting the `webview` hook drops the overlay (the `ui` rule).
+            self.last_webview = None;
         }
         self.reporter.reset();
         // The push path (`functor_lang_set_source`) already hid the overlay in the DOM;
@@ -778,6 +804,19 @@ impl GameProducer for FunctorLangWebGame {
             .push(functor_runtime_common::RecordedInput::UiEvent(event));
     }
 
+    fn webview_event(&mut self, event: functor_runtime_common::ui::UiEvent) {
+        // The `ui_event` shape, against the webview's own handler table.
+        if !self.has_webview {
+            return;
+        }
+        let handlers = std::mem::take(&mut self.webview_handlers);
+        self.ctx().deliver_ui_event(&handlers, &event);
+        self.webview_handlers = handlers;
+        // TODO(webview): record for replay once webview events get their own
+        // RecordedInput variant — a UiEvent entry would replay against the
+        // wrong (ui) handler table.
+    }
+
     fn render(&mut self, frame_time: FrameTime) -> Frame {
         // While scrubbing, draw at the scrubbed frame's recorded `tts` so
         // `tts`-driven visuals (orbiting lights, `sin(tts)` motion) rewind with
@@ -841,6 +880,32 @@ impl GameProducer for FunctorLangWebGame {
                 }
             }
         }
+        // The optional webview, evaluated beside `draw` like `ui` — same
+        // caching, same handler-adoption lockstep, its own handler table.
+        if self.has_webview {
+            match self
+                .session
+                .call("webview", vec![self.model.clone()], &mut FunctorHost)
+            {
+                Ok(value) => match html_node_value(&value) {
+                    Some(node) => {
+                        self.last_webview = Some(node.clone());
+                        self.webview_handlers = take_ui_handlers();
+                    }
+                    None => {
+                        let _ = take_ui_handlers();
+                        self.reporter.report_once(format!(
+                            "[functor-lang] webview must return an Html node (Html.div / Html.text / …), got {}",
+                            value.kind_name()
+                        ))
+                    }
+                },
+                Err(err) => {
+                    let _ = take_ui_handlers();
+                    self.reporter.frame_error("webview", &err)
+                }
+            }
+        }
         // The optional soundscape, evaluated beside `draw` (same settled model)
         // and cached — `audio_scene_json` is a `&self` accessor, and errors
         // need `&mut` dedupe (the `ui` pattern, same as the desktop producer).
@@ -870,6 +935,10 @@ AudioScene.empty), got {}",
 
     fn ui(&self) -> View {
         self.last_view.clone()
+    }
+
+    fn webview(&self) -> Option<HtmlNode> {
+        self.last_webview.clone()
     }
 
     fn state_debug(&self) -> String {
@@ -1451,6 +1520,69 @@ pub fn functor_lang_timeline_events() -> String {
 #[wasm_bindgen]
 pub fn functor_lang_timeline_events_gen() -> u32 {
     TIMELINE_LOG.with(|log| log.borrow().revision)
+}
+
+thread_local! {
+    /// The current webview HTML and a cheap revision counter — the page's
+    /// poll loop fetches the string only when the revision changes (the
+    /// timeline-events pattern). Empty string = no webview.
+    static WEBVIEW_HTML: RefCell<(String, u32)> = const { RefCell::new((String::new(), 0)) };
+    /// Interactions the page's DOM listeners queued since last frame —
+    /// drained by the frame loop into `GameProducer::webview_event`.
+    static WEBVIEW_EVENTS: RefCell<Vec<functor_runtime_common::ui::UiEvent>> =
+        const { RefCell::new(Vec::new()) };
+}
+
+/// Publish this frame's webview HTML (None = no `webview` hook). The DOM
+/// overlay polls the revision and re-reads `innerHTML` only on change.
+pub fn publish_webview_html(html: Option<String>) {
+    let html = html.unwrap_or_default();
+    WEBVIEW_HTML.with(|v| {
+        let mut v = v.borrow_mut();
+        if v.0 != html {
+            v.0 = html;
+            v.1 = v.1.wrapping_add(1);
+        }
+    });
+}
+
+/// Runtime → page: the webview HTML for the overlay div.
+#[wasm_bindgen]
+pub fn functor_lang_webview_html() -> String {
+    WEBVIEW_HTML.with(|v| v.borrow().0.clone())
+}
+
+/// Runtime → page: cheap webview revision (the timeline-events pattern).
+#[wasm_bindgen]
+pub fn functor_lang_webview_gen() -> u32 {
+    WEBVIEW_HTML.with(|v| v.borrow().1)
+}
+
+/// Page → runtime: a click on a webview element carrying `data-fn-click`.
+#[wasm_bindgen]
+pub fn functor_lang_webview_click(slot: u32) {
+    WEBVIEW_EVENTS.with(|q| {
+        q.borrow_mut().push(functor_runtime_common::ui::UiEvent {
+            slot,
+            kind: functor_runtime_common::ui::UiEventKind::Clicked,
+        })
+    });
+}
+
+/// Page → runtime: an edit in a webview `<input>` carrying `data-fn-input`.
+#[wasm_bindgen]
+pub fn functor_lang_webview_input(slot: u32, value: &str) {
+    WEBVIEW_EVENTS.with(|q| {
+        q.borrow_mut().push(functor_runtime_common::ui::UiEvent {
+            slot,
+            kind: functor_runtime_common::ui::UiEventKind::TextChanged(value.to_string()),
+        })
+    });
+}
+
+/// Drain the interactions the page queued since last frame.
+pub fn take_webview_events() -> Vec<functor_runtime_common::ui::UiEvent> {
+    WEBVIEW_EVENTS.with(|q| std::mem::take(&mut *q.borrow_mut()))
 }
 
 fn push_scrub(control: ScrubControl) {

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -1278,6 +1278,17 @@ async fn run_async() -> Result<(), JsValue> {
             // draining stops the queue bursting on resume.
             functor_lang_game::drain_input(&mut **game, !clock.is_pinned());
 
+            // Webview interactions drain HERE, before render replaces the
+            // handler table — the queued slots were clicked against the DOM
+            // the LAST render published, so they must resolve against that
+            // render's table, not this frame's. Pinned frames drain-and-drop
+            // like all input. [xreview]
+            for event in functor_lang_game::take_webview_events() {
+                if !clock.is_pinned() {
+                    game.webview_event(event);
+                }
+            }
+
             // The loading snapshot for `Sub.assets`: pushed every frame, the
             // producer only acts when it changed since the game last saw it.
             game.push_asset_progress(asset_cache.progress());
@@ -1554,6 +1565,16 @@ async fn run_async() -> Result<(), JsValue> {
                     game.ui_event(event);
                 }
             }
+
+            // The HTML/CSS webview overlay: publish the serialized tree for
+            // the page's overlay (a REAL DOM node above the canvas — the
+            // browser is the renderer here; blitz is the native analogue).
+            // Interactions drained pre-tick above. TODO(webview): cache the
+            // serialized string in the producer instead of clone+reserialize
+            // per frame (perf follow-up).
+            functor_lang_game::publish_webview_html(
+                game.webview().map(|node| node.to_html()),
+            );
 
             // Publish the scrubber state for the DOM slider to poll (the UI
             // itself is native HTML in index-functor-lang.html, outside the canvas).

--- a/site/player.html
+++ b/site/player.html
@@ -47,10 +47,17 @@
       /* The time-travel scrubber is the shared component (scrubber.js); it
          injects its own styles, reading the --scrub-* vars above so it matches
          this page's calm theme. */
+      /* The game's HTML/CSS webview overlay (`webview model`): a REAL DOM
+         layer above the canvas whose tree lives in a shadow root (the game's
+         stylesheet can't restyle the page chrome). Only handler-carrying
+         elements take pointer input — the rules live inside the shadow root.
+         Kept in sync with index-functor-lang.html. */
+      #webview { position: fixed; inset: 0; z-index: 5; pointer-events: none; overflow: hidden; }
     </style>
   </head>
   <body>
     <canvas id="canvas"></canvas>
+    <div id="webview"></div>
     <button id="mouselook" title="Control the camera with the mouse; Esc to release">🖱 mouse look</button>
     <script type="module">
 
@@ -107,6 +114,10 @@
         functor_lang_ui_pointer_leave,
         functor_lang_ui_wants_keyboard,
         functor_lang_ui_key,
+        functor_lang_webview_html,
+        functor_lang_webview_gen,
+        functor_lang_webview_click,
+        functor_lang_webview_input,
         functor_lang_is_running,
         functor_lang_scene_frame,
         functor_lang_inspector_trace,
@@ -260,6 +271,35 @@
         });
       };
 
+      // The webview overlay (the `webview model` hook): poll the runtime's
+      // revision each frame and swap innerHTML only on change. The tree
+      // renders inside a SHADOW ROOT so the game's <style> can't leak onto
+      // the page chrome. Kept in sync with index-functor-lang.html.
+      const setupWebview = () => {
+        const shadow = document.getElementById("webview").attachShadow({ mode: "open" });
+        const baseCss =
+          "<style>[data-fn-click], [data-fn-input] { pointer-events: auto; }</style>";
+        let lastGen = -1;
+        const poll = () => {
+          const gen = functor_lang_webview_gen();
+          if (gen !== lastGen) {
+            lastGen = gen;
+            const html = functor_lang_webview_html();
+            shadow.innerHTML = html ? baseCss + html : "";
+          }
+          requestAnimationFrame(poll);
+        };
+        requestAnimationFrame(poll);
+        shadow.addEventListener("click", (e) => {
+          const el = e.target.closest("[data-fn-click]");
+          if (el) functor_lang_webview_click(Number(el.getAttribute("data-fn-click")));
+        });
+        shadow.addEventListener("input", (e) => {
+          const el = e.target.closest("[data-fn-input]");
+          if (el) functor_lang_webview_input(Number(el.getAttribute("data-fn-input")), e.target.value);
+        });
+      };
+
       // The live-edit seam: the hosting page (the sandbox / the IDE) posts
       // .fun source (`functor-lang-set-source`) or a whole file set
       // (`functor-lang-set-project`, the IDE) and the runtime hot-swaps it,
@@ -377,6 +417,10 @@
           setupInput();
           if (!scrubberOff) mountScrubber();
         }
+        // The webview overlay renders even in deterministic captures (it is
+        // part of the frame's visual output); paused clocks drop its
+        // interactions runtime-side.
+        setupWebview();
         setupInspectorRelay();
         announceWhenReady();
       });


### PR DESCRIPTION
> **Stacked on #403** (the site player input-bridge sync); review this PR's diff against that branch. Design research: the html-css-ui-blitz notes; prototype spike, deliberately scoped — see *Follow-ups*.

## Demo

![examples/webview demo](https://gist.githubusercontent.com/tommy-xr/97667d4de4599ce98f3fdf86954757fe/raw/webview-demo.gif)

<sub>examples/webview — the `webview(model)` HTML/CSS counter card (blitz → CPU raster → GL texture) composited over the spinning lit cube. Rendered headlessly via --capture-frame.</sub>

![examples/webview still](https://gist.githubusercontent.com/tommy-xr/97667d4de4599ce98f3fdf86954757fe/raw/webview-still.png)

## What this is

Games get an optional **`webview(model)`** entry point returning an Elm-style **`Html.*` / `Attr.*` tree styled with real CSS** — flexbox, gradients, border-radius, `:hover` — as a third UI surface beside `draw` (3D) and `ui` (egui HUD):

```fun
let webview = (m: Model) =>
  Html.div([], [
    Html.style(css),                                   // real CSS, themeable
    Html.div([Attr.class("hud")], [
      Html.div([Attr.class("count")], [Html.text(Text.fixed(m.count, 0.0))]),
      Html.button([Attr.onClick(Inc)], [Html.text("+")]),
    ]),
  ])
```

One serializable tree, two renderers:

| Target | Renderer |
|---|---|
| **native** | [blitz](https://github.com/DioxusLabs/blitz) `blitz-dom` headless (Stylo styles + Taffy layout + Parley text) → `anyrender_vello_cpu` CPU paint → premultiplied-RGBA → glow texture, composited as an overlay quad. **No wgpu anywhere** — stays on the existing GL stack on every target (incl. the future Quest path: a world-space panel is the friendliest case for CPU raster). |
| **wasm** | the same serialized HTML becomes a **real DOM overlay** above the canvas, inside a **shadow root** (game CSS can't restyle host chrome — matching blitz's isolated document). The browser is the renderer; blitz never compiles to wasm. |

## Architecture

- **Functional core untouched.** The tree is plain data (`HtmlNode` in `functor_runtime_common::webview`, serde-derived); the DOM is shell state, exactly like egui's context. Hot-reload and time-travel invariants hold.
- **Interaction mirrors the egui `ui()` machinery exactly**: `Attr.onClick(msg)` / `Attr.onInput(tagger)` register in the per-eval handler table, nodes carry `slot` indexes (serialized as `data-fn-click/-input`), events fold through `update` via the shared `deliver_ui_event` — against the webview's **own** handler table (`GameProducer::webview` / `webview_event`).
- **Native events are real DOM semantics**: blitz's `EventDriver` synthesizes bubble chains, `:hover` restyles, and click = press+release on one element. The shell arbitrates presses with a **live hit-test** so a webview click never recaptures the cursor for free-look and never double-fires an egui widget.
- **Retained, not immediate**: reparse only when the serialized HTML changes (with a **shared FontContext** — a fresh one re-scans system fonts, ~30ms/re-render); repaint only on content/hover/press changes.
- **Guardrails**: script-capable tags and executable/spoofing attribute names (`on*`, `href`, `data-fn-*`, …) are construction-time teaching errors — game logic has no DOM access by design, and the webview must not become the escape hatch. `Html`/`Attr` are protected namespaces; `.funi` interfaces typecheck the builders (drift test extended).

## Verified (all agent-reproducible)

- **Unit**: `HtmlNode` serialization (escaping, raw `<style>`, void elements, slots); prelude builders + teaching errors + injection rejection; headless blitz render → pixel assertions (`tests/webview_render.rs`, no GL); `.funi` ≡ registry drift test.
- **Native end-to-end**: `--capture-frame` shows the styled card composited over the lit scene; headless click round-trip via `POST /input {"type":"webview_event","slot":1,"kind":"Clicked"}` → count folds through `update`.
- **wasm end-to-end**: Playwright — shadow-DOM overlay mounts, `+`/`+`/`−` → count `1`, Reset → `0`; same flow re-verified on the site player.
- **Suites**: common 338 ✅, desktop 50 ✅, functor-lang ✅, CI-strict build ✅.
- **Cross-engine review** (Claude + Codex, adversarial): 6 of 8 findings fixed in-PR (stale hover after reparse, wasm `<style>` leak → shadow root, ui/webview click double-fire, event/handler generation skew, `buttons` level on hover moves, `:active` repaint); 2 deferred with TODOs (producer-side HTML caching, DOM reconciliation).

## Performance

`webview_bench` (new desktop example, the `frame_bench` rules — release only, compare min):

| scenario | min |
|---|---|
| parse+resolve, shared FontContext | ~0.5 ms |
| paint 800×600@1 | ~0.8 ms |
| paint 2048×1536@2 (retina window) | ~3.1 ms |
| press hit-test | ~0.04 µs |

An idle webview costs one string compare per frame. **Debug-build paint is ~200× release** (~0.6 s/repaint at retina size — reads as a hang), hence `npm run build:cli:release` and the CLAUDE.md guidance: interactive native testing uses release builds. `frame_bench` is unaffected (the overlay isn't in its scope; nothing on its hot path changed).

## Follow-ups (docs/todo.md § Webview)

1. Native text input (focus/keyboard routing into blitz; wasm inputs already work)
2. Replay recording for webview events (own `RecordedInput` variant — TODOs in both producers)
3. DOM reconciliation instead of full reparse (also fixes wasm controlled-input focus loss)
4. Producer-side HTML caching (kill the per-frame tree clone + serialize)
5. CSS animation ticking (repaint-while-animating; we own blitz's clock)
6. Debug-build usability (dirty-region repaint or downscaled raster)
7. #402 — extract the shared player-page JS (the drift that hid the egui-input bug fixed by #403)

Blitz is pre-1.0 (`=0.3.0-beta.1`, pinned exact); budget for churn on upgrades.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
