### PR TITLE
feat(physics): synchronous world queries — linearVelocity, cast, castExcluding

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -966,6 +966,13 @@ body |> Physics.mass(m) / Physics.friction(f) / Physics.restitution(r)
 body |> Physics.sensor                                     // overlap-only, no forces
 Physics.scene(gravity, [body, …])                          // what `physics` returns
 Physics.position(tag)                                      // {x, y, z} of the LIVE body
+Physics.linearVelocity(tag)                                // {x, y, z} velocity of the LIVE body
+                                                           //   (Physics.velocity is the BUILDER)
+Physics.cast(origin, dir, maxDist)                         // SYNCHRONOUS ray -> rayHit record,
+                                                           //   in place (no tagger, no update)
+Physics.castExcluding(tag, origin, dir, maxDist)           //   same, ignoring one body — the
+                                                           //   grounding probe (skip your own
+                                                           //   collider)
 scene |> Physics.transformed(tag)                          // scene at the body's live pose
 Physics.applyImpulse(tag, v)                               // -> Effect (fire-and-forget)
 Physics.applyForce(tag, v)                                 //   force lasts ONE stepped frame
@@ -979,8 +986,12 @@ Physics.events(tagger)                                     // -> Sub (from `subs
                                                            //   sensor} per contact begin/end
 ```
 
-`Physics.position` / `Physics.transformed` read the live stepped world
-(Functor Lang runs in the shell's process — no boundary). A tag not in the world is
+`Physics.position` / `Physics.linearVelocity` / `Physics.cast` /
+`Physics.castExcluding` / `Physics.transformed` read the live stepped world
+(Functor Lang runs in the shell's process — no boundary). They work in **any**
+entry point, `tick` included: in `tick` they see the previous step (physics runs
+after `tick`), in `draw` this frame's. That one step of read latency is inherent
+to read → decide → step. A tag not in the world is
 a **spanned runtime error** (there is no Option-shaped return to match on),
 so only read tags your `physics` hook declares. The tag is cross-frame
 identity: same tag = same body; drop a body by not declaring it.
@@ -1012,6 +1023,35 @@ handler chaining a command queues it for next frame's step; chaining
 another query answers immediately (the world already stepped). Under the
 fake/replay runners raycasts are canned/recorded — physics-query logic is
 testable with no world at all.
+
+`Physics.cast` / `Physics.castExcluding` are the **synchronous** counterparts:
+same `rayHit` record, but answered in place, so `tick` can branch on the result
+while deciding. Use them for a character controller; use the `Physics.raycast`
+effect when you want the answer against THIS frame's post-step world (a hitscan
+weapon fired on the frame it lands). They are world reads, not environment reads
+— not routed through the effect runner and not logged, so unlike the effect they
+are not canned under `FakeEffects`; they read whatever world is live (an empty
+one misses). Determinism holds because the world is state the physics Timeline
+reconstructs from recorded declarations and commands. A miss is `hit: false`
+with zeroed fields, never an error.
+
+**The character-controller loop** is therefore one frame, not two:
+
+```functor
+let probe = (p) =>
+  Physics.castExcluding(playerTag, Vec3.make(p.x, p.y - 0.9, p.z),
+                        Vec3.make(0.0, -1.0, 0.0), 0.2)
+let tick = (m, dt, tts) =>
+  let pos = Physics.position(playerTag)
+  let vel = Physics.linearVelocity(playerTag)
+  let onGround = probe(pos).hit
+  ...   // decide, then return the command beside the model:
+  (m', Physics.setVelocity(playerTag, Vec3.make(vx, vy, vz)))
+```
+
+The read happens in `tick`, the command drains immediately after `tick` (no
+`update` hook needed), and this frame's step applies it — reads and writes both
+land inside the frame.
 
 `Physics.events` is a **Sub** (return it from `subscriptions`, alone or in
 `Sub.batch`; it requires `update`). Every contact begin/end from this

--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -1042,16 +1042,24 @@ let probe = (p) =>
   Physics.castExcluding(playerTag, Vec3.make(p.x, p.y - 0.9, p.z),
                         Vec3.make(0.0, -1.0, 0.0), 0.2)
 let tick = (m, dt, tts) =>
-  let pos = Physics.position(playerTag)
-  let vel = Physics.linearVelocity(playerTag)
-  let onGround = probe(pos).hit
-  ...   // decide, then return the command beside the model:
-  (m', Physics.setVelocity(playerTag, Vec3.make(vx, vy, vz)))
+  match m.started with          // guard the FIRST frame: nothing has been
+  | false => { m with started: true }   //   reconciled yet, so the reads below
+  | true =>                             //   would raise `no body tagged …`
+    let pos = Physics.position(playerTag) in
+    let vel = Physics.linearVelocity(playerTag) in
+    let onGround = probe(pos).hit in
+    let vy = if onGround && m.jump then 6.0 else vel.y in
+    (m, Physics.setVelocity(playerTag, Vec3.make(vel.x, vy, vel.z)))
 ```
 
 The read happens in `tick`, the command drains immediately after `tick` (no
-`update` hook needed), and this frame's step applies it — reads and writes both
-land inside the frame.
+`update` hook needed), and the next step applies it — normally this frame's
+(when the 60 Hz accumulator is short of a full step, no step runs at all that
+frame and it lands on the next one). Reads and writes both live in `tick`.
+
+Note the two rules this example obeys: local `let` needs `in`, and the
+pre-step readers raise on the first frame, before the `physics` hook's
+declaration has been reconciled and stepped — so gate them.
 
 `Physics.events` is a **Sub** (return it from `subscriptions`, alone or in
 `Sub.batch`; it requires `update`). Every contact begin/end from this

--- a/docs/physics.md
+++ b/docs/physics.md
@@ -153,6 +153,15 @@ below is retained as the reference design (types/semantics match the Rust
 engine one-for-one); an F# surface would need that data-crossing `DrawContext`
 plumbing and is deferred indefinitely.
 
+Because these are direct reads and not a `draw`-only view, they are valid in
+**any** entry point. In `tick` they answer against the previous step (physics
+runs after `tick`); in `draw`, against this frame's. Alongside `position` the
+same class provides `Physics.linearVelocity(tag)` and the synchronous ray
+queries `Physics.cast` / `Physics.castExcluding` — together the
+read-decide-write triple a character controller needs, all inside one frame:
+`tick` reads, returns a command effect beside the model, the drain queues it,
+and the same frame's step applies it.
+
 Read semantics worth knowing: physics reads of a missing tag are **loud
 spanned errors** — games read only tags their `physics` hook declares. (An
 Option-shaped variant return is possible now that Functor Lang has `match`; loud
@@ -231,7 +240,21 @@ right after the physics step, their messages folding through a second
 after it" — so results are same-frame **fresh** (the staleness the original
 frame order implied is designed out). Results ride the B6.5 structured effect
 log, so the fake/replay runners can can/replay raycasts — physics-query logic
-is testable without a world. `shapeCast` follows the same seam later. The F#
+is testable without a world. `shapeCast` follows the same seam later.
+
+**Queries — synchronous reads.** `Physics.cast(origin, dir, maxDist)` and
+`Physics.castExcluding(tag, origin, dir, maxDist)` return the same `rayHit`
+record *in place*, as world reads in the `Physics.position` class rather than
+effects: not routed through the `EffectRunner`, not logged, and therefore not
+canned under `FakeEffects`. That is sound because the physics world is
+deterministic state the Timeline reconstructs from recorded declarations and
+commands — a read of it is not an environment read. Use the synchronous form
+when the decision happens where the read happens (a controller in `tick`); use
+the deferred effect when you want this frame's post-step world. `castExcluding`
+skips one body's collider so a probe fired from inside a character's own capsule
+finds the ground instead of itself; excluding an absent tag excludes nothing.
+
+The F#
 sketch (the `Effect.httpGet` shape: token-keyed registry,
 result delivered as a message next drain):
 

--- a/docs/physics.md
+++ b/docs/physics.md
@@ -160,7 +160,9 @@ same class provides `Physics.linearVelocity(tag)` and the synchronous ray
 queries `Physics.cast` / `Physics.castExcluding` — together the
 read-decide-write triple a character controller needs, all inside one frame:
 `tick` reads, returns a command effect beside the model, the drain queues it,
-and the same frame's step applies it.
+and the next step applies it — normally this frame's, though a frame whose 60 Hz
+accumulator is short of a full step does not step at all, and the command lands
+on the following one.
 
 Read semantics worth knowing: physics reads of a missing tag are **loud
 spanned errors** — games read only tags their `physics` hook declares. (An

--- a/functor-prelude/prelude/physics.funi
+++ b/functor-prelude/prelude/physics.funi
@@ -14,6 +14,8 @@ type tag
 
 /// The live world-space position of a body.
 type position = { x: float, y: float, z: float }
+/// The live linear velocity of a body, in world units per second.
+type velocity = { x: float, y: float, z: float }
 /// A raycast result with hit position, normal, distance, and body tag.
 ///
 /// For a miss, `hit` is false and the remaining fields are zeroed.
@@ -73,6 +75,29 @@ let scene : (Vec3.t, List<body>) => world
 
 /// Read a body's live, stepped world position.
 let position : (tag) => position
+
+/// Read a body's live, stepped linear velocity.
+///
+/// The read counterpart of `Physics.setVelocity`. (`Physics.velocity` is the
+/// body-builder attribute that sets an *initial* velocity.)
+let linearVelocity : (tag) => velocity
+
+/// Cast a ray against the world and get the nearest hit immediately.
+///
+/// Unlike `Physics.raycast` — an effect whose answer arrives through `update`
+/// after the step — this answers in place, so `tick` can branch on it while
+/// deciding. It reads the world as of the last step, like `Physics.position`:
+/// in `tick` that is the previous step, in `draw` this frame's. A miss is
+/// `hit: false` with zeroed fields, not an error. `dir` need not be
+/// normalized, so `maxDist` is in world units.
+let cast : (Vec3.t, Vec3.t, float) => rayHit
+
+/// `Physics.cast`, ignoring one body — the grounding probe.
+///
+/// A ray cast from inside a character's own capsule would otherwise hit that
+/// capsule at distance 0 and report the character standing on itself. Excluding
+/// a tag that isn't in the world excludes nothing.
+let castExcluding : (tag, Vec3.t, Vec3.t, float) => rayHit
 
 /// Apply a body's live transform to a scene node.
 ///

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -6482,8 +6482,8 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
             "let main = () => Physics.cast(Vec3.make(0.0, 10.0, 0.0), \
              Vec3.make(0.0, -1.0, 0.0), 100.0)",
         );
-        assert_eq!(field(&hit, "hit"), Value::Bool(true));
-        assert_eq!(field(&hit, "tag"), Value::String(Rc::from("ball")));
+        assert!(matches!(field(&hit, "hit"), Value::Bool(true)));
+        assert!(matches!(field(&hit, "tag"), Value::String(s) if &*s == "ball"));
         assert!((num(&hit, "ny") - 1.0).abs() < 1e-5, "sphere top normal is +Y");
         assert!(num(&hit, "distance") > 0.0);
 
@@ -6492,7 +6492,7 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
             "let main = () => Physics.castExcluding(Physics.tag(\"ball\"), \
              Vec3.make(0.0, 10.0, 0.0), Vec3.make(0.0, -1.0, 0.0), 100.0)",
         );
-        assert_eq!(field(&floor, "tag"), Value::String(Rc::from("floor")));
+        assert!(matches!(field(&floor, "tag"), Value::String(s) if &*s == "floor"));
         assert!(
             num(&floor, "distance") > num(&hit, "distance"),
             "the floor is further than the ball in front of it"
@@ -6503,9 +6503,9 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
             "let main = () => Physics.cast(Vec3.make(0.0, 10.0, 0.0), \
              Vec3.make(0.0, 1.0, 0.0), 100.0)",
         );
-        assert_eq!(field(&miss, "hit"), Value::Bool(false));
+        assert!(matches!(field(&miss, "hit"), Value::Bool(false)));
         assert_eq!(num(&miss, "distance"), 0.0);
-        assert_eq!(field(&miss, "tag"), Value::String(Rc::from("")));
+        assert!(matches!(field(&miss, "tag"), Value::String(s) if s.is_empty()));
 
         crate::physics::remove_world(crate::physics::DEFAULT_WORLD);
     }
@@ -6525,25 +6525,29 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
             "{at}let probe = (p) => Physics.cast(origin(p), {down}, 10.0)\n\
              let main = () => probe(Physics.position(\"ball\"))"
         ));
-        assert_eq!(field(&selfhit, "tag"), Value::String(Rc::from("ball")));
+        assert!(matches!(field(&selfhit, "tag"), Value::String(s) if &*s == "ball"));
 
         let ground = eval(&format!(
             "{at}let probe = (p) => \
                Physics.castExcluding(Physics.tag(\"ball\"), origin(p), {down}, 10.0)\n\
              let main = () => probe(Physics.position(\"ball\"))"
         ));
-        assert_eq!(field(&ground, "tag"), Value::String(Rc::from("floor")));
-        assert_eq!(field(&ground, "hit"), Value::Bool(true));
+        assert!(matches!(field(&ground, "tag"), Value::String(s) if &*s == "floor"));
+        assert!(matches!(field(&ground, "hit"), Value::Bool(true)));
         // Standing on the floor: the probe reaches it within the ball's radius.
         let d = num(&ground, "distance");
         assert!(d > 0.0 && d < 1.0, "grounded distance = {d}");
 
-        // Excluding a tag that isn't in the world excludes nothing.
+        // Excluding a tag that isn't in the world excludes nothing: the ray
+        // still hits the nearest body along it (the ball resting on the
+        // floor), exactly as a plain `Physics.cast` would. This is what lets a
+        // not-yet-spawned character probe cleanly on its first frame instead
+        // of erroring.
         let unknown = eval(
             "let main = () => Physics.castExcluding(Physics.tag(\"nobody\"), \
              Vec3.make(0.0, 10.0, 0.0), Vec3.make(0.0, -1.0, 0.0), 100.0)",
         );
-        assert_eq!(field(&unknown, "tag"), Value::String(Rc::from("floor")));
+        assert!(matches!(field(&unknown, "tag"), Value::String(s) if &*s == "ball"));
 
         crate::physics::remove_world(crate::physics::DEFAULT_WORLD);
     }

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -2146,6 +2146,51 @@ fn register_physics(reg: &mut crate::host_registry::Registry) {
             None => Err(no_body(&tag)),
         },
     );
+    // The read counterpart of the `Physics.setVelocity` command. Named
+    // `linearVelocity` because `Physics.velocity` is already the body-builder
+    // attribute (an *initial* velocity), and a read and a builder must not
+    // share a name.
+    reg.fn1(
+        "Physics.linearVelocity",
+        "Physics.linearVelocity(tag)",
+        |tag: std::rc::Rc<str>| match live_velocity(&tag) {
+            Some(v) => Ok(Value::Record(Rc::new(vec![
+                ("x".to_string(), Value::Number(v[0] as f64)),
+                ("y".to_string(), Value::Number(v[1] as f64)),
+                ("z".to_string(), Value::Number(v[2] as f64)),
+            ]))),
+            None => Err(no_body(&tag)),
+        },
+    );
+    // SYNCHRONOUS world queries — the character-controller surface. Unlike
+    // `Physics.raycast` (an Effect deferred past the step, so its answer
+    // reaches `tick` a frame late) these answer in-place, in the same class as
+    // `Physics.position`: a direct read of the ACTIVE world as of the last
+    // step, NOT an environment read. That is why they are not routed through
+    // the `EffectRunner` and not logged — the physics world is deterministic
+    // state reconstructed from the Timeline's recorded declarations and
+    // commands, so a replayed frame reads back exactly what it read live.
+    //
+    // In `tick` these see last step's world; in `draw`, this frame's. That one
+    // step of read latency is inherent to read → decide → step and is what
+    // every fixed-step controller works against.
+    reg.fn3(
+        "Physics.cast",
+        "Physics.cast(origin, dir, maxDist)",
+        |origin: FunctorLangVec3, dir: FunctorLangVec3, max_dist: f64| {
+            sync_cast(origin, dir, max_dist, None, "Physics.cast")
+        },
+    );
+    // Excludes the named body, so a character can probe out of its own
+    // collider — a downward ray from inside a capsule would otherwise hit that
+    // capsule at distance 0 and report standing on itself.
+    reg.fn4(
+        "Physics.castExcluding",
+        "Physics.castExcluding(tag, origin, dir, maxDist)",
+        |tag: std::rc::Rc<str>, origin: FunctorLangVec3, dir: FunctorLangVec3, max_dist: f64| {
+            sync_cast(origin, dir, max_dist, Some(&tag), "Physics.castExcluding")
+        },
+    );
     // Scene LAST (subject-last), so it pipes: the way Functor Lang draws a physics body —
     // `Scene.cube() |> Scene.lit(…) |> Physics.transformed(crateTag)`
     // places the visual at the body's live pose (position + rotation).
@@ -4720,6 +4765,39 @@ fn live_transform(tag: &str) -> Option<([f32; 3], [f32; 4])> {
     physics::with_world(physics::active_world(), |w| w.body_transform(tag)).flatten()
 }
 
+/// Live linear velocity of a body in the ACTIVE world — the read counterpart
+/// of `Physics.setVelocity`, on the same world-scope rules as
+/// [`live_transform`].
+fn live_velocity(tag: &str) -> Option<[f32; 3]> {
+    physics::with_world(physics::active_world(), |w| w.body_velocity(tag)).flatten()
+}
+
+/// A synchronous ray query against the ACTIVE world, shared by `Physics.cast`
+/// and `Physics.castExcluding`. Returns the same record shape the deferred
+/// `Physics.raycast` effect hands its tagger (`ray_result_value`), so the two
+/// paths can never drift; a miss is `hit: false` with zeroed fields rather than
+/// an error, because "nothing there" is an ordinary answer a controller
+/// branches on.
+fn sync_cast(
+    origin: FunctorLangVec3,
+    dir: FunctorLangVec3,
+    max_dist: f64,
+    exclude: Option<&str>,
+    what: &str,
+) -> Result<Value, String> {
+    let (ox, oy, oz) = origin.0;
+    let (dx, dy, dz) = dir.0;
+    if [dx, dy, dz] == [0.0, 0.0, 0.0] {
+        return Err(format!("{what}: the direction must not be zero"));
+    }
+    let max_dist = positive(max_dist, &format!("{what} maxDist"))? as f32;
+    let hit = physics::with_world(physics::active_world(), |w| {
+        w.raycast_excluding([ox, oy, oz], [dx, dy, dz], max_dist, exclude)
+    })
+    .flatten();
+    Ok(ray_result_value(hit).to_functor_lang())
+}
+
 fn no_body(tag: &str) -> String {
     format!(
         "no body tagged \"{tag}\" in the physics world (bodies exist after the \
@@ -6331,6 +6409,240 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
         let scene3d = scene_of(&drawn).expect("a Scene");
         assert!((scene3d.xform.w.y as f64 - y).abs() < 1e-6);
 
+        crate::physics::remove_world(crate::physics::DEFAULT_WORLD);
+    }
+
+    /// A field of a record `Value`, for the synchronous-query tests.
+    fn field(value: &Value, name: &str) -> Value {
+        let Value::Record(fields) = value else {
+            panic!("expected a record, got {}", value.kind_name());
+        };
+        fields
+            .iter()
+            .find(|(k, _)| k == name)
+            .map(|(_, v)| v.clone())
+            .unwrap_or_else(|| panic!("no field `{name}`"))
+    }
+
+    fn num(value: &Value, name: &str) -> f64 {
+        match field(value, name) {
+            Value::Number(n) => n,
+            other => panic!("field `{name}` is {}", other.kind_name()),
+        }
+    }
+
+    /// Declare a floor at y = 0 and a ball, reconcile and step the singleton
+    /// world the way the driver does, and hand back nothing — the world is the
+    /// thread-local the prelude reads.
+    fn step_floor_and_ball(ball_y: f32, steps: usize) {
+        crate::physics::remove_world(crate::physics::DEFAULT_WORLD);
+        let scene = crate::physics::PhysicsScene::create(
+            [0.0, -9.81, 0.0],
+            vec![
+                crate::physics::Body::fixed(
+                    "floor".to_string(),
+                    crate::physics::Shape::Cuboid {
+                        extents: [20.0, 0.2, 20.0],
+                    },
+                )
+                .at([0.0, -0.1, 0.0]),
+                crate::physics::Body::dynamic(
+                    "ball".to_string(),
+                    crate::physics::Shape::Sphere { radius: 0.5 },
+                )
+                .at([0.0, ball_y, 0.0]),
+            ],
+        );
+        crate::physics::with_world(crate::physics::DEFAULT_WORLD, |w| {
+            w.reconcile(&scene);
+            for _ in 0..steps {
+                w.step_fixed();
+            }
+        });
+    }
+
+    // The synchronous character-controller queries: `Physics.linearVelocity`
+    // and `Physics.cast` are plain reads of the stepped world, answering in
+    // place rather than through a tagger — so `tick` can branch on them.
+    #[test]
+    fn sync_queries_read_the_stepped_world() {
+        step_floor_and_ball(5.0, 30);
+
+        // The falling ball has picked up downward velocity.
+        let vel = eval("let main = () => Physics.linearVelocity(\"ball\")");
+        let vy = num(&vel, "y");
+        assert!(vy < -1.0, "ball should be falling, vy = {vy}");
+        assert_eq!(num(&vel, "x"), 0.0);
+        assert_eq!(num(&vel, "z"), 0.0);
+
+        // A downward ray from well above hits the nearest body along it — the
+        // still-falling ball, whose top surface faces +Y. Same record shape the
+        // deferred effect hands its tagger.
+        let hit = eval(
+            "let main = () => Physics.cast(Vec3.make(0.0, 10.0, 0.0), \
+             Vec3.make(0.0, -1.0, 0.0), 100.0)",
+        );
+        assert_eq!(field(&hit, "hit"), Value::Bool(true));
+        assert_eq!(field(&hit, "tag"), Value::String(Rc::from("ball")));
+        assert!((num(&hit, "ny") - 1.0).abs() < 1e-5, "sphere top normal is +Y");
+        assert!(num(&hit, "distance") > 0.0);
+
+        // Excluding the ball lets the same ray through to the floor behind it.
+        let floor = eval(
+            "let main = () => Physics.castExcluding(Physics.tag(\"ball\"), \
+             Vec3.make(0.0, 10.0, 0.0), Vec3.make(0.0, -1.0, 0.0), 100.0)",
+        );
+        assert_eq!(field(&floor, "tag"), Value::String(Rc::from("floor")));
+        assert!(
+            num(&floor, "distance") > num(&hit, "distance"),
+            "the floor is further than the ball in front of it"
+        );
+
+        // A ray into empty space is a miss, not an error.
+        let miss = eval(
+            "let main = () => Physics.cast(Vec3.make(0.0, 10.0, 0.0), \
+             Vec3.make(0.0, 1.0, 0.0), 100.0)",
+        );
+        assert_eq!(field(&miss, "hit"), Value::Bool(false));
+        assert_eq!(num(&miss, "distance"), 0.0);
+        assert_eq!(field(&miss, "tag"), Value::String(Rc::from("")));
+
+        crate::physics::remove_world(crate::physics::DEFAULT_WORLD);
+    }
+
+    // The grounding probe: cast from inside the character's own collider. The
+    // plain cast hits the character itself; excluding it finds the ground.
+    #[test]
+    fn cast_excluding_skips_the_probing_body() {
+        // Rest the ball on the floor so a probe from its centre has both its
+        // own collider and the floor beneath it.
+        step_floor_and_ball(0.5, 240);
+
+        let down = "Vec3.make(0.0, -1.0, 0.0)";
+        let at = "let origin = (p) => Vec3.make(p.x, p.y, p.z)\n";
+
+        let selfhit = eval(&format!(
+            "{at}let probe = (p) => Physics.cast(origin(p), {down}, 10.0)\n\
+             let main = () => probe(Physics.position(\"ball\"))"
+        ));
+        assert_eq!(field(&selfhit, "tag"), Value::String(Rc::from("ball")));
+
+        let ground = eval(&format!(
+            "{at}let probe = (p) => \
+               Physics.castExcluding(Physics.tag(\"ball\"), origin(p), {down}, 10.0)\n\
+             let main = () => probe(Physics.position(\"ball\"))"
+        ));
+        assert_eq!(field(&ground, "tag"), Value::String(Rc::from("floor")));
+        assert_eq!(field(&ground, "hit"), Value::Bool(true));
+        // Standing on the floor: the probe reaches it within the ball's radius.
+        let d = num(&ground, "distance");
+        assert!(d > 0.0 && d < 1.0, "grounded distance = {d}");
+
+        // Excluding a tag that isn't in the world excludes nothing.
+        let unknown = eval(
+            "let main = () => Physics.castExcluding(Physics.tag(\"nobody\"), \
+             Vec3.make(0.0, 10.0, 0.0), Vec3.make(0.0, -1.0, 0.0), 100.0)",
+        );
+        assert_eq!(field(&unknown, "tag"), Value::String(Rc::from("floor")));
+
+        crate::physics::remove_world(crate::physics::DEFAULT_WORLD);
+    }
+
+    // The control loop a character controller needs closes inside ONE frame:
+    // `tick` reads the world synchronously (position / velocity / grounded),
+    // decides, and returns a command effect; draining that effect queues it,
+    // and the frame's step applies it. No `update` round trip, no second frame
+    // — this is the ordering `FrameCtx::before_physics` → `physics_phase`
+    // performs, spelled out.
+    #[test]
+    fn a_synchronous_read_decide_write_loop_closes_in_one_frame() {
+        step_floor_and_ball(0.5, 240);
+
+        // The "tick": read grounded-ness synchronously, then jump.
+        let src = "let origin = (p) => Vec3.make(p.x, p.y, p.z)\n\
+                   let hitOf = (h) => h.hit\n\
+                   let grounded = (p) => \
+                     hitOf(Physics.castExcluding(Physics.tag(\"ball\"), origin(p), \
+                       Vec3.make(0.0, -1.0, 0.0), 1.0))\n\
+                   let main = () => \
+                     if grounded(Physics.position(\"ball\")) then \
+                       Physics.setVelocity(\"ball\", Vec3.make(0.0, 6.0, 0.0)) \
+                     else \
+                       Effect.none()";
+        let effect = eval(src);
+        let Value::HostData(data) = &effect else {
+            panic!("the grounded read should have produced a command effect");
+        };
+        let tree = &data
+            .as_any()
+            .downcast_ref::<FunctorLangEffect>()
+            .expect("Effect")
+            .0;
+
+        // Draining needs no `update` hook — a command effect carries no tagger.
+        let module = functor_lang::lower(functor_lang::parse("let main = () => 0.0").unwrap())
+            .unwrap();
+        let session = functor_lang::Session::load(&module, &mut FunctorHost)
+            .unwrap_or_else(|f| panic!("load failed: {}", f.error.message));
+        let mut model = Value::Number(0.0);
+        let mut log = EffectLog::new();
+        let mut runner = FakeEffects::new(0.0, vec![]);
+        let deferred = drain_effects(
+            &session,
+            &mut model,
+            tree.clone(),
+            &mut runner,
+            &mut log,
+            &mut |m| panic!("unexpected report: {m}"),
+            false,
+        );
+        assert!(
+            deferred.is_empty(),
+            "a command effect must not defer past the step"
+        );
+
+        // The same frame's step applies it: the ball is now rising.
+        crate::physics::with_world(crate::physics::DEFAULT_WORLD, |w| {
+            w.step_frame(1.0 / 60.0);
+            let v = w.body_velocity("ball").unwrap();
+            assert!(v[1] > 0.0, "the jump should have landed this frame: {v:?}");
+        });
+
+        crate::physics::remove_world(crate::physics::DEFAULT_WORLD);
+    }
+
+    // Boundary errors mirror the deferred `Physics.raycast` arm, and an
+    // undeclared tag is loud like `Physics.position`.
+    #[test]
+    fn sync_query_boundaries_are_rejected() {
+        crate::physics::remove_world(crate::physics::DEFAULT_WORLD);
+        assert!(
+            fail_message("let main = () => Physics.linearVelocity(\"ghost\")")
+                .contains("no body tagged \"ghost\""),
+            "an undeclared tag should be a loud error"
+        );
+        assert_eq!(
+            fail_message(
+                "let main = () => Physics.cast(Vec3.make(0.0, 0.0, 0.0), \
+                 Vec3.make(0.0, 0.0, 0.0), 10.0)"
+            ),
+            "Physics.cast: the direction must not be zero"
+        );
+        assert_eq!(
+            fail_message(
+                "let main = () => Physics.castExcluding(Physics.tag(\"a\"), \
+                 Vec3.make(0.0, 0.0, 0.0), Vec3.make(0.0, 0.0, 0.0), 10.0)"
+            ),
+            "Physics.castExcluding: the direction must not be zero"
+        );
+        assert!(
+            fail_message(
+                "let main = () => Physics.cast(Vec3.make(0.0, 0.0, 0.0), \
+                 Vec3.make(0.0, -1.0, 0.0), 0.0)"
+            )
+            .contains("Physics.cast maxDist must be positive"),
+            "a non-positive maxDist should be rejected"
+        );
         crate::physics::remove_world(crate::physics::DEFAULT_WORLD);
     }
 

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -4787,10 +4787,28 @@ fn sync_cast(
 ) -> Result<Value, String> {
     let (ox, oy, oz) = origin.0;
     let (dx, dy, dz) = dir.0;
-    if [dx, dy, dz] == [0.0, 0.0, 0.0] {
-        return Err(format!("{what}: the direction must not be zero"));
+    // Validate with the SAME predicate the query itself applies (`World::
+    // raycast_excluding` normalizes and bails when the length is not finite
+    // and positive). Checking the components against exact zero instead would
+    // let three cases through to be silently answered as a MISS: non-finite
+    // components, finite-but-tiny vectors whose f32 norm underflows to zero,
+    // and huge ones whose squares overflow to infinity. For a grounding probe
+    // a silent miss is the worst outcome — `onGround` is false forever and the
+    // character simply never jumps — so these are loud errors instead.
+    let d = [dx as f32, dy as f32, dz as f32];
+    let len = (d[0] * d[0] + d[1] * d[1] + d[2] * d[2]).sqrt();
+    if !(len.is_finite() && len > 0.0) {
+        return Err(format!(
+            "{what}: the direction must be finite and non-zero, got ({dx}, {dy}, {dz})"
+        ));
     }
-    let max_dist = positive(max_dist, &format!("{what} maxDist"))? as f32;
+    // Formatted inline rather than via `positive(.., &format!(..))`: this is
+    // the per-frame controller path, and that helper's label allocates a
+    // String on every successful cast.
+    if !(max_dist > 0.0) {
+        return Err(format!("{what} maxDist must be positive, got {max_dist}"));
+    }
+    let max_dist = max_dist as f32;
     let hit = physics::with_world(physics::active_world(), |w| {
         w.raycast_excluding([ox, oy, oz], [dx, dy, dz], max_dist, exclude)
     })
@@ -6472,8 +6490,11 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
         let vel = eval("let main = () => Physics.linearVelocity(\"ball\")");
         let vy = num(&vel, "y");
         assert!(vy < -1.0, "ball should be falling, vy = {vy}");
-        assert_eq!(num(&vel, "x"), 0.0);
-        assert_eq!(num(&vel, "z"), 0.0);
+        // Tolerance rather than exact equality: free fall under [0,-9.81,0]
+        // happens to leave these bit-zero today, but any contact would make an
+        // exact assertion flake.
+        assert!(num(&vel, "x").abs() < 1e-6);
+        assert!(num(&vel, "z").abs() < 1e-6);
 
         // A downward ray from well above hits the nearest body along it — the
         // still-falling ball, whose top surface faces +Y. Same record shape the
@@ -6625,19 +6646,54 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
                 .contains("no body tagged \"ghost\""),
             "an undeclared tag should be a loud error"
         );
+        // The docs promise an empty world answers a cast as an ordinary miss
+        // rather than erroring — the asymmetry with the read above is
+        // deliberate: a tag read needs an identity that exists, a spatial
+        // query does not, and "nothing there" is what a controller branches on.
+        let empty = eval(
+            "let main = () => Physics.cast(Vec3.make(0.0, 10.0, 0.0), \
+             Vec3.make(0.0, -1.0, 0.0), 100.0)",
+        );
+        assert!(matches!(field(&empty, "hit"), Value::Bool(false)));
         assert_eq!(
             fail_message(
                 "let main = () => Physics.cast(Vec3.make(0.0, 0.0, 0.0), \
                  Vec3.make(0.0, 0.0, 0.0), 10.0)"
             ),
-            "Physics.cast: the direction must not be zero"
+            "Physics.cast: the direction must be finite and non-zero, got (0, 0, 0)"
         );
         assert_eq!(
             fail_message(
                 "let main = () => Physics.castExcluding(Physics.tag(\"a\"), \
                  Vec3.make(0.0, 0.0, 0.0), Vec3.make(0.0, 0.0, 0.0), 10.0)"
             ),
-            "Physics.castExcluding: the direction must not be zero"
+            "Physics.castExcluding: the direction must be finite and non-zero, got (0, 0, 0)"
+        );
+        // A DEGENERATE but nonzero direction is rejected too, rather than
+        // silently answered as a miss. 1e-27 (built by multiplication —
+        // Functor Lang has no exponent literal) is finite in f64, but its f32
+        // square underflows to zero, so the normalization inside the query
+        // would bail and report `hit: false` — indistinguishable from open
+        // sky, and a grounding probe built on it would never see the floor.
+        assert!(
+            fail_message(
+                "let tiny = 0.000000001 * 0.000000001 * 0.000000001\n\
+                 let main = () => Physics.cast(Vec3.make(0.0, 0.0, 0.0), \
+                 Vec3.make(tiny, 0.0, 0.0), 10.0)"
+            )
+            .contains("must be finite and non-zero"),
+            "a direction whose f32 norm underflows should be a loud error"
+        );
+        // The same at the other end: squaring 1e30 in f32 overflows to
+        // infinity, which the query also treats as unusable.
+        assert!(
+            fail_message(
+                "let huge = 10000000000.0 * 10000000000.0 * 10000000000.0\n\
+                 let main = () => Physics.cast(Vec3.make(0.0, 0.0, 0.0), \
+                 Vec3.make(huge, 0.0, 0.0), 10.0)"
+            )
+            .contains("must be finite and non-zero"),
+            "a direction whose f32 square overflows should be a loud error"
         );
         assert!(
             fail_message(

--- a/runtime/functor-runtime-common/src/physics/world.rs
+++ b/runtime/functor-runtime-common/src/physics/world.rs
@@ -535,8 +535,14 @@ impl World {
         }
         let ray = rapier3d::prelude::Ray::new(vec3(origin), d / len);
         let mut filter = QueryFilter::default();
-        if let Some((_, collider)) = exclude.and_then(|tag| self.tags.get(tag)) {
-            filter = filter.exclude_collider(*collider);
+        // Exclude the RIGID BODY, not the single collider the tag maps to: a
+        // tagged body owns exactly one collider today, but the moment one
+        // gains a second (a compound shape, or a separate sensor volume) a
+        // collider-level filter would quietly let the self-probe hit the
+        // character again. Excluding the body costs the same and carries no
+        // such invariant.
+        if let Some((body, _)) = exclude.and_then(|tag| self.tags.get(tag)) {
+            filter = filter.exclude_rigid_body(*body);
         }
         let pipeline = self.broad_phase.as_query_pipeline(
             self.narrow_phase.query_dispatcher(),

--- a/runtime/functor-runtime-common/src/physics/world.rs
+++ b/runtime/functor-runtime-common/src/physics/world.rs
@@ -510,17 +510,39 @@ impl World {
     /// filter) — an invisible trigger volume can occlude a solid body behind
     /// it.
     pub fn raycast(&self, origin: [f32; 3], dir: [f32; 3], max_dist: f32) -> Option<RayHit> {
+        self.raycast_excluding(origin, dir, max_dist, None)
+    }
+
+    /// [`Self::raycast`], but ignoring one body's collider.
+    ///
+    /// This is what a self-probe needs: a grounding ray cast from inside a
+    /// character's own capsule would otherwise hit that capsule at distance 0
+    /// and report the character standing on itself. An `exclude` tag that
+    /// isn't in the world excludes nothing — a body that doesn't exist can't
+    /// be hit anyway, so a not-yet-spawned character probes cleanly instead of
+    /// erroring on its first frame.
+    pub fn raycast_excluding(
+        &self,
+        origin: [f32; 3],
+        dir: [f32; 3],
+        max_dist: f32,
+        exclude: Option<&str>,
+    ) -> Option<RayHit> {
         let d = vec3(dir);
         let len = d.length();
         if !(len.is_finite() && len > 0.0) {
             return None;
         }
         let ray = rapier3d::prelude::Ray::new(vec3(origin), d / len);
+        let mut filter = QueryFilter::default();
+        if let Some((_, collider)) = exclude.and_then(|tag| self.tags.get(tag)) {
+            filter = filter.exclude_collider(*collider);
+        }
         let pipeline = self.broad_phase.as_query_pipeline(
             self.narrow_phase.query_dispatcher(),
             &self.bodies,
             &self.colliders,
-            QueryFilter::default(),
+            filter,
         );
         let (col_handle, hit) = pipeline.cast_ray_and_get_normal(&ray, max_dist, true)?;
         // Reverse handle→tag lookup: scenes are small; a scan beats carrying


### PR DESCRIPTION
A game jam found that a 3D character controller could not be built on the
`physics` hook, and the jam entry fell back to hand-rolled kinematics in `tick`.
This adds the smallest surface that unblocks it. It reports three blockers; two
turn out to be **overstated** and one is **real**.

## Assessment of the reported blockers

**1. "Physics state reads are only available to `draw`." — Corrected.**
`Physics.position` is not `draw`-only. It resolves through `live_transform` →
`physics::with_world(physics::active_world(), …)`: a direct read of the
thread-local live world, callable from **any** entry point, `tick` included.
The true statement is narrower — because `step_physics` runs *after* `tick`, a
read in `tick` sees the previous step. That one step of read latency is inherent
to read → decide → step in any fixed-step simulation, not a Functor limitation.
The docs and skill overstated this as "valid only in `draw`", and the jam entry's
notes cite exactly that wording ("Both the manual and the skill are explicit: in
`tick` you see *last* frame's stepped world") as reason #1 for abandoning the
hook. **So the misleading wording is itself a jam finding** — it cost a working
capability, not just clarity. This PR corrects it in
`.claude/skills/functor-lang/SKILL.md` and `docs/physics.md`: the reads are valid
in any entry point, with one step of read latency in `tick`.

**2. "Writes are `Effect`s, so control is a round trip through `update`." —
Corrected.** Physics commands are `Effect`-typed but are *not* environment
effects. `drain_effects` handles `EffectTree::Physics` as fire-and-forget: it
queues directly onto the world, never routes through the `EffectRunner`, and
explicitly requires no `update` hook ("tagger-less physics commands must not be
dropped over a missing hook"). Draining happens in `absorb`, immediately after
`tick` and *before* `physics_phase`; the command applies on the step's first
substep, after reconcile. So a `Physics.setVelocity` returned from `tick` takes
hold in **that same frame's step** — zero extra frames, no `update` involved.

**3. "There is no synchronous query API." — Confirmed, and it was two gaps.**
- No synchronous ray query. `Physics.raycast` is an `Effect` *and* deliberately
  deferred past the step, so its answer reaches game logic through `update`
  after the step — fresh for `draw`, but a frame late for a decision in `tick`.
- **No velocity read at all.** `Physics.velocity` is a body *builder* (initial
  velocity), not an accessor. `World::body_velocity` already existed in Rust but
  was never exposed to Functor Lang.

## What this adds

```
Physics.linearVelocity(tag)                        // {x, y, z}, live stepped world
Physics.cast(origin, dir, maxDist)                 // -> rayHit, synchronously
Physics.castExcluding(tag, origin, dir, maxDist)   // ...ignoring one body
```

`castExcluding` is the grounding probe: a ray from inside a character's own
capsule would otherwise hit that capsule at distance 0 and report the character
standing on itself. Excluding a tag that isn't in the world excludes nothing, so
a not-yet-spawned character probes cleanly on its first frame instead of
erroring.

The controller loop is now one frame:

```functor
let tick = (m, dt, tts) =>
  match m.started with          // guard the FIRST frame: nothing reconciled yet
  | false => { m with started: true }
  | true =>
    let pos = Physics.position(playerTag) in
    let vel = Physics.linearVelocity(playerTag) in
    let onGround = probe(pos).hit in
    let vy = if onGround && m.jump then 6.0 else vel.y in
    (m, Physics.setVelocity(playerTag, Vec3.make(vel.x, vy, vel.z)))
```

## Design notes

**No protocol change and no producer edits.** All three are typed-registry
entries, so desktop and wasm producers pick them up with no plumbing. The
alternative shapes considered — threading a physics snapshot into `tick` like
`sampledInput`, or wrapping rapier's `KinematicCharacterController` — both need
producer arity changes or a new protocol value, and neither is necessary once
the reads are synchronous.

**Determinism.** These are *world* reads, not environment reads: not routed
through the `EffectRunner` and not logged. That is the same class as
`Physics.position`, which is already load-bearing in every physics example's
`draw`, and the same reasoning the codebase already applies to physics commands
("per-frame *inputs* recorded by the physics Timeline, not environment reads
that replay must fake"). The world is deterministic state the Timeline
reconstructs from recorded declarations and commands, and replay re-steps
physics for real, so a replayed frame reads back what it read live. Reads use
`active_world()`, so a time-travel dry-run scope reroutes them to its projected
world exactly like the existing reads. Worth naming as a *bet* rather than a
proof: the deferred `Physics.raycast` is exact under replay by construction
(recorded values), whereas the sync path depends on the rapier world replaying
bit-identically — the same bet `Physics.position` already makes.

**Honest tradeoff.** Because they are world reads and not effects, these are
*not* canned under `FakeEffects` the way the `Physics.raycast` effect is.
Controller logic built on them needs a real (cheap, headless) world to test
rather than a fake runner — the tests here build one in a few lines. A
pure-function controller remains more unit-testable, so the jam's testability
point is only partly addressed. That is a deliberate trade for synchronous
reads.

**Reuse.** `sync_cast` returns `ray_result_value(...).to_functor_lang()` — the
exact record the deferred effect hands its tagger, so the two paths cannot
drift. `World::raycast` now delegates to `raycast_excluding(.., None)`.

**Error policy.** `Physics.linearVelocity` raises on an unknown tag while
`Physics.cast` answers a miss. That asymmetry is deliberate and now tested: a
tag read needs an identity that exists; a spatial query does not, and "nothing
there" is the ordinary answer a controller branches on.

## Cross-references

**The `physics`-hook freeze (audited separately) — verified, and these reads are
mostly immune.** A sibling audit (see #490) reports that reading bodies inside
the `physics` hook wedges the runtime permanently. I verified the mechanism
rather than assuming it, and the precise story matters here:

- **It is not a deadlock.** Nothing blocks. `with_world` takes a
  `RefCell::borrow_mut`, which would *panic* on re-entry — and that panic is
  unreachable anyway, because the `physics` hook is evaluated by
  `session.call("physics", …)` in `step_physics` entirely *outside* any world
  borrow; the world is only entered afterwards, in `physics_rt.advance`.
- **What actually happens is a self-sustaining error loop.** A read that raises
  inside the hook makes the hook return `Err`, so `step_physics` reports a
  `frame_error` and returns 0 steps, so the world is never reconciled, so the
  body never exists, so the next frame raises again — forever, with the message
  deduped. Physics silently stops advancing, which *looks* like a hang.
- **Do the new reads share it?** Split verdict, from the code:
  `Physics.linearVelocity` — **yes, identically**: it raises `no_body` through
  the same path as `Physics.position`. `Physics.cast` / `Physics.castExcluding`
  — **no**: they never raise for an absent body or an absent world (a miss is
  `hit: false`; an unknown exclude tag excludes nothing), so they cannot start
  the loop. Inside the hook they would read the pre-reconcile world and return
  misses — useless there, but harmless. (After this PR's review fixes they *can*
  raise on a malformed direction/`maxDist`, which is an author bug caught
  immediately, not a world-state race.)

Fixing the underlying freeze is out of scope here; this PR neither worsens nor
addresses it.

**`Physics.tryPosition` is the natural follow-up.** The bow jam entry asks for an
`Option.t`-returning read because reading a body on the frame it spawns raises —
a real crash class. This PR's surface makes that gap sharper, not softer:
`linearVelocity` adds a second raising read, and the first-frame guard in the
example above exists only to dodge it. An `Option`-shaped read (and the matching
`tryLinearVelocity`) would let the guard disappear and would also defuse the
error-loop above at its source, since a `None` cannot wedge the hook. Recommended
as the next slice on top of this one.

**Possible conflict with #490.** That PR audits the same
`.claude/skills/functor-lang/SKILL.md` and rewrites the physics-reads paragraph
with overlapping claims (reads work in any entry point; freshness follows when
the caller runs). Its hunks sit ~60–120 lines below the ones here, so git will
likely auto-merge, but the two will then state the same rule twice in adjacent
paragraphs. Deliberately **not** edited here to avoid duplicating that audit —
whichever lands second should fold the two passages together.

## Bench

`frame_bench`, release, base (`main` @ 4d663e5) vs this branch, back-to-back on
the same machine, 3 runs each, **min** column. Machine essentially quiet.

| cells | base min µs | branch min µs | Δ wall | allocs/frame | bytes/frame |
| --- | --- | --- | --- | --- | --- |
| 400 (20×20) | 504.3 | 506.7 | +0.5% | 13877 → 13877 | 843379 → 843379 |
| 1600 (40×40) | 1965.8 | 1982.2 | +0.8% | 54717 → 54717 | 3307219 → 3307219 |
| 3136 (56×56) | 3825.4 | 3892.9 | +1.8% | 106973 → 106973 | 6460243 → 6460243 |

**allocs/frame and bytes/frame are EXACTLY flat** at every size — the acceptance
numbers, and the expected result for read-only registry additions that no
benchmarked frame calls.

Wall-clock deltas are noise: run-to-run spread on a single side reached 9.6% at
400 cells and 5.0% at 3136, so +0.5–1.8% is well inside it. Corroborating this,
a confirming 2-run pass after the review fixes landed came in *faster than base*
(446–3466 µs min) purely because the machine had quieted further — same
allocs/bytes to the byte. Treat only the allocation columns as signal.

## Verification

- `cargo test -p functor_runtime_common` — **477 + 8 pass, exit 0** (re-run after
  the review fixes)
- `npm run check:docs` — passes (exit 0)
- `.funi` ↔ registry drift test (hard bijection, arity-checked) — passes
- The new SKILL.md example verified through `functor-lang parse`, not by eye

New tests in `functor_runtime_common`:
- `sync_queries_read_the_stepped_world` — velocity of a falling body, floor hit
  with +Y normal, miss is `hit: false` and not an error
- `cast_excluding_skips_the_probing_body` — plain cast hits self, excluding finds
  the floor, unknown exclude tag excludes nothing
- `a_synchronous_read_decide_write_loop_closes_in_one_frame` — the money test:
  synchronous grounded read → command effect → drain (no `update`) → same
  frame's step applies the jump
- `sync_query_boundaries_are_rejected` — zero / underflowing / overflowing
  direction, non-positive maxDist, undeclared tag, and the empty-world miss

## Review dispositions

`/xreview` (Claude Opus subagent + Codex CLI, `main...HEAD`). Codex: no
Critical/High. Claude: one High, several Medium. **Fixed** in dd30122:

- **[AGREED — both engines] Degenerate directions became silent misses.**
  `sync_cast` compared components against exact zero, so non-finite,
  underflowing (`f32` norm → 0) and overflowing (square → ∞) directions passed
  validation and were then quietly answered as `hit: false` by the query's own
  normalization guard. For a grounding probe that is the worst failure mode —
  `onGround` false forever, character never jumps, no diagnostic. Now validated
  with the *same* predicate the query applies, so it is a loud error; two new
  tests pin it.
- **[High, Claude] The SKILL.md controller example did not parse.** Local `let`
  requires `in`. Confirmed with `functor-lang parse` (`expected \`in\`, found
  \`let\``) — a broken snippet in the source of truth LLMs copy from. Fixed and
  re-verified through the parser. Codex independently flagged the same example
  for a different real defect (it read physics before the first reconcile, so it
  would raise on frame 1); the rewritten example guards the first frame.
- **[Medium, Claude] `exclude_collider` encoded a one-collider-per-body
  invariant.** Correct today, silently wrong the moment a body gains a compound
  shape or sensor volume. Switched to `exclude_rigid_body` — same cost, no
  invariant. (Codex explicitly did not count this as a defect; taken anyway as a
  free robustness win.)
- **[Low, Codex] `positive(.., &format!(..))` allocated a label String on every
  successful cast** — on the per-frame controller path. Validated inline.
- **[Low, Claude] Exact float equality on a simulated velocity** — replaced with
  a tolerance.
- **[Low, Claude] "This frame's step applies it" overstated** the zero-substep
  case. Softened in both docs.
- **[Low, Claude] Untested doc claim** that an empty world yields a miss — now
  asserted.

**Not taken, with reasons:**

- **Raise on an unknown `castExcluding` tag** (Claude, Medium). Rejected: Codex
  judged the error-policy split defensible, and the lenient behavior is the
  documented, tested contract that lets a not-yet-spawned character probe on its
  first frame. The `tryPosition` follow-up above pushes toward *more* leniency in
  reads, not less; tightening here would move against it.
- **Rename `Physics.cast` → `castRay`** (Claude, Low) — a fair point given
  `raycast` (the effect) and a roadmapped `shapeCast`, but the three member names
  were specified for this task. Flagging for a naming decision before the API is
  depended on; cheap now, expensive later.
- **Extract a shared `validate_ray` with the deferred `Physics.raycast` arm**
  (Claude, Low). The same degenerate-direction hole is pre-existing there. Left
  alone to keep this diff scoped; the new path is now the stricter of the two,
  and unifying them is a small follow-up.
- **Teach the docs how to test controller logic on the sync path** (Claude,
  Medium) — a real doc gap, but it wants the fake-world seam described under
  "follow-up gaps" rather than a paragraph here.

## Not included / follow-up gaps

- **A character-controller example.** A visual change needing GIF/PNG captures
  and level design; it belongs in its own PR stacked on this one.
- **Synchronous world reads are not canned under `FakeEffects`.** Closing this
  would mean a fake-world seam (a scriptable `World` stand-in the reads resolve
  against) — worth doing, out of scope here.
- **`shapeCast`.** A capsule sweep is what a controller ultimately wants for
  wall collision; a ray only answers "is there ground". `docs/physics.md` already
  parks `shapeCast` behind the same seam, and the synchronous variant should
  follow whenever it lands.
- **Rapier's `KinematicCharacterController`** is available (rapier 0.33 ships it
  unconditionally, unreferenced in the repo). Wrapping it would be a much larger,
  more opinionated surface — deliberately not attempted; these queries let a game
  author the feel itself, which the jam notes argue for ("platformer feel is
  authored, not simulated").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
