### PR TITLE
refactor: unify the producer reload clock behind now_ms()

### DIFF
--- a/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
@@ -26,8 +26,8 @@ use functor_lang::{Session, Value};
 
 use crate::functor_lang_prelude::{
     audio_scene_of, clear_audio_completions, clear_http_taggers, clear_preload_completions,
-    contains_effect, epoch_seconds, frame_value, html_node_value, take_ui_handlers, view_value,
-    EffectLog, EffectRunner, EffectTree, FunctorHost, NetEventKind, RealEffects, UiHandler,
+    contains_effect, frame_value, html_node_value, now_ms, take_ui_handlers, view_value, EffectLog,
+    EffectRunner, EffectTree, FunctorHost, NetEventKind, RealEffects, UiHandler,
 };
 use crate::functor_lang_producer::{
     journal_arm, journal_swap, FrameCtx, JournalEntry, Reporter, SpanSource,
@@ -39,11 +39,6 @@ use crate::timetravel::SceneRecorder;
 use crate::ui::View;
 use crate::webview::HtmlNode;
 use crate::{Frame, FrameTime};
-
-/// Milliseconds on the shared portable clock (see `epoch_seconds`).
-fn now_ms() -> f64 {
-    epoch_seconds() * 1000.0
-}
 
 fn replay_status(history_replay: Option<(usize, f64)>) -> String {
     history_replay.map_or_else(String::new, |(frames, elapsed_ms)| {

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -541,6 +541,14 @@ pub(crate) fn epoch_seconds() -> f64 {
     }
 }
 
+/// Milliseconds on the shared portable clock (see [`epoch_seconds`]). `pub` so
+/// both producers — the embedded one in this crate and the web one in the
+/// separate `functor-runtime-web` crate — time reloads/rewinds/seeks with the
+/// same clock instead of each reaching for a platform-specific `Date::now()`.
+pub fn now_ms() -> f64 {
+    epoch_seconds() * 1000.0
+}
+
 impl RealEffects {
     #[allow(clippy::new_without_default)]
     pub fn new() -> RealEffects {

--- a/runtime/functor-runtime-web/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-web/src/functor_lang_game.rs
@@ -25,7 +25,7 @@ use functor_lang::project::SourceMap;
 use functor_lang::{Session, Value};
 use functor_runtime_common::functor_lang_prelude::{
     audio_scene_of, clear_audio_completions, clear_http_taggers, clear_preload_completions,
-    contains_effect, frame_value, html_node_value, take_ui_handlers, view_value, EffectLog,
+    contains_effect, frame_value, html_node_value, now_ms, take_ui_handlers, view_value, EffectLog,
     EffectRunner, EffectTree, FunctorHost, NetEventKind, RealEffects, UiHandler,
 };
 use functor_runtime_common::functor_lang_producer::{
@@ -494,7 +494,7 @@ impl FunctorLangWebGame {
         // generation anchored at this rebound live frame.
         self.recorder
             .finish_reload(&self.model, self.physics_frame, live_model_was_safe);
-        let replay_started = js_sys::Date::now();
+        let replay_started = now_ms();
         let history_replay = match
             functor_runtime_common::functor_lang_producer::materialize_counterfactual_history(
                 &self.session,
@@ -505,7 +505,7 @@ impl FunctorLangWebGame {
                 !self.input_buf.is_empty(),
             )
         {
-            Ok(frames) => frames.map(|frames| (frames, js_sys::Date::now() - replay_started)),
+            Ok(frames) => frames.map(|frames| (frames, now_ms() - replay_started)),
             Err(error) => {
                 self.reporter.report_once(format!("[functor-lang] {error}"));
                 None
@@ -588,7 +588,7 @@ impl GameProducer for FunctorLangWebGame {
         // push keeps the old program (and the error goes back to the pusher,
         // who is looking at the source that caused it). No mtime bookkeeping
         // — the browser has no file watcher; pushes are the only reload.
-        let started = js_sys::Date::now();
+        let started = now_ms();
         // The push replaces the ENTRY buffer; siblings keep their last-fetched
         // text (the web has no filesystem to re-read, unlike the desktop
         // producer). A load failure leaves `self.sources` untouched.
@@ -610,7 +610,7 @@ impl GameProducer for FunctorLangWebGame {
         let status = format!(
             "reloaded {} from pushed source in {:.2}ms (model preserved{stored}{history})",
             self.path,
-            js_sys::Date::now() - started
+            now_ms() - started
         );
         web_sys::console::log_1(&format!("[functor-lang] {status}").into());
         Ok(status)
@@ -625,7 +625,7 @@ impl GameProducer for FunctorLangWebGame {
         if files.is_empty() {
             return Err("a pushed project needs at least the entry file".to_string());
         }
-        let started = js_sys::Date::now();
+        let started = now_ms();
         let loaded = load_source(files)?;
         self.sources = files.to_vec();
         self.path = files[0].0.clone();
@@ -641,7 +641,7 @@ impl GameProducer for FunctorLangWebGame {
 (model preserved{stored}{history})",
             self.path,
             files.len(),
-            js_sys::Date::now() - started
+            now_ms() - started
         );
         web_sys::console::log_1(&format!("[functor-lang] {status}").into());
         Ok(status)


### PR DESCRIPTION
First step of the web↔embedded Functor Lang producer convergence (plan: `producer-convergence.md`).

## What

Both producers timed reloads/rewinds/seeks with their own clock:
- **embedded** (`functor_lang_game_embedded.rs`) — a private `now_ms()` = `epoch_seconds() * 1000.0`
- **web** (`functor_lang_game.rs`) — raw `js_sys::Date::now()`, because `epoch_seconds` is `pub(crate)` and web is a separate crate

This exposes `functor_lang_prelude::now_ms()` and routes both through it. Embedded drops its private copy; web replaces all 6 `js_sys::Date::now()` timing sites.

## Why

Prep for merging the two ~1100-line near-identical producer shells. The reload/rewind/seek timing was one of only two genuine platform-seam items; `epoch_seconds()` is already `#[cfg(wasm32)]`-routed to `Date::now()`, so this collapse is free.

## Behavior

Identical. On wasm `now_ms()` = `(Date::now()/1000)*1000` = `Date::now()` (at most ~1 ULP off); the value feeds only displayed `{:.2}ms` reload-timing numbers. On native both producers already shared `epoch_seconds`.

## Verification

- `cargo build -p functor_runtime_common --features strict` → clean
- embedded producer inline test (`boots_ticks_renders_and_reloads_preserving_the_model`) → pass
- `cargo build -p functor-runtime-web --target wasm32-unknown-unknown` → clean

## Review

Cross-engine `/xreview` (Codex `medium` + Claude Opus 4.8), stack-aware `main...HEAD`. **Both engines independently returned no findings.** [AGREED] dispositions:
- wasm float round-trip is at most ~1 ULP, immaterial at `{:.2}ms` display resolution and used only as a difference of two identically-transformed reads — not a bug.
- All 6 replacements preserve intent; no orphaned `js_sys`/`epoch_seconds` imports or dead code.
- `pub` (vs `pub(crate)`) is necessary — the web crate is separate.

Verdict: ship as-is (0 Critical / 0 High / 0 Medium).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
