### PR TITLE
feat(lsp): go-to-definition into the .funi prelude, doc comments in hover

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -27,7 +27,10 @@ so scratch files must live in their own directory, not a shared one.
 Errors are always `file:line:col: error: message`. Tests live in `functor-lang/tests/`
 with goldens next to `functor-lang/examples/` (`UPDATE_GOLDENS=1 cargo test -p functor-lang`
 regenerates). VSCode gets live parse/lower/type diagnostics,
-`name : Type` hover, and go-to-definition via `tools/functor-lang-lsp`.
+`name : Type` hover (with the doc-comment block above the definition — the
+`.funi` prose for prelude calls), and go-to-definition via
+`tools/functor-lang-lsp` — including JUMPING INTO the prelude: definition on
+`Scene.cube` opens the materialized `Scene.funi` interface at its signature.
 
 ## Syntax subset
 

--- a/docs/functor-lang.md
+++ b/docs/functor-lang.md
@@ -324,6 +324,16 @@ snapshots — no GPU, fully agent-verifiable.
       velocities stored in the model survive hot-reload time travel.
       Component accessors and vector math (`Vec3.add`/`scale`/`length`, and
       Vec2/Vec4) are deliberately deferred until an API returns a Vec3.
+- [x] **Prelude go-to-definition + hover docs** (2026-07-18; prelude-infra
+      track). Go-to-definition on a host external (`Scene.cube`) jumps into
+      its `.funi` interface — the LSP materializes the embedded prelude to a
+      content-hashed read-only directory so the editor opens a real file —
+      and hover surfaces the doc-comment block above the definition: the
+      `.funi` prose for prelude calls, and (for free) a user's own comment
+      block above a `let` when hovering its references. A blank line breaks
+      attachment, so section headers don't leak. Project-local `.funi`
+      modules get both behaviors with no special casing (their files are
+      real). This closes the notes item "prelude as real code".
 - [x] **Typed external registry** (2026-07-16; prelude-infra track, PR 1).
       The generalized Functor Lang ↔ Rust bridge: hosts REGISTER externals as
       typed closures (`host_registry.rs`) instead of hand-writing `match

--- a/functor-lang/src/docs.rs
+++ b/functor-lang/src/docs.rs
@@ -1,0 +1,128 @@
+//! Doc-comment extraction for hover: the contiguous `//` comment block
+//! sitting DIRECTLY above a definition (no blank line between), rendered as
+//! prose. This is how the prelude `.funi` files' rich comments surface in
+//! the editor — hover on `Scene.model` shows the interface's own
+//! documentation — and user code gets the same treatment for free (a
+//! comment block right above a `let` shows on hover of its references).
+//!
+//! Comments are discarded at lex time, so this works from the SOURCE TEXT:
+//! given a definition span (a [`crate::goto::definition_span`] target), find
+//! the owning file in the [`SourceMap`] and walk back over whole lines. A
+//! blank line ends the block — section headers separated from the
+//! declarations they group (the `.funi` house style) deliberately do not
+//! attach.
+
+use crate::project::SourceMap;
+use crate::Span;
+
+/// The doc-comment block directly above `span`, with `//` markers stripped,
+/// joined by newlines. `None` when no comment line immediately precedes the
+/// definition (or the span falls outside the map's files).
+pub fn doc_comment(sources: &SourceMap, span: Span) -> Option<String> {
+    let file = sources.file_at(span.start);
+    let local = span.start.checked_sub(file.base)?;
+    if local > file.src.len() {
+        return None;
+    }
+    // `get` rather than a slice: definition spans from the parser always sit
+    // on char boundaries, but the span is caller-supplied public API.
+    let above = file.src.get(..local)?;
+
+    let mut lines: Vec<&str> = Vec::new();
+    let mut fragments = above.lines().rev();
+    // `above` usually ends mid-line: the definition line's leading text
+    // (indentation, or empty for a top-level `let`). Skip that fragment —
+    // it belongs to the definition, not to what precedes it — unless the
+    // slice ended exactly on a line break.
+    if !above.is_empty() && !above.ends_with('\n') {
+        let fragment = fragments.next()?;
+        if !fragment.trim().is_empty() {
+            // The definition shares its line with real code — no doc block.
+            return None;
+        }
+    }
+    for line in fragments {
+        let trimmed = line.trim_start();
+        match trimmed.strip_prefix("//") {
+            Some(rest) => lines.push(rest.strip_prefix(' ').unwrap_or(rest)),
+            None => break,
+        }
+    }
+    if lines.is_empty() {
+        return None;
+    }
+    lines.reverse();
+    Some(lines.join("\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::doc_comment;
+    use crate::project::load_single_source;
+
+    /// The entry's own defs: a comment block right above a `let` attaches;
+    /// a blank line breaks attachment.
+    #[test]
+    fn user_defs_attach_their_comment_block() {
+        let src = "// The player's walking speed,\n\
+                   // in units per second.\n\
+                   let speed = 4.0\n\
+                   \n\
+                   // A section header, separated by a blank line.\n\
+                   \n\
+                   let other = 1.0\n";
+        let project =
+            load_single_source("game", src).unwrap_or_else(|e| panic!("loads: {}", e.render()));
+        let speed = project
+            .module
+            .defs
+            .iter()
+            .find(|d| d.name == "speed")
+            .expect("speed def");
+        assert_eq!(
+            doc_comment(&project.sources, speed.span).as_deref(),
+            Some("The player's walking speed,\nin units per second.")
+        );
+        let other = project
+            .module
+            .defs
+            .iter()
+            .find(|d| d.name == "other")
+            .expect("other def");
+        assert_eq!(doc_comment(&project.sources, other.span), None);
+    }
+
+    /// Injected interface signatures: a `.funi` module's per-signature
+    /// comment blocks attach through the synthetic source, and a signature
+    /// without a directly-preceding block stays bare rather than stealing an
+    /// earlier one.
+    #[test]
+    fn interface_signatures_attach_their_funi_docs() {
+        let funi = "// The opaque widget handle.\n\
+                    type t\n\
+                    \n\
+                    // Make a widget of the given size,\n\
+                    // in pixels.\n\
+                    let make : (float) => t\n\
+                    let size : (t) => float\n";
+        let project = crate::project::load_sources_with_prelude(
+            vec![(std::path::PathBuf::from("game.fun"), "let x = 0.0\n".to_string())],
+            &[("Widget".to_string(), funi.to_string())],
+        )
+        .unwrap_or_else(|e| panic!("loads: {}", e.render()));
+        let sig = |name: &str| {
+            project
+                .module
+                .signatures
+                .iter()
+                .find(|s| s.name == name)
+                .unwrap_or_else(|| panic!("no signature {name}"))
+                .span
+        };
+        assert_eq!(
+            doc_comment(&project.sources, sig("Widget.make")).as_deref(),
+            Some("Make a widget of the given size,\nin pixels.")
+        );
+        assert_eq!(doc_comment(&project.sources, sig("Widget.size")), None);
+    }
+}

--- a/functor-lang/src/goto.rs
+++ b/functor-lang/src/goto.rs
@@ -71,6 +71,12 @@ struct Targets {
     ctors: HashMap<String, Span>,
     /// Declared types: name → the whole `type` declaration's span.
     types: HashMap<String, Span>,
+    /// Interface (`.funi`) signatures: canonical path (`Scene.cube`) → the
+    /// `let name : Type` declaration's span — for the engine prelude these
+    /// land in the injected `<prelude>/{module}.funi` sources (the LSP
+    /// materializes those to real files), and for a project's own `.funi`
+    /// modules in the on-disk file.
+    signatures: HashMap<String, Span>,
 }
 
 fn index_targets(module: &Module) -> Targets {
@@ -89,6 +95,9 @@ fn index_targets(module: &Module) -> Targets {
             Span::new(def.span.start, def.value.span.start),
         );
         collect_binders(&def.value, &mut targets.binders);
+    }
+    for sig in &module.signatures {
+        targets.signatures.insert(sig.name.clone(), sig.span);
     }
     targets
 }
@@ -162,6 +171,16 @@ fn visit(expr: &Expr, targets: &Targets, consider: &mut impl FnMut(Span, Span)) 
             offer(
                 name_region(expr.span, name),
                 targets.globals.get(name),
+                consider,
+            );
+        }
+        // A host external (`Scene.cube`) jumps to its interface signature —
+        // the `let cube : () => t` line of the owning `.funi`. Unregistered
+        // externals (no signature; the gradual seam) still answer nothing.
+        ExprKind::External(path) => {
+            offer(
+                expr.span,
+                targets.signatures.get(&path.join(".")),
                 consider,
             );
         }
@@ -389,6 +408,37 @@ mod tests {
     }
 
     // --- Nothing ---
+
+    /// A host external jumps to its `.funi` signature: the span lands in
+    /// the interface module's (synthetic) source, at the `let name : Type`
+    /// declaration. Unregistered externals still answer nothing.
+    #[test]
+    fn externals_jump_to_their_interface_signature() {
+        let funi = "// Make a widget.\nlet make : (float) => float\n";
+        let project = crate::project::load_sources_with_prelude(
+            vec![(
+                std::path::PathBuf::from("game.fun"),
+                "let x = Widget.make(2.0)\n".to_string(),
+            )],
+            &[("Widget".to_string(), funi.to_string())],
+        )
+        .unwrap_or_else(|e| panic!("loads: {}", e.render()));
+        let offset = "let x = Wid".len(); // inside the external reference
+        let span = definition_span(&project.module, offset).expect("external resolves");
+        let (file, line, _col) = project.sources.resolve(span.start);
+        assert_eq!(file.path.to_string_lossy(), "<prelude>/Widget.funi");
+        assert_eq!(line, 2, "the `let make : …` line, past the doc comment");
+        // An unregistered external (no signature) still has no definition.
+        let none = crate::project::load_sources_with_prelude(
+            vec![(
+                std::path::PathBuf::from("game.fun"),
+                "let x = Ghost.make(2.0)\n".to_string(),
+            )],
+            &[],
+        )
+        .unwrap_or_else(|e| panic!("loads: {}", e.render()));
+        assert_eq!(definition_span(&none.module, offset), None);
+    }
 
     #[test]
     fn builtins_and_literals_have_no_definition() {

--- a/functor-lang/src/lib.rs
+++ b/functor-lang/src/lib.rs
@@ -12,6 +12,7 @@ pub mod ast;
 pub mod codelens;
 pub mod complete;
 pub mod eval;
+pub mod docs;
 pub mod goto;
 pub mod hover;
 pub mod coverage;

--- a/tools/functor-lang-lsp/src/main.rs
+++ b/tools/functor-lang-lsp/src/main.rs
@@ -523,8 +523,17 @@ fn hover(uri: &str, documents: &HashMap<String, String>, position: &Value) -> Op
     let (_, types) = project.check_with_types();
     let (span, hover_text) = functor_lang::hover::hover_text(&project.module, &types, offset)?;
     let (_, range) = localize(&project, span)?;
+    // The doc-comment block above whatever this reference DEFINES — the
+    // `.funi` prose for a prelude external, the user's own comment for a
+    // project def — rendered as a paragraph under the type line.
+    let docs = functor_lang::goto::definition_span(&project.module, offset)
+        .and_then(|def| functor_lang::docs::doc_comment(&project.sources, def));
+    let value = match docs {
+        Some(docs) => format!("```functor\n{hover_text}\n```\n\n{docs}"),
+        None => format!("```functor\n{hover_text}\n```"),
+    };
     Some(json!({
-        "contents": { "kind": "markdown", "value": format!("```functor\n{hover_text}\n```") },
+        "contents": { "kind": "markdown", "value": value },
         "range": range,
     }))
 }
@@ -963,10 +972,85 @@ fn owns(file: &functor_lang::project::SourceFile, offset: usize) -> bool {
 
 /// A project-wide span → an LSP range local to the file it belongs to, plus
 /// that file's URI. Spans never straddle files (each node is lowered from one
-/// file), so both ends localize against the start file.
+/// file), so both ends localize against the start file. Spans landing in the
+/// injected `<prelude>/{module}.funi` sources map to the MATERIALIZED prelude
+/// (see [`materialized_prelude_dir`]) so go-to-definition on `Scene.cube`
+/// opens a real, readable interface file.
 fn localize(project: &functor_lang::project::Project, span: functor_lang::Span) -> Option<(String, Value)> {
     let file = project.sources.file_at(span.start);
-    Some((path_to_uri(&file.path), local_range(file, span)))
+    let path = if file.path.to_str().is_some_and(|p| p.starts_with('<')) {
+        // A synthetic source (`<prelude>/Scene.funi`, `<builtin>/Random.funi`,
+        // `<builtin>/Net.fun`) — materialize its text so the editor can open
+        // it. Definition targets in Net/Random/Key land here too.
+        materialize_synthetic(file)?
+    } else {
+        file.path.clone()
+    };
+    Some((path_to_uri(&path), local_range(file, span)))
+}
+
+/// The embedded prelude `.funi` interfaces written out as real files, so the
+/// editor can OPEN them (go-to-definition targets, browsable docs). Written
+/// once per content hash — a new prelude version gets a fresh directory, and
+/// an unchanged one reuses it — and marked read-only best-effort (they are
+/// generated views of the interfaces baked into this binary; edits would be
+/// silently ignored). `None` only if the temp dir is unwritable, in which
+/// case prelude jumps degrade to "no definition" rather than a broken URI.
+fn materialize_synthetic(file: &functor_lang::project::SourceFile) -> Option<std::path::PathBuf> {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    use std::sync::OnceLock;
+    // One cache directory per prelude version (the synthetic sources are
+    // fixed by this binary, so the prelude hash keys them all); the per-file
+    // content check below self-heals anything stale or truncated inside it.
+    static DIR: OnceLock<Option<std::path::PathBuf>> = OnceLock::new();
+    let dir = DIR
+        .get_or_init(|| {
+            let mut hasher = DefaultHasher::new();
+            for (name, src) in &functor_prelude::modules() {
+                name.hash(&mut hasher);
+                src.hash(&mut hasher);
+            }
+            let dir =
+                std::env::temp_dir().join(format!("functor-prelude-{:016x}", hasher.finish()));
+            std::fs::create_dir_all(&dir).ok()?;
+            Some(dir)
+        })
+        .clone()?;
+
+    let path = dir.join(file.path.file_name()?);
+    // Self-healing, ATOMIC write: rewrite when absent or when the on-disk
+    // text differs (a truncated write must never be served forever) via a
+    // temp file + rename, then mark read-only best-effort — these are
+    // generated views of interfaces baked into this binary.
+    if std::fs::read_to_string(&path).ok().as_deref() != Some(file.src.as_str()) {
+        let tmp = dir.join(format!(
+            ".{}.tmp-{}",
+            file.path.file_name()?.to_string_lossy(),
+            std::process::id()
+        ));
+        if std::fs::write(&tmp, &file.src).is_ok() {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644));
+            }
+            if std::fs::rename(&tmp, &path).is_ok() {
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    let _ =
+                        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o444));
+                }
+            } else {
+                let _ = std::fs::remove_file(&tmp);
+                return None;
+            }
+        } else {
+            return None;
+        }
+    }
+    Some(path)
 }
 
 /// A project-wide span → an LSP range in `file`'s local coordinates.

--- a/tools/functor-lang-lsp/tests/e2e.rs
+++ b/tools/functor-lang-lsp/tests/e2e.rs
@@ -639,7 +639,7 @@ fn prelude_gives_host_calls_real_types() {
     }));
     server.recv();
     server.send(json!({ "jsonrpc": "2.0", "method": "initialized", "params": {} }));
-    let text = "let s = () => Scene.cube()\n";
+    let text = "let s = () => Scene.cube()\nlet r = Random.seed(1.0)\n";
     server.send(json!({
         "jsonrpc": "2.0", "method": "textDocument/didOpen",
         "params": { "textDocument": {
@@ -659,8 +659,65 @@ fn prelude_gives_host_calls_real_types() {
     }));
     let response = server.recv();
     assert_eq!(
-        response["result"]["contents"]["value"], "```functor\nScene.cube : () => Scene.t\n```",
-        "prelude hover: {response}"
+        response["result"]["contents"]["value"],
+        "```functor\nScene.cube : () => Scene.t\n```\n\nPrimitive geometry.",
+        "prelude hover carries the .funi doc block: {response}"
+    );
+
+    // Go-to-definition on the same external jumps INTO the interface: a
+    // real, readable scene.funi materialized from the embedded prelude.
+    server.send(json!({
+        "jsonrpc": "2.0", "id": 5, "method": "textDocument/definition",
+        "params": {
+            "textDocument": { "uri": URI },
+            "position": { "line": 0, "character": col },
+        },
+    }));
+    let definition = server.recv();
+    let uri = definition["result"]["uri"].as_str().unwrap_or_default().to_string();
+    assert!(
+        uri.ends_with("Scene.funi"),
+        "definition lands in the materialized interface: {definition}"
+    );
+    // Percent-decode the path portion (temp dirs may contain encoded bytes).
+    let raw = uri.strip_prefix("file://").expect("file uri");
+    let mut decoded = Vec::new();
+    let bytes = raw.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            let hex = std::str::from_utf8(&bytes[i + 1..i + 3]).unwrap_or("");
+            if let Ok(b) = u8::from_str_radix(hex, 16) {
+                decoded.push(b);
+                i += 3;
+                continue;
+            }
+        }
+        decoded.push(bytes[i]);
+        i += 1;
+    }
+    let target = std::path::PathBuf::from(String::from_utf8(decoded).expect("utf8 path"));
+    let contents = std::fs::read_to_string(&target).expect("materialized file readable");
+    let line = definition["result"]["range"]["start"]["line"].as_u64().unwrap() as usize;
+    assert!(
+        contents.lines().nth(line).unwrap_or_default().contains("let cube"),
+        "the range points at the `let cube` signature: {definition}"
+    );
+
+    // Built-in interface modules (injected by the language, not the host
+    // prelude) materialize too: Random.seed jumps into Random.funi.
+    let col = "let r = Random.s".len() as i64;
+    server.send(json!({
+        "jsonrpc": "2.0", "id": 6, "method": "textDocument/definition",
+        "params": {
+            "textDocument": { "uri": URI },
+            "position": { "line": 1, "character": col },
+        },
+    }));
+    let builtin = server.recv();
+    assert!(
+        builtin["result"]["uri"].as_str().unwrap_or_default().ends_with("Random.funi"),
+        "Random.seed jumps into the materialized builtin interface: {builtin}"
     );
 
     server.send(json!({ "jsonrpc": "2.0", "id": 3, "method": "shutdown" }));


### PR DESCRIPTION
## Summary

The registry track's editor payoff — the notes item "update the prelude to be real code → support go-to-definition":

- **Go-to-definition on a host external jumps into its interface.** `goto` indexes `module.signatures`, so `Scene.cube` resolves to its `let cube : () => t` declaration; the LSP **materializes** the embedded interface sources into a content-hashed, read-only temp directory and rewrites synthetic paths there — the editor opens a real `Scene.funi` at the exact signature line. This covers the host prelude, the **built-in interface modules** (`Random.seed` → `Random.funi` — and it heals a pre-existing broken-URI case for `Net.*` constructor jumps), and project-local `.funi` files (which need no special casing at all).
- **Hover carries doc comments.** The contiguous `//` block directly above whatever a reference defines renders under the type line — `Scene.cube : () => Scene.t` now shows *"Primitive geometry."* from the interface's own prose, and user code gets the same for its own comment blocks. A blank line breaks attachment, so section headers don't leak. Extraction is a source-text walk-back (comments are discarded at lex time), living in a new `functor_lang::docs` module.

## Robustness (review-driven)

Cross-engine adversarial review (Claude + Codex): no Critical/High on the core; all findings applied — the **`<builtin>` materialization gap** (Codex's Medium: `Random.*` jumps returned an unopenable synthetic URI), **atomic self-healing cache writes** (temp-file + rename; content-compare so a truncated write is never served forever; per-file fail-open so one unwritable module degrades only itself), a defensive char-boundary `get` in the public doc API, and a percent-decoding e2e. Both engines independently verified the UTF-8/CRLF/file-start edges, the clickable-region convention, and the nearest-enclosing picking.

## Validation

Unit tests (goto external-jump incl. the unregistered-external negative; docs attachment/blank-line semantics for user defs and a synthetic interface) plus the LSP e2e over real stdio: hover text includes the doc block; definition URIs open readable materialized files with ranges pointing at the right signatures, for both `Scene.funi` and `Random.funi`. All suites green. No runtime code touched (check/editor-time only); frame_bench sanity run consistent with the machine-load band, allocs identical.

Known design boundary (flagged in review, deliberate): grouped signatures under one shared section header only attach docs to the first member — header-inheritance is possible later if the `.funi` house style wants it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)