### PR TITLE
feat(cli): functor test runs a project's expect tests under the engine prelude

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -336,8 +336,8 @@ expect (                                      // any expression works — a
 - The expression must CHECK as `bool` (`check`: "an `expect` test:
   expected bool, got …").
 - **Inert in the game loop**: `run native`/`run wasm`/`Session::load`
-  never evaluate expects — only `functor-lang test <entry.fun>` does (defs
-  load first, then each expect independently; one failure never stops the
+  never evaluate expects — only the test commands below do (defs load
+  first, then each expect independently; one failure never stops the
   rest; exit 1 on any failure). Sibling-module expects load and run with
   the project.
 - A failed TOP-LEVEL comparison (`==`/`<`/`>`) is decomposed: the report
@@ -347,8 +347,34 @@ expect (                                      // any expression works — a
   the pipe's argument.
 - Floats compare exactly; for computed floats prefer
   `Math.abs(a - b) < 0.001` over `==`.
-- Under plain `functor-lang test` the engine prelude doesn't exist —
-  expects calling `Scene.*` etc. error at runtime. Test pure logic:
+### Running them: `functor test` (a GAME) vs `functor-lang test` (pure logic)
+
+```sh
+functor -d examples/counter test          # a game project, under the ENGINE prelude
+functor -d examples/mp test --entry server   # multi-entry: pick the role
+cargo run -q -p functor-lang -- test file.fun   # a plain .fun, no engine
+```
+
+**Use `functor test` for anything in a game directory.** It typechecks the
+project (the `build` gate), then evaluates every expect in the entry and
+its siblings under the real engine host — headlessly: no GPU, no window,
+no game loop. Each failure prints at its `file:line:col` with the source
+line and, for a top-level comparison, both sides' values; the command
+exits non-zero if any expect failed. A project with no expects is a pass.
+
+`functor-lang test` is the LANGUAGE crate's dev command and runs under the
+plain `NoHost` prelude, where `Scene.*` / `Color.*` / `Physics.*` don't
+exist. Because `file = module` loads every sibling, pointing it at a game
+directory fails on the first engine call in ANY sibling — typically a
+top-level def like `let sky = Color.rgb(…)`, which aborts the def load
+before a single expect runs. Reach for it only for engine-free `.fun`
+files. Don't copy pure modules to a scratch directory to work around this;
+that's what `functor test` is for.
+
+- Expects may freely call engine externals under `functor test`
+  (`Scene.*`, `Color.*`, …) — they are pure constructors over protocol
+  values. `Effect.*` builds a *descriptor*; nothing is performed, so a
+  test never does IO. Still, the highest-value tests are pure logic:
   model/`tick`/`update` math.
 
 ## Semantics rules that WILL bite you

--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -350,8 +350,7 @@ expect (                                      // any expression works — a
 ### Running them: `functor test` (a GAME) vs `functor-lang test` (pure logic)
 
 ```sh
-functor -d examples/counter test          # a game project, under the ENGINE prelude
-functor -d examples/mp test --entry server   # multi-entry: pick the role
+functor -d examples/counter test                # a game project, under the ENGINE prelude
 cargo run -q -p functor-lang -- test file.fun   # a plain .fun, no engine
 ```
 
@@ -361,6 +360,8 @@ its siblings under the real engine host — headlessly: no GPU, no window,
 no game loop. Each failure prints at its `file:line:col` with the source
 line and, for a top-level comparison, both sides' values; the command
 exits non-zero if any expect failed. A project with no expects is a pass.
+In a multi-entry project `--entry` picks which entry is TYPECHECKED; it does
+not narrow the tests, because `file = module` loads every sibling either way.
 
 `functor-lang test` is the LANGUAGE crate's dev command and runs under the
 plain `NoHost` prelude, where `Scene.*` / `Color.*` / `Physics.*` don't
@@ -372,10 +373,11 @@ files. Don't copy pure modules to a scratch directory to work around this;
 that's what `functor test` is for.
 
 - Expects may freely call engine externals under `functor test`
-  (`Scene.*`, `Color.*`, …) — they are pure constructors over protocol
-  values. `Effect.*` builds a *descriptor*; nothing is performed, so a
-  test never does IO. Still, the highest-value tests are pure logic:
-  model/`tick`/`update` math.
+  (`Scene.*`, `Color.*`, …): no external performs IO or touches GL, and
+  `Effect.*` only builds a *descriptor* — nothing is performed. Note that
+  engine values are `HostData`, so `==` on them is a runtime error;
+  assert on numbers/records you derive instead. The highest-value tests
+  are pure logic anyway: model/`tick`/`update` math.
 
 ## Semantics rules that WILL bite you
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,8 +271,11 @@ ANY sibling.
 
 ```sh
 ./target/debug/functor -d examples/counter test
-./target/debug/functor -d examples/mp test --entry server   # multi-entry: pick the role
 ```
+
+`--entry` picks which entry is typechecked in a multi-entry project; it does NOT
+narrow the tests, since `file = module` loads every sibling either way — the
+whole directory's expects run whichever role you name.
 
 **Verify the language without a GPU:** `cargo run -q -p functor-lang -- run|check|trace|test|parse|ir <file.fun>`
 drives the interpreter/typechecker headlessly (the plain-`functor-lang` prelude, no engine host). See the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,6 +261,19 @@ asset's (future) per-asset config seat; if both declare (`url` + local file), th
 wins with a warning. Auto-reimport watches sidecar mtimes too, and a failed remote fetch
 during auto-reimport keeps the existing manifest (offline must not strip clip constants).
 
+**Run a game's inline `expect` tests.** `test` typechecks the project (the `build` gate), then
+evaluates every `expect` in the entry and its siblings under the ENGINE prelude — headlessly, no
+GPU/window/game loop. Failures print at their `file:line:col` with the source line and both sides
+of a failed comparison; exit is non-zero if any expect failed. Prefer this over
+`cargo run -p functor-lang -- test` for anything in a game directory: the language crate's command
+runs under the plain prelude, so `file = module` makes it fail on the first `Scene.*`/`Color.*` in
+ANY sibling.
+
+```sh
+./target/debug/functor -d examples/counter test
+./target/debug/functor -d examples/mp test --entry server   # multi-entry: pick the role
+```
+
 **Verify the language without a GPU:** `cargo run -q -p functor-lang -- run|check|trace|test|parse|ir <file.fun>`
 drives the interpreter/typechecker headlessly (the plain-`functor-lang` prelude, no engine host). See the
 `functor-lang` skill.

--- a/cli/src/commands/functor_lang_project.rs
+++ b/cli/src/commands/functor_lang_project.rs
@@ -179,7 +179,11 @@ impl FunctorLangProject {
     /// gitignored model must not abort the dev loop (the runtime's fallback +
     /// logged error covers it), and cold-URL HEAD probes must not delay
     /// launch (the fast-inner-loop rule).
-    pub fn build(&self, working_directory: &str, verify_assets: bool) -> Result<(), Error> {
+    pub fn build(
+        &self,
+        working_directory: &str,
+        verify_assets: bool,
+    ) -> Result<functor_lang::project::Project, Error> {
         refresh_manifest(working_directory);
         let path = self.entry_path(working_directory)?;
         let display = path.display().to_string();
@@ -240,7 +244,7 @@ impl FunctorLangProject {
         // diagnostics. (Bare-string consumer args are check-time type
         // errors since the flag day — no lint needed.)
         if !verify_assets {
-            return self.finish_build(&project);
+            return self.finish_build(project);
         }
         let findings = crate::util::asset_verify::verify_assets(
             &project.module,
@@ -269,11 +273,14 @@ impl FunctorLangProject {
                 findings.errors.len()
             )));
         }
-        self.finish_build(&project)
+        self.finish_build(project)
     }
 
     /// The successful-build tail: report what loaded.
-    fn finish_build(&self, project: &functor_lang::project::Project) -> Result<(), Error> {
+    fn finish_build(
+        &self,
+        project: functor_lang::project::Project,
+    ) -> Result<functor_lang::project::Project, Error> {
         // The user's own sibling `.fun` files: exclude the entry and the
         // prelude-injected builtin (`<builtin>/Net.fun`).
         let sibling_count = project
@@ -287,19 +294,20 @@ impl FunctorLangProject {
             entry: self.entry.clone(),
             sibling_count,
         });
-        Ok(())
+        Ok(project)
     }
 
     /// Run the project's inline `expect` tests headlessly under the ENGINE
     /// prelude (no GL context, no window, no game loop) — the thin CLI shell
-    /// over [`functor_runtime_common::functor_lang_test::run_project_expects`].
+    /// over [`functor_runtime_common::functor_lang_test::run_expects_in`].
     ///
-    /// Callers run [`Self::build`] first, so by here the project typechecks;
-    /// a remaining failure is a *runtime* one and renders as a positioned
-    /// diagnostic at the `expect` that produced it.
-    pub fn test(&self, working_directory: &str) -> Result<(), Error> {
-        let path = self.entry_path(working_directory)?;
-        let run = match functor_runtime_common::functor_lang_test::run_project_expects(&path) {
+    /// Takes the project [`Self::build`] already loaded and typechecked, so
+    /// the bytes evaluated are exactly the bytes verified (re-loading would
+    /// let an editor save land in between). A failure here is therefore a
+    /// *runtime* one, rendered as a positioned diagnostic at the `expect`
+    /// that produced it.
+    pub fn test(&self, project: &functor_lang::project::Project) -> Result<(), Error> {
+        let run = match functor_runtime_common::functor_lang_test::run_expects_in(project) {
             Ok(run) => run,
             Err(e) => {
                 emit(Event::Diagnostic {
@@ -314,7 +322,7 @@ impl FunctorLangProject {
                 });
                 return Err(Error::other(format!(
                     "cannot run the {} tests",
-                    path.display()
+                    self.entry
                 )));
             }
         };
@@ -329,9 +337,7 @@ impl FunctorLangProject {
                 line: Some(case.line),
                 col: Some(case.col),
                 message: message.clone(),
-                source_line: std::fs::read_to_string(&case.file)
-                    .ok()
-                    .and_then(|src| nth_line(&src, case.line)),
+                source_line: case.source_line.clone(),
             });
         }
 

--- a/cli/src/commands/functor_lang_project.rs
+++ b/cli/src/commands/functor_lang_project.rs
@@ -290,6 +290,70 @@ impl FunctorLangProject {
         Ok(())
     }
 
+    /// Run the project's inline `expect` tests headlessly under the ENGINE
+    /// prelude (no GL context, no window, no game loop) — the thin CLI shell
+    /// over [`functor_runtime_common::functor_lang_test::run_project_expects`].
+    ///
+    /// Callers run [`Self::build`] first, so by here the project typechecks;
+    /// a remaining failure is a *runtime* one and renders as a positioned
+    /// diagnostic at the `expect` that produced it.
+    pub fn test(&self, working_directory: &str) -> Result<(), Error> {
+        let path = self.entry_path(working_directory)?;
+        let run = match functor_runtime_common::functor_lang_test::run_project_expects(&path) {
+            Ok(run) => run,
+            Err(e) => {
+                emit(Event::Diagnostic {
+                    severity: Severity::Error,
+                    file: Some(e.file.display().to_string()),
+                    line: Some(e.line),
+                    col: Some(e.col),
+                    message: e.message,
+                    source_line: std::fs::read_to_string(&e.file)
+                        .ok()
+                        .and_then(|src| nth_line(&src, e.line)),
+                });
+                return Err(Error::other(format!(
+                    "cannot run the {} tests",
+                    path.display()
+                )));
+            }
+        };
+
+        for case in &run.cases {
+            let Some(message) = &case.failure else {
+                continue;
+            };
+            emit(Event::Diagnostic {
+                severity: Severity::Error,
+                file: Some(case.file.display().to_string()),
+                line: Some(case.line),
+                col: Some(case.col),
+                message: message.clone(),
+                source_line: std::fs::read_to_string(&case.file)
+                    .ok()
+                    .and_then(|src| nth_line(&src, case.line)),
+            });
+        }
+
+        if run.total() == 0 {
+            emit(Event::Info {
+                message: "no `expect` tests found".to_string(),
+            });
+            return Ok(());
+        }
+        let (passed, failed) = (run.passed(), run.failed());
+        if failed > 0 {
+            return Err(Error::other(format!(
+                "{} expect(s): {passed} passed, {failed} failed",
+                run.total()
+            )));
+        }
+        emit(Event::Info {
+            message: format!("{} expect(s): {passed} passed", run.total()),
+        });
+        Ok(())
+    }
+
     /// Spawn the runner on the entry (`run` and `develop` — hot reload is
     /// built into the producer, so there is no separate watch loop).
     pub async fn run(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -131,6 +131,12 @@ enum Command {
         #[arg(value_enum)]
         environment: Option<Environment>,
     },
+    /// Run the project's inline `expect` tests headlessly under the engine
+    /// prelude — no GPU, no window. Typechecks first (like `build`), then
+    /// evaluates every `expect` in the entry and its sibling modules,
+    /// reporting each failure at its source location. Exits non-zero if any
+    /// expect fails. E.g. `functor -d examples/platformer test`.
+    Test,
     /// Run the game (default `native`, an OpenGL window; `wasm` serves a dev
     /// server; `vr` runs it on an adb-attached headset, re-pushing on save).
     /// E.g. `functor -d examples/primitives run native`.
@@ -337,6 +343,7 @@ async fn run(args: &Args) -> io::Result<()> {
     let is_routed = matches!(
         &args.command,
         Command::Build { .. }
+            | Command::Test
             | Command::Run { .. }
             | Command::Develop { .. }
             | Command::Push { .. }
@@ -363,6 +370,12 @@ async fn run(args: &Args) -> io::Result<()> {
             | Command::Inspect { .. }
             | Command::Import => {
                 unreachable!("is_routed excludes")
+            }
+            // The typecheck gate runs first so an `expect` failure is
+            // unambiguously a RUNTIME failure, never a type error in disguise.
+            Command::Test => {
+                project.build(&working_directory_str, false)?;
+                project.test(&working_directory_str)
             }
             // `build` is the strict typecheck gate — nothing compiles for
             // either target (native interprets the file; wasm ships it as
@@ -408,7 +421,10 @@ async fn run(args: &Args) -> io::Result<()> {
         // The F#/Fable pipeline was removed in E3: every Functor project is now
         // Functor Lang (functor.json `"language": "functor-lang"`), routed above. A project that
         // isn't Functor Lang has no build/run/develop/push path.
-        Command::Build { .. } | Command::Run { .. } | Command::Develop { .. } => {
+        Command::Build { .. }
+        | Command::Test
+        | Command::Run { .. }
+        | Command::Develop { .. } => {
             Err(io::Error::other(
                 "not a Functor Lang project: functor.json needs \"language\": \"functor-lang\" \
 (the F#/Fable pipeline was removed in E3)",
@@ -452,6 +468,7 @@ fn command_name(command: &Command) -> &'static str {
         Command::Init { .. } => "init",
         Command::Docs { .. } => "docs",
         Command::Build { .. } => "build",
+        Command::Test => "test",
         Command::Run { .. } => "run",
         Command::Develop { .. } => "develop",
         Command::Inspect { .. } => "inspect",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -374,8 +374,8 @@ async fn run(args: &Args) -> io::Result<()> {
             // The typecheck gate runs first so an `expect` failure is
             // unambiguously a RUNTIME failure, never a type error in disguise.
             Command::Test => {
-                project.build(&working_directory_str, false)?;
-                project.test(&working_directory_str)
+                let loaded = project.build(&working_directory_str, false)?;
+                project.test(&loaded)
             }
             // `build` is the strict typecheck gate — nothing compiles for
             // either target (native interprets the file; wasm ships it as

--- a/runtime/functor-runtime-common/Cargo.toml
+++ b/runtime/functor-runtime-common/Cargo.toml
@@ -48,6 +48,10 @@ gltf = { version = "1.4.1", features = ["names", "KHR_materials_pbrSpecularGloss
 # drift tests keep the interface signatures in sync with the host registry.
 functor-prelude = { path = "../../functor-prelude" }
 
+[dev-dependencies]
+# Throwaway project directories for the headless `expect`-runner tests.
+tempfile = "3"
+
 [target.'cfg(not(any(target_arch = "wasm32")))'.dependencies]
 tokio = { version = "1", features = ["full"] }
 

--- a/runtime/functor-runtime-common/src/functor_lang_test.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_test.rs
@@ -1,0 +1,223 @@
+//! Run a game project's inline `expect` tests under the ENGINE prelude,
+//! headlessly — no GL context, no window, no game loop.
+//!
+//! `functor-lang test` (the language crate's CLI) evaluates expects under the
+//! plain `NoHost` prelude, so it fails on any project whose modules mention
+//! `Scene.*` / `Sprite.*` / `Camera.*` — and `file = module` means *every*
+//! sibling loads, so one rendering module is enough to make a whole game
+//! untestable. This module supplies the real [`FunctorHost`] instead, which is
+//! the same host the shells run and is a stateless value: every external is a
+//! pure constructor over the protocol types (a `Scene.cube(…)` builds a scene
+//! node; an `Effect.*` builds an effect *descriptor* — performing it is the
+//! producer's effect broker, which never runs here). Nothing in the registry
+//! touches GL, so instantiating it off-thread and off-GPU is safe.
+//!
+//! This is the library core behind `functor test`; the CLI command is a thin
+//! wrapper that renders [`ExpectRun`] as diagnostics.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use crate::functor_lang_prelude::FunctorHost;
+
+/// One evaluated `expect`, located in the file that wrote it.
+#[derive(Debug, Clone)]
+pub struct ExpectCase {
+    pub file: PathBuf,
+    pub line: usize,
+    pub col: usize,
+    /// `None` when the expect held; otherwise the human-facing reason (a
+    /// rendered comparison, or a located runtime error).
+    pub failure: Option<String>,
+}
+
+/// Every expect in the project, in source order.
+#[derive(Debug, Clone)]
+pub struct ExpectRun {
+    pub cases: Vec<ExpectCase>,
+}
+
+impl ExpectRun {
+    pub fn total(&self) -> usize {
+        self.cases.len()
+    }
+
+    pub fn failed(&self) -> usize {
+        self.cases.iter().filter(|c| c.failure.is_some()).count()
+    }
+
+    pub fn passed(&self) -> usize {
+        self.total() - self.failed()
+    }
+}
+
+/// The run never started: the project would not load, or evaluating its
+/// top-level defs failed (both abort every expect, so they are one error
+/// rather than N failures).
+#[derive(Debug, Clone)]
+pub struct ExpectRunError {
+    pub file: PathBuf,
+    pub line: usize,
+    pub col: usize,
+    pub message: String,
+}
+
+/// Load `entry` as a project (the entry plus every sibling `.fun`, plus the
+/// engine's bundled modules and `.funi` interfaces — exactly what `build` and
+/// the producers load) and evaluate its `expect` tests under the engine host.
+///
+/// Like `functor-lang test`, this does NOT typecheck: `check` is the static
+/// gate, and callers that want it (the `functor test` command does) run it
+/// first. A non-bool expect therefore reports as its own failure here.
+pub fn run_project_expects(entry: &Path) -> Result<ExpectRun, ExpectRunError> {
+    let project = functor_lang::project::load_with_bundled_modules(
+        entry,
+        &HashMap::new(),
+        &functor_prelude::bundled_modules(),
+    )
+    .map_err(|e| ExpectRunError {
+        file: e.path,
+        line: e.line,
+        col: e.col,
+        message: e.message,
+    })?;
+
+    let reports =
+        functor_lang::run_expects(&project.module, &mut FunctorHost).map_err(|failure| {
+            let (file, line, col) = project.sources.resolve(failure.error.span.start);
+            ExpectRunError {
+                file: file.path.clone(),
+                line,
+                col,
+                message: failure.error.message.clone(),
+            }
+        })?;
+
+    let cases = reports
+        .iter()
+        .map(|report| {
+            let (file, line, col) = project.sources.resolve(report.span.start);
+            let failure = match &report.outcome {
+                functor_lang::ExpectOutcome::Pass => None,
+                functor_lang::ExpectOutcome::Fail(Some(cmp)) => Some(format!(
+                    "expect failed: left {} right — left: {}, right: {}",
+                    cmp.op, cmp.lhs, cmp.rhs
+                )),
+                functor_lang::ExpectOutcome::Fail(None) => {
+                    Some("expect failed: expected true, got false".to_string())
+                }
+                // The error's own span can be inside a callee (a different
+                // file), so carry its location in the text — the case stays
+                // reported at the `expect` the developer wrote.
+                functor_lang::ExpectOutcome::Error(error) => Some(format!(
+                    "expect errored: {}",
+                    project.sources.render(error.span.start, &error.message)
+                )),
+            };
+            ExpectCase {
+                file: file.path.clone(),
+                line,
+                col,
+                failure,
+            }
+        })
+        .collect();
+
+    Ok(ExpectRun { cases })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Write a throwaway project directory and return its entry path.
+    fn project(name: &str, files: &[(&str, &str)]) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for (file, src) in files {
+            std::fs::write(dir.path().join(file), src).expect("write");
+        }
+        let entry = dir.path().join(name);
+        (dir, entry)
+    }
+
+    /// The whole point. `NoHost` cannot evaluate `Color.rgb`, and it is a
+    /// TOP-LEVEL def, so under `functor-lang test` the def load aborts before
+    /// any expect runs — the exact error the platformer jam entry hit
+    /// (`game.fun: unknown external `Color.rgb``) that forced it to copy its
+    /// pure modules to a scratch directory.
+    #[test]
+    fn expects_run_under_the_engine_prelude_which_nohost_cannot_load() {
+        let (_dir, entry) = project(
+            "game.fun",
+            &[(
+                "game.fun",
+                r#"let sky = Color.rgb(0.1, 0.2, 0.3)
+let ground = Scene.lit(sky, Scene.plane())
+
+let double = (n) => n * 2.0
+
+expect double(2.0) == 4.0
+expect List.length([Scene.cube(), Scene.sphere()]) == 2
+"#,
+            )],
+        );
+        let run = run_project_expects(&entry).expect("project runs");
+        assert_eq!(run.total(), 2);
+        assert_eq!(run.failed(), 0, "{:?}", run.cases);
+    }
+
+    #[test]
+    fn a_failing_expect_is_reported_with_its_location_and_does_not_stop_the_rest() {
+        let (_dir, entry) = project(
+            "game.fun",
+            &[(
+                "game.fun",
+                "let double = (n) => n * 2.0\nexpect double(2.0) == 5.0\nexpect double(3.0) == 6.0\n",
+            )],
+        );
+        let run = run_project_expects(&entry).expect("project runs");
+        assert_eq!(run.total(), 2);
+        assert_eq!(run.failed(), 1);
+        let bad = &run.cases[0];
+        assert_eq!(bad.line, 2);
+        assert_eq!(bad.file.file_name().unwrap(), "game.fun");
+        let message = bad.failure.as_deref().expect("a failure detail");
+        assert!(message.contains('4'), "{message}");
+        assert!(message.contains('5'), "{message}");
+        assert!(run.cases[1].failure.is_none());
+    }
+
+    #[test]
+    fn a_sibling_module_contributes_its_expects() {
+        let (_dir, entry) = project(
+            "game.fun",
+            &[
+                ("game.fun", "let sky = Color.rgb(0.1, 0.2, 0.3)\n"),
+                (
+                    "helpers.fun",
+                    "let inc = (n) => n + 1.0\nexpect inc(1.0) == 2.0\n",
+                ),
+            ],
+        );
+        let run = run_project_expects(&entry).expect("project runs");
+        assert_eq!(run.total(), 1);
+        assert_eq!(run.cases[0].file.file_name().unwrap(), "helpers.fun");
+        assert_eq!(run.failed(), 0);
+    }
+
+    #[test]
+    fn a_project_that_will_not_load_is_one_positioned_error() {
+        let (_dir, entry) = project("game.fun", &[("game.fun", "let broken = (\n")]);
+        let err = run_project_expects(&entry).expect_err("a load error");
+        assert_eq!(err.file.file_name().unwrap(), "game.fun");
+        assert!(!err.message.is_empty());
+    }
+
+    #[test]
+    fn a_project_with_no_expects_runs_clean() {
+        let (_dir, entry) = project("game.fun", &[("game.fun", "let x = 1.0\n")]);
+        let run = run_project_expects(&entry).expect("project runs");
+        assert_eq!(run.total(), 0);
+        assert_eq!(run.failed(), 0);
+    }
+}

--- a/runtime/functor-runtime-common/src/functor_lang_test.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_test.rs
@@ -6,11 +6,16 @@
 //! `Scene.*` / `Sprite.*` / `Camera.*` — and `file = module` means *every*
 //! sibling loads, so one rendering module is enough to make a whole game
 //! untestable. This module supplies the real [`FunctorHost`] instead, which is
-//! the same host the shells run and is a stateless value: every external is a
-//! pure constructor over the protocol types (a `Scene.cube(…)` builds a scene
-//! node; an `Effect.*` builds an effect *descriptor* — performing it is the
-//! producer's effect broker, which never runs here). Nothing in the registry
-//! touches GL, so instantiating it off-thread and off-GPU is safe.
+//! the same host the shells run and is a unit struct: no external in the
+//! registry touches GL, performs IO, or spawns a thread — they build protocol
+//! values (a `Scene.cube(…)` builds a scene node) or *descriptors* (an
+//! `Effect.*` describes an effect; performing it is the producer's effect
+//! broker, which never runs here). So it is safe to instantiate off-GPU.
+//!
+//! Two externals are not quite pure: the `Ui.*` widget constructors push into
+//! the prelude's `UI_HANDLERS` thread-local. The producer drains that after
+//! every `ui(model)` evaluation; [`run_project_expects`] does the same at the
+//! end, so a project whose expects construct widgets doesn't leak closures.
 //!
 //! This is the library core behind `functor test`; the CLI command is a thin
 //! wrapper that renders [`ExpectRun`] as diagnostics.
@@ -26,6 +31,10 @@ pub struct ExpectCase {
     pub file: PathBuf,
     pub line: usize,
     pub col: usize,
+    /// The offending source line, carried from the already-in-memory
+    /// `SourceFile` so the caller renders a caret without re-reading (and
+    /// without risking a *different* snapshot than the one evaluated).
+    pub source_line: Option<String>,
     /// `None` when the expect held; otherwise the human-facing reason (a
     /// rendered comparison, or a located runtime error).
     pub failure: Option<String>,
@@ -66,9 +75,10 @@ pub struct ExpectRunError {
 /// engine's bundled modules and `.funi` interfaces — exactly what `build` and
 /// the producers load) and evaluate its `expect` tests under the engine host.
 ///
-/// Like `functor-lang test`, this does NOT typecheck: `check` is the static
-/// gate, and callers that want it (the `functor test` command does) run it
-/// first. A non-bool expect therefore reports as its own failure here.
+/// Callers that already hold a loaded (and typechecked) project should use
+/// [`run_expects_in`] instead — loading twice would let an edit land between
+/// the check and the run, so the bytes evaluated would not be the bytes
+/// verified.
 pub fn run_project_expects(entry: &Path) -> Result<ExpectRun, ExpectRunError> {
     let project = functor_lang::project::load_with_bundled_modules(
         entry,
@@ -81,7 +91,20 @@ pub fn run_project_expects(entry: &Path) -> Result<ExpectRun, ExpectRunError> {
         col: e.col,
         message: e.message,
     })?;
+    run_expects_in(&project)
+}
 
+/// Evaluate an ALREADY-LOADED project's `expect` tests under the engine host.
+///
+/// Like `functor-lang test`, this does NOT typecheck: `check` is the static
+/// gate, and callers that want it (the `functor test` command does) run it on
+/// this same project first. A non-bool expect therefore reports as its own
+/// failure here.
+///
+/// Expects from the engine's own bundled modules are EXCLUDED: they are not
+/// the user's tests, and their `<builtin>/…` paths are not files anyone can
+/// open. (`build`'s module count filters the same marker.)
+pub fn run_expects_in(project: &functor_lang::project::Project) -> Result<ExpectRun, ExpectRunError> {
     let reports =
         functor_lang::run_expects(&project.module, &mut FunctorHost).map_err(|failure| {
             let (file, line, col) = project.sources.resolve(failure.error.span.start);
@@ -91,10 +114,23 @@ pub fn run_project_expects(entry: &Path) -> Result<ExpectRun, ExpectRunError> {
                 col,
                 message: failure.error.message.clone(),
             }
-        })?;
+        });
+    // The `Ui.*` constructors register handlers in a thread-local the producer
+    // drains per frame; nothing consumes them here, so drop whatever the
+    // expects accumulated (also on the error path — the def load runs first).
+    let _ = crate::functor_lang_prelude::take_ui_handlers();
+    let reports = reports?;
 
     let cases = reports
         .iter()
+        .filter(|report| {
+            !project
+                .sources
+                .resolve(report.span.start)
+                .0
+                .path
+                .starts_with("<builtin>")
+        })
         .map(|report| {
             let (file, line, col) = project.sources.resolve(report.span.start);
             let failure = match &report.outcome {
@@ -118,12 +154,18 @@ pub fn run_project_expects(entry: &Path) -> Result<ExpectRun, ExpectRunError> {
                 file: file.path.clone(),
                 line,
                 col,
+                source_line: nth_line(&file.src, line),
                 failure,
             }
         })
         .collect();
 
     Ok(ExpectRun { cases })
+}
+
+/// The 1-based `line`th line of `src`, for the diagnostic caret.
+fn nth_line(src: &str, line: usize) -> Option<String> {
+    src.lines().nth(line.checked_sub(1)?).map(str::to_string)
 }
 
 #[cfg(test)]

--- a/runtime/functor-runtime-common/src/lib.rs
+++ b/runtime/functor-runtime-common/src/lib.rs
@@ -77,6 +77,8 @@ pub mod functor_lang_game_embedded;
 pub mod functor_lang_prelude;
 pub mod host_registry;
 pub mod functor_lang_producer;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod functor_lang_test;
 pub mod model;
 pub mod net;
 pub mod physics;


### PR DESCRIPTION
## Motivation

`expect` tests exist in the language but there is no way to run them for a *game*. `functor-lang test` (a cargo dev binary, not something the shipped CLI installs) evaluates expects under the plain `NoHost` prelude — and because `file = module` loads every sibling, pointing it at a game directory dies on the first engine call in ANY sibling. Typically that's a top-level def, so the def load aborts before a single expect runs:

```
$ functor-lang test motion.fun
./game.fun:249:16: error: unknown external `Color.rgb`
```

This bit the jam hard. The platformer entry (`examples/platformer`, 17 expects covering its character controller) ships a `run-tests.sh` whose own comment calls itself "WORKAROUND, not the way this should work" — it copies the pure modules into a `mktemp -d` scratch directory with no engine-using sibling and tests them there. Two jam entries plus a docs agent hit the same wall, and it's why `expect` is deliberately undocumented publicly: docs PR #484 defers its public documentation to this feature.

## Design

`functor -d <dir> test` typechecks the project (the existing `build` gate), then evaluates every `expect` in the entry and its siblings under the real engine host — headlessly.

**How it runs headless.** `FunctorHost` is a unit struct over the typed external registry. No registered external touches GL, performs IO, or spawns a thread: they build protocol values (`Scene.cube()` → a scene node) or *descriptors* (`Effect.*` describes an effect; performing it is the producer's effect broker, which never runs here). So there is no GL context, no window, and no game loop — the same GPU-free precedent as the manifest generator and `build`'s typecheck. The one impurity is the `Ui.*` constructors, which push into the prelude's `UI_HANDLERS` thread-local; the runner drains it exactly as the producer does per frame.

**How failures are reported.** Each failing expect is an `Event::Diagnostic` at its `file:line:col`, with the source line and a caret, and — for a failed top-level comparison — both sides' rendered values. Exit is non-zero if any expect failed; a project with no expects is a pass.

```
error: game.fun:4:1: expect failed: left == right — left: 4, right: 5
  |
4 | expect double(2.0) == 5.0
  | ^
error: 2 expect(s): 1 passed, 1 failed
```

**Structure.** The core is `functor_runtime_common::functor_lang_test` (`run_expects_in(&Project)`, plus a `run_project_expects(&Path)` that loads first for standalone callers), unit-tested without spawning the binary. The CLI command is a thin wrapper: `build` hands `test` the project it already loaded and typechecked, so the bytes evaluated are exactly the bytes verified. No new language surface.

## What this unblocks

- **Public `expect` docs** — docs PR #484's deferral can be lifted in a follow-up now that the shipped binary can run them.
- **Deleting per-example `run-tests.sh`** — `examples/platformer`'s scratch-directory workaround becomes `functor -d examples/platformer test`.
- Agents can test a game's pure logic in place, instead of copying helpers to scratch projects.

## Verification

```
$ functor -d examples/platformer test          # the 17 jam tests, in place
✓ checked game.fun (+32 modules)
17 expect(s): 17 passed                                            EXIT=0   (190ms)

$ functor -d examples/counter test
3 expect(s): 3 passed                                              EXIT=0
$ functor -d examples/hello test
no `expect` tests found                                            EXIT=0
$ functor -d examples/mp test --entry server   # multi-entry routing
✓ checked server.fun (+33 modules)                                 EXIT=0
$ functor -d <fixture with 1 passing + 1 failing expect> test
error: 2 expect(s): 1 passed, 1 failed                             EXIT=1
```

- `cargo test -p functor-lang` and `cargo test -p functor_runtime_common`: **all green, 0 failures** (including 5 new tests for the runner — engine-prelude expects that `NoHost` cannot load, failure location/isolation, sibling-module expects, a load error, and an empty project).
- `npm run check:docs`: green.
- Exit codes checked in both directions.
- Pre-existing unrelated failure on main (`mario_hot_reload_recomputes_the_entire_extrapolated_future`) untouched.

## Review dispositions (`/xreview`: Claude subagent + Codex CLI)

**[AGREED — both engines] Double load / TOCTOU.** `build` typechecked one snapshot and `run_project_expects` re-read every file, so a save in between could evaluate un-typechecked source. **Fixed**: `build` returns the loaded `Project`; `test` runs `run_expects_in` against it. Also halves parse+lower cost.

**Fixed** (Claude): expects from the engine's own bundled modules (`<builtin>/…`) counted as the user's — latent today (`animator.fun` has none) but the fix is one filter with existing precedent in `finish_build`. • `Ui.*` handlers accumulating in a thread-local, plus a module doc that overstated the registry as purely constructive. • Source lines re-read from disk per failing expect instead of taken from the in-memory `SourceFile`. • Docs claimed `--entry` picks a role's tests; it only picks the typechecked entry, since `file = module` loads every sibling either way.

**Declined, with reasons:** sharing the expect-rendering code with `functor-lang`'s CLI — the two target different output systems (one prints `path:line: ok`, one emits structured diagnostic events), and Codex explicitly argued the duplication is justified. • Adding a step budget to the run — parity with `functor-lang test`, and a budget risks failing legitimately expensive tests; the hang-protection seam (`run_expects_budgeted`) stays available if a runaway ever shows up.

Both engines independently confirmed the headless-safety claim (no external touches GL, threads, or IO), the exit-code contract in every branch, and the `--entry` plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)