### PR TITLE
feat(vscode): download the functor CLI on demand for the live preview

### DIFF
--- a/tools/functor-lang-vscode/README.md
+++ b/tools/functor-lang-vscode/README.md
@@ -12,8 +12,10 @@ Language support for `.fun` source files and `.funi` interface files
   included, ~300ms debounce) with the model preserved — type, and the running
   game updates without losing state. A broken edit keeps the old program
   running; push results land in the status bar (errors also in the
-  "Functor Lang Preview" output channel). Needs the `functor` CLI on PATH (or point
-  the `functor-lang.functorPath` setting at the binary).
+  "Functor Lang Preview" output channel). Uses the `functor` CLI: the
+  `functor-lang.functorPath` setting (PATH by default), else a previously
+  downloaded copy, else the extension offers to download the newest GitHub
+  release for your platform (~17 MB, into the extension's global storage).
 
 ## The `functor-lang-lsp` language server
 

--- a/tools/functor-lang-vscode/client/cli-download.js
+++ b/tools/functor-lang-vscode/client/cli-download.js
@@ -1,0 +1,179 @@
+// Download-on-demand for the `functor` CLI the live preview spawns (see
+// extension.js resolveFunctorCli): when neither functor-lang.functorPath nor
+// PATH resolves, the newest GitHub release's platform archive is offered as
+// a one-click download into the extension's global storage.
+//
+// Decision logic (asset selection, paths) is pure and node-tested
+// (cli-download.test.js); the network/extract helpers are the thin IO shell.
+// NOTE: Functor releases are all PRE-releases, so the /releases/latest API
+// endpoint (non-prereleases only) returns nothing — list releases and take
+// the newest that carries a matching asset instead.
+const path = require("path");
+const fs = require("node:fs");
+const https = require("node:https");
+const { execFile, spawn } = require("node:child_process");
+
+const RELEASES_URL = "https://api.github.com/repos/tommy-xr/functor/releases?per_page=10";
+
+// Release archives exist for these four platforms (release-binaries.yml).
+function assetTargetFor(platform, arch) {
+  if (platform === "darwin" && arch === "arm64") return "aarch64-apple-darwin";
+  if (platform === "darwin" && arch === "x64") return "x86_64-apple-darwin";
+  if (platform === "linux" && arch === "x64") return "x86_64-unknown-linux-gnu";
+  if (platform === "win32" && arch === "x64") return "x86_64-pc-windows-msvc";
+  return null;
+}
+
+// Newest release (the API lists newest first) whose tag is a release version
+// and which carries this platform's archive. Returns
+// { version, assetName, url } or null.
+function pickAsset(releases, platform, arch) {
+  const target = assetTargetFor(platform, arch);
+  if (!target) return null;
+  for (const release of releases || []) {
+    const m = /^v(\d+\.\d+\.\d+)$/.exec(release.tag_name || "");
+    if (!m) continue;
+    const version = m[1];
+    const suffix = platform === "win32" ? ".zip" : ".tar.gz";
+    const assetName = `functor-${version}-${target}${suffix}`;
+    const asset = (release.assets || []).find((a) => a.name === assetName);
+    if (asset) return { version, assetName, url: asset.browser_download_url };
+  }
+  return null;
+}
+
+// Where a downloaded CLI lives inside the extension's global storage.
+function downloadedCliPath(storageDir, platform) {
+  return path.join(storageDir, "bin", platform === "win32" ? "functor.exe" : "functor");
+}
+
+// Does `cmd --version` run? ENOENT/any spawn error or nonzero exit → false.
+function commandWorks(cmd) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const done = (ok) => {
+      if (!settled) resolve(ok);
+      settled = true;
+    };
+    let child;
+    try {
+      child = spawn(cmd, ["--version"], { stdio: "ignore" });
+    } catch {
+      return done(false);
+    }
+    child.on("error", () => done(false));
+    child.on("exit", (code) => done(code === 0));
+    setTimeout(() => {
+      done(false);
+      try {
+        child.kill();
+      } catch {}
+    }, 10000).unref();
+  });
+}
+
+// GET returning parsed JSON. GitHub requires a User-Agent. Bounded: a stalled
+// request must not leave "Open Live Preview" pending forever.
+function fetchJson(url) {
+  return new Promise((resolve, reject) => {
+    const req = https.get(url, { headers: { "User-Agent": "functor-lang-vscode" } }, (res) => {
+      if (res.statusCode !== 200) {
+        res.resume();
+        return reject(new Error(`GET ${url} → HTTP ${res.statusCode}`));
+      }
+      let body = "";
+      res.on("data", (d) => (body += d));
+      res.on("end", () => {
+        try {
+          resolve(JSON.parse(body));
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+    req.setTimeout(15000, () => req.destroy(new Error("request timed out")));
+    req.on("error", reject);
+  });
+}
+
+// Download to a file, following redirects (release assets 302 to the CDN).
+// onProgress(received, total) fires per chunk; total may be 0 when unknown.
+// Bounded by an inactivity timeout; any failure destroys the write stream
+// and removes the partial file.
+function download(url, dest, onProgress, redirectsLeft = 5) {
+  return new Promise((resolve, reject) => {
+    const req = https.get(url, { headers: { "User-Agent": "functor-lang-vscode" } }, (res) => {
+      if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+        res.resume();
+        if (redirectsLeft === 0) return reject(new Error("too many redirects"));
+        return resolve(download(res.headers.location, dest, onProgress, redirectsLeft - 1));
+      }
+      if (res.statusCode !== 200) {
+        res.resume();
+        return reject(new Error(`GET ${url} → HTTP ${res.statusCode}`));
+      }
+      const total = Number(res.headers["content-length"]) || 0;
+      let received = 0;
+      const out = fs.createWriteStream(dest);
+      const fail = (err) => {
+        out.destroy();
+        fs.rmSync(dest, { force: true });
+        reject(err);
+      };
+      res.on("data", (chunk) => {
+        received += chunk.length;
+        if (onProgress) onProgress(received, total);
+      });
+      res.pipe(out);
+      out.on("finish", () => resolve());
+      out.on("error", fail);
+      res.on("error", fail);
+    });
+    req.setTimeout(30000, () => req.destroy(new Error("download stalled")));
+    req.on("error", reject);
+  });
+}
+
+// Extract the archive (system tar: present on macOS/Linux and Windows 10+,
+// where bsdtar also reads .zip) and install the binary it contains
+// (functor-<version>-<target>/functor[.exe]) as downloadedCliPath. Returns
+// the installed path.
+async function extractAndInstall(archivePath, storageDir, platform, version, target) {
+  const extractDir = path.join(storageDir, "extract-tmp");
+  fs.rmSync(extractDir, { recursive: true, force: true });
+  fs.mkdirSync(extractDir, { recursive: true });
+  const tarFlags = archivePath.endsWith(".zip") ? "-xf" : "-xzf";
+  await new Promise((resolve, reject) => {
+    execFile("tar", [tarFlags, archivePath, "-C", extractDir], (err) =>
+      err ? reject(err) : resolve()
+    );
+  });
+  const bin = platform === "win32" ? "functor.exe" : "functor";
+  // The tarballs nest a functor-<version>-<target>/ directory; the Windows
+  // zip is packaged from `$staging/*` and carries the binary at the archive
+  // root (release-binaries.yml). Accept both.
+  const extracted = [
+    path.join(extractDir, `functor-${version}-${target}`, bin),
+    path.join(extractDir, bin),
+  ].find(fs.existsSync);
+  if (!extracted) {
+    throw new Error(`archive did not contain ${bin}`);
+  }
+  const installed = downloadedCliPath(storageDir, platform);
+  fs.mkdirSync(path.dirname(installed), { recursive: true });
+  fs.copyFileSync(extracted, installed);
+  if (platform !== "win32") fs.chmodSync(installed, 0o755);
+  fs.rmSync(extractDir, { recursive: true, force: true });
+  return installed;
+}
+
+module.exports = {
+  RELEASES_URL,
+  assetTargetFor,
+  pickAsset,
+  downloadedCliPath,
+  commandWorks,
+  fetchJson,
+  download,
+  extractAndInstall,
+};

--- a/tools/functor-lang-vscode/client/cli-download.test.js
+++ b/tools/functor-lang-vscode/client/cli-download.test.js
@@ -1,0 +1,61 @@
+const { test } = require("node:test");
+const assert = require("node:assert");
+const path = require("path");
+const {
+  assetTargetFor,
+  pickAsset,
+  downloadedCliPath,
+  commandWorks,
+} = require("./cli-download");
+
+test("asset targets map the four released platforms, others null", () => {
+  assert.strictEqual(assetTargetFor("darwin", "arm64"), "aarch64-apple-darwin");
+  assert.strictEqual(assetTargetFor("darwin", "x64"), "x86_64-apple-darwin");
+  assert.strictEqual(assetTargetFor("linux", "x64"), "x86_64-unknown-linux-gnu");
+  assert.strictEqual(assetTargetFor("win32", "x64"), "x86_64-pc-windows-msvc");
+  assert.strictEqual(assetTargetFor("linux", "arm64"), null);
+});
+
+const releases = [
+  // Newest first, like the GitHub API. A tag without assets for the platform
+  // must be skipped in favor of an older complete release.
+  { tag_name: "v0.2.0", assets: [{ name: "functor-0.2.0-x86_64-unknown-linux-gnu.tar.gz", browser_download_url: "u1" }] },
+  {
+    tag_name: "v0.1.0",
+    assets: [
+      { name: "functor-0.1.0-aarch64-apple-darwin.tar.gz", browser_download_url: "u2" },
+      { name: "functor-0.1.0-x86_64-pc-windows-msvc.zip", browser_download_url: "u3" },
+    ],
+  },
+];
+
+test("pickAsset takes the newest release carrying the platform asset", () => {
+  assert.deepStrictEqual(pickAsset(releases, "linux", "x64"), {
+    version: "0.2.0",
+    assetName: "functor-0.2.0-x86_64-unknown-linux-gnu.tar.gz",
+    url: "u1",
+  });
+  // darwin-arm64 missing from v0.2.0 → falls back to v0.1.0
+  assert.deepStrictEqual(pickAsset(releases, "darwin", "arm64"), {
+    version: "0.1.0",
+    assetName: "functor-0.1.0-aarch64-apple-darwin.tar.gz",
+    url: "u2",
+  });
+});
+
+test("pickAsset uses .zip on windows and null when unsupported/empty", () => {
+  assert.strictEqual(pickAsset(releases, "win32", "x64").url, "u3");
+  assert.strictEqual(pickAsset(releases, "linux", "arm64"), null);
+  assert.strictEqual(pickAsset([], "linux", "x64"), null);
+  assert.strictEqual(pickAsset([{ tag_name: "preview", assets: [] }], "linux", "x64"), null);
+});
+
+test("downloadedCliPath differs only in the exe suffix", () => {
+  assert.strictEqual(downloadedCliPath("/s", "linux"), path.join("/s", "bin", "functor"));
+  assert.strictEqual(downloadedCliPath("/s", "win32"), path.join("/s", "bin", "functor.exe"));
+});
+
+test("commandWorks: real spawn success and failure", async () => {
+  assert.strictEqual(await commandWorks(process.execPath), true); // node --version
+  assert.strictEqual(await commandWorks("functor-definitely-not-installed-xyz"), false);
+});

--- a/tools/functor-lang-vscode/client/extension.js
+++ b/tools/functor-lang-vscode/client/extension.js
@@ -16,6 +16,7 @@ const { LanguageClient } = require("vscode-languageclient/node");
 // VS Code wiring around it.
 const inspector = require("./inspector.js");
 const { resolveServerCommand } = require("./server-path.js");
+const cliDownload = require("./cli-download.js");
 
 let client;
 // Resolves once the LanguageClient has started (server launched + initialized).
@@ -41,6 +42,9 @@ let previewChild;
 // Project dir the open preview is serving — used to tell "reveal the existing
 // panel" (same project) apart from "restart for a different sample".
 let previewProjectDir;
+// The extension's global-storage dir (set in activate) — where a
+// downloaded-on-demand functor CLI is installed (see resolveFunctorCli).
+let globalStorageDir;
 
 // Where `functor run wasm` serves the game — fixed by the CLI's dev server.
 const PREVIEW_URL = "http://127.0.0.1:8080";
@@ -62,6 +66,7 @@ const elog = (text) => {
 };
 
 function activate(context) {
+  globalStorageDir = context.globalStorageUri.fsPath;
   channel = vscode.window.createOutputChannel("Functor Lang");
   context.subscriptions.push(channel);
   elog("extension activated");
@@ -253,6 +258,105 @@ function waitForServer(timeoutMs) {
   });
 }
 
+// Resolve the `functor` CLI the preview spawns: the functor-lang.functorPath
+// setting (default: `functor` from PATH) → a previously downloaded copy in
+// global storage → offer to download the newest release's platform archive.
+// Returns the command to spawn, or null (unsupported platform, declined, or
+// failed download — the user has been messaged in every null case).
+//
+// Concurrent invocations share one in-flight resolution: a second "Open Live
+// Preview" during the download must not race a second download/extract into
+// the same storage paths (or double-prompt).
+let functorCliInFlight = null;
+function resolveFunctorCli() {
+  if (!functorCliInFlight) {
+    functorCliInFlight = resolveFunctorCliUncached().finally(() => {
+      functorCliInFlight = null;
+    });
+  }
+  return functorCliInFlight;
+}
+
+async function resolveFunctorCliUncached() {
+  const configured =
+    vscode.workspace.getConfiguration("functor-lang").get("functorPath") || "functor";
+  if (await cliDownload.commandWorks(configured)) return configured;
+
+  const downloaded = cliDownload.downloadedCliPath(globalStorageDir, process.platform);
+  if (await cliDownload.commandWorks(downloaded)) {
+    elog(`preview: using downloaded CLI ${downloaded}`);
+    return downloaded;
+  }
+
+  // Nothing runnable — offer the download.
+  let asset;
+  try {
+    const releases = await cliDownload.fetchJson(cliDownload.RELEASES_URL);
+    asset = cliDownload.pickAsset(releases, process.platform, process.arch);
+  } catch (e) {
+    vscode.window.showErrorMessage(
+      `Functor Lang: "${configured}" was not found, and querying GitHub releases failed ` +
+        `(${e.message}) — install the functor CLI and/or set functor-lang.functorPath.`
+    );
+    return null;
+  }
+  if (!asset) {
+    vscode.window.showErrorMessage(
+      `Functor Lang: "${configured}" was not found and no prebuilt functor CLI exists for ` +
+        `${process.platform}-${process.arch} — build it from source and set functor-lang.functorPath.`
+    );
+    return null;
+  }
+  const choice = await vscode.window.showInformationMessage(
+    `Functor Lang: the functor CLI ("${configured}") was not found. ` +
+      `Download functor v${asset.version} for this platform from GitHub releases (~17 MB)?`,
+    "Download",
+    "Cancel"
+  );
+  if (choice !== "Download") return null;
+
+  try {
+    const installed = await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: `Downloading functor v${asset.version}…`,
+      },
+      async (progress) => {
+        fs.mkdirSync(globalStorageDir, { recursive: true });
+        const archivePath = path.join(globalStorageDir, asset.assetName);
+        let lastPct = 0;
+        await cliDownload.download(asset.url, archivePath, (received, total) => {
+          if (!total) return;
+          const pct = Math.floor((received / total) * 100);
+          progress.report({ increment: pct - lastPct, message: `${pct}%` });
+          lastPct = pct;
+        });
+        const target = cliDownload.assetTargetFor(process.platform, process.arch);
+        const bin = await cliDownload.extractAndInstall(
+          archivePath,
+          globalStorageDir,
+          process.platform,
+          asset.version,
+          target
+        );
+        fs.rmSync(archivePath, { force: true });
+        return bin;
+      }
+    );
+    if (!(await cliDownload.commandWorks(installed))) {
+      throw new Error("the downloaded binary did not run");
+    }
+    elog(`preview: downloaded functor v${asset.version} to ${installed}`);
+    return installed;
+  } catch (e) {
+    vscode.window.showErrorMessage(
+      `Functor Lang: downloading the functor CLI failed (${e.message}) — install it ` +
+        `manually and/or set functor-lang.functorPath.`
+    );
+    return null;
+  }
+}
+
 // "Functor Lang: Open Live Preview" — serve the active file's project with
 // `functor run wasm` and host the running game in a webview panel that
 // hot-reloads from the LIVE buffer (unsaved included), model preserved.
@@ -307,8 +411,14 @@ async function openLivePreview() {
   // manual `functor run wasm`) this child exits with a bind error — logged
   // to the output channel — and the panel simply attaches to the running
   // server.
-  const functorPath =
-    vscode.workspace.getConfiguration("functor-lang").get("functorPath") || "functor";
+  const functorPath = await resolveFunctorCli();
+  if (!functorPath) return; // declined/failed download — already messaged
+  // The await above reopened the singleton window: a concurrent invocation
+  // may have created the panel while this one waited on the resolution.
+  if (previewPanel) {
+    previewPanel.reveal();
+    return;
+  }
   const output = vscode.window.createOutputChannel("Functor Lang Preview");
   // The child outlives the panel by a beat (kill() on dispose, exit later),
   // so every output write is gated on the panel still being alive — VSCode

--- a/tools/functor-lang-vscode/package.json
+++ b/tools/functor-lang-vscode/package.json
@@ -49,7 +49,7 @@
         "functor-lang.functorPath": {
           "type": "string",
           "default": "functor",
-          "description": "Path to the `functor` CLI binary the live preview uses to serve the game (resolved from PATH by default)."
+          "description": "Path to the `functor` CLI binary the live preview uses to serve the game. Resolved from PATH by default; when nothing runnable is found, the extension offers to download the newest release for this platform."
         },
         "functor-lang.serverPath": {
           "type": "string",
@@ -85,7 +85,7 @@
     ]
   },
   "scripts": {
-    "test": "node --test client/inspector.test.js client/server-path.test.js",
+    "test": "node --test client/inspector.test.js client/server-path.test.js client/cli-download.test.js",
     "test:e2e": "playwright test -c tests-integration/playwright.config.mjs",
     "vscode:prepublish": "node ../../scripts/generate-icons.mjs",
     "package:vsix": "npx --yes @vscode/vsce@3.9.2 package --out functor-lang-vscode.vsix",


### PR DESCRIPTION
Stacked on #407 (review only the last commit). Closes the last out-of-box gap: with just the VSIX installed, **Open Live Preview** now offers to fetch the CLI instead of failing.

## Resolution order

1. `functor-lang.functorPath` (default: `functor` from PATH) — probed with `--version`
2. a previously downloaded copy in the extension's global storage
3. consent prompt → download the newest release's platform archive (~17 MB) with a progress notification → extract → verify it runs → use it (and keep using it in future sessions)

Unsupported platforms, declined prompts, API failures, and a non-running download all surface clear messages naming `functor-lang.functorPath`.

## Notable details

- **All Functor releases are pre-releases**, so the `/releases/latest` endpoint returns nothing — the picker lists releases and takes the newest carrying this platform's asset.
- **The Windows zip has a different layout than the tarballs** (binary at the archive root vs. nested `functor-<v>-<target>/`) — caught by cross-review, the installer accepts both. Extraction uses system `tar` (macOS/Linux/Windows 10+, where bsdtar reads zip) — zero new dependencies, keeping the extension's plain-JS/no-bundler setup.
- Network calls are deadline-bounded (15s API / 30s download inactivity) and failed downloads remove the partial file; concurrent preview invocations share one in-flight resolution and the panel singleton is re-checked after the await (the download opened a reentrancy window).
- Decision logic (asset selection, paths, availability probe) is a pure node-tested module, matching the `inspector.js` pattern.

## Verification

- `npm test` — 20 pass (5 new).
- Headless end-to-end against the **real published v0.1.0 release**, both archive shapes: darwin-arm64 tar.gz → installed binary reports `functor-cli 0.1.0`; win32 zip → root-layout extract installs `functor.exe` (43MB).
- /xreview (Claude + Codex): fixed the win32 zip-layout High (Codex, verified against `release-binaries.yml`'s `Compress-Archive` invocation), the concurrent-invocation race ([AGREED]), missing network deadlines, and partial-file cleanup. Declined making the progress notification cancellable (deadlines bound the wait; complexity not warranted) and left the `per_page=10` release-list window as-is (every release builds all four platforms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)