### PR TITLE
feat(ui): Style.* — typed inline styles for the webview (the elm-css split)

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -194,7 +194,7 @@ let grab = (s) =>
 - **Protected namespaces**: a file whose module name collides with a
   builtin/prelude namespace (Net, Key, Random, List, Text, Math, Debug, Scene,
   Anim, Asset, Camera, Frame, Light, Fog, Color, Vec3, Skybox, Angle, Texture,
-  Time, Sub, Effect, Physics, RenderTarget, Ui, Html, Attr, AudioSource, AudioScene) is a
+  Time, Sub, Effect, Physics, RenderTarget, Ui, Html, Attr, Style, AudioSource, AudioScene) is a
   load error — rename the file. (`assets.fun` → `Assets` — the generated
   manifest — is fine; only the exact name collides.)
 - **`Net` is a built-in module**, always in scope: `type NetEvent =
@@ -249,7 +249,7 @@ open Widget                                              // …or open, bringing
 - This is how the **engine prelude's types are declared**: the `functor-prelude`
   crate ships a `.funi` for every host namespace (`Scene`, `Asset`, `Camera`,
   `Frame`, `Light`, `Fog`, `Skybox`, `RenderTarget`, `Texture`, `Angle`, `Time`,
-  `Sub`, `Effect`, `Physics`, `Ui`, `Html`, `Attr`, `AudioSource`, `AudioScene`),
+  `Sub`, `Effect`, `Physics`, `Ui`, `Html`, `Attr`, `Style`, `AudioSource`, `AudioScene`),
   loaded by the
   runner so engine calls carry real types (no longer `Unknown`). Each module's
   primary opaque handle is `Mod.t` (`Camera.t`, `Frame.t`, `Effect.t`, …);
@@ -655,6 +655,29 @@ Html.input([attr, …])                                      //   Parley) CPU-pa
 Attr.class("…") / Attr.style("…") / Attr.id("…")           // plain attributes; Attr.attr(name,
 Attr.value("…") / Attr.placeholder("…")                    //   value) for anything else
 Attr.attr("name", "value")
+Attr.styles([Style.widthPx(300.0), …])                     // TYPED inline styles: the Style list
+                                                           //   folds into ONE style="k: v; k: v"
+                                                           //   attribute at construction (the
+                                                           //   elm-css split: inline declarations
+                                                           //   typed; the cascade — selectors,
+                                                           //   :hover, keyframes — stays a string
+                                                           //   in Html.style)
+Style.flexRow() / Style.flexColumn()                       // display:flex + direction; a bare
+Style.gapPx(n)                                             //   string/number where a Style goes
+Style.justifyStart() / justifyCenter() / justifyEnd()      //   is a teaching error (the Angle
+Style.justifyBetween()                                     //   rule)
+Style.alignStart() / alignCenter() / alignEnd()
+Style.widthPx(n) / widthPct(n) / heightPx(n) / heightPct(n)
+Style.paddingPx(n) / Style.marginPx(n)                     // all sides
+Style.color(color) / Style.background(color)               // Color.t — the ONE color type across
+                                                           //   3D and UI, formatted rgb(r, g, b)
+Style.fontSizePx(n) / Style.bold() / Style.textCenter()
+Style.borderPx(n, color)                                   // solid border
+Style.roundedPx(n)                                         // border-radius
+Style.opacity(n)                                           // 0..1 (out of range errors)
+Style.raw("property", "value")                             // the escape hatch for the long tail
+                                                           //   of CSS; the property name is
+                                                           //   validated like Attr.attr
 Attr.onClick(msg)                                          // INTERACTIVE (the Ui.button shape):
                                                            //   a click on the element (or a
                                                            //   descendant — DOM bubbling)

--- a/examples/webview/game.fun
+++ b/examples/webview/game.fun
@@ -5,6 +5,11 @@
 // blitz (Stylo + Taffy + Parley) composited over the 3D frame; on wasm it is
 // a real DOM overlay above the canvas. An `Attr.onClick` click delivers its
 // msg verbatim through `update` — the `Ui.button` loop, with CSS styling.
+//
+// Styling is split two ways: per-element INLINE styles are typed
+// (`Attr.styles([Style.fontSizePx(40.0), …])` — a typo is a check error),
+// while the cascade half (selectors, :hover) stays a CSS string in
+// `Html.style`.
 
 type Model = { count: float, spin: float }
 type Msg =
@@ -34,8 +39,9 @@ let draw = (m: Model, tts) =>
     ],
   )
 
-// The stylesheet is plain CSS in a string — themeable without touching the
-// tree. .hud is a fixed-width card pinned by its margin; buttons get :hover.
+// The stylesheet keeps the cascade half of CSS — selectors, :hover, the
+// gradient — themeable without touching the tree. .hud is a fixed-width card
+// pinned by its margin; buttons get :hover.
 let css = "
   .hud { display: flex; flex-direction: column; gap: 12px; width: 300px;
          margin: 24px; padding: 20px;
@@ -43,8 +49,6 @@ let css = "
          border: 2px solid #8be9fd; border-radius: 14px;
          font-family: sans-serif; color: #f8f8f2; }
   .hud h1 { margin: 0; font-size: 22px; color: #8be9fd; }
-  .count { font-size: 40px; font-weight: bold; text-align: center; }
-  .row { display: flex; gap: 10px; justify-content: center; }
   button { padding: 8px 18px; font-size: 18px; font-weight: bold;
            background: #50fa7b; color: #1e1e3c; border: none; border-radius: 8px; }
   button:hover { background: #f1fa8c; }
@@ -56,8 +60,12 @@ let webview = (m: Model) =>
     Html.style(css),
     Html.div([Attr.class("hud")], [
       Html.h1([], [Html.text("Functor webview")]),
-      Html.div([Attr.class("count")], [Html.text(Text.fixed(m.count, 0.0))]),
-      Html.div([Attr.class("row")], [
+      // Typed inline styles: `Style.fontSizPx(40.0)` would be a check error.
+      Html.div(
+        [Attr.styles([Style.fontSizePx(40.0), Style.bold(), Style.textCenter()])],
+        [Html.text(Text.fixed(m.count, 0.0))],
+      ),
+      Html.div([Attr.styles([Style.flexRow(), Style.gapPx(10.0), Style.justifyCenter()])], [
         Html.button([Attr.onClick(Dec)], [Html.text("-")]),
         Html.button([Attr.onClick(Inc)], [Html.text("+")]),
         Html.button([Attr.class("ghost"), Attr.onClick(Reset)], [Html.text("Reset")]),

--- a/functor-lang/src/project.rs
+++ b/functor-lang/src/project.rs
@@ -69,6 +69,7 @@ const PROTECTED_NAMESPACES: &[&str] = &[
     "Ui",
     "Html",
     "Attr",
+    "Style",
     "AudioSource",
     "AudioScene",
     "Debug",

--- a/functor-prelude/prelude/attr.funi
+++ b/functor-prelude/prelude/attr.funi
@@ -9,6 +9,9 @@ type t
 
 let class : (string) => t
 let style : (string) => t
+// Typed inline styles (the `Style` module): the list folds into ONE
+// `style="k: v; k: v"` attribute at construction.
+let styles : (List<Style.t>) => t
 let id : (string) => t
 // Any attribute by name: `Attr.attr("placeholder", "Your name")`.
 let attr : (string, string) => t

--- a/functor-prelude/prelude/style.funi
+++ b/functor-prelude/prelude/style.funi
@@ -1,0 +1,56 @@
+// style.funi — the `Style` host module (interface only; implemented in Rust by
+// FunctorHost in functor_runtime_common::functor_lang_prelude). See docs/functor-lang-interfaces.md.
+//
+// Typed INLINE styles for `Attr.styles` — the declaration half of CSS as
+// branded values (the Angle rule: a bare string/number where a Style goes is
+// an error). Values are formatted at construction (`Style.widthPx(300.0)` IS
+// `width: 300px`); colors take `Color.t` — the one color type across 3D and
+// UI. Stylesheet CSS (selectors, :hover, keyframes) deliberately stays a
+// string in `Html.style`.
+
+// The opaque style-declaration handle.
+type t
+
+// Layout: flexbox. flexRow/flexColumn set display AND direction.
+let flexRow : () => t
+let flexColumn : () => t
+let gapPx : (float) => t
+let justifyStart : () => t
+let justifyCenter : () => t
+let justifyEnd : () => t
+let justifyBetween : () => t
+let alignStart : () => t
+let alignCenter : () => t
+let alignEnd : () => t
+
+// Sizing — pixels or percent of the parent.
+let widthPx : (float) => t
+let widthPct : (float) => t
+let heightPx : (float) => t
+let heightPct : (float) => t
+
+// Spacing — all sides.
+let paddingPx : (float) => t
+let marginPx : (float) => t
+
+// Color — text and background.
+let color : (Color.t) => t
+let background : (Color.t) => t
+
+// Text.
+let fontSizePx : (float) => t
+let bold : () => t
+let textCenter : () => t
+
+// Border: `borderPx(n, color)` is a solid border; `roundedPx` is
+// border-radius.
+let borderPx : (float, Color.t) => t
+let roundedPx : (float) => t
+
+// 0..1 (out of range is a construction-time error).
+let opacity : (float) => t
+
+// The escape hatch for the long tail of CSS:
+// `Style.raw("letter-spacing", "0.1em")`. The property name is validated
+// (letters/digits/dashes) like `Attr.attr`.
+let raw : (string, string) => t

--- a/functor-prelude/src/lib.rs
+++ b/functor-prelude/src/lib.rs
@@ -36,6 +36,7 @@ pub fn modules() -> Vec<(String, String)> {
         module("Ui", include_str!("../prelude/ui.funi")),
         module("Html", include_str!("../prelude/html.funi")),
         module("Attr", include_str!("../prelude/attr.funi")),
+        module("Style", include_str!("../prelude/style.funi")),
         module("AudioSource", include_str!("../prelude/audio_source.funi")),
         module("AudioScene", include_str!("../prelude/audio_scene.funi")),
     ]

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -773,6 +773,22 @@ impl HostData for FunctorLangHtmlAttr {
     }
 }
 
+/// One or more formatted CSS declarations (`width: 300px`) as an opaque
+/// Functor Lang value — `Style.widthPx(300.0)`. `Attr.styles` folds a list of
+/// these into ONE `style="…"` attribute (the Angle rule applied to inline
+/// styles); values are formatted at construction, so a Style is plain text
+/// by the time it reaches the fold.
+pub struct FunctorLangStyle(pub String);
+
+impl HostData for FunctorLangStyle {
+    fn type_name(&self) -> &'static str {
+        "Style"
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
 /// A [`Fog`] as an opaque Functor Lang value — `Fog.linear(…)`/`Fog.exp(…)`.
 /// `Frame.withFog` accepts ONLY this (the Angle rule).
 pub struct FunctorLangFog(pub Fog);
@@ -1046,6 +1062,7 @@ pub(crate) fn registry() -> &'static crate::host_registry::Registry {
         register_subs(&mut reg);
         register_ui_widgets(&mut reg);
         register_html(&mut reg);
+        register_style(&mut reg);
         register_audio(&mut reg);
         reg
     })
@@ -1141,6 +1158,7 @@ crate::host_returnable!(
     FunctorLangView,
     FunctorLangHtmlNode,
     FunctorLangHtmlAttr,
+    FunctorLangStyle,
     FunctorLangAudioSource,
     FunctorLangAudioScene,
 );
@@ -2476,6 +2494,124 @@ fn register_html(reg: &mut crate::host_registry::Registry) {
             FunctorLangHtmlAttr(HtmlAttr::Input(slot))
         },
     );
+    // Typed inline styles: the list folds into ONE `style="k: v; k: v"` pair
+    // at construction, so the shells need no new lowering — it is exactly an
+    // `Attr.style` by the time they see it.
+    reg.fn1(
+        "Attr.styles",
+        "Attr.styles([Style.widthPx(300.0), …])",
+        |styles: Vec<FunctorLangStyle>| {
+            let css = styles
+                .into_iter()
+                .map(|FunctorLangStyle(decl)| decl)
+                .collect::<Vec<_>>()
+                .join("; ");
+            FunctorLangHtmlAttr(HtmlAttr::Pair("style".to_string(), css))
+        },
+    );
+}
+
+/// `Color.t` -> the CSS `rgb(r, g, b)` form, quantized through [`ui::rgb_u8`]
+/// so inline styles and `Ui.textColor` agree on the same 0..1 -> 0..255
+/// rounding.
+fn css_color(color: FunctorLangColor) -> String {
+    let (r, g, b) = color.0;
+    let [r, g, b] = ui::rgb_u8(r, g, b);
+    format!("rgb({r}, {g}, {b})")
+}
+
+/// The `Style` vocabulary — typed INLINE styles for `Attr.styles` (the
+/// elm-css idea, scoped to the declaration half of CSS). Each constructor
+/// formats its value at construction (`Style.widthPx(300.0)` IS
+/// `width: 300px`); colors are `Color.t` (the one color type across 3D and
+/// UI). Stylesheet CSS — selectors, `:hover`, keyframes — deliberately stays
+/// a string in `Html.style`.
+fn register_style(reg: &mut crate::host_registry::Registry) {
+    /// A fixed declaration (`Style.bold()` -> `font-weight: bold`).
+    fn fixed(reg: &mut crate::host_registry::Registry, path: &'static str, css: &'static str) {
+        reg.fn0(path, format!("{path}()").leak() as &'static str, move || {
+            FunctorLangStyle(css.to_string())
+        });
+    }
+    /// A `px`-valued declaration (`Style.widthPx(300.0)` -> `width: 300px`).
+    fn px(reg: &mut crate::host_registry::Registry, path: &'static str, prop: &'static str) {
+        reg.fn1(path, format!("{path}(n)").leak() as &'static str, move |n: f64| {
+            FunctorLangStyle(format!("{prop}: {n}px"))
+        });
+    }
+    /// A `%`-valued declaration (`Style.widthPct(50.0)` -> `width: 50%`).
+    fn pct(reg: &mut crate::host_registry::Registry, path: &'static str, prop: &'static str) {
+        reg.fn1(path, format!("{path}(n)").leak() as &'static str, move |n: f64| {
+            FunctorLangStyle(format!("{prop}: {n}%"))
+        });
+    }
+    /// A color-valued declaration (`Style.color(Color.rgb(…))`).
+    fn colored(reg: &mut crate::host_registry::Registry, path: &'static str, prop: &'static str) {
+        reg.fn1(
+            path,
+            format!("{path}(color)").leak() as &'static str,
+            move |color: FunctorLangColor| FunctorLangStyle(format!("{prop}: {}", css_color(color))),
+        );
+    }
+
+    // Layout (flexbox).
+    fixed(reg, "Style.flexRow", "display: flex; flex-direction: row");
+    fixed(reg, "Style.flexColumn", "display: flex; flex-direction: column");
+    px(reg, "Style.gapPx", "gap");
+    fixed(reg, "Style.justifyStart", "justify-content: flex-start");
+    fixed(reg, "Style.justifyCenter", "justify-content: center");
+    fixed(reg, "Style.justifyEnd", "justify-content: flex-end");
+    fixed(reg, "Style.justifyBetween", "justify-content: space-between");
+    fixed(reg, "Style.alignStart", "align-items: flex-start");
+    fixed(reg, "Style.alignCenter", "align-items: center");
+    fixed(reg, "Style.alignEnd", "align-items: flex-end");
+    // Sizing.
+    px(reg, "Style.widthPx", "width");
+    pct(reg, "Style.widthPct", "width");
+    px(reg, "Style.heightPx", "height");
+    pct(reg, "Style.heightPct", "height");
+    // Spacing (all sides).
+    px(reg, "Style.paddingPx", "padding");
+    px(reg, "Style.marginPx", "margin");
+    // Color — Color.t, the one color type across 3D and UI.
+    colored(reg, "Style.color", "color");
+    colored(reg, "Style.background", "background");
+    // Text.
+    px(reg, "Style.fontSizePx", "font-size");
+    fixed(reg, "Style.bold", "font-weight: bold");
+    fixed(reg, "Style.textCenter", "text-align: center");
+    // Border.
+    reg.fn2(
+        "Style.borderPx",
+        "Style.borderPx(n, color)",
+        |n: f64, color: FunctorLangColor| {
+            FunctorLangStyle(format!("border: {n}px solid {}", css_color(color)))
+        },
+    );
+    px(reg, "Style.roundedPx", "border-radius");
+    // Misc.
+    reg.fn1("Style.opacity", "Style.opacity(n) — 0..1", |n: f64| {
+        if !(0.0..=1.0).contains(&n) {
+            return Err(format!("Style.opacity: expected 0..1, got {n}"));
+        }
+        Ok(FunctorLangStyle(format!("opacity: {n}")))
+    });
+    // The escape hatch for the long tail of CSS. The `Attr.attr` rule for the
+    // property NAME (letters/digits/dashes), so a hostile name can't smuggle
+    // extra declarations or break out of the attribute; the value is escaped
+    // by the serializer like any other attribute text.
+    reg.fn2(
+        "Style.raw",
+        "Style.raw(\"property\", \"value\")",
+        |name: String, value: String| {
+            if !valid_html_name(&name) {
+                return Err(format!(
+                    "Style.raw: `{name}` is not an allowed property name (letters/digits/dashes)"
+                ));
+            }
+            Ok(FunctorLangStyle(format!("{name}: {value}")))
+        },
+    );
 }
 
 /// The audio vocabulary — soundscape voices (the continuous, reconciled half
@@ -2649,6 +2785,7 @@ handle_arg!(
     FunctorLangView => "a View",
     FunctorLangHtmlNode => "an Html node",
     FunctorLangHtmlAttr => "an Attr",
+    FunctorLangStyle => "a Style",
     FunctorLangAudioSource => "an AudioSource",
 );
 
@@ -6411,6 +6548,61 @@ the game dir"
         let value = eval("let main = () => Html.style(\".a > .b { color: red; }\")");
         let node = html_node_value(&value).expect("style node");
         assert_eq!(node.to_html(), "<style>.a > .b { color: red; }</style>");
+        let _ = take_ui_handlers();
+    }
+
+    // Attr.styles (the elm-css split — inline declarations typed, stylesheet
+    // strings not): the Style list folds into ONE style="…" pair at
+    // construction. Pinned as the exact serialized attribute, including the
+    // px formatting and the ui::rgb_u8 color quantization.
+    #[test]
+    fn attr_styles_folds_into_one_style_attribute() {
+        let _ = take_ui_handlers();
+        let value = eval(
+            "let main = () => Html.div([Attr.styles([\n\
+               Style.flexRow(),\n\
+               Style.gapPx(10.0),\n\
+               Style.widthPx(300.0),\n\
+               Style.background(Color.rgb(0.1, 0.1, 0.2)),\n\
+               Style.borderPx(2.0, Color.rgb(1.0, 1.0, 1.0)),\n\
+               Style.opacity(0.5),\n\
+               Style.raw(\"letter-spacing\", \"0.1em\"),\n\
+             ])], [])",
+        );
+        let node = html_node_value(&value).expect("div node");
+        assert_eq!(
+            node.to_html(),
+            r#"<div style="display: flex; flex-direction: row; gap: 10px; width: 300px; background: rgb(26, 26, 51); border: 2px solid rgb(255, 255, 255); opacity: 0.5; letter-spacing: 0.1em"></div>"#
+        );
+        let _ = take_ui_handlers();
+    }
+
+    // The Angle rule applied to inline styles: bare values where a Style (or
+    // the list) goes, an out-of-range opacity, and an injection-shaped
+    // Style.raw property name are construction-time teaching errors.
+    #[test]
+    fn attr_styles_rejects_wrong_shapes_with_teaching_errors() {
+        let _ = take_ui_handlers();
+        assert_eq!(
+            run_fail("let main = () => Attr.styles(42.0)"),
+            "expected a list, got a number"
+        );
+        assert_eq!(
+            run_fail("let main = () => Attr.styles([42.0])"),
+            "Attr.styles: expected a Style, got a number"
+        );
+        assert_eq!(
+            run_fail("let main = () => Attr.styles([\"width: 300px\"])"),
+            "Attr.styles: expected a Style, got a string"
+        );
+        assert_eq!(
+            run_fail("let main = () => Style.opacity(1.5)"),
+            "Style.opacity: expected 0..1, got 1.5"
+        );
+        assert_eq!(
+            run_fail("let main = () => Style.raw(\"width;height\", \"10px\")"),
+            "Style.raw: `width;height` is not an allowed property name (letters/digits/dashes)"
+        );
         let _ = take_ui_handlers();
     }
 


### PR DESCRIPTION
Adds a `Style` prelude module — typed inline styles for the webview (the elm-css idea, deliberately scoped to inline styles only):

```fun
Html.div(
  [Attr.styles([Style.fontSizePx(40.0), Style.bold(), Style.textCenter()])],
  [Html.text(Text.fixed(m.count, 0.0))],
)
```

instead of the stringly `Attr.style("font-size: 40px; font-weight: bold; …")`.

## Design

- **The elm-css split.** Only the *declaration* half of CSS is typed. The cascade half — selectors, `:hover`, keyframes, gradients — stays a plain CSS string in `Html.style`. `examples/webview` now demonstrates exactly that split: the `.count` and row styles moved inline as typed `Style.*` calls; the card, gradient, and `button:hover` stay in the stylesheet.
- **`Style.t` is branded** (the `Angle` rule): a bare `"width: 300px"` string or number where a Style goes is a construction-time teaching error, and value formatting (`300.0` → `300px`, colors → `rgb(r, g, b)`) happens in the constructor, so a typo can't silently produce invalid CSS.
- **One color type across 3D and UI.** Color-valued properties take the existing `Color.t`; formatting quantizes through the same `ui::rgb_u8` (0..1 → 0..255, clamped/rounded) that `Ui.textColor` uses.
- **Zero shell changes.** `Attr.styles : (List<Style.t>) => Attr.t` folds the list into ONE `style="k: v; k: v"` pair at construction — it lowers to the existing `HtmlAttr::Pair("style", …)`, so blitz (native) and the DOM overlay (wasm) are untouched.

## The starter set

| Group | Constructors |
| --- | --- |
| Layout (flexbox) | `flexRow()` / `flexColumn()` (display + direction), `gapPx(n)`, `justifyStart/Center/End/Between()`, `alignStart/Center/End()` |
| Sizing | `widthPx(n)` / `widthPct(n)` / `heightPx(n)` / `heightPct(n)` |
| Spacing | `paddingPx(n)`, `marginPx(n)` (all sides; per-side can come later) |
| Color | `color(Color.t)`, `background(Color.t)` |
| Text | `fontSizePx(n)`, `bold()`, `textCenter()` |
| Border | `borderPx(n, Color.t)` (solid), `roundedPx(n)` |
| Misc | `opacity(n)` (0..1, out of range is a teaching error) |
| Escape hatch | `raw(name, value)` — the property NAME is validated like `Attr.attr` (letters/digits/dashes), so it can't smuggle extra declarations or break out of the attribute; the value is escaped by the serializer like any attribute text |

Everything registers through the typed external registry (`register_style`), the `.funi` interface ships in `functor-prelude` (`style.funi`, `Attr.styles` added to `attr.funi`), `Style` joins `PROTECTED_NAMESPACES`, and the `functor-lang` skill documents the vocabulary.

## Tests

- `attr_styles_folds_into_one_style_attribute` pins the exact serialized attribute — `style="display: flex; flex-direction: row; gap: 10px; width: 300px; background: rgb(26, 26, 51); border: 2px solid rgb(255, 255, 255); opacity: 0.5; letter-spacing: 0.1em"` — including px formatting and the `rgb_u8` color quantization.
- `attr_styles_rejects_wrong_shapes_with_teaching_errors`: a bare number for the list, a number/string in the list, `Style.opacity(1.5)`, and an injection-shaped `Style.raw("width;height", …)` all fail with teaching errors.
- The `.funi` ≡ registry drift test covers the new module (signatures + arities).

```
cargo test -p functor_runtime_common   349 passed (lib) + 6 + integration
cargo test -p functor-lang             101 + 135 + 37 + 46 + 52 + 18 + 15 + 100 passed
cargo test -p functor-cli              29 passed (typechecks every shipped example, incl. the updated webview)
cd runtime/functor-runtime-desktop && cargo build --features=strict   OK
```

## frame_bench (prelude touched → before/after, release, same machine)

`allocs/frame` and `bytes/frame` are **byte-identical** on both sides (13877 / 842251, 54717 / 3306091, 106973 / 6459115 across the three grids) — the change only adds registrations to the once-built registry; nothing on the per-frame path moved. `us/frame(min)` deltas are inside run-to-run spread.

## Review dispositions (xreview)

The Claude reviewer found **no Critical/High issues** (it verified attribute escaping via `escape_attr` on both shells, non-finite-float rejection by the `f64` `FromArg`, and registry ≡ `.funi` parity). Two Low notes, both by-design:

- `Style.raw`'s *value* can contain `;` and add further declarations — intentional (it's the escape hatch, strictly weaker than the untyped `Html.style`, and the serializer's attribute escaping still confines it to the `style` attribute); only the property NAME is validated.
- Mixing `Attr.style(…)` and `Attr.styles([…])` on one element emits two `style` attributes (the browser keeps the first) — the pre-existing duplicate-attribute behavior of any repeated `Attr`, not introduced here.

The Codex reviewer hit its known stale-session failure mode (its report cited replay/event-recording code untouched by this diff) and was discarded per the xreview skill's failure handling.

Not treated as a visual change: the example emits the same CSS declarations as before (they moved from the stylesheet to typed inline styles), so the rendered HUD is intentionally identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
