### PR TITLE
feat(examples): lobby — a pure-.fun master server (register/discover/join, all typed)

### DIFF
--- a/e2e/wasm-smoke.mjs
+++ b/e2e/wasm-smoke.mjs
@@ -70,6 +70,7 @@ async function waitPortFree(timeoutMs) {
 // lifecycle by the producer tests + native debug-server verification.
 const EXCLUDE = new Set([
   "loading",
+  "lobby",
   "mp",
   "wsdemo",
   "wsserverdemo",

--- a/examples/lobby/client.fun
+++ b/examples/lobby/client.fun
@@ -1,0 +1,86 @@
+// client.fun — the lobby client (`client` is the default entry):
+//
+//   functor -d examples/lobby run native
+//
+// The full discovery flow, all typed: connect to the master, ask
+// ListServers, pick the FIRST listed server, connect to it, Join, and land
+// in Playing on its Welcome. The connection to the game server exists only
+// in `subscriptions` once the model holds a discovered addr — the runtime's
+// per-frame reconciler opens it on the next frame (a model-driven
+// connection set). While the list is empty it simply asks again on each
+// (empty) reply — naive once-per-round-trip polling until a server appears.
+
+type Phase =
+  | Discovering
+  | Joining(addr: string)
+  | Playing(addr: string, motd: string)
+
+type Model = { phase: Phase }
+
+type Msg =
+  | MasterUp(id: float)
+  | FromMaster(id: float, wire: Protocol.Wire)
+  | ServerUp(id: float)
+  | FromServer(id: float, wire: Protocol.Wire)
+  | Ignore
+
+let fromMaster = (ev: Net.NetEvent): Msg =>
+  match ev with
+  | Net.Connected(id) => MasterUp(id)
+  | Net.Data(id, wire) => FromMaster(id, wire)
+  | _ => Ignore
+
+let fromServer = (ev: Net.NetEvent): Msg =>
+  match ev with
+  | Net.Connected(id) => ServerUp(id)
+  | Net.Data(id, wire) => FromServer(id, wire)
+  | _ => Ignore
+
+let init = { phase: Discovering }
+
+let update = (m: Model, msg: Msg) =>
+  match msg with
+  | MasterUp(id) => (m, Effect.sendMsg(id, Protocol.ListServers))
+  | FromMaster(id, wire) =>
+      (match wire with
+       | Protocol.Servers(servers) =>
+           (match servers with
+            | [first, ..rest] => { m with phase: Joining(first.addr) }
+            // Nothing listed yet: ask again (poll once per round trip).
+            | _ => (m, Effect.sendMsg(id, Protocol.ListServers)))
+       | _ => m)
+  | ServerUp(id) => (m, Effect.sendMsg(id, Protocol.Join("newcomer")))
+  | FromServer(_, wire) =>
+      (match wire with
+       | Protocol.Welcome(motd) =>
+           (match m.phase with
+            | Joining(addr) => { m with phase: Playing(addr, motd) }
+            | _ => m)
+       | _ => m)
+  | Ignore => m
+
+let subscriptions = (m: Model) =>
+  match m.phase with
+  | Discovering => Sub.connect(Protocol.masterUrl, fromMaster)
+  | Joining(addr) =>
+      Sub.batch([Sub.connect(Protocol.masterUrl, fromMaster), Sub.connect(addr, fromServer)])
+  | Playing(addr, _) =>
+      Sub.batch([Sub.connect(Protocol.masterUrl, fromMaster), Sub.connect(addr, fromServer)])
+
+let tick = (m: Model, dt: float, tts: float) => m
+
+let draw = (m: Model, tts: float) =>
+  // One cube, colored by phase: grey while discovering, blue while joining,
+  // green once Playing (the Welcome landed).
+  let color =
+    match m.phase with
+    | Discovering => Color.rgb(0.6, 0.6, 0.6)
+    | Joining(_) => Color.rgb(0.35, 0.60, 0.95)
+    | Playing(_, _) => Color.rgb(0.35, 0.85, 0.45) in
+  let cube = Scene.cube() |> Scene.lit(color) in
+  let ground = Scene.plane() |> Scene.scale(8.0) |> Scene.lit(Color.rgb(0.18, 0.2, 0.28)) in
+  Frame.createLit(
+    Camera.lookAt(Vec3.make(0.0, 3.0, -5.0), Vec3.make(0.0, 0.0, 0.0)),
+    Scene.group([ground, cube]),
+    [ Light.ambient(Color.rgb(0.35, 0.35, 0.42)),
+      Light.directional(Vec3.make(-0.4, -1.0, -0.35), Color.rgb(1.0, 0.95, 0.85), 1.1) ])

--- a/examples/lobby/client.fun
+++ b/examples/lobby/client.fun
@@ -9,19 +9,22 @@
 // per-frame reconciler opens it on the next frame (a model-driven
 // connection set). While the list is empty it simply asks again on each
 // (empty) reply — naive once-per-round-trip polling until a server appears.
+// If the discovered server dies (or a stale listing fails to connect), the
+// client falls back to Discovering and resumes polling instead of wedging.
 
 type Phase =
   | Discovering
   | Joining(addr: string)
   | Playing(addr: string, motd: string)
 
-type Model = { phase: Phase }
+type Model = { masterConn: float, phase: Phase }
 
 type Msg =
   | MasterUp(id: float)
   | FromMaster(id: float, wire: Protocol.Wire)
   | ServerUp(id: float)
   | FromServer(id: float, wire: Protocol.Wire)
+  | ServerGone
   | Ignore
 
 let fromMaster = (ev: Net.NetEvent): Msg =>
@@ -34,13 +37,17 @@ let fromServer = (ev: Net.NetEvent): Msg =>
   match ev with
   | Net.Connected(id) => ServerUp(id)
   | Net.Data(id, wire) => FromServer(id, wire)
+  // The discovered server dying — or a stale listing that never connects —
+  // must not wedge the client: fall back to discovery.
+  | Net.Disconnected(_) => ServerGone
+  | Net.Error(_, _) => ServerGone
   | _ => Ignore
 
-let init = { phase: Discovering }
+let init = { masterConn: -1.0, phase: Discovering }
 
 let update = (m: Model, msg: Msg) =>
   match msg with
-  | MasterUp(id) => (m, Effect.sendMsg(id, Protocol.ListServers))
+  | MasterUp(id) => ({ m with masterConn: id }, Effect.sendMsg(id, Protocol.ListServers))
   | FromMaster(id, wire) =>
       (match wire with
        | Protocol.Servers(servers) =>
@@ -57,6 +64,14 @@ let update = (m: Model, msg: Msg) =>
             | Joining(addr) => { m with phase: Playing(addr, motd) }
             | _ => m)
        | _ => m)
+  | ServerGone =>
+      // Drop the dead server connection and re-ask NOW — nothing else would
+      // (the master link stays quiet once a non-empty list was delivered).
+      // Already-Discovering dedups the Error+Disconnected double event.
+      (match m.phase with
+       | Discovering => m
+       | _ => ({ m with phase: Discovering },
+               Effect.sendMsg(m.masterConn, Protocol.ListServers)))
   | Ignore => m
 
 let subscriptions = (m: Model) =>
@@ -77,10 +92,4 @@ let draw = (m: Model, tts: float) =>
     | Discovering => Color.rgb(0.6, 0.6, 0.6)
     | Joining(_) => Color.rgb(0.35, 0.60, 0.95)
     | Playing(_, _) => Color.rgb(0.35, 0.85, 0.45) in
-  let cube = Scene.cube() |> Scene.lit(color) in
-  let ground = Scene.plane() |> Scene.scale(8.0) |> Scene.lit(Color.rgb(0.18, 0.2, 0.28)) in
-  Frame.createLit(
-    Camera.lookAt(Vec3.make(0.0, 3.0, -5.0), Vec3.make(0.0, 0.0, 0.0)),
-    Scene.group([ground, cube]),
-    [ Light.ambient(Color.rgb(0.35, 0.35, 0.42)),
-      Light.directional(Vec3.make(-0.4, -1.0, -0.35), Color.rgb(1.0, 0.95, 0.85), 1.1) ])
+  View.frame([Scene.cube() |> Scene.lit(color)])

--- a/examples/lobby/functor.json
+++ b/examples/lobby/functor.json
@@ -1,0 +1,8 @@
+{
+  "language": "functor-lang",
+  "entries": {
+    "client": "client.fun",
+    "server": "gameserver.fun",
+    "master": "master.fun"
+  }
+}

--- a/examples/lobby/gameserver.fun
+++ b/examples/lobby/gameserver.fun
@@ -1,0 +1,76 @@
+// gameserver.fun — a game server that registers itself with the master and
+// serves game clients:
+//
+//   functor -d examples/lobby run --entry server native --headless
+//
+// Two connections declared side by side in ONE `subscriptions`: the listener
+// for game clients, and the outbound registration link to the master. On the
+// master link opening it sends a typed Register carrying its own public url;
+// registration is connection-scoped, so if this process dies the master's
+// `Disconnected` event delists it — no heartbeat protocol needed.
+
+type Model = { registered: bool, players: float }
+
+type Msg =
+  | MasterUp(id: float)
+  | ClientPacket(cid: float, wire: Protocol.Wire)
+  | Ignore
+
+let gameBind = "127.0.0.1:9201"
+let gameUrl = "ws://127.0.0.1:9201/game"
+let serverName = "arena-1"
+
+let fromMaster = (ev: Net.NetEvent): Msg =>
+  match ev with
+  | Net.Connected(id) => MasterUp(id)
+  | _ => Ignore
+
+let fromClients = (ev: Net.NetEvent): Msg =>
+  match ev with
+  | Net.Data(cid, wire) => ClientPacket(cid, wire)
+  | _ => Ignore
+
+let init = { registered: false, players: 0.0 }
+
+let update = (m: Model, msg: Msg) =>
+  match msg with
+  | MasterUp(id) =>
+      ({ m with registered: true },
+       Effect.sendMsg(id, Protocol.Register(serverName, gameUrl)))
+  | ClientPacket(cid, wire) =>
+      (match wire with
+       | Protocol.Join(who) =>
+           ({ m with players: m.players + 1.0 },
+            Effect.sendMsg(cid, Protocol.Welcome(Text.concat("hello, ", who))))
+       | _ => m)
+  | Ignore => m
+
+let subscriptions = (m: Model) =>
+  Sub.batch([
+    Sub.listen(gameBind, fromClients),
+    Sub.connect(Protocol.masterUrl, fromMaster)
+  ])
+
+let tick = (m: Model, dt: float, tts: float) => m
+
+let draw = (m: Model, tts: float) =>
+  // A blue cube per joined player; the tall center pillar goes green once
+  // the server has registered with the master.
+  let pillar =
+    Scene.cube()
+    |> Scene.scaleXYZ(0.4, 2.0, 0.4)
+    |> Scene.lit(
+         if m.registered then Color.rgb(0.35, 0.85, 0.45)
+         else Color.rgb(0.6, 0.6, 0.6)) in
+  let players =
+    List.range(m.players) |> List.map((i) =>
+      Scene.cube()
+      |> Scene.scale(0.5)
+      |> Scene.translate(Vec3.make(i * 1.2 + 1.2, 0.0, 0.0))
+      |> Scene.lit(Color.rgb(0.35, 0.60, 0.95))) in
+  let ground = Scene.plane() |> Scene.scale(8.0) |> Scene.lit(Color.rgb(0.18, 0.2, 0.28)) in
+  Frame.createLit(
+    Camera.lookAt(Vec3.make(0.0, 4.0, -6.0), Vec3.make(0.0, 0.0, 0.0)),
+    Scene.group([ground, pillar, ..players]),
+    [ Light.ambient(Color.rgb(0.35, 0.35, 0.42)),
+      Light.directional(Vec3.make(-0.4, -1.0, -0.35), Color.rgb(1.0, 0.95, 0.85), 1.1) ])

--- a/examples/lobby/gameserver.fun
+++ b/examples/lobby/gameserver.fun
@@ -9,11 +9,12 @@
 // registration is connection-scoped, so if this process dies the master's
 // `Disconnected` event delists it — no heartbeat protocol needed.
 
-type Model = { registered: bool, players: float }
+type Model = { registered: bool, joined: List<float> }
 
 type Msg =
   | MasterUp(id: float)
   | ClientPacket(cid: float, wire: Protocol.Wire)
+  | ClientGone(cid: float)
   | Ignore
 
 let gameBind = "127.0.0.1:9201"
@@ -28,9 +29,10 @@ let fromMaster = (ev: Net.NetEvent): Msg =>
 let fromClients = (ev: Net.NetEvent): Msg =>
   match ev with
   | Net.Data(cid, wire) => ClientPacket(cid, wire)
+  | Net.Disconnected(cid) => ClientGone(cid)
   | _ => Ignore
 
-let init = { registered: false, players: 0.0 }
+let init = { registered: false, joined: [] }
 
 let update = (m: Model, msg: Msg) =>
   match msg with
@@ -40,9 +42,14 @@ let update = (m: Model, msg: Msg) =>
   | ClientPacket(cid, wire) =>
       (match wire with
        | Protocol.Join(who) =>
-           ({ m with players: m.players + 1.0 },
+           // Track the joined connection (idempotent per cid); ClientGone
+           // delists it, so `joined` is the CURRENT roster.
+           ({ m with joined:
+                [cid, ..m.joined |> List.filter((c) => not c == cid)] },
             Effect.sendMsg(cid, Protocol.Welcome(Text.concat("hello, ", who))))
        | _ => m)
+  | ClientGone(cid) =>
+      { m with joined: m.joined |> List.filter((c) => not c == cid) }
   | Ignore => m
 
 let subscriptions = (m: Model) =>
@@ -54,8 +61,8 @@ let subscriptions = (m: Model) =>
 let tick = (m: Model, dt: float, tts: float) => m
 
 let draw = (m: Model, tts: float) =>
-  // A blue cube per joined player; the tall center pillar goes green once
-  // the server has registered with the master.
+  // A blue cube per currently joined client; the tall center pillar goes
+  // green once the server has registered with the master.
   let pillar =
     Scene.cube()
     |> Scene.scaleXYZ(0.4, 2.0, 0.4)
@@ -63,14 +70,9 @@ let draw = (m: Model, tts: float) =>
          if m.registered then Color.rgb(0.35, 0.85, 0.45)
          else Color.rgb(0.6, 0.6, 0.6)) in
   let players =
-    List.range(m.players) |> List.map((i) =>
+    List.range(List.length(m.joined)) |> List.map((i) =>
       Scene.cube()
       |> Scene.scale(0.5)
       |> Scene.translate(Vec3.make(i * 1.2 + 1.2, 0.0, 0.0))
       |> Scene.lit(Color.rgb(0.35, 0.60, 0.95))) in
-  let ground = Scene.plane() |> Scene.scale(8.0) |> Scene.lit(Color.rgb(0.18, 0.2, 0.28)) in
-  Frame.createLit(
-    Camera.lookAt(Vec3.make(0.0, 4.0, -6.0), Vec3.make(0.0, 0.0, 0.0)),
-    Scene.group([ground, pillar, ..players]),
-    [ Light.ambient(Color.rgb(0.35, 0.35, 0.42)),
-      Light.directional(Vec3.make(-0.4, -1.0, -0.35), Color.rgb(1.0, 0.95, 0.85), 1.1) ])
+  View.frame([pillar, ..players])

--- a/examples/lobby/master.fun
+++ b/examples/lobby/master.fun
@@ -49,15 +49,9 @@ let tick = (m: Model, dt: float, tts: float) => m
 
 let draw = (m: Model, tts: float) =>
   // One green cube per registered server, in a row — an at-a-glance registry.
-  let nodes =
+  View.frame(
     m.entries |> List.map((e) =>
       Scene.cube()
       |> Scene.scale(0.7)
       |> Scene.translate(Vec3.make(e.cid * 1.5, 0.0, 0.0))
-      |> Scene.lit(Color.rgb(0.35, 0.85, 0.45))) in
-  let ground = Scene.plane() |> Scene.scale(8.0) |> Scene.lit(Color.rgb(0.18, 0.2, 0.28)) in
-  Frame.createLit(
-    Camera.lookAt(Vec3.make(0.0, 4.0, -6.0), Vec3.make(0.0, 0.0, 0.0)),
-    Scene.group([ground, ..nodes]),
-    [ Light.ambient(Color.rgb(0.35, 0.35, 0.42)),
-      Light.directional(Vec3.make(-0.4, -1.0, -0.35), Color.rgb(1.0, 0.95, 0.85), 1.1) ])
+      |> Scene.lit(Color.rgb(0.35, 0.85, 0.45))))

--- a/examples/lobby/master.fun
+++ b/examples/lobby/master.fun
@@ -1,0 +1,63 @@
+// master.fun — the master server:
+//
+//   functor -d examples/lobby run --entry master native --headless
+//
+// A tiny CONNECTION-SCOPED registry, pure Functor Lang — there is no engine
+// "master server" surface, just `Sub.listen` + typed messages. A game server
+// Registers over its own connection and stays listed exactly as long as that
+// connection lives: `Net.Disconnected` delists it, so no TTL machinery is
+// needed. Clients send ListServers and get the current Servers back.
+
+type Entry = { cid: float, info: Protocol.ServerInfo }
+
+type Model = { entries: List<Entry> }
+
+type Msg =
+  | Packet(cid: float, wire: Protocol.Wire)
+  | Gone(cid: float)
+  | Ignore
+
+let toMsg = (ev: Net.NetEvent): Msg =>
+  match ev with
+  | Net.Data(cid, wire) => Packet(cid, wire)
+  | Net.Disconnected(cid) => Gone(cid)
+  | _ => Ignore
+
+let init = { entries: [] }
+
+let listed = (m: Model): List<Protocol.ServerInfo> =>
+  m.entries |> List.map((e) => e.info)
+
+let update = (m: Model, msg: Msg) =>
+  match msg with
+  | Packet(cid, wire) =>
+      (match wire with
+       | Protocol.Register(name, addr) =>
+           // Upsert: re-registering over the same connection replaces.
+           let others = m.entries |> List.filter((e) => not e.cid == cid) in
+           { m with entries:
+               [{ cid: cid, info: Protocol.serverInfo(name, addr) }, ..others] }
+       | Protocol.ListServers => (m, Effect.sendMsg(cid, Protocol.Servers(listed(m))))
+       | _ => m)
+  | Gone(cid) =>
+      { m with entries: m.entries |> List.filter((e) => not e.cid == cid) }
+  | Ignore => m
+
+let subscriptions = (m: Model) => Sub.listen(Protocol.masterBind, toMsg)
+
+let tick = (m: Model, dt: float, tts: float) => m
+
+let draw = (m: Model, tts: float) =>
+  // One green cube per registered server, in a row — an at-a-glance registry.
+  let nodes =
+    m.entries |> List.map((e) =>
+      Scene.cube()
+      |> Scene.scale(0.7)
+      |> Scene.translate(Vec3.make(e.cid * 1.5, 0.0, 0.0))
+      |> Scene.lit(Color.rgb(0.35, 0.85, 0.45))) in
+  let ground = Scene.plane() |> Scene.scale(8.0) |> Scene.lit(Color.rgb(0.18, 0.2, 0.28)) in
+  Frame.createLit(
+    Camera.lookAt(Vec3.make(0.0, 4.0, -6.0), Vec3.make(0.0, 0.0, 0.0)),
+    Scene.group([ground, ..nodes]),
+    [ Light.ambient(Color.rgb(0.35, 0.35, 0.42)),
+      Light.directional(Vec3.make(-0.4, -1.0, -0.35), Color.rgb(1.0, 0.95, 0.85), 1.1) ])

--- a/examples/lobby/protocol.fun
+++ b/examples/lobby/protocol.fun
@@ -1,0 +1,23 @@
+// protocol.fun — the lobby wire shared by master.fun, gameserver.fun, and
+// client.fun (file = module: every entry loads this sibling as `Protocol`).
+// Three conversations, one typed ADT — sent with `Effect.sendMsg`, received
+// as `Net.Data`, no string codec anywhere:
+//
+//   game server -> master:  Register (connection-scoped: dropping the
+//                           connection delists the server)
+//   client     <-> master:  ListServers / Servers (discovery)
+//   client     <-> server:  Join / Welcome (the "game")
+
+type ServerInfo = { name: string, addr: string }
+
+type Wire =
+  | Register(name: string, addr: string)
+  | ListServers
+  | Servers(servers: List<ServerInfo>)
+  | Join(who: string)
+  | Welcome(motd: string)
+
+let masterBind = "127.0.0.1:9200"
+let masterUrl = "ws://127.0.0.1:9200/lobby"
+
+let serverInfo = (name: string, addr: string): ServerInfo => { name: name, addr: addr }

--- a/examples/lobby/view.fun
+++ b/examples/lobby/view.fun
@@ -1,0 +1,12 @@
+// view.fun — shared scene scaffolding for the three lobby roles (file =
+// module): the same ground plane, camera, and lights, so the role panes read
+// consistently side by side.
+
+let frame = (nodes: List<Scene.t>) =>
+  let ground =
+    Scene.plane() |> Scene.scale(8.0) |> Scene.lit(Color.rgb(0.18, 0.2, 0.28)) in
+  Frame.createLit(
+    Camera.lookAt(Vec3.make(0.0, 4.0, -6.0), Vec3.make(0.0, 0.0, 0.0)),
+    Scene.group([ground, ..nodes]),
+    [ Light.ambient(Color.rgb(0.35, 0.35, 0.42)),
+      Light.directional(Vec3.make(-0.4, -1.0, -0.35), Color.rgb(1.0, 0.95, 0.85), 1.1) ])

--- a/runtime/functor-netsim/tests/lobby.rs
+++ b/runtime/functor-netsim/tests/lobby.rs
@@ -1,0 +1,64 @@
+//! Netsim test of the master-server flow (`examples/lobby`): a master, a
+//! game server, and a client run as in-process producers over the virtual
+//! network. The game server registers with the master over its own
+//! connection (typed `Register`); the client discovers it (`ListServers` /
+//! `Servers`), opens a SECOND, model-driven connection to the discovered
+//! addr, `Join`s, and lands in `Playing` on the server's `Welcome` — the
+//! whole lobby handshake, typed end to end, no sockets, no GL.
+//!
+//! Still `#[ignore]`d by default (pulls the full desktop runtime as a
+//! dev-dependency); run with:
+//!
+//! ```sh
+//! cargo test -p functor-netsim --test lobby -- --ignored --nocapture
+//! ```
+
+use functor_netsim::{InstanceId, NetSim};
+use functor_runtime_desktop::functor_lang_game::FunctorLangGame;
+
+// Same process-global conn-queue caveat as tests/mp.rs: serialize the tests
+// in this binary and clear residue at each start.
+static NET_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn add_lobby(sim: &mut NetSim, entry: &str) -> InstanceId {
+    let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../examples/lobby")
+        .join(entry);
+    assert!(path.exists(), "missing {}", path.display());
+    sim.add_producer(Box::new(FunctorLangGame::create(path.to_str().unwrap())))
+}
+
+#[test]
+#[ignore = "pulls the desktop runtime dev-dependency; run with --ignored"]
+fn client_discovers_the_server_through_the_master_and_joins() {
+    let _guard = NET_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _ = functor_runtime_common::net::drain_conn_commands();
+
+    let mut sim = NetSim::new(1);
+    let master = add_lobby(&mut sim, "master.fun");
+    let server = add_lobby(&mut sim, "gameserver.fun");
+    let client = add_lobby(&mut sim, "client.fun");
+
+    // register → list → discover → connect → join → welcome takes several
+    // round trips (plus the client's empty-list re-asks if it raced the
+    // server's registration).
+    sim.step_n(60);
+
+    let master_state = sim.state(master);
+    let server_state = sim.state(server);
+    let client_state = sim.state(client);
+    println!("MASTER: {master_state}");
+    println!("SERVER: {server_state}");
+    println!("CLIENT: {client_state}");
+
+    // The game server registered (connection-scoped) and shows up by name.
+    assert!(master_state.contains("arena-1"), "master should list the server: {master_state}");
+    assert!(server_state.contains("registered: true"), "server should be registered: {server_state}");
+    // The client joined THROUGH discovery: it holds the discovered addr and
+    // the server's Welcome — and the server counted the join.
+    assert!(
+        client_state.contains("Playing") && client_state.contains("hello, newcomer"),
+        "client should reach Playing via the discovered server: {client_state}"
+    );
+    assert!(server_state.contains("players: 1"), "server should count the join: {server_state}");
+}

--- a/runtime/functor-netsim/tests/lobby.rs
+++ b/runtime/functor-netsim/tests/lobby.rs
@@ -60,5 +60,9 @@ fn client_discovers_the_server_through_the_master_and_joins() {
         client_state.contains("Playing") && client_state.contains("hello, newcomer"),
         "client should reach Playing via the discovered server: {client_state}"
     );
-    assert!(server_state.contains("players: 1"), "server should count the join: {server_state}");
+    // A non-empty roster: the joined client's cid is on the list.
+    assert!(
+        server_state.contains("joined: [") && !server_state.contains("joined: []"),
+        "server should have the client on its roster: {server_state}"
+    );
 }


### PR DESCRIPTION
## What

Stacked on #426. The master-server v1 spike from the multiplayer track, with **zero new engine surface**: `examples/lobby` is a three-entry project (`master` / `server` / `client` over a shared `protocol.fun`) where the master is itself a plain Functor Lang game — `Sub.listen` + `Effect.sendMsg`, and a **connection-scoped registry**: a game server stays listed exactly as long as its registration connection lives (`Net.Disconnected` delists it), so v1 needs no TTL/heartbeat machinery.

The flow, typed end to end:

1. The game server declares two connections side by side in one `subscriptions` — its game listener and the outbound master link — and sends `Register(name, url)` when the master link opens.
2. The client asks `ListServers` (re-asking once per round trip while the list is empty), picks the first `Servers` row, and declares a **second, model-driven connection** to the discovered addr — the per-frame reconciler opens it.
3. `Join` → `Welcome` → the client lands in `Playing`.

A hosted master (`multiplayer.functor.games`, likely a Cloudflare Worker + DO) is deliberately deferred — this proves the gestures and the protocol shape locally first.

## Visuals

| master (one registered server) | game server (registered + 1 player) | client (Playing) |
| --- | --- | --- |
| ![master](https://gist.githubusercontent.com/tommy-xr/030a2ec52b25157aaf112a0a0f1cec46/raw/lobby-master.png) | ![server](https://gist.githubusercontent.com/tommy-xr/030a2ec52b25157aaf112a0a0f1cec46/raw/lobby-server.png) | ![client](https://gist.githubusercontent.com/tommy-xr/030a2ec52b25157aaf112a0a0f1cec46/raw/lobby-client.png) |

Captured from **real processes over real sockets** (the pillar goes green on registration; the client cube goes green on `Welcome`). The delisting was also observed live: capturing the master *after* the server process exited shows an empty registry.

## Verification

- New netsim test (`tests/lobby.rs`): master + game server + client through the full handshake, deterministically, no sockets/GL — asserts the master lists `arena-1`, the server counts the join, and the client reaches `Playing("ws://…", "hello, newcomer")` **via discovery**.
- Real-socket run: the same flow as three `functor` processes over tokio-tungstenite (captures above).
- CLI example sweep typechecks all three entries; full suites green (runtime-common 362, CLI 38, netsim mp/typed/lobby 5).
- `lobby` added to the wasm-smoke exclude set (network demo, multi-entry — the same class of miss xreview caught on #423).

🤖 Generated with [Claude Code](https://claude.com/claude-code)