### PR TITLE
feat(debug): inject XR poses over the debug protocol

### DIFF
--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -109,6 +109,7 @@ JSON is tagged by `type`. Unknown keys/shapes return **400** with a message.
 {"type":"ui_event","slot":0,"kind":"Clicked"}                  // click widget slot 0
 {"type":"ui_event","slot":1,"kind":{"SliderChanged":0.5}}      // drag slider slot 1
 {"type":"ui_event","slot":2,"kind":{"TextChanged":"hi"}}       // edit text input slot 2
+{"type":"xr","left":{...},"right":{...},"head":{...}}          // set the XR device sample
 ```
 
 `ui_event` drives the game's interactive UI widgets without pixels or
@@ -117,6 +118,53 @@ frame's `ui(model)` tree, in construction order over the interactive widgets.
 An event for a slot the current view doesn't have is dropped (with a one-line
 runtime report), and the endpoint still returns 200 — delivery, not handling,
 is what's acknowledged.
+
+#### `{"type":"xr"}` — inject tracked poses (desktop)
+
+XR is **sampled**, not evented, so this command does not call an entry point: it
+sets the XR sample that every following fixed step feeds to `sampledInput`,
+through the exact path a headset takes. That means it also lands in the recorded
+input log, so a scripted pose sequence replays identically.
+
+The body is a whole [`xr` sample](#sampled-input-in-get-state) — the same shape
+`GET /state` reports — and it is **level state**, like a held key: it stays in
+force until the next `xr` command replaces it. Every field is optional and takes
+its default when omitted (hand inactive, no pose, `0.0`, an **identity**
+orientation), so name both hands each step rather than relying on a partial body
+to merge:
+
+```sh
+curl -s -X POST $H/input -d '{
+  "type": "xr",
+  "head":  { "position": [0.0, 0.0, 0.0] },
+  "left":  { "active": true,
+             "grip": { "position": [-0.3, -0.1, -0.6],
+                       "orientation": [0.0, 0.38, 0.0, 0.92] } },
+  "right": { "active": true,
+             "grip": { "position": [-0.05, -0.05, 0.12] },
+             "trigger": 1.0 }
+}'
+```
+
+An injected sample **overrides `--emulate-xr`** and supplies the `xr` domain even
+without it. That is the point: the mouse/keyboard emulator pins both hands to
+`z = -0.55` with identity orientations, so gestures like pulling a hand back
+toward your face, or aiming with a rotated grip, are inexpressible there and can
+only be driven this way. `held_keys` and `mouse` stay live alongside it.
+
+Pair it with `POST /time` `{"type":"advance","dts":0.016}` to step exactly one
+frame per pose, and the whole two-handed sequence is deterministic:
+
+```sh
+for i in $(seq 0 20); do
+  curl -s -X POST $H/input -d "$(pose_at $i)" >/dev/null   # your pose generator
+  curl -s -X POST $H/time  -d '{"type":"advance","dts":0.016}' >/dev/null
+done
+curl -s $H/state | jq -r .model
+```
+
+The device runtime rejects this command with **400**: Quest resamples the domain
+from live OpenXR tracking every frame, so an injected sample could never be seen.
 
 ### Sampled input in `GET /state`
 

--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -110,6 +110,7 @@ JSON is tagged by `type`. Unknown keys/shapes return **400** with a message.
 {"type":"ui_event","slot":1,"kind":{"SliderChanged":0.5}}      // drag slider slot 1
 {"type":"ui_event","slot":2,"kind":{"TextChanged":"hi"}}       // edit text input slot 2
 {"type":"xr","left":{...},"right":{...},"head":{...}}          // set the XR device sample
+{"type":"xr_clear"}                                            // drop it again
 ```
 
 `ui_event` drives the game's interactive UI widgets without pixels or
@@ -128,10 +129,13 @@ input log, so a scripted pose sequence replays identically.
 
 The body is a whole [`xr` sample](#sampled-input-in-get-state) — the same shape
 `GET /state` reports — and it is **level state**, like a held key: it stays in
-force until the next `xr` command replaces it. Every field is optional and takes
-its default when omitted (hand inactive, no pose, `0.0`, an **identity**
-orientation), so name both hands each step rather than relying on a partial body
-to merge:
+force until the next `xr` command replaces it, or `{"type":"xr_clear"}` releases
+it (restoring the `--emulate-xr` rig, or no `xr` domain at all). Every field is
+optional and takes its default when omitted (hand inactive, no pose, `0.0`, an
+**identity** orientation), so name both hands each step rather than relying on a
+partial body to merge. An **unknown** field is a 400, not a default — a
+misspelled `"triger"` would otherwise succeed and pin the game to a
+nothing-tracked sample:
 
 ```sh
 curl -s -X POST $H/input -d '{

--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -152,16 +152,23 @@ without it. That is the point: the mouse/keyboard emulator pins both hands to
 toward your face, or aiming with a rotated grip, are inexpressible there and can
 only be driven this way. `held_keys` and `mouse` stay live alongside it.
 
-Pair it with `POST /time` `{"type":"advance","dts":0.016}` to step exactly one
-frame per pose, and the whole two-handed sequence is deterministic:
+Pair it with `POST /time` to step one frame per pose. **Wait for `frame` to
+increment before sending the next pose**: `advance` sets the clock's single
+pending-step slot, so two advances arriving inside one request-drain collapse
+into one step and the intervening pose is never sampled. With the wait, the
+whole two-handed sequence is one pose per frame and reproducible:
 
 ```sh
 for i in $(seq 0 20); do
+  before=$(curl -s $H/state | jq .frame)
   curl -s -X POST $H/input -d "$(pose_at $i)" >/dev/null   # your pose generator
   curl -s -X POST $H/time  -d '{"type":"advance","dts":0.016}' >/dev/null
+  until [ "$(curl -s $H/state | jq .frame)" -gt "$before" ]; do :; done
 done
 curl -s $H/state | jq -r .model
 ```
+
+`e2e/xr-pose-injection.mjs` is the same loop in JavaScript, with assertions.
 
 The device runtime rejects this command with **400**: Quest resamples the domain
 from live OpenXR tracking every frame, so an injected sample could never be seen.

--- a/docs/vr.md
+++ b/docs/vr.md
@@ -117,6 +117,17 @@ controller levels for deterministic captures without adding a desktop-only
 game API. This is one shell adapter over the canonical snapshot; future
 gamepad/mobile adapters should produce that same target-neutral record.
 
+The emulator's fidelity is deliberately low: both hands sit on a fixed
+rig-local plane (`z = -0.55`) with **identity orientations**, so gestures that
+depend on depth (pulling a hand back toward your face) or on a controller's
+rotation (aiming along a grip's forward) cannot be expressed by mouse and
+keyboard at all. For those, **inject the sample directly** over the debug
+server — `POST /input {"type":"xr", …}` sets the XR sample every following fixed
+step feeds to `sampledInput`, so an arbitrary two-handed pose sequence is
+scriptable and deterministic with no headset and no window. See
+`docs/debug-runtime.md`, and `e2e/xr-pose-injection.mjs` for a worked
+pose-sequence driver.
+
 `examples/xr-controllers` is the shared-path reference: it maps both grip
 poses through the authored camera, visualizes each aim direction, and pulls an
 orb toward the right controller while trigger is held. Run it unchanged on

--- a/e2e/xr-pose-injection.mjs
+++ b/e2e/xr-pose-injection.mjs
@@ -147,8 +147,13 @@ function posePosition(model, name) {
   return xyz(block(block(model, name), "position"), `${name}.position`);
 }
 
-/** Run the whole injected sequence against a fresh runtime; return the state. */
-async function drive(port) {
+/** Run an injected sequence against a fresh runtime; return the state.
+ *
+ * `poseFn(i)` supplies step `i`'s pose, so a caller can drive the real sweep or
+ * a CONTROL sequence that holds one pose — the difference between the two is
+ * what proves the sequence itself (not merely "some hand was tracked") reached
+ * the simulation. */
+async function drive(port, poseFn = poseAt) {
   const base = `http://127.0.0.1:${port}`;
   const proc = spawn(
     BIN,
@@ -174,11 +179,18 @@ async function drive(port) {
     // Pin the clock so each pose gets exactly one fixed step.
     await post(base, "/time", { type: "set", tts: 0.0 });
     for (let i = 0; i < STEPS; i++) {
-      await post(base, "/input", poseAt(i));
+      await post(base, "/input", poseFn(i));
       await stepOneFrame(base);
     }
     const after = await state(base);
-    return { after, log };
+
+    // Release the injection: the game must fall back to "no XR device", which
+    // is only observable because the runtime stopped substituting our sample.
+    await post(base, "/input", { type: "xr_clear" });
+    await stepOneFrame(base);
+    const cleared = await state(base);
+
+    return { after, cleared, log };
   } finally {
     proc.kill("SIGKILL");
   }
@@ -207,12 +219,45 @@ console.log("\n▸ the pose sequence drove the simulation");
 const orb = point(after.model, "orb");
 const aim = posePosition(after.model, "rightAim");
 const init = { x: 0.0, y: 1.15, z: -0.7 };
-const moved = Math.hypot(orb.x - init.x, orb.y - init.y, orb.z - init.z);
-const toAim = Math.hypot(orb.x - aim.x, orb.y - aim.y, orb.z - aim.z);
+const dist = (a, b) => Math.hypot(a.x - b.x, a.y - b.y, a.z - b.z);
+const moved = dist(orb, init);
+const toAim = dist(orb, aim);
 check(moved > 0.1, `the orb left its init pose (moved ${moved.toFixed(3)})`);
 check(toAim < 0.5, `the orb was dragged to the injected aim (${toAim.toFixed(3)} away)`);
 
+// The control: the SAME machinery, but the hand held at the sweep's first pose
+// (z = -0.55, the plane --emulate-xr pins it to). If the harness were only
+// proving "a hand was tracked", this would land in the same place. It must not:
+// the swept hand ends 0.67 further back, and the orb has to follow it there.
+console.log("\n▸ the endpoint reflects the sequence, not just that XR was on");
+const control = await drive(8143, () => poseAt(0));
+const controlOrb = point(control.after.model, "orb");
+const spread = dist(orb, controlOrb);
+check(
+  spread > 0.3,
+  `a held first-pose control ends elsewhere (${spread.toFixed(3)} apart), so the sweep drove the result`,
+);
+// Rig-local +z is BACKWARD (OpenXR forward is -Z), and this camera sits at
+// z = -3 looking toward +Z — so a hand pulled toward the face travels toward
+// the camera, i.e. to SMALLER world z. The orb has to follow it there.
+check(
+  orb.z < controlOrb.z,
+  `pulling the hand toward the face drew the orb toward the camera (swept z ${orb.z.toFixed(3)} < held z ${controlOrb.z.toFixed(3)})`,
+);
+
+console.log("\n▸ releasing the injection restores the undriven state");
+check(
+  first.cleared.input.xr === undefined,
+  "xr_clear dropped the xr domain (no --emulate-xr to fall back to)",
+);
+check(
+  field(first.cleared.model, "rightGripTracked") === "false",
+  "the game returned to its Option.None branch",
+);
+
 console.log("\n▸ the sequence is deterministic");
+// Same inputs, a fresh process: this pins the injection path's reproducibility.
+// (It is not a test of recorded-log REPLAY — that path has its own coverage.)
 const second = await drive(8142);
 check(
   second.after.model === after.model,

--- a/e2e/xr-pose-injection.mjs
+++ b/e2e/xr-pose-injection.mjs
@@ -1,0 +1,182 @@
+// XR pose injection E2E: prove a synthetic two-hand pose sequence drives a real
+// game headlessly, with no headset and no GL window.
+//
+// This is the agent-verifiability proof for `POST /input {"type":"xr", …}`
+// (docs/debug-runtime.md). It drives `examples/xr-controllers` — whose
+// `sampledInput` reads `snapshot.xr` and whose `tick` pulls the orb toward the
+// right hand's aim — over the debug server:
+//
+//   1. NO `--emulate-xr`: assert the game starts on its `Option.None` branch
+//      (nothing tracked), so the `xr` domain provably comes from injection.
+//   2. Inject a two-hand sample whose right hand sits at z = +0.12 with the
+//      trigger held — a pose the desktop emulator CANNOT express (it pins both
+//      hands to z = -0.55, identity orientation, and derives the trigger from
+//      the keyboard). Step the clock one fixed frame per pose.
+//   3. Assert the game saw it: both hands tracked, `grabbing: true`, and the orb
+//      dragged from its `init` position to the injected aim point.
+//   4. Replay the identical sequence in a second process and assert the final
+//      model text matches byte for byte — the sequence is deterministic because
+//      the injected sample rides the same `sampledInput` path a headset takes.
+//
+// Run manually (needs the CLI built; the wasm bundle is not required):
+//
+//   cargo build -p functor-cli --no-default-features
+//   node e2e/xr-pose-injection.mjs
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const BIN = `${ROOT}target/debug/functor`;
+const SAMPLE = "examples/xr-controllers";
+const STEPS = 40;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** The right hand's pose at step `i`: a straight pull from the emulator's plane
+ *  (z = -0.55) back PAST the head to z = +0.12, trigger held the whole way. The
+ *  left hand holds a rotated grip. Neither is expressible via `--emulate-xr`. */
+function poseAt(i) {
+  const t = i / (STEPS - 1);
+  return {
+    type: "xr",
+    head: { position: [0.0, 0.0, 0.0] },
+    left: {
+      active: true,
+      grip: { position: [-0.3, -0.1, -0.6], orientation: [0.0, 0.38, 0.0, 0.92] },
+      aim: { position: [-0.3, -0.1, -0.6], orientation: [0.0, 0.38, 0.0, 0.92] },
+    },
+    right: {
+      active: true,
+      grip: { position: [-0.05, -0.05, -0.55 + t * 0.67] },
+      aim: { position: [-0.05, -0.05, -0.55 + t * 0.67] },
+      trigger: 1.0,
+    },
+  };
+}
+
+async function post(base, path, body) {
+  const res = await fetch(`${base}${path}`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  if (!res.ok) throw new Error(`POST ${path} → ${res.status}: ${text}`);
+  return text;
+}
+
+async function state(base) {
+  const res = await fetch(`${base}/state`);
+  if (!res.ok) throw new Error(`GET /state → ${res.status}`);
+  return res.json();
+}
+
+async function waitReady(base, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const s = await state(base);
+      if (s.frame > 0) return s;
+    } catch {
+      // not listening yet
+    }
+    await sleep(100);
+  }
+  throw new Error("runtime never reported a frame");
+}
+
+/** Read one numeric field out of the model's Rust `Debug` text. */
+function field(model, name) {
+  const m = model.match(new RegExp(`"${name}":\\s*([A-Za-z0-9_.+-]+)`));
+  return m ? m[1] : undefined;
+}
+
+/** Read a `{ x, y, z }` record field out of the model's `Debug` text. */
+function point(model, name) {
+  const m = model.match(
+    new RegExp(
+      `"${name}":\\s*\\{[^{}]*?"x":\\s*(-?[\\d.e+-]+)[^{}]*?"y":\\s*(-?[\\d.e+-]+)[^{}]*?"z":\\s*(-?[\\d.e+-]+)`,
+      "s",
+    ),
+  );
+  if (!m) throw new Error(`no ${name} point in model:\n${model}`);
+  return { x: +m[1], y: +m[2], z: +m[3] };
+}
+
+/** Run the whole injected sequence against a fresh runtime; return the state. */
+async function drive(port) {
+  const base = `http://127.0.0.1:${port}`;
+  const proc = spawn(
+    BIN,
+    ["-d", SAMPLE, "run", "native", "--headless", "--debug-port", String(port)],
+    { cwd: ROOT, stdio: ["ignore", "pipe", "pipe"] },
+  );
+  let log = "";
+  proc.stdout.on("data", (d) => (log += d));
+  proc.stderr.on("data", (d) => (log += d));
+
+  try {
+    await waitReady(base, 30000);
+
+    // No --emulate-xr, so the game must currently be on its Option.None branch.
+    const before = await state(base);
+    if (before.input.xr !== undefined) {
+      throw new Error(`expected no xr domain before injection, got ${JSON.stringify(before.input.xr)}`);
+    }
+    if (field(before.model, "rightGripTracked") !== "false") {
+      throw new Error(`expected rightGripTracked false, model:\n${before.model}`);
+    }
+
+    // Pin the clock so each pose gets exactly one fixed step.
+    await post(base, "/time", { type: "set", tts: 0.0 });
+    for (let i = 0; i < STEPS; i++) {
+      await post(base, "/input", poseAt(i));
+      await post(base, "/time", { type: "advance", dts: 1 / 60 });
+    }
+    const after = await state(base);
+    return { after, log };
+  } finally {
+    proc.kill("SIGKILL");
+  }
+}
+
+const failures = [];
+const check = (ok, what) => {
+  console.log(`  ${ok ? "✓" : "✗"} ${what}`);
+  if (!ok) failures.push(what);
+};
+
+const first = await drive(8141);
+const { after } = first;
+
+console.log("\n▸ the injected sample reached the game");
+check(after.input.xr !== undefined, "/state reports an xr domain (injection supplied it)");
+check(
+  after.input.xr?.right?.grip?.position?.[2] > 0,
+  "the right hand is at positive z — a pose --emulate-xr cannot produce",
+);
+check(field(after.model, "leftGripTracked") === "true", "left hand tracked");
+check(field(after.model, "rightGripTracked") === "true", "right hand tracked");
+check(field(after.model, "grabbing") === "true", "injected trigger drove `grabbing`");
+
+console.log("\n▸ the pose sequence drove the simulation");
+const orb = point(after.model, "orb");
+const aim = point(after.model, "rightAim");
+const init = { x: 0.0, y: 1.15, z: -0.7 };
+const moved = Math.hypot(orb.x - init.x, orb.y - init.y, orb.z - init.z);
+const toAim = Math.hypot(orb.x - aim.x, orb.y - aim.y, orb.z - aim.z);
+check(moved > 0.1, `the orb left its init pose (moved ${moved.toFixed(3)})`);
+check(toAim < 0.5, `the orb was dragged to the injected aim (${toAim.toFixed(3)} away)`);
+
+console.log("\n▸ the sequence is deterministic");
+const second = await drive(8142);
+check(
+  second.after.model === after.model,
+  "an identical injected sequence produced an identical model",
+);
+
+if (failures.length) {
+  console.error(`\n✗ xr-pose-injection failed: ${failures.join(", ")}`);
+  console.error(`\nfinal model:\n${after.model}`);
+  process.exit(1);
+}
+console.log("\n✓ xr-pose-injection passed");

--- a/e2e/xr-pose-injection.mjs
+++ b/e2e/xr-pose-injection.mjs
@@ -103,22 +103,48 @@ async function stepOneFrame(base, timeoutMs = 10000) {
   throw new Error(`frame never advanced past ${before}`);
 }
 
-/** Read one numeric field out of the model's Rust `Debug` text. */
+// The model arrives as the runtime's `Debug` text, whose record keys are
+// UNQUOTED (`rightGripTracked: false`, `orb: { x: 0, … }`) — so these readers
+// match bare identifiers, and nest by balancing braces rather than by a regex
+// that cannot see into a sub-record.
+
+/** Read one scalar field out of the model's `Debug` text. */
 function field(model, name) {
-  const m = model.match(new RegExp(`"${name}":\\s*([A-Za-z0-9_.+-]+)`));
+  const m = model.match(new RegExp(`\\b${name}:\\s*([A-Za-z0-9_.+-]+)`));
   return m ? m[1] : undefined;
 }
 
-/** Read a `{ x, y, z }` record field out of the model's `Debug` text. */
-function point(model, name) {
-  const m = model.match(
-    new RegExp(
-      `"${name}":\\s*\\{[^{}]*?"x":\\s*(-?[\\d.e+-]+)[^{}]*?"y":\\s*(-?[\\d.e+-]+)[^{}]*?"z":\\s*(-?[\\d.e+-]+)`,
-      "s",
-    ),
+/** The balanced `{…}` block that follows `name:`, so nested records work. */
+function block(text, name) {
+  const m = text.match(new RegExp(`\\b${name}:\\s*\\{`));
+  if (!m) throw new Error(`no ${name} record in:\n${text}`);
+  const open = m.index + m[0].length - 1;
+  let depth = 0;
+  for (let i = open; i < text.length; i++) {
+    if (text[i] === "{") depth++;
+    else if (text[i] === "}" && --depth === 0) return text.slice(open, i + 1);
+  }
+  throw new Error(`unbalanced ${name} record in:\n${text}`);
+}
+
+/** The `{ x, y, z }` immediately inside a block. */
+function xyz(text, what) {
+  const m = text.match(
+    /\bx:\s*(-?[\d.e+-]+),\s*y:\s*(-?[\d.e+-]+),\s*z:\s*(-?[\d.e+-]+)/,
   );
-  if (!m) throw new Error(`no ${name} point in model:\n${model}`);
+  if (!m) throw new Error(`no x/y/z in ${what}:\n${text}`);
   return { x: +m[1], y: +m[2], z: +m[3] };
+}
+
+/** A plain point field, e.g. `orb`. */
+function point(model, name) {
+  return xyz(block(model, name), name);
+}
+
+/** A tracked pose's position — a pose is `{ position, forward, up }`, so the
+ *  point lives one level down and a flat reader would miss it entirely. */
+function posePosition(model, name) {
+  return xyz(block(block(model, name), "position"), `${name}.position`);
 }
 
 /** Run the whole injected sequence against a fresh runtime; return the state. */
@@ -179,7 +205,7 @@ check(field(after.model, "grabbing") === "true", "injected trigger drove `grabbi
 
 console.log("\n▸ the pose sequence drove the simulation");
 const orb = point(after.model, "orb");
-const aim = point(after.model, "rightAim");
+const aim = posePosition(after.model, "rightAim");
 const init = { x: 0.0, y: 1.15, z: -0.7 };
 const moved = Math.hypot(orb.x - init.x, orb.y - init.y, orb.z - init.z);
 const toAim = Math.hypot(orb.x - aim.x, orb.y - aim.y, orb.z - aim.z);

--- a/e2e/xr-pose-injection.mjs
+++ b/e2e/xr-pose-injection.mjs
@@ -84,6 +84,25 @@ async function waitReady(base, timeoutMs) {
   throw new Error("runtime never reported a frame");
 }
 
+/** Advance exactly one fixed step and WAIT for it to land.
+ *
+ * `POST /time advance` sets the clock's single `pending_step` slot, which the
+ * loop consumes on its next iteration. Two advances that arrive inside one
+ * request-drain therefore collapse into ONE step — so a naive
+ * "post pose, post advance" loop silently drops poses at localhost speed, and
+ * how many it drops depends on timing. Waiting for `frame` to increment is what
+ * makes one pose == one frame, and the sequence reproducible. */
+async function stepOneFrame(base, timeoutMs = 10000) {
+  const before = (await state(base)).frame;
+  await post(base, "/time", { type: "advance", dts: 1 / 60 });
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if ((await state(base)).frame > before) return;
+    await sleep(5);
+  }
+  throw new Error(`frame never advanced past ${before}`);
+}
+
 /** Read one numeric field out of the model's Rust `Debug` text. */
 function field(model, name) {
   const m = model.match(new RegExp(`"${name}":\\s*([A-Za-z0-9_.+-]+)`));
@@ -130,7 +149,7 @@ async function drive(port) {
     await post(base, "/time", { type: "set", tts: 0.0 });
     for (let i = 0; i < STEPS; i++) {
       await post(base, "/input", poseAt(i));
-      await post(base, "/time", { type: "advance", dts: 1 / 60 });
+      await stepOneFrame(base);
     }
     const after = await state(base);
     return { after, log };

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test:ide": "node e2e/ide-project.mjs",
     "test:ide-page": "node e2e/ide-page.mjs",
     "test:runtime-target": "node e2e/runtime-target.mjs",
+    "test:xr-injection": "cargo build -p functor-cli --no-default-features && node e2e/xr-pose-injection.mjs",
     "demo:time-travel": "node site/demos/time-travel.mjs",
     "demo:instant-feedback": "node site/demos/instant-feedback.mjs",
     "demo:batteries-included": "node site/demos/batteries-included.mjs",

--- a/runtime/functor-runtime-common/src/camera.rs
+++ b/runtime/functor-runtime-common/src/camera.rs
@@ -7,10 +7,23 @@ use crate::math::Angle;
 ///
 /// The orientation is a unit quaternion in `[x, y, z, w]` order. Tracking
 /// local `+X` is right, `+Y` is up, and `-Z` is forward, matching OpenXR.
+///
+/// Deserialization fills missing fields from [`TrackingPose::IDENTITY`], so a
+/// scripted/injected pose can name only the part it cares about.
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
 pub struct TrackingPose {
     pub position: [f32; 3],
     pub orientation: [f32; 4],
+}
+
+/// The identity pose — NOT a field-wise zero: an all-zero quaternion is not a
+/// rotation. Hand-written for that reason, and so partial debug-injected poses
+/// (`{"position":[…]}`) default to an upright, forward-facing orientation.
+impl Default for TrackingPose {
+    fn default() -> Self {
+        TrackingPose::IDENTITY
+    }
 }
 
 impl TrackingPose {

--- a/runtime/functor-runtime-common/src/camera.rs
+++ b/runtime/functor-runtime-common/src/camera.rs
@@ -11,7 +11,7 @@ use crate::math::Angle;
 /// Deserialization fills missing fields from [`TrackingPose::IDENTITY`], so a
 /// scripted/injected pose can name only the part it cares about.
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct TrackingPose {
     pub position: [f32; 3],
     pub orientation: [f32; 4],

--- a/runtime/functor-runtime-common/src/debug_protocol.rs
+++ b/runtime/functor-runtime-common/src/debug_protocol.rs
@@ -80,7 +80,7 @@ pub const DEBUG_ROUTES: &[DebugRoute] = &[
     DebugRoute {
         method: "POST",
         path: "/input",
-        description: "inject input — {\"type\":\"key\",\"key\":\"w\",\"down\":true} | {\"type\":\"mouse_move\",\"x\":0,\"y\":0} | {\"type\":\"mouse_wheel\",\"delta\":1} | {\"type\":\"ui_event\",\"slot\":0,\"kind\":\"Clicked\"} | {\"type\":\"webview_event\",\"slot\":0,\"kind\":\"Clicked\"}",
+        description: "inject input — {\"type\":\"key\",\"key\":\"w\",\"down\":true} | {\"type\":\"mouse_move\",\"x\":0,\"y\":0} | {\"type\":\"mouse_wheel\",\"delta\":1} | {\"type\":\"ui_event\",\"slot\":0,\"kind\":\"Clicked\"} | {\"type\":\"webview_event\",\"slot\":0,\"kind\":\"Clicked\"} | {\"type\":\"xr\",\"left\":{...},\"right\":{...},\"head\":{...}} (desktop only; level state until the next xr command) | {\"type\":\"xr_clear\"} (drop it, restoring the emulator or no device)",
     },
     DebugRoute {
         method: "POST",
@@ -205,6 +205,13 @@ pub enum InputCommand {
     /// Boxed: the sample is an order of magnitude larger than the other
     /// commands, and would otherwise inflate every one of them.
     Xr(Box<XrInputSnapshot>),
+    /// Drop an injected sample, restoring whatever the runtime would sample on
+    /// its own — the `--emulate-xr` rig, or no `xr` domain at all.
+    ///
+    /// The release half of `Xr`'s held-key contract. Without it injection is a
+    /// one-way door: the first `xr` command would disable the emulator and make
+    /// a game's "no XR device" branch unreachable for the rest of the process.
+    XrClear,
 }
 
 /// A clock command sent through `POST /time`.
@@ -474,6 +481,35 @@ mod tests {
         // no head pose — i.e. "XR present, nothing tracked".
         let bare = serde_json::from_str::<InputCommand>(r#"{"type":"xr"}"#).unwrap();
         assert_eq!(bare, InputCommand::Xr(Box::default()));
+    }
+
+    /// Every field of an `xr` body is optional, so WITHOUT `deny_unknown_fields`
+    /// a typo is not a no-op — it is worse: the command still succeeds and
+    /// installs an all-default sample, flipping the game from "no XR device" to
+    /// "XR present, nothing tracked" and pinning it there. For a driver an agent
+    /// writes blind, that silent success is the expensive failure, so a
+    /// misspelling must be a 400 like every other malformed command.
+    #[test]
+    fn a_misspelled_xr_field_is_rejected_rather_than_silently_defaulted() {
+        for body in [
+            r#"{"type":"xr","lft":{"active":true}}"#,          // misspelled hand
+            r#"{"type":"xr","right":{"triger":1.0}}"#,         // misspelled control
+            r#"{"type":"xr","right":{"grip":{"pos":[0.0,0.0,0.0]}}}"#, // misspelled pose field
+        ] {
+            let err = serde_json::from_str::<InputCommand>(body)
+                .expect_err(&format!("{body} must be rejected"));
+            assert!(
+                err.to_string().contains("unknown field"),
+                "{body} rejected for the wrong reason: {err}"
+            );
+        }
+
+        // The tag itself must NOT count as an unknown field: `Xr` is an
+        // internally-tagged NEWTYPE variant, so `type` travels in the same map
+        // as the sample's own fields and a naive `deny_unknown_fields` would
+        // reject every valid body.
+        serde_json::from_str::<InputCommand>(r#"{"type":"xr","right":{"trigger":1.0}}"#)
+            .expect("a well-formed body still decodes");
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/debug_protocol.rs
+++ b/runtime/functor-runtime-common/src/debug_protocol.rs
@@ -10,7 +10,7 @@ use std::sync::mpsc::Sender;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{ui::UiEventKind, InputSnapshot};
+use crate::{ui::UiEventKind, InputSnapshot, XrInputSnapshot};
 
 /// Stable name returned by the discovery endpoint on every runtime target.
 pub const DEBUG_PROTOCOL_SERVICE: &str = "functor debug runtime";
@@ -195,6 +195,16 @@ pub enum InputCommand {
     MouseWheel { delta: i32 },
     UiEvent { slot: u32, kind: UiEventKind },
     WebviewEvent { slot: u32, kind: UiEventKind },
+    /// Set the XR device sample the next fixed step's `sampledInput` sees, so
+    /// tracked poses, grips, and buttons are scriptable without a headset.
+    ///
+    /// Level state, not an edge event: the injected sample stays in force until
+    /// the next `xr` command replaces it, exactly like a held key. It is a
+    /// WHOLE-sample replacement — a field the body omits takes its default
+    /// (inactive hand, no pose, `0.0`), so a driver sends both hands each step.
+    /// Boxed: the sample is an order of magnitude larger than the other
+    /// commands, and would otherwise inflate every one of them.
+    Xr(Box<XrInputSnapshot>),
 }
 
 /// A clock command sent through `POST /time`.
@@ -324,7 +334,7 @@ pub enum DebugRequest {
 mod tests {
     use std::collections::BTreeSet;
 
-    use crate::Key;
+    use crate::{Key, TrackingPose};
     use serde_json::{json, Value};
 
     use super::*;
@@ -423,6 +433,47 @@ mod tests {
             serde_json::from_str::<RewindCommand>(r#"{"frame":42}"#).unwrap(),
             RewindCommand { frame: 42 }
         );
+    }
+
+    #[test]
+    fn an_xr_command_decodes_a_whole_sample_and_defaults_what_it_omits() {
+        let command = serde_json::from_str::<InputCommand>(
+            r#"{"type":"xr",
+                "head": { "position": [0.0, 0.1, 0.0] },
+                "left": { "active": true,
+                          "grip": { "position": [-0.3, -0.1, -0.6],
+                                    "orientation": [0.0, 0.38, 0.0, 0.92] } },
+                "right": { "active": true,
+                           "grip": { "position": [-0.05, -0.05, 0.12] },
+                           "trigger": 1.0 }}"#,
+        )
+        .expect("xr command decodes");
+        let InputCommand::Xr(sample) = command else {
+            panic!("expected an xr command");
+        };
+
+        // An omitted `orientation` is IDENTITY, not an all-zero quaternion
+        // (which is not a rotation at all).
+        assert_eq!(
+            sample.head,
+            Some(TrackingPose::new([0.0, 0.1, 0.0], [0.0, 0.0, 0.0, 1.0]))
+        );
+        assert_eq!(
+            sample.left.grip,
+            Some(TrackingPose::new([-0.3, -0.1, -0.6], [0.0, 0.38, 0.0, 0.92]))
+        );
+        // Omitted controller fields take their defaults: no `aim` pose, and the
+        // left hand's trigger is released even though the right hand's is held.
+        assert_eq!(sample.left.aim, None);
+        assert_eq!(sample.left.trigger, 0.0);
+        assert_eq!(sample.right.trigger, 1.0);
+        assert_eq!(sample.right.thumbstick, [0.0, 0.0]);
+        assert!(!sample.right.primary_pressed);
+
+        // The minimal body is a fully-default sample: both hands inactive,
+        // no head pose — i.e. "XR present, nothing tracked".
+        let bare = serde_json::from_str::<InputCommand>(r#"{"type":"xr"}"#).unwrap();
+        assert_eq!(bare, InputCommand::Xr(Box::default()));
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/input.rs
+++ b/runtime/functor-runtime-common/src/input.rs
@@ -41,7 +41,7 @@ pub struct MouseSnapshot {
 /// inactive), so a debug-injected sample (`POST /input` `{"type":"xr",…}`) can
 /// name only the hand and controls it drives.
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct XrInputSnapshot {
     /// Center-eye pose relative to the rig reference.
     pub head: Option<TrackingPose>,
@@ -55,7 +55,7 @@ pub struct XrInputSnapshot {
 /// hand. Each pose is independently optional because OpenXR may have buttons
 /// while positional tracking is temporarily invalid.
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct XrControllerSnapshot {
     pub active: bool,
     pub grip: Option<TrackingPose>,

--- a/runtime/functor-runtime-common/src/input.rs
+++ b/runtime/functor-runtime-common/src/input.rs
@@ -36,7 +36,12 @@ pub struct MouseSnapshot {
 /// camera rig is established: +X right, +Y up, -Z forward. Keeping them
 /// rig-local lets a pure game map them through its current authored camera
 /// without a one-frame mismatch when locomotion moves that camera.
+///
+/// Deserialization defaults every missing field (no head pose, both hands
+/// inactive), so a debug-injected sample (`POST /input` `{"type":"xr",…}`) can
+/// name only the hand and controls it drives.
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
 pub struct XrInputSnapshot {
     /// Center-eye pose relative to the rig reference.
     pub head: Option<TrackingPose>,
@@ -50,6 +55,7 @@ pub struct XrInputSnapshot {
 /// hand. Each pose is independently optional because OpenXR may have buttons
 /// while positional tracking is temporarily invalid.
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
 pub struct XrControllerSnapshot {
     pub active: bool,
     pub grip: Option<TrackingPose>,

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -97,16 +97,27 @@ fn sampled_input_snapshot(
     }
 }
 
+/// Build this step's sampled input.
+///
+/// `xr_override` is a debug-injected XR sample (`POST /input` `{"type":"xr"}`).
+/// It WINS over the mouse/keyboard emulator, and supplies the `xr` domain even
+/// without `--emulate-xr` — the point is scripting tracked poses that no desktop
+/// device can express. It is level state, so it applies to every step until
+/// replaced, exactly like `held_keys`.
 fn desktop_input_snapshot(
     held_keys: &BTreeSet<InputKey>,
     mouse_pos: (i32, i32),
     emulate_xr: bool,
     xr_primary_down: bool,
     xr_surface: (i32, i32),
+    xr_override: Option<&XrInputSnapshot>,
 ) -> InputSnapshot {
-    let xr = emulate_xr.then(|| {
-        crate::desktop_xr_emulator::sample(held_keys, mouse_pos, xr_primary_down, xr_surface)
-    });
+    let xr = match xr_override {
+        Some(injected) => Some(injected.clone()),
+        None => emulate_xr.then(|| {
+            crate::desktop_xr_emulator::sample(held_keys, mouse_pos, xr_primary_down, xr_surface)
+        }),
+    };
     sampled_input_snapshot(held_keys, mouse_pos, xr)
 }
 
@@ -114,14 +125,22 @@ fn refresh_fixed_input_levels(
     snapshot: &mut InputSnapshot,
     held_keys: &BTreeSet<InputKey>,
     xr_primary_down: bool,
+    xr_override: Option<&XrInputSnapshot>,
 ) {
     snapshot.held_keys = held_keys.iter().copied().collect();
-    if let Some(xr) = snapshot.xr.as_mut() {
-        crate::desktop_xr_emulator::update_right_controls(
-            &mut xr.right,
-            held_keys,
-            xr_primary_down,
-        );
+    // An injected sample owns the whole XR domain — window keys must not
+    // re-derive its trigger/thumbstick out from under the driver.
+    match xr_override {
+        Some(injected) => snapshot.xr = Some(injected.clone()),
+        None => {
+            if let Some(xr) = snapshot.xr.as_mut() {
+                crate::desktop_xr_emulator::update_right_controls(
+                    &mut xr.right,
+                    held_keys,
+                    xr_primary_down,
+                );
+            }
+        }
     }
 }
 
@@ -555,6 +574,9 @@ fn service_debug_request(
     height: u32,
     held_keys: &mut BTreeSet<InputKey>,
     mouse_pos: &mut (i32, i32),
+    // The debug-injected XR sample, if any: `{"type":"xr"}` sets it and every
+    // later step samples it (see `desktop_input_snapshot`).
+    xr_override: &mut Option<XrInputSnapshot>,
     state_input: InputSnapshot,
     emulate_xr: bool,
     clock: &mut GameClock,
@@ -653,6 +675,7 @@ fn service_debug_request(
                 &cmd,
                 debug_server::InputCommand::Key { .. }
                     | debug_server::InputCommand::MouseMove { .. }
+                    | debug_server::InputCommand::Xr(_)
             );
             let result = match cmd {
                 debug_server::InputCommand::Key { key, down } => {
@@ -713,6 +736,14 @@ fn service_debug_request(
                     game.webview_event(functor_runtime_common::ui::UiEvent { slot, kind });
                     Ok(())
                 }
+                debug_server::InputCommand::Xr(snapshot) => {
+                    // No entry-point call here: XR is SAMPLED, not evented, so
+                    // the sample must reach the game through the same
+                    // `sampled_input` path a headset takes — which is what makes
+                    // it land in the recorded input log and replay identically.
+                    *xr_override = Some(*snapshot);
+                    Ok(())
+                }
             };
             // Input injected while PAUSED journals entry-point calls no `tick`
             // will sweep — fold them into the inspector's last-frame journal so
@@ -762,6 +793,7 @@ fn run_headless(
     } else {
         (0, 0)
     };
+    let mut xr_override: Option<XrInputSnapshot> = None;
     // Keep the debug protocol target-isomorphic even without pixels: uploaded
     // assets can be accepted now and are ready if headless rendering gains an
     // asset path later.
@@ -817,6 +849,7 @@ fn run_headless(
                     emulate_xr,
                     false,
                     crate::desktop_xr_emulator::reference_surface(),
+                    xr_override.as_ref(),
                 );
                 game.sampled_input(&snapshot);
             }
@@ -839,6 +872,7 @@ fn run_headless(
                     emulate_xr,
                     false,
                     crate::desktop_xr_emulator::reference_surface(),
+                    xr_override.as_ref(),
                 );
                 service_debug_request(
                     req,
@@ -850,6 +884,7 @@ fn run_headless(
                     0,
                     &mut held_keys,
                     &mut mouse_pos,
+                    &mut xr_override,
                     state_input,
                     emulate_xr,
                     &mut clock,
@@ -1138,6 +1173,7 @@ pub fn run(args: Args) {
         };
         let mut xr_primary_down = false;
         let mut xr_primary_clicked = false;
+        let mut xr_override: Option<XrInputSnapshot> = None;
         // `--fixed-time` is a deterministic capture pin: the one zero-delta
         // bootstrap step must not observe cursor motion from the host window.
         // Explicit debug input remains authoritative; key release/focus-loss
@@ -1149,6 +1185,7 @@ pub fn run(args: Args) {
             args.emulate_xr,
             false,
             window.get_size(),
+            xr_override.as_ref(),
         );
         // Whether the window owns the pointer (free-look). See the Escape /
         // MouseButton / Focus arms in the event loop. A hidden window never
@@ -1484,6 +1521,7 @@ Escape again to quit"
                                 &mut fixed_input_snapshot,
                                 &held_keys,
                                 xr_primary_down || xr_primary_clicked,
+                                xr_override.as_ref(),
                             );
                         }
                     }
@@ -1509,6 +1547,7 @@ Escape again to quit"
                                 &mut fixed_input_snapshot,
                                 &held_keys,
                                 false,
+                                xr_override.as_ref(),
                             );
                         }
                     }
@@ -1620,6 +1659,7 @@ Escape again to quit"
                             args.emulate_xr,
                             xr_primary_down || xr_primary_clicked,
                             window.get_size(),
+                            xr_override.as_ref(),
                         );
                         game.sampled_input(&snapshot);
                     }
@@ -2405,6 +2445,7 @@ Escape again to quit"
                             args.emulate_xr,
                             xr_primary_down || xr_primary_clicked,
                             window.get_size(),
+                            xr_override.as_ref(),
                         )
                     };
                     let sampled_input_changed = service_debug_request(
@@ -2417,6 +2458,7 @@ Escape again to quit"
                         fb_height as u32,
                         &mut held_keys,
                         &mut mouse_pos,
+                        &mut xr_override,
                         state_input,
                         args.emulate_xr,
                         &mut clock,
@@ -2448,6 +2490,7 @@ Escape again to quit"
                             args.emulate_xr,
                             xr_primary_down || xr_primary_clicked,
                             window.get_size(),
+                            xr_override.as_ref(),
                         );
                     }
                 }
@@ -2471,6 +2514,7 @@ Escape again to quit"
 #[cfg(test)]
 mod tests {
     use super::*;
+    use functor_runtime_common::{TrackingPose, XrControllerSnapshot};
     use std::io::Write;
 
     fn write_tmp(name: &str, contents: &str) -> std::path::PathBuf {
@@ -2519,7 +2563,7 @@ mod tests {
     #[test]
     fn fixed_level_refresh_preserves_mouse_and_tracked_poses() {
         let mut snapshot =
-            desktop_input_snapshot(&BTreeSet::new(), (100, 200), true, false, (800, 600));
+            desktop_input_snapshot(&BTreeSet::new(), (100, 200), true, false, (800, 600), None);
         let pose = snapshot
             .xr
             .as_ref()
@@ -2527,7 +2571,7 @@ mod tests {
             .expect("emulated grip");
         let held = BTreeSet::from([InputKey::Space]);
 
-        refresh_fixed_input_levels(&mut snapshot, &held, false);
+        refresh_fixed_input_levels(&mut snapshot, &held, false, None);
 
         assert_eq!(snapshot.mouse, MouseSnapshot { x: 100, y: 200 });
         assert_eq!(
@@ -2536,5 +2580,88 @@ mod tests {
         );
         assert_eq!(snapshot.xr.as_ref().unwrap().right.trigger, 1.0);
         assert_eq!(snapshot.held_keys, vec![InputKey::Space]);
+    }
+
+    /// A pose an emulated desktop rig CANNOT produce: the emulator pins both
+    /// hands to z = -0.55 with identity orientation, so a hand pulled BACK
+    /// toward the face with a rotated grip is exactly the gesture that was
+    /// previously untestable without a headset.
+    fn injected_sample() -> XrInputSnapshot {
+        XrInputSnapshot {
+            head: Some(TrackingPose::new([0.0, 0.05, 0.0], [0.0, 0.0, 0.0, 1.0])),
+            left: XrControllerSnapshot {
+                active: true,
+                grip: Some(TrackingPose::new([-0.3, -0.1, -0.6], [0.0, 0.38, 0.0, 0.92])),
+                aim: Some(TrackingPose::new([-0.3, -0.1, -0.6], [0.0, 0.38, 0.0, 0.92])),
+                ..XrControllerSnapshot::default()
+            },
+            right: XrControllerSnapshot {
+                active: true,
+                grip: Some(TrackingPose::new([-0.05, -0.05, 0.12], [0.0, 0.0, 0.0, 1.0])),
+                aim: Some(TrackingPose::new([-0.05, -0.05, 0.12], [0.0, 0.0, 0.0, 1.0])),
+                trigger: 1.0,
+                ..XrControllerSnapshot::default()
+            },
+        }
+    }
+
+    #[test]
+    fn an_injected_xr_sample_wins_over_the_desktop_emulator() {
+        let injected = injected_sample();
+        let held = BTreeSet::from([InputKey::Space]);
+
+        // ... even with --emulate-xr on and a mouse position that would
+        // otherwise synthesize a different right hand.
+        let snapshot = desktop_input_snapshot(
+            &held,
+            (700, 100),
+            true,
+            true,
+            (800, 600),
+            Some(&injected),
+        );
+        assert_eq!(snapshot.xr.as_ref(), Some(&injected));
+        // Keyboard/mouse domains stay live alongside it.
+        assert_eq!(snapshot.held_keys, vec![InputKey::Space]);
+        assert_eq!(snapshot.mouse, MouseSnapshot { x: 700, y: 100 });
+    }
+
+    #[test]
+    fn an_injected_xr_sample_supplies_the_domain_without_emulate_xr() {
+        let injected = injected_sample();
+        let plain = desktop_input_snapshot(&BTreeSet::new(), (0, 0), false, false, (800, 600), None);
+        assert_eq!(plain.xr, None, "no XR domain without a device or injection");
+
+        let snapshot = desktop_input_snapshot(
+            &BTreeSet::new(),
+            (0, 0),
+            false,
+            false,
+            (800, 600),
+            Some(&injected),
+        );
+        assert_eq!(snapshot.xr.as_ref(), Some(&injected));
+    }
+
+    #[test]
+    fn fixed_level_refresh_does_not_clobber_an_injected_sample() {
+        let injected = injected_sample();
+        let mut snapshot = desktop_input_snapshot(
+            &BTreeSet::new(),
+            (100, 200),
+            true,
+            false,
+            (800, 600),
+            Some(&injected),
+        );
+        // Space would drive the EMULATOR's trigger to 1.0; the injected sample
+        // owns the XR domain, so window keys must leave it alone.
+        let held = BTreeSet::from([InputKey::Enter]);
+
+        refresh_fixed_input_levels(&mut snapshot, &held, true, Some(&injected));
+
+        assert_eq!(snapshot.xr.as_ref(), Some(&injected));
+        assert_eq!(snapshot.xr.as_ref().unwrap().right.squeeze, 0.0);
+        assert_eq!(snapshot.held_keys, vec![InputKey::Enter]);
     }
 }

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -676,6 +676,7 @@ fn service_debug_request(
                 debug_server::InputCommand::Key { .. }
                     | debug_server::InputCommand::MouseMove { .. }
                     | debug_server::InputCommand::Xr(_)
+                    | debug_server::InputCommand::XrClear
             );
             let result = match cmd {
                 debug_server::InputCommand::Key { key, down } => {
@@ -742,6 +743,10 @@ fn service_debug_request(
                     // `sampled_input` path a headset takes — which is what makes
                     // it land in the recorded input log and replay identically.
                     *xr_override = Some(*snapshot);
+                    Ok(())
+                }
+                debug_server::InputCommand::XrClear => {
+                    *xr_override = None;
                     Ok(())
                 }
             };

--- a/runtime/functor-runtime-oculus/src/lib.rs
+++ b/runtime/functor-runtime-oculus/src/lib.rs
@@ -647,7 +647,7 @@ fn service_debug_request(
                 // domain from live OpenXR tracking every frame, so an injected
                 // sample would be silently overwritten before any `sampledInput`
                 // saw it. Injection is the DESKTOP substitute for this device.
-                InputCommand::Xr(_) => Err(
+                InputCommand::Xr(_) | InputCommand::XrClear => Err(
                     "xr injection is unsupported on the device runtime (it samples live \
 tracking); use the desktop runtime's --headless/--debug-port path"
                         .to_string(),

--- a/runtime/functor-runtime-oculus/src/lib.rs
+++ b/runtime/functor-runtime-oculus/src/lib.rs
@@ -643,6 +643,15 @@ fn service_debug_request(
                     game.webview_event(functor_runtime_common::ui::UiEvent { slot, kind });
                     Ok(())
                 }
+                // Rejected rather than honored: this runtime resamples the XR
+                // domain from live OpenXR tracking every frame, so an injected
+                // sample would be silently overwritten before any `sampledInput`
+                // saw it. Injection is the DESKTOP substitute for this device.
+                InputCommand::Xr(_) => Err(
+                    "xr injection is unsupported on the device runtime (it samples live \
+tracking); use the desktop runtime's --headless/--debug-port path"
+                        .to_string(),
+                ),
             };
             if clock.is_paused() {
                 game.absorb_paused_input();

--- a/tools/functor-sdk/src/game.ts
+++ b/tools/functor-sdk/src/game.ts
@@ -160,6 +160,13 @@ export class FunctorClient {
     return this.input({ type: "xr", ...sample });
   }
 
+  /** Drop an injected XR sample, restoring what the runtime samples on its own
+   * — the `--emulate-xr` rig, or no `xr` domain at all. The release half of
+   * {@link xr}'s held-key contract. */
+  xrClear(): Promise<void> {
+    return this.input({ type: "xr_clear" });
+  }
+
   // --- Drive: clock --------------------------------------------------------
 
   /** Pin the game clock so it stops advancing (a "pause"). With no argument,

--- a/tools/functor-sdk/src/game.ts
+++ b/tools/functor-sdk/src/game.ts
@@ -7,6 +7,7 @@ import type {
   RuntimeState,
   Scene,
   WaitForOptions,
+  XrInputSample,
   XrInputSnapshot,
 } from "./types.js";
 
@@ -147,6 +148,16 @@ export class FunctorClient {
   /** Scroll the mouse wheel. */
   mouseWheel(delta: number): Promise<void> {
     return this.input({ type: "mouse_wheel", delta });
+  }
+
+  /** Set the XR sample the next fixed step's `sampledInput` sees — tracked
+   * poses, grips, and buttons, without a headset (desktop runtimes only).
+   *
+   * Level state that stays in force until replaced, and a whole-sample
+   * replacement: see {@link XrInputSample}. Pair with `step()` for one pose per
+   * frame. The device runtime rejects it (it samples live tracking). */
+  xr(sample: XrInputSample): Promise<void> {
+    return this.input({ type: "xr", ...sample });
   }
 
   // --- Drive: clock --------------------------------------------------------

--- a/tools/functor-sdk/src/types.ts
+++ b/tools/functor-sdk/src/types.ts
@@ -100,7 +100,8 @@ export type InputCommand =
   | { type: "mouse_wheel"; delta: number }
   | { type: "ui_event"; slot: number; kind: UiEventKind }
   | { type: "webview_event"; slot: number; kind: UiEventKind }
-  | ({ type: "xr" } & XrInputSample);
+  | ({ type: "xr" } & XrInputSample)
+  | { type: "xr_clear" };
 
 /** An injected XR sample for `POST /input` (desktop only).
  *

--- a/tools/functor-sdk/src/types.ts
+++ b/tools/functor-sdk/src/types.ts
@@ -99,7 +99,28 @@ export type InputCommand =
   | { type: "mouse_move"; x: number; y: number }
   | { type: "mouse_wheel"; delta: number }
   | { type: "ui_event"; slot: number; kind: UiEventKind }
-  | { type: "webview_event"; slot: number; kind: UiEventKind };
+  | { type: "webview_event"; slot: number; kind: UiEventKind }
+  | ({ type: "xr" } & XrInputSample);
+
+/** An injected XR sample for `POST /input` (desktop only).
+ *
+ * Level state, not an edge event: it stays in force until replaced, and every
+ * following fixed step feeds it to `sampledInput`. A WHOLE-sample replacement —
+ * an omitted field takes its default (hand inactive, no pose, `0.0`, an identity
+ * orientation) — so send both hands each step rather than relying on a merge. */
+export interface XrInputSample {
+  head?: Partial<TrackingPose> | null;
+  left?: XrControllerSample;
+  right?: XrControllerSample;
+}
+
+/** One injected controller. See {@link XrInputSample} for the defaulting rule. */
+export type XrControllerSample = Partial<
+  Omit<XrControllerSnapshot, "grip" | "aim">
+> & {
+  grip?: Partial<TrackingPose> | null;
+  aim?: Partial<TrackingPose> | null;
+};
 
 export type UiEventKind =
   | "Clicked"

--- a/tools/functor-sdk/test/unit.test.ts
+++ b/tools/functor-sdk/test/unit.test.ts
@@ -150,6 +150,33 @@ test("xrInput returns the typed optional input domain", async () => {
   assert.deepEqual(await client.xrInput(), xr);
 });
 
+test("xr() posts a flat, tagged sample and passes partials through", async () => {
+  const calls: Array<{ path: string; body: unknown }> = [];
+  const http = {
+    postText: async (path: string, body: unknown) => {
+      calls.push({ path, body });
+      return "ok";
+    },
+  } as HttpClient;
+  const client = new FunctorClient(http);
+
+  // The wire shape is the sample INLINED beside the tag, not nested — and the
+  // runtime defaults everything omitted, so a partial hand is legal.
+  await client.xr({
+    right: { active: true, grip: { position: [0, 0, 0.12] }, trigger: 1 },
+  });
+
+  assert.deepEqual(calls, [
+    {
+      path: "/input",
+      body: {
+        type: "xr",
+        right: { active: true, grip: { position: [0, 0, 0.12] }, trigger: 1 },
+      },
+    },
+  ]);
+});
+
 test("reloadAssets uploads binary envelopes then finalizes the manifest", async () => {
   const calls: Array<{ path: string; body: unknown }> = [];
   const http = {


### PR DESCRIPTION
## Why

A VR bow game written during the jam could not be tested without putting on a headset — and that made it untestable by an agent at all. The only headset-free XR source is `--emulate-xr`, whose synthesis is fixed: **both hands pinned to the rig-local plane `z = -0.55`, every orientation identity, head pose identity.** The two things a bow (or a throw, or any two-handed tool) is *made of* — pulling a hand back toward your face, and aiming along a rotated grip — are not merely awkward there, they are inexpressible. And `POST /input` had no XR variant to route around it.

## What

Adds `{"type":"xr", …}` to the debug protocol's `InputCommand`: it sets the XR sample every following fixed step feeds to `sampledInput`, plus `{"type":"xr_clear"}` to release it.

**How it rides the existing determinism.** XR is *sampled*, not evented, so the command deliberately calls no entry point. It installs a sample that reaches the game through the exact path a headset takes, which is what makes it land in `RecordedInput::Snapshot` in the recorded input log — sampled input is already recorded as plain data for deterministic forward replay, so a scripted pose sequence inherits that property for free rather than needing a parallel mechanism.

It is **level state**, like a held key: in force until replaced or cleared. It is a **whole-sample replacement** (an omitted field defaults; an omitted orientation is *identity*, not an all-zero quaternion, which is not a rotation). It **overrides `--emulate-xr`** and supplies the `xr` domain without it. `held_keys` and `mouse` stay live alongside.

The **device runtime rejects it with 400**: Quest resamples the domain from live OpenXR tracking every frame, so an injected sample could never be observed. Injection is the desktop substitute for the device, not a device feature.

### The `pending_step` gotcha

`GameClock::advance()` has a **single `pending_step` slot**. Two `advance` requests arriving inside one request-drain therefore collapse into **one** step, and the pose in between is never sampled. A naive "post pose, post advance" loop silently drops poses at localhost speed, and *how many* it drops depends on timing — so the sequence isn't reproducible. The fix is to wait for `/state.frame` to increment after each advance; that is what makes one pose == one frame. This bit the harness during development, and the same broken pattern was corrected in the `docs/debug-runtime.md` example.

## Evidence

`e2e/xr-pose-injection.mjs` (`npm run test:xr-injection`) drives `examples/xr-controllers` headless, no `--emulate-xr`, no window. **12/12 assertions pass:**

```
▸ the injected sample reached the game
  ✓ /state reports an xr domain (injection supplied it)
  ✓ the right hand is at positive z — a pose --emulate-xr cannot produce
  ✓ left hand tracked            ✓ right hand tracked
  ✓ injected trigger drove `grabbing`
▸ the pose sequence drove the simulation
  ✓ the orb left its init pose (moved 2.046)
  ✓ the orb was dragged to the injected aim (0.416 away)
▸ the endpoint reflects the sequence, not just that XR was on
  ✓ a held first-pose control ends elsewhere (0.559 apart), so the sweep drove the result
  ✓ pulling the hand toward the face drew the orb toward the camera (swept z -2.713 < held z -2.159)
▸ releasing the injection restores the undriven state
  ✓ xr_clear dropped the xr domain      ✓ the game returned to its Option.None branch
▸ the sequence is deterministic
  ✓ an identical injected sequence produced an identical model
```

The sequence: 40 two-hand poses, one per fixed frame, sweeping the right hand from `z = -0.55` to `z = +0.12` with the trigger held — an emulator-impossible depth gesture — while the left holds a rotated grip. It has a **built-in negative control** (asserts the game starts on its `Option.None` branch, so the `xr` domain provably comes from injection) and a **held-pose control run** (proves the *sequence*, not merely "XR was on", determined the endpoint).

## Tests

| Suite | Result |
| --- | --- |
| `cargo test -p functor_runtime_common` | **475 passed**, 0 failed |
| `cargo test -p functor-runtime-desktop` | 68 passed, **1 pre-existing failure** (see below) |
| `tools/functor-sdk` (`npm test`) | 23 tests, 0 failed |
| `e2e/xr-pose-injection.mjs` | 12/12 assertions |

The desktop failure is `mario_hot_reload_recomputes_the_entire_extrapolated_future`, which is **already broken on `main`** and untouched by this branch: it string-replaces `let jumpVelocity = 12.0` but `examples/mario/game.fun` reads `13.0`, so the rewrite is a no-op and the test's own guard assert trips. Left alone as out of scope.

## Review dispositions

`/xreview` — two independent adversarial engines (Claude subagent + Codex CLI), correctness and simplicity. **No Critical, no High.** Both engines independently cleared the parts most likely to be subtly wrong: every snapshot-building call site threads `xr_override`, `refresh_fixed_input_levels` cannot clobber an injected sample, the sample genuinely reaches the recorded log, `stepOneFrame`'s frame-wait is race-free, and `TrackingPose::default() == IDENTITY` is correct.

| Finding | Engines | Disposition |
| --- | --- | --- |
| Malformed `xr` body silently accepted — every field optional, so a typo like `"lft"`/`"triger"` returned 200 and *engaged* the override with an all-default nothing-tracked sample, contradicting the documented "unknown keys → 400" | **[AGREED]** both | **Fixed** — `deny_unknown_fields` on the three XR structs, + a test covering three typo shapes and guarding that the internally-tagged newtype's `type` tag isn't itself rejected |
| e2e assertions didn't distinguish "the sequence drove the sim" from "a hand was tracked"; the two-process check was described as proving replay when it doesn't exercise the recorded log | **[AGREED]** both (different specifics) | **Fixed** — added the held-pose control run and the directional check; stopped overclaiming the determinism check |
| Harness couldn't parse the model at all: searched for JSON-style `"key":` against unquoted `Debug` text, and treated the `rightAim` *pose* as a bare point | Codex | **Fixed** (3dc7f68, found independently while getting the proof to run) |
| Injection was a one-way door — no way to clear `xr_override`, so `--emulate-xr` and the `xr: None` branch became unreachable for the process, despite docs promising held-key semantics | Claude | **Fixed** — added `xr_clear` (protocol, desktop, SDK, device rejection), now covered by the e2e |
| `GET /` discovery text omitted the new command | Codex | **Fixed** |
| `refresh_fixed_input_levels` clones to reinstall a value already present | Claude (Low) | **Not taken** — the clone is a no-op copy, but the explicit `match` states the "an injected sample owns the whole XR domain" invariant at the point it matters; rewriting it as an `is_none()` guard trades that legibility for nothing measurable off the hot path |
| `test:xr-injection` isn't wired into CI | Claude (Low) | **Not taken** — the job would need the GL-linked binary; left manual, consistent with the other `e2e/` scripts and the `#[ignore]`d golden tests |
| Validate finite/non-degenerate quaternions and control ranges | Codex (part of Medium) | **Not taken** — this is a debug endpoint for a trusted local driver; the runtime already tolerates arbitrary tracked input from a device, and range-policing would add a second, divergent notion of a valid pose |

## Note for consumers

This changes runtime crates, so **`npm run build:cli` is required** to get the feature — `functor run` does not rebuild the runtimes, and a running shell will silently not have it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
