### PR TITLE
fix(wasm): a refused WebSocket no longer traps the runtime

### DIFF
--- a/e2e/wasm-sim.mjs
+++ b/e2e/wasm-sim.mjs
@@ -26,13 +26,14 @@
 // suite covers that under impaired links, and link impairment is not exposed to
 // JS yet (it arrives with the IDE's latency knobs).
 //
-// Known gap, stated rather than papered over: this does NOT verify that the
-// single game is suspended while the sim runs. Doing that needs a live single
-// game to poke, and booting this project trips the pre-existing refused-socket
-// panic below — which may already have killed it, so a "suspension works"
-// assertion here could pass vacuously. The suspension gates are covered by
-// construction and review; a real test wants a project whose default entry opens
-// no socket, which is worth building when the panic is fixed. [xreview]
+// It also verifies the SUSPENSION invariant the design rests on: while a sim
+// owns the page the single game must stop simulating, or the two contend for the
+// thread's shared command queues. `window.__scrub.frame()` advances only when
+// the single game ticks, so it is the observable — and the test first asserts
+// the single game is genuinely RUNNING, without which "it stopped" would pass
+// vacuously. (That vacuity was real until the refused-socket panic was fixed:
+// booting this project used to trap the runtime, so there was nothing alive to
+// suspend.) [xreview]
 //
 // Run manually (owns its own server on :8080):
 //
@@ -184,6 +185,33 @@ async function main() {
     // Plus a moment for any follow-on connect to land before the snapshot.
     await sleep(1000);
 
+    // The single game must be ALIVE before we claim the sim suspends it —
+    // otherwise every assertion below passes for the wrong reason.
+    const singleFrame = () => page.evaluate(() => window.__scrub?.frame() ?? null);
+    // Wait in RENDER FRAMES, not wall-clock: the thing under test is whether the
+    // game ticks, and a slow runner would make a fixed sleep flaky in both
+    // directions (a false "not advancing", or a suspension "proved" without a
+    // single render opportunity). [xreview]
+    const waitRenderFrames = (n) =>
+      page.evaluate(
+        (count) =>
+          new Promise((resolve) => {
+            let seen = 0;
+            const tick = () => (++seen >= count ? resolve() : requestAnimationFrame(tick));
+            requestAnimationFrame(tick);
+          }),
+        n,
+      );
+
+    const frameA = await singleFrame();
+    await waitRenderFrames(20);
+    const frameB = await singleFrame();
+    check(
+      frameA !== null && frameB !== null && frameB > frameA,
+      "the single game is running before the sim starts",
+      `frames ${frameA} -> ${frameB}`,
+    );
+
     // 1. Start the sim: three producers built from this project's own sources.
     const socketsBefore = await page.evaluate(() => window.__socketsOpened);
     const count = await page.evaluate((entries) => window.__sim.start(entries, 1), ENTRIES);
@@ -270,22 +298,19 @@ async function main() {
     // started" line (console events flush asynchronously, so wall-clock phase
     // tagging in this process is racy).
     //
-    // Boot noise is deliberately excluded, and it is NOT this feature's: the
-    // page first boots the project's default entry as an ordinary single game,
-    // and `examples/mp`'s client immediately opens a REAL WebSocket to its
-    // server — which nothing is serving here, so the connection is refused.
-    //
-    // That refusal trips a wasm panic (`RuntimeError: unreachable`) in the
-    // single-game socket path. It is PRE-EXISTING: booting this project on an
-    // unmodified main produces the byte-identical three errors with no sim
-    // involved at all. Tracked separately; deliberately not fixed here so this
-    // change stays reviewable. Once the sim starts, the single game is
-    // suspended and the sim opens no sockets whatsoever.
+    // Boot is now expected to be CLEAN, which is a regression test in itself:
+    // `examples/mp`'s client opens a real WebSocket to a server nothing is
+    // serving, and that refusal used to trap the whole wasm runtime
+    // (`RuntimeError: unreachable`, preceded by a TypeError from the glue
+    // reading `message` off a plain `Event`). The only line the page may still
+    // print is Chrome's own ERR_CONNECTION_REFUSED, which is the browser
+    // reporting a genuinely absent server and is not ours to silence.
     const startedAt = log.findIndex((m) => m.includes("sim started"));
     check(startedAt >= 0, "the runtime logged the sim starting");
     const simLog = startedAt >= 0 ? log.slice(startedAt) : log;
     const errors = simLog.filter((m) => /error|panic|unreachable/i.test(m));
     check(errors.length === 0, "the sim logs no errors", errors.slice(0, 5).join(" | "));
+
 
     // 6. The sim opened no REAL sockets — the whole session crossed the virtual
     // network only. (Boot-time sockets belong to the single game, before the
@@ -298,7 +323,22 @@ async function main() {
       `${socketsBefore} -> ${socketsAfter}; sockets: ${socketLog.join(", ")}`,
     );
 
-    // 7. Stop tears the sim down and hands the page back.
+    // 7. The single game is SUSPENDED while the sim owns the page: its scene
+    // frame stops advancing, because it no longer ticks. This is the invariant
+    // that keeps the two from contending for the shared command queues.
+    const suspendedA = await singleFrame();
+    await waitRenderFrames(20);
+    const suspendedB = await singleFrame();
+    check(
+      // `!== null` guards the vacuity this check exists to prevent: if the
+      // scrubber seam vanished, `null === null` would report a suspension that
+      // was really an absence. [xreview]
+      suspendedA !== null && suspendedA === suspendedB,
+      "the single game is suspended while the sim runs",
+      `frames ${suspendedA} -> ${suspendedB}`,
+    );
+
+    // 8. Stop tears the sim down and hands the page back.
     await page.evaluate(() => window.__sim.stop());
     check((await page.evaluate(() => window.__sim.len())) === 0, "stop tears the sim down");
     const afterStop = await page.evaluate(() => {
@@ -313,6 +353,28 @@ async function main() {
       afterStop.includes("no simulation is running"),
       "the exports report cleanly once stopped",
       afterStop,
+    );
+
+    // 9. ...and the single game resumes simulating once it has the page back.
+    const resumedA = await singleFrame();
+    await waitRenderFrames(20);
+    const resumedB = await singleFrame();
+    check(
+      resumedA !== null && resumedB > resumedA,
+      "the single game resumes after the sim stops",
+      `frames ${resumedA} -> ${resumedB}`,
+    );
+
+    // 10. LAST, so it covers everything above — boot, the sim, suspension,
+    // stop, and resume. Nothing in the page's life may trap the runtime; a
+    // refused socket used to. Give any straggling error event a turn to be
+    // delivered before reading the log. [xreview]
+    await waitRenderFrames(5);
+    const traps = log.filter((m) => /unreachable|panic|TypeError/i.test(m));
+    check(
+      traps.length === 0,
+      "no wasm trap or JS type error, anywhere in the run",
+      traps.slice(0, 3).join(" | "),
     );
     if (process.env.SIM_DEBUG) {
       console.log("\n--- full page log ---");

--- a/runtime/functor-runtime-web/Cargo.toml
+++ b/runtime/functor-runtime-web/Cargo.toml
@@ -26,7 +26,7 @@ log = "0.4"
 
 [dependencies.web-sys]
 version = "0.3.4"
-features = ['Blob', 'HtmlCanvasElement', 'WebGl2RenderingContext', 'WebGlContextAttributes', 'WebGlPowerPreference', 'console', 'Window', 'Location', 'Performance', 'PerformanceTiming', 'Document', 'Element', 'Node', 'HtmlElement', 'Request', 'RequestInit', 'RequestCache', 'Response', 'Headers', 'AudioContext', 'BaseAudioContext', 'AudioBuffer', 'AudioBufferSourceNode', 'AudioDestinationNode', 'AudioNode', 'AudioParam', 'GainNode', 'StereoPannerNode', 'WebSocket', 'MessageEvent', 'CloseEvent', 'ErrorEvent']
+features = ['Blob', 'HtmlCanvasElement', 'WebGl2RenderingContext', 'WebGlContextAttributes', 'WebGlPowerPreference', 'console', 'Window', 'Location', 'Performance', 'PerformanceTiming', 'Document', 'Element', 'Node', 'HtmlElement', 'Request', 'RequestInit', 'RequestCache', 'Response', 'Headers', 'AudioContext', 'BaseAudioContext', 'AudioBuffer', 'AudioBufferSourceNode', 'AudioDestinationNode', 'AudioNode', 'AudioParam', 'GainNode', 'StereoPannerNode', 'WebSocket', 'MessageEvent', 'CloseEvent', 'Event']
 
 [profile.release]
 codegen-units = 1

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -969,7 +969,16 @@ fn ws_connect(state: &Rc<RefCell<WsClient>>, key: String, url: String) {
         let state = state.clone();
         Closure::<dyn FnMut(web_sys::CloseEvent)>::new(move |_e: web_sys::CloseEvent| {
             with_live_game(|g| g.net_push_disconnected(key.clone(), iid));
-            // Drop our handle so a still-declared Sub.connect reconnects next frame.
+            // Drop our handle so the key is free to be opened again.
+            //
+            // NB it will not be, today: `reconcile_connections` only emits a
+            // `Connect` for a key ABSENT from the producer's `live_conn_keys`,
+            // and that set is re-seeded from the declared subs every frame — so
+            // a still-declared `Sub.connect` never re-fires and a dropped
+            // connection stays down. (This comment used to claim the reconnect
+            // happened.) Reconnect/backoff is its own change: the shell would
+            // have to retract the key from the producer's live set here.
+            // [xreview]
             let mut s = state.borrow_mut();
             s.conns.remove(&id);
             s.by_key.remove(&key);
@@ -980,8 +989,18 @@ fn ws_connect(state: &Rc<RefCell<WsClient>>, key: String, url: String) {
 
     let on_error = {
         let key = key.clone();
-        Closure::<dyn FnMut(web_sys::ErrorEvent)>::new(move |e: web_sys::ErrorEvent| {
-            with_live_game(|g| g.net_push_conn_error(key.clone(), iid, e.message()));
+        // A WebSocket's `error` event is a PLAIN `Event`, not an `ErrorEvent` —
+        // it carries no `message`. Typing it as `ErrorEvent` and calling
+        // `.message()` made the generated glue read `length` off `undefined`,
+        // throwing a JS TypeError and then TRAPPING the wasm module: a game
+        // whose server simply wasn't up took the whole runtime down with it.
+        // The browser withholds the reason for a socket failure by design, so
+        // there is nothing to recover — and the endpoint is already the `key`
+        // this error is reported against. [xreview]
+        Closure::<dyn FnMut(web_sys::Event)>::new(move |_e: web_sys::Event| {
+            with_live_game(|g| {
+                g.net_push_conn_error(key.clone(), iid, "connection failed".to_string())
+            });
         })
     };
     ws.set_onerror(Some(on_error.as_ref().unchecked_ref()));
@@ -990,6 +1009,14 @@ fn ws_connect(state: &Rc<RefCell<WsClient>>, key: String, url: String) {
 
 #[wasm_bindgen(start)]
 pub fn main() {
+    // Report panics to the console with their message and location. Without a
+    // hook a wasm panic reaches the page as a bare `RuntimeError: unreachable`
+    // — no message, no file, no line — which is how the refused-socket trap in
+    // `ws_connect` stayed unexplained. (The job `console_error_panic_hook`
+    // does; two lines here, so we don't take the dependency.)
+    std::panic::set_hook(Box::new(|info| {
+        web_sys::console::error_1(&format!("[functor-lang] panic: {info}").into());
+    }));
     spawn_local(async {
         run_async().await.unwrap_throw();
     })


### PR DESCRIPTION
A game whose server simply wasn't running took the **whole wasm runtime** down
with it: the refusal produced a JS `TypeError` and then
`RuntimeError: unreachable`.

Found while building #474, proven pre-existing there (stash the change, rebuild
from clean `main`, boot-only probe → byte-identical errors), and deliberately
left for its own PR. This is that PR.

## Cause

`ws_connect`'s error handler was typed `Closure<dyn FnMut(web_sys::ErrorEvent)>`
and called `e.message()` — but a WebSocket's `error` event is a **plain `Event`**
with no `message` property. The generated glue read `length` off `undefined`
(the `TypeError`) and then trapped the module.

Retyped to `web_sys::Event`. The browser withholds the reason for a socket
failure by design, and the endpoint is already the `key` the error is reported
against, so the message is simply `"connection failed"` — the game receives a
normal `Net.Error` and carries on.

**Why it matters beyond a stray sample error:** a not-yet-started server is the
*normal* state in an IDE, so this would have fired constantly once multiplayer
lands in the browser.

## Diagnosability

The only evidence of the above was a bare `unreachable` — no message, no file,
no line. It took stashing the change and rebuilding from `main` to prove where
it came from. `main` now installs a panic hook via `std::panic::set_hook`, so
the next one reports message and location. Hand-rolled rather than taking a
`console_error_panic_hook` dependency for two lines.

## What it unlocked

The regression test is the documented exception from #474 turned into an
assertion: **no wasm trap or JS type error anywhere in the run**, boot included.

And because the runtime now survives boot, there is a live single game to
observe — so three checks that were impossible before close the verification gap
#474 had to leave open for its central suspension invariant:

- the single game **is running** before the sim starts (without which the next
  check passes vacuously — the exact trap the reviewer identified),
- it is **suspended** while the sim owns the page (`window.__scrub.frame()`
  advances only when it ticks),
- it **resumes** after the sim stops.

`npm run test:wasm-sim` is now 18 checks, all passing; `wsdemo`, `wsserverdemo`,
and `netdemo` still pass, since this touches a shared error path.

## Review dispositions (`/xreview` — Claude subagent + Codex)

Both engines independently confirmed the retyping is correct for every event
this handler can receive, and — the thing I most wanted checked — that **no
sibling mistyping exists**: `onopen` (`FnMut()`), `onmessage` (`MessageEvent`,
and `.data()` is genuinely one), `onclose` (`CloseEvent`, arg unused), and the
rAF callback are all correctly typed. No Critical or High findings.

Fixed from the review:

- **Vacuity guard** on the suspension check — `null === null` would have
  reported an absent scrubber as a suspended game, which is precisely the
  false-green that check exists to prevent.
- **The no-trap check moved last**, so it covers suspension/stop/resume rather
  than only what precedes it, and the frame-advance checks now wait in **render
  frames** instead of wall-clock, so a slow runner can't fake either direction.
- **A live lie in a comment:** `on_close` claimed a still-declared `Sub.connect`
  reconnects next frame. It does not — `reconcile_connections` only emits a
  `Connect` for a key *absent* from `live_conn_keys`, and that set is re-seeded
  from the declared subs every frame, so a dropped connection stays down
  forever. This change makes that observable (the runtime survives to sit there
  offline), so the comment now states the truth. **Reconnect/backoff is a real
  gap and its own change** — the shell would have to retract the key from the
  producer's live set on close.
- **web-sys features:** dropped the now-unused `ErrorEvent`, added the
  directly-used `Event` (previously only enabled transitively).

🤖 Generated with [Claude Code](https://claude.com/claude-code)