### PR TITLE
feat(vr): request a display refresh rate, and report what we get

### DIFF
--- a/runtime/functor-runtime-oculus/src/lib.rs
+++ b/runtime/functor-runtime-oculus/src/lib.rs
@@ -44,6 +44,17 @@ use khronos_egl as egl;
 use openxr as xr;
 
 /// GLES version to request. Quest 3 supports 3.2.
+/// Display refresh rate to aim for, in Hz.
+///
+/// Quest 3 offers 72/80/90/120; the runtime defaults to 72 and only changes on
+/// request. This picks the highest offered rate that does not exceed the
+/// target, so a headset advertising fewer options still gets a sane choice.
+///
+/// Raising this raises the frame budget's difficulty in exact proportion —
+/// 13.8 ms at 72 Hz, 11.1 ms at 90, 8.3 ms at 120 — so it is a measured
+/// decision, not a preference. See the `oculus-profiling` skill.
+const TARGET_REFRESH_RATE: f32 = 72.0;
+
 const GLES_MAJOR: i32 = 3;
 const GLES_MINOR: i32 = 2;
 
@@ -818,8 +829,18 @@ pub fn android_main(app: AndroidApp) {
         .initialize_android_loader()
         .expect("initialize android loader");
 
+    // Only ask for what the runtime advertises: an unsupported extension in the
+    // set fails xrCreateInstance outright, which would take the whole app down
+    // on a headset that happens not to offer it.
+    let available = entry
+        .enumerate_extensions()
+        .expect("enumerate OpenXR extensions");
+
     let mut extensions = xr::ExtensionSet::default();
     extensions.khr_opengl_es_enable = true;
+    // Without this the runtime picks the display rate and the app has no say —
+    // Quest defaults to 72 Hz no matter how much headroom the frame has.
+    extensions.fb_display_refresh_rate = available.fb_display_refresh_rate;
     // Required on Android: openxr only chains the activity/JVM context into
     // xrCreateInstance (XrInstanceCreateInfoAndroidKHR) when this is set —
     // without it the runtime can reject instance creation.
@@ -869,6 +890,41 @@ pub fn android_main(app: AndroidApp) {
         )
     }
     .expect("create session");
+
+    // Display refresh rate. Requesting one is a *request*: the runtime may
+    // refuse, and it can change underneath us (battery, thermals, system UI),
+    // so report what was actually granted rather than what was asked for.
+    if available.fb_display_refresh_rate {
+        match session.enumerate_display_refresh_rates() {
+            Ok(rates) => {
+                let current = session.get_display_refresh_rate().ok();
+                log::info!("display refresh rates available: {rates:?} (current {current:?})");
+                // The highest the display offers that is no faster than the
+                // target. Asking for an unlisted rate is an error, and asking
+                // for more than the frame can sustain just converts headroom
+                // into stale frames.
+                let choice = rates
+                    .iter()
+                    .copied()
+                    .filter(|rate| *rate <= TARGET_REFRESH_RATE + 0.5)
+                    .fold(f32::NAN, f32::max);
+                if choice.is_finite() {
+                    // The request is asynchronous: reading the rate back here
+                    // still returns the old one. The runtime confirms the
+                    // change with DisplayRefreshRateChangedFB, which the event
+                    // loop logs — so do not report a rate we have not been
+                    // told took effect.
+                    match session.request_display_refresh_rate(choice) {
+                        Ok(()) => log::info!("requested {choice} Hz"),
+                        Err(e) => log::warn!("display refresh rate {choice} Hz refused: {e}"),
+                    }
+                }
+            }
+            Err(e) => log::warn!("cannot enumerate display refresh rates: {e}"),
+        }
+    } else {
+        log::info!("XR_FB_display_refresh_rate unavailable; using the runtime default");
+    }
 
     // STAGE (floor-origin, room-scale) preferred; LOCAL (head-origin) is the
     // portable baseline when the runtime has no stage bounds set up.
@@ -976,6 +1032,13 @@ pub fn android_main(app: AndroidApp) {
         while let Some(event) = instance.poll_event(&mut event_storage).expect("poll_event") {
             use xr::Event::*;
             match event {
+                DisplayRefreshRateChangedFB(e) => {
+                    log::info!(
+                        "display refresh rate changed: {} Hz -> {} Hz",
+                        e.from_display_refresh_rate(),
+                        e.to_display_refresh_rate()
+                    );
+                }
                 SessionStateChanged(e) => {
                     log::info!("session state: {:?}", e.state());
                     session_focused = e.state() == xr::SessionState::FOCUSED;


### PR DESCRIPTION
The runtime never called `XR_FB_display_refresh_rate`, so Horizon ran it at the
**72 Hz default** no matter how much headroom a frame had. 90 Hz wasn't something
we were failing to reach — it was something we had never asked for.

This is the enabling increment for the 90 Hz effort: until the rate is
requestable, no measurement above 72 means anything.

## What it does

Enumerate the rates the headset offers and request the highest that doesn't
exceed a target. The extension is **capability-checked** against
`enumerate_extensions` first — an unsupported extension in the set fails
`xrCreateInstance` outright, which would take the whole app down on a headset
that doesn't offer it.

**The target stays 72 Hz, so this changes no behaviour.** Raising it is a
measured decision, and the measurement says not yet.

## The async trap

Requesting is asynchronous, and it's easy to get wrong: reading the rate back
immediately after the request **still returns the old value**. My first version
logged `requested 90 Hz (now Some(72.0))`, which reads like a refusal and isn't.

The runtime confirms with `DisplayRefreshRateChangedFB`, so that event is now
handled and logs the real transition:

```
display refresh rates available: [72.0, 80.0, 90.0, 120.0] (current Some(72.0))
display refresh rate changed: 72 Hz -> 90 Hz
```

That event is also the **only direct evidence the display moved**. Before
handling it I could infer the switch only from FPS exceeding 72, which is
circumstantial.

## Measurements

Quest 3, `examples/terrain`, release APK, VrApi telemetry, 30 s samples after
10 s warmup:

| Target | FPS mean | App (GPU) | GPU load | Stale |
| ---: | ---: | ---: | ---: | ---: |
| **72 Hz** | 72.5 | 11.76 ms | 0.93 | **0** |
| 80 Hz | 74.9 | 11.70 ms | 0.97 | 220 |
| 90 Hz | 73.6 | 11.70 ms | 0.97 | 510 |

**App time is constant at ~11.7 ms** — the app renders the same frame; only the
budget changes (13.8 / 12.5 / 11.1 ms). At 80 Hz, App plus compositor lands
around 12.4 ms against 12.5 ms, thin enough that 220 frames go stale.

So **80 Hz is ~1 ms of headroom away and 90 Hz ~1.6 ms** — a tuning distance,
not a redesign. The headset offers 72, 80, 90 and 120 Hz.

## Next increment

Land ~1 ms and flip the target to 80, then re-measure for zero stale frames.
The candidates, in the order the GPU counters rank them (69.6% fragment /
30.4% vertex, 44.7% texture fetch stall — see the `oculus-profiling` skill):

1. **Fixed foveated rendering** — absent from the runtime entirely, and terrain
   periphery is ideal content. Estimated 1–3 ms.
2. **Detail maps into a texture array**, sampling only the bands with real
   weight (12 → ~5 fetches).
3. **`textureGather` + a baked normal map** against the vertex-side fetch cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
