### PR TITLE
docs: open PRs as drafts until verification and media have landed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,12 @@ Prefix every PR title with a Conventional Commits-style type, optionally followe
 `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `perf:`, `build:`, `ci:`, or `chore:`. For example,
 `fix: preserve the timeline across hot reloads` or `feat(web): add timeline event markers`.
 
+Open PRs as **drafts** (`gh pr create --draft`) and mark them ready (`gh pr ready <N>`) only
+once the PR is actually complete: verification re-run after any review fixes, review findings
+dispositioned in the body, and — for visual changes — the pr-visuals GIF/PNG embedded. Draft
+status is the signal that captures/review are still landing, so an in-flight PR doesn't get
+merged before its media and dispositions do.
+
 ## Architecture
 
 **The MVU loop (Elm-style).** A game is a set of top-level Functor Lang bindings the runner looks up by


### PR DESCRIPTION
Adds the draft-PR convention to CLAUDE.md's Pull requests section: `gh pr create --draft`, then `gh pr ready` only once verification is re-run, review findings are dispositioned, and (for visual changes) the pr-visuals media is embedded. Motivated by #406, which was merged while its demo GIF was still being captured.

(Not a draft itself — one hunk of docs, complete as-is.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)