### PR TITLE
feat(runtime): record webview events for deterministic replay

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -89,7 +89,7 @@ Remaining, roughly in priority order:
 - [ ] Native text input: route focus/keyboard into blitz (`Ui.textInput`'s
       wants-keyboard gate; blitz has `Input` events + form support). wasm
       inputs already work.
-- [ ] Record webview events for replay — needs their own `RecordedInput`
+- [x] Record webview events for replay — needs their own `RecordedInput`
       variant (a `UiEvent` entry would replay against the wrong handler
       table; TODO comments in both producers).
 - [ ] Reconcile the DOM instead of full reparse on change (also fixes

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -558,10 +558,17 @@ impl FrameCtx<'_> {
                     let ui_handlers = events
                         .iter()
                         .any(|e| matches!(e, RecordedInput::UiEvent(_)))
-                        .then(|| self.eval_ui_handlers())
+                        .then(|| self.eval_handler_table("ui"))
+                        .unwrap_or_default();
+                    // Webview events carry their OWN table: same step-top
+                    // rebuild, from `webview(model)` instead of `ui(model)`.
+                    let webview_handlers = events
+                        .iter()
+                        .any(|e| matches!(e, RecordedInput::WebviewEvent(_)))
+                        .then(|| self.eval_handler_table("webview"))
                         .unwrap_or_default();
                     for event in events {
-                        self.replay_input(event.clone(), &ui_handlers);
+                        self.replay_input(event.clone(), &ui_handlers, &webview_handlers);
                     }
                 }
                 let frame_time = FrameTime {
@@ -585,21 +592,21 @@ impl FrameCtx<'_> {
         out
     }
 
-    /// Evaluate `ui(model)` for its HANDLER TABLE only (the view is discarded)
-    /// — how the replay path reconstructs the table a recorded frame's
-    /// `UiEvent`s resolved against. A failed evaluation reports (silenced under
-    /// the dry-run reporter) and yields an empty table, so the events drop as
-    /// unknown slots.
-    fn eval_ui_handlers(&mut self) -> Vec<UiHandler> {
+    /// Evaluate `entry(model)` (`"ui"` or `"webview"`) for its HANDLER TABLE
+    /// only (the view/tree is discarded) — how the replay path reconstructs
+    /// the table a recorded frame's events resolved against. A failed
+    /// evaluation reports (silenced under the dry-run reporter) and yields an
+    /// empty table, so the events drop as unknown slots.
+    fn eval_handler_table(&mut self, entry: &'static str) -> Vec<UiHandler> {
         match self
             .session
-            .call("ui", vec![self.model.clone()], &mut FunctorHost)
+            .call(entry, vec![self.model.clone()], &mut FunctorHost)
         {
             Ok(_) => take_ui_handlers(),
             Err(err) => {
                 // A failed evaluation must not leak a partial table.
                 let _ = take_ui_handlers();
-                self.reporter.frame_error("ui", &err);
+                self.reporter.frame_error(entry, &err);
                 Vec::new()
             }
         }
@@ -613,9 +620,15 @@ impl FrameCtx<'_> {
     /// as the live path does; an unknown code is dropped, like live. An entry
     /// point the game doesn't define resolves to an interpreter error, reported
     /// (and silenced) through the dry-run reporter. A `UiEvent` resolves against
-    /// `ui_handlers` — the step-top table the caller rebuilt (the live frame's
-    /// last-render contract).
-    fn replay_input(&mut self, event: RecordedInput, ui_handlers: &[UiHandler]) {
+    /// `ui_handlers` and a `WebviewEvent` against `webview_handlers` — the
+    /// step-top tables the caller rebuilt (the live frame's last-render
+    /// contract).
+    fn replay_input(
+        &mut self,
+        event: RecordedInput,
+        ui_handlers: &[UiHandler],
+        webview_handlers: &[UiHandler],
+    ) {
         let (entry, args) = match event {
             RecordedInput::Key { code, is_down } => {
                 let Some(key_value) = crate::key_input_value(code) else {
@@ -639,6 +652,10 @@ impl FrameCtx<'_> {
             }
             RecordedInput::UiEvent(event) => {
                 self.deliver_ui_event(ui_handlers, &event);
+                return;
+            }
+            RecordedInput::WebviewEvent(event) => {
+                self.deliver_ui_event(webview_handlers, &event);
                 return;
             }
         };

--- a/runtime/functor-runtime-common/src/input.rs
+++ b/runtime/functor-runtime-common/src/input.rs
@@ -81,6 +81,11 @@ pub enum RecordedInput {
     /// [`crate::ui::UiEvent`]). Replay rebuilds the frame's handler table from
     /// `ui(model)` and re-delivers, so UI-driven model changes replay too.
     UiEvent(crate::ui::UiEvent),
+    /// An interaction on a webview element (`Attr.onClick` / `Attr.onInput`).
+    /// Same event shape as [`RecordedInput::UiEvent`], but its OWN variant:
+    /// slots address the `webview(model)` handler table, so replay must
+    /// rebuild and resolve against that table — not the `ui` one.
+    WebviewEvent(crate::ui::UiEvent),
 }
 
 impl Key {

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -925,9 +925,10 @@ impl Game for FunctorLangGame {
         let handlers = std::mem::take(&mut self.webview_handlers);
         self.ctx().deliver_ui_event(&handlers, &event);
         self.webview_handlers = handlers;
-        // TODO(webview): record for replay once webview events get their own
-        // RecordedInput variant — a UiEvent entry would replay against the
-        // wrong (ui) handler table.
+        // Buffer for the frame-indexed input log like `ui_event` — its own
+        // variant, so replay resolves against the webview handler table.
+        self.input_buf
+            .push(functor_runtime_common::RecordedInput::WebviewEvent(event));
     }
 
     fn render(&mut self, frame_time: FrameTime) -> Frame {
@@ -2275,6 +2276,106 @@ mod tests {
             peak_y > 0.5,
             "the ghost should show the jump arc, peak y = {peak_y}"
         );
+    }
+
+    /// The webview flavor of the recorded-input replay (docs/time-travel.md
+    /// T6b): a live webview click is recorded as
+    /// `RecordedInput::WebviewEvent` and the forward-step replays it against
+    /// the WEBVIEW handler table. The game defines BOTH `ui` and `webview`
+    /// with DIFFERENT messages at slot 0, so replaying against the wrong (ui)
+    /// table — the hazard the dedicated variant exists to close — would
+    /// visibly diverge the model.
+    #[test]
+    fn forward_step_replays_recorded_webview_click_against_the_webview_table() {
+        use functor_runtime_common::ui::{UiEvent, UiEventKind};
+
+        let dir =
+            std::env::temp_dir().join(format!("functor-lang-webview-replay-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create temp project dir");
+        std::fs::write(
+            dir.join("game.fun"),
+            "type Msg = | UiClicked | WebClicked\n\
+             let init = { ui: 0.0, web: 0.0, t: 0.0 }\n\
+             let update = (m, msg) =>\n\
+               match msg with\n\
+               | UiClicked => { m with ui: m.ui + 1.0 }\n\
+               | WebClicked => { m with web: m.web + 1.0 }\n\
+             let tick = (m, dt, tts) => { m with t: m.t + dt }\n\
+             let ui = (m) => Ui.button(\"ui\", UiClicked)\n\
+             let webview = (m) => Html.button([Attr.onClick(WebClicked)], [Html.text(\"web\")])\n\
+             let draw = (m, tts) => Frame.create(Camera.lookAt(Vec3.make(0.0, 0.0, -5.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n",
+        )
+        .expect("write game");
+        let mut game = FunctorLangGame::create(dir.join("game.fun").to_str().expect("utf-8 path"));
+        assert!(game.has_webview, "the game must have a webview hook");
+
+        const SUB_DT: f32 = 1.0 / 60.0;
+        const K: usize = 5; // fork point
+        const N: usize = 10; // continuation window
+
+        // Drive K frames to the fork point.
+        let mut tts = 0.0f32;
+        for _ in 0..K {
+            tts += SUB_DT;
+            game.tick(FrameTime { tts, dts: SUB_DT });
+        }
+        let fork_model = game.model.clone();
+        let fork_prev_tts = game.prev_tts;
+        let fork_tts = tts;
+
+        // Live continuation: a render adopts both handler tables (the tree the
+        // user saw), then the shell reports a webview click, then N frames run.
+        let _ = game.render(FrameTime { tts, dts: SUB_DT });
+        game.webview_event(UiEvent {
+            slot: 0,
+            kind: UiEventKind::Clicked,
+        });
+        let mut live: Vec<String> = Vec::with_capacity(N);
+        for _ in 0..N {
+            tts += SUB_DT;
+            game.tick(FrameTime { tts, dts: SUB_DT });
+            live.push(game.model.to_string());
+        }
+        // The click routed to the WEBVIEW handler live: web = 1, ui untouched.
+        assert!(
+            live[0].contains("ui: 0") && live[0].contains("web: 1"),
+            "live click must hit the webview handler: {}",
+            live[0]
+        );
+
+        // The click was recorded as a WebviewEvent on the first continuation
+        // frame — the variant this test exists to pin.
+        let inputs = game.recorder.inputs_from(K as u64);
+        assert_eq!(inputs.len(), N, "one input entry per continuation frame");
+        let webview_events: usize = inputs
+            .iter()
+            .flatten()
+            .filter(|e| matches!(e, functor_runtime_common::RecordedInput::WebviewEvent(_)))
+            .count();
+        assert_eq!(webview_events, 1, "exactly one recorded webview click");
+
+        // Forward-step from the fork, replaying the recorded log: every frame's
+        // model reproduces the live continuation exactly (divisions = N fine
+        // steps of 1, so each boundary is one rendered frame).
+        let forward = functor_runtime_common::functor_lang_producer::forward_step_scene(
+            &game.session,
+            &fork_model,
+            game.has_physics,
+            game.has_subscriptions,
+            fork_prev_tts,
+            fork_tts,
+            SUB_DT,
+            N, // divisions
+            1, // steps per division
+            &inputs,
+        );
+        assert_eq!(forward.len(), N, "division count");
+        for (i, (m, _w)) in forward.iter().enumerate() {
+            assert_eq!(m.to_string(), live[i], "model diverged at frame {i}");
+        }
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// Regression (xreview): under the fixed-timestep loop a live input can be

--- a/runtime/functor-runtime-web/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-web/src/functor_lang_game.rs
@@ -812,9 +812,10 @@ impl GameProducer for FunctorLangWebGame {
         let handlers = std::mem::take(&mut self.webview_handlers);
         self.ctx().deliver_ui_event(&handlers, &event);
         self.webview_handlers = handlers;
-        // TODO(webview): record for replay once webview events get their own
-        // RecordedInput variant — a UiEvent entry would replay against the
-        // wrong (ui) handler table.
+        // Buffer for the frame-indexed input log like `ui_event` — its own
+        // variant, so replay resolves against the webview handler table.
+        self.input_buf
+            .push(functor_runtime_common::RecordedInput::WebviewEvent(event));
     }
 
     fn render(&mut self, frame_time: FrameTime) -> Frame {
@@ -1282,6 +1283,10 @@ pub fn drain_input(game: &mut dyn GameProducer, deliver: bool) {
             InputEvent::MouseMove { x, y } => game.mouse_move(x, y),
             InputEvent::MouseWheel { delta } => game.mouse_wheel(delta),
             InputEvent::UiEvent(event) => game.ui_event(event),
+            // Webview interactions arrive through their own queue
+            // (`take_webview_events`, drained by the frame loop), not the page
+            // input queue — but the shared enum makes the arm total.
+            InputEvent::WebviewEvent(event) => game.webview_event(event),
         }
     }
 }
@@ -1438,6 +1443,7 @@ fn input_marker(input: &InputEvent) -> (&'static str, String) {
         InputEvent::MouseMove { x, y } => ("mouse-move", format!("mouse move ({x}, {y})")),
         InputEvent::MouseWheel { delta } => ("mouse-wheel", format!("mouse wheel {delta:+}")),
         InputEvent::UiEvent(event) => ("ui-input", format!("UI {event:?}")),
+        InputEvent::WebviewEvent(event) => ("webview-input", format!("webview {event:?}")),
     }
 }
 


### PR DESCRIPTION
## What / why

Webview interactions (`Attr.onClick` / `Attr.onInput`) were the one input the frame-indexed log did not capture (the `TODO(webview)` in both producers' `webview_event`), so a session with webview clicks was not replay-deterministic. They couldn't simply be recorded as the existing `RecordedInput::UiEvent`: replay resolves that variant against the **ui** handler table (`ui(model)`), while webview slots address the **webview** table (`webview(model)`) — a recorded click would re-deliver the wrong message on replay.

## How

- **`RecordedInput::WebviewEvent(ui::UiEvent)`** (`input.rs`) — same event shape as `UiEvent`, its own variant so replay knows which table to rebuild. Serde-additive; the log is in-memory per-session (the serde derives are for the future on-disk log, unused today).
- **Recording**: both producers' `webview_event` (desktop + web) now buffer the event into `input_buf`, exactly mirroring `ui_event` — it lands on the frame of the next `tick` and replays before that frame's tick, matching live delivery order.
- **Replay delivery** (`functor_lang_producer.rs`): `step_scene_forward` rebuilds the webview handler table at the step top from the pre-input model (the live last-render contract) via `eval_handler_table("webview")` — `eval_ui_handlers` generalized to take the entry name — and `replay_input` delivers `WebviewEvent` through `deliver_ui_event` with that table. `UiEvent` still resolves against the ui table; each table is only evaluated when the step actually carries its event kind.
- **Timeline markers** (web): `input_marker` labels the new variant as `webview-input`, so webview interactions show on the DOM scrubber like ui ones.
- Checked off the item in `docs/todo.md` § Webview.

## Tests

- New desktop round-trip test `forward_step_replays_recorded_webview_click_against_the_webview_table`: a game defining **both** `ui` and `webview` with *different* messages at slot 0 records a live webview click; the forward-step replay reproduces the live per-frame models exactly. If the event were replayed against the ui table (the hazard this PR closes), the model would visibly diverge (`ui: 1` instead of `web: 1`).
- `cargo test -p functor_runtime_common` — 353 passed.
- `cargo test -p functor-runtime-desktop` — all passed (49 + integration tests), including the new test.
- `cargo check -p functor-runtime-web --target wasm32-unknown-unknown` — clean (the shared-enum `drain_input` match gets a routing arm for totality; webview events actually arrive via their own queue).
- `cargo build --features=strict` in `functor-runtime-desktop` (the CI deny-warnings build) — clean.
- Cross-engine review: the Claude reviewer verified live/replay semantics are mirrored (handler-table timing, `has_webview` gating, pinned-clock gate, event ordering vs `tick`) with no Critical/High findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)