### PR TITLE
fix: recompute extrapolated history after hot reload

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -896,6 +896,18 @@ plain data, pausing on an earlier frame and reloading keeps the selected cursor
 and the entire recorded future. Resume remains the explicit branch point: it
 discards that future, while the scrubber holds its prior visual span until the
 new branch fills it.
+Forward **extrapolation** adds one counterfactual step for input-only model games:
+after a safe reload at a scrubbed frame, it replays the session-long plain-data
+input and exact frame-clock logs from the NEW program's `init` through the newest
+retained frame once. Those logs retain frame zero even when the larger 900-frame
+model/world rings prune old snapshots. The rebuilt selected model becomes the visible anchor and
+Resume branch, later scrubs remain O(1) snapshot restores, and its future is
+projected from new-code history. This prevents old derived state (such as a
+jump's stored launch velocity) from dragging a constant-tweaked trajectory back
+to the recorded outcome. Replay is exact, including future key-up frames; Resume
+cuts off that recorded future, while an optional paused **coast from here**
+control is deferred. Games with `update` or physics keep selected-snapshot
+behavior until the fuller event/coeffect replay log exists.
 Closures **stored in the model** rebind too: they adopt the edited code
 with their captured values carried over (matched by the enclosing def's
 name; a closure whose def was renamed/deleted keeps its old body with a

--- a/docs/time-travel.md
+++ b/docs/time-travel.md
@@ -59,6 +59,21 @@ on both the desktop runner and the web/VSCode preview. Exercised by
   selected frame and recorded future both remain seekable. Resume is still the
   explicit branch point that discards that future, while the slider keeps its
   prior visual span as the new branch fills it.
+  **Extrapolation is the deliberate exception for input-only model games:**
+  after a safe reload at a scrubbed historical frame, it replays the
+  session-long plain-data input and exact frame-clock logs from the edited
+  program's `init` through the newest retained frame once. Inputs and `dts`/`tts`
+  stay available from frame zero even after
+  the larger 900-frame model/world rings prune their oldest snapshots. The selected counterfactual model
+  becomes the visible anchor and Resume branch; every later scrub is then an
+  ordinary O(1) snapshot restore, and extrapolation projects from new-code
+  history only. The reload status reports the rebuilt frame count and elapsed
+  time; a broken replay-origin invariant reports a diagnostic instead of
+  silently falling back to old-data semantics. Derived state from the old program (for example Mario's
+  already-launched vertical velocity) therefore cannot pull the edited
+  trajectory back toward the recorded failure. Games with `update` or physics
+  keep the selected-snapshot behavior; exact
+  reconstruction there needs the fuller T7–T8 event/coeffect log.
   "Rewind shows the earlier *code* version" (the harder frontier
   where code-bearing snapshots retain or replay old code) remains deferred.
 - **`tts` is a game clock, not a wall clock.** Both shells own a shared
@@ -318,7 +333,15 @@ Two implementation points decide whether it looks right:
 - **Replay recorded inputs, freeze the camera.** Forward-stepping replays the
   frame-indexed input log (see "The event log") for frames it has, then coasts;
   all divisions render with the *paused* camera so only world motion smears, not
-  the view.
+  the view. After a safe hot reload, an input-only model game with complete
+  retained history first replays from the edited program's `init` to rebuild the
+  complete retained timeline and adopt the selected frame; otherwise that
+  snapshot can carry old derived state into every future sample even though the
+  future loop itself is recomputed. Reconstruction is exact: a recorded key-up
+  still lands on its original frame, so a character may stop over a gap under
+  every edited constant. Pressing Resume branches at the selected frame and
+  discards those future inputs. An optional **coast from here** / replay-cutoff
+  control is deferred so authors can preview that branch without first resuming.
 
 The "tweak a constant" half rides existing hot-reload: swap the `.fun` with the
 model preserved, re-run the window, the ghost redraws — so you can tweak a jump
@@ -363,6 +386,17 @@ log cannot supply; it must never silently fall back to performing the live
 effect. Replaying literally from frame zero additionally requires retaining the
 initial model/code revision and all environmental inputs, so keyframe-based
 reconstruction is the incremental first step.
+
+Today a safe scrubbed reload irreversibly replaces the retained old-code model
+snapshots with the reconstructed timeline. That matches Resume's existing
+"discard the future" philosophy, but it also removes the old outcome an author
+might want beside the new one; T5 persistent forks are the intended comparison
+and retention mechanism.
+
+Reconstruction currently interprets the session log synchronously, so its time
+is O(session frames); the reload status exposes the measured frame count and
+elapsed time. Chunking/yielding long replays off the browser's interaction turn
+is a follow-up once real-session telemetry shows the appropriate threshold.
 
 The functional core should expose branch/event-log transitions as pure data and
 tests; shells own persistence, actual effect execution, branch selection, and

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -29,16 +29,15 @@ use std::collections::HashSet;
 
 use functor_lang::{line_col, project::SourceMap, RunError, Session, Span, Value};
 
+use crate::asset::AssetProgress;
 use crate::functor_lang_prelude::{
     asset_progress_value, assets_taggers, contains_effect, deliver_physics_events, drain_effects,
-    frame_value, http_response_value,
-    needs_update, net_conn_subs, net_event_value, perform_deferred_queries, physics_event_taggers,
-    physics_scene_value, split_model_effect, sub_messages_for_frame, take_audio_completion,
-    take_preload_completion,
-    take_http_tagger, take_ui_handlers, DryRunEffects, EffectLog, EffectRunner, EffectTree,
-    FunctorHost, NetEventKind, UiHandler,
+    frame_value, http_response_value, needs_update, net_conn_subs, net_event_value,
+    perform_deferred_queries, physics_event_taggers, physics_scene_value, split_model_effect,
+    sub_messages_for_frame, take_audio_completion, take_http_tagger, take_preload_completion,
+    take_ui_handlers, DryRunEffects, EffectLog, EffectRunner, EffectTree, FunctorHost,
+    NetEventKind, UiHandler,
 };
-use crate::asset::AssetProgress;
 use crate::input::RecordedInput;
 use crate::net::{push_conn_command, ConnCommand, HttpResult};
 use crate::physics::{self, PhysicsEvent, SteppedPhysics};
@@ -271,6 +270,10 @@ impl Reporter {
         self.last_error = None;
     }
 
+    fn last_error(&self) -> Option<String> {
+        self.last_error.clone()
+    }
+
     /// Print a message once per distinct string — a 60fps loop must not flood
     /// the sink with one persistent bug.
     pub fn report_once(&mut self, message: String) {
@@ -461,7 +464,9 @@ impl FrameCtx<'_> {
                         }
                     }
                     Ok(_) => {}
-                    Err(message) => self.reporter.report_once(format!("[functor-lang] {message}")),
+                    Err(message) => self
+                        .reporter
+                        .report_once(format!("[functor-lang] {message}")),
                 },
                 Err(err) => self.reporter.frame_error("subscriptions", &err),
             }
@@ -484,12 +489,17 @@ impl FrameCtx<'_> {
             // both must land on the same frame (docs/time-travel.md T6b).
             self.recorder.record_inputs(std::mem::take(self.input_buf));
             self.recorder
-                .record(self.model, *self.physics_frame, frame_time.tts as f64);
+                .record_timed(self.model, *self.physics_frame, frame_time);
         } else {
-            // Paused frame (`dts == 0`): drain-and-drop the buffer. Paused frames
-            // aren't part of the played timeline, so their buffered inputs must
-            // NOT leak into the next stepped frame's recorded events.
-            self.input_buf.clear();
+            // The shell runs one zero-delta bootstrap before frame zero so the
+            // model/physics hooks settle before first draw. It is not a visible
+            // timeline frame, but it can mutate a valid model and must therefore
+            // prefix an exact reconstruction. Later paused zero-delta renders
+            // are not simulation history and are discarded by the recorder.
+            self.recorder.record_replay_prefix(
+                frame_time,
+                std::mem::take(self.input_buf),
+            );
         }
     }
 
@@ -538,22 +548,22 @@ impl FrameCtx<'_> {
     /// live order — input arrives before `tick`) so a recorded jump replays.
     /// Beyond the recorded window (`inputs` runs out) the step COASTS on held
     /// state.
-    pub fn step_scene_forward(
+    fn step_scene_forward<'a>(
         &mut self,
         divisions: usize,
         steps_per_division: usize,
-        sub_dt: f32,
-        start_tts: f32,
-        inputs: &[Vec<RecordedInput>],
+        input_at: impl Fn(usize) -> Option<&'a [RecordedInput]>,
+        mut frame_time_at: impl FnMut(usize) -> FrameTime,
+        capture_from_division: usize,
     ) -> Vec<(Value, Option<Vec<u8>>)> {
-        let mut out = Vec::with_capacity(divisions);
+        let mut out = Vec::with_capacity(divisions.saturating_sub(capture_from_division));
         let mut step = 0usize;
-        for _div in 0..divisions {
+        for div in 0..divisions {
             for _ in 0..steps_per_division {
                 // Replay this fine step's recorded inputs before the frame body,
                 // so the model absorbs them exactly as the live frame did (coast
                 // when the log has no entry for this step).
-                if let Some(events) = inputs.get(step) {
+                if let Some(events) = input_at(step) {
                     // A recorded UiEvent resolved against the LAST RENDER's
                     // handler table live — the tree the user saw, built from
                     // the settled model BEFORE this step's inputs. Rebuild
@@ -576,10 +586,7 @@ impl FrameCtx<'_> {
                         self.replay_input(event.clone(), &ui_handlers, &webview_handlers);
                     }
                 }
-                let frame_time = FrameTime {
-                    dts: sub_dt,
-                    tts: start_tts + (step as f32 + 1.0) * sub_dt,
-                };
+                let frame_time = frame_time_at(step);
                 self.subscriptions_and_tick(frame_time);
                 self.physics_phase(frame_time);
                 step += 1;
@@ -587,12 +594,14 @@ impl FrameCtx<'_> {
             // Snapshot only at the division boundary — the strobe still has
             // `divisions` frames, but each is the result of accurate fine
             // integration over `steps_per_division` sub-ticks.
-            let world = if self.has_physics {
-                self.physics_rt.snapshot_world()
-            } else {
-                None
-            };
-            out.push((self.model.clone(), world));
+            if div >= capture_from_division {
+                let world = if self.has_physics {
+                    self.physics_rt.snapshot_world()
+                } else {
+                    None
+                };
+                out.push((self.model.clone(), world));
+            }
         }
         out
     }
@@ -623,8 +632,8 @@ impl FrameCtx<'_> {
     /// args, then [`Self::absorb`] the result (which honors `suppress_outbound`,
     /// so nothing escapes). A `Key` re-runs `Key::from_i32` on the raw code just
     /// as the live path does; an unknown code is dropped, like live. An entry
-    /// point the game doesn't define resolves to an interpreter error, reported
-    /// (and silenced) through the dry-run reporter. A `UiEvent` resolves against
+    /// point removed by the edited program is ignored, exactly as the live
+    /// shell would ignore that raw event. A `UiEvent` resolves against
     /// `ui_handlers` and a `WebviewEvent` against `webview_handlers` — the
     /// step-top tables the caller rebuilt (the live frame's last-render
     /// contract).
@@ -652,9 +661,10 @@ impl FrameCtx<'_> {
                     Value::Number(y as f64),
                 ],
             ),
-            RecordedInput::MouseWheel { delta } => {
-                ("mouseWheel", vec![self.model.clone(), Value::Number(delta as f64)])
-            }
+            RecordedInput::MouseWheel { delta } => (
+                "mouseWheel",
+                vec![self.model.clone(), Value::Number(delta as f64)],
+            ),
             RecordedInput::UiEvent(event) => {
                 self.deliver_ui_event(ui_handlers, &event);
                 return;
@@ -664,6 +674,9 @@ impl FrameCtx<'_> {
                 return;
             }
         };
+        if self.session.global(entry).is_none() {
+            return;
+        }
         match self.session.call(entry, args, &mut FunctorHost) {
             Ok(returned) => self.absorb(returned),
             Err(err) => self.reporter.frame_error(entry, &err),
@@ -732,13 +745,14 @@ to receive their messages; dropping them"
             }
             return;
         }
-        let subs = match self
-            .session
-            .call("subscriptions", vec![self.model.clone()], &mut FunctorHost)
-        {
-            Ok(subs) => subs,
-            Err(err) => return self.reporter.frame_error("subscriptions", &err),
-        };
+        let subs =
+            match self
+                .session
+                .call("subscriptions", vec![self.model.clone()], &mut FunctorHost)
+            {
+                Ok(subs) => subs,
+                Err(err) => return self.reporter.frame_error("subscriptions", &err),
+            };
         // Reconcile connections EVERY frame — including frame one (before the
         // timer window exists), so a declared connection opens immediately.
         self.reconcile_connections(&subs);
@@ -750,7 +764,11 @@ to receive their messages; dropping them"
         };
         let msgs = match sub_messages_for_frame(&subs, prev, tts) {
             Ok(msgs) => msgs,
-            Err(message) => return self.reporter.report_once(format!("[functor-lang] {message}")),
+            Err(message) => {
+                return self
+                    .reporter
+                    .report_once(format!("[functor-lang] {message}"))
+            }
         };
         for msg in msgs {
             let args = vec![self.model.clone(), msg];
@@ -776,7 +794,11 @@ to receive their messages; dropping them"
         }
         let taggers = match assets_taggers(subs) {
             Ok(taggers) => taggers,
-            Err(message) => return self.reporter.report_once(format!("[functor-lang] {message}")),
+            Err(message) => {
+                return self
+                    .reporter
+                    .report_once(format!("[functor-lang] {message}"))
+            }
         };
         if taggers.is_empty() {
             return;
@@ -838,7 +860,8 @@ to receive their messages; dropping them"
                     // time, applied at the step), so their problems — unknown
                     // tag, queue overflow — surface here, deduped.
                     for warning in warnings {
-                        self.reporter.report_once(format!("[functor-lang] {warning}"));
+                        self.reporter
+                            .report_once(format!("[functor-lang] {warning}"));
                     }
                     return steps;
                 }
@@ -875,7 +898,11 @@ to receive their messages; dropping them"
         }
         let conns = match net_conn_subs(subs) {
             Ok(conns) => conns,
-            Err(message) => return self.reporter.report_once(format!("[functor-lang] {message}")),
+            Err(message) => {
+                return self
+                    .reporter
+                    .report_once(format!("[functor-lang] {message}"))
+            }
         };
         // Dedupe by key (first declaration wins its listen/connect role) so a
         // key is opened at most once even if declared twice in one frame.
@@ -913,16 +940,21 @@ to receive their messages; dropping them"
         if !self.has_subscriptions {
             return;
         }
-        let subs = match self
-            .session
-            .call("subscriptions", vec![self.model.clone()], &mut FunctorHost)
-        {
-            Ok(subs) => subs,
-            Err(err) => return self.reporter.frame_error("subscriptions", &err),
-        };
+        let subs =
+            match self
+                .session
+                .call("subscriptions", vec![self.model.clone()], &mut FunctorHost)
+            {
+                Ok(subs) => subs,
+                Err(err) => return self.reporter.frame_error("subscriptions", &err),
+            };
         let conns = match net_conn_subs(&subs) {
             Ok(conns) => conns,
-            Err(message) => return self.reporter.report_once(format!("[functor-lang] {message}")),
+            Err(message) => {
+                return self
+                    .reporter
+                    .report_once(format!("[functor-lang] {message}"))
+            }
         };
         let Some(sub) = conns.into_iter().find(|c| c.key == key) else {
             return; // an event for a no-longer-declared connection: drop it
@@ -1072,6 +1104,39 @@ carries no payload to tag; dropped",
 /// they go nowhere.
 fn silent_emit(_: &str) {}
 
+enum ForwardInputs<'a> {
+    Dense(&'a [Vec<RecordedInput>]),
+    Recorder(&'a SceneRecorder),
+}
+
+impl ForwardInputs<'_> {
+    fn at(&self, step: usize) -> Option<&[RecordedInput]> {
+        match self {
+            ForwardInputs::Dense(inputs) => inputs.get(step).map(Vec::as_slice),
+            ForwardInputs::Recorder(recorder) => Some(recorder.replay_inputs_at_step(step)),
+        }
+    }
+}
+
+enum ForwardClock<'a> {
+    Fixed { tts: f32, dts: f32 },
+    Recorder(&'a SceneRecorder),
+}
+
+impl ForwardClock<'_> {
+    fn next(&mut self, step: usize) -> FrameTime {
+        match self {
+            ForwardClock::Fixed { tts, dts } => {
+                *tts += *dts;
+                FrameTime { tts: *tts, dts: *dts }
+            }
+            ForwardClock::Recorder(recorder) => recorder
+                .replay_frame_time_at_step(step)
+                .expect("counterfactual replay clock range was validated"),
+        }
+    }
+}
+
 /// RAII guard for a throwaway dry-run physics world: removes it from the global
 /// registry on drop, so a panic in the stepped game code (`session.call` runs the
 /// Functor Lang interpreter) can't leak the world. `forward_step_scene` runs repeatedly
@@ -1104,18 +1169,18 @@ impl Drop for DryWorld {
 /// drain. `prev_tts` seeds the subscription-timer window so timers stay
 /// continuous through the step; `start_tts` is the fork point's scene time.
 #[allow(clippy::too_many_arguments)]
-pub fn forward_step_scene(
+fn forward_step_scene_with_error(
     session: &Session,
     model: &Value,
     has_physics: bool,
     has_subscriptions: bool,
     prev_tts: Option<f64>,
-    start_tts: f32,
-    sub_dt: f32,
+    clock: ForwardClock<'_>,
     divisions: usize,
     steps_per_division: usize,
-    inputs: &[Vec<RecordedInput>],
-) -> Vec<(Value, Option<Vec<u8>>)> {
+    inputs: ForwardInputs<'_>,
+    capture_from_division: usize,
+) -> (Vec<(Value, Option<Vec<u8>>)>, Option<String>) {
     // Pause the paused-inspector journal for the whole dry run: `--ghost`
     // forward-projection replays `tick`/`update` over throwaway state, and those
     // calls must NOT land in the live frame's journal (they are not real frame
@@ -1155,7 +1220,7 @@ pub fn forward_step_scene(
 
     let mut model = model.clone();
     let mut physics_frame = 0u64;
-    let mut recorder = SceneRecorder::new();
+    let mut dry_recorder = SceneRecorder::new();
     let mut effect_runner = DryRunEffects::new();
     let mut effect_log = EffectLog::new();
     let mut deferred_queries: Vec<EffectTree> = Vec::new();
@@ -1176,12 +1241,13 @@ pub fn forward_step_scene(
     );
 
     let result = {
+        let mut clock = clock;
         let mut ctx = FrameCtx {
             session,
             model: &mut model,
             physics_rt: &mut physics_rt,
             physics_frame: &mut physics_frame,
-            recorder: &mut recorder,
+            recorder: &mut dry_recorder,
             effect_runner: &mut effect_runner as &mut dyn EffectRunner,
             effect_log: &mut effect_log,
             deferred_queries: &mut deferred_queries,
@@ -1196,13 +1262,117 @@ pub fn forward_step_scene(
             suppress_outbound: true,
             reporter: &mut reporter,
         };
-        ctx.step_scene_forward(divisions, steps_per_division, sub_dt, start_tts, inputs)
+        ctx.step_scene_forward(
+            divisions,
+            steps_per_division,
+            |step| inputs.at(step),
+            |step| clock.next(step),
+            capture_from_division,
+        )
     };
 
     // Natural drop order (declaration-reverse, also on unwind) restores the
     // world scope FIRST, then `dry_world`'s `Drop` removes the throwaway world
     // — so `active_world()` never points at a removed world.
-    result
+    (result, reporter.last_error())
+}
+
+/// Deterministically project a scene over throwaway state. Runtime errors are
+/// intentionally swallowed for visual previews, which simply omit/bound the
+/// affected projection; authoritative history replay uses the checked internal
+/// result instead.
+#[allow(clippy::too_many_arguments)]
+pub fn forward_step_scene(
+    session: &Session,
+    model: &Value,
+    has_physics: bool,
+    has_subscriptions: bool,
+    prev_tts: Option<f64>,
+    start_tts: f32,
+    sub_dt: f32,
+    divisions: usize,
+    steps_per_division: usize,
+    inputs: &[Vec<RecordedInput>],
+) -> Vec<(Value, Option<Vec<u8>>)> {
+    forward_step_scene_with_error(
+        session,
+        model,
+        has_physics,
+        has_subscriptions,
+        prev_tts,
+        ForwardClock::Fixed {
+            tts: start_tts,
+            dts: sub_dt,
+        },
+        divisions,
+        steps_per_division,
+        ForwardInputs::Dense(inputs),
+        0,
+    )
+    .0
+}
+
+/// Rebuild the complete retained pure-model timeline under the currently loaded
+/// program after a plain-data hot reload. Retained snapshots are old data: using
+/// them directly would preserve derived state from the old program (Mario's
+/// already-launched `vy`, for example), so a changed constant could alter only
+/// the beginning of a preview and then converge on the old outcome.
+///
+/// Replay starts from the edited program's actual `init` and is available only
+/// while the complete frame-zero input history is retained. Games with an
+/// `update` entry point are excluded for now because their model may depend on
+/// effect results or UI/network/audio/asset events that the input log does not
+/// yet capture. Physics games likewise need historical world replay.
+pub fn materialize_counterfactual_history(
+    session: &Session,
+    model: &mut Value,
+    recorder: &mut SceneRecorder,
+    has_physics: bool,
+    has_subscriptions: bool,
+    preserve_selected_model: bool,
+) -> Result<Option<usize>, String> {
+    if has_physics || session.global("update").is_some() {
+        return Ok(None);
+    }
+    let Some((lo, _, hi)) = recorder.counterfactual_replay_span()? else {
+        return Ok(None);
+    };
+    let Some(init) = session.global("init") else {
+        return Ok(None);
+    };
+    let recorded_frames = hi as usize + 1;
+    let prefix_len = recorder.replay_prefix_len();
+    let steps = prefix_len + recorded_frames;
+    let (stepped, replay_error) = forward_step_scene_with_error(
+        session,
+        &init,
+        false,
+        has_subscriptions,
+        None,
+        ForwardClock::Recorder(recorder),
+        steps,
+        1,
+        ForwardInputs::Recorder(recorder),
+        prefix_len + lo as usize,
+    );
+    if let Some(error) = replay_error {
+        return Err(format!(
+            "counterfactual history replay failed; retained old snapshots: {error}"
+        ));
+    }
+    let rebuilt: Vec<Value> = stepped.into_iter().map(|(model, _)| model).collect();
+    let selected_override = preserve_selected_model.then(|| model.clone());
+    let Some(selected) = recorder.materialize_counterfactual_history(
+        &rebuilt,
+        selected_override.as_ref(),
+    )? else {
+        return Err(
+            "counterfactual history replay produced an incomplete timeline; retained old snapshots"
+                .to_string(),
+        );
+    };
+    *model = selected;
+    Ok(Some(recorded_frames))
 }
 
 /// Forward-ghosting (docs/time-travel.md T6d): the shared producer body behind
@@ -1272,7 +1442,10 @@ pub fn ghost_frames(
         model,
         has_physics,
         has_subscriptions,
-        prev_tts,
+        // The projection starts at the selected frame's time. In particular,
+        // a scrubbed preview must not seed subscription windows from the old
+        // live tail's `prev_tts`.
+        recorder.current_scene_frame_tts().or(prev_tts),
         start_tts as f32,
         sub_dt,
         divisions,
@@ -1352,6 +1525,168 @@ mod tests {
             .unwrap_or_else(|f| panic!("session: {}", f.error.message));
         let model = session.global("init").expect("init");
         (session, model)
+    }
+
+    #[test]
+    fn failed_counterfactual_replay_keeps_the_old_history_atomically() {
+        let src = "\
+            let init = 0.0\n\
+            let tick = (m, dt, tts) => match m with | 0.0 => 1.0\n";
+        let project = functor_lang::project::load_single_source("game", src)
+            .unwrap_or_else(|e| panic!("load: {}", e.render()));
+        let session = Session::load(&project.module, &mut FunctorHost)
+            .unwrap_or_else(|f| panic!("session: {}", f.error.message));
+
+        let mut recorder = SceneRecorder::new();
+        for model in [10.0, 20.0, 30.0] {
+            recorder.record_inputs(Vec::new());
+            recorder.record(&Value::Number(model), 0, model / 60.0);
+        }
+        let mut model = Value::Number(30.0);
+        let mut physics = SteppedPhysics::new();
+        let mut physics_frame = 0;
+        recorder
+            .seek_scene_to(0, &mut model, &mut physics, &mut physics_frame, false)
+            .expect("scrub to a historical frame");
+        recorder.finish_reload(&model, physics_frame, true);
+
+        let error =
+            materialize_counterfactual_history(
+                &session,
+                &mut model,
+                &mut recorder,
+                false,
+                false,
+                false,
+            )
+                .expect_err("the second replayed tick has no matching arm");
+        assert!(error.contains("retained old snapshots"), "{error}");
+
+        recorder
+            .seek_scene_to(1, &mut model, &mut physics, &mut physics_frame, false)
+            .expect("old future remains seekable");
+        assert_eq!(model.to_string(), "20");
+    }
+
+    #[test]
+    fn same_source_counterfactual_replay_matches_cumulative_game_clock_tts() {
+        let src = "let init = 0.0\nlet tick = (m, dt, tts) => m + dt + tts\n";
+        let project = functor_lang::project::load_single_source("game", src)
+            .unwrap_or_else(|e| panic!("load: {}", e.render()));
+        let session = Session::load(&project.module, &mut FunctorHost)
+            .unwrap_or_else(|f| panic!("session: {}", f.error.message));
+
+        let mut recorder = SceneRecorder::new();
+        let mut recorded = Vec::new();
+        let mut tts = 0.0f32;
+        let mut live_model = 0.0f64;
+        let sub_dt = 1.0f32 / 60.0;
+        for frame in 0..1_000 {
+            let dts = if frame == 400 { 0.25 } else { sub_dt };
+            tts += dts;
+            live_model += dts as f64 + tts as f64;
+            let value = Value::Number(live_model);
+            recorded.push(value.to_string());
+            recorder.record_inputs(Vec::new());
+            recorder.record_timed(&value, 0, FrameTime { dts, tts });
+        }
+        let (lo, hi) = recorder.scene_frame_range().expect("retained history");
+        assert!(lo > 0, "exercise replay after model-ring pruning");
+
+        let mut model = Value::Number(0.0);
+        let mut physics = SteppedPhysics::new();
+        let mut physics_frame = 0;
+        recorder
+            .seek_scene_to(lo, &mut model, &mut physics, &mut physics_frame, false)
+            .expect("scrub retained history");
+        recorder.finish_reload(&model, physics_frame, true);
+        materialize_counterfactual_history(
+            &session,
+            &mut model,
+            &mut recorder,
+            false,
+            false,
+            false,
+        )
+            .expect("replay succeeds")
+            .expect("historical reload replays");
+
+        for frame in lo..=hi {
+            recorder
+                .seek_scene_to(frame, &mut model, &mut physics, &mut physics_frame, false)
+                .expect("seek rebuilt history");
+            assert_eq!(
+                model.to_string(),
+                recorded[frame as usize],
+                "same-source replay diverged at frame {frame}"
+            );
+        }
+    }
+
+    #[test]
+    fn counterfactual_replay_preserves_paused_input_and_ignores_removed_handlers() {
+        let src = "let init = 0.0\nlet tick = (m, dt, tts) => m + 1.0\n";
+        let project = functor_lang::project::load_single_source("game", src)
+            .unwrap_or_else(|e| panic!("load: {}", e.render()));
+        let session = Session::load(&project.module, &mut FunctorHost)
+            .unwrap_or_else(|f| panic!("session: {}", f.error.message));
+
+        let mut recorder = SceneRecorder::new();
+        recorder.record_replay_prefix(
+            FrameTime { dts: 0.0, tts: 0.0 },
+            Vec::new(),
+        );
+        for frame in 0..3 {
+            let inputs = (frame == 1)
+                .then(|| {
+                    vec![RecordedInput::Key {
+                        code: crate::Key::Right as i32,
+                        is_down: true,
+                    }]
+                })
+                .unwrap_or_default();
+            recorder.record_inputs(inputs);
+            recorder.record_timed(
+                &Value::Number((frame + 2) as f64),
+                0,
+                FrameTime {
+                    dts: 1.0 / 60.0,
+                    tts: (frame + 1) as f32 / 60.0,
+                },
+            );
+        }
+        let mut model = Value::Number(0.0);
+        let mut physics = SteppedPhysics::new();
+        let mut physics_frame = 0;
+        recorder
+            .seek_scene_to(1, &mut model, &mut physics, &mut physics_frame, false)
+            .expect("scrub into history");
+        // A live input while paused has already updated the authoritative model
+        // but is not part of the recorded future until Resume.
+        model = Value::Number(99.0);
+        recorder.finish_reload(&model, physics_frame, true);
+
+        assert_eq!(
+            materialize_counterfactual_history(
+                &session,
+                &mut model,
+                &mut recorder,
+                false,
+                false,
+                true,
+            )
+            .expect("removed input handler is not a replay error"),
+            Some(3)
+        );
+        assert_eq!(
+            model.to_string(),
+            "99",
+            "rebuild must not overwrite the authoritative paused-input model"
+        );
+        recorder
+            .seek_scene_to(2, &mut model, &mut physics, &mut physics_frame, false)
+            .expect("seek rebuilt recorded future");
+        assert_eq!(model.to_string(), "4", "other snapshots are reconstructed");
     }
 
     /// Drive one `deliver_ui_event` through a throwaway [`FrameCtx`] (the
@@ -1560,10 +1895,7 @@ mod tests {
             suppress_outbound: false,
             reporter: &mut reporter,
         };
-        ctx.before_physics(FrameTime {
-            dts: 0.2,
-            tts: 1.1,
-        });
+        ctx.before_physics(FrameTime { dts: 0.2, tts: 1.1 });
     }
 
     const ASSETS_SRC: &str = "\
@@ -1623,7 +1955,10 @@ mod tests {
             suppress_outbound: false,
             reporter: &mut reporter,
         };
-        ctx.before_physics(FrameTime { dts: 0.1, tts: tts as f32 });
+        ctx.before_physics(FrameTime {
+            dts: 0.1,
+            tts: tts as f32,
+        });
     }
 
     /// `Sub.assets` delivers the snapshot through `update` exactly when it
@@ -1643,7 +1978,13 @@ mod tests {
             total: 3,
             failed: vec![("a.glb".to_string(), "404".to_string())],
         };
-        run_assets_frame(&session, &mut model, Some(loading.clone()), &mut delivered, 1.1);
+        run_assets_frame(
+            &session,
+            &mut model,
+            Some(loading.clone()),
+            &mut delivered,
+            1.1,
+        );
         assert_model(&session, &model, "expectedFirst");
 
         // Same snapshot: no redelivery (count stays 1).
@@ -1656,7 +1997,13 @@ mod tests {
             total: 3,
             failed: vec![("a.glb".to_string(), "404".to_string())],
         };
-        run_assets_frame(&session, &mut model, Some(settled.clone()), &mut delivered, 1.3);
+        run_assets_frame(
+            &session,
+            &mut model,
+            Some(settled.clone()),
+            &mut delivered,
+            1.3,
+        );
         assert_model(&session, &model, "expectedSettled");
 
         // A time-travel branch restores an older model and INVALIDATES the
@@ -1693,7 +2040,10 @@ mod tests {
             "effect result: GotTime(42)"
         );
         assert_eq!(journal[2].entry, "tick");
-        assert_eq!(journal[2].provenance.render(&journal[2].args), "tick dt=0.2");
+        assert_eq!(
+            journal[2].provenance.render(&journal[2].args),
+            "tick dt=0.2"
+        );
 
         // Replaying each journaled call through the PR1 recorder reproduces the
         // exact result of a direct `call` (entry points are pure), and records

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -150,6 +150,13 @@ pub trait GameProducer {
         0
     }
 
+    /// Successful loaded-program revision. Safe plain-data reloads intentionally
+    /// leave `scene_timeline_generation` unchanged, but cached extrapolation must
+    /// still invalidate because the code that computes the future changed.
+    fn scene_program_revision(&self) -> u64 {
+        0
+    }
+
     /// The recorded `tts` of the frame the scene currently sits on (the scrubbed
     /// frame while dragging, else the newest recorded frame). Shells read this to
     /// REBASE their [`crate::GameClock`] when a time-travel branch resumes — on a
@@ -429,9 +436,7 @@ mod tests {
                 Light::ambient(0.1, 0.1, 0.1),
                 Light::directional(-1.0, -1.0, 0.0, 1.0, 1.0, 1.0, 0.8).cast_shadows(),
                 Light::point(0.0, 2.0, 0.0, 1.0, 0.0, 0.0, 1.0, 10.0),
-                Light::spot(
-                    0.0, 3.0, 0.0, 0.0, -1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 15.0, 0.5,
-                ),
+                Light::spot(0.0, 3.0, 0.0, 0.0, -1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 15.0, 0.5),
             ],
             render_targets: vec![RenderTargetPass {
                 target: RenderTargetDescriptor::new("feed"),
@@ -552,7 +557,10 @@ mod tests {
 
     #[test]
     fn frame_time_round_trips() {
-        let time = FrameTime { tts: 12.5, dts: 0.016 };
+        let time = FrameTime {
+            tts: 12.5,
+            dts: 0.016,
+        };
         let json = serde_json::to_string(&time).unwrap();
         let back: FrameTime = serde_json::from_str(&json).unwrap();
         assert_eq!(time.tts, back.tts);
@@ -615,7 +623,10 @@ mod tests {
             },
             r#"{"Send":{"conn":3,"payload":[1,2]}}"#,
         );
-        assert_wire(&ConnCommand::CloseConn { conn: 3 }, r#"{"CloseConn":{"conn":3}}"#);
+        assert_wire(
+            &ConnCommand::CloseConn { conn: 3 },
+            r#"{"CloseConn":{"conn":3}}"#,
+        );
         assert_wire(
             &ConnCommand::CloseKey {
                 key: "ws://server".to_string(),
@@ -671,7 +682,13 @@ mod tests {
 
         let scene = AudioScene::new(vec![
             AudioSource::ambient("bed".to_string(), "wind.ogg".to_string()),
-            AudioSource::at("fountain".to_string(), "water.ogg".to_string(), 1.0, 0.0, 2.0),
+            AudioSource::at(
+                "fountain".to_string(),
+                "water.ogg".to_string(),
+                1.0,
+                0.0,
+                2.0,
+            ),
         ]);
         assert_wire(
             &scene,

--- a/runtime/functor-runtime-common/src/timetravel.rs
+++ b/runtime/functor-runtime-common/src/timetravel.rs
@@ -28,10 +28,11 @@
 //! later increment unifies the two under one clock so a single `seek` restores
 //! model *and* world together (docs/time-travel.md, "One frame, one clock").
 
-use std::collections::VecDeque;
+use std::collections::{BTreeMap, VecDeque};
 
 use functor_lang::Value;
 
+use crate::FrameTime;
 use crate::input::RecordedInput;
 use crate::physics::SteppedPhysics;
 
@@ -188,6 +189,60 @@ impl<T: Clone> History<T> {
     }
 }
 
+/// Session-long input history with O(events) storage rather than one heap-sized
+/// `Vec` header per input-free frame. The contiguous frame range is tracked
+/// separately because fixed-step replay still advances through empty frames.
+struct InputHistory {
+    base: Option<Frame>,
+    next: Option<Frame>,
+    events: BTreeMap<Frame, Vec<RecordedInput>>,
+}
+
+impl InputHistory {
+    fn new() -> InputHistory {
+        InputHistory {
+            base: None,
+            next: None,
+            events: BTreeMap::new(),
+        }
+    }
+
+    fn record(&mut self, frame: Frame, inputs: Vec<RecordedInput>) {
+        match self.next {
+            None => self.base = Some(frame),
+            Some(next) => assert_eq!(frame, next, "input frames must be recorded consecutively"),
+        }
+        if !inputs.is_empty() {
+            self.events.insert(frame, inputs);
+        }
+        self.next = Some(frame + 1);
+    }
+
+    fn recorded_range(&self) -> Option<(Frame, Frame)> {
+        self.base.zip(self.next).and_then(|(base, next)| {
+            (next > base).then_some((base, next - 1))
+        })
+    }
+
+    fn at(&self, frame: Frame) -> &[RecordedInput] {
+        self.events.get(&frame).map(Vec::as_slice).unwrap_or(&[])
+    }
+
+    fn truncate_from(&mut self, frame: Frame) {
+        let Some(next) = self.next else { return };
+        if frame >= next {
+            return;
+        }
+        let base = self.base.expect("input history with a next frame has a base");
+        assert!(
+            frame >= base,
+            "truncate_from({frame}) predates input history (base {base})"
+        );
+        self.events.split_off(&frame);
+        self.next = Some(frame);
+    }
+}
+
 /// The coupled time-travel recorder shared by both Functor Lang shells (docs/time-travel.md
 /// T1–T3): records the MVU `model` and the physics fixed-frame in lockstep each
 /// rendered frame, and seeks/rewinds them together. It owns the recording rings
@@ -212,13 +267,22 @@ pub struct SceneRecorder {
     /// `tts` so `tts`-driven visuals (orbiting lights, `sin(tts)` bobbing)
     /// rewind too, not just model/world state (docs/time-travel.md).
     tts_history: History<f64>,
+    /// Exact per-frame `dts` / `tts`, retained for the current branch so a
+    /// same-source reconstruction replays debugger steps and f32 clock rounding
+    /// byte-identically even after the display-oriented `tts_history` prunes.
+    clock_history: History<FrameTime>,
+    /// The shell's one unrecorded bootstrap execution (`dts == 0`) before
+    /// frame zero. It can still mutate a valid model, so reconstruction must
+    /// replay it (and any input delivered before it) ahead of recorded frames.
+    replay_prefix: Option<(FrameTime, Vec<RecordedInput>)>,
     /// The frame-indexed input log (docs/time-travel.md T6, "The event log"):
     /// each rendered frame's recorded input events, keyed in LOCKSTEP with
     /// `model_history`. Unlike the other three rings this is PLAIN DATA
-    /// (`RecordedInput`), so it deliberately SURVIVES a hot reload — the log is
-    /// what lets "tweak a constant, replay my recorded inputs" work. Alignment
-    /// with the (reset) model ring holds because both key off `rendered_frame`.
-    input_history: History<Vec<RecordedInput>>,
+    /// (`RecordedInput`) and is retained from frame zero for the whole current
+    /// branch. That lets a scrubbed hot reload replay from the edited program's
+    /// `init` even after the much larger model/world snapshots have pruned their
+    /// first ~15-second window.
+    input_history: InputHistory,
     /// The rendered-frame index the next snapshot records at; monotonic.
     rendered_frame: u64,
     /// Bumps whenever existing recorded frames may have been replaced or a
@@ -226,6 +290,15 @@ pub struct SceneRecorder {
     /// this to rebuild from authoritative input history instead of guessing a
     /// branch from range movement.
     generation: u64,
+    /// Successful program swaps, including plain-data reloads that deliberately
+    /// keep the same timeline generation. Preview caches key on this revision:
+    /// a code edit changes extrapolation even when frame/range state does not.
+    program_revision: u64,
+    /// A plain-data reload preserved snapshots produced by the previous
+    /// program. Input-only extrapolation rebuilds the retained model timeline
+    /// from the input log under the new program instead of treating old-code
+    /// snapshots as authoritative.
+    counterfactual_replay: bool,
     /// While dragging: the frame the scrubber has non-destructively seeked to.
     /// `Some` = "scrubbing" (future intact); committed on resume.
     scrub_pos: Option<u64>,
@@ -243,9 +316,13 @@ impl SceneRecorder {
             model_history: History::bounded(DEFAULT_HISTORY_FRAMES),
             world_frame_history: History::bounded(DEFAULT_HISTORY_FRAMES),
             tts_history: History::bounded(DEFAULT_HISTORY_FRAMES),
-            input_history: History::bounded(DEFAULT_HISTORY_FRAMES),
+            clock_history: History::unbounded(),
+            replay_prefix: None,
+            input_history: InputHistory::new(),
             rendered_frame: 0,
             generation: 0,
+            program_revision: 0,
+            counterfactual_replay: false,
             scrub_pos: None,
         }
     }
@@ -267,6 +344,7 @@ impl SceneRecorder {
         physics_fixed_frame: u64,
         live_model_was_safe: bool,
     ) -> ReloadHistory {
+        self.program_revision = self.program_revision.wrapping_add(1);
         let current_frame = self.current_scene_frame();
         if live_model_was_safe && self.reload_history_is_safe() {
             // Input can update the live model while paused, without producing
@@ -279,9 +357,16 @@ impl SceneRecorder {
                 self.world_frame_history
                     .replace(frame, &physics_fixed_frame);
             }
+            // Ordinary hot reload at the live tail preserves the live model;
+            // only an explicitly scrubbed historical branch is counterfactual.
+            self.counterfactual_replay = self
+                .scrub_pos
+                .zip(self.model_history.recorded_range())
+                .is_some_and(|(selected, (_, hi))| selected < hi);
             return ReloadHistory::Preserved;
         }
 
+        self.counterfactual_replay = false;
         self.scrub_pos = None;
         let Some((frame, tts)) = current_frame.map(|frame| {
             let tts = *self.tts_history.seek(frame);
@@ -341,6 +426,89 @@ impl SceneRecorder {
         self.generation
     }
 
+    /// Monotonic successful-code-swap revision. Unlike [`Self::generation`], a
+    /// safe plain-data reload bumps this too, because extrapolation changes even
+    /// though the recorded frame range remains intact.
+    pub fn program_revision(&self) -> u64 {
+        self.program_revision
+    }
+
+    /// Complete replay target after a safe reload. Model snapshots may have
+    /// pruned frame zero; the small plain-data input log deliberately does not.
+    /// Return a diagnostic instead of silently falling back to old-data
+    /// semantics if that session-origin invariant is ever broken.
+    pub fn counterfactual_replay_span(
+        &self,
+    ) -> Result<Option<(Frame, Frame, Frame)>, String> {
+        if !self.counterfactual_replay {
+            return Ok(None);
+        }
+        let (lo, hi) = self.model_history.recorded_range().ok_or_else(|| {
+            "counterfactual replay unavailable: no model history is retained".to_string()
+        })?;
+        let (input_lo, input_hi) = self.input_history.recorded_range().ok_or_else(|| {
+            "counterfactual replay unavailable: the session input log is empty".to_string()
+        })?;
+        if input_lo != 0 || input_hi < hi {
+            return Err(format!(
+                "counterfactual replay unavailable: input history covers frames \
+                 {input_lo}..={input_hi}, not the required 0..={hi}"
+            ));
+        }
+        let selected = self.current_scene_frame().ok_or_else(|| {
+            "counterfactual replay unavailable: no selected frame".to_string()
+        })?;
+        let (clock_lo, clock_hi) = self.clock_history.recorded_range().ok_or_else(|| {
+            "counterfactual replay unavailable: the session clock log is empty".to_string()
+        })?;
+        if clock_lo != 0 || clock_hi < hi {
+            return Err(format!(
+                "counterfactual replay unavailable: clock history covers frames \
+                 {clock_lo}..={clock_hi}, not the required 0..={hi}"
+            ));
+        }
+        Ok(Some((lo, selected, hi)))
+    }
+
+    /// Replace the complete retained model timeline with models replayed under
+    /// the current program, returning the rebuilt selected model. The input,
+    /// world-frame, and `tts` rings keep their existing frame alignment.
+    pub fn materialize_counterfactual_history(
+        &mut self,
+        models: &[Value],
+        selected_override: Option<&Value>,
+    ) -> Result<Option<Value>, String> {
+        let Some((lo, selected, hi)) = self.counterfactual_replay_span()? else {
+            return Ok(None);
+        };
+        let retained = (hi - lo + 1) as usize;
+        if models.len() != retained {
+            return Err(format!(
+                "counterfactual replay produced {} frames, expected {}",
+                models.len(),
+                retained
+            ));
+        }
+        let (retained_lo, retained_hi) = self.model_history.recorded_range().ok_or_else(|| {
+            "counterfactual replay cannot replace an empty model history".to_string()
+        })?;
+        if (retained_lo, retained_hi) != (lo, hi) {
+            return Err("counterfactual replay target changed while rebuilding history".to_string());
+        }
+        for (frame, rebuilt) in (lo..=hi).zip(models) {
+            self.model_history.replace(
+                frame,
+                if frame == selected {
+                    selected_override.unwrap_or(rebuilt)
+                } else {
+                    rebuilt
+                },
+            );
+        }
+        self.counterfactual_replay = false;
+        Ok(Some(self.model_history.seek(selected).clone()))
+    }
+
     /// Commit a non-destructive scrub before an UNSAFE reload replaces the
     /// snapshot generation. Safe plain-data reloads must not call this: they
     /// retain both the selected cursor and its recorded future until Resume.
@@ -369,11 +537,68 @@ impl SceneRecorder {
     /// only when the sim advanced (`dts > 0`) — a paused frame would pile up
     /// frozen duplicates.
     pub fn record(&mut self, model: &Value, physics_fixed_frame: u64, tts: f64) {
+        self.record_timed(
+            model,
+            physics_fixed_frame,
+            FrameTime {
+                dts: 1.0 / 60.0,
+                tts: tts as f32,
+            },
+        );
+    }
+
+    /// Production recording path: retain the exact clock values the model saw.
+    pub fn record_timed(
+        &mut self,
+        model: &Value,
+        physics_fixed_frame: u64,
+        frame_time: FrameTime,
+    ) {
         self.model_history.record(self.rendered_frame, model);
         self.world_frame_history
             .record(self.rendered_frame, &physics_fixed_frame);
-        self.tts_history.record(self.rendered_frame, &tts);
+        self.tts_history
+            .record(self.rendered_frame, &(frame_time.tts as f64));
+        self.clock_history.record(self.rendered_frame, &frame_time);
         self.rendered_frame += 1;
+    }
+
+    pub fn frame_time_at(&self, frame: Frame) -> Option<FrameTime> {
+        self.clock_history.recorded_range().and_then(|(lo, hi)| {
+            (frame >= lo && frame <= hi).then(|| *self.clock_history.seek(frame))
+        })
+    }
+
+    /// Capture the shell's initial zero-delta settling execution. Later paused
+    /// renders are not simulation history and remain deliberately discarded.
+    pub fn record_replay_prefix(
+        &mut self,
+        frame_time: FrameTime,
+        inputs: Vec<RecordedInput>,
+    ) {
+        if self.rendered_frame == 0 && self.replay_prefix.is_none() {
+            self.replay_prefix = Some((frame_time, inputs));
+        }
+    }
+
+    pub fn replay_prefix_len(&self) -> usize {
+        usize::from(self.replay_prefix.is_some())
+    }
+
+    pub fn replay_frame_time_at_step(&self, step: usize) -> Option<FrameTime> {
+        match (&self.replay_prefix, step) {
+            (Some((frame_time, _)), 0) => Some(*frame_time),
+            (Some(_), step) => self.frame_time_at((step - 1) as Frame),
+            (None, step) => self.frame_time_at(step as Frame),
+        }
+    }
+
+    pub fn replay_inputs_at_step(&self, step: usize) -> &[RecordedInput] {
+        match (&self.replay_prefix, step) {
+            (Some((_, inputs)), 0) => inputs,
+            (Some(_), step) => self.inputs_at((step - 1) as Frame),
+            (None, step) => self.inputs_at(step as Frame),
+        }
     }
 
     /// Record this rendered frame's input events, keyed by the CURRENT
@@ -383,14 +608,14 @@ impl SceneRecorder {
     /// recorded for input-free frames, keeping the ring consecutive with the
     /// model ring.
     pub fn record_inputs(&mut self, inputs: Vec<RecordedInput>) {
-        self.input_history.record(self.rendered_frame, &inputs);
+        self.input_history.record(self.rendered_frame, inputs);
     }
 
     /// The recorded input events of `frame` — empty if that frame is outside the
     /// retained input window (never recorded, or pruned).
     pub fn inputs_at(&self, frame: u64) -> &[RecordedInput] {
         match self.input_history.recorded_range() {
-            Some((lo, hi)) if frame >= lo && frame <= hi => self.input_history.seek(frame),
+            Some((lo, hi)) if frame >= lo && frame <= hi => self.input_history.at(frame),
             _ => &[],
         }
     }
@@ -402,7 +627,7 @@ impl SceneRecorder {
     pub fn inputs_from(&self, start: u64) -> Vec<Vec<RecordedInput>> {
         match self.input_history.recorded_range() {
             Some((lo, hi)) => (start.max(lo)..=hi)
-                .map(|f| self.input_history.seek(f).clone())
+                .map(|f| self.input_history.at(f).to_vec())
                 .collect(),
             None => Vec::new(),
         }
@@ -455,6 +680,7 @@ impl SceneRecorder {
     ) -> bool {
         if let Some(k) = self.scrub_pos.take() {
             let _ = self.rewind_scene_to(k, model, physics, physics_frame, has_physics);
+            self.counterfactual_replay = false;
             true
         } else {
             false
@@ -518,6 +744,7 @@ impl SceneRecorder {
         // Truncate the input log too: a destructive branch discards the old
         // future consistently across all four rings (docs/time-travel.md T6b).
         self.input_history.truncate_from(frame + 1);
+        self.clock_history.truncate_from(frame + 1);
         self.rendered_frame = frame + 1;
         self.generation = self.generation.wrapping_add(1);
         self.scrub_pos = None;
@@ -750,6 +977,7 @@ mod tests {
     fn plain_data_reload_while_scrubbed_preserves_the_full_future_until_resume() {
         let mut rec = SceneRecorder::new();
         for frame in 0..5u64 {
+            rec.record_inputs(Vec::new());
             rec.record(&Value::Number(frame as f64), 0, frame as f64);
         }
         let mut model = Value::Number(0.0);
@@ -769,11 +997,104 @@ mod tests {
         assert_eq!(rec.scrub_render_tts(), Some(2.0));
         assert_eq!(rec.generation(), generation);
         assert_eq!(rec.next_frame(), 5, "reload must not branch the future");
+        assert_eq!(rec.counterfactual_replay_span(), Ok(Some((0, 2, 4))));
+
+        let rebuilt: Vec<Value> = (10..15).map(|n| Value::Number(n as f64)).collect();
+        model = rec
+            .materialize_counterfactual_history(&rebuilt, None)
+            .expect("valid replay history")
+            .expect("materialized history");
 
         assert!(rec.commit_scrub_if_resuming(&mut model, &mut physics, &mut physics_frame, false));
+        assert_eq!(model.to_string(), "12", "Resume adopts the rebuilt anchor");
+        assert_eq!(rec.counterfactual_replay_span(), Ok(None));
         assert_eq!(rec.scene_frame_range(), Some((0, 2)));
         assert_eq!(rec.next_frame(), 3);
         assert_ne!(rec.generation(), generation, "Resume commits the branch");
+    }
+
+    #[test]
+    fn counterfactual_replay_requires_a_historical_scrub_but_not_model_frame_zero() {
+        let mut live = SceneRecorder::new();
+        for frame in 0..3u64 {
+            live.record_inputs(Vec::new());
+            live.record(&Value::Number(frame as f64), 0, frame as f64);
+        }
+        assert_eq!(
+            live.finish_reload(&Value::Number(2.0), 0, true),
+            ReloadHistory::Preserved
+        );
+        assert!(
+            live.counterfactual_replay_span() == Ok(None),
+            "ordinary live-tail reload preserves the live model"
+        );
+
+        let mut tail = SceneRecorder::new();
+        for frame in 0..3u64 {
+            tail.record_inputs(Vec::new());
+            tail.record(&Value::Number(frame as f64), 0, frame as f64);
+        }
+        let mut tail_model = Value::Number(0.0);
+        let mut tail_physics = SteppedPhysics::new();
+        let mut tail_physics_frame = 0;
+        tail.seek_scene_to(
+            2,
+            &mut tail_model,
+            &mut tail_physics,
+            &mut tail_physics_frame,
+            false,
+        )
+        .expect("seek live tail");
+        tail.finish_reload(&tail_model, tail_physics_frame, true);
+        assert!(
+            tail.counterfactual_replay_span() == Ok(None),
+            "a cursor explicitly parked at the newest frame is still the live tail"
+        );
+
+        let mut pruned = SceneRecorder::new();
+        for frame in 0..=DEFAULT_HISTORY_FRAMES as u64 {
+            pruned.record_inputs(Vec::new());
+            pruned.record(&Value::Number(frame as f64), 0, frame as f64);
+        }
+        let (lo, _) = pruned.scene_frame_range().unwrap();
+        assert!(lo > 0);
+        let mut model = Value::Number(0.0);
+        let mut physics = SteppedPhysics::new();
+        let mut physics_frame = 0;
+        pruned
+            .seek_scene_to(lo, &mut model, &mut physics, &mut physics_frame, false)
+            .expect("seek pruned floor");
+        assert_eq!(
+            pruned.finish_reload(&model, physics_frame, true),
+            ReloadHistory::Preserved
+        );
+        assert_eq!(
+            pruned.counterfactual_replay_span(),
+            Ok(Some((lo, lo, DEFAULT_HISTORY_FRAMES as u64))),
+            "the session input log keeps frame zero after model pruning"
+        );
+    }
+
+    #[test]
+    fn counterfactual_replay_reports_a_missing_session_input_log() {
+        let mut rec = SceneRecorder::new();
+        for frame in 0..3u64 {
+            // Deliberately violate the producer invariant by omitting
+            // `record_inputs`; production must report this instead of silently
+            // retaining old-code snapshots.
+            rec.record(&Value::Number(frame as f64), 0, frame as f64);
+        }
+        let mut model = Value::Number(0.0);
+        let mut physics = SteppedPhysics::new();
+        let mut physics_frame = 0;
+        rec.seek_scene_to(1, &mut model, &mut physics, &mut physics_frame, false)
+            .expect("scrub into history");
+        rec.finish_reload(&model, physics_frame, true);
+
+        let error = rec
+            .counterfactual_replay_span()
+            .expect_err("missing input history must be diagnosed");
+        assert!(error.contains("session input log is empty"), "{error}");
     }
 
     #[test]
@@ -878,12 +1199,8 @@ mod tests {
         // but must not overwrite this live value with frame 2's snapshot.
         model = closure_model();
         let live_before = model.to_string();
-        let live_model_was_safe = rec.prepare_reload(
-            &mut model,
-            &mut physics,
-            &mut physics_frame,
-            false,
-        );
+        let live_model_was_safe =
+            rec.prepare_reload(&mut model, &mut physics, &mut physics_frame, false);
         assert!(!live_model_was_safe);
         assert_eq!(model.to_string(), live_before);
         assert_eq!(rec.scene_frame_range(), Some((0, 2)));

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -52,6 +52,14 @@ use std::time::SystemTime;
 
 use crate::game::Game;
 
+fn replay_status(history_replay: Option<(usize, f64)>) -> String {
+    history_replay.map_or_else(String::new, |(frames, elapsed_ms)| {
+        format!(
+            "; history recomputed from init ({frames} frames, {elapsed_ms:.2}ms)"
+        )
+    })
+}
+
 pub struct FunctorLangGame {
     path: String,
     /// Per-file mtimes of the WHOLE project (every sibling `.fun` — B8:
@@ -499,7 +507,13 @@ impl FunctorLangGame {
     /// is kept as well: `Sub.every` fires on the global time grid, so timers
     /// tick right through a reload. Returns the number of stored closures
     /// rebound, for the status line.
-    fn swap_in(&mut self, loaded: Loaded) -> usize {
+    fn swap_in(
+        &mut self,
+        loaded: Loaded,
+    ) -> (
+        usize,
+        Option<(usize, f64)>,
+    ) {
         let live_model_was_safe = self.recorder.prepare_reload(
             &mut self.model,
             &mut self.physics_rt,
@@ -571,7 +585,26 @@ impl FunctorLangGame {
         // generation anchored at this rebound live frame.
         self.recorder
             .finish_reload(&self.model, self.physics_frame, live_model_was_safe);
-        report.rebound
+        let replay_started = Instant::now();
+        let history_replay = match
+            functor_runtime_common::functor_lang_producer::materialize_counterfactual_history(
+                &self.session,
+                &mut self.model,
+                &mut self.recorder,
+                self.has_physics,
+                self.has_subscriptions,
+                !self.input_buf.is_empty(),
+            )
+        {
+            Ok(frames) => frames.map(|frames| {
+                (frames, replay_started.elapsed().as_secs_f64() * 1000.0)
+            }),
+            Err(error) => {
+                self.reporter.report_once(format!("[functor-lang] {error}"));
+                None
+            }
+        };
+        (report.rebound, history_replay)
     }
 
     fn report_stats(&mut self) {
@@ -640,16 +673,17 @@ impl Game for FunctorLangGame {
         };
         match loaded {
             Ok(loaded) => {
-                let rebound = self.swap_in(loaded);
+                let (rebound, history_replay) = self.swap_in(loaded);
                 let stored = if rebound > 0 {
                     format!("; {rebound} stored closure(s) rebound")
                 } else {
                     String::new()
                 };
+                let history = replay_status(history_replay);
                 events::emit(RuntimeEvent::HotReload {
                     ok: true,
                     message: format!(
-                        "hot-reloaded {} in {:.2}ms (model preserved{stored}; an edited \
+                        "hot-reloaded {} in {:.2}ms (model preserved{stored}{history}; an edited \
 `init` takes effect on restart)",
                         self.path,
                         started.elapsed().as_secs_f64() * 1000.0
@@ -681,15 +715,16 @@ impl Game for FunctorLangGame {
         let stamp = project_stamp(&self.path);
         let loaded = load_source(&self.path, source.to_string())?;
         self.pushed_entry = Some(source.to_string());
-        let rebound = self.swap_in(loaded);
+        let (rebound, history_replay) = self.swap_in(loaded);
         let stored = if rebound > 0 {
             format!("; {rebound} stored closure(s) rebound")
         } else {
             String::new()
         };
+        let history = replay_status(history_replay);
         self.stamp = stamp;
         let status = format!(
-            "reloaded {} from pushed source in {:.2}ms (model preserved{stored})",
+            "reloaded {} from pushed source in {:.2}ms (model preserved{stored}{history})",
             self.path,
             started.elapsed().as_secs_f64() * 1000.0
         );
@@ -744,6 +779,10 @@ impl Game for FunctorLangGame {
 
     fn scene_frame_range(&self) -> Option<(u64, u64)> {
         self.recorder.scene_frame_range()
+    }
+
+    fn scene_program_revision(&self) -> u64 {
+        self.recorder.program_revision()
     }
 
     fn current_scene_tts(&self) -> Option<f64> {
@@ -839,7 +878,8 @@ impl Game for FunctorLangGame {
             // coverage replays them lazily at pause time.
             let frame = self.recorder.current_scene_frame().unwrap_or(0);
             self.journal_ring.push_back((frame, journal.clone()));
-            while self.journal_ring.len() > functor_runtime_common::inspector::COVERAGE_RING_FRAMES {
+            while self.journal_ring.len() > functor_runtime_common::inspector::COVERAGE_RING_FRAMES
+            {
                 self.journal_ring.pop_front();
             }
             self.last_frame_journal = journal;
@@ -2383,6 +2423,187 @@ mod tests {
         }
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Bret-Victor authoring regression: a failed jump recorded under the old
+    /// program must be recomputed all the way through under a hot-reloaded
+    /// jump constant. The old future contributes inputs only, never model
+    /// snapshots or outcomes.
+    #[test]
+    fn mario_hot_reload_recomputes_the_entire_extrapolated_future() {
+        use functor_runtime_common::Key;
+
+        fn field(v: &Value, name: &str) -> f64 {
+            match v {
+                Value::Record(fields) => match &fields.iter().find(|(k, _)| k == name).unwrap().1 {
+                    Value::Number(x) => *x,
+                    Value::Bool(b) => (*b as i32) as f64,
+                    other => panic!("{name} is not a number/bool: {other}"),
+                },
+                _ => panic!("model is not a record"),
+            }
+        }
+
+        let mario = concat!(env!("CARGO_MANIFEST_DIR"), "/../../examples/mario/game.fun");
+        let source = std::fs::read_to_string(mario).expect("read mario source");
+        let weak_jump = source.replacen("let jumpVelocity = 12.0", "let jumpVelocity = 6.0", 1);
+        assert_ne!(weak_jump, source, "test must rewrite the jump constant");
+
+        let mut game = FunctorLangGame::create(mario);
+        const SUB_DT: f32 = 1.0 / 60.0;
+        let mut tts = 0.0f32;
+        // Match the browser workflow after the old ~15-second retention cliff:
+        // model snapshots have pruned frame zero, but the session input log has
+        // not, so edited-code reconstruction can still start from `init`.
+        for _ in 0..(functor_runtime_common::timetravel::DEFAULT_HISTORY_FRAMES + 30) {
+            tts += SUB_DT;
+            game.tick(FrameTime { tts, dts: SUB_DT });
+        }
+        assert!(
+            game.scene_frame_range().unwrap().0 > 0,
+            "the regression must exercise pruned model history"
+        );
+        game.reload_source(&weak_jump).expect("load weak jump");
+
+        const N: usize = 90;
+        game.key_event(Key::Right as i32, true);
+        let mut jumped = false;
+        let mut jump_frame = None;
+        for _ in 0..N {
+            if !jumped
+                && field(&game.model, "grounded") == 1.0
+                && field(&game.model, "x") + (8.0 * SUB_DT as f64) >= -3.0
+            {
+                game.key_event(Key::Up as i32, true);
+                jumped = true;
+                jump_frame = Some(game.recorder.next_frame());
+            }
+            tts += SUB_DT;
+            game.tick(FrameTime { tts, dts: SUB_DT });
+        }
+        assert!(jumped, "the weak jump must have fired");
+        assert_eq!(
+            field(&game.model, "x"),
+            -6.0,
+            "weak jump should fall and respawn"
+        );
+
+        // Scrub to an airborne frame AFTER the jump input. Replaying only from
+        // this old-code snapshot is the bug: it has already baked in the weak
+        // launch velocity, so the edited constant can never affect the jump.
+        // Counterfactual extrapolation must rebuild the selected anchor from
+        // retained inputs under the new program before projecting its future.
+        let s = jump_frame.expect("recorded jump frame") + 15;
+        game.seek_scene_to(s).expect("scrub into the failed jump");
+        let reload_status = game.reload_source(&source).expect("reload stronger jump");
+        assert!(
+            reload_status.contains("history recomputed from init (")
+                && reload_status.contains(" frames, "),
+            "reload status must disclose reconstruction and timing: {reload_status}"
+        );
+
+        // Reload recomputes every retained snapshot once, so later scrubbing is
+        // an O(1) restore and the old recorded failure has already disappeared.
+        game.seek_scene_to(s + 50).expect("seek rebuilt future");
+        assert!(
+            field(&game.model, "x") > 3.0,
+            "the retained future itself must be rebuilt under the stronger jump: {}",
+            game.model
+        );
+        game.seek_scene_to(s).expect("return to rebuilt anchor");
+
+        let inputs = game.recorder.inputs_from(s + 1);
+        let start_tts = game.recorder.current_scene_frame_tts().unwrap() as f32;
+        let anchor = game.model.clone();
+        let forward = functor_runtime_common::functor_lang_producer::forward_step_scene(
+            &game.session,
+            &anchor,
+            game.has_physics,
+            game.has_subscriptions,
+            Some(start_tts as f64),
+            start_tts,
+            SUB_DT,
+            10,
+            5,
+            &inputs,
+        );
+        let recomputed = &forward.last().expect("projected future").0;
+        assert!(
+            field(recomputed, "x") > 3.0,
+            "the stronger jump must clear the chasm instead of coalescing back to the old fall: {recomputed}"
+        );
+
+        // The counterfactual anchor is authoritative, not a preview-only
+        // illusion: Resume must branch from it and reach the same landing.
+        let mut branch_tts = start_tts;
+        for _ in 0..50 {
+            branch_tts += SUB_DT;
+            game.tick(FrameTime {
+                tts: branch_tts,
+                dts: SUB_DT,
+            });
+        }
+        assert!(
+            field(&game.model, "x") > 3.0,
+            "resumed play must follow the recomputed strong-jump branch: {}",
+            game.model
+        );
+    }
+
+    /// Same-code reconstruction is the determinism invariant behind edited-code
+    /// extrapolation: replaying the exact frame-indexed inputs from `init` must
+    /// reproduce every retained model byte-for-byte.
+    #[test]
+    fn scrubbed_same_source_reload_rebuilds_identical_history() {
+        use functor_runtime_common::Key;
+
+        fn retained_models(game: &mut FunctorLangGame) -> Vec<(u64, String)> {
+            let (lo, hi) = game.scene_frame_range().expect("recorded history");
+            (lo..=hi)
+                .map(|frame| {
+                    game.seek_scene_to(frame).expect("seek retained frame");
+                    (frame, game.model.to_string())
+                })
+                .collect()
+        }
+
+        let mario = concat!(env!("CARGO_MANIFEST_DIR"), "/../../examples/mario/game.fun");
+        let source = std::fs::read_to_string(mario).expect("read mario source");
+        let mut game = FunctorLangGame::create(mario);
+        const SUB_DT: f32 = 1.0 / 60.0;
+
+        // Exercise the real shell bootstrap: this zero-delta tick is not a
+        // visible timeline frame, but exact reconstruction must replay it.
+        game.tick(FrameTime { tts: 0.0, dts: 0.0 });
+
+        for frame in 0..120 {
+            match frame {
+                5 => game.key_event(Key::Right as i32, true),
+                25 => game.key_event(Key::Up as i32, true),
+                26 => game.key_event(Key::Up as i32, false),
+                // Exact reconstruction deliberately replays this release at its
+                // recorded frame. A future "coast" mode would instead cut off
+                // recorded input here, but that is a separate authoring choice.
+                70 => game.key_event(Key::Right as i32, false),
+                _ => {}
+            }
+            game.tick(FrameTime {
+                tts: (frame + 1) as f32 * SUB_DT,
+                dts: SUB_DT,
+            });
+        }
+
+        let selected = 40;
+        let before = retained_models(&mut game);
+        game.seek_scene_to(selected).expect("scrub into history");
+        let status = game.reload_source(&source).expect("reload identical source");
+        assert!(
+            status.contains("history recomputed from init (120 frames, "),
+            "reload status must disclose deterministic reconstruction: {status}"
+        );
+        let after = retained_models(&mut game);
+
+        assert_eq!(after, before, "same-source replay must be byte-identical");
     }
 
     /// Regression (xreview): under the fixed-timestep loop a live input can be

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -135,7 +135,11 @@ fn parse_input_script(path: &str) -> Result<HashMap<u64, Vec<RecordedInput>>, St
         let is_down = match parts[2].to_ascii_lowercase().as_str() {
             "down" => true,
             "up" => false,
-            other => return Err(format!("{path}:{lineno}: expected `down|up`, got `{other}`")),
+            other => {
+                return Err(format!(
+                    "{path}:{lineno}: expected `down|up`, got `{other}`"
+                ))
+            }
         };
         map.entry(frame).or_default().push(RecordedInput::Key {
             code: key as i32,
@@ -744,7 +748,9 @@ pub fn run(args: Args) {
     let mut game: Box<dyn Game> = if args.replay {
         Box::new(replay_game::ReplayGame::create(game_path.as_str()))
     } else if args.functor_lang {
-        Box::new(functor_lang_game::FunctorLangGame::create(game_path.as_str()))
+        Box::new(functor_lang_game::FunctorLangGame::create(
+            game_path.as_str(),
+        ))
     } else {
         // Functor Lang is the only game producer now (the F#/dylib path was removed in
         // E3). The CLI and SDK always pass --functor-lang; a bare invocation has no
@@ -761,13 +767,15 @@ pub fn run(args: Args) {
     // (the default) leaves live input and the wall-clock capture trigger
     // untouched.
     let input_script: Option<HashMap<u64, Vec<RecordedInput>>> =
-        args.input_script.as_ref().map(|path| match parse_input_script(path) {
-            Ok(map) => map,
-            Err(e) => {
-                eprintln!("error: {e}");
-                std::process::exit(1);
-            }
-        });
+        args.input_script
+            .as_ref()
+            .map(|path| match parse_input_script(path) {
+                Ok(map) => map,
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    std::process::exit(1);
+                }
+            });
 
     // `--capture-at-frame` only names a *deterministic* sim frame when playback
     // advances by a fixed dt — i.e. under `--input-script`. Without it the loop
@@ -799,7 +807,9 @@ pub fn run(args: Args) {
             std::process::exit(1);
         }
         if args.xreal_tracking {
-            eprintln!("warning: --xreal-tracking has no effect in --headless mode (no view to rotate)");
+            eprintln!(
+                "warning: --xreal-tracking has no effect in --headless mode (no view to rotate)"
+            );
         }
         run_headless(game, debug_requests, args.fixed_time);
         return;
@@ -929,20 +939,20 @@ pub fn run(args: Args) {
         // --trajectory/--strobe preview cache. The 32-division forward-sim is
         // the expensive part, and while PAUSED its anchor (scene frame + tts) is
         // frozen — so reuse the computed preview while the anchor key matches,
-        // but still refresh after a bounded number of frames so a hot-reload's
-        // edited code re-projects within ~half a second (the anchor can't see a
-        // code edit). While live, the last projection remains visible between
-        // wall-clock refreshes so continuous extrapolation bounds repeated work.
+        // but still refresh after a bounded number of frames for non-code state
+        // outside the anchor key. A program revision invalidates immediately.
+        // While live, the last projection remains visible between wall-clock
+        // refreshes so continuous extrapolation bounds repeated work.
         const PAUSED_PREVIEW_REUSE_FRAMES: u32 = 30;
         const LIVE_PREVIEW_INTERVAL_SECONDS: f32 = 0.1;
         let mut trail_cache: Option<(
-            (Option<u64>, u32, bool, bool, bool, usize, u32),
+            (Option<u64>, u32, bool, u64, bool, bool, usize, u32),
             functor_runtime_common::ScenePreview,
         )> = None;
         let mut trail_refresh: u32 = 0;
         let mut next_live_trail_refresh: f32 = 0.0;
         let mut ghost_cache: Option<(
-            (Option<u64>, u32, bool, usize, u32),
+            (Option<u64>, u32, bool, u64, usize, u32),
             Vec<(Frame, FrameTime)>,
         )> = None;
         let mut ghost_refresh: u32 = 0;
@@ -1122,11 +1132,8 @@ pub fn run(args: Args) {
                     // Printable text for a focused field. Only meaningful
                     // while the overlay wants the keyboard; otherwise Char
                     // events are dropped (the game hears keys, not text).
-                    glfw::WindowEvent::Char(c)
-                        if ui_wants_keyboard && !ignore_user_input =>
-                    {
-                        ui_keyboard
-                            .push(functor_runtime_common::ui::UiKeyboardEvent::Char(c));
+                    glfw::WindowEvent::Char(c) if ui_wants_keyboard && !ignore_user_input => {
+                        ui_keyboard.push(functor_runtime_common::ui::UiKeyboardEvent::Char(c));
                     }
                     // While a field is focused, Escape DEFOCUSES it (egui's
                     // built-in) instead of releasing the cursor — the next
@@ -1199,10 +1206,8 @@ Escape again to quit"
                                 // the cursor.
                                 if scrubber_wants_pointer
                                     || ui_wants_pointer
-                                    || webview_overlay.hit_interactive_css(
-                                        mouse_pos.0 as f32,
-                                        mouse_pos.1 as f32,
-                                    )
+                                    || webview_overlay
+                                        .hit_interactive_css(mouse_pos.0 as f32, mouse_pos.1 as f32)
                                 {
                                     mouse_primary_down = true;
                                     mouse_primary_clicked = true;
@@ -1406,10 +1411,9 @@ Escape again to quit"
             // captures byte-identical.
             const TRAIL_RATE: f32 = 20.0;
             let (preview_divisions, preview_window_s, strobe_copies) = if scrubber_visible {
-                let divisions =
-                    ((TRAIL_RATE * preview_window).round() as usize).clamp(1, 64);
-                let copies = ((preview_rate as f32 * preview_window).round() as usize)
-                    .clamp(1, divisions);
+                let divisions = ((TRAIL_RATE * preview_window).round() as usize).clamp(1, 64);
+                let copies =
+                    ((preview_rate as f32 * preview_window).round() as usize).clamp(1, divisions);
                 (divisions, preview_window, copies)
             } else {
                 (32usize, 1.6f32, 8usize)
@@ -1431,6 +1435,7 @@ Escape again to quit"
                     game.current_scene_frame(),
                     time.tts.to_bits(),
                     clock.is_paused(),
+                    game.scene_program_revision(),
                     trail_wanted,
                     strobe_wanted,
                     divisions,
@@ -1446,6 +1451,7 @@ Escape again to quit"
                             && k.4 == key.4
                             && k.5 == key.5
                             && k.6 == key.6
+                            && k.7 == key.7
                     } else {
                         trail_refresh > 0 && *k == key
                     }
@@ -1466,8 +1472,7 @@ Escape again to quit"
                     let script_slice: Option<Vec<Vec<RecordedInput>>> =
                         input_script.as_ref().map(|script| {
                             let sub_dt = 1.0f32 / 60.0;
-                            let steps_per_division =
-                                ((dt / sub_dt).round() as usize).max(1);
+                            let steps_per_division = ((dt / sub_dt).round() as usize).max(1);
                             let total = (divisions * steps_per_division) as u64;
                             // Under --ghost the live loop does NOT consume the
                             // script (the model holds at the init anchor while
@@ -1581,6 +1586,7 @@ Escape again to quit"
                         game.current_scene_frame(),
                         time.tts.to_bits(),
                         clock.is_paused(),
+                        game.scene_program_revision(),
                         divisions,
                         ghost_window.to_bits(),
                     );
@@ -1592,6 +1598,7 @@ Escape again to quit"
                                 && !k.2
                                 && k.3 == key.3
                                 && k.4 == key.4
+                                && k.5 == key.5
                         }
                     });
                     if cache_hit {
@@ -1731,8 +1738,24 @@ Escape again to quit"
                 let half_w = (fb_width as u32) / 2;
                 let right_w = fb_width as u32 - half_w;
                 let eyes = [
-                    (left_cam, functor_runtime_common::Viewport::with_offset(0, 0, half_w, fb_height as u32)),
-                    (right_cam, functor_runtime_common::Viewport::with_offset(half_w, 0, right_w, fb_height as u32)),
+                    (
+                        left_cam,
+                        functor_runtime_common::Viewport::with_offset(
+                            0,
+                            0,
+                            half_w,
+                            fb_height as u32,
+                        ),
+                    ),
+                    (
+                        right_cam,
+                        functor_runtime_common::Viewport::with_offset(
+                            half_w,
+                            0,
+                            right_w,
+                            fb_height as u32,
+                        ),
+                    ),
                 ];
                 for (camera, eye_viewport) in &eyes {
                     gl.disable(glow::SCISSOR_TEST);
@@ -1770,10 +1793,7 @@ Escape again to quit"
                         xform: cgmath::Matrix4::from_translation(cgmath::vec3(6.0, 0.0, 0.0)),
                     };
                 }
-                let frames = [
-                    (frame.clone(), time.clone()),
-                    (frame_b, time.clone()),
-                ];
+                let frames = [(frame.clone(), time.clone()), (frame_b, time.clone())];
                 functor_runtime_common::render_composited_frames(
                     &gl,
                     shader_version,
@@ -2149,7 +2169,10 @@ mod tests {
             map[&18][0],
             RecordedInput::Key { code, is_down: true } if code == InputKey::Up as i32
         ));
-        assert!(matches!(map[&71][0], RecordedInput::Key { is_down: false, .. }));
+        assert!(matches!(
+            map[&71][0],
+            RecordedInput::Key { is_down: false, .. }
+        ));
     }
 
     #[test]

--- a/runtime/functor-runtime-web/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-web/src/functor_lang_game.rs
@@ -40,6 +40,14 @@ use functor_runtime_common::webview::HtmlNode;
 use functor_runtime_common::{Frame, FrameTime};
 use wasm_bindgen::prelude::*;
 
+fn replay_status(history_replay: Option<(usize, f64)>) -> String {
+    history_replay.map_or_else(String::new, |(frames, elapsed_ms)| {
+        format!(
+            "; history recomputed from init ({frames} frames, {elapsed_ms:.2}ms)"
+        )
+    })
+}
+
 pub struct FunctorLangWebGame {
     path: String,
     /// The project's fetched source files (entry FIRST, then siblings) as
@@ -430,7 +438,7 @@ impl FunctorLangWebGame {
     /// as well: `Sub.every` fires on the global time grid, so timers tick
     /// right through a reload. Returns the number of stored closures rebound,
     /// for the status line.
-    fn swap_in(&mut self, loaded: Loaded) -> usize {
+    fn swap_in(&mut self, loaded: Loaded) -> (usize, Option<(usize, f64)>) {
         let live_model_was_safe = self.recorder.prepare_reload(
             &mut self.model,
             &mut self.physics_rt,
@@ -486,6 +494,23 @@ impl FunctorLangWebGame {
         // generation anchored at this rebound live frame.
         self.recorder
             .finish_reload(&self.model, self.physics_frame, live_model_was_safe);
+        let replay_started = js_sys::Date::now();
+        let history_replay = match
+            functor_runtime_common::functor_lang_producer::materialize_counterfactual_history(
+                &self.session,
+                &mut self.model,
+                &mut self.recorder,
+                self.has_physics,
+                self.has_subscriptions,
+                !self.input_buf.is_empty(),
+            )
+        {
+            Ok(frames) => frames.map(|frames| (frames, js_sys::Date::now() - replay_started)),
+            Err(error) => {
+                self.reporter.report_once(format!("[functor-lang] {error}"));
+                None
+            }
+        };
         self.has_ui = loaded.has_ui;
         if !self.has_ui {
             // Deleting the `ui` hook drops the HUD (the physics-world rule).
@@ -501,7 +526,7 @@ impl FunctorLangWebGame {
         // clear our shadow so the reloaded program's first draw re-shows it if
         // that program's `draw` still errors.
         self.overlay_error = None;
-        report.rebound
+        (report.rebound, history_replay)
     }
 
     /// Toggle the page's red draw-error overlay, touching the DOM only when the
@@ -575,14 +600,15 @@ impl GameProducer for FunctorLangWebGame {
         }
         let loaded = load_source(&sources)?;
         self.sources = sources;
-        let rebound = self.swap_in(loaded);
+        let (rebound, history_replay) = self.swap_in(loaded);
         let stored = if rebound > 0 {
             format!("; {rebound} stored closure(s) rebound")
         } else {
             String::new()
         };
+        let history = replay_status(history_replay);
         let status = format!(
-            "reloaded {} from pushed source in {:.2}ms (model preserved{stored})",
+            "reloaded {} from pushed source in {:.2}ms (model preserved{stored}{history})",
             self.path,
             js_sys::Date::now() - started
         );
@@ -603,14 +629,16 @@ impl GameProducer for FunctorLangWebGame {
         let loaded = load_source(files)?;
         self.sources = files.to_vec();
         self.path = files[0].0.clone();
-        let rebound = self.swap_in(loaded);
+        let (rebound, history_replay) = self.swap_in(loaded);
         let stored = if rebound > 0 {
             format!("; {rebound} stored closure(s) rebound")
         } else {
             String::new()
         };
+        let history = replay_status(history_replay);
         let status = format!(
-            "reloaded {} ({} file(s)) from pushed project in {:.2}ms (model preserved{stored})",
+            "reloaded {} ({} file(s)) from pushed project in {:.2}ms \
+(model preserved{stored}{history})",
             self.path,
             files.len(),
             js_sys::Date::now() - started
@@ -685,6 +713,10 @@ impl GameProducer for FunctorLangWebGame {
         self.recorder.generation()
     }
 
+    fn scene_program_revision(&self) -> u64 {
+        self.recorder.program_revision()
+    }
+
     fn current_scene_tts(&self) -> Option<f64> {
         self.recorder.current_scene_frame_tts()
     }
@@ -729,7 +761,8 @@ impl GameProducer for FunctorLangWebGame {
             // coverage replays them lazily at pause time.
             let frame = self.recorder.current_scene_frame().unwrap_or(0);
             self.journal_ring.push_back((frame, journal.clone()));
-            while self.journal_ring.len() > functor_runtime_common::inspector::COVERAGE_RING_FRAMES {
+            while self.journal_ring.len() > functor_runtime_common::inspector::COVERAGE_RING_FRAMES
+            {
                 self.journal_ring.pop_front();
             }
             self.last_frame_journal = journal;

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -139,7 +139,8 @@ fn functor_lang_game_path() -> Option<String> {
 /// alone.
 fn functor_lang_project_files() -> Option<Vec<String>> {
     use wasm_bindgen::JsCast;
-    let value = js_sys::Reflect::get(&window(), &JsValue::from_str("__functorLangProjectFiles")).ok()?;
+    let value =
+        js_sys::Reflect::get(&window(), &JsValue::from_str("__functorLangProjectFiles")).ok()?;
     let array = value.dyn_into::<js_sys::Array>().ok()?;
     let files: Vec<String> = array.iter().filter_map(|v| v.as_string()).collect();
     (!files.is_empty()).then_some(files)
@@ -181,7 +182,9 @@ fn parse_project_files(value: &JsValue) -> Option<Vec<(String, String)>> {
 /// `game.fun` + `pieces.fun` links exactly as it does natively. Failures are
 /// rendered strings (fetch status, parse/load position, contract violation) for
 /// `run_async` to fail loud with.
-async fn create_functor_lang_game(entry: &str) -> Result<functor_lang_game::FunctorLangWebGame, String> {
+async fn create_functor_lang_game(
+    entry: &str,
+) -> Result<functor_lang_game::FunctorLangWebGame, String> {
     // A page that already holds every source in memory (the IDE's
     // `?project=inline` boot) injects them directly — nothing to fetch, and
     // module names come from the given paths exactly as in the fetch path.
@@ -297,11 +300,7 @@ fn apply_pending_reload(game: &mut dyn GameProducer) {
             post_reload_result(true, &status, id);
         }
         Err(message) => {
-            functor_lang_game::publish_timeline_reload(
-                selected_frame,
-                false,
-                &message,
-            );
+            functor_lang_game::publish_timeline_reload(selected_frame, false, &message);
             show_error_overlay(&format!("[functor-lang] reload error: {message}"));
             post_reload_result(false, &message, id);
         }
@@ -910,7 +909,9 @@ fn ws_connect(state: &Rc<RefCell<WsClient>>, key: String, url: String) {
     let ws = match web_sys::WebSocket::new(&url) {
         Ok(ws) => ws,
         Err(_) => {
-            with_live_game(|g| g.net_push_conn_error(key, 0, "failed to open WebSocket".to_string()));
+            with_live_game(|g| {
+                g.net_push_conn_error(key, 0, "failed to open WebSocket".to_string())
+            });
             return;
         }
     };
@@ -989,7 +990,9 @@ async fn run_async() -> Result<(), JsValue> {
     // removed in E3. Async pushes (fetch results, WebSocket events) reach it
     // through the shared `GAME` handle (`perform_and_push` / `with_live_game`).
     let Some(path) = functor_lang_game_path() else {
-        let rendered = "[functor-lang] error: no game entry — window.__functorLangGamePath is not set".to_string();
+        let rendered =
+            "[functor-lang] error: no game entry — window.__functorLangGamePath is not set"
+                .to_string();
         web_sys::console::error_1(&rendered.as_str().into());
         show_error_overlay(&rendered);
         return Err(JsValue::from_str(&rendered));
@@ -1163,22 +1166,22 @@ async fn run_async() -> Result<(), JsValue> {
         // by the DOM preview <select>, with the shared forward window/samples
         // from the ⚙ popover. Same anchor cache as the desktop shell: while
         // paused the anchor (scene frame + tts) is frozen, so reuse the
-        // computed preview; the refresh bound re-projects a pushed source edit
-        // within ~half a second. Live projections remain painted every frame
-        // but refresh on a wall-clock cadence that bounds repeated dry runs.
+        // computed preview; the program revision invalidates immediately on a
+        // pushed source edit. Live projections remain painted every frame but
+        // refresh on a wall-clock cadence that bounds repeated dry runs.
         let mut preview_mode = functor_runtime_common::PreviewMode::Off;
         let mut preview_window: f32 = 2.0;
         let mut preview_rate: usize = 5;
         const PAUSED_PREVIEW_REUSE_FRAMES: u32 = 30;
         const LIVE_PREVIEW_INTERVAL_MS: f32 = 100.0;
         let mut preview_cache: Option<(
-            (Option<u64>, u32, bool, bool, bool, usize, u32),
+            (Option<u64>, u32, bool, u64, bool, bool, usize, u32),
             functor_runtime_common::ScenePreview,
         )> = None;
         let mut preview_refresh: u32 = 0;
         let mut next_live_preview_refresh: f32 = 0.0;
         let mut ghost_cache: Option<(
-            (Option<u64>, u32, bool, usize, u32),
+            (Option<u64>, u32, bool, u64, usize, u32),
             Vec<(Frame, FrameTime)>,
         )> = None;
         let mut ghost_refresh: u32 = 0;
@@ -1345,6 +1348,7 @@ async fn run_async() -> Result<(), JsValue> {
                     game.current_scene_frame(),
                     frame_time.tts.to_bits(),
                     clock.is_paused(),
+                    game.scene_program_revision(),
                     trail_wanted,
                     strobe_wanted,
                     preview_rate,
@@ -1361,6 +1365,7 @@ async fn run_async() -> Result<(), JsValue> {
                             && k.4 == key.4
                             && k.5 == key.5
                             && k.6 == key.6
+                            && k.7 == key.7
                     }
                 });
                 if cache_hit {
@@ -1374,8 +1379,7 @@ async fn run_async() -> Result<(), JsValue> {
                     // so dots stay visible between copies and both hold their
                     // density as the window resizes.
                     const TRAIL_RATE: f32 = 20.0;
-                    let divisions =
-                        ((TRAIL_RATE * preview_window).round() as usize).clamp(1, 64);
+                    let divisions = ((TRAIL_RATE * preview_window).round() as usize).clamp(1, 64);
                     let copies = ((preview_rate as f32 * preview_window).round() as usize)
                         .clamp(1, divisions);
                     let p = functor_runtime_common::scene_preview(
@@ -1391,11 +1395,9 @@ async fn run_async() -> Result<(), JsValue> {
                             eps: 0.04,
                             max_step: 3.0,
                             trail: trail_wanted,
-                            strobe: strobe_wanted.then(|| {
-                                functor_runtime_common::StrobeOptions {
-                                    copies,
-                                    ..Default::default()
-                                }
+                            strobe: strobe_wanted.then(|| functor_runtime_common::StrobeOptions {
+                                copies,
+                                ..Default::default()
                             }),
                         },
                     );
@@ -1450,13 +1452,14 @@ async fn run_async() -> Result<(), JsValue> {
             let ghosts = if selected.ghost {
                 // The ⚙ popover's rate × window, clamped to the compositor's
                 // 8-target cap.
-                let divisions = ((preview_rate as f32 * preview_window).round() as usize)
-                    .clamp(1, 8);
+                let divisions =
+                    ((preview_rate as f32 * preview_window).round() as usize).clamp(1, 8);
                 let dt = preview_window / divisions as f32;
                 let key = (
                     game.current_scene_frame(),
                     frame_time.tts.to_bits(),
                     clock.is_paused(),
+                    game.scene_program_revision(),
                     divisions,
                     preview_window.to_bits(),
                 );
@@ -1469,6 +1472,7 @@ async fn run_async() -> Result<(), JsValue> {
                             && !k.2
                             && k.3 == key.3
                             && k.4 == key.4
+                            && k.5 == key.5
                     }
                 });
                 if cache_hit {
@@ -1582,9 +1586,7 @@ async fn run_async() -> Result<(), JsValue> {
             // Interactions drained pre-tick above. TODO(webview): cache the
             // serialized string in the producer instead of clone+reserialize
             // per frame (perf follow-up).
-            functor_lang_game::publish_webview_html(
-                game.webview().map(|node| node.to_html()),
-            );
+            functor_lang_game::publish_webview_html(game.webview().map(|node| node.to_html()));
 
             // Publish the scrubber state for the DOM slider to poll (the UI
             // itself is native HTML in index-functor-lang.html, outside the canvas).


### PR DESCRIPTION
## Summary

- Recompute the retained input-only model timeline from the edited program `init` after a safe scrubbed hot reload, so old derived state cannot pull extrapolation back to the recorded outcome.
- Retain sparse session-long inputs plus exact frame clocks independently of the bounded model/world rings, removing the silent 900-frame cliff.
- Invalidate paused preview caches on every successful program swap and report reconstruction frame count and elapsed time in reload status/timeline markers.
- Preserve the initial zero-delta settle, removed-handler behavior, paused authoritative input, and atomic old-history fallback on replay errors.

## Behavior

Recorded future inputs remain exact by design. A recorded key-up still occurs at its original frame; Resume is the branch point that discards that future. A separate coast-from-here control is deferred.

A scrubbed safe reload currently replaces the retained old-code snapshots. Persistent fork retention remains the planned comparison mechanism. Long replay is synchronous and O(session frames); reload telemetry now exposes its cost, with chunked/asynchronous replay documented as follow-up work.

## Verification

- `cargo test -p functor_runtime_common` — 352 unit + 6 integration passed; 1 doc test ignored
- `cargo test -p functor-runtime-desktop` — 50 unit plus integration suites passed; GL-only tests ignored
- `cargo check -p functor-runtime-web --target wasm32-unknown-unknown`
- `npm run test:scrubber` — 19 passed
- `wasm-pack build runtime/functor-runtime-web --target=web`
- Chromium: paused Mario, scrubbed historical frame, same-source push returned `history recomputed from init (83 frames, 1.00ms)` with no replay errors
- Regression crosses the old 900-frame model retention boundary
- Same-source replay is byte-identical and covers exact `dts`/`tts`, nonstandard steps, bootstrap, removed handlers, and paused input

## Performance

`frame_bench` allocation counts and bytes/frame are unchanged from base:

| Grid | Base min us/frame | Change min us/frame | Allocs/frame | Bytes/frame |
| --- | ---: | ---: | ---: | ---: |
| 20x20 | 542.5 | 430.3 | 13,877 | 842,251 |
| 40x40 | 2,261.6 | 1,682.1 | 54,717 | 3,306,091 |
| 56x56 | 4,436.3 | 3,264.5 | 106,973 | 6,459,115 |

Wall-clock improvement is treated as run-to-run machine noise; the deterministic allocation metrics show no regression.

## Review disposition

- Fixed: replay failure is atomic and reports instead of partially replacing history.
- Fixed: session inputs are sparse and only the bounded model suffix is retained during replay.
- Fixed: exact clock sequence and the initial zero-delta settle are replayed.
- Fixed: removed input handlers ignore historical raw events like live execution.
- Fixed: buffered paused input remains authoritative at the selected frame.
- Deferred: chunk/yield very long synchronous session replays; telemetry is included to guide the threshold.
- Deferred: optional coast-from-here/replay-cutoff control.

Final Claude xreview: no Critical, High, or Medium findings; approve. Codex review findings above were fixed and covered by regressions.

## Visual verification

![Hot-reload extrapolation loop](https://gist.githubusercontent.com/tommy-xr/6cc959336a3212eb946b7ef754ca8b7c/raw/mario-hot-reload-extrapolation.gif)

<sub>Weak jump recorded under the old constant; after scrubbing and hot-reloading, Functor recomputes the whole strong-jump future, which clears the gap; Resume follows that rebuilt branch.</sub>

![Before, recomputed future, and resumed landing](https://gist.githubusercontent.com/tommy-xr/6cc959336a3212eb946b7ef754ca8b7c/raw/mario-hot-reload-extrapolation-before-after.png)