### PR TITLE
feat(site): functor boot loader on the editor surfaces

### DIFF
--- a/site/ide.html
+++ b/site/ide.html
@@ -47,6 +47,33 @@
         <div id="editor"></div>
       </section>
       <section class="preview-pane">
+        <!-- The boot loader. Static markup on purpose: it paints on the first
+             frame, long before the editor bundle and the wasm runtime arrive.
+             src/ide.ts dismisses it (`.is-done`); the rest is styles.css. -->
+        <div class="fn-boot" data-fn-boot>
+          <svg class="fn-boot-defs" aria-hidden="true">
+            <symbol id="fn-boot-mark" viewBox="366 163 385 690">
+              <path d="M382 341 545 179H735L615 300H548L382 466Z" />
+              <path d="M382 493 497 380V748L382 837Z" />
+              <path d="M518 426H693L597 522H518Z" />
+            </symbol>
+          </svg>
+          <div class="fn-boot-word" aria-hidden="true">FUNCTOR</div>
+          <div class="fn-boot-stage" aria-hidden="true">
+            <div class="fn-boot-spin">
+          <span class="fn-boot-slice" style="--i:0"><svg><use href="#fn-boot-mark" /></svg></span>
+          <span class="fn-boot-slice" style="--i:1"><svg><use href="#fn-boot-mark" /></svg></span>
+          <span class="fn-boot-slice" style="--i:2"><svg><use href="#fn-boot-mark" /></svg></span>
+          <span class="fn-boot-slice" style="--i:3"><svg><use href="#fn-boot-mark" /></svg></span>
+          <span class="fn-boot-slice" style="--i:4"><svg><use href="#fn-boot-mark" /></svg></span>
+          <span class="fn-boot-slice" style="--i:5"><svg><use href="#fn-boot-mark" /></svg></span>
+          <span class="fn-boot-slice" style="--i:6"><svg><use href="#fn-boot-mark" /></svg></span>
+          <span class="fn-boot-slice" style="--i:7"><svg><use href="#fn-boot-mark" /></svg></span>
+          <span class="fn-boot-slice" style="--i:8"><svg><use href="#fn-boot-mark" /></svg></span>
+            </div>
+          </div>
+          <p class="fn-boot-label">loading<span class="fn-boot-dots"></span></p>
+        </div>
         <iframe id="player" title="live game preview" allow="pointer-lock"></iframe>
       </section>
     </main>

--- a/site/ide.html
+++ b/site/ide.html
@@ -72,7 +72,7 @@
           <span class="fn-boot-slice" style="--i:8"><svg><use href="#fn-boot-mark" /></svg></span>
             </div>
           </div>
-          <p class="fn-boot-label">loading<span class="fn-boot-dots"></span></p>
+          <p class="fn-boot-label" role="status">loading<span class="fn-boot-dots"></span></p>
         </div>
         <iframe id="player" title="live game preview" allow="pointer-lock"></iframe>
       </section>

--- a/site/index.html
+++ b/site/index.html
@@ -68,7 +68,7 @@
             <span class="fn-boot-slice" style="--i:8"><svg><use href="#fn-boot-mark" /></svg></span>
               </div>
             </div>
-            <p class="fn-boot-label">loading<span class="fn-boot-dots"></span></p>
+            <p class="fn-boot-label" role="status">loading<span class="fn-boot-dots"></span></p>
           </div>
           <iframe
             class="hero-scene"

--- a/site/index.html
+++ b/site/index.html
@@ -43,6 +43,33 @@
       </div>
       <div class="hero-demo">
         <div class="hero-card">
+          <!-- The boot loader. Static markup on purpose: it paints on the first
+               frame, long before the editor bundle and the wasm runtime arrive.
+               src/hero.ts dismisses it (`.is-done`); the rest is styles.css. -->
+          <div class="fn-boot" data-fn-boot>
+            <svg class="fn-boot-defs" aria-hidden="true">
+              <symbol id="fn-boot-mark" viewBox="366 163 385 690">
+                <path d="M382 341 545 179H735L615 300H548L382 466Z" />
+                <path d="M382 493 497 380V748L382 837Z" />
+                <path d="M518 426H693L597 522H518Z" />
+              </symbol>
+            </svg>
+            <div class="fn-boot-word" aria-hidden="true">FUNCTOR</div>
+            <div class="fn-boot-stage" aria-hidden="true">
+              <div class="fn-boot-spin">
+            <span class="fn-boot-slice" style="--i:0"><svg><use href="#fn-boot-mark" /></svg></span>
+            <span class="fn-boot-slice" style="--i:1"><svg><use href="#fn-boot-mark" /></svg></span>
+            <span class="fn-boot-slice" style="--i:2"><svg><use href="#fn-boot-mark" /></svg></span>
+            <span class="fn-boot-slice" style="--i:3"><svg><use href="#fn-boot-mark" /></svg></span>
+            <span class="fn-boot-slice" style="--i:4"><svg><use href="#fn-boot-mark" /></svg></span>
+            <span class="fn-boot-slice" style="--i:5"><svg><use href="#fn-boot-mark" /></svg></span>
+            <span class="fn-boot-slice" style="--i:6"><svg><use href="#fn-boot-mark" /></svg></span>
+            <span class="fn-boot-slice" style="--i:7"><svg><use href="#fn-boot-mark" /></svg></span>
+            <span class="fn-boot-slice" style="--i:8"><svg><use href="#fn-boot-mark" /></svg></span>
+              </div>
+            </div>
+            <p class="fn-boot-label">loading<span class="fn-boot-dots"></span></p>
+          </div>
           <iframe
             class="hero-scene"
             src="player.html?game=examples%2Fhero.fun"

--- a/site/sandbox.html
+++ b/site/sandbox.html
@@ -69,7 +69,7 @@
           <span class="fn-boot-slice" style="--i:8"><svg><use href="#fn-boot-mark" /></svg></span>
             </div>
           </div>
-          <p class="fn-boot-label">loading<span class="fn-boot-dots"></span></p>
+          <p class="fn-boot-label" role="status">loading<span class="fn-boot-dots"></span></p>
         </div>
         <iframe id="player" title="live game preview" allow="pointer-lock"></iframe>
       </section>

--- a/site/sandbox.html
+++ b/site/sandbox.html
@@ -44,6 +44,33 @@
         <div id="editor"></div>
       </section>
       <section class="preview-pane">
+        <!-- The boot loader. Static markup on purpose: it paints on the first
+             frame, long before the editor bundle and the wasm runtime arrive.
+             src/sandbox.tsx dismisses it (`.is-done`); the rest is styles.css. -->
+        <div class="fn-boot" data-fn-boot>
+          <svg class="fn-boot-defs" aria-hidden="true">
+            <symbol id="fn-boot-mark" viewBox="366 163 385 690">
+              <path d="M382 341 545 179H735L615 300H548L382 466Z" />
+              <path d="M382 493 497 380V748L382 837Z" />
+              <path d="M518 426H693L597 522H518Z" />
+            </symbol>
+          </svg>
+          <div class="fn-boot-word" aria-hidden="true">FUNCTOR</div>
+          <div class="fn-boot-stage" aria-hidden="true">
+            <div class="fn-boot-spin">
+          <span class="fn-boot-slice" style="--i:0"><svg><use href="#fn-boot-mark" /></svg></span>
+          <span class="fn-boot-slice" style="--i:1"><svg><use href="#fn-boot-mark" /></svg></span>
+          <span class="fn-boot-slice" style="--i:2"><svg><use href="#fn-boot-mark" /></svg></span>
+          <span class="fn-boot-slice" style="--i:3"><svg><use href="#fn-boot-mark" /></svg></span>
+          <span class="fn-boot-slice" style="--i:4"><svg><use href="#fn-boot-mark" /></svg></span>
+          <span class="fn-boot-slice" style="--i:5"><svg><use href="#fn-boot-mark" /></svg></span>
+          <span class="fn-boot-slice" style="--i:6"><svg><use href="#fn-boot-mark" /></svg></span>
+          <span class="fn-boot-slice" style="--i:7"><svg><use href="#fn-boot-mark" /></svg></span>
+          <span class="fn-boot-slice" style="--i:8"><svg><use href="#fn-boot-mark" /></svg></span>
+            </div>
+          </div>
+          <p class="fn-boot-label">loading<span class="fn-boot-dots"></span></p>
+        </div>
         <iframe id="player" title="live game preview" allow="pointer-lock"></iframe>
       </section>
     </main>

--- a/site/src/hero.ts
+++ b/site/src/hero.ts
@@ -47,6 +47,12 @@ const setStatus = (state: HeroState, message = "") => {
   statusState = { state, message };
   dot.dataset.state = state;
   dot.title = message || state;
+  // The boot loader (static markup in index.html) evaporates the moment the
+  // card reports anything but "busy" — the scene is live, or there is an
+  // error worth reading. One class toggle; the animation is all CSS.
+  if (state !== "busy") {
+    document.querySelector("[data-fn-boot]")?.classList.add("is-done");
+  }
 };
 // Busy until the player's ready handshake: the bridge's onLive (or a
 // successful onResult) is what turns the dot green, never the mount itself.

--- a/site/src/hero.ts
+++ b/site/src/hero.ts
@@ -47,13 +47,14 @@ const setStatus = (state: HeroState, message = "") => {
   statusState = { state, message };
   dot.dataset.state = state;
   dot.title = message || state;
-  // The boot loader (static markup in index.html) evaporates the moment the
-  // card reports anything but "busy" — the scene is live, or there is an
-  // error worth reading. One class toggle; the animation is all CSS.
-  if (state !== "busy") {
-    document.querySelector("[data-fn-boot]")?.classList.add("is-done");
-  }
 };
+
+// The boot loader (static markup in index.html) evaporates when the PLAYER
+// reports in — never on any other status change, since a failure to fetch the
+// editable region says nothing about whether the card has pixels yet. One
+// class toggle; the 620ms evaporate is all CSS.
+const dismissBootLoader = () =>
+  document.querySelector("[data-fn-boot]")?.classList.add("is-done");
 // Busy until the player's ready handshake: the bridge's onLive (or a
 // successful onResult) is what turns the dot green, never the mount itself.
 setStatus("busy", "loading…");
@@ -69,9 +70,14 @@ const fullProgram = () => prefix + region + suffix;
 
 const bridge = new PlayerBridge(frame, {
   onReloading: () => setStatus("busy"),
-  onLive: () => setStatus("live", "live"),
-  onResult: (ok, message) =>
-    ok ? setStatus("live", message) : setStatus("error", message),
+  onLive: () => {
+    dismissBootLoader();
+    setStatus("live", "live");
+  },
+  onResult: (ok, message) => {
+    dismissBootLoader();
+    ok ? setStatus("live", message) : setStatus("error", message);
+  },
 });
 
 let editor: EditorView | null = null;

--- a/site/src/ide.ts
+++ b/site/src/ide.ts
@@ -206,6 +206,12 @@ const setStatus = (state: PillState, text: string, detail = "") => {
   // and — for errors — the Output panel. No separate error banner under the
   // editor: the preview pill is the single live indicator.
   els.status.title = detail;
+  // The boot loader (static markup in ide.html) evaporates the moment the
+  // preview reports anything but "busy" — it is live, or there is an error
+  // worth reading. One class toggle; the animation is all CSS.
+  if (state !== "busy") {
+    document.querySelector("[data-fn-boot]")?.classList.add("is-done");
+  }
 };
 
 // ---------------------------------------------------------------- editor

--- a/site/src/ide.ts
+++ b/site/src/ide.ts
@@ -206,13 +206,14 @@ const setStatus = (state: PillState, text: string, detail = "") => {
   // and — for errors — the Output panel. No separate error banner under the
   // editor: the preview pill is the single live indicator.
   els.status.title = detail;
-  // The boot loader (static markup in ide.html) evaporates the moment the
-  // preview reports anything but "busy" — it is live, or there is an error
-  // worth reading. One class toggle; the animation is all CSS.
-  if (state !== "busy") {
-    document.querySelector("[data-fn-boot]")?.classList.add("is-done");
-  }
 };
+
+// The boot loader (static markup in ide.html) evaporates when the PREVIEW
+// reports in — never on any other status change, since an error from, say, a
+// rejected new-file name says nothing about whether the pane has pixels yet.
+// One class toggle; the 620ms evaporate is all CSS.
+const dismissBootLoader = () =>
+  document.querySelector("[data-fn-boot]")?.classList.add("is-done");
 
 // ---------------------------------------------------------------- editor
 
@@ -314,8 +315,12 @@ const setDoc = (source: string) => {
 
 const bridge = new ProjectBridge(els.player, {
   onReloading: () => setStatus("busy", "◌ reloading…"),
-  onLive: () => setStatus("live", "● live"),
+  onLive: () => {
+    dismissBootLoader();
+    setStatus("live", "● live");
+  },
   onResult: (ok, message) => {
+    dismissBootLoader();
     if (ok) {
       // the runtime's "model preserved" note, reachable on hover
       setStatus("live", "● live", message);

--- a/site/src/sandbox.tsx
+++ b/site/src/sandbox.tsx
@@ -83,13 +83,14 @@ const setStatus = (state: PillState["state"], text: string, detail = "") => {
   // and — for errors — the Output panel. No separate error banner under the
   // editor: the preview pill is the single live indicator.
   pill.set({ state, text, detail });
-  // The boot loader (static markup in sandbox.html) evaporates the moment the
-  // preview reports anything but "busy" — it is live, or there is an error
-  // worth reading. One class toggle; the animation is all CSS.
-  if (state !== "busy") {
-    document.querySelector("[data-fn-boot]")?.classList.add("is-done");
-  }
 };
+
+// The boot loader (static markup in sandbox.html) evaporates when the PLAYER
+// reports in — never on any other status change, since an error from, say, a
+// bad #src= fragment says nothing about whether the pane has pixels yet. One
+// class toggle; the 620ms evaporate is all CSS.
+const dismissBootLoader = () =>
+  document.querySelector("[data-fn-boot]")?.classList.add("is-done");
 
 const statusBar = createStatusBarStore();
 // The sandbox edits only the entry buffer, but some examples also load sibling
@@ -101,8 +102,12 @@ let assetSources: [string, Uint8Array][] = [];
 
 const bridge = new PlayerBridge(frame, {
   onReloading: () => setStatus("busy", "◌ reloading…"),
-  onLive: () => setStatus("live", "● live"),
+  onLive: () => {
+    dismissBootLoader();
+    setStatus("live", "● live");
+  },
   onResult: (ok, message) => {
+    dismissBootLoader();
     if (ok) {
       // The runtime's status line ("reloaded … model preserved") stays
       // reachable — hover the pill, or the e2e's status() seam below.

--- a/site/src/sandbox.tsx
+++ b/site/src/sandbox.tsx
@@ -78,11 +78,18 @@ const picker = createStore<PickerState>({
 });
 const pill = createStore<PillState>({ state: "busy", text: "◌ loading…", detail: "" });
 
-const setStatus = (state: PillState["state"], text: string, detail = "") =>
+const setStatus = (state: PillState["state"], text: string, detail = "") => {
   // The detail (the reload note, or a parse error) lives in the pill's tooltip
   // and — for errors — the Output panel. No separate error banner under the
   // editor: the preview pill is the single live indicator.
   pill.set({ state, text, detail });
+  // The boot loader (static markup in sandbox.html) evaporates the moment the
+  // preview reports anything but "busy" — it is live, or there is an error
+  // worth reading. One class toggle; the animation is all CSS.
+  if (state !== "busy") {
+    document.querySelector("[data-fn-boot]")?.classList.add("is-done");
+  }
+};
 
 const statusBar = createStatusBarStore();
 // The sandbox edits only the entry buffer, but some examples also load sibling

--- a/site/styles.css
+++ b/site/styles.css
@@ -1182,6 +1182,8 @@ a:hover {
 .preview-pane {
   min-width: 0;
   min-height: 0;
+  /* The containing block for the boot loader; the hero card is already one. */
+  position: relative;
 }
 
 #player {
@@ -2042,7 +2044,10 @@ a:hover {
 .fn-boot {
   position: absolute;
   inset: 0;
-  z-index: 30;
+  /* Enough to clear the iframe and the hero's status dot (z-index 2), and no
+     more: .hero-card opens no stacking context, so a bigger value would paint
+     the loader over the sticky site header when the hero scrolls under it. */
+  z-index: 3;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -2057,12 +2062,21 @@ a:hover {
   pointer-events: none;
   /* cqi sizing for the wordmark below scales it from the hero card down to a
      narrow preview pane. */
-  container-type: size;
+  container-type: inline-size;
+  /* Safety valve. Dismissal is the player's readiness handshake, and a runtime
+     that never boots (a 404 on the wasm, no WebGL2) would otherwise leave this
+     claiming progress forever — worse than the blank pane it replaced. After
+     20s it retires and lets the bare surface show through. `.is-done` replaces
+     this animation outright, so a normal boot never reaches it. */
+  animation: fn-boot-give-up 600ms ease-in 20s forwards;
 }
 
-/* The preview panes host a loader; the hero card is already positioned. */
-.preview-pane {
-  position: relative;
+/* On the hero the loader covers the whole card, and the mini-editor mounts as
+   soon as hero.fun is fetched — well before the player's handshake. Keep it out
+   of the hit region (and out of the tab order) while it is occluded, so nobody
+   types into an editor they cannot see. */
+.fn-boot:not(.is-done) ~ .hero-editor {
+  visibility: hidden;
 }
 
 /* The <symbol> sprite each slice instantiates — never rendered itself. */
@@ -2099,7 +2113,7 @@ a:hover {
 .fn-boot-word {
   position: absolute;
   left: 50%;
-  top: 54%;
+  top: calc(50% + -22px);
   transform: translate(-50%, -50%);
   z-index: 0;
   font-family: var(--font-display);
@@ -2246,7 +2260,7 @@ a:hover {
    Layered so it reads as the solid coming apart, not just a div fading:
    (1) the slices spread along Z and drift up, staggered back-to-front;
    (2) the whole loader blurs, lifts and over-scales slightly;
-   (3) the backdrop wash dissolves a beat earlier than the mark.
+   (3) the horizon rule and the label retire a beat earlier than the mark.
    animation-fill-mode: forwards holds the final visibility:hidden, so the
    node is parked for good; removing it afterwards is never required. */
 
@@ -2286,7 +2300,6 @@ a:hover {
     opacity: 1;
     filter: blur(0) saturate(1);
     transform: translateY(0) scale(1);
-    background-color: var(--bg-panel);
   }
   35% {
     opacity: 0.92;
@@ -2296,14 +2309,13 @@ a:hover {
     opacity: 0;
     filter: blur(13px) saturate(1.25);
     transform: translateY(-14px) scale(1.055);
-    background-color: transparent;
     visibility: hidden;
   }
 }
 
 @keyframes fn-boot-slice-out {
   0% {
-    opacity: calc(1 - var(--i) * 0.035);
+    opacity: calc(1 - var(--i) * 0.02);
   }
   100% {
     opacity: 0;
@@ -2373,6 +2385,13 @@ a:hover {
   }
   50% {
     opacity: 1;
+  }
+}
+
+@keyframes fn-boot-give-up {
+  to {
+    opacity: 0;
+    visibility: hidden;
   }
 }
 

--- a/site/styles.css
+++ b/site/styles.css
@@ -2025,3 +2025,360 @@ a:hover {
 .exec-row.selected {
   color: var(--cyan);
 }
+
+/* ==== the boot loader ====================================================
+   The Functor mark, milled out of nine copies of itself along Z, spinning
+   over a surface that has not booted yet: the hero card, and the sandbox /
+   IDE preview panes. It is STATIC markup in each page's shell — it paints on
+   the first frame, before the editor bundle and the wasm runtime have
+   arrived, which is the whole point. The only JS is one class toggle:
+
+     document.querySelector('[data-fn-boot]')?.classList.add('is-done');
+
+   which runs the 620ms evaporate and parks the node at visibility:hidden.
+   The overlay is pointer-events:none from birth (not just once dismissed),
+   so a fast click — or an e2e — mid-boot is never intercepted by it. */
+
+.fn-boot {
+  position: absolute;
+  inset: 0;
+  z-index: 30;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-md);
+  /* Sits on whatever it covers: a hair of the panel tone plus a radial lift
+     so the mark reads on both #0d0221 (hero card) and --bg (preview pane). */
+  background:
+    radial-gradient(120% 90% at 50% 42%, rgba(65, 216, 230, 0.07), transparent 62%),
+    var(--bg-panel);
+  /* Purely decorative: it never takes a click, at any point in its life. */
+  pointer-events: none;
+  /* cqi sizing for the wordmark below scales it from the hero card down to a
+     narrow preview pane. */
+  container-type: size;
+}
+
+/* The preview panes host a loader; the hero card is already positioned. */
+.preview-pane {
+  position: relative;
+}
+
+/* The <symbol> sprite each slice instantiates — never rendered itself. */
+.fn-boot-defs {
+  display: none;
+}
+
+/* Faint horizon rule under the mark — one line, keeps the composition from
+   floating. The site's cyan → pink gradient rule at very low alpha. */
+.fn-boot::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: min(200px, 54%);
+  height: 1px;
+  transform: translate(-50%, 122px);
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(65, 216, 230, 0.34),
+    rgba(232, 88, 184, 0.24),
+    transparent
+  );
+  animation: fn-boot-rule 2.6s ease-in-out infinite;
+}
+
+/* The faded FUNCTOR wordmark behind the mark — the brand name stays readable
+   while the surface loads. Same face as the header wordmark, as a watermark.
+   It sits behind the LOWER half of the mark: the F's bottom is a narrow stem,
+   so only one letter is grazed (at 46% the wide head of the F parks exactly
+   on the "C"). Flex items stack with plain z-index, so the stage and label
+   sit above it without any extra positioning. */
+.fn-boot-word {
+  position: absolute;
+  left: 50%;
+  top: 54%;
+  transform: translate(-50%, -50%);
+  z-index: 0;
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: clamp(20px, 12cqi, 56px);
+  letter-spacing: 0.34em;
+  text-indent: 0.34em; /* recentre the trailing letter-space */
+  white-space: nowrap;
+  color: var(--text);
+  opacity: 0.09;
+  user-select: none;
+}
+
+.fn-boot-stage,
+.fn-boot-label {
+  z-index: 1;
+}
+
+.fn-boot-stage {
+  perspective: 620px;
+  width: 96px;
+  height: 132px;
+  animation: fn-boot-bob 3.4s ease-in-out infinite;
+}
+
+.fn-boot-spin {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transform-style: preserve-3d;
+  animation: fn-boot-spin 3.6s linear infinite;
+}
+
+/* Each slice is one copy of the mark, pushed back along Z. Nine of them read
+   as a milled solid rather than a flipping card — the whole point. */
+.fn-boot-slice {
+  position: absolute;
+  inset: 0;
+  display: block;
+  transform: translateZ(calc((4 - var(--i)) * 2.1px));
+  /* The front face is full cyan; the tail falls off toward a deep pink-violet
+     so the extrusion reads as a shadowed side wall, not a stack of stickers. */
+  color: color-mix(in oklab, var(--cyan), #5b2470 calc(var(--i) * 12%));
+  opacity: calc(1 - var(--i) * 0.02);
+}
+
+.fn-boot-slice svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+  fill: currentColor;
+}
+
+/* Only the front slice carries the bloom — glowing all nine smears the form. */
+.fn-boot-slice[style*="--i:0"] svg {
+  filter: drop-shadow(0 0 12px rgba(65, 216, 230, 0.55))
+    drop-shadow(0 0 30px rgba(65, 216, 230, 0.22));
+}
+
+.fn-boot-label {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 400;
+  letter-spacing: 0.42em;
+  text-indent: 0.42em; /* offset the trailing letter-space so it stays centred */
+  text-transform: uppercase;
+  color: var(--text-dim);
+  animation: fn-boot-label 2.6s ease-in-out infinite;
+}
+
+/* The dots cycle "" → "." → ".." → "..." without reflowing the label. */
+.fn-boot-dots {
+  display: inline-block;
+  width: 2.4em;
+  text-align: left;
+  text-indent: 0;
+}
+
+.fn-boot-dots::before {
+  content: "";
+  animation: fn-boot-dots 1.6s steps(1) infinite;
+}
+
+/* -- the resting (loading) state ---------------------------------------- */
+
+@keyframes fn-boot-spin {
+  from {
+    transform: rotateX(-11deg) rotateY(0deg);
+  }
+  to {
+    transform: rotateX(-11deg) rotateY(360deg);
+  }
+}
+
+@keyframes fn-boot-bob {
+  0%,
+  100% {
+    transform: translateY(-3px);
+  }
+  50% {
+    transform: translateY(3px);
+  }
+}
+
+@keyframes fn-boot-label {
+  0%,
+  100% {
+    opacity: 0.55;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@keyframes fn-boot-dots {
+  0% {
+    content: "";
+  }
+  25% {
+    content: ".";
+  }
+  50% {
+    content: "..";
+  }
+  75% {
+    content: "...";
+  }
+}
+
+@keyframes fn-boot-rule {
+  0%,
+  100% {
+    opacity: 0.35;
+    transform: translate(-50%, 122px) scaleX(0.86);
+  }
+  50% {
+    opacity: 1;
+    transform: translate(-50%, 122px) scaleX(1);
+  }
+}
+
+/* -- the exit: fade + evaporate ------------------------------------------
+   Layered so it reads as the solid coming apart, not just a div fading:
+   (1) the slices spread along Z and drift up, staggered back-to-front;
+   (2) the whole loader blurs, lifts and over-scales slightly;
+   (3) the backdrop wash dissolves a beat earlier than the mark.
+   animation-fill-mode: forwards holds the final visibility:hidden, so the
+   node is parked for good; removing it afterwards is never required. */
+
+.fn-boot.is-done {
+  animation: fn-boot-out 620ms cubic-bezier(0.32, 0, 0.24, 1) forwards;
+}
+
+.fn-boot.is-done .fn-boot-spin {
+  animation-play-state: paused;
+}
+
+.fn-boot.is-done .fn-boot-stage {
+  animation: none;
+}
+
+.fn-boot.is-done::after {
+  animation: fn-boot-rule-out 260ms ease-in forwards;
+}
+
+.fn-boot.is-done .fn-boot-label {
+  animation: fn-boot-label-out 320ms ease-in forwards;
+}
+
+.fn-boot.is-done .fn-boot-word {
+  animation: fn-boot-word-out 420ms ease-in forwards;
+}
+
+.fn-boot.is-done .fn-boot-slice {
+  animation: fn-boot-slice-out 620ms cubic-bezier(0.32, 0, 0.24, 1) forwards;
+  /* The tail evaporates first and the lit cyan face last, while the whole
+     stack stretches away from the viewer. */
+  animation-delay: calc((8 - var(--i)) * 22ms);
+}
+
+@keyframes fn-boot-out {
+  0% {
+    opacity: 1;
+    filter: blur(0) saturate(1);
+    transform: translateY(0) scale(1);
+    background-color: var(--bg-panel);
+  }
+  35% {
+    opacity: 0.92;
+    filter: blur(1.5px) saturate(1.15);
+  }
+  100% {
+    opacity: 0;
+    filter: blur(13px) saturate(1.25);
+    transform: translateY(-14px) scale(1.055);
+    background-color: transparent;
+    visibility: hidden;
+  }
+}
+
+@keyframes fn-boot-slice-out {
+  0% {
+    opacity: calc(1 - var(--i) * 0.035);
+  }
+  100% {
+    opacity: 0;
+    transform: translateZ(calc((4 - var(--i)) * 2.1px - var(--i) * 7px))
+      translateY(calc(var(--i) * -2.6px - 8px)) scale(1.04);
+  }
+}
+
+@keyframes fn-boot-label-out {
+  to {
+    opacity: 0;
+    transform: translateY(9px);
+    letter-spacing: 0.58em;
+  }
+}
+
+@keyframes fn-boot-word-out {
+  to {
+    opacity: 0;
+    letter-spacing: 0.5em;
+  }
+}
+
+@keyframes fn-boot-rule-out {
+  to {
+    opacity: 0;
+    transform: translate(-50%, 122px) scaleX(0.2);
+  }
+}
+
+/* -- reduced motion ------------------------------------------------------ */
+
+@media (prefers-reduced-motion: reduce) {
+  .fn-boot-spin {
+    /* Held at a 3/4 angle so the extrusion still reads. The pulse must animate
+       the STAGE, not this element: opacity on a preserve-3d node flattens it
+       and the shadowed back slice paints over the lit face. */
+    transform: rotateX(-11deg) rotateY(-32deg);
+    animation: none;
+  }
+
+  .fn-boot-stage {
+    animation: fn-boot-pulse 2.4s ease-in-out infinite;
+  }
+
+  .fn-boot::after,
+  .fn-boot-label {
+    animation: none;
+  }
+
+  .fn-boot.is-done {
+    animation: fn-boot-fade 300ms linear forwards;
+  }
+
+  .fn-boot.is-done .fn-boot-slice,
+  .fn-boot.is-done .fn-boot-label,
+  .fn-boot.is-done .fn-boot-word,
+  .fn-boot.is-done::after {
+    animation: none;
+  }
+}
+
+@keyframes fn-boot-pulse {
+  0%,
+  100% {
+    opacity: 0.6;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@keyframes fn-boot-fade {
+  to {
+    opacity: 0;
+    visibility: hidden;
+  }
+}


### PR DESCRIPTION
## What

The hero card, the sandbox preview pane and the IDE preview pane all sat blank while
their entry bundle (420–630kb) and the wasm runtime arrived. They now show a **boot
loader**: the Functor mark milled out of nine copies of itself along Z, spinning over
the faded `FUNCTOR` wordmark with a `LOADING…` label — which **evaporates** once the
player reports in.

![Functor boot loader — hero cold load](https://gist.githubusercontent.com/tommy-xr/70e18a0660f330e19059af3bdef89baa/raw/9a5c2532d9e97c9065c6ae4a23bcdd3c6ff57ab7/boot-loader.gif)

<sub>The real hero page (`index.html`) cold-loading: the boot loader holds the surface while the wasm player streams in, then evaporates into the booted scene. Captured headlessly via CDP `Page.startScreencast` against `site/dist` with the runtime bundle throttled.</sub>

![Boot loader at rest on the sandbox preview pane](https://gist.githubusercontent.com/tommy-xr/70e18a0660f330e19059af3bdef89baa/raw/9a5c2532d9e97c9065c6ae4a23bcdd3c6ff57ab7/boot-loader-still.png)

<sub>The resting loader on the sandbox preview pane.</sub>

## Where

| Surface | Mounts | Dismissed by |
| --- | --- | --- |
| Hero (`index.html`) | first child of `.hero-card` | `src/hero.ts` — the player bridge's `onLive` / `onResult` |
| Sandbox (`sandbox.html`) | first child of `.preview-pane` | `src/sandbox.tsx` — same bridge callbacks |
| IDE (`ide.html`) | first child of `.preview-pane` | `src/ide.ts` — same bridge callbacks |

Dismissal hangs off the **player's readiness handshake**, not off any non-`busy` status:
a status error from something else (a rejected new-file name in the IDE, a bad `#src=`
fragment in the sandbox, a failed source fetch on the hero) says nothing about whether
the pane has pixels yet, and must not retire a loader over a surface that is still
blank. One `dismissBootLoader()` per entry, called from the two callbacks that already
exist. No new state machinery, no new module, no timers in JS.

The markup is **static, in each page's shell** — it has to paint on the first frame,
before any JS runs, which is the whole point of the feature. The 620ms evaporate, the
`prefers-reduced-motion` fallback and the final `visibility: hidden` park are all CSS
(`.fn-boot*`, appended to `site/styles.css`).

Only the approved **variant A** ships (extruded mark + glow + wordmark + label); the
prototype's `.fn-flat` / `.fn-ring` variants are not included. The wordmark sits at the
user-tuned `top: calc(50% + -22px)`. The nine slices instantiate one SVG `<symbol>` via
`<use>` rather than repeating the path data nine times.

## Why the preview pane, not the whole split

On a throttled cold load the editor pane fills as soon as the bundle mounts CodeMirror;
the preview pane stays blank for as long again while the wasm runtime boots. Covering
the whole split would mean holding a loader over an already-mounted editor, so each page
gets exactly one instance, on the pane that is actually still empty.

## pointer-events

The overlay is **`pointer-events: none` from birth**, not merely once dismissed — the
3D-transformed slices' hit areas can escape ancestor overflow clipping and steal clicks
well outside their visible bounds. Making it inert from birth means a fast user, or an
e2e clicking mid-boot, is structurally unable to hit it rather than relying on the
dismissal having already run. Nothing regressed with it on, so it stays.

## Cross-engine review (`/xreview`) — dispositions

Reviewed against the stack parent by a Claude subagent and Codex independently. No
Critical. **Fixed** (second commit):

| Finding | Engines | Fix |
| --- | --- | --- |
| Loader sticks forever if the runtime never boots (wasm 404, no WebGL2) — worse than the blank pane it replaced | **both** | A 20s CSS safety valve (`fn-boot-give-up`); `.is-done` replaces the animation, so a normal boot never reaches it. Verified: `visibility` goes `visible` → `hidden` at 21s with no `.is-done` |
| `z-index: 30` outranked the sticky site header (`z-index: 20`) — `.hero-card` opens no stacking context, so scrolling the hero under the header wiped the nav links inside the card's x-range | **both** | `z-index: 3` — clears the iframe and the hero status dot (2), nothing more. Verified by capture |
| An unrelated status error retired a still-blank pane | Codex | Dismiss from the bridge's `onLive`/`onResult` only (see above) |
| The hero's mini-editor mounts on the source fetch, long before the player is live, so it was clickable/typable under the loader | Claude | `.fn-boot:not(.is-done) ~ .hero-editor { visibility: hidden }` |
| No status semantics on the label | **both** | `role="status"` |
| `.preview-pane` declared twice | Claude | Folded `position: relative` into the existing rule |
| `container-type: size` stronger than needed; inert `background-color` keyframes; slice exit started 0.035 below the resting opacity (a visible jump on dismissal) | Claude | All three applied |

**Declined, with reason:**

- *Emit the loader markup through a build-time partial instead of copying the subtree
  into three shells* (both engines, Low). `build.mjs` has slot machinery, but a second
  injector for three call sites trades a real requirement (the markup is static and
  visible in the shell you're reading) for indirection. Left as three copies.
- *Animating `content` for the `…` dots is non-standard — Firefox won't animate it*
  (Claude, Low). Graceful degradation: the label still reads `LOADING`, only the
  trailing dots are static there. Not worth a JS timer or a width hack.

## Verification

Re-run after the review fixes and after the rebase onto `main`:

- `npm run check:site` — pass (strict, `erasableSyntaxOnly`)
- `npm run site:build` — pass
- `e2e/site-sandbox.mjs` — **ALL CHECKS PASSED** (lang-intel completion/diagnostics
  checks ran, not skipped)
- `e2e/ide-page.mjs` — PASS
- `e2e/ide-project.mjs` — PASS
- `e2e/runtime-target.mjs` — ALL CHECKS PASSED

All suites and `site/demos/` are **unmodified**. One early `site-sandbox` run flaked on
the timing-sensitive `Space up` branch-marker check; it passed on every subsequent run,
and the base branch was verified green for comparison.

`.sandbox-controls` is declared twice in `styles.css` (~753 / ~792) — pre-existing, left
alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

