### PR TITLE
spike(session): SPIKE — a top-docked chrono bar over a live multiplayer dev session

### DIFF
--- a/e2e/spike-mp-dev-session.mjs
+++ b/e2e/spike-mp-dev-session.mjs
@@ -1,0 +1,470 @@
+// SPIKE harness: drive the multiplayer dev-session experience end to end and
+// capture it.
+//
+// This is the verification AND the capture script for the
+// `spike/multiplayer-dev-session` branch. It exists because the thing being
+// spiked is an EXPERIENCE — "does scrubbing a whole session feel exact, and can
+// you see a laggy client trail the server" — and the only honest evidence for
+// that is a real browser driving the real page.
+//
+// It asserts the spike's acceptance bar, through the RENDERED UI rather than
+// internals wherever it can:
+//
+//   1. the dev-server page for examples/mp runs a server + 2 client panes live;
+//   2. the chrono bar is docked TOP as a LAYOUT ROW — it sits entirely above the
+//      canvas rather than overlaying it;
+//   3. the pane chrome tiles the canvas exactly (no stale strip on the right);
+//   4. the rail carries a lag comb per client, and dialling a client's link to
+//      `mobile` makes THAT client's measured lag grow while the other's does not
+//      — i.e. the impairment knob visibly changes divergence;
+//   5. dragging the rail rewinds ALL panes together, via NetSim::seek, and is
+//      non-destructive (the recorded future survives);
+//   6. click-to-focus moves the loud chrome and the bar's ⌨ chip to one pane.
+//
+// Run manually (owns its own dev server on :8080):
+//
+//   npm run build:cli:debug      # target/debug/functor embeds this runtime
+//   node e2e/spike-mp-dev-session.mjs
+//   node e2e/spike-mp-dev-session.mjs --capture /tmp/spike   # + PNG/GIF
+//
+// `--capture <dir>` additionally writes `frames/*.png`, `still.png`, and (when
+// ffmpeg is on PATH) `spike.gif`.
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import net from "node:net";
+import { fileURLToPath } from "node:url";
+import { chromium } from "@playwright/test";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const BASE = "http://127.0.0.1:8080";
+const PORT = 8080;
+const PROJECT = "examples/mp";
+const ENTRIES = ["server.fun", "client.fun", "client.fun"];
+
+const captureIdx = process.argv.indexOf("--capture");
+const CAPTURE = captureIdx > 0 ? process.argv[captureIdx + 1] : null;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function portInUse() {
+  return new Promise((resolve) => {
+    const sock = net
+      .connect(PORT, "127.0.0.1")
+      .on("connect", () => {
+        sock.destroy();
+        resolve(true);
+      })
+      .on("error", () => resolve(false));
+  });
+}
+
+async function waitPortFree(timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!(await portInUse())) return true;
+    await sleep(200);
+  }
+  return false;
+}
+
+function cliPath() {
+  for (const p of ["target/debug/functor", "target/release/functor"]) {
+    if (existsSync(`${ROOT}${p}`)) return `${ROOT}${p}`;
+  }
+  throw new Error(
+    "no functor binary — run `npm run build:cli:debug` first (the CLI embeds the web runtime)",
+  );
+}
+
+const failures = [];
+const pageLog = [];
+function check(ok, label, detail = "") {
+  if (ok) {
+    console.log(`  PASS  ${label}`);
+  } else {
+    failures.push(label);
+    console.log(`  FAIL  ${label}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+async function main() {
+  if (!(await waitPortFree(10000))) {
+    throw new Error(`:${PORT} is busy — a stale dev server would serve the wrong project`);
+  }
+  const server = spawn(cliPath(), ["-d", PROJECT, "run", "wasm", "--no-open"], {
+    cwd: ROOT,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let serverOutput = "";
+  server.stdout.on("data", (d) => (serverOutput += d));
+  server.stderr.on("data", (d) => (serverOutput += d));
+
+  const browser = await chromium.launch({
+    args: [
+      "--use-gl=angle",
+      "--use-angle=swiftshader",
+      "--enable-unsafe-swiftshader",
+      "--ignore-gpu-blocklist",
+    ],
+  });
+
+  let shot = 0;
+  try {
+    // 1280x720 deliberately: the design's own stress case ("how a 1280x720
+    // laptop uses this feature at all").
+    const page = await browser.newPage({ viewport: { width: 1280, height: 720 } });
+    page.on("console", (m) => pageLog.push(m.text()));
+    page.on("pageerror", (e) => pageLog.push(`pageerror: ${e}`));
+
+    let up = false;
+    for (let i = 0; i < 60 && !up; i++) {
+      up = await portInUse();
+      if (!up) await sleep(500);
+    }
+    if (!up) {
+      throw new Error(
+        `the dev server never listened on :${PORT}. Its output was:\n${serverOutput || "(none)"}`,
+      );
+    }
+    for (let i = 0; i < 60; i++) {
+      try {
+        await page.goto(BASE);
+        break;
+      } catch {
+        await sleep(500);
+      }
+    }
+    await page.waitForFunction(() => typeof window.__sim === "object", null, { timeout: 60000 });
+    await sleep(1500); // let the single game finish booting
+
+    if (CAPTURE) {
+      rmSync(`${CAPTURE}/frames`, { recursive: true, force: true });
+      mkdirSync(`${CAPTURE}/frames`, { recursive: true });
+    }
+    const grab = async (label) => {
+      if (!CAPTURE) return;
+      const n = String(shot++).padStart(3, "0");
+      await page.screenshot({ path: `${CAPTURE}/frames/f${n}.png` });
+      if (label) console.log(`        frame ${n}  ${label}`);
+    };
+    // Hold on a beat, capturing, so the GIF reads at ~10fps.
+    const hold = async (frames, label) => {
+      for (let i = 0; i < frames; i++) {
+        await grab(i === 0 ? label : null);
+        await sleep(90);
+      }
+    };
+
+    // ---- 1. the session comes up -------------------------------------------
+    const count = await page.evaluate((e) => window.__sim.start(e, 1), ENTRIES);
+    check(count === 3, "server + 2 client panes start in one page", `got ${count}`);
+    // The bar drives itself from rAF, so wait for it to notice the session.
+    await page.waitForSelector("#chrono.on", { timeout: 15000 });
+    await page.waitForFunction(() => document.querySelectorAll("#panes .pane").length === 3);
+    // The bar mounts PAUSED so it never races a harness that steps by hand
+    // (e2e/wasm-sim.mjs). Press play, then let the clients connect and the world
+    // start moving.
+    await page.locator("#c-pause").click();
+    await sleep(2500);
+
+    const panesCount = await page.locator("#panes .pane").count();
+    check(panesCount === 3, "three pane chromes over three GL panes", `got ${panesCount}`);
+
+    // The role comes from the sim's LIVE routing tables, so it only becomes
+    // "server" once a client has connected to the bind. Chrome built from the
+    // first frame's answer labels every pane CLIENT forever.
+    const roles = await page.evaluate(() =>
+      [...document.querySelectorAll("#panes .pane .role")].map((el) => el.textContent.trim()),
+    );
+    check(
+      roles[0] === "server" && roles[1] === "client" && roles[2] === "client",
+      "the pane chrome reflects the SETTLED roles, not the first frame's",
+      JSON.stringify(roles),
+    );
+    check(
+      (await page.locator("#c-links [data-pane]").count()) === 2,
+      "the link row has a group per CLIENT and none for the server",
+    );
+    check(
+      await page.locator("#panes .pane").nth(0).locator(".model").isVisible(),
+      "the server pane shows its real model text",
+    );
+    await hold(6, "live, both clients on LAN");
+
+    // ---- 2. the chrono bar is a TOP-DOCKED LAYOUT ROW ----------------------
+    // The claim the design rests on: it reserves its own height above the stage
+    // instead of floating over the bottom of the canvas. So its box must end at
+    // or before the canvas's top edge — an overlay would fail this.
+    const boxes = await page.evaluate(() => {
+      const r = (sel) => {
+        const el = document.querySelector(sel);
+        if (!el) return null;
+        const b = el.getBoundingClientRect();
+        return { top: b.top, bottom: b.bottom, left: b.left, width: b.width };
+      };
+      return { chrono: r("#chrono"), canvas: r("#canvas") };
+    });
+    check(
+      boxes.chrono && boxes.canvas && boxes.chrono.bottom <= boxes.canvas.top + 1,
+      "the chrono bar is a layout row above the stage, not an overlay",
+      `chrono.bottom=${boxes.chrono?.bottom} canvas.top=${boxes.canvas?.top}`,
+    );
+    check(
+      boxes.chrono && Math.abs(boxes.chrono.width - 1280) < 2 && boxes.chrono.top < 2,
+      "it is full-width and docked at the very top",
+      `top=${boxes.chrono?.top} width=${boxes.chrono?.width}`,
+    );
+
+    // ---- 3. the pane chrome tiles the canvas exactly -----------------------
+    // The parked branch floored `pane_w` and left a stale strip on the right.
+    const tiling = await page.evaluate(() => {
+      const canvas = document.querySelector("#canvas").getBoundingClientRect();
+      const panes = [...document.querySelectorAll("#panes .pane")].map((el) => {
+        const b = el.getBoundingClientRect();
+        return { left: b.left - canvas.left, right: b.right - canvas.left };
+      });
+      return { width: canvas.width, panes };
+    });
+    const rightEdge = tiling.panes[tiling.panes.length - 1].right;
+    check(
+      Math.abs(rightEdge - tiling.width) < 1.5,
+      "the last pane absorbs the remainder (no stale strip)",
+      `right edge ${rightEdge.toFixed(2)} vs canvas ${tiling.width.toFixed(2)}`,
+    );
+
+    // ---- 4. lag combs, and the impairment knob -----------------------------
+    // Read the lag the UI actually renders (the pane header's ⇅ tag), so this
+    // asserts the picture rather than an internal.
+    const lags = () =>
+      page.evaluate(() =>
+        [...document.querySelectorAll("#panes .pane")].map((el) => {
+          const m = /\((\d+)f\)/.exec(el.querySelector(".lagtag").textContent || "");
+          return m ? Number(m[1]) : null;
+        }),
+      );
+    const combs = () => page.locator("#rail line.comb").count();
+    // The comb's x must be INSIDE the pinned gauge, never at rail scale — the
+    // whole reason the gauge exists is that 8 frames of lag is sub-pixel on a
+    // rail showing thousands of frames.
+    const combX = () =>
+      page.evaluate(() =>
+        [...document.querySelectorAll("#rail line.comb")].map((el) => ({
+          pane: Number(el.getAttribute("data-pane")),
+          behind: Number(el.getAttribute("data-behind")),
+          x: Number(el.getAttribute("x1")),
+        })),
+      );
+    const tlSpan = await page.evaluate(() => {
+      const t = window.__sim.timeline();
+      return Math.max(1, t.frame - (t.lo ?? 0));
+    });
+    const lanLags = await lags();
+    check(
+      lanLags[1] != null && lanLags[2] != null,
+      "each client's displayed server frame is MEASURED, not modelled",
+      `lags ${JSON.stringify(lanLags)}`,
+    );
+    check(
+      lanLags[1] <= 2 && lanLags[2] <= 2,
+      "on LAN the combs sit on the playhead (lag ~0 frames)",
+      `lags ${JSON.stringify(lanLags)}`,
+    );
+    check((await combs()) === 2, "the rail carries one lag comb per client", `got ${await combs()}`);
+
+    // Dial ONLY client 2 (pane 3) up to `mobile`.
+    await page.locator("#c-links [data-pane='2'] button", { hasText: "mobile" }).click();
+    await sleep(2500);
+    await hold(6, "client 2 on `mobile` — combs separate");
+    const mobileLags = await lags();
+    check(
+      mobileLags[2] > lanLags[2] + 2,
+      "dialling a client to `mobile` visibly grows ITS lag",
+      `client2 ${lanLags[2]}f -> ${mobileLags[2]}f`,
+    );
+    check(
+      Math.abs(mobileLags[1] - lanLags[1]) <= 2,
+      "the other client, still on LAN, is unaffected",
+      `client1 ${lanLags[1]}f -> ${mobileLags[1]}f`,
+    );
+
+    // THE reason the pinned lag gauge exists: a comb's offset must be a fixed
+    // ~4px per frame of lag, INDEPENDENT of how many frames the rail spans.
+    // Otherwise the most valuable signal in the UI shrinks as the recording
+    // grows — exactly when the user dialled latency up to look at it.
+    const cx = await combX();
+    const lagged = cx.find((c) => c.pane === 2);
+    const clean = cx.find((c) => c.pane === 1);
+    const railW = (await page.locator("#rail").boundingBox()).width;
+    const gap = clean.x - lagged.x;
+    const expected = (lagged.behind - clean.behind) * 4;
+    check(
+      Math.abs(gap - expected) <= 2,
+      "the comb sits at GAUGE scale — a fixed 4px per frame of lag",
+      `${lagged.behind - clean.behind}f apart -> ${gap.toFixed(1)}px (expected ~${expected})`,
+    );
+    // Context, not an assertion: what the same lag would be at rail scale. The
+    // design quotes 0.9px for 8 frames across 8000 recorded frames; the history
+    // ring caps a session well below that, so at THIS length the rail-scale comb
+    // would be cramped rather than literally sub-pixel. The gauge still earns its
+    // place (4x magnification plus fine-grained seek), but the figure in the doc
+    // assumes a longer recording than the ring allows.
+    console.log(
+      `        (same lag at rail scale: ${(((lagged.behind - clean.behind) / tlSpan) * railW).toFixed(2)}px over ${tlSpan} frames)`,
+    );
+
+    // `awful` pushes the comb far enough back that the pane's own cubes are
+    // visibly behind the server's, not just numerically behind.
+    await page.locator("#c-links [data-pane='2'] button", { hasText: "awful" }).click();
+    // Long enough that the coarse-zone drag below still lands on frames RECORDED
+    // under `awful` — otherwise we park before the knob was turned and the panes
+    // legitimately (but unhelpfully) realign.
+    await sleep(4500);
+    await hold(8, "client 2 on `awful` — the comb approaches the seam");
+    const awfulLags = await lags();
+    check(
+      awfulLags[2] > mobileLags[2],
+      "`awful` pushes the comb further back still",
+      `client2 ${mobileLags[2]}f -> ${awfulLags[2]}f`,
+    );
+
+    // ---- 5. scrubbing rewinds every pane together -------------------------
+    const states = () =>
+      page.evaluate(() => [0, 1, 2].map((i) => window.__sim.state(i)));
+    const before = await states();
+    const tl = await page.evaluate(() => window.__sim.timeline());
+    const railBox = await page.locator("#rail").boundingBox();
+    // Drag from the middle of the coarse zone: a real pointer drag on the real
+    // rail, not a scripted seek.
+    await page.mouse.move(railBox.x + railBox.width * 0.9, railBox.y + railBox.height / 2);
+    await page.mouse.down();
+    for (const f of [0.86, 0.83, 0.81, 0.79]) {
+      await page.mouse.move(railBox.x + railBox.width * f, railBox.y + railBox.height / 2);
+      await sleep(160);
+      await grab(null);
+    }
+    await page.mouse.up();
+    await hold(8, "parked in the past — every pane rewound together");
+    const parked = await page.evaluate(() => window.__sim.timeline());
+    const after = await states();
+    check(
+      parked.scrubPos != null && parked.scrubPos < tl.frame,
+      "dragging the rail parks the whole session in the past",
+      `scrubPos=${parked.scrubPos} live frame=${tl.frame}`,
+    );
+    check(
+      after.every((s, i) => s !== before[i]),
+      "ALL THREE panes rewound, each to its own view of that frame",
+    );
+    check(
+      parked.hi >= tl.hi,
+      "the seek is non-destructive — the recorded future survives",
+      `hi ${tl.hi} -> ${parked.hi}`,
+    );
+    check(
+      (await page.locator("#mode-chip").textContent()).includes("PARKED"),
+      "the mode chip says PARKED rather than implying live",
+    );
+
+    // The design's headline claim about the combs: parked, they show each
+    // client's RECORDED frame for that moment, so the stagger stays — that
+    // stagger is real lag, preserved. If the comb data only existed live, this
+    // is the check that would catch it.
+    const parkedLags = await lags();
+    const parkedCombs = await combX();
+    check(
+      parkedCombs.length === 2 && parkedLags[2] > parkedLags[1] + 2,
+      "parked, the combs stay STAGGERED — real lag, preserved",
+      `lags ${JSON.stringify(parkedLags)}, combs ${JSON.stringify(parkedCombs)}`,
+    );
+
+    // Resume commits the branch and the session runs on.
+    await page.locator("#c-pause").click();
+    await sleep(1200);
+    await hold(6, "resumed — the branch committed");
+    const resumed = await page.evaluate(() => window.__sim.timeline());
+    check(
+      resumed.scrubPos == null && resumed.frame > parked.scrubPos,
+      "resuming commits the branch and the session runs on",
+      `frame=${resumed.frame} scrubPos=${resumed.scrubPos}`,
+    );
+
+    // ---- 6. click-to-focus -------------------------------------------------
+    const paneBox = await page.locator("#panes .pane").nth(2).boundingBox();
+    await page.mouse.click(paneBox.x + paneBox.width / 2, paneBox.y + paneBox.height * 0.7);
+    await sleep(400);
+    await hold(6, "click-to-focus — loud chrome on pane 3");
+    const focus = await page.evaluate(() => ({
+      focused: [...document.querySelectorAll("#panes .pane")].map((el) =>
+        el.classList.contains("focused"),
+      ),
+      chip: document.querySelector("#focus-chip").textContent.trim(),
+      owned: document.querySelector("#focus-chip").classList.contains("owned"),
+    }));
+    check(
+      focus.focused.filter(Boolean).length === 1 && focus.focused[2],
+      "exactly one pane owns the keyboard, and it is the one clicked",
+      JSON.stringify(focus.focused),
+    );
+    check(
+      focus.chip.includes("3") && focus.owned,
+      "the bar's ⌨ chip names the owner and is filled",
+      `chip="${focus.chip}" owned=${focus.owned}`,
+    );
+
+    // Digits jump; the chip follows.
+    await page.keyboard.press("2");
+    await sleep(300);
+    const afterDigit = await page.evaluate(() =>
+      document.querySelector("#focus-chip").textContent.trim(),
+    );
+    check(afterDigit.includes("2"), "a digit jumps focus to that pane", `chip="${afterDigit}"`);
+    await hold(6, "digit 2 — focus moved");
+
+    // Esc releases: the chip goes hollow, so "will my keys go to the game?" is
+    // answerable at a glance.
+    await page.keyboard.press("Escape");
+    await sleep(300);
+    const released = await page.evaluate(() =>
+      document.querySelector("#focus-chip").classList.contains("owned"),
+    );
+    check(!released, "Esc releases the keyboard and the chip goes hollow");
+
+    if (CAPTURE) {
+      await page.screenshot({ path: `${CAPTURE}/still.png` });
+      console.log(`        wrote ${CAPTURE}/still.png`);
+      const ff = spawnSync("ffmpeg", [
+        "-y",
+        "-framerate", "10",
+        "-pattern_type", "glob",
+        "-i", `${CAPTURE}/frames/*.png`,
+        "-vf", "scale=960:-1:flags=lanczos,split[a][b];[a]palettegen[p];[b][p]paletteuse",
+        "-loop", "0",
+        `${CAPTURE}/spike.gif`,
+      ], { stdio: "inherit" });
+      if (ff.status === 0) console.log(`        wrote ${CAPTURE}/spike.gif`);
+      else console.log("        (no ffmpeg on PATH — PNG frames only)");
+    }
+
+    // LAST, so it covers everything above: nothing in the page's life may throw.
+    const errors = pageLog.filter((l) => /pageerror|\[chrono\] /.test(l));
+    check(errors.length === 0, "no page errors while driving the whole experience", errors.join(" | "));
+  } finally {
+    await browser.close();
+    server.kill("SIGTERM");
+  }
+
+  console.log("");
+  if (failures.length) {
+    console.log(`${failures.length} check(s) failed:`);
+    for (const f of failures) console.log(`  - ${f}`);
+    console.log("\npage log:\n" + pageLog.join("\n"));
+    process.exit(1);
+  }
+  console.log("all checks passed");
+}
+
+main().catch((e) => {
+  console.error(e);
+  console.error("\npage log:\n" + pageLog.join("\n"));
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:wasm-golden:update": "playwright test --update-snapshots",
     "test:wasm-smoke": "node e2e/wasm-smoke.mjs",
     "test:wasm-sim": "node e2e/wasm-sim.mjs",
+    "test:spike-mp-dev-session": "node e2e/spike-mp-dev-session.mjs",
     "test:wasm-remote-assets": "node e2e/remote-assets.mjs",
     "test:inspector-emit": "node e2e/inspector-emit.mjs",
     "test:scrubber": "node --test runtime/functor-runtime-web/timeline-model.test.js",

--- a/runtime/functor-netsim/src/lib.rs
+++ b/runtime/functor-netsim/src/lib.rs
@@ -749,6 +749,24 @@ impl NetSim {
         }
     }
 
+    /// The render clock for the sim's CURRENT position — the live frame, or the
+    /// scrubbed one while parked.
+    ///
+    /// A viewer must draw the panes at this time, not at the page's wall clock:
+    /// the sim advances only when [`step`](Self::step) is called, so borrowing
+    /// wall-clock time would keep `draw(model, tts)` animations moving while the
+    /// simulation stands still, and would not rewind when a
+    /// [`seek`](Self::seek) does.
+    pub fn display_time(&self) -> FrameTime {
+        let frame = self
+            .scrub_pos
+            .unwrap_or_else(|| self.frame.saturating_sub(1));
+        FrameTime {
+            tts: frame as f32 * self.dt,
+            dts: self.dt,
+        }
+    }
+
     /// The frame (camera + scene) an instance would render at this time — for a
     /// visualizer that draws each instance's view (see `functor-netsim-viz`).
     /// Takes `&mut self`: a producer evaluates its `draw` (and caches) here.

--- a/runtime/functor-runtime-web/index-functor-lang.html
+++ b/runtime/functor-runtime-web/index-functor-lang.html
@@ -57,7 +57,14 @@
          Tokens are the public --scrub-* family (design §8), extended with
          the player colours, so the spike reads as the same instrument.
          ================================================================== */
-      #chrono {
+      /* On :root, NOT on #chrono. The player colours are consumed by BOTH the
+         chrono bar (combs, chips) and the pane chrome, and #panes is a SIBLING
+         of #chrono — so scoping them to #chrono left every `var(--pc)` in the
+         pane chrome resolving to nothing: invalid at computed-value time. The
+         2px focused border, the digit badges, the role labels and the lag tags
+         all silently rendered as no colour at all, which is precisely the
+         "legible in a screenshot at thumbnail size" claim the design makes. */
+      :root {
         --scrub-bg: rgba(30, 24, 51, 0.94);
         --scrub-line: #2b2542;
         --scrub-text: #e9e6f2;
@@ -71,7 +78,12 @@
         --scrub-p1: #41d8e6;
         --scrub-p2: #e858b8;
         --scrub-p3: #f5a524;
-        --scrub-gauge-w: 144px;
+      }
+      #chrono {
+        /* Above #webview (z-index 5), which is `position: fixed; inset: 0` and
+           now spans this bar's grid row — a game's webview UI would otherwise
+           paint straight over the instrument. */
+        position: relative; z-index: 10;
         display: none;
         flex-direction: column; gap: 6px;
         padding: 8px 12px 9px;
@@ -114,11 +126,15 @@
       /* The link row is the second half of ONE instrument: dial impairment
          here, then scrub the rail to watch what that impairment did. Appears
          only when panes > 1. */
+      /* The CONTAINER stacks; each client's row is a flex line inside it. These
+         were both `.linkrow` at first, which laid the client groups out
+         horizontally — fine at two clients, overflowing at three. */
+      #chrono #c-links { display: flex; flex-direction: column; gap: 4px; }
       #chrono .linkrow {
         display: flex; align-items: center; gap: 8px;
         font-size: 11px; color: var(--scrub-dim);
       }
-      #chrono .linkrow .who { font-weight: 600; min-width: 34px; }
+      #chrono .linkrow .who { font-weight: 600; min-width: 58px; }
       #chrono .presets { display: flex; gap: 2px; }
       #chrono .presets button {
         padding: 3px 7px; font-size: 10px; border-radius: 3px;
@@ -187,7 +203,7 @@
         pointer-events: auto;
       }
       @media (prefers-reduced-motion: reduce) {
-        #panes .pane, #panes .pane.focused { transition: none; }
+        #panes .dot { animation: none; }
       }
     </style>
   </head>
@@ -605,13 +621,24 @@
         const mouselook = document.getElementById("mouselook");
 
         const FRAME_MS = 1000 / 60;
-        // The PINNED LAG GAUGE. A 132ms link at 60fps is ~8 frames; on a rail
-        // showing 8000 recorded frames across 900px that is 0.9 PIXELS — the
-        // single most valuable signal in the UI would be sub-pixel exactly when
-        // the user dialled latency up to look at it. So combs never live at
-        // rail scale: they live in a fixed-scale zone anchored to the playhead,
-        // ~4px per frame over ~36 frames (~600ms), with a seam and a `-36f`
-        // tick where the scales change.
+        // The PINNED LAG GAUGE. A 132ms link at 60fps is ~8 frames, and at rail
+        // scale that is a handful of pixels that keeps SHRINKING as the
+        // recording grows — the most valuable signal in the UI gets least
+        // legible exactly as a session gets interesting. So combs live in a
+        // fixed-scale zone anchored to the playhead: ~4px per frame over ~36
+        // frames (~600ms), with a seam and a `-36f` tick where the scales
+        // change, plus fine-grained seek inside it.
+        //
+        // Worth correcting against the design doc, which motivates this with
+        // "8 frames is 0.9 pixels on a rail showing 8000 recorded frames": a
+        // session cannot reach 8000 frames. `NetSim` records through
+        // `History::bounded(DEFAULT_HISTORY_FRAMES)` = 900
+        // (`functor-runtime-common/src/timetravel.rs:57`), so the rail never
+        // gets coarser than ~1px/frame and the sub-pixel case never arises. The
+        // gauge still earns its place — ~3.6x magnification at the bound, and
+        // frame-accurate seeking the rail cannot offer — but it is a magnifier,
+        // not a rescue from invisibility, which is why it now COLLAPSES while
+        // the rail is already finer than 4px/frame.
         const GAUGE_FRAMES = 36;
         const GAUGE_PX = 4;
         const GAUGE_W = GAUGE_FRAMES * GAUGE_PX;
@@ -644,6 +671,7 @@
         let dragAnchor = null; // {frame, x} captured at pointerdown
         let lastModelText = "";
         let modelDue = 0;
+        let lastRecordedFrame = -1;
 
         // ---- REAL lag measurement -----------------------------------------
         // The combs need "the server frame each client last DISPLAYED". No ack
@@ -715,10 +743,9 @@
         // frame late parked, which the wrap-aliasing above then turned into a
         // confident, completely wrong "239 frames behind". Anchoring both ends
         // of the subtraction to the same lookup makes the offset cancel.
-        const behindServer = (id, playhead) => {
-          const top = playhead + 1;
-          const ref = displayedServerFrame(0, top);
-          const mine = displayedServerFrame(id, top);
+        const referenceFrame = (playhead) => displayedServerFrame(0, playhead + 1);
+        const behindServer = (id, playhead, ref = referenceFrame(playhead)) => {
+          const mine = displayedServerFrame(id, playhead + 1);
           if (ref == null || mine == null) return null;
           return Math.max(0, ref - mine);
         };
@@ -738,7 +765,7 @@
             <span class="label" id="c-frame">#f <b>0</b></span>
             <span id="focus-chip">keys --</span>
           </div>
-          <div class="linkrow" id="c-links"></div>`;
+          <div id="c-links"></div>`;
         const rail = chrono.querySelector("#rail");
         const frameLabel = chrono.querySelector("#c-frame b");
         const focusChip = chrono.querySelector("#focus-chip");
@@ -890,9 +917,25 @@
           const span = Math.max(1, hi - lo);
           const xOf = (f) => ((Math.min(hi, Math.max(lo, f)) - lo) / span) * w;
           const xp = xOf(playhead);
+          // The gauge is a MAGNIFIER, so it only earns its place while the rail
+          // is coarser than it is. Early in a session (a few hundred recorded
+          // frames across ~1000px) the rail is already finer than 4px/frame, and
+          // a fixed-scale zone there was a DE-magnifier: a comb 20f behind drew
+          // at xp-80 while frame playhead-20 actually sat at xp-100 on the very
+          // track it was superimposed on — the comb pointed at the wrong place,
+          // and `frameAtX` inherited the same error, so a click in the gauge
+          // sought a different frame than the rail said. Below the crossover the
+          // gauge collapses and everything runs at rail scale.
+          const railPxPerFrame = w / span;
+          const magnifies = railPxPerFrame < GAUGE_PX;
+          const pxPerFrame = magnifies ? GAUGE_PX : railPxPerFrame;
           const gaugeRight = xp;
-          const gaugeLeft = Math.max(0, xp - GAUGE_W);
-          return { w, lo, hi, playhead, span, xOf, xp, gaugeLeft, gaugeRight, parked: t.scrubPos != null };
+          const gaugeLeft = magnifies ? Math.max(0, xp - GAUGE_W) : xp;
+          return {
+            w, lo, hi, playhead, span, xOf, xp,
+            gaugeLeft, gaugeRight, magnifies, pxPerFrame,
+            parked: t.scrubPos != null,
+          };
         };
         const drawRail = () => {
           const g = railGeom();
@@ -911,20 +954,22 @@
           // rail; parked, it follows the playhead back — which is the whole
           // point, because a parked comb shows that client's RECORDED frame for
           // that moment, and the stagger that survives is real lag preserved.
-          kids.push(svg("rect", {
-            x: g.gaugeLeft, y: 2, width: Math.max(0, g.gaugeRight - g.gaugeLeft), height: H - 4,
-            fill: "rgba(255,255,255,0.05)", stroke: "var(--scrub-line)", "stroke-width": 1,
-          }));
-          kids.push(svg("line", {
-            x1: g.gaugeLeft, y1: 2, x2: g.gaugeLeft, y2: H - 2,
-            stroke: "var(--scrub-dim)", "stroke-width": 1, "stroke-dasharray": "2 2",
-          }));
-          const seam = svg("text", {
-            x: g.gaugeLeft + 3, y: H - 4, fill: "var(--scrub-dim)", "font-size": 8,
-            "font-family": "var(--scrub-font)",
-          });
-          seam.textContent = `−${GAUGE_FRAMES}f`;
-          kids.push(seam);
+          if (g.magnifies) {
+            kids.push(svg("rect", {
+              x: g.gaugeLeft, y: 2, width: Math.max(0, g.gaugeRight - g.gaugeLeft), height: H - 4,
+              fill: "rgba(255,255,255,0.05)", stroke: "var(--scrub-line)", "stroke-width": 1,
+            }));
+            kids.push(svg("line", {
+              x1: g.gaugeLeft, y1: 2, x2: g.gaugeLeft, y2: H - 2,
+              stroke: "var(--scrub-dim)", "stroke-width": 1, "stroke-dasharray": "2 2",
+            }));
+            const seam = svg("text", {
+              x: g.gaugeLeft + 3, y: H - 4, fill: "var(--scrub-dim)", "font-size": 8,
+              "font-family": "var(--scrub-font)",
+            });
+            seam.textContent = `−${GAUGE_FRAMES}f`;
+            kids.push(seam);
+          }
           // The playhead.
           kids.push(svg("line", {
             x1: g.xp, y1: 2, x2: g.xp, y2: H - 2,
@@ -932,19 +977,31 @@
           }));
           // Lag combs: one tick per client, in that client's player colour, at
           // the server frame it last actually displayed. Only inside the gauge.
+          // One `ref` lookup for the whole rail, not one per client: each is an
+          // O(recorded frames) scan preceded by a full model pretty-print over
+          // the wasm boundary, and every client resolved the SAME reference.
+          const ref = referenceFrame(g.playhead);
           panes.forEach((p, i) => {
             if (p.role === "server") return;
-            const behind = behindServer(i, g.playhead);
+            const behind = behindServer(i, g.playhead, ref);
             if (behind == null) return;
-            const over = behind > GAUGE_FRAMES;
-            const x = over ? g.gaugeLeft + 2 : g.gaugeRight - behind * GAUGE_PX;
+            const over = g.magnifies && behind > GAUGE_FRAMES;
+            const x = over
+              ? g.gaugeLeft + 2
+              : Math.max(0, g.gaugeRight - behind * g.pxPerFrame);
             kids.push(svg("line", {
               class: "comb", "data-pane": i, "data-behind": behind,
               x1: x, y1: 16, x2: x, y2: H - 6,
               stroke: colorFor(i), "stroke-width": 3,
             }));
+            // Clamped into the viewBox: a zero-lag comb sits at x = w, where a
+            // middle-anchored label is half sheared off by the SVG edge — and
+            // "the LAN client sits on the playhead" is the baseline every other
+            // comb is read against, so it must be the clearest mark, not the
+            // least legible one.
             const lbl = svg("text", {
-              x: x, y: 10, fill: colorFor(i), "font-size": 10, "font-weight": 700,
+              x: Math.min(g.w - 6, Math.max(6, x)), y: 10,
+              fill: colorFor(i), "font-size": 10, "font-weight": 700,
               "text-anchor": "middle", "font-family": "var(--scrub-font)",
             });
             lbl.textContent = over ? `»${i + 1}` : String(i + 1);
@@ -959,7 +1016,7 @@
         // cannot offer. The gauge anchor is captured at pointerdown, otherwise
         // moving the playhead would move the gauge under the cursor.
         const frameAtX = (x, anchor) => {
-          if (x >= anchor.gaugeLeft) {
+          if (anchor.magnifies && x >= anchor.gaugeLeft) {
             const behind = Math.round((anchor.gaugeRight - x) / GAUGE_PX);
             return Math.max(anchor.lo, Math.min(anchor.hi, anchor.playhead - behind));
           }
@@ -1007,6 +1064,21 @@
           "keydown",
           (e) => {
             if (!panes.length) return;
+            // `,` and `.` are bare step keys by design — which means they are
+            // also ordinary characters. This listener is on `window` in the
+            // CAPTURE phase and calls `stopImmediatePropagation`, so without
+            // this guard typing a decimal point into a game's webview text
+            // field would silently step the simulation AND swallow the
+            // keystroke before the field ever saw it.
+            const target = e.composedPath()[0];
+            if (
+              target instanceof HTMLElement &&
+              (target.isContentEditable ||
+                target.tagName === "INPUT" ||
+                target.tagName === "TEXTAREA")
+            ) {
+              return;
+            }
             if (e.code === "Space" && (e.ctrlKey || e.metaKey)) {
               setPaused(!paused);
             } else if (e.key === "." || e.key === ",") {
@@ -1022,7 +1094,10 @@
                 // A deliberate hands-off state: nothing owns the keyboard.
                 stageOwnsKeys = false;
               } else if (e.key === "f") {
-                console.warn("[chrono] SPIKE: f-maximize is not implemented");
+                // f-maximize is out of scope for the spike (it needs the GL pane
+                // split to change, not just the chrome). Inert, and deliberately
+                // silent: a `[chrono] …` console line is what the harness treats
+                // as a failure signal.
                 return;
               } else {
                 return;
@@ -1064,10 +1139,16 @@
             paneSig = sig;
             panes = live;
             if (fresh) {
-              focused = panes.length ? panes.findIndex((p) => p.role !== "server") : -1;
-              if (focused < 0) focused = panes.length ? 0 : -1;
               linkChoice = panes.map(() => 0);
               serverSig.clear();
+            }
+            // Re-pick the default owner on every ROLE change, not only when the
+            // pane count changes. On the first frame nobody has connected yet so
+            // every instance reads "client" and `findIndex` returned 0 — the
+            // server, the one instance that by definition takes no input.
+            if (focused < 0 || !panes[focused] || panes[focused].role === "server") {
+              const firstClient = panes.findIndex((p) => p.role !== "server");
+              focused = firstClient >= 0 ? firstClient : panes.length ? 0 : -1;
             }
             if (panes.length) {
               buildPanes();
@@ -1115,6 +1196,9 @@
               try {
                 window.__sim.step(1);
                 recordServerSig();
+                // (also recorded below, driver-agnostically; this keeps every
+                // frame of a multi-frame catch-up in the ring rather than only
+                // the last one.)
               } catch (e) {
                 console.error("[chrono] step:", e);
                 setPaused(true);
@@ -1125,8 +1209,22 @@
 
           // ---- paint ----
           const t = window.__sim.timeline();
+          // Record the comb ring from the OBSERVED frame, not from the act of
+          // stepping. The bar mounts paused precisely so another driver can own
+          // the session (e2e/wasm-sim.mjs steps by hand) — and in that
+          // configuration recording only inside the bar's own step loop left the
+          // ring empty, so every comb read "no data", which is visually
+          // indistinguishable from "no lag".
+          if (t.scrubPos == null && t.frame !== lastRecordedFrame) {
+            lastRecordedFrame = t.frame;
+            recordServerSig();
+          }
           const playhead = t.scrubPos ?? t.frame;
-          frameLabel.textContent = String(playhead);
+          // One convention in both states. `t.frame` is the count of steps taken
+          // — one PAST the newest recorded frame, and a frame `seek` clamps away
+          // — so printing it live and `scrubPos` parked made the counter drop by
+          // one the instant you parked, with nothing having moved.
+          frameLabel.textContent = String(t.scrubPos ?? Math.max(0, t.frame - 1));
           chrono.querySelector("#mode-chip").textContent = t.scrubPos != null ? "SIM · PARKED" : "SIM";
           drawRail();
 

--- a/runtime/functor-runtime-web/index-functor-lang.html
+++ b/runtime/functor-runtime-web/index-functor-lang.html
@@ -8,7 +8,15 @@
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type" />
     <style>
       html, body { margin: 0; height: 100%; overflow: hidden; }
-      /* Fill the window; the runtime sizes the drawable buffer (and GL
+      /* SPIKE (multiplayer dev session): the page is a three-row shell —
+         header | chrono bar | stage — per the frontend design. There is no
+         header on the dev-server page, so it is two rows here. The chrono bar
+         is a LAYOUT ROW, not an overlay: it reserves its own height instead of
+         eating the top of the canvas. Its row collapses to 0 when no dev
+         session is running, so single-game behaviour is unchanged. */
+      body { display: grid; grid-template-rows: auto 1fr; }
+      #stage { position: relative; min-height: 0; }
+      /* Fill the stage; the runtime sizes the drawable buffer (and GL
          viewport) to match this displayed size each frame, scaled for HiDPI. */
       #canvas { display: block; width: 100%; height: 100%; }
       /* Explicit mouse-look toggle. The cursor stays FREE by default so the
@@ -35,11 +43,161 @@
          isolated document on native. The interior pointer-events rules live
          inside the shadow root (page CSS can't cross the boundary). */
       #webview { position: fixed; inset: 0; z-index: 5; pointer-events: none; overflow: hidden; }
+
+      /* ==================================================================
+         SPIKE: the chrono bar and the pane grid.
+         ------------------------------------------------------------------
+         Inline here on purpose. The real change (design §9 P0/P1) is
+         `mountScrubber({ dock })` inside the shared scrubber.js plus a
+         `--scrub-dock` token; doing that properly means inverting four
+         upward-opening surfaces and updating the site e2e's #scrubber
+         lookups. This spike is a SEPARATE bar so the shipped scrubber is
+         untouched and single-game views behave exactly as before.
+
+         Tokens are the public --scrub-* family (design §8), extended with
+         the player colours, so the spike reads as the same instrument.
+         ================================================================== */
+      #chrono {
+        --scrub-bg: rgba(30, 24, 51, 0.94);
+        --scrub-line: #2b2542;
+        --scrub-text: #e9e6f2;
+        --scrub-dim: #9b94b3;
+        --scrub-accent: #41d8e6;
+        --scrub-future: #4a4166;
+        --scrub-drop: #ff5470;
+        --scrub-font: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        /* Player colours: p1 = cyan (the server/authority), p2 = pink,
+           p3 = amber. One identity across pane border, comb, and label. */
+        --scrub-p1: #41d8e6;
+        --scrub-p2: #e858b8;
+        --scrub-p3: #f5a524;
+        --scrub-gauge-w: 144px;
+        display: none;
+        flex-direction: column; gap: 6px;
+        padding: 8px 12px 9px;
+        background: var(--scrub-bg);
+        color: var(--scrub-text);
+        font: 12px/1.3 var(--scrub-font);
+        /* Docked TOP, so the shadow and the hairline fall DOWNWARD — the
+           inverse of the bottom-docked scrubber (design §7.2). */
+        border-bottom: 1px solid var(--scrub-line);
+        box-shadow: 0 3px 16px rgba(0, 0, 0, 0.45);
+        user-select: none;
+      }
+      #chrono.on { display: flex; }
+      #chrono .row { display: flex; align-items: center; gap: 10px; }
+      #chrono button {
+        font: 12px/1 var(--scrub-font); padding: 5px 8px; cursor: pointer;
+        color: var(--scrub-text); background: rgba(255, 255, 255, 0.06);
+        border: 1px solid var(--scrub-line); border-radius: 5px;
+      }
+      #chrono button:hover { background: rgba(255, 255, 255, 0.13); }
+      /* The SIM/LIVE chip: the scrub GUARANTEE differs between substrates
+         (exact whole-environment seek vs ±2-3 frames clock-synced), and
+         hiding that burns trust (design §1). */
+      #chrono .chip {
+        font-size: 10px; letter-spacing: 0.14em; padding: 4px 7px;
+        border-radius: 4px; border: 1px solid var(--scrub-accent);
+        color: var(--scrub-accent); background: rgba(65, 216, 230, 0.1);
+      }
+      #chrono .label { color: var(--scrub-dim); font-variant-numeric: tabular-nums; }
+      #chrono .label b { color: var(--scrub-text); font-weight: 600; }
+      /* The keyboard's owner is global state, so it lives on the global bar,
+         mirrored by loud chrome on the pane itself. HOLLOW when the stage does
+         not own DOM focus — "will my keys go to the game?" at a glance. */
+      #chrono #focus-chip {
+        font-size: 11px; padding: 4px 8px; border-radius: 4px;
+        border: 1px solid currentColor;
+      }
+      #chrono #focus-chip.owned { background: color-mix(in srgb, currentColor 18%, transparent); }
+      #chrono #rail { flex: 1; min-width: 120px; height: 34px; display: block; cursor: pointer; }
+      /* The link row is the second half of ONE instrument: dial impairment
+         here, then scrub the rail to watch what that impairment did. Appears
+         only when panes > 1. */
+      #chrono .linkrow {
+        display: flex; align-items: center; gap: 8px;
+        font-size: 11px; color: var(--scrub-dim);
+      }
+      #chrono .linkrow .who { font-weight: 600; min-width: 34px; }
+      #chrono .presets { display: flex; gap: 2px; }
+      #chrono .presets button {
+        padding: 3px 7px; font-size: 10px; border-radius: 3px;
+        color: var(--scrub-dim);
+      }
+      /* `background: currentColor` cannot work here — the selected state also
+         sets `color`, so the fill would be the dark text colour on dark. The
+         player colour has to come in as its own variable. */
+      #chrono .presets button.sel {
+        color: #17131f; background: var(--pcolor); border-color: var(--pcolor);
+        font-weight: 700;
+      }
+      #chrono .readout { font-variant-numeric: tabular-nums; }
+
+      /* Pane chrome: a DOM overlay aligned to the GL pane columns. The bodies
+         are GL (one viewport of the shared context per instance), so this
+         layer is chrome only and must not eat pointer events except where it
+         is a control. */
+      #panes {
+        position: absolute; inset: 0; z-index: 6; display: none;
+        pointer-events: none;
+        font: 11px/1.4 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      }
+      #panes.on { display: block; }
+      #panes .pane {
+        position: absolute; box-sizing: border-box;
+        border: 1px solid color-mix(in srgb, var(--pc) 35%, transparent);
+        pointer-events: auto; cursor: pointer;
+      }
+      /* Loud chrome on the keyboard's owner: 2px at FULL player-colour
+         saturation plus a soft outer glow. The test is that the difference is
+         legible in a screenshot at thumbnail size (design §4). */
+      #panes .pane.focused {
+        border: 2px solid var(--pc);
+        box-shadow: 0 0 0 1px color-mix(in srgb, var(--pc) 45%, transparent),
+                    0 0 18px color-mix(in srgb, var(--pc) 40%, transparent) inset;
+      }
+      #panes .head {
+        display: flex; align-items: center; gap: 7px;
+        padding: 4px 8px;
+        background: rgba(23, 19, 31, 0.86);
+        border-bottom: 1px solid color-mix(in srgb, var(--pc) 30%, transparent);
+        color: #9b94b3;
+      }
+      #panes .pane.focused .head { color: #e9e6f2; }
+      /* Accessibility: colour is never the only channel — the digit is the
+         fallback that actually works (design §8). */
+      #panes .digit {
+        display: inline-block; min-width: 14px; text-align: center;
+        border-radius: 3px; padding: 0 3px;
+        color: #17131f; background: var(--pc); font-weight: 700;
+      }
+      #panes .role { color: var(--pc); letter-spacing: 0.1em; font-size: 9px; text-transform: uppercase; }
+      #panes .head .sp { margin-left: auto; }
+      #panes .you { color: var(--pc); font-weight: 700; }
+      #panes .lagtag { color: var(--pc); font-variant-numeric: tabular-nums; }
+      /* The server's model: `functorLangSimState(id)`'s pretty-printed TEXT in
+         a <pre>. Explicitly not parsed and not a tree view — the wasm export
+         documents that callers must not parse it (design §5.2). */
+      #panes .model {
+        margin: 6px 8px; padding: 6px 7px; max-height: 45%; overflow: auto;
+        white-space: pre-wrap; word-break: break-all;
+        font-size: 9.5px; line-height: 1.35;
+        color: #cfc9de; background: rgba(23, 19, 31, 0.8);
+        border: 1px solid #2b2542; border-radius: 4px;
+        pointer-events: auto;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        #panes .pane, #panes .pane.focused { transition: none; }
+      }
     </style>
   </head>
   <body>
-    <canvas id="canvas"></canvas>
-    <div id="webview"></div>
+    <div id="chrono"></div>
+    <div id="stage">
+      <canvas id="canvas"></canvas>
+      <div id="webview"></div>
+      <div id="panes"></div>
+    </div>
     <button id="mouselook" title="Control the camera with the mouse; Esc to release">🖱 mouse look</button>
     <script type="module">
 
@@ -66,6 +224,8 @@
         functorLangSimTimeline,
         functorLangSimSeek,
         functorLangSimLen,
+        functorLangSimSetLink,
+        functorLangSimPanes,
         functorLangStopSim,
       } from "./pkg/functor_runtime_web.js";
       // The time-travel scrubber is the shared component, served next to pkg/
@@ -382,8 +542,633 @@
           timeline: () => functorLangSimTimeline(),
           seek: (frame) => functorLangSimSeek(frame),
           len: () => functorLangSimLen(),
+          // Impair a link so the panes visibly disagree: {latencyTicks,
+          // jitterTicks, loss, reorder}, all optional. Per UNORDERED PAIR and
+          // shared by both directions — asymmetric lag is not expressible.
+          setLink: (a, b, opts = {}) =>
+            functorLangSimSetLink(
+              a,
+              b,
+              opts.latencyTicks ?? 1,
+              opts.jitterTicks ?? 0,
+              opts.loss ?? 0,
+              opts.reorder ?? false,
+            ),
+          panes: () => functorLangSimPanes(),
           stop: () => functorLangStopSim(),
         };
+      };
+
+      // ====================================================================
+      // SPIKE — the chrono bar.
+      //
+      // A tangible pass at ~/notes/projects/functor/design-multiplayer-ide-
+      // frontend.md: a full-width instrument docked at the TOP of the
+      // workspace, above everything it governs. It owns the session clock, the
+      // impairment of the links, and the identity of who has the keyboard.
+      // Panes below are its subjects.
+      //
+      // The mental model it exists to protect: THE RAIL IS SERVER TIME. Never
+      // client time, never wall time. Clients are drawn ON the rail as combs,
+      // at whatever frame each of them last actually displayed.
+      //
+      // WHAT IS FAKED, and why (kept in one list so nobody mistakes this for
+      // the shipped thing):
+      //
+      //  1. No Park/Parked/Resume+epoch protocol. This drives `NetSim::seek`
+      //     (#472) straight from the page, which is the plan's in-page fast
+      //     path with the protocol boundary omitted (plan PRs 12-13).
+      //  2. Keyboard focus routes NOTHING. `functorLangSimInput` does not
+      //     exist yet (plan PR 5) — while a session runs, input is
+      //     drained-and-discarded. The focus chrome, the digit/[/]/Esc
+      //     bindings and the ⌨ chip are real UI over a real focus MODEL; the
+      //     keys just have nowhere to go. This is the #1 product risk and the
+      //     spike does not hide it.
+      //  3. No wire log. `Packet` is private and drops are silent
+      //     early-returns, so there is no route-event stream to show (plan
+      //     PR 7). Faking one would have been the least honest thing here, so
+      //     the server pane shows its real model text instead.
+      //  4. The server is an equal third, not a 300px strip; `f`-maximize and
+      //     the comb→pane hairline connectors are not implemented.
+      //  5. The rAF step driver is JS, not the Rust session clock (plan PR 4).
+      //
+      // WHAT IS REAL: the panes (one GL viewport per wasm sim instance), the
+      // seek (whole-environment, exact, non-destructive while parked), the
+      // impairment (real `LinkProfile` on the real `VirtualNet`), and — the
+      // one that matters most — THE LAG COMBS ARE MEASURED, not modelled. See
+      // `displayedServerFrame` below.
+      // ====================================================================
+      const installChronoBar = () => {
+        const chrono = document.getElementById("chrono");
+        const panesEl = document.getElementById("panes");
+        const canvas = document.getElementById("canvas");
+        const mouselook = document.getElementById("mouselook");
+
+        const FRAME_MS = 1000 / 60;
+        // The PINNED LAG GAUGE. A 132ms link at 60fps is ~8 frames; on a rail
+        // showing 8000 recorded frames across 900px that is 0.9 PIXELS — the
+        // single most valuable signal in the UI would be sub-pixel exactly when
+        // the user dialled latency up to look at it. So combs never live at
+        // rail scale: they live in a fixed-scale zone anchored to the playhead,
+        // ~4px per frame over ~36 frames (~600ms), with a seam and a `-36f`
+        // tick where the scales change.
+        const GAUGE_FRAMES = 36;
+        const GAUGE_PX = 4;
+        const GAUGE_W = GAUGE_FRAMES * GAUGE_PX;
+        const PLAYER = ["var(--scrub-p1)", "var(--scrub-p2)", "var(--scrub-p3)"];
+        const colorFor = (i) => PLAYER[i % PLAYER.length];
+
+        // Presets write REAL LinkProfile fields. ms at the JS edge, ticks in
+        // the sim: `LinkProfile` is the sim's native unit and virtual_net.rs's
+        // tests pin it. Latency is ONE-WAY (a packet waits this long before it
+        // can be delivered), so the round trip is twice this.
+        const PRESETS = [
+          ["LAN", { ms: 17, jitterMs: 0, loss: 0 }],
+          ["Wi-Fi", { ms: 45, jitterMs: 12, loss: 0.002 }],
+          ["mobile", { ms: 132, jitterMs: 40, loss: 0.012 }],
+          ["awful", { ms: 350, jitterMs: 120, loss: 0.06 }],
+        ];
+        const toTicks = (ms) => Math.max(1, Math.round(ms / FRAME_MS));
+
+        // ---- session state owned by the bar --------------------------------
+        // Starts PAUSED, deliberately. `e2e/wasm-sim.mjs` is a CI gate that
+        // starts a session and steps it by hand, asserting exact states; a bar
+        // that auto-stepped on mount would race it. Paused, the bar only READS
+        // the sim, so an existing harness is unaffected and a human presses play.
+        let paused = true;
+        let panes = [];
+        let paneSig = ""; // count + roles; the chrome is rebuilt when it changes
+        let focused = -1; // pane index owning the keyboard
+        let stageOwnsKeys = false;
+        let linkChoice = []; // preset index per pane
+        let dragAnchor = null; // {frame, x} captured at pointerdown
+        let lastModelText = "";
+        let modelDue = 0;
+
+        // ---- REAL lag measurement -----------------------------------------
+        // The combs need "the server frame each client last DISPLAYED". No ack
+        // protocol exists, so instead of modelling it from the configured
+        // latency (which would make the gauge a picture of its own input) we
+        // MEASURE it: the server's broadcast snapshot is the authoritative
+        // player positions for that frame, and a client draws exactly the last
+        // snapshot it received. So record a signature of the server's positions
+        // per frame, and find the newest server frame whose signature matches
+        // what the client is showing right now. That frame IS the comb.
+        //
+        // The signature reads the model's pretty-printed text, which the wasm
+        // export documents as unparseable free-form. That is a real cheat and
+        // it is why this is a spike: the honest version is plan PR 7's route
+        // events plus PR 12's `Parked { frame, residual_ms }` acks.
+        const serverSig = new Map();
+        const sigOf = (text) => {
+          // Positional fields only: `x:`/`z:` but never `vx:`/`vz:`/`pid:`.
+          const re = /(?<![A-Za-z0-9_])([xz])\s*:\s*(-?\d+(?:\.\d+)?)/g;
+          const out = [];
+          let m;
+          while ((m = re.exec(text)) !== null) {
+            out.push(m[1] + Math.round(parseFloat(m[2]) * 1000));
+          }
+          return out.join(",");
+        };
+        const recordServerSig = () => {
+          const t = window.__sim.timeline();
+          serverSig.set(t.frame, sigOf(window.__sim.state(0)));
+          // Prune to the SEEKABLE floor (`lo`), not a fixed recent window. A
+          // 400-frame window silently dropped the sigs for frames a seek can
+          // still reach, so the combs vanished the moment you scrubbed further
+          // back than that — losing exactly the thing the design calls the most
+          // valuable in the UI: the stagger PRESERVED while parked.
+          if (t.frame % 64 === 0) {
+            for (const f of serverSig.keys()) {
+              if (f < (t.lo ?? 0)) serverSig.delete(f);
+            }
+          }
+        };
+        // The newest recorded server frame whose positions match what instance
+        // `id` is showing. Searched newest-first from `top`.
+        //
+        // ALIASING is the real limitation of the signature trick: the arena
+        // wraps, so a client's exact positions recur every ~240 frames. Because
+        // the search is newest-first, a lag of L < one lap always finds the
+        // right frame first — but a lag beyond a lap would alias onto the
+        // previous one. The honest fix is protocol acks (plan PR 12).
+        const displayedServerFrame = (id, top) => {
+          let sig;
+          try {
+            sig = sigOf(window.__sim.state(id));
+          } catch {
+            return null;
+          }
+          const floor = Math.max(0, window.__sim.timeline().lo ?? 0);
+          for (let f = top; f >= floor; f--) {
+            if (serverSig.get(f) === sig) return f;
+          }
+          return null;
+        };
+        // How many frames instance `id` trails the SERVER by, measured against
+        // the server's own comb rather than against the playhead.
+        //
+        // This is deliberately self-calibrating. The ring is keyed by
+        // `timeline().frame` (steps taken) while the playhead when parked is
+        // `scrubPos`, and the two conventions are offset by one — so measuring
+        // each client against the playhead read one frame early live and one
+        // frame late parked, which the wrap-aliasing above then turned into a
+        // confident, completely wrong "239 frames behind". Anchoring both ends
+        // of the subtraction to the same lookup makes the offset cancel.
+        const behindServer = (id, playhead) => {
+          const top = playhead + 1;
+          const ref = displayedServerFrame(0, top);
+          const mine = displayedServerFrame(id, top);
+          if (ref == null || mine == null) return null;
+          return Math.max(0, ref - mine);
+        };
+
+        // A debug seam for the spike harness: the comb measurement is the one
+        // part of this bar with a real chance of quietly reading zero, so it is
+        // inspectable rather than only visible.
+        window.__chrono = { serverSig, sigOf, displayedServerFrame, behindServer };
+
+        // ---- the instrument's DOM (built once) -----------------------------
+        chrono.innerHTML = `
+          <div class="row">
+            <span class="chip" id="mode-chip" title="Exact whole-environment seek: every instance AND the packets in flight between them are restored.">SIM</span>
+            <button id="c-pause" title="Ctrl+Space">&#9208;</button>
+            <button id="c-step" title="., one frame">&#9197;</button>
+            <svg id="rail" role="slider" aria-label="server time"></svg>
+            <span class="label" id="c-frame">#f <b>0</b></span>
+            <span id="focus-chip">keys --</span>
+          </div>
+          <div class="linkrow" id="c-links"></div>`;
+        const rail = chrono.querySelector("#rail");
+        const frameLabel = chrono.querySelector("#c-frame b");
+        const focusChip = chrono.querySelector("#focus-chip");
+        const linksEl = chrono.querySelector("#c-links");
+        const pauseBtn = chrono.querySelector("#c-pause");
+
+        const setPaused = (v) => {
+          paused = v;
+          pauseBtn.innerHTML = paused ? "&#9205;" : "&#9208;";
+          pauseBtn.title = paused ? "resume (Ctrl+Space)" : "pause (Ctrl+Space)";
+        };
+        // Clicking the bar takes DOM focus away from the stage, so the pane
+        // digit shortcuts go inert and the chip goes hollow.
+        chrono.addEventListener("pointerdown", () => {
+          stageOwnsKeys = false;
+        });
+        pauseBtn.addEventListener("click", () => setPaused(!paused));
+        chrono.querySelector("#c-step").addEventListener("click", () => stepOne());
+
+        // ---- pane chrome ---------------------------------------------------
+        // Rebuilt only when the pane COUNT changes; per-frame updates are text.
+        let paneNodes = [];
+        const buildPanes = () => {
+          panesEl.replaceChildren();
+          paneNodes = panes.map((p, i) => {
+            const el = document.createElement("div");
+            el.className = "pane";
+            el.style.setProperty("--pc", colorFor(i));
+            el.innerHTML = `
+              <div class="head">
+                <span class="digit">${i + 1}</span>
+                <span class="role">${p.role}</span>
+                <span>${p.entry}</span>
+                <span class="sp"></span>
+                <span class="lagtag"></span>
+                <span class="you"></span>
+              </div>
+              <pre class="model"${p.role === "server" ? "" : ' hidden'}></pre>`;
+            // Click to focus. On the shipped thing the click ALSO passes
+            // through to the game (no click-to-activate tax); here there is no
+            // input path, so it only focuses.
+            el.addEventListener("pointerdown", () => {
+              focused = i;
+              stageOwnsKeys = true;
+            });
+            panesEl.append(el);
+            return el;
+          });
+        };
+
+        // Mirror the Rust pane split EXACTLY, in framebuffer px, and convert to
+        // CSS px only at the end. Dividing CSS px with the same `gap = 2` (as
+        // the parked branch's e2e did) is off by the device pixel ratio, so the
+        // chrome drifts off its pane on a HiDPI display.
+        const paneRects = (n) => {
+          const dpr = window.devicePixelRatio || 1;
+          const fbW = canvas.width;
+          const fbH = canvas.height;
+          const gap = 2;
+          const contentW = Math.max(n, fbW - gap * (n - 1));
+          const paneW = Math.max(1, Math.floor(contentW / n));
+          const out = [];
+          for (let i = 0; i < n; i++) {
+            const x = i * (paneW + gap);
+            const w = i === n - 1 ? Math.max(1, fbW - x) : paneW;
+            out.push({ left: x / dpr, width: w / dpr, height: fbH / dpr });
+          }
+          return out;
+        };
+
+        // ---- the link row --------------------------------------------------
+        const applyLink = (id) => {
+          const [, p] = PRESETS[linkChoice[id]];
+          window.__sim.setLink(0, id, {
+            latencyTicks: toTicks(p.ms),
+            jitterTicks: p.jitterMs ? toTicks(p.jitterMs) : 0,
+            loss: p.loss,
+          });
+        };
+        const buildLinks = () => {
+          linksEl.replaceChildren();
+          panes.forEach((p, i) => {
+            if (p.role === "server") return;
+            const wrap = document.createElement("div");
+            wrap.className = "linkrow";
+            wrap.style.color = colorFor(i);
+            wrap.style.setProperty("--pcolor", colorFor(i));
+            const group = document.createElement("span");
+            group.className = "presets";
+            PRESETS.forEach(([name], pi) => {
+              const b = document.createElement("button");
+              b.textContent = name;
+              b.dataset.pi = String(pi);
+              b.addEventListener("click", () => {
+                linkChoice[i] = pi;
+                applyLink(i);
+                syncLinkRow();
+              });
+              group.append(b);
+            });
+            const readout = document.createElement("span");
+            readout.className = "readout";
+            wrap.append(
+              Object.assign(document.createElement("span"), {
+                className: "who",
+                textContent: `client ${i + 1}`,
+              }),
+              group,
+              readout,
+            );
+            wrap.dataset.pane = String(i);
+            linksEl.append(wrap);
+          });
+          syncLinkRow();
+        };
+        const syncLinkRow = () => {
+          for (const wrap of linksEl.querySelectorAll("[data-pane]")) {
+            const i = Number(wrap.dataset.pane);
+            const sel = linkChoice[i];
+            for (const b of wrap.querySelectorAll("button")) {
+              b.classList.toggle("sel", Number(b.dataset.pi) === sel);
+            }
+            const [, p] = PRESETS[sel];
+            // Report what the sim will ACTUALLY do: ms quantise to whole ticks.
+            const ms = Math.round(toTicks(p.ms) * FRAME_MS);
+            const jm = p.jitterMs ? Math.round(toTicks(p.jitterMs) * FRAME_MS) : 0;
+            wrap.querySelector(".readout").textContent =
+              `${ms}ms ±${jm} jitter, ${(p.loss * 100).toFixed(1)}% loss`;
+          }
+        };
+
+        // ---- the rail ------------------------------------------------------
+        const svgNs = "http://www.w3.org/2000/svg";
+        const svg = (tag, attrs) => {
+          const n = document.createElementNS(svgNs, tag);
+          for (const [k, v] of Object.entries(attrs)) n.setAttribute(k, String(v));
+          return n;
+        };
+        const railGeom = () => {
+          const w = Math.max(1, rail.clientWidth);
+          const t = window.__sim.timeline();
+          const lo = t.lo ?? 0;
+          // The playhead is the LIVE frame, not the last RECORDED one. `hi`
+          // trails `frame` by one, and the comb ring is keyed by `frame`, so
+          // taking `hi` here made every comb lookup miss by exactly one frame
+          // and read as "no data" — combs silently absent at every preset.
+          const playhead = t.scrubPos ?? t.frame;
+          const hi = Math.max(t.hi ?? 0, playhead);
+          const span = Math.max(1, hi - lo);
+          const xOf = (f) => ((Math.min(hi, Math.max(lo, f)) - lo) / span) * w;
+          const xp = xOf(playhead);
+          const gaugeRight = xp;
+          const gaugeLeft = Math.max(0, xp - GAUGE_W);
+          return { w, lo, hi, playhead, span, xOf, xp, gaugeLeft, gaugeRight, parked: t.scrubPos != null };
+        };
+        const drawRail = () => {
+          const g = railGeom();
+          const H = 34;
+          rail.setAttribute("viewBox", `0 0 ${g.w} ${H}`);
+          rail.setAttribute("width", g.w);
+          rail.setAttribute("height", H);
+          const kids = [];
+          const trackY = 11;
+          // The recorded range, then the past-of-playhead brightened. The rail
+          // IS server time; nothing on it is a client's clock.
+          kids.push(svg("rect", { x: 0, y: trackY, width: g.w, height: 4, rx: 2, fill: "var(--scrub-future)" }));
+          kids.push(svg("rect", { x: 0, y: trackY, width: Math.max(0, g.xp), height: 4, rx: 2, fill: "var(--scrub-accent)", "fill-opacity": 0.55 }));
+          // The pinned lag gauge: a fixed-scale magnifier on the present,
+          // anchored to the playhead. Live, it is the rightmost ~150px of the
+          // rail; parked, it follows the playhead back — which is the whole
+          // point, because a parked comb shows that client's RECORDED frame for
+          // that moment, and the stagger that survives is real lag preserved.
+          kids.push(svg("rect", {
+            x: g.gaugeLeft, y: 2, width: Math.max(0, g.gaugeRight - g.gaugeLeft), height: H - 4,
+            fill: "rgba(255,255,255,0.05)", stroke: "var(--scrub-line)", "stroke-width": 1,
+          }));
+          kids.push(svg("line", {
+            x1: g.gaugeLeft, y1: 2, x2: g.gaugeLeft, y2: H - 2,
+            stroke: "var(--scrub-dim)", "stroke-width": 1, "stroke-dasharray": "2 2",
+          }));
+          const seam = svg("text", {
+            x: g.gaugeLeft + 3, y: H - 4, fill: "var(--scrub-dim)", "font-size": 8,
+            "font-family": "var(--scrub-font)",
+          });
+          seam.textContent = `−${GAUGE_FRAMES}f`;
+          kids.push(seam);
+          // The playhead.
+          kids.push(svg("line", {
+            x1: g.xp, y1: 2, x2: g.xp, y2: H - 2,
+            stroke: "var(--scrub-text)", "stroke-width": 2,
+          }));
+          // Lag combs: one tick per client, in that client's player colour, at
+          // the server frame it last actually displayed. Only inside the gauge.
+          panes.forEach((p, i) => {
+            if (p.role === "server") return;
+            const behind = behindServer(i, g.playhead);
+            if (behind == null) return;
+            const over = behind > GAUGE_FRAMES;
+            const x = over ? g.gaugeLeft + 2 : g.gaugeRight - behind * GAUGE_PX;
+            kids.push(svg("line", {
+              class: "comb", "data-pane": i, "data-behind": behind,
+              x1: x, y1: 16, x2: x, y2: H - 6,
+              stroke: colorFor(i), "stroke-width": 3,
+            }));
+            const lbl = svg("text", {
+              x: x, y: 10, fill: colorFor(i), "font-size": 10, "font-weight": 700,
+              "text-anchor": "middle", "font-family": "var(--scrub-font)",
+            });
+            lbl.textContent = over ? `»${i + 1}` : String(i + 1);
+            kids.push(lbl);
+            // Stash for the pane header's own lag tag.
+            p.__behind = behind;
+          });
+          rail.replaceChildren(...kids);
+        };
+        // Seeking. Inside the gauge the scale is fine (one frame per ~4px), so
+        // dragging there is a genuine frame-stepping affordance the rail alone
+        // cannot offer. The gauge anchor is captured at pointerdown, otherwise
+        // moving the playhead would move the gauge under the cursor.
+        const frameAtX = (x, anchor) => {
+          if (x >= anchor.gaugeLeft) {
+            const behind = Math.round((anchor.gaugeRight - x) / GAUGE_PX);
+            return Math.max(anchor.lo, Math.min(anchor.hi, anchor.playhead - behind));
+          }
+          return Math.round(anchor.lo + (x / anchor.w) * anchor.span);
+        };
+        const seekTo = (f) => {
+          try {
+            window.__sim.seek(f);
+          } catch (e) {
+            console.error("[chrono] seek:", e);
+          }
+        };
+        rail.addEventListener("pointerdown", (e) => {
+          if (!panes.length) return;
+          rail.setPointerCapture(e.pointerId);
+          setPaused(true);
+          dragAnchor = railGeom();
+          seekTo(frameAtX(e.offsetX, dragAnchor));
+        });
+        rail.addEventListener("pointermove", (e) => {
+          if (!dragAnchor) return;
+          seekTo(frameAtX(e.offsetX, dragAnchor));
+        });
+        const endDrag = () => {
+          dragAnchor = null;
+        };
+        rail.addEventListener("pointerup", endDrag);
+        rail.addEventListener("pointercancel", endDrag);
+
+        // ---- keys ----------------------------------------------------------
+        // The conflict designed away: digits are also text, so pane shortcuts
+        // are live only when the STAGE owns DOM focus (i.e. after a click in a
+        // pane). And the bar's own pause must not steal Space from a focused
+        // pane, so the global scrub keys are Ctrl+Space / , / . — never bare.
+        const stepOne = () => {
+          setPaused(true);
+          try {
+            window.__sim.step(1);
+            recordServerSig();
+          } catch (e) {
+            console.error("[chrono] step:", e);
+          }
+        };
+        window.addEventListener(
+          "keydown",
+          (e) => {
+            if (!panes.length) return;
+            if (e.code === "Space" && (e.ctrlKey || e.metaKey)) {
+              setPaused(!paused);
+            } else if (e.key === "." || e.key === ",") {
+              stepOne();
+            } else if (stageOwnsKeys) {
+              if (e.key >= "1" && e.key <= "9") {
+                const i = Number(e.key) - 1;
+                if (i < panes.length) focused = i;
+              } else if (e.key === "[" || e.key === "]") {
+                const d = e.key === "[" ? -1 : 1;
+                focused = (focused + d + panes.length) % panes.length;
+              } else if (e.key === "0" || e.key === "Escape") {
+                // A deliberate hands-off state: nothing owns the keyboard.
+                stageOwnsKeys = false;
+              } else if (e.key === "f") {
+                console.warn("[chrono] SPIKE: f-maximize is not implemented");
+                return;
+              } else {
+                return;
+              }
+            } else {
+              return;
+            }
+            e.preventDefault();
+            e.stopImmediatePropagation();
+          },
+          true,
+        );
+
+        // ---- the frame loop ------------------------------------------------
+        let acc = 0;
+        let last = performance.now();
+        const tick = () => {
+          requestAnimationFrame(tick);
+          const now = performance.now();
+          const dtMs = now - last;
+          last = now;
+
+          let live = [];
+          try {
+            live = functorLangSimLen() > 0 ? window.__sim.panes() : [];
+          } catch {
+            live = [];
+          }
+          // Rebuild on the ROLE SIGNATURE, not just the pane count. `role` is
+          // derived from the sim's LIVE routing tables, so on the first frame —
+          // before anyone has connected — the server has no listener yet and
+          // every instance reads "client". Keying the rebuild on the count alone
+          // froze that first answer into the chrome: every pane labelled CLIENT
+          // for the rest of the session, no server model pane, a preset row for
+          // the server, and a self-link `setLink(0, 0)`.
+          const sig = live.map((p) => p.role).join(",");
+          if (sig !== paneSig) {
+            const fresh = live.length !== panes.length;
+            paneSig = sig;
+            panes = live;
+            if (fresh) {
+              focused = panes.length ? panes.findIndex((p) => p.role !== "server") : -1;
+              if (focused < 0) focused = panes.length ? 0 : -1;
+              linkChoice = panes.map(() => 0);
+              serverSig.clear();
+            }
+            if (panes.length) {
+              buildPanes();
+              // No `applyLink` on mount: `LinkProfile::PERFECT` — the sim's
+              // default — is exactly the LAN preset (1 tick, no jitter, no
+              // loss), so showing LAN selected is a true statement about the
+              // links rather than a claim we had to go and make true. It also
+              // keeps mounting the bar side-effect-free on the sim.
+              buildLinks();
+            }
+          } else {
+            panes = live;
+          }
+
+          const running = panes.length > 0;
+          chrono.classList.toggle("on", running);
+          panesEl.classList.toggle("on", running);
+          // #mouselook drives the SINGLE game's camera, which is suspended
+          // while a session owns the page — so it is not merely colliding with
+          // the top-docked bar (design §7.3), it is a control that would do
+          // nothing. Hide it for the duration.
+          if (mouselook) mouselook.style.display = running ? "none" : "";
+          // The shipped bottom-docked #scrubber is the SINGLE game's timeline,
+          // and that game is suspended while a session owns the page — so it
+          // sits over the panes advertising a clock that is not moving and a
+          // seek that governs nothing. Hide it, which is also the design's
+          // point about vacating the bottom edge (§7.12).
+          const legacy = document.getElementById("scrubber");
+          if (legacy) legacy.style.visibility = running ? "hidden" : "";
+          if (!running) {
+            acc = 0;
+            return;
+          }
+
+          if (paused) {
+            acc = 0;
+          } else {
+            acc += dtMs;
+            // Whole frames only, and never skip: `History::record` asserts
+            // strictly consecutive frames and a wasm assert aborts with no
+            // unwind. Capped so a long stall cannot wedge the tab.
+            let n = Math.min(8, Math.floor(acc / FRAME_MS));
+            acc -= Math.floor(acc / FRAME_MS) * FRAME_MS;
+            while (n-- > 0) {
+              try {
+                window.__sim.step(1);
+                recordServerSig();
+              } catch (e) {
+                console.error("[chrono] step:", e);
+                setPaused(true);
+                break;
+              }
+            }
+          }
+
+          // ---- paint ----
+          const t = window.__sim.timeline();
+          const playhead = t.scrubPos ?? t.frame;
+          frameLabel.textContent = String(playhead);
+          chrono.querySelector("#mode-chip").textContent = t.scrubPos != null ? "SIM · PARKED" : "SIM";
+          drawRail();
+
+          const rects = paneRects(panes.length);
+          panes.forEach((p, i) => {
+            const el = paneNodes[i];
+            if (!el) return;
+            const r = rects[i];
+            el.style.left = `${r.left}px`;
+            el.style.top = "0px";
+            el.style.width = `${r.width}px`;
+            el.style.height = `${r.height}px`;
+            const owner = stageOwnsKeys && i === focused;
+            el.classList.toggle("focused", owner);
+            el.querySelector(".you").textContent = owner ? "keys: you" : "";
+            const behind = p.__behind;
+            el.querySelector(".lagtag").textContent =
+              p.role === "server"
+                ? "authoritative"
+                : behind == null
+                  ? ""
+                  : `lag ${Math.round(behind * FRAME_MS)}ms (${behind}f)`;
+          });
+          focusChip.style.color = focused >= 0 ? colorFor(focused) : "var(--scrub-dim)";
+          focusChip.classList.toggle("owned", stageOwnsKeys);
+          focusChip.textContent = stageOwnsKeys && focused >= 0 ? `keys ${focused + 1}` : "keys --";
+
+          // The server's model text, throttled — a <pre> rewrite per frame is
+          // DOM work the render loop should not pay for. (Throttled in the rAF
+          // loop rather than on a setInterval, which the parked branch never
+          // cleared on stop.)
+          const modelEl = paneNodes[0] && paneNodes[0].querySelector(".model");
+          if (modelEl && now >= modelDue) {
+            modelDue = now + 200;
+            const text = window.__sim.state(0);
+            if (text !== lastModelText) {
+              lastModelText = text;
+              modelEl.textContent = text;
+            }
+          }
+        };
+        requestAnimationFrame(tick);
       };
 
       init().then(() => {
@@ -395,6 +1180,11 @@
           setupInput();
           mountScrubber();
           setupInspectorRelay();
+          // SPIKE: the multiplayer chrono bar. Its layout row collapses to 0
+          // height while no dev session is running, so a single-game page looks
+          // and behaves exactly as it did. Skipped in deterministic captures for
+          // the same reason the scrubber is.
+          installChronoBar();
         }
         // The webview overlay renders even in deterministic captures (it is
         // part of the frame's visual output); only its input wiring is inert

--- a/runtime/functor-runtime-web/index-functor-lang.html
+++ b/runtime/functor-runtime-web/index-functor-lang.html
@@ -672,6 +672,12 @@
         let lastModelText = "";
         let modelDue = 0;
         let lastRecordedFrame = -1;
+        // WHICH pane is the authority, derived from the sim's live routing
+        // tables rather than assumed to be pane 0. `start` takes entries in any
+        // order — `["client.fun", "server.fun", "client.fun"]` is valid — and
+        // hard-coding 0 signed the wrong model, measured lag against a client,
+        // and impaired a client-to-client link.
+        let serverIdx = -1;
 
         // ---- REAL lag measurement -----------------------------------------
         // The combs need "the server frame each client last DISPLAYED". No ack
@@ -696,11 +702,16 @@
           while ((m = re.exec(text)) !== null) {
             out.push(m[1] + Math.round(parseFloat(m[2]) * 1000));
           }
-          return out.join(",");
+          // An EMPTY signature is not a measurement. A model with no x/z
+          // fields yields "" for every instance, which would match the newest
+          // server frame and report a confident zero lag for a game this trick
+          // simply cannot measure. Refuse instead.
+          return out.length ? out.join(",") : null;
         };
         const recordServerSig = () => {
           const t = window.__sim.timeline();
-          serverSig.set(t.frame, sigOf(window.__sim.state(0)));
+          if (serverIdx < 0) return;
+          serverSig.set(t.frame, sigOf(window.__sim.state(serverIdx)));
           // Prune to the SEEKABLE floor (`lo`), not a fixed recent window. A
           // 400-frame window silently dropped the sigs for frames a seek can
           // still reach, so the combs vanished the moment you scrubbed further
@@ -727,6 +738,7 @@
           } catch {
             return null;
           }
+          if (sig == null) return null;
           const floor = Math.max(0, window.__sim.timeline().lo ?? 0);
           for (let f = top; f >= floor; f--) {
             if (serverSig.get(f) === sig) return f;
@@ -743,7 +755,8 @@
         // frame late parked, which the wrap-aliasing above then turned into a
         // confident, completely wrong "239 frames behind". Anchoring both ends
         // of the subtraction to the same lookup makes the offset cancel.
-        const referenceFrame = (playhead) => displayedServerFrame(0, playhead + 1);
+        const referenceFrame = (playhead) =>
+          serverIdx < 0 ? null : displayedServerFrame(serverIdx, playhead + 1);
         const behindServer = (id, playhead, ref = referenceFrame(playhead)) => {
           const mine = displayedServerFrame(id, playhead + 1);
           if (ref == null || mine == null) return null;
@@ -824,7 +837,9 @@
           const dpr = window.devicePixelRatio || 1;
           const fbW = canvas.width;
           const fbH = canvas.height;
-          const gap = 2;
+          // Mirrors lib.rs exactly, including dropping the gaps when the
+          // framebuffer is too narrow for them.
+          const gap = fbW >= n * 3 ? 2 : 0;
           const contentW = Math.max(n, fbW - gap * (n - 1));
           const paneW = Math.max(1, Math.floor(contentW / n));
           const out = [];
@@ -839,7 +854,7 @@
         // ---- the link row --------------------------------------------------
         const applyLink = (id) => {
           const [, p] = PRESETS[linkChoice[id]];
-          window.__sim.setLink(0, id, {
+          window.__sim.setLink(serverIdx, id, {
             latencyTicks: toTicks(p.ms),
             jitterTicks: p.jitterMs ? toTicks(p.jitterMs) : 0,
             loss: p.loss,
@@ -915,24 +930,61 @@
           const playhead = t.scrubPos ?? t.frame;
           const hi = Math.max(t.hi ?? 0, playhead);
           const span = Math.max(1, hi - lo);
-          const xOf = (f) => ((Math.min(hi, Math.max(lo, f)) - lo) / span) * w;
-          const xp = xOf(playhead);
-          // The gauge is a MAGNIFIER, so it only earns its place while the rail
-          // is coarser than it is. Early in a session (a few hundred recorded
-          // frames across ~1000px) the rail is already finer than 4px/frame, and
-          // a fixed-scale zone there was a DE-magnifier: a comb 20f behind drew
-          // at xp-80 while frame playhead-20 actually sat at xp-100 on the very
-          // track it was superimposed on — the comb pointed at the wrong place,
-          // and `frameAtX` inherited the same error, so a click in the gauge
-          // sought a different frame than the rail said. Below the crossover the
-          // gauge collapses and everything runs at rail scale.
+
+          // The rail is ONE piecewise-linear mapping with up to three regions,
+          // and `xOf` / `frameAtX` are exact inverses of each other over all of
+          // them. Getting this wrong is subtle and was wrong twice:
+          //
+          //  - the gauge is a MAGNIFIER, so it only earns its place while the
+          //    rail is coarser than it is. Early in a session (a few hundred
+          //    frames across ~1000px) the rail is already finer than 4px/frame,
+          //    and a fixed-scale zone there DE-magnified: a comb 20f behind drew
+          //    at xp-80 while frame playhead-20 sat at xp-100 on the very track
+          //    it was superimposed on.
+          //  - with the gauge simply overlaid at `[xp-144, xp]`, every x to the
+          //    RIGHT of the playhead also took the gauge branch, so while parked
+          //    the recorded future was seeked at 4px/frame — most of it
+          //    unreachable by position, and discontinuous at the seam.
+          //
+          // So the regions are laid out explicitly and they tile the rail:
+          // coarse past | gauge | recorded future. Live, the future span is zero
+          // and the gauge sits flush at the right edge — the design's picture.
           const railPxPerFrame = w / span;
           const magnifies = railPxPerFrame < GAUGE_PX;
-          const pxPerFrame = magnifies ? GAUGE_PX : railPxPerFrame;
-          const gaugeRight = xp;
-          const gaugeLeft = magnifies ? Math.max(0, xp - GAUGE_W) : xp;
+          const gStart = magnifies ? Math.max(lo, playhead - GAUGE_FRAMES) : playhead;
+          const gaugeW = magnifies ? Math.min(GAUGE_W, w * 0.4) : 0;
+          const pastFrames = gStart - lo;
+          const futureFrames = hi - playhead;
+          const restW = Math.max(0, w - gaugeW);
+          const shareTotal = pastFrames + futureFrames;
+          const pastW = shareTotal > 0 ? (restW * pastFrames) / shareTotal : restW;
+          const futureW = restW - pastW;
+          const gaugeLeft = pastW;
+          const gaugeRight = pastW + gaugeW;
+          const gaugeFrames = Math.max(1, playhead - gStart);
+          const pxPerFrame = magnifies ? gaugeW / gaugeFrames : railPxPerFrame;
+
+          const xOf = (f) => {
+            const c = Math.min(hi, Math.max(lo, f));
+            if (!magnifies) return ((c - lo) / span) * w;
+            if (c <= gStart) return pastFrames > 0 ? ((c - lo) / pastFrames) * pastW : 0;
+            if (c <= playhead) return gaugeLeft + ((c - gStart) / gaugeFrames) * gaugeW;
+            return gaugeRight + ((c - playhead) / Math.max(1, futureFrames)) * futureW;
+          };
+          const frameAt = (x) => {
+            if (!magnifies) return Math.round(lo + (x / w) * span);
+            if (x <= gaugeLeft) {
+              return Math.round(pastW > 0 ? lo + (x / pastW) * pastFrames : lo);
+            }
+            if (x <= gaugeRight) {
+              return Math.round(gStart + ((x - gaugeLeft) / Math.max(1, gaugeW)) * gaugeFrames);
+            }
+            return Math.round(
+              playhead + ((x - gaugeRight) / Math.max(1, futureW)) * futureFrames,
+            );
+          };
           return {
-            w, lo, hi, playhead, span, xOf, xp,
+            w, lo, hi, playhead, span, xOf, frameAt, xp: xOf(playhead),
             gaugeLeft, gaugeRight, magnifies, pxPerFrame,
             parked: t.scrubPos != null,
           };
@@ -985,10 +1037,11 @@
             if (p.role === "server") return;
             const behind = behindServer(i, g.playhead, ref);
             if (behind == null) return;
+            // Positioned through the rail's own mapping, so the comb points at
+            // the frame it names. `»` clamps at the seam when the lag exceeds
+            // the gauge's span.
             const over = g.magnifies && behind > GAUGE_FRAMES;
-            const x = over
-              ? g.gaugeLeft + 2
-              : Math.max(0, g.gaugeRight - behind * g.pxPerFrame);
+            const x = over ? g.gaugeLeft + 2 : g.xOf(g.playhead - behind);
             kids.push(svg("line", {
               class: "comb", "data-pane": i, "data-behind": behind,
               x1: x, y1: 16, x2: x, y2: H - 6,
@@ -1015,13 +1068,9 @@
         // dragging there is a genuine frame-stepping affordance the rail alone
         // cannot offer. The gauge anchor is captured at pointerdown, otherwise
         // moving the playhead would move the gauge under the cursor.
-        const frameAtX = (x, anchor) => {
-          if (anchor.magnifies && x >= anchor.gaugeLeft) {
-            const behind = Math.round((anchor.gaugeRight - x) / GAUGE_PX);
-            return Math.max(anchor.lo, Math.min(anchor.hi, anchor.playhead - behind));
-          }
-          return Math.round(anchor.lo + (x / anchor.w) * anchor.span);
-        };
+        // The exact inverse of the anchor's `xOf`, clamped to the seekable range.
+        const frameAtX = (x, anchor) =>
+          Math.max(anchor.lo, Math.min(anchor.hi, anchor.frameAt(Math.max(0, Math.min(anchor.w, x)))));
         const seekTo = (f) => {
           try {
             window.__sim.seek(f);
@@ -1126,6 +1175,23 @@
           } catch {
             live = [];
           }
+          // A NEW SESSION resets the bar. `start` replaces the sim, and a
+          // replacement of the same shape changes neither the pane count nor the
+          // role signature — so without this the bar kept `paused = false` from
+          // the previous session and immediately began auto-stepping a session a
+          // harness had just started and expected to own, on top of stale link
+          // selections and a stale comb ring. Detected by the frame counter
+          // going backwards while not parked, which only a fresh sim does.
+          if (live.length) {
+            const now = window.__sim.timeline();
+            if (now.scrubPos == null && now.frame < lastRecordedFrame) {
+              setPaused(true);
+              serverSig.clear();
+              lastRecordedFrame = -1;
+              paneSig = "";
+            }
+          }
+
           // Rebuild on the ROLE SIGNATURE, not just the pane count. `role` is
           // derived from the sim's LIVE routing tables, so on the first frame —
           // before anyone has connected — the server has no listener yet and
@@ -1138,6 +1204,7 @@
             const fresh = live.length !== panes.length;
             paneSig = sig;
             panes = live;
+            serverIdx = panes.findIndex((p) => p.role === "server");
             if (fresh) {
               linkChoice = panes.map(() => 0);
               serverSig.clear();
@@ -1180,6 +1247,7 @@
           if (legacy) legacy.style.visibility = running ? "hidden" : "";
           if (!running) {
             acc = 0;
+            serverIdx = -1;
             return;
           }
 
@@ -1256,10 +1324,13 @@
           // DOM work the render loop should not pay for. (Throttled in the rAF
           // loop rather than on a setInterval, which the parked branch never
           // cleared on stop.)
-          const modelEl = paneNodes[0] && paneNodes[0].querySelector(".model");
+          const modelEl =
+            serverIdx >= 0 && paneNodes[serverIdx]
+              ? paneNodes[serverIdx].querySelector(".model")
+              : null;
           if (modelEl && now >= modelDue) {
             modelDue = now + 200;
-            const text = window.__sim.state(0);
+            const text = window.__sim.state(serverIdx);
             if (text !== lastModelText) {
               lastModelText = text;
               modelEl.textContent = text;

--- a/runtime/functor-runtime-web/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-web/src/functor_lang_game.rs
@@ -33,12 +33,33 @@ pub struct WebPlatform {
     /// The overlay's shadow state — the last message shown (or `None` if hidden)
     /// — so a persistent error doesn't rewrite the DOM every frame.
     overlay_error: Option<String>,
+    /// May this producer drive the page's error overlay? True for the page's one
+    /// live game; FALSE for a dev-session instance. See [`WebPlatform::for_sim`].
+    owns_overlay: bool,
 }
 
 impl WebPlatform {
     pub fn new() -> WebPlatform {
         WebPlatform {
             overlay_error: None,
+            owns_overlay: true,
+        }
+    }
+
+    /// A platform for a **dev-session instance**, which must not touch the
+    /// page's draw-error overlay.
+    ///
+    /// `#functor-lang-error` is a single page-global div. With several instances
+    /// rendering per frame, each holding its OWN dedupe state, two panes failing
+    /// with different messages would show and hide it every frame — a 60 Hz
+    /// flash — and a pane's error would be reported page-wide with nothing
+    /// saying which pane it came from. Draw errors still reach the console
+    /// through the producer's reporter; surfacing them per pane belongs with the
+    /// pane chrome.
+    pub fn for_sim() -> WebPlatform {
+        WebPlatform {
+            overlay_error: None,
+            owns_overlay: false,
         }
     }
 }
@@ -101,6 +122,11 @@ impl ProducerPlatform for WebPlatform {
     /// state actually changes (draw breaks with a new message, or recovers) so a
     /// persistent error doesn't rewrite the overlay every frame.
     fn set_draw_overlay(&mut self, error: Option<&str>) {
+        // A session instance is one of N producers sharing this page; the
+        // overlay belongs to the single live game only.
+        if !self.owns_overlay {
+            return;
+        }
         // Dedupe by borrow: a persistent draw error re-reports the same message
         // every frame, so allocate a stored copy ONLY when the state changes.
         if self.overlay_error.as_deref() == error {

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -1621,7 +1621,11 @@ async fn run_async() -> Result<(), JsValue> {
                 // `pane_w` can floor to 0 outright. The LAST pane absorbs the
                 // remainder so the panes tile the framebuffer exactly, the same
                 // rule the desktop stereo path uses for odd widths.
-                let gap = 2;
+                // Drop the gaps entirely rather than overflow: below
+                // `panes * (1 + gap)` framebuffer px the gaps cannot fit, and
+                // clamping `pane_w` to 1 while `x` kept advancing by `1 + gap`
+                // pushed the later panes off the framebuffer.
+                let gap = if fb_w >= panes * 3 { 2 } else { 0 };
                 let content_w = (fb_w - gap * (panes - 1)).max(panes);
                 let pane_w = (content_w / panes).max(1);
                 for (i, sim_frame) in sim_frames.iter().enumerate() {

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -1590,7 +1590,59 @@ async fn run_async() -> Result<(), JsValue> {
             // ghost frame renders at ITS OWN division-boundary time, so
             // render-time animation (the skinned pose) advances through the
             // strobe instead of freezing at the paused pose.
-            if !ghosts.is_empty() {
+            // MULTI-PANE: while a dev session owns the page, the canvas shows
+            // one column per instance — the server's authoritative world beside
+            // each client's (latency-lagged) view of it. The single game's frame
+            // is not drawn at all; it is suspended.
+            //
+            // Same structure as the native `functor-netsim-viz`, including its
+            // scissor discipline: the shadow pass inside `render_frame` must run
+            // UNSCISSORED, and it re-scissors the main pass to the pane, so the
+            // test is disabled before each pane rather than once up front.
+            if let Some((sim_frames, sim_time)) = sim::render_frames() {
+                let (fb_w, fb_h) = (canvas.width() as i32, canvas.height() as i32);
+                let panes = sim_frames.len().max(1) as i32;
+                gl.disable(glow::SCISSOR_TEST);
+                gl.viewport(0, 0, fb_w, fb_h);
+                gl.clear_color(0.0, 0.0, 0.0, 1.0);
+                gl.clear(glow::COLOR_BUFFER_BIT | glow::DEPTH_BUFFER_BIT);
+
+                // Integer division floors, so N panes of `pane_w` plus the gaps
+                // leave a stale strip on the right — and at a narrow canvas
+                // `pane_w` can floor to 0 outright. The LAST pane absorbs the
+                // remainder so the panes tile the framebuffer exactly, the same
+                // rule the desktop stereo path uses for odd widths.
+                let gap = 2;
+                let content_w = (fb_w - gap * (panes - 1)).max(panes);
+                let pane_w = (content_w / panes).max(1);
+                for (i, sim_frame) in sim_frames.iter().enumerate() {
+                    let i = i as i32;
+                    let x = i * (pane_w + gap);
+                    let w = if i == panes - 1 {
+                        (fb_w - x).max(1)
+                    } else {
+                        pane_w
+                    };
+                    gl.disable(glow::SCISSOR_TEST);
+                    functor_runtime_common::render_frame(
+                        &gl,
+                        shader_version,
+                        asset_cache.clone(),
+                        &scene_context,
+                        &shadow_map,
+                        sim_frame,
+                        &sim_frame.camera,
+                        sim_time.clone(),
+                        functor_runtime_common::Viewport::with_offset(
+                            x.max(0) as u32,
+                            0,
+                            w as u32,
+                            fb_h.max(1) as u32,
+                        ),
+                        debug_render_mode,
+                    );
+                }
+            } else if !ghosts.is_empty() {
                 functor_runtime_common::render_composited_frames(
                     &gl,
                     shader_version,

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -1592,8 +1592,17 @@ async fn run_async() -> Result<(), JsValue> {
             // strobe instead of freezing at the paused pose.
             // MULTI-PANE: while a dev session owns the page, the canvas shows
             // one column per instance — the server's authoritative world beside
-            // each client's (latency-lagged) view of it. The single game's frame
-            // is not drawn at all; it is suspended.
+            // each client's (latency-lagged) view of it.
+            //
+            // The single game's frame is NOT DRAWN — but note it is still fully
+            // computed above and then discarded: `game.render`, the preview /
+            // ghost recompute, and the overlay all still run every rAF. Its
+            // MODEL is frozen (the pre-existing `sim::is_running()` gate), so
+            // nothing diverges, but this is wasted work and the comment further
+            // up promising the single game "stops rendering entirely" under
+            // multi-pane is not yet true. Gating those paths is plan PR 4; doing
+            // it here would mean restructuring the frame loop, which is more
+            // than a visualization spike should touch.
             //
             // Same structure as the native `functor-netsim-viz`, including its
             // scissor discipline: the shadow pass inside `render_frame` must run

--- a/runtime/functor-runtime-web/src/sim.rs
+++ b/runtime/functor-runtime-web/src/sim.rs
@@ -294,6 +294,13 @@ pub(crate) fn render_frames() -> Option<(Vec<Frame>, functor_runtime_common::Fra
     SIM.with(|sim| {
         let mut slot = sim.try_borrow_mut().ok()?;
         let sim = slot.as_mut()?;
+        // A sim with no instances must fall through to the single game, not
+        // return an empty pane list: the caller's multi-pane branch would clear
+        // the canvas to black and then draw nothing at all, with the single
+        // game's render skipped and no pane chrome either.
+        if sim.is_empty() {
+            return None;
+        }
         let time = sim.display_time();
         let frames = (0..sim.len())
             .map(|i| sim.render(i, time.clone()))
@@ -363,6 +370,11 @@ pub fn sim_set_link(
             return Err(format!(
                 "setLink: no such instance pair ({a}, {b}) — the sim has {}",
                 sim.len()
+            ));
+        }
+        if a == b {
+            return Err(format!(
+                "setLink: an instance has no link to itself (both ends are {a})"
             ));
         }
         if !(0.0..=1.0).contains(&loss) {

--- a/runtime/functor-runtime-web/src/sim.rs
+++ b/runtime/functor-runtime-web/src/sim.rs
@@ -29,6 +29,7 @@ use std::cell::RefCell;
 
 use functor_netsim::NetSim;
 use functor_runtime_common::functor_lang_game_embedded::FunctorLangEmbeddedGame;
+use functor_runtime_common::Frame;
 use wasm_bindgen::prelude::*;
 
 use crate::functor_lang_game::WebPlatform;
@@ -39,6 +40,12 @@ thread_local! {
     /// safe to drain per instance here (the native harness has to serialize its
     /// tests for exactly this reason).
     static SIM: RefCell<Option<NetSim>> = const { RefCell::new(None) };
+
+    /// The entry each instance was built from, positionally by id. The sim
+    /// knows an instance's role (it derives server/client from the live routing
+    /// tables) but not which FILE it came from, and a pane labelled only
+    /// "client" is ambiguous the moment two roles share a project.
+    static ENTRIES: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
 
     /// A `start_sim` is between its first await and installing its sim. Guards
     /// against two overlapping starts clobbering each other.
@@ -63,7 +70,7 @@ async fn build_sim(entries: &[String], seed: u64) -> Result<NetSim, JsValue> {
     for entry in entries {
         let sources = functor_netsim::entry_sources(entry, &project)
             .map_err(|e| JsValue::from_str(&format!("sim: {e}")))?;
-        let producer = FunctorLangEmbeddedGame::create(sources, Box::new(WebPlatform::new()))
+        let producer = FunctorLangEmbeddedGame::create(sources, Box::new(WebPlatform::for_sim()))
             .map_err(|e| JsValue::from_str(&format!("sim: cannot load '{entry}': {e}")))?;
         sim.add_producer(Box::new(producer));
     }
@@ -174,6 +181,7 @@ pub async fn start_sim(entries: JsValue, seed: f64) -> Result<usize, JsValue> {
     let count = sim.len();
     clear_shared_command_queues();
     SIM.with(|slot| *slot.borrow_mut() = Some(sim));
+    ENTRIES.with(|e| *e.borrow_mut() = entries.clone());
     log::info!(
         "[functor-lang] sim started: {count} instances ({})",
         entries.join(", ")
@@ -270,6 +278,111 @@ pub fn sim_seek(frame: u32) -> Result<String, JsValue> {
     with_sim("seek", |sim| sim.seek(frame as u64)).map_err(|e| JsValue::from_str(&e))
 }
 
+/// Every instance's frame for this render, in instance order, AND the clock they
+/// were drawn at — or `None` when no sim is running, which is the frame loop's
+/// signal to render the single game as usual.
+///
+/// Returns descriptions, not pixels: GL stays in the frame loop, so this module
+/// never touches a context. Takes `&mut` internally because a producer evaluates
+/// its `draw` here.
+///
+/// The clock is the sim's own [`NetSim::display_time`], never the page's wall
+/// clock. The sim advances only when stepped, so drawing at wall-clock time
+/// would keep `draw(model, tts)` animations moving while the session stands
+/// still, and would not rewind when a seek does.
+pub(crate) fn render_frames() -> Option<(Vec<Frame>, functor_runtime_common::FrameTime)> {
+    SIM.with(|sim| {
+        let mut slot = sim.try_borrow_mut().ok()?;
+        let sim = slot.as_mut()?;
+        let time = sim.display_time();
+        let frames = (0..sim.len())
+            .map(|i| sim.render(i, time.clone()))
+            .collect();
+        Some((frames, time))
+    })
+}
+
+/// One entry per instance, in pane order: `{id, role, entry, connections,
+/// inboundInFlight}`.
+///
+/// This is what pane chrome is drawn from — without it the view is N
+/// unattributed 3D scenes and the reader cannot tell the authoritative world
+/// from a client's copy of it. Rendering the chrome is the page's job (DOM over
+/// the canvas), not the renderer's.
+#[wasm_bindgen(js_name = functorLangSimPanes)]
+pub fn sim_panes() -> Result<JsValue, JsValue> {
+    with_sim("panes", |sim| {
+        let entries = ENTRIES.with(|e| e.borrow().clone());
+        let panes = js_sys::Array::new();
+        for id in 0..sim.len() {
+            let info = sim.client_info(id);
+            let obj = js_sys::Object::new();
+            let set = |key: &str, value: JsValue| {
+                let _ = js_sys::Reflect::set(&obj, &JsValue::from_str(key), &value);
+            };
+            set("id", JsValue::from_f64(id as f64));
+            set("role", JsValue::from_str(info.role.as_str()));
+            set(
+                "entry",
+                JsValue::from_str(entries.get(id).map(String::as_str).unwrap_or("")),
+            );
+            set("connections", JsValue::from_f64(info.connections as f64));
+            set(
+                "inboundInFlight",
+                JsValue::from_f64(info.inbound_in_flight as f64),
+            );
+            panes.push(&obj);
+        }
+        Ok(panes.into())
+    })
+    .map_err(|e| JsValue::from_str(&e))
+}
+
+/// Set the impairment on the link between two instances: `latencyTicks`,
+/// `jitterTicks`, `loss` (0..1), `reorder`.
+///
+/// This is what makes divergence VISIBLE — with a clean link every pane shows
+/// the same world, and the point of watching a server beside its clients is
+/// seeing them disagree. Impairment is configuration rather than recorded state,
+/// so it survives a rewind: dial it in, scrub back, and watch the same moment
+/// play out under the new conditions.
+///
+/// Ticks, not milliseconds: `LinkProfile` is the sim's native unit and
+/// `virtual_net.rs`'s tests pin it. The ms facade belongs at the JS edge.
+#[wasm_bindgen(js_name = functorLangSimSetLink)]
+pub fn sim_set_link(
+    a: usize,
+    b: usize,
+    latency_ticks: u32,
+    jitter_ticks: u32,
+    loss: f32,
+    reorder: bool,
+) -> Result<(), JsValue> {
+    with_sim("setLink", |sim| {
+        if a >= sim.len() || b >= sim.len() {
+            return Err(format!(
+                "setLink: no such instance pair ({a}, {b}) — the sim has {}",
+                sim.len()
+            ));
+        }
+        if !(0.0..=1.0).contains(&loss) {
+            return Err(format!("setLink: loss must be in 0..=1, got {loss}"));
+        }
+        sim.set_link(
+            a,
+            b,
+            functor_netsim::Link {
+                latency_ticks,
+                jitter_ticks,
+                loss,
+                reorder,
+            },
+        );
+        Ok(())
+    })
+    .map_err(|e| JsValue::from_str(&e))
+}
+
 /// Tear down the running sim (freeing its producers), if any, and resume the
 /// single game. Every shared queue is cleared with it, so the resumed game
 /// inherits none of the instances' pending commands — otherwise it would perform
@@ -277,5 +390,6 @@ pub fn sim_seek(frame: u32) -> Result<String, JsValue> {
 #[wasm_bindgen(js_name = functorLangStopSim)]
 pub fn stop_sim() {
     SIM.with(|sim| *sim.borrow_mut() = None);
+    ENTRIES.with(|e| e.borrow_mut().clear());
     clear_shared_command_queues();
 }


### PR DESCRIPTION
# 🧪 SPIKE — do not merge

**This is a visualization spike, not production code.** It exists to make the new
multiplayer dev-session experience *tangible* — so the design can be felt and
argued with before it is built for real. Parts of it are deliberately faked, and
the faked parts are listed below and in a comment block at the top of the spike
code itself.

The design it prototypes: [`design-multiplayer-ide-frontend.md`] and
[`plan-unified-scrubber-transport.md`] (private notes, 2026-07-25).

---

## What it looks like

A server and two clients live on the CLI dev-server page for `examples/mp`, under
one top-docked chrono bar. Client 3's link is dialled to `awful` (350ms), client 2
stays on LAN, and pane 3 owns the keyboard.

![the multiplayer dev session — 3 panes under one chrono bar](https://gist.githubusercontent.com/tommy-xr/633911bd2081fa8cb0c80e887727f7be/raw/live-focus.png)

The GIF runs the whole experience: live on LAN → dial client 3 to `mobile`, then
`awful` (watch its comb walk back toward the seam and its cubes fall behind) →
drag the rail to park the whole session in the past → resume → click-to-focus and
digit-jump between panes.

![driving the whole experience](https://gist.githubusercontent.com/tommy-xr/633911bd2081fa8cb0c80e887727f7be/raw/spike-mp-dev-session.gif)

Parked, mid-scrub. The chip says `SIM · PARKED`, all three panes have rewound to
their **own** view of frame 1000, and the lag stagger is *preserved* — client 3 is
still 27 frames behind. The rail's three regions are visible: coarse past, the
pinned gauge, and the recorded future to the right of the playhead.

![parked in the past, stagger preserved](https://gist.githubusercontent.com/tommy-xr/633911bd2081fa8cb0c80e887727f7be/raw/parked.png)

---

## What is REAL

| | |
| --- | --- |
| **The panes** | One GL viewport per wasm sim instance, from the one `NetSim`. Real `FunctorLangEmbeddedGame` producers, built from the really-fetched project sources. |
| **The seek** | `NetSim::seek` (#472) — whole-environment, exact, including the packets that were in flight. Non-destructive while parked; resuming commits the branch. |
| **The impairment** | Real `LinkProfile` on the real `VirtualNet`. Presets write real latency / jitter / loss; the readout is quantised to what the sim will *actually* do (ms at the JS edge, ticks in the sim). |
| **The lag combs** | **Measured, not modelled** — the highest-value part of this spike. See below. |
| **The focus model** | One pane owns the keyboard; click / digits / `[` `]` / `0` / `Esc`; grid-owns-DOM-focus gating with a hollow chip; `Ctrl+Space` / `,` / `.` for global scrub so bare Space is never stolen. |
| **The layout claim** | The chrono bar is a real grid row (`auto 1fr`) above the stage, not an overlay — asserted, not asserted-by-eye. The suspended single game's bottom-docked `#scrubber` is hidden, vacating the bottom edge. |

### The lag combs are measured

This is the one I most wanted to be honest about, because a gauge that renders its
own input is a very convincing lie. There is no ack protocol yet, so instead of
deriving the comb from the configured latency, the spike **measures** it: the
server's broadcast snapshot *is* the authoritative positions for a frame, and a
client draws the last snapshot it received — so a per-frame signature of the
server's positions identifies exactly which server frame each client is showing.

It falls out of that for free that parked combs stay staggered, which the design
calls the single most valuable thing this UI shows.

The cheat: the signature is scraped from the model's pretty-printed text, which the
wasm export explicitly documents as unparseable. It also aliases — the arena wraps
every ~240 frames, so a lag beyond one lap would match the previous one (guarded by
searching newest-first). The honest version is plan PR 7's route events plus PR 12's
`Parked { frame, residual_ms }` acks.

## What is FAKED

1. **No scrub protocol.** No `Park` / `Parked` / `Resume` + epoch. `NetSim::seek` is driven straight from the page — the plan's in-page fast path with the protocol boundary omitted (plan PRs 12–13).
2. **Keyboard focus routes nothing.** `functorLangSimInput` does not exist (plan PR 5); while a session runs, input is drained-and-discarded. The chrome, the bindings and the chip are real UI over a real focus *model* — the keys just have nowhere to go. This remains the #1 product risk and the spike does not hide it.
3. **No wire log.** `Packet` is private and drops are silent early-returns, so there is no route-event stream to show (plan PR 7). Faking the highest-trust panel in the design would have been the least honest thing available, so the server pane shows its real model text instead.
4. **The server is an equal third**, not a 300px strip; no `f`-maximize; no comb→pane hairline connectors.
5. **The step driver is JS rAF**, not the Rust session clock (plan PR 4).
6. **The bar is inline in `index-functor-lang.html`**, not `mountScrubber({ dock })` in the shared `scrubber.js`. Deliberate: the real re-dock (design §9 P0) means inverting four upward-opening surfaces and updating `e2e/site-sandbox.mjs`'s `#scrubber` lookups in the same commit. Keeping the spike separate leaves the shipped scrubber and every single-game view untouched.

## Path chosen, and why

**The CLI dev-server page rendering N panes from the one wasm sim** — the parked
`feat/sim-multi-pane` approach — rather than the design's v1 iframes.

`window.__sim` exists only on this page (#474), so it is the one surface where a
session can run *today*; iframe panes would have needed `__sim` exported from
`site/player.html` plus the whole `functor-scrub-*` postMessage control channel
first, which is the single largest piece of new frontend plumbing in the design.
This route reaches a real running experience in one sitting. The pane-source
abstraction in the design is what makes it a swap rather than a redesign.

## Fixed from `feat/sim-multi-pane`

That branch does not compile, and had review findings outstanding:

- **`render_frames` arity/pattern drift** — it takes no arguments and returns `Option<(Vec<Frame>, FrameTime)>`, but `lib.rs` called it with `&frame_time` and destructured the result as a bare `Vec`.
- **It computed `display_time()` and then passed the page wall clock anyway** — so `draw(model, tts)` animation kept moving while the session stood still, and did not rewind on a seek. Panes now draw at `NetSim::display_time()`.
- **`pane_w` floored to 0** at a narrow canvas and left a stale strip on the right. The last pane now absorbs the remainder (the desktop stereo rule), and the gaps are dropped entirely below `panes * 3` px rather than overflowing.
- **`WebPlatform::for_sim()` was dead code** — `build_sim` still constructed `WebPlatform::new()`, so `owns_overlay` was always true and never read. Now actually used, and it gates `set_draw_overlay`: the page-global error div belongs to the single live game.
- **The DPR mismatch** its e2e had (dividing CSS px with the same `gap = 2`): the pane chrome now mirrors the Rust split in *framebuffer* px and converts to CSS px only at the end.
- **`setInterval(…, 250)` never cleared on stop** — the model text is throttled inside the rAF loop instead, so there is nothing to leak.

Left unfixed, as noted: **render-target ids are keyed by string only**, so N panes
declaring the same target id share one FBO (`renderer.rs:33-38`). Not hit by
`examples/mp`; it will look like a network bug in any sample using a self-sampling
target, and it needs the namespace-or-document decision from the plan.

## Verification

- `node e2e/spike-mp-dev-session.mjs` — **26/26**, new in this PR. It drives the real page in a real browser and asserts the acceptance bar through the *rendered UI* where it can: the bar's box is above the canvas's; the panes tile it exactly; a dialled preset grows *that* client's measured lag and not the other's; the comb sits at a fixed 4px per frame of lag; a pointer drag on the rail parks all three panes non-destructively; the stagger survives parking; click and digits move the loud chrome and the chip. `--capture <dir>` writes the media above.
- `node e2e/wasm-sim.mjs` — the existing CI gate, **green**. The bar mounts *paused* precisely so it never races a harness that steps by hand, and mounting is side-effect-free on the sim.
- `cargo test -p functor-netsim -- --ignored` — green (incl. the 4 `scrub` tests).
- `cargo check -p functor-runtime-web --target wasm32-unknown-unknown` — clean.
- Branch is on top of **#482** (`601f8e0`).

## Review dispositions

`/xreview` ran both engines. They **agreed** on the top finding, which was a real
one and had been invisible to me *and* to a green test suite:

- **[AGREED, Critical/High] The player-colour tokens were scoped to `#chrono`, but the pane chrome lives in `#panes` — a sibling.** So every `var(--pc)` resolved to nothing: the 2px focused border, the glow, the digit badges, the role labels and the lag tags all rendered with no colour at all. The loudest claim in the design ("legible in a screenshot at thumbnail size") was the one thing not delivered, and the harness reported 26/26 throughout because it asserted `classList.contains("focused")` rather than anything about the rendering. One engine proved it with a pixel scan of the captures. Fixed (tokens on `:root`); compare the stills above.

Also fixed from the review: bare `,`/`.` stealing keystrokes from webview text
fields via a capture-phase listener; the gauge acting as a *de*-magnifier below the
crossover; the recorded future being unreachable by position while parked (the rail
is now one piecewise mapping of three tiling regions with `xOf`/`frameAt` exact
inverses); the default keyboard owner landing on the *server*; lag recording being
coupled to the bar being the stepper; `paused` surviving a session restart; empty
signatures reading as a confident zero lag; pane 0 hard-coded as the authority
instead of the derived `serverIdx`; a clipped zero-lag comb label; `#webview`
painting over the bar; `#c-links` laying its client rows out horizontally; `#f`
switching convention between live and parked; `render_frames` black-holing an empty
sim; `setLink(a, a)`.

**Dispositioned, not fixed** (both engines, Medium): the "suspended" single game
still runs its render / preview / ghost / UI / webview work every frame and
discards it. Its *model* is frozen, so nothing diverges — but the work is wasted
and a game declaring `ui`/`webview` would paint over the panes. Gating it is plan
PR 4 and needs the frame loop restructured, which is more than a visualization
spike should touch. Called out in the code.

## For the plan docs to absorb

1. **The pinned lag gauge's stated motivation cannot occur.** The design justifies it with "8 frames is 0.9 pixels on a rail showing 8000 recorded frames" — but `NetSim` records through `History::bounded(DEFAULT_HISTORY_FRAMES)` = **900** frames, so the rail never gets coarser than ~1px/frame and the sub-pixel case never arises. The gauge still earns its place (~3.6× at the bound, plus frame-accurate seek the rail cannot offer) — but it is a magnifier, not a rescue from invisibility, and it must **collapse** while the rail is already finer than 4px/frame or it silently becomes a de-magnifier that points at the wrong frame.
2. **The gauge cannot be a zone overlaid on a linear rail.** Anchoring it to the playhead means the rail has *three* regions once you can park (past / gauge / recorded future). Treating it as an overlay made everything right of the playhead seek at gauge scale. Worth stating in the design as one piecewise mapping.
3. **`scrub_pos` and "frames stepped" are offset by one**, and any UI correlating recorded per-frame data with the playhead will silently read one frame off — live *and* parked, in opposite directions. It cost me a confident, completely wrong "239 frames behind". Whatever PR 11's `session_time_history` exposes should pin its convention in the doc, loudly.
4. **`ClientRole` is derived from live routing tables, so it is `client` for everyone on frame 0** — before the server's `Sub.listen` has registered. Any chrome built from the first frame's answer is wrong forever. Worth a note wherever `client_info` is described.
5. **LAN reads as ~0 frames of lag, not 1.** `LinkProfile::PERFECT` delivers next tick, and within a step the routing lands before the client's own tick, so a clean link measures exactly 0 frames behind. Good for the design (combs stack on the playhead exactly as claimed) — worth knowing the baseline is 0 and not 1.
6. **Panes-as-equal-thirds is genuinely worse than the design's 300px strip**, and you can see it in the stills: the server pane spends most of its area on ground plane while its model text — the actually-useful content — is cramped into a small `<pre>`. The design's instinct is right and the strip should not be deferred.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
