### PR TITLE
feat(physics): per-axis velocity commands

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -1172,6 +1172,11 @@ scene |> Physics.transformed(tag)                          // scene at the body'
 Physics.applyImpulse(tag, v)                               // -> Effect (fire-and-forget)
 Physics.applyForce(tag, v)                                 //   force lasts ONE stepped frame
 Physics.setVelocity(tag, v) / Physics.teleport(tag, v)
+Physics.setVelocityXZ(tag, x, z)                           // write ONLY the horizontal plane;
+                                                           //   the solver keeps y (the
+                                                           //   character-controller command)
+Physics.setVelocityY(tag, v)                                // write ONLY the vertical axis;
+                                                           //   a jump that keeps the run
 Physics.raycast(origin, dir, maxDist, tagger)              // -> Effect (QUERY): tagger gets
                                                            //   {hit, x, y, z, nx, ny, nz,
                                                            //    distance, tag} — hit: false
@@ -1254,8 +1259,11 @@ let tick = (m, dt, tts) =>
     let pos = Physics.position(playerTag) in
     let vel = Physics.linearVelocity(playerTag) in
     let onGround = probe(pos).hit in
-    let vy = if onGround && m.jump then 6.0 else vel.y in
-    (m, Physics.setVelocity(playerTag, Vec3.make(vel.x, vy, vel.z)))
+    // Steer the horizontal plane only — the solver owns `y`.
+    (m, if onGround && m.jump then
+          Effect.batch([Physics.setVelocityXZ(playerTag, vel.x, vel.z),
+                        Physics.setVelocityY(playerTag, 6.0)])
+        else Physics.setVelocityXZ(playerTag, vel.x, vel.z))
 ```
 
 The read happens in `tick`, the command drains immediately after `tick` (no
@@ -1267,15 +1275,15 @@ Note the two rules this example obeys: local `let` needs `in`, and the
 pre-step readers raise on the first frame, before the `physics` hook's
 declaration has been reconciled and stepped — so gate them.
 
-⚠️ The sketch above is the LOOP SHAPE, not a usable controller: its
-`else vel.y` is the first of three traps below. See the next section.
+⚠️ The sketch above is the LOOP SHAPE, not a usable controller — it has no
+coyote time, jump buffering, or post-jump lockout. See the next section.
 
 ### Character controllers on the `physics` hook
 
 `examples/physics-controller` is the worked reference (a dynamic capsule, a
 moving kinematic deck, coyote time, jump buffering, landing squash, walls),
 with its whole feel layer as pure functions under `expect`. Read it before
-writing a controller. The recipe, and the three traps that are NOT obvious:
+writing a controller. The recipe, and the parts that are NOT obvious:
 
 **Declare the body `|> Physics.upright`.** This is not optional. A dynamic
 capsule that can rotate picks up angular velocity from any glancing contact and
@@ -1304,29 +1312,52 @@ let surfaceVelocity = (probe) =>
 Then steer RELATIVE to that surface (`target = carry.x + wish * speed`), so
 standing still rides along and a jump inherits the deck's motion.
 
-**The three traps.** All three come from `Physics.setVelocity` replacing ALL
-THREE components — there is no horizontal-only command — so the controller must
-say something about `vy` every frame. All three were measured as visible
-artifacts, not theorized:
+**Steer with `Physics.setVelocityXZ`, and never write `vy` while grounded.**
+This is the single most important rule, and it is what the per-axis command
+exists for. `Physics.setVelocity` replaces all three components, so a
+controller using it has to invent a vertical velocity every frame — and the
+only values available are a stale read or a guess. `setVelocityXZ` writes the
+horizontal plane and leaves `y` exactly as the solver left it, so the ground
+contact, the landing impulse, and gravity all stay where they belong:
 
-1. **Do not echo the read back while grounded.** The read is one step stale, so
-   it still carries the downward speed the solver just cancelled at the contact;
-   re-commanding it drives the capsule into the floor. A capsule that should
-   rest 0.90 above the surface rested at 0.40 — and, downstream, stopped against
-   a wall 0.45 units early, because a half-buried capsule catches the wall's
-   corner instead of its face.
-2. **Commanding `0.0` while grounded also sinks, just slower.** Overwriting `vy`
-   destroys the contact's own pushout impulse too, so each step's gravity
-   increment accumulates as penetration (0.98 drifting to 0.40 over 260 frames).
-   Instead, own the standing height with a **ground clamp**: the probe already
-   measured the distance, so correct toward the rest distance, `error / dt`,
-   bounded to a few units/s. This also buys stick-to-a-descending-deck for free.
-3. **The ground clamp will cancel your jump** unless you suppress it. For the
-   first frames after takeoff the feet are still within the probe's reach, so
-   the character reads as grounded and gets clamped back down — it rose 0.12
-   units instead of 1.16, `vy` flipping +6.83 to −6.37 in one frame. Arm a short
-   **post-jump lockout** (~0.1 s) when the jump fires, and treat grounding as
-   false for its duration.
+```functor
+(next, Physics.setVelocityXZ(playerTag, want.x, want.z))
+```
+
+The one frame that *should* write the vertical axis is the jump, and
+`Physics.setVelocityY` writes only that — so it keeps the run's horizontal
+momentum, and (unlike `applyImpulse`) does not scale with the body's mass:
+
+```functor
+Effect.batch([
+  Physics.setVelocityXZ(playerTag, want.x, want.z),
+  Physics.setVelocityY(playerTag, jumpSpeed + carry.y),
+])
+```
+
+The two masks are disjoint, so that pair applies as one whole-vector write.
+More generally, velocity commands in the same frame compose as **last-write-
+wins per axis**, against the live body at apply time.
+
+Doing this deleted the hand-written **ground clamp** the example used to
+carry — a `error / dt` correction toward the standing height, plus the `dt = 0`
+NaN guard it needed. Measured across a 400-frame scripted run, dropping the
+clamp for `setVelocityXZ` left the resting height (0.8987 vs 0.8988), the wall
+stop (`x = −6.3012`), the jump rise (`+0.9363`), and the platform ride (91
+frames on the deck) all unchanged; the only difference is a transient 0.04 dip
+during a hard landing that the clamp used to correct away instantly.
+
+⚠️ A clamp is still the answer for one thing the solver will not do:
+**sticking to a surface that drops away**. Without it a character on a
+descending platform goes briefly ballistic. Add it back only if you have
+descending platforms, and only for that.
+
+**Still arm a post-jump lockout** (~0.1 s) when the jump fires, and treat
+grounding as false for its duration. For the first frames after takeoff the
+feet are still within the probe's reach, so the character reads as grounded
+while it is physically leaving the ground: coyote time refills, a second tap
+gets a free second jump, and steering uses the ground acceleration rate in
+mid-air.
 
 **Keep the decisions pure.** Read the world in `tick`, pass a plain
 `observation` record (grounded, velocity, probe distance, rest height) to

--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -1360,7 +1360,8 @@ gets a free second jump, and steering uses the ground acceleration rate in
 mid-air.
 
 **Keep the decisions pure.** Read the world in `tick`, pass a plain
-`observation` record (grounded, velocity, probe distance, rest height) to
+`observation` record (`{ grounded, vx, vy, vz }` — no probe distance and no
+rest height, because the controller never writes the vertical axis) to
 pure functions, and command the result. The controller's feel then unit-tests
 under `functor test` with no GPU and no world — and the physics drive is
 recorded, so a scripted `--input-script` run is bit-deterministic too

--- a/docs/physics.md
+++ b/docs/physics.md
@@ -231,7 +231,19 @@ module Physics =
     let applyForce   (tag: string) (force: Vector3)   : effect<'msg>
     let setVelocity  (tag: string) (v: Vector3)       : effect<'msg>
     let teleport     (tag: string) (pos: Vector3)     : effect<'msg>
+    // Per-axis writes: the Y-up engine's natural partition, so a game can
+    // steer one part of the velocity and leave the rest to the solver.
+    let setVelocityXZ (tag: string) (x: float) (z: float) : effect<'msg>
+    let setVelocityY  (tag: string) (v: float)            : effect<'msg>
 ```
+
+`setVelocityXZ` / `setVelocityY` write only the axes they name and read the
+rest from the live body **at apply time** — after reconcile, and after any
+command already applied from the same frame's queue. Several velocity commands
+in one frame therefore compose as **last-write-wins per axis**, with every
+axis nobody wrote left exactly as the solver left it. The two masks partition
+all three axes, so issuing both in one frame equals a whole-vector
+`setVelocity`.
 
 **Queries — tagger effects.** *Shipped (Phase 4) on the Functor Lang surface*:
 `Physics.raycast(Vec3.make(ox, oy, oz), Vec3.make(dx, dy, dz), maxDist, tagger)` — the tagger

--- a/examples/physics-controller/README.md
+++ b/examples/physics-controller/README.md
@@ -9,7 +9,7 @@ interesting comparison is what each one has to write, and what it gets for
 free.
 
 ```sh
-functor -d examples/physics-controller test          # 39 expects (32 controller, 7 level data)
+functor -d examples/physics-controller test          # 34 expects (27 controller, 7 level data)
 functor -d examples/physics-controller run native    # WASD / arrows, SPACE to jump, ENTER to respawn
 ```
 
@@ -26,7 +26,7 @@ let tick = (model, dt, tts) =>
   let carry = surfaceVelocity(probe) in
   let sensed = Control.sense(dt, obs, m.jumpEdge, m.ctl) in   // decide (pure)
   let want   = Control.desiredVelocity(dt, obs, carry, sensed) in
-  (next, Physics.setVelocity(playerTag, Vec3.make(want.x, want.y, want.z)))  // write
+  (next, Physics.setVelocityXZ(playerTag, want.x, want.z))    // write (horizontal only)
 ```
 
 The reads see the previous step (physics runs after `tick`) and the command
@@ -35,14 +35,14 @@ within one frame. That one step of read latency is inherent to any
 read → decide → step simulation, not a Functor restriction.
 
 `control.fun` holds every decision as a pure function of an *observation*, so
-the entire feel layer — coyote time, jump buffering, acceleration, the ground
-clamp, landing response — is covered by `expect` tests that run in
-milliseconds with no GPU, no window, and no rapier world.
+the entire feel layer — coyote time, jump buffering, acceleration, landing
+response — is covered by `expect` tests that run in milliseconds with no GPU,
+no window, and no rapier world.
 
 The character body **must** be declared `|> Physics.upright`. A dynamic capsule
 that can rotate picks up angular velocity from any glancing contact and topples
 — and a tipped capsule's lowest point is no longer `feetOffset` below its
-center, so the grounding probe and the ground clamp both start lying. (This
+center, so the grounding probe starts lying. (This
 attribute did not exist before this example; adding it is part of this change.)
 
 ### The one idea worth stealing
@@ -96,7 +96,7 @@ whatever it stands on; the plaza's top face is `y = 0` and the deck's is
 | Riding the moving platform | **CLEAN** | `probe.tag` → `linearVelocity` tracks the deck's analytic velocity to within 0.030 on a 2.4 u/s deck. Relative offset `x − deckX` held at −0.48 ± 0.02 over 80 frames — bounded and oscillatory, not accumulating. |
 | Wall | **CLEAN, and free** | Held into the wall for 220 frames: stopped at `x = −6.3012` against a predicted −6.3000 (wall face −6.7, capsule radius 0.4) and stayed — `x` and `z` both constant to four decimals from f=260 to f=399. Zero collision code in the game. |
 | Edge / ledge fall-off | **CLEAN, and free** | Walking off the deck's edge simply stops being grounded; gravity and the solver do the rest. |
-| Standing height | **CLEAN, with a caveat** | A constant 0.8988 on the plaza and 2.1462–2.1488 on the deck. Getting here needed a ground clamp, a post-jump lockout, and `Physics.upright` — see below. |
+| Standing height | **CLEAN** | A constant 0.8987 on the plaza and 2.1462–2.1487 on the deck, owned entirely by the solver: the controller never writes the vertical axis. Needs `Physics.setVelocityXZ`, a post-jump lockout, and `Physics.upright` — see below. |
 | Keeping the capsule upright | **WAS IMPOSSIBLE — fixed in this change** | A rotating capsule visibly toppled (40-80° off vertical mid-jump) and then crept 0.19 units sideways along the wall with no input. No rotation lock, angular damping, or angular-velocity command existed in the `Physics` API, so this was unfixable in game code. This change adds `Physics.upright`. |
 
 ### The one thing that was genuinely impossible
@@ -109,8 +109,8 @@ depends on the frame), and once it leaned on the wall it crept
 0.19 units along `z` over 140 frames with no input, still accelerating. It also
 silently corrupted the controller, because a tipped capsule's lowest point is
 `radius + halfHeight·cos θ` below its center rather than the fixed
-`feetOffset` the probe and the ground clamp assume — which showed up as a
-±0.031 ripple in the standing height.
+`feetOffset` the probe assumes — which showed up as a ±0.031 ripple in the
+standing height.
 
 This change adds `Physics.upright`, a nullary body attribute in the shape of
 `Physics.sensor`, mapping to rapier's `LockedAxes::ROTATION_LOCKED`. With it,
@@ -118,42 +118,61 @@ the standing height is a **constant 0.8988** and the wall contact is
 **motionless in both `x` and `z`**. It is the smallest surface that fixes the
 problem, and it is off by default so existing bodies tumble exactly as before.
 
-### The two things that were awkward but correct
+### The vertical axis, and the workaround that is now gone
 
-Both are about `Physics.setVelocity` replacing **all three** velocity
-components — there is no horizontal-only command — so the controller must say
-something about `vy` every single frame. Two plausible answers are wrong, and
-both failures were *observable*, not theoretical:
+This example was originally written against `Physics.setVelocity`, which
+replaces **all three** components. A controller steering with it must say
+something about `vy` every single frame, and the only values available are a
+stale read or a guess. To keep the capsule at its standing height the example
+carried a hand-written **ground clamp**: while grounded, correct toward the
+rest distance the probe measured, `error / dt`, bounded — plus a `dt = 0`
+guard so the `--fixed-time` capture path did not divide by zero.
 
-1. **Echoing the read back sank the character half a unit into the floor.**
-   The read is one step stale, so while grounded it still carries the downward
-   speed the solver just cancelled at the contact. Re-commanding it drives the
-   capsule in. Measured: it rested at `y = 0.40` instead of 0.90. A downstream
-   symptom was that the wall stop landed at `x = −5.85` instead of −6.30,
-   because a half-buried capsule contacts the wall's corner rather than its
-   face.
+`Physics.setVelocityXZ` deletes all of that. It writes only the horizontal
+plane, so the solver keeps the `y` it is using to resolve the ground contact,
+and the controller simply has no vertical opinion to get wrong. The jump — the
+one frame that *should* drive the vertical axis — uses `Physics.setVelocityY`,
+which keeps the run's horizontal momentum and does not scale with mass.
 
-2. **Commanding `0` while grounded still sank it, slowly.** Overwriting `vy`
-   every frame also destroys the contact's own pushout impulse, so each step's
-   gravity increment accumulates as penetration: `y = 0.98` drifting to 0.40
-   over 260 frames.
+Measured over the 400-frame scripted run above, before and after:
 
-The fix is the standard character-controller **ground clamp**: while grounded,
-own the standing height explicitly by correcting toward the rest distance the
-probe already measured, `error / dt`, bounded. It also buys stick-to-a-
-descending-deck for free.
+| | ground clamp | `setVelocityXZ` |
+| --- | --- | --- |
+| resting height | 0.8988 | 0.8987 |
+| wall stop `x` | −6.3012 | −6.3012 |
+| jump rise | +0.9363 | +0.9363 |
+| frames on the deck | 91 | 91 |
+| lowest `y` | 0.8962 | 0.8554 |
 
-That fix then exposed a third, equally classic problem: **the ground clamp
-cancelled the jump.** For the first frames after takeoff the feet are still
-within the probe's reach, so the character read as grounded and the clamp
-yanked it back down — it rose 0.12 units instead of 1.16, with `vy` flipping
-+6.83 → −6.37 in one frame. The fix is a short post-jump lockout during which
-grounding is ignored (`jumpLockTime = 0.1`).
+Everything that matters is unchanged. The one difference is the last row: a
+transient ~0.04 dip at the hardest landing, where the solver briefly resolves
+its own penetration instead of the clamp erasing it in a single frame. It is
+not visible in motion.
 
-None of these three are Functor-specific; every engine's character controller
-carries the same three counter-measures. They are called out here because they
-are exactly the traps an author hits on day one, and all three are now pinned
-by regression `expect`s in `control.fun`.
+**One thing the clamp did that the solver will not**: stick to a surface that
+is dropping away. This level's deck only slides along `x`, so nothing here
+exercises it — but a character on a *descending* platform goes briefly
+ballistic without a clamp. Add one back for that case, and only for that case.
+
+**The post-jump lockout is still needed** (`jumpLockTime = 0.1`). For the first
+frames after takeoff the feet are still within the probe's reach, so the
+character reads as grounded while it is physically leaving the ground: coyote
+time refills, a second tap of SPACE gets a free second jump, and steering uses
+the ground acceleration rate in mid-air.
+
+**A note on the earlier measurements.** The two sinking failures this section
+used to report (a capsule resting at 0.40 instead of 0.90, from echoing the
+read back or from commanding `0` while grounded) were re-tested at the command
+layer while adding `setVelocityXZ`, and **neither reproduces**. Echoing the
+read back is bit-identical to issuing no command at all — the read and the
+command's apply point observe the same world state — and commanding `y = 0`
+while grounded recovers to the same resting height, because rapier resolves a
+landing's penetration positionally rather than through the velocity the game
+overwrites. Both were checked after a real drop-and-land, under a fixed frame
+time and a jittered one; see `masked_writes_are_transparent_on_the_untouched_axis`
+in `runtime/functor-runtime-common/src/physics/world.rs`. The case for the
+per-axis command is therefore ergonomic and architectural — a game should not
+have to author an axis the solver owns — not a sinking fix.
 
 ## Does this want a `postTick` hook?
 
@@ -195,11 +214,12 @@ have been fixed by `postTick`:
 
 1. **No rotation lock** (fixed here as `Physics.upright`). This was the only
    *impossible* item, and it is a body attribute, not a lifecycle question.
-2. **`Physics.setVelocity` is all-or-nothing across three axes**, which is what
-   forced the ground clamp to be written by hand. A per-axis or
-   horizontal-only velocity command would have removed both sinking failure
-   modes outright. Still open, and a much smaller, better-targeted change than
-   a new hook — the problem is the *shape of the command*, not when it runs.
+2. **`Physics.setVelocity` was all-or-nothing across three axes**, which is
+   what forced the ground clamp to be written by hand. **Now fixed**:
+   `Physics.setVelocityXZ` / `Physics.setVelocityY` write only the axes they
+   name, and this example's clamp is deleted. It was a much smaller,
+   better-targeted change than a new hook — the problem was the *shape of the
+   command*, not when it runs.
 
 That both real gaps turned out to be one-line API surface rather than frame
 ordering is itself the argument: the `tick`-plus-synchronous-queries loop was

--- a/examples/physics-controller/README.md
+++ b/examples/physics-controller/README.md
@@ -96,7 +96,7 @@ whatever it stands on; the plaza's top face is `y = 0` and the deck's is
 | Riding the moving platform | **CLEAN** | `probe.tag` → `linearVelocity` tracks the deck's analytic velocity to within 0.030 on a 2.4 u/s deck. Relative offset `x − deckX` held at −0.48 ± 0.02 over 80 frames — bounded and oscillatory, not accumulating. |
 | Wall | **CLEAN, and free** | Held into the wall for 220 frames: stopped at `x = −6.3012` against a predicted −6.3000 (wall face −6.7, capsule radius 0.4) and stayed — `x` and `z` both constant to four decimals from f=260 to f=399. Zero collision code in the game. |
 | Edge / ledge fall-off | **CLEAN, and free** | Walking off the deck's edge simply stops being grounded; gravity and the solver do the rest. |
-| Standing height | **CLEAN** | A constant 0.8987 on the plaza and 2.1462–2.1487 on the deck, owned entirely by the solver: the controller never writes the vertical axis. Needs `Physics.setVelocityXZ`, a post-jump lockout, and `Physics.upright` — see below. |
+| Standing height | **CLEAN** | A constant 0.8987 on the plaza and 2.1462–2.1487 on the deck, owned entirely by the solver: with `Physics.setVelocityXZ` the controller never writes the vertical axis, so there is nothing to hold it up by hand. Needs `Physics.upright` (and a post-jump lockout for the grounding read) — see below. |
 | Keeping the capsule upright | **WAS IMPOSSIBLE — fixed in this change** | A rotating capsule visibly toppled (40-80° off vertical mid-jump) and then crept 0.19 units sideways along the wall with no input. No rotation lock, angular damping, or angular-velocity command existed in the `Physics` API, so this was unfixable in game code. This change adds `Physics.upright`. |
 
 ### The one thing that was genuinely impossible

--- a/examples/physics-controller/control.fun
+++ b/examples/physics-controller/control.fun
@@ -81,7 +81,7 @@ let decay = (dt, t) => Math.max(0.0, t - dt)
 let sense = (dt, obs, jumpEdge, c) =>
   let lock = decay(dt, c.lock) in
   // While the post-jump lock is live, grounding is ignored outright: everything
-  // downstream — coyote refill, the landing edge, and the ground clamp — reads
+  // downstream — coyote refill, the landing edge, and the steering rate — reads
   // the character as airborne, which is what it physically is.
   let grounded = obs.grounded && not (lock > 0.0) in
   let landed = grounded && not c.grounded in
@@ -105,7 +105,7 @@ let sense = (dt, obs, jumpEdge, c) =>
 let jumpNow = (c) => c.coyote > 0.0 && c.buffer > 0.0
 
 // Close both windows so one press cannot fire twice, and arm the lock that
-// keeps the ground clamp off the character while it is leaving the ground.
+// keeps the character reading as airborne while it is leaving the ground.
 let consumeJump = (c) => { c with coyote: 0.0, buffer: 0.0, lock: jumpLockTime }
 
 // Move `current` toward `target` at `rate` units/s^2 without overshooting.
@@ -145,12 +145,18 @@ let desiredVelocity = (dt, obs, carry, c) =>
     z: approach(rate, dt, obs.vz, targetZ),
   }
 
-// The vertical velocity a JUMP commands, on the one frame it fires — the jump
-// speed plus whatever the surface underfoot was already doing, so a rising
-// lift launches you higher instead of out from under itself. `game.fun` sends
-// this with `Physics.setVelocityY` only when `jumpNow` is true; on every other
-// frame nothing writes the axis at all.
+// The vertical velocity a JUMP commands — the jump speed plus whatever the
+// surface underfoot was already doing, so a rising lift launches you higher
+// instead of out from under itself.
 let jumpVelocity = (carry) => jumpSpeed + carry.y
+
+// The whole vertical story, as data: `Some` on the one frame a jump fires and
+// `None` on every other. `game.fun` sends a `Physics.setVelocityY` exactly
+// when this is `Some`, so "the controller does not touch the vertical axis
+// unless it is jumping" is a property the expects below can pin, rather than
+// a convention a reader has to verify by eye.
+let verticalCommand = (carry, c): Option.t<float> =>
+  if jumpNow(c) then Option.Some(jumpVelocity(carry)) else Option.None
 
 // Landing squash as a vertical scale factor: 1.0 at rest, dipping right after
 // a hard landing and easing back as the timer drains.
@@ -229,17 +235,28 @@ expect (
   not jumpNow(consumeJump(land))
 )
 
-// A jump commands the jump speed. Every other frame commands NOTHING vertical
-// — `game.fun` only sends `Physics.setVelocityY` when `jumpNow` is true, so
-// the property to check here is simply when the jump fires, not what vy the
-// controller would have invented on the frames in between.
-expect jumpVelocity(still) == jumpSpeed
-expect jumpNow(sense(dt, onGround, true, zero))
-expect not jumpNow(sense(dt, obsAt(false, 0.0, -4.25), false, zero))
+// THE rule this example exists to demonstrate: the controller emits a vertical
+// command on the jump frame and on NO other frame, so the solver owns the
+// standing height, the landing, and gravity. `game.fun` sends a
+// `Physics.setVelocityY` exactly when `verticalCommand` is `Some`.
+expect (
+  let jumping = sense(dt, onGround, true, zero) in
+  verticalCommand(still, jumping) == Option.Some(jumpSpeed)
+)
+// Grounded and standing, falling through the air, and hard on the way down —
+// none of them command anything vertical.
+expect verticalCommand(still, sense(dt, onGround, false, zero)) == Option.None
+expect verticalCommand(still, sense(dt, air, false, zero)) == Option.None
+expect verticalCommand(still, sense(dt, obsAt(true, 0.0, -6.7), false, zero)) == Option.None
+expect verticalCommand(still, sense(dt, obsAt(false, 0.0, -4.25), false, zero)) == Option.None
 
 // Jumping off a moving deck inherits its vertical motion (a rising lift
 // launches you higher, not out from under itself).
-expect jumpVelocity({ x: 0.0, y: 2.0, z: 0.0 }) == jumpSpeed + 2.0
+expect (
+  let lift = { x: 0.0, y: 2.0, z: 0.0 } in
+  let jumping = sense(dt, onGround, true, zero) in
+  verticalCommand(lift, jumping) == Option.Some(jumpSpeed + 2.0)
+)
 
 // The post-jump lock, pinned. On the frame AFTER a jump fires the feet are
 // still within the probe's reach, so the raw observation still says grounded.

--- a/examples/physics-controller/control.fun
+++ b/examples/physics-controller/control.fun
@@ -19,9 +19,9 @@ let groundAccel = 45.0
 let airAccel = 14.0
 // How long after a jump grounding is ignored. For the first frames of a jump
 // the feet are still within the probe's reach, so without this the character
-// reads as grounded, the ground clamp corrects it back down to standing
-// height, and the jump is cancelled on the frame after it fires. Measured: it
-// rose 0.12 units instead of 1.2, with vy flipping +6.83 to -6.37 in one frame.
+// still reads as grounded while it is physically leaving the ground: coyote
+// time refills, a second tap of SPACE gets a free second jump, and steering
+// uses the ground acceleration rate in mid-air.
 let jumpLockTime = 0.1
 // Downward speed at which a landing reads as maximally hard.
 let landHardness = 6.0
@@ -122,66 +122,35 @@ let approach = (rate, dt, current, target) =>
 //           the air). Steering is relative to the SURFACE, so standing still
 //           on a moving deck rides along with it, and a jump inherits the
 //           deck's motion instead of stopping dead in mid-air.
-// How fast the ground clamp below may correct the standing height.
-let maxSnapSpeed = 6.0
-
-// The vertical axis is the subtle part, because `Physics.setVelocity` replaces
-// ALL THREE components — there is no horizontal-only command. So the controller
-// must say something about vy every frame, and two obvious answers are both
-// wrong. Measured, on a capsule that should rest with its center 0.90 above the
-// surface:
 //
-//   echo the read back      -> the read is one step stale, so while grounded it
-//                              still carries the downward speed the solver just
-//                              cancelled at the contact. Re-commanding it drives
-//                              the capsule in: it rested at y = 0.40, visibly
-//                              sunk half a unit into the floor.
-//   command 0 while grounded -> better, but overwriting vy every frame also
-//                              destroys the contact's own pushout impulse, so
-//                              each step's gravity increment accumulates as
-//                              penetration. It still sank, just slower —
-//                              y = 0.98 drifting to 0.40 over 260 frames.
+// The controller has NO opinion about the vertical axis, and that is the whole
+// trick. `Physics.setVelocityXZ` writes only x and z, so the solver keeps the
+// y it is using to resolve the ground contact — resting height, landing
+// impulse, and gravity all stay where they belong. Steering the horizontal
+// plane is the only thing a character controller actually wants to say.
 //
-// The rule that holds: while grounded, own the standing height EXPLICITLY.
-// The ground probe already measured the distance to the surface, so correct
-// toward the rest distance with a critically-damped `error / dt`. That is the
-// standard character-controller ground clamp, and it also buys stick-to-a-
-// descending-deck for free: a surface dropping away pulls the character down
-// with it instead of letting it go momentarily ballistic.
+// (With the whole-vector `Physics.setVelocity` this function had to invent a
+// vy every frame, which meant either echoing a stale read or guessing — and
+// then a ground clamp to undo the damage. That is all deleted.)
 //
-//   jumping  -> the jump speed, plus the surface's own rise
-//   grounded -> the surface's own vy, plus the height correction
-//   airborne -> pass the read through and let gravity own it (one step of
-//               delay, which integrates correctly)
-//
-// `obs.standHeight` is the capsule's rest distance from the surface, and
-// `obs.groundDistance` is what the probe measured; both come from the caller so
-// that this module stays free of engine constants.
-// NOTE both this and `desiredVelocity` branch on `c.grounded` — the EFFECTIVE
-// grounded state that `sense` already computed, which honours the post-jump
-// lock — never on the raw `obs.grounded`.
-let verticalVelocity = (dt, obs, carry, c) =>
-  if jumpNow(c) then jumpSpeed + carry.y
-  else if c.grounded then
-    let error = obs.standHeight - obs.groundDistance in
-    // `dt` is zero on the bootstrap sub-frame and on every frame under
-    // `--fixed-time` (the capture/golden path), where `error / dt` would be
-    // NaN or infinite. No time passing means no correction is owed.
-    let correction =
-      if dt > 0.0 then Math.max(-maxSnapSpeed, Math.min(maxSnapSpeed, error / dt))
-      else 0.0 in
-    carry.y + correction
-  else obs.vy
-
+// NOTE this branches on `c.grounded` — the EFFECTIVE grounded state that
+// `sense` already computed, which honours the post-jump lock — never on the
+// raw `obs.grounded`.
 let desiredVelocity = (dt, obs, carry, c) =>
   let rate = if c.grounded then groundAccel else airAccel in
   let targetX = carry.x + c.wishX * speed in
   let targetZ = carry.z + c.wishZ * speed in
   {
     x: approach(rate, dt, obs.vx, targetX),
-    y: verticalVelocity(dt, obs, carry, c),
     z: approach(rate, dt, obs.vz, targetZ),
   }
+
+// The vertical velocity a JUMP commands, on the one frame it fires — the jump
+// speed plus whatever the surface underfoot was already doing, so a rising
+// lift launches you higher instead of out from under itself. `game.fun` sends
+// this with `Physics.setVelocityY` only when `jumpNow` is true; on every other
+// frame nothing writes the axis at all.
+let jumpVelocity = (carry) => jumpSpeed + carry.y
 
 // Landing squash as a vertical scale factor: 1.0 at rest, dipping right after
 // a hard landing and easing back as the timer drains.
@@ -201,14 +170,14 @@ let normalizeWish = (x, z) =>
 // Tests. `functor -d examples/physics-controller test` runs these headlessly.
 // ---------------------------------------------------------------------------
 
-// An observation fixture. `standHeight` is the capsule's rest distance from a
-// surface and `groundDistance` is what the probe measured; equal means resting
-// at exactly the right height, so the ground clamp contributes nothing.
-let obsAt = (grounded, vx, vy, dist) =>
-  { grounded: grounded, vx: vx, vy: vy, vz: 0.0, standHeight: 0.9, groundDistance: dist }
+// An observation fixture. Note what it no longer needs: the probe distance and
+// the capsule's rest height were only ever inputs to the ground clamp, and the
+// solver owns the standing height now.
+let obsAt = (grounded, vx, vy) =>
+  { grounded: grounded, vx: vx, vy: vy, vz: 0.0 }
 
-let air = obsAt(false, 0.0, 0.0, 0.9)
-let onGround = obsAt(true, 0.0, 0.0, 0.9)
+let air = obsAt(false, 0.0, 0.0)
+let onGround = obsAt(true, 0.0, 0.0)
 let still = { x: 0.0, y: 0.0, z: 0.0 }
 let dt = 0.0166667
 
@@ -260,54 +229,22 @@ expect (
   not jumpNow(consumeJump(land))
 )
 
-// A jump commands the jump speed; a non-jumping frame passes vertical
-// velocity through untouched, leaving gravity in charge.
-expect (
-  let (want, _) = step(onGround, true, still, zero) in
-  want.y == jumpSpeed
-)
-expect (
-  let (want, _) = step(obsAt(false, 0.0, -4.25, 0.9), false, still, zero) in
-  want.y == -4.25
-)
+// A jump commands the jump speed. Every other frame commands NOTHING vertical
+// — `game.fun` only sends `Physics.setVelocityY` when `jumpNow` is true, so
+// the property to check here is simply when the jump fires, not what vy the
+// controller would have invented on the frames in between.
+expect jumpVelocity(still) == jumpSpeed
+expect jumpNow(sense(dt, onGround, true, zero))
+expect not jumpNow(sense(dt, obsAt(false, 0.0, -4.25), false, zero))
 
-// The sinking regression, pinned. A GROUNDED frame must NOT echo back the stale
-// downward speed the read still carries; resting at exactly the right height it
-// must command exactly the surface's own vy, which on static ground is 0.
-expect (
-  let (want, _) = step(obsAt(true, 0.0, -6.7, 0.9), false, still, zero) in
-  want.y == 0.0
-)
+// Jumping off a moving deck inherits its vertical motion (a rising lift
+// launches you higher, not out from under itself).
+expect jumpVelocity({ x: 0.0, y: 2.0, z: 0.0 }) == jumpSpeed + 2.0
 
-// The ground clamp: sunk below the rest height, it corrects UPWARD; hovering
-// within the probe's reach, it pulls DOWN to stick to the surface.
-expect (
-  let (want, _) = step(obsAt(true, 0.0, 0.0, 0.84), false, still, zero) in
-  want.y > 0.0
-)
-expect (
-  let (want, _) = step(obsAt(true, 0.0, 0.0, 0.98), false, still, zero) in
-  want.y < 0.0
-)
-
-// The correction is bounded, so a deep overlap cannot launch the character.
-expect (
-  let (want, _) = step(obsAt(true, 0.0, 0.0, 0.0), false, still, zero) in
-  want.y == maxSnapSpeed
-)
-
-// On a RISING surface, grounded vy follows the surface, so a lift carries its
-// passenger up instead of leaving them behind.
-expect (
-  let (want, _) = step(obsAt(true, 0.0, -6.7, 0.9), false, { x: 0.0, y: 2.0, z: 0.0 }, zero) in
-  want.y == 2.0
-)
-
-// The post-jump lock, pinned — the regression that made the jump collapse. On
-// the frame AFTER a jump fires, the feet are still within the probe's reach, so
-// the raw observation still says grounded. The lock must make the controller
-// treat that as airborne and pass the rising velocity through, instead of
-// clamping it back down to standing height.
+// The post-jump lock, pinned. On the frame AFTER a jump fires the feet are
+// still within the probe's reach, so the raw observation still says grounded.
+// The lock must make the controller treat that as airborne — otherwise coyote
+// time refills mid-takeoff and a second tap of SPACE gets a free second jump.
 expect (
   let (_, afterJump) = step(onGround, true, still, zero) in
   afterJump.lock == jumpLockTime
@@ -315,9 +252,9 @@ expect (
 expect (
   let (_, afterJump) = step(onGround, true, still, zero) in
   // Still physically overlapping the ground probe, and rising fast.
-  let rising = obsAt(true, 0.0, 6.83, 0.98) in
-  let (want, next) = step(rising, false, still, afterJump) in
-  not next.grounded && want.y == 6.83
+  let rising = obsAt(true, 0.0, 6.83) in
+  let (_, next) = step(rising, false, still, afterJump) in
+  not next.grounded && not jumpNow(sense(dt, rising, true, next))
 )
 
 // The lock expires, and grounding resumes: a landing after it is a real
@@ -326,13 +263,13 @@ expect (
   let (_, afterJump) = step(onGround, true, still, zero) in
   let expired =
     List.range(8.0) |> List.fold((c, _) => sense(dt, air, false, c), afterJump) in
-  not (expired.lock > 0.0) && sense(dt, obsAt(true, 0.0, -6.0, 0.9), false, expired).squash == squashTime
+  not (expired.lock > 0.0) && sense(dt, obsAt(true, 0.0, -6.0), false, expired).squash == squashTime
 )
 
 // Landing is an EDGE, not a level: the squash fires on the touchdown frame
 // and not on the frames that follow it.
 expect (
-  let hit = obsAt(true, 0.0, -6.0, 0.9) in
+  let hit = obsAt(true, 0.0, -6.0) in
   let touchdown = sense(dt, hit, false, zero) in
   let after = sense(dt, onGround, false, touchdown) in
   touchdown.squash == squashTime && after.squash < squashTime
@@ -340,8 +277,8 @@ expect (
 
 // A harder landing squashes more, and the squash eases back to 1.0.
 expect (
-  let soft = sense(dt, obsAt(true, 0.0, -1.5, 0.9), false, zero) in
-  let hard = sense(dt, obsAt(true, 0.0, -6.0, 0.9), false, zero) in
+  let soft = sense(dt, obsAt(true, 0.0, -1.5), false, zero) in
+  let hard = sense(dt, obsAt(true, 0.0, -6.0), false, zero) in
   squashScale(hard) < squashScale(soft) && squashScale(soft) < 1.0
 )
 expect squashScale(zero) == 1.0
@@ -351,23 +288,15 @@ expect squashScale(zero) == 1.0
 // horizontal scale from it. Note the squash timer must be live for this to
 // bite, which is why `expect squashScale(zero) == 1.0` alone cannot catch it.
 expect (
-  let rising = sense(dt, obsAt(true, 0.0, 4.0, 0.9), false, zero) in
+  let rising = sense(dt, obsAt(true, 0.0, 4.0), false, zero) in
   rising.landImpact == 0.0 && squashScale(rising) == 1.0
-)
-
-// A zero `dt` (the bootstrap sub-frame, and every frame under `--fixed-time`)
-// must not turn the ground clamp into NaN or infinity.
-expect (
-  let sunk = obsAt(true, 0.0, 0.0, 0.5) in
-  let sensed = sense(0.0, sunk, false, zero) in
-  desiredVelocity(0.0, sunk, still, sensed).y == 0.0
 )
 
 // Platform carry: with no steering wish, the commanded velocity converges on
 // the deck's own velocity — that is what riding a moving platform IS.
 expect (
   let deck = { x: 3.0, y: 0.0, z: 0.0 } in
-  let (want, _) = step(obsAt(true, 3.0, 0.0, 0.9), false, deck, zero) in
+  let (want, _) = step(obsAt(true, 3.0, 0.0), false, deck, zero) in
   want.x == 3.0
 )
 
@@ -375,7 +304,7 @@ expect (
 // toward the deck's velocity rather than away from it.
 expect (
   let deck = { x: 3.0, y: 0.0, z: 0.0 } in
-  let (want, _) = step(obsAt(true, 0.0, 0.0, 0.9), false, deck, zero) in
+  let (want, _) = step(obsAt(true, 0.0, 0.0), false, deck, zero) in
   want.x > 0.0 && want.x < 3.0
 )
 
@@ -384,16 +313,8 @@ expect (
 expect (
   let deck = { x: 3.0, y: 0.0, z: 0.0 } in
   let wish = { zero with wishX: 1.0 } in
-  let (want, _) = step(obsAt(true, 3.0 + speed, 0.0, 0.9), false, deck, wish) in
+  let (want, _) = step(obsAt(true, 3.0 + speed, 0.0), false, deck, wish) in
   want.x == 3.0 + speed
-)
-
-// Jumping off a moving deck inherits its vertical motion (a rising lift
-// launches you higher, not out from under itself).
-expect (
-  let lift = { x: 0.0, y: 2.0, z: 0.0 } in
-  let (want, _) = step(onGround, true, lift, zero) in
-  want.y == jumpSpeed + 2.0
 )
 
 // `approach` converges and never overshoots.

--- a/examples/physics-controller/game.fun
+++ b/examples/physics-controller/game.fun
@@ -16,7 +16,7 @@
 //
 //   read   Physics.position / linearVelocity / castExcluding   (synchronous)
 //   decide Control.sense / desiredVelocity                     (pure)
-//   write  Physics.setVelocity                                 (same-frame)
+//   write  Physics.setVelocityXZ (+ setVelocityY on a jump)     (same-frame)
 //
 // The reads see the PREVIOUS step (physics runs after `tick`) and the command
 // applies at the step that immediately follows this `tick`, so the loop closes
@@ -164,14 +164,13 @@ let tick = (model, dt, tts) =>
     let pos = Physics.position(playerTag) in
     let vel = Physics.linearVelocity(playerTag) in
     let probe = groundProbe(pos) in
-    // The observation handed to the pure controller. `groundDistance` is what
-    // the probe measured and `standHeight` is where the feet belong, so the
-    // controller can hold its standing height itself (see `verticalVelocity`).
+    // The observation handed to the pure controller. It needs no probe
+    // distance and no rest height: the controller never writes the vertical
+    // axis, so it has no standing height to hold. `vy` is here only so a
+    // landing's impact can scale the squash.
     let obs = {
       grounded: probe.hit,
       vx: vel.x, vy: vel.y, vz: vel.z,
-      standHeight: feetOffset,
-      groundDistance: probe.distance,
     } in
     let carry = surfaceVelocity(probe) in
     let sensed = Control.sense(dt, obs, m.jumpEdge, m.ctl) in
@@ -212,8 +211,18 @@ let tick = (model, dt, tts) =>
         carry: carry.x, deckVx: World.deckVx(m.clock),
         coy: ctl.coyote, sq: ctl.squash, impact: ctl.landImpact,
       } in
+      // Steer the horizontal plane and leave the vertical axis to the solver,
+      // which owns the ground contact, the landing impulse, and gravity. The
+      // ONLY frame that writes vy is the one a jump fires on — and because
+      // the two masks are disjoint, the pair applies as one whole-vector
+      // write without either clobbering the other.
       (trace(row, next),
-       Physics.setVelocity(playerTag, Vec3.make(want.x, want.y, want.z)))
+       if Control.jumpNow(sensed) then
+         Effect.batch([
+           Physics.setVelocityXZ(playerTag, want.x, want.z),
+           Physics.setVelocityY(playerTag, Control.jumpVelocity(carry)),
+         ])
+       else Physics.setVelocityXZ(playerTag, want.x, want.z))
 
 let input = (model, key, isDown) =>
   match key with

--- a/examples/physics-controller/game.fun
+++ b/examples/physics-controller/game.fun
@@ -90,7 +90,7 @@ let physics = (model) =>
       // Non-negotiable for a character. Without it the capsule picks up
       // angular velocity from any glancing contact and topples — and a tipped
       // capsule's lowest point is no longer `feetOffset` below its center, so
-      // the grounding probe and the ground clamp both start lying.
+      // the grounding probe starts lying about how far down the ground is.
       |> Physics.upright,
   ])
 
@@ -213,16 +213,15 @@ let tick = (model, dt, tts) =>
       } in
       // Steer the horizontal plane and leave the vertical axis to the solver,
       // which owns the ground contact, the landing impulse, and gravity. The
-      // ONLY frame that writes vy is the one a jump fires on — and because
-      // the two masks are disjoint, the pair applies as one whole-vector
-      // write without either clobbering the other.
+      // ONLY frame that writes vy is the one a jump fires on — `Control.
+      // verticalCommand` is `Some` exactly then, and its expects pin that.
+      // The two writes touch disjoint axes, so the pair applies as one
+      // whole-vector write without either clobbering the other.
+      let steer = Physics.setVelocityXZ(playerTag, want.x, want.z) in
       (trace(row, next),
-       if Control.jumpNow(sensed) then
-         Effect.batch([
-           Physics.setVelocityXZ(playerTag, want.x, want.z),
-           Physics.setVelocityY(playerTag, Control.jumpVelocity(carry)),
-         ])
-       else Physics.setVelocityXZ(playerTag, want.x, want.z))
+       match Control.verticalCommand(carry, sensed) with
+       | Option.Some(vy) => Effect.batch([steer, Physics.setVelocityY(playerTag, vy)])
+       | Option.None => steer)
 
 let input = (model, key, isDown) =>
   match key with

--- a/functor-prelude/prelude/physics.funi
+++ b/functor-prelude/prelude/physics.funi
@@ -125,14 +125,15 @@ let setVelocity : (tag, Vec3.t) => Effect.t
 /// Replace a body's HORIZONTAL velocity, leaving the vertical axis alone.
 ///
 /// The character-controller command. Steering owns x and z while the solver
-/// keeps the y it is using to resolve the ground contact, so a grounded body
-/// rests at its true standing height instead of sinking — with
-/// `Physics.setVelocity` the game must write all three, and both available
-/// answers for y (echo the read back, or command 0) drive the capsule into
-/// the floor.
+/// keeps the y it is using to resolve the ground contact, so the game never
+/// has to author a vertical velocity it has no opinion about — with
+/// `Physics.setVelocity` it must write all three every frame, and the only
+/// values available to it are a one-step-stale read or a guess.
 ///
 /// The preserved axis is read from the live world when the command applies —
-/// after reconcile, and after any command queued earlier the same frame.
+/// after reconcile, and after any command queued earlier the same frame. So
+/// velocity commands in one frame compose as last-write-wins per axis, and an
+/// axis nobody wrote is left exactly as the solver left it.
 let setVelocityXZ : (tag, float, float) => Effect.t
 
 /// Replace a body's VERTICAL velocity, leaving the horizontal plane alone.

--- a/functor-prelude/prelude/physics.funi
+++ b/functor-prelude/prelude/physics.funi
@@ -116,8 +116,31 @@ let transformed : (tag, Scene.t) => Scene.t
 let applyImpulse : (tag, Vec3.t) => Effect.t
 /// Apply a continuous force to a body for the next step.
 let applyForce : (tag, Vec3.t) => Effect.t
-/// Replace a body's linear velocity.
+/// Replace a body's linear velocity — all three axes.
+///
+/// For a character controller prefer `Physics.setVelocityXZ`: writing the
+/// vertical axis every frame fights the solver's own ground contact.
 let setVelocity : (tag, Vec3.t) => Effect.t
+
+/// Replace a body's HORIZONTAL velocity, leaving the vertical axis alone.
+///
+/// The character-controller command. Steering owns x and z while the solver
+/// keeps the y it is using to resolve the ground contact, so a grounded body
+/// rests at its true standing height instead of sinking — with
+/// `Physics.setVelocity` the game must write all three, and both available
+/// answers for y (echo the read back, or command 0) drive the capsule into
+/// the floor.
+///
+/// The preserved axis is read from the live world when the command applies —
+/// after reconcile, and after any command queued earlier the same frame.
+let setVelocityXZ : (tag, float, float) => Effect.t
+
+/// Replace a body's VERTICAL velocity, leaving the horizontal plane alone.
+///
+/// A jump that keeps the run: unlike `Physics.applyImpulse` the result does
+/// not depend on the body's mass, and unlike `Physics.setVelocity` it does not
+/// discard the horizontal momentum the character arrived with.
+let setVelocityY : (tag, float) => Effect.t
 /// Move a body immediately to a world position.
 let teleport : (tag, Vec3.t) => Effect.t
 

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -2278,6 +2278,38 @@ fn register_physics(reg: &mut crate::host_registry::Registry) {
         "Physics.teleport(tag, v)",
         physics_command(|tag, position| physics::PhysicsCommand::Teleport { tag, position }),
     );
+    // Per-axis velocity writes. `setVelocity` replaces all three components,
+    // which forces a character controller to say something about the vertical
+    // axis every frame even when the solver is the one that should own it —
+    // and every available answer sinks the body (see the world tests). These
+    // two split the Y-up engine's natural partition: the horizontal plane the
+    // game steers, and the vertical axis a jump owns for one frame.
+    reg.fn3(
+        "Physics.setVelocityXZ",
+        "Physics.setVelocityXZ(tag, x, z)",
+        |tag: std::rc::Rc<str>, x: f64, z: f64| {
+            FunctorLangEffect(EffectTree::Physics(
+                physics::PhysicsCommand::SetVelocityAxes {
+                    tag: tag.to_string(),
+                    velocity: [x as f32, 0.0, z as f32],
+                    axes: [true, false, true],
+                },
+            ))
+        },
+    );
+    reg.fn2(
+        "Physics.setVelocityY",
+        "Physics.setVelocityY(tag, v)",
+        |tag: std::rc::Rc<str>, v: f64| {
+            FunctorLangEffect(EffectTree::Physics(
+                physics::PhysicsCommand::SetVelocityAxes {
+                    tag: tag.to_string(),
+                    velocity: [0.0, v as f32, 0.0],
+                    axes: [false, true, false],
+                },
+            ))
+        },
+    );
     // Query EFFECT (docs/physics.md Phase 4): deferred until after the
     // frame's physics step, then the tagger receives the result record
     // `{hit, x, y, z, nx, ny, nz, distance, tag}` (hit: false with zeroed
@@ -4320,6 +4352,11 @@ dropping the rest"
                     physics::PhysicsCommand::ApplyImpulse { .. } => "physics.applyImpulse",
                     physics::PhysicsCommand::ApplyForce { .. } => "physics.applyForce",
                     physics::PhysicsCommand::SetVelocity { .. } => "physics.setVelocity",
+                    physics::PhysicsCommand::SetVelocityAxes { axes, .. } => match axes {
+                        [true, false, true] => "physics.setVelocityXZ",
+                        [false, true, false] => "physics.setVelocityY",
+                        _ => "physics.setVelocity",
+                    },
                     physics::PhysicsCommand::Teleport { .. } => "physics.teleport",
                 };
                 let tag = command.tag_and_kind().0.to_string();

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -2279,35 +2279,30 @@ fn register_physics(reg: &mut crate::host_registry::Registry) {
         physics_command(|tag, position| physics::PhysicsCommand::Teleport { tag, position }),
     );
     // Per-axis velocity writes. `setVelocity` replaces all three components,
-    // which forces a character controller to say something about the vertical
-    // axis every frame even when the solver is the one that should own it —
-    // and every available answer sinks the body (see the world tests). These
-    // two split the Y-up engine's natural partition: the horizontal plane the
-    // game steers, and the vertical axis a jump owns for one frame.
+    // which forces a character controller to author a vertical velocity every
+    // frame even though the solver is the one that owns it while grounded —
+    // and the only values available to the game are a stale read or a guess.
+    // These two split the Y-up engine's natural partition: the horizontal
+    // plane the game steers, and the vertical axis a jump owns for one frame.
     reg.fn3(
         "Physics.setVelocityXZ",
         "Physics.setVelocityXZ(tag, x, z)",
         |tag: std::rc::Rc<str>, x: f64, z: f64| {
-            FunctorLangEffect(EffectTree::Physics(
-                physics::PhysicsCommand::SetVelocityAxes {
-                    tag: tag.to_string(),
-                    velocity: [x as f32, 0.0, z as f32],
-                    axes: [true, false, true],
-                },
-            ))
+            FunctorLangEffect(EffectTree::Physics(physics::PhysicsCommand::SetVelocityXZ {
+                tag: tag.to_string(),
+                x: x as f32,
+                z: z as f32,
+            }))
         },
     );
     reg.fn2(
         "Physics.setVelocityY",
         "Physics.setVelocityY(tag, v)",
         |tag: std::rc::Rc<str>, v: f64| {
-            FunctorLangEffect(EffectTree::Physics(
-                physics::PhysicsCommand::SetVelocityAxes {
-                    tag: tag.to_string(),
-                    velocity: [0.0, v as f32, 0.0],
-                    axes: [false, true, false],
-                },
-            ))
+            FunctorLangEffect(EffectTree::Physics(physics::PhysicsCommand::SetVelocityY {
+                tag: tag.to_string(),
+                y: v as f32,
+            }))
         },
     );
     // Query EFFECT (docs/physics.md Phase 4): deferred until after the
@@ -4352,11 +4347,8 @@ dropping the rest"
                     physics::PhysicsCommand::ApplyImpulse { .. } => "physics.applyImpulse",
                     physics::PhysicsCommand::ApplyForce { .. } => "physics.applyForce",
                     physics::PhysicsCommand::SetVelocity { .. } => "physics.setVelocity",
-                    physics::PhysicsCommand::SetVelocityAxes { axes, .. } => match axes {
-                        [true, false, true] => "physics.setVelocityXZ",
-                        [false, true, false] => "physics.setVelocityY",
-                        _ => "physics.setVelocity",
-                    },
+                    physics::PhysicsCommand::SetVelocityXZ { .. } => "physics.setVelocityXZ",
+                    physics::PhysicsCommand::SetVelocityY { .. } => "physics.setVelocityY",
                     physics::PhysicsCommand::Teleport { .. } => "physics.teleport",
                 };
                 let tag = command.tag_and_kind().0.to_string();
@@ -6956,6 +6948,89 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
             w.step_frame(1.0 / 60.0);
             let v = w.body_velocity("ball").unwrap();
             assert!(v[0] > 0.0, "impulse not applied: {v:?}");
+            assert!(w.take_command_warnings().is_empty());
+        });
+        crate::physics::remove_world(crate::physics::DEFAULT_WORLD);
+    }
+
+    // The per-axis commands log their OWN kind (not the whole-vector one), and
+    // the masked write reaches the world preserving the axis it does not name.
+    #[test]
+    fn per_axis_velocity_commands_log_their_kind_and_preserve_the_other_axes() {
+        for (src, kind) in [
+            (
+                "let main = () => Physics.setVelocityXZ(\"ball\", 3.0, 4.0)",
+                "physics.setVelocityXZ",
+            ),
+            (
+                "let main = () => Physics.setVelocityY(\"ball\", 9.0)",
+                "physics.setVelocityY",
+            ),
+        ] {
+            crate::physics::remove_world(crate::physics::DEFAULT_WORLD);
+            let effect = eval(src);
+            let Value::HostData(data) = &effect else {
+                panic!("expected an Effect from `{src}`");
+            };
+            let tree = &data.as_any().downcast_ref::<FunctorLangEffect>().expect("Effect").0;
+
+            let module =
+                functor_lang::lower(functor_lang::parse("let update = (m, msg) => m").unwrap()).unwrap();
+            let session = functor_lang::Session::load(&module, &mut FunctorHost)
+                .unwrap_or_else(|f| panic!("load failed: {}", f.error.message));
+            let mut model = Value::Number(0.0);
+            let mut log = EffectLog::new();
+            let mut runner = FakeEffects::new(0.0, vec![]);
+            let deferred = drain_effects(
+                &session,
+                &mut model,
+                tree.clone(),
+                &mut runner,
+                &mut log,
+                &mut |m| panic!("unexpected report: {m}"),
+                false,
+            );
+            assert!(deferred.is_empty(), "nothing should defer here");
+            assert_eq!(log.len(), 1);
+            assert_eq!(log[0].kind, kind, "wrong effect-log kind for `{src}`");
+            assert_eq!(log[0].value, EffectValue::Text("ball".to_string()));
+        }
+
+        // And the masked write really is masked once it reaches the world: a
+        // body drifting on all three axes keeps its `y` through a setVelocityXZ.
+        crate::physics::remove_world(crate::physics::DEFAULT_WORLD);
+        let effect = eval("let main = () => Physics.setVelocityXZ(\"ball\", 3.0, 4.0)");
+        let Value::HostData(data) = &effect else {
+            panic!("expected an Effect");
+        };
+        let tree = &data.as_any().downcast_ref::<FunctorLangEffect>().expect("Effect").0;
+        let module =
+            functor_lang::lower(functor_lang::parse("let update = (m, msg) => m").unwrap()).unwrap();
+        let session = functor_lang::Session::load(&module, &mut FunctorHost)
+            .unwrap_or_else(|f| panic!("load failed: {}", f.error.message));
+        let mut model = Value::Number(0.0);
+        let mut log = EffectLog::new();
+        let mut runner = FakeEffects::new(0.0, vec![]);
+        let _ = drain_effects(
+            &session,
+            &mut model,
+            tree.clone(),
+            &mut runner,
+            &mut log,
+            &mut |m| panic!("unexpected report: {m}"),
+            false,
+        );
+        crate::physics::with_world(crate::physics::DEFAULT_WORLD, |w| {
+            w.reconcile(&crate::physics::PhysicsScene::create(
+                [0.0, 0.0, 0.0],
+                vec![crate::physics::Body::dynamic(
+                    "ball".to_string(),
+                    crate::physics::Shape::Sphere { radius: 0.5 },
+                )
+                .with_velocity([1.0, -5.0, 2.0])],
+            ));
+            w.step_frame(1.0 / 60.0);
+            assert_eq!(w.body_velocity("ball").unwrap(), [3.0, -5.0, 4.0]);
             assert!(w.take_command_warnings().is_empty());
         });
         crate::physics::remove_world(crate::physics::DEFAULT_WORLD);

--- a/runtime/functor-runtime-common/src/physics/goldens.rs
+++ b/runtime/functor-runtime-common/src/physics/goldens.rs
@@ -59,12 +59,32 @@ const FRAMES: u64 = 120;
 /// The frame's full command list — the declared scene, plus (at frame 45) an
 /// impulse kicking crate "a", exercising the Phase 3 command path: queued,
 /// applied after reconcile, replayed like any other input.
+///
+/// Frames 60 and 61 add the per-axis writes. Unlike every other command these
+/// are **state-dependent** — they read the axes they preserve off the live
+/// body when they apply — so seek-then-replay equivalence is a stronger claim
+/// for them than for a pure input, and worth pinning here: a replay resuming
+/// from a slightly different world would diverge on the preserved axis
+/// instead of reproducing it.
 fn commands_at(frame: u64) -> Vec<Command> {
     let mut cmds = vec![Command::DeclareScene(scene_at(frame))];
     if frame == 45 {
         cmds.push(Command::Apply(PhysicsCommand::ApplyImpulse {
             tag: "a".to_string(),
             impulse: [0.0, 4.0, 1.5],
+        }));
+    }
+    if frame == 60 {
+        cmds.push(Command::Apply(PhysicsCommand::SetVelocityXZ {
+            tag: "a".to_string(),
+            x: 1.5,
+            z: -0.75,
+        }));
+    }
+    if frame == 61 {
+        cmds.push(Command::Apply(PhysicsCommand::SetVelocityY {
+            tag: "a".to_string(),
+            y: 2.25,
         }));
     }
     cmds

--- a/runtime/functor-runtime-common/src/physics/world.rs
+++ b/runtime/functor-runtime-common/src/physics/world.rs
@@ -45,6 +45,23 @@ pub enum PhysicsCommand {
     /// a recorded frame, so a force lasts exactly one fixed step.
     ApplyForce { tag: String, force: [f32; 3] },
     SetVelocity { tag: String, velocity: [f32; 3] },
+    /// Replace only the axes flagged in `axes` (x, y, z), leaving the rest of
+    /// the body's linear velocity exactly as the world holds it at apply time.
+    ///
+    /// The character-controller case: steering owns the horizontal plane while
+    /// the solver keeps the vertical axis it is using to resolve the ground
+    /// contact. Writing all three every frame destroys that contact impulse,
+    /// so each step's gravity increment accumulates as penetration — see
+    /// `masked_writes_do_not_sink_a_grounded_capsule`.
+    ///
+    /// Unmasked axes are read from the live body, so several commands in one
+    /// frame compose: they apply in queue order, and the LAST write to a given
+    /// axis wins while every axis nobody wrote is untouched.
+    SetVelocityAxes {
+        tag: String,
+        velocity: [f32; 3],
+        axes: [bool; 3],
+    },
     /// Move the live body without touching its declaration (the declared
     /// cache is unchanged, so the next frame's unchanged declaration does not
     /// snap it back).
@@ -58,6 +75,7 @@ impl PhysicsCommand {
             PhysicsCommand::ApplyImpulse { tag, .. } => (tag, "applyImpulse"),
             PhysicsCommand::ApplyForce { tag, .. } => (tag, "applyForce"),
             PhysicsCommand::SetVelocity { tag, .. } => (tag, "setVelocity"),
+            PhysicsCommand::SetVelocityAxes { tag, .. } => (tag, "setVelocity"),
             PhysicsCommand::Teleport { tag, .. } => (tag, "teleport"),
         }
     }
@@ -693,6 +711,22 @@ impl World {
                 }
                 PhysicsCommand::SetVelocity { velocity, .. } => {
                     rb.set_linvel(vec3(*velocity), true);
+                }
+                PhysicsCommand::SetVelocityAxes { velocity, axes, .. } => {
+                    // Unmasked axes are read from the LIVE body here, not from
+                    // whatever the game read in `tick` — so this composes with
+                    // reconcile and with any command already applied from this
+                    // same frame's queue.
+                    let live = rb.linvel();
+                    let keep = [live.x, live.y, live.z];
+                    let next = std::array::from_fn(|i| {
+                        if axes[i] {
+                            velocity[i]
+                        } else {
+                            keep[i]
+                        }
+                    });
+                    rb.set_linvel(vec3(next), true);
                 }
                 PhysicsCommand::Teleport { position, .. } => {
                     let rotation = *rb.rotation();
@@ -1486,6 +1520,254 @@ mod tests {
         w.reconcile(&scene(vec![crate_at("a", [0.0, 5.0, 0.0])]));
         let (after, _) = w.body_transform("a").unwrap();
         assert_eq!(after[0], 3.0);
+    }
+
+    // ── per-axis velocity writes ────────────────────────────────────────
+
+    fn set_xz(tag: &str, x: f32, z: f32) -> PhysicsCommand {
+        PhysicsCommand::SetVelocityAxes {
+            tag: tag.to_string(),
+            velocity: [x, 0.0, z],
+            axes: [true, false, true],
+        }
+    }
+
+    fn set_y(tag: &str, y: f32) -> PhysicsCommand {
+        PhysicsCommand::SetVelocityAxes {
+            tag: tag.to_string(),
+            velocity: [0.0, y, 0.0],
+            axes: [false, true, false],
+        }
+    }
+
+    /// A body in a gravity-free world with a known starting velocity, for the
+    /// composition tests: with no gravity and no contacts the velocity after
+    /// one step is exactly what the command queue left behind.
+    fn drifting(velocity: [f32; 3]) -> World {
+        let mut w = World::new([0.0, 0.0, 0.0]);
+        w.reconcile(&PhysicsScene::create(
+            [0.0, 0.0, 0.0],
+            vec![crate_at("a", [0.0, 0.0, 0.0]).with_velocity(velocity)],
+        ));
+        w
+    }
+
+    #[test]
+    fn set_velocity_xz_leaves_the_vertical_axis_alone() {
+        let mut w = drifting([1.0, -5.0, 2.0]);
+        w.queue_command(set_xz("a", 7.0, -7.0));
+        w.step_frame(FIXED_DT);
+        assert_eq!(w.body_velocity("a").unwrap(), [7.0, -5.0, -7.0]);
+        assert!(w.take_command_warnings().is_empty());
+    }
+
+    #[test]
+    fn set_velocity_y_leaves_the_horizontal_plane_alone() {
+        let mut w = drifting([1.0, -5.0, 2.0]);
+        w.queue_command(set_y("a", 7.2));
+        w.step_frame(FIXED_DT);
+        assert_eq!(w.body_velocity("a").unwrap(), [1.0, 7.2, 2.0]);
+    }
+
+    /// The composition rule: commands apply in queue order against the LIVE
+    /// body, so the last write to a given axis wins and an axis nobody wrote
+    /// is untouched. The two masks partition all three axes, so issuing both
+    /// in one frame is exactly a whole-vector `SetVelocity`.
+    #[test]
+    fn same_frame_masked_writes_compose_per_axis() {
+        // Disjoint masks: together they equal the full write.
+        let mut w = drifting([1.0, -5.0, 2.0]);
+        w.queue_command(set_xz("a", 3.0, 4.0));
+        w.queue_command(set_y("a", 9.0));
+        w.step_frame(FIXED_DT);
+        assert_eq!(w.body_velocity("a").unwrap(), [3.0, 9.0, 4.0]);
+
+        // Order-independent, because the masks do not overlap.
+        let mut w = drifting([1.0, -5.0, 2.0]);
+        w.queue_command(set_y("a", 9.0));
+        w.queue_command(set_xz("a", 3.0, 4.0));
+        w.step_frame(FIXED_DT);
+        assert_eq!(w.body_velocity("a").unwrap(), [3.0, 9.0, 4.0]);
+
+        // Overlapping masks: last wins, per axis.
+        let mut w = drifting([1.0, -5.0, 2.0]);
+        w.queue_command(set_xz("a", 3.0, 4.0));
+        w.queue_command(set_xz("a", 6.0, 8.0));
+        w.step_frame(FIXED_DT);
+        assert_eq!(w.body_velocity("a").unwrap(), [6.0, -5.0, 8.0]);
+
+        // A masked write reads the axis it preserves from the live body, so a
+        // whole-vector write queued EARLIER in the same frame is visible to it
+        // — not the stale value the game read in `tick`.
+        let mut w = drifting([1.0, -5.0, 2.0]);
+        w.queue_command(PhysicsCommand::SetVelocity {
+            tag: "a".to_string(),
+            velocity: [0.0, 11.0, 0.0],
+        });
+        w.queue_command(set_xz("a", 3.0, 4.0));
+        w.step_frame(FIXED_DT);
+        assert_eq!(w.body_velocity("a").unwrap(), [3.0, 11.0, 4.0]);
+
+        // And the reverse order lets the full write clobber the masked one —
+        // "last wins per axis" with the full mask covering everything.
+        let mut w = drifting([1.0, -5.0, 2.0]);
+        w.queue_command(set_xz("a", 3.0, 4.0));
+        w.queue_command(PhysicsCommand::SetVelocity {
+            tag: "a".to_string(),
+            velocity: [0.0, 11.0, 0.0],
+        });
+        w.step_frame(FIXED_DT);
+        assert_eq!(w.body_velocity("a").unwrap(), [0.0, 11.0, 0.0]);
+    }
+
+    #[test]
+    fn masked_writes_share_the_unknown_and_non_dynamic_warnings() {
+        let mut w = World::new([0.0, 0.0, 0.0]);
+        w.reconcile(&scene(vec![ground(), crate_at("a", [0.0, 5.0, 0.0])]));
+        w.queue_command(set_xz("nobody", 1.0, 1.0));
+        w.queue_command(set_y("ground", 1.0));
+        w.step_frame(FIXED_DT);
+        let warnings = w.take_command_warnings();
+        assert_eq!(warnings.len(), 2, "{warnings:?}");
+        assert!(warnings[0].contains("unknown tag"), "{warnings:?}");
+        assert!(warnings[1].contains("non-dynamic"), "{warnings:?}");
+    }
+
+    /// The capsule's feet offset (half-height + radius) and the grounding
+    /// probe's skin, from `examples/physics-controller`.
+    const FEET: f32 = 0.9;
+    const PROBE_SKIN: f32 = 0.15;
+
+    /// What the character-controller harness observes each frame.
+    #[derive(Clone, Copy)]
+    struct Obs {
+        vy: f32,
+        grounded: bool,
+    }
+
+    /// Drive a character capsule for `frames` fixed steps under `policy`,
+    /// which is handed the body's live velocity each frame and queues whatever
+    /// it wants. Returns the body's final Y.
+    ///
+    /// Mirrors `examples/physics-controller`: gravity -22, an upright
+    /// frictionless capsule (half-height 0.5 + radius 0.4, so the feet sit
+    /// 0.9 below the center) standing on a fixed slab whose top is y = 0. The
+    /// correct resting height is therefore y = 0.90.
+    fn rest_height_dt(
+        spawn_y: f32,
+        frames: u32,
+        dt: impl Fn(u32) -> f32,
+        policy: impl Fn(&mut World, Obs),
+    ) -> f32 {
+        const GRAVITY: [f32; 3] = [0.0, -22.0, 0.0];
+        let declared = PhysicsScene::create(
+            GRAVITY,
+            vec![
+                Body::fixed(
+                    "ground".to_string(),
+                    Shape::Cuboid {
+                        extents: [40.0, 1.0, 40.0],
+                    },
+                )
+                .at([0.0, -0.5, 0.0])
+                .with_friction(0.8),
+                Body::dynamic(
+                    "player".to_string(),
+                    Shape::Capsule {
+                        half_height: 0.5,
+                        radius: 0.4,
+                    },
+                )
+                .at([0.0, spawn_y, 0.0])
+                .with_friction(0.0)
+                .with_restitution(0.0)
+                .with_mass(1.0)
+                .as_upright(),
+            ],
+        );
+        let mut w = World::new(GRAVITY);
+        for frame in 0..frames {
+            // Re-declared unchanged every frame, exactly as a `physics` hook
+            // does: an unchanged declaration means the simulation owns the
+            // body, so this is not a per-frame snap back to the spawn.
+            w.reconcile(&declared);
+            let y = w.body_transform("player").unwrap().0[1];
+            let vy = w.body_velocity("player").unwrap()[1];
+            // The same grounding probe the example uses: a ray from the
+            // capsule's center down past the feet by a 0.15 skin.
+            policy(
+                &mut w,
+                Obs {
+                    vy,
+                    grounded: y - FEET <= PROBE_SKIN,
+                },
+            );
+            w.step_frame(dt(frame));
+        }
+        w.body_transform("player").unwrap().0[1]
+    }
+
+    fn rest_height(spawn_y: f32, frames: u32, policy: impl Fn(&mut World, Obs)) -> f32 {
+        rest_height_dt(spawn_y, frames, |_| FIXED_DT, policy)
+    }
+
+    /// A masked write is EXACTLY transparent on the axes it does not name:
+    /// the body ends where the solver alone would have put it, so a game can
+    /// steer the horizontal plane without having any opinion about the
+    /// vertical one.
+    ///
+    /// That is the property the character-controller case needs, and it is
+    /// what `Physics.setVelocity` cannot offer — a controller steering with
+    /// the whole-vector command must author a `y` every frame, and the only
+    /// values available to it are a stale read or a guess.
+    ///
+    /// Investigated while adding this: the two sinking failures reported in
+    /// #503 (a capsule resting at 0.40 instead of 0.90) do NOT reproduce at
+    /// this layer. Echoing the read back is bit-identical to issuing no
+    /// command at all — the read and the command's apply point observe the
+    /// same world state — and commanding `y = 0` while grounded recovers to
+    /// the same resting height, because rapier resolves the landing's
+    /// penetration positionally rather than through the velocity the game
+    /// overwrites. Both were checked here after a real drop-and-land, under a
+    /// fixed frame time and under a jittered one (0- and 2-substep frames).
+    /// So this command's case is ergonomic and architectural, not a sinking
+    /// fix; whatever sank in #503 lived in the example, not in the surface.
+    #[test]
+    fn masked_writes_are_transparent_on_the_untouched_axis() {
+        // Dropped from a height, so it lands with real impact speed and the
+        // solver has actual penetration to recover from.
+        const SPAWN: f32 = 3.0;
+        let frames = 260;
+        let steer = |w: &mut World, _o: Obs| w.queue_command(set_xz("player", 0.0, 0.0));
+
+        let untouched = rest_height(SPAWN, frames, |_, _| {});
+        let masked = rest_height(SPAWN, frames, steer);
+        assert_eq!(
+            masked, untouched,
+            "a masked write moved the axis it does not name"
+        );
+        assert!(
+            (masked - FEET).abs() < 0.02,
+            "the capsule did not rest at its standing height: {masked}"
+        );
+
+        // Again under a JITTERED frame time, the way the real runtime drives
+        // it: some frames take no substep and some take two, so a command can
+        // sit pending across a frame and two can land before one substep.
+        let jitter = |f: u32| FIXED_DT * (0.6 + 0.9 * ((f % 7) as f32 / 6.0));
+        let untouched = rest_height_dt(SPAWN, frames, jitter, |_, _| {});
+        let masked = rest_height_dt(SPAWN, frames, jitter, steer);
+        assert_eq!(
+            masked, untouched,
+            "a masked write moved the untouched axis under a jittered frame time"
+        );
+
+        // The steered axes really are driven, so the test above is not just
+        // observing a command that did nothing at all.
+        let ran = rest_height(SPAWN, 60, |w, _| {
+            w.queue_command(set_xz("player", 4.0, 0.0));
+        });
+        assert!((ran - FEET).abs() < 0.02, "steering changed the height: {ran}");
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/physics/world.rs
+++ b/runtime/functor-runtime-common/src/physics/world.rs
@@ -45,23 +45,24 @@ pub enum PhysicsCommand {
     /// a recorded frame, so a force lasts exactly one fixed step.
     ApplyForce { tag: String, force: [f32; 3] },
     SetVelocity { tag: String, velocity: [f32; 3] },
-    /// Replace only the axes flagged in `axes` (x, y, z), leaving the rest of
-    /// the body's linear velocity exactly as the world holds it at apply time.
+    /// Replace a body's HORIZONTAL velocity, leaving `y` exactly as the world
+    /// holds it at apply time.
     ///
-    /// The character-controller case: steering owns the horizontal plane while
+    /// The character-controller case: steering owns the horizontal plane and
     /// the solver keeps the vertical axis it is using to resolve the ground
-    /// contact. Writing all three every frame destroys that contact impulse,
-    /// so each step's gravity increment accumulates as penetration — see
-    /// `masked_writes_do_not_sink_a_grounded_capsule`.
+    /// contact, so the game never has to author a `y` it has no opinion about.
+    /// The write is exactly transparent on `y` — see
+    /// `masked_writes_are_transparent_on_the_untouched_axis`.
     ///
-    /// Unmasked axes are read from the live body, so several commands in one
-    /// frame compose: they apply in queue order, and the LAST write to a given
-    /// axis wins while every axis nobody wrote is untouched.
-    SetVelocityAxes {
-        tag: String,
-        velocity: [f32; 3],
-        axes: [bool; 3],
-    },
+    /// The untouched axis is read from the LIVE body, so several velocity
+    /// commands in one frame compose: they apply in queue order, the LAST
+    /// write to a given axis wins, and an axis nobody wrote is untouched.
+    SetVelocityXZ { tag: String, x: f32, z: f32 },
+    /// Replace a body's VERTICAL velocity, leaving the horizontal plane
+    /// exactly as the world holds it at apply time — a jump that keeps the
+    /// run. Composes with [`PhysicsCommand::SetVelocityXZ`] by the same
+    /// last-write-wins-per-axis rule; together the two cover all three axes.
+    SetVelocityY { tag: String, y: f32 },
     /// Move the live body without touching its declaration (the declared
     /// cache is unchanged, so the next frame's unchanged declaration does not
     /// snap it back).
@@ -75,7 +76,8 @@ impl PhysicsCommand {
             PhysicsCommand::ApplyImpulse { tag, .. } => (tag, "applyImpulse"),
             PhysicsCommand::ApplyForce { tag, .. } => (tag, "applyForce"),
             PhysicsCommand::SetVelocity { tag, .. } => (tag, "setVelocity"),
-            PhysicsCommand::SetVelocityAxes { tag, .. } => (tag, "setVelocity"),
+            PhysicsCommand::SetVelocityXZ { tag, .. } => (tag, "setVelocityXZ"),
+            PhysicsCommand::SetVelocityY { tag, .. } => (tag, "setVelocityY"),
             PhysicsCommand::Teleport { tag, .. } => (tag, "teleport"),
         }
     }
@@ -712,21 +714,17 @@ impl World {
                 PhysicsCommand::SetVelocity { velocity, .. } => {
                     rb.set_linvel(vec3(*velocity), true);
                 }
-                PhysicsCommand::SetVelocityAxes { velocity, axes, .. } => {
-                    // Unmasked axes are read from the LIVE body here, not from
-                    // whatever the game read in `tick` — so this composes with
-                    // reconcile and with any command already applied from this
-                    // same frame's queue.
+                // The preserved axes are read from the LIVE body here, not
+                // from whatever the game read in `tick` — so these compose
+                // with reconcile and with any command already applied from
+                // this same frame's queue.
+                PhysicsCommand::SetVelocityXZ { x, z, .. } => {
                     let live = rb.linvel();
-                    let keep = [live.x, live.y, live.z];
-                    let next = std::array::from_fn(|i| {
-                        if axes[i] {
-                            velocity[i]
-                        } else {
-                            keep[i]
-                        }
-                    });
-                    rb.set_linvel(vec3(next), true);
+                    rb.set_linvel(vec3([*x, live.y, *z]), true);
+                }
+                PhysicsCommand::SetVelocityY { y, .. } => {
+                    let live = rb.linvel();
+                    rb.set_linvel(vec3([live.x, *y, live.z]), true);
                 }
                 PhysicsCommand::Teleport { position, .. } => {
                     let rotation = *rb.rotation();
@@ -1525,18 +1523,17 @@ mod tests {
     // ── per-axis velocity writes ────────────────────────────────────────
 
     fn set_xz(tag: &str, x: f32, z: f32) -> PhysicsCommand {
-        PhysicsCommand::SetVelocityAxes {
+        PhysicsCommand::SetVelocityXZ {
             tag: tag.to_string(),
-            velocity: [x, 0.0, z],
-            axes: [true, false, true],
+            x,
+            z,
         }
     }
 
     fn set_y(tag: &str, y: f32) -> PhysicsCommand {
-        PhysicsCommand::SetVelocityAxes {
+        PhysicsCommand::SetVelocityY {
             tag: tag.to_string(),
-            velocity: [0.0, y, 0.0],
-            axes: [false, true, false],
+            y,
         }
     }
 
@@ -1629,36 +1626,36 @@ mod tests {
         w.step_frame(FIXED_DT);
         let warnings = w.take_command_warnings();
         assert_eq!(warnings.len(), 2, "{warnings:?}");
-        assert!(warnings[0].contains("unknown tag"), "{warnings:?}");
-        assert!(warnings[1].contains("non-dynamic"), "{warnings:?}");
+        // The warning must name the command the game actually called, not the
+        // whole-vector one it is a sibling of.
+        assert_eq!(
+            warnings[0],
+            "physics setVelocityXZ for unknown tag \"nobody\""
+        );
+        assert_eq!(
+            warnings[1],
+            "physics setVelocityY on non-dynamic body \"ground\" has no effect"
+        );
     }
 
-    /// The capsule's feet offset (half-height + radius) and the grounding
-    /// probe's skin, from `examples/physics-controller`.
+    /// The capsule's feet offset (half-height + radius), from
+    /// `examples/physics-controller`.
     const FEET: f32 = 0.9;
-    const PROBE_SKIN: f32 = 0.15;
 
-    /// What the character-controller harness observes each frame.
-    #[derive(Clone, Copy)]
-    struct Obs {
-        vy: f32,
-        grounded: bool,
-    }
-
-    /// Drive a character capsule for `frames` fixed steps under `policy`,
-    /// which is handed the body's live velocity each frame and queues whatever
-    /// it wants. Returns the body's final Y.
+    /// Drive a character capsule for `frames` fixed steps, calling `policy`
+    /// each frame to queue whatever commands it wants. Returns the body's
+    /// final `(x, y)`.
     ///
     /// Mirrors `examples/physics-controller`: gravity -22, an upright
     /// frictionless capsule (half-height 0.5 + radius 0.4, so the feet sit
     /// 0.9 below the center) standing on a fixed slab whose top is y = 0. The
     /// correct resting height is therefore y = 0.90.
-    fn rest_height_dt(
+    fn run_capsule(
         spawn_y: f32,
         frames: u32,
         dt: impl Fn(u32) -> f32,
-        policy: impl Fn(&mut World, Obs),
-    ) -> f32 {
+        policy: impl Fn(&mut World),
+    ) -> (f32, f32) {
         const GRAVITY: [f32; 3] = [0.0, -22.0, 0.0];
         let declared = PhysicsScene::create(
             GRAVITY,
@@ -1691,24 +1688,19 @@ mod tests {
             // does: an unchanged declaration means the simulation owns the
             // body, so this is not a per-frame snap back to the spawn.
             w.reconcile(&declared);
-            let y = w.body_transform("player").unwrap().0[1];
-            let vy = w.body_velocity("player").unwrap()[1];
-            // The same grounding probe the example uses: a ray from the
-            // capsule's center down past the feet by a 0.15 skin.
-            policy(
-                &mut w,
-                Obs {
-                    vy,
-                    grounded: y - FEET <= PROBE_SKIN,
-                },
-            );
+            policy(&mut w);
             w.step_frame(dt(frame));
         }
-        w.body_transform("player").unwrap().0[1]
+        let (pos, _) = w.body_transform("player").unwrap();
+        (pos[0], pos[1])
     }
 
-    fn rest_height(spawn_y: f32, frames: u32, policy: impl Fn(&mut World, Obs)) -> f32 {
-        rest_height_dt(spawn_y, frames, |_| FIXED_DT, policy)
+    fn run_capsule_fixed(
+        spawn_y: f32,
+        frames: u32,
+        policy: impl Fn(&mut World),
+    ) -> (f32, f32) {
+        run_capsule(spawn_y, frames, |_| FIXED_DT, policy)
     }
 
     /// A masked write is EXACTLY transparent on the axes it does not name:
@@ -1738,36 +1730,60 @@ mod tests {
         // solver has actual penetration to recover from.
         const SPAWN: f32 = 3.0;
         let frames = 260;
-        let steer = |w: &mut World, _o: Obs| w.queue_command(set_xz("player", 0.0, 0.0));
+        // A NONZERO horizontal write, so this compares a real steering command
+        // against no command — not one no-op against another. The capsule is
+        // frictionless on flat ground, so driving x and z cannot itself change
+        // the height the solver settles at.
+        let steer = |w: &mut World| w.queue_command(set_xz("player", 4.0, -2.0));
 
-        let untouched = rest_height(SPAWN, frames, |_, _| {});
-        let masked = rest_height(SPAWN, frames, steer);
-        assert_eq!(
-            masked, untouched,
-            "a masked write moved the axis it does not name"
+        let (idle_x, untouched) = run_capsule_fixed(SPAWN, frames, |_| {});
+        let (driven_x, masked) = run_capsule_fixed(SPAWN, frames, steer);
+        // Tolerance, not bit-equality: the steered capsule really is sliding,
+        // so the solver does slightly different contact work and the last
+        // couple of float bits differ (~1e-7 here). Demanding an exact match
+        // would also be a cross-platform trap — this runs on x86 and ARM CI.
+        // The claim under test is that steering does not move the standing
+        // height, and 1e-4 is ~4000x tighter than the 0.4-unit sink the
+        // whole-vector command was supposed to cause.
+        assert!(
+            (masked - untouched).abs() < 1e-4,
+            "a masked write moved the axis it does not name: {masked} vs {untouched}"
         );
         assert!(
             (masked - FEET).abs() < 0.02,
             "the capsule did not rest at its standing height: {masked}"
         );
 
+        // The steered axis really was driven — otherwise the equality above
+        // would be the trivial one, two runs that both commanded nothing.
+        assert!(
+            (idle_x).abs() < 1e-6,
+            "the uncommanded capsule drifted in x: {idle_x}"
+        );
+        assert!(
+            driven_x > 10.0,
+            "the steered capsule did not travel: x = {driven_x}"
+        );
+
         // Again under a JITTERED frame time, the way the real runtime drives
         // it: some frames take no substep and some take two, so a command can
         // sit pending across a frame and two can land before one substep.
         let jitter = |f: u32| FIXED_DT * (0.6 + 0.9 * ((f % 7) as f32 / 6.0));
-        let untouched = rest_height_dt(SPAWN, frames, jitter, |_, _| {});
-        let masked = rest_height_dt(SPAWN, frames, jitter, steer);
-        assert_eq!(
-            masked, untouched,
-            "a masked write moved the untouched axis under a jittered frame time"
+        let (_, untouched) = run_capsule(SPAWN, frames, jitter, |_| {});
+        let (jx, masked) = run_capsule(SPAWN, frames, jitter, steer);
+        assert!(
+            (masked - untouched).abs() < 1e-4,
+            "a masked write moved the untouched axis under a jittered frame \
+             time: {masked} vs {untouched}"
         );
+        assert!(jx > 10.0, "the steered capsule did not travel: x = {jx}");
 
-        // The steered axes really are driven, so the test above is not just
-        // observing a command that did nothing at all.
-        let ran = rest_height(SPAWN, 60, |w, _| {
-            w.queue_command(set_xz("player", 4.0, 0.0));
-        });
-        assert!((ran - FEET).abs() < 0.02, "steering changed the height: {ran}");
+        // (The vertical mask's mirror property — a `y` write leaving x and z
+        // untouched — is pinned exactly in
+        // `set_velocity_y_leaves_the_horizontal_plane_alone`, in the
+        // contact-free world where it is a clean no-op. Commanding `y` here
+        // would not be a no-op: it cancels the fall and changes when the
+        // capsule lands.)
     }
 
     #[test]


### PR DESCRIPTION
Closes the API gap called out as still-open in #503's assessment:

> **`Physics.setVelocity` is all-or-nothing across three axes**, which is what
> forced the ground clamp to be written by hand. […] Still open, and a much
> smaller, better-targeted change than a new hook — the problem is the *shape
> of the command*, not when it runs.

## The design decision

Two commands, splitting the velocity vector on the Y-up engine's natural seam:

```
Physics.setVelocityXZ(tag, x, z)   // steer the horizontal plane
Physics.setVelocityY(tag, v)       // a jump that keeps the run
```

Three shapes were considered:

| shape | why not |
| --- | --- |
| `setVelocityX/Y/Z` | the dominant case (steer horizontally) needs two commands and an `Effect.batch` every frame; per-axis X and Z alone have no motivating use |
| optional-per-axis record | no ergonomic optional-field literal at a call site; verbose at every call for a case that is always "the horizontal plane" |
| **`setVelocityXZ` + `setVelocityY`** | **each is exactly one real use case, one call, pipes cleanly, and the two masks partition all three axes** |

`setVelocityY` earns its place independently of the controller: it is a
mass-independent jump that preserves horizontal momentum, which today needs
either `applyImpulse` (scales with mass) or a whole-vector `setVelocity`
(discards the run).

They land as two concrete `PhysicsCommand` variants — `SetVelocityXZ { tag, x, z }`
and `SetVelocityY { tag, y }`. (An earlier revision used one variant with a
`[bool; 3]` mask; both reviewers pointed out that six of its eight masks were
unconstructible from the prelude, and that the generality was exactly what
forced the effect log to mislabel them. Concrete variants make both `match`
sites exhaustive and the bad states unrepresentable.)

## Composition semantics (documented, and unit-tested)

Preserved axes are read from the **live body at apply time** — after reconcile,
and after any command already applied from the same frame's queue — not from
whatever the game read in `tick`. So:

- Velocity commands in one frame compose as **last-write-wins per axis**; an
  axis nobody wrote is left exactly as the solver left it.
- `setVelocityXZ` + `setVelocityY` in one frame == a whole-vector
  `setVelocity` (disjoint axes, order-independent).
- A whole-vector `setVelocity` queued *before* a `setVelocityXZ` is visible to
  it (its `y` survives); queued *after*, it clobbers everything.

Each of those is a case in `same_frame_masked_writes_compose_per_axis`.
`masked_writes_share_the_unknown_and_non_dynamic_warnings` pins that the new
commands inherit the unknown-tag and non-dynamic-body warnings *and* name
themselves correctly in them. Both producers get the commands free via the
typed registry (the `.funi` drift test passes unmodified).

These are the **first commands whose effect depends on world state at apply
time**, so they are added to the determinism goldens (frames 60/61): a
seek-then-replay that resumed from a slightly different world would diverge on
the preserved axis instead of reproducing it. It doesn't — goldens pass.

## Proof: the controller workaround is deleted

`examples/physics-controller` now steers with `setVelocityXZ` and jumps with
`setVelocityY`. Deleted: the `error / dt` **ground clamp**, `maxSnapSpeed`, its
`dt == 0` NaN guard (needed only because `--fixed-time` divides by zero), and
the `standHeight` / `groundDistance` observation fields that existed solely to
feed it — the subtlest logic in the example.

The rule that replaced it is now itself testable: `Control.verticalCommand`
returns `Option.t<float>`, `Some` only on a jump frame, and `game.fun` matches
on it — so "the controller never writes the vertical axis unless jumping" is
pinned by expects rather than asserted in a comment (36 expects, was 34).

The 400-frame scripted verification run (`ride-and-jump.input`), before/after:

| | ground clamp (base) | `setVelocityXZ` (this PR) |
| --- | --- | --- |
| resting height | 0.8988 | 0.8987 |
| wall stop `x` | −6.3012 | −6.3012 |
| jump rise | +0.9363 | +0.9363 |
| frames on the deck | 91 | 91 |
| first grounded frame | 11 | 11 |
| lowest `y` | 0.8962 | 0.8554 |

Everything that matters is unchanged. The single difference is the last row: a
transient ~0.04 dip at the hardest landing where the solver resolves its own
penetration instead of the clamp erasing it in one frame. Not visible in motion.

**One behaviour the clamp provided that the solver does not**: sticking to a
surface that drops away. This level's deck only slides along `x`, so nothing
here exercises it — noted in the example README and the skill as the one case
where you should still write a clamp.

## Correcting the record on #503's two sinking failures

#503 reported two measured failures (a capsule resting at 0.40 instead of 0.90:
one from echoing the velocity read back, one from commanding `0` while
grounded). I built a harness to re-prove them fixed-by-construction, and
**neither reproduces at the command layer**:

- **Echoing the read back is bit-identical to issuing no command at all.** The
  `Physics.linearVelocity` read and the command's apply point observe the same
  world state (`apply_pending` runs after reconcile, before the first substep,
  with no step in between), so writing back what you read is a no-op.
- **Commanding `y = 0` while grounded recovers to the same resting height**,
  because rapier resolves a landing's penetration positionally rather than
  through the velocity the game overwrites.

Both were checked after a real drop-and-land (so there *is* penetration to
recover from), under a fixed frame time and a jittered one (0- and 2-substep
frames). All policies rest at 0.89869.

So the case for this command is **ergonomic and architectural — a game should
not have to author an axis the solver owns — not a sinking fix.** The skill,
the `.funi` docs and the example README are updated rather than repeating a
mechanism that was disproved. The test that replaced the intended regression
test asserts the property that is actually true and load-bearing:
`masked_writes_are_transparent_on_the_untouched_axis` — a real steering command
leaves the standing height where the solver alone would have put it, under both
fixed and jittered frame times, while the body demonstrably travels.

## Review dispositions (`/xreview`: Claude subagent + Codex, in parallel)

Codex reported **no Critical or High**. Three findings were raised by **both**
engines and all three are fixed:

| finding | disposition |
| --- | --- |
| **[AGREED]** `.funi` / enum doc / registration comment assert the sinking failure modes this change disproved — and `.funi` ships to users via `functor docs` | **Fixed.** All three rewritten to the ergonomic rationale. |
| **[AGREED]** `axes: [bool; 3]` is over-general; six masks unconstructible, and it forces the effect-log `_` fallback to mislabel them | **Fixed.** Two concrete variants; both matches exhaustive. |
| **[AGREED]** harness computes an `Obs` every policy ignores (`PROBE_SKIN` dead) | **Fixed.** Deleted; policy is `Fn(&mut World)`. |

From the Claude reviewer alone:

| finding | disposition |
| --- | --- |
| High — transparency test only wrote zeros to an already-zero axis, so it compared a no-op against no write | **Fixed**, and it was right: steering for real revealed a ~1e-7 solver-noise delta, so the assertion is now a tight tolerance instead of bit-equality — also the correct call for x86-vs-ARM CI. |
| Medium — warnings misname masked writes as `setVelocity` | **Fixed** by the variant split; the test now asserts the exact warning strings. |
| Low — two new effect-log kind strings untested | **Fixed.** |
| Low — no golden coverage for a state-dependent command | **Fixed.** Added to `commands_at`. |
| Low — stale "ground clamp" prose in skill/example/README | **Fixed.** |
| Low — replacement expects were near-tautologies | **Fixed** via `Control.verticalCommand`. |
| Low — a masked write wakes the body even when it changes nothing | **Declined.** Not a regression (`setVelocity` does the same), and skipping the write would let a steered capsule fall asleep — a behaviour change beyond this PR's scope. The docs say "transparent on the velocity axis", not "inert". |

`dupfinder review` was run but hit its timeout during cold indexing (4996
functions) before emitting findings, so there is **no duplication signal** for
this change either way.

## Verification (re-run after the review fixes)

- `cargo test -p functor_runtime_common` — **515 + 8 pass**, including the
  `.funi` drift test, 61 physics tests, and the determinism goldens.
- `cargo test -p functor-lang` — all suites pass.
- Examples sweep — all **29** examples pass `functor test`;
  `physics-controller` 36/36.
- `npm run check:docs` — green.
- Scripted 400-frame run re-verified after the refactor: identical to the table
  above.
- `frame_bench`, release, base vs branch:

  | cells | allocs/frame | bytes/frame | us/frame (min) base → branch |
  | --- | --- | --- | --- |
  | 400 | 13877 (=) | 843379 (=) | 519.5 → 499.4 |
  | 1600 | 54717 (=) | 3307219 (=) | 2163.2 → 2139.0 |
  | 3136 | 106973 (=) | 6460243 (=) | 4197.6 → 3968.5 |

  **allocs/frame and bytes/frame byte-identical**; wall-clock inside run-to-run
  spread.

## Rebuild note

This changes `runtime/functor-runtime-common`, so `functor run` will not pick it
up until you `npm run build:cli` (the desktop runtime is compiled into the
binary and the web runtime is `include_bytes!`-embedded).

## Docs updated

`functor-prelude/prelude/physics.funi`, `docs/physics.md` (signatures +
composition semantics), the `functor-lang` skill's physics table and
character-controller section (its "three traps" prose is rewritten — two of the
three claims are the ones that did not reproduce), and
`examples/physics-controller/README.md`.

No visual change: the example renders identically at the same fixed time, so the
before/after evidence is the numeric trace table above rather than a GIF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
