### PR TITLE
feat(lang): add Option and Result stdlib modules

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -202,7 +202,8 @@ let grab = (s) =>
   (they evaluate first); siblings may reference the entry (`Game.foo`) if
   that creates no cycle.
 - **Protected namespaces**: a file whose module name collides with a
-  builtin/prelude namespace (Net, Key, Random, List, Text, Math, Debug, Scene,
+  builtin/prelude or bundled-core namespace (Net, Key, Random, Option, Result,
+  List, Text, Math, Debug, Scene,
   Anim, Asset, Camera, Frame, Light, Fog, Color, Vec3, Skybox, Angle, Texture,
   Time, Sub, Effect, Physics, RenderTarget, Ui, Html, Attr, Style, AudioSource, AudioScene) is a
   load error — rename the file. (`assets.fun` → `Assets` — the generated
@@ -232,8 +233,9 @@ let grab = (s) =>
   reason keys stopped being strings. `Random` is likewise built-in (the
   abstract `Random.Seed` — see the Random builtins above).
 - **Bundled modules use the ordinary module semantics.** The language-owned
-  `Net.fun` / `Key.fun` implementations and `Random.funi` interface are
-  in-memory sources distributed with every embedding. Hosts may inject
+  `Net.fun` / `Key.fun` builtins, `Random.funi` interface, and
+  `Option.fun` / `Result.fun` standard-library implementations are in-memory
+  sources distributed with every embedding. Hosts may inject
   additional bundled `.fun` implementations and `.funi` interfaces through
   the same project linker: they parse, lower, check, evaluate, participate in
   dependency ordering, appear in source maps (`<stdlib>/…` / `<prelude>/…`),
@@ -379,6 +381,40 @@ expect (                                      // any expression works — a
   which loop in the interpreter and consume no evaluation depth. A hand-rolled
   recursive list walk trips the cap around n≈60; the depth error names the cap
   value (128) and points at `List.fold`.
+
+## Standard library modules
+
+`Option` and `Result` are bundled `.fun` modules available in every project and
+under the plain `functor-lang` CLI. They are ordinary, generic ADTs — match
+their qualified constructors directly, annotate with `Option.t<'value>` /
+`Result.t<'value, 'error>`, and use their helpers subject-last so pipelines
+read naturally:
+
+```functor
+let label =
+  Option.Some(41.0)
+  |> Option.map((n) => n + 1.0)
+  |> Option.defaultWith(() => 0.0)
+
+let message = (result: Result.t<float, string>) =>
+  match result with
+  | Result.Ok(value) => Text.fromFloat(value)
+  | Result.Error(error) => error
+```
+
+`Option.Some(value)` / `Option.None` ·
+`Option.map(fn, option)` · `Option.bind(fn, option)` ·
+`Option.defaultValue(fallback, option)` ·
+`Option.defaultWith(() => fallback, option)` (the callback runs only for
+`None`) · `Option.isSome(option)` · `Option.isNone(option)` ·
+`Option.filter(predicate, option)` · `Option.toList(option)`.
+
+`Result.Ok(value)` / `Result.Error(error)` ·
+`Result.map(fn, result)` · `Result.mapError(fn, result)` ·
+`Result.bind(fn, result)` · `Result.defaultValue(fallback, result)` ·
+`Result.defaultWith(errorToValue, result)` (the callback receives the error
+and runs only for `Error`) · `Result.isOk(result)` ·
+`Result.isError(result)` · `Result.toOption(result)`.
 
 ## Builtins (the whole registry)
 

--- a/docs/functor-lang.md
+++ b/docs/functor-lang.md
@@ -499,9 +499,17 @@ snapshots — no GPU, fully agent-verifiable.
       themselves as `<stdlib>/…` or `<prelude>/…`. The existing language-owned
       `Net.fun`, `Key.fun`, and `Random.funi` now go through this path instead
       of bespoke pushes. Compatibility wrappers keep every current prelude
-      caller unchanged. This is the distribution substrate for the core
-      Option/Result modules and the engine-bundled Animator follow-ups; those
-      modules are deliberately separate slices.
+      caller unchanged. This is the distribution substrate for reusable core
+      and engine modules; consumers do not need a package/import step.
+      **Part 4 — core Option/Result — done (2026-07-23):** bundled ordinary
+      `.fun` implementations now provide generic `Option.t<'value>`
+      (`Some`/`None`) and `Result.t<'value, 'error>` (`Ok`/`Error`) in every
+      embedding, including the plain language CLI. Their subject-last helper
+      APIs cover mapping/binding, lazy/eager defaults, predicates, filtering
+      or error mapping, and `Option.toList` / `Result.toOption`; their
+      `<stdlib>/…` sources participate in the normal parser, checker,
+      dependency graph, evaluator, source maps, and hot-reload rebind path.
+      Engine-bundled Animator remains a separate follow-up.
 - [x] **Language: inline `expect` tests** (done 2026-07-19; design note in
       `~/notes` `inline-expect-tests.md` — the live red/green editor arc
       builds on this). `expect <bool-expr>` is a top-level item (contextual

--- a/functor-lang/src/complete.rs
+++ b/functor-lang/src/complete.rs
@@ -869,6 +869,38 @@ mod tests {
         assert_eq!(find(&items, "map").kind, CompletionKind::Function);
     }
 
+    // Bundled stdlib modules complete from their ordinary inferred `.fun`
+    // definitions, including generic signatures and constructors.
+    #[test]
+    fn standard_library_member_completion() {
+        let option = game(STUB, &[], "let s = Option.");
+        assert_eq!(
+            find(&option, "map").detail.as_deref(),
+            Some("Option.map : (('a) => 'b, Option.t<'a>) => Option.t<'b>")
+        );
+        assert_eq!(find(&option, "map").kind, CompletionKind::Function);
+        assert_eq!(
+            find(&option, "Some").detail.as_deref(),
+            Some("Option.Some : ('value) => t<'value>")
+        );
+        assert_eq!(find(&option, "Some").kind, CompletionKind::Constructor);
+        assert_eq!(
+            find(&option, "None").detail.as_deref(),
+            Some("Option.None : t<'value>")
+        );
+
+        let result = game(STUB, &[], "let s = Result.");
+        for member in ["map", "mapError", "bind", "defaultValue", "toOption"] {
+            assert!(
+                has(&result, member),
+                "missing {member} in {:?}",
+                labels(&result)
+            );
+        }
+        assert_eq!(find(&result, "Ok").kind, CompletionKind::Constructor);
+        assert_eq!(find(&result, "Error").kind, CompletionKind::Constructor);
+    }
+
     // Builtin module `Math.` — the function builtins complete as functions, but
     // the constant `Math.pi` completes as a Value (not a callable).
     #[test]

--- a/functor-lang/src/docs.rs
+++ b/functor-lang/src/docs.rs
@@ -125,4 +125,23 @@ mod tests {
         );
         assert_eq!(doc_comment(&project.sources, sig("Widget.size")), None);
     }
+
+    /// Bundled `.fun` implementations retain their own API documentation,
+    /// just like project definitions and prelude signatures.
+    #[test]
+    fn standard_library_defs_attach_their_source_docs() {
+        let project =
+            load_single_source("game", "let main = () => Option.None\n")
+                .unwrap_or_else(|e| panic!("loads: {}", e.render()));
+        let map = project
+            .module
+            .defs
+            .iter()
+            .find(|def| def.name == "Option.map")
+            .expect("Option.map definition");
+        assert_eq!(
+            doc_comment(&project.sources, map.span).as_deref(),
+            Some("Transform a present value; leave `None` unchanged.")
+        );
+    }
 }

--- a/functor-lang/src/project.rs
+++ b/functor-lang/src/project.rs
@@ -225,6 +225,9 @@ const KEY_MODULE_SRC: &str = "type t =\n\
      | Space | Enter | Escape\n\
      | Num0 | Num1 | Num2 | Num3 | Num4 | Num5 | Num6 | Num7 | Num8 | Num9\n";
 
+const OPTION_MODULE_SRC: &str = include_str!("../stdlib/option.fun");
+const RESULT_MODULE_SRC: &str = include_str!("../stdlib/result.fun");
+
 /// Language-owned modules available in every embedding, including the plain
 /// `functor-lang` CLI. Keeping them in the same descriptor shape as host
 /// modules is the distribution seam for reusable `.fun` stdlib code.
@@ -233,6 +236,8 @@ fn core_modules() -> Vec<BundledModule> {
         BundledModule::builtin("Net", NET_MODULE_SRC, BundledModuleKind::Implementation),
         BundledModule::builtin("Random", RANDOM_MODULE_SRC, BundledModuleKind::Interface),
         BundledModule::builtin("Key", KEY_MODULE_SRC, BundledModuleKind::Implementation),
+        BundledModule::implementation("Option", OPTION_MODULE_SRC),
+        BundledModule::implementation("Result", RESULT_MODULE_SRC),
     ]
 }
 

--- a/functor-lang/stdlib/option.fun
+++ b/functor-lang/stdlib/option.fun
@@ -1,0 +1,54 @@
+// An optional value. Helpers are subject-last so they compose with `|>`.
+
+type t<'value> =
+  | Some(value: 'value)
+  | None
+
+// Transform a present value; leave `None` unchanged.
+let map = (fn: ('value) => 'mapped, option: t<'value>): t<'mapped> =>
+  match option with
+  | Some(value) => Some(fn(value))
+  | None => None
+
+// Continue with an optional computation when a value is present.
+let bind = (fn: ('value) => t<'mapped>, option: t<'value>): t<'mapped> =>
+  match option with
+  | Some(value) => fn(value)
+  | None => None
+
+// Return the contained value, or an eager fallback for `None`.
+let defaultValue = (fallback: 'value, option: t<'value>): 'value =>
+  match option with
+  | Some(value) => value
+  | None => fallback
+
+// Return the contained value, computing the fallback only for `None`.
+let defaultWith = (fallback: () => 'value, option: t<'value>): 'value =>
+  match option with
+  | Some(value) => value
+  | None => fallback()
+
+// Whether the option contains a value.
+let isSome = (option: t<'value>): bool =>
+  match option with
+  | Some(_) => true
+  | None => false
+
+// Whether the option is `None`.
+let isNone = (option: t<'value>): bool =>
+  match option with
+  | Some(_) => false
+  | None => true
+
+// Keep a present value only when it satisfies the predicate.
+let filter = (predicate: ('value) => bool, option: t<'value>): t<'value> =>
+  match option with
+  | Some(value) =>
+      if predicate(value) then Some(value) else None
+  | None => None
+
+// Convert `Some(value)` to `[value]` and `None` to `[]`.
+let toList = (option: t<'value>): List<'value> =>
+  match option with
+  | Some(value) => [value]
+  | None => []

--- a/functor-lang/stdlib/result.fun
+++ b/functor-lang/stdlib/result.fun
@@ -1,0 +1,55 @@
+// A successful value or an error. Helpers are subject-last so they compose
+// with `|>`.
+
+type t<'value, 'error> =
+  | Ok(value: 'value)
+  | Error(error: 'error)
+
+// Transform a successful value; leave an error unchanged.
+let map = (fn: ('value) => 'mapped, result: t<'value, 'error>): t<'mapped, 'error> =>
+  match result with
+  | Ok(value) => Ok(fn(value))
+  | Error(error) => Error(error)
+
+// Transform an error; leave a successful value unchanged.
+let mapError = (fn: ('error) => 'mapped, result: t<'value, 'error>): t<'value, 'mapped> =>
+  match result with
+  | Ok(value) => Ok(value)
+  | Error(error) => Error(fn(error))
+
+// Continue with a result-producing computation after success.
+let bind =
+  (fn: ('value) => t<'mapped, 'error>, result: t<'value, 'error>): t<'mapped, 'error> =>
+    match result with
+    | Ok(value) => fn(value)
+    | Error(error) => Error(error)
+
+// Return the successful value, or an eager fallback for an error.
+let defaultValue = (fallback: 'value, result: t<'value, 'error>): 'value =>
+  match result with
+  | Ok(value) => value
+  | Error(_) => fallback
+
+// Return the successful value, or compute a fallback from the error.
+let defaultWith = (fallback: ('error) => 'value, result: t<'value, 'error>): 'value =>
+  match result with
+  | Ok(value) => value
+  | Error(error) => fallback(error)
+
+// Whether the result is successful.
+let isOk = (result: t<'value, 'error>): bool =>
+  match result with
+  | Ok(_) => true
+  | Error(_) => false
+
+// Whether the result contains an error.
+let isError = (result: t<'value, 'error>): bool =>
+  match result with
+  | Ok(_) => false
+  | Error(_) => true
+
+// Convert `Ok(value)` to `Option.Some(value)` and an error to `Option.None`.
+let toOption = (result: t<'value, 'error>): Option.t<'value> =>
+  match result with
+  | Ok(value) => Option.Some(value)
+  | Error(_) => Option.None

--- a/functor-lang/tests/project.rs
+++ b/functor-lang/tests/project.rs
@@ -787,11 +787,9 @@ let bad = f() + 1.0
 /// lowering (the backward-compatibility pin: bare names, IDs from zero,
 /// spans from zero).
 #[test]
-fn single_file_project_adds_only_the_builtin_modules() {
-    // A project always includes the built-in `Net` and `Random` prelude
-    // modules (so any game can `match ev with | Net.Connected(id) => …` and
-    // seed the PRNG), so its merged IR is plain lowering's defs/types PLUS
-    // theirs — nothing else changes.
+fn single_file_project_adds_only_the_core_modules() {
+    // A project always includes the language-owned modules, so its merged IR
+    // is plain lowering's defs/types plus those modules — nothing else changes.
     let src = "type Shape = | Circle(radius: float) | Point\n\
                let area = (s: Shape): float =>\n\
                match s with | Circle(r) => 3.14 * r * r | Point => 0.0\n\
@@ -811,9 +809,9 @@ fn single_file_project_adds_only_the_builtin_modules() {
     for ty in &plain.types {
         assert!(proj_types.contains(&ty.name.as_str()));
     }
-    // The ONLY additions are the built-in modules': Net's canonicalized
+    // The ONLY additions are the core modules': Net's canonicalized
     // `Net.NetEvent` / `Net.HttpResponse`, Random's abstract `Random.Seed`,
-    // and the input-key variant `Key.t`.
+    // the input-key variant `Key.t`, and the stdlib's generic Option/Result.
     assert!(
         proj_types.contains(&"Net.NetEvent") && proj_types.contains(&"Net.HttpResponse"),
         "the built-in Net module must be injected: {proj_types:?}"
@@ -826,11 +824,80 @@ fn single_file_project_adds_only_the_builtin_modules() {
         proj_types.contains(&"Key.t"),
         "the built-in Key module must be injected: {proj_types:?}"
     );
+    assert!(
+        proj_types.contains(&"Option.t") && proj_types.contains(&"Result.t"),
+        "the bundled stdlib modules must be injected: {proj_types:?}"
+    );
     assert_eq!(
         proj_types.len(),
-        plain.types.len() + 4,
-        "no types beyond the entry's + Net's two + Random.Seed + Key.t"
+        plain.types.len() + 6,
+        "no types beyond the entry's + Net(2) + Random + Key + Option + Result"
     );
+}
+
+#[test]
+fn bundled_option_module_runs_and_checks() {
+    let src = "let main = () =>\n\
+               let kept = Option.Some(20.0)\n\
+                 |> Option.map((n) => n + 1.0)\n\
+                 |> Option.bind((n) => Option.Some(n * 2.0))\n\
+                 |> Option.filter((n) => n > 40.0) in\n\
+               let removed = kept |> Option.filter((n) => n > 100.0) in\n\
+               let flags =\n\
+                 if Option.isSome(kept) && Option.isNone(removed) then 1.0 else 0.0 in\n\
+               Option.defaultValue(0.0, kept)\n\
+                 + Option.defaultWith(() => 5.0, removed)\n\
+                 + List.length(Option.toList(kept))\n\
+                 + flags\n";
+    let project = load("option-stdlib", &[("game.fun", src)]);
+    let diags = project.check();
+    assert!(diags.is_empty(), "Option API should check: {diags:?}");
+
+    let record = functor_lang::run(&project.module, Tracing::Off)
+        .unwrap_or_else(|f| panic!("Option API should run: {}", f.error.message));
+    match record.outcome {
+        RunOutcome::Main(Value::Number(n)) => assert_eq!(n, 49.0),
+        _ => panic!("expected a numeric main result"),
+    }
+
+    let option = project
+        .sources
+        .files()
+        .iter()
+        .find(|file| file.module == "Option")
+        .expect("Option source is mapped");
+    assert_eq!(option.path, PathBuf::from("<stdlib>/Option.fun"));
+    assert!(!option.interface);
+}
+
+#[test]
+fn bundled_result_module_runs_and_checks() {
+    let src = "let main = () =>\n\
+               let good = Result.Ok(20.0)\n\
+                 |> Result.map((n) => n + 1.0)\n\
+                 |> Result.bind((n) => Result.Ok(n * 2.0)) in\n\
+               let bad = Result.Error(\"no\")\n\
+                 |> Result.map((n) => n + 1.0)\n\
+                 |> Result.mapError((e) => Text.concat(e, \"!\")) in\n\
+               let flags =\n\
+                 if Result.isOk(good) && Result.isError(bad) then 1.0 else 0.0 in\n\
+               let options =\n\
+                 Option.defaultValue(0.0, Result.toOption(good))\n\
+                   + (if Option.isNone(Result.toOption(bad)) then 1.0 else 0.0) in\n\
+               Result.defaultValue(0.0, good)\n\
+                 + Result.defaultWith((e) => if e == \"no!\" then 5.0 else 0.0, bad)\n\
+                 + flags\n\
+                 + options\n";
+    let project = load("result-stdlib", &[("game.fun", src)]);
+    let diags = project.check();
+    assert!(diags.is_empty(), "Result API should check: {diags:?}");
+
+    let record = functor_lang::run(&project.module, Tracing::Off)
+        .unwrap_or_else(|f| panic!("Result API should run: {}", f.error.message));
+    match record.outcome {
+        RunOutcome::Main(Value::Number(n)) => assert_eq!(n, 91.0),
+        _ => panic!("expected a numeric main result"),
+    }
 }
 
 /// The built-in `Key` module: the `input` hook's key variant. Qualified

--- a/tools/functor-lang-lsp/src/main.rs
+++ b/tools/functor-lang-lsp/src/main.rs
@@ -1124,9 +1124,10 @@ fn owns(file: &functor_lang::project::SourceFile, offset: usize) -> bool {
 fn localize(project: &functor_lang::project::Project, span: functor_lang::Span) -> Option<(String, Value)> {
     let file = project.sources.file_at(span.start);
     let path = if file.path.to_str().is_some_and(|p| p.starts_with('<')) {
-        // A synthetic source (`<prelude>/Scene.funi`, `<builtin>/Random.funi`,
-        // `<builtin>/Net.fun`) — materialize its text so the editor can open
-        // it. Definition targets in Net/Random/Key land here too.
+        // A synthetic source (`<prelude>/Scene.funi`, `<stdlib>/Option.fun`,
+        // `<builtin>/Random.funi`) — materialize its text so the editor can
+        // open it. Definition targets in Net/Random/Key/Option/Result land
+        // here too.
         materialize_synthetic(file)?
     } else {
         file.path.clone()


### PR DESCRIPTION
## Summary

- bundle generic `Option` and `Result` implementation modules into every Functor Lang embedding
- provide subject-last mapping, binding, default, predicate, filtering/error-mapping, and conversion helpers
- expose inferred completion signatures and source documentation through the existing tooling path
- document the shipped API in the language skill and roadmap

Related: #307

## Testing

- `cargo test -p functor-lang -p functor_runtime_common -p functor-lang-lsp` (981 tests passed)
- `git diff --check`

## Review dispositions

- adversarial Claude review found no Critical, High, or Medium issues
- accepted one informational note about the pre-existing constructor completion-detail rendering inconsistency; changing that shared rendering behavior is outside this slice
- duplication review found no existing Functor Lang Option/Result implementation and no exact clone touching the changed lines
- Codex CLI review engine was unavailable after recursively entering its own review workflow; the completed independent review and full verification remained clean

No visual capture is required: this change has no rendered output.