### PR TITLE
feat(web): mountScrubber({ hidden }) — the seam without the chrome

### DIFF
--- a/runtime/functor-runtime-web/scrubber.js
+++ b/runtime/functor-runtime-web/scrubber.js
@@ -187,18 +187,26 @@ const HTML = `
     </div>
   </details>`;
 
-export function mountScrubber() {
-  if (!document.getElementById("functor-scrubber-style")) {
+// `hidden: true` mounts the SEAM without the chrome: the timeline model, the
+// runtime poll loop, and `window.__scrub` all run exactly as usual, but the
+// bar's DOM is never attached to the document — so nothing renders and
+// nothing enters the accessibility tree. This is for host pages that dock
+// their own transport UI over the seam (the sandbox's chrono bar) — an
+// honest replacement for hiding the bar with injected CSS.
+export function mountScrubber({ hidden = false } = {}) {
+  if (!hidden && !document.getElementById("functor-scrubber-style")) {
     const style = document.createElement("style");
     style.id = "functor-scrubber-style";
     style.textContent = STYLE;
     document.head.appendChild(style);
   }
 
+  // The element is always BUILT (every internal lookup and render targets
+  // it); when hidden it simply stays detached.
   const el = document.createElement("div");
   el.id = "scrubber";
   el.innerHTML = HTML;
-  document.body.appendChild(el);
+  if (!hidden) document.body.appendChild(el);
 
   const $ = (id) => el.querySelector(`#${id}`);
   const rail = $("scrub-rail");

--- a/runtime/functor-runtime-web/scrubber.js
+++ b/runtime/functor-runtime-web/scrubber.js
@@ -239,7 +239,9 @@ export function mountScrubber({ hidden = false } = {}) {
 
   const dispatch = (action) => {
     state = reduceTimeline(state, action);
-    render();
+    // Hidden mounts skip ALL rendering: state is owned by reduceTimeline and
+    // the seam reads it directly, so the detached DOM never needs painting.
+    if (!hidden) render();
   };
 
   const view = () => deriveTimelineView(state);
@@ -667,7 +669,7 @@ export function mountScrubber({ hidden = false } = {}) {
     }
     const range = functor_lang_scene_range();
     if (range.length === 2) {
-      el.style.display = "flex";
+      if (!hidden) el.style.display = "flex";
       const snapshot = {
         frame: functor_lang_scene_frame(),
         lo: range[0],
@@ -685,9 +687,9 @@ export function mountScrubber({ hidden = false } = {}) {
     } else {
       const paused = functor_lang_scrub_paused();
       if (paused && state.runtime) {
-        el.style.display = "flex";
+        if (!hidden) el.style.display = "flex";
         if (state.recordingAvailable) dispatch({ type: "recording-cleared" });
-      } else {
+      } else if (!hidden) {
         el.style.display = "none";
       }
       lastRuntimeSnapshotKey = "";

--- a/site/player.html
+++ b/site/player.html
@@ -502,13 +502,16 @@
         // mouse-look button too (there is no input to drive).
         const deterministic = params.has("fixed-time");
         // `?scrubber=0` is an explicit opt-out for the scrubber only (input and
-        // mouse-look stay live).
-        const scrubberOff = params.get("scrubber") === "0";
+        // mouse-look stay live). `?scrubber=hidden` mounts the seam
+        // (window.__scrub) without the bar's DOM — for host pages that dock
+        // their own transport UI.
+        const scrubberMode = params.get("scrubber");
+        const scrubberOff = scrubberMode === "0";
         if (deterministic) {
           document.getElementById("mouselook").style.display = "none";
         } else {
           setupInput();
-          if (!scrubberOff) mountScrubber();
+          if (!scrubberOff) mountScrubber({ hidden: scrubberMode === "hidden" });
         }
         // The webview overlay renders even in deterministic captures (it is
         // part of the frame's visual output); paused clocks drop its

--- a/site/player.html
+++ b/site/player.html
@@ -504,9 +504,15 @@
         // `?scrubber=0` is an explicit opt-out for the scrubber only (input and
         // mouse-look stay live). `?scrubber=hidden` mounts the seam
         // (window.__scrub) without the bar's DOM — for host pages that dock
-        // their own transport UI.
+        // their own transport UI. (Under ?fixed-time nothing mounts at all —
+        // deterministic captures have no seam; hosts wanting both should pin
+        // time through the seam instead.) Unknown values warn and mount the
+        // normal bar rather than silently disabling anything.
         const scrubberMode = params.get("scrubber");
         const scrubberOff = scrubberMode === "0";
+        if (scrubberMode !== null && scrubberMode !== "0" && scrubberMode !== "hidden") {
+          console.warn(`[player] unknown ?scrubber=${scrubberMode}; mounting the normal scrubber`);
+        }
         if (deterministic) {
           document.getElementById("mouselook").style.display = "none";
         } else {


### PR DESCRIPTION
Stacked on #523 (← #522).

`mountScrubber({ hidden: true })` mounts the time-travel **seam without the chrome**: the timeline model, runtime poll loop, and `window.__scrub` all run exactly as usual, but the bar's DOM is never attached — nothing renders, and nothing enters the accessibility tree.

`player.html` grows `?scrubber=hidden` alongside the existing `?scrubber=0` opt-out (`0` still mounts nothing at all; `hidden` keeps the seam).

**Why:** the next PR docks a host-owned chrono bar over the sandbox and drives the player through `__scrub`. Without this, the host must hide the in-frame bar with injected CSS — which leaves a phantom scrubber in the a11y tree and display-fighting hacks. This is the honest mechanism (design doc §7.1's `mountScrubber` option, minimal form).

No behavior change for any existing mount (default parameter).

**Verification:** `npm run test:site` — ALL CHECKS PASSED (110). Headless check: `?scrubber=hidden` yields a live `__scrub` (frame advancing) with no `#scrubber` element and no scrubber sliders in the accessibility tree; the default mount is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review dispositions (xreview: Claude + Codex)

- **[AGREED] hidden mode still rendered the detached tree every frame** → fixed: `dispatch()` skips `render()` when hidden (state lives in `reduceTimeline`; the seam reads it directly) and the rAF display writes are guarded.
- **`?scrubber=hidden` ignored under `?fixed-time`** (Claude) → documented as intended: deterministic captures mount no seam at all.
- **Unknown `?scrubber=` values silently mount the bar** (Claude) → now warns and mounts the normal bar (fail-visible beats fail-silent for a dev tool).
- Both reviewers independently confirmed the detached-mode invariants hold (no layout reads reachable, destroy safe, other mounts unaffected).
- Re-verified after fixes: seam alive under `?scrubber=hidden` with no DOM and nothing in the a11y tree; `npm run test:site` ALL CHECKS PASSED.
