### PR TITLE
docs(skills): game-jam — sweep fixer build caches between heavy agents

### DIFF
--- a/.claude/skills/game-jam/SKILL.md
+++ b/.claude/skills/game-jam/SKILL.md
@@ -107,6 +107,14 @@ numbers. Rules:
 - Sequencing mechanic: resume/spawn one agent, wait for its completion
   notification, then start the next — nearest-to-completion first so results
   land early.
+- **Disk hygiene between fixers (learned mid-run: a full disk killed a fixer
+  mid-build).** Every heavy fixer leaves a multi-GB `target/` cache in its
+  worktree; a long fixer queue fills the drive. Once a fixer's PR is pushed,
+  its `target/` is pure rebuildable cache — sweep finished fixers' caches
+  BEFORE starting the next heavy agent (`rm -rf .claude/worktrees/agent-*/target`
+  for done agents only; never the running one's), and check free space
+  (`df -h`) as part of each heavy launch. Don't wait for end-of-jam cleanup;
+  by then the drive may already be full.
 
 ## Phase 1.5 — gap fixers (sequential, after entries complete)
 


### PR DESCRIPTION
## What

One more operational lesson from the live jam: the fixer queue's accumulated `target/` caches (multi-GB per heavy agent worktree) filled the disk and killed the mouse-button fixer mid-build — every Bash call failing with `No space left on device`. Recovery was deleting the 13 finished agents' caches (~10.5 GB freed instantly; all their work was committed/pushed, so caches were pure rebuildable state).

The skill's concurrency section now says: sweep finished fixers' `target/` dirs **between** heavy agents and check `df` at each heavy launch — don't defer disk cleanup to end-of-jam.

## Notes

Docs/process-only. Follows #479/#491/#493 in the skill's lessons-from-the-first-run series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)