### PR TITLE
fix(debug): /time advances accumulate, batch, and refuse a fixed-time pin

### DIFF
--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -156,11 +156,12 @@ without it. That is the point: the mouse/keyboard emulator pins both hands to
 toward your face, or aiming with a rotated grip, are inexpressible there and can
 only be driven this way. `held_keys` and `mouse` stay live alongside it.
 
-Pair it with `POST /time` to step one frame per pose. **Wait for `frame` to
-increment before sending the next pose**: `advance` sets the clock's single
-pending-step slot, so two advances arriving inside one request-drain collapse
-into one step and the intervening pose is never sampled. With the wait, the
-whole two-handed sequence is one pose per frame and reproducible:
+Pair it with `POST /time` to step one frame per pose — and **wait for `frame` to
+increment before sending the next pose**. Advances accumulate (one advance is
+one stepped frame), but injected input is *level* state, not a queue: it is
+applied when the request is serviced, so any steps still queued when the next
+pose arrives run against the NEW pose. Waiting is what pins one pose to one
+frame:
 
 ```sh
 for i in $(seq 0 20); do
@@ -237,14 +238,43 @@ target-specific endpoints or string-keyed capability bags.
 ### `POST /time` — frame-loop control
 
 ```jsonc
-{"type":"set","tts":2.0}        // PAUSE: pin game time to a constant (dts=0)
-{"type":"advance","dts":0.016}  // STEP: run exactly one frame with this dt, then hold
-{"type":"resume"}               // RESUME: follow wall-clock again
+{"type":"set","tts":2.0}                    // PAUSE: pin game time to a constant (dts=0)
+{"type":"advance","dts":0.016}              // STEP: run exactly one frame with this dt, then hold
+{"type":"advance","dts":0.016,"frames":120} // BATCH: queue 120 such steps in one request
+{"type":"resume"}                           // RESUME: follow wall-clock again
 ```
 
-`--fixed-time <T>` pins the clock from launch (equivalent to an initial `set`).
-While the clock is pinned, **user keyboard/mouse input from the window is ignored**, but
-injected `/input` still applies — so an external driver has deterministic control.
+**Advances accumulate.** Each queued step runs exactly once, in order: `n`
+advances always run `n` model steps, whenever they arrive relative to a frame.
+A single advance is therefore one observable stepped frame — step, read
+`/state`, step again.
+
+**`frames` is the batch form** (default `1`), for skipping ahead when you do
+*not* need to observe between steps: one round trip instead of `n`, and the
+queue drains at up to 8 steps per rendered frame rather than one, so a
+600-frame skip costs ~75 rendered frames instead of 600. The clock parks at the
+end exactly as a single advance does.
+
+Two things follow from that speed. The response returns when the steps are
+*queued*, so poll `GET /state` until **`pending_steps` is 0** to know the batch
+has fully landed. And because up to 8 ticks run inside one rendered frame, a
+batch has ~`n/8` of the per-rendered-frame I/O points that `n` single advances
+would give it — network delivery, effect results, injected input, and rendering
+all happen once per rendered frame, not once per tick. Step one at a time when
+the game needs to see input or I/O between steps. (Batches are capped at
+1,000,000 queued steps; past that the request is a 409.)
+
+**`--fixed-time <T>` is not an initial `set`.** It is an *unconditional* capture
+pin: every frame is `{dts: 0, tts: T}`, and no clock control — pause, step,
+rebase — can move it. That is what makes golden captures byte-identical, so
+`/time` does not get to weaken it: `set`, `advance`, and `resume` all return
+**409 Conflict** with a message naming the pin while `--fixed-time` is in
+effect. To start pinned *and* step, launch WITHOUT `--fixed-time` and
+`POST {"type":"set","tts":T}` first.
+
+While the clock is pinned (either way), **user keyboard/mouse input from the window is
+ignored**, but injected `/input` still applies — so an external driver has deterministic
+control.
 
 ### `POST /reload-source` — network hot-reload (Functor Lang)
 

--- a/e2e/xr-pose-injection.mjs
+++ b/e2e/xr-pose-injection.mjs
@@ -86,12 +86,12 @@ async function waitReady(base, timeoutMs) {
 
 /** Advance exactly one fixed step and WAIT for it to land.
  *
- * `POST /time advance` sets the clock's single `pending_step` slot, which the
- * loop consumes on its next iteration. Two advances that arrive inside one
- * request-drain therefore collapse into ONE step — so a naive
- * "post pose, post advance" loop silently drops poses at localhost speed, and
- * how many it drops depends on timing. Waiting for `frame` to increment is what
- * makes one pose == one frame, and the sequence reproducible. */
+ * `POST /time advance` QUEUES a step (advances accumulate, so no step is ever
+ * lost), which the frame loop consumes on a later iteration. The wait is still
+ * REQUIRED here: an injected pose is level state applied when its request is
+ * serviced, so a step still queued when the next pose lands would run against
+ * the NEW pose. Waiting for `frame` to increment is what pins one pose to one
+ * frame, and makes the sequence reproducible. */
 async function stepOneFrame(base, timeoutMs = 10000) {
   const before = (await state(base)).frame;
   await post(base, "/time", { type: "advance", dts: 1 / 60 });

--- a/runtime/functor-runtime-common/src/debug_http.rs
+++ b/runtime/functor-runtime-common/src/debug_http.rs
@@ -321,7 +321,14 @@ fn handle(mut stream: TcpStream, tx: &mpsc::Sender<DebugRequest>) -> Option<()> 
                 return runtime_gone(&mut stream, cors_origin);
             }
             match recv(resp_rx) {
-                Ok(()) => respond_text(&mut stream, cors_origin, 200, "OK", "ok"),
+                Ok(Ok(())) => respond_text(&mut stream, cors_origin, 200, "OK", "ok"),
+                // The runtime CANNOT honor this command in its current mode
+                // (a `--fixed-time` pin). Silently answering `ok` to a no-op is
+                // the bug this replaces: a stepping harness then waits forever
+                // for a frame that will never come.
+                Ok(Err(message)) => {
+                    respond_text(&mut stream, cors_origin, 409, "Conflict", &message)
+                }
                 Err(_) => respond_text(
                     &mut stream,
                     cors_origin,
@@ -716,6 +723,43 @@ mod tests {
         let response = client.join().unwrap();
         assert!(response.starts_with("HTTP/1.1 200 OK\r\n"));
         assert!(response.ends_with("loaded project"));
+    }
+
+    /// A clock command the runtime cannot honor must be a LOUD 409, not a `200
+    /// ok` that did nothing — the silence a stepping harness cannot detect.
+    #[test]
+    fn a_time_command_the_runtime_refuses_is_a_conflict_not_an_ok() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let body = r#"{"type":"advance","dts":0.016,"frames":4}"#;
+        let request = format!(
+            "POST /time HTTP/1.1\r\nHost: localhost\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        let client = connect(&listener, request);
+        let (tx, rx) = mpsc::channel();
+        let server = std::thread::spawn(move || handle(listener.accept().unwrap().0, &tx));
+
+        match rx.recv().unwrap() {
+            DebugRequest::Time(command, response) => {
+                assert_eq!(
+                    command,
+                    TimeCommand::Advance {
+                        dts: 0.016,
+                        frames: 4
+                    }
+                );
+                response.send(Err("pinned by --fixed-time".into())).unwrap();
+            }
+            _ => panic!("expected time request"),
+        }
+
+        assert_eq!(server.join().unwrap(), Some(()));
+        let response = client.join().unwrap();
+        assert!(
+            response.starts_with("HTTP/1.1 409 Conflict\r\n"),
+            "{response}"
+        );
+        assert!(response.ends_with("pinned by --fixed-time"));
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/debug_protocol.rs
+++ b/runtime/functor-runtime-common/src/debug_protocol.rs
@@ -16,7 +16,12 @@ use crate::{ui::UiEventKind, InputSnapshot, XrInputSnapshot};
 pub const DEBUG_PROTOCOL_SERVICE: &str = "functor debug runtime";
 
 /// Version of the routes and JSON wire shapes in this module.
-pub const DEBUG_PROTOCOL_VERSION: u32 = 2;
+///
+/// 3 added `pending_steps` to `GET /state` and `frames` to `POST /time`'s
+/// `advance`, and made `/time` answer 409 under a `--fixed-time` pin. A client
+/// that batches advances or waits on `pending_steps` needs a v3 runtime: a v2
+/// one ignores `frames`, runs a single step, and reports no `pending_steps`.
+pub const DEBUG_PROTOCOL_VERSION: u32 = 3;
 
 /// Maximum accepted body size for either reload operation.
 pub const MAX_RELOAD_BYTES: usize = 4 * 1024 * 1024;
@@ -65,7 +70,7 @@ pub const DEBUG_ROUTES: &[DebugRoute] = &[
     DebugRoute {
         method: "GET",
         path: "/state",
-        description: "runtime state JSON: frame, tts, viewport, views, input snapshot (held_keys + mouse + optional xr), model (Debug text)",
+        description: "runtime state JSON: frame, tts, pending_steps (queued clock steps not yet run), viewport, views, input snapshot (held_keys + mouse + optional xr), model (Debug text)",
     },
     DebugRoute {
         method: "GET",
@@ -85,7 +90,7 @@ pub const DEBUG_ROUTES: &[DebugRoute] = &[
     DebugRoute {
         method: "POST",
         path: "/time",
-        description: "clock control — {\"type\":\"set\",\"tts\":2.0} (pause) | {\"type\":\"advance\",\"dts\":0.016} (step one frame) | {\"type\":\"resume\"}",
+        description: "clock control — {\"type\":\"set\",\"tts\":2.0} (pause) | {\"type\":\"advance\",\"dts\":0.016,\"frames\":1} (queue that many steps; advances accumulate) | {\"type\":\"resume\"} — 409 while --fixed-time pins the clock",
     },
     DebugRoute {
         method: "POST",
@@ -173,6 +178,10 @@ impl RuntimeView {
 pub struct RuntimeState {
     pub frame: u64,
     pub tts: f32,
+    /// Clock steps queued by `POST /time` `advance` and not yet run. Zero means
+    /// every requested step has been simulated, which is how a harness knows a
+    /// batched advance has fully landed without guessing a frame target.
+    pub pending_steps: u32,
     pub viewport: RuntimeViewport,
     pub views: Vec<RuntimeView>,
     pub model: String,
@@ -219,8 +228,19 @@ pub enum InputCommand {
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum TimeCommand {
     Set { tts: f32 },
-    Advance { dts: f32 },
+    /// Step the clock, then hold. `frames` (default 1) is the BATCH form: it
+    /// queues that many `dts` steps in one request instead of one round trip
+    /// per step. Queued steps accumulate — `n` advances always run `n` steps.
+    Advance {
+        dts: f32,
+        #[serde(default = "one_frame")]
+        frames: u32,
+    },
     Resume,
+}
+
+fn one_frame() -> u32 {
+    1
 }
 
 /// A coupled model-and-physics rewind sent through `POST /rewind`.
@@ -328,7 +348,9 @@ pub enum DebugRequest {
     Scene(Sender<String>),
     Trace(Sender<String>),
     Input(InputCommand, Sender<Result<(), String>>),
-    Time(TimeCommand, Sender<()>),
+    /// `Err` is a conflict the operator must resolve — today, a `/time` command
+    /// under an unconditional `--fixed-time` pin, which the clock cannot honor.
+    Time(TimeCommand, Sender<Result<(), String>>),
     ReloadSource(String, Sender<Result<String, String>>),
     ReloadProject(ProjectSources, Sender<Result<String, String>>),
     LoadProject(ProjectSources, Sender<Result<String, String>>),
@@ -351,6 +373,7 @@ mod tests {
         let state = RuntimeState {
             frame: 42,
             tts: 1.5,
+            pending_steps: 3,
             viewport: RuntimeViewport::new(1920, 1080),
             views: vec![RuntimeView::new("main", 1920, 1080)],
             model: "Model {\n  label: \"hello\"\n}".into(),
@@ -367,6 +390,7 @@ mod tests {
             json!({
                 "frame": 42,
                 "tts": 1.5,
+                "pending_steps": 3,
                 "viewport": { "width": 1920, "height": 1080 },
                 "views": [{
                     "name": "main",
@@ -434,7 +458,19 @@ mod tests {
         );
         assert_eq!(
             serde_json::from_str::<TimeCommand>(r#"{"type":"advance","dts":0.016}"#).unwrap(),
-            TimeCommand::Advance { dts: 0.016 }
+            TimeCommand::Advance {
+                dts: 0.016,
+                frames: 1
+            },
+            "an advance with no `frames` is still exactly one step"
+        );
+        assert_eq!(
+            serde_json::from_str::<TimeCommand>(r#"{"type":"advance","dts":0.016,"frames":120}"#)
+                .unwrap(),
+            TimeCommand::Advance {
+                dts: 0.016,
+                frames: 120
+            }
         );
         assert_eq!(
             serde_json::from_str::<RewindCommand>(r#"{"frame":42}"#).unwrap(),
@@ -553,6 +589,6 @@ mod tests {
         let discovery: Value = serde_json::from_str(&discovery_json()).unwrap();
         assert_eq!(discovery["service"], DEBUG_PROTOCOL_SERVICE);
         assert_eq!(discovery["protocol_version"], DEBUG_PROTOCOL_VERSION);
-        assert_eq!(DEBUG_PROTOCOL_VERSION, 2);
+        assert_eq!(DEBUG_PROTOCOL_VERSION, 3);
     }
 }

--- a/runtime/functor-runtime-common/src/game_clock.rs
+++ b/runtime/functor-runtime-common/src/game_clock.rs
@@ -19,6 +19,8 @@
 //! This is the deterministic-capture / golden-image path and MUST stay
 //! byte-identical, so it is checked first, ahead of every other control.
 
+use std::collections::VecDeque;
+
 use crate::FrameTime;
 
 /// The fixed model timestep, in seconds — the interval `tick` advances by under
@@ -36,6 +38,12 @@ pub const FIXED_DT: f32 = 1.0 / 60.0;
 /// physics' `MAX_SUBSTEPS_PER_FRAME`.
 const MAX_SUBSTEPS: usize = 8;
 
+/// Most steps `POST /time` `advance` may leave queued at once. They drain at
+/// [`MAX_SUBSTEPS`] per rendered frame, so this is ~3.5 hours of stepping at
+/// 60fps — far past any real harness, and short of a request that would wedge
+/// the clock indefinitely (or grow the queue without bound).
+const MAX_QUEUED_STEPS: u32 = 1_000_000;
+
 /// A frame-time source shared by the desktop and web shells. Constructed once
 /// per session (seeded with the shell's fixed-time option) and called each
 /// rendered frame via [`GameClock::fixed_frames`] (the fixed-timestep model
@@ -52,9 +60,21 @@ pub struct GameClock {
     /// Scrubber / debug pause. While paused, `dts = 0` and `game_time` is
     /// frozen. A queued [`GameClock::step`] also sets this.
     paused: bool,
-    /// A one-shot step (seconds) that advances `game_time` on the next frame,
-    /// then holds. Set by Step / debug Advance (both imply pause).
-    pending_step: Option<f32>,
+    /// Queued one-shot steps that advance `game_time`, then hold. Queued by
+    /// Step / debug Advance (both imply pause), and drained in order at up to
+    /// [`MAX_SUBSTEPS`] per rendered frame.
+    ///
+    /// It is a QUEUE, not a single slot: steps ACCUMULATE, so N advances always
+    /// run N steps. A single slot silently collapsed two advances that landed
+    /// between one frame's consumption into one step — unreachable through the
+    /// synchronous debug-HTTP transport (one in-flight request at a time), but
+    /// a live trap for any caller that can queue two commands before a frame
+    /// runs, and the reason a batch advance can mean anything at all.
+    ///
+    /// Consecutive steps of the same `dts` coalesce into one `(dts, count)`
+    /// run, so a 10,000-frame batch — or a per-frame `step` caller under a
+    /// fixed-time pin — costs one entry, not one per step.
+    pending_steps: VecDeque<(f32, u32)>,
     /// Queued FIXED-frame steps (the scrubber's drag-into-the-future
     /// catch-up): consumed up to [`MAX_SUBSTEPS`] whole `FIXED_DT` sub-frames
     /// per rendered frame — never one fat tick, preserving the fixed-timestep
@@ -82,11 +102,22 @@ impl GameClock {
             game_time: 0.0,
             accumulator: 0.0,
             paused: false,
-            pending_step: None,
+            pending_steps: VecDeque::new(),
             pending_frames: 0,
             fixed_time,
             started: false,
         }
+    }
+
+    /// Take the next queued step's `dts`, if any.
+    fn take_step(&mut self) -> Option<f32> {
+        let (dts, count) = self.pending_steps.front_mut()?;
+        let dts = *dts;
+        *count -= 1;
+        if *count == 0 {
+            self.pending_steps.pop_front();
+        }
+        Some(dts)
     }
 
     /// This frame's [`FrameTime`], given the real wall-clock delta since the last
@@ -97,7 +128,7 @@ impl GameClock {
         if let Some(t) = self.fixed_time {
             return FrameTime { dts: 0.0, tts: t };
         }
-        if let Some(step) = self.pending_step.take() {
+        if let Some(step) = self.take_step() {
             self.game_time += step;
             return FrameTime {
                 dts: step,
@@ -128,7 +159,10 @@ impl GameClock {
     /// - **Fixed-time** pins unconditionally (checked first): a single
     ///   `{ dts: 0, tts: <const> }` — the golden-capture path runs the body once
     ///   with `dts = 0`, byte-identical to [`Self::frame`].
-    /// - **Pending step** (Step / debug Advance): a single `{ dts: step, … }`.
+    /// - **Pending steps** (Step / debug Advance): the queued steps, in order,
+    ///   at most [`MAX_SUBSTEPS`] per rendered frame. One queued step — all a
+    ///   single advance can be — is one `{ dts: step, … }`, so one advance is
+    ///   one observable stepped frame.
     /// - **Paused**: EMPTY — no model advance. The shell still renders the frozen
     ///   (or scrubbed) pose once at the held `tts`.
     /// - **Live**: accumulate `real_delta` and emit one frame per whole
@@ -140,12 +174,22 @@ impl GameClock {
         if let Some(t) = self.fixed_time {
             return vec![FrameTime { dts: 0.0, tts: t }];
         }
-        if let Some(step) = self.pending_step.take() {
-            self.game_time += step;
-            return vec![FrameTime {
-                dts: step,
-                tts: self.game_time,
-            }];
+        if !self.pending_steps.is_empty() {
+            // Up to MAX_SUBSTEPS queued steps per rendered frame — the same
+            // clamp `pending_frames` uses. One advance at a time (all the
+            // synchronous debug transport can deliver) is therefore exactly one
+            // stepped frame, observable on its own; a `frames: n` batch
+            // fast-forwards without one round trip and one render per step.
+            let mut frames = Vec::new();
+            while frames.len() < MAX_SUBSTEPS {
+                let Some(step) = self.take_step() else { break };
+                self.game_time += step;
+                frames.push(FrameTime {
+                    dts: step,
+                    tts: self.game_time,
+                });
+            }
+            return frames;
         }
         if self.pending_frames > 0 {
             // Catch-up: whole FIXED_DT sub-frames, at most MAX_SUBSTEPS per
@@ -226,7 +270,7 @@ impl GameClock {
     /// clock) — this is what kills the pause→resume jump.
     pub fn toggle_pause(&mut self) {
         self.paused = !self.paused;
-        self.pending_step = None;
+        self.pending_steps.clear();
         self.pending_frames = 0;
     }
 
@@ -234,7 +278,7 @@ impl GameClock {
     /// scrubber's seek/step controls, which park on a frame.
     pub fn pause(&mut self) {
         self.paused = true;
-        self.pending_step = None;
+        self.pending_steps.clear();
         self.pending_frames = 0;
     }
 
@@ -242,7 +286,7 @@ impl GameClock {
     /// `game_time` (debug `POST /time` Resume).
     pub fn resume(&mut self) {
         self.paused = false;
-        self.pending_step = None;
+        self.pending_steps.clear();
         self.pending_frames = 0;
     }
 
@@ -252,23 +296,58 @@ impl GameClock {
         self.game_time = 0.0;
         self.accumulator = 0.0;
         self.paused = false;
-        self.pending_step = None;
+        self.pending_steps.clear();
         self.pending_frames = 0;
         self.started = false;
     }
 
     /// Pause and queue a one-frame step of `dt` seconds (Step / debug Advance).
     pub fn step(&mut self, dt: f32) {
+        self.step_n(dt, 1);
+    }
+
+    /// Pause and queue `count` steps of `dt` seconds each — [`Self::step`]'s
+    /// batch form (debug `POST /time` `{"type":"advance","dts":d,"frames":n}`).
+    ///
+    /// Steps ACCUMULATE onto whatever is already queued, so `n` advances always
+    /// run `n` model steps regardless of when they arrive relative to a frame.
+    /// They drain at up to [`MAX_SUBSTEPS`] per rendered frame, so a batch
+    /// fast-forwards instead of costing one rendered frame per step.
+    ///
+    /// A `--fixed-time` pin swallows the request (`count` is dropped, not
+    /// queued): the pin is unconditional, so a queued step could never run, and
+    /// a per-frame caller would otherwise grow the queue forever. Shells report
+    /// that conflict to the operator at the transport, not here.
+    pub fn step_n(&mut self, dt: f32, count: u32) {
         self.paused = true;
-        self.pending_step = Some(dt);
+        if count == 0 || self.fixed_time.is_some() {
+            return;
+        }
+        match self.pending_steps.back_mut() {
+            Some((queued_dt, queued)) if *queued_dt == dt => {
+                *queued = queued.saturating_add(count)
+            }
+            _ => self.pending_steps.push_back((dt, count)),
+        }
+    }
+
+    /// Steps still queued from [`Self::step`] / [`Self::step_n`].
+    pub fn pending_steps(&self) -> u32 {
+        self.pending_steps
+            .iter()
+            .fold(0u32, |total, (_, count)| total.saturating_add(*count))
     }
 
     /// Pause and queue `n` whole FIXED-frame steps — the scrubber's
     /// drag-into-the-future catch-up. Consumed at most [`MAX_SUBSTEPS`] per
     /// rendered frame (see [`Self::fixed_frames`]), so long drags animate.
-    /// Queuing again REPLACES the backlog (the newest drag wins).
+    /// Queuing again REPLACES the backlog (the newest drag wins) — including
+    /// any debug `advance` steps still queued, which would otherwise run FIRST
+    /// (they have priority in [`Self::fixed_frames`]) and overshoot the frame
+    /// the drag selected.
     pub fn step_frames(&mut self, n: u32) {
         self.paused = true;
+        self.pending_steps.clear();
         self.pending_frames = n;
     }
 
@@ -280,14 +359,49 @@ impl GameClock {
     /// Debug `POST /time` Set: pin the clock to `tts` (pause + rebase).
     pub fn set(&mut self, tts: f32) {
         self.paused = true;
-        self.pending_step = None;
+        self.pending_steps.clear();
         self.pending_frames = 0;
         self.game_time = tts;
     }
 
-    /// Debug `POST /time` Advance: step one frame by `dts` (implies pause).
-    pub fn advance(&mut self, dts: f32) {
-        self.step(dts);
+    /// Apply one debug `POST /time` command, shared by every shell that hosts
+    /// the debug server so the contract cannot drift between them.
+    ///
+    /// `Err` is a CONFLICT, surfaced to the operator as `409`: under a
+    /// `--fixed-time` pin no clock command can do anything, and answering `ok`
+    /// to a no-op strands a stepping harness. The pin stays unconditional (the
+    /// golden-capture path must not become network-dependent), so the fix is to
+    /// relaunch without it.
+    pub fn apply(&mut self, command: crate::debug_protocol::TimeCommand) -> Result<(), String> {
+        use crate::debug_protocol::TimeCommand;
+        if let Some(pinned) = self.fixed_time {
+            return Err(format!(
+                "the clock is pinned at tts = {pinned} by --fixed-time, which is an \
+unconditional capture pin: /time cannot set, advance, or resume it. Relaunch without \
+--fixed-time and POST {{\"type\":\"set\",\"tts\":{pinned}}} to start pinned at the same \
+time, then advance from there."
+            ));
+        }
+        match command {
+            TimeCommand::Set { tts } => self.set(tts),
+            TimeCommand::Advance { dts, frames } => {
+                // Bounded so one request cannot park the clock for weeks: the
+                // queue drains at MAX_SUBSTEPS per rendered frame, so the cap
+                // is ~3.5 hours of stepping at 60fps. Refuse loudly rather
+                // than accept a number we will not honor in any useful time.
+                let queued = self.pending_steps();
+                if queued.saturating_add(frames) > MAX_QUEUED_STEPS {
+                    return Err(format!(
+                        "advance would queue {frames} steps on top of {queued} already queued, \
+past the {MAX_QUEUED_STEPS} step cap. Advance in smaller batches, or POST \
+{{\"type\":\"set\",\"tts\":<t>}} to jump the clock instead of stepping to it."
+                    ));
+                }
+                self.step_n(dts, frames)
+            }
+            TimeCommand::Resume => self.resume(),
+        }
+        Ok(())
     }
 
     /// Rebase the clock so play continues from `tts` — used when a time-travel
@@ -506,6 +620,189 @@ mod tests {
         assert_eq!(frames[0].dts, 0.0);
         assert_eq!(frames[0].tts, 2.0);
         assert_eq!(clock.current_tts(), 2.0);
+    }
+
+    #[test]
+    fn advances_accumulate_instead_of_collapsing() {
+        // Two advances queued before ANY frame consumes them must run TWO
+        // steps. With a single `pending_step` slot the second overwrote the
+        // first and the pose between them was never sampled.
+        let mut clock = GameClock::new(None);
+        clock.step_n(FIXED_DT, 1);
+        clock.step_n(FIXED_DT, 1);
+        assert_eq!(clock.pending_steps(), 2);
+        let frames = clock.fixed_frames(0.0);
+        assert_eq!(frames.len(), 2, "both advances ran");
+        assert!((clock.current_tts() - 2.0 * FIXED_DT).abs() < 1e-6);
+        assert!(clock.fixed_frames(0.0).is_empty(), "then holds paused");
+    }
+
+    #[test]
+    fn one_advance_is_exactly_one_stepped_frame() {
+        // The property a stepping harness needs: post one advance, observe one
+        // frame. Queue-and-drain must not run ahead of what was asked for.
+        let mut clock = GameClock::new(None);
+        for i in 1..=5 {
+            clock.step_n(FIXED_DT, 1);
+            let frames = clock.fixed_frames(0.0);
+            assert_eq!(frames.len(), 1, "advance {i} stepped once");
+            assert!((frames[0].dts - FIXED_DT).abs() < 1e-6);
+            assert!(clock.fixed_frames(0.0).is_empty(), "and holds after {i}");
+        }
+    }
+
+    #[test]
+    fn a_batch_advance_runs_every_step_capped_per_rendered_frame() {
+        let mut clock = GameClock::new(None);
+        clock.step_n(FIXED_DT, 20);
+        assert_eq!(clock.pending_steps(), 20);
+        let a = clock.fixed_frames(0.0);
+        assert_eq!(a.len(), MAX_SUBSTEPS, "capped like the scrubber catch-up");
+        let b = clock.fixed_frames(0.0);
+        assert_eq!(b.len(), MAX_SUBSTEPS);
+        let c = clock.fixed_frames(0.0);
+        assert_eq!(c.len(), 20 - 2 * MAX_SUBSTEPS, "remainder drains");
+        assert!(clock.fixed_frames(0.0).is_empty());
+        // Every requested step ran, in order, at the requested dt.
+        assert!((clock.current_tts() - 20.0 * FIXED_DT).abs() < 1e-5);
+        // A zero-frame batch queues nothing (it still parks the clock).
+        clock.step_n(FIXED_DT, 0);
+        assert_eq!(clock.pending_steps(), 0);
+        assert!(clock.is_paused());
+    }
+
+    #[test]
+    fn queued_steps_keep_heterogeneous_dts_in_order() {
+        let mut clock = GameClock::new(None);
+        clock.step_n(0.5, 1);
+        clock.step_n(0.25, 2);
+        clock.step_n(0.5, 1);
+        let frames = clock.fixed_frames(0.0);
+        let dts: Vec<f32> = frames.iter().map(|f| f.dts).collect();
+        assert_eq!(dts, vec![0.5, 0.25, 0.25, 0.5]);
+        assert!((clock.current_tts() - 1.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn the_legacy_frame_path_consumes_one_queued_step_per_call() {
+        let mut clock = GameClock::new(None);
+        clock.step_n(0.25, 3);
+        for i in 1..=3 {
+            let f = clock.frame(1.0);
+            assert!((f.dts - 0.25).abs() < 1e-6, "call {i} stepped");
+        }
+        assert_eq!(clock.frame(1.0).dts, 0.0, "drained → holds paused");
+    }
+
+    #[test]
+    fn a_pause_transition_drops_every_queued_step() {
+        for (name, transition) in [
+            ("pause", GameClock::pause as fn(&mut GameClock)),
+            ("resume", GameClock::resume),
+            ("toggle", GameClock::toggle_pause),
+            ("restart", GameClock::restart),
+        ] {
+            let mut clock = GameClock::new(None);
+            clock.step_n(FIXED_DT, 40);
+            transition(&mut clock);
+            assert_eq!(clock.pending_steps(), 0, "{name} cleared the queue");
+        }
+        let mut clock = GameClock::new(None);
+        clock.step_n(FIXED_DT, 40);
+        clock.set(4.0);
+        assert_eq!(clock.pending_steps(), 0, "set cleared the queue");
+
+        // A scrubber drag supersedes a debug batch: queued steps have priority
+        // in fixed_frames, so keeping them would overshoot the dragged-to frame.
+        let mut clock = GameClock::new(None);
+        clock.step_n(FIXED_DT, 40);
+        clock.step_frames(3);
+        assert_eq!(clock.pending_steps(), 0, "the drag dropped the batch");
+        assert_eq!(clock.pending_frames(), 3);
+    }
+
+    #[test]
+    fn fixed_time_swallows_queued_steps_rather_than_hoarding_them() {
+        // The pin is unconditional, so a queued step could never run. Dropping
+        // it keeps a per-frame `step` caller (the --input-script driver) from
+        // growing the queue forever under `--fixed-time`.
+        let mut clock = GameClock::new(Some(2.0));
+        for _ in 0..1000 {
+            clock.step_n(FIXED_DT, 8);
+            let frames = clock.fixed_frames(0.016);
+            assert_eq!(frames.len(), 1);
+            assert_eq!(frames[0].tts, 2.0);
+            assert_eq!(frames[0].dts, 0.0);
+        }
+        assert_eq!(clock.pending_steps(), 0);
+        assert_eq!(clock.current_tts(), 2.0);
+    }
+
+    #[test]
+    fn apply_refuses_every_time_command_under_a_fixed_time_pin() {
+        use crate::debug_protocol::TimeCommand;
+        // Silently accepting these was the bug: the clock cannot move, but the
+        // pinned path still emits a frame each iteration, so even a harness
+        // waiting for /state.frame to increment saw a FALSE success.
+        let mut pinned = GameClock::new(Some(1.5));
+        for command in [
+            TimeCommand::Advance {
+                dts: FIXED_DT,
+                frames: 1,
+            },
+            TimeCommand::Set { tts: 9.0 },
+            TimeCommand::Resume,
+        ] {
+            let error = pinned.apply(command).expect_err("must be a conflict");
+            assert!(error.contains("--fixed-time"), "teaching message: {error}");
+            assert!(error.contains("1.5"), "names the pinned time: {error}");
+        }
+        assert_eq!(pinned.current_tts(), 1.5, "the pin never moved");
+
+        // Live, the same commands apply.
+        let mut clock = GameClock::new(None);
+        assert!(clock
+            .apply(TimeCommand::Advance {
+                dts: FIXED_DT,
+                frames: 3
+            })
+            .is_ok());
+        assert_eq!(clock.pending_steps(), 3);
+        assert!(clock.apply(TimeCommand::Set { tts: 4.0 }).is_ok());
+        assert_eq!(clock.pending_steps(), 0, "set drops the queue");
+        assert_eq!(clock.current_tts(), 4.0);
+        assert!(clock.apply(TimeCommand::Resume).is_ok());
+        assert!(!clock.is_paused());
+    }
+
+    #[test]
+    fn apply_refuses_a_batch_past_the_queue_cap() {
+        use crate::debug_protocol::TimeCommand;
+        let mut clock = GameClock::new(None);
+        let over = TimeCommand::Advance {
+            dts: FIXED_DT,
+            frames: MAX_QUEUED_STEPS + 1,
+        };
+        let error = clock.apply(over).expect_err("past the cap");
+        assert!(error.contains("cap"), "teaching message: {error}");
+        assert_eq!(clock.pending_steps(), 0, "nothing was queued");
+
+        // At the cap is fine; one more on top is not (the cap counts what is
+        // ALREADY queued, so a caller cannot walk past it in small batches).
+        assert!(clock
+            .apply(TimeCommand::Advance {
+                dts: FIXED_DT,
+                frames: MAX_QUEUED_STEPS
+            })
+            .is_ok());
+        assert_eq!(clock.pending_steps(), MAX_QUEUED_STEPS);
+        assert!(clock
+            .apply(TimeCommand::Advance {
+                dts: FIXED_DT,
+                frames: 1
+            })
+            .is_err());
+        assert_eq!(clock.pending_steps(), MAX_QUEUED_STEPS);
     }
 
     #[test]

--- a/runtime/functor-runtime-desktop/src/debug_server.rs
+++ b/runtime/functor-runtime-desktop/src/debug_server.rs
@@ -7,7 +7,6 @@ use std::sync::mpsc::Receiver;
 
 pub use functor_runtime_common::debug_protocol::{
     CaptureError, DebugRequest, InputCommand, RuntimeState, RuntimeView, RuntimeViewport,
-    TimeCommand,
 };
 /// Start the debug server and return the frame loop's request receiver.
 ///

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -600,6 +600,7 @@ fn service_debug_request(
             let _ = resp.send(debug_server::RuntimeState {
                 frame: *frame_count,
                 tts,
+                pending_steps: clock.pending_steps(),
                 viewport: debug_server::RuntimeViewport::new(width, height),
                 views: vec![debug_server::RuntimeView::new("main", width, height)],
                 model: game.state_debug(),
@@ -759,12 +760,7 @@ fn service_debug_request(
             let _ = resp.send(result);
         }
         debug_server::DebugRequest::Time(cmd, resp) => {
-            match cmd {
-                debug_server::TimeCommand::Set { tts } => clock.set(tts),
-                debug_server::TimeCommand::Advance { dts } => clock.advance(dts),
-                debug_server::TimeCommand::Resume => clock.resume(),
-            }
-            let _ = resp.send(());
+            let _ = resp.send(clock.apply(cmd));
         }
     }
     sampled_input_changed
@@ -1276,7 +1272,8 @@ pub fn run(args: Args) {
             // in whole 1/60 steps decoupled from the render rate, so the sim is
             // deterministic and a recorded frame is exactly one forward-step fine
             // step (the ghost replay's assumption). Scripted playback queued a
-            // one-shot `step` above, so this yields exactly one sub-frame then;
+            // one-shot `step` above, so that yields one sub-frame per iteration
+            // (a debug `advance` batch can queue more, draining ≤8 per frame);
             // --fixed-time / the debug pin yields one {dts:0} sub-frame; paused
             // yields none. `time` is the RENDER frame time — the settled `tts` the
             // frame is drawn / hot-reloaded / reported at (its `dts` is unused by
@@ -1736,13 +1733,14 @@ Escape again to quit"
             } else {
                 (32usize, 1.6f32, 8usize)
             };
-            // While a drag-into-the-future catch-up is draining, skip the
-            // preview recompute (the anchor moves every frame, so it would be
-            // a full forward-sim per frame and throttle the catch-up to a
-            // crawl) — it snaps back in on arrival.
+            // While a drag-into-the-future catch-up — or a batched debug
+            // `advance` — is draining, skip the preview recompute (the anchor
+            // moves every frame, so it would be a full forward-sim per frame
+            // and throttle the drain to a crawl) — it snaps back in on arrival.
             let preview_active = (trail_wanted || strobe_wanted)
                 && args.composite_demo == CompositeDemoArg::Off
-                && clock.pending_frames() == 0;
+                && clock.pending_frames() == 0
+                && clock.pending_steps() == 0;
             let preview: Option<functor_runtime_common::FramePreview> = if preview_active {
                 // Not bound by the 8-target compositor cap — this only reads node
                 // transforms — so sample finely for a smooth arc.
@@ -1865,8 +1863,10 @@ Escape again to quit"
             let ghost_frames = if ghost_active
                 && !args.stereo_sbs
                 && args.composite_demo == CompositeDemoArg::Off
-                // Skipped during a catch-up drain, like the scene-diff preview.
+                // Skipped during a catch-up or batched-advance drain, like the
+                // scene-diff preview.
                 && clock.pending_frames() == 0
+                && clock.pending_steps() == 0
             {
                 const MAX_GHOST: usize = 8;
                 // Interactive: the ⚙ popover's rate × window (clamped to the

--- a/runtime/functor-runtime-oculus/src/lib.rs
+++ b/runtime/functor-runtime-oculus/src/lib.rs
@@ -33,7 +33,6 @@ use android_activity::{AndroidApp, InputStatus, MainEvent, PollEvent};
 use functor_runtime_common::asset::AssetCache;
 use functor_runtime_common::debug_protocol::{
     CaptureError, DebugRequest, InputCommand, RuntimeState, RuntimeView, RuntimeViewport,
-    TimeCommand,
 };
 use functor_runtime_common::functor_lang_game_embedded::{FunctorLangEmbeddedGame, NativePlatform};
 use functor_runtime_common::protocol::GameProducer;
@@ -581,6 +580,7 @@ fn service_debug_request(
             let _ = response.send(RuntimeState {
                 frame: debug.frame_count,
                 tts: clock.current_tts(),
+                pending_steps: clock.pending_steps(),
                 viewport: RuntimeViewport::new(width, height),
                 views,
                 model: game.state_debug(),
@@ -659,12 +659,7 @@ tracking); use the desktop runtime's --headless/--debug-port path"
             let _ = response.send(result);
         }
         DebugRequest::Time(command, response) => {
-            match command {
-                TimeCommand::Set { tts } => clock.set(tts),
-                TimeCommand::Advance { dts } => clock.advance(dts),
-                TimeCommand::Resume => clock.resume(),
-            }
-            let _ = response.send(());
+            let _ = response.send(clock.apply(command));
         }
         DebugRequest::ReloadSource(source, response) => {
             let _ = response.send(game.reload_source(&source));

--- a/tools/functor-sdk/src/game.ts
+++ b/tools/functor-sdk/src/game.ts
@@ -181,11 +181,32 @@ export class FunctorClient {
     await this.http.postText("/time", { type: "advance", dts });
   }
 
-  /** Advance `n` steps, one frame at a time. */
+  /** Advance `n` steps, then hold — resolving once all `n` have actually run.
+   *
+   * Sent as ONE batched `advance` (`frames: n`) rather than `n` round trips;
+   * the runtime queues the steps and drains them at up to 8 per rendered
+   * frame, so this both costs less and finishes sooner than stepping in a
+   * loop. Completion is read from `state.pending_steps` reaching 0, which is
+   * exact — no frame-target arithmetic to race.
+   *
+   * That speed comes from running up to 8 ticks inside ONE rendered frame, so
+   * a batch also has ~n/8 of the per-rendered-frame I/O points a loop of
+   * {@link step} calls would give it: network delivery, effect results, and
+   * rendering happen once per rendered frame, not once per tick. Use `step` in
+   * a loop when the game needs to observe input, I/O, or the model between
+   * steps; use this to skip ahead. */
   async stepFrames(n: number, dts: number = DEFAULT_STEP_DT): Promise<void> {
-    for (let i = 0; i < n; i++) {
-      await this.step(dts);
-    }
+    if (n <= 0) return;
+    await this.http.postText("/time", { type: "advance", dts, frames: n });
+    await waitFor(
+      () => this.state(),
+      (s) => s.pending_steps === 0,
+      {
+        timeoutMs: 1000 + n * 100,
+        intervalMs: 5,
+        description: `${n} queued clock steps to run`,
+      },
+    );
   }
 
   /** Resume following the wall clock. */

--- a/tools/functor-sdk/src/types.ts
+++ b/tools/functor-sdk/src/types.ts
@@ -68,6 +68,9 @@ export interface RuntimeView {
 export interface RuntimeState {
   frame: number;
   tts: number;
+  /** Clock steps queued by `advance` that have not run yet. `0` means every
+   * requested step has been simulated. */
+  pending_steps: number;
   /** Combined/legacy output extent. Use `views` when view identity matters. */
   viewport: RuntimeViewport;
   views: RuntimeView[];

--- a/tools/functor-sdk/test/clock-stepping.e2e.test.ts
+++ b/tools/functor-sdk/test/clock-stepping.e2e.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { findRepoRoot, FunctorRunner } from "../src/index.js";
+
+// End-to-end contract for `POST /time` stepping (docs/debug-runtime.md), the
+// seam every scripted/LLM-driven session steers the game through:
+//
+//   1. N advances run exactly N model steps — they ACCUMULATE. A single
+//      `pending_step` slot used to let two advances landing between one frame's
+//      consumption collapse into one, silently dropping whatever input was
+//      injected for the lost step.
+//   2. One advance is one observable stepped frame, so a step/observe loop
+//      never skips a pose.
+//   3. `frames: n` is the same thing in one round trip.
+//
+//   npm run test:e2e:headless
+const e2eEnabled = process.env.FUNCTOR_E2E === "1";
+const headless = process.env.FUNCTOR_E2E_HEADLESS === "1";
+
+test(
+  "clock advances accumulate: N steps requested is N frames run",
+  { skip: !e2eEnabled, timeout: 120_000 },
+  async () => {
+    const repoRoot = findRepoRoot(process.cwd());
+    assert.ok(repoRoot, "must run from within the functor workspace");
+
+    const gameDir = join(repoRoot, "examples", "counter");
+    await using game = await FunctorRunner.launch({
+      gameDir,
+      repoRoot,
+      functorLangPath: join(gameDir, "game.fun"),
+      port: Number(process.env.FUNCTOR_E2E_PORT ?? 8104),
+      headless,
+    });
+
+    await game.pause();
+    // Settle: after a pause the loop stops stepping, so the frame counter
+    // stops moving and every later delta is caused only by our advances.
+    const settle = async () => {
+      let last = (await game.state()).frame;
+      for (;;) {
+        await new Promise((r) => setTimeout(r, 150));
+        const now = (await game.state()).frame;
+        if (now === last) return now;
+        last = now;
+      }
+    };
+
+    // One advance == one stepped frame, checked after EVERY step rather than
+    // only in total: a run that grouped several steps into one rendered frame
+    // would still reach the right total, but is not the property harnesses
+    // step/observe against.
+    let before = await settle();
+    for (let i = 1; i <= 10; i++) {
+      await game.step();
+      const s = await game.state();
+      assert.equal(s.frame, before + i, `advance ${i} ran exactly one frame`);
+      assert.equal(s.pending_steps, 0, `advance ${i} left nothing queued`);
+    }
+
+    // The batch form runs every requested step too.
+    before = await settle();
+    await game.stepFrames(50);
+    assert.equal(
+      (await game.state()).frame - before,
+      50,
+      "stepFrames(50) must run 50 frames and return once they have",
+    );
+
+    // And the clock holds afterwards — a batch parks like a single step.
+    const parked = await settle();
+    await new Promise((r) => setTimeout(r, 300));
+    assert.equal((await game.state()).frame, parked, "clock holds after a batch");
+  },
+);


### PR DESCRIPTION
## Why

Three findings from driving games headlessly during the jam, all at one seam:
`GameClock` + the debug server's `POST /time`. I verified each against the
runtime before changing anything — one of the three turned out to be
misdiagnosed, and one turned out to be worse than reported.

### 1. Advances could collapse — real mechanism, not reachable in practice

`pending_step: Option<f32>` was a single slot, so two advances arriving before a
frame consumed one overwrote each other. PR #486's harness was written around
this (`e2e/xr-pose-injection.mjs` waits for `/state.frame` to increment, and its
comment states the collapse as the reason).

**I could not reproduce it.** Against `origin/main`, headless and windowed, on
`examples/counter`:

| pattern | requested | frames actually run |
| --- | --- | --- |
| 300 sequential awaited advances | 300 | 300 |
| 300 `input` + `advance` pairs (the #486 shape) | 300 | 300 |
| 300 unawaited advances, 1 ms apart | 300 | 300 |
| 200 concurrent advances (`Promise.all`) | 200 | 200 |
| windowed (`--hidden`) sequential + concurrent | 100 each | 100 each |

The reason is structural: the debug HTTP server is a **single accept loop that
handles one connection to completion** (`debug_http.rs:32-44`), and each request
blocks on the runtime's ack. At most one `DebugRequest` is ever in flight, and a
request's ack is sent inside the very drain that applies it — so a second
advance would have to arrive in the microseconds before `try_recv` returns
`Empty`. It never did. I also checked the related worry: because `/state` is
serialized through the same channel, a read after an acked advance already
reflects the step (40/40 runs).

So the slot is a **latent** trap, not an active bug — but it is also what made a
batch advance meaningless, so the queue is a prerequisite for finding 2. The
#486 comment and the docs are corrected to say what is actually guaranteed.

### 2. No batch form — confirmed

`n` frames cost `n` round trips; the SDK's `stepFrames` looped. Measured ~20–23
ms/call, so 200 frames ≈ **4.5 s**.

### 3. `--fixed-time` silently swallowed `/time` — confirmed, and worse

Reported for `advance`; in fact **all three** commands were silent no-ops, and
`/state.frame` keeps ticking under the pin (the pinned path emits one
`{dts:0}` sub-frame per iteration), so even the documented "wait for
`/state.frame` to increment" workaround reported a **false success**. Base
runtime, `--fixed-time 1.5`:

```
advance → 200 ok      set → 200 ok      resume → 200 ok
tts before 1.5 → tts after 1.5   (frame 1204 → 1234)
```

`docs/debug-runtime.md`'s "`--fixed-time <T>` pins the clock from launch
(equivalent to an initial `set`)" was simply false.

## What

**Advances accumulate.** `pending_steps: VecDeque<(dts, count)>` — consecutive
equal-`dts` steps coalesce into a run, so a batch (or a per-frame `step` caller)
costs one entry. Each queued step runs exactly once, in order.

**`{"type":"advance","dts":d,"frames":n}`** (default 1) is the batch form. The
queue drains at up to `MAX_SUBSTEPS` (8) per rendered frame — the same clamp the
scrubber catch-up uses — so a batch fast-forwards. A single advance is still
exactly one observable stepped frame.

**`GET /state` gains `pending_steps`**, so a harness knows a batch has fully
landed without frame-target arithmetic. Protocol version → **3**.

**`/time` under `--fixed-time` returns 409** with a teaching message naming the
pin and the alternative (relaunch without it, `set` to the same tts, then
advance). The pin stays unconditional — golden captures must not become
network-dependent. `GameClock::apply` is shared by the desktop and Quest shells
so the rule cannot drift between them.

Batches are capped at 1,000,000 queued steps (a 409 past that), so one request
cannot wedge the clock or grow the queue without bound.

## The new contract

```jsonc
{"type":"advance","dts":0.016}              // one step, one observable frame
{"type":"advance","dts":0.016,"frames":120} // 120 steps, one round trip
{"type":"set","tts":2.0}                    // pause + rebase
{"type":"resume"}
// any of the above under --fixed-time → 409 Conflict
```

- `n` advances always run `n` steps, however they arrive.
- Poll `GET /state` until `pending_steps == 0` to know a batch has landed.
- A batch runs up to 8 ticks per rendered frame, so it has ~`n/8` of the
  per-rendered-frame I/O points (network, effects, injected input, rendering)
  that `n` single advances would give it. Step one at a time when the game needs
  to observe between steps.
- **Waiting for `frame` to increment is still required when input is
  interleaved with advances** — injected input is level state applied when its
  request is serviced, so a step still queued when the next pose arrives runs
  against the new pose. The accumulate fix does not make an unsynchronized
  pose loop correct, and the docs now say so.

## Verification

Rebuilt CLI, `examples/counter`, headless:

| | base | this branch |
| --- | --- | --- |
| 200 sequential advances | 200 frames, 4547 ms | 200 frames, 4547 ms |
| 200 concurrent advances | 200 frames | 200 frames |
| `frames: 200` batch | *not supported* | **200 frames, 24 ms for the request** |
| `/time` under `--fixed-time` | `200 ok`, nothing happened | **409 + teaching message** |

- `cargo test -p functor_runtime_common` — **492 passed** (10 new: accumulation,
  one-per-frame consumption, batch cap-per-frame drain, heterogeneous dts order,
  legacy `frame()` path, every pause transition clearing the queue, fixed-time
  swallowing, `apply` 409s, the queue cap, scrubber-supersedes-batch; plus a
  `debug_http` test pinning 409 on the wire).
- `tools/functor-sdk` e2e headless — **23 passed / 0 failed**, including a new
  `clock-stepping.e2e.test.ts` that asserts `frame == before + i` and
  `pending_steps == 0` after *each* of 10 advances, then that `stepFrames(50)`
  runs exactly 50 and parks.
- `--capture-frame --fixed-time 2.0` still captures normally (the pin path is
  untouched and checked first).
- `cargo test -p functor-runtime-desktop`: 68 passed, 1 failed —
  `mario_hot_reload_recomputes_the_entire_extrapolated_future`, which **fails
  identically on `origin/main` with this branch stashed** (pre-existing).
- **No benchmark run, deliberately:** `frame_bench` does not construct or call
  `GameClock` at all, and the live per-frame path changed only from
  `Option::take` to a `VecDeque` emptiness check — allocation-free (the deque
  never allocates unless a step is queued, which only happens while paused).

## Review dispositions (`/xreview`: Claude subagent + Codex, both engines)

**[AGREED] High — `stepFrames` could resolve before its batch finished.** Both
engines caught that reading the frame baseline *before* posting let live
sub-frames count toward the target. **Fixed** by adding `pending_steps` to
`/state` and waiting on it reaching 0 — exact, and one fewer round trip than the
baseline read.

**[AGREED] High — `stepFrames` batching changes I/O cadence for existing
callers.** Up to 8 ticks now run inside one rendered frame, so a batch has fewer
network/effect delivery points than a loop of single steps. **Documented rather
than reverted**: the exact "all `n` have run" contract is preserved, and the
lockstep multiplayer helper `stepAll` uses single `step`, not `stepFrames`, so
convergence harnesses are unaffected. The docstring and docs now state the
tradeoff and point to `step` when I/O between steps matters.

**[AGREED] Medium — unbounded queue / oversized batch.** **Fixed**: 1,000,000
step cap counted against what is already queued, refused with a 409.

**Medium — the accumulate fix does not make an unsynchronized pose loop
correct** (Claude). Correct and important: queued steps all sample the latest
injected input, so the old code dropped a pose and the new code would duplicate
one. **Fixed in the docs and the #486 e2e comment** — the wait is documented as
*required* when input is interleaved.

**Medium — protocol version not bumped** (Codex). **Fixed**: → 3, with a doc
comment on what a v2 runtime does with a v3 client.

**Medium — scrubber and debug backlogs retained each other** (Codex). Queued
steps have priority in `fixed_frames`, so a stale batch would overshoot a
dragged-to frame. **Fixed**: `step_frames` (the drag) now clears queued steps,
matching its documented "newest drag wins". Pre-existing in the reverse
direction and left alone.

**Medium — the e2e didn't prove one-advance-one-frame** (Codex). Fair — it
checked only the total. **Fixed**: asserts `+1` after every individual advance.

**Medium — `pending_steps()` was test-only API** (Claude). Resolved by the fix
above: it now backs the `/state` field.

**Low — `advance` was a redundant hop** (Claude). **Fixed**: removed; `apply`
calls `step_n` directly.

**Low — stale comment + scrubber preview gates ignored the new backlog**
(Claude). **Fixed**: comment corrected, and the two "skip the expensive preview
recompute during a drain" gates now also check `pending_steps()`.

**Not fixed (pre-existing, out of scope):**
- *`--capture-at-frame` can overshoot inside a multi-substep frame* (Codex). Real,
  but not introduced here: a live loop below 60 fps already emits 2+ substeps per
  rendered frame, and the scrubber catch-up emits up to 8.
- *`GameClock::frame()` has no production callers* (Claude) — pre-existing dead
  code; flagged, not deleted.

Neither engine found a Critical issue, and both independently confirmed the
`--fixed-time` / golden-capture path is preserved (pin checked first, queued
steps discarded under it).

## Note for consumers

The runtime shells are prebuilt — run `npm run build:cli` to pick this up;
`functor run` alone will not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
