### PR TITLE
fix(site): version badge shows the real release on deploy, dev locally

### DIFF
--- a/site/build.mjs
+++ b/site/build.mjs
@@ -53,13 +53,18 @@ await rm(dist, { recursive: true, force: true });
 await mkdir(`${dist}/pkg`, { recursive: true });
 await mkdir(`${dist}/examples`, { recursive: true });
 
-// The header version-badge names the build. On an exact release tag (vX.Y.Z)
-// it reads "vX.Y.Z · alpha"; every other checkout — local dev, ahead of a tag,
-// shallow, or no tags at all — reads "v0.0.0 · dev", so a dev build never
-// mislabels itself as the release it merely descends from.
+// The header version-badge names the build. A deploy (CI — the functor.games
+// build) names the release it ships from: the nearest reachable vX.Y.Z, walked
+// back from HEAD (hence the deploy's fetch-depth: 0). A local build is stricter
+// — only an exact, clean release tag counts; dev work, a commit ahead of a tag,
+// or a dirty tag checkout all read "v0.0.0 · dev", so a working copy never
+// mislabels itself as a release it merely descends from.
 let badge = "v0.0.0 · dev";
 try {
-  const tag = execSync("git describe --tags --exact-match --match 'v[0-9]*'", {
+  const describe = process.env.CI
+    ? "git describe --tags --abbrev=0 --match 'v[0-9]*'"
+    : "git describe --tags --exact-match --dirty --match 'v[0-9]*'";
+  const tag = execSync(describe, {
     cwd: root,
     stdio: ["ignore", "pipe", "ignore"],
   })

--- a/site/styles.css
+++ b/site/styles.css
@@ -18,7 +18,6 @@
   --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, monospace;
 
   /* Spacing scale — a single rhythm the whole landing page snaps to. */
-  --space-xs: 8px;
   --space-sm: 16px;
   --space-md: 24px;
   --space-lg: 40px;


### PR DESCRIPTION
The header version-badge regressed to **`v0.0.0 · dev`** on the functor.games deploy.

## Cause
The badge switched to `git describe --exact-match`, which only matches a tag sitting **exactly on HEAD**. The deploy builds `main` (which is ahead of the last tag), so nothing matched and it fell through to the dev label. The old `--abbrev=0` (walk back to the nearest tag) is what the deploy workflow was designed around (`fetch-depth: 0`).

## Fix
Split deploy vs local:
- **CI (deploy)** → `git describe --tags --abbrev=0` — names the release it ships from (e.g. **`v0.1.0 · alpha`**).
- **Local** → `git describe --tags --exact-match --dirty` — only an exact, clean release tag counts; dev work / ahead-of-tag / dirty-tag all read **`v0.0.0 · dev`** (the original goal — a working copy never claims to be a release).

Also re-applies two review fixes that were dropped in the **#442** squash-merge:
- the `--dirty` guard (now part of the local path)
- the unused `--space-xs` spacing token

## Verification
```
node site/build.mjs      -> v0.0.0 · dev     (local)
CI=1 node site/build.mjs -> v0.1.0 · alpha   (deploy)
```
`--space-xs`: no remaining references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)