### PR TITLE
feat(cli): functor mcp — an MCP server over the debug runtime

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,6 +304,12 @@ whole directory's expects run whichever role you name.
 drives the interpreter/typechecker headlessly (the plain-`functor-lang` prelude, no engine host). See the
 `functor-lang` skill.
 
+**Drive a game as an MCP client.** `functor mcp` serves the debug runtime
+(`docs/debug-runtime.md`) as MCP tools over stdio — launch/attach N game sessions, read
+`model_json`, pause/step the clock, inject input, capture frames, hot-reload source. Register
+it with `claude mcp add functor -- functor mcp`; see `docs/mcp.md`. It ignores `-d` (each
+launched game names its own directory) and owns stdout for JSON-RPC.
+
 **Capture a frame to PNG** (no OS screen-recording permission needed — the runner reads back its
 own framebuffer; ideal for verifying rendering changes). The CLI forwards extra args to
 the built-in desktop runtime (a leading `--` is optional):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,7 +306,7 @@ drives the interpreter/typechecker headlessly (the plain-`functor-lang` prelude,
 
 **Drive a game as an MCP client.** `functor mcp` serves the debug runtime
 (`docs/debug-runtime.md`) as MCP tools over stdio — launch/attach N game sessions, read
-`model_json`, pause/step the clock, inject input, capture frames, hot-reload source. Register
+the structured `model`, pause/step the clock, inject input, capture frames, hot-reload source. Register
 it with `claude mcp add functor -- functor mcp`; see `docs/mcp.md`. It ignores `-d` (each
 launched game names its own directory) and owns stdout for JSON-RPC.
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -43,3 +43,6 @@ functor_runtime_common = { path = "../runtime/functor-runtime-common" }
 # The desktop runtime (GLFW/OpenGL). `functor run native` drives its run loop
 # in-process — post-E3 there is a single `functor` binary, always with GL.
 functor-runtime-desktop = { path = "../runtime/functor-runtime-desktop" }
+rmcp = { version = "2.2.0", default-features = false, features = ["server", "macros", "transport-io"] }
+base64 = "0.22"
+schemars = "1.2"

--- a/cli/src/commands/mcp.rs
+++ b/cli/src/commands/mcp.rs
@@ -11,7 +11,7 @@
 //! plus a child process when the session was launched (rather than attached)
 //! by this server.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io;
 use std::net::TcpListener;
 use std::sync::{Arc, Mutex};
@@ -31,10 +31,14 @@ use tokio::process::{Child, Command};
 
 /// How long `launch_game` waits for a spawned runtime to answer discovery.
 const LAUNCH_TIMEOUT: Duration = Duration::from_secs(30);
-/// How long `step` waits for a queued batch of advances to drain.
-const STEP_TIMEOUT: Duration = Duration::from_secs(30);
+/// How long `step` tolerates a queued batch making NO progress before giving
+/// up. A large batch legitimately takes far longer than this to drain in total.
+const STEP_STALL_TIMEOUT: Duration = Duration::from_secs(30);
 /// Per-request timeout for the (loopback or adb-forwarded) debug server.
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+/// Lowest debug-protocol version whose contract these tools actually keep
+/// (`pending_steps` on `/state`, `frames` on `/time advance`, `model_json`).
+const REQUIRED_PROTOCOL_VERSION: u64 = 4;
 /// Bytes of a launched child's stdout/stderr kept for failure reporting.
 const LOG_TAIL_BYTES: usize = 8 * 1024;
 
@@ -46,18 +50,41 @@ pub async fn execute() -> io::Result<()> {
         .serve(stdio())
         .await
         .map_err(|error| io::Error::other(format!("failed to start the MCP server: {error}")))?;
-    let quit = service.waiting().await;
-    // Owned children are killed on drop (`kill_on_drop`), but the registry is
-    // reachable from the transport task's clone; drop them explicitly so a
-    // clean client disconnect never leaves a game running.
+    // Owned children are killed on drop (`kill_on_drop`), but a client that
+    // signals the server instead of closing stdin would never reach that drop —
+    // and every orphan is a whole desktop runtime holding a GL context. So
+    // shutdown is reached from either side.
+    let running = service.waiting();
+    tokio::pin!(running);
+    let quit = tokio::select! {
+        result = &mut running => result.map(|_| ()),
+        _ = shutdown_signal() => Ok(()),
+    };
     Registry::shutdown(&sessions);
-    quit.map(|_| ())
-        .map_err(|error| io::Error::other(format!("the MCP server task failed: {error}")))
+    quit.map_err(|error| io::Error::other(format!("the MCP server task failed: {error}")))
+}
+
+/// Resolve when the host asks this process to stop (SIGTERM or Ctrl-C).
+async fn shutdown_signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+        if let Ok(mut terminate) = signal(SignalKind::terminate()) {
+            tokio::select! {
+                _ = terminate.recv() => return,
+                _ = tokio::signal::ctrl_c() => return,
+            }
+        }
+    }
+    let _ = tokio::signal::ctrl_c().await;
 }
 
 /// One game the server can talk to.
 struct Session {
     url: String,
+    /// The port this server reserved for a launched runtime, held so a
+    /// concurrent launch cannot be handed the same one.
+    port: Option<u16>,
     /// `Some` only when this server spawned the runtime. An attached session
     /// (`connect_game`) is never killed — the runtime belongs to someone else.
     child: Option<Child>,
@@ -67,14 +94,35 @@ struct Session {
 struct Registry {
     next_id: u32,
     sessions: BTreeMap<String, Session>,
+    /// Ports handed to a launch. The OS never offers a port a live runtime
+    /// already holds, but it happily offers the same one twice inside the
+    /// window between `free_port` and the child's own bind — and MCP tool calls
+    /// can overlap, which is exactly the two-game case sessions exist for.
+    reserved: BTreeSet<u16>,
 }
 
 impl Registry {
-    fn insert(&mut self, url: String, child: Option<Child>) -> String {
+    fn insert(&mut self, url: String, port: Option<u16>, child: Option<Child>) -> String {
         self.next_id += 1;
         let id = format!("s{}", self.next_id);
-        self.sessions.insert(id.clone(), Session { url, child });
+        self.sessions
+            .insert(id.clone(), Session { url, port, child });
         id
+    }
+
+    /// Claim a port no other session has been handed.
+    fn reserve_port(&mut self) -> Result<u16, String> {
+        for _ in 0..64 {
+            let port = free_port()?;
+            if self.reserved.insert(port) {
+                return Ok(port);
+            }
+        }
+        Err("could not find a free port that is not already reserved by another session".into())
+    }
+
+    fn release_port(&mut self, port: u16) {
+        self.reserved.remove(&port);
     }
 
     /// The session's base URL, or an error naming the sessions that do exist —
@@ -98,7 +146,12 @@ impl Registry {
 
     fn remove(&mut self, id: &str) -> Result<Session, String> {
         match self.sessions.remove(id) {
-            Some(session) => Ok(session),
+            Some(session) => {
+                if let Some(port) = session.port {
+                    self.release_port(port);
+                }
+                Ok(session)
+            }
             None => Err(self.url(id).expect_err("id is absent")),
         }
     }
@@ -242,7 +295,11 @@ or \"headless\" (no GL, no capture)"
                 ))
             }
         };
-        let port = resolve!(free_port());
+        let port = resolve!(self
+            .sessions
+            .lock()
+            .expect("mcp registry poisoned")
+            .reserve_port());
         let exe = resolve!(std::env::current_exe()
             .map_err(|error| format!("cannot locate the functor executable: {error}")));
 
@@ -262,15 +319,20 @@ or \"headless\" (no GL, no capture)"
             .stderr(std::process::Stdio::piped())
             .kill_on_drop(true);
 
-        let mut child = resolve!(command
-            .spawn()
-            .map_err(|error| format!("failed to spawn the runtime: {error}")));
+        let mut child = match command.spawn() {
+            Ok(child) => child,
+            Err(error) => {
+                self.release_port(port);
+                return tool_error(format!("failed to spawn the runtime: {error}"));
+            }
+        };
         let log = Arc::new(Mutex::new(Vec::new()));
+        let mut drains = Vec::new();
         if let Some(stream) = child.stdout.take() {
-            drain_into(stream, log.clone());
+            drains.push(drain_into(stream, log.clone()));
         }
         if let Some(stream) = child.stderr.take() {
-            drain_into(stream, log.clone());
+            drains.push(drain_into(stream, log.clone()));
         }
 
         let url = format!("http://127.0.0.1:{port}");
@@ -278,15 +340,25 @@ or \"headless\" (no GL, no capture)"
             Ok(discovery) => discovery,
             Err(message) => {
                 let _ = child.start_kill();
+                self.release_port(port);
+                // The output that explains a failed launch — a bind error, a
+                // typecheck diagnostic — is written just before the child exits,
+                // so let the drain tasks reach EOF before reading the tail.
+                let _ = tokio::time::timeout(Duration::from_millis(500), async {
+                    for drain in drains {
+                        let _ = drain.await;
+                    }
+                })
+                .await;
                 return tool_error(format!("{message}\n\nruntime output:\n{}", tail(&log)));
             }
         };
 
-        let id = self
-            .sessions
-            .lock()
-            .expect("mcp registry poisoned")
-            .insert(url.clone(), Some(child));
+        let id = self.sessions.lock().expect("mcp registry poisoned").insert(
+            url.clone(),
+            Some(port),
+            Some(child),
+        );
         ok_text(
             serde_json::json!({
                 "session": id,
@@ -310,11 +382,11 @@ or \"headless\" (no GL, no capture)"
     ) -> Result<CallToolResult, ErrorData> {
         let url = args.url.trim_end_matches('/').to_string();
         let discovery = resolve!(self.discover(&url).await);
-        let id = self
-            .sessions
-            .lock()
-            .expect("mcp registry poisoned")
-            .insert(url.clone(), None);
+        let id =
+            self.sessions
+                .lock()
+                .expect("mcp registry poisoned")
+                .insert(url.clone(), None, None);
         ok_text(
             serde_json::json!({
                 "session": id,
@@ -435,11 +507,16 @@ or \"headless\" (no GL, no capture)"
             .bytes()
             .await
             .map_err(|error| format!("reading the captured PNG failed: {error}")));
+        // 503 is "no pixels right now", and the runtime says WHICH reason —
+        // headless, a dozing XR session, a capture timeout. Pass its own words
+        // through and only append the hint, so an attached Quest is not told to
+        // relaunch a process this server does not own.
         if status.as_u16() == 503 {
-            return tool_error(
-                "this runtime has no pixels to capture: it was started headless (--headless \
-creates no GL context). Relaunch the game with mode \"hidden\" to capture frames.",
-            );
+            return tool_error(format!(
+                "POST /capture -> 503: {}\n\nA session launched with mode \"headless\" has no GL \
+context at all — relaunch it with mode \"hidden\" to capture frames.",
+                String::from_utf8_lossy(&body)
+            ));
         }
         if !status.is_success() {
             return tool_error(format!(
@@ -460,6 +537,8 @@ creates no GL context). Relaunch the game with mode \"hidden\" to capture frames
     /// `{"type":"ui_event","slot":0,"kind":"Clicked"}` (also
     /// `{"SliderChanged":0.5}` / `{"TextChanged":"hi"}`),
     /// `{"type":"xr", "head":…, "left":…, "right":…}`, `{"type":"xr_clear"}`.
+    /// The list mirrors `POST /input` and is not exhaustive; an unrecognized
+    /// shape comes back as the runtime's own 400, which names the problem.
     /// Keys, held buttons and XR samples are LEVEL state: they stay in force
     /// across steps until released, which is how a paused session is scripted.
     #[tool]
@@ -480,16 +559,19 @@ creates no GL context). Relaunch the game with mode \"hidden\" to capture frames
         &self,
         Parameters(args): Parameters<PauseArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        let url = resolve!(self.url(&args.session));
         let tts = match args.tts {
             Some(tts) => tts,
-            None => resolve!(self.current_tts(&args.session).await),
+            None => resolve!(tts_of(&resolve!(self.state(&url).await))),
         };
-        self.proxy_post(
-            &args.session,
-            "/time",
-            serde_json::json!({ "type": "set", "tts": tts }).to_string(),
-        )
-        .await
+        ok_text(resolve!(
+            self.post(
+                &url,
+                "/time",
+                serde_json::json!({ "type": "set", "tts": tts }).to_string(),
+            )
+            .await
+        ))
     }
 
     /// Run exactly `frames` simulation steps of `dts` seconds each, WAIT for
@@ -509,17 +591,26 @@ creates no GL context). Relaunch the game with mode \"hidden\" to capture frames
             "frames": args.frames.unwrap_or(1),
         });
         resolve!(self.post(&url, "/time", body.to_string()).await);
-        let deadline = Instant::now() + STEP_TIMEOUT;
+        // The timeout is a STALL timeout, not a total one: a large batch drains
+        // at up to 8 steps per rendered frame, so a legitimate 100k-step skip
+        // takes minutes. Every observed step resets the clock; only a queue that
+        // stops moving is a failure.
+        let mut deadline = Instant::now() + STEP_STALL_TIMEOUT;
+        let mut remaining = u64::MAX;
         loop {
             let state = resolve!(self.state(&url).await);
-            if state["pending_steps"].as_u64().unwrap_or(0) == 0 {
+            let pending = state["pending_steps"].as_u64().unwrap_or(0);
+            if pending == 0 {
                 return ok_text(state.to_string());
             }
-            if Instant::now() >= deadline {
+            if pending < remaining {
+                remaining = pending;
+                deadline = Instant::now() + STEP_STALL_TIMEOUT;
+            } else if Instant::now() >= deadline {
                 return tool_error(format!(
-                    "the queued steps never drained ({} still pending after {}s)",
-                    state["pending_steps"],
-                    STEP_TIMEOUT.as_secs()
+                    "the queued steps stopped draining ({pending} still pending, no progress for \
+{}s) — the game loop may be stuck or the runtime paused from elsewhere",
+                    STEP_STALL_TIMEOUT.as_secs()
                 ));
             }
             tokio::time::sleep(Duration::from_millis(5)).await;
@@ -551,8 +642,7 @@ creates no GL context). Relaunch the game with mode \"hidden\" to capture frames
         Parameters(args): Parameters<RewindArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         let url = resolve!(self.url(&args.session));
-        let state = resolve!(self.state(&url).await);
-        let tts = state["tts"].as_f64().unwrap_or(0.0);
+        let tts = resolve!(tts_of(&resolve!(self.state(&url).await)));
         // The clock must be pinned before a rewind or the next wall-clock frame
         // would immediately overwrite the restored model. `/state` does not
         // report whether it already is, so this re-pins at the CURRENT time —
@@ -611,6 +701,13 @@ creates no GL context). Relaunch the game with mode \"hidden\" to capture frames
 }
 
 impl FunctorMcp {
+    fn release_port(&self, port: u16) {
+        self.sessions
+            .lock()
+            .expect("mcp registry poisoned")
+            .release_port(port);
+    }
+
     fn url(&self, session: &str) -> Result<String, String> {
         self.sessions
             .lock()
@@ -660,11 +757,6 @@ impl FunctorMcp {
             .map_err(|error| format!("GET /state returned invalid JSON: {error}"))
     }
 
-    async fn current_tts(&self, session: &str) -> Result<f64, String> {
-        let url = self.url(session)?;
-        Ok(self.state(&url).await?["tts"].as_f64().unwrap_or(0.0))
-    }
-
     /// Fetch and validate the discovery document, so an `http://…` that answers
     /// something else is rejected here rather than at the first real call.
     async fn discover(&self, url: &str) -> Result<Value, String> {
@@ -675,6 +767,20 @@ impl FunctorMcp {
             return Err(format!(
                 "{url} is not a Functor debug runtime (its / reports {})",
                 discovery["service"]
+            ));
+        }
+        // Below v4 the guarantees these tools advertise silently stop holding:
+        // a pre-v3 runtime ignores a batched `frames` and reports no
+        // `pending_steps` (so `step` would claim a 10-frame batch landed after
+        // running one), and a pre-v4 one never sends `model_json`. Refuse
+        // rather than mislead — this matters for a device APK, which versions
+        // independently of the CLI.
+        let version = discovery["protocol_version"].as_u64().unwrap_or(0);
+        if version < REQUIRED_PROTOCOL_VERSION {
+            return Err(format!(
+                "{url} speaks debug protocol v{version}, but these tools need \
+v{REQUIRED_PROTOCOL_VERSION} (batched steps report pending_steps, and /state carries \
+model_json). Rebuild that runtime from this version of Functor."
             ));
         }
         Ok(discovery)
@@ -721,6 +827,17 @@ impl Default for FunctorMcp {
     }
 }
 
+/// The runtime's current time, from a `/state` document. Never defaulted: a
+/// silent 0.0 would pin a paused game (or a rewind) to the start of time.
+fn tts_of(state: &Value) -> Result<f64, String> {
+    state["tts"].as_f64().ok_or_else(|| {
+        format!(
+            "GET /state did not report a numeric tts (got {})",
+            state["tts"]
+        )
+    })
+}
+
 /// Read a response body, turning a non-2xx into a message that carries the
 /// runtime's own text — the 400s from `/input`, `/time` and the reload routes
 /// are teaching errors, so they must reach the caller verbatim.
@@ -751,7 +868,7 @@ fn free_port() -> Result<u16, String> {
 
 /// Accumulate a child's output into a bounded tail buffer, so a launch that
 /// never serves can still report why.
-fn drain_into<R>(mut stream: R, log: Arc<Mutex<Vec<u8>>>)
+fn drain_into<R>(mut stream: R, log: Arc<Mutex<Vec<u8>>>) -> tokio::task::JoinHandle<()>
 where
     R: AsyncReadExt + Unpin + Send + 'static,
 {
@@ -768,7 +885,7 @@ where
                 buffer.drain(..excess);
             }
         }
-    });
+    })
 }
 
 fn tail(log: &Arc<Mutex<Vec<u8>>>) -> String {
@@ -782,8 +899,8 @@ mod tests {
     #[test]
     fn ids_are_short_sequential_and_resolve_to_their_url() {
         let mut registry = Registry::default();
-        let first = registry.insert("http://127.0.0.1:1".into(), None);
-        let second = registry.insert("http://127.0.0.1:2".into(), None);
+        let first = registry.insert("http://127.0.0.1:1".into(), None, None);
+        let second = registry.insert("http://127.0.0.1:2".into(), None, None);
 
         assert_eq!(first, "s1");
         assert_eq!(second, "s2");
@@ -796,21 +913,40 @@ mod tests {
         let empty = registry.url("s1").unwrap_err();
         assert!(empty.contains("no sessions yet"), "{empty}");
 
-        registry.insert("http://127.0.0.1:1".into(), None);
-        registry.insert("http://127.0.0.1:2".into(), None);
+        registry.insert("http://127.0.0.1:1".into(), None, None);
+        registry.insert("http://127.0.0.1:2".into(), None, None);
         let unknown = registry.url("s9").unwrap_err();
         assert!(unknown.contains("s1, s2"), "{unknown}");
     }
 
     #[test]
+    fn a_reserved_port_is_held_until_its_session_is_removed() {
+        let mut registry = Registry::default();
+        let port = registry.reserve_port().unwrap();
+        assert!(registry.reserved.contains(&port));
+
+        // A second reservation cannot be handed the same port, even though the
+        // first one's listener is already closed.
+        let other = registry.reserve_port().unwrap();
+        assert_ne!(port, other);
+
+        registry.insert("http://127.0.0.1:1".into(), Some(port), None);
+        registry.remove("s1").unwrap();
+        assert!(!registry.reserved.contains(&port));
+    }
+
+    #[test]
     fn removing_a_session_forgets_it_and_does_not_reuse_its_id() {
         let mut registry = Registry::default();
-        registry.insert("http://127.0.0.1:1".into(), None);
+        registry.insert("http://127.0.0.1:1".into(), None, None);
         let removed = registry.remove("s1").unwrap();
 
         assert_eq!(removed.url, "http://127.0.0.1:1");
         assert!(registry.url("s1").is_err());
-        assert_eq!(registry.insert("http://127.0.0.1:3".into(), None), "s2");
+        assert_eq!(
+            registry.insert("http://127.0.0.1:3".into(), None, None),
+            "s2"
+        );
         let Err(message) = registry.remove("s1") else {
             panic!("a removed id must not resolve again");
         };

--- a/cli/src/commands/mcp.rs
+++ b/cli/src/commands/mcp.rs
@@ -1,0 +1,819 @@
+//! `functor mcp` — an MCP (Model Context Protocol) server over the debug
+//! runtime (`docs/debug-runtime.md`).
+//!
+//! The debug runtime already lets an external driver observe and control a
+//! running game over localhost HTTP. This wraps that surface in the standard
+//! interface coding agents already speak, so "run this game, pause it, press a
+//! key, look at the model" needs no bespoke script.
+//!
+//! Everything here is CLI-only: the server is an HTTP client of the runtimes,
+//! never a part of them. It manages N concurrent sessions — each a base URL,
+//! plus a child process when the session was launched (rather than attached)
+//! by this server.
+
+use std::collections::BTreeMap;
+use std::io;
+use std::net::TcpListener;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use base64::Engine as _;
+use functor_runtime_common::debug_protocol::DEBUG_PROTOCOL_SERVICE;
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::{CallToolResult, ContentBlock};
+use rmcp::transport::stdio;
+use rmcp::{tool, tool_handler, tool_router, ErrorData, ServerHandler, ServiceExt};
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::Value;
+use tokio::io::AsyncReadExt;
+use tokio::process::{Child, Command};
+
+/// How long `launch_game` waits for a spawned runtime to answer discovery.
+const LAUNCH_TIMEOUT: Duration = Duration::from_secs(30);
+/// How long `step` waits for a queued batch of advances to drain.
+const STEP_TIMEOUT: Duration = Duration::from_secs(30);
+/// Per-request timeout for the (loopback or adb-forwarded) debug server.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+/// Bytes of a launched child's stdout/stderr kept for failure reporting.
+const LOG_TAIL_BYTES: usize = 8 * 1024;
+
+/// Serve MCP over stdio until the client disconnects.
+pub async fn execute() -> io::Result<()> {
+    let server = FunctorMcp::new();
+    let sessions = server.sessions.clone();
+    let service = server
+        .serve(stdio())
+        .await
+        .map_err(|error| io::Error::other(format!("failed to start the MCP server: {error}")))?;
+    let quit = service.waiting().await;
+    // Owned children are killed on drop (`kill_on_drop`), but the registry is
+    // reachable from the transport task's clone; drop them explicitly so a
+    // clean client disconnect never leaves a game running.
+    Registry::shutdown(&sessions);
+    quit.map(|_| ())
+        .map_err(|error| io::Error::other(format!("the MCP server task failed: {error}")))
+}
+
+/// One game the server can talk to.
+struct Session {
+    url: String,
+    /// `Some` only when this server spawned the runtime. An attached session
+    /// (`connect_game`) is never killed — the runtime belongs to someone else.
+    child: Option<Child>,
+}
+
+#[derive(Default)]
+struct Registry {
+    next_id: u32,
+    sessions: BTreeMap<String, Session>,
+}
+
+impl Registry {
+    fn insert(&mut self, url: String, child: Option<Child>) -> String {
+        self.next_id += 1;
+        let id = format!("s{}", self.next_id);
+        self.sessions.insert(id.clone(), Session { url, child });
+        id
+    }
+
+    /// The session's base URL, or an error naming the sessions that do exist —
+    /// a stale id is the most common agent mistake, so it must be self-correcting.
+    fn url(&self, id: &str) -> Result<String, String> {
+        match self.sessions.get(id) {
+            Some(session) => Ok(session.url.clone()),
+            None if self.sessions.is_empty() => Err(format!(
+                "unknown session {id:?}: no sessions yet — start one with launch_game or connect_game"
+            )),
+            None => Err(format!(
+                "unknown session {id:?}: known sessions are {}",
+                self.ids().join(", ")
+            )),
+        }
+    }
+
+    fn ids(&self) -> Vec<String> {
+        self.sessions.keys().cloned().collect()
+    }
+
+    fn remove(&mut self, id: &str) -> Result<Session, String> {
+        match self.sessions.remove(id) {
+            Some(session) => Ok(session),
+            None => Err(self.url(id).expect_err("id is absent")),
+        }
+    }
+
+    /// Kill every owned child. Attached sessions are only forgotten.
+    fn shutdown(registry: &Arc<Mutex<Registry>>) {
+        let mut guard = registry.lock().expect("mcp registry poisoned");
+        for (_, mut session) in std::mem::take(&mut guard.sessions) {
+            if let Some(child) = session.child.as_mut() {
+                let _ = child.start_kill();
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct FunctorMcp {
+    http: reqwest::Client,
+    sessions: Arc<Mutex<Registry>>,
+}
+
+fn ok_text(text: impl Into<String>) -> Result<CallToolResult, ErrorData> {
+    Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
+}
+
+/// A tool-level error: the request was valid, the operation failed in a way the
+/// caller should read (a 400 from `/input`, a load error from `/reload-source`).
+fn tool_error(text: impl Into<String>) -> Result<CallToolResult, ErrorData> {
+    Ok(CallToolResult::error(vec![ContentBlock::text(text)]))
+}
+
+/// Collapse an early `Err(String)` into a tool error, or run the body.
+macro_rules! resolve {
+    ($expr:expr) => {
+        match $expr {
+            Ok(value) => value,
+            Err(message) => return tool_error(message),
+        }
+    };
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct LaunchArgs {
+    /// Project directory (the one holding `functor.json`), absolute or relative
+    /// to the MCP server's working directory.
+    pub dir: String,
+    /// Named entry, for a project whose functor.json declares `entries`.
+    pub entry: Option<String>,
+    /// `"hidden"` (default) renders into an invisible window — `capture_frame`
+    /// works. `"headless"` creates no GL context at all — no display or GPU
+    /// needed, but `capture_frame` then fails.
+    pub mode: Option<String>,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct ConnectArgs {
+    /// Base URL of a running debug server, e.g. `http://127.0.0.1:8123`.
+    pub url: String,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct SessionArgs {
+    /// Session id from `launch_game` / `connect_game` (see `list_sessions`).
+    pub session: String,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct InputArgs {
+    pub session: String,
+    /// The `POST /input` body verbatim, tagged by `type`.
+    pub command: Value,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct PauseArgs {
+    pub session: String,
+    /// Time-to-show to pin at. Defaults to the session's current `tts`, so the
+    /// game freezes exactly where it is.
+    pub tts: Option<f64>,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct StepArgs {
+    pub session: String,
+    /// Delta time for each step, in seconds (default 0.016).
+    pub dts: Option<f64>,
+    /// How many steps to queue (default 1).
+    pub frames: Option<u32>,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct RewindArgs {
+    pub session: String,
+    /// The recorded rendered frame to restore.
+    pub frame: u64,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct ReloadSourceArgs {
+    pub session: String,
+    /// The complete new `.fun` source for the entry module.
+    pub source: String,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct ReloadProjectArgs {
+    pub session: String,
+    /// `[path, source]` pairs covering every sibling module, entry first.
+    pub files: Vec<(String, String)>,
+}
+
+#[tool_router]
+impl FunctorMcp {
+    pub fn new() -> Self {
+        Self {
+            http: reqwest::Client::builder()
+                .timeout(REQUEST_TIMEOUT)
+                .build()
+                .expect("failed to build the MCP HTTP client"),
+            sessions: Arc::new(Mutex::new(Registry::default())),
+        }
+    }
+
+    /// Start a game as a child process with its debug server on a free port,
+    /// and return its session id. Defaults to `hidden` mode (an invisible GL
+    /// window, so `capture_frame` returns pixels); `headless` needs no display
+    /// or GPU at all but has no pixels, so `capture_frame` fails there.
+    #[tool]
+    async fn launch_game(
+        &self,
+        Parameters(args): Parameters<LaunchArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let mode = args.mode.as_deref().unwrap_or("hidden");
+        let mode_flag = match mode {
+            "hidden" => "--hidden",
+            "headless" => "--headless",
+            other => {
+                return tool_error(format!(
+                    "unknown mode {other:?}: expected \"hidden\" (pixels, capture_frame works) \
+or \"headless\" (no GL, no capture)"
+                ))
+            }
+        };
+        let port = resolve!(free_port());
+        let exe = resolve!(std::env::current_exe()
+            .map_err(|error| format!("cannot locate the functor executable: {error}")));
+
+        let mut command = Command::new(exe);
+        command.arg("-d").arg(&args.dir);
+        if let Some(entry) = &args.entry {
+            command.arg("--entry").arg(entry);
+        }
+        command
+            .args(["run", "native", "--debug-port"])
+            .arg(port.to_string())
+            .arg(mode_flag)
+            // stdout is this server's JSON-RPC channel — a child must never
+            // inherit it, or its logs would corrupt the protocol stream.
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true);
+
+        let mut child = resolve!(command
+            .spawn()
+            .map_err(|error| format!("failed to spawn the runtime: {error}")));
+        let log = Arc::new(Mutex::new(Vec::new()));
+        if let Some(stream) = child.stdout.take() {
+            drain_into(stream, log.clone());
+        }
+        if let Some(stream) = child.stderr.take() {
+            drain_into(stream, log.clone());
+        }
+
+        let url = format!("http://127.0.0.1:{port}");
+        let discovery = match self.await_runtime(&url, &mut child).await {
+            Ok(discovery) => discovery,
+            Err(message) => {
+                let _ = child.start_kill();
+                return tool_error(format!("{message}\n\nruntime output:\n{}", tail(&log)));
+            }
+        };
+
+        let id = self
+            .sessions
+            .lock()
+            .expect("mcp registry poisoned")
+            .insert(url.clone(), Some(child));
+        ok_text(
+            serde_json::json!({
+                "session": id,
+                "url": url,
+                "port": port,
+                "mode": mode,
+                "owned": true,
+                "discovery": discovery,
+            })
+            .to_string(),
+        )
+    }
+
+    /// Attach to a debug server this process does NOT own — a runtime someone
+    /// else started, or an adb-forwarded Quest on `http://127.0.0.1:8123`.
+    /// `stop_game` on such a session only forgets it; the runtime keeps running.
+    #[tool]
+    async fn connect_game(
+        &self,
+        Parameters(args): Parameters<ConnectArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let url = args.url.trim_end_matches('/').to_string();
+        let discovery = resolve!(self.discover(&url).await);
+        let id = self
+            .sessions
+            .lock()
+            .expect("mcp registry poisoned")
+            .insert(url.clone(), None);
+        ok_text(
+            serde_json::json!({
+                "session": id,
+                "url": url,
+                "owned": false,
+                "discovery": discovery,
+            })
+            .to_string(),
+        )
+    }
+
+    /// List the known sessions: id, url, whether this server owns the process,
+    /// and whether the runtime currently answers `GET /state`.
+    #[tool]
+    async fn list_sessions(&self) -> Result<CallToolResult, ErrorData> {
+        let known: Vec<(String, String, bool)> = {
+            let guard = self.sessions.lock().expect("mcp registry poisoned");
+            guard
+                .sessions
+                .iter()
+                .map(|(id, session)| (id.clone(), session.url.clone(), session.child.is_some()))
+                .collect()
+        };
+        let mut sessions = Vec::with_capacity(known.len());
+        for (id, url, owned) in known {
+            let alive = self
+                .http
+                .get(format!("{url}/state"))
+                .timeout(Duration::from_secs(2))
+                .send()
+                .await
+                .map(|response| response.status().is_success())
+                .unwrap_or(false);
+            sessions.push(serde_json::json!({
+                "session": id, "url": url, "owned": owned, "alive": alive,
+            }));
+        }
+        ok_text(serde_json::json!({ "sessions": sessions }).to_string())
+    }
+
+    /// Drop a session. A launched (owned) game is killed; an attached one is
+    /// only forgotten.
+    #[tool]
+    async fn stop_game(
+        &self,
+        Parameters(args): Parameters<SessionArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let mut session = resolve!(self
+            .sessions
+            .lock()
+            .expect("mcp registry poisoned")
+            .remove(&args.session));
+        let owned = session.child.is_some();
+        if let Some(child) = session.child.as_mut() {
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+        }
+        ok_text(format!(
+            "stopped session {} ({})",
+            args.session,
+            if owned {
+                "killed the launched runtime"
+            } else {
+                "detached; the runtime is still running"
+            }
+        ))
+    }
+
+    /// Runtime state JSON: `frame`, `tts`, `pending_steps`, viewports, the
+    /// sampled `input`, and the model both as `Debug` text (`model`) and as a
+    /// structured, parseable JSON view (`model_json`) — read `model_json`.
+    #[tool]
+    async fn get_state(
+        &self,
+        Parameters(args): Parameters<SessionArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        self.proxy_get(&args.session, "/state").await
+    }
+
+    /// The current frame as data: the camera, the scene graph, and the lights
+    /// the game's `draw` produced. Works headlessly (it never renders).
+    #[tool]
+    async fn get_scene(
+        &self,
+        Parameters(args): Parameters<SessionArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        self.proxy_get(&args.session, "/scene").await
+    }
+
+    /// The paused inspector trace: the last real frame's entry-point
+    /// invocations with the value at every binder and variable read. Pause the
+    /// session first — while it is playing this reports `{"paused": false}`.
+    #[tool]
+    async fn get_trace(
+        &self,
+        Parameters(args): Parameters<SessionArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        self.proxy_get(&args.session, "/trace").await
+    }
+
+    /// Render the next frame and return it as a PNG image. Requires a GL
+    /// context: a session launched in `headless` mode has no pixels and this
+    /// fails — relaunch it in `hidden` mode.
+    #[tool]
+    async fn capture_frame(
+        &self,
+        Parameters(args): Parameters<SessionArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let url = resolve!(self.url(&args.session));
+        let response = resolve!(self
+            .http
+            .post(format!("{url}/capture"))
+            .send()
+            .await
+            .map_err(|error| format!("POST /capture on {} failed: {error}", args.session)));
+        let status = response.status();
+        let body = resolve!(response
+            .bytes()
+            .await
+            .map_err(|error| format!("reading the captured PNG failed: {error}")));
+        if status.as_u16() == 503 {
+            return tool_error(
+                "this runtime has no pixels to capture: it was started headless (--headless \
+creates no GL context). Relaunch the game with mode \"hidden\" to capture frames.",
+            );
+        }
+        if !status.is_success() {
+            return tool_error(format!(
+                "POST /capture → {status}: {}",
+                String::from_utf8_lossy(&body)
+            ));
+        }
+        Ok(CallToolResult::success(vec![ContentBlock::image(
+            base64::engine::general_purpose::STANDARD.encode(&body),
+            "image/png",
+        )]))
+    }
+
+    /// Inject one input event. `command` is the `POST /input` body verbatim,
+    /// tagged by `type`: `{"type":"key","key":"w","down":true}`,
+    /// `{"type":"mouse_move","x":10,"y":20}`, `{"type":"mouse_wheel","delta":1}`,
+    /// `{"type":"mouse_button","button":"left","down":true}`,
+    /// `{"type":"ui_event","slot":0,"kind":"Clicked"}` (also
+    /// `{"SliderChanged":0.5}` / `{"TextChanged":"hi"}`),
+    /// `{"type":"xr", "head":…, "left":…, "right":…}`, `{"type":"xr_clear"}`.
+    /// Keys, held buttons and XR samples are LEVEL state: they stay in force
+    /// across steps until released, which is how a paused session is scripted.
+    #[tool]
+    async fn send_input(
+        &self,
+        Parameters(args): Parameters<InputArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        self.proxy_post(&args.session, "/input", args.command.to_string())
+            .await
+    }
+
+    /// Pause: pin the clock to a constant time, so nothing advances until
+    /// `step` or `resume`. Window keyboard/mouse input is ignored while pinned,
+    /// but injected `send_input` still applies — this is how a driver gets
+    /// deterministic control. Defaults to pinning at the current `tts`.
+    #[tool]
+    async fn pause(
+        &self,
+        Parameters(args): Parameters<PauseArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let tts = match args.tts {
+            Some(tts) => tts,
+            None => resolve!(self.current_tts(&args.session).await),
+        };
+        self.proxy_post(
+            &args.session,
+            "/time",
+            serde_json::json!({ "type": "set", "tts": tts }).to_string(),
+        )
+        .await
+    }
+
+    /// Run exactly `frames` simulation steps of `dts` seconds each, WAIT for
+    /// them to land (polling until `pending_steps` is 0), then return the fresh
+    /// `/state`. Step one frame at a time when the game must see input or I/O
+    /// between steps — a batch runs up to 8 ticks per rendered frame, so it has
+    /// proportionally fewer input/network/render points.
+    #[tool]
+    async fn step(
+        &self,
+        Parameters(args): Parameters<StepArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let url = resolve!(self.url(&args.session));
+        let body = serde_json::json!({
+            "type": "advance",
+            "dts": args.dts.unwrap_or(0.016),
+            "frames": args.frames.unwrap_or(1),
+        });
+        resolve!(self.post(&url, "/time", body.to_string()).await);
+        let deadline = Instant::now() + STEP_TIMEOUT;
+        loop {
+            let state = resolve!(self.state(&url).await);
+            if state["pending_steps"].as_u64().unwrap_or(0) == 0 {
+                return ok_text(state.to_string());
+            }
+            if Instant::now() >= deadline {
+                return tool_error(format!(
+                    "the queued steps never drained ({} still pending after {}s)",
+                    state["pending_steps"],
+                    STEP_TIMEOUT.as_secs()
+                ));
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    }
+
+    /// Un-pin the clock: the game follows wall-clock time again, and window
+    /// input reaches it once more.
+    #[tool]
+    async fn resume(
+        &self,
+        Parameters(args): Parameters<SessionArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        self.proxy_post(
+            &args.session,
+            "/time",
+            serde_json::json!({ "type": "resume" }).to_string(),
+        )
+        .await
+    }
+
+    /// Restore the model and physics world to a recorded rendered frame, and
+    /// return the resulting `/state`. Rewind requires a pinned clock, so this
+    /// pins at the current time first. Frames outside the recorded window are
+    /// an error.
+    #[tool]
+    async fn rewind(
+        &self,
+        Parameters(args): Parameters<RewindArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let url = resolve!(self.url(&args.session));
+        let state = resolve!(self.state(&url).await);
+        let tts = state["tts"].as_f64().unwrap_or(0.0);
+        // The clock must be pinned before a rewind or the next wall-clock frame
+        // would immediately overwrite the restored model. `/state` does not
+        // report whether it already is, so this re-pins at the CURRENT time —
+        // a no-op for an already-paused session.
+        resolve!(
+            self.post(
+                &url,
+                "/time",
+                serde_json::json!({ "type": "set", "tts": tts }).to_string(),
+            )
+            .await
+        );
+        resolve!(
+            self.post(
+                &url,
+                "/rewind",
+                serde_json::json!({ "frame": args.frame }).to_string(),
+            )
+            .await
+        );
+        ok_text(resolve!(self.state(&url).await).to_string())
+    }
+
+    /// Hot-reload the entry module from new source, preserving the live model.
+    /// A source error is returned verbatim (the runtime keeps running the old
+    /// program). Use `reload_project` when sibling modules changed too.
+    #[tool]
+    async fn reload_source(
+        &self,
+        Parameters(args): Parameters<ReloadSourceArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        self.proxy_post(&args.session, "/reload-source", args.source)
+            .await
+    }
+
+    /// Hot-reload every sibling module at once from `[path, source]` pairs,
+    /// entry first, preserving the live model. A load error is returned
+    /// verbatim and the old program keeps running.
+    #[tool]
+    async fn reload_project(
+        &self,
+        Parameters(args): Parameters<ReloadProjectArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let files: Vec<Vec<String>> = args
+            .files
+            .into_iter()
+            .map(|(path, source)| vec![path, source])
+            .collect();
+        self.proxy_post(
+            &args.session,
+            "/reload-project",
+            serde_json::to_string(&files).expect("string pairs serialize"),
+        )
+        .await
+    }
+}
+
+impl FunctorMcp {
+    fn url(&self, session: &str) -> Result<String, String> {
+        self.sessions
+            .lock()
+            .expect("mcp registry poisoned")
+            .url(session)
+    }
+
+    async fn proxy_get(&self, session: &str, path: &str) -> Result<CallToolResult, ErrorData> {
+        let url = resolve!(self.url(session));
+        ok_text(resolve!(self.get(&url, path).await))
+    }
+
+    async fn proxy_post(
+        &self,
+        session: &str,
+        path: &str,
+        body: String,
+    ) -> Result<CallToolResult, ErrorData> {
+        let url = resolve!(self.url(session));
+        ok_text(resolve!(self.post(&url, path, body).await))
+    }
+
+    async fn get(&self, url: &str, path: &str) -> Result<String, String> {
+        let response = self
+            .http
+            .get(format!("{url}{path}"))
+            .send()
+            .await
+            .map_err(|error| format!("GET {path} on {url} failed: {error}"))?;
+        read_body(path, response).await
+    }
+
+    async fn post(&self, url: &str, path: &str, body: String) -> Result<String, String> {
+        let response = self
+            .http
+            .post(format!("{url}{path}"))
+            .body(body)
+            .send()
+            .await
+            .map_err(|error| format!("POST {path} on {url} failed: {error}"))?;
+        read_body(path, response).await
+    }
+
+    async fn state(&self, url: &str) -> Result<Value, String> {
+        let body = self.get(url, "/state").await?;
+        serde_json::from_str(&body)
+            .map_err(|error| format!("GET /state returned invalid JSON: {error}"))
+    }
+
+    async fn current_tts(&self, session: &str) -> Result<f64, String> {
+        let url = self.url(session)?;
+        Ok(self.state(&url).await?["tts"].as_f64().unwrap_or(0.0))
+    }
+
+    /// Fetch and validate the discovery document, so an `http://…` that answers
+    /// something else is rejected here rather than at the first real call.
+    async fn discover(&self, url: &str) -> Result<Value, String> {
+        let body = self.get(url, "/").await?;
+        let discovery: Value = serde_json::from_str(&body)
+            .map_err(|error| format!("{url}/ did not return JSON: {error}"))?;
+        if discovery["service"] != DEBUG_PROTOCOL_SERVICE {
+            return Err(format!(
+                "{url} is not a Functor debug runtime (its / reports {})",
+                discovery["service"]
+            ));
+        }
+        Ok(discovery)
+    }
+
+    /// Poll a freshly spawned runtime until its discovery endpoint answers,
+    /// failing fast if the child exits first.
+    async fn await_runtime(&self, url: &str, child: &mut Child) -> Result<Value, String> {
+        let deadline = Instant::now() + LAUNCH_TIMEOUT;
+        loop {
+            if let Ok(Some(status)) = child.try_wait() {
+                return Err(format!(
+                    "the runtime exited before serving {url} ({status})"
+                ));
+            }
+            if let Ok(discovery) = self.discover(url).await {
+                return Ok(discovery);
+            }
+            if Instant::now() >= deadline {
+                return Err(format!(
+                    "the runtime did not serve {url} within {}s",
+                    LAUNCH_TIMEOUT.as_secs()
+                ));
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+}
+
+#[tool_handler(
+    name = "functor",
+    instructions = "Drive Functor games over their debug runtime. Launch or attach to a game \
+(launch_game / connect_game), then observe it (get_state — read model_json — get_scene, \
+get_trace, capture_frame) and drive it (pause, send_input, step, resume, rewind, \
+reload_source). The deterministic loop is pause → send_input → step → get_state: while the \
+clock is pinned nothing advances on its own, and injected input is level state that holds \
+across steps."
+)]
+impl ServerHandler for FunctorMcp {}
+
+impl Default for FunctorMcp {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Read a response body, turning a non-2xx into a message that carries the
+/// runtime's own text — the 400s from `/input`, `/time` and the reload routes
+/// are teaching errors, so they must reach the caller verbatim.
+async fn read_body(path: &str, response: reqwest::Response) -> Result<String, String> {
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .map_err(|error| format!("reading the {path} response failed: {error}"))?;
+    if status.is_success() {
+        Ok(body)
+    } else {
+        Err(format!("{path} → {status}: {body}"))
+    }
+}
+
+/// Claim a free localhost port by binding and immediately releasing it. There
+/// is a race window before the runtime binds; on loopback with sequential
+/// launches it is not one worth a retry protocol.
+fn free_port() -> Result<u16, String> {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .map_err(|error| format!("could not find a free port: {error}"))?;
+    listener
+        .local_addr()
+        .map(|addr| addr.port())
+        .map_err(|error| format!("could not read the bound port: {error}"))
+}
+
+/// Accumulate a child's output into a bounded tail buffer, so a launch that
+/// never serves can still report why.
+fn drain_into<R>(mut stream: R, log: Arc<Mutex<Vec<u8>>>)
+where
+    R: AsyncReadExt + Unpin + Send + 'static,
+{
+    tokio::spawn(async move {
+        let mut chunk = [0u8; 4096];
+        while let Ok(read) = stream.read(&mut chunk).await {
+            if read == 0 {
+                break;
+            }
+            let mut buffer = log.lock().expect("mcp log poisoned");
+            buffer.extend_from_slice(&chunk[..read]);
+            if buffer.len() > LOG_TAIL_BYTES {
+                let excess = buffer.len() - LOG_TAIL_BYTES;
+                buffer.drain(..excess);
+            }
+        }
+    });
+}
+
+fn tail(log: &Arc<Mutex<Vec<u8>>>) -> String {
+    String::from_utf8_lossy(&log.lock().expect("mcp log poisoned")).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Registry;
+
+    #[test]
+    fn ids_are_short_sequential_and_resolve_to_their_url() {
+        let mut registry = Registry::default();
+        let first = registry.insert("http://127.0.0.1:1".into(), None);
+        let second = registry.insert("http://127.0.0.1:2".into(), None);
+
+        assert_eq!(first, "s1");
+        assert_eq!(second, "s2");
+        assert_eq!(registry.url("s2").unwrap(), "http://127.0.0.1:2");
+    }
+
+    #[test]
+    fn an_unknown_id_names_the_sessions_that_exist() {
+        let mut registry = Registry::default();
+        let empty = registry.url("s1").unwrap_err();
+        assert!(empty.contains("no sessions yet"), "{empty}");
+
+        registry.insert("http://127.0.0.1:1".into(), None);
+        registry.insert("http://127.0.0.1:2".into(), None);
+        let unknown = registry.url("s9").unwrap_err();
+        assert!(unknown.contains("s1, s2"), "{unknown}");
+    }
+
+    #[test]
+    fn removing_a_session_forgets_it_and_does_not_reuse_its_id() {
+        let mut registry = Registry::default();
+        registry.insert("http://127.0.0.1:1".into(), None);
+        let removed = registry.remove("s1").unwrap();
+
+        assert_eq!(removed.url, "http://127.0.0.1:1");
+        assert!(registry.url("s1").is_err());
+        assert_eq!(registry.insert("http://127.0.0.1:3".into(), None), "s2");
+        let Err(message) = registry.remove("s1") else {
+            panic!("a removed id must not resolve again");
+        };
+        assert!(message.contains("unknown session"), "{message}");
+    }
+}

--- a/cli/src/commands/mcp.rs
+++ b/cli/src/commands/mcp.rs
@@ -37,7 +37,7 @@ const STEP_STALL_TIMEOUT: Duration = Duration::from_secs(30);
 /// Per-request timeout for the (loopback or adb-forwarded) debug server.
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 /// Lowest debug-protocol version whose contract these tools actually keep
-/// (`pending_steps` on `/state`, `frames` on `/time advance`, `model_json`).
+/// (`pending_steps` on `/state`, `frames` on `/time advance`, `model`).
 const REQUIRED_PROTOCOL_VERSION: u64 = 4;
 /// Bytes of a launched child's stdout/stderr kept for failure reporting.
 const LOG_TAIL_BYTES: usize = 8 * 1024;
@@ -456,8 +456,9 @@ or \"headless\" (no GL, no capture)"
     }
 
     /// Runtime state JSON: `frame`, `tts`, `pending_steps`, viewports, the
-    /// sampled `input`, and the model both as `Debug` text (`model`) and as a
-    /// structured, parseable JSON view (`model_json`) — read `model_json`.
+    /// sampled `input`, and the game model — `model` is the structured,
+    /// parseable JSON view (the thing to read); `model_debug` is the
+    /// human-facing `Debug` text.
     #[tool]
     async fn get_state(
         &self,
@@ -772,15 +773,16 @@ impl FunctorMcp {
         // Below v4 the guarantees these tools advertise silently stop holding:
         // a pre-v3 runtime ignores a batched `frames` and reports no
         // `pending_steps` (so `step` would claim a 10-frame batch landed after
-        // running one), and a pre-v4 one never sends `model_json`. Refuse
+        // running one), and a pre-v4 one sends Debug text under `model`
+        // instead of structured JSON. Refuse
         // rather than mislead — this matters for a device APK, which versions
         // independently of the CLI.
         let version = discovery["protocol_version"].as_u64().unwrap_or(0);
         if version < REQUIRED_PROTOCOL_VERSION {
             return Err(format!(
                 "{url} speaks debug protocol v{version}, but these tools need \
-v{REQUIRED_PROTOCOL_VERSION} (batched steps report pending_steps, and /state carries \
-model_json). Rebuild that runtime from this version of Functor."
+v{REQUIRED_PROTOCOL_VERSION} (batched steps report pending_steps, and /state's model \
+is structured JSON). Rebuild that runtime from this version of Functor."
             ));
         }
         Ok(discovery)
@@ -813,7 +815,7 @@ model_json). Rebuild that runtime from this version of Functor."
 #[tool_handler(
     name = "functor",
     instructions = "Drive Functor games over their debug runtime. Launch or attach to a game \
-(launch_game / connect_game), then observe it (get_state — read model_json — get_scene, \
+(launch_game / connect_game), then observe it (get_state — read model — get_scene, \
 get_trace, capture_frame) and drive it (pause, send_input, step, resume, rewind, \
 reload_source). The deterministic loop is pause → send_input → step → get_state: while the \
 clock is pinned nothing advances on its own, and injected input is level state that holds \

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod docs;
+pub mod functor_lang_project;
 pub mod import;
 pub mod init;
 pub mod inspect;
-pub mod functor_lang_project;
+pub mod mcp;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -163,6 +163,12 @@ enum Command {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         runner_args: Vec<String>,
     },
+    /// Serve the debug runtime as MCP (Model Context Protocol) tools over
+    /// stdio, so a coding agent can launch, observe, and drive Functor games
+    /// through the standard interface (see `docs/mcp.md`). Register it with
+    /// `claude mcp add functor -- functor mcp`. Each game names its own
+    /// directory when it is launched, so the global `-d` flag is ignored.
+    Mcp,
     /// Inspect assets headlessly (no GPU/GL context).
     Inspect {
         #[command(subcommand)]
@@ -230,6 +236,14 @@ async fn main() -> tokio::io::Result<()> {
     if let Err(message) = validate_args(&args) {
         eprintln!("error: {message}");
         process::exit(2);
+    }
+
+    // `mcp` owns stdout: it speaks JSON-RPC there. It therefore dispatches
+    // BEFORE the output stream is initialized — a single event line (or a live
+    // region's ANSI) written to that stdout would corrupt the protocol. It also
+    // ignores `-d`, since each launched game names its own directory.
+    if matches!(args.command, Command::Mcp) {
+        return finish_inspect(commands::mcp::execute().await);
     }
 
     output::init(
@@ -368,6 +382,7 @@ async fn run(args: &Args) -> io::Result<()> {
             Command::Docs { .. }
             | Command::Init { .. }
             | Command::Inspect { .. }
+            | Command::Mcp
             | Command::Import => {
                 unreachable!("is_routed excludes")
             }
@@ -435,6 +450,8 @@ async fn run(args: &Args) -> io::Result<()> {
         )),
         // Handled earlier (before functor.json validation).
         Command::Inspect { .. } => unreachable!(),
+        // Handled earlier (before the output stream is initialized).
+        Command::Mcp => unreachable!(),
         // Handled earlier (right after functor.json validation).
         Command::Import => unreachable!(),
     }
@@ -454,7 +471,11 @@ fn take_entry_arg(runner_args: &[String]) -> io::Result<(Option<String>, Vec<Str
         } else if arg == "--entry" {
             match iter.next() {
                 Some(value) => entry = Some(value.clone()),
-                None => return Err(io::Error::other("--entry requires a value (--entry <name>)")),
+                None => {
+                    return Err(io::Error::other(
+                        "--entry requires a value (--entry <name>)",
+                    ))
+                }
             }
         } else {
             rest.push(arg.clone());
@@ -471,6 +492,7 @@ fn command_name(command: &Command) -> &'static str {
         Command::Test => "test",
         Command::Run { .. } => "run",
         Command::Develop { .. } => "develop",
+        Command::Mcp => "mcp",
         Command::Inspect { .. } => "inspect",
         Command::Import => "import",
         Command::Push { .. } => "push",

--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -424,11 +424,13 @@ session for simulating multiplayer games) lives in `tools/functor-sdk`. A client
 point at either `http://127.0.0.1:8077` (desktop) or the adb-forwarded
 `http://127.0.0.1:8123` (Quest) without changing API calls.
 
+An **MCP server** over the same endpoints ships as `functor mcp` — sessions,
+state, scene, capture, input, time, and rewind as standard tools for coding
+agents (docs/mcp.md).
+
 ## Future directions
 
 - **Multiplayer simulation.** Launch N runner instances, each on its own
   `--debug-port`, networked via `Sub.connect`/`Sub.listen`; pin all clocks and step
   them in lockstep, injecting input and observing state per client. This is the
   out-of-process counterpart to the in-process `functor-netsim` harness.
-- **An MCP server.** `functor mcp` will expose this surface (sessions, state,
-  scene, capture, input, time, rewind) as standard MCP tools for coding agents.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -85,6 +85,17 @@ Runtime errors come back as tool errors carrying the runtime's own message — a
 `/input` 400 explaining a misspelled field, a `/reload-source` 400 with the
 rendered load error, a `/time` 409 naming a `--fixed-time` pin.
 
+`launch_game` and `connect_game` both require **debug protocol v4 or newer**
+(`docs/debug-runtime.md`), and say so if the runtime is older. Below that, the
+guarantees above quietly stop holding: a pre-v3 runtime ignores a batched
+`frames` and reports no `pending_steps` (so `step` would call a ten-frame batch
+landed after one), and a pre-v4 one never sends `model_json`. This matters most
+for a device APK, which versions independently of the CLI — rebuild it from the
+same Functor version.
+
+Launched games are killed when the server stops, whether its client closes
+stdin or signals it (SIGTERM/Ctrl-C). Attached ones are always left running.
+
 ## `hidden` vs `headless`
 
 `launch_game`'s `mode` chooses which one:

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -53,7 +53,7 @@ URL plus, when the server launched it, the child process.
 
 | Tool | What it does |
 | --- | --- |
-| `get_state` | `frame`, `tts`, `pending_steps`, viewports, sampled `input`, and the model — read `model_json`, the structured view. |
+| `get_state` | `frame`, `tts`, `pending_steps`, viewports, sampled `input`, and the model — the structured JSON view (the default read; `model_debug` is the Debug text). |
 | `get_scene` | The camera, scene graph, and lights `draw` produced. Pure data, so it works headlessly. |
 | `get_trace` | The paused inspector trace: every entry point's binder and variable values for the last real frame. Pause first. |
 | `capture_frame` | A PNG of the next rendered frame, returned as an MCP image block. |
@@ -89,7 +89,8 @@ rendered load error, a `/time` 409 naming a `--fixed-time` pin.
 (`docs/debug-runtime.md`), and say so if the runtime is older. Below that, the
 guarantees above quietly stop holding: a pre-v3 runtime ignores a batched
 `frames` and reports no `pending_steps` (so `step` would call a ten-frame batch
-landed after one), and a pre-v4 one never sends `model_json`. This matters most
+landed after one), and a pre-v4 one sends Debug text under `model` instead of
+structured JSON. This matters most
 for a device APK, which versions independently of the CLI — rebuild it from the
 same Functor version.
 
@@ -119,12 +120,12 @@ pause      { "session": "s1" }                       // pin the clock where it i
 send_input { "session": "s1",
              "command": {"type":"ui_event","slot":0,"kind":"Clicked"} }
 step       { "session": "s1" }                       // one frame, waited for
-// → {"frame":9,"tts":0.13,"pending_steps":0,…,"model_json":{"count":1}}
+// → {"frame":9,"tts":0.13,"pending_steps":0,…,"model":{"count":1}}
 stop_game  { "session": "s1" }
 ```
 
 Nothing advanced between the click and the step, and `step` returned only once
-the step had actually run — so `model_json.count` is the click's effect, not a
+the step had actually run — so `model.count` is the click's effect, not a
 sample of a still-moving game.
 
 ## Connecting to a Quest

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,145 @@
+# `functor mcp` — MCP over the debug runtime
+
+`functor mcp` is an [MCP](https://modelcontextprotocol.io) server: it exposes the
+[debug runtime](debug-runtime.md) — launch a game, read its model, pause it,
+inject input, step the clock, capture a frame — as standard tools, over stdio.
+
+The capability is not new; the *interface* is. Any MCP-speaking agent can now
+drive a Functor game with no bespoke script, no HTTP plumbing, and no screen:
+`launch_game` → `pause` → `send_input` → `step` → `get_state`, reading the
+model back as structured JSON.
+
+It is a plain HTTP client of the runtimes and lives entirely in the CLI. The
+runtimes are unchanged.
+
+## Registering it
+
+With Claude Code:
+
+```sh
+claude mcp add functor -- functor mcp
+```
+
+For any other MCP client, the generic stdio-server config shape is:
+
+```jsonc
+{
+  "mcpServers": {
+    "functor": {
+      "command": "functor",       // or an absolute path to the binary
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+`functor mcp` speaks JSON-RPC on **stdout**, so it takes no `-d` and prints
+nothing else there — each game names its own directory when it is launched, and
+a launched runtime's own output is captured rather than inherited.
+
+## The tools
+
+**Sessions.** The server manages N concurrent games at once. A session is a base
+URL plus, when the server launched it, the child process.
+
+| Tool | What it does |
+| --- | --- |
+| `launch_game` | Spawn a game as a child on a free port and return its session id. `mode` is `hidden` (default) or `headless` — see below. |
+| `connect_game` | Attach to a runtime this server does **not** own (someone else's `--debug-port`, or an adb-forwarded Quest). |
+| `list_sessions` | Every session: id, url, owned/attached, and whether it currently answers. |
+| `stop_game` | Kill a launched game; merely forget an attached one. |
+
+**Observing.**
+
+| Tool | What it does |
+| --- | --- |
+| `get_state` | `frame`, `tts`, `pending_steps`, viewports, sampled `input`, and the model — read `model_json`, the structured view. |
+| `get_scene` | The camera, scene graph, and lights `draw` produced. Pure data, so it works headlessly. |
+| `get_trace` | The paused inspector trace: every entry point's binder and variable values for the last real frame. Pause first. |
+| `capture_frame` | A PNG of the next rendered frame, returned as an MCP image block. |
+
+**Driving.**
+
+| Tool | What it does |
+| --- | --- |
+| `pause` | Pin the clock (defaults to the current `tts`), so nothing advances on its own. |
+| `step` | Run `frames` steps of `dts` each, **wait for them to land**, and return the fresh state. |
+| `resume` | Follow wall-clock time again. |
+| `send_input` | Inject one `POST /input` command verbatim — key, mouse move/wheel/button, `ui_event`, or an `xr` sample. |
+| `rewind` | Restore model + physics to a recorded frame (it pins the clock first, as `/rewind` requires). |
+| `reload_source` / `reload_project` | Hot-reload the entry, or every sibling module, with the live model preserved. |
+
+Two semantics are worth internalizing, because they are what make the loop
+deterministic rather than racy:
+
+- **`step` waits.** `POST /time advance` only *queues* steps. `step` polls until
+  `pending_steps` is 0 before returning, so a caller can never read a
+  half-landed batch. A batch (`frames > 1`) runs up to 8 ticks per rendered
+  frame, so it has proportionally fewer input/network/render points — step one
+  at a time when the game must see input or I/O between steps.
+- **Input is level state.** A key, a held mouse button, and an injected XR sample
+  stay in force across steps until released or replaced. That is how a paused
+  session is scripted: press, step a few frames, release.
+
+Runtime errors come back as tool errors carrying the runtime's own message — a
+`/input` 400 explaining a misspelled field, a `/reload-source` 400 with the
+rendered load error, a `/time` 409 naming a `--fixed-time` pin.
+
+## `hidden` vs `headless`
+
+`launch_game`'s `mode` chooses which one:
+
+- **`hidden`** (default) creates a real GL context in a window that is never
+  shown and never takes focus. Rendering happens, so **`capture_frame` returns
+  pixels**. Needs a display/GPU.
+- **`headless`** creates no GL context at all — no display, no GPU, ideal for CI
+  or a remote box. `get_state`, `get_scene`, `send_input`, and `step` all work
+  (the game's `draw` is pure data), but there is nothing to read back:
+  **`capture_frame` fails** with an explanation. Audio is silent too, so
+  `Audio.playThen` completion messages are not delivered.
+
+## Driving a game deterministically
+
+```jsonc
+launch_game { "dir": "examples/counter", "mode": "headless" }
+// → {"session":"s1","url":"http://127.0.0.1:53127","port":53127,"owned":true,…}
+
+pause      { "session": "s1" }                       // pin the clock where it is
+send_input { "session": "s1",
+             "command": {"type":"ui_event","slot":0,"kind":"Clicked"} }
+step       { "session": "s1" }                       // one frame, waited for
+// → {"frame":9,"tts":0.13,"pending_steps":0,…,"model_json":{"count":1}}
+stop_game  { "session": "s1" }
+```
+
+Nothing advanced between the click and the step, and `step` returned only once
+the step had actually run — so `model_json.count` is the click's effect, not a
+sample of a still-moving game.
+
+## Connecting to a Quest
+
+The device runtime serves the same protocol on loopback port 8123. Forward it
+over USB, then attach:
+
+```sh
+adb forward tcp:8123 tcp:8123
+```
+
+```jsonc
+connect_game { "url": "http://127.0.0.1:8123" }
+```
+
+The session is **attached**, not owned: `stop_game` forgets it and leaves the
+headset running. Everything else is identical — `get_state`, `send_input`,
+`step`, `reload_project`. `capture_frame` returns the side-by-side PNG of the
+two raw eye buffers, and `/state.views` has `left` and `right` rather than
+`main`. Injected `xr` samples are rejected on device (Quest resamples live
+tracking every frame).
+
+## See also
+
+- [`docs/debug-runtime.md`](debug-runtime.md) — the HTTP surface these tools wrap,
+  with the exact request/response shapes.
+- `e2e/mcp-server.mjs` — the end-to-end proof, speaking raw JSON-RPC to the server.
+- `tools/functor-sdk` — the typed TypeScript SDK over the same endpoints, for
+  scripts rather than agents.

--- a/e2e/mcp-server.mjs
+++ b/e2e/mcp-server.mjs
@@ -68,6 +68,7 @@ class Rpc {
       const waiter = this.pending.get(message.id);
       if (waiter) {
         this.pending.delete(message.id);
+        clearTimeout(waiter.timer);
         message.error ? waiter.reject(new Error(JSON.stringify(message.error))) : waiter.resolve(message.result);
       }
     }
@@ -81,8 +82,11 @@ class Rpc {
     const id = this.nextId++;
     this.proc.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`);
     return new Promise((resolve, reject) => {
-      this.pending.set(id, { resolve, reject });
-      setTimeout(() => reject(new Error(`${method} timed out\nstderr:\n${this.stderr}`)), 60000);
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`${method} timed out\nstderr:\n${this.stderr}`));
+      }, 60000);
+      this.pending.set(id, { resolve, reject, timer });
     });
   }
 

--- a/e2e/mcp-server.mjs
+++ b/e2e/mcp-server.mjs
@@ -7,7 +7,7 @@
 //   1. initialize / notifications/initialized / tools/list, asserting the whole
 //      documented tool surface is advertised.
 //   2. launch_game on examples/counter in HEADLESS mode (no GL, so this runs
-//      anywhere CI does), and assert /state's structured `model_json` arrives.
+//      anywhere CI does), and assert /state's structured `model` arrives.
 //   3. pause, then step twice — asserting the frame advances and that `step`
 //      only returns once the queued steps have landed (pending_steps == 0).
 //   4. send_input: counter's model reacts to a UI click (its `update` handles
@@ -146,10 +146,10 @@ try {
   console.log("\n▸ the structured model view (protocol v4)");
   const state = await rpc.call("get_state", { session });
   check(
-    state.model_json !== null && typeof state.model_json === "object",
-    "get_state carries model_json as a structured object",
+    state.model !== null && typeof state.model === "object",
+    "get_state carries model as a structured object",
   );
-  check(state.model_json?.count === 0, `the counter starts at 0 (model_json.count = ${state.model_json?.count})`);
+  check(state.model?.count === 0, `the counter starts at 0 (model.count = ${state.model?.count})`);
 
   console.log("\n▸ pause + step is a deterministic clock");
   await rpc.call("pause", { session });
@@ -167,10 +167,10 @@ try {
   console.log("\n▸ injected input reaches the game");
   // counter's `update` handles Inc, delivered by clicking the button — slot 0,
   // the first interactive widget in its `ui` tree.
-  const before = (await rpc.call("get_state", { session })).model_json.count;
+  const before = (await rpc.call("get_state", { session })).model.count;
   await rpc.call("send_input", { session, command: { type: "ui_event", slot: 0, kind: "Clicked" } });
   const clicked = await rpc.call("step", { session });
-  check(clicked.model_json.count === before + 1, `a ui_event click incremented the model (${before} → ${clicked.model_json.count})`);
+  check(clicked.model.count === before + 1, `a ui_event click incremented the model (${before} → ${clicked.model.count})`);
 
   // A key event exercises the keyboard shape end to end. counter has no `input`
   // hook, so the assertion is that the runtime accepted and sampled it — not a

--- a/e2e/mcp-server.mjs
+++ b/e2e/mcp-server.mjs
@@ -1,0 +1,222 @@
+// `functor mcp` E2E: prove the MCP server really drives a game.
+//
+// This is the agent-verifiability proof for the MCP surface (docs/mcp.md): it
+// speaks raw JSON-RPC 2.0 over the server's stdio — no MCP client library — so
+// what is asserted is exactly what a coding agent's client would see.
+//
+//   1. initialize / notifications/initialized / tools/list, asserting the whole
+//      documented tool surface is advertised.
+//   2. launch_game on examples/counter in HEADLESS mode (no GL, so this runs
+//      anywhere CI does), and assert /state's structured `model_json` arrives.
+//   3. pause, then step twice — asserting the frame advances and that `step`
+//      only returns once the queued steps have landed (pending_steps == 0).
+//   4. send_input: counter's model reacts to a UI click (its `update` handles
+//      Inc), so a `ui_event` on slot 0 must increment `count` after a step.
+//      A `key` event is also injected to exercise that shape end to end.
+//   5. stop_game, then a clean shutdown of the server itself.
+//
+// Run manually (needs the CLI built; the wasm bundle is not required):
+//
+//   cargo build -p functor-cli --no-default-features
+//   node e2e/mcp-server.mjs
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const BIN = `${ROOT}target/debug/functor`;
+
+/** Every tool the server must advertise (docs/mcp.md). */
+const EXPECTED_TOOLS = [
+  "launch_game",
+  "connect_game",
+  "list_sessions",
+  "stop_game",
+  "get_state",
+  "get_scene",
+  "get_trace",
+  "capture_frame",
+  "send_input",
+  "pause",
+  "step",
+  "resume",
+  "rewind",
+  "reload_source",
+  "reload_project",
+];
+
+/** A line-delimited JSON-RPC client over a child's stdio. */
+class Rpc {
+  constructor(proc) {
+    this.proc = proc;
+    this.pending = new Map();
+    this.nextId = 1;
+    this.buffer = "";
+    this.stderr = "";
+    proc.stdout.setEncoding("utf8");
+    proc.stdout.on("data", (chunk) => this.#onData(chunk));
+    proc.stderr.on("data", (chunk) => (this.stderr += chunk));
+  }
+
+  #onData(chunk) {
+    this.buffer += chunk;
+    let index;
+    while ((index = this.buffer.indexOf("\n")) >= 0) {
+      const line = this.buffer.slice(0, index).trim();
+      this.buffer = this.buffer.slice(index + 1);
+      if (!line) continue;
+      const message = JSON.parse(line);
+      const waiter = this.pending.get(message.id);
+      if (waiter) {
+        this.pending.delete(message.id);
+        message.error ? waiter.reject(new Error(JSON.stringify(message.error))) : waiter.resolve(message.result);
+      }
+    }
+  }
+
+  notify(method, params) {
+    this.proc.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", method, params })}\n`);
+  }
+
+  request(method, params) {
+    const id = this.nextId++;
+    this.proc.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`);
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      setTimeout(() => reject(new Error(`${method} timed out\nstderr:\n${this.stderr}`)), 60000);
+    });
+  }
+
+  /** Call a tool and return its single text content block, parsed if it is JSON. */
+  async call(name, args = {}) {
+    const result = await this.request("tools/call", { name, arguments: args });
+    const text = result.content.map((block) => block.text ?? "").join("");
+    if (result.isError) throw new Error(`${name} failed: ${text}`);
+    try {
+      return JSON.parse(text);
+    } catch {
+      return text;
+    }
+  }
+}
+
+const failures = [];
+const check = (ok, what) => {
+  console.log(`  ${ok ? "✓" : "✗"} ${what}`);
+  if (!ok) failures.push(what);
+};
+
+const proc = spawn(BIN, ["mcp"], { cwd: ROOT, stdio: ["pipe", "pipe", "pipe"] });
+const rpc = new Rpc(proc);
+let session;
+
+try {
+  console.log("▸ the MCP handshake");
+  const initialized = await rpc.request("initialize", {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: "functor-e2e", version: "0" },
+  });
+  rpc.notify("notifications/initialized", {});
+  check(typeof initialized.protocolVersion === "string", `the server negotiated ${initialized.protocolVersion}`);
+  check(initialized.capabilities?.tools !== undefined, "the server advertises the tools capability");
+
+  const { tools } = await rpc.request("tools/list", {});
+  const names = tools.map((tool) => tool.name).sort();
+  const missing = EXPECTED_TOOLS.filter((name) => !names.includes(name));
+  check(missing.length === 0, `tools/list advertises all ${EXPECTED_TOOLS.length} tools${missing.length ? ` (missing ${missing})` : ""}`);
+  check(
+    tools.every((tool) => (tool.description ?? "").length > 20),
+    "every tool carries a real description (the agent-facing docs)",
+  );
+
+  console.log("\n▸ launching a game headlessly");
+  const launched = await rpc.call("launch_game", { dir: "examples/counter", mode: "headless" });
+  session = launched.session;
+  check(/^s\d+$/.test(session), `launch_game returned a session id (${session})`);
+  check(launched.discovery?.service === "functor debug runtime", "the child answered the debug-runtime discovery endpoint");
+  check(launched.owned === true, "the session is owned (this server spawned it)");
+
+  const listed = await rpc.call("list_sessions");
+  check(listed.sessions.length === 1 && listed.sessions[0].alive === true, "list_sessions reports it alive");
+
+  console.log("\n▸ the structured model view (protocol v4)");
+  const state = await rpc.call("get_state", { session });
+  check(
+    state.model_json !== null && typeof state.model_json === "object",
+    "get_state carries model_json as a structured object",
+  );
+  check(state.model_json?.count === 0, `the counter starts at 0 (model_json.count = ${state.model_json?.count})`);
+
+  console.log("\n▸ pause + step is a deterministic clock");
+  await rpc.call("pause", { session });
+  const paused = await rpc.call("get_state", { session });
+  const first = await rpc.call("step", { session });
+  const second = await rpc.call("step", { session });
+  check(first.frame > paused.frame, `the first step advanced the frame (${paused.frame} → ${first.frame})`);
+  check(second.frame > first.frame, `the second step advanced it again (→ ${second.frame})`);
+  check(second.pending_steps === 0, "step returns only once its queued steps have landed");
+  check(
+    Math.abs(second.tts - first.tts - 0.016) < 1e-4,
+    `each step advanced time by its dts (tts ${first.tts.toFixed(3)} → ${second.tts.toFixed(3)})`,
+  );
+
+  console.log("\n▸ injected input reaches the game");
+  // counter's `update` handles Inc, delivered by clicking the button — slot 0,
+  // the first interactive widget in its `ui` tree.
+  const before = (await rpc.call("get_state", { session })).model_json.count;
+  await rpc.call("send_input", { session, command: { type: "ui_event", slot: 0, kind: "Clicked" } });
+  const clicked = await rpc.call("step", { session });
+  check(clicked.model_json.count === before + 1, `a ui_event click incremented the model (${before} → ${clicked.model_json.count})`);
+
+  // A key event exercises the keyboard shape end to end. counter has no `input`
+  // hook, so the assertion is that the runtime accepted and sampled it — not a
+  // model change it cannot make.
+  await rpc.call("send_input", { session, command: { type: "key", key: "w", down: true } });
+  const held = await rpc.call("step", { session });
+  check(held.input.held_keys.includes("W"), `an injected key is held level state (held_keys = ${JSON.stringify(held.input.held_keys)})`);
+
+  console.log("\n▸ errors are teaching errors, not silence");
+  let capture = null;
+  try {
+    await rpc.call("capture_frame", { session });
+  } catch (error) {
+    capture = error.message;
+  }
+  check(capture !== null && /headless/.test(capture), "capture_frame on a headless session explains why there are no pixels");
+
+  let unknown = null;
+  try {
+    await rpc.call("get_state", { session: "s99" });
+  } catch (error) {
+    unknown = error.message;
+  }
+  check(unknown !== null && unknown.includes(session), "an unknown session id names the sessions that do exist");
+
+  console.log("\n▸ shutdown");
+  const stopped = await rpc.call("stop_game", { session });
+  session = null;
+  check(/killed/.test(stopped), "stop_game killed the launched runtime");
+  const empty = await rpc.call("list_sessions");
+  check(empty.sessions.length === 0, "the registry is empty again");
+} finally {
+  if (session) {
+    try {
+      await rpc.call("stop_game", { session });
+    } catch {
+      // best effort
+    }
+  }
+  proc.stdin.end();
+  const exit = await new Promise((resolve) => {
+    proc.on("exit", resolve);
+    setTimeout(() => resolve("timeout"), 5000);
+  });
+  check(exit === 0, `the server exited cleanly on stdin close (${exit})`);
+}
+
+if (failures.length) {
+  console.error(`\n✗ mcp-server failed: ${failures.join(", ")}`);
+  if (rpc.stderr) console.error(`\nserver stderr:\n${rpc.stderr}`);
+  process.exit(1);
+}
+console.log("\n✓ mcp-server passed");

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test:ide-page": "node e2e/ide-page.mjs",
     "test:runtime-target": "node e2e/runtime-target.mjs",
     "test:xr-injection": "cargo build -p functor-cli --no-default-features && node e2e/xr-pose-injection.mjs",
+    "test:mcp": "cargo build -p functor-cli --no-default-features && node e2e/mcp-server.mjs",
     "demo:time-travel": "node site/demos/time-travel.mjs",
     "demo:instant-feedback": "node site/demos/instant-feedback.mjs",
     "demo:batteries-included": "node site/demos/batteries-included.mjs",


### PR DESCRIPTION
Stacked on #528 (base `structured-model-json`).

## What & why

Competitive-analysis item 3 — *an agent-drivable surface, via the standard interface*. The
[debug runtime](https://github.com/tommy-xr/functor/blob/main/docs/debug-runtime.md) already lets an external driver observe and control a running
game over localhost HTTP; what was missing was the interface coding agents already speak.

`functor mcp` is an MCP server over that surface, over stdio. Any MCP client can now
`launch_game → pause → send_input → step → get_state` and read the model back as
structured JSON (#528's `model`) — no bespoke script, no HTTP plumbing, no screen.

The capability is not new; the interface is. It lives **entirely in the CLI**
(`cli/src/commands/mcp.rs`) — the runtimes are an HTTP dependency, not a participant.
Built on the official Rust SDK (`rmcp` 2.2.0, server + stdio transport, `#[tool_router]`).

Register it with:

```sh
claude mcp add functor -- functor mcp
```

## The tool surface

An **N-session registry** from the start: a session is a base URL plus, when this server
launched it, the child process.

| | |
| --- | --- |
| `launch_game` | spawn `current_exe()` as `functor -d <dir> run native --debug-port <free> --hidden\|--headless`; poll discovery until it answers |
| `connect_game` | attach to a runtime it does **not** own (an adb-forwarded Quest) |
| `list_sessions` / `stop_game` | bookkeeping; `stop_game` kills a launched game, only forgets an attached one |
| `get_state` / `get_scene` / `get_trace` | proxy the GETs; `get_state` carries `model` |
| `capture_frame` | `POST /capture` as an MCP **image block** (base64 PNG) |
| `send_input` | the `POST /input` body verbatim — key, mouse, `ui_event`, `xr` |
| `pause` / `step` / `resume` / `rewind` | clock control |
| `reload_source` / `reload_project` | hot-reload with the model preserved |

Two contracts the tool descriptions teach explicitly, because they are what makes the loop
deterministic rather than racy:

- **`step` waits.** `/time advance` only *queues*; `step` polls until `pending_steps` is 0,
  so a caller can never read a half-landed batch.
- **`rewind` pins first**, as the docs require — `/state` doesn't report pinned-ness, so it
  re-pins at the *current* tts (a no-op for an already-paused session).

Runtime 400s/409s come back as tool errors **verbatim** — they are the teaching messages.
Unknown session ids name the sessions that do exist. `mcp` dispatches before the CLI's
output stream is initialized, since it owns stdout for JSON-RPC.

Docs: new `docs/mcp.md` (registration, tool list, hidden-vs-headless, the Quest recipe, a
worked deterministic example); `docs/debug-runtime.md`'s MCP "future direction" now points
at the real thing.

## Verification

- `cargo build -p functor-cli --no-default-features` — clean.
- `cargo test -p functor-cli --no-default-features` — 33 passed (registry bookkeeping:
  id allocation, unknown-id messages, port reservation lifetime).
- `e2e/mcp-server.mjs` (`npm run test:mcp`) — spawns `functor mcp`, speaks raw JSON-RPC 2.0
  over stdio (no client library), drives `examples/counter` **headless** so CI needs no GL:

```
▸ the MCP handshake
  ✓ the server negotiated 2025-06-18
  ✓ the server advertises the tools capability
  ✓ tools/list advertises all 15 tools
  ✓ every tool carries a real description (the agent-facing docs)

▸ launching a game headlessly
  ✓ launch_game returned a session id (s1)
  ✓ the child answered the debug-runtime discovery endpoint
  ✓ the session is owned (this server spawned it)
  ✓ list_sessions reports it alive

▸ the structured model view (protocol v4)
  ✓ get_state carries model as a structured object
  ✓ the counter starts at 0 (model.count = 0)

▸ pause + step is a deterministic clock
  ✓ the first step advanced the frame (8 → 9)
  ✓ the second step advanced it again (→ 10)
  ✓ step returns only once its queued steps have landed
  ✓ each step advanced time by its dts (tts 0.116 → 0.132)

▸ injected input reaches the game
  ✓ a ui_event click incremented the model (0 → 1)
  ✓ an injected key is held level state (held_keys = ["W"])

▸ errors are teaching errors, not silence
  ✓ capture_frame on a headless session explains why there are no pixels
  ✓ an unknown session id names the sessions that do exist

▸ shutdown
  ✓ stop_game killed the launched runtime
  ✓ the registry is empty again
  ✓ the server exited cleanly on stdin close (0)

✓ mcp-server passed
```

- SIGTERM cleanup checked by hand: launch a game, `SIGTERM` the server, confirm the child's
  port stops answering.

## Review dispositions (`/xreview`: Claude subagent + Codex CLI)

Fixed — **[AGREED]** by both engines:

- **protocol version unchecked** — `discover` now requires v4. Below it the advertised
  guarantees quietly stop holding (pre-v3 ignores batched `frames` and reports no
  `pending_steps`, so `step` would call a ten-frame batch landed after one; pre-v4 sends no
  `model`). Matters for a device APK, which versions independently of the CLI.
- **free-port TOCTOU** — ports are reserved in the registry for the session's lifetime, so
  two overlapping `launch_game` calls can't be handed the same one.
- **orphaned games on signal** — shutdown is now reached from SIGTERM/Ctrl-C as well as a
  closed stdin.

Fixed — single-engine:

- `capture_frame` rewrote *every* 503 as "you launched it headless", so a dozing Quest was
  told to relaunch a process this server doesn't own. It now passes the runtime's own text
  through and only appends the hint.
- `step`'s 30s deadline is now a **stall** timeout — a legitimate 100k-step batch takes
  minutes to drain; only a queue that stops moving is a failure.
- a failed launch awaits the child's output drains before reading the tail, so the bind
  error / typecheck diagnostic is actually in the message (it raced before).
- `tts` is read strictly — a missing one no longer silently pins the clock (or a rewind) to
  time zero.
- the e2e's per-request timers are cleared on response.

Accepted, with reasons:

- **No per-session lock on clock tools** (Codex, High). A concurrent `pause`/`resume` during
  a `step` could clear the queue and make `step` see 0. An MCP client issues tool calls
  sequentially within a turn, and a lock wouldn't help across *two* clients anyway; the
  complexity isn't warranted for the failure mode.
- **`step` returns the whole `/state`** including the `model` Debug text alongside
  `model` (token cost). Returning the fresh state is the specified contract, and
  splitting it would cost a round trip per step.
- **`connect_game` accepts non-loopback URLs.** Deliberate: `--debug-bind 0.0.0.0` remote
  develop is a supported workflow. `discover`'s `service` check still gates everything.

Both engines independently confirmed the areas most at risk: no `std::sync::Mutex` guard is
held across an `.await`; stdout ownership is clean; and the `/time` → `pending_steps`
sequence is synchronous end-to-end, so the first poll can't see a stale zero.

## Follow-up

PR 3 (stacked on this) adds an `api_reference` search tool over `functor docs --format json`.


> **Naming** (2026-07-27): the structured view originally landed as a separate `model_json` field; before shipping v4 it was renamed so `model` IS the structured JSON (the default read) and the Debug text is `model_debug`. Tool descriptions, docs, and the e2e were updated in `refactor(cli): mcp reads the renamed structured model field`.
