### PR TITLE
feat(site): batteries-included demo GIF + CDN animation example

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:ide-page": "node e2e/ide-page.mjs",
     "demo:time-travel": "node site/demos/time-travel.mjs",
     "demo:instant-feedback": "node site/demos/instant-feedback.mjs",
+    "demo:batteries-included": "node site/demos/batteries-included.mjs",
     "demo:introspective": "node site/demos/introspective.mjs"
   },
   "devDependencies": {

--- a/site/demos/batteries-included.mjs
+++ b/site/demos/batteries-included.mjs
@@ -1,0 +1,122 @@
+// Reproducible capture of the "Batteries Included" hero GIF.
+//
+// Drives the demo editor over the batteries scene: a rigged character streamed
+// straight from a CDN, skinned and animated (idle → walk → run, blended) with no
+// asset pipeline to set up. The scene animates itself; this just holds while the
+// overlay captions name the batteries. Driven headless via window.__demoEditor.
+//
+// Prereqs: the web runtime wasm bundle (wasm-pack build
+// runtime/functor-runtime-web --target=web), @playwright/test's chromium, and
+// ffmpeg on PATH. Needs network access (the model streams from jsDelivr).
+//
+//   npm run demo:batteries-included                 # -> site/demos/batteries-included.gif
+//   node site/demos/batteries-included.mjs out.gif  # custom output path
+import { spawn, spawnSync, execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "@playwright/test";
+import { installOverlay } from "./lib/overlay.mjs";
+
+const ROOT = fileURLToPath(new URL("../..", import.meta.url));
+const PORT = 8234; // dedicated port
+const BASE = `http://127.0.0.1:${PORT}`;
+const GAME = process.env.DEMO_GAME || "examples/batteries.fun";
+const OUT = resolve(process.argv[2] || join(ROOT, "site/demos/batteries-included.gif"));
+const WIDTH = 1120;
+const HEIGHT = 640;
+const GIF_WIDTH = 820;
+const FPS = Number(process.env.DEMO_FPS || 14);
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+if (!process.env.DEMO_SKIP_BUILD) {
+  const build = spawnSync("node", ["site/build.mjs"], { cwd: ROOT, stdio: "inherit" });
+  if (build.status !== 0) process.exit(build.status ?? 1);
+}
+
+const server = spawn("node", ["site/serve.mjs", "--port", String(PORT)], {
+  cwd: ROOT,
+  stdio: "ignore",
+});
+process.on("exit", () => server.kill());
+for (let i = 0; ; i++) {
+  try {
+    if ((await fetch(BASE)).ok) break;
+  } catch {
+    /* not up yet */
+  }
+  if (i > 50) throw new Error(`site server never came up on ${PORT}`);
+  await sleep(100);
+}
+
+let browser;
+try {
+  browser = await chromium.launch();
+} catch {
+  browser = await chromium.launch({ channel: "chrome" });
+}
+const page = await browser.newPage({ viewport: { width: WIDTH, height: HEIGHT } });
+await page.goto(`${BASE}/demo-editor.html?game=${encodeURIComponent(GAME)}`, {
+  waitUntil: "load",
+});
+await page.evaluate(() => window.__demoEditor.ready);
+const ov = await installOverlay(page);
+
+const playerFrame = () => page.frames().find((f) => f.url().includes("player.html"));
+await sleep(1500);
+await playerFrame()
+  ?.addStyleTag({ content: '[title*="mouse"]{display:none!important}' })
+  .catch(() => {});
+await sleep(8000); // stream the model from the CDN and let it start animating
+
+// Show the code that does it — the CDN URL and the clip blend.
+await page.evaluate(() => {
+  const v = window.__demoEditor.view;
+  const i = v.state.doc.toString().indexOf("let hero");
+  v.dispatch({ selection: { anchor: i }, scrollIntoView: true });
+});
+await sleep(400);
+
+const framesDir = mkdtempSync(join(tmpdir(), "functor-bi-"));
+let n = 0;
+const snap = async () => {
+  await page.screenshot({ path: join(framesDir, `f${String(n).padStart(4, "0")}.png`) });
+  n++;
+};
+const hold = async (frames, ms = 70) => {
+  for (let k = 0; k < frames; k++) {
+    await snap();
+    await sleep(ms);
+  }
+};
+
+// The character auto-cycles idle → walk → run the whole time; the captions just
+// name what's happening. (hold() lets real time pass, so it keeps animating.)
+await ov.caption("A rigged character, streamed straight from a <b>URL</b>.");
+await hold(20, 70);
+await ov.caption("Skinned animation — <b>idle → walk → run</b>, blended.");
+await hold(20, 70);
+await ov.caption("Assets, animation, physics, audio — <b>batteries included</b>.");
+await hold(24, 70);
+
+await browser.close();
+server.kill();
+
+mkdirSync(dirname(OUT), { recursive: true });
+execFileSync(
+  "ffmpeg",
+  [
+    "-y",
+    "-framerate", String(FPS),
+    "-i", join(framesDir, "f%04d.png"),
+    "-vf",
+    `scale=${GIF_WIDTH}:-1:flags=lanczos,split[s0][s1];[s0]palettegen=stats_mode=diff[p];[s1][p]paletteuse=dither=bayer:bayer_scale=3`,
+    "-loop", "0",
+    OUT,
+  ],
+  { stdio: "inherit" }
+);
+rmSync(framesDir, { recursive: true, force: true });
+console.log(`\nwrote ${OUT} (${n} frames)`);

--- a/site/examples/batteries.fun
+++ b/site/examples/batteries.fun
@@ -1,0 +1,41 @@
+// batteries.fun — batteries included. A rigged character streamed straight from
+// a CDN and animated with a blend of its idle/walk/run clips. There is no asset
+// pipeline to wire up: Asset.model takes the URL, Anim.clip names a clip, and
+// the runtime handles loading, decoding, skinning, and blending — the character
+// auto-cycles idle → walk → run and back.
+
+let hero = Asset.model("https://cdn.jsdelivr.net/gh/BabylonJS/Assets@master/meshes/Xbot.glb")
+
+let init = { t: 0.0 }
+
+let tick = (model, dt: float, tts: float) => { model with t: model.t + dt }
+
+let absF = (x: float): float => if x < 0.0 then 0.0 - x else x
+
+// A 1D blend: each clip's weight peaks at its point on the speed axis (idle at
+// 0, walk at 0.5, run at 1) and fades to its neighbours; Anim.blend normalises.
+let idleWeight = (s: float): float => Math.clamp01(1.0 - s * 2.0)
+let walkWeight = (s: float): float => Math.clamp01(1.0 - absF(s - 0.5) * 2.0)
+let runWeight = (s: float): float => Math.clamp01(s * 2.0 - 1.0)
+
+let pose = (tts: float): Anim.t =>
+  let s = (1.0 - Math.cos(tts * 0.5)) * 0.5 in
+  Anim.blend([
+    (Anim.clip("idle", tts), idleWeight(s)),
+    (Anim.clip("walk", tts), walkWeight(s)),
+    (Anim.clip("run", tts), runWeight(s)),
+  ])
+
+let draw = (model, tts: float) =>
+  Frame.createLit(
+    Camera.lookAt(Vec3.make(0.0, 1.4, -3.4), Vec3.make(0.0, 0.9, 0.0)),
+    Scene.group([
+      Scene.plane() |> Scene.scale(10.0) |> Scene.lit(Color.rgb(0.4, 0.45, 0.55)),
+      Scene.model(hero)
+        |> Scene.animate(pose(tts))
+        |> Scene.rotateY(Angle.degrees(180.0)),
+    ]),
+    [
+      Light.ambient(Color.rgb(0.28, 0.28, 0.34)),
+      Light.directional(Vec3.make(-0.5, -1.0, 0.4), Color.rgb(1.0, 0.96, 0.88), 1.0),
+    ])

--- a/site/src/examples.js
+++ b/site/src/examples.js
@@ -14,6 +14,9 @@
 export const EXAMPLES = [
   { id: "hero", label: "Neon grid", source: "site/examples/hero.fun" },
   { id: "orbit", label: "Orbit", source: "site/examples/orbit.fun" },
+  // Single-file + a CORS-friendly CDN model (jsDelivr mirror of BabylonJS/Assets),
+  // so the rigged character streams and animates in the single-buffer sandbox.
+  { id: "batteries", label: "Animation", source: "site/examples/batteries.fun" },
   { id: "counter", label: "Counter", source: "examples/counter/game.fun" },
   { id: "primitives", label: "Primitives", source: "examples/primitives/game.fun" },
   { id: "ui", label: "UI widgets", source: "examples/ui/game.fun" },


### PR DESCRIPTION
The **Batteries Included** hero GIF — assets + animation just work.

## What's here
- **`site/examples/batteries.fun`** — a rigged character streamed from a CORS-friendly CDN (jsDelivr mirror of BabylonJS/Assets) and animated with an idle/walk/run clip blend. Single-file, so it runs in the sandbox (added to the picker as "Animation"). The web runtime skins + blends the clips — verified.
- **`site/demos/batteries-included.mjs`** — the capture: the character auto-cycles idle → walk → run while overlay captions name the batteries.

## Result
![batteries included](https://gist.githubusercontent.com/tommy-xr/566ba18644d2f79f8c0f27ca56683251/raw/batteries-included.gif)

The ~30 lines of visible code (`Asset.model("https://…")` + `Anim.clip`) are the point: no asset pipeline to set up.

## Usage
```sh
npm run demo:batteries-included   # -> site/demos/batteries-included.gif (gitignored)
```
Needs network (streams the model from jsDelivr).

🤖 Generated with [Claude Code](https://claude.com/claude-code)