### PR TITLE
feat(site): multiplayer pane grid — N client panes behind a chrono bar

### DIFF
--- a/runtime/functor-runtime-web/scrubber.js
+++ b/runtime/functor-runtime-web/scrubber.js
@@ -187,18 +187,26 @@ const HTML = `
     </div>
   </details>`;
 
-export function mountScrubber() {
-  if (!document.getElementById("functor-scrubber-style")) {
+// `hidden: true` mounts the SEAM without the chrome: the timeline model, the
+// runtime poll loop, and `window.__scrub` all run exactly as usual, but the
+// bar's DOM is never attached to the document — so nothing renders and
+// nothing enters the accessibility tree. This is for host pages that dock
+// their own transport UI over the seam (the sandbox's chrono bar) — an
+// honest replacement for hiding the bar with injected CSS.
+export function mountScrubber({ hidden = false } = {}) {
+  if (!hidden && !document.getElementById("functor-scrubber-style")) {
     const style = document.createElement("style");
     style.id = "functor-scrubber-style";
     style.textContent = STYLE;
     document.head.appendChild(style);
   }
 
+  // The element is always BUILT (every internal lookup and render targets
+  // it); when hidden it simply stays detached.
   const el = document.createElement("div");
   el.id = "scrubber";
   el.innerHTML = HTML;
-  document.body.appendChild(el);
+  if (!hidden) document.body.appendChild(el);
 
   const $ = (id) => el.querySelector(`#${id}`);
   const rail = $("scrub-rail");

--- a/runtime/functor-runtime-web/scrubber.js
+++ b/runtime/functor-runtime-web/scrubber.js
@@ -239,7 +239,9 @@ export function mountScrubber({ hidden = false } = {}) {
 
   const dispatch = (action) => {
     state = reduceTimeline(state, action);
-    render();
+    // Hidden mounts skip ALL rendering: state is owned by reduceTimeline and
+    // the seam reads it directly, so the detached DOM never needs painting.
+    if (!hidden) render();
   };
 
   const view = () => deriveTimelineView(state);
@@ -667,7 +669,7 @@ export function mountScrubber({ hidden = false } = {}) {
     }
     const range = functor_lang_scene_range();
     if (range.length === 2) {
-      el.style.display = "flex";
+      if (!hidden) el.style.display = "flex";
       const snapshot = {
         frame: functor_lang_scene_frame(),
         lo: range[0],
@@ -685,9 +687,9 @@ export function mountScrubber({ hidden = false } = {}) {
     } else {
       const paused = functor_lang_scrub_paused();
       if (paused && state.runtime) {
-        el.style.display = "flex";
+        if (!hidden) el.style.display = "flex";
         if (state.recordingAvailable) dispatch({ type: "recording-cleared" });
-      } else {
+      } else if (!hidden) {
         el.style.display = "none";
       }
       lastRuntimeSnapshotKey = "";

--- a/site/player.html
+++ b/site/player.html
@@ -502,13 +502,16 @@
         // mouse-look button too (there is no input to drive).
         const deterministic = params.has("fixed-time");
         // `?scrubber=0` is an explicit opt-out for the scrubber only (input and
-        // mouse-look stay live).
-        const scrubberOff = params.get("scrubber") === "0";
+        // mouse-look stay live). `?scrubber=hidden` mounts the seam
+        // (window.__scrub) without the bar's DOM — for host pages that dock
+        // their own transport UI.
+        const scrubberMode = params.get("scrubber");
+        const scrubberOff = scrubberMode === "0";
         if (deterministic) {
           document.getElementById("mouselook").style.display = "none";
         } else {
           setupInput();
-          if (!scrubberOff) mountScrubber();
+          if (!scrubberOff) mountScrubber({ hidden: scrubberMode === "hidden" });
         }
         // The webview overlay renders even in deterministic captures (it is
         // part of the frame's visual output); paused clocks drop its

--- a/site/player.html
+++ b/site/player.html
@@ -504,9 +504,15 @@
         // `?scrubber=0` is an explicit opt-out for the scrubber only (input and
         // mouse-look stay live). `?scrubber=hidden` mounts the seam
         // (window.__scrub) without the bar's DOM — for host pages that dock
-        // their own transport UI.
+        // their own transport UI. (Under ?fixed-time nothing mounts at all —
+        // deterministic captures have no seam; hosts wanting both should pin
+        // time through the seam instead.) Unknown values warn and mount the
+        // normal bar rather than silently disabling anything.
         const scrubberMode = params.get("scrubber");
         const scrubberOff = scrubberMode === "0";
+        if (scrubberMode !== null && scrubberMode !== "0" && scrubberMode !== "hidden") {
+          console.warn(`[player] unknown ?scrubber=${scrubberMode}; mounting the normal scrubber`);
+        }
         if (deterministic) {
           document.getElementById("mouselook").style.display = "none";
         } else {

--- a/site/src/components/SandboxControls.tsx
+++ b/site/src/components/SandboxControls.tsx
@@ -20,22 +20,34 @@ export interface PickerState {
   selected: string;
 }
 
+/** The multiplayer prototype's CLIENTS control (mp-panes.ts). */
+export interface ClientsState {
+  count: number;
+  /** Shown only for multiplayer-capable samples, or while panes are forced. */
+  visible: boolean;
+}
+
 export interface SandboxControlsProps {
   picker: Store<PickerState>;
   pill: Store<PillState>;
+  clients: Store<ClientsState>;
   runtimeTarget: RuntimeTargetCore;
   onSelect: (value: string) => void;
   onReset: () => void;
+  onClients: (count: number) => void;
 }
 
 export const SandboxControls = ({
   picker,
   pill,
+  clients,
   runtimeTarget,
   onSelect,
   onReset,
+  onClients,
 }: SandboxControlsProps) => {
   const { options, selected } = useSyncExternalStore(picker.subscribe, picker.getSnapshot);
+  const clientsState = useSyncExternalStore(clients.subscribe, clients.getSnapshot);
 
   return (
     <>
@@ -53,6 +65,23 @@ export const SandboxControls = ({
           </option>
         ))}
       </select>
+      {clientsState.visible && (
+        <>
+          <label className="picker-label" htmlFor="client-count">
+            clients
+          </label>
+          <select
+            id="client-count"
+            title="Run N clients of this program side by side (multiplayer prototype)"
+            value={String(clientsState.count)}
+            onChange={(event) => onClients(Number(event.target.value))}
+          >
+            <option value="1">1</option>
+            <option value="2">2</option>
+            <option value="3">3</option>
+          </select>
+        </>
+      )}
       <button id="reset" type="button" title="Reload the example (resets the model)" onClick={onReset}>
         ↺ reset
       </button>

--- a/site/src/examples.ts
+++ b/site/src/examples.ts
@@ -30,6 +30,13 @@ export interface Example {
   siblings?: ExampleCopy[];
   /** Local binary assets the project's `Asset.*` locators resolve to. */
   assets?: ExampleCopy[];
+  /**
+   * Marks a sample that declares a server entry point (the functor.json
+   * `entries` shape, like examples/mp) — the sandbox shows its CLIENTS
+   * control only for those. No current sample qualifies; the flag seats the
+   * gate for an orbs-style client/server sample.
+   */
+  multiplayer?: boolean;
 }
 
 export const EXAMPLES: Example[] = [

--- a/site/src/mp-panes.ts
+++ b/site/src/mp-panes.ts
@@ -45,9 +45,7 @@ interface ScrubSeam {
   seek(frame: number): void;
   togglePause(): void;
   step(): void;
-  model(): { preview: { enabled: boolean; seconds: number; rate: number } };
   view(): TimelineView | null;
-  setPreview(preview: { enabled?: boolean; seconds?: number; rate?: number }): void;
 }
 
 /** The slice of timeline-model's derived view the chrono bar renders. */
@@ -56,9 +54,6 @@ interface TimelineView {
   playheadUnit: number;
   recordedStartUnit: number;
   recordedEndUnit: number;
-  previewEndUnit: number;
-  previewFrames: number;
-  previewClippedFrames: number;
   selectedFrame: number;
   paused: boolean;
   eventMarkers: {
@@ -83,6 +78,8 @@ type PaneState = PillState["state"];
 
 interface Pane {
   index: number;
+  /** Aborts every listener this pane registered outside its own subtree. */
+  scope: AbortController;
   iframe: HTMLIFrameElement;
   shell: HTMLElement;
   tab: HTMLButtonElement;
@@ -114,6 +111,9 @@ export interface MultiplayerPanes {
 }
 
 const PLAYER_COLORS = ["var(--scrub-p1)", "var(--scrub-p2)", "var(--scrub-p3)", "var(--scrub-p4)"];
+
+/** One clamp for every entry point (the select offers the same range). */
+export const MAX_CLIENTS = 3;
 
 const LINK_PRESETS: LinkProfile[] = [
   { name: "LAN", ms: 8, jitter: 2, loss: 0 },
@@ -183,29 +183,12 @@ export function initMultiplayerPanes({
       <span class="mp-track"></span>
       <span class="mp-recorded" id="mp-recorded"></span>
       <span class="mp-played" id="mp-played"></span>
-      <span class="mp-future" id="mp-future"></span>
       <span class="mp-ticks" id="mp-ticks"></span>
       <span class="mp-markers" id="mp-markers"></span>
       <span class="mp-playhead" id="mp-playhead"></span>
-      <span class="mp-preview-handle" id="mp-preview-handle" title="Drag to stretch the extrapolation window"></span>
-      <span class="mp-overflow" id="mp-overflow"></span>
       <span class="mp-evt-tip" id="mp-evt-tip" role="status"></span>
       <span class="mp-rail-label"><b>#f</b> <span id="mp-frame">—</span></span>
     </span>
-    <button class="mp-sbtn" id="mp-extrap" title="Extrapolate: speculatively simulate forward from the parked frame">🔮</button>
-    <details class="mp-adv" id="mp-adv">
-      <summary title="Extrapolation settings">⚙</summary>
-      <div class="mp-adv-pop">
-        <label>show
-          <select id="mp-adv-mode">
-            <option value="1">trail</option><option value="2">strobe</option>
-            <option value="3" selected>both</option><option value="4">ghost</option>
-          </select>
-        </label>
-        <label>window <input id="mp-adv-win" type="number" step="0.5" min="0.5" max="5" value="2" />s</label>
-        <label>rate <input id="mp-adv-rate" type="number" min="1" max="30" value="5" />/s</label>
-      </div>
-    </details>
     <span class="mp-viewseg" role="group" aria-label="Pane layout">
       <button id="mp-view-tiled" aria-pressed="true" title="Tiled: every client visible">⊞ tiled</button>
       <button id="mp-view-tabs" aria-pressed="false" title="Tabs: one client full-size (f)">▤ tabs</button>
@@ -225,7 +208,6 @@ export function initMultiplayerPanes({
 
   const $ = (id: string) => chrono.querySelector(`#${id}`) as HTMLElement;
   const $btn = (id: string) => chrono.querySelector(`#${id}`) as HTMLButtonElement;
-  const $input = (id: string) => chrono.querySelector(`#${id}`) as HTMLInputElement;
 
   const panes: Pane[] = [];
   const makePane = (index: number, iframe: HTMLIFrameElement): Pane => {
@@ -265,6 +247,7 @@ export function initMultiplayerPanes({
       iframe,
       shell,
       tab,
+      scope: new AbortController(),
       state: "busy",
       link: { ...LINK_PRESETS[1] },
       frameLabels: [
@@ -281,7 +264,7 @@ export function initMultiplayerPanes({
     iframe.addEventListener("load", () => syncInnerScrubber());
     shell.querySelector(".mp-pane-hd")!.addEventListener("mousedown", () => focusPane(index));
     tab.addEventListener("click", () => focusPane(index));
-    buildLinkMenu(pane, shell.querySelector(".mp-link-host") as HTMLElement);
+    buildLinkMenu(pane, shell.querySelector(".mp-link-host") as HTMLElement, pane.scope.signal);
     panes.push(pane);
     return pane;
   };
@@ -312,15 +295,20 @@ export function initMultiplayerPanes({
         setPaneState(pane, ok ? "live" : "error", message);
         if (!ok) statusBar.appendOutput("error", `[${label}] ${message}`);
       },
+      signal: pane.scope.signal,
     });
     mirrors.push({ pane, bridge });
     // Runtime console lines from this mirror, prefixed with its identity.
-    window.addEventListener("message", (event) => {
-      const data = asPlayerMessage(event.data);
-      if (!data || data.type !== "functor-lang-console") return;
-      if (event.source !== iframe.contentWindow) return;
-      statusBar.appendOutput(data.level, `[${label}] ${data.message}`, data.frame ?? null);
-    });
+    window.addEventListener(
+      "message",
+      (event) => {
+        const data = asPlayerMessage(event.data);
+        if (!data || data.type !== "functor-lang-console") return;
+        if (event.source !== iframe.contentWindow) return;
+        statusBar.appendOutput(data.level, `[${label}] ${data.message}`, data.frame ?? null);
+      },
+      { signal: pane.scope.signal }
+    );
     // A mirror added mid-session boots the served program, then catches up to
     // the (possibly edited) buffer; the bridge holds the push until ready.
     if (frame.getAttribute("src")) {
@@ -333,6 +321,7 @@ export function initMultiplayerPanes({
     const removed = mirrors.pop();
     if (!removed) return;
     removed.bridge.reset();
+    removed.pane.scope.abort(); // window/document/bridge listeners
     removed.pane.shell.remove();
     removed.pane.tab.remove();
     panes.pop();
@@ -359,8 +348,9 @@ export function initMultiplayerPanes({
     for (const menu of document.querySelectorAll<HTMLElement>(".mp-link-menu")) {
       menu.hidden = true;
     }
-    (chrono.querySelector("#mp-adv") as HTMLDetailsElement).open = false;
   };
+
+  const moduleScope = new AbortController();
 
   // Clicking into a pane's iframe gives it the real keyboard; follow that
   // with the focus chrome so "who has my keys" never lies. The blur doubles
@@ -371,14 +361,8 @@ export function initMultiplayerPanes({
     const active = document.activeElement;
     const pane = panes.find((candidate) => candidate.iframe === active);
     if (pane) focusPane(pane.index);
-  });
+  }, { signal: moduleScope.signal });
 
-  // Click-away anywhere in the page dismisses too (each link menu already
-  // guards its own host; the ⚙ popover gets the same rule here).
-  document.addEventListener("mousedown", (event) => {
-    const adv = chrono.querySelector("#mp-adv") as HTMLDetailsElement;
-    if (adv.open && !adv.contains(event.target as Node)) adv.open = false;
-  });
 
   // Digits jump panes, [ ] cycle, f toggles tiled/tabs — but never while the
   // caret is in an editor or input (digits are text there, no exceptions).
@@ -398,7 +382,7 @@ export function initMultiplayerPanes({
     } else if (event.key === "f") {
       setView(grid.dataset.view === "tiled" ? "tabs" : "tiled");
     }
-  });
+  }, { signal: moduleScope.signal });
 
   // ------------------------------------------------------- tiled / tabs view
   const setView = (view: "tiled" | "tabs", force = false) => {
@@ -425,7 +409,7 @@ export function initMultiplayerPanes({
   // Live client-count change: grow or shrink the mirror set in place. Pane 1
   // is untouched, so its model (and the editor session) survive.
   const setCount = (n: number) => {
-    const target = Math.max(1, Math.min(PLAYER_COLORS.length, Math.floor(n) || 1));
+    const target = Math.max(1, Math.min(MAX_CLIENTS, Math.floor(n) || 1));
     while (panes.length < target) addMirror(true);
     while (panes.length > target) removeMirror();
     if (focused >= panes.length) focusPane(0);
@@ -435,7 +419,7 @@ export function initMultiplayerPanes({
   updateChrome();
 
   // -------------------------------------------------------------- link menu
-  function buildLinkMenu(pane: Pane, host: HTMLElement) {
+  function buildLinkMenu(pane: Pane, host: HTMLElement, signal: AbortSignal) {
     const chip = host.querySelector(".mp-link-chip") as HTMLButtonElement;
     const menu = document.createElement("div");
     menu.className = "mp-link-menu";
@@ -476,9 +460,13 @@ export function initMultiplayerPanes({
       }
       menu.hidden = !open;
     });
-    document.addEventListener("mousedown", (event) => {
-      if (!host.contains(event.target as Node)) menu.hidden = true;
-    });
+    document.addEventListener(
+      "mousedown",
+      (event) => {
+        if (!host.contains(event.target as Node)) menu.hidden = true;
+      },
+      { signal }
+    );
     for (const button of menu.querySelectorAll<HTMLButtonElement>(".mp-link-presets button")) {
       button.addEventListener("click", () => {
         const preset = LINK_PRESETS.find((candidate) => candidate.name === button.dataset.name);
@@ -506,9 +494,11 @@ export function initMultiplayerPanes({
   // shrink back to one client restore the page's own wording.
   let mainState: PaneState = "busy";
   let mainDetail = "";
+  const paneDetails = new Map<Pane, string>();
   let lastMain: { state: PaneState; text: string; detail: string } | null = null;
   const setPaneState = (pane: Pane, state: PaneState, detail = "") => {
     pane.state = state;
+    paneDetails.set(pane, detail);
     for (const dot of pane.dots) dot.dataset.state = state;
     pane.errStrip.hidden = state !== "error";
     if (state === "error") pane.errStrip.textContent = `✕ ${detail}`;
@@ -521,7 +511,8 @@ export function initMultiplayerPanes({
     }
     const states = [mainState, ...panes.slice(1).map((pane) => pane.state)];
     if (states.includes("error")) {
-      setPill("error", "✕ build error", mainDetail);
+      const failing = panes.find((pane) => pane.state === "error");
+      setPill("error", "✕ build error", (failing && paneDetails.get(failing)) || mainDetail);
     } else if (states.includes("busy")) {
       setPill("busy", "◐ reloading…", "");
     } else {
@@ -542,75 +533,6 @@ export function initMultiplayerPanes({
   $btn("mp-step").addEventListener("click", () => {
     for (const seam of seams()) seam.step();
   });
-  // The speculative preview (🔮): each pane simulates forward from its parked
-  // frame under the current code, replaying recorded input. Broadcast like
-  // pause — every pane extrapolates its own sim.
-  $btn("mp-extrap").addEventListener("click", () => {
-    const primary = primarySeam();
-    if (!primary) return;
-    const enabled = !primary.model().preview.enabled;
-    for (const seam of seams()) seam.setPreview({ enabled });
-  });
-
-  // ⚙ advanced: window/rate broadcast through the seam. The ghost-mode select
-  // isn't in the seam's model, so it reaches into each pane's own (hidden)
-  // scrubber select — a prototype-only shortcut, like the CSS injection.
-  const advWin = $input("mp-adv-win");
-  const advRate = $input("mp-adv-rate");
-  const advMode = chrono.querySelector("#mp-adv-mode") as HTMLSelectElement;
-  const pushAdv = () => {
-    if (!advWin.validity.valid || !advRate.validity.valid) return;
-    for (const seam of seams()) {
-      seam.setPreview({ seconds: advWin.valueAsNumber, rate: advRate.valueAsNumber });
-    }
-  };
-  advWin.addEventListener("input", pushAdv);
-  advRate.addEventListener("input", pushAdv);
-  advMode.addEventListener("change", () => {
-    for (const pane of panes) {
-      try {
-        const select = pane.iframe.contentDocument?.getElementById(
-          "scrub-mode"
-        ) as HTMLSelectElement | null;
-        if (select) {
-          select.value = advMode.value;
-          select.dispatchEvent(new Event("change"));
-        }
-      } catch {
-        // a pane mid-navigation has no reachable document
-      }
-    }
-  });
-
-  // The pink preview handle: drag to stretch the extrapolation window, exactly
-  // like the old in-frame scrubber's second slider.
-  const previewHandle = $("mp-preview-handle");
-  let previewDrag: { x: number; seconds: number } | null = null;
-  previewHandle.addEventListener("pointerdown", (event) => {
-    event.preventDefault();
-    event.stopPropagation();
-    previewHandle.setPointerCapture(event.pointerId);
-    previewDrag = { x: event.clientX, seconds: primarySeam()?.model().preview.seconds ?? 2 };
-  });
-  previewHandle.addEventListener("pointermove", (event) => {
-    if (!previewDrag || !previewHandle.hasPointerCapture(event.pointerId)) return;
-    const current = primarySeam()?.view();
-    const width = rail.getBoundingClientRect().width;
-    const span = current ? current.viewport.hi - current.viewport.lo : 0;
-    if (width <= 0 || span <= 0) return;
-    const deltaFrames = ((event.clientX - previewDrag.x) / width) * span;
-    for (const seam of seams()) {
-      seam.setPreview({ seconds: previewDrag.seconds + deltaFrames / 60 });
-    }
-    const settled = primarySeam()?.model().preview.seconds;
-    if (settled !== undefined) advWin.value = String(settled);
-  });
-  const endPreviewDrag = () => {
-    previewDrag = null;
-  };
-  previewHandle.addEventListener("pointerup", endPreviewDrag);
-  previewHandle.addEventListener("pointercancel", endPreviewDrag);
-
   const tip = $("mp-evt-tip");
   const showTip = (unit: number, text: string) => {
     tip.style.display = "block";
@@ -661,29 +583,18 @@ export function initMultiplayerPanes({
       $("mp-recorded").style.width =
         `${Math.max(current.recordedEndUnit - current.recordedStartUnit, 0) * 100}%`;
       $("mp-playhead").style.left = `${current.playheadUnit * 100}%`;
-      const previewOn = primary.model().preview.enabled;
-      const future = $("mp-future");
-      future.style.left = `${current.playheadUnit * 100}%`;
-      future.style.width = previewOn
-        ? `${Math.max(current.previewEndUnit - current.playheadUnit, 0) * 100}%`
-        : "0";
-      previewHandle.style.display = previewOn ? "block" : "none";
-      previewHandle.style.left = `${current.previewEndUnit * 100}%`;
-      previewHandle.classList.toggle("clipped", current.previewClippedFrames > 0);
-      const overflow = $("mp-overflow");
-      overflow.style.display = previewOn && current.previewClippedFrames > 0 ? "block" : "none";
-      overflow.textContent = `+${current.previewClippedFrames}`;
-      $btn("mp-extrap").classList.toggle("on", previewOn);
-      $btn("mp-extrap").setAttribute("aria-pressed", String(previewOn));
-      const labelHtml =
-        `${current.selectedFrame}` +
-        (previewOn ? ` <span class="fut">+${current.previewFrames}</span>` : "") +
-        ` / ${Math.round(current.viewport.hi)}`;
-      if (labelHtml !== lastLabel) {
-        lastLabel = labelHtml;
-        $("mp-frame").innerHTML = labelHtml;
+      const labelText = `${current.selectedFrame} / ${Math.round(current.viewport.hi)}`;
+      if (labelText !== lastLabel) {
+        lastLabel = labelText;
+        $("mp-frame").textContent = labelText;
       }
       $btn("mp-pause").textContent = current.paused ? "▶" : "⏸";
+      // A pane that boots while the session is parked must not run off on its
+      // own: keep every seam's pause state converged on the focused pane's.
+      // Idempotent, so this costs one boolean read per pane per frame.
+      for (const seam of seams()) {
+        if (seam !== primary && seam.paused() !== current.paused) seam.togglePause();
+      }
       // Second ticks (60 frames), heavier every 5s. Positions track the moving
       // viewport each frame; nodes are recycled, only count changes touch DOM.
       const lo = current.viewport.lo;
@@ -701,9 +612,15 @@ export function initMultiplayerPanes({
       });
       // Event markers (input / reload / reload-error): the reload ticks are the
       // "source changes on the timeline" — every hot-swap is already recorded.
-      const key = current.eventMarkers
-        .map((marker) => `${marker.id}:${marker.unit.toFixed(4)}:${marker.kind}`)
-        .join("|");
+      const key =
+        `${focused}|` +
+        current.eventMarkers
+          .map(
+            (marker) =>
+              `${marker.id}@${marker.frame}:${marker.unit.toFixed(4)}:${marker.kind}:` +
+              `${marker.category}:${marker.count}`
+          )
+          .join("|");
       if (key !== markerKey) {
         markerKey = key;
         hideTip();
@@ -739,11 +656,12 @@ export function initMultiplayerPanes({
   };
   // rAF, not a timer: while dragging the rail the playhead/label must track
   // the pointer at frame rate — a slow poll here reads as a sluggish sim.
-  // All DOM writes above are change-guarded, so the steady-state cost is
-  // reads only (same shape as the in-frame scrubber's own rAF loop).
+  // The label and marker writes are change-guarded; the geometry writes are
+  // plain style assignments (same shape as the in-frame scrubber's loop).
+  // At one client the chrono bar is display:none, so painting is skipped.
   let raf = 0;
   const tickLoop = () => {
-    paint();
+    if (panes.length > 1) paint();
     raf = requestAnimationFrame(tickLoop);
   };
   raf = requestAnimationFrame(tickLoop);
@@ -777,6 +695,8 @@ export function initMultiplayerPanes({
     count: () => panes.length,
     destroy() {
       cancelAnimationFrame(raf);
+      moduleScope.abort();
+      while (mirrors.length) removeMirror();
     },
   };
 }

--- a/site/src/mp-panes.ts
+++ b/site/src/mp-panes.ts
@@ -1,0 +1,782 @@
+// Multiplayer pane-grid PROTOTYPE for the sandbox (design:
+// ~/notes/projects/functor/design-multiplayer-ide-frontend.md — this is the
+// LIVE-mode skeleton of Addendum 2: hard per-client boundaries, iframe panes).
+//
+// The preview column becomes:
+//
+//   ┌ chrono bar ─ ⏸ ⏭ ═══rail═══╪══ 🔮 ⚙ | ⊞ tiled ▤ tabs ┐   (game side only —
+//   ├ pane grid ──────────────────────────────────────────────┤    the editor keeps
+//   │  ╔ 1 client · cyan  ⇅ Wi-Fi ▾   #f 841 ● ╗  ┌ 2 client ┐│    its full height)
+//   │  ║             iframe                    ║  │  iframe   ││
+//   └──╚══════════════════════════════════════╝──└───────────┘┘
+//
+// Each pane is a real `player.html` iframe running the same program — N
+// independent sims, hot-reloaded together with each pane's model preserved.
+// Panes grow/shrink LIVE (pane 1 wraps the page's #player once and never
+// moves again, so its model survives every count change).
+//
+// Prototype seams (all same-origin, so no postMessage transport yet):
+//  - the host chrono bar drives every pane through its `window.__scrub` seam
+//    (pause/step/seek/extrapolate broadcast; rail + markers mirror the
+//    focused pane);
+//  - mirror panes boot with `?scrubber=hidden` (the seam without the bar);
+//    pane 1 cannot re-boot (its model must survive), so while count > 1 its
+//    in-frame bar is suppressed with a REVERSIBLE injected style — removed
+//    the moment the count returns to 1, so single-client is exactly stock.
+//    The single-client unification (chrono bar at every N) follows separately
+//    with the a11y parity work it requires;
+//  - the per-pane link chip (LAN / Wi-Fi / mobile / awful) records a
+//    LinkProfile per client but impairs nothing until the transport carries
+//    it. It is labelled as such.
+//
+// This module is imperative DOM on purpose: it owns the preview column
+// OUTSIDE the React islands (like CodeMirror owns #editor), and publishes to
+// the page through the injected `setPill` / `statusBar` seams.
+
+import { PlayerBridge } from "./player-bridge.js";
+import { asPlayerMessage } from "./protocol.js";
+import type { StatusBar } from "./status-bar-store.js";
+import type { PillState } from "./components/StatusPill.js";
+
+/** The shared scrubber's `window.__scrub` seam (runtime/functor-runtime-web/scrubber.js). */
+interface ScrubSeam {
+  paused(): boolean;
+  frame(): number;
+  seek(frame: number): void;
+  togglePause(): void;
+  step(): void;
+  model(): { preview: { enabled: boolean; seconds: number; rate: number } };
+  view(): TimelineView | null;
+  setPreview(preview: { enabled?: boolean; seconds?: number; rate?: number }): void;
+}
+
+/** The slice of timeline-model's derived view the chrono bar renders. */
+interface TimelineView {
+  viewport: { lo: number; hi: number };
+  playheadUnit: number;
+  recordedStartUnit: number;
+  recordedEndUnit: number;
+  previewEndUnit: number;
+  previewFrames: number;
+  previewClippedFrames: number;
+  selectedFrame: number;
+  paused: boolean;
+  eventMarkers: {
+    id: number;
+    unit: number;
+    frame: number;
+    category: string;
+    kind: string;
+    labels: string[];
+    count: number;
+  }[];
+}
+
+interface LinkProfile {
+  name: string;
+  ms: number;
+  jitter: number;
+  loss: number;
+}
+
+type PaneState = PillState["state"];
+
+interface Pane {
+  index: number;
+  iframe: HTMLIFrameElement;
+  shell: HTMLElement;
+  tab: HTMLButtonElement;
+  state: PaneState;
+  link: LinkProfile;
+  frameLabels: HTMLElement[];
+  dots: HTMLElement[];
+  errStrip: HTMLElement;
+}
+
+export interface MultiplayerPanesOptions {
+  frame: HTMLIFrameElement;
+  count: number;
+  statusBar: StatusBar;
+  /** Writes the header pill (the page's pill store). */
+  setPill: (state: PaneState, text: string, detail: string) => void;
+  /** The current editor buffer, so a mirror added mid-session catches up. */
+  getSource: () => string;
+}
+
+export interface MultiplayerPanes {
+  setSrc(src: string): void;
+  push(source: string): void;
+  reset(): void;
+  aggregateStatus(state: PaneState, text: string, detail: string): void;
+  setCount(n: number): void;
+  count(): number;
+  destroy(): void;
+}
+
+const PLAYER_COLORS = ["var(--scrub-p1)", "var(--scrub-p2)", "var(--scrub-p3)", "var(--scrub-p4)"];
+
+const LINK_PRESETS: LinkProfile[] = [
+  { name: "LAN", ms: 8, jitter: 2, loss: 0 },
+  { name: "Wi-Fi", ms: 45, jitter: 12, loss: 1.2 },
+  { name: "mobile", ms: 132, jitter: 38, loss: 3.4 },
+  { name: "awful", ms: 400, jitter: 120, loss: 12 },
+];
+
+const HIDE_SCRUBBER_CSS = "#scrubber { display: none !important; }";
+
+// Suppress (or restore) pane 1's own bottom-docked scrubber overlay. While
+// count > 1 the host chrono bar is the one instrument; back at 1 the style is
+// removed and the stock in-frame bar returns. The `__scrub` seam is live
+// either way (it is how the chrono bar drives the pane).
+const setInnerScrubberHidden = (iframe: HTMLIFrameElement, hidden: boolean) => {
+  try {
+    const doc = iframe.contentDocument;
+    if (!doc) return;
+    const existing = doc.getElementById("mp-hide-scrubber");
+    if (hidden && !existing) {
+      const style = doc.createElement("style");
+      style.id = "mp-hide-scrubber";
+      style.textContent = HIDE_SCRUBBER_CSS;
+      (doc.head || doc.documentElement).appendChild(style);
+    } else if (!hidden && existing) {
+      existing.remove();
+    }
+  } catch {
+    // A pane that is mid-navigation has no reachable document yet; the load
+    // listener re-runs this.
+  }
+};
+
+// Mirror panes get the honest mechanism: mountScrubber({ hidden }) via the
+// player's ?scrubber=hidden — the seam mounts, the bar's DOM never does.
+const withHiddenScrubber = (src: string) => {
+  const url = new URL(src, window.location.href);
+  url.searchParams.set("scrubber", "hidden");
+  return url.toString();
+};
+
+const seamOf = (iframe: HTMLIFrameElement): ScrubSeam | null => {
+  try {
+    return (iframe.contentWindow as (Window & { __scrub?: ScrubSeam }) | null)?.__scrub ?? null;
+  } catch {
+    return null;
+  }
+};
+
+export function initMultiplayerPanes({
+  frame,
+  count,
+  statusBar,
+  setPill,
+  getSource,
+}: MultiplayerPanesOptions): MultiplayerPanes {
+  const previewPane = frame.closest(".preview-pane") as HTMLElement;
+  previewPane.classList.add("mp");
+
+  // ------------------------------------------------------------- chrono bar
+  const chrono = document.createElement("div");
+  chrono.className = "mp-chrono";
+  chrono.innerHTML = `
+    <button class="mp-sbtn" id="mp-pause" title="Pause / resume every client">⏸</button>
+    <button class="mp-sbtn" id="mp-step" title="Step every client one frame">⏭</button>
+    <span class="mp-rail" id="mp-rail" title="Drag to seek every client">
+      <span class="mp-track"></span>
+      <span class="mp-recorded" id="mp-recorded"></span>
+      <span class="mp-played" id="mp-played"></span>
+      <span class="mp-future" id="mp-future"></span>
+      <span class="mp-ticks" id="mp-ticks"></span>
+      <span class="mp-markers" id="mp-markers"></span>
+      <span class="mp-playhead" id="mp-playhead"></span>
+      <span class="mp-preview-handle" id="mp-preview-handle" title="Drag to stretch the extrapolation window"></span>
+      <span class="mp-overflow" id="mp-overflow"></span>
+      <span class="mp-evt-tip" id="mp-evt-tip" role="status"></span>
+      <span class="mp-rail-label"><b>#f</b> <span id="mp-frame">—</span></span>
+    </span>
+    <button class="mp-sbtn" id="mp-extrap" title="Extrapolate: speculatively simulate forward from the parked frame">🔮</button>
+    <details class="mp-adv" id="mp-adv">
+      <summary title="Extrapolation settings">⚙</summary>
+      <div class="mp-adv-pop">
+        <label>show
+          <select id="mp-adv-mode">
+            <option value="1">trail</option><option value="2">strobe</option>
+            <option value="3" selected>both</option><option value="4">ghost</option>
+          </select>
+        </label>
+        <label>window <input id="mp-adv-win" type="number" step="0.5" min="0.5" max="5" value="2" />s</label>
+        <label>rate <input id="mp-adv-rate" type="number" min="1" max="30" value="5" />/s</label>
+      </div>
+    </details>
+    <span class="mp-viewseg" role="group" aria-label="Pane layout">
+      <button id="mp-view-tiled" aria-pressed="true" title="Tiled: every client visible">⊞ tiled</button>
+      <button id="mp-view-tabs" aria-pressed="false" title="Tabs: one client full-size (f)">▤ tabs</button>
+    </span>`;
+
+  // -------------------------------------------------------------- pane grid
+  const tabsStrip = document.createElement("div");
+  tabsStrip.className = "mp-tabs";
+  tabsStrip.hidden = true;
+
+  const grid = document.createElement("div");
+  grid.className = "mp-grid";
+  grid.dataset.view = "tiled";
+
+  previewPane.prepend(chrono, tabsStrip);
+  previewPane.appendChild(grid);
+
+  const $ = (id: string) => chrono.querySelector(`#${id}`) as HTMLElement;
+  const $btn = (id: string) => chrono.querySelector(`#${id}`) as HTMLButtonElement;
+  const $input = (id: string) => chrono.querySelector(`#${id}`) as HTMLInputElement;
+
+  const panes: Pane[] = [];
+  const makePane = (index: number, iframe: HTMLIFrameElement): Pane => {
+    const color = PLAYER_COLORS[index % PLAYER_COLORS.length];
+    const shell = document.createElement("div");
+    shell.className = "mp-pane";
+    shell.style.setProperty("--pc", color);
+    shell.innerHTML = `
+      <div class="mp-pane-hd">
+        <span class="mp-digit">${index + 1}</span>
+        <span class="mp-role">client</span>
+        <span class="mp-link-host">
+          <button class="mp-link-chip"
+            title="Link impairment for this client (prototype — recorded per client; applies once the netsim transport lands)">⇅ Wi-Fi ▾</button>
+        </span>
+        <span class="mp-hd-r">
+          <span class="mp-you" hidden>⌨ you</span>
+          <span class="mp-pf"><b>#f</b> <span class="mp-pf-n">—</span></span>
+          <span class="mp-st" data-state="busy"></span>
+        </span>
+      </div>
+      <div class="mp-pane-body"></div>
+      <div class="mp-pane-err" hidden></div>`;
+    shell.querySelector(".mp-pane-body")!.appendChild(iframe);
+    grid.appendChild(shell);
+
+    const tab = document.createElement("button");
+    tab.className = "mp-tab";
+    tab.style.setProperty("--pc", color);
+    tab.innerHTML = `<span class="mp-digit">${index + 1}</span> client
+      <span class="mp-pf"><b>#f</b> <span class="mp-pf-n">—</span></span>
+      <span class="mp-st" data-state="busy"></span>`;
+    tabsStrip.appendChild(tab);
+
+    const pane: Pane = {
+      index,
+      iframe,
+      shell,
+      tab,
+      state: "busy",
+      link: { ...LINK_PRESETS[1] },
+      frameLabels: [
+        shell.querySelector(".mp-pf-n") as HTMLElement,
+        tab.querySelector(".mp-pf-n") as HTMLElement,
+      ],
+      dots: [
+        shell.querySelector(".mp-st") as HTMLElement,
+        tab.querySelector(".mp-st") as HTMLElement,
+      ],
+      errStrip: shell.querySelector(".mp-pane-err") as HTMLElement,
+    };
+
+    iframe.addEventListener("load", () => syncInnerScrubber());
+    shell.querySelector(".mp-pane-hd")!.addEventListener("mousedown", () => focusPane(index));
+    tab.addEventListener("click", () => focusPane(index));
+    buildLinkMenu(pane, shell.querySelector(".mp-link-host") as HTMLElement);
+    panes.push(pane);
+    return pane;
+  };
+
+  // Pane 1's in-frame scrubber shows exactly when it is the ONLY pane.
+  function syncInnerScrubber() {
+    setInnerScrubberHidden(panes[0].iframe, panes.length > 1);
+  }
+
+  // Pane 1 wraps the page's existing #player (lang-intel, the live trace, and
+  // the primary bridge keep talking to it untouched). Panes 2..N are mirrors,
+  // added and removed LIVE — pane 1's iframe never moves again after this
+  // wrap, so its running model survives every count change.
+  makePane(0, frame);
+  const mirrors: { pane: Pane; bridge: PlayerBridge }[] = [];
+
+  const addMirror = (pushCurrent: boolean) => {
+    const index = panes.length;
+    const label = `client ${index + 1}`;
+    const iframe = document.createElement("iframe");
+    iframe.title = `${label} preview`;
+    iframe.allow = "pointer-lock";
+    const pane = makePane(index, iframe);
+    const bridge = new PlayerBridge(iframe, {
+      onReloading: () => setPaneState(pane, "busy"),
+      onLive: () => setPaneState(pane, "live"),
+      onResult: (ok, message) => {
+        setPaneState(pane, ok ? "live" : "error", message);
+        if (!ok) statusBar.appendOutput("error", `[${label}] ${message}`);
+      },
+    });
+    mirrors.push({ pane, bridge });
+    // Runtime console lines from this mirror, prefixed with its identity.
+    window.addEventListener("message", (event) => {
+      const data = asPlayerMessage(event.data);
+      if (!data || data.type !== "functor-lang-console") return;
+      if (event.source !== iframe.contentWindow) return;
+      statusBar.appendOutput(data.level, `[${label}] ${data.message}`, data.frame ?? null);
+    });
+    // A mirror added mid-session boots the served program, then catches up to
+    // the (possibly edited) buffer; the bridge holds the push until ready.
+    if (frame.getAttribute("src")) {
+      iframe.src = withHiddenScrubber(frame.src);
+      if (pushCurrent) bridge.push(getSource());
+    }
+  };
+
+  const removeMirror = () => {
+    const removed = mirrors.pop();
+    if (!removed) return;
+    removed.bridge.reset();
+    removed.pane.shell.remove();
+    removed.pane.tab.remove();
+    panes.pop();
+  };
+
+  for (let i = 1; i < count; i++) addMirror(false);
+
+  // ------------------------------------------------------------ focus model
+  let focused = 0;
+  function focusPane(index: number) {
+    focused = index;
+    for (const pane of panes) {
+      const on = pane.index === index;
+      pane.shell.classList.toggle("focus", on);
+      pane.tab.classList.toggle("focus", on);
+      (pane.shell.querySelector(".mp-you") as HTMLElement).hidden = !on;
+    }
+  }
+  focusPane(0);
+
+  // Every transient surface (link menus, the ⚙ popover) dismisses together —
+  // popovers behave modally without blocking the page.
+  const closePopovers = () => {
+    for (const menu of document.querySelectorAll<HTMLElement>(".mp-link-menu")) {
+      menu.hidden = true;
+    }
+    (chrono.querySelector("#mp-adv") as HTMLDetailsElement).open = false;
+  };
+
+  // Clicking into a pane's iframe gives it the real keyboard; follow that
+  // with the focus chrome so "who has my keys" never lies. The blur doubles
+  // as click-away dismissal for the popovers — an iframe click never reaches
+  // this document's mousedown, but it always steals the window's focus.
+  window.addEventListener("blur", () => {
+    closePopovers();
+    const active = document.activeElement;
+    const pane = panes.find((candidate) => candidate.iframe === active);
+    if (pane) focusPane(pane.index);
+  });
+
+  // Click-away anywhere in the page dismisses too (each link menu already
+  // guards its own host; the ⚙ popover gets the same rule here).
+  document.addEventListener("mousedown", (event) => {
+    const adv = chrono.querySelector("#mp-adv") as HTMLDetailsElement;
+    if (adv.open && !adv.contains(event.target as Node)) adv.open = false;
+  });
+
+  // Digits jump panes, [ ] cycle, f toggles tiled/tabs — but never while the
+  // caret is in an editor or input (digits are text there, no exceptions).
+  window.addEventListener("keydown", (event) => {
+    const target = event.target as HTMLElement;
+    if (event.key === "Escape") {
+      closePopovers();
+      return;
+    }
+    if (target.closest?.(".cm-editor") || /^(INPUT|TEXTAREA|SELECT)$/.test(target.tagName)) return;
+    if (/^[1-9]$/.test(event.key)) {
+      const index = Number(event.key) - 1;
+      if (index < panes.length) focusPane(index);
+    } else if (event.key === "[" || event.key === "]") {
+      const delta = event.key === "]" ? 1 : -1;
+      focusPane((focused + delta + panes.length) % panes.length);
+    } else if (event.key === "f") {
+      setView(grid.dataset.view === "tiled" ? "tabs" : "tiled");
+    }
+  });
+
+  // ------------------------------------------------------- tiled / tabs view
+  const setView = (view: "tiled" | "tabs", force = false) => {
+    if (panes.length === 1 && !force) return;
+    grid.dataset.view = view;
+    tabsStrip.hidden = view !== "tabs";
+    $btn("mp-view-tiled").setAttribute("aria-pressed", String(view === "tiled"));
+    $btn("mp-view-tabs").setAttribute("aria-pressed", String(view === "tabs"));
+  };
+  $btn("mp-view-tiled").addEventListener("click", () => setView("tiled"));
+  $btn("mp-view-tabs").addEventListener("click", () => setView("tabs"));
+
+  // Everything on the chrono bar that depends on how many panes exist.
+  // (CSS keyed on data-count hides the pane header / 🔮 / view toggle.)
+  const updateChrome = () => {
+    const single = panes.length === 1;
+    previewPane.dataset.count = String(panes.length);
+    $btn("mp-view-tiled").disabled = single;
+    $btn("mp-view-tabs").disabled = single;
+    if (single) setView("tiled", true);
+    syncInnerScrubber();
+  };
+
+  // Live client-count change: grow or shrink the mirror set in place. Pane 1
+  // is untouched, so its model (and the editor session) survive.
+  const setCount = (n: number) => {
+    const target = Math.max(1, Math.min(PLAYER_COLORS.length, Math.floor(n) || 1));
+    while (panes.length < target) addMirror(true);
+    while (panes.length > target) removeMirror();
+    if (focused >= panes.length) focusPane(0);
+    updateChrome();
+    paintAggregate();
+  };
+  updateChrome();
+
+  // -------------------------------------------------------------- link menu
+  function buildLinkMenu(pane: Pane, host: HTMLElement) {
+    const chip = host.querySelector(".mp-link-chip") as HTMLButtonElement;
+    const menu = document.createElement("div");
+    menu.className = "mp-link-menu";
+    menu.hidden = true;
+    menu.innerHTML = `
+      <div class="mp-link-presets">
+        ${LINK_PRESETS.map(
+          (preset) =>
+            `<button data-name="${preset.name}" aria-pressed="${preset.name === "Wi-Fi"}">${preset.name}</button>`
+        ).join("")}
+      </div>
+      <label>⇅ <input class="mp-l-ms" type="number" min="0" value="45"> ms
+        ± <input class="mp-l-j" type="number" min="0" value="12"></label>
+      <label>✂ <input class="mp-l-loss" type="number" min="0" max="100" step="0.1" value="1.2"> % loss</label>
+      <p class="mp-link-note">prototype: recorded per client, applied when the netsim transport lands</p>`;
+    host.appendChild(menu);
+
+    const msInput = menu.querySelector(".mp-l-ms") as HTMLInputElement;
+    const jitterInput = menu.querySelector(".mp-l-j") as HTMLInputElement;
+    const lossInput = menu.querySelector(".mp-l-loss") as HTMLInputElement;
+
+    const paintChip = () => {
+      chip.textContent = `⇅ ${pane.link.name === "custom" ? `${pane.link.ms}ms` : pane.link.name} ▾`;
+      msInput.value = String(pane.link.ms);
+      jitterInput.value = String(pane.link.jitter);
+      lossInput.value = String(pane.link.loss);
+      for (const button of menu.querySelectorAll(".mp-link-presets button")) {
+        button.setAttribute(
+          "aria-pressed",
+          String((button as HTMLElement).dataset.name === pane.link.name)
+        );
+      }
+    };
+    chip.addEventListener("click", () => {
+      const open = menu.hidden;
+      for (const other of document.querySelectorAll<HTMLElement>(".mp-link-menu")) {
+        other.hidden = true;
+      }
+      menu.hidden = !open;
+    });
+    document.addEventListener("mousedown", (event) => {
+      if (!host.contains(event.target as Node)) menu.hidden = true;
+    });
+    for (const button of menu.querySelectorAll<HTMLButtonElement>(".mp-link-presets button")) {
+      button.addEventListener("click", () => {
+        const preset = LINK_PRESETS.find((candidate) => candidate.name === button.dataset.name);
+        if (preset) pane.link = { ...preset };
+        paintChip();
+      });
+    }
+    for (const input of menu.querySelectorAll("input")) {
+      input.addEventListener("input", () => {
+        pane.link = {
+          name: "custom",
+          ms: Number(msInput.value) || 0,
+          jitter: Number(jitterInput.value) || 0,
+          loss: Number(lossInput.value) || 0,
+        };
+        paintChip();
+      });
+    }
+    paintChip();
+  }
+
+  // -------------------------------------------------- aggregate status pill
+  // With one client the PAGE owns the pill (its exact loading…/live/error
+  // texts); with more, the pill aggregates every pane. `lastMain` lets a
+  // shrink back to one client restore the page's own wording.
+  let mainState: PaneState = "busy";
+  let mainDetail = "";
+  let lastMain: { state: PaneState; text: string; detail: string } | null = null;
+  const setPaneState = (pane: Pane, state: PaneState, detail = "") => {
+    pane.state = state;
+    for (const dot of pane.dots) dot.dataset.state = state;
+    pane.errStrip.hidden = state !== "error";
+    if (state === "error") pane.errStrip.textContent = `✕ ${detail}`;
+    paintAggregate();
+  };
+  const paintAggregate = () => {
+    if (panes.length === 1) {
+      if (lastMain) setPill(lastMain.state, lastMain.text, lastMain.detail);
+      return;
+    }
+    const states = [mainState, ...panes.slice(1).map((pane) => pane.state)];
+    if (states.includes("error")) {
+      setPill("error", "✕ build error", mainDetail);
+    } else if (states.includes("busy")) {
+      setPill("busy", "◐ reloading…", "");
+    } else {
+      setPill("live", `● ${panes.length} running`, mainDetail);
+    }
+  };
+
+  // ------------------------------------------------------ chrono bar wiring
+  const seams = () => panes.map((pane) => seamOf(pane.iframe)).filter((s): s is ScrubSeam => !!s);
+  const primarySeam = () => seamOf(panes[focused].iframe) ?? seams()[0] ?? null;
+
+  $btn("mp-pause").addEventListener("click", () => {
+    const primary = primarySeam();
+    if (!primary) return;
+    const desired = !primary.paused();
+    for (const seam of seams()) if (seam.paused() !== desired) seam.togglePause();
+  });
+  $btn("mp-step").addEventListener("click", () => {
+    for (const seam of seams()) seam.step();
+  });
+  // The speculative preview (🔮): each pane simulates forward from its parked
+  // frame under the current code, replaying recorded input. Broadcast like
+  // pause — every pane extrapolates its own sim.
+  $btn("mp-extrap").addEventListener("click", () => {
+    const primary = primarySeam();
+    if (!primary) return;
+    const enabled = !primary.model().preview.enabled;
+    for (const seam of seams()) seam.setPreview({ enabled });
+  });
+
+  // ⚙ advanced: window/rate broadcast through the seam. The ghost-mode select
+  // isn't in the seam's model, so it reaches into each pane's own (hidden)
+  // scrubber select — a prototype-only shortcut, like the CSS injection.
+  const advWin = $input("mp-adv-win");
+  const advRate = $input("mp-adv-rate");
+  const advMode = chrono.querySelector("#mp-adv-mode") as HTMLSelectElement;
+  const pushAdv = () => {
+    if (!advWin.validity.valid || !advRate.validity.valid) return;
+    for (const seam of seams()) {
+      seam.setPreview({ seconds: advWin.valueAsNumber, rate: advRate.valueAsNumber });
+    }
+  };
+  advWin.addEventListener("input", pushAdv);
+  advRate.addEventListener("input", pushAdv);
+  advMode.addEventListener("change", () => {
+    for (const pane of panes) {
+      try {
+        const select = pane.iframe.contentDocument?.getElementById(
+          "scrub-mode"
+        ) as HTMLSelectElement | null;
+        if (select) {
+          select.value = advMode.value;
+          select.dispatchEvent(new Event("change"));
+        }
+      } catch {
+        // a pane mid-navigation has no reachable document
+      }
+    }
+  });
+
+  // The pink preview handle: drag to stretch the extrapolation window, exactly
+  // like the old in-frame scrubber's second slider.
+  const previewHandle = $("mp-preview-handle");
+  let previewDrag: { x: number; seconds: number } | null = null;
+  previewHandle.addEventListener("pointerdown", (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    previewHandle.setPointerCapture(event.pointerId);
+    previewDrag = { x: event.clientX, seconds: primarySeam()?.model().preview.seconds ?? 2 };
+  });
+  previewHandle.addEventListener("pointermove", (event) => {
+    if (!previewDrag || !previewHandle.hasPointerCapture(event.pointerId)) return;
+    const current = primarySeam()?.view();
+    const width = rail.getBoundingClientRect().width;
+    const span = current ? current.viewport.hi - current.viewport.lo : 0;
+    if (width <= 0 || span <= 0) return;
+    const deltaFrames = ((event.clientX - previewDrag.x) / width) * span;
+    for (const seam of seams()) {
+      seam.setPreview({ seconds: previewDrag.seconds + deltaFrames / 60 });
+    }
+    const settled = primarySeam()?.model().preview.seconds;
+    if (settled !== undefined) advWin.value = String(settled);
+  });
+  const endPreviewDrag = () => {
+    previewDrag = null;
+  };
+  previewHandle.addEventListener("pointerup", endPreviewDrag);
+  previewHandle.addEventListener("pointercancel", endPreviewDrag);
+
+  const tip = $("mp-evt-tip");
+  const showTip = (unit: number, text: string) => {
+    tip.style.display = "block";
+    tip.style.left = `${Math.min(95, Math.max(5, unit * 100))}%`;
+    tip.textContent = text;
+  };
+  const hideTip = () => {
+    tip.style.display = "none";
+  };
+
+  const rail = $("mp-rail");
+  const seekAt = (event: PointerEvent) => {
+    const primary = primarySeam();
+    const current = primary?.view();
+    if (!current) return;
+    const rect = rail.getBoundingClientRect();
+    const unit =
+      rect.width > 0 ? Math.max(0, Math.min(1, (event.clientX - rect.left) / rect.width)) : 0;
+    const target = Math.round(
+      current.viewport.lo + unit * (current.viewport.hi - current.viewport.lo)
+    );
+    for (const seam of seams()) seam.seek(target);
+  };
+  rail.addEventListener("pointerdown", (event) => {
+    event.preventDefault();
+    rail.setPointerCapture(event.pointerId);
+    seekAt(event);
+  });
+  rail.addEventListener("pointermove", (event) => {
+    if (rail.hasPointerCapture(event.pointerId)) seekAt(event);
+  });
+
+  // The rail mirrors the FOCUSED pane (each pane is an independent sim in the
+  // prototype, so one authoritative rail per focus is the honest picture; the
+  // sim substrate replaces this with server time).
+  const markersHost = $("mp-markers");
+  const ticksHost = $("mp-ticks");
+  let markerKey = "";
+  let lastLabel = "";
+  const paint = () => {
+    const primary = primarySeam();
+    const current = primary?.view();
+    chrono.classList.toggle("dormant", !current);
+    if (primary && current) {
+      const span = Math.max(current.viewport.hi - current.viewport.lo, 1);
+      $("mp-played").style.width = `${Math.min(current.playheadUnit, 1) * 100}%`;
+      $("mp-recorded").style.left = `${current.recordedStartUnit * 100}%`;
+      $("mp-recorded").style.width =
+        `${Math.max(current.recordedEndUnit - current.recordedStartUnit, 0) * 100}%`;
+      $("mp-playhead").style.left = `${current.playheadUnit * 100}%`;
+      const previewOn = primary.model().preview.enabled;
+      const future = $("mp-future");
+      future.style.left = `${current.playheadUnit * 100}%`;
+      future.style.width = previewOn
+        ? `${Math.max(current.previewEndUnit - current.playheadUnit, 0) * 100}%`
+        : "0";
+      previewHandle.style.display = previewOn ? "block" : "none";
+      previewHandle.style.left = `${current.previewEndUnit * 100}%`;
+      previewHandle.classList.toggle("clipped", current.previewClippedFrames > 0);
+      const overflow = $("mp-overflow");
+      overflow.style.display = previewOn && current.previewClippedFrames > 0 ? "block" : "none";
+      overflow.textContent = `+${current.previewClippedFrames}`;
+      $btn("mp-extrap").classList.toggle("on", previewOn);
+      $btn("mp-extrap").setAttribute("aria-pressed", String(previewOn));
+      const labelHtml =
+        `${current.selectedFrame}` +
+        (previewOn ? ` <span class="fut">+${current.previewFrames}</span>` : "") +
+        ` / ${Math.round(current.viewport.hi)}`;
+      if (labelHtml !== lastLabel) {
+        lastLabel = labelHtml;
+        $("mp-frame").innerHTML = labelHtml;
+      }
+      $btn("mp-pause").textContent = current.paused ? "▶" : "⏸";
+      // Second ticks (60 frames), heavier every 5s. Positions track the moving
+      // viewport each frame; nodes are recycled, only count changes touch DOM.
+      const lo = current.viewport.lo;
+      const firstTick = Math.ceil(lo / 60) * 60;
+      const tickFrames: number[] = [];
+      for (let f = firstTick; f <= current.viewport.hi; f += 60) tickFrames.push(f);
+      while (ticksHost.children.length > tickFrames.length) ticksHost.lastChild?.remove();
+      while (ticksHost.children.length < tickFrames.length) {
+        ticksHost.appendChild(document.createElement("i"));
+      }
+      tickFrames.forEach((tickFrame, index) => {
+        const node = ticksHost.children[index] as HTMLElement;
+        node.className = tickFrame % 300 === 0 ? "mp-tick major" : "mp-tick";
+        node.style.left = `${((tickFrame - lo) / span) * 100}%`;
+      });
+      // Event markers (input / reload / reload-error): the reload ticks are the
+      // "source changes on the timeline" — every hot-swap is already recorded.
+      const key = current.eventMarkers
+        .map((marker) => `${marker.id}:${marker.unit.toFixed(4)}:${marker.kind}`)
+        .join("|");
+      if (key !== markerKey) {
+        markerKey = key;
+        hideTip();
+        markersHost.replaceChildren(
+          ...current.eventMarkers.map((marker) => {
+            const tick = document.createElement("button");
+            tick.className = `mp-evt ${marker.kind === "reload-error" ? "err" : marker.category}`;
+            tick.style.left = `${marker.unit * 100}%`;
+            const detail =
+              `frame ${marker.frame} · ${marker.labels[0]}` +
+              (marker.count > 1 ? ` · ${marker.count} events` : "");
+            tick.setAttribute("aria-label", detail);
+            tick.addEventListener("pointerdown", (event) => event.stopPropagation());
+            tick.addEventListener("click", (event) => {
+              event.stopPropagation();
+              for (const seam of seams()) seam.seek(marker.frame);
+            });
+            tick.addEventListener("mouseenter", () => showTip(marker.unit, detail));
+            tick.addEventListener("mouseleave", hideTip);
+            return tick;
+          })
+        );
+      }
+    }
+    for (const pane of panes) {
+      const seam = seamOf(pane.iframe);
+      const frameNow = seam ? seam.frame() : null;
+      const text = frameNow === null || frameNow === undefined ? "—" : String(frameNow);
+      for (const label of pane.frameLabels) {
+        if (label.textContent !== text) label.textContent = text;
+      }
+    }
+  };
+  // rAF, not a timer: while dragging the rail the playhead/label must track
+  // the pointer at frame rate — a slow poll here reads as a sluggish sim.
+  // All DOM writes above are change-guarded, so the steady-state cost is
+  // reads only (same shape as the in-frame scrubber's own rAF loop).
+  let raf = 0;
+  const tickLoop = () => {
+    paint();
+    raf = requestAnimationFrame(tickLoop);
+  };
+  raf = requestAnimationFrame(tickLoop);
+
+  return {
+    // Mirror a fresh program load into the extra panes.
+    setSrc(src) {
+      for (const { pane, bridge } of mirrors) {
+        bridge.reset();
+        setPaneState(pane, "busy");
+        pane.iframe.src = withHiddenScrubber(src);
+      }
+    },
+    // Mirror a debounced hot-reload push.
+    push(source) {
+      for (const { bridge } of mirrors) bridge.push(source);
+    },
+    reset() {
+      for (const { bridge } of mirrors) bridge.reset();
+    },
+    // The page's own status writer delegates here. It has ALREADY written the
+    // pill (its single-client wording); with more than one pane the aggregate
+    // overwrites it, and `lastMain` remembers the wording for a shrink to 1.
+    aggregateStatus(state, text, detail) {
+      mainState = state;
+      mainDetail = detail;
+      lastMain = { state, text, detail };
+      setPaneState(panes[0], state, detail);
+    },
+    setCount,
+    count: () => panes.length,
+    destroy() {
+      cancelAnimationFrame(raf);
+    },
+  };
+}

--- a/site/src/player-bridge.ts
+++ b/site/src/player-bridge.ts
@@ -46,6 +46,7 @@ export class PlayerBridge {
       onResult,
       debounceMs = PUSH_DEBOUNCE_MS,
       errorGraceMs = ERROR_GRACE_MS,
+      signal,
     }: BridgeOptions
   ) {
     this.iframe = iframe;
@@ -57,7 +58,11 @@ export class PlayerBridge {
 
     // Replies and readiness from the player iframe. Only trust the iframe we
     // created (same-origin, but be explicit about the source anyway).
-    window.addEventListener("message", (event) => this.#onMessage(event));
+    window.addEventListener(
+      "message",
+      (event) => this.#onMessage(event),
+      signal !== undefined ? { signal } : undefined
+    );
 
     // Handshake: the player posts a one-shot `functor-lang-preview-ready` when it
     // boots, but under load that can fire before this bridge exists (its message

--- a/site/src/protocol.ts
+++ b/site/src/protocol.ts
@@ -81,6 +81,8 @@ export interface BridgeOptions {
   onResult: (ok: boolean, message: string) => void;
   debounceMs?: number;
   errorGraceMs?: number;
+  /** Aborting detaches the bridge's window listener (for disposable panes). */
+  signal?: AbortSignal;
 }
 
 // --- player → editor ---------------------------------------------------------

--- a/site/src/sandbox.tsx
+++ b/site/src/sandbox.tsx
@@ -34,7 +34,9 @@ import { createRuntimeTargetCore } from "./runtime-target-core.js";
 import type { RuntimeTargetState } from "./runtime-target-core.js";
 import { createStore } from "./store.js";
 import { SandboxControls } from "./components/SandboxControls.js";
-import type { PickerState } from "./components/SandboxControls.js";
+import type { PickerState, ClientsState } from "./components/SandboxControls.js";
+import { initMultiplayerPanes } from "./mp-panes.js";
+import type { MultiplayerPanes } from "./mp-panes.js";
 import type { PillState } from "./components/StatusPill.js";
 import { StatusBar } from "./components/StatusBar.js";
 import { asPlayerMessage } from "./protocol.js";
@@ -79,11 +81,30 @@ const picker = createStore<PickerState>({
 });
 const pill = createStore<PillState>({ state: "busy", text: "◌ loading…", detail: "" });
 
+// Multiplayer pane-grid prototype (mp-panes.ts): #clients=2|3 turns the
+// preview column into a chrono bar + N client panes. A HASH param, not a
+// query: count changes apply live (panes grow/shrink in place, client 1's
+// model survives) with no page reload. ?clients= still parses for old links.
+const hashClients = () =>
+  Number(new URLSearchParams(window.location.hash.slice(1)).get("clients")) || 0;
+const requestedClients = Math.min(
+  4,
+  Math.max(
+    1,
+    hashClients() || Number(new URLSearchParams(window.location.search).get("clients")) || 1
+  )
+);
+let mp: MultiplayerPanes | null = null;
+const clients = createStore<ClientsState>({ count: requestedClients, visible: false });
+
 const setStatus = (state: PillState["state"], text: string, detail = "") => {
   // The detail (the reload note, or a parse error) lives in the pill's tooltip
   // and — for errors — the Output panel. No separate error banner under the
   // editor: the preview pill is the single live indicator.
   pill.set({ state, text, detail });
+  // In multiplayer the pill aggregates every pane ("● 3 running"); the primary
+  // pane's state feeds the same aggregate.
+  mp?.aggregateStatus(state, text, detail);
 };
 
 // The boot loader (static markup in sandbox.html) evaporates when the PLAYER
@@ -94,6 +115,58 @@ const dismissBootLoader = () =>
   document.querySelector("[data-fn-boot]")?.classList.add("is-done");
 
 const statusBar = createStatusBarStore();
+
+// One scrubber regardless of client count: the chrono bar mounts even for a
+// single client (tiled/tabs disabled, no pane chrome) so the instrument is in
+// the same place with the same look at every N. `getSource` lets a mirror
+// added mid-session catch up to the edited buffer (`view` exists by the time
+// any pane is added).
+mp = initMultiplayerPanes({
+  frame,
+  count: requestedClients,
+  statusBar,
+  setPill: (state, text, detail) => pill.set({ state, text, detail }),
+  getSource: () => view.state.doc.toString(),
+});
+
+// The CLIENTS control only appears for samples that support multiplayer (a
+// server entry point) — N panes of a single-entry scene are just N copies.
+// It stays visible while #clients= forces panes, so there is always a way
+// back to 1; the hash keeps working everywhere as the dev seam.
+const updateClientsStore = () => {
+  const example = EXAMPLES.find((candidate) => candidate.id === picker.getSnapshot().selected);
+  clients.set({
+    count: mp!.count(),
+    visible: Boolean(example?.multiplayer) || mp!.count() > 1,
+  });
+};
+updateClientsStore();
+
+// Reflect the live count into the hash (replaceState — no navigation, and the
+// #src= inline-program param survives alongside it).
+const writeClientsHash = (n: number) => {
+  const hash = new URLSearchParams(window.location.hash.slice(1));
+  if (n > 1) hash.set("clients", String(n));
+  else hash.delete("clients");
+  const url = new URL(window.location.href);
+  url.hash = hash.toString();
+  window.history.replaceState(null, "", url);
+};
+
+const selectClients = (n: number) => {
+  mp!.setCount(n);
+  writeClientsHash(mp!.count());
+  updateClientsStore();
+};
+
+// Back/forward (or a hand-edited hash) also applies live.
+window.addEventListener("hashchange", () => {
+  const n = hashClients() || 1;
+  if (n !== mp!.count()) {
+    mp!.setCount(n);
+    updateClientsStore();
+  }
+});
 // The sandbox edits only the entry buffer, but some examples also load sibling
 // modules (for example Mario's generated assets.fun manifest). Keep those
 // fetched sources so an external runtime receives the same complete project as
@@ -129,7 +202,11 @@ window.addEventListener("message", (event) => {
   const data = asPlayerMessage(event.data);
   if (!data || data.type !== "functor-lang-console") return;
   if (event.source !== frame.contentWindow) return;
-  statusBar.appendOutput(data.level, data.message, data.frame ?? null);
+  statusBar.appendOutput(
+    data.level,
+    mp && mp.count() > 1 ? `[client 1] ${data.message}` : data.message,
+    data.frame ?? null
+  );
 });
 
 
@@ -156,6 +233,7 @@ const view = new EditorView({
     EditorView.updateListener.of((update) => {
       if (update.docChanged && !programmaticEdit) {
         bridge.push(view.state.doc.toString());
+        mp?.push(view.state.doc.toString());
         runtimeTarget.projectChanged();
       }
     }),
@@ -215,6 +293,7 @@ const setDoc = (
   assets: [string, Uint8Array][] = []
 ) => {
   bridge.reset();
+  mp?.reset();
   // Wholesale document replacement (example switch, inline load, reset): drop
   // the wasm completion cache so the previous program's candidates can't leak.
   resetIntel();
@@ -263,6 +342,7 @@ const loadInline = (b64u: string) => {
   // `init` (a set-source push would preserve the default entry's model). The
   // loader derives module `Main` for a non-identifier entry label.
   frame.src = `player.html?src=${b64u}`;
+  mp?.setSrc(frame.src);
   return true;
 };
 
@@ -310,6 +390,7 @@ const loadExample = async (id: string) => {
   const params = new URLSearchParams({ game: url });
   for (const file of files) params.append("file", file);
   frame.src = `player.html?${params}`;
+  mp?.setSrc(frame.src);
 };
 
 const selectExample = (value: string) => {
@@ -321,8 +402,12 @@ const selectExample = (value: string) => {
   }
   const url = new URL(window.location.href);
   url.searchParams.set("example", value);
-  url.hash = "";
+  // Drop a stale inline program from the hash, but keep #clients=N alive.
+  const hash = new URLSearchParams(window.location.hash.slice(1));
+  hash.delete("src");
+  url.hash = hash.toString();
   window.history.replaceState(null, "", url);
+  updateClientsStore();
   loadExample(value);
 };
 
@@ -339,9 +424,11 @@ createRoot(document.querySelector(".sandbox-controls")!).render(
   <SandboxControls
     picker={picker}
     pill={pill}
+    clients={clients}
     runtimeTarget={runtimeTarget}
     onSelect={selectExample}
     onReset={resetExample}
+    onClients={selectClients}
   />
 );
 const statusBarHost = document.getElementById("statusbar")!;

--- a/site/src/sandbox.tsx
+++ b/site/src/sandbox.tsx
@@ -35,7 +35,7 @@ import type { RuntimeTargetState } from "./runtime-target-core.js";
 import { createStore } from "./store.js";
 import { SandboxControls } from "./components/SandboxControls.js";
 import type { PickerState, ClientsState } from "./components/SandboxControls.js";
-import { initMultiplayerPanes } from "./mp-panes.js";
+import { initMultiplayerPanes, MAX_CLIENTS } from "./mp-panes.js";
 import type { MultiplayerPanes } from "./mp-panes.js";
 import type { PillState } from "./components/StatusPill.js";
 import { StatusBar } from "./components/StatusBar.js";
@@ -88,7 +88,7 @@ const pill = createStore<PillState>({ state: "busy", text: "◌ loading…", det
 const hashClients = () =>
   Number(new URLSearchParams(window.location.hash.slice(1)).get("clients")) || 0;
 const requestedClients = Math.min(
-  4,
+  MAX_CLIENTS,
   Math.max(
     1,
     hashClients() || Number(new URLSearchParams(window.location.search).get("clients")) || 1
@@ -116,11 +116,11 @@ const dismissBootLoader = () =>
 
 const statusBar = createStatusBarStore();
 
-// One scrubber regardless of client count: the chrono bar mounts even for a
-// single client (tiled/tabs disabled, no pane chrome) so the instrument is in
-// the same place with the same look at every N. `getSource` lets a mirror
-// added mid-session catch up to the edited buffer (`view` exists by the time
-// any pane is added).
+// The pane system mounts at every count, but its chrome is dark at one
+// client — no chrono bar, no pane frame, the stock in-frame scrubber. The
+// single-client chrono unification follows separately with the a11y parity
+// it requires. `getSource` lets a mirror added mid-session catch up to the
+// edited buffer (`view` exists by the time any pane is added).
 mp = initMultiplayerPanes({
   frame,
   count: requestedClients,
@@ -135,9 +135,12 @@ mp = initMultiplayerPanes({
 // back to 1; the hash keeps working everywhere as the dev seam.
 const updateClientsStore = () => {
   const example = EXAMPLES.find((candidate) => candidate.id === picker.getSnapshot().selected);
+  // Latched: once the control has appeared (a flagged sample, or a forcing
+  // hash), shrinking back to 1 must not remove the only way to grow again.
   clients.set({
     count: mp!.count(),
-    visible: Boolean(example?.multiplayer) || mp!.count() > 1,
+    visible:
+      clients.getSnapshot().visible || Boolean(example?.multiplayer) || mp!.count() > 1,
   });
 };
 updateClientsStore();
@@ -150,6 +153,9 @@ const writeClientsHash = (n: number) => {
   else hash.delete("clients");
   const url = new URL(window.location.href);
   url.hash = hash.toString();
+  // Also retire the legacy ?clients= fallback — leaving it would resurrect
+  // the old count on the next reload after an explicit shrink.
+  url.searchParams.delete("clients");
   window.history.replaceState(null, "", url);
 };
 

--- a/site/styles.css
+++ b/site/styles.css
@@ -2498,7 +2498,7 @@ a:hover {
 }
 
 .mp-chrono.dormant .mp-rail,
-.mp-chrono.dormant .mp-frame-lbl {
+.mp-chrono.dormant .mp-rail-label {
   opacity: 0.35;
 }
 
@@ -2597,16 +2597,6 @@ a:hover {
   border: 1px solid #b9f8ff;
   box-shadow: 0 0 12px rgba(65, 216, 230, 0.6);
   pointer-events: none;
-}
-
-.mp-frame-lbl {
-  font-variant-numeric: tabular-nums;
-  white-space: nowrap;
-}
-
-.mp-frame-lbl b {
-  color: var(--text-dim);
-  font-weight: 400;
 }
 
 .mp-viewseg {
@@ -2711,7 +2701,9 @@ a:hover {
      border, real separation from depth. */
   border: 1px solid color-mix(in srgb, var(--pc) 12%, rgba(43, 37, 66, 0.6));
   border-radius: 5px;
-  overflow: hidden;
+  /* NOT overflow:hidden — the link menu must escape the pane. The children
+     carry the rounding: the header clips its top corners, the body clips the
+     iframe's bottom corners (unless the error strip is the last row). */
   background: #0b0817;
   box-shadow:
     0 2px 6px rgba(0, 0, 0, 0.45),
@@ -2730,6 +2722,7 @@ a:hover {
 .mp-pane-hd {
   position: relative;
   z-index: 6; /* the link menu must paint above the pane's iframe */
+  border-radius: 4px 4px 0 0;
   display: flex;
   align-items: center;
   gap: 8px;
@@ -2809,6 +2802,11 @@ a:hover {
   flex: 1;
   min-height: 0;
   position: relative;
+  overflow: hidden;
+}
+
+.mp-pane-body:last-child {
+  border-radius: 0 0 4px 4px;
 }
 
 .mp-pane-body iframe {
@@ -2820,6 +2818,7 @@ a:hover {
 }
 
 .mp-pane-err {
+  border-radius: 0 0 4px 4px;
   padding: 4px 9px;
   font: 10.5px/1.4 var(--font-mono);
   color: var(--red);
@@ -2960,25 +2959,6 @@ a:hover {
   opacity: 0.7;
 }
 
-.mp-rail-label .fut {
-  color: var(--pink);
-}
-
-.mp-future {
-  position: absolute;
-  top: 11px;
-  height: 8px;
-  border-radius: 3px;
-  background: var(--pink);
-  opacity: 0.9;
-  box-shadow: 0 0 10px rgba(232, 88, 184, 0.5);
-}
-
-#mp-extrap.on {
-  border-color: var(--pink);
-  box-shadow: 0 0 0 1px var(--pink), 0 2px 10px rgba(232, 88, 184, 0.4);
-}
-
 .mp-viewseg button:disabled {
   opacity: 0.35;
   cursor: default;
@@ -3014,10 +2994,8 @@ a:hover {
 }
 
 .preview-pane.mp[data-count="1"] .mp-pane.focus {
-  border-color: color-mix(in srgb, var(--pc) 12%, rgba(43, 37, 66, 0.6));
-  box-shadow:
-    0 2px 6px rgba(0, 0, 0, 0.45),
-    0 12px 36px rgba(0, 0, 0, 0.55);
+  border: 0;
+  box-shadow: none;
 }
 
 /* ---- restored scrubber polish: handles, tooltip, overflow chip, ⚙ ---- */
@@ -3041,41 +3019,6 @@ a:hover {
   outline-offset: 1px;
 }
 
-.mp-preview-handle {
-  display: none;
-  position: absolute;
-  top: 15px;
-  z-index: 3;
-  width: 14px;
-  height: 20px;
-  border-radius: 4px;
-  transform: translate(-50%, -50%);
-  background: var(--pink);
-  border: 1px solid #ffd0ee;
-  box-shadow: 0 0 12px rgba(232, 88, 184, 0.6);
-  cursor: ew-resize;
-  touch-action: none;
-}
-
-.mp-preview-handle.clipped {
-  border-radius: 4px 0 0 4px;
-}
-
-.mp-overflow {
-  display: none;
-  position: absolute;
-  right: 0;
-  top: -6px;
-  z-index: 4;
-  padding: 2px 4px;
-  border: 1px solid var(--pink);
-  border-radius: 5px;
-  color: #ffd0ee;
-  background: rgba(30, 24, 51, 0.96);
-  font-size: 9px;
-  pointer-events: none;
-}
-
 .mp-evt-tip {
   display: none;
   position: absolute;
@@ -3097,94 +3040,10 @@ a:hover {
   pointer-events: none;
 }
 
-.mp-adv {
-  position: relative;
-}
-
-.mp-adv > summary {
-  list-style: none;
-  user-select: none;
-  font: 13px/1 var(--font-mono);
-  color: var(--text);
-  cursor: pointer;
-  background: rgba(65, 216, 230, 0.1);
-  border: 1px solid var(--line);
-  border-radius: 5px;
-  padding: 5px 8px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
-}
-
-.mp-adv > summary::-webkit-details-marker {
-  display: none;
-}
-
-.mp-adv > summary:hover,
-.mp-adv[open] > summary {
-  border-color: var(--cyan);
-}
-
-.mp-adv-pop {
-  position: absolute;
-  top: calc(100% + 10px);
-  right: 0;
-  z-index: 30;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 10px 12px;
-  background: rgba(30, 24, 51, 0.98);
-  border-radius: 8px;
-  border: 1px solid var(--line);
-  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.5);
-  white-space: nowrap;
-  font-size: 12px;
-}
-
-.mp-adv-pop label {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  justify-content: space-between;
-}
-
-.mp-adv-pop select,
-.mp-adv-pop input[type="number"] {
-  font: 12px/1 var(--font-mono);
-  color: var(--text);
-  background: rgba(65, 216, 230, 0.1);
-  border: 1px solid var(--line);
-  border-radius: 5px;
-  padding: 4px 5px;
-}
-
-.mp-adv-pop select {
-  appearance: none;
-  -webkit-appearance: none;
-  padding-right: 20px;
-  cursor: pointer;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='5'%3E%3Cpath d='M0 0h8L4 5z' fill='%239b94b3'/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: right 7px center;
-}
-
-.mp-adv-pop input[type="number"] {
-  width: 46px;
-}
-
-/* ---- 🔮 is single-client only; multiplayer gets tiled/tabs in its place ---- */
-
-/* Whole-session forward extrapolation means N speculative re-simulations —
-   not v1, and a greyed magic wand invites bug reports. Hidden, not disabled
-   (design-multiplayer-ide-frontend.md §1); the view toggle takes the slot.
-   With one client the toggle is meaningless and the 🔮/⚙ pair returns. */
-.preview-pane.mp:not([data-count="1"]) #mp-extrap,
-.preview-pane.mp:not([data-count="1"]) .mp-adv {
-  display: none;
-}
-
-.preview-pane.mp[data-count="1"] .mp-viewseg {
-  display: none;
-}
+/* The 🔮 extrapolation surface ships with the single-client chrono
+   unification (it is single-client-only by design: whole-session forward
+   extrapolation means N speculative re-simulations). Until then the chrono
+   bar carries the view toggle alone. */
 
 /* ---- second ticks along the rail (every 60 frames; heavier each 5s) ---- */
 
@@ -3207,16 +3066,13 @@ a:hover {
 /* Numeric fields are raw text entry — the native spinner arrows fight the
    theme and are unusably small; type=number keeps validation and keyboard
    arrows working. */
-.mp-link-menu input[type="number"],
-.mp-adv-pop input[type="number"] {
+.mp-link-menu input[type="number"] {
   appearance: textfield;
   -moz-appearance: textfield;
 }
 
 .mp-link-menu input[type="number"]::-webkit-inner-spin-button,
-.mp-link-menu input[type="number"]::-webkit-outer-spin-button,
-.mp-adv-pop input[type="number"]::-webkit-inner-spin-button,
-.mp-adv-pop input[type="number"]::-webkit-outer-spin-button {
+.mp-link-menu input[type="number"]::-webkit-outer-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }

--- a/site/styles.css
+++ b/site/styles.css
@@ -17,6 +17,14 @@
   --font-display: "Orbitron", system-ui, sans-serif;
   --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, monospace;
 
+  /* Player-identity colors for multiplayer chrome (pane borders, tabs, lag
+     combs, Output prefixes). One identity everywhere; p1/p2 deliberately alias
+     the site accents so the multiplayer chrome reads as the same product. */
+  --scrub-p1: var(--cyan);
+  --scrub-p2: var(--pink);
+  --scrub-p3: var(--amber);
+  --scrub-p4: var(--green);
+
   /* Spacing scale — a single rhythm the whole landing page snaps to. */
   --space-sm: 16px;
   --space-md: 24px;
@@ -819,6 +827,7 @@ a:hover {
 }
 
 #example-picker,
+#client-count,
 #reset,
 #download,
 #restart {
@@ -832,8 +841,9 @@ a:hover {
   padding: 5px 9px;
 }
 
-/* Selects drop the OS widget chrome for a themed ▾ chip look. */
-#example-picker {
+/* Selects drop the OS widget chrome for the mockup's ▾ chip look. */
+#example-picker,
+#client-count {
   appearance: none;
   -webkit-appearance: none;
   padding-right: 24px;
@@ -843,7 +853,8 @@ a:hover {
   background-position: right 9px center;
 }
 
-#example-picker:hover {
+#example-picker:hover,
+#client-count:hover {
   border-color: var(--cyan);
   color: var(--cyan);
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='5'%3E%3Cpath d='M0 0h8L4 5z' fill='%2341d8e6'/%3E%3C/svg%3E");
@@ -2452,4 +2463,760 @@ a:hover {
     opacity: 0;
     visibility: hidden;
   }
+}
+
+/* ---------------------------------------------------------- mp pane grid */
+
+/* Multiplayer prototype (sandbox ?clients=N > 1): the preview column becomes
+   chrono bar | tab strip (tabs view) | pane grid. The chrono bar governs only
+   the game side — the editor keeps its full height. Player identity comes
+   from --pc (set per pane from --scrub-p1..p4). */
+
+.preview-pane.mp {
+  display: flex;
+  flex-direction: column;
+  background:
+    radial-gradient(120% 80% at 50% 0%, #171029 0%, var(--bg) 60%);
+}
+
+.mp-chrono {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px 14px;
+  font: 12px/1 var(--font-mono);
+  color: var(--text);
+  background: rgba(30, 24, 51, 0.92);
+  border-bottom: 1px solid var(--line);
+  box-shadow:
+    0 4px 12px rgba(0, 0, 0, 0.5),
+    0 14px 36px rgba(0, 0, 0, 0.38);
+  position: relative;
+  /* Above the pane grid (pane headers are z-index 6 for their link menus), so
+     the ⚙ popover and event tooltip never clip under the window chrome. */
+  z-index: 12;
+}
+
+.mp-chrono.dormant .mp-rail,
+.mp-chrono.dormant .mp-frame-lbl {
+  opacity: 0.35;
+}
+
+.mp-sbtn {
+  font: 13px/1 var(--font-mono);
+  color: var(--text);
+  cursor: pointer;
+  background: rgba(65, 216, 230, 0.1);
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  padding: 5px 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
+  transition: box-shadow 0.12s ease, border-color 0.12s ease;
+}
+
+.mp-sbtn:hover {
+  border-color: var(--cyan);
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.5);
+}
+
+.mp-rail {
+  position: relative;
+  flex: 1;
+  min-width: 80px;
+  height: 30px;
+  cursor: ew-resize;
+  touch-action: none;
+  user-select: none;
+}
+
+.mp-track,
+.mp-recorded,
+.mp-played {
+  position: absolute;
+  top: 12px;
+  height: 6px;
+  border-radius: 3px;
+}
+
+.mp-track {
+  left: 0;
+  right: 0;
+  background: rgba(155, 148, 179, 0.18);
+}
+
+.mp-recorded {
+  background: rgba(65, 216, 230, 0.3);
+}
+
+.mp-played {
+  left: 0;
+  background: var(--cyan);
+  opacity: 0.62;
+  box-shadow: 0 0 10px rgba(65, 216, 230, 0.45);
+}
+
+/* Event markers span the full rail (the mockup's .evt ticks): thin amber input
+   lines, slightly heavier violet reload / red error lines, each with a soft
+   glow so they read through the played bar. */
+.mp-evt {
+  position: absolute;
+  top: 3px;
+  height: 24px;
+  transform: translateX(-50%);
+  border-radius: 1px;
+  pointer-events: auto;
+}
+
+.mp-evt.input {
+  background: #ffd166;
+  width: 2px;
+  opacity: 0.75;
+  box-shadow: 0 0 5px rgba(255, 209, 102, 0.5);
+}
+
+.mp-evt.reload {
+  background: #b994ff;
+  width: 3px;
+  box-shadow: 0 0 6px rgba(185, 148, 255, 0.6);
+}
+
+.mp-evt.err {
+  background: #ff6b7d;
+  width: 3px;
+  box-shadow: 0 0 6px rgba(255, 107, 125, 0.6);
+}
+
+.mp-playhead {
+  position: absolute;
+  top: 15px;
+  width: 14px;
+  height: 20px;
+  border-radius: 4px;
+  transform: translate(-50%, -50%);
+  background: var(--cyan);
+  border: 1px solid #b9f8ff;
+  box-shadow: 0 0 12px rgba(65, 216, 230, 0.6);
+  pointer-events: none;
+}
+
+.mp-frame-lbl {
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.mp-frame-lbl b {
+  color: var(--text-dim);
+  font-weight: 400;
+}
+
+.mp-viewseg {
+  display: flex;
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  overflow: hidden;
+}
+
+.mp-viewseg button {
+  font: 10px/1 var(--font-mono);
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  background: transparent;
+  border: 0;
+  border-right: 1px solid var(--line);
+  padding: 6px 9px;
+  cursor: pointer;
+  transition: background 0.14s, color 0.14s;
+}
+
+.mp-viewseg button:last-child {
+  border-right: 0;
+}
+
+.mp-viewseg button:hover {
+  background: rgba(65, 216, 230, 0.07);
+  color: var(--text);
+}
+
+.mp-viewseg button[aria-pressed="true"] {
+  background: rgba(65, 216, 230, 0.14);
+  color: var(--cyan);
+}
+
+/* ---- tab strip (tabs view) ---- */
+
+.mp-tabs {
+  display: flex;
+  gap: 6px;
+  padding: 8px 10px 0;
+}
+
+.mp-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font: 10px/1 var(--font-mono);
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  cursor: pointer;
+  background: color-mix(in srgb, var(--pc) 6%, var(--bg-raised));
+  border: 1px solid color-mix(in srgb, var(--pc) 28%, var(--line));
+  border-radius: 5px 5px 0 0;
+  border-bottom: 0;
+  padding: 7px 12px;
+  filter: saturate(0.45);
+  transition: filter 0.18s;
+}
+
+.mp-tab.focus {
+  color: var(--pc);
+  background: color-mix(in srgb, var(--pc) 14%, var(--bg-raised));
+  border-color: var(--pc);
+  filter: none;
+  box-shadow: 0 -2px 14px color-mix(in srgb, var(--pc) 25%, transparent);
+}
+
+/* ---- the grid ---- */
+
+.mp-grid {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  gap: 10px;
+  padding: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  grid-auto-rows: minmax(0, 1fr);
+}
+
+.mp-grid[data-view="tabs"] {
+  grid-template-columns: 1fr;
+  padding-top: 0;
+}
+
+.mp-grid[data-view="tabs"] .mp-pane:not(.focus) {
+  display: none;
+}
+
+/* ---- pane shell ---- */
+
+.mp-pane {
+  --pc: var(--cyan);
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  /* The frame is the shadow, not the line: a whisper of player color on the
+     border, real separation from depth. */
+  border: 1px solid color-mix(in srgb, var(--pc) 12%, rgba(43, 37, 66, 0.6));
+  border-radius: 5px;
+  overflow: hidden;
+  background: #0b0817;
+  box-shadow:
+    0 2px 6px rgba(0, 0, 0, 0.45),
+    0 12px 36px rgba(0, 0, 0, 0.55);
+  transition: border-color 0.18s, box-shadow 0.18s;
+}
+
+.mp-pane.focus {
+  border-color: color-mix(in srgb, var(--pc) 55%, transparent);
+  box-shadow:
+    0 0 22px color-mix(in srgb, var(--pc) 28%, transparent),
+    0 2px 6px rgba(0, 0, 0, 0.45),
+    0 12px 36px rgba(0, 0, 0, 0.55);
+}
+
+.mp-pane-hd {
+  position: relative;
+  z-index: 6; /* the link menu must paint above the pane's iframe */
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 9px;
+  font: 10.5px/1 var(--font-mono);
+  color: var(--text-dim);
+  background: color-mix(in srgb, var(--pc) 8%, var(--bg-raised));
+  border-bottom: 1px solid color-mix(in srgb, var(--pc) 14%, var(--line));
+  filter: saturate(0.45);
+  transition: filter 0.18s;
+  cursor: default;
+  user-select: none;
+}
+
+.mp-pane.focus .mp-pane-hd {
+  filter: none;
+  background: color-mix(in srgb, var(--pc) 15%, var(--bg-raised));
+}
+
+.mp-digit {
+  width: 15px;
+  height: 15px;
+  display: grid;
+  place-items: center;
+  border-radius: 3px;
+  flex: none;
+  background: color-mix(in srgb, var(--pc) 24%, transparent);
+  color: var(--pc);
+  font-size: 9.5px;
+}
+
+.mp-role {
+  color: var(--pc);
+  letter-spacing: 0.05em;
+}
+
+.mp-hd-r {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  font-variant-numeric: tabular-nums;
+}
+
+.mp-you {
+  color: var(--pc);
+}
+
+.mp-pf b {
+  color: var(--text-dim);
+  font-weight: 400;
+}
+
+.mp-st {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  flex: none;
+}
+
+.mp-st[data-state="live"] {
+  background: var(--green);
+  box-shadow: 0 0 6px var(--green);
+}
+
+.mp-st[data-state="busy"] {
+  background: var(--amber);
+  box-shadow: 0 0 6px var(--amber);
+}
+
+.mp-st[data-state="error"] {
+  background: var(--red);
+  box-shadow: 0 0 6px var(--red);
+}
+
+.mp-pane-body {
+  flex: 1;
+  min-height: 0;
+  position: relative;
+}
+
+.mp-pane-body iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  display: block;
+  background: var(--bg);
+}
+
+.mp-pane-err {
+  padding: 4px 9px;
+  font: 10.5px/1.4 var(--font-mono);
+  color: var(--red);
+  background: rgba(242, 99, 127, 0.1);
+  border-top: 1px solid rgba(242, 99, 127, 0.35);
+}
+
+/* ---- per-pane link chip + menu ---- */
+
+.mp-link-host {
+  position: relative;
+}
+
+.mp-link-chip {
+  font: 10px/1 var(--font-mono);
+  color: var(--text-dim);
+  cursor: pointer;
+  background: transparent;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  padding: 3px 7px;
+  transition: border-color 0.14s, color 0.14s;
+}
+
+.mp-link-chip:hover {
+  border-color: color-mix(in srgb, var(--pc) 50%, transparent);
+  color: var(--text);
+}
+
+.mp-link-menu {
+  position: absolute;
+  left: 0;
+  top: calc(100% + 6px);
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  font: 11px/1.4 var(--font-mono);
+  color: var(--text);
+  background: rgba(30, 24, 51, 0.98);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.5);
+  white-space: nowrap;
+  filter: saturate(1); /* opt out of the dimmed-header filter */
+}
+
+.mp-link-presets {
+  display: flex;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.mp-link-presets button {
+  font: 10.5px/1 var(--font-mono);
+  color: var(--text-dim);
+  background: transparent;
+  border: 0;
+  border-right: 1px solid var(--line);
+  padding: 5px 9px;
+  cursor: pointer;
+}
+
+.mp-link-presets button:last-child {
+  border-right: 0;
+}
+
+.mp-link-presets button:hover {
+  background: rgba(65, 216, 230, 0.08);
+  color: var(--text);
+}
+
+.mp-link-presets button[aria-pressed="true"] {
+  background: rgba(232, 88, 184, 0.16);
+  color: var(--pink);
+}
+
+.mp-link-menu label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-dim);
+}
+
+.mp-link-menu input {
+  width: 52px;
+  font: 11px/1 var(--font-mono);
+  color: var(--text);
+  background: var(--bg);
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  padding: 3px 5px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.mp-link-note {
+  margin: 0;
+  max-width: 220px;
+  white-space: normal;
+  font-size: 9.5px;
+  color: var(--text-dim);
+  opacity: 0.8;
+}
+
+/* Narrow columns (the sandbox's preview at laptop width): stack the panes. */
+@media (max-width: 1280px) {
+  .preview-pane.mp .mp-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* `hidden` must win over the display rules above. */
+.mp-tabs[hidden],
+.mp-link-menu[hidden] {
+  display: none;
+}
+
+/* ---- under-rail frame label, future (extrapolation) segment, 🔮 state ---- */
+
+.mp-rail-label {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 9px;
+  color: var(--text-dim);
+  opacity: 0.78;
+  white-space: nowrap;
+  pointer-events: none;
+  font-variant-numeric: tabular-nums;
+}
+
+.mp-rail-label b {
+  font-weight: 400;
+  opacity: 0.7;
+}
+
+.mp-rail-label .fut {
+  color: var(--pink);
+}
+
+.mp-future {
+  position: absolute;
+  top: 11px;
+  height: 8px;
+  border-radius: 3px;
+  background: var(--pink);
+  opacity: 0.9;
+  box-shadow: 0 0 10px rgba(232, 88, 184, 0.5);
+}
+
+#mp-extrap.on {
+  border-color: var(--pink);
+  box-shadow: 0 0 0 1px var(--pink), 0 2px 10px rgba(232, 88, 184, 0.4);
+}
+
+.mp-viewseg button:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.mp-viewseg button:disabled:hover {
+  background: transparent;
+  color: var(--text-dim);
+}
+
+/* ---- single client: same instrument, no multiplayer chrome ---- */
+
+/* One client keeps the chrono bar (tiled/tabs disabled) but drops the pane
+   header — digits, roles, and link chips are multiplayer vocabulary — and the
+   focus glow, since there is nothing to disambiguate. */
+.preview-pane.mp[data-count="1"] .mp-pane-hd,
+.preview-pane.mp[data-count="1"] .mp-tabs,
+.preview-pane.mp[data-count="1"] .mp-chrono {
+  display: none;
+}
+
+/* One client is exactly today's sandbox: no chrome frame around the game and
+   the pane's own in-frame scrubber (the chrono bar appears at 2+). */
+.preview-pane.mp[data-count="1"] .mp-grid {
+  padding: 0;
+  gap: 0;
+}
+
+.preview-pane.mp[data-count="1"] .mp-pane {
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.preview-pane.mp[data-count="1"] .mp-pane.focus {
+  border-color: color-mix(in srgb, var(--pc) 12%, rgba(43, 37, 66, 0.6));
+  box-shadow:
+    0 2px 6px rgba(0, 0, 0, 0.45),
+    0 12px 36px rgba(0, 0, 0, 0.55);
+}
+
+/* ---- restored scrubber polish: handles, tooltip, overflow chip, ⚙ ---- */
+
+/* Breathing room between the rail (whose playhead overhangs its right edge
+   when fully caught up) and the 🔮 button. */
+.mp-rail {
+  margin-right: 8px;
+}
+
+.mp-evt {
+  appearance: none;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+}
+
+.mp-evt:hover,
+.mp-evt:focus-visible {
+  outline: 1px solid rgba(255, 255, 255, 0.75);
+  outline-offset: 1px;
+}
+
+.mp-preview-handle {
+  display: none;
+  position: absolute;
+  top: 15px;
+  z-index: 3;
+  width: 14px;
+  height: 20px;
+  border-radius: 4px;
+  transform: translate(-50%, -50%);
+  background: var(--pink);
+  border: 1px solid #ffd0ee;
+  box-shadow: 0 0 12px rgba(232, 88, 184, 0.6);
+  cursor: ew-resize;
+  touch-action: none;
+}
+
+.mp-preview-handle.clipped {
+  border-radius: 4px 0 0 4px;
+}
+
+.mp-overflow {
+  display: none;
+  position: absolute;
+  right: 0;
+  top: -6px;
+  z-index: 4;
+  padding: 2px 4px;
+  border: 1px solid var(--pink);
+  border-radius: 5px;
+  color: #ffd0ee;
+  background: rgba(30, 24, 51, 0.96);
+  font-size: 9px;
+  pointer-events: none;
+}
+
+.mp-evt-tip {
+  display: none;
+  position: absolute;
+  z-index: 5;
+  top: calc(100% + 8px);
+  max-width: min(280px, 60vw);
+  padding: 5px 7px;
+  transform: translateX(-50%);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  color: var(--text);
+  background: rgba(30, 24, 51, 0.98);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.45);
+  font-size: 10px;
+  line-height: 1.3;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  pointer-events: none;
+}
+
+.mp-adv {
+  position: relative;
+}
+
+.mp-adv > summary {
+  list-style: none;
+  user-select: none;
+  font: 13px/1 var(--font-mono);
+  color: var(--text);
+  cursor: pointer;
+  background: rgba(65, 216, 230, 0.1);
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  padding: 5px 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
+}
+
+.mp-adv > summary::-webkit-details-marker {
+  display: none;
+}
+
+.mp-adv > summary:hover,
+.mp-adv[open] > summary {
+  border-color: var(--cyan);
+}
+
+.mp-adv-pop {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  z-index: 30;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  background: rgba(30, 24, 51, 0.98);
+  border-radius: 8px;
+  border: 1px solid var(--line);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.5);
+  white-space: nowrap;
+  font-size: 12px;
+}
+
+.mp-adv-pop label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  justify-content: space-between;
+}
+
+.mp-adv-pop select,
+.mp-adv-pop input[type="number"] {
+  font: 12px/1 var(--font-mono);
+  color: var(--text);
+  background: rgba(65, 216, 230, 0.1);
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  padding: 4px 5px;
+}
+
+.mp-adv-pop select {
+  appearance: none;
+  -webkit-appearance: none;
+  padding-right: 20px;
+  cursor: pointer;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='5'%3E%3Cpath d='M0 0h8L4 5z' fill='%239b94b3'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 7px center;
+}
+
+.mp-adv-pop input[type="number"] {
+  width: 46px;
+}
+
+/* ---- 🔮 is single-client only; multiplayer gets tiled/tabs in its place ---- */
+
+/* Whole-session forward extrapolation means N speculative re-simulations —
+   not v1, and a greyed magic wand invites bug reports. Hidden, not disabled
+   (design-multiplayer-ide-frontend.md §1); the view toggle takes the slot.
+   With one client the toggle is meaningless and the 🔮/⚙ pair returns. */
+.preview-pane.mp:not([data-count="1"]) #mp-extrap,
+.preview-pane.mp:not([data-count="1"]) .mp-adv {
+  display: none;
+}
+
+.preview-pane.mp[data-count="1"] .mp-viewseg {
+  display: none;
+}
+
+/* ---- second ticks along the rail (every 60 frames; heavier each 5s) ---- */
+
+.mp-tick {
+  position: absolute;
+  top: 11px;
+  height: 8px;
+  width: 1px;
+  background: rgba(233, 230, 242, 0.28);
+  pointer-events: none;
+}
+
+.mp-tick.major {
+  top: 9px;
+  height: 12px;
+  width: 1px;
+  background: rgba(233, 230, 242, 0.5);
+}
+
+/* Numeric fields are raw text entry — the native spinner arrows fight the
+   theme and are unusably small; type=number keeps validation and keyboard
+   arrows working. */
+.mp-link-menu input[type="number"],
+.mp-adv-pop input[type="number"] {
+  appearance: textfield;
+  -moz-appearance: textfield;
+}
+
+.mp-link-menu input[type="number"]::-webkit-inner-spin-button,
+.mp-link-menu input[type="number"]::-webkit-outer-spin-button,
+.mp-adv-pop input[type="number"]::-webkit-inner-spin-button,
+.mp-adv-pop input[type="number"]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
 }


### PR DESCRIPTION
Stacked on #524 (← #523 ← #522). The LIVE-mode skeleton from the multiplayer dev-experience design (design doc Addendum 2): panes are transport endpoints with hard per-client boundaries — iframes locally, a device later — and the sim-substrate swap stays a pane-source change behind the same chrome.

- **Pane grid + chrono bar**: N player iframes behind one host transport bar (pause / step / seek / 🔮 extrapolate broadcast through each pane's `__scrub` seam; rail, markers, and second ticks mirror the focused pane).
- **Tiled ⇄ tabs** views (`f` toggles); player-color pane identity; focus model (click, digits, `[`/`]` — the editor's caret always wins).
- **Per-client link chips** (LAN/Wi-Fi/mobile/awful + custom): recorded per client, honestly labelled — impairment applies when the netsim transport lands.
- **Live `#clients=N`**: panes grow/shrink in place with no reload; pane 1 never re-boots, so its model survives every count change (grow 1→3 and client 1 keeps its recorded history).
- **Aggregate pill** (`● 3 running` / `◐ reloading` / `✕ build error`) and `[client N]`-prefixed Output lines.

**Dark by default.** One client is exactly today's sandbox — no chrome frame, the stock in-frame scrubber, stock pill texts — and the CLIENTS control appears only for samples flagged `multiplayer` in `examples.ts` (none yet; the flag seats the gate for an orbs-style client/server sample). Mirrors boot `?scrubber=hidden` (#524); pane 1's bar is suppressed via a reversible injected style only while count > 1.

**Deliberately deferred** to the next PR: mounting the chrono bar at N=1 (the unified-scrubber direction) — that requires a11y parity with the in-frame bar (role=slider playhead, keyboard seek) and re-pointing the scrubber e2e suite, so it gets its own review.

**Verification:** `check:site` clean; `npm run test:site` ALL CHECKS PASSED (suite untouched); headless checks for N=1 stockness, 1→3→1 live growth with pane-1 model preservation, mirror seam-without-bar, and in-frame scrubber restoration at N=1. Captures incoming (pr-visuals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Screenshots

![tiled 3-client grid](https://gist.githubusercontent.com/tommy-xr/3cb30aa6dcde3a76177764957a85321c/raw/mp-tiled.png)

<sub>Tiled — `#clients=3`: three client panes under the shared chrono bar (play/step, environment scrubber, TILED/TABS toggle).</sub>

![tabs view](https://gist.githubusercontent.com/tommy-xr/3cb30aa6dcde3a76177764957a85321c/raw/mp-tabs.png)

<sub>Tabs — one full-width client with a tab strip showing each client's frame counter.</sub>

![per-client link profile menu](https://gist.githubusercontent.com/tommy-xr/3cb30aa6dcde3a76177764957a85321c/raw/mp-linkmenu.png)

<sub>Per-client link profile — client 2's link chip open: LAN/Wi-Fi/mobile/awful presets plus latency, jitter, and loss fields.</sub>

![single-client unchanged](https://gist.githubusercontent.com/tommy-xr/3cb30aa6dcde3a76177764957a85321c/raw/mp-single.png)

<sub>Single-client (no hash) is visually stock: in-frame scrubber at the bottom, no chrono bar.</sub>

<sub>Captured headlessly with Playwright at 1600×950.</sub>



## Review dispositions (xreview: Claude + Codex, media-verified)

All Critical/High findings fixed in the follow-up commit; each fix has a headless probe:

- **[AGREED] link menu clipped by the pane** → the pane no longer clips; children carry the rounding (probe: rightmost pane's menu extends past the pane edge).
- **[AGREED] unreachable 🔮/⚙ extrapolation surface** → deleted from this PR (returns with the single-client unification, where it is reachable and gets its a11y).
- **[AGREED] N=1 focus shadow not stock** → flush (`box-shadow: none` verified).
- **Late-booting pane runs while parked** (Codex) → the paint loop converges every seam's pause state (probe: pause → shrink → grow → all panes paused).
- **[AGREED] `#clients=4` vs a 1–3 select** → one `MAX_CLIENTS = 3` for every entry point.
- **[AGREED] listener leaks on shrink/grow** → per-mirror `AbortController`; `PlayerBridge` accepts an optional `AbortSignal`.
- **Shrink-to-1 strands the user without the control** (Claude) → visibility latches for the session; the legacy `?clients=` query is retired on hash writes (Codex).
- Plus: marker-cache key completeness, mirror error detail on the pill, dead selector/comments, N=1 paint gating, honest `destroy()`.

**Deferred, justified:** keyboard/AT transport at N>1 (the rail is pointer-only and pane 1's accessible in-frame bar is suppressed) — this PR is dark-launched behind the hash; the a11y parity work is the core of the next PR and doing it twice against two DOM shapes would be churn.

Re-verified after fixes: `check:site` clean, `npm run test:site` ALL CHECKS PASSED, all headless probes green.