### PR TITLE
feat(cli): api_reference MCP tool over the embedded prelude docs

### DIFF
--- a/cli/src/commands/functor_lang_project.rs
+++ b/cli/src/commands/functor_lang_project.rs
@@ -65,9 +65,9 @@ pub fn detect(working_directory: &str) -> Option<FunctorLangConfig> {
     }
     let entries = match (json.get("entry"), json.get("entries")) {
         (Some(_), Some(_)) => FunctorLangEntries::Conflicting,
-        (None, Some(serde_json::Value::Object(map))) => FunctorLangEntries::Named(
-            map.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
-        ),
+        (None, Some(serde_json::Value::Object(map))) => {
+            FunctorLangEntries::Named(map.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+        }
         // A non-object `entries` is shaped wrong; carry that so selection
         // reports it instead of silently running the default entry.
         (None, Some(_)) => FunctorLangEntries::Malformed,
@@ -150,10 +150,9 @@ name → .fun path (e.g. {\"client\": \"client.fun\", \"server\": \"server.fun\"
     #[cfg(test)]
     fn all(&self) -> Result<Vec<FunctorLangProject>, Error> {
         match &self.entries {
-            FunctorLangEntries::Named(map) => map
-                .iter()
-                .map(|(k, _)| self.select(Some(k)))
-                .collect(),
+            FunctorLangEntries::Named(map) => {
+                map.iter().map(|(k, _)| self.select(Some(k))).collect()
+            }
             _ => self.select(None).map(|p| vec![p]),
         }
     }
@@ -320,10 +319,7 @@ impl FunctorLangProject {
                         .ok()
                         .and_then(|src| nth_line(&src, e.line)),
                 });
-                return Err(Error::other(format!(
-                    "cannot run the {} tests",
-                    self.entry
-                )));
+                return Err(Error::other(format!("cannot run the {} tests", self.entry)));
             }
         };
 
@@ -784,7 +780,8 @@ relative path inside it (got {})",
                 });
             }
 
-            let wasm_server_start = WasmDevServer::start_functor_lang(working_directory, &self.entry);
+            let wasm_server_start =
+                WasmDevServer::start_functor_lang(working_directory, &self.entry);
             if no_open {
                 emit(Event::Info {
                     message: "--no-open: skipping browser launch".to_string(),
@@ -911,7 +908,11 @@ headset over USB and accept its debugging prompt"
 /// require it up front with the install pointer, instead of a connection
 /// error after launch.
 async fn adb_require_runtime(serial: &str) -> Result<(), Error> {
-    let out = adb_output(Some(serial), &["shell", "pm", "list", "packages", VR_PACKAGE]).await?;
+    let out = adb_output(
+        Some(serial),
+        &["shell", "pm", "list", "packages", VR_PACKAGE],
+    )
+    .await?;
     let installed = out
         .lines()
         .any(|line| line.trim() == format!("package:{VR_PACKAGE}"));
@@ -934,10 +935,12 @@ fn spawn_logcat(serial: &str) {
     tokio::spawn(async move {
         use tokio::io::AsyncBufReadExt;
         let mut cmd = tokio::process::Command::new("adb");
-        cmd.args(["-s", &serial, "logcat", "-T", "1", "-v", "brief", "-s", "functor"])
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::null())
-            .kill_on_drop(true);
+        cmd.args([
+            "-s", &serial, "logcat", "-T", "1", "-v", "brief", "-s", "functor",
+        ])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .kill_on_drop(true);
         let Ok(mut child) = cmd.spawn() else {
             emit(Event::Warning {
                 message: "cannot stream the headset log (adb logcat failed to start)".to_string(),
@@ -1263,7 +1266,10 @@ mod tests {
         let config = named(&[("server", "server.fun"), ("client", "client.fun")]);
         assert_eq!(config.select(None).unwrap().entry, "client.fun");
         assert_eq!(
-            named(&[("server", "server.fun")]).select(None).unwrap().entry,
+            named(&[("server", "server.fun")])
+                .select(None)
+                .unwrap()
+                .entry,
             "server.fun"
         );
     }
@@ -1292,7 +1298,10 @@ mod tests {
             entries: FunctorLangEntries::Conflicting,
         };
         let err = config.select(None).unwrap_err();
-        assert!(err.to_string().contains("both `entry` and `entries`"), "{err}");
+        assert!(
+            err.to_string().contains("both `entry` and `entries`"),
+            "{err}"
+        );
     }
 
     #[test]
@@ -1348,8 +1357,9 @@ mod tests {
     /// example now fails `cargo test` instead of waiting for a manual sweep.
     #[test]
     fn every_shipped_example_typechecks() {
-        let examples: std::path::PathBuf =
-            [env!("CARGO_MANIFEST_DIR"), "..", "examples"].iter().collect();
+        let examples: std::path::PathBuf = [env!("CARGO_MANIFEST_DIR"), "..", "examples"]
+            .iter()
+            .collect();
         let mut dirs: Vec<std::path::PathBuf> = std::fs::read_dir(&examples)
             .expect("examples directory")
             .filter_map(|entry| entry.ok().map(|e| e.path()))
@@ -1365,7 +1375,11 @@ examples move?",
 
         let mut failures = Vec::new();
         for dir in &dirs {
-            let name = dir.file_name().unwrap_or_default().to_string_lossy().into_owned();
+            let name = dir
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .into_owned();
             let dir_str = dir.to_string_lossy().into_owned();
             let Some(config) = super::detect(&dir_str) else {
                 failures.push(format!("{name}: functor.json did not parse as a project"));

--- a/cli/src/commands/import.rs
+++ b/cli/src/commands/import.rs
@@ -290,7 +290,9 @@ fn execute_inner(dir: &Path, strict_remote: bool) -> io::Result<bool> {
     let mut input = ManifestInput::default();
     input.files = scanned.names();
     for path in &scanned.models {
-        let Some(file) = file_name(path) else { continue };
+        let Some(file) = file_name(path) else {
+            continue;
+        };
         let bytes = fs::read(path)?;
         let clips = match inspect_model(bytes, None, None) {
             Ok(report) => report
@@ -303,7 +305,9 @@ fn execute_inner(dir: &Path, strict_remote: bool) -> io::Result<bool> {
             // is real even when the clips are unknowable. Warn + no clips.
             Err(e) => {
                 emit(Event::Warning {
-                    message: format!("{file}: cannot inspect for clips ({e}) — importing without clip constants"),
+                    message: format!(
+                        "{file}: cannot inspect for clips ({e}) — importing without clip constants"
+                    ),
                 });
                 Vec::new()
             }
@@ -322,7 +326,9 @@ fn execute_inner(dir: &Path, strict_remote: bool) -> io::Result<bool> {
     // sidecar next to a same-named local file is its (future) config seat.
     let local_stems = scanned.local_stems();
     for path in &scanned.sidecars {
-        let Some(file) = file_name(path) else { continue };
+        let Some(file) = file_name(path) else {
+            continue;
+        };
         let name = file
             .strip_suffix(SIDECAR_SUFFIX)
             .expect("scan collected by suffix")
@@ -378,11 +384,7 @@ declares nothing"
                 // Auto-reimport keeps the download short: an unreachable
                 // host must not stall every `develop` launch. Explicit
                 // import affords the desktop fetcher's 300s for big models.
-                let timeout = std::time::Duration::from_secs(if strict_remote {
-                    30
-                } else {
-                    300
-                });
+                let timeout = std::time::Duration::from_secs(if strict_remote { 30 } else { 300 });
                 // The validator guards the disk cache for extensionless
                 // urls (verify_magic can only reject HTML there): a body
                 // inspect_model can't read is an error, never cached.
@@ -619,7 +621,9 @@ fn remove_stale(dir: &Path) -> io::Result<()> {
 /// The file's basename as a String (`None` for non-UTF-8 names, which are
 /// skipped — a manifest constant needs a printable path).
 fn file_name(path: &Path) -> Option<String> {
-    path.file_name().and_then(|s| s.to_str()).map(str::to_string)
+    path.file_name()
+        .and_then(|s| s.to_str())
+        .map(str::to_string)
 }
 
 #[cfg(test)]
@@ -647,12 +651,15 @@ mod tests {
         let (decl, warnings) =
             parse_sidecar(r#"{ "url": "https://cdn.example.com/shark.glb" }"#).unwrap();
         assert!(warnings.is_empty());
-        assert_eq!(decl.url.as_deref(), Some("https://cdn.example.com/shark.glb"));
+        assert_eq!(
+            decl.url.as_deref(),
+            Some("https://cdn.example.com/shark.glb")
+        );
         assert!(decl.kind.is_none());
 
         // Explicit kind.
-        let (decl, _) = parse_sidecar(r#"{ "kind": "sound", "url": "https://x/api/boom" }"#)
-            .unwrap();
+        let (decl, _) =
+            parse_sidecar(r#"{ "kind": "sound", "url": "https://x/api/boom" }"#).unwrap();
         assert!(matches!(decl.kind, Some(Kind::Sound)));
 
         // Unknown keys warn (a typo'd "ur" must not be silent).
@@ -680,9 +687,11 @@ mod tests {
 
         // An explicit kind contradicting a recognized url extension is an
         // error; agreeing or unrecognized-extension cases pass.
-        assert!(parse_sidecar(r#"{ "kind": "model", "url": "https://x/wood.png" }"#)
-            .unwrap_err()
-            .contains("extension"));
+        assert!(
+            parse_sidecar(r#"{ "kind": "model", "url": "https://x/wood.png" }"#)
+                .unwrap_err()
+                .contains("extension")
+        );
         assert!(parse_sidecar(r#"{ "kind": "texture", "url": "https://x/wood.png" }"#).is_ok());
         assert!(parse_sidecar(r#"{ "kind": "model", "url": "https://x/api/asset/9" }"#).is_ok());
     }

--- a/cli/src/commands/mcp.rs
+++ b/cli/src/commands/mcp.rs
@@ -293,11 +293,11 @@ impl FunctorMcp {
     }
 
     /// Search the engine API reference: the `.funi` prelude embedded in this
-    /// binary — every module, signature and doc comment `functor docs` renders.
-    /// `query` matches case-insensitively against item names, qualified paths
-    /// (`Scene.cube`), signatures and doc text; `module` narrows to one prelude
-    /// module, and browses all of its items when `query` is omitted. This tool
-    /// needs no session — it answers before any game is launched.
+    /// binary — the same reference `functor docs` renders. `query` matches
+    /// case-insensitively against item names, qualified paths (`Scene.cube`),
+    /// signatures and doc text, best matches first; `module` narrows to one
+    /// prelude module, and lists all of its items when `query` is omitted. This
+    /// tool needs no session — it answers before any game is launched.
     #[tool]
     async fn api_reference(
         &self,
@@ -308,15 +308,18 @@ impl FunctorMcp {
         let hits = resolve!(search_api(reference, query, args.module.as_deref()));
         if hits.is_empty() {
             return tool_error(format!(
-                "no API items match {query:?}{}. The prelude modules are {}.",
+                "no API items match {query:?}{}. {}",
                 match args.module.as_deref() {
                     Some(module) => format!(" in module {module:?}"),
                     None => String::new(),
                 },
-                module_names(reference).join(", ")
+                modules_hint(reference)
             ));
         }
-        ok_text(render_api_hits(&hits))
+        // A whole-module listing is bounded by the module itself, so browsing
+        // is never truncated — only an open search is.
+        let limit = (!query.trim().is_empty()).then_some(MAX_API_RESULTS);
+        ok_text(render_api_hits(&hits, limit))
     }
 
     /// Start a game as a child process with its debug server on a free port,
@@ -751,7 +754,9 @@ impl FunctorMcp {
         self.docs
             .get_or_init(|| {
                 functor_docgen::generate()
-                    .map_err(|error| format!("could not read the embedded API reference: {error}"))
+                    .map_err(|error| {
+                        format!("could not generate the embedded API reference: {error}")
+                    })
             })
             .as_ref()
             .map_err(String::clone)
@@ -890,16 +895,22 @@ impl Default for FunctorMcp {
 #[derive(Debug)]
 struct ApiHit<'a> {
     item: &'a ApiItem,
-    /// 0 = the item's own name, 1 = its path or signature, 2 = its prose.
+    /// 0 = the item's own name, 1 = its qualified path, 2 = its signature,
+    /// 3 = its prose.
     rank: u8,
 }
 
-fn module_names(reference: &ApiReference) -> Vec<&str> {
-    reference
-        .modules
-        .iter()
-        .map(|module| module.name.as_str())
-        .collect()
+/// The orienting hint every API teaching error ends with.
+fn modules_hint(reference: &ApiReference) -> String {
+    format!(
+        "The prelude modules are {}.",
+        reference
+            .modules
+            .iter()
+            .map(|module| module.name.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
 }
 
 /// Rank an item against an already-lowercased needle, or `None` if it misses.
@@ -907,15 +918,16 @@ fn rank_api_item(needle: &str, item: &ApiItem) -> Option<u8> {
     if item.name.eq_ignore_ascii_case(needle) || item.qualified_name.eq_ignore_ascii_case(needle) {
         return Some(0);
     }
-    if item.qualified_name.to_lowercase().contains(needle)
-        || item.declaration.to_lowercase().contains(needle)
-    {
+    if item.qualified_name.to_lowercase().contains(needle) {
         return Some(1);
+    }
+    if item.declaration.to_lowercase().contains(needle) {
+        return Some(2);
     }
     item.docs
         .as_deref()
         .is_some_and(|docs| docs.to_lowercase().contains(needle))
-        .then_some(2)
+        .then_some(3)
 }
 
 /// Search the reference, best matches first. `Err` is a teaching message: an
@@ -925,29 +937,22 @@ fn search_api<'a>(
     query: &str,
     module: Option<&str>,
 ) -> Result<Vec<ApiHit<'a>>, String> {
-    let wanted = module.map(str::trim).filter(|name| !name.is_empty());
+    let wanted = module.map(str::trim);
     let modules = match wanted {
-        Some(wanted) => {
-            let matched: Vec<_> = reference
-                .modules
-                .iter()
-                .filter(|module| module.name.eq_ignore_ascii_case(wanted))
-                .collect();
-            if matched.is_empty() {
-                return Err(format!(
-                    "unknown module {wanted:?}: the prelude modules are {}",
-                    module_names(reference).join(", ")
-                ));
-            }
-            matched
-        }
+        // A blank module is a client bug, not "no filter": answering it from
+        // the whole prelude would silently widen the scope that was asked for.
+        Some(wanted) => vec![reference
+            .modules
+            .iter()
+            .find(|module| module.name.eq_ignore_ascii_case(wanted))
+            .ok_or_else(|| format!("unknown module {wanted:?}. {}", modules_hint(reference)))?],
         None => reference.modules.iter().collect(),
     };
     let needle = query.trim().to_lowercase();
     if needle.is_empty() && wanted.is_none() {
         return Err(format!(
-            "give a query to search for, or a module to browse. The prelude modules are {}",
-            module_names(reference).join(", ")
+            "give a query to search for, or a module to list. {}",
+            modules_hint(reference)
         ));
     }
     let mut hits: Vec<ApiHit> = modules
@@ -968,28 +973,26 @@ fn search_api<'a>(
     Ok(hits)
 }
 
-/// Render matches as compact text: qualified name, signature, then the prose.
-fn render_api_hits(hits: &[ApiHit]) -> String {
+/// Render matches as compact text: qualified name at column 0, then the
+/// signature and the prose indented under it — a record type's signature spans
+/// several lines, so every line is indented or the shape would be ambiguous.
+fn render_api_hits(hits: &[ApiHit], limit: Option<usize>) -> String {
+    let shown = limit.unwrap_or(hits.len());
     let mut out = String::new();
-    for hit in hits.iter().take(MAX_API_RESULTS) {
+    for hit in hits.iter().take(shown) {
         out.push_str(&hit.item.qualified_name);
         out.push('\n');
-        out.push_str("  ");
-        out.push_str(&hit.item.declaration);
-        out.push('\n');
-        if let Some(docs) = &hit.item.docs {
-            for line in docs.lines() {
-                out.push_str("  ");
-                out.push_str(line);
-                out.push('\n');
-            }
+        let prose = hit.item.docs.as_deref().unwrap_or("");
+        for line in hit.item.declaration.lines().chain(prose.lines()) {
+            out.push_str("  ");
+            out.push_str(line);
+            out.push('\n');
         }
         out.push('\n');
     }
-    if hits.len() > MAX_API_RESULTS {
+    if hits.len() > shown {
         out.push_str(&format!(
-            "({} of {} matches shown — narrow with a more specific query, or a `module`)\n",
-            MAX_API_RESULTS,
+            "({shown} of {} matches shown — narrow with a more specific query)\n",
             hits.len()
         ));
     }
@@ -1078,7 +1081,7 @@ mod tests {
         assert_eq!(hits[0].item.qualified_name, "Scene.cube");
         assert_eq!(hits[0].rank, 0);
         // The rendered text carries the signature and the prose, not just a name.
-        let rendered = render_api_hits(&hits);
+        let rendered = render_api_hits(&hits, Some(super::MAX_API_RESULTS));
         assert!(rendered.contains("let cube : () => t"), "{rendered}");
     }
 
@@ -1089,7 +1092,8 @@ mod tests {
 
         assert_eq!(hits[0].rank, 0);
         assert!(
-            hits.iter().any(|hit| hit.item.qualified_name == "Scene.cube"),
+            hits.iter()
+                .any(|hit| hit.item.qualified_name == "Scene.cube"),
             "Scene.cube must match its own bare name"
         );
     }
@@ -1131,13 +1135,45 @@ mod tests {
     }
 
     #[test]
-    fn a_truncated_result_says_so() {
+    fn a_truncated_search_says_so_and_a_module_listing_is_whole() {
         let reference = reference();
         let hits = search_api(&reference, "", Some("Scene")).unwrap();
         assert!(hits.len() > super::MAX_API_RESULTS, "Scene is a big module");
 
-        let rendered = render_api_hits(&hits);
-        assert!(rendered.contains("matches shown"), "{rendered}");
+        let capped = render_api_hits(&hits, Some(super::MAX_API_RESULTS));
+        assert!(capped.contains("matches shown"), "{capped}");
+        // Listing a module is not truncated: `module` is already the narrowing
+        // the truncation notice would tell the caller to apply.
+        let whole = render_api_hits(&hits, None);
+        assert!(!whole.contains("matches shown"), "{whole}");
+        assert_eq!(
+            whole
+                .lines()
+                .filter(|line| line.starts_with("Scene."))
+                .count(),
+            hits.len()
+        );
+    }
+
+    #[test]
+    fn a_name_match_outranks_a_signature_match() {
+        let reference = reference();
+        let hits = search_api(&reference, "texture", None).unwrap();
+
+        let first = &hits[0];
+        assert!(
+            first.item.qualified_name.to_lowercase().contains("texture"),
+            "a name match must come before consumers that merely mention the type: {}",
+            first.item.qualified_name
+        );
+    }
+
+    #[test]
+    fn a_blank_module_is_a_teaching_error_rather_than_a_widened_search() {
+        let reference = reference();
+        let error = search_api(&reference, "cube", Some("  ")).unwrap_err();
+
+        assert!(error.contains("unknown module"), "{error}");
     }
 
     #[test]

--- a/cli/src/commands/mcp.rs
+++ b/cli/src/commands/mcp.rs
@@ -14,10 +14,11 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::io;
 use std::net::TcpListener;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 use base64::Engine as _;
+use functor_docgen::{ApiItem, ApiReference};
 use functor_runtime_common::debug_protocol::DEBUG_PROTOCOL_SERVICE;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{CallToolResult, ContentBlock};
@@ -41,6 +42,8 @@ const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 const REQUIRED_PROTOCOL_VERSION: u64 = 4;
 /// Bytes of a launched child's stdout/stderr kept for failure reporting.
 const LOG_TAIL_BYTES: usize = 8 * 1024;
+/// How many API-reference items one `api_reference` call returns.
+const MAX_API_RESULTS: usize = 20;
 
 /// Serve MCP over stdio until the client disconnects.
 pub async fn execute() -> io::Result<()> {
@@ -171,6 +174,9 @@ impl Registry {
 pub struct FunctorMcp {
     http: reqwest::Client,
     sessions: Arc<Mutex<Registry>>,
+    /// The prelude API reference, generated on first use. The `.funi` sources
+    /// are embedded in this binary, so it cannot change while we run.
+    docs: Arc<OnceLock<Result<ApiReference, String>>>,
 }
 
 fn ok_text(text: impl Into<String>) -> Result<CallToolResult, ErrorData> {
@@ -263,6 +269,16 @@ pub struct ReloadProjectArgs {
     pub files: Vec<(String, String)>,
 }
 
+#[derive(Deserialize, JsonSchema)]
+pub struct ApiReferenceArgs {
+    /// What to look for, matched case-insensitively against item names,
+    /// qualified paths (`Scene.cube`), signatures and doc text. Omit it (with
+    /// `module` set) to list a whole module.
+    pub query: Option<String>,
+    /// Narrow to one prelude module, e.g. `"Scene"` or `"Effect"`.
+    pub module: Option<String>,
+}
+
 #[tool_router]
 impl FunctorMcp {
     pub fn new() -> Self {
@@ -272,7 +288,35 @@ impl FunctorMcp {
                 .build()
                 .expect("failed to build the MCP HTTP client"),
             sessions: Arc::new(Mutex::new(Registry::default())),
+            docs: Arc::new(OnceLock::new()),
         }
+    }
+
+    /// Search the engine API reference: the `.funi` prelude embedded in this
+    /// binary — every module, signature and doc comment `functor docs` renders.
+    /// `query` matches case-insensitively against item names, qualified paths
+    /// (`Scene.cube`), signatures and doc text; `module` narrows to one prelude
+    /// module, and browses all of its items when `query` is omitted. This tool
+    /// needs no session — it answers before any game is launched.
+    #[tool]
+    async fn api_reference(
+        &self,
+        Parameters(args): Parameters<ApiReferenceArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let reference = resolve!(self.api_docs());
+        let query = args.query.as_deref().unwrap_or("");
+        let hits = resolve!(search_api(reference, query, args.module.as_deref()));
+        if hits.is_empty() {
+            return tool_error(format!(
+                "no API items match {query:?}{}. The prelude modules are {}.",
+                match args.module.as_deref() {
+                    Some(module) => format!(" in module {module:?}"),
+                    None => String::new(),
+                },
+                module_names(reference).join(", ")
+            ));
+        }
+        ok_text(render_api_hits(&hits))
     }
 
     /// Start a game as a child process with its debug server on a free port,
@@ -702,6 +746,17 @@ context at all — relaunch it with mode \"hidden\" to capture frames.",
 }
 
 impl FunctorMcp {
+    /// The prelude API reference, generated once per process.
+    fn api_docs(&self) -> Result<&ApiReference, String> {
+        self.docs
+            .get_or_init(|| {
+                functor_docgen::generate()
+                    .map_err(|error| format!("could not read the embedded API reference: {error}"))
+            })
+            .as_ref()
+            .map_err(String::clone)
+    }
+
     fn release_port(&self, port: u16) {
         self.sessions
             .lock()
@@ -819,7 +874,8 @@ is structured JSON). Rebuild that runtime from this version of Functor."
 get_trace, capture_frame) and drive it (pause, send_input, step, resume, rewind, \
 reload_source). The deterministic loop is pause → send_input → step → get_state: while the \
 clock is pinned nothing advances on its own, and injected input is level state that holds \
-across steps."
+across steps. api_reference searches the engine's prelude API and needs no session, so it \
+answers language/API questions before anything is launched."
 )]
 impl ServerHandler for FunctorMcp {}
 
@@ -827,6 +883,117 @@ impl Default for FunctorMcp {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// One API-reference item that matched a search, with the rank that decides
+/// how prominently it is reported.
+#[derive(Debug)]
+struct ApiHit<'a> {
+    item: &'a ApiItem,
+    /// 0 = the item's own name, 1 = its path or signature, 2 = its prose.
+    rank: u8,
+}
+
+fn module_names(reference: &ApiReference) -> Vec<&str> {
+    reference
+        .modules
+        .iter()
+        .map(|module| module.name.as_str())
+        .collect()
+}
+
+/// Rank an item against an already-lowercased needle, or `None` if it misses.
+fn rank_api_item(needle: &str, item: &ApiItem) -> Option<u8> {
+    if item.name.eq_ignore_ascii_case(needle) || item.qualified_name.eq_ignore_ascii_case(needle) {
+        return Some(0);
+    }
+    if item.qualified_name.to_lowercase().contains(needle)
+        || item.declaration.to_lowercase().contains(needle)
+    {
+        return Some(1);
+    }
+    item.docs
+        .as_deref()
+        .is_some_and(|docs| docs.to_lowercase().contains(needle))
+        .then_some(2)
+}
+
+/// Search the reference, best matches first. `Err` is a teaching message: an
+/// unknown module, or a search with nothing to go on.
+fn search_api<'a>(
+    reference: &'a ApiReference,
+    query: &str,
+    module: Option<&str>,
+) -> Result<Vec<ApiHit<'a>>, String> {
+    let wanted = module.map(str::trim).filter(|name| !name.is_empty());
+    let modules = match wanted {
+        Some(wanted) => {
+            let matched: Vec<_> = reference
+                .modules
+                .iter()
+                .filter(|module| module.name.eq_ignore_ascii_case(wanted))
+                .collect();
+            if matched.is_empty() {
+                return Err(format!(
+                    "unknown module {wanted:?}: the prelude modules are {}",
+                    module_names(reference).join(", ")
+                ));
+            }
+            matched
+        }
+        None => reference.modules.iter().collect(),
+    };
+    let needle = query.trim().to_lowercase();
+    if needle.is_empty() && wanted.is_none() {
+        return Err(format!(
+            "give a query to search for, or a module to browse. The prelude modules are {}",
+            module_names(reference).join(", ")
+        ));
+    }
+    let mut hits: Vec<ApiHit> = modules
+        .into_iter()
+        .flat_map(|module| module.items.iter())
+        .filter_map(|item| {
+            let rank = if needle.is_empty() {
+                Some(1)
+            } else {
+                rank_api_item(&needle, item)
+            };
+            rank.map(|rank| ApiHit { item, rank })
+        })
+        .collect();
+    // A stable sort keeps the prelude's own order within a rank, which is how
+    // the module-browse listing reads best.
+    hits.sort_by_key(|hit| hit.rank);
+    Ok(hits)
+}
+
+/// Render matches as compact text: qualified name, signature, then the prose.
+fn render_api_hits(hits: &[ApiHit]) -> String {
+    let mut out = String::new();
+    for hit in hits.iter().take(MAX_API_RESULTS) {
+        out.push_str(&hit.item.qualified_name);
+        out.push('\n');
+        out.push_str("  ");
+        out.push_str(&hit.item.declaration);
+        out.push('\n');
+        if let Some(docs) = &hit.item.docs {
+            for line in docs.lines() {
+                out.push_str("  ");
+                out.push_str(line);
+                out.push('\n');
+            }
+        }
+        out.push('\n');
+    }
+    if hits.len() > MAX_API_RESULTS {
+        out.push_str(&format!(
+            "({} of {} matches shown — narrow with a more specific query, or a `module`)\n",
+            MAX_API_RESULTS,
+            hits.len()
+        ));
+    }
+    out
 }
 
 /// The runtime's current time, from a `/state` document. Never defaulted: a
@@ -896,7 +1063,82 @@ fn tail(log: &Arc<Mutex<Vec<u8>>>) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::Registry;
+    use super::{render_api_hits, search_api, Registry};
+    use functor_docgen::ApiReference;
+
+    fn reference() -> ApiReference {
+        functor_docgen::generate().expect("the embedded prelude documents itself")
+    }
+
+    #[test]
+    fn an_exact_name_match_is_reported_first() {
+        let reference = reference();
+        let hits = search_api(&reference, "Scene.cube", None).unwrap();
+
+        assert_eq!(hits[0].item.qualified_name, "Scene.cube");
+        assert_eq!(hits[0].rank, 0);
+        // The rendered text carries the signature and the prose, not just a name.
+        let rendered = render_api_hits(&hits);
+        assert!(rendered.contains("let cube : () => t"), "{rendered}");
+    }
+
+    #[test]
+    fn a_bare_item_name_finds_it_across_modules() {
+        let reference = reference();
+        let hits = search_api(&reference, "cube", None).unwrap();
+
+        assert_eq!(hits[0].rank, 0);
+        assert!(
+            hits.iter().any(|hit| hit.item.qualified_name == "Scene.cube"),
+            "Scene.cube must match its own bare name"
+        );
+    }
+
+    #[test]
+    fn a_module_filter_narrows_and_browses() {
+        let reference = reference();
+        let browsed = search_api(&reference, "", Some("effect")).unwrap();
+
+        assert!(browsed.len() > 1, "browsing a module lists its items");
+        assert!(browsed
+            .iter()
+            .all(|hit| hit.item.qualified_name.starts_with("Effect.")));
+    }
+
+    #[test]
+    fn an_unknown_module_names_the_modules_that_exist() {
+        let reference = reference();
+        let error = search_api(&reference, "cube", Some("Nope")).unwrap_err();
+
+        assert!(error.contains("unknown module"), "{error}");
+        assert!(error.contains("Scene"), "{error}");
+    }
+
+    #[test]
+    fn a_search_with_nothing_to_go_on_names_the_modules() {
+        let reference = reference();
+        let error = search_api(&reference, "  ", None).unwrap_err();
+
+        assert!(error.contains("Scene"), "{error}");
+    }
+
+    #[test]
+    fn a_query_matching_nothing_returns_no_hits() {
+        let reference = reference();
+        assert!(search_api(&reference, "zzzznotathing", None)
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn a_truncated_result_says_so() {
+        let reference = reference();
+        let hits = search_api(&reference, "", Some("Scene")).unwrap();
+        assert!(hits.len() > super::MAX_API_RESULTS, "Scene is a big module");
+
+        let rendered = render_api_hits(&hits);
+        assert!(rendered.contains("matches shown"), "{rendered}");
+    }
 
     #[test]
     fn ids_are_short_sequential_and_resolve_to_their_url() {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -376,8 +376,7 @@ async fn run(args: &Args) -> io::Result<()> {
             }
             _ => (None, Vec::new()),
         };
-        let project =
-            config.select(args.entry.as_deref().or(trailing_entry.as_deref()))?;
+        let project = config.select(args.entry.as_deref().or(trailing_entry.as_deref()))?;
         return match &args.command {
             Command::Docs { .. }
             | Command::Init { .. }

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -375,9 +375,7 @@ impl PlainRenderer {
                 if let (Some(vaos), Some(buffers), Some(textures)) =
                     (gpu_live_vaos, gpu_live_buffers, gpu_live_textures)
                 {
-                    s.push_str(&format!(
-                        ", gpu vao {vaos}/buf {buffers}/tex {textures}"
-                    ));
+                    s.push_str(&format!(", gpu vao {vaos}/buf {buffers}/tex {textures}"));
                 }
                 if let Some(bytes) = gpu_bytes_per_frame {
                     s.push_str(&format!(", up {bytes:.0}B/frame"));
@@ -537,7 +535,9 @@ static LIVE_ACTIVE: AtomicBool = AtomicBool::new(false);
 /// firehose of transitive deps (notify/mio/tokio/hyper/glow/egui/gltf all use
 /// `log`), and so a noisy dependency warning never lands in normal CLI output.
 fn is_functor_target(target: &str) -> bool {
-    target.starts_with("functor") || target == "functor-lang" || target.starts_with("functor_lang::")
+    target.starts_with("functor")
+        || target == "functor-lang"
+        || target.starts_with("functor_lang::")
 }
 
 /// A `log::Log` that funnels every Functor `log::{debug,info,warn,error}!` call

--- a/cli/src/output/live.rs
+++ b/cli/src/output/live.rs
@@ -94,10 +94,7 @@ impl Panel {
                         format!("{textures}").cyan(),
                     );
                     if let Some(bytes) = s.gpu_bytes_per_frame {
-                        gpu.push_str(&format!(
-                            " · up {}",
-                            format!("{bytes:.0}B/f").cyan()
-                        ));
+                        gpu.push_str(&format!(" · up {}", format!("{bytes:.0}B/f").cyan()));
                     }
                     if let Some((hits, misses)) = s.gpu_cache {
                         gpu.push_str(&format!(

--- a/cli/src/util/asset_verify.rs
+++ b/cli/src/util/asset_verify.rs
@@ -78,7 +78,10 @@ pub fn verify_assets(
             };
             let path = path.join(".");
             // The sanctioned constructors: verify the locator itself.
-            if matches!(path.as_str(), "Asset.model" | "Asset.texture" | "Asset.sound") {
+            if matches!(
+                path.as_str(),
+                "Asset.model" | "Asset.texture" | "Asset.sound"
+            ) {
                 let Some((locator, span)) = string_arg(args, 0) else {
                     return; // dynamic construction — the data boundary, unlinted
                 };
@@ -287,11 +290,7 @@ mod tests {
             .unwrap_or_else(|e| panic!("load: {}", e.render()))
     }
 
-    fn run(
-        src: &str,
-        dir: &Path,
-        probe: &mut dyn FnMut(&str) -> UrlVerdict,
-    ) -> AssetFindings {
+    fn run(src: &str, dir: &Path, probe: &mut dyn FnMut(&str) -> UrlVerdict) -> AssetFindings {
         verify_assets(&project(src).module, dir, probe)
     }
 

--- a/cli/src/util/wasm_dev_server.rs
+++ b/cli/src/util/wasm_dev_server.rs
@@ -179,7 +179,8 @@ mod tests {
 
     #[test]
     fn escapes_entries_that_would_break_the_script() {
-        let html = render_functor_lang_index("we\"ird\\name.fun", &["we\"ird\\name.fun".to_string()]);
+        let html =
+            render_functor_lang_index("we\"ird\\name.fun", &["we\"ird\\name.fun".to_string()]);
         assert!(html.contains("we\\\"ird\\\\name.fun"));
     }
 

--- a/cli/src/util/wasm_export.rs
+++ b/cli/src/util/wasm_export.rs
@@ -112,7 +112,10 @@ name {RESERVED_ROOT:?} at the project root): {} — rename or move them",
     copy_project(root, &out, true, &mut stats)?;
 
     // The runtime files go in last so nothing in the project can shadow them.
-    std::fs::write(out.join("index.html"), render_functor_lang_index(entry, &files))?;
+    std::fs::write(
+        out.join("index.html"),
+        render_functor_lang_index(entry, &files),
+    )?;
     std::fs::write(out.join("scrubber.js"), SCRUBBER_JS)?;
     std::fs::write(out.join("timeline-model.js"), TIMELINE_MODEL_JS)?;
     let pkg = out.join("pkg");
@@ -218,8 +221,7 @@ fn missing_asset_references(root: &Path, entry: &str) -> Vec<String> {
 
 fn is_asset_path(s: &str) -> bool {
     // A URL ("https://cdn/x.png") is fetched remotely, not from the bundle.
-    !s.contains("://")
-        && functor_runtime_common::asset::is_project_asset_file(Path::new(s))
+    !s.contains("://") && functor_runtime_common::asset::is_project_asset_file(Path::new(s))
 }
 
 /// Will the path `s` be present in the exported bundle at the URL the
@@ -303,11 +305,20 @@ mod tests {
         let out = &export.out_dir;
         let index = fs::read_to_string(out.join("index.html")).unwrap();
         assert!(index.contains("window.__functorLangGamePath = \"game.fun\""));
-        assert!(index.contains("\"pieces.fun\""), "sibling module in the file list");
-        assert!(!fs::read(out.join("pkg/functor_runtime_web_bg.wasm")).unwrap().is_empty());
-        assert!(!fs::read(out.join("pkg/functor_runtime_web.js")).unwrap().is_empty());
         assert!(
-            fs::read_to_string(out.join("scrubber.js")).unwrap().contains("mountScrubber"),
+            index.contains("\"pieces.fun\""),
+            "sibling module in the file list"
+        );
+        assert!(!fs::read(out.join("pkg/functor_runtime_web_bg.wasm"))
+            .unwrap()
+            .is_empty());
+        assert!(!fs::read(out.join("pkg/functor_runtime_web.js"))
+            .unwrap()
+            .is_empty());
+        assert!(
+            fs::read_to_string(out.join("scrubber.js"))
+                .unwrap()
+                .contains("mountScrubber"),
             "the shared scrubber component ships with the bundle"
         );
         assert!(
@@ -321,8 +332,14 @@ mod tests {
         assert!(out.join("model.glb").is_file());
         assert!(out.join("tex/wall.png").is_file());
         assert!(!out.join(".DS_Store").exists(), "hidden files are excluded");
-        assert!(!out.join("stale.txt").exists(), "stale output is wiped, not carried over");
-        assert!(!out.join("dist").exists(), "the output dir is never copied into itself");
+        assert!(
+            !out.join("stale.txt").exists(),
+            "stale output is wiped, not carried over"
+        );
+        assert!(
+            !out.join("dist").exists(),
+            "the output dir is never copied into itself"
+        );
         // game.fun + pieces.fun + model.glb + tex/wall.png
         assert_eq!(export.file_count, 4);
         assert!(export.shadowed.is_empty());
@@ -340,8 +357,14 @@ mod tests {
 
         let out = &export.out_dir;
         let index = fs::read_to_string(out.join("index.html")).unwrap();
-        assert!(index.contains("__functorLangGamePath"), "the bundle's index wins");
-        assert!(!out.join("pkg/junk.js").exists(), "no merge into the runtime pkg/");
+        assert!(
+            index.contains("__functorLangGamePath"),
+            "the bundle's index wins"
+        );
+        assert!(
+            !out.join("pkg/junk.js").exists(),
+            "no merge into the runtime pkg/"
+        );
         assert_eq!(export.shadowed, vec!["index.html", "pkg"]);
     }
 
@@ -367,7 +390,12 @@ let g = "pkg/tex.png"
         let missing = missing_asset_references(dir.path(), "game.fun");
         assert_eq!(
             missing,
-            vec!["../outside.png", "/abs/path.jpg", "missing.glb", "pkg/tex.png"],
+            vec![
+                "../outside.png",
+                "/abs/path.jpg",
+                "missing.glb",
+                "pkg/tex.png"
+            ],
             "missing + unbundleable flagged; present / non-asset / comments / URLs not"
         );
     }
@@ -385,7 +413,10 @@ let g = "pkg/tex.png"
         let wd = dir.path().to_string_lossy().to_string();
         let export = export_functor_lang_wasm(&wd, "game.fun").unwrap();
         assert_eq!(export.file_count, 1, "only game.fun ships");
-        assert!(!export.out_dir.join(".hidden.fun").exists(), "hidden sibling not bundled");
+        assert!(
+            !export.out_dir.join(".hidden.fun").exists(),
+            "hidden sibling not bundled"
+        );
     }
 
     #[cfg(unix)]

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -73,7 +73,13 @@ URL plus, when the server launched it, the child process.
 
 | Tool | What it does |
 | --- | --- |
-| `api_reference` | Search the embedded `.funi` prelude — the same reference `functor docs` renders — by name, qualified path (`Scene.cube`), signature, or doc text. `module` narrows to one module, and browses all of it when `query` is omitted. **No session needed**: it answers before any game is launched. |
+| `api_reference` | Search the embedded `.funi` prelude — the same reference `functor docs` renders — by name, qualified path (`Scene.cube`), signature, or doc text. `module` narrows to one module, and lists all of it when `query` is omitted. **No session needed**: it answers before any game is launched. |
+
+Matches come back best-first — the item's own name, then its qualified path,
+then its signature, then its prose — capped at 20 per search, with a line
+saying so. A `module` listing is never capped: the module is the narrowing.
+An unknown module, or a search with neither a query nor a module, answers with
+the list of prelude modules rather than an empty result.
 
 Two semantics are worth internalizing, because they are what make the loop
 deterministic rather than racy:

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -69,6 +69,12 @@ URL plus, when the server launched it, the child process.
 | `rewind` | Restore model + physics to a recorded frame (it pins the clock first, as `/rewind` requires). |
 | `reload_source` / `reload_project` | Hot-reload the entry, or every sibling module, with the live model preserved. |
 
+**Reading the API.**
+
+| Tool | What it does |
+| --- | --- |
+| `api_reference` | Search the embedded `.funi` prelude — the same reference `functor docs` renders — by name, qualified path (`Scene.cube`), signature, or doc text. `module` narrows to one module, and browses all of it when `query` is omitted. **No session needed**: it answers before any game is launched. |
+
 Two semantics are worth internalizing, because they are what make the loop
 deterministic rather than racy:
 

--- a/e2e/mcp-server.mjs
+++ b/e2e/mcp-server.mjs
@@ -6,14 +6,16 @@
 //
 //   1. initialize / notifications/initialized / tools/list, asserting the whole
 //      documented tool surface is advertised.
-//   2. launch_game on examples/counter in HEADLESS mode (no GL, so this runs
+//   2. api_reference, called before any session exists (it is session-free):
+//      a known item's signature, a module listing, and the zero-match case.
+//   3. launch_game on examples/counter in HEADLESS mode (no GL, so this runs
 //      anywhere CI does), and assert /state's structured `model` arrives.
-//   3. pause, then step twice — asserting the frame advances and that `step`
+//   4. pause, then step twice — asserting the frame advances and that `step`
 //      only returns once the queued steps have landed (pending_steps == 0).
-//   4. send_input: counter's model reacts to a UI click (its `update` handles
+//   5. send_input: counter's model reacts to a UI click (its `update` handles
 //      Inc), so a `ui_event` on slot 0 must increment `count` after a step.
 //      A `key` event is also injected to exercise that shape end to end.
-//   5. stop_game, then a clean shutdown of the server itself.
+//   6. stop_game, then a clean shutdown of the server itself.
 //
 // Run manually (needs the CLI built; the wasm bundle is not required):
 //
@@ -42,6 +44,7 @@ const EXPECTED_TOOLS = [
   "rewind",
   "reload_source",
   "reload_project",
+  "api_reference",
 ];
 
 /** A line-delimited JSON-RPC client over a child's stdio. */
@@ -132,6 +135,23 @@ try {
     tools.every((tool) => (tool.description ?? "").length > 20),
     "every tool carries a real description (the agent-facing docs)",
   );
+
+  // Deliberately before any session exists: api_reference is session-free.
+  console.log("\n▸ the API reference, with no session");
+  const cube = await rpc.call("api_reference", { query: "Scene.cube" });
+  check(/Scene\.cube/.test(cube) && /let cube : \(\) => t/.test(cube), "api_reference returns Scene.cube's signature");
+
+  const effect = await rpc.call("api_reference", { module: "Effect" });
+  const effectItems = effect.split("\n").filter((line) => /^Effect\./.test(line));
+  check(effectItems.length > 1, `browsing a module lists its items (${effectItems.length} from Effect)`);
+
+  let missed = null;
+  try {
+    await rpc.call("api_reference", { query: "zzzznotathing" });
+  } catch (error) {
+    missed = error.message;
+  }
+  check(missed !== null && /Scene/.test(missed) && /Effect/.test(missed), "a query matching nothing names the available modules");
 
   console.log("\n▸ launching a game headlessly");
   const launched = await rpc.call("launch_game", { dir: "examples/counter", mode: "headless" });

--- a/e2e/mcp-server.mjs
+++ b/e2e/mcp-server.mjs
@@ -145,6 +145,11 @@ try {
   const effectItems = effect.split("\n").filter((line) => /^Effect\./.test(line));
   check(effectItems.length > 1, `browsing a module lists its items (${effectItems.length} from Effect)`);
 
+  // Scene has more items than a search's result cap: a module listing is whole.
+  const scene = await rpc.call("api_reference", { module: "Scene" });
+  const sceneItems = scene.split("\n").filter((line) => /^Scene\./.test(line));
+  check(sceneItems.length > 20 && !/matches shown/.test(scene), `a module listing is not truncated (${sceneItems.length} from Scene)`);
+
   let missed = null;
   try {
     await rpc.call("api_reference", { query: "zzzznotathing" });


### PR DESCRIPTION
## What / why

The `functor-lang` skill gives Claude the language surface. Every other coding agent has nothing — the docs half of competitive-analysis item 3. This exposes the **same reference `functor docs` renders** — the `.funi` prelude embedded in the binary — as an MCP tool, so any agent can look up `Scene.cube`'s signature or browse `Effect` without a skill, a website, or a checkout.

It fits the server it joins: no new runtime surface, no subprocess. `cli/` already depends on `functor-docgen`, so the reference is generated **in-process**, once per process (a `OnceLock` on the server struct), and searched in memory. stdout stays a pure JSON-RPC channel.

## The tool

`api_reference { query?: string, module?: string }` — **session-free**, the only tool here that is: it answers before any game is launched.

- `query` matches case-insensitively against item names, qualified paths (`Scene.cube`), signatures and doc text. Results are best-first: the item's own name → its qualified path → its signature → its prose, ties in prelude order.
- `module` narrows to one prelude module, and **lists all of it** when `query` is omitted.
- Searches are capped at 20 with a line saying so. A module listing is never capped — the module *is* the narrowing.
- An unknown module, a blank one, a search with nothing to go on, or zero matches all answer with the list of prelude modules, matching the server's teaching-error style.

Output is compact text — qualified name at column 0, signature and prose indented under it:

```
Physics.cast
  let cast : (Vec3.t, Vec3.t, float) => rayHit
  Cast a ray against the world and get the nearest hit immediately.
  …
```

## Verification

- `cargo build -p functor-cli --no-default-features` clean; `cargo test -p functor-cli --no-default-features` → **42 passed** (7 new focused tests over the pure search/rank/render functions: exact-match-first, name-outranks-signature, module filter + listing, unknown/blank module, zero match, truncation).
- `node e2e/mcp-server.mjs` — `api_reference` added to the exhaustive `EXPECTED_TOOLS`, plus a section that runs **before any session exists**:

```
▸ the MCP handshake
  ✓ tools/list advertises all 16 tools
  ✓ every tool carries a real description (the agent-facing docs)

▸ the API reference, with no session
  ✓ api_reference returns Scene.cube's signature
  ✓ browsing a module lists its items (14 from Effect)
  ✓ a module listing is not truncated (24 from Scene)
  ✓ a query matching nothing names the available modules
…
✓ mcp-server passed
```

- `npm run check:docs` → markdown + json generation ✓ (the docs pipeline is untouched).
- `docs/mcp.md` gains a "Reading the API" section with the ranking/cap rules.

## Review dispositions (`/xreview`: Claude subagent + `codex exec`, both over `git diff functor-mcp...HEAD`)

Zero Critical. The two engines agreed on the truncation and blank-module findings.

| Finding | Disposition |
| --- | --- |
| **High (both)** — a module listing was capped at 20 (Physics 35, Style 26, Scene 24) and told the caller to "narrow with a `module`" that was already set | **Fixed** — a listing is never capped; only an open search is, and its notice no longer suggests the already-applied narrowing. The test that asserted the old behavior now asserts both halves; the e2e checks Scene's 24 items come back whole. |
| **Medium (Claude)** — name-substring and signature-substring matches tied at rank 1, so `texture` reported `Texture.t` at position 10 behind consumers of the type | **Fixed** — split into rank 1 (qualified path) and rank 2 (signature); a regression test pins it. |
| **Medium (Claude)** — a multi-line record signature put its closing `}` in column 0, the position that marks a new item | **Fixed** — every declaration line is indented like the prose already was. |
| **Medium (Codex)** — the description implied module-level prose is searched; only item docs are | **Fixed** — reworded to "the same reference `functor docs` renders" + explicit match fields. |
| **Low (both)** — a whitespace-only `module` silently widened the search to the whole prelude | **Fixed** — it is now an unknown-module teaching error. |
| **Low (Codex)** — "could not *read* the embedded API reference" implies I/O that does not happen | **Fixed** — "could not generate". |
| **Low (Claude)** — zero matches returns `isError: true`; an empty result is not a failure | **Kept as-is** — every other self-correcting message in this server (unknown session, unknown mode, unknown module) is a `tool_error`, and consistency there matters more than the taxonomy: an agent that gets back a module list should see it the same way whichever mistake produced it. |
| **Low (Claude)** — a file-level `static` would beat the `Arc<OnceLock<…>>` struct field | **Kept as-is** — per-server state keeps the cache's lifetime tied to the server rather than the process, which is what a second embedding of `FunctorMcp` would want; the `Arc` clone is already in the struct's shape. |
| **Low (Claude)** — `search_api`'s module lookup built a `Vec` to test emptiness; the modules hint was built three times | **Fixed** — `find(...).ok_or_else(...)`, and one `modules_hint`. |

Both engines confirmed the e2e assertions are substantive rather than vacuous, and that the `OnceLock` cache cannot poison or deadlock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
