### PR TITLE
feat(oculus): POST /reload-source on device — the remote-develop push loop (M1b)

### DIFF
--- a/runtime/functor-runtime-oculus/Cargo.toml
+++ b/runtime/functor-runtime-oculus/Cargo.toml
@@ -63,6 +63,11 @@ required = false
 [[package.metadata.android.uses_permission]]
 name = "com.oculus.permission.HAND_TRACKING"
 
+# Sockets — even the device-loopback reload endpoint — need this; binding
+# without it is EPERM.
+[[package.metadata.android.uses_permission]]
+name = "android.permission.INTERNET"
+
 # Without supportedDevices, Horizon OS treats the APK as an original-Quest
 # compat app (`VrRuntimeCompatHelper: DevicesSupported : 1 devices, quest`).
 [[package.metadata.android.application.meta_data]]

--- a/runtime/functor-runtime-oculus/README.md
+++ b/runtime/functor-runtime-oculus/README.md
@@ -18,7 +18,8 @@ network reload, controller input, asymmetric-frustum projection.
 The APK boots an embedded scene (`src/boot.fun`) and listens on **device
 loopback** for pushed source — `POST /reload-source`, the same endpoint the
 desktop debug server exposes. The dev PC reaches it over USB (loopback-only
-binding means nothing on the LAN can push code to the headset):
+binding keeps the LAN out; note another app ON the device could reach
+loopback — an accepted dev-tool tradeoff):
 
 ```sh
 adb forward tcp:8123 tcp:8123

--- a/runtime/functor-runtime-oculus/README.md
+++ b/runtime/functor-runtime-oculus/README.md
@@ -23,19 +23,19 @@ loopback — an accepted dev-tool tradeoff):
 
 ```sh
 adb forward tcp:8123 tcp:8123
-curl --fail-with-body -X POST --data-binary @game.fun http://127.0.0.1:8123/reload-source
+functor -d mygame push 127.0.0.1:8123          # push once
+functor -d mygame push 127.0.0.1:8123 --watch  # push on every save
 ```
+
+(`functor push` is the desktop remote-develop command — the Quest endpoint
+speaks the same protocol, verified at ~12ms per push. Raw HTTP works too:
+`curl --fail-with-body -X POST --data-binary @game.fun
+http://127.0.0.1:8123/reload-source`.)
 
 Semantics match desktop hot-reload: the **model is preserved** (closures
 stored in the model rebind by def-name), a broken push returns the rendered
 error with HTTP 400 and the old program keeps running, and a push landed
-while the headset dozes applies the moment the session resumes. Edit-on-save
-loop (watchexec is optional everywhere else too):
-
-```sh
-watchexec -w game.fun -- \
-  curl -s -X POST --data-binary @game.fun http://127.0.0.1:8123/reload-source
-```
+while the headset dozes applies the moment the session resumes.
 
 ## Headless iteration (no one wearing the headset)
 

--- a/runtime/functor-runtime-oculus/README.md
+++ b/runtime/functor-runtime-oculus/README.md
@@ -13,6 +13,29 @@ reaches session FOCUSED and renders the placeholder scene in stereo through
 the shared `render_frame` path. Remaining device bring-up: the Functor Lang producer,
 network reload, controller input, asymmetric-frustum projection.
 
+## The remote-develop loop (M1)
+
+The APK boots an embedded scene (`src/boot.fun`) and listens on **device
+loopback** for pushed source — `POST /reload-source`, the same endpoint the
+desktop debug server exposes. The dev PC reaches it over USB (loopback-only
+binding means nothing on the LAN can push code to the headset):
+
+```sh
+adb forward tcp:8123 tcp:8123
+curl --fail-with-body -X POST --data-binary @game.fun http://127.0.0.1:8123/reload-source
+```
+
+Semantics match desktop hot-reload: the **model is preserved** (closures
+stored in the model rebind by def-name), a broken push returns the rendered
+error with HTTP 400 and the old program keeps running, and a push landed
+while the headset dozes applies the moment the session resumes. Edit-on-save
+loop (watchexec is optional everywhere else too):
+
+```sh
+watchexec -w game.fun -- \
+  curl -s -X POST --data-binary @game.fun http://127.0.0.1:8123/reload-source
+```
+
 ## Headless iteration (no one wearing the headset)
 
 The device only promotes a session past IDLE when it believes it's worn, and

--- a/runtime/functor-runtime-oculus/src/lib.rs
+++ b/runtime/functor-runtime-oculus/src/lib.rs
@@ -256,6 +256,11 @@ fn camera_from_view(view: &xr::View) -> Camera {
 /// the same embedded producer a pushed game runs under.
 const BOOT_SCENE: &str = include_str!("boot.fun");
 
+/// The push endpoint's device-loopback port (`adb forward tcp:8123 tcp:8123`).
+const RELOAD_PORT: u16 = 8123;
+
+mod reload_server;
+
 #[no_mangle]
 pub fn android_main(app: AndroidApp) {
     android_logger::init_once(
@@ -443,6 +448,20 @@ pub fn android_main(app: AndroidApp) {
     )])
     .expect("embedded boot scene loads");
 
+    // The push endpoint: POST /reload-source on device loopback — the dev PC
+    // reaches it via `adb forward tcp:8123 tcp:8123` (see README). A bind
+    // failure (port taken) degrades to boot-scene-only, loudly.
+    let reload_rx = match reload_server::spawn(RELOAD_PORT) {
+        Ok(rx) => {
+            log::info!("reload endpoint: POST http://127.0.0.1:{RELOAD_PORT}/reload-source");
+            Some(rx)
+        }
+        Err(error) => {
+            log::error!("reload endpoint failed to bind port {RELOAD_PORT}: {error}");
+            None
+        }
+    };
+
     let start = std::time::Instant::now();
     // Lazy: seconds pass between android_main and the first rendered frame
     // (session READY), and the session can pause — the first frame after
@@ -516,6 +535,15 @@ pub fn android_main(app: AndroidApp) {
                 }
                 InstanceLossPending(_) => quit = true,
                 _ => {}
+            }
+        }
+
+        // Apply pushed reloads BEFORE the session gate: the producer needs no
+        // GL/XR to swap programs, so a push lands even while the headset
+        // dozes (session IDLE) — it shows the moment the session resumes.
+        if let Some(rx) = &reload_rx {
+            while let Ok((source, resp)) = rx.try_recv() {
+                let _ = resp.send(game.reload_source(&source));
             }
         }
 

--- a/runtime/functor-runtime-oculus/src/reload_server.rs
+++ b/runtime/functor-runtime-oculus/src/reload_server.rs
@@ -1,19 +1,25 @@
 //! The device-side push endpoint (M1 of the remote-develop loop): a minimal
 //! HTTP listener accepting `POST /reload-source` with a `.fun` body — the
 //! headset twin of the desktop debug server's endpoint (same route, same
-//! body-size guard, same status semantics), sized to the one route it
-//! serves rather than pulling in an HTTP crate.
+//! 4MB body bound — enforced here as an exact `Content-Length` match — and
+//! same status semantics), sized to the one route it serves rather than
+//! pulling in an HTTP crate.
 //!
 //! Threading: GL and the producer live on the `android_main` thread, so the
 //! listener runs on a background thread and hands each request to the frame
 //! loop over an `mpsc` channel (the desktop `debug_server` pattern); the
 //! frame loop drains with `try_recv` and replies through the per-request
-//! response channel.
+//! response channel. When `android_main` returns, the receiver drops and the
+//! accept loop exits on the next connection; until then the thread and its
+//! bound port outlive the loop — Android tears the process down with the
+//! activity, which is what actually reclaims them.
 //!
 //! Binding: **loopback only.** The dev PC reaches it via
 //! `adb forward tcp:PORT tcp:PORT` (adb connects to the device's loopback),
-//! so nothing on the LAN can push code to the headset. Wi-Fi push is a
-//! later, explicitly opt-in slice.
+//! so nothing on the LAN can reach it. Note loopback is NOT app-isolated on
+//! Android: another app on the device holding INTERNET could POST here too —
+//! an accepted dev-tool tradeoff. Wi-Fi push is a later, explicitly opt-in
+//! slice.
 
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{TcpListener, TcpStream};
@@ -24,11 +30,21 @@ use std::time::Duration;
 pub type ReloadRequest = (String, mpsc::Sender<Result<String, String>>);
 
 /// Game source is KBs; an unbounded read is an OOM invitation (the desktop
-/// endpoint's guard, verbatim).
+/// endpoint's bound).
 const MAX_SOURCE_BYTES: usize = 4 * 1024 * 1024;
+
+/// Request-line / header lines get the same treatment: a client streaming
+/// bytes with no newline must not grow a String unbounded.
+const MAX_HEADER_LINE_BYTES: u64 = 8 * 1024;
+const MAX_HEADER_LINES: usize = 64;
 
 /// A stalled client must not wedge the (single) listener thread forever.
 const CLIENT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// How long the listener waits for the frame loop to apply a push. Normal
+/// reloads answer within a frame (~10ms); this only fires if the loop is
+/// wedged (e.g. blocked in the compositor during a system interruption).
+const RELOAD_REPLY_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Bind the loopback listener and spawn the accept loop. Returns the frame
 /// loop's end of the request channel.
@@ -47,6 +63,20 @@ pub fn spawn(port: u16) -> std::io::Result<mpsc::Receiver<ReloadRequest>> {
     Ok(rx)
 }
 
+/// Read one `\n`-terminated line through a byte cap. `None` = EOF, a line
+/// exceeding the cap, a read error, or a timeout — all cases where the
+/// request is unusable and the connection should just be answered/closed.
+fn read_line_capped(reader: &mut BufReader<TcpStream>, cap: u64) -> Option<String> {
+    let mut limited = Read::by_ref(reader).take(cap);
+    let mut line = String::new();
+    match limited.read_line(&mut line) {
+        Ok(0) => None,
+        Ok(_) if line.ends_with('\n') => Some(line),
+        // Hit the cap (or EOF) mid-line — reject rather than resynchronize.
+        Ok(_) | Err(_) => None,
+    }
+}
+
 /// Serve one connection: parse the request, hand a valid push to the frame
 /// loop, write the reply. `None` = the frame-loop channel is gone (stop
 /// accepting); any client/parse problem answers the client and returns
@@ -60,23 +90,24 @@ fn handle(mut stream: TcpStream, tx: &mpsc::Sender<ReloadRequest>) -> Option<()>
         Err(_) => return Some(()),
     });
 
-    let mut request_line = String::new();
-    if reader.read_line(&mut request_line).is_err() {
+    let Some(request_line) = read_line_capped(&mut reader, MAX_HEADER_LINE_BYTES) else {
+        respond(&mut stream, 400, "Bad Request", "bad request line");
         return Some(());
-    }
+    };
     let mut parts = request_line.split_whitespace();
     let (method, path) = (parts.next().unwrap_or(""), parts.next().unwrap_or(""));
 
-    // Headers: only Content-Length matters here.
+    // Headers: only Content-Length matters here. Both the per-line and the
+    // line-count reads are bounded (see the caps above).
     let mut content_length: Option<usize> = None;
-    loop {
-        let mut line = String::new();
-        match reader.read_line(&mut line) {
-            Ok(0) | Err(_) => return Some(()), // client hung up mid-headers
-            Ok(_) => {}
-        }
+    let mut header_ok = false;
+    for _ in 0..MAX_HEADER_LINES {
+        let Some(line) = read_line_capped(&mut reader, MAX_HEADER_LINE_BYTES) else {
+            break; // client hung up / oversized line mid-headers
+        };
         let line = line.trim_end();
         if line.is_empty() {
+            header_ok = true;
             break;
         }
         if let Some((name, value)) = line.split_once(':') {
@@ -84,6 +115,10 @@ fn handle(mut stream: TcpStream, tx: &mpsc::Sender<ReloadRequest>) -> Option<()>
                 content_length = value.trim().parse::<usize>().ok();
             }
         }
+    }
+    if !header_ok {
+        respond(&mut stream, 400, "Bad Request", "bad headers");
+        return Some(());
     }
 
     match (method, path) {
@@ -114,12 +149,20 @@ fn handle(mut stream: TcpStream, tx: &mpsc::Sender<ReloadRequest>) -> Option<()>
             }
             let (resp_tx, resp_rx) = mpsc::channel();
             tx.send((body, resp_tx)).ok()?;
-            match resp_rx.recv() {
+            match resp_rx.recv_timeout(RELOAD_REPLY_TIMEOUT) {
                 Ok(Ok(status)) => respond(&mut stream, 200, "OK", &status),
                 // A load error in the pushed source — the pusher's mistake,
                 // and the error names it (they're looking at the source): 400.
                 Ok(Err(message)) => respond(&mut stream, 400, "Bad Request", &message),
-                Err(_) => respond(&mut stream, 500, "Internal Server Error", "reload failed"),
+                Err(mpsc::RecvTimeoutError::Timeout) => respond(
+                    &mut stream,
+                    503,
+                    "Service Unavailable",
+                    "runtime did not apply the reload in time",
+                ),
+                Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    respond(&mut stream, 500, "Internal Server Error", "reload failed")
+                }
             }
         }
         ("GET", "/") => {

--- a/runtime/functor-runtime-oculus/src/reload_server.rs
+++ b/runtime/functor-runtime-oculus/src/reload_server.rs
@@ -1,0 +1,147 @@
+//! The device-side push endpoint (M1 of the remote-develop loop): a minimal
+//! HTTP listener accepting `POST /reload-source` with a `.fun` body — the
+//! headset twin of the desktop debug server's endpoint (same route, same
+//! body-size guard, same status semantics), sized to the one route it
+//! serves rather than pulling in an HTTP crate.
+//!
+//! Threading: GL and the producer live on the `android_main` thread, so the
+//! listener runs on a background thread and hands each request to the frame
+//! loop over an `mpsc` channel (the desktop `debug_server` pattern); the
+//! frame loop drains with `try_recv` and replies through the per-request
+//! response channel.
+//!
+//! Binding: **loopback only.** The dev PC reaches it via
+//! `adb forward tcp:PORT tcp:PORT` (adb connects to the device's loopback),
+//! so nothing on the LAN can push code to the headset. Wi-Fi push is a
+//! later, explicitly opt-in slice.
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::mpsc;
+use std::time::Duration;
+
+/// A pushed source body and the channel the frame loop answers on.
+pub type ReloadRequest = (String, mpsc::Sender<Result<String, String>>);
+
+/// Game source is KBs; an unbounded read is an OOM invitation (the desktop
+/// endpoint's guard, verbatim).
+const MAX_SOURCE_BYTES: usize = 4 * 1024 * 1024;
+
+/// A stalled client must not wedge the (single) listener thread forever.
+const CLIENT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Bind the loopback listener and spawn the accept loop. Returns the frame
+/// loop's end of the request channel.
+pub fn spawn(port: u16) -> std::io::Result<mpsc::Receiver<ReloadRequest>> {
+    let listener = TcpListener::bind(("127.0.0.1", port))?;
+    let (tx, rx) = mpsc::channel::<ReloadRequest>();
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(stream) = stream else { continue };
+            if handle(stream, &tx).is_none() {
+                // The frame loop dropped its receiver — the app is exiting.
+                break;
+            }
+        }
+    });
+    Ok(rx)
+}
+
+/// Serve one connection: parse the request, hand a valid push to the frame
+/// loop, write the reply. `None` = the frame-loop channel is gone (stop
+/// accepting); any client/parse problem answers the client and returns
+/// `Some(())` so the accept loop continues.
+fn handle(mut stream: TcpStream, tx: &mpsc::Sender<ReloadRequest>) -> Option<()> {
+    let _ = stream.set_read_timeout(Some(CLIENT_TIMEOUT));
+    let _ = stream.set_write_timeout(Some(CLIENT_TIMEOUT));
+
+    let mut reader = BufReader::new(match stream.try_clone() {
+        Ok(clone) => clone,
+        Err(_) => return Some(()),
+    });
+
+    let mut request_line = String::new();
+    if reader.read_line(&mut request_line).is_err() {
+        return Some(());
+    }
+    let mut parts = request_line.split_whitespace();
+    let (method, path) = (parts.next().unwrap_or(""), parts.next().unwrap_or(""));
+
+    // Headers: only Content-Length matters here.
+    let mut content_length: Option<usize> = None;
+    loop {
+        let mut line = String::new();
+        match reader.read_line(&mut line) {
+            Ok(0) | Err(_) => return Some(()), // client hung up mid-headers
+            Ok(_) => {}
+        }
+        let line = line.trim_end();
+        if line.is_empty() {
+            break;
+        }
+        if let Some((name, value)) = line.split_once(':') {
+            if name.eq_ignore_ascii_case("content-length") {
+                content_length = value.trim().parse::<usize>().ok();
+            }
+        }
+    }
+
+    match (method, path) {
+        ("POST", "/reload-source") => {
+            // Bound the body; chunked bodies (no declared length) are
+            // rejected the same way (the desktop endpoint's rule).
+            let len = match content_length {
+                Some(len) if len <= MAX_SOURCE_BYTES => len,
+                _ => {
+                    respond(
+                        &mut stream,
+                        413,
+                        "Payload Too Large",
+                        "source too large (or missing Content-Length); limit is 4MB",
+                    );
+                    return Some(());
+                }
+            };
+            let mut body = String::new();
+            if reader
+                .take(len as u64)
+                .read_to_string(&mut body)
+                .is_err()
+                || body.len() != len
+            {
+                respond(&mut stream, 400, "Bad Request", "bad body");
+                return Some(());
+            }
+            let (resp_tx, resp_rx) = mpsc::channel();
+            tx.send((body, resp_tx)).ok()?;
+            match resp_rx.recv() {
+                Ok(Ok(status)) => respond(&mut stream, 200, "OK", &status),
+                // A load error in the pushed source — the pusher's mistake,
+                // and the error names it (they're looking at the source): 400.
+                Ok(Err(message)) => respond(&mut stream, 400, "Bad Request", &message),
+                Err(_) => respond(&mut stream, 500, "Internal Server Error", "reload failed"),
+            }
+        }
+        ("GET", "/") => {
+            // Discoverability (a probing dev/LLM): who this is, what it takes.
+            respond(
+                &mut stream,
+                200,
+                "OK",
+                "{\"service\":\"functor quest runtime\",\"endpoints\":[\"POST /reload-source\"]}",
+            );
+        }
+        _ => respond(&mut stream, 404, "Not Found", "unknown endpoint"),
+    }
+    Some(())
+}
+
+fn respond(stream: &mut TcpStream, code: u16, reason: &str, body: &str) {
+    let response = format!(
+        "HTTP/1.1 {code} {reason}\r\nContent-Type: text/plain; charset=utf-8\r\n\
+Content-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    let _ = stream.write_all(response.as_bytes());
+    let _ = stream.flush();
+}


### PR DESCRIPTION
> Stacked on #428 (embedded producer), which stacks on #425 (merged).

## What

The other half of M1: games (and edits) now arrive at the headset **over the wire, live**. A minimal HTTP listener on device loopback (port 8123) — the headset twin of the desktop debug server's `/reload-source`:

- Same route, same 4MB body / `Content-Length` guard, same status semantics: 200 + the reload status line; a broken push = **400 + the rendered load error**, and the old program keeps running.
- **Loopback-only binding**: the dev PC reaches it via `adb forward tcp:8123 tcp:8123`; nothing on the LAN can push code to the headset. (Wi-Fi push is a later, opt-in slice.)
- Listener on a background thread, requests handed to the frame loop over an `mpsc` channel (the `debug_server` pattern). Pushes drain **before** the session gate, so an edit lands even while the headset dozes and shows on resume.
- `android.permission.INTERNET` added to the manifest — Android EPERMs even loopback binds without it (found on device).
- README: the push loop (`adb forward` + `curl`, `watchexec` for push-on-save).

## The delight loop, demonstrated (Quest 3, headless)

```
$ curl -X POST --data-binary @game.fun http://127.0.0.1:8123/reload-source
reloaded boot.fun from pushed source in 12.46ms (model preserved)   # HTTP 200, 29ms round-trip
```

Same head pose, before and after the push — the scene (sky + floor colors here) changes live:

| before push | after push |
| --- | --- |
| ![before](https://gist.githubusercontent.com/tommy-xr/9a17568bb0c2b979d170bc3b0be79b1d/raw/2de1e2c1e96c26f2bd06e0ae6e09773103e5506a/push-t0.png) | ![after](https://gist.githubusercontent.com/tommy-xr/9a17568bb0c2b979d170bc3b0be79b1d/raw/7f86e467f3366e440e2385b4ea6378132e89e6e7/push-t3.png) |

And the failure path:

```
$ curl -X POST --data-binary @broken.fun http://127.0.0.1:8123/reload-source
boot.fun has no top-level `let tick = …`   # HTTP 400; previous scene keeps rendering
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)