### PR TITLE
feat(terrain): add heightmap descriptors and decoding

### DIFF
--- a/functor-prelude/prelude/camera.funi
+++ b/functor-prelude/prelude/camera.funi
@@ -16,3 +16,9 @@ type mappedPose = { position: Input.point3, forward: Input.point3, up: Input.poi
 /// The returned position, forward, and up vectors are suitable for placing a
 /// controller representation or aiming a ray in the authored world.
 let mapTrackedPose : (t, Input.pose) => mappedPose
+
+/// Set near and far clipping distances; the camera is last for piping.
+///
+/// Large outdoor worlds should set the far plane explicitly. Keep the near
+/// plane as large as gameplay permits to preserve depth-buffer precision.
+let clip : (float, float, t) => t

--- a/functor-prelude/prelude/terrain.funi
+++ b/functor-prelude/prelude/terrain.funi
@@ -1,0 +1,31 @@
+//! Finite, asset-backed heightfield terrain shared by rendering and physics.
+//!
+//! Heightmaps should be 16-bit grayscale PNGs. Black maps to the declared
+//! minimum height and white maps to the maximum height.
+
+/// An immutable terrain descriptor.
+type t
+
+/// Create a terrain centered on the origin and spanning `width` by `depth` in XZ.
+let heightmap : (Asset.Texture, float, float, float, float) => t
+
+/// Set the maximum projected vertex spacing in pixels; lower is more detailed.
+///
+/// The default is 2 pixels. The terrain is last for piping.
+let maxPixelError : (float, t) => t
+
+/// Set the basic lit terrain color; the terrain is last for piping.
+let color : (Color.t, t) => t
+
+/// Blend lowland, highland, rock, and snow colors by height and slope.
+///
+/// `snowHeight` is in terrain-local world units. The terrain is last for
+/// piping.
+let layered : (Color.t, Color.t, Color.t, Color.t, float, t) => t
+
+/// Add camera-local GPU-instanced grass clusters.
+///
+/// `spacing`, `distance`, and `bladeHeight` are terrain-local world units.
+/// Grass is suppressed on steep, flooded, and snowy samples. The terrain is
+/// last for piping.
+let grass : (float, float, float, Color.t, t) => t

--- a/functor-prelude/src/lib.rs
+++ b/functor-prelude/src/lib.rs
@@ -40,6 +40,7 @@ pub fn bundled_modules() -> Vec<BundledModule> {
 pub fn modules() -> Vec<(String, String)> {
     vec![
         module("Scene", include_str!("../prelude/scene.funi")),
+        module("Terrain", include_str!("../prelude/terrain.funi")),
         module("Anim", include_str!("../prelude/anim.funi")),
         module("Asset", include_str!("../prelude/asset.funi")),
         module("Angle", include_str!("../prelude/angle.funi")),

--- a/runtime/functor-runtime-common/src/asset/pipelines/heightmap_pipeline.rs
+++ b/runtime/functor-runtime-common/src/asset/pipelines/heightmap_pipeline.rs
@@ -1,0 +1,191 @@
+use crate::asset::{AssetCache, AssetPipeline, AssetPipelineContext};
+use serde::{Deserialize, Deserializer, Serialize};
+
+/// CPU-resident 16-bit elevation samples. Keeping the source precision here
+/// lets both the GPU terrain renderer and Rapier heightfield adapter consume
+/// the exact same data.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct HeightmapData {
+    pub(crate) samples: Vec<u16>,
+    pub(crate) width: u32,
+    pub(crate) height: u32,
+    /// Deterministic content fingerprint for fast renderer/cache invalidation.
+    /// Semantic equality still includes the samples; `Arc<HeightmapData>`
+    /// takes a pointer fast path for unchanged per-frame declarations.
+    pub(crate) revision: u64,
+}
+
+impl<'de> Deserialize<'de> for HeightmapData {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        // `revision` is an optimization, never trusted wire input. Ignoring a
+        // serialized revision and recomputing it keeps equality/content
+        // identity sound across snapshots and external protocol values.
+        #[derive(Deserialize)]
+        struct Wire {
+            samples: Vec<u16>,
+            width: u32,
+            height: u32,
+        }
+
+        let Wire {
+            samples,
+            width,
+            height,
+        } = Wire::deserialize(deserializer)?;
+        Ok(Self {
+            revision: revision(width, height, &samples),
+            samples,
+            width,
+            height,
+        })
+    }
+}
+
+impl HeightmapData {
+    pub fn flat() -> Self {
+        let samples = vec![0; 4];
+        Self {
+            revision: revision(2, 2, &samples),
+            samples,
+            width: 2,
+            height: 2,
+        }
+    }
+
+    pub fn is_valid(&self) -> bool {
+        self.width >= 2
+            && self.height >= 2
+            && self.samples.len() == (self.width as usize * self.height as usize)
+    }
+}
+
+/// Decode a grayscale heightmap without losing 16-bit PNG precision.
+///
+/// Color and 8-bit images are accepted and converted to 16-bit luminance, but
+/// authored terrain should use 16-bit grayscale PNG. Decode failures become a
+/// flat sentinel instead of panicking the render thread.
+pub struct HeightmapPipeline;
+
+impl AssetPipeline<HeightmapData> for HeightmapPipeline {
+    fn process(
+        &self,
+        bytes: Vec<u8>,
+        _asset_cache: &AssetCache,
+        _context: AssetPipelineContext,
+    ) -> HeightmapData {
+        match image::load_from_memory(&bytes) {
+            Ok(image) => {
+                // Consume the decoded image. `to_luma16` clones even an
+                // already-authored 16-bit grayscale source, which would add
+                // another 32 MiB allocation for a 4096² heightmap.
+                let image = image.into_luma16();
+                let width = image.width();
+                let height = image.height();
+                if width < 2 || height < 2 {
+                    eprintln!(
+                        "[terrain] heightmap must be at least 2x2 pixels, got {width}x{height}"
+                    );
+                    return HeightmapData::flat();
+                }
+                let samples = image.into_raw();
+                HeightmapData {
+                    revision: revision(width, height, &samples),
+                    width,
+                    height,
+                    samples,
+                }
+            }
+            Err(error) => {
+                eprintln!("[terrain] cannot decode heightmap: {error}");
+                HeightmapData::flat()
+            }
+        }
+    }
+
+    fn unloaded_asset(&self, _context: AssetPipelineContext) -> HeightmapData {
+        HeightmapData::flat()
+    }
+}
+
+fn revision(width: u32, height: u32, samples: &[u16]) -> u64 {
+    // FNV-1a: tiny, deterministic on every target, and paid once at decode.
+    let mut hash = 0xcbf29ce484222325u64;
+    for byte in width
+        .to_le_bytes()
+        .into_iter()
+        .chain(height.to_le_bytes())
+        .chain(samples.iter().flat_map(|sample| sample.to_le_bytes()))
+    {
+        hash ^= byte as u64;
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use image::{DynamicImage, GrayImage, ImageBuffer, ImageFormat, Luma};
+
+    use super::*;
+
+    fn encode(image: DynamicImage) -> Vec<u8> {
+        let mut bytes = Cursor::new(Vec::new());
+        image.write_to(&mut bytes, ImageFormat::Png).unwrap();
+        bytes.into_inner()
+    }
+
+    fn process(bytes: Vec<u8>) -> HeightmapData {
+        HeightmapPipeline.process(bytes, &AssetCache::new(), AssetPipelineContext {})
+    }
+
+    #[test]
+    fn preserves_sixteen_bit_height_samples_exactly() {
+        let image: ImageBuffer<Luma<u16>, Vec<u16>> =
+            ImageBuffer::from_raw(2, 2, vec![0, 1, 32768, 65535]).unwrap();
+        let decoded = process(encode(DynamicImage::ImageLuma16(image)));
+        assert_eq!((decoded.width, decoded.height), (2, 2));
+        assert_eq!(decoded.samples, [0, 1, 32768, 65535]);
+    }
+
+    #[test]
+    fn expands_eight_bit_luminance_to_the_full_sixteen_bit_range() {
+        let image = GrayImage::from_raw(2, 2, vec![0, 1, 128, 255]).unwrap();
+        let decoded = process(encode(DynamicImage::ImageLuma8(image)));
+        assert_eq!(decoded.samples, [0, 257, 32896, 65535]);
+    }
+
+    #[test]
+    fn corrupt_image_becomes_a_flat_valid_fallback() {
+        let decoded = process(vec![1, 2, 3, 4]);
+        assert!(decoded.is_valid());
+        assert!(decoded.samples.iter().all(|sample| *sample == 0));
+    }
+
+    #[test]
+    fn undersized_images_become_a_flat_valid_fallback() {
+        for (width, height) in [(1, 1), (1, 2), (2, 1)] {
+            let image = GrayImage::from_pixel(width, height, Luma([255]));
+            let decoded = process(encode(DynamicImage::ImageLuma8(image)));
+            assert!(
+                decoded.is_valid(),
+                "{width}x{height} should use the valid fallback"
+            );
+            assert_eq!((decoded.width, decoded.height), (2, 2));
+            assert!(decoded.samples.iter().all(|sample| *sample == 0));
+        }
+    }
+
+    #[test]
+    fn deserialization_recomputes_untrusted_content_revision() {
+        let data = HeightmapData::flat();
+        let forged = format!(
+            r#"{{"samples":[0,0,0,0],"width":2,"height":2,"revision":{}}}"#,
+            data.revision.wrapping_add(1)
+        );
+        let decoded: HeightmapData = serde_json::from_str(&forged).unwrap();
+        assert_eq!(decoded, data);
+        assert_eq!(decoded.revision, data.revision);
+    }
+}

--- a/runtime/functor-runtime-common/src/asset/pipelines/mod.rs
+++ b/runtime/functor-runtime-common/src/asset/pipelines/mod.rs
@@ -6,3 +6,6 @@ pub use model_pipeline::*;
 
 mod raw_image_pipeline;
 pub use raw_image_pipeline::*;
+
+mod heightmap_pipeline;
+pub use heightmap_pipeline::*;

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -163,6 +163,7 @@ use crate::scene3d::{
     MaterialDescription, ModelDescription, ModelHandle, SpriteSampling, TextureDescription,
 };
 use crate::skybox::SkyboxDescription;
+use crate::terrain::TerrainDescription;
 use crate::ui::{self, View};
 use crate::webview::HtmlNode;
 use crate::{Camera, Camera2D, Frame, Light, Scene3D, SceneObject, Shape, SpriteLayer};
@@ -171,6 +172,9 @@ mod sprite;
 
 /// A [`Scene3D`] as an opaque Functor Lang value.
 pub struct FunctorLangScene(pub Scene3D);
+
+/// A [`TerrainDescription`] as an opaque, immutable Functor Lang value.
+pub struct FunctorLangTerrain(pub TerrainDescription);
 
 /// A [`Camera`] as an opaque Functor Lang value.
 pub struct FunctorLangCamera(pub Camera);
@@ -1110,6 +1114,18 @@ impl HostData for FunctorLangScene {
     }
 }
 
+impl HostData for FunctorLangTerrain {
+    fn type_name(&self) -> &'static str {
+        "Terrain"
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+    fn is_reload_safe_snapshot(&self) -> bool {
+        true
+    }
+}
+
 impl HostData for FunctorLangCamera {
     fn type_name(&self) -> &'static str {
         "Camera"
@@ -1198,6 +1214,7 @@ pub(crate) fn registry() -> &'static crate::host_registry::Registry {
         let mut reg = crate::host_registry::Registry::default();
         register_branded_constructors(&mut reg);
         register_ui_anchors(&mut reg);
+        register_terrain(&mut reg);
         register_scene(&mut reg);
         sprite::register(&mut reg);
         register_camera(&mut reg);
@@ -1291,6 +1308,7 @@ crate::host_returnable!(
     FunctorLangRenderTarget,
     FunctorLangFog,
     FunctorLangUiAnchor,
+    FunctorLangTerrain,
     FunctorLangScene,
     FunctorLangCamera,
     FunctorLangFrame,
@@ -1342,6 +1360,126 @@ fn material_scene(material: MaterialDescription, scene: FunctorLangScene) -> Fun
 /// moves — the order the source reads).
 fn transformed(scene: FunctorLangScene, xform: Matrix4<f32>) -> FunctorLangScene {
     FunctorLangScene(group(vec![scene.0], xform))
+}
+
+/// Immutable terrain descriptions are shared by rendering and heightfield
+/// physics. Dimensions and elevation stay attached to the heightmap locator,
+/// so the two consumers cannot silently drift.
+fn register_terrain(reg: &mut crate::host_registry::Registry) {
+    const HEIGHTMAP: &str = "Terrain.heightmap(asset, width, depth, minHeight, maxHeight) — \
+a texture Asset, positive dimensions, and maxHeight greater than minHeight";
+    reg.fn5(
+        "Terrain.heightmap",
+        HEIGHTMAP,
+        |asset: TextureAssetPath, width: f64, depth: f64, min_height: f64, max_height: f64| {
+            let (width, depth, min_height, max_height) = (
+                width as f32,
+                depth as f32,
+                min_height as f32,
+                max_height as f32,
+            );
+            if !width.is_finite()
+                || !depth.is_finite()
+                || !min_height.is_finite()
+                || !max_height.is_finite()
+                || width <= 0.0
+                || depth <= 0.0
+                || max_height <= min_height
+            {
+                return Err(format!("usage: {HEIGHTMAP}"));
+            }
+            Ok(FunctorLangTerrain(TerrainDescription::heightmap(
+                asset.path,
+                asset.while_pending,
+                width,
+                depth,
+                min_height,
+                max_height,
+            )))
+        },
+    );
+    reg.fn2(
+        "Terrain.maxPixelError",
+        "Terrain.maxPixelError(pixels, terrain) — a positive finite pixel error",
+        |pixels: f64, terrain: FunctorLangTerrain| {
+            let pixels = pixels as f32;
+            if !pixels.is_finite() || pixels <= 0.0 {
+                return Err(
+                    "Terrain.maxPixelError pixels must be a positive finite number".to_string(),
+                );
+            }
+            Ok(FunctorLangTerrain(terrain.0.with_max_pixel_error(pixels)))
+        },
+    );
+    reg.fn2(
+        "Terrain.color",
+        "Terrain.color(color, terrain)",
+        |color: FunctorLangColor, terrain: FunctorLangTerrain| {
+            let (r, g, b) = color.0;
+            FunctorLangTerrain(terrain.0.with_color([r, g, b]))
+        },
+    );
+    reg.fn6(
+        "Terrain.layered",
+        "Terrain.layered(low, high, rock, snow, snowHeight, terrain)",
+        |low: FunctorLangColor,
+         high: FunctorLangColor,
+         rock: FunctorLangColor,
+         snow: FunctorLangColor,
+         snow_height: f64,
+         terrain: FunctorLangTerrain| {
+            let snow_height = snow_height as f32;
+            if !snow_height.is_finite() {
+                return Err("Terrain.layered snowHeight must be finite".to_string());
+            }
+            let color = |FunctorLangColor((r, g, b))| [r, g, b];
+            Ok(FunctorLangTerrain(terrain.0.with_layers(
+                crate::terrain::TerrainLayers {
+                    low: color(low),
+                    high: color(high),
+                    rock: color(rock),
+                    snow: color(snow),
+                    snow_height,
+                },
+            )))
+        },
+    );
+    reg.fn5(
+        "Terrain.grass",
+        "Terrain.grass(spacing, distance, bladeHeight, color, terrain)",
+        |spacing: f64,
+         distance: f64,
+         blade_height: f64,
+         color: FunctorLangColor,
+         terrain: FunctorLangTerrain| {
+            let (spacing, distance, blade_height) = (
+                spacing as f32,
+                distance as f32,
+                blade_height as f32,
+            );
+            if !spacing.is_finite()
+                || !distance.is_finite()
+                || !blade_height.is_finite()
+                || spacing <= 0.0
+                || distance <= 0.0
+                || blade_height <= 0.0
+            {
+                return Err(
+                    "Terrain.grass spacing, distance, and bladeHeight must be positive finite numbers"
+                        .to_string(),
+                );
+            }
+            let (r, g, b) = color.0;
+            Ok(FunctorLangTerrain(
+                terrain.0.with_grass(crate::terrain::TerrainGrass {
+                    spacing,
+                    distance,
+                    blade_height,
+                    color: [r, g, b],
+                }),
+            ))
+        },
+    );
 }
 
 /// The Scene vocabulary — geometry constructors, assets, composition,
@@ -1643,6 +1781,22 @@ fn register_camera(reg: &mut crate::host_registry::Registry) {
                 ("forward".to_string(), point(mapped.forward)),
                 ("up".to_string(), point(mapped.up)),
             ])))
+        },
+    );
+    reg.fn3(
+        "Camera.clip",
+        "Camera.clip(near, far, camera) — finite distances with 0 < near < far",
+        |near: f64, far: f64, mut camera: FunctorLangCamera| {
+            let (near, far) = (near as f32, far as f32);
+            if !near.is_finite() || !far.is_finite() || near <= 0.0 || far <= near {
+                return Err(
+                    "usage: Camera.clip(near, far, camera) — finite distances with 0 < near < far"
+                        .to_string(),
+                );
+            }
+            camera.0.near = near;
+            camera.0.far = far;
+            Ok(camera)
         },
     );
 }
@@ -2943,6 +3097,53 @@ struct ModelPath {
     while_pending: Vec<String>,
 }
 
+/// A texture-asset locator for data-oriented consumers that need the original
+/// image samples, rather than a material [`TextureDescription`]. Terrain must
+/// retain the locator and placeholder chain so render and physics hydrate the
+/// same source.
+struct TextureAssetPath {
+    path: String,
+    while_pending: Vec<String>,
+}
+
+impl crate::host_registry::FromArg for TextureAssetPath {
+    fn from_arg(value: &Value, path: &str, span: Span) -> Result<Self, RunError> {
+        match value {
+            v if asset_of(v).is_some() => {
+                let locator = asset_path(v, AssetKind::Texture, path, span)?;
+                let chain = asset_of(v)
+                    .map(|asset| asset.while_pending.clone())
+                    .unwrap_or_default();
+                Ok(Self {
+                    path: locator,
+                    while_pending: chain,
+                })
+            }
+            Value::String(p) => Err(RunError {
+                message: format!(
+                    "{path}: bare asset paths are no longer accepted — reference the \
+generated manifest (run `functor import`, then Assets.<name>), or construct \
+Asset.texture({}) at the data boundary",
+                    if p.is_empty() {
+                        "\"file.png\"".to_string()
+                    } else {
+                        format!("\"{p}\"")
+                    }
+                ),
+                span,
+            }),
+            other => Err(RunError {
+                message: format!(
+                    "{path}: expected a texture Asset value (the generated manifest's \
+Assets.<name>, or Asset.texture(…)), got {}",
+                    other.kind_name()
+                ),
+                span,
+            }),
+        }
+    }
+}
+
 impl crate::host_registry::FromArg for ModelPath {
     fn from_arg(value: &Value, path: &str, span: Span) -> Result<Self, RunError> {
         match value {
@@ -3068,6 +3269,7 @@ macro_rules! handle_arg {
 }
 
 handle_arg!(
+    FunctorLangTerrain => "a Terrain",
     FunctorLangScene => "a Scene",
     FunctorLangLight => "a Light",
     FunctorLangCamera => "a Camera",
@@ -5221,6 +5423,35 @@ texture placeholder for a model asset; construct it with Asset.model(…)",
     }
 
     #[test]
+    fn camera_clip_supports_large_worlds_and_validates_depth_precision() {
+        let value = eval(
+            "let main = () =>\n\
+               Camera.lookAt(Vec3.make(0.0, 100.0, -500.0), Vec3.make(0.0, 0.0, 0.0))\n\
+               |> Camera.clip(0.5, 6000.0)",
+        );
+        let Value::HostData(data) = value else {
+            panic!("expected Camera host data");
+        };
+        let camera = data
+            .as_any()
+            .downcast_ref::<FunctorLangCamera>()
+            .expect("Camera");
+        assert_eq!((camera.0.near, camera.0.far), (0.5, 6000.0));
+        assert_eq!(
+            fail_message(
+                "let main = () => Camera.lookAt(Vec3.make(0.0, 1.0, -3.0), Vec3.make(0.0, 0.0, 0.0)) |> Camera.clip(1.0, 0.5)"
+            ),
+            "usage: Camera.clip(near, far, camera) — finite distances with 0 < near < far"
+        );
+        assert_eq!(
+            fail_message(
+                "let main = () => Camera.lookAt(Vec3.make(0.0, 1.0, -3.0), Vec3.make(0.0, 0.0, 0.0)) |> Camera.clip(1.0, 1.00000001)"
+            ),
+            "usage: Camera.clip(near, far, camera) — finite distances with 0 < near < far"
+        );
+    }
+
+    #[test]
     fn spot_light_and_normal_mapped_material() {
         let frame = frame_of(
             "let bumps = Texture.file(\"bumps-normal.png\")\n\
@@ -6875,6 +7106,44 @@ row 1 has 3"
         assert_eq!(
             run_fail("let main = () => Scene.heightmap([[0.0, 1.0], [2.0, \"x\"]])"),
             "expected a number, got a string"
+        );
+    }
+
+    #[test]
+    fn terrain_descriptor_validates_assets_and_dimensions() {
+        let usage = "usage: Terrain.heightmap(asset, width, depth, minHeight, maxHeight) — \
+a texture Asset, positive dimensions, and maxHeight greater than minHeight";
+        assert_eq!(
+            run_fail(
+                "let main = () => Terrain.heightmap(Asset.texture(\"world.png\"), 0.0, 4000.0, -80.0, 520.0)"
+            ),
+            usage
+        );
+        assert_eq!(
+            run_fail(
+                "let main = () => Terrain.heightmap(Asset.texture(\"world.png\"), 4000.0, 4000.0, 10.0, 10.0)"
+            ),
+            usage
+        );
+        assert!(run_fail(
+            "let main = () => Terrain.heightmap(\"world.png\", 4000.0, 4000.0, -80.0, 520.0)"
+        )
+        .contains("construct Asset.texture(\"world.png\") at the data boundary"));
+        assert!(run_fail(
+            "let main = () => Terrain.heightmap(Asset.model(\"world.glb\"), 4000.0, 4000.0, -80.0, 520.0)"
+        )
+        .contains("expected a texture asset, got a model asset"));
+        assert_eq!(
+            run_fail(
+                "let main = () => Terrain.heightmap(Asset.texture(\"world.png\"), 4000.0, 4000.0, -80.0, 520.0) |> Terrain.maxPixelError(0.0)"
+            ),
+            "Terrain.maxPixelError pixels must be a positive finite number"
+        );
+        assert_eq!(
+            run_fail(
+                "let main = () => Terrain.heightmap(Asset.texture(\"world.png\"), 0.00000000000000000000000000000000000000000000001, 4000.0, -80.0, 520.0)"
+            ),
+            usage
         );
     }
 

--- a/runtime/functor-runtime-common/src/lib.rs
+++ b/runtime/functor-runtime-common/src/lib.rs
@@ -91,6 +91,7 @@ pub mod shadow;
 pub mod skybox;
 mod shader_program;
 mod sprite2d;
+pub mod terrain;
 pub mod texture;
 pub mod timetravel;
 pub mod trajectory;
@@ -111,6 +112,7 @@ pub use renderer::*;
 pub use skybox::SkyboxDescription;
 pub use scene3d::*;
 pub use sprite2d::{Camera2D, SpriteLayer};
+pub use terrain::{TerrainDescription, TerrainGeometry, TerrainGrass, TerrainLayers};
 pub use trajectory::{
     frame_preview, interactive_preview, overlay, scene_preview, trajectory_trail, FramePreview,
     InteractivePreview, PreviewMode, PreviewOptions, SceneOverlays, ScenePreview, StrobeOptions,

--- a/runtime/functor-runtime-common/src/terrain.rs
+++ b/runtime/functor-runtime-common/src/terrain.rs
@@ -1,0 +1,152 @@
+use serde::{Deserialize, Serialize};
+
+/// The collision-relevant subset of a terrain descriptor.
+///
+/// Physics stores this rather than the full render descriptor so changing LOD,
+/// colors, or vegetation does not rebuild a multi-megabyte collider.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct TerrainGeometry {
+    pub heightmap: String,
+    pub width: f32,
+    pub depth: f32,
+    pub min_height: f32,
+    pub max_height: f32,
+}
+
+/// Height/slope-driven terrain colors evaluated per fragment.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct TerrainLayers {
+    pub low: [f32; 3],
+    pub high: [f32; 3],
+    pub rock: [f32; 3],
+    pub snow: [f32; 3],
+    pub snow_height: f32,
+}
+
+/// GPU-instanced grass clusters around the camera.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct TerrainGrass {
+    /// Approximate spacing between clusters in terrain-local world units.
+    pub spacing: f32,
+    /// Camera-centered draw radius in terrain-local world units.
+    pub distance: f32,
+    pub blade_height: f32,
+    pub color: [f32; 3],
+}
+
+/// A finite heightfield terrain shared by the rendering and physics protocols.
+///
+/// Heights are normalized unsigned samples from `heightmap`: black maps to
+/// `min_height`, white maps to `max_height`. The terrain is centered on the
+/// local origin, spans `width × depth` in XZ, and remains ordinary immutable
+/// protocol data so the render and physics adapters cannot drift.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct TerrainDescription {
+    pub heightmap: String,
+    #[serde(default)]
+    pub while_pending: Vec<String>,
+    pub width: f32,
+    pub depth: f32,
+    pub min_height: f32,
+    pub max_height: f32,
+    pub max_pixel_error: f32,
+    pub color: [f32; 3],
+    #[serde(default)]
+    pub layers: Option<TerrainLayers>,
+    #[serde(default)]
+    pub grass: Option<TerrainGrass>,
+}
+
+impl TerrainDescription {
+    pub const DEFAULT_MAX_PIXEL_ERROR: f32 = 2.0;
+    pub const DEFAULT_COLOR: [f32; 3] = [0.34, 0.48, 0.24];
+
+    pub fn heightmap(
+        heightmap: String,
+        while_pending: Vec<String>,
+        width: f32,
+        depth: f32,
+        min_height: f32,
+        max_height: f32,
+    ) -> Self {
+        Self {
+            heightmap,
+            while_pending,
+            width,
+            depth,
+            min_height,
+            max_height,
+            max_pixel_error: Self::DEFAULT_MAX_PIXEL_ERROR,
+            color: Self::DEFAULT_COLOR,
+            layers: None,
+            grass: None,
+        }
+    }
+
+    pub fn with_max_pixel_error(mut self, max_pixel_error: f32) -> Self {
+        self.max_pixel_error = max_pixel_error;
+        self
+    }
+
+    pub fn with_color(mut self, color: [f32; 3]) -> Self {
+        self.color = color;
+        self.layers = None;
+        self
+    }
+
+    pub fn with_layers(mut self, layers: TerrainLayers) -> Self {
+        self.layers = Some(layers);
+        self
+    }
+
+    pub fn with_grass(mut self, grass: TerrainGrass) -> Self {
+        self.grass = Some(grass);
+        self
+    }
+
+    pub fn geometry(&self) -> TerrainGeometry {
+        TerrainGeometry {
+            heightmap: self.heightmap.clone(),
+            width: self.width,
+            depth: self.depth,
+            min_height: self.min_height,
+            max_height: self.max_height,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn terrain_description_roundtrips_through_the_protocol() {
+        let terrain = TerrainDescription::heightmap(
+            "island.png".to_string(),
+            vec!["island-low.png".to_string()],
+            4000.0,
+            4000.0,
+            -80.0,
+            520.0,
+        )
+        .with_max_pixel_error(3.0)
+        .with_layers(TerrainLayers {
+            low: [0.2, 0.4, 0.1],
+            high: [0.3, 0.5, 0.2],
+            rock: [0.25, 0.22, 0.2],
+            snow: [0.9, 0.95, 1.0],
+            snow_height: 300.0,
+        })
+        .with_grass(TerrainGrass {
+            spacing: 8.0,
+            distance: 300.0,
+            blade_height: 2.2,
+            color: [0.15, 0.32, 0.08],
+        });
+        let json = serde_json::to_string(&terrain).unwrap();
+        assert_eq!(
+            serde_json::from_str::<TerrainDescription>(&json).unwrap(),
+            terrain
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- add a serializable `Terrain.t` descriptor shared by rendering and physics consumers
- decode 8-bit and 16-bit grayscale heightmaps while preserving 16-bit samples
- add explicit `Camera.clip` near/far control for world-scale scenes
- expose typed, documented Functor Lang APIs with validation and teaching errors

## Design

The game describes a finite XZ terrain as immutable data: source asset, world dimensions, and height range. Runtime shells hydrate that descriptor independently, preserving the functional-core/imperative-shell boundary and the headless protocol path.

This is the foundation of a four-PR stack:

1. this descriptor/decoding PR
2. [#469](https://github.com/tommy-xr/functor/pull/469) — renderer
3. [#470](https://github.com/tommy-xr/functor/pull/470) — physics
4. [#471](https://github.com/tommy-xr/functor/pull/471) — showcase

## Validation

- `cargo test -p functor_runtime_common`
- `npm run check:docs`
- WebAssembly target check
- Quest arm64 target check

## Review disposition

The descriptor stays plain serializable protocol data; decoded samples and GPU resources remain shell-owned. Heightmap revision identity is content-derived, invalid images resolve to a valid flat fallback, and clip-plane validation rejects precision-hostile values at the language boundary.

Rebased onto the latest `main`; the existing tracked-pose camera API and the new world-scale clip API remain additive. The full validation set was re-run after the rebase.
