### PR TITLE
feat(terrain): dress the layered bands with CC0 detail maps

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -547,7 +547,12 @@ let world =
   Terrain.heightmap(Assets.heightmap, 4000.0, 4000.0, -40.0, 420.0)
   |> Terrain.maxPixelError(2.0)                            // finite XZ heightfield: Asset.Texture,
   |> Terrain.layered(low, high, rock, snow, 340.0)         //   width, depth, min/max Y. Black maps
-  |> Terrain.grass(13.0, 520.0, 5.5, grassColor)           //   to min, white to max. Modifiers are
+  |> Terrain.textured(lowMap, highMap, rockMap, snowMap,   //   to min, white to max. `textured`
+       24.0)                                               //   dresses `layered`'s bands with
+  |> Terrain.grass(13.0, 520.0, 5.5, grassColor)           //   detail albedo (needs `layered`;
+                                                           //   tileSize in world units, sampled
+                                                           //   at two scales, fading to the band
+                                                           //   colors with distance). Modifiers are
 Scene.terrain(world)                                       //   descriptor-last; rendering uses a
                                                            //   camera-relative quadtree, a shared
                                                            //   GPU grid, 16-bit height sampling,

--- a/examples/terrain/.gitignore
+++ b/examples/terrain/.gitignore
@@ -1,0 +1,2 @@
+# Detail maps are fetched, not checked in (npm run fetch:assets).
+*.jpg

--- a/examples/terrain/ASSETS.md
+++ b/examples/terrain/ASSETS.md
@@ -1,0 +1,15 @@
+# Terrain sample assets
+
+`heightmap.png` is generated deterministically by `generate-heightmap.mjs` and is
+checked in. The detail albedo maps are fetched by `npm run fetch:assets` and are
+gitignored.
+
+| File | Source | License |
+| --- | --- | --- |
+| `detail-low.jpg` | [Forest Ground 04](https://polyhaven.com/a/forest_ground_04) — Poly Haven | CC0 |
+| `detail-high.jpg` | [Aerial Grass Rock](https://polyhaven.com/a/aerial_grass_rock) — Poly Haven | CC0 |
+| `detail-rock.jpg` | [Rock Face](https://polyhaven.com/a/rock_face) — Poly Haven | CC0 |
+| `detail-snow.jpg` | [Snow 02](https://polyhaven.com/a/snow_02) — Poly Haven | CC0 |
+
+CC0 waives attribution, but the sources are recorded here so the maps can be
+re-fetched or swapped deliberately.

--- a/examples/terrain/game.fun
+++ b/examples/terrain/game.fun
@@ -22,6 +22,12 @@ let world =
        Color.rgb(0.28, 0.25, 0.23),
        Color.rgb(0.86, 0.90, 0.91),
        340.0)
+  |> Terrain.textured(
+       Asset.texture("detail-low.jpg"),
+       Asset.texture("detail-high.jpg"),
+       Asset.texture("detail-rock.jpg"),
+       Asset.texture("detail-snow.jpg"),
+       24.0)
   |> Terrain.grass(13.0, 520.0, 5.5, Color.rgb(0.25, 0.46, 0.10))
 
 let terrainBody = Physics.tag("terrain")

--- a/functor-prelude/prelude/terrain.funi
+++ b/functor-prelude/prelude/terrain.funi
@@ -23,6 +23,18 @@ let color : (Color.t, t) => t
 /// piping.
 let layered : (Color.t, Color.t, Color.t, Color.t, float, t) => t
 
+/// Dress the `layered` bands with detail maps.
+///
+/// Each map supplies STRUCTURE, not color: it is divided by its own average, so
+/// it adds surface detail to the band's `layered` color without repainting it.
+/// (A photographic ground albedo averages brown; used directly it would turn a
+/// green hillside to dirt.) The maps blend by the same height and slope weights
+/// as the colors, so texturing changes what a band looks like, not where it
+/// falls. `tileSize` is the world-unit span of one tile; each map is sampled at
+/// two scales to hide the repeat, and detail fades out with distance. Requires
+/// `layered`. The terrain is last for piping.
+let textured : (Asset.Texture, Asset.Texture, Asset.Texture, Asset.Texture, float, t) => t
+
 /// Add camera-local GPU-instanced grass clusters.
 ///
 /// `spacing`, `distance`, and `bladeHeight` are terrain-local world units.

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -1419,6 +1419,36 @@ a texture Asset, positive dimensions, and maxHeight greater than minHeight";
             FunctorLangTerrain(terrain.0.with_color([r, g, b]))
         },
     );
+    const TEXTURED: &str = "Terrain.textured(low, high, rock, snow, tileSize, terrain) — \
+four texture Assets and a positive finite tile size in world units";
+    reg.fn6(
+        "Terrain.textured",
+        TEXTURED,
+        |low: TextureAssetPath,
+         high: TextureAssetPath,
+         rock: TextureAssetPath,
+         snow: TextureAssetPath,
+         tile_size: f64,
+         terrain: FunctorLangTerrain| {
+            let tile_size = tile_size as f32;
+            if !tile_size.is_finite() || tile_size <= 0.0 {
+                return Err(format!("usage: {TEXTURED}"));
+            }
+            let map = |asset: TextureAssetPath| crate::terrain::TerrainDetailTexture {
+                locator: asset.path,
+                while_pending: asset.while_pending,
+            };
+            Ok(FunctorLangTerrain(terrain.0.with_textures(
+                crate::terrain::TerrainTextures {
+                    low: map(low),
+                    high: map(high),
+                    rock: map(rock),
+                    snow: map(snow),
+                    tile_size,
+                },
+            )))
+        },
+    );
     reg.fn6(
         "Terrain.layered",
         "Terrain.layered(low, high, rock, snow, snowHeight, terrain)",

--- a/runtime/functor-runtime-common/src/scene3d/mod.rs
+++ b/runtime/functor-runtime-common/src/scene3d/mod.rs
@@ -110,6 +110,10 @@ pub struct PreloadDriveResult {
     pub terrain_publications: Vec<crate::terrain::TerrainHydrationPublication>,
 }
 
+/// First texture unit for terrain detail maps; must match the terrain
+/// renderer's `DETAIL_TEXTURE_UNIT0` (unit 0 is the height texture).
+const TERRAIN_DETAIL_UNIT0: u32 = 1;
+
 /// Decoded terrain sources receive one unused shell frame of grace before
 /// eviction. This retains ordinary frame-to-frame reuse without keeping every
 /// level/hot-reload heightmap alive for the process lifetime.
@@ -545,6 +549,41 @@ impl SceneContext {
         {
             crate::terrain::request_heightmap(source_descriptor);
         }
+        // Detail maps stream like any other texture. Bind them before the
+        // terrain program runs; a map still loading leaves the whole set
+        // unbound so the terrain shows its flat band colors rather than a
+        // checkerboard smeared across kilometres.
+        let detail_bound = terrain.detail_textures().is_some_and(|maps| {
+            let handles = maps.map(|map| {
+                let asset = render_context
+                    .asset_cache
+                    .load_asset_with_pipeline(self.texture_pipeline.clone(), &map.locator);
+                crate::asset::resolve_while_pending_state(
+                    &render_context.asset_cache,
+                    &self.texture_pipeline,
+                    &asset,
+                    &map.while_pending,
+                )
+            });
+            let ready = handles.iter().all(|state| {
+                matches!(
+                    state,
+                    crate::asset::WhilePendingState::Loaded(_)
+                        | crate::asset::WhilePendingState::Loading(Some(_))
+                )
+            });
+            if ready {
+                for (index, state) in handles.iter().enumerate() {
+                    let texture = match state {
+                        crate::asset::WhilePendingState::Loaded(texture)
+                        | crate::asset::WhilePendingState::Loading(Some(texture)) => texture,
+                        _ => unreachable!("checked above"),
+                    };
+                    texture.bind(TERRAIN_DETAIL_UNIT0 + index as u32, render_context);
+                }
+            }
+            ready
+        });
         self.terrain_renderer.borrow_mut().draw(
             render_context,
             terrain,
@@ -552,6 +591,7 @@ impl SceneContext {
             world,
             projection,
             view,
+            detail_bound,
         );
     }
 

--- a/runtime/functor-runtime-common/src/terrain.rs
+++ b/runtime/functor-runtime-common/src/terrain.rs
@@ -155,6 +155,33 @@ pub struct TerrainDescription {
     pub layers: Option<TerrainLayers>,
     #[serde(default)]
     pub grass: Option<TerrainGrass>,
+    #[serde(default)]
+    pub textures: Option<TerrainTextures>,
+}
+
+/// One detail albedo map, carrying its own `Asset.whilePending` chain so a
+/// terrain texture streams in exactly like any other asset.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct TerrainDetailTexture {
+    pub locator: String,
+    #[serde(default)]
+    pub while_pending: Vec<String>,
+}
+
+/// Per-band detail albedo for the bands [`TerrainLayers`] defines.
+///
+/// The renderer blends these with the SAME height/slope weights as the layer
+/// colors, so texturing changes what a band looks like without changing where
+/// it falls. Textures need `layers`; without it there are no bands to dress
+/// and the flat `color` is used instead.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct TerrainTextures {
+    pub low: TerrainDetailTexture,
+    pub high: TerrainDetailTexture,
+    pub rock: TerrainDetailTexture,
+    pub snow: TerrainDetailTexture,
+    /// World units covered by one tile of each detail map.
+    pub tile_size: f32,
 }
 
 impl TerrainDescription {
@@ -180,6 +207,7 @@ impl TerrainDescription {
             color: Self::DEFAULT_COLOR,
             layers: None,
             grass: None,
+            textures: None,
         }
     }
 
@@ -202,6 +230,19 @@ impl TerrainDescription {
     pub fn with_grass(mut self, grass: TerrainGrass) -> Self {
         self.grass = Some(grass);
         self
+    }
+
+    pub fn with_textures(mut self, textures: TerrainTextures) -> Self {
+        self.textures = Some(textures);
+        self
+    }
+
+    /// Every detail locator plus its pending chain, in binding order — the one
+    /// place the shell iterates terrain textures, so the renderer's sampler
+    /// order and the hydration order cannot drift apart.
+    pub fn detail_textures(&self) -> Option<[&TerrainDetailTexture; 4]> {
+        let t = self.textures.as_ref()?;
+        Some([&t.low, &t.high, &t.rock, &t.snow])
     }
 
     pub fn geometry(&self) -> TerrainGeometry {

--- a/runtime/functor-runtime-common/src/terrain_renderer.rs
+++ b/runtime/functor-runtime-common/src/terrain_renderer.rs
@@ -24,6 +24,11 @@ const PATCH_QUADS: u32 = 64;
 const MAX_LEVEL: u32 = 10;
 const MAX_INSTANCES: usize = 8192;
 const MAX_GRASS_INSTANCES: usize = 20_000;
+/// First texture unit for the detail maps. Unit 0 stays the height texture.
+const DETAIL_TEXTURE_UNIT0: i32 = 1;
+/// Detail fade band, as a fraction of the terrain's longest side.
+const DETAIL_FADE_START: f32 = 0.08;
+const DETAIL_FADE_END: f32 = 0.28;
 
 const VERTEX_SHADER_SOURCE: &str = r#"
         // uv.xy plus 1 for a duplicated skirt vertex.
@@ -114,8 +119,40 @@ const FRAGMENT_SHADER_SOURCE: &str = r#"
         uniform float maxTerrainHeight;
         uniform float snowHeight;
         uniform int debugMode; // 0=lit, 1=normals, 2=tangents
+        uniform int useTextures;
+        uniform sampler2D lowTex;
+        uniform sampler2D highTex;
+        uniform sampler2D rockTex;
+        uniform sampler2D snowTex;
+        uniform float detailTile;
+        uniform float detailFadeStart;
+        uniform float detailFadeEnd;
+        // Explicitly this shader's own: fog owns fogCameraPos and does not set
+        // it when fog is disabled, but the detail fade must work regardless.
+        uniform vec3 detailCameraPos;
 
         out vec4 fragColor;
+
+        // One tile repeat is obvious across kilometres, so sample a second
+        // time at an irrational multiple and average: the two lattices only
+        // re-align at their product, which is far past the fade distance.
+        //
+        // `fade` resolves to the map's own top mip — a 1x1 average — instead
+        // of to an authored color. That makes the distance transition
+        // seamless for ANY map without asking the game to hand-match a band
+        // color to its texture, which is what a fixed far color would require.
+        // Returns STRUCTURE, not color: the sample divided by the map's own
+        // average (its top mip). That average is ~1.0 by construction, so
+        // multiplying a band color by this adds the map's detail without
+        // shifting its hue — a photographic albedo averages brown, and using
+        // it directly would repaint a green hillside as dirt. It also makes
+        // the distance fade exact: as `fade` reaches 0 the ratio is 1.0, i.e.
+        // no change, so there is nothing to seam against.
+        vec3 detail(sampler2D tex, vec2 uv, float fade) {
+            vec3 near = mix(texture(tex, uv).rgb, texture(tex, uv * 0.137).rgb, 0.5);
+            vec3 average = max(textureLod(tex, uv, 32.0).rgb, vec3(1e-3));
+            return mix(vec3(1.0), clamp(near / average, 0.0, 2.5), fade);
+        }
 
         void main() {
             vec3 n = normalize(worldNormal);
@@ -135,15 +172,33 @@ const FRAGMENT_SHADER_SOURCE: &str = r#"
             if (useLayers == 1) {
                 float heightRange = max(maxTerrainHeight - minTerrainHeight, 1e-4);
                 float h = clamp((localHeight - minTerrainHeight) / heightRange, 0.0, 1.0);
-                albedo = mix(lowColor, highColor, smoothstep(0.15, 0.72, h));
+                float bandWeight = smoothstep(0.15, 0.72, h);
                 float slope = 1.0 - clamp(n.y, 0.0, 1.0);
                 float rockWeight = smoothstep(0.30, 0.67, slope);
-                albedo = mix(albedo, rockColor, rockWeight);
                 float snowWeight = smoothstep(
                     snowHeight,
                     snowHeight + heightRange * 0.08,
                     localHeight) * (1.0 - rockWeight * 0.72);
+
+                albedo = mix(lowColor, highColor, bandWeight);
+                albedo = mix(albedo, rockColor, rockWeight);
                 albedo = mix(albedo, snowColor, snowWeight);
+
+                if (useTextures == 1) {
+                    // Past the fade the detail is sub-pixel: sampling it only
+                    // buys aliasing, so resolve to the flat band colors that
+                    // the untextured terrain already renders correctly.
+                    float fade = 1.0 - smoothstep(
+                        detailFadeStart, detailFadeEnd, distance(worldPos, detailCameraPos));
+                    // The SAME weights as the colors above: texturing dresses
+                    // the bands, it does not move them.
+                    vec2 uv = worldPos.xz / detailTile;
+                    vec3 structure = mix(
+                        detail(lowTex, uv, fade), detail(highTex, uv, fade), bandWeight);
+                    structure = mix(structure, detail(rockTex, uv, fade), rockWeight);
+                    structure = mix(structure, detail(snowTex, uv, fade), snowWeight);
+                    albedo *= structure;
+                }
             }
             vec3 shaded = albedo * diffuseLight + specularLight;
             fragColor = vec4(applyFog(shaded, worldPos), 1.0);
@@ -267,6 +322,12 @@ struct TerrainUniforms {
     max_terrain_height: UniformLocation,
     snow_height: UniformLocation,
     debug_mode: UniformLocation,
+    use_textures: UniformLocation,
+    detail_textures: [UniformLocation; 4],
+    detail_tile: UniformLocation,
+    detail_fade_start: UniformLocation,
+    detail_fade_end: UniformLocation,
+    detail_camera_pos: UniformLocation,
     lighting: LightingUniforms,
     fog: FogUniforms,
 }
@@ -431,6 +492,10 @@ impl TerrainRenderer {
         world: &Matrix4<f32>,
         projection: &Matrix4<f32>,
         view: &Matrix4<f32>,
+        // Whether the shell resolved and bound the four detail maps to units
+        // 1..4 for this draw. Layers without textures — and a textured terrain
+        // whose maps have not streamed in — render the flat band colors.
+        detail_bound: bool,
     ) {
         if source.width < 2 || source.height < 2 {
             return;
@@ -560,6 +625,25 @@ impl TerrainRenderer {
                 DebugRenderMode::Default | DebugRenderMode::Physics => 0,
             };
             p.set_uniform_1i(gl, &u.debug_mode, debug_mode);
+            let detail = description
+                .textures
+                .as_ref()
+                .filter(|_| use_layers == 1 && detail_bound);
+            p.set_uniform_1i(gl, &u.use_textures, detail.is_some() as i32);
+            if let Some(textures) = detail {
+                for (unit, location) in u.detail_textures.iter().enumerate() {
+                    p.set_uniform_1i(gl, location, unit as i32 + DETAIL_TEXTURE_UNIT0);
+                }
+                p.set_uniform_1f(gl, &u.detail_tile, textures.tile_size);
+                // Scale the fade with the terrain, not the tile: what matters
+                // is how far the detail survives relative to the world it
+                // dresses, and the same tile reads very differently on a 200 m
+                // island and a 4 km map.
+                let span = description.width.max(description.depth);
+                p.set_uniform_1f(gl, &u.detail_fade_start, span * DETAIL_FADE_START);
+                p.set_uniform_1f(gl, &u.detail_fade_end, span * DETAIL_FADE_END);
+                p.set_uniform_vec3(gl, &u.detail_camera_pos, &ctx.camera_pos);
+            }
             u.lighting.set(p, ctx, view);
             u.fog.set(p, gl, ctx.fog, &ctx.camera_pos);
 
@@ -637,6 +721,17 @@ impl TerrainRenderer {
             max_terrain_height: program.get_uniform_location(ctx.gl, "maxTerrainHeight"),
             snow_height: program.get_uniform_location(ctx.gl, "snowHeight"),
             debug_mode: program.get_uniform_location(ctx.gl, "debugMode"),
+            use_textures: program.get_uniform_location(ctx.gl, "useTextures"),
+            detail_textures: [
+                program.get_uniform_location(ctx.gl, "lowTex"),
+                program.get_uniform_location(ctx.gl, "highTex"),
+                program.get_uniform_location(ctx.gl, "rockTex"),
+                program.get_uniform_location(ctx.gl, "snowTex"),
+            ],
+            detail_tile: program.get_uniform_location(ctx.gl, "detailTile"),
+            detail_fade_start: program.get_uniform_location(ctx.gl, "detailFadeStart"),
+            detail_fade_end: program.get_uniform_location(ctx.gl, "detailFadeEnd"),
+            detail_camera_pos: program.get_uniform_location(ctx.gl, "detailCameraPos"),
             lighting: LightingUniforms::get(&program, ctx.gl),
             fog: FogUniforms::get(&program, ctx.gl),
         };

--- a/scripts/fetch-assets.mjs
+++ b/scripts/fetch-assets.mjs
@@ -14,6 +14,9 @@ import path from "node:path";
 const MESHES_BASE = "https://raw.githubusercontent.com/BabylonJS/Assets/master/meshes";
 const SKYBOX_BASE =
   "https://raw.githubusercontent.com/BabylonJS/Assets/master/skyboxes/TropicalSunnyDay";
+// Poly Haven serves direct per-file CDN URLs (no archive to unpack), so its
+// textures drop straight into the same fetch as everything else. All CC0.
+const POLYHAVEN_BASE = "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k";
 
 // Which assets each sample needs (a sample loads them relative to its own dir).
 const TARGETS = [
@@ -36,6 +39,19 @@ const TARGETS = [
     dir: "examples/crossfade",
     baseUrl: MESHES_BASE,
     assets: ["Xbot.glb"],
+  },
+  {
+    // Terrain detail maps, one per `Terrain.layered` band. Poly Haven nests
+    // each texture under its own id, so these carry a full path rather than a
+    // bare filename.
+    dir: "examples/terrain",
+    baseUrl: POLYHAVEN_BASE,
+    assets: [
+      { from: "forest_ground_04/forest_ground_04_diff_1k.jpg", to: "detail-low.jpg" },
+      { from: "aerial_grass_rock/aerial_grass_rock_diff_1k.jpg", to: "detail-high.jpg" },
+      { from: "rock_face/rock_face_diff_1k.jpg", to: "detail-rock.jpg" },
+      { from: "snow_02/snow_02_diff_1k.jpg", to: "detail-snow.jpg" },
+    ],
   },
   {
     dir: "examples/atmosphere",
@@ -74,14 +90,18 @@ async function exists(filePath) {
 
 let failures = 0;
 for (const { dir, baseUrl, assets } of TARGETS) {
-  for (const name of assets) {
-    const dest = path.join(dir, name);
+  for (const asset of assets) {
+    // A bare string is fetched and saved under the same name; `{ from, to }`
+    // renames, for hosts that nest a file under a per-asset path.
+    const from = typeof asset === "string" ? asset : asset.from;
+    const to = typeof asset === "string" ? asset : asset.to;
+    const dest = path.join(dir, to);
     if (await exists(dest)) {
       console.log(`ok       ${dest}`);
       continue;
     }
 
-    const url = `${baseUrl}/${name}`;
+    const url = `${baseUrl}/${from}`;
     process.stdout.write(`fetching ${dest} ... `);
     try {
       const response = await fetch(url);


### PR DESCRIPTION
The terrain shaded as four flat color bands, so at any distance a hillside was a
smooth gradient with no surface. Adds `Terrain.textured(low, high, rock, snow,
tileSize)` — one detail map per `Terrain.layered` band, blended with the **same**
height/slope weights as the colors, so texturing changes what a band looks like,
not where it falls.

![before/after](https://gist.githubusercontent.com/tommy-xr/60e858181fec3916576ed379f74530e7/raw/terrain-ab.gif)

![side by side](https://gist.githubusercontent.com/tommy-xr/60e858181fec3916576ed379f74530e7/raw/terrain-compare.png)

Near slope at 1:1 — the band color is unchanged, what arrives is structure:

![1:1 crop](https://gist.githubusercontent.com/tommy-xr/60e858181fec3916576ed379f74530e7/raw/terrain-crop.png)

## The map supplies structure, not color

Each sample is divided by the map's own average (its top mip, which exists only
because #477 gave these textures mip chains) and multiplied onto the band color.

This matters more than it sounds. Photographic ground albedos all average brown —
measured means for every candidate, including Poly Haven's `leafy_grass` and
`sparse_grass`, are red-dominant:

| Map | Mean RGB |
| --- | --- |
| `leafy_grass` | 151, 131, 89 |
| `sparse_grass` | 79, 61, 21 |
| `aerial_grass_rock` | 114, 97, 36 |
| `forest_ground_04` | 106, 90, 68 |
| `rock_face` | 97, 70, 49 |
| `snow_02` | 165, 165, 167 |

So using a map **as** color repaints a green hillside as dirt — no choice of map
avoids it. Two earlier attempts confirmed this the hard way: replacement produced
a brown near field meeting a green distance in a visible ring, and gentle tinting
was seamless but invisible.

Dividing by the average also makes the distance fade exact rather than tuned: the
ratio tends to `1.0` as detail fades — literally no change — so there is nothing
to seam against.

## Details

- Sampled at two scales (`uv` and `uv * 0.137`) so the tile repeat does not read
  as a lattice across 4 km.
- Fade band scales with the terrain's longest side; the same tile reads very
  differently on a 200 m island and a 4 km map.
- Detail maps stream like any other texture. A map still loading leaves the whole
  set unbound, so the terrain shows its flat band colors rather than a
  checkerboard smeared across kilometres.
- Sampler order lives in one place (`TerrainDescription::detail_textures`) so the
  renderer's units and the shell's hydration order cannot drift apart.

## Assets

Four CC0 Poly Haven maps fetched by `npm run fetch:assets`, gitignored, credited
in `examples/terrain/ASSETS.md`. Poly Haven serves direct per-file URLs, so the
fetch script needed only a `{ from, to }` form to rename files nested under a
per-asset path.

## Verification

- `cargo test -p functor_runtime_common --lib` — 473 passed, 0 failed. Includes
  the drift test pinning `.funi` signatures against the typed registry, so
  `Terrain.textured` is consistent on both sides.
- `npm run check:docs` passes; `functor -d examples/terrain build native`
  typechecks.
- Skill + `.funi` docs updated in the same commit, per CLAUDE.md.

## Remaining before ready

- [ ] **Quest cost not measured.** This adds 8 texture fetches per fragment on
      terrain. Stacked follow-up will report `quest-benchmark` numbers and
      optimize.
- [ ] Terrain golden coverage (`terrain-t2`) — this shader has no regression net.
- [ ] `/xreview` per CLAUDE.md §5.

## Known limitation

Distant terrain stays smooth: metre-scale detail is sub-pixel at kilometre range,
so it correctly averages away. Adding kilometre-scale variation (a macro/color
map, and terrain shadowing) is separate work — see the review discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)