### PR TITLE
feat: bundle Animator with engine hosts

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -235,14 +235,15 @@ let grab = (s) =>
 - **Bundled modules use the ordinary module semantics.** The language-owned
   `Net.fun` / `Key.fun` builtins, `Random.funi` interface, and
   `Option.fun` / `Result.fun` standard-library implementations are in-memory
-  sources distributed with every embedding. Hosts may inject
-  additional bundled `.fun` implementations and `.funi` interfaces through
-  the same project linker: they parse, lower, check, evaluate, participate in
-  dependency ordering, appear in source maps (`<stdlib>/…` / `<prelude>/…`),
-  and rebind stored closures like project modules. Their namespaces are
-  reserved automatically. They are fixed for the lifetime of the host binary
-  and therefore are re-linked on a project hot reload but are not themselves
-  file-watched.
+  sources distributed with every embedding. Engine hosts additionally bundle
+  `Animator.fun`, a pure Functor Lang crossfade helper built on the host's
+  `Anim` interface. Hosts may inject additional bundled `.fun`
+  implementations and `.funi` interfaces through the same project linker:
+  they parse, lower, check, evaluate, participate in dependency ordering,
+  appear in source maps (`<stdlib>/…` / `<prelude>/…`), and rebind stored
+  closures like project modules. Their namespaces are reserved automatically.
+  They are fixed for the lifetime of the host binary and therefore are
+  re-linked on a project hot reload but are not themselves file-watched.
 - Constructor names must be unique per MODULE (not per project); values
   from a non-entry module display with their canonical tag
   (`Utils.Circle(2)` in run/trace/`/state` output). The entry's own names
@@ -415,6 +416,32 @@ let message = (result: Result.t<float, string>) =>
 `Result.defaultWith(errorToValue, result)` (the callback receives the error
 and runs only for `Error`) · `Result.isOk(result)` ·
 `Result.isError(result)` · `Result.toOption(result)`.
+
+Engine-hosted projects also receive `Animator`, an ordinary bundled `.fun`
+module built on `Anim`. Its state is plain record data suitable for model
+storage, hot reload, and time travel:
+
+```functor
+let init = { anim: Animator.start("idle", 0.0) }
+
+let run = (model, tts) =>
+  { model with anim: Animator.play("run", tts, model.anim) }
+
+let draw = (model, tts) =>
+  Scene.model(Assets.character)
+    |> Scene.animate(Animator.pose(model.anim, 0.5, tts))
+```
+
+`Animator.start(clip, tts)` starts a clip with no initial fade ·
+`Animator.play(clip, tts, state)` records a transition (replaying the current
+clip is a no-op) · `Animator.pose(state, fadeSeconds, tts)` derives an `Anim.t`
+using a smoothstep crossfade and clip-local playheads. A play during an
+in-flight transition uses the current clip as the new outgoing clip and
+restarts the fade; it does not snapshot the mid-blend pose.
+
+`Animator` is a reserved bundled namespace. A project that copied the earlier
+`examples/crossfade/animator.fun` should delete that sibling to use the bundled
+module, or rename it if it carries a customized implementation.
 
 ## Builtins (the whole registry)
 
@@ -594,6 +621,10 @@ Anim.blend([(anim, weight), …])                            // weighted pose mi
 Anim.rest()                                                // the bind pose — the base for
                                                            //   purely programmatic posing
                                                            //   (a model with no clips)
+Animator.start("idle", tts)                               // plain-data crossfade state;
+Animator.play("run", tts, state)                          //   records a transition
+Animator.pose(state, 0.5, tts)                            // smoothstep-derived Anim.t;
+                                                           //   bundled by engine hosts
 anim |> Anim.add(layerAnim, weight)                        // additive layer: the layer's
                                                            //   delta-from-bind on top of
                                                            //   anim (headShake over walk).

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ dist/
 # perf output
 perf*
 
+# Local semantic-review model/index cache.
+.fastembed_cache/
+
 # MacOS
 .DS_Store
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,8 +19,8 @@ web = []
 [dependencies]
 # The Functor Lang language, for `language: "functor-lang"` projects (docs/functor-lang.md Track C4).
 functor-lang = { path = "../functor-lang" }
-# The host prelude `.funi` interfaces — injected at load time so a game's
-# `Scene.*` calls typecheck against real types (docs/functor-lang-interfaces.md).
+# Engine-bundled `.fun` modules and host `.funi` interfaces, shared with the
+# runtimes and editor tooling.
 functor-prelude = { path = "../functor-prelude" }
 clap = { version = "4.5.6", features = ["derive"] }
 colored = "2.1.0"

--- a/cli/src/commands/functor_lang_project.rs
+++ b/cli/src/commands/functor_lang_project.rs
@@ -186,14 +186,13 @@ impl FunctorLangProject {
         // A load failure (parse error, bad module name, cycle) is a positioned
         // diagnostic too — surface its file:line:col structurally, like a check
         // error, rather than flattening it into the final text-only error.
-        // Inject the host prelude `.funi` interfaces so the game's `Scene.*`
-        // (etc.) externals typecheck against real types instead of `Unknown`
-        // (docs/functor-lang-interfaces.md). Check-time only — runtime evaluation is unchanged
-        // (the host provides the actual values).
-        let project = match functor_lang::project::load_with_prelude(
+        // Inject the engine's bundled `.fun` modules and `.funi` interfaces
+        // so reusable modules such as `Animator` execute and host externals
+        // such as `Scene.*` typecheck against their real types.
+        let project = match functor_lang::project::load_with_bundled_modules(
             &path,
             &std::collections::HashMap::new(),
-            &functor_prelude::modules(),
+            &functor_prelude::bundled_modules(),
         ) {
             Ok(project) => project,
             Err(e) => {
@@ -1047,10 +1046,10 @@ examples move?",
                         continue;
                     }
                 };
-                match functor_lang::project::load_with_prelude(
+                match functor_lang::project::load_with_bundled_modules(
                     &entry,
                     &std::collections::HashMap::new(),
-                    &functor_prelude::modules(),
+                    &functor_prelude::bundled_modules(),
                 ) {
                     Ok(loaded) => {
                         for diag in loaded.check() {

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -154,10 +154,10 @@ mod tests {
     }
 
     fn assert_project_typechecks(directory: &Path) {
-        let project = functor_lang::project::load_with_prelude(
+        let project = functor_lang::project::load_with_bundled_modules(
             &directory.join("game.fun"),
             &HashMap::new(),
-            &functor_prelude::modules(),
+            &functor_prelude::bundled_modules(),
         )
         .unwrap_or_else(|error| panic!("template should load: {}", error.render()));
         let diagnostics = project.check();

--- a/docs/functor-lang.md
+++ b/docs/functor-lang.md
@@ -518,7 +518,19 @@ snapshots — no GPU, fully agent-verifiable.
       or error mapping, and `Option.toList` / `Result.toOption`; their
       `<stdlib>/…` sources participate in the normal parser, checker,
       dependency graph, evaluator, source maps, and hot-reload rebind path.
-      Engine-bundled Animator remains a separate follow-up.
+      **Part 5 — engine-bundled Animator — done (2026-07-23):** the pure
+      Functor Lang crossfade module that began in `examples/crossfade` now
+      ships once in the engine bundle. Native, wasm, CLI checking, the LSP,
+      and browser analysis all consume the same bundle descriptor, so games
+      can call `Animator.start` / `play` / `pose` without copying a sibling
+      file. Its `<stdlib>/Animator.fun` implementation links against the
+      host-backed `Anim` interface through the ordinary module graph, remains
+      navigable/completable in editors, and re-links on project hot reload.
+      This completes the first engine-library customer of the bundled-module
+      substrate and closes #307. Existing projects that copied the earlier
+      `animator.fun` example module should remove that file to use the bundled
+      API, or rename it if they maintain a customized implementation; bundled
+      namespaces cannot be shadowed.
 - [x] **Language: inline `expect` tests** (done 2026-07-19; design note in
       `~/notes` `inline-expect-tests.md` — the live red/green editor arc
       builds on this). `expect <bool-expr>` is a top-level item (contextual

--- a/examples/crossfade/game.fun
+++ b/examples/crossfade/game.fun
@@ -8,10 +8,9 @@
 //   - RIGHT figure: `Animator.pose` — the same state, derived as a
 //     smoothstep crossfade. Transitions glide.
 //
-// The Animator is ~20 lines of pure Functor Lang in the sibling
-// `animator.fun` (file = module): crossfade state is plain data in the
-// model, the blend weights derive from `tts`, and time-travel replays a
-// mid-fade frame exactly.
+// Animator is an engine-bundled module implemented in pure Functor Lang:
+// crossfade state is plain data in the model, the blend weights derive from
+// `tts`, and time-travel replays a mid-fade frame exactly.
 //
 // Keys: 1-5 trigger states, 0 = auto-cycle (default, every 2.5s). Mashing
 // keys mid-fade shows the truncation policy on the right figure.

--- a/functor-lang/src/project.rs
+++ b/functor-lang/src/project.rs
@@ -111,6 +111,22 @@ impl BundledModule {
         BundledModule::new(name, src, BundledModuleKind::Interface, "<prelude>")
     }
 
+    /// Module name used by qualified access (`Animator`, `Scene`, …).
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Embedded source text linked for this module.
+    pub fn source(&self) -> &str {
+        &self.src
+    }
+
+    /// Whether this descriptor carries executable `.fun` source or a
+    /// host-backed `.funi` interface.
+    pub fn kind(&self) -> BundledModuleKind {
+        self.kind
+    }
+
     fn builtin(
         name: impl Into<String>,
         src: impl Into<String>,
@@ -565,7 +581,8 @@ namespace `{module}` — rename the file",
                 path,
                 format!(
                     "module name `{module}` (from {}) collides with the bundled module \
-namespace `{module}` — rename the file",
+namespace `{module}` — remove the file to use the bundled module, or rename it \
+if it is a customized module",
                     file_name(path)
                 ),
             ));

--- a/functor-lang/tests/project.rs
+++ b/functor-lang/tests/project.rs
@@ -1461,7 +1461,8 @@ fn project_file_cannot_shadow_a_bundled_module() {
     assert_eq!(
         err,
         "animator.fun:1:1: module name `Animator` (from animator.fun) collides with the bundled \
-module namespace `Animator` — rename the file"
+         module namespace `Animator` — remove the file to use the bundled module, or rename it \
+         if it is a customized module"
     );
 }
 

--- a/functor-prelude/Cargo.toml
+++ b/functor-prelude/Cargo.toml
@@ -3,8 +3,8 @@ name = "functor-prelude"
 version = "0.1.0"
 edition = "2021"
 
-# Zero dependencies by design: this crate is a thin holder of the host prelude
-# `.funi` interface text so it can be depended on by BOTH the runtime
-# (functor_runtime_common) and the editor tooling (tools/functor-lang-lsp) without
-# dragging in either's dependency graph.
+# This crate owns the engine's complete Functor Lang bundle: host `.funi`
+# interfaces plus reusable `.fun` implementations. It depends only on the
+# dependency-free language crate for the shared bundled-module descriptor.
 [dependencies]
+functor-lang = { path = "../functor-lang" }

--- a/functor-prelude/src/lib.rs
+++ b/functor-prelude/src/lib.rs
@@ -1,19 +1,42 @@
-//! The Functor host prelude as Functor Lang interface files (`.funi`).
+//! The Functor host bundle: interface files (`.funi`) and reusable Functor
+//! Lang implementation modules (`.fun`).
 //!
 //! The Functor Lang typechecker resolves host externals (`Scene.cube`, …) against
 //! interface-only modules injected at load time (see
-//! [`functor_lang::project::load_with_prelude`] and `docs/functor-lang-interfaces.md`). This crate holds the
-//! authoritative `.funi` text for those modules and exposes it as
-//! `(module name, source)` pairs — the exact shape the loader wants.
+//! [`functor_lang::project::load_with_bundled_modules`] and
+//! `docs/functor-lang-interfaces.md`). This crate holds the authoritative
+//! engine-owned source for every target.
 //!
-//! The `.funi` here declares only TYPES; the Rust implementations live in
+//! The `.funi` files declare only TYPES; their Rust implementations live in
 //! `functor_runtime_common::functor_lang_prelude::FunctorHost`. A drift test in that
-//! crate keeps the two in sync.
+//! crate keeps the two in sync. Bundled `.fun` files are ordinary executable
+//! modules linked and evaluated by `functor-lang`.
+
+use functor_lang::project::BundledModule;
+
+/// The complete engine-owned Functor Lang bundle.
+///
+/// Hosts should pass this to the `*_with_bundled_modules` loader matching
+/// their source form. Keeping interfaces and implementations together makes
+/// their availability identical in native, wasm, CLI, and editor tooling.
+pub fn bundled_modules() -> Vec<BundledModule> {
+    let mut bundled = modules()
+        .into_iter()
+        .map(|(name, src)| BundledModule::interface(name, src))
+        .collect::<Vec<_>>();
+    bundled.push(BundledModule::implementation(
+        "Animator",
+        include_str!("../stdlib/animator.fun"),
+    ));
+    bundled
+}
 
 /// The host prelude interface modules, as `(module name, .funi source)` pairs.
 ///
 /// The module name is what qualified access uses (`Scene.cube`); it is derived
 /// here explicitly rather than from a file name so the loader gets it verbatim.
+/// This interface-only view remains useful to the registry drift tests; hosts
+/// should load [`bundled_modules`] instead.
 pub fn modules() -> Vec<(String, String)> {
     vec![
         module("Scene", include_str!("../prelude/scene.funi")),
@@ -44,4 +67,24 @@ pub fn modules() -> Vec<(String, String)> {
 
 fn module(name: &str, src: &str) -> (String, String) {
     (name.to_string(), src.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use functor_lang::project::BundledModuleKind;
+
+    #[test]
+    fn engine_bundle_contains_interfaces_and_animator_implementation() {
+        let bundled = bundled_modules();
+        assert!(bundled.iter().any(|module| {
+            module.name() == "Scene" && module.kind() == BundledModuleKind::Interface
+        }));
+        let animator = bundled
+            .iter()
+            .find(|module| module.name() == "Animator")
+            .expect("Animator is distributed with every engine host");
+        assert_eq!(animator.kind(), BundledModuleKind::Implementation);
+        assert!(animator.source().contains("let pose"));
+    }
 }

--- a/functor-prelude/stdlib/animator.fun
+++ b/functor-prelude/stdlib/animator.fun
@@ -1,4 +1,5 @@
-// Animator — a derived crossfade over Anim clips, in pure Functor Lang.
+// Animator — the engine-bundled derived crossfade over Anim clips, in pure
+// Functor Lang.
 //
 // The engine's Anim.* algebra is stateless: a pose is a function of explicit
 // playheads and weights. This module derives smooth clip transitions from
@@ -44,17 +45,15 @@ let play = (clip: string, tts: float, st) =>
       fadeStart: tts,
     }
 
-let smoothstep = (t: float): float =>
-  let c = Math.clamp01(t) in
-  c * c * (3.0 - 2.0 * c)
-
 // The derived pose: a smoothstep crossfade from `prev` to `current` over
 // `fade` seconds, collapsing to the bare current clip once settled. A
 // non-positive fade is a hard cut (guards the divide).
 let pose = (st, fade: float, tts: float): Anim.t =>
   let w =
     (match fade > 0.0 with
-     | true => smoothstep((tts - st.fadeStart) / fade)
+     | true =>
+       let c = Math.clamp01((tts - st.fadeStart) / fade) in
+       c * c * (3.0 - 2.0 * c)
      | false => 1.0) in
   match w < 1.0 with
   | true =>

--- a/runtime/functor-runtime-common/Cargo.toml
+++ b/runtime/functor-runtime-common/Cargo.toml
@@ -43,10 +43,9 @@ async-trait = "0.1.80"
 # lines). The shell installs the logger; here we only emit through `log::*!`.
 log = "0.4"
 gltf = { version = "1.4.1", features = ["names", "KHR_materials_pbrSpecularGlossiness"] }
-# The host prelude `.funi` interface text: the embedded producer
-# (`functor_lang_game_embedded`) links pushed sources against it, and the drift
-# test keeps the declared Scene.* signatures in sync with the host registry.
-# Zero-dependency by design, so safe on every target (wasm included).
+# The engine's `.fun` implementation modules and host `.funi` interfaces. The
+# embedded producer links pushed sources against the complete bundle, while
+# drift tests keep the interface signatures in sync with the host registry.
 functor-prelude = { path = "../../functor-prelude" }
 
 [target.'cfg(not(any(target_arch = "wasm32")))'.dependencies]

--- a/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
@@ -225,13 +225,13 @@ fn load_source(sources: &[(String, String)]) -> Result<Loaded, String> {
         .iter()
         .map(|(p, s)| (std::path::PathBuf::from(p), s.clone()))
         .collect();
-    // Link the entry with its siblings, injecting the host prelude `.funi`
-    // interfaces so `Scene.*` (etc.) typecheck against real types — the exact
-    // path the other producers run (docs/functor-lang-interfaces.md). Check-time only;
-    // the FunctorHost still provides the actual runtime values.
-    let project =
-        functor_lang::project::load_sources_with_prelude(pairs, &functor_prelude::modules())
-            .map_err(|e| format!("cannot load {}", e.render()))?;
+    // Link the same executable `.fun` modules and host `.funi` interfaces as
+    // the other producers.
+    let project = functor_lang::project::load_sources_with_bundled_modules(
+        pairs,
+        &functor_prelude::bundled_modules(),
+    )
+    .map_err(|e| format!("cannot load {}", e.render()))?;
     let module = project.module;
     let source_map = project.sources;
     // Type diagnostics are advisory in the dev loop: warn, keep going

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -5092,10 +5092,10 @@ Color.rgb(r, g, b)"
              let good = () => Physics.position(Physics.tag(\"ball\"))\n",
         )
         .unwrap();
-        let project = functor_lang::project::load_with_prelude(
+        let project = functor_lang::project::load_with_bundled_modules(
             &dir.join("game.fun"),
             &Default::default(),
-            &functor_prelude::modules(),
+            &functor_prelude::bundled_modules(),
         )
         .unwrap_or_else(|e| panic!("loads: {}", e.render()));
         let diags: Vec<String> = project.check().into_iter().map(|d| d.message).collect();
@@ -5263,6 +5263,44 @@ Anim.clip(\"walk\", tts)"
             failure.error.message.contains("(anim, weight)"),
             "message: {}",
             failure.error.message
+        );
+    }
+
+    #[test]
+    fn bundled_animator_executes_against_anim_host() {
+        let sources = vec![(
+            std::path::PathBuf::from("game.fun"),
+            "let main =\n\
+             Animator.pose(\n\
+               Animator.play(\"run\", 2.0, Animator.start(\"idle\", 0.0)),\n\
+               1.0,\n\
+               2.5)"
+                .to_string(),
+        )];
+        let project = functor_lang::project::load_sources_with_bundled_modules(
+            sources,
+            &functor_prelude::bundled_modules(),
+        )
+        .unwrap_or_else(|error| panic!("bundle loads: {}", error.render()));
+        let diagnostics = project.check();
+        assert!(
+            diagnostics.is_empty(),
+            "Animator should typecheck against Anim: {diagnostics:#?}"
+        );
+        let session = functor_lang::Session::load(&project.module, &mut FunctorHost)
+            .unwrap_or_else(|failure| panic!("session loads: {}", failure.error.message));
+        let value = session.global("main").expect("entry value");
+        let AnimExpr::Blend(entries) = anim_of(&value, "test", Span::new(0, 0)).expect("Anim") else {
+            panic!("mid-transition Animator pose should be a blend");
+        };
+        assert_eq!(entries.len(), 2);
+        assert!(
+            matches!(&entries[0], (AnimExpr::Clip { name, playhead }, weight)
+                if name == "idle" && (*playhead - 2.5).abs() < 1e-6 && (*weight - 0.5).abs() < 1e-6)
+        );
+        assert!(
+            matches!(&entries[1], (AnimExpr::Clip { name, playhead }, weight)
+                if name == "run" && (*playhead - 0.5).abs() < 1e-6 && (*weight - 0.5).abs() < 1e-6)
         );
     }
 

--- a/runtime/functor-runtime-common/tests/prelude_typecheck.rs
+++ b/runtime/functor-runtime-common/tests/prelude_typecheck.rs
@@ -1,20 +1,20 @@
-//! The host prelude (`functor-prelude`) as a check-time overlay (funi 2e):
+//! The engine bundle (`functor-prelude`): reusable `.fun` modules execute,
 //! host calls get real types, and the MVU `(model, effect)` lift still works
 //! now that `Effect` has a concrete type instead of the old `Unknown` seam.
 
 use std::collections::HashMap;
 
-/// Check `src` as a single-file game WITH the host prelude injected.
+/// Check `src` as a single-file game with the complete engine bundle.
 fn check(src: &str) -> Vec<String> {
     let dir =
         std::env::temp_dir().join(format!("functor-prelude-typecheck-{}", src.len()));
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
     std::fs::write(dir.join("game.fun"), src).unwrap();
-    let project = match functor_lang::project::load_with_prelude(
+    let project = match functor_lang::project::load_with_bundled_modules(
         &dir.join("game.fun"),
         &HashMap::new(),
-        &functor_prelude::modules(),
+        &functor_prelude::bundled_modules(),
     ) {
         Ok(project) => project,
         Err(e) => {
@@ -57,6 +57,21 @@ fn host_calls_have_real_types() {
          Frame.create(Camera.lookAt(Vec3.make(0.0, 0.0, 0.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube())",
     );
     assert!(diags.iter().any(|m| m.contains("Frame.t")), "{diags:?}");
+}
+
+/// Engine-owned `.fun` modules participate in the same typecheck as the host
+/// interfaces they build upon.
+#[test]
+fn animator_is_available_without_a_project_sibling() {
+    let diags = check(
+        "let state = Animator.start(\"idle\", 0.0)\n\
+         let next = Animator.play(\"run\", 1.0, state)\n\
+         let pose : Anim.t = Animator.pose(next, 0.5, 1.25)",
+    );
+    assert!(
+        diags.is_empty(),
+        "bundled Animator should check clean: {diags:?}"
+    );
 }
 
 // --- typed assets (Track B.1) ---

--- a/runtime/functor-runtime-desktop/Cargo.toml
+++ b/runtime/functor-runtime-desktop/Cargo.toml
@@ -17,8 +17,8 @@ required-features = []
 [dependencies]
 # The Functor Lang language, for the --functor-lang producer (docs/functor-lang.md Track C2).
 functor-lang = { path = "../../functor-lang" }
-# The host prelude `.funi` interfaces — injected at load time so a game's
-# `Scene.*` calls typecheck against real types (docs/functor-lang-interfaces.md).
+# Engine-bundled `.fun` modules and host `.funi` interfaces, shared with the
+# CLI, other runtimes, and editor tooling.
 functor-prelude = { path = "../../functor-prelude" }
 functor_runtime_common = { path = "./../functor-runtime-common" }
 glow = "0.17"

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -262,12 +262,13 @@ fn load_project(path: &str, entry_src: Option<String>) -> Result<Loaded, String>
         Some(src) => std::collections::HashMap::from([(entry.to_path_buf(), src)]),
         None => std::collections::HashMap::new(),
     };
-    // Inject the host prelude `.funi` interfaces so `Scene.*` (etc.) typecheck
-    // against real types (docs/functor-lang-interfaces.md). Check-time only — the FunctorHost still
-    // provides the actual runtime values.
-    let project =
-        functor_lang::project::load_with_prelude(entry, &overrides, &functor_prelude::modules())
-            .map_err(|e| format!("cannot load {}", e.render()))?;
+    // Link the engine's executable `.fun` modules and host `.funi` interfaces.
+    let project = functor_lang::project::load_with_bundled_modules(
+        entry,
+        &overrides,
+        &functor_prelude::bundled_modules(),
+    )
+    .map_err(|e| format!("cannot load {}", e.render()))?;
     finish_load(path, project)
 }
 
@@ -283,9 +284,11 @@ fn load_sources(files: &[(String, String)]) -> Result<Loaded, String> {
         .iter()
         .map(|(path, source)| (PathBuf::from(path), source.clone()))
         .collect();
-    let project =
-        functor_lang::project::load_sources_with_prelude(sources, &functor_prelude::modules())
-            .map_err(|e| format!("cannot load {}", e.render()))?;
+    let project = functor_lang::project::load_sources_with_bundled_modules(
+        sources,
+        &functor_prelude::bundled_modules(),
+    )
+    .map_err(|e| format!("cannot load {}", e.render()))?;
     finish_load(path, project)
 }
 

--- a/scripts/next-version.mjs
+++ b/scripts/next-version.mjs
@@ -10,9 +10,10 @@
 //   - a breaking commit since the last release tag
 //     (`type!:` subject or a "BREAKING CHANGE:" body)   → minor bump
 //   - any change to the language/prelude surface
-//     (functor-prelude/prelude/*.funi) since the last
-//     tag, even if no commit message says so — the
-//     signatures are the honest record of that surface  → minor bump
+//     (functor-prelude/prelude/*.funi or
+//     functor-prelude/stdlib/*.fun) since the last tag,
+//     even if no commit message says so — these bundled
+//     modules are the honest record of that surface       → minor bump
 //   - anything else                                     → patch bump
 // From 1.0.0 on, the same signals map to major (breaking) and minor
 // (feat / surface change).
@@ -47,7 +48,14 @@ const breaking =
   subjects.some((s) => /^[a-z]+(\(.+\))?!:/.test(s)) ||
   /BREAKING[ -]CHANGE:/.test(git("log", `${last}..HEAD`, "--format=%b"));
 const feature = subjects.some((s) => /^feat(\(.+\))?:/.test(s));
-const surface = git("diff", "--name-only", `${last}..HEAD`, "--", "functor-prelude/prelude/*.funi")
+const surface = git(
+  "diff",
+  "--name-only",
+  `${last}..HEAD`,
+  "--",
+  "functor-prelude/prelude/*.funi",
+  "functor-prelude/stdlib/*.fun",
+)
   .split("\n")
   .filter(Boolean);
 

--- a/tools/functor-lang-lsp/src/expects.rs
+++ b/tools/functor-lang-lsp/src/expects.rs
@@ -121,24 +121,33 @@ pub fn evaluate_rows(
     budget: u64,
     path_to_uri: impl Fn(&std::path::Path) -> String,
 ) -> Option<(Vec<Row>, Vec<String>)> {
-    let prelude = functor_prelude::modules();
+    let bundled = functor_prelude::bundled_modules();
     let project = match entry {
-        Some(entry) => functor_lang::project::load_with_prelude(&entry, &overrides, &prelude)
-            .ok()
-            // Mirror `load_project`'s membership rule: a nearest functor.json
-            // whose entry project does NOT contain the requesting file must
-            // fall back to the single-file view, or the worker would paint
-            // (and authoritatively clear!) files of an unrelated project.
-            .filter(|project| {
-                single
-                    .as_ref()
-                    .is_none_or(|(path, _)| project.sources.file_by_path(path).is_some())
-            }),
+        Some(entry) => functor_lang::project::load_with_bundled_modules(
+            &entry,
+            &overrides,
+            &bundled,
+        )
+        .ok()
+        // Mirror `load_project`'s membership rule: a nearest functor.json
+        // whose entry project does NOT contain the requesting file must
+        // fall back to the single-file view, or the worker would paint
+        // (and authoritatively clear!) files of an unrelated project.
+        .filter(|project| {
+            single
+                .as_ref()
+                .is_none_or(|(path, _)| project.sources.file_by_path(path).is_some())
+        }),
         None => None,
     }
     .or_else(|| {
         let (path, text) = single?;
-        functor_lang::project::load_single_file(&path, &text, &prelude).ok()
+        functor_lang::project::load_single_file_with_bundled_modules(
+            &path,
+            &text,
+            &bundled,
+        )
+        .ok()
     })?;
     let row = |span: functor_lang::Span, state: &'static str, detail: Option<String>| {
         let file = project.sources.file_at(span.start);

--- a/tools/functor-lang-lsp/src/main.rs
+++ b/tools/functor-lang-lsp/src/main.rs
@@ -633,12 +633,18 @@ fn publish_diagnostics(writer: &mut impl Write, uri: &str, text: &str) {
 /// leak in). `None` on a non-`file:` URI or a load failure.
 fn load_project(uri: &str, documents: &HashMap<String, String>) -> Option<functor_lang::project::Project> {
     let path = uri_to_path(uri)?;
-    // The engine prelude (`Scene.*`, `Camera.*`, …) as a check-time overlay, so
-    // the editor shows real host types (`Scene.cube() : Scene.t`) instead of
-    // `Unknown`. This is what makes the LSP host-aware; the runtime injects the
-    // same set (funi 2e).
-    let prelude = functor_prelude::modules();
-    let single_file = || functor_lang::project::load_single_file(&path, documents.get(uri)?, &prelude).ok();
+    // The complete engine bundle: executable modules such as `Animator` plus
+    // `.funi` interfaces that give host calls their real types. The runtimes
+    // inject the same set.
+    let bundled = functor_prelude::bundled_modules();
+    let single_file = || {
+        functor_lang::project::load_single_file_with_bundled_modules(
+            &path,
+            documents.get(uri)?,
+            &bundled,
+        )
+        .ok()
+    };
     match discover_entry(&path) {
         Some(entry) => {
             let overrides: HashMap<PathBuf, String> = documents
@@ -649,7 +655,11 @@ fn load_project(uri: &str, documents: &HashMap<String, String>) -> Option<functo
             // file. A nearest `functor.json` whose entry lives in another dir,
             // or a broken sibling that fails the load, must not strip the open
             // buffer of all features — fall back to a single-file view.
-            match functor_lang::project::load_with_prelude(&entry, &overrides, &prelude) {
+            match functor_lang::project::load_with_bundled_modules(
+                &entry,
+                &overrides,
+                &bundled,
+            ) {
                 Ok(project) if project.sources.file_by_path(&path).is_some() => Some(project),
                 _ => single_file(),
             }
@@ -1135,7 +1145,7 @@ fn localize(project: &functor_lang::project::Project, span: functor_lang::Span) 
     Some((path_to_uri(&path), local_range(file, span)))
 }
 
-/// The embedded prelude `.funi` interfaces written out as real files, so the
+/// Embedded synthetic modules written out as real files, so the
 /// editor can OPEN them (go-to-definition targets, browsable docs). Written
 /// once per content hash — a new prelude version gets a fresh directory, and
 /// an unchanged one reuses it — and marked read-only best-effort (they are
@@ -1153,9 +1163,9 @@ fn materialize_synthetic(file: &functor_lang::project::SourceFile) -> Option<std
     let dir = DIR
         .get_or_init(|| {
             let mut hasher = DefaultHasher::new();
-            for (name, src) in &functor_prelude::modules() {
-                name.hash(&mut hasher);
-                src.hash(&mut hasher);
+            for module in &functor_prelude::bundled_modules() {
+                module.name().hash(&mut hasher);
+                module.source().hash(&mut hasher);
             }
             let dir =
                 std::env::temp_dir().join(format!("functor-prelude-{:016x}", hasher.finish()));

--- a/tools/functor-lang-lsp/tests/completion.rs
+++ b/tools/functor-lang-lsp/tests/completion.rs
@@ -1,5 +1,5 @@
 //! B-layer completion tests: drive `functor_lang::complete::complete` directly
-//! against the **real** engine prelude (`functor_prelude::modules()`) — no
+//! against the **real** engine bundle (`functor_prelude::bundled_modules()`) — no
 //! server spawn, no framed stdio. The A-layer unit tests in `complete.rs` use
 //! inline throwaway preludes for exact-label assertions; here we pin the real
 //! `scene.funi` surface so drift in the shipped prelude is caught.
@@ -7,7 +7,7 @@
 use std::path::PathBuf;
 
 use functor_lang::complete::{complete, CompletionKind};
-use functor_lang::project::{load_sources_with_prelude, Project};
+use functor_lang::project::{load_sources_with_bundled_modules, Project};
 
 /// A minimal, valid single-file project — the last-good parse the broken live
 /// buffers complete against. The real prelude gives it `Scene.*`.
@@ -15,8 +15,8 @@ const STUB: &str = "let main = () => 1.0";
 
 fn project() -> Project {
     let sources = vec![(PathBuf::from("game.fun"), STUB.to_string())];
-    let prelude = functor_prelude::modules();
-    load_sources_with_prelude(sources, &prelude)
+    let bundled = functor_prelude::bundled_modules();
+    load_sources_with_bundled_modules(sources, &bundled)
         .unwrap_or_else(|e| panic!("project loads: {}", e.render()))
 }
 
@@ -60,4 +60,24 @@ fn real_prelude_partial_member_filters() {
     let live = "let s = Scene.cu";
     let items = complete(&project, "Game", live, live.len());
     assert_eq!(labels(&items), ["cube"]);
+}
+
+#[test]
+fn bundled_animator_member_completion() {
+    let project = project();
+    let live = "let pose = Animator.";
+    let items = complete(&project, "Game", live, live.len());
+    let names = labels(&items);
+    for member in ["start", "play", "pose"] {
+        assert!(
+            names.contains(&member.to_string()),
+            "missing {member} in {names:?}"
+        );
+    }
+    assert!(
+        !names.contains(&"smoothstep".to_string()),
+        "implementation helper leaked into the public API: {names:?}"
+    );
+    let pose = find(&items, "pose");
+    assert_eq!(pose.kind, CompletionKind::Function);
 }

--- a/tools/functor-lang-wasm/src/lib.rs
+++ b/tools/functor-lang-wasm/src/lib.rs
@@ -398,10 +398,9 @@ fn single(src: &str) -> Vec<(PathBuf, String)> {
     vec![(PathBuf::from(USER_FILE), src.to_string())]
 }
 
-/// Load a file set as a project with the host prelude injected (so `Scene.*` /
-/// `Camera.*` / … typecheck), mirroring the LSP.
+/// Load a file set with the complete engine bundle, mirroring the LSP.
 fn load_sources(sources: Vec<(PathBuf, String)>) -> Result<Project, project::ProjectError> {
-    project::load_sources_with_prelude(sources, &functor_prelude::modules())
+    project::load_sources_with_bundled_modules(sources, &functor_prelude::bundled_modules())
 }
 
 /// Parse the `*_project` file-set payload: a JSON array of


### PR DESCRIPTION
## Summary

- move the pure Functor Lang `Animator` crossfade implementation from the crossfade example into the engine-owned bundle
- load the same complete bundle in the CLI, native and embedded runtimes, LSP, and browser analysis tooling
- expose only `Animator.start`, `Animator.play`, and `Animator.pose`, with source navigation through `<stdlib>/Animator.fun`
- update the crossfade example, language documentation, skill reference, and release surface detection

Closes #307.

## Compatibility

`Animator` is now a reserved bundled namespace. Projects that copied the earlier `animator.fun` example module should remove that sibling to use the bundled API, or rename it if they maintain a customized implementation. The collision diagnostic and documentation both provide this migration path.

## Verification

- `wasm-pack build runtime/functor-runtime-web --target=web`
- `cargo test -p functor-lang`
- `cargo test -p functor_runtime_common`
- `cargo test -p functor-lang-lsp`
- `cargo test -p functor-lang-wasm`
- `cargo test -p functor-cli every_shipped_example_typechecks`
- focused bundle execution, completion-surface, and collision-diagnostic tests after review fixes
- `node --check scripts/next-version.mjs`
- `node scripts/next-version.mjs` recognizes `functor-prelude/stdlib/animator.fun` as a language-surface change and selects `0.2.0`

## Review findings disposition

- local `animator.fun` collision: intentional namespace reservation; improved the teaching diagnostic, documented migration, and ensured the change receives a pre-1.0 minor release bump
- bundled `.fun` release classification: fixed by including `functor-prelude/stdlib/*.fun` in the surface pathspec
- accidental `Animator.smoothstep` export: fixed by making the helper local to `pose`; completion coverage pins the intended three-member API
- local semantic-review cache: removed from the worktree and added to `.gitignore`
- final clean-scope adversarial review found no additional correctness or simplicity issues

## Visuals

Not applicable: this changes module distribution and tooling parity without altering rendered output.