### PR TITLE
refactor(site): migrate runtime-target to TypeScript

### DIFF
--- a/site/src/runtime-target.ts
+++ b/site/src/runtime-target.ts
@@ -2,6 +2,15 @@
 // running Functor debug runtime. The in-page wasm preview stays independent:
 // the first explicit push starts a fresh model on the external runtime, then
 // later edits hot-reload there with the model preserved.
+//
+// The wire types below mirror the runtime's HTTP debug protocol
+// (runtime/functor-runtime-common/src/debug_protocol.rs). As with the
+// postMessage types in protocol.ts, response BODIES are asserted rather than
+// validated: the pre-migration code read these fields straight off
+// `response.json()`, and the few defensive runtime checks it did make (the
+// discovery handshake, `Number.isFinite(state.frame)`) are kept as they were.
+
+import type { ConsoleLevel, ProjectFile } from "./protocol.js";
 
 export const DEFAULT_RUNTIME_ENDPOINT = "http://127.0.0.1:8123";
 
@@ -16,8 +25,55 @@ const LIVE_PUSH_DEBOUNCE_MS = 300;
 const STATE_POLL_MS = 1_000;
 const STORAGE_KEY = "functor-runtime-endpoint-v1";
 
+/** The `GET /` handshake body every runtime target serves. */
+export interface RuntimeDiscovery {
+  service: string;
+  protocol_version: number;
+  endpoints: Record<string, string>;
+}
+
+/** A pixel rectangle in the runtime's output surface. */
+export interface RuntimeViewport {
+  width: number;
+  height: number;
+}
+
+/** One rendered view: desktop reports a single `main`, stereo XR one per eye. */
+export interface RuntimeView {
+  name: string;
+  viewport: RuntimeViewport;
+}
+
+/**
+ * The `GET /state` snapshot. `input` (held keys, mouse, optional XR) is a
+ * runtime-owned payload this client never reads, so it stays `unknown` here.
+ */
+export interface RuntimeState {
+  frame: number;
+  tts: number;
+  pending_steps: number;
+  viewport: RuntimeViewport;
+  views: RuntimeView[];
+  model: string;
+  input: unknown;
+}
+
+/** One project file as a caller may hand it over: a pair, or an IDE file. */
+export type ProjectFileInput = [string, string] | ProjectFile;
+
+/** Asset bytes as a caller may hand them over, alongside their path. */
+export type ProjectAssetBytes = Uint8Array | ArrayBuffer | ArrayBufferView | Blob;
+export type ProjectAssetInput =
+  | [string, ProjectAssetBytes]
+  | { path: string; bytes: ProjectAssetBytes };
+
 export class RuntimeHttpError extends Error {
-  constructor(method, url, status, body) {
+  readonly method: string;
+  readonly url: string;
+  readonly status: number;
+  readonly body: string;
+
+  constructor(method: string, url: string, status: number, body: string) {
     super(`${method} ${url} failed with status ${status}: ${body}`);
     this.name = "RuntimeHttpError";
     this.method = method;
@@ -31,14 +87,24 @@ export class RuntimeHttpError extends Error {
 // fetch client intentionally keeps the browser response as a Blob while using
 // the same canonical protocol routes and JSON bodies.
 export class BrowserRuntimeClient {
-  constructor(endpoint, { fetchImpl = fetch, timeoutMs = REQUEST_TIMEOUT_MS } = {}) {
+  readonly endpoint: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly timeoutMs: number;
+
+  constructor(
+    endpoint: unknown,
+    {
+      fetchImpl = fetch,
+      timeoutMs = REQUEST_TIMEOUT_MS,
+    }: { fetchImpl?: typeof fetch; timeoutMs?: number } = {}
+  ) {
     this.endpoint = normalizeEndpoint(endpoint);
     this.fetchImpl = fetchImpl;
     this.timeoutMs = timeoutMs;
   }
 
-  async discover() {
-    const discovery = await this.#json("GET", "/");
+  async discover(): Promise<RuntimeDiscovery> {
+    const discovery = await this.#json<RuntimeDiscovery>("GET", "/");
     if (
       discovery?.service !== SERVICE ||
       !Number.isInteger(discovery?.protocol_version) ||
@@ -51,19 +117,19 @@ export class BrowserRuntimeClient {
     return discovery;
   }
 
-  state() {
-    return this.#json("GET", "/state");
+  state(): Promise<RuntimeState> {
+    return this.#json<RuntimeState>("GET", "/state");
   }
 
-  loadProject(files) {
+  loadProject(files: [string, string][]): Promise<string> {
     return this.#text("POST", "/load-project", files);
   }
 
-  reloadProject(files) {
+  reloadProject(files: [string, string][]): Promise<string> {
     return this.#text("POST", "/reload-project", files);
   }
 
-  reloadAsset(path, bytes) {
+  reloadAsset(path: string, bytes: Uint8Array): Promise<string> {
     const pathBytes = new TextEncoder().encode(path);
     if (pathBytes.byteLength > 0xffff_ffff) throw new Error("asset path is too long");
     const body = new Uint8Array(4 + pathBytes.byteLength + bytes.byteLength);
@@ -79,25 +145,31 @@ export class BrowserRuntimeClient {
     ).then((response) => response.text());
   }
 
-  syncAssets(paths) {
+  syncAssets(paths: string[]): Promise<string> {
     return this.#text("POST", "/sync-assets", paths);
   }
 
-  capture() {
+  capture(): Promise<Blob> {
     return this.#request("POST", "/capture", undefined, CAPTURE_TIMEOUT_MS).then((response) =>
       response.blob()
     );
   }
 
-  async #json(method, path, body) {
-    return (await this.#request(method, path, body)).json();
+  async #json<T>(method: string, path: string, body?: unknown): Promise<T> {
+    return (await this.#request(method, path, body)).json() as Promise<T>;
   }
 
-  async #text(method, path, body) {
+  async #text(method: string, path: string, body?: unknown): Promise<string> {
     return (await this.#request(method, path, body)).text();
   }
 
-  async #request(method, path, body, timeoutMs = this.timeoutMs, contentType = null) {
+  async #request(
+    method: string,
+    path: string,
+    body?: unknown,
+    timeoutMs: number = this.timeoutMs,
+    contentType: string | null = null
+  ): Promise<Response> {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
     const url = `${this.endpoint}${path}`;
@@ -106,16 +178,26 @@ export class BrowserRuntimeClient {
       // `this.fetchImpl(...)` supplies the client as the Web API receiver,
       // which some browsers reject as an illegal invocation before networking.
       const fetchRequest = this.fetchImpl;
+      // `exactOptionalPropertyTypes` rejects an explicit `undefined` body even
+      // though fetch treats it exactly like an absent one, so the init is
+      // asserted rather than restructured — the request is unchanged.
       const response = await fetchRequest(url, {
         method,
         headers:
           body === undefined
             ? undefined
             : { "Content-Type": contentType ?? "application/json" },
+        // An explicit `contentType` is only ever passed with binary bytes (the
+        // asset envelope); every other body goes out as JSON text. The types
+        // cannot express that correlation, hence the assertion.
         body:
-          body === undefined ? undefined : contentType === null ? JSON.stringify(body) : body,
+          body === undefined
+            ? undefined
+            : contentType === null
+              ? JSON.stringify(body)
+              : (body as BodyInit),
         signal: controller.signal,
-      });
+      } as RequestInit);
       if (!response.ok) {
         throw new RuntimeHttpError(method, url, response.status, await response.text());
       }
@@ -126,7 +208,7 @@ export class BrowserRuntimeClient {
   }
 }
 
-export function normalizeEndpoint(raw) {
+export function normalizeEndpoint(raw: unknown): string {
   let value = String(raw ?? "").trim();
   if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(value)) value = `http://${value}`;
   const url = new URL(value);
@@ -140,7 +222,7 @@ export function normalizeEndpoint(raw) {
   return url.toString().replace(/\/$/, "");
 }
 
-const isLoopbackHost = (host) =>
+const isLoopbackHost = (host: string) =>
   host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "[::1]";
 
 const storedEndpoint = () => {
@@ -151,7 +233,7 @@ const storedEndpoint = () => {
   }
 };
 
-const rememberEndpoint = (endpoint) => {
+const rememberEndpoint = (endpoint: string) => {
   try {
     localStorage.setItem(STORAGE_KEY, endpoint);
   } catch {
@@ -159,12 +241,15 @@ const rememberEndpoint = (endpoint) => {
   }
 };
 
-const projectPairs = (files) => {
+// The producers are still JavaScript, so the shape checks in both normalizers
+// below stay exactly as they were: the input types are the contract, not a
+// guarantee, and the assertions keep the checks meaningful to the checker.
+const projectPairs = (files: ProjectFileInput[]): [string, string][] => {
   if (!Array.isArray(files) || files.length === 0) {
     throw new Error("the editor has no project files to push");
   }
   return files.map((file, index) => {
-    const pair = Array.isArray(file) ? file : [file?.path, file?.source];
+    const pair = (Array.isArray(file) ? file : [file?.path, file?.source]) as [string, string];
     if (
       pair.length !== 2 ||
       typeof pair[0] !== "string" ||
@@ -177,15 +262,20 @@ const projectPairs = (files) => {
   });
 };
 
-const projectAssets = async (files) => {
+const projectAssets = async (
+  files: ProjectAssetInput[] | null
+): Promise<[string, Uint8Array][]> => {
   if (!Array.isArray(files)) throw new Error("project assets must be an array");
   return Promise.all(
-    files.map(async (file, index) => {
-      const pair = Array.isArray(file) ? file : [file?.path, file?.bytes];
+    files.map(async (file, index): Promise<[string, Uint8Array]> => {
+      const pair = (Array.isArray(file) ? file : [file?.path, file?.bytes]) as [
+        string,
+        ProjectAssetBytes,
+      ];
       if (pair.length !== 2 || typeof pair[0] !== "string" || pair[0].length === 0) {
         throw new Error(`project asset ${index + 1} is not a [path, bytes] pair`);
       }
-      let bytes;
+      let bytes: Uint8Array;
       if (pair[1] instanceof Uint8Array) {
         bytes = pair[1];
       } else if (pair[1] instanceof ArrayBuffer) {
@@ -202,7 +292,7 @@ const projectAssets = async (files) => {
   );
 };
 
-const errorMessage = (error, endpoint, action) => {
+const errorMessage = (error: unknown, endpoint: string, action: string): string => {
   if (error instanceof RuntimeHttpError) {
     const detail = error.body.trim();
     if (error.status === 503 && action === "capture") {
@@ -210,7 +300,9 @@ const errorMessage = (error, endpoint, action) => {
     }
     return detail || `${action} failed with HTTP ${error.status}`;
   }
-  if (error?.name === "AbortError") {
+  // Read `name` off whatever was thrown, exactly as before: an aborted fetch
+  // rejects with a DOMException, but an injected fetch may throw anything.
+  if ((error as { name?: unknown } | null | undefined)?.name === "AbortError") {
     return `${action} timed out at ${endpoint}`;
   }
   if (error instanceof TypeError) {
@@ -220,10 +312,22 @@ const errorMessage = (error, endpoint, action) => {
   return error instanceof Error ? error.message : String(error);
 };
 
+export interface RuntimeTargetOptions {
+  host: HTMLElement;
+  getProject: () => ProjectFileInput[];
+  getAssets?: (() => ProjectAssetInput[] | Promise<ProjectAssetInput[]>) | null;
+  onOutput?: (level: ConsoleLevel, message: string) => void;
+}
+
 // Mount the same device-link control in the multi-file IDE and the single-file
 // sandbox. `getProject` is evaluated at push time, so queued edits always send
 // the latest complete source set.
-export function createRuntimeTarget({ host, getProject, getAssets = null, onOutput = () => {} }) {
+export function createRuntimeTarget({
+  host,
+  getProject,
+  getAssets = null,
+  onOutput = () => {},
+}: RuntimeTargetOptions) {
   if (!host) throw new Error("runtime target host is required");
 
   host.classList.add("runtime-target-host");
@@ -276,48 +380,52 @@ export function createRuntimeTarget({ host, getProject, getAssets = null, onOutp
     </details>
   `;
 
-  const details = host.querySelector(".runtime-target");
-  const summary = host.querySelector("[data-runtime-summary]");
-  const summaryState = host.querySelector("[data-runtime-summary-state]");
-  const endpointInput = host.querySelector("[data-runtime-endpoint]");
-  const pushButton = host.querySelector("[data-runtime-push]");
-  const captureButton = host.querySelector("[data-runtime-capture]");
-  const closeButton = host.querySelector("[data-runtime-close]");
-  const status = host.querySelector("[data-runtime-status]");
-  const telemetry = host.querySelector("[data-runtime-telemetry]");
-  const frameValue = host.querySelector("[data-runtime-frame]");
-  const timeValue = host.querySelector("[data-runtime-time]");
-  const viewsValue = host.querySelector("[data-runtime-views]");
-  const modelValue = host.querySelector("[data-runtime-model]");
-  const captureFrame = host.querySelector("[data-runtime-capture-frame]");
-  const captureImage = host.querySelector("[data-runtime-image]");
+  // Every query below targets the markup this function just wrote, so each
+  // element is present by construction.
+  const details = host.querySelector<HTMLDetailsElement>(".runtime-target")!;
+  const summary = host.querySelector<HTMLElement>("[data-runtime-summary]")!;
+  const summaryState = host.querySelector<HTMLElement>("[data-runtime-summary-state]")!;
+  const endpointInput = host.querySelector<HTMLInputElement>("[data-runtime-endpoint]")!;
+  const pushButton = host.querySelector<HTMLButtonElement>("[data-runtime-push]")!;
+  const captureButton = host.querySelector<HTMLButtonElement>("[data-runtime-capture]")!;
+  const closeButton = host.querySelector<HTMLButtonElement>("[data-runtime-close]")!;
+  const status = host.querySelector<HTMLElement>("[data-runtime-status]")!;
+  const telemetry = host.querySelector<HTMLElement>("[data-runtime-telemetry]")!;
+  const frameValue = host.querySelector<HTMLElement>("[data-runtime-frame]")!;
+  const timeValue = host.querySelector<HTMLElement>("[data-runtime-time]")!;
+  const viewsValue = host.querySelector<HTMLElement>("[data-runtime-views]")!;
+  const modelValue = host.querySelector<HTMLElement>("[data-runtime-model]")!;
+  const captureFrame = host.querySelector<HTMLElement>("[data-runtime-capture-frame]")!;
+  const captureImage = host.querySelector<HTMLImageElement>("[data-runtime-image]")!;
 
   endpointInput.value = storedEndpoint();
   const localEditorOrigin = isLoopbackHost(window.location.hostname);
 
-  let client = null;
+  let client: BrowserRuntimeClient | null = null;
   let connected = false;
   let live = false;
   let projectRevision = 0;
   let syncedRevision = -1;
   let freshRequiredRevision = 0;
   let freshSatisfiedRevision = -1;
-  let pushTimer = null;
-  let pollTimer = null;
-  let pollingGeneration = null;
+  // `clearTimeout` does not take null, so every clear below passes
+  // `?? undefined`; the stored handles are unchanged by the migration.
+  let pushTimer: ReturnType<typeof setTimeout> | null = null;
+  let pollTimer: ReturnType<typeof setTimeout> | null = null;
+  let pollingGeneration: number | null = null;
   let pushing = false;
   let pushQueued = false;
   let capturing = false;
   let captureQueued = false;
   let generation = 0;
-  let captureUrl = null;
-  let syncError = null;
-  let transportError = null;
-  let lastSyncedAssetSource = null;
-  let lastSyncedAssets = [];
+  let captureUrl: string | null = null;
+  let syncError: string | null = null;
+  let transportError: string | null = null;
+  let lastSyncedAssetSource: ProjectAssetInput[] | null = null;
+  let lastSyncedAssets: [string, Uint8Array][] = [];
   let assetSyncPending = false;
 
-  const renderStatus = (state, summaryText, message) => {
+  const renderStatus = (state: string, summaryText: string, message: string) => {
     details.dataset.state = state;
     summary.dataset.state = state;
     summaryState.textContent = summaryText;
@@ -325,7 +433,7 @@ export function createRuntimeTarget({ host, getProject, getAssets = null, onOutp
     status.textContent = message;
   };
 
-  const renderState = (state) => {
+  const renderState = (state: RuntimeState) => {
     if (!state || !Number.isFinite(state.frame)) return;
     const views = Array.isArray(state.views) ? state.views.map((view) => view.name).join(" + ") : "—";
     frameValue.textContent = String(state.frame);
@@ -345,8 +453,8 @@ export function createRuntimeTarget({ host, getProject, getAssets = null, onOutp
 
   const disconnect = () => {
     generation += 1;
-    clearTimeout(pushTimer);
-    clearTimeout(pollTimer);
+    clearTimeout(pushTimer ?? undefined);
+    clearTimeout(pollTimer ?? undefined);
     client = null;
     connected = false;
     live = false;
@@ -374,7 +482,7 @@ export function createRuntimeTarget({ host, getProject, getAssets = null, onOutp
   };
 
   const pollState = async () => {
-    clearTimeout(pollTimer);
+    clearTimeout(pollTimer ?? undefined);
     pollTimer = null;
     if (!connected || !client || capturing || pushing) return;
     const ownGeneration = generation;
@@ -401,7 +509,9 @@ export function createRuntimeTarget({ host, getProject, getAssets = null, onOutp
     } catch (error) {
       if (ownGeneration !== generation) return;
       if (capturing || pushing) return;
-      transportError = errorMessage(error, client.endpoint, "state poll");
+      // `client` was non-null on entry; only `disconnect()` clears it, and that
+      // bumps the generation the guard above already returned on.
+      transportError = errorMessage(error, client!.endpoint, "state poll");
       renderStatus(
         "error",
         syncError ? "sync error" : "retrying",
@@ -410,13 +520,13 @@ export function createRuntimeTarget({ host, getProject, getAssets = null, onOutp
     } finally {
       if (pollingGeneration === ownGeneration) pollingGeneration = null;
       if (ownGeneration === generation && connected && !capturing && !pushing) {
-        clearTimeout(pollTimer);
+        clearTimeout(pollTimer ?? undefined);
         pollTimer = setTimeout(pollState, STATE_POLL_MS);
       }
     }
   };
 
-  const ensureConnection = async () => {
+  const ensureConnection = async (): Promise<BrowserRuntimeClient | null> => {
     const endpoint = currentEndpoint();
     if (!client || client.endpoint !== endpoint) {
       client = new BrowserRuntimeClient(endpoint);
@@ -447,10 +557,10 @@ export function createRuntimeTarget({ host, getProject, getAssets = null, onOutp
     const sourceNeedsSync = syncedRevision < requestRevision || fresh;
     let endpoint = endpointInput.value;
     let assetCount = 0;
-    let resolvedAssetsSource = null;
-    let assets = [];
-    let sourceResult = null;
-    let runtime = null;
+    let resolvedAssetsSource: ProjectAssetInput[] | null = null;
+    let assets: [string, Uint8Array][] = [];
+    let sourceResult: string | null = null;
+    let runtime: BrowserRuntimeClient | null = null;
     let assetsMutated = false;
     let sourceAccepted = false;
     const priorAssetsKnown = lastSyncedAssetSource !== null;
@@ -559,7 +669,7 @@ export function createRuntimeTarget({ host, getProject, getAssets = null, onOutp
       return;
     }
     pushing = true;
-    clearTimeout(pollTimer);
+    clearTimeout(pollTimer ?? undefined);
     do {
       pushQueued = false;
       await pushOnce();
@@ -573,8 +683,8 @@ export function createRuntimeTarget({ host, getProject, getAssets = null, onOutp
     }
   };
 
-  const queuePush = ({ immediate = false } = {}) => {
-    clearTimeout(pushTimer);
+  const queuePush = ({ immediate = false }: { immediate?: boolean } = {}) => {
+    clearTimeout(pushTimer ?? undefined);
     // The initial load snapshots source before its first await. Edits that land
     // while that load is in flight must queue even though `live` is still false.
     if (pushing) {
@@ -593,7 +703,7 @@ export function createRuntimeTarget({ host, getProject, getAssets = null, onOutp
     }
   };
 
-  const projectChanged = ({ fresh = false } = {}) => {
+  const projectChanged = ({ fresh = false }: { fresh?: boolean } = {}) => {
     projectRevision += 1;
     if (fresh) freshRequiredRevision = projectRevision;
     syncError = null;
@@ -610,7 +720,7 @@ export function createRuntimeTarget({ host, getProject, getAssets = null, onOutp
     const ownGeneration = generation;
     let endpoint = endpointInput.value;
     capturing = true;
-    clearTimeout(pollTimer);
+    clearTimeout(pollTimer ?? undefined);
     captureButton.disabled = true;
     renderStatus("busy", "capture", "Waiting for the next rendered frame…");
     try {

--- a/site/src/runtime-target.ts
+++ b/site/src/runtime-target.ts
@@ -51,7 +51,8 @@ export interface RuntimeView {
 export interface RuntimeState {
   frame: number;
   tts: number;
-  pending_steps: number;
+  /** v3 and later only — this client still links v2 runtimes, which omit it. */
+  pending_steps?: number;
   viewport: RuntimeViewport;
   views: RuntimeView[];
   model: string;
@@ -67,11 +68,16 @@ export type ProjectAssetInput =
   | [string, ProjectAssetBytes]
   | { path: string; bytes: ProjectAssetBytes };
 
+// `declare` on the fields of both classes below: they are assigned by the
+// constructor, and a plain declaration would EMIT a field definition, creating
+// the properties (as undefined) before those assignments. That is observable
+// on this subclass — it would reorder `name` behind them — so declare the
+// types and let the constructor keep being the only thing that emits.
 export class RuntimeHttpError extends Error {
-  readonly method: string;
-  readonly url: string;
-  readonly status: number;
-  readonly body: string;
+  declare readonly method: string;
+  declare readonly url: string;
+  declare readonly status: number;
+  declare readonly body: string;
 
   constructor(method: string, url: string, status: number, body: string) {
     super(`${method} ${url} failed with status ${status}: ${body}`);
@@ -87,9 +93,9 @@ export class RuntimeHttpError extends Error {
 // fetch client intentionally keeps the browser response as a Blob while using
 // the same canonical protocol routes and JSON bodies.
 export class BrowserRuntimeClient {
-  readonly endpoint: string;
-  private readonly fetchImpl: typeof fetch;
-  private readonly timeoutMs: number;
+  declare readonly endpoint: string;
+  private declare readonly fetchImpl: typeof fetch;
+  private declare readonly timeoutMs: number;
 
   constructor(
     endpoint: unknown,
@@ -178,26 +184,24 @@ export class BrowserRuntimeClient {
       // `this.fetchImpl(...)` supplies the client as the Web API receiver,
       // which some browsers reject as an illegal invocation before networking.
       const fetchRequest = this.fetchImpl;
-      // `exactOptionalPropertyTypes` rejects an explicit `undefined` body even
-      // though fetch treats it exactly like an absent one, so the init is
-      // asserted rather than restructured — the request is unchanged.
       const response = await fetchRequest(url, {
         method,
-        headers:
-          body === undefined
-            ? undefined
-            : { "Content-Type": contentType ?? "application/json" },
-        // An explicit `contentType` is only ever passed with binary bytes (the
-        // asset envelope); every other body goes out as JSON text. The types
-        // cannot express that correlation, hence the assertion.
-        body:
-          body === undefined
-            ? undefined
-            : contentType === null
-              ? JSON.stringify(body)
-              : (body as BodyInit),
+        headers: (body === undefined
+          ? undefined
+          : { "Content-Type": contentType ?? "application/json" }) as HeadersInit,
+        // Two assertions, narrowed to the property that needs them: an
+        // explicit `contentType` is only ever passed with binary bytes (the
+        // asset envelope) while every other body goes out as JSON text, and
+        // `exactOptionalPropertyTypes` rejects the explicit `undefined` that
+        // fetch treats exactly like an absent body. `method` and `signal`
+        // stay checked.
+        body: (body === undefined
+          ? undefined
+          : contentType === null
+            ? JSON.stringify(body)
+            : body) as BodyInit,
         signal: controller.signal,
-      } as RequestInit);
+      });
       if (!response.ok) {
         throw new RuntimeHttpError(method, url, response.status, await response.text());
       }
@@ -313,7 +317,9 @@ const errorMessage = (error: unknown, endpoint: string, action: string): string 
 };
 
 export interface RuntimeTargetOptions {
-  host: HTMLElement;
+  /** Nullable because both callers pass `document.getElementById(…)`; the
+   *  guard below is what turns that into the teaching error. */
+  host: HTMLElement | null;
   getProject: () => ProjectFileInput[];
   getAssets?: (() => ProjectAssetInput[] | Promise<ProjectAssetInput[]>) | null;
   onOutput?: (level: ConsoleLevel, message: string) => void;

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -25,11 +25,13 @@
     "isolatedModules": true,
     "verbatimModuleSyntax": true,
 
-    // esbuild is not the only consumer: site/build.mjs imports modules out of
-    // src/ directly, so as those migrate they are executed by NODE's type
-    // stripping, which REJECTS non-erasable syntax (`enum`, `namespace`,
-    // parameter properties). Without this, such a construct would pass
-    // `check:site` and then break `site:build`; here it fails the check first.
+    // esbuild is not the only consumer. site/build.mjs imports modules out of
+    // src/ directly, and a migrated one is imported by its `.ts` specifier
+    // (Node, unlike esbuild, does NOT resolve `./x.js` to `x.ts`) — so it is
+    // executed by NODE's type stripping, which REJECTS non-erasable syntax
+    // (`enum`, `namespace`, parameter properties). Without this, such a
+    // construct would pass `check:site` and then break `site:build`; now the
+    // check fails first.
     "erasableSyntaxOnly": true,
 
     // The site runs in a BROWSER. Without this, tsc auto-includes every

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -25,6 +25,13 @@
     "isolatedModules": true,
     "verbatimModuleSyntax": true,
 
+    // esbuild is not the only consumer: site/build.mjs imports modules out of
+    // src/ directly, so as those migrate they are executed by NODE's type
+    // stripping, which REJECTS non-erasable syntax (`enum`, `namespace`,
+    // parameter properties). Without this, such a construct would pass
+    // `check:site` and then break `site:build`; here it fails the check first.
+    "erasableSyntaxOnly": true,
+
     // The site runs in a BROWSER. Without this, tsc auto-includes every
     // @types/* package in node_modules — @types/node among them — so
     // `process.platform`, `Buffer`, and `require` would all typecheck in code


### PR DESCRIPTION
## What

Wave 2 of the site's file-by-file TypeScript migration: `site/src/runtime-target.js` → `.ts` (702 lines, zero local imports), plus one tsconfig hardening.

**Types only — no behavior changes, no refactors, no renames.** Importers (`sandbox.js`, `ide.js`) are untouched and keep importing `./runtime-target.js`; esbuild and tsc both resolve that to the `.ts`.

Non-mechanical typing decisions:

- **HTTP debug-protocol shapes** (`RuntimeDiscovery`, `RuntimeViewport`, `RuntimeView`, `RuntimeState`) are declared here, mirroring `runtime/functor-runtime-common/src/debug_protocol.rs`. This module speaks the HTTP debug protocol, not the postMessage protocol in `protocol.ts`, so those types do not overlap. `RuntimeState.input` stays `unknown` — the client never reads it.
- **Two shapes ARE reused from `protocol.ts`**, verified against the real producers: `ProjectFile` (`ide.js` hands `createRuntimeTarget` the very same `project.files` array it hands `bridge.setProject`) and `ConsoleLevel` (the `onOutput` level both callers forward to `statusBar.appendOutput`).
- Response bodies are **asserted, not validated** — same stance `protocol.ts` documents. Every defensive runtime check the old code made (the discovery handshake, `Number.isFinite(state.frame)`, the `[path, source]` / `[path, bytes]` shape checks) is kept verbatim, because the producers are still JavaScript.
- `RuntimeState.pending_steps` is **optional**: `MIN_PROTOCOL_VERSION` is 2 and a v2 runtime omits it (`debug_protocol.rs` documents this at the version constant).
- Assertions are narrowed and commented in place: `headers`/`body` on the fetch init (`exactOptionalPropertyTypes` rejects the explicit `undefined` that fetch treats as absent; `body as BodyInit` carries the `contentType` correlation the types cannot express) — `method` and `signal` stay checked — and reading `.name` off an unknown thrown value for the `AbortError` check.
- Constructor-assigned class fields are `declare`d, so **no field definitions are emitted**; a plain declaration would create them (as `undefined`) ahead of the constructor's assignments, which on the `Error` subclass reorders `name` behind them.

## tsconfig hardening

`"erasableSyntaxOnly": true`. `site/build.mjs` imports modules out of `site/src` directly under Node, whose type stripping rejects `enum` / `namespace` / parameter properties — without the flag such a construct would pass `check:site` and break `site:build`. No existing `.ts` trips it.

## Bundle diff (main vs. HEAD)

`sandbox.js` and `ide.js` are **+56 bytes**; after normalising esbuild's identifier renaming, the diff is *one* construct and nothing else:

- seven × `clearTimeout(t ?? void 0)` — `clearTimeout` does not accept `null`, so the clears pass `?? undefined`; the stored handles are unchanged, and `clearTimeout(null)`/`clearTimeout(undefined)` are the same no-op.

`hero.js`, `demo-editor.js`, `docs.js`, `api-docs.js`, `features.js`: byte-identical. (Before the review fixes the delta also included emitted class-field definitions; `declare` removed those.)

## Verification

| check | result |
| --- | --- |
| `npm run check:site` | pass |
| `npm run site:build` | pass |
| `e2e/site-sandbox.mjs` | ALL CHECKS PASSED (incl. lang-intel completion checks — lang wasm present, nothing SKIPped) |
| `e2e/ide-page.mjs` | RESULT: PASS |
| `e2e/ide-project.mjs` | RESULT: PASS |
| `e2e/runtime-target.mjs` | ALL CHECKS PASSED (24 checks — the dedicated suite for this file) |

## Review (`/xreview` — Claude subagent + Codex CLI, independent)

Both engines verified the migration is semantics-preserving; the Claude reviewer did it mechanically, by emitting both files through esbuild with this tsconfig and diffing the output. **No Critical or High findings from either engine.**

| # | Finding | Engine(s) | Disposition |
| --- | --- | --- | --- |
| 1 | `pending_steps` typed required, but a v2 runtime (still accepted) omits it | **[AGREED]** both | **Fixed** — now optional, with the v3 note |
| 2 | Emitted class fields reorder `name` on the `RuntimeHttpError` subclass | Codex (Claude noted it as unobservable) | **Fixed** — `declare` fields, so nothing is emitted; also shrinks the bundle delta to the `?? void 0` calls alone |
| 3 | `host: HTMLElement` contradicts both callers' `getElementById` and the function's own null guard | Claude | **Fixed** — `HTMLElement \| null`; the guard is the narrowing |
| 4 | `as RequestInit` on the whole literal stops checking `method`/`signal` too | Claude | **Fixed** — narrowed to `headers`/`body` |
| 5 | tsconfig comment implies Node resolves `./x.js` → `x.ts` (it does not; esbuild does) | Claude | **Fixed** — comment corrected |
| 6 | `RuntimeViewport`/`RuntimeView`/`RuntimeState` duplicate `tools/functor-sdk/src/types.ts` | Claude | **Won't fix (documented)** — the root `package.json` has no workspaces and `@functor/sdk` is not a site dependency, and `site/tsconfig.json` pins `"types": []`; importing across would need build/dependency changes well beyond this migration. Rust stays the single source of truth for the wire shape |

Full verification (all six checks above) was **re-run green after these fixes**, including a fresh bundle diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
