### PR TITLE
feat(lang): Asset.whilePending — placeholder assets while the real one streams in (B.4)

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -409,6 +409,21 @@ Asset.sound("boom.ogg")                                    //   per KIND (types 
                                                            //   tightens them to the Asset
                                                            //   kinds; the constructors are
                                                            //   fully typed now
+asset |> Asset.whilePending(placeholder)                   // placeholder rendered WHILE the
+                                                           //   asset streams in (instead of
+                                                           //   the empty/checkerboard
+                                                           //   fallback). Subject-last:
+                                                           //   pipes. The placeholder is
+                                                           //   just another SAME-KIND asset,
+                                                           //   so it chains (a low-poly
+                                                           //   proxy can carry its own).
+                                                           //   Models + textures only —
+                                                           //   sounds decode at play time
+                                                           //   (no pending state; teaching
+                                                           //   error). A FAILED asset still
+                                                           //   shows the fallback: failure
+                                                           //   is not pending, and
+                                                           //   Sub.assets still reports it
 Scene.group([scene, …])
 Color.rgb(r, g, b)                                         // Color VALUES only (the
                                                            //   Angle rule): every color

--- a/examples/loading/game.fun
+++ b/examples/loading/game.fun
@@ -71,12 +71,21 @@ let fraction = (model) =>
     (model.loaded + model.failed - model.baseLoaded)
       / (model.total - model.baseTotal)
 
+// The 15MB shark shows the `Asset.whilePending` placeholder pattern: the
+// 2KB box stands in (streams near-instantly) until the shark is decoded —
+// under FUNCTOR_THROTTLE_ASSETS you can watch the swap. The placeholder is
+// just another asset value; a FAILED shark would show the empty fallback
+// (failure is not pending) and still count in Sub.assets' `failed`.
+let shark =
+  Asset.model("https://assets.babylonjs.com/meshes/shark.glb")
+    |> Asset.whilePending(Asset.model("https://assets.babylonjs.com/meshes/box.glb"))
+
 let models = () =>
   Scene.group([
     Scene.model("https://assets.babylonjs.com/meshes/ExplodingBarrel.glb")
       |> Scene.scale(0.35)
       |> Scene.translate(Vec3.make(0.0, -1.2, 0.0)),
-    Scene.model("https://assets.babylonjs.com/meshes/shark.glb")
+    Scene.model(shark)
       |> Scene.scale(0.18)
       |> Scene.rotateY(Angle.degrees(200.0))
       |> Scene.translate(Vec3.make(-2.2, 0.7, 0.0)),

--- a/functor-prelude/prelude/asset.funi
+++ b/functor-prelude/prelude/asset.funi
@@ -17,3 +17,13 @@ type Sound
 let model : (string) => Model
 let texture : (string) => Texture
 let sound : (string) => Sound
+
+// A placeholder rendered WHILE the asset streams in, instead of the empty /
+// checkerboard fallback (subject-last, so it pipes:
+// `asset |> Asset.whilePending(placeholder)`). The placeholder is just
+// another asset of the SAME kind, so it chains — a low-poly proxy can carry
+// its own placeholder. Models and textures only (sounds decode at play time
+// — no pending state; the host teaches). A FAILED asset still shows the
+// fallback: failure is not pending. Gradually typed ('a ties the result to
+// the asset's kind); the flag day tightens the kinds.
+let whilePending : ('placeholder, 'asset) => 'asset

--- a/runtime/functor-runtime-common/src/asset/asset_cache.rs
+++ b/runtime/functor-runtime-common/src/asset/asset_cache.rs
@@ -77,6 +77,18 @@ impl AssetCache {
         progress.failed.remove(path);
     }
 
+    /// Whether `path` was started but has not yet settled (loaded or failed)
+    /// — [`resolve_while_pending`]'s liveness check. A started load must
+    /// keep being polled to completion (futures advance only when polled),
+    /// or `Sub.assets`' settled gate (`loaded + failed == total`) never
+    /// fires.
+    pub fn is_unsettled(&self, path: &str) -> bool {
+        let progress = self.progress.lock().unwrap();
+        progress.started.contains(path)
+            && !progress.loaded.contains(path)
+            && !progress.failed.contains_key(path)
+    }
+
     pub fn load_asset_with_pipeline<T: 'static>(
         self: &Arc<Self>,
         pipeline: Arc<BuiltAssetPipeline<T>>,
@@ -163,6 +175,51 @@ impl AssetCache {
     }
 }
 
+/// The asset to RENDER for a primary that carries an `Asset.whilePending`
+/// chain: the primary when LOADED; while it is still loading, the first
+/// LOADED chain entry; otherwise the pipeline fallback. A FAILED primary
+/// falls back exactly like a chainless one — failure is not pending, and a
+/// placeholder must not mask it (`Sub.assets` still reports it).
+///
+/// Liveness contract: asset futures only advance when POLLED, and this is
+/// the only poll site for chain entries. So new entries are requested only
+/// while the primary is pending (a warm-cache primary never touches its
+/// placeholders), but every entry the cache has STARTED keeps being driven
+/// here until it settles — even once the primary (or an earlier entry) has
+/// landed, and even after a hot-reload eviction. An abandoned in-flight
+/// placeholder would otherwise sit in `Sub.assets`' `total` forever and
+/// hold the settled gate (`loaded + failed == total`) open.
+pub fn resolve_while_pending<T: 'static>(
+    cache: &Arc<AssetCache>,
+    pipeline: &Arc<super::BuiltAssetPipeline<T>>,
+    primary: &AssetHandle<T>,
+    while_pending: &[String],
+) -> Arc<T> {
+    if while_pending.is_empty() {
+        // The overwhelmingly common case: byte-identical to the old
+        // single-poll `get()` path.
+        return primary.get();
+    }
+    let primary_state = primary.poll_state();
+    let pending = matches!(primary_state, super::AssetPollState::Loading);
+    let mut stand_in: Option<Arc<T>> = None;
+    for locator in while_pending {
+        if pending || cache.is_unsettled(locator) {
+            let handle = cache.load_asset_with_pipeline(pipeline.clone(), locator);
+            if let super::AssetPollState::Loaded(asset) = handle.poll_state() {
+                if pending && stand_in.is_none() {
+                    stand_in = Some(asset);
+                }
+            }
+        }
+    }
+    match primary_state {
+        super::AssetPollState::Loaded(asset) => asset,
+        super::AssetPollState::Failed => primary.fallback(),
+        super::AssetPollState::Loading => stand_in.unwrap_or_else(|| primary.fallback()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -236,5 +293,112 @@ mod tests {
         assert_eq!((progress.loaded, progress.total), (1, 2));
 
         let _ = std::fs::remove_file(&good);
+    }
+
+    /// `Asset.whilePending` resolution: the first LOADED chain entry stands
+    /// in while the primary loads (failed entries skipped); a loaded primary
+    /// wins outright; a FAILED primary keeps the fallback (a placeholder
+    /// must not mask failure). Local reads settle on their first poll, so a
+    /// genuinely-pending primary is a hand-built never-resolving handle.
+    #[test]
+    fn while_pending_resolves_placeholders_only_while_loading() {
+        let cache = Arc::new(AssetCache::new());
+        let pipeline = super::super::build_pipeline(Box::new(BytesLen));
+
+        let pending_forever: AssetHandle<usize> = AssetHandle::new(
+            std::future::pending::<Result<Arc<usize>, String>>(),
+            Arc::new(0),
+        );
+        let placeholder = temp_file("wp-placeholder.bin", b"12");
+        let real = temp_file("wp-real.bin", b"1234567");
+
+        // Pending primary + a chain whose FIRST entry fails (missing file):
+        // the failed entry is skipped and the loaded one stands in. The
+        // resolve call itself requests the chain loads.
+        let chain = vec!["wp/does-not-exist.bin".to_string(), placeholder.clone()];
+        let shown = resolve_while_pending(&cache, &pipeline, &pending_forever, &chain);
+        assert_eq!(*shown, 2, "loaded placeholder (2 bytes) stands in");
+
+        // An empty chain on a pending primary keeps today's fallback.
+        let shown = resolve_while_pending(&cache, &pipeline, &pending_forever, &[]);
+        assert_eq!(*shown, 0, "no chain -> pipeline fallback");
+
+        // A loaded primary wins even with a loaded placeholder available.
+        let primary = cache.load_asset_with_pipeline(pipeline.clone(), &real);
+        settle(&primary);
+        let shown = resolve_while_pending(&cache, &pipeline, &primary, &chain);
+        assert_eq!(*shown, 7, "loaded primary wins");
+
+        // A FAILED primary falls back to the pipeline default (0), NOT the
+        // placeholder — failure is not pending, and must stay visible.
+        let failed = cache.load_asset_with_pipeline(pipeline.clone(), "wp/missing-primary.bin");
+        settle(&failed);
+        let shown = resolve_while_pending(&cache, &pipeline, &failed, &chain);
+        assert_eq!(*shown, 0, "failed primary keeps the fallback");
+
+        for f in [placeholder, real] {
+            let _ = std::fs::remove_file(&f);
+        }
+    }
+
+    /// Liveness: a STARTED chain entry keeps being driven to settled even
+    /// once the primary has landed — an abandoned placeholder would sit in
+    /// `Sub.assets`' total forever and hold the settled gate open. The
+    /// synchronously-testable strand is hot-reload eviction: evicting an
+    /// inactive placeholder leaves it started-but-not-loaded, and only the
+    /// resolve call re-drives it.
+    #[test]
+    fn while_pending_drives_started_entries_to_settled() {
+        let cache = Arc::new(AssetCache::new());
+        let pipeline = super::super::build_pipeline(Box::new(BytesLen));
+
+        let placeholder = temp_file("wp-live-placeholder.bin", b"12");
+        let real = temp_file("wp-live-real.bin", b"1234567");
+        let chain = vec![placeholder.clone()];
+
+        // Pending primary requests + settles the placeholder (sync read).
+        let pending_forever: AssetHandle<usize> = AssetHandle::new(
+            std::future::pending::<Result<Arc<usize>, String>>(),
+            Arc::new(0),
+        );
+        let _ = resolve_while_pending(&cache, &pipeline, &pending_forever, &chain);
+        let progress = cache.progress();
+        assert_eq!((progress.loaded, progress.total), (1, 1));
+
+        // The primary lands; hot reload then evicts the (now inactive)
+        // placeholder: started-but-unsettled — the strand.
+        let primary = cache.load_asset_with_pipeline(pipeline.clone(), &real);
+        settle(&primary);
+        cache.evict(&placeholder);
+        pipeline.evict(&placeholder);
+        assert!(cache.is_unsettled(&placeholder));
+        let progress = cache.progress();
+        assert_eq!((progress.loaded, progress.total), (1, 2), "placeholder pending again");
+
+        // The next resolve — primary LOADED, so no new placeholder is
+        // NEEDED for display — still re-drives the started entry, and the
+        // settled gate can fire again.
+        let shown = resolve_while_pending(&cache, &pipeline, &primary, &chain);
+        assert_eq!(*shown, 7, "primary still shown");
+        let progress = cache.progress();
+        assert_eq!(
+            (progress.loaded, progress.total),
+            (2, 2),
+            "started placeholder driven back to settled"
+        );
+        assert!(!cache.is_unsettled(&placeholder));
+
+        // An entry that was NEVER started is not requested once the primary
+        // is loaded (placeholders stay lazy).
+        let never = temp_file("wp-live-never.bin", b"123");
+        let shown =
+            resolve_while_pending(&cache, &pipeline, &primary, &[never.clone()]);
+        assert_eq!(*shown, 7);
+        let progress = cache.progress();
+        assert_eq!(progress.total, 2, "never-needed placeholder never counted");
+
+        for f in [placeholder, real, never] {
+            let _ = std::fs::remove_file(&f);
+        }
     }
 }

--- a/runtime/functor-runtime-common/src/asset/asset_handle.rs
+++ b/runtime/functor-runtime-common/src/asset/asset_handle.rs
@@ -19,6 +19,13 @@ impl<T> AssetHandle<T> {
         }
     }
 
+    /// The pipeline's stand-in for this asset, WITHOUT polling — for callers
+    /// that already called [`Self::poll_state`] this frame and must not
+    /// advance the future a second time.
+    pub fn fallback(&self) -> Arc<T> {
+        self.fallback_asset.clone()
+    }
+
     pub fn new<F>(future: F, fallback_asset: Arc<T>) -> AssetHandle<T>
     where
         F: Future<Output = Result<Arc<T>, String>> + 'static,

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -680,9 +680,14 @@ impl AssetKind {
 /// (the pre-manifest form, deprecated at B.6) and check the KIND, so a
 /// wrong-kind asset is a teaching error at the call instead of a silent
 /// fallback at draw.
+#[derive(Clone)]
 struct FunctorLangAsset {
     kind: AssetKind,
     path: String,
+    /// `Asset.whilePending` placeholder locators, tried in order while
+    /// `path` is still loading (empty for a plain locator). Same kind as
+    /// `path` by construction.
+    while_pending: Vec<String>,
 }
 
 impl HostData for FunctorLangAsset {
@@ -1164,9 +1169,10 @@ fn register_scene(reg: &mut crate::host_registry::Registry) {
 the game dir";
     reg.fn1("Scene.model", MODEL, |path: ModelPath| {
         FunctorLangScene(Scene3D::model(ModelDescription {
-            handle: ModelHandle::File(path.0),
+            handle: ModelHandle::File(path.path),
             overrides: Vec::new(),
             animation: None,
+            while_pending: path.while_pending,
         }))
     });
     // A subdivided XZ grid displaced by per-vertex heights — the Functor Lang
@@ -1843,6 +1849,7 @@ fn register_assets(reg: &mut crate::host_registry::Registry) {
             Value::String(p) if !p.is_empty() => Ok(FunctorLangAsset {
                 kind,
                 path: p.to_string(),
+                while_pending: Vec::new(),
             }),
             _ => Err(format!(
                 "usage: {path}(\"{}\") — a non-empty {} path relative to the game dir",
@@ -1866,6 +1873,72 @@ fn register_assets(reg: &mut crate::host_registry::Registry) {
         "Asset.sound(\"file.ogg\") — a non-empty sound path relative to the game dir",
         asset_ctor("Asset.sound", AssetKind::Sound),
     );
+    // Placeholder-LAST subject threading: `asset |> Asset.whilePending(ph)`.
+    // The placeholder renders while the asset streams in; it is just another
+    // asset, so it chains (a low-poly proxy can carry its own placeholder).
+    // Sounds are rejected: they decode at play time, outside the asset
+    // cache, so there is no pending state to render.
+    reg.fn2(
+        "Asset.whilePending",
+        "Asset.whilePending(placeholder, asset) — same-kind model or texture Asset values \
+(pipes: asset |> Asset.whilePending(placeholder))",
+        |placeholder: AssetArg, asset: AssetArg| -> Result<FunctorLangAsset, String> {
+            let (placeholder, asset) = (placeholder.0, asset.0);
+            if asset.kind == AssetKind::Sound || placeholder.kind == AssetKind::Sound {
+                return Err(
+                    "Asset.whilePending: sounds have no pending state to render (they \
+decode at play time, outside the asset cache) — whilePending applies to model and \
+texture assets"
+                        .to_string(),
+                );
+            }
+            if placeholder.kind != asset.kind {
+                return Err(format!(
+                    "Asset.whilePending: the placeholder must match the asset's kind — \
+got a {} placeholder for a {} asset; construct it with {}",
+                    placeholder.kind.noun(),
+                    asset.kind.noun(),
+                    asset.kind.constructor(),
+                ));
+            }
+            // The OUTER placeholder is tried first, then its own chain, then
+            // any chain the asset already carried.
+            let mut while_pending =
+                Vec::with_capacity(1 + placeholder.while_pending.len() + asset.while_pending.len());
+            while_pending.push(placeholder.path);
+            while_pending.extend(placeholder.while_pending);
+            while_pending.extend(asset.while_pending);
+            Ok(FunctorLangAsset {
+                kind: asset.kind,
+                path: asset.path,
+                while_pending,
+            })
+        },
+    );
+}
+
+/// A branded Asset argument at the registry seam (`Asset.whilePending`) —
+/// teaches the Angle rule for assets: bare strings must go through the
+/// `Asset.*` constructors first.
+struct AssetArg(FunctorLangAsset);
+
+impl crate::host_registry::FromArg for AssetArg {
+    fn from_arg(value: &Value, path: &str, span: Span) -> Result<Self, RunError> {
+        if let Some(asset) = asset_of(value) {
+            return Ok(AssetArg(asset.clone()));
+        }
+        let message = match value {
+            Value::String(s) => format!(
+                "{path}: expected an Asset value, got a bare string (\"{s}\") — construct \
+one with Asset.model/texture(…) first"
+            ),
+            other => format!(
+                "{path}: expected an Asset value (Asset.model/texture(…)), got {}",
+                other.kind_name()
+            ),
+        };
+        Err(RunError { message, span })
+    }
 }
 
 /// The Anim pose algebra — clip sampling, blending, the rest pose, additive
@@ -2006,15 +2079,29 @@ impl crate::host_registry::FromArg for FunctorLangColor {
 
 /// A model-asset argument: a non-empty path string, or an `Asset.model`
 /// locator (a wrong-kind asset gets `asset_path`'s teaching error) — the
-/// typed-manifest front door at the registry seam.
-struct ModelPath(String);
+/// typed-manifest front door at the registry seam. Carries the asset's
+/// `Asset.whilePending` chain (empty for the string form).
+struct ModelPath {
+    path: String,
+    while_pending: Vec<String>,
+}
 
 impl crate::host_registry::FromArg for ModelPath {
     fn from_arg(value: &Value, path: &str, span: Span) -> Result<Self, RunError> {
         match value {
-            Value::String(p) if !p.is_empty() => Ok(ModelPath(p.to_string())),
+            Value::String(p) if !p.is_empty() => Ok(ModelPath {
+                path: p.to_string(),
+                while_pending: Vec::new(),
+            }),
             v if asset_of(v).is_some() => {
-                asset_path(v, AssetKind::Model, path, span).map(ModelPath)
+                // asset_path enforces the KIND (teaching error); the chain
+                // rides along.
+                let locator = asset_path(v, AssetKind::Model, path, span)?;
+                let chain = asset_of(v).map(|a| a.while_pending.clone()).unwrap_or_default();
+                Ok(ModelPath {
+                    path: locator,
+                    while_pending: chain,
+                })
             }
             _ => Err(RunError {
                 message: "usage: Scene.model(\"file.glb\") — a non-empty glTF path \
@@ -3652,11 +3739,19 @@ fn texture_of(value: &Value, what: &str, span: Span) -> Result<TextureDescriptio
             if let Some(t) = data.as_any().downcast_ref::<FunctorLangTexture>() {
                 return Ok(t.0.clone());
             }
-            if asset_of(value).is_some() {
-                // A texture asset carries a file path; a wrong-kind asset is
-                // a teaching error from asset_path.
-                return asset_path(value, AssetKind::Texture, what, span)
-                    .map(TextureDescription::File);
+            if let Some(asset) = asset_of(value) {
+                // A texture asset carries a file path (and possibly an
+                // `Asset.whilePending` chain); a wrong-kind asset is a
+                // teaching error from asset_path.
+                let file = asset_path(value, AssetKind::Texture, what, span)?;
+                return Ok(if asset.while_pending.is_empty() {
+                    TextureDescription::File(file)
+                } else {
+                    TextureDescription::FileWhilePending {
+                        file,
+                        while_pending: asset.while_pending.clone(),
+                    }
+                });
             }
             Err(RunError {
                 message: format!("{what}: expected a Texture, got {}", value.kind_name()),
@@ -4208,13 +4303,102 @@ construct it with Asset.sound(…)",
     }
 
     /// An Asset is plain data (kind + path), so storing one in the model must
-    /// not invalidate hot-reload time-travel history.
+    /// not invalidate hot-reload time-travel history — with or without a
+    /// whilePending chain.
     #[test]
     fn assets_are_reload_safe_snapshots() {
-        let value = eval("let main = () => Asset.model(\"shark.glb\")");
-        match &value {
-            Value::HostData(data) => assert!(data.is_reload_safe_snapshot()),
-            other => panic!("expected a HostData asset, got {}", other.kind_name()),
+        for src in [
+            "let main = () => Asset.model(\"shark.glb\")",
+            "let main = () => Asset.model(\"shark.glb\") |> Asset.whilePending(Asset.model(\"box.glb\"))",
+        ] {
+            let value = eval(src);
+            match &value {
+                Value::HostData(data) => assert!(data.is_reload_safe_snapshot()),
+                other => panic!("expected a HostData asset, got {}", other.kind_name()),
+            }
+        }
+    }
+
+    // --- Asset.whilePending (Track B.4) ---
+
+    /// The chain reaches the protocol: `Scene.model` carries `while_pending`,
+    /// and nested placeholders flatten OUTER-first (the last-applied
+    /// placeholder is tried first, then its own chain, then the asset's).
+    #[test]
+    fn while_pending_chains_flatten_into_the_model_description() {
+        let camera = "Camera.lookAt(Vec3.make(0.0, 1.0, -3.0), Vec3.make(0.0, 0.0, 0.0))";
+        let frame = frame_of(&format!(
+            "let proxy = Asset.model(\"low.glb\") |> Asset.whilePending(Asset.model(\"cube.glb\"))\n\
+             let boss = Asset.model(\"boss.glb\") |> Asset.whilePending(proxy)\n\
+             let main = () => Frame.create({camera}, Scene.model(boss))"
+        ));
+        let json = serde_json::to_string(&frame).expect("serialize");
+        assert!(
+            json.contains("\"while_pending\":[\"low.glb\",\"cube.glb\"]"),
+            "json: {json}"
+        );
+        assert!(json.contains("boss.glb"), "json: {json}");
+        // And it round-trips through the protocol.
+        let back: Frame = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(serde_json::to_string(&back).unwrap(), json);
+    }
+
+    /// A chainless model keeps the exact pre-B.4 wire shape (no
+    /// `while_pending` key at all) — replays and cross-version scenes agree.
+    #[test]
+    fn chainless_models_keep_the_old_wire_shape() {
+        let camera = "Camera.lookAt(Vec3.make(0.0, 1.0, -3.0), Vec3.make(0.0, 0.0, 0.0))";
+        let frame = frame_of(&format!(
+            "let main = () => Frame.create({camera}, Scene.model(\"shark.glb\"))"
+        ));
+        let json = serde_json::to_string(&frame).expect("serialize");
+        assert!(!json.contains("while_pending"), "json: {json}");
+    }
+
+    /// Texture chains produce the `FileWhilePending` description; chainless
+    /// texture assets keep the plain `File` shape.
+    #[test]
+    fn while_pending_textures_flow_into_materials() {
+        let camera = "Camera.lookAt(Vec3.make(0.0, 1.0, -3.0), Vec3.make(0.0, 0.0, 0.0))";
+        let frame = frame_of(&format!(
+            "let wood = Asset.texture(\"wood.png\") |> Asset.whilePending(Asset.texture(\"grey.png\"))\n\
+             let main = () => Frame.create({camera}, Scene.plane() |> Scene.litTexture(wood))"
+        ));
+        let json = serde_json::to_string(&frame).expect("serialize");
+        assert!(
+            json.contains("FileWhilePending") && json.contains("grey.png"),
+            "json: {json}"
+        );
+        let frame = frame_of(&format!(
+            "let main = () => Frame.create({camera}, \
+Scene.plane() |> Scene.litTexture(Asset.texture(\"wood.png\")))"
+        ));
+        let json = serde_json::to_string(&frame).expect("serialize");
+        assert!(!json.contains("FileWhilePending"), "json: {json}");
+    }
+
+    /// whilePending teaches: sounds have no pending state, kinds must match,
+    /// and bare strings must construct an Asset first.
+    #[test]
+    fn while_pending_teaching_errors() {
+        for (src, want) in [
+            (
+                "let main = () => Asset.sound(\"a.ogg\") |> Asset.whilePending(Asset.sound(\"b.ogg\"))",
+                "Asset.whilePending: sounds have no pending state to render (they decode at \
+play time, outside the asset cache) — whilePending applies to model and texture assets",
+            ),
+            (
+                "let main = () => Asset.model(\"a.glb\") |> Asset.whilePending(Asset.texture(\"b.png\"))",
+                "Asset.whilePending: the placeholder must match the asset's kind — got a \
+texture placeholder for a model asset; construct it with Asset.model(…)",
+            ),
+            (
+                "let main = () => Asset.model(\"a.glb\") |> Asset.whilePending(\"b.glb\")",
+                "Asset.whilePending: expected an Asset value, got a bare string (\"b.glb\") \
+— construct one with Asset.model/texture(…) first",
+            ),
+        ] {
+            assert_eq!(fail_message(src), want, "for {src}");
         }
     }
 

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -65,7 +65,12 @@
 /// of any type enumerated in this module changes incompatibly. Informational
 /// for now — nothing transmits or checks it; [`GameProducer`] impls all speak
 /// the current version.
-pub const PROTOCOL_VERSION: u32 = 1;
+///
+/// v2: `Asset.whilePending` — `ModelDescription.while_pending` (defaulted,
+/// omitted when empty, so v1 frames read back and chainless frames stay v1-
+/// shaped) and the `TextureDescription::FileWhilePending` variant (a v1
+/// reader cannot decode a frame carrying one).
+pub const PROTOCOL_VERSION: u32 = 2;
 
 /// The producer side of the protocol: one game logic instance as consumed by a
 /// runtime shell's frame loop. Every method carries a payload enumerated in
@@ -370,6 +375,7 @@ mod tests {
                     handle: ModelHandle::File("barrel.glb".to_string()),
                     overrides: vec![],
                     animation: None,
+                    while_pending: vec![],
                 }),
                 // A monitor: samples the "feed" render target declared below.
                 Scene3D {
@@ -435,6 +441,54 @@ mod tests {
         assert_wire(
             &RenderTargetDescriptor::new("feed"),
             r#"{"id":"feed","width":512,"height":512}"#,
+        );
+    }
+
+    // The `Asset.whilePending` wire vocabulary (protocol v2): the model
+    // chain field is OMITTED when empty (chainless frames keep the v1
+    // shape), and chained textures use the FileWhilePending variant.
+    #[test]
+    fn while_pending_wire_is_pinned() {
+        use crate::scene3d::{ModelDescription, ModelHandle};
+        use crate::TextureDescription;
+
+        // ModelDescription has no PartialEq (matrix overrides), so pin the
+        // JSON text and round-trip by re-serialization instead.
+        let pin_model = |model: &ModelDescription, expected: &str| {
+            let json = serde_json::to_string(model).expect("serialize");
+            assert_eq!(json, expected);
+            let back: ModelDescription = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(serde_json::to_string(&back).unwrap(), json);
+        };
+        let chainless = ModelDescription {
+            handle: ModelHandle::File("boss.glb".to_string()),
+            overrides: vec![],
+            animation: None,
+            while_pending: vec![],
+        };
+        pin_model(
+            &chainless,
+            r#"{"handle":{"File":"boss.glb"},"overrides":[],"animation":null}"#,
+        );
+        let chained = ModelDescription {
+            while_pending: vec!["low.glb".to_string(), "cube.glb".to_string()],
+            ..chainless
+        };
+        pin_model(
+            &chained,
+            r#"{"handle":{"File":"boss.glb"},"overrides":[],"animation":null,"while_pending":["low.glb","cube.glb"]}"#,
+        );
+
+        assert_wire(
+            &TextureDescription::File("wood.png".to_string()),
+            r#"{"File":"wood.png"}"#,
+        );
+        assert_wire(
+            &TextureDescription::FileWhilePending {
+                file: "wood.png".to_string(),
+                while_pending: vec!["grey.png".to_string()],
+            },
+            r#"{"FileWhilePending":{"file":"wood.png","while_pending":["grey.png"]}}"#,
         );
     }
 

--- a/runtime/functor-runtime-common/src/scene3d/material_description.rs
+++ b/runtime/functor-runtime-common/src/scene3d/material_description.rs
@@ -176,6 +176,24 @@ fn bind_texture_description(
                 .load_asset_with_pipeline(scene_context.texture_pipeline.clone(), file);
             asset.get().bind(unit, context);
         }
+        // `Asset.whilePending`: the first loaded chain entry binds while the
+        // primary streams in (instead of the checkerboard fallback); a FAILED
+        // primary keeps the fallback — failure is not pending.
+        TextureDescription::FileWhilePending {
+            file,
+            while_pending,
+        } => {
+            let asset = context
+                .asset_cache
+                .load_asset_with_pipeline(scene_context.texture_pipeline.clone(), file);
+            crate::asset::resolve_while_pending(
+                &context.asset_cache,
+                &scene_context.texture_pipeline,
+                &asset,
+                while_pending,
+            )
+            .bind(unit, context);
+        }
         TextureDescription::RenderTarget(id) => {
             // Select the unit BEFORE any lazy fallback creation: creating the
             // fallback binds/unbinds TEXTURE_2D on the active unit, which would

--- a/runtime/functor-runtime-common/src/scene3d/mod.rs
+++ b/runtime/functor-runtime-common/src/scene3d/mod.rs
@@ -678,7 +678,16 @@ impl Scene3D {
                             .asset_cache
                             .load_asset_with_pipeline(scene_context.model_pipeline.clone(), str);
 
-                        let hydrated_model = model.get();
+                        // While the primary streams in, an `Asset.whilePending`
+                        // chain renders its first loaded placeholder instead of
+                        // the empty fallback (chainless models resolve exactly
+                        // like the old `get()`).
+                        let hydrated_model = crate::asset::resolve_while_pending(
+                            &render_context.asset_cache,
+                            &scene_context.model_pipeline,
+                            &model,
+                            &model_description.while_pending,
+                        );
 
                         let matrix = world_matrix * self.xform;
 

--- a/runtime/functor-runtime-common/src/scene3d/model_description.rs
+++ b/runtime/functor-runtime-common/src/scene3d/model_description.rs
@@ -40,4 +40,11 @@ pub struct ModelDescription {
     /// clock.
     #[serde(default)]
     pub animation: Option<AnimExpr>,
+    /// Placeholder model locators tried in order WHILE `handle` is still
+    /// loading (`Asset.whilePending`): the first loaded entry renders until
+    /// the primary is ready. A FAILED primary renders the empty fallback
+    /// like before — failure is not pending, and must stay visible. Skipped
+    /// on the wire when empty, so plain models keep their JSON shape.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub while_pending: Vec<String>,
 }

--- a/runtime/functor-runtime-common/src/scene3d/texture_description.rs
+++ b/runtime/functor-runtime-common/src/scene3d/texture_description.rs
@@ -13,6 +13,15 @@ pub enum TextureDescription {
     /// same UVs show a file texture and a render target flipped relative to
     /// each other.
     RenderTarget(String),
+    /// A file texture with placeholder fallbacks tried WHILE IT LOADS
+    /// (`Asset.whilePending`): the first loaded chain entry binds until
+    /// `file` itself is ready; a FAILED `file` falls back like a plain
+    /// `File` (failure is not pending — it must stay visible). Emitted only
+    /// when a chain exists, so plain textures keep the `File` wire shape.
+    FileWhilePending {
+        file: String,
+        while_pending: Vec<String>,
+    },
 }
 
 impl TextureDescription {

--- a/runtime/functor-runtime-common/tests/prelude_typecheck.rs
+++ b/runtime/functor-runtime-common/tests/prelude_typecheck.rs
@@ -96,3 +96,17 @@ fn asset_consumers_accept_both_forms() {
     );
     assert!(diags.is_empty(), "both forms should check clean: {diags:?}");
 }
+
+/// `Asset.whilePending` is gradually typed but ties its result to the asset
+/// argument, so a chained locator still flows into `Scene.model` cleanly.
+#[test]
+fn while_pending_checks_clean_in_both_positions() {
+    let diags = check(
+        "let proxy = Asset.model(\"low.glb\")\n\
+         let boss = Asset.model(\"boss.glb\") |> Asset.whilePending(proxy)\n\
+         let scene = Scene.model(boss)\n\
+         let tex = Asset.texture(\"wood.png\") |> Asset.whilePending(Asset.texture(\"grey.png\"))\n\
+         let mat = Scene.plane() |> Scene.litTexture(tex)",
+    );
+    assert!(diags.is_empty(), "whilePending should check clean: {diags:?}");
+}


### PR DESCRIPTION
Track B.4 (follows #384, #387, #391, #397): the placeholder combinator from the design's §2c — the LOD-zero pattern with no new concepts.

```functor
let shark =
  Asset.model("https://…/shark.glb")                       // 15MB, streams for a while
    |> Asset.whilePending(Asset.model("https://…/box.glb")) // 2KB, on screen in one frame
```

The placeholder renders instead of the empty/checkerboard fallback while the asset loads. It is just another SAME-KIND asset, so it **chains** (a low-poly proxy can carry its own placeholder; outer placeholder tried first, then its chain, then the asset's). `examples/loading` now demos it live — the box stands in at the shark's transform until the shark lands (GIF below).

## Demo

![Asset.whilePending: box placeholder then shark](https://gist.githubusercontent.com/tommy-xr/87ecdb59d75ffa18877e600a08250305/raw/demo.gif)

<sub>`examples/loading` under `FUNCTOR_THROTTLE_ASSETS=600` (warm disk cache, so the timeline is reproducible): the 2KB box stands in at the shark's transform while the 15MB shark streams, then the real model takes over at t≈26s. Captured headlessly via `--capture-frame`.</sub>

| placeholder standing in (t≈15s) | shark landed (t≈31s) |
|---|---|
| ![placeholder](https://gist.githubusercontent.com/tommy-xr/87ecdb59d75ffa18877e600a08250305/raw/wp-early.png) | ![loaded](https://gist.githubusercontent.com/tommy-xr/87ecdb59d75ffa18877e600a08250305/raw/wp-late.png) |

## How it works

- **Resolution at the shell's substitution point** (`asset::resolve_while_pending`, shared native+wasm render path): primary when LOADED; while Loading, the first loaded chain entry; a FAILED primary keeps the fallback — **failure is not pending**, must stay visible, and still counts in `Sub.assets`. The render sites move from `AssetHandle::get()` (which collapses Loading/Failed) to `poll_state()`; chainless assets take a fast path byte-identical to the old `get()`.
- **Liveness contract** (the [AGREED] review catch, below): chain entries are *requested* only while the primary is pending (a warm-cache primary never touches its placeholders), but every entry the cache has STARTED keeps being polled here until it settles — even after the primary lands, and even across a hot-reload eviction. Asset futures only advance when polled; an abandoned in-flight placeholder would otherwise sit in `Sub.assets`' `total` forever and hold the settled gate open (a hung loading screen).
- **Protocol v2**: `ModelDescription.while_pending` (defaulted, omitted when empty) + `TextureDescription::FileWhilePending` (emitted only with a chain) — chainless frames keep byte-identical v1 wire shapes, pinned by new tests. Sounds are rejected with a teaching error (they decode at play time, outside the asset cache — no pending state). `whilePendingColor` is consciously deferred: it needs a solid-color texture protocol variant and is ill-defined for models; it rides the future `Texture.raw`/Bytes work.
- funi: `whilePending : ('placeholder, 'asset) => 'asset` — gradually typed, result tied to the asset argument so chains flow into `Scene.model`/`litTexture` cleanly; registered via the typed registry; skill updated in this PR.

## Perf (frame_bench, release, 2× per side, min column)

| grid | main us/frame(min) | B.4 | allocs/frame | bytes/frame |
|---|---|---|---|---|
| 20×20 | 640.3 / 686.7 | 624.9 / 686.6 | 13877 → **13877** | 840043 → 842251 |
| 40×40 | 2700.3 / 2723.3 | 2436.9 / 2707.0 | 54717 → **54717** | 3303883 → 3306091 |
| 56×56 | 5367.2 / 5307.2 | 4915.9 / 4981.9 | 106973 → **106973** | 6456907 → 6459115 |

Allocs/frame **identical**; bytes/frame **+2208 flat at every size** — the 24-byte `Vec` field on `ModelDescription` times the per-frame scene clones, no new allocations; wall-clock within run-to-run spread.

## Verification

- Resolution unit tests over a fake pipeline: placeholder-while-loading (incl. failed-entry skip), loaded primary wins, failed primary keeps the fallback, empty chain ≡ `get()`, and the **liveness regression** — an evicted inactive placeholder is driven back to settled and never-needed entries stay uncounted.
- Prelude tests: chain flattening into the protocol + round-trip, chainless wire shape unchanged, teaching errors (sound / kind mismatch / bare string), reload-safety with chains. Wire-shape pins for v1 and v2 forms. Typecheck test. Golden images 0-diff. All examples build.
- Live throttled captures (`FUNCTOR_THROTTLE_ASSETS=600`, cold cache): box placeholder at the shark's transform at t≈7s, real shark at rest.

## xreview disposition (two-engine review: Claude + Codex)

- **[AGREED, Medium] stranded placeholders could hang `Sub.assets`' settled gate** — both engines independently derived that superseded (Claude) and hot-reload-evicted (Codex) chain entries stop being polled while staying in `total`. **Fixed** with the started-but-unsettled driving rule + regression test.
- **[AGREED, Low]** chainless double-poll vs old `get()` — **fixed** (fast path + a no-poll `fallback()` accessor). **Codex Low** `PROTOCOL_VERSION` unbumped despite a new enum variant — **fixed** (v2 + exact JSON pins). **Claude Low** triple `asset_of` in `ModelPath` — **fixed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
