### PR TITLE
feat(vscode): bundle the functor CLI in platform VSIXes — all-in-one install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,15 @@ jobs:
           pattern: lsp-*
           path: lsp
 
+      # The platform archives — each VSIX also bundles its platform's functor
+      # CLI, so the extension is an all-in-one install (archive names are
+      # unique, so a flat merge is safe).
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: functor-*
+          path: cli
+          merge-multiple: true
+
       # Root deps too: the extension's vscode:prepublish hook runs the repo's
       # icon generator (scripts/generate-icons.mjs).
       - name: Install npm dependencies
@@ -147,14 +156,21 @@ jobs:
             x86_64-pc-windows-msvc:win32-x64; do
             target="${pair%%:*}"
             vt="${pair##*:}"
-            rm -rf server && mkdir server
+            rm -rf server bin && mkdir server bin
             if [[ "$vt" == win32-x64 ]]; then
               cp "$GITHUB_WORKSPACE/lsp/lsp-$target/functor-lang-lsp.exe" server/
+              # The zip carries the binary at the archive root. unzip, NOT
+              # tar: ubuntu's GNU tar cannot read zip (bsdtar is a mac thing).
+              unzip -o -j "$GITHUB_WORKSPACE/cli/functor-$VERSION-$target.zip" functor.exe -d bin
             else
               # download-artifact does not preserve the exec bit; vsce records
               # file modes into the VSIX, so restore it before packaging.
               cp "$GITHUB_WORKSPACE/lsp/lsp-$target/functor-lang-lsp" server/
               chmod +x server/functor-lang-lsp
+              # The tarball nests functor-<version>-<target>/functor.
+              tar -xzf "$GITHUB_WORKSPACE/cli/functor-$VERSION-$target.tar.gz" -C bin \
+                --strip-components=1 "functor-$VERSION-$target/functor"
+              chmod +x bin/functor
             fi
             npx --yes @vscode/vsce@3.9.2 package --target "$vt" --pre-release \
               --out "out/functor-lang-$VERSION-$vt.vsix"

--- a/tools/functor-lang-vscode/README.md
+++ b/tools/functor-lang-vscode/README.md
@@ -13,9 +13,11 @@ Language support for `.fun` source files and `.funi` interface files
   game updates without losing state. A broken edit keeps the old program
   running; push results land in the status bar (errors also in the
   "Functor Lang Preview" output channel). Uses the `functor` CLI: the
-  `functor.functorPath` setting (PATH by default), else a previously
-  downloaded copy, else the extension offers to download the newest GitHub
-  release for your platform (~17 MB, into the extension's global storage).
+  `functor.functorPath` setting when set; otherwise the binary **bundled in
+  the platform VSIX** (released builds ship one, so the extension works
+  all-in-one), else PATH, else a previously downloaded copy — and when none
+  of those run, the extension offers to download the newest GitHub release
+  for your platform (~17 MB, into the extension's global storage).
 
 ## The `functor-lang-lsp` language server
 

--- a/tools/functor-lang-vscode/client/cli-download.js
+++ b/tools/functor-lang-vscode/client/cli-download.js
@@ -47,6 +47,12 @@ function downloadedCliPath(storageDir, platform) {
   return path.join(storageDir, "bin", platform === "win32" ? "functor.exe" : "functor");
 }
 
+// Where the platform VSIX bundles the functor CLI (staged by the release
+// pipeline next to the language server; absent in dev checkouts).
+function bundledCliPath(extensionDir, platform) {
+  return path.join(extensionDir, "bin", platform === "win32" ? "functor.exe" : "functor");
+}
+
 // `cmd --version`'s first stdout line, or null when it can't run (ENOENT/any
 // spawn error, nonzero exit, 10s hang). Doubles as the availability probe
 // (commandWorks) and the version shown in the status bar tooltip.
@@ -184,6 +190,7 @@ module.exports = {
   assetTargetFor,
   pickAsset,
   downloadedCliPath,
+  bundledCliPath,
   commandVersion,
   commandWorks,
   fetchJson,

--- a/tools/functor-lang-vscode/client/extension.js
+++ b/tools/functor-lang-vscode/client/extension.js
@@ -45,6 +45,9 @@ let previewProjectDir;
 // The extension's global-storage dir (set in activate) — where a
 // downloaded-on-demand functor CLI is installed (see resolveFunctorCli).
 let globalStorageDir;
+// The extension's install dir (set in activate) — where a platform VSIX
+// bundles the functor CLI (bin/) and the language server (server/).
+let extensionDir;
 // The "$(zap) functor" status bar item; its tooltip lists the extension,
 // language server, and functor CLI versions as they become known.
 let versionStatus;
@@ -79,6 +82,7 @@ const elog = (text) => {
 
 function activate(context) {
   globalStorageDir = context.globalStorageUri.fsPath;
+  extensionDir = context.extensionPath;
   channel = vscode.window.createOutputChannel("Functor Lang");
   context.subscriptions.push(channel);
   elog("extension activated");
@@ -287,25 +291,44 @@ function waitForServer(timeoutMs) {
   });
 }
 
-// Fill in the tooltip's CLI line: the configured/PATH binary, else a
-// previously downloaded copy. Runs in the background at activation.
+// The auto-resolution candidates for the functor CLI, in order (mirrors the
+// language server's serverPath semantics): the binary bundled in a platform
+// VSIX (version-matched to the extension) → PATH → a previously downloaded
+// copy in global storage.
+function autoCliCandidates() {
+  return [
+    cliDownload.bundledCliPath(extensionDir, process.platform),
+    "functor",
+    cliDownload.downloadedCliPath(globalStorageDir, process.platform),
+  ];
+}
+
+// Fill in the tooltip's CLI line. Runs in the background at activation.
+// Mirrors resolveFunctorCliUncached: an explicit setting never falls through,
+// so a broken one reports itself rather than promising a download.
 async function probeCliVersion() {
-  const configured =
-    vscode.workspace.getConfiguration("functor").get("functorPath") || "functor";
-  versionInfo.cli =
-    (await cliDownload.commandVersion(configured)) ||
-    (await cliDownload.commandVersion(
-      cliDownload.downloadedCliPath(globalStorageDir, process.platform)
-    )) ||
-    "not found — the live preview offers a download";
+  const configured = vscode.workspace.getConfiguration("functor").get("functorPath");
+  if (configured) {
+    versionInfo.cli =
+      (await cliDownload.commandVersion(configured)) ||
+      `functor.functorPath ("${configured}") did not run`;
+  } else {
+    let v = null;
+    for (const candidate of autoCliCandidates()) {
+      v = await cliDownload.commandVersion(candidate);
+      if (v) break;
+    }
+    versionInfo.cli = v || "not found — the live preview offers a download";
+  }
   renderVersionStatus();
 }
 
 // Resolve the `functor` CLI the preview spawns: the functor.functorPath
-// setting (default: `functor` from PATH) → a previously downloaded copy in
-// global storage → offer to download the newest release's platform archive.
-// Returns the command to spawn, or null (unsupported platform, declined, or
-// failed download — the user has been messaged in every null case).
+// setting when set (an explicit-but-broken setting errors rather than
+// silently falling through) → the auto candidates above → offer to download
+// the newest release's platform archive. Returns the command to spawn, or
+// null (unsupported platform, declined, or failed download — the user has
+// been messaged in every null case).
 //
 // Concurrent invocations share one in-flight resolution: a second "Open Live
 // Preview" during the download must not race a second download/extract into
@@ -321,14 +344,19 @@ function resolveFunctorCli() {
 }
 
 async function resolveFunctorCliUncached() {
-  const configured =
-    vscode.workspace.getConfiguration("functor").get("functorPath") || "functor";
-  if (await cliDownload.commandWorks(configured)) return configured;
-
-  const downloaded = cliDownload.downloadedCliPath(globalStorageDir, process.platform);
-  if (await cliDownload.commandWorks(downloaded)) {
-    elog(`preview: using downloaded CLI ${downloaded}`);
-    return downloaded;
+  const configured = vscode.workspace.getConfiguration("functor").get("functorPath");
+  if (configured) {
+    if (await cliDownload.commandWorks(configured)) return configured;
+    vscode.window.showErrorMessage(
+      `Functor: functor.functorPath ("${configured}") did not run — fix or clear the setting.`
+    );
+    return null;
+  }
+  for (const candidate of autoCliCandidates()) {
+    if (await cliDownload.commandWorks(candidate)) {
+      elog(`preview: using functor CLI ${candidate}`);
+      return candidate;
+    }
   }
 
   // Nothing runnable — offer the download.
@@ -338,20 +366,20 @@ async function resolveFunctorCliUncached() {
     asset = cliDownload.pickAsset(releases, process.platform, process.arch);
   } catch (e) {
     vscode.window.showErrorMessage(
-      `Functor: "${configured}" was not found, and querying GitHub releases failed ` +
+      `Functor: the functor CLI was not found (not bundled, not on PATH), and querying GitHub releases failed ` +
         `(${e.message}) — install the functor CLI and/or set functor.functorPath.`
     );
     return null;
   }
   if (!asset) {
     vscode.window.showErrorMessage(
-      `Functor: "${configured}" was not found and no prebuilt functor CLI exists for ` +
+      `Functor: the functor CLI was not found and no prebuilt one exists for ` +
         `${process.platform}-${process.arch} — build it from source and set functor.functorPath.`
     );
     return null;
   }
   const choice = await vscode.window.showInformationMessage(
-    `Functor: the functor CLI ("${configured}") was not found. ` +
+    `Functor: the functor CLI was not found (not bundled, not on PATH). ` +
       `Download functor v${asset.version} for this platform from GitHub releases (~17 MB)?`,
     "Download",
     "Cancel"

--- a/tools/functor-lang-vscode/package.json
+++ b/tools/functor-lang-vscode/package.json
@@ -48,8 +48,8 @@
       "properties": {
         "functor.functorPath": {
           "type": "string",
-          "default": "functor",
-          "description": "Path to the `functor` CLI binary the live preview uses to serve the game. Resolved from PATH by default; when nothing runnable is found, the extension offers to download the newest release for this platform."
+          "default": "",
+          "description": "Path to the `functor` CLI binary the live preview uses to serve the game. Empty (the default) resolves automatically: the binary bundled with the extension, else PATH, else a previously downloaded copy — offering a download of the newest release when none of those run."
         },
         "functor.serverPath": {
           "type": "string",


### PR DESCRIPTION
Stacked on #410 (review the last commit). Completes the all-in-one story: a Marketplace install of the extension now carries **everything** — language server *and* the `functor` CLI the live preview spawns, all version-matched to the same release tag (visible in the status bar tooltip).

## What

- The `vsix` job also stages each platform's `functor` binary — extracted from the release archives already built in the same run — into the extension's `bin/` before packaging. Platform VSIXes grow to **~17.5 MB** (from ~1.1 MB), which is normal territory for binary-bundling extensions.
- `functor.functorPath`'s default becomes `""` (auto), mirroring `functor.serverPath`: an explicit setting always wins and **errors loudly when broken** (no silent fallthrough); auto resolves **bundled → PATH → previously downloaded copy → download-on-demand offer**. Dev checkouts have no bundled binary, so PATH still wins there (the e2e harness's `target/debug` PATH injection keeps working). The status bar probe mirrors the same chain via a shared `autoCliCandidates()`.

## Verification

- `npm test` — 21 pass; `actionlint` clean.
- The exact CI packaging loop run locally against the **real published v0.1.0 archives** (win32 zip + correctly-nested tarballs): all four VSIXes package with `extension/bin/functor(.exe)` + `extension/server/*`, exec bits recorded in the zip.
- /xreview (Claude + Codex) earned its keep twice here:
  - **[AGREED] ubuntu's GNU tar cannot read zip** — my local loop only passed because macOS `tar` is bsdtar. The win32 extraction now uses `unzip -o -j` (preinstalled on the runners). The *extension's* zip handling is unaffected (it runs on the user's machine, where Windows 10+ `tar.exe` is bsdtar).
  - Codex caught that a stray `git checkout package.json` after my packaging simulation had **reverted the default-`""` change** before committing — the auto chain would have been unreachable. Restored, and the broken-explicit-path tooltip message now matches the resolver's semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)