### PR TITLE
feat(cli): run vr — one-command remote develop on an adb-attached headset

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,7 @@ The wasm bundle is unaffected either way: `wasm-pack build` is release by defaul
 ```sh
 ./target/debug/functor -d examples/primitives run native   # opens a window (native is the default env)
 ./target/debug/functor -d examples/primitives run wasm      # serves the .fun + wasm at http://127.0.0.1:8080
+./target/debug/functor -d examples/primitives run vr        # runs it on an adb-attached headset (see runtime/functor-runtime-oculus/README.md), re-pushing on save
 ./target/debug/functor -d examples/primitives build [native|wasm]
 ./target/debug/functor -d examples/primitives develop [native|wasm]   # = run; Functor Lang hot-reload is built in
 ```

--- a/cli/src/commands/functor_lang_project.rs
+++ b/cli/src/commands/functor_lang_project.rs
@@ -452,17 +452,19 @@ with --debug-port (and --debug-bind 0.0.0.0 if remote)?"
         // The initial push, with retries: a cold app start needs a moment
         // to bind its endpoint. (The typecheck gate already ran — `run`
         // builds before dispatching, same as native/wasm.)
-        let files = read_project_files(&entry_path)?;
+        let files = read_project_json(&entry_path)?;
         let mut attempted = None;
         for _ in 0..20 {
             match post_reload_project(&addr, &files) {
                 Ok((200, body)) => {
                     emit(Event::Info { message: body });
-                    attempted = Some(serde_json::to_string(&files).unwrap_or_default());
+                    attempted = Some(files.clone());
                     break;
                 }
-                // The endpoint answered and said no — the project is the
-                // problem (shouldn't happen post-gate), not the transport.
+                // The endpoint answered and said no (400/413) — the project
+                // or protocol is the problem, not the transport. (A 503
+                // can't realistically arrive: the server's 30s reply
+                // timeout is far behind our 5s client read timeout.)
                 Ok((status, body)) => {
                     return Err(Error::other(format!("push rejected ({status}): {body}")))
                 }
@@ -490,10 +492,9 @@ is the functor VR runtime running? (`adb logcat -s functor` for its startup log)
             tokio::time::sleep(std::time::Duration::from_millis(300)).await;
             // Atomic-save editors briefly unlink files mid-save; wait for
             // the next poll rather than failing the loop.
-            let Ok(files) = read_project_files(&entry_path) else {
+            let Ok(current) = read_project_json(&entry_path) else {
                 continue;
             };
-            let current = serde_json::to_string(&files).unwrap_or_default();
             if current == attempted {
                 continue;
             }
@@ -507,7 +508,7 @@ is the functor VR runtime running? (`adb logcat -s functor` for its startup log)
                 attempted = current;
                 continue;
             }
-            match post_reload_project(&addr, &files) {
+            match post_reload_project(&addr, &current) {
                 Ok((200, body)) => {
                     emit(Event::Info { message: body });
                     attempted = current;
@@ -738,10 +739,29 @@ async fn adb_device() -> Result<String, Error> {
         .collect();
     match devices.as_slice() {
         [one] => Ok(one.clone()),
-        [] => Err(Error::other(
-            "no device attached (`adb devices` lists none) — connect the headset over USB \
-and accept its debugging prompt",
-        )),
+        [] => {
+            // The common first-connect states deserve their real diagnosis,
+            // not "none": `unauthorized` = the USB-debugging prompt hasn't
+            // been accepted; `offline` = a wedged connection.
+            let stuck = out.lines().find_map(|line| {
+                let mut fields = line.split_whitespace();
+                match (fields.next(), fields.next()) {
+                    (Some(serial), Some(state @ ("unauthorized" | "offline"))) => {
+                        Some(format!("{serial} is {state}"))
+                    }
+                    _ => None,
+                }
+            });
+            Err(Error::other(match stuck {
+                Some(stuck) => format!(
+                    "device attached but not ready ({stuck}) — put the headset on and \
+accept the USB-debugging prompt (unauthorized), or reconnect the cable (offline)"
+                ),
+                None => "no device attached (`adb devices` lists none) — connect the \
+headset over USB and accept its debugging prompt"
+                    .to_string(),
+            }))
+        }
         _ => Err(Error::other(
             "multiple devices attached — set ANDROID_SERIAL to pick one",
         )),
@@ -802,9 +822,11 @@ fn spawn_logcat(serial: &str) {
     });
 }
 
-/// The project's `.fun`/`.funi` files as `(file name, source)`, entry FIRST —
-/// the `reload_project` wire contract (`file = module`, so names are enough).
-fn read_project_files(entry_path: &Path) -> Result<Vec<(String, String)>, Error> {
+/// The project's `.fun`/`.funi` files as the `/reload-project` wire body — a
+/// JSON array of `[file name, source]` pairs, entry FIRST (`file = module`,
+/// so names are enough). Serialized once: the watch loop's change-compare
+/// and the POST body are the same string.
+fn read_project_json(entry_path: &Path) -> Result<String, Error> {
     let mut files = Vec::new();
     for path in functor_lang::project::project_files(entry_path)? {
         let name = path
@@ -814,14 +836,13 @@ fn read_project_files(entry_path: &Path) -> Result<Vec<(String, String)>, Error>
             .to_string();
         files.push((name, std::fs::read_to_string(&path)?));
     }
-    Ok(files)
+    serde_json::to_string(&files).map_err(Error::other)
 }
 
-/// POST the whole project file set to the runtime's `/reload-project` as a
-/// JSON array of `[path, source]` pairs.
-fn post_reload_project(addr: &str, files: &[(String, String)]) -> Result<(u16, String), Error> {
-    let body = serde_json::to_string(files).map_err(Error::other)?;
-    http_post(addr, "/reload-project", "application/json", &body)
+/// POST the whole project file set (the `read_project_json` body) to the
+/// runtime's `/reload-project`.
+fn post_reload_project(addr: &str, files_json: &str) -> Result<(u16, String), Error> {
+    http_post(addr, "/reload-project", "application/json", files_json)
 }
 
 /// Minimal HTTP POST over std::net — one dependency-free request to the

--- a/cli/src/commands/functor_lang_project.rs
+++ b/cli/src/commands/functor_lang_project.rs
@@ -301,6 +301,15 @@ impl FunctorLangProject {
         develop: bool,
     ) -> Result<(), Error> {
         refresh_manifest(working_directory);
+        if matches!(environment, Environment::Vr) {
+            if !runner_args.is_empty() {
+                emit(Event::Warning {
+                    message: "runner args are ignored on vr (they configure the desktop runtime)"
+                        .to_string(),
+                });
+            }
+            return self.run_vr(working_directory).await;
+        }
         if matches!(environment, Environment::Wasm) {
             return self.run_wasm(working_directory, runner_args, develop).await;
         }
@@ -418,6 +427,103 @@ with --debug-port (and --debug-bind 0.0.0.0 if remote)?"
                 }
             }
             tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        }
+    }
+
+    /// `run vr` / `develop vr`: run the game on an adb-attached headset
+    /// running the functor VR runtime (a tool APK built once — see
+    /// runtime/functor-runtime-oculus/README.md). One command: launch the
+    /// app, forward the push port, push the whole project, then keep
+    /// watching and re-pushing on save (hot reload is built in, like
+    /// native — `run` and `develop` are the same here too), streaming the
+    /// headset's runtime log into this terminal.
+    async fn run_vr(&self, working_directory: &str) -> Result<(), Error> {
+        let entry_path = self.entry_path(working_directory)?;
+        let serial = adb_device().await?;
+        adb_require_runtime(&serial).await?;
+        // `am start` on the running singleTask activity is a no-op resume —
+        // idempotent, so no need to check whether the app is already up.
+        adb_run(&serial, &["shell", "am", "start", "-n", VR_COMPONENT]).await?;
+        let forward = format!("tcp:{VR_PORT}");
+        adb_run(&serial, &["forward", &forward, &forward]).await?;
+        spawn_logcat(&serial);
+        let addr = format!("127.0.0.1:{VR_PORT}");
+
+        // The initial push, with retries: a cold app start needs a moment
+        // to bind its endpoint. (The typecheck gate already ran — `run`
+        // builds before dispatching, same as native/wasm.)
+        let files = read_project_files(&entry_path)?;
+        let mut attempted = None;
+        for _ in 0..20 {
+            match post_reload_project(&addr, &files) {
+                Ok((200, body)) => {
+                    emit(Event::Info { message: body });
+                    attempted = Some(serde_json::to_string(&files).unwrap_or_default());
+                    break;
+                }
+                // The endpoint answered and said no — the project is the
+                // problem (shouldn't happen post-gate), not the transport.
+                Ok((status, body)) => {
+                    return Err(Error::other(format!("push rejected ({status}): {body}")))
+                }
+                Err(_) => tokio::time::sleep(std::time::Duration::from_millis(500)).await,
+            }
+        }
+        let mut attempted = attempted.ok_or_else(|| {
+            Error::other(format!(
+                "cannot reach the headset's reload endpoint (http://{addr} via adb forward) — \
+is the functor VR runtime running? (`adb logcat -s functor` for its startup log)"
+            ))
+        })?;
+        emit(Event::Info {
+            message: format!(
+                "watching {} + siblings — edit and save to hot-reload on the headset \
+(Ctrl-C to stop)",
+                self.entry
+            ),
+        });
+
+        // The watch loop, shaped like `push --watch`: poll contents (not
+        // mtimes), track the last ATTEMPTED file set, and re-push the WHOLE
+        // set on any change (file = module — a sibling edit must ship too).
+        loop {
+            tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+            // Atomic-save editors briefly unlink files mid-save; wait for
+            // the next poll rather than failing the loop.
+            let Ok(files) = read_project_files(&entry_path) else {
+                continue;
+            };
+            let current = serde_json::to_string(&files).unwrap_or_default();
+            if current == attempted {
+                continue;
+            }
+            // The same check gate `run native` uses — structured file:line
+            // diagnostics beat the device's rendered 400 body, and a broken
+            // edit never leaves the machine.
+            if self.build(working_directory, false).is_err() {
+                emit(Event::Warning {
+                    message: "check failed — the headset keeps the previous program".to_string(),
+                });
+                attempted = current;
+                continue;
+            }
+            match post_reload_project(&addr, &files) {
+                Ok((200, body)) => {
+                    emit(Event::Info { message: body });
+                    attempted = current;
+                }
+                Ok((status, body)) => {
+                    emit(Event::Warning {
+                        message: format!("push rejected ({status}): {body}"),
+                    });
+                    attempted = current;
+                }
+                // Transport failure (cable out, app restarting): leave
+                // `attempted` alone so the same content retries next poll.
+                Err(e) => emit(Event::Warning {
+                    message: format!("push failed ({e}); retrying…"),
+                }),
+            }
         }
     }
 
@@ -576,10 +682,161 @@ fn refresh_manifest(working_directory: &str) {
     }
 }
 
+// --- `run vr` plumbing -------------------------------------------------------
+
+/// The functor VR runtime tool APK (runtime/functor-runtime-oculus).
+const VR_PACKAGE: &str = "dev.functor.runner";
+const VR_COMPONENT: &str = "dev.functor.runner/android.app.NativeActivity";
+/// Its device-loopback push port (`adb forward` bridges it to this machine).
+const VR_PORT: u16 = 8123;
+
+/// Run one adb command to completion; stdout on success, a rendered error
+/// (including the "adb isn't installed" case) otherwise.
+async fn adb_output(serial: Option<&str>, args: &[&str]) -> Result<String, Error> {
+    let mut cmd = tokio::process::Command::new("adb");
+    if let Some(serial) = serial {
+        cmd.args(["-s", serial]);
+    }
+    cmd.args(args);
+    let out = cmd.output().await.map_err(|e| {
+        Error::other(format!(
+            "cannot run adb ({e}) — install Android platform-tools and ensure `adb` is on PATH"
+        ))
+    })?;
+    if !out.status.success() {
+        return Err(Error::other(format!(
+            "adb {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&out.stderr).trim()
+        )));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+/// adb, success/failure only.
+async fn adb_run(serial: &str, args: &[&str]) -> Result<(), Error> {
+    adb_output(Some(serial), args).await.map(|_| ())
+}
+
+/// The attached device's serial: `ANDROID_SERIAL` when set (adb's own
+/// convention), else the single `adb devices` entry — zero or several is an
+/// error with the fix in the message.
+async fn adb_device() -> Result<String, Error> {
+    if let Ok(serial) = std::env::var("ANDROID_SERIAL") {
+        return Ok(serial);
+    }
+    let out = adb_output(None, &["devices"]).await?;
+    let devices: Vec<String> = out
+        .lines()
+        .filter_map(|line| {
+            let mut fields = line.split_whitespace();
+            match (fields.next(), fields.next()) {
+                (Some(serial), Some("device")) => Some(serial.to_string()),
+                _ => None,
+            }
+        })
+        .collect();
+    match devices.as_slice() {
+        [one] => Ok(one.clone()),
+        [] => Err(Error::other(
+            "no device attached (`adb devices` lists none) — connect the headset over USB \
+and accept its debugging prompt",
+        )),
+        _ => Err(Error::other(
+            "multiple devices attached — set ANDROID_SERIAL to pick one",
+        )),
+    }
+}
+
+/// The tool APK ships separately from games (games are text, pushed live) —
+/// require it up front with the install pointer, instead of a connection
+/// error after launch.
+async fn adb_require_runtime(serial: &str) -> Result<(), Error> {
+    let out = adb_output(Some(serial), &["shell", "pm", "list", "packages", VR_PACKAGE]).await?;
+    let installed = out
+        .lines()
+        .any(|line| line.trim() == format!("package:{VR_PACKAGE}"));
+    if installed {
+        Ok(())
+    } else {
+        Err(Error::other(format!(
+            "the functor VR runtime isn't installed on {serial} — build + install the tool APK \
+(see runtime/functor-runtime-oculus/README.md): npm run build:oculus:apk && \
+adb install -r target-android/debug/apk/functor_runtime_oculus.apk"
+        )))
+    }
+}
+
+/// Stream the headset's runtime log (`adb logcat -s functor`) into the CLI's
+/// event stream, so on-device `[functor-lang]` errors and `Debug.log` traces read
+/// like `run native`'s console. `-T 1` starts at now (no history replay).
+fn spawn_logcat(serial: &str) {
+    let serial = serial.to_string();
+    tokio::spawn(async move {
+        use tokio::io::AsyncBufReadExt;
+        let mut cmd = tokio::process::Command::new("adb");
+        cmd.args(["-s", &serial, "logcat", "-T", "1", "-v", "brief", "-s", "functor"])
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .kill_on_drop(true);
+        let Ok(mut child) = cmd.spawn() else {
+            emit(Event::Warning {
+                message: "cannot stream the headset log (adb logcat failed to start)".to_string(),
+            });
+            return;
+        };
+        let Some(stdout) = child.stdout.take() else {
+            return;
+        };
+        let mut lines = tokio::io::BufReader::new(stdout).lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            // brief format: `I/functor (12345): <message>` — keep the
+            // message, drop the logcat framing (separator lines have no
+            // "): " and are skipped).
+            if let Some((_, message)) = line.split_once("): ") {
+                emit(Event::Info {
+                    message: format!("headset: {message}"),
+                });
+            }
+        }
+    });
+}
+
+/// The project's `.fun`/`.funi` files as `(file name, source)`, entry FIRST —
+/// the `reload_project` wire contract (`file = module`, so names are enough).
+fn read_project_files(entry_path: &Path) -> Result<Vec<(String, String)>, Error> {
+    let mut files = Vec::new();
+    for path in functor_lang::project::project_files(entry_path)? {
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .ok_or_else(|| Error::other(format!("non-UTF8 file name: {}", path.display())))?
+            .to_string();
+        files.push((name, std::fs::read_to_string(&path)?));
+    }
+    Ok(files)
+}
+
+/// POST the whole project file set to the runtime's `/reload-project` as a
+/// JSON array of `[path, source]` pairs.
+fn post_reload_project(addr: &str, files: &[(String, String)]) -> Result<(u16, String), Error> {
+    let body = serde_json::to_string(files).map_err(Error::other)?;
+    http_post(addr, "/reload-project", "application/json", &body)
+}
+
 /// Minimal HTTP POST over std::net — one dependency-free request to the
 /// runner's tiny_http server. Returns (status, body). `Connection: close`
 /// keeps the read side trivial (read to EOF, split headers off).
 fn post_reload_source(addr: &str, source: &str) -> Result<(u16, String), Error> {
+    http_post(addr, "/reload-source", "text/plain", source)
+}
+
+fn http_post(
+    addr: &str,
+    path: &str,
+    content_type: &str,
+    body: &str,
+) -> Result<(u16, String), Error> {
     use std::io::{Read, Write};
     use std::net::ToSocketAddrs;
     let timeout = std::time::Duration::from_secs(5);
@@ -594,11 +851,11 @@ fn post_reload_source(addr: &str, source: &str) -> Result<(u16, String), Error> 
     stream.set_write_timeout(Some(timeout))?;
     write!(
         stream,
-        "POST /reload-source HTTP/1.1\r\nHost: {addr}\r\nContent-Type: text/plain\r\n\
+        "POST {path} HTTP/1.1\r\nHost: {addr}\r\nContent-Type: {content_type}\r\n\
 Content-Length: {}\r\nConnection: close\r\n\r\n",
-        source.len()
+        body.len()
     )?;
-    stream.write_all(source.as_bytes())?;
+    stream.write_all(body.as_bytes())?;
     let mut response = String::new();
     stream.read_to_string(&mut response)?;
     let status = response

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -66,6 +66,9 @@ struct Args {
 enum Environment {
     Wasm,
     Native,
+    /// A headset running the functor VR runtime APK, attached over adb —
+    /// launches the app, pushes the project, and re-pushes on save.
+    Vr,
 }
 
 impl Environment {
@@ -77,6 +80,7 @@ impl Environment {
         match self {
             Environment::Wasm => "wasm",
             Environment::Native => "native",
+            Environment::Vr => "vr",
         }
     }
 }
@@ -97,7 +101,8 @@ enum Command {
         environment: Option<Environment>,
     },
     /// Run the game (default `native`, an OpenGL window; `wasm` serves a dev
-    /// server). E.g. `functor -d examples/primitives run native`.
+    /// server; `vr` runs it on an adb-attached headset, re-pushing on save).
+    /// E.g. `functor -d examples/primitives run native`.
     Run {
         #[arg(value_enum)]
         environment: Option<Environment>,

--- a/runtime/functor-runtime-oculus/Cargo.toml
+++ b/runtime/functor-runtime-oculus/Cargo.toml
@@ -35,6 +35,8 @@ glow = "0.17"
 cgmath = "0.18"
 log = "0.4"
 android_logger = "0.14"
+# The /reload-project wire body: a JSON array of (path, source) pairs.
+serde_json = "1.0"
 
 # cargo-apk packaging metadata (`cargo apk build` from this directory).
 # functor-runner-on-Quest is a tool APK, like functor-runner is a binary: the

--- a/runtime/functor-runtime-oculus/README.md
+++ b/runtime/functor-runtime-oculus/README.md
@@ -22,15 +22,19 @@ binding keeps the LAN out; note another app ON the device could reach
 loopback — an accepted dev-tool tradeoff):
 
 ```sh
-adb forward tcp:8123 tcp:8123
-functor -d mygame push 127.0.0.1:8123          # push once
-functor -d mygame push 127.0.0.1:8123 --watch  # push on every save
+functor -d mygame run vr    # the whole loop, one command
 ```
 
-(`functor push` is the desktop remote-develop command — the Quest endpoint
-speaks the same protocol, verified at ~12ms per push. Raw HTTP works too:
-`curl --fail-with-body -X POST --data-binary @game.fun
-http://127.0.0.1:8123/reload-source`.)
+`run vr` finds the adb device, launches this APK, forwards the port, pushes
+the whole project (`POST /reload-project` — sibling modules included), then
+re-checks + re-pushes on every save while streaming the headset's runtime
+log into the terminal. The pieces also work individually:
+
+```sh
+adb forward tcp:8123 tcp:8123
+functor -d mygame push 127.0.0.1:8123 [--watch]   # entry-only push (desktop remote-develop command)
+curl --fail-with-body -X POST --data-binary @game.fun http://127.0.0.1:8123/reload-source
+```
 
 Semantics match desktop hot-reload: the **model is preserved** (closures
 stored in the model rebind by def-name), a broken push returns the rendered

--- a/runtime/functor-runtime-oculus/src/lib.rs
+++ b/runtime/functor-runtime-oculus/src/lib.rs
@@ -542,8 +542,12 @@ pub fn android_main(app: AndroidApp) {
         // GL/XR to swap programs, so a push lands even while the headset
         // dozes (session IDLE) — it shows the moment the session resumes.
         if let Some(rx) = &reload_rx {
-            while let Ok((source, resp)) = rx.try_recv() {
-                let _ = resp.send(game.reload_source(&source));
+            while let Ok((body, resp)) = rx.try_recv() {
+                let result = match body {
+                    reload_server::ReloadBody::Source(source) => game.reload_source(&source),
+                    reload_server::ReloadBody::Project(files) => game.reload_project(&files),
+                };
+                let _ = resp.send(result);
             }
         }
 

--- a/runtime/functor-runtime-oculus/src/reload_server.rs
+++ b/runtime/functor-runtime-oculus/src/reload_server.rs
@@ -26,8 +26,19 @@ use std::net::{TcpListener, TcpStream};
 use std::sync::mpsc;
 use std::time::Duration;
 
-/// A pushed source body and the channel the frame loop answers on.
-pub type ReloadRequest = (String, mpsc::Sender<Result<String, String>>);
+/// What a push carries.
+pub enum ReloadBody {
+    /// A single pushed entry (`POST /reload-source`) — siblings keep their
+    /// last-pushed text.
+    Source(String),
+    /// A whole-project push (`POST /reload-project`): every file as
+    /// `(path, source)`, entry FIRST — the producer's `reload_project`
+    /// contract. The wire body is a JSON array of pairs.
+    Project(Vec<(String, String)>),
+}
+
+/// A pushed body and the channel the frame loop answers on.
+pub type ReloadRequest = (ReloadBody, mpsc::Sender<Result<String, String>>);
 
 /// Game source is KBs; an unbounded read is an OOM invitation (the desktop
 /// endpoint's bound).
@@ -122,7 +133,7 @@ fn handle(mut stream: TcpStream, tx: &mpsc::Sender<ReloadRequest>) -> Option<()>
     }
 
     match (method, path) {
-        ("POST", "/reload-source") => {
+        ("POST", "/reload-source") | ("POST", "/reload-project") => {
             // Bound the body; chunked bodies (no declared length) are
             // rejected the same way (the desktop endpoint's rule).
             let len = match content_length {
@@ -147,8 +158,27 @@ fn handle(mut stream: TcpStream, tx: &mpsc::Sender<ReloadRequest>) -> Option<()>
                 respond(&mut stream, 400, "Bad Request", "bad body");
                 return Some(());
             }
+            let reload = if path == "/reload-project" {
+                // The whole file set as a JSON array of (path, source)
+                // pairs, entry first. A malformed body is the pusher's
+                // mistake — reject before bothering the frame loop.
+                match serde_json::from_str::<Vec<(String, String)>>(&body) {
+                    Ok(files) => ReloadBody::Project(files),
+                    Err(error) => {
+                        respond(
+                            &mut stream,
+                            400,
+                            "Bad Request",
+                            &format!("body must be a JSON array of [path, source] pairs: {error}"),
+                        );
+                        return Some(());
+                    }
+                }
+            } else {
+                ReloadBody::Source(body)
+            };
             let (resp_tx, resp_rx) = mpsc::channel();
-            tx.send((body, resp_tx)).ok()?;
+            tx.send((reload, resp_tx)).ok()?;
             match resp_rx.recv_timeout(RELOAD_REPLY_TIMEOUT) {
                 Ok(Ok(status)) => respond(&mut stream, 200, "OK", &status),
                 // A load error in the pushed source — the pusher's mistake,
@@ -171,7 +201,7 @@ fn handle(mut stream: TcpStream, tx: &mpsc::Sender<ReloadRequest>) -> Option<()>
                 &mut stream,
                 200,
                 "OK",
-                "{\"service\":\"functor quest runtime\",\"endpoints\":[\"POST /reload-source\"]}",
+                "{\"service\":\"functor quest runtime\",\"endpoints\":[\"POST /reload-source\",\"POST /reload-project\"]}",
             );
         }
         _ => respond(&mut stream, 404, "Not Found", "unknown endpoint"),


### PR DESCRIPTION
> Stacked on #430 (reload endpoint). Closes the `run native` / `run wasm` / **`run vr`** symmetry.

## What

```sh
functor -d mygame run vr
```

One command: find the adb device (`ANDROID_SERIAL` respected; clear errors for missing adb / no device / several devices / APK not installed), launch the VR runtime, `adb forward` the push port, **push the whole project**, then re-check + re-push on every save — with the headset's runtime log streamed into the terminal through the CLI event stream, so on-device `[functor-lang]` errors and `Debug.log` traces read exactly like `run native`. (`develop vr` = same, matching `develop = run` everywhere else.)

Two supporting pieces:

- **`POST /reload-project` on the device endpoint** — a JSON array of `[path, source]` pairs, entry first (the producer's `reload_project` contract; same 4MB bound and status semantics as `/reload-source`). The CLI pushes the `project_files` set, so **editing a sibling module hot-reloads too** (`functor push` was entry-only).
- **The local typecheck gate on every re-push** (the same gate `run native` uses): a broken edit gets caret diagnostics in the terminal and never leaves the machine — "the headset keeps the previous program".

## Verified end-to-end (Quest 3, two-file project)

```
▸ run …/vr-e2e (vr)
✓ checked game.fun (+24 modules)
headset: functor_runtime_oculus: functor oculus runtime starting
headset: … session state: READY
reloaded game.fun (2 file(s)) from pushed project in 8.19ms (model preserved)
watching game.fun + siblings — edit and save to hot-reload on the headset (Ctrl-C to stop)
headset: … session state: FOCUSED
```

Editing the **sibling** `palette.fun` (sky color) re-pushed in 11.53ms and the headset changed in the next screencap:

| before sibling edit | after (palette.fun saved) |
| --- | --- |
| ![before](https://gist.githubusercontent.com/tommy-xr/9a17568bb0c2b979d170bc3b0be79b1d/raw/defbf779c6f1a24615efb19d4f2097c9604113f4/vr-e2e-t0.png) | ![after](https://gist.githubusercontent.com/tommy-xr/9a17568bb0c2b979d170bc3b0be79b1d/raw/35ea224d69267fdc79f44efde42bb712d70429e9/vr-e2e-t1.png) |

A broken sibling (`Color.wrong`) was rejected by the local gate (caret diagnostic + "check failed — the headset keeps the previous program", nothing pushed); the fix re-pushed in 11.91ms.

Known limitation (documented): no asset host on the device yet — primitives-only games until asset sync (M3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)