### PR TITLE
feat(physics): a character controller on the physics hook, and Physics.upright

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -1193,6 +1193,83 @@ Note the two rules this example obeys: local `let` needs `in`, and the
 pre-step readers raise on the first frame, before the `physics` hook's
 declaration has been reconciled and stepped — so gate them.
 
+⚠️ The sketch above is the LOOP SHAPE, not a usable controller: its
+`else vel.y` is the first of three traps below. See the next section.
+
+### Character controllers on the `physics` hook
+
+`examples/physics-controller` is the worked reference (a dynamic capsule, a
+moving kinematic deck, coyote time, jump buffering, landing squash, walls),
+with its whole feel layer as pure functions under `expect`. Read it before
+writing a controller. The recipe, and the three traps that are NOT obvious:
+
+**Grounding** is `Physics.castExcluding` from the capsule's center, straight
+down, reaching `feetOffset + skin`. Excluding your own tag is mandatory — a ray
+starting inside your collider otherwise hits it at distance 0 and reports the
+character standing on itself. Keep `skin` small (~0.15): it is also the knob
+that decides how far AHEAD of physical contact your landing response fires.
+
+**Moving-platform carry needs no platform identity.** The probe reports which
+body it hit, so ask that body for its velocity — one line, no per-platform
+state, no "which deck was I on last frame". Fixed bodies read back zero, so
+static ground needs no special case; a kinematic body whose declared pose is
+re-derived each frame reads back the velocity rapier derived from that motion:
+
+```functor
+let surfaceVelocity = (probe) =>
+  if probe.hit then Physics.linearVelocity(probe.tag) else zeroVelocity
+```
+
+Then steer RELATIVE to that surface (`target = carry.x + wish * speed`), so
+standing still rides along and a jump inherits the deck's motion.
+
+**The three traps.** All three come from `Physics.setVelocity` replacing ALL
+THREE components — there is no horizontal-only command — so the controller must
+say something about `vy` every frame. All three were measured as visible
+artifacts, not theorized:
+
+1. **Do not echo the read back while grounded.** The read is one step stale, so
+   it still carries the downward speed the solver just cancelled at the contact;
+   re-commanding it drives the capsule into the floor. A capsule that should
+   rest 0.90 above the surface rested at 0.40 — and, downstream, stopped against
+   a wall 0.45 units early, because a half-buried capsule catches the wall's
+   corner instead of its face.
+2. **Commanding `0.0` while grounded also sinks, just slower.** Overwriting `vy`
+   destroys the contact's own pushout impulse too, so each step's gravity
+   increment accumulates as penetration (0.98 drifting to 0.40 over 260 frames).
+   Instead, own the standing height with a **ground clamp**: the probe already
+   measured the distance, so correct toward the rest distance, `error / dt`,
+   bounded to a few units/s. This also buys stick-to-a-descending-deck for free.
+3. **The ground clamp will cancel your jump** unless you suppress it. For the
+   first frames after takeoff the feet are still within the probe's reach, so
+   the character reads as grounded and gets clamped back down — it rose 0.12
+   units instead of 1.16, `vy` flipping +6.83 to −6.37 in one frame. Arm a short
+   **post-jump lockout** (~0.1 s) when the jump fires, and treat grounding as
+   false for its duration.
+
+**Keep the decisions pure.** Read the world in `tick`, pass a plain
+`observation` record (grounded, velocity, probe distance, rest height) to
+pure functions, and command the result. The controller's feel then unit-tests
+under `functor test` with no GPU and no world — and the physics drive is
+recorded, so a scripted `--input-script` run is bit-deterministic too
+(verified: 400 frames of identical trace and a byte-identical capture across
+two runs).
+
+**Everything else comes free from the solver**: walls stop you, edges drop you,
+and props can be knocked around — which is the whole reason to put a character
+on the `physics` hook rather than hand-rolling kinematics like
+`examples/platformer`.
+
+**There is no `postTick` hook, and a controller does not want one.** Reads in
+`tick` see the previous step, which is inherent to read → decide → step. A
+post-step hook would read fresher but its commands would wait a full frame (the
+write asymmetry), so total loop latency would not improve — and measured against
+real landings, the grounding probe's `skin` already makes the landing response
+fire 1–3 frames *before* physical contact, so removing a frame of read latency
+pushes it further from contact, not closer. Anything purely visual can already
+read the fresh post-step world in `draw`; post-step events already arrive
+through `Physics.events`.
+
 `Physics.events` is a **Sub** (return it from `subscriptions`, alone or in
 `Sub.batch`; it requires `update`). Every contact begin/end from this
 frame's physics step arrives post-step as `{started: bool, a: Physics.tag,

--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -1085,6 +1085,14 @@ body |> Physics.at(v)                                      // body-last: pipes
 body |> Physics.velocity(v)
 body |> Physics.mass(m) / Physics.friction(f) / Physics.restitution(r)
 body |> Physics.sensor                                     // overlap-only, no forces
+body |> Physics.upright                                    // lock rotation: the body
+                                                           //   translates but never tips.
+                                                           //   REQUIRED for a character
+                                                           //   capsule — otherwise a
+                                                           //   glancing contact spins it,
+                                                           //   and a tipped capsule breaks
+                                                           //   any fixed standing-height
+                                                           //   assumption. Off by default
 Physics.scene(gravity, [body, …])                          // what `physics` returns
 Physics.position(tag)                                      // {x, y, z} of the LIVE body
 Physics.linearVelocity(tag)                                // {x, y, z} velocity of the LIVE body
@@ -1202,6 +1210,13 @@ declaration has been reconciled and stepped — so gate them.
 moving kinematic deck, coyote time, jump buffering, landing squash, walls),
 with its whole feel layer as pure functions under `expect`. Read it before
 writing a controller. The recipe, and the three traps that are NOT obvious:
+
+**Declare the body `|> Physics.upright`.** This is not optional. A dynamic
+capsule that can rotate picks up angular velocity from any glancing contact and
+topples — measured at ~40° off vertical mid-jump, then creeping sideways along
+a wall with no input. It also silently corrupts everything below, because a
+tipped capsule's lowest point is `radius + halfHeight·cos θ` below its center,
+not the fixed `feetOffset` the probe and clamp assume.
 
 **Grounding** is `Physics.castExcluding` from the capsule's center, straight
 down, reaching `feetOffset + skin`. Excluding your own tag is mandatory — a ray

--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -1213,7 +1213,7 @@ writing a controller. The recipe, and the three traps that are NOT obvious:
 
 **Declare the body `|> Physics.upright`.** This is not optional. A dynamic
 capsule that can rotate picks up angular velocity from any glancing contact and
-topples — measured at ~40° off vertical mid-jump, then creeping sideways along
+topples — measured at 40-80° off vertical mid-jump, then creeping sideways along
 a wall with no input. It also silently corrupts everything below, because a
 tipped capsule's lowest point is `radius + halfHeight·cos θ` below its center,
 not the fixed `feetOffset` the probe and clamp assume.

--- a/examples/physics-controller/README.md
+++ b/examples/physics-controller/README.md
@@ -9,7 +9,7 @@ interesting comparison is what each one has to write, and what it gets for
 free.
 
 ```sh
-functor -d examples/physics-controller test          # 37 expects over the pure control logic
+functor -d examples/physics-controller test          # 39 expects (32 controller, 7 level data)
 functor -d examples/physics-controller run native    # WASD / arrows, SPACE to jump, ENTER to respawn
 ```
 
@@ -38,6 +38,12 @@ read → decide → step simulation, not a Functor restriction.
 the entire feel layer — coyote time, jump buffering, acceleration, the ground
 clamp, landing response — is covered by `expect` tests that run in
 milliseconds with no GPU, no window, and no rapier world.
+
+The character body **must** be declared `|> Physics.upright`. A dynamic capsule
+that can rotate picks up angular velocity from any glancing contact and topples
+— and a tipped capsule's lowest point is no longer `feetOffset` below its
+center, so the grounding probe and the ground clamp both start lying. (This
+attribute did not exist before this example; adding it is part of this change.)
 
 ### The one idea worth stealing
 
@@ -82,17 +88,36 @@ whatever it stands on; the plaza's top face is `y = 0` and the deck's is
 
 | Mechanic | Verdict | Evidence |
 | --- | --- | --- |
-| Grounded detection (`castExcluding` probe) | **CLEAN** | `grounded` flips exactly at the four expected frames (11, 102, 121, 133, 169). No flicker on any seam across 400 frames. |
-| Jump | **CLEAN** | Apex rise 1.1625 vs. the theoretical `v²/2g` = 1.1782 (98.7%; the deficit is one step of discretization). |
+| Grounded detection (`castExcluding` probe) | **CLEAN** | `grounded` flips at exactly the five expected frames (11, 102, 121, 133, 169). No flicker on any seam across 400 frames. |
+| Jump | **CLEAN** | Apex rise 1.1612 vs. the theoretical `v²/2g` = 1.1782 (98.6%; the deficit is one step of discretization). |
 | Coyote time | **CLEAN** | Walked off the deck at f=102; `coyote` drains 0.1033 → 0.0000 over frames 102–109, i.e. exactly the 0.12 s window. |
 | Jump buffering | **CLEAN** | Pure test: a press while airborne fires on the touchdown frame. |
-| Landing detection / squash | **CLEAN** | Fires once per touchdown as an edge (f=11, 121, 169), never as a level; `landImpact` records 3.67 / 7.10 / 6.73. |
+| Landing detection / squash | **CLEAN** | Fires once per touchdown as an edge (f=11, 121, 169), never as a level; `landImpact` records 3.67 / 6.97 / 6.73. |
 | Riding the moving platform | **CLEAN** | `probe.tag` → `linearVelocity` tracks the deck's analytic velocity to within 0.030 on a 2.4 u/s deck. Relative offset `x − deckX` held at −0.48 ± 0.02 over 80 frames — bounded and oscillatory, not accumulating. |
-| Wall | **CLEAN, and free** | Held into the wall for 220 frames: stopped at `x = −6.2994` against a predicted −6.3000 (wall face −6.7, capsule radius 0.4) and stayed. Zero collision code in the game. |
+| Wall | **CLEAN, and free** | Held into the wall for 220 frames: stopped at `x = −6.3012` against a predicted −6.3000 (wall face −6.7, capsule radius 0.4) and stayed — `x` and `z` both constant to four decimals from f=260 to f=399. Zero collision code in the game. |
 | Edge / ledge fall-off | **CLEAN, and free** | Walking off the deck's edge simply stops being grounded; gravity and the solver do the rest. |
-| Standing height | **AWKWARD-BUT-CORRECT** | Holds 0.8683–0.8995 on the plaza and 2.1462–2.1488 on the deck. Getting here needed a ground clamp and a post-jump lockout — see below. |
+| Standing height | **CLEAN, with a caveat** | A constant 0.8988 on the plaza and 2.1462–2.1488 on the deck. Getting here needed a ground clamp, a post-jump lockout, and `Physics.upright` — see below. |
+| Keeping the capsule upright | **WAS IMPOSSIBLE — fixed in this change** | A rotating capsule visibly toppled (~40° off vertical mid-jump) and then crept 0.19 units sideways along the wall with no input. No rotation lock, angular damping, or angular-velocity command existed in the `Physics` API, so this was unfixable in game code. This change adds `Physics.upright`. |
 
-### The two things that were genuinely awkward
+### The one thing that was genuinely impossible
+
+**A dynamic capsule could not be kept upright.** Nothing in the `Physics`
+module locked rotation, damped angular velocity, or let a game command it, so a
+character body picked up spin from every glancing contact. Measured: the
+capsule sat ~40° off vertical mid-jump, and once it leaned on the wall it crept
+0.19 units along `z` over 140 frames with no input, still accelerating. It also
+silently corrupted the controller, because a tipped capsule's lowest point is
+`radius + halfHeight·cos θ` below its center rather than the fixed
+`feetOffset` the probe and the ground clamp assume — which showed up as a
+±0.031 ripple in the standing height.
+
+This change adds `Physics.upright`, a nullary body attribute in the shape of
+`Physics.sensor`, mapping to rapier's `LockedAxes::ROTATION_LOCKED`. With it,
+the standing height is a **constant 0.8988** and the wall contact is
+**motionless in both `x` and `z`**. It is the smallest surface that fixes the
+problem, and it is off by default so existing bodies tumble exactly as before.
+
+### The two things that were awkward but correct
 
 Both are about `Physics.setVelocity` replacing **all three** velocity
 components — there is no horizontal-only command — so the controller must say
@@ -164,10 +189,17 @@ The remaining arguments do not survive contact with the API either:
   asymmetry), which is *worse* for responsiveness, because input arrives
   pre-step.
 
-The genuine gap this exercise found is not a hook at all. It is that
-`Physics.setVelocity` is all-or-nothing across three axes, which is what forced
-the ground clamp to be written by hand. A per-axis or horizontal-only velocity
-command would have removed the two sinking failure modes above outright. That
-is a much smaller, better-targeted change than a new lifecycle hook — and
-notably, `postTick` would *not* have fixed it either, since the problem is the
-shape of the command, not when it runs.
+The genuine gaps this exercise found are not hooks at all, and neither would
+have been fixed by `postTick`:
+
+1. **No rotation lock** (fixed here as `Physics.upright`). This was the only
+   *impossible* item, and it is a body attribute, not a lifecycle question.
+2. **`Physics.setVelocity` is all-or-nothing across three axes**, which is what
+   forced the ground clamp to be written by hand. A per-axis or
+   horizontal-only velocity command would have removed both sinking failure
+   modes outright. Still open, and a much smaller, better-targeted change than
+   a new hook — the problem is the *shape of the command*, not when it runs.
+
+That both real gaps turned out to be one-line API surface rather than frame
+ordering is itself the argument: the `tick`-plus-synchronous-queries loop was
+never the thing standing in the way.

--- a/examples/physics-controller/README.md
+++ b/examples/physics-controller/README.md
@@ -97,14 +97,15 @@ whatever it stands on; the plaza's top face is `y = 0` and the deck's is
 | Wall | **CLEAN, and free** | Held into the wall for 220 frames: stopped at `x = −6.3012` against a predicted −6.3000 (wall face −6.7, capsule radius 0.4) and stayed — `x` and `z` both constant to four decimals from f=260 to f=399. Zero collision code in the game. |
 | Edge / ledge fall-off | **CLEAN, and free** | Walking off the deck's edge simply stops being grounded; gravity and the solver do the rest. |
 | Standing height | **CLEAN, with a caveat** | A constant 0.8988 on the plaza and 2.1462–2.1488 on the deck. Getting here needed a ground clamp, a post-jump lockout, and `Physics.upright` — see below. |
-| Keeping the capsule upright | **WAS IMPOSSIBLE — fixed in this change** | A rotating capsule visibly toppled (~40° off vertical mid-jump) and then crept 0.19 units sideways along the wall with no input. No rotation lock, angular damping, or angular-velocity command existed in the `Physics` API, so this was unfixable in game code. This change adds `Physics.upright`. |
+| Keeping the capsule upright | **WAS IMPOSSIBLE — fixed in this change** | A rotating capsule visibly toppled (40-80° off vertical mid-jump) and then crept 0.19 units sideways along the wall with no input. No rotation lock, angular damping, or angular-velocity command existed in the `Physics` API, so this was unfixable in game code. This change adds `Physics.upright`. |
 
 ### The one thing that was genuinely impossible
 
 **A dynamic capsule could not be kept upright.** Nothing in the `Physics`
 module locked rotation, damped angular velocity, or let a game command it, so a
 character body picked up spin from every glancing contact. Measured: the
-capsule sat ~40° off vertical mid-jump, and once it leaned on the wall it crept
+capsule sat 40–80° off vertical mid-jump (it kept rotating, so the angle
+depends on the frame), and once it leaned on the wall it crept
 0.19 units along `z` over 140 frames with no input, still accelerating. It also
 silently corrupted the controller, because a tipped capsule's lowest point is
 `radius + halfHeight·cos θ` below its center rather than the fixed

--- a/examples/physics-controller/README.md
+++ b/examples/physics-controller/README.md
@@ -1,0 +1,173 @@
+# `examples/physics-controller`
+
+A platformer character controller where the character is a **real dynamic
+physics body**, steered entirely from `tick`.
+
+This is the counterpart to `examples/platformer`, which hand-rolls its
+kinematics as a pure function and uses no physics world at all. The
+interesting comparison is what each one has to write, and what it gets for
+free.
+
+```sh
+functor -d examples/physics-controller test          # 37 expects over the pure control logic
+functor -d examples/physics-controller run native    # WASD / arrows, SPACE to jump, ENTER to respawn
+```
+
+## The shape of it
+
+The whole control loop is **one frame**, and it all lives in `tick`:
+
+```functor
+let tick = (model, dt, tts) =>
+  …
+  let pos   = Physics.position(playerTag) in         // read  (synchronous)
+  let vel   = Physics.linearVelocity(playerTag) in
+  let probe = groundProbe(pos) in
+  let carry = surfaceVelocity(probe) in
+  let sensed = Control.sense(dt, obs, m.jumpEdge, m.ctl) in   // decide (pure)
+  let want   = Control.desiredVelocity(dt, obs, carry, sensed) in
+  (next, Physics.setVelocity(playerTag, Vec3.make(want.x, want.y, want.z)))  // write
+```
+
+The reads see the previous step (physics runs after `tick`) and the command
+applies at the step immediately following this `tick`, so the loop closes
+within one frame. That one step of read latency is inherent to any
+read → decide → step simulation, not a Functor restriction.
+
+`control.fun` holds every decision as a pure function of an *observation*, so
+the entire feel layer — coyote time, jump buffering, acceleration, the ground
+clamp, landing response — is covered by `expect` tests that run in
+milliseconds with no GPU, no window, and no rapier world.
+
+### The one idea worth stealing
+
+Moving-platform carry is one line, with **no platform identity, no per-platform
+state, and no "which deck was I on last frame"**:
+
+```functor
+let surfaceVelocity = (probe) =>
+  if probe.hit then Physics.linearVelocity(probe.tag) else zeroVelocity
+```
+
+The grounding probe already reports *which body* it hit, so asking that body
+for its velocity is the whole mechanic. A fixed body reads back zero, so static
+ground needs no special case, and a kinematic deck whose declared pose is
+re-derived each frame reads back the velocity rapier derived from that motion.
+
+## Verifying it without a human at the window
+
+Two headless paths, both reproducible from a bare clone.
+
+```sh
+functor -d examples/physics-controller test
+
+# set `traceOn = true` in game.fun for the per-frame rows the table below cites
+functor -d examples/physics-controller run native \
+  --input-script "$PWD/examples/physics-controller/ride-and-jump.input" \
+  --script-dt 0.0166667 --capture-frame /tmp/f.png --capture-at-frame 400
+```
+
+`ride-and-jump.input` is the committed scripted run: the character falls onto a
+**moving** deck, rides it with zero input, walks off its edge, jumps from the
+plaza, and finally runs into a wall and stays there.
+
+Both are deterministic. Two runs of the 400-frame script produced **identical
+traces and a byte-identical capture PNG**.
+
+## Evidence, mechanic by mechanic
+
+Measured from the scripted run above. The capsule's rest height is 0.90 above
+whatever it stands on; the plaza's top face is `y = 0` and the deck's is
+`y = 1.25`, so the expected resting centers are 0.90 and 2.15.
+
+| Mechanic | Verdict | Evidence |
+| --- | --- | --- |
+| Grounded detection (`castExcluding` probe) | **CLEAN** | `grounded` flips exactly at the four expected frames (11, 102, 121, 133, 169). No flicker on any seam across 400 frames. |
+| Jump | **CLEAN** | Apex rise 1.1625 vs. the theoretical `v²/2g` = 1.1782 (98.7%; the deficit is one step of discretization). |
+| Coyote time | **CLEAN** | Walked off the deck at f=102; `coyote` drains 0.1033 → 0.0000 over frames 102–109, i.e. exactly the 0.12 s window. |
+| Jump buffering | **CLEAN** | Pure test: a press while airborne fires on the touchdown frame. |
+| Landing detection / squash | **CLEAN** | Fires once per touchdown as an edge (f=11, 121, 169), never as a level; `landImpact` records 3.67 / 7.10 / 6.73. |
+| Riding the moving platform | **CLEAN** | `probe.tag` → `linearVelocity` tracks the deck's analytic velocity to within 0.030 on a 2.4 u/s deck. Relative offset `x − deckX` held at −0.48 ± 0.02 over 80 frames — bounded and oscillatory, not accumulating. |
+| Wall | **CLEAN, and free** | Held into the wall for 220 frames: stopped at `x = −6.2994` against a predicted −6.3000 (wall face −6.7, capsule radius 0.4) and stayed. Zero collision code in the game. |
+| Edge / ledge fall-off | **CLEAN, and free** | Walking off the deck's edge simply stops being grounded; gravity and the solver do the rest. |
+| Standing height | **AWKWARD-BUT-CORRECT** | Holds 0.8683–0.8995 on the plaza and 2.1462–2.1488 on the deck. Getting here needed a ground clamp and a post-jump lockout — see below. |
+
+### The two things that were genuinely awkward
+
+Both are about `Physics.setVelocity` replacing **all three** velocity
+components — there is no horizontal-only command — so the controller must say
+something about `vy` every single frame. Two plausible answers are wrong, and
+both failures were *observable*, not theoretical:
+
+1. **Echoing the read back sank the character half a unit into the floor.**
+   The read is one step stale, so while grounded it still carries the downward
+   speed the solver just cancelled at the contact. Re-commanding it drives the
+   capsule in. Measured: it rested at `y = 0.40` instead of 0.90. A downstream
+   symptom was that the wall stop landed at `x = −5.85` instead of −6.30,
+   because a half-buried capsule contacts the wall's corner rather than its
+   face.
+
+2. **Commanding `0` while grounded still sank it, slowly.** Overwriting `vy`
+   every frame also destroys the contact's own pushout impulse, so each step's
+   gravity increment accumulates as penetration: `y = 0.98` drifting to 0.40
+   over 260 frames.
+
+The fix is the standard character-controller **ground clamp**: while grounded,
+own the standing height explicitly by correcting toward the rest distance the
+probe already measured, `error / dt`, bounded. It also buys stick-to-a-
+descending-deck for free.
+
+That fix then exposed a third, equally classic problem: **the ground clamp
+cancelled the jump.** For the first frames after takeoff the feet are still
+within the probe's reach, so the character read as grounded and the clamp
+yanked it back down — it rose 0.12 units instead of 1.16, with `vy` flipping
++6.83 → −6.37 in one frame. The fix is a short post-jump lockout during which
+grounding is ignored (`jumpLockTime = 0.1`).
+
+None of these three are Functor-specific; every engine's character controller
+carries the same three counter-measures. They are called out here because they
+are exactly the traps an author hits on day one, and all three are now pinned
+by regression `expect`s in `control.fun`.
+
+## Does this want a `postTick` hook?
+
+No — and the measurement is the reason, so it is recorded here.
+
+The argument for a `postTick` (running after the physics step, before `draw`)
+is that it could react to a physics outcome with one frame less delay. Measured
+against the actual landings:
+
+- Landing on the deck: the probe first reported grounded at **f=11**, when the
+  feet were still **0.137 above** the deck's surface and falling at 3.67 u/s.
+  Physical contact resolved at f=13–14.
+- Landing on the plaza: grounded at **f=121**, feet **0.085 above** the surface.
+  Contact resolved at f=122.
+
+The landing response therefore already fires *1–3 frames **before** physical
+contact*, because the grounding probe reaches ahead of the feet by `probeSkin`.
+A `postTick` would make it fire one frame **earlier still** — further ahead of
+contact, not closer to it. **The sign of the dominant error term is the opposite
+of what `postTick` would correct**, and `probeSkin` is a single game-owned
+constant that already gives the author finer control over that timing than a
+hook could.
+
+The remaining arguments do not survive contact with the API either:
+
+- Anything purely **visual** can already read the fresh post-step world:
+  `draw` runs after the step, which is how this example's camera never trails
+  the body it follows.
+- Post-step **events** already have a home: `Physics.events` delivers contacts
+  through `update` after the step.
+- A controller is a **closed loop**, so only total loop latency matters. `tick`
+  reads stale and commands into the very next step: one frame. A `postTick`
+  would read fresh but its commands would wait a full frame (the write
+  asymmetry), which is *worse* for responsiveness, because input arrives
+  pre-step.
+
+The genuine gap this exercise found is not a hook at all. It is that
+`Physics.setVelocity` is all-or-nothing across three axes, which is what forced
+the ground clamp to be written by hand. A per-axis or horizontal-only velocity
+command would have removed the two sinking failure modes above outright. That
+is a much smaller, better-targeted change than a new lifecycle hook — and
+notably, `postTick` would *not* have fixed it either, since the problem is the
+shape of the command, not when it runs.

--- a/examples/physics-controller/control.fun
+++ b/examples/physics-controller/control.fun
@@ -61,6 +61,13 @@ let zero: Ctl = {
   wishZ: 0.0,
 }
 
+// Clear the transient feel state after a respawn, but KEEP `started` — that is
+// the "the physics world has been reconciled" gate, not controller state, and
+// clearing it would make the character free-fall one uncommanded frame. The
+// steering wish is kept too: it belongs to the keys currently held down.
+let respawned = (c) =>
+  { c with grounded: false, coyote: 0.0, buffer: 0.0, squash: 0.0, lock: 0.0, landImpact: 0.0 }
+
 let decay = (dt, t) => Math.max(0.0, t - dt)
 
 // Advance the state machine from one observation.
@@ -88,7 +95,10 @@ let sense = (dt, obs, jumpEdge, c) =>
     buffer: if jumpEdge then bufferTime else decay(dt, c.buffer),
     // The landing response starts on the observed touchdown edge.
     squash: if landed then squashTime else decay(dt, c.squash),
-    landImpact: if landed then -obs.vy else c.landImpact,
+    // Clamped at zero: a touchdown observed while still moving UPWARD (a rising
+    // deck, or a lock expiring under a low ceiling) would otherwise record a
+    // negative impact and turn the squash into a stretch.
+    landImpact: if landed then Math.max(0.0, -obs.vy) else c.landImpact,
   }
 
 // Both windows must be open for a jump to fire.
@@ -154,7 +164,12 @@ let verticalVelocity = (dt, obs, carry, c) =>
   if jumpNow(c) then jumpSpeed + carry.y
   else if c.grounded then
     let error = obs.standHeight - obs.groundDistance in
-    let correction = Math.max(-maxSnapSpeed, Math.min(maxSnapSpeed, error / dt)) in
+    // `dt` is zero on the bootstrap sub-frame and on every frame under
+    // `--fixed-time` (the capture/golden path), where `error / dt` would be
+    // NaN or infinite. No time passing means no correction is owed.
+    let correction =
+      if dt > 0.0 then Math.max(-maxSnapSpeed, Math.min(maxSnapSpeed, error / dt))
+      else 0.0 in
     carry.y + correction
   else obs.vy
 
@@ -172,7 +187,9 @@ let desiredVelocity = (dt, obs, carry, c) =>
 // a hard landing and easing back as the timer drains.
 let squashScale = (c) =>
   let t = c.squash / squashTime in
-  let hardness = Math.min(1.0, c.landImpact / landHardness) in
+  // Bounded on BOTH sides: this must never exceed 1.0, or the "squash" becomes
+  // a stretch and `game.fun` derives an inverted horizontal scale from it.
+  let hardness = Math.max(0.0, Math.min(1.0, c.landImpact / landHardness)) in
   1.0 - 0.35 * hardness * t
 
 // Normalize a steering wish so diagonals are not faster than the axes.
@@ -328,6 +345,23 @@ expect (
   squashScale(hard) < squashScale(soft) && squashScale(soft) < 1.0
 )
 expect squashScale(zero) == 1.0
+
+// An UPWARD touchdown must not invert the squash into a stretch. Without the
+// clamps this returns > 1.0, and `game.fun` then derives an inverted
+// horizontal scale from it. Note the squash timer must be live for this to
+// bite, which is why `expect squashScale(zero) == 1.0` alone cannot catch it.
+expect (
+  let rising = sense(dt, obsAt(true, 0.0, 4.0, 0.9), false, zero) in
+  rising.landImpact == 0.0 && squashScale(rising) == 1.0
+)
+
+// A zero `dt` (the bootstrap sub-frame, and every frame under `--fixed-time`)
+// must not turn the ground clamp into NaN or infinity.
+expect (
+  let sunk = obsAt(true, 0.0, 0.0, 0.5) in
+  let sensed = sense(0.0, sunk, false, zero) in
+  desiredVelocity(0.0, sunk, still, sensed).y == 0.0
+)
 
 // Platform carry: with no steering wish, the commanded velocity converges on
 // the deck's own velocity — that is what riding a moving platform IS.

--- a/examples/physics-controller/control.fun
+++ b/examples/physics-controller/control.fun
@@ -1,0 +1,383 @@
+// control.fun — the character controller's decision logic, as pure functions.
+//
+// Nothing in this file touches the engine prelude: every function takes what
+// the world was OBSERVED to be (`obs`) and returns what to do about it. That
+// keeps the whole feel layer — coyote time, jump buffering, acceleration,
+// landing response — covered by `expect` tests with no GPU, no window, and no
+// rapier world. See the expects at the bottom of the file.
+//
+// `game.fun` owns the two impure lines: reading the observation out of the
+// physics world, and commanding the resulting velocity back into it.
+
+// Tuning. All of the platformer's "feel" is here.
+let speed = 6.0
+let jumpSpeed = 7.2
+let coyoteTime = 0.12
+let bufferTime = 0.12
+let squashTime = 0.18
+let groundAccel = 45.0
+let airAccel = 14.0
+// How long after a jump grounding is ignored. For the first frames of a jump
+// the feet are still within the probe's reach, so without this the character
+// reads as grounded, the ground clamp corrects it back down to standing
+// height, and the jump is cancelled on the frame after it fires. Measured: it
+// rose 0.12 units instead of 1.2, with vy flipping +6.83 to -6.37 in one frame.
+let jumpLockTime = 0.1
+// Downward speed at which a landing reads as maximally hard.
+let landHardness = 6.0
+
+// The controller's own state. Everything here is plain data, so it snapshots,
+// hot-reloads, and time-travels with the rest of the model.
+type Ctl = {
+  // Gate for the first frame: the physics reads raise before the `physics`
+  // hook's declaration has been reconciled and stepped.
+  started: bool,
+  // Grounded as of the last observation.
+  grounded: bool,
+  // Seconds of jump grace remaining after leaving the ground.
+  coyote: float,
+  // Seconds a buffered jump press stays live.
+  buffer: float,
+  // Seconds of landing-squash remaining.
+  squash: float,
+  // Seconds remaining in which grounding is ignored, just after a jump.
+  lock: float,
+  // Downward speed at the most recent touchdown; scales the squash.
+  landImpact: float,
+  // Steering wish, in world XZ, from `sampledInput`.
+  wishX: float,
+  wishZ: float,
+}
+
+let zero: Ctl = {
+  started: false,
+  grounded: false,
+  coyote: 0.0,
+  buffer: 0.0,
+  squash: 0.0,
+  lock: 0.0,
+  landImpact: 0.0,
+  wishX: 0.0,
+  wishZ: 0.0,
+}
+
+let decay = (dt, t) => Math.max(0.0, t - dt)
+
+// Advance the state machine from one observation.
+//
+//   obs       — { grounded: bool, vx, vy, vz } as read back from the world
+//   jumpEdge  — a jump press arrived since the last tick
+//
+// Note the ordering that makes coyote time work: `grounded` is written from
+// this observation, but `landed` is computed against the PREVIOUS one, so a
+// touchdown is an edge rather than a level.
+let sense = (dt, obs, jumpEdge, c) =>
+  let lock = decay(dt, c.lock) in
+  // While the post-jump lock is live, grounding is ignored outright: everything
+  // downstream — coyote refill, the landing edge, and the ground clamp — reads
+  // the character as airborne, which is what it physically is.
+  let grounded = obs.grounded && not (lock > 0.0) in
+  let landed = grounded && not c.grounded in
+  { c with
+    lock: lock,
+    grounded: grounded,
+    // Refilled while grounded, drains in the air: a jump stays legal for a
+    // moment after walking off a ledge.
+    coyote: if grounded then coyoteTime else decay(dt, c.coyote),
+    // A press slightly BEFORE touchdown still fires on landing.
+    buffer: if jumpEdge then bufferTime else decay(dt, c.buffer),
+    // The landing response starts on the observed touchdown edge.
+    squash: if landed then squashTime else decay(dt, c.squash),
+    landImpact: if landed then -obs.vy else c.landImpact,
+  }
+
+// Both windows must be open for a jump to fire.
+let jumpNow = (c) => c.coyote > 0.0 && c.buffer > 0.0
+
+// Close both windows so one press cannot fire twice, and arm the lock that
+// keeps the ground clamp off the character while it is leaving the ground.
+let consumeJump = (c) => { c with coyote: 0.0, buffer: 0.0, lock: jumpLockTime }
+
+// Move `current` toward `target` at `rate` units/s^2 without overshooting.
+let approach = (rate, dt, current, target) =>
+  let d = target - current in
+  let step = rate * dt in
+  if Math.abs(d) < step then target
+  else if d > 0.0 then current + step
+  else current - step
+
+// The velocity to command this frame.
+//
+//   carry — the velocity of whatever surface the ground probe hit ({0,0,0} in
+//           the air). Steering is relative to the SURFACE, so standing still
+//           on a moving deck rides along with it, and a jump inherits the
+//           deck's motion instead of stopping dead in mid-air.
+// How fast the ground clamp below may correct the standing height.
+let maxSnapSpeed = 6.0
+
+// The vertical axis is the subtle part, because `Physics.setVelocity` replaces
+// ALL THREE components — there is no horizontal-only command. So the controller
+// must say something about vy every frame, and two obvious answers are both
+// wrong. Measured, on a capsule that should rest with its center 0.90 above the
+// surface:
+//
+//   echo the read back      -> the read is one step stale, so while grounded it
+//                              still carries the downward speed the solver just
+//                              cancelled at the contact. Re-commanding it drives
+//                              the capsule in: it rested at y = 0.40, visibly
+//                              sunk half a unit into the floor.
+//   command 0 while grounded -> better, but overwriting vy every frame also
+//                              destroys the contact's own pushout impulse, so
+//                              each step's gravity increment accumulates as
+//                              penetration. It still sank, just slower —
+//                              y = 0.98 drifting to 0.40 over 260 frames.
+//
+// The rule that holds: while grounded, own the standing height EXPLICITLY.
+// The ground probe already measured the distance to the surface, so correct
+// toward the rest distance with a critically-damped `error / dt`. That is the
+// standard character-controller ground clamp, and it also buys stick-to-a-
+// descending-deck for free: a surface dropping away pulls the character down
+// with it instead of letting it go momentarily ballistic.
+//
+//   jumping  -> the jump speed, plus the surface's own rise
+//   grounded -> the surface's own vy, plus the height correction
+//   airborne -> pass the read through and let gravity own it (one step of
+//               delay, which integrates correctly)
+//
+// `obs.standHeight` is the capsule's rest distance from the surface, and
+// `obs.groundDistance` is what the probe measured; both come from the caller so
+// that this module stays free of engine constants.
+// NOTE both this and `desiredVelocity` branch on `c.grounded` — the EFFECTIVE
+// grounded state that `sense` already computed, which honours the post-jump
+// lock — never on the raw `obs.grounded`.
+let verticalVelocity = (dt, obs, carry, c) =>
+  if jumpNow(c) then jumpSpeed + carry.y
+  else if c.grounded then
+    let error = obs.standHeight - obs.groundDistance in
+    let correction = Math.max(-maxSnapSpeed, Math.min(maxSnapSpeed, error / dt)) in
+    carry.y + correction
+  else obs.vy
+
+let desiredVelocity = (dt, obs, carry, c) =>
+  let rate = if c.grounded then groundAccel else airAccel in
+  let targetX = carry.x + c.wishX * speed in
+  let targetZ = carry.z + c.wishZ * speed in
+  {
+    x: approach(rate, dt, obs.vx, targetX),
+    y: verticalVelocity(dt, obs, carry, c),
+    z: approach(rate, dt, obs.vz, targetZ),
+  }
+
+// Landing squash as a vertical scale factor: 1.0 at rest, dipping right after
+// a hard landing and easing back as the timer drains.
+let squashScale = (c) =>
+  let t = c.squash / squashTime in
+  let hardness = Math.min(1.0, c.landImpact / landHardness) in
+  1.0 - 0.35 * hardness * t
+
+// Normalize a steering wish so diagonals are not faster than the axes.
+let normalizeWish = (x, z) =>
+  let len = Math.sqrt(x * x + z * z) in
+  if len > 1.0 then (x / len, z / len) else (x, z)
+
+// ---------------------------------------------------------------------------
+// Tests. `functor -d examples/physics-controller test` runs these headlessly.
+// ---------------------------------------------------------------------------
+
+// An observation fixture. `standHeight` is the capsule's rest distance from a
+// surface and `groundDistance` is what the probe measured; equal means resting
+// at exactly the right height, so the ground clamp contributes nothing.
+let obsAt = (grounded, vx, vy, dist) =>
+  { grounded: grounded, vx: vx, vy: vy, vz: 0.0, standHeight: 0.9, groundDistance: dist }
+
+let air = obsAt(false, 0.0, 0.0, 0.9)
+let onGround = obsAt(true, 0.0, 0.0, 0.9)
+let still = { x: 0.0, y: 0.0, z: 0.0 }
+let dt = 0.0166667
+
+// `desiredVelocity` branches on the EFFECTIVE grounded state, so tests must run
+// the observation through `sense` first, exactly as `tick` does.
+let step = (obs, jumpEdge, carry, c) =>
+  let sensed = sense(dt, obs, jumpEdge, c) in
+  (desiredVelocity(dt, obs, carry, sensed),
+   if jumpNow(sensed) then consumeJump(sensed) else sensed)
+
+// Grounded refills coyote time to full.
+expect sense(dt, onGround, false, zero).coyote == coyoteTime
+
+// Leaving the ground drains it, and after coyoteTime it is spent.
+expect (
+  let c = sense(dt, onGround, false, zero) in
+  let c2 = sense(dt, air, false, c) in
+  c2.coyote < coyoteTime && c2.coyote > 0.0
+)
+
+// Coyote time is a real grace window: a jump pressed a few frames AFTER
+// walking off still fires...
+expect (
+  let grounded = sense(dt, onGround, false, zero) in
+  let f1 = sense(dt, air, false, grounded) in
+  let f2 = sense(dt, air, false, f1) in
+  let pressed = sense(dt, air, true, f2) in
+  jumpNow(pressed)
+)
+
+// ...but not once the window has fully drained (0.12s is ~8 frames).
+expect (
+  let grounded = sense(dt, onGround, false, zero) in
+  let drained =
+    List.range(12.0) |> List.fold((c, _) => sense(dt, air, false, c), grounded) in
+  not (drained.coyote > 0.0) && not jumpNow(sense(dt, air, true, drained))
+)
+
+// Jump buffering: a press while still falling fires on the touchdown frame.
+expect (
+  let pressedInAir = sense(dt, air, true, zero) in
+  let land = sense(dt, onGround, false, pressedInAir) in
+  jumpNow(land)
+)
+
+// Consuming closes both windows, so a held press cannot double-jump.
+expect (
+  let land = sense(dt, onGround, false, sense(dt, air, true, zero)) in
+  not jumpNow(consumeJump(land))
+)
+
+// A jump commands the jump speed; a non-jumping frame passes vertical
+// velocity through untouched, leaving gravity in charge.
+expect (
+  let (want, _) = step(onGround, true, still, zero) in
+  want.y == jumpSpeed
+)
+expect (
+  let (want, _) = step(obsAt(false, 0.0, -4.25, 0.9), false, still, zero) in
+  want.y == -4.25
+)
+
+// The sinking regression, pinned. A GROUNDED frame must NOT echo back the stale
+// downward speed the read still carries; resting at exactly the right height it
+// must command exactly the surface's own vy, which on static ground is 0.
+expect (
+  let (want, _) = step(obsAt(true, 0.0, -6.7, 0.9), false, still, zero) in
+  want.y == 0.0
+)
+
+// The ground clamp: sunk below the rest height, it corrects UPWARD; hovering
+// within the probe's reach, it pulls DOWN to stick to the surface.
+expect (
+  let (want, _) = step(obsAt(true, 0.0, 0.0, 0.84), false, still, zero) in
+  want.y > 0.0
+)
+expect (
+  let (want, _) = step(obsAt(true, 0.0, 0.0, 0.98), false, still, zero) in
+  want.y < 0.0
+)
+
+// The correction is bounded, so a deep overlap cannot launch the character.
+expect (
+  let (want, _) = step(obsAt(true, 0.0, 0.0, 0.0), false, still, zero) in
+  want.y == maxSnapSpeed
+)
+
+// On a RISING surface, grounded vy follows the surface, so a lift carries its
+// passenger up instead of leaving them behind.
+expect (
+  let (want, _) = step(obsAt(true, 0.0, -6.7, 0.9), false, { x: 0.0, y: 2.0, z: 0.0 }, zero) in
+  want.y == 2.0
+)
+
+// The post-jump lock, pinned — the regression that made the jump collapse. On
+// the frame AFTER a jump fires, the feet are still within the probe's reach, so
+// the raw observation still says grounded. The lock must make the controller
+// treat that as airborne and pass the rising velocity through, instead of
+// clamping it back down to standing height.
+expect (
+  let (_, afterJump) = step(onGround, true, still, zero) in
+  afterJump.lock == jumpLockTime
+)
+expect (
+  let (_, afterJump) = step(onGround, true, still, zero) in
+  // Still physically overlapping the ground probe, and rising fast.
+  let rising = obsAt(true, 0.0, 6.83, 0.98) in
+  let (want, next) = step(rising, false, still, afterJump) in
+  not next.grounded && want.y == 6.83
+)
+
+// The lock expires, and grounding resumes: a landing after it is a real
+// landing, squash and all.
+expect (
+  let (_, afterJump) = step(onGround, true, still, zero) in
+  let expired =
+    List.range(8.0) |> List.fold((c, _) => sense(dt, air, false, c), afterJump) in
+  not (expired.lock > 0.0) && sense(dt, obsAt(true, 0.0, -6.0, 0.9), false, expired).squash == squashTime
+)
+
+// Landing is an EDGE, not a level: the squash fires on the touchdown frame
+// and not on the frames that follow it.
+expect (
+  let hit = obsAt(true, 0.0, -6.0, 0.9) in
+  let touchdown = sense(dt, hit, false, zero) in
+  let after = sense(dt, onGround, false, touchdown) in
+  touchdown.squash == squashTime && after.squash < squashTime
+)
+
+// A harder landing squashes more, and the squash eases back to 1.0.
+expect (
+  let soft = sense(dt, obsAt(true, 0.0, -1.5, 0.9), false, zero) in
+  let hard = sense(dt, obsAt(true, 0.0, -6.0, 0.9), false, zero) in
+  squashScale(hard) < squashScale(soft) && squashScale(soft) < 1.0
+)
+expect squashScale(zero) == 1.0
+
+// Platform carry: with no steering wish, the commanded velocity converges on
+// the deck's own velocity — that is what riding a moving platform IS.
+expect (
+  let deck = { x: 3.0, y: 0.0, z: 0.0 } in
+  let (want, _) = step(obsAt(true, 3.0, 0.0, 0.9), false, deck, zero) in
+  want.x == 3.0
+)
+
+// Standing STILL on a deck the character is not yet matching, it accelerates
+// toward the deck's velocity rather than away from it.
+expect (
+  let deck = { x: 3.0, y: 0.0, z: 0.0 } in
+  let (want, _) = step(obsAt(true, 0.0, 0.0, 0.9), false, deck, zero) in
+  want.x > 0.0 && want.x < 3.0
+)
+
+// Steering on a moving deck is relative to the deck, so walking forward on a
+// deck moving at 3.0 gives deck speed plus walk speed.
+expect (
+  let deck = { x: 3.0, y: 0.0, z: 0.0 } in
+  let wish = { zero with wishX: 1.0 } in
+  let (want, _) = step(obsAt(true, 3.0 + speed, 0.0, 0.9), false, deck, wish) in
+  want.x == 3.0 + speed
+)
+
+// Jumping off a moving deck inherits its vertical motion (a rising lift
+// launches you higher, not out from under itself).
+expect (
+  let lift = { x: 0.0, y: 2.0, z: 0.0 } in
+  let (want, _) = step(onGround, true, lift, zero) in
+  want.y == jumpSpeed + 2.0
+)
+
+// `approach` converges and never overshoots.
+expect approach(45.0, dt, 0.0, 6.0) == 45.0 * dt
+expect approach(45.0, dt, 6.0, 6.0) == 6.0
+expect approach(45.0, dt, 5.999, 6.0) == 6.0
+expect approach(45.0, dt, 0.0, -6.0) == -45.0 * dt
+
+// Diagonal steering is normalized; a single axis is left alone.
+expect (
+  let (x, z) = normalizeWish(1.0, 1.0) in
+  Math.abs(Math.sqrt(x * x + z * z) - 1.0) < 0.0001
+)
+expect (
+  let (x, z) = normalizeWish(1.0, 0.0) in
+  x == 1.0 && z == 0.0
+)
+expect (
+  let (x, z) = normalizeWish(0.0, 0.0) in
+  x == 0.0 && z == 0.0
+)

--- a/examples/physics-controller/functor.json
+++ b/examples/physics-controller/functor.json
@@ -1,0 +1,4 @@
+{
+  "language": "functor-lang",
+  "entry": "game.fun"
+}

--- a/examples/physics-controller/game.fun
+++ b/examples/physics-controller/game.fun
@@ -29,7 +29,6 @@ let groundTag = Physics.tag("ground")
 let ledgeTag = Physics.tag("ledge")
 let wallTag = Physics.tag("wall")
 let deckTag = Physics.tag("deck")
-let noTag = Physics.tag("")
 
 // The capsule: half-height 0.5 plus radius 0.4, so the feet sit 0.9 below the
 // body's center. The ground probe's length follows from exactly that number.
@@ -48,8 +47,17 @@ let probeSkin = 0.15
 // `Debug.log` returns its value unchanged, so `trace` is pure with respect to
 // the model: the game runs identically with `traceOn` either way.
 let traceOn = false
+// `row` is a THUNK so the record is only built when tracing is on.
 let trace = (row, m) =>
-  if traceOn then (let logged = Debug.log("row", row) in m) else m
+  if traceOn then (let logged = Debug.log("row", row()) in m) else m
+
+// Put the body back at the spawn, at rest. Used by both the fall-out-of-the-
+// world path and the ENTER key.
+let respawn =
+  Effect.batch([
+    Physics.teleport(playerTag, Vec3.make(World.spawn.x, World.spawn.y, World.spawn.z)),
+    Physics.setVelocity(playerTag, Vec3.make(0.0, 0.0, 0.0)),
+  ])
 
 let slabBody = (tag, s: World.Slab) =>
   Physics.fixed(tag, Physics.box(s.w, s.h, s.d))
@@ -78,7 +86,12 @@ let physics = (model) =>
       |> Physics.at(Vec3.make(World.spawn.x, World.spawn.y, World.spawn.z))
       |> Physics.friction(0.0)
       |> Physics.restitution(0.0)
-      |> Physics.mass(1.0),
+      |> Physics.mass(1.0)
+      // Non-negotiable for a character. Without it the capsule picks up
+      // angular velocity from any glancing contact and topples — and a tipped
+      // capsule's lowest point is no longer `feetOffset` below its center, so
+      // the grounding probe and the ground clamp both start lying.
+      |> Physics.upright,
   ])
 
 let init = {
@@ -86,6 +99,8 @@ let init = {
   // A jump press latched as a rising edge, plus the held state that derives it.
   jumpEdge: false,
   jumpHeld: false,
+  // ENTER's own rising-edge latch (key repeats arrive as `isDown = true`).
+  enterHeld: false,
   clock: 0.0,
   frame: 0.0,
   // Whether the ground probe hit the moving deck, and that surface's velocity —
@@ -171,15 +186,12 @@ let tick = (model, dt, tts) =>
     // spawn (a changed declaration would teleport it, but then every later
     // frame's declaration would be a change back again).
     if pos.y < World.voidY then
-      ({ next with falls: next.falls + 1.0, ctl: Control.zero },
-       Effect.batch([
-         Physics.teleport(playerTag, Vec3.make(World.spawn.x, World.spawn.y, World.spawn.z)),
-         Physics.setVelocity(playerTag, Vec3.make(0.0, 0.0, 0.0)),
-       ]))
+      ({ next with falls: next.falls + 1.0, ctl: Control.respawned(next.ctl) }, respawn)
     else
-      // One row per frame under `traceOn`: everything the headless
-      // verification run in README.md asserts on.
-      let row = {
+      // Built lazily: under the default `traceOn = false` this record — and the
+      // `Math.cos` inside `World.deckVx` — is never constructed, because `if`
+      // only evaluates the branch it takes.
+      let row = () => {
         f: next.frame,
         x: pos.x, y: pos.y, z: pos.z, vy: vel.y,
         g: obs.grounded, deck: next.onDeck,
@@ -193,13 +205,14 @@ let input = (model, key, isDown) =>
   match key with
   | Key.Enter =>
     (match isDown with
-     | false => model
+     | false => { model with enterHeld: false }
      | true =>
-       (model,
-        Effect.batch([
-          Physics.teleport(playerTag, Vec3.make(World.spawn.x, World.spawn.y, World.spawn.z)),
-          Physics.setVelocity(playerTag, Vec3.make(0.0, 0.0, 0.0)),
-        ])))
+       // Rising edge: GLFW delivers key REPEATS as `isDown = true`, so without
+       // the latch holding ENTER would queue a teleport every repeat.
+       (match model.enterHeld with
+        | true => model
+        | false =>
+          ({ model with enterHeld: true, ctl: Control.respawned(model.ctl) }, respawn)))
   | _ => model
 
 // -- drawing -----------------------------------------------------------------
@@ -230,16 +243,9 @@ let deckVisual = () =>
 let playerVisual = (model) =>
   let sy = Control.squashScale(model.ctl) in
   let sxz = 1.0 + (1.0 - sy) * 0.7 in
-  Scene.group([
-    Scene.cylinder()
-      |> Scene.scaleXYZ(capsuleRadius * 2.0 * sxz, feetOffset * 2.0 * sy, capsuleRadius * 2.0 * sxz)
-      |> Scene.lit(bodyColor),
-    // A nose, so facing and motion read at a glance.
-    Scene.sphere()
-      |> Scene.scale(0.22)
-      |> Scene.lit(Color.rgb(0.95, 0.95, 0.98))
-      |> Scene.translate(Vec3.make(0.0, feetOffset * sy * 0.7, -capsuleRadius * 0.9)),
-  ])
+  Scene.cylinder()
+    |> Scene.scaleXYZ(capsuleRadius * 2.0 * sxz, feetOffset * 2.0 * sy, capsuleRadius * 2.0 * sxz)
+    |> Scene.lit(bodyColor)
     |> Scene.translate(Vec3.make(0.0, -feetOffset * (1.0 - sy), 0.0))
     |> Physics.transformed(playerTag)
 

--- a/examples/physics-controller/game.fun
+++ b/examples/physics-controller/game.fun
@@ -1,0 +1,279 @@
+// physics-controller — a platformer character controller where the character
+// is a REAL dynamic physics body, driven from `tick`.
+//
+// The counterpart to `examples/platformer`, which hand-rolls its kinematics as
+// a pure function and uses no physics world at all. This one puts a dynamic
+// capsule in the `physics` hook and steers it with the SYNCHRONOUS physics
+// queries, so collision, walls, and slopes come from the solver instead of
+// from collision code in the game.
+//
+//   functor -d examples/physics-controller run native
+//   functor -d examples/physics-controller test          # the pure control logic
+//
+// Controls: WASD / arrows to run, SPACE to jump, ENTER to respawn.
+//
+// THE WHOLE CONTROL LOOP IS ONE FRAME, and it all lives in `tick`:
+//
+//   read   Physics.position / linearVelocity / castExcluding   (synchronous)
+//   decide Control.sense / desiredVelocity                     (pure)
+//   write  Physics.setVelocity                                 (same-frame)
+//
+// The reads see the PREVIOUS step (physics runs after `tick`) and the command
+// applies at the step that immediately follows this `tick`, so the loop closes
+// within one frame. That one step of read latency is inherent to any
+// read -> decide -> step simulation, not a Functor restriction.
+
+// Branded body identities: declared once, used as the VALUE at every site.
+let playerTag = Physics.tag("player")
+let groundTag = Physics.tag("ground")
+let ledgeTag = Physics.tag("ledge")
+let wallTag = Physics.tag("wall")
+let deckTag = Physics.tag("deck")
+let noTag = Physics.tag("")
+
+// The capsule: half-height 0.5 plus radius 0.4, so the feet sit 0.9 below the
+// body's center. The ground probe's length follows from exactly that number.
+let capsuleHalfHeight = 0.5
+let capsuleRadius = 0.4
+let feetOffset = capsuleHalfHeight + capsuleRadius
+// Skin thickness: how far past the feet the probe looks. Too small and the
+// character flickers un-grounded over a seam; too large and it claims to be
+// standing while still visibly airborne.
+let probeSkin = 0.15
+
+// Flip to `true` to print one line of controller state per frame; the scripted
+// verification run in `README.md` reads exactly this. Off by default, because
+// a `Debug.log` in `tick` fires ~60 times a second.
+//
+// `Debug.log` returns its value unchanged, so `trace` is pure with respect to
+// the model: the game runs identically with `traceOn` either way.
+let traceOn = false
+let trace = (row, m) =>
+  if traceOn then (let logged = Debug.log("row", row) in m) else m
+
+let slabBody = (tag, s: World.Slab) =>
+  Physics.fixed(tag, Physics.box(s.w, s.h, s.d))
+    |> Physics.at(Vec3.make(s.x, s.y, s.z))
+    |> Physics.friction(0.8)
+
+// The world. The deck is KINEMATIC and its declared pose is re-derived from the
+// clock every frame: the runtime drives a kinematic body toward each newly
+// declared pose, so the deck moves without any command effects, and rapier
+// derives the velocity that the controller reads back as `carry`.
+//
+// Never read a body from inside this hook — it is a pure declaration.
+let physics = (model) =>
+  let deck = World.deckAt(model.clock) in
+  Physics.scene(Vec3.make(0.0, -22.0, 0.0), [
+    slabBody(groundTag, World.ground),
+    slabBody(ledgeTag, World.ledge),
+    slabBody(wallTag, World.wall),
+    Physics.kinematic(deckTag, Physics.box(deck.w, deck.h, deck.d))
+      |> Physics.at(Vec3.make(deck.x, deck.y, deck.z))
+      |> Physics.friction(0.8),
+    // Low friction on the character: the controller commands its horizontal
+    // velocity outright every frame, so surface friction would only fight it.
+    // Platform carry comes from the probe, not from being dragged along.
+    Physics.dynamic(playerTag, Physics.capsule(capsuleHalfHeight, capsuleRadius))
+      |> Physics.at(Vec3.make(World.spawn.x, World.spawn.y, World.spawn.z))
+      |> Physics.friction(0.0)
+      |> Physics.restitution(0.0)
+      |> Physics.mass(1.0),
+  ])
+
+let init = {
+  ctl: Control.zero,
+  // A jump press latched as a rising edge, plus the held state that derives it.
+  jumpEdge: false,
+  jumpHeld: false,
+  clock: 0.0,
+  frame: 0.0,
+  // Whether the ground probe hit the moving deck, and that surface's velocity —
+  // model state purely so the HUD and the headless trace can show them.
+  onDeck: false,
+  carryX: 0.0,
+  falls: 0.0,
+}
+
+// Held-key steering. There is no `Input.isHeld`, so this is the usual scan.
+let held = (k, snap) => snap.heldKeys |> List.any((h) => h == k)
+
+let axis = (neg, pos, snap) =>
+  (if held(pos, snap) then 1.0 else 0.0) - (if held(neg, snap) then 1.0 else 0.0)
+
+// `sampledInput` runs once per fixed simulation step, which is what held-key
+// movement needs (the `input` hook's repeats would be frame-rate dependent).
+// The jump is latched as a rising EDGE here and consumed by `tick`, so the
+// press survives to the frame that can act on it.
+let sampledInput = (model, snapshot: Input.snapshot) =>
+  let wishX = axis(Key.A, Key.D, snapshot) + axis(Key.Left, Key.Right, snapshot) in
+  let wishZ = axis(Key.W, Key.S, snapshot) + axis(Key.Up, Key.Down, snapshot) in
+  let (nx, nz) = Control.normalizeWish(wishX, wishZ) in
+  let jumping = held(Key.Space, snapshot) in
+  { model with
+    ctl: { model.ctl with wishX: nx, wishZ: nz },
+    // Rising edge only: holding SPACE must not re-arm the buffer every frame.
+    // The latch is sticky until `tick` consumes it, so a press cannot be lost
+    // between a sampled step and the tick that acts on it.
+    jumpEdge: model.jumpEdge || (jumping && not model.jumpHeld),
+    jumpHeld: jumping,
+  }
+
+let zeroVelocity: Physics.velocity = { x: 0.0, y: 0.0, z: 0.0 }
+
+// The grounding probe: straight down from the capsule's center, past the feet
+// by `probeSkin`, ignoring the character's own collider. Without the exclusion
+// the ray would hit the capsule it starts inside at distance 0 and report the
+// character standing on itself.
+let groundProbe = (pos) =>
+  Physics.castExcluding(playerTag,
+                        Vec3.make(pos.x, pos.y, pos.z),
+                        Vec3.make(0.0, -1.0, 0.0),
+                        feetOffset + probeSkin)
+
+// The velocity of whatever we are standing on — the whole of moving-platform
+// carry, with no platform identity, no "which deck was I on last frame", and
+// no per-platform state. A fixed body reads back zero, so static ground needs
+// no special case.
+let surfaceVelocity = (probe) =>
+  if probe.hit then Physics.linearVelocity(probe.tag) else zeroVelocity
+
+let tick = (model, dt, tts) =>
+  let m = { model with clock: model.clock + dt, frame: model.frame + 1.0 } in
+  // The pre-step physics reads raise on the very first frame: the `physics`
+  // hook's declaration has not been reconciled and stepped yet.
+  if not m.ctl.started then { m with ctl: { m.ctl with started: true } }
+  else
+    let pos = Physics.position(playerTag) in
+    let vel = Physics.linearVelocity(playerTag) in
+    let probe = groundProbe(pos) in
+    // The observation handed to the pure controller. `groundDistance` is what
+    // the probe measured and `standHeight` is where the feet belong, so the
+    // controller can hold its standing height itself (see `verticalVelocity`).
+    let obs = {
+      grounded: probe.hit,
+      vx: vel.x, vy: vel.y, vz: vel.z,
+      standHeight: feetOffset,
+      groundDistance: probe.distance,
+    } in
+    let carry = surfaceVelocity(probe) in
+    let sensed = Control.sense(dt, obs, m.jumpEdge, m.ctl) in
+    let want = Control.desiredVelocity(dt, obs, carry, sensed) in
+    let ctl = if Control.jumpNow(sensed) then Control.consumeJump(sensed) else sensed in
+    let next =
+      { m with
+        ctl: ctl,
+        jumpEdge: false,
+        onDeck: probe.hit && probe.tag == deckTag,
+        carryX: carry.x,
+      } in
+    // Fell out of the world: put the body back rather than re-declaring its
+    // spawn (a changed declaration would teleport it, but then every later
+    // frame's declaration would be a change back again).
+    if pos.y < World.voidY then
+      ({ next with falls: next.falls + 1.0, ctl: Control.zero },
+       Effect.batch([
+         Physics.teleport(playerTag, Vec3.make(World.spawn.x, World.spawn.y, World.spawn.z)),
+         Physics.setVelocity(playerTag, Vec3.make(0.0, 0.0, 0.0)),
+       ]))
+    else
+      // One row per frame under `traceOn`: everything the headless
+      // verification run in README.md asserts on.
+      let row = {
+        f: next.frame,
+        x: pos.x, y: pos.y, z: pos.z, vy: vel.y,
+        g: obs.grounded, deck: next.onDeck,
+        carry: carry.x, deckVx: World.deckVx(m.clock),
+        coy: ctl.coyote, sq: ctl.squash, impact: ctl.landImpact,
+      } in
+      (trace(row, next),
+       Physics.setVelocity(playerTag, Vec3.make(want.x, want.y, want.z)))
+
+let input = (model, key, isDown) =>
+  match key with
+  | Key.Enter =>
+    (match isDown with
+     | false => model
+     | true =>
+       (model,
+        Effect.batch([
+          Physics.teleport(playerTag, Vec3.make(World.spawn.x, World.spawn.y, World.spawn.z)),
+          Physics.setVelocity(playerTag, Vec3.make(0.0, 0.0, 0.0)),
+        ])))
+  | _ => model
+
+// -- drawing -----------------------------------------------------------------
+
+let slabColor = Color.rgb(0.42, 0.45, 0.52)
+let deckColor = Color.rgb(0.85, 0.55, 0.25)
+let bodyColor = Color.rgb(0.30, 0.72, 0.95)
+let groundColor = Color.rgb(0.30, 0.33, 0.38)
+
+let slabVisual = (color, s: World.Slab) =>
+  Scene.cube()
+    |> Scene.scaleXYZ(s.w, s.h, s.d)
+    |> Scene.lit(color)
+    |> Scene.translate(Vec3.make(s.x, s.y, s.z))
+
+// The deck's visual is placed by `Physics.transformed`, not by re-deriving the
+// pose: the picture and the collider cannot disagree. It must be a FUNCTION,
+// not a top-level value — a top-level initializer evaluates at load, when no
+// body has been declared yet, and `Physics.transformed` would raise there.
+let deckVisual = () =>
+  Scene.cube()
+    |> Scene.scaleXYZ(World.deckHome.w, World.deckHome.h, World.deckHome.d)
+    |> Scene.lit(deckColor)
+    |> Physics.transformed(deckTag)
+
+// The landing squash scales about the FEET, not the center, so the character
+// flattens onto the surface instead of sinking through it.
+let playerVisual = (model) =>
+  let sy = Control.squashScale(model.ctl) in
+  let sxz = 1.0 + (1.0 - sy) * 0.7 in
+  Scene.group([
+    Scene.cylinder()
+      |> Scene.scaleXYZ(capsuleRadius * 2.0 * sxz, feetOffset * 2.0 * sy, capsuleRadius * 2.0 * sxz)
+      |> Scene.lit(bodyColor),
+    // A nose, so facing and motion read at a glance.
+    Scene.sphere()
+      |> Scene.scale(0.22)
+      |> Scene.lit(Color.rgb(0.95, 0.95, 0.98))
+      |> Scene.translate(Vec3.make(0.0, feetOffset * sy * 0.7, -capsuleRadius * 0.9)),
+  ])
+    |> Scene.translate(Vec3.make(0.0, -feetOffset * (1.0 - sy), 0.0))
+    |> Physics.transformed(playerTag)
+
+// `draw` runs AFTER the step, so this read is this frame's pose: the camera
+// never trails the body it follows.
+let draw = (model, tts) =>
+  let pos = Physics.position(playerTag) in
+  Frame.createLit(
+    Camera.lookAt(Vec3.make(pos.x + 6.5, pos.y + 4.5, pos.z + 12.0),
+                  Vec3.make(pos.x, pos.y + 0.7, pos.z)),
+    Scene.group([
+      slabVisual(groundColor, World.ground),
+      slabVisual(slabColor, World.ledge),
+      slabVisual(slabColor, World.wall),
+      deckVisual(),
+      playerVisual(model),
+    ]),
+    [
+      Light.ambient(Color.rgb(0.28, 0.30, 0.36)),
+      // Deliberately oblique, so the capsule's SIDES catch light and the
+      // landing squash is legible as a change in silhouette.
+      Light.directional(Vec3.make(-0.55, -0.7, -0.45), Color.rgb(1.0, 0.97, 0.92), 1.05)
+        |> Light.castShadows,
+    ])
+
+let onOff = (b) => if b then "yes" else "no"
+
+let ui = (model) =>
+  Ui.column([
+    Ui.text(Text.join("", ["grounded  ", onOff(model.ctl.grounded)])),
+    Ui.text(Text.join("", ["on deck   ", onOff(model.onDeck)])),
+    Ui.text(Text.join("", ["carry vx  ", Text.fixed(model.carryX, 2.0)])),
+    Ui.text(Text.join("", ["coyote    ", Text.fixed(model.ctl.coyote, 3.0)])),
+    Ui.text(Text.join("", ["squash    ", Text.fixed(model.ctl.squash, 3.0)])),
+    Ui.text(Text.join("", ["falls     ", Text.fixed(model.falls, 0.0)])),
+  ])
+    |> Ui.panel(Ui.topLeft())

--- a/examples/physics-controller/game.fun
+++ b/examples/physics-controller/game.fun
@@ -99,8 +99,10 @@ let init = {
   // A jump press latched as a rising edge, plus the held state that derives it.
   jumpEdge: false,
   jumpHeld: false,
-  // ENTER's own rising-edge latch (key repeats arrive as `isDown = true`).
+  // ENTER's own rising-edge latch (key repeats arrive as `isDown = true`), and
+  // the respawn request it raises for `tick` to perform.
   enterHeld: false,
+  respawnPending: false,
   clock: 0.0,
   frame: 0.0,
   // Whether the ground probe hit the moving deck, and that surface's velocity —
@@ -182,15 +184,27 @@ let tick = (model, dt, tts) =>
         onDeck: probe.hit && probe.tag == deckTag,
         carryX: carry.x,
       } in
-    // Fell out of the world: put the body back rather than re-declaring its
-    // spawn (a changed declaration would teleport it, but then every later
-    // frame's declaration would be a change back again).
-    if pos.y < World.voidY then
-      ({ next with falls: next.falls + 1.0, ctl: Control.respawned(next.ctl) }, respawn)
+    // Respawn — either because the character fell out of the world, or because
+    // ENTER asked for one. Both go through `tick`, and both return `respawn`
+    // INSTEAD of this frame's velocity command, never alongside it: commands
+    // apply in queue order, so a `setVelocity` issued after the respawn's would
+    // win and hand the body back its pre-teleport fall speed.
+    //
+    // The body is put back with a command rather than by re-declaring its
+    // spawn: a changed declaration would teleport it, but then every later
+    // frame's declaration would be a change back again.
+    let fellOut = pos.y < World.voidY in
+    if fellOut || m.respawnPending then
+      ({ next with
+         falls: if fellOut then next.falls + 1.0 else next.falls,
+         respawnPending: false,
+         ctl: Control.respawned(next.ctl) },
+       respawn)
     else
-      // Built lazily: under the default `traceOn = false` this record — and the
+      // Built lazily: under the default `traceOn = false` the record — and the
       // `Math.cos` inside `World.deckVx` — is never constructed, because `if`
-      // only evaluates the branch it takes.
+      // only evaluates the branch it takes. (The closure itself is still
+      // allocated each frame; only its body is skipped.)
       let row = () => {
         f: next.frame,
         x: pos.x, y: pos.y, z: pos.z, vy: vel.y,
@@ -208,11 +222,12 @@ let input = (model, key, isDown) =>
      | false => { model with enterHeld: false }
      | true =>
        // Rising edge: GLFW delivers key REPEATS as `isDown = true`, so without
-       // the latch holding ENTER would queue a teleport every repeat.
+       // the latch holding ENTER would request a respawn every repeat. The key
+       // only records the INTENT — `tick` performs it, so the respawn is not
+       // immediately undone by that same frame's velocity command.
        (match model.enterHeld with
         | true => model
-        | false =>
-          ({ model with enterHeld: true, ctl: Control.respawned(model.ctl) }, respawn)))
+        | false => { model with enterHeld: true, respawnPending: true }))
   | _ => model
 
 // -- drawing -----------------------------------------------------------------

--- a/examples/physics-controller/ride-and-jump.input
+++ b/examples/physics-controller/ride-and-jump.input
@@ -1,0 +1,30 @@
+# ride-and-jump.input — the reproducible headless verification run.
+#
+# Deterministic scripted playback: the sim advances by a FIXED --script-dt per
+# rendered frame and each frame's events are fed before that frame's tick, so
+# frame N is always the same sim state. Paths must be ABSOLUTE (the runner makes
+# the project directory its cwd before parsing them).
+#
+#   functor -d examples/physics-controller run native \
+#     --input-script "$PWD/examples/physics-controller/ride-and-jump.input" \
+#     --script-dt 0.0166667 --capture-frame /tmp/f.png --capture-at-frame 60
+#
+# What it proves, with no GPU window and no human at the keyboard — see
+# README.md for the measured numbers:
+#
+#   f 1..~13    FALL: spawned above the moving deck, gravity only, no input.
+#   f ~14       LANDING on the MOVING deck: grounded flips true, the probe
+#               reports the deck, and the squash timer fires on that one frame.
+#   f 14..70    CARRY with ZERO input: the player's x tracks the deck's, so
+#               `carry` equals the deck's analytic velocity every frame.
+#   f 71        walk +Z (S), off the deck's near edge.
+#   f ~95       EDGE: grounded flips false with no ground beneath, coyote time
+#               starts draining, then a second landing on the plaza below.
+#   f 130       JUMP from the plaza (rising edge; the buffer/coyote pair fires).
+#   f 175..     run -X into the wall and stay there: the solver stops the
+#               capsule at the wall face with no collision code in the game.
+71 S down
+100 S up
+130 Space down
+133 Space up
+175 A down

--- a/examples/physics-controller/world.fun
+++ b/examples/physics-controller/world.fun
@@ -1,0 +1,64 @@
+// world.fun — the level, as pure data.
+//
+// A slab is a box given by its CENTER and its full extents, which is what
+// `Physics.box` wants; `top` derives the surface the player actually stands on.
+// The moving deck's pose is an analytic function of the game clock, so the
+// `physics` hook can re-declare it every frame without storing any per-platform
+// state (the runtime drives a kinematic body toward each newly declared pose,
+// and derives its velocity from that motion — which is what the controller's
+// ground probe reads back as `carry`).
+
+type Slab = { x: float, y: float, z: float, w: float, h: float, d: float }
+
+// The plaza. Its top face is exactly y = 0, so ground-plane visuals line up
+// with resting bodies.
+let ground: Slab = { x: 0.0, y: -0.5, z: 0.0, w: 40.0, h: 1.0, d: 40.0 }
+
+// A static platform to jump onto.
+let ledge: Slab = { x: 9.0, y: 1.7, z: 0.0, w: 6.0, h: 0.6, d: 6.0 }
+
+// A wall to run into. With a dynamic capsule this needs no controller code at
+// all — the solver refuses the penetration.
+let wall: Slab = { x: -7.0, y: 1.5, z: 0.0, w: 0.6, h: 3.0, d: 12.0 }
+
+// The moving deck: a kinematic slab sliding along X.
+let deckHome: Slab = { x: 0.0, y: 1.0, z: -8.0, w: 8.0, h: 0.5, d: 5.0 }
+let deckTravel = 4.0
+let deckOmega = 0.6
+
+// The deck's center X at time t, and its analytic velocity — the value the
+// controller should observe coming back out of `Physics.linearVelocity`.
+let deckX = (t) => deckHome.x + deckTravel * Math.sin(deckOmega * t)
+let deckVx = (t) => deckTravel * deckOmega * Math.cos(deckOmega * t)
+
+let deckAt = (t) => { deckHome with x: deckX(t) }
+
+// The player spawns just above the deck's home pose, so the run starts with a
+// short fall onto a moving surface: a landing and a carry in the first second.
+let spawn = { x: 0.0, y: 2.6, z: -8.0 }
+
+// A slab's standing surface.
+let top = (s: Slab) => s.y + s.h / 2.0
+
+// Fall out of the world and respawn.
+let voidY = -12.0
+
+expect top(ground) == 0.0
+expect top(deckHome) == 1.25
+
+// The deck starts at its home X, moving at full speed (the derivative of a
+// sine at zero is its maximum), so the carry is exercised immediately.
+expect deckX(0.0) == 0.0
+expect deckVx(0.0) == deckTravel * deckOmega
+
+// A quarter period later it is at full travel and momentarily at rest.
+expect (
+  let quarter = Math.pi / 2.0 / deckOmega in
+  Math.abs(deckX(quarter) - deckTravel) < 0.0001
+    && Math.abs(deckVx(quarter)) < 0.0001
+)
+
+// The player spawns above the deck's standing surface, so the run begins with
+// a fall onto it rather than beside it.
+expect spawn.y > top(deckHome)
+expect spawn.x == deckX(0.0)

--- a/functor-prelude/prelude/physics.funi
+++ b/functor-prelude/prelude/physics.funi
@@ -70,6 +70,14 @@ let restitution : (float, body) => body
 /// Make a body a non-solid sensor; the body is last for piping.
 let sensor : (body) => body
 
+/// Lock a body's rotation so it translates but never tips.
+///
+/// The character-controller attribute: an upright capsule that lands, scuffs a
+/// ledge, or leans on a wall would otherwise pick up angular velocity and
+/// topple, which also invalidates any fixed standing-height assumption a
+/// grounding probe makes. The body is last for piping.
+let upright : (body) => body
+
 /// Declare a physics world from gravity and bodies.
 let scene : (Vec3.t, List<body>) => world
 

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -116,6 +116,7 @@
 //! Physics.at/velocity(v, body)                        -> Body
 //! Physics.mass/friction/restitution(n, body)                -> Body
 //! Physics.sensor(body)                                      -> Body
+//! Physics.upright(body)                                     -> Body
 //! Physics.scene(Vec3.make(gx, gy, gz), [body, …])                      -> PhysicsScene
 //! Physics.position(tag)                                     -> {x, y, z}
 //! Physics.transformed(tag, scene)                           -> Scene
@@ -2146,6 +2147,11 @@ fn register_physics(reg: &mut crate::host_registry::Registry) {
     reg.fn1("Physics.sensor", "Physics.sensor(body)", |body: FunctorLangBody| {
         FunctorLangBody(body.0.as_sensor())
     });
+    reg.fn1(
+        "Physics.upright",
+        "Physics.upright(body)",
+        |body: FunctorLangBody| FunctorLangBody(body.0.as_upright()),
+    );
     reg.fn2(
         "Physics.scene",
         "Physics.scene(Vec3.make(gx, gy, gz), [body, …])",
@@ -6390,6 +6396,21 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
         assert_eq!(scene.bodies[1].mass, Some(2.0));
         assert_eq!(scene.bodies[1].restitution, 0.5);
         assert!(scene.bodies[2].sensor);
+    }
+
+    // `Physics.upright` locks a body's rotation — the character-capsule
+    // attribute. Default is off, so existing bodies keep tumbling as before.
+    #[test]
+    fn physics_upright_locks_rotation_and_defaults_off() {
+        let value = eval(
+            "let main = () => Physics.scene(Vec3.make(0.0, -9.81, 0.0), [\n\
+               Physics.dynamic(\"player\", Physics.capsule(0.5, 0.4)) |> Physics.upright,\n\
+               Physics.dynamic(\"barrel\", Physics.capsule(0.5, 0.4)),\n\
+             ])",
+        );
+        let scene = physics_scene_value(&value).expect("a PhysicsScene");
+        assert!(scene.bodies[0].rotation_locked);
+        assert!(!scene.bodies[1].rotation_locked);
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/physics/scene.rs
+++ b/runtime/functor-runtime-common/src/physics/scene.rs
@@ -83,6 +83,11 @@ pub struct Body {
     pub restitution: f32,
     /// A sensor detects overlaps but produces no contact forces.
     pub sensor: bool,
+    /// Rotation is locked on all three axes: the body translates but never
+    /// tips. The character-controller case — an upright capsule that must not
+    /// tumble when it lands, scuffs a ledge, or leans on a wall.
+    #[serde(default)]
+    pub rotation_locked: bool,
     pub authority: Authority,
 }
 
@@ -100,6 +105,7 @@ impl Body {
             friction: 0.5,
             restitution: 0.0,
             sensor: false,
+            rotation_locked: false,
             authority: Authority::Local,
         }
     }
@@ -152,6 +158,12 @@ impl Body {
 
     pub fn as_sensor(mut self) -> Body {
         self.sensor = true;
+        self
+    }
+
+    /// Lock the body's rotation so it translates but never tips.
+    pub fn as_upright(mut self) -> Body {
+        self.rotation_locked = true;
         self
     }
 

--- a/runtime/functor-runtime-common/src/physics/world.rs
+++ b/runtime/functor-runtime-common/src/physics/world.rs
@@ -725,6 +725,14 @@ impl World {
         let rb = builder
             .pose(pose_of(body))
             .linvel(vec3(body.velocity))
+            // An upright body translates but never tips (the character-capsule
+            // case). Locking the axes also zeroes any angular velocity rapier
+            // would otherwise integrate from a glancing contact.
+            .locked_axes(if body.rotation_locked {
+                LockedAxes::ROTATION_LOCKED
+            } else {
+                LockedAxes::empty()
+            })
             .build();
 
         collider = collider
@@ -831,6 +839,16 @@ impl World {
         }
         if prev.sensor != next.sensor {
             self.colliders[col_handle].set_sensor(next.sensor);
+        }
+        if prev.rotation_locked != next.rotation_locked {
+            self.bodies[rb_handle].set_locked_axes(
+                if next.rotation_locked {
+                    LockedAxes::ROTATION_LOCKED
+                } else {
+                    LockedAxes::empty()
+                },
+                true,
+            );
         }
         // `authority` is inert in Phase 1: cached (by reconcile) but never
         // written to the live world.

--- a/runtime/functor-runtime-common/src/physics/world.rs
+++ b/runtime/functor-runtime-common/src/physics/world.rs
@@ -722,18 +722,16 @@ impl World {
             BodyKind::Kinematic => RigidBodyBuilder::kinematic_position_based(),
             BodyKind::Fixed => RigidBodyBuilder::fixed(),
         };
-        let rb = builder
-            .pose(pose_of(body))
-            .linvel(vec3(body.velocity))
+        let mut builder = builder.pose(pose_of(body)).linvel(vec3(body.velocity));
+        if body.rotation_locked {
             // An upright body translates but never tips (the character-capsule
-            // case). Locking the axes also zeroes any angular velocity rapier
-            // would otherwise integrate from a glancing contact.
-            .locked_axes(if body.rotation_locked {
-                LockedAxes::ROTATION_LOCKED
-            } else {
-                LockedAxes::empty()
-            })
-            .build();
+            // case). This stops the solver from ACCUMULATING spin; a body that
+            // already has angular velocity keeps it, which is why the reconcile
+            // path also cancels the spin when the lock is switched on. At spawn
+            // there is none to cancel — angular velocity is not declarable.
+            builder = builder.locked_axes(LockedAxes::ROTATION_LOCKED);
+        }
+        let rb = builder.build();
 
         collider = collider
             .friction(body.friction)
@@ -799,7 +797,18 @@ impl World {
                     rb.set_linvel(linvel, true);
                 }
                 // Angular velocity is never declarable — always physics-owned.
-                rb.set_angvel(angvel, true);
+                // But an upright body has no angular velocity to preserve:
+                // carrying the pre-rebuild spin over would leave it rotating
+                // forever, since locking the axes only stops inertia from
+                // ACCUMULATING spin, it does not cancel spin already present.
+                rb.set_angvel(
+                    if next.rotation_locked {
+                        Vector::ZERO
+                    } else {
+                        angvel
+                    },
+                    true,
+                );
             }
             return true;
         }
@@ -841,7 +850,8 @@ impl World {
             self.colliders[col_handle].set_sensor(next.sensor);
         }
         if prev.rotation_locked != next.rotation_locked {
-            self.bodies[rb_handle].set_locked_axes(
+            let rb = &mut self.bodies[rb_handle];
+            rb.set_locked_axes(
                 if next.rotation_locked {
                     LockedAxes::ROTATION_LOCKED
                 } else {
@@ -849,6 +859,14 @@ impl World {
                 },
                 true,
             );
+            // Locking only zeroes the effective inverse inertia, so an already
+            // spinning body would keep its angular velocity and rotate forever.
+            // Standing a tumbling body up is the whole point of turning the
+            // lock on mid-run (hot-reloading `|> Physics.upright` onto a live
+            // capsule), so cancel the spin too.
+            if next.rotation_locked {
+                rb.set_angvel(Vector::ZERO, true);
+            }
         }
         // `authority` is inert in Phase 1: cached (by reconcile) but never
         // written to the live world.
@@ -1352,6 +1370,66 @@ mod tests {
         assert_eq!(w.step_frame(1.0), MAX_SUBSTEPS_PER_FRAME);
         // Backlog was dropped: a normal frame takes exactly one substep again.
         assert_eq!(w.step_frame(FIXED_DT), 1);
+    }
+
+    // Angular velocity is not declarable and has no command, so these tests
+    // reach into the live body directly.
+    fn spin_up(w: &mut World, tag: &str, angvel: [f32; 3]) {
+        let (rb, _) = w.tags[tag];
+        w.bodies[rb].set_angvel(Vector::new(angvel[0], angvel[1], angvel[2]), true);
+    }
+
+    fn spin_of(w: &World, tag: &str) -> f32 {
+        let (rb, _) = w.tags[tag];
+        w.bodies[rb].angvel().length()
+    }
+
+    // An upright body must not tip. Locking the axes stops the solver from
+    // ACCUMULATING spin, but it does not cancel spin already present -- so
+    // switching the lock on (hot-reloading `|> Physics.upright` onto a live,
+    // tumbling capsule) has to zero the angular velocity too, or the body
+    // rotates forever at a fixed rate.
+    #[test]
+    fn turning_upright_on_cancels_existing_spin() {
+        let mut w = World::new([0.0, 0.0, 0.0]);
+        w.reconcile(&scene(vec![crate_at("a", [0.0, 5.0, 0.0])]));
+        spin_up(&mut w, "a", [0.0, 4.0, 0.0]);
+        assert!(spin_of(&w, "a") > 1.0, "spin was not set up");
+
+        // Re-declare the SAME body as upright: the ordinary reconcile path.
+        w.reconcile(&scene(vec![crate_at("a", [0.0, 5.0, 0.0]).as_upright()]));
+        assert_eq!(spin_of(&w, "a"), 0.0);
+        for _ in 0..30 {
+            w.step_fixed();
+        }
+        assert_eq!(spin_of(&w, "a"), 0.0, "an upright body regained spin");
+    }
+
+    // The same through the STRUCTURAL rebuild path: a mass change despawns and
+    // respawns the body, then restores its live velocities -- which must not
+    // hand the old spin back to a now-locked body.
+    #[test]
+    fn an_upright_body_rebuilt_structurally_does_not_regain_spin() {
+        let mut w = World::new([0.0, 0.0, 0.0]);
+        w.reconcile(&scene(vec![crate_at("a", [0.0, 5.0, 0.0])]));
+        spin_up(&mut w, "a", [0.0, 4.0, 0.0]);
+        assert!(spin_of(&w, "a") > 1.0);
+
+        w.reconcile(&scene(vec![crate_at("a", [0.0, 5.0, 0.0])
+            .as_upright()
+            .with_mass(2.0)]));
+        assert_eq!(spin_of(&w, "a"), 0.0);
+    }
+
+    // A body that is NOT upright keeps its spin across a structural rebuild --
+    // the pre-existing behavior the fix above must leave alone.
+    #[test]
+    fn a_free_body_keeps_its_spin_across_a_rebuild() {
+        let mut w = World::new([0.0, 0.0, 0.0]);
+        w.reconcile(&scene(vec![crate_at("a", [0.0, 5.0, 0.0])]));
+        spin_up(&mut w, "a", [0.0, 4.0, 0.0]);
+        w.reconcile(&scene(vec![crate_at("a", [0.0, 5.0, 0.0]).with_mass(2.0)]));
+        assert!(spin_of(&w, "a") > 1.0);
     }
 
     #[test]


### PR DESCRIPTION
## The question

Does Functor need a **`postTick` hook** (after the physics step, before `draw`), or do `tick` + the newly-merged synchronous queries (`Physics.linearVelocity` / `cast` / `castExcluding`, #492) suffice for a real character controller on the `physics` hook?

The jam's 3D platformer (`examples/platformer`) chose hand-rolled kinematics and cited physics-read staleness plus the missing sync queries. Both of those are now resolved, so this PR settles the remaining question by **building the thing and measuring it**.

## Visuals

![physics-controller demo](https://gist.githubusercontent.com/tommy-xr/f7ab974129c01b324c7f95116c6d19c3/raw/physics-controller.gif)

<sub>The scripted `ride-and-jump.input` run, sampled every 12 sim frames: the capsule falls onto the moving deck, rides it, walks off the edge, lands on the plaza, jumps, and runs into the wall. Rendered headlessly frame-by-frame via `--input-script` + `--capture-at-frame` (each frame replays deterministically from frame 0).</sub>

![riding the deck at frame 60](https://gist.githubusercontent.com/tommy-xr/f7ab974129c01b324c7f95116c6d19c3/raw/physics-controller-f60.png)

<sub>Frame 60 — riding the kinematic deck: `on deck yes`, `carry vx 1.99`.</sub>

**Before → after: `Physics.upright`**

![Physics.upright before and after](https://gist.githubusercontent.com/tommy-xr/f7ab974129c01b324c7f95116c6d19c3/raw/physics-controller-upright-beforeafter.png)

<sub>Both at sim frame 140, mid-jump. **Before** (the `Physics.upright` line deleted from the player body): the capsule has toppled ~40° off vertical — and a tipped capsule's lowest point is no longer `feetOffset` below its center, so the grounding probe and the ground clamp both start lying. **After** (this PR): it stays upright.</sub>

## Verdict: no `postTick` hook

Every mechanic a platformer needs is CLEAN on the `physics` hook using only `tick`. The two genuine gaps the exercise surfaced are both one-line API surface, not frame ordering — and neither would have been fixed by `postTick`.

## What's here

- **`examples/physics-controller/`** — a platformer character controller whose character is a real dynamic capsule in the `physics` hook, steered entirely from `tick`. Grounding probe, coyote time, jump buffering, landing squash, a moving kinematic deck it rides, walls, edges. `control.fun` holds every decision as a pure function of an observation, so the feel layer is covered by `expect`s with no GPU and no rapier world.
- **`Physics.upright`** — a new body attribute (see "the impossible one" below).
- **A "character controllers on the physics hook" section** in the `functor-lang` skill, including a correction: the skill's existing controller sketch contained one of the three traps.

## Evidence, mechanic by mechanic

Measured from the committed 400-frame scripted run (`ride-and-jump.input`, `--script-dt 0.0166667`). Rest height is 0.90 above the surface; the plaza's top is `y = 0` and the deck's `y = 1.25`.

| Mechanic | Verdict | Evidence |
| --- | --- | --- |
| Grounded detection (`castExcluding`) | **CLEAN** | Flips at exactly the five expected frames (11, 102, 121, 133, 169); no seam flicker across 400 frames. |
| Jump | **CLEAN** | Apex rise 1.1612 vs. theoretical `v²/2g` = 1.1782 (98.6%). |
| Coyote time | **CLEAN** | Off the deck at f=102; drains 0.1033 → 0.0000 over f=102–109, exactly the 0.12 s window. |
| Jump buffering | **CLEAN** | A press while airborne fires on the touchdown frame. |
| Landing / squash | **CLEAN** | Fires once per touchdown as an edge (f=11, 121, 169), never as a level. |
| Riding the moving platform | **CLEAN** | Tracks the deck's analytic velocity to within 0.030 on a 2.4 u/s deck; relative offset bounded at −0.48 ± 0.02 over 80 frames, non-accumulating. |
| Wall | **CLEAN, and free** | Stopped at `x = −6.3012` vs. a predicted −6.3000, with `x` and `z` constant to four decimals from f=260 to f=399. Zero collision code in the game. |
| Edge fall-off | **CLEAN, and free** | Walking off simply stops being grounded. |
| Standing height | **CLEAN, with a caveat** | A constant 0.8988. Needed a ground clamp, a post-jump lockout, and `Physics.upright`. |
| Keeping the capsule upright | **WAS IMPOSSIBLE — fixed here** | See below. |

Both runs of the scripted script produced identical traces and a **byte-identical capture PNG**, so determinism under physics holds.

## The one thing that was genuinely impossible

**A dynamic capsule could not be kept upright.** No rotation lock, angular damping, or angular-velocity command existed anywhere in `Physics`. Measured: ~40° off vertical mid-jump, then creeping 0.19 units along `z` while leaning on the wall with no input, still accelerating. It also silently corrupted the controller — a tipped capsule's lowest point is `radius + halfHeight·cos θ` below its center, not the fixed `feetOffset` the probe and clamp assume, which showed up as a ±0.031 standing-height ripple.

`Physics.upright` is the smallest fix: a nullary body attribute shaped exactly like `Physics.sensor`, mapping to rapier's `LockedAxes::ROTATION_LOCKED`, applied at spawn and on reconcile. **Off by default**, so existing bodies tumble as before. With it, standing height is a constant 0.8988 and the wall contact is motionless in both axes.

## Why not `postTick`

The argument for it is reacting to a physics outcome one frame sooner. Measured against real landings, that argument inverts:

- Deck landing: probe reported grounded at **f=11**, feet still **0.137 above** the surface. Contact resolved f=13–14.
- Plaza landing: grounded at **f=121**, feet **0.085 above**. Contact f=122.

The landing response already fires **1–3 frames *before* physical contact**, because the grounding probe reaches ahead by `probeSkin`. A `postTick` would fire it one frame earlier still — *further* from contact, not closer. **The sign of the dominant error term is opposite to what `postTick` corrects**, and `probeSkin` is a single game-owned constant giving finer control than a hook could.

The rest doesn't survive the API either: anything purely visual can already read the fresh post-step world in `draw` (this example's camera does); post-step events already arrive via `Physics.events`; and since a controller is a closed loop, `postTick` would read fresher but its commands would wait a full frame (the write asymmetry) — worse, since input arrives pre-step.

**The two real gaps** are `Physics.upright` (fixed here) and the fact that `Physics.setVelocity` is all-or-nothing across three axes, which is what forced the ground clamp to be hand-written. A per-axis velocity command would remove both sinking failure modes; still open, and far smaller than a lifecycle hook.

## The three traps (now documented + regression-tested)

All three come from `setVelocity` replacing all three components, and all three were *observed*, not theorized:

1. **Echoing the read back sank the capsule half a unit into the floor** (rested at 0.40 instead of 0.90) — the read is one step stale and still carries the velocity the solver just cancelled. It also made the wall stop land 0.45 units early.
2. **Commanding `0` while grounded still sank it**, slower (0.98 → 0.40 over 260 frames) — overwriting `vy` destroys the contact's pushout impulse. Fix: a ground clamp driven by the probe's `distance`.
3. **The ground clamp then cancelled the jump** — the feet are still in probe range just after takeoff, so it rose 0.12 units instead of 1.16. Fix: a short post-jump lockout.

## Verification

- `functor -d examples/physics-controller test` — 39 expects pass
- `cargo test -p functor_runtime_common` — 504 pass, including the `.funi`↔registry drift test
- `npm run check:docs` — passes
- 400-frame scripted run byte-identical across two runs

## Review

Two `xreview` rounds (Claude subagent + Codex CLI in parallel), both with the media attached.

**Round 1** (against the example). Both engines **independently raised the capsule-rotation defect** — the [AGREED] High finding, and the one genuinely impossible item, now fixed by `Physics.upright`. Also dispositioned: the vacuous `squashScale` expect and the negative-impact stretch (fixed + new expect), the unguarded `error / dt` under `--fixed-time` (fixed + new expect), the respawn clearing the `started` gate (fixed), ENTER lacking a rising edge (fixed), the eagerly-built trace row (now lazy), dead `noTag` and the occluded nose sphere (removed), and two README counting errors (corrected).

**Round 2** (against the `Physics.upright` commit). Both engines again converged on the same two Medium findings, both real and both fixed in `ac13ef4`:

- **Enabling the lock did not cancel spin already present.** Rapier's `set_locked_axes` only zeroes the effective inverse inertia; the solver integrates `angvel` raw. So a body that was already tumbling kept tumbling forever — precisely the adoption path the docs prescribe, since the physics world survives hot reload and the natural fix is to add `|> Physics.upright` to a live game. The structural-rebuild path had the same hole. Both now zero `angvel` when the body is upright, pinned by three world-level tests including a negative control.
- **ENTER's respawn was immediately undone.** `input` queued the teleport, then the same frame's `tick` queued `setVelocity(want)`; commands apply in queue order, and `want.y` was the *pre-teleport* fall speed. ENTER now records intent and `tick` performs it. Verified: ENTER at frame 140 while rising at `vy = +3.9` now arrives at spawn with `vy = -0.367`.

Round 2 also correctly caught two overstated claims (the lazy trace row still allocates a closure; the tilt is 40–80° not ~40°) — both corrected in the prose. **No findings left open.**

## Promotion

`examples/physics-controller` is **sample-quality and worth promoting**: it is the missing counterpart to `examples/platformer` (authored-feel kinematics vs. a solver-driven body), it needs no assets, and it is fully verifiable headlessly. It is proposed here as a real example rather than a scratch project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


