### PR TITLE
fix(test): mario hot-reload test tracks the current jump constant

### DIFF
--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -2725,8 +2725,33 @@ mod tests {
 
         let mario = concat!(env!("CARGO_MANIFEST_DIR"), "/../../examples/mario/game.fun");
         let source = std::fs::read_to_string(mario).expect("read mario source");
-        let weak_jump = source.replacen("let jumpVelocity = 12.0", "let jumpVelocity = 6.0", 1);
-        assert_ne!(weak_jump, source, "test must rewrite the jump constant");
+        // `jumpVelocity` is the example's tuning knob, so read the CURRENT value
+        // out of the source and weaken it, rather than hardcoding the literal:
+        // a hardcoded needle silently stops matching the moment the example is
+        // retuned, turning the whole regression into a no-op.
+        const JUMP_BINDING: &str = "let jumpVelocity = ";
+        let jump_line = source
+            .lines()
+            .find(|line| line.starts_with(JUMP_BINDING))
+            .expect("mario source must define `let jumpVelocity = <number>`");
+        let tuned_jump: f64 = jump_line[JUMP_BINDING.len()..]
+            .split_whitespace()
+            .next()
+            .and_then(|literal| literal.parse().ok())
+            .expect("`let jumpVelocity` must be followed by a number literal");
+        // Half the tuned launch speed falls short of the chasm; the downstream
+        // "weak jump should fall and respawn" assertion is the check that this
+        // is still true if the example's other tunables move. `{:?}` (not `{}`)
+        // so an integral half still prints as a float literal.
+        let weak_jump = source.replacen(
+            jump_line,
+            &format!("{JUMP_BINDING}{:?}", tuned_jump / 2.0),
+            1,
+        );
+        assert_ne!(
+            weak_jump, source,
+            "test must rewrite the jump constant (looked for {jump_line:?})"
+        );
 
         let mut game = FunctorLangGame::create(mario);
         const SUB_DT: f32 = 1.0 / 60.0;


### PR DESCRIPTION
## The bug

`mario_hot_reload_recomputes_the_entire_extrapolated_future` fails on clean `main`.

It builds its "weak jump" variant of the mario source with:

```rust
let weak_jump = source.replacen("let jumpVelocity = 12.0", "let jumpVelocity = 6.0", 1);
assert_ne!(weak_jump, source, "test must rewrite the jump constant");
```

but `examples/mario/game.fun:18` reads `let jumpVelocity = 13.0` — the example was
retuned after the test was written. The needle matches nothing, `replacen` returns the
source unchanged, and the test trips its own guard assertion:

```
assertion `left != right` failed: test must rewrite the jump constant
```

## The fix

Read the current constant out of the source and halve it, instead of hardcoding the
literal. A retune of the example can no longer turn the rewrite into a no-op:

- a missing or unparseable `let jumpVelocity = <number>` line now panics loudly with a
  message naming what it looked for, rather than silently doing nothing;
- the guard `assert_ne!` is kept and now reports the needle it used;
- `{:?}` (not `{}`) formats the halved value so an integral half still emits a float
  literal (`6.0`, not `6`) — valid Functor Lang.

## Verification

- The test passes, and passes **all** of its interior assertions — so the mechanism it
  claims to exercise genuinely engages: pruned model history (`scene_frame_range().0 > 0`),
  the weak jump falling into the chasm and respawning at `x == -6.0`, the reload status
  disclosing `history recomputed from init (N frames, …)`, the retained future rebuilt
  under the stronger constant (`x > 3.0`), and resumed play branching from the
  counterfactual anchor to the same landing.
- `cargo test -p functor-runtime-desktop` — **69/69 lib tests green**, integration suites green.
- No hot path touched, so no `frame_bench` run is needed (test-only change).

## Why CI didn't catch it

`build-native.yml` runs `cargo test -p functor_runtime_common -p functor-lang` and
`cargo test -p functor-netsim --test terrain` — it does **not** run the
`functor-runtime-desktop` crate's tests, which is how a test failing on clean `main`
went unnoticed. Widening CI is out of scope here (it would need its own triage of
whatever else that suite surfaces on Linux/Windows), but it's the reason this sat broken.

## Review

`/xreview` (Claude Opus subagent + Codex CLI), **no Critical or High findings from either engine**.
Both independently re-simulated the mario physics and confirmed the halved constant still
exercises the intended failure: weak `6.5` respawns into the chasm, `13.0` clears to `x ≈ 3.87`.
The Claude reviewer additionally found the halving stays correct for any tuned value up to ~23.0,
and that past that point the failure is loud (`assert_eq!(x, -6.0)`), never silent.

Dispositions:

- **Applied (Low, simplicity):** dropped a needless `to_string()`, replaced
  `trim_start_matches` (which strips *repeated* prefixes) with a single slice off a shared
  `JUMP_BINDING` constant. ~9 lines instead of 23.
- **Not fixed (Low, Codex):** `{:?}` could emit exponent notation (`5e-20`) for an absurd
  retune. Halving any plausible jump velocity never produces exponent form, and the
  reload would fail loudly if it did.
- **Not fixed (Low, Claude):** the test also hardcodes `runSpeed` (8.0), `chasmHalf` (-3.0)
  and `startX` (-6.0). Unlike the jump needle these fail **loudly** rather than silently,
  so they are not the reported bug — out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
