### PR TITLE
feat(examples): add XR controller interaction

### DIFF
--- a/docs/vr.md
+++ b/docs/vr.md
@@ -117,14 +117,29 @@ controller levels for deterministic captures without adding a desktop-only
 game API. This is one shell adapter over the canonical snapshot; future
 gamepad/mobile adapters should produce that same target-neutral record.
 
+`examples/xr-controllers` is the shared-path reference: it maps both grip
+poses through the authored camera, visualizes each aim direction, and pulls an
+orb toward the right controller while trigger is held. Run it unchanged on
+desktop or Quest:
+
+```sh
+functor -d examples/xr-controllers run native --emulate-xr
+functor -d examples/xr-controllers run vr
+
+# Reproducible held-trigger frame (the script path is project-relative):
+functor -d examples/xr-controllers run native --emulate-xr \
+  --input-script grab.script --capture-frame /tmp/xr-grab.png \
+  --capture-at-frame 60
+```
+
 ## After bring-up (in rough order)
 
 - The typed XR snapshot is exposed to Functor Lang through the per-tick
   `sampledInput` hook and maps through the authored rig with
   `Camera.mapTrackedPose`; desktop can synthesize the same record with
-  `--emulate-xr`. Next, add a controller-driven example. Keep gamepad and
-  mobile-touch input as typed sibling domains rather than XR-specific producer
-  APIs.
+  `--emulate-xr`, and `examples/xr-controllers` exercises both paths. Keep
+  gamepad and mobile-touch input as typed sibling domains rather than
+  XR-specific producer APIs.
 - Add the Android audio host; sound bytes already synchronize, but Quest
   currently drains playback commands.
 - Add a browser surface over the isomorphic debug API for edit/push/inspect/

--- a/examples/xr-controllers/functor.json
+++ b/examples/xr-controllers/functor.json
@@ -1,0 +1,4 @@
+{
+  "language": "functor-lang",
+  "entry": "game.fun"
+}

--- a/examples/xr-controllers/game.fun
+++ b/examples/xr-controllers/game.fun
@@ -1,0 +1,165 @@
+// Controller-driven XR example. The same sampled-input code runs against real
+// Quest Touch controllers or the desktop `--emulate-xr` adapter.
+//
+// Desktop:
+//   functor -d examples/xr-controllers run native --emulate-xr
+//   Mouse moves the right controller; left-click/Space grabs the orb.
+// Deterministic capture:
+//   functor -d examples/xr-controllers run native --emulate-xr \
+//     --input-script grab.script --capture-frame /tmp/xr-grab.png \
+//     --capture-at-frame 60
+// Quest:
+//   functor -d examples/xr-controllers run vr
+
+let camera =
+  Camera.lookAt(
+    Vec3.make(0.0, 1.6, -3.0),
+    Vec3.make(0.0, 1.2, 0.0))
+
+let fallbackPose = (x) =>
+  Camera.mapTrackedPose(camera, {
+    position: { x: x, y: -0.12, z: -0.55 },
+    orientation: { x: 0.0, y: 0.0, z: 0.0, w: 1.0 }
+  })
+
+let fallbackLeft = fallbackPose(-0.24)
+let fallbackRight = fallbackPose(0.24)
+
+let point = (x, y, z): Input.point3 => { x: x, y: y, z: z }
+
+let init = {
+  leftGrip: fallbackLeft,
+  leftAim: fallbackLeft,
+  leftGripTracked: false,
+  leftAimTracked: false,
+  rightGrip: fallbackRight,
+  rightAim: fallbackRight,
+  rightGripTracked: false,
+  rightAimTracked: false,
+  orb: point(0.0, 1.15, -0.7),
+  grabbing: false,
+  squeeze: 0.0
+}
+
+let mappedPose = (fallback, trackedPose) =>
+  match trackedPose with
+  | Option.None => fallback
+  | Option.Some(pose) => Camera.mapTrackedPose(camera, pose)
+
+let sampledInput = (model, snapshot: Input.snapshot) =>
+  match snapshot.xr with
+  | Option.None =>
+    {
+      model with
+      leftGripTracked: false,
+      leftAimTracked: false,
+      rightGripTracked: false,
+      rightAimTracked: false,
+      grabbing: false,
+      squeeze: 0.0
+    }
+  | Option.Some(xr) =>
+    let leftGripTracked = xr.left.active && Option.isSome(xr.left.grip) in
+    let leftAimTracked = xr.left.active && Option.isSome(xr.left.aim) in
+    let rightGripTracked = xr.right.active && Option.isSome(xr.right.grip) in
+    let rightAimTracked = xr.right.active && Option.isSome(xr.right.aim) in
+    let leftGrip = mappedPose(fallbackLeft, xr.left.grip) in
+    let rightGrip = mappedPose(fallbackRight, xr.right.grip) in
+    {
+      model with
+      leftGrip: leftGrip,
+      leftAim: mappedPose(leftGrip, xr.left.aim),
+      leftGripTracked: leftGripTracked,
+      leftAimTracked: leftAimTracked,
+      rightGrip: rightGrip,
+      rightAim: mappedPose(rightGrip, xr.right.aim),
+      rightGripTracked: rightGripTracked,
+      rightAimTracked: rightAimTracked,
+      grabbing: rightAimTracked && xr.right.trigger > 0.5,
+      squeeze: if rightAimTracked then xr.right.squeeze else 0.0
+    }
+
+let ahead = (pose, distance): Input.point3 => {
+  x: pose.position.x + pose.forward.x * distance,
+  y: pose.position.y + pose.forward.y * distance,
+  z: pose.position.z + pose.forward.z * distance
+}
+
+let approach = (from, target, amount): Input.point3 => {
+  x: from.x + (target.x - from.x) * amount,
+  y: from.y + (target.y - from.y) * amount,
+  z: from.z + (target.z - from.z) * amount
+}
+
+let tick = (model, dt, tts) =>
+  if model.grabbing then
+    let amount = Math.min(1.0, dt * 8.0) in
+    { model with orb: approach(model.orb, ahead(model.rightAim, 0.3), amount) }
+  else model
+
+let at = (point, scene) =>
+  scene |> Scene.translate(Vec3.make(point.x, point.y, point.z))
+
+let visible = (shown, scene) =>
+  if shown then scene else Scene.group([])
+
+let controller = (gripTracked, aimTracked, grip, aim, color) =>
+  Scene.group([
+    visible(
+      gripTracked,
+      Scene.cube()
+        |> Scene.scaleXYZ(0.035, 0.05, 0.09)
+        |> Scene.emissive(color)
+        |> at(grip.position)),
+    visible(
+      aimTracked,
+      Scene.sphere()
+        |> Scene.scale(0.025)
+        |> Scene.emissive(Color.rgb(0.95, 0.98, 1.0))
+        |> at(ahead(aim, 0.3))),
+  ])
+
+let orb = (model) =>
+  Scene.sphere()
+    |> Scene.scale(0.09 + model.squeeze * 0.04)
+    |> Scene.emissive(
+      if model.grabbing
+      then Color.rgb(1.0, 0.2, 0.72)
+      else Color.rgb(0.1, 0.85, 1.0))
+    |> at(model.orb)
+
+let draw = (model, tts) =>
+  Frame.createLit(
+    camera,
+    Scene.group([
+      Scene.plane()
+        |> Scene.scale(8.0)
+        |> Scene.lit(Color.rgb(0.08, 0.09, 0.16)),
+      Scene.cylinder()
+        |> Scene.scaleXYZ(0.45, 0.03, 0.45)
+        |> Scene.emissive(Color.rgb(0.15, 0.18, 0.32))
+        |> Scene.translate(Vec3.make(0.0, 0.02, -0.7)),
+      orb(model),
+      controller(
+        model.leftGripTracked,
+        model.leftAimTracked,
+        model.leftGrip,
+        model.leftAim,
+        Color.rgb(0.45, 0.35, 1.0)),
+      controller(
+        model.rightGripTracked,
+        model.rightAimTracked,
+        model.rightGrip,
+        model.rightAim,
+        if model.grabbing
+        then Color.rgb(1.0, 0.2, 0.72)
+        else Color.rgb(0.1, 0.85, 1.0)),
+    ]),
+    [
+      Light.ambient(Color.rgb(0.12, 0.12, 0.2)),
+      Light.directional(
+        Vec3.make(-0.4, -1.0, 0.3),
+        Color.rgb(0.8, 0.9, 1.0),
+        0.8),
+    ])
+    |> Frame.withClearColor(Color.rgb(0.015, 0.02, 0.06))

--- a/examples/xr-controllers/grab.script
+++ b/examples/xr-controllers/grab.script
@@ -1,0 +1,3 @@
+# Deterministic desktop proof: hold the right trigger, then release it.
+20 Space down
+80 Space up


### PR DESCRIPTION
## Summary

- add a controller-driven Functor Lang example that consumes the canonical `Input.snapshot`
- map Quest/desktop grip and aim poses through the authored `Frame.camera`
- pull and scale an orb with trigger/squeeze while handling pose loss without stale interaction
- include a deterministic desktop input script and document identical desktop/Quest launch paths

Follow-up to merged #466.

## Verification

- `./target/debug/functor -d examples/xr-controllers build native`
- `npm run check:docs`
- `git diff --check`
- headless `--emulate-xr --input-script grab.script` run inspected through `/state`
- pushed unchanged project to Quest 3; verified 3360×1760 stereo render plus
  partial-tracking behavior (grips valid / aims absent hides pointers and
  refuses a stale grab)

## Review findings

- Fixed: grip and aim are mapped independently; controller bodies use grip while pointers and grabbing use aim.
- Fixed: XR-domain loss and missing poses hide only the affected visualization and clear interaction state, preventing stale grabs.
- Fixed: fallback handedness is derived through `Camera.mapTrackedPose`, so it follows the authored camera basis.
- Fixed: the deterministic capture command is shell-copyable and the script comment describes the actual trigger-only input.
- Final code review: clean from both independent reviewers.

## Visual proof

![XR controller grab and release](https://gist.githubusercontent.com/tommy-xr/d2a0c9d0bc0b7317f28c3201ca84aee9/raw/functor-pr467-xr-controller-grab.gif)

<sub>The same sampledInput game maps authored-camera grip/aim poses on desktop emulation and Quest; trigger pulls the cyan orb into the right-hand aim and turns both pink. Captured deterministically with `--emulate-xr --input-script grab.script --capture-at-frame`.</sub>

| Neutral — frame 19 | Grabbed — frame 60 | Released — frame 90 |
| --- | --- | --- |
| ![Neutral controller state](https://gist.githubusercontent.com/tommy-xr/d2a0c9d0bc0b7317f28c3201ca84aee9/raw/functor-pr467-xr-neutral-f19.png) | ![Grabbed controller state](https://gist.githubusercontent.com/tommy-xr/d2a0c9d0bc0b7317f28c3201ca84aee9/raw/functor-pr467-xr-grabbed-f60.png) | ![Released controller state](https://gist.githubusercontent.com/tommy-xr/d2a0c9d0bc0b7317f28c3201ca84aee9/raw/functor-pr467-xr-released-f90.png) |

<sub>Media-aware cross-review: **PASS** — both reviewers confirmed the scripted grab/release sequence, coherent authored-camera mapping, and unclipped controller geometry.</sub>
