### PR TITLE
build: add `npm run build` for the whole tree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,21 @@ language, prelude, and semantics are documented in the **`functor-lang` skill** 
 **Prerequisites:** Rust stable + `wasm32-unknown-unknown` target, Node 22 / npm 10, and
 `wasm-pack`.
 
-**Build the CLI.** Order matters — the CLI embeds the web runtime bundle at compile time via
+**Build everything** — the CLI, both wasm bundles, and the site:
+
+```sh
+npm run build
+```
+
+Reach for this when you don't know which pieces a change touches. The individual
+targets are silently order-dependent, and getting the order wrong fails at
+runtime rather than at build time: a site built against a stale
+`runtime/functor-runtime-web/pkg` looks fine but its sandbox hangs at
+`loading…` with a missing-export error in the console, and without
+`build:lang-wasm` the editor's `/pkg/functor_lang_wasm.js` 404s so its
+"0 problems" indicator isn't checking anything.
+
+**Build just the CLI.** Order matters — the CLI embeds the web runtime bundle at compile time via
 `include_bytes!`, so the wasm bundle must exist before the `functor` binary is built:
 
 ```sh

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -30,9 +30,15 @@ cargo build --release --bin functor                          # the CLI (embeds t
 Or use the bundled convenience script, which runs both in order:
 
 ```sh
+npm run build              # everything: CLI, both wasm bundles, and the site
 npm run build:cli          # release build → target/release/functor
 npm run build:cli:debug    # debug build   → target/debug/functor
 ```
+
+`npm run build` is the one to reach for when you are unsure which pieces a
+change touches: the individual targets are order-dependent, and the wrong order
+fails at runtime rather than at build time (a site built against a stale runtime
+bundle hangs at `loading…` instead of erroring).
 
 **Prefer the release build (`npm run build:cli`) for interactive use** — the debug
 build's CPU-bound paths (the webview overlay's software raster, rapier physics) are

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   },
   "scripts": {
     "clean": "git clean -fdX",
+    "build": "npm run build:cli && npm run build:lang-wasm && npm run site:build",
     "build:cli": "wasm-pack build runtime/functor-runtime-web --target=web && cargo build --release --bin functor",
     "build:cli:debug": "wasm-pack build runtime/functor-runtime-web --target=web && cargo build --bin functor",
     "build:lang-wasm": "wasm-pack build tools/functor-lang-wasm --target=web",


### PR DESCRIPTION
The build targets are silently order-dependent, and getting the order wrong fails
at **runtime rather than at build time** — the worst place for it. Both failure
modes bit me during the sandbox work (#521):

- A site built against a stale `runtime/functor-runtime-web/pkg` **looks fine and
  serves**, but the sandbox hangs forever at `◌ loading…` with a missing-export
  error buried in the browser console. Nothing in the build says a word.
- Without `build:lang-wasm`, `/pkg/functor_lang_wasm.js` 404s, so the editor's
  language intel silently does nothing — its "0 problems" indicator isn't
  checking anything.

Neither is discoverable from the build output, and both cost a full
debug-and-rebuild cycle.

## What it does

```sh
npm run build
```

Runs `build:cli` (which already sequences the runtime wasm bundle before the CLI
that `include_bytes!`s it), then `build:lang-wasm`, then `site:build` — which
copies both `pkg` directories into `dist`.

Reach for it when you don't know which pieces a change touches. The granular
targets stay exactly as they were for when you do.

## Verification

Run end to end from a cleaned `site/dist` — **exit 0**, producing:

- `target/release/functor`
- `runtime/functor-runtime-web/pkg/functor_runtime_web_bg.wasm`
- `tools/functor-lang-wasm/pkg/functor_lang_wasm_bg.wasm`
- `site/dist/pkg/functor_lang_wasm.js` — the file whose absence is otherwise
  invisible
- `site/dist/examples/terrain.fun`

Documented in both places builds are already described: `CLAUDE.md`'s Commands
section and `DEVELOPMENT.md`, each explaining *why* the order matters rather than
just listing the command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)