### PR TITLE
feat(vscode): functor.* prefix + a functor status bar item with version tooltip

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -871,7 +871,7 @@ errors), `run native`, `develop` (hot reload is built in), and `run wasm`
 (the `.fun` ships as text and is interpreted in the browser; file-watch hot
 reload is native-only — reload the page to pick up saved edits, or push
 source with a `{ type: "functor-lang-set-source", source }` postMessage to the page
-for a model-preserving in-place reload; the VSCode **"Functor Lang: Open Live
+for a model-preserving in-place reload; the VSCode **"Functor: Open Live
 Preview"** command does exactly that from the live buffer as you type).
 
 `examples/hello/game.fun` is the reference

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -179,6 +179,10 @@ jobs:
       # --version; the VSIX e2e path covers it.)
       - name: Build language server
         shell: bash
+        env:
+          # Baked into the LSP's initialize serverInfo.version (shown in the
+          # extension's status bar tooltip), like the CLI's --version.
+          FUNCTOR_RELEASE_VERSION: ${{ inputs.version }}
         run: |
           cargo build --bin functor-lang-lsp --release --target ${{ matrix.lsp_target }}
           # The musl build must actually be static — it has to run on any

--- a/docs/functor-lang.md
+++ b/docs/functor-lang.md
@@ -697,8 +697,8 @@ First-class `.fun` editor support, built on the `functor_lang` crate's front-end
       `textDocument/implementation`); `cargo test -p functor-lang -p functor-lang-lsp` green.
 - [x] **D4. Live game preview in the editor** (done 2026-07-03, needs C5).
       A VSCode webview panel hosting the wasm runtime: the extension's
-      **"Functor Lang: Open Live Preview"** command serves the project
-      (`functor run wasm --no-open`, binary from `functor-lang.functorPath`) in a
+      **"Functor: Open Live Preview"** command serves the project
+      (`functor run wasm --no-open`, binary from `functor.functorPath`) in a
       full-size iframe and pushes the LIVE buffer (300ms debounce, unsaved
       included) into it, and the new `functor_lang_set_source` wasm export mirrors
       the native reload path — parse → lower → check-as-warnings →

--- a/tools/functor-lang-lsp/src/main.rs
+++ b/tools/functor-lang-lsp/src/main.rs
@@ -227,7 +227,14 @@ fn run(
                             "commands": ["functor.inspector.cycleExecution"],
                         },
                     },
-                    "serverInfo": { "name": "functor-lang-lsp" },
+                    // Version surfaces in the extension's status bar tooltip.
+                    // Release builds bake the release version via
+                    // FUNCTOR_RELEASE_VERSION (like the CLI); dev builds fall
+                    // back to the crate version.
+                    "serverInfo": {
+                        "name": "functor-lang-lsp",
+                        "version": option_env!("FUNCTOR_RELEASE_VERSION").unwrap_or(env!("CARGO_PKG_VERSION")),
+                    },
                 });
                 write_message(
                     writer,
@@ -1511,6 +1518,18 @@ mod inspector_server_tests {
             response(&out, 1)["result"]["capabilities"]["executeCommandProvider"]["commands"],
             json!(["functor.inspector.cycleExecution"])
         );
+    }
+
+    #[test]
+    fn initialize_reports_a_server_version() {
+        let out = drive(vec![json!({
+            "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": { "capabilities": {} }
+        })]);
+        let info = &response(&out, 1)["result"]["serverInfo"];
+        assert_eq!(info["name"], json!("functor-lang-lsp"));
+        // Dev builds report the crate version (release builds bake
+        // FUNCTOR_RELEASE_VERSION instead).
+        assert_eq!(info["version"], json!(env!("CARGO_PKG_VERSION")));
     }
 
     #[test]

--- a/tools/functor-lang-vscode/README.md
+++ b/tools/functor-lang-vscode/README.md
@@ -6,20 +6,20 @@ Language support for `.fun` source files and `.funi` interface files
 - **Syntax highlighting** — TextMate grammar (`syntaxes/functor-lang.tmLanguage.json`).
 - **Diagnostics** — parse/lower errors as you type, via the `functor-lang-lsp` language
   server (`tools/functor-lang-lsp` in this repo) speaking LSP over stdio.
-- **Live preview** — the **"Functor Lang: Open Live Preview"** command (docs/functor-lang.md D4)
+- **Live preview** — the **"Functor: Open Live Preview"** command (docs/functor-lang.md D4)
   serves the active file's project with `functor run wasm` in a webview panel
   beside the editor, and hot-reloads it from the **live buffer** (unsaved
   included, ~300ms debounce) with the model preserved — type, and the running
   game updates without losing state. A broken edit keeps the old program
   running; push results land in the status bar (errors also in the
   "Functor Lang Preview" output channel). Uses the `functor` CLI: the
-  `functor-lang.functorPath` setting (PATH by default), else a previously
+  `functor.functorPath` setting (PATH by default), else a previously
   downloaded copy, else the extension offers to download the newest GitHub
   release for your platform (~17 MB, into the extension's global storage).
 
 ## The `functor-lang-lsp` language server
 
-Resolution order (see `client/server-path.js`): the `functor-lang.serverPath`
+Resolution order (see `client/server-path.js`): the `functor.serverPath`
 setting if set, else the binary **bundled inside the platform VSIX** (released
 builds ship one per platform under `server/`), else **PATH**. A dev checkout
 packaged locally has no bundled binary, so build and install the server from

--- a/tools/functor-lang-vscode/client/cli-download.js
+++ b/tools/functor-lang-vscode/client/cli-download.js
@@ -64,9 +64,13 @@ function commandVersion(cmd) {
       return done(null);
     }
     let out = "";
+    let exitCode = null;
     child.stdout.on("data", (d) => (out += d));
     child.on("error", () => done(null));
-    child.on("exit", (code) => done(code === 0 ? out.trim().split("\n")[0] || "unknown" : null));
+    child.on("exit", (code) => (exitCode = code));
+    // 'close' (not 'exit') — stdout may still have undelivered data when the
+    // process exits; close fires after the stdio streams have drained.
+    child.on("close", () => done(exitCode === 0 ? out.trim().split("\n")[0] || "unknown" : null));
     setTimeout(() => {
       done(null);
       try {

--- a/tools/functor-lang-vscode/client/cli-download.js
+++ b/tools/functor-lang-vscode/client/cli-download.js
@@ -1,5 +1,5 @@
 // Download-on-demand for the `functor` CLI the live preview spawns (see
-// extension.js resolveFunctorCli): when neither functor-lang.functorPath nor
+// extension.js resolveFunctorCli): when neither functor.functorPath nor
 // PATH resolves, the newest GitHub release's platform archive is offered as
 // a one-click download into the extension's global storage.
 //

--- a/tools/functor-lang-vscode/client/cli-download.js
+++ b/tools/functor-lang-vscode/client/cli-download.js
@@ -47,29 +47,37 @@ function downloadedCliPath(storageDir, platform) {
   return path.join(storageDir, "bin", platform === "win32" ? "functor.exe" : "functor");
 }
 
-// Does `cmd --version` run? ENOENT/any spawn error or nonzero exit → false.
-function commandWorks(cmd) {
+// `cmd --version`'s first stdout line, or null when it can't run (ENOENT/any
+// spawn error, nonzero exit, 10s hang). Doubles as the availability probe
+// (commandWorks) and the version shown in the status bar tooltip.
+function commandVersion(cmd) {
   return new Promise((resolve) => {
     let settled = false;
-    const done = (ok) => {
-      if (!settled) resolve(ok);
+    const done = (v) => {
+      if (!settled) resolve(v);
       settled = true;
     };
     let child;
     try {
-      child = spawn(cmd, ["--version"], { stdio: "ignore" });
+      child = spawn(cmd, ["--version"], { stdio: ["ignore", "pipe", "ignore"] });
     } catch {
-      return done(false);
+      return done(null);
     }
-    child.on("error", () => done(false));
-    child.on("exit", (code) => done(code === 0));
+    let out = "";
+    child.stdout.on("data", (d) => (out += d));
+    child.on("error", () => done(null));
+    child.on("exit", (code) => done(code === 0 ? out.trim().split("\n")[0] || "unknown" : null));
     setTimeout(() => {
-      done(false);
+      done(null);
       try {
         child.kill();
       } catch {}
     }, 10000).unref();
   });
+}
+
+async function commandWorks(cmd) {
+  return (await commandVersion(cmd)) !== null;
 }
 
 // GET returning parsed JSON. GitHub requires a User-Agent. Bounded: a stalled
@@ -172,6 +180,7 @@ module.exports = {
   assetTargetFor,
   pickAsset,
   downloadedCliPath,
+  commandVersion,
   commandWorks,
   fetchJson,
   download,

--- a/tools/functor-lang-vscode/client/cli-download.test.js
+++ b/tools/functor-lang-vscode/client/cli-download.test.js
@@ -5,6 +5,7 @@ const {
   assetTargetFor,
   pickAsset,
   downloadedCliPath,
+  commandVersion,
   commandWorks,
 } = require("./cli-download");
 
@@ -58,4 +59,9 @@ test("downloadedCliPath differs only in the exe suffix", () => {
 test("commandWorks: real spawn success and failure", async () => {
   assert.strictEqual(await commandWorks(process.execPath), true); // node --version
   assert.strictEqual(await commandWorks("functor-definitely-not-installed-xyz"), false);
+});
+
+test("commandVersion returns the first --version line, null when unrunnable", async () => {
+  assert.strictEqual(await commandVersion(process.execPath), process.version);
+  assert.strictEqual(await commandVersion("functor-definitely-not-installed-xyz"), null);
 });

--- a/tools/functor-lang-vscode/client/extension.js
+++ b/tools/functor-lang-vscode/client/extension.js
@@ -45,6 +45,20 @@ let previewProjectDir;
 // The extension's global-storage dir (set in activate) — where a
 // downloaded-on-demand functor CLI is installed (see resolveFunctorCli).
 let globalStorageDir;
+// The "$(zap) functor" status bar item; its tooltip lists the extension,
+// language server, and functor CLI versions as they become known.
+let versionStatus;
+const versionInfo = { extension: "", server: "starting…", cli: null };
+function renderVersionStatus() {
+  if (!versionStatus) return;
+  const md = new vscode.MarkdownString();
+  md.appendMarkdown(`**functor** extension v${versionInfo.extension}\n\n`);
+  md.appendMarkdown(`- language server: ${versionInfo.server}\n`);
+  md.appendMarkdown(
+    `- functor CLI: ${versionInfo.cli || "not found — the live preview offers a download"}\n`
+  );
+  versionStatus.tooltip = md;
+}
 
 // Where `functor run wasm` serves the game — fixed by the CLI's dev server.
 const PREVIEW_URL = "http://127.0.0.1:8080";
@@ -70,6 +84,14 @@ function activate(context) {
   channel = vscode.window.createOutputChannel("Functor Lang");
   context.subscriptions.push(channel);
   elog("extension activated");
+  versionStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
+  versionStatus.text = "$(zap) functor";
+  versionInfo.extension = context.extension.packageJSON.version;
+  renderVersionStatus();
+  versionStatus.show();
+  context.subscriptions.push(versionStatus);
+  // Fills in the CLI line of the tooltip in the background.
+  probeCliVersion();
   // Setting > bundled platform binary > PATH; stdio is the
   // vscode-languageclient default.
   const serverCommand = resolveServerCommand(
@@ -119,6 +141,11 @@ function activate(context) {
   clientStarted = client.start().then(
     () => {
       elog("language server started (functor-lang-lsp)");
+      const si = client.initializeResult && client.initializeResult.serverInfo;
+      versionInfo.server = si
+        ? `${si.name}${si.version ? ` v${si.version}` : ""}`
+        : "running (no serverInfo)";
+      renderVersionStatus();
       client.onNotification(inspector.COVERAGE, (params) => {
         const grouped = inspector.groupCoverage(params);
         if (!grouped) return;
@@ -128,7 +155,11 @@ function activate(context) {
         vscode.window.visibleTextEditors.forEach(paintCoverage);
       });
     },
-    (e) => elog(`language server FAILED to start: ${e && e.message ? e.message : e}`)
+    (e) => {
+      elog(`language server FAILED to start: ${e && e.message ? e.message : e}`);
+      versionInfo.server = "failed to start (see the Functor Lang output)";
+      renderVersionStatus();
+    }
   );
 
   context.subscriptions.push(
@@ -258,6 +289,19 @@ function waitForServer(timeoutMs) {
   });
 }
 
+// Fill in the tooltip's CLI line: the configured/PATH binary, else a
+// previously downloaded copy. Runs in the background at activation.
+async function probeCliVersion() {
+  const configured =
+    vscode.workspace.getConfiguration("functor").get("functorPath") || "functor";
+  versionInfo.cli =
+    (await cliDownload.commandVersion(configured)) ||
+    (await cliDownload.commandVersion(
+      cliDownload.downloadedCliPath(globalStorageDir, process.platform)
+    ));
+  renderVersionStatus();
+}
+
 // Resolve the `functor` CLI the preview spawns: the functor.functorPath
 // setting (default: `functor` from PATH) → a previously downloaded copy in
 // global storage → offer to download the newest release's platform archive.
@@ -343,9 +387,12 @@ async function resolveFunctorCliUncached() {
         return bin;
       }
     );
-    if (!(await cliDownload.commandWorks(installed))) {
+    const installedVersion = await cliDownload.commandVersion(installed);
+    if (!installedVersion) {
       throw new Error("the downloaded binary did not run");
     }
+    versionInfo.cli = installedVersion;
+    renderVersionStatus();
     elog(`preview: downloaded functor v${asset.version} to ${installed}`);
     return installed;
   } catch (e) {

--- a/tools/functor-lang-vscode/client/extension.js
+++ b/tools/functor-lang-vscode/client/extension.js
@@ -48,15 +48,13 @@ let globalStorageDir;
 // The "$(zap) functor" status bar item; its tooltip lists the extension,
 // language server, and functor CLI versions as they become known.
 let versionStatus;
-const versionInfo = { extension: "", server: "starting…", cli: null };
+const versionInfo = { extension: "", server: "starting…", cli: "checking…" };
 function renderVersionStatus() {
   if (!versionStatus) return;
   const md = new vscode.MarkdownString();
   md.appendMarkdown(`**functor** extension v${versionInfo.extension}\n\n`);
   md.appendMarkdown(`- language server: ${versionInfo.server}\n`);
-  md.appendMarkdown(
-    `- functor CLI: ${versionInfo.cli || "not found — the live preview offers a download"}\n`
-  );
+  md.appendMarkdown(`- functor CLI: ${versionInfo.cli}\n`);
   versionStatus.tooltip = md;
 }
 
@@ -298,7 +296,8 @@ async function probeCliVersion() {
     (await cliDownload.commandVersion(configured)) ||
     (await cliDownload.commandVersion(
       cliDownload.downloadedCliPath(globalStorageDir, process.platform)
-    ));
+    )) ||
+    "not found — the live preview offers a download";
   renderVersionStatus();
 }
 

--- a/tools/functor-lang-vscode/client/extension.js
+++ b/tools/functor-lang-vscode/client/extension.js
@@ -28,7 +28,7 @@ let clientStarted;
 // last-used port is persisted across sessions in globalState.
 let inspectorState;
 let inspectorStatus;
-const INSPECTOR_PORT_KEY = "functor-lang.inspector.port";
+const INSPECTOR_PORT_KEY = "functor.inspector.port";
 // The open preview panel, if any. A singleton: the dev server owns a fixed
 // port, so a second panel would race the first for it — and closing either
 // panel would kill the server out from under the other. Re-running the
@@ -73,7 +73,7 @@ function activate(context) {
   // Setting > bundled platform binary > PATH; stdio is the
   // vscode-languageclient default.
   const serverCommand = resolveServerCommand(
-    vscode.workspace.getConfiguration("functor-lang").get("serverPath"),
+    vscode.workspace.getConfiguration("functor").get("serverPath"),
     context.extensionPath,
     process.platform,
     fs.existsSync
@@ -132,7 +132,7 @@ function activate(context) {
   );
 
   context.subscriptions.push(
-    vscode.commands.registerCommand("functor-lang.openLivePreview", openLivePreview)
+    vscode.commands.registerCommand("functor.openLivePreview", openLivePreview)
   );
 
   // --- Test-only inspector-trace inject seam -------------------------------
@@ -148,7 +148,7 @@ function activate(context) {
     // `when: functorLangTestHooks` menu entry in package.json).
     vscode.commands.executeCommand("setContext", "functorLangTestHooks", true);
     context.subscriptions.push(
-      vscode.commands.registerCommand("functor-lang.inspector._injectTrace", async () => {
+      vscode.commands.registerCommand("functor.inspector._injectTrace", async () => {
         const file = process.env.FUNCTOR_INSPECTOR_TEST_TRACE;
         if (!file || !client) return;
         const doc = JSON.parse(fs.readFileSync(file, "utf8"));
@@ -258,7 +258,7 @@ function waitForServer(timeoutMs) {
   });
 }
 
-// Resolve the `functor` CLI the preview spawns: the functor-lang.functorPath
+// Resolve the `functor` CLI the preview spawns: the functor.functorPath
 // setting (default: `functor` from PATH) → a previously downloaded copy in
 // global storage → offer to download the newest release's platform archive.
 // Returns the command to spawn, or null (unsupported platform, declined, or
@@ -279,7 +279,7 @@ function resolveFunctorCli() {
 
 async function resolveFunctorCliUncached() {
   const configured =
-    vscode.workspace.getConfiguration("functor-lang").get("functorPath") || "functor";
+    vscode.workspace.getConfiguration("functor").get("functorPath") || "functor";
   if (await cliDownload.commandWorks(configured)) return configured;
 
   const downloaded = cliDownload.downloadedCliPath(globalStorageDir, process.platform);
@@ -295,20 +295,20 @@ async function resolveFunctorCliUncached() {
     asset = cliDownload.pickAsset(releases, process.platform, process.arch);
   } catch (e) {
     vscode.window.showErrorMessage(
-      `Functor Lang: "${configured}" was not found, and querying GitHub releases failed ` +
-        `(${e.message}) — install the functor CLI and/or set functor-lang.functorPath.`
+      `Functor: "${configured}" was not found, and querying GitHub releases failed ` +
+        `(${e.message}) — install the functor CLI and/or set functor.functorPath.`
     );
     return null;
   }
   if (!asset) {
     vscode.window.showErrorMessage(
-      `Functor Lang: "${configured}" was not found and no prebuilt functor CLI exists for ` +
-        `${process.platform}-${process.arch} — build it from source and set functor-lang.functorPath.`
+      `Functor: "${configured}" was not found and no prebuilt functor CLI exists for ` +
+        `${process.platform}-${process.arch} — build it from source and set functor.functorPath.`
     );
     return null;
   }
   const choice = await vscode.window.showInformationMessage(
-    `Functor Lang: the functor CLI ("${configured}") was not found. ` +
+    `Functor: the functor CLI ("${configured}") was not found. ` +
       `Download functor v${asset.version} for this platform from GitHub releases (~17 MB)?`,
     "Download",
     "Cancel"
@@ -350,14 +350,14 @@ async function resolveFunctorCliUncached() {
     return installed;
   } catch (e) {
     vscode.window.showErrorMessage(
-      `Functor Lang: downloading the functor CLI failed (${e.message}) — install it ` +
-        `manually and/or set functor-lang.functorPath.`
+      `Functor: downloading the functor CLI failed (${e.message}) — install it ` +
+        `manually and/or set functor.functorPath.`
     );
     return null;
   }
 }
 
-// "Functor Lang: Open Live Preview" — serve the active file's project with
+// "Functor: Open Live Preview" — serve the active file's project with
 // `functor run wasm` and host the running game in a webview panel that
 // hot-reloads from the LIVE buffer (unsaved included), model preserved.
 async function openLivePreview() {
@@ -393,13 +393,13 @@ async function openLivePreview() {
 
   if (!editor || !editor.document.fileName.endsWith(".fun")) {
     vscode.window.showErrorMessage(
-      "Functor Lang: open the project's .fun file first — the preview serves the project it belongs to."
+      "Functor: open the project's .fun file first — the preview serves the project it belongs to."
     );
     return;
   }
   if (!project) {
     vscode.window.showErrorMessage(
-      `Functor Lang: no functor.json with "language": "functor-lang" found in any directory above ` +
+      `Functor: no functor.json with "language": "functor-lang" found in any directory above ` +
         `${editor.document.fileName} — create one ({"language": "functor-lang", "entry": "game.fun"}) ` +
         "in the project directory."
     );
@@ -437,7 +437,7 @@ async function openLivePreview() {
   child.stderr.on("data", (d) => log(d.toString()));
   child.on("error", (e) => {
     vscode.window.showErrorMessage(
-      `Functor Lang: cannot start "${functorPath}" (${e.message}) — set functor-lang.functorPath to the functor CLI binary.`
+      `Functor: cannot start "${functorPath}" (${e.message}) — set functor.functorPath to the functor CLI binary.`
     );
   });
   child.on("exit", (code) => log(`[functor exited with code ${code}]\n`));
@@ -540,13 +540,13 @@ async function openLivePreview() {
     readyTimeout = setTimeout(() => {
       if (ready || disposed) return;
       vscode.window.showErrorMessage(
-        `Functor Lang: ${PREVIEW_URL} answered but never announced the Functor Lang preview — ` +
+        `Functor: ${PREVIEW_URL} answered but never announced the Functor Lang preview — ` +
           `is something else using that port?`
       );
     }, SERVER_WAIT_MS);
   } else {
     vscode.window.showErrorMessage(
-      `Functor Lang: the functor dev server did not come up at ${PREVIEW_URL} — see the "Functor Lang Preview" output.`
+      `Functor: the functor dev server did not come up at ${PREVIEW_URL} — see the "Functor Lang Preview" output.`
     );
   }
 }

--- a/tools/functor-lang-vscode/client/inspector.js
+++ b/tools/functor-lang-vscode/client/inspector.js
@@ -20,9 +20,9 @@ const DEFAULT_PORT = 8077;
 
 // Command ids (kept in sync with package.json's contributes.commands and the
 // registrations in extension.js). Prefixed `functor-lang.` to match the
-// existing `functor-lang.openLivePreview` convention.
-const ATTACH_COMMAND = "functor-lang.inspector.attach";
-const DETACH_COMMAND = "functor-lang.inspector.detach";
+// existing `functor.openLivePreview` convention.
+const ATTACH_COMMAND = "functor.inspector.attach";
+const DETACH_COMMAND = "functor.inspector.detach";
 
 // --- webview relay --------------------------------------------------------
 // The preview webview forwards `functor-inspector-trace` window messages (from

--- a/tools/functor-lang-vscode/client/server-path.js
+++ b/tools/functor-lang-vscode/client/server-path.js
@@ -1,6 +1,6 @@
 // Resolve the command used to launch the functor-lang-lsp language server:
 //
-//   1. the `functor-lang.serverPath` setting, when set — explicit always wins
+//   1. the `functor.serverPath` setting, when set — explicit always wins
 //   2. the binary bundled inside a platform-specific VSIX
 //      (server/functor-lang-lsp[.exe], staged by the release pipeline)
 //   3. bare "functor-lang-lsp", resolved from PATH (dev checkouts — see

--- a/tools/functor-lang-vscode/package.json
+++ b/tools/functor-lang-vscode/package.json
@@ -19,39 +19,39 @@
   "contributes": {
     "commands": [
       {
-        "command": "functor-lang.openLivePreview",
-        "title": "Functor Lang: Open Live Preview"
+        "command": "functor.openLivePreview",
+        "title": "Functor: Open Live Preview"
       },
       {
-        "command": "functor-lang.inspector.attach",
-        "title": "Functor Lang: Attach Inspector"
+        "command": "functor.inspector.attach",
+        "title": "Functor: Attach Inspector"
       },
       {
-        "command": "functor-lang.inspector.detach",
-        "title": "Functor Lang: Detach Inspector"
+        "command": "functor.inspector.detach",
+        "title": "Functor: Detach Inspector"
       },
       {
-        "command": "functor-lang.inspector._injectTrace",
-        "title": "Functor Lang: [test] Inject Inspector Trace"
+        "command": "functor.inspector._injectTrace",
+        "title": "Functor: [test] Inject Inspector Trace"
       }
     ],
     "menus": {
       "commandPalette": [
         {
-          "command": "functor-lang.inspector._injectTrace",
+          "command": "functor.inspector._injectTrace",
           "when": "functorLangTestHooks"
         }
       ]
     },
     "configuration": {
-      "title": "Functor Lang",
+      "title": "Functor",
       "properties": {
-        "functor-lang.functorPath": {
+        "functor.functorPath": {
           "type": "string",
           "default": "functor",
           "description": "Path to the `functor` CLI binary the live preview uses to serve the game. Resolved from PATH by default; when nothing runnable is found, the extension offers to download the newest release for this platform."
         },
-        "functor-lang.serverPath": {
+        "functor.serverPath": {
           "type": "string",
           "default": "",
           "description": "Path to the `functor-lang-lsp` language server binary. Empty (the default) uses the binary bundled with the extension, falling back to PATH."

--- a/tools/functor-lang-vscode/tests-integration/README.md
+++ b/tools/functor-lang-vscode/tests-integration/README.md
@@ -19,7 +19,7 @@ makes **live-value inlay hints** appear in the editor for a `.fun` file.
    the on-disk `game.fun`** (the LSP's hash gate) and arms the inject seam via
    env (`FUNCTOR_LANG_TEST_HOOKS=1`, `FUNCTOR_INSPECTOR_TEST_TRACE=<file>`).
 2. The test opens `game.fun` (Quick Open) and runs
-   `Functor Lang: [test] Inject Inspector Trace` (Command Palette). That
+   `Functor: [test] Inject Inspector Trace` (Command Palette). That
    test-only command — registered **only** when `FUNCTOR_LANG_TEST_HOOKS=1` —
    forwards the trace through the exact
    `client.sendNotification("functor/inspector/trace", …)` call the real preview

--- a/tools/functor-lang-vscode/tests-integration/inspector-inlay.spec.mjs
+++ b/tools/functor-lang-vscode/tests-integration/inspector-inlay.spec.mjs
@@ -12,7 +12,7 @@ import { test, expect, openFile, runCommand } from "./baseTest.mjs";
 import { EXPECTED_HINT, EXPECTED_RANGE_HINT } from "./trace.mjs";
 
 // The palette title of the guarded inject command (see extension.js).
-const INJECT_COMMAND = "Functor Lang: [test] Inject Inspector Trace";
+const INJECT_COMMAND = "Functor: [test] Inject Inspector Trace";
 // Distinctive substring to type into the palette (brackets omitted so fuzzy
 // matching isn't thrown off).
 const INJECT_QUERY = "Inject Inspector Trace";

--- a/tools/functor-lang-vscode/tests-integration/preview-webview.spec.mjs
+++ b/tools/functor-lang-vscode/tests-integration/preview-webview.spec.mjs
@@ -1,5 +1,5 @@
 // The full wasm push path, end to end: open the live preview
-// (`Functor Lang: Open Live Preview` spawns `functor run wasm` and hosts the
+// (`Functor: Open Live Preview` spawns `functor run wasm` and hosts the
 // game in a webview), let the game RUN, pause it via the real scrubber
 // button, and assert the runtime-emitted `functor-inspector-trace`
 // (postMessage → webview relay → LSP notification) produces live-value inlay
@@ -21,7 +21,7 @@ test("live preview: pausing a real frame relays a trace and shows live hints", a
   workbox,
 }) => {
   await openFile(workbox, "game.fun");
-  await runCommand(workbox, "Functor Lang: Open Live Preview");
+  await runCommand(workbox, "Functor: Open Live Preview");
 
   // Step into the game page: workbench webview → active-frame → game iframe.
   const gamePage = workbox


### PR DESCRIPTION
Stacked on #409 (review the last three commits). Two user-facing polish items for the extension:

## `functor.*` prefix (commit 1)

Settings, command IDs, and user-facing titles drop the `-lang`: `functor.functorPath`, `functor.serverPath`, `functor.openLivePreview`, `functor.inspector.*`, and **"Functor: …"** command titles / message prefixes. The language id `functor-lang`, grammar, output channel names, and extension id are deliberately unchanged — they're the file-type identity, not a prefix users type. e2e specs, docs, and the `functor-lang` skill reference updated. No migration concerns: the extension has never been published.

## `$(zap) functor` status bar item (commits 2–3)

Appears once the extension activates (i.e. a `.fun` file opens); hovering shows:

- **extension** version (the VSIX version the pipeline injects)
- **language server** — the LSP's `initialize` `serverInfo` now reports a version (`FUNCTOR_RELEASE_VERSION` baked by the release pipeline, crate version in dev builds; new Rust test)
- **functor CLI** — `--version` of the configured/PATH binary, else the downloaded copy; shows `checking…` until the probe finishes and updates live when a download installs one

`commandWorks` became a wrapper over the new `commandVersion` probe, so one spawn serves both availability and display.

## Verification

- Extension: `npm test` — 21 pass. LSP: `cargo test -p functor-lang-lsp` — 44 pass including the new `serverInfo` test. `actionlint` clean on the workflow change.
- /xreview (Claude + Codex): no findings above Low; fixed the `'close'`-vs-`'exit'` stdout drain in `commandVersion` ([AGREED]), the premature "not found" tooltip state, and a missed rename in the `functor-lang` skill. Declined migrating the `INSPECTOR_PORT_KEY` globalState key (no published users to migrate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)