### PR TITLE
feat(input): add a mouseButton hook and held mouse-button state

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -205,7 +205,7 @@ let grab = (s) =>
   (they evaluate first); siblings may reference the entry (`Game.foo`) if
   that creates no cycle.
 - **Protected namespaces**: a file whose module name collides with a
-  builtin/prelude or bundled-core namespace (Net, Key, Random, Option, Result,
+  builtin/prelude or bundled-core namespace (Net, Key, Mouse, Random, Option, Result,
   List, Text, Math, Debug, Scene,
   Sprite, Anim, Asset, Camera, Camera2D, Frame, Light, Fog, Color, Vec3, Skybox,
   Angle, Texture, Time, Input, Sub, Effect, Physics, RenderTarget, Ui, Html, Attr,
@@ -236,9 +236,17 @@ let grab = (s) =>
   (`key == Key.Enter`); a typo (`Key.Enterr`) is a load-time error — the
   reason keys stopped being strings. `Random` is likewise built-in (the
   abstract `Random.Seed` — see the Random builtins above).
+- **`Mouse` is a built-in module**: `Mouse.t`, the variant the `mouseButton`
+  hook's `button` parameter carries — `Mouse.Left`, `Mouse.Right`,
+  `Mouse.Middle`. The `Key` story exactly: match constructors
+  (`| Mouse.Left =>`) or compare (`button == Mouse.Right`), and a typo is a
+  load-time error. Buttons the platform reports that Functor does not name are
+  never delivered (no `Unknown` variant reaches game logic).
 - **`Input` is the engine's continuously sampled input module.**
   `Input.snapshot` contains `heldKeys: List<Key.t>`, a pixel-space `mouse`
-  record, and `xr: Option.t<Input.xr>`. XR head/grip/aim poses are rig-local
+  record (`{ x, y, buttons: { left, right, middle } }` — `buttons` is the HELD
+  level state, the complement to `mouseButton`'s edges), and
+  `xr: Option.t<Input.xr>`. XR head/grip/aim poses are rig-local
   plain data: position `{x,y,z}` and quaternion `{x,y,z,w}`, with +X right,
   +Y up, and -Z forward. Each controller also carries `active`, analog
   trigger/squeeze/thumbstick state, and named button booleans. Missing XR,
@@ -246,7 +254,7 @@ let grab = (s) =>
   `Option.None`/`active: false`, never stale values. Future gamepad and mobile
   touch domains belong as typed siblings of `xr` on the snapshot.
 - **Bundled modules use the ordinary module semantics.** The language-owned
-  `Net.fun` / `Key.fun` builtins, `Random.funi` interface, and
+  `Net.fun` / `Key.fun` / `Mouse.fun` builtins, `Random.funi` interface, and
   `Option.fun` / `Result.fun` standard-library implementations are in-memory
   sources distributed with every embedding. Engine hosts additionally bundle
   `Animator.fun`, a pure Functor Lang crossfade helper built on the host's
@@ -1146,6 +1154,12 @@ let sampledInput = (model, snapshot: Input.snapshot) => model'
                                             // before every simulation tick
 let mouseMove = (model, x, y) => model'     // OPTIONAL; window pixels
 let mouseWheel = (model, delta) => model'   // OPTIONAL
+let mouseButton = (model, button, isDown) => model'
+                                            // OPTIONAL; button: Mouse.t — match
+                                            // | Mouse.Left / Mouse.Right /
+                                            // Mouse.Middle. Delivered while the
+                                            // cursor is captured, so click-to-
+                                            // shoot works under free-look
 let update = (model, msg) => model'         // OPTIONAL; msgs are ADT variants
                                             // ANY entry point may instead return
                                             // (model', effect) — a 2-tuple whose
@@ -1197,7 +1211,10 @@ debug server's `/time` advance. To *see* colliders, run with
 (collider outlines, contacts, body frames).
 
 `sampledInput` is the level-state complement to the edge-oriented `input` /
-`mouseMove` hooks. Shells sample it once per fixed simulation step; a hook may
+`mouseMove` / `mouseButton` hooks — `mouseButton` tells you a click HAPPENED,
+`snapshot.mouse.buttons.left` tells you it is still held (so a full-auto weapon
+reads the snapshot and a semi-auto one takes the edge). Shells sample it once
+per fixed simulation step; a hook may
 return either a bare model or `(model, effect)` like other model-updating entry
 points. Samples are plain data recorded in the frame input log, so rewind,
 forward ghosting, and counterfactual history replay re-run the same snapshot

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,10 +71,15 @@ name (contract in the `functor-lang` skill; reference: `examples/hello/game.fun`
 - `init` — the initial model, a plain Functor Lang value
 - `input = (model, key, isDown) => model'` — OPTIONAL; keyboard events, keys as the built-in
   `Key` module's variants (`Key.W`, `Key.Up`, `Key.Space`, `Key.Num0`..`Key.Num9`).
-  `mouseMove`/`mouseWheel` are the analogous optional entry points
+  `mouseMove`/`mouseWheel`/`mouseButton` are the analogous optional entry points
+- `mouseButton = (model, button, isDown) => model'` — OPTIONAL; mouse-button edges, buttons as
+  the built-in `Mouse` module's variants (`Mouse.Left`, `Mouse.Right`, `Mouse.Middle`).
+  Delivered **while the cursor is captured** (the rule `mouseMove`/`mouseWheel` already follow),
+  so click-to-shoot works under free-look; a held button is swept released on focus loss
 - `sampledInput = (model, snapshot: Input.snapshot) => model'` — OPTIONAL; per-fixed-step
-  held/device state. `snapshot` has keyboard/mouse plus typed device domains (`xr` first;
-  gamepad and mobile touch extend it as siblings)
+  held/device state. `snapshot` has keyboard/mouse (`mouse.buttons.left`/`.right`/`.middle` for
+  held buttons — the level twin of `mouseButton`'s edges, so full-auto fire is a `sampledInput`
+  read) plus typed device domains (`xr` first; gamepad and mobile touch extend it as siblings)
 - `tick = (model, dt, tts) => model'` — per-frame simulation step
 - `update = (model, msg) => model'` — OPTIONAL; handles messages (ADT variants) from subscriptions/effects
 - `subscriptions = (model) => Sub.every(...)` — OPTIONAL declarative timers, polled each frame (requires `update`)
@@ -82,7 +87,8 @@ name (contract in the `functor-lang` skill; reference: `examples/hello/game.fun`
 - `physics = (model) => Physics.scene(...)`, `soundScape = (model) => AudioScene.create(...)`,
   `ui = (model) => …` — OPTIONAL hooks
 
-The model-updating entry points (`tick`, `input`, `sampledInput`, `mouseMove`, `mouseWheel`, `update`) may return
+The model-updating entry points (`tick`, `input`, `sampledInput`, `mouseMove`, `mouseWheel`,
+`mouseButton`, `update`) may return
 a `(model', effect)` tuple instead of a bare model, whose effect result folds back through
 `update`. `init` is a plain value (an Effect in it is rejected at load); `draw`/`physics`/
 `soundScape`/`ui`/`subscriptions` return their own specific values. The model is a plain

--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -106,12 +106,20 @@ JSON is tagged by `type`. Unknown keys/shapes return **400** with a message.
 {"type":"key","key":"w","down":true}      // key press / release
 {"type":"mouse_move","x":10,"y":20}       // absolute cursor position
 {"type":"mouse_wheel","delta":1}          // scroll
+{"type":"mouse_button","button":"left","down":true}            // "left"|"right"|"middle"
 {"type":"ui_event","slot":0,"kind":"Clicked"}                  // click widget slot 0
 {"type":"ui_event","slot":1,"kind":{"SliderChanged":0.5}}      // drag slider slot 1
 {"type":"ui_event","slot":2,"kind":{"TextChanged":"hi"}}       // edit text input slot 2
 {"type":"xr","left":{...},"right":{...},"head":{...}}          // set the XR device sample
 {"type":"xr_clear"}                                            // drop it again
 ```
+
+`mouse_button` is both an edge and level state, exactly like `key`: it calls the
+game's `mouseButton` hook AND updates the held buttons that later steps'
+`sampledInput` sees (`mouse.buttons`), so holding one across several
+`/time advance` steps scripts full-auto fire. A release is delivered only if the
+game saw the press. Unlike window buttons it ignores cursor capture — a
+headless/hidden session has no capture to acquire.
 
 `ui_event` drives the game's interactive UI widgets without pixels or
 hit-testing (docs/ui-interaction.md): `slot` is the widget's index in the
@@ -187,7 +195,7 @@ tracking is valid:
 ```jsonc
 {
   "held_keys": [],
-  "mouse": { "x": 0, "y": 0 },
+  "mouse": { "x": 0, "y": 0, "buttons": { "left": false, "right": false, "middle": false } },
   "xr": {
     "head": {
       "position": [0.0, 0.0, 0.0],

--- a/docs/functor-lang.md
+++ b/docs/functor-lang.md
@@ -291,6 +291,21 @@ snapshots — no GPU, fully agent-verifiable.
       server's wire format (`{"type":"key","key":"w"}`) is unchanged.
       Key values are plain data (nullary variants), so a key stored in the
       model snapshots and hot-reloads like any field.
+- [x] **Mouse buttons (`Mouse.t` + the `mouseButton` hook)** (2026-07-26). The
+      `Key.t` design applied to the pointer: an optional
+      `mouseButton(model, button, isDown)` entry point whose `button` is the
+      built-in `Mouse` module's variant (`<builtin>/Mouse.fun`, injected beside
+      `Key`): `Mouse.Left`/`Right`/`Middle`. Buttons reach game logic **while
+      the cursor is captured** — the rule `mouseMove`/`mouseWheel` already
+      followed, and the fix for clicks being eaten by free-look capture — and a
+      held button is swept released on focus loss, Escape, and the console
+      toggle so it cannot fire forever. The held level state rides on the
+      sampled snapshot as `mouse.buttons.{left,right,middle}`, making
+      `mouseButton` the edge and `sampledInput` the level (semi- vs. full-auto).
+      All three producers plus the replay path build the variant from one shared
+      conversion, so live input, forward-step projection, and the journal agree;
+      `POST /input {"type":"mouse_button","button":"left","down":true}` scripts
+      it headlessly as both edge and level.
 - [x] **Branded `Color` values** (2026-07-16; strong-typing track). The Angle
       rule applied to color: `Color.rgb(r, g, b)` makes an opaque `Color.t`,
       and every color parameter — `Scene.color`/`lit`/`emissive`/

--- a/docs/time-travel.md
+++ b/docs/time-travel.md
@@ -176,7 +176,7 @@ construction (the invariant physics already proves with goldens).
 | Whole-game frame-clock pause/step/resume | **Shipped** as debug server `POST /time` (pins `dts=0`) — desktop only |
 | egui backend in both shells (real `Context` + `Painter`, v0.34) | **Shipped** (`ui.rs`, both runners) |
 | **egui receiving pointer input / clicks** | *Missing — `RawInput` is empty, every element `.interactable(false)`* |
-| **Mouse clicks reaching game/overlay at all** | *Missing — `MouseEvent` is only `MouseMove`/`MouseWheel`; button presses feed cursor-capture only* |
+| **Mouse clicks reaching game/overlay at all** | **Shipped** as the `mouseButton` hook (`Mouse.Left`/`Right`/`Middle`) plus held `mouse.buttons` on the sampled snapshot; buttons reach the game while the cursor is captured |
 | Interactive UI (buttons with actions) | *Missing — `View` is `Empty/Text/Row/Column/Panel`, not parameterized over a message* |
 | Web debug server / control channel | *Missing — but egui itself runs on web* |
 | Serializable model (disk/wire) | *Missing (`Closure`/`HostData` aren't `Serialize`) — **not needed** for in-session rewind* |

--- a/docs/ui-interaction.md
+++ b/docs/ui-interaction.md
@@ -94,9 +94,11 @@ game's perspective this is fully Elm-controlled.
 - **Routing policy.** Pointer: when the cursor is free, events feed egui;
   when egui doesn't want the pointer, a click recaptures for free-look (as
   today). Keyboard: when egui wants keyboard (a text field is focused), key
-  events are suppressed from the game's `input` hook. A raw `mouseButton`
-  game hook (click-to-shoot into the 3D world) is out of scope — a natural
-  follow-up on the same plumbing.
+  events are suppressed from the game's `input` hook. The raw `mouseButton`
+  game hook (click-to-shoot into the 3D world) has since LANDED on this same
+  plumbing: buttons reach the game only **while the cursor is captured**, which
+  is exactly the state in which egui does not want the pointer — so the two
+  consumers never contend for the same click.
 
 - **Headless testability (LLM-native).** Because `UiEvent` is serializable
   and routed through one producer method, the debug server gains

--- a/functor-lang/src/project.rs
+++ b/functor-lang/src/project.rs
@@ -244,6 +244,17 @@ const KEY_MODULE_SRC: &str = "type t =\n\
      | Space | Enter | Escape\n\
      | Num0 | Num1 | Num2 | Num3 | Num4 | Num5 | Num6 | Num7 | Num8 | Num9\n";
 
+/// The built-in `Mouse` module (the mouse twin of `Key`): the variant the
+/// `mouseButton` hook's `button` parameter carries — `Mouse.Left`,
+/// `Mouse.Right`, `Mouse.Middle` — so a typo is a check-time
+/// unknown-constructor error instead of a silently dead arm. The shells build
+/// matching `Mouse.*` values (`functor_runtime_common::MouseButton::ctor_tag`);
+/// `Unknown` is filtered before dispatch and deliberately has no constructor
+/// here. Keep in sync with the `MouseButton` enum in
+/// `functor_runtime_common::input`.
+const MOUSE_MODULE_SRC: &str = "type t =\n\
+     | Left | Right | Middle\n";
+
 const OPTION_MODULE_SRC: &str = include_str!("../stdlib/option.fun");
 const RESULT_MODULE_SRC: &str = include_str!("../stdlib/result.fun");
 
@@ -255,6 +266,7 @@ fn core_modules() -> Vec<BundledModule> {
         BundledModule::builtin("Net", NET_MODULE_SRC, BundledModuleKind::Implementation),
         BundledModule::builtin("Random", RANDOM_MODULE_SRC, BundledModuleKind::Interface),
         BundledModule::builtin("Key", KEY_MODULE_SRC, BundledModuleKind::Implementation),
+        BundledModule::builtin("Mouse", MOUSE_MODULE_SRC, BundledModuleKind::Implementation),
         BundledModule::implementation("Option", OPTION_MODULE_SRC),
         BundledModule::implementation("Result", RESULT_MODULE_SRC),
     ]

--- a/functor-lang/tests/project.rs
+++ b/functor-lang/tests/project.rs
@@ -811,7 +811,8 @@ fn single_file_project_adds_only_the_core_modules() {
     }
     // The ONLY additions are the core modules': Net's canonicalized
     // `Net.NetEvent` / `Net.HttpResponse`, Random's abstract `Random.Seed`,
-    // the input-key variant `Key.t`, and the stdlib's generic Option/Result.
+    // the input variants `Key.t` / `Mouse.t`, and the stdlib's generic
+    // Option/Result.
     assert!(
         proj_types.contains(&"Net.NetEvent") && proj_types.contains(&"Net.HttpResponse"),
         "the built-in Net module must be injected: {proj_types:?}"
@@ -825,13 +826,17 @@ fn single_file_project_adds_only_the_core_modules() {
         "the built-in Key module must be injected: {proj_types:?}"
     );
     assert!(
+        proj_types.contains(&"Mouse.t"),
+        "the built-in Mouse module must be injected: {proj_types:?}"
+    );
+    assert!(
         proj_types.contains(&"Option.t") && proj_types.contains(&"Result.t"),
         "the bundled stdlib modules must be injected: {proj_types:?}"
     );
     assert_eq!(
         proj_types.len(),
-        plain.types.len() + 6,
-        "no types beyond the entry's + Net(2) + Random + Key + Option + Result"
+        plain.types.len() + 7,
+        "no types beyond the entry's + Net(2) + Random + Key + Mouse + Option + Result"
     );
 }
 

--- a/functor-prelude/prelude/input.funi
+++ b/functor-prelude/prelude/input.funi
@@ -35,8 +35,13 @@ type xr = {
   right: controller
 }
 
-/// Mouse position in shell-provided surface coordinates.
-type mouse = { x: float, y: float }
+/// Which mouse buttons are held right now — the level complement of the
+/// `mouseButton(model, button, isDown)` edge hook, and what continuous
+/// behavior (full-auto fire, drag) should read.
+type mouseButtons = { left: bool, right: bool, middle: bool }
+
+/// Mouse position in shell-provided surface coordinates, plus held buttons.
+type mouse = { x: float, y: float, buttons: mouseButtons }
 
 /// Held and continuously sampled input for one simulation tick.
 type snapshot = {

--- a/runtime/functor-runtime-common/src/debug_protocol.rs
+++ b/runtime/functor-runtime-common/src/debug_protocol.rs
@@ -80,7 +80,7 @@ pub const DEBUG_ROUTES: &[DebugRoute] = &[
     DebugRoute {
         method: "POST",
         path: "/input",
-        description: "inject input — {\"type\":\"key\",\"key\":\"w\",\"down\":true} | {\"type\":\"mouse_move\",\"x\":0,\"y\":0} | {\"type\":\"mouse_wheel\",\"delta\":1} | {\"type\":\"ui_event\",\"slot\":0,\"kind\":\"Clicked\"} | {\"type\":\"webview_event\",\"slot\":0,\"kind\":\"Clicked\"} | {\"type\":\"xr\",\"left\":{...},\"right\":{...},\"head\":{...}} (desktop only; level state until the next xr command) | {\"type\":\"xr_clear\"} (drop it, restoring the emulator or no device)",
+        description: "inject input — {\"type\":\"key\",\"key\":\"w\",\"down\":true} | {\"type\":\"mouse_move\",\"x\":0,\"y\":0} | {\"type\":\"mouse_wheel\",\"delta\":1} | {\"type\":\"mouse_button\",\"button\":\"left\",\"down\":true} (edge + held level, like key) | {\"type\":\"ui_event\",\"slot\":0,\"kind\":\"Clicked\"} | {\"type\":\"webview_event\",\"slot\":0,\"kind\":\"Clicked\"} | {\"type\":\"xr\",\"left\":{...},\"right\":{...},\"head\":{...}} (desktop only; level state until the next xr command) | {\"type\":\"xr_clear\"} (drop it, restoring the emulator or no device)",
     },
     DebugRoute {
         method: "POST",
@@ -193,6 +193,14 @@ pub enum InputCommand {
     Key { key: String, down: bool },
     MouseMove { x: i32, y: i32 },
     MouseWheel { delta: i32 },
+    /// A mouse-button edge, `button` spelled `"left"` / `"right"` /
+    /// `"middle"` (the [`crate::MouseButton::from_name`] wire spelling).
+    ///
+    /// Both an edge AND level state, exactly like `key`: it calls the game's
+    /// `mouseButton` hook and updates the held buttons the next step's
+    /// `sampledInput` samples — so full-auto fire is scriptable by holding
+    /// `down: true` across several `/time advance` steps.
+    MouseButton { button: String, down: bool },
     UiEvent { slot: u32, kind: UiEventKind },
     WebviewEvent { slot: u32, kind: UiEventKind },
     /// Set the XR device sample the next fixed step's `sampledInput` sees, so
@@ -356,7 +364,11 @@ mod tests {
             model: "Model {\n  label: \"hello\"\n}".into(),
             input: InputSnapshot {
                 held_keys: vec![Key::W, Key::Up],
-                mouse: crate::MouseSnapshot { x: 10, y: 20 },
+                mouse: crate::MouseSnapshot {
+                    x: 10,
+                    y: 20,
+                    ..Default::default()
+                },
                 xr: None,
             },
         };
@@ -375,7 +387,11 @@ mod tests {
                 "model": "Model {\n  label: \"hello\"\n}",
                 "input": {
                     "held_keys": ["W", "Up"],
-                    "mouse": { "x": 10, "y": 20 }
+                    "mouse": {
+                        "x": 10,
+                        "y": 20,
+                        "buttons": { "left": false, "right": false, "middle": false }
+                    }
                 }
             })
         );
@@ -430,6 +446,16 @@ mod tests {
             InputCommand::UiEvent {
                 slot: 3,
                 kind: UiEventKind::SliderChanged(0.5)
+            }
+        );
+        assert_eq!(
+            serde_json::from_str::<InputCommand>(
+                r#"{"type":"mouse_button","button":"left","down":true}"#
+            )
+            .unwrap(),
+            InputCommand::MouseButton {
+                button: "left".into(),
+                down: true
             }
         );
         assert_eq!(

--- a/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
@@ -103,6 +103,7 @@ pub struct FunctorLangEmbeddedGame {
     pending_sampled_input: Option<crate::InputSnapshot>,
     has_mouse_move: bool,
     has_mouse_wheel: bool,
+    has_mouse_button: bool,
     has_subscriptions: bool,
     /// The previous frame's total-time, the left edge of the `(prev, tts]`
     /// window subscriptions fire over. `None` until the first frame has run
@@ -210,6 +211,7 @@ struct Loaded {
     has_sampled_input: bool,
     has_mouse_move: bool,
     has_mouse_wheel: bool,
+    has_mouse_button: bool,
     has_subscriptions: bool,
     has_physics: bool,
     has_soundscape: bool,
@@ -297,6 +299,11 @@ return them beside the model as `(model, effect)`"
     if has_mouse_wheel {
         require_function(&path, &session, "mouseWheel", 2)?;
     }
+    // `mouseButton(model, button, isDown)` — the `input` twin for the pointer.
+    let has_mouse_button = session.global("mouseButton").is_some();
+    if has_mouse_button {
+        require_function(&path, &session, "mouseButton", 3)?;
+    }
     // The MVU pair: `subscriptions(model)` declares timers whose fired
     // messages fold through `update(model, msg)` — so subscriptions
     // without an update have nowhere to deliver.
@@ -348,6 +355,7 @@ return them beside the model as `(model, effect)`"
         has_sampled_input,
         has_mouse_move,
         has_mouse_wheel,
+        has_mouse_button,
         has_subscriptions,
         has_physics,
         has_soundscape,
@@ -395,6 +403,7 @@ impl FunctorLangEmbeddedGame {
             pending_sampled_input: None,
             has_mouse_move: loaded.has_mouse_move,
             has_mouse_wheel: loaded.has_mouse_wheel,
+            has_mouse_button: loaded.has_mouse_button,
             has_subscriptions: loaded.has_subscriptions,
             prev_tts: None,
             effect_runner: RealEffects::new(),
@@ -463,6 +472,7 @@ impl FunctorLangEmbeddedGame {
         self.pending_sampled_input = None;
         self.has_mouse_move = loaded.has_mouse_move;
         self.has_mouse_wheel = loaded.has_mouse_wheel;
+        self.has_mouse_button = loaded.has_mouse_button;
         self.has_subscriptions = loaded.has_subscriptions;
         self.has_physics = loaded.has_physics;
         if !self.has_physics {
@@ -553,6 +563,7 @@ impl FunctorLangEmbeddedGame {
         self.pending_sampled_input = None;
         self.has_mouse_move = loaded.has_mouse_move;
         self.has_mouse_wheel = loaded.has_mouse_wheel;
+        self.has_mouse_button = loaded.has_mouse_button;
         self.has_subscriptions = loaded.has_subscriptions;
         self.prev_tts = None;
         self.asset_progress = None;
@@ -877,6 +888,25 @@ impl GameProducer for FunctorLangEmbeddedGame {
         }
         self.input_buf
             .push(crate::RecordedInput::MouseWheel { delta });
+    }
+
+    fn mouse_button(&mut self, button: i32, is_down: bool) {
+        // The optional `mouseButton` entry point: (model, button, isDown) =>
+        // model. Buttons cross as the built-in `Mouse` module's variants
+        // (`Mouse.Left`) — mirrors the other producers.
+        if !self.has_mouse_button {
+            return;
+        }
+        let Some(button_value) = crate::mouse_button_input_value(button) else {
+            return; // unrecognized code / MouseButton::Unknown — never delivered.
+        };
+        let args = vec![self.model.clone(), button_value, Value::Bool(is_down)];
+        match self.session.call("mouseButton", args, &mut FunctorHost) {
+            Ok(returned) => self.ctx().absorb(returned),
+            Err(err) => self.reporter.frame_error("mouseButton", &err),
+        }
+        self.input_buf
+            .push(crate::RecordedInput::MouseButton { button, is_down });
     }
 
     fn ui_event(&mut self, event: crate::ui::UiEvent) {
@@ -1291,7 +1321,11 @@ let draw = (model, tts) =>
 
         let snapshot = crate::InputSnapshot {
             held_keys: vec![crate::Key::W, crate::Key::Space],
-            mouse: crate::MouseSnapshot { x: 42, y: 9 },
+            mouse: crate::MouseSnapshot {
+                x: 42,
+                y: 9,
+                ..Default::default()
+            },
             xr: Some(crate::XrInputSnapshot {
                 right: crate::XrControllerSnapshot {
                     active: true,
@@ -1333,7 +1367,11 @@ let draw = (model, tts) =>
         )
         .expect("sampled-input game loads");
         let snapshot = |x| crate::InputSnapshot {
-            mouse: crate::MouseSnapshot { x, y: 0 },
+            mouse: crate::MouseSnapshot {
+                    x,
+                    y: 0,
+                    ..Default::default()
+                },
             ..crate::InputSnapshot::default()
         };
 
@@ -1443,7 +1481,11 @@ let draw = (model, tts) =>
         .expect("sampled-input game loads");
         for (frame, x) in [1, 2, 3].into_iter().enumerate() {
             game.sampled_input(&crate::InputSnapshot {
-                mouse: crate::MouseSnapshot { x, y: 0 },
+                mouse: crate::MouseSnapshot {
+                    x,
+                    y: 0,
+                    ..Default::default()
+                },
                 ..crate::InputSnapshot::default()
             });
             game.tick(frame_time((frame + 1) as f32 / 60.0, 1.0 / 60.0));
@@ -1494,7 +1536,11 @@ let draw = (model, tts) =>
 
         for (frame, x) in [1, 2].into_iter().enumerate() {
             game.sampled_input(&crate::InputSnapshot {
-                mouse: crate::MouseSnapshot { x, y: 0 },
+                mouse: crate::MouseSnapshot {
+                    x,
+                    y: 0,
+                    ..Default::default()
+                },
                 ..crate::InputSnapshot::default()
             });
             game.tick(frame_time((frame + 1) as f32 / 60.0, 1.0 / 60.0));
@@ -1534,7 +1580,11 @@ let draw = (model, tts) =>
         .expect("sampled-input game loads");
         for (frame, x) in [1, 2, 3].into_iter().enumerate() {
             game.sampled_input(&crate::InputSnapshot {
-                mouse: crate::MouseSnapshot { x, y: 0 },
+                mouse: crate::MouseSnapshot {
+                    x,
+                    y: 0,
+                    ..Default::default()
+                },
                 ..crate::InputSnapshot::default()
             });
             game.tick(frame_time((frame + 1) as f32 / 60.0, 1.0 / 60.0));

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -86,6 +86,7 @@ pub enum Provenance {
     SampledInput,
     MouseMove,
     MouseWheel,
+    MouseButton,
     Subscription,
     EffectResult,
     PhysicsQuery,
@@ -135,6 +136,19 @@ impl Provenance {
             Provenance::SampledInput => "sampled input".to_string(),
             Provenance::MouseMove => "mouseMove".to_string(),
             Provenance::MouseWheel => "mouseWheel".to_string(),
+            // Same shape as `input`: the `Mouse.*` variant plus the edge, so a
+            // click is as readable in the trace as a keypress.
+            Provenance::MouseButton => {
+                let button = match args.get(1) {
+                    Some(v @ Value::Variant { .. }) => v.to_string(),
+                    _ => String::new(),
+                };
+                let dir = match args.get(2) {
+                    Some(Value::Bool(false)) => "up",
+                    _ => "down",
+                };
+                format!("mouseButton: {button} {dir}")
+            }
             Provenance::Subscription => format!("subscription: {}", msg()),
             Provenance::EffectResult => format!("effect result: {}", msg()),
             Provenance::PhysicsQuery => format!("physics query: {}", msg()),
@@ -621,8 +635,18 @@ impl FrameCtx<'_> {
                                 }
                             }
                             RecordedInput::MouseMove { x, y } => {
-                                sampled_input.get_or_insert_with(Default::default).mouse =
-                                    crate::MouseSnapshot { x: *x, y: *y };
+                                let sample = sampled_input.get_or_insert_with(Default::default);
+                                sample.mouse.x = *x;
+                                sample.mouse.y = *y;
+                            }
+                            RecordedInput::MouseButton { button, is_down } => {
+                                if let Some(button) = crate::MouseButton::from_i32(*button) {
+                                    sampled_input
+                                        .get_or_insert_with(Default::default)
+                                        .mouse
+                                        .buttons
+                                        .set(button, *is_down);
+                                }
                             }
                             _ => {}
                         }
@@ -713,6 +737,15 @@ impl FrameCtx<'_> {
                 "mouseWheel",
                 vec![self.model.clone(), Value::Number(delta as f64)],
             ),
+            RecordedInput::MouseButton { button, is_down } => {
+                let Some(button_value) = crate::mouse_button_input_value(button) else {
+                    return; // unrecognized code / Unknown — dropped, like live.
+                };
+                (
+                    "mouseButton",
+                    vec![self.model.clone(), button_value, Value::Bool(is_down)],
+                )
+            }
             RecordedInput::Snapshot(snapshot) => {
                 self.deliver_sampled_input(&snapshot, false);
                 return;
@@ -1786,7 +1819,11 @@ mod tests {
             .unwrap_or_else(|f| panic!("session: {}", f.error.message));
         let sample = |x| {
             vec![RecordedInput::Snapshot(Box::new(crate::InputSnapshot {
-                mouse: crate::MouseSnapshot { x, y: 0 },
+                mouse: crate::MouseSnapshot {
+                    x,
+                    y: 0,
+                    ..Default::default()
+                },
                 ..crate::InputSnapshot::default()
             }))]
         };
@@ -1811,7 +1848,11 @@ mod tests {
         assert_eq!(stepped[2].0.to_string(), "20.5");
 
         let carried = crate::InputSnapshot {
-            mouse: crate::MouseSnapshot { x: 30, y: 0 },
+            mouse: crate::MouseSnapshot {
+                x: 30,
+                y: 0,
+                ..Default::default()
+            },
             ..crate::InputSnapshot::default()
         };
         let (from_live_tail, error) = forward_step_scene_with_error(
@@ -1833,6 +1874,59 @@ mod tests {
         assert_eq!(error, None);
         assert_eq!(from_live_tail[0].0.to_string(), "30.5");
         assert_eq!(from_live_tail[1].0.to_string(), "30.5");
+    }
+
+    /// Regression: a replayed `MouseMove` must update only x/y, never replace
+    /// the whole `MouseSnapshot`. Assigning a fresh snapshot resets `buttons`,
+    /// so moving the cursor while holding a button would silently release it on
+    /// replay and diverge from the live run (where the button stays down).
+    #[test]
+    fn replayed_mouse_move_preserves_held_mouse_buttons() {
+        let src = "let init = 0.0\n\
+                   let sampledInput = (m, snapshot) =>\n\
+                   \x20 if snapshot.mouse.buttons.left then snapshot.mouse.x else 0.0 - 1.0\n\
+                   let tick = (m, dt, tts) => m\n";
+        let project = functor_lang::project::load_single_source("game", src)
+            .unwrap_or_else(|e| panic!("load: {}", e.render()));
+        let session = Session::load(&project.module, &mut FunctorHost)
+            .unwrap_or_else(|f| panic!("session: {}", f.error.message));
+
+        let press = vec![RecordedInput::MouseButton {
+            button: crate::MouseButton::Left as i32,
+            is_down: true,
+        }];
+        let drag = vec![RecordedInput::MouseMove { x: 7, y: 3 }];
+        let release = vec![RecordedInput::MouseButton {
+            button: crate::MouseButton::Left as i32,
+            is_down: false,
+        }];
+
+        let stepped = forward_step_scene(
+            &session,
+            &Value::Number(0.0),
+            false,
+            false,
+            None,
+            0.0,
+            1.0 / 60.0,
+            4,
+            1,
+            &[press, drag, Vec::new(), release],
+        );
+        // Held at press (cursor still at the origin), then still held THROUGH
+        // the move — which is the bug this pins — and across the quiet step.
+        assert_eq!(stepped[0].0.to_string(), "0");
+        assert_eq!(
+            stepped[1].0.to_string(),
+            "7",
+            "a mouse move keeps the held button and applies the new position"
+        );
+        assert_eq!(
+            stepped[2].0.to_string(),
+            "7",
+            "the held button carries through a step with no input"
+        );
+        assert_eq!(stepped[3].0.to_string(), "-1", "the release is honored");
     }
 
     /// Drive one `deliver_ui_event` through a throwaway [`FrameCtx`] (the

--- a/runtime/functor-runtime-common/src/input.rs
+++ b/runtime/functor-runtime-common/src/input.rs
@@ -23,11 +23,53 @@ pub struct InputSnapshot {
     pub xr: Option<XrInputSnapshot>,
 }
 
-/// Last known mouse position in output pixels.
+/// Last known mouse position in output pixels, plus which buttons are held.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MouseSnapshot {
     pub x: i32,
     pub y: i32,
+    /// Buttons held right now — the level complement of the `mouseButton`
+    /// edges. Defaulted on the wire so an older `/state` capture (and a
+    /// hand-written debug injection) still deserializes.
+    #[serde(default)]
+    pub buttons: MouseButtons,
+}
+
+/// Which mouse buttons are held for one sampled step.
+///
+/// A record rather than a `Vec<MouseButton>`: held buttons are a tiny fixed
+/// set, and a game asks "is fire held?" (`snapshot.mouse.buttons.left`) far
+/// more often than it iterates them — no list-membership helper needed on the
+/// hot path. Further buttons (back/forward) can join as sibling fields.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MouseButtons {
+    pub left: bool,
+    pub right: bool,
+    pub middle: bool,
+}
+
+impl MouseButtons {
+    /// Fold one button edge into the held set. `MouseButton::Unknown` (a
+    /// platform button Functor does not model) leaves the set untouched — it
+    /// is never delivered as an edge either.
+    pub fn set(&mut self, button: MouseButton, is_down: bool) {
+        match button {
+            MouseButton::Left => self.left = is_down,
+            MouseButton::Right => self.right = is_down,
+            MouseButton::Middle => self.middle = is_down,
+            MouseButton::Unknown => {}
+        }
+    }
+
+    /// Whether `button` is currently held.
+    pub fn is_down(&self, button: MouseButton) -> bool {
+        match button {
+            MouseButton::Left => self.left,
+            MouseButton::Right => self.right,
+            MouseButton::Middle => self.middle,
+            MouseButton::Unknown => false,
+        }
+    }
 }
 
 /// One frame of XR input in the tracking rig's local coordinates.
@@ -127,6 +169,69 @@ pub enum Key {
     Num9,
 }
 
+/// Canonical mouse-button identifier shared across every runtime, mirroring
+/// [`Key`]: shells translate their platform button (GLFW's
+/// `glfw::MouseButton`, the browser's `MouseEvent.button`) into this enum and
+/// pass its `as i32` discriminant across the wasm/producer boundary.
+///
+/// `Unknown = 0` (like `Key`) so an unmodeled platform button decodes to a
+/// value the producers drop rather than mis-delivering as `Left`. New buttons
+/// only ever go at the END — the discriminants are the wire representation.
+#[repr(i32)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum MouseButton {
+    Unknown = 0,
+    Left = 1,
+    Right,
+    Middle,
+}
+
+impl MouseButton {
+    /// All button variants in discriminant order (guarded by
+    /// `mouse_button_from_i32_round_trips`).
+    pub const ALL: [MouseButton; 4] = [
+        MouseButton::Unknown,
+        MouseButton::Left,
+        MouseButton::Right,
+        MouseButton::Middle,
+    ];
+
+    /// The button whose `as i32` discriminant equals `value`, if any.
+    pub fn from_i32(value: i32) -> Option<MouseButton> {
+        MouseButton::ALL.into_iter().find(|b| *b as i32 == value)
+    }
+
+    /// Parse the case-insensitive wire spelling used by debug input
+    /// (`"left"`, `"Right"`, `"middle"`), so the desktop and device debug
+    /// servers accept exactly the same button names.
+    pub fn from_name(name: &str) -> Option<MouseButton> {
+        match name.to_ascii_lowercase().as_str() {
+            "left" => Some(MouseButton::Left),
+            "right" => Some(MouseButton::Right),
+            "middle" => Some(MouseButton::Middle),
+            _ => None,
+        }
+    }
+
+    /// The button's short display name (`"Left"`) — for human-facing labels
+    /// like the web timeline's input markers.
+    pub fn name(self) -> String {
+        format!("{self:?}")
+    }
+
+    /// The built-in `Mouse` module's constructor tag (`"Mouse.Left"`) — the
+    /// `Value::Variant` the producers hand a game's `mouseButton` hook. `None`
+    /// for `Unknown`, which is never delivered. Keep in sync with
+    /// `MOUSE_MODULE_SRC` in `functor_lang::project` (guarded by
+    /// `mouse_ctor_tags_cover_the_module` here).
+    pub fn ctor_tag(self) -> Option<String> {
+        match self {
+            MouseButton::Unknown => None,
+            _ => Some(format!("Mouse.{self:?}")),
+        }
+    }
+}
+
 /// One recorded input event at the raw boundary scalars — pre-`Key::from_i32`,
 /// pre-name-formatting — so a replay re-runs the *identical* path the live
 /// frame took (docs/time-travel.md, "The event log"). It is PLAIN DATA — `Copy`
@@ -146,6 +251,9 @@ pub enum RecordedInput {
     MouseMove { x: i32, y: i32 },
     /// A wheel notch (±1 per notch).
     MouseWheel { delta: i32 },
+    /// A mouse-button edge carrying the raw `MouseButton as i32` code, so
+    /// replay re-runs `MouseButton::from_i32` exactly as the live path does.
+    MouseButton { button: i32, is_down: bool },
     /// The continuously sampled input delivered before one simulation tick.
     ///
     /// Unlike edge events above, this is recorded every tick whose game
@@ -282,6 +390,20 @@ impl Key {
 /// `functor_lang_producer`), so live input and replay cannot drift.
 pub fn key_input_value(code: i32) -> Option<functor_lang::Value> {
     let tag = Key::from_i32(code)?.ctor_tag()?;
+    Some(functor_lang::Value::Variant {
+        ctor: std::rc::Rc::from(tag.as_str()),
+        args: std::rc::Rc::new(Vec::new()),
+    })
+}
+
+/// The `Value` a game's `mouseButton` hook receives for a raw button code: the
+/// built-in `Mouse` module's variant (`Mouse.Left`). `None` for an
+/// unrecognized code or `MouseButton::Unknown` — the event is dropped, never
+/// delivered. The mouse twin of [`key_input_value`], and likewise the ONE
+/// conversion every delivery path shares (desktop, web, debug injection, and
+/// the time-travel replay), so live input and replay cannot drift.
+pub fn mouse_button_input_value(code: i32) -> Option<functor_lang::Value> {
+    let tag = MouseButton::from_i32(code)?.ctor_tag()?;
     Some(functor_lang::Value::Variant {
         ctor: std::rc::Rc::from(tag.as_str()),
         args: std::rc::Rc::new(Vec::new()),
@@ -454,6 +576,23 @@ pub fn input_snapshot_value(snapshot: &InputSnapshot) -> functor_lang::Value {
             record([
                 ("x", functor_lang::Value::Number(snapshot.mouse.x as f64)),
                 ("y", functor_lang::Value::Number(snapshot.mouse.y as f64)),
+                (
+                    "buttons",
+                    record([
+                        (
+                            "left",
+                            functor_lang::Value::Bool(snapshot.mouse.buttons.left),
+                        ),
+                        (
+                            "right",
+                            functor_lang::Value::Bool(snapshot.mouse.buttons.right),
+                        ),
+                        (
+                            "middle",
+                            functor_lang::Value::Bool(snapshot.mouse.buttons.middle),
+                        ),
+                    ]),
+                ),
             ]),
         ),
         ("xr", option_value(xr)),
@@ -463,8 +602,9 @@ pub fn input_snapshot_value(snapshot: &InputSnapshot) -> functor_lang::Value {
 #[cfg(test)]
 mod tests {
     use super::{
-        input_snapshot_value, tracking_pose_from_value, tracking_pose_value, InputSnapshot, Key,
-        MouseSnapshot, RecordedInput, XrControllerSnapshot, XrInputSnapshot,
+        input_snapshot_value, mouse_button_input_value, tracking_pose_from_value,
+        tracking_pose_value, InputSnapshot, Key, MouseButton, MouseButtons, MouseSnapshot,
+        RecordedInput, XrControllerSnapshot, XrInputSnapshot,
     };
     use crate::TrackingPose;
 
@@ -517,6 +657,84 @@ mod tests {
         assert_eq!(declared, expected, "Key enum and KEY_MODULE_SRC drifted");
     }
 
+    /// The mouse twin of `ctor_tags_cover_the_module`: every deliverable
+    /// `MouseButton` maps to a constructor the built-in `Mouse` module
+    /// declares, and it declares nothing else.
+    #[test]
+    fn mouse_ctor_tags_cover_the_module() {
+        let project = functor_lang::project::load_single_source("game", "let x = 0.0\n")
+            .unwrap_or_else(|e| panic!("empty project loads: {}", e.render()));
+        let mouse_ty = project
+            .module
+            .types
+            .iter()
+            .find(|t| t.name == "Mouse.t")
+            .expect("the built-in Mouse module is injected");
+        let declared: std::collections::BTreeSet<String> = match &mouse_ty.body {
+            functor_lang::ast::TypeBody::Variants(variants) => {
+                variants.iter().map(|v| v.name.clone()).collect()
+            }
+            _ => panic!("Mouse.t must be a variant type"),
+        };
+        let expected: std::collections::BTreeSet<String> = MouseButton::ALL
+            .into_iter()
+            .filter_map(|b| b.ctor_tag())
+            .collect();
+        assert_eq!(
+            declared, expected,
+            "MouseButton enum and MOUSE_MODULE_SRC drifted"
+        );
+    }
+
+    #[test]
+    fn mouse_button_from_i32_round_trips() {
+        for (i, button) in MouseButton::ALL.iter().enumerate() {
+            assert_eq!(
+                *button as i32, i as i32,
+                "MouseButton::ALL must be contiguous from 0"
+            );
+            assert_eq!(MouseButton::from_i32(*button as i32), Some(*button));
+        }
+        assert_eq!(MouseButton::from_i32(MouseButton::ALL.len() as i32), None);
+        assert_eq!(MouseButton::from_i32(-1), None);
+    }
+
+    #[test]
+    fn mouse_button_names_and_wire_spellings_are_canonical() {
+        assert_eq!(MouseButton::Left.name(), "Left");
+        assert_eq!(MouseButton::Left.ctor_tag().as_deref(), Some("Mouse.Left"));
+        assert_eq!(MouseButton::Unknown.ctor_tag(), None);
+        assert_eq!(MouseButton::from_name("left"), Some(MouseButton::Left));
+        assert_eq!(MouseButton::from_name("Right"), Some(MouseButton::Right));
+        assert_eq!(MouseButton::from_name("MIDDLE"), Some(MouseButton::Middle));
+        assert_eq!(MouseButton::from_name("thumb"), None);
+        // Unknown is never delivered as a variant.
+        assert!(mouse_button_input_value(MouseButton::Unknown as i32).is_none());
+        assert_eq!(
+            mouse_button_input_value(MouseButton::Right as i32)
+                .unwrap()
+                .to_string(),
+            "Mouse.Right"
+        );
+    }
+
+    #[test]
+    fn held_buttons_fold_edges_and_ignore_unknown() {
+        let mut buttons = MouseButtons::default();
+        buttons.set(MouseButton::Left, true);
+        buttons.set(MouseButton::Middle, true);
+        assert!(buttons.is_down(MouseButton::Left));
+        assert!(buttons.is_down(MouseButton::Middle));
+        assert!(!buttons.is_down(MouseButton::Right));
+        buttons.set(MouseButton::Left, false);
+        assert!(!buttons.is_down(MouseButton::Left));
+        // An unmodeled platform button cannot corrupt the held set.
+        let before = buttons;
+        buttons.set(MouseButton::Unknown, true);
+        assert_eq!(buttons, before);
+        assert!(!buttons.is_down(MouseButton::Unknown));
+    }
+
     #[test]
     fn from_i32_round_trips() {
         for (i, key) in Key::ALL.iter().enumerate() {
@@ -555,7 +773,11 @@ mod tests {
     fn input_snapshot_omits_absent_xr_and_round_trips_present_xr() {
         let desktop = InputSnapshot {
             held_keys: vec![Key::W],
-            mouse: MouseSnapshot { x: 10, y: 20 },
+            mouse: MouseSnapshot {
+                x: 10,
+                y: 20,
+                ..Default::default()
+            },
             xr: None,
         };
         let desktop_json = serde_json::to_value(&desktop).unwrap();
@@ -563,9 +785,19 @@ mod tests {
             desktop_json,
             serde_json::json!({
                 "held_keys": ["W"],
-                "mouse": { "x": 10, "y": 20 }
+                "mouse": {
+                    "x": 10,
+                    "y": 20,
+                    "buttons": { "left": false, "right": false, "middle": false }
+                }
             })
         );
+        // Mouse buttons are defaulted on the wire, so a capture taken before
+        // they existed (and a hand-written injection) still decodes.
+        let legacy: InputSnapshot =
+            serde_json::from_value(serde_json::json!({ "held_keys": [], "mouse": { "x": 1, "y": 2 } }))
+                .unwrap();
+        assert_eq!(legacy.mouse.buttons, MouseButtons::default());
 
         let xr = InputSnapshot {
             xr: Some(XrInputSnapshot {
@@ -589,7 +821,15 @@ mod tests {
     fn functor_value_preserves_the_typed_snapshot_shape() {
         let snapshot = InputSnapshot {
             held_keys: vec![Key::W, Key::Space],
-            mouse: MouseSnapshot { x: 12, y: -4 },
+            mouse: MouseSnapshot {
+                x: 12,
+                y: -4,
+                buttons: MouseButtons {
+                    left: true,
+                    right: false,
+                    middle: false,
+                },
+            },
             xr: Some(XrInputSnapshot {
                 head: Some(TrackingPose::IDENTITY),
                 left: XrControllerSnapshot::default(),
@@ -607,7 +847,12 @@ mod tests {
             rendered.contains("heldKeys: [Key.W, Key.Space]"),
             "{rendered}"
         );
-        assert!(rendered.contains("mouse: { x: 12, y: -4 }"), "{rendered}");
+        assert!(
+            rendered.contains(
+                "mouse: { x: 12, y: -4, buttons: { left: true, right: false, middle: false } }"
+            ),
+            "{rendered}"
+        );
         assert!(rendered.contains("xr: Option.Some("), "{rendered}");
         assert!(rendered.contains("trigger: 0.75"), "{rendered}");
         assert!(rendered.contains("primaryPressed: true"), "{rendered}");

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -253,6 +253,12 @@ pub trait GameProducer {
     /// Deliver a mouse-wheel event (vertical scroll offset).
     fn mouse_wheel(&mut self, delta: i32);
 
+    /// Deliver a mouse-button edge. `button` is a [`crate::MouseButton`] as
+    /// `i32`. Defaulted (unlike the three above) so producers with no game
+    /// logic to run — replays, netsim — stay untouched; the Functor Lang
+    /// producers call `mouseButton(model, button, isDown)`.
+    fn mouse_button(&mut self, _button: i32, _is_down: bool) {}
+
     /// Deliver an interaction on an interactive UI widget
     /// ([`crate::ui::UiEvent`], slot-addressed — docs/ui-interaction.md). The
     /// default drops it: the honest no-op for producers with no interactive
@@ -649,6 +655,18 @@ mod tests {
         // Serde uses the names (the debug server's held_keys), pinned too.
         assert_wire(&Key::W, r#""W""#);
         assert_wire(&Key::Escape, r#""Escape""#);
+    }
+
+    /// Same contract as the keys above: a mouse button crosses the boundary as
+    /// its i32 discriminant, so the table is pinned here.
+    #[test]
+    fn mouse_button_discriminants_are_pinned() {
+        use crate::MouseButton;
+        assert_eq!(MouseButton::Unknown as i32, 0);
+        assert_eq!(MouseButton::Left as i32, 1);
+        assert_eq!(MouseButton::Right as i32, 2);
+        assert_eq!(MouseButton::Middle as i32, 3);
+        assert_wire(&MouseButton::Left, r#""Left""#);
     }
 
     #[test]

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -91,6 +91,7 @@ pub struct FunctorLangGame {
     pending_sampled_input: Option<functor_runtime_common::InputSnapshot>,
     has_mouse_move: bool,
     has_mouse_wheel: bool,
+    has_mouse_button: bool,
     has_subscriptions: bool,
     /// The previous frame's total-time, the left edge of the `(prev, tts]`
     /// window subscriptions fire over. `None` until the first frame has run
@@ -238,6 +239,7 @@ struct Loaded {
     has_sampled_input: bool,
     has_mouse_move: bool,
     has_mouse_wheel: bool,
+    has_mouse_button: bool,
     has_subscriptions: bool,
     has_physics: bool,
     has_soundscape: bool,
@@ -358,6 +360,11 @@ return them beside the model as `(model, effect)`"
     if has_mouse_wheel {
         require_function(path, &session, "mouseWheel", 2)?;
     }
+    // `mouseButton(model, button, isDown)` — the `input` twin for the pointer.
+    let has_mouse_button = session.global("mouseButton").is_some();
+    if has_mouse_button {
+        require_function(path, &session, "mouseButton", 3)?;
+    }
     // The MVU pair: `subscriptions(model)` declares timers whose fired
     // messages fold through `update(model, msg)` — so subscriptions without
     // an update have nowhere to deliver.
@@ -409,6 +416,7 @@ return them beside the model as `(model, effect)`"
         has_sampled_input,
         has_mouse_move,
         has_mouse_wheel,
+        has_mouse_button,
         has_subscriptions,
         has_physics,
         has_soundscape,
@@ -478,6 +486,7 @@ impl FunctorLangGame {
             pending_sampled_input: None,
             has_mouse_move: loaded.has_mouse_move,
             has_mouse_wheel: loaded.has_mouse_wheel,
+            has_mouse_button: loaded.has_mouse_button,
             has_subscriptions: loaded.has_subscriptions,
             prev_tts: None,
             has_physics: loaded.has_physics,
@@ -585,6 +594,7 @@ impl FunctorLangGame {
         self.pending_sampled_input = None;
         self.has_mouse_move = loaded.has_mouse_move;
         self.has_mouse_wheel = loaded.has_mouse_wheel;
+        self.has_mouse_button = loaded.has_mouse_button;
         self.has_subscriptions = loaded.has_subscriptions;
         self.has_physics = loaded.has_physics;
         if !self.has_physics {
@@ -676,6 +686,7 @@ impl FunctorLangGame {
         self.pending_sampled_input = None;
         self.has_mouse_move = loaded.has_mouse_move;
         self.has_mouse_wheel = loaded.has_mouse_wheel;
+        self.has_mouse_button = loaded.has_mouse_button;
         self.has_subscriptions = loaded.has_subscriptions;
         self.prev_tts = None;
         self.asset_progress = None;
@@ -1125,6 +1136,26 @@ impl Game for FunctorLangGame {
         }
         self.input_buf
             .push(functor_runtime_common::RecordedInput::MouseWheel { delta });
+    }
+
+    fn mouse_button(&mut self, button: i32, is_down: bool) {
+        // The optional `mouseButton` entry point: (model, button, isDown) =>
+        // model. Buttons cross as the built-in `Mouse` module's variants
+        // (`Mouse.Left`), mirroring keys.
+        if !self.has_mouse_button {
+            return;
+        }
+        let Some(button_value) = functor_runtime_common::mouse_button_input_value(button) else {
+            return; // unrecognized code / MouseButton::Unknown — never delivered.
+        };
+        let args = vec![self.model.clone(), button_value, Value::Bool(is_down)];
+        journal_push("mouseButton", &args, Provenance::MouseButton);
+        match self.session.call("mouseButton", args, &mut FunctorHost) {
+            Ok(returned) => self.ctx().absorb(returned),
+            Err(err) => self.reporter.frame_error("mouseButton", &err),
+        }
+        self.input_buf
+            .push(functor_runtime_common::RecordedInput::MouseButton { button, is_down });
     }
 
     fn ui_event(&mut self, event: functor_runtime_common::ui::UiEvent) {

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -148,11 +148,14 @@ fn release_held_mouse_buttons(
     held_buttons: &mut MouseButtons,
     deliver: bool,
 ) {
-    for button in [
-        functor_runtime_common::MouseButton::Left,
-        functor_runtime_common::MouseButton::Right,
-        functor_runtime_common::MouseButton::Middle,
-    ] {
+    // Driven off `ALL` rather than a literal list: a button added to the enum
+    // must be swept too, or it becomes exactly the stuck-down bug this exists
+    // to prevent.
+    for button in functor_runtime_common::MouseButton::ALL
+        .iter()
+        .copied()
+        .filter(|b| *b != functor_runtime_common::MouseButton::Unknown)
+    {
         if held_buttons.is_down(button) {
             held_buttons.set(button, false);
             if deliver {
@@ -1472,6 +1475,19 @@ pub fn run(args: Args) {
                                 &mut held_buttons,
                                 !ignore_user_input,
                             );
+                            // Under a pinned clock the sampled snapshot is not
+                            // rebuilt per frame, so the cleared level has to be
+                            // written into it or `sampledInput` reports the
+                            // button held forever (as `Focus(false)` does).
+                            if clock.is_fixed_time() {
+                                refresh_fixed_input_levels(
+                                    &mut fixed_input_snapshot,
+                                    &held_keys,
+                                    held_buttons,
+                                    false,
+                                    xr_override.as_ref(),
+                                );
+                            }
                             window.set_cursor_mode(glfw::CursorMode::Normal);
                             cursor_captured = false;
                             println!(
@@ -1500,6 +1516,16 @@ Escape again to quit"
                             &mut held_buttons,
                             !ignore_user_input,
                         );
+                        // Same pinned-clock caveat as the Escape arm above.
+                        if clock.is_fixed_time() {
+                            refresh_fixed_input_levels(
+                                &mut fixed_input_snapshot,
+                                &held_keys,
+                                held_buttons,
+                                false,
+                                xr_override.as_ref(),
+                            );
+                        }
                         if !hidden {
                             if scrubber_visible {
                                 window.set_cursor_mode(glfw::CursorMode::Normal);
@@ -1628,6 +1654,10 @@ Escape again to quit"
                     // this sits before the `ignore_user_input` catch-all so a
                     // button held at a pin transition can't stick, while the
                     // game only hears edges it may act on.
+                    // NOTE: `--emulate-xr` never captures the cursor (its left
+                    // click drives the emulated XR primary instead), so window
+                    // buttons do not reach `mouseButton` under it — inject them
+                    // through `POST /input` when scripting that rig.
                     glfw::WindowEvent::MouseButton(button, action, _) if cursor_captured => {
                         let mapped = map_mouse_button(button);
                         if mapped != functor_runtime_common::MouseButton::Unknown {

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -13,8 +13,8 @@ use std::time::Instant;
 
 use functor_runtime_common::asset::AssetCache;
 use functor_runtime_common::{
-    Frame, FrameTime, GameClock, InputSnapshot, MouseSnapshot, RecordedInput, SceneContext,
-    XrInputSnapshot,
+    Frame, FrameTime, GameClock, InputSnapshot, MouseButtons, MouseSnapshot, RecordedInput,
+    SceneContext, XrInputSnapshot,
 };
 use std::collections::{BTreeSet, HashMap, HashSet};
 
@@ -82,9 +82,23 @@ fn map_key(key: Key) -> InputKey {
     }
 }
 
+/// Translate a GLFW mouse button into the canonical engine button code passed
+/// across the game boundary. Buttons Functor does not model (4..8) become
+/// `MouseButton::Unknown` and are never delivered.
+fn map_mouse_button(button: glfw::MouseButton) -> functor_runtime_common::MouseButton {
+    use functor_runtime_common::MouseButton as Btn;
+    match button {
+        glfw::MouseButtonLeft => Btn::Left,
+        glfw::MouseButtonRight => Btn::Right,
+        glfw::MouseButtonMiddle => Btn::Middle,
+        _ => Btn::Unknown,
+    }
+}
+
 fn sampled_input_snapshot(
     held_keys: &BTreeSet<InputKey>,
     mouse_pos: (i32, i32),
+    held_buttons: MouseButtons,
     xr: Option<XrInputSnapshot>,
 ) -> InputSnapshot {
     InputSnapshot {
@@ -92,6 +106,7 @@ fn sampled_input_snapshot(
         mouse: MouseSnapshot {
             x: mouse_pos.0,
             y: mouse_pos.1,
+            buttons: held_buttons,
         },
         xr,
     }
@@ -107,6 +122,7 @@ fn sampled_input_snapshot(
 fn desktop_input_snapshot(
     held_keys: &BTreeSet<InputKey>,
     mouse_pos: (i32, i32),
+    held_buttons: MouseButtons,
     emulate_xr: bool,
     xr_primary_down: bool,
     xr_surface: (i32, i32),
@@ -118,16 +134,43 @@ fn desktop_input_snapshot(
             crate::desktop_xr_emulator::sample(held_keys, mouse_pos, xr_primary_down, xr_surface)
         }),
     };
-    sampled_input_snapshot(held_keys, mouse_pos, xr)
+    sampled_input_snapshot(held_keys, mouse_pos, held_buttons, xr)
+}
+
+/// Release every mouse button the game currently holds — the button twin of
+/// the `held_keys` sweep on focus loss. A button held when the window loses
+/// focus (or when the cursor is released, which stops delivering its events)
+/// would otherwise never get its up edge, leaving a game firing forever.
+/// `deliver` is false while the clock is pinned: the level state must still
+/// clear, but an unlogged edge would diverge forward-step replay.
+fn release_held_mouse_buttons(
+    game: &mut dyn Game,
+    held_buttons: &mut MouseButtons,
+    deliver: bool,
+) {
+    for button in [
+        functor_runtime_common::MouseButton::Left,
+        functor_runtime_common::MouseButton::Right,
+        functor_runtime_common::MouseButton::Middle,
+    ] {
+        if held_buttons.is_down(button) {
+            held_buttons.set(button, false);
+            if deliver {
+                game.mouse_button(button as i32, false);
+            }
+        }
+    }
 }
 
 fn refresh_fixed_input_levels(
     snapshot: &mut InputSnapshot,
     held_keys: &BTreeSet<InputKey>,
+    held_buttons: MouseButtons,
     xr_primary_down: bool,
     xr_override: Option<&XrInputSnapshot>,
 ) {
     snapshot.held_keys = held_keys.iter().copied().collect();
+    snapshot.mouse.buttons = held_buttons;
     // An injected sample owns the whole XR domain — window keys must not
     // re-derive its trigger/thumbstick out from under the driver.
     match xr_override {
@@ -574,6 +617,9 @@ fn service_debug_request(
     height: u32,
     held_keys: &mut BTreeSet<InputKey>,
     mouse_pos: &mut (i32, i32),
+    // Held mouse buttons, maintained from the GLFW stream and `POST /input`
+    // the same way `held_keys` is.
+    held_buttons: &mut MouseButtons,
     // The debug-injected XR sample, if any: `{"type":"xr"}` sets it and every
     // later step samples it (see `desktop_input_snapshot`).
     xr_override: &mut Option<XrInputSnapshot>,
@@ -675,6 +721,7 @@ fn service_debug_request(
                 &cmd,
                 debug_server::InputCommand::Key { .. }
                     | debug_server::InputCommand::MouseMove { .. }
+                    | debug_server::InputCommand::MouseButton { .. }
                     | debug_server::InputCommand::Xr(_)
                     | debug_server::InputCommand::XrClear
             );
@@ -728,6 +775,26 @@ fn service_debug_request(
                 debug_server::InputCommand::MouseWheel { delta } => {
                     game.mouse_wheel(delta);
                     Ok(())
+                }
+                debug_server::InputCommand::MouseButton { button, down } => {
+                    // Edge + level, with the same held-state discipline as an
+                    // injected key: a release is delivered only if the game saw
+                    // the press. Unlike window buttons this ignores cursor
+                    // capture — a headless/hidden session has no capture to
+                    // acquire, and scripted clicks are the whole point.
+                    match functor_runtime_common::MouseButton::from_name(&button) {
+                        Some(b) => {
+                            if down {
+                                held_buttons.set(b, true);
+                                game.mouse_button(b as i32, true);
+                            } else if held_buttons.is_down(b) {
+                                held_buttons.set(b, false);
+                                game.mouse_button(b as i32, false);
+                            }
+                            Ok(())
+                        }
+                        None => Err(format!("unknown mouse button: {}", button)),
+                    }
                 }
                 debug_server::InputCommand::UiEvent { slot, kind } => {
                     game.ui_event(functor_runtime_common::ui::UiEvent { slot, kind });
@@ -793,6 +860,7 @@ fn run_headless(
     let mut frame_count: u64 = 0;
     let mut clock = GameClock::new(fixed_time);
     let mut held_keys: BTreeSet<InputKey> = BTreeSet::new();
+    let mut held_buttons = MouseButtons::default();
     let mut mouse_pos: (i32, i32) = if emulate_xr {
         crate::desktop_xr_emulator::centered_pointer(crate::desktop_xr_emulator::reference_surface())
     } else {
@@ -851,6 +919,7 @@ fn run_headless(
                 let snapshot = desktop_input_snapshot(
                     &held_keys,
                     mouse_pos,
+                    held_buttons,
                     emulate_xr,
                     false,
                     crate::desktop_xr_emulator::reference_surface(),
@@ -874,6 +943,7 @@ fn run_headless(
                 let state_input = desktop_input_snapshot(
                     &held_keys,
                     mouse_pos,
+                    held_buttons,
                     emulate_xr,
                     false,
                     crate::desktop_xr_emulator::reference_surface(),
@@ -889,6 +959,7 @@ fn run_headless(
                     0,
                     &mut held_keys,
                     &mut mouse_pos,
+                    &mut held_buttons,
                     &mut xr_override,
                     state_input,
                     emulate_xr,
@@ -1171,6 +1242,9 @@ pub fn run(args: Args) {
         // GLFW event stream and the debug server's POST /input. Generic and
         // serializable, unlike the game model (which is Debug text only).
         let mut held_keys: BTreeSet<InputKey> = BTreeSet::new();
+        // Held mouse buttons — the level complement of the `mouseButton`
+        // edges, sampled into `Input.snapshot.mouse.buttons`.
+        let mut held_buttons = MouseButtons::default();
         let mut mouse_pos: (i32, i32) = if args.emulate_xr {
             crate::desktop_xr_emulator::centered_pointer(window.get_size())
         } else {
@@ -1187,6 +1261,7 @@ pub fn run(args: Args) {
         let mut fixed_input_snapshot = desktop_input_snapshot(
             &held_keys,
             mouse_pos,
+            held_buttons,
             args.emulate_xr,
             false,
             window.get_size(),
@@ -1390,6 +1465,13 @@ pub fn run(args: Args) {
                     // released quits, preserving the Esc-Esc exit.
                     glfw::WindowEvent::Key(Key::Escape, _, Action::Press, _) => {
                         if cursor_captured {
+                            // Releasing the cursor stops delivering button
+                            // events, so anything held must get its up edge now.
+                            release_held_mouse_buttons(
+                                &mut *game,
+                                &mut held_buttons,
+                                !ignore_user_input,
+                            );
                             window.set_cursor_mode(glfw::CursorMode::Normal);
                             cursor_captured = false;
                             println!(
@@ -1412,6 +1494,12 @@ Escape again to quit"
                         if !ui_wants_keyboard && !webview_wants_keyboard =>
                     {
                         scrubber_visible = !scrubber_visible;
+                        // Same reason as Escape: this arm can drop capture.
+                        release_held_mouse_buttons(
+                            &mut *game,
+                            &mut held_buttons,
+                            !ignore_user_input,
+                        );
                         if !hidden {
                             if scrubber_visible {
                                 window.set_cursor_mode(glfw::CursorMode::Normal);
@@ -1525,9 +1613,52 @@ Escape again to quit"
                             refresh_fixed_input_levels(
                                 &mut fixed_input_snapshot,
                                 &held_keys,
+                                held_buttons,
                                 xr_primary_down || xr_primary_clicked,
                                 xr_override.as_ref(),
                             );
+                        }
+                    }
+                    // Mouse buttons reach the game only while the cursor is
+                    // CAPTURED — the same rule `CursorPos`/`Scroll` follow
+                    // below. While the cursor is released the pointer belongs
+                    // to the overlays (and the left button recaptures — the
+                    // arm above), so a click there is not a game click.
+                    // Bookkeeping/delivery discipline mirrors keys exactly:
+                    // this sits before the `ignore_user_input` catch-all so a
+                    // button held at a pin transition can't stick, while the
+                    // game only hears edges it may act on.
+                    glfw::WindowEvent::MouseButton(button, action, _) if cursor_captured => {
+                        let mapped = map_mouse_button(button);
+                        if mapped != functor_runtime_common::MouseButton::Unknown {
+                            match action {
+                                Action::Press => {
+                                    // A press the game never saw must not enter
+                                    // the held set, or its release would leak a
+                                    // phantom edge.
+                                    if !ignore_user_input {
+                                        held_buttons.set(mapped, true);
+                                        game.mouse_button(mapped as i32, true);
+                                    }
+                                }
+                                Action::Release => {
+                                    let was_held = held_buttons.is_down(mapped);
+                                    held_buttons.set(mapped, false);
+                                    if was_held && !ignore_user_input {
+                                        game.mouse_button(mapped as i32, false);
+                                    }
+                                }
+                                Action::Repeat => {}
+                            }
+                            if clock.is_fixed_time() {
+                                refresh_fixed_input_levels(
+                                    &mut fixed_input_snapshot,
+                                    &held_keys,
+                                    held_buttons,
+                                    xr_primary_down || xr_primary_clicked,
+                                    xr_override.as_ref(),
+                                );
+                            }
                         }
                     }
                     glfw::WindowEvent::Focus(false) => {
@@ -1547,10 +1678,19 @@ Escape again to quit"
                         mouse_primary_clicked = false;
                         xr_primary_down = false;
                         xr_primary_clicked = false;
+                        // The GAME's held buttons need the same sweep as
+                        // `held_keys` above, or a click held at alt-tab fires
+                        // forever.
+                        release_held_mouse_buttons(
+                            &mut *game,
+                            &mut held_buttons,
+                            !ignore_user_input,
+                        );
                         if clock.is_fixed_time() {
                             refresh_fixed_input_levels(
                                 &mut fixed_input_snapshot,
                                 &held_keys,
+                                held_buttons,
                                 false,
                                 xr_override.as_ref(),
                             );
@@ -1661,6 +1801,7 @@ Escape again to quit"
                         let snapshot = desktop_input_snapshot(
                             &held_keys,
                             mouse_pos,
+                            held_buttons,
                             args.emulate_xr,
                             xr_primary_down || xr_primary_clicked,
                             window.get_size(),
@@ -2447,6 +2588,7 @@ Escape again to quit"
                         desktop_input_snapshot(
                             &held_keys,
                             mouse_pos,
+                            held_buttons,
                             args.emulate_xr,
                             xr_primary_down || xr_primary_clicked,
                             window.get_size(),
@@ -2463,6 +2605,7 @@ Escape again to quit"
                         fb_height as u32,
                         &mut held_keys,
                         &mut mouse_pos,
+                        &mut held_buttons,
                         &mut xr_override,
                         state_input,
                         args.emulate_xr,
@@ -2492,6 +2635,7 @@ Escape again to quit"
                         fixed_input_snapshot = desktop_input_snapshot(
                             &held_keys,
                             mouse_pos,
+                            held_buttons,
                             args.emulate_xr,
                             xr_primary_down || xr_primary_clicked,
                             window.get_size(),
@@ -2567,18 +2711,36 @@ mod tests {
 
     #[test]
     fn fixed_level_refresh_preserves_mouse_and_tracked_poses() {
-        let mut snapshot =
-            desktop_input_snapshot(&BTreeSet::new(), (100, 200), true, false, (800, 600), None);
+        let mut snapshot = desktop_input_snapshot(
+            &BTreeSet::new(),
+            (100, 200),
+            MouseButtons::default(),
+            true,
+            false,
+            (800, 600),
+            None,
+        );
         let pose = snapshot
             .xr
             .as_ref()
             .and_then(|xr| xr.right.grip)
             .expect("emulated grip");
         let held = BTreeSet::from([InputKey::Space]);
+        // A button held at the fixed-step boundary is level state like a key:
+        // the refresh must carry it, not drop it.
+        let mut buttons = MouseButtons::default();
+        buttons.set(functor_runtime_common::MouseButton::Right, true);
 
-        refresh_fixed_input_levels(&mut snapshot, &held, false, None);
+        refresh_fixed_input_levels(&mut snapshot, &held, buttons, false, None);
 
-        assert_eq!(snapshot.mouse, MouseSnapshot { x: 100, y: 200 });
+        assert_eq!(
+            snapshot.mouse,
+            MouseSnapshot {
+                x: 100,
+                y: 200,
+                buttons
+            }
+        );
         assert_eq!(
             snapshot.xr.as_ref().and_then(|xr| xr.right.grip),
             Some(pose)
@@ -2620,6 +2782,7 @@ mod tests {
         let snapshot = desktop_input_snapshot(
             &held,
             (700, 100),
+            MouseButtons::default(),
             true,
             true,
             (800, 600),
@@ -2628,18 +2791,34 @@ mod tests {
         assert_eq!(snapshot.xr.as_ref(), Some(&injected));
         // Keyboard/mouse domains stay live alongside it.
         assert_eq!(snapshot.held_keys, vec![InputKey::Space]);
-        assert_eq!(snapshot.mouse, MouseSnapshot { x: 700, y: 100 });
+        assert_eq!(
+            snapshot.mouse,
+            MouseSnapshot {
+                x: 700,
+                y: 100,
+                ..Default::default()
+            }
+        );
     }
 
     #[test]
     fn an_injected_xr_sample_supplies_the_domain_without_emulate_xr() {
         let injected = injected_sample();
-        let plain = desktop_input_snapshot(&BTreeSet::new(), (0, 0), false, false, (800, 600), None);
+        let plain = desktop_input_snapshot(
+            &BTreeSet::new(),
+            (0, 0),
+            MouseButtons::default(),
+            false,
+            false,
+            (800, 600),
+            None,
+        );
         assert_eq!(plain.xr, None, "no XR domain without a device or injection");
 
         let snapshot = desktop_input_snapshot(
             &BTreeSet::new(),
             (0, 0),
+            MouseButtons::default(),
             false,
             false,
             (800, 600),
@@ -2654,6 +2833,7 @@ mod tests {
         let mut snapshot = desktop_input_snapshot(
             &BTreeSet::new(),
             (100, 200),
+            MouseButtons::default(),
             true,
             false,
             (800, 600),
@@ -2663,7 +2843,13 @@ mod tests {
         // owns the XR domain, so window keys must leave it alone.
         let held = BTreeSet::from([InputKey::Enter]);
 
-        refresh_fixed_input_levels(&mut snapshot, &held, true, Some(&injected));
+        refresh_fixed_input_levels(
+            &mut snapshot,
+            &held,
+            MouseButtons::default(),
+            true,
+            Some(&injected),
+        );
 
         assert_eq!(snapshot.xr.as_ref(), Some(&injected));
         assert_eq!(snapshot.xr.as_ref().unwrap().right.squeeze, 0.0);

--- a/runtime/functor-runtime-oculus/src/lib.rs
+++ b/runtime/functor-runtime-oculus/src/lib.rs
@@ -635,6 +635,24 @@ fn service_debug_request(
                     game.mouse_wheel(delta);
                     Ok(())
                 }
+                // Edge + held level, mirroring the injected-key discipline: a
+                // release only reaches the game if it saw the press. There is
+                // no cursor capture to respect on this runtime.
+                InputCommand::MouseButton { button, down } => {
+                    match functor_runtime_common::MouseButton::from_name(&button) {
+                        Some(b) => {
+                            if down {
+                                debug.input.mouse.buttons.set(b, true);
+                                game.mouse_button(b as i32, true);
+                            } else if debug.input.mouse.buttons.is_down(b) {
+                                debug.input.mouse.buttons.set(b, false);
+                                game.mouse_button(b as i32, false);
+                            }
+                            Ok(())
+                        }
+                        None => Err(format!("unknown mouse button: {button}")),
+                    }
+                }
                 InputCommand::UiEvent { slot, kind } => {
                     game.ui_event(functor_runtime_common::ui::UiEvent { slot, kind });
                     Ok(())

--- a/runtime/functor-runtime-web/index-functor-lang.html
+++ b/runtime/functor-runtime-web/index-functor-lang.html
@@ -47,6 +47,7 @@
         functor_lang_key_event,
         functor_lang_mouse_move,
         functor_lang_mouse_wheel,
+        functor_lang_mouse_button,
         functor_lang_ui_pointer,
         functor_lang_ui_pointer_leave,
         functor_lang_ui_key,
@@ -202,6 +203,42 @@
           functor_lang_mouse_wheel(Math.sign(e.deltaY));
         });
 
+        // Mouse buttons reach the game only while pointer-locked — the same
+        // rule mousemove follows above, and the browser twin of the desktop's
+        // "only while the cursor is captured". While the cursor is FREE it
+        // belongs to the scrubber and the `Ui.*` widget path below.
+        // MouseEvent.button (0 left, 1 middle, 2 right) → the runtime's
+        // canonical MouseButton discriminants (1 left, 2 right, 3 middle).
+        const buttonCode = (button) =>
+          button === 0 ? 1 : button === 2 ? 2 : button === 1 ? 3 : 0;
+        const gameButtons = new Set();
+        canvas.addEventListener("mousedown", (e) => {
+          if (document.pointerLockElement !== canvas) return;
+          const code = buttonCode(e.button);
+          if (code === 0) return;
+          e.preventDefault();
+          functor_lang_mouse_button(code, true);
+          gameButtons.add(code);
+        });
+        window.addEventListener("mouseup", (e) => {
+          const code = buttonCode(e.button);
+          // Deliver the release only if the game saw the press, so a button
+          // pressed before locking (or on an overlay) can't leak a phantom up.
+          if (code !== 0 && gameButtons.delete(code)) functor_lang_mouse_button(code, false);
+        });
+        // Right-click while aiming must fire, not open the context menu.
+        canvas.addEventListener("contextmenu", (e) => {
+          if (document.pointerLockElement === canvas) e.preventDefault();
+        });
+        // A button released outside the window (or after the lock drops) may
+        // never emit a mouseup here — synthesize releases so the edge hook and
+        // the next sampled snapshot both recover, mirroring `blur` for keys.
+        const releaseGameButtons = () => {
+          for (const code of gameButtons) functor_lang_mouse_button(code, false);
+          gameButtons.clear();
+        };
+        window.addEventListener("blur", releaseGameButtons);
+
         // Interactive game UI (docs/ui-interaction.md U3): while the pointer
         // is FREE (not look mode), its canvas position + primary button drive
         // the game's `Ui.*` widgets. CSS px — the runtime scales by the
@@ -228,6 +265,7 @@
         });
         document.addEventListener("pointerlockchange", () => {
           if (document.pointerLockElement === canvas) functor_lang_ui_pointer_leave();
+          else releaseGameButtons();
         });
       };
 

--- a/runtime/functor-runtime-web/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-web/src/functor_lang_game.rs
@@ -200,6 +200,13 @@ pub fn functor_lang_mouse_wheel(delta: i32) {
     push_input(InputEvent::MouseWheel { delta });
 }
 
+/// Deliver a mouse-button edge (`button` = `functor_runtime_common::MouseButton`
+/// as i32). The page maps the browser's `MouseEvent.button` before calling.
+#[wasm_bindgen]
+pub fn functor_lang_mouse_button(button: i32, is_down: bool) {
+    push_input(InputEvent::MouseButton { button, is_down });
+}
+
 thread_local! {
     /// The page's UNLOCKED pointer over the canvas — `(pos in CSS px,
     /// primary button down, press latched since last sample)` — for the
@@ -370,13 +377,32 @@ pub fn drain_input(
             }
             InputEvent::MouseMove { x, y } => {
                 if deliver {
-                    snapshot.mouse = functor_runtime_common::MouseSnapshot { x, y };
+                    // x/y only — a move must not clear the held buttons.
+                    snapshot.mouse.x = x;
+                    snapshot.mouse.y = y;
                     game.mouse_move(x, y);
                 }
             }
             InputEvent::MouseWheel { delta } => {
                 if deliver {
                     game.mouse_wheel(delta);
+                }
+            }
+            InputEvent::MouseButton { button, is_down } => {
+                // Same level/edge split as keys: the held set tracks physical
+                // state (so a release while paused can't stick), the hook only
+                // sees edges we actually deliver.
+                if let Some(mapped) = functor_runtime_common::MouseButton::from_i32(button)
+                    .filter(|b| *b != functor_runtime_common::MouseButton::Unknown)
+                {
+                    if is_down && deliver {
+                        snapshot.mouse.buttons.set(mapped, true);
+                    } else if !is_down && (deliver || recover_releases) {
+                        snapshot.mouse.buttons.set(mapped, false);
+                    }
+                }
+                if deliver {
+                    game.mouse_button(button, is_down);
                 }
             }
             // Only the time-travel recorder creates snapshots; the page input
@@ -550,6 +576,20 @@ fn input_marker(input: &InputEvent) -> Option<(&'static str, String)> {
         }
         InputEvent::MouseMove { x, y } => Some(("mouse-move", format!("mouse move ({x}, {y})"))),
         InputEvent::MouseWheel { delta } => Some(("mouse-wheel", format!("mouse wheel {delta:+}"))),
+        InputEvent::MouseButton { button, is_down } => {
+            let name = functor_runtime_common::MouseButton::from_i32(*button)
+                .map(|b| b.name())
+                .unwrap_or_else(|| format!("button {button}"));
+            let edge = if *is_down { "down" } else { "up" };
+            Some((
+                if *is_down {
+                    "mouse-button-down"
+                } else {
+                    "mouse-button-up"
+                },
+                format!("mouse {name} {edge}"),
+            ))
+        }
         InputEvent::Snapshot(_) => None,
         InputEvent::UiEvent(event) => Some(("ui-input", format!("UI {event:?}"))),
         InputEvent::WebviewEvent(event) => Some(("webview-input", format!("webview {event:?}"))),

--- a/site/manual/index.html
+++ b/site/manual/index.html
@@ -187,6 +187,7 @@ let draw = (m, tts) =>
               <tr><td><code>sampledInput</code></td><td><code>(model, snapshot) => model'</code></td><td>optional; <em>level</em> state (what is held right now) rather than edges — one <code>Input.snapshot</code> immediately before every tick</td></tr>
               <tr><td><code>mouseMove</code></td><td><code>(model, x, y) => model'</code></td><td>optional; window pixels</td></tr>
               <tr><td><code>mouseWheel</code></td><td><code>(model, delta) => model'</code></td><td>optional</td></tr>
+              <tr><td><code>mouseButton</code></td><td><code>(model, button, isDown) => model'</code></td><td>optional; <code>button</code> is a <code>Mouse.t</code> variant — <code>Mouse.Left</code>, <code>Mouse.Right</code>, or <code>Mouse.Middle</code>. Delivered while the cursor is captured, so click-to-shoot works under free-look</td></tr>
               <tr><td><code>update</code></td><td><code>(model, msg) => model'</code></td><td>optional; messages are your variant values</td></tr>
               <tr><td><code>subscriptions</code></td><td><code>(model) => Sub</code></td><td>optional (requires <code>update</code>); declarative timers</td></tr>
               <tr><td><code>physics</code></td><td><code>(model) => Physics.scene(…)</code></td><td>optional; declarative bodies, reconciled each frame</td></tr>
@@ -197,7 +198,7 @@ let draw = (m, tts) =>
           <p>
             The model-returning entry points (<code>tick</code>, <code>input</code>,
             <code>sampledInput</code>, <code>mouseMove</code>, <code>mouseWheel</code>,
-            <code>update</code>) may instead
+            <code>mouseButton</code>, <code>update</code>) may instead
             return a 2-tuple <code>(model', effect)</code> to issue one-shot
             <a href="#prelude-effects">effects</a>.
           </p>
@@ -214,7 +215,11 @@ let draw = (m, tts) =>
       dx: (if held(Key.D) then 1.0 else 0.0) - (if held(Key.A) then 1.0 else 0.0) }</pre>
           <p>
             The snapshot is a plain record — <code>heldKeys : List&lt;Key.t&gt;</code>,
-            <code>mouse : { x, y }</code>, and <code>xr : Option.t&lt;…&gt;</code> for headset
+            <code>mouse : { x, y, buttons }</code> (with
+            <code>buttons.left</code> / <code>.right</code> / <code>.middle</code> for the
+            buttons held right now — the level twin of <code>mouseButton</code>'s edges, so a
+            full-auto weapon reads the snapshot while a semi-auto one takes the edge), and
+            <code>xr : Option.t&lt;…&gt;</code> for headset
             head and controller poses (see <code>Input</code> in the
             <a href="../docs/">API reference</a>). Being plain data is what lets sampled input be
             recorded and replayed deterministically.
@@ -612,11 +617,12 @@ type t&lt;'value, 'error> = | Ok(value: 'value) | Error(error: 'error)   // Resu
             </tbody>
           </table>
 
-          <h3 id="stdlib-debug">Debug and Key</h3>
+          <h3 id="stdlib-debug">Debug, Key, and Mouse</h3>
           <table>
             <tbody>
               <tr><td><code>Debug.log(label, subject)</code></td><td>prints <code>label: subject</code> and returns the subject <em>unchanged</em>, so it drops into a pipeline — <code>model.hp |> Debug.log("hp")</code> — and removing it changes nothing but the logging</td></tr>
               <tr><td><code>Key.t</code></td><td><code>Key.A</code>–<code>Key.Z</code>, <code>Key.Num0</code>–<code>Key.Num9</code>, <code>Key.Up/Down/Left/Right</code>, <code>Key.Space</code>, <code>Key.Enter</code>, <code>Key.Escape</code></td></tr>
+              <tr><td><code>Mouse.t</code></td><td><code>Mouse.Left</code>, <code>Mouse.Right</code>, <code>Mouse.Middle</code> — the <code>mouseButton</code> hook's <code>button</code></td></tr>
             </tbody>
           </table>
         </section>
@@ -627,6 +633,7 @@ type t&lt;'value, 'error> = | Ok(value: 'value) | Error(error: 'error)   // Resu
             <li><code>x |> f(a)</code> is <code>f(a, x)</code> — pipelines <em>append</em> (thread-last).</li>
             <li>Assignment is <code>:=</code> (not <code>&lt;-</code>) and must be followed by <code>;</code> and a continuation.</li>
             <li><code>if</code> is an expression: both branches are required, and chains use <code>else if</code> rather than <code>elif</code>.</li>
+            <li>Mouse buttons only reach <code>mouseButton</code> while the cursor is <em>captured</em> — the same rule <code>mouseMove</code> follows. Click the window first (or you will see nothing), and note a held button is force-released on focus loss.</li>
             <li>Angles, Durations, and render targets are branded <em>values</em> — <code>Sub.every(0.5, …)</code> and <code>Scene.rotateY(1.57)</code> are errors.</li>
             <li>A nested <code>match</code> inside an arm eats the following arms — parenthesize it.</li>
             <li>Constructor names are global to the file's value namespace; nullary constructors never take parens. Module variants are the exception — <code>Option.Some</code>, never bare <code>Some</code>.</li>

--- a/site/player.html
+++ b/site/player.html
@@ -110,6 +110,7 @@
         functor_lang_key_event,
         functor_lang_mouse_move,
         functor_lang_mouse_wheel,
+        functor_lang_mouse_button,
         functor_lang_ui_pointer,
         functor_lang_ui_pointer_leave,
         functor_lang_ui_wants_keyboard,
@@ -268,6 +269,43 @@
           functor_lang_mouse_wheel(Math.sign(e.deltaY));
         });
 
+        // Mouse buttons reach the game only while pointer-locked — the same
+        // rule mousemove follows above, and the browser twin of the desktop's
+        // "only while the cursor is captured". While the cursor is FREE it
+        // belongs to the scrubber and the `Ui.*` widget path below.
+        // MouseEvent.button (0 left, 1 middle, 2 right) → the runtime's
+        // canonical MouseButton discriminants (1 left, 2 right, 3 middle).
+        // Kept in sync with index-functor-lang.html.
+        const buttonCode = (button) =>
+          button === 0 ? 1 : button === 2 ? 2 : button === 1 ? 3 : 0;
+        const gameButtons = new Set();
+        canvas.addEventListener("mousedown", (e) => {
+          if (document.pointerLockElement !== canvas) return;
+          const code = buttonCode(e.button);
+          if (code === 0) return;
+          e.preventDefault();
+          functor_lang_mouse_button(code, true);
+          gameButtons.add(code);
+        });
+        window.addEventListener("mouseup", (e) => {
+          const code = buttonCode(e.button);
+          // Deliver the release only if the game saw the press, so a button
+          // pressed before locking (or on an overlay) can't leak a phantom up.
+          if (code !== 0 && gameButtons.delete(code)) functor_lang_mouse_button(code, false);
+        });
+        // Right-click while aiming must fire, not open the context menu.
+        canvas.addEventListener("contextmenu", (e) => {
+          if (document.pointerLockElement === canvas) e.preventDefault();
+        });
+        // A button released outside the window (or after the lock drops) may
+        // never emit a mouseup here — synthesize releases so the edge hook and
+        // the next sampled snapshot both recover, mirroring `blur` for keys.
+        const releaseGameButtons = () => {
+          for (const code of gameButtons) functor_lang_mouse_button(code, false);
+          gameButtons.clear();
+        };
+        window.addEventListener("blur", releaseGameButtons);
+
         // Interactive game UI (docs/ui-interaction.md U3): while the pointer
         // is FREE (not look mode), its canvas position + primary button drive
         // the game's `Ui.*` widgets. CSS px — the runtime scales by the
@@ -295,6 +333,7 @@
         });
         document.addEventListener("pointerlockchange", () => {
           if (document.pointerLockElement === canvas) functor_lang_ui_pointer_leave();
+          else releaseGameButtons();
         });
       };
 

--- a/tools/functor-sdk/README.md
+++ b/tools/functor-sdk/README.md
@@ -27,6 +27,7 @@ await using game = await FunctorRunner.launch({
 
 await game.pause();              // pin the clock
 await game.keyDown("up");        // inject input
+await game.mouseDown("left");    // ...including mouse buttons (held until mouseUp)
 await game.step();               // advance exactly one frame
 const state = await game.state();// observe the result
 const xr = await game.xrInput();  // rig-local head/controllers on XR targets
@@ -35,7 +36,8 @@ const png = await game.capture();// PNG bytes of the frame
 ```
 
 `state.input` is one extensible sampled-input record. It always carries held
-keys and the last mouse position; XR targets add typed rig-local head and
+keys and the last mouse position plus which buttons are held
+(`state.input.mouse.buttons`); XR targets add typed rig-local head and
 controller state (`game.xrInput()`). Future gamepad and mobile-touch domains
 can extend the same record without target-specific clients.
 

--- a/tools/functor-sdk/src/game.ts
+++ b/tools/functor-sdk/src/game.ts
@@ -2,6 +2,7 @@ import type { HttpClient } from "./client.js";
 import type {
   InputCommand,
   KeyName,
+  MouseButtonName,
   ProjectAssets,
   ProjectSources,
   RuntimeState,
@@ -148,6 +149,23 @@ export class FunctorClient {
   /** Scroll the mouse wheel. */
   mouseWheel(delta: number): Promise<void> {
     return this.input({ type: "mouse_wheel", delta });
+  }
+
+  /** Press or release a mouse button.
+   *
+   * Both an edge and level state, like {@link key}: the `mouseButton` hook
+   * fires, and the button stays held in later steps' `sampledInput` until
+   * released — so holding one across several `step()`s scripts full-auto fire. */
+  mouseButton(button: MouseButtonName, down: boolean): Promise<void> {
+    return this.input({ type: "mouse_button", button, down });
+  }
+
+  mouseDown(button: MouseButtonName = "left"): Promise<void> {
+    return this.mouseButton(button, true);
+  }
+
+  mouseUp(button: MouseButtonName = "left"): Promise<void> {
+    return this.mouseButton(button, false);
   }
 
   /** Set the XR sample the next fixed step's `sampledInput` sees — tracked

--- a/tools/functor-sdk/src/types.ts
+++ b/tools/functor-sdk/src/types.ts
@@ -36,6 +36,16 @@ export interface XrInputSnapshot {
   right: XrControllerSnapshot;
 }
 
+/** Wire spelling of a mouse button for `POST /input`. */
+export type MouseButtonName = "left" | "right" | "middle";
+
+/** Which mouse buttons are held, as reported in an `InputSnapshot`. */
+export interface MouseButtons {
+  left: boolean;
+  right: boolean;
+  middle: boolean;
+}
+
 /** Runtime-owned input sampled independently of the game model.
  *
  * Typed device domains extend this record: XR is available today; gamepad and
@@ -44,8 +54,11 @@ export interface XrInputSnapshot {
 export interface InputSnapshot {
   /** Keys currently held, by canonical name. */
   held_keys: KeyName[];
-  /** Last known cursor position in window pixels. */
-  mouse: { x: number; y: number };
+  /** Last known cursor position in window pixels, plus the buttons held.
+   *
+   * `buttons` is absent from older runtimes' `/state`; treat a missing field
+   * as "no button held". */
+  mouse: { x: number; y: number; buttons?: MouseButtons };
   /** Present while an XR target has valid head tracking. */
   xr?: XrInputSnapshot;
 }
@@ -98,6 +111,7 @@ export type InputCommand =
   | { type: "key"; key: string; down: boolean }
   | { type: "mouse_move"; x: number; y: number }
   | { type: "mouse_wheel"; delta: number }
+  | { type: "mouse_button"; button: MouseButtonName; down: boolean }
   | { type: "ui_event"; slot: number; kind: UiEventKind }
   | { type: "webview_event"; slot: number; kind: UiEventKind }
   | ({ type: "xr" } & XrInputSample)

--- a/tools/functor-sdk/test/functor-lang-mouse-button.e2e.test.ts
+++ b/tools/functor-sdk/test/functor-lang-mouse-button.e2e.test.ts
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { findRepoRoot, FunctorRunner } from "../src/index.js";
+
+// Mouse buttons reach the Functor Lang model two ways, and this pins BOTH:
+//   * the edge, through the optional `mouseButton` entry point —
+//     (model, button, isDown) => model, buttons as the built-in `Mouse`
+//     module's variants (Mouse.Left, Mouse.Right, Mouse.Middle);
+//   * the level, through `sampledInput`'s `snapshot.mouse.buttons`.
+const e2eEnabled = process.env.FUNCTOR_E2E === "1";
+const headless = process.env.FUNCTOR_E2E_HEADLESS === "1";
+
+// `edges` counts left PRESSES, `heldSteps` counts fixed steps during which the
+// left button was held, and `rights` proves the variant is discriminated rather
+// than collapsed to "a click happened".
+const GAME = `let init = { edges: 0.0, heldSteps: 0.0, rights: 0.0 }
+let mouseButton = (m, button, isDown) =>
+  match button with
+  | Mouse.Left => (if isDown then { m with edges: m.edges + 1.0 } else m)
+  | Mouse.Right => (if isDown then { m with rights: m.rights + 1.0 } else m)
+  | _ => m
+let sampledInput = (m, snapshot: Input.snapshot) =>
+  if snapshot.mouse.buttons.left then { m with heldSteps: m.heldSteps + 1.0 } else m
+let tick = (m, dt, tts) => m
+let draw = (m, tts) =>
+  Frame.create(Camera.lookAt(Vec3.make(0.0, 2.0, -6.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube())
+`;
+
+/** Read one numeric field out of the (stringly-typed) Debug model. */
+function field(model: string, name: string): number {
+  const m = model.match(new RegExp(`\\b${name}:\\s*(-?[0-9.]+)`));
+  assert.ok(m, `could not find ${name} in model: ${model.slice(0, 200)}`);
+  return Number(m[1]);
+}
+
+test(
+  "mouse buttons reach the model as edges (mouseButton) and levels (sampledInput)",
+  { skip: !e2eEnabled, timeout: 120_000 },
+  async () => {
+    const repoRoot = findRepoRoot(process.cwd());
+    assert.ok(repoRoot, "must run from within the functor workspace");
+
+    const dir = mkdtempSync(join(tmpdir(), "functor-lang-mouse-button-"));
+    const functorLangPath = join(dir, "game.fun");
+    writeFileSync(functorLangPath, GAME);
+
+    await using runner = await FunctorRunner.launch({
+      gameDir: dir,
+      repoRoot,
+      functorLangPath,
+      port: Number(process.env.FUNCTOR_E2E_PORT ?? 8096),
+      headless,
+    });
+    await runner.pause();
+
+    const model = async () => (await runner.state()).model;
+    // `buttons` is optional on the type (older runtimes omit it); a runtime
+    // that supports this feature at all must report it.
+    const buttons = async () => {
+      const held = (await runner.state()).input.mouse.buttons;
+      assert.ok(held, "/state must report mouse.buttons");
+      return held;
+    };
+
+    assert.equal(field(await model(), "edges"), 0, "no clicks yet");
+    assert.deepEqual(
+      await buttons(),
+      { left: false, right: false, middle: false },
+      "nothing held at rest",
+    );
+
+    // One press: exactly one edge, and the level goes hot.
+    await runner.mouseDown("left");
+    await runner.step();
+    assert.equal(field(await model(), "edges"), 1, "the press fired mouseButton once");
+    assert.equal((await buttons()).left, true, "the runtime reports left held");
+
+    // Held across further steps: no new edges, but the level keeps sampling —
+    // this is what makes full-auto fire scriptable.
+    const heldAfterFirst = field(await model(), "heldSteps");
+    await runner.step();
+    await runner.step();
+    assert.equal(field(await model(), "edges"), 1, "holding does not re-fire the edge");
+    assert.ok(
+      field(await model(), "heldSteps") > heldAfterFirst,
+      "the held level keeps accumulating while the button is down",
+    );
+
+    // REGRESSION: moving the cursor must not release the held button. A
+    // mouse-move that replaced the whole mouse snapshot would silently clear
+    // `buttons`, so a drag would drop the click on replay but not live.
+    await runner.mouseMove(42, 7);
+    await runner.step();
+    const dragged = await runner.state();
+    assert.equal(dragged.input.mouse.x, 42, "the move applied");
+    assert.equal(dragged.input.mouse.y, 7, "the move applied");
+    assert.equal(
+      dragged.input.mouse.buttons?.left,
+      true,
+      "moving the cursor must NOT release a held button",
+    );
+
+    // Release: the level clears and stops accumulating.
+    await runner.mouseUp("left");
+    await runner.step();
+    assert.equal((await buttons()).left, false, "the release cleared the level");
+    const heldAtRelease = field(await model(), "heldSteps");
+    await runner.step();
+    assert.equal(
+      field(await model(), "heldSteps"),
+      heldAtRelease,
+      "a released button stops sampling",
+    );
+
+    // The right button lands on its own match arm and its own level bit.
+    await runner.mouseDown("right");
+    await runner.step();
+    assert.equal(field(await model(), "rights"), 1, "Mouse.Right is discriminated");
+    assert.equal(field(await model(), "edges"), 1, "...and did not count as a left click");
+    assert.deepEqual(await buttons(), { left: false, right: true, middle: false });
+  },
+);


### PR DESCRIPTION
## What

Mouse buttons had no path into game logic. `mouseMove`/`mouseWheel` existed, but a click was simply unreachable — and under cursor capture (free-look) window buttons were dropped entirely, so **click-to-shoot was impossible**.

This applies the existing `Key.t` design to the pointer:

- **A builtin `Mouse` module** — `Mouse.Left` / `Mouse.Right` / `Mouse.Middle`, injected beside `Key`, so a typo is a check-time error rather than a silent no-match.
- **An optional `mouseButton = (model, button, isDown) => model'` entry point**, delivered **while the cursor is captured** (the rule `mouseMove`/`mouseWheel` already follow — this is the fix for clicks being eaten by free-look) and routed through `absorb`, so returning `(model', effect)` works for free.
- **Held level state** on the sampled snapshot as `mouse.buttons.{left,right,middle}` — `mouseButton` is the **edge**, `sampledInput` is the **level**. Semi-auto takes the edge; full-auto reads the snapshot.
- **`POST /input {"type":"mouse_button","button":"left","down":true}`** — edge + level like `key`, so holding a button across several `/time advance` steps scripts full-auto fire headlessly.

All three producers (desktop GLFW, web/wasm, oculus) plus the deterministic replay/forward-step path build the variant from **one shared conversion** (`mouse_button_input_value`), so live input, forward-step projection, and the journal cannot drift. A held button is swept released on focus loss, Escape, and the `~` console toggle, so it can never fire forever.

```
let mouseButton = (m, button, isDown) =>
  match button with
  | Mouse.Left => (if isDown then fire(m) else m)
  | _ => m

let sampledInput = (m, snapshot: Input.snapshot) =>
  if snapshot.mouse.buttons.left then fullAuto(m) else m
```

## Latent bug fixed along the way

Replayed `MouseMove` assigned a whole `MouseSnapshot`, which **reset `buttons`** — so dragging while holding a button would silently drop the button on replay while keeping it held live: a live/replay divergence. It now assigns x/y only (same fix in the web `drain_input`), pinned by `replayed_mouse_move_preserves_held_mouse_buttons`, which was **verified to fail when the fix is reverted** (asserts exactly at "a mouse move keeps the held button").

## Verification

- `cargo test -p functor_runtime_common` — **492 passed**; `-p functor-lang` — all green; `-p functor-runtime-desktop` — 68 passed. The one desktop failure (`mario_hot_reload_recomputes_the_entire_extrapolated_future`) is **pre-existing** and reproduces on clean `main`.
- **New committed e2e** `tools/functor-sdk/test/functor-lang-mouse-button.e2e.test.ts` drives the real headless runtime through press-edge → held-level accumulation → drag-while-held → release → right-button discrimination. Full SDK e2e suite: **23 passed / 1 skipped / 0 failed**.
- An unknown button name is a **400** with a teaching message and the runtime survives; `mouse_button_input_value` drops unrecognized codes, so `MouseButton::Unknown` can never reach game logic.
- `npm run check:docs` clean; site builds.

### Benchmarks (per-frame hot path — producer + snapshot conversion)

`frame_bench`, release, base vs. branch, 3 runs each, same machine:

| grid | allocs/frame (base → branch) | bytes/frame (base → branch) | us/frame min (base → branch) |
| --- | --- | --- | --- |
| 20x20 | 13877 → **13877** | 843379 → **843379** | 455.2 → 441.8 |
| 40x40 | 54717 → **54717** | 3307219 → **3307219** | 1873.1 → 1741.3 |
| 56x56 | 106973 → **106973** | 6460243 → **6460243** | 3673.5 → 3668.2 |

**allocs/frame and bytes/frame are byte-identical** at every size — the deterministic signal shows zero added cost. Wall clock is within run-to-run spread (branch mins happen to land slightly lower; noise). Note `frame_bench`'s workload has no `sampledInput` hook, so this measures that games *without* the hook pay nothing; games with it gain one small record per step.

## Review (`/xreview` — Claude subagent + Codex, in parallel)

Both engines **independently flagged the same real gap**, which is fixed in b3d7ac8:

- **[AGREED] `site/player.html` was missed entirely.** The marketing site's wasm host page claims to be "kept in sync with `index-functor-lang.html`" but had no button wiring, so a game in the sandbox/docs player got no edges and a permanently-false `mouse.buttons` — silently diverging from `run wasm`. The whole block is now ported.
- **Pinned-clock stuck button (Claude, Medium).** Under `--fixed-time`, the Escape and `~` sweeps cleared `held_buttons` and sent the up edge but never refreshed `fixed_input_snapshot` (which isn't rebuilt per frame), so `sampledInput` would report the button held *forever*. Both now do the `is_fixed_time()` refresh that the `Focus(false)` sweep already did.
- **Drift-proofing (Claude, Low).** `release_held_mouse_buttons` iterates `MouseButton::ALL` instead of a literal list, so a new button can't escape the sweep.
- **Stale doc row (Claude, Low).** `docs/time-travel.md`'s "Mouse clicks reaching game/overlay at all — *Missing*" row flipped to Shipped; `--emulate-xr`'s no-capture caveat documented.

Dispositioned **without** change, with reasons:

- *"A release while paused suppresses the edge"* (Codex, Medium) — **deliberate**: an unlogged edge would diverge forward-step replay, and it matches the existing **key** discipline exactly. Diverging one arm from its twin would be the bug.
- *"`index-functor-lang.html` lacks pointerlockchange recovery"* (Codex, Medium) — **false**; line 268 already calls `releaseGameButtons()`. Verified directly.
- *"The wasm export can deliver a release without a press"* (Codex, Low) — the arm is symmetric with the pre-existing `Key` arm, the host page gates it, and unknown codes are dropped before any hook sees them.

Every fix was re-validated afterwards (tests + a rebuilt binary + the full e2e suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Visuals

Manual page (`site/manual/`) built at the base ref and at this branch, screenshotted headlessly (Playwright/chromium) at 1440px desktop and 390px mobile. Only the docs page changed visually; `site/player.html` is JS wiring with no rendered output.

**Game-contract entry points — the new `mouseButton` row + the effect-tuple paragraph** (desktop)

![entry points before/after](https://gist.githubusercontent.com/tommy-xr/323878a0fa7d574d47b1542c0dbaff9f/raw/entry-desktop-ba.png)

**`sampledInput` snapshot — `mouse : { x, y, buttons }`** (desktop)

![snapshot paragraph before/after](https://gist.githubusercontent.com/tommy-xr/323878a0fa7d574d47b1542c0dbaff9f/raw/snapshot-desktop-ba.png)

**Stdlib section — "Debug and Key" → "Debug, Key, and Mouse", with the new `Mouse.t` row** (desktop)

![stdlib before/after](https://gist.githubusercontent.com/tommy-xr/323878a0fa7d574d47b1542c0dbaff9f/raw/stdlib-desktop-ba.png)

**Sharp edges — the new cursor-capture bullet** (desktop)

![sharp edges before/after](https://gist.githubusercontent.com/tommy-xr/323878a0fa7d574d47b1542c0dbaff9f/raw/sharp-desktop-ba.png)

<details>
<summary>Mobile (390px) — the entry-point table gained a row, so the reflow is checked too</summary>

![entry points mobile before/after](https://gist.githubusercontent.com/tommy-xr/323878a0fa7d574d47b1542c0dbaff9f/raw/entry-mobile-ba.png)

![sharp edges mobile before/after](https://gist.githubusercontent.com/tommy-xr/323878a0fa7d574d47b1542c0dbaff9f/raw/sharp-mobile-ba.png)

</details>


## Caveat for reviewers

The **oculus (Quest) dispatch arm** is the one piece not compile-verified here. `runtime/functor-runtime-oculus` is deliberately its own workspace outside the root one (`android-activity` → `ndk-sys` hard-fails for non-Android targets), and this machine has `cargo-ndk` but **no NDK installed**, so it cannot be built. The arm is a small mechanical mirror of the desktop injection arm over the same shared API (`MouseButton::from_name`, `MouseButtons::set`/`is_down`, `GameProducer::mouse_button`) and uses `debug.input.mouse.buttons`, which is the shared `InputSnapshot` the crate already consumes — but it wants a real `cargo ndk` build (or a device run via the `vr-device-loop` skill) before anyone relies on scripted clicks on-device. Note `GameProducer::mouse_button` has a defaulted no-op body, so an unbuilt device runtime degrades to "no button events", never to a break.
