### PR TITLE
fix(functor-lang): unknown type annotations are diagnosed instead of silently disabling checks

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -1587,23 +1587,39 @@ variant type; a foreign literal arm is a can-never-match error);
 exhaustiveness checks all ctors / `true`+`false` / catch-all; arm results
 must agree.
 
-⚠️ **A MISSPELLED OR MISCASED TYPE NAME SILENTLY DISABLES CHECKING.** An
-unrecognized annotation resolves to `Unknown`, which absorbs everything —
-so the primitives' exact lowercase spelling matters: `float`, `string`,
-`bool`, and `List<…>`. Writing `Float`, `String`, `Bool`, `int`, or `Number`
-does **not** error; it just turns that binding into a dynamic seam and
-throws away every diagnostic you annotated it to get. Verified:
+**Type names are lowercase**: `float`, `string`, `bool`, `List<…>`. A
+miscased or misspelled name is a **check error** with a did-you-mean, so
+you find out immediately:
 
 ```functor
 let f = (x: Float): Float => x + 1.0
-let bad = f("this is a string")   // `check` reports NOTHING (exit 0);
-                                  //   it blows up only at run time
+// error: unknown type name `Float` — did you mean `float`?
+//        (Functor Lang's primitive types are lowercase)
 ```
 
-The same trap applies to a mistyped nominal (`Postion` for `Position`).
-When an annotation you added stops catching an obvious error, suspect its
-spelling first. (`functor-lang check` cannot warn about this today — an
-unknown type name is exactly the `Unknown` gradual seam.)
+`Int`, `Number`, and `Double` are errors too — Functor Lang has a single
+number type, `float`. A mistyped nominal (`Postion` for `Position`)
+suggests the declared type it is closest to; a name that resembles nothing
+in scope tells you to declare it or to write `unknown`.
+
+⚠️ **Historical note (this WAS a silent trap).** Until the diagnostic
+landed, an unrecognized annotation resolved to `Unknown` — which absorbs
+everything — so `let x: Float = "hi"` typechecked clean and every
+annotation you added for safety was quietly inert. If you are reading older
+`.fun` code (or older docs) written against that behavior, its `Float`/
+`String` annotations were never checking anything, and fixing the casing
+may surface real type errors that were always there.
+
+`unknown` is the **explicit** gradual seam — the one annotation that
+deliberately absorbs anything, in both directions:
+
+```functor
+let handle = (payload: unknown) => …   // a host value only the two ends type
+```
+
+Use it where a value is genuinely dynamic (`Net.Data`'s payload is declared
+this way). Everywhere else, an unknown name is now an error rather than a
+silent opt-out of checking.
 
 ## Keeping this skill honest
 

--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -246,8 +246,8 @@ let grab = (s) =>
   Failure(error: string)`, the value an `Effect.httpGet`/`httpPost` tagger
   receives (`Response` = the request completed at ANY HTTP status;
   `Failure` = a transport error). `Data` carries an `Effect.sendMsg`
-  payload decoded back into a plain-data value; its field type `NetData` is
-  deliberately UNDECLARED (the gradual `Unknown` seam), so the bound value
+  payload decoded back into a plain-data value; its field type is
+  deliberately `unknown` (the EXPLICIT gradual seam), so the bound value
   matches directly against whatever ADT the two ends share — declare the
   protocol ADT once in a shared sibling module and match its ctors
   (`match w with | Protocol.Ping(n) => …`). A corrupt/version-skewed typed
@@ -1569,8 +1569,9 @@ unification with let-polymorphism — generic functions instantiate fresh at
 every use, element types flow through `List.map`/`filter`/`fold`, and
 apostrophe-prefixed annotation names are type variables (`(xs: List<'a>, seed: 'b): List<'b>`). Inference has teeth: unannotated bad calls, mixed-element
 lists, and contradictory `mut` use are errors now. `Unknown` remains ONLY
-at genuinely-dynamic seams (host values, unrecognized type
-names) and absorbs anything — but a BUILTIN namespace is not such a seam:
+at genuinely-dynamic seams (host values, and the `unknown` annotation you
+write on purpose — an UNRECOGNIZED type name is an error, not a seam)
+and absorbs anything — but a BUILTIN namespace is not such a seam:
 its member set is closed, so `List.tail` / `Text.padLeft` are check errors, not
 `Unknown` (see "Builtins"). Function TYPES **do** annotate —
 `(f: (float) => float)`, `(f: ('a) => 'b)`, and the parenthesized

--- a/docs/multiplayer.md
+++ b/docs/multiplayer.md
@@ -99,9 +99,11 @@ Effect.sendMsg(connId, msg)   // send a plain-data VALUE; received as Net.Data(i
 ```
 
 `Net` is a built-in module, always in scope:
-`type NetEvent = | Connected(id: Float) | Message(id: Float, text: String) |
-Data(id: Float, value: NetData) | Disconnected(id: Float) |
-Error(id: Float, text: String)`. The connection id is
+`type NetEvent = | Connected(id: float) | Message(id: float, text: string) |
+Data(id: float, value: unknown) | Disconnected(id: float) |
+Error(id: float, text: string)`. `Data`'s payload is `unknown` — the explicit
+gradual seam, since its real type is whatever ADT the two ends share. The
+connection id is
 assigned by the runtime and reported via `Connected`; the game stores it in its
 model and names it in `Effect.send`. `examples/wsdemo` (client) and
 `examples/wsserverdemo` (server) are the ports.

--- a/e2e/functor-lang-preview-reload.mjs
+++ b/e2e/functor-lang-preview-reload.mjs
@@ -33,10 +33,10 @@ const ROOT = fileURLToPath(new URL("..", import.meta.url));
 // The model shape hello-cubes's init establishes: { spin, beat }. Every push
 // keeps `tick` accumulating spin at 0.5/s so the survival probes have a
 // value that only time-across-reloads can produce.
-const TICK = `let tick = (model, dt: Float, tts: Float) => { model with spin: model.spin + dt * 0.5 }`;
+const TICK = `let tick = (model, dt: float, tts: float) => { model with spin: model.spin + dt * 0.5 }`;
 // A static, unmistakably green frame — draw ignores the model, so the pixel
 // assertion can't be confused by animation phase.
-const GREEN_DRAW = `let draw = (model, tts: Float) =>
+const GREEN_DRAW = `let draw = (model, tts: float) =>
   Frame.create(
     Camera.lookAt(Vec3.make(0.0, 0.0, -6.0), Vec3.make(0.0, 0.0, 0.0)),
     Scene.sphere() |> Scene.emissive(Color.rgb(0.1, 1.0, 0.2)) |> Scene.scale(2.0))`;
@@ -50,7 +50,7 @@ ${GREEN_DRAW}
 // access is a spanned runtime error; a fresh init has spin = 0.0).
 const probe = (cond) => `let probeBoom = (m) => m.thisFieldDoesNotExist
 let init = { spin: 0.0, beat: 0.0 }
-let tick = (model, dt: Float, tts: Float) =>
+let tick = (model, dt: float, tts: float) =>
   match ${cond} with
   | true => { model with spin: model.spin + dt * 0.5 }
   | false => probeBoom(model)

--- a/e2e/ide-page.mjs
+++ b/e2e/ide-page.mjs
@@ -226,7 +226,7 @@ try {
     await poll(() => page.locator(".cm-lintRange-error").count(), (n) => n === 0);
     await page.evaluate(
       (src) => window.__ide.setActiveSource(src),
-      `${gameSource}let oops = (x: Float) => x + "type error"\n`
+      `${gameSource}let oops = (x: float) => x + "type error"\n`
     );
     const underlined = await poll(() => page.locator(".cm-lintRange-error").count(), (n) => n > 0);
     if (underlined > 0) console.log("type error draws a lint underline ✓");

--- a/e2e/ide-project.mjs
+++ b/e2e/ide-project.mjs
@@ -32,8 +32,8 @@ let glow = 0.9
 const PIECES_BROKEN = `let speed =
 `;
 const GAME = `let init = { t: 0.0 }
-let tick = (model, dt: Float, tts: Float) => { model with t: model.t + dt * Pieces.speed }
-let draw = (model, tts: Float) =>
+let tick = (model, dt: float, tts: float) => { model with t: model.t + dt * Pieces.speed }
+let draw = (model, tts: float) =>
   Frame.create(
     Camera.lookAt(Vec3.make(0.0, 0.0, -6.0), Vec3.make(0.0, 0.0, 0.0)),
     Scene.sphere() |> Scene.emissive(Color.rgb(0.1, 1.0, Pieces.glow)) |> Scene.scale(2.0))

--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -37,8 +37,8 @@ const BASE = `http://127.0.0.1:${PORT}`;
 const ROOT = fileURLToPath(new URL("..", import.meta.url));
 
 const GREEN = `let init = { t: 0.0 }
-let tick = (model, dt: Float, tts: Float) => { model with t: model.t + dt }
-let draw = (model, tts: Float) =>
+let tick = (model, dt: float, tts: float) => { model with t: model.t + dt }
+let draw = (model, tts: float) =>
   Frame.create(
     Camera.lookAt(Vec3.make(0.0, 0.0, -6.0), Vec3.make(0.0, 0.0, 0.0)),
     Scene.sphere() |> Scene.emissive(Color.rgb(0.1, 1.0, 0.2)) |> Scene.scale(2.0))
@@ -49,8 +49,8 @@ const BROKEN = "let init = {\n";
 // read in both tick and draw): only a fresh `init` runs it cleanly, so this
 // catches the sandbox hot-swapping an inline program onto a foreign model.
 const INLINE_SPIN = `let init = { spin: 0.0 }
-let tick = (model, dt: Float, tts: Float) => { model with spin: model.spin + dt }
-let draw = (model, tts: Float) =>
+let tick = (model, dt: float, tts: float) => { model with spin: model.spin + dt }
+let draw = (model, tts: float) =>
   Frame.create(
     Camera.lookAt(Vec3.make(0.0, 0.0, -6.0), Vec3.make(0.0, 0.0, 0.0)),
     Scene.cube() |> Scene.rotateY(Angle.radians(model.spin)) |> Scene.emissive(Color.rgb(1.0, 0.2, 0.8)))
@@ -61,8 +61,8 @@ let draw = (model, tts: Float) =>
 // and show the unavailable prefix rather than collapsing or disappearing.
 const CLOSURE_HISTORY = `let offset = (k) => (x) => x + k
 let init = { t: 0.0, behavior: offset(1.0) }
-let tick = (model, dt: Float, tts: Float) => { model with t: model.t + dt }
-let draw = (model, tts: Float) =>
+let tick = (model, dt: float, tts: float) => { model with t: model.t + dt }
+let draw = (model, tts: float) =>
   Frame.create(
     Camera.lookAt(Vec3.make(0.0, 0.0, -6.0), Vec3.make(0.0, 0.0, 0.0)),
     Scene.cube() |> Scene.rotateY(Angle.radians(model.t)) |> Scene.emissive(Color.rgb(0.2, 0.8, 1.0)))
@@ -76,8 +76,8 @@ let draw = (model, tts: Float) =>
 // a hot-swap onto the record-model default would throw at draw).
 const INTEL_SRC = `let speed = 2.0
 let init = 0.0
-let tick = (model, dt: Float, tts: Float) => model + dt
-let draw = (model, tts: Float) =>
+let tick = (model, dt: float, tts: float) => model + dt
+let draw = (model, tts: float) =>
   Frame.create(
     Camera.lookAt(Vec3.make(0.0, 0.0, -6.0), Vec3.make(0.0, 0.0, 0.0)),
     Scene.sphere() |> Scene.emissive(Color.rgb(0.1, 1.0, 0.2))
@@ -1047,7 +1047,7 @@ for (const example of examples) {
     // A clean program using prelude names.
     const clean = JSON.parse(
       mod.functor_lang_analyze(
-        "let draw = (model, tts: Float) =>\n" +
+        "let draw = (model, tts: float) =>\n" +
           "  Frame.create(Camera.lookAt(Vec3.make(0.0, 0.0, -6.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n"
       )
     );
@@ -1080,7 +1080,7 @@ for (const example of examples) {
 // bad def is removed — all while the push loop keeps the status pill live.
 {
   const CLEAN = GREEN;
-  const TYPE_ERROR = `${GREEN}let oops = (x: Float) => x + "type error"\n`;
+  const TYPE_ERROR = `${GREEN}let oops = (x: float) => x + "type error"\n`;
 
   const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
   await page.goto(`${BASE}/sandbox.html`);
@@ -1256,7 +1256,7 @@ for (const example of examples) {
   };
 
   // A type error fills the Problems tab and panel.
-  const BAD = `${GREEN}let oops = (x: Float) => x + "status bar"\n`;
+  const BAD = `${GREEN}let oops = (x: float) => x + "status bar"\n`;
   await page.evaluate((s) => window.__sandbox.setSource(s), BAD);
   const flagged = await waitFor(() => tabText(problemsTab), (t) => t.includes("1 problem"));
   check("problems tab counts the type error", flagged.includes("1 problem"), flagged);
@@ -1418,14 +1418,14 @@ for (const example of examples) {
   // arm after; `never` requires hp < 0 — unreachable (statically runnable →
   // dark). Unique arm texts so line lookup can't collide with init.
   const PARITY = `let init = { n: 0.0, hp: 1.0 }
-let tick = (model, dt: Float, tts: Float) =>
+let tick = (model, dt: float, tts: float) =>
   match model.hp < 0.0 with
   | true => { n: model.n, hp: 0.0 }
   | false =>
     match model.n < 60.0 with
     | true => { n: model.n + 1.0, hp: 1.0 }
     | false => { n: model.n + 1.0, hp: 2.0 }
-let draw = (model, tts: Float) =>
+let draw = (model, tts: float) =>
   Frame.create(
     Camera.lookAt(0.0, 0.0, -6.0, 0.0, 0.0, 0.0),
     Scene.sphere() |> Scene.emissive(Color.rgb(0.1, 1.0, 0.2)))

--- a/examples/inspector/game.fun
+++ b/examples/inspector/game.fun
@@ -13,11 +13,11 @@
 
 type Msg =
   | Tick
-  | GotTime(t: Float)
+  | GotTime(t: float)
 
 type Model = {
-  ticks: Float,
-  lastTime: Float,
+  ticks: float,
+  lastTime: float,
 }
 
 let init = { ticks: 0.0, lastTime: 0.0 }
@@ -31,9 +31,9 @@ let update = (model: Model, msg: Msg) =>
 
 let subscriptions = (model: Model) => Sub.every(Time.seconds(1.0), Tick)
 
-let tick = (model: Model, dt: Float, tts: Float) => model
+let tick = (model: Model, dt: float, tts: float) => model
 
-let draw = (model: Model, tts: Float) =>
+let draw = (model: Model, tts: float) =>
   Frame.create(
     Camera.lookAt(Vec3.make(0.0, 1.5, -4.0), Vec3.make(0.0, 0.0, 0.0)),
     Scene.cube() |> Scene.rotateY(Angle.radians(tts)),

--- a/functor-lang/src/ir.rs
+++ b/functor-lang/src/ir.rs
@@ -101,8 +101,8 @@ pub struct Signature {
     pub span: Span,
 }
 
-/// `type Position = { x: Float, y: Float }` or
-/// `type Shape = | Circle(radius: Float) | Point` — the body ([`TypeBody`])
+/// `type Position = { x: float, y: float }` or
+/// `type Shape = | Circle(radius: float) | Point` — the body ([`TypeBody`])
 /// is carried through from the AST verbatim, fields keeping their symbolic
 /// [`TypeName`]s; other types reference this one by name. Constructor names
 /// live in the *value* namespace (see [`crate::lower`]).

--- a/functor-lang/src/lower.rs
+++ b/functor-lang/src/lower.rs
@@ -212,7 +212,10 @@ fn lower_module(
                 // Builtin type names would shadow the primitives in
                 // annotations (the checker resolves `float` before user
                 // types), yielding nonsense like "expected float, got float".
-                if matches!(decl.name.as_str(), "float" | "bool" | "string" | "List") {
+                if matches!(
+                    decl.name.as_str(),
+                    "float" | "bool" | "string" | "unknown" | "List"
+                ) {
                     return Err(LowerError {
                         message: format!("cannot redeclare builtin type `{}`", decl.name),
                         span: decl.span,

--- a/functor-lang/src/project.rs
+++ b/functor-lang/src/project.rs
@@ -201,20 +201,21 @@ impl Project {
 /// completed request (any HTTP status), `Failure` for a transport error.
 ///
 /// `Data(id, value)` is an `Effect.sendMsg` payload decoded back into a
-/// plain-data value. Its field is deliberately typed with the UNDECLARED name
-/// `NetData`, which the checker resolves to `Unknown` — the gradual seam: the
-/// payload's real type is whatever ADT the two ends share (the same
-/// shared-module declaration on both sides), so games match it directly
-/// against their own constructors.
+/// plain-data value. Its field is deliberately typed `unknown` — the EXPLICIT
+/// gradual seam: the payload's real type is whatever ADT the two ends share
+/// (the same shared-module declaration on both sides), so games match it
+/// directly against their own constructors. (It used to say `NetData`, an
+/// undeclared name that fell through to `Unknown` implicitly; that fall-through
+/// is now a check error, so the seam has to be spelled.)
 const NET_MODULE_SRC: &str = "type NetEvent =\n\
-     | Connected(id: Float)\n\
-     | Message(id: Float, text: String)\n\
-     | Data(id: Float, value: NetData)\n\
-     | Disconnected(id: Float)\n\
-     | Error(id: Float, text: String)\n\
+     | Connected(id: float)\n\
+     | Message(id: float, text: string)\n\
+     | Data(id: float, value: unknown)\n\
+     | Disconnected(id: float)\n\
+     | Error(id: float, text: string)\n\
      type HttpResponse =\n\
-     | Response(status: Float, body: String)\n\
-     | Failure(error: String)\n";
+     | Response(status: float, body: string)\n\
+     | Failure(error: string)\n";
 
 /// The built-in `Random` interface module (injected beside `Net` in [`link`]).
 /// `Seed` is an abstract type — the brand that keeps PRNG seeds out of

--- a/functor-lang/src/types.rs
+++ b/functor-lang/src/types.rs
@@ -118,7 +118,9 @@ pub enum Type {
 impl fmt::Display for Type {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Type::Unknown => write!(f, "Unknown"),
+            // Spelled as it is WRITTEN: `unknown` is a real annotation now,
+            // so a type copied out of hover into the source still checks.
+            Type::Unknown => write!(f, "unknown"),
             // Raw display; hover/errors normalize vars to 'a, 'b first
             // (see `Checker::zonk_normalized`).
             Type::Var(v) => write!(f, "'{}", var_name(*v)),
@@ -403,12 +405,17 @@ fn nearest_member(member: &str, members: &[&'static str]) -> Option<&'static str
 /// capitalizes them, so `Float`/`String`/`Bool` are the mistake people
 /// actually make — and `Int`/`Number`/`Double` name a type Functor Lang
 /// doesn't have (all numbers are `float`).
+///
+/// Deliberately NOT here: `Any`/`Object`/`Dynamic`. Answering those with
+/// "did you mean `unknown`?" would recommend the check-disabling seam as a
+/// typo fix — reinstating, by suggestion, the exact trap this diagnostic
+/// exists to close. They fall through to the neutral message, which mentions
+/// `unknown` as a deliberate choice without endorsing it.
 fn miscased_primitive(name: &str) -> Option<&'static str> {
     match name.to_lowercase().as_str() {
         "float" | "int" | "integer" | "number" | "double" | "num" => Some("float"),
         "string" | "str" | "text" => Some("string"),
         "bool" | "boolean" => Some("bool"),
-        "unknown" | "any" | "dynamic" | "obj" | "object" => Some("unknown"),
         _ => None,
     }
 }
@@ -1422,61 +1429,89 @@ the type: `type Name<{name}> = …`"
     /// The teaching message for an unrecognized type name, with a
     /// did-you-mean when one is confident enough to name.
     ///
-    /// The overwhelmingly common case is a MISCASED primitive — `Float` for
-    /// `float` — because every other language spells them capitalized. That
-    /// gets a flat, certain correction. Otherwise the name is matched against
-    /// everything actually in scope (primitives, `unknown`, and the declared
-    /// record/variant types), case-insensitively first — `NetEvnt` for
-    /// `NetEvent` is still a typo of a real type — then by typo-scale edit
-    /// distance. With no confident candidate the message points at the two
-    /// real options: declare the type, or say `unknown` on purpose.
+    /// A DECLARED type always wins: the name is matched against everything
+    /// actually in scope (primitives, `unknown`, and the declared record and
+    /// variant types) before any built-in correction table, so a project that
+    /// declares `Text` or `Number` gets its own type suggested rather than
+    /// `string`/`float`. Declared types are canonical (`Asset.Model`,
+    /// `Utils.Position`), so their MEMBER part matches too — writing `Model`
+    /// unqualified suggests the qualified `Asset.Model` rather than
+    /// misdirecting to "declare it".
+    ///
+    /// Only then the miscased-primitive table, which covers the common
+    /// `Float`-for-`float` mistake. With no confident candidate the message
+    /// points at the real options.
     fn unknown_type_message(&self, name: &str) -> String {
         let head = format!("unknown type name `{name}`");
+        let lowered = name.to_lowercase();
+        // A candidate matches on its full canonical name OR on its member
+        // part, so an unqualified `Model` finds `Asset.Model`.
+        let member_of = |c: &str| c.rsplit_once('.').map_or(c, |(_, m)| m).to_lowercase();
+        let declared: Vec<&str> = self
+            .records
+            .keys()
+            .chain(self.variants.keys())
+            .map(String::as_str)
+            .collect();
+        // A DECLARED type that differs only by case (or by qualification) is
+        // a certain hit, and outranks the primitive table — a project that
+        // declares `Number` means its own type, not `float`.
+        if let Some(hit) = declared
+            .iter()
+            .find(|c| c.to_lowercase() == lowered || member_of(c) == lowered)
+        {
+            return format!("{head} — did you mean `{hit}`?");
+        }
         if let Some(prim) = miscased_primitive(name) {
-            // Distinguish "you capitalized it" from "that type doesn't
-            // exist here": `Int`/`Number` are not miscasings of `float`,
-            // they are a different type system's idea of numbers.
-            let why = if name.to_lowercase() == prim {
+            // Distinguish "you capitalized it" from "that type doesn't exist
+            // here": `Int`/`Number` are not miscasings of `float`, they are
+            // another language's idea of numbers.
+            let why = if lowered == prim {
                 "Functor Lang's primitive types are lowercase"
-            } else if prim == "float" {
-                "Functor Lang has a single number type, `float`"
             } else {
-                "that is how Functor Lang spells it"
+                "Functor Lang has a single number type, `float`"
             };
             return format!("{head} — did you mean `{prim}`? ({why})");
         }
+        // No certain hit: fall back to typo-scale edit distance over
+        // everything in scope. Distance is measured case-INSENSITIVELY, so
+        // `Flaot` reads as a two-edit typo of `float` rather than a
+        // three-edit one that spends its budget on the capital F. Budget: 2
+        // for a name long enough that two edits still leave it recognizable,
+        // 1 for short names where 2 edits could reach anything.
         let mut candidates: Vec<&str> = vec!["float", "string", "bool", "unknown", "List"];
-        candidates.extend(self.records.keys().map(String::as_str));
-        candidates.extend(self.variants.keys().map(String::as_str));
-        // A pure case difference is a certain hit; only then fall back to
-        // edit distance, budgeted like `nearest_member` so an honestly-novel
-        // name suggests nothing rather than something misleading.
-        let lowered = name.to_lowercase();
+        candidates.extend(declared);
+        let budget = if name.chars().count() >= 4 { 2 } else { 1 };
         let near = candidates
             .iter()
-            .find(|c| c.to_lowercase() == lowered)
-            .copied()
-            .or_else(|| {
-                // Distance is measured case-INSENSITIVELY, so `Flaot` reads as
-                // a two-edit typo of `float` rather than a three-edit one that
-                // spends its whole budget on the capital F. Budget: 2 for a
-                // name long enough that two edits still leave it recognizable,
-                // 1 for short names where 2 edits could reach anything.
-                let budget = if name.chars().count() >= 4 { 2 } else { 1 };
-                candidates
-                    .iter()
-                    .map(|c| (edit_distance(&lowered, &c.to_lowercase()), *c))
-                    .filter(|(distance, _)| *distance <= budget)
-                    .min_by_key(|(distance, c)| (*distance, *c))
-                    .map(|(_, c)| c)
-            });
-        match near {
-            Some(near) => format!("{head} — did you mean `{near}`?"),
-            None => format!(
-                "{head} — declare it (`type {name} = …`), or write `unknown` \
-if this position is deliberately untyped"
-            ),
+            .map(|c| {
+                let distance = edit_distance(&lowered, &c.to_lowercase())
+                    .min(edit_distance(&lowered, &member_of(c)));
+                (distance, *c)
+            })
+            .filter(|(distance, _)| *distance <= budget)
+            .min_by_key(|(distance, c)| (*distance, *c))
+            .map(|(_, c)| c);
+        if let Some(near) = near {
+            return format!("{head} — did you mean `{near}`?");
         }
+        // A type VARIABLE is apostrophe-prefixed; a bare lowercase name in
+        // type position is most often that mistake, not a missing type.
+        if name.chars().next().is_some_and(char::is_lowercase) {
+            return format!("{head} — a type variable is spelled `'{name}`");
+        }
+        // "declare it" only makes sense for a name that could BE a
+        // declaration; `type Foo.Bar = …` does not parse.
+        if name.contains('.') {
+            return format!(
+                "{head} — that module declares no such type (or write `unknown` \
+if this position is deliberately untyped)"
+            );
+        }
+        format!(
+            "{head} — declare it (`type {name} = …`), or write `unknown` \
+if this position is deliberately untyped"
+        )
     }
 
     fn resolve_annotation(&mut self, ty: Option<&TypeName>, report: bool) -> Type {

--- a/functor-lang/src/types.rs
+++ b/functor-lang/src/types.rs
@@ -12,23 +12,28 @@
 //! annotations are scoped type variables (`(xs: List<a>, f: (a) => b)`).
 //!
 //! **Gradualness survives at the seams**: [`Type::Unknown`] remains for
-//! host values and unrecognized UPPERCASE type names, absorbs anything in
+//! host values and for the annotation `unknown`, absorbs anything in
 //! unification, and never binds a variable — dynamic where the world is
-//! dynamic, inferred everywhere else. Record literals resolve NOMINALLY,
-//! F#-style: the unique declared type with exactly that field set (no
-//! match → anonymous data, still gradual; several → ambiguity error
-//! asking for an annotation).
+//! dynamic, inferred everywhere else. It is no longer where UNRECOGNIZED
+//! type names land: an unknown name is a check error (see
+//! `Checker::unknown_type_message`), because resolving `Float` to `Unknown`
+//! silently disabled checking wherever someone capitalized a primitive.
+//! Record literals resolve NOMINALLY, F#-style: the unique declared type
+//! with exactly that field set (no match → anonymous data, still gradual;
+//! several → ambiguity error asking for an annotation).
 //!
 //! ## The type language
 //!
-//! - Primitives `Float`, `String`, `Bool` (numbers are all Float).
-//! - Declared record types (`type Position = { x: Float, y: Float }`) —
+//! - Primitives `float`, `string`, `bool` (numbers are all `float`).
+//!   Lowercase — a capitalized `Float` is a diagnosed error, not a type.
+//! - `unknown` — the explicit dynamic seam, compatible with everything.
+//! - Declared record types (`type Position = { x: float, y: float }`) —
 //!   nominal, by name.
-//! - Declared variant types (`type Shape = | Circle(radius: Float) | Point`)
+//! - Declared variant types (`type Shape = | Circle(radius: float) | Point`)
 //!   — nominal, by name, like records.
 //! - `List<T>`.
 //! - Function types, from lambda annotations
-//!   (`(a: Float, b: Float): Float => …`); an unannotated return type is the
+//!   (`(a: float, b: float): float => …`); an unannotated return type is the
 //!   body's type when that is known (inferred in a single quiet enrichment
 //!   pass — a *chain* of unannotated-return functions may stay Unknown).
 //!
@@ -84,8 +89,10 @@ use std::fmt;
 #[derive(Clone, PartialEq)]
 pub enum Type {
     /// Not known statically; compatible with everything (see module docs).
-    /// After B7 this is the GRADUAL seam only (host values, unknown
-    /// uppercase type names) — unannotated code gets real [`Type::Var`]s.
+    /// After B7 this is the GRADUAL seam only (host values, and the
+    /// explicitly-written `unknown` annotation) — unannotated code gets real
+    /// [`Type::Var`]s, and an unrecognized type NAME is now an error rather
+    /// than a silent arrival here.
     Unknown,
     /// An inference variable (B7). Solved through the checker's
     /// substitution; a variable still free after a def's inference is
@@ -389,6 +396,21 @@ fn nearest_member(member: &str, members: &[&'static str]) -> Option<&'static str
         .filter(|(distance, _)| *distance <= budget)
         .min_by_key(|(distance, name)| (*distance, *name))
         .map(|(_, name)| name)
+}
+
+/// The primitive a capitalized/aliased spelling was reaching for. Functor
+/// Lang's primitives are lowercase, but nearly every other language
+/// capitalizes them, so `Float`/`String`/`Bool` are the mistake people
+/// actually make — and `Int`/`Number`/`Double` name a type Functor Lang
+/// doesn't have (all numbers are `float`).
+fn miscased_primitive(name: &str) -> Option<&'static str> {
+    match name.to_lowercase().as_str() {
+        "float" | "int" | "integer" | "number" | "double" | "num" => Some("float"),
+        "string" | "str" | "text" => Some("string"),
+        "bool" | "boolean" => Some("bool"),
+        "unknown" | "any" | "dynamic" | "obj" | "object" => Some("unknown"),
+        _ => None,
+    }
 }
 
 /// Levenshtein distance, for [`nearest_member`]'s typo suggestions.
@@ -1259,10 +1281,11 @@ impl Checker<'_> {
         (renumber_with(&a, &order), renumber_with(&b, &order))
     }
 
-    /// Resolve an annotation to a [`Type`]. Unknown type *names* are not
-    /// errors (they may be generics like `T`); a recognized name applied at
-    /// the wrong arity is. `report: false` resolves silently (the signature
-    /// pre-pass, whose annotations the body pass resolves again).
+    /// Resolve an annotation to a [`Type`]. An unrecognized type *name* is an
+    /// error (generics are spelled `'a`, and the dynamic seam is spelled
+    /// `unknown` — so nothing legitimate is unrecognized); so is a recognized
+    /// name applied at the wrong arity. `report: false` resolves silently (the
+    /// signature pre-pass, whose annotations the body pass resolves again).
     fn resolve_type(&mut self, ty: &TypeName, report: bool) -> Type {
         let arity_error = |checker: &mut Checker, takes: usize| {
             if report {
@@ -1287,6 +1310,18 @@ impl Checker<'_> {
                     "string" => Type::String,
                     _ => Type::Bool,
                 }
+            }
+            // The EXPLICIT gradual seam: `unknown` is compatible with
+            // everything and disables checking at that position on purpose
+            // (a host payload whose real type only the two ends know — see
+            // `Net.Data`'s value). Every OTHER unrecognized name is an error,
+            // so opting out of checking is a thing you write, not a typo you
+            // get away with.
+            "unknown" => {
+                if !ty.args.is_empty() {
+                    return arity_error(self, 0);
+                }
+                Type::Unknown
             }
             "List" => {
                 if ty.args.len() != 1 {
@@ -1363,15 +1398,84 @@ the type: `type Name<{name}> = …`"
                 self.annot_vars.insert(name.to_string(), var.clone());
                 var
             }
-            // Unrecognized UPPERCASE names stay Unknown — the gradual seam
-            // for host-side types this module doesn't declare. Still resolve
-            // any arguments so nested annotations get their diagnostics.
+            // An unrecognized name is an ERROR, not a silent `Unknown`. This
+            // used to be the gradual seam, and it was a trap: `let x: Float =
+            // "hi"` typechecked clean, because miscased `Float` resolved to
+            // `Unknown` and disabled checking at that position instead of
+            // meaning `float`. The seam is still reachable — you write
+            // `unknown` for it — but you now have to MEAN it.
+            //
+            // Arguments still resolve first, so nested annotations report too.
             _ => {
                 for arg in &ty.args {
                     self.resolve_type(arg, report);
                 }
+                if report {
+                    let message = self.unknown_type_message(&ty.name);
+                    self.diag(ty.span, message);
+                }
                 Type::Unknown
             }
+        }
+    }
+
+    /// The teaching message for an unrecognized type name, with a
+    /// did-you-mean when one is confident enough to name.
+    ///
+    /// The overwhelmingly common case is a MISCASED primitive — `Float` for
+    /// `float` — because every other language spells them capitalized. That
+    /// gets a flat, certain correction. Otherwise the name is matched against
+    /// everything actually in scope (primitives, `unknown`, and the declared
+    /// record/variant types), case-insensitively first — `NetEvnt` for
+    /// `NetEvent` is still a typo of a real type — then by typo-scale edit
+    /// distance. With no confident candidate the message points at the two
+    /// real options: declare the type, or say `unknown` on purpose.
+    fn unknown_type_message(&self, name: &str) -> String {
+        let head = format!("unknown type name `{name}`");
+        if let Some(prim) = miscased_primitive(name) {
+            // Distinguish "you capitalized it" from "that type doesn't
+            // exist here": `Int`/`Number` are not miscasings of `float`,
+            // they are a different type system's idea of numbers.
+            let why = if name.to_lowercase() == prim {
+                "Functor Lang's primitive types are lowercase"
+            } else if prim == "float" {
+                "Functor Lang has a single number type, `float`"
+            } else {
+                "that is how Functor Lang spells it"
+            };
+            return format!("{head} — did you mean `{prim}`? ({why})");
+        }
+        let mut candidates: Vec<&str> = vec!["float", "string", "bool", "unknown", "List"];
+        candidates.extend(self.records.keys().map(String::as_str));
+        candidates.extend(self.variants.keys().map(String::as_str));
+        // A pure case difference is a certain hit; only then fall back to
+        // edit distance, budgeted like `nearest_member` so an honestly-novel
+        // name suggests nothing rather than something misleading.
+        let lowered = name.to_lowercase();
+        let near = candidates
+            .iter()
+            .find(|c| c.to_lowercase() == lowered)
+            .copied()
+            .or_else(|| {
+                // Distance is measured case-INSENSITIVELY, so `Flaot` reads as
+                // a two-edit typo of `float` rather than a three-edit one that
+                // spends its whole budget on the capital F. Budget: 2 for a
+                // name long enough that two edits still leave it recognizable,
+                // 1 for short names where 2 edits could reach anything.
+                let budget = if name.chars().count() >= 4 { 2 } else { 1 };
+                candidates
+                    .iter()
+                    .map(|c| (edit_distance(&lowered, &c.to_lowercase()), *c))
+                    .filter(|(distance, _)| *distance <= budget)
+                    .min_by_key(|(distance, c)| (*distance, *c))
+                    .map(|(_, c)| c)
+            });
+        match near {
+            Some(near) => format!("{head} — did you mean `{near}`?"),
+            None => format!(
+                "{head} — declare it (`type {name} = …`), or write `unknown` \
+if this position is deliberately untyped"
+            ),
         }
     }
 

--- a/functor-lang/tests/check.rs
+++ b/functor-lang/tests/check.rs
@@ -500,6 +500,39 @@ fn typos_suggest_the_nearest_declared_type() {
     assert!(message.contains("did you mean `float`?"), "{message}");
 }
 
+/// A DECLARED type beats the built-in correction table: a project that
+/// declares `Number` gets its own type suggested, not `float`.
+#[test]
+fn a_declared_type_wins_over_the_primitive_table() {
+    let (message, _, _) = single_diag("type Number = { n: float }\nlet f = (x: number) => x");
+    assert!(message.contains("did you mean `Number`?"), "{message}");
+}
+
+/// `Any`/`Object` must NOT be answered with "did you mean `unknown`?" —
+/// that would recommend the check-disabling seam as a typo fix.
+#[test]
+fn dynamic_sounding_names_do_not_recommend_the_seam() {
+    for bad in ["Any", "Object", "Dynamic"] {
+        let (message, _, _) = single_diag(&format!("let f = (x: {bad}) => x"));
+        assert!(
+            !message.contains("did you mean `unknown`"),
+            "`{bad}` must not be corrected TO the seam: {message}"
+        );
+        assert!(message.contains("declare it"), "{message}");
+    }
+}
+
+/// A bare lowercase name in type position is usually a type variable
+/// written without its apostrophe — say so rather than "declare it".
+#[test]
+fn a_bare_lowercase_name_suggests_the_type_variable_spelling() {
+    let (message, _, _) = single_diag("let f = (xs: List<zz>) => xs");
+    assert_eq!(
+        message,
+        "unknown type name `zz` — a type variable is spelled `'zz`"
+    );
+}
+
 /// With no confident candidate, the message names the two real ways out
 /// instead of guessing.
 #[test]

--- a/functor-lang/tests/check.rs
+++ b/functor-lang/tests/check.rs
@@ -446,15 +446,107 @@ fn error_type_argument_arity() {
     assert_eq!(message, "`List` takes 1 type argument(s), got 0");
 }
 
+// An unrecognized type name is an ERROR. It used to resolve silently to
+// `Unknown`, which disabled checking at that position — the trap that let
+// `let x: Float = "hi"` typecheck clean. A generic parameter is spelled
+// `'a`, not `T`, so nothing legitimate relied on the fall-through.
+#[test]
+fn unknown_type_name_is_an_error() {
+    let (message, line, col) = single_diag("let id = (x: 'a): T => x");
+    assert!(message.starts_with("unknown type name `T`"), "{message}");
+    assert_eq!((line, col), (1, 19));
+}
+
+/// The headline case: a miscased primitive is certainly wrong, and says so
+/// with the exact correction.
+#[test]
+fn miscased_primitives_suggest_the_lowercase_spelling() {
+    for (bad, good) in [("Float", "float"), ("String", "string"), ("Bool", "bool")] {
+        let (message, _, _) = single_diag(&format!("let x: {bad} = 1.0"));
+        assert_eq!(
+            message,
+            format!(
+                "unknown type name `{bad}` — did you mean `{good}`? \
+(Functor Lang's primitive types are lowercase)"
+            )
+        );
+    }
+}
+
+/// A type from another language's number tower is not a *casing* mistake, so
+/// it gets its own explanation rather than a misleading one.
+#[test]
+fn foreign_number_types_point_at_float() {
+    for bad in ["Int", "Integer", "Number", "Double"] {
+        let (message, _, _) = single_diag(&format!("let x: {bad} = 1.0"));
+        assert_eq!(
+            message,
+            format!(
+                "unknown type name `{bad}` — did you mean `float`? \
+(Functor Lang has a single number type, `float`)"
+            )
+        );
+    }
+}
+
+/// A typo of a DECLARED type suggests that type — matched case-insensitively
+/// so the capital doesn't eat the edit budget.
+#[test]
+fn typos_suggest_the_nearest_declared_type() {
+    let (message, _, _) = single_diag("type Point = { x: float }\nlet f = (p: Pont) => p");
+    assert!(message.contains("did you mean `Point`?"), "{message}");
+
+    let (message, _, _) = single_diag("let x: Flaot = 1.0");
+    assert!(message.contains("did you mean `float`?"), "{message}");
+}
+
+/// With no confident candidate, the message names the two real ways out
+/// instead of guessing.
+#[test]
+fn a_novel_name_suggests_nothing_and_teaches_the_options() {
+    let (message, _, _) = single_diag("let f = (x: Quaternion) => x");
+    assert_eq!(
+        message,
+        "unknown type name `Quaternion` — declare it (`type Quaternion = …`), \
+or write `unknown` if this position is deliberately untyped"
+    );
+}
+
+/// The trap itself: previously silent, now diagnosed — and once the
+/// annotation is spelled correctly, it actually checks.
+#[test]
+fn the_miscased_annotation_trap_is_closed() {
+    let (message, _, _) = single_diag("let x: Float = \"hi\"");
+    assert!(message.starts_with("unknown type name `Float`"), "{message}");
+
+    let (message, _, _) = single_diag("let x: float = \"hi\"");
+    assert_eq!(message, "`x`: expected float, got string");
+}
+
 // Gradual typing: these must NOT error.
 
-// …but an *unknown* type name is not an error — it may be a generic
-// parameter (`T`) or a type this module doesn't declare.
+/// `unknown` is the EXPLICIT dynamic seam — it absorbs anything in both
+/// directions, which is what host payloads (`Net.Data`'s value) need.
 #[test]
-fn unknown_type_names_are_not_errors() {
-    assert_clean("let id = (x: T): T => x");
-    // An Unknown annotation checks against nothing, even with a known body.
-    assert_clean("let f = (x: T): T => 1.0");
+fn unknown_is_a_writable_gradual_seam() {
+    assert_clean("let f = (x: unknown): unknown => x");
+    assert_clean("let f = (x: unknown): float => x");
+    assert_clean("let f = (x: float): unknown => x");
+    assert_clean("let f = (x: unknown): string => x");
+}
+
+/// Every legitimate annotation form still resolves — the error must not
+/// catch primitives, generics, containers, or declared nominals.
+#[test]
+fn legitimate_type_names_still_resolve() {
+    assert_clean("let x: float = 1.0");
+    assert_clean("let x: List<float> = [1.0]");
+    assert_clean("let x: (float, string) = (1.0, \"s\")");
+    assert_clean("let f: (float) => float = (n: float) => n");
+    assert_clean("let f = (xs: List<'a>, g: ('a) => 'b): List<'b> => List.map(g, xs)");
+    assert_clean("type Point = { x: float }\nlet f = (p: Point) => p.x");
+    assert_clean("type Box<'a> = | Wrap(v: 'a)\nlet f = (b: Box<float>) => b");
+    assert_clean("type Opaque\nlet f = (o: Opaque) => o");
 }
 
 #[test]

--- a/functor-lang/tests/ir.rs
+++ b/functor-lang/tests/ir.rs
@@ -113,6 +113,11 @@ fn error_redeclare_builtin_type() {
     assert_eq!(message, "cannot redeclare builtin type `float`");
     let (message, _, _) = lower_err("type List = { head: float }");
     assert_eq!(message, "cannot redeclare builtin type `List`");
+    // `unknown` is reserved for the same reason: `resolve_type` answers it
+    // before consulting declared types, so a user's `type unknown` could
+    // never be reached from an annotation.
+    let (message, _, _) = lower_err("type unknown = { x: float }");
+    assert_eq!(message, "cannot redeclare builtin type `unknown`");
 }
 
 /// A lowering error's position points at the offending identifier itself.

--- a/functor-lang/tests/recorder.rs
+++ b/functor-lang/tests/recorder.rs
@@ -65,7 +65,7 @@ fn records_let_bindings_and_params_and_result() {
 
 #[test]
 fn records_match_binders() {
-    let src = "type Shape = | Circle(radius: Float) | Square(side: Float)\n\
+    let src = "type Shape = | Circle(radius: float) | Square(side: float)\n\
                let area = (shape) =>\n  \
                match shape with\n  \
                | Circle(r) => r + 1.0\n  \

--- a/site/manual/index.html
+++ b/site/manual/index.html
@@ -69,7 +69,7 @@ npm run build:cli                    # builds the functor CLI + runtimes</pre>
           <p>And the game itself — here is the smallest interesting one:</p>
           <pre class="functor-lang runnable">let init = {}
 let tick = (m, dt, tts) => m
-let draw = (m, tts: Float) =>
+let draw = (m, tts: float) =>
   Frame.create(
     Camera.lookAt(Vec3.make(0.0, 2.0, -6.0), Vec3.make(0.0, 0.0, 0.0)),
     Scene.cube()
@@ -102,7 +102,7 @@ type Msg = | Beat
 
 let init = { spin: 0.0, beat: 0.0 }
 
-let tick = (model, dt: Float, tts: Float) =>
+let tick = (model, dt: float, tts: float) =>
   { model with spin: model.spin + dt }
 
 let update = (model, msg) =>
@@ -111,7 +111,7 @@ let update = (model, msg) =>
 
 let subscriptions = (model) => Sub.every(Time.seconds(1.0), Beat)
 
-let draw = (model, tts: Float) =>
+let draw = (model, tts: float) =>
   Frame.create(
     Camera.lookAt(Vec3.make(0.0, 2.0, -6.0), Vec3.make(0.0, 0.0, 0.0)),
     Scene.sphere()
@@ -238,7 +238,7 @@ let draw = (m, tts) =>
           <h2>The language</h2>
 
           <h3>Values and bindings</h3>
-          <pre class="functor-lang">let threshold = 10          // every number is a Float (f64)
+          <pre class="functor-lang">let threshold = 10          // every number is a float (f64)
 let name = "neon\n"         // strings: \" \\ \n \t
 let on = true
 let origin = { x: 0.0, y: 0.0 }
@@ -250,32 +250,39 @@ let scores = [1.0, 2.0, 3.0]</pre>
           </p>
 
           <h3>Functions</h3>
-          <pre class="functor-lang">let area = (w: Float, h: Float): Float => w * h   // annotations optional
+          <pre class="functor-lang">let area = (w: float, h: float): float => w * h   // annotations optional
 let describe = (score) => Text.concat("score: ", Text.fromFloat(score))</pre>
           <p>
             Typing uses Hindley–Milner inference with let-polymorphism: unannotated code still
-            gets full types, and bad calls or mixed-element lists are errors. <em>Gradual</em>
-            <code>Unknown</code> values remain only at genuinely dynamic seams. Annotations make
+            gets full types, and bad calls or mixed-element lists are errors. Annotations make
             intent explicit; <code>functor build</code> reports all diagnostics. Evaluation depth
             is capped at 128 — deep iteration belongs in <code>List.*</code>.
           </p>
+          <p>
+            <strong>Type names are lowercase</strong> — <code>float</code>, <code>string</code>,
+            <code>bool</code>. Writing <code>Float</code> is an error with a did-you-mean, as is
+            <code>Int</code> or <code>Number</code> (there is one number type,
+            <code>float</code>). The one <em>gradual</em> annotation is <code>unknown</code>,
+            which is compatible with everything — write it where a value is genuinely dynamic
+            (a host payload only the two ends can type), and nowhere else.
+          </p>
 
           <h3>Records</h3>
-          <pre class="functor-lang">type Position = { x: Float, y: Float }        // nominal in annotations
+          <pre class="functor-lang">type Position = { x: float, y: float }        // nominal in annotations
 
 let p = { x: 0.0, y: 1.0 }
 let nudged = { p with x: p.x + 1.0 }          // update: fields must exist</pre>
 
           <h3>Variants and match</h3>
           <pre class="functor-lang">type Shape =
-  | Circle(radius: Float)     // leading | required — first alternative too
-  | Rect(w: Float, h: Float)
+  | Circle(radius: float)     // leading | required — first alternative too
+  | Rect(w: float, h: float)
   | Point                     // nullary: no parens, ever
 
 let c = Circle(2.0)           // constructors are CALLED positionally
 let shapes = [c, Rect(3.0, 4.0), Point]
 
-let area = (s: Shape): Float =>
+let area = (s: Shape): float =>
   match s with
   | Circle(r) => 3.14 * r * r // ctor patterns bind positionally
   | Rect(w, _) => w * w       // sub-patterns: names or _ only (no nesting)
@@ -303,7 +310,7 @@ let area = (s: Shape): Float =>
             <code>else if</code>; there is no <code>elif</code> keyword. A bool-literal
             <code>match</code> is equally valid.
           </p>
-          <pre class="functor-lang">let sizeOf = (n: Float): String =>
+          <pre class="functor-lang">let sizeOf = (n: float): string =>
   if n > 100.0 then "huge"
   else if n > 10.0 then "big"
   else "small"</pre>
@@ -324,7 +331,7 @@ let report = (scores) =>
     |> Text.toBullets</pre>
 
           <h3>Tuples</h3>
-          <pre class="functor-lang">let minMax = (a: Float, b: Float): Float * Float =>
+          <pre class="functor-lang">let minMax = (a: float, b: float): float * float =>
   match a &lt; b with
   | true => (a, b)            // (e) is grouping, not a 1-tuple
   | false => (b, a)
@@ -459,7 +466,7 @@ let pos = model.pos |> Vec3.add(step)</pre>
             each axis independently. The primitives have no size arguments, so
             <code>scaleXYZ</code> is how you get a <em>box</em> — a platform, a wall, a slab:
           </p>
-          <pre class="functor-lang">let platform = (w: Float, h: Float, d: Float) =>
+          <pre class="functor-lang">let platform = (w: float, h: float, d: float) =>
   Scene.cube() |> Scene.scaleXYZ(w, h, d)   // Scene.cube() is 1×1×1, centered</pre>
 
           <h3>Camera, lights, frames</h3>

--- a/site/src/ide.tsx
+++ b/site/src/ide.tsx
@@ -107,9 +107,9 @@ const STARTER: Project = {
 // a .zip to run it with \`functor -d <dir> build wasm\`.
 let init = { t: 0.0 }
 
-let tick = (model, dt: Float, tts: Float) => { model with t: model.t + dt }
+let tick = (model, dt: float, tts: float) => { model with t: model.t + dt }
 
-let draw = (model, tts: Float) =>
+let draw = (model, tts: float) =>
   Frame.create(
     Camera.lookAt(Vec3.make(0.0, 2.0, -6.0), Vec3.make(0.0, 0.5, 0.0)),
     Scene.group([

--- a/tools/functor-lang-lsp/src/main.rs
+++ b/tools/functor-lang-lsp/src/main.rs
@@ -378,8 +378,11 @@ fn run(
             ("textDocument/didOpen", None) => {
                 let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
                 let text = params["textDocument"]["text"].as_str().unwrap_or("");
-                publish_diagnostics(writer, uri, text);
+                // Insert BEFORE checking: the project loader stands each open
+                // buffer in for its on-disk file, so this document must already
+                // be in the map for its unsaved text to be the one checked.
                 documents.insert(uri.to_string(), text.to_string());
+                publish_diagnostics(writer, uri, text, &documents);
                 if let Some(project) = load_project(uri, &documents) {
                     projects.insert(uri.to_string(), project);
                 }
@@ -409,7 +412,7 @@ fn run(
                         Some(change_tx) => {
                             let _ = change_tx.send(uri.to_string());
                         }
-                        None => publish_diagnostics(writer, uri, text),
+                        None => publish_diagnostics(writer, uri, text, &documents),
                     }
                     if let Some(project) = load_project(uri, &documents) {
                         projects.insert(uri.to_string(), project);
@@ -451,8 +454,8 @@ fn run(
             // expect-evaluation worker for the settled state.
             ("$/functorFlush", None) => {
                 let uri = params["uri"].as_str().unwrap_or("");
-                if let Some(text) = documents.get(uri) {
-                    publish_diagnostics(writer, uri, text);
+                if let Some(text) = documents.get(uri).cloned() {
+                    publish_diagnostics(writer, uri, &text, &documents);
                     if expect_budget > 0 {
                         let generation = *expect_generations.get(uri).unwrap_or(&0);
                         spawn_expect_worker(uri, &documents, generation, expect_budget, &trace_tx);
@@ -591,9 +594,23 @@ fn spawn_expect_worker(
 }
 
 /// Run the Functor Lang front-end over `text` and publish the outcome: one diagnostic
-/// for the first parse/lower failure, every `functor_lang::check` type diagnostic for
-/// a lowered module, or an empty list (clearing squiggles) when clean.
-fn publish_diagnostics(writer: &mut impl Write, uri: &str, text: &str) {
+/// for the first parse/lower failure, every type diagnostic for a lowered module, or
+/// an empty list (clearing squiggles) when clean.
+///
+/// Parsing and lowering are per-buffer (syntax is a property of one file), but the
+/// TYPE check runs over the whole project when one loads — the engine prelude plus
+/// sibling modules. That is load-bearing now that an unrecognized type name is an
+/// error: checking a game buffer in isolation has no `Scene.t` / `Input.snapshot` /
+/// sibling `Utils.Shape` in scope, so every qualified annotation would squiggle red
+/// in the editor while `functor build` reported the file clean. Project diagnostics
+/// are filtered to the spans this file owns and localized back into it. The
+/// isolated check remains the fallback for a buffer with no loadable project.
+fn publish_diagnostics(
+    writer: &mut impl Write,
+    uri: &str,
+    text: &str,
+    documents: &HashMap<String, String>,
+) {
     let diagnostic = |message: &str, span: functor_lang::Span| {
         json!({
             "range": span_to_range(text, span),
@@ -603,7 +620,7 @@ fn publish_diagnostics(writer: &mut impl Write, uri: &str, text: &str) {
         })
     };
     // Parse and lowering stop at the first error; a clean module then gets
-    // ALL of the gradual checker's type diagnostics.
+    // ALL of the checker's type diagnostics.
     let parsed = if uri_to_path(uri)
         .and_then(|path| path.extension().map(|extension| extension == "funi"))
         .unwrap_or(false)
@@ -616,13 +633,40 @@ fn publish_diagnostics(writer: &mut impl Write, uri: &str, text: &str) {
         Err(err) => vec![diagnostic(&err.message, err.span)],
         Ok(program) => match functor_lang::lower(program) {
             Err(err) => vec![diagnostic(&err.message, err.span)],
-            Ok(module) => functor_lang::check(&module)
-                .into_iter()
-                .map(|err| diagnostic(&err.message, err.span))
-                .collect(),
+            Ok(module) => project_diagnostics(uri, documents)
+                .unwrap_or_else(|| {
+                    functor_lang::check(&module)
+                        .into_iter()
+                        .map(|err| diagnostic(&err.message, err.span))
+                        .collect()
+                }),
         },
     };
     write_diagnostics(writer, uri, diagnostics);
+}
+
+/// This file's type diagnostics, checked in the context of its whole project
+/// (engine prelude + siblings) and localized back to this buffer. `None` when no
+/// project loads for the URI, so the caller falls back to the isolated check.
+fn project_diagnostics(uri: &str, documents: &HashMap<String, String>) -> Option<Vec<Value>> {
+    let project = load_project(uri, documents)?;
+    let path = uri_to_path(uri)?;
+    let file = project.sources.file_by_path(&path)?;
+    Some(
+        project
+            .check()
+            .into_iter()
+            .filter(|err| owns(file, err.span.start))
+            .map(|err| {
+                json!({
+                    "range": local_range(file, err.span),
+                    "severity": 1, // Error
+                    "source": "functor-lang",
+                    "message": err.message,
+                })
+            })
+            .collect(),
+    )
 }
 
 /// Load the Functor Lang program an open document belongs to. With a `functor.json`
@@ -1432,6 +1476,7 @@ mod tests {
             &mut output,
             "file:///project/widget.funi",
             "type Handle\nlet size : (Handle) => float",
+            &HashMap::new(),
         );
         let output = String::from_utf8(output).unwrap();
         assert!(output.contains(r#""diagnostics":[]"#), "{output}");

--- a/tools/functor-lang-lsp/tests/e2e.rs
+++ b/tools/functor-lang-lsp/tests/e2e.rs
@@ -808,3 +808,57 @@ fn expect_statuses_over_real_stdio() {
     server.send(json!({ "jsonrpc": "2.0", "method": "exit" }));
     server.child.wait().expect("wait for exit");
 }
+
+/// Editor diagnostics are PROJECT-aware, not per-buffer. Now that an
+/// unrecognized type name is a hard error, checking a game buffer in
+/// isolation — with no engine prelude and no siblings in scope — would
+/// squiggle every qualified annotation (`Scene.t`, `Input.snapshot`) red
+/// while `functor build` reported the same file clean. Regression test for
+/// that divergence: annotations the project resolves must publish NO
+/// diagnostics, while a genuine error in the same buffer still does.
+#[test]
+fn prelude_type_annotations_do_not_squiggle() {
+    let mut server = Server::spawn();
+    server.send(json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": { "capabilities": {} },
+    }));
+    server.recv();
+    server.send(json!({ "jsonrpc": "2.0", "method": "initialized", "params": {} }));
+
+    let text = "let render = (s: Scene.t): Scene.t => s\n";
+    server.send(json!({
+        "jsonrpc": "2.0", "method": "textDocument/didOpen",
+        "params": { "textDocument": {
+            "uri": URI, "languageId": "functor-lang", "version": 1, "text": text,
+        } },
+    }));
+    let published = server.recv();
+    assert_eq!(
+        published["params"]["diagnostics"],
+        json!([]),
+        "`Scene.t` is a real prelude type — it must not be reported unknown: {published}"
+    );
+
+    // …but a genuinely unknown type name in the same buffer still errors.
+    let broken = "let render = (s: Scene.t): Nonsuch => s\n";
+    server.send(json!({
+        "jsonrpc": "2.0", "method": "textDocument/didChange",
+        "params": {
+            "textDocument": { "uri": URI },
+            "contentChanges": [{ "text": broken }],
+        },
+    }));
+    let published = server.recv();
+    let message = published["params"]["diagnostics"][0]["message"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(
+        message.contains("unknown type name `Nonsuch`"),
+        "a real unknown type must still be diagnosed: {published}"
+    );
+
+    server.send(json!({ "jsonrpc": "2.0", "id": 2, "method": "shutdown" }));
+    server.recv_until("shutdown reply", |message| message["id"] == 2);
+    server.send(json!({ "jsonrpc": "2.0", "method": "exit" }));
+    server.child.wait().expect("wait for exit");
+}

--- a/tools/functor-lang-vscode/syntaxes/functor-lang.tmLanguage.json
+++ b/tools/functor-lang-vscode/syntaxes/functor-lang.tmLanguage.json
@@ -127,7 +127,7 @@
     "primitive-type": {
       "comment": "The lowercase primitive types (F#/OCaml convention)",
       "name": "support.type.primitive.functor",
-      "match": "\\b(float|bool|string)\\b"
+      "match": "\\b(float|bool|string|unknown)\\b"
     },
     "type-name": {
       "comment": "Any other uppercase identifier is a type: `type` decl names, annotations after `:`, and generic arguments (`List<float>`)",

--- a/tools/functor-lang-wasm/src/lib.rs
+++ b/tools/functor-lang-wasm/src/lib.rs
@@ -504,7 +504,7 @@ mod tests {
     // one def is reported).
     #[test]
     fn valid_program_with_prelude_is_clean() {
-        let src = "let draw = (model, tts: Float) =>\n  \
+        let src = "let draw = (model, tts: float) =>\n  \
             Frame.create(Camera.lookAt(Vec3.make(0.0, 0.0, -6.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n";
         let out = parse(&analyze_json(src));
         assert_eq!(out["diagnostics"].as_array().unwrap().len(), 0, "{out}");
@@ -733,7 +733,7 @@ mod tests {
     // The IDE's two-file starter shape: game.fun references a sibling module.
     // Single-file analyze errors on the unknown `Palette`; the project variant
     // resolves it — the reason the `_project` API exists.
-    const GAME: &str = "let draw = (model, tts: Float) =>\n  \
+    const GAME: &str = "let draw = (model, tts: float) =>\n  \
         Frame.create(Camera.lookAt(Vec3.make(0.0, 0.0, -6.0), Vec3.make(0.0, 0.0, 0.0)), \
         Scene.sphere() |> Scene.emissive(Color.rgb(0.15, 1.0, Palette.glow)))\n";
     const PALETTE: &str = "let glow = 0.85\nlet sky = 0.18\n";
@@ -761,12 +761,13 @@ mod tests {
         }
 
         // The observable difference from the single-file pass: the sibling
-        // member RESOLVES. Single-file, `Palette` is tolerated but Unknown;
-        // with the project, `Palette.glow` types as float.
+        // member RESOLVES. Single-file, `Palette` is tolerated but `unknown`
+        // (the seam prints as it is written); with the project, `Palette.glow`
+        // types as float.
         let member = GAME.find("Palette.glow").unwrap() + "Palette.".len();
         let offset = utf16_len(&GAME[..member]);
         let single = parse(&hover_json(GAME, offset));
-        assert!(single["text"].as_str().unwrap().contains("Unknown"), "{single}");
+        assert!(single["text"].as_str().unwrap().contains("unknown"), "{single}");
         let project = parse(&hover_project_json(&files, "game.fun", offset));
         assert!(project["text"].as_str().unwrap().contains("float"), "{project}");
     }

--- a/tools/functor-sdk/test/functor-lang-effects.e2e.test.ts
+++ b/tools/functor-sdk/test/functor-lang-effects.e2e.test.ts
@@ -18,8 +18,8 @@ const e2eEnabled = process.env.FUNCTOR_E2E === "1";
 const headless = process.env.FUNCTOR_E2E_HEADLESS === "1";
 
 const game = `type Msg =
-  | Rolled(n: Float)
-  | Stamped(t: Float)
+  | Rolled(n: float)
+  | Stamped(t: float)
 let init = { roll: -1.0, at: -1.0 }
 let tick = (m, dt, tts) => m
 let update = (m, msg) =>

--- a/tools/functor-sdk/test/functor-lang-perf.e2e.test.ts
+++ b/tools/functor-sdk/test/functor-lang-perf.e2e.test.ts
@@ -53,7 +53,7 @@ const GATE_US = BUDGET_US * 0.6;
 const ENTITIES = 100;
 const heavyGame = `let tau = 6.2831853
 
-let entity = (i: Float) => { i: i, phase: i * 0.618 }
+let entity = (i: float) => { i: i, phase: i * 0.618 }
 
 let init = { entities: List.range(${ENTITIES}) |> List.map(entity) }
 
@@ -61,18 +61,18 @@ let init = { entities: List.range(${ENTITIES}) |> List.map(entity) }
 let tick = (m, dt, tts) =>
   { m with entities: m.entities |> List.map((e) => { e with phase: e.phase + dt }) }
 
-let pointPos = (i: Float, tts: Float) =>
+let pointPos = (i: float, tts: float) =>
   let a = tts * 0.6 + i * (tau / 2.0) in
   { x: Math.cos(a) * 4.0, y: 2.4, z: Math.sin(a) * 4.0 }
 
-let marker = (i: Float, tts: Float, r: Float, g: Float, b: Float) =>
+let marker = (i: float, tts: float, r: float, g: float, b: float) =>
   let p = pointPos(i, tts) in
   Scene.sphere()
     |> Scene.scale(0.15)
     |> Scene.emissive(Color.rgb(r, g, b))
     |> Scene.translate(Vec3.make(p.x, p.y, p.z))
 
-let pointLight = (i: Float, tts: Float, r: Float, g: Float, b: Float) =>
+let pointLight = (i: float, tts: float, r: float, g: float, b: float) =>
   let p = pointPos(i, tts) in
   Light.point(Vec3.make(p.x, p.y, p.z), Color.rgb(r, g, b), 1.4, 6.0)
 
@@ -86,7 +86,7 @@ let shapeFor = (e) =>
     |> Scene.rotateY(Angle.radians(e.phase))
     |> Scene.translate(Vec3.make(Math.cos(a) * r, 0.4 + Math.sin(e.phase) * 0.2, Math.sin(a) * r))
 
-let draw = (m, tts: Float) =>
+let draw = (m, tts: float) =>
   Frame.createLit(
     Camera.firstPerson(
       Vec3.make(0.0, 9.0, -16.0),


### PR DESCRIPTION
## The trap

A miscased or misspelled type annotation resolved to `Type::Unknown`, which is compatible with everything. So this typechecked **clean**:

```functor
let x: Float = "hi"                      // exit 0, no diagnostics
let f = (n: Float): Float => "not a num" // both annotations inert
```

Functor Lang's primitives are lowercase (`float`/`string`/`bool`), but every other language capitalizes them — so the natural spelling silently turned the binding into a dynamic seam and threw away every diagnostic the annotation was written to get.

**Three strikes.** Three independent game-jam workstreams hit this, and it was promoted repeatedly:

1. The manual's own examples used `Float` (pool D-7/D11).
2. Nine inert annotations shipped in the promoted shooting-range example (since fixed).
3. `examples/inspector/game.fun` had it live on `main` (fixed here).

Plus a fourth, found while fixing: **the language's own bundled `Net` module** declared its fields `Float`/`String`, so `NetEvent`'s field types were all `Unknown`.

## The fix

An unrecognized type name is now a check **error** with a did-you-mean. The gradual seam survives — but you have to write it: **`unknown`** is a real annotation that resolves to `Type::Unknown` on purpose.

That distinction is the whole design. Opting out of checking should be something you *say*, not something you get by mistyping.

### Case table

| Case | Verdict | Message | Rationale |
| --- | --- | --- | --- |
| Miscased primitive (`Float`, `String`, `Bool`) | **error** | ``did you mean `float`? (Functor Lang's primitive types are lowercase)`` | Certainly wrong; the exact correction is knowable |
| Foreign number type (`Int`, `Integer`, `Number`, `Double`) | **error** | ``did you mean `float`? (Functor Lang has a single number type, `float`)`` | Not a casing mistake — a different type system's idea of numbers, so it gets its own explanation |
| Typo of a declared type (`Pont` → `Point`) | **error** | ``did you mean `Point`?`` | Matched case-insensitively, budgeted edit distance |
| Unqualified member of a qualified type (`Model` → `Asset.Model`) | **error** | ``did you mean `Asset.Model`?`` | Candidates match on their member part; "declare it" would misdirect when the type exists |
| Bare lowercase name (`zz`) | **error** | ``a type variable is spelled `'zz` `` | Type variables are apostrophe-prefixed; this is the second-likeliest mistake |
| Qualified miss (`Foo.Bar`) | **error** | ``that module declares no such type…`` | `type Foo.Bar = …` does not parse, so "declare it" is bad advice |
| Novel name (`Quaternion`) | **error** | ``declare it (`type Quaternion = …`), or write `unknown`…`` | No confident candidate — name the two real options rather than guess |
| **`unknown`** | **allowed** | — | The explicit dynamic seam; absorbs anything, both directions |
| `Any` / `Object` / `Dynamic` | **error, no seam suggestion** | falls through to the neutral message | Answering these with "did you mean `unknown`?" would recommend the check-disabling escape hatch as a typo fix — reinstating the very trap this closes |
| Primitives, generics `'a`, `List<T>`, tuples, fn types, records, variants, abstract types, `Scene.t` | **unchanged** | — | Negative controls, all tested |

**Error, not warning.** Repo precedent is teaching errors (`build` treats diagnostics as errors; the closed-builtin-namespace change shipped as hard errors). The blast-radius measurement below made that affordable.

## Blast radius — measured, not assumed

I instrumented the `Type::Unknown` fall-through and swept **all 32 example entries**. Only three names reached it repo-wide:

| Name | Hits | Source |
| --- | --- | --- |
| `Float` | 198 | 192 from the bundled `Net` module (6 × 32 projects) + **6 in `examples/inspector`** |
| `String` | 128 | all bundled `Net` (4 × 32) |
| `NetData` | 32 | all bundled `Net` (1 × 32) |

Every example sat at an identical floor of 11 hits — which *was the bundled prelude itself*. The only example above the floor was `examples/inspector`.

**Zero legitimate uses of unknown type names anywhere in the repo.** Nothing depended on the fall-through, so a hard error breaks nothing that was working.

### Diagnostics that changed, and why each is correct

- `examples/inspector/game.fun` — 6 miscased `Float` → `float`. The annotations were wrong; they were checking nothing. **Fixed here.**
- Bundled `Net` module (`functor-lang/src/project.rs`) — `Float`/`String` → `float`/`string`. The language's own source now passes its own checker. **Fixed here.**
- `Net.Data`'s payload — was the undeclared name `NetData`, documented in-source as a *deliberate* seam. That's exactly the case `unknown` exists for, so it is now `value: unknown`. Same resolved type, now explicit and greppable.
- Test/tooling snippets that would newly fail: `functor-lang/tests/recorder.rs`, the two `tools/functor-sdk` e2e `.fun` programs. **Fixed.**
- After the fixes: **all 32 example entries typecheck clean.**

## Review dispositions (`/xreview` — Claude subagent + Codex CLI)

No Critical findings from either engine. All High/Medium dispositioned:

| # | Finding | Engines | Disposition |
| --- | --- | --- | --- |
| 1 | **LSP squiggles valid prelude annotations.** `publish_diagnostics` typechecked each buffer in ISOLATION — no prelude, no siblings — so `Scene.t` / `Input.snapshot` would show as errors in the editor while `functor build` called the file clean | Codex (High) | **Fixed.** The type check now runs over the loaded project and localizes diagnostics back to the buffer; isolated check remains the fallback. Regression test added — **verified failing without the fix** |
| 2 | **Site starter + manual teach the now-erroring spelling.** `site/src/ide.ts`'s downloadable starter and ~11 manual code blocks used `Float`/`String` | **[AGREED]** (High) | **Fixed.** Both lowercased; the manual now documents the lowercase rule and `unknown` |
| 3 | **Suggestions can't reach module-qualified types** — `Model` never suggests `Asset.Model` | Claude (High) | **Fixed.** Candidates match on their member part too |
| 4 | **`Any`/`Object`/`Dynamic` → "did you mean `unknown`?"** recommends the escape hatch as a typo fix | **[AGREED]** (Medium) | **Fixed.** Removed from the table; they fall through to the neutral message |
| 5 | **`miscased_primitive` shadows a declared type** — a project's own `type Number` got "did you mean `float`?" | **[AGREED]** (Medium) | **Fixed.** Declared types are now consulted *first* |
| 6 | **`type unknown` collision** — a user could declare it but no annotation could ever reach it | **[AGREED]** (Medium) | **Fixed.** Reserved in lowering, like `float`/`bool`/`string`/`List` |
| 7 | Bare lowercase generic got "declare it (`type a = …`)" | Claude (Medium) | **Fixed.** Now teaches the `'a` spelling |
| 8 | `Type::Unknown` displayed as `Unknown`, which is an *error* if written | Claude (Medium) | **Fixed.** Prints `unknown`, so a type copied out of hover still checks |
| 9 | Qualified fallback suggested the unparseable `type Foo.Bar = …` | Claude (Medium) | **Fixed.** Distinct message for qualified misses |
| 10 | `docs/functor-lang.md` lines 176/427 describe the old seam | Claude (Low) | **Won't fix — deliberate.** These are historical `[x] done` roadmap entries (B4/B7) recording what each milestone shipped. Rewriting them would falsify the roadmap record |

Both engines independently confirmed: no duplicate diagnostics (each annotation reports once — the signature pre-pass is `report: false`), and the `.funi` prelude resolves cleanly. No duplication signals.

## Docs

- **`functor-lang` skill** — the loud ⚠️ Float-casing section rewritten: the rule, the new error, `unknown`, and a historical note that older code's `Float` annotations were never checking anything (so fixing the casing may surface real errors that were always there). Net module description updated; the stale "unrecognized type names are a gradual seam" line corrected.
- **`site/manual/index.html`** — lowercase annotations throughout, plus a new paragraph on the casing rule and `unknown`.
- **`docs/multiplayer.md`** — the `NetEvent` signature.
- Module docs in `types.rs`/`ir.rs` (which themselves used `Float`).

## Compat note

**Previously-silent code may now fail `build` — that is the point.** Any `.fun` with a miscased or misspelled annotation now errors. The fix is mechanical (lowercase the primitive, or correct the type name), and the diagnostic names it exactly. Code that genuinely needs a dynamic position writes `unknown`.

Two smaller behavior changes ride along: `type unknown` is now refused (as `float`/`List` already were), and `Type::Unknown` renders as `unknown` in hover/errors.

## Verification

- `cargo test -p functor-lang` — **all pass** (incl. new diagnostic + negative-control tests)
- `cargo test -p functor_runtime_common` — **533 pass**
- `cargo test -p functor-lang-lsp` — pass, incl. the new project-diagnostics regression test. One pre-existing failure (`prelude_gives_host_calls_real_types`, a `.funi` doc-string mismatch) **confirmed failing identically on `main`** — unrelated
- Full examples sweep — **all 32 entries clean**
- `npm run check:docs` — pass
- `cargo build --workspace` — clean (CLI excluded; it needs the wasm bundle CI builds)

Not run: golden images (needs a GL display) and `frame_bench` — this is a check-time-only change with no per-frame path touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
