### PR TITLE
fix(time-travel): a branch rewinds the subscription-timer window too

### DIFF
--- a/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
@@ -438,6 +438,7 @@ impl FunctorLangEmbeddedGame {
             &mut self.physics_rt,
             &mut self.physics_frame,
             self.has_physics,
+            &mut self.prev_tts,
         );
         let (model, report) = functor_lang::rebind_value(&self.model, &self.module, &loaded.module);
         self.model = model;
@@ -707,6 +708,7 @@ impl GameProducer for FunctorLangEmbeddedGame {
             &mut self.physics_rt,
             &mut self.physics_frame,
             self.has_physics,
+            &mut self.prev_tts,
         );
         if result.is_ok() {
             self.deferred_queries.clear();

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -381,6 +381,7 @@ impl FrameCtx<'_> {
                 self.physics_rt,
                 self.physics_frame,
                 self.has_physics,
+                self.prev_tts,
             )
         {
             self.deferred_queries.clear();

--- a/runtime/functor-runtime-common/src/timetravel.rs
+++ b/runtime/functor-runtime-common/src/timetravel.rs
@@ -827,10 +827,10 @@ impl SceneRecorder {
         // breaks across the branch. Timers fire over `(prev_tts, tts]`; leaving
         // `prev_tts` at the live tail while the clock rebases to this frame
         // makes that window empty or negative, so every timer stays silent
-        // until the clock climbs back past where it used to be — and if the
-        // branch instead moves time FORWARD, the window spans the whole gap and
-        // the timers fire as a burst. Taken from `tts_history` BEFORE the
-        // truncate below, which is why this line sits here rather than after.
+        // until the clock climbs back past where it used to be. (A branch that
+        // moved time FORWARD would fire them as a burst instead, but that is
+        // unreachable here: `frame` is clamped to the newest recorded frame,
+        // which is where `prev_tts` already sits.)
         //
         // The forward-step/ghost path already guards this hazard explicitly
         // (`functor_lang_producer.rs`, "a scrubbed preview must not seed
@@ -1160,17 +1160,13 @@ mod tests {
         rec.rewind_scene_to(3, &mut model, &mut physics, &mut physics_frame, false, &mut prev_tts)
             .expect("rewind");
 
+        // The next frame's window is then (3.0, 3.0+dt] — forward and non-empty.
+        // With the bug it was (9.0, 3.0+dt]: negative, so every timer was mute
+        // for six seconds of game time.
         assert_eq!(
             prev_tts,
             Some(3.0),
             "prev_tts must follow the model back to the branch frame's recorded tts"
-        );
-        // The next frame's window is (3.0, 3.0+dt] — forward and non-empty.
-        // With the bug it was (9.0, 3.0+dt]: negative, so every timer was mute
-        // for six seconds of game time.
-        assert!(
-            prev_tts.unwrap() < 3.0 + 1.0,
-            "the next frame's timer window must open forward from the branch"
         );
     }
 
@@ -1346,7 +1342,22 @@ mod tests {
         rec.seek_scene_to(2, &mut model, &mut physics, &mut physics_frame, false)
             .expect("seek");
         assert!(!rec.reload_history_is_safe());
-        rec.commit_scrub_before_reload(&mut model, &mut physics, &mut physics_frame, false, &mut None);
+        // The reload-while-scrubbed branch restores the timer window too — the
+        // third path into `rewind_scene_to`, which the dedicated tests above
+        // don't reach. [xreview]
+        let mut prev_tts = Some(4.0);
+        rec.commit_scrub_before_reload(
+            &mut model,
+            &mut physics,
+            &mut physics_frame,
+            false,
+            &mut prev_tts,
+        );
+        assert_eq!(
+            prev_tts,
+            Some(2.0),
+            "an unsafe reload while scrubbed branches, so its timer window rewinds too"
+        );
         let generation = rec.generation();
 
         assert_eq!(

--- a/runtime/functor-runtime-common/src/timetravel.rs
+++ b/runtime/functor-runtime-common/src/timetravel.rs
@@ -460,11 +460,12 @@ impl SceneRecorder {
         physics: &mut SteppedPhysics,
         physics_frame: &mut u64,
         has_physics: bool,
+        prev_tts: &mut Option<f64>,
     ) -> bool {
         let live_model_is_safe = model.is_reload_safe_snapshot();
         if !self.reload_history_is_safe() || !live_model_is_safe {
             let authoritative_model = model.clone();
-            self.commit_scrub_before_reload(model, physics, physics_frame, has_physics);
+            self.commit_scrub_before_reload(model, physics, physics_frame, has_physics, prev_tts);
             *model = authoritative_model;
         }
         live_model_is_safe
@@ -590,9 +591,10 @@ impl SceneRecorder {
         physics: &mut SteppedPhysics,
         physics_frame: &mut u64,
         has_physics: bool,
+        prev_tts: &mut Option<f64>,
     ) {
         if let Some(frame) = self.scrub_pos {
-            let _ = self.rewind_scene_to(frame, model, physics, physics_frame, has_physics);
+            let _ = self.rewind_scene_to(frame, model, physics, physics_frame, has_physics, prev_tts);
         }
     }
 
@@ -758,9 +760,10 @@ impl SceneRecorder {
         physics: &mut SteppedPhysics,
         physics_frame: &mut u64,
         has_physics: bool,
+        prev_tts: &mut Option<f64>,
     ) -> bool {
         if let Some(k) = self.scrub_pos.take() {
-            let _ = self.rewind_scene_to(k, model, physics, physics_frame, has_physics);
+            let _ = self.rewind_scene_to(k, model, physics, physics_frame, has_physics, prev_tts);
             self.counterfactual_replay = false;
             true
         } else {
@@ -807,6 +810,7 @@ impl SceneRecorder {
         physics: &mut SteppedPhysics,
         physics_frame: &mut u64,
         has_physics: bool,
+        prev_tts: &mut Option<f64>,
     ) -> Result<String, String> {
         let (lo, hi) = self
             .model_history
@@ -819,6 +823,20 @@ impl SceneRecorder {
             let _ = physics.rewind_to_frame(fixed);
             *physics_frame = physics.current_fixed_frame();
         }
+        // Rewind the SUBSCRIPTION-TIMER window with the model, or `Sub.every`
+        // breaks across the branch. Timers fire over `(prev_tts, tts]`; leaving
+        // `prev_tts` at the live tail while the clock rebases to this frame
+        // makes that window empty or negative, so every timer stays silent
+        // until the clock climbs back past where it used to be — and if the
+        // branch instead moves time FORWARD, the window spans the whole gap and
+        // the timers fire as a burst. Taken from `tts_history` BEFORE the
+        // truncate below, which is why this line sits here rather than after.
+        //
+        // The forward-step/ghost path already guards this hazard explicitly
+        // (`functor_lang_producer.rs`, "a scrubbed preview must not seed
+        // subscription windows from the old live tail's prev_tts"); this is the
+        // same rule for the destructive path, which never had it. [xreview]
+        *prev_tts = Some(*self.tts_history.seek(frame));
         self.model_history.truncate_from(frame + 1);
         self.world_frame_history.truncate_from(frame + 1);
         self.tts_history.truncate_from(frame + 1);
@@ -1110,12 +1128,75 @@ mod tests {
             .expect("valid replay history")
             .expect("materialized history");
 
-        assert!(rec.commit_scrub_if_resuming(&mut model, &mut physics, &mut physics_frame, false));
+        assert!(rec.commit_scrub_if_resuming(&mut model, &mut physics, &mut physics_frame, false, &mut None));
         assert_eq!(model.to_string(), "12", "Resume adopts the rebuilt anchor");
         assert_eq!(rec.counterfactual_replay_span(), Ok(None));
         assert_eq!(rec.scene_frame_range(), Some((0, 2)));
         assert_eq!(rec.next_frame(), 3);
         assert_ne!(rec.generation(), generation, "Resume commits the branch");
+    }
+
+    /// A branch must rewind the SUBSCRIPTION-TIMER window with the model.
+    ///
+    /// `Sub.every` fires over `(prev_tts, tts]`. Leaving `prev_tts` at the live
+    /// tail across a rewind makes that window empty or negative, so timers stay
+    /// silent until the clock climbs back past where it used to be — the bug
+    /// this pins. The forward-step/ghost path already guarded it; the
+    /// destructive path never did.
+    #[test]
+    fn a_branch_rewinds_the_subscription_timer_window_with_the_model() {
+        let mut rec = SceneRecorder::new();
+        for frame in 0..10u64 {
+            rec.record_inputs(Vec::new());
+            // tts advances a second per frame, so a stale window is unmistakable.
+            rec.record(&Value::Number(frame as f64), 0, frame as f64);
+        }
+        let mut model = Value::Number(0.0);
+        let mut physics = SteppedPhysics::new();
+        let mut physics_frame = 0;
+
+        // The live tail: the game has been running to frame 9 (tts 9.0).
+        let mut prev_tts = Some(9.0);
+        rec.rewind_scene_to(3, &mut model, &mut physics, &mut physics_frame, false, &mut prev_tts)
+            .expect("rewind");
+
+        assert_eq!(
+            prev_tts,
+            Some(3.0),
+            "prev_tts must follow the model back to the branch frame's recorded tts"
+        );
+        // The next frame's window is (3.0, 3.0+dt] — forward and non-empty.
+        // With the bug it was (9.0, 3.0+dt]: negative, so every timer was mute
+        // for six seconds of game time.
+        assert!(
+            prev_tts.unwrap() < 3.0 + 1.0,
+            "the next frame's timer window must open forward from the branch"
+        );
+    }
+
+    /// The same rule on the path a resume actually takes: park, then resume.
+    #[test]
+    fn resuming_from_a_scrub_rewinds_the_timer_window_too() {
+        let mut rec = SceneRecorder::new();
+        for frame in 0..10u64 {
+            rec.record_inputs(Vec::new());
+            rec.record(&Value::Number(frame as f64), 0, frame as f64);
+        }
+        let mut model = Value::Number(0.0);
+        let mut physics = SteppedPhysics::new();
+        let mut physics_frame = 0;
+        rec.seek_scene_to(4, &mut model, &mut physics, &mut physics_frame, false)
+            .expect("seek");
+
+        let mut prev_tts = Some(9.0);
+        assert!(rec.commit_scrub_if_resuming(
+            &mut model,
+            &mut physics,
+            &mut physics_frame,
+            false,
+            &mut prev_tts
+        ));
+        assert_eq!(prev_tts, Some(4.0), "resume commits the branch and its window");
     }
 
     #[test]
@@ -1265,7 +1346,7 @@ mod tests {
         rec.seek_scene_to(2, &mut model, &mut physics, &mut physics_frame, false)
             .expect("seek");
         assert!(!rec.reload_history_is_safe());
-        rec.commit_scrub_before_reload(&mut model, &mut physics, &mut physics_frame, false);
+        rec.commit_scrub_before_reload(&mut model, &mut physics, &mut physics_frame, false, &mut None);
         let generation = rec.generation();
 
         assert_eq!(
@@ -1304,7 +1385,7 @@ mod tests {
             .expect("seek");
 
         assert!(!rec.reload_history_is_safe());
-        rec.commit_scrub_before_reload(&mut model, &mut physics, &mut physics_frame, false);
+        rec.commit_scrub_before_reload(&mut model, &mut physics, &mut physics_frame, false, &mut None);
         assert_eq!(rec.scene_frame_range(), Some((0, 2)));
         assert!(rec.reload_history_is_safe());
 
@@ -1334,7 +1415,7 @@ mod tests {
         model = closure_model();
         let live_before = model.to_string();
         let live_model_was_safe =
-            rec.prepare_reload(&mut model, &mut physics, &mut physics_frame, false);
+            rec.prepare_reload(&mut model, &mut physics, &mut physics_frame, false, &mut None);
         assert!(!live_model_was_safe);
         assert_eq!(model.to_string(), live_before);
         assert_eq!(rec.scene_frame_range(), Some((0, 2)));

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -560,6 +560,7 @@ impl FunctorLangGame {
             &mut self.physics_rt,
             &mut self.physics_frame,
             self.has_physics,
+            &mut self.prev_tts,
         );
         let (model, report) = functor_lang::rebind_value(&self.model, &self.module, &loaded.module);
         self.model = model;
@@ -919,6 +920,7 @@ impl Game for FunctorLangGame {
             &mut self.physics_rt,
             &mut self.physics_frame,
             self.has_physics,
+            &mut self.prev_tts,
         );
         if result.is_ok() {
             // No in-flight frame work should carry across the branch (matches


### PR DESCRIPTION
A bug in the **shipped single-game scrubber**, reproducible today with no
multiplayer involved: open `examples/hello`, scrub back five seconds, hit resume
— and its `Sub.every` timers stay silent for five seconds of game time.

`rewind_scene_to` restored the model and the physics world but left `prev_tts` at
the **live tail**. `Sub.every` fires over `(prev_tts, tts]`, so after any branch
that window was empty or negative and **every timer stayed silent** until the
clock climbed back past where it used to be.

Every resume-from-a-scrub is a branch (`commit_scrub_if_resuming`), as is an
unsafe reload while scrubbed and a debug-server `/rewind`. Four shipped examples
use `Sub.every` — `hello`, `hello-cubes`, `crossfade`, `inspector`.

## The fix

`prev_tts` is threaded through `SceneRecorder::rewind_scene_to` and restored from
`tts_history` **atomically with the model**.

Threading it through the recorder rather than patching the call sites is
deliberate: three paths rewind (`rewind_scene_to`, `commit_scrub_if_resuming`,
`commit_scrub_before_reload`) and two producers call them, so the compiler now
enforces what a comment could only ask for.

Corroborating evidence this was a missing rule rather than a design choice: the
forward-step/ghost path **already guards exactly this hazard** — "a scrubbed
preview must not seed subscription windows from the old live tail's `prev_tts`"
(`functor_lang_producer.rs`). The destructive path never had it.

## Tests

Three regression tests covering **all three paths** into `rewind_scene_to`, each
verified to **fail without the one-line restore** (they see the stale live tail
instead of the branch frame's tts):

- `a_branch_rewinds_the_subscription_timer_window_with_the_model` — the direct path.
- `resuming_from_a_scrub_rewinds_the_timer_window_too` — park, then
  `commit_scrub_if_resuming` (what a resume actually does).
- `closure_history_restarts_at_the_rebound_current_frame` — an unsafe reload
  while scrubbed, via `commit_scrub_before_reload`.

## Verification

- 461 `functor_runtime_common` tests (+2 new, +1 assertion added to an existing test).
- The netsim suites that exercise this through `commit_branch` — scrub, mp,
  typed — all pass.
- Strict build (`--features functor_runtime_common/strict`) clean.

## Review dispositions (fable reviewer)

No Critical or High findings. Fixed here:

- **A comment of mine was factually wrong.** It claimed the restore had to read
  `tts_history` "BEFORE the truncate below". It doesn't:
  `truncate_from(frame + 1)` drops frames `>= frame + 1`, so `frame` itself
  survives and either placement works. Bogus justification removed.
- **An overstated failure mode.** I claimed a forward-moving branch fires timers
  as a burst. It *would*, but it's unreachable — `frame` is clamped to the newest
  recorded frame, which is exactly where `prev_tts` already sits. Softened to the
  conditional it is.
- **A vacuous assertion in my own test** — `prev_tts.unwrap() < 4.0` is strictly
  implied by the `assert_eq!(prev_tts, Some(3.0))` two lines above. Deleted.
- **An untested path** — the reload-while-scrubbed branch had no assertion
  anywhere. Now pinned.

Filed as follow-ups (both pre-existing, both the same shape as this bug —
cross-frame producer state a branch should restore and doesn't):

- **Medium** — `swap_in`'s unsafe-reload branch path doesn't invalidate
  `delivered_asset_progress`, so a `Sub.assets` game branched back past a
  delivered snapshot never re-learns it. The other two branch paths guard this.
- **Low** — `journal_ring` survives a branch with colliding frame keys, so
  inspector coverage can mix executions from both branches.

## How it was found

Via multiplayer work — the Codex reviewer flagged it on #472, and the
multiplayer-session design independently named it blocking, since
server-authoritative scrubbing makes every scrub-resume a branch. But it is **not
a multiplayer prerequisite**: it is a defect in shipped single-player
time-travel, and it would be worth fixing if the multiplayer work never happened.
It does also unblock that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
