### PR TITLE
feat(lang): add string interpolation

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -84,10 +84,13 @@ let sumList = (xs: List<float>): float =>     // list PATTERNS: [] / [a,b] / [h,
   | [] => 0.0
   | [head, ..rest] => head + sumList(rest)    // refutable; needs a catch-all or [..r]
 let s = "text\n"                              // strings: escapes \" \\ \n \t
+let label = $"score: {threshold}; {{ready}}"  // interpolation: `$"…"` with full expressions in {}
+                                              //   strings inline raw; other values use canonical
+                                              //   display; {{ and }} are literal braces
 let flag = true                               // bools
 
 let isHigh = (score: float): bool => score > threshold   // annotations OPTIONAL (gradual)
-let describe = (score) => Text.concat("score: ", Text.fromFloat(score))
+let describe = (score) => $"score: {score}"
 
 let report = (scores) =>
   scores

--- a/cli/src/util/asset_verify.rs
+++ b/cli/src/util/asset_verify.rs
@@ -24,7 +24,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use functor_lang::ir::{Expr, ExprKind, Module};
+use functor_lang::ir::{Expr, ExprKind, Module, StringPart};
 use functor_lang::Span;
 
 /// One finding, anchored to the offending argument's span.
@@ -172,6 +172,13 @@ fn walk(expr: &Expr, f: &mut impl FnMut(&Expr)) {
         | ExprKind::External(_)
         | ExprKind::LocalMut { .. }
         | ExprKind::Ctor { .. } => {}
+        ExprKind::InterpolatedString(parts) => {
+            for part in parts {
+                if let StringPart::Expr(expr) = part {
+                    walk(expr, f);
+                }
+            }
+        }
         ExprKind::Record(fields) => {
             for field in fields {
                 walk(&field.value, f);
@@ -369,4 +376,14 @@ mod tests {
         assert!(f.warnings.is_empty());
     }
 
+    #[test]
+    fn asset_constructors_inside_interpolation_holes_are_checked() {
+        let f = run(
+            r#"let label = $"asset: {Asset.model("gone.glb")}""#,
+            &std::env::temp_dir(),
+            &mut no_probe,
+        );
+        assert_eq!(f.errors.len(), 1);
+        assert!(f.errors[0].message.contains("\"gone.glb\""));
+    }
 }

--- a/docs/functor-lang.md
+++ b/docs/functor-lang.md
@@ -531,6 +531,18 @@ snapshots — no GPU, fully agent-verifiable.
       `animator.fun` example module should remove that file to use the bundled
       API, or rename it if they maintain a customized implementation; bundled
       namespaces cannot be shadowed.
+- [x] **Language: string interpolation** (done 2026-07-23). An explicit
+      F#-style `$"score: {score}"` literal accepts full Functor expressions
+      in each `{…}` hole and evaluates them left-to-right. String values
+      insert their raw contents; every other value uses the same deterministic
+      structural rendering as `run`/`trace`, so numbers, bools, lists, records,
+      tuples, and variants work without a separate conversion function.
+      Existing string escapes remain unchanged, and `{{` / `}}` emit literal
+      braces. Interpolation expressions participate in normal name resolution,
+      typechecking, editor navigation, coverage, and hot-reload rebinding.
+      *Verify:* parser/error-span tests, checker traversal, nested
+      interpolation + structural-brace runtime tests, full language suite,
+      and the release `frame_bench` acceptance comparison.
 - [x] **Language: inline `expect` tests** (done 2026-07-19; design note in
       `~/notes` `inline-expect-tests.md` — the live red/green editor arc
       builds on this). `expect <bool-expr>` is a top-level item (contextual

--- a/functor-lang/src/ast.rs
+++ b/functor-lang/src/ast.rs
@@ -126,6 +126,9 @@ pub enum ExprKind {
     /// Ints and floats both parse to f64 (Functor Lang has one number type for now).
     Number(f64),
     String(String),
+    /// `$"score: {score}"` — text and full expression holes, evaluated
+    /// left-to-right. `{{` / `}}` produce literal braces.
+    InterpolatedString(Vec<StringPart>),
     Bool(bool),
     /// A possibly-qualified name: `x` is `["x"]`, `Text.toBullets` is
     /// `["Text", "toBullets"]`. The parser absorbs a `.segment` into the
@@ -235,6 +238,12 @@ pub enum ExprKind {
         scrutinee: Box<Expr>,
         arms: Vec<MatchArm>,
     },
+}
+
+#[derive(Debug)]
+pub enum StringPart {
+    Text(String),
+    Expr(Expr),
 }
 
 /// One `| pattern => body` arm of a `match`.

--- a/functor-lang/src/complete.rs
+++ b/functor-lang/src/complete.rs
@@ -218,7 +218,7 @@ fn context_at(live_text: &str, offset: usize) -> Context {
         return Context::None;
     }
     let prefix = &live_text[..offset];
-    let Ok(mut tokens) = crate::lexer::lex(prefix, 0) else {
+    let Some(mut tokens) = lex_completion_prefix(prefix) else {
         return Context::None;
     };
     tokens.pop(); // drop the Eof sentinel the lexer always appends
@@ -289,7 +289,13 @@ fn context_at(live_text: &str, offset: usize) -> Context {
         },
         // A literal / range touching the cursor offers nothing — there is no
         // member completion off a number or string in v1.
-        TokenKind::Number(_) | TokenKind::Str(_) | TokenKind::DotDot | TokenKind::TypeVar(_)
+        TokenKind::Number(_)
+        | TokenKind::Str(_)
+        | TokenKind::InterpolatedStart
+        | TokenKind::InterpolatedText(_)
+        | TokenKind::InterpolatedEnd
+        | TokenKind::DotDot
+        | TokenKind::TypeVar(_)
             if touches =>
         {
             Context::None
@@ -300,6 +306,47 @@ fn context_at(live_text: &str, offset: usize) -> Context {
             partial: String::new(),
         },
     }
+}
+
+/// Lex a cursor prefix, recovering the deliberately unfinished delimiters
+/// that occur while typing inside an interpolation hole. The synthetic suffix
+/// is discarded by span before context classification, so it can only make
+/// the real prefix lexable; it never becomes a completion token itself.
+fn lex_completion_prefix(prefix: &str) -> Option<Vec<Token>> {
+    match crate::lexer::lex(prefix, 0) {
+        Ok(tokens) => return Some(tokens),
+        Err(error) if error.message.starts_with("unterminated ") => {}
+        Err(_) => return None,
+    }
+    // Editor recovery, not language acceptance: eight unfinished nested
+    // templates is ample for a live cursor and keeps a broken-buffer
+    // completion request bounded to a small number of lexer passes.
+    for depth in 1..=8 {
+        let suffix = "}\"".repeat(depth);
+        let recovered = format!("{prefix}{suffix}");
+        if let Ok(mut tokens) = crate::lexer::lex(&recovered, 0) {
+            if tokens.iter().any(|token| {
+                matches!(
+                    token.kind,
+                    TokenKind::Str(_) | TokenKind::InterpolatedText(_)
+                ) && token.span.start < prefix.len()
+                    && token.span.end > prefix.len()
+            }) {
+                return None;
+            }
+            let in_interpolation_hole = tokens.iter().any(|token| {
+                token.kind == TokenKind::InterpolatedOpen && token.span.end <= prefix.len()
+            }) && tokens.iter().any(|token| {
+                token.kind == TokenKind::InterpolatedClose && token.span.start >= prefix.len()
+            });
+            if !in_interpolation_hole {
+                continue;
+            }
+            tokens.retain(|token| token.kind == TokenKind::Eof || token.span.end <= prefix.len());
+            return Some(tokens);
+        }
+    }
+    None
 }
 
 /// The dotted qualifier ending at `tokens[end]` (an `Ident`): walk back over an
@@ -1385,6 +1432,27 @@ mod tests {
     #[test]
     fn cursor_in_string_is_empty() {
         let live = "let s = \"Scene.";
+        let items = game(STUB, &[("Scene", SCENE)], live);
+        assert!(items.is_empty(), "{:?}", labels(&items));
+    }
+
+    #[test]
+    fn completion_works_inside_an_interpolation_hole() {
+        let items = game(STUB, &[("Scene", SCENE)], r#"let s = $"scene: {Scene."#);
+        assert!(has(&items, "cube"), "{:?}", labels(&items));
+    }
+
+    #[test]
+    fn local_completion_works_inside_a_fresh_interpolation_hole() {
+        let src = r#"let f = (score: float): string => $"score: {score}""#;
+        let hole = src.rfind("score").unwrap();
+        let items = fresh(src, &[], hole + 3);
+        assert!(has(&items, "score"), "{:?}", labels(&items));
+    }
+
+    #[test]
+    fn cursor_in_a_string_inside_an_interpolation_hole_is_empty() {
+        let live = r#"let s = $"text: {"Scene."#;
         let items = game(STUB, &[("Scene", SCENE)], live);
         assert!(items.is_empty(), "{:?}", labels(&items));
     }

--- a/functor-lang/src/eval.rs
+++ b/functor-lang/src/eval.rs
@@ -30,11 +30,14 @@
 //! marker event) after [`MAX_TRACE_EVENTS`] so a hot loop can't produce an
 //! unbounded transcript; evaluation itself continues.
 
-use crate::ir::{BindingId, Def, ExpectDef, Expr, ExprKind, Module, Pattern, PatternKind};
+use crate::ir::{
+    BindingId, Def, ExpectDef, Expr, ExprKind, Module, Pattern, PatternKind, StringPart,
+};
 use crate::span::Span;
 use crate::value::{Closure, Env, Value};
 use crate::RunError;
 use std::collections::HashMap;
+use std::fmt::Write;
 use std::rc::Rc;
 
 /// Evaluation depth cap: pathological or unboundedly recursive Functor Lang code must
@@ -708,6 +711,35 @@ impl Fuel {
     }
 }
 
+fn step_budget_error(limit: u64, span: Span) -> RunError {
+    RunError {
+        message: format!(
+            "evaluation exceeded its step budget ({limit} steps) — the embedding \
+tool bounds test evaluation (a live editor re-runs on every edit); look for runaway recursion \
+or an oversized computation"
+        ),
+        span,
+    }
+}
+
+/// A formatter sink that refuses to materialize more bytes than the current
+/// tooling budget permits. `Value::Display` is iterative, so this also keeps
+/// rendering a shared, structurally large value bounded by the same fuel that
+/// bounds its construction.
+struct FuelWriter<'a> {
+    out: &'a mut String,
+    remaining: u64,
+}
+
+impl std::fmt::Write for FuelWriter<'_> {
+    fn write_str(&mut self, text: &str) -> std::fmt::Result {
+        let bytes = u64::try_from(text.len()).map_err(|_| std::fmt::Error)?;
+        self.remaining = self.remaining.checked_sub(bytes).ok_or(std::fmt::Error)?;
+        self.out.push_str(text);
+        Ok(())
+    }
+}
+
 struct Interp<'h> {
     globals: HashMap<String, Value>,
     /// Live `let mut` slots, keyed by binding, as a stack per binding (the
@@ -829,17 +861,7 @@ impl Interp<'_> {
         if let Some(fuel) = &mut self.fuel {
             match fuel.remaining.checked_sub(units) {
                 Some(rest) => fuel.remaining = rest,
-                None => {
-                    return Err(RunError {
-                        message: format!(
-                            "evaluation exceeded its step budget ({} steps) — the embedding \
-tool bounds test evaluation (a live editor re-runs on every edit); look for runaway recursion \
-or an oversized computation",
-                            fuel.limit
-                        ),
-                        span,
-                    });
-                }
+                None => return Err(step_budget_error(fuel.limit, span)),
             }
         }
         Ok(())
@@ -899,10 +921,61 @@ evaluation depth."
         }
     }
 
+    fn eval_interpolated(
+        &mut self,
+        parts: &[StringPart],
+        env: &Env,
+        span: Span,
+    ) -> Result<Value, RunError> {
+        let mut out = String::new();
+        for part in parts {
+            match part {
+                StringPart::Text(text) => {
+                    self.charge(text.len() as u64, span)?;
+                    out.push_str(text);
+                }
+                StringPart::Expr(part) => match self.eval(part, env)? {
+                    Value::String(text) => {
+                        self.charge(text.len() as u64, span)?;
+                        out.push_str(&text);
+                    }
+                    value => {
+                        self.append_interpolated_value(&mut out, &value, span)?;
+                    }
+                },
+            }
+        }
+        Ok(Value::String(Rc::from(out)))
+    }
+
+    fn append_interpolated_value(
+        &mut self,
+        out: &mut String,
+        value: &Value,
+        span: Span,
+    ) -> Result<(), RunError> {
+        let Some(fuel) = self.fuel else {
+            // Writing directly avoids the extra allocation that `to_string`
+            // would impose on every unbudgeted game-loop interpolation.
+            write!(out, "{value}").expect("writing to a String cannot fail");
+            return Ok(());
+        };
+        let mut writer = FuelWriter {
+            out,
+            remaining: fuel.remaining,
+        };
+        if write!(&mut writer, "{value}").is_err() {
+            return Err(step_budget_error(fuel.limit, span));
+        }
+        self.fuel.as_mut().expect("fuel was present").remaining = writer.remaining;
+        Ok(())
+    }
+
     fn eval_inner(&mut self, expr: &Expr, env: &Env) -> Result<Value, RunError> {
         match &expr.kind {
             ExprKind::Number(n) => Ok(Value::Number(*n)),
             ExprKind::String(s) => Ok(Value::String(Rc::from(s.as_str()))),
+            ExprKind::InterpolatedString(parts) => self.eval_interpolated(parts, env, expr.span),
             ExprKind::Bool(b) => Ok(Value::Bool(*b)),
             ExprKind::Local { binding, name } => {
                 let value = env.lookup(*binding).ok_or_else(|| RunError {
@@ -2594,7 +2667,8 @@ pub fn render_trace(events: &[TraceEvent]) -> String {
 
 #[cfg(test)]
 mod deep_value_tests {
-    use super::{value_eq, Span, Value};
+    use super::{value_eq, FuelWriter, Span, Value};
+    use std::fmt::Write;
     use std::rc::Rc;
 
     /// A list nested `depth` levels: `[[…[0]…]]`.
@@ -2631,6 +2705,19 @@ mod deep_value_tests {
             .expect("spawn small-stack worker")
             .join()
             .expect("deep display/eq must complete on a small stack");
+    }
+
+    #[test]
+    fn fuel_writer_stops_structural_rendering_at_its_byte_limit() {
+        let shared = Value::String(Rc::from("x".repeat(1024)));
+        let value = Value::List(Rc::new(vec![shared; 100]));
+        let mut out = String::new();
+        let mut writer = FuelWriter {
+            out: &mut out,
+            remaining: 32,
+        };
+        assert!(write!(&mut writer, "{value}").is_err());
+        assert!(out.len() <= 32, "rendered {} bytes past the cap", out.len());
     }
 }
 

--- a/functor-lang/src/goto.rs
+++ b/functor-lang/src/goto.rs
@@ -301,6 +301,12 @@ mod tests {
     }
 
     #[test]
+    fn interpolation_reference_resolves_to_the_parameter() {
+        let src = r#"let f = (score: float): string => $"score: {score}""#;
+        assert_eq!(def_at(src, "score}\""), Some("score: float"));
+    }
+
+    #[test]
     fn let_reference_resolves_to_the_binder_region() {
         let src = "let f = (x) => let y = x in y + 1.0";
         assert_eq!(def_at(src, "y +"), Some("let y = "));

--- a/functor-lang/src/hover.rs
+++ b/functor-lang/src/hover.rs
@@ -154,6 +154,13 @@ pub(crate) fn children(expr: &Expr) -> Vec<&Expr> {
             items.iter().chain(std::iter::once(tail.as_ref())).collect()
         }
         ExprKind::Tuple(items) => items.iter().collect(),
+        ExprKind::InterpolatedString(parts) => parts
+            .iter()
+            .filter_map(|part| match part {
+                crate::ir::StringPart::Text(_) => None,
+                crate::ir::StringPart::Expr(expr) => Some(expr),
+            })
+            .collect(),
         ExprKind::FieldAccess { object, .. } => vec![object],
         ExprKind::Call { callee, args } => std::iter::once(callee.as_ref())
             .chain(args.iter())
@@ -232,6 +239,16 @@ mod tests {
     #[test]
     fn hover_on_a_local_reference_shows_the_inferred_type() {
         let text = hover_at("let f = (score: float): bool => score > 1.0", "score >").unwrap();
+        assert_eq!(text, "score : float");
+    }
+
+    #[test]
+    fn hover_walks_interpolation_holes() {
+        let text = hover_at(
+            r#"let f = (score: float): string => $"score: {score}""#,
+            "score}\"",
+        )
+        .unwrap();
         assert_eq!(text, "score : float");
     }
 

--- a/functor-lang/src/ir.rs
+++ b/functor-lang/src/ir.rs
@@ -139,6 +139,9 @@ pub struct Expr {
 pub enum ExprKind {
     Number(f64),
     String(String),
+    /// `$"score: {score}"`, retaining expression nodes so interpolation
+    /// participates in checking, tooling, tracing, and hot reload normally.
+    InterpolatedString(Vec<StringPart>),
     Bool(bool),
     /// Reference to an enclosing lambda's parameter. `name` duplicates the
     /// binding's name for readability; `binding` is authoritative.
@@ -248,6 +251,12 @@ pub enum ExprKind {
         scrutinee: Box<Expr>,
         arms: Vec<MatchArm>,
     },
+}
+
+#[derive(Debug)]
+pub enum StringPart {
+    Text(String),
+    Expr(Expr),
 }
 
 /// One lowered `| pattern => body` arm. Pattern variables are bindings

--- a/functor-lang/src/lexer.rs
+++ b/functor-lang/src/lexer.rs
@@ -9,6 +9,11 @@ use crate::ParseError;
 pub enum TokenKind {
     Number(f64),
     Str(String),
+    InterpolatedStart,
+    InterpolatedText(String),
+    InterpolatedOpen,
+    InterpolatedClose,
+    InterpolatedEnd,
     Ident(String),
     /// A type variable in type position: `'a`, `'msg`. Stored WITH the leading
     /// apostrophe, so the string is exactly the source spelling.
@@ -65,6 +70,11 @@ pub fn describe(kind: &TokenKind) -> String {
     match kind {
         Number(n) => format!("number `{n}`"),
         Str(_) => "a string".to_string(),
+        InterpolatedStart => "an interpolated string".to_string(),
+        InterpolatedText(_) => "interpolated string text".to_string(),
+        InterpolatedOpen => "`{` in an interpolated string".to_string(),
+        InterpolatedClose => "`}` in an interpolated string".to_string(),
+        InterpolatedEnd => "the end of an interpolated string".to_string(),
         Ident(name) => format!("`{name}`"),
         TypeVar(name) => format!("`{name}`"),
         Let => "`let`".to_string(),
@@ -114,11 +124,30 @@ pub fn describe(kind: &TokenKind) -> String {
 /// file as well as its position; `functor_lang::project::SourceMap` renders them.
 /// Single-file callers pass 0.
 pub fn lex(src: &str, base: usize) -> Result<Vec<Token>, ParseError> {
+    lex_with_interpolation_depth(src, base, 0)
+}
+
+// Keep recursive interpolation scanning within the parser's nesting budget:
+// machine-generated source must fail as a diagnostic, never a host overflow.
+const MAX_INTERPOLATION_DEPTH: usize = 76;
+
+fn lex_with_interpolation_depth(
+    src: &str,
+    base: usize,
+    interpolation_depth: usize,
+) -> Result<Vec<Token>, ParseError> {
     let bytes = src.as_bytes();
     let mut tokens = Vec::new();
     let mut i = 0;
     while i < bytes.len() {
         let start = i;
+        if bytes[i] == b'$' && bytes.get(i + 1) == Some(&b'"') {
+            let (mut interpolation, next) =
+                lex_interpolated_string(src, i, base, interpolation_depth + 1)?;
+            tokens.append(&mut interpolation);
+            i = next;
+            continue;
+        }
         let kind = match bytes[i] {
             b' ' | b'\t' | b'\r' | b'\n' => {
                 i += 1;
@@ -335,24 +364,9 @@ fn lex_string(src: &str, start: usize, base: usize) -> Result<(TokenKind, usize)
                 return Ok((TokenKind::Str(s), i + 1));
             }
             Some(b'\\') => {
-                let escaped = match bytes.get(i + 1) {
-                    Some(b'"') => b'"',
-                    Some(b'\\') => b'\\',
-                    Some(b'n') => b'\n',
-                    Some(b't') => b'\t',
-                    _ => {
-                        // Size the span by the escaped char's UTF-8 width so
-                        // it stays sliceable (spans must be char-boundary
-                        // aligned); a `\` at end of input spans just itself.
-                        let escaped_len = src[i + 1..].chars().next().map_or(0, char::len_utf8);
-                        return Err(ParseError {
-                            message: "unknown escape sequence".to_string(),
-                            span: Span::new(base + i, base + i + 1 + escaped_len),
-                        });
-                    }
-                };
+                let (escaped, next) = lex_escape(src, i, base)?;
                 out.push(escaped);
-                i += 2;
+                i = next;
             }
             Some(&b) => {
                 out.push(b);
@@ -360,4 +374,218 @@ fn lex_string(src: &str, start: usize, base: usize) -> Result<(TokenKind, usize)
             }
         }
     }
+}
+
+/// Lex an F#-style interpolated string (`$"hello {name}"`). Interpolation
+/// holes are lexed recursively as ordinary Functor expressions; dedicated
+/// boundary tokens let the parser consume exactly one expression per hole.
+/// `{{` and `}}` are literal braces in the surrounding text.
+fn lex_interpolated_string(
+    src: &str,
+    start: usize,
+    base: usize,
+    depth: usize,
+) -> Result<(Vec<Token>, usize), ParseError> {
+    if depth > MAX_INTERPOLATION_DEPTH {
+        return Err(ParseError {
+            message: "interpolation nested too deeply".to_string(),
+            span: Span::new(base + start, base + start + 2),
+        });
+    }
+    let bytes = src.as_bytes();
+    let mut tokens = vec![Token {
+        kind: TokenKind::InterpolatedStart,
+        span: Span::new(base + start, base + start + 2),
+    }];
+    let mut text = Vec::new();
+    let mut text_start = start + 2;
+    let mut i = text_start;
+
+    loop {
+        match bytes.get(i) {
+            None => {
+                return Err(ParseError {
+                    message: "unterminated interpolated string".to_string(),
+                    span: Span::new(base + start, base + start + 2),
+                })
+            }
+            Some(b'"') => {
+                push_interpolated_text(&mut tokens, &mut text, text_start, i, base);
+                tokens.push(Token {
+                    kind: TokenKind::InterpolatedEnd,
+                    span: Span::new(base + i, base + i + 1),
+                });
+                return Ok((tokens, i + 1));
+            }
+            Some(b'{') if bytes.get(i + 1) == Some(&b'{') => {
+                text.push(b'{');
+                i += 2;
+            }
+            Some(b'}') if bytes.get(i + 1) == Some(&b'}') => {
+                text.push(b'}');
+                i += 2;
+            }
+            Some(b'{') => {
+                push_interpolated_text(&mut tokens, &mut text, text_start, i, base);
+                tokens.push(Token {
+                    kind: TokenKind::InterpolatedOpen,
+                    span: Span::new(base + i, base + i + 1),
+                });
+                let close = find_interpolation_close(src, i + 1, base, i, depth)?;
+                let mut hole_tokens =
+                    lex_with_interpolation_depth(&src[i + 1..close], base + i + 1, depth)?;
+                hole_tokens.pop(); // the containing interpolation is the delimiter
+                tokens.append(&mut hole_tokens);
+                tokens.push(Token {
+                    kind: TokenKind::InterpolatedClose,
+                    span: Span::new(base + close, base + close + 1),
+                });
+                i = close + 1;
+                text_start = i;
+            }
+            Some(b'}') => {
+                return Err(ParseError {
+                    message:
+                        "unmatched `}` in interpolated string (write `}}` for a literal brace)"
+                            .to_string(),
+                    span: Span::new(base + i, base + i + 1),
+                })
+            }
+            Some(b'\\') => {
+                let (escaped, next) = lex_escape(src, i, base)?;
+                text.push(escaped);
+                i = next;
+            }
+            Some(&b) => {
+                text.push(b);
+                i += 1;
+            }
+        }
+    }
+}
+
+fn lex_escape(src: &str, slash: usize, base: usize) -> Result<(u8, usize), ParseError> {
+    let escaped = match src.as_bytes().get(slash + 1) {
+        Some(b'"') => b'"',
+        Some(b'\\') => b'\\',
+        Some(b'n') => b'\n',
+        Some(b't') => b'\t',
+        _ => {
+            // Size the span by the escaped char's UTF-8 width so it stays
+            // sliceable; a trailing `\` spans just itself.
+            let escaped_len = src[slash + 1..].chars().next().map_or(0, char::len_utf8);
+            return Err(ParseError {
+                message: "unknown escape sequence".to_string(),
+                span: Span::new(base + slash, base + slash + 1 + escaped_len),
+            });
+        }
+    };
+    Ok((escaped, slash + 2))
+}
+
+fn push_interpolated_text(
+    tokens: &mut Vec<Token>,
+    text: &mut Vec<u8>,
+    start: usize,
+    end: usize,
+    base: usize,
+) {
+    if text.is_empty() {
+        return;
+    }
+    let value = String::from_utf8(std::mem::take(text))
+        .expect("interpolated string contents are valid UTF-8");
+    tokens.push(Token {
+        kind: TokenKind::InterpolatedText(value),
+        span: Span::new(base + start, base + end),
+    });
+}
+
+/// Find the `}` ending one interpolation hole, ignoring balanced record
+/// braces, comments, quoted strings, and nested interpolated strings.
+fn find_interpolation_close(
+    src: &str,
+    mut i: usize,
+    base: usize,
+    opening: usize,
+    depth: usize,
+) -> Result<usize, ParseError> {
+    let bytes = src.as_bytes();
+    let mut braces = 0usize;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'/' if bytes.get(i + 1) == Some(&b'/') => {
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+            }
+            b'$' if bytes.get(i + 1) == Some(&b'"') => {
+                i = scan_interpolated_string(src, i, base, depth + 1)?;
+            }
+            b'"' => {
+                let (_, next) = lex_string(src, i, base)?;
+                i = next;
+            }
+            b'{' => {
+                braces += 1;
+                i += 1;
+            }
+            b'}' if braces == 0 => return Ok(i),
+            b'}' => {
+                braces -= 1;
+                i += 1;
+            }
+            _ => {
+                let c = src[i..].chars().next().expect("scan is on a char boundary");
+                i += c.len_utf8();
+            }
+        }
+    }
+    Err(ParseError {
+        message: "unterminated interpolation hole".to_string(),
+        span: Span::new(base + opening, base + opening + 1),
+    })
+}
+
+fn scan_interpolated_string(
+    src: &str,
+    start: usize,
+    base: usize,
+    depth: usize,
+) -> Result<usize, ParseError> {
+    if depth > MAX_INTERPOLATION_DEPTH {
+        return Err(ParseError {
+            message: "interpolation nested too deeply".to_string(),
+            span: Span::new(base + start, base + start + 2),
+        });
+    }
+    let bytes = src.as_bytes();
+    let mut i = start + 2;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'"' => return Ok(i + 1),
+            b'\\' => i += if i + 1 < bytes.len() { 2 } else { 1 },
+            b'{' if bytes.get(i + 1) == Some(&b'{') => i += 2,
+            b'}' if bytes.get(i + 1) == Some(&b'}') => i += 2,
+            b'{' => {
+                i = find_interpolation_close(src, i + 1, base, i, depth)? + 1;
+            }
+            b'}' => {
+                return Err(ParseError {
+                    message:
+                        "unmatched `}` in interpolated string (write `}}` for a literal brace)"
+                            .to_string(),
+                    span: Span::new(base + i, base + i + 1),
+                })
+            }
+            _ => {
+                let c = src[i..].chars().next().expect("scan is on a char boundary");
+                i += c.len_utf8();
+            }
+        }
+    }
+    Err(ParseError {
+        message: "unterminated interpolated string".to_string(),
+        span: Span::new(base + start, base + start + 2),
+    })
 }

--- a/functor-lang/src/lower.rs
+++ b/functor-lang/src/lower.rs
@@ -661,6 +661,16 @@ impl Lowerer<'_> {
             }
             ast::ExprKind::Number(n) => ExprKind::Number(n),
             ast::ExprKind::String(s) => ExprKind::String(s),
+            ast::ExprKind::InterpolatedString(parts) => {
+                let mut lowered = Vec::with_capacity(parts.len());
+                for part in parts {
+                    lowered.push(match part {
+                        ast::StringPart::Text(text) => StringPart::Text(text),
+                        ast::StringPart::Expr(expr) => StringPart::Expr(self.expr(expr)?),
+                    });
+                }
+                ExprKind::InterpolatedString(lowered)
+            }
             ast::ExprKind::Bool(b) => ExprKind::Bool(b),
             ast::ExprKind::Record(fields) => {
                 let mut lowered: Vec<Field> = Vec::new();

--- a/functor-lang/src/parser.rs
+++ b/functor-lang/src/parser.rs
@@ -30,8 +30,9 @@
 //! mul       := unary (("*" | "/") unary)*           (left-assoc)
 //! unary     := "-" unary | postfix
 //! postfix   := primary ("(" expr,* ")" | "." ident)*
-//! primary   := number | string | "true" | "false" | qualifiedIdent
+//! primary   := number | string | interpolatedString | "true" | "false" | qualifiedIdent
 //!            | record | list | tuple | lambda | "(" expr ")"
+//! interpolatedString := '$"' (text | "{{" | "}}" | "{" expr "}")* '"'
 //! tuple     := "(" expr ("," expr)+ ","? ")"
 //! record    := "{" (ident ":" expr),* "}"
 //!            | "{" expr "with" (ident ":" expr),+ "}"
@@ -1182,6 +1183,7 @@ and an `else` branch)",
                     span,
                 })
             }
+            TokenKind::InterpolatedStart => self.interpolated_string(),
             TokenKind::True => {
                 self.bump();
                 Ok(Expr {
@@ -1207,6 +1209,40 @@ and an `else` branch)",
                 }
             }
             _ => self.error("an expression"),
+        }
+    }
+
+    fn interpolated_string(&mut self) -> Result<Expr, ParseError> {
+        let open = self.bump();
+        let mut parts = Vec::new();
+        loop {
+            match self.peek_kind() {
+                TokenKind::InterpolatedText(text) => {
+                    let text = text.clone();
+                    self.bump();
+                    parts.push(StringPart::Text(text));
+                }
+                TokenKind::InterpolatedOpen => {
+                    self.bump();
+                    let expr = self.expr()?;
+                    self.expect(
+                        TokenKind::InterpolatedClose,
+                        "`}` after interpolation expression",
+                    )?;
+                    parts.push(StringPart::Expr(expr));
+                }
+                TokenKind::InterpolatedEnd => {
+                    let close = self.bump();
+                    return Ok(Expr {
+                        kind: ExprKind::InterpolatedString(parts),
+                        span: open.span.to(close.span),
+                    });
+                }
+                _ => {
+                    return self
+                        .error("interpolated string text, an interpolation expression, or `\"`")
+                }
+            }
         }
     }
 

--- a/functor-lang/src/rebind.rs
+++ b/functor-lang/src/rebind.rs
@@ -460,6 +460,13 @@ fn collect(expr: &Expr, def: &str, path: &mut Vec<String>, index: &mut ModuleInd
                 seg(item, format!("({i})"), path, index);
             }
         }
+        ExprKind::InterpolatedString(parts) => {
+            for (i, part) in parts.iter().enumerate() {
+                if let crate::ir::StringPart::Expr(expr) = part {
+                    seg(expr, format!("{{{i}}}"), path, index);
+                }
+            }
+        }
         ExprKind::Call { callee, args } => {
             seg(callee, "callee".to_string(), path, index);
             for (i, arg) in args.iter().enumerate() {
@@ -606,6 +613,13 @@ pub(crate) fn each_child<'a>(expr: &'a Expr, f: &mut impl FnMut(&'a Expr)) {
         ExprKind::Tuple(items) => {
             for item in items {
                 f(item);
+            }
+        }
+        ExprKind::InterpolatedString(parts) => {
+            for part in parts {
+                if let crate::ir::StringPart::Expr(expr) = part {
+                    f(expr);
+                }
             }
         }
         ExprKind::Let { value, body, .. } => {

--- a/functor-lang/src/types.rs
+++ b/functor-lang/src/types.rs
@@ -73,7 +73,9 @@
 
 use crate::ast::{BinOp, TypeBody, TypeName};
 use crate::eval::{builtin, callee_label, Builtin};
-use crate::ir::{BindingId, Expr, ExprId, ExprKind, Field, MatchArm, Module, Pattern, PatternKind};
+use crate::ir::{
+    BindingId, Expr, ExprId, ExprKind, Field, MatchArm, Module, Pattern, PatternKind, StringPart,
+};
 use crate::span::Span;
 use crate::CheckError;
 use std::collections::HashMap;
@@ -664,6 +666,7 @@ fn check_impl(
                 }
                 ExprKind::Number(_) => Type::Float,
                 ExprKind::String(_) => Type::String,
+                ExprKind::InterpolatedString(_) => Type::String,
                 ExprKind::Bool(_) => Type::Bool,
                 _ => checker.fresh(),
             },
@@ -1500,6 +1503,14 @@ missing {missing}. Did you forget an argument?"
                 Type::Tuple(items.iter().map(|item| self.infer(item)).collect())
             }
             ExprKind::String(_) => Type::String,
+            ExprKind::InterpolatedString(parts) => {
+                for part in parts {
+                    if let StringPart::Expr(part) = part {
+                        self.infer(part);
+                    }
+                }
+                Type::String
+            }
             ExprKind::Bool(_) => Type::Bool,
             ExprKind::Local { binding, .. } => self
                 .locals

--- a/functor-lang/tests/check.rs
+++ b/functor-lang/tests/check.rs
@@ -31,6 +31,16 @@ fn assert_clean(src: &str) {
     assert!(diags.is_empty(), "expected no diagnostics, got {diags:?}");
 }
 
+#[test]
+fn interpolation_is_string_and_checks_every_hole() {
+    assert_clean(
+        r#"let label: string = $"value: {if true then 1.0 else 2.0}; data: {[true, false]}""#,
+    );
+    let (message, line, col) = single_diag(r#"let label = $"bad: {1.0 + "x"}""#);
+    assert_eq!(message, "`+` needs float operands, got string");
+    assert_eq!((line, col), (1, 27));
+}
+
 /// The `functor-lang check` diagnostics for `examples/checks/broken.fun`, compared
 /// against the committed `broken.check` golden (rendered exactly as the CLI
 /// prints them). Regenerate with `UPDATE_GOLDENS=1 cargo test -p functor-lang`.

--- a/functor-lang/tests/expects.rs
+++ b/functor-lang/tests/expects.rs
@@ -256,6 +256,19 @@ fn text_join_doubling_cannot_amplify_past_the_budget() {
 }
 
 #[test]
+fn string_interpolation_doubling_cannot_amplify_past_the_budget() {
+    let src = r#"
+let grow = (s, _) => $"{s}{s}"
+expect List.fold(grow, "x", List.range(26.0)) == ""
+"#;
+    let out = budgeted(src, 10_000);
+    let ExpectOutcome::Error(err) = &out[0].outcome else {
+        panic!("expected interpolation growth to exceed the budget");
+    };
+    assert!(err.message.contains("step budget"), "unexpected: {err:?}");
+}
+
+#[test]
 fn container_construction_is_charged() {
     // The depth-amplifier probe: a fold whose body is a NESTED LITERAL adds
     // ~5 levels of value depth per single call charge — under per-call-only

--- a/functor-lang/tests/parser.rs
+++ b/functor-lang/tests/parser.rs
@@ -102,6 +102,75 @@ fn error_unterminated_string() {
 }
 
 #[test]
+fn interpolated_string_parses_text_and_full_expression_holes() {
+    let src = r#"let label = $"score: {1.0 + 2.0}; {{ready}}""#;
+    let program = functor_lang::parse(src).expect("source should parse");
+    let Item::Let(binding) = &program.items[0] else {
+        panic!("expected a let binding");
+    };
+    let ExprKind::InterpolatedString(parts) = &binding.value.kind else {
+        panic!("expected an interpolated string");
+    };
+    assert_eq!(parts.len(), 3);
+    assert!(matches!(
+        &parts[0],
+        functor_lang::ast::StringPart::Text(text) if text == "score: "
+    ));
+    assert!(matches!(
+        &parts[1],
+        functor_lang::ast::StringPart::Expr(expr)
+            if matches!(expr.kind, ExprKind::Binary { .. })
+    ));
+    assert!(matches!(
+        &parts[2],
+        functor_lang::ast::StringPart::Text(text) if text == "; {ready}"
+    ));
+    assert_eq!(
+        &src[binding.value.span.start..binding.value.span.end],
+        &src[12..]
+    );
+}
+
+#[test]
+fn interpolation_errors_are_targeted_and_spanned() {
+    assert_eq!(
+        parse_err(r#"let s = $"hello {name"#),
+        ("unterminated interpolation hole".to_string(), 1, 17)
+    );
+    assert_eq!(
+        parse_err(r#"let s = $"hello }""#),
+        (
+            "unmatched `}` in interpolated string (write `}}` for a literal brace)".to_string(),
+            1,
+            17
+        )
+    );
+    assert_eq!(
+        parse_err(r#"let s = $"hello {}""#),
+        (
+            "expected an expression, found `}` in an interpolated string".to_string(),
+            1,
+            18
+        )
+    );
+}
+
+#[test]
+fn deeply_nested_interpolation_is_a_clean_error() {
+    let depth = 1000;
+    let mut src = String::from("let s = ");
+    for _ in 0..depth {
+        src.push_str("$\"{");
+    }
+    src.push_str("\"x\"");
+    for _ in 0..depth {
+        src.push_str("}\"");
+    }
+    let (message, _, _) = parse_err(&src);
+    assert_eq!(message, "interpolation nested too deeply");
+}
+
+#[test]
 fn error_record_field_missing_colon() {
     assert_eq!(
         parse_err("let p = { x: 1.0, y }"),

--- a/functor-lang/tests/run.rs
+++ b/functor-lang/tests/run.rs
@@ -44,6 +44,49 @@ fn main_result(src: &str) -> String {
     }
 }
 
+#[test]
+fn string_interpolation_renders_values_and_literal_braces() {
+    assert_eq!(
+        main_result(
+            r#"
+type Status = | Ready
+let main = () =>
+  let point = { x: 2.0, y: 3.0 } in
+  $"name: {"Ada"}; score: {1.0 + 2.0}; active: {true}; point: {point}; status: {Ready}; {{ok}}"
+"#
+        ),
+        r#""name: Ada; score: 3; active: true; point: { x: 2, y: 3 }; status: Ready; {ok}""#
+    );
+}
+
+#[test]
+fn string_interpolation_supports_nested_strings_and_structural_braces() {
+    assert_eq!(
+        main_result(
+            r#"
+let main = () =>
+  let n = 4.0 in
+  $"outer {$"inner {n}"} / {{ {({ value: n }).value} }}"
+"#
+        ),
+        r#""outer inner 4 / { 4 }""#
+    );
+}
+
+#[test]
+fn string_interpolation_evaluates_holes_left_to_right() {
+    assert_eq!(
+        main_result(
+            r#"
+let main = () =>
+  let mut n = 0.0 in
+  $"{n := n + 1.0; n}{n := n + 1.0; n}"
+"#
+        ),
+        r#""12""#
+    );
+}
+
 /// The `functor-lang run` / `functor-lang trace` output for `examples/{name}.fun`, compared
 /// against the committed `{name}.run` / `{name}.trace` golden.
 /// Regenerate with `UPDATE_GOLDENS=1 cargo test -p functor-lang`.

--- a/site/src/docs.js
+++ b/site/src/docs.js
@@ -20,15 +20,14 @@ const KEYWORDS = new Set([
 ]);
 const ATOMS = new Set(["true", "false"]);
 
-const TOKEN =
-  /\/\/[^\n]*|"(?:[^"\\]|\\.)*"?|\d+(?:\.\d+)?|[A-Za-z_][A-Za-z0-9_]*|\|>|=>|:=|&&|\|\||[+\-*/<>=|]/g;
+const CODE_TOKEN =
+  /^(?:\d+(?:\.\d+)?|[A-Za-z_][A-Za-z0-9_]*|\|>|=>|:=|&&|\|\||[+\-*/<>=|])/;
 
 const escapeHtml = (s) =>
   s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 
 const classify = (token) => {
   if (token.startsWith("//")) return "tok-c";
-  if (token.startsWith('"')) return "tok-s";
   if (/^\d/.test(token)) return "tok-n";
   if (/^[A-Z]/.test(token)) return "tok-t";
   if (KEYWORDS.has(token)) return "tok-k";
@@ -39,15 +38,84 @@ const classify = (token) => {
 
 const highlight = (source) => {
   let html = "";
-  let last = 0;
-  for (const match of source.matchAll(TOKEN)) {
-    html += escapeHtml(source.slice(last, match.index));
-    const cls = classify(match[0]);
-    const text = escapeHtml(match[0]);
-    html += cls ? `<span class="${cls}">${text}</span>` : text;
-    last = match.index + match[0].length;
+  const contexts = [];
+  let i = 0;
+  const emit = (text, cls = null) => {
+    const escaped = escapeHtml(text);
+    html += cls ? `<span class="${cls}">${escaped}</span>` : escaped;
+  };
+  const emitString = () => {
+    const start = i++;
+    while (i < source.length) {
+      if (source[i] === "\\") i += Math.min(2, source.length - i);
+      else if (source[i++] === '"') break;
+    }
+    emit(source.slice(start, i), "tok-s");
+  };
+
+  while (i < source.length) {
+    const context = contexts.at(-1);
+    if (context?.kind === "interpolated") {
+      const start = i;
+      if (source.startsWith("{{", i) || source.startsWith("}}", i)) i += 2;
+      else if (source[i] === "\\") i += Math.min(2, source.length - i);
+      else if (source[i] === '"') {
+        i += 1;
+        contexts.pop();
+      } else if (source[i] === "{") {
+        emit("{", "tok-o");
+        i += 1;
+        contexts.push({ kind: "hole", braces: 0 });
+        continue;
+      } else if (source[i] === "}") {
+        // Invalid language input still needs a progress-safe preview; the
+        // parser will report that a literal brace must be written as `}}`.
+        i += 1;
+      } else {
+        while (i < source.length && !/["\\{}]/.test(source[i])) i += 1;
+      }
+      emit(source.slice(start, i), "tok-s");
+      continue;
+    }
+    if (source.startsWith("//", i)) {
+      const end = source.indexOf("\n", i);
+      const next = end === -1 ? source.length : end;
+      emit(source.slice(i, next), "tok-c");
+      i = next;
+      continue;
+    }
+    if (source.startsWith('$"', i)) {
+      emit('$"', "tok-s");
+      i += 2;
+      contexts.push({ kind: "interpolated" });
+      continue;
+    }
+    if (source[i] === '"') {
+      emitString();
+      continue;
+    }
+    if (context?.kind === "hole" && source[i] === "{") {
+      context.braces += 1;
+      emit(source[i++], "tok-o");
+      continue;
+    }
+    if (context?.kind === "hole" && source[i] === "}") {
+      if (context.braces === 0) contexts.pop();
+      else context.braces -= 1;
+      emit(source[i++], "tok-o");
+      continue;
+    }
+    const match = source.slice(i).match(CODE_TOKEN);
+    if (match) {
+      const cls = classify(match[0]);
+      const text = escapeHtml(match[0]);
+      html += cls ? `<span class="${cls}">${text}</span>` : text;
+      i += match[0].length;
+      continue;
+    }
+    emit(source[i++]);
   }
-  return html + escapeHtml(source.slice(last));
+  return html;
 };
 
 const toBase64Url = (s) =>

--- a/site/src/functor-lang.js
+++ b/site/src/functor-lang.js
@@ -23,13 +23,70 @@ const ATOMS = new Set(["true", "false"]);
 
 export const functorLangLanguage = StreamLanguage.define({
   name: "functor-lang",
-  token(stream) {
+  startState: () => ({ contexts: [] }),
+  copyState: (state) => ({
+    contexts: state.contexts.map((context) => ({ ...context })),
+  }),
+  token(stream, state) {
+    const context = state.contexts.at(-1);
+    if (context?.kind === "interpolated") {
+      if (stream.match('\\"') || stream.match("\\\\") || stream.match("\\n") || stream.match("\\t")) {
+        return "string";
+      }
+      if (stream.match("{{") || stream.match("}}")) return "string";
+      if (stream.match('"')) {
+        state.contexts.pop();
+        return "string";
+      }
+      if (stream.match("{")) {
+        state.contexts.push({ kind: "hole", braces: 0 });
+        return "bracket";
+      }
+      while (!stream.eol() && !/["\\{}]/.test(stream.peek())) stream.next();
+      if (stream.pos === stream.start) stream.next();
+      return "string";
+    }
+    if (context?.kind === "string") {
+      while (!stream.eol()) {
+        if (stream.next() === "\\") stream.next();
+        else if (stream.current().endsWith('"')) {
+          state.contexts.pop();
+          break;
+        }
+      }
+      return "string";
+    }
     if (stream.eatSpace()) return null;
     if (stream.match("//")) {
       stream.skipToEnd();
       return "comment";
     }
-    if (stream.match(/^"(?:[^"\\]|\\.)*"?/)) return "string";
+    if (stream.match('$"')) {
+      state.contexts.push({ kind: "interpolated" });
+      return "string";
+    }
+    if (stream.match('"')) {
+      state.contexts.push({ kind: "string" });
+      while (!stream.eol()) {
+        if (stream.next() === "\\") stream.next();
+        else if (stream.current().endsWith('"')) {
+          state.contexts.pop();
+          break;
+        }
+      }
+      return "string";
+    }
+    if (context?.kind === "hole") {
+      if (stream.match("{")) {
+        context.braces += 1;
+        return "bracket";
+      }
+      if (stream.match("}")) {
+        if (context.braces === 0) state.contexts.pop();
+        else context.braces -= 1;
+        return "bracket";
+      }
+    }
     if (stream.match(/^\d+(\.\d+)?/)) return "number";
     // Uppercase head: constructors and prelude namespaces (Scene, Math, …).
     if (stream.match(/^[A-Z][A-Za-z0-9_]*/)) return "typeName";

--- a/tools/functor-lang-vscode/syntaxes/functor-lang.tmLanguage.json
+++ b/tools/functor-lang-vscode/syntaxes/functor-lang.tmLanguage.json
@@ -3,17 +3,7 @@
   "name": "Functor Lang",
   "scopeName": "source.functor",
   "patterns": [
-    { "include": "#comment" },
-    { "include": "#string" },
-    { "include": "#keyword" },
-    { "include": "#boolean" },
-    { "include": "#number" },
-    { "include": "#type-variable" },
-    { "include": "#primitive-type" },
-    { "include": "#qualified-name" },
-    { "include": "#type-name" },
-    { "include": "#operator" },
-    { "include": "#punctuation" }
+    { "include": "#expression" }
   ],
   "repository": {
     "comment": {
@@ -39,6 +29,73 @@
           "name": "invalid.illegal.unknown-escape.functor",
           "match": "\\\\."
         }
+      ]
+    },
+    "interpolated-string": {
+      "name": "string.quoted.double.interpolated.functor",
+      "begin": "\\$\"",
+      "end": "\"",
+      "beginCaptures": {
+        "0": { "name": "punctuation.definition.string.begin.functor" }
+      },
+      "endCaptures": {
+        "0": { "name": "punctuation.definition.string.end.functor" }
+      },
+      "patterns": [
+        {
+          "name": "constant.character.escape.functor",
+          "match": "\\\\[\\\\\"nt]|\\{\\{|\\}\\}"
+        },
+        { "include": "#interpolation-hole" },
+        {
+          "name": "invalid.illegal.unknown-escape.functor",
+          "match": "\\\\."
+        }
+      ]
+    },
+    "interpolation-hole": {
+      "begin": "(?<!\\{)\\{(?!\\{)",
+      "end": "\\}",
+      "contentName": "meta.embedded.expression.functor",
+      "beginCaptures": {
+        "0": { "name": "punctuation.section.interpolation.begin.functor" }
+      },
+      "endCaptures": {
+        "0": { "name": "punctuation.section.interpolation.end.functor" }
+      },
+      "patterns": [
+        { "include": "#nested-braces" },
+        { "include": "#expression" }
+      ]
+    },
+    "nested-braces": {
+      "begin": "\\{",
+      "end": "\\}",
+      "beginCaptures": {
+        "0": { "name": "punctuation.section.braces.begin.functor" }
+      },
+      "endCaptures": {
+        "0": { "name": "punctuation.section.braces.end.functor" }
+      },
+      "patterns": [
+        { "include": "#nested-braces" },
+        { "include": "#expression" }
+      ]
+    },
+    "expression": {
+      "patterns": [
+        { "include": "#comment" },
+        { "include": "#interpolated-string" },
+        { "include": "#string" },
+        { "include": "#keyword" },
+        { "include": "#boolean" },
+        { "include": "#number" },
+        { "include": "#type-variable" },
+        { "include": "#primitive-type" },
+        { "include": "#qualified-name" },
+        { "include": "#type-name" },
+        { "include": "#operator" },
+        { "include": "#punctuation" }
       ]
     },
     "keyword": {


### PR DESCRIPTION
## Summary

- add F#-style `$"score: {score}"` literals with full Functor expressions in each hole
- evaluate holes left-to-right; insert strings raw and render other values with the canonical deterministic `Value` display
- support nested interpolation, existing string escapes, and `{{` / `}}` literal braces with targeted parse diagnostics and a nesting bound
- carry interpolation expressions through lowering, typechecking, coverage/navigation/completion, hot-reload rebinding, and dependency analysis
- highlight hole expressions correctly in VS Code, the site CodeMirror editor, and static docs code blocks
- document the syntax in the Functor Lang skill and roadmap

Restacked onto current `main` at `7cfcc75`.

## Safety and resource bounds

Interpolation output consumes the existing tooling evaluation budget. Composite values render through a fuel-limited `fmt::Write` sink, so a structurally large/shared value cannot allocate its full textual form before the budget rejects it. Pathological nested templates fail with `interpolation nested too deeply` rather than overflowing the host stack.

## Verification

- `RUSTC_WRAPPER= cargo test -q -p functor-lang -p functor-cli` — 599 tests passed after restack
- focused parser, nested-template, left-to-right evaluation, completion/hover/goto, and budget-amplification tests
- `npm run site:build`
- CodeMirror and static-doc tokenizer probes for nested interpolation, record braces, and invalid unmatched-brace progress
- TextMate grammar JSON validation
- `git diff --check`

No visual media is needed: this adds tokenizer support, but no checked-in site page or example currently contains an interpolated literal, so the rendered site has no before/after visual change.

## Frame benchmark

Release `frame_bench`, preserved parent binary vs this branch, three runs each on the same machine. Allocations and bytes are the acceptance signal and are exactly unchanged. Wall-clock minima were load-noisy but show no regression.

| Grid | Parent min (µs/frame) | Branch min (µs/frame) | Allocs/frame (both) | Bytes/frame (both) |
| --- | ---: | ---: | ---: | ---: |
| 20x20 | 785.6 | 711.4 | 13,877 | 842,251 |
| 40x40 | 3,468.3 | 3,078.9 | 54,717 | 3,306,091 |
| 56x56 | 7,259.8 | 5,243.7 | 106,973 | 6,459,115 |

## Review disposition

- **Fixed (High):** composite values were initially formatted before charging their output bytes; formatting now writes through the fuel-limited sink and has a direct cap test.
- **Fixed (Medium):** interpolation holes initially lacked VS Code/site syntax highlighting; all three tokenizers now distinguish string text from hole expressions.
- **Fixed (Medium):** CodeMirror state snapshots shallow-copied mutable hole depth; `copyState` now clones each context.
- **Fixed (Medium):** invalid lone `}` text could stall the static docs tokenizer; it now always consumes and styles the byte.
- **Claude Opus 4.8 restack re-review:** no P0/P1 correctness or simplicity defects. It noted three P2 test-coverage gaps: braces inside quoted strings in a hole, braces hidden by a `//` comment, and adjacent `{{{x}}}` runs. All three paths were judged correct by inspection.
- **Independent Codex restack review:** no actionable findings.
- Duplicate prevention reused canonical `Value::Display` and lexer escape/string helpers. The prior final token scan found no new actionable clone; the one introduced TextMate pattern-list clone was removed by routing both contexts through `#expression`.
