### PR TITLE
feat(vr): synchronize project assets to Quest

### DIFF
--- a/cli/src/commands/functor_lang_project.rs
+++ b/cli/src/commands/functor_lang_project.rs
@@ -439,6 +439,7 @@ with --debug-port (and --debug-bind 0.0.0.0 if remote)?"
     /// headset's runtime log into this terminal.
     async fn run_vr(&self, working_directory: &str) -> Result<(), Error> {
         let entry_path = self.entry_path(working_directory)?;
+        let project_root = Path::new(working_directory);
         let serial = adb_device().await?;
         adb_require_runtime(&serial).await?;
         // `am start` on the running singleTask activity is a no-op resume —
@@ -449,22 +450,54 @@ with --debug-port (and --debug-bind 0.0.0.0 if remote)?"
         spawn_logcat(&serial);
         let addr = format!("127.0.0.1:{VR_PORT}");
 
-        // The initial push, with retries: a cold app start needs a moment
-        // to bind its endpoint. (The typecheck gate already ran — `run`
-        // builds before dispatching, same as native/wasm.)
+        // Wait for the cold app to bind its endpoint, clearing any previous
+        // project's upload manifest in the same round trip. Assets land
+        // BEFORE the new game starts, so its first Sub.assets snapshot cannot
+        // observe transient "missing on Android" failures.
+        let mut ready = false;
+        for _ in 0..20 {
+            match post_asset_manifest(&addr, &[]) {
+                Ok((200, _)) => {
+                    ready = true;
+                    break;
+                }
+                Ok((status, body)) => {
+                    return Err(Error::other(format!(
+                        "asset sync rejected ({status}): {body}"
+                    )))
+                }
+                Err(_) => tokio::time::sleep(std::time::Duration::from_millis(500)).await,
+            }
+        }
+        if !ready {
+            return Err(Error::other(format!(
+                "cannot reach the headset's debug endpoint (http://{addr} via adb forward) — \
+is the functor VR runtime running? (`adb logcat -s functor` for its startup log)"
+            )));
+        }
+
+        let mut attempted_assets = project_asset_files(project_root)?;
+        let report = sync_project_assets(&addr, &attempted_assets, None)?;
+        let mut observed_assets = attempted_assets.clone();
+        emit(Event::Info {
+            message: format!(
+                "synced {} project asset(s) ({:.1} MB) to the headset",
+                report.files,
+                report.bytes as f64 / (1024.0 * 1024.0)
+            ),
+        });
+
+        // Load only after every initial asset is resident. Keep retries for a
+        // cable reconnect between the readiness probe and this request.
         let files = read_project_json(&entry_path)?;
         let mut attempted = None;
         for _ in 0..20 {
-            match post_reload_project(&addr, &files) {
+            match post_load_project(&addr, &files) {
                 Ok((200, body)) => {
                     emit(Event::Info { message: body });
                     attempted = Some(files.clone());
                     break;
                 }
-                // The endpoint answered and said no (400/413) — the project
-                // or protocol is the problem, not the transport. (A 503
-                // can't realistically arrive: the server's 30s reply
-                // timeout is far behind our 5s client read timeout.)
                 Ok((status, body)) => {
                     return Err(Error::other(format!("push rejected ({status}): {body}")))
                 }
@@ -479,7 +512,7 @@ is the functor VR runtime running? (`adb logcat -s functor` for its startup log)
         })?;
         emit(Event::Info {
             message: format!(
-                "watching {} + siblings — edit and save to hot-reload on the headset \
+                "watching {} + siblings + project assets — edit and save to hot-reload on the headset \
 (Ctrl-C to stop)",
                 self.entry
             ),
@@ -495,17 +528,54 @@ is the functor VR runtime running? (`adb logcat -s functor` for its startup log)
             let Ok(current) = read_project_json(&entry_path) else {
                 continue;
             };
-            if current == attempted {
+            let Ok(current_assets) = project_asset_files(project_root) else {
+                continue;
+            };
+            let assets_changed = current_assets != observed_assets;
+            if current == attempted && !assets_changed {
                 continue;
             }
             // The same check gate `run native` uses — structured file:line
             // diagnostics beat the device's rendered 400 body, and a broken
-            // edit never leaves the machine.
+            // edit never mutates either source OR assets on the headset.
             if self.build(working_directory, false).is_err() {
                 emit(Event::Warning {
                     message: "check failed — the headset keeps the previous program".to_string(),
                 });
                 attempted = current;
+                observed_assets = current_assets;
+                continue;
+            }
+            // An asset add/rename can regenerate assets.fun during `build`.
+            // Sync and push the exact post-build snapshots, in that order.
+            let current = read_project_json(&entry_path)?;
+            let current_assets = project_asset_files(project_root)?;
+            if current_assets != attempted_assets {
+                match sync_project_assets(&addr, &current_assets, Some(&attempted_assets)) {
+                    Ok(report) => {
+                        emit(Event::Info {
+                            message: format!(
+                                "synced {} changed asset(s) ({:.1} MB) to the headset",
+                                report.files,
+                                report.bytes as f64 / (1024.0 * 1024.0)
+                            ),
+                        });
+                        attempted_assets = current_assets.clone();
+                        observed_assets = current_assets;
+                    }
+                    // Leave the last synchronized inventory in place so the
+                    // same bytes retry after a cable reconnect/runtime restart.
+                    Err(e) => {
+                        emit(Event::Warning {
+                            message: format!("asset sync failed ({e}); retrying…"),
+                        });
+                        continue;
+                    }
+                }
+            } else {
+                observed_assets = current_assets;
+            }
+            if current == attempted {
                 continue;
             }
             match post_reload_project(&addr, &current) {
@@ -822,6 +892,158 @@ fn spawn_logcat(serial: &str) {
     });
 }
 
+/// One synchronizable project asset and the cheap metadata fingerprint used by
+/// the 300ms watch loop. Bytes are read only for the initial push or when this
+/// fingerprint changes, so large models are not re-read continuously.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ProjectAssetFile {
+    locator: String,
+    disk_path: PathBuf,
+    len: u64,
+    modified_ns: u128,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct AssetSyncReport {
+    files: usize,
+    bytes: u64,
+}
+
+/// Recursively collect self-contained GLB models, textures, and audio files.
+/// Hidden directories and the generated `dist/` tree never ship.
+fn project_asset_files(root: &Path) -> Result<Vec<ProjectAssetFile>, Error> {
+    fn visit(
+        root: &Path,
+        directory: &Path,
+        is_root: bool,
+        out: &mut Vec<ProjectAssetFile>,
+    ) -> Result<(), Error> {
+        for entry in std::fs::read_dir(directory)? {
+            let entry = entry?;
+            let name = entry.file_name();
+            let name = name
+                .to_str()
+                .ok_or_else(|| Error::other(format!("non-UTF8 file name: {:?}", name)))?;
+            if name.starts_with('.') || (is_root && name == "dist") {
+                continue;
+            }
+            let path = entry.path();
+            let file_type = entry.file_type()?;
+            if file_type.is_dir() {
+                visit(root, &path, false, out)?;
+                continue;
+            }
+            // Follow symlinked files (matching `build wasm`), but never recurse
+            // through symlinked directories.
+            let metadata = if file_type.is_symlink() {
+                match std::fs::metadata(&path) {
+                    Ok(metadata) if metadata.is_file() => metadata,
+                    _ => continue,
+                }
+            } else if file_type.is_file() {
+                entry.metadata()?
+            } else {
+                continue;
+            };
+            if !functor_runtime_common::asset::is_live_project_asset_file(&path) {
+                continue;
+            }
+            let relative = path
+                .strip_prefix(root)
+                .map_err(|_| Error::other(format!("asset escaped project: {}", path.display())))?;
+            let locator = relative
+                .components()
+                .map(|component| {
+                    component.as_os_str().to_str().ok_or_else(|| {
+                        Error::other(format!("non-UTF8 asset path: {}", relative.display()))
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?
+                .join("/");
+            functor_runtime_common::debug_protocol::validate_project_asset_path(&locator)
+                .map_err(Error::other)?;
+            let modified_ns = metadata
+                .modified()
+                .ok()
+                .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+                .map_or(0, |duration| duration.as_nanos());
+            out.push(ProjectAssetFile {
+                locator,
+                disk_path: path,
+                len: metadata.len(),
+                modified_ns,
+            });
+        }
+        Ok(())
+    }
+
+    let mut files = Vec::new();
+    visit(root, root, true, &mut files)?;
+    files.sort_by(|a, b| a.locator.cmp(&b.locator));
+    Ok(files)
+}
+
+/// Push added/changed files individually, then finalize with the complete path
+/// manifest so assets deleted on the host disappear from the runtime cache.
+fn sync_project_assets(
+    addr: &str,
+    current: &[ProjectAssetFile],
+    previous: Option<&[ProjectAssetFile]>,
+) -> Result<AssetSyncReport, Error> {
+    let mut report = AssetSyncReport::default();
+    for asset in current {
+        let unchanged = previous.is_some_and(|files| {
+            files.iter().any(|old| {
+                old.locator == asset.locator
+                    && old.len == asset.len
+                    && old.modified_ns == asset.modified_ns
+            })
+        });
+        if unchanged {
+            continue;
+        }
+        let bytes = std::fs::read(&asset.disk_path)?;
+        let body =
+            functor_runtime_common::debug_protocol::encode_project_asset(&asset.locator, &bytes)
+                .map_err(Error::other)?;
+        let (status, response) = http_post_bytes(
+            addr,
+            "/reload-asset",
+            "application/octet-stream",
+            &body,
+            std::time::Duration::from_secs(30),
+        )?;
+        if status != 200 {
+            return Err(Error::other(format!(
+                "asset {} rejected ({status}): {response}",
+                asset.locator
+            )));
+        }
+        report.files += 1;
+        report.bytes += bytes.len() as u64;
+    }
+
+    let paths: Vec<&str> = current.iter().map(|asset| asset.locator.as_str()).collect();
+    let (status, response) = post_asset_manifest(addr, &paths)?;
+    if status != 200 {
+        return Err(Error::other(format!(
+            "asset manifest rejected ({status}): {response}"
+        )));
+    }
+    Ok(report)
+}
+
+fn post_asset_manifest(addr: &str, paths: &[&str]) -> Result<(u16, String), Error> {
+    let manifest = serde_json::to_vec(paths).map_err(Error::other)?;
+    http_post_bytes(
+        addr,
+        "/sync-assets",
+        "application/json",
+        &manifest,
+        std::time::Duration::from_secs(5),
+    )
+}
+
 /// The project's `.fun`/`.funi` files as the `/reload-project` wire body — a
 /// JSON array of `[file name, source]` pairs, entry FIRST (`file = module`,
 /// so names are enough). Serialized once: the watch loop's change-compare
@@ -845,6 +1067,12 @@ fn post_reload_project(addr: &str, files_json: &str) -> Result<(u16, String), Er
     http_post(addr, "/reload-project", "application/json", files_json)
 }
 
+/// Load the first pushed project as a new game, taking its model from `init`.
+/// Later watch-loop edits use `/reload-project` and preserve that model.
+fn post_load_project(addr: &str, files_json: &str) -> Result<(u16, String), Error> {
+    http_post(addr, "/load-project", "application/json", files_json)
+}
+
 /// Minimal HTTP POST over std::net — one dependency-free request to the
 /// runner's shared debug HTTP server. Returns (status, body). `Connection: close`
 /// keeps the read side trivial (read to EOF, split headers off).
@@ -858,11 +1086,26 @@ fn http_post(
     content_type: &str,
     body: &str,
 ) -> Result<(u16, String), Error> {
+    http_post_bytes(
+        addr,
+        path,
+        content_type,
+        body.as_bytes(),
+        std::time::Duration::from_secs(5),
+    )
+}
+
+fn http_post_bytes(
+    addr: &str,
+    path: &str,
+    content_type: &str,
+    body: &[u8],
+    timeout: std::time::Duration,
+) -> Result<(u16, String), Error> {
     use std::io::{Read, Write};
     use std::net::ToSocketAddrs;
-    let timeout = std::time::Duration::from_secs(5);
-    // connect_timeout, not connect: a blackholed host must fail in 5s, not
-    // the OS's ~75s TCP give-up.
+    // connect_timeout, not connect: a blackholed host must fail on our
+    // request budget, not the OS's ~75s TCP give-up.
     let sockaddr = addr
         .to_socket_addrs()?
         .next()
@@ -876,9 +1119,10 @@ fn http_post(
 Content-Length: {}\r\nConnection: close\r\n\r\n",
         body.len()
     )?;
-    stream.write_all(body.as_bytes())?;
-    let mut response = String::new();
-    stream.read_to_string(&mut response)?;
+    stream.write_all(body)?;
+    let mut response = Vec::new();
+    stream.read_to_end(&mut response)?;
+    let response = String::from_utf8_lossy(&response);
     let status = response
         .lines()
         .next()
@@ -912,7 +1156,7 @@ fn entry_escapes_project(entry: &str) -> bool {
 mod tests {
     #[cfg(feature = "web")]
     use super::entry_escapes_project;
-    use super::{nth_line, FunctorLangConfig, FunctorLangEntries};
+    use super::{nth_line, project_asset_files, FunctorLangConfig, FunctorLangEntries};
 
     fn single(entry: &str) -> FunctorLangConfig {
         FunctorLangConfig {
@@ -994,6 +1238,35 @@ mod tests {
         };
         let err = config.select(None).unwrap_err();
         assert!(err.to_string().contains("must be a path"), "{err}");
+    }
+
+    #[test]
+    fn vr_asset_scan_is_recursive_and_skips_hidden_and_dist_files() {
+        let root = std::env::temp_dir().join(format!("functor-vr-assets-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        for directory in ["models", "textures/walls", ".cache", "dist/web"] {
+            std::fs::create_dir_all(root.join(directory)).unwrap();
+        }
+        for (path, bytes) in [
+            ("models/ship.glb", b"model".as_slice()),
+            ("models/ship.bin", b"external buffer"),
+            ("models/ship.gltf", b"external model"),
+            ("textures/walls/grid.PNG", b"texture"),
+            ("theme.ogg", b"audio"),
+            ("notes.txt", b"not an asset"),
+            (".cache/hidden.png", b"hidden"),
+            ("dist/web/stale.glb", b"generated"),
+        ] {
+            std::fs::write(root.join(path), bytes).unwrap();
+        }
+
+        let files = project_asset_files(&root).unwrap();
+        let locators: Vec<&str> = files.iter().map(|asset| asset.locator.as_str()).collect();
+        assert_eq!(
+            locators,
+            vec!["models/ship.glb", "textures/walls/grid.PNG", "theme.ogg",]
+        );
+        let _ = std::fs::remove_dir_all(root);
     }
 
     /// Every shipped example typechecks against the engine prelude — the

--- a/cli/src/util/wasm_export.rs
+++ b/cli/src/util/wasm_export.rs
@@ -42,12 +42,6 @@ const RESERVED_ROOT: &[&str] = &[
     "timeline-model.js",
 ];
 
-/// Extensions the runtime fetches at runtime: models (plus the external
-/// buffers/images a non-embedded `.gltf` references), audio, textures.
-const ASSET_EXTENSIONS: &[&str] = &[
-    "glb", "gltf", "bin", "wav", "ogg", "mp3", "png", "jpg", "jpeg", "hdr",
-];
-
 #[derive(Debug)]
 pub struct WasmExport {
     /// The bundle directory: `<project>/dist/web`.
@@ -225,10 +219,7 @@ fn missing_asset_references(root: &Path, entry: &str) -> Vec<String> {
 fn is_asset_path(s: &str) -> bool {
     // A URL ("https://cdn/x.png") is fetched remotely, not from the bundle.
     !s.contains("://")
-        && Path::new(s)
-            .extension()
-            .and_then(|e| e.to_str())
-            .is_some_and(|ext| ASSET_EXTENSIONS.iter().any(|a| ext.eq_ignore_ascii_case(a)))
+        && functor_runtime_common::asset::is_project_asset_file(Path::new(s))
 }
 
 /// Will the path `s` be present in the exported bundle at the URL the

--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -83,6 +83,9 @@ screenshot run has no reason to grab your mouse.
 | `POST /time` | control the frame clock (see below) |
 | `POST /reload-source` | swap game logic from the request body (see below) |
 | `POST /reload-project` | swap all sibling modules from a JSON array of `[path, source]` pairs, entry first |
+| `POST /load-project` | start a new sibling-module project from the same body, initializing its model from `init` |
+| `POST /reload-asset` | upload one project-relative texture/model/audio asset as a binary path+bytes envelope |
+| `POST /sync-assets` | finish a sync from a JSON array of current asset paths; uploaded paths absent from the manifest are removed |
 | `POST /rewind` | restore recorded model + physics to `{"frame":42}` (pin the clock first) |
 
 ### `POST /input`
@@ -133,8 +136,36 @@ functor -d mygame push <host>:<port> --watch  # re-push on every save
 
 (`curl --data-binary @game.fun http://<host>:<port>/reload-source` works too.)
 
-`functor run vr` uses `/reload-project`, so sibling `.fun`/`.funi` modules have
-the same file-as-module behavior on Quest as on desktop.
+`functor run vr` uses `/load-project` for the initial push, so the headset
+starts with the project's `init` model. Its watch loop then uses
+`/reload-project`, preserving that live model across edits. Both routes carry
+all sibling `.fun`/`.funi` modules, with the same file-as-module behavior as
+desktop.
+
+### Project asset sync
+
+Source and assets remain separate operations. `POST /reload-asset` carries one
+file: a big-endian four-byte UTF-8 path length, that many path bytes, then the
+raw asset bytes. Paths are forward-slash, project-relative locators with no
+`.`/`..` segments. One file may be up to 256 MB. After uploading added or
+changed files, `POST /sync-assets` receives the complete current path list and
+evicts uploads deleted on the host.
+
+`functor run vr` performs this automatically for self-contained `.glb` models,
+textures, and sounds. (`.gltf` models with external URI dependencies remain a
+renderer limitation and are not live-synchronized.) It scans recursively,
+excluding hidden paths and the generated root `dist/` tree; the watch loop
+fingerprints metadata and reads large bytes only when an asset changes.
+Replacing an upload evicts cached model/texture/skybox decodes so the next
+frame uses the new bytes. The TypeScript SDK exposes the same flow as
+`client.reloadAsset(path, bytes)` and `client.reloadAssets(files)`. It also
+distinguishes `client.loadProject(files)` (new `init` model) from
+`client.reloadProject(files)` (model preserved).
+
+Sound bytes participate in transport/cache synchronization, but the Quest
+shell does not yet have an Android audio-output host. They therefore do not
+drive `Sub.assets` or play yet; audio output remains a separate device-runtime
+milestone.
 
 ## Two workflows
 

--- a/docs/vr.md
+++ b/docs/vr.md
@@ -23,7 +23,7 @@ games deploy over the network.
 | [#437](https://github.com/tommy-xr/functor/pull/437) | Exact asymmetric OpenXR projections, fixing binocular double vision | merged; Quest 3 verified |
 | [#438](https://github.com/tommy-xr/functor/pull/438) | Shared desktop/Quest debug protocol, whole-project REPL, raw stereo capture, TypeScript SDK parity, device benchmark | merged; Quest 3 verified |
 | [#453](https://github.com/tommy-xr/functor/pull/453) | Compose live OpenXR head/eye tracking onto the authored `Frame.camera` rig | merged; Quest 3 verified |
-| current change | Push project `.glb` models, textures, and sounds through the shared debug protocol; initialize the first pushed project from `init` | Quest 3 verified with synthwave textures + animated Xbot |
+| [#460](https://github.com/tommy-xr/functor/pull/460) | Push project `.glb` models, textures, and sounds through the shared debug protocol; initialize the first pushed project from `init` | draft; Quest 3 verified with synthwave textures + animated Xbot |
 
 ## Working today on the Xreal One
 

--- a/docs/vr.md
+++ b/docs/vr.md
@@ -22,7 +22,8 @@ games deploy over the network.
 | [#431](https://github.com/tommy-xr/functor/pull/431) | `functor run vr`: launch, forward, whole-project push, watch, and log streaming | merged |
 | [#437](https://github.com/tommy-xr/functor/pull/437) | Exact asymmetric OpenXR projections, fixing binocular double vision | merged; Quest 3 verified |
 | [#438](https://github.com/tommy-xr/functor/pull/438) | Shared desktop/Quest debug protocol, whole-project REPL, raw stereo capture, TypeScript SDK parity, device benchmark | merged; Quest 3 verified |
-| [#453](https://github.com/tommy-xr/functor/pull/453) | Compose live OpenXR head/eye tracking onto the authored `Frame.camera` rig | current PR; Quest 3 verified |
+| [#453](https://github.com/tommy-xr/functor/pull/453) | Compose live OpenXR head/eye tracking onto the authored `Frame.camera` rig | merged; Quest 3 verified |
+| current change | Push project `.glb` models, textures, and sounds through the shared debug protocol; initialize the first pushed project from `init` | Quest 3 verified with synthwave textures + animated Xbot |
 
 ## Working today on the Xreal One
 
@@ -69,7 +70,8 @@ full, proven sequence. The short path is:
    `runtime/functor-runtime-oculus/lib/arm64-v8a/` (the crate README has the
    Maven command), then `npm run build:oculus:apk` and `adb install -r …`.
 2. Run `functor -d yourgame run vr`. It uses device-loopback port 8123 through
-   adb, pushes every `.fun`/`.funi`, and re-pushes on save.
+   adb, loads every `.fun`/`.funi` plus project models/textures/sounds, and
+   re-pushes changed source or assets on save.
 3. If Meta Home remains visible, recreate `adb forward`, send `prox_close`, and
    restart NativeActivity with `am start -S`. Wait for `/state`'s frame to
    advance; server readiness alone does not mean XR is rendering.
@@ -85,15 +87,16 @@ torn frames and 3.09 ms mean application time.
 The authored-camera release verification sustained 72 FPS minimum in two
 30-second `primitives` runs (3.31–3.36 ms mean application time). A
 source/geometry-heavy `synthwave` run also held 72 FPS minimum with zero stale
-or torn frames; texture assets were not synchronized, so that run is not a
-final texture-pipeline measurement.
+or torn frames. Project texture/model synchronization is now verified on Quest
+3 with the textured synthwave scene and the animated `Xbot.glb` example; a
+release performance pass over those asset-heavy scenes is still outstanding.
 
 ## After bring-up (in rough order)
 
-- Sync or host project assets so texture/model/audio locators work in the
-  laptop-to-headset loop; whole-project reload currently transfers source only.
 - Controllers + a VR `InputContext` (head/hands) with desktop mouse/keyboard
   emulation, shock2quest-style, so VR games iterate without a headset.
+- Add the Android audio host; sound bytes already synchronize, but Quest
+  currently drains playback commands.
 - Add a browser surface over the isomorphic debug API for edit/push/inspect/
   capture without target-specific SDK calls.
 - Make the release APK reproducible and publishable (release signing, CI

--- a/runtime/functor-runtime-common/src/asset/asset_cache.rs
+++ b/runtime/functor-runtime-common/src/asset/asset_cache.rs
@@ -36,6 +36,9 @@ struct ProgressState {
 pub struct AssetCache {
     bytes_cache: Arc<Mutex<HashMap<String, Vec<u8>>>>,
     progress: Arc<Mutex<ProgressState>>,
+    /// Paths whose bytes came from the debug protocol rather than disk/CDN.
+    /// The final manifest of each sync removes uploads deleted on the host.
+    uploaded_paths: Mutex<HashSet<String>>,
 }
 
 impl AssetCache {
@@ -43,6 +46,7 @@ impl AssetCache {
         AssetCache {
             bytes_cache: Arc::new(Mutex::new(HashMap::new())),
             progress: Arc::new(Mutex::new(ProgressState::default())),
+            uploaded_paths: Mutex::new(HashSet::new()),
         }
     }
 
@@ -66,6 +70,13 @@ impl AssetCache {
         self.bytes_cache.lock().unwrap().keys().cloned().collect()
     }
 
+    /// Clone bytes already resident in the shared cache without starting a
+    /// filesystem/network load. Native audio uses this for remotely uploaded
+    /// sounds; render pipelines use the async handle path below.
+    pub fn cached_bytes(&self, path: &str) -> Option<Vec<u8>> {
+        self.bytes_cache.lock().unwrap().get(path).cloned()
+    }
+
     /// Forget the cached bytes for `path` so the next load re-reads the file
     /// (asset hot-reload). Pipelines cache decoded handles separately — evict
     /// there too (`SceneContext::evict_asset` does both). The path counts as
@@ -75,6 +86,53 @@ impl AssetCache {
         let mut progress = self.progress.lock().unwrap();
         progress.loaded.remove(path);
         progress.failed.remove(path);
+    }
+
+    /// Install bytes uploaded by a remote-development client. Returns whether
+    /// the bytes changed and decoded pipeline handles therefore need eviction.
+    ///
+    /// Uploaded bytes use the exact locator as the cache key, so existing
+    /// renderer code remains unaware of where they came from. A later draw
+    /// decodes from this warm byte cache instead of touching Android's
+    /// filesystem.
+    pub fn replace_uploaded(&self, path: &str, bytes: Vec<u8>) -> bool {
+        let changed = {
+            let mut cache = self.bytes_cache.lock().unwrap();
+            if cache.get(path).is_some_and(|current| *current == bytes) {
+                false
+            } else {
+                cache.insert(path.to_string(), bytes);
+                true
+            }
+        };
+        self.uploaded_paths.lock().unwrap().insert(path.to_string());
+        if changed {
+            let mut progress = self.progress.lock().unwrap();
+            progress.loaded.remove(path);
+            progress.failed.remove(path);
+        }
+        changed
+    }
+
+    /// Complete an uploaded-project sync, forgetting assets that are absent
+    /// from its current manifest. Returns removed locators so shells can evict
+    /// their decoded model/texture/skybox handles too.
+    pub fn retain_uploaded(&self, current: &HashSet<String>) -> Vec<String> {
+        let removed = {
+            let mut uploaded = self.uploaded_paths.lock().unwrap();
+            let mut removed: Vec<String> = uploaded.difference(current).cloned().collect();
+            removed.sort();
+            uploaded.retain(|path| current.contains(path));
+            removed
+        };
+        for path in &removed {
+            self.bytes_cache.lock().unwrap().remove(path);
+            let mut progress = self.progress.lock().unwrap();
+            progress.started.remove(path);
+            progress.loaded.remove(path);
+            progress.failed.remove(path);
+        }
+        removed
     }
 
     /// Whether `path` was started but has not yet settled (loaded or failed)
@@ -299,6 +357,43 @@ mod tests {
         assert_eq!((progress.loaded, progress.total), (1, 2));
 
         let _ = std::fs::remove_file(&good);
+    }
+
+    #[test]
+    fn uploaded_bytes_replace_disk_loading_and_report_real_changes() {
+        let cache = AssetCache::new();
+        assert!(cache.replace_uploaded("textures/a.png", vec![1, 2, 3]));
+        assert!(!cache.replace_uploaded("textures/a.png", vec![1, 2, 3]));
+        assert!(cache.replace_uploaded("textures/a.png", vec![4, 5]));
+        assert_eq!(
+            cache
+                .bytes_cache
+                .lock()
+                .unwrap()
+                .get("textures/a.png")
+                .cloned(),
+            Some(vec![4, 5])
+        );
+    }
+
+    #[test]
+    fn uploaded_manifest_removes_deleted_assets_only() {
+        let cache = AssetCache::new();
+        cache.replace_uploaded("keep.glb", vec![1]);
+        cache.replace_uploaded("delete.png", vec![2]);
+        {
+            let mut progress = cache.progress.lock().unwrap();
+            progress.started.insert("delete.png".to_string());
+            progress.loaded.insert("delete.png".to_string());
+        }
+
+        let current = HashSet::from(["keep.glb".to_string()]);
+        assert_eq!(cache.retain_uploaded(&current), vec!["delete.png"]);
+        let bytes = cache.bytes_cache.lock().unwrap();
+        assert!(bytes.contains_key("keep.glb"));
+        assert!(!bytes.contains_key("delete.png"));
+        drop(bytes);
+        assert_eq!(cache.progress(), AssetProgress::default());
     }
 
     /// `Asset.whilePending` resolution: the first LOADED chain entry stands

--- a/runtime/functor-runtime-common/src/asset/mod.rs
+++ b/runtime/functor-runtime-common/src/asset/mod.rs
@@ -14,3 +14,34 @@ pub use asset_loader::*;
 pub use asset_pipeline::*;
 
 pub use renderable_asset::*;
+
+/// File extensions copied/synchronized with a project because the runtimes
+/// may resolve them dynamically. `bin` covers external glTF buffers.
+pub const PROJECT_ASSET_EXTENSIONS: &[&str] = &[
+    "glb", "gltf", "bin", "wav", "ogg", "mp3", "png", "jpg", "jpeg", "hdr",
+];
+
+/// Whether a filesystem path is a project asset the runtime may load.
+pub fn is_project_asset_file(path: &std::path::Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| {
+            PROJECT_ASSET_EXTENSIONS
+                .iter()
+                .any(|candidate| extension.eq_ignore_ascii_case(candidate))
+        })
+}
+
+/// Whether an asset can be consumed from one independently uploaded blob.
+/// `.gltf` projects may reference sibling buffers/images, but the current
+/// model pipeline only decodes self-contained `.glb`; keep those multi-file
+/// models out of live push until URI resolution is cache-aware.
+pub fn is_live_project_asset_file(path: &std::path::Path) -> bool {
+    is_project_asset_file(path)
+        && !path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| {
+                extension.eq_ignore_ascii_case("gltf") || extension.eq_ignore_ascii_case("bin")
+            })
+}

--- a/runtime/functor-runtime-common/src/debug_http.rs
+++ b/runtime/functor-runtime-common/src/debug_http.rs
@@ -13,8 +13,8 @@ use std::time::Duration;
 use serde::de::DeserializeOwned;
 
 use crate::debug_protocol::{
-    self, CaptureError, DebugRequest, InputCommand, ProjectSources, RewindCommand, RuntimeState,
-    TimeCommand,
+    self, CaptureError, DebugRequest, InputCommand, ProjectAssetPaths, ProjectSources,
+    RewindCommand, RuntimeState, TimeCommand,
 };
 
 const MAX_HEADER_LINE_BYTES: u64 = 8 * 1024;
@@ -82,12 +82,19 @@ fn parse_json<T: DeserializeOwned>(
     reader: &mut BufReader<TcpStream>,
     content_length: Option<usize>,
 ) -> Result<T, String> {
-    let body =
-        read_body(reader, content_length, MAX_COMMAND_BYTES).map_err(|error| match error {
-            BodyError::MissingLength => "missing Content-Length".to_string(),
-            BodyError::TooLarge => "body too large".to_string(),
-            BodyError::Invalid => "bad body".to_string(),
-        })?;
+    parse_json_capped(reader, content_length, MAX_COMMAND_BYTES)
+}
+
+fn parse_json_capped<T: DeserializeOwned>(
+    reader: &mut BufReader<TcpStream>,
+    content_length: Option<usize>,
+    max_bytes: usize,
+) -> Result<T, String> {
+    let body = read_body(reader, content_length, max_bytes).map_err(|error| match error {
+        BodyError::MissingLength => "missing Content-Length".to_string(),
+        BodyError::TooLarge => "body too large".to_string(),
+        BodyError::Invalid => "bad body".to_string(),
+    })?;
     serde_json::from_slice(&body).map_err(|error| error.to_string())
 }
 
@@ -347,7 +354,85 @@ fn handle(mut stream: TcpStream, tx: &mpsc::Sender<DebugRequest>) -> Option<()> 
             }
             respond_result(&mut stream, cors_origin, recv(resp_rx), "rewind")
         }
-        ("POST", "/reload-source") | ("POST", "/reload-project") => {
+        ("POST", "/reload-asset") => {
+            let body = match read_body(
+                &mut reader,
+                content_length,
+                debug_protocol::MAX_ASSET_BYTES + debug_protocol::MAX_ASSET_PATH_BYTES + 4,
+            ) {
+                Ok(body) => body,
+                Err(BodyError::MissingLength | BodyError::TooLarge) => {
+                    respond_text(
+                        &mut stream,
+                        cors_origin,
+                        413,
+                        "Payload Too Large",
+                        "asset too large (or missing Content-Length); limit is 256MB",
+                    );
+                    return Some(());
+                }
+                Err(BodyError::Invalid) => {
+                    respond_text(&mut stream, cors_origin, 400, "Bad Request", "bad body");
+                    return Some(());
+                }
+            };
+            let asset = match debug_protocol::decode_project_asset(body) {
+                Ok(asset) => asset,
+                Err(error) => {
+                    respond_text(
+                        &mut stream,
+                        cors_origin,
+                        400,
+                        "Bad Request",
+                        &format!("bad asset body: {error}"),
+                    );
+                    return Some(());
+                }
+            };
+            let (resp_tx, resp_rx) = mpsc::channel();
+            if tx.send(DebugRequest::ReloadAsset(asset, resp_tx)).is_err() {
+                return runtime_gone(&mut stream, cors_origin);
+            }
+            respond_result(&mut stream, cors_origin, recv(resp_rx), "asset reload")
+        }
+        ("POST", "/sync-assets") => {
+            let paths = match parse_json_capped::<ProjectAssetPaths>(
+                &mut reader,
+                content_length,
+                debug_protocol::MAX_ASSET_MANIFEST_BYTES,
+            ) {
+                Ok(paths) => paths,
+                Err(error) => {
+                    respond_text(
+                        &mut stream,
+                        cors_origin,
+                        400,
+                        "Bad Request",
+                        &format!("body must be a JSON array of asset paths: {error}"),
+                    );
+                    return Some(());
+                }
+            };
+            if let Some(error) = paths
+                .iter()
+                .find_map(|path| debug_protocol::validate_project_asset_path(path).err())
+            {
+                respond_text(
+                    &mut stream,
+                    cors_origin,
+                    400,
+                    "Bad Request",
+                    &format!("bad asset manifest: {error}"),
+                );
+                return Some(());
+            }
+            let (resp_tx, resp_rx) = mpsc::channel();
+            if tx.send(DebugRequest::SyncAssets(paths, resp_tx)).is_err() {
+                return runtime_gone(&mut stream, cors_origin);
+            }
+            respond_result(&mut stream, cors_origin, recv(resp_rx), "asset sync")
+        }
+        ("POST", "/reload-source") | ("POST", "/reload-project") | ("POST", "/load-project") => {
             let body = match read_body(
                 &mut reader,
                 content_length,
@@ -370,7 +455,7 @@ fn handle(mut stream: TcpStream, tx: &mpsc::Sender<DebugRequest>) -> Option<()> 
                 }
             };
             let (resp_tx, resp_rx) = mpsc::channel();
-            let request = if path == "/reload-project" {
+            let request = if path == "/reload-project" || path == "/load-project" {
                 let files = match serde_json::from_slice::<ProjectSources>(&body) {
                     Ok(files) => files,
                     Err(error) => {
@@ -384,7 +469,11 @@ fn handle(mut stream: TcpStream, tx: &mpsc::Sender<DebugRequest>) -> Option<()> 
                         return Some(());
                     }
                 };
-                DebugRequest::ReloadProject(files, resp_tx)
+                if path == "/load-project" {
+                    DebugRequest::LoadProject(files, resp_tx)
+                } else {
+                    DebugRequest::ReloadProject(files, resp_tx)
+                }
             } else {
                 let source = match String::from_utf8(body) {
                     Ok(source) => source,
@@ -601,6 +690,98 @@ mod tests {
         let response = client.join().unwrap();
         assert!(response.starts_with("HTTP/1.1 200 OK\r\n"));
         assert!(response.ends_with("reloaded project"));
+    }
+
+    #[test]
+    fn load_project_is_distinct_from_model_preserving_reload() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let body = r#"[["game.fun","let init = 1"]]"#;
+        let request = format!(
+            "POST /load-project HTTP/1.1\r\nHost: localhost\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        let client = connect(&listener, request);
+        let (tx, rx) = mpsc::channel();
+        let server = std::thread::spawn(move || handle(listener.accept().unwrap().0, &tx));
+
+        match rx.recv().unwrap() {
+            DebugRequest::LoadProject(files, response) => {
+                assert_eq!(files, vec![("game.fun".into(), "let init = 1".into())]);
+                response.send(Ok("loaded project".into())).unwrap();
+            }
+            _ => panic!("expected new project load request"),
+        }
+
+        assert_eq!(server.join().unwrap(), Some(()));
+        let response = client.join().unwrap();
+        assert!(response.starts_with("HTTP/1.1 200 OK\r\n"));
+        assert!(response.ends_with("loaded project"));
+    }
+
+    #[test]
+    fn asset_manifest_accepts_more_than_the_ordinary_command_limit() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let paths: Vec<String> = (0..4_000)
+            .map(|index| format!("textures/{index:04}.png"))
+            .collect();
+        let body = serde_json::to_string(&paths).unwrap();
+        assert!(body.len() > MAX_COMMAND_BYTES);
+        let request = format!(
+            "POST /sync-assets HTTP/1.1\r\nHost: localhost\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        let client = connect(&listener, request);
+        let (tx, rx) = mpsc::channel();
+        let server = std::thread::spawn(move || handle(listener.accept().unwrap().0, &tx));
+
+        match rx.recv().unwrap() {
+            DebugRequest::SyncAssets(actual, response) => {
+                assert_eq!(actual, paths);
+                response.send(Ok("synced assets".into())).unwrap();
+            }
+            _ => panic!("expected asset sync request"),
+        }
+
+        assert_eq!(server.join().unwrap(), Some(()));
+        let response = client.join().unwrap();
+        assert!(response.starts_with("HTTP/1.1 200 OK\r\n"));
+    }
+
+    #[test]
+    fn reload_asset_decodes_binary_and_round_trips_runtime_status() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let body = debug_protocol::encode_project_asset("textures/grid.png", &[0, 1, 255]).unwrap();
+        let mut request = format!(
+            "POST /reload-asset HTTP/1.1\r\nHost: localhost\r\nContent-Length: {}\r\n\r\n",
+            body.len()
+        )
+        .into_bytes();
+        request.extend_from_slice(&body);
+        let address = listener.local_addr().unwrap();
+        let client = std::thread::spawn(move || {
+            let mut stream = TcpStream::connect(address).unwrap();
+            stream.write_all(&request).unwrap();
+            stream.shutdown(Shutdown::Write).unwrap();
+            let mut response = String::new();
+            stream.read_to_string(&mut response).unwrap();
+            response
+        });
+        let (tx, rx) = mpsc::channel();
+        let server = std::thread::spawn(move || handle(listener.accept().unwrap().0, &tx));
+
+        match rx.recv().unwrap() {
+            DebugRequest::ReloadAsset(asset, response) => {
+                assert_eq!(asset.path, "textures/grid.png");
+                assert_eq!(asset.bytes, vec![0, 1, 255]);
+                response.send(Ok("reloaded asset".into())).unwrap();
+            }
+            _ => panic!("expected asset reload request"),
+        }
+
+        assert_eq!(server.join().unwrap(), Some(()));
+        let response = client.join().unwrap();
+        assert!(response.starts_with("HTTP/1.1 200 OK\r\n"));
+        assert!(response.ends_with("reloaded asset"));
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/debug_protocol.rs
+++ b/runtime/functor-runtime-common/src/debug_protocol.rs
@@ -16,10 +16,23 @@ use crate::{ui::UiEventKind, Key};
 pub const DEBUG_PROTOCOL_SERVICE: &str = "functor debug runtime";
 
 /// Version of the routes and JSON wire shapes in this module.
-pub const DEBUG_PROTOCOL_VERSION: u32 = 1;
+pub const DEBUG_PROTOCOL_VERSION: u32 = 2;
 
 /// Maximum accepted body size for either reload operation.
 pub const MAX_RELOAD_BYTES: usize = 4 * 1024 * 1024;
+
+/// Maximum accepted size of one uploaded project asset. Assets transfer one
+/// at a time so a project with several large models never has to exist as one
+/// giant request in either the CLI or the runtime.
+pub const MAX_ASSET_BYTES: usize = 256 * 1024 * 1024;
+
+/// Maximum UTF-8 byte length of an uploaded asset's project-relative path.
+pub const MAX_ASSET_PATH_BYTES: usize = 4 * 1024;
+
+/// Maximum JSON size of a complete uploaded-asset path manifest. This is
+/// intentionally larger than ordinary debug commands: projects can contain
+/// thousands of individually small assets.
+pub const MAX_ASSET_MANIFEST_BYTES: usize = 16 * 1024 * 1024;
 
 /// One endpoint in the canonical debug-runtime surface.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -83,6 +96,21 @@ pub const DEBUG_ROUTES: &[DebugRoute] = &[
         method: "POST",
         path: "/reload-project",
         description: "swap the whole project from a JSON array of [path, source] pairs (entry first), model preserved — 400 with the load error on a broken push",
+    },
+    DebugRoute {
+        method: "POST",
+        path: "/load-project",
+        description: "load a new whole project from a JSON array of [path, source] pairs (entry first), model initialized from init — 400 with the load error on a broken push",
+    },
+    DebugRoute {
+        method: "POST",
+        path: "/reload-asset",
+        description: "upload one project asset as a binary path+bytes envelope and evict its decoded render data",
+    },
+    DebugRoute {
+        method: "POST",
+        path: "/sync-assets",
+        description: "finish an asset sync from a JSON array of current project-relative paths, removing uploads absent from the manifest",
     },
     DebugRoute {
         method: "POST",
@@ -209,6 +237,87 @@ pub enum CaptureError {
 /// A whole-project push: `(path, source)` pairs with the entry first.
 pub type ProjectSources = Vec<(String, String)>;
 
+/// One project-relative asset uploaded by `POST /reload-asset`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProjectAsset {
+    pub path: String,
+    pub bytes: Vec<u8>,
+}
+
+/// The set of uploaded project assets that should remain available.
+pub type ProjectAssetPaths = Vec<String>;
+
+/// Encode one asset for `POST /reload-asset`: a big-endian u32 path length,
+/// UTF-8 project-relative path, then the raw file bytes.
+pub fn encode_project_asset(path: &str, bytes: &[u8]) -> Result<Vec<u8>, String> {
+    validate_project_asset_path(path)?;
+    let path_len = u32::try_from(path.len()).map_err(|_| "asset path is too long".to_string())?;
+    let mut body = Vec::with_capacity(4 + path.len() + bytes.len());
+    body.extend_from_slice(&path_len.to_be_bytes());
+    body.extend_from_slice(path.as_bytes());
+    body.extend_from_slice(bytes);
+    Ok(body)
+}
+
+/// Decode the binary body accepted by `POST /reload-asset`.
+pub fn decode_project_asset(body: Vec<u8>) -> Result<ProjectAsset, String> {
+    if body.len() < 4 {
+        return Err("asset body is missing its path length".to_string());
+    }
+    let path_len = u32::from_be_bytes(body[..4].try_into().unwrap()) as usize;
+    if path_len > MAX_ASSET_PATH_BYTES {
+        return Err(format!(
+            "asset path is too long ({path_len} bytes; limit is {MAX_ASSET_PATH_BYTES})"
+        ));
+    }
+    let path_end = 4usize
+        .checked_add(path_len)
+        .filter(|end| *end <= body.len())
+        .ok_or_else(|| "asset body is shorter than its declared path".to_string())?;
+    let path = std::str::from_utf8(&body[4..path_end])
+        .map_err(|_| "asset path must be UTF-8".to_string())?
+        .to_string();
+    validate_project_asset_path(&path)?;
+    let bytes_len = body.len() - path_end;
+    if bytes_len > MAX_ASSET_BYTES {
+        return Err(format!(
+            "asset is too large ({bytes_len} bytes; limit is {MAX_ASSET_BYTES})"
+        ));
+    }
+    Ok(ProjectAsset {
+        path,
+        bytes: body[path_end..].to_vec(),
+    })
+}
+
+/// Asset locators uploaded from a project must be portable, relative paths.
+/// The bytes remain in memory, but rejecting ambiguous/escaping names keeps
+/// browser, desktop, and Quest lookups identical.
+pub fn validate_project_asset_path(path: &str) -> Result<(), String> {
+    if path.is_empty() {
+        return Err("asset path must not be empty".to_string());
+    }
+    if path.len() > MAX_ASSET_PATH_BYTES {
+        return Err(format!(
+            "asset path is too long ({} bytes; limit is {MAX_ASSET_PATH_BYTES})",
+            path.len()
+        ));
+    }
+    if path.contains('\\') {
+        return Err("asset path must use forward slashes".to_string());
+    }
+    if path.contains('\0') || path.contains("://") || path.starts_with('/') {
+        return Err("asset path must be project-relative".to_string());
+    }
+    if path
+        .split('/')
+        .any(|segment| segment.is_empty() || segment == "." || segment == "..")
+    {
+        return Err("asset path must not contain empty, `.` or `..` segments".to_string());
+    }
+    Ok(())
+}
+
 /// Request delivered from a runtime's transport thread to its frame loop.
 pub enum DebugRequest {
     Capture(Sender<Result<Vec<u8>, CaptureError>>),
@@ -219,6 +328,9 @@ pub enum DebugRequest {
     Time(TimeCommand, Sender<()>),
     ReloadSource(String, Sender<Result<String, String>>),
     ReloadProject(ProjectSources, Sender<Result<String, String>>),
+    LoadProject(ProjectSources, Sender<Result<String, String>>),
+    ReloadAsset(ProjectAsset, Sender<Result<String, String>>),
+    SyncAssets(ProjectAssetPaths, Sender<Result<String, String>>),
     Rewind(u64, Sender<Result<String, String>>),
 }
 
@@ -262,6 +374,37 @@ mod tests {
                 }
             })
         );
+    }
+
+    #[test]
+    fn project_asset_binary_round_trips_nested_paths_and_bytes() {
+        let body = encode_project_asset("models/ship.glb", &[0, 1, 2, 255]).unwrap();
+        assert_eq!(
+            decode_project_asset(body).unwrap(),
+            ProjectAsset {
+                path: "models/ship.glb".into(),
+                bytes: vec![0, 1, 2, 255],
+            }
+        );
+    }
+
+    #[test]
+    fn project_asset_paths_reject_escaping_or_ambiguous_names() {
+        for path in [
+            "",
+            "/ship.glb",
+            "../ship.glb",
+            "models/../ship.glb",
+            "models//ship.glb",
+            "models\\ship.glb",
+            "https://example.com/ship.glb",
+        ] {
+            assert!(
+                validate_project_asset_path(path).is_err(),
+                "should reject {path:?}"
+            );
+        }
+        assert!(validate_project_asset_path("models/ship.glb").is_ok());
     }
 
     #[test]
@@ -309,6 +452,9 @@ mod tests {
             "POST /time",
             "POST /reload-source",
             "POST /reload-project",
+            "POST /load-project",
+            "POST /reload-asset",
+            "POST /sync-assets",
             "POST /rewind",
         ]
         .into_iter()
@@ -332,6 +478,6 @@ mod tests {
         let discovery: Value = serde_json::from_str(&discovery_json()).unwrap();
         assert_eq!(discovery["service"], DEBUG_PROTOCOL_SERVICE);
         assert_eq!(discovery["protocol_version"], DEBUG_PROTOCOL_VERSION);
-        assert_eq!(DEBUG_PROTOCOL_VERSION, 1);
+        assert_eq!(DEBUG_PROTOCOL_VERSION, 2);
     }
 }

--- a/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
@@ -507,6 +507,57 @@ impl FunctorLangEmbeddedGame {
         (report.rebound, history_replay)
     }
 
+    /// Install a freshly loaded project as a NEW game. This is deliberately
+    /// separate from `swap_in`: a device runtime boots a tiny placeholder
+    /// program, so its first real project cannot preserve that unrelated
+    /// model or runtime history.
+    fn reset_in(&mut self, loaded: Loaded) {
+        self.ctx().close_all_connections();
+        physics::remove_world(physics::DEFAULT_WORLD);
+        clear_http_taggers();
+        clear_audio_completions();
+        clear_preload_completions();
+
+        self.source_hashes = inspector_sources(&loaded.sources);
+        self.last_frame_journal.clear();
+        self.journal_ring.clear();
+        self.runnable = functor_lang::coverage::runnable_offsets(&loaded.module);
+        self.cached_trace = None;
+        journal_swap();
+        self.reporter
+            .set_source(SpanSource::Project(loaded.sources));
+        self.module = loaded.module;
+        self.session = loaded.session;
+        self.model = loaded.init;
+        self.has_input = loaded.has_input;
+        self.has_mouse_move = loaded.has_mouse_move;
+        self.has_mouse_wheel = loaded.has_mouse_wheel;
+        self.has_subscriptions = loaded.has_subscriptions;
+        self.prev_tts = None;
+        self.asset_progress = None;
+        self.delivered_asset_progress = None;
+        self.has_physics = loaded.has_physics;
+        self.has_soundscape = loaded.has_soundscape;
+        self.last_soundscape_json = empty_soundscape_json();
+        self.has_ui = loaded.has_ui;
+        self.last_view = View::Empty;
+        self.ui_handlers.clear();
+        self.has_webview = loaded.has_webview;
+        self.last_webview = None;
+        self.webview_handlers.clear();
+        self.effect_runner = RealEffects::new();
+        self.effect_log = EffectLog::new();
+        self.deferred_queries.clear();
+        self.pending_events.clear();
+        self.physics_rt = physics::SteppedPhysics::new();
+        self.physics_frame = 0;
+        self.recorder = SceneRecorder::new();
+        self.input_buf.clear();
+        self.last_frame = empty_frame();
+        self.reporter.reset();
+        self.platform.on_reload();
+    }
+
     /// Bundle this producer's per-frame state into the shared [`FrameCtx`]
     /// (docs/time-travel.md T6a) — the frame body and its helpers (`absorb`,
     /// `pump_subscriptions`, `step_physics`, `deliver_*`) live there, one copy
@@ -600,6 +651,25 @@ impl GameProducer for FunctorLangEmbeddedGame {
         let status = format!(
             "reloaded {} ({} file(s)) from pushed project in {:.2}ms \
 (model preserved{stored}{history})",
+            self.path,
+            files.len(),
+            now_ms() - started
+        );
+        log::info!("[functor-lang] {status}");
+        Ok(status)
+    }
+
+    fn load_project(&mut self, files: &[(String, String)]) -> Result<String, String> {
+        if files.is_empty() {
+            return Err("a pushed project needs at least the entry file".to_string());
+        }
+        let started = now_ms();
+        let loaded = load_source(files)?;
+        self.sources = files.to_vec();
+        self.path = files[0].0.clone();
+        self.reset_in(loaded);
+        let status = format!(
+            "loaded {} ({} file(s)) from pushed project in {:.2}ms (model initialized)",
             self.path,
             files.len(),
             now_ms() - started
@@ -1135,5 +1205,34 @@ let draw = (model, tts) =>
         let ft = frame_time(0.1, 0.016);
         game.tick(ft.clone());
         let _ = game.render(ft); // still renders under the old program
+    }
+
+    #[test]
+    fn loading_a_new_project_initializes_its_own_model() {
+        let mut game = FunctorLangEmbeddedGame::create(
+            vec![("boot.fun".to_string(), BOOT.to_string())],
+            Box::new(NativePlatform),
+        )
+        .expect("boot scene loads");
+        game.tick(frame_time(0.016, 0.016));
+
+        let project = BOOT
+            .replace("spin:", "speed:")
+            .replace("model.spin", "model.speed");
+        let status = game
+            .load_project(&[("game.fun".to_string(), project)])
+            .expect("new project loads");
+
+        assert!(status.contains("model initialized"), "{status}");
+        let model = game.state_debug();
+        assert!(model.contains("speed"), "{model}");
+        assert!(!model.contains("spin"), "{model}");
+        let ft = frame_time(0.032, 0.016);
+        game.tick(ft.clone());
+        let frame = game.render(ft);
+        assert!(
+            !matches!(&frame.scene.obj, crate::SceneObject::Group(children) if children.is_empty()),
+            "new project renders with its initialized model"
+        );
     }
 }

--- a/runtime/functor-runtime-common/src/game_clock.rs
+++ b/runtime/functor-runtime-common/src/game_clock.rs
@@ -240,6 +240,17 @@ impl GameClock {
         self.pending_frames = 0;
     }
 
+    /// Start a newly loaded game at its beginning while preserving an
+    /// unconditional `--fixed-time` capture pin.
+    pub fn restart(&mut self) {
+        self.game_time = 0.0;
+        self.accumulator = 0.0;
+        self.paused = false;
+        self.pending_step = None;
+        self.pending_frames = 0;
+        self.started = false;
+    }
+
     /// Pause and queue a one-frame step of `dt` seconds (Step / debug Advance).
     pub fn step(&mut self, dt: f32) {
         self.paused = true;
@@ -299,6 +310,26 @@ mod tests {
         clock.step_frames(5);
         clock.toggle_pause();
         assert_eq!(clock.pending_frames(), 0);
+    }
+
+    #[test]
+    fn restart_clears_live_history_but_preserves_fixed_time() {
+        let mut clock = GameClock::new(None);
+        let _ = clock.fixed_frames(0.25);
+        clock.pause();
+        clock.restart();
+        assert!(!clock.is_paused());
+        let first = clock.fixed_frames(0.0);
+        assert_eq!(first.len(), 1);
+        assert_eq!(first[0].dts, 0.0);
+        assert_eq!(first[0].tts, 0.0);
+
+        let mut fixed = GameClock::new(Some(3.0));
+        fixed.restart();
+        let pinned = fixed.fixed_frames(100.0);
+        assert_eq!(pinned.len(), 1);
+        assert_eq!(pinned[0].dts, 0.0);
+        assert_eq!(pinned[0].tts, 3.0);
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -115,6 +115,15 @@ pub trait GameProducer {
         Err("this producer does not support project reload (not an .fun game)".to_string())
     }
 
+    /// Load a complete pushed project as a NEW game. Unlike
+    /// [`GameProducer::reload_project`], this takes the model from the new
+    /// program's `init` and resets producer-owned runtime history. Device
+    /// shells use it for their first project push; later edits use
+    /// `reload_project` so the live model survives.
+    fn load_project(&mut self, _files: &[(String, String)]) -> Result<String, String> {
+        Err("this producer does not support project loading (not an .fun game)".to_string())
+    }
+
     /// Rewind the whole scene — model AND physics world — to an earlier
     /// RENDERED frame, restoring both to the state they had at the end of that
     /// frame and branching the recorded future from there (docs/time-travel.md

--- a/runtime/functor-runtime-desktop/src/audio.rs
+++ b/runtime/functor-runtime-desktop/src/audio.rs
@@ -15,13 +15,13 @@
 
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
-use std::fs::File;
-use std::io::BufReader;
+use std::io::{BufReader, Cursor};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::mpsc::Sender;
 use std::sync::Arc;
 use std::time::Duration;
 
+use functor_runtime_common::asset::AssetCache;
 use functor_runtime_common::audio::{AudioCommand, AudioScene, AudioSource, Listener, SceneUpdate};
 use rodio::source::Source;
 use rodio::{Decoder, OutputStream, OutputStreamHandle, Sink};
@@ -129,13 +129,14 @@ pub struct AudioPlayer {
     // path instead (`RefCell` because `decode` takes `&self`). Not reset on hot
     // reload — a path that's still missing stays quiet until the file appears.
     warned_paths: RefCell<HashSet<String>>,
+    asset_cache: Arc<AssetCache>,
 }
 
 impl AudioPlayer {
     /// Open the default output device. `None` when there is no device (headless
     /// / CI) — the runner then simply drops audio commands. `completion_tx`
     /// carries finished `playThen` tokens back to the main loop.
-    pub fn new(completion_tx: Sender<u64>) -> Option<AudioPlayer> {
+    pub fn new(completion_tx: Sender<u64>, asset_cache: Arc<AssetCache>) -> Option<AudioPlayer> {
         match OutputStream::try_default() {
             Ok((stream, handle)) => Some(AudioPlayer {
                 _stream: stream,
@@ -148,12 +149,21 @@ impl AudioPlayer {
                 },
                 voices: HashMap::new(),
                 warned_paths: RefCell::new(HashSet::new()),
+                asset_cache,
             }),
             Err(e) => {
                 eprintln!("[audio] no output device, audio disabled: {e}");
                 None
             }
         }
+    }
+
+    /// Drop decoded/live state for a sound whose backing bytes changed.
+    /// Existing detached one-shots finish; the next command/soundscape frame
+    /// decodes the replacement bytes.
+    pub fn evict_asset(&mut self, path: &str) {
+        self.voices.retain(|_, voice| voice.source.sound != path);
+        self.warned_paths.borrow_mut().remove(path);
     }
 
     /// Update the listener from the render camera (called each frame).
@@ -303,15 +313,20 @@ impl AudioPlayer {
         }
     }
 
-    fn decode(&self, path: &str) -> Option<Decoder<BufReader<File>>> {
-        let file = match File::open(path) {
-            Ok(f) => f,
+    fn decode(&self, path: &str) -> Option<Decoder<BufReader<Cursor<Vec<u8>>>>> {
+        let bytes = match self
+            .asset_cache
+            .cached_bytes(path)
+            .map(Ok)
+            .unwrap_or_else(|| std::fs::read(path))
+        {
+            Ok(bytes) => bytes,
             Err(e) => {
                 self.warn_once(path, format_args!("[audio] open '{path}': {e}"));
                 return None;
             }
         };
-        match Decoder::new(BufReader::new(file)) {
+        match Decoder::new(BufReader::new(Cursor::new(bytes))) {
             Ok(s) => Some(s),
             Err(e) => {
                 self.warn_once(path, format_args!("[audio] decode '{path}': {e}"));

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -638,6 +638,58 @@ impl FunctorLangGame {
         (report.rebound, history_replay)
     }
 
+    fn reset_in(&mut self, loaded: Loaded) {
+        self.ctx().close_all_connections();
+        physics::remove_world(physics::DEFAULT_WORLD);
+        clear_http_taggers();
+        clear_audio_completions();
+        clear_preload_completions();
+
+        self.source_hashes = inspector_sources(&loaded.sources);
+        self.last_frame_journal.clear();
+        self.journal_ring.clear();
+        self.runnable = functor_lang::coverage::runnable_offsets(&loaded.module);
+        self.cached_trace = None;
+        journal_swap();
+        self.reporter
+            .set_source(SpanSource::Project(loaded.sources));
+        self.module = loaded.module;
+        self.session = loaded.session;
+        self.model = loaded.init;
+        self.has_input = loaded.has_input;
+        self.has_mouse_move = loaded.has_mouse_move;
+        self.has_mouse_wheel = loaded.has_mouse_wheel;
+        self.has_subscriptions = loaded.has_subscriptions;
+        self.prev_tts = None;
+        self.asset_progress = None;
+        self.delivered_asset_progress = None;
+        self.has_physics = loaded.has_physics;
+        self.has_soundscape = loaded.has_soundscape;
+        self.last_soundscape_json = empty_soundscape_json();
+        self.has_ui = loaded.has_ui;
+        self.last_view = View::Empty;
+        self.ui_handlers.clear();
+        self.has_webview = loaded.has_webview;
+        self.last_webview = None;
+        self.webview_handlers.clear();
+        self.effect_runner = RealEffects::new();
+        self.effect_log = EffectLog::new();
+        self.deferred_queries.clear();
+        self.pending_events.clear();
+        self.physics_rt = physics::SteppedPhysics::new();
+        self.physics_frame = 0;
+        self.recorder = SceneRecorder::new();
+        self.input_buf.clear();
+        self.last_frame = empty_frame();
+        self.reporter.reset();
+        self.frames = 0;
+        self.tick_ns = 0;
+        self.physics_ns = 0;
+        self.draw_ns = 0;
+        self.render_ns = 0;
+        self.swap_ns = 0;
+    }
+
     fn report_stats(&mut self) {
         if self.frames > 0 && self.frames % STATS_EVERY == 0 {
             let tick_us = self.tick_ns as f64 / STATS_EVERY as f64 / 1000.0;
@@ -807,6 +859,29 @@ impl Game for FunctorLangGame {
             "reloaded {} ({} file(s)) from pushed project in {:.2}ms \
 (model preserved{stored}{history})",
             self.path,
+            files.len(),
+            started.elapsed().as_secs_f64() * 1000.0
+        );
+        events::emit(RuntimeEvent::HotReload {
+            ok: true,
+            message: status.clone(),
+        });
+        Ok(status)
+    }
+
+    fn load_project(&mut self, files: &[(String, String)]) -> Result<String, String> {
+        if files.is_empty() {
+            return Err("a pushed project needs at least the entry file".to_string());
+        }
+        let started = Instant::now();
+        let loaded = load_sources(files)?;
+        self.pushed_project = Some(files.to_vec());
+        self.pushed_entry = None;
+        self.reset_in(loaded);
+        self.stamp = project_stamp(&self.path);
+        let status = format!(
+            "loaded {} ({} file(s)) from pushed project in {:.2}ms (model initialized)",
+            files[0].0,
             files.len(),
             started.elapsed().as_secs_f64() * 1000.0
         );
@@ -1648,6 +1723,15 @@ mod tests {
             "9",
             "a rejected project push must keep the previous program"
         );
+
+        let new_game = BASE.replace("{ n: 0.0 }", "{ speed: 3.0 }");
+        let status = game
+            .load_project(&[("other.fun".to_string(), new_game)])
+            .expect("new project load should initialize its model");
+        assert!(status.contains("model initialized"), "{status}");
+        let model = game.state_debug();
+        assert!(model.contains("speed"), "{model}");
+        assert!(!model.contains("n:"), "{model}");
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -13,7 +13,7 @@ use std::time::Instant;
 
 use functor_runtime_common::asset::AssetCache;
 use functor_runtime_common::{Frame, FrameTime, GameClock, RecordedInput, SceneContext};
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 use functor_runtime_common::Key as InputKey;
 use glfw::{Action, Key};
@@ -476,13 +476,16 @@ fn service_debug_request(
     req: debug_server::DebugRequest,
     game: &mut dyn Game,
     frame: &Frame,
-    frame_count: u64,
+    frame_count: &mut u64,
     tts: f32,
     width: u32,
     height: u32,
     held_keys: &mut BTreeSet<InputKey>,
     mouse_pos: &mut (i32, i32),
     clock: &mut GameClock,
+    asset_cache: &Arc<AssetCache>,
+    scene_context: &SceneContext,
+    mut audio_player: Option<&mut audio::AudioPlayer>,
     // The webview keyboard gate, mirrored from the GLFW routing: `Some` iff a
     // webview text field is focused (`webview_wants_keyboard`), and injected
     // keys then type into it (queued into the next frame's WorkerInput)
@@ -497,7 +500,7 @@ fn service_debug_request(
         }
         debug_server::DebugRequest::State(resp) => {
             let _ = resp.send(debug_server::RuntimeState {
-                frame: frame_count,
+                frame: *frame_count,
                 tts,
                 viewport: debug_server::RuntimeViewport::new(width, height),
                 views: vec![debug_server::RuntimeView::new("main", width, height)],
@@ -527,6 +530,40 @@ fn service_debug_request(
         }
         debug_server::DebugRequest::ReloadProject(files, resp) => {
             let _ = resp.send(game.reload_project(&files));
+        }
+        debug_server::DebugRequest::LoadProject(files, resp) => {
+            let result = game.load_project(&files);
+            if result.is_ok() {
+                clock.restart();
+                *frame_count = 0;
+            }
+            let _ = resp.send(result);
+        }
+        debug_server::DebugRequest::ReloadAsset(asset, resp) => {
+            let changed = asset_cache.replace_uploaded(&asset.path, asset.bytes);
+            if changed {
+                scene_context.evict_asset(&asset.path);
+                if let Some(player) = audio_player.as_deref_mut() {
+                    player.evict_asset(&asset.path);
+                }
+            }
+            let status = if changed { "reloaded" } else { "unchanged" };
+            let _ = resp.send(Ok(format!("{status} asset {}", asset.path)));
+        }
+        debug_server::DebugRequest::SyncAssets(paths, resp) => {
+            let current: HashSet<String> = paths.into_iter().collect();
+            let removed = asset_cache.retain_uploaded(&current);
+            for path in &removed {
+                scene_context.evict_asset(path);
+                if let Some(player) = audio_player.as_deref_mut() {
+                    player.evict_asset(path);
+                }
+            }
+            let _ = resp.send(Ok(format!(
+                "synced {} asset(s), removed {}",
+                current.len(),
+                removed.len()
+            )));
         }
         debug_server::DebugRequest::Rewind(frame, resp) => {
             let result = game.rewind_scene_to(frame);
@@ -640,6 +677,11 @@ fn run_headless(
     let mut clock = GameClock::new(fixed_time);
     let mut held_keys: BTreeSet<InputKey> = BTreeSet::new();
     let mut mouse_pos: (i32, i32) = (0, 0);
+    // Keep the debug protocol target-isomorphic even without pixels: uploaded
+    // assets can be accepted now and are ready if headless rendering gains an
+    // asset path later.
+    let asset_cache = Arc::new(AssetCache::new());
+    let scene_context = SceneContext::new();
 
     // Same networking machinery as the windowed loop — driving networked/stateful
     // games is the whole point of a headless runner. Audio is omitted (no device
@@ -687,13 +729,16 @@ fn run_headless(
                     req,
                     &mut *game,
                     &frame,
-                    frame_count,
+                    &mut frame_count,
                     time.tts,
                     0, // no framebuffer in headless
                     0,
                     &mut held_keys,
                     &mut mouse_pos,
                     &mut clock,
+                    &asset_cache,
+                    &scene_context,
+                    None,
                     None, // no webview overlay in headless
                     &|| {
                         Err(debug_server::CaptureError::Unavailable(
@@ -1019,7 +1064,7 @@ pub fn run(args: Args) {
         // the game before the next tick (like net results). The player is `mut`
         // so the listener can be updated from each frame's camera.
         let (audio_tx, audio_rx) = std::sync::mpsc::channel::<u64>();
-        let mut audio_player = audio::AudioPlayer::new(audio_tx);
+        let mut audio_player = audio::AudioPlayer::new(audio_tx, asset_cache.clone());
 
         // Xreal head tracking: a background thread owns the TCP stream +
         // sensor fusion; the loop reads the latest orientation each frame and
@@ -1097,6 +1142,9 @@ pub fn run(args: Args) {
                     log::info!("asset '{}' changed on disk; reloading", path);
                     asset_cache.evict(&path);
                     scene_context.evict_asset(&path);
+                    if let Some(player) = &mut audio_player {
+                        player.evict_asset(&path);
+                    }
                 }
             }
 
@@ -2156,13 +2204,16 @@ Escape again to quit"
                         req,
                         &mut *game,
                         &frame,
-                        frame_count,
+                        &mut frame_count,
                         time.tts,
                         fb_width as u32,
                         fb_height as u32,
                         &mut held_keys,
                         &mut mouse_pos,
                         &mut clock,
+                        &asset_cache,
+                        &scene_context,
+                        audio_player.as_mut(),
                         // The webview focus gate: injected keys type into a
                         // focused webview field (queued for the next frame's
                         // overlay pass) instead of reaching the game.

--- a/runtime/functor-runtime-oculus/README.md
+++ b/runtime/functor-runtime-oculus/README.md
@@ -9,10 +9,11 @@ over the shared debug-runtime protocol.
 ## Status
 
 The OpenXR shell, interpreted Functor Lang producer, USB remote-develop loop,
-authored-camera rig, and exact asymmetric per-eye projection are verified on
-Quest 3. The shared debug/REPL protocol adds raw stereo framebuffer capture and
-desktop-isomorphic control. Remaining device work includes controller/hand
-input, asset sync, and multiview rendering.
+authored-camera rig, exact asymmetric per-eye projection, and project asset
+sync are implemented for Quest 3. The shared debug/REPL protocol adds raw
+stereo framebuffer capture and desktop-isomorphic control. Remaining device
+work includes controller/hand input, an Android audio host, and multiview
+rendering.
 
 ## Camera contract
 
@@ -41,10 +42,20 @@ loopback — an accepted dev-tool tradeoff):
 functor -d mygame run vr    # the whole loop, one command
 ```
 
-`run vr` finds the adb device, launches this APK, forwards the port, pushes
-the whole project (`POST /reload-project` — sibling modules included), then
-re-checks + re-pushes on every save while streaming the headset's runtime
-log into the terminal. The pieces also work individually:
+`run vr` finds the adb device, launches this APK, forwards the port, loads
+the whole source project (`POST /load-project` — sibling modules included)
+plus its model/texture/audio files, then re-checks + re-pushes changed source
+or assets on every save while streaming the headset's runtime log into the
+terminal. The initial load takes the model from `init`; later source pushes use
+`POST /reload-project` and preserve it. Assets transfer individually through
+`POST /reload-asset`; a final
+`POST /sync-assets` manifest removes deleted uploads and changed render assets
+are decoded again on the next frame. The pieces also work individually:
+
+Sound bytes are synchronized into the device cache, but Quest audio playback
+is still pending its Android audio host; the shell currently drains audio
+commands without playing them. Sounds therefore do not yet drive
+`Sub.assets`, whose current load/decode pipeline covers models and textures.
 
 ```sh
 adb forward tcp:8123 tcp:8123
@@ -57,14 +68,15 @@ curl --fail --show-error --retry 30 --retry-delay 1 \
 ```
 
 `GET /`, `GET /state`, `GET /scene`, `GET /trace`, `POST /capture`,
-`POST /input`, `POST /time`, `POST /reload-source`, `POST /reload-project`,
-and `POST /rewind` have the same request/response forms as desktop. `/state`
-reports `left` and `right` views; `/capture` returns their raw framebuffer
-pixels as one left-then-right side-by-side PNG, before compositor warping.
-The server is reachable while the headset dozes, but capture correctly returns
-503 until XR is rendering. After any adb reconnect, recreate the port forward;
-poll `/state` until `frame` advances before capture so cached paused state is not
-mistaken for readiness.
+`POST /input`, `POST /time`, `POST /reload-source`, `POST /load-project`,
+`POST /reload-project`, `POST /reload-asset`, `POST /sync-assets`, and
+`POST /rewind` have the same
+request/response forms as desktop. `/state` reports `left` and `right` views;
+`/capture` returns their raw framebuffer pixels as one left-then-right
+side-by-side PNG, before compositor warping. The server is reachable while the
+headset dozes, but capture correctly returns 503 until XR is rendering. After
+any adb reconnect, recreate the port forward; poll `/state` until `frame`
+advances before capture so cached paused state is not mistaken for readiness.
 
 ## Benchmark on the actual headset
 

--- a/runtime/functor-runtime-oculus/src/lib.rs
+++ b/runtime/functor-runtime-oculus/src/lib.rs
@@ -25,7 +25,7 @@
 //! fork predates the 0.18 release that shipped GLES/Android support),
 //! `android-activity` instead of the deprecated `ndk-glue`.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashSet};
 use std::sync::{mpsc, Arc};
 use std::time::Instant;
 
@@ -289,6 +289,8 @@ fn service_debug_request(
     debug: &mut DebugLoopState,
     eyes: &[EyeTarget],
     session_running: bool,
+    asset_cache: &Arc<AssetCache>,
+    scene_context: &SceneContext,
 ) {
     match request {
         DebugRequest::Capture(response) => {
@@ -406,6 +408,36 @@ fn service_debug_request(
         }
         DebugRequest::ReloadProject(files, response) => {
             let _ = response.send(game.reload_project(&files));
+        }
+        DebugRequest::LoadProject(files, response) => {
+            let result = game.load_project(&files);
+            if result.is_ok() {
+                clock.restart();
+                debug.frame_count = 0;
+            }
+            let _ = response.send(result);
+        }
+        DebugRequest::ReloadAsset(asset, response) => {
+            let changed = asset_cache.replace_uploaded(&asset.path, asset.bytes);
+            if changed {
+                scene_context.evict_asset(&asset.path);
+            }
+            let status = if changed { "reloaded" } else { "unchanged" };
+            log::info!("{status} project asset '{}'", asset.path);
+            let _ = response.send(Ok(format!("{status} asset {}", asset.path)));
+        }
+        DebugRequest::SyncAssets(paths, response) => {
+            let current: HashSet<String> = paths.into_iter().collect();
+            let removed = asset_cache.retain_uploaded(&current);
+            for path in &removed {
+                scene_context.evict_asset(path);
+                log::info!("removed project asset '{path}'");
+            }
+            let _ = response.send(Ok(format!(
+                "synced {} asset(s), removed {}",
+                current.len(),
+                removed.len()
+            )));
         }
         DebugRequest::Rewind(frame, response) => {
             let result = game.rewind_scene_to(frame);
@@ -713,6 +745,8 @@ pub fn android_main(app: AndroidApp) {
                     &mut debug,
                     &eyes,
                     session_running,
+                    &asset_cache,
+                    &scene_context,
                 );
             }
         }
@@ -809,16 +843,15 @@ pub fn android_main(app: AndroidApp) {
         // the authored center-eye rig; live OpenXR eye deltas compose onto it
         // below, so the same camera positions the world on every target.
         game.check_hot_reload(frame_time.clone());
+        game.push_asset_progress(asset_cache.progress());
         for sub_frame in &sub_frames {
             game.tick(sub_frame.clone());
             debug.frame_count += 1;
         }
         let frame = game.render(frame_time.clone());
-        // No audio/HTTP/preload/asset hosts on device yet (M1): drain the
-        // command queues so they don't grow unbounded (and
-        // `push_asset_progress` is deliberately never fed — `Sub.assets`
-        // stays quiet). Games using those effects run; the effects just
-        // don't produce sound/replies here yet.
+        // No audio/HTTP/preload hosts on device yet: drain their command
+        // queues so they don't grow unbounded. Asset progress is real and fed
+        // above; the remaining effects run but do not produce sound/replies.
         let _ = game.audio_drain_commands();
         let _ = game.net_drain_commands();
         let _ = game.net_drain_conn_commands();

--- a/tools/functor-sdk/README.md
+++ b/tools/functor-sdk/README.md
@@ -36,6 +36,27 @@ const png = await game.capture();// PNG bytes of the frame
 `FunctorRunner.connect(url)` attaches to an already-running runtime instead of
 spawning one (and won't kill it on dispose).
 
+Project assets can be pushed from Node or a loopback-hosted browser without
+target-specific APIs:
+
+```ts
+const quest = await FunctorRunner.connect("http://127.0.0.1:8123");
+await quest.reloadAssets([
+  ["models/Xbot.glb", new Uint8Array(await modelFile.arrayBuffer())],
+  ["textures/grid.png", new Uint8Array(await textureFile.arrayBuffer())],
+]);
+await quest.loadProject([
+  ["game.fun", gameSource],
+  ["assets.fun", assetManifestSource],
+]);
+```
+
+Files upload individually, then one manifest removes stale uploads. Upload the
+initial asset set before `loadProject` so `init` and the first frame see it
+resident. The same calls work against desktop and the adb-forwarded Quest runtime.
+`loadProject` initializes a new game from `init`; use `reloadProject` for later
+source edits that should preserve the live model.
+
 By default the runner is launched with `--hidden`: the GL window is never shown
 and never steals focus or the cursor, but keeps its GL context, so `capture()`
 works. Pass `visible: true` to show the window (e.g. to watch a script drive the

--- a/tools/functor-sdk/src/client.ts
+++ b/tools/functor-sdk/src/client.ts
@@ -58,11 +58,22 @@ export class HttpClient {
     return res.text();
   }
 
+  /** POST caller-provided bytes without JSON stringification. */
+  async postRawBinary(
+    path: string,
+    body: Uint8Array,
+    contentType = "application/octet-stream",
+  ): Promise<string> {
+    const res = await this.send("POST", path, body, contentType, true);
+    return res.text();
+  }
+
   private async send(
     method: string,
     path: string,
     body?: unknown,
     rawContentType?: string,
+    binary = false,
   ): Promise<Response> {
     const url = `${this.baseUrl}${path}`;
     const response = await fetch(url, {
@@ -74,6 +85,8 @@ export class HttpClient {
       body:
         body === undefined
           ? undefined
+          : binary
+            ? (body as Uint8Array)
           : rawContentType === undefined
             ? JSON.stringify(body)
             : String(body),

--- a/tools/functor-sdk/src/game.ts
+++ b/tools/functor-sdk/src/game.ts
@@ -2,6 +2,7 @@ import type { HttpClient } from "./client.js";
 import type {
   InputCommand,
   KeyName,
+  ProjectAssets,
   ProjectSources,
   RuntimeState,
   Scene,
@@ -71,6 +72,39 @@ export class FunctorClient {
   /** Hot-reload a complete sibling-module project, preserving the model. */
   reloadProject(files: ProjectSources): Promise<string> {
     return this.http.postText("/reload-project", files);
+  }
+
+  /** Load a complete sibling-module project as a new game, initializing its
+   * model from `init`. Use reloadProject for subsequent live edits. */
+  loadProject(files: ProjectSources): Promise<string> {
+    return this.http.postText("/load-project", files);
+  }
+
+  /** Upload one project-relative texture/model/audio asset. Existing decoded
+   * render data for the locator is evicted when the bytes changed. */
+  reloadAsset(path: string, bytes: Uint8Array): Promise<string> {
+    const pathBytes = new TextEncoder().encode(path);
+    if (pathBytes.byteLength > 0xffff_ffff) {
+      throw new Error("asset path is too long");
+    }
+    const body = new Uint8Array(4 + pathBytes.byteLength + bytes.byteLength);
+    new DataView(body.buffer).setUint32(0, pathBytes.byteLength, false);
+    body.set(pathBytes, 4);
+    body.set(bytes, 4 + pathBytes.byteLength);
+    return this.http.postRawBinary("/reload-asset", body);
+  }
+
+  /** Upload the current asset set, then remove uploads absent from its
+   * manifest. Files transfer individually so large projects stay bounded by
+   * their largest asset rather than total project size. */
+  async reloadAssets(files: ProjectAssets): Promise<string> {
+    for (const [path, bytes] of files) {
+      await this.reloadAsset(path, bytes);
+    }
+    return this.http.postText(
+      "/sync-assets",
+      files.map(([path]) => path),
+    );
   }
 
   /** Restore the recorded model and physics state at a rendered frame. */

--- a/tools/functor-sdk/src/types.ts
+++ b/tools/functor-sdk/src/types.ts
@@ -75,6 +75,9 @@ export type UiEventKind =
 /** Whole-project wire body for `POST /reload-project`, entry file first. */
 export type ProjectSources = Array<[path: string, source: string]>;
 
+/** Project-relative texture/model/audio bytes for the runtime asset cache. */
+export type ProjectAssets = Array<[path: string, bytes: Uint8Array]>;
+
 /** Options for polling helpers like `waitFor` / `waitForState`. */
 export interface WaitForOptions {
   /** Total time to wait before giving up, ms (default 10_000). */

--- a/tools/functor-sdk/test/unit.test.ts
+++ b/tools/functor-sdk/test/unit.test.ts
@@ -3,7 +3,14 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { test } from "node:test";
 
-import { findRepoRoot, formatCrashOutput, stepAll, waitFor } from "../src/index.js";
+import {
+  findRepoRoot,
+  formatCrashOutput,
+  FunctorClient,
+  HttpClient,
+  stepAll,
+  waitFor,
+} from "../src/index.js";
 
 // Pure unit tests — no runtime required, always run.
 
@@ -95,4 +102,60 @@ test("waitFor throws on timeout with the description", async () => {
     ),
     /timed out after 20ms waiting for the impossible/,
   );
+});
+
+test("reloadAssets uploads binary envelopes then finalizes the manifest", async () => {
+  const calls: Array<{ path: string; body: unknown }> = [];
+  const http = {
+    postRawBinary: async (path: string, body: Uint8Array) => {
+      calls.push({ path, body });
+      return "reloaded";
+    },
+    postText: async (path: string, body: unknown) => {
+      calls.push({ path, body });
+      return "synced";
+    },
+  } as HttpClient;
+  const client = new FunctorClient(http);
+
+  assert.equal(
+    await client.reloadAssets([["textures/grid.png", Uint8Array.of(0, 1, 255)]]),
+    "synced",
+  );
+  assert.equal(calls[0].path, "/reload-asset");
+  const envelope = calls[0].body as Uint8Array;
+  const pathLength = new DataView(
+    envelope.buffer,
+    envelope.byteOffset,
+    envelope.byteLength,
+  ).getUint32(0, false);
+  assert.equal(
+    new TextDecoder().decode(envelope.slice(4, 4 + pathLength)),
+    "textures/grid.png",
+  );
+  assert.deepEqual([...envelope.slice(4 + pathLength)], [0, 1, 255]);
+  assert.deepEqual(calls[1], {
+    path: "/sync-assets",
+    body: ["textures/grid.png"],
+  });
+});
+
+test("project load and reload use distinct lifecycle routes", async () => {
+  const calls: Array<{ path: string; body: unknown }> = [];
+  const http = {
+    postText: async (path: string, body: unknown) => {
+      calls.push({ path, body });
+      return "ok";
+    },
+  } as HttpClient;
+  const client = new FunctorClient(http);
+  const files: [string, string][] = [["game.fun", "let init = 0"]];
+
+  await client.loadProject(files);
+  await client.reloadProject(files);
+
+  assert.deepEqual(calls, [
+    { path: "/load-project", body: files },
+    { path: "/reload-project", body: files },
+  ]);
 });


### PR DESCRIPTION
## Summary

- synchronize project `.glb` models, textures, and sounds over the shared desktop/Quest debug protocol, with cache invalidation for changed and deleted uploads
- make `functor run vr` push initial assets before loading the project, then watch source and asset fingerprints without rereading large files every poll
- distinguish new-project `/load-project` initialization from model-preserving `/reload-project`, resetting clock/frame/runtime state for a clean first frame
- expose the same asset and project lifecycle through `@functor/sdk`; desktop audio can decode uploaded sound bytes

## Scope

- live model sync currently supports self-contained `.glb`; external-URI `.gltf`/`.bin` projects remain excluded until model URI resolution is cache-aware
- Quest receives sound bytes, but Android audio output remains a separate milestone; desktop consumes synchronized sounds today

## Verification

- `cargo test -q -p functor_runtime_common -p functor-runtime-desktop -p functor-cli` — 399 common + 62 desktop + 39 CLI tests passed (plus integration targets; expected GL-only ignores)
- `npm test --prefix tools/functor-sdk` — 28 passed
- `cargo check -q -p functor_runtime_common -p functor-runtime-desktop -p functor-cli`
- `npm run build:oculus:apk` — signed debug APK built and installed on Quest 3
- Quest 3: uploaded `examples/animation/Xbot.glb` before `/load-project`; project initialized in 17.02 ms at frame 1 / tts 0.0167 s, then advanced normally with the animated model visible in both eyes
- Quest 3: textured synthwave scene verified from synchronized texture bytes

### Per-frame benchmark

Three paired release runs of `frame_bench` against `origin/main` and this branch. Allocations and bytes/frame were identical in every run:

| Scene | allocs/frame | bytes/frame | Base min range | Change min range |
| --- | ---: | ---: | ---: | ---: |
| 400 cells | 13,877 | 842,251 | 1041.8–1053.6 µs | 783.8–1059.3 µs |
| 1600 cells | 54,717 | 3,306,091 | 4127.8–4270.0 µs | 4132.8–4368.6 µs |
| 3136 cells | 106,973 | 6,459,115 | 8234.0–9446.0 µs | 8122.4–8805.3 µs |

The deterministic allocation metrics have zero regression; wall-clock results overlap normal run-to-run spread.

## Review dispositions

Two independent review passes caught and verified fixes for:

- asset mutations occurring before the source check gate
- initial game startup racing asset residency
- stale load progress after deleting an uploaded asset
- Quest not feeding uploaded decode progress into `Sub.assets`
- new-project loads inheriting clock/frame state
- external-URI `.gltf` files being advertised as live-syncable
- uploaded desktop sounds bypassing the synchronized cache
- large asset manifests incorrectly sharing the 64 KB command cap

Final adversarial re-review: **PASS**, no remaining concrete correctness or simplicity finding.

## Visual verification

![Animated Xbot synchronized to Quest 3](https://gist.githubusercontent.com/tommy-xr/ded5a615909898cfe6a339d3f8d07d7e/raw/functor-pr460-xbot-quest3.gif)

<sub>Animated Xbot rendered from the synchronized `Xbot.glb`; raw side-by-side Quest 3 stereo captures from multiple animation poses.</sub>

![Xbot mid-stride on Quest 3](https://gist.githubusercontent.com/tommy-xr/ded5a615909898cfe6a339d3f8d07d7e/raw/functor-pr460-xbot-quest3-still.png)

<sub>Mid-stride still from the final reviewed APK after browser-to-headset project and asset synchronization.</sub>
