### PR TITLE
refactor(examples): asteroids adopts List/Math/boolean builtins + clear color

### DIFF
--- a/examples/asteroids/font.fun
+++ b/examples/asteroids/font.fun
@@ -45,13 +45,13 @@ let glyphCubes = (gx, gz, s, rows) =>
 
 // A word centered on (cx, cz): glyphs are 3 cells + 1 gap wide (4*s pitch).
 let word = (s, cx, cz, glyphs) =>
-  let count = Lib.length(glyphs) in
+  let count = List.length(glyphs) in
   let width = count * 4.0 * s - s in
   // startX/row origin are CELL CENTERS, hence the half-cell offsets.
   let startX = cx - width * 0.5 + s * 0.5 in
   let folded = glyphs |> List.fold((acc, g) =>
     let (gx, out) = acc in
-    (gx + 4.0 * s, Lib.append(glyphCubes(gx, cz - 2.0 * s, s, g), out)),
+    (gx + 4.0 * s, glyphCubes(gx, cz - 2.0 * s, s, g) |> List.append(out)),
     (startX, [])) in
   let (ignored, cubes) = folded in
   Scene.group(cubes)

--- a/examples/asteroids/game.fun
+++ b/examples/asteroids/game.fun
@@ -14,8 +14,6 @@
 // The playfield is the XZ plane (Y-up, camera overhead); positions wrap
 // at the field edges like the arcade original.
 
-open Lib
-
 // ---------- tuning ----------
 let worldX = 21.0        // half-extent of the playfield in x
 let worldZ = 15.0        // half-extent in z
@@ -137,7 +135,7 @@ let bulletHitsRock = (a, b) =>
 let assignHits = (bullets, rocks) =>
   rocks |> List.fold((acc, a) =>
     let (bs, kept, struck) = acc in
-    (match bs |> Lib.any((b) => bulletHitsRock(a, b)) with
+    (match bs |> List.any((b) => bulletHitsRock(a, b)) with
      | true => (Lib.removeFirst((b) => bulletHitsRock(a, b), bs), kept, [a, ..struck])
      | false => (bs, [a, ..kept], struck)),
     (bullets, [], []))
@@ -205,10 +203,10 @@ let setHeld = (held, key, isDown) =>
   | _ => held
 
 let startPressed = (key, isDown) =>
-  Lib.and(isDown, Lib.or(key == Key.Enter, key == Key.Space))
+  isDown && (key == Key.Enter || key == Key.Space)
 
 let restartPressed = (key, isDown) =>
-  Lib.and(isDown, Lib.or(key == Key.Enter, key == Key.R))
+  isDown && (key == Key.Enter || key == Key.R)
 
 // Spawn a bullet at the ship's nose, inheriting the ship's velocity.
 let fire = (model) =>
@@ -243,7 +241,7 @@ let input = (model, key, isDown) =>
   | _ =>
     (match restartPressed(key, isDown) with
      | true => (model, Effect.random(Seeded))
-     | false => (match Lib.and(key == Key.M, isDown) with
+     | false => (match key == Key.M && isDown with
                  | true => { model with phase: Menu }
                  | false => model))
 
@@ -256,7 +254,7 @@ let stepShip = (ship, held, dt) =>
   let heading = ship.heading + axis(held.left, held.right) * turnSpeed * dt in
   let acc = (match held.thrust with | true => thrustAccel | false => 0.0) in
   // Floored at 0 so a pathological frame (dt > 2s) can't reverse velocity.
-  let keep = Lib.floorAt(0.0, 1.0 - drag * dt) in
+  let keep = Math.max(0.0, 1.0 - drag * dt) in
   let vx = (ship.vel.x + Math.sin(heading) * acc * dt) * keep in
   let vz = (ship.vel.z + Math.cos(heading) * acc * dt) * keep in
   { pos: { x: wrap(ship.pos.x + vx * dt, worldX),
@@ -285,15 +283,15 @@ let tickPlaying = (model, dt, tts) =>
   let movedA = moveRocks(model.asteroids, dt) in
   let hits = assignHits(movedB, movedA) in
   let (keptB, kept, struck) = hits in
-  let rocks = Lib.append(kept, struck |> List.map(splitRock) |> Lib.flatten) in
+  let rocks = kept |> List.append(struck |> List.map(splitRock) |> List.flatten) in
   let gained = struck |> List.fold((acc, a) => acc + pointsFor(a.size), 0.0) in
   let anyKill = (match struck with | [] => false | _ => true) in
   let killFx = (match anyKill with
                 | true => [Effect.play(Assets.explosion)]
                 | false => []) in
-  let shield = Lib.floorAt(0.0, model.shield - dt) in
-  let shipHit = Lib.and(shield == 0.0,
-                        rocks |> Lib.any((a) => rockHitsShip(ship, a))) in
+  let shield = Math.max(0.0, model.shield - dt) in
+  let shipHit = shield == 0.0
+                && (rocks |> List.any((a) => rockHitsShip(ship, a))) in
   let base = { model with
                  ship: ship,
                  bullets: keptB,
@@ -305,9 +303,9 @@ let tickPlaying = (model, dt, tts) =>
     (let lives = model.lives - 1.0 in
      match lives < 1.0 with
      | true => ({ base with lives: 0.0, phase: Lost },
-                fxOf(Lib.append(killFx, [Effect.play(Assets.ship_explosion)])))
+                fxOf(killFx |> List.append([Effect.play(Assets.ship_explosion)])))
      | false => ({ base with lives: lives, ship: newShip, shield: respawnShield },
-                 fxOf(Lib.append(killFx, [Effect.play(Assets.ship_explosion)]))))
+                 fxOf(killFx |> List.append([Effect.play(Assets.ship_explosion)]))))
   | false =>
     (match rocks with
      | [] =>
@@ -316,7 +314,7 @@ let tickPlaying = (model, dt, tts) =>
           (let (_, nextSeed) = Random.step(model.seed) in
            ({ base with wave: model.wave + 1.0,
                         seed: nextSeed,
-                        shield: Lib.floorAt(1.5, shield),
+                        shield: Math.max(1.5, shield),
                         asteroids: spawnWave(nextSeed, waveRocks(model.wave + 1.0)) },
             fxOf(killFx)))
         | false => ({ base with phase: Won }, fxOf(killFx)))
@@ -382,7 +380,7 @@ let shipBody = (thrusting) =>
                   |> Scene.translate(Vec3.make(0.0, 0.0, 0.0 - 0.85))
                   |> Scene.emissive(Color.rgb(1.0, 0.55, 0.1))]
      | false => []) in
-  Scene.group(Lib.append([
+  Scene.group([
     // Kenney crafts model nose-toward--Z; flip to face our +Z forward.
     // The glb's craft_racer node carries a baked [2, 0, 1.5] placement
     // translation (kit-scene leftover) — counter it first or the body
@@ -391,15 +389,15 @@ let shipBody = (thrusting) =>
       |> Scene.translate(Vec3.make(0.0 - 2.0, 0.0, 0.0 - 1.5))
       |> Scene.rotateY(Angle.degrees(180.0))
       |> Scene.scale(1.5),
-  ], flame))
+  ] |> List.append(flame))
 
 // Hidden entirely on Menu/Lost; blinks while the respawn shield runs.
 let shipScenes = (model, tts) =>
-  let visible = Lib.or(model.shield < 0.001, Math.sin(tts * 18.0) > 0.0) in
+  let visible = model.shield < 0.001 || Math.sin(tts * 18.0) > 0.0 in
   match visible with
   | false => []
   | true =>
-    [shipBody(Lib.and(model.held.thrust, model.phase == Playing))
+    [shipBody(model.held.thrust && model.phase == Playing)
        |> Scene.rotateY(Angle.radians(model.ship.heading))
        |> Scene.translate(Vec3.make(model.ship.pos.x, 0.0, model.ship.pos.z))]
 
@@ -452,10 +450,9 @@ let draw = (model, tts) =>
                  Scene.group(titleScenes(model, tts))]),
     [Light.ambient(Color.rgb(0.3, 0.3, 0.38)),
      Light.directional(Vec3.make(-0.45, -1.0, -0.3), Color.rgb(1.0, 0.97, 0.9), 1.1)])
-    // Distance fog starting past the whole scene: nothing in play is
-    // fogged, but the pass's clear color becomes deep space (there is no
-    // Frame.clearColor — see the findings log).
-    |> Frame.withFog(Fog.linear(80.0, 160.0, Color.rgb(0.01, 0.012, 0.035)))
+    // Deep-space background. Nothing in play needs fog blending, so this is
+    // a plain clear color rather than a distant-fog trick.
+    |> Frame.withClearColor(Color.rgb(0.01, 0.012, 0.035))
 
 // ---------- sound ----------
 // One-shots (laser/explosions) fire as Effects above; the thrust loop is

--- a/examples/asteroids/lib.fun
+++ b/examples/asteroids/lib.fun
@@ -1,38 +1,7 @@
-// lib.fun — module Lib: tiny helpers Asteroids needs that the builtin
-// registry doesn't cover today (no List.length/append/flatten/any, and no
-// boolean &&/||/! operators — see the exercise's findings log).
-
-let length = (xs) =>
-  xs |> List.fold((acc, x) => acc + 1.0, 0.0)
-
-let and = (a, b) =>
-  match a with
-  | true => b
-  | false => false
-
-let or = (a, b) =>
-  match a with
-  | true => true
-  | false => b
-
-// True when any element satisfies pred. Subject-LAST so it pipes:
-// `rocks |> Lib.any(pred)`.
-let any = (pred, xs) =>
-  xs |> List.fold((acc, x) => (match acc with | true => true | false => pred(x)), false)
-
-// NOTE: a naive recursive append hits the interpreter's evaluation-depth
-// cap (~200 frames) at list lengths well under 100, so these are built on
-// the iterative List.fold instead (findings log: no builtin
-// List.reverse/append/flatten).
-let reverse = (xs) =>
-  xs |> List.fold((acc, x) => [x, ..acc], [])
-
-// a ++ b: prepend a's elements onto b, walking a back to front.
-let append = (a, b) =>
-  reverse(a) |> List.fold((acc, x) => [x, ..acc], b)
-
-let flatten = (xss) =>
-  reverse(xss) |> List.fold((acc, xs) => append(xs, acc), [])
+// lib.fun — module Lib: the one helper Asteroids still needs that the
+// builtin registry doesn't cover today. length/and/or/any/reverse/append/
+// flatten/floorAt were all replaced by builtins (List.*, the && / ||
+// operators, Math.max); only removeFirst has no builtin equivalent.
 
 // Remove the FIRST element satisfying pred (if any), preserving order.
 let removeFirst = (pred, xs) =>
@@ -45,10 +14,4 @@ let removeFirst = (pred, xs) =>
                  | false => ([x, ..out], false))),
     ([], false)) in
   let (out, _) = folded in
-  reverse(out)
-
-// Clamp v to at least lo (no Math.max builtin).
-let floorAt = (lo, v) =>
-  match v < lo with
-  | true => lo
-  | false => v
+  List.reverse(out)


### PR DESCRIPTION
## What

`examples/asteroids` still carried helpers and a rendering trick that shipped as first-class features *after* the example was written. This adopts them — no gameplay change.

- **`lib.fun`: 54 → 16 lines.** `length` / `and` / `or` / `any` / `reverse` / `append` / `flatten` / `floorAt` → the `List.*` and `Math.max` builtins and the `&&` / `||` operators. Only `removeFirst` (no builtin equivalent) remains.
- **`Lib.and` / `Lib.or` call sites → `&&` / `||`**, parenthesizing piped operands where the boolean operators bind tighter than `|>` (e.g. `shield == 0.0 && (rocks |> List.any(…))`).
- **`Lib.floorAt(lo, v)` → `Math.max(lo, v)`**; `Lib.append`/`Lib.flatten`/`Lib.any`/`List.length` → the builtins (verified subject-last arg order preserves list order at every site).
- **The distant-fog clear-color trick → `Frame.withClearColor`.** Nothing in play was ever within the old `near=80` fog range (farthest geometry ≈ 56 units from the overhead camera), so the fog only ever set the background — now stated directly.
- Dropped the now-dead `open Lib` (only `Lib.removeFirst`, qualified, survives).

## Why this instead of restacking #338

#338 set out to do this migration, but it's been overtaken: main independently migrated asteroids to the *branded* `Random.Seed` / `Key` / `Color` / `Vec3` APIs (#364/#366/#369/#372) — a generation past #338's older `Random.step` approach. Those PRs branded the types but never applied these ergonomic cleanups, which is what this PR finishes. (Suggest closing #338.)

The literal-tuple-pattern input rewrite from #338 is intentionally **not** included: keys are now `Key.t` constructors, and the language forbids ctors as tuple sub-patterns — the `&&`/`||` rewrite is the right simplification there instead. The centered title stays scene-space 3D `Font` glyphs (rocks drift *under* the floating letters — deliberate), so `Ui.center()` doesn't apply without a visual regression.

## Verification

- `functor build` typechecks the project.
- **Menu frame is byte-identical** (same md5) before vs. after at `--fixed-time 2` — the fog→clearColor and every builtin swap are pixel-for-pixel behavior-preserving.
- **Headless play-through** (debug server): Enter starts a run, 50+ ticks run through `tickPlaying`, a shot lands a **hit → split → score 20** (exercising `assignHits`→`removeFirst`→`splitRock`→`List.append`), and a ship collision fires the `shield == 0.0 && (rocks |> List.any …)` path (**lives 2**) — **zero runtime errors/warnings**.
- **`/xreview`**: the Claude reviewer traced all conversions (append arg-order, `&&`/`||` precedence, `Math.max`/`floorAt`, `List.any` empty-list, fog geometry) — no Critical/High/Medium findings; the one Low (`open Lib` dead) is applied here. Codex was unavailable (usage limit), so this ran single-engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Visuals

![Asteroids menu demo](https://gist.githubusercontent.com/tommy-xr/82cad09645dff15f7fecd3d5befa23d5/raw/asteroids-menu.gif)

<sub>The ASTEROIDS menu (phase `Menu` at init): rocks drift over time via a decorrelated PRNG stream. Rendered headlessly via `--capture-frame` / `--fixed-time` (sweep 0.0..3.0). This PR is a **behavior-preserving refactor** (adopts `List`/`Math`/boolean builtins + `Frame.withClearColor`) — the menu render is **byte-identical before vs after** (md5 `429b6db46b6881a8574e2bf9b13effbb`), so the visual is **unchanged by design**; the media just confirms the example still renders and animates correctly after the refactor.</sub>

![Asteroids menu still](https://gist.githubusercontent.com/tommy-xr/82cad09645dff15f7fecd3d5befa23d5/raw/asteroids-menu.png)
