### PR TITLE
feat(functor-lang): add >=, <=, and != comparison operators

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -97,6 +97,8 @@ let label = $"score: {threshold}; {{ready}}"  // interpolation: `$"…"` with fu
 let flag = true                               // bools
 
 let isHigh = (score: float): bool => score > threshold   // annotations OPTIONAL (gradual)
+let inRange = (n: float): bool => n >= 0.0 && n <= 1.0   // `<=` `>=` `!=` are ordinary
+let changed = (a: float, b: float): bool => a != b       //   comparisons (no `<>`)
 let describe = (score) => $"score: {score}"
 
 let report = (scores) =>
@@ -128,12 +130,17 @@ let sum3 = (a, b, c) =>
 let main = () => report([12.0, 3.5, 40.0])    // zero-param main is run's entry point
 ```
 
-Operators: `+ - * /` `< > ==` (conventional precedence; pipelines bind
-loosest), unary `-`, and the **short-circuiting booleans** `&&` / `||` plus
-prefix `not`. That list is EXHAUSTIVE — there is **no `>=`, `<=`, `!=`, `<>`,
-`%`, or `^`**. Writing `x >= 0.0` is a parse error (`` expected an
-expression, found `=` ``); spell it `not (x < 0.0)`, and inequality as
-`not (a == b)`.
+Operators: `+ - * /` `< > <= >= == !=` (conventional precedence; pipelines
+bind loosest), unary `-`, and the **short-circuiting booleans** `&&` / `||`
+plus prefix `not`. That list is EXHAUSTIVE — there is **no `<>`, `%`, or
+`^`**. Inequality is `!=` ONLY; F#'s `<>` is not an alias (it lexes as `<`
+then `>` and fails as an ordinary parse error), and bare `!` is not prefix
+negation (that stays `not`) — `!` exists only as part of `!=`.
+`<=`/`>=` are valid wherever `<`/`>` are (both operands must be `float`),
+and `!=` is the exact NEGATION of `==`: same operand rules, same errors on
+the same inputs — comparing functions with `!=` is the same check-time
+rejection (`` functions cannot be compared with `!=` ``), and host/engine
+values are the same runtime error.
 Modulo is `Math.mod(a, b)` and exponentiation `Math.pow(base, exp)`.
 Precedence (tightest→loosest): comparisons > `not` > `&&` > `||`
 > pipelines. So `not a == b` is `not (a == b)`, `a || b && c` is
@@ -416,7 +423,12 @@ that's what `functor test` is for.
   a *top-level initializer* may only demand globals defined above it.
 - **Equality `==` is structural**; comparing functions is rejected at
   CHECK time (`` functions cannot be compared with `==` ``), not just at
-  run time.
+  run time. `!=` behaves identically in every respect — it IS `==`
+  negated, so it rejects the same operands with the same (reworded)
+  errors.
+- **Comparisons are IEEE**, so NaN (`0.0 / 0.0`) is false against
+  everything — including itself — under `<`, `>`, `<=`, `>=`, and `==`;
+  `nan != nan` is therefore `true`.
 - **Division is IEEE** (`1.0/0.0` = `inf`); the engine boundary rejects
   non-finite numbers.
 - **Greedy match arms**: arm bodies are full expressions, so a nested

--- a/docs/functor-lang.md
+++ b/docs/functor-lang.md
@@ -333,6 +333,20 @@ snapshots — no GPU, fully agent-verifiable.
       velocities stored in the model survive hot-reload time travel.
       Component accessors and vector math (`Vec3.add`/`scale`/`length`, and
       Vec2/Vec4) are deliberately deferred until an API returns a Vec3.
+- [x] **`>=` / `<=` / `!=` comparison operators** (2026-07-26; game-jam gap
+      track). Every one of the seven jam entries hit the missing set, and two
+      bugs in the racer traced directly to the `not (a > b)` workaround it
+      forced. The three operators join `<`/`>`/`==` at the SAME precedence
+      level, with no other semantics invented: `<=`/`>=` are ordinary float
+      comparisons (IEEE, so every NaN comparison is false), and `!=` is the
+      exact negation of `==` — the same structural walk, so it rejects
+      functions at check time and host values at run time on exactly the
+      inputs `==` does, with the operator the source wrote named in the
+      message. Deliberately NOT added: F#'s `<>` (inequality is `!=` only;
+      `<>` stays an ordinary parse error) and prefix `!` (negation stays
+      `not`; `!` exists only inside `!=`). Because `>=` lexes as one token,
+      the parser splits it back apart at its two generic-close sites, so a
+      space-free `type Box<'v>= …` / `List<float>= …` still parses.
 - [x] **Prelude go-to-definition + hover docs** (2026-07-18; prelude-infra
       track). Go-to-definition on a host external (`Scene.cube`) jumps into
       its `.funi` interface — the LSP materializes the embedded prelude to a

--- a/functor-lang/src/ast.rs
+++ b/functor-lang/src/ast.rs
@@ -315,7 +315,31 @@ pub enum BinOp {
     Div,
     Lt,
     Gt,
+    Le,
+    Ge,
     Eq,
+    /// `!=` — the exact negation of [`BinOp::Eq`]: same operand rules, same
+    /// errors on the same inputs.
+    Ne,
+}
+
+impl BinOp {
+    /// The operator's source spelling — the single source of truth for
+    /// diagnostics in the typechecker and the interpreter.
+    pub fn symbol(self) -> &'static str {
+        match self {
+            BinOp::Add => "+",
+            BinOp::Sub => "-",
+            BinOp::Mul => "*",
+            BinOp::Div => "/",
+            BinOp::Lt => "<",
+            BinOp::Gt => ">",
+            BinOp::Le => "<=",
+            BinOp::Ge => ">=",
+            BinOp::Eq => "==",
+            BinOp::Ne => "!=",
+        }
+    }
 }
 
 /// The short-circuiting boolean operators. `And` binds tighter than `Or`;

--- a/functor-lang/src/eval.rs
+++ b/functor-lang/src/eval.rs
@@ -780,7 +780,13 @@ impl Interp<'_> {
         use crate::ast::BinOp;
         let env = Env::empty();
         if let ExprKind::Binary {
-            op: op @ (BinOp::Eq | BinOp::Lt | BinOp::Gt),
+            op:
+                op @ (BinOp::Eq
+                | BinOp::Ne
+                | BinOp::Lt
+                | BinOp::Gt
+                | BinOp::Le
+                | BinOp::Ge),
             lhs,
             rhs,
         } = &expect.expr.kind
@@ -797,11 +803,7 @@ impl Interp<'_> {
                 Ok(Value::Bool(true)) => ExpectOutcome::Pass,
                 // Comparisons only produce bools, so anything else is false.
                 Ok(_) => ExpectOutcome::Fail(Some(FailedCompare {
-                    op: match op {
-                        BinOp::Eq => "==",
-                        BinOp::Lt => "<",
-                        _ => ">",
-                    },
+                    op: op.symbol(),
                     lhs: l.to_string(),
                     rhs: r.to_string(),
                 })),
@@ -1344,15 +1346,23 @@ evaluation depth."
             BinOp::Div => self.arith(lhs, rhs, span, |a, b| a / b),
             BinOp::Lt => self.compare(lhs, rhs, span, |a, b| a < b),
             BinOp::Gt => self.compare(lhs, rhs, span, |a, b| a > b),
-            BinOp::Eq => {
+            // IEEE ordering, like `<`/`>`: every comparison with NaN is false.
+            BinOp::Le => self.compare(lhs, rhs, span, |a, b| a <= b),
+            BinOp::Ge => self.compare(lhs, rhs, span, |a, b| a >= b),
+            // `!=` is the exact negation of `==`: the SAME structural walk,
+            // so it errors on functions/host values on exactly the inputs
+            // `==` does (and `NaN != NaN` is true, since `NaN == NaN` is
+            // false — the IEEE behaviour `<`/`<=` already have).
+            BinOp::Eq | BinOp::Ne => {
                 // Charge AFTER the walk (the count isn't known up front):
                 // one comparison can overshoot the budget by at most the
                 // value's size — itself budget-bounded to build — so total
                 // work stays O(budget).
                 let mut compared = 0u64;
-                let eq = value_eq(&lhs, &rhs, span, &mut compared)?;
+                let negated = matches!(op, BinOp::Ne);
+                let eq = value_eq(&lhs, &rhs, span, &mut compared, op.symbol())?;
                 self.charge(compared, span)?;
-                Ok(Value::Bool(eq))
+                Ok(Value::Bool(eq != negated))
             }
         }
     }
@@ -2225,7 +2235,15 @@ fn pattern_binder_sites<'a>(pattern: &'a Pattern, out: &mut Vec<(BindingId, &'a 
 /// recursion limit), and this runs inside editor/tooling processes where a
 /// stack overflow is a host crash. Pairs push in reverse so comparison
 /// order stays left-to-right (first mismatch/error is the leftmost).
-fn value_eq(a: &Value, b: &Value, span: Span, compared: &mut u64) -> Result<bool, RunError> {
+fn value_eq(
+    a: &Value,
+    b: &Value,
+    span: Span,
+    compared: &mut u64,
+    // The operator being evaluated (`==` or `!=`) — errors name the one the
+    // source actually wrote.
+    op: &str,
+) -> Result<bool, RunError> {
     /// Pending work. `MissingField` stands in for a record field whose name
     /// the other record lacks — pushed IN POSITION so the not-equal verdict
     /// lands in field order (an earlier field's function-comparison error
@@ -2301,13 +2319,13 @@ fn value_eq(a: &Value, b: &Value, span: Span, compared: &mut u64) -> Result<bool
                 | Value::Ctor { .. },
             ) => {
                 return Err(RunError {
-                    message: "functions cannot be compared with `==`".to_string(),
+                    message: format!("functions cannot be compared with `{op}`"),
                     span,
                 })
             }
             (Value::HostData(_), _) | (_, Value::HostData(_)) => {
                 return Err(RunError {
-                    message: "host values cannot be compared with `==`".to_string(),
+                    message: format!("host values cannot be compared with `{op}`"),
                     span,
                 })
             }
@@ -2853,7 +2871,7 @@ mod deep_value_tests {
                 let text = deep.to_string();
                 assert!(text.starts_with("[[[[") && text.len() > 400_000);
                 let mut compared = 0u64;
-                let same = value_eq(&deep, &deep.clone(), Span::new(0, 0), &mut compared)
+                let same = value_eq(&deep, &deep.clone(), Span::new(0, 0), &mut compared, "==")
                     .expect("comparable");
                 assert!(same);
                 assert!(compared > 200_000);

--- a/functor-lang/src/lexer.rs
+++ b/functor-lang/src/lexer.rs
@@ -44,6 +44,7 @@ pub enum TokenKind {
     DotDot,
     Eq,
     EqEq,
+    BangEq,
     FatArrow,
     PipeGt,
     PipePipe,
@@ -55,6 +56,8 @@ pub enum TokenKind {
     Slash,
     Lt,
     Gt,
+    LtEq,
+    GtEq,
     Eof,
 }
 
@@ -103,6 +106,7 @@ pub fn describe(kind: &TokenKind) -> String {
         DotDot => "`..`".to_string(),
         Eq => "`=`".to_string(),
         EqEq => "`==`".to_string(),
+        BangEq => "`!=`".to_string(),
         FatArrow => "`=>`".to_string(),
         PipeGt => "`|>`".to_string(),
         PipePipe => "`||`".to_string(),
@@ -114,6 +118,8 @@ pub fn describe(kind: &TokenKind) -> String {
         Slash => "`/`".to_string(),
         Lt => "`<`".to_string(),
         Gt => "`>`".to_string(),
+        LtEq => "`<=`".to_string(),
+        GtEq => "`>=`".to_string(),
         Eof => "end of input".to_string(),
     }
 }
@@ -229,13 +235,34 @@ fn lex_with_interpolation_depth(
                 i += 1;
                 TokenKind::Slash
             }
-            b'<' => {
-                i += 1;
-                TokenKind::Lt
-            }
-            b'>' => {
-                i += 1;
-                TokenKind::Gt
+            // `<=` / `>=` are single tokens. A generic close immediately
+            // followed by `=` (`List<float>= …`) therefore lexes as `>=`; the
+            // parser splits it back apart at its two generic-close sites.
+            b'<' => match bytes.get(i + 1) {
+                Some(b'=') => {
+                    i += 2;
+                    TokenKind::LtEq
+                }
+                _ => {
+                    i += 1;
+                    TokenKind::Lt
+                }
+            },
+            b'>' => match bytes.get(i + 1) {
+                Some(b'=') => {
+                    i += 2;
+                    TokenKind::GtEq
+                }
+                _ => {
+                    i += 1;
+                    TokenKind::Gt
+                }
+            },
+            // `!` exists ONLY as `!=`; bare `!` falls through to the
+            // unexpected-character error (prefix negation is `not`).
+            b'!' if bytes.get(i + 1) == Some(&b'=') => {
+                i += 2;
+                TokenKind::BangEq
             }
             b'=' => match bytes.get(i + 1) {
                 Some(b'=') => {

--- a/functor-lang/src/parser.rs
+++ b/functor-lang/src/parser.rs
@@ -147,6 +147,31 @@ impl Parser {
         }
     }
 
+    /// Close a generic argument list (`Box<'a>`, `List<float>`). Because `>=`
+    /// lexes as ONE token, a space-free `type Box<'a>= …` / `let xs:
+    /// List<float>= …` arrives here as `>=` — split it, consuming the `>` and
+    /// leaving an `=` in the stream for the caller.
+    fn expect_generic_close(&mut self) -> Result<Token, ParseError> {
+        if self.peek_kind() == &TokenKind::GtEq {
+            let span = self.peek().span;
+            self.tokens[self.pos] = Token {
+                kind: TokenKind::Eq,
+                span: Span::new(span.start + 1, span.end),
+            };
+            return Ok(Token {
+                kind: TokenKind::Gt,
+                span: Span::new(span.start, span.start + 1),
+            });
+        }
+        self.expect(TokenKind::Gt, "`,` or `>`")
+    }
+
+    /// Whether the cursor sits on a generic close — including the `>=` that a
+    /// space-free `>` + `=` lexes as (see [`Self::expect_generic_close`]).
+    fn at_generic_close(&self) -> bool {
+        matches!(self.peek_kind(), TokenKind::Gt | TokenKind::GtEq)
+    }
+
     fn expect_ident(&mut self, expected: &str) -> Result<(String, Span), ParseError> {
         match self.peek_kind() {
             TokenKind::Ident(name) => {
@@ -297,14 +322,14 @@ rebind surface); `mut` is for `let mut … in …` inside a function"
                 params.push(param);
                 if self.peek_kind() == &TokenKind::Comma {
                     self.bump();
-                    if self.peek_kind() == &TokenKind::Gt {
+                    if self.at_generic_close() {
                         break; // trailing comma
                     }
                 } else {
                     break;
                 }
             }
-            end_span = self.expect(TokenKind::Gt, "`,` or `>`")?.span;
+            end_span = self.expect_generic_close()?.span;
         }
         // No `= body` → an ABSTRACT type: an opaque nominal (`type SceneNode`),
         // no fields or constructors — host code produces/consumes its values.
@@ -550,14 +575,14 @@ rebind surface); `mut` is for `let mut … in …` inside a function"
                 args.push(self.type_name()?);
                 if self.peek_kind() == &TokenKind::Comma {
                     self.bump();
-                    if self.peek_kind() == &TokenKind::Gt {
+                    if self.at_generic_close() {
                         break; // trailing comma
                     }
                 } else {
                     break;
                 }
             }
-            let close = self.expect(TokenKind::Gt, "`,` or `>`")?;
+            let close = self.expect_generic_close()?;
             span = span.to(close.span);
         }
         Ok(TypeName { name, args, span })
@@ -1061,7 +1086,14 @@ and an `else` branch)",
     fn comparison(&mut self) -> Result<Expr, ParseError> {
         use TokenKind::*;
         self.left_assoc(
-            &[(Lt, BinOp::Lt), (Gt, BinOp::Gt), (EqEq, BinOp::Eq)],
+            &[
+                (Lt, BinOp::Lt),
+                (Gt, BinOp::Gt),
+                (LtEq, BinOp::Le),
+                (GtEq, BinOp::Ge),
+                (EqEq, BinOp::Eq),
+                (BangEq, BinOp::Ne),
+            ],
             Self::additive,
         )
     }

--- a/functor-lang/src/parser.rs
+++ b/functor-lang/src/parser.rs
@@ -25,7 +25,8 @@
 //! tuplePat  := "(" subpat ("," subpat)+ ","? ")"
 //! subpat    := "_" | lowerIdent
 //! pipeline  := cmp ("|>" cmp)*
-//! cmp       := add (("<" | ">" | "==") add)*        (left-assoc)
+//! cmp       := add (("<" | ">" | "<=" | ">=" | "==" | "!=") add)*
+//!                                                   (left-assoc)
 //! add       := mul (("+" | "-") mul)*               (left-assoc)
 //! mul       := unary (("*" | "/") unary)*           (left-assoc)
 //! unary     := "-" unary | postfix
@@ -148,16 +149,36 @@ impl Parser {
     }
 
     /// Close a generic argument list (`Box<'a>`, `List<float>`). Because `>=`
-    /// lexes as ONE token, a space-free `type Box<'a>= …` / `let xs:
-    /// List<float>= …` arrives here as `>=` — split it, consuming the `>` and
-    /// leaving an `=` in the stream for the caller.
+    /// lexes as ONE token, a space-free generic close followed by `=` arrives
+    /// here as `>=`: split it, consuming the `>` and putting what remains back
+    /// in the stream for the caller. Two shapes reach this, and both are real
+    /// grammar — `type Box<'a>= …` / `let xs: List<float>= …` leave an `=`,
+    /// and a return annotation (`(xs): List<float>=> xs`, lexed `>=` then `>`)
+    /// leaves a `=>` reassembled from the halves.
     fn expect_generic_close(&mut self) -> Result<Token, ParseError> {
         if self.peek_kind() == &TokenKind::GtEq {
             let span = self.peek().span;
-            self.tokens[self.pos] = Token {
-                kind: TokenKind::Eq,
-                span: Span::new(span.start + 1, span.end),
+            // A `>` sitting immediately after the `>=` means the source wrote
+            // `>=>`: the leftover `=` and that `>` are one fat arrow.
+            let arrow_end = self
+                .tokens
+                .get(self.pos + 1)
+                .filter(|next| next.kind == TokenKind::Gt && next.span.start == span.end)
+                .map(|next| next.span.end);
+            let rest = match arrow_end {
+                Some(end) => {
+                    self.tokens.remove(self.pos + 1);
+                    Token {
+                        kind: TokenKind::FatArrow,
+                        span: Span::new(span.start + 1, end),
+                    }
+                }
+                None => Token {
+                    kind: TokenKind::Eq,
+                    span: Span::new(span.start + 1, span.end),
+                },
             };
+            self.tokens[self.pos] = rest;
             return Ok(Token {
                 kind: TokenKind::Gt,
                 span: Span::new(span.start, span.start + 1),

--- a/functor-lang/src/types.rs
+++ b/functor-lang/src/types.rs
@@ -2413,7 +2413,7 @@ is {other}"
             // errors. `!=` is the exact negation, so it shares every rule
             // here; only the diagnostics' operator and certain verdict differ.
             BinOp::Eq | BinOp::Ne => {
-                let sym = op_str(op);
+                let sym = op.symbol();
                 let certain = if matches!(op, BinOp::Ne) {
                     "always true"
                 } else {
@@ -2520,14 +2520,14 @@ is {other}"
                 &ty,
                 &Type::Float,
                 span,
-                &format!("`{}` operand", op_str(op)),
+                &format!("`{}` operand", op.symbol()),
             );
             return;
         }
         if !compatible(&ty, &Type::Float) {
             self.diag(
                 span,
-                format!("`{}` needs float operands, got {ty}", op_str(op)),
+                format!("`{}` needs float operands, got {ty}", op.symbol()),
             );
         }
     }
@@ -2572,8 +2572,4 @@ fn is_effect_seam(ty: &Type) -> bool {
             .is_some_and(|(module, _)| module == "Effect"),
         _ => false,
     }
-}
-
-fn op_str(op: BinOp) -> &'static str {
-    op.symbol()
 }

--- a/functor-lang/src/types.rs
+++ b/functor-lang/src/types.rs
@@ -2400,7 +2400,7 @@ is {other}"
                 self.require_float(op, rhs, rhs_span);
                 Type::Float
             }
-            BinOp::Lt | BinOp::Gt => {
+            BinOp::Lt | BinOp::Gt | BinOp::Le | BinOp::Ge => {
                 self.require_float(op, lhs, lhs_span);
                 self.require_float(op, rhs, rhs_span);
                 Type::Bool
@@ -2410,8 +2410,15 @@ is {other}"
             // known types cannot be equal always yield `false`. Runtime
             // equality is STRUCTURAL, so two same-shaped nominal record types
             // may legitimately compare — only differing declared shapes are
-            // errors.
-            BinOp::Eq => {
+            // errors. `!=` is the exact negation, so it shares every rule
+            // here; only the diagnostics' operator and certain verdict differ.
+            BinOp::Eq | BinOp::Ne => {
+                let sym = op_str(op);
+                let certain = if matches!(op, BinOp::Ne) {
+                    "always true"
+                } else {
+                    "always false"
+                };
                 let (lhs, rhs) = (&self.zonk(lhs), &self.zonk(rhs));
                 // A known function on EITHER side is a certain runtime error
                 // regardless of the other side — check before variables get
@@ -2419,7 +2426,7 @@ is {other}"
                 if contains_fn(lhs) || contains_fn(rhs) {
                     self.diag(
                         node_span,
-                        "functions cannot be compared with `==`".to_string(),
+                        format!("functions cannot be compared with `{sym}`"),
                     );
                     return Type::Bool;
                 }
@@ -2430,7 +2437,7 @@ is {other}"
                 free_vars_of(lhs, &mut vars);
                 free_vars_of(rhs, &mut vars);
                 if !vars.is_empty() {
-                    self.unify(lhs, rhs, node_span, "`==` operands");
+                    self.unify(lhs, rhs, node_span, &format!("`{sym}` operands"));
                     return Type::Bool;
                 }
                 match (lhs, rhs) {
@@ -2443,7 +2450,7 @@ is {other}"
                     _ if contains_fn(lhs) || contains_fn(rhs) => {
                         self.diag(
                             node_span,
-                            "functions cannot be compared with `==`".to_string(),
+                            format!("functions cannot be compared with `{sym}`"),
                         );
                     }
                     (Type::Record(x, xargs), Type::Record(y, yargs)) => {
@@ -2457,8 +2464,8 @@ is {other}"
                             self.diag(
                                 node_span,
                                 format!(
-                                    "`==` compares records with different shapes \
-                                     ({lhs} and {rhs}) — always false"
+                                    "`{sym}` compares records with different shapes \
+                                     ({lhs} and {rhs}) — {certain}"
                                 ),
                             );
                         }
@@ -2466,8 +2473,8 @@ is {other}"
                             self.diag(
                                 node_span,
                                 format!(
-                                    "`==` compares records with different shapes \
-                                     ({x} and {y}) — always false"
+                                    "`{sym}` compares records with different shapes \
+                                     ({x} and {y}) — {certain}"
                                 ),
                             );
                         }
@@ -2477,7 +2484,7 @@ is {other}"
                             self.diag(
                                 node_span,
                                 format!(
-                                    "`==` compares different types {lhs} and {rhs} (always false)"
+                                    "`{sym}` compares different types {lhs} and {rhs} ({certain})"
                                 ),
                             );
                         }
@@ -2568,13 +2575,5 @@ fn is_effect_seam(ty: &Type) -> bool {
 }
 
 fn op_str(op: BinOp) -> &'static str {
-    match op {
-        BinOp::Add => "+",
-        BinOp::Sub => "-",
-        BinOp::Mul => "*",
-        BinOp::Div => "/",
-        BinOp::Lt => "<",
-        BinOp::Gt => ">",
-        BinOp::Eq => "==",
-    }
+    op.symbol()
 }

--- a/functor-lang/tests/check.rs
+++ b/functor-lang/tests/check.rs
@@ -1534,6 +1534,60 @@ fn not_operand_must_be_bool() {
     assert_eq!(message, "`not` needs bool operands, got float");
 }
 
+// --- `>=` / `<=` / `!=` ---
+
+#[test]
+fn new_comparisons_check_clean() {
+    assert_clean(
+        "let atMost = (a: float, b: float): bool => a <= b\n\
+         let atLeast = (a: float, b: float): bool => a >= b\n\
+         let differs = (a: float, b: float): bool => a != b",
+    );
+}
+
+#[test]
+fn ordering_operands_must_be_float() {
+    // Same rule (and same message shape) as `<`/`>`.
+    let (message, _, _) = single_diag("let f = (s: string) => s <= 1.0");
+    assert_eq!(message, "`<=` needs float operands, got string");
+    let (message, _, _) = single_diag("let f = (s: string) => s >= 1.0");
+    assert_eq!(message, "`>=` needs float operands, got string");
+}
+
+#[test]
+fn inequality_rejects_functions_like_equality() {
+    // `==`'s check-time function rejection, inherited verbatim by `!=` —
+    // only the operator named in the message differs.
+    let (message, _, _) = single_diag("let f = (g: (float) => float) => g != g");
+    assert_eq!(message, "functions cannot be compared with `!=`");
+    let (message, _, _) = single_diag("let f = (g: (float) => float) => g == g");
+    assert_eq!(message, "functions cannot be compared with `==`");
+}
+
+#[test]
+fn inequality_on_different_types_is_certainly_true() {
+    // The `==` "always false" diagnostic, with `!=`'s inverted verdict.
+    let (message, _, _) = single_diag("let f = (s: string) => s != 1.0");
+    assert_eq!(
+        message,
+        "`!=` compares different types string and float (always true)"
+    );
+}
+
+#[test]
+fn new_comparisons_result_in_bool() {
+    let (message, _, _) = single_diag("let f = (a: float, b: float): float => a <= b");
+    assert!(
+        message.contains("bool") && message.contains("float"),
+        "unexpected: {message}"
+    );
+    let (message, _, _) = single_diag("let f = (a: float, b: float): float => a != b");
+    assert!(
+        message.contains("bool") && message.contains("float"),
+        "unexpected: {message}"
+    );
+}
+
 #[test]
 fn logical_result_is_bool() {
     // The `&&` result feeds a float context — the mismatch proves it typed

--- a/functor-lang/tests/parser.rs
+++ b/functor-lang/tests/parser.rs
@@ -643,6 +643,79 @@ fn bare_ampersand_is_a_lex_error() {
     assert_eq!(message, "unexpected character `&`");
 }
 
+// --- `>=` / `<=` / `!=` ---
+
+#[test]
+fn ordering_and_inequality_operators_parse() {
+    use functor_lang::ast::BinOp;
+    for (src, expected) in [
+        ("let v = a <= b", "<="),
+        ("let v = a >= b", ">="),
+        ("let v = a != b", "!="),
+    ] {
+        let ExprKind::Binary { op, .. } = parsed_value(src) else {
+            panic!("expected a comparison at the root of `{src}`");
+        };
+        assert_eq!(BinOp::symbol(op), expected);
+    }
+}
+
+#[test]
+fn new_comparisons_bind_like_the_old_ones() {
+    // Comparisons are looser than arithmetic and tighter than `&&`, exactly
+    // like `<`/`>`/`==`: `a + b <= c && d != e` is `((a+b) <= c) && (d != e)`.
+    use functor_lang::ast::LogicalOp;
+    let ExprKind::Logical {
+        op: LogicalOp::And,
+        lhs,
+        rhs,
+    } = parsed_value("let v = a + b <= c && d != e")
+    else {
+        panic!("expected an `&&` at the root");
+    };
+    let ExprKind::Binary { lhs: sum, .. } = lhs.kind else {
+        panic!("expected a comparison on the left of `&&`");
+    };
+    assert!(
+        matches!(sum.kind, ExprKind::Binary { .. }),
+        "expected `a + b` under the comparison, got {:?}",
+        sum.kind
+    );
+    assert!(matches!(rhs.kind, ExprKind::Binary { .. }));
+}
+
+#[test]
+fn not_is_looser_than_the_new_comparisons() {
+    // `not a != b` is `not (a != b)` — the same rule `==` has.
+    let ExprKind::Not(inner) = parsed_value("let v = not a != b") else {
+        panic!("expected a `not` at the root");
+    };
+    assert!(matches!(inner.kind, ExprKind::Binary { .. }));
+}
+
+#[test]
+fn generic_close_followed_immediately_by_eq_parses() {
+    // `>=` lexes as ONE token, so a space-free generic close (`Box<'v>=`,
+    // `List<float>=`) must be split back apart by the parser.
+    functor_lang::parse("type Box<'v>= { item: 'v }").unwrap();
+    functor_lang::parse("let xs: List<float>= [1.0]").unwrap();
+}
+
+#[test]
+fn bare_bang_is_a_lex_error() {
+    // `!` exists only as `!=`; prefix negation stays `not`.
+    let (message, _, _) = parse_err("let v = !a");
+    assert_eq!(message, "unexpected character `!`");
+}
+
+#[test]
+fn fsharp_inequality_is_not_an_operator() {
+    // `<>` is deliberately NOT aliased to `!=` — it lexes as `<` then `>`
+    // and fails as an ordinary unknown-operator parse error.
+    let (message, _, _) = parse_err("let v = a <> b");
+    assert_eq!(message, "expected an expression, found `>`");
+}
+
 // --- `if … then … else …` conditional expression ---
 
 #[test]

--- a/functor-lang/tests/parser.rs
+++ b/functor-lang/tests/parser.rs
@@ -702,6 +702,15 @@ fn generic_close_followed_immediately_by_eq_parses() {
 }
 
 #[test]
+fn generic_close_followed_immediately_by_a_fat_arrow_parses() {
+    // `>=>` lexes as `>=` then `>`: splitting the `>=` must REASSEMBLE the
+    // leftover `=` and that `>` into the lambda's fat arrow, not leave a bare
+    // `=`. A return annotation is where this shape occurs.
+    functor_lang::parse("let f = (xs: List<float>): List<float>=> xs").unwrap();
+    functor_lang::parse("let f = (x: Box<float>): Box<float>=> x").unwrap();
+}
+
+#[test]
 fn bare_bang_is_a_lex_error() {
     // `!` exists only as `!=`; prefix negation stays `not`.
     let (message, _, _) = parse_err("let v = !a");

--- a/functor-lang/tests/run.rs
+++ b/functor-lang/tests/run.rs
@@ -914,6 +914,113 @@ fn error_comparing_unapplied_ctors() {
     assert_eq!(message, "functions cannot be compared with `==`");
 }
 
+// --- `>=` / `<=` / `!=` ---
+
+#[test]
+fn ordering_operators_evaluate() {
+    for (src, expected) in [
+        ("1.0 <= 2.0", "true"),
+        ("2.0 <= 2.0", "true"),
+        ("3.0 <= 2.0", "false"),
+        ("3.0 >= 2.0", "true"),
+        ("2.0 >= 2.0", "true"),
+        ("1.0 >= 2.0", "false"),
+    ] {
+        assert_eq!(
+            main_result(&format!("let main = () => {src}")),
+            expected,
+            "{src}"
+        );
+    }
+}
+
+/// `<=` must agree with the pre-operator workaround (`not (a > b)`) on every
+/// ordering of two finite numbers — the gymnastics it replaces.
+#[test]
+fn ordering_operators_match_the_not_workaround() {
+    for (a, b) in [("1.0", "2.0"), ("2.0", "2.0"), ("3.0", "2.0")] {
+        assert_eq!(
+            main_result(&format!("let main = () => {a} <= {b}")),
+            main_result(&format!("let main = () => not ({a} > {b})")),
+            "{a} <= {b}"
+        );
+        assert_eq!(
+            main_result(&format!("let main = () => {a} >= {b}")),
+            main_result(&format!("let main = () => not ({a} < {b})")),
+            "{a} >= {b}"
+        );
+    }
+}
+
+/// `!=` is the exact negation of `==` — same structural walk, so the pair is
+/// tested together on every value shape (and `not (a == b)`, the workaround,
+/// agrees).
+#[test]
+fn inequality_is_the_exact_negation_of_equality() {
+    for src in [
+        "1.0",
+        "\"a\"",
+        "true",
+        "[1.0, 2.0]",
+        "(1.0, \"a\")",
+        "{ x: 1.0 }",
+    ] {
+        for other in [
+            "1.0",
+            "\"a\"",
+            "true",
+            "[1.0, 2.0]",
+            "(1.0, \"a\")",
+            "{ x: 1.0 }",
+            "2.0",
+        ] {
+            let eq = main_result(&format!("let main = () => {src} == {other}"));
+            let ne = main_result(&format!("let main = () => {src} != {other}"));
+            let workaround = main_result(&format!("let main = () => not ({src} == {other})"));
+            assert_ne!(eq, ne, "{src} vs {other}");
+            assert_eq!(ne, workaround, "{src} vs {other}");
+        }
+    }
+}
+
+/// NaN is representable (`0.0 / 0.0` — division is IEEE), and every operator
+/// treats it exactly as IEEE does: `==` false, `!=` true, all four orderings
+/// false. Tested as a pair so the `==`/`!=` symmetry is pinned.
+#[test]
+fn nan_comparisons_follow_ieee() {
+    const NAN: &str = "let nan = 0.0 / 0.0\n";
+    for (src, expected) in [
+        ("nan == nan", "false"),
+        ("nan != nan", "true"),
+        ("nan < nan", "false"),
+        ("nan > nan", "false"),
+        ("nan <= nan", "false"),
+        ("nan >= nan", "false"),
+        ("nan <= 1.0", "false"),
+        ("nan >= 1.0", "false"),
+    ] {
+        assert_eq!(
+            main_result(&format!("{NAN}let main = () => {src}")),
+            expected,
+            "{src}"
+        );
+    }
+}
+
+/// The operand rules are inherited unchanged: ordering needs numbers, and
+/// `!=` rejects functions exactly where `==` does — naming the operator the
+/// source wrote.
+#[test]
+fn error_new_comparisons_reject_bad_operands() {
+    let (message, _, _) = run_err("let main = () => \"a\" <= \"b\"");
+    assert_eq!(
+        message,
+        "comparison needs numbers, got a string and a string"
+    );
+    let (message, _, _) = run_err(&format!("{SHAPE}let main = () => Circle != Circle"));
+    assert_eq!(message, "functions cannot be compared with `!=`");
+}
+
 // Currying: over-applying a saturated constructor is still an error (the
 // resulting variant isn't callable); under-applying it (here, zero args) is a
 // legal partial rather than an arity error.

--- a/site/manual/index.html
+++ b/site/manual/index.html
@@ -346,18 +346,27 @@ let span = (a, b) =>
 
           <h3>Operators and equality</h3>
           <p>
-            <code>+ - * /</code>, <code>&lt; > ==</code>, unary <code>-</code>, and the
-            short-circuiting booleans <code>&amp;&amp;</code> / <code>||</code> with prefix
-            <code>not</code>. Precedence, tightest to loosest: comparisons →
+            <code>+ - * /</code>, <code>&lt; > &lt;= >= == !=</code>, unary <code>-</code>,
+            and the short-circuiting booleans <code>&amp;&amp;</code> / <code>||</code> with
+            prefix <code>not</code>. Precedence, tightest to loosest: comparisons →
             <code>not</code> → <code>&amp;&amp;</code> → <code>||</code> → pipelines. So
             <code>not a == b</code> means <code>not (a == b)</code>.
           </p>
           <p>
             <strong>The comparison set is exactly <code>&lt;</code>, <code>></code>,
-            <code>==</code></strong> — there is no <code>>=</code>, <code>&lt;=</code>, or
-            <code>!=</code>, and reaching for one is a parse error. Write
-            <code>not (a &lt; b)</code> for “at least”, and <code>not (a == b)</code> for
-            “differs”.
+            <code>&lt;=</code>, <code>>=</code>, <code>==</code>, <code>!=</code></strong> —
+            all six at the same precedence. Inequality is <code>!=</code>; F#’s
+            <code>&lt;></code> is not an alias, and prefix negation stays <code>not</code>
+            (bare <code>!</code> is not an operator).
+          </p>
+          <pre class="functor-lang">let inRange = (n: float): bool =&gt; n &gt;= 0.0 &amp;&amp; n &lt;= 1.0
+let changed = (a: float, b: float): bool =&gt; a != b</pre>
+          <p>
+            <code>&lt;=</code> and <code>>=</code> are valid wherever <code>&lt;</code> and
+            <code>></code> are; <code>!=</code> is the exact negation of <code>==</code> —
+            the same operands, the same errors. Comparisons follow IEEE, so
+            <code>0.0 / 0.0</code> (NaN) is false against everything including itself, which
+            makes <code>nan != nan</code> true.
           </p>
           <p>
             <code>==</code> is structural (comparing

--- a/site/src/functor-lang.ts
+++ b/site/src/functor-lang.ts
@@ -115,7 +115,10 @@ export const functorLangLanguage = StreamLanguage.define<State>({
       stream.match("=>") ||
       stream.match(":=") ||
       stream.match("&&") ||
-      stream.match("||")
+      stream.match("||") ||
+      stream.match("<=") ||
+      stream.match(">=") ||
+      stream.match("!=")
     )
       return "operator";
     if (stream.match(/^[+\-*/<>=|]/)) return "operator";

--- a/tools/functor-lang-vscode/syntaxes/functor-lang.tmLanguage.json
+++ b/tools/functor-lang-vscode/syntaxes/functor-lang.tmLanguage.json
@@ -146,7 +146,7 @@
         },
         {
           "name": "keyword.operator.comparison.functor",
-          "match": "==|<|>"
+          "match": "==|!=|<=|>=|<|>"
         },
         {
           "name": "keyword.operator.assignment.functor",


### PR DESCRIPTION
## Why

**All seven game-jam entries hit this.** Functor Lang had `<`, `>`, `==` and nothing
else, so every "at most" / "at least" / "is not" became `not (a > b)` gymnastics — and
the parse error for `a <= b` was `expected an expression, found '='`: accurate, but it
never names the actual problem. One entry carried a `spent(n)` helper purely to make
the double-negative readable.

Two real bugs in the racer traced directly to the workaround: the off-by-one boundary
that `not (a > b)` inverts under is exactly where a lap/checkpoint test wants `<=`, and
a hand-rolled negation of `==` drifted from what the author meant.

## What this adds

`>=`, `<=`, and `!=`, at the **same precedence level** as the existing comparisons
(tighter than `not`, looser than arithmetic) — no new precedence tier, no new
evaluation strategy.

| operator | operands | result | errors |
| --- | --- | --- | --- |
| `<=` / `>=` | both `float` (same rule as `<` / `>`) | `bool` | check: `` `<=` needs float operands, got string ``; run: `comparison needs numbers, got …` |
| `!=` | anything `==` accepts | `bool` | **exactly `==`'s**, reworded to name `!=` |

`!=` is not a new comparison — it is `==` negated over the *same structural walk*:

- functions on either side → the same **check-time** rejection
  (`` functions cannot be compared with `!=` ``), never just a runtime failure
- `HostData` (engine values) → the same runtime error
- different known types → the same certain-verdict diagnostic, with the verdict
  inverted: `` `!=` compares different types string and float (always true) ``
- structural over records / tuples / lists / variants, identically

**NaN**: comparisons are IEEE, so `0.0 / 0.0` is false against everything including
itself under `<`, `>`, `<=`, `>=`, `==` — which makes `nan != nan` true. `==` and `!=`
are tested together on NaN so the symmetry is pinned, not assumed.

## The `<>` question

F# spells inequality `<>`; the jam asked for `!=`. Nothing in the skill or docs stated
a direction, so this ships **`!=` only** — the language already diverges from F# where
pragmatic (`:=` not `<-`, thread-last pipelines, no `elif`), and one spelling per
concept is the smaller language. `<>` lexes as `<` then `>` and fails as an ordinary
parse error (`expected an expression, found '>'`), pinned by a test.

**Question for review:** aliasing `<>` would be roughly a one-line lexer change. Worth
it for F# muscle memory, or is one spelling correct? Happy to add it — I did not want
to ship two spellings silently.

Prefix `!` is likewise **not** negation (that stays `not`); `!` exists only inside
`!=`, and a bare `!` is `unexpected character '!'`.

## One non-obvious implementation note

`>=` lexes as a single token, so a space-free generic close (`type Box<'v>= …`,
`let xs: List<float>= …`) would otherwise stop parsing. The parser splits that token
back apart at its two generic-close sites (`expect_generic_close`), so both still
parse — covered by a test.

## Verification

All re-run after the review fixes below.

- `cargo test -p functor-lang` — **green** (581 tests, up from 564; +17 new across lexer/parser,
  typechecker, and evaluator). **No goldens regenerated** — no existing snapshot
  changed, since the `==`-only messages are byte-identical.
- `cargo test -p functor_runtime_common` — **green** (496 + 8).
- **Examples sweep**: the CLI's `every_shipped_example_typechecks` test passes, and
  `functor -d <dir> build native` over all 28 `examples/*/` projects clears the
  typecheck gate. The 6 that report errors report *only* missing gitignored assets
  (unfetched clone), which the CLI checks strictly after typechecking.
- `npm run check:docs` — green.

## Benchmarks (release, same machine, back-to-back)

This touches binary-op evaluation, the interpreter hot path.

`frame_bench` — **allocs/frame and bytes/frame are byte-identical** at every size:

| cells | us/frame (min) base | us/frame (min) branch | allocs/frame | bytes/frame |
| --- | --- | --- | --- | --- |
| 400 | 442.2 / 477.0 | 443.9 / 452.6 | 13877 → 13877 | 843379 → 843379 |
| 1600 | 1731.2 / 1745.0 | 1748.0 / 1748.3 | 54717 → 54717 | 3307219 → 3307219 |
| 3136 | 3375.0 / 3404.5 | 3395.7 / 3430.1 | 106973 → 106973 | 6460243 → 6460243 |

Wall-clock deltas sit inside the two-run spread on each side.

`functor-lang bench --all` (medians, ms/op) — base → branch: adt 65.9 → 66.6,
arith_loop 184.3 → 183.2 (a first branch run read 193.0; a repeat gave 183.2, so that
was noise), call_piped 365.2 → 371.5, call_saturated 371.9 → 367.3, fold_floor
139.6 → 138.1, list_map 40.5 → 40.5, pattern_match 79.5 → 76.9, record_update
35.5 → 34.5, recursion 434.8 → 455.8. Mixed sign, all inside the harness's reported
spread.

## Docs updated in this PR

- **`functor-lang` skill** — the operator list, the (previously loud) "that list is
  EXHAUSTIVE — there is no `>=`, `<=`, `!=`" note, the `==`-is-structural semantics
  bullet (now covering `!=`), a new IEEE/NaN bullet, and a syntax-sample line.
- **`site/manual/index.html`** — the "Operators and equality" section, which
  explicitly told readers to write `not (a < b)` and `not (a == b)`.
- **`docs/functor-lang.md`** — a roadmap entry recording the change and the `<>` / `!`
  decisions.
- Syntax highlighting: the VSCode tmLanguage comparison pattern and the site's
  CodeMirror tokenizer.

## The manual, before and after

The "Operators and equality" section previously told readers to write `not (a < b)`
and `not (a == b)`. Desktop (1100px):

**Before**

![manual before](https://gist.githubusercontent.com/tommy-xr/1932ac9704d7b2a860e52f64a65bf4ec/raw/manual-before.png)

**After**

![manual after](https://gist.githubusercontent.com/tommy-xr/1932ac9704d7b2a860e52f64a65bf4ec/raw/manual-after.png)

At mobile width (390px), the new example block wraps inside its own scroll container
like the page's other `pre`s:

![manual after, mobile](https://gist.githubusercontent.com/tommy-xr/1932ac9704d7b2a860e52f64a65bf4ec/raw/manual-after-mobile.png)

## Review (`/xreview` — Claude subagent + Codex, independent)

**[AGREED — both engines] `>=>` regression, High/Medium → fixed in e4aeffd.**
A generic return annotation with no space before the arrow
(`let f = (xs: List<float>): List<float>=> xs`) lexes as `>=` then `>`, so splitting
the `>=` left a bare `=` and destroyed the fat arrow. It parsed before this PR, so it
was a real regression, and it was reproduced from the CLI before fixing. The split now
reassembles the leftover `=` with the following adjacent `>` into a `FatArrow`. Only
two things can follow a generic close and start with `=` (`=` and `=>`); both are
handled and both have tests.

**[AGREED] Stale grammar doc comment (Low) → fixed.** The parser's own `cmp` production
still listed only `<`/`>`/`==`.

**[Claude, Low] `op_str` was a dead one-line wrapper → fixed.** Call sites now use
`BinOp::symbol` directly.

**[Codex, Medium] The certainty verdict is imprecise for containers → declined, with
reason.** Codex notes `List<float> != List<string>` is reported "always true" though
two *empty* lists compare structurally equal. True — but this is **pre-existing and
symmetric**: on `main`, `==` on the same pair already reports "always false", which is
wrong in exactly the same case. Verified:

```
error: `==` compares different types List<float> and List<string> (always false)
error: `!=` compares different types List<float> and List<string> (always true)
```

`!=` inheriting `==`'s diagnostic verbatim is precisely this PR's design goal. Making
the verdict value-shape-aware would change `==`'s long-standing behavior and belongs in
its own change, not smuggled in here.

Both engines confirmed no missed `BinOp`/`TokenKind` match sites (`lower.rs`,
`rebind.rs`, `hover.rs`, `trace`, `coverage`, IR printing, `tools/`, `runtime/`), that
the eval-budget `charge` accounting is unchanged for `!=`, and that the split spans are
byte-correct.

**Verdict: 0 unresolved agreed Critical/High.**

## Consumers must rebuild

The operators live in the interpreter, which is compiled into the shells — `functor
run` does not rebuild them. Anyone wanting `>=` / `<=` / `!=` in a game needs
`npm run build:cli` (the wasm bundle then the CLI); an old binary will still reject the
new syntax at parse time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
