### PR TITLE
feat(vr): expose sampled Quest controller input

### DIFF
--- a/.claude/skills/vr-device-loop/SKILL.md
+++ b/.claude/skills/vr-device-loop/SKILL.md
@@ -21,8 +21,11 @@ VR debug APIs isomorphic. Read `runtime/functor-runtime-oculus/README.md` and
 - Keep the canonical debug routes and wire types in
   `functor-runtime-common`; desktop reports `main`, Quest reports `left` and
   `right` through the same `views` field.
-- Treat source and assets separately. `/reload-project` transfers `.fun`/`.funi`
-  source; it does not currently transfer texture, model, or audio files.
+- Treat source and assets as separate coordinated operations.
+  `/load-project`/`/reload-project` transfer `.fun`/`.funi`; changed
+  texture/model/audio bytes use `/reload-asset`, and `/sync-assets` finalizes
+  the current manifest and removes deleted uploads. `functor run vr`
+  orchestrates both streams.
 - Use release APKs for performance claims. Verify Android does not report the
   installed package as `DEBUGGABLE`.
 
@@ -74,7 +77,7 @@ Prefer the integrated loop:
 ```
 
 It launches, forwards port 8123, pushes the whole project, watches `.fun`/`.funi`
-files, and streams logs. For individual operations:
+and asset files, and streams logs. For individual operations:
 
 ```sh
 adb -s SERIAL forward tcp:8123 tcp:8123
@@ -87,6 +90,12 @@ Use the TypeScript SDK for scripted `/input`, `/time`, reload, rewind, and
 multi-client assertions. Validate clock behavior by observing a stable frame
 after `set`, exactly one increment after `advance`, and progression after
 `resume`.
+
+For controller work, inspect `/state.input.xr` only after two advancing frame
+samples. Require a near-identity rig-local head pose after centering; wake each
+controller and verify `active`, independently valid grip/aim poses, analog
+range/motion, and button transitions. Never accept a retained pose after a
+controller becomes inactive or tracking validity is lost.
 
 ## Capture both raw eyes
 

--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -76,7 +76,7 @@ screenshot run has no reason to grab your mouse.
 | Method & path | Purpose |
 | --- | --- |
 | `POST /capture` | PNG (`image/png`) of the next rendered frame |
-| `GET /state` | runtime state JSON: `frame`, `tts`, combined/legacy `viewport`, `views` (`main` on desktop; `left` + `right` on Quest), `input` (structured `held_keys` + `mouse`), `model` (Rust `Debug` text) |
+| `GET /state` | runtime state JSON: `frame`, `tts`, combined/legacy `viewport`, `views` (`main` on desktop; `left` + `right` on Quest), `input` (structured `held_keys` + `mouse` + optional typed device domains), `model` (Rust `Debug` text) |
 | `GET /scene` | current frame as JSON: `camera` + `scene` + `lights` |
 | `GET /trace` | paused-inspector trace: the last real frame's entry-point invocations plus a synthesized `draw` pass, replayed while paused. Each site (binders AND variable reads, `site`) carries the full `value`, a depth-limited `preview`, and `kind` (primitive/composite — the editor's inline-vs-hover policy); `{ "paused": false, "invocations": [] }` while playing. Paused docs also carry `coverage` (per-file span starts with the frame OFFSETS they executed on, over a ±120-frame journal ring — positive offsets appear when scrubbed behind the live head) and `runnable` (the static could-run set) — the recency gutter's data |
 | `POST /input` | inject input (see below) |
@@ -107,6 +107,63 @@ frame's `ui(model)` tree, in construction order over the interactive widgets.
 An event for a slot the current view doesn't have is dropped (with a one-line
 runtime report), and the endpoint still returns 200 — delivery, not handling,
 is what's acknowledged.
+
+### Sampled input in `GET /state`
+
+`input` is runtime-owned data sampled for one simulation frame. Keyboard and
+mouse keep their existing event entry points; continuously sampled devices add
+typed sibling domains to the same record. Quest currently adds `xr` while head
+tracking is valid:
+
+```jsonc
+{
+  "held_keys": [],
+  "mouse": { "x": 0, "y": 0 },
+  "xr": {
+    "head": {
+      "position": [0.0, 0.0, 0.0],
+      "orientation": [0.0, 0.0, 0.0, 1.0]
+    },
+    "left": {
+      "active": true,
+      "grip": { "position": [-0.2, -0.3, -0.4], "orientation": [0, 0, 0, 1] },
+      "aim": { "position": [-0.2, -0.3, -0.4], "orientation": [0, 0, 0, 1] },
+      "trigger": 0.0,
+      "squeeze": 0.0,
+      "thumbstick": [0.0, 0.0],
+      "primary_pressed": false,
+      "secondary_pressed": false,
+      "thumbstick_pressed": false,
+      "menu_pressed": false
+    },
+    "right": {
+      "active": false,
+      "grip": null,
+      "aim": null,
+      "trigger": 0.0,
+      "squeeze": 0.0,
+      "thumbstick": [0.0, 0.0],
+      "primary_pressed": false,
+      "secondary_pressed": false,
+      "thumbstick_pressed": false,
+      "menu_pressed": false
+    }
+  }
+}
+```
+
+Tracked poses use OpenXR's rig-local convention: +X right, +Y up, -Z forward;
+quaternions are `[x, y, z, w]`. Head and controller poses are relative to the
+same center-eye reference that anchors the authored `Frame.camera`, so a game
+can map them through the camera from the same model update without mixing
+tracking-space coordinates into portable game state. `active` means an input
+source is available for that hand. Grip and aim are independently nullable
+because buttons can remain available during a temporary pose-tracking loss.
+Analog values are normalized to `0..1`; thumbstick axes to `-1..1`.
+
+Non-XR runtimes omit `xr`, preserving the previous desktop JSON shape. Future
+gamepad and mobile-touch support should add typed sibling fields rather than
+target-specific endpoints or string-keyed capability bags.
 
 ### `POST /time` — frame-loop control
 
@@ -202,6 +259,7 @@ point at either `http://127.0.0.1:8077` (desktop) or the adb-forwarded
   `--debug-port`, networked via `Sub.connect`/`Sub.listen`; pin all clocks and step
   them in lockstep, injecting input and observing state per client. This is the
   out-of-process counterpart to the in-process `functor-netsim` harness.
-- **Richer observation.** `/state.input` now reports held keys + mouse as structured
-  JSON (game-agnostic, runtime-owned). Still open: a parseable snapshot of the game
-  *model* itself (today `Debug` text — the model isn't `Serialize`).
+- **Richer observation.** `/state.input` reports held keys, mouse, and optional
+  typed sampled-device domains as game-agnostic runtime data. Still open: a
+  parseable snapshot of the game *model* itself (today `Debug` text — the model
+  isn't `Serialize`).

--- a/docs/vr.md
+++ b/docs/vr.md
@@ -23,7 +23,8 @@ games deploy over the network.
 | [#437](https://github.com/tommy-xr/functor/pull/437) | Exact asymmetric OpenXR projections, fixing binocular double vision | merged; Quest 3 verified |
 | [#438](https://github.com/tommy-xr/functor/pull/438) | Shared desktop/Quest debug protocol, whole-project REPL, raw stereo capture, TypeScript SDK parity, device benchmark | merged; Quest 3 verified |
 | [#453](https://github.com/tommy-xr/functor/pull/453) | Compose live OpenXR head/eye tracking onto the authored `Frame.camera` rig | merged; Quest 3 verified |
-| [#460](https://github.com/tommy-xr/functor/pull/460) | Push project `.glb` models, textures, and sounds through the shared debug protocol; initialize the first pushed project from `init` | draft; Quest 3 verified with synthwave textures + animated Xbot |
+| [#460](https://github.com/tommy-xr/functor/pull/460) | Push project `.glb` models, textures, and sounds through the shared debug protocol; initialize the first pushed project from `init` | merged; Quest 3 verified with synthwave textures + animated Xbot |
+| current | Sample Quest Touch grip/aim poses, analog controls, and buttons into the shared typed input snapshot | in progress; Quest 3 + debug/SDK verified |
 
 ## Working today on the Xreal One
 
@@ -87,14 +88,23 @@ torn frames and 3.09 ms mean application time.
 The authored-camera release verification sustained 72 FPS minimum in two
 30-second `primitives` runs (3.31–3.36 ms mean application time). A
 source/geometry-heavy `synthwave` run also held 72 FPS minimum with zero stale
-or torn frames. Project texture/model synchronization is now verified on Quest
-3 with the textured synthwave scene and the animated `Xbot.glb` example; a
-release performance pass over those asset-heavy scenes is still outstanding.
+or torn frames. Project texture/model synchronization is verified on Quest 3
+with the textured synthwave scene and the animated `Xbot.glb` example. Matched
+30-second release runs held 72 FPS minimum: synthwave used 1.66 ms mean
+application time and animation used 3.95 ms. The few VrApi `Stale` samples
+occurred despite ample application/GPU headroom and zero torn frames,
+consistent with occasional compositor reuse rather than missed application
+deadlines.
+
+With Touch action sampling enabled, a matched synthwave release rerun held 72
+FPS p5/min with 0.78 ms mean application time and zero stale/torn frames.
 
 ## After bring-up (in rough order)
 
-- Controllers + a VR `InputContext` (head/hands) with desktop mouse/keyboard
-  emulation, shock2quest-style, so VR games iterate without a headset.
+- Finish the sampled-input split: expose the typed XR snapshot to Functor Lang,
+  then add desktop emulation and a controller-driven example. Keep gamepad and
+  mobile-touch input as typed sibling domains rather than XR-specific producer
+  APIs.
 - Add the Android audio host; sound bytes already synchronize, but Quest
   currently drains playback commands.
 - Add a browser surface over the isomorphic debug API for edit/push/inspect/

--- a/docs/vr.md
+++ b/docs/vr.md
@@ -24,7 +24,7 @@ games deploy over the network.
 | [#438](https://github.com/tommy-xr/functor/pull/438) | Shared desktop/Quest debug protocol, whole-project REPL, raw stereo capture, TypeScript SDK parity, device benchmark | merged; Quest 3 verified |
 | [#453](https://github.com/tommy-xr/functor/pull/453) | Compose live OpenXR head/eye tracking onto the authored `Frame.camera` rig | merged; Quest 3 verified |
 | [#460](https://github.com/tommy-xr/functor/pull/460) | Push project `.glb` models, textures, and sounds through the shared debug protocol; initialize the first pushed project from `init` | merged; Quest 3 verified with synthwave textures + animated Xbot |
-| current | Sample Quest Touch grip/aim poses, analog controls, and buttons into the shared typed input snapshot | in progress; Quest 3 + debug/SDK verified |
+| [#463](https://github.com/tommy-xr/functor/pull/463) | Sample Quest Touch grip/aim poses, analog controls, and buttons into the shared typed input snapshot | ready; Quest 3 + debug/SDK verified |
 
 ## Working today on the Xreal One
 

--- a/runtime/functor-runtime-common/src/camera.rs
+++ b/runtime/functor-runtime-common/src/camera.rs
@@ -7,7 +7,7 @@ use crate::math::Angle;
 ///
 /// The orientation is a unit quaternion in `[x, y, z, w]` order. Tracking
 /// local `+X` is right, `+Y` is up, and `-Z` is forward, matching OpenXR.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub struct TrackingPose {
     pub position: [f32; 3],
     pub orientation: [f32; 4],
@@ -42,6 +42,17 @@ impl TrackingPose {
         Some(Self::from_parts(position, orientation))
     }
 
+    /// Express `self` relative to a tracking-space reference pose.
+    ///
+    /// The result is target-neutral rig-local data: its origin/orientation are
+    /// the reference center eye, with OpenXR's +X right, +Y up, -Z forward
+    /// convention. Controller snapshots use this form so games can map poses
+    /// through the authored camera that belongs to the same model update.
+    pub fn relative_to(self, reference: Self) -> Option<Self> {
+        let (position, orientation) = Self::relative_parts(reference, self)?;
+        Some(Self::from_parts(position, orientation))
+    }
+
     fn position_vector(self) -> Option<Vector3<f32>> {
         self.position
             .iter()
@@ -71,6 +82,17 @@ impl TrackingPose {
                 orientation.s,
             ],
         }
+    }
+
+    fn relative_parts(reference: Self, tracked: Self) -> Option<(Vector3<f32>, Quaternion<f32>)> {
+        let reference_position = reference.position_vector()?;
+        let tracked_position = tracked.position_vector()?;
+        let inverse_reference = reference.unit_orientation()?.conjugate();
+        let tracked_orientation = tracked.unit_orientation()?;
+        Some((
+            inverse_reference.rotate_vector(tracked_position - reference_position),
+            inverse_reference * tracked_orientation,
+        ))
     }
 }
 
@@ -204,14 +226,7 @@ impl Camera {
         let backward = -forward;
         let to_world = |v: Vector3<f32>| right * v.x + up * v.y + backward * v.z;
 
-        let reference_position = reference.position_vector()?;
-        let tracked_position = tracked.position_vector()?;
-        let reference_orientation = reference.unit_orientation()?;
-        let tracked_orientation = tracked.unit_orientation()?;
-        let inverse_reference = reference_orientation.conjugate();
-
-        let local_offset = inverse_reference.rotate_vector(tracked_position - reference_position);
-        let local_orientation = inverse_reference * tracked_orientation;
+        let (local_offset, local_orientation) = TrackingPose::relative_parts(reference, tracked)?;
         let world_position = eye + to_world(local_offset);
         let world_forward =
             to_world(local_orientation.rotate_vector(-Vector3::unit_z())).normalize();
@@ -560,6 +575,35 @@ mod tests {
         let expected = Vector3::new(yaw.sin(), 0.0, yaw.cos());
 
         assert!(got.dot(expected) > 0.9999, "forward = {got:?}");
+    }
+
+    #[test]
+    fn tracking_pose_can_be_normalized_to_the_rig_reference() {
+        use cgmath::Rotation3;
+
+        let half_turn_y = Quaternion::from_angle_y(Rad(std::f32::consts::PI));
+        let pose = |position, orientation: Quaternion<f32>| {
+            TrackingPose::new(
+                position,
+                [
+                    orientation.v.x,
+                    orientation.v.y,
+                    orientation.v.z,
+                    orientation.s,
+                ],
+            )
+        };
+        let reference = pose([10.0, 2.0, 4.0], half_turn_y);
+        // World -X from a 180-degree-yaw reference is rig-local +X.
+        let tracked = pose([9.0, 2.5, 4.0], half_turn_y);
+        let relative = tracked.relative_to(reference).unwrap();
+        assert!(approx(relative.position[0], 1.0));
+        assert!(approx(relative.position[1], 0.5));
+        assert!(approx(relative.position[2], 0.0));
+        assert!(approx(relative.orientation[0], 0.0));
+        assert!(approx(relative.orientation[1], 0.0));
+        assert!(approx(relative.orientation[2], 0.0));
+        assert!(approx(relative.orientation[3].abs(), 1.0));
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/debug_protocol.rs
+++ b/runtime/functor-runtime-common/src/debug_protocol.rs
@@ -10,7 +10,7 @@ use std::sync::mpsc::Sender;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{ui::UiEventKind, Key};
+use crate::{ui::UiEventKind, InputSnapshot};
 
 /// Stable name returned by the discovery endpoint on every runtime target.
 pub const DEBUG_PROTOCOL_SERVICE: &str = "functor debug runtime";
@@ -65,7 +65,7 @@ pub const DEBUG_ROUTES: &[DebugRoute] = &[
     DebugRoute {
         method: "GET",
         path: "/state",
-        description: "runtime state JSON: frame, tts, viewport, views, input (held_keys + mouse), model (Debug text)",
+        description: "runtime state JSON: frame, tts, viewport, views, input snapshot (held_keys + mouse + optional xr), model (Debug text)",
     },
     DebugRoute {
         method: "GET",
@@ -164,20 +164,6 @@ impl RuntimeView {
     }
 }
 
-/// Runtime-owned input state, independent of the game model.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct RuntimeInput {
-    pub held_keys: Vec<Key>,
-    pub mouse: RuntimeMouse,
-}
-
-/// Last known pointer position in output pixels.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct RuntimeMouse {
-    pub x: i32,
-    pub y: i32,
-}
-
 /// Snapshot returned by `GET /state`.
 ///
 /// `viewport`, `input`, and `model` retain the desktop wire shape. `views` is
@@ -190,7 +176,7 @@ pub struct RuntimeState {
     pub viewport: RuntimeViewport,
     pub views: Vec<RuntimeView>,
     pub model: String,
-    pub input: RuntimeInput,
+    pub input: InputSnapshot,
 }
 
 impl RuntimeState {
@@ -338,6 +324,7 @@ pub enum DebugRequest {
 mod tests {
     use std::collections::BTreeSet;
 
+    use crate::Key;
     use serde_json::{json, Value};
 
     use super::*;
@@ -350,9 +337,10 @@ mod tests {
             viewport: RuntimeViewport::new(1920, 1080),
             views: vec![RuntimeView::new("main", 1920, 1080)],
             model: "Model {\n  label: \"hello\"\n}".into(),
-            input: RuntimeInput {
+            input: InputSnapshot {
                 held_keys: vec![Key::W, Key::Up],
-                mouse: RuntimeMouse { x: 10, y: 20 },
+                mouse: crate::MouseSnapshot { x: 10, y: 20 },
+                xr: None,
             },
         };
 

--- a/runtime/functor-runtime-common/src/input.rs
+++ b/runtime/functor-runtime-common/src/input.rs
@@ -1,5 +1,68 @@
 use serde::{Deserialize, Serialize};
 
+use crate::TrackingPose;
+
+/// Runtime-owned input sampled for one simulation frame.
+///
+/// Keyboard and mouse retain their event entry points, while this plain-data
+/// snapshot is the extensible shell → producer seam for continuously sampled
+/// devices. XR is the first typed domain; gamepads and mobile touches can add
+/// sibling fields without turning device capabilities into stringly-typed
+/// maps or adding target-specific producer methods.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct InputSnapshot {
+    /// Keys currently held, in canonical discriminant order.
+    pub held_keys: Vec<Key>,
+    /// Last known mouse position in output pixels.
+    pub mouse: MouseSnapshot,
+    /// Live XR tracking/controller state when the target supplies it.
+    ///
+    /// Omitted rather than serialized as `null` on non-XR targets, preserving
+    /// the existing desktop `/state` wire shape.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub xr: Option<XrInputSnapshot>,
+}
+
+/// Last known mouse position in output pixels.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MouseSnapshot {
+    pub x: i32,
+    pub y: i32,
+}
+
+/// One frame of XR input in the tracking rig's local coordinates.
+///
+/// Poses are relative to the center-eye reference captured when the authored
+/// camera rig is established: +X right, +Y up, -Z forward. Keeping them
+/// rig-local lets a pure game map them through its current authored camera
+/// without a one-frame mismatch when locomotion moves that camera.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct XrInputSnapshot {
+    /// Center-eye pose relative to the rig reference.
+    pub head: Option<TrackingPose>,
+    pub left: XrControllerSnapshot,
+    pub right: XrControllerSnapshot,
+}
+
+/// Target-neutral state for one tracked XR controller.
+///
+/// `active` reports whether the runtime currently has an input source for the
+/// hand. Each pose is independently optional because OpenXR may have buttons
+/// while positional tracking is temporarily invalid.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct XrControllerSnapshot {
+    pub active: bool,
+    pub grip: Option<TrackingPose>,
+    pub aim: Option<TrackingPose>,
+    pub trigger: f32,
+    pub squeeze: f32,
+    pub thumbstick: [f32; 2],
+    pub primary_pressed: bool,
+    pub secondary_pressed: bool,
+    pub thumbstick_pressed: bool,
+    pub menu_pressed: bool,
+}
+
 /// Canonical key identifier shared across the F# <-> Rust boundary and all
 /// runtimes (desktop GLFW, web). Producers (e.g. the desktop runtime's
 /// `glfw::Key` mapping in `functor-runtime-desktop`) translate their platform
@@ -176,7 +239,8 @@ pub fn key_input_value(code: i32) -> Option<functor_lang::Value> {
 
 #[cfg(test)]
 mod tests {
-    use super::Key;
+    use super::{InputSnapshot, Key, MouseSnapshot, XrControllerSnapshot, XrInputSnapshot};
+    use crate::TrackingPose;
 
     #[test]
     fn names_are_canonical() {
@@ -250,5 +314,39 @@ mod tests {
         assert_eq!(Key::from_name("9"), Some(Key::Num9));
         assert_eq!(Key::from_name("unknown"), None);
         assert_eq!(Key::from_name(""), None);
+    }
+
+    #[test]
+    fn input_snapshot_omits_absent_xr_and_round_trips_present_xr() {
+        let desktop = InputSnapshot {
+            held_keys: vec![Key::W],
+            mouse: MouseSnapshot { x: 10, y: 20 },
+            xr: None,
+        };
+        let desktop_json = serde_json::to_value(&desktop).unwrap();
+        assert_eq!(
+            desktop_json,
+            serde_json::json!({
+                "held_keys": ["W"],
+                "mouse": { "x": 10, "y": 20 }
+            })
+        );
+
+        let xr = InputSnapshot {
+            xr: Some(XrInputSnapshot {
+                head: Some(TrackingPose::IDENTITY),
+                left: XrControllerSnapshot {
+                    active: true,
+                    trigger: 0.75,
+                    thumbstick: [-0.25, 1.0],
+                    primary_pressed: true,
+                    ..XrControllerSnapshot::default()
+                },
+                right: XrControllerSnapshot::default(),
+            }),
+            ..InputSnapshot::default()
+        };
+        let encoded = serde_json::to_string(&xr).unwrap();
+        assert_eq!(serde_json::from_str::<InputSnapshot>(&encoded).unwrap(), xr);
     }
 }

--- a/runtime/functor-runtime-desktop/src/debug_server.rs
+++ b/runtime/functor-runtime-desktop/src/debug_server.rs
@@ -6,9 +6,10 @@
 use std::sync::mpsc::Receiver;
 
 pub use functor_runtime_common::debug_protocol::{
-    CaptureError, DebugRequest, InputCommand, RuntimeInput, RuntimeMouse, RuntimeState, RuntimeView,
-    RuntimeViewport, TimeCommand,
+    CaptureError, DebugRequest, InputCommand, RuntimeState, RuntimeView, RuntimeViewport,
+    TimeCommand,
 };
+pub use functor_runtime_common::{InputSnapshot, MouseSnapshot};
 
 /// Start the debug server and return the frame loop's request receiver.
 ///

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -505,12 +505,13 @@ fn service_debug_request(
                 viewport: debug_server::RuntimeViewport::new(width, height),
                 views: vec![debug_server::RuntimeView::new("main", width, height)],
                 model: game.state_debug(),
-                input: debug_server::RuntimeInput {
+                input: debug_server::InputSnapshot {
                     held_keys: held_keys.iter().copied().collect(),
-                    mouse: debug_server::RuntimeMouse {
+                    mouse: debug_server::MouseSnapshot {
                         x: mouse_pos.0,
                         y: mouse_pos.1,
                     },
+                    xr: None,
                 },
             });
         }

--- a/runtime/functor-runtime-oculus/README.md
+++ b/runtime/functor-runtime-oculus/README.md
@@ -9,11 +9,12 @@ over the shared debug-runtime protocol.
 ## Status
 
 The OpenXR shell, interpreted Functor Lang producer, USB remote-develop loop,
-authored-camera rig, exact asymmetric per-eye projection, and project asset
-sync are implemented for Quest 3. The shared debug/REPL protocol adds raw
-stereo framebuffer capture and desktop-isomorphic control. Remaining device
-work includes controller/hand input, an Android audio host, and multiview
-rendering.
+authored-camera rig, exact asymmetric per-eye projection, project asset sync,
+and sampled Touch controller input are implemented for Quest 3. The shared
+debug/REPL protocol adds raw stereo framebuffer capture, rig-local
+head/controller inspection, and desktop-isomorphic control. Remaining input
+work is the Functor Lang surface, desktop emulation, and hand tracking;
+Android audio and multiview rendering are also still open.
 
 ## Camera contract
 
@@ -77,6 +78,15 @@ side-by-side PNG, before compositor warping. The server is reachable while the
 headset dozes, but capture correctly returns 503 until XR is rendering. After
 any adb reconnect, recreate the port forward; poll `/state` until `frame`
 advances before capture so cached paused state is not mistaken for readiness.
+
+While valid tracking is available, `/state.input.xr` contains center-head plus
+per-hand grip/aim poses, trigger, squeeze, thumbstick, primary/secondary,
+thumbstick-click, and menu state. Poses are relative to the same center-eye
+tracking reference that anchors `Frame.camera` (+X right, +Y up, -Z forward),
+not absolute stage coordinates. An inactive or untracked controller is
+represented explicitly instead of retaining a stale pose. This is the first
+half of the input slice: runtime/debug tooling can inspect it; the portable
+Functor Lang input record follows separately.
 
 ## Benchmark on the actual headset
 

--- a/runtime/functor-runtime-oculus/src/lib.rs
+++ b/runtime/functor-runtime-oculus/src/lib.rs
@@ -25,20 +25,21 @@
 //! fork predates the 0.18 release that shipped GLES/Android support),
 //! `android-activity` instead of the deprecated `ndk-glue`.
 
-use std::collections::{BTreeSet, HashSet};
+use std::collections::HashSet;
 use std::sync::{mpsc, Arc};
 use std::time::Instant;
 
 use android_activity::{AndroidApp, InputStatus, MainEvent, PollEvent};
 use functor_runtime_common::asset::AssetCache;
 use functor_runtime_common::debug_protocol::{
-    CaptureError, DebugRequest, InputCommand, RuntimeInput, RuntimeMouse, RuntimeState,
-    RuntimeView, RuntimeViewport, TimeCommand,
+    CaptureError, DebugRequest, InputCommand, RuntimeState, RuntimeView, RuntimeViewport,
+    TimeCommand,
 };
 use functor_runtime_common::functor_lang_game_embedded::{FunctorLangEmbeddedGame, NativePlatform};
 use functor_runtime_common::protocol::GameProducer;
 use functor_runtime_common::{
-    Frame, FrameTime, GameClock, Key, SceneContext, TrackingPose, Viewport,
+    Frame, FrameTime, GameClock, InputSnapshot, Key, SceneContext, TrackingPose, Viewport,
+    XrControllerSnapshot, XrInputSnapshot,
 };
 use khronos_egl as egl;
 use openxr as xr;
@@ -254,11 +255,261 @@ fn create_eye_target(
 }
 
 /// Convert OpenXR's pose layout into the shell-independent tracking pose used
-/// by the authored camera rig.
-fn tracking_pose_from_view(view: &xr::View) -> TrackingPose {
-    let p = view.pose.position;
-    let o = view.pose.orientation;
+/// by the authored camera rig and sampled controller input.
+fn tracking_pose(pose: xr::Posef) -> TrackingPose {
+    let p = pose.position;
+    let o = pose.orientation;
     TrackingPose::new([p.x, p.y, p.z], [o.x, o.y, o.z, o.w])
+}
+
+fn tracking_pose_from_view(view: &xr::View) -> TrackingPose {
+    tracking_pose(view.pose)
+}
+
+/// OpenXR action set backing the target-neutral sampled-input snapshot.
+///
+/// One action per logical control uses left/right subaction paths. That keeps
+/// the public snapshot symmetric and lets another OpenXR target bind the same
+/// controls without introducing Quest button names into the engine contract.
+struct XrActions {
+    action_set: xr::ActionSet,
+    left_path: xr::Path,
+    right_path: xr::Path,
+    grip: xr::Action<xr::Posef>,
+    aim: xr::Action<xr::Posef>,
+    trigger: xr::Action<f32>,
+    squeeze: xr::Action<f32>,
+    thumbstick: xr::Action<xr::Vector2f>,
+    primary: xr::Action<bool>,
+    secondary: xr::Action<bool>,
+    thumbstick_click: xr::Action<bool>,
+    menu: xr::Action<bool>,
+    left_grip_space: xr::Space,
+    right_grip_space: xr::Space,
+    left_aim_space: xr::Space,
+    right_aim_space: xr::Space,
+}
+
+impl XrActions {
+    fn create(instance: &xr::Instance, session: &xr::Session<xr::OpenGlEs>) -> Self {
+        let left_path = instance
+            .string_to_path("/user/hand/left")
+            .expect("left hand path");
+        let right_path = instance
+            .string_to_path("/user/hand/right")
+            .expect("right hand path");
+        let hands = [left_path, right_path];
+        let action_set = instance
+            .create_action_set("gameplay", "Gameplay input", 0)
+            .expect("create gameplay action set");
+        let grip = action_set
+            .create_action::<xr::Posef>("grip_pose", "Grip pose", &hands)
+            .expect("create grip action");
+        let aim = action_set
+            .create_action::<xr::Posef>("aim_pose", "Aim pose", &hands)
+            .expect("create aim action");
+        let trigger = action_set
+            .create_action::<f32>("trigger", "Trigger", &hands)
+            .expect("create trigger action");
+        let squeeze = action_set
+            .create_action::<f32>("squeeze", "Squeeze", &hands)
+            .expect("create squeeze action");
+        let thumbstick = action_set
+            .create_action::<xr::Vector2f>("thumbstick", "Thumbstick", &hands)
+            .expect("create thumbstick action");
+        let primary = action_set
+            .create_action::<bool>("primary", "Primary button", &hands)
+            .expect("create primary action");
+        let secondary = action_set
+            .create_action::<bool>("secondary", "Secondary button", &hands)
+            .expect("create secondary action");
+        let thumbstick_click = action_set
+            .create_action::<bool>("thumbstick_click", "Thumbstick click", &hands)
+            .expect("create thumbstick click action");
+        let menu = action_set
+            .create_action::<bool>("menu", "Menu button", &hands)
+            .expect("create menu action");
+
+        let path = |value: &str| instance.string_to_path(value).expect("OpenXR input path");
+        let touch_profile = path("/interaction_profiles/oculus/touch_controller");
+        instance
+            .suggest_interaction_profile_bindings(
+                touch_profile,
+                &[
+                    xr::Binding::new(&grip, path("/user/hand/left/input/grip/pose")),
+                    xr::Binding::new(&grip, path("/user/hand/right/input/grip/pose")),
+                    xr::Binding::new(&aim, path("/user/hand/left/input/aim/pose")),
+                    xr::Binding::new(&aim, path("/user/hand/right/input/aim/pose")),
+                    xr::Binding::new(&trigger, path("/user/hand/left/input/trigger/value")),
+                    xr::Binding::new(&trigger, path("/user/hand/right/input/trigger/value")),
+                    xr::Binding::new(&squeeze, path("/user/hand/left/input/squeeze/value")),
+                    xr::Binding::new(&squeeze, path("/user/hand/right/input/squeeze/value")),
+                    xr::Binding::new(&thumbstick, path("/user/hand/left/input/thumbstick")),
+                    xr::Binding::new(&thumbstick, path("/user/hand/right/input/thumbstick")),
+                    xr::Binding::new(&primary, path("/user/hand/left/input/x/click")),
+                    xr::Binding::new(&primary, path("/user/hand/right/input/a/click")),
+                    xr::Binding::new(&secondary, path("/user/hand/left/input/y/click")),
+                    xr::Binding::new(&secondary, path("/user/hand/right/input/b/click")),
+                    xr::Binding::new(
+                        &thumbstick_click,
+                        path("/user/hand/left/input/thumbstick/click"),
+                    ),
+                    xr::Binding::new(
+                        &thumbstick_click,
+                        path("/user/hand/right/input/thumbstick/click"),
+                    ),
+                    xr::Binding::new(&menu, path("/user/hand/left/input/menu/click")),
+                ],
+            )
+            .expect("suggest Touch controller bindings");
+
+        // Portable simple-controller fallback for non-Meta OpenXR runtimes.
+        // Analog controls remain inactive; fully tracked grip/aim poses plus
+        // select/menu still populate the same typed snapshot.
+        instance
+            .suggest_interaction_profile_bindings(
+                path("/interaction_profiles/khr/simple_controller"),
+                &[
+                    xr::Binding::new(&grip, path("/user/hand/left/input/grip/pose")),
+                    xr::Binding::new(&grip, path("/user/hand/right/input/grip/pose")),
+                    xr::Binding::new(&aim, path("/user/hand/left/input/aim/pose")),
+                    xr::Binding::new(&aim, path("/user/hand/right/input/aim/pose")),
+                    xr::Binding::new(&primary, path("/user/hand/left/input/select/click")),
+                    xr::Binding::new(&primary, path("/user/hand/right/input/select/click")),
+                    xr::Binding::new(&menu, path("/user/hand/left/input/menu/click")),
+                    xr::Binding::new(&menu, path("/user/hand/right/input/menu/click")),
+                ],
+            )
+            .expect("suggest simple controller bindings");
+
+        session
+            .attach_action_sets(&[&action_set])
+            .expect("attach gameplay action set");
+        let left_grip_space = grip
+            .create_space(session, left_path, xr::Posef::IDENTITY)
+            .expect("left grip space");
+        let right_grip_space = grip
+            .create_space(session, right_path, xr::Posef::IDENTITY)
+            .expect("right grip space");
+        let left_aim_space = aim
+            .create_space(session, left_path, xr::Posef::IDENTITY)
+            .expect("left aim space");
+        let right_aim_space = aim
+            .create_space(session, right_path, xr::Posef::IDENTITY)
+            .expect("right aim space");
+
+        Self {
+            action_set,
+            left_path,
+            right_path,
+            grip,
+            aim,
+            trigger,
+            squeeze,
+            thumbstick,
+            primary,
+            secondary,
+            thumbstick_click,
+            menu,
+            left_grip_space,
+            right_grip_space,
+            left_aim_space,
+            right_aim_space,
+        }
+    }
+
+    fn sample(
+        &self,
+        session: &xr::Session<xr::OpenGlEs>,
+        stage: &xr::Space,
+        time: xr::Time,
+        reference: TrackingPose,
+        head: TrackingPose,
+    ) -> XrInputSnapshot {
+        let controller = |path, grip_space: &xr::Space, aim_space: &xr::Space| {
+            let grip_active = self.grip.is_active(session, path).unwrap_or(false);
+            let aim_active = self.aim.is_active(session, path).unwrap_or(false);
+            let trigger = self.trigger.state(session, path).expect("trigger state");
+            let squeeze = self.squeeze.state(session, path).expect("squeeze state");
+            let thumbstick = self
+                .thumbstick
+                .state(session, path)
+                .expect("thumbstick state");
+            let primary = self.primary.state(session, path).expect("primary state");
+            let secondary = self
+                .secondary
+                .state(session, path)
+                .expect("secondary state");
+            let thumbstick_click = self
+                .thumbstick_click
+                .state(session, path)
+                .expect("thumbstick click state");
+            let menu = self.menu.state(session, path).expect("menu state");
+            let locate = |active: bool, space: &xr::Space| {
+                active
+                    .then(|| space.locate(stage, time).ok())
+                    .flatten()
+                    .filter(|location| {
+                        location
+                            .location_flags
+                            .contains(xr::SpaceLocationFlags::POSITION_VALID)
+                            && location
+                                .location_flags
+                                .contains(xr::SpaceLocationFlags::ORIENTATION_VALID)
+                            && location
+                                .location_flags
+                                .contains(xr::SpaceLocationFlags::POSITION_TRACKED)
+                            && location
+                                .location_flags
+                                .contains(xr::SpaceLocationFlags::ORIENTATION_TRACKED)
+                    })
+                    .and_then(|location| tracking_pose(location.pose).relative_to(reference))
+            };
+            XrControllerSnapshot {
+                active: grip_active
+                    || aim_active
+                    || trigger.is_active
+                    || squeeze.is_active
+                    || thumbstick.is_active
+                    || primary.is_active
+                    || secondary.is_active
+                    || thumbstick_click.is_active
+                    || menu.is_active,
+                grip: locate(grip_active, grip_space),
+                aim: locate(aim_active, aim_space),
+                trigger: trigger
+                    .is_active
+                    .then_some(trigger.current_state.clamp(0.0, 1.0))
+                    .unwrap_or(0.0),
+                squeeze: squeeze
+                    .is_active
+                    .then_some(squeeze.current_state.clamp(0.0, 1.0))
+                    .unwrap_or(0.0),
+                thumbstick: if thumbstick.is_active {
+                    [
+                        thumbstick.current_state.x.clamp(-1.0, 1.0),
+                        thumbstick.current_state.y.clamp(-1.0, 1.0),
+                    ]
+                } else {
+                    [0.0, 0.0]
+                },
+                primary_pressed: primary.is_active && primary.current_state,
+                secondary_pressed: secondary.is_active && secondary.current_state,
+                thumbstick_pressed: thumbstick_click.is_active && thumbstick_click.current_state,
+                menu_pressed: menu.is_active && menu.current_state,
+            }
+        };
+
+        XrInputSnapshot {
+            head: head.relative_to(reference),
+            left: controller(self.left_path, &self.left_grip_space, &self.left_aim_space),
+            right: controller(
+                self.right_path,
+                &self.right_grip_space,
+                &self.right_aim_space,
+            ),
+        }
+    }
 }
 
 /// Placeholder frame until the Functor Lang producer is wired (device bring-up): an
@@ -276,8 +527,7 @@ const RELOAD_PORT: u16 = 8123;
 #[derive(Default)]
 struct DebugLoopState {
     frame_count: u64,
-    held_keys: BTreeSet<Key>,
-    mouse: (i32, i32),
+    input: InputSnapshot,
     last_frame: Option<Frame>,
     pending_capture: Option<mpsc::Sender<Result<Vec<u8>, CaptureError>>>,
 }
@@ -334,13 +584,7 @@ fn service_debug_request(
                 viewport: RuntimeViewport::new(width, height),
                 views,
                 model: game.state_debug(),
-                input: RuntimeInput {
-                    held_keys: debug.held_keys.iter().copied().collect(),
-                    mouse: RuntimeMouse {
-                        x: debug.mouse.0,
-                        y: debug.mouse.1,
-                    },
-                },
+                input: debug.input.clone(),
             });
         }
         DebugRequest::Scene(response) => {
@@ -361,11 +605,20 @@ fn service_debug_request(
                 InputCommand::Key { key, down } => match Key::from_name(&key) {
                     Some(key) if down => {
                         game.key_event(key as i32, true);
-                        debug.held_keys.insert(key);
+                        if !debug.input.held_keys.contains(&key) {
+                            debug.input.held_keys.push(key);
+                            debug.input.held_keys.sort_unstable();
+                        }
                         Ok(())
                     }
                     Some(key) => {
-                        if debug.held_keys.remove(&key) {
+                        if let Some(index) = debug
+                            .input
+                            .held_keys
+                            .iter()
+                            .position(|candidate| *candidate == key)
+                        {
+                            debug.input.held_keys.remove(index);
                             game.key_event(key as i32, false);
                         }
                         Ok(())
@@ -373,7 +626,8 @@ fn service_debug_request(
                     None => Err(format!("unknown key: {key}")),
                 },
                 InputCommand::MouseMove { x, y } => {
-                    debug.mouse = (x, y);
+                    debug.input.mouse.x = x;
+                    debug.input.mouse.y = y;
                     game.mouse_move(x, y);
                     Ok(())
                 }
@@ -609,6 +863,7 @@ pub fn android_main(app: AndroidApp) {
                 )
             }
         };
+    let xr_actions = XrActions::create(&instance, &session);
 
     let view_config_views = instance
         .enumerate_view_configuration_views(system, xr::ViewConfigurationType::PRIMARY_STEREO)
@@ -659,6 +914,7 @@ pub fn android_main(app: AndroidApp) {
     let mut last_frame_at: Option<Instant> = None;
     let mut debug = DebugLoopState::default();
     let mut session_running = false;
+    let mut session_focused = false;
     // The first valid center-eye pose becomes the tracking origin for the
     // authored `Frame.camera`. It survives source reload and session doze so
     // model-driven locomotion and physical room-scale motion remain additive.
@@ -699,6 +955,7 @@ pub fn android_main(app: AndroidApp) {
             match event {
                 SessionStateChanged(e) => {
                     log::info!("session state: {:?}", e.state());
+                    session_focused = e.state() == xr::SessionState::FOCUSED;
                     match e.state() {
                         xr::SessionState::READY => {
                             session
@@ -716,6 +973,7 @@ pub fn android_main(app: AndroidApp) {
                             }
                             session.end().expect("session end");
                             session_running = false;
+                            session_focused = false;
                             last_frame_at = None;
                         }
                         xr::SessionState::EXITING | xr::SessionState::LOSS_PENDING => {
@@ -736,6 +994,9 @@ pub fn android_main(app: AndroidApp) {
         // Service debug requests before the XR session gate. Source reload,
         // state, trace, input, and time control remain useful while the headset
         // dozes; capture reports an honest 503 until rendering resumes.
+        if !session_running || !session_focused {
+            debug.input.xr = None;
+        }
         if let Some(rx) = &debug_rx {
             while let Ok(request) = rx.try_recv() {
                 service_debug_request(
@@ -758,25 +1019,10 @@ pub fn android_main(app: AndroidApp) {
 
         let xr_frame_state = frame_wait.wait().expect("frame wait");
         frame_stream.begin().expect("frame begin");
-
-        if !xr_frame_state.should_render {
-            // READY can remain true while the compositor temporarily declines
-            // pixels. Do not strand a request until the HTTP timeout (or make
-            // every retry report "already pending"); answer honestly now.
-            if let Some(response) = debug.pending_capture.take() {
-                let _ = response.send(Err(CaptureError::Unavailable(
-                    "capture is unavailable because the XR compositor declined rendering"
-                        .to_string(),
-                )));
-            }
-            frame_stream
-                .end(
-                    xr_frame_state.predicted_display_time,
-                    xr::EnvironmentBlendMode::OPAQUE,
-                    &[],
-                )
-                .expect("frame end (no render)");
-            continue;
+        if session_focused {
+            session
+                .sync_actions(&[(&xr_actions.action_set).into()])
+                .expect("sync gameplay actions");
         }
 
         if tracking_reference_reset_at.is_some_and(|change_time| {
@@ -796,6 +1042,7 @@ pub fn android_main(app: AndroidApp) {
         let tracking_valid = view_state.contains(xr::ViewStateFlags::POSITION_VALID)
             && view_state.contains(xr::ViewStateFlags::ORIENTATION_VALID);
         if !tracking_valid {
+            debug.input.xr = None;
             // OpenXR leaves the view poses undefined when either validity bit
             // is absent. Do not read those poses or submit them for compositor
             // reprojection; a mono authored-camera fallback would be actively
@@ -815,17 +1062,53 @@ pub fn android_main(app: AndroidApp) {
             last_frame_at = None;
             continue;
         }
+        let center_pose = views.first().and_then(|left| {
+            let left = tracking_pose_from_view(left);
+            views
+                .get(1)
+                .and_then(|right| TrackingPose::midpoint(left, tracking_pose_from_view(right)))
+                .or_else(|| TrackingPose::midpoint(left, left))
+        });
         if tracking_reference.is_none() {
-            tracking_reference = views.first().and_then(|left| {
-                let left = tracking_pose_from_view(left);
-                views
-                    .get(1)
-                    .and_then(|right| TrackingPose::midpoint(left, tracking_pose_from_view(right)))
-                    .or_else(|| TrackingPose::midpoint(left, left))
-            });
+            tracking_reference = center_pose;
             if tracking_reference.is_some() {
                 log::info!("camera rig centered: Frame.camera is the reference center-eye pose");
             }
+        }
+        debug.input.xr = session_focused
+            .then(|| {
+                tracking_reference
+                    .zip(center_pose)
+                    .map(|(reference, head)| {
+                        xr_actions.sample(
+                            &session,
+                            &stage,
+                            xr_frame_state.predicted_display_time,
+                            reference,
+                            head,
+                        )
+                    })
+            })
+            .flatten();
+
+        if !xr_frame_state.should_render {
+            // `should_render` controls layer submission, not tracking
+            // validity. Keep the freshly sampled input visible to `/state`
+            // while honestly declining a framebuffer capture.
+            if let Some(response) = debug.pending_capture.take() {
+                let _ = response.send(Err(CaptureError::Unavailable(
+                    "capture is unavailable because the XR compositor declined rendering"
+                        .to_string(),
+                )));
+            }
+            frame_stream
+                .end(
+                    xr_frame_state.predicted_display_time,
+                    xr::EnvironmentBlendMode::OPAQUE,
+                    &[],
+                )
+                .expect("frame end (no render)");
+            continue;
         }
 
         let now = Instant::now();

--- a/tools/functor-sdk/README.md
+++ b/tools/functor-sdk/README.md
@@ -29,9 +29,15 @@ await game.pause();              // pin the clock
 await game.keyDown("up");        // inject input
 await game.step();               // advance exactly one frame
 const state = await game.state();// observe the result
+const xr = await game.xrInput();  // rig-local head/controllers on XR targets
 const png = await game.capture();// PNG bytes of the frame
 // `await using` shuts the runtime down at scope exit.
 ```
+
+`state.input` is one extensible sampled-input record. It always carries held
+keys and the last mouse position; XR targets add typed rig-local head and
+controller state (`game.xrInput()`). Future gamepad and mobile-touch domains
+can extend the same record without target-specific clients.
 
 `FunctorRunner.connect(url)` attaches to an already-running runtime instead of
 spawning one (and won't kill it on dispose).

--- a/tools/functor-sdk/src/game.ts
+++ b/tools/functor-sdk/src/game.ts
@@ -7,6 +7,7 @@ import type {
   RuntimeState,
   Scene,
   WaitForOptions,
+  XrInputSnapshot,
 } from "./types.js";
 
 /** Default per-step delta time (seconds), ~one frame at 60 Hz. */
@@ -55,6 +56,12 @@ export class FunctorClient {
   async isKeyDown(key: KeyName): Promise<boolean> {
     const want = canonicalKeyName(key);
     return (await this.heldKeys()).some((k) => k === want);
+  }
+
+  /** Latest rig-local XR head/controller snapshot, or undefined on non-XR
+   * targets and while XR tracking is unavailable. */
+  async xrInput(): Promise<XrInputSnapshot | undefined> {
+    return (await this.state()).input.xr;
   }
 
   /** Capture the next rendered frame as PNG bytes. */

--- a/tools/functor-sdk/src/types.ts
+++ b/tools/functor-sdk/src/types.ts
@@ -6,12 +6,48 @@ export type KeyName =
   | "Up" | "Down" | "Left" | "Right" | "Space" | "Enter" | "Escape" | "Unknown"
   | (string & {});
 
-/** Runtime-owned input snapshot (independent of the game model). */
+export type Vec3 = [number, number, number];
+export type Quaternion = [x: number, y: number, z: number, w: number];
+
+/** A rig-local tracked pose: +X right, +Y up, -Z forward. */
+export interface TrackingPose {
+  position: Vec3;
+  orientation: Quaternion;
+}
+
+/** One target-neutral tracked XR controller. */
+export interface XrControllerSnapshot {
+  active: boolean;
+  grip: TrackingPose | null;
+  aim: TrackingPose | null;
+  trigger: number;
+  squeeze: number;
+  thumbstick: [x: number, y: number];
+  primary_pressed: boolean;
+  secondary_pressed: boolean;
+  thumbstick_pressed: boolean;
+  menu_pressed: boolean;
+}
+
+/** XR tracking and controllers sampled for one simulation frame. */
+export interface XrInputSnapshot {
+  head: TrackingPose | null;
+  left: XrControllerSnapshot;
+  right: XrControllerSnapshot;
+}
+
+/** Runtime-owned input sampled independently of the game model.
+ *
+ * Typed device domains extend this record: XR is available today; gamepad and
+ * mobile-touch snapshots can be added without replacing keyboard/mouse or
+ * introducing target-specific clients. */
 export interface InputSnapshot {
   /** Keys currently held, by canonical name. */
   held_keys: KeyName[];
   /** Last known cursor position in window pixels. */
   mouse: { x: number; y: number };
+  /** Present while an XR target has valid head tracking. */
+  xr?: XrInputSnapshot;
 }
 
 export interface RuntimeViewport {
@@ -38,8 +74,6 @@ export interface RuntimeState {
   input: InputSnapshot;
   model: string;
 }
-
-export type Vec3 = [number, number, number];
 
 /** Camera block from `GET /scene`. */
 export interface Camera {

--- a/tools/functor-sdk/test/unit.test.ts
+++ b/tools/functor-sdk/test/unit.test.ts
@@ -104,6 +104,52 @@ test("waitFor throws on timeout with the description", async () => {
   );
 });
 
+test("xrInput returns the typed optional input domain", async () => {
+  const xr = {
+    head: {
+      position: [0, 0, 0] as [number, number, number],
+      orientation: [0, 0, 0, 1] as [number, number, number, number],
+    },
+    left: {
+      active: true,
+      grip: null,
+      aim: null,
+      trigger: 0.5,
+      squeeze: 0,
+      thumbstick: [0, 1] as [number, number],
+      primary_pressed: true,
+      secondary_pressed: false,
+      thumbstick_pressed: false,
+      menu_pressed: false,
+    },
+    right: {
+      active: false,
+      grip: null,
+      aim: null,
+      trigger: 0,
+      squeeze: 0,
+      thumbstick: [0, 0] as [number, number],
+      primary_pressed: false,
+      secondary_pressed: false,
+      thumbstick_pressed: false,
+      menu_pressed: false,
+    },
+  };
+  const http = {
+    getJson: async () => ({
+      frame: 1,
+      tts: 0,
+      viewport: { width: 1, height: 1 },
+      views: [],
+      model: "{}",
+      input: { held_keys: [], mouse: { x: 0, y: 0 }, xr },
+    }),
+  } as unknown as HttpClient;
+  const client = new FunctorClient(http);
+
+  assert.deepEqual(await client.xrInput(), xr);
+});
+
 test("reloadAssets uploads binary envelopes then finalizes the manifest", async () => {
   const calls: Array<{ path: string; body: unknown }> = [];
   const http = {


### PR DESCRIPTION
## Summary

- add a shared, serializable `InputSnapshot` with an optional typed XR domain; future gamepad and mobile-touch support can add sibling domains without target-specific APIs
- sample Quest Touch grip/aim poses, trigger, squeeze, thumbsticks, buttons, and center-head pose through an OpenXR action set
- normalize poses to the same center-eye tracking reference used by the authored `Frame.camera`
- expose the snapshot through `/state` and the TypeScript SDK while preserving the existing desktop JSON shape
- clear XR data on focus/tracking loss and require actively tracked controller poses, preventing stuck controls or stale poses

This is deliberately the first half of the input slice: runtime/debug tooling can inspect controllers now. A follow-up will expose the portable snapshot to Functor Lang and add desktop emulation/controller-driven examples.

## Verification

- `cargo test -p functor_runtime_common`: 408 unit + 8 integration tests passed
- `npm test --prefix tools/functor-sdk`: 12 passed, 17 intentionally skipped
- `cargo check -p functor-runtime-desktop`: passed
- `npm run build:oculus`: passed after the final review fixes
- release `cargo apk build`: passed; installed package is not `DEBUGGABLE`
- release APK SHA-256: `a3b0e992e48fcce62c9cad827263f7f5bdba4b0339e73060855558043d6558f8`
- `git diff --check`: passed

Quest 3 live acceptance:

- both hands reported independently tracked grip + aim poses with real motion
- observed right trigger `0.19`, right squeeze `0.61`, left X, right A, both thumbsticks, and right stick-click transitions
- controllers becoming inactive cleared their poses instead of retaining stale values
- sending the app to Home cleared `input.xr` immediately while frames paused; resuming restored XR only after focus and advancing frames returned
- latest synthwave release benchmark: 72.621 FPS mean, 72 FPS p5/min, 0.779 ms mean App, 1.034 ms mean compositor, 0 stale, 0 torn

The shared host `frame_bench` retained exact allocation/byte parity with `origin/main` at every scene size:

| Objects | Allocs/frame | Bytes/frame |
| ---: | ---: | ---: |
| 400 | 13,877 | 843,379 |
| 1,600 | 54,717 | 3,307,219 |
| 3,136 | 106,973 | 6,460,243 |

Wall-clock results remained within the machine's observed run-to-run spread. The full desktop suite also retains an existing `main` failure in the Mario example assertion (`jumpVelocity` expects 12 while the example currently uses 13); this change does not touch it.

## Review

Cross-engine review is clean after fixes. Findings addressed:

- sample before the compositor `should_render` gate so valid tracking is not erased when pixels are skipped
- clear XR input while the session is unfocused
- require both valid and actively tracked controller position/orientation flags
- remove an unused producer hook that implied the Functor Lang half already existed
- describe the Khronos binding as a simple-controller fallback, not 3DoF

The debug protocol remains v2 because `xr` is an additive optional field: old clients ignore it and new clients accept its absence. Final focused reviews from both independent reviewers reported no actionable findings. Duplication prevention reused the existing shared input and camera-tracking abstractions; no actionable duplication was found.

No visual media is required: this changes sampled debug/SDK data, not rendered output.
