### PR TITLE
feat(vr): compose tracking onto authored cameras

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -570,6 +570,13 @@ anim |> Anim.rotate("jointName", ax, ay, az)               // additive local XYZ
                                                            //   enclosing mask still can)
 Camera.lookAt(eye, target)                                 // two Vec3s; up=+Y, fov 45°
 Camera.firstPerson(eye, yaw, pitch, fov)                   // Vec3 eye; Angles for the rest
+                                                           //   On XR this is the authored
+                                                           //   reference center-eye rig:
+                                                           //   live head/eye deltas compose
+                                                           //   in its local basis. Position,
+                                                           //   orientation, near/far remain
+                                                           //   game-owned; OpenXR owns IPD
+                                                           //   and per-eye optical FOV
 Light.ambient(color) / Light.point(pos, color, intensity, range)
 Light.directional(dir, color, intensity) |> Light.castShadows
 Light.spot(pos, dir, color, intensity, range, coneAngle)

--- a/docs/functor-lang.md
+++ b/docs/functor-lang.md
@@ -51,6 +51,15 @@ Layout decision: Functor Lang lives **in this repo** as crates in the root works
 (e.g. `functor-lang/`), keeping the loop with its forcing client tight. Extract later if
 the standalone direction takes off.
 
+### Cross-target camera contract
+
+`Frame.camera` describes the same authored view on desktop, web, and XR. An XR
+shell treats it as the reference center-eye rig: the first valid headset pose
+is neutral, and later head/eye translation and rotation compose in the
+camera's local basis. The game therefore owns locomotion, orientation, and
+near/far clipping without needing a VR-specific model; OpenXR owns the
+physical IPD and exact asymmetric per-eye optical projection.
+
 ## Milestone 0 — de-risking spike (throwaway)
 
 The one real bet: **can a tree-walking interpreter run per-frame game logic at

--- a/docs/vr.md
+++ b/docs/vr.md
@@ -21,7 +21,7 @@ games deploy over the network.
 | [#430](https://github.com/tommy-xr/functor/pull/430) | Device-loopback source reload over adb forwarding | merged |
 | [#431](https://github.com/tommy-xr/functor/pull/431) | `functor run vr`: launch, forward, whole-project push, watch, and log streaming | merged |
 | [#437](https://github.com/tommy-xr/functor/pull/437) | Exact asymmetric OpenXR projections, fixing binocular double vision | merged; Quest 3 verified |
-| `feat/isomorphic-vr-debug-capture` | Shared desktop/Quest debug protocol, whole-project REPL, raw stereo capture, TypeScript SDK parity, device benchmark | current branch; Quest 3 verified |
+| [#438](https://github.com/tommy-xr/functor/pull/438) | Shared desktop/Quest debug protocol, whole-project REPL, raw stereo capture, TypeScript SDK parity, device benchmark | merged; Quest 3 verified |
 
 ## Working today on the Xreal One
 
@@ -53,6 +53,11 @@ magnetometer; the Xreal Eye's 6DoF is not host-accessible).
 - The shared shaders are gamma-naive; the Quest's sRGB swapchain will render
   brighter than desktop until the pipeline is gamma-explicit (TODO'd at
   `COLOR_FORMAT`).
+- **Quest camera composition:** the first valid center-eye tracking pose maps
+  to the authored `Frame.camera`. Later eye translation/rotation composes in
+  that camera's local basis; authored camera changes move the rig, while
+  OpenXR owns IPD/optical FOV and the camera keeps its near/far range. Verified
+  on Quest 3 with raw stereo capture and a live authored-camera translation.
 
 ## Device-day checklist (Quest 3)
 
@@ -76,11 +81,14 @@ The first measured Quest 3 release run (`primitives`, 15 seconds after a
 5-second warmup) sustained 72.7 FPS mean / 72 FPS minimum, with zero stale or
 torn frames and 3.09 ms mean application time.
 
+The authored-camera release verification sustained 72 FPS minimum in two
+30-second `primitives` runs (3.31–3.36 ms mean application time). A
+source/geometry-heavy `synthwave` run also held 72 FPS minimum with zero stale
+or torn frames; texture assets were not synchronized, so that run is not a
+final texture-pipeline measurement.
+
 ## After bring-up (in rough order)
 
-- Make the game camera the VR tracking origin (position/orientation and clip
-  range) so identical `Frame` values have the same world framing on desktop and
-  Quest; compose the live head/eye pose on top.
 - Sync or host project assets so texture/model/audio locators work in the
   laptop-to-headset loop; whole-project reload currently transfers source only.
 - Controllers + a VR `InputContext` (head/hands) with desktop mouse/keyboard

--- a/docs/vr.md
+++ b/docs/vr.md
@@ -22,6 +22,7 @@ games deploy over the network.
 | [#431](https://github.com/tommy-xr/functor/pull/431) | `functor run vr`: launch, forward, whole-project push, watch, and log streaming | merged |
 | [#437](https://github.com/tommy-xr/functor/pull/437) | Exact asymmetric OpenXR projections, fixing binocular double vision | merged; Quest 3 verified |
 | [#438](https://github.com/tommy-xr/functor/pull/438) | Shared desktop/Quest debug protocol, whole-project REPL, raw stereo capture, TypeScript SDK parity, device benchmark | merged; Quest 3 verified |
+| [#453](https://github.com/tommy-xr/functor/pull/453) | Compose live OpenXR head/eye tracking onto the authored `Frame.camera` rig | current PR; Quest 3 verified |
 
 ## Working today on the Xreal One
 

--- a/runtime/functor-runtime-common/src/camera.rs
+++ b/runtime/functor-runtime-common/src/camera.rs
@@ -1,7 +1,89 @@
-use cgmath::{perspective, vec3, Matrix4, Point3, Rad};
+use cgmath::{perspective, vec3, InnerSpace, Matrix4, Point3, Quaternion, Rad, Rotation, Vector3};
 use serde::{Deserialize, Serialize};
 
 use crate::math::Angle;
+
+/// A pose reported by a tracking system, in its right-handed local space.
+///
+/// The orientation is a unit quaternion in `[x, y, z, w]` order. Tracking
+/// local `+X` is right, `+Y` is up, and `-Z` is forward, matching OpenXR.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct TrackingPose {
+    pub position: [f32; 3],
+    pub orientation: [f32; 4],
+}
+
+impl TrackingPose {
+    pub const IDENTITY: TrackingPose = TrackingPose {
+        position: [0.0, 0.0, 0.0],
+        orientation: [0.0, 0.0, 0.0, 1.0],
+    };
+
+    pub fn new(position: [f32; 3], orientation: [f32; 4]) -> Self {
+        Self {
+            position,
+            orientation,
+        }
+    }
+
+    /// The center pose between two tracked eyes. Position is the midpoint;
+    /// orientation is the shortest-path halfway rotation. Returns `None` for
+    /// non-finite positions or invalid quaternions.
+    pub fn midpoint(left: Self, right: Self) -> Option<Self> {
+        let lp = left.position_vector()?;
+        let rp = right.position_vector()?;
+        let lq = left.unit_orientation()?;
+        let mut rq = right.unit_orientation()?;
+        if lq.dot(rq) < 0.0 {
+            rq = -rq;
+        }
+        let orientation = lq.slerp(rq, 0.5).normalize();
+        let position = (lp + rp) * 0.5;
+        Some(Self::from_parts(position, orientation))
+    }
+
+    fn position_vector(self) -> Option<Vector3<f32>> {
+        self.position
+            .iter()
+            .all(|component| component.is_finite())
+            .then(|| Vector3::from(self.position))
+    }
+
+    fn unit_orientation(self) -> Option<Quaternion<f32>> {
+        let [x, y, z, w] = self.orientation;
+        let q = Quaternion::new(w, x, y, z);
+        let magnitude2 = q.magnitude2();
+        (self
+            .orientation
+            .iter()
+            .all(|component| component.is_finite())
+            && magnitude2.is_normal())
+        .then(|| q / magnitude2.sqrt())
+    }
+
+    fn from_parts(position: Vector3<f32>, orientation: Quaternion<f32>) -> Self {
+        Self {
+            position: position.into(),
+            orientation: [
+                orientation.v.x,
+                orientation.v.y,
+                orientation.v.z,
+                orientation.s,
+            ],
+        }
+    }
+}
+
+/// A tracked pose mapped into the authored camera's world-space rig.
+///
+/// Controller/hand input can use the same mapping as the eye cameras, keeping
+/// rendered hands and head motion in one coordinate system.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct MappedTrackingPose {
+    pub position: [f32; 3],
+    pub forward: [f32; 3],
+    pub up: [f32; 3],
+}
 
 /// A camera description produced by the game's `draw3d`. Stores plain scalars
 /// (so it serializes cleanly across the wasm boundary); the runtime turns it
@@ -87,6 +169,81 @@ impl Camera {
             ..self.clone()
         };
         (shifted(-1.0), shifted(1.0))
+    }
+
+    /// Map a live tracking pose into this authored camera's local rig.
+    ///
+    /// `reference` is the tracking-space center-eye pose captured when the rig
+    /// is established. At that pose, the mapped position and orientation equal
+    /// this camera exactly. Subsequent room-scale translation and rotation are
+    /// applied in the camera's local right/up/backward basis, so moving the
+    /// authored camera moves the whole rig without discarding live tracking.
+    pub fn map_tracking_pose(
+        &self,
+        reference: TrackingPose,
+        tracked: TrackingPose,
+    ) -> Option<MappedTrackingPose> {
+        let eye = Vector3::from(self.eye);
+        let target = Vector3::from(self.target);
+        let authored_up = Vector3::from(self.up);
+        let gaze = target - eye;
+        let gaze_distance = gaze.magnitude();
+        let right = gaze.cross(authored_up);
+        if !eye.x.is_finite()
+            || !eye.y.is_finite()
+            || !eye.z.is_finite()
+            || !gaze_distance.is_normal()
+            || !right.magnitude().is_normal()
+        {
+            return None;
+        }
+
+        let forward = gaze / gaze_distance;
+        let right = right.normalize();
+        let up = right.cross(forward).normalize();
+        let backward = -forward;
+        let to_world = |v: Vector3<f32>| right * v.x + up * v.y + backward * v.z;
+
+        let reference_position = reference.position_vector()?;
+        let tracked_position = tracked.position_vector()?;
+        let reference_orientation = reference.unit_orientation()?;
+        let tracked_orientation = tracked.unit_orientation()?;
+        let inverse_reference = reference_orientation.conjugate();
+
+        let local_offset = inverse_reference.rotate_vector(tracked_position - reference_position);
+        let local_orientation = inverse_reference * tracked_orientation;
+        let world_position = eye + to_world(local_offset);
+        let world_forward =
+            to_world(local_orientation.rotate_vector(-Vector3::unit_z())).normalize();
+        let world_up = to_world(local_orientation.rotate_vector(Vector3::unit_y())).normalize();
+
+        Some(MappedTrackingPose {
+            position: world_position.into(),
+            forward: world_forward.into(),
+            up: world_up.into(),
+        })
+    }
+
+    /// Compose one tracked eye onto this authored camera. Invalid tracking or
+    /// a degenerate authored camera falls back to the authored camera for this
+    /// frame rather than injecting NaNs into the renderer.
+    ///
+    /// The authored camera keeps its target distance, field-of-view value, and
+    /// clip range. XR shells override only the optical projection with the
+    /// runtime's exact per-eye FOV.
+    pub fn compose_tracked_view(&self, reference: TrackingPose, tracked: TrackingPose) -> Camera {
+        let Some(mapped) = self.map_tracking_pose(reference, tracked) else {
+            return self.clone();
+        };
+        let distance = (Vector3::from(self.target) - Vector3::from(self.eye)).magnitude();
+        let position = Vector3::from(mapped.position);
+        let target = position + Vector3::from(mapped.forward) * distance;
+        Camera {
+            eye: mapped.position,
+            target: target.into(),
+            up: mapped.up,
+            ..self.clone()
+        }
     }
 
     pub fn view_matrix(&self) -> Matrix4<f32> {
@@ -235,8 +392,7 @@ mod tests {
         let right = -0.82_f32;
         let projection = cam.projection_matrix_from_fov_angles(left, right, -0.76, 0.88);
         let project_x = |angle: f32| {
-            let clip = projection
-                * Vector4::new(cam.near * angle.tan(), 0.0, -cam.near, 1.0);
+            let clip = projection * Vector4::new(cam.near * angle.tan(), 0.0, -cam.near, 1.0);
             clip.x / clip.w
         };
 
@@ -309,6 +465,134 @@ mod tests {
             assert_eq!(l.eye, cam.eye);
             assert_eq!(r.eye, cam.eye);
         }
+    }
+
+    #[test]
+    fn identity_tracking_pose_preserves_the_authored_camera() {
+        let camera = Camera::look_at(
+            [3.0, 2.0, -4.0],
+            [7.0, 3.0, 2.0],
+            [0.0, 1.0, 0.0],
+            Angle::from_degrees(67.0),
+        );
+        let composed = camera.compose_tracked_view(TrackingPose::IDENTITY, TrackingPose::IDENTITY);
+
+        for i in 0..3 {
+            assert!(approx(composed.eye[i], camera.eye[i]));
+            assert!(approx(composed.target[i], camera.target[i]));
+        }
+        let authored_matrix = camera.view_matrix();
+        let composed_matrix = composed.view_matrix();
+        let authored_view: &[f32; 16] = authored_matrix.as_ref();
+        let composed_view: &[f32; 16] = composed_matrix.as_ref();
+        for (actual, expected) in composed_view.iter().zip(authored_view.iter()) {
+            assert!(approx(*actual, *expected), "{actual} != {expected}");
+        }
+        assert_eq!(composed.fov_radians, camera.fov_radians);
+        assert_eq!(composed.near, camera.near);
+        assert_eq!(composed.far, camera.far);
+    }
+
+    #[test]
+    fn tracked_eye_offsets_preserve_stereo_about_the_authored_camera() {
+        let camera = Camera::first_person(
+            [2.0, 3.0, 4.0],
+            Angle::from_degrees(0.0),
+            Angle::from_degrees(0.0),
+            Angle::from_degrees(60.0),
+        );
+        let half_ipd = 0.032;
+        let left_pose = TrackingPose::new([-half_ipd, 1.6, 0.0], [0.0, 0.0, 0.0, 1.0]);
+        let right_pose = TrackingPose::new([half_ipd, 1.6, 0.0], [0.0, 0.0, 0.0, 1.0]);
+        let reference = TrackingPose::midpoint(left_pose, right_pose).unwrap();
+        let left = camera.compose_tracked_view(reference, left_pose);
+        let right = camera.compose_tracked_view(reference, right_pose);
+        let (expected_left, expected_right) = camera.stereo_eyes(half_ipd * 2.0);
+
+        for i in 0..3 {
+            assert!(approx(left.eye[i], expected_left.eye[i]));
+            assert!(approx(right.eye[i], expected_right.eye[i]));
+            assert!(approx(
+                left.target[i] - left.eye[i],
+                right.target[i] - right.eye[i]
+            ));
+        }
+    }
+
+    #[test]
+    fn tracking_translation_uses_the_authored_camera_basis() {
+        let camera = Camera::look_at(
+            [10.0, 2.0, 20.0],
+            [15.0, 2.0, 20.0], // authored forward = +X
+            [0.0, 1.0, 0.0],
+            Angle::from_degrees(45.0),
+        );
+        let tracked = TrackingPose::new([1.0, 0.5, -2.0], [0.0, 0.0, 0.0, 1.0]);
+        let mapped = camera
+            .map_tracking_pose(TrackingPose::IDENTITY, tracked)
+            .unwrap();
+
+        // For an authored +X gaze, local tracking +X/+Y/-Z map to world
+        // +Z/+Y/+X respectively.
+        assert!(approx(mapped.position[0], 12.0));
+        assert!(approx(mapped.position[1], 2.5));
+        assert!(approx(mapped.position[2], 21.0));
+    }
+
+    #[test]
+    fn tracking_rotation_is_relative_to_the_reference_pose() {
+        use cgmath::{Deg, Rotation3};
+
+        let camera = Camera::first_person(
+            [1.0, 2.0, 3.0],
+            Angle::from_degrees(0.0),
+            Angle::from_degrees(0.0),
+            Angle::from_degrees(45.0),
+        );
+        let reference_q = Quaternion::from_angle_y(Deg(35.0));
+        let relative_q = Quaternion::from_angle_y(Deg(20.0));
+        let tracked_q = reference_q * relative_q;
+        let pose =
+            |q: Quaternion<f32>| TrackingPose::new([0.0, 0.0, 0.0], [q.v.x, q.v.y, q.v.z, q.s]);
+        let composed = camera.compose_tracked_view(pose(reference_q), pose(tracked_q));
+        let got = (Vector3::from(composed.target) - Vector3::from(composed.eye)).normalize();
+        let yaw = 20.0_f32.to_radians();
+        let expected = Vector3::new(yaw.sin(), 0.0, yaw.cos());
+
+        assert!(got.dot(expected) > 0.9999, "forward = {got:?}");
+    }
+
+    #[test]
+    fn midpoint_handles_equivalent_opposite_quaternion_signs() {
+        let left = TrackingPose::new([-0.03, 1.0, 2.0], [0.0, 0.0, 0.0, 1.0]);
+        let right = TrackingPose::new([0.03, 1.0, 2.0], [0.0, 0.0, 0.0, -1.0]);
+        let midpoint = TrackingPose::midpoint(left, right).unwrap();
+
+        assert_eq!(midpoint.position, [0.0, 1.0, 2.0]);
+        assert!(approx(midpoint.orientation[3].abs(), 1.0));
+    }
+
+    #[test]
+    fn invalid_tracking_or_authored_camera_falls_back_without_nans() {
+        let camera = Camera::default();
+        let invalid = TrackingPose::new([f32::NAN, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]);
+        let fallback = camera.compose_tracked_view(TrackingPose::IDENTITY, invalid);
+        assert_eq!(fallback.eye, camera.eye);
+        assert_eq!(fallback.target, camera.target);
+
+        let degenerate = Camera::look_at(
+            [1.0, 1.0, 1.0],
+            [1.0, 1.0, 1.0],
+            [0.0, 1.0, 0.0],
+            Angle::from_degrees(45.0),
+        );
+        let fallback =
+            degenerate.compose_tracked_view(TrackingPose::IDENTITY, TrackingPose::IDENTITY);
+        assert!(fallback.eye.iter().all(|component| component.is_finite()));
+        assert!(fallback
+            .target
+            .iter()
+            .all(|component| component.is_finite()));
     }
 
     #[test]

--- a/runtime/functor-runtime-desktop/src/xreal.rs
+++ b/runtime/functor-runtime-desktop/src/xreal.rs
@@ -29,7 +29,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use cgmath::{InnerSpace, Quaternion, Rotation, Rotation3, Vector3, Zero};
-use functor_runtime_common::Camera;
+use functor_runtime_common::{Camera, TrackingPose};
 
 pub const DEFAULT_ADDR: &str = "169.254.2.1:52998";
 
@@ -250,44 +250,14 @@ pub fn gyro_bias(samples: &[ImuSample]) -> Vector3<f32> {
 }
 
 /// Rotate a game camera by the (recentered) head orientation. `q` is in the
-/// head frame — x right, y up, z forward — so it's applied in the *camera's
-/// local basis*: whatever direction the game camera faces, looking left turns
-/// the view left. Falls back to the unrotated camera for a degenerate gaze
-/// (same guard as `Camera::stereo_eyes`).
+/// head frame — x right, y up, z backward — so the shared tracked-camera rig
+/// applies it in the camera's local basis: whatever direction the game camera
+/// faces, looking left turns the view left.
 pub fn apply_head_rotation(camera: &Camera, q: Quaternion<f32>) -> Camera {
-    let eye = Vector3::new(camera.eye[0], camera.eye[1], camera.eye[2]);
-    let target = Vector3::new(camera.target[0], camera.target[1], camera.target[2]);
-    let up = Vector3::new(camera.up[0], camera.up[1], camera.up[2]);
-
-    let gaze = target - eye;
-    let dist = gaze.magnitude();
-    let right = gaze.cross(up);
-    if !dist.is_normal() || !right.magnitude().is_normal() {
-        return camera.clone();
-    }
-    let f = gaze / dist;
-    let r = right.normalize();
-    let u = r.cross(f).normalize();
-    // Right-handed camera basis (r, u, b) with b = backward — matching the
-    // head frame — so quaternion rotations keep their sign when mapped
-    // through it. (Using forward as the third axis would make the basis
-    // left-handed and mirror every head turn.)
-    let b = -f;
-
-    // Head-local gaze (−z) and up, rotated by the head orientation…
-    let f_local = q.rotate_vector(-Vector3::unit_z());
-    let u_local = q.rotate_vector(Vector3::unit_y());
-    // …mapped back into the world through the camera basis.
-    let to_world = |v: Vector3<f32>| r * v.x + u * v.y + b * v.z;
-    let new_f = to_world(f_local);
-    let new_u = to_world(u_local);
-
-    let new_target = eye + new_f * dist;
-    Camera {
-        target: [new_target.x, new_target.y, new_target.z],
-        up: [new_u.x, new_u.y, new_u.z],
-        ..camera.clone()
-    }
+    camera.compose_tracked_view(
+        TrackingPose::IDENTITY,
+        TrackingPose::new([0.0, 0.0, 0.0], [q.v.x, q.v.y, q.v.z, q.s]),
+    )
 }
 
 /// Handle to the background reader thread. The thread owns the TCP

--- a/runtime/functor-runtime-oculus/Cargo.toml
+++ b/runtime/functor-runtime-oculus/Cargo.toml
@@ -32,7 +32,6 @@ ndk-context = "0.1"
 khronos-egl = { version = "6.0", features = ["dynamic"] }
 libloading = "0.8"
 glow = "0.17"
-cgmath = "0.18"
 log = "0.4"
 android_logger = "0.14"
 # Frame/trace debug responses.

--- a/runtime/functor-runtime-oculus/README.md
+++ b/runtime/functor-runtime-oculus/README.md
@@ -9,10 +9,25 @@ over the shared debug-runtime protocol.
 ## Status
 
 The OpenXR shell, interpreted Functor Lang producer, USB remote-develop loop,
-and exact asymmetric per-eye projection are **verified on hardware** (Quest 3,
-Horizon OS v205). The shared debug/REPL protocol adds raw stereo framebuffer
-capture and desktop-isomorphic control. Remaining device work includes
-controller/hand input, asset sync, and multiview rendering.
+authored-camera rig, and exact asymmetric per-eye projection are verified on
+Quest 3. The shared debug/REPL protocol adds raw stereo framebuffer capture and
+desktop-isomorphic control. Remaining device work includes controller/hand
+input, asset sync, and multiview rendering.
+
+## Camera contract
+
+`Frame.camera` stays target-independent. On Quest its pose is the center-eye
+view when tracking is established; live OpenXR eye poses are applied as
+reference-relative translation and rotation in that camera's local basis.
+Changing the game camera therefore moves the whole play-space rig (locomotion),
+while moving your head remains live and shell-owned. The authored near/far clip
+range is preserved. OpenXR still owns IPD and the exact per-eye optical FOV.
+
+The reference center is the midpoint of the first valid left/right eye poses.
+It survives source reload and session doze; an OpenXR reference-space change
+recenters it at the runtime's announced change time. Existing desktop games
+therefore begin with their authored framing instead of inheriting the Quest's
+absolute stage coordinates.
 
 ## The remote-develop loop (M1)
 

--- a/runtime/functor-runtime-oculus/src/boot.fun
+++ b/runtime/functor-runtime-oculus/src/boot.fun
@@ -2,9 +2,9 @@
 // pushed over the network (POST /reload-source replaces it live, model
 // preserved). VR-adapted from the CLI's 3d template: a floor plane for
 // spatial reference, and a spinning cube + sphere ~2.5m in front of the
-// stage origin at standing eye height. The camera below is ignored on the
-// headset (per-eye HMD-pose cameras own the view — look around!); it makes
-// the same scene sensible if run on desktop.
+// stage origin at standing eye height. The authored camera is the reference
+// center-eye pose on the headset; live head/eye motion composes onto it, so
+// this scene starts with the same framing on desktop and in VR.
 
 let init = {}
 

--- a/runtime/functor-runtime-oculus/src/lib.rs
+++ b/runtime/functor-runtime-oculus/src/lib.rs
@@ -30,7 +30,6 @@ use std::sync::{mpsc, Arc};
 use std::time::Instant;
 
 use android_activity::{AndroidApp, InputStatus, MainEvent, PollEvent};
-use cgmath::{Quaternion, Rotation, Vector3};
 use functor_runtime_common::asset::AssetCache;
 use functor_runtime_common::debug_protocol::{
     CaptureError, DebugRequest, InputCommand, RuntimeInput, RuntimeMouse, RuntimeState,
@@ -38,7 +37,9 @@ use functor_runtime_common::debug_protocol::{
 };
 use functor_runtime_common::functor_lang_game_embedded::{FunctorLangEmbeddedGame, NativePlatform};
 use functor_runtime_common::protocol::GameProducer;
-use functor_runtime_common::{Camera, Frame, FrameTime, GameClock, Key, SceneContext, Viewport};
+use functor_runtime_common::{
+    Frame, FrameTime, GameClock, Key, SceneContext, TrackingPose, Viewport,
+};
 use khronos_egl as egl;
 use openxr as xr;
 
@@ -252,25 +253,12 @@ fn create_eye_target(
     }
 }
 
-/// Derive a Functor `Camera` from an OpenXR eye view. The exact asymmetric
-/// projection is built separately from `view.fov` and passed directly to the
-/// shared renderer; this camera owns the eye pose and clip distances.
-fn camera_from_view(view: &xr::View) -> Camera {
+/// Convert OpenXR's pose layout into the shell-independent tracking pose used
+/// by the authored camera rig.
+fn tracking_pose_from_view(view: &xr::View) -> TrackingPose {
     let p = view.pose.position;
     let o = view.pose.orientation;
-    let q = Quaternion::new(o.w, o.x, o.y, o.z);
-    let eye = Vector3::new(p.x, p.y, p.z);
-    let forward = q.rotate_vector(-Vector3::unit_z());
-    let up = q.rotate_vector(Vector3::unit_y());
-    let target = eye + forward;
-    Camera {
-        eye: [eye.x, eye.y, eye.z],
-        target: [target.x, target.y, target.z],
-        up: [up.x, up.y, up.z],
-        fov_radians: view.fov.angle_up - view.fov.angle_down,
-        near: 0.1,
-        far: 100.0,
-    }
+    TrackingPose::new([p.x, p.y, p.z], [o.x, o.y, o.z, o.w])
 }
 
 /// Placeholder frame until the Functor Lang producer is wired (device bring-up): an
@@ -576,14 +564,19 @@ pub fn android_main(app: AndroidApp) {
 
     // STAGE (floor-origin, room-scale) preferred; LOCAL (head-origin) is the
     // portable baseline when the runtime has no stage bounds set up.
-    let stage = session
-        .create_reference_space(xr::ReferenceSpaceType::STAGE, xr::Posef::IDENTITY)
-        .unwrap_or_else(|e| {
-            log::warn!("STAGE reference space unavailable ({e}); falling back to LOCAL");
-            session
-                .create_reference_space(xr::ReferenceSpaceType::LOCAL, xr::Posef::IDENTITY)
-                .expect("local space")
-        });
+    let (stage, stage_type) =
+        match session.create_reference_space(xr::ReferenceSpaceType::STAGE, xr::Posef::IDENTITY) {
+            Ok(stage) => (stage, xr::ReferenceSpaceType::STAGE),
+            Err(e) => {
+                log::warn!("STAGE reference space unavailable ({e}); falling back to LOCAL");
+                (
+                    session
+                        .create_reference_space(xr::ReferenceSpaceType::LOCAL, xr::Posef::IDENTITY)
+                        .expect("local space"),
+                    xr::ReferenceSpaceType::LOCAL,
+                )
+            }
+        };
 
     let view_config_views = instance
         .enumerate_view_configuration_views(system, xr::ViewConfigurationType::PRIMARY_STEREO)
@@ -634,6 +627,11 @@ pub fn android_main(app: AndroidApp) {
     let mut last_frame_at: Option<Instant> = None;
     let mut debug = DebugLoopState::default();
     let mut session_running = false;
+    // The first valid center-eye pose becomes the tracking origin for the
+    // authored `Frame.camera`. It survives source reload and session doze so
+    // model-driven locomotion and physical room-scale motion remain additive.
+    let mut tracking_reference: Option<TrackingPose> = None;
+    let mut tracking_reference_reset_at: Option<xr::Time> = None;
     let mut quit = false;
     let mut event_storage = xr::EventDataBuffer::new();
 
@@ -695,6 +693,10 @@ pub fn android_main(app: AndroidApp) {
                     }
                 }
                 InstanceLossPending(_) => quit = true,
+                ReferenceSpaceChangePending(e) if e.reference_space_type() == stage_type => {
+                    tracking_reference_reset_at = Some(e.change_time());
+                    log::info!("tracking-space change pending; camera rig will recenter");
+                }
                 _ => {}
             }
         }
@@ -743,13 +745,54 @@ pub fn android_main(app: AndroidApp) {
             continue;
         }
 
-        let (_, views) = session
+        if tracking_reference_reset_at.is_some_and(|change_time| {
+            xr_frame_state.predicted_display_time.as_nanos() >= change_time.as_nanos()
+        }) {
+            tracking_reference = None;
+            tracking_reference_reset_at = None;
+        }
+
+        let (view_state, views) = session
             .locate_views(
                 xr::ViewConfigurationType::PRIMARY_STEREO,
                 xr_frame_state.predicted_display_time,
                 &stage,
             )
             .expect("locate views");
+        let tracking_valid = view_state.contains(xr::ViewStateFlags::POSITION_VALID)
+            && view_state.contains(xr::ViewStateFlags::ORIENTATION_VALID);
+        if !tracking_valid {
+            // OpenXR leaves the view poses undefined when either validity bit
+            // is absent. Do not read those poses or submit them for compositor
+            // reprojection; a mono authored-camera fallback would be actively
+            // misleading here.
+            if let Some(response) = debug.pending_capture.take() {
+                let _ = response.send(Err(CaptureError::Unavailable(
+                    "capture is unavailable because XR tracking is invalid".to_string(),
+                )));
+            }
+            frame_stream
+                .end(
+                    xr_frame_state.predicted_display_time,
+                    xr::EnvironmentBlendMode::OPAQUE,
+                    &[],
+                )
+                .expect("frame end (invalid tracking)");
+            last_frame_at = None;
+            continue;
+        }
+        if tracking_reference.is_none() {
+            tracking_reference = views.first().and_then(|left| {
+                let left = tracking_pose_from_view(left);
+                views
+                    .get(1)
+                    .and_then(|right| TrackingPose::midpoint(left, tracking_pose_from_view(right)))
+                    .or_else(|| TrackingPose::midpoint(left, left))
+            });
+            if tracking_reference.is_some() {
+                log::info!("camera rig centered: Frame.camera is the reference center-eye pose");
+            }
+        }
 
         let now = Instant::now();
         let real_delta = last_frame_at
@@ -762,8 +805,9 @@ pub fn android_main(app: AndroidApp) {
         };
 
         // The game produces this frame (subscriptions → update → tick →
-        // physics inside `tick`; `render` = the pure `draw`). The game's own
-        // camera is ignored below — per-eye HMD-pose cameras own the view.
+        // physics inside `tick`; `render` = the pure `draw`). Frame.camera is
+        // the authored center-eye rig; live OpenXR eye deltas compose onto it
+        // below, so the same camera positions the world on every target.
         game.check_hot_reload(frame_time.clone());
         for sub_frame in &sub_frames {
             game.tick(sub_frame.clone());
@@ -795,7 +839,13 @@ pub fn android_main(app: AndroidApp) {
                 gl.disable(glow::SCISSOR_TEST);
                 gl.enable(glow::DEPTH_TEST);
             }
-            let camera = camera_from_view(view);
+            let camera = tracking_reference
+                .map(|reference| {
+                    frame
+                        .camera
+                        .compose_tracked_view(reference, tracking_pose_from_view(view))
+                })
+                .unwrap_or_else(|| frame.camera.clone());
             let projection = camera.projection_matrix_from_fov_angles(
                 view.fov.angle_left,
                 view.fov.angle_right,


### PR DESCRIPTION
## Summary

- treat Frame.camera as the authored center-eye rig on Quest
- compose reference-relative OpenXR eye translation and rotation in the authored camera local basis
- preserve game-owned locomotion and near/far clipping while OpenXR owns IPD and asymmetric optical FOV
- share the tracking mapper with Xreal and make it reusable for future controller/hand poses
- recenter on OpenXR reference-space changes and submit no layer for invalid tracking

## Camera contract

The first valid center-eye pose is neutral. At that pose, XR matches the authored Frame.camera. Later physical movement is additive, while changing Frame.camera moves the whole rig. The tracking reference survives source reload and session doze.

## Verification

- common runtime: 390 unit tests + 7 prelude integration tests passed
- desktop runtime: 62 tests passed
- targeted final pass: 13 camera tests + 16 Xreal tests passed
- Oculus arm64 debug cross-build passed
- non-debuggable release APK packaged, aligned, signed, installed, and launched on Quest 3
- raw stereo capture: 3360x1760, two complete 1680x1760 eyes, correct vertical alignment/disparity/framing, no fallback assets
- live authored-camera translation from x=0 to x=3 moved the scene coherently in both Quest eyes, then source was restored

### Host frame benchmark

Back-to-back origin/main vs change release binaries used the same lockfile. Allocations and bytes/frame were exactly unchanged. Best minimum timing deltas were +0.03% (20x20), +0.82% (40x40), and -4.50% (56x56), within run-to-run noise.

### Quest release benchmark

Quest 3, two 1680x1760 eyes:

- primitives run 1: 72.483 FPS mean / 72 min, 3.358 ms mean App, 0 stale, 1 torn
- primitives rerun: 72.531 FPS mean / 72 min, 3.313 ms mean App, 3 stale, 0 torn
- synthwave source/geometry stress: 72.586 FPS mean / 72 min, 0.721 ms mean App, 0 stale, 0 torn

The synthwave texture assets are not synchronized yet, so that result covers source/interpreter/geometry cost rather than final texture behavior.

## Review disposition

Adversarial review found that invalid OpenXR views were still being submitted and that tracking-loss time could leak into recovery. Both findings are fixed: invalid tracking now ends with no projection layer, cancels pending capture honestly, and resets frame timing. A final media-aware cross-engine review inspected the implementation and both full-resolution stereo captures; both reviewers returned Ship with 0 Critical and 0 High findings.

## Media

![Quest 3 authored-camera rig translation](https://gist.githubusercontent.com/tommy-xr/4a2d4330672f84e720b73aa08ccc5b8f/raw/quest3-authored-camera-x0-to-x3.gif)

<sub>Quest 3 raw stereo: hot-reloading the authored camera from x=0 to x=3 moves the XR rig coherently in both eyes.</sub>

### Authored camera x=0 → x=3

![Quest 3 authored-camera x=0 to x=3 comparison](https://gist.githubusercontent.com/tommy-xr/4a2d4330672f84e720b73aa08ccc5b8f/raw/quest3-authored-camera-x0-to-x3-comparison.png)

<sub>Each panel preserves the complete 3360×1760 raw stereo capture (1680×1760 per eye).</sub>

[Full-resolution x=0 raw stereo](https://gist.githubusercontent.com/tommy-xr/4a2d4330672f84e720b73aa08ccc5b8f/raw/quest3-authored-camera-x0-raw-stereo.png) · [Full-resolution x=3 raw stereo](https://gist.githubusercontent.com/tommy-xr/4a2d4330672f84e720b73aa08ccc5b8f/raw/quest3-authored-camera-x3-raw-stereo.png)
