### PR TITLE
feat(input): emulate XR controllers on desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ functor -d examples/primitives run wasm
 ```
 
 `native` is the default environment, so `... run` is equivalent to `... run native`.
+XR games can use the Quest-isomorphic desktop adapter with
+`... run native --emulate-xr`; see [the VR guide](docs/vr.md#desktop-xr-emulation)
+for its mouse/keyboard controls and deterministic `--input-script` path.
 (These commands assume `functor` is on your `PATH`; when running from a source build,
 use `./target/release/functor` instead — see [DEVELOPMENT.md](DEVELOPMENT.md).)
 

--- a/docs/vr.md
+++ b/docs/vr.md
@@ -99,13 +99,32 @@ deadlines.
 With Touch action sampling enabled, a matched synthwave release rerun held 72
 FPS p5/min with 0.78 ms mean application time and zero stale/torn frames.
 
+## Desktop XR emulation
+
+Run a Functor Lang game with `--emulate-xr` to synthesize the same
+`Input.snapshot.xr` record that Quest supplies:
+
+```sh
+functor -d examples/my-xr-game run native --emulate-xr
+```
+
+The mouse moves the right controller over a rig-local plane; left-click or
+Space drives trigger, Enter drives squeeze, arrows drive the thumbstick, and
+1/2/3 drive primary, secondary, and thumbstick-click. Both controller poses and
+the identity head pose appear in `/state.input.xr`, including under
+`--headless`. An `--input-script` can therefore drive the same emulated
+controller levels for deterministic captures without adding a desktop-only
+game API. This is one shell adapter over the canonical snapshot; future
+gamepad/mobile adapters should produce that same target-neutral record.
+
 ## After bring-up (in rough order)
 
 - The typed XR snapshot is exposed to Functor Lang through the per-tick
   `sampledInput` hook and maps through the authored rig with
-  `Camera.mapTrackedPose`. Next, add desktop emulation and a controller-driven
-  example. Keep gamepad and mobile-touch input as typed sibling domains rather
-  than XR-specific producer APIs.
+  `Camera.mapTrackedPose`; desktop can synthesize the same record with
+  `--emulate-xr`. Next, add a controller-driven example. Keep gamepad and
+  mobile-touch input as typed sibling domains rather than XR-specific producer
+  APIs.
 - Add the Android audio host; sound bytes already synchronize, but Quest
   currently drains playback commands.
 - Add a browser surface over the isomorphic debug API for edit/push/inspect/

--- a/runtime/functor-runtime-desktop/src/debug_server.rs
+++ b/runtime/functor-runtime-desktop/src/debug_server.rs
@@ -9,8 +9,6 @@ pub use functor_runtime_common::debug_protocol::{
     CaptureError, DebugRequest, InputCommand, RuntimeState, RuntimeView, RuntimeViewport,
     TimeCommand,
 };
-pub use functor_runtime_common::{InputSnapshot, MouseSnapshot};
-
 /// Start the debug server and return the frame loop's request receiver.
 ///
 /// `127.0.0.1` keeps it local; `0.0.0.0` exposes it for remote development.

--- a/runtime/functor-runtime-desktop/src/desktop_xr_emulator.rs
+++ b/runtime/functor-runtime-desktop/src/desktop_xr_emulator.rs
@@ -1,0 +1,164 @@
+//! Opt-in mouse/keyboard adapter for exercising XR input on desktop.
+//!
+//! This is deliberately a shell adapter over the canonical
+//! [`functor_runtime_common::InputSnapshot`] protocol. Games consume the same
+//! `Input.snapshot` record as Quest; a future gamepad or mobile adapter can
+//! synthesize that record without changing Functor Lang.
+
+use std::collections::BTreeSet;
+
+use functor_runtime_common::{Key, TrackingPose, XrControllerSnapshot, XrInputSnapshot};
+
+const REFERENCE_SURFACE: (i32, i32) = (800, 600);
+
+pub fn reference_surface() -> (i32, i32) {
+    REFERENCE_SURFACE
+}
+
+pub fn centered_pointer(surface_size: (i32, i32)) -> (i32, i32) {
+    (surface_size.0 / 2, surface_size.1 / 2)
+}
+
+pub fn update_right_controls(
+    controller: &mut XrControllerSnapshot,
+    held_keys: &BTreeSet<Key>,
+    primary_down: bool,
+) {
+    let held = |key| held_keys.contains(&key);
+    let axis = |positive, negative| match (held(positive), held(negative)) {
+        (true, false) => 1.0,
+        (false, true) => -1.0,
+        _ => 0.0,
+    };
+
+    controller.trigger = if primary_down || held(Key::Space) {
+        1.0
+    } else {
+        0.0
+    };
+    controller.squeeze = if held(Key::Enter) { 1.0 } else { 0.0 };
+    controller.thumbstick = [axis(Key::Right, Key::Left), axis(Key::Up, Key::Down)];
+    controller.primary_pressed = held(Key::Num1);
+    controller.secondary_pressed = held(Key::Num2);
+    controller.thumbstick_pressed = held(Key::Num3);
+}
+
+/// Synthesize one rig-local XR sample.
+///
+/// The mouse moves the right controller over a plane in front of the head.
+/// Space/left-click = trigger, Enter = squeeze, arrows = thumbstick,
+/// 1/2 = primary/secondary, and 3 = thumbstick click.
+pub fn sample(
+    held_keys: &BTreeSet<Key>,
+    mouse_pos: (i32, i32),
+    primary_down: bool,
+    surface_size: (i32, i32),
+) -> XrInputSnapshot {
+    let width = surface_size.0.max(1) as f32;
+    let height = surface_size.1.max(1) as f32;
+    let normalized_x = ((mouse_pos.0 as f32 - width * 0.5) / (width * 0.5)).clamp(-1.0, 1.0);
+    let normalized_y = ((height * 0.5 - mouse_pos.1 as f32) / (height * 0.5)).clamp(-1.0, 1.0);
+    let pose = |position| Some(TrackingPose::new(position, [0.0, 0.0, 0.0, 1.0]));
+    let left_pose = pose([-0.24, -0.12, -0.55]);
+    let right_pose = pose([
+        0.24 + normalized_x * 0.28,
+        -0.12 + normalized_y * 0.22,
+        -0.55,
+    ]);
+    let mut right = XrControllerSnapshot {
+        active: true,
+        grip: right_pose,
+        aim: right_pose,
+        ..XrControllerSnapshot::default()
+    };
+    update_right_controls(&mut right, held_keys, primary_down);
+
+    XrInputSnapshot {
+        head: Some(TrackingPose::IDENTITY),
+        left: XrControllerSnapshot {
+            active: true,
+            grip: left_pose,
+            aim: left_pose,
+            ..XrControllerSnapshot::default()
+        },
+        right,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn centered_pointer_produces_a_stable_two_controller_rig() {
+        let surface = reference_surface();
+        let snapshot = sample(&BTreeSet::new(), centered_pointer(surface), false, surface);
+        assert_eq!(snapshot.head, Some(TrackingPose::IDENTITY));
+        assert!(snapshot.left.active);
+        assert!(snapshot.right.active);
+        assert_eq!(
+            snapshot.left.grip.expect("left grip").position,
+            [-0.24, -0.12, -0.55]
+        );
+        assert_eq!(
+            snapshot.right.aim.expect("right aim").position,
+            [0.24, -0.12, -0.55]
+        );
+
+        let resized = (1600, 900);
+        assert_eq!(
+            sample(&BTreeSet::new(), centered_pointer(resized), false, resized,)
+                .right
+                .aim
+                .expect("resized right aim")
+                .position,
+            [0.24, -0.12, -0.55]
+        );
+    }
+
+    #[test]
+    fn keys_and_mouse_button_map_to_controller_levels() {
+        let held_keys = BTreeSet::from([
+            Key::Space,
+            Key::Enter,
+            Key::Right,
+            Key::Up,
+            Key::Num1,
+            Key::Num2,
+            Key::Num3,
+        ]);
+        let surface = reference_surface();
+        let snapshot = sample(&held_keys, centered_pointer(surface), false, surface);
+        assert_eq!(snapshot.right.trigger, 1.0);
+        assert_eq!(snapshot.right.squeeze, 1.0);
+        assert_eq!(snapshot.right.thumbstick, [1.0, 1.0]);
+        assert!(snapshot.right.primary_pressed);
+        assert!(snapshot.right.secondary_pressed);
+        assert!(snapshot.right.thumbstick_pressed);
+
+        let mouse_trigger = sample(&BTreeSet::new(), centered_pointer(surface), true, surface);
+        assert_eq!(mouse_trigger.right.trigger, 1.0);
+
+        let opposing = BTreeSet::from([Key::Left, Key::Right, Key::Up, Key::Down]);
+        assert_eq!(
+            sample(&opposing, centered_pointer(surface), false, surface)
+                .right
+                .thumbstick,
+            [0.0, 0.0]
+        );
+    }
+
+    #[test]
+    fn pointer_motion_is_clamped_to_the_emulation_plane() {
+        let snapshot = sample(
+            &BTreeSet::new(),
+            (i32::MAX, i32::MIN),
+            false,
+            reference_surface(),
+        );
+        let [x, y, z] = snapshot.right.grip.expect("right grip").position;
+        assert!((x - 0.52).abs() < f32::EPSILON);
+        assert!((y - 0.10).abs() < f32::EPSILON);
+        assert!((z + 0.55).abs() < f32::EPSILON);
+    }
+}

--- a/runtime/functor-runtime-desktop/src/lib.rs
+++ b/runtime/functor-runtime-desktop/src/lib.rs
@@ -25,6 +25,8 @@ mod audio;
 #[cfg(not(target_arch = "wasm32"))]
 mod debug_server;
 #[cfg(not(target_arch = "wasm32"))]
+mod desktop_xr_emulator;
+#[cfg(not(target_arch = "wasm32"))]
 mod net_dispatch;
 #[cfg(not(target_arch = "wasm32"))]
 mod replay_game;

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -14,6 +14,7 @@ use std::time::Instant;
 use functor_runtime_common::asset::AssetCache;
 use functor_runtime_common::{
     Frame, FrameTime, GameClock, InputSnapshot, MouseSnapshot, RecordedInput, SceneContext,
+    XrInputSnapshot,
 };
 use std::collections::{BTreeSet, HashMap, HashSet};
 
@@ -81,14 +82,65 @@ fn map_key(key: Key) -> InputKey {
     }
 }
 
-fn sampled_input_snapshot(held_keys: &BTreeSet<InputKey>, mouse_pos: (i32, i32)) -> InputSnapshot {
+fn sampled_input_snapshot(
+    held_keys: &BTreeSet<InputKey>,
+    mouse_pos: (i32, i32),
+    xr: Option<XrInputSnapshot>,
+) -> InputSnapshot {
     InputSnapshot {
         held_keys: held_keys.iter().copied().collect(),
         mouse: MouseSnapshot {
             x: mouse_pos.0,
             y: mouse_pos.1,
         },
-        xr: None,
+        xr,
+    }
+}
+
+fn desktop_input_snapshot(
+    held_keys: &BTreeSet<InputKey>,
+    mouse_pos: (i32, i32),
+    emulate_xr: bool,
+    xr_primary_down: bool,
+    xr_surface: (i32, i32),
+) -> InputSnapshot {
+    let xr = emulate_xr.then(|| {
+        crate::desktop_xr_emulator::sample(held_keys, mouse_pos, xr_primary_down, xr_surface)
+    });
+    sampled_input_snapshot(held_keys, mouse_pos, xr)
+}
+
+fn refresh_fixed_input_levels(
+    snapshot: &mut InputSnapshot,
+    held_keys: &BTreeSet<InputKey>,
+    xr_primary_down: bool,
+) {
+    snapshot.held_keys = held_keys.iter().copied().collect();
+    if let Some(xr) = snapshot.xr.as_mut() {
+        crate::desktop_xr_emulator::update_right_controls(
+            &mut xr.right,
+            held_keys,
+            xr_primary_down,
+        );
+    }
+}
+
+fn apply_scripted_events(
+    game: &mut dyn Game,
+    held_keys: &mut BTreeSet<InputKey>,
+    events: &[RecordedInput],
+) {
+    for event in events {
+        if let RecordedInput::Key { code, is_down } = event {
+            game.key_event(*code, *is_down);
+            if let Some(key) = InputKey::from_i32(*code) {
+                if *is_down {
+                    held_keys.insert(key);
+                } else {
+                    held_keys.remove(&key);
+                }
+            }
+        }
     }
 }
 
@@ -208,6 +260,14 @@ pub struct Args {
     /// CI / scripted / LLM-driven runs.
     #[arg(long)]
     headless: bool,
+
+    /// Synthesize an XR head and two controllers from desktop input, using the
+    /// same `Input.snapshot.xr` shape as Quest. The mouse moves the right
+    /// controller; left-click/Space is trigger, Enter is squeeze, arrows are
+    /// the thumbstick, and 1/2/3 are controller buttons. Intended for
+    /// developing and capturing XR games without wearing a headset.
+    #[arg(long)]
+    emulate_xr: bool,
 
     /// Create the GL window hidden: it is never shown, never takes focus, and
     /// never captures the cursor, so a run doesn't steal input from the user.
@@ -495,6 +555,8 @@ fn service_debug_request(
     height: u32,
     held_keys: &mut BTreeSet<InputKey>,
     mouse_pos: &mut (i32, i32),
+    state_input: InputSnapshot,
+    emulate_xr: bool,
     clock: &mut GameClock,
     asset_cache: &Arc<AssetCache>,
     scene_context: &SceneContext,
@@ -506,7 +568,8 @@ fn service_debug_request(
     // has no webview overlay.
     mut webview_keyboard: Option<&mut Vec<crate::webview_keys::WebviewKey>>,
     capture: &dyn Fn() -> Result<Vec<u8>, debug_server::CaptureError>,
-) {
+) -> bool {
+    let mut sampled_input_changed = false;
     match req {
         debug_server::DebugRequest::Capture(resp) => {
             let _ = resp.send(capture());
@@ -518,14 +581,7 @@ fn service_debug_request(
                 viewport: debug_server::RuntimeViewport::new(width, height),
                 views: vec![debug_server::RuntimeView::new("main", width, height)],
                 model: game.state_debug(),
-                input: debug_server::InputSnapshot {
-                    held_keys: held_keys.iter().copied().collect(),
-                    mouse: debug_server::MouseSnapshot {
-                        x: mouse_pos.0,
-                        y: mouse_pos.1,
-                    },
-                    xr: None,
-                },
+                input: state_input,
             });
         }
         debug_server::DebugRequest::Scene(resp) => {
@@ -593,6 +649,11 @@ fn service_debug_request(
             let _ = resp.send(result);
         }
         debug_server::DebugRequest::Input(cmd, resp) => {
+            sampled_input_changed = matches!(
+                &cmd,
+                debug_server::InputCommand::Key { .. }
+                    | debug_server::InputCommand::MouseMove { .. }
+            );
             let result = match cmd {
                 debug_server::InputCommand::Key { key, down } => {
                     // The focus gate first (the GLFW routing rule): while a
@@ -635,7 +696,9 @@ fn service_debug_request(
                 }
                 debug_server::InputCommand::MouseMove { x, y } => {
                     *mouse_pos = (x, y);
-                    game.mouse_move(x, y);
+                    if !emulate_xr {
+                        game.mouse_move(x, y);
+                    }
                     Ok(())
                 }
                 debug_server::InputCommand::MouseWheel { delta } => {
@@ -668,6 +731,7 @@ fn service_debug_request(
             let _ = resp.send(());
         }
     }
+    sampled_input_changed
 }
 
 /// Headless game loop: drives the game + debug server with no GL window, for CI /
@@ -680,6 +744,9 @@ fn run_headless(
     mut game: Box<dyn Game>,
     debug_requests: Option<std::sync::mpsc::Receiver<debug_server::DebugRequest>>,
     fixed_time: Option<f32>,
+    emulate_xr: bool,
+    input_script: Option<HashMap<u64, Vec<RecordedInput>>>,
+    script_dt: f32,
 ) {
     // Stderr, not stdout: keep the CLI's `--json` ndjson stream (stdout) clean
     // even under `--headless`. This is an out-of-band notice, not an event.
@@ -690,7 +757,11 @@ fn run_headless(
     let mut frame_count: u64 = 0;
     let mut clock = GameClock::new(fixed_time);
     let mut held_keys: BTreeSet<InputKey> = BTreeSet::new();
-    let mut mouse_pos: (i32, i32) = (0, 0);
+    let mut mouse_pos: (i32, i32) = if emulate_xr {
+        crate::desktop_xr_emulator::centered_pointer(crate::desktop_xr_emulator::reference_surface())
+    } else {
+        (0, 0)
+    };
     // Keep the debug protocol target-isomorphic even without pixels: uploaded
     // assets can be accepted now and are ready if headless rendering gains an
     // asset path later.
@@ -708,6 +779,9 @@ fn run_headless(
 
     loop {
         let elapsed = start_time.elapsed().as_secs_f32();
+        if input_script.is_some() {
+            clock.step(script_dt);
+        }
         // Fixed-timestep model loop, same as the windowed loop (docs/time-travel
         // .md): 0..N fixed 1/60 steps per iteration (one per debug `/time advance`,
         // one {dts:0} under a pin, none while paused). `time` carries the settled
@@ -724,8 +798,20 @@ fn run_headless(
         game.check_hot_reload(time.clone());
         deliver_net_ws(&mut *game, &net_rx, &ws_rx);
         for sub in &sub_frames {
+            if let Some(events) = input_script
+                .as_ref()
+                .and_then(|script| script.get(&frame_count))
+            {
+                apply_scripted_events(&mut *game, &mut held_keys, events);
+            }
             if game.samples_input() {
-                let snapshot = sampled_input_snapshot(&held_keys, mouse_pos);
+                let snapshot = desktop_input_snapshot(
+                    &held_keys,
+                    mouse_pos,
+                    emulate_xr,
+                    false,
+                    crate::desktop_xr_emulator::reference_surface(),
+                );
                 game.sampled_input(&snapshot);
             }
             game.tick(sub.clone());
@@ -743,6 +829,13 @@ fn run_headless(
 
         if let Some(rx) = &debug_requests {
             while let Ok(req) = rx.try_recv() {
+                let state_input = desktop_input_snapshot(
+                    &held_keys,
+                    mouse_pos,
+                    emulate_xr,
+                    false,
+                    crate::desktop_xr_emulator::reference_surface(),
+                );
                 service_debug_request(
                     req,
                     &mut *game,
@@ -753,6 +846,8 @@ fn run_headless(
                     0,
                     &mut held_keys,
                     &mut mouse_pos,
+                    state_input,
+                    emulate_xr,
                     &mut clock,
                     &asset_cache,
                     &scene_context,
@@ -852,7 +947,14 @@ pub fn run(args: Args) {
                 "warning: --xreal-tracking has no effect in --headless mode (no view to rotate)"
             );
         }
-        run_headless(game, debug_requests, args.fixed_time);
+        run_headless(
+            game,
+            debug_requests,
+            args.fixed_time,
+            args.emulate_xr,
+            input_script,
+            args.script_dt,
+        );
         return;
     }
 
@@ -909,7 +1011,7 @@ pub fn run(args: Args) {
             // click recaptures; Escape while released quits. Losing focus
             // also releases, so cmd-tabbing away hands the pointer back.
             // A hidden window never gets focus, so it must not grab the cursor.
-            if !hidden {
+            if !hidden && !args.emulate_xr {
                 window.set_cursor_mode(glfw::CursorMode::Disabled);
             }
 
@@ -1024,16 +1126,29 @@ pub fn run(args: Args) {
         // GLFW event stream and the debug server's POST /input. Generic and
         // serializable, unlike the game model (which is Debug text only).
         let mut held_keys: BTreeSet<InputKey> = BTreeSet::new();
-        let mut mouse_pos: (i32, i32) = (0, 0);
+        let mut mouse_pos: (i32, i32) = if args.emulate_xr {
+            crate::desktop_xr_emulator::centered_pointer(window.get_size())
+        } else {
+            (0, 0)
+        };
+        let mut xr_primary_down = false;
+        let mut xr_primary_clicked = false;
         // `--fixed-time` is a deterministic capture pin: the one zero-delta
-        // bootstrap step must not observe cursor motion or release bookkeeping
-        // from the host window. An explicit input script remains authoritative
-        // and uses the live runtime-owned snapshot below.
-        let fixed_input_snapshot = InputSnapshot::default();
+        // bootstrap step must not observe cursor motion from the host window.
+        // Explicit debug input remains authoritative; key release/focus-loss
+        // bookkeeping also clears held levels so fixed captures cannot stick.
+        // An input script uses the live runtime-owned snapshot below.
+        let mut fixed_input_snapshot = desktop_input_snapshot(
+            &held_keys,
+            mouse_pos,
+            args.emulate_xr,
+            false,
+            window.get_size(),
+        );
         // Whether the window owns the pointer (free-look). See the Escape /
         // MouseButton / Focus arms in the event loop. A hidden window never
         // captures (and never receives the events that would toggle this).
-        let mut cursor_captured = !hidden;
+        let mut cursor_captured = !hidden && !args.emulate_xr;
 
         use glfw::Context;
 
@@ -1254,6 +1369,9 @@ Escape again to quit"
                             if scrubber_visible {
                                 window.set_cursor_mode(glfw::CursorMode::Normal);
                                 cursor_captured = false;
+                            } else if args.emulate_xr {
+                                window.set_cursor_mode(glfw::CursorMode::Normal);
+                                cursor_captured = false;
                             } else {
                                 window.set_cursor_mode(glfw::CursorMode::Disabled);
                                 cursor_captured = true;
@@ -1290,6 +1408,9 @@ Escape again to quit"
                                 {
                                     mouse_primary_down = true;
                                     mouse_primary_clicked = true;
+                                } else if args.emulate_xr {
+                                    xr_primary_down = !ignore_user_input;
+                                    xr_primary_clicked = xr_primary_down;
                                 } else {
                                     window.set_cursor_mode(glfw::CursorMode::Disabled);
                                     cursor_captured = true;
@@ -1304,7 +1425,10 @@ Escape again to quit"
                                     }
                                 }
                             }
-                            Action::Release => mouse_primary_down = false,
+                            Action::Release => {
+                                mouse_primary_down = false;
+                                xr_primary_down = false;
+                            }
                             Action::Repeat => {}
                         }
                     }
@@ -1350,6 +1474,13 @@ Escape again to quit"
                         {
                             game.key_event(k as i32, false);
                         }
+                        if clock.is_fixed_time() && was_held {
+                            refresh_fixed_input_levels(
+                                &mut fixed_input_snapshot,
+                                &held_keys,
+                                xr_primary_down || xr_primary_clicked,
+                            );
+                        }
                     }
                     glfw::WindowEvent::Focus(false) => {
                         for k in std::mem::take(&mut held_keys) {
@@ -1366,6 +1497,15 @@ Escape again to quit"
                         // press — clear it so the scrubber stays live. [xreview]
                         mouse_primary_down = false;
                         mouse_primary_clicked = false;
+                        xr_primary_down = false;
+                        xr_primary_clicked = false;
+                        if clock.is_fixed_time() {
+                            refresh_fixed_input_levels(
+                                &mut fixed_input_snapshot,
+                                &held_keys,
+                                false,
+                            );
+                        }
                     }
                     _ if ignore_user_input => {}
                     // While a webview field is focused, key presses drive the
@@ -1462,28 +1602,24 @@ Escape again to quit"
             for sub in &sub_frames {
                 if let Some(script) = input_script.as_ref().filter(|_| !args.ghost) {
                     if let Some(events) = script.get(&frame_count) {
-                        for ev in events {
-                            if let RecordedInput::Key { code, is_down } = ev {
-                                game.key_event(*code, *is_down);
-                                if let Some(key) = InputKey::from_i32(*code) {
-                                    if *is_down {
-                                        held_keys.insert(key);
-                                    } else {
-                                        held_keys.remove(&key);
-                                    }
-                                }
-                            }
-                        }
+                        apply_scripted_events(&mut *game, &mut held_keys, events);
                     }
                 }
                 if game.samples_input() {
                     if clock.is_fixed_time() && input_script.is_none() {
                         game.sampled_input(&fixed_input_snapshot);
                     } else {
-                        let snapshot = sampled_input_snapshot(&held_keys, mouse_pos);
+                        let snapshot = desktop_input_snapshot(
+                            &held_keys,
+                            mouse_pos,
+                            args.emulate_xr,
+                            xr_primary_down || xr_primary_clicked,
+                            window.get_size(),
+                        );
                         game.sampled_input(&snapshot);
                     }
                 }
+                xr_primary_clicked = false;
                 game.tick(sub.clone());
                 if args.capture_at_frame == Some(frame_count) {
                     capture_due = true;
@@ -2232,7 +2368,19 @@ Escape again to quit"
             // reads from). GL stays on this thread; we only reply over channels.
             if let Some(rx) = &debug_requests {
                 while let Ok(req) = rx.try_recv() {
-                    service_debug_request(
+                    let fixed_sample = clock.is_fixed_time() && input_script.is_none();
+                    let state_input = if fixed_sample {
+                        fixed_input_snapshot.clone()
+                    } else {
+                        desktop_input_snapshot(
+                            &held_keys,
+                            mouse_pos,
+                            args.emulate_xr,
+                            xr_primary_down || xr_primary_clicked,
+                            window.get_size(),
+                        )
+                    };
+                    let sampled_input_changed = service_debug_request(
                         req,
                         &mut *game,
                         &frame,
@@ -2242,6 +2390,8 @@ Escape again to quit"
                         fb_height as u32,
                         &mut held_keys,
                         &mut mouse_pos,
+                        state_input,
+                        args.emulate_xr,
                         &mut clock,
                         &asset_cache,
                         &scene_context,
@@ -2264,6 +2414,15 @@ Escape again to quit"
                                 .map_err(debug_server::CaptureError::Failed)
                         },
                     );
+                    if fixed_sample && sampled_input_changed {
+                        fixed_input_snapshot = desktop_input_snapshot(
+                            &held_keys,
+                            mouse_pos,
+                            args.emulate_xr,
+                            xr_primary_down || xr_primary_clicked,
+                            window.get_size(),
+                        );
+                    }
                 }
             }
 
@@ -2328,5 +2487,27 @@ mod tests {
         assert!(parse_input_script(bad_key.to_str().unwrap()).is_err());
         let bad_dir = write_tmp("functor-test-baddir.script", "0 Right sideways\n");
         assert!(parse_input_script(bad_dir.to_str().unwrap()).is_err());
+    }
+
+    #[test]
+    fn fixed_level_refresh_preserves_mouse_and_tracked_poses() {
+        let mut snapshot =
+            desktop_input_snapshot(&BTreeSet::new(), (100, 200), true, false, (800, 600));
+        let pose = snapshot
+            .xr
+            .as_ref()
+            .and_then(|xr| xr.right.grip)
+            .expect("emulated grip");
+        let held = BTreeSet::from([InputKey::Space]);
+
+        refresh_fixed_input_levels(&mut snapshot, &held, false);
+
+        assert_eq!(snapshot.mouse, MouseSnapshot { x: 100, y: 200 });
+        assert_eq!(
+            snapshot.xr.as_ref().and_then(|xr| xr.right.grip),
+            Some(pose)
+        );
+        assert_eq!(snapshot.xr.as_ref().unwrap().right.trigger, 1.0);
+        assert_eq!(snapshot.held_keys, vec![InputKey::Space]);
     }
 }


### PR DESCRIPTION
## Summary

- add an opt-in `--emulate-xr` desktop shell adapter that synthesizes the canonical Quest-shaped `Input.snapshot.xr`
- map mouse/keyboard input to a stable head/controller rig, including deterministic `--input-script` and headless/debug-server operation
- keep fixed-time, cursor ownership, resize, short-click, focus-loss, and debug injection behavior consistent with what `sampledInput` receives
- document the controls and the extension point for future gamepad/mobile sampled-input adapters

Follow-up to merged #465.

## Desktop controls

| Desktop input | Emulated right controller |
| --- | --- |
| mouse | grip/aim position on a rig-local plane |
| left click or Space | trigger |
| Enter | squeeze |
| arrow keys | thumbstick |
| 1 / 2 / 3 | primary / secondary / thumbstick click |

The adapter only produces the shared `InputSnapshot` protocol. Games do not gain a desktop-specific API, and future gamepad/touch domains can remain typed sibling fields on that protocol.

## Review disposition

The cross-engine review found no Critical/High issues. All Medium/Low findings were addressed:

- keep GLFW cursor ownership aligned with XR mode, including scrubber transitions
- make fixed-time `/state` and `sampledInput` consume one canonical snapshot
- preserve frozen poses while focus/release cleanup updates only held/button levels
- wire input scripts through headless mode and share their event application
- latch short mouse clicks, cancel opposing thumbstick keys, scale motion after resize, and keep injected/live mouse routing isomorphic

The pre-write API index found no existing desktop/XR emulator to reuse. The cold semantic scan was stopped after 36 minutes at 2,560/3,347 functions because another local scan was competing for the embedding model; neither independent reviewer found an actionable duplication, and the duplicated script/snapshot construction they did identify was consolidated into shared helpers.

## Verification

- `cargo test -p functor-runtime-desktop desktop_xr_emulator` (3 passed)
- `cargo test -p functor-runtime-desktop fixed_level_refresh_preserves_mouse_and_tracked_poses` (passed)
- `cargo check -p functor-runtime-desktop`
- `cargo build -p functor-cli`
- `npm run check:docs`
- `git diff --check`
- live headless probe: scripted Space is visible in held keys, XR trigger, and the Functor Lang `sampledInput` model
- live fixed-time probe: debug Space down/up stays identical across `/state.input.xr` and the sampled game model
- final cross-engine review: clean

The full desktop library run passed 65 tests and hit one unrelated existing fixture failure: the Mario hot-reload test still searches for `jumpVelocity = 12.0`, while the current example uses `13.0`.
