### PR TITLE
feat(webview): native text input — keyboard routing, focus survival across re-renders

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -709,12 +709,21 @@ Attr.onClick(msg)                                          // INTERACTIVE (the U
                                                            //    "kind":"Clicked"}.
 Attr.onInput(tagger)                                       // INTERACTIVE (the Ui.textInput
                                                            //   shape): each edit applies the
-                                                           //   tagger to the new text. NOTE: text
-                                                           //   inputs are wasm-complete; native
-                                                           //   focus/keyboard routing is still a
-                                                           //   prototype gap (clicks work
-                                                           //   everywhere). `examples/webview` is
-                                                           //   the reference
+                                                           //   tagger to the new text, on BOTH
+                                                           //   shells — clicking the input
+                                                           //   focuses it, keys then type into
+                                                           //   the field instead of the game's
+                                                           //   `input` hook (Escape defocuses
+                                                           //   first, releases the cursor
+                                                           //   second), and focus survives the
+                                                           //   per-edit re-render (caret resets
+                                                           //   to the end when an update
+                                                           //   transforms the text — the
+                                                           //   Ui.textInput rule). IME
+                                                           //   composition (CJK/dead keys) is
+                                                           //   native-deferred.
+                                                           //   `examples/webview` is the
+                                                           //   reference
 
 Physics.tag("name")                                        // BRANDED body identity (the
                                                            //   RenderTarget rule): declare

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -86,14 +86,17 @@ Prototype landed 2026-07-18: `webview(model)` → `Html.*`/`Attr.*` tree, blitz
 (CPU-painted) natively, DOM overlay on wasm; clicks fold through `update`.
 Remaining, roughly in priority order:
 
-- [ ] Native text input: route focus/keyboard into blitz (`Ui.textInput`'s
-      wants-keyboard gate; blitz has `Input` events + form support). wasm
-      inputs already work.
+- [x] Native text input (2026-07-18): GLFW keys route into blitz while an
+      `Html.input` is focused (`Ui.textInput`'s wants-keyboard gate; Escape
+      defocuses first), and focus survives the per-keystroke document rebuild
+      via the `data-fn-input` slot (caret to end). IME composition (CJK/
+      dead keys) deferred — blitz has `Ime` events when we want it.
 - [x] Record webview events for replay — needs their own `RecordedInput`
       variant (a `UiEvent` entry would replay against the wrong handler
       table; TODO comments in both producers).
-- [ ] Reconcile the DOM instead of full reparse on change (also fixes
-      focus/caret loss in wasm controlled inputs, and native selection state).
+- [ ] Reconcile the DOM instead of full reparse on change (would preserve
+      native selection state and text-input scroll across re-renders; the
+      focus/caret loss itself is now papered over by the slot-restore).
 - [ ] Cache the serialized HTML in the producer (today: tree clone +
       `to_html` per frame per shell — the `webview_bench` numbers).
 - [x] Tick CSS animations/transitions: the render worker repaints while

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -89,8 +89,11 @@ Remaining, roughly in priority order:
 - [x] Native text input (2026-07-18): GLFW keys route into blitz while an
       `Html.input` is focused (`Ui.textInput`'s wants-keyboard gate; Escape
       defocuses first), and focus survives the per-keystroke document rebuild
-      via the `data-fn-input` slot (caret to end). IME composition (CJK/
-      dead keys) deferred — blitz has `Ime` events when we want it.
+      via the `data-fn-input` slot (caret to end). Deferred: IME composition
+      (CJK/dead keys — blitz has `Ime` events when we want it), modifier
+      combos (shift-selection/select-all/clipboard; blitz supports them, the
+      lowering drops modifiers today), and native `placeholder` rendering
+      (blitz has none — wasm shows it).
 - [x] Record webview events for replay — needs their own `RecordedInput`
       variant (a `UiEvent` entry would replay against the wrong handler
       table; TODO comments in both producers).

--- a/e2e/webview-input.spec.mjs
+++ b/e2e/webview-input.spec.mjs
@@ -1,0 +1,44 @@
+import { test, expect } from "@playwright/test";
+
+// The wasm controlled-input path, end to end through a REAL DOM: click the
+// shadow-root <input> of examples/webview, type, and assert the model
+// round-trip (the greeting line) — including focus survival across the
+// per-keystroke innerHTML swap (the slot + selection restore in
+// index-functor-lang.html's setupWebview). The native counterpart is the
+// worker-level keyboard/focus tests in
+// runtime/functor-runtime-desktop/src/webview_overlay.rs.
+//
+// Run with the webview sample served:
+//   FUNCTOR_SAMPLE=webview npx playwright test e2e/webview-input.spec.mjs
+const SAMPLE = process.env.FUNCTOR_SAMPLE || "lighting";
+
+test.describe(() => {
+  test.skip(SAMPLE !== "webview", "needs the webview sample: FUNCTOR_SAMPLE=webview");
+
+  test("typing into the webview input round-trips through the model", async ({ page }) => {
+    const errors = [];
+    page.on("pageerror", (e) => errors.push(String(e)));
+    page.on("console", (m) => {
+      if (m.type() === "error") errors.push(m.text());
+    });
+
+    await page.goto("/");
+    await expect(page.locator("#canvas")).toBeVisible();
+    // Wasm init + the first webview render (the overlay polls per rAF).
+    const input = page.locator("#webview input");
+    await expect(input).toBeVisible({ timeout: 30000 });
+    await expect(input).toHaveAttribute("placeholder", "your name");
+
+    await input.click();
+    // Slow enough that every keystroke's model round-trip swaps the overlay's
+    // innerHTML BETWEEN characters — each subsequent character only lands if
+    // the swap re-focused the rebuilt input (the focus-survival seam).
+    await input.pressSequentially("Ada", { delay: 150 });
+
+    await expect(input).toHaveValue("Ada");
+    await expect(
+      page.locator("#webview p").filter({ hasText: "Hello, Ada!" }),
+    ).toBeVisible();
+    expect(errors, `page errors:\n${errors.join("\n")}`).toEqual([]);
+  });
+});

--- a/examples/webview/game.fun
+++ b/examples/webview/game.fun
@@ -11,19 +11,21 @@
 // while the cascade half (selectors, :hover) stays a CSS string in
 // `Html.style`.
 
-type Model = { count: float, spin: float }
+type Model = { count: float, spin: float, name: string }
 type Msg =
   | Inc
   | Dec
   | Reset
+  | SetName(name: string)
 
-let init = { count: 0.0, spin: 0.0 }
+let init = { count: 0.0, spin: 0.0, name: "" }
 
 let update = (m: Model, msg: Msg) =>
   match msg with
   | Inc => { m with count: m.count + 1.0 }
   | Dec => { m with count: m.count - 1.0 }
   | Reset => { m with count: 0.0 }
+  | SetName(name) => { m with name: name }
 
 let tick = (m: Model, dt, tts) => { m with spin: m.spin + dt * 20.0 }
 
@@ -53,7 +55,20 @@ let css = "
            background: #50fa7b; color: #1e1e3c; border: none; border-radius: 8px; }
   button:hover { background: #f1fa8c; }
   button.ghost { background: transparent; color: #8be9fd; border: 1px solid #8be9fd; }
+  input { padding: 8px 10px; font-size: 16px; font-family: sans-serif;
+          background: rgba(10, 12, 28, 0.9); color: #f8f8f2;
+          border: 1px solid #8be9fd; border-radius: 8px; }
 "
+
+// A CONTROLLED text input (the Ui.textInput loop, HTML flavor): the field
+// shows the MODEL's text, each keystroke delivers SetName(newText) through
+// `update`, and the greeting proves the round-trip. Natively, keys route
+// into the blitz document while the field is focused (the game's `input`
+// hook is suppressed; Escape defocuses first, releases the cursor second).
+let greeting = (m: Model) =>
+  match m.name == "" with
+  | true => "Type your name above."
+  | false => Text.concat("Hello, ", Text.concat(m.name, "!"))
 
 let webview = (m: Model) =>
   Html.div([], [
@@ -70,5 +85,7 @@ let webview = (m: Model) =>
         Html.button([Attr.onClick(Inc)], [Html.text("+")]),
         Html.button([Attr.class("ghost"), Attr.onClick(Reset)], [Html.text("Reset")]),
       ]),
+      Html.input([Attr.value(m.name), Attr.placeholder("your name"), Attr.onInput(SetName)]),
+      Html.p([], [Html.text(greeting(m))]),
     ]),
   ])

--- a/runtime/functor-runtime-desktop/Cargo.toml
+++ b/runtime/functor-runtime-desktop/Cargo.toml
@@ -65,6 +65,9 @@ blitz-traits = "=0.3.0-beta.1"
 anyrender = "=0.11.1"
 anyrender_vello_cpu = "=0.14.0"
 markup5ever = "0.39"
+# The key/code/modifier vocabulary of blitz's BlitzKeyEvent (keep in lockstep
+# with the version blitz-traits uses).
+keyboard-types = "0.7"
 
 [dev-dependencies]
 functor_runtime_common = { path = "./../functor-runtime-common" }

--- a/runtime/functor-runtime-desktop/src/lib.rs
+++ b/runtime/functor-runtime-desktop/src/lib.rs
@@ -35,6 +35,10 @@ mod run;
 // headless render test in tests/.
 #[cfg(not(target_arch = "wasm32"))]
 pub mod webview_overlay;
+// The GLFW→blitz keyboard lowering for the webview overlay (native text
+// input): the plain-data key type crossing the worker channel + its mapping.
+#[cfg(not(target_arch = "wasm32"))]
+mod webview_keys;
 #[cfg(not(target_arch = "wasm32"))]
 mod ws_host;
 #[cfg(not(target_arch = "wasm32"))]

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -543,6 +543,12 @@ fn service_debug_request(
     held_keys: &mut BTreeSet<InputKey>,
     mouse_pos: &mut (i32, i32),
     clock: &mut GameClock,
+    // The webview keyboard gate, mirrored from the GLFW routing: `Some` iff a
+    // webview text field is focused (`webview_wants_keyboard`), and injected
+    // keys then type into it (queued into the next frame's WorkerInput)
+    // instead of reaching the game. Always `None` in the headless loop, which
+    // has no webview overlay.
+    mut webview_keyboard: Option<&mut Vec<crate::webview_keys::WebviewKey>>,
     capture: &dyn Fn() -> Result<Vec<u8>, debug_server::CaptureError>,
 ) {
     match req {
@@ -589,18 +595,34 @@ fn service_debug_request(
         }
         debug_server::DebugRequest::Input(cmd, resp) => {
             let result = match cmd {
-                debug_server::InputCommand::Key { key, down } => match key_from_str(&key) {
-                    Some(k) => {
-                        game.key_event(k as i32, down);
+                debug_server::InputCommand::Key { key, down } => {
+                    // The focus gate first (the GLFW routing rule): while a
+                    // webview field is focused, an injected press types into
+                    // it (or is swallowed if unmapped, like non-edit GLFW
+                    // presses) and its release is swallowed too — never a
+                    // phantom edge to the game's `input` hook.
+                    if let Some(webview_keys) = webview_keyboard.as_deref_mut() {
                         if down {
-                            held_keys.insert(k);
-                        } else {
-                            held_keys.remove(&k);
+                            if let Some(k) = crate::webview_keys::webview_key_from_str(&key) {
+                                webview_keys.push(k);
+                            }
                         }
                         Ok(())
+                    } else {
+                        match key_from_str(&key) {
+                            Some(k) => {
+                                game.key_event(k as i32, down);
+                                if down {
+                                    held_keys.insert(k);
+                                } else {
+                                    held_keys.remove(&k);
+                                }
+                                Ok(())
+                            }
+                            None => Err(format!("unknown key: {}", key)),
+                        }
                     }
-                    None => Err(format!("unknown key: {}", key)),
-                },
+                }
                 debug_server::InputCommand::MouseMove { x, y } => {
                     *mouse_pos = (x, y);
                     game.mouse_move(x, y);
@@ -713,6 +735,7 @@ fn run_headless(
                     &mut held_keys,
                     &mut mouse_pos,
                     &mut clock,
+                    None, // no webview overlay in headless
                     &|| {
                         Err(debug_server::CaptureError::Unavailable(
                             "capture is unavailable in --headless mode".to_string(),
@@ -903,6 +926,15 @@ pub fn run(args: Args) {
         // `input` hook, and Escape defocuses the field instead of releasing
         // the cursor (docs/ui-interaction.md U4).
         let mut ui_wants_keyboard = false;
+        // Same latch for the webview overlay (an `Html.input` is focused in
+        // the blitz document): keyboard input routes to the webview under
+        // the identical rules — see the `ui_wants_keyboard` arms below.
+        let mut webview_wants_keyboard = false;
+        // Keyboard input queued for the focused webview field, drained into
+        // each frame's WorkerInput. Persistent (not per-frame) because the
+        // debug server's injected keys land AFTER the frame's overlay pass —
+        // they type on the next frame, like a keystroke between frames.
+        let mut webview_keys: Vec<crate::webview_keys::WebviewKey> = Vec::new();
         // The time-travel console (`~`): HIDDEN by default in the native game
         // (it's a dev tool you summon with `~`, which also frees the cursor so
         // you can scrub right away; --scrubber starts it open, e.g. for
@@ -1116,9 +1148,22 @@ pub fn run(args: Args) {
             // pinned nothing is collected — typing is inert like all other
             // window input.
             let mut ui_keyboard: Vec<functor_runtime_common::ui::UiKeyboardEvent> = Vec::new();
+            // Webview keystrokes collect into the persistent `webview_keys`
+            // queue (declared above the loop). The webview arms sit FIRST:
+            // it draws above the game UI, so when both latches are somehow up
+            // the webview field wins (the scrubber-over-ui rule, keyboard
+            // flavor).
             for (_, event) in glfw::flush_messages(&events) {
+                use crate::webview_keys::WebviewKey;
                 match event {
                     glfw::WindowEvent::Close => window.set_should_close(true),
+                    // Printable text for a focused webview field (the egui
+                    // Char rule below, webview flavor).
+                    glfw::WindowEvent::Char(c)
+                        if webview_wants_keyboard && !ignore_user_input =>
+                    {
+                        webview_keys.push(WebviewKey::Char(c));
+                    }
                     // Printable text for a focused field. Only meaningful
                     // while the overlay wants the keyboard; otherwise Char
                     // events are dropped (the game hears keys, not text).
@@ -1127,6 +1172,15 @@ pub fn run(args: Args) {
                     {
                         ui_keyboard
                             .push(functor_runtime_common::ui::UiKeyboardEvent::Char(c));
+                    }
+                    // While a webview field is focused, Escape DEFOCUSES it
+                    // (the worker blurs the blitz document — blitz has no
+                    // built-in Escape) instead of releasing the cursor; the
+                    // next Escape then falls through to the arm below.
+                    glfw::WindowEvent::Key(Key::Escape, _, Action::Press, _)
+                        if webview_wants_keyboard && !ignore_user_input =>
+                    {
+                        webview_keys.push(WebviewKey::Escape);
                     }
                     // While a field is focused, Escape DEFOCUSES it (egui's
                     // built-in) instead of releasing the cursor — the next
@@ -1158,10 +1212,11 @@ Escape again to quit"
                     // free-look. Before the `ignore_user_input` catch-all so it
                     // works while the clock is pinned (paused). Never grabs the
                     // pointer on a hidden window. Guarded off while a text
-                    // field is focused — typing '`' must insert, not toggle
-                    // (the char arrives via the Char arm above).
+                    // field (egui or webview) is focused — typing '`' must
+                    // insert, not toggle (the char arrives via a Char arm
+                    // above).
                     glfw::WindowEvent::Key(Key::GraveAccent, _, Action::Press, _)
-                        if !ui_wants_keyboard =>
+                        if !ui_wants_keyboard && !webview_wants_keyboard =>
                     {
                         scrubber_visible = !scrubber_visible;
                         if !hidden {
@@ -1209,6 +1264,15 @@ Escape again to quit"
                                 } else {
                                     window.set_cursor_mode(glfw::CursorMode::Disabled);
                                     cursor_captured = true;
+                                    // Entering free-look: blur any focused
+                                    // webview field. The recapturing click
+                                    // never reaches the blitz document (the
+                                    // captured pointer is hidden from the
+                                    // overlay), so without this the field
+                                    // would keep eating WASD as text.
+                                    if webview_wants_keyboard {
+                                        webview_keys.push(WebviewKey::Escape);
+                                    }
                                 }
                             }
                             Action::Release => mouse_primary_down = false,
@@ -1243,13 +1307,17 @@ Escape again to quit"
                         let k = map_key(key);
                         // Deliver the release only if the game SAW the press
                         // (it's in held_keys) — a press swallowed by a focused
-                        // text field must not leak a phantom release edge to
-                        // the game's `input` hook (xreview). Unknown keys are
-                        // never tracked; keep their pre-existing passthrough,
-                        // but not while a field is focused.
+                        // text field (egui or webview) must not leak a phantom
+                        // release edge to the game's `input` hook (xreview).
+                        // Unknown keys are never tracked; keep their
+                        // pre-existing passthrough, but not while a field is
+                        // focused.
                         let was_held = held_keys.remove(&k);
                         if !ignore_user_input
-                            && (was_held || (k == InputKey::Unknown && !ui_wants_keyboard))
+                            && (was_held
+                                || (k == InputKey::Unknown
+                                    && !ui_wants_keyboard
+                                    && !webview_wants_keyboard))
                         {
                             game.key_event(k as i32, false);
                         }
@@ -1271,6 +1339,31 @@ Escape again to quit"
                         mouse_primary_clicked = false;
                     }
                     _ if ignore_user_input => {}
+                    // While a webview field is focused, key presses drive the
+                    // WEBVIEW: the editing subset maps to `WebviewKey`s the
+                    // render worker lowers to blitz key events (Repeat works —
+                    // each press lowers to a full pair), printable keys arrive
+                    // via the Char arm, and the game's `input` hook hears none
+                    // of it (the focus gate — presses swallowed here never
+                    // enter held_keys, so the release arm can't leak a
+                    // phantom edge either).
+                    glfw::WindowEvent::Key(key, _, Action::Press | Action::Repeat, _)
+                        if webview_wants_keyboard =>
+                    {
+                        let mapped = match key {
+                            Key::Backspace => Some(WebviewKey::Backspace),
+                            Key::Delete => Some(WebviewKey::Delete),
+                            Key::Left => Some(WebviewKey::Left),
+                            Key::Right => Some(WebviewKey::Right),
+                            Key::Home => Some(WebviewKey::Home),
+                            Key::End => Some(WebviewKey::End),
+                            Key::Enter => Some(WebviewKey::Enter),
+                            _ => None,
+                        };
+                        if let Some(mapped) = mapped {
+                            webview_keys.push(mapped);
+                        }
+                    }
                     // While a field is focused, key presses drive the OVERLAY:
                     // the editing subset maps across (press+release pairs are
                     // synthesized by the lowering, so Repeat works), printable
@@ -1927,9 +2020,11 @@ Escape again to quit"
                 dpi_scale,
                 webview_html.as_deref(),
                 webview_pointer,
+                std::mem::take(&mut webview_keys),
                 time.tts as f64,
             );
             webview_wants_pointer = webview_out.wants_pointer;
+            webview_wants_keyboard = webview_out.wants_keyboard;
             if !ignore_user_input {
                 for event in webview_out.events {
                     game.webview_event(event);
@@ -2093,6 +2188,14 @@ Escape again to quit"
                         &mut held_keys,
                         &mut mouse_pos,
                         &mut clock,
+                        // The webview focus gate: injected keys type into a
+                        // focused webview field (queued for the next frame's
+                        // overlay pass) instead of reaching the game.
+                        if webview_wants_keyboard {
+                            Some(&mut webview_keys)
+                        } else {
+                            None
+                        },
                         // GL readback on the render thread (a real Failed on error).
                         &|| {
                             encode_framebuffer_png(&gl, fb_width as u32, fb_height as u32)

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -597,25 +597,36 @@ fn service_debug_request(
             let result = match cmd {
                 debug_server::InputCommand::Key { key, down } => {
                     // The focus gate first (the GLFW routing rule): while a
-                    // webview field is focused, an injected press types into
+                    // webview field is focused, an injected PRESS types into
                     // it (or is swallowed if unmapped, like non-edit GLFW
-                    // presses) and its release is swallowed too — never a
-                    // phantom edge to the game's `input` hook.
-                    if let Some(webview_keys) = webview_keyboard.as_deref_mut() {
-                        if down {
+                    // presses). Releases never route to the webview — they
+                    // take the game path with the GLFW release arm's
+                    // held-key discipline, so a key held from before focus
+                    // can't stick, and a press the webview swallowed can't
+                    // leak a phantom release edge. [xreview]
+                    if down {
+                        if let Some(webview_keys) = webview_keyboard.as_deref_mut() {
                             if let Some(k) = crate::webview_keys::webview_key_from_str(&key) {
                                 webview_keys.push(k);
                             }
+                            Ok(())
+                        } else {
+                            match key_from_str(&key) {
+                                Some(k) => {
+                                    game.key_event(k as i32, true);
+                                    held_keys.insert(k);
+                                    Ok(())
+                                }
+                                None => Err(format!("unknown key: {}", key)),
+                            }
                         }
-                        Ok(())
                     } else {
                         match key_from_str(&key) {
                             Some(k) => {
-                                game.key_event(k as i32, down);
-                                if down {
-                                    held_keys.insert(k);
-                                } else {
-                                    held_keys.remove(&k);
+                                // Deliver the release only if the game saw
+                                // the press (mirrors the GLFW release arm).
+                                if held_keys.remove(&k) {
+                                    game.key_event(k as i32, false);
                                 }
                                 Ok(())
                             }

--- a/runtime/functor-runtime-desktop/src/webview_keys.rs
+++ b/runtime/functor-runtime-desktop/src/webview_keys.rs
@@ -1,0 +1,206 @@
+//! GLFW → blitz keyboard lowering for the native webview overlay.
+//!
+//! The run loop collects keyboard input for a focused webview text field as
+//! [`WebviewKey`]s — plain data that crosses the worker channel (no blitz
+//! types, the `webview_overlay` protocol rule) — and the render worker lowers
+//! each one to the [`blitz_traits::events::UiEvent`]s blitz's editing stack
+//! expects: a `KeyDown`/`KeyUp` pair (blitz edits on the down; the up keeps
+//! the DOM event stream honest). Printable text comes from GLFW's `Char`
+//! events (so layout/shift handling is the OS's), the editing subset from
+//! `Key` events — the same split the egui `Ui.textInput` route uses.
+//!
+//! IME composition is NOT wired (no `Ime` events) — CJK/dead-key input is a
+//! known follow-up; plain Latin typing works through `Char`.
+
+use blitz_traits::events::{BlitzKeyEvent, KeyState, UiEvent as BlitzUiEvent};
+use blitz_traits::SmolStr;
+use keyboard_types::{Code, Key, Location, Modifiers};
+
+/// One keyboard event for a focused webview input, main thread → worker.
+/// `Escape` is handled by the worker itself (it blurs the focused element —
+/// blitz has no built-in Escape behavior); everything else lowers to blitz
+/// key events via [`lower_key`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum WebviewKey {
+    /// A printable character (GLFW `WindowEvent::Char` — post-layout).
+    Char(char),
+    Backspace,
+    Delete,
+    Left,
+    Right,
+    Home,
+    End,
+    Enter,
+    /// Defocus the focused element (the worker calls `clear_focus`).
+    Escape,
+}
+
+/// Lower one [`WebviewKey`] to the blitz event(s) it means, for this build's
+/// target OS. `Escape` lowers to nothing (the worker handles it directly).
+pub(crate) fn lower_key(key: &WebviewKey) -> Vec<BlitzUiEvent> {
+    lower_key_for(key, cfg!(target_os = "macos"))
+}
+
+/// The OS-explicit core of [`lower_key`], split out so tests cover both
+/// paths. On macOS blitz cfg-routes Backspace editing through the Apple
+/// standard keybindings (`blitz-dom` `text.rs` — the `Key::Backspace` arm is
+/// `#[cfg(not(target_os = "macos"))]`), so a plain `KeyDown(Backspace)`
+/// would be silently ignored there.
+fn lower_key_for(key: &WebviewKey, apple_keybindings: bool) -> Vec<BlitzUiEvent> {
+    let (kt_key, code) = match key {
+        WebviewKey::Escape => return Vec::new(),
+        WebviewKey::Char(c) => (Key::Character(c.to_string()), Code::Unidentified),
+        WebviewKey::Backspace if apple_keybindings => {
+            return vec![
+                BlitzUiEvent::AppleStandardKeybinding(SmolStr::new_static("deleteBackward:")),
+                // The release also FLUSHES the driver queue: blitz's
+                // AppleStandardKeybinding arm queues the generated `input`
+                // DOM event but only a subsequent `handle_dom_event` drains
+                // the queue (KeyUp has no default action of its own).
+                BlitzUiEvent::KeyUp(BlitzKeyEvent {
+                    key: Key::Backspace,
+                    code: Code::Backspace,
+                    modifiers: Modifiers::empty(),
+                    location: Location::Standard,
+                    is_auto_repeating: false,
+                    is_composing: false,
+                    state: KeyState::Released,
+                    text: None,
+                }),
+            ];
+        }
+        WebviewKey::Backspace => (Key::Backspace, Code::Backspace),
+        WebviewKey::Delete => (Key::Delete, Code::Delete),
+        WebviewKey::Left => (Key::ArrowLeft, Code::ArrowLeft),
+        WebviewKey::Right => (Key::ArrowRight, Code::ArrowRight),
+        WebviewKey::Home => (Key::Home, Code::Home),
+        WebviewKey::End => (Key::End, Code::End),
+        WebviewKey::Enter => (Key::Enter, Code::Enter),
+    };
+    let make = |state: KeyState| BlitzKeyEvent {
+        key: kt_key.clone(),
+        code,
+        modifiers: Modifiers::empty(),
+        location: Location::Standard,
+        is_auto_repeating: false,
+        is_composing: false,
+        state,
+        text: match &kt_key {
+            Key::Character(s) if state.is_pressed() => Some(SmolStr::from(s.as_str())),
+            _ => None,
+        },
+    };
+    vec![
+        BlitzUiEvent::KeyDown(make(KeyState::Pressed)),
+        BlitzUiEvent::KeyUp(make(KeyState::Released)),
+    ]
+}
+
+/// The debug server's `POST /input {"type":"key",…}` names, mapped to the
+/// webview route: a single printable character types into the focused field;
+/// the editing-key names cover the same subset the GLFW gate routes. `None`
+/// means "not a webview key" — the injection falls through to the game (the
+/// caller only consults this while the webview wants the keyboard).
+pub(crate) fn webview_key_from_str(name: &str) -> Option<WebviewKey> {
+    let mut chars = name.chars();
+    if let (Some(c), None) = (chars.next(), chars.next()) {
+        if !c.is_control() {
+            return Some(WebviewKey::Char(c));
+        }
+    }
+    match name.to_ascii_lowercase().as_str() {
+        "backspace" => Some(WebviewKey::Backspace),
+        "delete" => Some(WebviewKey::Delete),
+        "left" => Some(WebviewKey::Left),
+        "right" => Some(WebviewKey::Right),
+        "home" => Some(WebviewKey::Home),
+        "end" => Some(WebviewKey::End),
+        "enter" => Some(WebviewKey::Enter),
+        "escape" => Some(WebviewKey::Escape),
+        // The game map spells the space bar "space"; in a text field it types.
+        "space" => Some(WebviewKey::Char(' ')),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn down_up(events: &[BlitzUiEvent]) -> (&BlitzKeyEvent, &BlitzKeyEvent) {
+        match events {
+            [BlitzUiEvent::KeyDown(down), BlitzUiEvent::KeyUp(up)] => (down, up),
+            other => panic!("expected KeyDown+KeyUp pair, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn char_lowers_to_character_pair_with_text_on_the_press() {
+        let events = lower_key_for(&WebviewKey::Char('a'), false);
+        let (down, up) = down_up(&events);
+        assert_eq!(down.key, Key::Character("a".into()));
+        assert_eq!(down.state, KeyState::Pressed);
+        assert_eq!(down.text.as_deref(), Some("a"));
+        assert!(down.modifiers.is_empty());
+        assert_eq!(up.key, Key::Character("a".into()));
+        assert_eq!(up.state, KeyState::Released);
+        assert_eq!(up.text, None);
+    }
+
+    #[test]
+    fn editing_keys_lower_to_named_pairs() {
+        for (key, expect_key, expect_code) in [
+            (WebviewKey::Delete, Key::Delete, Code::Delete),
+            (WebviewKey::Left, Key::ArrowLeft, Code::ArrowLeft),
+            (WebviewKey::Right, Key::ArrowRight, Code::ArrowRight),
+            (WebviewKey::Home, Key::Home, Code::Home),
+            (WebviewKey::End, Key::End, Code::End),
+            (WebviewKey::Enter, Key::Enter, Code::Enter),
+        ] {
+            let events = lower_key_for(&key, false);
+            let (down, up) = down_up(&events);
+            assert_eq!(down.key, expect_key, "{key:?}");
+            assert_eq!(down.code, expect_code, "{key:?}");
+            assert_eq!(down.text, None, "{key:?}");
+            assert_eq!(up.state, KeyState::Released, "{key:?}");
+        }
+    }
+
+    #[test]
+    fn backspace_lowers_per_target_os() {
+        // Non-mac: a plain named pair.
+        let events = lower_key_for(&WebviewKey::Backspace, false);
+        let (down, _) = down_up(&events);
+        assert_eq!(down.key, Key::Backspace);
+        // macOS: blitz only edits Backspace via the Apple standard
+        // keybinding, so the lowering must emit that instead — followed by
+        // the queue-flushing release (see lower_key_for).
+        match &lower_key_for(&WebviewKey::Backspace, true)[..] {
+            [BlitzUiEvent::AppleStandardKeybinding(cmd), BlitzUiEvent::KeyUp(up)] => {
+                assert_eq!(cmd.as_str(), "deleteBackward:");
+                assert_eq!(up.key, Key::Backspace);
+            }
+            other => panic!("expected AppleStandardKeybinding + KeyUp, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn escape_lowers_to_nothing() {
+        assert!(lower_key_for(&WebviewKey::Escape, false).is_empty());
+        assert!(lower_key_for(&WebviewKey::Escape, true).is_empty());
+    }
+
+    #[test]
+    fn debug_server_names_map_to_webview_keys() {
+        assert_eq!(webview_key_from_str("a"), Some(WebviewKey::Char('a')));
+        assert_eq!(webview_key_from_str("F"), Some(WebviewKey::Char('F')));
+        assert_eq!(webview_key_from_str("~"), Some(WebviewKey::Char('~')));
+        assert_eq!(webview_key_from_str("enter"), Some(WebviewKey::Enter));
+        assert_eq!(webview_key_from_str("backspace"), Some(WebviewKey::Backspace));
+        assert_eq!(webview_key_from_str("escape"), Some(WebviewKey::Escape));
+        assert_eq!(webview_key_from_str("space"), Some(WebviewKey::Char(' ')));
+        // Multi-char non-names are not webview keys (fall through to the game).
+        assert_eq!(webview_key_from_str("up"), None);
+        assert_eq!(webview_key_from_str("w"), Some(WebviewKey::Char('w')));
+    }
+}

--- a/runtime/functor-runtime-desktop/src/webview_overlay.rs
+++ b/runtime/functor-runtime-desktop/src/webview_overlay.rs
@@ -43,6 +43,17 @@
 //! ([`WebviewOverlay::hit_interactive_css`]) is a point-in-rect test against
 //! the worker's latest snapshot of interactive-element boxes, so the run
 //! loop's synchronous press decision never waits on the worker.
+//!
+//! Keyboard: clicking an `<input>` focuses it (blitz's pointer handling),
+//! which flips the `wants_keyboard` latch the shell routes on (the
+//! `Ui.textInput` focus gate). The shell's keystrokes cross the channel as
+//! plain [`WebviewKey`]s, are lowered to blitz key events
+//! (`webview_keys::lower_key`), and type into the focused field; the DOM
+//! `input` events they generate come back as `TextChanged` [`UiEvent`]s.
+//! Because a controlled input's keystroke re-renders the HTML (a FRESH
+//! document), focus is restored across rebuilds by the focused element's
+//! `data-fn-input` slot, caret at the end. IME composition is not wired
+//! (follow-up).
 
 use std::sync::mpsc::{Receiver, Sender, TryRecvError};
 use std::sync::Arc;
@@ -61,6 +72,8 @@ use functor_runtime_common::ui::{PointerState, UiEvent, UiEventKind};
 use glow::HasContext;
 use markup5ever::LocalName;
 
+use crate::webview_keys::{lower_key, WebviewKey};
+
 /// How long the main thread will block for the worker's FIRST frame when the
 /// webview first activates (capture determinism — see the module doc).
 /// Generous because a debug-build retina paint is ~600ms; it is paid at most
@@ -68,11 +81,14 @@ use markup5ever::LocalName;
 const FIRST_FRAME_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// What one webview frame produced: interactions to fold through `update`,
-/// and whether the pointer is over an interactive element (the shell's
-/// click-arbitration latch, like `ui_wants_pointer`).
+/// whether the pointer is over an interactive element (the shell's
+/// click-arbitration latch, like `ui_wants_pointer`), and whether a text
+/// input is focused (the shell's keyboard-routing latch, like
+/// `ui_wants_keyboard`).
 pub struct WebviewOutput {
     pub events: Vec<UiEvent>,
     pub wants_pointer: bool,
+    pub wants_keyboard: bool,
 }
 
 impl WebviewOutput {
@@ -80,6 +96,7 @@ impl WebviewOutput {
         WebviewOutput {
             events: Vec::new(),
             wants_pointer: false,
+            wants_keyboard: false,
         }
     }
 }
@@ -106,6 +123,9 @@ struct WorkerInput {
     dpi_scale: f32,
     /// Pointer sample in framebuffer pixels (the overlays' shared space).
     pointer: PointerState,
+    /// Keyboard events for the focused text input this frame, in order
+    /// (collected by the shell only while `wants_keyboard` — the focus gate).
+    keys: Vec<WebviewKey>,
     /// The animation clock blitz `resolve(t)` ticks on (the shell owns it).
     clock: f64,
     /// Bumped on `Clear`; outputs stamped with an older epoch are stale
@@ -128,6 +148,9 @@ struct WorkerOutput {
     epoch: u64,
     events: Vec<UiEvent>,
     wants_pointer: bool,
+    /// Whether the document's focused node is an editable text input — the
+    /// shell's keyboard-routing latch (`webview_wants_keyboard`).
+    wants_keyboard: bool,
     /// CSS-px boxes `(x, y, w, h)` of elements carrying `data-fn-click` /
     /// `data-fn-input`, from the resolved layout. `None` = unchanged since
     /// the last send (the main thread keeps its snapshot).
@@ -206,6 +229,7 @@ pub struct WebviewOverlay {
     /// buttons that keep their place across re-renders — the repeat-click
     /// case — test identically to the old live hit-test).
     wants_pointer: bool,
+    wants_keyboard: bool,
     interactive_rects: Vec<(f32, f32, f32, f32)>,
     /// Size of the currently uploaded texture (0 = nothing to composite).
     tex_w: u32,
@@ -294,6 +318,7 @@ impl WebviewOverlay {
             epoch: 0,
             waited_first_frame: false,
             wants_pointer: false,
+            wants_keyboard: false,
             interactive_rects: Vec::new(),
             tex_w: 0,
             tex_h: 0,
@@ -319,10 +344,12 @@ impl WebviewOverlay {
     /// results non-blocking, upload the newest frame (if any) as the overlay
     /// texture, and composite the quad. `pointer.pos` is in framebuffer
     /// pixels (the egui overlays' space); the worker divides by `dpi_scale`
-    /// for blitz's CSS px. `clock` is the shell's frame time (`tts`, seconds)
-    /// — the clock CSS animations tick on, so `--fixed-time` pins webview
-    /// poses too (deterministic captures) and pausing freezes the overlay's
-    /// animations coherently with the game.
+    /// for blitz's CSS px. `keys` is this frame's keyboard input for the
+    /// focused text field, in order (the shell collects it only while
+    /// `wants_keyboard` — the focus gate). `clock` is the shell's frame time
+    /// (`tts`, seconds) — the clock CSS animations tick on, so `--fixed-time`
+    /// pins webview poses too (deterministic captures) and pausing freezes
+    /// the overlay's animations coherently with the game.
     pub fn frame(
         &mut self,
         fb_width: u32,
@@ -330,6 +357,7 @@ impl WebviewOverlay {
         dpi_scale: f32,
         html: Option<&str>,
         pointer: PointerState,
+        keys: Vec<WebviewKey>,
         clock: f64,
     ) -> WebviewOutput {
         let Some(html) = html else {
@@ -341,6 +369,7 @@ impl WebviewOverlay {
                 self.active = false;
                 self.last_html = None;
                 self.wants_pointer = false;
+                self.wants_keyboard = false;
                 self.interactive_rects = Vec::new();
                 self.tex_w = 0;
                 self.tex_h = 0;
@@ -352,6 +381,7 @@ impl WebviewOverlay {
                         fb_height,
                         dpi_scale,
                         pointer: PointerState::default(),
+                        keys: Vec::new(),
                         clock,
                         epoch: self.epoch,
                     });
@@ -381,6 +411,7 @@ impl WebviewOverlay {
                 fb_height,
                 dpi_scale,
                 pointer,
+                keys,
                 clock,
                 epoch: self.epoch,
             });
@@ -415,6 +446,7 @@ impl WebviewOverlay {
             }
             events.extend(out.events);
             self.wants_pointer = out.wants_pointer;
+            self.wants_keyboard = out.wants_keyboard;
             if let Some(rects) = out.interactive_rects {
                 self.interactive_rects = rects;
             }
@@ -476,6 +508,7 @@ impl WebviewOverlay {
         WebviewOutput {
             events,
             wants_pointer: self.wants_pointer,
+            wants_keyboard: self.wants_keyboard,
         }
     }
 }
@@ -520,6 +553,7 @@ struct WorkerState {
     /// Last-sent snapshots, so an idle cycle sends nothing at all.
     sent_rects: Vec<(f32, f32, f32, f32)>,
     sent_wants_pointer: bool,
+    sent_wants_keyboard: bool,
 }
 
 impl WorkerState {
@@ -540,6 +574,7 @@ impl WorkerState {
             generation: 0,
             sent_rects: Vec::new(),
             sent_wants_pointer: false,
+            sent_wants_keyboard: false,
         }
     }
 
@@ -547,10 +582,10 @@ impl WorkerState {
     /// cycle worked): reconcile the DOM once against the batch's LAST HTML
     /// directive — intermediate documents would never be painted, so parsing
     /// them would only let a backlog starve the worker (e.g. a debug build
-    /// with per-frame re-renders) — then feed every pointer sample of the
-    /// current epoch, in order, so no press/release edge is coalesced away.
-    /// The expensive resolve+paint happens once, in
-    /// [`WorkerState::finish_cycle`].
+    /// with per-frame re-renders) — then feed every pointer/keyboard sample
+    /// of the current epoch, in order, so no press/release edge (or
+    /// keystroke) is coalesced away. The expensive resolve+paint happens
+    /// once, in [`WorkerState::finish_cycle`].
     fn run_cycle(&mut self, batch: Vec<WorkerInput>) -> Option<WorkerOutput> {
         let last = batch.last().expect("batch is non-empty");
         let epoch = last.epoch;
@@ -568,18 +603,18 @@ impl WorkerState {
         self.view_h = last.fb_height;
         self.view_scale = scale;
 
-        // Split the batch: the last HTML directive wins; pointer samples
-        // stamped with an OLDER epoch belong to a document Cleared mid-batch
-        // — the main thread discards their results anyway, so don't
-        // synthesize edges from them on the new document.
+        // Split the batch: the last HTML directive wins; pointer/keyboard
+        // samples stamped with an OLDER epoch belong to a document Cleared
+        // mid-batch — the main thread discards their results anyway, so
+        // don't synthesize edges from them on the new document.
         let mut html_action: Option<HtmlMsg> = None;
-        let mut pointers: Vec<PointerState> = Vec::with_capacity(batch.len());
+        let mut samples: Vec<(PointerState, Vec<WebviewKey>)> = Vec::with_capacity(batch.len());
         for input in batch {
             if !matches!(input.html, HtmlMsg::Unchanged) {
                 html_action = Some(input.html);
             }
             if input.epoch == epoch {
-                pointers.push(input.pointer);
+                samples.push((input.pointer, input.keys));
             }
         }
 
@@ -595,9 +630,17 @@ impl WorkerState {
                 // equal and never be re-sent (dead press arbitration).
                 self.sent_rects = Vec::new();
                 self.sent_wants_pointer = false;
+                self.sent_wants_keyboard = false;
                 return None;
             }
             Some(HtmlMsg::Set(html)) => {
+                // Focus survival across re-renders: every keystroke in a
+                // controlled input changes the model → new HTML → a FRESH
+                // document, which would drop focus (and the wants-keyboard
+                // latch) after the first character. Remember the focused
+                // element's handler slot — the stable identity across
+                // rebuilds — and re-focus the matching node below.
+                let focused_slot = self.doc.as_ref().and_then(focused_input_slot);
                 let viewport =
                     Viewport::new(self.view_w, self.view_h, scale, ColorScheme::Dark);
                 let mut doc = HtmlDocument::from_html(
@@ -633,6 +676,19 @@ impl WorkerState {
                 // of pressing the button (the repeated-click repro). Resolve
                 // now so same-cycle events see real geometry.
                 doc.resolve(self.clock);
+                // Re-focus the input the OLD document had focused (matched by
+                // its `data-fn-input` slot), caret at the end — the
+                // documented controlled-input semantics ("an update that
+                // transforms the text resets the cursor to the end"). A
+                // vanished slot (the input left the tree) just drops focus.
+                if let Some(id) = focused_slot.and_then(|slot| find_input_by_slot(&doc, slot)) {
+                    doc.set_focus_to(id);
+                    let mut sink = EventCollector { events: Vec::new() };
+                    let mut driver = EventDriver::new(&mut doc as &mut dyn Document, &mut sink);
+                    for ev in lower_key(&WebviewKey::End) {
+                        driver.handle_ui_event(ev);
+                    }
+                }
                 self.doc = Some(doc);
                 self.dirty = true;
                 // Re-establish hover on the fresh DOM: clearing `hover_pos`
@@ -659,8 +715,12 @@ impl WorkerState {
         }
 
         let mut events: Vec<UiEvent> = Vec::new();
-        for pointer in pointers {
+        for (pointer, keys) in samples {
+            // Pointer before keys within one frame's sample: a click that
+            // focuses a field and the keys typed the same frame land in
+            // program order (focus first, then text).
             self.apply_pointer(pointer, scale, &mut events);
+            self.apply_keys(keys, &mut events);
         }
         self.finish_cycle(events)
     }
@@ -726,6 +786,40 @@ impl WorkerState {
         events.extend(collector.events);
     }
 
+    /// Feed one frame's keyboard input for the focused text field through
+    /// blitz's editing stack (a no-op without a document). Each key lowers to
+    /// the `KeyDown`/`KeyUp` pair blitz edits on (`webview_keys::lower_key`);
+    /// the resulting DOM `input` events come back through the collector as
+    /// slot-stamped `TextChanged` [`UiEvent`]s. `Escape` instead DEFOCUSES
+    /// the field (blitz has no built-in Escape behavior), dropping the
+    /// wants-keyboard latch so the shell's next Escape releases the cursor —
+    /// the `Ui.textInput` two-step rule.
+    fn apply_keys(&mut self, keys: Vec<WebviewKey>, events: &mut Vec<UiEvent>) {
+        let Some(doc) = &mut self.doc else {
+            return;
+        };
+        if keys.is_empty() {
+            return;
+        }
+        let mut collector = EventCollector { events: Vec::new() };
+        for key in &keys {
+            if matches!(key, WebviewKey::Escape) {
+                // Blur directly: the driver has no defocus event, and no
+                // handler observes blur — the latch flip is the effect.
+                doc.clear_focus();
+            } else {
+                let mut driver = EventDriver::new(doc as &mut dyn Document, &mut collector);
+                for ev in lower_key(key) {
+                    driver.handle_ui_event(ev);
+                }
+            }
+        }
+        // Any key changes what's painted: text, caret/selection, or the
+        // focus ring (Escape).
+        self.dirty = true;
+        events.extend(collector.events);
+    }
+
     /// Resolve + repaint once for the whole input batch, and package the
     /// results. Returns `None` when there is nothing to report (idle).
     fn finish_cycle(&mut self, events: Vec<UiEvent>) -> Option<WorkerOutput> {
@@ -740,6 +834,10 @@ impl WorkerState {
             .get_hover_node_id()
             .map(|id| chain_has_handler(doc, id))
             .unwrap_or(false);
+        // Keyboard latch: an editable element is focused (a click on an
+        // `<input>` focuses it in blitz's pointer handling; Escape or a
+        // click elsewhere clears it).
+        let wants_keyboard = focused_editable(doc);
         // Repaint when dirty OR while CSS animations/transitions are active:
         // `resolve(t)` above already advanced blitz's clock, and
         // `is_animating()` reports live @keyframes/transitions, so ticking
@@ -787,14 +885,17 @@ impl WorkerState {
             && events.is_empty()
             && rects_msg.is_none()
             && wants_pointer == self.sent_wants_pointer
+            && wants_keyboard == self.sent_wants_keyboard
         {
             return None; // truly idle — keep both channels quiet
         }
         self.sent_wants_pointer = wants_pointer;
+        self.sent_wants_keyboard = wants_keyboard;
         Some(WorkerOutput {
             epoch: self.epoch,
             events,
             wants_pointer,
+            wants_keyboard,
             interactive_rects: rects_msg,
             frame,
         })
@@ -858,6 +959,48 @@ pub fn render_html_to_rgba(html: &str, width: u32, height: u32, scale: f32) -> V
         &mut buf,
     );
     buf
+}
+
+/// Whether the document's focused node is an editable text element — the
+/// keyboard-routing latch (`wants_keyboard`).
+fn focused_editable(doc: &BaseDocument) -> bool {
+    doc.get_focussed_node_id()
+        .and_then(|id| doc.get_node(id))
+        .and_then(|node| node.element_data())
+        .is_some_and(|el| el.text_input_data().is_some())
+}
+
+/// The `data-fn-input` slot of the focused element (walking up like the
+/// bubble chain, though the slot sits on the `<input>` itself) — the stable
+/// identity used to restore focus across document rebuilds.
+fn focused_input_slot(doc: &BaseDocument) -> Option<u32> {
+    let input = LocalName::from("data-fn-input");
+    let mut current = doc.get_focussed_node_id();
+    while let Some(id) = current {
+        let node = doc.get_node(id)?;
+        if let Some(slot) = node.attr(input.clone()).and_then(|v| v.parse::<u32>().ok()) {
+            return Some(slot);
+        }
+        current = node.parent;
+    }
+    None
+}
+
+/// Find the element carrying `data-fn-input="slot"` — the re-focus target
+/// after a rebuild ([`focused_input_slot`]'s inverse).
+fn find_input_by_slot(doc: &BaseDocument, slot: u32) -> Option<usize> {
+    let input = LocalName::from("data-fn-input");
+    let mut stack = vec![doc.root_node().id];
+    while let Some(id) = stack.pop() {
+        let Some(node) = doc.get_node(id) else {
+            continue;
+        };
+        if node.attr(input.clone()).and_then(|v| v.parse::<u32>().ok()) == Some(slot) {
+            return Some(id);
+        }
+        stack.extend(node.children.iter().copied());
+    }
+    None
 }
 
 /// Whether `node_id` or any ancestor carries a webview handler attribute —
@@ -927,5 +1070,157 @@ fn pointer_event(x: f32, y: f32, primary_held: bool) -> BlitzPointerEvent {
         details: Default::default(),
         element: Default::default(),
         active_pointers: Default::default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Headless keyboard/focus tests driving the worker's real cycle
+    //! ([`WorkerState::run_cycle`]) — the exact code the render thread runs,
+    //! no GL and no window: synthetic clicks focus, `WebviewKey`s type
+    //! through blitz's editing stack, and focus survives a document rebuild.
+
+    use super::*;
+
+    const FB: (u32, u32) = (400, 300);
+
+    /// A controlled input (slot 0, seeded from `value`) at the top-left —
+    /// margins zeroed so the input's 200x30 box sits at the origin — plus a
+    /// label that changes across "re-renders".
+    fn page(value: &str, label: &str) -> String {
+        format!(
+            "<style>html,body{{margin:0}}input{{width:200px;height:30px}}</style>\
+             <div><input value=\"{value}\" data-fn-input=\"0\"><p>{label}</p></div>"
+        )
+    }
+
+    fn input(html: Option<&str>, pointer: PointerState, keys: Vec<WebviewKey>) -> WorkerInput {
+        WorkerInput {
+            html: match html {
+                Some(h) => HtmlMsg::Set(Arc::from(h)),
+                None => HtmlMsg::Unchanged,
+            },
+            fb_width: FB.0,
+            fb_height: FB.1,
+            dpi_scale: 1.0,
+            pointer,
+            keys,
+            clock: 0.0,
+            epoch: 0,
+        }
+    }
+
+    fn hover(x: f32, y: f32, down: bool) -> PointerState {
+        PointerState {
+            pos: Some((x, y)),
+            primary_down: down,
+        }
+    }
+
+    /// Click inside the input (press then release, two frame samples) — the
+    /// synthetic version of the shell's press/release edges.
+    fn click_input(state: &mut WorkerState) -> Option<WorkerOutput> {
+        let down = input(None, hover(50.0, 15.0, true), vec![]);
+        let up = input(None, hover(50.0, 15.0, false), vec![]);
+        state.run_cycle(vec![down, up])
+    }
+
+    fn text_changes(out: &WorkerOutput) -> Vec<&str> {
+        out.events
+            .iter()
+            .filter_map(|e| match &e.kind {
+                UiEventKind::TextChanged(s) => Some(s.as_str()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn click_focuses_the_input_and_typing_emits_text_changed() {
+        let mut state = WorkerState::new();
+        let out = state
+            .run_cycle(vec![input(Some(&page("", "hello")), PointerState::default(), vec![])])
+            .expect("first cycle paints");
+        assert!(!out.wants_keyboard, "nothing focused on load");
+
+        let out = click_input(&mut state).expect("click cycle reports");
+        assert!(out.wants_keyboard, "clicking the input focuses it");
+
+        let out = state
+            .run_cycle(vec![input(
+                None,
+                hover(50.0, 15.0, false),
+                vec![WebviewKey::Char('h'), WebviewKey::Char('i')],
+            )])
+            .expect("typing cycle reports");
+        assert_eq!(text_changes(&out), vec!["h", "hi"], "each keystroke emits the full value");
+        assert!(out.wants_keyboard);
+    }
+
+    #[test]
+    fn backspace_and_enter_edit_through_the_os_specific_lowering() {
+        let mut state = WorkerState::new();
+        state.run_cycle(vec![input(Some(&page("hi", "x")), PointerState::default(), vec![])]);
+        click_input(&mut state);
+        // Backspace exercises the per-OS lowering (Apple standard keybinding
+        // on macOS, a plain KeyDown elsewhere) against real blitz.
+        let out = state
+            .run_cycle(vec![input(None, hover(50.0, 15.0, false), vec![WebviewKey::Backspace])])
+            .expect("edit cycle reports");
+        assert_eq!(text_changes(&out), vec!["h"]);
+    }
+
+    #[test]
+    fn focus_survives_a_rebuild_with_the_caret_at_the_end() {
+        let mut state = WorkerState::new();
+        state.run_cycle(vec![input(Some(&page("", "greeting")), PointerState::default(), vec![])]);
+        click_input(&mut state);
+        let out = state
+            .run_cycle(vec![input(None, hover(50.0, 15.0, false), vec![WebviewKey::Char('h'), WebviewKey::Char('i')])])
+            .expect("typing reports");
+        assert_eq!(text_changes(&out), vec!["h", "hi"]);
+
+        // The controlled round-trip: the model echoes the value into NEW html
+        // (label changed too) — a fresh document. Focus must survive by slot.
+        let out = state
+            .run_cycle(vec![input(Some(&page("hi", "Hello, hi!")), hover(50.0, 15.0, false), vec![])])
+            .expect("rebuild cycle reports");
+        assert!(out.wants_keyboard, "focus restored on the rebuilt document");
+
+        // Caret restored to the END: the next character appends (a lost
+        // caret would prepend "!hi").
+        let out = state
+            .run_cycle(vec![input(None, hover(50.0, 15.0, false), vec![WebviewKey::Char('!')])])
+            .expect("post-rebuild typing reports");
+        assert_eq!(text_changes(&out), vec!["hi!"]);
+    }
+
+    #[test]
+    fn escape_defocuses_and_drops_the_keyboard_latch() {
+        let mut state = WorkerState::new();
+        state.run_cycle(vec![input(Some(&page("", "x")), PointerState::default(), vec![])]);
+        let out = click_input(&mut state).expect("click cycle reports");
+        assert!(out.wants_keyboard);
+        let out = state
+            .run_cycle(vec![input(None, hover(50.0, 15.0, false), vec![WebviewKey::Escape])])
+            .expect("escape cycle reports");
+        assert!(!out.wants_keyboard, "Escape blurs the field");
+    }
+
+    #[test]
+    fn a_vanished_slot_drops_focus_instead_of_guessing() {
+        let mut state = WorkerState::new();
+        state.run_cycle(vec![input(Some(&page("", "x")), PointerState::default(), vec![])]);
+        click_input(&mut state);
+        // Rebuild WITHOUT the input: no node carries the slot — focus (and
+        // the latch) must drop, not land somewhere arbitrary.
+        let out = state
+            .run_cycle(vec![input(
+                Some("<style>html,body{margin:0}</style><p>gone</p>"),
+                hover(50.0, 15.0, false),
+                vec![],
+            )])
+            .expect("rebuild cycle reports");
+        assert!(!out.wants_keyboard);
     }
 }

--- a/runtime/functor-runtime-desktop/src/webview_overlay.rs
+++ b/runtime/functor-runtime-desktop/src/webview_overlay.rs
@@ -52,8 +52,15 @@
 //! `input` events they generate come back as `TextChanged` [`UiEvent`]s.
 //! Because a controlled input's keystroke re-renders the HTML (a FRESH
 //! document), focus is restored across rebuilds by the focused element's
-//! `data-fn-input` slot, caret at the end. IME composition is not wired
-//! (follow-up).
+//! `data-fn-input` slot, caret at the end (the documented `Ui.textInput`
+//! rule; per-caret preservation for identity round-trips is part of the
+//! DOM-reconciliation follow-up, docs/todo.md § Webview). Like
+//! `wants_pointer`, the latch is a worker-cycle-stale snapshot: keys typed
+//! in the frame(s) between clicking the field and the worker's report still
+//! go to the game (and vice versa after Escape) — the accepted async-overlay
+//! tradeoff. Not wired (follow-ups): IME composition (CJK/dead keys),
+//! modifier combos (shift-selection, select-all, clipboard), and
+//! `placeholder` rendering (blitz has none).
 
 use std::sync::mpsc::{Receiver, Sender, TryRecvError};
 use std::sync::Arc;
@@ -970,9 +977,11 @@ fn focused_editable(doc: &BaseDocument) -> bool {
         .is_some_and(|el| el.text_input_data().is_some())
 }
 
-/// The `data-fn-input` slot of the focused element (walking up like the
-/// bubble chain, though the slot sits on the `<input>` itself) — the stable
-/// identity used to restore focus across document rebuilds.
+/// The `data-fn-input` slot of the focused element — the stable identity
+/// used to restore focus across document rebuilds. Walks up the parent
+/// chain defensively: blitz focuses the pointer hit-test's node, which can
+/// be a descendant of the slot-stamped `<input>` rather than the element
+/// itself.
 fn focused_input_slot(doc: &BaseDocument) -> Option<u32> {
     let input = LocalName::from("data-fn-input");
     let mut current = doc.get_focussed_node_id();

--- a/runtime/functor-runtime-web/index-functor-lang.html
+++ b/runtime/functor-runtime-web/index-functor-lang.html
@@ -123,7 +123,26 @@
         // release whose press was swallowed by a focused field never leaks
         // a phantom release edge.
         const gameHeld = new Set();
+        // The webview keyboard gate (native parity): while an Html.input in
+        // the webview's shadow root is focused, keys are the BROWSER's —
+        // they type into the real DOM field — and the game's input hook
+        // hears none of it. Escape DEFOCUSES the field first (the
+        // Ui.textInput rule); the release-side gameHeld discipline already
+        // keeps a swallowed press from leaking a phantom release.
+        const webviewActiveInput = () => {
+          const shadow = document.getElementById("webview").shadowRoot;
+          const active = shadow && shadow.activeElement;
+          return active && active.hasAttribute("data-fn-input") ? active : null;
+        };
         window.addEventListener("keydown", (e) => {
+          const webviewInput = webviewActiveInput();
+          if (webviewInput) {
+            if (e.key === "Escape") {
+              webviewInput.blur();
+              e.preventDefault();
+            }
+            return;
+          }
           if (functor_lang_ui_wants_keyboard()) {
             if (e.metaKey || e.ctrlKey || e.altKey) return;
             if (functor_lang_ui_key(e.key)) e.preventDefault();
@@ -289,7 +308,34 @@
           if (gen !== lastGen) {
             lastGen = gen;
             const html = functor_lang_webview_html();
+            // Focus survival across re-renders (the native slot-restore rule):
+            // swapping innerHTML destroys the focused <input> mid-typing, so
+            // remember its data-fn-input slot + selection and re-focus the
+            // matching element in the new tree. Selection is restored only
+            // when the value round-tripped unchanged; a transforming update
+            // resets the caret to the end (the documented Ui.textInput
+            // semantics).
+            const active = shadow.activeElement;
+            const focusSlot = active && active.getAttribute("data-fn-input");
+            const focusState = focusSlot != null && {
+              value: active.value,
+              start: active.selectionStart,
+              end: active.selectionEnd,
+            };
             shadow.innerHTML = html ? baseCss + html : "";
+            if (focusSlot != null) {
+              const el = shadow.querySelector(`[data-fn-input="${focusSlot}"]`);
+              if (el) {
+                el.focus();
+                if (el.setSelectionRange) {
+                  if (el.value === focusState.value) {
+                    el.setSelectionRange(focusState.start, focusState.end);
+                  } else {
+                    el.setSelectionRange(el.value.length, el.value.length);
+                  }
+                }
+              }
+            }
           }
           requestAnimationFrame(poll);
         };

--- a/site/player.html
+++ b/site/player.html
@@ -195,7 +195,26 @@
         // focused field never leaks a phantom release edge. Kept in sync with
         // index-functor-lang.html.
         const gameHeld = new Set();
+        // The webview keyboard gate (native parity): while an Html.input in
+        // the webview's shadow root is focused, keys are the BROWSER's —
+        // they type into the real DOM field — and the game's input hook
+        // hears none of it. Escape DEFOCUSES the field first (the
+        // Ui.textInput rule); the release-side gameHeld discipline already
+        // keeps a swallowed press from leaking a phantom release.
+        const webviewActiveInput = () => {
+          const shadow = document.getElementById("webview").shadowRoot;
+          const active = shadow && shadow.activeElement;
+          return active && active.hasAttribute("data-fn-input") ? active : null;
+        };
         window.addEventListener("keydown", (e) => {
+          const webviewInput = webviewActiveInput();
+          if (webviewInput) {
+            if (e.key === "Escape") {
+              webviewInput.blur();
+              e.preventDefault();
+            }
+            return;
+          }
           if (functor_lang_ui_wants_keyboard()) {
             if (e.metaKey || e.ctrlKey || e.altKey) return;
             if (functor_lang_ui_key(e.key)) e.preventDefault();
@@ -285,7 +304,34 @@
           if (gen !== lastGen) {
             lastGen = gen;
             const html = functor_lang_webview_html();
+            // Focus survival across re-renders (the native slot-restore rule):
+            // swapping innerHTML destroys the focused <input> mid-typing, so
+            // remember its data-fn-input slot + selection and re-focus the
+            // matching element in the new tree. Selection is restored only
+            // when the value round-tripped unchanged; a transforming update
+            // resets the caret to the end (the documented Ui.textInput
+            // semantics).
+            const active = shadow.activeElement;
+            const focusSlot = active && active.getAttribute("data-fn-input");
+            const focusState = focusSlot != null && {
+              value: active.value,
+              start: active.selectionStart,
+              end: active.selectionEnd,
+            };
             shadow.innerHTML = html ? baseCss + html : "";
+            if (focusSlot != null) {
+              const el = shadow.querySelector(`[data-fn-input="${focusSlot}"]`);
+              if (el) {
+                el.focus();
+                if (el.setSelectionRange) {
+                  if (el.value === focusState.value) {
+                    el.setSelectionRange(focusState.start, focusState.end);
+                  } else {
+                    el.setSelectionRange(el.value.length, el.value.length);
+                  }
+                }
+              }
+            }
           }
           requestAnimationFrame(poll);
         };


### PR DESCRIPTION
Was stacked on #415 (webview-animated), which merged — now based on main. Completes **docs/todo.md § Webview "Native text input"**: clicking an `Html.input` focuses it in the blitz document, typing works natively, and the controlled-input loop (`Attr.value` + `Attr.onInput`) now behaves the same on both shells. IME composition (CJK/dead keys) is **deferred** — blitz has `Ime` events when we want it.

## Design

**Worker protocol.** `WorkerInput` gains `keys: Vec<WebviewKey>` — a plain-data key type (`Char(char)` + the editing subset + `Escape`), so no blitz types cross the channel. `WorkerOutput` gains `wants_keyboard`: true iff the document's focused node is an editable text element (`text_input_data`), the webview flavor of the `Ui.textInput` focus latch. Keys apply interleaved with the same cycle's pointer samples (pointer first within a frame, so a focusing click and same-frame text land in program order).

**GLFW → blitz lowering** (`webview_keys.rs`, unit-tested). GLFW `Char` events (post-layout printable text) lower to `Character` `KeyDown`/`KeyUp` pairs with `text` on the press; the editing keys (Backspace, Delete, ←/→, Home/End, Enter) lower to named pairs. blitz edits on the down; the up keeps the DOM stream honest. Two blitz quirks found and handled:
- On macOS, blitz's `Key::Backspace` editing arm is `#[cfg(not(target_os = "macos"))]` — Backspace must route through the **Apple standard keybinding** (`deleteBackward:`).
- blitz's `AppleStandardKeybinding` arm queues the generated `input` DOM event but never drains the driver queue — the lowering follows it with the Backspace `KeyUp`, which flushes it.

**run.rs routing** mirrors the egui `ui_wants_keyboard` arms one-for-one: a `webview_wants_keyboard` latch from `WorkerOutput`; while set, `Char` events and edit-key presses queue into the next `WorkerInput` and the game's `input` hook hears nothing (swallowed presses never enter `held_keys`, so the existing release discipline can't leak a phantom edge); **Escape defocuses the field first** (the worker calls `clear_focus` — blitz has no built-in Escape) and only a second Escape releases the cursor; the `~` scrubber toggle is guarded off while focused; a **free-look recapture click blurs the field** (that click never reaches the blitz document, so the field would otherwise keep eating WASD as text). The debug server's injected keys honor the same gate (`webview_key_from_str`).

**Focus survival across re-renders** — the critical piece: every keystroke in a controlled input changes the model → new HTML → the worker builds a **fresh document**, which would drop focus after the first character. Before reparsing, the worker records the focused element's `data-fn-input` slot (the stable identity the `Attr.onInput` builder stamps); after resolving the new document it re-focuses the matching node and moves the caret to the end via a synthetic `End` press — exactly the documented `Ui.textInput` semantics ("an update that transforms the text resets the cursor to the end"). A vanished slot just drops focus.

**wasm parity** (`index-functor-lang.html` + `site/player.html`, the keep-in-sync pair — the drift risk is tracked as the todo's page-sync item):
- The same slot-based focus restore around the `innerHTML` swap, plus **selection restore** when the value round-tripped unchanged (mid-string editing keeps its caret); a transforming update resets to the end, matching native.
- A real fix uncovered by the e2e test: the pages' `keydown` handler `preventDefault`ed every game-mapped key with no DOM-focus gate, so a focused shadow-root input **could never type** letters the game maps (and the game heard keys while typing). The handler now yields to the browser while a `data-fn-input` element is focused, with Escape blurring first — the native gate, mirrored.

## Evidence

- **Unit tests** (`cargo test -p functor-runtime-desktop`, 59 lib tests): the lowering table (both OS paths), plus headless worker-cycle tests driving the real blitz stack — click-to-focus flips `wants_keyboard`, typing emits per-keystroke `TextChanged` with the full value, **focus survives a rebuild with the caret at the end** (the next char appends, not prepends), Escape defocuses, a vanished slot drops focus.
- **wasm e2e** (`FUNCTOR_SAMPLE=webview npx playwright test e2e/webview-input.spec.mjs`, passing): clicks the shadow-root input of `examples/webview`, types "Ada" slowly enough that every keystroke's model round-trip swaps `innerHTML` between characters, asserts the value and the "Hello, Ada!" greeting.
- **Native headless drive**: the keyboard path can't be *focused* headlessly today (the debug server has no click injection and `--hidden` hides the pointer from the overlay), so the native typing evidence is the worker tests above; the debug-server key gate is wired for when a real window has a focused field. The controlled round-trip itself is driven headlessly via `POST /input {"type":"webview_event","slot":3,"kind":{"TextChanged":"Functor"}}` (capture below).

## Demo

`examples/webview` grows a controlled name field + greeting:

```
Html.input([Attr.value(m.name), Attr.placeholder("your name"), Attr.onInput(SetName)]),
Html.p([], [Html.text(greeting(m))]),
```

![typing demo (wasm)](https://gist.githubusercontent.com/tommy-xr/5b4e9760bd740c33f5f0d2ee4601a526/raw/webview-typing.gif)

<sub>Typing "Functor" into the controlled `Html.input` on the wasm shell — every keystroke round-trips model → HTML → overlay swap, and focus survives each swap (the slot restore). Captured headlessly with Playwright.</sub>

**Native (blitz), rendered headlessly** — the input rendered empty, and after the controlled round-trip (`POST /input` TextChanged injection + `/capture`):

![native empty](https://gist.githubusercontent.com/tommy-xr/5b4e9760bd740c33f5f0d2ee4601a526/raw/native-input.png)
![native round-trip](https://gist.githubusercontent.com/tommy-xr/5b4e9760bd740c33f5f0d2ee4601a526/raw/native-roundtrip.png)

Known cosmetic gap: blitz does not render the `placeholder` text natively (the field shows empty); wasm shows it (browser-native).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Review (xreview: Claude subagent + Codex CLI, both with the media)

Both engines confirmed the media shows the feature working (visual axis: PASS) and verified the two load-bearing blitz claims against the crate source (the macOS Backspace cfg and the Apple-keybinding queue flush). Dispositions:

- **Fixed** — injected debug-server key releases were swallowed while a webview field was focused, which could leave a pre-focus held key stuck in the game forever; releases now always take the game path with the GLFW arms' `held_keys` discipline (second commit).
- **Justified (documented)** — native caret always resets to the end on the per-keystroke rebuild, so mid-string arrow editing warps to the end. This matches the documented `Ui.textInput` semantics and typing/append (the HUD name-field case) is unaffected; per-caret preservation for identity round-trips (which wasm already does via the DOM) is explicitly part of the existing DOM-reconciliation follow-up (docs/todo.md § Webview). Single-engine finding; both the module doc and todo now name it.
- **Documented** — the `wants_keyboard` latch is a worker-cycle-stale snapshot (same accepted tradeoff as `wants_pointer`): keys typed between the focusing click and the worker's report go to the game for a frame or two. Called out in the module doc.
- **Deferred (now listed in todo + module doc)** — modifier combos (shift-selection/select-all/clipboard; blitz supports them, the lowering drops modifiers today) and native `placeholder` rendering (blitz has none).
- **Out of scope** — Codex's remaining findings (handler-table generations vs worker latency, pointer edges across mid-gesture rebuilds, channel backpressure, the first-frame block, resolve frequency, rect-vs-hit-test fidelity) concern the pre-existing overlay architecture from #404/#414, not this diff; its "Clear relabels old events with the new epoch" claim is incorrect — `run_cycle` filters samples to the batch's final epoch before any event synthesis.
