### PR TITLE
perf(terrain): hold 72 Hz on Quest with detail maps enabled

### DIFF
--- a/examples/terrain/game.fun
+++ b/examples/terrain/game.fun
@@ -27,7 +27,7 @@ let world =
        Asset.texture("detail-high.jpg"),
        Asset.texture("detail-rock.jpg"),
        Asset.texture("detail-snow.jpg"),
-       24.0)
+       8.0)
   |> Terrain.grass(13.0, 520.0, 5.5, Color.rgb(0.25, 0.46, 0.10))
 
 let terrainBody = Physics.tag("terrain")

--- a/runtime/functor-runtime-common/src/asset/pipelines/texture_pipeline.rs
+++ b/runtime/functor-runtime-common/src/asset/pipelines/texture_pipeline.rs
@@ -2,8 +2,31 @@ use image::ImageFormat;
 
 use crate::{
     asset::{AssetCache, AssetPipeline},
-    texture::{Texture2D, TextureData, TextureFormat, TextureOptions, JPEG, PNG},
+    texture::{
+        Texture2D, TextureData, TextureFormat, TextureOptions, TERRAIN_DETAIL_ANISOTROPY, JPEG, PNG,
+    },
 };
+
+/// Decode an image, or `None` if the bytes are not one we handle.
+///
+/// Unhandled formats and corrupt bytes both fall back to the checkerboard,
+/// never a panic: asset hot-reload can catch a file mid-write, and the render
+/// thread polls asset futures (a panic aborts the runtime). The next save
+/// reloads it again.
+fn decode(bytes: &Vec<u8>) -> Option<TextureData> {
+    let decoded = match image::guess_format(bytes) {
+        Ok(ImageFormat::Png) => PNG.load(bytes),
+        Ok(ImageFormat::Jpeg) => JPEG.load(bytes),
+        other => Err(format!("unhandled format: {:?}", other)),
+    };
+    match decoded {
+        Ok(data) => Some(data),
+        Err(e) => {
+            eprintln!("[texture] cannot decode image: {e}");
+            None
+        }
+    }
+}
 
 pub struct TexturePipeline;
 
@@ -14,21 +37,8 @@ impl AssetPipeline<Texture2D> for TexturePipeline {
         _asset_cache: &AssetCache,
         context: crate::asset::AssetPipelineContext,
     ) -> Texture2D {
-        // Unhandled formats and corrupt bytes both fall back to the
-        // checkerboard, never a panic: asset hot-reload can catch a file
-        // mid-write, and the render thread polls asset futures (a panic
-        // aborts the runtime). The next save reloads it again.
-        let decoded = match image::guess_format(&bytes) {
-            Ok(ImageFormat::Png) => PNG.load(&bytes),
-            Ok(ImageFormat::Jpeg) => JPEG.load(&bytes),
-            other => Err(format!("unhandled format: {:?}", other)),
-        };
-        let texture_data = match decoded {
-            Ok(data) => data,
-            Err(e) => {
-                eprintln!("[texture] cannot decode image: {e}");
-                return self.unloaded_asset(context);
-            }
+        let Some(texture_data) = decode(&bytes) else {
+            return self.unloaded_asset(context);
         };
         Texture2D::init_from_data(
             texture_data,
@@ -43,6 +53,7 @@ impl AssetPipeline<Texture2D> for TexturePipeline {
                 // moves. The fallback checkerboard below deliberately keeps
                 // level 0 so a missing asset still reads as a flat marker.
                 mipmap: true,
+                ..TextureOptions::default()
             },
         )
     }
@@ -50,6 +61,51 @@ impl AssetPipeline<Texture2D> for TexturePipeline {
     fn unloaded_asset(&self, _context: crate::asset::AssetPipelineContext) -> Texture2D {
         let texture_data = TextureData::checkerboard_pattern(8, 8, [0, 255, 0, 255]);
         Texture2D::init_from_data(texture_data, TextureOptions::default())
+    }
+}
+
+/// Terrain detail maps: tiled, sampled almost entirely at grazing angles, and
+/// normalized in the shader against their own mean.
+///
+/// A separate pipeline rather than a flag on the shared one, so the anisotropy
+/// reduction and the mean scan apply to exactly the four maps that need them
+/// and to nothing else in the engine. The asset cache keys decoded assets per
+/// pipeline (bytes are still shared), so this costs no extra download.
+pub struct TerrainDetailPipeline;
+
+impl AssetPipeline<Texture2D> for TerrainDetailPipeline {
+    fn process(
+        &self,
+        bytes: Vec<u8>,
+        _asset_cache: &AssetCache,
+        context: crate::asset::AssetPipelineContext,
+    ) -> Texture2D {
+        let Some(texture_data) = decode(&bytes) else {
+            return self.unloaded_asset(context);
+        };
+        Texture2D::init_from_data(
+            texture_data,
+            TextureOptions {
+                wrap: true,
+                linear: true,
+                mipmap: true,
+                anisotropy: TERRAIN_DETAIL_ANISOTROPY,
+                compute_average: true,
+            },
+        )
+    }
+
+    fn unloaded_asset(&self, _context: crate::asset::AssetPipelineContext) -> Texture2D {
+        // White: the shader divides by the average, so a neutral stand-in
+        // leaves the band color untouched while the real map streams in.
+        let texture_data = TextureData::solid_color([255, 255, 255, 255]);
+        Texture2D::init_from_data(
+            texture_data,
+            TextureOptions {
+                compute_average: true,
+                ..TextureOptions::default()
+            },
+        )
     }
 }
 

--- a/runtime/functor-runtime-common/src/scene3d/mod.rs
+++ b/runtime/functor-runtime-common/src/scene3d/mod.rs
@@ -48,6 +48,9 @@ pub use texture_description::*;
 pub struct SceneContext {
     model_pipeline: Arc<BuiltAssetPipeline<Model>>,
     texture_pipeline: Arc<BuiltAssetPipeline<Texture2D>>,
+    /// Terrain detail maps decode through their own pipeline so their reduced
+    /// anisotropy and mean-color scan stay scoped to them.
+    terrain_detail_pipeline: Arc<BuiltAssetPipeline<Texture2D>>,
     cube: RefCell<Box<dyn Geometry>>,
     cylinder: RefCell<Box<dyn Geometry>>,
     sphere: RefCell<Box<dyn Geometry>>,
@@ -210,6 +213,7 @@ impl SceneContext {
     pub fn evict_asset(&self, path: &str) {
         self.model_pipeline.evict(path);
         self.texture_pipeline.evict(path);
+        self.terrain_detail_pipeline.evict(path);
         self.raw_image_pipeline.evict(path);
         self.heightmap_pipeline.evict(path);
         self.skyboxes
@@ -231,6 +235,9 @@ impl SceneContext {
             terrain_renderer: RefCell::new(TerrainRenderer::default()),
             terrain_frame_serial: Cell::new(0),
             texture_pipeline: asset::build_pipeline(Box::new(TexturePipeline)),
+            terrain_detail_pipeline: asset::build_pipeline(Box::new(
+                crate::asset::pipelines::TerrainDetailPipeline,
+            )),
             model_pipeline: asset::build_pipeline(Box::new(ModelPipeline)),
             render_targets: RefCell::new(HashMap::new()),
             render_target_warned: RefCell::new(HashSet::new()),
@@ -553,14 +560,14 @@ impl SceneContext {
         // terrain program runs; a map still loading leaves the whole set
         // unbound so the terrain shows its flat band colors rather than a
         // checkerboard smeared across kilometres.
-        let detail_bound = terrain.detail_textures().is_some_and(|maps| {
+        let detail_bound = terrain.detail_textures().and_then(|maps| {
             let handles = maps.map(|map| {
                 let asset = render_context
                     .asset_cache
-                    .load_asset_with_pipeline(self.texture_pipeline.clone(), &map.locator);
+                    .load_asset_with_pipeline(self.terrain_detail_pipeline.clone(), &map.locator);
                 crate::asset::resolve_while_pending_state(
                     &render_context.asset_cache,
-                    &self.texture_pipeline,
+                    &self.terrain_detail_pipeline,
                     &asset,
                     &map.while_pending,
                 )
@@ -572,17 +579,20 @@ impl SceneContext {
                         | crate::asset::WhilePendingState::Loading(Some(_))
                 )
             });
-            if ready {
-                for (index, state) in handles.iter().enumerate() {
-                    let texture = match state {
-                        crate::asset::WhilePendingState::Loaded(texture)
-                        | crate::asset::WhilePendingState::Loading(Some(texture)) => texture,
-                        _ => unreachable!("checked above"),
-                    };
-                    texture.bind(TERRAIN_DETAIL_UNIT0 + index as u32, render_context);
-                }
+            if !ready {
+                return None;
             }
-            ready
+            let mut averages = [[1.0f32; 3]; 4];
+            for (index, state) in handles.iter().enumerate() {
+                let texture = match state {
+                    crate::asset::WhilePendingState::Loaded(texture)
+                    | crate::asset::WhilePendingState::Loading(Some(texture)) => texture,
+                    _ => unreachable!("checked above"),
+                };
+                texture.bind(TERRAIN_DETAIL_UNIT0 + index as u32, render_context);
+                averages[index] = texture.average_color();
+            }
+            Some(averages)
         });
         self.terrain_renderer.borrow_mut().draw(
             render_context,

--- a/runtime/functor-runtime-common/src/terrain_renderer.rs
+++ b/runtime/functor-runtime-common/src/terrain_renderer.rs
@@ -26,9 +26,20 @@ const MAX_INSTANCES: usize = 8192;
 const MAX_GRASS_INSTANCES: usize = 20_000;
 /// First texture unit for the detail maps. Unit 0 stays the height texture.
 const DETAIL_TEXTURE_UNIT0: i32 = 1;
-/// Detail fade band, as a fraction of the terrain's longest side.
-const DETAIL_FADE_START: f32 = 0.08;
-const DETAIL_FADE_END: f32 = 0.28;
+/// Furthest the detail band may reach, in metres from the camera.
+///
+/// A cap, not a flat value. Detail stops being resolvable at a distance that
+/// depends on the surface, not on how large the world is, so a 4 km map gains
+/// nothing from carrying tiled detail out to a kilometre — that is fill rate
+/// spent below a pixel. But the band must still shrink with the terrain: on a
+/// 200 m island an absolute 400 m would put the entire world at full detail
+/// permanently, which is why the fraction below also applies.
+const DETAIL_FADE_MAX_END: f32 = 400.0;
+/// The band is also bounded by a fraction of the terrain's longest side, which
+/// is what governs on anything smaller than ~1.4 km.
+const DETAIL_FADE_END_FRACTION: f32 = 0.28;
+/// Detail holds at full strength within this fraction of the band's end.
+const DETAIL_FADE_START_FRACTION: f32 = 0.15;
 
 const VERTEX_SHADER_SOURCE: &str = r#"
         // uv.xy plus 1 for a duplicated skirt vertex.
@@ -130,6 +141,9 @@ const FRAGMENT_SHADER_SOURCE: &str = r#"
         // Explicitly this shader's own: fog owns fogCameraPos and does not set
         // it when fog is disabled, but the detail fade must work regardless.
         uniform vec3 detailCameraPos;
+        // Each map's mean RGB, computed once on the CPU at load. Sampling the
+        // top mip per fragment cost one fetch per map to recover a constant.
+        uniform vec3 detailAverage[4];
 
         out vec4 fragColor;
 
@@ -142,16 +156,15 @@ const FRAGMENT_SHADER_SOURCE: &str = r#"
         // seamless for ANY map without asking the game to hand-match a band
         // color to its texture, which is what a fixed far color would require.
         // Returns STRUCTURE, not color: the sample divided by the map's own
-        // average (its top mip). That average is ~1.0 by construction, so
+        // average, supplied as a uniform. The ratio is ~1.0 on average, so
         // multiplying a band color by this adds the map's detail without
         // shifting its hue — a photographic albedo averages brown, and using
         // it directly would repaint a green hillside as dirt. It also makes
-        // the distance fade exact: as `fade` reaches 0 the ratio is 1.0, i.e.
+        // the distance fade exact: as `fade` reaches 0 the result is 1.0, i.e.
         // no change, so there is nothing to seam against.
-        vec3 detail(sampler2D tex, vec2 uv, float fade) {
+        vec3 detail(sampler2D tex, vec2 uv, float fade, vec3 average) {
             vec3 near = mix(texture(tex, uv).rgb, texture(tex, uv * 0.137).rgb, 0.5);
-            vec3 average = max(textureLod(tex, uv, 32.0).rgb, vec3(1e-3));
-            return mix(vec3(1.0), clamp(near / average, 0.0, 2.5), fade);
+            return mix(vec3(1.0), clamp(near / max(average, vec3(1e-3)), 0.0, 2.5), fade);
         }
 
         void main() {
@@ -190,14 +203,30 @@ const FRAGMENT_SHADER_SOURCE: &str = r#"
                     // the untextured terrain already renders correctly.
                     float fade = 1.0 - smoothstep(
                         detailFadeStart, detailFadeEnd, distance(worldPos, detailCameraPos));
-                    // The SAME weights as the colors above: texturing dresses
-                    // the bands, it does not move them.
-                    vec2 uv = worldPos.xz / detailTile;
-                    vec3 structure = mix(
-                        detail(lowTex, uv, fade), detail(highTex, uv, fade), bandWeight);
-                    structure = mix(structure, detail(rockTex, uv, fade), rockWeight);
-                    structure = mix(structure, detail(snowTex, uv, fade), snowWeight);
-                    albedo *= structure;
+                    // Past the band every detail() is exactly vec3(1.0), so
+                    // the 8 fetches it takes to compute that are pure waste —
+                    // and on a terrain vista most of the screen is past it.
+                    // The branch is coherent (it tracks distance), which is
+                    // what a tile-based GPU wants.
+                    // Safe despite `texture()`'s implicit derivatives inside
+                    // non-uniform control flow: the only quads that straddle
+                    // this branch are ones where fade ~ 0, so a bad sample is
+                    // multiplied by ~0 and clamped. Moving this threshold off
+                    // zero would make that no longer true.
+                    if (fade > 0.0) {
+                        // The SAME weights as the colors above: texturing
+                        // dresses the bands, it does not move them.
+                        vec2 uv = worldPos.xz / detailTile;
+                        vec3 structure = mix(
+                            detail(lowTex, uv, fade, detailAverage[0]),
+                            detail(highTex, uv, fade, detailAverage[1]),
+                            bandWeight);
+                        structure = mix(
+                            structure, detail(rockTex, uv, fade, detailAverage[2]), rockWeight);
+                        structure = mix(
+                            structure, detail(snowTex, uv, fade, detailAverage[3]), snowWeight);
+                        albedo *= structure;
+                    }
                 }
             }
             vec3 shaded = albedo * diffuseLight + specularLight;
@@ -328,6 +357,7 @@ struct TerrainUniforms {
     detail_fade_start: UniformLocation,
     detail_fade_end: UniformLocation,
     detail_camera_pos: UniformLocation,
+    detail_averages: [UniformLocation; 4],
     lighting: LightingUniforms,
     fog: FogUniforms,
 }
@@ -492,10 +522,11 @@ impl TerrainRenderer {
         world: &Matrix4<f32>,
         projection: &Matrix4<f32>,
         view: &Matrix4<f32>,
-        // Whether the shell resolved and bound the four detail maps to units
-        // 1..4 for this draw. Layers without textures — and a textured terrain
-        // whose maps have not streamed in — render the flat band colors.
-        detail_bound: bool,
+        // The four detail maps' mean colors when the shell bound them to units
+        // 1..4 for this draw, else `None`. Layers without textures — and a
+        // textured terrain whose maps have not streamed in — render the flat
+        // band colors.
+        detail_bound: Option<[[f32; 3]; 4]>,
     ) {
         if source.width < 2 || source.height < 2 {
             return;
@@ -628,21 +659,26 @@ impl TerrainRenderer {
             let detail = description
                 .textures
                 .as_ref()
-                .filter(|_| use_layers == 1 && detail_bound);
+                .filter(|_| use_layers == 1 && detail_bound.is_some());
             p.set_uniform_1i(gl, &u.use_textures, detail.is_some() as i32);
             if let Some(textures) = detail {
                 for (unit, location) in u.detail_textures.iter().enumerate() {
                     p.set_uniform_1i(gl, location, unit as i32 + DETAIL_TEXTURE_UNIT0);
                 }
                 p.set_uniform_1f(gl, &u.detail_tile, textures.tile_size);
-                // Scale the fade with the terrain, not the tile: what matters
-                // is how far the detail survives relative to the world it
-                // dresses, and the same tile reads very differently on a 200 m
-                // island and a 4 km map.
                 let span = description.width.max(description.depth);
-                p.set_uniform_1f(gl, &u.detail_fade_start, span * DETAIL_FADE_START);
-                p.set_uniform_1f(gl, &u.detail_fade_end, span * DETAIL_FADE_END);
+                let fade_end = DETAIL_FADE_MAX_END.min(span * DETAIL_FADE_END_FRACTION);
+                p.set_uniform_1f(gl, &u.detail_fade_start, fade_end * DETAIL_FADE_START_FRACTION);
+                p.set_uniform_1f(gl, &u.detail_fade_end, fade_end);
                 p.set_uniform_vec3(gl, &u.detail_camera_pos, &ctx.camera_pos);
+                let averages = detail_bound.expect("checked by the filter above");
+                for (location, average) in u.detail_averages.iter().zip(averages) {
+                    p.set_uniform_vec3(
+                        gl,
+                        location,
+                        &Vector3::new(average[0], average[1], average[2]),
+                    );
+                }
             }
             u.lighting.set(p, ctx, view);
             u.fog.set(p, gl, ctx.fog, &ctx.camera_pos);
@@ -732,6 +768,9 @@ impl TerrainRenderer {
             detail_fade_start: program.get_uniform_location(ctx.gl, "detailFadeStart"),
             detail_fade_end: program.get_uniform_location(ctx.gl, "detailFadeEnd"),
             detail_camera_pos: program.get_uniform_location(ctx.gl, "detailCameraPos"),
+            detail_averages: std::array::from_fn(|i| {
+                program.get_uniform_location(ctx.gl, &format!("detailAverage[{i}]"))
+            }),
             lighting: LightingUniforms::get(&program, ctx.gl),
             fog: FogUniforms::get(&program, ctx.gl),
         };

--- a/runtime/functor-runtime-common/src/texture/texture_2d.rs
+++ b/runtime/functor-runtime-common/src/texture/texture_2d.rs
@@ -9,9 +9,9 @@ use super::{PixelFormat, RuntimeTexture, TextureData};
 
 pub struct Texture2D {
     ora: RuntimeRenderableAsset<TextureData>,
+    average: [f32; 3],
 }
 
-#[derive(Default)]
 pub struct TextureOptions {
     pub wrap: bool,
     pub linear: bool,
@@ -22,13 +22,43 @@ pub struct TextureOptions {
     /// level-0 texels they were authored as. Turn it on for textures that
     /// minify, where the alternative is aliasing.
     pub mipmap: bool,
+    /// Anisotropic taps to request, clamped to what the device supports. Only
+    /// meaningful with `mipmap`, since anisotropy samples mip levels.
+    ///
+    /// Costs bandwidth in proportion to the taps, and it is charged per
+    /// fragment at grazing angles — which is most of a terrain. Surfaces that
+    /// are mostly grazing and mostly tiled want fewer taps than the default.
+    pub anisotropy: f32,
+    /// Compute the image's mean color at load (see [`Texture2D::average_color`]).
+    ///
+    /// Off by default: it is an O(pixels) scan that only terrain detail maps
+    /// consume, and every sprite and UI texture would otherwise pay it.
+    pub compute_average: bool,
 }
 
-/// Anisotropic taps to request when a mip chain is built.
+/// Taps for textures that do not say otherwise. Hardware commonly reports 16;
+/// the visible gain past 8 is slight and the bandwidth cost is not.
+pub const DEFAULT_ANISOTROPY: f32 = 8.0;
+
+/// Taps for tiled terrain detail maps.
 ///
-/// Hardware commonly reports 16; the visible gain past 8 on terrain-angle
-/// surfaces is slight and the bandwidth cost is not, which matters on Quest.
-const ANISOTROPY_TAPS: f32 = 8.0;
+/// Terrain is overwhelmingly grazing-angle, so anisotropy is charged over
+/// almost the whole surface. Measured on a Quest 3: 8 taps on these four maps
+/// cost 8.9-13.6 ms of a 13.8 ms frame; 2 taps still missed 72 Hz. The
+/// distance fade already limits how far the detail is asked to hold up.
+pub const TERRAIN_DETAIL_ANISOTROPY: f32 = 1.0;
+
+impl Default for TextureOptions {
+    fn default() -> Self {
+        Self {
+            wrap: false,
+            linear: false,
+            mipmap: false,
+            anisotropy: DEFAULT_ANISOTROPY,
+            compute_average: false,
+        }
+    }
+}
 
 /// The device's anisotropy limit, or `None` where the extension is absent.
 ///
@@ -47,10 +77,51 @@ fn max_anisotropy(gl: &glow::Context) -> Option<f32> {
 
 impl Texture2D {
     pub fn init_from_data(data: TextureData, opts: TextureOptions) -> Texture2D {
+        let average = opts
+            .compute_average
+            .then(|| average_color(&data))
+            .unwrap_or([1.0; 3]);
         Texture2D {
             ora: RuntimeRenderableAsset::new(data, opts),
+            average,
         }
     }
+
+    /// The image's mean RGB, computed once at load, or white when
+    /// `compute_average` was not requested.
+    ///
+    /// Terrain detail maps divide each sample by this to contribute structure
+    /// rather than color; reading it from the texture's top mip instead would
+    /// cost a fetch per map per fragment to recover a constant.
+    ///
+    /// Deliberately in the same (non-linear) space as the samples that divide
+    /// by it: textures upload as `RGB`/`RGBA`, never `SRGB8_*`, and
+    /// `FRAMEBUFFER_SRGB` is never enabled, so `texture()` returns the stored
+    /// bytes unmodified. Switching either of those would silently invalidate
+    /// this divisor.
+    pub fn average_color(&self) -> [f32; 3] {
+        self.average
+    }
+}
+
+/// Mean RGB over every texel. Ignores alpha: these are albedo maps, and a
+/// transparent texel's color still contributes to what the eye averages.
+fn average_color(data: &TextureData) -> [f32; 3] {
+    let stride = match data.format {
+        PixelFormat::RGB => 3,
+        PixelFormat::RGBA => 4,
+    };
+    let texels = data.bytes.len() / stride;
+    if texels == 0 {
+        return [1.0, 1.0, 1.0];
+    }
+    let mut totals = [0u64; 3];
+    for texel in data.bytes.chunks_exact(stride) {
+        for channel in 0..3 {
+            totals[channel] += texel[channel] as u64;
+        }
+    }
+    std::array::from_fn(|channel| totals[channel] as f32 / texels as f32 / 255.0)
 }
 
 /// The minification filter for `options` — a pure function so the mip/filter
@@ -136,12 +207,16 @@ impl RenderableAsset for TextureData {
                 gl.generate_mipmap(glow::TEXTURE_2D);
                 // Anisotropy only samples levels a mip chain provides, so it
                 // is meaningless (and on some drivers ignored) without one.
-                if let Some(device_max) = max_anisotropy(gl) {
-                    gl.tex_parameter_f32(
-                        glow::TEXTURE_2D,
-                        glow::TEXTURE_MAX_ANISOTROPY,
-                        ANISOTROPY_TAPS.min(device_max),
-                    );
+                // 1.0 is the GL default, so skip the probe and the set when
+                // nothing is being asked for.
+                if options.anisotropy > 1.0 {
+                    if let Some(device_max) = max_anisotropy(gl) {
+                        gl.tex_parameter_f32(
+                            glow::TEXTURE_2D,
+                            glow::TEXTURE_MAX_ANISOTROPY,
+                            options.anisotropy.min(device_max),
+                        );
+                    }
                 }
             }
 
@@ -160,7 +235,50 @@ mod tests {
             wrap: true,
             linear,
             mipmap,
+            ..TextureOptions::default()
         }
+    }
+
+    fn rgba(texels: &[[u8; 4]]) -> TextureData {
+        TextureData {
+            bytes: texels.iter().flatten().copied().collect(),
+            width: texels.len() as u32,
+            height: 1,
+            format: PixelFormat::RGBA,
+        }
+    }
+
+    #[test]
+    fn average_color_is_the_mean_over_texels() {
+        // Half black, half white: the mean is the midpoint, and alpha is
+        // deliberately ignored.
+        let data = rgba(&[[0, 0, 0, 0], [255, 255, 255, 255]]);
+        let average = average_color(&data);
+        for channel in average {
+            assert!((channel - 0.5).abs() < 0.01, "{average:?}");
+        }
+    }
+
+    #[test]
+    fn average_color_reads_three_byte_texels_at_the_right_stride() {
+        let data = TextureData {
+            bytes: vec![255, 0, 0, 0, 0, 255],
+            width: 2,
+            height: 1,
+            format: PixelFormat::RGB,
+        };
+        let average = average_color(&data);
+        assert!((average[0] - 0.5).abs() < 0.01, "{average:?}");
+        assert!(average[1].abs() < 0.01, "{average:?}");
+        assert!((average[2] - 0.5).abs() < 0.01, "{average:?}");
+    }
+
+    // The mean is only paid for when a consumer asks for it.
+    #[test]
+    fn textures_without_compute_average_report_white() {
+        let opaque_black = rgba(&[[0, 0, 0, 255]]);
+        let texture = Texture2D::init_from_data(opaque_black, TextureOptions::default());
+        assert_eq!(texture.average_color(), [1.0, 1.0, 1.0]);
     }
 
     // The default must stay mip-free: sprites, UI, and the fallback


### PR DESCRIPTION
`examples/terrain` ran at **44 fps** on a Quest 3 with detail maps on — 20.6 ms
against a 13.8 ms budget, 838 stale frames. It now holds **72 fps at 11.76 ms
with zero stale or torn frames.**

Raw stereo capture from the device (left eye | right eye), before and after:

![8x vs 1x anisotropy on device](https://gist.githubusercontent.com/tommy-xr/60e858181fec3916576ed379f74530e7/raw/quest-aniso-compare.png)

## Anisotropy was almost all of it

#477 requested 8 anisotropic taps for every mipmapped texture. Since #480 that
includes four terrain detail maps sampled twice each — and terrain is
overwhelmingly grazing angles, precisely where anisotropy is charged.

| Config | FPS | App | GPU load | Stale |
| --- | ---: | ---: | ---: | ---: |
| before (8×) | 44 | 20.63 ms | 0.98 | 838 |
| 2× | 68.6 | 12.98 ms | 0.97 | 204 |
| **this change** | **72** | **11.76 ms** | 0.93 | **0** |

The tell: the saving was *larger* on the smooth heightmap (−13.6 ms) than the
eroded one (−8.9 ms). More grazing area, more taps — which also explains why the
smooth map benchmarked *slower* before the fix. 2× was measured, not assumed.

**Scoped, not global.** Terrain detail decodes through its own
`TerrainDetailPipeline`, so model albedos and every other loaded texture keep the
8-tap default on every target. `TextureOptions` grows an `anisotropy` field to
say so, and the same pipeline gates the mean-colour scan — terrain-only data that
every sprite and UI texture was otherwise paying for.

Quality cost, measured on device: 5.47% of pixels differ by >16/255, mean
absolute difference 4.27, concentrated in the mid-distance ground band.

## Detail is visible in the headset — credit to the tile, not the fade

The tile drops **24 m → 8 m**. That is what made detail read from inside the
world.

The fade change is a **fill-rate cut**, and an earlier version of this
description claimed the opposite. The old band started at 320 m, so nothing
nearer than that was fading at all; the old band was ≥ the new one at *every*
distance. Corrected in the commit message.

The band is **capped** at 400 m rather than made absolute — detail stops being
resolvable at a distance that depends on the surface, not on world size, so a
4 km map gains nothing carrying tiled detail out to a kilometre. But it still
scales below ~1.4 km (`× 0.28` of span), because an absolute band would put a
200 m island entirely at full detail permanently — the case the original
relative band existed to handle.

## Smaller changes

- Each map's average is computed once on the CPU at load and passed as a uniform,
  replacing a `textureLod(…, 32.0)` per fragment per map that resampled a
  constant. **Measured flat** (11.74 → 11.76 ms, noise); kept because it is
  strictly less work and decouples the average from mip availability.
- The detail block early-outs at zero fade. **Also measured flat** at this camera
  height, where nearly every visible fragment is in-band; expected to matter for
  a ground-level view.

## Verification

- `cargo test -p functor_runtime_common --lib` — **509 passed** (3 new on
  `average_color`, including the previously-unreachable RGB stride path).
- **All 7 golden scenarios pass unchanged** — 0.00% for six, 0.02% for
  `lighting-t2` (noise). Direct evidence the rescoping worked: a global 1× would
  have moved every textured golden.
- Device: **72.655 fps mean, 72 p5, 72 min, 0 stale, 0 torn.** Release APK,
  verified not `DEBUGGABLE`, 1680×1760 per eye, 30 s samples after 10 s warmup.

## Review

`/xreview` (Claude + Codex) raised 2 agreed High findings — global anisotropy
scope, and the absolute fade band breaking terrains under ~1.4 km. Both fixed
above, and the false rationale they exposed is corrected. Both engines
independently verified `average_color` is numerically equivalent to the old
`textureLod` (max delta 0.8/255; textures upload as `RGB`/`RGBA`, never sRGB
internal formats, and `FRAMEBUFFER_SRGB` is never enabled, so mean and sample
share a space).

## Not in this PR

Base terrain still costs 7.5–8.8 ms with **no** detail maps. Later profiled with
`ovrgpuprofiler`: **69.6% fragment / 30.4% vertex, 44.7% texture fetch stall,
32.7% L1 miss against 0.23% L2**, and ~3.68 M vertices/frame. Tracked as the
90 Hz effort — foveated rendering (absent from the runtime entirely),
`textureGather` + a baked normal map, and detail maps into a texture array.
Profiling skill in #499.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
