### PR TITLE
feat(lang): inline `expect` tests + `functor-lang test` verb

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -18,9 +18,10 @@ cargo run -q -p functor-lang -- ir file.fun      # name-resolved core IR (merged
 cargo run -q -p functor-lang -- run file.fun     # evaluate: main()'s result, or the entry's bindings
 cargo run -q -p functor-lang -- trace file.fun   # enter/exit call story with values (kept on failure)
 cargo run -q -p functor-lang -- check file.fun   # typechecker: ALL diagnostics, exit 1
+cargo run -q -p functor-lang -- test file.fun    # run the `expect` tests: per-test ok/FAILED, exit 1
 ```
 
-`ir`/`check`/`run`/`trace` treat the file as a PROJECT ENTRY: every sibling
+`ir`/`check`/`run`/`trace`/`test` treat the file as a PROJECT ENTRY: every sibling
 `.fun` in its directory loads with it (file = module — see Modules below),
 so scratch files must live in their own directory, not a shared one.
 
@@ -256,6 +257,43 @@ open Widget                                              // …or open, bringing
   modules that own several name each (`Scene.t`; `Physics.shape`/`body`/`world`;
   `Ui.view`/`anchor`; `Html.node`/`Attr.t`; `Asset.Model`/`Texture`/`Sound`). Physics query/event results are records
   (`Physics.position`, `Physics.rayHit`, `Physics.collisionEvent`).
+
+## Inline tests (`expect`)
+
+`expect <bool-expr>` is a top-level ITEM — an inline test written next to
+the code it exercises:
+
+```functor
+let area = (s: Shape): float => …
+
+expect area(Point) == 0.0
+expect area(Rect(3.0, 4.0)) == 12.0
+expect (                                      // any expression works — a
+  let m = tick(init, 0.016, 0.016) in         //   let-in chain is the
+  m.score == 0.0                              //   multi-step setup block
+)
+```
+
+- **Unnamed** — the span (`file:line`) is the test's identity. `expect` is
+  contextual (the `open` rule): only item position means a test, so the
+  name stays usable everywhere else. `.funi` files refuse it.
+- The expression must CHECK as `bool` (`check`: "an `expect` test:
+  expected bool, got …").
+- **Inert in the game loop**: `run native`/`run wasm`/`Session::load`
+  never evaluate expects — only `functor-lang test <entry.fun>` does (defs
+  load first, then each expect independently; one failure never stops the
+  rest; exit 1 on any failure). Sibling-module expects load and run with
+  the project.
+- A failed TOP-LEVEL comparison (`==`/`<`/`>`) is decomposed: the report
+  carries both sides' actual values (`left: 12, right: 12.5`).
+- Pipe-then-compare needs parens (pipelines bind loosest):
+  `expect (xs |> List.map(f)) == ys` — without them the `==` folds into
+  the pipe's argument.
+- Floats compare exactly; for computed floats prefer
+  `Math.abs(a - b) < 0.001` over `==`.
+- Under plain `functor-lang test` the engine prelude doesn't exist —
+  expects calling `Scene.*` etc. error at runtime. Test pure logic:
+  model/`tick`/`update` math.
 
 ## Semantics rules that WILL bite you
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,7 +215,7 @@ asset's (future) per-asset config seat; if both declare (`url` + local file), th
 wins with a warning. Auto-reimport watches sidecar mtimes too, and a failed remote fetch
 during auto-reimport keeps the existing manifest (offline must not strip clip constants).
 
-**Verify the language without a GPU:** `cargo run -q -p functor-lang -- run|check|trace|parse|ir <file.fun>`
+**Verify the language without a GPU:** `cargo run -q -p functor-lang -- run|check|trace|test|parse|ir <file.fun>`
 drives the interpreter/typechecker headlessly (the plain-`functor-lang` prelude, no engine host). See the
 `functor-lang` skill.
 

--- a/docs/functor-lang.md
+++ b/docs/functor-lang.md
@@ -490,6 +490,21 @@ snapshots — no GPU, fully agent-verifiable.
       implementation satisfies its interface; consumers typecheck against
       the `.funi` alone. The LLM payoff is the point: an interface file is
       the concise, load-into-context summary of a module.
+- [x] **Language: inline `expect` tests** (done 2026-07-19; design note in
+      `~/notes` `inline-expect-tests.md` — the live red/green editor arc
+      builds on this). `expect <bool-expr>` is a top-level item (contextual
+      keyword, the `open` rule) lowered OUTSIDE defs, so `Session::load` /
+      `run` never evaluate it — the game loop is untouched. The checker
+      requires bool ("an `expect` test: expected bool, got …");
+      `functor_lang::run_expects` loads defs then evaluates each expect
+      independently, decomposing a top-level comparison so a failure
+      reports both sides' actual values; `functor-lang test <entry.fun>`
+      renders per-test `file:line: ok/FAILED` lines + a summary, exit 1 on
+      any failure. Expects in sibling modules load and run with the
+      project; `.funi` files refuse them. *Verify (done):* 15 tests
+      (contextual-name pin, `.funi` rejection, check errors, comparison
+      decomposition, per-test independence, run/Session inertness,
+      multi-file); `.ir` goldens regenerated (the new `expects` field).
 
 ## Track C — Functor Lang as a second producer behind the seam
 

--- a/functor-lang/examples/functions.ir
+++ b/functor-lang/examples/functions.ir
@@ -576,4 +576,5 @@ Module {
         },
     ],
     signatures: [],
+    expects: [],
 }

--- a/functor-lang/examples/lists.ir
+++ b/functor-lang/examples/lists.ir
@@ -576,4 +576,5 @@ Module {
         },
     ],
     signatures: [],
+    expects: [],
 }

--- a/functor-lang/examples/pure_pipeline.ir
+++ b/functor-lang/examples/pure_pipeline.ir
@@ -359,4 +359,5 @@ Module {
         },
     ],
     signatures: [],
+    expects: [],
 }

--- a/functor-lang/examples/records.ir
+++ b/functor-lang/examples/records.ir
@@ -743,4 +743,5 @@ Module {
         },
     ],
     signatures: [],
+    expects: [],
 }

--- a/functor-lang/examples/shapes.ir
+++ b/functor-lang/examples/shapes.ir
@@ -845,4 +845,5 @@ Module {
         },
     ],
     signatures: [],
+    expects: [],
 }

--- a/functor-lang/examples/strings.ir
+++ b/functor-lang/examples/strings.ir
@@ -749,4 +749,5 @@ Module {
         },
     ],
     signatures: [],
+    expects: [],
 }

--- a/functor-lang/examples/tuples.ir
+++ b/functor-lang/examples/tuples.ir
@@ -808,4 +808,5 @@ Module {
         },
     ],
     signatures: [],
+    expects: [],
 }

--- a/functor-lang/src/ast.rs
+++ b/functor-lang/src/ast.rs
@@ -21,6 +21,18 @@ pub enum Item {
     /// (`.funi`): the type of a value the host implements (a module is either a
     /// `.fun` or a `.funi`, never both, so there is no paired implementation).
     Sig(SigDecl),
+    Expect(ExpectDecl),
+}
+
+/// `expect <expr>` — an inline test: a bool expression evaluated by test
+/// tooling (`functor-lang test`, the editor), NEVER by the game loop. Like
+/// `open`, `expect` is a *contextual* keyword: it only means this at the top
+/// level, so the name stays usable everywhere else. Tests are unnamed — the
+/// span (file:line) is their identity.
+#[derive(Debug)]
+pub struct ExpectDecl {
+    pub expr: Expr,
+    pub span: Span,
 }
 
 /// `let name : Type` in a `.funi` — a value signature with no body.

--- a/functor-lang/src/eval.rs
+++ b/functor-lang/src/eval.rs
@@ -30,7 +30,7 @@
 //! marker event) after [`MAX_TRACE_EVENTS`] so a hot loop can't produce an
 //! unbounded transcript; evaluation itself continues.
 
-use crate::ir::{BindingId, Def, Expr, ExprKind, Module, Pattern, PatternKind};
+use crate::ir::{BindingId, Def, ExpectDef, Expr, ExprKind, Module, Pattern, PatternKind};
 use crate::span::Span;
 use crate::value::{Closure, Env, Value};
 use crate::RunError;
@@ -380,6 +380,74 @@ pub fn run_with_host(
     }
 }
 
+/// The result of one `expect` test (see [`run_expects`]). The span is the
+/// test's identity — there are no names; render `file:line` via the project
+/// source map.
+#[derive(Debug)]
+pub struct ExpectReport {
+    pub span: Span,
+    pub outcome: ExpectOutcome,
+}
+
+#[derive(Debug)]
+pub enum ExpectOutcome {
+    Pass,
+    /// Evaluated to `false`. When the expression's top level is a comparison,
+    /// both sides' rendered values are carried for the report.
+    Fail(Option<FailedCompare>),
+    /// Evaluation failed (a spanned runtime error), or the expression did not
+    /// produce a bool (unchecked code — `check` catches this statically).
+    Error(RunError),
+}
+
+/// The sides of a failed top-level comparison: `expect a == b` reports what
+/// `a` and `b` actually were (rendered with [`Value`]'s deterministic
+/// `Display`).
+#[derive(Debug)]
+pub struct FailedCompare {
+    pub op: &'static str,
+    pub lhs: String,
+    pub rhs: String,
+}
+
+/// Evaluate a module's `expect` tests: top-level defs load first (exactly as
+/// [`Session::load`] — initializers run, `main` is not called), then each
+/// expect evaluates independently over the loaded globals. A def-load failure
+/// is the returned `Err`; a failing or erroring expect is its own report and
+/// never stops the remaining tests. (One `Interp` is shared across expects —
+/// independence holds because `depth`/`call_depth` unwind on error, globals
+/// are read-only after the load, and `mut_slots` entries are keyed by
+/// per-expect-unique `BindingId`s, so a leaked slot is unreachable.)
+pub fn run_expects(
+    module: &Module,
+    host: &mut dyn Host,
+) -> Result<Vec<ExpectReport>, RunFailure> {
+    let mut interp = Interp {
+        globals: HashMap::new(),
+        mut_slots: HashMap::new(),
+        trace: Vec::new(),
+        tracing: Tracing::Off,
+        recorder: None,
+        depth: 0,
+        call_depth: 0,
+        host,
+    };
+    if let Err(error) = interp.eval_defs(module) {
+        return Err(RunFailure {
+            error,
+            trace: interp.trace,
+        });
+    }
+    Ok(module
+        .expects
+        .iter()
+        .map(|expect| ExpectReport {
+            span: expect.span,
+            outcome: interp.eval_expect(expect),
+        })
+        .collect())
+}
+
 /// A persistent interpreter session for embedding (the C2 producer): load a
 /// module once, then call top-level functions per frame. Globals are
 /// evaluated at load; each `call` runs with a fresh interpreter over the
@@ -569,6 +637,55 @@ impl Interp<'_> {
             bindings.push((def.name.clone(), value));
         }
         Ok(bindings)
+    }
+
+    /// Evaluate one `expect`. A top-level comparison is decomposed — the two
+    /// sides evaluate separately — so a failure reports both actual values.
+    fn eval_expect(&mut self, expect: &ExpectDef) -> ExpectOutcome {
+        use crate::ast::BinOp;
+        let env = Env::empty();
+        if let ExprKind::Binary {
+            op: op @ (BinOp::Eq | BinOp::Lt | BinOp::Gt),
+            lhs,
+            rhs,
+        } = &expect.expr.kind
+        {
+            let l = match self.eval(lhs, &env) {
+                Ok(v) => v,
+                Err(e) => return ExpectOutcome::Error(e),
+            };
+            let r = match self.eval(rhs, &env) {
+                Ok(v) => v,
+                Err(e) => return ExpectOutcome::Error(e),
+            };
+            return match self.binary_op(*op, l.clone(), r.clone(), expect.expr.span) {
+                Ok(Value::Bool(true)) => ExpectOutcome::Pass,
+                // Comparisons only produce bools, so anything else is false.
+                Ok(_) => ExpectOutcome::Fail(Some(FailedCompare {
+                    op: match op {
+                        BinOp::Eq => "==",
+                        BinOp::Lt => "<",
+                        _ => ">",
+                    },
+                    lhs: l.to_string(),
+                    rhs: r.to_string(),
+                })),
+                // e.g. `==` on functions — a runtime error, not a plain fail.
+                Err(e) => ExpectOutcome::Error(e),
+            };
+        }
+        match self.eval(&expect.expr, &env) {
+            Ok(Value::Bool(true)) => ExpectOutcome::Pass,
+            Ok(Value::Bool(false)) => ExpectOutcome::Fail(None),
+            Ok(other) => ExpectOutcome::Error(RunError {
+                message: format!(
+                    "an `expect` must evaluate to a bool, got {other} — write a comparison \
+(`expect actual == expected`)"
+                ),
+                span: expect.expr.span,
+            }),
+            Err(e) => ExpectOutcome::Error(e),
+        }
     }
 
     fn run_module(&mut self, module: &Module) -> Result<RunOutcome, RunError> {

--- a/functor-lang/src/ir.rs
+++ b/functor-lang/src/ir.rs
@@ -74,6 +74,22 @@ pub struct Module {
     /// externals; they have no body, so evaluation never sees them (the host
     /// provides the value at runtime — there is no paired `.fun`).
     pub signatures: Vec<Signature>,
+    /// `expect <expr>` inline tests, in file order. Deliberately OUTSIDE
+    /// `defs`: loading a session ([`crate::eval::Session::load`]) never
+    /// evaluates them — only test tooling does
+    /// ([`crate::eval::run_expects`]).
+    pub expects: Vec<ExpectDef>,
+}
+
+/// One lowered `expect <expr>` test. `module` is the owning module's
+/// canonical prefix (`"Utils"`; empty for the entry) — the checker scopes
+/// bare record literals by it, like a def's name prefix. Unnamed: the span
+/// is the test's identity.
+#[derive(Debug)]
+pub struct ExpectDef {
+    pub module: String,
+    pub expr: Expr,
+    pub span: Span,
 }
 
 /// One `.funi` value signature: a canonical name (`Scene.cube`) and its

--- a/functor-lang/src/lib.rs
+++ b/functor-lang/src/lib.rs
@@ -31,8 +31,9 @@ pub mod types;
 pub mod value;
 
 pub use eval::{
-    render_trace, run, run_with_host, Host, NoHost, RecordedBinding, RecordedInvocation,
-    RecordedKind, RecordedSite, RunFailure, RunOutcome, RunRecord, Session, Tracing,
+    render_trace, run, run_expects, run_with_host, ExpectOutcome, ExpectReport, FailedCompare,
+    Host, NoHost, RecordedBinding, RecordedInvocation, RecordedKind, RecordedSite, RunFailure,
+    RunOutcome, RunRecord, Session, Tracing,
 };
 pub use lower::lower;
 pub use parser::{parse, parse_interface};

--- a/functor-lang/src/lower.rs
+++ b/functor-lang/src/lower.rs
@@ -132,6 +132,8 @@ pub(crate) fn exports_of(program: &ast::Program) -> Exports {
                 exports.signatures.insert(decl.name.clone());
             }
             ast::Item::Open(_) => {}
+            // An expect binds nothing.
+            ast::Item::Expect(_) => {}
         }
     }
     exports
@@ -182,6 +184,8 @@ fn lower_module(
     for item in &program.items {
         match item {
             ast::Item::Open(_) => {}
+            // An expect declares no names.
+            ast::Item::Expect(_) => {}
             // A signature shares the value namespace with `let`s for DUPLICATE
             // DETECTION only — it is never lowered to a `Global` (references
             // stay `External`; `.funi` files have no value expressions, so
@@ -376,6 +380,7 @@ qualify uses (`{prev}.{name}` / `{}.{name}`)",
     let mut types = Vec::new();
     let mut defs = Vec::new();
     let mut signatures = Vec::new();
+    let mut expects = Vec::new();
     for item in program.items {
         match item {
             // Opens were consumed in pass 1b; they leave no IR (and no
@@ -413,6 +418,19 @@ qualify uses (`{prev}.{name}` / `{}.{name}`)",
                     span: decl.span,
                 });
             }
+            // An expect: no name, no DefId — its expression lowers like a
+            // def body (globals resolve canonically), kept in its own list
+            // so session loading never evaluates it.
+            ast::Item::Expect(decl) => {
+                expects.push(ExpectDef {
+                    module: match lowerer.project {
+                        Some(env) if env.name != env.entry => env.name.to_string(),
+                        _ => String::new(),
+                    },
+                    expr: lowerer.expr(decl.expr)?,
+                    span: decl.span,
+                });
+            }
         }
     }
     let bases = IdBases {
@@ -425,6 +443,7 @@ qualify uses (`{prev}.{name}` / `{}.{name}`)",
             types,
             defs,
             signatures,
+            expects,
         },
         bases,
         lowerer.deps,

--- a/functor-lang/src/main.rs
+++ b/functor-lang/src/main.rs
@@ -6,10 +6,11 @@
 //! functor-lang check <file.fun>   # typecheck the project; all diagnostics, exit 1
 //! functor-lang run <file.fun>     # evaluate; print main's result, or the entry's bindings
 //! functor-lang trace <file.fun>   # evaluate with the call trace; print the trace
+//! functor-lang test <file.fun>    # evaluate the project's `expect` tests; exit 1 on failure
 //! functor-lang bench [--all] [--json] [<file.fun>|<dir>]  # time interpreter eval (see bench.rs)
 //! ```
 //!
-//! `ir`/`check`/`run`/`trace` treat the file as a project entry (B8): every
+//! `ir`/`check`/`run`/`trace`/`test` treat the file as a project entry (B8): every
 //! sibling `.fun` file in its directory loads with it — file = module,
 //! whole-program checking. `parse` stays single-file (it shows one file's
 //! surface syntax).
@@ -31,12 +32,14 @@ fn main() {
         bench::main(&args[1..]);
     }
     let (command, path) = match args.as_slice() {
-        [command, path] if ["parse", "ir", "check", "run", "trace"].contains(&command.as_str()) => {
+        [command, path]
+            if ["parse", "ir", "check", "run", "trace", "test"].contains(&command.as_str()) =>
+        {
             (command.as_str(), path)
         }
         _ => {
             eprintln!(
-                "usage: functor-lang <parse|ir|check|run|trace> <file.fun>\n       functor-lang bench [--all] [--json] [<file.fun>|<dir>]"
+                "usage: functor-lang <parse|ir|check|run|trace|test> <file.fun>\n       functor-lang bench [--all] [--json] [<file.fun>|<dir>]"
             );
             exit(2);
         }
@@ -89,6 +92,59 @@ fn main() {
             );
         }
         if !diags.is_empty() {
+            exit(1);
+        }
+        return;
+    }
+    if command == "test" {
+        // Like `run`, `test` does not typecheck first — `check` is the
+        // static gate; here a non-bool expect reports as its own error.
+        let reports = match functor_lang::run_expects(&project.module, &mut functor_lang::NoHost) {
+            Ok(reports) => reports,
+            Err(failure) => {
+                let (file, line, col) = project.sources.resolve(failure.error.span.start);
+                eprintln!(
+                    "{}:{line}:{col}: error: {}",
+                    file.path.display(),
+                    failure.error.message
+                );
+                exit(1);
+            }
+        };
+        if reports.is_empty() {
+            println!("no `expect` tests found");
+            return;
+        }
+        let mut failed = 0usize;
+        for report in &reports {
+            let (file, line, _col) = project.sources.resolve(report.span.start);
+            let at = format!("{}:{line}", file.path.display());
+            match &report.outcome {
+                functor_lang::ExpectOutcome::Pass => println!("{at}: ok"),
+                functor_lang::ExpectOutcome::Fail(detail) => {
+                    failed += 1;
+                    match detail {
+                        Some(cmp) => println!(
+                            "{at}: FAILED: left {} right — left: {}, right: {}",
+                            cmp.op, cmp.lhs, cmp.rhs
+                        ),
+                        None => println!("{at}: FAILED: expected true, got false"),
+                    }
+                }
+                functor_lang::ExpectOutcome::Error(error) => {
+                    failed += 1;
+                    let (efile, eline, ecol) = project.sources.resolve(error.span.start);
+                    println!(
+                        "{at}: ERROR: {}:{eline}:{ecol}: {}",
+                        efile.path.display(),
+                        error.message
+                    );
+                }
+            }
+        }
+        let passed = reports.len() - failed;
+        println!("{} expects: {passed} passed, {failed} failed", reports.len());
+        if failed > 0 {
             exit(1);
         }
         return;

--- a/functor-lang/src/parser.rs
+++ b/functor-lang/src/parser.rs
@@ -167,7 +167,11 @@ impl Parser {
                 TokenKind::Ident(name) if name == "open" => {
                     items.push(Item::Open(self.open_decl()?))
                 }
-                _ => return self.error("`let`, `type`, or `open` at top level"),
+                // `expect` is contextual the same way.
+                TokenKind::Ident(name) if name == "expect" => {
+                    items.push(Item::Expect(self.expect_decl()?))
+                }
+                _ => return self.error("`let`, `type`, `open`, or `expect` at top level"),
             }
         }
         Ok(Program { items })
@@ -191,6 +195,23 @@ impl Parser {
             module,
             span: kw.span.to(module_span),
         })
+    }
+
+    /// `expect <expr>` — an inline test. The expression is full-width (a
+    /// `let … in` chain works as a setup block), checked as `bool`.
+    fn expect_decl(&mut self) -> Result<ExpectDecl, ParseError> {
+        let kw = self.bump();
+        if self.interface {
+            return Err(ParseError {
+                message: "interface files (.funi) declare signatures — `expect` tests belong \
+in a `.fun` file"
+                    .to_string(),
+                span: kw.span,
+            });
+        }
+        let expr = self.expr()?;
+        let span = kw.span.to(expr.span);
+        Ok(ExpectDecl { expr, span })
     }
 
     /// An optional `: Type` binding annotation between a `let` binder name and

--- a/functor-lang/src/project.rs
+++ b/functor-lang/src/project.rs
@@ -637,6 +637,7 @@ allowed (within one file, definitions may still be mutually recursive)",
         types: Vec::new(),
         defs: Vec::new(),
         signatures: Vec::new(),
+        expects: Vec::new(),
     };
     let mut by_module: HashMap<String, Module> = files
         .iter()
@@ -648,6 +649,7 @@ allowed (within one file, definitions may still be mutually recursive)",
         merged.types.extend(module.types);
         merged.defs.extend(module.defs);
         merged.signatures.extend(module.signatures);
+        merged.expects.extend(module.expects);
     }
 
     Ok(Project {

--- a/functor-lang/src/types.rs
+++ b/functor-lang/src/types.rs
@@ -719,6 +719,15 @@ fn check_impl(
         }
     }
 
+    // `expect` tests: each must be a bool. Checked after every def has
+    // generalized, so an expect instantiates the same schemes a later def
+    // would (`expect id(1.0) == 1.0` beside `id` used at string elsewhere).
+    for exp in &module.expects {
+        checker.annot_vars.clear();
+        checker.current_module = exp.module.clone();
+        checker.expect(&exp.expr, &Type::Bool, "an `expect` test");
+    }
+
     checker.diags.sort_by_key(|d| d.span.start);
     // ONE display order for the whole table: the same variable must hover
     // as the same 'a everywhere (per-entry renumbering showed `q : 'a`

--- a/functor-lang/tests/expects.rs
+++ b/functor-lang/tests/expects.rs
@@ -1,0 +1,186 @@
+//! `expect` inline tests: parsing (contextual keyword), checking (must be
+//! bool), evaluation (`run_expects` — pass / decomposed comparison failure /
+//! runtime error, independence between expects), and the load-inertness
+//! guarantee (`run` / `Session::load` never evaluate them).
+
+use functor_lang::{ExpectOutcome, NoHost, Tracing};
+
+fn lower(src: &str) -> functor_lang::ir::Module {
+    let program = functor_lang::parse(src).expect("source should parse");
+    functor_lang::lower(program).expect("source should lower")
+}
+
+fn reports(src: &str) -> Vec<functor_lang::ExpectReport> {
+    functor_lang::run_expects(&lower(src), &mut NoHost)
+        .unwrap_or_else(|failure| panic!("defs should load: {}", failure.error.message))
+}
+
+// ---------------------------------------------------------------- parsing
+
+#[test]
+fn expect_parses_at_top_level() {
+    let module = lower("let x = 2.0\nexpect x == 2.0\n");
+    assert_eq!(module.expects.len(), 1);
+    assert_eq!(module.defs.len(), 1);
+}
+
+#[test]
+fn expect_stays_a_usable_name() {
+    // Contextual keyword: binding and using `expect` as an ordinary name
+    // still parses (the `open` rule).
+    let module = lower("let expect = 2.0\nlet f = (expect) => expect + 1.0\n");
+    assert_eq!(module.defs.len(), 2);
+    assert!(module.expects.is_empty());
+}
+
+#[test]
+fn expect_is_rejected_in_interface_files() {
+    let err = functor_lang::parse_interface("expect 1.0 == 1.0\n")
+        .expect_err("interface expect should be rejected");
+    assert!(
+        err.message.contains("`expect` tests belong"),
+        "unexpected message: {}",
+        err.message
+    );
+}
+
+#[test]
+fn expect_body_may_be_a_let_in_block() {
+    let ok = reports("let double = (x) => x * 2.0\nexpect (\n  let y = double(3.0) in\n  y == 6.0\n)\n");
+    assert!(matches!(ok[0].outcome, ExpectOutcome::Pass));
+}
+
+// --------------------------------------------------------------- checking
+
+#[test]
+fn non_bool_expect_is_a_check_error() {
+    let module = lower("expect 1.0 + 1.0\n");
+    let diags = functor_lang::check(&module);
+    assert_eq!(diags.len(), 1);
+    assert!(
+        diags[0]
+            .message
+            .contains("an `expect` test: expected bool, got float"),
+        "unexpected message: {}",
+        diags[0].message
+    );
+}
+
+#[test]
+fn bool_expect_checks_clean() {
+    let module = lower("let x = 1.0\nexpect x > 0.0\nexpect x == 1.0\n");
+    assert!(functor_lang::check(&module).is_empty());
+}
+
+// ------------------------------------------------------------- evaluation
+
+#[test]
+fn passing_and_failing_expects_report_independently() {
+    let out = reports("let x = 2.0\nexpect x == 2.0\nexpect x == 3.0\nexpect x > 1.0\n");
+    assert_eq!(out.len(), 3);
+    assert!(matches!(out[0].outcome, ExpectOutcome::Pass));
+    assert!(matches!(out[1].outcome, ExpectOutcome::Fail(Some(_))));
+    assert!(matches!(out[2].outcome, ExpectOutcome::Pass));
+}
+
+#[test]
+fn failed_comparison_decomposes_both_sides() {
+    let out = reports("let area = (w, h) => w * h\nexpect area(3.0, 4.0) == 12.5\n");
+    let ExpectOutcome::Fail(Some(cmp)) = &out[0].outcome else {
+        panic!("expected a decomposed failure, got {:?}", out[0].outcome);
+    };
+    assert_eq!(cmp.op, "==");
+    assert_eq!(cmp.lhs, "12");
+    assert_eq!(cmp.rhs, "12.5");
+}
+
+#[test]
+fn failed_bare_bool_has_no_decomposition() {
+    let out = reports("expect false\n");
+    assert!(matches!(out[0].outcome, ExpectOutcome::Fail(None)));
+}
+
+#[test]
+fn structural_equality_covers_composite_values() {
+    let out = reports(
+        "let double = (x) => x * 2.0\nexpect ([1.0, 2.0] |> List.map(double)) == [2.0, 4.0]\n",
+    );
+    assert!(matches!(out[0].outcome, ExpectOutcome::Pass));
+}
+
+#[test]
+fn erroring_expect_reports_and_the_rest_still_run() {
+    // Comparing functions is a runtime error (the one structural-== error).
+    let out = reports("let f = (x) => x\nexpect f == f\nexpect 1.0 == 1.0\n");
+    assert!(matches!(out[0].outcome, ExpectOutcome::Error(_)));
+    assert!(matches!(out[1].outcome, ExpectOutcome::Pass));
+}
+
+#[test]
+fn non_bool_expect_is_a_runtime_error_when_unchecked() {
+    let out = reports("expect 1.0 + 1.0\n");
+    let ExpectOutcome::Error(err) = &out[0].outcome else {
+        panic!("expected an error outcome, got {:?}", out[0].outcome);
+    };
+    assert!(
+        err.message.contains("must evaluate to a bool"),
+        "unexpected message: {}",
+        err.message
+    );
+}
+
+// -------------------------------------------------------------- multi-file
+
+#[test]
+fn sibling_module_expects_run_with_the_project() {
+    let dir = std::env::temp_dir().join(format!(
+        "functor-lang-expects-test-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("create scratch dir");
+    std::fs::write(
+        dir.join("game.fun"),
+        "let scale = 2.0\nexpect Utils.area(3.0, 4.0) * scale == 24.0\n",
+    )
+    .expect("write entry");
+    std::fs::write(
+        dir.join("utils.fun"),
+        "let area = (w, h) => w * h\nexpect area(2.0, 2.0) == 4.0\n",
+    )
+    .expect("write sibling");
+    let project = functor_lang::project::load(&dir.join("game.fun"))
+        .unwrap_or_else(|err| panic!("project loads: {}", err.message));
+    assert!(project.check().is_empty(), "project should check clean");
+    let out = functor_lang::run_expects(&project.module, &mut NoHost)
+        .unwrap_or_else(|failure| panic!("defs should load: {}", failure.error.message));
+    assert_eq!(out.len(), 2);
+    assert!(out.iter().all(|r| matches!(r.outcome, ExpectOutcome::Pass)));
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+// ---------------------------------------------------- inert in the game loop
+
+#[test]
+fn run_never_evaluates_expects() {
+    // The expect would error at runtime (no arm matches 1); `run` must not
+    // notice — expects are test-tooling-only.
+    let src = "type Shape = | Circle(radius: float)\n\
+               let area = (s: Shape) => match s with | Circle(r) => r\n\
+               expect area(1.0) == 1.0\n\
+               let main = () => 42.0\n";
+    let record = functor_lang::run(&lower(src), Tracing::Off)
+        .unwrap_or_else(|failure| panic!("run should ignore expects: {}", failure.error.message));
+    match record.outcome {
+        functor_lang::RunOutcome::Main(value) => assert_eq!(value.to_string(), "42"),
+        functor_lang::RunOutcome::Bindings(_) => panic!("expected a main outcome"),
+    }
+}
+
+#[test]
+fn session_load_never_evaluates_expects() {
+    let src = "let x = 1.0\nexpect x == 2.0\n";
+    let session = functor_lang::Session::load(&lower(src), &mut NoHost)
+        .unwrap_or_else(|failure| panic!("load should ignore expects: {}", failure.error.message));
+    assert!(session.global("x").is_some());
+}


### PR DESCRIPTION
## What

`expect <bool-expr>` is a new top-level item — an inline test written next to the code it exercises:

```functor
let area = (s: Shape): float => …

expect area(Point) == 0.0
expect area(Rect(3.0, 4.0)) == 12.0
expect (                                  // any expression works — a let-in
  let m = tick(init, 0.016, 0.016) in     // chain is the multi-step setup block
  m.score == 0.0
)
```

- **Contextual keyword** (the `open` rule): only item position means a test, so `expect` stays usable as a name — no breakage. `.funi` files refuse it with a teaching error.
- **Unnamed**: the span (`file:line`) is the test's identity.
- **Checked as bool**: `check` reports \"an `expect` test: expected bool, got …\" (the LSP shows this in-editor for free — diagnostics route through the same project load).
- **Inert in the game loop**: expects lower OUTSIDE `Module.defs`, so `Session::load` / `run` / both producers never evaluate them. Only test tooling does.
- **`functor-lang test <entry.fun>`**: loads defs (like `Session::load`), then evaluates each expect independently — one failure never stops the rest. A failed top-level comparison (`==`/`<`/`>`) is **decomposed**: `FAILED: left == right — left: 12, right: 12.5`. Exit 1 on any failure.
- Sibling-module expects load and run with the project (file = module).

First arc of the inline-tests initiative — next arcs (separate PRs): an interpreter fuel budget, then live red/green/re-running status in the VSCode LSP and the web IDE via LSP-local / wasm-local `run_expects`.

## Verification

- 15 new tests in `functor-lang/tests/expects.rs`: contextual-name pin, `.funi` rejection, check errors, comparison decomposition, per-expect independence after an error, `run`/`Session::load` inertness, multi-file project expects.
- All existing suites green: `cargo test -p functor-lang` (504 tests, 11 suites), `-p functor_runtime_common` (359), `-p functor-lang-lsp` (36+). `.ir` goldens regenerated (the new `expects` field). `cargo check` clean on desktop/CLI/LSP natively and `functor-runtime-web` on wasm32; strict-feature build green.
- No per-frame hot path touched: `eval()`/`eval_inner()`/`call()` are unchanged — the new code only runs under `functor-lang test` (no frame_bench delta possible; `Module` gains one load-time field).

## Review

`/xreview` (Claude reviewer; Codex unavailable — usage limit): **no Critical/High findings**. Confirmed safe: depth/call_depth unwinding between expects, tooling walkers (rebind, codelens, hover — expects' spans are typed, so hover works inside them), all `Module` construction sites, wasm single-source path. Low notes dispositioned: (1) `test` deliberately doesn't typecheck first — `check` is the static gate, mirroring `run`; documented in the skill. (2) zero expects exits 0 — intended. (3) shared-`Interp` independence reasoning now documented on `run_expects`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)