### PR TITLE
feat(debug): the model in GET /state is structured JSON (protocol v4)

### DIFF
--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -103,16 +103,19 @@ screenshot run has no reason to grab your mouse.
 `model` is opaque `Debug` text; `model_json` is the **parseable** sibling — a
 total, lossy JSON view of the live model. Plain data maps structurally
 (records as objects, lists as arrays, numbers/strings/bools as themselves);
-everything else becomes a sigil-keyed object no record field can collide with
-(`$` is not a Functor Lang identifier character):
+everything else becomes a sigil-keyed object no source-authored record field
+can collide with (`$` is not a Functor Lang identifier character — though a record
+key that arrived off the network in a typed message can carry one, so treat
+the sigils as a strong convention rather than a proof):
 
 ```jsonc
 {"$tuple": [1.0, 2.0]}                 // tuples, kept distinct from lists
 {"$ctor": "Playing", "args": [7.0]}    // variants: constructor + positional args
 {"$fn": "<fn(dt)>"}                    // closures/callables (their Display form)
 {"$host": "SceneNode"}                 // opaque host values
-{"$number": "NaN"}                     // non-finite numbers (JSON can't carry them)
-{"$truncated": "max depth"}            // nesting past the safety bound (128)
+{"$number": "NaN"}                     // NaN/Infinity/-Infinity (JS spellings)
+{"$truncated": "max depth"}            // nesting past the bound (128 — what
+                                       // stock JSON parsers accept anyway)
 ```
 
 It is a one-way observation format (there is deliberately no parser back),

--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -86,7 +86,7 @@ screenshot run has no reason to grab your mouse.
 | Method & path | Purpose |
 | --- | --- |
 | `POST /capture` | PNG (`image/png`) of the next rendered frame |
-| `GET /state` | runtime state JSON: `frame`, `tts`, combined/legacy `viewport`, `views` (`main` on desktop; `left` + `right` on Quest), `input` (structured `held_keys` + `mouse` + optional typed device domains), `model` (Rust `Debug` text), `model_json` (structured — see below) |
+| `GET /state` | runtime state JSON: `frame`, `tts`, combined/legacy `viewport`, `views` (`main` on desktop; `left` + `right` on Quest), `input` (structured `held_keys` + `mouse` + optional typed device domains), `model` (structured JSON — see below), `model_debug` (Rust `Debug` text) |
 | `GET /scene` | current frame as JSON: `camera` + `scene` + `lights` |
 | `GET /trace` | paused-inspector trace: the last real frame's entry-point invocations plus a synthesized `draw` pass, replayed while paused. Each site (binders AND variable reads, `site`) carries the full `value`, a depth-limited `preview`, and `kind` (primitive/composite — the editor's inline-vs-hover policy); `{ "paused": false, "invocations": [] }` while playing. Paused docs also carry `coverage` (per-file span starts with the frame OFFSETS they executed on, over a ±120-frame journal ring — positive offsets appear when scrubbed behind the live head) and `runnable` (the static could-run set) — the recency gutter's data |
 | `POST /input` | inject input (see below) |
@@ -98,10 +98,15 @@ screenshot run has no reason to grab your mouse.
 | `POST /sync-assets` | finish a sync from a JSON array of current asset paths; uploaded paths absent from the manifest are removed |
 | `POST /rewind` | restore recorded model + physics to `{"frame":42}` (pin the clock first) |
 
-### `model_json` in `GET /state`
+### `model` in `GET /state`
 
-`model` is opaque `Debug` text; `model_json` is the **parseable** sibling — a
-total, lossy JSON view of the live model. Plain data maps structurally
+`model` is the structured view — a total, lossy JSON view of the live model,
+and the default thing to read. (`model_debug` is the Rust-`Debug` pretty-print:
+the human/eyeball view, strictly more faithful exactly where `model` is lossy —
+full depth, construction order — but opaque text; don't parse it. Before
+protocol v4, `model` carried that text and there was no structured view — gate
+on `GET /`'s `protocol_version` before reading `model` as data.)
+Plain data maps structurally
 (records as objects, lists as arrays, numbers/strings/bools as themselves);
 everything else becomes a sigil-keyed object no source-authored record field
 can collide with (`$` is not a Functor Lang identifier character — though a record
@@ -119,7 +124,8 @@ the sigils as a strong convention rather than a proof):
 ```
 
 It is a one-way observation format (there is deliberately no parser back),
-and it is `null` for producers without a structured model (e.g. `--replay`).
+and it is `null` for producers without a structured model (e.g. `--replay`,
+whose `model_debug` still describes the replay position).
 
 ### `POST /input`
 

--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -119,8 +119,9 @@ the sigils as a strong convention rather than a proof):
 {"$fn": "<fn(dt)>"}                    // closures/callables (their Display form)
 {"$host": "SceneNode"}                 // opaque host values
 {"$number": "NaN"}                     // NaN/Infinity/-Infinity (JS spellings)
-{"$truncated": "max depth"}            // nesting past the bound (128 — what
-                                       // stock JSON parsers accept anyway)
+{"$truncated": "max depth"}            // nesting past the bound (120 emitted
+                                       // containers — within what stock JSON
+                                       // parsers accept)
 ```
 
 It is a one-way observation format (there is deliberately no parser back),

--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -86,7 +86,7 @@ screenshot run has no reason to grab your mouse.
 | Method & path | Purpose |
 | --- | --- |
 | `POST /capture` | PNG (`image/png`) of the next rendered frame |
-| `GET /state` | runtime state JSON: `frame`, `tts`, combined/legacy `viewport`, `views` (`main` on desktop; `left` + `right` on Quest), `input` (structured `held_keys` + `mouse` + optional typed device domains), `model` (Rust `Debug` text) |
+| `GET /state` | runtime state JSON: `frame`, `tts`, combined/legacy `viewport`, `views` (`main` on desktop; `left` + `right` on Quest), `input` (structured `held_keys` + `mouse` + optional typed device domains), `model` (Rust `Debug` text), `model_json` (structured — see below) |
 | `GET /scene` | current frame as JSON: `camera` + `scene` + `lights` |
 | `GET /trace` | paused-inspector trace: the last real frame's entry-point invocations plus a synthesized `draw` pass, replayed while paused. Each site (binders AND variable reads, `site`) carries the full `value`, a depth-limited `preview`, and `kind` (primitive/composite — the editor's inline-vs-hover policy); `{ "paused": false, "invocations": [] }` while playing. Paused docs also carry `coverage` (per-file span starts with the frame OFFSETS they executed on, over a ±120-frame journal ring — positive offsets appear when scrubbed behind the live head) and `runnable` (the static could-run set) — the recency gutter's data |
 | `POST /input` | inject input (see below) |
@@ -97,6 +97,26 @@ screenshot run has no reason to grab your mouse.
 | `POST /reload-asset` | upload one project-relative texture/model/audio asset as a binary path+bytes envelope |
 | `POST /sync-assets` | finish a sync from a JSON array of current asset paths; uploaded paths absent from the manifest are removed |
 | `POST /rewind` | restore recorded model + physics to `{"frame":42}` (pin the clock first) |
+
+### `model_json` in `GET /state`
+
+`model` is opaque `Debug` text; `model_json` is the **parseable** sibling — a
+total, lossy JSON view of the live model. Plain data maps structurally
+(records as objects, lists as arrays, numbers/strings/bools as themselves);
+everything else becomes a sigil-keyed object no record field can collide with
+(`$` is not a Functor Lang identifier character):
+
+```jsonc
+{"$tuple": [1.0, 2.0]}                 // tuples, kept distinct from lists
+{"$ctor": "Playing", "args": [7.0]}    // variants: constructor + positional args
+{"$fn": "<fn(dt)>"}                    // closures/callables (their Display form)
+{"$host": "SceneNode"}                 // opaque host values
+{"$number": "NaN"}                     // non-finite numbers (JSON can't carry them)
+{"$truncated": "max depth"}            // nesting past the safety bound (128)
+```
+
+It is a one-way observation format (there is deliberately no parser back),
+and it is `null` for producers without a structured model (e.g. `--replay`).
 
 ### `POST /input`
 
@@ -400,7 +420,5 @@ point at either `http://127.0.0.1:8077` (desktop) or the adb-forwarded
   `--debug-port`, networked via `Sub.connect`/`Sub.listen`; pin all clocks and step
   them in lockstep, injecting input and observing state per client. This is the
   out-of-process counterpart to the in-process `functor-netsim` harness.
-- **Richer observation.** `/state.input` reports held keys, mouse, and optional
-  typed sampled-device domains as game-agnostic runtime data. Still open: a
-  parseable snapshot of the game *model* itself (today `Debug` text — the model
-  isn't `Serialize`).
+- **An MCP server.** `functor mcp` will expose this surface (sessions, state,
+  scene, capture, input, time, rewind) as standard MCP tools for coding agents.

--- a/e2e/xr-pose-injection.mjs
+++ b/e2e/xr-pose-injection.mjs
@@ -215,6 +215,16 @@ check(field(after.model, "leftGripTracked") === "true", "left hand tracked");
 check(field(after.model, "rightGripTracked") === "true", "right hand tracked");
 check(field(after.model, "grabbing") === "true", "injected trigger drove `grabbing`");
 
+console.log("\n▸ model_json mirrors the model as structured data (protocol v4)");
+check(
+  after.model_json !== null && typeof after.model_json === "object",
+  "/state.model_json is a structured object",
+);
+check(
+  after.model_json?.grabbing === true,
+  "model_json.grabbing is a typed bool (no Debug-text matching needed)",
+);
+
 console.log("\n▸ the pose sequence drove the simulation");
 const orb = point(after.model, "orb");
 const aim = posePosition(after.model, "rightAim");

--- a/e2e/xr-pose-injection.mjs
+++ b/e2e/xr-pose-injection.mjs
@@ -172,8 +172,8 @@ async function drive(port, poseFn = poseAt) {
     if (before.input.xr !== undefined) {
       throw new Error(`expected no xr domain before injection, got ${JSON.stringify(before.input.xr)}`);
     }
-    if (field(before.model, "rightGripTracked") !== "false") {
-      throw new Error(`expected rightGripTracked false, model:\n${before.model}`);
+    if (field(before.model_debug, "rightGripTracked") !== "false") {
+      throw new Error(`expected rightGripTracked false, model_debug:\n${before.model_debug}`);
     }
 
     // Pin the clock so each pose gets exactly one fixed step.
@@ -211,23 +211,23 @@ check(
   after.input.xr?.right?.grip?.position?.[2] > 0,
   "the right hand is at positive z — a pose --emulate-xr cannot produce",
 );
-check(field(after.model, "leftGripTracked") === "true", "left hand tracked");
-check(field(after.model, "rightGripTracked") === "true", "right hand tracked");
-check(field(after.model, "grabbing") === "true", "injected trigger drove `grabbing`");
+check(field(after.model_debug, "leftGripTracked") === "true", "left hand tracked");
+check(field(after.model_debug, "rightGripTracked") === "true", "right hand tracked");
+check(field(after.model_debug, "grabbing") === "true", "injected trigger drove `grabbing`");
 
-console.log("\n▸ model_json mirrors the model as structured data (protocol v4)");
+console.log("\n▸ the structured model is the default read (protocol v4)");
 check(
-  after.model_json !== null && typeof after.model_json === "object",
-  "/state.model_json is a structured object",
+  after.model !== null && typeof after.model === "object",
+  "/state.model is a structured object",
 );
 check(
-  after.model_json?.grabbing === true,
-  "model_json.grabbing is a typed bool (no Debug-text matching needed)",
+  after.model?.grabbing === true,
+  "model.grabbing is a typed bool (no Debug-text matching needed)",
 );
 
 console.log("\n▸ the pose sequence drove the simulation");
-const orb = point(after.model, "orb");
-const aim = posePosition(after.model, "rightAim");
+const orb = point(after.model_debug, "orb");
+const aim = posePosition(after.model_debug, "rightAim");
 const init = { x: 0.0, y: 1.15, z: -0.7 };
 const dist = (a, b) => Math.hypot(a.x - b.x, a.y - b.y, a.z - b.z);
 const moved = dist(orb, init);
@@ -241,7 +241,7 @@ check(toAim < 0.5, `the orb was dragged to the injected aim (${toAim.toFixed(3)}
 // the swept hand ends 0.67 further back, and the orb has to follow it there.
 console.log("\n▸ the endpoint reflects the sequence, not just that XR was on");
 const control = await drive(8143, () => poseAt(0));
-const controlOrb = point(control.after.model, "orb");
+const controlOrb = point(control.after.model_debug, "orb");
 const spread = dist(orb, controlOrb);
 check(
   spread > 0.3,
@@ -261,7 +261,7 @@ check(
   "xr_clear dropped the xr domain (no --emulate-xr to fall back to)",
 );
 check(
-  field(first.cleared.model, "rightGripTracked") === "false",
+  field(first.cleared.model_debug, "rightGripTracked") === "false",
   "the game returned to its Option.None branch",
 );
 
@@ -270,13 +270,13 @@ console.log("\n▸ the sequence is deterministic");
 // (It is not a test of recorded-log REPLAY — that path has its own coverage.)
 const second = await drive(8142);
 check(
-  second.after.model === after.model,
+  second.after.model_debug === after.model_debug,
   "an identical injected sequence produced an identical model",
 );
 
 if (failures.length) {
   console.error(`\n✗ xr-pose-injection failed: ${failures.join(", ")}`);
-  console.error(`\nfinal model:\n${after.model}`);
+  console.error(`\nfinal model_debug:\n${after.model_debug}`);
   process.exit(1);
 }
 console.log("\n✓ xr-pose-injection passed");

--- a/runtime/functor-runtime-common/src/debug_protocol.rs
+++ b/runtime/functor-runtime-common/src/debug_protocol.rs
@@ -21,7 +21,10 @@ pub const DEBUG_PROTOCOL_SERVICE: &str = "functor debug runtime";
 /// `advance`, and made `/time` answer 409 under a `--fixed-time` pin. A client
 /// that batches advances or waits on `pending_steps` needs a v3 runtime: a v2
 /// one ignores `frames`, runs a single step, and reports no `pending_steps`.
-pub const DEBUG_PROTOCOL_VERSION: u32 = 3;
+///
+/// 4 added `model_json` to `GET /state` — the structured (total, lossy) JSON
+/// view of the model. A pre-v4 runtime simply omits the field.
+pub const DEBUG_PROTOCOL_VERSION: u32 = 4;
 
 /// Maximum accepted body size for either reload operation.
 pub const MAX_RELOAD_BYTES: usize = 4 * 1024 * 1024;
@@ -70,7 +73,7 @@ pub const DEBUG_ROUTES: &[DebugRoute] = &[
     DebugRoute {
         method: "GET",
         path: "/state",
-        description: "runtime state JSON: frame, tts, pending_steps (queued clock steps not yet run), viewport, views, input snapshot (held_keys + mouse + optional xr), model (Debug text)",
+        description: "runtime state JSON: frame, tts, pending_steps (queued clock steps not yet run), viewport, views, input snapshot (held_keys + mouse + optional xr), model (Debug text), model_json (structured lossy JSON view of the model)",
     },
     DebugRoute {
         method: "GET",
@@ -624,6 +627,6 @@ mod tests {
         let discovery: Value = serde_json::from_str(&discovery_json()).unwrap();
         assert_eq!(discovery["service"], DEBUG_PROTOCOL_SERVICE);
         assert_eq!(discovery["protocol_version"], DEBUG_PROTOCOL_VERSION);
-        assert_eq!(DEBUG_PROTOCOL_VERSION, 3);
+        assert_eq!(DEBUG_PROTOCOL_VERSION, 4);
     }
 }

--- a/runtime/functor-runtime-common/src/debug_protocol.rs
+++ b/runtime/functor-runtime-common/src/debug_protocol.rs
@@ -185,6 +185,13 @@ pub struct RuntimeState {
     pub viewport: RuntimeViewport,
     pub views: Vec<RuntimeView>,
     pub model: String,
+    /// A structured JSON view of the model
+    /// ([`crate::protocol::GameProducer::state_json`]):
+    /// parseable, total, lossy (callables/host values are sigil placeholders).
+    /// `Null` for producers without a structured model. `default` so payloads
+    /// from runtimes predating the field still deserialize.
+    #[serde(default)]
+    pub model_json: serde_json::Value,
     pub input: InputSnapshot,
 }
 
@@ -385,6 +392,7 @@ mod tests {
             viewport: RuntimeViewport::new(1920, 1080),
             views: vec![RuntimeView::new("main", 1920, 1080)],
             model: "Model {\n  label: \"hello\"\n}".into(),
+            model_json: json!({ "label": "hello" }),
             input: InputSnapshot {
                 held_keys: vec![Key::W, Key::Up],
                 mouse: crate::MouseSnapshot {
@@ -409,6 +417,7 @@ mod tests {
                     "viewport": { "width": 1920, "height": 1080 }
                 }],
                 "model": "Model {\n  label: \"hello\"\n}",
+                "model_json": { "label": "hello" },
                 "input": {
                     "held_keys": ["W", "Up"],
                     "mouse": {

--- a/runtime/functor-runtime-common/src/debug_protocol.rs
+++ b/runtime/functor-runtime-common/src/debug_protocol.rs
@@ -22,8 +22,11 @@ pub const DEBUG_PROTOCOL_SERVICE: &str = "functor debug runtime";
 /// that batches advances or waits on `pending_steps` needs a v3 runtime: a v2
 /// one ignores `frames`, runs a single step, and reports no `pending_steps`.
 ///
-/// 4 added `model_json` to `GET /state` — the structured (total, lossy) JSON
-/// view of the model. A pre-v4 runtime simply omits the field.
+/// 4 made `GET /state`'s `model` the structured (total, lossy) JSON view of
+/// the model and moved the Rust-`Debug` pretty-print to `model_debug`. This
+/// REDEFINES `model`: a pre-v4 runtime sends the Debug text under `model`
+/// and has no `model_debug`, so clients must gate on the version before
+/// reading `model` as data.
 pub const DEBUG_PROTOCOL_VERSION: u32 = 4;
 
 /// Maximum accepted body size for either reload operation.
@@ -73,7 +76,7 @@ pub const DEBUG_ROUTES: &[DebugRoute] = &[
     DebugRoute {
         method: "GET",
         path: "/state",
-        description: "runtime state JSON: frame, tts, pending_steps (queued clock steps not yet run), viewport, views, input snapshot (held_keys + mouse + optional xr), model (Debug text), model_json (structured lossy JSON view of the model)",
+        description: "runtime state JSON: frame, tts, pending_steps (queued clock steps not yet run), viewport, views, input snapshot (held_keys + mouse + optional xr), model (structured lossy JSON view of the model), model_debug (Rust Debug text)",
     },
     DebugRoute {
         method: "GET",
@@ -187,14 +190,19 @@ pub struct RuntimeState {
     pub pending_steps: u32,
     pub viewport: RuntimeViewport,
     pub views: Vec<RuntimeView>,
-    pub model: String,
-    /// A structured JSON view of the model
-    /// ([`crate::protocol::GameProducer::state_json`]):
-    /// parseable, total, lossy (callables/host values are sigil placeholders).
-    /// `Null` for producers without a structured model. `default` so payloads
-    /// from runtimes predating the field still deserialize.
+    /// The structured JSON view of the model
+    /// ([`crate::protocol::GameProducer::state_json`]) — the default thing to
+    /// read: parseable, total, lossy (callables/host values are sigil
+    /// placeholders). `Null` for producers without a structured model.
+    /// `default` because pre-v4 payloads carry Debug TEXT under this key —
+    /// version-gate before reading (see [`DEBUG_PROTOCOL_VERSION`]).
     #[serde(default)]
-    pub model_json: serde_json::Value,
+    pub model: serde_json::Value,
+    /// The Rust-`Debug` pretty-print of the model — the human/eyeball view,
+    /// strictly more faithful where `model` is lossy (full depth,
+    /// construction order, closure params). Opaque text; don't parse it.
+    #[serde(default)]
+    pub model_debug: String,
     pub input: InputSnapshot,
 }
 
@@ -394,8 +402,8 @@ mod tests {
             pending_steps: 3,
             viewport: RuntimeViewport::new(1920, 1080),
             views: vec![RuntimeView::new("main", 1920, 1080)],
-            model: "Model {\n  label: \"hello\"\n}".into(),
-            model_json: json!({ "label": "hello" }),
+            model: json!({ "label": "hello" }),
+            model_debug: "Model {\n  label: \"hello\"\n}".into(),
             input: InputSnapshot {
                 held_keys: vec![Key::W, Key::Up],
                 mouse: crate::MouseSnapshot {
@@ -419,8 +427,8 @@ mod tests {
                     "name": "main",
                     "viewport": { "width": 1920, "height": 1080 }
                 }],
-                "model": "Model {\n  label: \"hello\"\n}",
-                "model_json": { "label": "hello" },
+                "model": { "label": "hello" },
+                "model_debug": "Model {\n  label: \"hello\"\n}",
                 "input": {
                     "held_keys": ["W", "Up"],
                     "mouse": {

--- a/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
@@ -1063,6 +1063,10 @@ AudioScene.empty), got {}",
         self.model.to_string()
     }
 
+    fn state_json(&self) -> serde_json::Value {
+        crate::functor_lang_prelude::value_to_json(&self.model)
+    }
+
     /// The paused-inspector trace (visual-debugger PR2b), same contract and
     /// caching as the other producers: the byte-stable stub while playing, and
     /// a lazily built + cached full doc while paused.

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -450,6 +450,65 @@ impl EffectValue {
     }
 }
 
+/// Depth bound for [`value_to_json`]. Value nesting is user-controlled (see
+/// the `Value` `Display` doc — a fold wrapping `[acc]` per step builds depth
+/// past any recursion limit), and this walker recurses; past the bound a node
+/// becomes `{"$truncated": "max depth"}` instead of risking the host's stack.
+/// Far deeper than any real model, so truncation marks pathology, not data.
+const VALUE_JSON_MAX_DEPTH: usize = 128;
+
+/// A total, LOSSY JSON view of a [`Value`], for observation surfaces (the
+/// debug server's `GET /state` `model_json`). Unlike
+/// [`effect_value_from_value`] it never fails: plain data maps structurally
+/// (numbers, strings, bools; lists as arrays; records as objects — field
+/// order is the serde_json map's, not construction order), and everything
+/// else becomes a sigil-keyed object no record field can collide with (`$` is
+/// not a Functor Lang identifier character):
+///
+/// - tuples: `{"$tuple": [...]}` (so they stay distinct from lists)
+/// - variants: `{"$ctor": "Some", "args": [...]}`
+/// - callables: `{"$fn": "<fn(dt)>"}` — the `Display` form
+/// - host values: `{"$host": "SceneNode"}` — the `type_name`
+/// - non-finite numbers: `{"$number": "NaN"}` (JSON numbers can't carry them)
+///
+/// A one-way observation format: there is deliberately no parser back.
+pub fn value_to_json(value: &Value) -> serde_json::Value {
+    value_to_json_at(value, 0)
+}
+
+fn value_to_json_at(value: &Value, depth: usize) -> serde_json::Value {
+    use serde_json::{json, Value as Json};
+    if depth > VALUE_JSON_MAX_DEPTH {
+        return json!({ "$truncated": "max depth" });
+    }
+    let items_json = |items: &[Value]| -> Vec<Json> {
+        items.iter().map(|v| value_to_json_at(v, depth + 1)).collect()
+    };
+    match value {
+        Value::Number(n) if n.is_finite() => json!(n),
+        Value::Number(n) => json!({ "$number": n.to_string() }),
+        Value::String(s) => json!(s.as_ref()),
+        Value::Bool(b) => json!(b),
+        Value::List(items) => Json::Array(items_json(items)),
+        Value::Tuple(items) => json!({ "$tuple": items_json(items) }),
+        Value::Record(fields) => Json::Object(
+            fields
+                .iter()
+                .map(|(k, v)| (k.clone(), value_to_json_at(v, depth + 1)))
+                .collect(),
+        ),
+        Value::Variant { ctor, args } => {
+            json!({ "$ctor": ctor.as_ref(), "args": items_json(args) })
+        }
+        Value::Ctor { .. }
+        | Value::Closure(_)
+        | Value::Partial(_)
+        | Value::Builtin(_)
+        | Value::HostFn(_) => json!({ "$fn": value.to_string() }),
+        Value::HostData(host) => json!({ "$host": host.type_name() }),
+    }
+}
+
 /// The inverse of [`EffectValue::to_functor_lang`]: the plain-data subset of
 /// [`Value`], for payloads the GAME hands the host (`Effect.sendMsg`). A
 /// non-data value — a closure, an unapplied constructor, a host handle — is a
@@ -7867,6 +7926,75 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
         let json = serde_json::to_string(&value).expect("serialize");
         let back: EffectValue = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back, value);
+    }
+
+    /// The lossy model-JSON walker (`GET /state` `model_json`): plain data
+    /// maps structurally; callables, host values, and non-finite numbers
+    /// become sigil placeholders instead of failing.
+    #[test]
+    fn value_to_json_is_total_and_lossy() {
+        struct TestHost;
+        impl HostData for TestHost {
+            fn type_name(&self) -> &'static str {
+                "TestHost"
+            }
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
+        }
+        let model = Value::Record(Rc::new(vec![
+            ("count".to_string(), Value::Number(3.0)),
+            ("name".to_string(), Value::String(Rc::from("hello"))),
+            ("alive".to_string(), Value::Bool(true)),
+            (
+                "items".to_string(),
+                Value::List(Rc::new(vec![Value::Number(1.0), Value::Number(2.0)])),
+            ),
+            (
+                "pos".to_string(),
+                Value::Tuple(Rc::new(vec![Value::Number(1.0), Value::Number(2.0)])),
+            ),
+            (
+                "state".to_string(),
+                Value::Variant {
+                    ctor: Rc::from("Playing"),
+                    args: Rc::new(vec![Value::Number(7.0)]),
+                },
+            ),
+            ("spawn".to_string(), Value::HostFn(Rc::from("Scene.cube"))),
+            ("handle".to_string(), Value::HostData(Rc::new(TestHost))),
+            ("bad".to_string(), Value::Number(f64::NAN)),
+        ]));
+        assert_eq!(
+            value_to_json(&model),
+            serde_json::json!({
+                "count": 3.0,
+                "name": "hello",
+                "alive": true,
+                "items": [1.0, 2.0],
+                "pos": { "$tuple": [1.0, 2.0] },
+                "state": { "$ctor": "Playing", "args": [7.0] },
+                "spawn": { "$fn": "<host Scene.cube>" },
+                "handle": { "$host": "TestHost" },
+                "bad": { "$number": "NaN" },
+            })
+        );
+    }
+
+    /// Nesting past the bound truncates with a marker instead of risking the
+    /// host's stack (nesting depth is user-controlled — see `Value`'s
+    /// `Display` doc).
+    #[test]
+    fn value_to_json_bounds_depth() {
+        let mut value = Value::Number(0.0);
+        for _ in 0..(VALUE_JSON_MAX_DEPTH + 10) {
+            value = Value::List(Rc::new(vec![value]));
+        }
+        let mut node = &value_to_json(&value);
+        while let Some(items) = node.as_array() {
+            node = &items[0];
+        }
+        assert_eq!(node, &serde_json::json!({ "$truncated": "max depth" }));
     }
 
     /// A diverged replay fails loud with the position, not silently wrong.

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -450,47 +450,68 @@ impl EffectValue {
     }
 }
 
-/// Depth bound for [`value_to_json`]. Value nesting is user-controlled (see
+/// Depth bound for [`value_to_json`], measured in **emitted JSON
+/// containers**, not Functor values — a tuple or variant emits two nested
+/// containers (the sigil object plus its array), so charging per value would
+/// overshoot the real JSON depth 2×. Value nesting is user-controlled (see
 /// the `Value` `Display` doc — a fold wrapping `[acc]` per step builds depth
-/// past any recursion limit), and this walker recurses; past the bound a node
-/// becomes `{"$truncated": "max depth"}` instead of risking the host's stack.
-/// Far deeper than any real model, so truncation marks pathology, not data.
-const VALUE_JSON_MAX_DEPTH: usize = 128;
+/// past any recursion limit), so unbounded depth must be refused somewhere —
+/// and for JSON output the bound is a property of the FORMAT, not this
+/// walker: `serde_json::Value` recurses in its own `Serialize` and `Drop`
+/// impls, and serde_json's default *parse* recursion limit on the consuming
+/// side is 128 containers, so deeper output would overflow producing or be
+/// rejected consuming. 120 leaves headroom for the wrapping `RuntimeState`
+/// object and the truncation marker itself. Past the bound a node becomes
+/// `{"$truncated": "max depth"}` — visible, not silently dropped; the
+/// `model` Display text on the same response still shows the full value.
+const VALUE_JSON_MAX_DEPTH: usize = 120;
 
 /// A total, LOSSY JSON view of a [`Value`], for observation surfaces (the
 /// debug server's `GET /state` `model_json`). Unlike
 /// [`effect_value_from_value`] it never fails: plain data maps structurally
 /// (numbers, strings, bools; lists as arrays; records as objects — field
 /// order is the serde_json map's, not construction order), and everything
-/// else becomes a sigil-keyed object no record field can collide with (`$` is
-/// not a Functor Lang identifier character):
+/// else becomes a sigil-keyed object no source-authored record field can
+/// collide with (`$` is not a Functor Lang identifier character; a record key
+/// arriving off the network via a typed message CAN carry `$`, so treat
+/// sigils as a strong convention, not a proof):
 ///
 /// - tuples: `{"$tuple": [...]}` (so they stay distinct from lists)
 /// - variants: `{"$ctor": "Some", "args": [...]}`
 /// - callables: `{"$fn": "<fn(dt)>"}` — the `Display` form
 /// - host values: `{"$host": "SceneNode"}` — the `type_name`
-/// - non-finite numbers: `{"$number": "NaN"}` (JSON numbers can't carry them)
+/// - non-finite numbers: `{"$number": "NaN" | "Infinity" | "-Infinity"}`
+///   (JSON numbers can't carry them; the JS spellings, not Rust's `inf`)
 ///
 /// A one-way observation format: there is deliberately no parser back.
 pub fn value_to_json(value: &Value) -> serde_json::Value {
     value_to_json_at(value, 0)
 }
 
+/// `depth` is the JSON-container depth this node is emitted at: lists and
+/// records place children one container deeper, tuples and variants two (the
+/// sigil object wrapping the args array).
 fn value_to_json_at(value: &Value, depth: usize) -> serde_json::Value {
     use serde_json::{json, Value as Json};
     if depth > VALUE_JSON_MAX_DEPTH {
         return json!({ "$truncated": "max depth" });
     }
-    let items_json = |items: &[Value]| -> Vec<Json> {
-        items.iter().map(|v| value_to_json_at(v, depth + 1)).collect()
+    let items_json = |items: &[Value], charge: usize| -> Vec<Json> {
+        items
+            .iter()
+            .map(|v| value_to_json_at(v, depth + charge))
+            .collect()
     };
     match value {
         Value::Number(n) if n.is_finite() => json!(n),
-        Value::Number(n) => json!({ "$number": n.to_string() }),
+        Value::Number(n) if n.is_nan() => json!({ "$number": "NaN" }),
+        Value::Number(n) => {
+            json!({ "$number": if *n > 0.0 { "Infinity" } else { "-Infinity" } })
+        }
         Value::String(s) => json!(s.as_ref()),
         Value::Bool(b) => json!(b),
-        Value::List(items) => Json::Array(items_json(items)),
-        Value::Tuple(items) => json!({ "$tuple": items_json(items) }),
+        Value::List(items) => Json::Array(items_json(items, 1)),
+        Value::Tuple(items) => json!({ "$tuple": items_json(items, 2) }),
         Value::Record(fields) => Json::Object(
             fields
                 .iter()
@@ -498,7 +519,7 @@ fn value_to_json_at(value: &Value, depth: usize) -> serde_json::Value {
                 .collect(),
         ),
         Value::Variant { ctor, args } => {
-            json!({ "$ctor": ctor.as_ref(), "args": items_json(args) })
+            json!({ "$ctor": ctor.as_ref(), "args": items_json(args, 2) })
         }
         Value::Ctor { .. }
         | Value::Closure(_)
@@ -7964,6 +7985,8 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
             ("spawn".to_string(), Value::HostFn(Rc::from("Scene.cube"))),
             ("handle".to_string(), Value::HostData(Rc::new(TestHost))),
             ("bad".to_string(), Value::Number(f64::NAN)),
+            ("up".to_string(), Value::Number(f64::INFINITY)),
+            ("down".to_string(), Value::Number(f64::NEG_INFINITY)),
         ]));
         assert_eq!(
             value_to_json(&model),
@@ -7977,6 +8000,8 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
                 "spawn": { "$fn": "<host Scene.cube>" },
                 "handle": { "$host": "TestHost" },
                 "bad": { "$number": "NaN" },
+                "up": { "$number": "Infinity" },
+                "down": { "$number": "-Infinity" },
             })
         );
     }
@@ -7995,6 +8020,31 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
             node = &items[0];
         }
         assert_eq!(node, &serde_json::json!({ "$truncated": "max depth" }));
+    }
+
+    /// The bound is charged in emitted JSON containers (a tuple emits TWO —
+    /// sigil object + args array), so even the deepest producible
+    /// `model_json`, wrapped in a full `RuntimeState`, stays inside
+    /// serde_json's default 128-container parse limit and round-trips.
+    #[test]
+    fn deep_model_json_round_trips_through_runtime_state() {
+        let mut value = Value::Number(0.0);
+        for _ in 0..300 {
+            value = Value::Tuple(Rc::new(vec![Value::Number(1.0), value]));
+        }
+        let state = crate::debug_protocol::RuntimeState {
+            frame: 1,
+            tts: 0.0,
+            pending_steps: 0,
+            viewport: crate::debug_protocol::RuntimeViewport::new(1, 1),
+            views: vec![],
+            model: String::new(),
+            model_json: value_to_json(&value),
+            input: crate::InputSnapshot::default(),
+        };
+        let back: crate::debug_protocol::RuntimeState = serde_json::from_str(&state.to_json())
+            .expect("deep model_json must stay parseable by stock serde_json");
+        assert_eq!(back.model_json, state.model_json);
     }
 
     /// A diverged replay fails loud with the position, not silently wrong.

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -467,7 +467,7 @@ impl EffectValue {
 const VALUE_JSON_MAX_DEPTH: usize = 120;
 
 /// A total, LOSSY JSON view of a [`Value`], for observation surfaces (the
-/// debug server's `GET /state` `model_json`). Unlike
+/// debug server's `GET /state` `model`, protocol v4). Unlike
 /// [`effect_value_from_value`] it never fails: plain data maps structurally
 /// (numbers, strings, bools; lists as arrays; records as objects — field
 /// order is the serde_json map's, not construction order), and everything
@@ -7949,7 +7949,7 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
         assert_eq!(back, value);
     }
 
-    /// The lossy model-JSON walker (`GET /state` `model_json`): plain data
+    /// The lossy model-JSON walker (`GET /state` `model`, v4): plain data
     /// maps structurally; callables, host values, and non-finite numbers
     /// become sigil placeholders instead of failing.
     #[test]
@@ -8024,10 +8024,10 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
 
     /// The bound is charged in emitted JSON containers (a tuple emits TWO —
     /// sigil object + args array), so even the deepest producible
-    /// `model_json`, wrapped in a full `RuntimeState`, stays inside
+    /// `model`, wrapped in a full `RuntimeState`, stays inside
     /// serde_json's default 128-container parse limit and round-trips.
     #[test]
-    fn deep_model_json_round_trips_through_runtime_state() {
+    fn deep_model_round_trips_through_runtime_state() {
         let mut value = Value::Number(0.0);
         for _ in 0..300 {
             value = Value::Tuple(Rc::new(vec![Value::Number(1.0), value]));
@@ -8038,13 +8038,13 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
             pending_steps: 0,
             viewport: crate::debug_protocol::RuntimeViewport::new(1, 1),
             views: vec![],
-            model: String::new(),
-            model_json: value_to_json(&value),
+            model: value_to_json(&value),
+            model_debug: String::new(),
             input: crate::InputSnapshot::default(),
         };
         let back: crate::debug_protocol::RuntimeState = serde_json::from_str(&state.to_json())
-            .expect("deep model_json must stay parseable by stock serde_json");
-        assert_eq!(back.model_json, state.model_json);
+            .expect("a deep model must stay parseable by stock serde_json");
+        assert_eq!(back.model, state.model);
     }
 
     /// A diverged replay fails loud with the position, not silently wrong.

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -48,7 +48,7 @@
 //! - `emit_state_debug` → `String`: a Rust-`Debug` pretty-print of the live
 //!   model, surfaced as the `model` field of the debug server's `GET /state`.
 //!   Free-form by design; consumers must not parse it. The PARSEABLE sibling
-//!   is `state_json` → `model_json` (see [`GameProducer::state_json`]).
+//!   is `state_json` → the v4 `model` field (see [`GameProducer::state_json`]).
 //!
 //! # In-process only (NOT part of the data protocol — known limitations)
 //!
@@ -304,7 +304,7 @@ pub trait GameProducer {
     fn state_debug(&self) -> String;
 
     /// A structured JSON view of the live game model (the debug server's
-    /// `GET /state` `model_json` field) — the parseable sibling of
+    /// `GET /state` `model` field, protocol v4) — the parseable sibling of
     /// [`GameProducer::state_debug`], via `functor_lang_prelude::value_to_json`:
     /// total and lossy (callables and host values become sigil-keyed
     /// placeholders). The default, `Null`, is the honest answer for producers

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -47,7 +47,8 @@
 //!
 //! - `emit_state_debug` → `String`: a Rust-`Debug` pretty-print of the live
 //!   model, surfaced as the `model` field of the debug server's `GET /state`.
-//!   Free-form by design; consumers must not parse it.
+//!   Free-form by design; consumers must not parse it. The PARSEABLE sibling
+//!   is `state_json` → `model_json` (see [`GameProducer::state_json`]).
 //!
 //! # In-process only (NOT part of the data protocol — known limitations)
 //!
@@ -301,6 +302,16 @@ pub trait GameProducer {
     /// introspection (the debug server's `GET /state` `model` field). Opaque
     /// debug text — see the module doc; consumers must not parse it.
     fn state_debug(&self) -> String;
+
+    /// A structured JSON view of the live game model (the debug server's
+    /// `GET /state` `model_json` field) — the parseable sibling of
+    /// [`GameProducer::state_debug`], via `functor_lang_prelude::value_to_json`:
+    /// total and lossy (callables and host values become sigil-keyed
+    /// placeholders). The default, `Null`, is the honest answer for producers
+    /// without a structured model (e.g. the replay producer).
+    fn state_json(&self) -> serde_json::Value {
+        serde_json::Value::Null
+    }
 
     /// The paused-inspector trace (visual-debugger PR2): the wire-contract JSON
     /// for the last real frame's entry-point invocations, replayed on demand

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -1316,6 +1316,10 @@ AudioScene.empty), got {}",
         self.model.to_string()
     }
 
+    fn state_json(&self) -> serde_json::Value {
+        functor_runtime_common::functor_lang_prelude::value_to_json(&self.model)
+    }
+
     /// The paused-inspector trace (visual-debugger PR2). When NOT paused, a
     /// cheap early-out: `paused: false` with empty invocations — and NO
     /// `frame`/`tts`, which change every frame: the LSP's idle poll dedups on

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -805,8 +805,8 @@ fn service_debug_request(
                 pending_steps: clock.pending_steps(),
                 viewport: debug_server::RuntimeViewport::new(width, height),
                 views: vec![debug_server::RuntimeView::new("main", width, height)],
-                model: game.state_debug(),
-                model_json: game.state_json(),
+                model: game.state_json(),
+                model_debug: game.state_debug(),
                 input: state_input,
             });
         }

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -806,6 +806,7 @@ fn service_debug_request(
                 viewport: debug_server::RuntimeViewport::new(width, height),
                 views: vec![debug_server::RuntimeView::new("main", width, height)],
                 model: game.state_debug(),
+                model_json: game.state_json(),
                 input: state_input,
             });
         }

--- a/runtime/functor-runtime-oculus/src/lib.rs
+++ b/runtime/functor-runtime-oculus/src/lib.rs
@@ -637,8 +637,8 @@ fn service_debug_request(
                 pending_steps: clock.pending_steps(),
                 viewport: RuntimeViewport::new(width, height),
                 views,
-                model: game.state_debug(),
-                model_json: game.state_json(),
+                model: game.state_json(),
+                model_debug: game.state_debug(),
                 input: debug.input.clone(),
             });
         }

--- a/runtime/functor-runtime-oculus/src/lib.rs
+++ b/runtime/functor-runtime-oculus/src/lib.rs
@@ -638,6 +638,7 @@ fn service_debug_request(
                 viewport: RuntimeViewport::new(width, height),
                 views,
                 model: game.state_debug(),
+                model_json: game.state_json(),
                 input: debug.input.clone(),
             });
         }

--- a/site/src/runtime-target-core.ts
+++ b/site/src/runtime-target-core.ts
@@ -61,7 +61,12 @@ export interface RuntimeState {
   pending_steps?: number;
   viewport: RuntimeViewport;
   views: RuntimeView[];
-  model: string;
+  /** v4+: the structured JSON model view; pre-v4 runtimes send the Debug
+   * text under this key. This panel only displays a dump, so it reads
+   * `model_debug` and falls back to a pre-v4 string `model`. */
+  model: unknown;
+  /** v4 and later only — the Rust-`Debug` model dump. */
+  model_debug?: string;
   input: unknown;
 }
 
@@ -435,7 +440,12 @@ export function createRuntimeTargetCore({
   const renderState = (state: RuntimeState) => {
     if (!state || !Number.isFinite(state.frame)) return;
     const views = Array.isArray(state.views) ? state.views.map((view) => view.name).join(" + ") : "—";
-    const model = typeof state.model === "string" ? state.model.trim() : "";
+    const model =
+      typeof state.model_debug === "string"
+        ? state.model_debug.trim()
+        : typeof state.model === "string"
+          ? state.model.trim()
+          : "";
     update({
       telemetry: {
         frame: String(state.frame),

--- a/tools/functor-sdk/src/types.ts
+++ b/tools/functor-sdk/src/types.ts
@@ -90,9 +90,8 @@ export type ModelJson =
   | { [key: string]: ModelJson };
 
 /** Runtime state from `GET /state`. `input` is structured and game-agnostic;
- * `model` is the game model rendered with Rust's pretty-`Debug` (not structured
- * JSON), so reading fields from it is best-effort string matching —
- * `model_json` is the structured sibling to read fields from. */
+ * `model` is the structured, lossy JSON view of the game model — the default
+ * thing to read fields from. */
 export interface RuntimeState {
   frame: number;
   tts: number;
@@ -103,11 +102,16 @@ export interface RuntimeState {
   viewport: RuntimeViewport;
   views: RuntimeView[];
   input: InputSnapshot;
-  model: string;
   /** Structured, lossy JSON view of the model (`null` for producers without
-   * a structured model, e.g. replay). Protocol v4+; absent from older
-   * runtimes. */
-  model_json?: ModelJson;
+   * a structured model, e.g. replay). Protocol v4+ — a pre-v4 runtime sends
+   * the Debug TEXT under this key instead; gate on `GET /`'s
+   * `protocol_version` before reading it as data. */
+  model: ModelJson;
+  /** The Rust-`Debug` pretty-print of the model: the human-facing view (full
+   * depth, construction order where `model` is lossy). Opaque text — don't
+   * parse it. v4 and later — a pre-v4 runtime omits it (and sends the text
+   * under `model` instead). */
+  model_debug: string;
 }
 
 /** Camera block from `GET /scene`. */

--- a/tools/functor-sdk/src/types.ts
+++ b/tools/functor-sdk/src/types.ts
@@ -105,8 +105,9 @@ export interface RuntimeState {
   input: InputSnapshot;
   model: string;
   /** Structured, lossy JSON view of the model (`null` for producers without
-   * a structured model, e.g. replay). */
-  model_json: ModelJson;
+   * a structured model, e.g. replay). Protocol v4+; absent from older
+   * runtimes. */
+  model_json?: ModelJson;
 }
 
 /** Camera block from `GET /scene`. */

--- a/tools/functor-sdk/src/types.ts
+++ b/tools/functor-sdk/src/types.ts
@@ -75,9 +75,24 @@ export interface RuntimeView {
   viewport: RuntimeViewport;
 }
 
+/** A structured JSON view of a Functor Lang value: plain data maps structurally
+ * (records as objects, lists as arrays), and everything else is a sigil-keyed
+ * object no record field can collide with — `{"$tuple": [...]}`,
+ * `{"$ctor": "Some", "args": [...]}`, `{"$fn": "<fn(dt)>"}`,
+ * `{"$host": "SceneNode"}`, `{"$number": "NaN"}`, and
+ * `{"$truncated": "max depth"}` past the nesting bound. */
+export type ModelJson =
+  | number
+  | string
+  | boolean
+  | null
+  | ModelJson[]
+  | { [key: string]: ModelJson };
+
 /** Runtime state from `GET /state`. `input` is structured and game-agnostic;
  * `model` is the game model rendered with Rust's pretty-`Debug` (not structured
- * JSON), so reading fields from it is best-effort string matching. */
+ * JSON), so reading fields from it is best-effort string matching —
+ * `model_json` is the structured sibling to read fields from. */
 export interface RuntimeState {
   frame: number;
   tts: number;
@@ -89,6 +104,9 @@ export interface RuntimeState {
   views: RuntimeView[];
   input: InputSnapshot;
   model: string;
+  /** Structured, lossy JSON view of the model (`null` for producers without
+   * a structured model, e.g. replay). */
+  model_json: ModelJson;
 }
 
 /** Camera block from `GET /scene`. */

--- a/tools/functor-sdk/test/functor-lang-closure-rebind.e2e.test.ts
+++ b/tools/functor-sdk/test/functor-lang-closure-rebind.e2e.test.ts
@@ -50,11 +50,11 @@ test(
     });
 
     await runner.pause();
-    const base = xOf((await runner.state()).model);
+    const base = xOf((await runner.state()).model_debug);
     const DT = 0.25;
     await runner.step(DT);
     await runner.step(DT);
-    const before = xOf((await runner.state()).model);
+    const before = xOf((await runner.state()).model_debug);
     // The stored closure is makeSpin(2.0): each step adds k*dt = 0.5.
     assert.ok(
       Math.abs(before - base - 2 * (2.0 * DT)) < 1e-4,
@@ -76,7 +76,7 @@ test(
     );
 
     await runner.step(DT);
-    const after = xOf((await runner.state()).model);
+    const after = xOf((await runner.state()).model_debug);
     // THE assertion: new body (k*dt*10) with the OLD captured k = 2 —
     // and the old x, since the model itself survived too. (The edit must
     // stay dt-proportional: paused frames still tick with dt = 0, so a

--- a/tools/functor-sdk/test/functor-lang-effects.e2e.test.ts
+++ b/tools/functor-sdk/test/functor-lang-effects.e2e.test.ts
@@ -60,13 +60,13 @@ test(
     });
 
     await runner.pause();
-    let model = (await runner.state()).model;
+    let model = (await runner.state()).model_debug;
     assert.equal(fieldOf(model, "roll"), -1, `sentinel intact: ${model}`);
 
     // One key press = one Effect.random, whose update chains an Effect.now.
     await runner.key("Space", true);
     await runner.step(0.1);
-    model = (await runner.state()).model;
+    model = (await runner.state()).model_debug;
     const roll = fieldOf(model, "roll");
     const at = fieldOf(model, "at");
     assert.ok(roll >= 0 && roll < 1, `roll in [0,1): ${model}`);

--- a/tools/functor-sdk/test/functor-lang-hot-reload.e2e.test.ts
+++ b/tools/functor-sdk/test/functor-lang-hot-reload.e2e.test.ts
@@ -52,10 +52,10 @@ test(
     // (The game free-runs on the wall clock between launch and pause, so all
     // assertions are RELATIVE to the pinned baseline.)
     await runner.pause();
-    const base = spinOf((await runner.state()).model);
+    const base = spinOf((await runner.state()).model_debug);
     const DT = 0.1;
     for (let i = 0; i < 3; i++) await runner.step(DT);
-    const before = spinOf((await runner.state()).model);
+    const before = spinOf((await runner.state()).model_debug);
     assert.ok(
       Math.abs(before - base - 3 * DT) < 1e-4,
       `three steps at speed 1.0 should add ~0.3 to ${base}, got ${before}`,
@@ -71,7 +71,7 @@ test(
       { timeoutMs: 10_000, description: "hot reload observed in logs" },
     );
     await runner.step(DT);
-    const after = spinOf((await runner.state()).model);
+    const after = spinOf((await runner.state()).model_debug);
 
     // THE assertion: the new spin is the OLD value plus one step of the NEW
     // behavior — state survived the edit AND the edit took effect.
@@ -95,7 +95,7 @@ test(
       { timeoutMs: 10_000, description: "broken reload reported" },
     );
     await runner.step(DT);
-    const still = spinOf((await runner.state()).model);
+    const still = spinOf((await runner.state()).model_debug);
     assert.ok(
       Math.abs(still - (after + DT * -5.0)) < 1e-4,
       `the old program should keep running after a broken edit, got ${still}`,

--- a/tools/functor-sdk/test/functor-lang-input.e2e.test.ts
+++ b/tools/functor-sdk/test/functor-lang-input.e2e.test.ts
@@ -39,7 +39,7 @@ test(
     });
     await runner.pause();
 
-    const model = async () => (await runner.state()).model;
+    const model = async () => (await runner.state()).model_debug;
     assert.match(await model(), /presses: 0/, "no input yet");
 
     // A press+release is two events; the key crosses as its `Key.*` variant.

--- a/tools/functor-sdk/test/functor-lang-modules-hot-reload.e2e.test.ts
+++ b/tools/functor-sdk/test/functor-lang-modules-hot-reload.e2e.test.ts
@@ -58,10 +58,10 @@ test(
 
     // Pin the clock: every state change below is an explicit, exact step.
     await runner.pause();
-    const base = spinOf((await runner.state()).model);
+    const base = spinOf((await runner.state()).model_debug);
     const DT = 0.1;
     for (let i = 0; i < 3; i++) await runner.step(DT);
-    const before = spinOf((await runner.state()).model);
+    const before = spinOf((await runner.state()).model_debug);
     assert.ok(
       Math.abs(before - base - 3 * DT) < 1e-4,
       `three steps at Config.speed 1.0 should add ~0.3 to ${base}, got ${before}`,
@@ -75,7 +75,7 @@ test(
       { timeoutMs: 10_000, description: "sibling edit observed as hot reload" },
     );
     await runner.step(DT);
-    const after = spinOf((await runner.state()).model);
+    const after = spinOf((await runner.state()).model_debug);
 
     // THE assertion: the new spin is the OLD value plus one step of the NEW
     // sibling constant — state survived a non-entry edit AND it took effect.
@@ -93,7 +93,7 @@ test(
       { timeoutMs: 10_000, description: "broken sibling reload reported" },
     );
     await runner.step(DT);
-    const still = spinOf((await runner.state()).model);
+    const still = spinOf((await runner.state()).model_debug);
     assert.ok(
       Math.abs(still - (after + DT * -5.0)) < 1e-4,
       `the old program should keep running after a broken sibling edit, got ${still}`,
@@ -109,7 +109,7 @@ test(
       { timeoutMs: 10_000, description: "fixed sibling reloaded" },
     );
     await runner.step(DT);
-    const fixed = spinOf((await runner.state()).model);
+    const fixed = spinOf((await runner.state()).model_debug);
     assert.ok(
       Math.abs(fixed - (still + DT * 2.0)) < 1e-4,
       `expected ${still} + ${DT}*2 after the fix, got ${fixed}`,

--- a/tools/functor-sdk/test/functor-lang-mouse-button.e2e.test.ts
+++ b/tools/functor-sdk/test/functor-lang-mouse-button.e2e.test.ts
@@ -57,7 +57,7 @@ test(
     });
     await runner.pause();
 
-    const model = async () => (await runner.state()).model;
+    const model = async () => (await runner.state()).model_debug;
     // `buttons` is optional on the type (older runtimes omit it); a runtime
     // that supports this feature at all must report it.
     const buttons = async () => {

--- a/tools/functor-sdk/test/functor-lang-subscriptions.e2e.test.ts
+++ b/tools/functor-sdk/test/functor-lang-subscriptions.e2e.test.ts
@@ -85,7 +85,7 @@ test(
       { timeoutMs: 10_000, description: "hot reload observed in logs" },
     );
     await runner.step(1.0);
-    const model = (await runner.state()).model;
+    const model = (await runner.state()).model_debug;
     assert.equal(
       fieldOf(model, "beats"),
       1,
@@ -95,17 +95,17 @@ test(
     // One step per period -> one message per step, exactly.
     await runner.step(1.0);
     await runner.step(1.0);
-    let beats = fieldOf((await runner.state()).model, "beats");
+    let beats = fieldOf((await runner.state()).model_debug, "beats");
     assert.equal(beats, 3, `two more 1s steps should make 3 beats, got ${beats}`);
 
     // Time.millis(1000) fires in lockstep with Time.seconds(1.0).
-    const echoes = fieldOf((await runner.state()).model, "echoes");
+    const echoes = fieldOf((await runner.state()).model_debug, "echoes");
     assert.equal(echoes, beats, `millis/seconds parity: ${echoes} vs ${beats}`);
 
     // A long frame collapses missed boundaries into ONE firing (the F#
     // crossedBoundary rule: floor comparison, not a counter).
     await runner.step(4.0);
-    beats = fieldOf((await runner.state()).model, "beats");
+    beats = fieldOf((await runner.state()).model_debug, "beats");
     assert.equal(beats, 4, `a 4s frame fires Beat once, not four times: ${beats}`);
   },
 );

--- a/tools/functor-sdk/test/held-input.e2e.test.ts
+++ b/tools/functor-sdk/test/held-input.e2e.test.ts
@@ -51,14 +51,14 @@ test(
 
     // Baseline: nothing held — structured snapshot AND game model.
     assert.equal(await game.isKeyDown("Up"), false, "Up should start released");
-    assert.equal(gameSawUp((await game.state()).model), false, "game should start with up released");
+    assert.equal(gameSawUp((await game.state()).model_debug), false, "game should start with up released");
 
     // Positive: press 'up', step a frame.
     await game.keyDown("up");
     await game.step();
     assert.equal(await game.isKeyDown("Up"), true, "runtime should report Up held");
     assert.equal(
-      gameSawUp((await game.state()).model),
+      gameSawUp((await game.state()).model_debug),
       true,
       "game should see up held (regression: input not reaching the game)",
     );
@@ -67,7 +67,7 @@ test(
     await game.keyUp("up");
     await game.step();
     assert.equal(await game.isKeyDown("Up"), false, "runtime should report Up released");
-    assert.equal(gameSawUp((await game.state()).model), false, "game should see up released");
+    assert.equal(gameSawUp((await game.state()).model_debug), false, "game should see up released");
 
     // The render path produces a valid PNG — windowed only (headless has no GL).
     if (!headless) {

--- a/tools/functor-sdk/test/multiplayer.e2e.test.ts
+++ b/tools/functor-sdk/test/multiplayer.e2e.test.ts
@@ -73,10 +73,10 @@ test(
 
     // The server should accept both connections and track a player for each.
     const serverState = await server.waitForState(
-      (s) => serverPlayerCount(s.model) === 2,
+      (s) => serverPlayerCount(s.model_debug) === 2,
       { ...waitOpts, description: "server to track 2 players" },
     );
-    assert.equal(serverPlayerCount(serverState.model), 2);
+    assert.equal(serverPlayerCount(serverState.model_debug), 2);
 
     // Each client should reach "in-world" and see both players in the snapshot
     // the server broadcasts — i.e. the clients converge on a shared world. The
@@ -87,11 +87,11 @@ test(
       ["B", clientB],
     ] as const) {
       const converged = await client.waitForState(
-        (s) => clientStatus(s.model) === "in-world" && clientWorldCount(s.model) === 2,
+        (s) => clientStatus(s.model_debug) === "in-world" && clientWorldCount(s.model_debug) === 2,
         { ...waitOpts, description: `client ${name} to see both players` },
       );
-      assert.equal(clientStatus(converged.model), "in-world");
-      assert.equal(clientWorldCount(converged.model), 2, `client ${name} sees both players`);
+      assert.equal(clientStatus(converged.model_debug), "in-world");
+      assert.equal(clientWorldCount(converged.model_debug), 2, `client ${name} sees both players`);
     }
   },
 );


### PR DESCRIPTION
## What

`GET /state`'s model view was opaque Rust-`Debug` text, so agents and tests read game state by string matching. As of this PR (protocol **v4**), **`model` is the structured JSON view of the live model — the default thing to read** — and the `Debug` pretty-print moves to **`model_debug`** (the human/eyeball view). This resolves the "still open" note in `docs/debug-runtime.md` and is the observation seam for the `functor mcp` server stacked on top (#529).

- `value_to_json` walker in `functor_runtime_common::functor_lang_prelude`, next to `effect_value_from_value` (the existing plain-data wire mapping). **Total and lossy**: plain data maps structurally; everything else becomes a sigil-keyed object no source-authored record field can collide with (`$` is not a Functor Lang identifier character): `{"$tuple": […]}`, `{"$ctor": "Some", "args": […]}`, `{"$fn": "<fn(dt)>"}`, `{"$host": "SceneNode"}`, `{"$number": "NaN"}`.
- Depth is bounded at 120 **emitted JSON containers** (`{"$truncated": "max depth"}` past it): nesting is user-controlled, and for JSON the bound is a property of the format — `serde_json::Value` recurses in its own `Serialize`/`Drop`, and stock serde_json parsers reject >128 containers anyway. Sized so the deepest producible payload wrapped in `RuntimeState` still round-trips (test included). `model_debug` remains strictly more faithful exactly where `model` is lossy (full depth, construction order, closure params).
- `GameProducer::state_json()` with a `Null` default (the honest answer for the replay producer, whose `model_debug` still describes the replay position); both Functor Lang producers implement it, so **desktop and Quest** report it.
- **v4 redefines `model`**: pre-v4 runtimes sent the Debug text under that key. Clients gate on `GET /`'s `protocol_version`; the site device panel reads `model_debug` with a pre-v4 string-`model` fallback (its mock e2e pins that path), and SDK/e2e consumers move off Debug-text matching where the structured view serves.
- SDK: `model: ModelJson` + `model_debug: string`; docs: `model` section in `docs/debug-runtime.md`.

## Verification

- `cargo test -p functor_runtime_common` — 526 passed (walker unit tests: every `Value` case, both infinities, depth bound, deep-tuple `RuntimeState` round-trip); desktop suite green; SDK `tsc` clean and `FUNCTOR_E2E=1 npm test` 24/24 against the live runtime; site builds, `node e2e/runtime-target.mjs` all checks pass (pre-v4 fallback path).
- `node e2e/xr-pose-injection.mjs` — all checks pass, including assertions that `/state.model` is structured and carries a typed bool through the real headless runtime.
- Live headless: `examples/counter` → `model: {"count": 0.0}`, `model_debug: "{ count: 0 }"`, `protocol_version: 4`.
- Not perf-sensitive: the walker runs only on `/state` requests, never per-frame.

## Review dispositions (xreview: Claude/Opus + Codex; both engines ran, dupfinder cold-index timed out — no duplication evidence)

Fixed:
- **[AGREED] protocol version not bumped** (Claude High, Codex Medium) → bumped to 4 with doc line; test pin updated; `GET /` discovery description updated (Codex Low).
- **[AGREED-adjacent] depth semantics** (Claude Medium: recursion vs the codebase's iterative invariant; Codex Medium: depth charged per value, not per JSON container, so ~63 nested tuples could exceed serde_json's 128-container parse limit) → bound now charged in emitted JSON containers (tuples/variants charge 2) at 120, with a deep-tuple round-trip test. Kept the capped recursive walker rather than an iterative rewrite: `serde_json::Value` itself recurses in `Serialize`/`Drop`, so unbounded depth is unrepresentable in the output format regardless of walker style — the cap is the format's. The `model_debug` text on the same response still shows full depth.
- **SDK typed the new field as always-present against pre-v4 runtimes** (Claude Medium, Codex Medium) → resolved by the v4 redefinition: the SDK types the current protocol (its existing convention, cf. `pending_steps`) and documents the pre-v4 shape.
- **`inf`/`-inf` spellings** (Claude Low) → `NaN`/`Infinity`/`-Infinity`, both infinities tested.
- **sigil-collision claim overstated** (Claude Low: network-supplied record keys may carry `$`) → doc/comment softened to source-authored fields.
- **untested shell wiring** (Claude Low) → e2e assertions added (above).

Accepted / not fixed:
- **/state serializes the model twice per poll** (Claude Medium) — accepted for v1: `/state` is polled at a few Hz (never per-frame), the Debug dump already walked the full model per poll, and the MCP consumer always wants the JSON view. Revisit with a query flag if profiling ever shows it.
- **record field order is alphabetical, not construction order** (Claude Low) — documented behavior; enabling serde_json `preserve_order` would change map ordering crate-wide. `model_debug` preserves construction order.
- **future-directions MCP bullet is a promise** (Claude Low) — kept: the Future directions section is exactly for planned work, and the MCP PR is stacked on this one.

> **Naming** (2026-07-27): originally landed as an additive `model_json` field; renamed before anything shipped v4 so the structured view IS `model` and the Debug text is `model_debug` — the structured view is the default read, and no legacy field name is carried forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
