### PR TITLE
refactor(site): migrate the entry files to TypeScript

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -20,14 +20,14 @@ npm run test:ide-page    # headless e2e — the IDE page (e2e/ide-page.mjs)
   `index-functor-lang.html`, but the `.fun` entry comes from `?game=` (one file) or
   `?project=inline` (the IDE pushes the whole file set by postMessage). Keep its
   input mapping and set-source/set-project seam in sync with that page.
-- `sandbox.html` / `src/sandbox.js` — the single-buffer editor over a served
+- `sandbox.html` / `src/sandbox.ts` — the single-buffer editor over a served
   example (pushes `functor-lang-set-source`).
-- `ide.html` / `src/ide.js` — the multi-file IDE: a file sidebar, per-file
+- `ide.html` / `src/ide.ts` — the multi-file IDE: a file sidebar, per-file
   editing, a live preview fed the whole project via `functor-lang-set-project`
-  (`src/project-bridge.js`), localStorage persistence, and project download as a
+  (`src/project-bridge.ts`), localStorage persistence, and project download as a
   `.zip` (`src/zip.ts`, a store-only writer). Asset (`.glb`/audio) management is a
   follow-up.
-- `src/runtime-target.js` — the shared external-runtime link in both editors.
+- `src/runtime-target.ts` — the shared external-runtime link in both editors.
   The first explicit push uses `/load-project` (fresh `init`); later edits use
   `/reload-project` (model preserved), with `/state` telemetry and `/capture`
   shown in the panel. Sandbox examples also upload their declared local assets
@@ -52,6 +52,6 @@ npm run test:ide-page    # headless e2e — the IDE page (e2e/ide-page.mjs)
 - `docs.html` — compatibility redirect to the manual, preserving old anchors.
 - `src/examples.ts` is the single source of truth for the sandbox's example set
   (id + dropdown label + repo source path). `build.mjs` copies each entry's
-  `game.fun` at build time and `src/sandbox.js` builds the dropdown from the same
+  `game.fun` at build time and `src/sandbox.ts` builds the dropdown from the same
   list, so the sandbox dropdown always matches what ships in the repo.
 - Deploy: publish `site/dist` to any static host.

--- a/site/build.mjs
+++ b/site/build.mjs
@@ -262,12 +262,12 @@ await esbuild.build({
   // `src/docs.js` would silently win. Name the file that actually exists. The
   // OUTPUT basenames are unchanged either way (esbuild always emits `.js`).
   entryPoints: [
-    `${site}src/sandbox.js`,
-    `${site}src/ide.js`,
+    `${site}src/sandbox.ts`,
+    `${site}src/ide.ts`,
     `${site}src/docs.ts`,
     `${site}src/api-docs.ts`,
-    `${site}src/hero.js`,
-    `${site}src/demo-editor.js`,
+    `${site}src/hero.ts`,
+    `${site}src/demo-editor.ts`,
     `${site}src/features.ts`,
   ],
   bundle: true,

--- a/site/src/demo-editor.ts
+++ b/site/src/demo-editor.ts
@@ -1,6 +1,6 @@
 // A standalone, full-featured Functor Lang editor beside a live scene — the
 // hero editor's demo-grade sibling. Unlike the landing hero's mini-editor
-// (mini-editor.js — deliberately stripped to keep the landing bundle tiny),
+// (mini-editor.ts — deliberately stripped to keep the landing bundle tiny),
 // this composes the SAME language intelligence the sandbox uses — completion,
 // codelenses, hover types, diagnostics, and the paused-inspector live-value
 // overlay — plus state-preserving hot reload. It carries none of the sandbox's
@@ -10,7 +10,7 @@
 //
 // This is a lean re-composition of the shared, already-modular seams
 // (setupLangIntel, wireLiveTrace, PlayerBridge) rather than a fork of
-// sandbox.js — the only overlap is constructing the editor view.
+// sandbox.ts — the only overlap is constructing the editor view.
 
 import { basicSetup } from "codemirror";
 import { EditorView, keymap } from "@codemirror/view";

--- a/site/src/demo-editor.ts
+++ b/site/src/demo-editor.ts
@@ -20,7 +20,15 @@ import { functorLangLanguage, synthwaveEditorTheme } from "./functor-lang.js";
 import { setupLangIntel, wireLiveTrace } from "./lang-intel.js";
 import { PlayerBridge } from "./player-bridge.js";
 
-const frame = document.getElementById("player");
+/** The demo / e2e seam this page exposes (site/demos/ drives it). */
+interface DemoEditorSeam {
+  ready: Promise<boolean>;
+  view: EditorView;
+  frame: HTMLIFrameElement;
+  source: () => string;
+}
+
+const frame = document.getElementById("player") as HTMLIFrameElement;
 const game = new URLSearchParams(location.search).get("game") || "examples/hero.fun";
 
 // wireLiveTrace drives an executions picker through a status bar; the demo has
@@ -41,7 +49,7 @@ const bridge = new PlayerBridge(frame, {
 let programmaticEdit = false;
 
 const view = new EditorView({
-  parent: document.getElementById("editor"),
+  parent: document.getElementById("editor")!,
   extensions: [
     basicSetup,
     keymap.of([indentWithTab]),
@@ -74,7 +82,7 @@ wireLiveTrace(view, noopStatusBar, frame, langReady);
 })();
 
 // Demo / e2e seam.
-window.__demoEditor = {
+(window as Window & { __demoEditor?: DemoEditorSeam }).__demoEditor = {
   ready: langReady,
   view,
   frame,

--- a/site/src/docs.ts
+++ b/site/src/docs.ts
@@ -1,6 +1,6 @@
 // Docs page enhancement: syntax-highlight the <pre class="functor-lang"> blocks and
 // give the runnable ones (class "runnable") a "▶ try it" button that opens
-// the program in the sandbox via the #src= fragment (see sandbox.js).
+// the program in the sandbox via the #src= fragment (see sandbox.ts).
 //
 // The tokenizer mirrors src/functor-lang.ts's CodeMirror StreamLanguage; it's a few
 // regexes, so a static-HTML variant beats dragging CodeMirror onto the docs

--- a/site/src/examples.ts
+++ b/site/src/examples.ts
@@ -2,7 +2,7 @@
 // this one list, so it can't drift:
 //   - build.mjs (Node)   uses `id` + `source` to copy the .fun into
 //     dist/examples/<id>.fun at build time;
-//   - sandbox.js (browser) uses `id` + `label` to build the scene dropdown.
+//   - sandbox.ts (browser) uses `id` + `label` to build the scene dropdown.
 // The site e2e derives its per-example smoke test from the rendered picker, so
 // it tracks this list automatically too.
 //

--- a/site/src/hero.ts
+++ b/site/src/hero.ts
@@ -8,16 +8,32 @@
 // or lint) so the landing bundle stays tiny. It NEVER reloads the iframe; every
 // edit is a source push, because state preservation IS the demo.
 
+import type { EditorView } from "@codemirror/view";
 import { createMiniEditor } from "./mini-editor.js";
 import { PlayerBridge } from "./player-bridge.js";
+
+/** The status dot's three states — also its `data-state` attribute value. */
+type HeroState = "busy" | "live" | "error";
+
+interface HeroStatus {
+  state: HeroState;
+  message: string;
+}
+
+/** The landing page's e2e seam (driven by e2e/site-sandbox.mjs). */
+interface HeroSeam {
+  setRegion(src: string): void;
+  region: () => string;
+  status: () => HeroStatus;
+}
 
 const HERO_URL = "examples/hero.fun";
 const OPEN = "// <editable>";
 const CLOSE = "// </editable>";
 
-const frame = document.querySelector(".hero-scene");
-const mount = document.getElementById("hero-editor");
-const card = document.querySelector(".hero-card");
+const frame = document.querySelector<HTMLIFrameElement>(".hero-scene")!;
+const mount = document.getElementById("hero-editor")!;
+const card = document.querySelector(".hero-card")!;
 
 // A small, unobtrusive status dot pinned to the card corner: green when the
 // last edit is live, red on a broken edit (the old program keeps running).
@@ -26,8 +42,8 @@ const dot = document.createElement("div");
 dot.className = "hero-status";
 card.appendChild(dot);
 
-let statusState = { state: "busy", message: "" };
-const setStatus = (state, message = "") => {
+let statusState: HeroStatus = { state: "busy", message: "" };
+const setStatus = (state: HeroState, message = "") => {
   statusState = { state, message };
   dot.dataset.state = state;
   dot.title = message || state;
@@ -52,10 +68,10 @@ const bridge = new PlayerBridge(frame, {
     ok ? setStatus("live", message) : setStatus("error", message),
 });
 
-let editor = null;
+let editor: EditorView | null = null;
 
 const boot = async () => {
-  let source;
+  let source: string;
   try {
     const response = await fetch(HERO_URL);
     if (!response.ok) {
@@ -100,7 +116,7 @@ const boot = async () => {
 boot();
 
 // Test seam for the headless e2e (e2e/site-sandbox.mjs), on the landing window.
-window.__hero = {
+(window as Window & { __hero?: HeroSeam }).__hero = {
   setRegion(src) {
     if (editor) {
       editor.dispatch({

--- a/site/src/hero.ts
+++ b/site/src/hero.ts
@@ -3,8 +3,8 @@
 // Edit the region and the running grid hot-swaps with the model preserved —
 // the wave keeps rolling — then drag the timeline back through the change.
 //
-// This is the light sibling of sandbox.js: it reuses the same editor↔player
-// seam (player-bridge.ts) but a stripped editor (mini-editor.js — no basicSetup
+// This is the light sibling of sandbox.ts: it reuses the same editor↔player
+// seam (player-bridge.ts) but a stripped editor (mini-editor.ts — no basicSetup
 // or lint) so the landing bundle stays tiny. It NEVER reloads the iframe; every
 // edit is a source push, because state preservation IS the demo.
 

--- a/site/src/ide.ts
+++ b/site/src/ide.ts
@@ -24,7 +24,61 @@ import {
 import { ProjectBridge } from "./project-bridge.js";
 import { createStatusBar } from "./status-bar.js";
 import { createRuntimeTarget } from "./runtime-target.js";
+import { asPlayerMessage } from "./protocol.js";
+import type { ProjectFile } from "./protocol.js";
 import { zipFiles } from "./zip.js";
+
+/** The in-memory project: a flat module space plus the open file's path. */
+interface Project {
+  active: string;
+  files: ProjectFile[];
+}
+
+/**
+ * The project as read back from localStorage. This is the shape it is EXPECTED
+ * to have, not one anything guarantees: the store is user-editable, so every
+ * field is optional and `loadProject` re-validates each one at runtime (a
+ * mismatch falls through to the starter). Typing it as `unknown` instead would
+ * only move those same runtime checks behind a wall of casts.
+ */
+interface StoredProject {
+  active?: string;
+  files?: ProjectFile[];
+}
+
+/** The status pill's three states — also its `data-state` attribute value. */
+type PillState = "busy" | "live" | "error";
+
+/** `validName`'s verdict: exactly one of the two fields is ever present. */
+interface NameCheck {
+  path?: string;
+  error?: string;
+}
+
+type RuntimeTarget = ReturnType<typeof createRuntimeTarget>;
+type RuntimeTargetState = ReturnType<RuntimeTarget["state"]>;
+
+/** The IDE's e2e seam (driven by e2e/ide-page.mjs and e2e/ide-project.mjs). */
+interface IdeSeam {
+  setActiveSource(source: string): void;
+  openFile: (path: string) => void;
+  newFile: (path: string, source?: string) => void;
+  files: () => ProjectFile[];
+  status: () => {
+    state: string | undefined;
+    text: string | null;
+    message: string;
+  };
+  runtimeTarget: () => RuntimeTargetState;
+  triggerComplete(source: string, cursor: number): void;
+  acceptCompletion: () => boolean;
+}
+
+/** The readiness seam, shared in NAME (not shape) with the sandbox's. */
+interface LangSeam {
+  ready: Promise<boolean>;
+  expects: () => ReturnType<typeof currentExpects>;
+}
 
 const STORAGE_KEY = "functor-ide-project-v1";
 const ENTRY = "game.fun"; // the program root; every other .fun is a sibling module
@@ -45,7 +99,7 @@ const FILE_ICON =
 // A two-file starter: game.fun draws using constants from palette.fun (a
 // sibling module — file = module, so palette.fun is module `Palette`), to show
 // the multi-file loop the sandbox can't.
-const STARTER = {
+const STARTER: Project = {
   active: ENTRY,
   files: [
     {
@@ -79,23 +133,25 @@ let sky = 0.18
 };
 
 const els = {
-  fileList: document.getElementById("file-list"),
-  newFile: document.getElementById("new-file"),
-  download: document.getElementById("download"),
-  restart: document.getElementById("restart"),
-  status: document.getElementById("status"),
-  activeName: document.getElementById("active-file"),
-  editorHost: document.getElementById("editor"),
-  player: document.getElementById("player"),
+  fileList: document.getElementById("file-list")!,
+  newFile: document.getElementById("new-file")!,
+  download: document.getElementById("download")!,
+  restart: document.getElementById("restart")!,
+  status: document.getElementById("status")!,
+  activeName: document.getElementById("active-file")!,
+  editorHost: document.getElementById("editor")!,
+  player: document.getElementById("player") as HTMLIFrameElement,
 };
 
 // ---------------------------------------------------------------- project
 
 let project = loadProject();
 
-function loadProject() {
+function loadProject(): Project {
   try {
-    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY));
+    // A missing key parses as `null` (JSON.parse coerces), which the validation
+    // below rejects — the starter is the fallback either way.
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!) as StoredProject | null;
     const seen = new Set();
     const valid =
       stored &&
@@ -111,13 +167,16 @@ function loadProject() {
       }) &&
       stored.files.some((f) => f.path === ENTRY);
     if (valid) {
-      const active = stored.files.some((f) => f.path === stored.active) ? stored.active : ENTRY;
+      // The guard proves `active` matched a validated (string) path.
+      const active = stored.files!.some((f) => f.path === stored.active)
+        ? stored.active!
+        : ENTRY;
       // The loader's contract (preview AND language analysis): the ENTRY is
       // files[0] — its module is the program root. Every mutation here keeps
       // that order, but a hand-edited localStorage could reorder.
       const files = [
-        ...stored.files.filter((f) => f.path === ENTRY),
-        ...stored.files.filter((f) => f.path !== ENTRY),
+        ...stored.files!.filter((f) => f.path === ENTRY),
+        ...stored.files!.filter((f) => f.path !== ENTRY),
       ];
       return { files, active };
     }
@@ -140,7 +199,7 @@ const activeFile = () => project.files.find((f) => f.path === project.active);
 
 // ---------------------------------------------------------------- status
 
-const setStatus = (state, text, detail = "") => {
+const setStatus = (state: PillState, text: string, detail = "") => {
   els.status.dataset.state = state;
   els.status.textContent = text;
   // The detail (the reload note, or a parse error) lives in the pill's tooltip
@@ -152,7 +211,7 @@ const setStatus = (state, text, detail = "") => {
 // ---------------------------------------------------------------- editor
 
 let programmaticEdit = false;
-let runtimeTarget = null;
+let runtimeTarget: RuntimeTarget | null = null;
 
 const view = new EditorView({
   parent: els.editorHost,
@@ -182,7 +241,7 @@ const langReady = setupLangIntel().then((extensions) => {
   return extensions.length > 0;
 });
 
-const statusBar = createStatusBar({ host: document.getElementById("statusbar") });
+const statusBar = createStatusBar({ host: document.getElementById("statusbar")! });
 runtimeTarget = createRuntimeTarget({
   host: document.getElementById("runtime-target"),
   getProject: () => project.files,
@@ -221,7 +280,7 @@ onDiagnostics((diags) => {
 // Runtime console traces (Functor Lang `Debug.log` and friends), forwarded by the
 // player page — see the console hook in player.html. Guarded to OUR iframe.
 window.addEventListener("message", (event) => {
-  const data = event.data;
+  const data = asPlayerMessage(event.data);
   if (!data || data.type !== "functor-lang-console") return;
   if (event.source !== els.player.contentWindow) return;
   statusBar.appendOutput(data.level, data.message, data.frame ?? null);
@@ -233,7 +292,7 @@ window.addEventListener("message", (event) => {
 // opened buffer's hash (openFile below calls it after setDoc).
 wireLiveTrace(view, statusBar, els.player, langReady);
 
-const setDoc = (source) => {
+const setDoc = (source: string) => {
   programmaticEdit = true;
   view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: source } });
   programmaticEdit = false;
@@ -268,7 +327,8 @@ const bridge = new ProjectBridge(els.player, {
 const schedulePush = () => {
   saveProject();
   bridge.setProject(project.files);
-  runtimeTarget.projectChanged();
+  // Assigned during boot, before any edit or seam call can reach these.
+  runtimeTarget!.projectChanged();
 };
 
 // ---------------------------------------------------------------- sidebar
@@ -307,7 +367,7 @@ const renderFileList = () => {
   els.activeName.textContent = project.active;
 };
 
-const openFile = (path) => {
+const openFile = (path: string) => {
   if (path === project.active) return;
   // A stale caller (e.g. a problem row outliving a delete) must not point
   // `active` at a file that no longer exists.
@@ -327,7 +387,7 @@ const openFile = (path) => {
 
 // A valid sibling filename: `<name>.fun`, a bare module stem (no path
 // separators — the project is a flat module space), and not already taken.
-const validName = (raw) => {
+const validName = (raw: string): NameCheck => {
   const path = raw.trim();
   if (!MODULE_FILE.test(path)) {
     return { error: "name must be a bare module like `enemy.fun` (letters, digits, _)" };
@@ -346,12 +406,13 @@ const newFile = () => {
     setStatus("error", "✖ error", error);
     return;
   }
-  project.files.push({ path, source: `// ${path}\n` });
-  openFile(path);
+  // `error` was falsy, so validName returned the other arm: `path` is set.
+  project.files.push({ path: path!, source: `// ${path}\n` });
+  openFile(path!);
   schedulePush(); // a new empty module can't break the build; keep the preview in sync
 };
 
-const deleteFile = (path) => {
+const deleteFile = (path: string) => {
   if (path === ENTRY) return;
   if (!window.confirm(`Delete ${path}? This can't be undone.`)) return;
   project.files = project.files.filter((f) => f.path !== path);
@@ -360,7 +421,7 @@ const deleteFile = (path) => {
   resetIntel();
   if (project.active === path) {
     project.active = ENTRY;
-    setDoc(activeFile().source);
+    setDoc(activeFile()!.source);
   } else {
     // Topology changed under an unchanged buffer: without a doc change the
     // linter never reruns, leaving diagnostics/inlays/lenses stale forever.
@@ -397,7 +458,7 @@ const restart = () => {
   setStatus("busy", "◌ loading…");
   els.player.src = "player.html?project=inline";
   bridge.setProject(project.files);
-  runtimeTarget.restart();
+  runtimeTarget!.restart();
 };
 
 // ---------------------------------------------------------------- boot
@@ -407,7 +468,7 @@ els.download.addEventListener("click", download);
 els.restart.addEventListener("click", restart);
 
 renderFileList();
-setDoc(activeFile().source);
+setDoc(activeFile()!.source);
 setStatus("busy", "◌ loading…");
 // Store the file set BEFORE the iframe loads, so the bridge can flush it the
 // moment the player announces it's ready (no lost first push).
@@ -416,7 +477,7 @@ els.player.src = "player.html?project=inline";
 
 // Test seam for the headless e2e (e2e/ide-page.mjs): drive files without
 // synthesizing DOM events, and read status.
-window.__ide = {
+(window as Window & { __ide?: IdeSeam }).__ide = {
   setActiveSource(source) {
     setDoc(source);
     const file = activeFile();
@@ -435,7 +496,7 @@ window.__ide = {
     text: els.status.textContent,
     message: els.status.title,
   }),
-  runtimeTarget: () => runtimeTarget.state(),
+  runtimeTarget: () => runtimeTarget!.state(),
   // Replace the active buffer, place the cursor, and open the completion popup
   // (explicit trigger) — the sandbox's seam, minus any push (programmaticEdit
   // suppresses the mirror-and-push listener).
@@ -455,7 +516,7 @@ window.__ide = {
 
 // Whether language analysis is available (false = degraded, pkg absent) — the
 // same readiness seam the sandbox exposes for e2e.
-window.__lang = {
+(window as Window & { __lang?: LangSeam }).__lang = {
   ready: langReady,
   expects: () => currentExpects(view),
 };

--- a/site/src/player-bridge.ts
+++ b/site/src/player-bridge.ts
@@ -1,4 +1,4 @@
-// The editor ↔ player postMessage protocol, factored out of sandbox.js so the
+// The editor ↔ player postMessage protocol, factored out of sandbox.ts so the
 // landing hero can drive the same live-reload loop. Dependency-free (no
 // CodeMirror): the consumer owns the editor and hands source strings in.
 //

--- a/site/src/protocol.ts
+++ b/site/src/protocol.ts
@@ -53,9 +53,10 @@ export interface SetSource {
  *
  * `files` must be non-empty and every `path` non-blank — the player rejects
  * anything else as a "malformed project push" (player.html). That is a runtime
- * precondition rather than a type: the only producer is ide.js, which is still
- * JavaScript, so a non-empty-tuple type here would be an unchecked assertion
- * at the boundary rather than a real guarantee.
+ * precondition rather than a type: the only producer is ide.ts, which builds
+ * this list from user-editable localStorage, so a non-empty-tuple type here
+ * would be an unchecked assertion at the boundary rather than a real
+ * guarantee.
  */
 export interface SetProject {
   type: "functor-lang-set-project";

--- a/site/src/sandbox.ts
+++ b/site/src/sandbox.ts
@@ -24,14 +24,49 @@ import {
 import { PlayerBridge } from "./player-bridge.js";
 import { createStatusBar } from "./status-bar.js";
 import { createRuntimeTarget } from "./runtime-target.js";
+import { asPlayerMessage } from "./protocol.js";
 import { EXAMPLES } from "./examples.js";
 
-const frame = document.getElementById("player");
-const statusPill = document.getElementById("status");
-const picker = document.getElementById("example-picker");
-const resetButton = document.getElementById("reset");
+/** The preview pill's three states — also its `data-state` attribute value. */
+type PillState = "busy" | "live" | "error";
 
-const setStatus = (state, text, detail = "") => {
+/** The sandbox's e2e seam (driven by e2e/site-sandbox.mjs). */
+interface SandboxSeam {
+  setSource(source: string): void;
+  source: () => string;
+  status: () => {
+    state: string | undefined;
+    text: string | null;
+    message: string;
+  };
+  runtimeTarget: () => RuntimeTargetState;
+  getSource: () => string;
+  triggerComplete(source: string, cursor: number): void;
+  acceptCompletion: () => boolean;
+}
+
+// The language-analysis seam, shared in NAME (not shape) with the IDE's — each
+// page declares its own, so the two never have to agree. The payload types are
+// lang-intel's internals; naming them through `ReturnType` keeps this seam
+// exact without widening that module's public surface.
+interface LangSeam {
+  ready: Promise<boolean>;
+  analyze: (source: string) => ReturnType<typeof analyzeCached>;
+  complete: (source: string, offset: number) => ReturnType<typeof completeAt>;
+  liveHints: () => ReturnType<typeof currentLiveHints>;
+  coverage: () => ReturnType<typeof currentCoverage>;
+  expects: () => ReturnType<typeof currentExpects>;
+}
+
+type RuntimeTarget = ReturnType<typeof createRuntimeTarget>;
+type RuntimeTargetState = ReturnType<RuntimeTarget["state"]>;
+
+const frame = document.getElementById("player") as HTMLIFrameElement;
+const statusPill = document.getElementById("status")!;
+const picker = document.getElementById("example-picker") as HTMLSelectElement;
+const resetButton = document.getElementById("reset")!;
+
+const setStatus = (state: PillState, text: string, detail = "") => {
   statusPill.dataset.state = state;
   statusPill.textContent = text;
   // The detail (the reload note, or a parse error) lives in the pill's tooltip
@@ -40,14 +75,14 @@ const setStatus = (state, text, detail = "") => {
   statusPill.title = detail;
 };
 
-const statusBar = createStatusBar({ host: document.getElementById("statusbar") });
-let runtimeTarget = null;
+const statusBar = createStatusBar({ host: document.getElementById("statusbar")! });
+let runtimeTarget: RuntimeTarget | null = null;
 // The sandbox edits only the entry buffer, but some examples also load sibling
 // modules (for example Mario's generated assets.fun manifest). Keep those
 // fetched sources so an external runtime receives the same complete project as
 // the in-page wasm preview.
-let siblingSources = [];
-let assetSources = [];
+let siblingSources: [string, string][] = [];
+let assetSources: [string, Uint8Array][] = [];
 
 const bridge = new PlayerBridge(frame, {
   onReloading: () => setStatus("busy", "◌ reloading…"),
@@ -70,7 +105,7 @@ const bridge = new PlayerBridge(frame, {
 // Runtime console traces (Functor Lang `Debug.log` and friends), forwarded by the
 // player page — see the console hook in player.html. Guarded to OUR iframe.
 window.addEventListener("message", (event) => {
-  const data = event.data;
+  const data = asPlayerMessage(event.data);
   if (!data || data.type !== "functor-lang-console") return;
   if (event.source !== frame.contentWindow) return;
   statusBar.appendOutput(data.level, data.message, data.frame ?? null);
@@ -83,7 +118,7 @@ window.addEventListener("message", (event) => {
 let programmaticEdit = false;
 
 const view = new EditorView({
-  parent: document.getElementById("editor"),
+  parent: document.getElementById("editor")!,
   extensions: [
     basicSetup,
     keymap.of([indentWithTab]),
@@ -143,7 +178,7 @@ onDiagnostics((diags) => {
   );
 });
 
-window.__lang = {
+(window as Window & { __lang?: LangSeam }).__lang = {
   ready: langReady,
   analyze: (source) => analyzeCached(source),
   complete: (source, offset) => completeAt(source, offset),
@@ -152,7 +187,11 @@ window.__lang = {
   expects: () => currentExpects(view),
 };
 
-const setDoc = (source, siblings = [], assets = []) => {
+const setDoc = (
+  source: string,
+  siblings: [string, string][] = [],
+  assets: [string, Uint8Array][] = []
+) => {
   bridge.reset();
   // Wholesale document replacement (example switch, inline load, reset): drop
   // the wasm completion cache so the previous program's candidates can't leak.
@@ -168,20 +207,20 @@ const setDoc = (source, siblings = [], assets = []) => {
 // An inline program from the URL fragment (the docs' "try it" buttons):
 // #src=<base64url> becomes the editor buffer and the player's ?src= data:
 // URL, so it starts with a fresh init — no served file involved.
-const fromBase64Url = (b64u) =>
+const fromBase64Url = (b64u: string) =>
   new TextDecoder().decode(
     Uint8Array.from(atob(b64u.replace(/-/g, "+").replace(/_/g, "/")), (c) => c.charCodeAt(0))
   );
 
-let inlineB64 = null;
+let inlineB64: string | null = null;
 
 // A monotonically increasing load token: each picker change / reset / inline
 // load claims a new one, and a fetch that finishes after a newer load started
 // is ignored — a slow earlier response must not overwrite a newer selection.
 let loadToken = 0;
 
-const loadInline = (b64u) => {
-  let source;
+const loadInline = (b64u: string) => {
+  let source: string;
   try {
     source = fromBase64Url(b64u);
   } catch {
@@ -208,7 +247,7 @@ const loadInline = (b64u) => {
   return true;
 };
 
-const loadExample = async (id) => {
+const loadExample = async (id: string) => {
   const token = ++loadToken;
   const example = EXAMPLES.find((candidate) => candidate.id === id);
   const files = [
@@ -232,7 +271,7 @@ const loadExample = async (id) => {
     responses.slice(0, files.length).map((response) => response.text())
   );
   const assets = await Promise.all(
-    responses.slice(files.length).map(async (response, index) => [
+    responses.slice(files.length).map(async (response, index): Promise<[string, Uint8Array]> => [
       assetFiles[index].output,
       new Uint8Array(await response.arrayBuffer()),
     ])
@@ -240,8 +279,9 @@ const loadExample = async (id) => {
   if (token !== loadToken) return;
   const url = files[0];
   const source = sources[0];
-  const siblings = files.slice(1).map((path, index) => [
-    path.split("/").pop(),
+  const siblings = files.slice(1).map((path, index): [string, string] => [
+    // Every path here has at least one segment, so `pop` always yields one.
+    path.split("/").pop()!,
     sources[index + 1],
   ]);
   // A fresh iframe (fresh model: init runs) rather than a source push, so
@@ -262,10 +302,11 @@ for (const example of EXAMPLES) {
 
 picker.addEventListener("change", () => {
   if (picker.value === "__inline") {
-    loadInline(inlineB64);
+    // The `__inline` option only exists once loadInline has stored its source.
+    loadInline(inlineB64!);
     return;
   }
-  const url = new URL(window.location);
+  const url = new URL(window.location.href);
   url.searchParams.set("example", picker.value);
   url.hash = "";
   window.history.replaceState(null, "", url);
@@ -273,18 +314,18 @@ picker.addEventListener("change", () => {
 });
 
 resetButton.addEventListener("click", () =>
-  picker.value === "__inline" ? loadInline(inlineB64) : loadExample(picker.value)
+  picker.value === "__inline" ? loadInline(inlineB64!) : loadExample(picker.value)
 );
 
 const inlineSrc = new URLSearchParams(window.location.hash.slice(1)).get("src");
 const requested = new URLSearchParams(window.location.search).get("example");
-const initial = EXAMPLES.some((e) => e.id === requested) ? requested : EXAMPLES[0].id;
+const initial = EXAMPLES.some((e) => e.id === requested) ? requested! : EXAMPLES[0].id;
 picker.value = initial;
 if (!(inlineSrc && loadInline(inlineSrc))) loadExample(initial);
 
 // Test seam for the headless e2e (e2e/site-sandbox.mjs): set the buffer and
 // observe results without synthesizing keyboard events.
-window.__sandbox = {
+(window as Window & { __sandbox?: SandboxSeam }).__sandbox = {
   setSource(source) {
     view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: source } });
   },
@@ -294,7 +335,8 @@ window.__sandbox = {
     text: statusPill.textContent,
     message: statusPill.title,
   }),
-  runtimeTarget: () => runtimeTarget.state(),
+  // Assigned during boot, long before any e2e call can reach this seam.
+  runtimeTarget: () => runtimeTarget!.state(),
   getSource: () => view.state.doc.toString(),
   // Replace the buffer, place the cursor, and open the completion popup
   // (explicit trigger). Guarded so it does NOT push to the runtime — completion

--- a/site/src/zip.ts
+++ b/site/src/zip.ts
@@ -44,7 +44,7 @@ const concat = (arrs: Bytes[]): Bytes => {
  * One archive member: a path inside the zip and its text content.
  *
  * Structurally the IDE's `ProjectFile`, but deliberately its own type — the
- * caller (ide.js) also zips a synthesised `functor.json` manifest that is not
+ * caller (ide.ts) also zips a synthesised `functor.json` manifest that is not
  * part of the project's module space.
  */
 export interface ZipEntry {


### PR DESCRIPTION
**Stacked on #500** (`site-ts-lang-intel`). Retargets to `main` once #500 merges — review only the diff against `site-ts-lang-intel`.

Wave 4, the **final** wave of the site TypeScript migration. The last four `.js` modules under `site/src` become `.ts`:

| file | lines | notes |
| --- | --- | --- |
| `hero.ts` | 116 | status dot typed (`HeroState`/`HeroStatus`); `editor: EditorView \| null` |
| `demo-editor.ts` | 82 | seam interface for `__demoEditor` |
| `sandbox.ts` | 317 | sibling/asset tuples, load tokens, both `window` seams |
| `ide.ts` | 461 | project model, localStorage boundary, both `window` seams |

**Completes step 3 of the site TS/React migration — `site/src` is now 100% TypeScript** (`ls site/src` shows only `.ts`, plus the pre-existing `api-reference-html.mjs` build helper). `allowJs` stays off; `check:site` covers every module in the directory.

## Non-mechanical decisions

- **`site/build.mjs` esbuild `entryPoints`** — these four files ARE entry points, and entry points are *paths*, not module specifiers: a literal `.js` path silently misses its `.ts` sibling. All four repointed. **Output names verified, not assumed:** the built `site/dist/assets/` still contains exactly `sandbox.js  ide.js  docs.js  api-docs.js  hero.js  demo-editor.js  features.js` — esbuild derives output basenames from the entry basename and always emits `.js`, so the HTML pages' `<script>` srcs are untouched.
- **`window.__sandbox` / `__ide` / `__hero` / `__demoEditor` / `__lang`** — typed with a per-file interface applied at the assignment (`(window as Window & { __ide?: IdeSeam }).__ide = …`) rather than a `declare global`. Deliberate: sandbox and ide both publish `__lang` with *different* shapes, and a global augmentation would merge them into a conflict. The interfaces mirror the existing objects exactly; the ~236 e2e/demo references see identical runtime shapes.
- **`LangSeam` payload types via `ReturnType<typeof …>`** — lang-intel's `AnalyzeResult`, `CompletionResponse`, `LiveHint`, `CovState`, `ExpectGutterRow` are module-internal. Naming them through `ReturnType` keeps these seams exact without widening #500's public surface from this stacked branch.
- **`StoredProject` (ide)** — the localStorage payload is typed as the shape it is *expected* to have, all fields optional, with `loadProject`'s existing runtime validation unchanged. `unknown` was tried first; it only relocates the same checks behind a wall of casts, and the narrowing does not survive into the `if (valid)` block.
- **`asPlayerMessage(event.data)` in the two console listeners** (sandbox, ide) — the one place a type could not be *added* without touching an expression: `event.data` is `any`, so the listener body was wholly unchecked. This reuses `protocol.ts`'s existing narrowing helper, and is provably behavior-identical — the very next line is the unchanged `if (!data || data.type !== "functor-lang-console") return;`, and `asPlayerMessage` passes through exactly the messages whose `type` is in the known set (which includes `functor-lang-console`) and nulls everything else.
- **`new URL(window.location)` → `new URL(window.location.href)` (sandbox)** — `lib.dom` types the `URL` constructor as `string | URL`, and `Location` is neither. `.href` is precisely what the implicit stringifier already produced. The alternative (`as unknown as URL`) would have asserted something false.
- **`site/README.md`** — the `src/` inventory named `sandbox.js` / `ide.js`; also corrects `project-bridge.js` / `runtime-target.js`, stale since waves 1–2, since after this PR every `.js` reference in that list is wrong.
- **No dedup.** The ~130 duplicated lines between sandbox and ide (`setStatus`, the `EditorView` construction, the diagnostics→Problems mapping, the console listener, `triggerComplete`/`acceptCompletion`) are typed in place. That extraction is deferred to the React-islands step, which subsumes it.

## Bundle residual

esbuild at `origin/site-ts-lang-intel` vs HEAD, unminified for readability (identifier renaming makes a minified diff meaningless), same options otherwise:

| bundle | changed lines |
| --- | --- |
| `hero.js` | 2 — the `// site/src/hero.js` → `.ts` module banner, nothing else |
| `demo-editor.js` | 2 — the module banner, nothing else |
| `ide.js` | 4 — banner + `asPlayerMessage(event.data)` |
| `sandbox.js` | 8 — banner + `asPlayerMessage(event.data)` + `window.location.href` + 2 retained source comments |

That is the complete residual: every changed line is one of the four dispositioned items above. Minified, the shipped bundles move `ide.js` +4 bytes and `sandbox.js` +9 bytes; `hero.js`, `demo-editor.js`, `docs.js`, `api-docs.js`, and `features.js` are **byte-identical**. No new function reached either bundle — `asPlayerMessage` was already there via `player-bridge.ts`.

## Verification

All green, on the full suite these four files are precisely what drives:

| check | result |
| --- | --- |
| `npm run check:site` | pass |
| `npm run site:build` | pass — 7 bundles, output names unchanged |
| `e2e/site-sandbox.mjs` | **ALL CHECKS PASSED** (28 checks) |
| `e2e/ide-page.mjs` | **PASS** (22 checks) |
| `e2e/ide-project.mjs` | **PASS** |
| `e2e/runtime-target.mjs` | **ALL CHECKS PASSED** (18 checks) |

The language-intelligence checks genuinely **RAN** — `site/dist/pkg/functor_lang_wasm_bg.wasm` was present, and hover tooltips, completion popups, live-value inlays, coverage colouring, and the expect gutter all asserted real results rather than skipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Cross-engine review (`/xreview`)

Two independent adversarial reviewers (a Claude subagent + Codex CLI), both scoped to `origin/site-ts-lang-intel...HEAD`. **Neither engine found a Critical, High, or Medium issue** — no behavioral defect in the change.

Both independently verified the four things most at risk, and agreed:

- the esbuild entry paths correctly name `.ts` sources, no dangling path remains, and the `.js` in the HTML `<script src>` tags correctly names esbuild **output** basenames;
- the seam shapes are unchanged, and the hand-written seam interfaces accurately describe their objects (each field checked against its real producer);
- every added `!` / `as` is sound at its point of use — including `inlineB64!` (set before the `__inline` option can exist), `requested!` (inside the `some` guard), `runtimeTarget!` (assigned unconditionally at module top level; `createRuntimeTarget` throws on a null host, so the old un-asserted code had identical throw semantics), and `activeFile()!`;
- `asPlayerMessage(event.data)` and `new URL(window.location.href)` are behavior-identical (the former returns the *same object reference* for a known discriminant, adds no field validation, and yields the same early-return decision for every input class).

**Findings and dispositions:**

| # | Finding | Engines | Disposition |
| --- | --- | --- | --- |
| 1 | Low — module comments still name `sandbox.js` / `ide.js` / `mini-editor.js`, files that no longer exist | **[AGREED]** both | **Fixed** (`31b8f70`, comments only). Import specifiers deliberately keep `.js`. |
| 2 | Low — `protocol.ts`'s justification for `SetProject.files` ("the only producer is ide.js, **which is still JavaScript**") is falsified by this branch | Claude | **Fixed** (`31b8f70`). Reason restated on its real grounds — ide builds that list from user-editable localStorage, so a non-empty-tuple type would still be an unchecked assertion. Type unchanged. |
| 3 | Low — `NameCheck` could be a discriminated union (`error?: never`) narrowed via `"error" in result`, removing two `path!` | Codex | **Declined** — that restructures `newFile`'s destructuring, i.e. a refactor past the types-only contract. The other engine proved both assertions sound. |
| 4 | Low — the localStorage boundary type is "dishonest"; parse as `unknown` and narrow | Codex | **Declined** — deliberate and documented in the code. `unknown` was tried first: it only relocates the same runtime checks behind casts, and the narrowing does not survive into the `if (valid)` block. The other engine verified this boundary is behavior-identical to before. |

Full verification (`check:site`, `site:build`, all four e2e suites) was **re-run after the fixes** — all green, lang-intel checks running rather than skipping.
