### PR TITLE
feat(tooling): live expect-test gutters — red/green/re-running in VSCode and the web IDE

### DIFF
--- a/e2e/ide-page.mjs
+++ b/e2e/ide-page.mjs
@@ -287,6 +287,40 @@ try {
     if (await waitStatus("live", "after delete-sibling checks")) {
       console.log("delete-sibling checks keep the preview live ✓");
     }
+
+    // (e) Inline expect tests: typing expects earns live gutter states — a
+    // pass, a fail (with the decomposed actual-vs-expected detail, which
+    // also lands in Problems), and an unrunnable engine call.
+    await page.evaluate(
+      (src) => window.__ide.setActiveSource(src),
+      `${gameSource}let double = (x) => x * 2.0\n` +
+        `expect double(4.0) == 8.0\n` +
+        `expect double(4.0) == 9.0\n` +
+        `expect Scene.cube() == Scene.cube()\n`
+    );
+    const expectRows = await poll(
+      () => page.evaluate(() => window.__lang.expects()),
+      (rows) => rows.length === 3 && rows.every((r) => r.state !== "running")
+    );
+    const states = expectRows.map((r) => r.state).join(",");
+    if (states === "pass,fail,unrunnable") {
+      console.log("expect gutter settles to pass/fail/unrunnable ✓");
+    } else {
+      fail(`expect gutter states: ${states || "(none)"}`);
+    }
+    if ((expectRows[1] || {}).detail.includes("left: 8, right: 9")) {
+      console.log("failing expect carries the decomposed detail ✓");
+    } else {
+      fail(`fail detail: ${JSON.stringify(expectRows[1])}`);
+    }
+    const dots = await page.locator(".cm-expect").count();
+    if (dots === 3) console.log("expect gutter renders three dots ✓");
+    else fail(`expected 3 gutter dots, got ${dots}`);
+
+    await page.evaluate((src) => window.__ide.setActiveSource(src), gameSource);
+    if (await waitStatus("live", "after expect checks")) {
+      console.log("expect checks keep the preview live ✓");
+    }
   }
 
   console.log(process.exitCode ? "RESULT: FAIL" : "RESULT: PASS");

--- a/examples/counter/game.fun
+++ b/examples/counter/game.fun
@@ -16,6 +16,17 @@ let update = (m: Model, msg: Msg) =>
   match msg with
   | Inc => { m with count: m.count + 1.0 }
 
+// Inline tests: `expect` runs under `functor-lang test game.fun` (and live
+// in the editor gutter — red/green as you type), never in the game loop.
+// The functional core makes MVU logic directly testable: update is just a
+// function of (model, msg).
+expect update(init, Inc).count == 1.0
+expect update(update(init, Inc), Inc).count == 2.0
+expect (
+  let clicked = update(init, Inc) in    // a let-in chain is the setup block
+  clicked.count > init.count
+)
+
 let tick = (m: Model, dt, tts) => m
 
 let draw = (m: Model, tts) =>

--- a/functor-lang/src/eval.rs
+++ b/functor-lang/src/eval.rs
@@ -401,6 +401,35 @@ pub enum ExpectOutcome {
     Error(RunError),
 }
 
+impl ExpectOutcome {
+    /// The tooling-facing `(state, detail)` — ONE shared mapping for every
+    /// editor gutter (the LSP and the web IDE): `pass` / `fail` /
+    /// `unrunnable` (an engine-external call — the plain evaluator has no
+    /// host) / `error`. An `Error`'s detail is the bare message; callers
+    /// holding a `SourceMap` may prefer a located rendering.
+    pub fn status(&self) -> (&'static str, Option<String>) {
+        match self {
+            ExpectOutcome::Pass => ("pass", None),
+            ExpectOutcome::Fail(Some(cmp)) => (
+                "fail",
+                Some(format!(
+                    "left {} right — left: {}, right: {}",
+                    cmp.op, cmp.lhs, cmp.rhs
+                )),
+            ),
+            ExpectOutcome::Fail(None) => ("fail", Some("expected true, got false".to_string())),
+            ExpectOutcome::Error(error) if error.message.starts_with("unknown external") => (
+                "unrunnable",
+                Some(format!(
+                    "{} — engine calls need the runtime; run `functor test` or the game",
+                    error.message
+                )),
+            ),
+            ExpectOutcome::Error(error) => ("error", Some(error.message.clone())),
+        }
+    }
+}
+
 /// The sides of a failed top-level comparison: `expect a == b` reports what
 /// `a` and `b` actually were (rendered with [`Value`]'s deterministic
 /// `Display`).
@@ -902,10 +931,12 @@ evaluation depth."
                     None if self.host.provides(&joined) => {
                         Ok(Value::HostFn(Rc::from(joined.as_str())))
                     }
-                    None => Err(RunError {
-                        message: format!("unknown external `{joined}`"),
-                        span: expr.span,
-                    }),
+                    // `#[cold]` helper: the message formatting must not
+                    // enlarge this hot frame (eval recursion sits near the
+                    // stack budget at the 128-depth cap — the call_curried
+                    // rule; adding the formatting inline here overflowed the
+                    // deep-recursion test's 2MB stack in debug).
+                    None => Err(unknown_external_error(path, joined, expr.span)),
                 }
             }
             // Container CONSTRUCTION charges one step (the depth invariant
@@ -2419,6 +2450,29 @@ fn fork_seed(i: f64, seed: f64) -> f64 {
 }
 
 /// Resolve an [`ExprKind::External`] path against the registry.
+/// The error for an external that resolved nowhere. A typo'd member of a
+/// BUILTIN namespace (`List.fooo`) is a user error everywhere — it must not
+/// read (or classify — see [`ExpectOutcome::status`]) like a host external
+/// that merely isn't available in this embedding. `#[cold]`: keeps the
+/// formatting locals out of `eval_inner`'s recursion frame.
+#[cold]
+#[inline(never)]
+fn unknown_external_error(path: &[String], joined: String, span: Span) -> RunError {
+    let message = match path.first() {
+        Some(head) if BUILTIN_NAMESPACES.contains(&head.as_str()) => {
+            format!("`{head}` has no builtin `{}`", path[1..].join("."))
+        }
+        _ => format!("unknown external `{joined}`"),
+    };
+    RunError { message, span }
+}
+
+/// The namespaces the BUILTIN registry owns: an unknown member of one of
+/// these is a typo (a plain error), never a host-provided external — the
+/// distinction the unknown-external error message (and through it the
+/// expect gutter's `unrunnable` classification) rests on.
+pub const BUILTIN_NAMESPACES: &[&str] = &["List", "Text", "Math", "Random", "Debug"];
+
 pub fn builtin(path: &[String]) -> Option<Builtin> {
     let joined = path.join(".");
     Some(match joined.as_str() {

--- a/functor-lang/tests/run.rs
+++ b/functor-lang/tests/run.rs
@@ -179,9 +179,16 @@ fn error_calling_a_non_function() {
 
 #[test]
 fn error_unknown_external_with_span() {
+    // A typo'd member of a BUILTIN namespace is a plain user error — it
+    // must not read like a host external that isn't available here (the
+    // expect gutter's `unrunnable` classification rests on the distinction).
     let (message, line, col) = run_err("let main = () => List.frobnicate(1.0)");
-    assert_eq!(message, "unknown external `List.frobnicate`");
+    assert_eq!(message, "`List` has no builtin `frobnicate`");
     assert_eq!((line, col), (1, 18));
+    // A namespace the builtin registry does NOT own stays an unknown
+    // external (under a host it could be host-provided).
+    let (message, _, _) = run_err("let main = () => Scene.cube()");
+    assert_eq!(message, "unknown external `Scene.cube`");
 }
 
 #[test]

--- a/site/src/ide.js
+++ b/site/src/ide.js
@@ -19,6 +19,7 @@ import {
   onDiagnostics,
   wireLiveTrace,
   refreshLiveValues,
+  currentExpects,
 } from "./lang-intel.js";
 import { ProjectBridge } from "./project-bridge.js";
 import { createStatusBar } from "./status-bar.js";
@@ -444,4 +445,7 @@ window.__ide = {
 
 // Whether language analysis is available (false = degraded, pkg absent) — the
 // same readiness seam the sandbox exposes for e2e.
-window.__lang = { ready: langReady };
+window.__lang = {
+  ready: langReady,
+  expects: () => currentExpects(view),
+};

--- a/site/src/lang-intel.js
+++ b/site/src/lang-intel.js
@@ -40,8 +40,16 @@ let analyzeProjectFn = null; // (filesJson, active) => JSON string
 let hoverProjectFn = null; // (filesJson, active, offset) => JSON string
 let completeProjectFn = null; // (filesJson, active, offset) => JSON string
 let resetFn = null; // () => void, clears the wasm completion cache
+let expectsProjectFn = null; // (filesJson, active, budget) => JSON string — optional export
 let lastKey = null;
 let lastResult = null;
+let lastExpectKey = null;
+let lastExpectRows = null;
+
+// The browser's per-lint-pass step budget for inline `expect` tests: bounds
+// main-thread work (see run_expects_budgeted — total interpreter work is
+// O(budget)). Modest by design: this runs synchronously in the lint pass.
+const EXPECT_BUDGET = 200_000;
 
 // The multi-file seam (the IDE): the host registers a provider returning the
 // whole file set (`[{ path, source }]`, entry first) plus the active path;
@@ -144,6 +152,30 @@ const toDiagnostics = (view) => {
           const to = Math.max(from, Math.min(d.to | 0, len));
           return { from, to, severity: d.severity || "error", message: d.message || "" };
         });
+  // Inline expect tests ride the same heartbeat: refresh the gutter, and
+  // surface failing/erroring expects as diagnostics too (squiggle + the
+  // Problems panel carry the decomposed actual-vs-expected detail).
+  const rows = expectRowsCached(doc.toString());
+  if (rows !== null) {
+    const marks = expectSetFor(rows, doc);
+    queueMicrotask(() => {
+      // Dispatch outside the lint pass; skip if another edit landed first
+      // (its demote-to-running already superseded this set).
+      if (view.state.doc === doc) view.dispatch({ effects: setExpects.of(marks) });
+    });
+    for (const row of rows) {
+      if (row.state !== "fail" && row.state !== "error") continue;
+      const from = Math.max(0, Math.min(row.from | 0, len));
+      const to = Math.min(from + "expect".length, len);
+      diagnostics.push({
+        from,
+        to,
+        severity: "error",
+        message: `expect ${row.state === "fail" ? "failed" : "errored"}${row.detail ? `: ${row.detail}` : ""}`,
+      });
+    }
+    diagnostics.sort((a, z) => a.from - z.from);
+  }
   if (diagnosticsListener) diagnosticsListener(diagnostics);
   return diagnostics;
 };
@@ -735,6 +767,134 @@ const coverageSetFor = (fileName, source, doc) => {
   return RangeSet.of(ranges);
 };
 
+// --- Inline expect-test gutter -------------------------------------------------
+// Live red/green for `expect` tests, evaluated by the analysis wasm on each
+// lint pass (budgeted — see EXPECT_BUDGET). States mirror the LSP/VSCode
+// gutter: running (in-flight, shown between an edit and the next settled
+// pass) / pass / fail / error / unrunnable (engine calls need the runtime).
+// An edit DEMOTES existing markers to running in place (positions mapped
+// through the change) — the "show when they are re-running" state.
+
+const EXPECT_STATES = ["running", "pass", "fail", "error", "unrunnable"];
+
+class ExpectMarker extends GutterMarker {
+  constructor(state, detail) {
+    super();
+    this.state = state;
+    this.detail = detail || "";
+  }
+  eq(other) {
+    return other.state === this.state && other.detail === this.detail;
+  }
+  toDOM() {
+    const el = document.createElement("div");
+    el.className = `cm-expect cm-expect-${this.state}`;
+    el.title =
+      this.state === "running"
+        ? "expect: re-running…"
+        : `expect: ${this.state}${this.detail ? ` — ${this.detail}` : ""}`;
+    return el;
+  }
+}
+
+const setExpects = StateEffect.define();
+
+const expectField = StateField.define({
+  create: () => RangeSet.empty,
+  update(value, tr) {
+    for (const effect of tr.effects) {
+      if (effect.is(setExpects)) return effect.value;
+      if (effect.is(clearDecorations)) return RangeSet.empty;
+    }
+    if (tr.docChanged) {
+      // Keep the gutter through the edit, demoted to `running`: map each
+      // marker's position and swap in the in-flight marker.
+      const ranges = [];
+      const cursor = value.iter();
+      while (cursor.value) {
+        const from = tr.changes.mapPos(cursor.from, 1);
+        ranges.push(new ExpectMarker("running", "").range(from));
+        cursor.next();
+      }
+      // Dedup positions (two expects collapsing onto one line after a
+      // deletion) — RangeSet.of requires sorted, and duplicates are noise.
+      const seen = new Set();
+      const unique = ranges
+        .sort((a, z) => a.from - z.from)
+        .filter((r) => !seen.has(r.from) && seen.add(r.from));
+      return RangeSet.of(unique);
+    }
+    return value;
+  },
+});
+
+const expectGutter = gutter({
+  class: "cm-expect-gutter",
+  markers: (view) => view.state.field(expectField, false) || RangeSet.empty,
+});
+
+// Evaluate the active file's expects, memoized per (doc, context) key like
+// analyzeCached. Returns rows ([{from, state, detail}]), null when the
+// project didn't load (keep the current gutter), or null when unavailable.
+const expectRowsCached = (docString) => {
+  if (!expectsProjectFn) return null;
+  const args = projectArgs(docString);
+  const key = cacheKey(docString, args);
+  if (key === lastExpectKey) return lastExpectRows;
+  let rows = null;
+  try {
+    const filesJson = args
+      ? args.filesJson
+      : JSON.stringify([{ path: "game.fun", source: docString }]);
+    const active = args ? args.active : "game.fun";
+    rows = JSON.parse(expectsProjectFn(filesJson, active, EXPECT_BUDGET)).rows;
+  } catch (e) {
+    // A wasm trap (e.g. a pathologically deep value exhausting the engine
+    // stack on teardown — the browser has no big-stack worker seam) can
+    // leave the instance unsafe: disable the feature for this session.
+    console.info(`[lang-intel] expect evaluation disabled after a trap: ${e}`);
+    expectsProjectFn = null;
+    rows = null;
+  }
+  lastExpectKey = key;
+  lastExpectRows = rows;
+  return rows;
+};
+
+// Rows → a marker set against the current doc (one marker per line; the
+// first row wins a shared line).
+const expectSetFor = (rows, doc) => {
+  const ranges = [];
+  const seen = new Set();
+  for (const row of rows || []) {
+    if (!EXPECT_STATES.includes(row.state)) continue;
+    const at = doc.lineAt(Math.min(Math.max(row.from | 0, 0), doc.length)).from;
+    if (seen.has(at)) continue;
+    seen.add(at);
+    ranges.push(new ExpectMarker(row.state, row.detail).range(at));
+  }
+  ranges.sort((a, z) => a.from - z.from);
+  return RangeSet.of(ranges);
+};
+
+// The introspection/e2e seam (window.__lang.expects): the current gutter as
+// plain rows.
+export const currentExpects = (view) => {
+  const set = view.state.field(expectField, false);
+  if (!set) return [];
+  const rows = [];
+  const cursor = set.iter();
+  while (cursor.value) {
+    rows.push({
+      line: view.state.doc.lineAt(cursor.from).number,
+      state: cursor.value.state,
+      detail: cursor.value.detail,
+    });
+    cursor.next();
+  }
+  return rows;
+};
+
 // Rebuild the overlay for the current buffer: async (the hash check), token-
 // guarded so a stale completion can't clobber a newer state.
 const refreshLive = async (view) => {
@@ -913,6 +1073,24 @@ const intelTheme = EditorView.theme({
   ".cm-cov-before": { background: "rgba(65, 216, 230, 0.55)" },
   ".cm-cov-after": { background: "rgba(232, 88, 184, 0.55)" },
   ".cm-cov-dark": { background: "rgba(233, 230, 242, 0.14)" },
+  // The expect-test gutter: a dot per test line — the VSCode gutter's states
+  // in the calm theme (green pass / red fail / hollow red error / amber
+  // running / gray unrunnable).
+  ".cm-expect-gutter": {
+    width: "10px",
+  },
+  ".cm-expect": {
+    width: "8px",
+    height: "8px",
+    borderRadius: "50%",
+    margin: "4px 1px 0 1px",
+    boxSizing: "border-box",
+  },
+  ".cm-expect-pass": { background: "#6fdc92" },
+  ".cm-expect-fail": { background: "#e05561" },
+  ".cm-expect-error": { border: "1.5px solid #e05561" },
+  ".cm-expect-running": { border: "1.5px dashed #d8a657" },
+  ".cm-expect-unrunnable": { border: "1.5px solid rgba(233, 230, 242, 0.35)" },
   // Codelenses: a dimmed signature line above the def.
   ".cm-lens": {
     fontFamily: mono,
@@ -979,6 +1157,12 @@ export const setupLangIntel = async () => {
     completeProjectFn = mod.functor_lang_complete_project;
     // reset is optional — an older bundle without it just skips cache clearing.
     resetFn = typeof mod.functor_lang_reset === "function" ? mod.functor_lang_reset : null;
+    // Expect evaluation is optional too — an older bundle degrades to no
+    // test gutter, not to no intel.
+    expectsProjectFn =
+      typeof mod.functor_lang_expects_project === "function"
+        ? mod.functor_lang_expects_project
+        : null;
   } catch {
     console.info(
       "[lang-intel] language analysis unavailable (pkg not built) — editor runs without diagnostics"
@@ -992,6 +1176,8 @@ export const setupLangIntel = async () => {
     liveField,
     coverageField,
     coverageGutter,
+    expectField,
+    expectGutter,
     initialRefresh,
     // Register the completion source on the language's data facet — basicSetup's
     // autocompletion() picks it up via languageDataAt (no second popup).

--- a/site/src/sandbox.js
+++ b/site/src/sandbox.js
@@ -19,6 +19,7 @@ import {
   wireLiveTrace,
   currentLiveHints,
   currentCoverage,
+  currentExpects,
 } from "./lang-intel.js";
 import { PlayerBridge } from "./player-bridge.js";
 import { createStatusBar } from "./status-bar.js";
@@ -130,6 +131,7 @@ window.__lang = {
   complete: (source, offset) => completeAt(source, offset),
   liveHints: () => currentLiveHints(),
   coverage: () => currentCoverage(view),
+  expects: () => currentExpects(view),
 };
 
 const setDoc = (source) => {

--- a/tools/functor-lang-lsp/src/expects.rs
+++ b/tools/functor-lang-lsp/src/expects.rs
@@ -1,0 +1,264 @@
+//! Live `expect` test status — the editor half of inline tests.
+//!
+//! On every buffer edit the server immediately pushes the project's expects
+//! as `running` (the in-flight state); once the debounce settles, a WORKER
+//! thread reloads the project from the live buffers and evaluates the
+//! expects with [`functor_lang::run_expects_budgeted`], and the results
+//! re-enter the server loop (as `$/functorExpects`, generation-tagged so a
+//! stale run never paints) to be relayed to the client as the custom
+//! notification [`STATUS`]:
+//!
+//! ```json
+//! { "generation": 7, "files": { "file:///…/game.fun": [
+//!     { "line": 12, "state": "pass",       "detail": null },
+//!     { "line": 14, "state": "fail",       "detail": "left == right — left: 12, right: 12.5" },
+//!     { "line": 15, "state": "error",      "detail": "game.fun:3:5: no pattern matched 1" },
+//!     { "line": 16, "state": "unrunnable", "detail": "unknown external `Scene.cube` — engine calls need the runtime; run `functor test` or the game" }
+//! ] } }
+//! ```
+//!
+//! `line` is 0-based (LSP convention), the line of the `expect` keyword.
+//! States: `running` | `pass` | `fail` | `error` | `unrunnable` (an expect
+//! that calls an engine external — the plain evaluator has no host).
+//!
+//! The worker thread's stack follows `run_expects_budgeted`'s contract
+//! (value depth ≤ budget ⇒ ~100 bytes/level): the default 10^6 budget gets
+//! a 256MB reserved stack, scaled up if `FUNCTOR_LSP_EXPECT_BUDGET` raises
+//! the budget. A budget of 0 disables the feature.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use serde_json::{json, Value};
+
+/// The client-facing notification method.
+pub const STATUS: &str = "functor/tests/status";
+
+/// The default per-phase step budget (see `run_expects_budgeted`): well
+/// under a second of interpreter work, far above any sane test's needs.
+pub const DEFAULT_BUDGET: u64 = 1_000_000;
+
+/// One expect's status row.
+pub struct Row {
+    pub uri: String,
+    /// 0-based line of the `expect` keyword.
+    pub line: u64,
+    pub state: &'static str,
+    pub detail: Option<String>,
+}
+
+/// The `functor/tests/status` params for a set of rows. `all_uris` seeds an
+/// explicit (possibly empty) entry for EVERY project file, so a file whose
+/// last expect was just deleted gets an authoritative `[]` and the client
+/// clears its gutter — absent uris are left untouched client-side.
+pub fn status_params(generation: u64, rows: &[Row], all_uris: &[String]) -> Value {
+    // BTreeMap: deterministic file order in the payload (tests diff it).
+    let mut files: BTreeMap<&str, Vec<Value>> = BTreeMap::new();
+    for uri in all_uris {
+        files.entry(uri).or_default();
+    }
+    for row in rows {
+        files.entry(&row.uri).or_default().push(json!({
+            "line": row.line,
+            "state": row.state,
+            "detail": row.detail,
+        }));
+    }
+    json!({ "generation": generation, "files": files })
+}
+
+/// Every real (non-synthetic) file of a project as a uri — the authoritative
+/// key set for [`status_params`].
+pub fn project_uris(
+    project: &functor_lang::project::Project,
+    path_to_uri: impl Fn(&std::path::Path) -> String,
+) -> Vec<String> {
+    project
+        .sources
+        .files()
+        .iter()
+        .filter(|file| !file.path.to_str().is_some_and(|p| p.starts_with('<')))
+        .map(|file| path_to_uri(&file.path))
+        .collect()
+}
+
+/// Every expect in `project` as a `running` row — the immediate push on
+/// each edit, so the gutter shows in-flight state while the debounce and
+/// the evaluation worker do their work.
+pub fn running_rows(
+    project: &functor_lang::project::Project,
+    path_to_uri: impl Fn(&std::path::Path) -> String,
+) -> Vec<Row> {
+    project
+        .module
+        .expects
+        .iter()
+        .map(|expect| {
+            let file = project.sources.file_at(expect.span.start);
+            let (_, line, _) = project.sources.resolve(expect.span.start);
+            Row {
+                uri: path_to_uri(&file.path),
+                line: (line.max(1) - 1) as u64,
+                state: "running",
+                detail: None,
+            }
+        })
+        .collect()
+}
+
+/// Evaluate a project's expects: the final rows plus the project's full uri
+/// set (the authoritative keys — a loaded project with zero expects clears
+/// gutters via empty lists). `None` means the buffer didn't load (nothing to
+/// report; the previous states stand and diagnostics carry the why). Runs on
+/// the CALLER's thread — callers are responsible for the stack contract (a
+/// worker with `~100 * budget` bytes reserved). Loads the project fresh from
+/// `entry` + `overrides` (live buffers), because IR/values are `Rc`-based
+/// and cannot cross threads.
+pub fn evaluate_rows(
+    entry: Option<PathBuf>,
+    single: Option<(PathBuf, String)>,
+    overrides: std::collections::HashMap<PathBuf, String>,
+    budget: u64,
+    path_to_uri: impl Fn(&std::path::Path) -> String,
+) -> Option<(Vec<Row>, Vec<String>)> {
+    let prelude = functor_prelude::modules();
+    let project = match entry {
+        Some(entry) => functor_lang::project::load_with_prelude(&entry, &overrides, &prelude)
+            .ok()
+            // Mirror `load_project`'s membership rule: a nearest functor.json
+            // whose entry project does NOT contain the requesting file must
+            // fall back to the single-file view, or the worker would paint
+            // (and authoritatively clear!) files of an unrelated project.
+            .filter(|project| {
+                single
+                    .as_ref()
+                    .is_none_or(|(path, _)| project.sources.file_by_path(path).is_some())
+            }),
+        None => None,
+    }
+    .or_else(|| {
+        let (path, text) = single?;
+        functor_lang::project::load_single_file(&path, &text, &prelude).ok()
+    })?;
+    let row = |span: functor_lang::Span, state: &'static str, detail: Option<String>| {
+        let file = project.sources.file_at(span.start);
+        let (_, line, _) = project.sources.resolve(span.start);
+        Row {
+            uri: path_to_uri(&file.path),
+            line: (line.max(1) - 1) as u64,
+            state,
+            detail,
+        }
+    };
+    let located = |error: &functor_lang::RunError| {
+        let (file, line, col) = project.sources.resolve(error.span.start);
+        format!(
+            "{}:{line}:{col}: {}",
+            file.path
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_default(),
+            error.message
+        )
+    };
+    let uris = project_uris(&project, &path_to_uri);
+    let rows = match functor_lang::run_expects_budgeted(&project.module, &mut functor_lang::NoHost, Some(budget)) {
+        Ok(reports) => reports
+            .iter()
+            .map(|report| {
+                // The shared outcome mapping (ExpectOutcome::status — the
+                // web IDE uses the same one); errors upgrade the bare
+                // message to a located rendering.
+                let (state, detail) = report.outcome.status();
+                let detail = match &report.outcome {
+                    functor_lang::ExpectOutcome::Error(error) if state == "error" => {
+                        Some(located(error))
+                    }
+                    _ => detail,
+                };
+                row(report.span, state, detail)
+            })
+            .collect(),
+        // The def load failed (or exceeded the budget): every expect gets
+        // the load error — the tests can't run until the defs do.
+        Err(failure) => {
+            let detail = format!("defs failed to load: {}", located(&failure.error));
+            project
+                .module
+                .expects
+                .iter()
+                .map(|expect| row(expect.span, "error", Some(detail.clone())))
+                .collect()
+        }
+    };
+    Some((rows, uris))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn uri(path: &std::path::Path) -> String {
+        format!("file://{}", path.display())
+    }
+
+    fn rows_for(src: &str, budget: u64) -> Vec<Row> {
+        let dir = std::env::temp_dir().join(format!("functor-lsp-expects-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("game.fun");
+        std::fs::write(&path, src).unwrap();
+        let (rows, _uris) =
+            evaluate_rows(None, Some((path, src.to_string())), Default::default(), budget, uri)
+                .expect("loadable source");
+        let _ = std::fs::remove_dir_all(&dir);
+        rows
+    }
+
+    #[test]
+    fn outcomes_map_to_states_with_details() {
+        let src = "let area = (w, h) => w * h\n\
+                   expect area(3.0, 4.0) == 12.0\n\
+                   expect area(3.0, 4.0) == 12.5\n\
+                   expect Scene.cube() == Scene.cube()\n";
+        let rows = rows_for(src, DEFAULT_BUDGET);
+        assert_eq!(
+            rows.iter().map(|r| (r.line, r.state)).collect::<Vec<_>>(),
+            vec![(1, "pass"), (2, "fail"), (3, "unrunnable")]
+        );
+        assert_eq!(
+            rows[1].detail.as_deref(),
+            Some("left == right — left: 12, right: 12.5")
+        );
+        assert!(rows[2].detail.as_deref().unwrap().contains("Scene.cube"));
+    }
+
+    #[test]
+    fn budget_exhaustion_is_an_error_row() {
+        let src = "let sum = (n) => List.range(n) |> List.fold((a, x) => a + x, 0.0)\n\
+                   expect sum(10000.0) == 0.0\n";
+        let rows = rows_for(src, 100);
+        assert_eq!(rows[0].state, "error");
+        assert!(rows[0].detail.as_deref().unwrap().contains("step budget"));
+    }
+
+    #[test]
+    fn status_params_group_rows_by_file_and_seed_empty_files() {
+        let rows = vec![
+            Row { uri: "file:///a.fun".into(), line: 3, state: "pass", detail: None },
+            Row { uri: "file:///b.fun".into(), line: 0, state: "running", detail: None },
+            Row { uri: "file:///a.fun".into(), line: 5, state: "fail", detail: Some("x".into()) },
+        ];
+        let all = vec![
+            "file:///a.fun".to_string(),
+            "file:///b.fun".to_string(),
+            "file:///empty.fun".to_string(),
+        ];
+        let params = status_params(9, &rows, &all);
+        assert_eq!(params["generation"], 9);
+        assert_eq!(params["files"]["file:///a.fun"].as_array().unwrap().len(), 2);
+        assert_eq!(params["files"]["file:///b.fun"][0]["state"], "running");
+        // The expect-less file gets an authoritative empty list (clears it).
+        assert_eq!(params["files"]["file:///empty.fun"].as_array().unwrap().len(), 0);
+    }
+}

--- a/tools/functor-lang-lsp/src/main.rs
+++ b/tools/functor-lang-lsp/src/main.rs
@@ -29,6 +29,7 @@
 //! change triggers server-initiated `workspace/inlayHint/refresh` and
 //! `workspace/codeLens/refresh` requests.
 
+mod expects;
 mod inspector;
 
 use std::collections::HashMap;
@@ -187,6 +188,16 @@ fn run(
     let mut selected: HashMap<String, usize> = HashMap::new();
     let mut next_request_id: i64 = 1;
     let mut attach_stop: Option<Arc<AtomicBool>> = None;
+    // Live expect-test status (see `expects`): a PER-URI monotonic
+    // generation gates stale worker results — per-uri, not global, so a
+    // result for one project is never dropped because an unrelated file was
+    // edited meanwhile (which would leave its gutter stuck on `running`).
+    // A 0 budget disables the feature entirely.
+    let mut expect_generations: HashMap<String, u64> = HashMap::new();
+    let expect_budget = std::env::var("FUNCTOR_LSP_EXPECT_BUDGET")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(expects::DEFAULT_BUDGET);
     while let Some(message) = next() {
         // A message with an `id` but no `method` is the client's response to one
         // of our server-initiated refresh requests: fire-and-forget, so tolerate
@@ -374,6 +385,13 @@ fn run(
                 }
                 // A just-opened matching document gets the current coverage.
                 push_coverage(writer, trace.as_ref(), &documents);
+                // Expect tests: show `running` now, evaluate right away (open
+                // is already a settled buffer — no debounce to wait out).
+                if expect_budget > 0 {
+                    let generation = bump_generation(&mut expect_generations, uri);
+                    push_expects_running(writer, projects.get(uri), generation);
+                    spawn_expect_worker(uri, &documents, generation, expect_budget, &trace_tx);
+                }
             }
             ("textDocument/didChange", None) => {
                 let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
@@ -399,6 +417,17 @@ fn run(
                     // The edit changed the hash: the gate re-evaluates (and
                     // the client's gutter clears via the empty push).
                     push_coverage(writer, trace.as_ref(), &documents);
+                    // Expect tests: flip the gutter to `running` immediately
+                    // (the in-flight state); the evaluation itself waits for
+                    // the debounce flush. Without a debouncer (tests),
+                    // evaluate now — no flush will come.
+                    if expect_budget > 0 {
+                        let generation = bump_generation(&mut expect_generations, uri);
+                        push_expects_running(writer, projects.get(uri), generation);
+                        if debounce.is_none() {
+                            spawn_expect_worker(uri, &documents, generation, expect_budget, &trace_tx);
+                        }
+                    }
                 }
             }
             ("textDocument/didClose", None) => {
@@ -407,13 +436,39 @@ fn run(
                 projects.remove(uri);
                 // Clear stale squiggles for the closed file.
                 write_diagnostics(writer, uri, vec![]);
+                // And its expect gutter/problems (an authoritative empty list).
+                if expect_budget > 0 {
+                    let generation = bump_generation(&mut expect_generations, uri);
+                    let params = expects::status_params(generation, &[], &[uri.to_string()]);
+                    write_message(
+                        writer,
+                        &json!({ "jsonrpc": "2.0", "method": expects::STATUS, "params": params }),
+                    );
+                }
             }
             // A debounce-thread flush: `uri`'s buffer has settled — publish its
-            // diagnostics from the latest stored document.
+            // diagnostics from the latest stored document, and kick off the
+            // expect-evaluation worker for the settled state.
             ("$/functorFlush", None) => {
                 let uri = params["uri"].as_str().unwrap_or("");
                 if let Some(text) = documents.get(uri) {
                     publish_diagnostics(writer, uri, text);
+                    if expect_budget > 0 {
+                        let generation = *expect_generations.get(uri).unwrap_or(&0);
+                        spawn_expect_worker(uri, &documents, generation, expect_budget, &trace_tx);
+                    }
+                }
+            }
+            // An expect worker finished: relay its statuses to the client —
+            // unless another edit has already superseded that run.
+            ("$/functorExpects", None) => {
+                let for_uri = params["uri"].as_str().unwrap_or("");
+                let current = *expect_generations.get(for_uri).unwrap_or(&0);
+                if params["generation"].as_u64() == Some(current) {
+                    write_message(
+                        writer,
+                        &json!({ "jsonrpc": "2.0", "method": expects::STATUS, "params": params }),
+                    );
                 }
             }
             // A pushed trace (extension relay, wasm postMessage, tests, or the
@@ -450,6 +505,89 @@ fn run(
         }
     }
     0
+}
+
+/// Advance and return `uri`'s expect generation (see the per-uri map in
+/// [`run`]).
+fn bump_generation(generations: &mut HashMap<String, u64>, uri: &str) -> u64 {
+    let entry = generations.entry(uri.to_string()).or_insert(0);
+    *entry += 1;
+    *entry
+}
+
+/// Push the project's expects as `running` — the immediate in-flight state on
+/// every edit, ahead of the debounce and the worker. A project with no
+/// expects still pushes (empty per-file lists), clearing a gutter whose last
+/// expect was just deleted. On an UNPARSEABLE edit the projects map keeps
+/// the last good load, so the running rows paint at the stale project's
+/// lines — transiently honest (the worker reports nothing for a broken
+/// buffer, and diagnostics carry the why) rather than flickering clear.
+fn push_expects_running(
+    writer: &mut impl Write,
+    project: Option<&functor_lang::project::Project>,
+    generation: u64,
+) {
+    let Some(project) = project else { return };
+    let rows = expects::running_rows(project, |path| path_to_uri(path));
+    let uris = expects::project_uris(project, |path| path_to_uri(path));
+    let params = expects::status_params(generation, &rows, &uris);
+    write_message(
+        writer,
+        &json!({ "jsonrpc": "2.0", "method": expects::STATUS, "params": params }),
+    );
+}
+
+/// Evaluate `uri`'s project's expects on a WORKER thread and inject the
+/// result back into the server loop as `$/functorExpects` (generation-tagged;
+/// the loop drops stale runs). The worker reloads the project from the live
+/// buffer snapshots — IR/values are `Rc`-based and cannot cross threads — and
+/// its stack follows `run_expects_budgeted`'s contract: ~100 bytes per
+/// budget step of possible value depth, floored at 256MB (reserved virtual
+/// memory, committed lazily).
+fn spawn_expect_worker(
+    uri: &str,
+    documents: &HashMap<String, String>,
+    generation: u64,
+    budget: u64,
+    tx: &Sender<Incoming>,
+) {
+    let Some(path) = uri_to_path(uri) else { return };
+    let entry = discover_entry(&path);
+    let single = documents.get(uri).map(|text| (path, text.clone()));
+    let overrides: HashMap<PathBuf, String> = documents
+        .iter()
+        .filter_map(|(u, text)| Some((uri_to_path(u)?, text.clone())))
+        .collect();
+    let tx = tx.clone();
+    let stack = usize::try_from(budget.saturating_mul(200))
+        .unwrap_or(usize::MAX)
+        .max(256 << 20);
+    let uri = uri.to_string();
+    let spawned = std::thread::Builder::new()
+        .stack_size(stack)
+        .spawn(move || {
+            // Unloadable buffer: report nothing (running states stand; the
+            // diagnostics say why). Loadable: authoritative per-file lists —
+            // a project with zero expects clears gutters via empty lists.
+            let Some((rows, uris)) =
+                expects::evaluate_rows(entry, single, overrides, budget, |p| path_to_uri(p))
+            else {
+                return;
+            };
+            let mut params = expects::status_params(generation, &rows, &uris);
+            // The gate key: results are per-REQUESTING-uri (its generation).
+            params["uri"] = json!(uri);
+            let _ = tx.send(Incoming::Msg(json!({
+                "jsonrpc": "2.0",
+                "method": "$/functorExpects",
+                "params": params,
+            })));
+        });
+    if let Err(err) = spawned {
+        // A denied 256MB stack reservation must not leave a silent forever-
+        // `running` gutter — stderr is the LSP client's log channel.
+        eprintln!("functor-lang-lsp: expect worker failed to spawn: {err}");
+    }
 }
 
 /// Run the Functor Lang front-end over `text` and publish the outcome: one diagnostic

--- a/tools/functor-lang-lsp/tests/e2e.rs
+++ b/tools/functor-lang-lsp/tests/e2e.rs
@@ -17,10 +17,19 @@ struct Server {
 
 impl Server {
     fn spawn() -> Server {
+        // Most tests assert exact message SEQUENCES: disable the async
+        // expect-evaluation worker so no unsolicited `functor/tests/status`
+        // interleaves (the expects flow has its own test, spawned with a
+        // budget).
+        Server::spawn_with_expect_budget("0")
+    }
+
+    fn spawn_with_expect_budget(budget: &str) -> Server {
         let mut child = Command::new(env!("CARGO_BIN_EXE_functor-lang-lsp"))
             // These tests assert diagnostic content, not typing cadence: disable
             // the didChange debounce so publishes are immediate and deterministic.
             .env("FUNCTOR_LSP_DIAGNOSTICS_DEBOUNCE_MS", "0")
+            .env("FUNCTOR_LSP_EXPECT_BUDGET", budget)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .spawn()
@@ -32,6 +41,19 @@ impl Server {
             stdin,
             stdout,
         }
+    }
+
+    /// Read messages until one satisfies `want` (skipping unrelated
+    /// notifications — the expects worker is async, so its status pushes
+    /// interleave with request replies).
+    fn recv_until(&mut self, what: &str, want: impl Fn(&Value) -> bool) -> Value {
+        for _ in 0..50 {
+            let message = self.recv();
+            if want(&message) {
+                return message;
+            }
+        }
+        panic!("never received {what}");
     }
 
     fn send(&mut self, message: Value) {
@@ -722,6 +744,67 @@ fn prelude_gives_host_calls_real_types() {
 
     server.send(json!({ "jsonrpc": "2.0", "id": 3, "method": "shutdown" }));
     server.recv();
+    server.send(json!({ "jsonrpc": "2.0", "method": "exit" }));
+    server.child.wait().expect("wait for exit");
+}
+
+/// The live expect-test flow: didOpen pushes `running` immediately, then the
+/// async worker's settled statuses arrive with pass/fail/unrunnable states
+/// and the decomposed-comparison detail; an edit re-pushes `running` and
+/// re-evaluates.
+#[test]
+fn expect_statuses_over_real_stdio() {
+    let mut server = Server::spawn_with_expect_budget("1000000");
+    server.send(json!({ "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {} }));
+    server.recv();
+
+    let src = "let area = (w, h) => w * h\n\
+               expect area(3.0, 4.0) == 12.0\n\
+               expect area(3.0, 4.0) == 12.5\n\
+               expect Scene.cube() == Scene.cube()\n";
+    server.send(json!({
+        "jsonrpc": "2.0", "method": "textDocument/didOpen",
+        "params": { "textDocument": { "uri": URI, "text": src } },
+    }));
+    let is_status = |message: &Value| message["method"] == "functor/tests/status";
+    // The immediate push: every expect `running`.
+    let running = server.recv_until("the running push", is_status);
+    let rows = running["params"]["files"][URI].as_array().expect("rows").clone();
+    assert_eq!(rows.len(), 3);
+    assert!(rows.iter().all(|row| row["state"] == "running"), "{running}");
+    assert_eq!(rows[0]["line"], 1);
+
+    // The worker's settled statuses.
+    let settled = server.recv_until("settled statuses", |message| {
+        is_status(message) && message["params"]["files"][URI][0]["state"] != "running"
+    });
+    let rows = settled["params"]["files"][URI].as_array().expect("rows").clone();
+    assert_eq!(rows[0]["state"], "pass");
+    assert_eq!(rows[1]["state"], "fail");
+    assert_eq!(
+        rows[1]["detail"], "left == right — left: 12, right: 12.5",
+        "decomposed comparison detail: {settled}"
+    );
+    assert_eq!(rows[2]["state"], "unrunnable", "engine call: {settled}");
+
+    // Fix the failing expect: running again, then all runnable ones pass.
+    let fixed = src.replace("== 12.5", "== 12.0");
+    server.send(json!({
+        "jsonrpc": "2.0", "method": "textDocument/didChange",
+        "params": {
+            "textDocument": { "uri": URI },
+            "contentChanges": [{ "text": fixed }],
+        },
+    }));
+    let settled = server.recv_until("re-settled statuses", |message| {
+        is_status(message)
+            && message["params"]["files"][URI][1]["state"] != "running"
+            && message["params"]["files"][URI][1]["state"] != "fail"
+    });
+    assert_eq!(settled["params"]["files"][URI][1]["state"], "pass", "{settled}");
+
+    server.send(json!({ "jsonrpc": "2.0", "id": 2, "method": "shutdown" }));
+    server.recv_until("shutdown reply", |message| message["id"] == 2);
     server.send(json!({ "jsonrpc": "2.0", "method": "exit" }));
     server.child.wait().expect("wait for exit");
 }

--- a/tools/functor-lang-vscode/client/expects.js
+++ b/tools/functor-lang-vscode/client/expects.js
@@ -1,0 +1,79 @@
+// Live `expect` test status — the pure half of the gutter wiring (the
+// inspector.js pattern: decision logic here, node-tested; extension.js does
+// the vscode.Range/setDecorations plumbing).
+//
+// The LSP pushes `functor/tests/status`:
+//   { generation, files: { "<uri>": [ { line, state, detail } ] } }
+// Every uri present is AUTHORITATIVE for that file (an empty list clears
+// it); absent uris keep their previous rows. States: running | pass | fail
+// | error | unrunnable; unknown states are dropped (a newer server must not
+// break an older extension).
+
+const STATUS = "functor/tests/status";
+const EXPECT_STATES = ["running", "pass", "fail", "error", "unrunnable"];
+
+// Merge one status push into `byUri` (a Map of uri → rows). Returns the
+// list of uris whose rows changed (the files to repaint), or null for a
+// malformed push.
+function mergeStatuses(byUri, params) {
+  if (!params || typeof params.files !== "object" || params.files === null) {
+    return null;
+  }
+  const touched = [];
+  for (const [uri, rows] of Object.entries(params.files)) {
+    if (!Array.isArray(rows)) continue;
+    const kept = rows.filter(
+      (row) =>
+        row &&
+        typeof row.line === "number" &&
+        EXPECT_STATES.includes(row.state)
+    );
+    byUri.set(uri, kept);
+    touched.push(uri);
+  }
+  return touched;
+}
+
+// Per-state line lists for one uri's rows — what each decoration type gets.
+function groupByState(rows) {
+  const groups = { running: [], pass: [], fail: [], error: [], unrunnable: [] };
+  for (const row of rows || []) groups[row.state].push(row.line);
+  return groups;
+}
+
+// The Problems-panel entries for one uri's rows: failing/erroring expects
+// only, with the decomposed/actual detail as the message.
+function problemRows(rows) {
+  return (rows || [])
+    .filter((row) => row.state === "fail" || row.state === "error")
+    .map((row) => ({
+      line: row.line,
+      message:
+        row.state === "fail"
+          ? `expect failed${row.detail ? `: ${row.detail}` : ""}`
+          : `expect errored${row.detail ? `: ${row.detail}` : ""}`,
+    }));
+}
+
+// Hover text for the gutter line (running/unrunnable/pass want context too).
+function hoverText(row) {
+  switch (row.state) {
+    case "running":
+      return "expect: re-running…";
+    case "pass":
+      return "expect: pass";
+    case "unrunnable":
+      return `expect: not runnable in the editor${row.detail ? ` — ${row.detail}` : ""}`;
+    default:
+      return `expect: ${row.state}${row.detail ? ` — ${row.detail}` : ""}`;
+  }
+}
+
+module.exports = {
+  STATUS,
+  EXPECT_STATES,
+  mergeStatuses,
+  groupByState,
+  problemRows,
+  hoverText,
+};

--- a/tools/functor-lang-vscode/client/expects.test.js
+++ b/tools/functor-lang-vscode/client/expects.test.js
@@ -1,0 +1,57 @@
+const test = require("node:test");
+const assert = require("node:assert");
+const expects = require("./expects");
+
+test("mergeStatuses replaces per-uri, keeps absent uris, drops unknown states", () => {
+  const byUri = new Map([["file:///old.fun", [{ line: 1, state: "pass" }]]]);
+  const touched = expects.mergeStatuses(byUri, {
+    generation: 3,
+    files: {
+      "file:///a.fun": [
+        { line: 2, state: "pass" },
+        { line: 4, state: "sparkly" }, // future state: dropped
+        { line: 5, state: "fail", detail: "left == right — left: 1, right: 2" },
+      ],
+      "file:///b.fun": [], // authoritative clear
+    },
+  });
+  assert.deepStrictEqual(touched.sort(), ["file:///a.fun", "file:///b.fun"]);
+  assert.strictEqual(byUri.get("file:///a.fun").length, 2);
+  assert.deepStrictEqual(byUri.get("file:///b.fun"), []);
+  // Absent uri untouched.
+  assert.strictEqual(byUri.get("file:///old.fun").length, 1);
+});
+
+test("mergeStatuses rejects malformed pushes", () => {
+  assert.strictEqual(expects.mergeStatuses(new Map(), null), null);
+  assert.strictEqual(expects.mergeStatuses(new Map(), { files: 3 }), null);
+});
+
+test("groupByState buckets lines per state", () => {
+  const groups = expects.groupByState([
+    { line: 1, state: "pass" },
+    { line: 2, state: "fail" },
+    { line: 3, state: "pass" },
+    { line: 4, state: "running" },
+    { line: 5, state: "unrunnable" },
+    { line: 6, state: "error" },
+  ]);
+  assert.deepStrictEqual(groups.pass, [1, 3]);
+  assert.deepStrictEqual(groups.fail, [2]);
+  assert.deepStrictEqual(groups.running, [4]);
+  assert.deepStrictEqual(groups.unrunnable, [5]);
+  assert.deepStrictEqual(groups.error, [6]);
+});
+
+test("problemRows carries fail/error details only", () => {
+  const rows = expects.problemRows([
+    { line: 1, state: "pass" },
+    { line: 2, state: "fail", detail: "left == right — left: 1, right: 2" },
+    { line: 3, state: "error", detail: "game.fun:3:1: no pattern matched 1" },
+    { line: 4, state: "unrunnable", detail: "unknown external `Scene.cube`" },
+  ]);
+  assert.strictEqual(rows.length, 2);
+  assert.strictEqual(rows[0].line, 2);
+  assert.match(rows[0].message, /left == right/);
+  assert.match(rows[1].message, /no pattern matched/);
+});

--- a/tools/functor-lang-vscode/client/extension.js
+++ b/tools/functor-lang-vscode/client/extension.js
@@ -15,6 +15,9 @@ const { LanguageClient } = require("vscode-languageclient/node");
 // `node --test` (client/inspector.test.js) — extension.js keeps only the thin
 // VS Code wiring around it.
 const inspector = require("./inspector.js");
+// Live expect-test gutter decision logic (grouping, problem rows, hover
+// text) — same pure-module pattern (client/expects.test.js).
+const expects = require("./expects.js");
 const { resolveServerCommand } = require("./server-path.js");
 const cliDownload = require("./cli-download.js");
 
@@ -136,8 +139,59 @@ function activate(context) {
       );
     }
   };
+  // --- Live expect-test gutter ---------------------------------------------
+  // Five decoration types (running / pass / fail / error / unrunnable). The
+  // LSP pushes authoritative per-file rows (`functor/tests/status`); we
+  // repaint visible editors, and failing/erroring expects also land in a
+  // dedicated Problems collection carrying the decomposed actual-vs-expected
+  // detail. Decision logic is in expects.js (pure, node-tested).
+  const expectDecorations = {};
+  for (const state of expects.EXPECT_STATES) {
+    expectDecorations[state] = vscode.window.createTextEditorDecorationType({
+      gutterIconPath: vscode.Uri.file(
+        path.join(context.extensionPath, "media", `expect-${state}.svg`)
+      ),
+      gutterIconSize: "contain",
+    });
+    context.subscriptions.push(expectDecorations[state]);
+  }
+  const expectDiagnostics = vscode.languages.createDiagnosticCollection("functor-tests");
+  context.subscriptions.push(expectDiagnostics);
+  const expectsByUri = new Map();
+  const paintExpects = (editor) => {
+    const rows = expectsByUri.get(editor.document.uri.toString()) || [];
+    const groups = expects.groupByState(rows);
+    for (const state of expects.EXPECT_STATES) {
+      editor.setDecorations(
+        expectDecorations[state],
+        groups[state].map((line) => ({
+          range: new vscode.Range(line, 0, line, 0),
+          hoverMessage: expects.hoverText(
+            rows.find((row) => row.line === line && row.state === state)
+          ),
+        }))
+      );
+    }
+  };
+  const publishExpectProblems = (uri) => {
+    expectDiagnostics.set(
+      vscode.Uri.parse(uri),
+      expects.problemRows(expectsByUri.get(uri)).map((row) => {
+        const diagnostic = new vscode.Diagnostic(
+          new vscode.Range(row.line, 0, row.line, 1000),
+          row.message,
+          vscode.DiagnosticSeverity.Error
+        );
+        diagnostic.source = "functor expect";
+        return diagnostic;
+      })
+    );
+  };
   context.subscriptions.push(
-    vscode.window.onDidChangeVisibleTextEditors((editors) => editors.forEach(paintCoverage))
+    vscode.window.onDidChangeVisibleTextEditors((editors) => {
+      editors.forEach(paintCoverage);
+      editors.forEach(paintExpects);
+    })
   );
 
   clientStarted = client.start().then(
@@ -155,6 +209,24 @@ function activate(context) {
         const total = Object.values(grouped.groups).reduce((n, l) => n + l.length, 0);
         elog(`inspector coverage: ${total} gutter lines for ${grouped.uri}`);
         vscode.window.visibleTextEditors.forEach(paintCoverage);
+      });
+      client.onNotification(expects.STATUS, (params) => {
+        // Normalize uri keys through vscode.Uri so map lookups match editor
+        // documents (percent-encoding differences).
+        const raw = new Map();
+        const touched = expects.mergeStatuses(raw, params);
+        if (!touched) return;
+        // Normalize uri keys through vscode.Uri EVERYWHERE (map keys and the
+        // Problems publish) so lookups match editor documents — raw server
+        // uris can differ in percent-encoding/drive-letter case.
+        for (const [uri, rows] of raw) {
+          expectsByUri.set(vscode.Uri.parse(uri).toString(), rows);
+        }
+        for (const uri of touched) {
+          publishExpectProblems(vscode.Uri.parse(uri).toString());
+        }
+        elog(`expect status: ${touched.length} file(s), generation ${params.generation}`);
+        vscode.window.visibleTextEditors.forEach(paintExpects);
       });
     },
     (e) => {

--- a/tools/functor-lang-vscode/media/expect-error.svg
+++ b/tools/functor-lang-vscode/media/expect-error.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><circle cx="8" cy="8" r="3.25" fill="none" stroke="#e05561" stroke-width="1.5"/><circle cx="8" cy="8" r="1" fill="#e05561"/></svg>

--- a/tools/functor-lang-vscode/media/expect-fail.svg
+++ b/tools/functor-lang-vscode/media/expect-fail.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><circle cx="8" cy="8" r="4" fill="#e05561"/></svg>

--- a/tools/functor-lang-vscode/media/expect-pass.svg
+++ b/tools/functor-lang-vscode/media/expect-pass.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><circle cx="8" cy="8" r="4" fill="#6fdc92"/></svg>

--- a/tools/functor-lang-vscode/media/expect-running.svg
+++ b/tools/functor-lang-vscode/media/expect-running.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><circle cx="8" cy="8" r="3.25" fill="none" stroke="#d8a657" stroke-width="1.5" stroke-dasharray="3.4 1.7"/></svg>

--- a/tools/functor-lang-vscode/media/expect-unrunnable.svg
+++ b/tools/functor-lang-vscode/media/expect-unrunnable.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><circle cx="8" cy="8" r="3.25" fill="none" stroke="#8a8a8a" stroke-width="1.5"/></svg>

--- a/tools/functor-lang-vscode/package.json
+++ b/tools/functor-lang-vscode/package.json
@@ -85,7 +85,7 @@
     ]
   },
   "scripts": {
-    "test": "node --test client/inspector.test.js client/server-path.test.js client/cli-download.test.js",
+    "test": "node --test client/inspector.test.js client/server-path.test.js client/cli-download.test.js client/expects.test.js",
     "test:e2e": "playwright test -c tests-integration/playwright.config.mjs",
     "vscode:prepublish": "node ../../scripts/generate-icons.mjs",
     "package:vsix": "npx --yes @vscode/vsce@3.9.2 package --out functor-lang-vscode.vsix",

--- a/tools/functor-lang-wasm/src/lib.rs
+++ b/tools/functor-lang-wasm/src/lib.rs
@@ -108,6 +108,28 @@ pub fn functor_lang_complete_project(files_json: &str, active: &str, offset: f64
     complete_project_json(files_json, active, offset.max(0.0) as usize)
 }
 
+/// Evaluate the project's inline `expect` tests under a step budget and
+/// report the ACTIVE file's rows (the live-gutter seam — the same states as
+/// the LSP's `functor/tests/status`):
+///
+/// ```json
+/// { "rows": [{ "from": u16, "state": "pass|fail|error|unrunnable", "detail": str|null }] }
+/// ```
+///
+/// `from` is the `expect` keyword's whole-document UTF-16 offset in the
+/// active file. `{"rows": null}` means the project didn't load (keep the
+/// previous gutter; diagnostics carry the why); an EMPTY `rows` is
+/// authoritative (clears the gutter). The budget bounds interpreter steps
+/// (see `run_expects_budgeted`) — the browser runs this on the main thread,
+/// so keep it modest; the caller must also try/catch: a pathologically
+/// deep value can still exhaust the engine's wasm call stack on teardown
+/// (native runs on a big-stack worker; the browser has no such seam — trap,
+/// catch, reinit).
+#[wasm_bindgen]
+pub fn functor_lang_expects_project(files_json: &str, active: &str, budget: f64) -> String {
+    expects_project_json(files_json, active, budget.max(0.0) as u64)
+}
+
 /// See [`functor_lang_analyze`]. Pure — the tested seam.
 pub fn analyze_json(src: &str) -> String {
     analyze_impl(single(src), Path::new(USER_FILE))
@@ -183,6 +205,52 @@ fn analyze_impl(sources: Vec<(PathBuf, String)>, active: &Path) -> String {
     // "no completions until the value is fully typed" gap.
     LAST_GOOD.with(|cell| *cell.borrow_mut() = Some(project));
     doc
+}
+
+/// See [`functor_lang_expects_project`]. Pure — the tested seam.
+pub fn expects_project_json(files_json: &str, active: &str, budget: u64) -> String {
+    let no_load = || json!({ "rows": Value::Null }).to_string();
+    let Some(sources) = parse_files(files_json) else {
+        return no_load();
+    };
+    let Ok(project) = load_sources(sources) else {
+        return no_load();
+    };
+    let Some(file) = project.sources.file_by_path(Path::new(active)) else {
+        return no_load();
+    };
+    let row = |span: functor_lang::Span, state: &str, detail: Option<String>| {
+        json!({ "from": to_u16(file, span.start), "state": state, "detail": detail })
+    };
+    let rows: Vec<Value> = match functor_lang::run_expects_budgeted(
+        &project.module,
+        &mut functor_lang::NoHost,
+        Some(budget),
+    ) {
+        Ok(reports) => reports
+            .iter()
+            .filter(|report| owns(file, report.span.start))
+            .map(|report| {
+                // The shared outcome mapping (ExpectOutcome::status — the
+                // LSP paints the same states).
+                let (state, detail) = report.outcome.status();
+                row(report.span, state, detail)
+            })
+            .collect(),
+        // The def load failed (or exceeded the budget): every expect gets
+        // the load error — the tests can't run until the defs do.
+        Err(failure) => {
+            let detail = format!("defs failed to load: {}", failure.error.message);
+            project
+                .module
+                .expects
+                .iter()
+                .filter(|expect| owns(file, expect.span.start))
+                .map(|expect| row(expect.span, "error", Some(detail.clone())))
+                .collect()
+        }
+    };
+    json!({ "rows": rows }).to_string()
 }
 
 /// See [`functor_lang_hover`]. Pure — the tested seam. `offset` is UTF-16.
@@ -787,6 +855,66 @@ mod tests {
         assert_eq!(out["diagnostics"].as_array().unwrap().len(), 0);
         assert_eq!(complete_project_json("[]", "game.fun", 0), empty_completion());
         assert_eq!(hover_project_json("[{\"path\": 1}]", "game.fun", 0), "");
+    }
+
+    // --- Inline `expect` tests (the live-gutter seam) -----------------------
+
+    // Outcomes map to gutter states, offsets are active-file UTF-16, and
+    // sibling-file expects are filtered out of the active report.
+    #[test]
+    fn expects_report_active_file_states() {
+        let game = "let area = (w, h) => w * h\n\
+                    expect area(3.0, 4.0) == 12.0\n\
+                    expect area(3.0, 4.0) == 12.5\n\
+                    expect Scene.cube() == Scene.cube()\n";
+        let files = files_json(&[("game.fun", game), ("palette.fun", "let glow = 0.85\nexpect glow > 0.0\n")]);
+        let out = parse(&expects_project_json(&files, "game.fun", 1_000_000));
+        let rows = out["rows"].as_array().unwrap();
+        assert_eq!(rows.len(), 3, "sibling expects filtered: {out}");
+        assert_eq!(rows[0]["state"], "pass");
+        assert_eq!(rows[1]["state"], "fail");
+        assert_eq!(
+            rows[1]["detail"], "left == right — left: 12, right: 12.5",
+            "{out}"
+        );
+        assert_eq!(rows[2]["state"], "unrunnable");
+        // `from` lands on the second `expect` keyword (UTF-16 == byte here).
+        let from = rows[1]["from"].as_u64().unwrap() as usize;
+        assert!(game[from..].starts_with("expect area(3.0, 4.0) == 12.5"), "{out}");
+        // The sibling's own report carries only its row.
+        let sibling = parse(&expects_project_json(&files, "palette.fun", 1_000_000));
+        let rows = sibling["rows"].as_array().unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["state"], "pass");
+    }
+
+    // Unloadable input is `rows: null` (keep the previous gutter), never an
+    // exception; a loadable project with no expects is an EMPTY rows array
+    // (authoritative clear).
+    #[test]
+    fn expects_distinguish_unloadable_from_empty() {
+        let broken = files_json(&[("game.fun", "let broken = {\n")]);
+        let out = parse(&expects_project_json(&broken, "game.fun", 1_000));
+        assert!(out["rows"].is_null(), "{out}");
+        assert!(parse(&expects_project_json("not json", "game.fun", 1_000))["rows"].is_null());
+
+        let clean = files_json(&[("game.fun", "let x = 1.0\n")]);
+        let out = parse(&expects_project_json(&clean, "game.fun", 1_000));
+        assert_eq!(out["rows"].as_array().unwrap().len(), 0, "{out}");
+    }
+
+    // A budget-exceeding expect reports as an error row (the browser's
+    // main-thread bound).
+    #[test]
+    fn expects_budget_reports_error_rows() {
+        let files = files_json(&[(
+            "game.fun",
+            "let sum = (n) => List.range(n) |> List.fold((a, x) => a + x, 0.0)\nexpect sum(10000.0) == 0.0\n",
+        )]);
+        let out = parse(&expects_project_json(&files, "game.fun", 200));
+        let rows = out["rows"].as_array().unwrap();
+        assert_eq!(rows[0]["state"], "error");
+        assert!(rows[0]["detail"].as_str().unwrap().contains("step budget"), "{out}");
     }
 
     // Hover round-trips on a non-ASCII line: the returned span's UTF-16 offsets


### PR DESCRIPTION
Follows #422/#429/#432 (all merged): the visible half of inline tests — every `expect` shows live status in the editor gutter, re-evaluated as you type, in BOTH editors from one shared core.

## What

**Language crate** — `ExpectOutcome::status()`: one shared outcome→(state, detail) mapping for every frontend. States: `running` / `pass` / `fail` / `error` / `unrunnable` (engine calls can't run outside the runtime). A typo'd builtin member (`List.fooo`) now errors as `\`List\` has no builtin \`fooo\`` — a better CLI error, and it keeps user typos out of the `unrunnable` bucket. No frame-path changes.

**LSP** — on every edit the server immediately pushes all expects as `running` (the in-flight state); after the debounce settles, a worker thread (stack sized to the budget per `run_expects_budgeted`'s contract) reloads the project from live buffers and evaluates under `NoHost`; results re-enter the loop generation-tagged (**per-uri** generations — a result is never dropped because an unrelated file was edited) and relay as `functor/tests/status`. Authoritative per-file lists (empty = clear); unloadable buffers report nothing (running stands, diagnostics say why); `didClose` clears; `FUNCTOR_LSP_EXPECT_BUDGET` tunes (0 disables).

**VSCode** — five gutter dot states with hover detail; failing/erroring expects also land in a `functor-tests` Problems collection with the decomposed actual-vs-expected. Pure logic in `client/expects.js` (node-tested).

**Web IDE** — `functor_lang_expects_project` wasm export (same mapping; `rows: null` = unloadable vs `[]` = authoritative clear); a CodeMirror gutter with the same five states — an edit demotes markers to `running` **in place** (positions mapped through the change); fail/error rows join the lint diagnostics → squiggles + the status-bar Problems tab. Budget 200k on the main thread; a wasm trap disables the feature for the session (the browser has no big-stack worker seam — documented divergence from native).

**Example** — `examples/counter` now carries three expects over `update`, including the let-in setup-block form (passes `functor-lang test` and `check`).

## Verification

- **968 Rust tests** (functor-lang 532 / LSP 48 incl. a new framed e2e driving didOpen→running→settled→edit→re-settled / wasm 22 / runtime-common 366) + **25 node tests** + strict build clean; all re-run after the restack onto main.
- **Real-browser Playwright IDE probe** extended: typing expects settles the gutter to `pass,fail,unrunnable`, the fail row carries `left: 8, right: 9`, three dots render, preview stays live. `RESULT: PASS`.
- No interpreter hot-path changes (the one eval.rs touch is a `#[cold]` error-message helper — extracted after the inline version's formatting locals overflowed the deep-recursion test's 2MB debug stack, which also flags how close debug eval frames sit to that cliff at the 128-depth cap).

## Review

`/xreview` (Claude reviewer; Codex still rate-limited): no Critical/High. All four Mediums fixed: per-uri generation gating (cross-project results were droppable → stuck `running`), the worker now mirrors `load_project`'s project-membership fallback, VSCode Problems publish uses normalized uris (Windows drive-letter case), and builtin-typo misclassification (above). Lows: comment corrected, `didClose` clear added, worker spawn failure now logged. By-design and noted: a web wasm trap disables the gutter for the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)