### PR TITLE
feat(vscode): platform VSIXes with the bundled language server, published on release

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -41,23 +41,32 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # lsp_target: linux ships the language server as a static musl
+          # build — it runs inside any VS Code install (glibc floor 2.28,
+          # older than the ubuntu-latest toolchain links against), and the
+          # crate is pure Rust so musl costs nothing. The GL-linked `functor`
+          # binary itself stays gnu.
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             bin: functor
             lsp_bin: functor-lang-lsp
+            lsp_target: x86_64-unknown-linux-musl
           - os: macos-14 # Apple Silicon (native)
             target: aarch64-apple-darwin
             bin: functor
             lsp_bin: functor-lang-lsp
+            lsp_target: aarch64-apple-darwin
           - os: macos-14 # Intel, cross-compiled on the arm64 runner
             target: x86_64-apple-darwin
             bin: functor
             lsp_bin: functor-lang-lsp
+            lsp_target: x86_64-apple-darwin
             cross: true
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             bin: functor.exe
             lsp_bin: functor-lang-lsp.exe
+            lsp_target: x86_64-pc-windows-msvc
 
     steps:
       - uses: actions/checkout@v6
@@ -68,7 +77,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: wasm32-unknown-unknown,${{ matrix.target }}
+          targets: wasm32-unknown-unknown,${{ matrix.target }},${{ matrix.lsp_target }}
 
       - name: Install wasm-pack
         run: npm install -g wasm-pack
@@ -168,11 +177,21 @@ jobs:
       # pattern. (No exec sanity check: it's a blocking stdio server with no
       # --version; the VSIX e2e path covers it.)
       - name: Build language server
-        run: cargo build --bin functor-lang-lsp --release --target ${{ matrix.target }}
+        shell: bash
+        run: |
+          cargo build --bin functor-lang-lsp --release --target ${{ matrix.lsp_target }}
+          # The musl build must actually be static — it has to run on any
+          # glibc a supported VS Code install may have.
+          if [[ "${{ matrix.lsp_target }}" == *-musl ]]; then
+            file "target/${{ matrix.lsp_target }}/release/functor-lang-lsp" | grep -qi "static"
+          fi
 
+      # Artifact name stays keyed by the PLATFORM (matrix.target) — the vsix
+      # job maps platforms to vsce targets and doesn't care which triple the
+      # server was compiled for.
       - name: Upload language server
         uses: actions/upload-artifact@v4
         with:
           name: lsp-${{ matrix.target }}
-          path: target/${{ matrix.target }}/release/${{ matrix.lsp_bin }}
+          path: target/${{ matrix.lsp_target }}/release/${{ matrix.lsp_bin }}
           retention-days: 14

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -44,16 +44,20 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             bin: functor
+            lsp_bin: functor-lang-lsp
           - os: macos-14 # Apple Silicon (native)
             target: aarch64-apple-darwin
             bin: functor
+            lsp_bin: functor-lang-lsp
           - os: macos-14 # Intel, cross-compiled on the arm64 runner
             target: x86_64-apple-darwin
             bin: functor
+            lsp_bin: functor-lang-lsp
             cross: true
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             bin: functor.exe
+            lsp_bin: functor-lang-lsp.exe
 
     steps:
       - uses: actions/checkout@v6
@@ -155,4 +159,20 @@ jobs:
         with:
           name: functor-${{ matrix.target }}
           path: ${{ env.ASSET }}
+          retention-days: 14
+
+      # The language server ships inside the platform VSIXes (the vsix job in
+      # release.yml). A tiny pure-Rust crate, so the warm toolchain/cache make
+      # this nearly free. Artifact names deliberately do NOT start with
+      # "functor-" — the publish job downloads the release archives by that
+      # pattern. (No exec sanity check: it's a blocking stdio server with no
+      # --version; the VSIX e2e path covers it.)
+      - name: Build language server
+        run: cargo build --bin functor-lang-lsp --release --target ${{ matrix.target }}
+
+      - name: Upload language server
+        uses: actions/upload-artifact@v4
+        with:
+          name: lsp-${{ matrix.target }}
+          path: target/${{ matrix.target }}/release/${{ matrix.lsp_bin }}
           retention-days: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,17 @@ name: Release
 #   1. resolves + validates the version and that the tag vX.Y.Z is free
 #   2. generates release notes from the conventional commits since the last
 #      release tag (git-cliff, config in cliff.toml)
-#   3. builds + sanity-checks the `functor` binary for every supported
-#      platform (release-binaries.yml, reused via workflow_call)
-#   4. creates the vX.Y.Z tag and a PRE-RELEASE GitHub release (Functor is
-#      alpha) with the notes and all platform archives attached
-#   5. dispatches Deploy Site, so the deployed site header picks up the new
+#   3. builds + sanity-checks the `functor` binary (and the functor-lang-lsp
+#      language server) for every supported platform (release-binaries.yml,
+#      reused via workflow_call)
+#   4. packages a platform VS Code extension VSIX per target with the
+#      language server bundled and the release version injected
+#   5. creates the vX.Y.Z tag and a PRE-RELEASE GitHub release (Functor is
+#      alpha) with the notes, platform archives, and VSIXes attached
+#   6. publishes the VSIXes to the VS Code Marketplace and Open VSX — each
+#      gated on its PAT secret (VSCE_PAT / OVSX_PAT), skipped with a notice
+#      when the secret isn't configured
+#   7. dispatches Deploy Site, so the deployed site header picks up the new
 #      tag (a GITHUB_TOKEN-created tag does not fire push-triggered workflows
 #      on its own — explicit workflow_dispatch is the sanctioned exception)
 #
@@ -100,8 +106,69 @@ jobs:
     with:
       version: ${{ needs.prepare.outputs.version }}
 
-  publish:
+  # One VSIX per platform, each bundling that platform's language server.
+  # vsce's --target makes the Marketplace serve the right one automatically;
+  # release-page installs pick the file matching their platform.
+  vsix:
     needs: [prepare, binaries]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      VERSION: ${{ needs.prepare.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      # Each lsp-<target> artifact lands in its own subdir of lsp/.
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: lsp-*
+          path: lsp
+
+      # Root deps too: the extension's vscode:prepublish hook runs the repo's
+      # icon generator (scripts/generate-icons.mjs).
+      - name: Install npm dependencies
+        run: |
+          npm ci
+          npm ci --prefix tools/functor-lang-vscode
+
+      - name: Package platform VSIXes
+        working-directory: tools/functor-lang-vscode
+        run: |
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
+          mkdir -p out
+          for pair in \
+            x86_64-unknown-linux-gnu:linux-x64 \
+            aarch64-apple-darwin:darwin-arm64 \
+            x86_64-apple-darwin:darwin-x64 \
+            x86_64-pc-windows-msvc:win32-x64; do
+            target="${pair%%:*}"
+            vt="${pair##*:}"
+            rm -rf server && mkdir server
+            if [[ "$vt" == win32-x64 ]]; then
+              cp "$GITHUB_WORKSPACE/lsp/lsp-$target/functor-lang-lsp.exe" server/
+            else
+              # download-artifact does not preserve the exec bit; vsce records
+              # file modes into the VSIX, so restore it before packaging.
+              cp "$GITHUB_WORKSPACE/lsp/lsp-$target/functor-lang-lsp" server/
+              chmod +x server/functor-lang-lsp
+            fi
+            npx --yes @vscode/vsce@3.9.2 package --target "$vt" --pre-release \
+              --out "out/functor-lang-$VERSION-$vt.vsix"
+          done
+          ls -l out
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: vsix-bundles
+          path: tools/functor-lang-vscode/out/*.vsix
+          retention-days: 14
+
+  publish:
+    needs: [prepare, binaries, vsix]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -111,12 +178,22 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # Flattens every artifact (release-notes + the per-platform archives
-      # from release-binaries.yml) into assets/.
+      # Only what gets attached to the release lands in assets/: the platform
+      # archives (functor-*), the notes, and the VSIXes — NOT the raw lsp-*
+      # binaries (whose identical filenames would also collide when merged).
       - uses: actions/download-artifact@v4
         with:
+          pattern: functor-*
           path: assets
           merge-multiple: true
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-notes
+          path: assets
+      - uses: actions/download-artifact@v4
+        with:
+          name: vsix-bundles
+          path: assets
 
       # The tag is created + pushed explicitly, then the release attaches to
       # it: `gh release create --target <sha>` is rejected with a 403 for the
@@ -136,7 +213,53 @@ jobs:
             --title "v$VERSION" \
             --prerelease \
             --notes-file assets/release-notes.md \
-            assets/functor-*.tar.gz assets/functor-*.zip
+            assets/functor-*.tar.gz assets/functor-*.zip assets/*.vsix
+
+  # Marketplace publishes are gated on their PATs. Secrets are not readable in
+  # a job-level `if:`, so each job checks the env inside the step and skips
+  # with a notice when unconfigured — a missing publisher account must never
+  # fail the release (the VSIXes are on the release page regardless).
+  publish-marketplace:
+    needs: publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: vsix-bundles
+          path: vsix
+      - name: Publish to the VS Code Marketplace
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: |
+          if [[ -z "$VSCE_PAT" ]]; then
+            echo "::notice::VSCE_PAT is not configured — skipping the VS Code Marketplace publish"
+            exit 0
+          fi
+          for f in vsix/*.vsix; do
+            npx --yes @vscode/vsce@3.9.2 publish --pre-release --packagePath "$f" -p "$VSCE_PAT"
+          done
+
+  publish-openvsx:
+    needs: publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: vsix-bundles
+          path: vsix
+      - name: Publish to Open VSX
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+        run: |
+          if [[ -z "$OVSX_PAT" ]]; then
+            echo "::notice::OVSX_PAT is not configured — skipping the Open VSX publish"
+            exit 0
+          fi
+          for f in vsix/*.vsix; do
+            npx --yes ovsx@1.0.2 publish --pre-release --packagePath "$f" -p "$OVSX_PAT"
+          done
 
   # A separate job so a failed dispatch can be rerun without tripping over
   # the already-created release in `publish`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,7 +237,8 @@ jobs:
             exit 0
           fi
           for f in vsix/*.vsix; do
-            npx --yes @vscode/vsce@3.9.2 publish --pre-release --packagePath "$f" -p "$VSCE_PAT"
+            npx --yes @vscode/vsce@3.9.2 publish --pre-release --skip-duplicate \
+              --packagePath "$f" -p "$VSCE_PAT"
           done
 
   publish-openvsx:
@@ -258,7 +259,8 @@ jobs:
             exit 0
           fi
           for f in vsix/*.vsix; do
-            npx --yes ovsx@1.0.2 publish --pre-release --packagePath "$f" -p "$OVSX_PAT"
+            npx --yes ovsx@1.0.2 publish --pre-release --skip-duplicate \
+              --packagePath "$f" -p "$OVSX_PAT"
           done
 
   # A separate job so a failed dispatch can be rerun without tripping over

--- a/tools/functor-lang-vscode/.vscodeignore
+++ b/tools/functor-lang-vscode/.vscodeignore
@@ -3,4 +3,5 @@
 test/**
 tests-integration/**
 client/*.test.js
-*.vsix
+out/**
+**/*.vsix

--- a/tools/functor-lang-vscode/.vscodeignore
+++ b/tools/functor-lang-vscode/.vscodeignore
@@ -1,0 +1,6 @@
+# Kept out of the packaged VSIX (server/ — the bundled LSP binary staged by
+# the release pipeline — ships; everything else is dev-only).
+test/**
+tests-integration/**
+client/*.test.js
+*.vsix

--- a/tools/functor-lang-vscode/README.md
+++ b/tools/functor-lang-vscode/README.md
@@ -15,18 +15,21 @@ Language support for `.fun` source files and `.funi` interface files
   "Functor Lang Preview" output channel). Needs the `functor` CLI on PATH (or point
   the `functor-lang.functorPath` setting at the binary).
 
-## Prerequisite: `functor-lang-lsp` on PATH
+## The `functor-lang-lsp` language server
 
-The extension launches the `functor-lang-lsp` **binary from your PATH** — it is not
-bundled. Build and install it from the repo root:
+Resolution order (see `client/server-path.js`): the `functor-lang.serverPath`
+setting if set, else the binary **bundled inside the platform VSIX** (released
+builds ship one per platform under `server/`), else **PATH**. A dev checkout
+packaged locally has no bundled binary, so build and install the server from
+the repo root:
 
 ```sh
 cargo install --path tools/functor-lang-lsp
 # or: cargo build -p functor-lang-lsp && ln -s "$PWD/target/debug/functor-lang-lsp" ~/.local/bin/
 ```
 
-Without it, highlighting still works but diagnostics are silently absent
-(VSCode reports the failed server launch in the Output panel).
+Without a resolvable server, highlighting still works but diagnostics are
+silently absent (VSCode reports the failed server launch in the Output panel).
 
 ## Install
 

--- a/tools/functor-lang-vscode/client/extension.js
+++ b/tools/functor-lang-vscode/client/extension.js
@@ -1,5 +1,6 @@
 // Functor Lang extension entry point: an LSP client for `.fun` documents (launching
-// the `functor-lang-lsp` binary from PATH — see ../README.md for how to get it there)
+// the `functor-lang-lsp` binary — bundled in platform VSIXes, from PATH in dev
+// checkouts; see ./server-path.js)
 // and the live game preview panel (docs/functor-lang.md D4). Plain JS on purpose — no
 // bundler or TS build step; the only runtime dependency is
 // vscode-languageclient.
@@ -14,6 +15,7 @@ const { LanguageClient } = require("vscode-languageclient/node");
 // `node --test` (client/inspector.test.js) — extension.js keeps only the thin
 // VS Code wiring around it.
 const inspector = require("./inspector.js");
+const { resolveServerCommand } = require("./server-path.js");
 
 let client;
 // Resolves once the LanguageClient has started (server launched + initialized).
@@ -63,11 +65,19 @@ function activate(context) {
   channel = vscode.window.createOutputChannel("Functor Lang");
   context.subscriptions.push(channel);
   elog("extension activated");
+  // Setting > bundled platform binary > PATH; stdio is the
+  // vscode-languageclient default.
+  const serverCommand = resolveServerCommand(
+    vscode.workspace.getConfiguration("functor-lang").get("serverPath"),
+    context.extensionPath,
+    process.platform,
+    fs.existsSync
+  );
+  elog(`language server command: ${serverCommand}`);
   client = new LanguageClient(
     "functor-lang",
     "Functor Lang Language Server",
-    // Resolved from PATH; stdio is the vscode-languageclient default.
-    { command: "functor-lang-lsp" },
+    { command: serverCommand },
     { documentSelector: [{ language: "functor-lang" }] }
   );
   // --- Recency gutter (inspector coverage) --------------------------------

--- a/tools/functor-lang-vscode/client/server-path.js
+++ b/tools/functor-lang-vscode/client/server-path.js
@@ -1,0 +1,23 @@
+// Resolve the command used to launch the functor-lang-lsp language server:
+//
+//   1. the `functor-lang.serverPath` setting, when set — explicit always wins
+//   2. the binary bundled inside a platform-specific VSIX
+//      (server/functor-lang-lsp[.exe], staged by the release pipeline)
+//   3. bare "functor-lang-lsp", resolved from PATH (dev checkouts — see
+//      ../README.md for how to get it there)
+//
+// Pure decision logic with fs injected, node-tested like inspector.js.
+const path = require("path");
+
+function resolveServerCommand(configured, extensionPath, platform, existsSync) {
+  if (configured) return configured;
+  const bundled = path.join(
+    extensionPath,
+    "server",
+    platform === "win32" ? "functor-lang-lsp.exe" : "functor-lang-lsp"
+  );
+  if (existsSync(bundled)) return bundled;
+  return "functor-lang-lsp";
+}
+
+module.exports = { resolveServerCommand };

--- a/tools/functor-lang-vscode/client/server-path.test.js
+++ b/tools/functor-lang-vscode/client/server-path.test.js
@@ -1,0 +1,33 @@
+const { test } = require("node:test");
+const assert = require("node:assert");
+const path = require("path");
+const { resolveServerCommand } = require("./server-path");
+
+const EXT = path.join("/ext", "root");
+const bundledUnix = path.join(EXT, "server", "functor-lang-lsp");
+const bundledWin = path.join(EXT, "server", "functor-lang-lsp.exe");
+
+test("an explicit setting always wins", () => {
+  const cmd = resolveServerCommand("/opt/lsp/functor-lang-lsp", EXT, "darwin", () => true);
+  assert.strictEqual(cmd, "/opt/lsp/functor-lang-lsp");
+});
+
+test("the bundled binary is preferred when present", () => {
+  const cmd = resolveServerCommand(undefined, EXT, "darwin", (p) => p === bundledUnix);
+  assert.strictEqual(cmd, bundledUnix);
+});
+
+test("windows looks for the .exe", () => {
+  const cmd = resolveServerCommand(undefined, EXT, "win32", (p) => p === bundledWin);
+  assert.strictEqual(cmd, bundledWin);
+});
+
+test("no setting and no bundle falls back to PATH", () => {
+  const cmd = resolveServerCommand(undefined, EXT, "linux", () => false);
+  assert.strictEqual(cmd, "functor-lang-lsp");
+});
+
+test("an empty setting is treated as unset", () => {
+  const cmd = resolveServerCommand("", EXT, "linux", () => false);
+  assert.strictEqual(cmd, "functor-lang-lsp");
+});

--- a/tools/functor-lang-vscode/package.json
+++ b/tools/functor-lang-vscode/package.json
@@ -50,6 +50,11 @@
           "type": "string",
           "default": "functor",
           "description": "Path to the `functor` CLI binary the live preview uses to serve the game (resolved from PATH by default)."
+        },
+        "functor-lang.serverPath": {
+          "type": "string",
+          "default": "",
+          "description": "Path to the `functor-lang-lsp` language server binary. Empty (the default) uses the binary bundled with the extension, falling back to PATH."
         }
       }
     },
@@ -80,7 +85,7 @@
     ]
   },
   "scripts": {
-    "test": "node --test client/inspector.test.js",
+    "test": "node --test client/inspector.test.js client/server-path.test.js",
     "test:e2e": "playwright test -c tests-integration/playwright.config.mjs",
     "vscode:prepublish": "node ../../scripts/generate-icons.mjs",
     "package:vsix": "npx --yes @vscode/vsce@3.9.2 package --out functor-lang-vscode.vsix",


### PR DESCRIPTION
The VS Code extension joins the release train: each release now ships one VSIX per platform (`linux-x64`, `darwin-arm64`, `darwin-x64`, `win32-x64`) with that platform's `functor-lang-lsp` bundled and the release version injected, attached to the GitHub release and published to the VS Code Marketplace + Open VSX when their PATs are configured.

## Extension (commit 1)

- Server resolution becomes: **`functor-lang.serverPath` setting** (new) → **bundled `server/functor-lang-lsp[.exe]`** inside the VSIX → **PATH** (dev checkouts, unchanged). Decision logic is a pure module (`client/server-path.js`), node-tested like `inspector.js`; the chosen command is logged to the output channel.
- `.vscodeignore` keeps test suites out of the package. The `functor` CLI for the preview panel stays PATH/config-resolved — bundling it would add ~17MB per VSIX.

## Pipeline (commits 2–3)

- `release-binaries.yml` also builds the language server per target (warm toolchain, tiny crate). **Linux ships a static musl build** (asserted `static` in CI): VS Code's glibc floor (2.28) is older than what ubuntu-latest links against, and the pure-Rust crate makes musl free. Artifacts are named `lsp-<target>`, deliberately outside the `functor-*` pattern the publish job downloads.
- A `vsix` job stages each server, injects the version (`npm version`), packages via `vsce package --target --pre-release`, and the publish job attaches all four VSIXes to the release (scoped artifact downloads avoid the identical-filename collision).
- `publish-marketplace` / `publish-openvsx` publish with `--pre-release --skip-duplicate` (rerunnable), each **skipping with a notice when `VSCE_PAT` / `OVSX_PAT` isn't configured** — a missing publisher account never fails the release. Publisher id: `functor` (register on both marketplaces before adding the PATs).

## Verification

- Extension: `npm test` — 15 pass (5 new resolution tests).
- The exact CI packaging loop was run locally against a simulated artifact layout: all four VSIXes produced with correct `Version`/`TargetPlatform`/`PreRelease` manifest fields; the unix server keeps its exec bit inside the zip (`-rwxr-xr-x`, vsce records file modes); win32 carries the `.exe`; no test dirs leak. The loop avoids bash-4-only constructs so it runs under macOS bash 3.2 (caught locally).
- `actionlint` clean on both workflows; `ovsx@1.0.2` verified to support `--pre-release`/`--skip-duplicate`.
- /xreview (Claude + Codex): applied the musl/glibc High and `--skip-duplicate` Medium; empirically refuted the nested-VSIX finding (sequential packages byte-identical in size; hardened `.vscodeignore` anyway); declined excluding `media/**` — the `cov-*.svg` gutter icons are loaded at runtime.

End-to-end proof will be the next release dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)