### PR TITLE
refactor(site): render the sandbox chrome with React islands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "functor4",
+  "name": "functor2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -13,11 +13,18 @@
         "@lezer/highlight": "^1.2.3",
         "@playwright/test": "^1.61.0",
         "@resvg/resvg-js": "^2.6.2",
+        "@types/react": "^19.2.17",
+        "@types/react-dom": "^19.2.3",
         "@vscode/test-electron": "^2.4.1",
         "codemirror": "^6.0.2",
         "esbuild": "^0.28.1",
         "png-to-ico": "^3.0.2",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
         "typescript": "^5.9.3"
+      },
+      "engines": {
+        "node": ">=22.18"
       }
     },
     "node_modules/@codemirror/autocomplete": {
@@ -838,6 +845,26 @@
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
     "node_modules/@vscode/test-electron": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
@@ -947,6 +974,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
       "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1317,6 +1351,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -1354,6 +1411,13 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -53,10 +53,14 @@
     "@lezer/highlight": "^1.2.3",
     "@playwright/test": "^1.61.0",
     "@resvg/resvg-js": "^2.6.2",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
     "@vscode/test-electron": "^2.4.1",
     "codemirror": "^6.0.2",
     "esbuild": "^0.28.1",
     "png-to-ico": "^3.0.2",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
     "typescript": "^5.9.3"
   }
 }

--- a/site/build.mjs
+++ b/site/build.mjs
@@ -262,7 +262,7 @@ await esbuild.build({
   // `src/docs.js` would silently win. Name the file that actually exists. The
   // OUTPUT basenames are unchanged either way (esbuild always emits `.js`).
   entryPoints: [
-    `${site}src/sandbox.ts`,
+    `${site}src/sandbox.tsx`,
     `${site}src/ide.ts`,
     `${site}src/docs.ts`,
     `${site}src/api-docs.ts`,
@@ -272,6 +272,9 @@ await esbuild.build({
   ],
   bundle: true,
   minify: true,
+  // `minify` is what selects React's PRODUCTION build: esbuild defines
+  // process.env.NODE_ENV as "production" when minifying a browser bundle, so
+  // the dev react-dom is dead-code-eliminated. Keep them together.
   format: "esm",
   // The editor dynamic-imports the language wasm glue at runtime from /pkg/;
   // esbuild must not try to bundle that path (it's copied in above, or absent).

--- a/site/sandbox.html
+++ b/site/sandbox.html
@@ -22,6 +22,12 @@
   </head>
   <body class="sandbox-page">
     <!--@header suffix="SANDBOX" active="sandbox"-->
+      <!--
+        The pre-JS paint. sandbox.tsx renders this row as a React island, which
+        replaces these children on mount — keep the skeleton in step with the
+        initial stores there (notably the pill's state and label) so the swap is
+        invisible.
+      -->
       <div class="sandbox-controls">
         <label class="picker-label" for="example-picker">scene</label>
         <select id="example-picker"></select>

--- a/site/src/components/RuntimeTargetPanel.tsx
+++ b/site/src/components/RuntimeTargetPanel.tsx
@@ -1,0 +1,146 @@
+// The external-runtime link's panel, rendered from `runtime-target-core.ts`'s
+// snapshot. The core is created once by the page and merely subscribed to here
+// — a controller that re-created itself on a React remount would drop queued
+// pushes and restart the `/state` poll chain.
+//
+// The markup mirrors `runtime-target.ts`'s (the IDE's imperative view) element
+// for element, class for class, data-attribute for data-attribute.
+
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
+import type { RuntimeTargetCore } from "../runtime-target-core.js";
+
+export const RuntimeTargetPanel = ({ core }: { core: RuntimeTargetCore }) => {
+  const snapshot = useSyncExternalStore(core.subscribe, core.getSnapshot);
+  const details = useRef<HTMLDetailsElement>(null);
+  const summary = useRef<HTMLElement>(null);
+  const endpoint = useRef<HTMLInputElement>(null);
+  // The endpoint field stays UNCONTROLLED and is mirrored into the core by
+  // native listeners: it is written by the user and, in the e2e harness,
+  // assigned directly and given a bare `change` event — neither of which
+  // React's synthetic `onChange` (an `input`-delegated listener behind a value
+  // tracker) would see.
+  const [initialEndpoint] = useState(() => core.getSnapshot().endpoint);
+
+  useEffect(() => {
+    const input = endpoint.current;
+    if (!input) return;
+    const onInput = () => core.setEndpoint(input.value);
+    const onChange = () => {
+      core.setEndpoint(input.value);
+      core.disconnect();
+    };
+    input.addEventListener("input", onInput);
+    input.addEventListener("change", onChange);
+    return () => {
+      input.removeEventListener("input", onInput);
+      input.removeEventListener("change", onChange);
+    };
+  }, [core]);
+
+  return (
+    <details className="runtime-target" data-state={snapshot.state} ref={details}>
+      <summary data-runtime-summary="" data-state={snapshot.state} ref={summary}>
+        <span className="runtime-target-dot" aria-hidden="true"></span>
+        <span>device</span>
+        <span className="runtime-target-summary-state" data-runtime-summary-state="">
+          {snapshot.summaryText}
+        </span>
+      </summary>
+      <div className="runtime-target-panel">
+        <div className="runtime-target-heading">
+          <span>EXTERNAL RUNTIME</span>
+          <span className="runtime-target-kind">QUEST / DESKTOP</span>
+          <button
+            data-runtime-close=""
+            type="button"
+            aria-label="Close external runtime panel"
+            // Imperative on purpose: the `<details>` is uncontrolled (the user
+            // toggles it natively), and the close must be visible in the DOM
+            // the instant the click handler returns.
+            onClick={() => {
+              if (details.current) details.current.open = false;
+              summary.current?.focus();
+            }}
+          >
+            ×
+          </button>
+        </div>
+        <label className="runtime-target-label">
+          endpoint
+          <input
+            data-runtime-endpoint=""
+            type="url"
+            inputMode="url"
+            spellCheck="false"
+            autoComplete="off"
+            aria-label="Functor runtime endpoint"
+            defaultValue={initialEndpoint}
+            ref={endpoint}
+          />
+        </label>
+        <p className="runtime-target-hint">
+          Quest over USB: <code>adb forward tcp:8123 tcp:8123</code>
+        </p>
+        <div className="runtime-target-actions">
+          <button
+            data-runtime-push=""
+            type="button"
+            disabled={snapshot.pushDisabled}
+            onClick={core.push}
+          >
+            push + go live
+          </button>
+          <button
+            data-runtime-capture=""
+            type="button"
+            disabled={snapshot.captureDisabled}
+            onClick={core.capture}
+          >
+            capture
+          </button>
+        </div>
+        <p
+          className="runtime-target-status"
+          data-runtime-status=""
+          data-state={snapshot.state}
+          aria-live="polite"
+        >
+          {snapshot.message}
+        </p>
+        <div
+          className="runtime-target-telemetry"
+          data-runtime-telemetry=""
+          hidden={snapshot.telemetry === null}
+        >
+          <div>
+            <span>FRAME</span>
+            <strong data-runtime-frame="">{snapshot.telemetry?.frame ?? "—"}</strong>
+          </div>
+          <div>
+            <span>TIME</span>
+            <strong data-runtime-time="">{snapshot.telemetry?.time ?? "—"}</strong>
+          </div>
+          <div>
+            <span>VIEWS</span>
+            <strong data-runtime-views="">{snapshot.telemetry?.views ?? "—"}</strong>
+          </div>
+        </div>
+        <pre className="runtime-target-model" data-runtime-model="" hidden={snapshot.model === ""}>
+          {snapshot.model}
+        </pre>
+        <figure
+          className="runtime-target-capture"
+          data-runtime-capture-frame=""
+          hidden={snapshot.captureUrl === null}
+        >
+          <img
+            data-runtime-image=""
+            alt="Captured frame from the linked Functor runtime"
+            src={snapshot.captureUrl ?? undefined}
+          />
+          <figcaption>RAW RUNTIME CAPTURE</figcaption>
+        </figure>
+      </div>
+    </details>
+  );
+};

--- a/site/src/components/RuntimeTargetPanel.tsx
+++ b/site/src/components/RuntimeTargetPanel.tsx
@@ -6,7 +6,7 @@
 // The markup mirrors `runtime-target.ts`'s (the IDE's imperative view) element
 // for element, class for class, data-attribute for data-attribute.
 
-import { useEffect, useRef, useState, useSyncExternalStore } from "react";
+import { useLayoutEffect, useRef, useState, useSyncExternalStore } from "react";
 import type { RuntimeTargetCore } from "../runtime-target-core.js";
 
 export const RuntimeTargetPanel = ({ core }: { core: RuntimeTargetCore }) => {
@@ -21,7 +21,10 @@ export const RuntimeTargetPanel = ({ core }: { core: RuntimeTargetCore }) => {
   // tracker) would see.
   const [initialEndpoint] = useState(() => core.getSnapshot().endpoint);
 
-  useEffect(() => {
+  // A LAYOUT effect, so the listeners are installed during the commit rather
+  // than after paint: the field is reachable the moment it is in the document,
+  // and an endpoint written in a passive-effect window would be lost.
+  useLayoutEffect(() => {
     const input = endpoint.current;
     if (!input) return;
     const onInput = () => core.setEndpoint(input.value);

--- a/site/src/components/SandboxControls.tsx
+++ b/site/src/components/SandboxControls.tsx
@@ -1,0 +1,73 @@
+// The sandbox's header controls: the scene picker, reset, the external-runtime
+// panel, and the live status pill. The page keeps owning the load logic — this
+// island renders the two small stores it publishes and calls back on intent.
+
+import { useSyncExternalStore } from "react";
+import { RuntimeTargetPanel } from "./RuntimeTargetPanel.js";
+import type { RuntimeTargetCore } from "../runtime-target-core.js";
+import type { Store } from "../store.js";
+
+/** One row of the scene picker: the repo examples plus a possible snippet. */
+export interface PickerOption {
+  value: string;
+  label: string;
+}
+
+export interface PickerState {
+  options: PickerOption[];
+  selected: string;
+}
+
+/** The preview pill: its `data-state`, its label, and its tooltip detail. */
+export interface PillState {
+  state: "busy" | "live" | "error";
+  text: string;
+  detail: string;
+}
+
+export interface SandboxControlsProps {
+  picker: Store<PickerState>;
+  pill: Store<PillState>;
+  runtimeTarget: RuntimeTargetCore;
+  onSelect: (value: string) => void;
+  onReset: () => void;
+}
+
+export const SandboxControls = ({
+  picker,
+  pill,
+  runtimeTarget,
+  onSelect,
+  onReset,
+}: SandboxControlsProps) => {
+  const { options, selected } = useSyncExternalStore(picker.subscribe, picker.getSnapshot);
+  const status = useSyncExternalStore(pill.subscribe, pill.getSnapshot);
+
+  return (
+    <>
+      <label className="picker-label" htmlFor="example-picker">
+        scene
+      </label>
+      <select
+        id="example-picker"
+        value={selected}
+        onChange={(event) => onSelect(event.target.value)}
+      >
+        {options.map((option) => (
+          <option value={option.value} key={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+      <button id="reset" type="button" title="Reload the example (resets the model)" onClick={onReset}>
+        ↺ reset
+      </button>
+      <div id="runtime-target" className="runtime-target-host">
+        <RuntimeTargetPanel core={runtimeTarget} />
+      </div>
+      <span id="status" className="status-pill" data-state={status.state} title={status.detail}>
+        {status.text}
+      </span>
+    </>
+  );
+};

--- a/site/src/components/StatusBar.tsx
+++ b/site/src/components/StatusBar.tsx
@@ -7,7 +7,7 @@
 // styles.css and the e2e selectors are untouched — including keeping all three
 // lists MOUNTED and toggled with `display`, exactly as before.
 
-import { useEffect, useLayoutEffect, useRef, useState, useSyncExternalStore } from "react";
+import { useLayoutEffect, useRef, useState, useSyncExternalStore } from "react";
 import { outputPreamble } from "../status-bar-store.js";
 import type { StatusBarStore } from "../status-bar-store.js";
 
@@ -23,11 +23,17 @@ export const StatusBar = ({ store }: { store: StatusBarStore }) => {
   const { problems, output, executions } = useSyncExternalStore(store.subscribe, store.getSnapshot);
   const [open, setOpen] = useState<TabName | null>(null);
   const outputList = useRef<HTMLDivElement>(null);
-  // Stick to the bottom only while the user is already there (don't yank the
-  // scroll out from under them mid-read). Tracked from scroll events rather
-  // than measured mid-update: by the time a layout effect runs, the new lines
-  // are already in the DOM and the pre-append position is gone.
+  // Stick to the bottom only if the user is already there (don't yank the
+  // scroll out from under them mid-read). Measured HERE, during the render
+  // that carries new lines: the DOM still holds the previous ones, so this is
+  // the same pre-append reading the imperative bar took just before appending.
   const stick = useRef(true);
+  const rendered = useRef(output);
+  if (rendered.current !== output) {
+    rendered.current = output;
+    const list = outputList.current;
+    if (list) stick.current = list.scrollTop + list.clientHeight >= list.scrollHeight - 4;
+  }
 
   // The tab goes loud (red ✖) only for errors — a warnings-only file keeps the
   // calm glyph.
@@ -35,19 +41,16 @@ export const StatusBar = ({ store }: { store: StatusBarStore }) => {
 
   useLayoutEffect(() => {
     const list = outputList.current;
-    // Lines appended while the panel was hidden couldn't stick to the bottom
-    // (a display:none subtree measures 0) — land on the newest, not the oldest.
     if (list && open === "output" && stick.current) list.scrollTop = list.scrollHeight;
-  }, [output, open]);
+    // Only new lines: an `open` change is the other effect's job.
+  }, [output]);
 
-  // Opening the panel is the one moment a hidden list must be re-pinned even
-  // if the user had scrolled away inside it earlier.
-  useEffect(() => {
+  // Lines appended while the panel was hidden couldn't stick to the bottom (a
+  // display:none subtree measures 0) — on open, land on the newest, not the
+  // oldest, exactly as the imperative bar's tab handler did.
+  useLayoutEffect(() => {
     const list = outputList.current;
-    if (list && open === "output") {
-      stick.current = true;
-      list.scrollTop = list.scrollHeight;
-    }
+    if (list && open === "output") list.scrollTop = list.scrollHeight;
   }, [open]);
 
   const panel = (name: TabName) => ({
@@ -87,14 +90,7 @@ export const StatusBar = ({ store }: { store: StatusBarStore }) => {
             })
           )}
         </div>
-        <div
-          {...panel("output")}
-          ref={outputList}
-          onScroll={(event) => {
-            const list = event.currentTarget;
-            stick.current = list.scrollTop + list.clientHeight >= list.scrollHeight - 4;
-          }}
-        >
+        <div {...panel("output")} ref={outputList}>
           {output.map((line) => (
             <div className={`output-line output-${line.level}`} key={line.id}>
               <span className="output-preamble">{outputPreamble(line.frame, line.time)}</span>

--- a/site/src/components/StatusBar.tsx
+++ b/site/src/components/StatusBar.tsx
@@ -1,0 +1,129 @@
+// The VSCode-style bottom status bar: a slim strip with three toggleable
+// panels — Problems (live type diagnostics), Output (runtime console traces +
+// reload results), and Executions (the paused inspector's entry-point picker).
+//
+// The rows come from `status-bar-store.ts`; this is only the view. It renders
+// the same markup the imperative `status-bar.ts` builds (still the IDE's), so
+// styles.css and the e2e selectors are untouched — including keeping all three
+// lists MOUNTED and toggled with `display`, exactly as before.
+
+import { useEffect, useLayoutEffect, useRef, useState, useSyncExternalStore } from "react";
+import { outputPreamble } from "../status-bar-store.js";
+import type { StatusBarStore } from "../status-bar-store.js";
+
+/** Which panel a tab opens; also the tab's `data-tab`. */
+type TabName = "problems" | "output" | "executions";
+
+const problemsLabel = (count: number, errors: number): string =>
+  count === 0
+    ? "✓ 0 problems"
+    : `${errors > 0 ? "✖" : "⚠"} ${count} problem${count === 1 ? "" : "s"}`;
+
+export const StatusBar = ({ store }: { store: StatusBarStore }) => {
+  const { problems, output, executions } = useSyncExternalStore(store.subscribe, store.getSnapshot);
+  const [open, setOpen] = useState<TabName | null>(null);
+  const outputList = useRef<HTMLDivElement>(null);
+  // Stick to the bottom only while the user is already there (don't yank the
+  // scroll out from under them mid-read). Tracked from scroll events rather
+  // than measured mid-update: by the time a layout effect runs, the new lines
+  // are already in the DOM and the pre-append position is gone.
+  const stick = useRef(true);
+
+  // The tab goes loud (red ✖) only for errors — a warnings-only file keeps the
+  // calm glyph.
+  const errors = problems.filter((item) => (item.severity || "error") === "error").length;
+
+  useLayoutEffect(() => {
+    const list = outputList.current;
+    // Lines appended while the panel was hidden couldn't stick to the bottom
+    // (a display:none subtree measures 0) — land on the newest, not the oldest.
+    if (list && open === "output" && stick.current) list.scrollTop = list.scrollHeight;
+  }, [output, open]);
+
+  // Opening the panel is the one moment a hidden list must be re-pinned even
+  // if the user had scrolled away inside it earlier.
+  useEffect(() => {
+    const list = outputList.current;
+    if (list && open === "output") {
+      stick.current = true;
+      list.scrollTop = list.scrollHeight;
+    }
+  }, [open]);
+
+  const panel = (name: TabName) => ({
+    className: `statusbar-list ${name}-list`,
+    style: open === name ? undefined : { display: "none" },
+  });
+
+  const tab = (name: TabName, label: string, extra = "") => (
+    <button
+      type="button"
+      className={`statusbar-tab${open === name ? " active" : ""}${extra}`}
+      data-tab={name}
+      onClick={() => setOpen(open === name ? null : name)}
+    >
+      {label}
+    </button>
+  );
+
+  return (
+    <>
+      <div className="statusbar-panel" hidden={open === null}>
+        <div {...panel("problems")}>
+          {problems.length === 0 ? (
+            <div className="statusbar-empty">No problems detected.</div>
+          ) : (
+            problems.map((item, index) => {
+              const severity = item.severity || "error";
+              return (
+                <button type="button" className="problem-row" key={index} onClick={item.jump}>
+                  <span className={`problem-icon severity-${severity}`}>
+                    {severity === "error" ? "✖" : "⚠"}
+                  </span>
+                  <span className="problem-message">{item.message}</span>
+                  <span className="problem-loc">{item.loc}</span>
+                </button>
+              );
+            })
+          )}
+        </div>
+        <div
+          {...panel("output")}
+          ref={outputList}
+          onScroll={(event) => {
+            const list = event.currentTarget;
+            stick.current = list.scrollTop + list.clientHeight >= list.scrollHeight - 4;
+          }}
+        >
+          {output.map((line) => (
+            <div className={`output-line output-${line.level}`} key={line.id}>
+              <span className="output-preamble">{outputPreamble(line.frame, line.time)}</span>
+              {` ${line.text}`}
+            </div>
+          ))}
+        </div>
+        <div {...panel("executions")}>
+          {executions.length === 0 ? (
+            <div className="statusbar-empty">Pause the game to inspect the frame's executions.</div>
+          ) : (
+            executions.map((item, index) => (
+              <button
+                type="button"
+                className={`exec-row${item.selected ? " selected" : ""}`}
+                key={index}
+                onClick={item.onPick}
+              >
+                {item.label}
+              </button>
+            ))
+          )}
+        </div>
+      </div>
+      <div className="statusbar-strip">
+        {tab("problems", problemsLabel(problems.length, errors), errors > 0 ? " has-problems" : "")}
+        {tab("output", "output")}
+        {tab("executions", executions.length ? `⏸ ${executions.length} executions` : "executions")}
+      </div>
+    </>
+  );
+};

--- a/site/src/runtime-target-core.ts
+++ b/site/src/runtime-target-core.ts
@@ -235,7 +235,7 @@ export function normalizeEndpoint(raw: unknown): string {
 const isLoopbackHost = (host: string) =>
   host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "[::1]";
 
-export const storedEndpoint = (): string => {
+const storedEndpoint = (): string => {
   try {
     return localStorage.getItem(STORAGE_KEY) || DEFAULT_RUNTIME_ENDPOINT;
   } catch {
@@ -328,12 +328,15 @@ export interface RuntimeTargetCoreOptions {
   onOutput?: (level: ConsoleLevel, message: string) => void;
 }
 
+/** The link's four display states; each is a `data-state` CSS selector. */
+export type RuntimeLinkState = "off" | "busy" | "live" | "error";
+
 /** Everything a view renders. One object, replaced on every change. */
 export interface RuntimeTargetSnapshot {
   /** The raw endpoint text, as typed — normalized only at request time. */
   endpoint: string;
-  /** `data-state` on the details/summary/status trio: off | busy | live | error. */
-  state: string;
+  /** `data-state` on the details/summary/status trio. */
+  state: RuntimeLinkState;
   /** The collapsed summary's trailing word ("off", "live", "sync error", …). */
   summaryText: string;
   /** The panel's status sentence. */
@@ -426,7 +429,7 @@ export function createRuntimeTargetCore({
   let lastSyncedAssets: [string, Uint8Array][] = [];
   let assetSyncPending = false;
 
-  const renderStatus = (state: string, summaryText: string, message: string) =>
+  const renderStatus = (state: RuntimeLinkState, summaryText: string, message: string) =>
     update({ state, summaryText, message });
 
   const renderState = (state: RuntimeState) => {
@@ -470,14 +473,17 @@ export function createRuntimeTargetCore({
       URL.revokeObjectURL(captureUrl);
       captureUrl = null;
     }
+    // One notification: every field the disconnect resets, at once.
     update({
       pushDisabled: !localEditorOrigin,
       captureDisabled: true,
       telemetry: null,
       model: "",
       captureUrl: null,
+      state: "off",
+      summaryText: "off",
+      message: "Endpoint changed. Push to start a fresh model.",
     });
-    renderStatus("off", "off", "Endpoint changed. Push to start a fresh model.");
   };
 
   const pollState = async () => {

--- a/site/src/runtime-target-core.ts
+++ b/site/src/runtime-target-core.ts
@@ -1,0 +1,812 @@
+// The external-runtime link's CLIENT and CONTROLLER, split out of the DOM
+// component so either a React view (the sandbox) or the imperative one
+// (`runtime-target.ts`, still used by the IDE) can render it. Every line of
+// protocol and state-machine behaviour below is carried over unchanged from
+// that module; only the writes that used to poke elements now publish a
+// snapshot for a view to render.
+//
+// The in-page wasm preview stays independent: the first explicit push starts a
+// fresh model on the external runtime, then later edits hot-reload there with
+// the model preserved.
+//
+// The wire types below mirror the runtime's HTTP debug protocol
+// (runtime/functor-runtime-common/src/debug_protocol.rs). As with the
+// postMessage types in protocol.ts, response BODIES are asserted rather than
+// validated: the pre-migration code read these fields straight off
+// `response.json()`, and the few defensive runtime checks it did make (the
+// discovery handshake, `Number.isFinite(state.frame)`) are kept as they were.
+
+import type { ConsoleLevel, ProjectFile } from "./protocol.js";
+
+export const DEFAULT_RUNTIME_ENDPOINT = "http://127.0.0.1:8123";
+
+const SERVICE = "functor debug runtime";
+const MIN_PROTOCOL_VERSION = 2;
+const REQUEST_TIMEOUT_MS = 10_000;
+const ASSET_TIMEOUT_MS = 40_000;
+// Quest's raw 3360×1760 stereo PNG can take >10s to encode and transfer. The
+// runtime itself waits up to 30s for a captured frame; leave transfer margin.
+const CAPTURE_TIMEOUT_MS = 40_000;
+const LIVE_PUSH_DEBOUNCE_MS = 300;
+const STATE_POLL_MS = 1_000;
+const STORAGE_KEY = "functor-runtime-endpoint-v1";
+
+/** The `GET /` handshake body every runtime target serves. */
+export interface RuntimeDiscovery {
+  service: string;
+  protocol_version: number;
+  endpoints: Record<string, string>;
+}
+
+/** A pixel rectangle in the runtime's output surface. */
+export interface RuntimeViewport {
+  width: number;
+  height: number;
+}
+
+/** One rendered view: desktop reports a single `main`, stereo XR one per eye. */
+export interface RuntimeView {
+  name: string;
+  viewport: RuntimeViewport;
+}
+
+/**
+ * The `GET /state` snapshot. `input` (held keys, mouse, optional XR) is a
+ * runtime-owned payload this client never reads, so it stays `unknown` here.
+ */
+export interface RuntimeState {
+  frame: number;
+  tts: number;
+  /** v3 and later only — this client still links v2 runtimes, which omit it. */
+  pending_steps?: number;
+  viewport: RuntimeViewport;
+  views: RuntimeView[];
+  model: string;
+  input: unknown;
+}
+
+/** One project file as a caller may hand it over: a pair, or an IDE file. */
+export type ProjectFileInput = [string, string] | ProjectFile;
+
+/** Asset bytes as a caller may hand them over, alongside their path. */
+export type ProjectAssetBytes = Uint8Array | ArrayBuffer | ArrayBufferView | Blob;
+export type ProjectAssetInput =
+  | [string, ProjectAssetBytes]
+  | { path: string; bytes: ProjectAssetBytes };
+
+// `declare` on the fields of both classes below: they are assigned by the
+// constructor, and a plain declaration would EMIT a field definition, creating
+// the properties (as undefined) before those assignments. That is observable
+// on this subclass — it would reorder `name` behind them — so declare the
+// types and let the constructor keep being the only thing that emits.
+export class RuntimeHttpError extends Error {
+  declare readonly method: string;
+  declare readonly url: string;
+  declare readonly status: number;
+  declare readonly body: string;
+
+  constructor(method: string, url: string, status: number, body: string) {
+    super(`${method} ${url} failed with status ${status}: ${body}`);
+    this.name = "RuntimeHttpError";
+    this.method = method;
+    this.url = url;
+    this.status = status;
+    this.body = body;
+  }
+}
+
+// The TypeScript SDK is Node-oriented (`capture()` returns a Buffer). This
+// fetch client intentionally keeps the browser response as a Blob while using
+// the same canonical protocol routes and JSON bodies.
+export class BrowserRuntimeClient {
+  declare readonly endpoint: string;
+  private declare readonly fetchImpl: typeof fetch;
+  private declare readonly timeoutMs: number;
+
+  constructor(
+    endpoint: unknown,
+    {
+      fetchImpl = fetch,
+      timeoutMs = REQUEST_TIMEOUT_MS,
+    }: { fetchImpl?: typeof fetch; timeoutMs?: number } = {}
+  ) {
+    this.endpoint = normalizeEndpoint(endpoint);
+    this.fetchImpl = fetchImpl;
+    this.timeoutMs = timeoutMs;
+  }
+
+  async discover(): Promise<RuntimeDiscovery> {
+    const discovery = await this.#json<RuntimeDiscovery>("GET", "/");
+    if (
+      discovery?.service !== SERVICE ||
+      !Number.isInteger(discovery?.protocol_version) ||
+      discovery.protocol_version < MIN_PROTOCOL_VERSION
+    ) {
+      throw new Error(
+        `not a compatible Functor runtime (expected ${SERVICE} protocol ${MIN_PROTOCOL_VERSION}+)`
+      );
+    }
+    return discovery;
+  }
+
+  state(): Promise<RuntimeState> {
+    return this.#json<RuntimeState>("GET", "/state");
+  }
+
+  loadProject(files: [string, string][]): Promise<string> {
+    return this.#text("POST", "/load-project", files);
+  }
+
+  reloadProject(files: [string, string][]): Promise<string> {
+    return this.#text("POST", "/reload-project", files);
+  }
+
+  reloadAsset(path: string, bytes: Uint8Array): Promise<string> {
+    const pathBytes = new TextEncoder().encode(path);
+    if (pathBytes.byteLength > 0xffff_ffff) throw new Error("asset path is too long");
+    const body = new Uint8Array(4 + pathBytes.byteLength + bytes.byteLength);
+    new DataView(body.buffer).setUint32(0, pathBytes.byteLength, false);
+    body.set(pathBytes, 4);
+    body.set(bytes, 4 + pathBytes.byteLength);
+    return this.#request(
+      "POST",
+      "/reload-asset",
+      body,
+      ASSET_TIMEOUT_MS,
+      "application/octet-stream"
+    ).then((response) => response.text());
+  }
+
+  syncAssets(paths: string[]): Promise<string> {
+    return this.#text("POST", "/sync-assets", paths);
+  }
+
+  capture(): Promise<Blob> {
+    return this.#request("POST", "/capture", undefined, CAPTURE_TIMEOUT_MS).then((response) =>
+      response.blob()
+    );
+  }
+
+  async #json<T>(method: string, path: string, body?: unknown): Promise<T> {
+    return (await this.#request(method, path, body)).json() as Promise<T>;
+  }
+
+  async #text(method: string, path: string, body?: unknown): Promise<string> {
+    return (await this.#request(method, path, body)).text();
+  }
+
+  async #request(
+    method: string,
+    path: string,
+    body?: unknown,
+    timeoutMs: number = this.timeoutMs,
+    contentType: string | null = null
+  ): Promise<Response> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    const url = `${this.endpoint}${path}`;
+    try {
+      // Invoke an injected/global fetch as a plain function. Calling it as
+      // `this.fetchImpl(...)` supplies the client as the Web API receiver,
+      // which some browsers reject as an illegal invocation before networking.
+      const fetchRequest = this.fetchImpl;
+      const response = await fetchRequest(url, {
+        method,
+        headers: (body === undefined
+          ? undefined
+          : { "Content-Type": contentType ?? "application/json" }) as HeadersInit,
+        // Two assertions, narrowed to the property that needs them: an
+        // explicit `contentType` is only ever passed with binary bytes (the
+        // asset envelope) while every other body goes out as JSON text, and
+        // `exactOptionalPropertyTypes` rejects the explicit `undefined` that
+        // fetch treats exactly like an absent body. `method` and `signal`
+        // stay checked.
+        body: (body === undefined
+          ? undefined
+          : contentType === null
+            ? JSON.stringify(body)
+            : body) as BodyInit,
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        throw new RuntimeHttpError(method, url, response.status, await response.text());
+      }
+      return response;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+export function normalizeEndpoint(raw: unknown): string {
+  let value = String(raw ?? "").trim();
+  if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(value)) value = `http://${value}`;
+  const url = new URL(value);
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("runtime endpoint must use http:// or https://");
+  }
+  if (url.username || url.password) throw new Error("runtime endpoint cannot include credentials");
+  url.search = "";
+  url.hash = "";
+  url.pathname = url.pathname.replace(/\/+$/, "");
+  return url.toString().replace(/\/$/, "");
+}
+
+const isLoopbackHost = (host: string) =>
+  host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "[::1]";
+
+export const storedEndpoint = (): string => {
+  try {
+    return localStorage.getItem(STORAGE_KEY) || DEFAULT_RUNTIME_ENDPOINT;
+  } catch {
+    return DEFAULT_RUNTIME_ENDPOINT;
+  }
+};
+
+const rememberEndpoint = (endpoint: string) => {
+  try {
+    localStorage.setItem(STORAGE_KEY, endpoint);
+  } catch {
+    /* endpoint persistence is a convenience */
+  }
+};
+
+// The producers are still JavaScript, so the shape checks in both normalizers
+// below stay exactly as they were: the input types are the contract, not a
+// guarantee, and the assertions keep the checks meaningful to the checker.
+const projectPairs = (files: ProjectFileInput[]): [string, string][] => {
+  if (!Array.isArray(files) || files.length === 0) {
+    throw new Error("the editor has no project files to push");
+  }
+  return files.map((file, index) => {
+    const pair = (Array.isArray(file) ? file : [file?.path, file?.source]) as [string, string];
+    if (
+      pair.length !== 2 ||
+      typeof pair[0] !== "string" ||
+      typeof pair[1] !== "string" ||
+      pair[0].length === 0
+    ) {
+      throw new Error(`project file ${index + 1} is not a [path, source] pair`);
+    }
+    return pair;
+  });
+};
+
+const projectAssets = async (
+  files: ProjectAssetInput[] | null
+): Promise<[string, Uint8Array][]> => {
+  if (!Array.isArray(files)) throw new Error("project assets must be an array");
+  return Promise.all(
+    files.map(async (file, index): Promise<[string, Uint8Array]> => {
+      const pair = (Array.isArray(file) ? file : [file?.path, file?.bytes]) as [
+        string,
+        ProjectAssetBytes,
+      ];
+      if (pair.length !== 2 || typeof pair[0] !== "string" || pair[0].length === 0) {
+        throw new Error(`project asset ${index + 1} is not a [path, bytes] pair`);
+      }
+      let bytes: Uint8Array;
+      if (pair[1] instanceof Uint8Array) {
+        bytes = pair[1];
+      } else if (pair[1] instanceof ArrayBuffer) {
+        bytes = new Uint8Array(pair[1]);
+      } else if (ArrayBuffer.isView(pair[1])) {
+        bytes = new Uint8Array(pair[1].buffer, pair[1].byteOffset, pair[1].byteLength);
+      } else if (typeof Blob !== "undefined" && pair[1] instanceof Blob) {
+        bytes = new Uint8Array(await pair[1].arrayBuffer());
+      } else {
+        throw new Error(`project asset ${index + 1} has unsupported bytes`);
+      }
+      return [pair[0], bytes];
+    })
+  );
+};
+
+const errorMessage = (error: unknown, endpoint: string, action: string): string => {
+  if (error instanceof RuntimeHttpError) {
+    const detail = error.body.trim();
+    if (error.status === 503 && action === "capture") {
+      return "capture unavailable — wake the headset and wait for XR rendering";
+    }
+    return detail || `${action} failed with HTTP ${error.status}`;
+  }
+  // Read `name` off whatever was thrown, exactly as before: an aborted fetch
+  // rejects with a DOMException, but an injected fetch may throw anything.
+  if ((error as { name?: unknown } | null | undefined)?.name === "AbortError") {
+    return `${action} timed out at ${endpoint}`;
+  }
+  if (error instanceof TypeError) {
+    const detail = error.message && error.message !== "Failed to fetch" ? ` (${error.message})` : "";
+    return `cannot reach ${endpoint}${detail} — check the runtime, adb port forward, and browser local-network permission`;
+  }
+  return error instanceof Error ? error.message : String(error);
+};
+
+export interface RuntimeTargetCoreOptions {
+  getProject: () => ProjectFileInput[];
+  getAssets?: (() => ProjectAssetInput[] | Promise<ProjectAssetInput[]>) | null;
+  onOutput?: (level: ConsoleLevel, message: string) => void;
+}
+
+/** Everything a view renders. One object, replaced on every change. */
+export interface RuntimeTargetSnapshot {
+  /** The raw endpoint text, as typed — normalized only at request time. */
+  endpoint: string;
+  /** `data-state` on the details/summary/status trio: off | busy | live | error. */
+  state: string;
+  /** The collapsed summary's trailing word ("off", "live", "sync error", …). */
+  summaryText: string;
+  /** The panel's status sentence. */
+  message: string;
+  pushDisabled: boolean;
+  captureDisabled: boolean;
+  /** The `/state` telemetry row, or null while nothing has been polled. */
+  telemetry: { frame: string; time: string; views: string } | null;
+  /** The polled model dump; empty hides the block. */
+  model: string;
+  /** Object URL of the last capture; null hides the figure. */
+  captureUrl: string | null;
+}
+
+/** The state seam both editor pages expose to their e2e harness. */
+export interface RuntimeTargetState {
+  endpoint: string;
+  connected: boolean;
+  live: boolean;
+  fresh: boolean;
+  status: string;
+  message: string;
+}
+
+export interface RuntimeTargetCore {
+  subscribe: (listener: () => void) => () => void;
+  getSnapshot: () => RuntimeTargetSnapshot;
+  /** The endpoint field changed (an `input` or a `change` event). */
+  setEndpoint: (value: string) => void;
+  /** The endpoint field was committed (its native `change`) — relink. */
+  disconnect: () => void;
+  /** "push + go live". */
+  push: () => void;
+  capture: () => void;
+  projectChanged: (options?: { fresh?: boolean }) => void;
+  restart: () => void;
+  destroy: () => void;
+  state: () => RuntimeTargetState;
+}
+
+// `getProject` is evaluated at push time, so queued edits always send the
+// latest complete source set.
+export function createRuntimeTargetCore({
+  getProject,
+  getAssets = null,
+  onOutput = () => {},
+}: RuntimeTargetCoreOptions): RuntimeTargetCore {
+  const localEditorOrigin = isLoopbackHost(window.location.hostname);
+
+  let snapshot: RuntimeTargetSnapshot = {
+    endpoint: storedEndpoint(),
+    // The markup's initial `data-state="off"` on the status line; no CSS rule
+    // matches "off" on the summary, so this is the pre-migration paint.
+    state: "off",
+    summaryText: "off",
+    message: "Ready to start a fresh model, then preserve it across edits.",
+    pushDisabled: false,
+    captureDisabled: true,
+    telemetry: null,
+    model: "",
+    captureUrl: null,
+  };
+  const listeners = new Set<() => void>();
+  const update = (patch: Partial<RuntimeTargetSnapshot>): void => {
+    snapshot = { ...snapshot, ...patch };
+    for (const listener of listeners) listener();
+  };
+
+  let client: BrowserRuntimeClient | null = null;
+  let connected = false;
+  let live = false;
+  let projectRevision = 0;
+  let syncedRevision = -1;
+  let freshRequiredRevision = 0;
+  let freshSatisfiedRevision = -1;
+  // `clearTimeout` does not take null, so every clear below passes
+  // `?? undefined`; the stored handles are unchanged by the migration.
+  let pushTimer: ReturnType<typeof setTimeout> | null = null;
+  let pollTimer: ReturnType<typeof setTimeout> | null = null;
+  let pollingGeneration: number | null = null;
+  let pushing = false;
+  let pushQueued = false;
+  let capturing = false;
+  let captureQueued = false;
+  let generation = 0;
+  let captureUrl: string | null = null;
+  let syncError: string | null = null;
+  let transportError: string | null = null;
+  let lastSyncedAssetSource: ProjectAssetInput[] | null = null;
+  let lastSyncedAssets: [string, Uint8Array][] = [];
+  let assetSyncPending = false;
+
+  const renderStatus = (state: string, summaryText: string, message: string) =>
+    update({ state, summaryText, message });
+
+  const renderState = (state: RuntimeState) => {
+    if (!state || !Number.isFinite(state.frame)) return;
+    const views = Array.isArray(state.views) ? state.views.map((view) => view.name).join(" + ") : "—";
+    const model = typeof state.model === "string" ? state.model.trim() : "";
+    update({
+      telemetry: {
+        frame: String(state.frame),
+        time: Number.isFinite(state.tts) ? `${state.tts.toFixed(2)}s` : "—",
+        views: views || "—",
+      },
+      model,
+    });
+  };
+
+  const currentEndpoint = () => normalizeEndpoint(snapshot.endpoint);
+  const projectIsDirty = () =>
+    syncedRevision < projectRevision ||
+    freshSatisfiedRevision < freshRequiredRevision ||
+    assetSyncPending;
+
+  const disconnect = () => {
+    generation += 1;
+    clearTimeout(pushTimer ?? undefined);
+    clearTimeout(pollTimer ?? undefined);
+    client = null;
+    connected = false;
+    live = false;
+    syncedRevision = -1;
+    freshRequiredRevision = projectRevision;
+    freshSatisfiedRevision = -1;
+    pushQueued = false;
+    captureQueued = false;
+    syncError = null;
+    transportError = null;
+    lastSyncedAssetSource = null;
+    lastSyncedAssets = [];
+    assetSyncPending = false;
+    if (captureUrl) {
+      URL.revokeObjectURL(captureUrl);
+      captureUrl = null;
+    }
+    update({
+      pushDisabled: !localEditorOrigin,
+      captureDisabled: true,
+      telemetry: null,
+      model: "",
+      captureUrl: null,
+    });
+    renderStatus("off", "off", "Endpoint changed. Push to start a fresh model.");
+  };
+
+  const pollState = async () => {
+    clearTimeout(pollTimer ?? undefined);
+    pollTimer = null;
+    if (!connected || !client || capturing || pushing) return;
+    const ownGeneration = generation;
+    // Pushes and captures request an immediate refresh, but they must not start
+    // independent polling chains when a state request is already in flight.
+    if (pollingGeneration === ownGeneration) return;
+    pollingGeneration = ownGeneration;
+    try {
+      const state = await client.state();
+      if (ownGeneration !== generation) return;
+      if (capturing || pushing) return;
+      renderState(state);
+      if (transportError) {
+        transportError = null;
+        if (syncError) {
+          renderStatus("error", "sync error", syncError);
+        } else if (projectIsDirty()) {
+          renderStatus("busy", "syncing", "Connection restored. Retrying the latest project…");
+          queuePush({ immediate: true });
+        } else {
+          renderStatus("live", "live", "Connection restored. Project is synchronized.");
+        }
+      }
+    } catch (error) {
+      if (ownGeneration !== generation) return;
+      if (capturing || pushing) return;
+      // `client` was non-null on entry; only `disconnect()` clears it, and that
+      // bumps the generation the guard above already returned on.
+      transportError = errorMessage(error, client!.endpoint, "state poll");
+      renderStatus(
+        "error",
+        syncError ? "sync error" : "retrying",
+        syncError ? `${syncError} Runtime unreachable: ${transportError}` : transportError
+      );
+    } finally {
+      if (pollingGeneration === ownGeneration) pollingGeneration = null;
+      if (ownGeneration === generation && connected && !capturing && !pushing) {
+        clearTimeout(pollTimer ?? undefined);
+        pollTimer = setTimeout(pollState, STATE_POLL_MS);
+      }
+    }
+  };
+
+  const ensureConnection = async (): Promise<BrowserRuntimeClient | null> => {
+    const endpoint = currentEndpoint();
+    if (!client || client.endpoint !== endpoint) {
+      client = new BrowserRuntimeClient(endpoint);
+      connected = false;
+    }
+    const runtime = client;
+    if (!connected) {
+      await runtime.discover();
+      // Endpoint changes disconnect the old client while discovery is in
+      // flight. Do not let its late response mark the replacement as linked.
+      if (client !== runtime) return null;
+      connected = true;
+      rememberEndpoint(endpoint);
+      update({ captureDisabled: false });
+    }
+    return runtime;
+  };
+
+  const pushOnce = async () => {
+    const ownGeneration = generation;
+    // Snapshot the authored project and its fresh-model requirement before the
+    // first await. A reset that arrives during discovery or asset transfer gets
+    // a later revision and therefore remains fresh in the queued push.
+    const requestRevision = projectRevision;
+    const files = projectPairs(getProject());
+    const rawAssetsSnapshot = getAssets ? getAssets() : null;
+    const fresh = !live || freshSatisfiedRevision < freshRequiredRevision;
+    const sourceNeedsSync = syncedRevision < requestRevision || fresh;
+    let endpoint = snapshot.endpoint;
+    let assetCount = 0;
+    let resolvedAssetsSource: ProjectAssetInput[] | null = null;
+    let assets: [string, Uint8Array][] = [];
+    let sourceResult: string | null = null;
+    let runtime: BrowserRuntimeClient | null = null;
+    let assetsMutated = false;
+    let sourceAccepted = false;
+    const priorAssetsKnown = lastSyncedAssetSource !== null;
+    const priorAssets = lastSyncedAssets;
+    syncError = null;
+    renderStatus("busy", "syncing", connected ? "Sending the latest project…" : "Finding the runtime…");
+    update({ pushDisabled: true });
+    try {
+      runtime = await ensureConnection();
+      if (ownGeneration !== generation || !runtime) return;
+      endpoint = runtime.endpoint;
+      if (getAssets) {
+        resolvedAssetsSource = await rawAssetsSnapshot;
+        assets = await projectAssets(resolvedAssetsSource);
+        assetCount = assets.length;
+        if (resolvedAssetsSource !== lastSyncedAssetSource) {
+          assetSyncPending = true;
+          for (const [path, bytes] of assets) {
+            await runtime.reloadAsset(path, bytes);
+            assetsMutated = true;
+          }
+          if (ownGeneration !== generation) return;
+        }
+      }
+      if (sourceNeedsSync) {
+        sourceResult = fresh
+          ? await runtime.loadProject(files)
+          : await runtime.reloadProject(files);
+        if (ownGeneration !== generation) return;
+        live = true;
+        syncedRevision = Math.max(syncedRevision, requestRevision);
+        if (fresh) {
+          freshSatisfiedRevision = Math.max(freshSatisfiedRevision, requestRevision);
+        }
+        sourceAccepted = true;
+      }
+      // Finalize deletions only after the new source is accepted. If source
+      // loading fails, the last-good program keeps every asset it still needs.
+      if (getAssets && resolvedAssetsSource !== lastSyncedAssetSource) {
+        await runtime.syncAssets(assets.map(([path]) => path));
+        if (ownGeneration !== generation) return;
+        lastSyncedAssetSource = resolvedAssetsSource;
+        lastSyncedAssets = assets;
+        assetSyncPending = false;
+      }
+      if (ownGeneration !== generation) return;
+      syncError = null;
+      transportError = null;
+      renderStatus(
+        "live",
+        "live",
+        fresh && sourceResult
+          ? `Fresh model loaded from ${files.length} source file${files.length === 1 ? "" : "s"}${
+              getAssets ? ` + ${assetCount} asset${assetCount === 1 ? "" : "s"}` : ""
+            }.`
+          : sourceResult ?? `Synchronized ${assetCount} project asset${assetCount === 1 ? "" : "s"}.`
+      );
+    } catch (error) {
+      if (ownGeneration !== generation) return;
+      let message = errorMessage(error, endpoint, "push");
+      // Asset reloads are eager. If the runtime definitively rejects the new
+      // source, restore the last browser-synchronized bytes + manifest so the
+      // last-good program cannot keep an overwritten or partially uploaded set.
+      if (
+        error instanceof RuntimeHttpError &&
+        (error.status === 400 || error.status === 413) &&
+        runtime &&
+        assetsMutated &&
+        !sourceAccepted &&
+        priorAssetsKnown
+      ) {
+        try {
+          for (const [path, bytes] of priorAssets) await runtime.reloadAsset(path, bytes);
+          await runtime.syncAssets(priorAssets.map(([path]) => path));
+          message = `${message} Last-good assets were restored.`;
+        } catch (rollbackError) {
+          message = `${message} Asset rollback also failed: ${errorMessage(
+            rollbackError,
+            endpoint,
+            "asset rollback"
+          )}`;
+        }
+      }
+      if (ownGeneration !== generation) return;
+      if (error instanceof RuntimeHttpError) {
+        syncError = message;
+        transportError = null;
+        renderStatus("error", "sync error", message);
+      } else {
+        transportError = message;
+        renderStatus("error", connected ? "retrying" : "offline", message);
+      }
+      onOutput("error", `[device] ${message}`);
+    } finally {
+      if (ownGeneration === generation) update({ pushDisabled: false });
+    }
+  };
+
+  const flushPush = async () => {
+    if (capturing) {
+      pushQueued = true;
+      return;
+    }
+    if (pushing) {
+      pushQueued = true;
+      return;
+    }
+    pushing = true;
+    clearTimeout(pollTimer ?? undefined);
+    do {
+      pushQueued = false;
+      await pushOnce();
+    } while (pushQueued);
+    pushing = false;
+    if (captureQueued) {
+      captureQueued = false;
+      capture();
+    } else if (connected) {
+      pollState();
+    }
+  };
+
+  const queuePush = ({ immediate = false }: { immediate?: boolean } = {}) => {
+    clearTimeout(pushTimer ?? undefined);
+    // The initial load snapshots source before its first await. Edits that land
+    // while that load is in flight must queue even though `live` is still false.
+    if (pushing) {
+      pushQueued = true;
+      return;
+    }
+    if (!live && !immediate) return;
+    if (capturing) {
+      pushQueued = true;
+      return;
+    }
+    if (immediate) {
+      flushPush();
+    } else {
+      pushTimer = setTimeout(flushPush, LIVE_PUSH_DEBOUNCE_MS);
+    }
+  };
+
+  const projectChanged = ({ fresh = false }: { fresh?: boolean } = {}) => {
+    projectRevision += 1;
+    if (fresh) freshRequiredRevision = projectRevision;
+    syncError = null;
+    queuePush();
+  };
+
+  const capture = async () => {
+    if (capturing) return;
+    if (pushing) {
+      captureQueued = true;
+      update({ captureDisabled: true });
+      return;
+    }
+    const ownGeneration = generation;
+    let endpoint = snapshot.endpoint;
+    capturing = true;
+    clearTimeout(pollTimer ?? undefined);
+    update({ captureDisabled: true });
+    renderStatus("busy", "capture", "Waiting for the next rendered frame…");
+    try {
+      const runtime = await ensureConnection();
+      if (ownGeneration !== generation || !runtime) return;
+      endpoint = runtime.endpoint;
+      const blob = await runtime.capture();
+      if (ownGeneration !== generation) return;
+      if (captureUrl) URL.revokeObjectURL(captureUrl);
+      captureUrl = URL.createObjectURL(blob);
+      update({ captureUrl });
+      transportError = null;
+      if (syncError) {
+        renderStatus(
+          "error",
+          "sync error",
+          "Captured the last-good framebuffer; the latest editor source is not synchronized."
+        );
+      } else if (projectIsDirty()) {
+        renderStatus(
+          "busy",
+          "syncing",
+          "Captured the last-good framebuffer. Retrying the latest project…"
+        );
+        queuePush({ immediate: true });
+      } else {
+        renderStatus("live", live ? "live" : "linked", "Captured the runtime framebuffer.");
+      }
+    } catch (error) {
+      if (ownGeneration !== generation) return;
+      const message = errorMessage(error, endpoint, "capture");
+      if (!(error instanceof RuntimeHttpError)) transportError = message;
+      renderStatus("error", live ? "capture error" : "offline", message);
+      onOutput("error", `[device] ${message}`);
+    } finally {
+      capturing = false;
+      if (ownGeneration === generation) update({ captureDisabled: !connected });
+      if (pushQueued) flushPush();
+      if (ownGeneration === generation && connected) pollState();
+    }
+  };
+
+  const restart = () => {
+    if (!live) return;
+    projectRevision += 1;
+    freshRequiredRevision = projectRevision;
+    syncError = null;
+    queuePush({ immediate: true });
+  };
+
+  if (!localEditorOrigin) {
+    update({ pushDisabled: true });
+    renderStatus(
+      "off",
+      "local only",
+      "For safety, Functor runtimes accept editor links only from a localhost-served IDE."
+    );
+  }
+
+  const destroy = () => {
+    disconnect();
+    if (captureUrl) URL.revokeObjectURL(captureUrl);
+  };
+  window.addEventListener("pagehide", destroy, { once: true });
+
+  return {
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    getSnapshot: () => snapshot,
+    setEndpoint: (value) => update({ endpoint: value }),
+    disconnect,
+    push: () => queuePush({ immediate: true }),
+    capture,
+    projectChanged,
+    restart,
+    destroy,
+    state: () => ({
+      endpoint: snapshot.endpoint,
+      connected,
+      live,
+      fresh: !live || freshSatisfiedRevision < freshRequiredRevision,
+      status: snapshot.state,
+      message: snapshot.message,
+    }),
+  };
+}

--- a/site/src/runtime-target.ts
+++ b/site/src/runtime-target.ts
@@ -1,323 +1,20 @@
-// A browser-native client + compact UI for linking either editor surface to a
-// running Functor debug runtime. The in-page wasm preview stays independent:
-// the first explicit push starts a fresh model on the external runtime, then
-// later edits hot-reload there with the model preserved.
-//
-// The wire types below mirror the runtime's HTTP debug protocol
-// (runtime/functor-runtime-common/src/debug_protocol.rs). As with the
-// postMessage types in protocol.ts, response BODIES are asserted rather than
-// validated: the pre-migration code read these fields straight off
-// `response.json()`, and the few defensive runtime checks it did make (the
-// discovery handshake, `Number.isFinite(state.frame)`) are kept as they were.
+// The imperative DOM view of the external-runtime link, mounted by the IDE.
+// All protocol and state-machine behaviour lives in `runtime-target-core.ts`;
+// this module owns only the markup and the snapshot→DOM writes. (The sandbox
+// renders the same core through `components/RuntimeTargetPanel.tsx`; this file
+// goes away when the IDE converts too.)
 
-import type { ConsoleLevel, ProjectFile } from "./protocol.js";
-
-export const DEFAULT_RUNTIME_ENDPOINT = "http://127.0.0.1:8123";
-
-const SERVICE = "functor debug runtime";
-const MIN_PROTOCOL_VERSION = 2;
-const REQUEST_TIMEOUT_MS = 10_000;
-const ASSET_TIMEOUT_MS = 40_000;
-// Quest's raw 3360×1760 stereo PNG can take >10s to encode and transfer. The
-// runtime itself waits up to 30s for a captured frame; leave transfer margin.
-const CAPTURE_TIMEOUT_MS = 40_000;
-const LIVE_PUSH_DEBOUNCE_MS = 300;
-const STATE_POLL_MS = 1_000;
-const STORAGE_KEY = "functor-runtime-endpoint-v1";
-
-/** The `GET /` handshake body every runtime target serves. */
-export interface RuntimeDiscovery {
-  service: string;
-  protocol_version: number;
-  endpoints: Record<string, string>;
-}
-
-/** A pixel rectangle in the runtime's output surface. */
-export interface RuntimeViewport {
-  width: number;
-  height: number;
-}
-
-/** One rendered view: desktop reports a single `main`, stereo XR one per eye. */
-export interface RuntimeView {
-  name: string;
-  viewport: RuntimeViewport;
-}
-
-/**
- * The `GET /state` snapshot. `input` (held keys, mouse, optional XR) is a
- * runtime-owned payload this client never reads, so it stays `unknown` here.
- */
-export interface RuntimeState {
-  frame: number;
-  tts: number;
-  /** v3 and later only — this client still links v2 runtimes, which omit it. */
-  pending_steps?: number;
-  viewport: RuntimeViewport;
-  views: RuntimeView[];
-  model: string;
-  input: unknown;
-}
-
-/** One project file as a caller may hand it over: a pair, or an IDE file. */
-export type ProjectFileInput = [string, string] | ProjectFile;
-
-/** Asset bytes as a caller may hand them over, alongside their path. */
-export type ProjectAssetBytes = Uint8Array | ArrayBuffer | ArrayBufferView | Blob;
-export type ProjectAssetInput =
-  | [string, ProjectAssetBytes]
-  | { path: string; bytes: ProjectAssetBytes };
-
-// `declare` on the fields of both classes below: they are assigned by the
-// constructor, and a plain declaration would EMIT a field definition, creating
-// the properties (as undefined) before those assignments. That is observable
-// on this subclass — it would reorder `name` behind them — so declare the
-// types and let the constructor keep being the only thing that emits.
-export class RuntimeHttpError extends Error {
-  declare readonly method: string;
-  declare readonly url: string;
-  declare readonly status: number;
-  declare readonly body: string;
-
-  constructor(method: string, url: string, status: number, body: string) {
-    super(`${method} ${url} failed with status ${status}: ${body}`);
-    this.name = "RuntimeHttpError";
-    this.method = method;
-    this.url = url;
-    this.status = status;
-    this.body = body;
-  }
-}
-
-// The TypeScript SDK is Node-oriented (`capture()` returns a Buffer). This
-// fetch client intentionally keeps the browser response as a Blob while using
-// the same canonical protocol routes and JSON bodies.
-export class BrowserRuntimeClient {
-  declare readonly endpoint: string;
-  private declare readonly fetchImpl: typeof fetch;
-  private declare readonly timeoutMs: number;
-
-  constructor(
-    endpoint: unknown,
-    {
-      fetchImpl = fetch,
-      timeoutMs = REQUEST_TIMEOUT_MS,
-    }: { fetchImpl?: typeof fetch; timeoutMs?: number } = {}
-  ) {
-    this.endpoint = normalizeEndpoint(endpoint);
-    this.fetchImpl = fetchImpl;
-    this.timeoutMs = timeoutMs;
-  }
-
-  async discover(): Promise<RuntimeDiscovery> {
-    const discovery = await this.#json<RuntimeDiscovery>("GET", "/");
-    if (
-      discovery?.service !== SERVICE ||
-      !Number.isInteger(discovery?.protocol_version) ||
-      discovery.protocol_version < MIN_PROTOCOL_VERSION
-    ) {
-      throw new Error(
-        `not a compatible Functor runtime (expected ${SERVICE} protocol ${MIN_PROTOCOL_VERSION}+)`
-      );
-    }
-    return discovery;
-  }
-
-  state(): Promise<RuntimeState> {
-    return this.#json<RuntimeState>("GET", "/state");
-  }
-
-  loadProject(files: [string, string][]): Promise<string> {
-    return this.#text("POST", "/load-project", files);
-  }
-
-  reloadProject(files: [string, string][]): Promise<string> {
-    return this.#text("POST", "/reload-project", files);
-  }
-
-  reloadAsset(path: string, bytes: Uint8Array): Promise<string> {
-    const pathBytes = new TextEncoder().encode(path);
-    if (pathBytes.byteLength > 0xffff_ffff) throw new Error("asset path is too long");
-    const body = new Uint8Array(4 + pathBytes.byteLength + bytes.byteLength);
-    new DataView(body.buffer).setUint32(0, pathBytes.byteLength, false);
-    body.set(pathBytes, 4);
-    body.set(bytes, 4 + pathBytes.byteLength);
-    return this.#request(
-      "POST",
-      "/reload-asset",
-      body,
-      ASSET_TIMEOUT_MS,
-      "application/octet-stream"
-    ).then((response) => response.text());
-  }
-
-  syncAssets(paths: string[]): Promise<string> {
-    return this.#text("POST", "/sync-assets", paths);
-  }
-
-  capture(): Promise<Blob> {
-    return this.#request("POST", "/capture", undefined, CAPTURE_TIMEOUT_MS).then((response) =>
-      response.blob()
-    );
-  }
-
-  async #json<T>(method: string, path: string, body?: unknown): Promise<T> {
-    return (await this.#request(method, path, body)).json() as Promise<T>;
-  }
-
-  async #text(method: string, path: string, body?: unknown): Promise<string> {
-    return (await this.#request(method, path, body)).text();
-  }
-
-  async #request(
-    method: string,
-    path: string,
-    body?: unknown,
-    timeoutMs: number = this.timeoutMs,
-    contentType: string | null = null
-  ): Promise<Response> {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), timeoutMs);
-    const url = `${this.endpoint}${path}`;
-    try {
-      // Invoke an injected/global fetch as a plain function. Calling it as
-      // `this.fetchImpl(...)` supplies the client as the Web API receiver,
-      // which some browsers reject as an illegal invocation before networking.
-      const fetchRequest = this.fetchImpl;
-      const response = await fetchRequest(url, {
-        method,
-        headers: (body === undefined
-          ? undefined
-          : { "Content-Type": contentType ?? "application/json" }) as HeadersInit,
-        // Two assertions, narrowed to the property that needs them: an
-        // explicit `contentType` is only ever passed with binary bytes (the
-        // asset envelope) while every other body goes out as JSON text, and
-        // `exactOptionalPropertyTypes` rejects the explicit `undefined` that
-        // fetch treats exactly like an absent body. `method` and `signal`
-        // stay checked.
-        body: (body === undefined
-          ? undefined
-          : contentType === null
-            ? JSON.stringify(body)
-            : body) as BodyInit,
-        signal: controller.signal,
-      });
-      if (!response.ok) {
-        throw new RuntimeHttpError(method, url, response.status, await response.text());
-      }
-      return response;
-    } finally {
-      clearTimeout(timeout);
-    }
-  }
-}
-
-export function normalizeEndpoint(raw: unknown): string {
-  let value = String(raw ?? "").trim();
-  if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(value)) value = `http://${value}`;
-  const url = new URL(value);
-  if (url.protocol !== "http:" && url.protocol !== "https:") {
-    throw new Error("runtime endpoint must use http:// or https://");
-  }
-  if (url.username || url.password) throw new Error("runtime endpoint cannot include credentials");
-  url.search = "";
-  url.hash = "";
-  url.pathname = url.pathname.replace(/\/+$/, "");
-  return url.toString().replace(/\/$/, "");
-}
-
-const isLoopbackHost = (host: string) =>
-  host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "[::1]";
-
-const storedEndpoint = () => {
-  try {
-    return localStorage.getItem(STORAGE_KEY) || DEFAULT_RUNTIME_ENDPOINT;
-  } catch {
-    return DEFAULT_RUNTIME_ENDPOINT;
-  }
-};
-
-const rememberEndpoint = (endpoint: string) => {
-  try {
-    localStorage.setItem(STORAGE_KEY, endpoint);
-  } catch {
-    /* endpoint persistence is a convenience */
-  }
-};
-
-// The producers are still JavaScript, so the shape checks in both normalizers
-// below stay exactly as they were: the input types are the contract, not a
-// guarantee, and the assertions keep the checks meaningful to the checker.
-const projectPairs = (files: ProjectFileInput[]): [string, string][] => {
-  if (!Array.isArray(files) || files.length === 0) {
-    throw new Error("the editor has no project files to push");
-  }
-  return files.map((file, index) => {
-    const pair = (Array.isArray(file) ? file : [file?.path, file?.source]) as [string, string];
-    if (
-      pair.length !== 2 ||
-      typeof pair[0] !== "string" ||
-      typeof pair[1] !== "string" ||
-      pair[0].length === 0
-    ) {
-      throw new Error(`project file ${index + 1} is not a [path, source] pair`);
-    }
-    return pair;
-  });
-};
-
-const projectAssets = async (
-  files: ProjectAssetInput[] | null
-): Promise<[string, Uint8Array][]> => {
-  if (!Array.isArray(files)) throw new Error("project assets must be an array");
-  return Promise.all(
-    files.map(async (file, index): Promise<[string, Uint8Array]> => {
-      const pair = (Array.isArray(file) ? file : [file?.path, file?.bytes]) as [
-        string,
-        ProjectAssetBytes,
-      ];
-      if (pair.length !== 2 || typeof pair[0] !== "string" || pair[0].length === 0) {
-        throw new Error(`project asset ${index + 1} is not a [path, bytes] pair`);
-      }
-      let bytes: Uint8Array;
-      if (pair[1] instanceof Uint8Array) {
-        bytes = pair[1];
-      } else if (pair[1] instanceof ArrayBuffer) {
-        bytes = new Uint8Array(pair[1]);
-      } else if (ArrayBuffer.isView(pair[1])) {
-        bytes = new Uint8Array(pair[1].buffer, pair[1].byteOffset, pair[1].byteLength);
-      } else if (typeof Blob !== "undefined" && pair[1] instanceof Blob) {
-        bytes = new Uint8Array(await pair[1].arrayBuffer());
-      } else {
-        throw new Error(`project asset ${index + 1} has unsupported bytes`);
-      }
-      return [pair[0], bytes];
-    })
-  );
-};
-
-const errorMessage = (error: unknown, endpoint: string, action: string): string => {
-  if (error instanceof RuntimeHttpError) {
-    const detail = error.body.trim();
-    if (error.status === 503 && action === "capture") {
-      return "capture unavailable — wake the headset and wait for XR rendering";
-    }
-    return detail || `${action} failed with HTTP ${error.status}`;
-  }
-  // Read `name` off whatever was thrown, exactly as before: an aborted fetch
-  // rejects with a DOMException, but an injected fetch may throw anything.
-  if ((error as { name?: unknown } | null | undefined)?.name === "AbortError") {
-    return `${action} timed out at ${endpoint}`;
-  }
-  if (error instanceof TypeError) {
-    const detail = error.message && error.message !== "Failed to fetch" ? ` (${error.message})` : "";
-    return `cannot reach ${endpoint}${detail} — check the runtime, adb port forward, and browser local-network permission`;
-  }
-  return error instanceof Error ? error.message : String(error);
-};
+import { createRuntimeTargetCore, storedEndpoint } from "./runtime-target-core.js";
+import type {
+  ProjectAssetInput,
+  ProjectFileInput,
+  RuntimeTargetCore,
+  RuntimeTargetSnapshot,
+} from "./runtime-target-core.js";
+import type { ConsoleLevel } from "./protocol.js";
 
 export interface RuntimeTargetOptions {
-  /** Nullable because both callers pass `document.getElementById(…)`; the
+  /** Nullable because the caller passes `document.getElementById(…)`; the
    *  guard below is what turns that into the teaching error. */
   host: HTMLElement | null;
   getProject: () => ProjectFileInput[];
@@ -325,15 +22,12 @@ export interface RuntimeTargetOptions {
   onOutput?: (level: ConsoleLevel, message: string) => void;
 }
 
-// Mount the same device-link control in the multi-file IDE and the single-file
-// sandbox. `getProject` is evaluated at push time, so queued edits always send
-// the latest complete source set.
 export function createRuntimeTarget({
   host,
   getProject,
   getAssets = null,
   onOutput = () => {},
-}: RuntimeTargetOptions) {
+}: RuntimeTargetOptions): RuntimeTargetCore {
   if (!host) throw new Error("runtime target host is required");
 
   host.classList.add("runtime-target-host");
@@ -405,414 +99,50 @@ export function createRuntimeTarget({
   const captureImage = host.querySelector<HTMLImageElement>("[data-runtime-image]")!;
 
   endpointInput.value = storedEndpoint();
-  const localEditorOrigin = isLoopbackHost(window.location.hostname);
 
-  let client: BrowserRuntimeClient | null = null;
-  let connected = false;
-  let live = false;
-  let projectRevision = 0;
-  let syncedRevision = -1;
-  let freshRequiredRevision = 0;
-  let freshSatisfiedRevision = -1;
-  // `clearTimeout` does not take null, so every clear below passes
-  // `?? undefined`; the stored handles are unchanged by the migration.
-  let pushTimer: ReturnType<typeof setTimeout> | null = null;
-  let pollTimer: ReturnType<typeof setTimeout> | null = null;
-  let pollingGeneration: number | null = null;
-  let pushing = false;
-  let pushQueued = false;
-  let capturing = false;
-  let captureQueued = false;
-  let generation = 0;
-  let captureUrl: string | null = null;
-  let syncError: string | null = null;
-  let transportError: string | null = null;
-  let lastSyncedAssetSource: ProjectAssetInput[] | null = null;
-  let lastSyncedAssets: [string, Uint8Array][] = [];
-  let assetSyncPending = false;
+  const core = createRuntimeTargetCore({ getProject, getAssets, onOutput });
 
-  const renderStatus = (state: string, summaryText: string, message: string) => {
-    details.dataset.state = state;
-    summary.dataset.state = state;
-    summaryState.textContent = summaryText;
-    status.dataset.state = state;
-    status.textContent = message;
-  };
-
-  const renderState = (state: RuntimeState) => {
-    if (!state || !Number.isFinite(state.frame)) return;
-    const views = Array.isArray(state.views) ? state.views.map((view) => view.name).join(" + ") : "—";
-    frameValue.textContent = String(state.frame);
-    timeValue.textContent = Number.isFinite(state.tts) ? `${state.tts.toFixed(2)}s` : "—";
-    viewsValue.textContent = views || "—";
-    telemetry.hidden = false;
-    const model = typeof state.model === "string" ? state.model.trim() : "";
-    modelValue.textContent = model;
-    modelValue.hidden = model.length === 0;
-  };
-
-  const currentEndpoint = () => normalizeEndpoint(endpointInput.value);
-  const projectIsDirty = () =>
-    syncedRevision < projectRevision ||
-    freshSatisfiedRevision < freshRequiredRevision ||
-    assetSyncPending;
-
-  const disconnect = () => {
-    generation += 1;
-    clearTimeout(pushTimer ?? undefined);
-    clearTimeout(pollTimer ?? undefined);
-    client = null;
-    connected = false;
-    live = false;
-    syncedRevision = -1;
-    freshRequiredRevision = projectRevision;
-    freshSatisfiedRevision = -1;
-    pushQueued = false;
-    captureQueued = false;
-    syncError = null;
-    transportError = null;
-    lastSyncedAssetSource = null;
-    lastSyncedAssets = [];
-    assetSyncPending = false;
-    pushButton.disabled = !localEditorOrigin;
-    captureButton.disabled = true;
-    telemetry.hidden = true;
-    modelValue.hidden = true;
-    captureFrame.hidden = true;
-    if (captureUrl) {
-      URL.revokeObjectURL(captureUrl);
-      captureUrl = null;
+  // The endpoint field is the one input the core does not own: it is written
+  // by the user (and, in the e2e, assigned directly and given a bare `change`),
+  // so its value is mirrored INTO the core on both events rather than rendered
+  // back out of it.
+  const render = (snapshot: RuntimeTargetSnapshot): void => {
+    details.dataset.state = snapshot.state;
+    summary.dataset.state = snapshot.state;
+    summaryState.textContent = snapshot.summaryText;
+    status.dataset.state = snapshot.state;
+    status.textContent = snapshot.message;
+    pushButton.disabled = snapshot.pushDisabled;
+    captureButton.disabled = snapshot.captureDisabled;
+    telemetry.hidden = snapshot.telemetry === null;
+    if (snapshot.telemetry) {
+      frameValue.textContent = snapshot.telemetry.frame;
+      timeValue.textContent = snapshot.telemetry.time;
+      viewsValue.textContent = snapshot.telemetry.views;
+    }
+    modelValue.textContent = snapshot.model;
+    modelValue.hidden = snapshot.model.length === 0;
+    captureFrame.hidden = snapshot.captureUrl === null;
+    if (snapshot.captureUrl) {
+      captureImage.src = snapshot.captureUrl;
+    } else {
       captureImage.removeAttribute("src");
     }
-    renderStatus("off", "off", "Endpoint changed. Push to start a fresh model.");
   };
+  core.subscribe(() => render(core.getSnapshot()));
+  render(core.getSnapshot());
 
-  const pollState = async () => {
-    clearTimeout(pollTimer ?? undefined);
-    pollTimer = null;
-    if (!connected || !client || capturing || pushing) return;
-    const ownGeneration = generation;
-    // Pushes and captures request an immediate refresh, but they must not start
-    // independent polling chains when a state request is already in flight.
-    if (pollingGeneration === ownGeneration) return;
-    pollingGeneration = ownGeneration;
-    try {
-      const state = await client.state();
-      if (ownGeneration !== generation) return;
-      if (capturing || pushing) return;
-      renderState(state);
-      if (transportError) {
-        transportError = null;
-        if (syncError) {
-          renderStatus("error", "sync error", syncError);
-        } else if (projectIsDirty()) {
-          renderStatus("busy", "syncing", "Connection restored. Retrying the latest project…");
-          queuePush({ immediate: true });
-        } else {
-          renderStatus("live", "live", "Connection restored. Project is synchronized.");
-        }
-      }
-    } catch (error) {
-      if (ownGeneration !== generation) return;
-      if (capturing || pushing) return;
-      // `client` was non-null on entry; only `disconnect()` clears it, and that
-      // bumps the generation the guard above already returned on.
-      transportError = errorMessage(error, client!.endpoint, "state poll");
-      renderStatus(
-        "error",
-        syncError ? "sync error" : "retrying",
-        syncError ? `${syncError} Runtime unreachable: ${transportError}` : transportError
-      );
-    } finally {
-      if (pollingGeneration === ownGeneration) pollingGeneration = null;
-      if (ownGeneration === generation && connected && !capturing && !pushing) {
-        clearTimeout(pollTimer ?? undefined);
-        pollTimer = setTimeout(pollState, STATE_POLL_MS);
-      }
-    }
-  };
-
-  const ensureConnection = async (): Promise<BrowserRuntimeClient | null> => {
-    const endpoint = currentEndpoint();
-    if (!client || client.endpoint !== endpoint) {
-      client = new BrowserRuntimeClient(endpoint);
-      connected = false;
-    }
-    const runtime = client;
-    if (!connected) {
-      await runtime.discover();
-      // Endpoint changes disconnect the old client while discovery is in
-      // flight. Do not let its late response mark the replacement as linked.
-      if (client !== runtime) return null;
-      connected = true;
-      rememberEndpoint(endpoint);
-      captureButton.disabled = false;
-    }
-    return runtime;
-  };
-
-  const pushOnce = async () => {
-    const ownGeneration = generation;
-    // Snapshot the authored project and its fresh-model requirement before the
-    // first await. A reset that arrives during discovery or asset transfer gets
-    // a later revision and therefore remains fresh in the queued push.
-    const requestRevision = projectRevision;
-    const files = projectPairs(getProject());
-    const rawAssetsSnapshot = getAssets ? getAssets() : null;
-    const fresh = !live || freshSatisfiedRevision < freshRequiredRevision;
-    const sourceNeedsSync = syncedRevision < requestRevision || fresh;
-    let endpoint = endpointInput.value;
-    let assetCount = 0;
-    let resolvedAssetsSource: ProjectAssetInput[] | null = null;
-    let assets: [string, Uint8Array][] = [];
-    let sourceResult: string | null = null;
-    let runtime: BrowserRuntimeClient | null = null;
-    let assetsMutated = false;
-    let sourceAccepted = false;
-    const priorAssetsKnown = lastSyncedAssetSource !== null;
-    const priorAssets = lastSyncedAssets;
-    syncError = null;
-    renderStatus("busy", "syncing", connected ? "Sending the latest project…" : "Finding the runtime…");
-    pushButton.disabled = true;
-    try {
-      runtime = await ensureConnection();
-      if (ownGeneration !== generation || !runtime) return;
-      endpoint = runtime.endpoint;
-      if (getAssets) {
-        resolvedAssetsSource = await rawAssetsSnapshot;
-        assets = await projectAssets(resolvedAssetsSource);
-        assetCount = assets.length;
-        if (resolvedAssetsSource !== lastSyncedAssetSource) {
-          assetSyncPending = true;
-          for (const [path, bytes] of assets) {
-            await runtime.reloadAsset(path, bytes);
-            assetsMutated = true;
-          }
-          if (ownGeneration !== generation) return;
-        }
-      }
-      if (sourceNeedsSync) {
-        sourceResult = fresh
-          ? await runtime.loadProject(files)
-          : await runtime.reloadProject(files);
-        if (ownGeneration !== generation) return;
-        live = true;
-        syncedRevision = Math.max(syncedRevision, requestRevision);
-        if (fresh) {
-          freshSatisfiedRevision = Math.max(freshSatisfiedRevision, requestRevision);
-        }
-        sourceAccepted = true;
-      }
-      // Finalize deletions only after the new source is accepted. If source
-      // loading fails, the last-good program keeps every asset it still needs.
-      if (getAssets && resolvedAssetsSource !== lastSyncedAssetSource) {
-        await runtime.syncAssets(assets.map(([path]) => path));
-        if (ownGeneration !== generation) return;
-        lastSyncedAssetSource = resolvedAssetsSource;
-        lastSyncedAssets = assets;
-        assetSyncPending = false;
-      }
-      if (ownGeneration !== generation) return;
-      syncError = null;
-      transportError = null;
-      renderStatus(
-        "live",
-        "live",
-        fresh && sourceResult
-          ? `Fresh model loaded from ${files.length} source file${files.length === 1 ? "" : "s"}${
-              getAssets ? ` + ${assetCount} asset${assetCount === 1 ? "" : "s"}` : ""
-            }.`
-          : sourceResult ?? `Synchronized ${assetCount} project asset${assetCount === 1 ? "" : "s"}.`
-      );
-    } catch (error) {
-      if (ownGeneration !== generation) return;
-      let message = errorMessage(error, endpoint, "push");
-      // Asset reloads are eager. If the runtime definitively rejects the new
-      // source, restore the last browser-synchronized bytes + manifest so the
-      // last-good program cannot keep an overwritten or partially uploaded set.
-      if (
-        error instanceof RuntimeHttpError &&
-        (error.status === 400 || error.status === 413) &&
-        runtime &&
-        assetsMutated &&
-        !sourceAccepted &&
-        priorAssetsKnown
-      ) {
-        try {
-          for (const [path, bytes] of priorAssets) await runtime.reloadAsset(path, bytes);
-          await runtime.syncAssets(priorAssets.map(([path]) => path));
-          message = `${message} Last-good assets were restored.`;
-        } catch (rollbackError) {
-          message = `${message} Asset rollback also failed: ${errorMessage(
-            rollbackError,
-            endpoint,
-            "asset rollback"
-          )}`;
-        }
-      }
-      if (ownGeneration !== generation) return;
-      if (error instanceof RuntimeHttpError) {
-        syncError = message;
-        transportError = null;
-        renderStatus("error", "sync error", message);
-      } else {
-        transportError = message;
-        renderStatus("error", connected ? "retrying" : "offline", message);
-      }
-      onOutput("error", `[device] ${message}`);
-    } finally {
-      if (ownGeneration === generation) pushButton.disabled = false;
-    }
-  };
-
-  const flushPush = async () => {
-    if (capturing) {
-      pushQueued = true;
-      return;
-    }
-    if (pushing) {
-      pushQueued = true;
-      return;
-    }
-    pushing = true;
-    clearTimeout(pollTimer ?? undefined);
-    do {
-      pushQueued = false;
-      await pushOnce();
-    } while (pushQueued);
-    pushing = false;
-    if (captureQueued) {
-      captureQueued = false;
-      capture();
-    } else if (connected) {
-      pollState();
-    }
-  };
-
-  const queuePush = ({ immediate = false }: { immediate?: boolean } = {}) => {
-    clearTimeout(pushTimer ?? undefined);
-    // The initial load snapshots source before its first await. Edits that land
-    // while that load is in flight must queue even though `live` is still false.
-    if (pushing) {
-      pushQueued = true;
-      return;
-    }
-    if (!live && !immediate) return;
-    if (capturing) {
-      pushQueued = true;
-      return;
-    }
-    if (immediate) {
-      flushPush();
-    } else {
-      pushTimer = setTimeout(flushPush, LIVE_PUSH_DEBOUNCE_MS);
-    }
-  };
-
-  const projectChanged = ({ fresh = false }: { fresh?: boolean } = {}) => {
-    projectRevision += 1;
-    if (fresh) freshRequiredRevision = projectRevision;
-    syncError = null;
-    queuePush();
-  };
-
-  const capture = async () => {
-    if (capturing) return;
-    if (pushing) {
-      captureQueued = true;
-      captureButton.disabled = true;
-      return;
-    }
-    const ownGeneration = generation;
-    let endpoint = endpointInput.value;
-    capturing = true;
-    clearTimeout(pollTimer ?? undefined);
-    captureButton.disabled = true;
-    renderStatus("busy", "capture", "Waiting for the next rendered frame…");
-    try {
-      const runtime = await ensureConnection();
-      if (ownGeneration !== generation || !runtime) return;
-      endpoint = runtime.endpoint;
-      const blob = await runtime.capture();
-      if (ownGeneration !== generation) return;
-      if (captureUrl) URL.revokeObjectURL(captureUrl);
-      captureUrl = URL.createObjectURL(blob);
-      captureImage.src = captureUrl;
-      captureFrame.hidden = false;
-      transportError = null;
-      if (syncError) {
-        renderStatus(
-          "error",
-          "sync error",
-          "Captured the last-good framebuffer; the latest editor source is not synchronized."
-        );
-      } else if (projectIsDirty()) {
-        renderStatus(
-          "busy",
-          "syncing",
-          "Captured the last-good framebuffer. Retrying the latest project…"
-        );
-        queuePush({ immediate: true });
-      } else {
-        renderStatus("live", live ? "live" : "linked", "Captured the runtime framebuffer.");
-      }
-    } catch (error) {
-      if (ownGeneration !== generation) return;
-      const message = errorMessage(error, endpoint, "capture");
-      if (!(error instanceof RuntimeHttpError)) transportError = message;
-      renderStatus("error", live ? "capture error" : "offline", message);
-      onOutput("error", `[device] ${message}`);
-    } finally {
-      capturing = false;
-      if (ownGeneration === generation) captureButton.disabled = !connected;
-      if (pushQueued) flushPush();
-      if (ownGeneration === generation && connected) pollState();
-    }
-  };
-
-  const restart = () => {
-    if (!live) return;
-    projectRevision += 1;
-    freshRequiredRevision = projectRevision;
-    syncError = null;
-    queuePush({ immediate: true });
-  };
-
-  endpointInput.addEventListener("change", disconnect);
-  pushButton.addEventListener("click", () => queuePush({ immediate: true }));
-  captureButton.addEventListener("click", capture);
+  endpointInput.addEventListener("input", () => core.setEndpoint(endpointInput.value));
+  endpointInput.addEventListener("change", () => {
+    core.setEndpoint(endpointInput.value);
+    core.disconnect();
+  });
+  pushButton.addEventListener("click", core.push);
+  captureButton.addEventListener("click", core.capture);
   closeButton.addEventListener("click", () => {
     details.open = false;
     summary.focus();
   });
 
-  if (!localEditorOrigin) {
-    pushButton.disabled = true;
-    renderStatus(
-      "off",
-      "local only",
-      "For safety, Functor runtimes accept editor links only from a localhost-served IDE."
-    );
-  }
-
-  const destroy = () => {
-    disconnect();
-    if (captureUrl) URL.revokeObjectURL(captureUrl);
-  };
-  window.addEventListener("pagehide", destroy, { once: true });
-
-  return {
-    projectChanged,
-    restart,
-    capture,
-    destroy,
-    state: () => ({
-      endpoint: endpointInput.value,
-      connected,
-      live,
-      fresh: !live || freshSatisfiedRevision < freshRequiredRevision,
-      status: status.dataset.state,
-      message: status.textContent,
-    }),
-  };
+  return core;
 }

--- a/site/src/runtime-target.ts
+++ b/site/src/runtime-target.ts
@@ -4,7 +4,7 @@
 // renders the same core through `components/RuntimeTargetPanel.tsx`; this file
 // goes away when the IDE converts too.)
 
-import { createRuntimeTargetCore, storedEndpoint } from "./runtime-target-core.js";
+import { createRuntimeTargetCore } from "./runtime-target-core.js";
 import type {
   ProjectAssetInput,
   ProjectFileInput,
@@ -98,9 +98,10 @@ export function createRuntimeTarget({
   const captureFrame = host.querySelector<HTMLElement>("[data-runtime-capture-frame]")!;
   const captureImage = host.querySelector<HTMLImageElement>("[data-runtime-image]")!;
 
-  endpointInput.value = storedEndpoint();
-
   const core = createRuntimeTargetCore({ getProject, getAssets, onOutput });
+  // The core read the persisted endpoint; seed the field from it rather than
+  // reading storage a second time, so the two can never disagree.
+  endpointInput.value = core.getSnapshot().endpoint;
 
   // The endpoint field is the one input the core does not own: it is written
   // by the user (and, in the e2e, assigned directly and given a bare `change`),

--- a/site/src/sandbox.tsx
+++ b/site/src/sandbox.tsx
@@ -120,6 +120,14 @@ window.addEventListener("message", (event) => {
 });
 
 
+// Created once, outside React: this controller carries the live link's queued
+// pushes and its `/state` poll chain, so a re-render must never restart it.
+const runtimeTarget = createRuntimeTargetCore({
+  getProject: () => [["game.fun", view.state.doc.toString()], ...siblingSources],
+  getAssets: () => assetSources,
+  onOutput: (level, message) => statusBar.appendOutput(level, message),
+});
+
 // Set while loadExample replaces the buffer programmatically: that content is
 // exactly what the fresh iframe is about to fetch, so pushing it back would
 // be a redundant reload (and would mislabel a fresh load as a hot reload).
@@ -139,14 +147,6 @@ const view = new EditorView({
       }
     }),
   ],
-});
-
-// Created once, outside React: this controller carries the live link's queued
-// pushes and its `/state` poll chain, so a re-render must never restart it.
-const runtimeTarget = createRuntimeTargetCore({
-  getProject: () => [["game.fun", view.state.doc.toString()], ...siblingSources],
-  getAssets: () => assetSources,
-  onOutput: (level, message) => statusBar.appendOutput(level, message),
 });
 
 // Live type diagnostics: load the analysis wasm lazily and, once ready, append

--- a/site/src/sandbox.tsx
+++ b/site/src/sandbox.tsx
@@ -3,7 +3,14 @@
 // VSCode live-preview panel uses). Edits are debounced and pushed as
 // `functor-lang-set-source`; the runtime hot-swaps the program with the model
 // preserved and replies `functor-lang-set-source-result`.
+//
+// The page shell is static HTML; the CHROME around the editor (the picker, the
+// pill, the external-runtime panel, the status bar) renders as React islands
+// mounted into that shell's containers. The editor itself is not React —
+// CodeMirror owns `#editor`'s subtree — and all the load/push logic below
+// stays plain imperative code that publishes to small stores.
 
+import { createRoot } from "react-dom/client";
 import { basicSetup } from "codemirror";
 import { EditorView, keymap } from "@codemirror/view";
 import { StateEffect } from "@codemirror/state";
@@ -22,23 +29,21 @@ import {
   currentExpects,
 } from "./lang-intel.js";
 import { PlayerBridge } from "./player-bridge.js";
-import { createStatusBar } from "./status-bar.js";
-import { createRuntimeTarget } from "./runtime-target.js";
+import { createStatusBarStore } from "./status-bar-store.js";
+import { createRuntimeTargetCore } from "./runtime-target-core.js";
+import type { RuntimeTargetState } from "./runtime-target-core.js";
+import { createStore } from "./store.js";
+import { SandboxControls } from "./components/SandboxControls.js";
+import type { PickerState, PillState } from "./components/SandboxControls.js";
+import { StatusBar } from "./components/StatusBar.js";
 import { asPlayerMessage } from "./protocol.js";
 import { EXAMPLES } from "./examples.js";
-
-/** The preview pill's three states — also its `data-state` attribute value. */
-type PillState = "busy" | "live" | "error";
 
 /** The sandbox's e2e seam (driven by e2e/site-sandbox.mjs). */
 interface SandboxSeam {
   setSource(source: string): void;
   source: () => string;
-  status: () => {
-    state: string | undefined;
-    text: string | null;
-    message: string;
-  };
+  status: () => { state: string; text: string; message: string };
   runtimeTarget: () => RuntimeTargetState;
   getSource: () => string;
   triggerComplete(source: string, cursor: number): void;
@@ -58,25 +63,28 @@ interface LangSeam {
   expects: () => ReturnType<typeof currentExpects>;
 }
 
-type RuntimeTarget = ReturnType<typeof createRuntimeTarget>;
-type RuntimeTargetState = ReturnType<RuntimeTarget["state"]>;
-
 const frame = document.getElementById("player") as HTMLIFrameElement;
-const statusPill = document.getElementById("status")!;
-const picker = document.getElementById("example-picker") as HTMLSelectElement;
-const resetButton = document.getElementById("reset")!;
 
-const setStatus = (state: PillState, text: string, detail = "") => {
-  statusPill.dataset.state = state;
-  statusPill.textContent = text;
+// An inline program from the URL fragment (the docs' "try it" buttons):
+// #src=<base64url> becomes the editor buffer and the player's ?src= data:
+// URL, so it starts with a fresh init — no served file involved.
+const inlineSrc = new URLSearchParams(window.location.hash.slice(1)).get("src");
+const requested = new URLSearchParams(window.location.search).get("example");
+const initialExample = EXAMPLES.some((e) => e.id === requested) ? requested! : EXAMPLES[0].id;
+
+const picker = createStore<PickerState>({
+  options: EXAMPLES.map((example) => ({ value: example.id, label: example.label })),
+  selected: initialExample,
+});
+const pill = createStore<PillState>({ state: "busy", text: "◌ loading…", detail: "" });
+
+const setStatus = (state: PillState["state"], text: string, detail = "") =>
   // The detail (the reload note, or a parse error) lives in the pill's tooltip
   // and — for errors — the Output panel. No separate error banner under the
   // editor: the preview pill is the single live indicator.
-  statusPill.title = detail;
-};
+  pill.set({ state, text, detail });
 
-const statusBar = createStatusBar({ host: document.getElementById("statusbar")! });
-let runtimeTarget: RuntimeTarget | null = null;
+const statusBar = createStatusBarStore();
 // The sandbox edits only the entry buffer, but some examples also load sibling
 // modules (for example Mario's generated assets.fun manifest). Keep those
 // fetched sources so an external runtime receives the same complete project as
@@ -127,14 +135,15 @@ const view = new EditorView({
     EditorView.updateListener.of((update) => {
       if (update.docChanged && !programmaticEdit) {
         bridge.push(view.state.doc.toString());
-        runtimeTarget?.projectChanged();
+        runtimeTarget.projectChanged();
       }
     }),
   ],
 });
 
-runtimeTarget = createRuntimeTarget({
-  host: document.getElementById("runtime-target"),
+// Created once, outside React: this controller carries the live link's queued
+// pushes and its `/state` poll chain, so a re-render must never restart it.
+const runtimeTarget = createRuntimeTargetCore({
   getProject: () => [["game.fun", view.state.doc.toString()], ...siblingSources],
   getAssets: () => assetSources,
   onOutput: (level, message) => statusBar.appendOutput(level, message),
@@ -201,12 +210,9 @@ const setDoc = (
   programmaticEdit = true;
   view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: source } });
   programmaticEdit = false;
-  runtimeTarget?.projectChanged({ fresh: true });
+  runtimeTarget.projectChanged({ fresh: true });
 };
 
-// An inline program from the URL fragment (the docs' "try it" buttons):
-// #src=<base64url> becomes the editor buffer and the player's ?src= data:
-// URL, so it starts with a fresh init — no served file involved.
 const fromBase64Url = (b64u: string) =>
   new TextDecoder().decode(
     Uint8Array.from(atob(b64u.replace(/-/g, "+").replace(/_/g, "/")), (c) => c.charCodeAt(0))
@@ -230,13 +236,13 @@ const loadInline = (b64u: string) => {
   inlineB64 = b64u;
   // Reflect the inline program in the picker so it (and Reset) don't lie
   // about what's loaded.
-  if (!picker.querySelector('option[value="__inline"]')) {
-    const option = document.createElement("option");
-    option.value = "__inline";
-    option.textContent = "docs snippet";
-    picker.appendChild(option);
-  }
-  picker.value = "__inline";
+  const options = picker.getSnapshot().options;
+  picker.set({
+    options: options.some((option) => option.value === "__inline")
+      ? options
+      : [...options, { value: "__inline", label: "docs snippet" }],
+    selected: "__inline",
+  });
   loadToken += 1; // supersede any in-flight example fetch
   setDoc(source);
   setStatus("busy", "◌ loading…");
@@ -293,35 +299,43 @@ const loadExample = async (id: string) => {
   frame.src = `player.html?${params}`;
 };
 
-for (const example of EXAMPLES) {
-  const option = document.createElement("option");
-  option.value = example.id;
-  option.textContent = example.label;
-  picker.appendChild(option);
-}
-
-picker.addEventListener("change", () => {
-  if (picker.value === "__inline") {
+const selectExample = (value: string) => {
+  picker.set({ ...picker.getSnapshot(), selected: value });
+  if (value === "__inline") {
     // The `__inline` option only exists once loadInline has stored its source.
     loadInline(inlineB64!);
     return;
   }
   const url = new URL(window.location.href);
-  url.searchParams.set("example", picker.value);
+  url.searchParams.set("example", value);
   url.hash = "";
   window.history.replaceState(null, "", url);
-  loadExample(picker.value);
-});
+  loadExample(value);
+};
 
-resetButton.addEventListener("click", () =>
-  picker.value === "__inline" ? loadInline(inlineB64!) : loadExample(picker.value)
+const resetExample = () => {
+  const selected = picker.getSnapshot().selected;
+  if (selected === "__inline") loadInline(inlineB64!);
+  else loadExample(selected);
+};
+
+// Mount the islands into the static shell's containers. Both keep their
+// element ids and class names, so styles.css and every e2e selector match the
+// rendered DOM exactly as they matched the hand-built one.
+createRoot(document.querySelector(".sandbox-controls")!).render(
+  <SandboxControls
+    picker={picker}
+    pill={pill}
+    runtimeTarget={runtimeTarget}
+    onSelect={selectExample}
+    onReset={resetExample}
+  />
 );
+const statusBarHost = document.getElementById("statusbar")!;
+statusBarHost.className = "statusbar";
+createRoot(statusBarHost).render(<StatusBar store={statusBar} />);
 
-const inlineSrc = new URLSearchParams(window.location.hash.slice(1)).get("src");
-const requested = new URLSearchParams(window.location.search).get("example");
-const initial = EXAMPLES.some((e) => e.id === requested) ? requested! : EXAMPLES[0].id;
-picker.value = initial;
-if (!(inlineSrc && loadInline(inlineSrc))) loadExample(initial);
+if (!(inlineSrc && loadInline(inlineSrc))) loadExample(initialExample);
 
 // Test seam for the headless e2e (e2e/site-sandbox.mjs): set the buffer and
 // observe results without synthesizing keyboard events.
@@ -330,13 +344,14 @@ if (!(inlineSrc && loadInline(inlineSrc))) loadExample(initial);
     view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: source } });
   },
   source: () => view.state.doc.toString(),
-  status: () => ({
-    state: statusPill.dataset.state,
-    text: statusPill.textContent,
-    message: statusPill.title,
-  }),
-  // Assigned during boot, long before any e2e call can reach this seam.
-  runtimeTarget: () => runtimeTarget!.state(),
+  // Read the pill's store, which the rendered pill mirrors exactly: the seam
+  // stays synchronous with the page's own state rather than racing a React
+  // commit. The fields are the pre-migration ones (`title` was the detail).
+  status: () => {
+    const { state, text, detail } = pill.getSnapshot();
+    return { state, text, message: detail };
+  },
+  runtimeTarget: () => runtimeTarget.state(),
   getSource: () => view.state.doc.toString(),
   // Replace the buffer, place the cursor, and open the completion popup
   // (explicit trigger). Guarded so it does NOT push to the runtime — completion

--- a/site/src/status-bar-store.ts
+++ b/site/src/status-bar-store.ts
@@ -11,7 +11,7 @@
 import type { ConsoleLevel } from "./protocol.js";
 import type { Execution, Problem, StatusBar } from "./status-bar.js";
 
-export const MAX_OUTPUT_LINES = 500;
+const MAX_OUTPUT_LINES = 500;
 
 /** One rendered output row. `time` is stamped at append, not at flush. */
 export interface OutputLine {
@@ -44,13 +44,7 @@ const clock = (date: Date): string => {
 export const outputPreamble = (frame: number | null, time: string): string =>
   frame == null ? `[${time}]` : `[Frame ${frame} | ${time}]`;
 
-export const createStatusBarStore = (
-  // Injectable so a test can drive the flush deterministically; the page uses
-  // the real rAF.
-  schedule: (flush: () => void) => void = (flush) => {
-    requestAnimationFrame(flush);
-  }
-): StatusBarStore => {
+export const createStatusBarStore = (): StatusBarStore => {
   let snapshot: StatusBarSnapshot = { problems: [], output: [], executions: [] };
   const listeners = new Set<() => void>();
 
@@ -92,7 +86,7 @@ export const createStatusBarStore = (
       pending.push({ level, text, frame, time: clock(new Date()), id: nextId++ });
       if (!flushScheduled) {
         flushScheduled = true;
-        schedule(flushOutput);
+        requestAnimationFrame(flushOutput);
       }
     },
 

--- a/site/src/status-bar-store.ts
+++ b/site/src/status-bar-store.ts
@@ -1,0 +1,103 @@
+// The status bar's LOGIC, split out of the DOM component so a React view can
+// render it: the problems list, the rAF-coalesced output log (capped, newest
+// wins), and the paused inspector's executions picker.
+//
+// The store deliberately implements the same `StatusBar` handle the imperative
+// `status-bar.ts` returns, so its producers — the page's own `appendOutput`
+// calls and `wireLiveTrace`'s `setExecutions` — are unchanged by the migration.
+// The types still live in `status-bar.ts` while the IDE renders that version;
+// they move here when the IDE converts and that module goes away.
+
+import type { ConsoleLevel } from "./protocol.js";
+import type { Execution, Problem, StatusBar } from "./status-bar.js";
+
+export const MAX_OUTPUT_LINES = 500;
+
+/** One rendered output row. `time` is stamped at append, not at flush. */
+export interface OutputLine {
+  level: ConsoleLevel;
+  text: string;
+  frame: number | null;
+  time: string;
+  /** Render key: appends are monotonic, so a counter is a stable identity. */
+  id: number;
+}
+
+export interface StatusBarSnapshot {
+  problems: Problem[];
+  output: OutputLine[];
+  executions: Execution[];
+}
+
+export interface StatusBarStore extends StatusBar {
+  subscribe: (listener: () => void) => () => void;
+  getSnapshot: () => StatusBarSnapshot;
+}
+
+// Each line carries a `[Frame N | HH:MM:SS]` preamble — the game frame it was
+// emitted on (when the runtime had one) and the wall clock.
+const clock = (date: Date): string => {
+  const two = (n: number): string => String(n).padStart(2, "0");
+  return `${two(date.getHours())}:${two(date.getMinutes())}:${two(date.getSeconds())}`;
+};
+
+export const outputPreamble = (frame: number | null, time: string): string =>
+  frame == null ? `[${time}]` : `[Frame ${frame} | ${time}]`;
+
+export const createStatusBarStore = (
+  // Injectable so a test can drive the flush deterministically; the page uses
+  // the real rAF.
+  schedule: (flush: () => void) => void = (flush) => {
+    requestAnimationFrame(flush);
+  }
+): StatusBarStore => {
+  let snapshot: StatusBarSnapshot = { problems: [], output: [], executions: [] };
+  const listeners = new Set<() => void>();
+
+  const emit = (next: StatusBarSnapshot): void => {
+    snapshot = next;
+    for (const listener of listeners) listener();
+  };
+
+  // Appends are rAF-coalesced: a per-frame `Debug.log` in tick/draw arrives
+  // ~60/sec, and one store update (hence one React render) per frame keeps the
+  // panel usable under a logging loop.
+  let pending: OutputLine[] = [];
+  let flushScheduled = false;
+  let nextId = 0;
+
+  const flushOutput = (): void => {
+    flushScheduled = false;
+    if (pending.length === 0) return;
+    // A burst larger than the cap only ever shows its tail — skip the rest.
+    const lines = pending.slice(-MAX_OUTPUT_LINES);
+    pending = [];
+    emit({ ...snapshot, output: [...snapshot.output, ...lines].slice(-MAX_OUTPUT_LINES) });
+  };
+
+  return {
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    getSnapshot: () => snapshot,
+
+    setProblems: (items) => emit({ ...snapshot, problems: items }),
+
+    // `frame` is the game frame the line belongs to (null when the runtime had
+    // none to offer — boot lines, host-side reload errors).
+    appendOutput: (level, text, frame = null) => {
+      pending.push({ level, text, frame, time: clock(new Date()), id: nextId++ });
+      if (!flushScheduled) {
+        flushScheduled = true;
+        schedule(flushOutput);
+      }
+    },
+
+    // The paused frame's entry-point executions (the inspector's picker), in
+    // frame order. Empty while the game plays.
+    setExecutions: (items) => emit({ ...snapshot, executions: items }),
+  };
+};

--- a/site/src/store.ts
+++ b/site/src/store.ts
@@ -1,0 +1,29 @@
+// The smallest external store a React island can subscribe to with
+// `useSyncExternalStore`: the page's imperative code (the player bridge, the
+// example loader) keeps calling plain functions, and the view re-renders.
+// A `set` replaces the snapshot object, so identity comparison is the change
+// signal.
+
+export interface Store<T> {
+  subscribe: (listener: () => void) => () => void;
+  getSnapshot: () => T;
+  set: (next: T) => void;
+}
+
+export const createStore = <T>(initial: T): Store<T> => {
+  let snapshot = initial;
+  const listeners = new Set<() => void>();
+  return {
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    getSnapshot: () => snapshot,
+    set: (next) => {
+      snapshot = next;
+      for (const listener of listeners) listener();
+    },
+  };
+};

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -25,6 +25,12 @@
     "isolatedModules": true,
     "verbatimModuleSyntax": true,
 
+    // The sandbox chrome renders as React islands (site/src/components/*.tsx).
+    // esbuild reads this key too, so the automatic runtime is configured once
+    // here for both the checker and the bundler — no per-file JSX pragma and
+    // no `import React` needed.
+    "jsx": "react-jsx",
+
     // esbuild is not the only consumer. site/build.mjs imports modules out of
     // src/ directly, and a migrated one is imported by its `.ts` specifier
     // (Node, unlike esbuild, does NOT resolve `./x.js` to `x.ts`) — so it is
@@ -49,5 +55,8 @@
     "noEmit": true,
     "skipLibCheck": true
   },
-  "include": ["src/**/*.ts"]
+  // `.tsx` joins the checked set alongside `.ts` — the React islands in
+  // src/components/ are checked directly, not merely transitively via their
+  // importer.
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }


### PR DESCRIPTION
Step 4, PR A of the site modernisation: React arrives, and the **sandbox page's chrome** renders as islands mounted into the existing static shell. Behaviour-preserving — identical pixels, identical interactions, every e2e suite passing unmodified.

## Architecture

The static HTML shell still paints first; React mounts into the containers it already had. CodeMirror keeps owning `#editor` — React never touches that subtree. All load/push logic stays plain imperative code that publishes to small stores the islands subscribe to with `useSyncExternalStore`. No state library, no context, no `StrictMode` (a double-mount would restart the runtime link's poll chain).

| File | What it is |
| --- | --- |
| `site/src/store.ts` | The ~20-line external store the islands subscribe to |
| `site/src/status-bar-store.ts` | The status bar's LOGIC — problems, the rAF-coalesced 500-line output log, executions — implementing the same `StatusBar` handle its producers already call |
| `site/src/components/StatusBar.tsx` | Its view: same markup, same class names, all three lists kept mounted and toggled with `display` |
| `site/src/runtime-target-core.ts` | The external-runtime client + state machine, lifted out of `runtime-target.ts` unchanged; the DOM writes became one snapshot |
| `site/src/components/RuntimeTargetPanel.tsx` | The device panel's React view |
| `site/src/components/SandboxControls.tsx` | Scene picker, reset, the device panel, the status pill |
| `site/src/runtime-target.ts` | Now only the imperative view over the same core — still the IDE's, until PR B |
| `site/src/sandbox.ts` → `sandbox.tsx` | Mounts the two roots; `build.mjs`'s entry PATH follows (output is still `dist/assets/sandbox.js`) |

`site/src/status-bar.ts` is untouched and still the IDE's. Transitional duplication of *view* code is expected; PR B converts the IDE onto these components and both old views go away.

Only two `tsconfig.json` changes: `"jsx": "react-jsx"`, and `.tsx` added to `include` so the components are checked directly rather than merely transitively. Every existing flag stays (`verbatimModuleSyntax`, `exactOptionalPropertyTypes`, `erasableSyntaxOnly` — all compatible).

## Seam preservation

`window.__sandbox` / `__lang` / `__scrub` keep their shapes verbatim, and no file under `e2e/` or `site/demos/` was edited.

- **`__sandbox.status()`** now reads the pill's store instead of the pill's DOM. Same three fields, same values, and *synchronous* with the page's own state rather than racing a React commit.
- **The endpoint input stays UNCONTROLLED** with native `input`/`change` listeners attached via ref. `e2e/runtime-target.mjs:332` assigns `.value` directly and dispatches an untrusted `change` — React's synthetic `onChange` (an `input`-delegated listener behind a value tracker) would see neither. The listeners install in a *layout* effect so they exist from the commit.
- **The runtime-link controller is created once, outside React**, so a re-render can't restart its `/state` poll chain (`runtime-target.mjs` asserts ≤3 polls in 2.25s) or drop pushes queued during an in-flight load.
- **`details.open = false`** on the panel's close button stays an imperative DOM write — the suite reads `.open` with no wait after the click.
- Rendered DOM stays selector-compatible: `#example-picker` (a real `<select>` with `.options`), `#reset`, `#status`, `.runtime-target` (a native `<details>`), every `data-runtime-*` hook, `.statusbar-tab[data-tab=…]`, `.problem-row`, `.output-line`, `.exec-row`, and the text contracts (`"left + right"`, `"sync error"`, `"✓ 0 problems"`, `/⏸ \d+ executions/`, `/^\[Frame \d+ \| \d{2}:\d{2}:\d{2}\]/`).

## Bundle delta

| Bundle | main | HEAD | |
| --- | --- | --- | --- |
| `sandbox.js` | 431,671 B | 627,322 B | **+195,651 B** (+45%); gzip 140,408 → 201,387 B (+61 kB) |
| `ide.js` | 433,823 B | 434,760 B | +937 B — `runtime-target.ts` now imports the shared core |
| `hero.js`, `demo-editor.js`, `docs.js`, `api-docs.js`, `features.js` | | | **byte-identical** (SHA-256 verified) |

The sandbox delta is react-dom. It ships in **production** mode: esbuild defines `process.env.NODE_ENV` as `"production"` when minifying a browser bundle, and the bundle contains only `cjs/react-dom-client.production.js` (verified — no development build, no `process.env` reference survives). A comment in `build.mjs` ties that to `minify`.

## Visual parity

Built and served at `main` and at HEAD, screenshotted with headless chromium at 1280×800 and 390×844 in matched states. The live WebGL preview and the output lines' `[Frame N | HH:MM:SS]` preamble are masked (pink) — they differ between any two runs of the same build.

**Byte-identical:** desktop, mobile, mobile + device panel, problems panel, and an element-only shot of the opened external-runtime panel.
**Not identical:** the desktop `output`/`device` pair, by **111 px of 1,024,000** — the runtime's own hot-reload duration text (`5.00ms` vs `7.00ms`). Zoomed crops confirmed it is that glyph and nothing else.

| | main | React islands |
| --- | --- | --- |
| desktop | ![](https://gist.githubusercontent.com/tommy-xr/b3af031b780d7adbdb4a1fa3e23550ca/raw/before-desktop.png) | ![](https://gist.githubusercontent.com/tommy-xr/b3af031b780d7adbdb4a1fa3e23550ca/raw/after-desktop.png) |
| mobile (390px) | ![](https://gist.githubusercontent.com/tommy-xr/b3af031b780d7adbdb4a1fa3e23550ca/raw/before-mobile.png) | ![](https://gist.githubusercontent.com/tommy-xr/b3af031b780d7adbdb4a1fa3e23550ca/raw/after-mobile.png) |
| problems panel | ![](https://gist.githubusercontent.com/tommy-xr/b3af031b780d7adbdb4a1fa3e23550ca/raw/before-problems.png) | ![](https://gist.githubusercontent.com/tommy-xr/b3af031b780d7adbdb4a1fa3e23550ca/raw/after-problems.png) |
| output panel | ![](https://gist.githubusercontent.com/tommy-xr/b3af031b780d7adbdb4a1fa3e23550ca/raw/before-output.png) | ![](https://gist.githubusercontent.com/tommy-xr/b3af031b780d7adbdb4a1fa3e23550ca/raw/after-output.png) |
| device panel (element) | ![](https://gist.githubusercontent.com/tommy-xr/b3af031b780d7adbdb4a1fa3e23550ca/raw/before-panel.png) | ![](https://gist.githubusercontent.com/tommy-xr/b3af031b780d7adbdb4a1fa3e23550ca/raw/after-panel.png) |

## Verification

All re-run **after** the review fixes:

| Check | Result |
| --- | --- |
| `npm run check:site` | pass |
| `npm run site:build` | pass |
| `FUNCTOR_SITE_PORT=8291 node e2e/site-sandbox.mjs` | **ALL CHECKS PASSED** (lang-intel genuinely ran, not skipped) |
| `FUNCTOR_SITE_PORT=8292 node e2e/ide-page.mjs` | RESULT: PASS |
| `FUNCTOR_SITE_PORT=8293 node e2e/ide-project.mjs` | RESULT: PASS |
| `node e2e/runtime-target.mjs` | **ALL CHECKS PASSED** (all 24, incl. every ordering assertion) |

Note for anyone reproducing: the checked-in wasm bundles were a day stale versus today's runtime commits, so `e2e/site-sandbox.mjs` failed at "hero never loaded" **on `main` too**. `wasm-pack build runtime/functor-runtime-web --target=web` + `npm run build:lang-wasm` first. One scrubber-timing flake (`__scrub.range()` inside player.html, unrelated to this change) appeared once and passed on a clean re-run.

## Review dispositions (`/xreview` — Claude subagent + Codex CLI)

0 Critical. 0 High. Both engines independently confirmed the state-machine port is faithful and the rendered chrome is intact.

**[AGREED] Medium — endpoint listeners attached in a passive effect.** Fixed: `useLayoutEffect`, so they install during the commit.
**[AGREED] Medium — the autoscroll's `stick` flag didn't reproduce the pre-append measurement.** Fixed: it now measures during the render that carries the new lines, while the DOM still holds the old ones — the imperative bar's reading exactly. The scroll-event heuristic (which diverged on resize, wrapping, and cap trimming) is gone, along with its handler.
**Medium — the static shell's controls markup is replaced on mount and duplicates the pill's initial state.** Kept deliberately (the shell must paint before JS) and commented in `sandbox.html` as the pre-JS paint that tracks `sandbox.tsx`'s initial stores.
**Medium — the store's `schedule` injection was speculative.** Fixed: dropped.
**Low — TDZ guard removed around `runtimeTarget`.** Fixed: the core is constructed before the editor view.
**Low — `disconnect()` notifies twice; the field re-reads localStorage; `state` typed as `string`.** All three fixed (one snapshot, seed from the core, a `RuntimeLinkState` union so a typo'd `data-state` fails the check).
**Low — dead `MAX_OUTPUT_LINES` export.** Fixed.
**Low — `key={index}` on problems/executions rows.** Not changed, deliberately: both lists are replaced wholesale, the rows hold no local state, and a content-derived key would collide on two identical diagnostics.
**Visual — the device panel's body sat behind the screenshot mask.** Addressed: added an element-only capture of the opened panel; it is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
