### PR TITLE
feat(web): link browser editors to external runtimes

### DIFF
--- a/.github/workflows/wasm-smoke.yml
+++ b/.github/workflows/wasm-smoke.yml
@@ -98,3 +98,6 @@ jobs:
 
       - name: Run IDE page browser tests
         run: npm run test:ide-page
+
+      - name: Run browser runtime-target tests
+        run: npm run test:runtime-target

--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -36,6 +36,16 @@ web IDE. Browser origins are accepted only when their host is exactly `localhost
 unauthenticated developer control port. Close the adb forward and desktop runner
 when they are not in use.
 
+The browser IDE and sandbox expose this as their shared **device** panel: enter
+the runtime URL, choose **push + go live**, and subsequent source edits preserve
+the remote model. The sandbox uploads the selected example's declared local
+assets before source and finalizes asset deletion only after source is accepted
+(the IDE does not yet author binary assets). The panel polls `/state` and
+displays `/capture`. When
+linking Quest on its forwarded `8123`, serve the site on a different loopback
+port (for example `npm run site:serve -- --port 8124`). Chromium may show its
+one-time local-network-access prompt on the first connection.
+
 ## Headless mode
 
 Add `--headless` to run with **no GL window** — the game loop and debug server run

--- a/e2e/runtime-target.mjs
+++ b/e2e/runtime-target.mjs
@@ -318,6 +318,35 @@ try {
       () => document.querySelector("[data-runtime-status]")?.dataset.state === "live",
       { timeout: 10_000 }
     );
+
+    // A capture requested behind a push belongs to that endpoint. Changing the
+    // target while the push is in flight must discard it rather than capturing
+    // from the replacement runtime when the stale request completes.
+    delayNextReloadMs = 2_000;
+    cursor = requests.length;
+    await page.evaluate(() =>
+      window.__sandbox.setSource(`${window.__sandbox.getSource()}\n// edit before endpoint change`)
+    );
+    await nextRequest("/reload-project", cursor);
+    await page.click("[data-runtime-capture]");
+    await page.locator("[data-runtime-endpoint]").evaluate((input, value) => {
+      input.value = value;
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+    }, `${RUNTIME}/`);
+    await sleep(2_150);
+    check(
+      "sandbox clears a queued capture when the endpoint changes",
+      !requests.slice(cursor).some((request) => request.path === "/capture"),
+      requests.slice(cursor).map((request) => request.path).join(",")
+    );
+    cursor = requests.length;
+    await page.click("[data-runtime-push]");
+    await nextRequest("/load-project", cursor);
+    await page.waitForFunction(
+      () => document.querySelector("[data-runtime-status]")?.dataset.state === "live",
+      { timeout: 10_000 }
+    );
+
     await sleep(200);
     const statePollsBefore = requests.filter((request) => request.path === "/state").length;
     await sleep(2_250);
@@ -352,6 +381,74 @@ try {
         marioAssetUploads.every((request) => requests.indexOf(request) < requests.indexOf(marioLoad)) &&
         requests.indexOf(marioLoad) < requests.indexOf(marioManifest),
       marioAssetUploads.map((request) => uploadedAssetPath(request.rawBody)).join(",")
+    );
+
+    await page.waitForFunction(
+      () => document.querySelector("[data-runtime-status]")?.dataset.state === "live",
+      undefined,
+      { timeout: 10_000 }
+    );
+    rejectNextProjectStatus = 413;
+    cursor = requests.length;
+    await page.click("#reset");
+    const rejectedMarioLoad = await nextRequest("/load-project", cursor);
+    const rollbackUploads = await nextRequests("/reload-asset", cursor, 4);
+    const rollbackManifest = await nextRequest("/sync-assets", cursor);
+    await page.waitForFunction(
+      () =>
+        document.querySelector("[data-runtime-summary-state]")?.textContent === "sync error" &&
+        document
+          .querySelector("[data-runtime-status]")
+          ?.textContent.includes("Last-good assets were restored."),
+      undefined,
+      { timeout: 10_000 }
+    );
+    check(
+      "sandbox restores overwritten assets when replacement source is rejected",
+      rollbackUploads.map((request) => uploadedAssetPath(request.rawBody)).join(",") ===
+        "ground.png,hero-atlas.png,ground.png,hero-atlas.png" &&
+        requests.indexOf(rejectedMarioLoad) < requests.indexOf(rollbackUploads[2]) &&
+        JSON.parse(rollbackManifest.body).join(",") === "ground.png,hero-atlas.png",
+      rollbackUploads.map((request) => uploadedAssetPath(request.rawBody)).join(",")
+    );
+
+    cursor = requests.length;
+    await page.click("#reset");
+    await nextRequest("/load-project", cursor);
+    await page.waitForFunction(
+      () => document.querySelector("[data-runtime-status]")?.dataset.state === "live",
+      undefined,
+      { timeout: 10_000 }
+    );
+
+    // A 503 can mean the runtime's reply wait expired even though the queued
+    // source may still apply later. Do not race that uncertain outcome by
+    // restoring old asset bytes.
+    rejectNextProjectStatus = 503;
+    cursor = requests.length;
+    await page.click("#reset");
+    await nextRequest("/load-project", cursor);
+    const ambiguousUploads = await nextRequests("/reload-asset", cursor, 2);
+    await page.waitForFunction(
+      () => document.querySelector("[data-runtime-summary-state]")?.textContent === "sync error",
+      undefined,
+      { timeout: 10_000 }
+    );
+    await sleep(100);
+    check(
+      "sandbox does not roll assets back after an ambiguous runtime timeout",
+      ambiguousUploads.length === 2 &&
+        requests.slice(cursor).filter((request) => request.path === "/reload-asset").length === 2 &&
+        !requests.slice(cursor).some((request) => request.path === "/sync-assets")
+    );
+
+    cursor = requests.length;
+    await page.click("#reset");
+    await nextRequest("/load-project", cursor);
+    await page.waitForFunction(
+      () => document.querySelector("[data-runtime-status]")?.dataset.state === "live",
+      undefined,
+      { timeout: 10_000 }
     );
 
     rejectNextProjectStatus = 413;

--- a/e2e/runtime-target.mjs
+++ b/e2e/runtime-target.mjs
@@ -1,0 +1,496 @@
+// Browser-runtime link e2e. A hermetic fake debug runtime verifies that BOTH
+// editor surfaces:
+//   - load the whole current project on the first explicit push;
+//   - hot-reload later edits with the model preserved;
+//   - fresh-load resets/restarts;
+//   - poll state and render a binary capture.
+//
+// Run manually (needs the two wasm bundles used by site:build):
+//   npm run test:runtime-target
+
+import { spawn, spawnSync } from "node:child_process";
+import { createServer } from "node:http";
+import { fileURLToPath } from "node:url";
+import { chromium } from "@playwright/test";
+
+const SITE_PORT = 8136;
+const RUNTIME_PORT = 8137;
+const BASE = `http://127.0.0.1:${SITE_PORT}`;
+const RUNTIME = `http://127.0.0.1:${RUNTIME_PORT}`;
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Valid 1×1 PNG. The transport and browser image decode are what this suite
+// exercises; real stereo pixels are covered by the Quest device loop.
+const PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+  "base64"
+);
+
+let failures = 0;
+const check = (name, ok, detail = "") => {
+  console.log(`${ok ? "PASS" : "FAIL"}: ${name}${ok || !detail ? "" : ` — ${detail}`}`);
+  if (!ok) failures += 1;
+};
+
+const requests = [];
+let frame = 40;
+let delayNextLoadMs = 0;
+let delayNextReloadMs = 0;
+let delayNextCaptureMs = 0;
+let delayNextAssetMs = 0;
+let dropNextReload = false;
+let rejectNextProjectStatus = 0;
+
+const readBody = async (request) => {
+  const chunks = [];
+  for await (const chunk of request) chunks.push(chunk);
+  return Buffer.concat(chunks);
+};
+
+const uploadedAssetPath = (body) => {
+  const pathLength = body.readUInt32BE(0);
+  return body.subarray(4, 4 + pathLength).toString("utf8");
+};
+
+const runtimeServer = createServer(async (request, response) => {
+  const origin = request.headers.origin;
+  if (origin) {
+    response.setHeader("Access-Control-Allow-Origin", origin);
+    response.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+    response.setHeader("Access-Control-Allow-Headers", "Content-Type");
+    response.setHeader("Access-Control-Allow-Private-Network", "true");
+  }
+  if (request.method === "OPTIONS") {
+    response.writeHead(204).end();
+    return;
+  }
+
+  const rawBody = await readBody(request);
+  const body = rawBody.toString("utf8");
+  requests.push({ method: request.method, path: request.url, body, rawBody });
+
+  if (request.method === "GET" && request.url === "/") {
+    response
+      .writeHead(200, { "Content-Type": "application/json" })
+      .end(
+        JSON.stringify({
+          service: "functor debug runtime",
+          protocol_version: 2,
+          endpoints: {},
+        })
+      );
+  } else if (request.method === "GET" && request.url === "/state") {
+    frame += 1;
+    response
+      .writeHead(200, { "Content-Type": "application/json" })
+      .end(
+        JSON.stringify({
+          frame,
+          tts: frame / 90,
+          viewport: { width: 2048, height: 1024 },
+          views: [
+            { name: "left", viewport: { width: 1024, height: 1024 } },
+            { name: "right", viewport: { width: 1024, height: 1024 } },
+          ],
+          model: `{ ticks: ${frame} }`,
+          input: { held_keys: [], mouse: { x: 0, y: 0 } },
+        })
+      );
+  } else if (
+    request.method === "POST" &&
+    (request.url === "/load-project" || request.url === "/reload-project")
+  ) {
+    if (request.url === "/reload-project" && dropNextReload) {
+      dropNextReload = false;
+      request.socket.destroy();
+      return;
+    }
+    if (rejectNextProjectStatus !== 0) {
+      const status = rejectNextProjectStatus;
+      rejectNextProjectStatus = 0;
+      response
+        .writeHead(status, { "Content-Type": "text/plain; charset=utf-8" })
+        .end("project rejected");
+      return;
+    }
+    const delayMs =
+      request.url === "/load-project" ? delayNextLoadMs : delayNextReloadMs;
+    delayNextLoadMs = 0;
+    delayNextReloadMs = 0;
+    if (delayMs > 0) await sleep(delayMs);
+    response
+      .writeHead(200, { "Content-Type": "text/plain; charset=utf-8" })
+      .end(request.url === "/load-project" ? "loaded fresh model" : "reloaded; model preserved");
+  } else if (request.method === "POST" && request.url === "/capture") {
+    const delayMs = delayNextCaptureMs;
+    delayNextCaptureMs = 0;
+    if (delayMs > 0) await sleep(delayMs);
+    response.writeHead(200, { "Content-Type": "image/png" }).end(PNG);
+  } else if (request.method === "POST" && request.url === "/reload-asset") {
+    const delayMs = delayNextAssetMs;
+    delayNextAssetMs = 0;
+    if (delayMs > 0) await sleep(delayMs);
+    response.writeHead(200, { "Content-Type": "text/plain; charset=utf-8" }).end("asset updated");
+  } else if (request.method === "POST" && request.url === "/sync-assets") {
+    response.writeHead(200, { "Content-Type": "text/plain; charset=utf-8" }).end("assets synced");
+  } else {
+    response.writeHead(404).end("not found");
+  }
+});
+
+const listen = (server, port) =>
+  new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", resolve);
+  });
+
+const waitForSite = async () => {
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    try {
+      const response = await fetch(BASE);
+      if (response.ok) return;
+    } catch {}
+    await sleep(250);
+  }
+  throw new Error(`site did not start at ${BASE}`);
+};
+
+const nextRequest = async (path, start) => {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    const match = requests.slice(start).find((request) => request.path === path);
+    if (match) return match;
+    await sleep(50);
+  }
+  throw new Error(`timed out waiting for ${path}; saw ${JSON.stringify(requests.slice(start))}`);
+};
+
+const nextRequests = async (path, start, count) => {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    const matches = requests.slice(start).filter((request) => request.path === path);
+    if (matches.length >= count) return matches;
+    await sleep(50);
+  }
+  throw new Error(
+    `timed out waiting for ${count} ${path} requests; saw ${JSON.stringify(requests.slice(start))}`
+  );
+};
+
+const openAndPush = async (page) => {
+  await page.click("[data-runtime-summary]");
+  await page.fill("[data-runtime-endpoint]", RUNTIME);
+  await page.click("[data-runtime-push]");
+  try {
+    await page.waitForFunction(
+      () => document.querySelector("[data-runtime-status]")?.dataset.state === "live",
+      undefined,
+      { timeout: 10_000 }
+    );
+  } catch {
+    const state = await page.evaluate(async () => ({
+      target: window.__sandbox?.runtimeTarget?.() ?? window.__ide?.runtimeTarget?.(),
+      text: document.querySelector("[data-runtime-status]")?.textContent,
+      disabled: document.querySelector("[data-runtime-push]")?.disabled,
+      secure: window.isSecureContext,
+      permission: await navigator.permissions
+        .query({ name: "local-network-access" })
+        .then((result) => result.state)
+        .catch((error) => error.message),
+      plainFetch: await fetch(document.querySelector("[data-runtime-endpoint]").value)
+        .then((result) => `HTTP ${result.status}`)
+        .catch((error) => `${error.name}: ${error.message}`),
+    }));
+    throw new Error(
+      `runtime target did not become live: ${JSON.stringify(state)}; ` +
+        `requests=${JSON.stringify(requests)}`
+    );
+  }
+};
+
+const build = spawnSync("node", ["site/build.mjs"], { cwd: ROOT, stdio: "inherit" });
+if (build.status !== 0) process.exit(build.status ?? 1);
+
+await listen(runtimeServer, RUNTIME_PORT);
+const runtimeProbe = await fetch(RUNTIME);
+if (!runtimeProbe.ok) throw new Error(`fake runtime probe failed: HTTP ${runtimeProbe.status}`);
+const siteServer = spawn("node", ["site/serve.mjs", "--port", String(SITE_PORT)], {
+  cwd: ROOT,
+  stdio: "ignore",
+});
+const browser = await chromium.launch({
+  args: [
+    "--use-gl=angle",
+    "--use-angle=swiftshader",
+    "--enable-unsafe-swiftshader",
+    "--ignore-gpu-blocklist",
+  ],
+});
+
+try {
+  await waitForSite();
+  const context = await browser.newContext({ viewport: { width: 1180, height: 720 } });
+  await context.grantPermissions(["local-network-access"], { origin: BASE });
+
+  // Sandbox: a single-file project, live reload, fresh example reset, state,
+  // and capture.
+  {
+    const page = await context.newPage();
+    await page.goto(`${BASE}/sandbox.html`);
+    await page.waitForFunction(() => window.__sandbox?.status().state === "live", {
+      timeout: 20_000,
+    });
+
+    let cursor = requests.length;
+    delayNextLoadMs = 500;
+    const initialPush = openAndPush(page);
+    const initial = await nextRequest("/load-project", cursor);
+    const initialFiles = JSON.parse(initial.body);
+    check(
+      "sandbox first push fresh-loads game.fun",
+      initialFiles.length === 1 && initialFiles[0][0] === "game.fun"
+    );
+    await page.evaluate(() =>
+      window.__sandbox.setSource(`${window.__sandbox.getSource()}\n// edit during first load`)
+    );
+    await initialPush;
+    const initialFollowup = await nextRequest("/reload-project", cursor);
+    check(
+      "sandbox queues edits made during its initial load",
+      JSON.parse(initialFollowup.body)[0][1].includes("// edit during first load")
+    );
+
+    cursor = requests.length;
+    await page.evaluate(() =>
+      window.__sandbox.setSource(`${window.__sandbox.getSource()}\n// device live edit`)
+    );
+    const reload = await nextRequest("/reload-project", cursor);
+    check(
+      "sandbox edits hot-reload with model preservation",
+      JSON.parse(reload.body)[0][1].includes("// device live edit")
+    );
+
+    dropNextReload = true;
+    cursor = requests.length;
+    await page.evaluate(() =>
+      window.__sandbox.setSource(`${window.__sandbox.getSource()}\n// retry after reconnect`)
+    );
+    await nextRequest("/reload-project", cursor);
+    const retriedReload = (await nextRequests("/reload-project", cursor, 2))[1];
+    check(
+      "sandbox retries an unsent edit after transport recovery",
+      JSON.parse(retriedReload.body)[0][1].includes("// retry after reconnect")
+    );
+
+    await page.waitForFunction(
+      () => document.querySelector("[data-runtime-views]")?.textContent === "left + right",
+      { timeout: 10_000 }
+    );
+    check("sandbox renders stereo state telemetry", true);
+
+    cursor = requests.length;
+    await page.click("[data-runtime-capture]");
+    await nextRequest("/capture", cursor);
+    await page.waitForFunction(
+      () => {
+        const image = document.querySelector("[data-runtime-image]");
+        return image?.complete && image.naturalWidth === 1;
+      },
+      { timeout: 10_000 }
+    );
+    check("sandbox displays the runtime PNG capture", true);
+
+    // Reset during an in-flight hot reload must not lose its fresh-model
+    // intent when the older response completes.
+    delayNextReloadMs = 500;
+    cursor = requests.length;
+    await page.evaluate(() =>
+      window.__sandbox.setSource(`${window.__sandbox.getSource()}\n// edit before reset`)
+    );
+    await nextRequest("/reload-project", cursor);
+    cursor = requests.length;
+    await page.click("#reset");
+    await nextRequest("/load-project", cursor);
+    check("sandbox reset queues a fresh load behind an in-flight edit", true);
+
+    await page.waitForFunction(
+      () => document.querySelector("[data-runtime-status]")?.dataset.state === "live",
+      { timeout: 10_000 }
+    );
+    await sleep(200);
+    const statePollsBefore = requests.filter((request) => request.path === "/state").length;
+    await sleep(2_250);
+    const statePollsAfter = requests.filter((request) => request.path === "/state").length;
+    check(
+      "sandbox keeps one state polling chain",
+      statePollsAfter - statePollsBefore <= 3,
+      `${statePollsAfter - statePollsBefore} polls in 2.25s`
+    );
+
+    cursor = requests.length;
+    await page.selectOption("#example-picker", "mario");
+    const marioLoad = await nextRequest("/load-project", cursor);
+    const marioFiles = JSON.parse(marioLoad.body);
+    const marioAssetUploads = requests
+      .slice(cursor)
+      .filter((request) => request.path === "/reload-asset");
+    const marioManifest = requests
+      .slice(cursor)
+      .find((request) => request.path === "/sync-assets");
+    check(
+      "sandbox example push includes sibling modules",
+      marioFiles.map(([path]) => path).join(",") === "game.fun,assets.fun" &&
+        marioFiles[1][1].includes("Asset.texture"),
+      marioFiles.map(([path]) => path).join(",")
+    );
+    check(
+      "sandbox uploads assets before source and finalizes its manifest after",
+      marioAssetUploads.map((request) => uploadedAssetPath(request.rawBody)).join(",") ===
+        "ground.png,hero-atlas.png" &&
+        JSON.parse(marioManifest?.body ?? "[]").join(",") === "ground.png,hero-atlas.png" &&
+        marioAssetUploads.every((request) => requests.indexOf(request) < requests.indexOf(marioLoad)) &&
+        requests.indexOf(marioLoad) < requests.indexOf(marioManifest),
+      marioAssetUploads.map((request) => uploadedAssetPath(request.rawBody)).join(",")
+    );
+
+    rejectNextProjectStatus = 413;
+    cursor = requests.length;
+    await page.selectOption("#example-picker", "hero");
+    await nextRequest("/load-project", cursor);
+    await page.waitForFunction(
+      () => document.querySelector("[data-runtime-summary-state]")?.textContent === "sync error",
+      undefined,
+      { timeout: 10_000 }
+    );
+    check(
+      "sandbox preserves the last-good asset manifest when new source is rejected",
+      !requests.slice(cursor).some((request) => request.path === "/sync-assets")
+    );
+    check("sandbox labels every HTTP project rejection as a sync error", true);
+
+    cursor = requests.length;
+    await page.selectOption("#example-picker", "mario");
+    await nextRequest("/load-project", cursor);
+    await page.waitForFunction(
+      () => document.querySelector("[data-runtime-status]")?.dataset.state === "live",
+      undefined,
+      { timeout: 10_000 }
+    );
+
+    // A newer reset that lands during asset transfer must retain its own fresh
+    // model request after the older reset completes.
+    delayNextAssetMs = 500;
+    cursor = requests.length;
+    await page.click("#reset");
+    await nextRequest("/reload-asset", cursor);
+    await page.click("#reset");
+    const resetLoads = await nextRequests("/load-project", cursor, 2);
+    check(
+      "sandbox preserves a fresh reset queued during asset transfer",
+      resetLoads.length >= 2
+    );
+    await page.waitForFunction(
+      () => document.querySelector("[data-runtime-status]")?.dataset.state === "live",
+      undefined,
+      { timeout: 10_000 }
+    );
+
+    // Quest capture can take seconds. An edit made during it must wait and then
+    // send the latest source, rather than racing the single runtime server.
+    delayNextCaptureMs = 1_500;
+    cursor = requests.length;
+    await page.click("[data-runtime-capture]");
+    await nextRequest("/capture", cursor);
+    const captureRequestIndex = requests.findIndex(
+      (request, index) => index >= cursor && request.path === "/capture"
+    );
+    await page.evaluate(() =>
+      window.__sandbox.setSource(`${window.__sandbox.getSource()}\n// edit during capture`)
+    );
+    await sleep(1_200);
+    check(
+      "sandbox does not push concurrently with capture",
+      !requests
+        .slice(captureRequestIndex + 1)
+        .some((request) => request.path === "/reload-project")
+    );
+    check(
+      "sandbox suspends state polling during capture",
+      !requests
+        .slice(captureRequestIndex + 1)
+        .some((request) => request.path === "/state")
+    );
+    cursor = requests.length;
+    const postCaptureReload = await nextRequest("/reload-project", cursor);
+    check(
+      "sandbox flushes the latest edit after capture",
+      JSON.parse(postCaptureReload.body)[0][1].includes("// edit during capture")
+    );
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.click("[data-runtime-close]");
+    check(
+      "sandbox panel closes from its in-panel control at 390px",
+      !(await page.locator(".runtime-target").evaluate((details) => details.open))
+    );
+    await page.close();
+  }
+
+  // IDE: the complete in-memory sibling-module project, live sibling edit, and
+  // explicit restart.
+  {
+    const page = await context.newPage();
+    await page.addInitScript(() => localStorage.removeItem("functor-ide-project-v1"));
+    await page.goto(`${BASE}/ide.html`);
+    await page.waitForFunction(() => window.__ide?.status().state === "live", {
+      timeout: 20_000,
+    });
+
+    let cursor = requests.length;
+    await openAndPush(page);
+    const initial = await nextRequest("/load-project", cursor);
+    const files = JSON.parse(initial.body);
+    check(
+      "IDE first push includes entry and sibling modules",
+      files.map(([path]) => path).join(",") === "game.fun,palette.fun"
+    );
+
+    cursor = requests.length;
+    await page.evaluate(() => window.__ide.openFile("palette.fun"));
+    await page.evaluate(() =>
+      window.__ide.setActiveSource("let glow = 0.42\nlet sky = 0.24\n")
+    );
+    const reload = await nextRequest("/reload-project", cursor);
+    const changedFiles = JSON.parse(reload.body);
+    check(
+      "IDE sibling edits hot-reload the complete project",
+      changedFiles.find(([path]) => path === "palette.fun")?.[1].includes("0.42")
+    );
+
+    cursor = requests.length;
+    await page.click("#restart");
+    await nextRequest("/load-project", cursor);
+    check("IDE restart fresh-loads the linked runtime", true);
+
+    await page.waitForFunction(
+      () => document.querySelector("[data-runtime-status]")?.dataset.state === "live",
+      { timeout: 10_000 }
+    );
+    const target = await page.evaluate(() => window.__ide.runtimeTarget());
+    check(
+      "IDE exposes a live linked-target status",
+      target.connected && target.live && target.status === "live",
+      JSON.stringify(target)
+    );
+    await page.close();
+  }
+
+  await context.close();
+} finally {
+  await browser.close();
+  siteServer.kill();
+  await new Promise((resolve) => runtimeServer.close(resolve));
+}
+
+console.log(failures === 0 ? "\nALL CHECKS PASSED" : `\n${failures} CHECK(S) FAILED`);
+process.exit(failures === 0 ? 0 : 1);

--- a/e2e/runtime-target.mjs
+++ b/e2e/runtime-target.mjs
@@ -364,9 +364,7 @@ try {
     const marioAssetUploads = requests
       .slice(cursor)
       .filter((request) => request.path === "/reload-asset");
-    const marioManifest = requests
-      .slice(cursor)
-      .find((request) => request.path === "/sync-assets");
+    const marioManifest = await nextRequest("/sync-assets", cursor);
     check(
       "sandbox example push includes sibling modules",
       marioFiles.map(([path]) => path).join(",") === "game.fun,assets.fun" &&

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:site": "node e2e/site-sandbox.mjs",
     "test:ide": "node e2e/ide-project.mjs",
     "test:ide-page": "node e2e/ide-page.mjs",
+    "test:runtime-target": "node e2e/runtime-target.mjs",
     "demo:time-travel": "node site/demos/time-travel.mjs",
     "demo:instant-feedback": "node site/demos/instant-feedback.mjs",
     "demo:batteries-included": "node site/demos/batteries-included.mjs",

--- a/site/README.md
+++ b/site/README.md
@@ -27,6 +27,16 @@ npm run test:ide-page    # headless e2e — the IDE page (e2e/ide-page.mjs)
   (`src/project-bridge.js`), localStorage persistence, and project download as a
   `.zip` (`src/zip.js`, a store-only writer). Asset (`.glb`/audio) management is a
   follow-up.
+- `src/runtime-target.js` — the shared external-runtime link in both editors.
+  The first explicit push uses `/load-project` (fresh `init`); later edits use
+  `/reload-project` (model preserved), with `/state` telemetry and `/capture`
+  shown in the panel. Sandbox examples also upload their declared local assets
+  before source, then finalize deletions after source is accepted; binary asset
+  management in the multi-file IDE remains a follow-up. To link a Quest, keep
+  its adb forward on `8123` and serve the site on another loopback port:
+  `npm run site:serve -- --port 8124`. The runtime intentionally rejects
+  non-loopback browser origins because its code-push API has no authentication.
+  Current Chromium may ask once for local-network access when the link starts.
 - `src/functor-lang.js` — the Functor Lang CodeMirror language + synthwave theme,
   shared by both editors.
 - `manual/index.html` — getting started, the game contract, language principles,

--- a/site/ide.html
+++ b/site/ide.html
@@ -31,6 +31,7 @@
         <button id="restart" type="button" title="Reload the preview with a fresh model">
           ↻ restart
         </button>
+        <div id="runtime-target"></div>
         <span id="status" class="status-pill" data-state="busy">◌ loading…</span>
       </div>
       <nav class="site-nav">

--- a/site/sandbox.html
+++ b/site/sandbox.html
@@ -30,6 +30,7 @@
         <button id="reset" type="button" title="Reload the example (resets the model)">
           ↺ reset
         </button>
+        <div id="runtime-target"></div>
         <span id="status" class="status-pill" data-state="busy">◌ loading…</span>
       </div>
       <nav class="site-nav">

--- a/site/src/ide.js
+++ b/site/src/ide.js
@@ -23,6 +23,7 @@ import {
 } from "./lang-intel.js";
 import { ProjectBridge } from "./project-bridge.js";
 import { createStatusBar } from "./status-bar.js";
+import { createRuntimeTarget } from "./runtime-target.js";
 import { zipFiles } from "./zip.js";
 
 const STORAGE_KEY = "functor-ide-project-v1";
@@ -151,6 +152,7 @@ const setStatus = (state, text, detail = "") => {
 // ---------------------------------------------------------------- editor
 
 let programmaticEdit = false;
+let runtimeTarget = null;
 
 const view = new EditorView({
   parent: els.editorHost,
@@ -181,6 +183,11 @@ const langReady = setupLangIntel().then((extensions) => {
 });
 
 const statusBar = createStatusBar({ host: document.getElementById("statusbar") });
+runtimeTarget = createRuntimeTarget({
+  host: document.getElementById("runtime-target"),
+  getProject: () => project.files,
+  onOutput: (level, message) => statusBar.appendOutput(level, message),
+});
 
 // Each lint pass (of the ACTIVE file — the per-document model) refreshes the
 // Problems panel; clicking a problem jumps the editor to it. Positions
@@ -261,6 +268,7 @@ const bridge = new ProjectBridge(els.player, {
 const schedulePush = () => {
   saveProject();
   bridge.setProject(project.files);
+  runtimeTarget.projectChanged();
 };
 
 // ---------------------------------------------------------------- sidebar
@@ -389,6 +397,7 @@ const restart = () => {
   setStatus("busy", "◌ loading…");
   els.player.src = "player.html?project=inline";
   bridge.setProject(project.files);
+  runtimeTarget.restart();
 };
 
 // ---------------------------------------------------------------- boot
@@ -426,6 +435,7 @@ window.__ide = {
     text: els.status.textContent,
     message: els.status.title,
   }),
+  runtimeTarget: () => runtimeTarget.state(),
   // Replace the active buffer, place the cursor, and open the completion popup
   // (explicit trigger) — the sandbox's seam, minus any push (programmaticEdit
   // suppresses the mirror-and-push listener).

--- a/site/src/runtime-target.js
+++ b/site/src/runtime-target.js
@@ -1,0 +1,665 @@
+// A browser-native client + compact UI for linking either editor surface to a
+// running Functor debug runtime. The in-page wasm preview stays independent:
+// the first explicit push starts a fresh model on the external runtime, then
+// later edits hot-reload there with the model preserved.
+
+export const DEFAULT_RUNTIME_ENDPOINT = "http://127.0.0.1:8123";
+
+const SERVICE = "functor debug runtime";
+const MIN_PROTOCOL_VERSION = 2;
+const REQUEST_TIMEOUT_MS = 10_000;
+const ASSET_TIMEOUT_MS = 40_000;
+// Quest's raw 3360×1760 stereo PNG can take >10s to encode and transfer. The
+// runtime itself waits up to 30s for a captured frame; leave transfer margin.
+const CAPTURE_TIMEOUT_MS = 40_000;
+const LIVE_PUSH_DEBOUNCE_MS = 300;
+const STATE_POLL_MS = 1_000;
+const STORAGE_KEY = "functor-runtime-endpoint-v1";
+
+export class RuntimeHttpError extends Error {
+  constructor(method, url, status, body) {
+    super(`${method} ${url} failed with status ${status}: ${body}`);
+    this.name = "RuntimeHttpError";
+    this.method = method;
+    this.url = url;
+    this.status = status;
+    this.body = body;
+  }
+}
+
+// The TypeScript SDK is Node-oriented (`capture()` returns a Buffer). This
+// fetch client intentionally keeps the browser response as a Blob while using
+// the same canonical protocol routes and JSON bodies.
+export class BrowserRuntimeClient {
+  constructor(endpoint, { fetchImpl = fetch, timeoutMs = REQUEST_TIMEOUT_MS } = {}) {
+    this.endpoint = normalizeEndpoint(endpoint);
+    this.fetchImpl = fetchImpl;
+    this.timeoutMs = timeoutMs;
+  }
+
+  async discover() {
+    const discovery = await this.#json("GET", "/");
+    if (
+      discovery?.service !== SERVICE ||
+      !Number.isInteger(discovery?.protocol_version) ||
+      discovery.protocol_version < MIN_PROTOCOL_VERSION
+    ) {
+      throw new Error(
+        `not a compatible Functor runtime (expected ${SERVICE} protocol ${MIN_PROTOCOL_VERSION}+)`
+      );
+    }
+    return discovery;
+  }
+
+  state() {
+    return this.#json("GET", "/state");
+  }
+
+  loadProject(files) {
+    return this.#text("POST", "/load-project", files);
+  }
+
+  reloadProject(files) {
+    return this.#text("POST", "/reload-project", files);
+  }
+
+  reloadAsset(path, bytes) {
+    const pathBytes = new TextEncoder().encode(path);
+    if (pathBytes.byteLength > 0xffff_ffff) throw new Error("asset path is too long");
+    const body = new Uint8Array(4 + pathBytes.byteLength + bytes.byteLength);
+    new DataView(body.buffer).setUint32(0, pathBytes.byteLength, false);
+    body.set(pathBytes, 4);
+    body.set(bytes, 4 + pathBytes.byteLength);
+    return this.#request(
+      "POST",
+      "/reload-asset",
+      body,
+      ASSET_TIMEOUT_MS,
+      "application/octet-stream"
+    ).then((response) => response.text());
+  }
+
+  syncAssets(paths) {
+    return this.#text("POST", "/sync-assets", paths);
+  }
+
+  capture() {
+    return this.#request("POST", "/capture", undefined, CAPTURE_TIMEOUT_MS).then((response) =>
+      response.blob()
+    );
+  }
+
+  async #json(method, path, body) {
+    return (await this.#request(method, path, body)).json();
+  }
+
+  async #text(method, path, body) {
+    return (await this.#request(method, path, body)).text();
+  }
+
+  async #request(method, path, body, timeoutMs = this.timeoutMs, contentType = null) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    const url = `${this.endpoint}${path}`;
+    try {
+      // Invoke an injected/global fetch as a plain function. Calling it as
+      // `this.fetchImpl(...)` supplies the client as the Web API receiver,
+      // which some browsers reject as an illegal invocation before networking.
+      const fetchRequest = this.fetchImpl;
+      const response = await fetchRequest(url, {
+        method,
+        headers:
+          body === undefined
+            ? undefined
+            : { "Content-Type": contentType ?? "application/json" },
+        body:
+          body === undefined ? undefined : contentType === null ? JSON.stringify(body) : body,
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        throw new RuntimeHttpError(method, url, response.status, await response.text());
+      }
+      return response;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+export function normalizeEndpoint(raw) {
+  let value = String(raw ?? "").trim();
+  if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(value)) value = `http://${value}`;
+  const url = new URL(value);
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("runtime endpoint must use http:// or https://");
+  }
+  if (url.username || url.password) throw new Error("runtime endpoint cannot include credentials");
+  url.search = "";
+  url.hash = "";
+  url.pathname = url.pathname.replace(/\/+$/, "");
+  return url.toString().replace(/\/$/, "");
+}
+
+const isLoopbackHost = (host) =>
+  host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "[::1]";
+
+const storedEndpoint = () => {
+  try {
+    return localStorage.getItem(STORAGE_KEY) || DEFAULT_RUNTIME_ENDPOINT;
+  } catch {
+    return DEFAULT_RUNTIME_ENDPOINT;
+  }
+};
+
+const rememberEndpoint = (endpoint) => {
+  try {
+    localStorage.setItem(STORAGE_KEY, endpoint);
+  } catch {
+    /* endpoint persistence is a convenience */
+  }
+};
+
+const projectPairs = (files) => {
+  if (!Array.isArray(files) || files.length === 0) {
+    throw new Error("the editor has no project files to push");
+  }
+  return files.map((file, index) => {
+    const pair = Array.isArray(file) ? file : [file?.path, file?.source];
+    if (
+      pair.length !== 2 ||
+      typeof pair[0] !== "string" ||
+      typeof pair[1] !== "string" ||
+      pair[0].length === 0
+    ) {
+      throw new Error(`project file ${index + 1} is not a [path, source] pair`);
+    }
+    return pair;
+  });
+};
+
+const projectAssets = async (files) => {
+  if (!Array.isArray(files)) throw new Error("project assets must be an array");
+  return Promise.all(
+    files.map(async (file, index) => {
+      const pair = Array.isArray(file) ? file : [file?.path, file?.bytes];
+      if (pair.length !== 2 || typeof pair[0] !== "string" || pair[0].length === 0) {
+        throw new Error(`project asset ${index + 1} is not a [path, bytes] pair`);
+      }
+      let bytes;
+      if (pair[1] instanceof Uint8Array) {
+        bytes = pair[1];
+      } else if (pair[1] instanceof ArrayBuffer) {
+        bytes = new Uint8Array(pair[1]);
+      } else if (ArrayBuffer.isView(pair[1])) {
+        bytes = new Uint8Array(pair[1].buffer, pair[1].byteOffset, pair[1].byteLength);
+      } else if (typeof Blob !== "undefined" && pair[1] instanceof Blob) {
+        bytes = new Uint8Array(await pair[1].arrayBuffer());
+      } else {
+        throw new Error(`project asset ${index + 1} has unsupported bytes`);
+      }
+      return [pair[0], bytes];
+    })
+  );
+};
+
+const errorMessage = (error, endpoint, action) => {
+  if (error instanceof RuntimeHttpError) {
+    const detail = error.body.trim();
+    if (error.status === 503 && action === "capture") {
+      return "capture unavailable — wake the headset and wait for XR rendering";
+    }
+    return detail || `${action} failed with HTTP ${error.status}`;
+  }
+  if (error?.name === "AbortError") {
+    return `${action} timed out at ${endpoint}`;
+  }
+  if (error instanceof TypeError) {
+    const detail = error.message && error.message !== "Failed to fetch" ? ` (${error.message})` : "";
+    return `cannot reach ${endpoint}${detail} — check the runtime, adb port forward, and browser local-network permission`;
+  }
+  return error instanceof Error ? error.message : String(error);
+};
+
+// Mount the same device-link control in the multi-file IDE and the single-file
+// sandbox. `getProject` is evaluated at push time, so queued edits always send
+// the latest complete source set.
+export function createRuntimeTarget({ host, getProject, getAssets = null, onOutput = () => {} }) {
+  if (!host) throw new Error("runtime target host is required");
+
+  host.classList.add("runtime-target-host");
+  host.innerHTML = `
+    <details class="runtime-target">
+      <summary data-runtime-summary>
+        <span class="runtime-target-dot" aria-hidden="true"></span>
+        <span>device</span>
+        <span class="runtime-target-summary-state" data-runtime-summary-state>off</span>
+      </summary>
+      <div class="runtime-target-panel">
+        <div class="runtime-target-heading">
+          <span>EXTERNAL RUNTIME</span>
+          <span class="runtime-target-kind">QUEST / DESKTOP</span>
+          <button data-runtime-close type="button" aria-label="Close external runtime panel">×</button>
+        </div>
+        <label class="runtime-target-label">
+          endpoint
+          <input
+            data-runtime-endpoint
+            type="url"
+            inputmode="url"
+            spellcheck="false"
+            autocomplete="off"
+            aria-label="Functor runtime endpoint"
+          />
+        </label>
+        <p class="runtime-target-hint">
+          Quest over USB:
+          <code>adb forward tcp:8123 tcp:8123</code>
+        </p>
+        <div class="runtime-target-actions">
+          <button data-runtime-push type="button">push + go live</button>
+          <button data-runtime-capture type="button" disabled>capture</button>
+        </div>
+        <p class="runtime-target-status" data-runtime-status data-state="off" aria-live="polite">
+          Ready to start a fresh model, then preserve it across edits.
+        </p>
+        <div class="runtime-target-telemetry" data-runtime-telemetry hidden>
+          <div><span>FRAME</span><strong data-runtime-frame>—</strong></div>
+          <div><span>TIME</span><strong data-runtime-time>—</strong></div>
+          <div><span>VIEWS</span><strong data-runtime-views>—</strong></div>
+        </div>
+        <pre class="runtime-target-model" data-runtime-model hidden></pre>
+        <figure class="runtime-target-capture" data-runtime-capture-frame hidden>
+          <img data-runtime-image alt="Captured frame from the linked Functor runtime" />
+          <figcaption>RAW RUNTIME CAPTURE</figcaption>
+        </figure>
+      </div>
+    </details>
+  `;
+
+  const details = host.querySelector(".runtime-target");
+  const summary = host.querySelector("[data-runtime-summary]");
+  const summaryState = host.querySelector("[data-runtime-summary-state]");
+  const endpointInput = host.querySelector("[data-runtime-endpoint]");
+  const pushButton = host.querySelector("[data-runtime-push]");
+  const captureButton = host.querySelector("[data-runtime-capture]");
+  const closeButton = host.querySelector("[data-runtime-close]");
+  const status = host.querySelector("[data-runtime-status]");
+  const telemetry = host.querySelector("[data-runtime-telemetry]");
+  const frameValue = host.querySelector("[data-runtime-frame]");
+  const timeValue = host.querySelector("[data-runtime-time]");
+  const viewsValue = host.querySelector("[data-runtime-views]");
+  const modelValue = host.querySelector("[data-runtime-model]");
+  const captureFrame = host.querySelector("[data-runtime-capture-frame]");
+  const captureImage = host.querySelector("[data-runtime-image]");
+
+  endpointInput.value = storedEndpoint();
+  const localEditorOrigin = isLoopbackHost(window.location.hostname);
+
+  let client = null;
+  let connected = false;
+  let live = false;
+  let projectRevision = 0;
+  let syncedRevision = -1;
+  let freshRequiredRevision = 0;
+  let freshSatisfiedRevision = -1;
+  let pushTimer = null;
+  let pollTimer = null;
+  let pollingGeneration = null;
+  let pushing = false;
+  let pushQueued = false;
+  let capturing = false;
+  let captureQueued = false;
+  let generation = 0;
+  let captureUrl = null;
+  let syncError = null;
+  let transportError = null;
+  let lastSyncedAssetSource = null;
+  let assetSyncPending = false;
+
+  const renderStatus = (state, summaryText, message) => {
+    details.dataset.state = state;
+    summary.dataset.state = state;
+    summaryState.textContent = summaryText;
+    status.dataset.state = state;
+    status.textContent = message;
+  };
+
+  const renderState = (state) => {
+    if (!state || !Number.isFinite(state.frame)) return;
+    const views = Array.isArray(state.views) ? state.views.map((view) => view.name).join(" + ") : "—";
+    frameValue.textContent = String(state.frame);
+    timeValue.textContent = Number.isFinite(state.tts) ? `${state.tts.toFixed(2)}s` : "—";
+    viewsValue.textContent = views || "—";
+    telemetry.hidden = false;
+    const model = typeof state.model === "string" ? state.model.trim() : "";
+    modelValue.textContent = model;
+    modelValue.hidden = model.length === 0;
+  };
+
+  const currentEndpoint = () => normalizeEndpoint(endpointInput.value);
+  const projectIsDirty = () =>
+    syncedRevision < projectRevision ||
+    freshSatisfiedRevision < freshRequiredRevision ||
+    assetSyncPending;
+
+  const disconnect = () => {
+    generation += 1;
+    clearTimeout(pushTimer);
+    clearTimeout(pollTimer);
+    client = null;
+    connected = false;
+    live = false;
+    syncedRevision = -1;
+    freshRequiredRevision = projectRevision;
+    freshSatisfiedRevision = -1;
+    pushQueued = false;
+    syncError = null;
+    transportError = null;
+    lastSyncedAssetSource = null;
+    assetSyncPending = false;
+    pushButton.disabled = !localEditorOrigin;
+    captureButton.disabled = true;
+    telemetry.hidden = true;
+    modelValue.hidden = true;
+    captureFrame.hidden = true;
+    if (captureUrl) {
+      URL.revokeObjectURL(captureUrl);
+      captureUrl = null;
+      captureImage.removeAttribute("src");
+    }
+    renderStatus("off", "off", "Endpoint changed. Push to start a fresh model.");
+  };
+
+  const pollState = async () => {
+    clearTimeout(pollTimer);
+    pollTimer = null;
+    if (!connected || !client || capturing || pushing) return;
+    const ownGeneration = generation;
+    // Pushes and captures request an immediate refresh, but they must not start
+    // independent polling chains when a state request is already in flight.
+    if (pollingGeneration === ownGeneration) return;
+    pollingGeneration = ownGeneration;
+    try {
+      const state = await client.state();
+      if (ownGeneration !== generation) return;
+      if (capturing || pushing) return;
+      renderState(state);
+      if (transportError) {
+        transportError = null;
+        if (syncError) {
+          renderStatus("error", "sync error", syncError);
+        } else if (projectIsDirty()) {
+          renderStatus("busy", "syncing", "Connection restored. Retrying the latest project…");
+          queuePush({ immediate: true });
+        } else {
+          renderStatus("live", "live", "Connection restored. Project is synchronized.");
+        }
+      }
+    } catch (error) {
+      if (ownGeneration !== generation) return;
+      if (capturing || pushing) return;
+      transportError = errorMessage(error, client.endpoint, "state poll");
+      renderStatus(
+        "error",
+        syncError ? "sync error" : "retrying",
+        syncError ? `${syncError} Runtime unreachable: ${transportError}` : transportError
+      );
+    } finally {
+      if (pollingGeneration === ownGeneration) pollingGeneration = null;
+      if (ownGeneration === generation && connected && !capturing && !pushing) {
+        clearTimeout(pollTimer);
+        pollTimer = setTimeout(pollState, STATE_POLL_MS);
+      }
+    }
+  };
+
+  const ensureConnection = async () => {
+    const endpoint = currentEndpoint();
+    if (!client || client.endpoint !== endpoint) {
+      client = new BrowserRuntimeClient(endpoint);
+      connected = false;
+    }
+    const runtime = client;
+    if (!connected) {
+      await runtime.discover();
+      // Endpoint changes disconnect the old client while discovery is in
+      // flight. Do not let its late response mark the replacement as linked.
+      if (client !== runtime) return null;
+      connected = true;
+      rememberEndpoint(endpoint);
+      captureButton.disabled = false;
+    }
+    return runtime;
+  };
+
+  const pushOnce = async () => {
+    const ownGeneration = generation;
+    // Snapshot the authored project and its fresh-model requirement before the
+    // first await. A reset that arrives during discovery or asset transfer gets
+    // a later revision and therefore remains fresh in the queued push.
+    const requestRevision = projectRevision;
+    const files = projectPairs(getProject());
+    const rawAssetsSnapshot = getAssets ? getAssets() : null;
+    const fresh = !live || freshSatisfiedRevision < freshRequiredRevision;
+    const sourceNeedsSync = syncedRevision < requestRevision || fresh;
+    let endpoint = endpointInput.value;
+    let assetCount = 0;
+    let resolvedAssetsSource = null;
+    let assets = [];
+    let sourceResult = null;
+    syncError = null;
+    renderStatus("busy", "syncing", connected ? "Sending the latest project…" : "Finding the runtime…");
+    pushButton.disabled = true;
+    try {
+      const runtime = await ensureConnection();
+      if (ownGeneration !== generation || !runtime) return;
+      endpoint = runtime.endpoint;
+      if (getAssets) {
+        resolvedAssetsSource = await rawAssetsSnapshot;
+        assets = await projectAssets(resolvedAssetsSource);
+        assetCount = assets.length;
+        if (resolvedAssetsSource !== lastSyncedAssetSource) {
+          assetSyncPending = true;
+          for (const [path, bytes] of assets) await runtime.reloadAsset(path, bytes);
+          if (ownGeneration !== generation) return;
+        }
+      }
+      if (sourceNeedsSync) {
+        sourceResult = fresh
+          ? await runtime.loadProject(files)
+          : await runtime.reloadProject(files);
+        if (ownGeneration !== generation) return;
+        live = true;
+        syncedRevision = Math.max(syncedRevision, requestRevision);
+        if (fresh) {
+          freshSatisfiedRevision = Math.max(freshSatisfiedRevision, requestRevision);
+        }
+      }
+      // Finalize deletions only after the new source is accepted. If source
+      // loading fails, the last-good program keeps every asset it still needs.
+      if (getAssets && resolvedAssetsSource !== lastSyncedAssetSource) {
+        await runtime.syncAssets(assets.map(([path]) => path));
+        if (ownGeneration !== generation) return;
+        lastSyncedAssetSource = resolvedAssetsSource;
+        assetSyncPending = false;
+      }
+      if (ownGeneration !== generation) return;
+      syncError = null;
+      transportError = null;
+      renderStatus(
+        "live",
+        "live",
+        fresh && sourceResult
+          ? `Fresh model loaded from ${files.length} source file${files.length === 1 ? "" : "s"}${
+              getAssets ? ` + ${assetCount} asset${assetCount === 1 ? "" : "s"}` : ""
+            }.`
+          : sourceResult ?? `Synchronized ${assetCount} project asset${assetCount === 1 ? "" : "s"}.`
+      );
+    } catch (error) {
+      if (ownGeneration !== generation) return;
+      const message = errorMessage(error, endpoint, "push");
+      if (error instanceof RuntimeHttpError) {
+        syncError = message;
+        transportError = null;
+        renderStatus("error", "sync error", message);
+      } else {
+        transportError = message;
+        renderStatus("error", connected ? "retrying" : "offline", message);
+      }
+      onOutput("error", `[device] ${message}`);
+    } finally {
+      if (ownGeneration === generation) pushButton.disabled = false;
+    }
+  };
+
+  const flushPush = async () => {
+    if (capturing) {
+      pushQueued = true;
+      return;
+    }
+    if (pushing) {
+      pushQueued = true;
+      return;
+    }
+    pushing = true;
+    clearTimeout(pollTimer);
+    do {
+      pushQueued = false;
+      await pushOnce();
+    } while (pushQueued);
+    pushing = false;
+    if (captureQueued) {
+      captureQueued = false;
+      capture();
+    } else if (connected) {
+      pollState();
+    }
+  };
+
+  const queuePush = ({ immediate = false } = {}) => {
+    clearTimeout(pushTimer);
+    // The initial load snapshots source before its first await. Edits that land
+    // while that load is in flight must queue even though `live` is still false.
+    if (pushing) {
+      pushQueued = true;
+      return;
+    }
+    if (!live && !immediate) return;
+    if (capturing) {
+      pushQueued = true;
+      return;
+    }
+    if (immediate) {
+      flushPush();
+    } else {
+      pushTimer = setTimeout(flushPush, LIVE_PUSH_DEBOUNCE_MS);
+    }
+  };
+
+  const projectChanged = ({ fresh = false } = {}) => {
+    projectRevision += 1;
+    if (fresh) freshRequiredRevision = projectRevision;
+    syncError = null;
+    queuePush();
+  };
+
+  const capture = async () => {
+    if (capturing) return;
+    if (pushing) {
+      captureQueued = true;
+      captureButton.disabled = true;
+      return;
+    }
+    const ownGeneration = generation;
+    let endpoint = endpointInput.value;
+    capturing = true;
+    clearTimeout(pollTimer);
+    captureButton.disabled = true;
+    renderStatus("busy", "capture", "Waiting for the next rendered frame…");
+    try {
+      const runtime = await ensureConnection();
+      if (ownGeneration !== generation || !runtime) return;
+      endpoint = runtime.endpoint;
+      const blob = await runtime.capture();
+      if (ownGeneration !== generation) return;
+      if (captureUrl) URL.revokeObjectURL(captureUrl);
+      captureUrl = URL.createObjectURL(blob);
+      captureImage.src = captureUrl;
+      captureFrame.hidden = false;
+      transportError = null;
+      if (syncError) {
+        renderStatus(
+          "error",
+          "sync error",
+          "Captured the last-good framebuffer; the latest editor source is not synchronized."
+        );
+      } else if (projectIsDirty()) {
+        renderStatus(
+          "busy",
+          "syncing",
+          "Captured the last-good framebuffer. Retrying the latest project…"
+        );
+        queuePush({ immediate: true });
+      } else {
+        renderStatus("live", live ? "live" : "linked", "Captured the runtime framebuffer.");
+      }
+    } catch (error) {
+      if (ownGeneration !== generation) return;
+      const message = errorMessage(error, endpoint, "capture");
+      if (!(error instanceof RuntimeHttpError)) transportError = message;
+      renderStatus("error", live ? "capture error" : "offline", message);
+      onOutput("error", `[device] ${message}`);
+    } finally {
+      capturing = false;
+      if (ownGeneration === generation) captureButton.disabled = !connected;
+      if (pushQueued) flushPush();
+      if (ownGeneration === generation && connected) pollState();
+    }
+  };
+
+  const restart = () => {
+    if (!live) return;
+    projectRevision += 1;
+    freshRequiredRevision = projectRevision;
+    syncError = null;
+    queuePush({ immediate: true });
+  };
+
+  endpointInput.addEventListener("change", disconnect);
+  pushButton.addEventListener("click", () => queuePush({ immediate: true }));
+  captureButton.addEventListener("click", capture);
+  closeButton.addEventListener("click", () => {
+    details.open = false;
+    summary.focus();
+  });
+
+  if (!localEditorOrigin) {
+    pushButton.disabled = true;
+    renderStatus(
+      "off",
+      "local only",
+      "For safety, Functor runtimes accept editor links only from a localhost-served IDE."
+    );
+  }
+
+  const destroy = () => {
+    disconnect();
+    if (captureUrl) URL.revokeObjectURL(captureUrl);
+  };
+  window.addEventListener("pagehide", destroy, { once: true });
+
+  return {
+    projectChanged,
+    restart,
+    capture,
+    destroy,
+    state: () => ({
+      endpoint: endpointInput.value,
+      connected,
+      live,
+      fresh: !live || freshSatisfiedRevision < freshRequiredRevision,
+      status: status.dataset.state,
+      message: status.textContent,
+    }),
+  };
+}

--- a/site/src/runtime-target.js
+++ b/site/src/runtime-target.js
@@ -314,6 +314,7 @@ export function createRuntimeTarget({ host, getProject, getAssets = null, onOutp
   let syncError = null;
   let transportError = null;
   let lastSyncedAssetSource = null;
+  let lastSyncedAssets = [];
   let assetSyncPending = false;
 
   const renderStatus = (state, summaryText, message) => {
@@ -353,9 +354,11 @@ export function createRuntimeTarget({ host, getProject, getAssets = null, onOutp
     freshRequiredRevision = projectRevision;
     freshSatisfiedRevision = -1;
     pushQueued = false;
+    captureQueued = false;
     syncError = null;
     transportError = null;
     lastSyncedAssetSource = null;
+    lastSyncedAssets = [];
     assetSyncPending = false;
     pushButton.disabled = !localEditorOrigin;
     captureButton.disabled = true;
@@ -447,11 +450,16 @@ export function createRuntimeTarget({ host, getProject, getAssets = null, onOutp
     let resolvedAssetsSource = null;
     let assets = [];
     let sourceResult = null;
+    let runtime = null;
+    let assetsMutated = false;
+    let sourceAccepted = false;
+    const priorAssetsKnown = lastSyncedAssetSource !== null;
+    const priorAssets = lastSyncedAssets;
     syncError = null;
     renderStatus("busy", "syncing", connected ? "Sending the latest project…" : "Finding the runtime…");
     pushButton.disabled = true;
     try {
-      const runtime = await ensureConnection();
+      runtime = await ensureConnection();
       if (ownGeneration !== generation || !runtime) return;
       endpoint = runtime.endpoint;
       if (getAssets) {
@@ -460,7 +468,10 @@ export function createRuntimeTarget({ host, getProject, getAssets = null, onOutp
         assetCount = assets.length;
         if (resolvedAssetsSource !== lastSyncedAssetSource) {
           assetSyncPending = true;
-          for (const [path, bytes] of assets) await runtime.reloadAsset(path, bytes);
+          for (const [path, bytes] of assets) {
+            await runtime.reloadAsset(path, bytes);
+            assetsMutated = true;
+          }
           if (ownGeneration !== generation) return;
         }
       }
@@ -474,6 +485,7 @@ export function createRuntimeTarget({ host, getProject, getAssets = null, onOutp
         if (fresh) {
           freshSatisfiedRevision = Math.max(freshSatisfiedRevision, requestRevision);
         }
+        sourceAccepted = true;
       }
       // Finalize deletions only after the new source is accepted. If source
       // loading fails, the last-good program keeps every asset it still needs.
@@ -481,6 +493,7 @@ export function createRuntimeTarget({ host, getProject, getAssets = null, onOutp
         await runtime.syncAssets(assets.map(([path]) => path));
         if (ownGeneration !== generation) return;
         lastSyncedAssetSource = resolvedAssetsSource;
+        lastSyncedAssets = assets;
         assetSyncPending = false;
       }
       if (ownGeneration !== generation) return;
@@ -497,7 +510,31 @@ export function createRuntimeTarget({ host, getProject, getAssets = null, onOutp
       );
     } catch (error) {
       if (ownGeneration !== generation) return;
-      const message = errorMessage(error, endpoint, "push");
+      let message = errorMessage(error, endpoint, "push");
+      // Asset reloads are eager. If the runtime definitively rejects the new
+      // source, restore the last browser-synchronized bytes + manifest so the
+      // last-good program cannot keep an overwritten or partially uploaded set.
+      if (
+        error instanceof RuntimeHttpError &&
+        (error.status === 400 || error.status === 413) &&
+        runtime &&
+        assetsMutated &&
+        !sourceAccepted &&
+        priorAssetsKnown
+      ) {
+        try {
+          for (const [path, bytes] of priorAssets) await runtime.reloadAsset(path, bytes);
+          await runtime.syncAssets(priorAssets.map(([path]) => path));
+          message = `${message} Last-good assets were restored.`;
+        } catch (rollbackError) {
+          message = `${message} Asset rollback also failed: ${errorMessage(
+            rollbackError,
+            endpoint,
+            "asset rollback"
+          )}`;
+        }
+      }
+      if (ownGeneration !== generation) return;
       if (error instanceof RuntimeHttpError) {
         syncError = message;
         transportError = null;

--- a/site/src/sandbox.js
+++ b/site/src/sandbox.js
@@ -23,6 +23,7 @@ import {
 } from "./lang-intel.js";
 import { PlayerBridge } from "./player-bridge.js";
 import { createStatusBar } from "./status-bar.js";
+import { createRuntimeTarget } from "./runtime-target.js";
 import { EXAMPLES } from "./examples.js";
 
 const frame = document.getElementById("player");
@@ -40,6 +41,13 @@ const setStatus = (state, text, detail = "") => {
 };
 
 const statusBar = createStatusBar({ host: document.getElementById("statusbar") });
+let runtimeTarget = null;
+// The sandbox edits only the entry buffer, but some examples also load sibling
+// modules (for example Mario's generated assets.fun manifest). Keep those
+// fetched sources so an external runtime receives the same complete project as
+// the in-page wasm preview.
+let siblingSources = [];
+let assetSources = [];
 
 const bridge = new PlayerBridge(frame, {
   onReloading: () => setStatus("busy", "◌ reloading…"),
@@ -82,9 +90,19 @@ const view = new EditorView({
     functorLangLanguage,
     synthwaveEditorTheme,
     EditorView.updateListener.of((update) => {
-      if (update.docChanged && !programmaticEdit) bridge.push(view.state.doc.toString());
+      if (update.docChanged && !programmaticEdit) {
+        bridge.push(view.state.doc.toString());
+        runtimeTarget?.projectChanged();
+      }
     }),
   ],
+});
+
+runtimeTarget = createRuntimeTarget({
+  host: document.getElementById("runtime-target"),
+  getProject: () => [["game.fun", view.state.doc.toString()], ...siblingSources],
+  getAssets: () => assetSources,
+  onOutput: (level, message) => statusBar.appendOutput(level, message),
 });
 
 // Live type diagnostics: load the analysis wasm lazily and, once ready, append
@@ -134,14 +152,17 @@ window.__lang = {
   expects: () => currentExpects(view),
 };
 
-const setDoc = (source) => {
+const setDoc = (source, siblings = [], assets = []) => {
   bridge.reset();
   // Wholesale document replacement (example switch, inline load, reset): drop
   // the wasm completion cache so the previous program's candidates can't leak.
   resetIntel();
+  siblingSources = siblings;
+  assetSources = assets;
   programmaticEdit = true;
   view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: source } });
   programmaticEdit = false;
+  runtimeTarget?.projectChanged({ fresh: true });
 };
 
 // An inline program from the URL fragment (the docs' "try it" buttons):
@@ -194,18 +215,38 @@ const loadExample = async (id) => {
     `examples/${encodeURIComponent(id)}.fun`,
     ...(example?.siblings?.map(({ output }) => output) ?? []),
   ];
-  const url = files[0];
-  const response = await fetch(url);
+  const assetFiles = example?.assets ?? [];
+  const resourcePaths = [...files, ...assetFiles.map(({ output }) => output)];
+  const responses = await Promise.all(resourcePaths.map((file) => fetch(file)));
   if (token !== loadToken) return; // a newer load superseded this one
-  if (!response.ok) {
-    setStatus("error", "✖ error", `cannot fetch ${url}: HTTP ${response.status}`);
+  const failed = responses.findIndex((response) => !response.ok);
+  if (failed !== -1) {
+    setStatus(
+      "error",
+      "✖ error",
+      `cannot fetch ${resourcePaths[failed]}: HTTP ${responses[failed].status}`
+    );
     return;
   }
-  const source = await response.text();
+  const sources = await Promise.all(
+    responses.slice(0, files.length).map((response) => response.text())
+  );
+  const assets = await Promise.all(
+    responses.slice(files.length).map(async (response, index) => [
+      assetFiles[index].output,
+      new Uint8Array(await response.arrayBuffer()),
+    ])
+  );
   if (token !== loadToken) return;
+  const url = files[0];
+  const source = sources[0];
+  const siblings = files.slice(1).map((path, index) => [
+    path.split("/").pop(),
+    sources[index + 1],
+  ]);
   // A fresh iframe (fresh model: init runs) rather than a source push, so
   // switching examples resets state; the ready announcement re-arms pushes.
-  setDoc(source);
+  setDoc(source, siblings, assets);
   setStatus("busy", "◌ loading…");
   const params = new URLSearchParams({ game: url });
   for (const file of files) params.append("file", file);
@@ -253,6 +294,7 @@ window.__sandbox = {
     text: statusPill.textContent,
     message: statusPill.title,
   }),
+  runtimeTarget: () => runtimeTarget.state(),
   getSource: () => view.state.doc.toString(),
   // Replace the buffer, place the cursor, and open the completion popup
   // (explicit trigger). Guarded so it does NOT push to the runtime — completion

--- a/site/styles.css
+++ b/site/styles.css
@@ -855,6 +855,305 @@ a:hover {
   color: var(--amber);
 }
 
+/* Shared external-runtime link for the sandbox and multi-file IDE. It stays a
+   compact header control until opened, then reads like a tiny device console:
+   source link above, live runtime telemetry and the raw capture below. */
+.runtime-target-host {
+  position: relative;
+}
+
+.runtime-target {
+  position: relative;
+}
+
+.runtime-target > summary {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 6px 10px;
+  color: var(--text);
+  background: var(--bg-raised);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  font-size: 0.75rem;
+  line-height: 1.2;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+}
+
+.runtime-target > summary::-webkit-details-marker {
+  display: none;
+}
+
+.runtime-target > summary:hover,
+.runtime-target[open] > summary {
+  color: var(--cyan);
+  border-color: rgba(65, 216, 230, 0.65);
+}
+
+.runtime-target-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--text-dim);
+  box-shadow: 0 0 0 3px rgba(155, 148, 179, 0.1);
+}
+
+.runtime-target-summary-state {
+  color: var(--text-dim);
+  font-size: 0.62rem;
+}
+
+.runtime-target > summary[data-state="busy"] .runtime-target-dot {
+  background: var(--amber);
+  box-shadow: 0 0 10px rgba(238, 200, 119, 0.65);
+}
+
+.runtime-target > summary[data-state="live"] .runtime-target-dot {
+  background: var(--green);
+  box-shadow: 0 0 10px rgba(111, 220, 146, 0.7);
+}
+
+.runtime-target > summary[data-state="error"] .runtime-target-dot {
+  background: var(--red);
+  box-shadow: 0 0 10px rgba(242, 99, 127, 0.65);
+}
+
+.runtime-target-panel {
+  position: absolute;
+  z-index: 40;
+  top: calc(100% + 10px);
+  left: 0;
+  width: min(430px, calc(100vw - 32px));
+  padding: 16px;
+  background:
+    linear-gradient(135deg, rgba(65, 216, 230, 0.06), transparent 42%),
+    var(--bg-panel);
+  border: 1px solid rgba(65, 216, 230, 0.45);
+  border-radius: 6px;
+  box-shadow: 0 18px 55px rgba(0, 0, 0, 0.65);
+}
+
+.runtime-target-panel::before {
+  content: "";
+  position: absolute;
+  inset: 5px;
+  border: 1px solid rgba(232, 88, 184, 0.12);
+  pointer-events: none;
+}
+
+.runtime-target-heading,
+.runtime-target-actions,
+.runtime-target-telemetry {
+  display: flex;
+  align-items: center;
+}
+
+.runtime-target-heading {
+  position: relative;
+  gap: 10px;
+  margin-bottom: 13px;
+  color: var(--cyan);
+  font-family: var(--font-display);
+  font-size: 0.65rem;
+  letter-spacing: 0.12em;
+}
+
+.runtime-target-kind {
+  margin-left: auto;
+  color: var(--pink);
+  font-family: var(--font-mono);
+  font-size: 0.58rem;
+}
+
+.runtime-target-heading button {
+  flex: none;
+  width: 28px;
+  height: 28px;
+  margin: -7px -7px -7px 0;
+  padding: 0;
+  color: var(--text-dim);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  font: 1rem/1 var(--font-mono);
+  cursor: pointer;
+}
+
+.runtime-target-heading button:hover,
+.runtime-target-heading button:focus-visible {
+  color: var(--cyan);
+  border-color: var(--line);
+  outline: none;
+}
+
+.runtime-target-label {
+  position: relative;
+  display: block;
+  color: var(--text-dim);
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.runtime-target-label input {
+  display: block;
+  width: 100%;
+  margin-top: 5px;
+  padding: 8px 10px;
+  color: var(--text);
+  background: rgba(15, 12, 29, 0.88);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  font: 0.78rem/1.4 var(--font-mono);
+  outline: none;
+}
+
+.runtime-target-label input:focus {
+  border-color: var(--cyan);
+  box-shadow: 0 0 0 2px rgba(65, 216, 230, 0.12);
+}
+
+.runtime-target-hint {
+  position: relative;
+  margin: 7px 0 12px;
+  color: var(--text-dim);
+  font-size: 0.65rem;
+}
+
+.runtime-target-hint code {
+  color: var(--amber);
+}
+
+.runtime-target-actions {
+  position: relative;
+  gap: 8px;
+}
+
+.runtime-target-actions button {
+  padding: 7px 10px;
+  color: var(--text);
+  background: var(--bg-raised);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  font: 0.7rem var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  cursor: pointer;
+}
+
+.runtime-target-actions button:first-child {
+  color: var(--bg);
+  background: var(--cyan);
+  border-color: var(--cyan);
+  font-weight: 600;
+}
+
+.runtime-target-actions button:hover:not(:disabled) {
+  border-color: var(--pink);
+}
+
+.runtime-target-actions button:disabled {
+  opacity: 0.42;
+  cursor: not-allowed;
+}
+
+.runtime-target-status {
+  position: relative;
+  margin: 12px 0 0;
+  padding-top: 10px;
+  color: var(--text-dim);
+  border-top: 1px solid var(--line);
+  font-size: 0.7rem;
+  line-height: 1.45;
+  max-height: 92px;
+  overflow: auto;
+}
+
+.runtime-target-status[data-state="live"] {
+  color: var(--green);
+}
+
+.runtime-target-status[data-state="busy"] {
+  color: var(--amber);
+}
+
+.runtime-target-status[data-state="error"] {
+  color: var(--red);
+}
+
+.runtime-target-telemetry {
+  position: relative;
+  gap: 20px;
+  margin-top: 12px;
+}
+
+.runtime-target-telemetry div {
+  display: grid;
+  gap: 1px;
+}
+
+.runtime-target-telemetry span,
+.runtime-target-capture figcaption {
+  color: var(--text-dim);
+  font-size: 0.55rem;
+  letter-spacing: 0.11em;
+}
+
+.runtime-target-telemetry strong {
+  color: var(--text);
+  font-size: 0.72rem;
+  font-weight: 600;
+}
+
+.runtime-target-model {
+  position: relative;
+  max-height: 68px;
+  margin: 11px 0 0;
+  padding: 8px 10px;
+  overflow: auto;
+  color: var(--cyan);
+  background: rgba(15, 12, 29, 0.72);
+  border-left: 2px solid var(--pink);
+  font: 0.66rem/1.4 var(--font-mono);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.runtime-target-capture {
+  position: relative;
+  margin: 12px 0 0;
+}
+
+.runtime-target-capture img {
+  display: block;
+  width: 100%;
+  max-height: 190px;
+  object-fit: contain;
+  background: #06050c;
+  border: 1px solid var(--line);
+}
+
+.runtime-target-capture figcaption {
+  margin-top: 4px;
+  text-align: right;
+}
+
+@media (max-width: 820px) {
+  .runtime-target-panel {
+    position: fixed;
+    top: 74px;
+    right: 12px;
+    left: 12px;
+    width: auto;
+    max-height: calc(100vh - 90px);
+    overflow: auto;
+  }
+}
+
 .sandbox-split {
   flex: 1;
   display: grid;


### PR DESCRIPTION
## Summary

- add one shared Device panel to both the browser IDE and sandbox
- fresh-load the authored project, preserve the remote model across later edits, and expose live state plus raw framebuffer capture
- send complete sibling-module projects; sandbox examples also upload declared assets before source and finalize deletions only after source acceptance
- keep source synchronization truthful across reconnects, resets, long captures, endpoint changes, and rejected edits
- document localhost/Quest forwarding and run the new browser-runtime e2e in CI

## Verification

- `npm run test:runtime-target`
- `npm run test:ide-page`
- `FUNCTOR_SITE_PORT=8142 npm run test:site`
- `npm run build:oculus:apk`
- Quest 3: exact final build fresh-loaded Mario as 2 source files + 2 assets, then hot-reloaded with `model preserved`; `/state` advanced with `left` + `right` views
- Quest 3: browser capture path returned a 3360x1760 stereo PNG; desktop and 390px layouts visually checked
- `git diff --check` and JavaScript syntax checks

No engine per-frame path changed, so the runtime frame benchmark is not applicable.

## Review dispositions

- fixed the agreed mobile trap with an in-panel close control and a 390px interaction test
- fixed incomplete sandbox pushes by retaining sibling sources and synchronizing declared assets
- replaced fresh/dirty booleans with project revisions so first-load edits, reconnect retries, and resets during asset transfer cannot be lost
- serialize capture and source operations, suspend state polling during both, and preserve last-good source/asset truth on failures
- upload asset bytes before source but defer manifest deletion until the new source is accepted
- restore last-known asset bytes + manifest after definitive 400/413 rejection, while avoiding rollback for ambiguous 503/transport outcomes
- discard captures queued behind an old push when the endpoint changes
- final media-aware adversarial re-review after fixes: no remaining findings

Binary asset authoring in the multi-file IDE remains a follow-up; the IDE currently authors source files only.

## Visual proof

![Browser editor linking, live reload, and Quest capture](https://gist.githubusercontent.com/tommy-xr/8db7b52094a7acf63b010b3e1428cb0b/raw/functor-pr473-browser-runtime-target.gif)

<sub>Push from either browser editor to Quest: sibling source and declared assets sync safely, live edits preserve the model, and stereo telemetry/capture stay in the panel.</sub>

<sub>The loop is a reproducible Playwright sequence against the hermetic debug-runtime protocol; its capture response uses the verified raw Quest framebuffer. The stills below are from the actual Quest 3 browser session.</sub>

| Desktop Sandbox + Quest | 390px mobile panel + Quest |
| --- | --- |
| ![Desktop Sandbox showing live Quest telemetry and capture](https://gist.githubusercontent.com/tommy-xr/8db7b52094a7acf63b010b3e1428cb0b/raw/functor-pr473-quest-desktop.png) | ![Mobile runtime panel showing live Quest telemetry and capture](https://gist.githubusercontent.com/tommy-xr/8db7b52094a7acf63b010b3e1428cb0b/raw/functor-pr473-quest-mobile.png) |