### PR TITLE
refactor(site): share one build-time header across pages

### DIFF
--- a/site/build.mjs
+++ b/site/build.mjs
@@ -14,6 +14,7 @@ import { execSync, spawnSync } from "node:child_process";
 import { dirname } from "node:path";
 import esbuild from "esbuild";
 import { EXAMPLES } from "./src/examples.js";
+import { injectHeader } from "./src/header.js";
 
 const site = fileURLToPath(new URL(".", import.meta.url));
 const root = fileURLToPath(new URL("..", import.meta.url));
@@ -111,9 +112,10 @@ for (const page of PAGES) {
   await mkdir(dirname(target), { recursive: true });
   if (page.endsWith(".html")) {
     const html = await readFile(`${site}${page}`, "utf8");
+    // The shared header first (it carries the badge span), then stamp the badge.
     await writeFile(
       target,
-      html.replace(
+      injectHeader(html, page).replace(
         /(<span class="version-badge"[^>]*>)[^<]*(<\/span>)/,
         `$1${badge}$2`
       )

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -21,16 +21,8 @@
     <link rel="stylesheet" href="../styles.css" />
   </head>
   <body class="docs-page api-page">
-    <header class="site-header">
-      <a class="wordmark" href="../"><svg class="wordmark-mark" viewBox="366 163 385 690" fill="currentColor" aria-hidden="true"><path d="M382 341 545 179H735L615 300H548L382 466Z"/><path d="M382 493 497 380V748L382 837Z"/><path d="M518 426H693L597 522H518Z"/></svg>FUNCTOR<span class="wordmark-accent">//DOCS</span></a>
-      <span class="version-badge" title="Functor is alpha software — everything may change between releases">alpha</span>
-      <nav class="site-nav">
-        <a href="../sandbox.html">Sandbox</a>
-        <a href="../manual/">Manual</a>
-        <a href="../docs/" aria-current="page">API Reference</a>
-        <a class="nav-github" href="https://github.com/tommy-xr/functor" aria-label="Functor on GitHub" title="GitHub"><svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg></a>
-      </nav>
-    </header>
+    <!--@header prefix="../" suffix="DOCS" active="docs"-->
+    <!--/@header-->
 
     <div class="docs-layout api-layout">
       <nav class="docs-nav api-nav" aria-label="API modules">

--- a/site/ide.html
+++ b/site/ide.html
@@ -21,9 +21,7 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body class="ide-page">
-    <header class="site-header">
-      <a class="wordmark" href="./"><svg class="wordmark-mark" viewBox="366 163 385 690" fill="currentColor" aria-hidden="true"><path d="M382 341 545 179H735L615 300H548L382 466Z"/><path d="M382 493 497 380V748L382 837Z"/><path d="M518 426H693L597 522H518Z"/></svg>FUNCTOR<span class="wordmark-accent">//IDE</span></a>
-      <span class="version-badge" title="Functor is alpha software — everything may change between releases">alpha</span>
+    <!--@header suffix="IDE"-->
       <div class="sandbox-controls">
         <button id="download" type="button" title="Download the project as a .zip">
           ↓ project.zip
@@ -34,14 +32,7 @@
         <div id="runtime-target"></div>
         <span id="status" class="status-pill" data-state="busy">◌ loading…</span>
       </div>
-      <nav class="site-nav">
-        <a href="sandbox.html">Sandbox</a>
-        <a href="ide.html" aria-current="page">IDE</a>
-        <a href="manual/">Manual</a>
-        <a href="docs/">API Reference</a>
-        <a class="nav-github" href="https://github.com/tommy-xr/functor" aria-label="Functor on GitHub" title="GitHub"><svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg></a>
-      </nav>
-    </header>
+    <!--/@header-->
 
     <main class="ide-split">
       <aside class="file-pane">

--- a/site/index.html
+++ b/site/index.html
@@ -24,22 +24,8 @@
     <!-- Backdrop: a slow cyan/violet/pink aurora wash. Purely decorative. -->
     <div class="site-backdrop" aria-hidden="true"></div>
 
-    <header class="site-header">
-      <a class="wordmark" href="./"><svg class="wordmark-mark" viewBox="366 163 385 690" fill="currentColor" aria-hidden="true"><path d="M382 341 545 179H735L615 300H548L382 466Z"/><path d="M382 493 497 380V748L382 837Z"/><path d="M518 426H693L597 522H518Z"/></svg>FUNCTOR</a>
-      <span class="version-badge" title="Functor is alpha software — everything may change between releases">alpha</span>
-      <input type="checkbox" id="nav-toggle" class="nav-toggle" />
-      <label class="nav-burger" for="nav-toggle" aria-label="Toggle menu">
-        <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
-          <line x1="4" y1="7" x2="20" y2="7" /><line x1="4" y1="12" x2="20" y2="12" /><line x1="4" y1="17" x2="20" y2="17" />
-        </svg>
-      </label>
-      <nav class="site-nav">
-        <a href="sandbox.html">Sandbox</a>
-        <a href="manual/">Manual</a>
-        <a href="docs/">API Reference</a>
-        <a class="nav-github" href="https://github.com/tommy-xr/functor" aria-label="Functor on GitHub" title="GitHub"><svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg></a>
-      </nav>
-    </header>
+    <!--@header-->
+    <!--/@header-->
 
     <!-- The demo card IS a functor program: site/examples/hero.fun,
          interpreted live by the wasm runtime in this iframe. -->

--- a/site/manual/index.html
+++ b/site/manual/index.html
@@ -21,16 +21,8 @@
     <link rel="stylesheet" href="../styles.css" />
   </head>
   <body class="docs-page" data-sandbox-href="../sandbox.html">
-    <header class="site-header">
-      <a class="wordmark" href="../"><svg class="wordmark-mark" viewBox="366 163 385 690" fill="currentColor" aria-hidden="true"><path d="M382 341 545 179H735L615 300H548L382 466Z"/><path d="M382 493 497 380V748L382 837Z"/><path d="M518 426H693L597 522H518Z"/></svg>FUNCTOR<span class="wordmark-accent">//MANUAL</span></a>
-      <span class="version-badge" title="Functor is alpha software — everything may change between releases">alpha</span>
-      <nav class="site-nav">
-        <a href="../sandbox.html">Sandbox</a>
-        <a href="../manual/" aria-current="page">Manual</a>
-        <a href="../docs/">API Reference</a>
-        <a class="nav-github" href="https://github.com/tommy-xr/functor" aria-label="Functor on GitHub" title="GitHub"><svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg></a>
-      </nav>
-    </header>
+    <!--@header prefix="../" suffix="MANUAL" active="manual"-->
+    <!--/@header-->
 
     <div class="docs-layout">
       <nav class="docs-nav">

--- a/site/sandbox.html
+++ b/site/sandbox.html
@@ -21,9 +21,7 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body class="sandbox-page">
-    <header class="site-header">
-      <a class="wordmark" href="./"><svg class="wordmark-mark" viewBox="366 163 385 690" fill="currentColor" aria-hidden="true"><path d="M382 341 545 179H735L615 300H548L382 466Z"/><path d="M382 493 497 380V748L382 837Z"/><path d="M518 426H693L597 522H518Z"/></svg>FUNCTOR<span class="wordmark-accent">//SANDBOX</span></a>
-      <span class="version-badge" title="Functor is alpha software — everything may change between releases">alpha</span>
+    <!--@header suffix="SANDBOX" active="sandbox"-->
       <div class="sandbox-controls">
         <label class="picker-label" for="example-picker">scene</label>
         <select id="example-picker"></select>
@@ -33,14 +31,7 @@
         <div id="runtime-target"></div>
         <span id="status" class="status-pill" data-state="busy">◌ loading…</span>
       </div>
-      <nav class="site-nav">
-        <a href="sandbox.html" aria-current="page">Sandbox</a>
-        <a href="ide.html">IDE</a>
-        <a href="manual/">Manual</a>
-        <a href="docs/">API Reference</a>
-        <a class="nav-github" href="https://github.com/tommy-xr/functor" aria-label="Functor on GitHub" title="GitHub"><svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg></a>
-      </nav>
-    </header>
+    <!--/@header-->
 
     <main class="sandbox-split">
       <section class="editor-pane">

--- a/site/src/header.js
+++ b/site/src/header.js
@@ -1,0 +1,122 @@
+// The shared site header, rendered at BUILD time (see build.mjs) into every
+// page that carries an `<!--@header-->` block. Build-only — no client bundle
+// imports this, so the header stays plain markup in the shipped HTML: no
+// runtime cost and no pop-in on the landing page.
+//
+// Pages differ along three axes, which are exactly this module's inputs:
+//   prefix   — "" at the site root, "../" from docs/ and manual/
+//   suffix   — the pink wordmark tag ("SANDBOX", "IDE", "DOCS", "MANUAL")
+//   active   — which nav entry gets aria-current
+// plus a `controls` slot for the sandbox/IDE toolbars, which the page owns
+// (it is the block's inner markup — see injectHeader).
+//
+// The burger markup is emitted on every page; CSS decides where it shows
+// (styles.css: `.landing-page` opts in at <=620px, `.docs-page` wraps the nav
+// into a scrollable row at <=720px instead).
+
+// The Functor mark — the same art as the favicon and the VS Code file icon
+// (docs/media/functor-icon.svg).
+const MARK =
+  '<svg class="wordmark-mark" viewBox="366 163 385 690" fill="currentColor" aria-hidden="true">' +
+  '<path d="M382 341 545 179H735L615 300H548L382 466Z"/>' +
+  '<path d="M382 493 497 380V748L382 837Z"/>' +
+  '<path d="M518 426H693L597 522H518Z"/></svg>';
+
+const GITHUB_MARK =
+  '<svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>';
+
+const BURGER = `<input type="checkbox" id="nav-toggle" class="nav-toggle" />
+      <label class="nav-burger" for="nav-toggle" aria-label="Toggle menu">
+        <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
+          <line x1="4" y1="7" x2="20" y2="7" /><line x1="4" y1="12" x2="20" y2="12" /><line x1="4" y1="17" x2="20" y2="17" />
+        </svg>
+      </label>`;
+
+// The one nav model for the whole site. The IDE is deliberately absent: it is
+// still in development, so it ships unlinked and is reached by typing its URL.
+// The landing footer (index.html) mirrors this list — keep them in step.
+const NAV = [
+  { id: "sandbox", href: "sandbox.html", label: "Sandbox" },
+  { id: "manual", href: "manual/", label: "Manual" },
+  { id: "docs", href: "docs/", label: "API Reference" },
+];
+
+const GITHUB = "https://github.com/tommy-xr/functor";
+
+const KEYS = new Set(["prefix", "suffix", "active"]);
+const NAV_IDS = new Set(NAV.map(({ id }) => id));
+
+// The badge ships as the literal "alpha"; build.mjs stamps the release tag
+// over it afterwards (one regex, unchanged by this module — which is why a
+// page may carry only ONE header block; injectHeader enforces that).
+const renderHeader = ({ prefix = "", suffix = "", active = "", controls = "" }) => {
+  const nav = [
+    ...NAV.map(
+      ({ id, href, label }) =>
+        `<a href="${prefix}${href}"${id === active ? ' aria-current="page"' : ""}>${label}</a>`
+    ),
+    `<a class="nav-github" href="${GITHUB}" aria-label="Functor on GitHub" title="GitHub">${GITHUB_MARK}</a>`,
+  ];
+
+  const children = [
+    `<a class="wordmark" href="${prefix || "./"}">${MARK}FUNCTOR${
+      suffix ? `<span class="wordmark-accent">//${suffix}</span>` : ""
+    }</a>`,
+    '<span class="version-badge" title="Functor is alpha software — everything may change between releases">alpha</span>',
+    BURGER,
+    ...(controls ? [controls] : []),
+    `<nav class="site-nav">\n        ${nav.join("\n        ")}\n      </nav>`,
+  ];
+
+  return `<header class="site-header">\n      ${children.join("\n      ")}\n    </header>`;
+};
+
+// A page's header block: `<!--@header attr="…"--> …controls… <!--/@header-->`.
+// The leading indentation is deliberately NOT consumed, so the emitted
+// `<header>` keeps the page's own indentation (and matches the closing tag
+// this module renders).
+const BLOCK = /<!--@header([^>]*?)-->([\s\S]*?)<!--\/@header-->/g;
+const ATTR = /([a-z]+)="([^"]*)"/g;
+
+// Replace each block with the rendered header; the block's inner markup
+// becomes the controls slot, so page-specific toolbars stay in the page they
+// belong to. `page` only names the file in error messages.
+//
+// Every failure mode throws rather than passing the page through unchanged: a
+// mistyped marker would otherwise ship a page with NO header, and a mistyped
+// attribute (`prefx="../"`) would ship silently-broken relative links — both
+// with a green build.
+export const injectHeader = (html, page = "page") => {
+  let blocks = 0;
+
+  const out = html.replace(BLOCK, (_match, rawAttrs, controls) => {
+    blocks += 1;
+    const options = {};
+    // Consume the recognised attributes; anything left over is a typo (an
+    // unknown key, or a form this parser does not accept such as single
+    // quotes) and must fail the build rather than be ignored.
+    const rest = rawAttrs
+      .replace(ATTR, (_attr, key, value) => {
+        if (!KEYS.has(key)) {
+          throw new Error(`${page}: unknown @header attribute "${key}"`);
+        }
+        options[key] = value;
+        return "";
+      })
+      .trim();
+    if (rest) throw new Error(`${page}: unparsed @header attributes: ${rest}`);
+    if (options.active && !NAV_IDS.has(options.active)) {
+      throw new Error(`${page}: @header active="${options.active}" is not a nav entry`);
+    }
+    return renderHeader({ ...options, controls: controls.trim() });
+  });
+
+  // One block per page: each rendered header carries `id="nav-toggle"` and a
+  // version-badge span, and build.mjs stamps only the first badge.
+  if (blocks > 1) throw new Error(`${page}: ${blocks} @header blocks — expected at most one`);
+  // A marker surviving the replace means the block is malformed (unclosed, or
+  // a `>` inside the attributes), which would ship a headerless page.
+  if (/<!--\/?@header/.test(out)) throw new Error(`${page}: malformed @header block`);
+
+  return out;
+};


### PR DESCRIPTION
The site header was duplicated verbatim across five pages and had drifted. This
extracts it into a single build-time template — **59 lines of duplicated markup
removed, one 122-line module added**.

This is step 1 of an incremental site cleanup; the follow-ups are listed at the
bottom.

## Why build-time, not React

The header is entirely static markup — the burger is a CSS-only
`<input type=checkbox>` + `:checked` selector, no JS. Rendering it with a
runtime component would either add layout shift on every page (client-rendered)
or use React purely as a templating language (server-rendered). A plain template
applied by `build.mjs` gets the identical result with no new dependency and no
client bundle cost, and the shipped HTML stays plain static markup.

React is still the right call for the **IDE/sandbox app shell** — the file list,
problems/output panels, and status pill are hand-rolled `createElement` with real
state. That is a separate, later step.

## How it works

`site/src/header.js` exports `injectHeader(html, page)`, which `build.mjs` applies
as pages are copied to `dist`. Pages carry a block whose inner markup becomes the
controls slot, so page-specific toolbars stay in the page they belong to:

```html
<!--@header suffix="SANDBOX" active="sandbox"-->
  <div class="sandbox-controls">…</div>
<!--/@header-->
```

Pages vary along exactly three axes — `prefix` (`""` at the root, `"../"` from
`docs/` and `manual/`), `suffix` (the pink wordmark tag), and `active`
(`aria-current`).

## Behavior deltas — exactly two, both intended

- **The IDE nav link is removed everywhere** (it was on `sandbox.html` and
  `ide.html`). The IDE is still in development, so it ships unlinked and is
  reached by typing its URL. Nothing else in the repo links to `ide.html`, and
  the landing footer never listed it, so this is consistent site-wide.
- **Burger markup is now emitted on every page**, but stays inert off the landing
  page — gated purely by the existing CSS (`styles.css:113,118` set
  `display: none` globally; only `.landing-page` opts in at ≤620px). `docs`/
  `manual` keep their own scrollable-row treatment at ≤720px.

Everything else is byte-for-byte identical in the built output.

## Verification

- **Output diff vs the committed baseline** — `index.html` is byte-identical; the
  other four differ only by the two deltas above. Header indentation matches the
  original.
- **e2e** — `test:site`, `test:ide`, `test:ide-page`, `test:runtime-target` all
  pass, re-run after the review fixes.
- **Visual** — all five pages screenshotted at 1280px and 390px. Nav resolves
  identically everywhere; the burger activates only on landing/mobile, as before.

## Review dispositions (`/xreview` — Claude + Codex)

No Critical findings. Both engines agreed on three, all **fixed**:

| Finding | Severity | Disposition |
| --- | --- | --- |
| A malformed/unclosed block or unknown attribute failed **silently** — shipping a headerless page, or broken relative links from a typo'd `prefix`, with a green build | High | Fixed — `injectHeader` throws on unknown/unparsed attributes, an invalid `active`, a malformed block, and >1 block per page |
| Multiple blocks → duplicate `id="nav-toggle"` and only the first version badge stamped | Medium | Fixed — one block per page is enforced |
| `[ \t]*` in the block regex stripped the `<header>` indentation | Low | Fixed — indentation is no longer consumed |
| `renderHeader` exported with no importer; manual indent bookkeeping | Low | Fixed — unexported; children joined instead of hand-indented |

Both engines independently confirmed the burger is genuinely inert off the
landing page, that there are no `id` collisions, and that there is no injection
vector. A guard test exercised all seven failure modes plus both happy paths
(valid block; no block at all, as on `player.html`).

## Follow-ups (not in this PR)

- **`sandbox.js` / `ide.js`** still duplicate ~130 lines (`setStatus`, `EditorView`
  construction, the diagnostics→Problems mapping, the console listener, the
  `triggerComplete`/`acceptCompletion` e2e seams).
- **`site/player.html` (520 lines) and `runtime/functor-runtime-web/index-functor-lang.html`
  (407)** are ~50% the same file — pointer-lock, mouselook, scrubber mounting,
  console forwarding — independently drifted. The largest remaining duplication
  in the web surface.
- **Mobile nav on sandbox/ide** — these two pages have no mobile nav treatment at
  all. Adding the burger there is a design decision (the header holds
  `sandbox-controls` at `flex: 1`), so it belongs in a design pass, not this
  refactor.
- `.sandbox-controls` is declared twice in `styles.css` (753 and 792) — pre-existing,
  left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)