### PR TITLE
fix(lang): deep values can't crash in-process tooling — iterative walks + an enforced depth≤budget contract

### DIFF
--- a/functor-lang/src/eval.rs
+++ b/functor-lang/src/eval.rs
@@ -440,6 +440,16 @@ pub fn run_expects(
 /// hot path branch-free. Total interpreter work is O(budget), so the budget
 /// bounds wall-clock up to the per-step constant; pick it accordingly
 /// (~10^6 is comfortably sub-second).
+///
+/// STACK CONTRACT for in-process embedding (the LSP / wasm IDE seam): a
+/// budgeted run cannot build a value nested deeper than `budget` levels (each
+/// level costs ≥ 1 step), but DROPPING a value that deep recurses to its
+/// depth (`Value` deliberately has no iterative Drop — one was measured at
+/// ~2x frame_bench). Run this on a worker thread whose stack covers the
+/// budget — ~100 bytes per level, so `budget * 100` bytes reserved (e.g.
+/// `std::thread::Builder::stack_size(256 << 20)` comfortably covers a 10^6
+/// budget; reserved virtual stack commits lazily). Rendering and comparison
+/// are depth-safe regardless (`Display`/`value_eq` are iterative).
 pub fn run_expects_budgeted(
     module: &Module,
     host: &mut dyn Host,
@@ -644,14 +654,16 @@ impl Session {
 /// A step budget for bounded evaluation ([`run_expects_budgeted`] — the live
 /// tooling seam: an editor evaluating on every edit must not hang on a
 /// runaway expect). A step is one function CALL (closures, builtins, ctors —
-/// [`Interp::call`]), or one element/byte a bulk builtin materializes or
-/// scans (`List.range`'s count; `List.append`/`flatten` output elements;
+/// [`Interp::call`]), one container CONSTRUCTED (list/tuple/record literals
+/// and updates — what makes value depth ≤ budget, the stack contract's
+/// arithmetic), or one element/byte a bulk builtin materializes or scans
+/// (`List.range`'s count; `List.append`/`flatten` output elements;
 /// `Text.concat`/`join`/`toBullets` output bytes; `reverse`/`maximum`/
 /// `split` input size). Charging GROWTH builtins by output is what makes
 /// the budget honest — `(x) => List.append(x, x)` doubles per call, so a
 /// per-call-only charge would allow exponential work under a linear budget.
-/// The per-node eval path is deliberately uncharged so the frame loop stays
-/// branch-free. `limit` is kept for the error message.
+/// The general per-node eval path is deliberately uncharged so the frame
+/// loop stays branch-free. `limit` is kept for the error message.
 #[derive(Clone, Copy)]
 struct Fuel {
     remaining: u64,
@@ -896,7 +908,14 @@ evaluation depth."
                     }),
                 }
             }
+            // Container CONSTRUCTION charges one step (the depth invariant
+            // behind run_expects_budgeted's stack contract: every level of a
+            // value's nesting was constructed once, so value depth ≤ budget.
+            // Without this, a nested literal in a fold body builds up to
+            // MAX_EVAL_DEPTH levels per single call charge). `fuel: None`
+            // (every game-loop path) makes each a one-branch no-op.
             ExprKind::Record(fields) => {
+                self.charge(1, expr.span)?;
                 let mut out = Vec::with_capacity(fields.len());
                 for field in fields {
                     out.push((field.name.clone(), self.eval(&field.value, env)?));
@@ -904,6 +923,7 @@ evaluation depth."
                 Ok(Value::Record(Rc::new(out)))
             }
             ExprKind::Tuple(items) => {
+                self.charge(1, expr.span)?;
                 let mut values = Vec::with_capacity(items.len());
                 for item in items {
                     values.push(self.eval(item, env)?);
@@ -911,6 +931,7 @@ evaluation depth."
                 Ok(Value::Tuple(Rc::new(values)))
             }
             ExprKind::List(items) => {
+                self.charge(1, expr.span)?;
                 let mut out = Vec::with_capacity(items.len());
                 for item in items {
                     out.push(self.eval(item, env)?);
@@ -918,6 +939,7 @@ evaluation depth."
                 Ok(Value::List(Rc::new(out)))
             }
             ExprKind::ListCons { items, tail } => {
+                self.charge(1, expr.span)?;
                 let mut out = Vec::with_capacity(items.len());
                 for item in items {
                     out.push(self.eval(item, env)?);
@@ -937,6 +959,7 @@ evaluation depth."
                 }
             }
             ExprKind::RecordUpdate { base, fields } => {
+                self.charge(1, expr.span)?;
                 let base_value = self.eval(base, env)?;
                 let Value::Record(base_fields) = &base_value else {
                     return Err(RunError {
@@ -2093,90 +2116,103 @@ fn pattern_binder_sites<'a>(pattern: &'a Pattern, out: &mut Vec<(BindingId, &'a 
 /// against the step budget, since a single `==` on a large value is O(size)
 /// work that no call-path charge sees (review probe: repeated big-list
 /// compares did ~9x10^8 uncharged comparisons under a 10^6 budget).
+/// Iterative (explicit pair worklist), NOT recursive: value depth is
+/// user-controlled (an iteratively-built `[acc]` nest goes far past any
+/// recursion limit), and this runs inside editor/tooling processes where a
+/// stack overflow is a host crash. Pairs push in reverse so comparison
+/// order stays left-to-right (first mismatch/error is the leftmost).
 fn value_eq(a: &Value, b: &Value, span: Span, compared: &mut u64) -> Result<bool, RunError> {
-    *compared += 1;
-    match (a, b) {
-        (Value::Number(x), Value::Number(y)) => Ok(x == y),
-        (Value::String(x), Value::String(y)) => Ok(x == y),
-        (Value::Bool(x), Value::Bool(y)) => Ok(x == y),
-        (Value::List(xs), Value::List(ys)) => {
-            if xs.len() != ys.len() {
-                return Ok(false);
-            }
-            for (x, y) in xs.iter().zip(ys.iter()) {
-                if !value_eq(x, y, span, compared)? {
-                    return Ok(false);
-                }
-            }
-            Ok(true)
-        }
-        // Structural, element-wise; arity difference is simply unequal.
-        (Value::Tuple(xs), Value::Tuple(ys)) => {
-            if xs.len() != ys.len() {
-                return Ok(false);
-            }
-            for (x, y) in xs.iter().zip(ys.iter()) {
-                if !value_eq(x, y, span, compared)? {
-                    return Ok(false);
-                }
-            }
-            Ok(true)
-        }
-        (Value::Record(xs), Value::Record(ys)) => {
-            if xs.len() != ys.len() {
-                return Ok(false);
-            }
-            for (name, x) in xs.iter() {
-                match ys.iter().find(|(n, _)| n == name) {
-                    Some((_, y)) if value_eq(x, y, span, compared)? => {}
-                    _ => return Ok(false),
-                }
-            }
-            Ok(true)
-        }
-        // Structural: same constructor, equal args (a function argument
-        // still raises the function-comparison error below).
-        (Value::Variant { ctor: xc, args: xs }, Value::Variant { ctor: yc, args: ys }) => {
-            if xc != yc || xs.len() != ys.len() {
-                return Ok(false);
-            }
-            for (x, y) in xs.iter().zip(ys.iter()) {
-                if !value_eq(x, y, span, compared)? {
-                    return Ok(false);
-                }
-            }
-            Ok(true)
-        }
-        // An unapplied constructor is a function value — no equality.
-        (
-            Value::Closure(_)
-            | Value::Partial(_)
-            | Value::Builtin(_)
-            | Value::HostFn(_)
-            | Value::Ctor { .. },
-            _,
-        )
-        | (
-            _,
-            Value::Closure(_)
-            | Value::Partial(_)
-            | Value::Builtin(_)
-            | Value::HostFn(_)
-            | Value::Ctor { .. },
-        ) => {
-            Err(RunError {
-                message: "functions cannot be compared with `==`".to_string(),
-                span,
-            })
-        }
-        (Value::HostData(_), _) | (_, Value::HostData(_)) => Err(RunError {
-            message: "host values cannot be compared with `==`".to_string(),
-            span,
-        }),
-        // Different kinds are simply unequal (structural, not typed — B4 adds
-        // the typechecker that would reject this statically).
-        _ => Ok(false),
+    /// Pending work. `MissingField` stands in for a record field whose name
+    /// the other record lacks — pushed IN POSITION so the not-equal verdict
+    /// lands in field order (an earlier field's function-comparison error
+    /// still fires first, exactly like the old interleaved walk).
+    enum Work<'a> {
+        Pair(&'a Value, &'a Value),
+        MissingField,
     }
+    let mut work: Vec<Work> = vec![Work::Pair(a, b)];
+    while let Some(item) = work.pop() {
+        let (a, b) = match item {
+            Work::Pair(a, b) => (a, b),
+            Work::MissingField => return Ok(false),
+        };
+        *compared += 1;
+        match (a, b) {
+            (Value::Number(x), Value::Number(y)) => {
+                if x != y {
+                    return Ok(false);
+                }
+            }
+            (Value::String(x), Value::String(y)) => {
+                if x != y {
+                    return Ok(false);
+                }
+            }
+            (Value::Bool(x), Value::Bool(y)) => {
+                if x != y {
+                    return Ok(false);
+                }
+            }
+            // Structural, element-wise; arity difference is simply unequal.
+            (Value::List(xs), Value::List(ys)) | (Value::Tuple(xs), Value::Tuple(ys)) => {
+                if xs.len() != ys.len() {
+                    return Ok(false);
+                }
+                work.extend(xs.iter().zip(ys.iter()).rev().map(|(x, y)| Work::Pair(x, y)));
+            }
+            (Value::Record(xs), Value::Record(ys)) => {
+                if xs.len() != ys.len() {
+                    return Ok(false);
+                }
+                for (name, x) in xs.iter().rev() {
+                    match ys.iter().find(|(n, _)| n == name) {
+                        Some((_, y)) => work.push(Work::Pair(x, y)),
+                        None => work.push(Work::MissingField),
+                    }
+                }
+            }
+            // Structural: same constructor, equal args (a function argument
+            // still raises the function-comparison error below).
+            (Value::Variant { ctor: xc, args: xs }, Value::Variant { ctor: yc, args: ys }) => {
+                if xc != yc || xs.len() != ys.len() {
+                    return Ok(false);
+                }
+                work.extend(xs.iter().zip(ys.iter()).rev().map(|(x, y)| Work::Pair(x, y)));
+            }
+            // An unapplied constructor is a function value — no equality.
+            (
+                Value::Closure(_)
+                | Value::Partial(_)
+                | Value::Builtin(_)
+                | Value::HostFn(_)
+                | Value::Ctor { .. },
+                _,
+            )
+            | (
+                _,
+                Value::Closure(_)
+                | Value::Partial(_)
+                | Value::Builtin(_)
+                | Value::HostFn(_)
+                | Value::Ctor { .. },
+            ) => {
+                return Err(RunError {
+                    message: "functions cannot be compared with `==`".to_string(),
+                    span,
+                })
+            }
+            (Value::HostData(_), _) | (_, Value::HostData(_)) => {
+                return Err(RunError {
+                    message: "host values cannot be compared with `==`".to_string(),
+                    span,
+                })
+            }
+            // Different kinds are simply unequal (structural, not typed — B4
+            // adds the typechecker that would reject this statically).
+            _ => return Ok(false),
+        }
+    }
+    Ok(true)
 }
 
 /// The trace label for a call site, from its callee's IR shape. Also used by
@@ -2500,6 +2536,48 @@ pub fn render_trace(events: &[TraceEvent]) -> String {
         }
     }
     out
+}
+
+#[cfg(test)]
+mod deep_value_tests {
+    use super::{value_eq, Span, Value};
+    use std::rc::Rc;
+
+    /// A list nested `depth` levels: `[[…[0]…]]`.
+    fn nest(depth: usize) -> Value {
+        let mut v = Value::Number(0.0);
+        for _ in 0..depth {
+            v = Value::List(Rc::new(vec![v]));
+        }
+        v
+    }
+
+    /// Display and value_eq must be ITERATIVE: on a deliberately SMALL stack
+    /// (512KB), walking a 200k-deep value recursively would overflow (~100 B
+    /// per frame ⇒ ~20MB), while the worklist versions stay flat. The built
+    /// values are `mem::forget`-leaked because `Value`'s drop glue IS
+    /// recursive by design (see the NOTE in `value.rs` and the stack
+    /// contract on `run_expects_budgeted`) — this pin is exactly about the
+    /// walks that must NOT share that constraint.
+    #[test]
+    fn display_and_eq_are_depth_safe_on_a_small_stack() {
+        std::thread::Builder::new()
+            .stack_size(512 * 1024)
+            .spawn(|| {
+                let deep = nest(200_000);
+                let text = deep.to_string();
+                assert!(text.starts_with("[[[[") && text.len() > 400_000);
+                let mut compared = 0u64;
+                let same = value_eq(&deep, &deep.clone(), Span::new(0, 0), &mut compared)
+                    .expect("comparable");
+                assert!(same);
+                assert!(compared > 200_000);
+                std::mem::forget(deep);
+            })
+            .expect("spawn small-stack worker")
+            .join()
+            .expect("deep display/eq must complete on a small stack");
+    }
 }
 
 #[cfg(test)]

--- a/functor-lang/src/value.rs
+++ b/functor-lang/src/value.rs
@@ -233,87 +233,121 @@ impl Value {
     }
 }
 
+// NOTE on deep values and the native stack: `Value` deliberately has NO
+// manual `Drop` — an iterative-teardown Drop was built and measured at ~2x
+// frame_bench wall-clock (every dying container paid worklist/TLS churn that
+// compiled drop glue does for free), so dropping a deeply nested value
+// (an iteratively-built `[acc]` fold nest) still recurses to the value's
+// depth, like any Rust tree. Bounded evaluation makes this safe by
+// arithmetic instead: a budgeted run cannot BUILD a value deeper than its
+// step budget, so tooling that evaluates user code in-process runs it on a
+// worker thread whose stack scales with the budget (~100 bytes/level — see
+// `run_expects_budgeted`). `Display` and `value_eq` are iterative, so
+// rendering/comparing a deep value is depth-safe everywhere.
+
 impl fmt::Display for Value {
+    /// Iterative (explicit work stack), NOT recursive: a value's nesting
+    /// depth is user-controlled (a fold wrapping `[acc]` per step builds
+    /// depth far past any recursion limit for one budget-charge per level),
+    /// and rendering runs inside editor/tooling processes where a stack
+    /// overflow is a host crash, not an error. Output is byte-identical to
+    /// the old recursive rendering (pinned by the run/trace goldens).
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Value::Number(n) => write!(f, "{n}"),
-            Value::String(s) => write!(f, "{s:?}"),
-            Value::Bool(b) => write!(f, "{b}"),
-            Value::Tuple(items) => {
-                write!(f, "(")?;
-                for (i, item) in items.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, ", ")?;
-                    }
-                    write!(f, "{item}")?;
-                }
-                write!(f, ")")
-            }
-            Value::List(items) => {
-                write!(f, "[")?;
-                for (i, item) in items.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, ", ")?;
-                    }
-                    write!(f, "{item}")?;
-                }
-                write!(f, "]")
-            }
-            Value::Record(fields) => {
-                write!(f, "{{ ")?;
-                for (i, (name, value)) in fields.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, ", ")?;
-                    }
-                    write!(f, "{name}: {value}")?;
-                }
-                write!(f, " }}")
-            }
-            Value::Variant { ctor, args } => {
-                write!(f, "{ctor}")?;
-                if args.is_empty() {
-                    return Ok(());
-                }
-                write!(f, "(")?;
-                for (i, arg) in args.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, ", ")?;
-                    }
-                    write!(f, "{arg}")?;
-                }
-                write!(f, ")")
-            }
-            Value::Ctor { name, .. } => write!(f, "<ctor {name}>"),
-            Value::Closure(closure) => {
-                write!(f, "<fn(")?;
-                for (i, param) in closure.params.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, ", ")?;
-                    }
-                    write!(f, "{}", param.name)?;
-                }
-                write!(f, ")>")
-            }
-            Value::Partial(p) => {
-                // How many args are still needed, derived live from the
-                // callee's arity (a Partial's callee is always a closure,
-                // ctor, or builtin — see [`Partial`]).
-                let arity = match &p.callee {
-                    Value::Closure(c) => c.params.len(),
-                    Value::Ctor { arity, .. } => *arity,
-                    Value::Builtin(b) => crate::eval::builtin_arity(*b),
-                    _ => p.applied.len(),
-                };
-                write!(
-                    f,
-                    "<partial {} more>",
-                    arity.saturating_sub(p.applied.len())
-                )
-            }
-            Value::Builtin(b) => write!(f, "<builtin {}>", builtin_name(*b)),
-            Value::HostFn(path) => write!(f, "<host {path}>"),
-            Value::HostData(data) => write!(f, "<{}>", data.type_name()),
+        /// Pending work: a value to render, or literal text (separators,
+        /// closers, field names — all borrowed from `self` or 'static).
+        enum Tok<'a> {
+            Val(&'a Value),
+            Text(&'a str),
         }
+        let mut stack: Vec<Tok> = vec![Tok::Val(self)];
+        while let Some(tok) = stack.pop() {
+            let value = match tok {
+                Tok::Text(s) => {
+                    f.write_str(s)?;
+                    continue;
+                }
+                Tok::Val(value) => value,
+            };
+            match value {
+                Value::Number(n) => write!(f, "{n}")?,
+                Value::String(s) => write!(f, "{s:?}")?,
+                Value::Bool(b) => write!(f, "{b}")?,
+                // Sequences push their parts in REVERSE (the stack pops
+                // last-in-first), so text still emits left-to-right.
+                Value::Tuple(items) => {
+                    f.write_str("(")?;
+                    stack.push(Tok::Text(")"));
+                    for (i, item) in items.iter().enumerate().rev() {
+                        stack.push(Tok::Val(item));
+                        if i > 0 {
+                            stack.push(Tok::Text(", "));
+                        }
+                    }
+                }
+                Value::List(items) => {
+                    f.write_str("[")?;
+                    stack.push(Tok::Text("]"));
+                    for (i, item) in items.iter().enumerate().rev() {
+                        stack.push(Tok::Val(item));
+                        if i > 0 {
+                            stack.push(Tok::Text(", "));
+                        }
+                    }
+                }
+                Value::Record(fields) => {
+                    f.write_str("{ ")?;
+                    stack.push(Tok::Text(" }"));
+                    for (i, (name, value)) in fields.iter().enumerate().rev() {
+                        stack.push(Tok::Val(value));
+                        stack.push(Tok::Text(": "));
+                        stack.push(Tok::Text(name));
+                        if i > 0 {
+                            stack.push(Tok::Text(", "));
+                        }
+                    }
+                }
+                Value::Variant { ctor, args } => {
+                    write!(f, "{ctor}")?;
+                    if !args.is_empty() {
+                        f.write_str("(")?;
+                        stack.push(Tok::Text(")"));
+                        for (i, arg) in args.iter().enumerate().rev() {
+                            stack.push(Tok::Val(arg));
+                            if i > 0 {
+                                stack.push(Tok::Text(", "));
+                            }
+                        }
+                    }
+                }
+                Value::Ctor { name, .. } => write!(f, "<ctor {name}>")?,
+                Value::Closure(closure) => {
+                    write!(f, "<fn(")?;
+                    for (i, param) in closure.params.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, ", ")?;
+                        }
+                        write!(f, "{}", param.name)?;
+                    }
+                    write!(f, ")>")?
+                }
+                Value::Partial(p) => {
+                    // How many args are still needed, derived live from the
+                    // callee's arity (a Partial's callee is always a closure,
+                    // ctor, or builtin — see [`Partial`]).
+                    let arity = match &p.callee {
+                        Value::Closure(c) => c.params.len(),
+                        Value::Ctor { arity, .. } => *arity,
+                        Value::Builtin(b) => crate::eval::builtin_arity(*b),
+                        _ => p.applied.len(),
+                    };
+                    write!(f, "<partial {} more>", arity.saturating_sub(p.applied.len()))?
+                }
+                Value::Builtin(b) => write!(f, "<builtin {}>", builtin_name(*b))?,
+                Value::HostFn(path) => write!(f, "<host {path}>")?,
+                Value::HostData(data) => write!(f, "<{}>", data.type_name())?,
+            }
+        }
+        Ok(())
     }
 }
 

--- a/functor-lang/tests/expects.rs
+++ b/functor-lang/tests/expects.rs
@@ -256,6 +256,22 @@ fn text_join_doubling_cannot_amplify_past_the_budget() {
 }
 
 #[test]
+fn container_construction_is_charged() {
+    // The depth-amplifier probe: a fold whose body is a NESTED LITERAL adds
+    // ~5 levels of value depth per single call charge — under per-call-only
+    // charging this passes a 4k budget (~2k call charges for 1000
+    // iterations) while building 5000 levels deep. Container-construction
+    // charges (~5k more) must trip it — the arithmetic behind the
+    // run_expects_budgeted stack contract (value depth ≤ budget).
+    let src = "let deep = List.range(1000.0) |> List.fold((acc, x) => [[[[[acc]]]]], [0.0])\n\
+               expect List.length(deep) == 1.0\n";
+    let failure = functor_lang::run_expects_budgeted(&lower(src), &mut NoHost, Some(4_000))
+        .err()
+        .expect("the def-load fold should exceed the budget");
+    assert!(failure.error.message.contains("step budget"));
+}
+
+#[test]
 fn structural_equality_is_charged_by_size() {
     // A single `==` on a large value is O(size) work no call charge sees:
     // comparing a 500-element list 50 times is ~25k comparison nodes on a
@@ -286,6 +302,40 @@ fn unbudgeted_run_expects_is_unbounded() {
                expect sum(10000.0) == 49995000.0\n";
     let out = reports(src);
     assert!(matches!(out[0].outcome, ExpectOutcome::Pass));
+}
+
+// ------------------------------------------------- deep values must not crash
+
+#[test]
+fn deep_values_are_safe_under_the_documented_stack_contract() {
+    // A fold wrapping `[acc]` per step builds value DEPTH iteratively —
+    // ~50k levels here, far past any recursion limit. The run_expects_budgeted
+    // stack contract: a budgeted run can't build deeper than its budget, so
+    // in-process embedders run it on a worker whose stack covers the budget
+    // (~100 B/level). This test IS that embedding: budget 500k on a worker
+    // with a 256MB stack — build, compare (iterative value_eq, both the
+    // passing and the Display-rendered failing case), and the deep value's
+    // DROP (recursive, hence the contract) must all complete. On the default
+    // 2MB test-thread stack the drop alone aborted the process.
+    std::thread::Builder::new()
+        .stack_size(256 << 20)
+        .spawn(|| {
+            let src = "let nest = List.range(50000.0) |> List.fold((acc, x) => [acc], [0.0])\n\
+                       expect nest == nest\n\
+                       expect nest == [1.0]\n";
+            let out = functor_lang::run_expects_budgeted(&lower(src), &mut NoHost, Some(500_000))
+                .unwrap_or_else(|failure| panic!("defs should load: {}", failure.error.message));
+            assert!(matches!(out[0].outcome, ExpectOutcome::Pass));
+            let ExpectOutcome::Fail(Some(cmp)) = &out[1].outcome else {
+                panic!("expected a decomposed failure");
+            };
+            // The rendering really is the ~50k-deep value, not a truncation.
+            assert!(cmp.lhs.starts_with("[[[["));
+            assert!(cmp.lhs.len() > 100_000);
+        })
+        .expect("spawn worker")
+        .join()
+        .expect("deep-value worker must complete without overflowing");
 }
 
 // ---------------------------------------------------- inert in the game loop


### PR DESCRIPTION
Third arc of the inline-tests initiative (follows #422, #429): the prerequisite before the LSP/wasm IDE evaluates `expect` tests in the editor process, where a stack overflow is a host crash rather than an error. An iteratively-built value (`List.fold((acc, x) => [acc], …)`) nests arbitrarily deep for linear budget cost, and three recursive walks would each abort the process on one.

## What

- **`Value`'s `Display` → iterative** (explicit token stack). Output byte-identical — pinned by the run/trace goldens, and the reviewer walked every variant (empty containers, spacing, escaping) confirming equivalence.
- **`value_eq` → iterative** (explicit pair worklist). A `MissingField` sentinel keeps record semantics exactly interleaved (an earlier field's function-comparison error still fires before a later field's missing-name verdict — a review-caught divergence).
- **Container construction now charges 1 budget step** (list/tuple/record literals, cons, update). Review probe: a fold body nesting N literal levels added N depth per single call charge, so achievable depth was `MAX_EVAL_DEPTH × budget` — voiding the stack contract. With the charge, **value depth ≤ budget holds by construction**.
- **`Drop` deliberately stays recursive.** An iterative-teardown Drop was built and measured at **~2x frame_bench wall-clock** (every dying container paid worklist/TLS churn that compiled drop glue does for free) — rejected. Instead `run_expects_budgeted` documents the embedding contract: run budgeted evaluation on a worker thread whose stack covers the budget (~100 B/level; 256MB comfortably covers 10⁶). Safe by arithmetic, zero frame-loop cost.

## Verification

- New tests: a **512KB-small-stack pin** (200k-deep render + compare — fails loudly if either walk regresses to recursion), the **256MB-worker integration test** (50k-deep build/compare/render/drop — the drop alone aborted the process on a default stack), and a **budget pin for the literal-nesting depth amplifier**. functor-lang total: 532 green; runtime-common 359; strict build clean.
- **frame_bench, interleaved A/B** (change→base→change→base, same thermal conditions): identical within 0.4% both directions; allocs/frame byte-identical. (Absolute numbers drifted ~10% with machine thermals during this work — interleaving was the honest methodology; the rejected Drop design's 2x was measured unambiguously.)

## Review

`/xreview` (Claude reviewer; Codex still at its usage limit): confirmed Display/value_eq byte-equivalence, then found **High**: the stack contract's `depth ≤ budget` arithmetic was violable by up to 128× via nested literals in fold bodies — fixed with the container-construction charge (reviewer's prescribed option), plus their record-ordering and test-doesn't-pin-the-invariant findings and a committed scratch-file catch. All four dispositions applied and re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)