### PR TITLE
feat(lang): add bundled stdlib module substrate

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -231,6 +231,16 @@ let grab = (s) =>
   (`key == Key.Enter`); a typo (`Key.Enterr`) is a load-time error — the
   reason keys stopped being strings. `Random` is likewise built-in (the
   abstract `Random.Seed` — see the Random builtins above).
+- **Bundled modules use the ordinary module semantics.** The language-owned
+  `Net.fun` / `Key.fun` implementations and `Random.funi` interface are
+  in-memory sources distributed with every embedding. Hosts may inject
+  additional bundled `.fun` implementations and `.funi` interfaces through
+  the same project linker: they parse, lower, check, evaluate, participate in
+  dependency ordering, appear in source maps (`<stdlib>/…` / `<prelude>/…`),
+  and rebind stored closures like project modules. Their namespaces are
+  reserved automatically. They are fixed for the lifetime of the host binary
+  and therefore are re-linked on a project hot reload but are not themselves
+  file-watched.
 - Constructor names must be unique per MODULE (not per project); values
   from a non-entry module display with their canonical tag
   (`Utils.Circle(2)` in run/trace/`/state` output). The entry's own names

--- a/docs/functor-lang.md
+++ b/docs/functor-lang.md
@@ -490,6 +490,18 @@ snapshots — no GPU, fully agent-verifiable.
       implementation satisfies its interface; consumers typecheck against
       the `.funi` alone. The LLM payoff is the point: an interface file is
       the concise, load-into-context summary of a module.
+      **Part 3 — bundled implementation modules — substrate done
+      (2026-07-23):** generalized the interface-injection path into one
+      bundled-source descriptor for executable `.fun` implementations and
+      host-backed `.funi` interfaces. Both use the ordinary project linker
+      (parse/lower/check/dependency order/eval/source maps/rebind), while
+      bundled names are reserved automatically and synthetic sources identify
+      themselves as `<stdlib>/…` or `<prelude>/…`. The existing language-owned
+      `Net.fun`, `Key.fun`, and `Random.funi` now go through this path instead
+      of bespoke pushes. Compatibility wrappers keep every current prelude
+      caller unchanged. This is the distribution substrate for the core
+      Option/Result modules and the engine-bundled Animator follow-ups; those
+      modules are deliberately separate slices.
 - [x] **Language: inline `expect` tests** (done 2026-07-19; design note in
       `~/notes` `inline-expect-tests.md` — the live red/green editor arc
       builds on this). `expect <bool-expr>` is a top-level item (contextual

--- a/functor-lang/src/project.rs
+++ b/functor-lang/src/project.rs
@@ -75,6 +75,73 @@ const PROTECTED_NAMESPACES: &[&str] = &[
     "Debug",
 ];
 
+/// One source module bundled by the language or a host rather than read from
+/// the user's project directory.
+///
+/// Implementation modules are ordinary `.fun` code with executable bodies;
+/// interface modules are `.funi` declarations whose values remain
+/// host-provided externals. Both travel through the same parser, lowerer,
+/// checker, dependency graph, evaluator, source map, and reload-rebind path as
+/// project modules.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BundledModuleKind {
+    Implementation,
+    Interface,
+}
+
+/// An in-memory module distributed with the language or host runtime.
+#[derive(Clone, Debug)]
+pub struct BundledModule {
+    name: String,
+    src: String,
+    kind: BundledModuleKind,
+    directory: &'static str,
+}
+
+impl BundledModule {
+    /// Bundle a reusable `.fun` implementation module. Diagnostics and
+    /// go-to-definition identify it as `<stdlib>/{name}.fun`.
+    pub fn implementation(name: impl Into<String>, src: impl Into<String>) -> BundledModule {
+        BundledModule::new(name, src, BundledModuleKind::Implementation, "<stdlib>")
+    }
+
+    /// Bundle a host `.funi` interface module. Diagnostics and
+    /// go-to-definition keep the established `<prelude>/{name}.funi` path.
+    pub fn interface(name: impl Into<String>, src: impl Into<String>) -> BundledModule {
+        BundledModule::new(name, src, BundledModuleKind::Interface, "<prelude>")
+    }
+
+    fn builtin(
+        name: impl Into<String>,
+        src: impl Into<String>,
+        kind: BundledModuleKind,
+    ) -> BundledModule {
+        BundledModule::new(name, src, kind, "<builtin>")
+    }
+
+    fn new(
+        name: impl Into<String>,
+        src: impl Into<String>,
+        kind: BundledModuleKind,
+        directory: &'static str,
+    ) -> BundledModule {
+        BundledModule {
+            name: name.into(),
+            src: src.into(),
+            kind,
+            directory,
+        }
+    }
+
+    fn path(&self) -> PathBuf {
+        let extension = match self.kind {
+            BundledModuleKind::Implementation => "fun",
+            BundledModuleKind::Interface => "funi",
+        };
+        PathBuf::from(format!("{}/{}.{}", self.directory, self.name, extension))
+    }
+}
+
 /// A loaded multi-file program: the merged module plus the per-file source
 /// map that renders its project-wide spans.
 pub struct Project {
@@ -157,6 +224,24 @@ const KEY_MODULE_SRC: &str = "type t =\n\
      | Up | Down | Left | Right\n\
      | Space | Enter | Escape\n\
      | Num0 | Num1 | Num2 | Num3 | Num4 | Num5 | Num6 | Num7 | Num8 | Num9\n";
+
+/// Language-owned modules available in every embedding, including the plain
+/// `functor-lang` CLI. Keeping them in the same descriptor shape as host
+/// modules is the distribution seam for reusable `.fun` stdlib code.
+fn core_modules() -> Vec<BundledModule> {
+    vec![
+        BundledModule::builtin("Net", NET_MODULE_SRC, BundledModuleKind::Implementation),
+        BundledModule::builtin("Random", RANDOM_MODULE_SRC, BundledModuleKind::Interface),
+        BundledModule::builtin("Key", KEY_MODULE_SRC, BundledModuleKind::Implementation),
+    ]
+}
+
+fn prelude_modules(prelude: &[(String, String)]) -> Vec<BundledModule> {
+    prelude
+        .iter()
+        .map(|(name, src)| BundledModule::interface(name.clone(), src.clone()))
+        .collect()
+}
 
 pub struct SourceFile {
     pub path: PathBuf,
@@ -341,7 +426,7 @@ pub fn load_with_overrides(
     entry_path: &Path,
     overrides: &HashMap<PathBuf, String>,
 ) -> Result<Project, ProjectError> {
-    load_with_prelude(entry_path, overrides, &[])
+    load_with_bundled_modules(entry_path, overrides, &[])
 }
 
 /// [`load_with_overrides`], plus a set of injected PRELUDE interface modules —
@@ -355,6 +440,19 @@ pub fn load_with_prelude(
     entry_path: &Path,
     overrides: &HashMap<PathBuf, String>,
     prelude: &[(String, String)],
+) -> Result<Project, ProjectError> {
+    let bundled = prelude_modules(prelude);
+    load_with_bundled_modules(entry_path, overrides, &bundled)
+}
+
+/// [`load_with_overrides`], plus implementation and interface modules bundled
+/// by the embedding. Unlike project files they are supplied in memory and are
+/// never watched for edits. Their names are reserved automatically, so a user
+/// file cannot shadow a bundled module.
+pub fn load_with_bundled_modules(
+    entry_path: &Path,
+    overrides: &HashMap<PathBuf, String>,
+    bundled: &[BundledModule],
 ) -> Result<Project, ProjectError> {
     let at = |path: &Path, message: String| ProjectError {
         path: path.to_path_buf(),
@@ -382,7 +480,7 @@ pub fn load_with_prelude(
 
     // The ENTRY is always loaded, so its stem must name a valid module even
     // when it has no siblings — an on-disk one-file project must NOT take the
-    // single-source `Main` fallback in `load_sources_with_prelude`, which
+    // single-source `Main` fallback in `load_sources_with_bundled_modules`, which
     // exists for the inline wasm/docs single-entry case where the path is
     // only a label.
     module_name(entry_path).map_err(|message| at(entry_path, message))?;
@@ -398,7 +496,7 @@ pub fn load_with_prelude(
         };
         sources.push((path.clone(), src));
     }
-    load_sources_with_prelude(sources, prelude)
+    load_sources_with_bundled_modules(sources, bundled)
 }
 
 /// Link an already-read set of project sources (entry FIRST, then siblings —
@@ -412,6 +510,18 @@ pub fn load_sources_with_prelude(
     sources: Vec<(PathBuf, String)>,
     prelude: &[(String, String)],
 ) -> Result<Project, ProjectError> {
+    let bundled = prelude_modules(prelude);
+    load_sources_with_bundled_modules(sources, &bundled)
+}
+
+/// Link already-read project sources plus implementation and interface
+/// modules supplied by the embedding. This is the shared in-memory seam used
+/// by native, wasm, editor tooling, and future stdlib modules.
+pub fn load_sources_with_bundled_modules(
+    sources: Vec<(PathBuf, String)>,
+    bundled: &[BundledModule],
+) -> Result<Project, ProjectError> {
+    let core = core_modules();
     let at = |path: &Path, message: String| ProjectError {
         path: path.to_path_buf(),
         line: 1,
@@ -429,7 +539,7 @@ pub fn load_sources_with_prelude(
     let mut base = 0usize;
     for (path, src) in sources.iter() {
         let module = if single {
-            single_module_name(path)
+            single_module_name(path, bundled, &core)
         } else {
             module_name(path).map_err(|message| at(path, message))?
         };
@@ -438,6 +548,18 @@ pub fn load_sources_with_prelude(
                 path,
                 format!(
                     "module name `{module}` (from {}) collides with the builtin/prelude \
+namespace `{module}` — rename the file",
+                    file_name(path)
+                ),
+            ));
+        }
+        // Include core dynamically so future stdlib modules are reserved even
+        // before they are added to the host-oriented protected-name list.
+        if bundled.iter().chain(&core).any(|item| item.name == module) {
+            return Err(at(
+                path,
+                format!(
+                    "module name `{module}` (from {}) collides with the bundled module \
 namespace `{module}` — rename the file",
                     file_name(path)
                 ),
@@ -466,67 +588,48 @@ come from file names, capitalized",
         // next file's base.
         base += len + 1;
     }
-    push_prelude(&mut files, prelude);
+    push_bundled(&mut files, bundled)?;
+    push_bundled(&mut files, &core)?;
     link(files)
 }
 
-/// Append injected PRELUDE interface modules to `files` (after the project's
-/// own files), assigning span bases past the last one. They are exempt from
-/// the protected-namespace check — they OWN those namespaces.
-fn push_prelude(files: &mut Vec<SourceFile>, prelude: &[(String, String)]) {
+/// Append bundled modules to `files`, assigning span bases past the last one.
+/// They are exempt from the project-file protected-namespace check because
+/// they own their namespaces. Duplicate descriptors still fail loudly.
+fn push_bundled(
+    files: &mut Vec<SourceFile>,
+    bundled: &[BundledModule],
+) -> Result<(), ProjectError> {
     let mut base = files.last().map_or(0, |f| f.base + f.src.len() + 1);
-    for (module, src) in prelude {
+    for item in bundled {
+        let path = item.path();
+        if let Some(previous) = files.iter().find(|file| file.module == item.name) {
+            return Err(ProjectError {
+                path,
+                line: 1,
+                col: 1,
+                message: format!(
+                    "bundled module `{}` is already supplied by {}",
+                    item.name,
+                    previous.path.display()
+                ),
+            });
+        }
         files.push(SourceFile {
-            interface: true,
-            path: PathBuf::from(format!("<prelude>/{module}.funi")),
-            module: module.clone(),
-            src: src.clone(),
+            interface: item.kind == BundledModuleKind::Interface,
+            path,
+            module: item.name.clone(),
+            src: item.src.clone(),
             base,
         });
-        base += src.len() + 1;
+        base += item.src.len() + 1;
     }
+    Ok(())
 }
 
-/// Parse, lower, and link a set of source files into one merged module,
-/// injecting the built-in `Net` module. Shared by the filesystem loader
-/// and the single-source (wasm) loader.
-fn link(mut files: Vec<SourceFile>) -> Result<Project, ProjectError> {
-    // The built-in `Net` module: a prelude-provided ADT always in scope, so
-    // any game can `match ev with | Net.Connected(id) => …` without declaring
-    // the type. Canonicalized to `Net.NetEvent` / `Net.Connected` / …; the
-    // host builds matching `Net.*` values. Appended LAST so the entry stays
-    // index 0. Both the filesystem and single-source loaders reach it here.
-    let base = files.last().map_or(0, |f| f.base + f.src.len() + 1);
-    files.push(SourceFile {
-        interface: false,
-        path: PathBuf::from("<builtin>/Net.fun"),
-        module: "Net".to_string(),
-        src: NET_MODULE_SRC.to_string(),
-        base,
-    });
-
-    // The built-in `Random` interface module — the abstract `Seed` type and
-    // the signatures that brand the Random builtins (see RANDOM_MODULE_SRC).
-    let base = files.last().map_or(0, |f| f.base + f.src.len() + 1);
-    files.push(SourceFile {
-        interface: true,
-        path: PathBuf::from("<builtin>/Random.funi"),
-        module: "Random".to_string(),
-        src: RANDOM_MODULE_SRC.to_string(),
-        base,
-    });
-
-    // The built-in `Key` module — the `input` hook's key variant (see
-    // KEY_MODULE_SRC).
-    let base = files.last().map_or(0, |f| f.base + f.src.len() + 1);
-    files.push(SourceFile {
-        interface: false,
-        path: PathBuf::from("<builtin>/Key.fun"),
-        module: "Key".to_string(),
-        src: KEY_MODULE_SRC.to_string(),
-        base,
-    });
-
+/// Parse, lower, and link a complete set of project and bundled source files
+/// into one merged module.
+fn link(files: Vec<SourceFile>) -> Result<Project, ProjectError> {
     let entry = files[0].module.clone();
 
     // Parse every file (spans land in the project-wide space).
@@ -670,15 +773,16 @@ allowed (within one file, definitions may still be mutually recursive)",
 
 /// Load a project from ONE in-memory entry source (no filesystem) — the
 /// wasm producer's path, where the game is fetched as a single text and
-/// there are no sibling files. The built-in `Net` module is still injected.
+/// there are no sibling files. The core bundled modules are still injected.
 pub fn load_single_source(module: &str, src: &str) -> Result<Project, ProjectError> {
-    let files = vec![SourceFile {
+    let mut files = vec![SourceFile {
         interface: false,
         path: PathBuf::from(format!("{module}.fun")),
         module: module.to_string(),
         src: src.to_string(),
         base: 0,
     }];
+    push_bundled(&mut files, &core_modules())?;
     link(files)
 }
 
@@ -693,7 +797,20 @@ pub fn load_single_file(
     src: &str,
     prelude: &[(String, String)],
 ) -> Result<Project, ProjectError> {
-    let module = single_module_name(path);
+    let bundled = prelude_modules(prelude);
+    load_single_file_with_bundled_modules(path, src, &bundled)
+}
+
+/// Load one in-memory file plus implementation and interface modules supplied
+/// by the embedding. The synthetic modules are available for checking,
+/// completion, navigation, and evaluation but are not project files.
+pub fn load_single_file_with_bundled_modules(
+    path: &Path,
+    src: &str,
+    bundled: &[BundledModule],
+) -> Result<Project, ProjectError> {
+    let core = core_modules();
+    let module = single_module_name(path, bundled, &core);
     let mut files = vec![SourceFile {
         interface: is_interface(path),
         path: path.to_path_buf(),
@@ -701,19 +818,25 @@ pub fn load_single_file(
         src: src.to_string(),
         base: 0,
     }];
-    push_prelude(&mut files, prelude);
+    push_bundled(&mut files, bundled)?;
+    push_bundled(&mut files, &core)?;
     link(files)
 }
 
 /// The module name for a SINGLE-source project (one entry, no siblings): the
 /// file's derived name, or `Main` when the stem isn't an identifier OR
-/// capitalizes to a protected namespace (`net.fun` → `Net`), which would
-/// otherwise collide with the builtin module `link` injects and fail the load.
-/// A single file is its own bare entry, so the name only labels it — nothing
-/// references it by name.
-fn single_module_name(path: &Path) -> String {
+/// capitalizes to a protected or bundled namespace (`net.fun` → `Net`), which
+/// would otherwise collide with an injected module and fail the load. A single
+/// file is its own bare entry, so the name only labels it — nothing references
+/// it by name.
+fn single_module_name(path: &Path, bundled: &[BundledModule], core: &[BundledModule]) -> String {
     match module_name(path) {
-        Ok(name) if !PROTECTED_NAMESPACES.contains(&name.as_str()) => name,
+        Ok(name)
+            if !PROTECTED_NAMESPACES.contains(&name.as_str())
+                && !bundled.iter().chain(core).any(|item| item.name == name) =>
+        {
+            name
+        }
         _ => "Main".to_string(),
     }
 }

--- a/functor-lang/tests/project.rs
+++ b/functor-lang/tests/project.rs
@@ -1269,6 +1269,177 @@ fn injected_prelude_types_host_externals() {
     );
 }
 
+// ── Bundled implementation modules ──────────────────────────────────────
+
+/// A bundled `.fun` module is real executable language code, not an
+/// interface-shaped host external.
+#[test]
+fn bundled_implementation_module_runs_and_checks() {
+    let sources = vec![(
+        PathBuf::from("game.fun"),
+        "let main = () => Stdlib.double(21.0)\n".to_string(),
+    )];
+    let bundled = [functor_lang::project::BundledModule::implementation(
+        "Stdlib",
+        "let double = (n: float): float => n * 2.0\n",
+    )];
+    let project = functor_lang::project::load_sources_with_bundled_modules(sources, &bundled)
+        .unwrap_or_else(|e| panic!("bundled module should load: {}", e.render()));
+
+    let diags = project.check();
+    assert!(diags.is_empty(), "bundled module should check: {diags:?}");
+    let record = functor_lang::run(&project.module, Tracing::Off)
+        .unwrap_or_else(|f| panic!("bundled module should run: {}", f.error.message));
+    match record.outcome {
+        RunOutcome::Main(Value::Number(n)) => assert_eq!(n, 42.0),
+        _ => panic!("expected a numeric main result"),
+    }
+
+    let stdlib = project
+        .sources
+        .files()
+        .iter()
+        .find(|file| file.module == "Stdlib")
+        .expect("bundled source is mapped");
+    assert_eq!(stdlib.path, PathBuf::from("<stdlib>/Stdlib.fun"));
+    assert!(!stdlib.interface);
+}
+
+/// Engine stdlib code can depend on an injected host interface: all bundled
+/// modules share the normal export/dependency graph.
+#[test]
+fn bundled_implementation_can_depend_on_interface() {
+    let sources = vec![(
+        PathBuf::from("game.fun"),
+        "let unused = () => Animator.pose()\nlet main = () => 0.0\n".to_string(),
+    )];
+    let bundled = [
+        functor_lang::project::BundledModule::interface("Anim", "type t\nlet rest : () => t\n"),
+        functor_lang::project::BundledModule::implementation(
+            "Animator",
+            "let pose = (): Anim.t => Anim.rest()\n",
+        ),
+    ];
+    let project = functor_lang::project::load_sources_with_bundled_modules(sources, &bundled)
+        .unwrap_or_else(|e| panic!("bundled dependency should load: {}", e.render()));
+    let diags = project.check();
+    assert!(
+        diags.is_empty(),
+        "implementation should typecheck against interface: {diags:?}"
+    );
+}
+
+#[test]
+fn stored_closure_from_bundled_module_rebinds_across_reload() {
+    let sources = || {
+        vec![(
+            PathBuf::from("game.fun"),
+            "let main = () => Stdlib.makeAdder(3.0)\n".to_string(),
+        )]
+    };
+    let old_bundled = [functor_lang::project::BundledModule::implementation(
+        "Stdlib",
+        "let makeAdder = (n) => (x) => x + n\n",
+    )];
+    let old = functor_lang::project::load_sources_with_bundled_modules(sources(), &old_bundled)
+        .unwrap_or_else(|e| panic!("old bundled module should load: {}", e.render()));
+    let record = functor_lang::run(&old.module, Tracing::Off)
+        .unwrap_or_else(|f| panic!("old bundled module should run: {}", f.error.message));
+    let RunOutcome::Main(stored) = record.outcome else {
+        panic!("expected a stored closure");
+    };
+
+    let new_bundled = [functor_lang::project::BundledModule::implementation(
+        "Stdlib",
+        "let makeAdder = (n) => (x) => x + n * 10.0\n",
+    )];
+    let new = functor_lang::project::load_sources_with_bundled_modules(sources(), &new_bundled)
+        .unwrap_or_else(|e| panic!("new bundled module should load: {}", e.render()));
+    let (rebound, report) = functor_lang::rebind_value(&stored, &old.module, &new.module);
+    assert_eq!(report.rebound, 1, "warnings: {:?}", report.warnings);
+
+    let session = functor_lang::Session::load(&new.module, &mut functor_lang::NoHost)
+        .unwrap_or_else(|f| panic!("new bundled module should load: {}", f.error.message));
+    let result = session
+        .apply(
+            rebound,
+            vec![Value::Number(2.0)],
+            "bundled closure",
+            &mut functor_lang::NoHost,
+        )
+        .expect("rebound bundled closure should apply");
+    assert_eq!(number(&result), 32.0);
+}
+
+#[test]
+fn project_file_cannot_shadow_a_bundled_module() {
+    let sources = vec![
+        (
+            PathBuf::from("game.fun"),
+            "let main = () => 0.0\n".to_string(),
+        ),
+        (
+            PathBuf::from("animator.fun"),
+            "let pose = 1.0\n".to_string(),
+        ),
+    ];
+    let bundled = [functor_lang::project::BundledModule::implementation(
+        "Animator",
+        "let pose = 2.0\n",
+    )];
+    let err = match functor_lang::project::load_sources_with_bundled_modules(sources, &bundled) {
+        Err(err) => err.render(),
+        Ok(_) => panic!("project shadowing should fail"),
+    };
+    assert_eq!(
+        err,
+        "animator.fun:1:1: module name `Animator` (from animator.fun) collides with the bundled \
+module namespace `Animator` — rename the file"
+    );
+}
+
+#[test]
+fn single_file_named_like_a_bundled_module_uses_main_label() {
+    let path = PathBuf::from("animator.fun");
+    let bundled = [functor_lang::project::BundledModule::implementation(
+        "Animator",
+        "let pose = 2.0\n",
+    )];
+    let project = functor_lang::project::load_single_file_with_bundled_modules(
+        &path,
+        "let main = () => Animator.pose\n",
+        &bundled,
+    )
+    .unwrap_or_else(|e| panic!("single-file label should not shadow: {}", e.render()));
+
+    assert_eq!(project.entry, "Main");
+    assert!(
+        project.check().is_empty(),
+        "bundled module should remain usable"
+    );
+}
+
+#[test]
+fn duplicate_bundled_module_descriptors_are_refused() {
+    let sources = vec![(
+        PathBuf::from("game.fun"),
+        "let main = () => 0.0\n".to_string(),
+    )];
+    let bundled = [
+        functor_lang::project::BundledModule::implementation("Shared", "let x = 1.0\n"),
+        functor_lang::project::BundledModule::interface("Shared", "let x : float\n"),
+    ];
+    let err = match functor_lang::project::load_sources_with_bundled_modules(sources, &bundled) {
+        Err(err) => err.render(),
+        Ok(_) => panic!("duplicate bundled modules should fail"),
+    };
+    assert_eq!(
+        err,
+        "<prelude>/Shared.funi:1:1: bundled module `Shared` is already supplied by \
+<stdlib>/Shared.fun"
+    );
+}
+
 /// Editor temp files and other non-identifier `.fun` stems (`.#game.fun`,
 /// `2d.fun`) are ignored by the loader, not treated as modules — so a stray
 /// temp file next to `game.fun` can't break the load (or hot reload). Their


### PR DESCRIPTION
## Summary

- add one bundled-module descriptor for executable `.fun` implementations and host-backed `.funi` interfaces
- route `Net`, `Key`, and `Random` through the shared project-linker path while preserving existing prelude APIs
- reserve bundled namespaces, expose synthetic sources to tooling, and preserve dependency ordering and hot-reload closure rebinding
- document the distribution substrate for the upcoming `Option`/`Result` and engine-bundled `Animator` slices

Progresses #307.

## Verification

- `cargo test -p functor-lang` — 538 passed
- `cargo test -p functor_runtime_common` — 391 passed, 1 doc test ignored
- `cargo check -p functor-lang-lsp -p functor-lang-wasm`
- `git diff --check`

## Review dispositions

- adversarial review found no correctness findings and no Critical/High/Medium issues
- addressed both Low simplicity notes: consolidated prelude conversion and documented the forward-looking core reservation check
- retained the short test rebind overlap as intentional independent invariant coverage
- duplication scan found no production clone touching the loader
- the secondary Codex CLI reviewer could not initialize its nested read-only app server; per the review fallback, completed with the Claude review and local inspection

## Performance

No benchmark required: this changes project loading/linking only, not a per-frame hot path.