### PR TITLE
feat(site): standalone full-featured demo editor

### DIFF
--- a/site/build.mjs
+++ b/site/build.mjs
@@ -18,7 +18,7 @@ const site = fileURLToPath(new URL(".", import.meta.url));
 const root = fileURLToPath(new URL("..", import.meta.url));
 const dist = `${site}dist`;
 
-const PAGES = ["index.html", "sandbox.html", "ide.html", "player.html", "docs.html", "styles.css"];
+const PAGES = ["index.html", "sandbox.html", "ide.html", "player.html", "docs.html", "demo-editor.html", "styles.css"];
 
 // Favicons, generated from docs/media/functor-icon.svg by `npm run generate:icons`
 // (gitignored — site:build regenerates them first). Copied defensively so a stale
@@ -116,7 +116,7 @@ if (langPkgPresent) {
 }
 
 await esbuild.build({
-  entryPoints: [`${site}src/sandbox.js`, `${site}src/ide.js`, `${site}src/docs.js`, `${site}src/hero.js`],
+  entryPoints: [`${site}src/sandbox.js`, `${site}src/ide.js`, `${site}src/docs.js`, `${site}src/hero.js`, `${site}src/demo-editor.js`],
   bundle: true,
   minify: true,
   format: "esm",

--- a/site/demo-editor.html
+++ b/site/demo-editor.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" href="favicon.svg" type="image/svg+xml" />
+    <link rel="icon" href="favicon.ico" sizes="any" />
+    <title>functor — demo editor</title>
+    <meta
+      name="description"
+      content="A standalone, full-featured Functor Lang editor beside a live scene — used to record the site's feature-showcase demos."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Orbitron:wght@600;800&family=JetBrains+Mono:ital,wght@0,400;0,600;1,400&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <!-- Reuses the sandbox's full-height split layout (.sandbox-page /
+       .sandbox-split / .editor-pane / .preview-pane), minus all the chrome:
+       no header, picker, reset, or status bar. It exists to be recorded. -->
+  <body class="sandbox-page demo-editor-page">
+    <main class="sandbox-split">
+      <section class="editor-pane">
+        <div id="editor"></div>
+      </section>
+      <section class="preview-pane">
+        <iframe id="player" title="live game preview" allow="pointer-lock"></iframe>
+      </section>
+    </main>
+
+    <script type="module" src="assets/demo-editor.js"></script>
+  </body>
+</html>

--- a/site/src/demo-editor.js
+++ b/site/src/demo-editor.js
@@ -1,0 +1,82 @@
+// A standalone, full-featured Functor Lang editor beside a live scene — the
+// hero editor's demo-grade sibling. Unlike the landing hero's mini-editor
+// (mini-editor.js — deliberately stripped to keep the landing bundle tiny),
+// this composes the SAME language intelligence the sandbox uses — completion,
+// codelenses, hover types, diagnostics, and the paused-inspector live-value
+// overlay — plus state-preserving hot reload. It carries none of the sandbox's
+// chrome (picker / reset / problems / executions); it exists to be recorded for
+// the site's feature-showcase GIFs (see site/demos/). `?game=<path>` selects
+// the scene (default: the synthwave hero).
+//
+// This is a lean re-composition of the shared, already-modular seams
+// (setupLangIntel, wireLiveTrace, PlayerBridge) rather than a fork of
+// sandbox.js — the only overlap is constructing the editor view.
+
+import { basicSetup } from "codemirror";
+import { EditorView, keymap } from "@codemirror/view";
+import { StateEffect } from "@codemirror/state";
+import { indentWithTab } from "@codemirror/commands";
+import { functorLangLanguage, synthwaveEditorTheme } from "./functor-lang.js";
+import { setupLangIntel, wireLiveTrace } from "./lang-intel.js";
+import { PlayerBridge } from "./player-bridge.js";
+
+const frame = document.getElementById("player");
+const game = new URLSearchParams(location.search).get("game") || "examples/hero.fun";
+
+// wireLiveTrace drives an executions picker through a status bar; the demo has
+// none, so a no-op stub satisfies the contract (the inline live-value overlay
+// it installs on the editor needs nothing from it).
+const noopStatusBar = { setExecutions() {} };
+
+// Every edit is a source push — the runtime hot-swaps with the model preserved,
+// which is the whole point of the Instant Feedback demo. No callbacks needed.
+const bridge = new PlayerBridge(frame, {
+  onReloading() {},
+  onLive() {},
+  onResult() {},
+});
+
+// Guards the initial programmatic buffer fill from being pushed back as a
+// redundant reload (it is exactly what the fresh iframe is about to fetch).
+let programmaticEdit = false;
+
+const view = new EditorView({
+  parent: document.getElementById("editor"),
+  extensions: [
+    basicSetup,
+    keymap.of([indentWithTab]),
+    functorLangLanguage,
+    synthwaveEditorTheme,
+    EditorView.updateListener.of((update) => {
+      if (update.docChanged && !programmaticEdit) bridge.push(view.state.doc.toString());
+    }),
+  ],
+});
+
+// Language intelligence loads lazily (the analysis wasm); append its extensions
+// once ready. Degrades to a plain editor if the pkg is absent.
+const langReady = setupLangIntel().then((extensions) => {
+  if (extensions.length) view.dispatch({ effects: StateEffect.appendConfig.of(extensions) });
+  return extensions.length > 0;
+});
+
+// The paused-inspector overlay: live values inline in the editor when the scene
+// is paused (via the player's scrubber).
+wireLiveTrace(view, noopStatusBar, frame, langReady);
+
+// Load the chosen scene into both the editor buffer and the player.
+(async () => {
+  const source = await (await fetch(game)).text();
+  programmaticEdit = true;
+  view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: source } });
+  programmaticEdit = false;
+  frame.src = `player.html?game=${encodeURIComponent(game)}`;
+})();
+
+// Demo / e2e seam.
+window.__demoEditor = {
+  ready: langReady,
+  view,
+  frame,
+  source: () => view.state.doc.toString(),
+};


### PR DESCRIPTION
A standalone, clean **editor-beside-scene** page (`site/demo-editor.html`) with the **full** language intelligence the landing hero's mini-editor lacks — the "standalone hero editor for demos" idea. It's the reusable base for the upcoming **Instant Feedback** GIF (PR to follow).

## What it has (that the hero editor doesn't)
- **Completion** (scope-aware, from the analysis wasm)
- **Codelenses** — type signatures on every def
- **Hover types** + **diagnostics** (inline squiggles)
- **Live value visualization** — inline values flowing into the code when the scene is paused
- State-preserving **hot reload** (every edit is a source push)

## Screenshot (paused → live values + codelenses; grid recolored green by a live edit)
![demo editor](https://gist.githubusercontent.com/tommy-xr/566ba18644d2f79f8c0f27ca56683251/raw/demo-editor.png)

Note the inline live values (`t= 6.5833 (×120)`, `ix= 0…11 (×120)`, `depth= 0…0.9 (×120)`) and the per-def signatures — and the dots are green because a live edit to the emissive hot-swapped while the wave kept rolling.

## Design / anti-duplication
Deliberately **not** a fork of `sandbox.js`. It's a lean re-composition of the already-modular shared seams — `setupLangIntel`, `wireLiveTrace`, `PlayerBridge`, the `functor-lang` theme — plus the sandbox's split-layout CSS reused verbatim (`.sandbox-page`/`.sandbox-split`/`.editor-pane`/`.preview-pane`). The only overlap with `sandbox.js` is constructing the `EditorView`; there's no picker/reset/problems/executions chrome. If shared glue grows, we can extract a `createEditor` helper (tracked as a possible follow-up).

`?game=<path>` selects the scene (default: the synthwave hero).

## Verification
Headless (Playwright): `langReady=true`; completion popup opens; a valid edit hot-reloads the scene (magenta→green); pausing populates **56** inline live-value decorations. Build adds the page to `PAGES` and `demo-editor.js` to the esbuild entry points.

## Known, out-of-scope
A benign `functor_lang_is_running` load-race pageerror comes from the shared `player.html` (the **sandbox throws the identical one**) — not introduced here. Can file a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)