### PR TITLE
feat(examples): examples/mp speaks the typed wire — Protocol.Wire replaces the string codec

### DIFF
--- a/docs/multiplayer.md
+++ b/docs/multiplayer.md
@@ -118,9 +118,11 @@ shared ADT's constructors. Plain-text `Effect.send` traffic shares the
 connection untouched (interop with non-Functor peers); a frame that fails to
 decode (version skew, corruption) arrives as `Net.Error`. Typed sends land in
 the structured effect log as data (`net.sendMsg` records), so they replay and
-introspect like every other effect. The netsim fixtures
-(`runtime/functor-netsim/tests/fixtures/typed/`) are the reference: an
-escalating typed ping/pong with no string codec anywhere.
+introspect like every other effect. `examples/mp` is the full reference — its
+client and server exchange the shared `Protocol.Wire` ADT (typed `Move`s up,
+typed `Snapshot`s down, full float precision) with no string codec anywhere;
+the netsim fixtures (`runtime/functor-netsim/tests/fixtures/typed/`) are the
+minimal ping/pong form.
 
 Two sharp edges, by design: (1) constructors match by their **canonical tag**,
 which includes the module prefix — `Protocol.Ping` sent from one end only matches

--- a/examples/mp/client.fun
+++ b/examples/mp/client.fun
@@ -2,12 +2,14 @@
 //
 //   functor -d examples/mp run native
 //
-// Connects to server.fun, sends its movement input, and renders the world
-// snapshots the server broadcasts. It holds NO authoritative state — it just
-// draws what the server last sent (naive, so movement lags by the round
-// trip). WASD drives it live; on connect it auto-moves +x so a headless test
-// produces motion with no input injection. The wire format, palette, and
-// scene live in the shared Protocol / View siblings (file = module).
+// Connects to server.fun, sends its movement as typed `Protocol.Move` values,
+// and renders the `Protocol.Snapshot` rows the server broadcasts — the wire
+// is the shared `Protocol.Wire` ADT (file = module), sent with
+// `Effect.sendMsg` and received as `Net.Data`, so there is no parsing and a
+// protocol typo is a check-time error. The client holds NO authoritative
+// state — it just draws what the server last sent (naive, so movement lags by
+// the round trip). WASD drives it live; on connect it auto-moves +x so a
+// headless test produces motion with no input injection.
 
 type ConnState =
   | Online(id: float)
@@ -17,7 +19,7 @@ type Model = { conn: ConnState, world: List<Protocol.Row>, status: string }
 
 type Msg =
   | Joined(id: float)
-  | Snapshot(text: string)
+  | Packet(id: float, wire: Protocol.Wire)
   | Dropped
   | ConnErr(text: string)
 
@@ -25,9 +27,9 @@ type Msg =
 let toMsg = (ev: Net.NetEvent): Msg =>
   match ev with
   | Net.Connected(id) => Joined(id)
-  | Net.Message(_, text) => Snapshot(text)
-  // The mp wire is the string snapshot; typed payloads are not part of it.
-  | Net.Data(_, _) => ConnErr("unexpected typed message")
+  | Net.Data(id, wire) => Packet(id, wire)
+  // The mp protocol is typed; plain text is not part of it.
+  | Net.Message(_, _) => ConnErr("unexpected text message")
   | Net.Disconnected(_) => Dropped
   | Net.Error(_, message) => ConnErr(message)
 
@@ -36,8 +38,14 @@ let init = { conn: Offline, world: [], status: "connecting" }
 let update = (m: Model, msg: Msg) =>
   match msg with
   // On connect, auto-move +x so a headless test produces motion with no input.
-  | Joined(id) => ({ m with conn: Online(id), status: "connected" }, Effect.send(id, "1 0"))
-  | Snapshot(text) => { m with world: Protocol.decode(text), status: "in-world" }
+  | Joined(id) => ({ m with conn: Online(id), status: "connected" },
+                   Effect.sendMsg(id, Protocol.Move(1.0, 0.0)))
+  | Packet(_, wire) =>
+      // A Snapshot replaces the drawn world; any other wire value from the
+      // server is ignored (a Move is client->server only).
+      (match wire with
+       | Protocol.Snapshot(rows) => { m with world: rows, status: "in-world" }
+       | _ => m)
   | Dropped => { m with conn: Offline, status: "disconnected" }
   | ConnErr(message) => { m with status: Text.concat("error: ", message) }
 
@@ -46,14 +54,14 @@ let subscriptions = (m: Model) => Sub.connect(Protocol.serverUrl, toMsg)
 
 let tick = (m: Model, dt: float, tts: float) => m
 
-// WASD -> a velocity string the server understands; other keys send nothing.
-let velocityFor = (key: Key.t): string =>
+// WASD -> a velocity for the server; other keys map to the empty list.
+let velocityFor = (key: Key.t): List<float> =>
   match key with
-  | Key.W => "0 1"
-  | Key.S => "0 -1"
-  | Key.A => "-1 0"
-  | Key.D => "1 0"
-  | _ => ""
+  | Key.W => [0.0, 1.0]
+  | Key.S => [0.0, -1.0]
+  | Key.A => [-1.0, 0.0]
+  | Key.D => [1.0, 0.0]
+  | _ => []
 
 // Key down sends the direction; key release sends a stop. Both need the live
 // connection id, so nothing is sent until the socket has opened.
@@ -64,8 +72,8 @@ let input = (m: Model, key: Key.t, isDown: bool) =>
     (match isDown with
      | true =>
        (match velocityFor(key) with
-        | "" => m
-        | v => (m, Effect.send(id, v)))
-     | false => (m, Effect.send(id, "0 0")))
+        | [vx, vz] => (m, Effect.sendMsg(id, Protocol.Move(vx, vz)))
+        | _ => m)
+     | false => (m, Effect.sendMsg(id, Protocol.Move(0.0, 0.0))))
 
 let draw = (m: Model, tts: float) => View.world(m.world)

--- a/examples/mp/protocol.fun
+++ b/examples/mp/protocol.fun
@@ -1,40 +1,22 @@
-// protocol.fun — the wire protocol shared by client.fun and server.fun
+// protocol.fun — the typed wire protocol shared by client.fun and server.fun
 // (file = module: both entries load this sibling as `Protocol`, so the two
-// roles cannot drift apart).
+// roles typecheck against ONE declaration and cannot drift).
 //
-// Wire format: "pid,x*100,z*100|pid,x*100,z*100|...". Coordinates are
-// fixed-point integers (x * 100), so an encoded coordinate rounds to within
-// 0.01 world units (`Text.fixed(n, 0.0)` ROUNDS).
+// The `Wire` ADT below IS the protocol: values are sent with
+// `Effect.sendMsg(conn, wire)` and arrive on the other end decoded, as
+// `Net.Data(id, wire)` — no string codec, no parsing, full float precision.
 
 type Row = { pid: float, x: float, z: float }
+
+type Wire =
+  | Move(vx: float, vz: float)
+  | Snapshot(rows: List<Row>)
 
 let bind = "127.0.0.1:9001"
 let serverUrl = "ws://127.0.0.1:9001/play"
 let arena = 4.0
 
 let row = (pid: float, x: float, z: float): Row => { pid: pid, x: x, z: z }
-
-let encodeRow = (r: Row): string =>
-  Text.join(
-    ",",
-    [Text.fixed(r.pid, 0.0), Text.fixed(r.x * 100.0, 0.0), Text.fixed(r.z * 100.0, 0.0)])
-
-// [Row] -> "pid,x,z|pid,x,z|..." (the server's broadcast snapshot).
-let encode = (rows: List<Row>): string =>
-  Text.join("|", List.map(encodeRow, rows))
-
-// "pid,x*100,z*100|..." -> [Row]. Fold+cons filters malformed rows (not
-// exactly 3 fields) and undoes the *100 fixed-point; draw order is
-// irrelevant, so the reversal cons introduces doesn't matter.
-let decode = (s: string): List<Row> =>
-  Text.split("|", s) |> List.fold((acc, rowText) =>
-    match Text.split(",", rowText) with
-    | [p, x, z] =>
-        [row(Text.parseFloat(p),
-             Text.parseFloat(x) / 100.0,
-             Text.parseFloat(z) / 100.0), ..acc]
-    | _ => acc,
-    [])
 
 // A distinct color per player id (wrapping every 4), shared so a given
 // player is the same color in every pane of the netsim viewer.

--- a/examples/mp/server.fun
+++ b/examples/mp/server.fun
@@ -5,12 +5,13 @@
 // Tracks a player per connection, integrates their movement, and broadcasts
 // the whole world to every client each tick. Naive (full-state, no delta, no
 // prediction) — enough to prove the loop and to drive deterministically
-// through the netsim. The wire format, palette, and scene live in the shared
-// Protocol / View siblings (file = module), so the roles cannot drift.
+// through the netsim. The protocol is the shared `Protocol.Wire` ADT
+// (file = module), sent typed with `Effect.sendMsg` and received as
+// `Net.Data` — no string codec on either end.
 //
 // `Sub.listen(bind, toMsg)` binds the address; each accepted client surfaces
 // through the `toMsg` closure carrying its own connection id, which we reply
-// to with `Effect.send`.
+// to with `Effect.sendMsg`.
 
 type Player = { cid: float, pid: float, x: float, z: float, vx: float, vz: float }
 
@@ -18,7 +19,7 @@ type Model = { players: List<Player>, nextPid: float }
 
 type Msg =
   | Joined(cid: float)
-  | Moved(cid: float, text: string)
+  | Packet(cid: float, wire: Protocol.Wire)
   | Left(cid: float)
   | NetErr(text: string)
 
@@ -28,9 +29,9 @@ let speed = 2.0
 let toMsg = (ev: Net.NetEvent): Msg =>
   match ev with
   | Net.Connected(cid) => Joined(cid)
-  | Net.Message(cid, text) => Moved(cid, text)
-  // The mp wire is the "vx vz" string; typed payloads are not part of it.
-  | Net.Data(_, _) => NetErr("unexpected typed message")
+  | Net.Data(cid, wire) => Packet(cid, wire)
+  // The mp protocol is typed; plain text is not part of it.
+  | Net.Message(_, _) => NetErr("unexpected text message")
   | Net.Disconnected(cid) => Left(cid)
   | Net.Error(cid, message) => NetErr(message)
 
@@ -51,12 +52,11 @@ let update = (m: Model, msg: Msg): Model =>
       // Spawn the new player on its own z-lane so players don't overlap.
       let p = { cid: cid, pid: m.nextPid, x: -2.0, z: m.nextPid * 1.8 - 1.8, vx: 0.0, vz: 0.0 } in
       { m with players: [p, ..m.players], nextPid: m.nextPid + 1.0 }
-  | Moved(cid, text) =>
-      // "vx vz" -> set that client's velocity; a malformed packet is ignored.
-      (match Text.split(" ", text) with
-       | [vxs, vzs] =>
-           let vx = Text.parseFloat(vxs) in
-           let vz = Text.parseFloat(vzs) in
+  | Packet(cid, wire) =>
+      // A Move sets that client's velocity; any other wire value from a
+      // client is ignored (a Snapshot is server->client only).
+      (match wire with
+       | Protocol.Move(vx, vz) =>
            { m with players:
                m.players |> List.map((p) =>
                  if p.cid == cid then { p with vx: vx, vz: vz } else p) }
@@ -69,12 +69,12 @@ let update = (m: Model, msg: Msg): Model =>
 let subscriptions = (m: Model) => Sub.listen(Protocol.bind, toMsg)
 
 let tick = (m: Model, dt: float, tts: float) =>
-  // Integrate, then broadcast the snapshot to every client.
+  // Integrate, then broadcast the typed snapshot to every client.
   let players =
     m.players |> List.map((p) =>
       { p with x: wrapAxis(p.x, p.vx, dt), z: wrapAxis(p.z, p.vz, dt) }) in
-  let snapshot = Protocol.encode(players |> List.map((p) => Protocol.row(p.pid, p.x, p.z))) in
-  let sends = players |> List.map((p) => Effect.send(p.cid, snapshot)) in
+  let rows = players |> List.map((p) => Protocol.row(p.pid, p.x, p.z)) in
+  let sends = players |> List.map((p) => Effect.sendMsg(p.cid, Protocol.Snapshot(rows))) in
   ({ m with players: players }, Effect.batch(sends))
 
 let draw = (m: Model, tts: float) =>

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -7603,13 +7603,68 @@ a number",
         assert_eq!(fountain.position, Some([5.0, 0.5, 0.0]));
     }
 
+    /// A framed `Protocol.Move(vx, vz)` wire text, as the mp client sends it.
+    /// (`Protocol` is a non-entry sibling module, so its ctors carry the
+    /// qualified canonical tag.)
+    fn mp_move_frame(vx: f64, vz: f64) -> String {
+        encode_typed_msg(&EffectValue::Variant(
+            "Protocol.Move".into(),
+            vec![EffectValue::Number(vx), EffectValue::Number(vz)],
+        ))
+    }
+
+    /// A framed `Protocol.Snapshot(rows)` wire text, as the mp server
+    /// broadcasts it.
+    fn mp_snapshot_frame(rows: &[(f64, f64, f64)]) -> String {
+        encode_typed_msg(&EffectValue::Variant(
+            "Protocol.Snapshot".into(),
+            vec![EffectValue::List(
+                rows.iter()
+                    .map(|(pid, x, z)| {
+                        EffectValue::Record(vec![
+                            ("pid".into(), EffectValue::Number(*pid)),
+                            ("x".into(), EffectValue::Number(*x)),
+                            ("z".into(), EffectValue::Number(*z)),
+                        ])
+                    })
+                    .collect(),
+            )],
+        ))
+    }
+
+    /// Decode a broadcast payload back to (pid, x, z) rows — fails loud on
+    /// anything but a framed `Protocol.Snapshot`.
+    fn mp_decode_rows(payload: &[u8]) -> Vec<(f64, f64, f64)> {
+        let text = std::str::from_utf8(payload).expect("utf8 payload");
+        match decode_typed_msg(text).expect("a typed frame").expect("frame decodes") {
+            EffectValue::Variant(ctor, args) if ctor == "Protocol.Snapshot" => match &args[..] {
+                [EffectValue::List(rows)] => rows
+                    .iter()
+                    .map(|row| match row {
+                        EffectValue::Record(fields) => {
+                            let get = |name: &str| match fields.iter().find(|(k, _)| k == name) {
+                                Some((_, EffectValue::Number(v))) => *v,
+                                other => panic!("bad row field {name}: {other:?}"),
+                            };
+                            (get("pid"), get("x"), get("z"))
+                        }
+                        other => panic!("row is not a record: {other:?}"),
+                    })
+                    .collect(),
+                other => panic!("Snapshot args: {other:?}"),
+            },
+            other => panic!("not a Protocol.Snapshot: {other:?}"),
+        }
+    }
+
     /// Headless server-lifecycle test for the `examples/mp` server entry,
     /// with no socket. Loads the SHIPPED `server.fun` so this tracks the
-    /// example, and exercises the whole server spine — `toMsg` decoding, the
-    /// join/move/left `update` logic, `wrapAxis` integration, the `Text.*` wire
-    /// encoding, and the broadcast-the-whole-world-to-every-client `Effect.send`
-    /// (the naive server's defining behavior), plus a malformed packet ignored
-    /// and a disconnect dropping a player.
+    /// example, and exercises the whole server spine — `toMsg` decoding typed
+    /// `Net.Data` packets, the join/move/left `update` logic, `wrapAxis`
+    /// integration, and the broadcast-the-whole-world-to-every-client
+    /// `Effect.sendMsg` (the naive server's defining behavior), plus a
+    /// plain-text packet ignored (the protocol is typed) and a disconnect
+    /// dropping a player.
     #[test]
     fn mp_server_broadcasts_the_world_to_every_client() {
         let _guard = CONN_QUEUE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
@@ -7672,29 +7727,29 @@ a number",
         assert!(conns.len() == 1 && conns[0].listen && conns[0].key == "127.0.0.1:9001");
 
         // Two clients join (pid 0 on cid 1, pid 1 on cid 2), each sends a
-        // velocity, and a single-token packet from cid 1 is IGNORED (its
-        // velocity is not reset — a 2-token "vx vz" is the only valid form).
+        // typed Move, and a plain-TEXT packet from cid 1 is IGNORED (the
+        // protocol is the typed Wire ADT; its velocity is not reset).
         let mut model = session.global("init").unwrap();
         model = feed(&session, model, event(NetEventKind::Connected, 1, ""));
         model = feed(&session, model, event(NetEventKind::Connected, 2, ""));
-        model = feed(&session, model, event(NetEventKind::Message, 1, "1 0")); // pid 0: +x
-        model = feed(&session, model, event(NetEventKind::Message, 2, "0 1")); // pid 1: +z
+        model = feed(&session, model, event(NetEventKind::Message, 1, &mp_move_frame(1.0, 0.0))); // pid 0: +x
+        model = feed(&session, model, event(NetEventKind::Message, 2, &mp_move_frame(0.0, 1.0))); // pid 1: +z
         model = feed(&session, model, event(NetEventKind::Message, 1, "junk")); // ignored
 
-        // Tick (dt = 0.5). pid 0: x = -2 + 1·2·0.5 = -1.0, z = -1.8 -> "0,-100,-180".
-        // pid 1: x = -2.0, z = 0 + 1·2·0.5 = 1.0 -> "1,-200,100". pid 0 still
-        // moving proves the "junk" packet did NOT reset its velocity.
+        // Tick (dt = 0.5). pid 0: x = -2 + 1·2·0.5 = -1.0, z = -1.8.
+        // pid 1: x = -2.0, z = 0 + 1·2·0.5 = 1.0. pid 0 still moving proves
+        // the text packet did NOT reset its velocity. Full float precision —
+        // the typed wire has no *100 fixed-point rounding.
         let (model, sends) = broadcast(&session, model);
         // The WHOLE world goes to EVERY client — two identical full snapshots.
-        let snapshot = b"1,-200,100|0,-100,-180".to_vec();
+        let world = vec![(1.0, -2.0, 1.0), (0.0, -1.0, -1.8)];
         assert_eq!(sends.len(), 2, "one Send per client, got: {sends:?}");
         let mut recipients: Vec<u64> = sends.iter().map(|(c, _)| *c).collect();
         recipients.sort();
         assert_eq!(recipients, vec![1, 2], "broadcast reaches both clients");
-        assert!(
-            sends.iter().all(|(_, p)| *p == snapshot),
-            "every client receives the full world, got: {sends:?}"
-        );
+        for (_, payload) in &sends {
+            assert_eq!(mp_decode_rows(payload), world, "every client receives the full world");
+        }
 
         // Client 1 disconnects -> Left drops pid 0. The next tick broadcasts
         // only pid 1, and only to the client that is still connected (cid 2).
@@ -7702,19 +7757,20 @@ a number",
         let (_, sends) = broadcast(&session, model);
         assert_eq!(sends.len(), 1, "only the remaining client is served: {sends:?}");
         assert_eq!(sends[0].0, 2);
+        let rows = mp_decode_rows(&sends[0].1);
         assert!(
-            sends[0].1.starts_with(b"1,"),
-            "snapshot no longer contains pid 0, got: {:?}",
-            String::from_utf8_lossy(&sends[0].1)
+            rows.len() == 1 && rows[0].0 == 1.0,
+            "snapshot no longer contains pid 0, got: {rows:?}"
         );
     }
 
     /// Headless client-lifecycle test for the `examples/mp` client entry,
     /// with no socket. Loads the SHIPPED `client.fun` (and its Protocol/View
-    /// siblings) and drives connect (auto-move sent), a snapshot decoded into
-    /// the world, WASD `input` producing sends, and a disconnect. The snapshot
-    /// fed in is the exact wire string the server entry broadcasts, so this
-    /// doubles as a wire round-trip check between the two roles.
+    /// siblings) and drives connect (typed auto-move sent), a typed Snapshot
+    /// landing in the world, WASD `input` producing typed Move sends, and a
+    /// disconnect. The snapshot fed in is the exact frame the server entry
+    /// broadcasts (same builder), so this doubles as a wire round-trip check
+    /// between the two roles.
     #[test]
     fn mp_client_decodes_snapshots_and_sends_input() {
         let _guard = CONN_QUEUE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
@@ -7783,24 +7839,24 @@ a number",
         let conns = net_conn_subs(&subs).expect("a Sub tree");
         assert!(!conns[0].listen && conns[0].key == "ws://127.0.0.1:9001/play");
 
-        // The socket opens (id 5): store it and auto-move +x (Effect.send "1 0").
+        // The socket opens (id 5): store it and auto-move +x (a typed Move).
         let connected = call(&session, "toMsg", vec![event(NetEventKind::Connected, 5, "")]);
         let joined = call(&session, "update", vec![session.global("init").unwrap(), connected]);
         let (model, _) = split_model_effect(joined.clone());
         assert_eq!(field(&model, "conn").to_string(), "Online(5)");
         assert_eq!(field(&model, "status").to_string(), "\"connected\"");
-        assert_eq!(sends_of(&session, joined), vec![(5, b"1 0".to_vec())]);
+        assert_eq!(sends_of(&session, joined), vec![(5, mp_move_frame(1.0, 0.0).into_bytes())]);
 
         // WASD `input` (the trickiest hook: nested match, mixed bare/tuple arms)
-        // sends the mapped velocity on keydown, a stop on keyup, and NOTHING for
-        // a non-WASD key or before the socket opens.
+        // sends the mapped typed Move on keydown, a stop on keyup, and NOTHING
+        // for a non-WASD key or before the socket opens.
         assert_eq!(
             sends_of(&session, call(&session, "input", vec![model.clone(), key("W"), Value::Bool(true)])),
-            vec![(5, b"0 1".to_vec())]
+            vec![(5, mp_move_frame(0.0, 1.0).into_bytes())]
         );
         assert_eq!(
             sends_of(&session, call(&session, "input", vec![model.clone(), key("A"), Value::Bool(true)])),
-            vec![(5, b"-1 0".to_vec())]
+            vec![(5, mp_move_frame(-1.0, 0.0).into_bytes())]
         );
         assert!(
             sends_of(&session, call(&session, "input", vec![model.clone(), key("X"), Value::Bool(true)])).is_empty(),
@@ -7808,7 +7864,7 @@ a number",
         );
         assert_eq!(
             sends_of(&session, call(&session, "input", vec![model.clone(), key("W"), Value::Bool(false)])),
-            vec![(5, b"0 0".to_vec())],
+            vec![(5, mp_move_frame(0.0, 0.0).into_bytes())],
             "key release sends a stop"
         );
         assert!(
@@ -7816,9 +7872,13 @@ a number",
             "input before connect sends nothing"
         );
 
-        // A server snapshot (the exact wire string server.fun broadcasts)
-        // decodes into the world, binding each pid to its own coordinates.
-        let msg = call(&session, "toMsg", vec![event(NetEventKind::Message, 5, "1,-200,100|0,-100,-180")]);
+        // A server snapshot (the exact frame server.fun broadcasts) lands in
+        // the world, binding each pid to its own coordinates.
+        let msg = call(&session, "toMsg", vec![event(
+            NetEventKind::Message,
+            5,
+            &mp_snapshot_frame(&[(1.0, -2.0, 1.0), (0.0, -1.0, -1.8)]),
+        )]);
         let (model, _) = split_model_effect(call(&session, "update", vec![model, msg]));
         assert_eq!(field(&model, "status").to_string(), "\"in-world\"");
         let world = match field(&model, "world") {
@@ -7833,7 +7893,8 @@ a number",
                 .unwrap_or_else(|| panic!("no player pid {pid}"));
             (num(field(p, "x")), num(field(p, "z")))
         };
-        // *100 fixed-point undone, per-pid (a swapped decoder would fail here).
+        // Per-pid coordinates, full float precision (a swapped field order
+        // would fail here).
         assert_eq!(at(0.0), (-1.0, -1.8));
         assert_eq!(at(1.0), (-2.0, 1.0));
 


### PR DESCRIPTION
## What

Stacked on #424. The mp example now demonstrates the typed-message API end-to-end: its protocol is the shared `Protocol.Wire` ADT —

```fun
type Wire =
  | Move(vx: float, vz: float)
  | Snapshot(rows: List<Row>)
```

— sent with `Effect.sendMsg` and received as `Net.Data`. The `encode`/`parseSnapshot` string codec and its `*100` fixed-point rounding are **deleted**; clients now converge on full-precision floats, and a protocol typo is a check-time error on both roles (one shared declaration). Plain text arriving on the connection is ignored as not-part-of-the-protocol.

## Verification

- Prelude lifecycle tests reworked to drive typed frames with shared builders — the snapshot fed to the client is built identically to what the server test asserts, preserving the cross-role round-trip check (`cargo test -p functor_runtime_common`, 362).
- `cargo test -p functor-netsim --test mp --test typed -- --ignored` (4) — the netsim assertions are model-shaped and pass unchanged; server + 2 clients converge on identical full-precision worlds.
- CLI example sweep typechecks both entries (38).
- **Real sockets**: ran server + client as separate `--headless` processes over tokio-tungstenite; the client reached `in-world` with full-precision rows via typed `Move`/`Snapshot` frames (queried via the debug server's `/state`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)