### PR TITLE
feat(examples): webview-animated — CSS @keyframes + :hover transitions in the webview

### DIFF
--- a/examples/webview-animated/functor.json
+++ b/examples/webview-animated/functor.json
@@ -1,0 +1,4 @@
+{
+  "language": "functor-lang",
+  "entry": "game.fun"
+}

--- a/examples/webview-animated/game.fun
+++ b/examples/webview-animated/game.fun
@@ -4,7 +4,10 @@
 //  * CSS-driven: the LIVE badge pulse and the energy-bar sweep are pure
 //    `@keyframes` in the stylesheet — the model never changes for them.
 //    The webview's animation clock is the GAME clock, so `--fixed-time T`
-//    renders them deterministically at time T (natively they tick live).
+//    renders them deterministically at time T. Use `infinite` loops (as
+//    here): a one-shot animation on an element appearing mid-session
+//    resolves as already-finished under the game-clock anchor and never
+//    plays (see webview_overlay.rs) (natively they tick live).
 //  * Model-driven: the boost counter re-renders through the Elm loop —
 //    Attr.onClick(Boost) delivers a msg through `update`, coexisting with
 //    the CSS animations.

--- a/examples/webview-animated/game.fun
+++ b/examples/webview-animated/game.fun
@@ -1,0 +1,107 @@
+// webview-animated — CSS @keyframes + :hover transitions in the webview.
+//
+// Two halves of this HUD animate on DIFFERENT clocks:
+//  * CSS-driven: the LIVE badge pulse and the energy-bar sweep are pure
+//    `@keyframes` in the stylesheet — the model never changes for them.
+//    The webview's animation clock is the GAME clock, so `--fixed-time T`
+//    renders them deterministically at time T (natively they tick live).
+//  * Model-driven: the boost counter re-renders through the Elm loop —
+//    Attr.onClick(Boost) delivers a msg through `update`, coexisting with
+//    the CSS animations.
+
+type Model = { boosts: float }
+type Msg = | Boost
+
+let init = { boosts: 0.0 }
+
+let update = (m: Model, msg: Msg) =>
+  match msg with
+  | Boost => { m with boosts: m.boosts + 1.0 }
+
+// Nothing simulates per-frame: all motion is CSS- or tts-driven.
+let tick = (m: Model, dt, tts) => m
+
+// The 3D backdrop moves on draw's tts (NOT tick), so a --fixed-time sweep
+// poses it too — same 2s period as the CSS loops, for a seamless GIF.
+let draw = (m: Model, tts) =>
+  Frame.createLit(
+    Camera.lookAt(Vec3.make(0.0, 1.4, -4.5), Vec3.make(0.0, 0.6, 0.0)),
+    Scene.group([
+      Scene.sphere()
+        |> Scene.lit(Color.rgb(0.9, 0.35, 0.55))
+        |> Scene.translate(Vec3.make(0.6, 0.9 + 0.25 * Math.sin(tts * Math.pi), 0.0)),
+      Scene.sphere()
+        |> Scene.scale(0.35)
+        |> Scene.emissive(Color.rgb(0.55, 0.9, 1.0))
+        |> Scene.translate(Vec3.make(
+             0.6 + 1.6 * Math.cos(tts * Math.pi),
+             0.9,
+             1.6 * Math.sin(tts * Math.pi),
+           )),
+      Scene.plane()
+        |> Scene.lit(Color.rgb(0.16, 0.18, 0.28))
+        |> Scene.scale(9.0),
+    ]),
+    [
+      Light.ambient(Color.rgb(0.22, 0.22, 0.28)),
+      Light.directional(Vec3.make(-0.5, -1.0, 0.4), Color.rgb(1.0, 1.0, 1.0), 0.9),
+    ],
+  )
+
+// The stylesheet is plain CSS in a string. Both @keyframes share a 2s
+// period; the button's :hover fade is a 0.3s transition.
+let css = "
+  .hud { display: flex; flex-direction: column; gap: 14px; width: 320px;
+         margin: 24px; padding: 20px;
+         background: rgba(16, 18, 34, 0.9);
+         border: 2px solid #ff79c6; border-radius: 14px;
+         font-family: sans-serif; color: #f8f8f2; }
+  .titleRow { display: flex; align-items: center; justify-content: space-between; }
+  .hud h1 { margin: 0; font-size: 20px; color: #ff79c6; }
+
+  /* CSS-driven: pulses forever with zero model updates (2s period). */
+  .live { padding: 4px 12px; border-radius: 999px;
+          background: #ff5555; color: #ffffff;
+          font-size: 12px; font-weight: bold; letter-spacing: 1px;
+          animation: pulse 2s ease-in-out infinite; }
+  @keyframes pulse { 0% { opacity: 1; } 50% { opacity: 0.25; } 100% { opacity: 1; } }
+
+  /* CSS-driven: the fill sweeps 8% -> 92% -> 8% (2s period). */
+  .bar { height: 12px; border-radius: 6px;
+         background: rgba(255, 255, 255, 0.12); }
+  .fill { height: 12px; border-radius: 6px;
+          background: linear-gradient(90deg, #8be9fd, #50fa7b);
+          animation: charge 2s ease-in-out infinite; }
+  @keyframes charge { 0% { width: 8%; } 50% { width: 92%; } 100% { width: 8%; } }
+
+  /* :hover transition — the box-shadow glow + background fade in over
+     0.3s. This shows LIVE under a real cursor (run `run native` and hover
+     the button); a headless capture can't hover, so the GIF shows the
+     resting style. */
+  button { padding: 10px 16px; font-size: 16px; font-weight: bold;
+           border: none; border-radius: 8px;
+           background: #44475a; color: #f8f8f2;
+           transition: background 0.3s ease, box-shadow 0.3s ease; }
+  button:hover { background: #bd93f9;
+                 box-shadow: 0 0 18px rgba(189, 147, 249, 0.85); }
+  .count { font-size: 14px; color: #8be9fd; }
+"
+
+let webview = (m: Model) =>
+  Html.div([], [
+    Html.style(css),
+    Html.div([Attr.class("hud")], [
+      Html.div([Attr.class("titleRow")], [
+        Html.h1([], [Html.text("Reactor status")]),
+        Html.span([Attr.class("live")], [Html.text("LIVE")]),   // CSS pulse
+      ]),
+      Html.div([Attr.class("bar")], [
+        Html.div([Attr.class("fill")], []),                     // CSS sweep
+      ]),
+      // Model-driven: the click re-renders the count through `update`.
+      Html.button([Attr.onClick(Boost)], [Html.text("Boost")]),
+      Html.div([Attr.class("count")], [
+        Html.text(Text.concat("boosts: ", Text.fixed(m.boosts, 0.0))),
+      ]),
+    ]),
+  ])

--- a/runtime/functor-runtime-desktop/src/webview_overlay.rs
+++ b/runtime/functor-runtime-desktop/src/webview_overlay.rs
@@ -619,7 +619,12 @@ impl WorkerState {
                 // re-render) restarts running @keyframes mid-loop, and
                 // `--fixed-time T` — where the first resolve already happens
                 // at T — pins animations to their from-pose instead of their
-                // pose at T.
+                // pose at T. Known constraint [xreview]: a NON-infinite
+                // (one-shot) animation on an element that appears mid-session
+                // resolves as already-finished under this anchor and never
+                // plays — per-animation start-time preservation needs the DOM
+                // reconciliation follow-up (docs/todo.md § Webview). Game
+                // HUDs should use `infinite` loops + transitions meanwhile.
                 doc.resolve(0.0);
                 // A fresh document has NO layout until resolved — the hover
                 // re-establishing move below would hit-test nothing, leaving

--- a/runtime/functor-runtime-desktop/src/webview_overlay.rs
+++ b/runtime/functor-runtime-desktop/src/webview_overlay.rs
@@ -611,6 +611,16 @@ impl WorkerState {
                     },
                 )
                 .into_inner();
+                // Anchor CSS animations at game-time ZERO before resolving at
+                // the current clock: blitz starts an animation at the
+                // timestamp of the resolve that first sees it, so anchoring a
+                // fresh document at 0 makes the animation timeline the GAME
+                // clock itself. Without this, every reparse (a model-driven
+                // re-render) restarts running @keyframes mid-loop, and
+                // `--fixed-time T` — where the first resolve already happens
+                // at T — pins animations to their from-pose instead of their
+                // pose at T.
+                doc.resolve(0.0);
                 // A fresh document has NO layout until resolved — the hover
                 // re-establishing move below would hit-test nothing, leaving
                 // `wants_pointer` false until the mouse physically moves, and

--- a/runtime/functor-runtime-desktop/tests/webview_render.rs
+++ b/runtime/functor-runtime-desktop/tests/webview_render.rs
@@ -109,3 +109,66 @@ fn css_animation_ticks_under_the_clock() {
     assert_eq!(px(&at_half, w, 50, 50), [0, 0, 0, 0]);
     assert_eq!(px(&at_half, w, 150, 50), [255, 0, 0, 255]);
 }
+
+#[test]
+fn fresh_doc_anchored_at_zero_renders_the_clock_pose() {
+    // The worker's reparse path resolves a fresh document at 0.0 BEFORE the
+    // current clock (webview_overlay::run_cycle): blitz anchors an animation
+    // at the first resolve that sees it, so without the zero anchor a doc
+    // (re)parsed at clock T would render the from-pose (elapsed 0) — exactly
+    // what `--fixed-time T` captures hit, and why a model-driven re-render
+    // used to restart running @keyframes. This pins the anchoring semantics
+    // the fix relies on across blitz upgrades.
+    use anyrender::ImageRenderer;
+    use anyrender_vello_cpu::VelloCpuImageRenderer;
+    use blitz_dom::DocumentConfig;
+    use blitz_html::HtmlDocument;
+    use blitz_traits::shell::{ColorScheme, Viewport};
+
+    const ANIM_HTML: &str = r#"
+<html><head><style>
+  html, body { margin: 0; background: transparent; }
+  @keyframes slide { from { margin-left: 0px; } to { margin-left: 200px; } }
+  .box { width: 100px; height: 100px; background: rgb(255, 0, 0);
+         animation: slide 1s linear infinite; }
+</style></head>
+<body><div class="box"></div></body></html>
+"#;
+
+    let (w, h) = (400, 200);
+    let fresh_doc = || {
+        HtmlDocument::from_html(
+            ANIM_HTML,
+            DocumentConfig {
+                viewport: Some(Viewport::new(w, h, 1.0, ColorScheme::Dark)),
+                ..Default::default()
+            },
+        )
+        .into_inner()
+    };
+    let paint = |doc: &mut blitz_dom::BaseDocument| {
+        let mut renderer = VelloCpuImageRenderer::new(w, h);
+        let mut buf = Vec::new();
+        renderer.render_to_vec(
+            |scene| blitz_paint::paint_scene(scene, doc, 1.0, w, h, 0, 0),
+            &mut buf,
+        );
+        buf
+    };
+
+    // First resolve AT the clock (the old behavior): anchored at 0.5, so the
+    // pose is the from-pose — the box sits at the left edge.
+    let mut unanchored = fresh_doc();
+    unanchored.resolve(0.5);
+    let at_anchor = paint(&mut unanchored);
+    assert_eq!(px(&at_anchor, w, 50, 50), [255, 0, 0, 255]);
+
+    // Zero-anchored then resolved at the same clock (the worker's sequence):
+    // the pose is 0.5s into the animation — the box slid 100px right.
+    let mut anchored = fresh_doc();
+    anchored.resolve(0.0);
+    anchored.resolve(0.5);
+    let at_half = paint(&mut anchored);
+    assert_eq!(px(&at_half, w, 50, 50), [0, 0, 0, 0]);
+    assert_eq!(px(&at_half, w, 150, 50), [255, 0, 0, 255]);
+}


### PR DESCRIPTION
Stacked on #414 (threaded webview rendering) — this PR targets `feat/webview-render-thread` and should retarget to `main` when #414 merges.

A new demo-card example, `examples/webview-animated`, showing off CSS animations and transitions in the webview — plus a one-line runtime fix that makes the "webview animation clock is the game clock" story actually hold.

## What the example demonstrates

Two halves of the HUD animate on different clocks, called out with comments in the source:

- **CSS-driven** (zero model updates): a pulsing `LIVE` badge (`@keyframes` opacity loop) and a sweeping energy bar (`@keyframes` width loop), both on a shared 2s period.
- **`:hover` transition**: the Boost button's background + box-shadow glow fade in over 0.3s under a real cursor (a headless capture can't hover, so the GIF shows the resting style — run `functor -d examples/webview-animated run native` and hover to see it live).
- **The Elm loop still present**: `Attr.onClick(Boost)` folds through `update` and re-renders the boost counter — model-driven re-render coexisting with CSS-driven animation.

The 3D backdrop (a lit sphere + an emissive orbiter) moves on `draw`'s `tts` — not `tick` — with the same 2s period, so a `--fixed-time` sweep poses everything coherently.

## fix(webview): anchor CSS animations at game-time zero on reparse

blitz starts an animation at the timestamp of the **first resolve that sees it**, and the render worker's first resolve of a fresh document happened at the *current* clock. Two consequences:

- every reparse (a model-driven re-render, e.g. clicking a button) **restarted running `@keyframes` mid-loop**;
- under `--fixed-time T` the first resolve already happens at T, so captures always rendered the **from-pose** (elapsed 0) instead of the pose at T.

The fix resolves a fresh document at `0.0` before resolving at the current clock, making the animation timeline the game clock itself. A new test in `webview_render.rs` pins the anchoring semantics (first-resolve-at-T = from-pose; zero-anchored = pose at T) against blitz upgrades.

## Determinism evidence

`--fixed-time T` now deterministically renders CSS animations at time T:

- capture at `--fixed-time 0.5` twice → **byte-identical** PNGs (`cmp` clean, PIL diff bbox `None`);
- capture at `--fixed-time 0.5` vs `1.0` → the keyframes moved: the energy-bar fill measures 319 px vs 587 px (device px), matching the 8% → 92% `@keyframes` sweep, and the badge opacity differs.

Every one of the GIF's 24 frames is such a deterministic `--fixed-time` capture swept over `[0, 2)` — consecutive frames all differ (PIL-verified), and the loop is seamless because all animations share the 2s period.

## Media

![webview-animated demo](https://gist.githubusercontent.com/tommy-xr/21b373b0c80884486e7a7685f128a847/raw/demo.gif)

<sub>One 2s period: the LIVE badge pulses and the energy bar sweeps via pure CSS `@keyframes` while the tts-driven spheres orbit behind. 24 frames rendered headlessly via `--capture-frame` / `--fixed-time` over `[0, 2)`.</sub>

![still at t=1.0](https://gist.githubusercontent.com/tommy-xr/21b373b0c80884486e7a7685f128a847/raw/shot.png)

<sub>Still at `--fixed-time 1.0`: the bar at its 92% peak, the badge mid-fade at 0.25 opacity — CSS state pinned deterministically by the game clock.</sub>

## Verification

- `functor -d examples/webview-animated build native` — typechecks.
- `cargo test -p functor-cli` — 29 passed, including `every_shipped_example_typechecks` (the new example joins the sweep automatically).
- `cargo test -p functor-runtime-desktop --test webview_render` — 4 passed, including the new anchor test.
- `cargo check -p functor-runtime-desktop --features strict` — clean.
- `webview_bench` (release, interleaved runs, min column): before/after parse mins overlap (523–602 us vs 581–600 us, medians swing 2× run-to-run) — the bench's parse+resolve path itself is unchanged (it already anchors at 0.0); the fix adds one incremental resolve per **reparse**, off the per-frame path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
