### PR TITLE
refactor(site): typecheck the editor↔player protocol

### DIFF
--- a/.github/workflows/wasm-smoke.yml
+++ b/.github/workflows/wasm-smoke.yml
@@ -69,6 +69,13 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
 
+      # Typecheck the site's TypeScript. esbuild STRIPS types without checking
+      # them, so the site build stays green on a type error — this step is the
+      # only thing that enforces them. Needs nothing but npm, so it runs first
+      # and fails fast, before the expensive Rust/wasm builds below.
+      - name: Typecheck the site
+        run: npm run check:site
+
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "@vscode/test-electron": "^2.4.1",
         "codemirror": "^6.0.2",
         "esbuild": "^0.28.1",
-        "png-to-ico": "^3.0.2"
+        "png-to-ico": "^3.0.2",
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/@codemirror/autocomplete": {
@@ -1452,6 +1453,20 @@
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.24.6",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test:inspector-emit": "node e2e/inspector-emit.mjs",
     "test:scrubber": "node --test runtime/functor-runtime-web/timeline-model.test.js",
     "test:vscode-e2e": "playwright test -c tools/functor-lang-vscode/tests-integration/playwright.config.mjs",
+    "check:site": "tsc -p site --noEmit",
     "site:build": "npm run generate:icons && node site/build.mjs",
     "site:serve": "node site/serve.mjs",
     "test:site": "node e2e/site-sandbox.mjs",
@@ -51,6 +52,7 @@
     "@vscode/test-electron": "^2.4.1",
     "codemirror": "^6.0.2",
     "esbuild": "^0.28.1",
-    "png-to-ico": "^3.0.2"
+    "png-to-ico": "^3.0.2",
+    "typescript": "^5.9.3"
   }
 }

--- a/site/src/hero.js
+++ b/site/src/hero.js
@@ -4,7 +4,7 @@
 // the wave keeps rolling — then drag the timeline back through the change.
 //
 // This is the light sibling of sandbox.js: it reuses the same editor↔player
-// seam (player-bridge.js) but a stripped editor (mini-editor.js — no basicSetup
+// seam (player-bridge.ts) but a stripped editor (mini-editor.js — no basicSetup
 // or lint) so the landing bundle stays tiny. It NEVER reloads the iframe; every
 // edit is a source push, because state preservation IS the demo.
 

--- a/site/src/ide.js
+++ b/site/src/ide.js
@@ -1,7 +1,7 @@
 // The web IDE: a file sidebar + multi-file Functor Lang editor + live preview.
 // The IDE holds the WHOLE project in memory (nothing is served) and pushes it
 // over the `functor-lang-set-project` seam to a `player.html?project=inline`
-// iframe (see project-bridge.js): the preview boots from memory and hot-swaps
+// iframe (see project-bridge.ts): the preview boots from memory and hot-swaps
 // on every edit, model preserved. Work is persisted to localStorage; the
 // project downloads as a .zip that drops into `functor -d <dir> build wasm`.
 

--- a/site/src/player-bridge.ts
+++ b/site/src/player-bridge.ts
@@ -7,6 +7,9 @@
 // with the model preserved and replies `functor-lang-set-source-result`. The
 // player announces itself with `functor-lang-preview-ready` after it boots.
 
+import { asPlayerMessage } from "./protocol.js";
+import type { BridgeOptions, PreviewHello, SetSource } from "./protocol.js";
+
 // Same cadence as the VSCode extension: fast enough to feel live, slow enough
 // not to push a reload per keystroke.
 const PUSH_DEBOUNCE_MS = 300;
@@ -17,19 +20,33 @@ const PUSH_DEBOUNCE_MS = 300;
 const ERROR_GRACE_MS = 4000;
 
 export class PlayerBridge {
-  // iframe: the player element. Callbacks map protocol events to UI:
-  //   onReloading()          — a push was sent (busy)
-  //   onLive()               — the player is ready with nothing pending
-  //   onResult(ok, message)  — a hot-swap reply came back
+  readonly iframe: HTMLIFrameElement;
+  private readonly onReloading: () => void;
+  private readonly onLive: () => void;
+  private readonly onResult: (ok: boolean, message: string) => void;
+  private readonly debounceMs: number;
+  private readonly errorGraceMs: number;
+
+  private previewReady = false;
+  private dirty = false;
+  private pushTimer: ReturnType<typeof setTimeout> | undefined;
+  private errorTimer: ReturnType<typeof setTimeout> | undefined;
+  private lastSource = "";
+  // Correlates results with pushes: each posted push gets a fresh id, the
+  // runtime echoes it in the result, and a result for anything but the
+  // LATEST push is stale — ignore it, its reply is coming. Results with no
+  // id (an older runtime) are accepted as before.
+  private pushId = 0;
+
   constructor(
-    iframe,
+    iframe: HTMLIFrameElement,
     {
       onReloading,
       onLive,
       onResult,
       debounceMs = PUSH_DEBOUNCE_MS,
       errorGraceMs = ERROR_GRACE_MS,
-    }
+    }: BridgeOptions
   ) {
     this.iframe = iframe;
     this.onReloading = onReloading;
@@ -37,17 +54,6 @@ export class PlayerBridge {
     this.onResult = onResult;
     this.debounceMs = debounceMs;
     this.errorGraceMs = errorGraceMs;
-
-    this.previewReady = false;
-    this.dirty = false;
-    this.pushTimer = null;
-    this.errorTimer = null;
-    this.lastSource = "";
-    // Correlates results with pushes: each posted push gets a fresh id, the
-    // runtime echoes it in the result, and a result for anything but the
-    // LATEST push is stale — ignore it, its reply is coming. Results with no
-    // id (an older runtime) are accepted as before.
-    this.pushId = 0;
 
     // Replies and readiness from the player iframe. Only trust the iframe we
     // created (same-origin, but be explicit about the source anyway).
@@ -65,12 +71,13 @@ export class PlayerBridge {
   // Greet the player so an already-live one re-announces readiness. Harmless if
   // the player isn't up yet: it ignores the hello and its one-shot ready (now
   // reaching our attached listener) covers that direction.
-  #hello() {
-    this.iframe.contentWindow?.postMessage({ type: "functor-lang-preview-hello" }, "*");
+  #hello(): void {
+    const message: PreviewHello = { type: "functor-lang-preview-hello" };
+    this.iframe.contentWindow?.postMessage(message, "*");
   }
 
   // Debounced live edit: swap in `source` once the buffer settles.
-  push(source) {
+  push(source: string): void {
     this.lastSource = source;
     clearTimeout(this.pushTimer);
     this.pushTimer = setTimeout(() => this.#post(), this.debounceMs);
@@ -78,7 +85,7 @@ export class PlayerBridge {
 
   // Reset for a fresh iframe load (fresh model: init runs). Cancels any pending
   // push and drops readiness until the next `functor-lang-preview-ready`.
-  reset() {
+  reset(): void {
     clearTimeout(this.pushTimer);
     clearTimeout(this.errorTimer);
     this.previewReady = false;
@@ -89,7 +96,7 @@ export class PlayerBridge {
   // last good program running, so the preview IS still live; show that now and
   // only surface the error if the program stays broken past the grace window.
   // Any success (the usual next keystroke that re-parses) clears it instantly.
-  #deliverResult(ok, message) {
+  #deliverResult(ok: boolean, message: string): void {
     clearTimeout(this.errorTimer);
     if (ok) {
       this.onResult(true, message);
@@ -99,7 +106,7 @@ export class PlayerBridge {
     }
   }
 
-  #post() {
+  #post(): void {
     if (!this.previewReady || !this.iframe.contentWindow) {
       this.dirty = true;
       return;
@@ -107,15 +114,22 @@ export class PlayerBridge {
     this.dirty = false;
     this.onReloading();
     this.pushId += 1;
-    this.iframe.contentWindow.postMessage(
-      { type: "functor-lang-set-source", source: this.lastSource, id: this.pushId },
-      "*"
-    );
+    const message: SetSource = {
+      type: "functor-lang-set-source",
+      source: this.lastSource,
+      id: this.pushId,
+    };
+    // Re-read `contentWindow` (rather than reusing the guarded reference) and
+    // post NON-optionally, exactly as the pre-migration code did: if
+    // `onReloading()` above swapped the iframe, the push must reach the NEW
+    // window, and a detached one must throw loudly rather than be silently
+    // dropped (a dropped push leaves the status stuck on "reloading…").
+    this.iframe.contentWindow!.postMessage(message, "*");
   }
 
-  #onMessage(event) {
+  #onMessage(event: MessageEvent): void {
     if (event.source !== this.iframe.contentWindow) return;
-    const data = event.data;
+    const data = asPlayerMessage(event.data);
     if (!data) return;
     if (data.type === "functor-lang-preview-ready") {
       // Idempotent: the one-shot ready and a hello-ack ready can both arrive for

--- a/site/src/project-bridge.ts
+++ b/site/src/project-bridge.ts
@@ -1,5 +1,5 @@
 // The multi-file editor ↔ player bridge — the whole-project sibling of
-// player-bridge.js (which pushes a single source buffer). The IDE owns every
+// player-bridge.ts (which pushes a single source buffer). The IDE owns every
 // .fun in memory, so it pushes the full file set over `functor-lang-set-project`
 // to a `player.html?project=inline` iframe: the player boots from memory (no
 // fetch) on the first push, then hot-swaps (model preserved) on each edit.
@@ -9,6 +9,9 @@
 // `functor-lang-preview-ready` once the producer is live, and
 // `functor-lang-set-source-result` (with our echoed id) for every hot-swap.
 
+import { asPlayerMessage } from "./protocol.js";
+import type { BridgeOptions, ProjectFile, SetProject } from "./protocol.js";
+
 const PUSH_DEBOUNCE_MS = 300;
 
 // A rejected edit keeps the last good program running, so an error isn't urgent.
@@ -17,19 +20,30 @@ const PUSH_DEBOUNCE_MS = 300;
 const ERROR_GRACE_MS = 4000;
 
 export class ProjectBridge {
-  // iframe: the player element. Callbacks map protocol events to UI:
-  //   onReloading()          — a push was sent (busy)
-  //   onLive()               — the player booted / is ready
-  //   onResult(ok, message)  — a hot-swap reply came back
+  readonly iframe: HTMLIFrameElement;
+  private readonly onReloading: () => void;
+  private readonly onLive: () => void;
+  private readonly onResult: (ok: boolean, message: string) => void;
+  private readonly debounceMs: number;
+  private readonly errorGraceMs: number;
+
+  private waiting = false; // player announced project-waiting (safe to push)
+  private files: ProjectFile[] | null = null; // latest full file set
+  private pushTimer: ReturnType<typeof setTimeout> | undefined;
+  private errorTimer: ReturnType<typeof setTimeout> | undefined;
+  // Correlates results with pushes: each push gets a fresh id, the runtime
+  // echoes it, and a result for anything but the LATEST push is stale.
+  private pushId = 0;
+
   constructor(
-    iframe,
+    iframe: HTMLIFrameElement,
     {
       onReloading,
       onLive,
       onResult,
       debounceMs = PUSH_DEBOUNCE_MS,
       errorGraceMs = ERROR_GRACE_MS,
-    }
+    }: BridgeOptions
   ) {
     this.iframe = iframe;
     this.onReloading = onReloading;
@@ -38,19 +52,11 @@ export class ProjectBridge {
     this.debounceMs = debounceMs;
     this.errorGraceMs = errorGraceMs;
 
-    this.waiting = false; // player announced project-waiting (safe to push)
-    this.files = null; // latest full file set
-    this.pushTimer = null;
-    this.errorTimer = null;
-    // Correlates results with pushes: each push gets a fresh id, the runtime
-    // echoes it, and a result for anything but the LATEST push is stale.
-    this.pushId = 0;
-
     window.addEventListener("message", (event) => this.#onMessage(event));
   }
 
   // Debounced whole-project push: swap in the file set once edits settle.
-  setProject(files) {
+  setProject(files: ProjectFile[]): void {
     this.files = files;
     clearTimeout(this.pushTimer);
     this.pushTimer = setTimeout(() => this.#send(), this.debounceMs);
@@ -58,7 +64,7 @@ export class ProjectBridge {
 
   // Reset for a fresh iframe (a new project=inline load): drop the handshake
   // state until the next `functor-lang-project-waiting`.
-  reset() {
+  reset(): void {
     clearTimeout(this.pushTimer);
     clearTimeout(this.errorTimer);
     this.waiting = false;
@@ -68,7 +74,7 @@ export class ProjectBridge {
   // last good program running, so the preview IS still live; show that now and
   // only surface the error if the program stays broken past the grace window.
   // Any success (the usual next keystroke that re-parses) clears it instantly.
-  #deliverResult(ok, message) {
+  #deliverResult(ok: boolean, message: string): void {
     clearTimeout(this.errorTimer);
     if (ok) {
       this.onResult(true, message);
@@ -78,7 +84,7 @@ export class ProjectBridge {
     }
   }
 
-  #send() {
+  #send(): void {
     clearTimeout(this.pushTimer); // an early flush cancels the pending timer
     if (!this.iframe.contentWindow || !this.files) return;
     // The player drops anything sent before it announces `project-waiting`;
@@ -86,15 +92,20 @@ export class ProjectBridge {
     if (!this.waiting) return;
     this.onReloading();
     this.pushId += 1;
-    this.iframe.contentWindow.postMessage(
-      { type: "functor-lang-set-project", files: this.files, id: this.pushId },
-      "*"
-    );
+    const message: SetProject = {
+      type: "functor-lang-set-project",
+      files: this.files,
+      id: this.pushId,
+    };
+    // Re-read `contentWindow` after `onReloading()`, matching PlayerBridge:
+    // a callback that swapped the iframe must not have its push sent to the
+    // outgoing window, and a detached one must throw rather than be dropped.
+    this.iframe.contentWindow!.postMessage(message, "*");
   }
 
-  #onMessage(event) {
+  #onMessage(event: MessageEvent): void {
     if (event.source !== this.iframe.contentWindow) return;
-    const data = event.data;
+    const data = asPlayerMessage(event.data);
     if (!data) return;
     if (data.type === "functor-lang-project-waiting") {
       // The player is armed: flush the initial (or any held) project to boot it.

--- a/site/src/protocol.ts
+++ b/site/src/protocol.ts
@@ -1,0 +1,166 @@
+// The editor ↔ player postMessage protocol — the seam between an editor page
+// (sandbox, IDE, hero, demo-editor) and the wasm runtime inside its player
+// iframe. Both bridges (player-bridge.ts, project-bridge.ts) speak it, the
+// player implements the other end (site/player.html), and the VSCode
+// live-preview panel speaks the single-source half of it.
+//
+// These messages cross a window boundary, so nothing checks them at runtime
+// beyond the `type` discriminant: a payload typo used to fail silently. The
+// types here are the single written-down description of that contract — keep
+// them in step with site/player.html when the protocol changes.
+
+/** One file of an in-memory project (the IDE's flat module space). */
+export interface ProjectFile {
+  path: string;
+  source: string;
+}
+
+// --- editor → player ---------------------------------------------------------
+
+/**
+ * Greet a player that may already be live. Its one-shot `preview-ready` can
+ * fire before a bridge attaches its listener; an already-live player answers a
+ * hello with a fresh `preview-ready`.
+ */
+export interface PreviewHello {
+  type: "functor-lang-preview-hello";
+}
+
+/**
+ * Hot-swap the single entry buffer, preserving the model.
+ *
+ * `id` is optional because it is not universal: both bridges here always send
+ * one, but the VSCode live-preview panel posts id-less pushes
+ * (tools/functor-lang-vscode/client/extension.js), and the player and runtime
+ * both accept them — an id-less push simply gets an id-less result (the
+ * pre-id protocol).
+ */
+export interface SetSource {
+  type: "functor-lang-set-source";
+  source: string;
+  id?: number;
+}
+
+/**
+ * Boot from / hot-swap a whole in-memory project (the IDE's push).
+ *
+ * `files` must be non-empty and every `path` non-blank — the player rejects
+ * anything else as a "malformed project push" (player.html). That is a runtime
+ * precondition rather than a type: the only producer is ide.js, which is still
+ * JavaScript, so a non-empty-tuple type here would be an unchecked assertion
+ * at the boundary rather than a real guarantee.
+ */
+export interface SetProject {
+  type: "functor-lang-set-project";
+  files: ProjectFile[];
+  /** Optional for the same reason as {@link SetSource.id}. */
+  id?: number;
+}
+
+export type EditorMessage = PreviewHello | SetSource | SetProject;
+
+/**
+ * The callback contract both bridges expose: how protocol events map to UI.
+ * It lives here rather than in either bridge so the two stay independent
+ * siblings — `import type` + `verbatimModuleSyntax` erase it entirely, so
+ * neither bundle pulls in the other.
+ */
+export interface BridgeOptions {
+  /** a push was sent (busy) */
+  onReloading: () => void;
+  /** the player is ready with nothing pending (or, for a project, booted) */
+  onLive: () => void;
+  /** a hot-swap reply came back */
+  onResult: (ok: boolean, message: string) => void;
+  debounceMs?: number;
+  errorGraceMs?: number;
+}
+
+// --- player → editor ---------------------------------------------------------
+
+/** The producer is live. Also sent in answer to a `preview-hello`. */
+export interface PreviewReady {
+  type: "functor-lang-preview-ready";
+}
+
+/**
+ * The player's listener is armed and it is waiting to be handed a project —
+ * only after this may a `set-project` push land (`player.html?project=inline`).
+ */
+export interface ProjectWaiting {
+  type: "functor-lang-project-waiting";
+}
+
+/**
+ * The reply to a `set-source` / `set-project` hot-swap. `id` echoes the push
+ * it answers; a result for anything but the latest push is stale. It is
+ * optional because an older runtime omits it.
+ */
+export interface SetSourceResult {
+  type: "functor-lang-set-source-result";
+  ok: boolean;
+  message: string;
+  id?: number;
+}
+
+export type ConsoleLevel = "log" | "warn" | "error";
+
+/**
+ * A forwarded runtime console line (Functor Lang `Debug.log` and friends).
+ * `frame` is the game frame it was emitted on, or null before the runtime has
+ * recorded one (the Output panel then shows the time alone).
+ */
+export interface ConsoleLine {
+  type: "functor-lang-console";
+  level: ConsoleLevel;
+  message: string;
+  frame: number | null;
+}
+
+/**
+ * The paused inspector's trace — live values and entry-point executions for
+ * the paused frame. The payload is the interpreter's own shape, consumed only
+ * by lang-intel; it stays `unknown` here until that module migrates.
+ */
+export interface InspectorTrace {
+  type: "functor-inspector-trace";
+  trace: unknown;
+}
+
+export type PlayerMessage =
+  | PreviewReady
+  | ProjectWaiting
+  | SetSourceResult
+  | ConsoleLine
+  | InspectorTrace;
+
+const PLAYER_MESSAGE_TYPES = new Set<PlayerMessage["type"]>([
+  "functor-lang-preview-ready",
+  "functor-lang-project-waiting",
+  "functor-lang-set-source-result",
+  "functor-lang-console",
+  "functor-inspector-trace",
+]);
+
+/**
+ * Narrow a `MessageEvent.data` of unknown provenance to a player message.
+ * Anything that is not an object carrying one of the KNOWN discriminants is
+ * rejected — null, numbers, and another library's window traffic alike.
+ *
+ * Checking the discriminant (rather than merely "has some string `type`") is
+ * what makes the returned type honest. It is also behaviour-preserving: every
+ * consumer already switched on these exact types and ignored the rest.
+ *
+ * The PAYLOAD fields are asserted, not validated: the player is same-origin
+ * first-party code (site/player.html) and the `event.source` check upstream
+ * pins the sender to our own iframe, so a well-formed discriminant implies a
+ * well-formed body. Validating fields here would additionally CHANGE
+ * behaviour — the old code passed a malformed body straight through to the
+ * callbacks — so it is deliberately out of scope for this migration.
+ */
+export const asPlayerMessage = (data: unknown): PlayerMessage | null =>
+  typeof data === "object" &&
+  data !== null &&
+  PLAYER_MESSAGE_TYPES.has((data as { type?: PlayerMessage["type"] }).type as PlayerMessage["type"])
+    ? (data as PlayerMessage)
+    : null;

--- a/site/src/protocol.ts
+++ b/site/src/protocol.ts
@@ -1,13 +1,20 @@
-// The editor ↔ player postMessage protocol — the seam between an editor page
-// (sandbox, IDE, hero, demo-editor) and the wasm runtime inside its player
-// iframe. Both bridges (player-bridge.ts, project-bridge.ts) speak it, the
-// player implements the other end (site/player.html), and the VSCode
-// live-preview panel speaks the single-source half of it.
+// The SITE's editor ↔ player postMessage protocol — the seam between an editor
+// page (sandbox, IDE, hero, demo-editor) and the wasm runtime inside its
+// player iframe. Both bridges (player-bridge.ts, project-bridge.ts) speak it;
+// site/player.html implements the other end.
 //
 // These messages cross a window boundary, so nothing checks them at runtime
-// beyond the `type` discriminant: a payload typo used to fail silently. The
-// types here are the single written-down description of that contract — keep
-// them in step with site/player.html when the protocol changes.
+// beyond the `type` discriminant: a payload typo used to fail silently. Keep
+// these types in step with site/player.html when the protocol changes.
+//
+// SCOPE — this describes the site's seam, not every speaker of every related
+// message. Two neighbours overlap without being covered here:
+//   • The VSCode live-preview panel sends `set-source`/`set-project` too, but
+//     also a `functor-lang-preview-navigate` of its own, and its preview page
+//     (runtime/functor-runtime-web/index-functor-lang.html) has no `hello`
+//     handler — so the hello/ready handshake below is player.html-specific.
+//   • The Rust web runtime posts `set-source-result` directly
+//     (functor-runtime-web/src/lib.rs), in the same shape as player.html.
 
 /** One file of an in-memory project (the IDE's flat module space). */
 export interface ProjectFile {
@@ -62,8 +69,7 @@ export type EditorMessage = PreviewHello | SetSource | SetProject;
 /**
  * The callback contract both bridges expose: how protocol events map to UI.
  * It lives here rather than in either bridge so the two stay independent
- * siblings — `import type` + `verbatimModuleSyntax` erase it entirely, so
- * neither bundle pulls in the other.
+ * siblings — neither has to import the other just to name its own options.
  */
 export interface BridgeOptions {
   /** a push was sent (busy) */
@@ -94,7 +100,9 @@ export interface ProjectWaiting {
 /**
  * The reply to a `set-source` / `set-project` hot-swap. `id` echoes the push
  * it answers; a result for anything but the latest push is stale. It is
- * optional because an older runtime omits it.
+ * omitted whenever the push carried no id — by older runtimes, but also by
+ * the CURRENT one for an id-less push (the VSCode panel's, or a rejected
+ * malformed project).
  */
 export interface SetSourceResult {
   type: "functor-lang-set-source-result";
@@ -134,7 +142,7 @@ export type PlayerMessage =
   | ConsoleLine
   | InspectorTrace;
 
-const PLAYER_MESSAGE_TYPES = new Set<PlayerMessage["type"]>([
+const PLAYER_MESSAGE_TYPES: ReadonlySet<string> = new Set<PlayerMessage["type"]>([
   "functor-lang-preview-ready",
   "functor-lang-project-waiting",
   "functor-lang-set-source-result",
@@ -158,9 +166,10 @@ const PLAYER_MESSAGE_TYPES = new Set<PlayerMessage["type"]>([
  * behaviour — the old code passed a malformed body straight through to the
  * callbacks — so it is deliberately out of scope for this migration.
  */
-export const asPlayerMessage = (data: unknown): PlayerMessage | null =>
-  typeof data === "object" &&
-  data !== null &&
-  PLAYER_MESSAGE_TYPES.has((data as { type?: PlayerMessage["type"] }).type as PlayerMessage["type"])
+export const asPlayerMessage = (data: unknown): PlayerMessage | null => {
+  if (typeof data !== "object" || data === null) return null;
+  const { type } = data as { type?: unknown };
+  return typeof type === "string" && PLAYER_MESSAGE_TYPES.has(type)
     ? (data as PlayerMessage)
     : null;
+};

--- a/site/src/sandbox.js
+++ b/site/src/sandbox.js
@@ -1,5 +1,5 @@
 // The sandbox page: a CodeMirror editor wired to the runtime iframe over the
-// editor↔player postMessage seam (player-bridge.js — the same protocol the
+// editor↔player postMessage seam (player-bridge.ts — the same protocol the
 // VSCode live-preview panel uses). Edits are debounced and pushed as
 // `functor-lang-set-source`; the runtime hot-swaps the program with the model
 // preserved and replies `functor-lang-set-source-result`.

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -1,0 +1,41 @@
+{
+  // Typecheck-only: esbuild does the transpiling (site/build.mjs), so this
+  // never emits. `npm run check:site` runs it.
+  //
+  // The site is migrating to TypeScript file by file. `include` picks up only
+  // .ts files, so a module joins the checked set the moment it is renamed —
+  // no per-file bookkeeping here. esbuild and tsc both resolve a `./x.js`
+  // import to `x.ts`, so a migration needs no import-specifier churn and the
+  // still-JS importers keep working untouched.
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": true,
+
+    // esbuild transpiles each file in isolation, so the source must never
+    // depend on cross-file type elision: `verbatimModuleSyntax` forces
+    // type-only imports to say `import type`.
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+
+    // A migrated .ts importing a still-.js sibling (say hero.ts importing
+    // mini-editor.js) is otherwise TS7016 "could not find a declaration file".
+    // `checkJs` stays off, so the .js files are resolved but never checked.
+    "allowJs": true,
+
+    // NEVER set `useDefineForClassFields: false` here. esbuild honours this
+    // file for the plain .js under site/ too, so that key would silently
+    // change class-field semantics in every unmigrated module. Leaving it
+    // implied by `target` keeps esbuild's behaviour identical to today's.
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -25,10 +25,13 @@
     "isolatedModules": true,
     "verbatimModuleSyntax": true,
 
-    // A migrated .ts importing a still-.js sibling (say hero.ts importing
-    // mini-editor.js) is otherwise TS7016 "could not find a declaration file".
-    // `checkJs` stays off, so the .js files are resolved but never checked.
-    "allowJs": true,
+    // The site runs in a BROWSER. Without this, tsc auto-includes every
+    // @types/* package in node_modules — @types/node among them — so
+    // `process.platform`, `Buffer`, and `require` would all typecheck in code
+    // that can never use them, and `ReturnType<typeof setTimeout>` would
+    // resolve to NodeJS.Timeout instead of number. An empty list means the
+    // `lib` above is the whole ambient world.
+    "types": [],
 
     // NEVER set `useDefineForClassFields: false` here. esbuild honours this
     // file for the plain .js under site/ too, so that key would silently


### PR DESCRIPTION
Step 1 of migrating the site to TypeScript, file by file. **Typecheck-only** —
esbuild still does the transpiling; `tsc --noEmit` runs via the new
`npm run check:site`. Bundle sizes are unchanged (types are stripped).

## Why this file first

`site/src/protocol.ts` writes down the editor↔player postMessage contract for
the first time. These messages cross a **window boundary**, so nothing checked
them beyond the `type` discriminant — a payload typo failed silently. That is
the same class of bug the header PR's review caught in `injectHeader`, and it
is the highest-value place in the site to put types.

The contract is now enumerated: `ProjectFile`, the editor→player messages
(`PreviewHello`, `SetSource`, `SetProject`), the player→editor messages
(`PreviewReady`, `ProjectWaiting`, `SetSourceResult`, `ConsoleLine`,
`InspectorTrace`), the shared `BridgeOptions` callback contract, and an
`asPlayerMessage` narrowing guard.

## The migration mechanic

**esbuild and tsc both resolve a `./x.js` import specifier to `x.ts`.** So a
module joins the checked set purely by being renamed — no import-specifier
churn anywhere, and the still-JS importers (`sandbox.js`, `ide.js`, `hero.js`,
`demo-editor.js`) are untouched. `include` is `src/**/*.ts`, so there is no
per-file bookkeeping in the tsconfig either.

`allowJs: true` is set so the next step works: the first `.ts` importing a
still-`.js` sibling would otherwise hit `TS7016`. `checkJs` stays off, so the
`.js` files are resolved but never checked.

## Behaviour parity

The bridges are otherwise **exactly** behaviour-preserving. Both reviewers
diffed them against the originals and specifically cleared:

- **Class-field ordering** — fields are now declared rather than assigned in the
  constructor body. Under `useDefineForClassFields` they are defined *before*
  the body runs; nothing is read before assignment, nothing is shadowed, no
  subclassing. Verified against esbuild's actual emitted output.
- **`pushTimer`/`errorTimer` `null` → `undefined`** — only ever passed to
  `clearTimeout` (which accepts `undefined`) or reassigned from `setTimeout`.
  No truthiness test or comparison anywhere.
- **`asPlayerMessage`** — gates on the known discriminants. Everything it
  rejects but the old `if (!data) return;` accepted would have fallen through
  both branches anyway. All five types `player.html` actually posts are in the
  set, as is the `set-source-result` the Rust runtime sends.
- **tsconfig × esbuild on the remaining `.js`** — `useDefineForClassFields` is
  inferred `true` from `target: ES2022`, which is also the spec semantics
  esbuild already applied to `.js` class fields. A/B tested in-browser: both
  configurations behave identically. A comment in the tsconfig warns never to
  set that key explicitly, since esbuild honours it for plain `.js` too.

## Verification

- `npm run check:site` — exit 0
- `npm run site:build` — succeeds; bundles unchanged in size
- e2e (all re-run **after** the review fixes): `site-sandbox` ALL CHECKS PASSED ·
  `ide-page` PASS · `ide-project` PASS · `runtime-target` ALL CHECKS PASSED

## Review dispositions (`/xreview` — Claude + Codex)

No Critical or High findings. All dispositioned:

| Finding | Severity | Disposition |
| --- | --- | --- |
| `asPlayerMessage` asserted `PlayerMessage` for *any* object with a string `type`, so a malformed known message reached callbacks with `undefined` fields | Medium | **Fixed** — gates on the known discriminant set; behaviour-preserving, and the payload-trust boundary is now documented |
| `SetSource.id` declared required, but the VSCode live-preview panel sends **id-less** pushes (`extension.js:615,663`), which the player and runtime both accept | Medium | **Fixed** — `id?: number` on `SetSource` and `SetProject`. An inaccurate type is worse than no type |
| `#post()` re-read `contentWindow` through optional chaining after `onReloading()`, silently dropping a push where the original threw | Low | **Fixed** — non-optional post, matching the original's evaluation order and failure mode |
| `project-bridge` captured `contentWindow` *before* `onReloading()`, contradicting its sibling's documented invariant | Low | **Fixed** — mirrors `player-bridge` |
| `SetProject` typed as permitting empty arrays, which `player.html` rejects | Low | **Documented** — the only producer is still-JS `ide.js`, so a non-empty-tuple type would be an unchecked assertion, not a guarantee |
| Dead `eslint-disable` comment (no ESLint in this repo) | Low | **Fixed** — removed |
| `tsconfig` lacked `allowJs`, which the next migration step would hit | Low | **Fixed** — verified `TS7016` reproduces without it |
| Lockfile `name` churn from `npm install` (`functor4` → `functor2`) | Low | **Reverted** — only the `typescript` devDependency addition remains |

## Follow-ups

- `e2e/runtime-target.mjs` hardcodes ports 8136/8137 and ignores
  `FUNCTOR_SITE_PORT` unlike its siblings; a crashed run orphans a
  `site/serve.mjs` that silently serves a **stale `dist`** to the next run. This
  cost real debugging time in this session.
- `player.html:441` calls `functor_lang_is_running()` unguarded in its message
  handler; a message arriving pre-init throws `TypeError: Cannot read properties
  of undefined`. Observable on `main` today, benign only because
  `announceWhenReady` runs inside `init().then()`.
- Duplicated `PUSH_DEBOUNCE_MS` / `ERROR_GRACE_MS` / `#deliverResult` across the
  two bridges is pre-existing and untouched here.

Next in the sequence: continue migrating `site/src` file by file, then React
islands for the sandbox/IDE chrome only.

---

## Second review round (Fable + `/xreview`: Claude + Codex)

Three independent reviewers over the branch diff. No Critical or High findings.
Two Medium findings materially improved the change:

| Finding | Severity | Disposition |
| --- | --- | --- |
| **`@types/node` was auto-included into a browser-only program.** Proven with `tsc --listFiles`: `process`, `Buffer`, `require`, `__dirname` all typechecked in code that can never use them, and `ReturnType<typeof setTimeout>` resolved to `NodeJS.Timeout` instead of `number` — the exact bug class the typechecker exists to catch | Medium | **Fixed** — `"types": []`. Program is now exactly the three `.ts` files plus `lib`. Verified with a probe: the Node globals above now error |
| **`check:site` was wired into nothing.** esbuild strips types without checking them, so the entire value of the PR was a command nobody ran, and step 2 would land on a red baseline | Medium | **Fixed** — added to `wasm-smoke.yml`, which is **PR-triggered** and already does `npm ci`; placed before the Rust/wasm builds so a type error fails fast |
| `allowJs: true` was dead config — no `.js` enters the program today, and enabling it silently pulls `lang-intel.js` (~1000 lines) + CodeMirror into the program the moment a `.ts` imports a `.js` sibling | Low | **Fixed** — dropped. It gets added in the step that first needs it, as an explicit decision |
| protocol.ts's header overclaimed: `functor-lang-preview-navigate` (VSCode-only) is not in `EditorMessage`, and the hello/ready handshake is `player.html`-specific — the VSCode preview page has no hello handler | Low | **Fixed** — header narrowed to the site's seam, with the VSCode and Rust-runtime neighbours documented as explicitly out of scope |
| The `BridgeOptions` placement rationale was factually wrong (claimed `import type` keeps the bundles independent, but both bridges *value*-import `asPlayerMessage` from the same module anyway) | Low | **Fixed** — rationale corrected |
| `SetSourceResult.id` comment understated when id-less results occur — the *current* runtime also omits it for any id-less push, not just older ones | Low | **Fixed** |
| `asPlayerMessage`'s double cast | Low | **Fixed** — `ReadonlySet<string>` removes both |
| Importer comments still referenced `player-bridge.js` / `project-bridge.js` after the rename (the `import` specifiers correctly stay `.js` — that is the migration mechanic) | Low | **Fixed** |
| Timer fields `null` → `undefined` "violates the exact-preservation bar" | Low | **Kept, deliberate** — reviewers split: Codex raised it, Fable and the Claude reviewer independently cleared it. The fields are only ever passed to `clearTimeout` (identical for both) or reassigned; no consumer reads them, and `private` erasure makes them unreachable in practice. `undefined` is the idiomatic TS sentinel, and with `types: []` the field is now correctly typed `number` |

**Independently confirmed clean by all three**, with evidence, so as not to be re-litigated: the discriminant set is exhaustive against all five types `player.html` posts plus the runtime's `set-source-result`; every protocol field matches its real producer; the `contentWindow!` assertions reproduce the originals' re-read and throw-on-detached behaviour; class-field ordering and own-property enumeration order are unchanged; and the tsconfig does not perturb how esbuild compiles the remaining `.js` (rebuilt both refs — `api-docs.js`, `docs.js`, `features.js` are byte-identical).

## Verification (re-run after these fixes)

- `npm run check:site` — exit 0; `--listFiles` shows only the three `.ts` + lib
- `npm run site:build` — succeeds
- e2e: `site-sandbox` ALL CHECKS PASSED · `ide-page` PASS · `ide-project` PASS · `runtime-target` ALL CHECKS PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)
