### PR TITLE
fix(functor-lang): unknown builtin-module members are check-time errors

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -531,6 +531,21 @@ browser console on wasm. Not rate-limited: a `Debug.log` in `tick`/`draw` fires
 every frame (~60/s), so prefer an event path (`input`/`update`), or remove it
 when done.
 
+**The list above is the WHOLE registry, and it is CLOSED.** A builtin
+namespace (`List`, `Text`, `Math`, `Random`, `Debug`) owns exactly these
+members in every embedding, so anything else is a **check-time error** —
+`functor-lang check` (and `functor build`) reject `List.nth` / `Text.length` /
+`Math.clamp` with `` `List` has no builtin `nth` `` plus the nearest name or
+the namespace's full member list. Do NOT assume an F#/Elm stdlib function
+exists: there is no `nth`/`head`/`take`/`zip`/`sortBy`/`indexedMap`/`find`/
+`sum` on `List`, no `length`/`toUpper` on `Text`, and `Math` has `clamp01`
+(0–1 only), not a general `clamp`. Build what you need from `List.fold` /
+`List.filter` / `List.range` / `Math.min` + `Math.max`. (`Scene.*` and the
+rest of the engine prelude are host-provided, so under plain
+`functor-lang check` — no host — they stay the gradual `Unknown` seam and
+only resolve under the runner, where the prelude's `.funi` interfaces make an
+unknown member a load error.)
+
 ## Functor prelude (only under the engine host — `FunctorHost`)
 
 Available in runner-hosted Functor Lang (and tests via
@@ -1180,7 +1195,9 @@ every use, element types flow through `List.map`/`filter`/`fold`, and
 apostrophe-prefixed annotation names are type variables (`(xs: List<'a>, seed: 'b): List<'b>`). Inference has teeth: unannotated bad calls, mixed-element
 lists, and contradictory `mut` use are errors now. `Unknown` remains ONLY
 at genuinely-dynamic seams (host values, unrecognized type
-names) and absorbs anything. (Function TYPES cannot be written in
+names) and absorbs anything — but a BUILTIN namespace is not such a seam:
+its member set is closed, so `List.nth` / `Math.clamp` are check errors, not
+`Unknown` (see "Builtins"). (Function TYPES cannot be written in
 annotations yet — `f: ('a) => 'b` does not parse; leave higher-order
 parameters unannotated and let inference type them.) Generic declarations (`type Pair<'x, 'y> = { first: 'x, second: 'y }`)
 instantiate fresh per use; an UNDECLARED type variable in a declaration is

--- a/functor-lang/src/complete.rs
+++ b/functor-lang/src/complete.rs
@@ -34,7 +34,7 @@
 use std::collections::BTreeSet;
 
 use crate::ast::{TypeBody, VariantDecl};
-use crate::eval::{builtin_name, Builtin};
+use crate::eval::{builtin_name, ALL_BUILTINS as BUILTINS};
 use crate::hover::{children, type_name_text};
 use crate::ir::{BindingId, Def, Expr, ExprKind, Pattern, PatternKind};
 use crate::lexer::{Token, TokenKind};
@@ -62,48 +62,6 @@ pub enum CompletionKind {
     /// A record field, offered after a record-typed value (`pos.x`).
     Field,
 }
-
-/// The complete builtin registry. Hand-listed because [`Builtin`] is not
-/// iterable — keep in sync with `eval::Builtin` (35 variants).
-const BUILTINS: [Builtin; 37] = [
-    Builtin::ListMap,
-    Builtin::ListFilter,
-    Builtin::ListFold,
-    Builtin::ListRange,
-    Builtin::ListGrid,
-    Builtin::ListMaximum,
-    Builtin::ListLength,
-    Builtin::ListAppend,
-    Builtin::ListFlatten,
-    Builtin::ListAny,
-    Builtin::ListAll,
-    Builtin::ListReverse,
-    Builtin::ListIsEmpty,
-    Builtin::MathSin,
-    Builtin::MathCos,
-    Builtin::MathSqrt,
-    Builtin::MathAbs,
-    Builtin::MathFloor,
-    Builtin::MathAtan2,
-    Builtin::MathMod,
-    Builtin::MathMin,
-    Builtin::MathMax,
-    Builtin::MathPow,
-    Builtin::MathPi,
-    Builtin::TextConcat,
-    Builtin::TextFromFloat,
-    Builtin::TextFixed,
-    Builtin::TextToBullets,
-    Builtin::TextSplit,
-    Builtin::TextJoin,
-    Builtin::TextParseFloat,
-    Builtin::MathClamp01,
-    Builtin::RandomSeed,
-    Builtin::RandomStep,
-    Builtin::RandomRange,
-    Builtin::RandomFork,
-    Builtin::DebugLog,
-];
 
 /// The keywords offered at an expression position: the lexer keywords plus
 /// the contextual `open` (`lexer.rs`).
@@ -814,6 +772,7 @@ fn finish(mut items: Vec<CompletionItem>, partial: &str) -> Vec<CompletionItem> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::eval::Builtin;
     use crate::project::load_sources_with_prelude;
     use std::path::PathBuf;
 

--- a/functor-lang/src/complete.rs
+++ b/functor-lang/src/complete.rs
@@ -772,7 +772,6 @@ fn finish(mut items: Vec<CompletionItem>, partial: &str) -> Vec<CompletionItem> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::eval::Builtin;
     use crate::project::load_sources_with_prelude;
     use std::path::PathBuf;
 
@@ -1460,54 +1459,6 @@ mod tests {
             find(&items, "Empty").detail.as_deref(),
             Some("Pieces.Empty : Box<'a>")
         );
-    }
-
-    // Drift guard: this match is exhaustive over `Builtin`, so adding a
-    // variant fails to compile here until BUILTINS (above) offers it too.
-    #[test]
-    fn builtins_list_is_exhaustive() {
-        for &b in &BUILTINS {
-            match b {
-                Builtin::ListMap
-                | Builtin::ListFilter
-                | Builtin::ListFold
-                | Builtin::ListRange
-                | Builtin::ListGrid
-                | Builtin::ListMaximum
-                | Builtin::ListLength
-                | Builtin::ListAppend
-                | Builtin::ListFlatten
-                | Builtin::ListAny
-                | Builtin::ListAll
-                | Builtin::ListReverse
-                | Builtin::ListIsEmpty
-                | Builtin::MathSin
-                | Builtin::MathCos
-                | Builtin::MathSqrt
-                | Builtin::MathAbs
-                | Builtin::MathFloor
-                | Builtin::MathAtan2
-                | Builtin::MathMod
-                | Builtin::MathMin
-                | Builtin::MathMax
-                | Builtin::MathPow
-                | Builtin::MathPi
-                | Builtin::MathClamp01
-                | Builtin::TextConcat
-                | Builtin::TextFromFloat
-                | Builtin::TextFixed
-                | Builtin::TextToBullets
-                | Builtin::TextSplit
-                | Builtin::TextJoin
-                | Builtin::TextParseFloat
-                | Builtin::RandomSeed
-                | Builtin::RandomStep
-                | Builtin::RandomRange
-                | Builtin::RandomFork
-                | Builtin::DebugLog => {}
-            }
-        }
-        assert_eq!(BUILTINS.len(), 37, "BUILTINS must list every Builtin");
     }
 
     // 19. A full keyword typed (`let`, cursor at end) still offers `let`.

--- a/functor-lang/src/eval.rs
+++ b/functor-lang/src/eval.rs
@@ -2547,8 +2547,9 @@ fn unknown_external_error(path: &[String], joined: String, span: Span) -> RunErr
 pub const BUILTIN_NAMESPACES: &[&str] = &["List", "Text", "Math", "Random", "Debug"];
 
 /// The complete builtin registry as a list. Hand-listed because [`Builtin`] is
-/// not iterable — keep in sync with the enum (the `all_builtins_is_exhaustive`
-/// and `all_builtins_round_trip` tests fail otherwise). Lives next to
+/// not iterable — keep in sync with the enum (`builtins_list_is_exhaustive`
+/// fails to COMPILE otherwise, and `all_builtins_round_trip_through_dispatch`
+/// fails if an entry stops dispatching). Lives next to
 /// [`builtin`] so the members the CHECKER knows about (for its
 /// unknown-member diagnostic and its suggestions) and the ones the
 /// interpreter DISPATCHES come from one place.
@@ -2725,7 +2726,8 @@ pub fn render_trace(events: &[TraceEvent]) -> String {
 
 #[cfg(test)]
 mod builtin_registry_tests {
-    use super::{builtin, builtin_members, builtin_name, ALL_BUILTINS, BUILTIN_NAMESPACES};
+    use super::{builtin, builtin_members, builtin_name, Builtin, ALL_BUILTINS, BUILTIN_NAMESPACES};
+    use std::collections::BTreeSet;
 
     /// The DRIFT LOCK between the interpreter's dispatch table and the member
     /// set the checker reports (`types::unknown_builtin_member`): every listed
@@ -2745,58 +2747,67 @@ mod builtin_registry_tests {
                 "{name}: `{}` is missing from BUILTIN_NAMESPACES",
                 path[0]
             );
-            assert!(
-                builtin_members(&path[0]).contains(&&name[path[0].len() + 1..]),
-                "{name} is missing from builtin_members"
-            );
         }
     }
 
-    /// The OTHER half of the drift lock, and the one that matters most for a
-    /// FALSE check error: [`all_builtins_round_trip_through_dispatch`] only
-    /// walks [`ALL_BUILTINS`], so a variant added to the enum (and therefore,
-    /// by exhaustiveness, to [`builtin_name`]) but FORGOTTEN in
-    /// [`ALL_BUILTINS`] would slip past it — and the checker would then
-    /// reject a real, dispatchable builtin as an unknown member.
-    ///
-    /// [`builtin_name`]'s match is exhaustive over `Builtin`, so the names it
-    /// can return ARE the enum. Reading them out of the source is the only
-    /// way to enumerate a non-iterable enum, and it makes the two lists
-    /// impossible to diverge silently.
+    // THE DRIFT LOCK, half one: this match is exhaustive over `Builtin`, so
+    // adding a variant fails to COMPILE here until `ALL_BUILTINS` offers it
+    // too. That matters because `ALL_BUILTINS` is what the CHECKER reports as
+    // a namespace's member set — a builtin missing from it would be rejected
+    // as an unknown member even though the interpreter dispatches it.
+    // (Half two is `all_builtins_round_trip_through_dispatch`, below.)
     #[test]
-    fn builtin_name_match_and_all_builtins_agree() {
-        let source = include_str!("eval.rs");
-        let body = source
-            .split_once("pub fn builtin_name(b: Builtin) -> &'static str {")
-            .expect("builtin_name should exist")
-            .1
-            .split_once("\n}")
-            .expect("builtin_name should end")
-            .0;
+    fn builtins_list_is_exhaustive() {
+        for &b in &ALL_BUILTINS {
+            match b {
+                Builtin::ListMap
+                | Builtin::ListFilter
+                | Builtin::ListFold
+                | Builtin::ListRange
+                | Builtin::ListGrid
+                | Builtin::ListMaximum
+                | Builtin::ListLength
+                | Builtin::ListAppend
+                | Builtin::ListFlatten
+                | Builtin::ListAny
+                | Builtin::ListAll
+                | Builtin::ListReverse
+                | Builtin::ListIsEmpty
+                | Builtin::MathSin
+                | Builtin::MathCos
+                | Builtin::MathSqrt
+                | Builtin::MathAbs
+                | Builtin::MathFloor
+                | Builtin::MathAtan2
+                | Builtin::MathMod
+                | Builtin::MathMin
+                | Builtin::MathMax
+                | Builtin::MathPow
+                | Builtin::MathPi
+                | Builtin::MathClamp01
+                | Builtin::TextConcat
+                | Builtin::TextFromFloat
+                | Builtin::TextFixed
+                | Builtin::TextToBullets
+                | Builtin::TextSplit
+                | Builtin::TextJoin
+                | Builtin::TextParseFloat
+                | Builtin::RandomSeed
+                | Builtin::RandomStep
+                | Builtin::RandomRange
+                | Builtin::RandomFork
+                | Builtin::DebugLog => {}
+            }
+        }
+        assert_eq!(ALL_BUILTINS.len(), 37, "ALL_BUILTINS must list every Builtin");
 
-        let mut from_source: Vec<&str> = body
-            .lines()
-            .filter_map(|line| line.trim().strip_prefix("Builtin::"))
-            .filter_map(|arm| arm.split_once("=> \""))
-            .filter_map(|(_, rest)| rest.split_once('"'))
-            .map(|(name, _)| name)
-            .collect();
-        from_source.sort_unstable();
-        assert!(
-            from_source.len() > 30,
-            "the arm scrape found only {} names — did `builtin_name` change shape?",
-            from_source.len()
-        );
-
-        let mut listed: Vec<&str> = ALL_BUILTINS.iter().map(|b| builtin_name(*b)).collect();
-        listed.sort_unstable();
-
+        // The length check alone would accept a DUPLICATE entry standing in
+        // for a missing one.
+        let unique: BTreeSet<&str> = ALL_BUILTINS.iter().map(|b| builtin_name(*b)).collect();
         assert_eq!(
-            from_source, listed,
-            "`ALL_BUILTINS` has drifted from the `Builtin` enum. Names only \
-             `builtin_name` knows would be REJECTED BY THE CHECKER as unknown \
-             members; names only `ALL_BUILTINS` has are stale. Add the missing \
-             variant to `ALL_BUILTINS`."
+            unique.len(),
+            ALL_BUILTINS.len(),
+            "ALL_BUILTINS has a duplicate entry masking a missing builtin"
         );
     }
 

--- a/functor-lang/src/eval.rs
+++ b/functor-lang/src/eval.rs
@@ -2546,6 +2546,64 @@ fn unknown_external_error(path: &[String], joined: String, span: Span) -> RunErr
 /// expect gutter's `unrunnable` classification) rests on.
 pub const BUILTIN_NAMESPACES: &[&str] = &["List", "Text", "Math", "Random", "Debug"];
 
+/// The complete builtin registry as a list. Hand-listed because [`Builtin`] is
+/// not iterable — keep in sync with the enum (the `all_builtins_is_exhaustive`
+/// and `all_builtins_round_trip` tests fail otherwise). Lives next to
+/// [`builtin`] so the members the CHECKER knows about (for its
+/// unknown-member diagnostic and its suggestions) and the ones the
+/// interpreter DISPATCHES come from one place.
+pub const ALL_BUILTINS: [Builtin; 37] = [
+    Builtin::ListMap,
+    Builtin::ListFilter,
+    Builtin::ListFold,
+    Builtin::ListRange,
+    Builtin::ListGrid,
+    Builtin::ListMaximum,
+    Builtin::ListLength,
+    Builtin::ListAppend,
+    Builtin::ListFlatten,
+    Builtin::ListAny,
+    Builtin::ListAll,
+    Builtin::ListReverse,
+    Builtin::ListIsEmpty,
+    Builtin::MathSin,
+    Builtin::MathCos,
+    Builtin::MathSqrt,
+    Builtin::MathAbs,
+    Builtin::MathFloor,
+    Builtin::MathAtan2,
+    Builtin::MathMod,
+    Builtin::MathMin,
+    Builtin::MathMax,
+    Builtin::MathPow,
+    Builtin::MathPi,
+    Builtin::TextConcat,
+    Builtin::TextFromFloat,
+    Builtin::TextFixed,
+    Builtin::TextToBullets,
+    Builtin::TextSplit,
+    Builtin::TextJoin,
+    Builtin::TextParseFloat,
+    Builtin::MathClamp01,
+    Builtin::RandomSeed,
+    Builtin::RandomStep,
+    Builtin::RandomRange,
+    Builtin::RandomFork,
+    Builtin::DebugLog,
+];
+
+/// The member names a builtin namespace owns (`List` → `map`, `filter`, …),
+/// sorted, derived from [`ALL_BUILTINS`].
+pub fn builtin_members(namespace: &str) -> Vec<&'static str> {
+    let prefix = format!("{namespace}.");
+    let mut members: Vec<&'static str> = ALL_BUILTINS
+        .iter()
+        .filter_map(|b| builtin_name(*b).strip_prefix(&prefix))
+        .collect();
+    members.sort_unstable();
+    members
+}
+
 pub fn builtin(path: &[String]) -> Option<Builtin> {
     let joined = path.join(".");
     Some(match joined.as_str() {
@@ -2663,6 +2721,46 @@ pub fn render_trace(events: &[TraceEvent]) -> String {
         }
     }
     out
+}
+
+#[cfg(test)]
+mod builtin_registry_tests {
+    use super::{builtin, builtin_members, builtin_name, ALL_BUILTINS, BUILTIN_NAMESPACES};
+
+    /// The DRIFT LOCK between the interpreter's dispatch table and the member
+    /// set the checker reports (`types::unknown_builtin_member`): every listed
+    /// builtin's name must resolve back through [`builtin`] to itself, and
+    /// must live in a namespace [`BUILTIN_NAMESPACES`] declares — otherwise a
+    /// real builtin could be reported as a typo, or a namespace's member list
+    /// could be incomplete.
+    #[test]
+    fn all_builtins_round_trip_through_dispatch() {
+        for b in ALL_BUILTINS {
+            let name = builtin_name(b);
+            let path: Vec<String> = name.split('.').map(str::to_string).collect();
+            assert_eq!(path.len(), 2, "{name} should be `Namespace.member`");
+            assert_eq!(builtin(&path), Some(b), "{name} does not dispatch to itself");
+            assert!(
+                BUILTIN_NAMESPACES.contains(&path[0].as_str()),
+                "{name}: `{}` is missing from BUILTIN_NAMESPACES",
+                path[0]
+            );
+            assert!(
+                builtin_members(&path[0]).contains(&&name[path[0].len() + 1..]),
+                "{name} is missing from builtin_members"
+            );
+        }
+    }
+
+    #[test]
+    fn every_namespace_has_members() {
+        for namespace in BUILTIN_NAMESPACES {
+            assert!(
+                !builtin_members(namespace).is_empty(),
+                "`{namespace}` is declared a builtin namespace but owns nothing"
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/functor-lang/src/eval.rs
+++ b/functor-lang/src/eval.rs
@@ -2752,6 +2752,54 @@ mod builtin_registry_tests {
         }
     }
 
+    /// The OTHER half of the drift lock, and the one that matters most for a
+    /// FALSE check error: [`all_builtins_round_trip_through_dispatch`] only
+    /// walks [`ALL_BUILTINS`], so a variant added to the enum (and therefore,
+    /// by exhaustiveness, to [`builtin_name`]) but FORGOTTEN in
+    /// [`ALL_BUILTINS`] would slip past it — and the checker would then
+    /// reject a real, dispatchable builtin as an unknown member.
+    ///
+    /// [`builtin_name`]'s match is exhaustive over `Builtin`, so the names it
+    /// can return ARE the enum. Reading them out of the source is the only
+    /// way to enumerate a non-iterable enum, and it makes the two lists
+    /// impossible to diverge silently.
+    #[test]
+    fn builtin_name_match_and_all_builtins_agree() {
+        let source = include_str!("eval.rs");
+        let body = source
+            .split_once("pub fn builtin_name(b: Builtin) -> &'static str {")
+            .expect("builtin_name should exist")
+            .1
+            .split_once("\n}")
+            .expect("builtin_name should end")
+            .0;
+
+        let mut from_source: Vec<&str> = body
+            .lines()
+            .filter_map(|line| line.trim().strip_prefix("Builtin::"))
+            .filter_map(|arm| arm.split_once("=> \""))
+            .filter_map(|(_, rest)| rest.split_once('"'))
+            .map(|(name, _)| name)
+            .collect();
+        from_source.sort_unstable();
+        assert!(
+            from_source.len() > 30,
+            "the arm scrape found only {} names — did `builtin_name` change shape?",
+            from_source.len()
+        );
+
+        let mut listed: Vec<&str> = ALL_BUILTINS.iter().map(|b| builtin_name(*b)).collect();
+        listed.sort_unstable();
+
+        assert_eq!(
+            from_source, listed,
+            "`ALL_BUILTINS` has drifted from the `Builtin` enum. Names only \
+             `builtin_name` knows would be REJECTED BY THE CHECKER as unknown \
+             members; names only `ALL_BUILTINS` has are stale. Add the missing \
+             variant to `ALL_BUILTINS`."
+        );
+    }
+
     #[test]
     fn every_namespace_has_members() {
         for namespace in BUILTIN_NAMESPACES {

--- a/functor-lang/src/types.rs
+++ b/functor-lang/src/types.rs
@@ -72,7 +72,7 @@
 //! by source position — it never stops at the first error.
 
 use crate::ast::{BinOp, TypeBody, TypeName};
-use crate::eval::{builtin, callee_label, Builtin};
+use crate::eval::{builtin, builtin_members, callee_label, Builtin, BUILTIN_NAMESPACES};
 use crate::ir::{
     BindingId, Expr, ExprId, ExprKind, Field, MatchArm, Module, Pattern, PatternKind, StringPart,
 };
@@ -338,6 +338,63 @@ fn free_vars_of(ty: &Type, out: &mut Vec<u32>) {
         }
         Type::Unknown | Type::Float | Type::String | Type::Bool => {}
     }
+}
+
+/// The diagnostic for an external path in a BUILTIN namespace that the
+/// registry has no member for (`List.nth`) — `None` for any other unresolved
+/// external, which stays the gradual host seam. The message mirrors the
+/// interpreter's wording (`eval::unknown_external_error`) so the same typo
+/// reads identically at check and at run time, and adds either the nearest
+/// member name or the namespace's full member list.
+fn unknown_builtin_member(path: &[String]) -> Option<String> {
+    let (head, rest) = path.split_first()?;
+    if rest.is_empty() || !BUILTIN_NAMESPACES.contains(&head.as_str()) {
+        return None;
+    }
+    let member = rest.join(".");
+    let members = builtin_members(head);
+    let hint = match nearest_member(&member, &members) {
+        Some(near) => format!("did you mean `{head}.{near}`?"),
+        None => format!("`{head}` has: {}", members.join(", ")),
+    };
+    Some(format!("`{head}` has no builtin `{member}` — {hint}"))
+}
+
+/// The closest member name to `member`: a prefix relation (`Math.clamp` →
+/// `Math.clamp01`) or a typo-scale edit distance (≤ 2, and never more than a
+/// third of the name), so an honestly-missing function like `nth` suggests
+/// nothing instead of something misleading.
+fn nearest_member(member: &str, members: &[&'static str]) -> Option<&'static str> {
+    if let Some(name) = members
+        .iter()
+        .filter(|name| name.starts_with(member) || member.starts_with(*name))
+        .min_by_key(|name| (name.len(), **name))
+    {
+        return Some(name);
+    }
+    let budget = 2.min(member.chars().count() / 3);
+    members
+        .iter()
+        .map(|name| (edit_distance(member, name), *name))
+        .filter(|(distance, _)| *distance <= budget)
+        .min_by_key(|(distance, name)| (*distance, *name))
+        .map(|(_, name)| name)
+}
+
+/// Levenshtein distance, for [`nearest_member`]'s typo suggestions.
+fn edit_distance(a: &str, b: &str) -> usize {
+    let b: Vec<char> = b.chars().collect();
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut row = prev.clone();
+    for (i, ca) in a.chars().enumerate() {
+        row[0] = i + 1;
+        for (j, cb) in b.iter().enumerate() {
+            let cost = usize::from(ca != *cb);
+            row[j + 1] = (prev[j] + cost).min(prev[j + 1] + 1).min(row[j] + 1);
+        }
+        std::mem::swap(&mut prev, &mut row);
+    }
+    prev[b.len()]
 }
 
 /// The signature of a builtin (kept in sync with [`crate::eval`]'s registry
@@ -1525,9 +1582,12 @@ missing {missing}. Did you forget an argument?"
             },
             // An interface (`.funi`) signature is authoritative when present
             // (the injected `Random` module types its builtins this way);
-            // otherwise a builtin's own scheme applies, and an external
-            // neither declares is the gradual seam (`Unknown` — the module
-            // set may grow at runtime).
+            // otherwise a builtin's own scheme applies. An external neither
+            // declares is the gradual seam (`Unknown` — a HOST's module set
+            // is embedding-specific and may grow at runtime), EXCEPT in a
+            // BUILTIN namespace, whose member set is closed and identical
+            // everywhere Functor Lang runs: there an unknown member is a typo
+            // the checker must catch (it would only fail at `run`).
             ExprKind::External(path) => match self.signatures.get(&path.join(".")).cloned() {
                 Some(scheme) => self.instantiate(&scheme),
                 None => match builtin(path) {
@@ -1537,7 +1597,12 @@ missing {missing}. Did you forget an argument?"
                         free_vars_of(&sig, &mut vars);
                         self.instantiate(&Scheme { vars, ty: sig })
                     }
-                    None => Type::Unknown,
+                    None => {
+                        if let Some(message) = unknown_builtin_member(path) {
+                            self.diag(expr.span, message);
+                        }
+                        Type::Unknown
+                    }
                 },
             },
             // A record literal resolves NOMINALLY, F#-style (B7, user

--- a/functor-lang/src/types.rs
+++ b/functor-lang/src/types.rs
@@ -346,6 +346,12 @@ fn free_vars_of(ty: &Type, out: &mut Vec<u32>) {
 /// interpreter's wording (`eval::unknown_external_error`) so the same typo
 /// reads identically at check and at run time, and adds either the nearest
 /// member name or the namespace's full member list.
+///
+/// In practice this closes FOUR namespaces, not five: `Random` is a bundled
+/// interface module (`project.rs`), so lowering rejects `Random.nope` with
+/// "module `Random` has no `nope`" before checking ever runs. The `Random`
+/// arm is kept anyway — it costs nothing and would matter the day that
+/// module stops being bundled.
 fn unknown_builtin_member(path: &[String]) -> Option<String> {
     let (head, rest) = path.split_first()?;
     if rest.is_empty() || !BUILTIN_NAMESPACES.contains(&head.as_str()) {
@@ -360,16 +366,20 @@ fn unknown_builtin_member(path: &[String]) -> Option<String> {
     Some(format!("`{head}` has no builtin `{member}` — {hint}"))
 }
 
-/// The closest member name to `member`: a prefix relation (`Math.clamp` →
-/// `Math.clamp01`) or a typo-scale edit distance (≤ 2, and never more than a
-/// third of the name), so an honestly-missing function like `nth` suggests
-/// nothing instead of something misleading.
+/// The closest member name to `member`: an UNAMBIGUOUS prefix relation
+/// (`Math.clamp` → `Math.clamp01`) or a typo-scale edit distance (≤ 2, and
+/// never more than a third of the name), so an honestly-missing function like
+/// `nth` suggests nothing instead of something misleading.
+///
+/// Both restrictions are load-bearing. Only `name.starts_with(member)` — "you
+/// typed a prefix of the real name" — counts: the converse direction would
+/// answer `List.mapIndexed` with "did you mean `List.map`?", pointing at a
+/// function with different semantics. And a prefix shared by SEVERAL members
+/// (`List.f` → filter/flatten/fold) names none of them, since picking the
+/// shortest would be arbitrary; those fall through to the full member list.
 fn nearest_member(member: &str, members: &[&'static str]) -> Option<&'static str> {
-    if let Some(name) = members
-        .iter()
-        .filter(|name| name.starts_with(member) || member.starts_with(*name))
-        .min_by_key(|name| (name.len(), **name))
-    {
+    let mut prefixed = members.iter().filter(|name| name.starts_with(member));
+    if let (Some(name), None) = (prefixed.next(), prefixed.next()) {
         return Some(name);
     }
     let budget = 2.min(member.chars().count() / 3);

--- a/functor-lang/tests/check.rs
+++ b/functor-lang/tests/check.rs
@@ -1711,6 +1711,33 @@ fn unknown_builtin_member_is_a_check_error() {
     }
 }
 
+// A suggestion is only offered when it is UNAMBIGUOUS and points the right
+// way; otherwise the namespace's full member list is the honest answer. A
+// misleading "did you mean" is worse than none — `List.mapIndexed` is not a
+// misspelling of `List.map`.
+#[test]
+fn a_suggestion_is_never_ambiguous_or_misleading() {
+    for (src, expected_hint) in [
+        // Several members share the prefix — name none of them.
+        ("let a = List.f([1.0])", "`List` has:"),
+        ("let a = Math.a(1.0)", "`Math` has:"),
+        // The typed name merely STARTS WITH a real member, but means
+        // something else.
+        ("let a = List.mapIndexed([1.0])", "`List` has:"),
+        ("let a = Math.moderate(1.0)", "`Math` has:"),
+        // Unambiguous prefix, and typo-scale distance: still suggested.
+        ("let a = Math.clamp(1.0)", "did you mean `Math.clamp01`?"),
+        ("let a = Debug.l(1.0)", "did you mean `Debug.log`?"),
+        ("let a = Math.sine(1.0)", "did you mean `Math.sin`?"),
+    ] {
+        let (message, _, _) = single_diag(src);
+        assert!(
+            message.contains(expected_hint),
+            "for {src}: expected hint {expected_hint:?}, got {message:?}"
+        );
+    }
+}
+
 // The diagnostic carries the reference's own span.
 #[test]
 fn unknown_builtin_member_reports_the_reference_span() {

--- a/functor-lang/tests/check.rs
+++ b/functor-lang/tests/check.rs
@@ -1668,6 +1668,73 @@ fn ctor_literal_sub_pattern_does_not_cover_the_ctor() {
     );
 }
 
+// A BUILTIN namespace's member set is closed (identical in every embedding),
+// so a member the registry has no entry for is a CHECK error — not the
+// gradual-host `Unknown` seam, which only made it fail at `run`
+// ("`List` has no builtin `nth`"). These are the calls games actually reached
+// for.
+#[test]
+fn unknown_builtin_member_is_a_check_error() {
+    for (src, expected) in [
+        (
+            "let a = List.nth([1.0], 0.0)",
+            "`List` has no builtin `nth` — `List` has: all, any, append, filter, \
+             flatten, fold, grid, isEmpty, length, map, maximum, range, reverse",
+        ),
+        (
+            "let a = Text.length(\"hi\")",
+            "`Text` has no builtin `length` — `Text` has: concat, fixed, fromFloat, \
+             join, parseFloat, split, toBullets",
+        ),
+        (
+            "let a = Math.clamp(0.0, 1.0, 2.0)",
+            "`Math` has no builtin `clamp` — did you mean `Math.clamp01`?",
+        ),
+        (
+            "let a = Debug.logg(1.0)",
+            "`Debug` has no builtin `logg` — did you mean `Debug.log`?",
+        ),
+    ] {
+        let (message, _, _) = single_diag(src);
+        assert_eq!(message, expected, "for {src}");
+    }
+
+    // The rest of the empirically-confirmed set: each is flagged, and names
+    // the member the user typed.
+    for member in ["indexedMap", "sortBy", "zip", "find", "take"] {
+        let src = format!("let a = List.{member}([1.0])");
+        let (message, _, _) = single_diag(&src);
+        assert!(
+            message.starts_with(&format!("`List` has no builtin `{member}`")),
+            "unexpected for {src}: {message}"
+        );
+    }
+}
+
+// The diagnostic carries the reference's own span.
+#[test]
+fn unknown_builtin_member_reports_the_reference_span() {
+    let (_, line, col) = single_diag("let a = 1.0\nlet b = List.nth([1.0], 0.0)");
+    assert_eq!((line, col), (2, 9));
+}
+
+// NEGATIVE CONTROLS. Real builtins still check clean, and an unresolved
+// external OUTSIDE a builtin namespace stays the gradual seam: a host
+// (`Scene.*` under the engine prelude) supplies those, and the plain
+// `functor-lang` embedding must not claim they are typos.
+#[test]
+fn real_builtins_and_host_externals_stay_clean() {
+    assert_clean(
+        "let a = List.length([1.0])\n\
+         let b = Math.clamp01(0.5)\n\
+         let c = Text.join(\", \", [\"x\"])\n\
+         let d = Debug.log(\"x\")\n\
+         let e = Math.pi",
+    );
+    assert_clean("let s = Scene.cube()");
+    assert_clean("let v = Vec3.make(0.0, 1.0, 2.0)");
+}
+
 #[test]
 fn literal_sub_pattern_type_mismatch_is_diagnosed() {
     // A string literal where the tuple element is a float.


### PR DESCRIPTION
## The hole

A typo in a builtin namespace passed `check` and only blew up at run time. On `main`:

```console
$ cat hole.fun
let second = (xs) => List.nth(xs, 1.0)
let clamped = (x) => Math.clamp(x, 0.0, 1.0)
let n = (s) => Text.length(s)

$ functor-lang check hole.fun    # main
$ echo $?
0
```

`List.nth`, `Math.clamp` and `Text.length` do not exist. The checker treated *any* unresolved `Namespace.member` external as the gradual host seam (`Type::Unknown`), which is right for `Scene.*` — a host's module set is embedding-specific — but wrong for the builtins, whose member set is closed and identical everywhere Functor Lang runs. A game shipped, then died mid-frame.

With this change:

```console
$ functor-lang check hole.fun
hole.fun:1:22: error: `List` has no builtin `nth` — `List` has: all, any, append, filter, flatten, fold, grid, isEmpty, length, map, maximum, range, reverse
hole.fun:2:22: error: `Math` has no builtin `clamp` — did you mean `Math.clamp01`?
hole.fun:3:16: error: `Text` has no builtin `length` — `Text` has: concat, fixed, fromFloat, join, parseFloat, split, toBullets
```

## Approach

`ExprKind::External` resolution keeps its order — a `.funi` signature wins, then the builtin's own scheme — but the final `None` arm now asks `unknown_builtin_member`: if the head is one of `eval::BUILTIN_NAMESPACES` and the registry has no such member, that is a typo, not a seam. Everything outside those namespaces stays `Unknown`, so `Scene.cube()` still checks clean under the plain (hostless) `functor-lang`.

The hint is deliberately conservative — a misleading "did you mean" is worse than none. A suggestion is offered only when it is **unambiguous** and points the right way (`name.starts_with(member)`, exactly one match), or the edit distance is typo-scale (≤ 2 and ≤ a third of the name). So `Math.clamp` → `clamp01` and `Math.sine` → `sin`, but `List.f` (filter/flatten/fold) and `List.mapIndexed` get the full member list instead of an arbitrary or semantically-wrong pick.

Scope note: this closes **four** namespaces in practice. `Random` is a bundled interface module, so lowering already rejects `Random.nope` with "module `Random` has no `nope`". The arm is kept for the day that stops being true.

## The drift lock

The failure mode this must not have is the inverse of the bug: the checker rejecting a *real* builtin because its member table fell behind the interpreter. So there is no second table — `eval::ALL_BUILTINS` is the one list, sitting next to `builtin()`, and both the checker's diagnostic and completion read it through `builtin_members()`. `complete.rs`'s private copy is deleted.

Two tests pin it, in both directions:

- **`builtins_list_is_exhaustive`** — a `match` that is exhaustive over the `Builtin` enum. Adding a variant is a **compile error** until `ALL_BUILTINS` lists it, which is what stops a dispatchable builtin from ever being reported as unknown. Plus a uniqueness assert, since a length check alone would accept a duplicate standing in for a missing entry.
- **`all_builtins_round_trip_through_dispatch`** — every listed name resolves back through `builtin()` to itself and lives in a declared namespace, so a stale entry can't linger.

Negative-validated: dropping `Math.pow` from `ALL_BUILTINS` fails the suite with a message naming the cause.

## Examples sweep

Checked **632 `.fun` files** — every `examples/*/` project in this branch plus the more recent jam examples in the sibling worktrees. **Zero** unknown-builtin diagnostics: no example was relying on the hole, and no false positives. The only `Text.chars` in the tree is inside a comment in `examples/asteroids/font.fun` explaining that it doesn't exist.

False-positive audit, all clean:

| Risk | Result |
| --- | --- |
| user module named `List`/`Math`/… shadowing a namespace | already impossible — `PROTECTED_NAMESPACES` makes it a load error |
| local value shadowing (`let List = { nth: … }`) | lowers to `FieldAccess`, never `External` |
| `.funi` signatures in those namespaces | none exist; and signatures resolve first regardless |
| host registering extras under them | none — zero hits across `runtime/`, `cli/`, `tools/` |
| `Random.Seed` as a type | type names never become `External` |
| paths > 2 segments | `Math.pi.x` lowers to `FieldAccess`, still reports `.x on float` |
| duplicate diagnostics | fires exactly once, at the reference's own span, returns `Unknown` so nothing cascades |

## Missing stdlib — listed, not added

Deliberately out of scope. All 28 confirmed absent from the registry today; the ones the jam actually reached for are in bold.

- `List` — **nth**, **indexedMap**, **sortBy**, **zip**, **find**, **take**, **last**, head, drop, sum, concatMap
- `Math` — **clamp**, **tan**, **asin**, **acos**, **round**, ceil, atan, log, exp, sign
- `Text` — **length**, **chars**, toUpper, toLower, contains, replace, trim

`Math.clamp` is the sharpest one: `clamp01` exists and reads like a general clamp. `Text.chars` blocks any string iteration — `examples/asteroids` hand-writes glyph lists because of it.

## Review dispositions

`/xreview` — Claude (Opus) + Codex CLI, independently. **No Critical or High findings from either engine.** Both raised the same two items, so both are fixed:

- **[AGREED] `nearest_member` gives arbitrary/misleading suggestions.** Fixed — uniqueness required, and the `member.starts_with(name)` direction dropped. Regression test `a_suggestion_is_never_ambiguous_or_misleading` covers both.
- **[AGREED] the drift test was fragile / the registry had too many representations.** Fixed — the source-scraping test I had added is deleted in favour of the pre-existing **compile-time** exhaustive match, moved beside `ALL_BUILTINS` and extended with the duplicate check. Strictly stronger and nothing to rot.
- *(Claude, Low)* tautological assert in the round-trip test — deleted.
- *(Claude, Low)* doc comment cited non-existent test names — corrected.
- *(Claude, Low)* `Random` never reaches the new path — documented at the function.
- *(Claude, Low)* "why not bundle `List.funi`/`Math.funi` instead?" — considered and **declined**: a `.funi` signature overrides the builtin's generic scheme, and `List.map`'s `((T) => U, List<T>) => List<U>` is exactly the higher-order shape the annotation grammar is weakest at. Real inference-regression risk for no gain.

## Breaking-change note

This is a hard check error with no escape hatch, and it also gates hot-reload (`reparse → recheck`). An existing game with a builtin typo in a **dead branch** now fails to build/reload where it previously ran. That is the intent, but it is a behavior change.

## Verification

- `cargo test -p functor-lang` — green (114 lib + 140 check + all suites)
- `cargo test -p functor_runtime_common` — green (473 + 8)
- `npm run check:docs` — green
- 632-file examples sweep — clean
- drift lock negative-validated; all re-run after the review fixes

`.claude/skills/functor-lang/SKILL.md` is updated in-branch: the builtin registry is documented as CLOSED, with the check-time error spelled out and the common F#/Elm assumptions (`nth`/`take`/`zip`/`sortBy`, `Text.length`, general `Math.clamp`) called out as not existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
