### PR TITLE
feat(terrain): add stereo-stable quadtree rendering

### DIFF
--- a/functor-prelude/prelude/scene.funi
+++ b/functor-prelude/prelude/scene.funi
@@ -21,6 +21,8 @@ let plane : () => t
 let model : (Asset.Model) => t
 /// Create terrain from a rectangular grid of height values.
 let heightmap : (List<List<float>>) => t
+/// Create a scene node from an asset-backed terrain descriptor.
+let terrain : (Terrain.t) => t
 
 /// Group scene nodes under one transform.
 let group : (List<t>) => t

--- a/functor-prelude/prelude/terrain.funi
+++ b/functor-prelude/prelude/terrain.funi
@@ -26,6 +26,6 @@ let layered : (Color.t, Color.t, Color.t, Color.t, float, t) => t
 /// Add camera-local GPU-instanced grass clusters.
 ///
 /// `spacing`, `distance`, and `bladeHeight` are terrain-local world units.
-/// Grass is suppressed on steep, flooded, and snowy samples. The terrain is
+/// Grass is suppressed on steep, low-lying, and snowy samples. The terrain is
 /// last for piping.
 let grass : (float, float, float, Color.t, t) => t

--- a/runtime/functor-runtime-common/src/asset/asset_cache.rs
+++ b/runtime/functor-runtime-common/src/asset/asset_cache.rs
@@ -259,11 +259,27 @@ pub fn resolve_while_pending<T: 'static>(
     primary: &AssetHandle<T>,
     while_pending: &[String],
 ) -> Arc<T> {
-    if while_pending.is_empty() {
-        // The overwhelmingly common case: byte-identical to the old
-        // single-poll `get()` path.
-        return primary.get();
+    match resolve_while_pending_state(cache, pipeline, primary, while_pending) {
+        WhilePendingState::Loaded(asset) | WhilePendingState::Loading(Some(asset)) => asset,
+        WhilePendingState::Loading(None) | WhilePendingState::Failed => primary.fallback(),
     }
+}
+
+/// Explicit state behind [`resolve_while_pending`]. Long-lived shell caches
+/// use this to retain stand-ins only while the primary is actually pending.
+#[derive(Clone, Debug, PartialEq)]
+pub enum WhilePendingState<T> {
+    Loading(Option<Arc<T>>),
+    Loaded(Arc<T>),
+    Failed,
+}
+
+pub fn resolve_while_pending_state<T: 'static>(
+    cache: &Arc<AssetCache>,
+    pipeline: &Arc<super::BuiltAssetPipeline<T>>,
+    primary: &AssetHandle<T>,
+    while_pending: &[String],
+) -> WhilePendingState<T> {
     let primary_state = primary.poll_state();
     let pending = matches!(primary_state, super::AssetPollState::Loading);
     let mut stand_in: Option<Arc<T>> = None;
@@ -278,9 +294,9 @@ pub fn resolve_while_pending<T: 'static>(
         }
     }
     match primary_state {
-        super::AssetPollState::Loaded(asset) => asset,
-        super::AssetPollState::Failed => primary.fallback(),
-        super::AssetPollState::Loading => stand_in.unwrap_or_else(|| primary.fallback()),
+        super::AssetPollState::Loaded(asset) => WhilePendingState::Loaded(asset),
+        super::AssetPollState::Failed => WhilePendingState::Failed,
+        super::AssetPollState::Loading => WhilePendingState::Loading(stand_in),
     }
 }
 

--- a/runtime/functor-runtime-common/src/asset/pipelines/heightmap_pipeline.rs
+++ b/runtime/functor-runtime-common/src/asset/pipelines/heightmap_pipeline.rs
@@ -10,8 +10,7 @@ pub struct HeightmapData {
     pub(crate) width: u32,
     pub(crate) height: u32,
     /// Deterministic content fingerprint for fast renderer/cache invalidation.
-    /// Semantic equality still includes the samples; `Arc<HeightmapData>`
-    /// takes a pointer fast path for unchanged per-frame declarations.
+    /// Semantic equality still includes the samples.
     pub(crate) revision: u64,
 }
 

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -1510,6 +1510,11 @@ manifest's Assets.<name>, or Asset.model(\"file.glb\")";
             while_pending: path.while_pending,
         }))
     });
+    reg.fn1(
+        "Scene.terrain",
+        "Scene.terrain(terrain)",
+        |terrain: FunctorLangTerrain| FunctorLangScene(Scene3D::terrain(terrain.0)),
+    );
     // A subdivided XZ grid displaced by per-vertex heights — the Functor Lang
     // face of F#'s `Scene3D.heightmap` (the protocol `Heightmap` shape). The
     // surface is a list of ROWS (each an equal-length list of heights):
@@ -7107,6 +7112,33 @@ row 1 has 3"
             run_fail("let main = () => Scene.heightmap([[0.0, 1.0], [2.0, \"x\"]])"),
             "expected a number, got a string"
         );
+    }
+
+    #[test]
+    fn terrain_descriptor_emits_the_protocol_leaf() {
+        let frame = frame_of(
+            "let world =\n\
+               Terrain.heightmap(Asset.texture(\"world.png\"), 4000.0, 4000.0, -80.0, 520.0)\n\
+               |> Terrain.maxPixelError(3.0)\n\
+               |> Terrain.color(Color.rgb(0.2, 0.4, 0.1))\n\
+             let main = () =>\n\
+               Frame.create(\n\
+                 Camera.lookAt(Vec3.make(0.0, 400.0, -900.0), Vec3.make(0.0, 0.0, 0.0)),\n\
+                 Scene.terrain(world))",
+        );
+        let SceneObject::Terrain(terrain) = &frame.scene.obj else {
+            panic!("expected a Terrain node, got {:?}", frame.scene.obj);
+        };
+        assert_eq!(terrain.heightmap, "world.png");
+        assert_eq!((terrain.width, terrain.depth), (4000.0, 4000.0));
+        assert_eq!((terrain.min_height, terrain.max_height), (-80.0, 520.0));
+        assert_eq!(terrain.max_pixel_error, 3.0);
+        assert_eq!(terrain.color, [0.2, 0.4, 0.1]);
+
+        let json = serde_json::to_string(&frame).expect("serialize");
+        assert!(json.contains(r#""Terrain""#), "json: {json}");
+        let back: Frame = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(serde_json::to_string(&back).unwrap(), json);
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/lib.rs
+++ b/runtime/functor-runtime-common/src/lib.rs
@@ -92,6 +92,7 @@ pub mod skybox;
 mod shader_program;
 mod sprite2d;
 pub mod terrain;
+mod terrain_renderer;
 pub mod texture;
 pub mod timetravel;
 pub mod trajectory;

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -69,6 +69,8 @@
 /// for now — nothing transmits or checks it; [`GameProducer`] impls all speak
 /// the current version.
 ///
+/// v6: heightmap terrain — the `SceneObject::Terrain` variant.
+///
 /// v5: sampled input — [`crate::InputSnapshot`] at the shell → producer seam.
 ///
 /// v4: sprite atlas source rectangles and nearest/linear sampling — the
@@ -82,7 +84,7 @@
 /// omitted when empty, so v1 frames read back and chainless frames stay v1-
 /// shaped) and the `TextureDescription::FileWhilePending` variant (a v1
 /// reader cannot decode a frame carrying one).
-pub const PROTOCOL_VERSION: u32 = 5;
+pub const PROTOCOL_VERSION: u32 = 6;
 
 /// The producer side of the protocol: one game logic instance as consumed by a
 /// runtime shell's frame loop. Every method carries a payload enumerated in
@@ -413,7 +415,7 @@ mod tests {
     fn sprite_atlas_material_wire_is_pinned() {
         use crate::{MaterialDescription, SpriteSampling, TextureDescription};
 
-        assert_eq!(PROTOCOL_VERSION, 5);
+        assert_eq!(PROTOCOL_VERSION, 6);
         let material = MaterialDescription::sprite_texture_tinted(
             TextureDescription::FileClamped("hero-atlas.png".to_string()),
             Some([96.0, 0.0, 96.0, 96.0]),

--- a/runtime/functor-runtime-common/src/render_context.rs
+++ b/runtime/functor-runtime-common/src/render_context.rs
@@ -126,4 +126,19 @@ pub struct RenderContext<'a> {
     /// The pass camera's world position — frame-constant, computed once per
     /// pass rather than per draw (the fog shader blends by distance from it).
     pub camera_pos: Vector3<f32>,
+    /// Stable center-camera data used only for terrain LOD selection.
+    ///
+    /// Stereo shells render the same [`Frame`](crate::Frame) twice with
+    /// per-eye view cameras. Keeping terrain selection tied to one live
+    /// tracked center pose makes both eyes draw the exact same patch set,
+    /// avoiding binocular shimmer while preserving per-eye rasterization.
+    pub lod_camera_pos: Vector3<f32>,
+    /// World-to-clip matrices whose frusta are unioned for culling. Stereo
+    /// shells provide both tracked eyes; mono passes use only element zero.
+    pub lod_view_projections: [Matrix4<f32>; 2],
+    pub lod_frustum_count: usize,
+    /// Vertical projection scale (`cot(fov_y / 2)`), used to turn terrain
+    /// world-space vertex spacing into projected pixels.
+    pub lod_projection_scale: f32,
+    pub viewport_height: f32,
 }

--- a/runtime/functor-runtime-common/src/renderer.rs
+++ b/runtime/functor-runtime-common/src/renderer.rs
@@ -59,6 +59,8 @@ pub fn render_frame(
         frame,
         camera,
         None,
+        None,
+        None,
         frame_time,
         viewport,
         debug_render_mode,
@@ -67,8 +69,11 @@ pub fn render_frame(
 
 /// Render one `Frame` using an externally supplied projection matrix for the
 /// main pass. XR shells use this to preserve the runtime's exact asymmetric
-/// per-eye frustum; render-target passes retain their own cameras and ordinary
-/// symmetric projections.
+/// per-eye frustum. `lod_camera`, `lod_view_projections`, and the shared LOD
+/// scale describe the tracked stereo pair used by both eye calls, so terrain
+/// draws the union of both eye frusta without regenerating per eye.
+/// Render-target passes retain their own cameras and ordinary symmetric
+/// projections.
 #[allow(clippy::too_many_arguments)]
 pub fn render_frame_with_projection(
     gl: &glow::Context,
@@ -79,6 +84,11 @@ pub fn render_frame_with_projection(
     frame: &Frame,
     camera: &Camera,
     projection_matrix: &Matrix4<f32>,
+    lod_camera: &Camera,
+    lod_view_projections: &[Matrix4<f32>],
+    lod_projection_scale: f32,
+    lod_viewport_height: f32,
+    terrain_frame_id: u64,
     frame_time: FrameTime,
     viewport: Viewport,
     debug_render_mode: DebugRenderMode,
@@ -92,6 +102,13 @@ pub fn render_frame_with_projection(
         frame,
         camera,
         Some(projection_matrix),
+        Some((
+            lod_camera,
+            lod_view_projections,
+            lod_projection_scale,
+            lod_viewport_height,
+        )),
+        Some(terrain_frame_id),
         frame_time,
         viewport,
         debug_render_mode,
@@ -108,10 +125,14 @@ fn render_frame_inner(
     frame: &Frame,
     camera: &Camera,
     projection_matrix: Option<&Matrix4<f32>>,
+    lod_view: Option<(&Camera, &[Matrix4<f32>], f32, f32)>,
+    terrain_frame_id: Option<u64>,
     frame_time: FrameTime,
     viewport: Viewport,
     debug_render_mode: DebugRenderMode,
 ) {
+    scene_context.begin_terrain_frame(terrain_frame_id);
+
     // Allocate buffers for EVERY declared target up front, so a target whose
     // scene samples a later-declared target reads last frame's image (initially
     // the clear color) rather than the magenta fallback. A duplicate id is a
@@ -190,6 +211,11 @@ target frame are ignored (depth 1 only)",
             pass.frame.fog.as_ref(),
             pass.frame.skybox.as_ref(),
             width as f32 / height as f32,
+            height as f32,
+            &pass.frame.camera,
+            None,
+            None,
+            None,
             None,
         );
         render_sprite_layers(
@@ -256,6 +282,11 @@ target frame are ignored (depth 1 only)",
         frame.fog.as_ref(),
         frame.skybox.as_ref(),
         viewport.aspect(),
+        viewport.height as f32,
+        lod_view.map_or(&frame.camera, |(camera, _, _, _)| camera),
+        lod_view.map(|(_, projections, _, _)| projections),
+        lod_view.map(|(_, _, projection_scale, _)| projection_scale),
+        lod_view.map(|(_, _, _, viewport_height)| viewport_height),
         projection_matrix,
     );
 
@@ -333,6 +364,11 @@ fn render_sprite_layers(
             None,
             None,
             fitted.aspect(),
+            fitted.height as f32,
+            &camera,
+            None,
+            None,
+            None,
             Some(&projection),
         );
     }
@@ -394,6 +430,7 @@ pub fn render_composited_frames(
         return;
     }
     let weights = normalize_weights(&weights[..n]);
+    scene_context.begin_terrain_frame(None);
 
     // 1. Render each input frame into its own full-viewport offscreen target,
     //    at its own frame time.
@@ -444,6 +481,11 @@ pub fn render_composited_frames(
             frame.fog.as_ref(),
             frame.skybox.as_ref(),
             width as f32 / height as f32,
+            height as f32,
+            &frame.camera,
+            None,
+            None,
+            None,
             None,
         );
         render_sprite_layers(
@@ -544,8 +586,22 @@ fn forward_pass(
     fog: Option<&crate::fog::Fog>,
     skybox: Option<&crate::skybox::SkyboxDescription>,
     aspect: f32,
+    viewport_height: f32,
+    lod_camera: &Camera,
+    lod_view_projections: Option<&[Matrix4<f32>]>,
+    lod_projection_scale: Option<f32>,
+    lod_viewport_height: Option<f32>,
     projection_matrix: Option<&Matrix4<f32>>,
 ) {
+    let default_lod_projection = lod_camera.projection_matrix(aspect);
+    let mut terrain_frusta = [Matrix4::from_scale(1.0); 2];
+    let supplied_frusta = lod_view_projections.unwrap_or(&[]);
+    let lod_frustum_count = supplied_frusta.len().clamp(1, terrain_frusta.len());
+    if supplied_frusta.is_empty() {
+        terrain_frusta[0] = default_lod_projection * lod_camera.view_matrix();
+    } else {
+        terrain_frusta[..lod_frustum_count].copy_from_slice(&supplied_frusta[..lod_frustum_count]);
+    }
     let render_context = RenderContext {
         gl,
         shader_version,
@@ -557,6 +613,16 @@ fn forward_pass(
         shadow,
         fog,
         camera_pos: cgmath::Vector3::new(camera.eye[0], camera.eye[1], camera.eye[2]),
+        lod_camera_pos: cgmath::Vector3::new(
+            lod_camera.eye[0],
+            lod_camera.eye[1],
+            lod_camera.eye[2],
+        ),
+        lod_view_projections: terrain_frusta,
+        lod_frustum_count,
+        lod_projection_scale: lod_projection_scale
+            .unwrap_or_else(|| default_lod_projection.y.y.abs()),
+        viewport_height: lod_viewport_height.unwrap_or(viewport_height),
     };
 
     // The game supplies the camera; derive its ordinary projection from the

--- a/runtime/functor-runtime-common/src/renderer.rs
+++ b/runtime/functor-runtime-common/src/renderer.rs
@@ -131,7 +131,7 @@ fn render_frame_inner(
     viewport: Viewport,
     debug_render_mode: DebugRenderMode,
 ) {
-    scene_context.begin_terrain_frame(terrain_frame_id);
+    scene_context.begin_terrain_frame(gl, terrain_frame_id);
 
     // Allocate buffers for EVERY declared target up front, so a target whose
     // scene samples a later-declared target reads last frame's image (initially
@@ -430,7 +430,7 @@ pub fn render_composited_frames(
         return;
     }
     let weights = normalize_weights(&weights[..n]);
-    scene_context.begin_terrain_frame(None);
+    scene_context.begin_terrain_frame(gl, None);
 
     // 1. Render each input frame into its own full-viewport offscreen target,
     //    at its own frame time.

--- a/runtime/functor-runtime-common/src/scene3d/mod.rs
+++ b/runtime/functor-runtime-common/src/scene3d/mod.rs
@@ -1,5 +1,8 @@
 use std::collections::{HashMap, HashSet};
-use std::{cell::RefCell, sync::Arc};
+use std::{
+    cell::{Cell, RefCell},
+    sync::Arc,
+};
 
 use glow::HasContext;
 
@@ -9,7 +12,9 @@ use serde::{Deserialize, Serialize};
 use crate::{
     asset::{
         self,
-        pipelines::{ModelPipeline, RawImagePipeline, TexturePipeline},
+        pipelines::{
+            HeightmapData, HeightmapPipeline, ModelPipeline, RawImagePipeline, TexturePipeline,
+        },
         AssetCache, AssetHandle, AssetPollState, BuiltAssetPipeline,
     },
     composite::{
@@ -27,6 +32,7 @@ use crate::{
     shader::{Shader, ShaderType},
     shader_program::{ShaderProgram, UniformLocation},
     skybox::{SkyboxDescription, SKYBOX_FRAGMENT_SHADER_SOURCE, SKYBOX_VERTEX_SHADER_SOURCE},
+    terrain_renderer::TerrainRenderer,
     texture::{RuntimeTexture, Texture2D, TextureData},
     DebugRenderMode, RenderContext, RenderPass,
 };
@@ -52,6 +58,9 @@ pub struct SceneContext {
     // GL mesh each frame; static terrain uploads exactly once. Keyed by
     // (rows, cols) — the stable identity of the mesh across frames.
     heightmaps: RefCell<HashMap<(u32, u32), geometry::HeightmapMesh>>,
+    heightmap_pipeline: Arc<BuiltAssetPipeline<HeightmapData>>,
+    terrain_renderer: RefCell<TerrainRenderer>,
+    terrain_frame_serial: Cell<u64>,
     // Render targets persist across frames/hot reloads, keyed by the target's
     // string id (the cross-frame identity). Buffers for ids a game stops
     // declaring are kept until exit — TODO: evict.
@@ -128,6 +137,7 @@ impl SceneContext {
         self.model_pipeline.evict(path);
         self.texture_pipeline.evict(path);
         self.raw_image_pipeline.evict(path);
+        self.heightmap_pipeline.evict(path);
         self.skyboxes
             .borrow_mut()
             .retain(|faces, _| !faces.split('\n').any(|face| face == path));
@@ -141,6 +151,9 @@ impl SceneContext {
             quad: RefCell::new(geometry::Quad::create()),
             plane: RefCell::new(geometry::Plane::create()),
             heightmaps: RefCell::new(HashMap::new()),
+            heightmap_pipeline: asset::build_pipeline(Box::new(HeightmapPipeline)),
+            terrain_renderer: RefCell::new(TerrainRenderer::default()),
+            terrain_frame_serial: Cell::new(0),
             texture_pipeline: asset::build_pipeline(Box::new(TexturePipeline)),
             model_pipeline: asset::build_pipeline(Box::new(ModelPipeline)),
             render_targets: RefCell::new(HashMap::new()),
@@ -152,6 +165,15 @@ impl SceneContext {
             composite_program: RefCell::new(None),
             preloads: RefCell::new(Vec::new()),
         }
+    }
+
+    pub(crate) fn begin_terrain_frame(&self, external_frame: Option<u64>) {
+        let frame = external_frame.unwrap_or_else(|| {
+            let next = self.terrain_frame_serial.get().wrapping_add(1);
+            self.terrain_frame_serial.set(next);
+            next
+        });
+        self.terrain_renderer.borrow_mut().begin_frame(frame);
     }
 
     /// The shell's per-frame preload step (B.5): turn this frame's
@@ -219,6 +241,34 @@ impl SceneContext {
             false
         });
         settled
+    }
+
+    fn draw_terrain(
+        &self,
+        render_context: &RenderContext,
+        terrain: &crate::terrain::TerrainDescription,
+        world: &Matrix4<f32>,
+        projection: &Matrix4<f32>,
+        view: &Matrix4<f32>,
+    ) {
+        let handle = render_context
+            .asset_cache
+            .load_asset_with_pipeline(self.heightmap_pipeline.clone(), &terrain.heightmap);
+        let source = crate::asset::resolve_while_pending(
+            &render_context.asset_cache,
+            &self.heightmap_pipeline,
+            &handle,
+            &terrain.while_pending,
+        );
+        crate::terrain::publish_heightmap(&terrain.heightmap, source.clone());
+        self.terrain_renderer.borrow_mut().draw(
+            render_context,
+            terrain,
+            source,
+            world,
+            projection,
+            view,
+        );
     }
 
     #[cfg(test)]
@@ -606,6 +656,7 @@ pub enum Shape {
 pub enum SceneObject {
     Geometry(Shape),
     Model(ModelDescription),
+    Terrain(Box<crate::terrain::TerrainDescription>),
     Material(MaterialDescription, Vec<Scene3D>),
     Group(Vec<Scene3D>),
 }
@@ -663,6 +714,13 @@ impl Scene3D {
         }
     }
 
+    pub fn terrain(terrain: crate::terrain::TerrainDescription) -> Self {
+        Scene3D {
+            obj: SceneObject::Terrain(Box::new(terrain)),
+            xform: Matrix4::identity(),
+        }
+    }
+
     /// Set the animation expression on every `Model` node in this subtree —
     /// `Scene.animate`'s semantics. Piping right after `Scene.model` targets
     /// that one model; applying over a group animates each model in it.
@@ -685,7 +743,7 @@ impl Scene3D {
                     .map(|item| item.with_animation(expr.clone()))
                     .collect(),
             ),
-            geometry @ SceneObject::Geometry(_) => geometry,
+            leaf @ (SceneObject::Geometry(_) | SceneObject::Terrain(_)) => leaf,
         };
         Scene3D { obj, ..self }
     }
@@ -959,6 +1017,23 @@ named \"{name}\" — {hint}"
                     }
                 }
             }
+
+            // The dedicated GPU terrain path is initialized and drawn here;
+            // keeping it as its own scene leaf (rather than a giant
+            // `Shape::Heightmap`) lets rendering choose LOD without changing
+            // the pure scene description. Terrain receives the forward
+            // pass's shadows but does not yet render into the shadow map.
+            SceneObject::Terrain(terrain) if !depth_pass => {
+                let xform = world_matrix * self.xform;
+                scene_context.draw_terrain(
+                    render_context,
+                    terrain,
+                    &xform,
+                    projection_matrix,
+                    view_matrix,
+                );
+            }
+            SceneObject::Terrain(_) => {}
 
             SceneObject::Material(material_description, items) => {
                 let material = material_description.get(render_context, scene_context);

--- a/runtime/functor-runtime-common/src/scene3d/mod.rs
+++ b/runtime/functor-runtime-common/src/scene3d/mod.rs
@@ -59,6 +59,7 @@ pub struct SceneContext {
     // (rows, cols) — the stable identity of the mesh across frames.
     heightmaps: RefCell<HashMap<(u32, u32), geometry::HeightmapMesh>>,
     heightmap_pipeline: Arc<BuiltAssetPipeline<HeightmapData>>,
+    terrain_decode_residency: RefCell<TerrainDecodeResidency>,
     terrain_renderer: RefCell<TerrainRenderer>,
     terrain_frame_serial: Cell<u64>,
     // Render targets persist across frames/hot reloads, keyed by the target's
@@ -104,6 +105,42 @@ enum PreloadHandle {
 /// stalled asset): beyond it the OLDEST token drops — its registered message
 /// then expires unclaimed, exactly like a capped [`PENDING_AUDIO`] eviction.
 const PRELOAD_TOKENS_CAP: usize = 1024;
+
+/// Decoded terrain sources receive one unused shell frame of grace before
+/// eviction. This retains ordinary frame-to-frame reuse without keeping every
+/// level/hot-reload heightmap alive for the process lifetime.
+#[derive(Default)]
+struct TerrainDecodeResidency {
+    epoch: u64,
+    last_used: HashMap<String, u64>,
+}
+
+impl TerrainDecodeResidency {
+    fn begin_epoch(&mut self) {
+        self.epoch = self.epoch.wrapping_add(1);
+    }
+
+    fn mark<'a>(&mut self, locators: impl IntoIterator<Item = &'a str>) {
+        for locator in locators {
+            if let Some(last_used) = self.last_used.get_mut(locator) {
+                *last_used = self.epoch;
+            } else {
+                self.last_used.insert(locator.to_string(), self.epoch);
+            }
+        }
+    }
+
+    fn evict_stale(&mut self, mut evict: impl FnMut(&str)) {
+        let epoch = self.epoch;
+        self.last_used.retain(|locator, last_used| {
+            let recent = epoch.wrapping_sub(*last_used) <= 1;
+            if !recent {
+                evict(locator);
+            }
+            recent
+        });
+    }
+}
 
 enum SkyboxEntry {
     /// Six pending face loads, in `SkyboxDescription::faces` order.
@@ -152,6 +189,7 @@ impl SceneContext {
             plane: RefCell::new(geometry::Plane::create()),
             heightmaps: RefCell::new(HashMap::new()),
             heightmap_pipeline: asset::build_pipeline(Box::new(HeightmapPipeline)),
+            terrain_decode_residency: RefCell::new(TerrainDecodeResidency::default()),
             terrain_renderer: RefCell::new(TerrainRenderer::default()),
             terrain_frame_serial: Cell::new(0),
             texture_pipeline: asset::build_pipeline(Box::new(TexturePipeline)),
@@ -167,13 +205,13 @@ impl SceneContext {
         }
     }
 
-    pub(crate) fn begin_terrain_frame(&self, external_frame: Option<u64>) {
+    pub(crate) fn begin_terrain_frame(&self, gl: &glow::Context, external_frame: Option<u64>) {
         let frame = external_frame.unwrap_or_else(|| {
             let next = self.terrain_frame_serial.get().wrapping_add(1);
             self.terrain_frame_serial.set(next);
             next
         });
-        self.terrain_renderer.borrow_mut().begin_frame(frame);
+        self.terrain_renderer.borrow_mut().begin_frame(gl, frame);
     }
 
     /// The shell's per-frame preload step (B.5): turn this frame's
@@ -190,6 +228,11 @@ impl SceneContext {
         asset_cache: &Arc<AssetCache>,
         commands: Vec<crate::asset::preload::PreloadCommand>,
     ) -> Vec<u64> {
+        {
+            let mut residency = self.terrain_decode_residency.borrow_mut();
+            residency.begin_epoch();
+            residency.evict_stale(|locator| self.heightmap_pipeline.evict(locator));
+        }
         use crate::asset::preload::PreloadKind;
         let mut preloads = self.preloads.borrow_mut();
         for cmd in commands {
@@ -251,6 +294,10 @@ impl SceneContext {
         projection: &Matrix4<f32>,
         view: &Matrix4<f32>,
     ) {
+        self.terrain_decode_residency.borrow_mut().mark(
+            std::iter::once(terrain.heightmap.as_str())
+                .chain(terrain.while_pending.iter().map(String::as_str)),
+        );
         let handle = render_context
             .asset_cache
             .load_asset_with_pipeline(self.heightmap_pipeline.clone(), &terrain.heightmap);
@@ -1307,5 +1354,27 @@ mod preload_tests {
         assert_eq!(ctx.preloads_in_flight(), 0);
         // The path counted once in progress despite three commands.
         assert_eq!(cache.progress().total, 1);
+    }
+
+    #[test]
+    fn terrain_decode_residency_evicts_sources_after_one_unused_epoch() {
+        let mut residency = TerrainDecodeResidency::default();
+        let mut evicted = Vec::new();
+
+        residency.begin_epoch();
+        residency.mark(["world-a.png", "proxy-a.png"]);
+        residency.evict_stale(|locator| evicted.push(locator.to_string()));
+        assert!(evicted.is_empty());
+
+        residency.begin_epoch();
+        residency.mark(["world-b.png"]);
+        residency.evict_stale(|locator| evicted.push(locator.to_string()));
+        assert!(evicted.is_empty(), "one unused epoch is retained as grace");
+
+        residency.begin_epoch();
+        residency.mark(["world-b.png"]);
+        residency.evict_stale(|locator| evicted.push(locator.to_string()));
+        evicted.sort();
+        assert_eq!(evicted, ["proxy-a.png", "world-a.png"]);
     }
 }

--- a/runtime/functor-runtime-common/src/scene3d/mod.rs
+++ b/runtime/functor-runtime-common/src/scene3d/mod.rs
@@ -146,6 +146,19 @@ impl TerrainDecodeResidency {
         );
     }
 
+    fn mark_unsettled(
+        &mut self,
+        locators: &[String],
+        mut is_unsettled: impl FnMut(&str) -> bool,
+    ) {
+        self.mark(
+            locators
+                .iter()
+                .filter(|locator| is_unsettled(locator))
+                .map(String::as_str),
+        );
+    }
+
     fn evict_stale(&mut self, mut evict: impl FnMut(&str)) {
         let epoch = self.epoch;
         self.last_used.retain(|locator, last_used| {
@@ -313,6 +326,15 @@ impl SceneContext {
         let handle = render_context
             .asset_cache
             .load_asset_with_pipeline(self.heightmap_pipeline.clone(), &terrain.heightmap);
+        // Snapshot residency before polling. A hot-reloaded stand-in can
+        // decode and settle synchronously inside resolve_while_pending_state;
+        // after that poll is_unsettled() is already false, so a post-poll
+        // mark alone would let the new decoded handle escape eviction.
+        self.terrain_decode_residency
+            .borrow_mut()
+            .mark_unsettled(&terrain.while_pending, |locator| {
+                render_context.asset_cache.is_unsettled(locator)
+            });
         let resolved = crate::asset::resolve_while_pending_state(
             &render_context.asset_cache,
             &self.heightmap_pipeline,
@@ -1424,5 +1446,92 @@ mod preload_tests {
         residency.evict_stale(|locator| evicted.push(locator.to_string()));
         assert_eq!(evicted, ["world-low.png"]);
         assert!(residency.last_used.contains_key("world.png"));
+    }
+
+    #[test]
+    fn synchronously_reloaded_terrain_stand_in_remains_evictable() {
+        let ctx = SceneContext::new();
+        let cache = Arc::new(AssetCache::new());
+        let primary = temp_glb("terrain-residency-primary.png");
+        let stand_in = temp_glb("terrain-residency-stand-in.png");
+        let pending = vec![stand_in.clone()];
+        let primary_handle =
+            cache.load_asset_with_pipeline(ctx.heightmap_pipeline.clone(), &primary);
+        assert!(matches!(
+            primary_handle.poll_state(),
+            AssetPollState::Loaded(_)
+        ));
+        let stand_in_handle =
+            cache.load_asset_with_pipeline(ctx.heightmap_pipeline.clone(), &stand_in);
+        assert!(matches!(
+            stand_in_handle.poll_state(),
+            AssetPollState::Loaded(_)
+        ));
+
+        // Let the original settled stand-in age out of decoded residency.
+        {
+            let mut residency = ctx.terrain_decode_residency.borrow_mut();
+            residency.begin_epoch();
+            residency.mark([primary.as_str(), stand_in.as_str()]);
+            residency.evict_stale(|locator| ctx.heightmap_pipeline.evict(locator));
+            residency.begin_epoch();
+            residency.mark([primary.as_str()]);
+            residency.evict_stale(|locator| ctx.heightmap_pipeline.evict(locator));
+            residency.begin_epoch();
+            residency.mark([primary.as_str()]);
+            residency.evict_stale(|locator| ctx.heightmap_pipeline.evict(locator));
+        }
+        assert!(ctx.heightmap_pipeline.get_opt(&stand_in).is_none());
+
+        // Hot reload makes the already-started stand-in unsettled. Its local
+        // read then settles synchronously during resolution while the primary
+        // remains loaded.
+        cache.evict(&stand_in);
+        ctx.heightmap_pipeline.evict(&stand_in);
+        assert!(cache.is_unsettled(&stand_in));
+        {
+            let mut residency = ctx.terrain_decode_residency.borrow_mut();
+            residency.mark_unsettled(&pending, |locator| cache.is_unsettled(locator));
+        }
+        assert!(matches!(
+            crate::asset::resolve_while_pending_state(
+                &cache,
+                &ctx.heightmap_pipeline,
+                &primary_handle,
+                &pending,
+            ),
+            crate::asset::WhilePendingState::Loaded(_)
+        ));
+        assert!(!cache.is_unsettled(&stand_in));
+        ctx.terrain_decode_residency.borrow_mut().mark_source(
+            &primary,
+            &pending,
+            false,
+            |locator| cache.is_unsettled(locator),
+        );
+        assert!(
+            ctx.terrain_decode_residency
+                .borrow()
+                .last_used
+                .contains_key(&stand_in),
+            "the pre-poll mark retains a synchronously settled decode"
+        );
+
+        // The refreshed decode still receives one grace epoch, then expires.
+        {
+            let mut residency = ctx.terrain_decode_residency.borrow_mut();
+            residency.begin_epoch();
+            residency.mark([primary.as_str()]);
+            residency.evict_stale(|locator| ctx.heightmap_pipeline.evict(locator));
+            assert!(ctx.heightmap_pipeline.get_opt(&stand_in).is_some());
+            residency.begin_epoch();
+            residency.mark([primary.as_str()]);
+            residency.evict_stale(|locator| ctx.heightmap_pipeline.evict(locator));
+        }
+        assert!(ctx.heightmap_pipeline.get_opt(&stand_in).is_none());
+
+        for path in [primary, stand_in] {
+            let _ = std::fs::remove_file(path);
+        }
     }
 }

--- a/runtime/functor-runtime-common/src/scene3d/mod.rs
+++ b/runtime/functor-runtime-common/src/scene3d/mod.rs
@@ -130,6 +130,22 @@ impl TerrainDecodeResidency {
         }
     }
 
+    fn mark_source(
+        &mut self,
+        primary: &str,
+        while_pending: &[String],
+        primary_is_loading: bool,
+        mut is_unsettled: impl FnMut(&str) -> bool,
+    ) {
+        self.mark(std::iter::once(primary));
+        self.mark(
+            while_pending
+                .iter()
+                .filter(|locator| primary_is_loading || is_unsettled(locator))
+                .map(String::as_str),
+        );
+    }
+
     fn evict_stale(&mut self, mut evict: impl FnMut(&str)) {
         let epoch = self.epoch;
         self.last_used.retain(|locator, last_used| {
@@ -294,19 +310,29 @@ impl SceneContext {
         projection: &Matrix4<f32>,
         view: &Matrix4<f32>,
     ) {
-        self.terrain_decode_residency.borrow_mut().mark(
-            std::iter::once(terrain.heightmap.as_str())
-                .chain(terrain.while_pending.iter().map(String::as_str)),
-        );
         let handle = render_context
             .asset_cache
             .load_asset_with_pipeline(self.heightmap_pipeline.clone(), &terrain.heightmap);
-        let source = crate::asset::resolve_while_pending(
+        let resolved = crate::asset::resolve_while_pending_state(
             &render_context.asset_cache,
             &self.heightmap_pipeline,
             &handle,
             &terrain.while_pending,
         );
+        let primary_is_loading =
+            matches!(&resolved, crate::asset::WhilePendingState::Loading(_));
+        self.terrain_decode_residency.borrow_mut().mark_source(
+            &terrain.heightmap,
+            &terrain.while_pending,
+            primary_is_loading,
+            |locator| render_context.asset_cache.is_unsettled(locator),
+        );
+        let source = match resolved {
+            crate::asset::WhilePendingState::Loaded(data)
+            | crate::asset::WhilePendingState::Loading(Some(data)) => data,
+            crate::asset::WhilePendingState::Loading(None)
+            | crate::asset::WhilePendingState::Failed => handle.fallback(),
+        };
         crate::terrain::publish_heightmap(&terrain.heightmap, source.clone());
         self.terrain_renderer.borrow_mut().draw(
             render_context,
@@ -1376,5 +1402,27 @@ mod preload_tests {
         residency.evict_stale(|locator| evicted.push(locator.to_string()));
         evicted.sort();
         assert_eq!(evicted, ["proxy-a.png", "world-a.png"]);
+    }
+
+    #[test]
+    fn settled_terrain_stand_ins_expire_while_the_primary_stays_resident() {
+        let mut residency = TerrainDecodeResidency::default();
+        let pending = vec!["world-low.png".to_string()];
+        let mut evicted = Vec::new();
+
+        residency.begin_epoch();
+        residency.mark_source("world.png", &pending, true, |_| false);
+        residency.evict_stale(|locator| evicted.push(locator.to_string()));
+
+        residency.begin_epoch();
+        residency.mark_source("world.png", &pending, false, |_| false);
+        residency.evict_stale(|locator| evicted.push(locator.to_string()));
+        assert!(evicted.is_empty(), "stand-in keeps one epoch of grace");
+
+        residency.begin_epoch();
+        residency.mark_source("world.png", &pending, false, |_| false);
+        residency.evict_stale(|locator| evicted.push(locator.to_string()));
+        assert_eq!(evicted, ["world-low.png"]);
+        assert!(residency.last_used.contains_key("world.png"));
     }
 }

--- a/runtime/functor-runtime-common/src/shader_program.rs
+++ b/runtime/functor-runtime-common/src/shader_program.rs
@@ -1,6 +1,6 @@
 use std::slice;
 
-use cgmath::{conv::array4x4, Matrix4, Vector3, Vector4};
+use cgmath::{conv::array4x4, Matrix3, Matrix4, Vector3, Vector4};
 use glow::*;
 
 pub struct ShaderProgram {
@@ -127,6 +127,25 @@ impl ShaderProgram {
                 Some(&uniform_location.native_uniform_location),
                 false,
                 raw,
+            );
+        }
+    }
+
+    pub fn set_uniform_matrix3(
+        &self,
+        gl: &glow::Context,
+        uniform_location: &UniformLocation,
+        matrix: &Matrix3<f32>,
+    ) {
+        let raw = [
+            matrix.x.x, matrix.x.y, matrix.x.z, matrix.y.x, matrix.y.y, matrix.y.z, matrix.z.x,
+            matrix.z.y, matrix.z.z,
+        ];
+        unsafe {
+            gl.uniform_matrix_3_f32_slice(
+                Some(&uniform_location.native_uniform_location),
+                false,
+                &raw,
             );
         }
     }

--- a/runtime/functor-runtime-common/src/shadow.rs
+++ b/runtime/functor-runtime-common/src/shadow.rs
@@ -206,6 +206,14 @@ pub fn render_shadow_pass(
         // Fog is a forward-pass concern; the depth pass renders no color.
         fog: None,
         camera_pos: cgmath::Vector3::new(0.0, 0.0, 0.0),
+        // Terrain currently skips the shadow-only pass; keep a complete
+        // context so adding that pass later cannot accidentally select LOD
+        // independently for the two eyes.
+        lod_camera_pos: cgmath::Vector3::new(0.0, 0.0, 0.0),
+        lod_view_projections: [Matrix4::identity(); 2],
+        lod_frustum_count: 1,
+        lod_projection_scale: 1.0,
+        viewport_height: shadow_map.size as f32,
     };
 
     let mut depth_material = DepthMaterial::create();

--- a/runtime/functor-runtime-common/src/terrain.rs
+++ b/runtime/functor-runtime-common/src/terrain.rs
@@ -1,4 +1,37 @@
 use serde::{Deserialize, Serialize};
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    sync::{Arc, Weak},
+};
+
+use crate::asset::pipelines::HeightmapData;
+
+thread_local! {
+    /// Decoded terrain sources shared by the render and physics adapters on
+    /// the runtime thread. The descriptor remains plain immutable data; this
+    /// is only the shell-side hydration cache, analogous to GPU resources.
+    static HEIGHTMAPS: RefCell<HashMap<String, Weak<HeightmapData>>> =
+        RefCell::new(HashMap::new());
+}
+
+pub(crate) fn publish_heightmap(locator: &str, data: Arc<HeightmapData>) {
+    HEIGHTMAPS.with(|heightmaps| {
+        let mut heightmaps = heightmaps.borrow_mut();
+        let unchanged = heightmaps
+            .get(locator)
+            .and_then(Weak::upgrade)
+            // HeightmapData is Eq, so Arc equality first takes the pointer
+            // fast path and only compares samples after a real reload.
+            .is_some_and(|current| current == data);
+        if !unchanged {
+            // The asset pipeline and current physics declaration own the
+            // samples. This lookup bridge must not pin a 32 MiB 4096² map
+            // after its runtime/project has gone away.
+            heightmaps.insert(locator.to_string(), Arc::downgrade(&data));
+        }
+    });
+}
 
 /// The collision-relevant subset of a terrain descriptor.
 ///
@@ -148,5 +181,18 @@ mod tests {
             serde_json::from_str::<TerrainDescription>(&json).unwrap(),
             terrain
         );
+    }
+
+    #[test]
+    fn hydration_registry_does_not_retain_heightmap_samples() {
+        let locator = "weak-registry-test.png";
+        let data = Arc::new(HeightmapData::flat());
+        let weak = Arc::downgrade(&data);
+        publish_heightmap(locator, data.clone());
+        assert_eq!(Arc::strong_count(&data), 1);
+
+        drop(data);
+        assert!(weak.upgrade().is_none());
+        HEIGHTMAPS.with(|heightmaps| heightmaps.borrow_mut().remove(locator));
     }
 }

--- a/runtime/functor-runtime-common/src/terrain_renderer.rs
+++ b/runtime/functor-runtime-common/src/terrain_renderer.rs
@@ -1,0 +1,1697 @@
+//! GPU terrain rendering: a finite quadtree selected on the CPU and drawn as
+//! instances of one immutable 64×64 grid.
+//!
+//! The heightmap stays a 16-bit integer texture. Vertices sample it directly,
+//! so changing LOD uploads only a small instance list; it never rebuilds or
+//! uploads a world-sized mesh. Border skirts hide T-junctions between adjacent
+//! LODs. Selection uses the frame's stable center camera, shared by both eyes.
+
+use std::{collections::HashMap, sync::Arc};
+
+use cgmath::{InnerSpace, Matrix, Matrix3, Matrix4, SquareMatrix, Vector3, Vector4};
+use glow::HasContext;
+
+use crate::{
+    asset::pipelines::HeightmapData,
+    fog::{FogUniforms, FOG_GLSL},
+    light::{lighting_glsl, LightingUniforms},
+    shader::{Shader, ShaderType},
+    shader_program::{ShaderProgram, UniformLocation},
+    DebugRenderMode, RenderContext, TerrainDescription, TerrainGrass,
+};
+
+const PATCH_QUADS: u32 = 64;
+const MAX_LEVEL: u32 = 10;
+const MAX_INSTANCES: usize = 8192;
+const MAX_GRASS_INSTANCES: usize = 20_000;
+
+const VERTEX_SHADER_SOURCE: &str = r#"
+        // uv.xy plus 1 for a duplicated skirt vertex.
+        layout (location = 0) in vec3 inGrid;
+        // normalized heightmap offset.xy and scale.xy.
+        layout (location = 1) in vec4 inPatch;
+
+        uniform mat4 world;
+        uniform mat3 normalMatrix;
+        uniform mat4 view;
+        uniform mat4 projection;
+        uniform highp usampler2D heightmapTex;
+        uniform vec3 terrainSize; // width, depth, height range
+        uniform float minHeight;
+        uniform float skirtDepth;
+
+        out vec3 worldNormal;
+        out vec3 worldTangent;
+        out vec3 worldPos;
+        out float localHeight;
+
+        float heightAt(vec2 uv) {
+            ivec2 size = textureSize(heightmapTex, 0);
+            ivec2 maxCoord = size - ivec2(1);
+            vec2 p = clamp(uv, vec2(0.0), vec2(1.0)) * vec2(maxCoord);
+            ivec2 a = ivec2(floor(p));
+            ivec2 b = min(a + ivec2(1), maxCoord);
+            vec2 f = fract(p);
+            float h00 = float(texelFetch(heightmapTex, a, 0).r);
+            float h10 = float(texelFetch(heightmapTex, ivec2(b.x, a.y), 0).r);
+            float h01 = float(texelFetch(heightmapTex, ivec2(a.x, b.y), 0).r);
+            float h11 = float(texelFetch(heightmapTex, b, 0).r);
+            float normalized = mix(mix(h00, h10, f.x), mix(h01, h11, f.x), f.y)
+                / 65535.0;
+            return minHeight + normalized * terrainSize.z;
+        }
+
+        void main() {
+            vec2 uv = inPatch.xy + inGrid.xy * inPatch.zw;
+            ivec2 texSize = textureSize(heightmapTex, 0);
+            vec2 texel = 1.0 / vec2(max(texSize - ivec2(1), ivec2(1)));
+
+            float h = heightAt(uv);
+            float hL = heightAt(uv - vec2(texel.x, 0.0));
+            float hR = heightAt(uv + vec2(texel.x, 0.0));
+            float hD = heightAt(uv - vec2(0.0, texel.y));
+            float hU = heightAt(uv + vec2(0.0, texel.y));
+            float dx = terrainSize.x * texel.x;
+            float dz = terrainSize.y * texel.y;
+            float dhdx = (hR - hL) / max(2.0 * dx, 1e-5);
+            float dhdz = (hU - hD) / max(2.0 * dz, 1e-5);
+
+            vec3 localNormal = normalize(vec3(-dhdx, 1.0, -dhdz));
+            vec3 localTangent = normalize(vec3(1.0, dhdx, 0.0));
+            worldNormal = normalMatrix * localNormal;
+            worldTangent = mat3(world) * localTangent;
+
+            vec3 localPos = vec3(
+                (uv.x - 0.5) * terrainSize.x,
+                h - inGrid.z * skirtDepth,
+                (uv.y - 0.5) * terrainSize.y);
+            vec4 wp = world * vec4(localPos, 1.0);
+            worldPos = wp.xyz;
+            localHeight = h;
+            gl_Position = projection * view * wp;
+        }
+"#;
+
+const FRAGMENT_SHADER_SOURCE: &str = r#"
+        in vec3 worldNormal;
+        in vec3 worldTangent;
+        in vec3 worldPos;
+        in float localHeight;
+
+        uniform vec3 terrainColor;
+        uniform int useLayers;
+        uniform vec3 lowColor;
+        uniform vec3 highColor;
+        uniform vec3 rockColor;
+        uniform vec3 snowColor;
+        uniform float minTerrainHeight;
+        uniform float maxTerrainHeight;
+        uniform float snowHeight;
+        uniform int debugMode; // 0=lit, 1=normals, 2=tangents
+
+        out vec4 fragColor;
+
+        void main() {
+            vec3 n = normalize(worldNormal);
+            if (debugMode == 1) {
+                fragColor = vec4(n * 0.5 + 0.5, 1.0);
+                return;
+            }
+            if (debugMode == 2) {
+                fragColor = vec4(normalize(worldTangent) * 0.5 + 0.5, 1.0);
+                return;
+            }
+
+            vec3 diffuseLight;
+            vec3 specularLight;
+            accumulateLights(n, worldPos, diffuseLight, specularLight);
+            vec3 albedo = terrainColor;
+            if (useLayers == 1) {
+                float heightRange = max(maxTerrainHeight - minTerrainHeight, 1e-4);
+                float h = clamp((localHeight - minTerrainHeight) / heightRange, 0.0, 1.0);
+                albedo = mix(lowColor, highColor, smoothstep(0.15, 0.72, h));
+                float slope = 1.0 - clamp(n.y, 0.0, 1.0);
+                float rockWeight = smoothstep(0.30, 0.67, slope);
+                albedo = mix(albedo, rockColor, rockWeight);
+                float snowWeight = smoothstep(
+                    snowHeight,
+                    snowHeight + heightRange * 0.08,
+                    localHeight) * (1.0 - rockWeight * 0.72);
+                albedo = mix(albedo, snowColor, snowWeight);
+            }
+            vec3 shaded = albedo * diffuseLight + specularLight;
+            fragColor = vec4(applyFog(shaded, worldPos), 1.0);
+        }
+"#;
+
+const GRASS_VERTEX_SHADER_SOURCE: &str = r#"
+        // A small crossed-blade cluster, authored around the local origin.
+        layout (location = 0) in vec3 inBlade;
+        // Terrain-local x/z, random rotation, and height scale.
+        layout (location = 1) in vec4 inGrass;
+
+        uniform mat4 world;
+        uniform mat4 view;
+        uniform mat4 projection;
+        uniform highp usampler2D heightmapTex;
+        uniform vec3 terrainSize; // width, depth, height range
+        uniform float minHeight;
+        uniform float snowHeight;
+        uniform float bladeHeight;
+        uniform float time;
+
+        out vec3 worldPos;
+        out float shade;
+        out float visibility;
+
+        float heightAt(vec2 uv) {
+            ivec2 size = textureSize(heightmapTex, 0);
+            ivec2 maxCoord = size - ivec2(1);
+            vec2 p = clamp(uv, vec2(0.0), vec2(1.0)) * vec2(maxCoord);
+            ivec2 a = ivec2(floor(p));
+            ivec2 b = min(a + ivec2(1), maxCoord);
+            vec2 f = fract(p);
+            float h00 = float(texelFetch(heightmapTex, a, 0).r);
+            float h10 = float(texelFetch(heightmapTex, ivec2(b.x, a.y), 0).r);
+            float h01 = float(texelFetch(heightmapTex, ivec2(a.x, b.y), 0).r);
+            float h11 = float(texelFetch(heightmapTex, b, 0).r);
+            return minHeight
+                + mix(mix(h00, h10, f.x), mix(h01, h11, f.x), f.y)
+                    / 65535.0 * terrainSize.z;
+        }
+
+        void main() {
+            vec2 uv = vec2(
+                inGrass.x / terrainSize.x + 0.5,
+                inGrass.y / terrainSize.y + 0.5);
+            ivec2 texSize = textureSize(heightmapTex, 0);
+            vec2 texel = 1.0 / vec2(max(texSize - ivec2(1), ivec2(1)));
+            float h = heightAt(uv);
+            float hL = heightAt(uv - vec2(texel.x, 0.0));
+            float hR = heightAt(uv + vec2(texel.x, 0.0));
+            float hD = heightAt(uv - vec2(0.0, texel.y));
+            float hU = heightAt(uv + vec2(0.0, texel.y));
+            float dx = terrainSize.x * texel.x;
+            float dz = terrainSize.y * texel.y;
+            vec3 normal = normalize(vec3(
+                -(hR - hL) / max(2.0 * dx, 1e-5),
+                1.0,
+                -(hU - hD) / max(2.0 * dz, 1e-5)));
+
+            float low = minHeight + terrainSize.z * 0.16;
+            float aboveWater = smoothstep(low, low + terrainSize.z * 0.06, h);
+            float belowSnow = 1.0 - smoothstep(
+                snowHeight - terrainSize.z * 0.05,
+                snowHeight,
+                h);
+            float flatEnough = smoothstep(0.68, 0.80, normal.y);
+            visibility = aboveWater * belowSnow * flatEnough;
+
+            float angle = inGrass.z;
+            float c = cos(angle);
+            float s = sin(angle);
+            vec3 blade = inBlade * bladeHeight * inGrass.w * visibility;
+            blade.xz = mat2(c, -s, s, c) * blade.xz;
+            float wind = sin(time * 1.7 + inGrass.x * 0.019 + inGrass.y * 0.013);
+            blade.xz += vec2(wind, wind * 0.37) * blade.y * blade.y * 0.16;
+
+            vec3 localPos = vec3(inGrass.x, h, inGrass.y) + blade;
+            vec4 wp = world * vec4(localPos, 1.0);
+            worldPos = wp.xyz;
+            shade = mix(0.68, 1.12, inBlade.y) * mix(0.86, 1.08, inGrass.w - 0.7);
+            gl_Position = projection * view * wp;
+        }
+"#;
+
+const GRASS_FRAGMENT_SHADER_SOURCE: &str = r#"
+        in vec3 worldPos;
+        in float shade;
+        in float visibility;
+
+        uniform vec3 grassColor;
+
+        out vec4 fragColor;
+
+        void main() {
+            if (visibility < 0.08) {
+                discard;
+            }
+            fragColor = vec4(applyFog(grassColor * shade, worldPos), 1.0);
+        }
+"#;
+
+struct TerrainUniforms {
+    world: UniformLocation,
+    normal_matrix: UniformLocation,
+    view: UniformLocation,
+    projection: UniformLocation,
+    heightmap: UniformLocation,
+    terrain_size: UniformLocation,
+    min_height: UniformLocation,
+    skirt_depth: UniformLocation,
+    color: UniformLocation,
+    use_layers: UniformLocation,
+    low_color: UniformLocation,
+    high_color: UniformLocation,
+    rock_color: UniformLocation,
+    snow_color: UniformLocation,
+    min_terrain_height: UniformLocation,
+    max_terrain_height: UniformLocation,
+    snow_height: UniformLocation,
+    debug_mode: UniformLocation,
+    lighting: LightingUniforms,
+    fog: FogUniforms,
+}
+
+struct TerrainProgram {
+    program: ShaderProgram,
+    uniforms: TerrainUniforms,
+}
+
+struct GrassUniforms {
+    world: UniformLocation,
+    view: UniformLocation,
+    projection: UniformLocation,
+    heightmap: UniformLocation,
+    terrain_size: UniformLocation,
+    min_height: UniformLocation,
+    snow_height: UniformLocation,
+    blade_height: UniformLocation,
+    time: UniformLocation,
+    color: UniformLocation,
+    fog: FogUniforms,
+}
+
+struct GrassProgram {
+    program: ShaderProgram,
+    uniforms: GrassUniforms,
+}
+
+struct TerrainGeometry {
+    key: TerrainInstanceKey,
+    vao: glow::VertexArray,
+    _grid_vbo: glow::Buffer,
+    _index_ebo: glow::Buffer,
+    instance_vbo: glow::Buffer,
+    index_count: i32,
+    last_used_frame: u64,
+    cache_key: Option<PatchCacheKey>,
+    scratch_instances: Vec<[f32; 4]>,
+    uploaded_instances: Vec<[f32; 4]>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct TerrainInstanceKey {
+    heightmap: String,
+    terrain_width_bits: u32,
+    terrain_depth_bits: u32,
+    min_height_bits: u32,
+    max_height_bits: u32,
+    max_pixel_error_bits: u32,
+    world_bits: [u32; 16],
+}
+
+impl TerrainInstanceKey {
+    fn new(description: &TerrainDescription, world: &Matrix4<f32>) -> Self {
+        let matrix: &[f32; 16] = world.as_ref();
+        Self {
+            heightmap: description.heightmap.clone(),
+            terrain_width_bits: description.width.to_bits(),
+            terrain_depth_bits: description.depth.to_bits(),
+            min_height_bits: description.min_height.to_bits(),
+            max_height_bits: description.max_height.to_bits(),
+            max_pixel_error_bits: description.max_pixel_error.to_bits(),
+            world_bits: std::array::from_fn(|index| matrix[index].to_bits()),
+        }
+    }
+
+    fn matches(&self, description: &TerrainDescription, world: &Matrix4<f32>) -> bool {
+        let matrix: &[f32; 16] = world.as_ref();
+        self.heightmap == description.heightmap
+            && self.terrain_width_bits == description.width.to_bits()
+            && self.terrain_depth_bits == description.depth.to_bits()
+            && self.min_height_bits == description.min_height.to_bits()
+            && self.max_height_bits == description.max_height.to_bits()
+            && self.max_pixel_error_bits == description.max_pixel_error.to_bits()
+            && self
+                .world_bits
+                .iter()
+                .zip(matrix)
+                .all(|(cached, current)| *cached == current.to_bits())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct PatchCacheKey {
+    sample_width: u32,
+    sample_height: u32,
+    terrain_width: f32,
+    terrain_depth: f32,
+    min_height: f32,
+    max_height: f32,
+    max_pixel_error: f32,
+    world: Matrix4<f32>,
+    camera_pos: Vector3<f32>,
+    view_projections: [Matrix4<f32>; 2],
+    frustum_count: usize,
+    projection_scale: f32,
+    viewport_height: f32,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct GrassCacheKey {
+    camera_cell_x: i32,
+    camera_cell_z: i32,
+    terrain_width: f32,
+    terrain_depth: f32,
+    grass: TerrainGrass,
+}
+
+struct GrassGeometry {
+    key: TerrainInstanceKey,
+    vao: glow::VertexArray,
+    _blade_vbo: glow::Buffer,
+    instance_vbo: glow::Buffer,
+    vertex_count: i32,
+    last_used_frame: u64,
+    cache_key: Option<GrassCacheKey>,
+    scratch_instances: Vec<[f32; 4]>,
+    uploaded_instances: Vec<[f32; 4]>,
+}
+
+struct HeightTexture {
+    source: Arc<HeightmapData>,
+    texture: glow::Texture,
+}
+
+#[derive(Default)]
+pub(crate) struct TerrainRenderer {
+    program: Option<TerrainProgram>,
+    geometries: Vec<TerrainGeometry>,
+    grass_program: Option<GrassProgram>,
+    grass_geometries: Vec<GrassGeometry>,
+    height_textures: HashMap<String, HeightTexture>,
+    current_frame: u64,
+}
+
+impl TerrainRenderer {
+    pub(crate) fn begin_frame(&mut self, frame: u64) {
+        self.current_frame = frame;
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn draw(
+        &mut self,
+        ctx: &RenderContext,
+        description: &TerrainDescription,
+        source: Arc<HeightmapData>,
+        world: &Matrix4<f32>,
+        projection: &Matrix4<f32>,
+        view: &Matrix4<f32>,
+    ) {
+        if source.width < 2 || source.height < 2 {
+            return;
+        }
+
+        self.ensure_program(ctx);
+        let patch_key = PatchCacheKey {
+            sample_width: source.width,
+            sample_height: source.height,
+            terrain_width: description.width,
+            terrain_depth: description.depth,
+            min_height: description.min_height,
+            max_height: description.max_height,
+            max_pixel_error: description.max_pixel_error,
+            world: *world,
+            camera_pos: ctx.lod_camera_pos,
+            view_projections: ctx.lod_view_projections,
+            frustum_count: ctx.lod_frustum_count,
+            projection_scale: ctx.lod_projection_scale,
+            viewport_height: ctx.viewport_height,
+        };
+        let geometry_index = self.ensure_geometry(ctx.gl, description, world, &patch_key);
+        let height_texture =
+            self.ensure_height_texture(ctx.gl, &description.heightmap, source.clone());
+        let geometry = &mut self.geometries[geometry_index];
+        let gl = ctx.gl;
+
+        if geometry.cache_key.as_ref() != Some(&patch_key) {
+            select_patches_into(
+                description,
+                source.width,
+                source.height,
+                world,
+                ctx.lod_camera_pos,
+                &ctx.lod_view_projections[..ctx.lod_frustum_count],
+                ctx.lod_projection_scale,
+                ctx.viewport_height,
+                &mut geometry.scratch_instances,
+            );
+            if geometry.uploaded_instances != geometry.scratch_instances {
+                unsafe {
+                    gl.bind_buffer(glow::ARRAY_BUFFER, Some(geometry.instance_vbo));
+                    let bytes = slice_bytes(&geometry.scratch_instances);
+                    gl.buffer_sub_data_u8_slice(glow::ARRAY_BUFFER, 0, bytes);
+                    crate::gpu_counters::gpu_counters().uploaded(bytes.len());
+                    gl.bind_buffer(glow::ARRAY_BUFFER, None);
+                }
+                geometry
+                    .uploaded_instances
+                    .clone_from(&geometry.scratch_instances);
+            }
+            geometry.cache_key = Some(patch_key);
+        }
+        if geometry.uploaded_instances.is_empty() {
+            return;
+        }
+
+        let program = self.program.as_ref().expect("terrain program initialized");
+        let normal_matrix = terrain_normal_matrix(world);
+        unsafe {
+            let p = &program.program;
+            let u = &program.uniforms;
+            p.use_program(gl);
+            p.set_uniform_matrix4(gl, &u.world, world);
+            p.set_uniform_matrix3(gl, &u.normal_matrix, &normal_matrix);
+            p.set_uniform_matrix4(gl, &u.view, view);
+            p.set_uniform_matrix4(gl, &u.projection, projection);
+            p.set_uniform_1i(gl, &u.heightmap, 0);
+            p.set_uniform_vec3(
+                gl,
+                &u.terrain_size,
+                &Vector3::new(
+                    description.width,
+                    description.depth,
+                    description.max_height - description.min_height,
+                ),
+            );
+            let (use_layers, low, high, rock, snow, snow_height) = match description.layers.as_ref()
+            {
+                Some(layers) => (
+                    1,
+                    layers.low,
+                    layers.high,
+                    layers.rock,
+                    layers.snow,
+                    layers.snow_height,
+                ),
+                None => (
+                    0,
+                    description.color,
+                    description.color,
+                    description.color,
+                    description.color,
+                    description.max_height,
+                ),
+            };
+            p.set_uniform_1i(gl, &u.use_layers, use_layers);
+            for (location, color) in [
+                (&u.low_color, low),
+                (&u.high_color, high),
+                (&u.rock_color, rock),
+                (&u.snow_color, snow),
+            ] {
+                p.set_uniform_vec3(gl, location, &Vector3::new(color[0], color[1], color[2]));
+            }
+            p.set_uniform_1f(gl, &u.min_terrain_height, description.min_height);
+            p.set_uniform_1f(gl, &u.max_terrain_height, description.max_height);
+            p.set_uniform_1f(gl, &u.snow_height, snow_height);
+            p.set_uniform_1f(gl, &u.min_height, description.min_height);
+            p.set_uniform_1f(
+                gl,
+                &u.skirt_depth,
+                ((description.max_height - description.min_height) * 0.03).max(2.0),
+            );
+            p.set_uniform_vec3(
+                gl,
+                &u.color,
+                &Vector3::new(
+                    description.color[0],
+                    description.color[1],
+                    description.color[2],
+                ),
+            );
+            let debug_mode = match ctx.debug_render_mode {
+                DebugRenderMode::Normals => 1,
+                DebugRenderMode::Tangents => 2,
+                DebugRenderMode::Default | DebugRenderMode::Physics => 0,
+            };
+            p.set_uniform_1i(gl, &u.debug_mode, debug_mode);
+            u.lighting.set(p, ctx, view);
+            u.fog.set(p, gl, ctx.fog, &ctx.camera_pos);
+
+            gl.active_texture(glow::TEXTURE0);
+            gl.bind_texture(glow::TEXTURE_2D, Some(height_texture));
+            gl.bind_vertex_array(Some(geometry.vao));
+            gl.draw_elements_instanced(
+                glow::TRIANGLES,
+                geometry.index_count,
+                glow::UNSIGNED_SHORT,
+                0,
+                geometry.uploaded_instances.len() as i32,
+            );
+            gl.bind_vertex_array(None);
+            gl.bind_texture(glow::TEXTURE_2D, None);
+        }
+
+        if matches!(
+            ctx.debug_render_mode,
+            DebugRenderMode::Default | DebugRenderMode::Physics
+        ) {
+            if let Some(grass) = description.grass.as_ref() {
+                self.draw_grass(
+                    ctx,
+                    description,
+                    grass,
+                    height_texture,
+                    world,
+                    projection,
+                    view,
+                );
+            }
+        }
+    }
+
+    fn ensure_program(&mut self, ctx: &RenderContext) {
+        if self.program.is_some() {
+            return;
+        }
+        let vertex = Shader::build(
+            ctx.gl,
+            ShaderType::Vertex,
+            VERTEX_SHADER_SOURCE,
+            ctx.shader_version,
+        );
+        let fragment_source = format!(
+            "{}\n{}\n{}",
+            FOG_GLSL,
+            lighting_glsl(),
+            FRAGMENT_SHADER_SOURCE
+        );
+        let fragment = Shader::build(
+            ctx.gl,
+            ShaderType::Fragment,
+            &fragment_source,
+            ctx.shader_version,
+        );
+        let program = ShaderProgram::link(ctx.gl, &vertex, &fragment);
+        let uniforms = TerrainUniforms {
+            world: program.get_uniform_location(ctx.gl, "world"),
+            normal_matrix: program.get_uniform_location(ctx.gl, "normalMatrix"),
+            view: program.get_uniform_location(ctx.gl, "view"),
+            projection: program.get_uniform_location(ctx.gl, "projection"),
+            heightmap: program.get_uniform_location(ctx.gl, "heightmapTex"),
+            terrain_size: program.get_uniform_location(ctx.gl, "terrainSize"),
+            min_height: program.get_uniform_location(ctx.gl, "minHeight"),
+            skirt_depth: program.get_uniform_location(ctx.gl, "skirtDepth"),
+            color: program.get_uniform_location(ctx.gl, "terrainColor"),
+            use_layers: program.get_uniform_location(ctx.gl, "useLayers"),
+            low_color: program.get_uniform_location(ctx.gl, "lowColor"),
+            high_color: program.get_uniform_location(ctx.gl, "highColor"),
+            rock_color: program.get_uniform_location(ctx.gl, "rockColor"),
+            snow_color: program.get_uniform_location(ctx.gl, "snowColor"),
+            min_terrain_height: program.get_uniform_location(ctx.gl, "minTerrainHeight"),
+            max_terrain_height: program.get_uniform_location(ctx.gl, "maxTerrainHeight"),
+            snow_height: program.get_uniform_location(ctx.gl, "snowHeight"),
+            debug_mode: program.get_uniform_location(ctx.gl, "debugMode"),
+            lighting: LightingUniforms::get(&program, ctx.gl),
+            fog: FogUniforms::get(&program, ctx.gl),
+        };
+        self.program = Some(TerrainProgram { program, uniforms });
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn draw_grass(
+        &mut self,
+        ctx: &RenderContext,
+        description: &TerrainDescription,
+        grass: &TerrainGrass,
+        height_texture: glow::Texture,
+        world: &Matrix4<f32>,
+        projection: &Matrix4<f32>,
+        view: &Matrix4<f32>,
+    ) {
+        self.ensure_grass_program(ctx);
+        let cache_key = grass_cache_key(description, grass, world, ctx.lod_camera_pos);
+        let geometry_index = self.ensure_grass_geometry(ctx.gl, description, world, &cache_key);
+        let geometry = &mut self.grass_geometries[geometry_index];
+        if geometry.cache_key.as_ref() != Some(&cache_key) {
+            select_grass_instances_into(
+                description,
+                grass,
+                &cache_key,
+                &mut geometry.scratch_instances,
+            );
+            if geometry.uploaded_instances != geometry.scratch_instances {
+                unsafe {
+                    ctx.gl
+                        .bind_buffer(glow::ARRAY_BUFFER, Some(geometry.instance_vbo));
+                    let bytes = slice_bytes(&geometry.scratch_instances);
+                    ctx.gl
+                        .buffer_sub_data_u8_slice(glow::ARRAY_BUFFER, 0, bytes);
+                    crate::gpu_counters::gpu_counters().uploaded(bytes.len());
+                    ctx.gl.bind_buffer(glow::ARRAY_BUFFER, None);
+                }
+                geometry
+                    .uploaded_instances
+                    .clone_from(&geometry.scratch_instances);
+            }
+            geometry.cache_key = Some(cache_key);
+        }
+        if geometry.uploaded_instances.is_empty() {
+            return;
+        }
+
+        let program = self
+            .grass_program
+            .as_ref()
+            .expect("grass program initialized");
+        let gl = ctx.gl;
+        let snow_height = description
+            .layers
+            .as_ref()
+            .map(|layers| layers.snow_height)
+            .unwrap_or(description.max_height + grass.blade_height);
+        unsafe {
+            let p = &program.program;
+            let u = &program.uniforms;
+            p.use_program(gl);
+            p.set_uniform_matrix4(gl, &u.world, world);
+            p.set_uniform_matrix4(gl, &u.view, view);
+            p.set_uniform_matrix4(gl, &u.projection, projection);
+            p.set_uniform_1i(gl, &u.heightmap, 0);
+            p.set_uniform_vec3(
+                gl,
+                &u.terrain_size,
+                &Vector3::new(
+                    description.width,
+                    description.depth,
+                    description.max_height - description.min_height,
+                ),
+            );
+            p.set_uniform_1f(gl, &u.min_height, description.min_height);
+            p.set_uniform_1f(gl, &u.snow_height, snow_height);
+            p.set_uniform_1f(gl, &u.blade_height, grass.blade_height);
+            p.set_uniform_1f(gl, &u.time, ctx.frame_time.tts);
+            p.set_uniform_vec3(
+                gl,
+                &u.color,
+                &Vector3::new(grass.color[0], grass.color[1], grass.color[2]),
+            );
+            u.fog.set(p, gl, ctx.fog, &ctx.camera_pos);
+
+            gl.active_texture(glow::TEXTURE0);
+            gl.bind_texture(glow::TEXTURE_2D, Some(height_texture));
+            gl.bind_vertex_array(Some(geometry.vao));
+            gl.draw_arrays_instanced(
+                glow::TRIANGLES,
+                0,
+                geometry.vertex_count,
+                geometry.uploaded_instances.len() as i32,
+            );
+            gl.bind_vertex_array(None);
+            gl.bind_texture(glow::TEXTURE_2D, None);
+        }
+    }
+
+    fn ensure_grass_program(&mut self, ctx: &RenderContext) {
+        if self.grass_program.is_some() {
+            return;
+        }
+        let vertex = Shader::build(
+            ctx.gl,
+            ShaderType::Vertex,
+            GRASS_VERTEX_SHADER_SOURCE,
+            ctx.shader_version,
+        );
+        let fragment_source = format!("{}\n{}", FOG_GLSL, GRASS_FRAGMENT_SHADER_SOURCE);
+        let fragment = Shader::build(
+            ctx.gl,
+            ShaderType::Fragment,
+            &fragment_source,
+            ctx.shader_version,
+        );
+        let program = ShaderProgram::link(ctx.gl, &vertex, &fragment);
+        let uniforms = GrassUniforms {
+            world: program.get_uniform_location(ctx.gl, "world"),
+            view: program.get_uniform_location(ctx.gl, "view"),
+            projection: program.get_uniform_location(ctx.gl, "projection"),
+            heightmap: program.get_uniform_location(ctx.gl, "heightmapTex"),
+            terrain_size: program.get_uniform_location(ctx.gl, "terrainSize"),
+            min_height: program.get_uniform_location(ctx.gl, "minHeight"),
+            snow_height: program.get_uniform_location(ctx.gl, "snowHeight"),
+            blade_height: program.get_uniform_location(ctx.gl, "bladeHeight"),
+            time: program.get_uniform_location(ctx.gl, "time"),
+            color: program.get_uniform_location(ctx.gl, "grassColor"),
+            fog: FogUniforms::get(&program, ctx.gl),
+        };
+        self.grass_program = Some(GrassProgram { program, uniforms });
+    }
+
+    fn ensure_geometry(
+        &mut self,
+        gl: &glow::Context,
+        description: &TerrainDescription,
+        world: &Matrix4<f32>,
+        patch_key: &PatchCacheKey,
+    ) -> usize {
+        if let Some(index) = self.geometries.iter().position(|geometry| {
+            geometry.key.matches(description, world)
+                && geometry.cache_key.as_ref() == Some(patch_key)
+        }) {
+            self.geometries[index].last_used_frame = self.current_frame;
+            return index;
+        }
+        let key = TerrainInstanceKey::new(description, world);
+        if let Some(index) = self
+            .geometries
+            .iter()
+            .position(|geometry| geometry.last_used_frame != self.current_frame)
+        {
+            let geometry = &mut self.geometries[index];
+            geometry.key = key;
+            geometry.last_used_frame = self.current_frame;
+            geometry.cache_key = None;
+            return index;
+        }
+        let (vertices, indices) = build_patch_mesh();
+        unsafe {
+            let counters = crate::gpu_counters::gpu_counters();
+            let vao = gl.create_vertex_array().expect("terrain VAO");
+            counters.vao_created();
+            gl.bind_vertex_array(Some(vao));
+
+            let grid_vbo = gl.create_buffer().expect("terrain grid VBO");
+            counters.buffer_created();
+            gl.bind_buffer(glow::ARRAY_BUFFER, Some(grid_vbo));
+            let vertex_bytes = slice_bytes(&vertices);
+            gl.buffer_data_u8_slice(glow::ARRAY_BUFFER, vertex_bytes, glow::STATIC_DRAW);
+            counters.uploaded(vertex_bytes.len());
+            gl.enable_vertex_attrib_array(0);
+            gl.vertex_attrib_pointer_f32(0, 3, glow::FLOAT, false, 12, 0);
+
+            let instance_vbo = gl.create_buffer().expect("terrain instance VBO");
+            counters.buffer_created();
+            gl.bind_buffer(glow::ARRAY_BUFFER, Some(instance_vbo));
+            gl.buffer_data_size(
+                glow::ARRAY_BUFFER,
+                (MAX_INSTANCES * std::mem::size_of::<[f32; 4]>()) as i32,
+                glow::DYNAMIC_DRAW,
+            );
+            gl.enable_vertex_attrib_array(1);
+            gl.vertex_attrib_pointer_f32(1, 4, glow::FLOAT, false, 16, 0);
+            gl.vertex_attrib_divisor(1, 1);
+
+            let index_ebo = gl.create_buffer().expect("terrain index EBO");
+            counters.buffer_created();
+            gl.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, Some(index_ebo));
+            let index_bytes = slice_bytes(&indices);
+            gl.buffer_data_u8_slice(glow::ELEMENT_ARRAY_BUFFER, index_bytes, glow::STATIC_DRAW);
+            counters.uploaded(index_bytes.len());
+
+            gl.bind_vertex_array(None);
+            gl.bind_buffer(glow::ARRAY_BUFFER, None);
+            gl.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, None);
+            self.geometries.push(TerrainGeometry {
+                key,
+                vao,
+                _grid_vbo: grid_vbo,
+                _index_ebo: index_ebo,
+                instance_vbo,
+                index_count: indices.len() as i32,
+                last_used_frame: self.current_frame,
+                cache_key: None,
+                scratch_instances: Vec::new(),
+                uploaded_instances: Vec::new(),
+            });
+        }
+        self.geometries.len() - 1
+    }
+
+    fn ensure_grass_geometry(
+        &mut self,
+        gl: &glow::Context,
+        description: &TerrainDescription,
+        world: &Matrix4<f32>,
+        grass_key: &GrassCacheKey,
+    ) -> usize {
+        if let Some(index) = self.grass_geometries.iter().position(|geometry| {
+            geometry.key.matches(description, world)
+                && geometry.cache_key.as_ref() == Some(grass_key)
+        }) {
+            self.grass_geometries[index].last_used_frame = self.current_frame;
+            return index;
+        }
+        let key = TerrainInstanceKey::new(description, world);
+        if let Some(index) = self
+            .grass_geometries
+            .iter()
+            .position(|geometry| geometry.last_used_frame != self.current_frame)
+        {
+            let geometry = &mut self.grass_geometries[index];
+            geometry.key = key;
+            geometry.last_used_frame = self.current_frame;
+            geometry.cache_key = None;
+            return index;
+        }
+        let vertices = build_grass_cluster();
+        unsafe {
+            let counters = crate::gpu_counters::gpu_counters();
+            let vao = gl.create_vertex_array().expect("grass VAO");
+            counters.vao_created();
+            gl.bind_vertex_array(Some(vao));
+
+            let blade_vbo = gl.create_buffer().expect("grass blade VBO");
+            counters.buffer_created();
+            gl.bind_buffer(glow::ARRAY_BUFFER, Some(blade_vbo));
+            let vertex_bytes = slice_bytes(&vertices);
+            gl.buffer_data_u8_slice(glow::ARRAY_BUFFER, vertex_bytes, glow::STATIC_DRAW);
+            counters.uploaded(vertex_bytes.len());
+            gl.enable_vertex_attrib_array(0);
+            gl.vertex_attrib_pointer_f32(0, 3, glow::FLOAT, false, 12, 0);
+
+            let instance_vbo = gl.create_buffer().expect("grass instance VBO");
+            counters.buffer_created();
+            gl.bind_buffer(glow::ARRAY_BUFFER, Some(instance_vbo));
+            gl.buffer_data_size(
+                glow::ARRAY_BUFFER,
+                (MAX_GRASS_INSTANCES * std::mem::size_of::<[f32; 4]>()) as i32,
+                glow::DYNAMIC_DRAW,
+            );
+            gl.enable_vertex_attrib_array(1);
+            gl.vertex_attrib_pointer_f32(1, 4, glow::FLOAT, false, 16, 0);
+            gl.vertex_attrib_divisor(1, 1);
+
+            gl.bind_vertex_array(None);
+            gl.bind_buffer(glow::ARRAY_BUFFER, None);
+            self.grass_geometries.push(GrassGeometry {
+                key,
+                vao,
+                _blade_vbo: blade_vbo,
+                instance_vbo,
+                vertex_count: vertices.len() as i32,
+                last_used_frame: self.current_frame,
+                cache_key: None,
+                scratch_instances: Vec::new(),
+                uploaded_instances: Vec::new(),
+            });
+        }
+        self.grass_geometries.len() - 1
+    }
+
+    fn ensure_height_texture(
+        &mut self,
+        gl: &glow::Context,
+        locator: &str,
+        source: Arc<HeightmapData>,
+    ) -> glow::Texture {
+        let unchanged = self
+            .height_textures
+            .get(locator)
+            .is_some_and(|entry| Arc::ptr_eq(&entry.source, &source));
+        if unchanged {
+            crate::gpu_counters::gpu_counters().cache_hit();
+            return self.height_textures[locator].texture;
+        }
+
+        let counters = crate::gpu_counters::gpu_counters();
+        counters.cache_miss();
+        if let Some(stale) = self.height_textures.remove(locator) {
+            unsafe {
+                gl.delete_texture(stale.texture);
+            }
+            counters.texture_deleted();
+        }
+
+        let max_size = unsafe { gl.get_parameter_i32(glow::MAX_TEXTURE_SIZE) }.max(2) as u32;
+        let resized;
+        let (samples, width, height) = if source.width > max_size || source.height > max_size {
+            let fitted = fit_heightmap(&source, max_size);
+            eprintln!(
+                "[terrain] \"{locator}\" is {}x{}, above this GPU's {}px texture limit; \
+rendering a {}x{} height copy",
+                source.width, source.height, max_size, fitted.1, fitted.2
+            );
+            resized = Some(fitted);
+            let fitted = resized.as_ref().unwrap();
+            (fitted.0.as_slice(), fitted.1, fitted.2)
+        } else {
+            resized = None;
+            (source.samples.as_slice(), source.width, source.height)
+        };
+        let _keep_resized_alive = &resized;
+
+        let texture = unsafe {
+            let texture = gl.create_texture().expect("terrain height texture");
+            counters.texture_created();
+            gl.active_texture(glow::TEXTURE0);
+            gl.bind_texture(glow::TEXTURE_2D, Some(texture));
+            gl.pixel_store_i32(glow::UNPACK_ALIGNMENT, 1);
+            let bytes = slice_bytes(samples);
+            gl.tex_image_2d(
+                glow::TEXTURE_2D,
+                0,
+                glow::R16UI as i32,
+                width as i32,
+                height as i32,
+                0,
+                glow::RED_INTEGER,
+                glow::UNSIGNED_SHORT,
+                glow::PixelUnpackData::Slice(Some(bytes)),
+            );
+            counters.uploaded(bytes.len());
+            gl.tex_parameter_i32(
+                glow::TEXTURE_2D,
+                glow::TEXTURE_MIN_FILTER,
+                glow::NEAREST as i32,
+            );
+            gl.tex_parameter_i32(
+                glow::TEXTURE_2D,
+                glow::TEXTURE_MAG_FILTER,
+                glow::NEAREST as i32,
+            );
+            gl.tex_parameter_i32(
+                glow::TEXTURE_2D,
+                glow::TEXTURE_WRAP_S,
+                glow::CLAMP_TO_EDGE as i32,
+            );
+            gl.tex_parameter_i32(
+                glow::TEXTURE_2D,
+                glow::TEXTURE_WRAP_T,
+                glow::CLAMP_TO_EDGE as i32,
+            );
+            gl.pixel_store_i32(glow::UNPACK_ALIGNMENT, 4);
+            gl.bind_texture(glow::TEXTURE_2D, None);
+            texture
+        };
+        self.height_textures
+            .insert(locator.to_string(), HeightTexture { source, texture });
+        texture
+    }
+}
+
+fn build_grass_cluster() -> Vec<[f32; 3]> {
+    let mut vertices = Vec::with_capacity(18);
+    for angle in [
+        0.0f32,
+        std::f32::consts::FRAC_PI_3,
+        std::f32::consts::FRAC_PI_3 * 2.0,
+    ] {
+        let (sin, cos) = angle.sin_cos();
+        let left = [-cos * 0.09, 0.0, sin * 0.09];
+        let top = [0.0, 1.0, 0.0];
+        let right = [cos * 0.09, 0.0, -sin * 0.09];
+        vertices.extend_from_slice(&[left, top, right, right, top, left]);
+    }
+    vertices
+}
+
+fn build_patch_mesh() -> (Vec<[f32; 3]>, Vec<u16>) {
+    let side = PATCH_QUADS + 1;
+    let mut vertices = Vec::with_capacity((side * side + side * 4) as usize);
+    for z in 0..side {
+        for x in 0..side {
+            vertices.push([
+                x as f32 / PATCH_QUADS as f32,
+                z as f32 / PATCH_QUADS as f32,
+                0.0,
+            ]);
+        }
+    }
+
+    let mut indices = Vec::with_capacity((PATCH_QUADS * PATCH_QUADS * 6 + side * 24) as usize);
+    for z in 0..PATCH_QUADS {
+        for x in 0..PATCH_QUADS {
+            let a = (z * side + x) as u16;
+            let b = a + 1;
+            let c = ((z + 1) * side + x) as u16;
+            let d = c + 1;
+            // Counter-clockwise from +Y in the engine's XZ ground plane.
+            indices.extend_from_slice(&[a, c, b, b, c, d]);
+        }
+    }
+
+    // One ordered loop around the patch. Duplicated vertices get lowered in
+    // the shader; triangles connect them to the main border as a vertical
+    // skirt, masking coarse/fine T-junctions.
+    let mut perimeter = Vec::with_capacity((PATCH_QUADS * 4) as usize);
+    for x in 0..side {
+        perimeter.push(x as u16);
+    }
+    for z in 1..side {
+        perimeter.push((z * side + PATCH_QUADS) as u16);
+    }
+    for x in (0..PATCH_QUADS).rev() {
+        perimeter.push((PATCH_QUADS * side + x) as u16);
+    }
+    for z in (1..PATCH_QUADS).rev() {
+        perimeter.push((z * side) as u16);
+    }
+    let skirt_start = vertices.len() as u16;
+    for main in &perimeter {
+        let mut vertex = vertices[*main as usize];
+        vertex[2] = 1.0;
+        vertices.push(vertex);
+    }
+    for i in 0..perimeter.len() {
+        let next = (i + 1) % perimeter.len();
+        let a = perimeter[i];
+        let b = perimeter[next];
+        let sa = skirt_start + i as u16;
+        let sb = skirt_start + next as u16;
+        indices.extend_from_slice(&[a, sa, b, b, sa, sb]);
+    }
+    (vertices, indices)
+}
+
+fn grass_cache_key(
+    description: &TerrainDescription,
+    grass: &TerrainGrass,
+    world: &Matrix4<f32>,
+    camera_world: Vector3<f32>,
+) -> GrassCacheKey {
+    let inverse = world.invert().unwrap_or_else(Matrix4::identity);
+    let local4 = inverse * Vector4::new(camera_world.x, camera_world.y, camera_world.z, 1.0);
+    let camera_local = local4.truncate() / local4.w.max(1e-6);
+    let camera_cell_x = (camera_local.x / grass.spacing).floor() as i32;
+    let camera_cell_z = (camera_local.z / grass.spacing).floor() as i32;
+    GrassCacheKey {
+        camera_cell_x,
+        camera_cell_z,
+        terrain_width: description.width,
+        terrain_depth: description.depth,
+        grass: grass.clone(),
+    }
+}
+
+fn select_grass_instances_into(
+    description: &TerrainDescription,
+    grass: &TerrainGrass,
+    key: &GrassCacheKey,
+    instances: &mut Vec<[f32; 4]>,
+) {
+    instances.clear();
+    let radius_cells = (grass.distance / grass.spacing).ceil().max(0.0) as i32;
+    let estimated = std::f32::consts::PI * radius_cells as f32 * radius_cells as f32;
+    let stride = (estimated / MAX_GRASS_INSTANCES as f32)
+        .sqrt()
+        .ceil()
+        .max(1.0) as i32;
+    let anchor_x = key.camera_cell_x as f32 * grass.spacing;
+    let anchor_z = key.camera_cell_z as f32 * grass.spacing;
+    let half_width = description.width * 0.5;
+    let half_depth = description.depth * 0.5;
+    let radius_squared = grass.distance * grass.distance;
+    let desired_capacity =
+        ((estimated / (stride * stride) as f32).ceil() as usize).min(MAX_GRASS_INSTANCES);
+    if instances.capacity() < desired_capacity {
+        instances.reserve(desired_capacity);
+    }
+
+    for dz in (-radius_cells..=radius_cells).step_by(stride as usize) {
+        for dx in (-radius_cells..=radius_cells).step_by(stride as usize) {
+            let cell_x = key.camera_cell_x.saturating_add(dx);
+            let cell_z = key.camera_cell_z.saturating_add(dz);
+            let hash = grass_hash(cell_x, cell_z);
+            let jitter_x = hash_unit(hash) - 0.5;
+            let jitter_z = hash_unit(hash.rotate_left(13)) - 0.5;
+            let x = cell_x as f32 * grass.spacing + jitter_x * grass.spacing * 0.76;
+            let z = cell_z as f32 * grass.spacing + jitter_z * grass.spacing * 0.76;
+            let distance_squared = (x - anchor_x).powi(2) + (z - anchor_z).powi(2);
+            if distance_squared > radius_squared
+                || x < -half_width
+                || x > half_width
+                || z < -half_depth
+                || z > half_depth
+            {
+                continue;
+            }
+            let rotation = hash_unit(hash.rotate_left(7)) * std::f32::consts::TAU;
+            let scale = 0.75 + hash_unit(hash.rotate_left(23)) * 0.5;
+            instances.push([x, z, rotation, scale]);
+            if instances.len() == MAX_GRASS_INSTANCES {
+                return;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+fn select_grass_instances(
+    description: &TerrainDescription,
+    grass: &TerrainGrass,
+    world: &Matrix4<f32>,
+    camera_world: Vector3<f32>,
+) -> (GrassCacheKey, Vec<[f32; 4]>) {
+    let key = grass_cache_key(description, grass, world, camera_world);
+    let mut instances = Vec::new();
+    select_grass_instances_into(description, grass, &key, &mut instances);
+    (key, instances)
+}
+
+fn grass_hash(x: i32, z: i32) -> u32 {
+    let mut value =
+        (x as u32).wrapping_mul(0x9e37_79b1) ^ (z as u32).wrapping_mul(0x85eb_ca77) ^ 0xc2b2_ae3d;
+    value ^= value >> 16;
+    value = value.wrapping_mul(0x7feb_352d);
+    value ^= value >> 15;
+    value = value.wrapping_mul(0x846c_a68b);
+    value ^ (value >> 16)
+}
+
+fn hash_unit(hash: u32) -> f32 {
+    (hash & 0x00ff_ffff) as f32 / 0x0100_0000 as f32
+}
+
+#[derive(Clone, Copy)]
+struct Plane {
+    normal: Vector3<f32>,
+    d: f32,
+}
+
+impl Plane {
+    fn normalized(v: Vector4<f32>) -> Self {
+        let normal = v.truncate();
+        let length = normal.magnitude().max(1e-6);
+        Self {
+            normal: normal / length,
+            d: v.w / length,
+        }
+    }
+
+    fn excludes_sphere(self, center: Vector3<f32>, radius: f32) -> bool {
+        self.normal.dot(center) + self.d < -radius
+    }
+}
+
+fn frustum_planes(m: &Matrix4<f32>) -> [Plane; 6] {
+    // cgmath stores columns; assemble rows for the standard row4 ± rowN
+    // extraction from a world→clip matrix.
+    let r0 = Vector4::new(m.x.x, m.y.x, m.z.x, m.w.x);
+    let r1 = Vector4::new(m.x.y, m.y.y, m.z.y, m.w.y);
+    let r2 = Vector4::new(m.x.z, m.y.z, m.z.z, m.w.z);
+    let r3 = Vector4::new(m.x.w, m.y.w, m.z.w, m.w.w);
+    [
+        Plane::normalized(r3 + r0),
+        Plane::normalized(r3 - r0),
+        Plane::normalized(r3 + r1),
+        Plane::normalized(r3 - r1),
+        Plane::normalized(r3 + r2),
+        Plane::normalized(r3 - r2),
+    ]
+}
+
+#[allow(clippy::too_many_arguments)]
+fn select_patches_into(
+    description: &TerrainDescription,
+    sample_width: u32,
+    sample_height: u32,
+    world: &Matrix4<f32>,
+    camera_world: Vector3<f32>,
+    view_projections: &[Matrix4<f32>],
+    projection_scale: f32,
+    viewport_height: f32,
+    patches: &mut Vec<[f32; 4]>,
+) {
+    patches.clear();
+    let inverse = world.invert().unwrap_or_else(Matrix4::identity);
+    let local4 = inverse * Vector4::new(camera_world.x, camera_world.y, camera_world.z, 1.0);
+    let camera_local = local4.truncate() / local4.w.max(1e-6);
+    let scales = [
+        world.x.truncate().magnitude(),
+        world.y.truncate().magnitude(),
+        world.z.truncate().magnitude(),
+    ];
+    let min_scale = scales
+        .iter()
+        .copied()
+        .fold(f32::INFINITY, f32::min)
+        .max(1e-4);
+    let max_scale = scales.iter().copied().fold(0.0, f32::max).max(1e-4);
+    debug_assert!(!view_projections.is_empty());
+    debug_assert!(view_projections.len() <= 2);
+    let frusta = [
+        frustum_planes(&view_projections[0]),
+        frustum_planes(view_projections.get(1).unwrap_or(&view_projections[0])),
+    ];
+    let frusta = &frusta[..view_projections.len()];
+    let max_level = max_quadtree_level(sample_width, sample_height);
+    // A quadtree begins with one leaf; every split atomically replaces one
+    // leaf with four (+3). Reserving split tokens up front guarantees the
+    // traversal can never outgrow the fixed instance VBO, even while sibling
+    // branches are still pending on the recursion stack.
+    let mut remaining_splits = (MAX_INSTANCES - 1) / 3;
+
+    #[allow(clippy::too_many_arguments)]
+    fn visit(
+        description: &TerrainDescription,
+        world: &Matrix4<f32>,
+        camera_local: Vector3<f32>,
+        frusta: &[[Plane; 6]],
+        min_scale: f32,
+        max_scale: f32,
+        projection_scale: f32,
+        viewport_height: f32,
+        max_level: u32,
+        level: u32,
+        u: f32,
+        v: f32,
+        scale: f32,
+        remaining_splits: &mut usize,
+        out: &mut Vec<[f32; 4]>,
+    ) {
+        let half_width = description.width * scale * 0.5;
+        let half_depth = description.depth * scale * 0.5;
+        let center_local = Vector3::new(
+            (u + scale * 0.5 - 0.5) * description.width,
+            (description.min_height + description.max_height) * 0.5,
+            (v + scale * 0.5 - 0.5) * description.depth,
+        );
+        let center4 = world * Vector4::new(center_local.x, center_local.y, center_local.z, 1.0);
+        let center_world = center4.truncate() / center4.w.max(1e-6);
+        let half_height = (description.max_height - description.min_height) * 0.5;
+        let radius =
+            transformed_aabb_radius(world, Vector3::new(half_width, half_height, half_depth));
+        if frusta.iter().all(|planes| {
+            planes
+                .iter()
+                .any(|plane| plane.excludes_sphere(center_world, radius))
+        }) {
+            return;
+        }
+
+        let min = Vector3::new(
+            center_local.x - half_width,
+            description.min_height,
+            center_local.z - half_depth,
+        );
+        let max = Vector3::new(
+            center_local.x + half_width,
+            description.max_height,
+            center_local.z + half_depth,
+        );
+        let dx = (min.x - camera_local.x).max(0.0) + (camera_local.x - max.x).max(0.0);
+        let dy = (min.y - camera_local.y).max(0.0) + (camera_local.y - max.y).max(0.0);
+        let dz = (min.z - camera_local.z).max(0.0) + (camera_local.z - max.z).max(0.0);
+        let distance = (dx * dx + dy * dy + dz * dz).sqrt() * min_scale;
+        let vertex_spacing =
+            description.width.max(description.depth) * scale * max_scale / PATCH_QUADS as f32;
+        let projected_spacing =
+            vertex_spacing * projection_scale * viewport_height * 0.5 / distance.max(0.5);
+        let should_split = projected_spacing > description.max_pixel_error
+            && level < max_level
+            && *remaining_splits > 0;
+        if should_split {
+            *remaining_splits -= 1;
+            let child = scale * 0.5;
+            visit(
+                description,
+                world,
+                camera_local,
+                frusta,
+                min_scale,
+                max_scale,
+                projection_scale,
+                viewport_height,
+                max_level,
+                level + 1,
+                u,
+                v,
+                child,
+                remaining_splits,
+                out,
+            );
+            visit(
+                description,
+                world,
+                camera_local,
+                frusta,
+                min_scale,
+                max_scale,
+                projection_scale,
+                viewport_height,
+                max_level,
+                level + 1,
+                u + child,
+                v,
+                child,
+                remaining_splits,
+                out,
+            );
+            visit(
+                description,
+                world,
+                camera_local,
+                frusta,
+                min_scale,
+                max_scale,
+                projection_scale,
+                viewport_height,
+                max_level,
+                level + 1,
+                u,
+                v + child,
+                child,
+                remaining_splits,
+                out,
+            );
+            visit(
+                description,
+                world,
+                camera_local,
+                frusta,
+                min_scale,
+                max_scale,
+                projection_scale,
+                viewport_height,
+                max_level,
+                level + 1,
+                u + child,
+                v + child,
+                child,
+                remaining_splits,
+                out,
+            );
+        } else {
+            out.push([u, v, scale, scale]);
+        }
+    }
+
+    visit(
+        description,
+        world,
+        camera_local,
+        frusta,
+        min_scale,
+        max_scale,
+        projection_scale,
+        viewport_height,
+        max_level,
+        0,
+        0.0,
+        0.0,
+        1.0,
+        &mut remaining_splits,
+        patches,
+    );
+    debug_assert!(patches.len() <= MAX_INSTANCES);
+}
+
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
+fn select_patches(
+    description: &TerrainDescription,
+    sample_width: u32,
+    sample_height: u32,
+    world: &Matrix4<f32>,
+    camera_world: Vector3<f32>,
+    view_projection: &Matrix4<f32>,
+    projection_scale: f32,
+    viewport_height: f32,
+) -> Vec<[f32; 4]> {
+    let mut patches = Vec::new();
+    select_patches_into(
+        description,
+        sample_width,
+        sample_height,
+        world,
+        camera_world,
+        std::slice::from_ref(view_projection),
+        projection_scale,
+        viewport_height,
+        &mut patches,
+    );
+    patches
+}
+
+fn max_quadtree_level(width: u32, height: u32) -> u32 {
+    let cells = width.saturating_sub(1).max(height.saturating_sub(1));
+    let mut covered = PATCH_QUADS;
+    let mut level = 0;
+    while covered < cells && level < MAX_LEVEL {
+        covered = covered.saturating_mul(2);
+        level += 1;
+    }
+    level
+}
+
+fn fit_heightmap(source: &HeightmapData, max_size: u32) -> (Vec<u16>, u32, u32) {
+    let ratio = (max_size as f64 / source.width as f64).min(max_size as f64 / source.height as f64);
+    let width = ((source.width as f64 * ratio).floor() as u32).max(2);
+    let height = ((source.height as f64 * ratio).floor() as u32).max(2);
+    let mut samples = Vec::with_capacity((width * height) as usize);
+    for y in 0..height {
+        let source_y = y as u64 * (source.height - 1) as u64 / (height - 1) as u64;
+        for x in 0..width {
+            let source_x = x as u64 * (source.width - 1) as u64 / (width - 1) as u64;
+            samples.push(source.samples[(source_y * source.width as u64 + source_x) as usize]);
+        }
+    }
+    (samples, width, height)
+}
+
+fn terrain_normal_matrix(world: &Matrix4<f32>) -> Matrix3<f32> {
+    let linear = Matrix3::from_cols(world.x.truncate(), world.y.truncate(), world.z.truncate());
+    linear
+        .invert()
+        .map(|matrix| matrix.transpose())
+        .unwrap_or_else(Matrix3::identity)
+}
+
+fn transformed_aabb_radius(world: &Matrix4<f32>, half_extents: Vector3<f32>) -> f32 {
+    let x = world.x.truncate();
+    let y = world.y.truncate();
+    let z = world.z.truncate();
+    let extents = Vector3::new(
+        x.x.abs() * half_extents.x + y.x.abs() * half_extents.y + z.x.abs() * half_extents.z,
+        x.y.abs() * half_extents.x + y.y.abs() * half_extents.y + z.y.abs() * half_extents.z,
+        x.z.abs() * half_extents.x + y.z.abs() * half_extents.y + z.z.abs() * half_extents.z,
+    );
+    extents.magnitude()
+}
+
+fn slice_bytes<T>(slice: &[T]) -> &[u8] {
+    unsafe { std::slice::from_raw_parts(slice.as_ptr().cast::<u8>(), std::mem::size_of_val(slice)) }
+}
+
+#[cfg(test)]
+mod tests {
+    use cgmath::{perspective, vec3, Deg, EuclideanSpace, Matrix4, Point3};
+
+    use super::*;
+
+    fn terrain() -> TerrainDescription {
+        TerrainDescription::heightmap(
+            "world.png".to_string(),
+            vec![],
+            4000.0,
+            4000.0,
+            -80.0,
+            520.0,
+        )
+    }
+
+    #[test]
+    fn patch_mesh_is_one_grid_plus_a_closed_skirt() {
+        let (vertices, indices) = build_patch_mesh();
+        let surface_vertices = ((PATCH_QUADS + 1) * (PATCH_QUADS + 1)) as usize;
+        assert_eq!(
+            vertices.len(),
+            surface_vertices + (PATCH_QUADS * 4) as usize
+        );
+        assert_eq!(
+            indices.len(),
+            (PATCH_QUADS * PATCH_QUADS * 6 + PATCH_QUADS * 4 * 6) as usize
+        );
+        assert!(vertices[..surface_vertices]
+            .iter()
+            .all(|vertex| vertex[2] == 0.0));
+        assert!(vertices[surface_vertices..]
+            .iter()
+            .all(|vertex| vertex[2] == 1.0));
+    }
+
+    #[test]
+    fn grass_cluster_is_three_double_sided_blades() {
+        assert_eq!(build_grass_cluster().len(), 18);
+    }
+
+    #[test]
+    fn grass_selection_is_deterministic_camera_local_and_bounded() {
+        let description = terrain();
+        let grass = TerrainGrass {
+            spacing: 8.0,
+            distance: 300.0,
+            blade_height: 2.5,
+            color: [0.1, 0.3, 0.08],
+        };
+        let world = Matrix4::from_translation(vec3(200.0, 0.0, -100.0));
+        let camera = vec3(220.0, 50.0, -80.0);
+        let (key_a, instances_a) = select_grass_instances(&description, &grass, &world, camera);
+        let (key_b, instances_b) = select_grass_instances(&description, &grass, &world, camera);
+        assert_eq!(key_a, key_b);
+        assert_eq!(instances_a, instances_b);
+        assert!(!instances_a.is_empty());
+        assert!(instances_a.len() <= MAX_GRASS_INSTANCES);
+        assert!(instances_a.iter().all(|instance| {
+            instance[0].abs() <= description.width * 0.5
+                && instance[1].abs() <= description.depth * 0.5
+                && instance[3] >= 0.75
+                && instance[3] <= 1.25
+        }));
+    }
+
+    #[test]
+    fn extreme_grass_density_never_exceeds_the_instance_budget() {
+        let description = terrain();
+        let grass = TerrainGrass {
+            spacing: 0.1,
+            distance: 10_000.0,
+            blade_height: 1.0,
+            color: [0.1, 0.3, 0.08],
+        };
+        let (_, instances) = select_grass_instances(
+            &description,
+            &grass,
+            &Matrix4::identity(),
+            Vector3::new(0.0, 20.0, 0.0),
+        );
+        assert!(instances.len() <= MAX_GRASS_INSTANCES);
+    }
+
+    #[test]
+    fn four_k_heightmap_needs_six_quadtree_levels() {
+        assert_eq!(max_quadtree_level(4096, 4096), 6);
+        assert_eq!(max_quadtree_level(4097, 4097), 6);
+        assert_eq!(max_quadtree_level(65, 65), 0);
+    }
+
+    #[test]
+    fn projected_error_refines_nearby_patches_and_stays_bounded() {
+        let description = terrain();
+        let eye = Point3::new(0.0, 100.0, -500.0);
+        let view = Matrix4::look_at_rh(eye, Point3::new(0.0, 0.0, 0.0), vec3(0.0, 1.0, 0.0));
+        let projection = perspective(Deg(60.0), 1.0, 0.1, 6000.0);
+        let patches = select_patches(
+            &description,
+            4096,
+            4096,
+            &Matrix4::identity(),
+            eye.to_vec(),
+            &(projection * view),
+            projection.y.y,
+            1600.0,
+        );
+        assert!(patches.len() > 1, "near terrain should refine");
+        assert!(patches.len() <= MAX_INSTANCES);
+        assert!(patches.iter().all(|patch| patch[2] >= 1.0 / 64.0));
+    }
+
+    #[test]
+    fn stereo_culling_keeps_the_exact_union_of_displaced_eye_frusta() {
+        let mut description = terrain();
+        description.width = 200.0;
+        description.depth = 200.0;
+        description.min_height = 0.0;
+        description.max_height = 2.0;
+        description.max_pixel_error = 0.1;
+        let projection = perspective(Deg(24.0), 1.0, 0.1, 500.0);
+        let left_eye = Point3::new(-45.0, 12.0, -90.0);
+        let right_eye = Point3::new(45.0, 12.0, -90.0);
+        let left_view =
+            Matrix4::look_at_rh(left_eye, Point3::new(-45.0, 0.0, 0.0), Vector3::unit_y());
+        let right_view =
+            Matrix4::look_at_rh(right_eye, Point3::new(45.0, 0.0, 0.0), Vector3::unit_y());
+        let left_vp = projection * left_view;
+        let right_vp = projection * right_view;
+        let select = |frusta: &[Matrix4<f32>]| {
+            let mut patches = Vec::new();
+            select_patches_into(
+                &description,
+                257,
+                257,
+                &Matrix4::identity(),
+                Vector3::new(0.0, 12.0, -90.0),
+                frusta,
+                projection.y.y,
+                1600.0,
+                &mut patches,
+            );
+            patches
+        };
+        let left = select(std::slice::from_ref(&left_vp));
+        let right = select(std::slice::from_ref(&right_vp));
+        let union = select(&[left_vp, right_vp]);
+
+        assert!(union.len() > left.len(), "right-eye-only patches were lost");
+        assert!(union.len() > right.len(), "left-eye-only patches were lost");
+        assert!(left.iter().all(|patch| union.contains(patch)));
+        assert!(right.iter().all(|patch| union.contains(patch)));
+    }
+
+    #[test]
+    fn fully_refined_quadtree_never_exceeds_the_fixed_instance_buffer() {
+        let mut description = terrain();
+        description.max_pixel_error = f32::MIN_POSITIVE;
+        let eye = Point3::new(0.0, 5000.0, 0.0);
+        let view = Matrix4::look_at_rh(
+            eye,
+            Point3::new(0.0, 0.0, 0.0),
+            Vector3::new(0.0, 0.0, -1.0),
+        );
+        let projection = perspective(Deg(120.0), 1.0, 0.1, 10_000.0);
+        let patches = select_patches(
+            &description,
+            PATCH_QUADS * (1 << MAX_LEVEL) + 1,
+            PATCH_QUADS * (1 << MAX_LEVEL) + 1,
+            &Matrix4::identity(),
+            eye.to_vec(),
+            &(projection * view),
+            projection.y.y,
+            2048.0,
+        );
+        assert!(patches.len() <= MAX_INSTANCES);
+        assert!(
+            patches.len() > MAX_INSTANCES - 32,
+            "test should exhaust the split budget, got {} patches",
+            patches.len()
+        );
+    }
+
+    #[test]
+    fn terrain_normals_use_inverse_transpose_for_non_uniform_scale() {
+        let world = Matrix4::from_nonuniform_scale(2.0, 1.0, 0.5);
+        let local = Vector3::new(1.0, 1.0, 0.0).normalize();
+        let actual = (terrain_normal_matrix(&world) * local).normalize();
+        let expected = Vector3::new(0.5, 1.0, 0.0).normalize();
+        assert!((actual - expected).magnitude() < 1e-6);
+    }
+
+    #[test]
+    fn transformed_patch_bounds_stay_conservative_under_shear() {
+        let world = Matrix4::new(
+            1.0, 0.0, 0.0, 0.0, //
+            1.0, 0.0, 0.0, 0.0, //
+            1.0, 0.0, 0.0, 0.0, //
+            0.0, 0.0, 0.0, 1.0,
+        );
+        assert_eq!(
+            transformed_aabb_radius(&world, Vector3::new(1.0, 1.0, 1.0)),
+            3.0
+        );
+    }
+
+    #[test]
+    fn oversized_sources_fit_the_gpu_limit_and_preserve_corners() {
+        let source = HeightmapData {
+            width: 4,
+            height: 3,
+            samples: (0..12).collect(),
+            revision: 1,
+        };
+        let (samples, width, height) = fit_heightmap(&source, 3);
+        assert_eq!((width, height), (3, 2));
+        assert_eq!(samples.first(), Some(&0));
+        assert_eq!(samples.last(), Some(&11));
+    }
+}

--- a/runtime/functor-runtime-common/src/terrain_renderer.rs
+++ b/runtime/functor-runtime-common/src/terrain_renderer.rs
@@ -1117,8 +1117,9 @@ fn select_grass_instances_into(
 ) {
     instances.clear();
     let radius_cells = (grass.distance / grass.spacing).ceil().max(0.0) as i32;
-    let estimated = std::f32::consts::PI * radius_cells as f32 * radius_cells as f32;
-    let stride = (estimated / MAX_GRASS_INSTANCES as f32)
+    let radius_cells_f64 = f64::from(radius_cells);
+    let estimated = std::f64::consts::PI * radius_cells_f64 * radius_cells_f64;
+    let stride = (estimated / MAX_GRASS_INSTANCES as f64)
         .sqrt()
         .ceil()
         .max(1.0) as i32;
@@ -1127,8 +1128,9 @@ fn select_grass_instances_into(
     let half_width = description.width * 0.5;
     let half_depth = description.depth * 0.5;
     let radius_squared = grass.distance * grass.distance;
-    let desired_capacity =
-        ((estimated / (stride * stride) as f32).ceil() as usize).min(MAX_GRASS_INSTANCES);
+    let stride_f64 = f64::from(stride);
+    let desired_capacity = ((estimated / (stride_f64 * stride_f64)).ceil() as usize)
+        .min(MAX_GRASS_INSTANCES);
     if instances.capacity() < desired_capacity {
         instances.reserve(desired_capacity);
     }
@@ -1597,6 +1599,24 @@ mod tests {
     }
 
     #[test]
+    fn extreme_valid_grass_range_does_not_overflow_decimation_math() {
+        let description = terrain();
+        let grass = TerrainGrass {
+            spacing: 1.0,
+            distance: f32::MAX,
+            blade_height: 1.0,
+            color: [0.1, 0.3, 0.08],
+        };
+        let (_, instances) = select_grass_instances(
+            &description,
+            &grass,
+            &Matrix4::identity(),
+            Vector3::new(0.0, 20.0, 0.0),
+        );
+        assert!(instances.len() <= MAX_GRASS_INSTANCES);
+    }
+
+    #[test]
     fn decimated_grass_uses_a_world_stable_sampling_lattice() {
         let description = terrain();
         let grass = TerrainGrass {
@@ -1606,8 +1626,9 @@ mod tests {
             color: [0.1, 0.3, 0.08],
         };
         let radius_cells = (grass.distance / grass.spacing).ceil() as i32;
-        let estimated = std::f32::consts::PI * radius_cells as f32 * radius_cells as f32;
-        let stride = (estimated / MAX_GRASS_INSTANCES as f32).sqrt().ceil() as i32;
+        let estimated =
+            std::f64::consts::PI * f64::from(radius_cells) * f64::from(radius_cells);
+        let stride = (estimated / MAX_GRASS_INSTANCES as f64).sqrt().ceil() as i32;
         assert!(stride > 1, "test must exercise decimated selection");
 
         let (_, first) = select_grass_instances(

--- a/runtime/functor-runtime-common/src/terrain_renderer.rs
+++ b/runtime/functor-runtime-common/src/terrain_renderer.rs
@@ -380,8 +380,9 @@ struct GrassGeometry {
 }
 
 struct HeightTexture {
-    source: Arc<HeightmapData>,
+    revision: u64,
     texture: glow::Texture,
+    last_used_frame: u64,
 }
 
 #[derive(Default)]
@@ -395,8 +396,22 @@ pub(crate) struct TerrainRenderer {
 }
 
 impl TerrainRenderer {
-    pub(crate) fn begin_frame(&mut self, frame: u64) {
+    pub(crate) fn begin_frame(&mut self, gl: &glow::Context, frame: u64) {
+        if self.current_frame == frame {
+            return;
+        }
         self.current_frame = frame;
+        let counters = crate::gpu_counters::gpu_counters();
+        self.height_textures.retain(|_, entry| {
+            let recent = frame.wrapping_sub(entry.last_used_frame) <= 1;
+            if !recent {
+                unsafe {
+                    gl.delete_texture(entry.texture);
+                }
+                counters.texture_deleted();
+            }
+            recent
+        });
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -905,12 +920,16 @@ impl TerrainRenderer {
         locator: &str,
         source: Arc<HeightmapData>,
     ) -> glow::Texture {
-        let unchanged = self
+        if self
             .height_textures
             .get(locator)
-            .is_some_and(|entry| Arc::ptr_eq(&entry.source, &source));
-        if unchanged {
+            .is_some_and(|entry| entry.revision == source.revision)
+        {
             crate::gpu_counters::gpu_counters().cache_hit();
+            self.height_textures
+                .get_mut(locator)
+                .expect("unchanged terrain texture exists")
+                .last_used_frame = self.current_frame;
             return self.height_textures[locator].texture;
         }
 
@@ -984,8 +1003,14 @@ rendering a {}x{} height copy",
             gl.bind_texture(glow::TEXTURE_2D, None);
             texture
         };
-        self.height_textures
-            .insert(locator.to_string(), HeightTexture { source, texture });
+        self.height_textures.insert(
+            locator.to_string(),
+            HeightTexture {
+                revision: source.revision,
+                texture,
+                last_used_frame: self.current_frame,
+            },
+        );
         texture
     }
 }
@@ -1108,10 +1133,20 @@ fn select_grass_instances_into(
         instances.reserve(desired_capacity);
     }
 
-    for dz in (-radius_cells..=radius_cells).step_by(stride as usize) {
-        for dx in (-radius_cells..=radius_cells).step_by(stride as usize) {
-            let cell_x = key.camera_cell_x.saturating_add(dx);
-            let cell_z = key.camera_cell_z.saturating_add(dz);
+    let min_cell_x = key.camera_cell_x.saturating_sub(radius_cells);
+    let max_cell_x = key.camera_cell_x.saturating_add(radius_cells);
+    let min_cell_z = key.camera_cell_z.saturating_sub(radius_cells);
+    let max_cell_z = key.camera_cell_z.saturating_add(radius_cells);
+    let stride_i64 = i64::from(stride);
+    let min_cell_x_i64 = i64::from(min_cell_x);
+    let min_cell_z_i64 = i64::from(min_cell_z);
+    let first_cell_x = min_cell_x_i64 + (-min_cell_x_i64).rem_euclid(stride_i64);
+    let first_cell_z = min_cell_z_i64 + (-min_cell_z_i64).rem_euclid(stride_i64);
+
+    for cell_z in (first_cell_z..=i64::from(max_cell_z)).step_by(stride as usize) {
+        for cell_x in (first_cell_x..=i64::from(max_cell_x)).step_by(stride as usize) {
+            let cell_x = cell_x as i32;
+            let cell_z = cell_z as i32;
             let hash = grass_hash(cell_x, cell_z);
             let jitter_x = hash_unit(hash) - 0.5;
             let jitter_z = hash_unit(hash.rotate_left(13)) - 0.5;
@@ -1476,6 +1511,8 @@ fn slice_bytes<T>(slice: &[T]) -> &[u8] {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use cgmath::{perspective, vec3, Deg, EuclideanSpace, Matrix4, Point3};
 
     use super::*;
@@ -1557,6 +1594,48 @@ mod tests {
             Vector3::new(0.0, 20.0, 0.0),
         );
         assert!(instances.len() <= MAX_GRASS_INSTANCES);
+    }
+
+    #[test]
+    fn decimated_grass_uses_a_world_stable_sampling_lattice() {
+        let description = terrain();
+        let grass = TerrainGrass {
+            spacing: 0.5,
+            distance: 100.0,
+            blade_height: 1.0,
+            color: [0.1, 0.3, 0.08],
+        };
+        let radius_cells = (grass.distance / grass.spacing).ceil() as i32;
+        let estimated = std::f32::consts::PI * radius_cells as f32 * radius_cells as f32;
+        let stride = (estimated / MAX_GRASS_INSTANCES as f32).sqrt().ceil() as i32;
+        assert!(stride > 1, "test must exercise decimated selection");
+
+        let (_, first) = select_grass_instances(
+            &description,
+            &grass,
+            &Matrix4::identity(),
+            Vector3::new(0.0, 20.0, 0.0),
+        );
+        let (_, moved_one_cell) = select_grass_instances(
+            &description,
+            &grass,
+            &Matrix4::identity(),
+            Vector3::new(grass.spacing, 20.0, 0.0),
+        );
+        let moved: HashSet<[u32; 4]> = moved_one_cell
+            .iter()
+            .map(|instance| instance.map(f32::to_bits))
+            .collect();
+        let retained = first
+            .iter()
+            .filter(|instance| moved.contains(&instance.map(f32::to_bits)))
+            .count();
+
+        assert!(
+            retained * 10 > first.len() * 9,
+            "moving one cell replaced too much grass: retained {retained}/{}",
+            first.len()
+        );
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/trajectory.rs
+++ b/runtime/functor-runtime-common/src/trajectory.rs
@@ -72,7 +72,7 @@ fn collect_transforms(
                 path.pop();
             }
         }
-        SceneObject::Geometry(_) | SceneObject::Model(_) => {
+        SceneObject::Geometry(_) | SceneObject::Model(_) | SceneObject::Terrain(_) => {
             out.insert(path.clone(), w);
         }
     }
@@ -112,7 +112,7 @@ fn collect_anchor(
                 path.pop();
             }
         }
-        SceneObject::Geometry(_) | SceneObject::Model(_) => {
+        SceneObject::Geometry(_) | SceneObject::Model(_) | SceneObject::Terrain(_) => {
             out.insert(
                 path.clone(),
                 AnchorLeaf {
@@ -257,7 +257,7 @@ fn collect_sample_leaves<'a>(
                 path.pop();
             }
         }
-        SceneObject::Geometry(_) | SceneObject::Model(_) => {
+        SceneObject::Geometry(_) | SceneObject::Model(_) | SceneObject::Terrain(_) => {
             out.insert(
                 path.clone(),
                 SampleLeaf {

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -1117,6 +1117,7 @@ pub fn run(args: Args) {
         let start_time = Instant::now();
         let mut last_time: f32 = 0.0;
         let mut frame_count: u64 = 0;
+        let mut terrain_frame_id: u64 = 0;
         // The shared game clock (docs/time-travel.md): `tts` accumulates the real
         // frame delta while live, freezes on pause (scrubber / debug POST /time),
         // and rebases on a time-travel branch. `--fixed-time` seeds an
@@ -2021,9 +2022,25 @@ Escape again to quit"
                         ),
                     ),
                 ];
-                for (camera, eye_viewport) in &eyes {
+                let eye_projections = [
+                    eyes[0].0.projection_matrix(eyes[0].1.aspect()),
+                    eyes[1].0.projection_matrix(eyes[1].1.aspect()),
+                ];
+                let lod_view_projections = [
+                    eye_projections[0] * eyes[0].0.view_matrix(),
+                    eye_projections[1] * eyes[1].0.view_matrix(),
+                ];
+                let lod_projection_scale = eye_projections[0]
+                    .y
+                    .y
+                    .abs()
+                    .max(eye_projections[1].y.y.abs());
+                terrain_frame_id = terrain_frame_id.wrapping_add(1);
+                for ((camera, eye_viewport), projection) in
+                    eyes.iter().zip(eye_projections.iter())
+                {
                     gl.disable(glow::SCISSOR_TEST);
-                    functor_runtime_common::render_frame(
+                    functor_runtime_common::render_frame_with_projection(
                         &gl,
                         shader_version,
                         asset_cache.clone(),
@@ -2031,6 +2048,12 @@ Escape again to quit"
                         &shadow_map,
                         drawn_frame,
                         camera,
+                        projection,
+                        &view_camera,
+                        &lod_view_projections,
+                        lod_projection_scale,
+                        fb_height as f32,
+                        terrain_frame_id,
                         time.clone(),
                         *eye_viewport,
                         args.debug_render.into(),

--- a/runtime/functor-runtime-oculus/src/lib.rs
+++ b/runtime/functor-runtime-oculus/src/lib.rs
@@ -920,6 +920,7 @@ pub fn android_main(app: AndroidApp) {
     // model-driven locomotion and physical room-scale motion remain additive.
     let mut tracking_reference: Option<TrackingPose> = None;
     let mut tracking_reference_reset_at: Option<xr::Time> = None;
+    let mut terrain_frame_id = 0_u64;
     let mut quit = false;
     let mut event_storage = xr::EventDataBuffer::new();
 
@@ -1148,6 +1149,51 @@ pub fn android_main(app: AndroidApp) {
         let mut captured_eyes = capture_due.then(Vec::new);
         let mut capture_error = None;
 
+        // Terrain LOD follows the tracked center pose for distance, while
+        // culling uses the exact union of both displaced/canted eye frusta.
+        // Both eye draws receive the same fixed-size data and pixel scale, so
+        // selection is conservative and byte-identical across the pair.
+        let tracked_center = views.first().and_then(|left| {
+            let left = tracking_pose_from_view(left);
+            views
+                .get(1)
+                .and_then(|right| TrackingPose::midpoint(left, tracking_pose_from_view(right)))
+                .or_else(|| TrackingPose::midpoint(left, left))
+        });
+        let lod_camera = match (tracking_reference, tracked_center) {
+            (Some(reference), Some(center)) => frame.camera.compose_tracked_view(reference, center),
+            _ => frame.camera.clone(),
+        };
+        let fallback_lod_projection = lod_camera.projection_matrix(1.0);
+        let mut lod_view_projections = [fallback_lod_projection * lod_camera.view_matrix(); 2];
+        let mut lod_frustum_count = 0;
+        let mut lod_projection_scale = 0.0_f32;
+        let mut lod_viewport_height = 1.0_f32;
+        for (slot, (eye, view)) in eyes.iter().zip(views.iter()).take(2).enumerate() {
+            let eye_camera = tracking_reference
+                .map(|reference| {
+                    frame
+                        .camera
+                        .compose_tracked_view(reference, tracking_pose_from_view(view))
+                })
+                .unwrap_or_else(|| frame.camera.clone());
+            let eye_projection = eye_camera.projection_matrix_from_fov_angles(
+                view.fov.angle_left,
+                view.fov.angle_right,
+                view.fov.angle_down,
+                view.fov.angle_up,
+            );
+            lod_view_projections[slot] = eye_projection * eye_camera.view_matrix();
+            lod_frustum_count += 1;
+            lod_projection_scale = lod_projection_scale.max(eye_projection.y.y.abs());
+            lod_viewport_height = lod_viewport_height.max(eye.height as f32);
+        }
+        if lod_frustum_count == 0 {
+            lod_frustum_count = 1;
+            lod_projection_scale = fallback_lod_projection.y.y.abs();
+        }
+        terrain_frame_id = terrain_frame_id.wrapping_add(1);
+
         for (eye, view) in eyes.iter_mut().zip(views.iter()) {
             use glow::HasContext;
             let image_index = eye.swapchain.acquire_image().expect("acquire") as usize;
@@ -1181,6 +1227,11 @@ pub fn android_main(app: AndroidApp) {
                 &frame,
                 &camera,
                 &projection,
+                &lod_camera,
+                &lod_view_projections[..lod_frustum_count],
+                lod_projection_scale,
+                lod_viewport_height,
+                terrain_frame_id,
                 frame_time.clone(),
                 Viewport::new(eye.width, eye.height),
                 functor_runtime_common::DebugRenderMode::Default,


### PR DESCRIPTION
## Summary

- render finite heightmaps with a camera-relative quadtree and one shared 64×64 GPU patch
- submit visible patches through a bounded instance buffer with frustum culling and skirts
- choose LOD once from a stereo union frustum and reuse the selection for both VR eyes
- add height/slope material bands and bounded camera-local instanced grass
- retain 16-bit height samples through GPU upload

## Stack

This PR now targets `main` after [#468](https://github.com/tommy-xr/functor/pull/468) merged. Follow-ups:

1. [#470](https://github.com/tommy-xr/functor/pull/470) — physics
2. [#471](https://github.com/tommy-xr/functor/pull/471) — showcase

## VR/performance properties

- fixed patch and grass instance budgets
- no world-sized CPU mesh
- one LOD/grass selection shared by both eyes, including desktop side-by-side stereo
- one compact instance upload per terrain frame
- conservative transformed bounds and crack-hiding skirts
- bounded decoded-heightmap and GPU height-texture residency
- world-anchored grass decimation, so dense grass does not reshuffle when the camera crosses a cell

Release `frame_bench` retained byte-exact allocation counts versus the base:

| workload | allocations/frame | bytes/frame |
| --- | ---: | ---: |
| 20×20 | 13,877 | 843,379 |
| 40×40 | 54,717 | 3,307,219 |
| 56×56 | 106,973 | 6,460,243 |

Wall-clock results were not used for a performance claim: same-commit minima varied substantially with machine load, while the deterministic allocation/byte signal stayed exact.

## Validation

- full final stack: 470 runtime unit tests and 8 prelude integration tests
- WebAssembly release build
- Quest arm64 target check
- native and self-contained WebAssembly terrain sample builds
- release `frame_bench`, base and change
- deterministic exact-source PNG/GIF capture
- final adversarial re-review: no Critical, High, or Medium findings

## Review disposition

The external review findings are addressed:

- height textures and decoded heightmaps now expire after one unused frame/epoch instead of retaining every terrain ever drawn
- hot-reloaded stand-ins are marked before polling, so even synchronously settled replacements remain evictable
- grass decimation uses an absolute world lattice and overflow-safe arithmetic
- desktop side-by-side stereo now shares the exact union frustum, center LOD camera, projection scale, and terrain frame id
- regressions cover settled and synchronously refreshed stand-in eviction, stable decimated grass, extreme valid ranges, instance bounds, and stereo union culling

Terrain/water coupling and a descriptor-owned transform contract are intentionally follow-up API work; neither is inferred heuristically in this PR.

## Visual evidence

![4 km terrain with animated grass](https://gist.githubusercontent.com/tommy-xr/d44b227ce3001b94e64e7bc1914069f3/raw/terrain-grass-wind.gif)

<sub>4 km × 4 km heightmap terrain with stereo-stable quadtree LOD, layered slope/height material, fog, a snow-capped ridge, and GPU-instanced grass animated across one exact wind period. Rendered headlessly from the release CLI via `--capture-frame` / `--fixed-time`.</sub>

![4 km terrain still](https://gist.githubusercontent.com/tommy-xr/d44b227ce3001b94e64e7bc1914069f3/raw/terrain-showcase.png)

<!-- terrain-pr-visuals:d44b227ce3001b94e64e7bc1914069f3 -->
