### PR TITLE
feat(lang): Effect.preload / preloadThen — warm the asset cache ahead of draw (B.5)

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -585,6 +585,25 @@ Sub.connect(url, tagger) / Sub.listen(addr, tagger)        // persistent connect
 Effect.send(connId, text)                                  // send on an open connection
 Effect.none() / Effect.batch([fx, …])                      //   random: [0,1); now: epoch secs
 
+Effect.preload(asset)                                      // warm the asset cache ahead of
+Effect.preloadThen(asset, msg)                             //   draw referencing the asset —
+                                                           //   the imperative prefetch
+                                                           //   (declarative draw-references-
+                                                           //   it loading stays the default).
+                                                           //   Model/texture Asset VALUES
+                                                           //   only: sounds decode at play
+                                                           //   time (teaching error), bare
+                                                           //   strings teach toward Asset.*.
+                                                           //   preloadThen delivers msg (a
+                                                           //   VALUE, like playThen) through
+                                                           //   update when the load SETTLES —
+                                                           //   loaded or failed (Sub.assets'
+                                                           //   failed list says which).
+                                                           //   Preloads count in Sub.assets
+                                                           //   totals; works on wasm too
+                                                           //   (unlike playThen completion).
+                                                           //   examples/loading's SPACE flow
+                                                           //   is the reference
 Effect.play(sound)                                         // one-shot: fire-and-forget,
 Effect.playAt(sound, pos)                                  //   non-spatial / positioned
 Effect.playThen(sound, msg)                                // one-shot; delivers msg (a VALUE,

--- a/examples/loading/game.fun
+++ b/examples/loading/game.fun
@@ -16,49 +16,77 @@
 // count toward settling, and the HUD shows them: a loading screen must end
 // even when the CDN doesn't cooperate.
 //
-// The SPACE transition demonstrates the two late-request idioms:
-//   1. Progress is CUMULATIVE (total never resets), so a per-phase bar
-//      subtracts the baseline captured at the transition (baseLoaded /
-//      baseTotal below).
-//   2. The new assets only enter the snapshot on the frame AFTER draw first
-//      references them, so the keypress sets its own `transitioning` flag —
-//      the game knows it just asked — and clears it when the batch settles.
+// The SPACE transition is the `Effect.preload` demo (B.5): the new batch is
+// WARMED imperatively — phase 1 keeps playing untouched while the models
+// stream, and `Effect.preloadThen` delivers Phase2Warmed through `update`
+// when the anchor load settles, so phase 2 appears fully loaded (the
+// no-loading-screen transition; draw's later references are cache hits).
+// One late-request idiom remains: progress is CUMULATIVE (total never
+// resets), so the warming bar subtracts the baseline captured at SPACE
+// (baseLoaded / baseTotal). The old second idiom — inferring "did the
+// snapshot see my new assets yet?" from totals via a transitioning flag —
+// is gone: the game KNOWS it is warming (its own phase state) and is TOLD
+// when it's done (the preloadThen message). (Pending effect messages reset
+// on hot reload — the HTTP-tagger rule — so a reload mid-warming strands
+// phase 1.5 until restart; the dev-loop tradeoff the engine documents.)
 
+// phase: 1.0 = playing phase 1; 1.5 = SPACE pressed, phase-2 batch warming
+// via Effect.preload (phase 1 still on screen); 2.0 = warmed, phase 2 drawn.
+// warmed counts the batch's settlements — phase 2 draws when all three land.
 let init = {
   loaded: 0.0, failed: 0.0, total: 0.0, done: false,
-  phase: 1.0,
+  phase: 1.0, warmed: 0.0,
   baseLoaded: 0.0, baseTotal: 0.0,
-  transitioning: false,
 }
 
-let update = (model, p) =>
-  let failedCount = List.length(p.failed) in
-  let settledAll = p.total > 0.0 && p.loaded + failedCount == p.total in
-  { model with
-      loaded: p.loaded,
-      failed: failedCount,
-      total: p.total,
-      done: settledAll,
-      // Idiom 2: the flag clears once the phase-2 batch is both KNOWN
-      // (total grew past the baseline) and settled.
-      transitioning:
-        model.transitioning && not (settledAll && p.total > model.baseTotal) }
+// The phase-2 batch as Asset values (the preload surface takes values, not
+// strings) — another size ladder (1.1MB gull, 4.6MB plane, 11MB boombox).
+let gull = Asset.model("https://assets.babylonjs.com/meshes/seagulf.glb")
+let aeroplane = Asset.model("https://assets.babylonjs.com/meshes/aerobatic_plane.glb")
+let boombox = Asset.model("https://assets.babylonjs.com/meshes/boombox.glb")
 
-let subscriptions = (model) => Sub.assets((p) => p)
+type Msg<'p> =
+  | Progress(p: 'p)
+  | Phase2Warmed
+
+let update = (model, msg) =>
+  match msg with
+  // One batch member settled (loaded or failed — Sub.assets says which).
+  // Phase 2 first DRAWS when all three have landed: every reference below
+  // is then a cache hit, so the batch appears at once, fully loaded.
+  | Phase2Warmed =>
+    let warmed = model.warmed + 1.0 in
+    { model with
+        warmed: warmed,
+        phase: (if warmed == 3.0 then 2.0 else model.phase) }
+  | Progress(p) =>
+    let failedCount = List.length(p.failed) in
+    let settledAll = p.total > 0.0 && p.loaded + failedCount == p.total in
+    { model with
+        loaded: p.loaded,
+        failed: failedCount,
+        total: p.total,
+        done: settledAll }
+
+let subscriptions = (model) => Sub.assets(Progress)
 
 let input = (model, key, isDown) =>
   match key with
   | Key.Space =>
     if isDown && model.phase == 1.0
     then
-      // Idiom 1 + 2: capture the baseline for a fresh per-phase bar, and
-      // raise our own flag — the snapshot won't know about the new assets
-      // until the next frame's draw references them.
-      { model with
-          phase: 2.0,
-          transitioning: true,
-          baseLoaded: model.loaded + model.failed,
-          baseTotal: model.total }
+      // Warm the batch imperatively; each member reports its settlement,
+      // and the count gates the transition. The baseline (remaining idiom)
+      // gives the warming bar a fresh 0..1 range.
+      ({ model with
+           phase: 1.5,
+           baseLoaded: model.loaded + model.failed,
+           baseTotal: model.total },
+       Effect.batch([
+         Effect.preloadThen(gull, Phase2Warmed),
+         Effect.preloadThen(aeroplane, Phase2Warmed),
+         Effect.preloadThen(boombox, Phase2Warmed),
+       ]))
     else model
   | _ => model
 
@@ -101,15 +129,15 @@ let models = () =>
 // boombox), placed above the phase-1 row.
 let phase2Models = () =>
   Scene.group([
-    Scene.model("https://assets.babylonjs.com/meshes/seagulf.glb")
+    Scene.model(gull)
       |> Scene.scale(0.001)
       |> Scene.translate(Vec3.make(-3.0, -1.6, 0.0)),
-    Scene.model("https://assets.babylonjs.com/meshes/aerobatic_plane.glb")
+    Scene.model(aeroplane)
       |> Scene.scale(3.0)
       |> Scene.rotateY(Angle.degrees(150.0))
       |> Scene.translate(Vec3.make(1.7, 2.0, 0.0)),
     // The glTF-sample BoomBox is authored at centimeter scale (~1cm tall).
-    Scene.model("https://assets.babylonjs.com/meshes/boombox.glb")
+    Scene.model(boombox)
       |> Scene.scale(22.0)
       |> Scene.rotateY(Angle.degrees(180.0))
       |> Scene.translate(Vec3.make(0.0, 1.6, 0.0)),
@@ -136,11 +164,13 @@ let bar = (model) =>
 let draw = (model, tts) =>
   let base = models() in
   let scene =
-    if model.phase > 1.0 then Scene.group([base, phase2Models()])
+    if model.phase == 2.0 then Scene.group([base, phase2Models()])
     else base
   in
+  // The bar shows while anything is unsettled OR the game is warming — its
+  // own phase state, no snapshot inference needed.
   let withBar =
-    if model.transitioning || not model.done
+    if model.phase == 1.5 || not model.done
     then Scene.group([scene, bar(model)])
     else scene
   in
@@ -154,9 +184,9 @@ let draw = (model, tts) =>
 
 let ui = (model) =>
   let status =
-    if model.transitioning && model.total == model.baseTotal
-    then "Requesting more assets..."
-    else if not model.done
+    if model.phase == 1.5 && model.total == model.baseTotal
+    then "Warming phase 2 (Effect.preload)..."
+    else if model.phase == 1.5 || not model.done
     then
       Text.concat(
         "Loading ",

--- a/functor-prelude/prelude/effect.funi
+++ b/functor-prelude/prelude/effect.funi
@@ -25,3 +25,14 @@ let play : ('sound) => t
 let playAt : ('sound, Vec3.t) => t
 // Play once and deliver `'msg` (a message VALUE, not a tagger) when it finishes.
 let playThen : ('sound, 'msg) => t
+// Warm the asset cache ahead of `draw` referencing the asset (a model or
+// texture Asset VALUE — sounds decode at play time, nothing to warm; the
+// host teaches). Declarative loading stays the default; preload is the
+// imperative prefetch (start streaming the boss when the player grabs the
+// key). Counts in Sub.assets like any load.
+let preload : ('asset) => t
+// Preload and deliver `'msg` (a message VALUE, like playThen) through
+// `update` when the load SETTLES — loaded or failed (Sub.assets' failed
+// list says which). Works on wasm too (the shell's own driver detects
+// settlement, unlike audio finishes).
+let preloadThen : ('asset, 'msg) => t

--- a/runtime/functor-runtime-common/src/asset/asset_cache.rs
+++ b/runtime/functor-runtime-common/src/asset/asset_cache.rs
@@ -120,14 +120,20 @@ impl AssetCache {
             let default_asset = pipeline.unloaded_asset(context);
 
             let context = super::AssetPipelineContext {};
-            let pipeline = pipeline.clone();
+            let inner_pipeline = pipeline.clone();
             // If bytes are already cached, return a handle immediately
             let future = async move {
-                let decoded = Arc::new(pipeline.process(bytes, self_arc.as_ref(), context));
+                let decoded = Arc::new(inner_pipeline.process(bytes, self_arc.as_ref(), context));
                 progress.lock().unwrap().loaded.insert(asset_path_owned);
                 Ok(decoded)
             };
-            return Arc::new(AssetHandle::new(future, Arc::new(default_asset)));
+            let handle = Arc::new(AssetHandle::new(future, Arc::new(default_asset)));
+            // Cache the handle like the cold path below does — without this,
+            // every later request down this branch (bytes cached by ANOTHER
+            // pipeline's load: e.g. preloaded as a model, then sampled as a
+            // texture) minted a fresh handle and re-decoded per call.
+            pipeline.cache(asset_path, handle.clone());
+            return handle;
         }
 
         let context = AssetPipelineContext {};
@@ -339,6 +345,32 @@ mod tests {
         for f in [placeholder, real] {
             let _ = std::fs::remove_file(&f);
         }
+    }
+
+    /// The cached-bytes branch must CACHE its handle like the cold path: a
+    /// path whose bytes another pipeline loaded (preloaded as a model, then
+    /// requested as a texture) must hand back one stable handle, not a fresh
+    /// re-decoding handle per call.
+    #[test]
+    fn cached_bytes_branch_caches_the_handle() {
+        let cache = Arc::new(AssetCache::new());
+        let pipeline_a = super::super::build_pipeline(Box::new(BytesLen));
+        let pipeline_b = super::super::build_pipeline(Box::new(BytesLen));
+        let path = temp_file("cross-pipeline.bin", b"12345");
+
+        // Pipeline A's cold load populates the bytes cache.
+        settle(&cache.load_asset_with_pipeline(pipeline_a.clone(), &path));
+
+        // Pipeline B's first request goes down the cached-bytes branch...
+        let first = cache.load_asset_with_pipeline(pipeline_b.clone(), &path);
+        // ...and a second request must return the SAME handle, not a fresh
+        // re-decoding one.
+        let second = cache.load_asset_with_pipeline(pipeline_b.clone(), &path);
+        assert!(Arc::ptr_eq(&first, &second), "handle must be cached");
+        settle(&first);
+        assert_eq!(*first.get(), 5);
+
+        let _ = std::fs::remove_file(&path);
     }
 
     /// Liveness: a STARTED chain entry keeps being driven to settled even

--- a/runtime/functor-runtime-common/src/asset/mod.rs
+++ b/runtime/functor-runtime-common/src/asset/mod.rs
@@ -6,6 +6,7 @@ mod asset_pipeline;
 mod renderable_asset;
 
 pub mod pipelines;
+pub mod preload;
 
 pub use asset_cache::*;
 pub use asset_handle::*;

--- a/runtime/functor-runtime-common/src/asset/preload.rs
+++ b/runtime/functor-runtime-common/src/asset/preload.rs
@@ -1,0 +1,112 @@
+//! The `Effect.preload` command queue (Track B.5 of the asset revamp) —
+//! the asset analogue of [`crate::audio`]'s one-shot queue.
+//!
+//! Performing `Effect.preload(asset)` queues a [`PreloadCommand`]; the SHELL
+//! drains the queue each frame (`SceneContext::drive_preloads`) into
+//! `AssetCache::load_asset_with_pipeline` calls, warming exactly the cache
+//! entry `draw` will later hit. The shell also keeps polling each in-flight
+//! preload handle until it settles — asset futures advance only when polled,
+//! and an abandoned preload would otherwise sit in `Sub.assets`' `total`
+//! forever (the `resolve_while_pending` liveness rule, applied to preloads).
+//!
+//! `Effect.preloadThen` correlates its completion MESSAGE with the load via a
+//! token, exactly like `Effect.playThen`: this module mints tokens, the
+//! producer holds the pending message (`functor_lang_prelude::
+//! register_preload_completion`), and the shell reports settlement through
+//! `GameProducer::preload_push_settled`. Settled means loaded OR failed —
+//! the message always arrives; `Sub.assets`' `failed` list carries which.
+
+use std::cell::Cell;
+use std::collections::VecDeque;
+use std::sync::Mutex;
+
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
+
+/// Which pipeline a preload warms. Sounds never appear here: they decode at
+/// play time, outside the asset cache (the prelude rejects them with a
+/// teaching error).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PreloadKind {
+    Model,
+    Texture,
+}
+
+/// One queued `Effect.preload` / `preloadThen`: plain data across the
+/// logic↔runtime boundary (the [`crate::audio::AudioCommand`] shape).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PreloadCommand {
+    pub kind: PreloadKind,
+    pub locator: String,
+    /// `Some` for `preloadThen`: the completion token whose message the
+    /// producer holds until the shell reports the load settled.
+    pub token: Option<u64>,
+}
+
+static OUTBOUND: Lazy<Mutex<VecDeque<PreloadCommand>>> =
+    Lazy::new(|| Mutex::new(VecDeque::new()));
+
+/// Queue a command for the shell to perform (called by the effect drain).
+pub fn push_command(cmd: PreloadCommand) {
+    OUTBOUND.lock().unwrap().push_back(cmd);
+}
+
+/// Take everything queued since the last drain (the shell calls this each
+/// frame via `SceneContext::drive_preloads`).
+pub fn drain_commands() -> Vec<PreloadCommand> {
+    OUTBOUND.lock().unwrap().drain(..).collect()
+}
+
+/// The drain as a JSON array — the `GameProducer::preload_drain_commands`
+/// wire form.
+pub fn drain_commands_json() -> String {
+    serde_json::to_string(&drain_commands()).unwrap_or_else(|_| "[]".to_string())
+}
+
+thread_local! {
+    static NEXT_TOKEN: Cell<u64> = const { Cell::new(1) };
+}
+
+/// A fresh correlation token for a `preloadThen`.
+pub fn next_token() -> u64 {
+    NEXT_TOKEN.with(|c| {
+        let token = c.get();
+        c.set(token + 1);
+        token
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn commands_round_trip_the_wire_and_drain_once() {
+        // The queue is process-global and other tests drain it with exact
+        // assertions — serialize with them (the audio queue's rule).
+        let _guard = crate::audio::OUTBOUND_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let _ = drain_commands(); // isolate from other tests' leftovers
+        push_command(PreloadCommand {
+            kind: PreloadKind::Model,
+            locator: "boss.glb".to_string(),
+            token: None,
+        });
+        push_command(PreloadCommand {
+            kind: PreloadKind::Texture,
+            locator: "https://cdn/wood.png".to_string(),
+            token: Some(7),
+        });
+        let json = drain_commands_json();
+        assert_eq!(
+            json,
+            r#"[{"kind":"Model","locator":"boss.glb","token":null},{"kind":"Texture","locator":"https://cdn/wood.png","token":7}]"#
+        );
+        let back: Vec<PreloadCommand> = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.len(), 2);
+        assert_eq!(back[1].token, Some(7));
+        // Drained means drained.
+        assert_eq!(drain_commands_json(), "[]");
+    }
+}

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -290,6 +290,28 @@ pub enum EffectTree {
         sound: String,
         message: Value,
     },
+    /// Warm the asset cache ahead of `draw` referencing the asset
+    /// (`Effect.preload`) — the imperative prefetch; declarative loading
+    /// (draw references it → it loads) stays the default. Fire-and-forget:
+    /// queues a [`crate::asset::preload::PreloadCommand`] the shell drains
+    /// into a cache load and then POLLS to settlement (the
+    /// `resolve_while_pending` liveness rule — an unpolled preload would
+    /// strand in `Sub.assets`' total).
+    PreloadAsset {
+        kind: crate::asset::preload::PreloadKind,
+        locator: String,
+    },
+    /// A preload whose settlement is reported back frames later
+    /// (`Effect.preloadThen`) — the [`Self::PlayAudioThen`] shape: mint a
+    /// token, register `message` by it, queue a tokened command. When the
+    /// shell reports the load SETTLED — loaded OR failed (`Sub.assets`'
+    /// `failed` list says which) — the producer delivers `message` VERBATIM
+    /// through `update`.
+    PreloadAssetThen {
+        kind: crate::asset::preload::PreloadKind,
+        locator: String,
+        message: Value,
+    },
 }
 
 pub struct FunctorLangEffect(pub EffectTree);
@@ -2211,6 +2233,80 @@ fn register_effects(reg: &mut crate::host_registry::Registry) {
             })
         },
     );
+    // Warm the asset cache ahead of `draw` referencing the asset — the
+    // imperative prefetch (start streaming the boss when the player picks up
+    // the key). Declarative loading stays the default; a preload just makes
+    // the later reference a cache hit. Asset VALUES only (a new post-B.3
+    // surface grows no new string coercion).
+    reg.fn1(
+        "Effect.preload",
+        "Effect.preload(asset) — a model or texture Asset value to start loading now",
+        |asset: PreloadableAsset| {
+            FunctorLangEffect(EffectTree::PreloadAsset {
+                kind: asset.kind,
+                locator: asset.locator,
+            })
+        },
+    );
+    // Preload and deliver `msg` (a message VALUE, like playThen) through
+    // `update` when the load SETTLES — loaded or failed (Sub.assets' failed
+    // list says which).
+    reg.fn2(
+        "Effect.preloadThen",
+        "Effect.preloadThen(asset, msg) — a model or texture Asset value, and the \
+message delivered when its load settles",
+        |asset: PreloadableAsset, msg: Value| {
+            FunctorLangEffect(EffectTree::PreloadAssetThen {
+                kind: asset.kind,
+                locator: asset.locator,
+                message: msg,
+            })
+        },
+    );
+}
+
+/// An `Effect.preload` argument: a MODEL or TEXTURE Asset value. Sounds
+/// teach (they decode at play time, outside the asset cache — there is
+/// nothing to warm), and bare strings teach toward the constructors — a new
+/// post-flag-day surface accepts no string coercion.
+struct PreloadableAsset {
+    kind: crate::asset::preload::PreloadKind,
+    locator: String,
+}
+
+impl crate::host_registry::FromArg for PreloadableAsset {
+    fn from_arg(value: &Value, path: &str, span: Span) -> Result<Self, RunError> {
+        if let Some(asset) = asset_of(value) {
+            let kind = match asset.kind {
+                AssetKind::Model => crate::asset::preload::PreloadKind::Model,
+                AssetKind::Texture => crate::asset::preload::PreloadKind::Texture,
+                AssetKind::Sound => {
+                    return Err(RunError {
+                        message: format!(
+                            "{path}: sounds have nothing to preload (they decode at play \
+time, outside the asset cache) — preload applies to model and texture assets"
+                        ),
+                        span,
+                    })
+                }
+            };
+            return Ok(PreloadableAsset {
+                kind,
+                locator: asset.path.clone(),
+            });
+        }
+        let message = match value {
+            Value::String(s) => format!(
+                "{path}: expected an Asset value, got a bare string (\"{s}\") — construct \
+one with Asset.model/texture(…) first"
+            ),
+            other => format!(
+                "{path}: expected an Asset value (Asset.model/texture(…)), got {}",
+                other.kind_name()
+            ),
+        };
+        Err(RunError { message, span })
+    }
 }
 
 /// The Sub vocabulary — what the optional `subscriptions` hook returns.
@@ -3224,6 +3320,43 @@ pub fn clear_audio_completions() {
     PENDING_AUDIO.with(|m| m.borrow_mut().clear());
 }
 
+thread_local! {
+    /// In-flight `Effect.preloadThen` completion MESSAGES, keyed by the
+    /// preload's token — the asset analogue of [`PENDING_AUDIO`], with the
+    /// same rules: a plain message VALUE delivered verbatim; bounded (a
+    /// shell that drops the command leaves its message un-taken); cleared on
+    /// hot reload (a stored message may close over the OLD session).
+    static PENDING_PRELOAD: std::cell::RefCell<std::collections::HashMap<u64, Value>> =
+        std::cell::RefCell::new(std::collections::HashMap::new());
+}
+
+/// Register a `preloadThen` completion message for `token` (see
+/// [`PENDING_PRELOAD`]; the cap and eviction mirror
+/// [`register_audio_completion`]).
+pub fn register_preload_completion(token: u64, message: Value) {
+    PENDING_PRELOAD.with(|m| {
+        let mut map = m.borrow_mut();
+        map.insert(token, message);
+        while map.len() > PENDING_AUDIO_CAP {
+            if let Some(oldest) = map.keys().copied().min() {
+                map.remove(&oldest);
+            } else {
+                break;
+            }
+        }
+    });
+}
+
+/// Take the completion message for a settled preload's `token`, if any.
+pub fn take_preload_completion(token: u64) -> Option<Value> {
+    PENDING_PRELOAD.with(|m| m.borrow_mut().remove(&token))
+}
+
+/// Drop all in-flight `preloadThen` completion messages (hot reload).
+pub fn clear_preload_completions() {
+    PENDING_PRELOAD.with(|m| m.borrow_mut().clear());
+}
+
 /// What an interactive UI widget delivers when the shell reports an
 /// interaction on it (docs/ui-interaction.md): either a message VALUE handed
 /// to `update` verbatim (a button — the `Sub.every` shape) or a TAGGER applied
@@ -3533,9 +3666,12 @@ pub fn needs_update(tree: &EffectTree) -> bool {
         | EffectTree::Http { .. }
         // Audio one-shots are fire-and-forget too. `playThen`'s completion
         // needs `update`, but arrives frames later via the audio-finished
-        // hook — the same shape as Http.
+        // hook — the same shape as Http. Preloads likewise: `preloadThen`'s
+        // settlement arrives via the shell's preload driver.
         | EffectTree::PlayAudio { .. }
-        | EffectTree::PlayAudioThen { .. } => false,
+        | EffectTree::PlayAudioThen { .. }
+        | EffectTree::PreloadAsset { .. }
+        | EffectTree::PreloadAssetThen { .. } => false,
         EffectTree::Now { .. } | EffectTree::Random { .. } | EffectTree::Raycast { .. } => true,
         EffectTree::Batch(items) => items.iter().any(needs_update),
     }
@@ -3734,6 +3870,53 @@ dropping the rest"
                 log.push(EffectRecord {
                     kind: "audio.playThen",
                     value: EffectValue::Text(sound),
+                });
+                if log.len() > EFFECT_LOG_CAP {
+                    log.remove(0);
+                }
+                continue;
+            }
+            EffectTree::PreloadAsset { kind, locator } => {
+                // Fire-and-forget prefetch: queue a PreloadCommand for the
+                // shell's driver (drained via preload_drain_commands). No
+                // token — nothing folds back through update.
+                if !suppress_outbound {
+                    crate::asset::preload::push_command(crate::asset::preload::PreloadCommand {
+                        kind,
+                        locator: locator.clone(),
+                        token: None,
+                    });
+                }
+                log.push(EffectRecord {
+                    kind: "asset.preload",
+                    value: EffectValue::Text(locator),
+                });
+                if log.len() > EFFECT_LOG_CAP {
+                    log.remove(0);
+                }
+                continue;
+            }
+            EffectTree::PreloadAssetThen {
+                kind,
+                locator,
+                message,
+            } => {
+                // The playThen shape: mint a token, register the completion
+                // MESSAGE by it, queue a tokened command. Settlement lands
+                // frames later; the producer's preload-settled hook delivers
+                // the message then.
+                if !suppress_outbound {
+                    let token = crate::asset::preload::next_token();
+                    register_preload_completion(token, message);
+                    crate::asset::preload::push_command(crate::asset::preload::PreloadCommand {
+                        kind,
+                        locator: locator.clone(),
+                        token: Some(token),
+                    });
+                }
+                log.push(EffectRecord {
+                    kind: "asset.preloadThen",
+                    value: EffectValue::Text(locator),
                 });
                 if log.len() > EFFECT_LOG_CAP {
                     log.remove(0);
@@ -6954,6 +7137,141 @@ the game dir"
 
         // The token is consumed (a duplicate/late finish finds no message).
         assert!(take_audio_completion(token).is_none());
+    }
+
+    // --- Effect.preload / preloadThen (Track B.5) ---
+
+    /// `Effect.preload` queues a shell command for the right pipeline and
+    /// logs; `preloadThen` additionally registers its completion message,
+    /// which the settled hook folds through `update` verbatim — the playThen
+    /// shape, driven end to end with no shell.
+    #[test]
+    fn preload_queues_commands_and_completes_through_update() {
+        let _guard = crate::audio::OUTBOUND_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let _ = crate::asset::preload::drain_commands(); // clear the shared queue
+        clear_preload_completions();
+        let src = "\
+            type Model = | Cold | Warm\n\
+            let init = Cold\n\
+            let boss = Asset.model(\"boss.glb\")\n\
+            let wood = Asset.texture(\"wood.png\")\n\
+            let warm = Effect.batch([Effect.preload(wood), Effect.preloadThen(boss, Warm)])\n\
+            let update = (m: Model, msg: Model) => msg\n";
+        let project = functor_lang::project::load_single_source("game", src)
+            .unwrap_or_else(|e| panic!("load: {}", e.render()));
+        let session = functor_lang::Session::load(&project.module, &mut FunctorHost)
+            .unwrap_or_else(|f| panic!("session: {}", f.error.message));
+        let mut model = session.global("init").unwrap();
+        let mut log = EffectLog::new();
+
+        let warm = effect_of(&session.global("warm").unwrap()).unwrap().0.clone();
+        let _ = drain_effects(
+            &session,
+            &mut model,
+            warm,
+            &mut FakeEffects::new(0.0, vec![]),
+            &mut log,
+            &mut |m| panic!("unexpected report: {m}"),
+            false,
+        );
+        let kinds: Vec<&str> = log.iter().map(|r| r.kind).collect();
+        assert!(kinds.contains(&"asset.preload"), "{kinds:?}");
+        assert!(kinds.contains(&"asset.preloadThen"), "{kinds:?}");
+
+        // Two commands queued: the tokenless texture warm, the tokened model.
+        let commands = crate::asset::preload::drain_commands();
+        let token = match commands.as_slice() {
+            [
+                crate::asset::preload::PreloadCommand {
+                    kind: crate::asset::preload::PreloadKind::Texture,
+                    locator: tex,
+                    token: None,
+                },
+                crate::asset::preload::PreloadCommand {
+                    kind: crate::asset::preload::PreloadKind::Model,
+                    locator: model_loc,
+                    token: Some(t),
+                },
+            ] => {
+                assert_eq!(tex, "wood.png");
+                assert_eq!(model_loc, "boss.glb");
+                *t
+            }
+            other => panic!("expected texture+tokened model commands, got: {other:?}"),
+        };
+
+        // The load settles: take the registered message and fold it through
+        // `update` (delivered verbatim — no tagger).
+        let message = take_preload_completion(token).expect("a message for the token");
+        let (model, _) = split_model_effect(
+            session
+                .call("update", vec![model, message], &mut FunctorHost)
+                .unwrap(),
+        );
+        assert_eq!(model.to_string(), "Warm");
+
+        // Consumed: a duplicate/late settle finds no message.
+        assert!(take_preload_completion(token).is_none());
+    }
+
+    /// Under a suppressed-outbound runner (fake/dry-run/replay) preloads log
+    /// but queue nothing and register nothing — the deterministic test seam.
+    #[test]
+    fn preload_suppressed_outbound_only_logs() {
+        let _guard = crate::audio::OUTBOUND_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let _ = crate::asset::preload::drain_commands();
+        clear_preload_completions();
+        let src = "\
+            let init = 0.0\n\
+            let warm = Effect.preloadThen(Asset.model(\"boss.glb\"), 1.0)\n\
+            let update = (m, msg) => msg\n";
+        let project = functor_lang::project::load_single_source("game", src)
+            .unwrap_or_else(|e| panic!("load: {}", e.render()));
+        let session = functor_lang::Session::load(&project.module, &mut FunctorHost)
+            .unwrap_or_else(|f| panic!("session: {}", f.error.message));
+        let mut model = session.global("init").unwrap();
+        let mut log = EffectLog::new();
+        let warm = effect_of(&session.global("warm").unwrap()).unwrap().0.clone();
+        let _ = drain_effects(
+            &session,
+            &mut model,
+            warm,
+            &mut FakeEffects::new(0.0, vec![]),
+            &mut log,
+            &mut |m| panic!("unexpected report: {m}"),
+            true, // suppress_outbound
+        );
+        assert_eq!(log.last().map(|r| r.kind), Some("asset.preloadThen"));
+        assert!(crate::asset::preload::drain_commands().is_empty());
+    }
+
+    /// Preload teaches: sounds have nothing to warm, and bare strings must
+    /// construct an Asset value first (no new string coercion post-B.3).
+    #[test]
+    fn preload_teaching_errors() {
+        for (src, want) in [
+            (
+                "let main = () => Effect.preload(Asset.sound(\"boom.ogg\"))",
+                "Effect.preload: sounds have nothing to preload (they decode at play time, \
+outside the asset cache) — preload applies to model and texture assets",
+            ),
+            (
+                "let main = () => Effect.preload(\"boss.glb\")",
+                "Effect.preload: expected an Asset value, got a bare string (\"boss.glb\") — \
+construct one with Asset.model/texture(…) first",
+            ),
+            (
+                "let main = () => Effect.preloadThen(42.0, 1.0)",
+                "Effect.preloadThen: expected an Asset value (Asset.model/texture(…)), got \
+a number",
+            ),
+        ] {
+            assert_eq!(fail_message(src), want, "for {src}");
+        }
     }
 
     /// `PENDING_AUDIO` is bounded: because audio finishes are best-effort (a

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -34,6 +34,7 @@ use crate::functor_lang_prelude::{
     frame_value, http_response_value,
     needs_update, net_conn_subs, net_event_value, perform_deferred_queries, physics_event_taggers,
     physics_scene_value, split_model_effect, sub_messages_for_frame, take_audio_completion,
+    take_preload_completion,
     take_http_tagger, take_ui_handlers, DryRunEffects, EffectLog, EffectRunner, EffectTree,
     FunctorHost, NetEventKind, UiHandler,
 };
@@ -92,6 +93,9 @@ pub enum Provenance {
     NetEvent,
     HttpResponse,
     AudioFinished,
+    /// A `preloadThen` load settled (loaded or failed) — the shell's preload
+    /// driver reported it.
+    PreloadSettled,
     UiEvent,
     /// The frame's pure render pass — never journaled during play; the trace
     /// builder synthesizes one draw invocation against the frozen model.
@@ -137,6 +141,7 @@ impl Provenance {
             Provenance::NetEvent => format!("net event: {}", msg()),
             Provenance::HttpResponse => format!("http response: {}", msg()),
             Provenance::AudioFinished => format!("audio finished: {}", msg()),
+            Provenance::PreloadSettled => format!("preload settled: {}", msg()),
             Provenance::UiEvent => format!("ui event: {}", msg()),
             Provenance::Draw => "draw".to_string(),
         }
@@ -1039,6 +1044,22 @@ carries no payload to tag; dropped",
         };
         let args = vec![self.model.clone(), message];
         journal_push("update", &args, Provenance::AudioFinished);
+        match self.session.call("update", args, &mut FunctorHost) {
+            Ok(returned) => self.absorb(returned),
+            Err(err) => self.reporter.frame_error("update", &err),
+        }
+    }
+
+    /// Route a SETTLED `preloadThen` (loaded or failed) to the completion
+    /// MESSAGE registered when it fired — the audio-completion shape:
+    /// delivered verbatim, orphaned tokens (a reload dropped the message
+    /// mid-flight) silently ignored.
+    pub fn deliver_preload_completion(&mut self, token: u64) {
+        let Some(message) = take_preload_completion(token) else {
+            return;
+        };
+        let args = vec![self.model.clone(), message];
+        journal_push("update", &args, Provenance::PreloadSettled);
         match self.session.call("update", args, &mut FunctorHost) {
             Ok(returned) => self.absorb(returned),
             Err(err) => self.reporter.frame_error("update", &err),

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -314,6 +314,24 @@ pub trait GameProducer {
     /// delivers its completion message.
     fn audio_push_finished(&mut self, token: i32);
 
+    /// Take the `Effect.preload` commands the game queued this frame (a JSON
+    /// array of [`crate::asset::preload::PreloadCommand`]). The shell warms
+    /// its asset cache with them and POLLS each load to settlement (see
+    /// `SceneContext::drive_preloads`); a driver without an asset cache just
+    /// ignores the returned JSON. The default DRAINS the process-global
+    /// queue — never leaves it accumulating — so implementors are correct by
+    /// default (the queue lives in this crate, unlike the per-producer state
+    /// behind the other methods).
+    fn preload_drain_commands(&self) -> String {
+        crate::asset::preload::drain_commands_json()
+    }
+
+    /// Report that a preload (`token`) SETTLED — loaded or failed — so the
+    /// game delivers its `preloadThen` completion message. `u64` end to end —
+    /// a new surface takes no i32 narrowing (unlike the legacy audio token).
+    /// Default: no-op.
+    fn preload_push_settled(&mut self, _token: u64) {}
+
     fn quit(&mut self);
 }
 

--- a/runtime/functor-runtime-common/src/scene3d/mod.rs
+++ b/runtime/functor-runtime-common/src/scene3d/mod.rs
@@ -68,7 +68,33 @@ pub struct SceneContext {
     // The screen-space compositor's fullscreen-average program, built lazily on
     // first use and cached like the skybox program (docs/time-travel.md T5).
     composite_program: RefCell<Option<(ShaderProgram, CompositeUniforms)>>,
+    // In-flight `Effect.preload` loads (B.5), polled each frame by
+    // `drive_preloads` until they settle — asset futures advance only when
+    // polled, and nothing else polls an asset `draw` isn't referencing yet.
+    preloads: RefCell<Vec<PreloadEntry>>,
 }
+
+/// One in-flight `Effect.preload` target: the handle being driven plus every
+/// `preloadThen` completion token waiting on its settlement. Deduped by
+/// (kind, locator): re-preloading an in-flight asset merges into the existing
+/// entry instead of growing the list — a game spamming preload of a stalled
+/// URL each frame must not accumulate entries (or per-frame polls).
+struct PreloadEntry {
+    kind: crate::asset::preload::PreloadKind,
+    locator: String,
+    handle: PreloadHandle,
+    tokens: Vec<u64>,
+}
+
+enum PreloadHandle {
+    Model(Arc<AssetHandle<Model>>),
+    Texture(Arc<AssetHandle<Texture2D>>),
+}
+
+/// Waiting-token bound per in-flight entry (spamming `preloadThen` at one
+/// stalled asset): beyond it the OLDEST token drops — its registered message
+/// then expires unclaimed, exactly like a capped [`PENDING_AUDIO`] eviction.
+const PRELOAD_TOKENS_CAP: usize = 1024;
 
 enum SkyboxEntry {
     /// Six pending face loads, in `SkyboxDescription::faces` order.
@@ -124,7 +150,80 @@ impl SceneContext {
             skyboxes: RefCell::new(HashMap::new()),
             skybox_program: RefCell::new(None),
             composite_program: RefCell::new(None),
+            preloads: RefCell::new(Vec::new()),
         }
+    }
+
+    /// The shell's per-frame preload step (B.5): turn this frame's
+    /// `Effect.preload` commands (from `GameProducer::preload_drain_commands`)
+    /// into cache loads, and POLL every in-flight preload until it settles —
+    /// futures advance only when polled, and an unpolled preload would
+    /// strand in `Sub.assets`' total (the `resolve_while_pending` liveness
+    /// rule). Returns the `preloadThen` tokens that settled this frame
+    /// (loaded or failed), for the shell to report via
+    /// `GameProducer::preload_push_settled`. Once `draw` starts referencing
+    /// a warmed asset it hits the same cached handle.
+    pub fn drive_preloads(
+        &self,
+        asset_cache: &Arc<AssetCache>,
+        commands: Vec<crate::asset::preload::PreloadCommand>,
+    ) -> Vec<u64> {
+        use crate::asset::preload::PreloadKind;
+        let mut preloads = self.preloads.borrow_mut();
+        for cmd in commands {
+            if let Some(entry) = preloads
+                .iter_mut()
+                .find(|e| e.kind == cmd.kind && e.locator == cmd.locator)
+            {
+                // Already in flight: merge (the cache would hand back the
+                // same handle anyway); just accumulate the completion token.
+                if let Some(token) = cmd.token {
+                    entry.tokens.push(token);
+                    if entry.tokens.len() > PRELOAD_TOKENS_CAP {
+                        entry.tokens.remove(0);
+                    }
+                }
+                continue;
+            }
+            let handle = match cmd.kind {
+                PreloadKind::Model => PreloadHandle::Model(
+                    asset_cache
+                        .load_asset_with_pipeline(self.model_pipeline.clone(), &cmd.locator),
+                ),
+                PreloadKind::Texture => PreloadHandle::Texture(
+                    asset_cache
+                        .load_asset_with_pipeline(self.texture_pipeline.clone(), &cmd.locator),
+                ),
+            };
+            preloads.push(PreloadEntry {
+                kind: cmd.kind,
+                locator: cmd.locator,
+                handle,
+                tokens: cmd.token.into_iter().collect(),
+            });
+        }
+        let mut settled = Vec::new();
+        preloads.retain_mut(|entry| {
+            let still_loading = match &entry.handle {
+                PreloadHandle::Model(handle) => {
+                    matches!(handle.poll_state(), AssetPollState::Loading)
+                }
+                PreloadHandle::Texture(handle) => {
+                    matches!(handle.poll_state(), AssetPollState::Loading)
+                }
+            };
+            if still_loading {
+                return true;
+            }
+            settled.append(&mut entry.tokens);
+            false
+        });
+        settled
+    }
+
+    #[cfg(test)]
+    pub(crate) fn preloads_in_flight(&self) -> usize {
+        self.preloads.borrow().len()
     }
 
     /// Create (or recreate, if the declared size changed) the buffers for a
@@ -1017,4 +1116,121 @@ where
         array[3][2],
         array[3][3],
     ))
+}
+
+#[cfg(test)]
+mod preload_tests {
+    use super::*;
+    use crate::asset::preload::{PreloadCommand, PreloadKind};
+    use crate::asset::AssetCache;
+
+    fn temp_glb(name: &str) -> String {
+        // A minimal valid-magic glb (the model pipeline falls back panic-free
+        // on truncated content — decode result doesn't matter here, only that
+        // the byte-load SETTLES).
+        let path = std::env::temp_dir().join(format!(
+            "functor-preload-test-{}-{}",
+            std::process::id(),
+            name
+        ));
+        std::fs::write(&path, b"glTF").unwrap();
+        path.to_string_lossy().to_string()
+    }
+
+    /// The driver loads queued commands through the pipelines, drives them
+    /// to settlement (local reads settle on the first poll), reports settled
+    /// preloadThen tokens exactly once, and counts the loads in the cache's
+    /// progress (so `Sub.assets` sees preloads like any other load).
+    #[test]
+    fn drive_preloads_loads_settles_and_reports_tokens() {
+        let ctx = SceneContext::new();
+        let cache = Arc::new(AssetCache::new());
+        let model = temp_glb("boss");
+        let texture = temp_glb("wood");
+        let missing = "preload/does-not-exist.glb".to_string();
+
+        let settled = ctx.drive_preloads(
+            &cache,
+            vec![
+                PreloadCommand {
+                    kind: PreloadKind::Model,
+                    locator: model.clone(),
+                    token: Some(7),
+                },
+                PreloadCommand {
+                    kind: PreloadKind::Model,
+                    locator: missing.clone(),
+                    token: Some(8),
+                },
+                PreloadCommand {
+                    kind: PreloadKind::Texture,
+                    locator: texture.clone(),
+                    token: None,
+                },
+            ],
+        );
+        // Local reads settle on the first poll: the loaded model AND the
+        // failed one both report (settled = loaded OR failed); the tokenless
+        // texture settles silently.
+        let mut sorted = settled.clone();
+        sorted.sort();
+        assert_eq!(sorted, vec![7, 8]);
+        assert_eq!(ctx.preloads_in_flight(), 0, "nothing left in flight");
+
+        // Preloads count in Sub.assets' snapshot like any load: 3 started,
+        // 1 failed (progress keys by PATH, so distinct files are used).
+        let progress = cache.progress();
+        assert_eq!(progress.total, 3);
+        assert_eq!(progress.failed.len(), 1);
+        assert_eq!(progress.failed[0].0, missing);
+
+        // A later frame with no commands is a cheap no-op.
+        assert!(ctx.drive_preloads(&cache, vec![]).is_empty());
+
+        for f in [model, texture] {
+            let _ = std::fs::remove_file(&f);
+        }
+    }
+
+    /// Duplicate commands for one (kind, locator) MERGE into a single
+    /// in-flight entry (no unbounded growth from spamming a stalled URL),
+    /// and every waiting token still reports on settlement.
+    #[test]
+    fn duplicate_preloads_merge_and_report_every_token() {
+        let ctx = SceneContext::new();
+        let cache = Arc::new(AssetCache::new());
+        // A remote url with no fetcher installed stays Loading? No — it
+        // fails fast ("remote assets are not supported"); use a missing
+        // local path scheduled twice IN ONE BATCH so the merge happens
+        // before the first poll settles it.
+        let missing = "preload/dup-missing.glb".to_string();
+        let settled = ctx.drive_preloads(
+            &cache,
+            vec![
+                PreloadCommand {
+                    kind: PreloadKind::Model,
+                    locator: missing.clone(),
+                    token: Some(41),
+                },
+                PreloadCommand {
+                    kind: PreloadKind::Model,
+                    locator: missing.clone(),
+                    token: Some(42),
+                },
+                PreloadCommand {
+                    kind: PreloadKind::Model,
+                    locator: missing.clone(),
+                    token: None,
+                },
+            ],
+        );
+        // One merged entry, settled on the first poll (missing file fails
+        // fast), BOTH tokens delivered.
+        let mut sorted = settled.clone();
+        sorted.sort();
+        assert_eq!(sorted, vec![41, 42]);
+        assert_eq!(ctx.preloads_in_flight(), 0);
+        // The path counted once in progress despite three commands.
+        assert_eq!(cache.progress().total, 1);
+    }
 }

--- a/runtime/functor-runtime-common/tests/prelude_typecheck.rs
+++ b/runtime/functor-runtime-common/tests/prelude_typecheck.rs
@@ -110,3 +110,18 @@ fn while_pending_checks_clean_in_both_positions() {
     );
     assert!(diags.is_empty(), "whilePending should check clean: {diags:?}");
 }
+
+/// `Effect.preload`/`preloadThen` check clean with Asset values and produce
+/// Effect.t (usable in the (model, effect) seam).
+#[test]
+fn preload_checks_clean() {
+    let diags = check(
+        "type Msg = | Warm\n\
+         let boss = Asset.model(\"boss.glb\")\n\
+         let a = Effect.preload(boss)\n\
+         let b = Effect.preloadThen(boss, Warm)\n\
+         let c = Effect.batch([a, b])\n\
+         let update = (m, msg) => match msg with | Warm => (m, Effect.preload(Asset.texture(\"wood.png\")))",
+    );
+    assert!(diags.is_empty(), "preload should check clean: {diags:?}");
+}

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -33,9 +33,9 @@ use functor_lang::project::SourceMap;
 use functor_lang::{Session, Value};
 use functor_runtime_common::events::{self, RuntimeEvent};
 use functor_runtime_common::functor_lang_prelude::{
-    audio_scene_of, clear_audio_completions, clear_http_taggers, frame_value, html_node_value,
-    take_ui_handlers, view_value, EffectLog, EffectRunner, EffectTree, FunctorHost, NetEventKind,
-    RealEffects, UiHandler,
+    audio_scene_of, clear_audio_completions, clear_http_taggers, clear_preload_completions,
+    frame_value, html_node_value, take_ui_handlers, view_value, EffectLog, EffectRunner,
+    EffectTree, FunctorHost, NetEventKind, RealEffects, UiHandler,
 };
 use functor_runtime_common::functor_lang_producer::{
     journal_arm, journal_push, journal_swap, FrameCtx, JournalEntry, Provenance, Reporter,
@@ -560,6 +560,7 @@ impl FunctorLangGame {
         // too — drop them alongside the HTTP taggers (a late finish for a
         // dropped token arrives orphaned and is ignored).
         clear_audio_completions();
+        clear_preload_completions();
         // The widget handler table holds msgs/taggers into the OLD session;
         // the next render's `ui(model)` rebuilds it against the new one. A
         // click landing in the gap resolves an unknown slot and is dropped.
@@ -721,6 +722,7 @@ impl Game for FunctorLangGame {
             self.delivered_asset_progress = None;
             clear_http_taggers();
             clear_audio_completions();
+            clear_preload_completions();
             // The paused frame moved to `target`, for which we hold no journal
             // (only the last real frame's) — drop the stale trace so the
             // inspector reports the rewound frame with no invocations (PR2).
@@ -1172,6 +1174,11 @@ AudioScene.empty), got {}",
     }
     fn audio_push_finished(&mut self, token: i32) {
         self.ctx().deliver_audio_completion(token as u64);
+    }
+
+    // preload_drain_commands: the trait default drains the shared queue.
+    fn preload_push_settled(&mut self, token: u64) {
+        self.ctx().deliver_preload_completion(token);
     }
 
     fn quit(&mut self) {

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -693,9 +693,12 @@ fn run_headless(
         dispatch_net_ws(&mut *game, &net_tx, &http_client, &mut ws_manager);
 
         // The frame is pure data (no GL); it powers GET /scene. Drain and drop
-        // audio commands (no device in headless) so they don't pile up.
+        // audio and preload commands (no device / no asset cache in headless)
+        // so they don't pile up. Like playThen, a preloadThen's message never
+        // delivers headless — the known Sub.assets-under---headless gap.
         let frame = game.render(time.clone());
         let _ = game.audio_drain_commands();
+        let _ = game.preload_drain_commands();
 
         if let Some(rx) = &debug_requests {
             while let Ok(req) = rx.try_recv() {
@@ -1076,6 +1079,15 @@ pub fn run(args: Args) {
             // The loading snapshot for `Sub.assets`: pushed every frame, the
             // producer only acts when it changed since the game last saw it.
             game.push_asset_progress(asset_cache.progress());
+
+            // Effect.preload (B.5): warm the cache with this frame's queued
+            // preloads and drive in-flight ones to settlement; a settled
+            // preloadThen delivers its message through update.
+            let preload_commands =
+                serde_json::from_str(&game.preload_drain_commands()).unwrap_or_default();
+            for token in scene_context.drive_preloads(&asset_cache, preload_commands) {
+                game.preload_push_settled(token);
+            }
 
             // Asset hot-reload, the twin of the .fun check above: a model/
             // texture saved on disk is evicted from the caches so the next

--- a/runtime/functor-runtime-web/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-web/src/functor_lang_game.rs
@@ -24,9 +24,9 @@ use std::cell::RefCell;
 use functor_lang::project::SourceMap;
 use functor_lang::{Session, Value};
 use functor_runtime_common::functor_lang_prelude::{
-    audio_scene_of, clear_audio_completions, clear_http_taggers, contains_effect, frame_value,
-    html_node_value, take_ui_handlers, view_value, EffectLog, EffectRunner, EffectTree,
-    FunctorHost, NetEventKind, RealEffects, UiHandler,
+    audio_scene_of, clear_audio_completions, clear_http_taggers, clear_preload_completions,
+    contains_effect, frame_value, html_node_value, take_ui_handlers, view_value, EffectLog,
+    EffectRunner, EffectTree, FunctorHost, NetEventKind, RealEffects, UiHandler,
 };
 use functor_runtime_common::functor_lang_producer::{
     journal_arm, journal_swap, FrameCtx, JournalEntry, Reporter, SpanSource,
@@ -476,6 +476,7 @@ impl FunctorLangWebGame {
         self.pending_events.clear();
         clear_http_taggers();
         clear_audio_completions();
+        clear_preload_completions();
         // The widget handler table holds msgs/taggers into the OLD session;
         // the next render's `ui(model)` rebuilds it against the new one.
         self.ui_handlers.clear();
@@ -1036,6 +1037,11 @@ AudioScene.empty), got {}",
     }
     fn audio_push_finished(&mut self, token: i32) {
         self.ctx().deliver_audio_completion(token as u64);
+    }
+
+    // preload_drain_commands: the trait default drains the shared queue.
+    fn preload_push_settled(&mut self, token: u64) {
+        self.ctx().deliver_preload_completion(token);
     }
 
     fn quit(&mut self) {

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -1293,6 +1293,16 @@ async fn run_async() -> Result<(), JsValue> {
             // producer only acts when it changed since the game last saw it.
             game.push_asset_progress(asset_cache.progress());
 
+            // Effect.preload (B.5): warm the cache with this frame's queued
+            // preloads and drive in-flight ones to settlement. Unlike audio
+            // finishes (undetectable on Web Audio today), preload settlement
+            // comes from the driver's own polling — preloadThen works on wasm.
+            let preload_commands =
+                serde_json::from_str(&game.preload_drain_commands()).unwrap_or_default();
+            for token in scene_context.drive_preloads(&asset_cache, preload_commands) {
+                game.preload_push_settled(token);
+            }
+
             for sub in &sub_frames {
                 game.tick(sub.clone());
             }


### PR DESCRIPTION
Track B.5 (follows #384, #387, #391, #397, #406): the imperative prefetch from the design's §2d.

```functor
| Key.Space =>
    ({ model with phase: Warming },
     Effect.batch([
       Effect.preload(gull),
       Effect.preload(aeroplane),
       Effect.preloadThen(boombox, Phase2Warmed),   // msg VALUE, delivered when the load settles
     ]))
```

Declarative loading (draw references it → it loads) stays the default — a preload just makes the later reference a **cache hit**. `examples/loading`'s SPACE flow is the demo: phase 1 keeps playing while the phase-2 batch warms, and phase 2 first draws when `Phase2Warmed` lands — appearing **fully loaded** (the no-loading-screen transition). The old "did the snapshot see my assets yet?" `transitioning` idiom is gone; the cumulative-baseline bar idiom remains.

## Demo

![Effect.preload: SPACE warms phase 2 while phase 1 keeps playing](https://gist.githubusercontent.com/tommy-xr/03a931a7d51c202b5e5c0009a07ef4c8/raw/b5-demo.gif)

<sub>`examples/loading` (`FUNCTOR_THROTTLE_ASSETS=1200`, phase-1-only warm cache, driven headlessly via the debug server): SPACE fires the preload batch — phase 1 keeps playing while the warming bar tracks the batch against the SPACE baseline — then `Phase2Warmed` delivers and phase 2 appears fully loaded.</sub>

| warming (phase 1.5) | landed (phase 2) |
|---|---|
| ![warming](https://gist.githubusercontent.com/tommy-xr/03a931a7d51c202b5e5c0009a07ef4c8/raw/b5-warming.png) | ![landed](https://gist.githubusercontent.com/tommy-xr/03a931a7d51c202b5e5c0009a07ef4c8/raw/b5-landed.png) |

## How it works

- **The `playThen` shape end to end**: performing the effect queues a plain-data `PreloadCommand` (new `asset::preload`, the `AudioCommand` pattern); `preloadThen` mints a token and registers its completion message (`PENDING_PRELOAD`, capped + cleared on hot reload, mirroring `PENDING_AUDIO`).
- **The shell's driver** (`SceneContext::drive_preloads`, called beside `push_asset_progress` in both shells): turns commands into `AssetCache` loads via the right pipeline and **polls every in-flight preload to settlement** — the B.4 liveness rule again: futures only advance when polled, and an unpolled preload would strand in `Sub.assets`' total. Settled tokens flow through `GameProducer::preload_push_settled` (defaulted — replay/netsim untouched) → the message folds through `update` verbatim.
- **Settled = loaded OR failed** — the message always arrives; `Sub.assets`' `failed` list says which. Preloads count in `Sub.assets` like any load (loading screens can gate on them).
- **Wasm parity bonus**: settlement comes from the driver's own polling, so `preloadThen` works on wasm — unlike `playThen`, whose audio finish Web Audio can't report today. Headless drains-and-drops like audio.
- Asset VALUES only (models/textures): sounds teach (nothing to warm — they decode at play time), bare strings teach toward `Asset.*` (no new string surface post-B.3).

## Verification

- Broker tests: commands queued with the right kinds/tokens, `asset.preload`/`asset.preloadThen` logged, the completion message delivered through `update` verbatim and consumed once, and `suppress_outbound` logs-only (the fake/replay determinism seam).
- Driver test over real pipelines: loads, settles (a FAILED load settles too), reports tokens exactly once, counts in `AssetProgress` — plus the path-keyed progress subtlety documented.
- Teaching-error + typecheck tests. All examples build. `cargo test -p functor_runtime_common`: 343 + 7 green (incl. the funi↔registry drift test).
- **Live e2e** (debug server): phase 1 settles 3/3 → SPACE → `total` jumps to 6 as the preloads enter the snapshot, `phase: 1.5` while warming → **`phase: 2` the moment `Phase2Warmed` delivers** → capture shows all six models on screen.
- frame_bench: allocs/frame and bytes/frame **byte-identical to main** (the new arms only run when a preload performs).

## xreview disposition (two-engine review: Claude + Codex)

- **[AGREED] preload tests raced on the process-global command queue** (exact-count assertions, parallel test binary) — **fixed**: all three acquire the audio queue's `OUTBOUND_TEST_LOCK`.
- **Codex Medium: duplicate/stalled preloads grew the in-flight list unboundedly** (an entry per command, polled per frame) — **fixed**: entries dedupe by (kind, locator), tokens merge (capped), every waiting token still reports; regression test.
- **Codex Medium: the cache's cached-bytes branch never cached its handle** (pre-existing — a path whose bytes another pipeline loaded minted a fresh re-decoding handle on EVERY request; B.5's cross-pipeline paths made it likely) — **fixed** + cross-pipeline `Arc::ptr_eq` test.
- **Codex Medium: phase 2 gated on the boombox alone** (a fast/failed boombox could flip while the gull still streamed) — **fixed**: all three batch members `preloadThen`, a settlement count gates the transition; re-verified live (`warmed: 3` → `phase: 2`).
- **Codex Low: i32 token narrowing** — **fixed**: `preload_push_settled` takes `u64` end to end (the new surface takes no narrowing; audio's legacy i32 unchanged).
- **Claude Low: a producer forgetting to override `preload_drain_commands` would leak the queue** — **fixed**: the trait default now DRAINS (the queue lives in the same crate), and the producer overrides are gone.
- **Accepted, documented**: hot reload during warming strands the example at phase 1.5 (pending effect messages reset on reload — the HTTP-tagger rule; noted in the example header). Native/wasm drain-timing differs by ≤1 frame (imperceptible against multi-second warms). The `PENDING_*`/queue duplication vs audio stays — two consumers don't justify the abstraction yet.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

