### PR TITLE
fix(oculus): use exact per-eye projections

### DIFF
--- a/docs/vr.md
+++ b/docs/vr.md
@@ -63,8 +63,8 @@ magnetometer; the Xreal Eye's 6DoF is not host-accessible).
 
 ## After bring-up (in rough order)
 
-- Visual pass: gamma, asymmetric eye frusta (needs a raw-projection seam in
-  the shared renderer), then `GL_OVR_multiview2`.
+- Visual pass: gamma, then `GL_OVR_multiview2`. Exact asymmetric eye frusta
+  now pass through the shared renderer's raw-projection seam.
 - Controllers + a VR `InputContext` (head/hands) with desktop mouse/keyboard
   emulation, shock2quest-style, so VR games iterate without a headset.
 - On-device frame capture (`POST /capture` currently returns 503 on the

--- a/runtime/functor-runtime-common/src/camera.rs
+++ b/runtime/functor-runtime-common/src/camera.rs
@@ -100,6 +100,53 @@ impl Camera {
     pub fn projection_matrix(&self, aspect: f32) -> Matrix4<f32> {
         perspective(Rad(self.fov_radians), aspect, self.near, self.far)
     }
+
+    /// Build an asymmetric perspective projection from four view-space field-
+    /// of-view angles. This is the projection form supplied per eye by XR
+    /// runtimes, where the optical center usually does not sit at the middle
+    /// of the render target.
+    ///
+    /// Angles are measured from the forward axis: left/down are negative and
+    /// right/up are positive. The resulting matrix uses OpenGL's right-handed
+    /// view convention and `[-1, 1]` clip-space depth, matching
+    /// [`view_matrix`](Self::view_matrix) and the shared GLES renderer.
+    pub fn projection_matrix_from_fov_angles(
+        &self,
+        angle_left: f32,
+        angle_right: f32,
+        angle_down: f32,
+        angle_up: f32,
+    ) -> Matrix4<f32> {
+        let left = angle_left.tan();
+        let right = angle_right.tan();
+        let down = angle_down.tan();
+        let up = angle_up.tan();
+        let width = right - left;
+        let height = up - down;
+        let depth = self.far - self.near;
+
+        // Column-major OpenGL projection. Writing this directly (instead of
+        // cgmath::frustum) also preserves OpenXR's valid reversed-angle form,
+        // where a negative width or height intentionally flips the image.
+        Matrix4::new(
+            2.0 / width,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            2.0 / height,
+            0.0,
+            0.0,
+            (right + left) / width,
+            (up + down) / height,
+            -(self.far + self.near) / depth,
+            -1.0,
+            0.0,
+            0.0,
+            -(2.0 * self.far * self.near) / depth,
+            0.0,
+        )
+    }
 }
 
 impl Default for Camera {
@@ -136,6 +183,65 @@ mod tests {
         // Horizontal scale shrinks by exactly the aspect ratio (so geometry
         // keeps its proportions; you just see more to the sides).
         assert!(approx(wide.x.x, square.x.x / 2.0));
+    }
+
+    #[test]
+    fn symmetric_fov_angles_match_the_standard_perspective() {
+        let cam = Camera::default();
+        let aspect = 1.37;
+        let half_vertical = cam.fov_radians / 2.0;
+        let half_horizontal = (half_vertical.tan() * aspect).atan();
+        let symmetric = cam.projection_matrix(aspect);
+        let from_angles = cam.projection_matrix_from_fov_angles(
+            -half_horizontal,
+            half_horizontal,
+            -half_vertical,
+            half_vertical,
+        );
+
+        let symmetric: &[f32; 16] = symmetric.as_ref();
+        let from_angles: &[f32; 16] = from_angles.as_ref();
+        for (actual, expected) in from_angles.iter().zip(symmetric.iter()) {
+            assert!(approx(*actual, *expected), "{actual} != {expected}");
+        }
+    }
+
+    #[test]
+    fn asymmetric_fov_edges_map_to_clip_space_edges() {
+        use cgmath::Vector4;
+
+        let cam = Camera::default();
+        let angles = (-0.82_f32, 0.71_f32, -0.76_f32, 0.88_f32);
+        let projection =
+            cam.projection_matrix_from_fov_angles(angles.0, angles.1, angles.2, angles.3);
+        let near = cam.near;
+        let project = |x: f32, y: f32| {
+            let clip = projection * Vector4::new(x, y, -near, 1.0);
+            [clip.x / clip.w, clip.y / clip.w]
+        };
+
+        assert!(approx(project(near * angles.0.tan(), 0.0)[0], -1.0));
+        assert!(approx(project(near * angles.1.tan(), 0.0)[0], 1.0));
+        assert!(approx(project(0.0, near * angles.2.tan())[1], -1.0));
+        assert!(approx(project(0.0, near * angles.3.tan())[1], 1.0));
+    }
+
+    #[test]
+    fn reversed_fov_angles_preserve_requested_clip_space_flip() {
+        use cgmath::Vector4;
+
+        let cam = Camera::default();
+        let left = 0.71_f32;
+        let right = -0.82_f32;
+        let projection = cam.projection_matrix_from_fov_angles(left, right, -0.76, 0.88);
+        let project_x = |angle: f32| {
+            let clip = projection
+                * Vector4::new(cam.near * angle.tan(), 0.0, -cam.near, 1.0);
+            clip.x / clip.w
+        };
+
+        assert!(approx(project_x(left), -1.0));
+        assert!(approx(project_x(right), 1.0));
     }
 
     // Eyes must sit `ipd` apart along the camera's right vector, with both

--- a/runtime/functor-runtime-common/src/renderer.rs
+++ b/runtime/functor-runtime-common/src/renderer.rs
@@ -13,13 +13,11 @@ use crate::{
 
 /// Render one `Frame` to the currently-bound (default) framebuffer.
 ///
-/// This is the *shared* per-frame render path: both shells — the desktop runner
-/// (`functor-runtime-desktop`) and the web runtime (`functor-runtime-web`) — call
-/// this with their own GL context, so the shadow + forward orchestration lives in
-/// one type-checked place instead of being copy-pasted (and drifting) between the
-/// two. The shells keep only what is genuinely platform-specific: creating the GL
-/// context, obtaining the `Frame` (dylib FFI vs. JsValue marshalling), computing
-/// the viewport (window framebuffer vs. canvas), input, and frame capture.
+/// This is the *shared* per-frame render path: the desktop, web, and XR shells
+/// call this with their own GL context, so the shadow + forward orchestration
+/// lives in one type-checked place instead of drifting between platforms. The
+/// shells keep only what is genuinely platform-specific: creating the GL
+/// context, obtaining the `Frame`, computing the viewport, input, and capture.
 ///
 /// Steps, mirroring what each shell used to do inline:
 /// 1. Render-target passes — each declared target's inner frame gets its own
@@ -47,6 +45,68 @@ pub fn render_frame(
     // The camera to render from — usually `&frame.camera`; stereo shells pass
     // each per-eye camera (`Camera::stereo_eyes`) with a per-eye viewport.
     camera: &Camera,
+    frame_time: FrameTime,
+    viewport: Viewport,
+    debug_render_mode: DebugRenderMode,
+) {
+    render_frame_inner(
+        gl,
+        shader_version,
+        asset_cache,
+        scene_context,
+        shadow_map,
+        frame,
+        camera,
+        None,
+        frame_time,
+        viewport,
+        debug_render_mode,
+    );
+}
+
+/// Render one `Frame` using an externally supplied projection matrix for the
+/// main pass. XR shells use this to preserve the runtime's exact asymmetric
+/// per-eye frustum; render-target passes retain their own cameras and ordinary
+/// symmetric projections.
+#[allow(clippy::too_many_arguments)]
+pub fn render_frame_with_projection(
+    gl: &glow::Context,
+    shader_version: &str,
+    asset_cache: Arc<AssetCache>,
+    scene_context: &SceneContext,
+    shadow_map: &ShadowMap,
+    frame: &Frame,
+    camera: &Camera,
+    projection_matrix: &Matrix4<f32>,
+    frame_time: FrameTime,
+    viewport: Viewport,
+    debug_render_mode: DebugRenderMode,
+) {
+    render_frame_inner(
+        gl,
+        shader_version,
+        asset_cache,
+        scene_context,
+        shadow_map,
+        frame,
+        camera,
+        Some(projection_matrix),
+        frame_time,
+        viewport,
+        debug_render_mode,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn render_frame_inner(
+    gl: &glow::Context,
+    shader_version: &str,
+    asset_cache: Arc<AssetCache>,
+    scene_context: &SceneContext,
+    shadow_map: &ShadowMap,
+    frame: &Frame,
+    camera: &Camera,
+    projection_matrix: Option<&Matrix4<f32>>,
     frame_time: FrameTime,
     viewport: Viewport,
     debug_render_mode: DebugRenderMode,
@@ -133,6 +193,7 @@ target frame are ignored (depth 1 only)",
             pass.frame.fog.as_ref(),
             pass.frame.skybox.as_ref(),
             width as f32 / height as f32,
+            None,
         );
         unsafe {
             gl.bind_framebuffer(glow::FRAMEBUFFER, None);
@@ -189,6 +250,7 @@ target frame are ignored (depth 1 only)",
         frame.fog.as_ref(),
         frame.skybox.as_ref(),
         viewport.aspect(),
+        projection_matrix,
     );
 }
 
@@ -279,6 +341,7 @@ pub fn render_composited_frames(
             frame.fog.as_ref(),
             frame.skybox.as_ref(),
             width as f32 / height as f32,
+            None,
         );
         unsafe {
             gl.bind_framebuffer(glow::FRAMEBUFFER, None);
@@ -369,6 +432,7 @@ fn forward_pass(
     fog: Option<&crate::fog::Fog>,
     skybox: Option<&crate::skybox::SkyboxDescription>,
     aspect: f32,
+    projection_matrix: Option<&Matrix4<f32>>,
 ) {
     let render_context = RenderContext {
         gl,
@@ -383,10 +447,13 @@ fn forward_pass(
         camera_pos: cgmath::Vector3::new(camera.eye[0], camera.eye[1], camera.eye[2]),
     };
 
-    // The game supplies the camera; derive view/projection from it + the aspect.
+    // The game supplies the camera; derive its ordinary projection from the
+    // aspect unless a platform shell (XR) supplied an exact projection.
     let world_matrix = Matrix4::identity();
     let view_matrix = camera.view_matrix();
-    let projection_matrix = camera.projection_matrix(aspect);
+    let projection_matrix = projection_matrix
+        .copied()
+        .unwrap_or_else(|| camera.projection_matrix(aspect));
 
     // The skybox draws first, behind everything (it writes no depth); fog
     // does not apply to it — the sky IS the horizon.

--- a/runtime/functor-runtime-oculus/README.md
+++ b/runtime/functor-runtime-oculus/README.md
@@ -8,10 +8,10 @@ over the network (the `POST /reload-source` remote-develop loop).
 
 ## Status
 
-Phase 1 **verified on hardware** (Quest 3, Horizon OS v205): the OpenXR shell
-reaches session FOCUSED and renders the placeholder scene in stereo through
-the shared `render_frame` path. Remaining device bring-up: the Functor Lang producer,
-network reload, controller input, asymmetric-frustum projection.
+The OpenXR shell, interpreted Functor Lang producer, and USB remote-develop
+loop are **verified on hardware** (Quest 3, Horizon OS v205). Per-eye rendering
+uses each view's exact asymmetric OpenXR frustum. Remaining device bring-up:
+controller input and asset sync.
 
 ## The remote-develop loop (M1)
 

--- a/runtime/functor-runtime-oculus/src/lib.rs
+++ b/runtime/functor-runtime-oculus/src/lib.rs
@@ -224,11 +224,9 @@ fn create_eye_target(
     }
 }
 
-/// Derive a Functor `Camera` from an OpenXR eye view. The vertical field of
-/// view is symmetrized (`angle_up - angle_down`) — Quest eye frusta are
-/// mildly asymmetric, so this is approximate. TODO(device bring-up): teach
-/// the shared renderer to take a raw projection matrix so the exact
-/// asymmetric frustum (and correct stereo overlap) is used.
+/// Derive a Functor `Camera` from an OpenXR eye view. The exact asymmetric
+/// projection is built separately from `view.fov` and passed directly to the
+/// shared renderer; this camera owns the eye pose and clip distances.
 fn camera_from_view(view: &xr::View) -> Camera {
     let p = view.pose.position;
     let o = view.pose.orientation;
@@ -614,14 +612,22 @@ pub fn android_main(app: AndroidApp) {
                 gl.disable(glow::SCISSOR_TEST);
                 gl.enable(glow::DEPTH_TEST);
             }
-            functor_runtime_common::render_frame(
+            let camera = camera_from_view(view);
+            let projection = camera.projection_matrix_from_fov_angles(
+                view.fov.angle_left,
+                view.fov.angle_right,
+                view.fov.angle_down,
+                view.fov.angle_up,
+            );
+            functor_runtime_common::render_frame_with_projection(
                 &gl,
                 "#version 300 es",
                 asset_cache.clone(),
                 &scene_context,
                 &shadow_map,
                 &frame,
-                &camera_from_view(view),
+                &camera,
+                &projection,
                 frame_time.clone(),
                 Viewport::new(eye.width, eye.height),
                 functor_runtime_common::DebugRenderMode::Default,


### PR DESCRIPTION
## Summary

- preserve each OpenXR view's exact asymmetric four-angle FOV instead of reducing it to a centered vertical FOV
- add a narrowly scoped shared-renderer projection override for XR main passes while leaving desktop, web, and render-target cameras unchanged
- cover symmetric, asymmetric, and reversed-FOV projection behavior with unit tests
- update Oculus status and VR follow-up documentation

## Root cause

The Oculus shell rendered each eye with a centered projection but submitted the runtime's original asymmetric `XrFovf` to the compositor. The rendered pixels and compositor warp therefore disagreed about each eye's optical center, producing double vision.

## Verification

- `cargo test -p functor_runtime_common` — 373 tests passed (366 unit + 7 integration; one doc test ignored)
- `cargo check -p functor_runtime_common`
- `npm run build:oculus`
- `npm run build:oculus:apk` — APK signed and both arm64 native libraries alignment-verified
- installed and launched autonomously on an ADB-attached Quest 3; OpenXR reached `FOCUSED` with 1680×1760 swapchains per eye and no runtime errors
- user verified in-headset that binocular fusion is correct in the updated build
- cross-engine adversarial review: both reviewers reported no correctness, simplicity, duplication, or visual findings; zero agreed Critical/High issues
- duplication scan found no actionable new duplication

### Per-frame benchmark

Release `frame_bench`, three runs per side; wall-clock columns use the best minimum. Allocations and bytes are deterministic and remained identical.

| Scene | Before | After | Allocs/frame | Bytes/frame |
| --- | ---: | ---: | ---: | ---: |
| 20×20 | 429.3 µs | 429.8 µs | 13,877 | 842,251 |
| 40×40 | 1,692.4 µs | 1,698.0 µs | 54,717 | 3,306,091 |
| 56×56 | 3,300.2 µs | 3,310.9 µs | 106,973 | 6,459,115 |

The 0.1–0.3% timing differences are within observed run-to-run noise.

## Before → after

**Before — centered projection**

![Quest compositor capture before the projection fix](https://gist.githubusercontent.com/tommy-xr/525263616aa0d49619d03a03bce0e9fc/raw/functor-quest-audit.png)

**After — exact asymmetric per-eye projection**

![Quest compositor capture after the projection fix](https://gist.githubusercontent.com/tommy-xr/525263616aa0d49619d03a03bce0e9fc/raw/functor-after-projection.png)

![Second post-fix Quest compositor capture](https://gist.githubusercontent.com/tommy-xr/525263616aa0d49619d03a03bce0e9fc/raw/functor-diagnostic.png)

<sub>Original ADB compositor captures. Head pose differs between before and after. Raw eye panels exercise the per-eye path but cannot alone prove fusion; the post-fix build was also confirmed in-headset.</sub>

## Device recording

![Four-second Quest recording after the projection fix](https://gist.githubusercontent.com/tommy-xr/525263616aa0d49619d03a03bce0e9fc/raw/functor-after-final.gif)

<sub>Four-second, 48-frame ADB recording from the clean final APK.</sub>

Media gist: https://gist.github.com/tommy-xr/525263616aa0d49619d03a03bce0e9fc
