### PR TITLE
feat(netsim): run the multiplayer sim in the browser

### DIFF
--- a/.github/workflows/wasm-smoke.yml
+++ b/.github/workflows/wasm-smoke.yml
@@ -9,6 +9,12 @@ name: WASM smoke
 #
 # Software WebGL2 (swiftshader, set in e2e/wasm-smoke.mjs) means no GPU is
 # needed, so this runs on a plain ubuntu runner.
+#
+# It has since become the home for the browser-side e2e suite generally (remote
+# assets, the sandbox and IDE pages, the multiplayer netsim): they all need the
+# same expensive setup — the wasm bundle, the CLI that embeds it, and headless
+# Chromium — so they run as extra steps here rather than paying for it again in
+# a job of their own.
 
 on:
   push:
@@ -83,6 +89,14 @@ jobs:
 
       - name: Run wasm smoke
         run: npm run test:wasm-smoke
+
+      # The multiplayer netsim hosted in the browser: a server + two clients
+      # from one multi-entry project stepped over the virtual network in a
+      # single page, then rewound as ONE environment. Same "works native, broken
+      # in wasm" guard as the smoke above, for the seam the IDEs' multiplayer
+      # view is built on — and it asserts no REAL sockets are opened.
+      - name: Run wasm netsim e2e
+        run: npm run test:wasm-sim
 
       # Remote (URL) asset loading in the browser: builds a wasm bundle that
       # loads a good URL and a 404 URL from a localhost CORS server and asserts

--- a/docs/multiplayer.md
+++ b/docs/multiplayer.md
@@ -184,6 +184,57 @@ over an extended debug-server API (add `/net` inject + `/tick` step to the
 existing `/input`, `/time`, `/state`, `/scene`). Slower, less deterministic;
 validates the real I/O + serialization path. Smoke/integration only.
 
+## Whole-environment time travel
+
+`NetSim::seek(frame)` rewinds **every instance's model AND the virtual network**
+to the state they settled in at that frame — so a rewound frame shows each
+client's own lagging view, the server's authoritative one, and the packets that
+were genuinely mid-flight between them.
+
+It splits along a line the code already draws: each producer records and
+restores its own model (`SceneRecorder` runs inside the frame body `tick`
+executes, and `seek_scene_to` restores it), so the sim only snapshots what lives
+*outside* the producers — the network and its routing tables.
+
+The **snapshot cut** is load-bearing. Only delivery touches a model outside
+`tick` (`deliver_net_event` folds an inbound message through `update` on the
+spot), so the snapshot is taken after a frame's sends are routed and the network
+has advanced but *before* delivery — the one instant where every model still
+equals its recorded frame. `seek` then replays that frame's pending deliveries,
+so a parked frame shows exactly what a viewer saw live and seeking is idempotent.
+
+Semantics match the single-game scrubber: a seek is non-destructive **while
+parked**, and stepping on **commits the branch**. The commit is rebuilt from the
+recorded frame, so stepping on from an untouched scrub reproduces the original
+timeline byte-for-byte. Because a scrub-back is a plain restore and never a
+re-step, none of this needs determinism — the property `History` relies on for
+one game holds for N games plus the network.
+
+Two rules the harness enforces loudly rather than silently skewing: every
+instance must join before the sim's first step (frame alignment), and a seek
+preflights every instance's recorded range before mutating anything (a producer's
+own `seek_scene_to` *clamps* rather than refusing). Link impairment is treated as
+configuration, not recorded state, so it survives a restore — "rewind, worsen the
+link, watch it again" works.
+
+### In the browser
+
+The netsim is platform-free, so it also runs in the **web runtime**, hosting the
+same shared `FunctorLangEmbeddedGame` producers behind the `WebPlatform` seam:
+a whole session — a server and N clients from one multi-entry project — simulated
+inside a single page, with no sockets opened (the sim routes the games' own
+connect/send commands through the virtual network itself). This is the foundation
+for simulating multiplayer inside the VSCode and browser IDEs.
+
+The page exposes it as `window.__sim` (`start` / `step` / `state` / `timeline` /
+`seek` / `len` / `stop`), mirroring the `window.__scrub` seam. While a sim is
+running the single game is **suspended**: producers share the thread's command
+queues and each drain empties them for everyone, so a live single game would
+steal the instances' commands and dispatch them to real sockets. `e2e/wasm-sim.mjs`
+(`npm run test:wasm-sim`) drives `examples/mp` as a server plus two clients in
+headless Chromium and asserts the convergence, the whole-environment rewind, and
+the exact replay.
+
 ## Roadmap (small, stacked PRs; each protocol ships with a netsim test)
 
 | Phase | Scope | Targets |

--- a/e2e/wasm-sim.mjs
+++ b/e2e/wasm-sim.mjs
@@ -1,0 +1,301 @@
+// wasm netsim test: a WHOLE multiplayer session — an authoritative server and
+// two clients — must run inside one browser page, deterministically, and rewind
+// as a single environment.
+//
+// This is the browser counterpart of `functor-netsim`'s native `scrub` suite,
+// and it guards the class of "works native, broken in wasm" bugs that a Rust
+// test cannot see: the producers here are the real `WebPlatform` ones, built
+// from the real fetched project sources, stepped through the real virtual
+// network in wasm.
+//
+// It asserts the properties a multi-pane IDE scrubber depends on:
+//
+//   1. N instances of a multi-entry project (`examples/mp`: server.fun +
+//      client.fun x2 over a shared protocol.fun) load and step in ONE page;
+//   2. they genuinely talk to each other — the clients converge on the
+//      server's authoritative world — with NO real sockets involved;
+//   3. a whole-environment seek rewinds every instance at once, each to its
+//      OWN view of that frame;
+//   4. it is non-destructive while parked, and stepping on commits the branch
+//      and replays the original timeline exactly.
+//
+// Scope split, deliberately: this test covers the WASM INTEGRATION — that real
+// WebPlatform producers, built from really-fetched sources, step and rewind in a
+// browser. It runs on perfect links, so it does not exercise the harder
+// restore-packets-that-were-mid-flight case; `functor-netsim`'s native `scrub`
+// suite covers that under impaired links, and link impairment is not exposed to
+// JS yet (it arrives with the IDE's latency knobs).
+//
+// Known gap, stated rather than papered over: this does NOT verify that the
+// single game is suspended while the sim runs. Doing that needs a live single
+// game to poke, and booting this project trips the pre-existing refused-socket
+// panic below — which may already have killed it, so a "suspension works"
+// assertion here could pass vacuously. The suspension gates are covered by
+// construction and review; a real test wants a project whose default entry opens
+// no socket, which is worth building when the panic is fixed. [xreview]
+//
+// Run manually (owns its own server on :8080):
+//
+//   npm run build:cli:debug   # so target/debug/functor embeds this runtime
+//   node e2e/wasm-sim.mjs
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import net from "node:net";
+import { fileURLToPath } from "node:url";
+import { chromium } from "@playwright/test";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const BASE = "http://127.0.0.1:8080";
+const PORT = 8080;
+const PROJECT = "examples/mp";
+// One server and two clients, so the test covers a client's view diverging from
+// BOTH the server's and the other client's.
+const ENTRIES = ["server.fun", "client.fun", "client.fun"];
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function portInUse() {
+  return new Promise((resolve) => {
+    const sock = net
+      .connect(PORT, "127.0.0.1")
+      .on("connect", () => {
+        sock.destroy();
+        resolve(true);
+      })
+      .on("error", () => resolve(false));
+  });
+}
+
+async function waitPortFree(timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!(await portInUse())) return true;
+    await sleep(200);
+  }
+  return false;
+}
+
+function cliPath() {
+  for (const p of ["target/debug/functor", "target/release/functor"]) {
+    if (existsSync(`${ROOT}${p}`)) return `${ROOT}${p}`;
+  }
+  throw new Error(
+    "no functor binary — run `npm run build:cli:debug` first (the CLI embeds the web runtime)",
+  );
+}
+
+const failures = [];
+function check(ok, label, detail = "") {
+  if (ok) {
+    console.log(`  PASS  ${label}`);
+  } else {
+    failures.push(label);
+    console.log(`  FAIL  ${label}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+async function main() {
+  if (!(await waitPortFree(10000))) {
+    throw new Error(`:${PORT} is busy — a stale dev server would serve the wrong project`);
+  }
+  const server = spawn(cliPath(), ["-d", PROJECT, "run", "wasm"], {
+    cwd: ROOT,
+    stdio: "ignore",
+  });
+  const browser = await chromium.launch({
+    args: ["--use-gl=swiftshader", "--enable-unsafe-swiftshader"],
+  });
+
+  try {
+    const page = await browser.newPage();
+    const log = [];
+    page.on("console", (m) => log.push(m.text()));
+    page.on("pageerror", (e) => log.push(`pageerror: ${e}`));
+
+    // Count every real WebSocket the page constructs, from before the first
+    // script runs. The sim must open NONE: it routes the games' own
+    // connect/send commands through the virtual network instead of the real
+    // dispatcher, and this is what would catch that regression.
+    await page.addInitScript(() => {
+      window.__socketsOpened = 0;
+      window.__socketLog = [];
+      const Real = window.WebSocket;
+      window.WebSocket = function (...args) {
+        window.__socketsOpened++;
+        window.__socketLog.push(`${Math.round(performance.now())}ms ${args[0]}`);
+        return new Real(...args);
+      };
+      window.WebSocket.prototype = Real.prototype;
+      Object.assign(window.WebSocket, Real);
+    });
+
+    for (let i = 0; i < 120; i++) {
+      try {
+        await page.goto(BASE);
+        break;
+      } catch {
+        await sleep(500);
+      }
+    }
+    // The single-game runtime loads first; the sim seam is installed with it.
+    await page.waitForFunction(() => typeof window.__sim === "object", null, {
+      timeout: 60000,
+    });
+
+    // Let the single game finish booting FIRST — it opens its own real socket
+    // within the first frames, and snapshotting the counter before that would
+    // blame the sim for the single game's connect.
+    await sleep(3000);
+
+    // 1. Start the sim: three producers built from this project's own sources.
+    const socketsBefore = await page.evaluate(() => window.__socketsOpened);
+    const count = await page.evaluate((entries) => window.__sim.start(entries, 1), ENTRIES);
+    check(count === 3, "three instances start in one page", `got ${count}`);
+
+    // Bad input is rejected rather than silently mangled (a bare string would
+    // otherwise be iterated character by character into 12 "entries").
+    const badArgs = await page.evaluate(async () => {
+      const errs = [];
+      for (const bad of ["server.fun", ["server.fun", null], []]) {
+        try {
+          await window.__sim.start(bad, 1);
+          errs.push("accepted");
+        } catch (e) {
+          errs.push(String(e));
+        }
+      }
+      return errs;
+    });
+    check(
+      badArgs.every((e) => e !== "accepted"),
+      "malformed entries are rejected, not mangled",
+      badArgs.join(" | "),
+    );
+
+    // 2. Step, and read every instance's view.
+    await page.evaluate(() => window.__sim.step(60));
+    const views = async () =>
+      page.evaluate((n) => Array.from({ length: n }, (_, i) => window.__sim.state(i)), 3);
+    const anchorViews = await views();
+    const anchor = (await page.evaluate(() => window.__sim.timeline())).frame - 1;
+
+    check(
+      anchorViews[1].includes("in-world") && anchorViews[2].includes("in-world"),
+      "both clients joined the server's world (no real sockets)",
+      anchorViews[1],
+    );
+    check(
+      anchorViews[0].includes("players") && !anchorViews[0].includes("players: []"),
+      "the server tracks the connected players",
+      anchorViews[0],
+    );
+
+    // 3. Step well past the anchor, recording the timeline to reproduce.
+    const timeline = [];
+    for (let i = 0; i < 40; i++) {
+      await page.evaluate(() => window.__sim.step(1));
+      timeline.push(await views());
+    }
+    const liveViews = timeline[timeline.length - 1];
+    check(
+      liveViews.every((v, i) => v !== anchorViews[i]),
+      "every instance advanced past the anchor",
+    );
+
+    // 4. Whole-environment seek: all three rewind at once, each to its own view.
+    await page.evaluate((f) => window.__sim.seek(f), anchor);
+    const rewound = await views();
+    check(
+      JSON.stringify(rewound) === JSON.stringify(anchorViews),
+      "a seek rewinds every instance to its own view of the anchor frame",
+      `got ${JSON.stringify(rewound)}`,
+    );
+    const parked = await page.evaluate(() => window.__sim.timeline());
+    check(parked.scrubPos === anchor, "the sim reports where it is parked", `${parked.scrubPos}`);
+    check(
+      parked.hi > anchor,
+      "the recorded future survives while parked (non-destructive)",
+      `hi=${parked.hi}`,
+    );
+
+    // 5. Stepping on commits the branch and replays the timeline exactly.
+    const replayed = [];
+    for (let i = 0; i < 40; i++) {
+      await page.evaluate(() => window.__sim.step(1));
+      replayed.push(await views());
+    }
+    check(
+      JSON.stringify(replayed) === JSON.stringify(timeline),
+      "replay from a scrub reproduces the original timeline exactly",
+    );
+
+    // Assert on the SIM's own log only, keyed off the runtime's in-band "sim
+    // started" line (console events flush asynchronously, so wall-clock phase
+    // tagging in this process is racy).
+    //
+    // Boot noise is deliberately excluded, and it is NOT this feature's: the
+    // page first boots the project's default entry as an ordinary single game,
+    // and `examples/mp`'s client immediately opens a REAL WebSocket to its
+    // server — which nothing is serving here, so the connection is refused.
+    //
+    // That refusal trips a wasm panic (`RuntimeError: unreachable`) in the
+    // single-game socket path. It is PRE-EXISTING: booting this project on an
+    // unmodified main produces the byte-identical three errors with no sim
+    // involved at all. Tracked separately; deliberately not fixed here so this
+    // change stays reviewable. Once the sim starts, the single game is
+    // suspended and the sim opens no sockets whatsoever.
+    const startedAt = log.findIndex((m) => m.includes("sim started"));
+    check(startedAt >= 0, "the runtime logged the sim starting");
+    const simLog = startedAt >= 0 ? log.slice(startedAt) : log;
+    const errors = simLog.filter((m) => /error|panic|unreachable/i.test(m));
+    check(errors.length === 0, "the sim logs no errors", errors.slice(0, 5).join(" | "));
+
+    // 6. The sim opened no REAL sockets — the whole session crossed the virtual
+    // network only. (Boot-time sockets belong to the single game, before the
+    // sim existed, so compare against the count at start.)
+    const socketsAfter = await page.evaluate(() => window.__socketsOpened);
+    const socketLog = await page.evaluate(() => window.__socketLog);
+    check(
+      socketsAfter === socketsBefore,
+      "the sim opened no real WebSockets",
+      `${socketsBefore} -> ${socketsAfter}; sockets: ${socketLog.join(", ")}`,
+    );
+
+    // 7. Stop tears the sim down and hands the page back.
+    await page.evaluate(() => window.__sim.stop());
+    check((await page.evaluate(() => window.__sim.len())) === 0, "stop tears the sim down");
+    const afterStop = await page.evaluate(() => {
+      try {
+        window.__sim.state(0);
+        return "no error";
+      } catch (e) {
+        return String(e);
+      }
+    });
+    check(
+      afterStop.includes("no simulation is running"),
+      "the exports report cleanly once stopped",
+      afterStop,
+    );
+    if (process.env.SIM_DEBUG) {
+      console.log("\n--- full page log ---");
+      for (const line of log) console.log(`  ${line.replace(/\s+/g, " ").slice(0, 200)}`);
+    }
+  } finally {
+    await browser.close();
+    server.kill("SIGKILL");
+    await waitPortFree(10000);
+  }
+}
+
+console.log(`wasm netsim: ${PROJECT} as ${ENTRIES.join(" + ")}\n`);
+try {
+  await main();
+} catch (e) {
+  failures.push(`harness error: ${e}`);
+  console.log(`  FAIL  harness — ${e}`);
+}
+console.log(
+  failures.length === 0 ? "\nALL CHECKS PASSED" : `\n${failures.length} CHECK(S) FAILED`,
+);
+process.exit(failures.length === 0 ? 0 : 1);

--- a/e2e/wasm-sim.mjs
+++ b/e2e/wasm-sim.mjs
@@ -85,6 +85,9 @@ function cliPath() {
 }
 
 const failures = [];
+// Module-scoped so a harness throw inside main() can still dump what the page
+// said before it failed.
+const pageLog = [];
 function check(ok, label, detail = "") {
   if (ok) {
     console.log(`  PASS  ${label}`);
@@ -98,17 +101,31 @@ async function main() {
   if (!(await waitPortFree(10000))) {
     throw new Error(`:${PORT} is busy — a stale dev server would serve the wrong project`);
   }
-  const server = spawn(cliPath(), ["-d", PROJECT, "run", "wasm"], {
+  // `--no-open`: on a headless runner there is no browser to launch, and
+  // without this the dev server never becomes reachable. Its output is piped
+  // (not ignored) so a failure to start is diagnosable instead of silent.
+  const server = spawn(cliPath(), ["-d", PROJECT, "run", "wasm", "--no-open"], {
     cwd: ROOT,
-    stdio: "ignore",
+    stdio: ["ignore", "pipe", "pipe"],
   });
+  let serverOutput = "";
+  server.stdout.on("data", (d) => (serverOutput += d));
+  server.stderr.on("data", (d) => (serverOutput += d));
+
+  // The same GL flags the wasm-smoke job uses: software rendering that comes up
+  // on any runner, CI included, with no real GPU.
   const browser = await chromium.launch({
-    args: ["--use-gl=swiftshader", "--enable-unsafe-swiftshader"],
+    args: [
+      "--use-gl=angle",
+      "--use-angle=swiftshader",
+      "--enable-unsafe-swiftshader",
+      "--ignore-gpu-blocklist",
+    ],
   });
 
   try {
     const page = await browser.newPage();
-    const log = [];
+    const log = pageLog;
     page.on("console", (m) => log.push(m.text()));
     page.on("pageerror", (e) => log.push(`pageerror: ${e}`));
 
@@ -129,7 +146,20 @@ async function main() {
       Object.assign(window.WebSocket, Real);
     });
 
-    for (let i = 0; i < 120; i++) {
+    // Wait for the dev server to actually be listening, and say so plainly if
+    // it never starts — retrying `goto` blindly turns "the server died" into an
+    // opaque timeout 60s later, which is exactly how this first failed in CI.
+    let up = false;
+    for (let i = 0; i < 60 && !up; i++) {
+      up = await portInUse();
+      if (!up) await sleep(500);
+    }
+    if (!up) {
+      throw new Error(
+        `the dev server never listened on :${PORT}. Its output was:\n${serverOutput || "(none)"}`,
+      );
+    }
+    for (let i = 0; i < 60; i++) {
       try {
         await page.goto(BASE);
         break;
@@ -144,8 +174,15 @@ async function main() {
 
     // Let the single game finish booting FIRST — it opens its own real socket
     // within the first frames, and snapshotting the counter before that would
-    // blame the sim for the single game's connect.
-    await sleep(3000);
+    // blame the sim for the single game's connect. Wait for that socket rather
+    // than a fixed sleep: a slow runner would otherwise push the boot past the
+    // deadline and make the no-real-sockets check flaky in exactly that way.
+    for (let i = 0; i < 40; i++) {
+      if (await page.evaluate(() => window.__socketsOpened > 0)) break;
+      await sleep(250);
+    }
+    // Plus a moment for any follow-on connect to land before the snapshot.
+    await sleep(1000);
 
     // 1. Start the sim: three producers built from this project's own sources.
     const socketsBefore = await page.evaluate(() => window.__socketsOpened);
@@ -294,6 +331,14 @@ try {
 } catch (e) {
   failures.push(`harness error: ${e}`);
   console.log(`  FAIL  harness — ${e}`);
+  // A harness failure with no context is unactionable in CI — dump whatever the
+  // page managed to say before it went wrong.
+  if (pageLog.length) {
+    console.log("\n--- page log ---");
+    for (const line of pageLog.slice(-30)) {
+      console.log(`  ${line.replace(/\s+/g, " ").slice(0, 200)}`);
+    }
+  }
 }
 console.log(
   failures.length === 0 ? "\nALL CHECKS PASSED" : `\n${failures.length} CHECK(S) FAILED`,

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:wasm-golden": "playwright test",
     "test:wasm-golden:update": "playwright test --update-snapshots",
     "test:wasm-smoke": "node e2e/wasm-smoke.mjs",
+    "test:wasm-sim": "node e2e/wasm-sim.mjs",
     "test:wasm-remote-assets": "node e2e/remote-assets.mjs",
     "test:inspector-emit": "node e2e/inspector-emit.mjs",
     "test:scrubber": "node --test runtime/functor-runtime-web/timeline-model.test.js",

--- a/runtime/functor-netsim/src/lib.rs
+++ b/runtime/functor-netsim/src/lib.rs
@@ -174,6 +174,38 @@ pub struct NetSim {
     /// See [`reapply_link_config`](NetSim::reapply_link_config).
     links: HashMap<(InstanceId, InstanceId), LinkProfile>,
     partitioned: std::collections::HashSet<(InstanceId, InstanceId)>,
+    /// The last error [`step`](NetSim::step) swallowed, for drivers that cannot
+    /// see stderr. See [`take_last_error`](NetSim::take_last_error).
+    last_error: Option<String>,
+}
+
+/// The source list for one instance of a multi-entry project: `entry` first —
+/// that is how a producer picks its entry — then every other project file in its
+/// original order.
+///
+/// Every role therefore loads an IDENTICAL module set and differs only in which
+/// file leads, which is exactly what a multi-entry project needs: `file = module`
+/// means the shared `protocol.fun` loads with both ends, and wire constructors
+/// match by canonical module-qualified name, so a per-role copy of the protocol
+/// would silently fail to match.
+///
+/// Errors naming the available files when `entry` isn't one of them — a typo'd
+/// role is otherwise a confusing "no listener" much later.
+pub fn entry_sources(
+    entry: &str,
+    project: &[(String, String)],
+) -> Result<Vec<(String, String)>, String> {
+    if !project.iter().any(|(path, _)| path == entry) {
+        let available: Vec<&str> = project.iter().map(|(p, _)| p.as_str()).collect();
+        return Err(format!(
+            "no project file named '{entry}' — the project has: {}",
+            available.join(", ")
+        ));
+    }
+    let mut sources = Vec::with_capacity(project.len());
+    sources.extend(project.iter().filter(|(p, _)| p == entry).cloned());
+    sources.extend(project.iter().filter(|(p, _)| p != entry).cloned());
+    Ok(sources)
 }
 
 /// An unordered instance pair, so link config is keyed the same either way round.
@@ -197,7 +229,17 @@ impl NetSim {
             scrub_pos: None,
             links: HashMap::new(),
             partitioned: std::collections::HashSet::new(),
+            last_error: None,
         }
+    }
+
+    /// Take the last error a [`step`](Self::step) reported without failing —
+    /// today, a branch commit that could not be honored, which leaves the sim
+    /// parked. `step` cannot return a `Result` without churning every caller,
+    /// and a driver that cannot see stderr (the browser) must not read a step
+    /// that did nothing as a step that worked.
+    pub fn take_last_error(&mut self) -> Option<String> {
+        self.last_error.take()
     }
 
     /// Add an already-constructed in-process [`GameProducer`] (e.g. an
@@ -345,7 +387,12 @@ impl NetSim {
             match self.commit_branch(frame) {
                 Ok(()) => self.scrub_pos = None,
                 Err(e) => {
-                    eprintln!("[netsim] {e} — staying parked on frame {frame}");
+                    // Recorded as well as printed: a driver that cannot see
+                    // stderr (the browser) would otherwise read a step that did
+                    // nothing as a step that succeeded.
+                    let message = format!("{e} — staying parked on frame {frame}");
+                    eprintln!("[netsim] {message}");
+                    self.last_error = Some(message);
                     return;
                 }
             }
@@ -622,5 +669,54 @@ impl NetSim {
             .get(&conn)
             .cloned()
             .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::entry_sources;
+
+    fn project() -> Vec<(String, String)> {
+        vec![
+            ("client.fun".to_string(), "c".to_string()),
+            ("protocol.fun".to_string(), "p".to_string()),
+            ("server.fun".to_string(), "s".to_string()),
+        ]
+    }
+
+    #[test]
+    fn the_chosen_entry_leads_and_every_sibling_follows() {
+        let server = entry_sources("server.fun", &project()).expect("server is a project file");
+        assert_eq!(server[0].0, "server.fun", "the entry must lead the list");
+        assert_eq!(server.len(), 3, "all siblings load with it (file = module)");
+    }
+
+    #[test]
+    fn every_role_loads_an_identical_module_set() {
+        // Only the ORDER differs — which is what lets both ends match the same
+        // `protocol.fun` constructors (they are module-qualified).
+        let mut client: Vec<String> = entry_sources("client.fun", &project())
+            .unwrap()
+            .into_iter()
+            .map(|(p, _)| p)
+            .collect();
+        let mut server: Vec<String> = entry_sources("server.fun", &project())
+            .unwrap()
+            .into_iter()
+            .map(|(p, _)| p)
+            .collect();
+        client.sort();
+        server.sort();
+        assert_eq!(client, server);
+    }
+
+    #[test]
+    fn an_unknown_entry_names_what_the_project_actually_has() {
+        let err = entry_sources("sever.fun", &project()).unwrap_err();
+        assert!(err.contains("no project file named 'sever.fun'"), "{err}");
+        assert!(
+            err.contains("server.fun"),
+            "the typo's intended target is listed: {err}"
+        );
     }
 }

--- a/runtime/functor-runtime-web/Cargo.toml
+++ b/runtime/functor-runtime-web/Cargo.toml
@@ -8,6 +8,10 @@ crate-type = ["cdylib"]
 
 [dependencies]
 functor_runtime_common = { path = "./../functor-runtime-common" }
+# The deterministic multiplayer harness. Platform-free (it drives
+# `Box<dyn GameProducer>` over the virtual network), so it compiles to wasm as
+# is — this is what lets the IDE simulate a whole session in the browser.
+functor-netsim = { path = "./../functor-netsim" }
 functor-prelude = { path = "../../functor-prelude" }
 # The Functor Lang language, for the in-runtime interpreter producer (docs/functor-lang.md C5).
 functor-lang = { path = "../../functor-lang" }

--- a/runtime/functor-runtime-web/index-functor-lang.html
+++ b/runtime/functor-runtime-web/index-functor-lang.html
@@ -60,6 +60,13 @@
         functor_lang_webview_gen,
         functor_lang_webview_click,
         functor_lang_webview_input,
+        functorLangStartSim,
+        functorLangSimStep,
+        functorLangSimState,
+        functorLangSimTimeline,
+        functorLangSimSeek,
+        functorLangSimLen,
+        functorLangStopSim,
       } from "./pkg/functor_runtime_web.js";
       // The time-travel scrubber is the shared component, served next to pkg/
       // by the dev server (see runtime/functor-runtime-web/scrubber.js). It
@@ -357,7 +364,30 @@
         });
       };
 
+      // The multiplayer netsim seam, mirroring `window.__scrub`: several game
+      // instances (a server + N clients from one multi-entry project) stepped
+      // over a virtual network in this page, scrubbable as ONE environment.
+      // Exposed on `window` so the IDE — and `e2e/wasm-sim.mjs` — can drive it
+      // without importing the module themselves. No sockets are opened: the sim
+      // routes the games' own connect/send commands internally.
+      //
+      // Installed INSIDE init().then() — these wrappers call straight into wasm,
+      // so publishing them earlier would let a caller (or a test waiting on
+      // `window.__sim`) invoke an uninitialized module.
+      const installSim = () => {
+        window.__sim = {
+          start: (entries, seed = 1) => functorLangStartSim(entries, seed),
+          step: (frames = 1) => functorLangSimStep(frames),
+          state: (id) => functorLangSimState(id),
+          timeline: () => functorLangSimTimeline(),
+          seek: (frame) => functorLangSimSeek(frame),
+          len: () => functorLangSimLen(),
+          stop: () => functorLangStopSim(),
+        };
+      };
+
       init().then(() => {
+        installSim();
         // In a deterministic capture (?fixed-time), don't wire up input — a
         // stray mouse move would turn the camera, like on native.
         const deterministic = new URLSearchParams(window.location.search).has("fixed-time");

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -26,6 +26,7 @@ use wasm_bindgen_futures::{spawn_local, JsFuture};
 use wasm_bindgen::prelude::*;
 
 mod functor_lang_game;
+mod sim;
 use functor_lang_game::WebPlatform;
 
 fn window() -> web_sys::Window {
@@ -185,11 +186,20 @@ fn parse_project_files(value: &JsValue) -> Option<Vec<(String, String)>> {
 /// rendered strings (fetch status, parse/load position, contract violation) for
 /// `run_async` to fail loud with.
 async fn create_functor_lang_game(entry: &str) -> Result<FunctorLangEmbeddedGame, String> {
+    let sources = load_project_sources(entry).await?;
+    FunctorLangEmbeddedGame::create(sources, Box::new(WebPlatform::new()))
+}
+
+/// The project's `(path, source)` pairs, however this page supplies them —
+/// in-memory or fetched. Split out from [`create_functor_lang_game`] because the
+/// netsim (`sim.rs`) needs the same sources to build SEVERAL producers from,
+/// one per role, without fetching the project once per instance.
+pub(crate) async fn load_project_sources(entry: &str) -> Result<Vec<(String, String)>, String> {
     // A page that already holds every source in memory (the IDE's
     // `?project=inline` boot) injects them directly — nothing to fetch, and
     // module names come from the given paths exactly as in the fetch path.
     if let Some(sources) = functor_lang_project_sources() {
-        return FunctorLangEmbeddedGame::create(sources, Box::new(WebPlatform::new()));
+        return Ok(sources);
     }
     // The CLI injects the whole project file list; a page that set only the
     // entry (or none) falls back to loading the entry alone.
@@ -207,7 +217,7 @@ async fn create_functor_lang_game(entry: &str) -> Result<FunctorLangEmbeddedGame
         }
         sources.push((path.clone(), src));
     }
-    FunctorLangEmbeddedGame::create(sources, Box::new(WebPlatform::new()))
+    Ok(sources)
 }
 
 thread_local! {
@@ -359,6 +369,15 @@ pub fn functor_lang_set_project(files: JsValue, id: Option<f64>) {
 /// in a socket-event microtask, never mid-frame, so the borrow can't collide
 /// with the frame loop.
 fn with_live_game(f: impl FnOnce(&mut dyn GameProducer)) {
+    // A running netsim suspends the single game, and that has to include its
+    // ASYNC arrivals: sockets opened before the sim started stay open, and an
+    // inbound message here would fold through `update` and queue effects onto
+    // the queues the sim instances share (the sim would then attribute them to
+    // instance 0). Drop them — the single game is not simulating, so it has no
+    // frame to receive them into.
+    if sim::is_running() {
+        return;
+    }
     let Some(game) = GAME.with(|g| g.borrow().clone()) else {
         return;
     };
@@ -1280,10 +1299,17 @@ async fn run_async() -> Result<(), JsValue> {
             // frame (a paused frame's input would diverge the replay log; a
             // fixed-time frame must stay deterministic for captures), and
             // draining stops the queue bursting on resume.
+            // A running netsim suspends the single game the same way a pinned
+            // clock does — drain-and-DISCARD. Delivering input here would fold
+            // it through the single game's `update`, whose effects land on the
+            // queues the sim instances share, and the sim's next step would
+            // attribute that stray `Effect.send` to instance 0. Typing in a
+            // suspended game must not inject packets into the simulation.
+            let suspended = clock.is_pinned() || sim::is_running();
             functor_lang_game::drain_input(
                 &mut **game,
                 &mut input_snapshot,
-                !clock.is_pinned(),
+                !suspended,
                 clock.is_paused() && !clock.is_fixed_time(),
             );
 
@@ -1293,40 +1319,55 @@ async fn run_async() -> Result<(), JsValue> {
             // render's table, not this frame's. Pinned frames drain-and-drop
             // like all input. [xreview]
             for event in functor_lang_game::take_webview_events() {
-                if !clock.is_pinned() {
+                if !suspended {
                     game.webview_event(event);
                 }
             }
 
-            // The loading snapshot for `Sub.assets`: pushed every frame, the
-            // producer only acts when it changed since the game last saw it.
-            game.push_asset_progress(asset_cache.progress());
+            // While a netsim owns the page (`sim.rs`), the single game is
+            // SUSPENDED: it neither ticks nor dispatches. Producers share this
+            // thread's command queues (net/conn/audio/preload), and each drain
+            // empties the queue for everyone — so a live single game would steal
+            // the sim instances' commands and dispatch them to REAL sockets,
+            // while the sim would swallow the single game's.
+            //
+            // Its MODEL is frozen (no tick, no input, no delivered socket
+            // events — see `with_live_game`); it does keep rendering that frozen
+            // model, so a `tts`-driven animation in `draw` still moves. Freezing
+            // the clock too belongs with the multi-pane view, where the sim owns
+            // the viewport and the single game stops rendering entirely.
+            if !sim::is_running() {
+                // The loading snapshot for `Sub.assets`: pushed every frame, the
+                // producer only acts when it changed since the game last saw it.
+                // Inside the gate — it reaches `update`, so it queues effects.
+                game.push_asset_progress(asset_cache.progress());
 
-            // Effect.preload (B.5): warm the cache with this frame's queued
-            // preloads and drive in-flight ones to settlement. Unlike audio
-            // finishes (undetectable on Web Audio today), preload settlement
-            // comes from the driver's own polling — preloadThen works on wasm.
-            let preload_commands =
-                serde_json::from_str(&game.preload_drain_commands()).unwrap_or_default();
-            for token in scene_context.drive_preloads(&asset_cache, preload_commands) {
-                game.preload_push_settled(token);
-            }
-
-            for sub in &sub_frames {
-                if game.samples_input() {
-                    game.sampled_input(&input_snapshot);
+                // Effect.preload (B.5): warm the cache with this frame's queued
+                // preloads and drive in-flight ones to settlement. Unlike audio
+                // finishes (undetectable on Web Audio today), preload settlement
+                // comes from the driver's own polling — preloadThen works on wasm.
+                let preload_commands =
+                    serde_json::from_str(&game.preload_drain_commands()).unwrap_or_default();
+                for token in scene_context.drive_preloads(&asset_cache, preload_commands) {
+                    game.preload_push_settled(token);
                 }
-                game.tick(sub.clone());
-            }
 
-            // Perform any networking commands this frame's tick queued; results
-            // are pushed back into the inbox asynchronously and decoded by a later
-            // tick (see dispatch_net_commands).
-            dispatch_net_commands(&**game);
-            // Play any one-shot sounds this frame's tick queued (fetch + decode
-            // the first time, then from the cache).
-            dispatch_audio_commands(&**game);
-            dispatch_conn_commands(&**game, &ws_state);
+                for sub in &sub_frames {
+                    if game.samples_input() {
+                        game.sampled_input(&input_snapshot);
+                    }
+                    game.tick(sub.clone());
+                }
+
+                // Perform any networking commands this frame's tick queued; results
+                // are pushed back into the inbox asynchronously and decoded by a later
+                // tick (see dispatch_net_commands).
+                dispatch_net_commands(&**game);
+                // Play any one-shot sounds this frame's tick queued (fetch + decode
+                // the first time, then from the cache).
+                dispatch_audio_commands(&**game);
+                dispatch_conn_commands(&**game, &ws_state);
+            }
 
             let mut frame: Frame = game.render(frame_time.clone());
 
@@ -1578,7 +1619,9 @@ async fn run_async() -> Result<(), JsValue> {
                 &view,
             );
             functor_lang_game::set_ui_wants_keyboard(ui_out.wants_keyboard);
-            if !clock.is_pinned() {
+            // `suspended`, not just pinned: a UI event reaches `update` too, so a
+            // running sim must swallow it like every other input path.
+            if !suspended {
                 for event in ui_out.events {
                     game.ui_event(event);
                 }

--- a/runtime/functor-runtime-web/src/sim.rs
+++ b/runtime/functor-runtime-web/src/sim.rs
@@ -1,0 +1,281 @@
+//! The deterministic multiplayer netsim, hosted in the browser.
+//!
+//! Natively the netsim is a test harness; on the web it is the substance of
+//! **simulating a whole multiplayer session inside the IDE** — several clients
+//! and a server running side by side, over a virtual network, scrubbable as one
+//! environment. This module is the first half of that: it builds N producers
+//! from the project's own entries, steps them through a [`NetSim`], and exposes
+//! the sim's state and its whole-environment seek to JavaScript. Rendering the
+//! instances into panes comes next and builds on exactly these exports.
+//!
+//! Two properties make this cheap rather than a port:
+//!
+//! - `functor-netsim` is platform-free — it drives `Box<dyn GameProducer>` over
+//!   the shared `VirtualNet`, so it compiles to wasm32 untouched (its desktop
+//!   dependency is dev-only).
+//! - the web runtime already runs the SHARED `FunctorLangEmbeddedGame` behind a
+//!   `WebPlatform` seam, so an instance here is the same producer the single-game
+//!   path uses — built once per role, with that role's entry hoisted to the front
+//!   of the shared file set (`file = module`: every sibling loads with it, which
+//!   is exactly how a multi-entry project shares its `protocol.fun`).
+//!
+//! **No real sockets are opened.** A producer's `Sub.connect`/`Sub.listen`/
+//! `Effect.send` become commands on the shared queue; the single-game frame loop
+//! dispatches those to `web_sys::WebSocket`, but here the sim drains them itself
+//! and routes them through the virtual network instead. That is the same seam
+//! the native harness uses, and it is why the sim is deterministic.
+
+use std::cell::RefCell;
+
+use functor_netsim::NetSim;
+use functor_runtime_common::functor_lang_game_embedded::FunctorLangEmbeddedGame;
+use wasm_bindgen::prelude::*;
+
+use crate::functor_lang_game::WebPlatform;
+
+thread_local! {
+    /// The live sim, if one has been started. Single-threaded by construction on
+    /// wasm, which is also what makes the producers' shared net-command queue
+    /// safe to drain per instance here (the native harness has to serialize its
+    /// tests for exactly this reason).
+    static SIM: RefCell<Option<NetSim>> = const { RefCell::new(None) };
+
+    /// A `start_sim` is between its first await and installing its sim. Guards
+    /// against two overlapping starts clobbering each other.
+    static STARTING: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// Upper bound on frames per [`sim_step`] call. A simulation step runs real game
+/// code with no yield point, so an unbounded count would wedge the tab with no
+/// way back — the same reason the effect broker caps its drain.
+const MAX_STEP_FRAMES: u32 = 10_000;
+
+/// Build every instance. Fallible and side-effect-free with respect to the
+/// shared queues, so a failure leaves the page exactly as it was.
+async fn build_sim(entries: &[String], seed: u64) -> Result<NetSim, JsValue> {
+    // Fetch the project's sources ONCE and reuse them for every instance: the
+    // roles differ only in which file leads the list.
+    let project = crate::load_project_sources(&entries[0])
+        .await
+        .map_err(|e| JsValue::from_str(&e))?;
+
+    let mut sim = NetSim::new(seed);
+    for entry in entries {
+        let sources = functor_netsim::entry_sources(entry, &project)
+            .map_err(|e| JsValue::from_str(&format!("sim: {e}")))?;
+        let producer = FunctorLangEmbeddedGame::create(sources, Box::new(WebPlatform::new()))
+            .map_err(|e| JsValue::from_str(&format!("sim: cannot load '{entry}': {e}")))?;
+        sim.add_producer(Box::new(producer));
+    }
+    Ok(sim)
+}
+
+/// Is a simulation running? The single-game frame loop asks each frame: while a
+/// sim owns the page the single game is suspended, because producers share this
+/// thread's command queues and each drain empties them for everyone (see the
+/// call site in `lib.rs`).
+pub(crate) fn is_running() -> bool {
+    SIM.with(|sim| sim.borrow().is_some())
+}
+
+/// Run `f` against the live sim, or return a uniform "no sim" error.
+///
+/// `try_borrow_mut`, not `borrow_mut`: the borrow is held across arbitrary
+/// producer execution, and a page that wraps `console` could in principle
+/// re-enter a `__sim` export from a producer's log call. A panic in wasm
+/// aborts with no unwind, which would leave the borrow flag set and the
+/// runtime permanently wedged — a plain error is strictly better.
+fn with_sim<T>(op: &str, f: impl FnOnce(&mut NetSim) -> Result<T, String>) -> Result<T, String> {
+    SIM.with(|sim| {
+        let Ok(mut slot) = sim.try_borrow_mut() else {
+            return Err(format!("{op}: the simulation is busy (re-entered)"));
+        };
+        match slot.as_mut() {
+            Some(sim) => f(sim),
+            None => Err(format!(
+                "{op}: no simulation is running — call functorLangStartSim first"
+            )),
+        }
+    })
+}
+
+/// Clear EVERY shared command queue this thread's producers write to.
+///
+/// The sim routes conn commands itself, but a game can also queue HTTP
+/// (`Effect.httpGet`), audio (`Effect.play`), and preload commands — and
+/// `NetSim::step` drains none of those. Left behind, they are performed FOR REAL
+/// by whichever frame loop drains next: after `stop_sim` the resumed single game
+/// would fire the sim instances' HTTP requests and play their sounds, then push
+/// the completions into its own `update` where those taggers are meaningless.
+///
+/// So both the sim's start and its stop clear all four. Note the consequence,
+/// which is deliberate for now: a simulated game's non-network effects are
+/// DROPPED rather than performed — the sim models the network, not the browser.
+fn clear_shared_command_queues() {
+    let _ = functor_runtime_common::net::drain_conn_commands();
+    let _ = functor_runtime_common::net::drain_commands();
+    let _ = functor_runtime_common::audio::drain_commands();
+    let _ = functor_runtime_common::asset::preload::drain_commands();
+}
+
+/// Start a simulation: one instance per entry in `entries`, all sharing the
+/// project's files, wired through a seeded virtual network.
+///
+/// `entries` is an array of project-relative `.fun` paths — one per instance,
+/// repeated for repeated roles (`["server.fun", "client.fun", "client.fun"]` is
+/// a server and two clients). Every instance must be created before the sim
+/// steps, so this builds them all up front.
+///
+/// Replaces any previous sim on success; on failure (an unknown entry, a load
+/// error) the previous one is left running and nothing is torn down.
+#[wasm_bindgen(js_name = functorLangStartSim)]
+pub async fn start_sim(entries: JsValue, seed: f64) -> Result<usize, JsValue> {
+    let array = js_sys::Array::from(&entries);
+    if !js_sys::Array::is_array(&entries) {
+        return Err(JsValue::from_str(
+            "sim: entries must be an ARRAY of project .fun paths — a bare string \
+             would be iterated character by character",
+        ));
+    }
+    let mut parsed: Vec<String> = Vec::with_capacity(array.length() as usize);
+    for (i, value) in array.iter().enumerate() {
+        let Some(entry) = value.as_string() else {
+            return Err(JsValue::from_str(&format!(
+                "sim: entry {i} is not a string — every instance needs a project \
+                 .fun path"
+            )));
+        };
+        parsed.push(entry);
+    }
+    let entries = parsed;
+    if entries.is_empty() {
+        return Err(JsValue::from_str(
+            "sim: no entries given — pass one project .fun path per instance, \
+             e.g. [\"server.fun\", \"client.fun\", \"client.fun\"]",
+        ));
+    }
+
+    // Reject a second concurrent start: both would await the fetch, both would
+    // build producers, and the loser's instances would be dropped after it had
+    // already cleared the shared queues.
+    if STARTING.with(|s| s.replace(true)) {
+        return Err(JsValue::from_str(
+            "sim: a simulation is already starting — await that call first",
+        ));
+    }
+    let result = build_sim(&entries, seed as u64).await;
+    STARTING.with(|s| s.set(false));
+    let sim = result?;
+
+    // Everything is built and can no longer fail, so it is now safe to disturb
+    // shared state: clear the queues (including anything the producers'
+    // construction queued, which would otherwise be drained by instance 0 on the
+    // first step) and install the sim.
+    let count = sim.len();
+    clear_shared_command_queues();
+    SIM.with(|slot| *slot.borrow_mut() = Some(sim));
+    log::info!(
+        "[functor-lang] sim started: {count} instances ({})",
+        entries.join(", ")
+    );
+    Ok(count)
+}
+
+/// Advance the simulation by `frames` lockstep frames.
+///
+/// Surfaces a failed branch commit (stepping on from a scrub whose frame the
+/// producers can no longer restore) as an error rather than stepping silently
+/// nowhere.
+#[wasm_bindgen(js_name = functorLangSimStep)]
+pub fn sim_step(frames: u32) -> Result<(), JsValue> {
+    if frames > MAX_STEP_FRAMES {
+        return Err(JsValue::from_str(&format!(
+            "step: {frames} frames at once would wedge the page — step at most \
+             {MAX_STEP_FRAMES}, in chunks"
+        )));
+    }
+    with_sim("step", |sim| {
+        sim.step_n(frames as usize);
+        match sim.take_last_error() {
+            Some(e) => Err(format!("step: {e}")),
+            None => Ok(()),
+        }
+    })
+    .map_err(|e| JsValue::from_str(&e))
+}
+
+/// Number of instances in the running sim (0 when none is running).
+#[wasm_bindgen(js_name = functorLangSimLen)]
+pub fn sim_len() -> usize {
+    SIM.with(|sim| sim.borrow().as_ref().map(|s| s.len()).unwrap_or(0))
+}
+
+/// One instance's model, pretty-printed. Free-form text for display and
+/// assertions — callers must not parse it (see `protocol::GameProducer`).
+#[wasm_bindgen(js_name = functorLangSimState)]
+pub fn sim_state(id: usize) -> Result<String, JsValue> {
+    with_sim("state", |sim| {
+        if id >= sim.len() {
+            return Err(format!(
+                "state: no instance {id} — the sim has {}",
+                sim.len()
+            ));
+        }
+        Ok(sim.state(id))
+    })
+    .map_err(|e| JsValue::from_str(&e))
+}
+
+/// The live frame count, the frames a seek can reach, and where a seek is
+/// currently parked — as `{frame, lo, hi, scrubPos}`, the shape a timeline UI
+/// needs in one call. `lo`/`hi` are `null` before the first step.
+#[wasm_bindgen(js_name = functorLangSimTimeline)]
+pub fn sim_timeline() -> Result<JsValue, JsValue> {
+    with_sim("timeline", |sim| {
+        let obj = js_sys::Object::new();
+        let set = |key: &str, value: JsValue| {
+            let _ = js_sys::Reflect::set(&obj, &JsValue::from_str(key), &value);
+        };
+        set("frame", JsValue::from_f64(sim.frame() as f64));
+        match sim.frame_range() {
+            Some((lo, hi)) => {
+                set("lo", JsValue::from_f64(lo as f64));
+                set("hi", JsValue::from_f64(hi as f64));
+            }
+            None => {
+                set("lo", JsValue::NULL);
+                set("hi", JsValue::NULL);
+            }
+        }
+        set(
+            "scrubPos",
+            match sim.scrub_pos() {
+                Some(f) => JsValue::from_f64(f as f64),
+                None => JsValue::NULL,
+            },
+        );
+        Ok(obj.into())
+    })
+    .map_err(|e| JsValue::from_str(&e))
+}
+
+/// **Whole-environment seek**: park every instance AND the virtual network on
+/// `frame`, so each pane shows its own view of that moment and the packets that
+/// were in flight between them are in flight again.
+///
+/// Non-destructive while parked — the recorded future survives, so a timeline UI
+/// can drag freely. The next [`sim_step`] commits the branch.
+#[wasm_bindgen(js_name = functorLangSimSeek)]
+pub fn sim_seek(frame: u32) -> Result<String, JsValue> {
+    with_sim("seek", |sim| sim.seek(frame as u64)).map_err(|e| JsValue::from_str(&e))
+}
+
+/// Tear down the running sim (freeing its producers), if any, and resume the
+/// single game. Every shared queue is cleared with it, so the resumed game
+/// inherits none of the instances' pending commands — otherwise it would perform
+/// their HTTP requests and play their sounds as if they were its own.
+#[wasm_bindgen(js_name = functorLangStopSim)]
+pub fn stop_sim() {
+    SIM.with(|sim| *sim.borrow_mut() = None);
+    clear_shared_command_queues();
+}


### PR DESCRIPTION
Hosts the deterministic netsim inside the **wasm runtime**: a whole multiplayer
session — an authoritative server and N clients from one multi-entry project —
simulated in a single page, with the whole-environment seek from #472.

This is the core half of *simulating multiplayer inside the VSCode and browser
IDEs*. Multi-pane rendering (client panes + server output) builds directly on
these exports and is the next PR; nothing here touches the renderer.

## Why it's small

Two gaps the plan assumed turned out not to exist:

- **`functor-netsim` compiles to wasm32 untouched** — it drives
  `Box<dyn GameProducer>` over the shared `VirtualNet`, and its desktop
  dependency is dev-only.
- **The web runtime already runs the shared `FunctorLangEmbeddedGame`** behind a
  `WebPlatform` seam, so an instance here is the same producer the single-game
  path uses. Each role is built from the same fetched project sources with its
  own entry hoisted to the front (`functor_netsim::entry_sources` — a producer
  picks its entry as `sources.first()`), so `file = module` gives every role an
  identical module set and the shared `protocol.fun` matches on both ends.

**No real sockets.** The instances' own `Sub.connect`/`Effect.send` commands are
routed through the virtual network rather than the real dispatcher — asserted by
instrumenting `window.WebSocket` in the e2e, not merely by construction.

## The hazard this had to solve

Producers share this thread's command queues (net / conn / audio / preload), and
**each drain empties them for everyone**. A live single game would steal the sim
instances' commands and dispatch them to real WebSockets; the sim would swallow
the single game's.

So while a sim runs the single game is **suspended** — and that had to mean more
than "doesn't tick". Input, UI events, webview events, and async socket/HTTP
completions all reach `update` and queue effects, so all of them are gated too
(drain-and-discard, reusing the discipline the pinned clock already uses). Its
model is frozen; it does keep rendering that frozen model, so a `tts`-driven
animation in `draw` still moves — freezing the clock belongs with the multi-pane
view, where the single game stops rendering entirely.

## Verification

`npm run test:wasm-sim` — 14 checks in headless Chromium (swiftshader):

- three instances of `examples/mp` load and step in one page;
- both clients converge on the server's authoritative world;
- a whole-environment seek rewinds every instance to its **own** view of the
  anchor frame, non-destructively;
- stepping on commits the branch and replays the original timeline exactly;
- the sim opens **no real WebSockets**;
- malformed entries are rejected, and `stop` tears down cleanly.

Plus the existing suites: 12 netsim tests, 441 `functor_runtime_common`, strict
build clean, wasm warning count unchanged (24, all pre-existing).

## Review dispositions (`/xreview` — Claude subagent + Codex)

Both engines agreed on two **High** findings, both fixed:

1. **Suspension was incomplete.** Only tick/dispatch were gated; `drain_input`,
   webview events, `ui_event`, and `with_live_game` (async socket/HTTP arrivals)
   still ran single-game code, whose effects land on the shared queue — where
   the sim's next step attributes them to instance 0. Typing in a suspended game
   could inject packets into the simulation.
2. **Only the conn queue was cleared.** Sim instances also push HTTP, audio, and
   preload commands, which `NetSim::step` never drains. They accumulated, and
   after `stop` the resumed single game would perform them **for real** and push
   completions into its own `update`, where those taggers are meaningless. All
   four queues are now cleared at start and stop, with the deliberate
   consequence documented: a simulated game's non-network effects are dropped —
   the sim models the network, not the browser.

Also fixed: `start_sim` is transactional (build everything before disturbing
shared state) and rejects concurrent starts; a failed branch commit is surfaced
instead of stepping silently nowhere (`NetSim::take_last_error` — a browser
driver can't see stderr); `window.__sim` is installed inside `init().then()`
rather than before it; `entries` is validated (a bare string was being iterated
character by character into 12 entries); and frames-per-step is capped so one
call can't wedge the tab.

**Stated gaps rather than papered over.** The e2e runs on perfect links, so it
doesn't exercise the restore-packets-mid-flight case — the native `scrub` suite
covers that under impaired links, and link impairment isn't exposed to JS until
the IDE's latency knobs. And it does *not* verify the suspension gates: that
needs a live single game to poke, and booting this project trips the
pre-existing panic below, which may already have killed it — so such an
assertion could pass vacuously.

## A pre-existing bug, proven not assumed

Booting `examples/mp` in the browser logs a JS `TypeError` and
`RuntimeError: unreachable` — **a Rust panic in wasm** — because its client opens
a real WebSocket to a server nothing is serving and the refusal traps.

Confirmed pre-existing by stashing this entire change, rebuilding the CLI from
clean `main`, and running a boot-only probe with no sim in the page: the
byte-identical three errors. Deliberately not fixed here. It matters for what
comes next — a not-yet-started server is the *normal* state in an IDE, so this
will fire constantly once multiplayer lands in the browser; the web runtime also
appears to lack `console_error_panic_hook`, so it surfaces as a bare
`unreachable` with no message. Tracked for its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)