### PR TITLE
feat(prelude): Vec3 accessors and arithmetic

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -726,11 +726,19 @@ v |> Vec3.add(b)                                           // a + b
 v |> Vec3.sub(origin)                                      // "v minus origin" (subject LAST:
                                                            //   Vec3.sub(b, a) == a - b)
 v |> Vec3.scale(k)                                         // negate with Vec3.scale(0.0 - 1.0)
-a |> Vec3.dot(b) / a |> Vec3.cross(b)                      // a · b (commutative) / a × b
+a |> Vec3.dot(b) / a |> Vec3.cross(b)                      // a · b (commutative) / a × b.
+                                                           //   Strafe axis is up × forward:
+                                                           //   up |> Vec3.cross(forward) = +X
+                                                           //   (forward +Z, up +Y)
 v |> Vec3.length() / v |> Vec3.normalize()                 // ZERO normalizes to ZERO, not NaN
 a |> Vec3.distance(b)                                      // |a - b|, symmetric
 from |> Vec3.lerp(target, t)                               // t=0 → from, t=1 → target; NOT
                                                            //   clamped (it extrapolates)
+                                                           // Vec3 components are f32: accessors
+                                                           //   return ROUNDED values (compare
+                                                           //   with a tolerance), and an op that
+                                                           //   overflows the f32 range is an
+                                                           //   error, never a NaN
 scene |> Scene.color(color)                                // scene-last: pipes
 scene |> Scene.lit(color)                                  // diffuse+specular
 Texture.file("wood.png")                                   // a Texture.t from a path

--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -721,6 +721,16 @@ Vec3.make(x, y, z)                                         // Vec3 VALUES only: 
                                                            //   one. Reads (Physics.position,
                                                            //   rayHit) still hand back plain
                                                            //   {x, y, z} records
+Vec3.x(v) / Vec3.y(v) / Vec3.z(v)                          // read components back
+v |> Vec3.add(b)                                           // a + b
+v |> Vec3.sub(origin)                                      // "v minus origin" (subject LAST:
+                                                           //   Vec3.sub(b, a) == a - b)
+v |> Vec3.scale(k)                                         // negate with Vec3.scale(0.0 - 1.0)
+a |> Vec3.dot(b) / a |> Vec3.cross(b)                      // a · b (commutative) / a × b
+v |> Vec3.length() / v |> Vec3.normalize()                 // ZERO normalizes to ZERO, not NaN
+a |> Vec3.distance(b)                                      // |a - b|, symmetric
+from |> Vec3.lerp(target, t)                               // t=0 → from, t=1 → target; NOT
+                                                           //   clamped (it extrapolates)
 scene |> Scene.color(color)                                // scene-last: pipes
 scene |> Scene.lit(color)                                  // diffuse+specular
 Texture.file("wood.png")                                   // a Texture.t from a path

--- a/docs/functor-lang.md
+++ b/docs/functor-lang.md
@@ -346,8 +346,27 @@ snapshots — no GPU, fully agent-verifiable.
       keeps floats (scale factors, not a spatial vector). Like Color, a Vec3
       is reload-safe (three module-independent f32s), so spawn points and
       velocities stored in the model survive hot-reload time travel.
-      Component accessors and vector math (`Vec3.add`/`scale`/`length`, and
-      Vec2/Vec4) are deliberately deferred until an API returns a Vec3.
+      Component accessors and vector math were deferred here and landed
+      below; Vec2/Vec4 remain deferred until an API needs them.
+- [x] **`Vec3` accessors and arithmetic** (2026-07-26; game-jam gap track).
+      The deferral above cost every jam entry that needed 3D math its own
+      vector module — four wrote one in parallel and the bow entry shipped a
+      whole `v3.fun`, each re-deriving add/scale/normalize on a plain
+      `{x, y, z}` record and converting back with `Vec3.make` at every
+      prelude boundary (~48 such conversions across the entries; the `toss`
+      example even shadows the prelude name with its own record type). The
+      brand STAYS opaque — the fix is `Vec3.x`/`y`/`z` plus
+      `add`/`sub`/`scale`/`dot`/`cross`/`length`/`normalize`/`distance`/
+      `lerp`, so a game keeps vectors as `Vec3` end-to-end instead of
+      unpacking and rebuilding. Making `Vec3.t` a plain record was the
+      considered alternative and was rejected: it would let a bare `{x, y, z}`
+      coerce at every boundary, retiring the very teaching error the brand
+      exists for. Argument order is thread-last like the rest of the prelude
+      (subject LAST), so `Vec3.sub(b, a)` is `a - b` and
+      `v |> Vec3.sub(origin)` reads "v minus origin". Normalizing the zero
+      vector yields the ZERO vector — not NaN, not an error — because
+      per-frame code normalizes an idle velocity constantly and must not
+      fault the frame or poison a transform.
 - [x] **`>=` / `<=` / `!=` comparison operators** (2026-07-26; game-jam gap
       track). Every one of the seven jam entries hit the missing set, and two
       bugs in the racer traced directly to the `not (a > b)` workaround it

--- a/functor-prelude/prelude/vec3.funi
+++ b/functor-prelude/prelude/vec3.funi
@@ -19,6 +19,10 @@
 //! `a - b`, so `v |> Vec3.sub(origin)` reads as "v minus origin"; likewise
 //! `a |> Vec3.cross(b)` is `a × b`, and `from |> Vec3.lerp(target, t)` moves
 //! `from` toward `target`.
+//!
+//! Components are 32-bit floats and every vector is **finite**: an operation
+//! whose result would overflow that range is an error naming the operation,
+//! rather than an infinity that becomes a NaN and silently blanks the scene.
 
 /// An opaque 3D vector.
 type t
@@ -27,12 +31,16 @@ type t
 let make : (float, float, float) => t
 
 /// The X component of a vector.
+///
+/// Components are stored as 32-bit floats, so a value that is not exactly
+/// representable comes back rounded (`Vec3.x(Vec3.make(0.1, 0.0, 0.0))` is
+/// `0.10000000149011612`). Compare components with a tolerance, not `==`.
 let x : (t) => float
 
-/// The Y component of a vector.
+/// The Y component of a vector. Rounded to 32-bit like `Vec3.x`.
 let y : (t) => float
 
-/// The Z component of a vector.
+/// The Z component of a vector. Rounded to 32-bit like `Vec3.x`.
 let z : (t) => float
 
 /// Componentwise sum. `Vec3.add(b, a)` is `a + b`, so `a |> Vec3.add(b)`
@@ -52,8 +60,13 @@ let scale : (float, t) => t
 let dot : (t, t) => float
 
 /// The cross product. `Vec3.cross(b, a)` is `a × b`, so `a |> Vec3.cross(b)`
-/// reads as "a cross b" — the result is perpendicular to both, right-handed
-/// (`Vec3.cross(up, forward)` yields screen-right in Functor's Y-up frame).
+/// reads as "a cross b" — the result is perpendicular to both, right-handed:
+/// `X × Y = Z`.
+///
+/// Mind the order for a strafe axis. In Functor's Y-up right-handed frame the
+/// world-space "right" of a gaze is `up × forward`, which in this argument
+/// order is `up |> Vec3.cross(forward)` — with `forward = +Z` and `up = +Y`
+/// that is `+X`. The other order gives `-X`.
 let cross : (t, t) => t
 
 /// The Euclidean length (magnitude) of a vector.
@@ -65,7 +78,9 @@ let length : (t) => float
 /// `Vec3.normalize(Vec3.make(0.0, 0.0, 0.0))` is the zero vector. Per-frame
 /// code normalizes a velocity or an input direction that is legitimately
 /// zero all the time, so this must not fault the frame; test the length
-/// first when you need a fallback direction.
+/// first when you need a fallback direction. Zero is the ONLY input that
+/// yields a non-unit result — the length is computed with enough range that
+/// even the largest representable vector normalizes correctly.
 let normalize : (t) => t
 
 /// The distance between two points — symmetric, so argument order is free.

--- a/functor-prelude/prelude/vec3.funi
+++ b/functor-prelude/prelude/vec3.funi
@@ -1,7 +1,79 @@
 //! Branded 3D vectors used for positions, directions, velocities, and gravity.
+//!
+//! Vectors are **opaque** — like `Angle` and `Color`, a `Vec3` is built once
+//! (`Vec3.make`) and passed as a value, so three interleaved bare floats can
+//! never be mistaken for a position. Read components back with `Vec3.x` /
+//! `Vec3.y` / `Vec3.z`, and combine vectors with the arithmetic below rather
+//! than unpacking to a record and rebuilding.
+//!
+//! **Argument order is thread-last**, matching the rest of the prelude
+//! (`Scene.translate(v, scene)`): the *subject* is the LAST parameter, so a
+//! pipeline reads left-to-right as the subject being acted on.
+//!
+//! ```
+//! // v - origin, scaled by 2, then normalized
+//! let dir = v |> Vec3.sub(origin) |> Vec3.scale(2.0) |> Vec3.normalize()
+//! ```
+//!
+//! For the non-commutative operations this means `Vec3.sub(b, a)` computes
+//! `a - b`, so `v |> Vec3.sub(origin)` reads as "v minus origin"; likewise
+//! `a |> Vec3.cross(b)` is `a × b`, and `from |> Vec3.lerp(target, t)` moves
+//! `from` toward `target`.
 
 /// An opaque 3D vector.
 type t
 
 /// Construct a vector from X, Y, and Z components.
 let make : (float, float, float) => t
+
+/// The X component of a vector.
+let x : (t) => float
+
+/// The Y component of a vector.
+let y : (t) => float
+
+/// The Z component of a vector.
+let z : (t) => float
+
+/// Componentwise sum. `Vec3.add(b, a)` is `a + b`, so `a |> Vec3.add(b)`
+/// reads as "a plus b" (addition is commutative, so the order is free).
+let add : (t, t) => t
+
+/// Componentwise difference. `Vec3.sub(b, a)` is `a - b`, so
+/// `v |> Vec3.sub(origin)` reads as "v minus origin".
+let sub : (t, t) => t
+
+/// Multiply every component by a scalar: `v |> Vec3.scale(2.0)` doubles `v`.
+/// Scaling by a negative number negates: `v |> Vec3.scale(0.0 - 1.0)`.
+let scale : (float, t) => t
+
+/// The dot product `a · b` — commutative, so argument order does not matter.
+/// Zero when the vectors are perpendicular.
+let dot : (t, t) => float
+
+/// The cross product. `Vec3.cross(b, a)` is `a × b`, so `a |> Vec3.cross(b)`
+/// reads as "a cross b" — the result is perpendicular to both, right-handed
+/// (`Vec3.cross(up, forward)` yields screen-right in Functor's Y-up frame).
+let cross : (t, t) => t
+
+/// The Euclidean length (magnitude) of a vector.
+let length : (t) => float
+
+/// A unit vector pointing the same way.
+///
+/// **A zero-length vector normalizes to zero**, not an error and not NaN —
+/// `Vec3.normalize(Vec3.make(0.0, 0.0, 0.0))` is the zero vector. Per-frame
+/// code normalizes a velocity or an input direction that is legitimately
+/// zero all the time, so this must not fault the frame; test the length
+/// first when you need a fallback direction.
+let normalize : (t) => t
+
+/// The distance between two points — symmetric, so argument order is free.
+/// `a |> Vec3.distance(b)` is the length of `a - b`.
+let distance : (t, t) => float
+
+/// Linear interpolation. `Vec3.lerp(target, t, from)` moves `from` toward
+/// `target` by fraction `t`, so `from |> Vec3.lerp(target, 0.5)` is the
+/// midpoint. `t` is NOT clamped: `0.0` yields `from`, `1.0` yields `target`,
+/// and values outside `0..1` extrapolate.
+let lerp : (t, float, t) => t

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -1214,6 +1214,7 @@ pub(crate) fn registry() -> &'static crate::host_registry::Registry {
     REGISTRY.get_or_init(|| {
         let mut reg = crate::host_registry::Registry::default();
         register_branded_constructors(&mut reg);
+        register_vec3(&mut reg);
         register_ui_anchors(&mut reg);
         register_terrain(&mut reg);
         register_scene(&mut reg);
@@ -1330,6 +1331,117 @@ crate::host_returnable!(
     FunctorLangAudioSource,
     FunctorLangAudioScene,
 );
+
+/// `Vec3` component accessors and arithmetic (vec3.funi).
+///
+/// The brand stays opaque — these let a game keep vectors as `Vec3` all the
+/// way through instead of unpacking to a `{x, y, z}` record, doing the math
+/// itself, and rebuilding with `Vec3.make` at every prelude boundary. (Every
+/// game-jam entry that needed 3D math wrote that module by hand; four wrote
+/// it in parallel and one shipped a whole `v3.fun`.)
+///
+/// **Argument order is thread-last**, like the rest of the prelude
+/// (`Scene.translate(v, scene)`): the subject is LAST, so `Vec3.sub(b, a)`
+/// computes `a - b` and `v |> Vec3.sub(origin)` reads "v minus origin".
+///
+/// Arithmetic is done in `f32` — the brand's own storage — so a value that
+/// round-trips through these functions is bit-identical to one built by
+/// `Vec3.make` from the same components, on every target.
+fn register_vec3(reg: &mut crate::host_registry::Registry) {
+    reg.fn1("Vec3.x", "Vec3.x(v)", |v: FunctorLangVec3| Value::Number(v.0 .0 as f64));
+    reg.fn1("Vec3.y", "Vec3.y(v)", |v: FunctorLangVec3| Value::Number(v.0 .1 as f64));
+    reg.fn1("Vec3.z", "Vec3.z(v)", |v: FunctorLangVec3| Value::Number(v.0 .2 as f64));
+
+    reg.fn2(
+        "Vec3.add",
+        "Vec3.add(b, a) — a + b; a |> Vec3.add(b)",
+        |b: FunctorLangVec3, a: FunctorLangVec3| {
+            FunctorLangVec3((a.0 .0 + b.0 .0, a.0 .1 + b.0 .1, a.0 .2 + b.0 .2))
+        },
+    );
+    reg.fn2(
+        "Vec3.sub",
+        "Vec3.sub(b, a) — a - b; v |> Vec3.sub(origin)",
+        |b: FunctorLangVec3, a: FunctorLangVec3| {
+            FunctorLangVec3((a.0 .0 - b.0 .0, a.0 .1 - b.0 .1, a.0 .2 - b.0 .2))
+        },
+    );
+    reg.fn2(
+        "Vec3.scale",
+        "Vec3.scale(k, v) — v |> Vec3.scale(2.0)",
+        |k: f64, v: FunctorLangVec3| {
+            let k = k as f32;
+            FunctorLangVec3((v.0 .0 * k, v.0 .1 * k, v.0 .2 * k))
+        },
+    );
+    reg.fn2(
+        "Vec3.dot",
+        "Vec3.dot(b, a) — a · b",
+        |b: FunctorLangVec3, a: FunctorLangVec3| Value::Number(dot(a.0, b.0) as f64),
+    );
+    reg.fn2(
+        "Vec3.cross",
+        "Vec3.cross(b, a) — a × b; a |> Vec3.cross(b)",
+        |b: FunctorLangVec3, a: FunctorLangVec3| {
+            let (ax, ay, az) = a.0;
+            let (bx, by, bz) = b.0;
+            FunctorLangVec3((ay * bz - az * by, az * bx - ax * bz, ax * by - ay * bx))
+        },
+    );
+    reg.fn1("Vec3.length", "Vec3.length(v)", |v: FunctorLangVec3| {
+        Value::Number(length(v.0) as f64)
+    });
+    reg.fn1("Vec3.normalize", "Vec3.normalize(v)", |v: FunctorLangVec3| {
+        FunctorLangVec3(normalize(v.0))
+    });
+    reg.fn2(
+        "Vec3.distance",
+        "Vec3.distance(b, a) — |a - b|",
+        |b: FunctorLangVec3, a: FunctorLangVec3| {
+            Value::Number(length((a.0 .0 - b.0 .0, a.0 .1 - b.0 .1, a.0 .2 - b.0 .2)) as f64)
+        },
+    );
+    reg.fn3(
+        "Vec3.lerp",
+        "Vec3.lerp(target, t, from) — from |> Vec3.lerp(target, 0.5)",
+        |target: FunctorLangVec3, t: f64, from: FunctorLangVec3| {
+            let t = t as f32;
+            let (fx, fy, fz) = from.0;
+            let (tx, ty, tz) = target.0;
+            FunctorLangVec3((
+                fx + (tx - fx) * t,
+                fy + (ty - fy) * t,
+                fz + (tz - fz) * t,
+            ))
+        },
+    );
+}
+
+fn dot(a: (f32, f32, f32), b: (f32, f32, f32)) -> f32 {
+    a.0 * b.0 + a.1 * b.1 + a.2 * b.2
+}
+
+fn length(v: (f32, f32, f32)) -> f32 {
+    dot(v, v).sqrt()
+}
+
+/// A unit vector in the same direction; **the zero vector normalizes to
+/// zero** rather than to NaN or an error.
+///
+/// Per-frame code normalizes a velocity or a movement-stick direction that is
+/// legitimately zero constantly, so faulting the frame (or handing back NaN,
+/// which would then poison a transform and blank the screen) is the wrong
+/// default. The guard is `len > 0.0` on the f32 magnitude, which also catches
+/// a length that underflows to zero; a non-finite input still propagates,
+/// since the engine boundary rejects non-finite numbers on its own.
+fn normalize(v: (f32, f32, f32)) -> (f32, f32, f32) {
+    let len = length(v);
+    if len > 0.0 {
+        (v.0 / len, v.1 / len, v.2 / len)
+    } else {
+        (0.0, 0.0, 0.0)
+    }
+}
 
 fn register_ui_anchors(reg: &mut crate::host_registry::Registry) {
     reg.fn0("Ui.topLeft", "Ui.topLeft()", || FunctorLangUiAnchor(ui::Anchor::TopLeft));
@@ -5810,6 +5922,237 @@ Vec3.make(x, y, z)"
             fail("let main = () => Vec3.make(1.0, \"x\", 0.0)"),
             "expected a number, got a string"
         );
+    }
+
+    // --- Vec3 accessors and arithmetic ---
+
+    /// Evaluate a Functor Lang expression to a number.
+    fn eval_number(expr: &str) -> f64 {
+        match eval(&format!("let main = () => {expr}")) {
+            Value::Number(n) => n,
+            other => panic!("expected a number from `{expr}`, got a {}", value_kind(&other)),
+        }
+    }
+
+    /// Evaluate a Functor Lang expression to a `Vec3`, read back through the
+    /// public accessors (so the test exercises the same path a game does).
+    fn eval_vec3(expr: &str) -> (f64, f64, f64) {
+        (
+            eval_number(&format!("({expr}) |> Vec3.x()")),
+            eval_number(&format!("({expr}) |> Vec3.y()")),
+            eval_number(&format!("({expr}) |> Vec3.z()")),
+        )
+    }
+
+    /// f32 arithmetic widened to f64 is not exactly the f64 answer, and the
+    /// x86/ARM rounding of a `sqrt`-derived value can differ in the last
+    /// bits, so vector comparisons are always toleranced.
+    fn assert_close(actual: (f64, f64, f64), expected: (f64, f64, f64)) {
+        let ok = (actual.0 - expected.0).abs() < 1e-6
+            && (actual.1 - expected.1).abs() < 1e-6
+            && (actual.2 - expected.2).abs() < 1e-6;
+        assert!(ok, "expected {expected:?}, got {actual:?}");
+    }
+
+    /// The components a game stores go in and come back out unchanged.
+    #[test]
+    fn vec3_accessors_read_components() {
+        assert_close(
+            eval_vec3("Vec3.make(1.5, -2.25, 3.0)"),
+            (1.5, -2.25, 3.0),
+        );
+    }
+
+    /// Every arithmetic op, in direct-call form.
+    #[test]
+    fn vec3_arithmetic() {
+        let a = "Vec3.make(1.0, 2.0, 3.0)";
+        let b = "Vec3.make(10.0, 20.0, 30.0)";
+
+        // add is commutative; both spellings agree.
+        assert_close(eval_vec3(&format!("Vec3.add({b}, {a})")), (11.0, 22.0, 33.0));
+        assert_close(eval_vec3(&format!("Vec3.add({a}, {b})")), (11.0, 22.0, 33.0));
+
+        // sub(b, a) == a - b — the subject is the LAST argument.
+        assert_close(eval_vec3(&format!("Vec3.sub({b}, {a})")), (-9.0, -18.0, -27.0));
+        assert_close(eval_vec3(&format!("Vec3.sub({a}, {b})")), (9.0, 18.0, 27.0));
+
+        assert_close(eval_vec3(&format!("Vec3.scale(2.0, {a})")), (2.0, 4.0, 6.0));
+        // Negation is a scale by -1.
+        assert_close(
+            eval_vec3(&format!("Vec3.scale(0.0 - 1.0, {a})")),
+            (-1.0, -2.0, -3.0),
+        );
+
+        assert_eq!(eval_number(&format!("Vec3.dot({b}, {a})")), 140.0);
+        // Perpendicular vectors dot to zero.
+        assert_eq!(
+            eval_number("Vec3.dot(Vec3.make(0.0, 1.0, 0.0), Vec3.make(1.0, 0.0, 0.0))"),
+            0.0
+        );
+
+        // cross(b, a) == a × b, right-handed: X × Y = Z.
+        assert_close(
+            eval_vec3("Vec3.cross(Vec3.make(0.0, 1.0, 0.0), Vec3.make(1.0, 0.0, 0.0))"),
+            (0.0, 0.0, 1.0),
+        );
+        // …and is anti-commutative.
+        assert_close(
+            eval_vec3("Vec3.cross(Vec3.make(1.0, 0.0, 0.0), Vec3.make(0.0, 1.0, 0.0))"),
+            (0.0, 0.0, -1.0),
+        );
+
+        assert_eq!(eval_number("Vec3.length(Vec3.make(3.0, 4.0, 0.0))"), 5.0);
+        assert_eq!(eval_number("Vec3.length(Vec3.make(0.0, 0.0, 0.0))"), 0.0);
+
+        // distance is symmetric.
+        assert_eq!(
+            eval_number("Vec3.distance(Vec3.make(0.0, 0.0, 0.0), Vec3.make(3.0, 4.0, 0.0))"),
+            5.0
+        );
+        assert_eq!(
+            eval_number("Vec3.distance(Vec3.make(3.0, 4.0, 0.0), Vec3.make(0.0, 0.0, 0.0))"),
+            5.0
+        );
+
+        // lerp(target, t, from): t = 0 is `from`, t = 1 is `target`.
+        assert_close(eval_vec3(&format!("Vec3.lerp({b}, 0.0, {a})")), (1.0, 2.0, 3.0));
+        assert_close(
+            eval_vec3(&format!("Vec3.lerp({b}, 1.0, {a})")),
+            (10.0, 20.0, 30.0),
+        );
+        assert_close(eval_vec3(&format!("Vec3.lerp({b}, 0.5, {a})")), (5.5, 11.0, 16.5));
+        // t is not clamped — it extrapolates.
+        assert_close(eval_vec3(&format!("Vec3.lerp({b}, 2.0, {a})")), (19.0, 38.0, 57.0));
+    }
+
+    /// A normalized vector is unit-length and keeps its direction.
+    #[test]
+    fn vec3_normalize_yields_a_unit_vector() {
+        assert_close(
+            eval_vec3("Vec3.normalize(Vec3.make(0.0, 5.0, 0.0))"),
+            (0.0, 1.0, 0.0),
+        );
+        let len = eval_number("Vec3.length(Vec3.normalize(Vec3.make(1.0, 2.0, 3.0)))");
+        assert!((len - 1.0).abs() < 1e-6, "expected unit length, got {len}");
+    }
+
+    /// The documented zero policy: normalizing the zero vector yields the
+    /// ZERO vector — not NaN, not an error. Per-frame code normalizes an idle
+    /// velocity constantly, so this must not fault the frame or poison a
+    /// transform with NaN.
+    #[test]
+    fn vec3_normalize_of_zero_is_zero() {
+        let v = eval_vec3("Vec3.normalize(Vec3.make(0.0, 0.0, 0.0))");
+        assert_eq!(v, (0.0, 0.0, 0.0));
+        assert!(!v.0.is_nan() && !v.1.is_nan() && !v.2.is_nan());
+        assert_eq!(
+            eval_number("Vec3.length(Vec3.normalize(Vec3.make(0.0, 0.0, 0.0)))"),
+            0.0
+        );
+    }
+
+    /// Thread-last is the point of the argument order: a pipeline of the
+    /// non-commutative ops must read left-to-right as the subject being
+    /// acted on, and agree with the direct-call spelling.
+    #[test]
+    fn vec3_pipelines_read_subject_first() {
+        // `v |> Vec3.sub(origin)` is "v minus origin".
+        assert_close(
+            eval_vec3("Vec3.make(5.0, 7.0, 9.0) |> Vec3.sub(Vec3.make(1.0, 2.0, 3.0))"),
+            (4.0, 5.0, 6.0),
+        );
+        // `a |> Vec3.cross(b)` is "a cross b" (X × Y = Z).
+        assert_close(
+            eval_vec3("Vec3.make(1.0, 0.0, 0.0) |> Vec3.cross(Vec3.make(0.0, 1.0, 0.0))"),
+            (0.0, 0.0, 1.0),
+        );
+        // `from |> Vec3.lerp(target, t)` moves `from` toward `target`.
+        assert_close(
+            eval_vec3("Vec3.make(0.0, 0.0, 0.0) |> Vec3.lerp(Vec3.make(4.0, 8.0, 12.0), 0.25)"),
+            (1.0, 2.0, 3.0),
+        );
+        // A whole chain: (v - origin) doubled, then normalized.
+        assert_close(
+            eval_vec3(
+                "Vec3.make(1.0, 2.0, 3.0) \
+                 |> Vec3.sub(Vec3.make(1.0, 2.0, 0.0)) \
+                 |> Vec3.scale(2.0) \
+                 |> Vec3.normalize()",
+            ),
+            (0.0, 0.0, 1.0),
+        );
+        assert_eq!(
+            eval_number("Vec3.make(3.0, 4.0, 0.0) |> Vec3.length()"),
+            5.0
+        );
+    }
+
+    /// The new functions are ordinary consumers of the brand, so they keep
+    /// the Angle-rule teaching errors: a bare number (or a bare `{x, y, z}`
+    /// record, the shape games hand-rolled before this existed) is refused.
+    #[test]
+    fn vec3_arithmetic_refuses_unbranded_values() {
+        // The error names the function that rejected the value, as the other
+        // branded consumers do.
+        for (src, path) in [
+            ("let main = () => Vec3.length(1.0)", "Vec3.length"),
+            ("let main = () => Vec3.x(1.0)", "Vec3.x"),
+            (
+                "let main = () => Vec3.add(1.0, Vec3.make(1.0, 2.0, 3.0))",
+                "Vec3.add",
+            ),
+        ] {
+            assert_eq!(
+                fail_message(src),
+                format!(
+                    "{path}: expected a Vec3, got a bare number — wrap the components: \
+Vec3.make(x, y, z)"
+                ),
+                "in `{src}`"
+            );
+        }
+        // A structural record is NOT a Vec3 — the brand is what makes an
+        // axis transposition unrepresentable.
+        let record = fail_message("let main = () => Vec3.length({ x: 1.0, y: 2.0, z: 3.0 })");
+        assert!(
+            record.contains("expected a Vec3"),
+            "a bare record must be refused, got: {record}"
+        );
+        // Arity slips still teach the shape.
+        assert_eq!(
+            fail_message("let main = () => Vec3.scale(2.0)"),
+            "usage: Vec3.scale(k, v) — v |> Vec3.scale(2.0)"
+        );
+    }
+
+    /// A vector that round-trips through the arithmetic is still a plain
+    /// three-f32 brand, so a velocity a game keeps in its model across
+    /// frames does not lose hot-reload time-travel history.
+    #[test]
+    fn computed_vec3s_stay_reload_safe() {
+        let v = eval(
+            "let main = () => Vec3.make(1.0, 2.0, 3.0) \
+             |> Vec3.add(Vec3.make(1.0, 0.0, 0.0)) |> Vec3.normalize()",
+        );
+        assert!(v.is_reload_safe_snapshot());
+    }
+
+    /// The whole point: a computed vector feeds the prelude directly, with
+    /// no unpack-and-rebuild at the boundary.
+    #[test]
+    fn computed_vec3s_feed_the_prelude_directly() {
+        let frame = frame_of(
+            "let main = () =>\n\
+             let eye = Vec3.make(0.0, 2.0, 0.0) |> Vec3.add(Vec3.make(0.0, 0.0, -6.0)) in\n\
+             Frame.create(\n\
+             Camera.lookAt(eye, Vec3.make(0.0, 0.0, 0.0)),\n\
+             Scene.cube() |> Scene.translate(Vec3.make(1.0, 0.0, 0.0) |> Vec3.scale(3.0)))",
+        );
+        // The camera got the summed eye, and the scene the scaled offset.
+        let json = serde_json::to_string(&frame).expect("frame serializes");
+        assert!(json.contains("-6.0"), "camera eye z should be -6: {json}");
+        assert!(json.contains("3.0"), "translate x should be 3: {json}");
     }
 
     // A Vec3 stored in the model (a spawn point, a velocity) survives hot

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -1344,9 +1344,13 @@ crate::host_returnable!(
 /// (`Scene.translate(v, scene)`): the subject is LAST, so `Vec3.sub(b, a)`
 /// computes `a - b` and `v |> Vec3.sub(origin)` reads "v minus origin".
 ///
-/// Arithmetic is done in `f32` — the brand's own storage — so a value that
-/// round-trips through these functions is bit-identical to one built by
-/// `Vec3.make` from the same components, on every target.
+/// Every intermediate is computed in `f64` and the result is finite-checked
+/// before it is re-branded ([`vec3_finite`]). `Vec3.make` can only ever build
+/// a finite vector (its components go through the finite-checked `f64`
+/// extractor), and the arithmetic below preserves that invariant — so a
+/// `Vec3` reaching the renderer is ALWAYS componentwise finite, and a NaN can
+/// never reach a transform (where it would blank the scene and serialize as
+/// `null` in the `Frame` wire form).
 fn register_vec3(reg: &mut crate::host_registry::Registry) {
     reg.fn1("Vec3.x", "Vec3.x(v)", |v: FunctorLangVec3| Value::Number(v.0 .0 as f64));
     reg.fn1("Vec3.y", "Vec3.y(v)", |v: FunctorLangVec3| Value::Number(v.0 .1 as f64));
@@ -1356,90 +1360,124 @@ fn register_vec3(reg: &mut crate::host_registry::Registry) {
         "Vec3.add",
         "Vec3.add(b, a) — a + b; a |> Vec3.add(b)",
         |b: FunctorLangVec3, a: FunctorLangVec3| {
-            FunctorLangVec3((a.0 .0 + b.0 .0, a.0 .1 + b.0 .1, a.0 .2 + b.0 .2))
+            let (a, b) = (widen(a), widen(b));
+            vec3_finite("Vec3.add", (a.0 + b.0, a.1 + b.1, a.2 + b.2))
         },
     );
     reg.fn2(
         "Vec3.sub",
         "Vec3.sub(b, a) — a - b; v |> Vec3.sub(origin)",
         |b: FunctorLangVec3, a: FunctorLangVec3| {
-            FunctorLangVec3((a.0 .0 - b.0 .0, a.0 .1 - b.0 .1, a.0 .2 - b.0 .2))
+            let (a, b) = (widen(a), widen(b));
+            vec3_finite("Vec3.sub", (a.0 - b.0, a.1 - b.1, a.2 - b.2))
         },
     );
     reg.fn2(
         "Vec3.scale",
         "Vec3.scale(k, v) — v |> Vec3.scale(2.0)",
         |k: f64, v: FunctorLangVec3| {
-            let k = k as f32;
-            FunctorLangVec3((v.0 .0 * k, v.0 .1 * k, v.0 .2 * k))
+            let v = widen(v);
+            vec3_finite("Vec3.scale", (v.0 * k, v.1 * k, v.2 * k))
         },
     );
     reg.fn2(
         "Vec3.dot",
         "Vec3.dot(b, a) — a · b",
-        |b: FunctorLangVec3, a: FunctorLangVec3| Value::Number(dot(a.0, b.0) as f64),
+        |b: FunctorLangVec3, a: FunctorLangVec3| Value::Number(vec3_dot(widen(a), widen(b))),
     );
     reg.fn2(
         "Vec3.cross",
         "Vec3.cross(b, a) — a × b; a |> Vec3.cross(b)",
         |b: FunctorLangVec3, a: FunctorLangVec3| {
-            let (ax, ay, az) = a.0;
-            let (bx, by, bz) = b.0;
-            FunctorLangVec3((ay * bz - az * by, az * bx - ax * bz, ax * by - ay * bx))
+            let ((ax, ay, az), (bx, by, bz)) = (widen(a), widen(b));
+            vec3_finite(
+                "Vec3.cross",
+                (ay * bz - az * by, az * bx - ax * bz, ax * by - ay * bx),
+            )
         },
     );
     reg.fn1("Vec3.length", "Vec3.length(v)", |v: FunctorLangVec3| {
-        Value::Number(length(v.0) as f64)
+        Value::Number(vec3_length(widen(v)))
     });
     reg.fn1("Vec3.normalize", "Vec3.normalize(v)", |v: FunctorLangVec3| {
-        FunctorLangVec3(normalize(v.0))
+        let v = widen(v);
+        let len = vec3_length(v);
+        // `len` is finite for every representable input (see `vec3_length`),
+        // so the only non-dividable case is a true zero.
+        let unit = if len > 0.0 {
+            (v.0 / len, v.1 / len, v.2 / len)
+        } else {
+            (0.0, 0.0, 0.0)
+        };
+        vec3_finite("Vec3.normalize", unit)
     });
     reg.fn2(
         "Vec3.distance",
         "Vec3.distance(b, a) — |a - b|",
         |b: FunctorLangVec3, a: FunctorLangVec3| {
-            Value::Number(length((a.0 .0 - b.0 .0, a.0 .1 - b.0 .1, a.0 .2 - b.0 .2)) as f64)
+            let (a, b) = (widen(a), widen(b));
+            Value::Number(vec3_length((a.0 - b.0, a.1 - b.1, a.2 - b.2)))
         },
     );
     reg.fn3(
         "Vec3.lerp",
         "Vec3.lerp(target, t, from) — from |> Vec3.lerp(target, 0.5)",
         |target: FunctorLangVec3, t: f64, from: FunctorLangVec3| {
-            let t = t as f32;
-            let (fx, fy, fz) = from.0;
-            let (tx, ty, tz) = target.0;
-            FunctorLangVec3((
-                fx + (tx - fx) * t,
-                fy + (ty - fy) * t,
-                fz + (tz - fz) * t,
-            ))
+            let (f, g) = (widen(from), widen(target));
+            // Endpoint-exact: `t == 0` yields `from` and `t == 1` yields
+            // `target` bit-for-bit, which `from + (target - from) * t` does
+            // not guarantee once `target - from` overflows.
+            let mix = |f: f64, g: f64| {
+                if t == 0.0 {
+                    f
+                } else if t == 1.0 {
+                    g
+                } else {
+                    f * (1.0 - t) + g * t
+                }
+            };
+            vec3_finite("Vec3.lerp", (mix(f.0, g.0), mix(f.1, g.1), mix(f.2, g.2)))
         },
     );
 }
 
-fn dot(a: (f32, f32, f32), b: (f32, f32, f32)) -> f32 {
+/// The brand's `f32` storage widened to `f64` for arithmetic. Widening is
+/// exact, so no precision is invented; it only removes the overflow cliff
+/// (squaring an `f32` component overflows well below the `f32` range, which
+/// would make `Vec3.length` infinite for a length that is representable).
+fn widen(v: FunctorLangVec3) -> (f64, f64, f64) {
+    (v.0 .0 as f64, v.0 .1 as f64, v.0 .2 as f64)
+}
+
+fn vec3_dot(a: (f64, f64, f64), b: (f64, f64, f64)) -> f64 {
     a.0 * b.0 + a.1 * b.1 + a.2 * b.2
 }
 
-fn length(v: (f32, f32, f32)) -> f32 {
-    dot(v, v).sqrt()
+/// Always finite for a componentwise-finite `f32` input: the largest possible
+/// sum of squares is ~3·(3.4e38)² ≈ 3.5e77, comfortably inside `f64`.
+fn vec3_length(v: (f64, f64, f64)) -> f64 {
+    vec3_dot(v, v).sqrt()
 }
 
-/// A unit vector in the same direction; **the zero vector normalizes to
-/// zero** rather than to NaN or an error.
+/// Narrow an `f64` result back into the brand, refusing a component that is
+/// not finite in `f32`.
 ///
-/// Per-frame code normalizes a velocity or a movement-stick direction that is
-/// legitimately zero constantly, so faulting the frame (or handing back NaN,
-/// which would then poison a transform and blank the screen) is the wrong
-/// default. The guard is `len > 0.0` on the f32 magnitude, which also catches
-/// a length that underflows to zero; a non-finite input still propagates,
-/// since the engine boundary rejects non-finite numbers on its own.
-fn normalize(v: (f32, f32, f32)) -> (f32, f32, f32) {
-    let len = length(v);
-    if len > 0.0 {
-        (v.0 / len, v.1 / len, v.2 / len)
+/// This is the invariant that keeps NaN out of the renderer. Overflowing to
+/// infinity is a real possibility from perfectly legal inputs — a divergent
+/// integrator (`pos |> Vec3.add(vel |> Vec3.scale(dt))` with a too-stiff
+/// spring) doubles every frame and crosses the `f32` range in seconds — and
+/// an infinity that then reaches `Vec3.normalize` or a transform would
+/// silently blank the scene. Failing loudly at the operation that overflowed
+/// names the culprit instead.
+fn vec3_finite(path: &str, v: (f64, f64, f64)) -> Result<FunctorLangVec3, String> {
+    let (x, y, z) = (v.0 as f32, v.1 as f32, v.2 as f32);
+    if x.is_finite() && y.is_finite() && z.is_finite() {
+        Ok(FunctorLangVec3((x, y, z)))
     } else {
-        (0.0, 0.0, 0.0)
+        Err(format!(
+            "{path}: the result is not a finite vector ({x}, {y}, {z}) — a Vec3 component \
+must stay within the 32-bit float range"
+        ))
     }
 }
 
@@ -6024,6 +6062,125 @@ Vec3.make(x, y, z)"
         assert_close(eval_vec3(&format!("Vec3.lerp({b}, 0.5, {a})")), (5.5, 11.0, 16.5));
         // t is not clamped — it extrapolates.
         assert_close(eval_vec3(&format!("Vec3.lerp({b}, 2.0, {a})")), (19.0, 38.0, 57.0));
+    }
+
+    /// The strafe-axis identity the docs promise, pinned numerically: the
+    /// world-space "right" of a gaze is `up × forward`, which in this
+    /// argument order is `up |> Vec3.cross(forward)`. Getting this backwards
+    /// is the predictable cross-product mistake, so both orders are asserted.
+    #[test]
+    fn vec3_cross_strafe_axis_matches_the_docs() {
+        let forward = "Vec3.make(0.0, 0.0, 1.0)";
+        let up = "Vec3.make(0.0, 1.0, 0.0)";
+        // up × forward == +X — the documented strafe axis.
+        assert_close(
+            eval_vec3(&format!("{up} |> Vec3.cross({forward})")),
+            (1.0, 0.0, 0.0),
+        );
+        // forward × up == -X — the other order.
+        assert_close(
+            eval_vec3(&format!("{forward} |> Vec3.cross({up})")),
+            (-1.0, 0.0, 0.0),
+        );
+    }
+
+    /// Accessors round to the brand's `f32` storage — documented, and pinned
+    /// with a value that is NOT exactly representable so the rounding cannot
+    /// be accidentally hidden by a well-chosen test constant.
+    #[test]
+    fn vec3_accessors_round_to_f32() {
+        let x = eval_number("Vec3.x(Vec3.make(0.1, 0.0, 0.0))");
+        assert_eq!(x, 0.1f32 as f64);
+        assert_ne!(x, 0.1f64, "the f32 rounding is real and must stay documented");
+    }
+
+    /// Functor Lang has no exponent notation in float literals, so a huge
+    /// constant has to be spelled out in full.
+    fn lit(n: f64) -> String {
+        format!("{n:.1}")
+    }
+
+    /// A length that IS representable must not overflow to infinity just
+    /// because the intermediate squares would leave the `f32` range — and
+    /// such a vector must normalize to a real unit vector, not to zero (which
+    /// is indistinguishable from the documented zero-vector case).
+    #[test]
+    fn vec3_length_and_normalize_survive_huge_vectors() {
+        let c = lit(2.0e19);
+        let big = &format!("Vec3.make({c}, {c}, {c})");
+        let len = eval_number(&format!("Vec3.length({big})"));
+        assert!(len.is_finite(), "length overflowed to {len}");
+        assert!(
+            (len - 3.4641016e19).abs() / 3.4641016e19 < 1e-5,
+            "unexpected length {len}"
+        );
+        let unit = eval_vec3(&format!("Vec3.normalize({big})"));
+        assert_ne!(unit, (0.0, 0.0, 0.0), "a huge vector must not normalize to zero");
+        let unit_len = eval_number(&format!("Vec3.length(Vec3.normalize({big}))"));
+        assert!((unit_len - 1.0).abs() < 1e-6, "expected unit length, got {unit_len}");
+    }
+
+    /// An operation that overflows the `f32` range fails LOUDLY, naming the
+    /// operation — it must never hand back an infinity that becomes a NaN and
+    /// silently blanks the scene (a NaN transform also serializes as `null`,
+    /// which the `Frame` wire form cannot round-trip).
+    #[test]
+    fn vec3_overflow_is_an_error_not_a_nan() {
+        let (big, huge) = (lit(1.0e20), lit(1.0e19));
+        let msg = fail_message(&format!(
+            "let main = () => Vec3.make({big}, 0.0, 0.0) |> Vec3.scale({huge})"
+        ));
+        assert!(
+            msg.starts_with("Vec3.scale: the result is not a finite vector"),
+            "overflow should name the op, got: {msg}"
+        );
+        // …and the same guard covers the other producers.
+        let (p, n) = (lit(3.0e38), lit(-3.0e38));
+        for (src, path) in [
+            (
+                format!(
+                    "let main = () => Vec3.make({p}, 0.0, 0.0) \
+                     |> Vec3.add(Vec3.make({p}, 0.0, 0.0))"
+                ),
+                "Vec3.add",
+            ),
+            (
+                format!(
+                    "let main = () => Vec3.make({p}, 0.0, 0.0) \
+                     |> Vec3.sub(Vec3.make({n}, 0.0, 0.0))"
+                ),
+                "Vec3.sub",
+            ),
+        ] {
+            assert!(
+                fail_message(&src).starts_with(path),
+                "{path} overflow should be an error"
+            );
+        }
+    }
+
+    /// `lerp` is endpoint-exact even when `target - from` would overflow, so
+    /// `t = 0` can never turn a legal vector into a NaN.
+    #[test]
+    fn vec3_lerp_endpoints_are_exact_at_extremes() {
+        let (p, n) = (lit(3.0e38), lit(-3.0e38));
+        let from = &format!("Vec3.make({p}, 0.0, 0.0)");
+        let target = &format!("Vec3.make({n}, 0.0, 0.0)");
+        // Endpoints are EXACT (the f32-rounded input, unchanged) — an
+        // absolute tolerance is meaningless at this magnitude.
+        assert_eq!(
+            eval_vec3(&format!("{from} |> Vec3.lerp({target}, 0.0)")),
+            (3.0e38f32 as f64, 0.0, 0.0),
+        );
+        assert_eq!(
+            eval_vec3(&format!("{from} |> Vec3.lerp({target}, 1.0)")),
+            (-3.0e38f32 as f64, 0.0, 0.0),
+        );
+        // The midpoint of those extremes is representable and is zero.
+        assert_eq!(
+            eval_vec3(&format!("{from} |> Vec3.lerp({target}, 0.5)")),
+            (0.0, 0.0, 0.0),
+        );
     }
 
     /// A normalized vector is unit-length and keeps its direction.

--- a/runtime/functor-runtime-common/tests/prelude_typecheck.rs
+++ b/runtime/functor-runtime-common/tests/prelude_typecheck.rs
@@ -154,3 +154,51 @@ fn preload_checks_clean() {
     );
     assert!(diags.is_empty(), "preload should check clean: {diags:?}");
 }
+
+/// The `Vec3` accessors and arithmetic typecheck in both the direct-call and
+/// the thread-last pipeline spelling, and compose with the prelude consumers
+/// with no unpack-and-rebuild at the boundary.
+#[test]
+fn vec3_arithmetic_checks_clean() {
+    let diags = check(
+        "let origin = Vec3.make(0.0, 0.0, 0.0)\n\
+         let a = Vec3.make(1.0, 2.0, 3.0)\n\
+         let b = Vec3.make(4.0, 5.0, 6.0)\n\
+         let sum = a |> Vec3.add(b)\n\
+         let diff = a |> Vec3.sub(origin)\n\
+         let scaled = diff |> Vec3.scale(2.0)\n\
+         let unit = scaled |> Vec3.normalize()\n\
+         let d: float = a |> Vec3.dot(b)\n\
+         let perp = a |> Vec3.cross(b)\n\
+         let len: float = unit |> Vec3.length()\n\
+         let dist: float = a |> Vec3.distance(b)\n\
+         let mid = a |> Vec3.lerp(b, 0.5)\n\
+         let cx: float = Vec3.x(sum)\n\
+         let cy: float = Vec3.y(sum)\n\
+         let cz: float = Vec3.z(sum)\n\
+         let total = cx + cy + cz + d + len + dist\n\
+         let scene = Scene.cube() |> Scene.translate(perp) |> Scene.scale(total)\n\
+         let draw = (m, tts) => Frame.create(Camera.lookAt(mid, unit), scene)",
+    );
+    assert!(diags.is_empty(), "Vec3 arithmetic should check clean: {diags:?}");
+}
+
+/// The brand is still enforced STATICALLY: a bare number or a structural
+/// `{x, y, z}` record where a Vec3 belongs stays a check-time error, so the
+/// arithmetic did not open a coercion hole at the prelude boundary.
+#[test]
+fn vec3_arithmetic_rejects_unbranded_values_at_check_time() {
+    assert!(
+        !check("let bad = Vec3.length(1.0)").is_empty(),
+        "a bare number must not check as a Vec3"
+    );
+    assert!(
+        !check("let bad = Vec3.add({ x: 1.0, y: 2.0, z: 3.0 }, Vec3.make(0.0, 0.0, 0.0))")
+            .is_empty(),
+        "a bare record must not check as a Vec3"
+    );
+    assert!(
+        !check("let bad: float = Vec3.make(1.0, 2.0, 3.0) |> Vec3.normalize()").is_empty(),
+        "normalize returns a Vec3, not a float"
+    );
+}

--- a/site/manual/index.html
+++ b/site/manual/index.html
@@ -414,7 +414,7 @@ let pos = model.pos |> Vec3.add(step)</pre>
               <tr><td><code>v |&gt; Vec3.sub(origin)</code></td><td><code>v - origin</code>; direct-call form is <code>Vec3.sub(origin, v)</code></td></tr>
               <tr><td><code>v |&gt; Vec3.scale(k)</code></td><td>multiply every component; negate with <code>Vec3.scale(0.0 - 1.0)</code></td></tr>
               <tr><td><code>a |&gt; Vec3.dot(b)</code></td><td><code>a · b</code> — commutative; zero when perpendicular</td></tr>
-              <tr><td><code>a |&gt; Vec3.cross(b)</code></td><td><code>a × b</code>, right-handed — <code>Vec3.cross(up, forward)</code> is screen-right in Functor's Y-up frame</td></tr>
+              <tr><td><code>a |&gt; Vec3.cross(b)</code></td><td><code>a × b</code>, right-handed (<code>X × Y = Z</code>). For a strafe axis mind the order: world-space "right" is <code>up × forward</code>, i.e. <code>up |&gt; Vec3.cross(forward)</code> — with <code>forward = +Z</code>, <code>up = +Y</code> that is <code>+X</code>; the other order gives <code>-X</code></td></tr>
               <tr><td><code>v |&gt; Vec3.length()</code></td><td>magnitude</td></tr>
               <tr><td><code>v |&gt; Vec3.normalize()</code></td><td>unit vector. <strong>The zero vector normalizes to zero</strong> — not NaN, not an error, because per-frame code normalizes an idle velocity constantly. Test the length first if you need a fallback direction</td></tr>
               <tr><td><code>a |&gt; Vec3.distance(b)</code></td><td><code>|a - b|</code> — symmetric, so the order is free</td></tr>
@@ -425,6 +425,14 @@ let pos = model.pos |> Vec3.add(step)</pre>
             Reads that come <em>back</em> from the engine (<code>Physics.position</code>, a ray
             hit) still hand you a plain <code>{x, y, z}</code> record; wrap one with
             <code>Vec3.make</code> to bring it into the arithmetic above.
+          </p>
+          <p>
+            Components are 32-bit floats, so <code>Vec3.x</code> and friends return a
+            <em>rounded</em> value (<code>Vec3.x(Vec3.make(0.1, 0.0, 0.0))</code> is
+            <code>0.10000000149011612</code>) — compare with a tolerance, not <code>==</code>.
+            Every vector is also <strong>finite</strong>: an operation whose result would
+            overflow the 32-bit range is an error naming the operation, rather than an infinity
+            that becomes a NaN and silently blanks the scene.
           </p>
 
           <h3>Scene</h3>

--- a/site/manual/index.html
+++ b/site/manual/index.html
@@ -388,6 +388,45 @@ let changed = (a: float, b: float): bool =&gt; a != b</pre>
             <code>functor-lang</code> interpreter.
           </p>
 
+          <h3 id="prelude-vec3">Vec3</h3>
+          <p>
+            Every position, direction, velocity, and gravity parameter takes a
+            <code>Vec3</code> value — never three bare floats, so an axis transposition is
+            unrepresentable. Vectors are <strong>opaque</strong>: build one with
+            <code>Vec3.make</code>, read components back with <code>Vec3.x/y/z</code>, and
+            combine them with the arithmetic below rather than unpacking to a record and
+            rebuilding at the boundary.
+          </p>
+          <p>
+            Argument order is <strong>thread-last</strong>, like the rest of the prelude: the
+            <em>subject</em> is the last parameter, so a pipeline reads left-to-right as the
+            subject being acted on. <code>Vec3.sub(b, a)</code> computes <code>a - b</code>,
+            which is what makes <code>v |&gt; Vec3.sub(origin)</code> read as "v minus origin".
+          </p>
+<pre>let toTarget = target |> Vec3.sub(model.pos)
+let step = toTarget |> Vec3.normalize() |> Vec3.scale(speed * dt)
+let pos = model.pos |> Vec3.add(step)</pre>
+          <table>
+            <tbody>
+              <tr><td><code>Vec3.make(x, y, z)</code></td><td>the only constructor</td></tr>
+              <tr><td><code>Vec3.x(v)</code> · <code>Vec3.y(v)</code> · <code>Vec3.z(v)</code></td><td>read a component back out</td></tr>
+              <tr><td><code>a |&gt; Vec3.add(b)</code></td><td><code>a + b</code> — commutative, so the order is free</td></tr>
+              <tr><td><code>v |&gt; Vec3.sub(origin)</code></td><td><code>v - origin</code>; direct-call form is <code>Vec3.sub(origin, v)</code></td></tr>
+              <tr><td><code>v |&gt; Vec3.scale(k)</code></td><td>multiply every component; negate with <code>Vec3.scale(0.0 - 1.0)</code></td></tr>
+              <tr><td><code>a |&gt; Vec3.dot(b)</code></td><td><code>a · b</code> — commutative; zero when perpendicular</td></tr>
+              <tr><td><code>a |&gt; Vec3.cross(b)</code></td><td><code>a × b</code>, right-handed — <code>Vec3.cross(up, forward)</code> is screen-right in Functor's Y-up frame</td></tr>
+              <tr><td><code>v |&gt; Vec3.length()</code></td><td>magnitude</td></tr>
+              <tr><td><code>v |&gt; Vec3.normalize()</code></td><td>unit vector. <strong>The zero vector normalizes to zero</strong> — not NaN, not an error, because per-frame code normalizes an idle velocity constantly. Test the length first if you need a fallback direction</td></tr>
+              <tr><td><code>a |&gt; Vec3.distance(b)</code></td><td><code>|a - b|</code> — symmetric, so the order is free</td></tr>
+              <tr><td><code>from |&gt; Vec3.lerp(target, t)</code></td><td><code>t = 0</code> is <code>from</code>, <code>t = 1</code> is <code>target</code>. <code>t</code> is <strong>not</strong> clamped — values outside <code>0..1</code> extrapolate</td></tr>
+            </tbody>
+          </table>
+          <p>
+            Reads that come <em>back</em> from the engine (<code>Physics.position</code>, a ray
+            hit) still hand you a plain <code>{x, y, z}</code> record; wrap one with
+            <code>Vec3.make</code> to bring it into the arithmetic above.
+          </p>
+
           <h3>Scene</h3>
           <table>
             <tbody>


### PR DESCRIPTION
## The gap

`Vec3` was opaque with **exactly one** member — `Vec3.make(x, y, z)`. No component accessors, no arithmetic. So every game that needed 3D math re-implemented it on a plain `{x, y, z}` record and converted back at the prelude boundary.

The game jam made this concrete. Of the seven entries:

| Entry | What it wrote | Evidence |
| --- | --- | --- |
| **bow** | a whole sibling module `v3.fun` (11 defs) | header: *"the small vector algebra the engine does not ship… the prelude offers only `Vec3.make`"* |
| **shooting-range** | an inline vector module (`vec`/`vadd`/`vmul`/`vlen`/`v3`) | header: *"`Vec3.t` is an opaque engine value with no arithmetic, so the game keeps its own plain-data vector and converts at the engine boundary"* |
| **platformer** | `p3` records + hand-expanded add/scale/cross in `step` | comments *"screen-right is up × forward"*, then expands it by hand |
| **physics-controller** | `{x,y,z}` records, a hand-made zero vector, 2D `normalizeWish` | — |
| **xr-controllers**, **toss** | per-axis scale/add/lerp written out longhand | `examples/toss` even shadows the prelude name: `type Vec3 = { x, y, z }` |

Four wrote a vector module in parallel; **~48 `Vec3.make(r.x, r.y, r.z)` conversions** exist across those entries purely to re-enter the brand. Four of six independently rediscovered the same "only rescale if length > 1" idiom because there was no `normalize`, and only bow wrote a general one — inventing both an epsilon and a fallback direction, i.e. a policy decision each game had to make for itself.

## The design decision: keep the brand (Option B)

Two options were on the table:

- **A — make `Vec3.t` a plain `{x, y, z}` record.** Free accessors, structural equality, and the ~48 conversions vanish because games' own records *are* Vec3s.
- **B — keep the brand opaque, add accessors + arithmetic.** ← chosen

**B wins because A retires the very teaching error the brand exists for.** `Vec3` is in the documented "Angle rule" family (`Angle`, `Color`, `Texture`, `RenderTarget`): a bare number or bare record at a prelude boundary is refused, so an axis transposition is unrepresentable. Under A, `Scene.translate({x: 1, y: 2, z: 3})` would silently coerce at *every* boundary. B also keeps all existing examples working untouched, and it still removes the conversion tax — with accessors a game keeps vectors as `Vec3` end-to-end rather than unpacking and rebuilding.

Verified the brand still holds after the change, at **both** check time and run time:

```
Vec3.length(1.0)                        → Vec3.length: expected a Vec3, got a bare number
                                          — wrap the components: Vec3.make(x, y, z)
Vec3.length({ x: 1.0, y: 2.0, z: 3.0 }) → expected a Vec3 …   (also a check-time diagnostic)
```

### Argument order — thread-last, subject LAST

Pipelines *append* the subject (`x |> f(a)` == `f(a, x)`), and the prelude is already subject-last (`Scene.translate(v, scene)`, `Physics.at(v, body)`). bow's hand-rolled `V3` independently picked the same convention. So:

| Direct call | Computes | Pipeline | Reads as |
| --- | --- | --- | --- |
| `Vec3.add(b, a)` | `a + b` | `a \|> Vec3.add(b)` | "a plus b" (commutative, order free) |
| `Vec3.sub(b, a)` | **`a - b`** | `v \|> Vec3.sub(origin)` | **"v minus origin"** |
| `Vec3.scale(k, v)` | `v * k` | `v \|> Vec3.scale(2.0)` | "v scaled by 2" |
| `Vec3.dot(b, a)` | `a · b` | `a \|> Vec3.dot(b)` | commutative, order free |
| `Vec3.cross(b, a)` | **`a × b`** | `a \|> Vec3.cross(b)` | "a cross b" |
| `Vec3.length(v)` | `\|v\|` | `v \|> Vec3.length()` | — |
| `Vec3.normalize(v)` | unit | `v \|> Vec3.normalize()` | — |
| `Vec3.distance(b, a)` | `\|a - b\|` | `a \|> Vec3.distance(b)` | symmetric, order free |
| `Vec3.lerp(target, t, from)` | `from → target` | `from \|> Vec3.lerp(target, 0.5)` | "from, halfway to target" |
| `Vec3.x/y/z(v)` | component | — | — |

```
let toTarget = target |> Vec3.sub(model.pos)
let step     = toTarget |> Vec3.normalize() |> Vec3.scale(speed * dt)
let pos      = model.pos |> Vec3.add(step)
```

### Two documented policy decisions

- **`normalize` of the zero vector is the ZERO vector** — not NaN, not an error. Per-frame code normalizes an idle velocity or a centred movement stick constantly; faulting the frame would be hostile and NaN would poison a transform. Zero is the *only* input that yields a non-unit result.
- **Overflow is an error, not an infinity.** Every vector in the system is componentwise finite (`Vec3.make` already guaranteed it), and the arithmetic preserves that: an operation whose result leaves the f32 range fails naming the operation.

## Implementation

Registered through the **typed external registry** (`register_vec3` in `functor_lang_prelude.rs`) — one typed closure per entry, arity/usage/conversion errors derived, no legacy `match path` arms. Both producers (desktop + wasm) therefore get it for free. The drift test (`prelude_signatures_map_to_host_paths`) confirms the `.funi` signatures ≡ registry paths as a hard bijection, with matching arities.

## Review dispositions (`/xreview` — Claude subagent + Codex, both adversarial)

Both engines independently confirmed: thread-last order correct for every non-commutative op, `.funi`↔registry bijection intact, teaching errors preserved, no helper name collisions, no x86/ARM divergence in the ordinary path.

| # | Finding | Engines | Disposition |
| --- | --- | --- | --- |
| 1 | **Non-finite Vec3 escapes to the renderer.** f32 arithmetic can overflow to `inf` from legal inputs; `normalize` turns that into NaN, which reaches `Scene.translate`/`Camera.lookAt`/gravity. Claude empirically produced a `Frame` serializing as `"xform":[…,[null,0.0,0.0,1.0]]` — the wire form can't round-trip that `null`. | **[AGREED]** Claude High, Codex High | **Fixed.** All intermediates now computed in f64 and finite-checked before re-branding (`vec3_finite`). Overflow is an error naming the op. |
| 2 | **`length`/`normalize` broken for large-but-representable vectors.** Squaring in f32 overflows far below the f32 component range: `length((2e19)³)` → `inf`, and `normalize` → **zero**, indistinguishable from the documented zero-vector case, so a game's `if length > 0` fallback silently takes the wrong branch. | **[AGREED]** Claude Medium, Codex High | **Fixed** by the same f64 accumulation. Regression test asserts a 2e19-per-component vector normalizes to a real unit vector. |
| 3 | **`lerp` NaN at `t == 0`** when `target - from` overflows (`f32::MAX` → `-f32::MAX`): `-inf * 0` = NaN, violating the documented endpoint. | Codex High | **Fixed.** `lerp` is now endpoint-exact — `t == 0`/`t == 1` return the endpoint bit-for-bit. Test covers the extreme pair. |
| 4 | **Cross-product doc example operand-swapped.** With `cross(b, a) = a × b`, `Vec3.cross(up, forward)` is `forward × up` = **−X**, not the strafe axis. | Codex **Critical**; Claude rated it Low ("technically correct but contradicts the repo's own +X is right") | **Fixed — I adjudicated in Codex's favour.** The engine's right-handed basis gives `right = up × forward` = +X, matching `CLAUDE.md`'s "+X is right". Claude's defence relied on a `look_at_rh` subtlety (view-X is −X when gazing down +Z) that makes the phrase "screen-right" genuinely ambiguous, so **"screen-right" is dropped entirely** in favour of the unambiguous world-frame identity, and both orders are now pinned by a numeric test. |
| 5 | **Accessor f32 rounding undocumented**, and the test used only exactly-representable constants so it couldn't notice. | Claude Medium | **Fixed.** Documented in `.funi`/manual/skill; new test pins `Vec3.x(Vec3.make(0.1, …))` == `0.1f32 as f64` **and** asserts it differs from `0.1f64`, so the rounding can't be hidden again. |
| 6 | Generic helper names `dot`/`length`/`normalize` in a 6000-line module; a second hand-rolled copy vs `audio.rs`. | Claude Low | **Partly taken.** Renamed `vec3_dot`/`vec3_length`. Did **not** refactor `audio.rs` or swap to cgmath — unrelated code, out of scope for this PR. |
| 7 | No benchmark comparison. | Claude Low (process) | **Done** — below. |

Fixes landed in `c94cb75`; all verification re-run afterwards.

## Verification

- `cargo test -p functor_runtime_common` — **529 passed**, 0 failed (15 of them new Vec3 tests: every op, thread-last pipeline forms, the cross strafe-axis identity in both orders, normalize-of-zero, huge-vector length/normalize, overflow-is-an-error, lerp endpoint exactness, accessor rounding, teaching errors at both check and run time, reload-safety of computed vectors)
- `cargo test -p functor-lang` — **581 passed**, 0 failed
- `npm run check:docs` — green (every new signature carries `///` docs)
- **Examples sweep** — all **31** example entries (every `entry`/`entries` across `examples/*/functor.json`) load and typecheck clean through the engine bundle
- Drift test green: 12 registered paths ≡ 12 `.funi` signatures, arities matching

### frame_bench (base `926089c` vs branch, release)

`allocs/frame` and `bytes/frame` — the deterministic acceptance metrics — are **byte-identical at all three sizes, on every run**:

| cells | allocs/frame | bytes/frame |
| --- | --- | --- |
| 400 | 13877 (both) | 843379 (both) |
| 1600 | 54717 (both) | 3307219 (both) |
| 3136 | 106973 (both) | 6460243 (both) |

**Wall-clock was not measurable on this machine** and I'm not going to dress it up: the host became progressively contended during the run, and `tick` — an identity model pass-through on a pure-interpreter path this PR does not touch — drifted **0.46 → 1.80 µs/call across runs of identical code, including at the base commit**. The earliest, least-contended pair overlapped (400 cells, min: base 461–520 µs, branch 499–522 µs). Note also that the synthwave-shaped `frame_bench` workload calls **no** Vec3 arithmetic, so the only possible delta is 12 additional entries in the registry's lookup map.

## Notes for consumers

**Rebuild required.** This changes `runtime/functor-runtime-common` (the prelude), so `functor run` alone won't pick it up — run `npm run build:cli` first, or the running shell silently won't have `Vec3.add` and friends.

No example was converted in this PR. The candidates (`physics-controller`, `toss`, `hello`) all mix vector math with 2D-only helpers and record-shaped model fields, so a faithful conversion would have been a behaviour-affecting refactor rather than the drop-in simplification the brief asked for — better as its own PR where captures can prove no visual change. The jam entries that motivated this live in other worktrees and aren't in `examples/` yet.

## Docs

- `functor-prelude/prelude/vec3.funi` — module doc with the thread-last rule + pipeline example; per-function docs incl. the two policy decisions
- `.claude/skills/functor-lang/SKILL.md` — Vec3 section extended (the stale surface listed only `Vec3.make`)
- `docs/functor-lang.md` — the stale roadmap note *"Component accessors and vector math … are deliberately deferred"* replaced with the landed entry + the A/B rationale
- `site/manual/index.html` — new `Vec3` section in the prelude reference

## Manual (before / after)

Desktop (~1280px):

![Manual Vec3 section before/after (desktop)](https://gist.githubusercontent.com/tommy-xr/02efe5f274d4f20a79a78c8fe87d168b/raw/manual-vec3-before-after-desktop.png)

Mobile (~390px) — the new reference table stays inside its own row/column layout; `document.documentElement.scrollWidth` matched `clientWidth` at both viewport widths, so there's no page-level horizontal overflow from the new section:

![Manual Vec3 section before/after (mobile)](https://gist.githubusercontent.com/tommy-xr/02efe5f274d4f20a79a78c8fe87d168b/raw/manual-vec3-before-after-mobile.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

