### PR TITLE
fix(oculus): Quest device bring-up — activity context, ANR input drain, Horizon manifest

### DIFF
--- a/runtime/functor-runtime-oculus/Cargo.toml
+++ b/runtime/functor-runtime-oculus/Cargo.toml
@@ -27,6 +27,8 @@ openxr = "0.21"
 # Modern replacement for the deprecated ndk-glue: provides android_main and
 # feeds ndk-context, which openxr's initialize_android_loader() reads.
 android-activity = { version = "0.6", features = ["native-activity"] }
+# For the ndk_context activity swap in android_main (see the comment there).
+ndk-context = "0.1"
 khronos-egl = { version = "6.0", features = ["dynamic"] }
 libloading = "0.8"
 glow = "0.17"
@@ -50,6 +52,31 @@ target_sdk_version = 32
 name = "android.hardware.vr.headtracking"
 required = true
 version = 1
+
+# Optional hand tracking: bypasses Horizon's "controllers required" launch
+# interceptor, so the tool APK launches with controllers asleep (headless /
+# automated runs included). Real hand input is later roadmap work.
+[[package.metadata.android.uses_feature]]
+name = "oculus.software.handtracking"
+required = false
+
+[[package.metadata.android.uses_permission]]
+name = "com.oculus.permission.HAND_TRACKING"
+
+# Without supportedDevices, Horizon OS treats the APK as an original-Quest
+# compat app (`VrRuntimeCompatHelper: DevicesSupported : 1 devices, quest`).
+[[package.metadata.android.application.meta_data]]
+name = "com.oculus.supportedDevices"
+value = "quest2|questpro|quest3"
+
+# Immersive VR activity: single instance, landscape, no decor — matches
+# Meta's native samples (and the working shock2quest manifest).
+[package.metadata.android.application.activity]
+theme = "@android:style/Theme.Black.NoTitleBar.Fullscreen"
+config_changes = "density|keyboard|keyboardHidden|navigation|orientation|screenLayout|screenSize|uiMode"
+launch_mode = "singleTask"
+orientation = "landscape"
+resizeable_activity = false
 
 [[package.metadata.android.application.activity.intent_filter]]
 actions = ["android.intent.action.MAIN"]

--- a/runtime/functor-runtime-oculus/README.md
+++ b/runtime/functor-runtime-oculus/README.md
@@ -8,10 +8,25 @@ over the network (the `POST /reload-source` remote-develop loop).
 
 ## Status
 
-Phase 1: the OpenXR shell cross-compiles (instance/session/swapchains/frame
-loop, per-eye rendering with head-pose cameras, placeholder scene). Device
-bring-up (Functor Lang producer, network reload, controller input, asymmetric-frustum
-projection) happens against real hardware.
+Phase 1 **verified on hardware** (Quest 3, Horizon OS v205): the OpenXR shell
+reaches session FOCUSED and renders the placeholder scene in stereo through
+the shared `render_frame` path. Remaining device bring-up: the Functor Lang producer,
+network reload, controller input, asymmetric-frustum projection.
+
+## Headless iteration (no one wearing the headset)
+
+The device only promotes a session past IDLE when it believes it's worn, and
+blocks launches when controllers are asleep — both bypassable for automated
+runs (the manifest's optional `oculus.software.handtracking` handles the
+controller gate):
+
+```sh
+adb shell am broadcast -a com.oculus.vrpowermanager.prox_close   # fake "worn"
+adb shell am start -n dev.functor.runner/android.app.NativeActivity
+adb logcat -s functor    # expect IDLE → READY → SYNCHRONIZED → VISIBLE → FOCUSED
+adb exec-out screencap -p > /tmp/quest.png   # both rendered eyes, via compositor
+# undo: adb shell am broadcast -a com.oculus.vrpowermanager.automation_disable
+```
 
 ## Prerequisites
 
@@ -43,12 +58,21 @@ npm run build:oculus:apk   # → target-android/debug/apk/functor_runtime_oculus
 cargo apk run              # builds + adb installs + launches on the headset
 ```
 
-**One manual artifact:** OpenXR on Quest needs **Meta's loader**. Download the
+**One manual artifact:** the APK must bundle an OpenXR loader as
+`lib/arm64-v8a/libopenxr_loader.so` (gitignored; `runtime_libs = "lib"`
+bundles it). Without it the app aborts at startup with a clear message.
+The easy path is the **standard Khronos loader** — Meta endorses it on
+Horizon OS, it needs no developer login, and it's verified working on a
+Quest 3 (OS v205):
+
+```sh
+curl -sO https://repo1.maven.org/maven2/org/khronos/openxr/openxr_loader_for_android/1.1.61/openxr_loader_for_android-1.1.61.aar
+unzip -j openxr_loader_for_android-1.1.61.aar 'jni/arm64-v8a/libopenxr_loader.so' -d lib/arm64-v8a/
+```
+
+(Meta's own loader from the
 [Meta OpenXR Mobile SDK](https://developer.oculus.com/downloads/package/oculus-openxr-mobile-sdk/)
-and copy `OpenXR/Libs/Android/arm64-v8a/Release/libopenxr_loader.so` to
-`lib/arm64-v8a/` in this directory (gitignored; `runtime_libs = "lib"` bundles
-it into the APK). Without it the app aborts at startup with a clear message.
-Do not substitute the Khronos loader — Meta's is the supported path.
+works identically if you have one on hand.)
 
 ## Architecture notes
 

--- a/runtime/functor-runtime-oculus/src/lib.rs
+++ b/runtime/functor-runtime-oculus/src/lib.rs
@@ -27,7 +27,7 @@
 
 use std::sync::Arc;
 
-use android_activity::{AndroidApp, MainEvent, PollEvent};
+use android_activity::{AndroidApp, InputStatus, MainEvent, PollEvent};
 use cgmath::{Quaternion, Rotation, Vector3};
 use functor_runtime_common::asset::AssetCache;
 use functor_runtime_common::{Camera, Frame, FrameTime, SceneContext, Viewport};
@@ -277,6 +277,30 @@ pub fn android_main(app: AndroidApp) {
     );
     log::info!("functor oculus runtime starting");
 
+    // Meta's runtime refuses to bind a session to an activity that isn't
+    // resumed with a window ("xrCreateSession: Activity is not yet in the
+    // ready state") — the session then parks in IDLE forever and Horizon's
+    // loading interstitial times out. Pump the Android event loop until the
+    // activity is ready before touching EGL/OpenXR.
+    let mut resumed = false;
+    let mut destroyed = false;
+    while !destroyed && !(resumed && app.native_window().is_some()) {
+        app.poll_events(Some(std::time::Duration::from_millis(16)), |event| {
+            if let PollEvent::Main(main) = event {
+                match main {
+                    MainEvent::Resume { .. } => resumed = true,
+                    MainEvent::Pause => resumed = false,
+                    MainEvent::Destroy => destroyed = true,
+                    _ => {}
+                }
+            }
+        });
+    }
+    if destroyed {
+        return;
+    }
+    log::info!("activity resumed with window; initializing EGL + OpenXR");
+
     let egl_ctx = init_egl();
     let gl = unsafe {
         glow::Context::from_loader_function(|s| {
@@ -289,10 +313,23 @@ pub fn android_main(app: AndroidApp) {
     };
     let gl = Arc::new(gl);
 
-    // OpenXR: Meta's libopenxr_loader.so is dlopen'd (the crate's `loaded`
-    // feature); the Android loader hook must run before create_instance.
+    // android-activity stores the *Application* in ndk_context, but Meta's
+    // runtime needs the *Activity* in XrInstanceCreateInfoAndroidKHR to track
+    // the app's lifecycle — handed the Application, it logs "xrCreateSession:
+    // Activity is not yet in the ready state" and parks the session in IDLE
+    // forever. The openxr crate populates that struct from ndk_context; the
+    // only ndk_context reads happen below on this same thread (loader +
+    // instance init), so the non-atomic release→initialize swap is safe here.
+    unsafe {
+        ndk_context::release_android_context();
+        ndk_context::initialize_android_context(app.vm_as_ptr(), app.activity_as_ptr());
+    }
+
+    // OpenXR: libopenxr_loader.so (Khronos or Meta's) is dlopen'd (the
+    // crate's `loaded` feature); the Android loader hook must run before
+    // create_instance.
     let entry = unsafe { xr::Entry::load() }.expect(
-        "load libopenxr_loader.so — is Meta's loader bundled in the APK? (see README)",
+        "load libopenxr_loader.so — is an OpenXR loader bundled in the APK? (see README)",
     );
     entry
         .initialize_android_loader()
@@ -407,6 +444,18 @@ pub fn android_main(app: AndroidApp) {
                 }
             }
         });
+
+        // Drain Android input events: real input arrives via OpenXR actions,
+        // but an undrained queue is an "isn't responding" ANR — the
+        // dispatcher times out waiting on the unread events. Key events are
+        // consumed (Handled): default-handling an unhandled BACK would
+        // finish the activity.
+        if let Ok(mut input_iter) = app.input_events_iter() {
+            while input_iter.next(|event| match event {
+                android_activity::input::InputEvent::KeyEvent(_) => InputStatus::Handled,
+                _ => InputStatus::Unhandled,
+            }) {}
+        }
 
         // OpenXR events: drive the session state machine.
         while let Some(event) = instance.poll_event(&mut event_storage).expect("poll_event") {


### PR DESCRIPTION
## What

Four fixes that take the Phase-1 Quest shell (#189) from parking forever in `IDLE` to **FOCUSED and rendering in stereo on a real Quest 3** (Horizon OS v205, GLES 3.2):

1. **The blocker — swap the real Activity into `ndk_context` before OpenXR init.** `android-activity` stores the *Application* object there, but Meta's runtime needs the *Activity* in `XrInstanceCreateInfoAndroidKHR` to track the app's lifecycle. Handed the Application, it logs `xrCreateSession: Activity is not yet in the ready state` and never promotes the session out of IDLE — Horizon's three-dots interstitial times out after 15 s. (`ndk-glue`-era apps never hit this; it stored the Activity.)
2. **Drain Android input events each frame.** An undrained queue is an "isn't responding" ANR. Key events are consumed (`Handled`) so a stray BACK can't finish the activity.
3. **Wait for resumed-with-window before EGL/OpenXR init** — makes activity readiness at `xrCreateSession` deterministic instead of racing the interstitial.
4. **Horizon manifest metadata** (via cargo-apk): `com.oculus.supportedDevices` (without it the app runs in original-Quest-1 compat mode), `singleTask` + landscape, and *optional* hand-tracking — which also bypasses the "controllers required" launch interceptor, required for headless launches.

README: the standard **Khronos loader from Maven Central** is now the documented path (Meta endorses it on Horizon OS; verified on-device; no developer login) + a **headless iteration recipe** (`prox_close` broadcast to fake "worn", logcat session states, `screencap` for pixels) so agents can drive the device with nobody wearing it.

## Verification (on device, headless)

```
session state: IDLE → READY → SYNCHRONIZED → VISIBLE → FOCUSED   (~120 ms)
```

Both eyes compositing our swapchain (placeholder scene is an empty group, so the uniform clear color is the expected output):

![Quest 3 stereo screencap](https://gist.githubusercontent.com/tommy-xr/9a17568bb0c2b979d170bc3b0be79b1d/raw/0d946eb72ce733ee0979c8c2cb02076db86a675c/quest-capture.png)

A/B debugging that isolated the blocker: `com.tommybuilds.shock2quest` (ndk-glue era, installed on the same device) launches headlessly to FOCUSED in <1 s with `xrCreateSession: Activity is **already** in the ready state`, while this shell — same OS, same loader — stayed "not yet ready" forever; diffing the two `OpenXR_SessionImpl` logs pointed at the activity handle.

## Review

`/xreview` run (Claude reviewer; **Codex unavailable — OpenAI usage limit**, so no cross-engine agreement signal this time): no Critical/High. Dispositions:

- *Back-key default-handling could finish the activity* (Low-Med) → **fixed**, key events consumed.
- *`ndk_context` swap comment overstated safety* (Low) → **fixed**, comment now states the same-thread timing argument.
- *Stale "Meta's loader" wording in panic message* (Low) → **fixed**.
- *Merge the pre-init wait loop into the main loop* (Low, simplicity) → **declined**: lazy-init inside the main loop would Option-wrap ~8 init locals (EGL ctx, gl, instance, session, spaces, swapchains); the 15-line wait loop is the simpler shape.

Re-verified on device after the review fixes (same FOCUSED chain, screencap above is from the post-fix build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)