### PR TITLE
feat(site): homepage refresh — grounded copy, aurora backdrop, platforms, spacing system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,6 +269,18 @@ assembles the GIF, hosts the binaries in a gist, and embeds them in the PR body 
 and it runs the capture in a subagent so the image-heavy work stays out of the
 main context.
 
+## The marketing site (`site/`)
+
+When working on the marketing site (`site/` — the landing page, sandbox, and docs;
+static HTML/CSS/JS built by `site/build.mjs`, served with `npm run site:serve`),
+**use the `frontend-design` skill** for any visual/layout/copy work. It calibrates the
+design toward a distinctive, intentional aesthetic and away from generic defaults —
+load it before editing markup or styles. The site has an established look (synthwave:
+dark-violet base, cyan primary + pink accent, Orbitron display / JetBrains Mono body,
+a shared spacing scale in `:root`); extend that system rather than inventing a new one,
+and verify changes by building and screenshotting (headless Chrome via Playwright works)
+across desktop **and** mobile widths.
+
 ## Performance-sensitive changes
 
 Whenever a change touches a **per-frame hot path** — the interpreter/evaluator

--- a/site/build.mjs
+++ b/site/build.mjs
@@ -53,29 +53,29 @@ await rm(dist, { recursive: true, force: true });
 await mkdir(`${dist}/pkg`, { recursive: true });
 await mkdir(`${dist}/examples`, { recursive: true });
 
-// The latest release tag (vX.Y.Z), stamped into each page's header
-// version-badge so the deployed site names the release it accompanies. No
-// reachable tag (fresh history, shallow checkout) → the badge stays the
-// source's plain "alpha".
-let version = "";
+// The header version-badge names the build. On an exact release tag (vX.Y.Z)
+// it reads "vX.Y.Z · alpha"; every other checkout — local dev, ahead of a tag,
+// shallow, or no tags at all — reads "v0.0.0 · dev", so a dev build never
+// mislabels itself as the release it merely descends from.
+let badge = "v0.0.0 · dev";
 try {
-  const tag = execSync("git describe --tags --abbrev=0 --match 'v[0-9]*'", {
+  const tag = execSync("git describe --tags --exact-match --match 'v[0-9]*'", {
     cwd: root,
     stdio: ["ignore", "pipe", "ignore"],
   })
     .toString()
     .trim();
-  if (/^v\d+\.\d+\.\d+$/.test(tag)) version = tag;
+  if (/^v\d+\.\d+\.\d+$/.test(tag)) badge = `${tag} · alpha`;
 } catch {}
 
 for (const page of PAGES) {
-  if (version && page.endsWith(".html")) {
+  if (page.endsWith(".html")) {
     const html = await readFile(`${site}${page}`, "utf8");
     await writeFile(
       `${dist}/${page}`,
       html.replace(
         /(<span class="version-badge"[^>]*>)[^<]*(<\/span>)/,
-        `$1${version} · alpha$2`
+        `$1${badge}$2`
       )
     );
   } else {

--- a/site/index.html
+++ b/site/index.html
@@ -21,9 +21,18 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body class="landing-page">
+    <!-- Backdrop: a slow cyan/violet/pink aurora wash. Purely decorative. -->
+    <div class="site-backdrop" aria-hidden="true"></div>
+
     <header class="site-header">
       <a class="wordmark" href="./"><svg class="wordmark-mark" viewBox="366 163 385 690" fill="currentColor" aria-hidden="true"><path d="M382 341 545 179H735L615 300H548L382 466Z"/><path d="M382 493 497 380V748L382 837Z"/><path d="M518 426H693L597 522H518Z"/></svg>FUNCTOR</a>
       <span class="version-badge" title="Functor is alpha software — everything may change between releases">alpha</span>
+      <input type="checkbox" id="nav-toggle" class="nav-toggle" hidden />
+      <label class="nav-burger" for="nav-toggle" aria-label="Toggle menu">
+        <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
+          <line x1="4" y1="7" x2="20" y2="7" /><line x1="4" y1="12" x2="20" y2="12" /><line x1="4" y1="17" x2="20" y2="17" />
+        </svg>
+      </label>
       <nav class="site-nav">
         <a href="sandbox.html">Sandbox</a>
         <a href="docs.html">Docs</a>
@@ -36,15 +45,13 @@
     <section class="hero">
       <div class="hero-copy">
         <h1 class="hero-title">FUNCTOR</h1>
-        <p class="hero-tagline">A functional toolkit for 3D games.</p>
+        <p class="hero-tagline">Game development from an alternate timeline.</p>
         <p class="hero-sub">
-          Write your game in Functor Lang — a tiny interpreted language — and edit it live while
-          it runs, with the model preserved mid-frame. Every session records itself, so you can
-          pause the running game and scrub back through its timeline.
+          A free, open-source 3D game engine.
         </p>
         <div class="hero-actions">
           <a class="button-primary" href="sandbox.html">▶ Open the sandbox</a>
-          <a class="button-ghost" href="docs.html">Get started</a>
+          <a class="button-pink" href="docs.html">Get started</a>
         </div>
       </div>
       <div class="hero-demo">
@@ -58,119 +65,109 @@
           <!-- Reserved slot: commit 5 mounts a small editable code panel here. -->
           <div id="hero-editor" class="hero-editor" hidden></div>
         </div>
-        <p class="hero-caption">
-          This is live. Change a number and watch it take hold mid-wave — or drag the
-          timeline to rewind the scene.
-        </p>
       </div>
     </section>
 
-    <section class="code-sample">
-      <h2>The language</h2>
-      <p>
-        Model–View–Update, all the way down. This is real Functor Lang — hit
-        <strong>▶ try it</strong> to open it live in the sandbox.
-      </p>
-      <pre><code><span class="tok-c">// a pulsing sphere with a beat counter</span>
-<span class="tok-k">type</span> <span class="tok-t">Msg</span> = | <span class="tok-t">Beat</span>
-
-<span class="tok-k">let</span> init = { spin: <span class="tok-n">0.0</span>, beat: <span class="tok-n">0.0</span> }
-
-<span class="tok-k">let</span> tick = (model, dt: <span class="tok-t">Float</span>, tts: <span class="tok-t">Float</span>) =>
-  { model <span class="tok-k">with</span> spin: model.spin + dt }
-
-<span class="tok-k">let</span> update = (model, msg) =>
-  <span class="tok-k">match</span> msg <span class="tok-k">with</span>
-  | <span class="tok-t">Beat</span> => { model <span class="tok-k">with</span> beat: model.beat + <span class="tok-n">1.0</span> }
-
-<span class="tok-k">let</span> subscriptions = (model) => <span class="tok-t">Sub</span>.every(<span class="tok-t">Time</span>.seconds(<span class="tok-n">1.0</span>), <span class="tok-t">Beat</span>)
-
-<span class="tok-k">let</span> draw = (model, tts: <span class="tok-t">Float</span>) =>
-  <span class="tok-t">Frame</span>.create(
-    <span class="tok-t">Camera</span>.lookAt(<span class="tok-n">0.0</span>, <span class="tok-n">2.0</span>, <span class="tok-n">-6.0</span>, <span class="tok-n">0.0</span>, <span class="tok-n">0.0</span>, <span class="tok-n">0.0</span>),
-    <span class="tok-t">Scene</span>.sphere()
-      |> <span class="tok-t">Scene</span>.emissive(<span class="tok-n">1.0</span>, <span class="tok-n">0.3</span>, <span class="tok-n">0.8</span>)
-      |> <span class="tok-t">Scene</span>.scale(<span class="tok-n">1.0</span> + <span class="tok-n">0.2</span> * <span class="tok-t">Math</span>.sin(model.spin * <span class="tok-n">4.0</span>)))</code><a
-        class="try-button"
-        href="sandbox.html#src=Ly8gYSBwdWxzaW5nIHNwaGVyZSB3aXRoIGEgYmVhdCBjb3VudGVyCnR5cGUgTXNnID0gfCBCZWF0CgpsZXQgaW5pdCA9IHsgc3BpbjogMC4wLCBiZWF0OiAwLjAgfQoKbGV0IHRpY2sgPSAobW9kZWwsIGR0OiBGbG9hdCwgdHRzOiBGbG9hdCkgPT4KICB7IG1vZGVsIHdpdGggc3BpbjogbW9kZWwuc3BpbiArIGR0IH0KCmxldCB1cGRhdGUgPSAobW9kZWwsIG1zZykgPT4KICBtYXRjaCBtc2cgd2l0aAogIHwgQmVhdCA9PiB7IG1vZGVsIHdpdGggYmVhdDogbW9kZWwuYmVhdCArIDEuMCB9CgpsZXQgc3Vic2NyaXB0aW9ucyA9IChtb2RlbCkgPT4gU3ViLmV2ZXJ5KFRpbWUuc2Vjb25kcygxLjApLCBCZWF0KQoKbGV0IGRyYXcgPSAobW9kZWwsIHR0czogRmxvYXQpID0-CiAgRnJhbWUuY3JlYXRlKAogICAgQ2FtZXJhLmxvb2tBdCgwLjAsIDIuMCwgLTYuMCwgMC4wLCAwLjAsIDAuMCksCiAgICBTY2VuZS5zcGhlcmUoKQogICAgICB8PiBTY2VuZS5lbWlzc2l2ZSgxLjAsIDAuMywgMC44KQogICAgICB8PiBTY2VuZS5zY2FsZSgxLjAgKyAwLjIgKiBNYXRoLnNpbihtb2RlbC5zcGluICogNC4wKSkp"
-        title="Open this program live in the sandbox"
-        target="_blank"
-        >▶ try it</a></pre>
+    <section class="fun-interstitial">
+      <p>Put the <span class="fun-accent">fun</span> in functional programming.</p>
     </section>
 
     <section class="differentiators">
-      <h2 class="section-title">What makes it different</h2>
+      <h2 class="section-title">Features</h2>
       <div class="features">
         <div class="feature">
-          <h2>Whole-game time travel</h2>
+          <h2>Instant Feedback</h2>
           <p>
-            Every session records itself as it runs. Pause, drag the timeline back, and
-            single-step forward — the whole game replays, deterministically.
+            Edit your game while it runs. The runtime swaps your code under the live model —
+            no rebuild, no restart, no losing your place.
           </p>
         </div>
         <div class="feature">
-          <h2>State-preserving hot reload</h2>
+          <h2>Travel Through Time</h2>
           <p>
-            Save an edit and the runtime swaps the program under the running model. Closures
-            rebind to the new code and their captured values carry over — the ball keeps bouncing,
-            mid-arc, with your new gravity.
+            Rewind while editing, make changes, or extrapolate forward to see how your edits
+            ripple through gameplay.
           </p>
         </div>
         <div class="feature">
-          <h2>Pure MVU + honest effects</h2>
+          <h2>Batteries Included</h2>
           <p>
-            A game is pure Model–View–Update. Effects are values too — randomness, time, network —
-            performed by the shell and folded back through <code>update</code>.
+            Asset management, networking, physics, and spatial audio — in the box, ready to use.
           </p>
         </div>
         <div class="feature">
-          <h2>One source, every target</h2>
+          <h2>Introspective</h2>
           <p>
-            The same <code>.fun</code> runs on desktop GL, browser WebGL2, and Quest OpenXR — one
-            renderer behind all three: primitives, glTF, lighting and shadows, physics, spatial
-            audio.
+            Analyze the live values coursing through your game at any moment — nothing is hidden
+            behind opaque binary state.
+          </p>
+        </div>
+        <div class="feature">
+          <h2>LLM-Native</h2>
+          <p>
+            Games run and respond headlessly, so your favorite coding agent can build right
+            alongside you.
           </p>
         </div>
       </div>
-      <p class="llm-banner">
-        <strong>LLM-native.</strong> The runtime is introspectable at runtime: a text-only path
-        with no GPU window, live evaluation, and serializable state an agent can drive and observe.
-      </p>
     </section>
 
     <section class="how-it-works">
-      <h2>How it works</h2>
-      <ol>
-        <li>
-          <strong>Games are written in Functor Lang</strong> — a small, interpreted, F#-inspired functional
-          language. There is no compile step: the source ships as text and a tree-walking
-          interpreter inside the runtime evaluates it, natively and in the browser.
-        </li>
-        <li>
-          <strong>Because there is no build, the same source runs live in the browser</strong> —
-          that is the in-page <a href="sandbox.html">sandbox</a>: edit the code and the runtime
-          swaps the program under the running model, no rebuild.
-        </li>
-        <li>
-          <strong>The runtime is the imperative shell</strong>: rendering, input, physics
-          stepping, audio, networking. Your game stays a pure
-          <code>model → Frame</code> function.
-        </li>
-      </ol>
+      <h2>How does it work?</h2>
+      <p>
+        Functor is a functional language built for game development, inspired by Elm and F#.
+        Pure functions, interpreted, no compilation. Functor lives in a Rust runtime that does
+        the heavy lifting — graphics and physics.
+      </p>
+    </section>
+
+    <section class="platforms">
+      <h2 class="section-title">Build and run anywhere</h2>
+      <div class="platform-grid">
+        <div class="platform">
+          <div class="platform-icons">
+            <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M3 5.1 10.2 4v7.1H3zm8.4-1.3L21 2.5v8.6h-9.6zM3 12.9h7.2V20L3 18.9zm8.4 0H21v8.6l-9.6-1.3z"/></svg>
+            <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.05 12.04c-.03-2.6 2.13-3.85 2.22-3.91-1.21-1.77-3.1-2.02-3.77-2.05-1.6-.16-3.13.94-3.94.94-.81 0-2.07-.92-3.4-.9-1.75.03-3.36 1.02-4.26 2.58-1.82 3.16-.47 7.83 1.3 10.4.86 1.25 1.89 2.66 3.24 2.61 1.3-.05 1.79-.84 3.36-.84 1.57 0 2.01.84 3.39.81 1.4-.02 2.29-1.28 3.15-2.54.99-1.46 1.4-2.87 1.42-2.94-.03-.01-2.72-1.04-2.75-4.13zM14.6 4.6c.72-.87 1.2-2.08 1.07-3.28-1.03.04-2.28.69-3.02 1.56-.66.77-1.24 2-1.08 3.18 1.15.09 2.32-.58 3.03-1.46z"/></svg>
+          </div>
+          <h3>Native</h3>
+          <p>Windows · macOS</p>
+        </div>
+        <div class="platform">
+          <div class="platform-icons">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><circle cx="12" cy="12" r="9" /><path d="M3 12h18M12 3c2.5 2.5 3.9 5.7 3.9 9s-1.4 6.5-3.9 9c-2.5-2.5-3.9-5.7-3.9-9S9.5 5.5 12 3z" /></svg>
+          </div>
+          <h3>Browser</h3>
+          <p>WebAssembly · no install</p>
+        </div>
+        <div class="platform">
+          <div class="platform-icons">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><path d="M4.2 8.5h15.6c.94 0 1.7.76 1.7 1.7v3.4c0 .94-.76 1.7-1.7 1.7h-3.9c-.53 0-1.03-.25-1.35-.68l-1.03-1.37c-.68-.9-2.06-.9-2.74 0l-1.03 1.37c-.32.43-.82.68-1.35.68H4.2c-.94 0-1.7-.76-1.7-1.7v-3.4c0-.94.76-1.7 1.7-1.7z" /></svg>
+          </div>
+          <h3>VR</h3>
+          <p>Meta Quest</p>
+        </div>
+      </div>
     </section>
 
     <section class="cta-band">
       <h2>Build a game as a pure function.</h2>
-      <p>Nothing to install — write Functor Lang in the browser and watch it hot-reload live.</p>
+      <p>Nothing to install — try in the browser now.</p>
       <a class="button-primary" href="sandbox.html">▶ Open the sandbox</a>
     </section>
 
-    <hr class="gradient-rule" />
-
     <footer class="landing-footer">
-      <p>
-        <a href="https://github.com/tommy-xr/functor">github.com/tommy-xr/functor</a>
-        · built with functor — the demo above is a <code>.fun</code> file
+      <div class="footer-brand">
+        <svg class="wordmark-mark" viewBox="366 163 385 690" fill="currentColor" aria-hidden="true"><path d="M382 341 545 179H735L615 300H548L382 466Z"/><path d="M382 493 497 380V748L382 837Z"/><path d="M518 426H693L597 522H518Z"/></svg>
+        <span>FUNCTOR</span>
+      </div>
+      <nav class="footer-links">
+        <a href="sandbox.html">Sandbox</a>
+        <a href="docs.html">Docs</a>
+        <a href="https://github.com/tommy-xr/functor">GitHub</a>
+      </nav>
+      <p class="footer-tagline">
+        Free &amp; open source ·
+        <a href="https://github.com/tommy-xr/functor/blob/main/LICENSE">MIT License</a>
       </p>
     </footer>
 

--- a/site/index.html
+++ b/site/index.html
@@ -27,7 +27,7 @@
     <header class="site-header">
       <a class="wordmark" href="./"><svg class="wordmark-mark" viewBox="366 163 385 690" fill="currentColor" aria-hidden="true"><path d="M382 341 545 179H735L615 300H548L382 466Z"/><path d="M382 493 497 380V748L382 837Z"/><path d="M518 426H693L597 522H518Z"/></svg>FUNCTOR</a>
       <span class="version-badge" title="Functor is alpha software — everything may change between releases">alpha</span>
-      <input type="checkbox" id="nav-toggle" class="nav-toggle" hidden />
+      <input type="checkbox" id="nav-toggle" class="nav-toggle" />
       <label class="nav-burger" for="nav-toggle" aria-label="Toggle menu">
         <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
           <line x1="4" y1="7" x2="20" y2="7" /><line x1="4" y1="12" x2="20" y2="12" /><line x1="4" y1="17" x2="20" y2="17" />

--- a/site/styles.css
+++ b/site/styles.css
@@ -79,15 +79,6 @@ a:hover {
   background-clip: padding-box;
 }
 
-/* Flourish (b): the one decorative divider — a thin cyan→pink rule. */
-.gradient-rule {
-  height: 1px;
-  border: 0;
-  max-width: 780px;
-  margin: 0 auto;
-  background: linear-gradient(90deg, var(--cyan), var(--pink));
-}
-
 /* ------------------------------------------------------------- site header */
 
 /* Shared top bar across the landing, sandbox, and docs pages: wordmark left,
@@ -118,6 +109,12 @@ a:hover {
   margin-left: auto;
 }
 
+/* The toggle checkbox is irrelevant off the mobile breakpoint (nav is always
+   shown), so drop it from the layout and tab order there. */
+.nav-toggle {
+  display: none;
+}
+
 /* Hamburger toggle — hidden until the mobile breakpoint (landing only). */
 .nav-burger {
   display: none;
@@ -136,6 +133,27 @@ a:hover {
 @media (max-width: 620px) {
   .landing-page .nav-burger {
     display: inline-flex;
+  }
+
+  /* Keyboard-reachable but visually hidden — clip (not display:none) so it
+     stays focusable; keyboard focus lands here and Space toggles the menu. */
+  .landing-page .nav-toggle {
+    display: block;
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+  }
+
+  /* Surface that focus on the visible burger. */
+  .landing-page .nav-toggle:focus-visible ~ .nav-burger {
+    color: var(--cyan);
+    outline: 2px solid var(--cyan);
+    outline-offset: 3px;
+    border-radius: 3px;
   }
 
   /* Collapse the links into a dropdown that the checkbox reveals. */
@@ -341,7 +359,6 @@ a:hover {
 }
 
 .button-primary,
-.button-ghost,
 .button-pink {
   font-family: var(--font-mono);
   font-weight: 600;
@@ -380,17 +397,6 @@ a:hover {
   border-color: #5ce2ee;
   transform: translateY(-2px);
   box-shadow: 0 10px 22px -10px rgba(0, 0, 0, 0.75), 0 0 26px -6px rgba(65, 216, 230, 0.7);
-}
-
-.button-ghost {
-  color: var(--text-dim);
-  border: 1px solid var(--line);
-}
-
-.button-ghost:hover {
-  text-decoration: none;
-  color: var(--cyan);
-  border-color: var(--cyan);
 }
 
 /* Differentiators + section titles. */

--- a/site/styles.css
+++ b/site/styles.css
@@ -16,6 +16,16 @@
   --red: #f2637f;
   --font-display: "Orbitron", system-ui, sans-serif;
   --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, monospace;
+
+  /* Spacing scale — a single rhythm the whole landing page snaps to. */
+  --space-xs: 8px;
+  --space-sm: 16px;
+  --space-md: 24px;
+  --space-lg: 40px;
+  --space-xl: 64px;
+  --space-2xl: 96px;
+  /* Vertical gap between major landing sections. */
+  --section-gap: var(--space-2xl);
 }
 
 * {
@@ -92,11 +102,57 @@ a:hover {
   border-bottom: 1px solid var(--line);
 }
 
+/* Landing only: keep the bar pinned as you scroll, lifted with a soft shadow.
+   Scoped away from the sandbox/docs full-height flex layouts. */
+.landing-page .site-header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  box-shadow: 0 2px 14px rgba(0, 0, 0, 0.45);
+}
+
 .site-nav {
   display: flex;
   align-items: center;
   gap: 20px;
   margin-left: auto;
+}
+
+/* Hamburger toggle — hidden until the mobile breakpoint (landing only). */
+.nav-burger {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  margin-left: auto;
+  padding: 4px;
+  color: var(--text-dim);
+  cursor: pointer;
+}
+
+.nav-burger:hover {
+  color: var(--cyan);
+}
+
+@media (max-width: 620px) {
+  .landing-page .nav-burger {
+    display: inline-flex;
+  }
+
+  /* Collapse the links into a dropdown that the checkbox reveals. */
+  .landing-page .site-nav {
+    display: none;
+    order: 3;
+    flex-basis: 100%;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+    margin-left: 0;
+    padding: 6px 0 4px;
+  }
+
+  .landing-page .nav-toggle:checked ~ .site-nav {
+    display: flex;
+  }
 }
 
 .site-nav a {
@@ -124,16 +180,62 @@ a:hover {
 
 /* ---------------------------------------------------------------- landing */
 
+/* Synthwave backdrop for the landing page only. Two fixed layers behind all
+   content (z-index -1), so they cost nothing to lay out and don't scroll:
+   ::before  — very faint grain so the large gradients don't band.
+   .site-backdrop — a slow cyan/violet/pink aurora wash that drifts.
+   The body must be transparent (the base --bg stays on <html>) or its opaque
+   fill would paint over the z-index:-1 layers. */
+.landing-page {
+  background: transparent;
+}
+
+.landing-page::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='140' height='140' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E");
+}
+
+.site-backdrop {
+  position: fixed;
+  inset: -12%;
+  z-index: -2;
+  pointer-events: none;
+  background:
+    radial-gradient(40% 55% at 20% 24%, rgba(65, 216, 230, 0.09), transparent 64%),
+    radial-gradient(44% 52% at 82% 14%, rgba(232, 88, 184, 0.07), transparent 64%),
+    radial-gradient(56% 60% at 60% 88%, rgba(126, 86, 224, 0.08), transparent 68%);
+  animation: aurora-drift 28s ease-in-out infinite alternate;
+}
+
+@keyframes aurora-drift {
+  from {
+    transform: translate3d(-3%, -2%, 0) scale(1.05) rotate(-2deg);
+  }
+  to {
+    transform: translate3d(4%, 3%, 0) scale(1.15) rotate(2deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .site-backdrop {
+    animation: none;
+  }
+}
+
 /* Hero mini-sandbox band: copy left, a live demo card right; stacks below 900px. */
 .hero {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   align-items: center;
-  gap: 56px;
-  max-width: 1160px;
+  gap: var(--space-xl);
+  max-width: 1100px;
   min-height: 72vh;
   margin: 0 auto;
-  padding: 56px 24px;
+  padding: var(--space-xl) var(--space-md);
 }
 
 .hero-copy {
@@ -161,13 +263,6 @@ a:hover {
   aspect-ratio: 16 / 10;
   border: 0;
   background: #0d0221;
-}
-
-.hero-caption {
-  margin: 14px 2px 0;
-  font-size: 0.8rem;
-  color: var(--text-dim);
-  font-style: italic;
 }
 
 /* The live code panel below the scene, inside the card. ~8 visible lines of
@@ -246,7 +341,8 @@ a:hover {
 }
 
 .button-primary,
-.button-ghost {
+.button-ghost,
+.button-pink {
   font-family: var(--font-mono);
   font-weight: 600;
   letter-spacing: 0.04em;
@@ -254,6 +350,22 @@ a:hover {
   border-radius: 4px;
   font-size: 0.85rem;
   line-height: 1.4;
+  transition: transform 0.15s ease, background 0.2s ease, border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.button-pink {
+  color: var(--bg);
+  background: var(--pink);
+  border: 1px solid var(--pink);
+}
+
+.button-pink:hover {
+  text-decoration: none;
+  background: #f06fc6;
+  border-color: #f06fc6;
+  transform: translateY(-2px);
+  box-shadow: 0 10px 22px -10px rgba(0, 0, 0, 0.75), 0 0 26px -6px rgba(232, 88, 184, 0.7);
 }
 
 .button-primary {
@@ -266,6 +378,8 @@ a:hover {
   text-decoration: none;
   background: #5ce2ee;
   border-color: #5ce2ee;
+  transform: translateY(-2px);
+  box-shadow: 0 10px 22px -10px rgba(0, 0, 0, 0.75), 0 0 26px -6px rgba(65, 216, 230, 0.7);
 }
 
 .button-ghost {
@@ -285,25 +399,32 @@ a:hover {
   letter-spacing: 0.06em;
   color: var(--text);
   font-size: 1.15rem;
-  max-width: 1180px;
+  max-width: 1100px;
   margin: 0 auto;
-  padding: 64px 24px 0;
+  padding: var(--section-gap) var(--space-md) 0;
+  text-align: center;
 }
 
+/* Five feature cards: flex-wrap + centered so a wrapped row (e.g. the orphan
+   5th) stays centered instead of stranded left. */
 .features {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
   gap: 24px;
-  max-width: 1180px;
+  max-width: 1100px;
   margin: 0 auto;
-  padding: 20px 24px 0;
+  padding: var(--space-md) var(--space-md) 0;
 }
 
 .feature {
+  flex: 1 1 180px;
+  max-width: 240px;
   background: var(--bg-panel);
   border: 1px solid var(--line);
   border-radius: 6px;
   padding: 20px 22px 18px;
+  box-shadow: 0 16px 38px -26px rgba(0, 0, 0, 0.85);
 }
 
 .feature h2 {
@@ -321,59 +442,86 @@ a:hover {
   font-size: 0.92rem;
 }
 
-.code-sample,
-.how-it-works {
-  max-width: 780px;
+/* Platforms — three grouped cards (Native / Browser / VR), centered like the
+   feature row so a wrapped card stays centered. */
+.platform-grid {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 24px;
+  max-width: 1100px;
   margin: 0 auto;
-  padding: 48px 24px 0;
+  padding: var(--space-md) var(--space-md) 0;
 }
 
-.code-sample h2,
+.platform {
+  flex: 1 1 220px;
+  max-width: 300px;
+  background: var(--bg-panel);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 28px 24px;
+  text-align: center;
+  box-shadow: 0 16px 38px -26px rgba(0, 0, 0, 0.85);
+}
+
+.platform-icons {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+  color: var(--cyan);
+  margin-bottom: 16px;
+}
+
+.platform-icons svg {
+  width: 30px;
+  height: 30px;
+  display: block;
+}
+
+.platform h3 {
+  font-family: var(--font-display);
+  font-size: 0.9rem;
+  letter-spacing: 0.06em;
+  color: var(--text);
+  margin: 0 0 6px;
+}
+
+.platform p {
+  color: var(--text-dim);
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.how-it-works {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: var(--section-gap) var(--space-md) 0;
+  text-align: center;
+}
+
 .how-it-works h2 {
   font-family: var(--font-display);
   letter-spacing: 0.06em;
   color: var(--text);
 }
 
-.code-sample p,
-.how-it-works li {
+/* Keep the prose at a comfortable reading measure, left-aligned under the
+   heading (not stretched across the full 1100px column). */
+.how-it-works p {
   color: var(--text-dim);
-}
-
-.code-sample pre {
-  position: relative;
-  background: var(--bg-panel);
-  border: 1px solid var(--line);
-  border-left: 3px solid var(--cyan);
-  border-radius: 6px;
-  padding: 20px;
-  overflow-x: auto;
-  font-size: 0.85rem;
-}
-
-/* The one-line LLM-native banner under the differentiators. */
-.llm-banner {
-  max-width: 1180px;
-  margin: 28px auto 0;
-  padding: 16px 22px;
-  background: var(--bg-panel);
-  border: 1px solid var(--line);
-  border-left: 3px solid var(--pink);
-  border-radius: 6px;
-  color: var(--text-dim);
-  font-size: 0.9rem;
-}
-
-.llm-banner strong {
-  color: var(--text);
-}
-
-/* Closing call-to-action band. */
-.cta-band {
-  text-align: center;
   max-width: 720px;
   margin: 0 auto;
-  padding: 72px 24px 24px;
+}
+
+/* Closing call-to-action band — left-aligned to the same column as the other
+   sections so all the headings share one left edge. */
+.cta-band {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: var(--section-gap) var(--space-md);
+  text-align: center;
 }
 
 .cta-band h2 {
@@ -384,7 +532,8 @@ a:hover {
 
 .cta-band p {
   color: var(--text-dim);
-  margin-bottom: 24px;
+  max-width: 720px;
+  margin: 0 auto 24px;
 }
 
 .tok-k { color: var(--pink); }
@@ -395,32 +544,103 @@ a:hover {
 .tok-a { color: var(--amber); }
 .tok-o { color: var(--text-dim); }
 
-.how-it-works ol {
-  padding-left: 20px;
+/* The "put the FUN in functional programming" band between the hero and features. */
+.fun-interstitial {
+  text-align: center;
+  padding: var(--section-gap) var(--space-md) 0;
 }
 
-.how-it-works li {
-  margin-bottom: 12px;
+.fun-interstitial p {
+  font-family: var(--font-display);
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  font-size: clamp(1.1rem, 2.6vw, 1.7rem);
+  color: var(--text-dim);
+  margin: 0;
 }
 
-.how-it-works code {
-  color: var(--green);
+.fun-interstitial .fun-accent {
+  background: linear-gradient(90deg, var(--cyan), var(--pink));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
 }
 
 .landing-footer {
-  text-align: center;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-sm);
   color: var(--text-dim);
   font-size: 0.85rem;
-  padding: 56px 24px 32px;
+  padding: var(--space-lg) var(--space-md);
+  background: #000;
+}
+
+/* Full-width cyan→pink accent along the very top of the footer. */
+.landing-footer::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, var(--cyan), var(--pink));
+}
+
+.footer-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  font-family: var(--font-display);
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  color: var(--text);
+  font-size: 0.85rem;
+}
+
+.footer-brand .wordmark-mark {
+  height: 1.5em;
+  width: auto;
+  color: var(--cyan);
+}
+
+.footer-links {
+  display: flex;
+  gap: 22px;
+}
+
+.footer-links a {
+  color: var(--text-dim);
+  letter-spacing: 0.03em;
+}
+
+.footer-links a:hover {
+  color: var(--cyan);
+  text-decoration: none;
+}
+
+.footer-tagline {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--text-dim);
 }
 
 /* Hero stacks to one column on narrow viewports. */
 @media (max-width: 900px) {
   .hero {
     grid-template-columns: 1fr;
-    gap: 32px;
+    gap: var(--space-lg);
     min-height: 0;
-    padding: 40px 24px;
+    padding: var(--space-lg) var(--space-md);
+  }
+}
+
+/* Tighten the section rhythm on phones. */
+@media (max-width: 620px) {
+  :root {
+    --section-gap: var(--space-xl);
   }
 }
 


### PR DESCRIPTION
Refreshes the marketing landing page (`site/`): de-LLM-ified copy, a calmer synthwave backdrop, a new Platforms section, and a consistent spacing system. Built with the `frontend-design` skill.

## What changed

**Copy**
- Hero → "Game development from an alternate timeline." / "A free, open-source 3D game engine."
- Removed the live-demo caption and the "The language" section (it lives in the docs)
- "What makes it different" → **Features** (5 cards; LLM-native folded in)
- "How it works" → **"How does it work?"** (Elm/F# prose)

**New Platforms section** — "Build and run anywhere": Native (Windows · macOS), Browser (WebAssembly), VR (Meta Quest).

**Backdrop** — subtle drifting cyan/violet **aurora** (CSS radial gradients) replacing the flat background; `prefers-reduced-motion` aware. (Explored an SVG "MVU pipeline" backdrop first — dropped it as too busy / semantically wrong.)

**Layout & styling**
- Shared **spacing scale** in `:root` drives a consistent section rhythm (96px desktop / 64px mobile)
- Centered section headers; balanced 5-up feature row; card drop-shadows
- **Full-width black footer** with an edge-to-edge cyan→pink accent; **MIT license** link
- Pink secondary button; **tactile button hover** (lift + drop-shadow + color glow)

**Mobile** — header collapses the nav into a **CSS-only hamburger** (scoped to the landing page; sandbox/docs headers untouched)

**`build.mjs`** — version badge reads `v0.0.0 · dev` off-release and `vX.Y.Z · alpha` only on an exact release tag (previously showed the nearest tag locally, which was misleading)

**`CLAUDE.md`** — added a note to use the `frontend-design` skill for site work

## Visuals

### Hero — before / after
| Before | After |
| --- | --- |
| ![before hero](https://gist.githubusercontent.com/tommy-xr/566ba18644d2f79f8c0f27ca56683251/raw/before-hero.png) | ![after hero](https://gist.githubusercontent.com/tommy-xr/566ba18644d2f79f8c0f27ca56683251/raw/after-hero.png) |

### New Platforms section
![platforms](https://gist.githubusercontent.com/tommy-xr/566ba18644d2f79f8c0f27ca56683251/raw/platforms.png)

### Full page (after)
![after full](https://gist.githubusercontent.com/tommy-xr/566ba18644d2f79f8c0f27ca56683251/raw/after-full.png)

## Verification
- `node site/build.mjs` succeeds; badge stamps `v0.0.0 · dev` on this branch
- Rendered headlessly (Playwright + Chrome) at desktop (1280) and mobile (390) widths; mobile hamburger open/closed verified; sandbox header confirmed unaffected

## Notes / follow-ups
- Draft pending `/xreview` (per definition of done — mainly the `build.mjs` badge logic)
- Per-feature hero **GIFs** are a planned follow-up (may restructure the feature cards into alternating gif/description rows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)