### PR TITLE
feat(netsim): whole-environment time travel — seek the sim, not one client

### DIFF
--- a/runtime/functor-netsim/src/lib.rs
+++ b/runtime/functor-netsim/src/lib.rs
@@ -22,6 +22,7 @@ use functor_runtime_common::net::{
     ConnCommand, ConnectionId, LinkProfile, NetEvent, NodeId, VirtualNet,
 };
 use functor_runtime_common::protocol::GameProducer;
+use functor_runtime_common::timetravel::{History, DEFAULT_HISTORY_FRAMES};
 use functor_runtime_common::FrameTime;
 
 pub use functor_runtime_common::net::LinkProfile as Link;
@@ -130,6 +131,28 @@ impl Instance {
     }
 }
 
+/// The harness-owned half of a whole-environment snapshot.
+///
+/// Whole-environment time travel splits in two, along the line the code already
+/// draws: **each producer records and restores its own model** (`SceneRecorder`
+/// runs inside the frame body `tick` executes, and `seek_scene_to` restores it),
+/// so the sim only has to snapshot what lives OUTSIDE the producers — the
+/// network and the routing tables built from it.
+///
+/// This is a plain deep copy, unlike the model ring's `Rc` structural sharing:
+/// what keeps it affordable is that the models are not in here at all, and what
+/// remains (in-flight packets and undelivered events) is bounded by the traffic
+/// actually crossing a frame. It is the part to measure first if the ring ever
+/// shows up in a profile.
+#[derive(Clone)]
+struct SimSnapshot {
+    vnet: VirtualNet,
+    /// authority -> (server instance, its listen key).
+    listeners: HashMap<String, (InstanceId, String)>,
+    /// Per-instance `(keys, outbox)`, positionally indexed by [`InstanceId`].
+    routes: Vec<(HashMap<ConnectionId, String>, Vec<ConnCommand>)>,
+}
+
 /// A deterministic in-process multiplayer simulation.
 pub struct NetSim {
     vnet: VirtualNet,
@@ -138,6 +161,28 @@ pub struct NetSim {
     listeners: HashMap<String, (InstanceId, String)>,
     frame: u64,
     dt: f32,
+    /// Per-frame ring of the harness state, the network half of a whole-
+    /// environment scrub. Shares the producers' horizon so [`frame_range`] and
+    /// each instance's `scene_frame_range` agree on what is still reachable.
+    ///
+    /// [`frame_range`]: NetSim::frame_range
+    history: History<SimSnapshot>,
+    /// Frame the sim is parked on, if a [`seek`](NetSim::seek) is in effect.
+    scrub_pos: Option<u64>,
+    /// Link impairment as CONFIGURED (as opposed to as recorded), so a restore
+    /// brings back the traffic without undoing the caller's current settings.
+    /// See [`reapply_link_config`](NetSim::reapply_link_config).
+    links: HashMap<(InstanceId, InstanceId), LinkProfile>,
+    partitioned: std::collections::HashSet<(InstanceId, InstanceId)>,
+}
+
+/// An unordered instance pair, so link config is keyed the same either way round.
+fn pair(a: InstanceId, b: InstanceId) -> (InstanceId, InstanceId) {
+    if a <= b {
+        (a, b)
+    } else {
+        (b, a)
+    }
 }
 
 impl NetSim {
@@ -148,6 +193,10 @@ impl NetSim {
             listeners: HashMap::new(),
             frame: 0,
             dt: 1.0 / 60.0,
+            history: History::bounded(DEFAULT_HISTORY_FRAMES),
+            scrub_pos: None,
+            links: HashMap::new(),
+            partitioned: std::collections::HashSet::new(),
         }
     }
 
@@ -157,7 +206,24 @@ impl NetSim {
     /// Producers share this process's runtime — including the process-global
     /// net-command queue — so [`step`](Self::step) drains each one's outbound
     /// commands atomically to keep them isolated.
+    ///
+    /// # Panics
+    ///
+    /// If the sim has already stepped. Every instance must join before frame 0
+    /// so that sim frame `f` and each producer's rendered frame `f` name the
+    /// same instant — the alignment [`seek`](Self::seek) rests on. A late joiner
+    /// would start recording at ITS frame 0 while the sim was at frame `n`, and
+    /// the snapshots taken before it joined describe a network that has no node
+    /// for it. Late join is a real feature (a player connecting mid-session),
+    /// but it needs per-instance frame offsets in the snapshot; until then this
+    /// is a loud error rather than a silently skewed timeline.
     pub fn add_producer(&mut self, producer: Box<dyn GameProducer>) -> InstanceId {
+        assert_eq!(
+            self.frame, 0,
+            "add_producer after the sim has stepped: every instance must join \
+             before frame 0, or its recorded frames no longer align with the \
+             sim's (see NetSim::seek)"
+        );
         let node = self.vnet.add_node();
         let id = self.instances.len();
         self.instances.push(Instance::from_producer(producer, node));
@@ -166,19 +232,53 @@ impl NetSim {
 
     /// Set the link impairment (latency/jitter/loss/reorder) between two instances.
     pub fn set_link(&mut self, a: InstanceId, b: InstanceId, profile: LinkProfile) {
+        self.links.insert(pair(a, b), profile);
         self.vnet
             .set_link(self.instances[a].node, self.instances[b].node, profile);
     }
 
     /// Cut traffic between two instances until [`heal`](Self::heal).
     pub fn partition(&mut self, a: InstanceId, b: InstanceId) {
+        self.partitioned.insert(pair(a, b));
         self.vnet
             .partition(self.instances[a].node, self.instances[b].node);
     }
 
     pub fn heal(&mut self, a: InstanceId, b: InstanceId) {
+        self.partitioned.remove(&pair(a, b));
         self.vnet
             .heal(self.instances[a].node, self.instances[b].node);
+    }
+
+    /// Re-apply the CURRENT link configuration over a restored network.
+    ///
+    /// Impairment is configuration, not simulation state: rewinding must bring
+    /// back the packets that were in flight, but not silently undo the profile
+    /// the caller has since dialed in. Keeping it live is what makes the
+    /// "rewind, worsen the link, watch it again" gesture work — and when
+    /// nothing was changed, re-applying is identical to restoring, so exact
+    /// replay is unaffected.
+    /// The configuration is authoritative over EVERY pair, not just the ones it
+    /// names: a heal performed while parked has to survive the restore too, and
+    /// that is only expressible by healing the pairs the config doesn't list.
+    fn reapply_link_config(&mut self) {
+        let links: Vec<((InstanceId, InstanceId), LinkProfile)> =
+            self.links.iter().map(|(k, v)| (*k, *v)).collect();
+        for ((a, b), profile) in links {
+            self.vnet
+                .set_link(self.instances[a].node, self.instances[b].node, profile);
+        }
+        let partitioned = self.partitioned.clone();
+        for a in 0..self.instances.len() {
+            for b in (a + 1)..self.instances.len() {
+                let (na, nb) = (self.instances[a].node, self.instances[b].node);
+                if partitioned.contains(&pair(a, b)) {
+                    self.vnet.partition(na, nb);
+                } else {
+                    self.vnet.heal(na, nb);
+                }
+            }
+        }
     }
 
     /// The Debug-formatted model of an instance.
@@ -196,6 +296,10 @@ impl NetSim {
     }
 
     /// The current simulation frame (number of [`step`](Self::step)s taken).
+    ///
+    /// This is the LIVE frame and does not move while a [`seek`](Self::seek) is
+    /// parked — a viewer labelling "you are here" wants
+    /// [`scrub_pos`](Self::scrub_pos) first, falling back to this.
     pub fn frame(&self) -> u64 {
         self.frame
     }
@@ -234,6 +338,18 @@ impl NetSim {
     /// commands they produced through the virtual network, advance it one tick,
     /// and deliver the resulting events back to each instance.
     pub fn step(&mut self) {
+        // Stepping on from a scrubbed frame commits the branch first. A failed
+        // commit leaves the sim parked (nothing was mutated — `commit_branch`
+        // preflights) rather than advancing a half-rewound environment.
+        if let Some(frame) = self.scrub_pos {
+            match self.commit_branch(frame) {
+                Ok(()) => self.scrub_pos = None,
+                Err(e) => {
+                    eprintln!("[netsim] {e} — staying parked on frame {frame}");
+                    return;
+                }
+            }
+        }
         let time = FrameTime {
             tts: self.frame as f32 * self.dt,
             dts: self.dt,
@@ -276,7 +392,155 @@ impl NetSim {
         }
 
         self.vnet.advance(1);
+
+        // THE SNAPSHOT CUT, and it is load-bearing. Only `deliver` touches a
+        // producer's model outside `tick` (`deliver_net_event` folds an inbound
+        // message through `update` on the spot), so here — after this frame's
+        // sends are routed and the network has advanced, but before delivery —
+        // every instance's model is still EXACTLY the one its `SceneRecorder`
+        // recorded for this frame. That is what makes a seek coherent: the
+        // restored models and the restored network name the same instant.
+        //
+        // The pending deliveries are captured inside the network snapshot, so
+        // committing a branch replays them (see `commit_branch`) and the
+        // original frame order is reproduced exactly.
+        let settled = self.frame - 1;
+        self.history.record(settled, &self.snapshot());
+
         self.deliver();
+    }
+
+    /// The harness state as of right now.
+    fn snapshot(&self) -> SimSnapshot {
+        SimSnapshot {
+            vnet: self.vnet.clone(),
+            listeners: self.listeners.clone(),
+            routes: self
+                .instances
+                .iter()
+                .map(|inst| (inst.keys.clone(), inst.outbox.clone()))
+                .collect(),
+        }
+    }
+
+    fn restore(&mut self, snapshot: SimSnapshot) {
+        self.vnet = snapshot.vnet;
+        self.listeners = snapshot.listeners;
+        for (inst, (keys, outbox)) in self.instances.iter_mut().zip(snapshot.routes) {
+            inst.keys = keys;
+            inst.outbox = outbox;
+        }
+        self.reapply_link_config();
+    }
+
+    /// The frames a [`seek`](Self::seek) can currently reach, or `None` before
+    /// the first [`step`](Self::step).
+    pub fn frame_range(&self) -> Option<(u64, u64)> {
+        self.history.recorded_range()
+    }
+
+    /// Verify every instance can actually restore `frame` BEFORE anything is
+    /// mutated, so a seek/branch is all-or-nothing.
+    ///
+    /// This cannot be delegated to the producers: `SceneRecorder::seek_scene_to`
+    /// and `rewind_scene_to` **clamp** to their own recorded range and return
+    /// `Ok` (`timetravel.rs`), and their only hard failures are an empty history
+    /// or a pruned *physics* frame — which a game without physics never reaches.
+    /// So a producer whose ring has pruned past `frame` would silently restore a
+    /// DIFFERENT frame and report success, quietly desynchronizing the panes
+    /// from each other and from the network. Checking the ranges here turns that
+    /// into a loud error.
+    fn preflight(&self, frame: u64, op: &str) -> Result<(), String> {
+        for (id, inst) in self.instances.iter().enumerate() {
+            let range = inst.producer.scene_frame_range().ok_or_else(|| {
+                format!("{op}: instance {id} has recorded no frames to restore")
+            })?;
+            if frame < range.0 || frame > range.1 {
+                return Err(format!(
+                    "{op}: instance {id} cannot restore sim frame {frame} — it \
+                     retains frames {}..={} (its history was pruned, or it did \
+                     not step with the sim)",
+                    range.0, range.1
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// The frame a [`seek`](Self::seek) has parked the sim on, if any.
+    pub fn scrub_pos(&self) -> Option<u64> {
+        self.scrub_pos
+    }
+
+    /// **Whole-environment seek.** Restore every instance's model AND the
+    /// network to the state they settled in at `frame` — so a rewound frame
+    /// shows each client's own lagging view, the server's authoritative one, and
+    /// the packets that were genuinely mid-flight between them at that frame.
+    ///
+    /// Non-destructive **while parked**, in the same sense as the single-game
+    /// scrubber: the recorded future is retained on both sides (the sim's ring
+    /// and every producer's), so the caller can drag freely. The next
+    /// [`step`](Self::step) is what commits the branch and drops that future.
+    /// Because a scrub-back is a plain restore and never a re-step, **this needs
+    /// no determinism at all** — the same property `History` relies on for one
+    /// game holds for N games plus the network.
+    ///
+    /// The parked state is the frame as a viewer SAW it — the snapshot cut is
+    /// taken before delivery, so the seek finishes the frame by replaying its
+    /// pending deliveries. Seeking is therefore idempotent (each seek restores
+    /// from the recorded frame and re-delivers), and `seek(f)` then
+    /// [`state`](Self::state) equals what `state` returned live at frame `f`.
+    ///
+    /// `frame` is clamped into [`frame_range`](Self::frame_range). Errors if
+    /// nothing is recorded yet, or if any instance refuses the seek (reported
+    /// with the instance id; instances that already seeked are left where they
+    /// are, since the caller's recourse is another seek).
+    pub fn seek(&mut self, frame: u64) -> Result<String, String> {
+        let (lo, hi) = self
+            .frame_range()
+            .ok_or_else(|| "seek: nothing recorded yet".to_string())?;
+        let frame = frame.clamp(lo, hi);
+        self.preflight(frame, "seek")?;
+        for (id, inst) in self.instances.iter_mut().enumerate() {
+            inst.producer
+                .seek_scene_to(frame)
+                .map_err(|e| format!("seek: instance {id}: {e}"))?;
+        }
+        let snapshot = self.history.seek(frame).clone();
+        self.restore(snapshot);
+        self.deliver();
+        self.scrub_pos = Some(frame);
+        Ok(format!("scrubbed to sim frame {frame}"))
+    }
+
+    /// Commit the branch a [`seek`](Self::seek) parked on: drop the recorded
+    /// future beyond the scrubbed frame on both sides (the sim's ring and every
+    /// producer's), and finish that frame by running its pending deliveries.
+    ///
+    /// Called automatically by [`step`](Self::step) — resuming from a scrubbed
+    /// frame is what commits the branch, matching the single-game scrubber
+    /// (`run.rs`, "resuming from there is what commits the branch").
+    ///
+    /// Rebuilt from the RECORDED frame rather than from whatever the seek left
+    /// on screen: `rewind_scene_to` resets each model to its recorded frame,
+    /// the network snapshot is restored again, and the frame's pending
+    /// deliveries are replayed. So the branch point is the genuine end of frame
+    /// `frame` no matter how the user dragged the scrubber to get there, and
+    /// stepping on from an untouched scrub reproduces the original timeline
+    /// exactly instead of shifting the network by a frame.
+    fn commit_branch(&mut self, frame: u64) -> Result<(), String> {
+        self.preflight(frame, "branch")?;
+        let snapshot = self.history.seek(frame).clone();
+        for (id, inst) in self.instances.iter_mut().enumerate() {
+            inst.producer
+                .rewind_scene_to(frame)
+                .map_err(|e| format!("branch: instance {id}: {e}"))?;
+        }
+        self.restore(snapshot);
+        self.history.truncate_from(frame + 1);
+        self.frame = frame + 1;
+        self.deliver();
+        Ok(())
     }
 
     /// Advance the simulation by `n` frames.

--- a/runtime/functor-netsim/tests/scrub.rs
+++ b/runtime/functor-netsim/tests/scrub.rs
@@ -1,0 +1,238 @@
+//! Whole-environment time travel over the netsim: scrubbing the SIM, not one
+//! client.
+//!
+//! `examples/mp` (an authoritative server + two clients) is stepped, then
+//! `NetSim::seek` rewinds the entire environment to an earlier frame — every
+//! instance's model AND the virtual network — and `resume` returns to live.
+//! The properties under test are the ones a multi-pane scrubber in the IDEs
+//! depends on:
+//!
+//! - a seek restores *every* instance at once, each to its own view of that
+//!   frame (a client's lagging world, not the server's authoritative one), and
+//!   is non-destructive until the next step;
+//! - the network is restored too, so packets that were mid-flight at that frame
+//!   are mid-flight again — asserted through the strongest available property:
+//!   stepping on from an untouched scrub REPLAYS the original timeline exactly,
+//!   which is only possible if the in-flight packets came back with the models;
+//! - resuming from a scrubbed frame commits the branch, matching the shipped
+//!   single-game scrubber (`run.rs`) rather than jumping back to live.
+//!
+//! Note the load-bearing asymmetry (`timetravel.rs` module docs): scrubbing
+//! BACKWARD is a plain restore and needs no determinism. These tests therefore
+//! assert exact equality, not approximate convergence.
+//!
+//! `#[ignore]`d by default like the sibling suites (they pull the full desktop
+//! runtime as a dev-dependency); run with:
+//!
+//! ```sh
+//! cargo test -p functor-netsim --test scrub -- --ignored --nocapture
+//! ```
+
+use functor_netsim::{InstanceId, Link, NetSim};
+use functor_runtime_desktop::functor_lang_game::FunctorLangGame;
+
+// Same process-global conn-queue caveat as tests/mp.rs: serialize the tests in
+// this binary and clear residue at each start.
+static NET_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn add_mp(sim: &mut NetSim, entry: &str) -> InstanceId {
+    let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../examples/mp")
+        .join(entry);
+    assert!(path.exists(), "missing {}", path.display());
+    sim.add_producer(Box::new(FunctorLangGame::create(path.to_str().unwrap())))
+}
+
+/// Every instance's view of the environment, in one comparable value.
+fn views(sim: &NetSim, ids: &[InstanceId]) -> Vec<String> {
+    ids.iter().map(|id| sim.state(*id)).collect()
+}
+
+#[test]
+#[ignore = "pulls the desktop runtime dev-dependency; run with --ignored"]
+fn a_scrub_rewinds_every_instance_and_stepping_on_replays_the_timeline_exactly() {
+    let _guard = NET_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _ = functor_runtime_common::net::drain_conn_commands();
+
+    let mut sim = NetSim::new(1);
+    let ids = [
+        add_mp(&mut sim, "server.fun"),
+        add_mp(&mut sim, "client.fun"),
+        add_mp(&mut sim, "client.fun"),
+    ];
+
+    // Impair the links so packets are GENUINELY mid-flight at the snapshot cut.
+    // Under `LinkProfile::PERFECT` the one-tick latency is consumed by the same
+    // frame's `vnet.advance(1)`, so nothing is ever in flight when the snapshot
+    // is taken and the restore-the-network claim would go untested. [xreview]
+    let laggy = Link {
+        latency_ticks: 4,
+        jitter_ticks: 2,
+        ..Link::PERFECT
+    };
+    sim.set_link(ids[0], ids[1], laggy);
+    sim.set_link(ids[0], ids[2], laggy);
+
+    // Nothing is reachable before the first step.
+    assert_eq!(sim.frame_range(), None);
+    assert!(sim.seek(0).is_err(), "seek must refuse an empty history");
+
+    // Connect and let snapshots flow; the anchor is the frame we will scrub to.
+    sim.step_n(30);
+    let anchor = sim.frame() - 1;
+    let anchor_views = views(&sim, &ids);
+    assert!(
+        sim.in_flight() > 0,
+        "the anchor frame must have packets in flight, or restoring the \
+         network proves nothing"
+    );
+
+    // Simulate well past it, recording each frame's views as the timeline to
+    // reproduce.
+    let mut timeline = Vec::new();
+    for _ in 0..40 {
+        sim.step();
+        timeline.push(views(&sim, &ids));
+    }
+    let live_frame = sim.frame();
+    // Non-vacuity PER INSTANCE: a whole-vector compare would still pass if one
+    // pane happened to look identical at both frames, while the test claims
+    // every instance rewinds. [xreview]
+    for (i, live) in timeline.last().unwrap().iter().enumerate() {
+        assert_ne!(
+            live, &anchor_views[i],
+            "instance {i} must differ between the anchor and the live frame, \
+             or its rewind proves nothing"
+        );
+    }
+    assert_eq!(sim.frame_range(), Some((0, live_frame - 1)));
+
+    // The whole environment rewinds together — each instance to its OWN view of
+    // the anchor frame (the clients' lagging worlds, not the server's).
+    sim.seek(anchor).expect("seek to the anchor frame");
+    assert_eq!(sim.scrub_pos(), Some(anchor));
+    assert_eq!(
+        views(&sim, &ids),
+        anchor_views,
+        "every instance must restore to its own view of the anchor frame"
+    );
+    // Non-destructive while parked: the recorded future is still there.
+    assert_eq!(sim.frame_range(), Some((0, live_frame - 1)));
+
+    // Stepping on commits the branch — and because the network was restored
+    // WITH the models (including the packets in flight at that instant), the
+    // replayed timeline is byte-identical to the original.
+    let mut replayed = Vec::new();
+    for _ in 0..40 {
+        sim.step();
+        replayed.push(views(&sim, &ids));
+    }
+    assert_eq!(sim.scrub_pos(), None);
+    assert_eq!(
+        replayed, timeline,
+        "replay from a scrub must reproduce the original timeline exactly"
+    );
+    assert_eq!(sim.frame(), live_frame, "the branch must not shift frames");
+}
+
+#[test]
+#[ignore = "pulls the desktop runtime dev-dependency; run with --ignored"]
+fn seek_clamps_into_range_and_the_sim_steps_on_after_a_scrub() {
+    let _guard = NET_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _ = functor_runtime_common::net::drain_conn_commands();
+
+    let mut sim = NetSim::new(7);
+    let server = add_mp(&mut sim, "server.fun");
+    let client = add_mp(&mut sim, "client.fun");
+
+    sim.step_n(30);
+    let (lo, hi) = sim.frame_range().expect("frames recorded");
+
+    // Out-of-range seeks clamp rather than erroring — a scrubber drags past the
+    // ends constantly.
+    sim.seek(hi + 500).expect("clamps to the live end");
+    assert_eq!(sim.scrub_pos(), Some(hi));
+    sim.seek(0).expect("clamps to the recorded floor");
+    assert_eq!(sim.scrub_pos(), Some(lo));
+
+    // Stepping on from a scrubbed position keeps the sim coherent, and the
+    // branch it commits starts exactly at the scrubbed frame.
+    let branch_views = views(&sim, &[server, client]);
+    sim.step();
+    assert_eq!(sim.scrub_pos(), None, "stepping commits the branch");
+    // The branch rewound to the end of frame `lo`, and this step ran frame
+    // `lo + 1` — so the recorded future beyond the scrub is gone and the
+    // timeline continues from the scrubbed frame rather than from live.
+    assert_eq!(
+        sim.frame(),
+        lo + 2,
+        "the committed branch continues from the scrubbed frame, not from live"
+    );
+    assert_eq!(
+        sim.frame_range(),
+        Some((lo, lo + 1)),
+        "committing the branch drops the recorded future"
+    );
+    sim.step_n(20);
+    let after = views(&sim, &[server, client]);
+    println!("SERVER: {}", after[0]);
+    println!("CLIENT: {}", after[1]);
+    assert_ne!(
+        after, branch_views,
+        "the branch must actually simulate forward from the scrubbed frame"
+    );
+}
+
+#[test]
+#[ignore = "pulls the desktop runtime dev-dependency; run with --ignored"]
+fn a_seek_past_the_pruned_horizon_is_refused_loudly() {
+    let _guard = NET_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _ = functor_runtime_common::net::drain_conn_commands();
+
+    // Step past the bounded ring so BOTH sides have pruned. This is the regime
+    // where the sim's horizon and the producers' have to agree — and where a
+    // producer's own `seek_scene_to` would silently CLAMP to a different frame
+    // rather than refuse, which is why the sim checks the ranges itself. [xreview]
+    let mut sim = NetSim::new(3);
+    let ids = [add_mp(&mut sim, "server.fun"), add_mp(&mut sim, "client.fun")];
+    sim.step_n(functor_runtime_common::timetravel::DEFAULT_HISTORY_FRAMES + 60);
+
+    let (lo, hi) = sim.frame_range().expect("frames recorded");
+    assert!(lo > 0, "the ring must have pruned, or this proves nothing");
+
+    // Inside the horizon: a real restore, not a clamp.
+    let views_at_lo = {
+        sim.seek(lo).expect("seek to the oldest retained frame");
+        views(&sim, &ids)
+    };
+    sim.seek(hi).expect("seek to the newest frame");
+    sim.seek(lo).expect("re-seek to the oldest frame");
+    assert_eq!(
+        views(&sim, &ids),
+        views_at_lo,
+        "seeking is idempotent: the same frame restores the same environment"
+    );
+
+    // Below it: clamped to the floor, which is a real restore of a real frame —
+    // never a silent restore of some other frame.
+    sim.seek(lo - 1).expect("a pruned frame clamps to the floor");
+    assert_eq!(sim.scrub_pos(), Some(lo));
+    assert_eq!(views(&sim, &ids), views_at_lo);
+}
+
+#[test]
+#[should_panic(expected = "add_producer after the sim has stepped")]
+#[ignore = "pulls the desktop runtime dev-dependency; run with --ignored"]
+fn joining_after_the_sim_has_stepped_is_refused() {
+    let _guard = NET_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _ = functor_runtime_common::net::drain_conn_commands();
+
+    // A late joiner would record from ITS frame 0 while the sim is at frame n,
+    // and every snapshot taken before it joined describes a network with no
+    // node for it — so the frame alignment a seek depends on would be broken
+    // silently. [xreview]
+    let mut sim = NetSim::new(5);
+    add_mp(&mut sim, "server.fun");
+    sim.step_n(5);
+    add_mp(&mut sim, "client.fun");
+}

--- a/runtime/functor-runtime-common/src/net/virtual_net.rs
+++ b/runtime/functor-runtime-common/src/net/virtual_net.rs
@@ -19,6 +19,7 @@ use super::{ConnectionId, LinkProfile, NetEvent, Rng};
 pub type NodeId = u64;
 
 /// A packet in flight: scheduled to land on `dest` at `deliver_tick`.
+#[derive(Clone)]
 struct Packet {
     deliver_tick: u64,
     seq: u64,
@@ -26,6 +27,7 @@ struct Packet {
     event: NetEvent,
 }
 
+#[derive(Clone)]
 struct Connection {
     a: NodeId,
     b: NodeId,
@@ -57,6 +59,13 @@ impl Connection {
 }
 
 /// Deterministic in-memory network. See module docs.
+///
+/// `Clone` is the network half of a whole-environment time-travel snapshot: the
+/// state here (logical clock, RNG position, in-flight packets, per-node undrained
+/// events, connections, link profiles) is exactly what a scrub must restore
+/// alongside each instance's model, so a rewound frame shows the packets that
+/// were genuinely mid-flight at that frame rather than today's.
+#[derive(Clone)]
 pub struct VirtualNet {
     now: u64,
     rng: Rng,


### PR DESCRIPTION
Rewinds every game instance's model **and** the virtual network together, so a
multiplayer session (server + N clients) can be scrubbed as one environment
rather than one pane at a time.

This is the first slice of a larger arc: **defining and simulating multiplayer
games inside the VSCode and browser IDEs** — multiple live clients, server
output, and a time scrubber that works across the whole environment instead of
per-client. This PR is the load-bearing seam that makes such a scrubber
possible, and it lands entirely headless: no UI, no wasm, no GL, no sockets.

## Why it's small

Two facts in the existing code did most of the work, both verified rather than
assumed:

- **Every producer already records its own model per frame** — `SceneRecorder::record_timed`
  runs inside the shared frame body that `GameProducer::tick` executes — and the
  trait already exposes `seek_scene_to` (non-destructive park) and
  `rewind_scene_to` (destructive branch). So the sim never needed a new
  model-snapshot API: it only has to snapshot what lives OUTSIDE the producers,
  the network and the routing tables built from it. `VirtualNet` gains `Clone`
  for that (all leaf types were already `Clone`).
- **Only `deliver()` mutates a model outside `tick`** — `deliver_net_event` folds
  an inbound message through `update` on the spot.

## The snapshot cut

That second fact fixes where the snapshot must be taken, and it is load-bearing:
**after the frame's sends are routed and the network has advanced, but BEFORE
delivery** — the one instant where every model still equals its recorded frame.
Restored models and restored network then name the same moment.

From there:

- `seek(f)` replays that frame's pending deliveries, so a parked frame shows
  exactly what a viewer saw live at frame `f`, and seeking is idempotent.
- Stepping on **commits the branch**, matching the shipped single-game scrubber
  (`run.rs` — "resuming from there is what commits the branch"). It is rebuilt
  from the recorded frame, so an untouched scrub replays the original timeline
  byte-for-byte.

Because a scrub-back is a plain restore and never a re-step, this needs no
determinism at all — the property `History` already relies on for one game holds
for N games plus the network.

## Verification

Headless, `cargo test -p functor-netsim --test scrub -- --ignored`:

- **rewind 40 frames → step forward 40 → byte-identical timeline** across server
  and both clients, over impaired links (latency 4 ± 2 ticks) with packets
  genuinely in flight at the snapshot cut;
- seek clamps into range, is idempotent, and a committed branch continues from
  the scrubbed frame while dropping the recorded future;
- the pruned-horizon regime (past the 900-frame ring, where both sides prune);
- late join is refused loudly.

Existing suites re-run after the review fixes: 9 netsim tests, 433 + 8
`functor_runtime_common` tests, strict build clean. Not a per-frame hot path
(the netsim is a test/tooling harness), so no `frame_bench` run.

## Review dispositions (`/xreview` — Claude subagent + Codex, both engines)

Three findings both engines raised, all **fixed**:

1. **`seek` trusted a refusal that doesn't exist.** `SceneRecorder::seek_scene_to`
   *clamps* and returns `Ok`; its only hard failures are an empty history or a
   pruned *physics* frame, which a game without physics never reaches. A pruned
   pane would have silently restored a **different** frame. Now every instance's
   recorded range is preflighted before anything mutates — all-or-nothing, loud
   error.
2. **`add_producer` after stepping** broke frame alignment (late instance records
   from its own frame 0), regressed `next_node` so a later add reused a node id,
   and was silently skipped by `restore`'s `zip`. Now a loud error; genuine late
   join needs per-instance frame offsets in the snapshot.
3. **A failed branch commit** left half-rewound producers mixed with live ones and
   ticked on. Now the sim stays parked.

Also fixed: the exact-replay test used `LinkProfile::PERFECT`, whose one-tick
latency is consumed by the same frame's `advance(1)` — so nothing was ever in
flight at the cut and the restore-the-network claim went untested (caught by
Codex); per-instance non-vacuity assertions; link impairment now treated as
configuration that survives a restore, so "rewind, worsen the link, replay"
works; stale doc references to a `resume` method that the branch-commit
semantics replaced.

**Deferred, deliberately — pre-existing, not introduced here:** `rewind_scene_to`
restores model + physics but leaves the producer's `prev_tts` and
`live_conn_keys` at the live tail, so after a branch `Sub.every` timers stay
suppressed until the clock catches up, and branching across a connection
lifecycle emits a spurious `CloseKey`/reconnect. This is the same shared
machinery the single-game scrubber commits a branch through, so it has the issue
today too — and the forward-step path already guards exactly this hazard
(`functor_lang_producer.rs`: "a scrubbed preview must not seed subscription
windows from the old live tail's `prev_tts`"), which is good evidence the fix
belongs in `SceneRecorder` rather than here. Filed for its own PR; it fixes both
scrubbers at once. This PR's tests don't hit it (`examples/mp` has no
`Sub.every`, and the branch point is after connections are established).

## What's next

Forward extrapolate across the environment (harder — predicted futures must
include in-flight packets arriving), then the netsim on wasm32, multi-pane
rendering + server output in the web runtime, and the whole-environment scrubber
in the IDEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)