### PR TITLE
feat(terrain): add shared heightfield physics

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -941,6 +941,11 @@ Physics.tag("name")                                        // BRANDED body ident
                                                            //   where a tag goes is a check
                                                            //   error
 Physics.box(w, h, d) / sphere(r) / capsule(halfH, r)       // -> Shape (box = FULL extents)
+Physics.heightfield(terrainTag, world)                     // fixed body from the SAME Terrain.t;
+                                                           //   one collider capped at 1025²
+                                                           //   collision samples; supports translation
+                                                           //   via Physics.at only — pair with an
+                                                           //   unrotated, unscaled Scene.terrain
 Physics.dynamic(tag, shape)                                // simulated body
 Physics.kinematic(tag, shape) / Physics.fixed(tag, shape)
 body |> Physics.at(v)                                      // body-last: pipes

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -57,7 +57,9 @@ jobs:
       # runtime compiled. The functor-lang suite runs on the default test-thread stack —
       # that is deliberate: it guards the MAX_EVAL_DEPTH-fits-2-MiB budget (#221).
       - name: Run tests
-        run: cargo test -p functor_runtime_common -p functor-lang
+        run: |
+          cargo test -p functor_runtime_common -p functor-lang
+          cargo test -p functor-netsim --test terrain
 
       - name: Validate API documentation generation
         run: npm run check:docs

--- a/functor-prelude/prelude/physics.funi
+++ b/functor-prelude/prelude/physics.funi
@@ -39,6 +39,15 @@ let sphere : (float) => shape
 /// Create a capsule shape from half-height and radius.
 let capsule : (float, float) => shape
 
+/// Create a fixed heightfield body from a shared terrain descriptor.
+///
+/// The renderer and collider share dimensions, elevation range, asset
+/// resolution, and pending-asset chain. Collision uses at most 1025 samples
+/// per axis to bound frame-thread work; larger render sources are decimated.
+/// The body supports translation via `Physics.at`; pair it only with an
+/// unrotated, unscaled `Scene.terrain`, using the same translation.
+let heightfield : (tag, Terrain.t) => body
+
 /// Create a dynamic body affected by forces and collisions.
 let dynamic : (tag, shape) => body
 /// Create a kinematic body driven explicitly by the game.

--- a/runtime/functor-netsim/Cargo.toml
+++ b/runtime/functor-netsim/Cargo.toml
@@ -14,3 +14,4 @@ serde_json = "1.0"
 # `functor-netsim-viz` bin — is an allowed dev-dependency cycle, not a real one.
 [dev-dependencies]
 functor-runtime-desktop = { path = "./../functor-runtime-desktop" }
+image = "0.25"

--- a/runtime/functor-netsim/src/lib.rs
+++ b/runtime/functor-netsim/src/lib.rs
@@ -18,11 +18,22 @@
 
 use std::{collections::HashMap, sync::Arc};
 
-use functor_runtime_common::asset::{preload::PreloadCommand, AssetCache};
+use functor_runtime_common::asset::{
+    preload::{
+        next_token_state, restore_next_token_state, PreloadCommand, PreloadKind,
+        TOKENS_PER_TARGET_CAP,
+    },
+    AssetCache,
+};
+use functor_runtime_common::functor_lang_prelude::{
+    clear_preload_completions, restore_preload_completions, snapshot_preload_completions,
+    PreloadCompletionSnapshot,
+};
 use functor_runtime_common::net::{
     ConnCommand, ConnectionId, LinkProfile, NetEvent, NodeId, VirtualNet,
 };
 use functor_runtime_common::protocol::GameProducer;
+use functor_runtime_common::terrain::{TerrainHydrationPublication, TerrainSource};
 use functor_runtime_common::timetravel::{History, DEFAULT_HISTORY_FRAMES};
 use functor_runtime_common::{FrameTime, SceneContext};
 
@@ -81,6 +92,116 @@ struct Instance {
     /// delivery) so the shared producer queue stays attributed to the right
     /// instance; routed on the NEXT frame.
     outbox: Vec<ConnCommand>,
+    /// Preload commands captured atomically after this instance's game code,
+    /// waiting to be submitted at the start of its next recorded frame.
+    preload_outbox: Vec<PreloadCommand>,
+    /// Commands already submitted to `SceneContext` but not settled. Keeping
+    /// the logical requests beside the shell snapshot lets a branch reconstruct
+    /// an asynchronous load without snapshotting cache internals.
+    preload_pending: Vec<PreloadCommand>,
+    /// Replayed tokened commands whose assets are warm now but whose original
+    /// timeline did not settle until a later frame.
+    preload_deferred: Vec<PreloadCommand>,
+}
+
+#[derive(Clone)]
+struct PreloadSettlement {
+    owner: InstanceId,
+    program_revision: u64,
+    kind: PreloadKind,
+    locator: String,
+    frame: u64,
+    outcome: PreloadOutcome,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum PreloadOutcome {
+    Settled,
+    Dropped,
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct TerrainHydrationKey {
+    owner: InstanceId,
+    program_revision: u64,
+    source: TerrainSource,
+}
+
+#[derive(Clone)]
+struct TerrainPublicationEvent {
+    frame: u64,
+    publication: TerrainHydrationPublication,
+}
+
+#[derive(Default)]
+struct TerrainHydrationTimeline {
+    publications: Vec<TerrainPublicationEvent>,
+    terminal_frame: Option<u64>,
+    observed_through: Option<u64>,
+}
+
+fn prune_replay_publications<T>(
+    items: &mut Vec<T>,
+    oldest: u64,
+    pending_interval_in_window: bool,
+    frame: impl Fn(&T) -> u64,
+) -> bool {
+    let first_in_window = items.partition_point(|item| frame(item) < oldest);
+    if first_in_window == items.len() && !pending_interval_in_window {
+        items.clear();
+        return false;
+    }
+    items.drain(..first_in_window.saturating_sub(1));
+    true
+}
+
+impl TerrainHydrationTimeline {
+    fn should_defer(&self, frame: u64) -> bool {
+        self.publications.iter().any(|event| event.frame > frame)
+            || self.terminal_frame.is_some_and(|terminal| terminal > frame)
+            || self
+                .observed_through
+                .is_some_and(|observed| observed >= frame)
+    }
+
+    fn prune_before(&mut self, oldest: u64) -> bool {
+        // A publication immediately before the history window is the baseline
+        // surface for every retained pending frame until a newer publication
+        // supersedes it. Keep that one event alongside all in-window events
+        // while the source is still relevant; otherwise a seek whose physics
+        // snapshot has no terrain body cannot recreate the current stand-in
+        // when the body later respawns. A fully aged-out terminal source drops
+        // every publication so its decoded heightmap Arc is not pinned.
+        if self
+            .terminal_frame
+            .is_some_and(|frame| frame < oldest)
+        {
+            self.terminal_frame = None;
+        }
+        if self
+            .observed_through
+            .is_some_and(|frame| frame < oldest)
+        {
+            self.observed_through = None;
+        }
+        let pending_interval_in_window =
+            self.terminal_frame.is_some() || self.observed_through.is_some();
+        prune_replay_publications(
+            &mut self.publications,
+            oldest,
+            pending_interval_in_window,
+            |event| event.frame,
+        )
+    }
+}
+
+impl PreloadSettlement {
+    fn matches(&self, owner: InstanceId, program_revision: u64, command: &PreloadCommand) -> bool {
+        self.owner == owner
+            && self.program_revision == program_revision
+            && self.kind == command.kind
+            && self.locator == command.locator
+    }
 }
 
 impl Instance {
@@ -94,24 +215,240 @@ impl Instance {
             node,
             keys: HashMap::new(),
             outbox: Vec::new(),
+            preload_outbox: Vec::new(),
+            preload_pending: Vec::new(),
+            preload_deferred: Vec::new(),
         }
     }
 
-    fn tick(&mut self, time: FrameTime) {
+    fn tick(
+        &mut self,
+        time: FrameTime,
+        frame: u64,
+        owner: InstanceId,
+        settlements: &mut HashMap<u64, PreloadSettlement>,
+        terrain_hydrations: &mut HashMap<TerrainHydrationKey, TerrainHydrationTimeline>,
+    ) {
         self.producer
             .push_asset_progress(self.asset_cache.progress());
-        self.producer.tick(time);
-        // Functor's preload and terrain request queues are process-global,
-        // like the connection queue. Drain immediately after this producer's
-        // game code so requests cannot be claimed by the next instance.
-        let commands: Vec<PreloadCommand> =
-            serde_json::from_str(&self.producer.preload_drain_commands()).unwrap_or_default();
-        for token in self
-            .scene_context
-            .drive_preloads(&self.asset_cache, commands)
-        {
+
+        // Match the interactive shells' frame boundary: preload settlement
+        // folds through `update` BEFORE `tick`, so the producer records the
+        // post-completion model for this frame. Commands produced by that
+        // completion stay attributed to this same instance.
+        let mut commands = std::mem::take(&mut self.preload_outbox);
+        commands.extend(std::mem::take(&mut self.preload_deferred));
+        let mut commands_to_drive = Vec::with_capacity(commands.len());
+        let program_revision = self.producer.scene_program_revision();
+        for command in commands {
+            let recorded_outcome = command
+                .token
+                .and_then(|token| settlements.get(&token))
+                .filter(|settlement| settlement.matches(owner, program_revision, &command));
+            if let Some(recorded) = recorded_outcome {
+                if recorded.frame > frame {
+                    self.preload_deferred.push(command);
+                    continue;
+                }
+                if recorded.outcome == PreloadOutcome::Dropped {
+                    continue;
+                }
+            }
+            let already_pending = self.preload_pending.iter().any(|pending| {
+                command
+                    .token
+                    .zip(pending.token)
+                    .is_some_and(|(token, other)| token == other)
+                    || (command.token.is_none()
+                        && pending.token.is_none()
+                        && command.kind == pending.kind
+                        && command.locator == pending.locator)
+            });
+            if !already_pending {
+                if command.token.is_some()
+                    && self
+                        .preload_pending
+                        .iter()
+                        .filter(|pending| {
+                            pending.token.is_some()
+                                && pending.kind == command.kind
+                                && pending.locator == command.locator
+                        })
+                        .count()
+                        >= TOKENS_PER_TARGET_CAP
+                {
+                    let oldest = self
+                        .preload_pending
+                        .iter()
+                        .position(|pending| {
+                            pending.token.is_some()
+                                && pending.kind == command.kind
+                                && pending.locator == command.locator
+                        })
+                        .expect("the counted target has an oldest token");
+                    let dropped = self.preload_pending.remove(oldest);
+                    if let Some(token) = dropped.token {
+                        settlements.insert(
+                            token,
+                            PreloadSettlement {
+                                owner,
+                                program_revision,
+                                kind: dropped.kind,
+                                locator: dropped.locator,
+                                frame,
+                                outcome: PreloadOutcome::Dropped,
+                            },
+                        );
+                    }
+                }
+                self.preload_pending.push(command.clone());
+            }
+            commands_to_drive.push(command);
+        }
+        self.scene_context.capture_terrain_requests();
+        let terrain_requests = self.scene_context.snapshot_terrain_requests();
+        for source in &terrain_requests {
+            if let Some(timeline) = terrain_hydrations.get(&TerrainHydrationKey {
+                owner,
+                program_revision,
+                source: source.clone(),
+            }) {
+                if let Some(event) = timeline
+                    .publications
+                    .iter()
+                    .rev()
+                    .find(|event| event.frame <= frame)
+                {
+                    self.scene_context
+                        .replay_terrain_publication(&event.publication);
+                }
+            }
+        }
+        let (deferred_terrain, active_terrain): (Vec<_>, Vec<_>) =
+            terrain_requests.into_iter().partition(|source| {
+                terrain_hydrations
+                    .get(&TerrainHydrationKey {
+                        owner,
+                        program_revision,
+                        source: source.clone(),
+                    })
+                    .is_some_and(|timeline| timeline.should_defer(frame))
+            });
+        self.scene_context
+            .restore_terrain_requests(active_terrain.clone());
+        let drive_result = self.scene_context.drive_preloads_deferring_terrain(
+            &self.asset_cache,
+            commands_to_drive,
+            &deferred_terrain,
+        );
+        let mut remaining_terrain = self.scene_context.snapshot_terrain_requests();
+        for source in &active_terrain {
+            let timeline = terrain_hydrations
+                .entry(TerrainHydrationKey {
+                    owner,
+                    program_revision,
+                    source: source.clone(),
+                })
+                .or_default();
+            if remaining_terrain.contains(source) {
+                timeline.observed_through = Some(
+                    timeline
+                        .observed_through
+                        .map_or(frame, |observed| observed.max(frame)),
+                );
+            } else {
+                timeline.terminal_frame.get_or_insert(frame);
+            }
+        }
+        for publication in drive_result.terrain_publications {
+            let revision = publication.revision();
+            let timeline = terrain_hydrations
+                .entry(TerrainHydrationKey {
+                    owner,
+                    program_revision,
+                    source: publication.source.clone(),
+                })
+                .or_default();
+            if timeline
+                .publications
+                .last()
+                .is_none_or(|event| event.publication.revision() != revision)
+            {
+                timeline.publications.push(TerrainPublicationEvent {
+                    frame,
+                    publication,
+                });
+            }
+        }
+        remaining_terrain.extend(deferred_terrain);
+        self.scene_context
+            .restore_terrain_requests(remaining_terrain);
+        for token in drive_result.settled {
+            let command = self
+                .preload_pending
+                .iter()
+                .find(|command| command.token == Some(token))
+                .cloned();
+            self.preload_pending
+                .retain(|command| command.token != Some(token));
+            if let Some(command) = command {
+                settlements.insert(
+                    token,
+                    PreloadSettlement {
+                        owner,
+                        program_revision,
+                        kind: command.kind,
+                        locator: command.locator,
+                        frame,
+                        outcome: PreloadOutcome::Settled,
+                    },
+                );
+            }
             self.producer.preload_push_settled(token);
         }
+        let asset_cache = &self.asset_cache;
+        self.preload_pending.retain(|command| {
+            command.token.is_some() || asset_cache.is_unsettled(&command.locator)
+        });
+        self.capture_preload_commands();
+
+        self.producer.tick(time);
+        // Physics.heightfield emits a process-global terrain hydration request
+        // during the tick's physics phase. Claim it before another producer
+        // runs; the actual asset polling remains next-frame work.
+        self.scene_context.capture_terrain_requests();
+        self.capture_preload_commands();
+    }
+
+    /// Claim every process-global preload command emitted by the most recent
+    /// callback on this producer. Deferring execution preserves the shell's
+    /// before-tick settlement order while keeping ownership atomic.
+    fn capture_preload_commands(&mut self) {
+        let commands: Vec<PreloadCommand> =
+            serde_json::from_str(&self.producer.preload_drain_commands()).unwrap_or_default();
+        self.preload_outbox.extend(commands);
+    }
+
+    /// Restore the logical preload driver at a whole-environment snapshot.
+    /// In-flight requests are resubmitted against the still-warm asset cache,
+    /// with their opaque completion messages restored beside them.
+    fn restore_preloads(
+        &mut self,
+        mut queued: Vec<PreloadCommand>,
+        pending: Vec<PreloadCommand>,
+        deferred: Vec<PreloadCommand>,
+        completions: Vec<PreloadCompletionSnapshot>,
+        terrain_requests: Vec<functor_runtime_common::terrain::TerrainSource>,
+    ) {
+        self.scene_context.reset_preloads();
+        self.scene_context
+            .restore_terrain_requests(terrain_requests);
+        queued.extend(pending);
+        queued.extend(deferred);
+        restore_preload_completions(completions);
+        self.preload_outbox = queued;
+        self.preload_pending.clear();
+        self.preload_deferred.clear();
     }
 
     fn drain_conn_commands(&self) -> Vec<ConnCommand> {
@@ -155,20 +492,34 @@ impl Instance {
 /// draws: **each producer records and restores its own model** (`SceneRecorder`
 /// runs inside the frame body `tick` executes, and `seek_scene_to` restores it),
 /// so the sim only has to snapshot what lives OUTSIDE the producers — the
-/// network and the routing tables built from it.
+/// virtual network, routing tables, and shell-owned preload queues.
 ///
-/// This is a plain deep copy, unlike the model ring's `Rc` structural sharing:
-/// what keeps it affordable is that the models are not in here at all, and what
-/// remains (in-flight packets and undelivered events) is bounded by the traffic
-/// actually crossing a frame. It is the part to measure first if the ring ever
-/// shows up in a profile.
+/// The network state is a plain deep copy, while pending preload messages use
+/// Functor values' ordinary structural sharing. Models are not duplicated here;
+/// what remains (in-flight packets, undelivered events, and logical asset
+/// requests) is bounded by the traffic actually crossing a frame. It is the
+/// part to measure first if the ring ever shows up in a profile.
 #[derive(Clone)]
 struct SimSnapshot {
     vnet: VirtualNet,
     /// authority -> (server instance, its listen key).
     listeners: HashMap<String, (InstanceId, String)>,
-    /// Per-instance `(keys, outbox)`, positionally indexed by [`InstanceId`].
-    routes: Vec<(HashMap<ConnectionId, String>, Vec<ConnCommand>)>,
+    /// Per-instance shell queues, positionally indexed by [`InstanceId`].
+    routes: Vec<InstanceSnapshot>,
+    /// Process-global token generator at this exact pre-delivery cut.
+    preload_next_token: u64,
+}
+
+#[derive(Clone)]
+struct InstanceSnapshot {
+    keys: HashMap<ConnectionId, String>,
+    net_outbox: Vec<ConnCommand>,
+    preload_outbox: Vec<PreloadCommand>,
+    preload_pending: Vec<PreloadCommand>,
+    preload_deferred: Vec<PreloadCommand>,
+    preload_completions: Vec<PreloadCompletionSnapshot>,
+    terrain_requests: Vec<functor_runtime_common::terrain::TerrainSource>,
+    program_revision: u64,
 }
 
 /// A deterministic in-process multiplayer simulation.
@@ -195,6 +546,15 @@ pub struct NetSim {
     /// The last error [`step`](NetSim::step) swallowed, for drivers that cannot
     /// see stderr. See [`take_last_error`](NetSim::take_last_error).
     last_error: Option<String>,
+    /// Original terminal outcome per token. This is timeline metadata rather
+    /// than point-in-time state: a later settlement teaches earlier snapshots
+    /// how long an untouched replay must keep a now-warm asset pending, while
+    /// an overload tombstone keeps a deliberately evicted token from reviving.
+    preload_settlements: HashMap<u64, PreloadSettlement>,
+    /// Original publication and terminal frames for each instance's terrain
+    /// source. These preserve stand-in → primary collision transitions after
+    /// a seek even though every decoded heightmap is now warm.
+    terrain_hydrations: HashMap<TerrainHydrationKey, TerrainHydrationTimeline>,
 }
 
 /// The source list for one instance of a multi-entry project: `entry` first —
@@ -248,6 +608,8 @@ impl NetSim {
             links: HashMap::new(),
             partitioned: std::collections::HashSet::new(),
             last_error: None,
+            preload_settlements: HashMap::new(),
+            terrain_hydrations: HashMap::new(),
         }
     }
 
@@ -422,8 +784,17 @@ impl NetSim {
         // Tick each instance and drain the commands IT produced ATOMICALLY —
         // so a producer sharing the process-global conn queue (Functor Lang) stays
         // isolated: each drain reads only the instance that just ticked.
-        for inst in &mut self.instances {
-            inst.tick(time.clone());
+        let frame = self.frame;
+        let settlements = &mut self.preload_settlements;
+        let terrain_hydrations = &mut self.terrain_hydrations;
+        for (id, inst) in self.instances.iter_mut().enumerate() {
+            inst.tick(
+                time.clone(),
+                frame,
+                id,
+                settlements,
+                terrain_hydrations,
+            );
             let cmds = inst.drain_conn_commands();
             inst.outbox.extend(cmds);
         }
@@ -471,6 +842,12 @@ impl NetSim {
         // original frame order is reproduced exactly.
         let settled = self.frame - 1;
         self.history.record(settled, &self.snapshot());
+        if let Some((oldest, _)) = self.history.recorded_range() {
+            self.preload_settlements
+                .retain(|_, settlement| settlement.frame >= oldest);
+            self.terrain_hydrations
+                .retain(|_, timeline| timeline.prune_before(oldest));
+        }
 
         self.deliver();
     }
@@ -483,17 +860,56 @@ impl NetSim {
             routes: self
                 .instances
                 .iter()
-                .map(|inst| (inst.keys.clone(), inst.outbox.clone()))
+                .map(|inst| {
+                    let tokens: Vec<u64> = inst
+                        .preload_outbox
+                        .iter()
+                        .chain(&inst.preload_pending)
+                        .chain(&inst.preload_deferred)
+                        .filter_map(|command| command.token)
+                        .collect();
+                    InstanceSnapshot {
+                        keys: inst.keys.clone(),
+                        net_outbox: inst.outbox.clone(),
+                        preload_outbox: inst.preload_outbox.clone(),
+                        preload_pending: inst.preload_pending.clone(),
+                        preload_deferred: inst.preload_deferred.clone(),
+                        preload_completions: snapshot_preload_completions(&tokens),
+                        terrain_requests: inst.scene_context.snapshot_terrain_requests(),
+                        program_revision: inst.producer.scene_program_revision(),
+                    }
+                })
                 .collect(),
+            preload_next_token: next_token_state(),
         }
     }
 
     fn restore(&mut self, snapshot: SimSnapshot) {
         self.vnet = snapshot.vnet;
         self.listeners = snapshot.listeners;
-        for (inst, (keys, outbox)) in self.instances.iter_mut().zip(snapshot.routes) {
-            inst.keys = keys;
-            inst.outbox = outbox;
+        // Completion messages are process-global in the Functor Lang host.
+        // Replace the entire set atomically for this whole-environment
+        // snapshot; abandoned-future tokens must not cross the branch.
+        clear_preload_completions();
+        functor_runtime_common::terrain::clear_hydrated_heightmaps();
+        restore_next_token_state(snapshot.preload_next_token);
+        for (inst, route) in self.instances.iter_mut().zip(snapshot.routes) {
+            inst.keys = route.keys;
+            inst.outbox = route.net_outbox;
+            let completions = if inst.producer.scene_program_revision() == route.program_revision {
+                route.preload_completions
+            } else {
+                // Hot reload invalidates messages that may close over the
+                // old session, matching every interactive producer.
+                Vec::new()
+            };
+            inst.restore_preloads(
+                route.preload_outbox,
+                route.preload_pending,
+                route.preload_deferred,
+                completions,
+                route.terrain_requests,
+            );
         }
         self.reapply_link_config();
     }
@@ -626,6 +1042,7 @@ impl NetSim {
             self.instances[client].push_error(&client_key, 0, "no listener for endpoint");
             let cmds = self.instances[client].drain_conn_commands();
             self.instances[client].outbox.extend(cmds);
+            self.instances[client].capture_preload_commands();
             return;
         };
         let client_node = self.instances[client].node;
@@ -678,6 +1095,7 @@ impl NetSim {
             // frame.
             let cmds = self.instances[id].drain_conn_commands();
             self.instances[id].outbox.extend(cmds);
+            self.instances[id].capture_preload_commands();
         }
     }
 
@@ -692,7 +1110,7 @@ impl NetSim {
 
 #[cfg(test)]
 mod tests {
-    use super::entry_sources;
+    use super::{entry_sources, prune_replay_publications};
 
     fn project() -> Vec<(String, String)> {
         vec![
@@ -736,5 +1154,34 @@ mod tests {
             err.contains("server.fun"),
             "the typo's intended target is listed: {err}"
         );
+    }
+
+    #[test]
+    fn terrain_publication_pruning_keeps_only_a_relevant_pre_window_baseline() {
+        let mut frames = vec![2, 10, 20];
+        assert!(prune_replay_publications(
+            &mut frames,
+            15,
+            false,
+            |frame| *frame
+        ));
+        assert_eq!(frames, vec![10, 20]);
+
+        assert!(!prune_replay_publications(
+            &mut frames,
+            30,
+            false,
+            |frame| *frame
+        ));
+        assert!(frames.is_empty(), "terminal sources must release their Arc");
+
+        let mut pending_frames = vec![2, 10, 20];
+        assert!(prune_replay_publications(
+            &mut pending_frames,
+            30,
+            true,
+            |frame| *frame
+        ));
+        assert_eq!(pending_frames, vec![20]);
     }
 }

--- a/runtime/functor-netsim/src/lib.rs
+++ b/runtime/functor-netsim/src/lib.rs
@@ -16,14 +16,15 @@
 //! `VirtualNet` connection id is used as the shared `ConnectionId` both ends see,
 //! so a send from either side routes to the other.
 
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
+use functor_runtime_common::asset::{preload::PreloadCommand, AssetCache};
 use functor_runtime_common::net::{
     ConnCommand, ConnectionId, LinkProfile, NetEvent, NodeId, VirtualNet,
 };
 use functor_runtime_common::protocol::GameProducer;
 use functor_runtime_common::timetravel::{History, DEFAULT_HISTORY_FRAMES};
-use functor_runtime_common::FrameTime;
+use functor_runtime_common::{FrameTime, SceneContext};
 
 pub use functor_runtime_common::net::LinkProfile as Link;
 
@@ -70,6 +71,8 @@ fn authority(endpoint: &str) -> &str {
 /// [`NetSim::step`]).
 struct Instance {
     producer: Box<dyn GameProducer>,
+    asset_cache: Arc<AssetCache>,
+    scene_context: SceneContext,
     node: NodeId,
     /// This instance's routing key (the url/bind its game used) per connection.
     keys: HashMap<ConnectionId, String>,
@@ -86,6 +89,8 @@ impl Instance {
         // evaluated `init`).
         Instance {
             producer,
+            asset_cache: Arc::new(AssetCache::new()),
+            scene_context: SceneContext::new(),
             node,
             keys: HashMap::new(),
             outbox: Vec::new(),
@@ -93,7 +98,20 @@ impl Instance {
     }
 
     fn tick(&mut self, time: FrameTime) {
+        self.producer
+            .push_asset_progress(self.asset_cache.progress());
         self.producer.tick(time);
+        // Functor's preload and terrain request queues are process-global,
+        // like the connection queue. Drain immediately after this producer's
+        // game code so requests cannot be claimed by the next instance.
+        let commands: Vec<PreloadCommand> =
+            serde_json::from_str(&self.producer.preload_drain_commands()).unwrap_or_default();
+        for token in self
+            .scene_context
+            .drive_preloads(&self.asset_cache, commands)
+        {
+            self.producer.preload_push_settled(token);
+        }
     }
 
     fn drain_conn_commands(&self) -> Vec<ConnCommand> {

--- a/runtime/functor-netsim/tests/preload.rs
+++ b/runtime/functor-netsim/tests/preload.rs
@@ -1,0 +1,307 @@
+//! Per-instance preload ownership and whole-environment replay.
+
+use std::sync::Mutex;
+
+use functor_netsim::{InstanceId, NetSim};
+
+mod support;
+use support::{add_source_game, install_controlled_fetcher, ControlledFetches};
+
+static PRELOAD_LOCK: Mutex<()> = Mutex::new(());
+
+fn begin_controlled_preload_test() -> ControlledFetches {
+    let _ = functor_runtime_common::asset::preload::drain_commands();
+    functor_runtime_common::functor_lang_prelude::clear_preload_completions();
+    install_controlled_fetcher()
+}
+
+fn add_preload_game(
+    sim: &mut NetSim,
+    root: &std::path::Path,
+    name: &str,
+    first: u32,
+) -> InstanceId {
+    let dir = root.join(name);
+    let locator = format!(
+        "https://netsim.invalid/{name}-{}-{first}.png",
+        std::process::id()
+    );
+    let second = first * 10;
+    let source = format!(
+        "let warmed = Asset.texture({locator:?})\n\
+         let init = 0.0\n\
+         let update = (model, msg) =>\n\
+           if msg == {first}.0\n\
+           then (model + msg, Effect.preloadThen(warmed, {second}.0))\n\
+           else model + msg\n\
+         let tick = (model, dt, tts) =>\n\
+           if model == 0.0\n\
+           then (1.0, Effect.preloadThen(warmed, {first}.0))\n\
+           else model\n\
+         let draw = (model, tts) => Frame.create(\n\
+           Camera.lookAt(Vec3.make(0.0, 0.0, -1.0), Vec3.make(0.0, 0.0, 0.0)),\n\
+           Scene.group([]))\n"
+    );
+    add_source_game(sim, &dir, source)
+}
+
+fn states(sim: &NetSim, ids: &[InstanceId]) -> Vec<String> {
+    ids.iter().map(|id| sim.state(*id)).collect()
+}
+
+fn preload_batch(locator: &str, count: usize) -> String {
+    let effects = std::iter::repeat_n(
+        format!("Effect.preloadThen(Asset.texture({locator:?}), 1.0)"),
+        count,
+    )
+    .collect::<Vec<_>>()
+    .join(", ");
+    format!("Effect.batch([{effects}])")
+}
+
+fn add_delivery_game(
+    sim: &mut NetSim,
+    root: &std::path::Path,
+    name: &str,
+    marker: u32,
+    subscription: &str,
+) -> InstanceId {
+    let dir = root.join(name);
+    let locator = format!(
+        "https://netsim.invalid/delivery-{name}-{}-{marker}.png",
+        std::process::id()
+    );
+    let warmed = marker * 10;
+    let source = format!(
+        "let asset = Asset.texture({locator:?})\n\
+         let toMsg = (event) =>\n\
+           match event with\n\
+           | Net.Connected(_) => {marker}.0\n\
+           | _ => 0.0\n\
+         let init = 0.0\n\
+         let update = (model, msg) =>\n\
+           if msg == {marker}.0\n\
+           then (1.0, Effect.preloadThen(asset, {warmed}.0))\n\
+           else model + msg\n\
+         let subscriptions = (model) => {subscription}\n\
+         let tick = (model, dt, tts) => model\n\
+         let draw = (model, tts) => Frame.create(\n\
+           Camera.lookAt(Vec3.make(0.0, 0.0, -1.0), Vec3.make(0.0, 0.0, 0.0)),\n\
+           Scene.group([]))\n"
+    );
+    add_source_game(sim, &dir, source)
+}
+
+#[test]
+fn network_delivery_preloads_stay_with_the_emitting_instance_and_replay() {
+    let _guard = PRELOAD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let fetches = begin_controlled_preload_test();
+
+    let root = std::env::temp_dir().join(format!(
+        "functor-netsim-delivery-preload-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&root);
+    let mut sim = NetSim::new(7);
+    let ids = [
+        add_delivery_game(
+            &mut sim,
+            &root,
+            "server",
+            10,
+            "Sub.listen(\"127.0.0.1:9321\", toMsg)",
+        ),
+        add_delivery_game(
+            &mut sim,
+            &root,
+            "client",
+            20,
+            "Sub.connect(\"ws://127.0.0.1:9321/play\", toMsg)",
+        ),
+    ];
+
+    // The Connected events are delivered after frame 0's snapshot cut. Each
+    // update queues a preloadThen onto the process-global queue; capture must
+    // happen before delivery advances to the other instance.
+    sim.step();
+    let anchor = sim.frame() - 1;
+    let connected = states(&sim, &ids);
+    assert_eq!(connected, vec!["1".to_string(), "1".to_string()]);
+
+    let mut original = Vec::new();
+    for _ in 0..3 {
+        sim.step();
+        original.push(states(&sim, &ids));
+    }
+    assert_eq!(fetches.lock().unwrap().len(), 2);
+    assert_eq!(original.last().unwrap(), &connected);
+    for (_, sender) in std::mem::take(&mut *fetches.lock().unwrap()) {
+        sender
+            .send(Err("controlled delivery preload settlement".to_string()))
+            .expect("the pending asset future still owns its receiver");
+    }
+    for _ in 0..2 {
+        sim.step();
+        original.push(states(&sim, &ids));
+    }
+    assert_eq!(
+        original.last().unwrap(),
+        &vec!["101".to_string(), "201".to_string()],
+        "each Connected handler must receive only its own preload completion"
+    );
+
+    // Seeking frame 0 restores its pending Connected events, whose replay must
+    // recreate the per-instance preload outboxes. Stepping on then reproduces
+    // the settlement frame exactly.
+    sim.seek(anchor).expect("seek to connected-event snapshot");
+    assert_eq!(states(&sim, &ids), connected);
+    let mut replayed = Vec::new();
+    for _ in 0..original.len() {
+        sim.step();
+        replayed.push(states(&sim, &ids));
+    }
+    assert_eq!(replayed, original);
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn preload_then_is_instance_owned_and_replays_across_a_scrub() {
+    let _guard = PRELOAD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+    // Hold both remote loads unresolved until the test releases them. This
+    // guarantees the snapshot cuts through a genuinely in-flight preload,
+    // rather than relying on timing or asset size.
+    let fetches = begin_controlled_preload_test();
+
+    let root = std::env::temp_dir().join(format!("functor-netsim-preload-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    let mut sim = NetSim::new(11);
+    let ids = [
+        add_preload_game(&mut sim, &root, "first", 10),
+        add_preload_game(&mut sim, &root, "second", 20),
+    ];
+
+    // Frame 0 captures each producer's first preload command. Frame 1 submits
+    // both, and the controlled fetcher keeps them in flight at the snapshot.
+    sim.step_n(2);
+    let anchor = sim.frame() - 1;
+    let anchor_states = states(&sim, &ids);
+    assert_eq!(
+        fetches.lock().unwrap().len(),
+        2,
+        "each instance must own and start its own request"
+    );
+
+    // Keep the futures unresolved across three more recorded frames. After the
+    // live run settles them, the cache is warm; replay must nevertheless hold
+    // their completion messages until the same original frame.
+    let mut original = Vec::new();
+    for _ in 0..3 {
+        sim.step();
+        original.push(states(&sim, &ids));
+    }
+    assert_eq!(
+        original.last().unwrap(),
+        &vec!["1".to_string(), "1".to_string()],
+        "the controlled requests remain genuinely pending"
+    );
+
+    for (_, sender) in std::mem::take(&mut *fetches.lock().unwrap()) {
+        sender
+            .send(Err("controlled preload settlement".to_string()))
+            .expect("the pending asset future still owns its receiver");
+    }
+
+    // The first settlement's update queues a SECOND preloadThen. That command
+    // must remain with the producer whose completion handler emitted it; with
+    // the old process-global drain, the following producer claimed it.
+    for _ in 0..4 {
+        sim.step();
+        original.push(states(&sim, &ids));
+    }
+    assert_eq!(
+        original.last().unwrap(),
+        &vec!["111".to_string(), "221".to_string()],
+        "each producer should receive both of its own chained completions"
+    );
+
+    // The anchor predates settlement. Its tokens have since been consumed, so
+    // exact replay proves both the logical in-flight requests and their
+    // completion messages were restored, and that completion landed before
+    // the producer recorded each replayed tick.
+    sim.seek(anchor).expect("seek to in-flight preload");
+    assert_eq!(states(&sim, &ids), anchor_states);
+    let mut replayed = Vec::new();
+    for _ in 0..original.len() {
+        sim.step();
+        replayed.push(states(&sim, &ids));
+    }
+    assert_eq!(
+        replayed, original,
+        "branching before preload settlement must replay both producers exactly"
+    );
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn replay_does_not_revive_a_preload_token_dropped_by_the_per_target_cap() {
+    let _guard = PRELOAD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let fetches = begin_controlled_preload_test();
+
+    let root =
+        std::env::temp_dir().join(format!("functor-netsim-preload-cap-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    let locator = format!("https://netsim.invalid/capped-{}.png", std::process::id());
+    // The effect broker caps one drain at 1,000 nodes, so cross the 1,024
+    // per-target token limit in two frames. Token 1 is intentionally evicted.
+    let first = preload_batch(&locator, 900);
+    let second = preload_batch(&locator, 125);
+    let source = format!(
+        "let init = 0.0\n\
+         let update = (model, msg) => model + msg\n\
+         let tick = (model, dt, tts) =>\n\
+           if model == 0.0 then (1.0, {first})\n\
+           else if model == 1.0 then (2.0, {second})\n\
+           else model\n\
+         let draw = (model, tts) => Frame.create(\n\
+           Camera.lookAt(Vec3.make(0.0, 0.0, -1.0), Vec3.make(0.0, 0.0, 0.0)),\n\
+           Scene.group([]))\n"
+    );
+    let mut sim = NetSim::new(17);
+    let id = add_source_game(&mut sim, &root, source);
+
+    sim.step();
+    let anchor = sim.frame() - 1;
+    let mut original = Vec::new();
+    sim.step();
+    original.push(sim.state(id));
+    sim.step();
+    original.push(sim.state(id));
+    assert_eq!(fetches.lock().unwrap().len(), 1);
+    for (_, sender) in std::mem::take(&mut *fetches.lock().unwrap()) {
+        sender
+            .send(Err("controlled capped preload settlement".to_string()))
+            .expect("the pending asset future still owns its receiver");
+    }
+    sim.step();
+    original.push(sim.state(id));
+    assert_eq!(
+        original,
+        vec!["2".to_string(), "2".to_string(), "1026".to_string()],
+        "exactly 1,024 of the 1,025 completion messages should be delivered"
+    );
+
+    // The failed asset is warm now. Without a dropped-token tombstone, token 1
+    // would settle immediately after this seek and alter both timing and state.
+    sim.seek(anchor).expect("seek before the capped batch");
+    let mut replayed = Vec::new();
+    for _ in 0..original.len() {
+        sim.step();
+        replayed.push(sim.state(id));
+    }
+    assert_eq!(replayed, original);
+
+    let _ = std::fs::remove_dir_all(root);
+}

--- a/runtime/functor-netsim/tests/support/mod.rs
+++ b/runtime/functor-netsim/tests/support/mod.rs
@@ -1,0 +1,29 @@
+use std::sync::{Arc, Mutex};
+
+use functor_netsim::{InstanceId, NetSim};
+use functor_runtime_common::io::{set_remote_fetcher, RemoteFetchSender};
+use functor_runtime_desktop::functor_lang_game::FunctorLangGame;
+
+pub type ControlledFetches = Arc<Mutex<Vec<(String, RemoteFetchSender)>>>;
+
+pub fn install_controlled_fetcher() -> ControlledFetches {
+    let fetches = Arc::new(Mutex::new(Vec::new()));
+    let captured = fetches.clone();
+    set_remote_fetcher(move |url, sender| {
+        captured.lock().unwrap().push((url, sender));
+    });
+    fetches
+}
+
+pub fn add_source_game(
+    sim: &mut NetSim,
+    dir: &std::path::Path,
+    source: String,
+) -> InstanceId {
+    std::fs::create_dir_all(dir).unwrap();
+    let game = dir.join("game.fun");
+    std::fs::write(&game, source).unwrap();
+    sim.add_producer(Box::new(FunctorLangGame::create(
+        game.to_str().unwrap(),
+    )))
+}

--- a/runtime/functor-netsim/tests/terrain.rs
+++ b/runtime/functor-netsim/tests/terrain.rs
@@ -1,0 +1,52 @@
+//! Headless terrain hydration through NetSim's per-instance asset shell.
+
+use functor_netsim::NetSim;
+use functor_runtime_common::physics::{remove_world, with_world, DEFAULT_WORLD};
+use functor_runtime_desktop::functor_lang_game::FunctorLangGame;
+
+#[test]
+#[ignore = "pulls the desktop runtime dev-dependency; run with --ignored"]
+fn physics_only_terrain_hydrates_without_a_renderer() {
+    remove_world(DEFAULT_WORLD);
+    let dir = std::env::temp_dir().join(format!(
+        "functor-netsim-terrain-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let heightmap = dir.join("height.png");
+    let pixels = image::ImageBuffer::from_fn(2, 2, |x, y| {
+        image::Luma([if x == 1 && y == 1 { u16::MAX } else { 0 }])
+    });
+    pixels.save(&heightmap).unwrap();
+    let source = format!(
+        "let world = Terrain.heightmap(Asset.texture({path:?}), 20.0, 20.0, 0.0, 10.0)\n\
+         let terrainTag = Physics.tag(\"netsim-terrain\")\n\
+         let terrainBody = Physics.heightfield(terrainTag, world)\n\
+         let init = 0.0\n\
+         let tick = (model, dt, tts) => model\n\
+         let physics = (model) => Physics.scene(Vec3.make(0.0, -9.81, 0.0), \
+           [terrainBody])\n\
+         let draw = (model, tts) => Frame.create(\
+           Camera.lookAt(Vec3.make(0.0, 5.0, -10.0), Vec3.make(0.0, 0.0, 0.0)), \
+           Scene.group([]))\n",
+        path = heightmap.to_string_lossy()
+    );
+    let game = dir.join("game.fun");
+    std::fs::write(&game, source).unwrap();
+
+    let mut sim = NetSim::new(1);
+    sim.add_producer(Box::new(FunctorLangGame::create(
+        game.to_str().unwrap(),
+    )));
+    sim.step_n(3);
+
+    with_world(DEFAULT_WORLD, |world| {
+        assert!(
+            world.body_transform("netsim-terrain").is_some(),
+            "physics-only terrain should hydrate through NetSim's asset shell"
+        );
+    });
+
+    remove_world(DEFAULT_WORLD);
+    let _ = std::fs::remove_dir_all(dir);
+}

--- a/runtime/functor-netsim/tests/terrain.rs
+++ b/runtime/functor-netsim/tests/terrain.rs
@@ -1,11 +1,52 @@
 //! Headless terrain hydration through NetSim's per-instance asset shell.
 
+use std::sync::Mutex;
+
 use functor_netsim::NetSim;
 use functor_runtime_common::physics::{remove_world, with_world, DEFAULT_WORLD};
-use functor_runtime_desktop::functor_lang_game::FunctorLangGame;
+
+mod support;
+use support::{add_source_game, install_controlled_fetcher};
+
+static TERRAIN_LOCK: Mutex<()> = Mutex::new(());
+
+fn heightmap_png(sample: u16) -> Vec<u8> {
+    let pixels = image::ImageBuffer::from_pixel(2, 2, image::Luma([sample]));
+    let mut png = std::io::Cursor::new(Vec::new());
+    image::DynamicImage::ImageLuma16(pixels)
+        .write_to(&mut png, image::ImageFormat::Png)
+        .unwrap();
+    png.into_inner()
+}
+
+fn terrain_game_source(declarations: &str, tag: &str, remove_on_frame_three: bool) -> String {
+    let bodies = if remove_on_frame_three {
+        "if model == 3.0\n\
+         then Physics.scene(Vec3.make(0.0, -9.81, 0.0), [])\n\
+         else Physics.scene(Vec3.make(0.0, -9.81, 0.0), [terrainBody])"
+    } else {
+        "Physics.scene(Vec3.make(0.0, -9.81, 0.0), [terrainBody])"
+    };
+    let tick = if remove_on_frame_three {
+        "model + 1.0"
+    } else {
+        "model"
+    };
+    format!(
+        "{declarations}\n\
+         let terrainBody = Physics.heightfield(Physics.tag({tag:?}), world)\n\
+         let init = 0.0\n\
+         let tick = (model, dt, tts) => {tick}\n\
+         let physics = (model) => {bodies}\n\
+         let draw = (model, tts) => Frame.create(\
+           Camera.lookAt(Vec3.make(0.0, 5.0, -10.0), Vec3.make(0.0, 0.0, 0.0)), \
+           Scene.group([]))\n"
+    )
+}
 
 #[test]
 fn physics_only_terrain_hydrates_without_a_renderer() {
+    let _guard = TERRAIN_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     remove_world(DEFAULT_WORLD);
     let dir = std::env::temp_dir().join(format!(
         "functor-netsim-terrain-{}",
@@ -17,26 +58,13 @@ fn physics_only_terrain_hydrates_without_a_renderer() {
         image::Luma([if x == 1 && y == 1 { u16::MAX } else { 0 }])
     });
     pixels.save(&heightmap).unwrap();
-    let source = format!(
-        "let world = Terrain.heightmap(Asset.texture({path:?}), 20.0, 20.0, 0.0, 10.0)\n\
-         let terrainTag = Physics.tag(\"netsim-terrain\")\n\
-         let terrainBody = Physics.heightfield(terrainTag, world)\n\
-         let init = 0.0\n\
-         let tick = (model, dt, tts) => model\n\
-         let physics = (model) => Physics.scene(Vec3.make(0.0, -9.81, 0.0), \
-           [terrainBody])\n\
-         let draw = (model, tts) => Frame.create(\
-           Camera.lookAt(Vec3.make(0.0, 5.0, -10.0), Vec3.make(0.0, 0.0, 0.0)), \
-           Scene.group([]))\n",
+    let declarations = format!(
+        "let world = Terrain.heightmap(Asset.texture({path:?}), 20.0, 20.0, 0.0, 10.0)",
         path = heightmap.to_string_lossy()
     );
-    let game = dir.join("game.fun");
-    std::fs::write(&game, source).unwrap();
-
+    let source = terrain_game_source(&declarations, "netsim-terrain", false);
     let mut sim = NetSim::new(1);
-    sim.add_producer(Box::new(FunctorLangGame::create(
-        game.to_str().unwrap(),
-    )));
+    add_source_game(&mut sim, &dir, source);
     sim.step_n(3);
 
     with_world(DEFAULT_WORLD, |world| {
@@ -45,6 +73,107 @@ fn physics_only_terrain_hydrates_without_a_renderer() {
             "physics-only terrain should hydrate through NetSim's asset shell"
         );
     });
+
+    remove_world(DEFAULT_WORLD);
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn terrain_stand_in_and_primary_replay_at_their_original_frames() {
+    let _guard = TERRAIN_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    remove_world(DEFAULT_WORLD);
+    let fetches = install_controlled_fetcher();
+
+    let dir = std::env::temp_dir().join(format!(
+        "functor-netsim-terrain-replay-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let primary = format!(
+        "https://netsim.invalid/terrain-primary-{}.png",
+        std::process::id()
+    );
+    let stand_in = format!(
+        "https://netsim.invalid/terrain-stand-in-{}.png",
+        std::process::id()
+    );
+    let declarations = format!(
+        "let primary = Asset.texture({primary:?})\n\
+         let standIn = Asset.texture({stand_in:?})\n\
+         let heightmap = primary |> Asset.whilePending(standIn)\n\
+         let world = Terrain.heightmap(heightmap, 20.0, 20.0, 0.0, 10.0)"
+    );
+    let source = terrain_game_source(&declarations, "replay-terrain", true);
+    let mut sim = NetSim::new(2);
+    add_source_game(&mut sim, &dir, source);
+    sim.step_n(2);
+    assert_eq!(fetches.lock().unwrap().len(), 2);
+    let mut pending = std::mem::take(&mut *fetches.lock().unwrap());
+    let stand_in_index = pending
+        .iter()
+        .position(|(url, _)| url == &stand_in)
+        .expect("the stand-in request");
+    let (_, stand_in_sender) = pending.swap_remove(stand_in_index);
+    let (primary_url, primary_sender) = pending.pop().expect("the primary request");
+    assert_eq!(primary_url, primary);
+
+    let terrain_height = || {
+        with_world(DEFAULT_WORLD, |world| {
+            world
+                .raycast([0.0, 20.0, 0.0], [0.0, -1.0, 0.0], 100.0)
+                .map(|hit| hit.position[1].round() as i32)
+        })
+        .flatten()
+    };
+    stand_in_sender
+        .send(Ok(heightmap_png(0)))
+        .expect("the pending stand-in future still owns its receiver");
+    // The stand-in publishes on frame 2, but that frame deliberately removes
+    // the body. The replay anchor therefore owns no old Rapier collider even
+    // though the pending terrain request retains the active stand-in surface.
+    sim.step();
+    let anchor = sim.frame() - 1;
+    assert_eq!(terrain_height(), None);
+
+    let mut original = Vec::new();
+    sim.step();
+    original.push(terrain_height());
+    sim.step();
+    original.push(terrain_height());
+
+    primary_sender
+        .send(Ok(heightmap_png(u16::MAX)))
+        .expect("the pending primary future still owns its receiver");
+    sim.step();
+    original.push(terrain_height());
+    for _ in 0..3 {
+        sim.step();
+        original.push(terrain_height());
+    }
+    assert_eq!(
+        original,
+        vec![
+            Some(0),
+            Some(0),
+            Some(10),
+            Some(10),
+            Some(10),
+            Some(10),
+        ]
+    );
+
+    sim.seek(anchor).expect("seek to the pending heightmap");
+    assert_eq!(terrain_height(), None);
+    let mut replayed = Vec::new();
+    for _ in 0..original.len() {
+        sim.step();
+        replayed.push(terrain_height());
+    }
+    assert_eq!(replayed, original);
+    assert!(
+        fetches.lock().unwrap().is_empty(),
+        "replay should reuse the warm decoded heightmap"
+    );
 
     remove_world(DEFAULT_WORLD);
     let _ = std::fs::remove_dir_all(dir);

--- a/runtime/functor-netsim/tests/terrain.rs
+++ b/runtime/functor-netsim/tests/terrain.rs
@@ -5,7 +5,6 @@ use functor_runtime_common::physics::{remove_world, with_world, DEFAULT_WORLD};
 use functor_runtime_desktop::functor_lang_game::FunctorLangGame;
 
 #[test]
-#[ignore = "pulls the desktop runtime dev-dependency; run with --ignored"]
 fn physics_only_terrain_hydrates_without_a_renderer() {
     remove_world(DEFAULT_WORLD);
     let dir = std::env::temp_dir().join(format!(

--- a/runtime/functor-runtime-common/Cargo.toml
+++ b/runtime/functor-runtime-common/Cargo.toml
@@ -31,7 +31,7 @@ once_cell = "1.19.0"
 # (rewind/replay/netcode Timeline) and `debug-render` for the collider
 # wireframe overlay (`--debug-render physics`; render-only, no sim impact).
 rapier3d = { version = "0.33", features = ["serde-serialize", "debug-render"] }
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 # sha256 of each loaded `.fun` file's text — the paused-inspector wire
 # contract's `sources` hash the LSP gates its live-value overlay on

--- a/runtime/functor-runtime-common/src/asset/asset_cache.rs
+++ b/runtime/functor-runtime-common/src/asset/asset_cache.rs
@@ -265,8 +265,10 @@ pub fn resolve_while_pending<T: 'static>(
     }
 }
 
-/// Explicit state behind [`resolve_while_pending`]. Long-lived shell caches
-/// use this to retain stand-ins only while the primary is actually pending.
+/// Explicit state behind [`resolve_while_pending`]. Callers that hydrate
+/// long-lived shell resources need to distinguish a loaded placeholder from
+/// a loaded primary: the placeholder may be published, but the request must
+/// remain active so the primary future keeps advancing.
 #[derive(Clone, Debug, PartialEq)]
 pub enum WhilePendingState<T> {
     Loading(Option<Arc<T>>),
@@ -298,6 +300,18 @@ pub fn resolve_while_pending_state<T: 'static>(
         super::AssetPollState::Failed => WhilePendingState::Failed,
         super::AssetPollState::Loading => WhilePendingState::Loading(stand_in),
     }
+}
+
+/// Whether a placeholder in `while_pending` was started and still needs
+/// polling. Long-lived shell requests must remain registered until this is
+/// false even after the primary settles, or `Sub.assets` can be stranded.
+pub fn while_pending_chain_is_unsettled(
+    cache: &AssetCache,
+    while_pending: &[String],
+) -> bool {
+    while_pending
+        .iter()
+        .any(|locator| cache.is_unsettled(locator))
 }
 
 #[cfg(test)]
@@ -456,6 +470,92 @@ mod tests {
         for f in [placeholder, real] {
             let _ = std::fs::remove_file(&f);
         }
+    }
+
+    #[test]
+    fn while_pending_state_keeps_placeholder_requests_alive_until_primary_promotes() {
+        use std::{cell::Cell, rc::Rc, task::Poll};
+
+        let cache = Arc::new(AssetCache::new());
+        let pipeline = super::super::build_pipeline(Box::new(BytesLen));
+        let placeholder = temp_file("wp-promote-placeholder.bin", b"12");
+        let polls = Rc::new(Cell::new(0));
+        let primary = AssetHandle::new(
+            futures::future::poll_fn({
+                let polls = polls.clone();
+                move |_| {
+                    if polls.replace(polls.get() + 1) == 0 {
+                        Poll::Pending
+                    } else {
+                        Poll::Ready(Ok(Arc::new(7)))
+                    }
+                }
+            }),
+            Arc::new(0),
+        );
+
+        let first = resolve_while_pending_state(
+            &cache,
+            &pipeline,
+            &primary,
+            std::slice::from_ref(&placeholder),
+        );
+        assert!(matches!(
+            first,
+            WhilePendingState::Loading(Some(value)) if *value == 2
+        ));
+
+        let second = resolve_while_pending_state(
+            &cache,
+            &pipeline,
+            &primary,
+            std::slice::from_ref(&placeholder),
+        );
+        assert!(matches!(
+            second,
+            WhilePendingState::Loaded(value) if *value == 7
+        ));
+
+        let _ = std::fs::remove_file(placeholder);
+    }
+
+    #[test]
+    fn settled_primary_reports_a_still_pending_started_placeholder() {
+        let cache = Arc::new(AssetCache::new());
+        let pipeline = super::super::build_pipeline(Box::new(BytesLen));
+        let real = temp_file("wp-settled-primary.bin", b"1234567");
+        let primary = cache.load_asset_with_pipeline(pipeline.clone(), &real);
+        settle(&primary);
+
+        let pending = "wp/pending-placeholder.bin".to_string();
+        cache
+            .progress
+            .lock()
+            .unwrap()
+            .started
+            .insert(pending.clone());
+        pipeline.cache(
+            &pending,
+            Arc::new(AssetHandle::new(
+                std::future::pending::<Result<Arc<usize>, String>>(),
+                Arc::new(0),
+            )),
+        );
+        assert!(matches!(
+            resolve_while_pending_state(
+                &cache,
+                &pipeline,
+                &primary,
+                std::slice::from_ref(&pending)
+            ),
+            WhilePendingState::Loaded(value) if *value == 7
+        ));
+        assert!(while_pending_chain_is_unsettled(
+            &cache,
+            std::slice::from_ref(&pending)
+        ));
+
+        let _ = std::fs::remove_file(real);
     }
 
     /// The cached-bytes branch must CACHE its handle like the cold path: a

--- a/runtime/functor-runtime-common/src/asset/preload.rs
+++ b/runtime/functor-runtime-common/src/asset/preload.rs
@@ -43,6 +43,10 @@ pub struct PreloadCommand {
     pub token: Option<u64>,
 }
 
+/// Waiting-token bound per in-flight target. Beyond it the oldest token drops
+/// unclaimed, matching the bounded completion-message registry.
+pub const TOKENS_PER_TARGET_CAP: usize = 1024;
+
 static OUTBOUND: Lazy<Mutex<VecDeque<PreloadCommand>>> =
     Lazy::new(|| Mutex::new(VecDeque::new()));
 
@@ -74,6 +78,18 @@ pub fn next_token() -> u64 {
         c.set(token + 1);
         token
     })
+}
+
+/// Snapshot the next correlation token for a whole-shell time-travel driver.
+/// Restoring it makes effects replayed after the snapshot mint the same tokens,
+/// so shell-owned completion timing can be correlated exactly.
+pub fn next_token_state() -> u64 {
+    NEXT_TOKEN.with(Cell::get)
+}
+
+/// Restore a value captured by [`next_token_state`].
+pub fn restore_next_token_state(next: u64) {
+    NEXT_TOKEN.with(|c| c.set(next));
 }
 
 #[cfg(test)]
@@ -108,5 +124,14 @@ mod tests {
         assert_eq!(back[1].token, Some(7));
         // Drained means drained.
         assert_eq!(drain_commands_json(), "[]");
+
+        let next = next_token_state();
+        let token = next_token();
+        restore_next_token_state(next);
+        assert_eq!(
+            next_token(),
+            token,
+            "restoring the generator reproduces correlation tokens"
+        );
     }
 }

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -2028,6 +2028,22 @@ fn register_physics(reg: &mut crate::host_registry::Registry) {
             }))
         },
     );
+    reg.fn2(
+        "Physics.heightfield",
+        "Physics.heightfield(tag, terrain)",
+        |tag: std::rc::Rc<str>, terrain: FunctorLangTerrain| {
+            // This constructor remains plain immutable protocol data. The
+            // physics adapter requests and hydrates the source whenever it
+            // consumes a scene, including bodies hoisted into eager globals.
+            FunctorLangBody(physics::Body::fixed(
+                tag.to_string(),
+                physics::Shape::Heightfield {
+                    geometry: terrain.0.geometry(),
+                    data: None,
+                },
+            ))
+        },
+    );
     // Bodies (tag, shape). The tag brand is erased at runtime, so it arrives
     // as the plain string (Rc<str>, allocation-light like `Physics.tag`).
     fn body_ctor(
@@ -6212,6 +6228,31 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
         assert!(scene.bodies[2].sensor);
     }
 
+    #[test]
+    fn physics_heightfield_consumes_the_shared_terrain_descriptor() {
+        let value = eval(
+            "let terrain = Terrain.heightmap(Asset.texture(\"physics-terrain.png\"), 4000.0, 4000.0, -80.0, 520.0)\n\
+             let main = () => Physics.heightfield(Physics.tag(\"world\"), terrain)",
+        );
+        let Value::HostData(data) = value else {
+            panic!("expected Body host data");
+        };
+        let body = data
+            .as_any()
+            .downcast_ref::<FunctorLangBody>()
+            .expect("Body");
+        assert_eq!(body.0.kind, physics::BodyKind::Fixed);
+        let physics::Shape::Heightfield { geometry, data } = &body.0.shape else {
+            panic!("expected a heightfield");
+        };
+        assert_eq!((geometry.width, geometry.depth), (4000.0, 4000.0));
+        assert!(data.is_none(), "hydration belongs to World::reconcile");
+
+        let json = serde_json::to_string(&body.0).expect("serialize");
+        let back: physics::Body = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, body.0);
+    }
+
     // End to end across the seam: reconcile + step the singleton world the
     // way the FunctorLangGame driver does, then read it back from Functor Lang — the in-process
     // live read that is the whole point of the Functor Lang surface.
@@ -6275,7 +6316,9 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
                 .at([0.0, y, 0.0])],
             )
         };
-        crate::physics::with_world(crate::physics::DEFAULT_WORLD, |w| w.reconcile(&ball_at(5.0)));
+        crate::physics::with_world(crate::physics::DEFAULT_WORLD, |w| {
+            w.reconcile(&ball_at(5.0))
+        });
         let scoped = crate::physics::create_world([0.0, 0.0, 0.0]);
         crate::physics::with_world(scoped, |w| w.reconcile(&ball_at(9.0)));
 

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -3764,6 +3764,15 @@ thread_local! {
         std::cell::RefCell::new(std::collections::HashMap::new());
 }
 
+/// An opaque copy of one pending `preloadThen` completion message for a
+/// whole-shell time-travel snapshot. The message stays private so shells can
+/// retain and restore it without depending on Functor Lang's runtime values.
+#[derive(Clone)]
+pub struct PreloadCompletionSnapshot {
+    token: u64,
+    message: Value,
+}
+
 /// Register a `preloadThen` completion message for `token` (see
 /// [`PENDING_PRELOAD`]; the cap and eviction mirror
 /// [`register_audio_completion`]).
@@ -3784,6 +3793,35 @@ pub fn register_preload_completion(token: u64, message: Value) {
 /// Take the completion message for a settled preload's `token`, if any.
 pub fn take_preload_completion(token: u64) -> Option<Value> {
     PENDING_PRELOAD.with(|m| m.borrow_mut().remove(&token))
+}
+
+/// Clone the still-pending messages for `tokens` into a whole-shell snapshot.
+/// Missing tokens are hot-reload orphans and are deliberately omitted.
+pub fn snapshot_preload_completions(tokens: &[u64]) -> Vec<PreloadCompletionSnapshot> {
+    PENDING_PRELOAD.with(|m| {
+        let map = m.borrow();
+        tokens
+            .iter()
+            .filter_map(|token| {
+                map.get(token).cloned().map(|message| PreloadCompletionSnapshot {
+                    token: *token,
+                    message,
+                })
+            })
+            .collect()
+    })
+}
+
+/// Restore completion messages captured by [`snapshot_preload_completions`].
+/// The caller must reject snapshots from a previous program revision: a
+/// message may close over the session that created it.
+pub fn restore_preload_completions(snapshots: Vec<PreloadCompletionSnapshot>) {
+    PENDING_PRELOAD.with(|m| {
+        let mut map = m.borrow_mut();
+        for snapshot in snapshots {
+            map.insert(snapshot.token, snapshot.message);
+        }
+    });
 }
 
 /// Drop all in-flight `preloadThen` completion messages (hot reload).
@@ -8108,6 +8146,11 @@ the game dir"
             other => panic!("expected texture+tokened model commands, got: {other:?}"),
         };
 
+        // Whole-shell history snapshots the still-pending completion without
+        // exposing the Functor Lang message value to the shell.
+        let completion_snapshot = snapshot_preload_completions(&[token]);
+        assert_eq!(completion_snapshot.len(), 1);
+
         // The load settles: take the registered message and fold it through
         // `update` (delivered verbatim — no tagger).
         let message = take_preload_completion(token).expect("a message for the token");
@@ -8119,6 +8162,16 @@ the game dir"
         assert_eq!(model.to_string(), "Warm");
 
         // Consumed: a duplicate/late settle finds no message.
+        assert!(take_preload_completion(token).is_none());
+
+        // Restoring the shell snapshot re-arms exactly that historical token.
+        restore_preload_completions(completion_snapshot);
+        assert_eq!(
+            take_preload_completion(token)
+                .expect("restored message")
+                .to_string(),
+            "Warm"
+        );
         assert!(take_preload_completion(token).is_none());
     }
 

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -569,7 +569,7 @@ impl FrameCtx<'_> {
         mut frame_time_at: impl FnMut(usize) -> FrameTime,
         capture_from_division: usize,
         mut sampled_input: Option<crate::InputSnapshot>,
-    ) -> Vec<(Value, Option<Vec<u8>>)> {
+    ) -> Vec<(Value, Option<physics::PhysicsSnapshot>)> {
         let mut out = Vec::with_capacity(divisions.saturating_sub(capture_from_division));
         let mut step = 0usize;
         for div in 0..divisions {
@@ -1255,7 +1255,10 @@ fn forward_step_scene_with_error(
     inputs: ForwardInputs<'_>,
     capture_from_division: usize,
     initial_sampled_input: Option<crate::InputSnapshot>,
-) -> (Vec<(Value, Option<Vec<u8>>)>, Option<String>) {
+) -> (
+    Vec<(Value, Option<physics::PhysicsSnapshot>)>,
+    Option<String>,
+) {
     // Pause the paused-inspector journal for the whole dry run: `--ghost`
     // forward-projection replays `tick`/`update` over throwaway state, and those
     // calls must NOT land in the live frame's journal (they are not real frame
@@ -1271,10 +1274,10 @@ fn forward_step_scene_with_error(
     // snapshot read lazily inserts an empty `DEFAULT_WORLD` — benign, and
     // ghosting only runs during live play when the world already exists.)
     let dry_world = if has_physics {
-        physics::with_world(physics::DEFAULT_WORLD, |w| w.snapshot()).map(|bytes| {
+        physics::with_world(physics::DEFAULT_WORLD, |w| w.checkpoint()).map(|snapshot| {
             let id = physics::create_world([0.0, -9.81, 0.0]);
             physics::with_world(id, |w| {
-                let _ = w.restore(&bytes);
+                w.restore_checkpoint(&snapshot);
             });
             DryWorld(id)
         })
@@ -1369,7 +1372,7 @@ pub fn forward_step_scene(
     divisions: usize,
     steps_per_division: usize,
     inputs: &[Vec<RecordedInput>],
-) -> Vec<(Value, Option<Vec<u8>>)> {
+) -> Vec<(Value, Option<physics::PhysicsSnapshot>)> {
     forward_step_scene_with_error(
         session,
         model,
@@ -1551,9 +1554,9 @@ pub fn ghost_frames(
     let mut frames = Vec::with_capacity(stepped.len());
     for (i, (model_i, world_i)) in stepped.iter().enumerate() {
         let _world_scope = match (&draw_world, world_i) {
-            (Some(dry), Some(bytes)) => {
+            (Some(dry), Some(snapshot)) => {
                 physics::with_world(dry.0, |w| {
-                    let _ = w.restore(bytes);
+                    w.restore_checkpoint(snapshot);
                 });
                 Some(physics::ActiveWorldScope::enter(dry.0))
             }

--- a/runtime/functor-runtime-common/src/physics/driver.rs
+++ b/runtime/functor-runtime-common/src/physics/driver.rs
@@ -102,8 +102,8 @@ impl SteppedPhysics {
     /// Byte-exact snapshot of this recorder's world (the determinism oracle
     /// the goldens assert) — the forward-step samples it after each stepped
     /// division. `None` when the world does not exist.
-    pub fn snapshot_world(&self) -> Option<Vec<u8>> {
-        with_world(self.world, |w| w.snapshot())
+    pub fn snapshot_world(&self) -> Option<super::PhysicsSnapshot> {
+        with_world(self.world, |w| w.checkpoint())
     }
 
     /// One rendered frame's worth of recorded physics: simulate whole fixed
@@ -140,6 +140,10 @@ impl SteppedPhysics {
                 // (the same discipline as World::step_frame).
                 self.accumulator %= FIXED_DT;
             }
+            // Resolve terrain once at the live shell boundary, then move that
+            // exact immutable scene into the command log. Replays must never
+            // consult whatever asset revision happens to be loaded later.
+            let mut scene = Some(scene.hydrated_heightfields());
             let (events, warnings) = with_world(self.world, |w| {
                 let mut events = Vec::new();
                 for i in 0..steps {
@@ -149,7 +153,9 @@ impl SteppedPhysics {
                     // one DeclareScene per rendered frame keeps the log lean.
                     let mut cmds: Vec<Command> = Vec::new();
                     if i == 0 {
-                        cmds.push(Command::DeclareScene(scene.clone()));
+                        cmds.push(Command::DeclareScene(
+                            scene.take().expect("first fixed substep owns the scene"),
+                        ));
                         for command in w.take_pending_commands() {
                             cmds.push(Command::Apply(command));
                         }
@@ -282,8 +288,12 @@ impl SteppedPhysics {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
+    use crate::asset::pipelines::HeightmapData;
     use crate::physics::{remove_world, Body, Shape};
+    use crate::terrain::{TerrainGeometry, TerrainSource};
 
     fn scene_at(t: u64) -> PhysicsScene {
         PhysicsScene::create(
@@ -424,6 +434,70 @@ mod tests {
         assert!(
             snapshot() == snap_20,
             "seek must re-apply recorded commands to land byte-exact"
+        );
+        remove_world(DEFAULT_WORLD);
+    }
+
+    #[test]
+    fn replay_uses_the_heightmap_revision_recorded_live() {
+        let mut sp = fresh();
+        let source = TerrainSource {
+            locator: "timeline-heightfield.png".to_string(),
+            while_pending: Vec::new(),
+        };
+        let scene = PhysicsScene::create(
+            [0.0, -9.81, 0.0],
+            vec![Body::fixed(
+                "terrain".to_string(),
+                Shape::Heightfield {
+                    geometry: TerrainGeometry {
+                        source: source.clone(),
+                        width: 20.0,
+                        depth: 20.0,
+                        min_height: 0.0,
+                        max_height: 10.0,
+                    },
+                    data: None,
+                },
+            )],
+        );
+        let samples = |sample, revision| {
+            Arc::new(HeightmapData {
+                samples: vec![sample; 4],
+                width: 2,
+                height: 2,
+                revision,
+            })
+        };
+        let hit_y = || {
+            with_world(DEFAULT_WORLD, |world| {
+                world
+                    .raycast([0.0, 20.0, 0.0], [0.0, -1.0, 0.0], 30.0)
+                    .expect("terrain ray hit")
+                    .position[1]
+            })
+            .unwrap()
+        };
+
+        let first_samples = samples(16384, 1);
+        crate::terrain::publish_heightmap(&source, first_samples.clone());
+        sp.advance(&scene, FIXED_DT);
+        let first_height = hit_y();
+
+        let reloaded_samples = samples(49152, 2);
+        crate::terrain::publish_heightmap(&source, reloaded_samples.clone());
+        sp.advance(&scene, FIXED_DT);
+        let reloaded_height = hit_y();
+        assert!(
+            reloaded_height > first_height + 4.0,
+            "{first_height} -> {reloaded_height}"
+        );
+
+        let warnings = sp.seek_to_frame(1);
+        assert!(warnings.is_empty(), "{warnings:?}");
+        assert!(
+            (hit_y() - first_height).abs() < 0.001,
+            "replay consulted the newer global heightmap revision"
         );
         remove_world(DEFAULT_WORLD);
     }

--- a/runtime/functor-runtime-common/src/physics/scene.rs
+++ b/runtime/functor-runtime-common/src/physics/scene.rs
@@ -6,7 +6,11 @@
 //! per-frame declared-scene history is exactly what a replay re-executes, so
 //! these types carry no handles or live state.
 
+use std::sync::Arc;
+
 use serde::{Deserialize, Serialize};
+
+use crate::{asset::pipelines::HeightmapData, terrain::TerrainGeometry};
 
 /// Standard gravity, Y-up (the coordinate convention — see CLAUDE.md).
 pub const DEFAULT_GRAVITY: [f32; 3] = [0.0, -9.81, 0.0];
@@ -20,7 +24,19 @@ pub enum Shape {
     Sphere { radius: f32 },
     /// Capsule along the local Y axis: a segment of `2 * half_height` with
     /// spherical caps of `radius`.
-    Capsule { half_height: f32, radius: f32 },
+    Capsule {
+        half_height: f32,
+        radius: f32,
+    },
+    /// A fixed terrain surface hydrated from the same descriptor and decoded
+    /// samples as `Scene.terrain`. The live adapter decimates oversized
+    /// sources into one bounded heightfield collider.
+    Heightfield {
+        geometry: TerrainGeometry,
+        /// `None` while the shell is loading the requested source. Reconcile
+        /// keeps any prior live collider, or defers the initial spawn.
+        data: Option<Arc<HeightmapData>>,
+    },
 }
 
 /// How the body participates in simulation.
@@ -164,5 +180,25 @@ impl PhysicsScene {
             gravity: DEFAULT_GRAVITY,
             bodies: Vec::new(),
         }
+    }
+
+    /// Resolve shell-owned heightmap samples into the immutable scene that
+    /// will be recorded and simulated this fixed frame.
+    ///
+    /// This happens before timeline recording rather than in
+    /// `World::reconcile`: replay must consume the exact asset revision that
+    /// live simulation saw, independent of later loads or hot reloads.
+    pub(crate) fn hydrated_heightfields(&self) -> PhysicsScene {
+        let mut scene = self.clone();
+        for body in &mut scene.bodies {
+            let Shape::Heightfield { geometry, data } = &mut body.shape else {
+                continue;
+            };
+            crate::terrain::request_heightmap(geometry.source.clone());
+            if let Some(latest) = crate::terrain::hydrated_heightmap(&geometry.source) {
+                *data = Some(latest);
+            }
+        }
+        scene
     }
 }

--- a/runtime/functor-runtime-common/src/physics/timeline.rs
+++ b/runtime/functor-runtime-common/src/physics/timeline.rs
@@ -25,7 +25,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use super::{PhysicsCommand, PhysicsEvent, PhysicsScene, World};
+use super::{PhysicsCommand, PhysicsEvent, PhysicsScene, PhysicsSnapshot, World};
 
 /// A fixed-step frame number.
 pub type Frame = u64;
@@ -62,18 +62,16 @@ pub trait Simulatable {
 }
 
 impl Simulatable for World {
-    type Snapshot = Vec<u8>;
+    type Snapshot = PhysicsSnapshot;
     type Command = Command;
     type Event = Event;
 
-    fn snapshot(&self) -> Vec<u8> {
-        World::snapshot(self)
+    fn snapshot(&self) -> PhysicsSnapshot {
+        self.checkpoint()
     }
 
-    fn restore(&mut self, s: &Vec<u8>) {
-        // A Timeline only restores snapshots it recorded itself, so a parse
-        // failure is a corrupted history — unrecoverable, and loud is right.
-        World::restore(self, s).expect("timeline snapshot failed to restore");
+    fn restore(&mut self, snapshot: &PhysicsSnapshot) {
+        self.restore_checkpoint(snapshot);
     }
 
     fn step(&mut self, cmds: &[Command]) -> Vec<PhysicsEvent> {
@@ -305,10 +303,10 @@ mod tests {
     fn seek_restores_a_recorded_frame_bit_exact() {
         let mut tl = TimelineLog::keyframes(4);
         let mut sim = World::new(DEFAULT_GRAVITY);
-        let mut at_7 = Vec::new();
+        let mut at_7 = None;
         for f in 0..20 {
             if f == 7 {
-                at_7 = Simulatable::snapshot(&sim);
+                at_7 = Some(Simulatable::snapshot(&sim));
             }
             let cmds = cmds_at(f);
             tl.record(f, &sim, &cmds);
@@ -318,7 +316,10 @@ mod tests {
         // 7 is not a keyframe (cadence 4): seek restores keyframe 4 and
         // re-steps 4..7.
         tl.seek(7, &mut sim);
-        assert!(Simulatable::snapshot(&sim) == at_7, "seek(7) diverged");
+        assert!(
+            Simulatable::snapshot(&sim) == at_7.expect("captured frame 7"),
+            "seek(7) diverged"
+        );
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/physics/world.rs
+++ b/runtime/functor-runtime-common/src/physics/world.rs
@@ -174,6 +174,56 @@ pub struct World {
     command_warnings: Vec<String>,
 }
 
+impl Clone for World {
+    fn clone(&self) -> Self {
+        Self {
+            gravity: self.gravity,
+            integration_parameters: self.integration_parameters,
+            pipeline: PhysicsPipeline::new(),
+            islands: self.islands.clone(),
+            broad_phase: self.broad_phase.clone(),
+            narrow_phase: self.narrow_phase.clone(),
+            bodies: self.bodies.clone(),
+            colliders: self.colliders.clone(),
+            impulse_joints: self.impulse_joints.clone(),
+            multibody_joints: self.multibody_joints.clone(),
+            ccd_solver: self.ccd_solver.clone(),
+            tags: self.tags.clone(),
+            declared: self.declared.clone(),
+            accumulator: self.accumulator,
+            frame: self.frame,
+            pending: self.pending.clone(),
+            forced: self.forced.clone(),
+            events: self.events.clone(),
+            command_warnings: self.command_warnings.clone(),
+        }
+    }
+}
+
+/// Cheap in-process physics checkpoint. Rapier's `SharedShape` and terrain
+/// samples remain Arc-shared across timeline keyframes and ghost previews,
+/// avoiding repeated multi-megabyte JSON snapshots on the frame thread.
+#[derive(Clone)]
+pub struct PhysicsSnapshot {
+    world: Box<World>,
+}
+
+impl std::fmt::Debug for PhysicsSnapshot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PhysicsSnapshot")
+            .field("frame", &self.world.frame)
+            .field("bodies", &self.world.bodies.len())
+            .field("colliders", &self.world.colliders.len())
+            .finish()
+    }
+}
+
+impl PartialEq for PhysicsSnapshot {
+    fn eq(&self, other: &Self) -> bool {
+        self.world.snapshot() == other.world.snapshot()
+    }
+}
+
 impl World {
     pub fn new(gravity: [f32; 3]) -> World {
         let mut integration_parameters = IntegrationParameters::default();
@@ -199,6 +249,16 @@ impl World {
             events: Vec::new(),
             command_warnings: Vec::new(),
         }
+    }
+
+    pub fn checkpoint(&self) -> PhysicsSnapshot {
+        PhysicsSnapshot {
+            world: Box::new(self.clone()),
+        }
+    }
+
+    pub fn restore_checkpoint(&mut self, snapshot: &PhysicsSnapshot) {
+        *self = snapshot.world.as_ref().clone();
     }
 
     /// Queue a command for the next stepped frame (applied after that frame's
@@ -278,15 +338,17 @@ impl World {
 
         // Spawns / updates, in tag order.
         for (tag, body) in wanted {
-            match self.declared.get(tag) {
+            let accepted = match self.declared.get(tag) {
                 None => self.spawn(body),
                 Some(prev) if prev != body => {
                     let prev = prev.clone();
-                    self.apply_divergence(&prev, body);
+                    self.apply_divergence(&prev, body)
                 }
-                Some(_) => {} // unchanged: the simulation owns this body
+                Some(_) => true, // unchanged: the simulation owns this body
+            };
+            if accepted {
+                self.declared.insert(tag.clone(), body.clone());
             }
-            self.declared.insert(tag.clone(), body.clone());
         }
     }
 
@@ -623,7 +685,10 @@ impl World {
 
     // ── reconcile internals ─────────────────────────────────────────────
 
-    fn spawn(&mut self, body: &Body) {
+    fn spawn(&mut self, body: &Body) -> bool {
+        let Some(mut collider) = collider_of(&body.shape) else {
+            return false;
+        };
         let builder = match body.kind {
             BodyKind::Dynamic => RigidBodyBuilder::dynamic(),
             BodyKind::Kinematic => RigidBodyBuilder::kinematic_position_based(),
@@ -634,7 +699,7 @@ impl World {
             .linvel(vec3(body.velocity))
             .build();
 
-        let mut collider = collider_of(&body.shape)
+        collider = collider
             .friction(body.friction)
             .restitution(body.restitution)
             .sensor(body.sensor)
@@ -650,6 +715,7 @@ impl World {
             self.colliders
                 .insert_with_parent(collider.build(), rb_handle, &mut self.bodies);
         self.tags.insert(body.tag.clone(), (rb_handle, col_handle));
+        true
     }
 
     fn despawn(&mut self, tag: &str) {
@@ -674,14 +740,18 @@ impl World {
     /// *live* pose/velocities for every field whose declaration didn't change:
     /// a mass change on a falling crate must not teleport it back to its
     /// declared spawn pose.
-    fn apply_divergence(&mut self, prev: &Body, next: &Body) {
+    fn apply_divergence(&mut self, prev: &Body, next: &Body) -> bool {
         if prev.kind != next.kind || prev.shape != next.shape || prev.mass != next.mass {
+            if !shape_is_ready(&next.shape) {
+                return false;
+            }
             let live = self.tags.get(&next.tag).and_then(|(rb, _)| {
                 let rb = self.bodies.get(*rb)?;
                 Some((*rb.position(), rb.linvel(), rb.angvel()))
             });
             self.despawn(&next.tag);
-            self.spawn(next);
+            let spawned = self.spawn(next);
+            debug_assert!(spawned);
             if let (Some((pose, linvel, angvel)), Some((rb_handle, _))) =
                 (live, self.tags.get(&next.tag).copied())
             {
@@ -695,7 +765,7 @@ impl World {
                 // Angular velocity is never declarable — always physics-owned.
                 rb.set_angvel(angvel, true);
             }
-            return;
+            return true;
         }
 
         let (rb_handle, col_handle) = self.tags[&next.tag];
@@ -736,6 +806,7 @@ impl World {
         }
         // `authority` is inert in Phase 1: cached (by reconcile) but never
         // written to the live world.
+        true
     }
 }
 
@@ -763,22 +834,117 @@ fn pose_of(body: &Body) -> Pose {
     Pose::from_parts(vec3(body.position), rotation)
 }
 
-fn collider_of(shape: &Shape) -> ColliderBuilder {
-    match *shape {
-        Shape::Cuboid { extents } => {
-            ColliderBuilder::cuboid(extents[0] / 2.0, extents[1] / 2.0, extents[2] / 2.0)
-        }
-        Shape::Sphere { radius } => ColliderBuilder::ball(radius),
+/// Bound the first terrain collision implementation to a 1025² grid. A 4096²
+/// render source therefore keeps metre-scale visual detail without retaining
+/// >100 MiB of collision data on Quest.
+/// Streaming higher-resolution collision tiles is a follow-up.
+const MAX_HEIGHTFIELD_CELLS_PER_AXIS: usize = 1024;
+
+fn shape_is_ready(shape: &Shape) -> bool {
+    !matches!(shape, Shape::Heightfield { data: None, .. })
+}
+
+fn collider_of(shape: &Shape) -> Option<ColliderBuilder> {
+    match shape {
+        Shape::Cuboid { extents } => Some(ColliderBuilder::cuboid(
+            extents[0] / 2.0,
+            extents[1] / 2.0,
+            extents[2] / 2.0,
+        )),
+        Shape::Sphere { radius } => Some(ColliderBuilder::ball(*radius)),
         Shape::Capsule {
             half_height,
             radius,
-        } => ColliderBuilder::capsule_y(half_height, radius),
+        } => Some(ColliderBuilder::capsule_y(*half_height, *radius)),
+        Shape::Heightfield { geometry, data } => data
+            .as_deref()
+            .map(|data| heightfield_collider(geometry, data)),
     }
+}
+
+fn heightfield_collider(
+    terrain: &crate::terrain::TerrainGeometry,
+    data: &crate::asset::pipelines::HeightmapData,
+) -> ColliderBuilder {
+    debug_assert!(data.is_valid());
+    let (cells_x, cells_z) = collision_cell_counts(data);
+    let height_range = terrain.max_height - terrain.min_height;
+    let matrix = Array2::from_fn(cells_z + 1, cells_x + 1, |row, col| {
+        sample_height_for_collision(data, col, cells_x, row, cells_z)
+    });
+    let shape = SharedShape::heightfield_with_flags(
+        matrix,
+        Vector::new(terrain.width, height_range, terrain.depth),
+        HeightFieldFlags::FIX_INTERNAL_EDGES,
+    );
+    ColliderBuilder::new(shape).translation(Vector::new(0.0, terrain.min_height, 0.0))
+}
+
+fn sample_height_for_collision(
+    data: &crate::asset::pipelines::HeightmapData,
+    target_x: usize,
+    target_cells_x: usize,
+    target_z: usize,
+    target_cells_z: usize,
+) -> f32 {
+    let source_cells_x = data.width.saturating_sub(1) as usize;
+    let source_cells_z = data.height.saturating_sub(1) as usize;
+    let source_x = target_x as f64 * source_cells_x as f64 / target_cells_x as f64;
+    let source_z = target_z as f64 * source_cells_z as f64 / target_cells_z as f64;
+    let x0 = source_x.floor() as usize;
+    let z0 = source_z.floor() as usize;
+    let x1 = (x0 + 1).min(source_cells_x);
+    let z1 = (z0 + 1).min(source_cells_z);
+    let fx = (source_x - x0 as f64) as f32;
+    let fz = (source_z - z0 as f64) as f32;
+    let width = data.width as usize;
+    let height = |x, z| data.samples[z * width + x] as f32 / 65535.0;
+    let (h00, h10, h01, h11) = (
+        height(x0, z0),
+        height(x1, z0),
+        height(x0, z1),
+        height(x1, z1),
+    );
+    if fx + fz <= 1.0 {
+        h00 + fx * (h10 - h00) + fz * (h01 - h00)
+    } else {
+        h11 + (1.0 - fx) * (h01 - h11) + (1.0 - fz) * (h10 - h11)
+    }
+}
+
+fn collision_cell_counts(data: &crate::asset::pipelines::HeightmapData) -> (usize, usize) {
+    (
+        (data.width.saturating_sub(1) as usize).min(MAX_HEIGHTFIELD_CELLS_PER_AXIS),
+        (data.height.saturating_sub(1) as usize).min(MAX_HEIGHTFIELD_CELLS_PER_AXIS),
+    )
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
+
+    fn flat_heightfield(width: u32, height: u32, sample: u16) -> Shape {
+        Shape::Heightfield {
+            geometry: crate::terrain::TerrainGeometry {
+                source: crate::terrain::TerrainSource {
+                    locator: "test.png".to_string(),
+                    while_pending: Vec::new(),
+                },
+                width: 20.0,
+                depth: 20.0,
+                min_height: 0.0,
+                max_height: 10.0,
+            },
+            data: Some(Arc::new(crate::asset::pipelines::HeightmapData {
+                samples: vec![sample; (width * height) as usize],
+                width,
+                height,
+                revision: 1,
+            })),
+        }
+    }
 
     fn ground() -> Body {
         Body::fixed(
@@ -801,6 +967,129 @@ mod tests {
 
     fn scene(bodies: Vec<Body>) -> PhysicsScene {
         PhysicsScene::create([0.0, -9.81, 0.0], bodies)
+    }
+
+    #[test]
+    fn heightfield_raycast_matches_declared_elevation() {
+        let terrain = flat_heightfield(260, 260, 32768);
+        let Shape::Heightfield {
+            data: Some(data), ..
+        } = &terrain
+        else {
+            unreachable!()
+        };
+        assert_eq!(collision_cell_counts(data), (259, 259));
+
+        let mut world = World::new([0.0, -9.81, 0.0]);
+        world.reconcile(&scene(vec![Body::fixed("terrain".to_string(), terrain)]));
+        world.step_frame(FIXED_DT);
+        let hit = world
+            .raycast([0.0, 20.0, 0.0], [0.0, -1.0, 0.0], 30.0)
+            .expect("ray should hit the heightfield");
+        assert_eq!(hit.tag, "terrain");
+        assert!((hit.position[1] - 5.0).abs() < 0.01, "{hit:?}");
+        assert!(hit.normal[1] > 0.99, "{hit:?}");
+    }
+
+    #[test]
+    fn heightfield_uses_rapier_triangles_not_bilinear_interpolation() {
+        let shape = Shape::Heightfield {
+            geometry: crate::terrain::TerrainGeometry {
+                source: crate::terrain::TerrainSource {
+                    locator: "triangle-test.png".to_string(),
+                    while_pending: Vec::new(),
+                },
+                width: 20.0,
+                depth: 20.0,
+                min_height: 0.0,
+                max_height: 10.0,
+            },
+            data: Some(Arc::new(crate::asset::pipelines::HeightmapData {
+                // Only the far (+X,+Z) corner is raised.
+                samples: vec![0, 0, 0, 65535],
+                width: 2,
+                height: 2,
+                revision: 1,
+            })),
+        };
+        let mut world = World::new([0.0, 0.0, 0.0]);
+        world.reconcile(&scene(vec![Body::fixed("terrain".to_string(), shape)]));
+        world.step_frame(FIXED_DT);
+
+        let lower = world
+            .raycast([-5.0, 20.0, -5.0], [0.0, -1.0, 0.0], 30.0)
+            .expect("lower triangle");
+        let upper = world
+            .raycast([5.0, 20.0, 5.0], [0.0, -1.0, 0.0], 30.0)
+            .expect("upper triangle");
+        assert!(lower.position[1].abs() < 0.001, "{lower:?}");
+        assert!((upper.position[1] - 5.0).abs() < 0.001, "{upper:?}");
+    }
+
+    #[test]
+    fn capped_heightfield_samples_exact_fractional_source_positions() {
+        let data = crate::asset::pipelines::HeightmapData {
+            // Along X: 0, 0, 1, 1. The middle of this three-cell source is
+            // halfway up the discontinuity; flooring would incorrectly pick 0.
+            samples: vec![0, 0, 65535, 65535, 0, 0, 65535, 65535],
+            width: 4,
+            height: 2,
+            revision: 1,
+        };
+        let middle = sample_height_for_collision(&data, 1, 2, 0, 1);
+        assert!((middle - 0.5).abs() < 0.0001, "{middle}");
+    }
+
+    #[test]
+    fn pending_heightfield_defers_spawn_and_preserves_the_last_settled_surface() {
+        let ready = flat_heightfield(3, 3, 32768);
+        let mut pending = ready.clone();
+        let Shape::Heightfield { data, .. } = &mut pending else {
+            unreachable!()
+        };
+        *data = None;
+
+        let mut world = World::new([0.0, -9.81, 0.0]);
+        world.reconcile(&scene(vec![Body::fixed(
+            "terrain".to_string(),
+            pending.clone(),
+        )]));
+        assert!(world.body_transform("terrain").is_none());
+
+        world.reconcile(&scene(vec![Body::fixed("terrain".to_string(), ready)]));
+        assert!(world.body_transform("terrain").is_some());
+
+        world.reconcile(&scene(vec![Body::fixed("terrain".to_string(), pending)]));
+        assert!(world.body_transform("terrain").is_some());
+    }
+
+    #[test]
+    fn collision_resolution_and_timeline_heightfield_memory_are_bounded() {
+        let oversized = crate::asset::pipelines::HeightmapData {
+            samples: Vec::new(),
+            width: 4097,
+            height: 4097,
+            revision: 1,
+        };
+        assert_eq!(collision_cell_counts(&oversized), (1024, 1024));
+
+        // Exercise the actual cap, not just its arithmetic: the full retained
+        // collider is one shared shape and remains shared by checkpoints.
+        let terrain = flat_heightfield(1025, 1025, 32768);
+        let mut world = World::new([0.0, -9.81, 0.0]);
+        world.reconcile(&scene(vec![Body::fixed("terrain".to_string(), terrain)]));
+        assert_eq!(world.colliders.len(), 1);
+        let checkpoint = world.checkpoint();
+        let live_shape = world.colliders.iter().next().unwrap().1.shared_shape();
+        let saved_shape = checkpoint
+            .world
+            .colliders
+            .iter()
+            .next()
+            .unwrap()
+            .1
+            .shared_shape();
+        assert!(Arc::ptr_eq(&live_shape.0, &saved_shape.0));
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/physics/world.rs
+++ b/runtime/functor-runtime-common/src/physics/world.rs
@@ -1027,6 +1027,42 @@ mod tests {
     }
 
     #[test]
+    fn rectangular_heightfield_keeps_source_x_on_world_x() {
+        let shape = Shape::Heightfield {
+            geometry: crate::terrain::TerrainGeometry {
+                source: crate::terrain::TerrainSource {
+                    locator: "axis-test.png".to_string(),
+                    while_pending: Vec::new(),
+                },
+                width: 30.0,
+                depth: 10.0,
+                min_height: 0.0,
+                max_height: 10.0,
+            },
+            data: Some(Arc::new(crate::asset::pipelines::HeightmapData {
+                // A left-to-right ramp repeated along Z. Rectangular source
+                // dimensions make an accidental row/X transposition visible.
+                samples: vec![0, 32768, 65535, 0, 32768, 65535],
+                width: 3,
+                height: 2,
+                revision: 1,
+            })),
+        };
+        let mut world = World::new([0.0, 0.0, 0.0]);
+        world.reconcile(&scene(vec![Body::fixed("terrain".to_string(), shape)]));
+        world.step_frame(FIXED_DT);
+
+        let left = world
+            .raycast([-7.5, 20.0, 0.0], [0.0, -1.0, 0.0], 30.0)
+            .expect("left side of the X ramp");
+        let right = world
+            .raycast([7.5, 20.0, 0.0], [0.0, -1.0, 0.0], 30.0)
+            .expect("right side of the X ramp");
+        assert!((left.position[1] - 2.5).abs() < 0.001, "{left:?}");
+        assert!((right.position[1] - 7.5).abs() < 0.001, "{right:?}");
+    }
+
+    #[test]
     fn capped_heightfield_samples_exact_fractional_source_positions() {
         let data = crate::asset::pipelines::HeightmapData {
             // Along X: 0, 0, 1, 1. The middle of this three-cell source is

--- a/runtime/functor-runtime-common/src/scene3d/mod.rs
+++ b/runtime/functor-runtime-common/src/scene3d/mod.rs
@@ -324,6 +324,11 @@ impl SceneContext {
         self.terrain_requests.borrow_mut().retain(|source| {
             let handle = asset_cache
                 .load_asset_with_pipeline(self.heightmap_pipeline.clone(), &source.locator);
+            self.terrain_decode_residency
+                .borrow_mut()
+                .mark_unsettled(&source.while_pending, |locator| {
+                    asset_cache.is_unsettled(locator)
+                });
             let resolved = crate::asset::resolve_while_pending_state(
                 asset_cache,
                 &self.heightmap_pipeline,

--- a/runtime/functor-runtime-common/src/scene3d/mod.rs
+++ b/runtime/functor-runtime-common/src/scene3d/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::{
     cell::{Cell, RefCell},
     sync::Arc,
@@ -60,6 +60,7 @@ pub struct SceneContext {
     heightmaps: RefCell<HashMap<(u32, u32), geometry::HeightmapMesh>>,
     heightmap_pipeline: Arc<BuiltAssetPipeline<HeightmapData>>,
     terrain_decode_residency: RefCell<TerrainDecodeResidency>,
+    terrain_requests: RefCell<BTreeSet<crate::terrain::TerrainSource>>,
     terrain_renderer: RefCell<TerrainRenderer>,
     terrain_frame_serial: Cell<u64>,
     // Render targets persist across frames/hot reloads, keyed by the target's
@@ -219,6 +220,7 @@ impl SceneContext {
             heightmaps: RefCell::new(HashMap::new()),
             heightmap_pipeline: asset::build_pipeline(Box::new(HeightmapPipeline)),
             terrain_decode_residency: RefCell::new(TerrainDecodeResidency::default()),
+            terrain_requests: RefCell::new(BTreeSet::new()),
             terrain_renderer: RefCell::new(TerrainRenderer::default()),
             terrain_frame_serial: Cell::new(0),
             texture_pipeline: asset::build_pipeline(Box::new(TexturePipeline)),
@@ -257,11 +259,11 @@ impl SceneContext {
         asset_cache: &Arc<AssetCache>,
         commands: Vec<crate::asset::preload::PreloadCommand>,
     ) -> Vec<u64> {
-        {
-            let mut residency = self.terrain_decode_residency.borrow_mut();
-            residency.begin_epoch();
-            residency.evict_stale(|locator| self.heightmap_pipeline.evict(locator));
-        }
+        self.terrain_decode_residency.borrow_mut().begin_epoch();
+        self.drive_terrain_requests(asset_cache);
+        self.terrain_decode_residency
+            .borrow_mut()
+            .evict_stale(|locator| self.heightmap_pipeline.evict(locator));
         use crate::asset::preload::PreloadKind;
         let mut preloads = self.preloads.borrow_mut();
         for cmd in commands {
@@ -315,6 +317,54 @@ impl SceneContext {
         settled
     }
 
+    fn drive_terrain_requests(&self, asset_cache: &Arc<AssetCache>) {
+        self.terrain_requests
+            .borrow_mut()
+            .extend(crate::terrain::take_heightmap_requests());
+        self.terrain_requests.borrow_mut().retain(|source| {
+            let handle = asset_cache
+                .load_asset_with_pipeline(self.heightmap_pipeline.clone(), &source.locator);
+            let resolved = crate::asset::resolve_while_pending_state(
+                asset_cache,
+                &self.heightmap_pipeline,
+                &handle,
+                &source.while_pending,
+            );
+            let primary_is_loading =
+                matches!(&resolved, crate::asset::WhilePendingState::Loading(_));
+            self.terrain_decode_residency.borrow_mut().mark_source(
+                &source.locator,
+                &source.while_pending,
+                primary_is_loading,
+                |locator| asset_cache.is_unsettled(locator),
+            );
+            match resolved {
+                crate::asset::WhilePendingState::Loading(stand_in) => {
+                    if let Some(data) = stand_in {
+                        crate::terrain::publish_heightmap(source, data);
+                    }
+                    true
+                }
+                crate::asset::WhilePendingState::Loaded(data) => {
+                    crate::terrain::publish_heightmap(source, data);
+                    crate::asset::while_pending_chain_is_unsettled(
+                        asset_cache,
+                        &source.while_pending,
+                    )
+                }
+                crate::asset::WhilePendingState::Failed => {
+                    // Rendering uses the pipeline fallback after terminal
+                    // failure; publish that same flat surface for collision.
+                    crate::terrain::publish_heightmap(source, handle.fallback());
+                    crate::asset::while_pending_chain_is_unsettled(
+                        asset_cache,
+                        &source.while_pending,
+                    )
+                }
+            }
+        });
+    }
+
     fn draw_terrain(
         &self,
         render_context: &RenderContext,
@@ -341,6 +391,7 @@ impl SceneContext {
             &handle,
             &terrain.while_pending,
         );
+        let source_descriptor = terrain.source();
         let primary_is_loading =
             matches!(&resolved, crate::asset::WhilePendingState::Loading(_));
         self.terrain_decode_residency.borrow_mut().mark_source(
@@ -350,12 +401,32 @@ impl SceneContext {
             |locator| render_context.asset_cache.is_unsettled(locator),
         );
         let source = match resolved {
-            crate::asset::WhilePendingState::Loaded(data)
-            | crate::asset::WhilePendingState::Loading(Some(data)) => data,
-            crate::asset::WhilePendingState::Loading(None)
-            | crate::asset::WhilePendingState::Failed => handle.fallback(),
+            crate::asset::WhilePendingState::Loaded(data) => {
+                crate::terrain::publish_heightmap(&source_descriptor, data.clone());
+                data
+            }
+            crate::asset::WhilePendingState::Loading(Some(data)) => {
+                crate::terrain::publish_heightmap(&source_descriptor, data.clone());
+                data
+            }
+            crate::asset::WhilePendingState::Loading(None) => handle.fallback(),
+            crate::asset::WhilePendingState::Failed => {
+                let fallback = handle.fallback();
+                crate::terrain::publish_heightmap(&source_descriptor, fallback.clone());
+                fallback
+            }
         };
-        crate::terrain::publish_heightmap(&terrain.heightmap, source.clone());
+        // Drawing ordinarily polls again next frame. If the node disappears,
+        // retain any source or placeholder already in flight so the shared
+        // asset-progress gate cannot be stranded indefinitely.
+        if primary_is_loading
+            || crate::asset::while_pending_chain_is_unsettled(
+                &render_context.asset_cache,
+                &terrain.while_pending,
+            )
+        {
+            crate::terrain::request_heightmap(source_descriptor);
+        }
         self.terrain_renderer.borrow_mut().draw(
             render_context,
             terrain,

--- a/runtime/functor-runtime-common/src/scene3d/mod.rs
+++ b/runtime/functor-runtime-common/src/scene3d/mod.rs
@@ -102,10 +102,13 @@ enum PreloadHandle {
     Texture(Arc<AssetHandle<Texture2D>>),
 }
 
-/// Waiting-token bound per in-flight entry (spamming `preloadThen` at one
-/// stalled asset): beyond it the OLDEST token drops — its registered message
-/// then expires unclaimed, exactly like a capped [`PENDING_AUDIO`] eviction.
-const PRELOAD_TOKENS_CAP: usize = 1024;
+/// Replay-aware result from the shell asset driver. Ordinary shells consume
+/// only `settled`; whole-environment drivers also retain terrain publications
+/// so warm caches cannot change collision timing after a seek.
+pub struct PreloadDriveResult {
+    pub settled: Vec<u64>,
+    pub terrain_publications: Vec<crate::terrain::TerrainHydrationPublication>,
+}
 
 /// Decoded terrain sources receive one unused shell frame of grace before
 /// eviction. This retains ordinary frame-to-frame reuse without keeping every
@@ -259,8 +262,42 @@ impl SceneContext {
         asset_cache: &Arc<AssetCache>,
         commands: Vec<crate::asset::preload::PreloadCommand>,
     ) -> Vec<u64> {
+        self.drive_preloads_internal(asset_cache, commands, &[], false)
+            .settled
+    }
+
+    /// NetSim's replay-aware preload step. Terrain requests named in
+    /// `deferred_terrain` remain resident but are not polled or published this
+    /// frame, preserving the original collision-hydration boundary even when
+    /// the decoded asset cache is warm after a seek.
+    pub fn drive_preloads_deferring_terrain(
+        &self,
+        asset_cache: &Arc<AssetCache>,
+        commands: Vec<crate::asset::preload::PreloadCommand>,
+        deferred_terrain: &[crate::terrain::TerrainSource],
+    ) -> PreloadDriveResult {
+        self.drive_preloads_internal(asset_cache, commands, deferred_terrain, true)
+    }
+
+    fn drive_preloads_internal(
+        &self,
+        asset_cache: &Arc<AssetCache>,
+        commands: Vec<crate::asset::preload::PreloadCommand>,
+        deferred_terrain: &[crate::terrain::TerrainSource],
+        capture_terrain_publications: bool,
+    ) -> PreloadDriveResult {
         self.terrain_decode_residency.borrow_mut().begin_epoch();
-        self.drive_terrain_requests(asset_cache);
+        for source in deferred_terrain {
+            self.terrain_decode_residency.borrow_mut().mark_source(
+                &source.locator,
+                &source.while_pending,
+                true,
+                |_| true,
+            );
+        }
+        self.capture_terrain_requests();
+        let terrain_publications =
+            self.drive_terrain_requests(asset_cache, capture_terrain_publications);
         self.terrain_decode_residency
             .borrow_mut()
             .evict_stale(|locator| self.heightmap_pipeline.evict(locator));
@@ -273,9 +310,11 @@ impl SceneContext {
             {
                 // Already in flight: merge (the cache would hand back the
                 // same handle anyway); just accumulate the completion token.
-                if let Some(token) = cmd.token {
+                if let Some(token) = cmd.token.filter(|token| !entry.tokens.contains(token)) {
                     entry.tokens.push(token);
-                    if entry.tokens.len() > PRELOAD_TOKENS_CAP {
+                    if entry.tokens.len()
+                        > crate::asset::preload::TOKENS_PER_TARGET_CAP
+                    {
                         entry.tokens.remove(0);
                     }
                 }
@@ -314,13 +353,61 @@ impl SceneContext {
             settled.append(&mut entry.tokens);
             false
         });
-        settled
+        PreloadDriveResult {
+            settled,
+            terrain_publications,
+        }
     }
 
-    fn drive_terrain_requests(&self, asset_cache: &Arc<AssetCache>) {
+    /// Claim terrain hydration requests emitted by the producer that just ran.
+    /// Multi-producer shells call this immediately after each producer callback
+    /// so the process-global request queue cannot be attributed to a different
+    /// instance on the next frame. Single-producer shells can rely on
+    /// [`Self::drive_preloads`] calling it for them.
+    pub fn capture_terrain_requests(&self) {
         self.terrain_requests
             .borrow_mut()
             .extend(crate::terrain::take_heightmap_requests());
+    }
+
+    /// Clone the logical terrain hydration queue for a whole-shell snapshot.
+    ///
+    /// Asset handles remain cache-owned and warm across a seek; restoring this
+    /// plain descriptor set prevents requests from an abandoned future from
+    /// leaking into the new branch.
+    pub fn snapshot_terrain_requests(&self) -> Vec<crate::terrain::TerrainSource> {
+        self.terrain_requests.borrow().iter().cloned().collect()
+    }
+
+    /// Replace the logical terrain hydration queue from a whole-shell snapshot.
+    pub fn restore_terrain_requests(&self, requests: Vec<crate::terrain::TerrainSource>) {
+        *self.terrain_requests.borrow_mut() = requests.into_iter().collect();
+    }
+
+    /// Re-publish one opaque terrain surface captured from the original
+    /// timeline. The data stays owned by the common runtime; NetSim only
+    /// schedules this event.
+    pub fn replay_terrain_publication(
+        &self,
+        publication: &crate::terrain::TerrainHydrationPublication,
+    ) {
+        crate::terrain::replay_heightmap_publication(publication);
+    }
+
+    /// Discard only the in-flight preload driver state before restoring a
+    /// whole-shell snapshot. Decoded pipeline handles and terrain hydration
+    /// remain warm; the snapshot's logical preload commands are re-submitted
+    /// on the next frame.
+    pub fn reset_preloads(&self) {
+        self.preloads.borrow_mut().clear();
+    }
+
+    fn drive_terrain_requests(
+        &self,
+        asset_cache: &Arc<AssetCache>,
+        capture_publications: bool,
+    ) -> Vec<crate::terrain::TerrainHydrationPublication> {
+        let mut publications = Vec::new();
         self.terrain_requests.borrow_mut().retain(|source| {
             let handle = asset_cache
                 .load_asset_with_pipeline(self.heightmap_pipeline.clone(), &source.locator);
@@ -346,12 +433,28 @@ impl SceneContext {
             match resolved {
                 crate::asset::WhilePendingState::Loading(stand_in) => {
                     if let Some(data) = stand_in {
-                        crate::terrain::publish_heightmap(source, data);
+                        if capture_publications {
+                            crate::terrain::publish_heightmap(source, data.clone());
+                            publications.push(crate::terrain::TerrainHydrationPublication::new(
+                                source.clone(),
+                                data,
+                            ));
+                        } else {
+                            crate::terrain::publish_heightmap(source, data);
+                        }
                     }
                     true
                 }
                 crate::asset::WhilePendingState::Loaded(data) => {
-                    crate::terrain::publish_heightmap(source, data);
+                    if capture_publications {
+                        crate::terrain::publish_heightmap(source, data.clone());
+                        publications.push(crate::terrain::TerrainHydrationPublication::new(
+                            source.clone(),
+                            data,
+                        ));
+                    } else {
+                        crate::terrain::publish_heightmap(source, data);
+                    }
                     crate::asset::while_pending_chain_is_unsettled(
                         asset_cache,
                         &source.while_pending,
@@ -360,7 +463,16 @@ impl SceneContext {
                 crate::asset::WhilePendingState::Failed => {
                     // Rendering uses the pipeline fallback after terminal
                     // failure; publish that same flat surface for collision.
-                    crate::terrain::publish_heightmap(source, handle.fallback());
+                    let data = handle.fallback();
+                    if capture_publications {
+                        crate::terrain::publish_heightmap(source, data.clone());
+                        publications.push(crate::terrain::TerrainHydrationPublication::new(
+                            source.clone(),
+                            data,
+                        ));
+                    } else {
+                        crate::terrain::publish_heightmap(source, data);
+                    }
                     crate::asset::while_pending_chain_is_unsettled(
                         asset_cache,
                         &source.while_pending,
@@ -368,6 +480,7 @@ impl SceneContext {
                 }
             }
         });
+        publications
     }
 
     fn draw_terrain(
@@ -1463,6 +1576,13 @@ mod preload_tests {
                     locator: missing.clone(),
                     token: Some(42),
                 },
+                // Restoring a whole-shell snapshot may resubmit a token to an
+                // entry that is still alive in the driver. It stays one-shot.
+                PreloadCommand {
+                    kind: PreloadKind::Model,
+                    locator: missing.clone(),
+                    token: Some(42),
+                },
                 PreloadCommand {
                     kind: PreloadKind::Model,
                     locator: missing.clone(),
@@ -1476,8 +1596,32 @@ mod preload_tests {
         sorted.sort();
         assert_eq!(sorted, vec![41, 42]);
         assert_eq!(ctx.preloads_in_flight(), 0);
-        // The path counted once in progress despite three commands.
+        // The path counted once in progress despite repeated commands.
         assert_eq!(cache.progress().total, 1);
+    }
+
+    #[test]
+    fn terrain_request_snapshot_restore_discards_future_requests() {
+        let ctx = SceneContext::new();
+        let earlier = crate::terrain::TerrainSource {
+            locator: "terrain/earlier.png".to_string(),
+            while_pending: Vec::new(),
+        };
+        let future = crate::terrain::TerrainSource {
+            locator: "terrain/future.png".to_string(),
+            while_pending: Vec::new(),
+        };
+
+        crate::terrain::request_heightmap(earlier.clone());
+        ctx.capture_terrain_requests();
+        let snapshot = ctx.snapshot_terrain_requests();
+
+        crate::terrain::request_heightmap(future);
+        ctx.capture_terrain_requests();
+        assert_eq!(ctx.snapshot_terrain_requests().len(), 2);
+
+        ctx.restore_terrain_requests(snapshot);
+        assert_eq!(ctx.snapshot_terrain_requests(), vec![earlier]);
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/terrain.rs
+++ b/runtime/functor-runtime-common/src/terrain.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::{
     cell::RefCell,
-    collections::HashMap,
+    collections::{BTreeSet, HashMap},
     sync::{Arc, Weak},
 };
 
@@ -11,15 +11,40 @@ thread_local! {
     /// Decoded terrain sources shared by the render and physics adapters on
     /// the runtime thread. The descriptor remains plain immutable data; this
     /// is only the shell-side hydration cache, analogous to GPU resources.
-    static HEIGHTMAPS: RefCell<HashMap<String, Weak<HeightmapData>>> =
+    static HEIGHTMAPS: RefCell<HashMap<TerrainSource, Weak<HeightmapData>>> =
         RefCell::new(HashMap::new());
+    /// Sources requested by `Physics.heightfield` since the shell last drove
+    /// terrain asset hydration. A set keeps repeated fixed substeps cheap.
+    static HEIGHTMAP_REQUESTS: RefCell<BTreeSet<TerrainSource>> =
+        RefCell::new(BTreeSet::new());
 }
 
-pub(crate) fn publish_heightmap(locator: &str, data: Arc<HeightmapData>) {
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct TerrainSource {
+    pub locator: String,
+    #[serde(default)]
+    pub while_pending: Vec<String>,
+}
+
+pub(crate) fn request_heightmap(source: TerrainSource) {
+    HEIGHTMAP_REQUESTS.with(|requests| {
+        requests.borrow_mut().insert(source);
+    });
+}
+
+pub(crate) fn take_heightmap_requests() -> Vec<TerrainSource> {
+    HEIGHTMAP_REQUESTS.with(|requests| {
+        std::mem::take(&mut *requests.borrow_mut())
+            .into_iter()
+            .collect()
+    })
+}
+
+pub(crate) fn publish_heightmap(source: &TerrainSource, data: Arc<HeightmapData>) {
     HEIGHTMAPS.with(|heightmaps| {
         let mut heightmaps = heightmaps.borrow_mut();
         let unchanged = heightmaps
-            .get(locator)
+            .get(source)
             .and_then(Weak::upgrade)
             // HeightmapData is Eq, so Arc equality first takes the pointer
             // fast path and only compares samples after a real reload.
@@ -28,9 +53,20 @@ pub(crate) fn publish_heightmap(locator: &str, data: Arc<HeightmapData>) {
             // The asset pipeline and current physics declaration own the
             // samples. This lookup bridge must not pin a 32 MiB 4096² map
             // after its runtime/project has gone away.
-            heightmaps.insert(locator.to_string(), Arc::downgrade(&data));
+            heightmaps.insert(source.clone(), Arc::downgrade(&data));
         }
     });
+}
+
+pub(crate) fn hydrated_heightmap(source: &TerrainSource) -> Option<Arc<HeightmapData>> {
+    HEIGHTMAPS.with(|heightmaps| {
+        let mut heightmaps = heightmaps.borrow_mut();
+        let hydrated = heightmaps.get(source).and_then(Weak::upgrade);
+        if hydrated.is_none() {
+            heightmaps.remove(source);
+        }
+        hydrated
+    })
 }
 
 /// The collision-relevant subset of a terrain descriptor.
@@ -39,7 +75,7 @@ pub(crate) fn publish_heightmap(locator: &str, data: Arc<HeightmapData>) {
 /// colors, or vegetation does not rebuild a multi-megabyte collider.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct TerrainGeometry {
-    pub heightmap: String,
+    pub source: TerrainSource,
     pub width: f32,
     pub depth: f32,
     pub min_height: f32,
@@ -139,11 +175,18 @@ impl TerrainDescription {
 
     pub fn geometry(&self) -> TerrainGeometry {
         TerrainGeometry {
-            heightmap: self.heightmap.clone(),
+            source: self.source(),
             width: self.width,
             depth: self.depth,
             min_height: self.min_height,
             max_height: self.max_height,
+        }
+    }
+
+    pub fn source(&self) -> TerrainSource {
+        TerrainSource {
+            locator: self.heightmap.clone(),
+            while_pending: self.while_pending.clone(),
         }
     }
 }
@@ -185,14 +228,17 @@ mod tests {
 
     #[test]
     fn hydration_registry_does_not_retain_heightmap_samples() {
-        let locator = "weak-registry-test.png";
+        let source = TerrainSource {
+            locator: "weak-registry-test.png".to_string(),
+            while_pending: Vec::new(),
+        };
         let data = Arc::new(HeightmapData::flat());
         let weak = Arc::downgrade(&data);
-        publish_heightmap(locator, data.clone());
+        publish_heightmap(&source, data.clone());
         assert_eq!(Arc::strong_count(&data), 1);
 
         drop(data);
         assert!(weak.upgrade().is_none());
-        HEIGHTMAPS.with(|heightmaps| heightmaps.borrow_mut().remove(locator));
+        HEIGHTMAPS.with(|heightmaps| heightmaps.borrow_mut().remove(&source));
     }
 }

--- a/runtime/functor-runtime-common/src/terrain.rs
+++ b/runtime/functor-runtime-common/src/terrain.rs
@@ -26,6 +26,25 @@ pub struct TerrainSource {
     pub while_pending: Vec<String>,
 }
 
+/// One decoded surface published from the terrain asset driver into the
+/// render/physics hydration bridge. Whole-environment replay keeps these
+/// events opaque and re-publishes them at their original frames.
+#[derive(Clone)]
+pub struct TerrainHydrationPublication {
+    pub source: TerrainSource,
+    data: Arc<HeightmapData>,
+}
+
+impl TerrainHydrationPublication {
+    pub(crate) fn new(source: TerrainSource, data: Arc<HeightmapData>) -> Self {
+        Self { source, data }
+    }
+
+    pub fn revision(&self) -> u64 {
+        self.data.revision
+    }
+}
+
 pub(crate) fn request_heightmap(source: TerrainSource) {
     HEIGHTMAP_REQUESTS.with(|requests| {
         requests.borrow_mut().insert(source);
@@ -67,6 +86,18 @@ pub(crate) fn hydrated_heightmap(source: &TerrainSource) -> Option<Arc<Heightmap
         }
         hydrated
     })
+}
+
+/// Clear the process-global render/physics hydration bridge when a whole shell
+/// restores an earlier snapshot. The restored physics world already owns its
+/// historical collider; leaving future decoded samples here would let the next
+/// `Physics.heightfield` declaration install them before their recorded frame.
+pub fn clear_hydrated_heightmaps() {
+    HEIGHTMAPS.with(|heightmaps| heightmaps.borrow_mut().clear());
+}
+
+pub(crate) fn replay_heightmap_publication(publication: &TerrainHydrationPublication) {
+    publish_heightmap(&publication.source, publication.data.clone());
 }
 
 /// The collision-relevant subset of a terrain descriptor.

--- a/runtime/functor-runtime-common/src/terrain_renderer.rs
+++ b/runtime/functor-runtime-common/src/terrain_renderer.rs
@@ -56,8 +56,14 @@ const VERTEX_SHADER_SOURCE: &str = r#"
             float h10 = float(texelFetch(heightmapTex, ivec2(b.x, a.y), 0).r);
             float h01 = float(texelFetch(heightmapTex, ivec2(a.x, b.y), 0).r);
             float h11 = float(texelFetch(heightmapTex, b, 0).r);
-            float normalized = mix(mix(h00, h10, f.x), mix(h01, h11, f.x), f.y)
-                / 65535.0;
+            // Match Rapier's default heightfield diagonal exactly. Bilinear
+            // interpolation would produce a different surface inside every
+            // non-coplanar source cell.
+            float sampleHeight = f.x + f.y <= 1.0
+                ? h00 + f.x * (h10 - h00) + f.y * (h01 - h00)
+                : h11 + (1.0 - f.x) * (h01 - h11)
+                      + (1.0 - f.y) * (h10 - h11);
+            float normalized = sampleHeight / 65535.0;
             return minHeight + normalized * terrainSize.z;
         }
 
@@ -175,9 +181,11 @@ const GRASS_VERTEX_SHADER_SOURCE: &str = r#"
             float h10 = float(texelFetch(heightmapTex, ivec2(b.x, a.y), 0).r);
             float h01 = float(texelFetch(heightmapTex, ivec2(a.x, b.y), 0).r);
             float h11 = float(texelFetch(heightmapTex, b, 0).r);
-            return minHeight
-                + mix(mix(h00, h10, f.x), mix(h01, h11, f.x), f.y)
-                    / 65535.0 * terrainSize.z;
+            float sampleHeight = f.x + f.y <= 1.0
+                ? h00 + f.x * (h10 - h00) + f.y * (h01 - h00)
+                : h11 + (1.0 - f.x) * (h01 - h11)
+                      + (1.0 - f.y) * (h10 - h11);
+            return minHeight + sampleHeight / 65535.0 * terrainSize.z;
         }
 
         void main() {

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -2269,11 +2269,14 @@ mod tests {
 
         // The live continuation at 1/60: the ground truth the sub-stepped
         // forward-step must match at its division boundaries.
-        let mut live: Vec<(String, Option<Vec<u8>>)> = Vec::with_capacity(N);
+        let mut live: Vec<(
+            String,
+            Option<functor_runtime_common::physics::PhysicsSnapshot>,
+        )> = Vec::with_capacity(N);
         for _ in 0..N {
             tts += SUB_DT;
             game.tick(FrameTime { tts, dts: SUB_DT });
-            let world = physics::with_world(physics::DEFAULT_WORLD, |w| w.snapshot());
+            let world = physics::with_world(physics::DEFAULT_WORLD, |w| w.checkpoint());
             live.push((game.model.to_string(), world));
         }
 

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -796,6 +796,12 @@ fn run_headless(
         // Same per-frame ordering as the windowed loop (the source of truth),
         // minus everything that needs GL.
         game.check_hot_reload(time.clone());
+        game.push_asset_progress(asset_cache.progress());
+        let preload_commands =
+            serde_json::from_str(&game.preload_drain_commands()).unwrap_or_default();
+        for token in scene_context.drive_preloads(&asset_cache, preload_commands) {
+            game.preload_push_settled(token);
+        }
         deliver_net_ws(&mut *game, &net_rx, &ws_rx);
         for sub in &sub_frames {
             if let Some(events) = input_script
@@ -820,12 +826,10 @@ fn run_headless(
         dispatch_net_ws(&mut *game, &net_tx, &http_client, &mut ws_manager);
 
         // The frame is pure data (no GL); it powers GET /scene. Drain and drop
-        // audio and preload commands (no device / no asset cache in headless)
-        // so they don't pile up. Like playThen, a preloadThen's message never
-        // delivers headless — the known Sub.assets-under---headless gap.
+        // audio commands so they do not pile up. Preloads and physics terrain
+        // requests are driven above through the CPU-only asset cache.
         let frame = game.render(time.clone());
         let _ = game.audio_drain_commands();
-        let _ = game.preload_drain_commands();
 
         if let Some(rx) = &debug_requests {
             while let Ok(req) = rx.try_recv() {

--- a/runtime/functor-runtime-oculus/src/lib.rs
+++ b/runtime/functor-runtime-oculus/src/lib.rs
@@ -1129,6 +1129,11 @@ pub fn android_main(app: AndroidApp) {
         // every target.
         game.check_hot_reload(frame_time.clone());
         game.push_asset_progress(asset_cache.progress());
+        let preload_commands =
+            serde_json::from_str(&game.preload_drain_commands()).unwrap_or_default();
+        for token in scene_context.drive_preloads(&asset_cache, preload_commands) {
+            game.preload_push_settled(token);
+        }
         for sub_frame in &sub_frames {
             if game.samples_input() {
                 game.sampled_input(&debug.input);
@@ -1137,13 +1142,12 @@ pub fn android_main(app: AndroidApp) {
             debug.frame_count += 1;
         }
         let frame = game.render(frame_time.clone());
-        // No audio/HTTP/preload hosts on device yet: drain their command
-        // queues so they don't grow unbounded. Asset progress is real and fed
-        // above; the remaining effects run but do not produce sound/replies.
+        // No audio/HTTP hosts on device yet: drain their command queues so
+        // they don't grow unbounded. Preloads and physics terrain requests
+        // are driven above through the shared asset cache.
         let _ = game.audio_drain_commands();
         let _ = game.net_drain_commands();
         let _ = game.net_drain_conn_commands();
-        let _ = game.preload_drain_commands();
 
         let capture_due = debug.pending_capture.is_some();
         let mut captured_eyes = capture_due.then(Vec::new);


### PR DESCRIPTION
## Summary

- add `Physics.heightfield(tag, terrain)` over the same immutable descriptor used by `Scene.terrain`
- hydrate terrain independently of drawing, including physics-only/headless runs
- build one seam-free Rapier heightfield capped at a 1025² collision grid
- match Rapier's triangle interpolation in rendering and collision resampling
- structurally share height samples and Rapier shapes across in-process timeline checkpoints
- preserve prior collision while replacement data is pending

## Stack

This PR is based on [#469](https://github.com/tommy-xr/functor/pull/469). The showcase follows in [#471](https://github.com/tommy-xr/functor/pull/471).

## Determinism and loading

The live shell resolves the current heightmap revision before recording a fixed physics frame. The exact hydrated scene is moved into timeline history; replay never consults later asset or hot-reload state. Hoisted/eager Functor Lang bodies therefore promote when loading finishes without making historical collision asset-dependent.

Primary and `whilePending` requests remain polled until every started load settles, even if terrain leaves the draw scene. Failed sources resolve to the same flat fallback in rendering and collision. Decoded stand-ins are marked before polling, which closes the synchronous hot-reload settlement edge without pinning settled placeholders.

NetSim now owns each producer's preload and terrain-hydration queues at the same atomic shell boundaries as network commands. Whole-environment replay restores pending commands and completion messages, preserves their original settlement/publication frames even when the decoded asset cache is warm, and re-publishes the latest terrain surface valid at each replayed frame. A body that was absent at the snapshot can therefore respawn against the historical stand-in and still promote to the primary heightmap on the original frame.

## Validation

- 470 runtime unit tests and 8 prelude integration tests
- 3 always-on NetSim preload ownership/replay regressions
- 2 always-on NetSim terrain tests: physics-only hydration plus stand-in → primary replay with an absent/respawned body
- all 11 ignored whole-environment NetSim tests run explicitly
- WebAssembly release build and Quest arm64 target check
- native and self-contained WebAssembly terrain sample builds
- `npm run check:docs`
- release `frame_bench`: exact allocation/byte parity with the base at all workloads (13,877 / 54,717 / 106,973 allocations per frame); wall-clock treated as load noise
- focused duplicate scan: 0 clones
- final adversarial re-review: no Critical, High, or Medium findings

## Review disposition

Adversarial findings addressed:

- replaced tiled compound collision with one collider to remove internal contact seams
- moved hydration ahead of timeline recording so replay uses the historical asset revision
- retained primary and placeholder requests through terminal settlement without permanent decode residency
- added a non-symmetric rectangular heightfield regression that catches X/Z transposition
- promoted the physics-only hydration test into the default native CI matrix
- resampled capped collision at exact fractional source coordinates
- kept eager/hoisted `Physics.heightfield` values as immutable descriptors
- made preload commands, completion messages, terrain requests, and terrain publication timing instance-owned and snapshot-restorable in NetSim
- preserved dropped-token tombstones so replay cannot revive commands evicted by the 1,024-token per-target cap
- retained one pre-history terrain publication only while a retained pending interval needs it, then released the strong heightmap reference when terminal state ages out
- kept replay publication capture out of the ordinary desktop/VR `SceneContext` path

The bounded initial collider is deliberate. Camera-local higher-resolution collision streaming and real on-device construction/per-frame measurements remain focused follow-up work.

A warning for render/physics transform mismatch is deferred in favor of a future descriptor-owned placement contract: matching independent scene nodes by source would otherwise be ambiguous. Water behavior and vegetation/waterline coupling are out of scope.

## Visual evidence

![4 km terrain with animated grass](https://gist.githubusercontent.com/tommy-xr/d44b227ce3001b94e64e7bc1914069f3/raw/terrain-grass-wind.gif)

<sub>4 km × 4 km heightmap terrain with stereo-stable quadtree LOD, layered slope/height material, fog, a snow-capped ridge, and GPU-instanced grass animated across one exact wind period. Rendered headlessly from the release CLI via `--capture-frame` / `--fixed-time`.</sub>

![4 km terrain still](https://gist.githubusercontent.com/tommy-xr/d44b227ce3001b94e64e7bc1914069f3/raw/terrain-showcase.png)

<!-- terrain-pr-visuals:d44b227ce3001b94e64e7bc1914069f3 -->
