### PR TITLE
feat(site): one scrubber at every client count — the chrono bar unification

### DIFF
--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -540,25 +540,33 @@ for (const example of examples) {
   const player = playerFrame(page);
 
   // The seam appears once the scrubber is wired; history then accrues as the
-  // scene ticks.
+  // scene ticks. The sandbox player boots with ?scrubber=hidden — the seam
+  // without the bar — and the HOST page's chrono bar is the one transport.
   await player.waitForFunction(() => window.__scrub, { timeout: 10000 });
-  const sandboxHasScrubber = await player.evaluate(
-    () => !!document.getElementById("scrubber")
+  const chronoReplacesScrubber = await player.evaluate(
+    () => !!window.__scrub && !document.getElementById("scrubber")
   );
-  check("sandbox player has the scrubber element", sandboxHasScrubber);
-  const customHandles = await player.evaluate(() =>
-    ["scrub-playhead", "scrub-preview-handle"].every((id) => {
+  const chronoVisible = await page.evaluate(
+    () => getComputedStyle(document.querySelector(".mp-chrono")).display === "flex"
+  );
+  check(
+    "sandbox chrono bar replaces the in-frame scrubber",
+    chronoReplacesScrubber && chronoVisible,
+    JSON.stringify({ chronoReplacesScrubber, chronoVisible })
+  );
+  const customHandles = await page.evaluate(() =>
+    ["mp-rail", "mp-preview-handle"].every((id) => {
       const handle = document.getElementById(id);
       return handle?.getAttribute("role") === "slider" && handle.tabIndex === 0;
     })
   );
-  check("scrubber exposes two keyboard-focusable slider handles", customHandles);
-  const handleColors = await player.evaluate(() => ({
-    playhead: getComputedStyle(document.getElementById("scrub-playhead")).backgroundColor,
-    preview: getComputedStyle(document.getElementById("scrub-preview-handle")).backgroundColor,
+  check("chrono bar exposes two keyboard-focusable slider handles", customHandles);
+  const handleColors = await page.evaluate(() => ({
+    playhead: getComputedStyle(document.getElementById("mp-playhead")).backgroundColor,
+    preview: getComputedStyle(document.getElementById("mp-preview-handle")).backgroundColor,
   }));
   check(
-    "scrubber handles keep their solid cyan and pink fills",
+    "chrono bar handles keep their solid cyan and pink fills",
     handleColors.playhead === "rgb(65, 216, 230)" &&
       handleColors.preview === "rgb(232, 88, 184)",
     JSON.stringify(handleColors)
@@ -577,21 +585,25 @@ for (const example of examples) {
   // Extrapolation is a live mode: its second handle follows the advancing tail
   // by a fixed logical window. Pausing freezes the anchor; it does not enable
   // the control or the renderer.
-  await player.evaluate(() => window.__scrub.setPreview({ enabled: true, seconds: 2 }));
-  await player.waitForFunction(
-    () => getComputedStyle(document.getElementById("scrub-preview-handle")).display === "block",
+  await page.evaluate(() => document.getElementById("mp-extrap").click());
+  await player.evaluate(() => window.__scrub.setPreview({ seconds: 2 }));
+  await page.waitForFunction(
+    () => getComputedStyle(document.getElementById("mp-preview-handle")).display === "block",
+    null,
     { timeout: 3000 }
   );
   const livePreview0 = await player.evaluate(() => window.__scrub.view());
   await sleep(300);
-  const livePreview1 = await player.evaluate(() => ({
-    view: window.__scrub.view(),
-    handleVisible:
-      getComputedStyle(document.getElementById("scrub-preview-handle")).display === "block",
-    endpointClipped: document
-      .getElementById("scrub-preview-handle")
-      .classList.contains("fully-clipped"),
-  }));
+  const livePreview1 = {
+    view: await player.evaluate(() => window.__scrub.view()),
+    ...(await page.evaluate(() => ({
+      handleVisible:
+        getComputedStyle(document.getElementById("mp-preview-handle")).display === "block",
+      endpointClipped: document
+        .getElementById("mp-preview-handle")
+        .classList.contains("fully-clipped"),
+    }))),
+  };
   check(
     "live extrapolation keeps its pink endpoint tracking the live tail",
     !livePreview0.paused &&
@@ -614,12 +626,15 @@ for (const example of examples) {
     () => window.__scrub.events().some((event) => event.kind === "key-down"),
     { timeout: 3000 }
   );
-  const inputMarker = await player.evaluate(
-    () => !!document.querySelector("#scrub-events .scrub-event.input")
-  );
+  const inputMarker = await page
+    .waitForFunction(() => !!document.querySelector("#mp-markers .mp-evt.input"), null, {
+      timeout: 3000,
+    })
+    .then(() => true)
+    .catch(() => false);
   check("timeline renders recorded input markers", inputMarker);
-  const accessibleInputMarkers = await player
-    .getByRole("button", { name: /frame \d+, Space down/ })
+  const accessibleInputMarkers = await page
+    .getByRole("button", { name: /frame \d+ · Space down/ })
     .count();
   check(
     "timeline markers are present in the accessibility tree",
@@ -634,9 +649,12 @@ for (const example of examples) {
     () => window.__scrub.events().some((event) => event.kind === "reload-ok"),
     { timeout: 5000 }
   );
-  const reloadMarker = await player.evaluate(
-    () => !!document.querySelector("#scrub-events .scrub-event.reload")
-  );
+  const reloadMarker = await page
+    .waitForFunction(() => !!document.querySelector("#mp-markers .mp-evt.reload"), null, {
+      timeout: 3000,
+    })
+    .then(() => true)
+    .catch(() => false);
   check("timeline renders successful hot-reload boundaries", reloadMarker);
   const rangeAfterSafeReload = await player.evaluate(() => window.__scrub.range());
   check(
@@ -680,22 +698,24 @@ for (const example of examples) {
     previewAfter.previewEndFrame > previewAfter.viewport.hi && previewAfter.previewClippedFrames > 0,
     JSON.stringify(previewAfter)
   );
-  const transportAccessibility = await player.evaluate(() => ({
-    pause: document.getElementById("scrub-pause").getAttribute("aria-label"),
-    extrapolating: document.getElementById("scrub-extrapolate").getAttribute("aria-pressed"),
+  const transportAccessibility = await page.evaluate(() => ({
+    pause: document.getElementById("mp-pause").getAttribute("aria-label"),
+    extrapolating: document.getElementById("mp-extrap").getAttribute("aria-pressed"),
   }));
   check(
     "transport and extrapolation expose their current state accessibly",
     transportAccessibility.pause === "Resume" && transportAccessibility.extrapolating === "true",
     JSON.stringify(transportAccessibility)
   );
-  const clippedHandlesRemainIndependent = await player.evaluate(() => {
-    const playhead = document.getElementById("scrub-playhead");
-    const preview = document.getElementById("scrub-preview-handle");
+  // (#mp-playhead is pointer-events:none, so it can never be the hit itself —
+  // the invariant is that the clipped endpoint does not sit over it.)
+  const clippedHandlesRemainIndependent = await page.evaluate(() => {
+    const playhead = document.getElementById("mp-playhead");
+    const preview = document.getElementById("mp-preview-handle");
     const rect = playhead.getBoundingClientRect();
     return (
       preview.classList.contains("fully-clipped") &&
-      document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2) === playhead
+      document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2) !== preview
     );
   });
   check(
@@ -721,18 +741,17 @@ for (const example of examples) {
 
   // Markers have generous invisible hit targets, expose hover detail, and seek
   // when selected.
-  const markerDetail = await player.evaluate(() => {
-    const marker = document.querySelector("#scrub-events .scrub-event-hit");
+  const markerDetail = await page.evaluate(() => {
+    const marker = document.querySelector("#mp-markers .mp-evt");
     marker.dispatchEvent(new MouseEvent("mouseenter"));
-    return document.getElementById("scrub-event-detail").textContent;
+    return document.getElementById("mp-evt-tip").textContent;
   });
   check("hovering a marker exposes its frame and label", markerDetail.includes("frame"), markerDetail);
-  const selectedMarkerFrame = await player.evaluate(() => {
-    const marker = document.querySelector("#scrub-events .scrub-event-hit");
+  const selectedMarkerFrame = await page.evaluate(() => {
+    const marker = document.querySelector("#mp-markers .mp-evt");
+    const labelled = marker.getAttribute("aria-label").match(/frame (\d+)/);
     marker.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    return window.__scrub.model().selectedEventId !== null
-      ? Number(marker.getAttribute("aria-label").match(/frame (\d+)/)[1])
-      : -1;
+    return labelled ? Number(labelled[1]) : -1;
   });
   await player.waitForFunction(
     (frame) => Math.abs(window.__scrub.frame() - frame) <= 1,
@@ -870,11 +889,11 @@ for (const example of examples) {
         .find((event) => event.id > lastId && event.kind === "reload-ok"),
     reloadWhileScrubbed.lastId
   );
-  const reloadTransportIsVisible = await player.evaluate(() => {
-    const scrubber = document.getElementById("scrubber");
-    const step = document.getElementById("scrub-step");
+  const reloadTransportIsVisible = await page.evaluate(() => {
+    const chrono = document.querySelector(".mp-chrono");
+    const step = document.getElementById("mp-step");
     return (
-      getComputedStyle(scrubber).display === "flex" &&
+      getComputedStyle(chrono).display === "flex" &&
       getComputedStyle(step).visibility !== "hidden" &&
       !step.disabled
     );
@@ -890,7 +909,7 @@ for (const example of examples) {
       safeReloadView.hasUnavailableHistory === reloadWhileScrubbed.hadUnavailableHistory,
     JSON.stringify(safeReloadView)
   );
-  await player.locator("#scrub-step").click();
+  await page.locator("#mp-step").click();
   await sleep(500);
   const postReloadStep = await player.evaluate(() => ({
     paused: window.__scrub.paused(),
@@ -907,8 +926,11 @@ for (const example of examples) {
       postReloadStep.view.unavailableAfterStartUnit < 1,
     JSON.stringify({ postReloadStep, scrubConsole: scrubConsole.slice(-8) })
   );
-  const preservedRailStartsAtHistoryFloor = await player.evaluate(
-    () => Number(document.getElementById("scrub-played").getAttribute("x")) === 0
+  // Host geometry: the recorded (cyan) band's left edge is recordedStartUnit —
+  // 0 means the preserved history still reaches back to the timeline floor
+  // (the same quantity the in-frame bar carried in scrub-played's x attr).
+  const preservedRailStartsAtHistoryFloor = await page.evaluate(
+    () => parseFloat(document.getElementById("mp-recorded").style.left) === 0
   );
   check(
     "preserved history keeps its cyan rail before the reload boundary",
@@ -967,23 +989,32 @@ for (const example of examples) {
     beforeReload.lastId,
     { timeout: 5000 }
   );
-  const afterReload = await player.evaluate(() => {
-    const view = window.__scrub.view();
-    return {
-      frame: window.__scrub.frame(),
-      range: window.__scrub.range(),
-      view,
-      stripeWidth: Number(document.getElementById("scrub-unavailable").getAttribute("width")),
-      stripeAfterWidth: Number(
-        document.getElementById("scrub-unavailable-after").getAttribute("width")
-      ),
-      playheadVisible: getComputedStyle(document.getElementById("scrub-playhead")).display,
-      previewVisible: getComputedStyle(document.getElementById("scrub-preview-handle")).display,
-      playheadValueText: document.getElementById("scrub-playhead").getAttribute("aria-valuetext"),
-      label: document.getElementById("scrub-count").textContent,
-      reloadFrame: window.__scrub.events().findLast((event) => event.kind === "reload-ok").frame,
-    };
-  });
+  // Let the host chrono bar's rAF paint catch up to the post-reload view
+  // before sampling its stripes/label (the seam is already settled).
+  await page
+    .waitForFunction(
+      () => parseFloat(document.getElementById("mp-unavailable").style.width) > 0,
+      null,
+      { timeout: 3000 }
+    )
+    .catch(() => {});
+  const afterReloadSeam = await player.evaluate(() => ({
+    frame: window.__scrub.frame(),
+    range: window.__scrub.range(),
+    view: window.__scrub.view(),
+    reloadFrame: window.__scrub.events().findLast((event) => event.kind === "reload-ok").frame,
+  }));
+  const afterReloadChrono = await page.evaluate(() => ({
+    stripeWidth: parseFloat(document.getElementById("mp-unavailable").style.width),
+    stripeAfterWidth: parseFloat(
+      document.getElementById("mp-unavailable-after").style.width
+    ),
+    playheadVisible: getComputedStyle(document.getElementById("mp-playhead")).display,
+    previewVisible: getComputedStyle(document.getElementById("mp-preview-handle")).display,
+    playheadValueText: document.getElementById("mp-rail").getAttribute("aria-valuetext"),
+    label: document.getElementById("mp-frame").textContent,
+  }));
+  const afterReload = { ...afterReloadSeam, ...afterReloadChrono };
   check(
     "closure reload keeps the paused frame and frozen viewport",
     afterReload.frame === beforeReload.frame &&
@@ -1344,7 +1375,7 @@ for (const example of examples) {
 
   // Let a few frames run, then pause via the real scrubber button.
   await sleep(800);
-  await playerFrame(page).evaluate(() => document.getElementById("scrub-pause")?.click());
+  await page.evaluate(() => document.getElementById("mp-pause")?.click());
 
   // Live inlays appear (the relay → setLiveTrace → hash gate → overlay path).
   const liveCount = await waitFor(() => page.locator(".cm-live-value").count(), (n) => n > 0);
@@ -1393,13 +1424,13 @@ for (const example of examples) {
 
   // Resuming play clears the overlay (the runtime's unpaused stub bumps the
   // trace generation; stale inlays over a running game would be lies).
-  await playerFrame(page).evaluate(() => document.getElementById("scrub-pause")?.click());
+  await page.evaluate(() => document.getElementById("mp-pause")?.click());
   const resumed = await waitFor(() => page.locator(".cm-live-value").count(), (n) => n === 0, 6000);
   check("resuming clears the live overlay", resumed === 0, `count=${resumed}`);
 
   // Pause again: the overlay returns, then an edit clears it instantly —
   // stale values must never drift over moved text (hash gate).
-  await playerFrame(page).evaluate(() => document.getElementById("scrub-pause")?.click());
+  await page.evaluate(() => document.getElementById("mp-pause")?.click());
   await waitFor(() => page.locator(".cm-live-value").count(), (n) => n > 0);
   await page.evaluate((s) => window.__sandbox.setSource(s), `${GREEN}// paused edit\n`);
   const cleared = await waitFor(() => page.locator(".cm-live-value").count(), (n) => n === 0, 4000);
@@ -1460,7 +1491,7 @@ let draw = (model, tts: float) =>
     () => window.__scrub && window.__scrub.range().length === 2 && window.__scrub.range()[1] > 80,
     { timeout: 30000 }
   );
-  await player.evaluate(() => document.getElementById("scrub-pause")?.click());
+  await page.evaluate(() => document.getElementById("mp-pause")?.click());
   const cov = await waitFor(
     () => page.evaluate(() => window.__lang.coverage()),
     (c) => c[lateLine] === "now"

--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -555,7 +555,7 @@ for (const example of examples) {
     JSON.stringify({ chronoReplacesScrubber, chronoVisible })
   );
   const customHandles = await page.evaluate(() =>
-    ["mp-rail", "mp-preview-handle"].every((id) => {
+    ["mp-playhead", "mp-preview-handle"].every((id) => {
       const handle = document.getElementById(id);
       return handle?.getAttribute("role") === "slider" && handle.tabIndex === 0;
     })
@@ -753,12 +753,21 @@ for (const example of examples) {
     marker.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     return labelled ? Number(labelled[1]) : -1;
   });
+  // The click must SELECT the event on the seam (highlight/activeEvent latch),
+  // not merely seek — the assertion the original in-frame check carried.
+  const markerSelected = await player.evaluate(
+    () => window.__scrub.model().selectedEventId !== null
+  );
   await player.waitForFunction(
     (frame) => Math.abs(window.__scrub.frame() - frame) <= 1,
     selectedMarkerFrame,
     { timeout: 3000 }
   );
-  check("selecting a marker seeks to its frame", selectedMarkerFrame >= 0);
+  check(
+    "selecting a marker seeks to its frame",
+    markerSelected && selectedMarkerFrame >= 0,
+    JSON.stringify({ markerSelected, selectedMarkerFrame })
+  );
 
   // Seek snaps to a frame within the range.
   const rng = await player.evaluate(() => window.__scrub.range());
@@ -1011,7 +1020,7 @@ for (const example of examples) {
     ),
     playheadVisible: getComputedStyle(document.getElementById("mp-playhead")).display,
     previewVisible: getComputedStyle(document.getElementById("mp-preview-handle")).display,
-    playheadValueText: document.getElementById("mp-rail").getAttribute("aria-valuetext"),
+    playheadValueText: document.getElementById("mp-playhead").getAttribute("aria-valuetext"),
     label: document.getElementById("mp-frame").textContent,
   }));
   const afterReload = { ...afterReloadSeam, ...afterReloadChrono };

--- a/runtime/functor-runtime-web/scrubber.js
+++ b/runtime/functor-runtime-web/scrubber.js
@@ -642,7 +642,12 @@ export function mountScrubber({ hidden = false } = {}) {
     // 2 strobe / 3 both / 4 ghost) — the ghost-mode select isn't part of the
     // reducer's state, so hosts driving a hidden mount set it through here.
     setPreview: ({ mode: previewMode, ...preview }) => {
-      if (previewMode !== undefined) mode.value = String(previewMode);
+      // Only accept a mode the select actually offers — assigning an unknown
+      // value would blank the select and push mode 0 (renderer off) while the
+      // model still says enabled.
+      if (previewMode !== undefined && mode.querySelector(`option[value="${previewMode}"]`)) {
+        mode.value = String(previewMode);
+      }
       dispatch({ type: "preview-changed", preview });
       syncInputs();
       pushPreview();

--- a/runtime/functor-runtime-web/scrubber.js
+++ b/runtime/functor-runtime-web/scrubber.js
@@ -638,7 +638,11 @@ export function mountScrubber({ hidden = false } = {}) {
     view,
     events: () => state.events,
     selectEvent: (id) => dispatch({ type: "event-selected", id }),
-    setPreview: (preview) => {
+    // Accepts the timeline-model preview fields plus `mode` (1 trail /
+    // 2 strobe / 3 both / 4 ghost) — the ghost-mode select isn't part of the
+    // reducer's state, so hosts driving a hidden mount set it through here.
+    setPreview: ({ mode: previewMode, ...preview }) => {
+      if (previewMode !== undefined) mode.value = String(previewMode);
       dispatch({ type: "preview-changed", preview });
       syncInputs();
       pushPreview();

--- a/site/src/mp-panes.ts
+++ b/site/src/mp-panes.ts
@@ -43,6 +43,7 @@ interface ScrubSeam {
   togglePause(): void;
   step(): void;
   model(): { preview: { enabled: boolean; seconds: number; rate: number } };
+  selectEvent(id: number | null): void;
   view(): TimelineView | null;
   setPreview(preview: {
     enabled?: boolean;
@@ -57,6 +58,7 @@ interface ScrubSeam {
 interface TimelineView {
   viewport: { lo: number; hi: number };
   recorded: { lo: number; hi: number };
+  recordingAvailable: boolean;
   playheadUnit: number;
   playheadClippedBefore: boolean;
   playheadClippedAfter: boolean;
@@ -129,6 +131,9 @@ const PLAYER_COLORS = ["var(--scrub-p1)", "var(--scrub-p2)", "var(--scrub-p3)", 
 /** One clamp for every entry point (the select offers the same range). */
 export const MAX_CLIENTS = 3;
 
+/** The timeline's fixed tick rate (timeline-model.js TIMELINE_FPS). */
+const TIMELINE_FPS = 60;
+
 const LINK_PRESETS: LinkProfile[] = [
   { name: "LAN", ms: 8, jitter: 2, loss: 0 },
   { name: "Wi-Fi", ms: 45, jitter: 12, loss: 1.2 },
@@ -160,8 +165,7 @@ export function initMultiplayerPanes({
   chrono.innerHTML = `
     <button class="mp-sbtn" id="mp-pause" title="Pause / resume every client">⏸</button>
     <button class="mp-sbtn" id="mp-step" title="Step every client one frame">⏭</button>
-    <span class="mp-rail" id="mp-rail" title="Drag to seek every client"
-      role="slider" tabindex="0" aria-label="Time-travel timeline" aria-orientation="horizontal">
+    <span class="mp-rail" id="mp-rail" title="Drag to seek every client">
       <span class="mp-track"></span>
       <span class="mp-unavailable" id="mp-unavailable"></span>
       <span class="mp-unavailable mp-unavailable-after" id="mp-unavailable-after"></span>
@@ -170,7 +174,8 @@ export function initMultiplayerPanes({
       <span class="mp-future" id="mp-future"></span>
       <span class="mp-ticks" id="mp-ticks"></span>
       <span class="mp-markers" id="mp-markers"></span>
-      <span class="mp-playhead" id="mp-playhead"></span>
+      <span class="mp-playhead" id="mp-playhead" role="slider" tabindex="0"
+        aria-label="Selected frame" aria-orientation="horizontal"></span>
       <span class="mp-preview-handle" id="mp-preview-handle" role="slider" tabindex="0"
         aria-label="Extrapolation endpoint" aria-orientation="horizontal"
         title="Drag to stretch the extrapolation window"></span>
@@ -368,6 +373,7 @@ export function initMultiplayerPanes({
     const target = event.target as HTMLElement;
     if (event.key === "Escape") {
       closePopovers();
+      primarySeam()?.selectEvent(null);
       return;
     }
     if (target.closest?.(".cm-editor") || /^(INPUT|TEXTAREA|SELECT)$/.test(target.tagName)) return;
@@ -407,6 +413,13 @@ export function initMultiplayerPanes({
   // is untouched, so its model (and the editor session) survive.
   const setCount = (n: number) => {
     const target = Math.max(1, Math.min(MAX_CLIENTS, Math.floor(n) || 1));
+    // Extrapolation is single-client-only, and its controls are hidden at
+    // N > 1 — so leaving single must switch it OFF, or a pane keeps
+    // speculatively re-simulating with no way to stop it.
+    if (panes.length === 1 && target > 1) {
+      for (const seam of seams()) seam.setPreview({ enabled: false });
+      (chrono.querySelector("#mp-adv") as HTMLDetailsElement).open = false;
+    }
     while (panes.length < target) addMirror(true);
     while (panes.length > target) removeMirror();
     if (focused >= panes.length) focusPane(0);
@@ -584,9 +597,20 @@ export function initMultiplayerPanes({
   };
   previewHandle.addEventListener("pointerup", endPreviewDrag);
   previewHandle.addEventListener("pointercancel", endPreviewDrag);
+  previewHandle.addEventListener("lostpointercapture", endPreviewDrag);
   previewHandle.addEventListener("keydown", (event) => {
+    if (event.key === "Home" || event.key === "End") {
+      event.preventDefault();
+      event.stopPropagation();
+      const seconds = event.key === "Home" ? 0.5 : 5;
+      for (const seam of seams()) seam.setPreview({ seconds });
+      advWin.value = String(seconds);
+      return;
+    }
+    const step = event.shiftKey ? 1 : 0.5;
     const deltas: Record<string, number> = {
-      ArrowLeft: -0.5, ArrowDown: -0.5, ArrowRight: 0.5, ArrowUp: 0.5,
+      ArrowLeft: -step, ArrowDown: -step, ArrowRight: step, ArrowUp: step,
+      PageDown: -1, PageUp: 1,
     };
     const delta = deltas[event.key];
     if (delta === undefined) return;
@@ -628,7 +652,8 @@ export function initMultiplayerPanes({
   rail.addEventListener("pointermove", (event) => {
     if (rail.hasPointerCapture(event.pointerId)) seekAt(event);
   });
-  rail.addEventListener("keydown", (event) => {
+  const playheadEl = $("mp-playhead");
+  playheadEl.addEventListener("keydown", (event) => {
     const current = primarySeam()?.view();
     if (!current) return;
     const steps = event.shiftKey ? 10 : 1;
@@ -637,10 +662,12 @@ export function initMultiplayerPanes({
       ArrowDown: current.selectedFrame - steps,
       ArrowRight: current.selectedFrame + steps,
       ArrowUp: current.selectedFrame + steps,
-      PageDown: current.selectedFrame - 60,
-      PageUp: current.selectedFrame + 60,
-      Home: current.viewport.lo,
-      End: current.viewport.hi,
+      PageDown: current.selectedFrame - TIMELINE_FPS,
+      PageUp: current.selectedFrame + TIMELINE_FPS,
+      // Recorded bounds, not the viewport's: after a reload the viewport can
+      // include striped history that is provably unseekable.
+      Home: current.recorded.lo,
+      End: current.recorded.hi,
     };
     const target = targets[event.key];
     if (target === undefined) return;
@@ -656,13 +683,35 @@ export function initMultiplayerPanes({
   const ticksHost = $("mp-ticks");
   let markerKey = "";
   let lastLabel = "";
+  // The host owns the ⚙ configuration: a freshly navigated player boots with
+  // the seam defaults (2s / 5 / both), which would silently diverge from the
+  // values the inputs display — push them whenever the primary seam changes.
+  let lastPrimaryWindow: Window | null = null;
   const paint = () => {
     const primary = primarySeam();
+    const primaryWindow = panes[focused]?.iframe.contentWindow ?? null;
+    if (primary && primaryWindow !== lastPrimaryWindow) {
+      lastPrimaryWindow = primaryWindow;
+      if (advWin.validity.valid && advRate.validity.valid) {
+        primary.setPreview({
+          seconds: advWin.valueAsNumber,
+          rate: advRate.valueAsNumber,
+          mode: Number(advMode.value),
+        });
+      }
+    }
     const current = primary?.view();
     chrono.classList.toggle("dormant", !current);
     if (primary && current) {
       const span = Math.max(current.viewport.hi - current.viewport.lo, 1);
-      $("mp-played").style.width = `${Math.min(current.playheadUnit, 1) * 100}%`;
+      const played = $("mp-played");
+      played.style.left = `${current.recordedStartUnit * 100}%`;
+      played.style.width = `${
+        Math.max(
+          Math.min(current.playheadUnit, current.recordedEndUnit) - current.recordedStartUnit,
+          0
+        ) * 100
+      }%`;
       $("mp-recorded").style.left = `${current.recordedStartUnit * 100}%`;
       $("mp-recorded").style.width =
         `${Math.max(current.recordedEndUnit - current.recordedStartUnit, 0) * 100}%`;
@@ -694,6 +743,18 @@ export function initMultiplayerPanes({
         previewOn && current.previewFrames > 0 && current.previewEndUnit <= current.playheadUnit
       );
       previewHandle.setAttribute(
+        "aria-valuemin",
+        String(current.selectedFrame + Math.round(0.5 * TIMELINE_FPS))
+      );
+      previewHandle.setAttribute(
+        "aria-valuemax",
+        String(current.selectedFrame + 5 * TIMELINE_FPS)
+      );
+      previewHandle.setAttribute(
+        "aria-valuenow",
+        String(current.selectedFrame + current.previewFrames)
+      );
+      previewHandle.setAttribute(
         "aria-valuetext",
         `${primary.model().preview.seconds} seconds ahead` +
           (current.previewClippedFrames ? `, ${current.previewClippedFrames} frames clipped` : "")
@@ -710,17 +771,23 @@ export function initMultiplayerPanes({
         ` / ${Math.round(current.viewport.hi)}`;
       // The stripes' availability note is ARIA-only, but it shares the label's
       // change guard so it repaints exactly when the label does.
-      const availability = striped
-        ? `, recorded frames ${Math.round(current.recorded.lo)} to ` +
-          `${Math.round(current.recorded.hi)}; striped history outside that range is unavailable`
-        : "";
+      // Mirrors timeline-model's describeRecordedAvailability exactly.
+      const availability = !current.recordingAvailable
+        ? ", no recorded history is currently available"
+        : striped
+          ? `, recorded frames ${Math.round(current.recorded.lo)} to ` +
+            `${Math.round(current.recorded.hi)}; striped history outside that range is unavailable`
+          : "";
       if (labelHtml + availability !== lastLabel) {
         lastLabel = labelHtml + availability;
         $("mp-frame").innerHTML = labelHtml;
-        rail.setAttribute("aria-valuemin", String(Math.round(current.viewport.lo)));
-        rail.setAttribute("aria-valuemax", String(Math.round(current.viewport.hi)));
-        rail.setAttribute("aria-valuenow", String(current.selectedFrame));
-        rail.setAttribute(
+        playheadEl.setAttribute("aria-valuemin", String(Math.round(current.viewport.lo)));
+        playheadEl.setAttribute(
+          "aria-valuemax",
+          String(Math.max(Math.round(current.viewport.hi), current.selectedFrame))
+        );
+        playheadEl.setAttribute("aria-valuenow", String(current.selectedFrame));
+        playheadEl.setAttribute(
           "aria-valuetext",
           `frame ${current.selectedFrame} of ${Math.round(current.viewport.hi)}` +
             (outside ? ", outside the frozen viewport" : "") +
@@ -777,10 +844,13 @@ export function initMultiplayerPanes({
             tick.addEventListener("pointerdown", (event) => event.stopPropagation());
             tick.addEventListener("click", (event) => {
               event.stopPropagation();
+              primarySeam()?.selectEvent(marker.id);
               for (const seam of seams()) seam.seek(marker.frame);
             });
             tick.addEventListener("mouseenter", () => showTip(marker.unit, detail));
             tick.addEventListener("mouseleave", hideTip);
+            tick.addEventListener("focus", () => showTip(marker.unit, detail));
+            tick.addEventListener("blur", hideTip);
             return tick;
           })
         );

--- a/site/src/mp-panes.ts
+++ b/site/src/mp-panes.ts
@@ -19,12 +19,9 @@
 //  - the host chrono bar drives every pane through its `window.__scrub` seam
 //    (pause/step/seek/extrapolate broadcast; rail + markers mirror the
 //    focused pane);
-//  - mirror panes boot with `?scrubber=hidden` (the seam without the bar);
-//    pane 1 cannot re-boot (its model must survive), so while count > 1 its
-//    in-frame bar is suppressed with a REVERSIBLE injected style — removed
-//    the moment the count returns to 1, so single-client is exactly stock.
-//    The single-client unification (chrono bar at every N) follows separately
-//    with the a11y parity work it requires;
+//  - every pane (the sandbox player included) boots with `?scrubber=hidden`
+//    — the seam without the bar — and the chrono bar is the ONE transport
+//    instrument at every client count, single included;
 //  - the per-pane link chip (LAN / Wi-Fi / mobile / awful) records a
 //    LinkProfile per client but impairs nothing until the transport carries
 //    it. It is labelled as such.
@@ -45,15 +42,32 @@ interface ScrubSeam {
   seek(frame: number): void;
   togglePause(): void;
   step(): void;
+  model(): { preview: { enabled: boolean; seconds: number; rate: number } };
   view(): TimelineView | null;
+  setPreview(preview: {
+    enabled?: boolean;
+    seconds?: number;
+    rate?: number;
+    /** 1 trail / 2 strobe / 3 both / 4 ghost (scrubber.js seam extension). */
+    mode?: number;
+  }): void;
 }
 
 /** The slice of timeline-model's derived view the chrono bar renders. */
 interface TimelineView {
   viewport: { lo: number; hi: number };
+  recorded: { lo: number; hi: number };
   playheadUnit: number;
+  playheadClippedBefore: boolean;
+  playheadClippedAfter: boolean;
   recordedStartUnit: number;
   recordedEndUnit: number;
+  hasUnavailableHistory: boolean;
+  unavailableEndUnit: number;
+  unavailableAfterStartUnit: number;
+  previewEndUnit: number;
+  previewFrames: number;
+  previewClippedFrames: number;
   selectedFrame: number;
   paused: boolean;
   eventMarkers: {
@@ -122,39 +136,6 @@ const LINK_PRESETS: LinkProfile[] = [
   { name: "awful", ms: 400, jitter: 120, loss: 12 },
 ];
 
-const HIDE_SCRUBBER_CSS = "#scrubber { display: none !important; }";
-
-// Suppress (or restore) pane 1's own bottom-docked scrubber overlay. While
-// count > 1 the host chrono bar is the one instrument; back at 1 the style is
-// removed and the stock in-frame bar returns. The `__scrub` seam is live
-// either way (it is how the chrono bar drives the pane).
-const setInnerScrubberHidden = (iframe: HTMLIFrameElement, hidden: boolean) => {
-  try {
-    const doc = iframe.contentDocument;
-    if (!doc) return;
-    const existing = doc.getElementById("mp-hide-scrubber");
-    if (hidden && !existing) {
-      const style = doc.createElement("style");
-      style.id = "mp-hide-scrubber";
-      style.textContent = HIDE_SCRUBBER_CSS;
-      (doc.head || doc.documentElement).appendChild(style);
-    } else if (!hidden && existing) {
-      existing.remove();
-    }
-  } catch {
-    // A pane that is mid-navigation has no reachable document yet; the load
-    // listener re-runs this.
-  }
-};
-
-// Mirror panes get the honest mechanism: mountScrubber({ hidden }) via the
-// player's ?scrubber=hidden — the seam mounts, the bar's DOM never does.
-const withHiddenScrubber = (src: string) => {
-  const url = new URL(src, window.location.href);
-  url.searchParams.set("scrubber", "hidden");
-  return url.toString();
-};
-
 const seamOf = (iframe: HTMLIFrameElement): ScrubSeam | null => {
   try {
     return (iframe.contentWindow as (Window & { __scrub?: ScrubSeam }) | null)?.__scrub ?? null;
@@ -179,16 +160,38 @@ export function initMultiplayerPanes({
   chrono.innerHTML = `
     <button class="mp-sbtn" id="mp-pause" title="Pause / resume every client">⏸</button>
     <button class="mp-sbtn" id="mp-step" title="Step every client one frame">⏭</button>
-    <span class="mp-rail" id="mp-rail" title="Drag to seek every client">
+    <span class="mp-rail" id="mp-rail" title="Drag to seek every client"
+      role="slider" tabindex="0" aria-label="Time-travel timeline" aria-orientation="horizontal">
       <span class="mp-track"></span>
+      <span class="mp-unavailable" id="mp-unavailable"></span>
+      <span class="mp-unavailable mp-unavailable-after" id="mp-unavailable-after"></span>
       <span class="mp-recorded" id="mp-recorded"></span>
       <span class="mp-played" id="mp-played"></span>
+      <span class="mp-future" id="mp-future"></span>
       <span class="mp-ticks" id="mp-ticks"></span>
       <span class="mp-markers" id="mp-markers"></span>
       <span class="mp-playhead" id="mp-playhead"></span>
+      <span class="mp-preview-handle" id="mp-preview-handle" role="slider" tabindex="0"
+        aria-label="Extrapolation endpoint" aria-orientation="horizontal"
+        title="Drag to stretch the extrapolation window"></span>
+      <span class="mp-overflow" id="mp-overflow"></span>
       <span class="mp-evt-tip" id="mp-evt-tip" role="status"></span>
       <span class="mp-rail-label"><b>#f</b> <span id="mp-frame">—</span></span>
     </span>
+    <button class="mp-sbtn" id="mp-extrap" title="Extrapolate: speculatively simulate forward from the parked frame">🔮</button>
+    <details class="mp-adv" id="mp-adv">
+      <summary title="Extrapolation settings">⚙</summary>
+      <div class="mp-adv-pop">
+        <label>show
+          <select id="mp-adv-mode">
+            <option value="1">trail</option><option value="2">strobe</option>
+            <option value="3" selected>both</option><option value="4">ghost</option>
+          </select>
+        </label>
+        <label>window <input id="mp-adv-win" type="number" step="0.5" min="0.5" max="5" value="2" />s</label>
+        <label>rate <input id="mp-adv-rate" type="number" min="1" max="30" value="5" />/s</label>
+      </div>
+    </details>
     <span class="mp-viewseg" role="group" aria-label="Pane layout">
       <button id="mp-view-tiled" aria-pressed="true" title="Tiled: every client visible">⊞ tiled</button>
       <button id="mp-view-tabs" aria-pressed="false" title="Tabs: one client full-size (f)">▤ tabs</button>
@@ -261,18 +264,12 @@ export function initMultiplayerPanes({
       errStrip: shell.querySelector(".mp-pane-err") as HTMLElement,
     };
 
-    iframe.addEventListener("load", () => syncInnerScrubber());
     shell.querySelector(".mp-pane-hd")!.addEventListener("mousedown", () => focusPane(index));
     tab.addEventListener("click", () => focusPane(index));
     buildLinkMenu(pane, shell.querySelector(".mp-link-host") as HTMLElement, pane.scope.signal);
     panes.push(pane);
     return pane;
   };
-
-  // Pane 1's in-frame scrubber shows exactly when it is the ONLY pane.
-  function syncInnerScrubber() {
-    setInnerScrubberHidden(panes[0].iframe, panes.length > 1);
-  }
 
   // Pane 1 wraps the page's existing #player (lang-intel, the live trace, and
   // the primary bridge keep talking to it untouched). Panes 2..N are mirrors,
@@ -312,7 +309,7 @@ export function initMultiplayerPanes({
     // A mirror added mid-session boots the served program, then catches up to
     // the (possibly edited) buffer; the bridge holds the push until ready.
     if (frame.getAttribute("src")) {
-      iframe.src = withHiddenScrubber(frame.src);
+      iframe.src = frame.src; // already carries ?scrubber=hidden (the page adds it)
       if (pushCurrent) bridge.push(getSource());
     }
   };
@@ -348,6 +345,7 @@ export function initMultiplayerPanes({
     for (const menu of document.querySelectorAll<HTMLElement>(".mp-link-menu")) {
       menu.hidden = true;
     }
+    (chrono.querySelector("#mp-adv") as HTMLDetailsElement).open = false;
   };
 
   const moduleScope = new AbortController();
@@ -403,7 +401,6 @@ export function initMultiplayerPanes({
     $btn("mp-view-tiled").disabled = single;
     $btn("mp-view-tabs").disabled = single;
     if (single) setView("tiled", true);
-    syncInnerScrubber();
   };
 
   // Live client-count change: grow or shrink the mirror set in place. Pane 1
@@ -533,6 +530,73 @@ export function initMultiplayerPanes({
   $btn("mp-step").addEventListener("click", () => {
     for (const seam of seams()) seam.step();
   });
+  // The speculative preview (🔮): the pane simulates forward from its parked
+  // frame under the current code, replaying recorded input. Broadcast like
+  // pause (single-client-only in the UI; the CSS hides it at N > 1).
+  $btn("mp-extrap").addEventListener("click", () => {
+    const primary = primarySeam();
+    if (!primary) return;
+    const enabled = !primary.model().preview.enabled;
+    for (const seam of seams()) seam.setPreview({ enabled });
+  });
+
+  // ⚙ advanced — everything goes through the seam (the panes' scrubber DOM is
+  // never attached, so there is nothing to reach into cross-frame).
+  const advWin = chrono.querySelector("#mp-adv-win") as HTMLInputElement;
+  const advRate = chrono.querySelector("#mp-adv-rate") as HTMLInputElement;
+  const advMode = chrono.querySelector("#mp-adv-mode") as HTMLSelectElement;
+  const pushAdv = () => {
+    if (!advWin.validity.valid || !advRate.validity.valid) return;
+    for (const seam of seams()) {
+      seam.setPreview({ seconds: advWin.valueAsNumber, rate: advRate.valueAsNumber });
+    }
+  };
+  advWin.addEventListener("input", pushAdv);
+  advRate.addEventListener("input", pushAdv);
+  advMode.addEventListener("change", () => {
+    for (const seam of seams()) seam.setPreview({ mode: Number(advMode.value) });
+  });
+
+  // The pink preview handle: drag (or arrow keys) to stretch the window.
+  const previewHandle = $("mp-preview-handle");
+  let previewDrag: { x: number; seconds: number } | null = null;
+  previewHandle.addEventListener("pointerdown", (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    previewHandle.setPointerCapture(event.pointerId);
+    previewDrag = { x: event.clientX, seconds: primarySeam()?.model().preview.seconds ?? 2 };
+  });
+  previewHandle.addEventListener("pointermove", (event) => {
+    if (!previewDrag || !previewHandle.hasPointerCapture(event.pointerId)) return;
+    const current = primarySeam()?.view();
+    const width = rail.getBoundingClientRect().width;
+    const span = current ? current.viewport.hi - current.viewport.lo : 0;
+    if (width <= 0 || span <= 0) return;
+    const deltaFrames = ((event.clientX - previewDrag.x) / width) * span;
+    for (const seam of seams()) {
+      seam.setPreview({ seconds: previewDrag.seconds + deltaFrames / 60 });
+    }
+    const settled = primarySeam()?.model().preview.seconds;
+    if (settled !== undefined) advWin.value = String(settled);
+  });
+  const endPreviewDrag = () => {
+    previewDrag = null;
+  };
+  previewHandle.addEventListener("pointerup", endPreviewDrag);
+  previewHandle.addEventListener("pointercancel", endPreviewDrag);
+  previewHandle.addEventListener("keydown", (event) => {
+    const deltas: Record<string, number> = {
+      ArrowLeft: -0.5, ArrowDown: -0.5, ArrowRight: 0.5, ArrowUp: 0.5,
+    };
+    const delta = deltas[event.key];
+    if (delta === undefined) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const seconds = (primarySeam()?.model().preview.seconds ?? 2) + delta;
+    for (const seam of seams()) seam.setPreview({ seconds });
+    const settled = primarySeam()?.model().preview.seconds;
+    if (settled !== undefined) advWin.value = String(settled);
+  });
   const tip = $("mp-evt-tip");
   const showTip = (unit: number, text: string) => {
     tip.style.display = "block";
@@ -564,6 +628,26 @@ export function initMultiplayerPanes({
   rail.addEventListener("pointermove", (event) => {
     if (rail.hasPointerCapture(event.pointerId)) seekAt(event);
   });
+  rail.addEventListener("keydown", (event) => {
+    const current = primarySeam()?.view();
+    if (!current) return;
+    const steps = event.shiftKey ? 10 : 1;
+    const targets: Record<string, number> = {
+      ArrowLeft: current.selectedFrame - steps,
+      ArrowDown: current.selectedFrame - steps,
+      ArrowRight: current.selectedFrame + steps,
+      ArrowUp: current.selectedFrame + steps,
+      PageDown: current.selectedFrame - 60,
+      PageUp: current.selectedFrame + 60,
+      Home: current.viewport.lo,
+      End: current.viewport.hi,
+    };
+    const target = targets[event.key];
+    if (target === undefined) return;
+    event.preventDefault();
+    event.stopPropagation();
+    for (const seam of seams()) seam.seek(Math.round(target));
+  });
 
   // The rail mirrors the FOCUSED pane (each pane is an independent sim in the
   // prototype, so one authoritative rail per focus is the honest picture; the
@@ -583,12 +667,69 @@ export function initMultiplayerPanes({
       $("mp-recorded").style.width =
         `${Math.max(current.recordedEndUnit - current.recordedStartUnit, 0) * 100}%`;
       $("mp-playhead").style.left = `${current.playheadUnit * 100}%`;
-      const labelText = `${current.selectedFrame} / ${Math.round(current.viewport.hi)}`;
-      if (labelText !== lastLabel) {
-        lastLabel = labelText;
-        $("mp-frame").textContent = labelText;
+      const outside = current.playheadClippedBefore || current.playheadClippedAfter;
+      $("mp-playhead").classList.toggle("outside", outside);
+      // Unavailable-history stripes: the frozen viewport's regions whose
+      // snapshots did not survive a reload (same geometry as the in-frame bar).
+      const striped = current.hasUnavailableHistory;
+      $("mp-unavailable").style.width = striped
+        ? `${current.unavailableEndUnit * 100}%`
+        : "0";
+      const unavailableAfter = $("mp-unavailable-after");
+      unavailableAfter.style.left = `${current.unavailableAfterStartUnit * 100}%`;
+      unavailableAfter.style.width = striped
+        ? `${Math.max(1 - current.unavailableAfterStartUnit, 0) * 100}%`
+        : "0";
+      const previewOn = primary.model().preview.enabled;
+      const future = $("mp-future");
+      future.style.left = `${current.playheadUnit * 100}%`;
+      future.style.width = previewOn
+        ? `${Math.max(current.previewEndUnit - current.playheadUnit, 0) * 100}%`
+        : "0";
+      previewHandle.style.display = previewOn ? "block" : "none";
+      previewHandle.style.left = `${current.previewEndUnit * 100}%`;
+      previewHandle.classList.toggle("clipped", current.previewClippedFrames > 0);
+      previewHandle.classList.toggle(
+        "fully-clipped",
+        previewOn && current.previewFrames > 0 && current.previewEndUnit <= current.playheadUnit
+      );
+      previewHandle.setAttribute(
+        "aria-valuetext",
+        `${primary.model().preview.seconds} seconds ahead` +
+          (current.previewClippedFrames ? `, ${current.previewClippedFrames} frames clipped` : "")
+      );
+      const overflow = $("mp-overflow");
+      overflow.style.display = previewOn && current.previewClippedFrames > 0 ? "block" : "none";
+      overflow.textContent = `+${current.previewClippedFrames}`;
+      $btn("mp-extrap").classList.toggle("on", previewOn);
+      $btn("mp-extrap").setAttribute("aria-pressed", String(previewOn));
+      const labelHtml =
+        `${current.selectedFrame}` +
+        (outside ? ` <span class="out">outside</span>` : "") +
+        (previewOn ? ` <span class="fut">+${current.previewFrames}</span>` : "") +
+        ` / ${Math.round(current.viewport.hi)}`;
+      // The stripes' availability note is ARIA-only, but it shares the label's
+      // change guard so it repaints exactly when the label does.
+      const availability = striped
+        ? `, recorded frames ${Math.round(current.recorded.lo)} to ` +
+          `${Math.round(current.recorded.hi)}; striped history outside that range is unavailable`
+        : "";
+      if (labelHtml + availability !== lastLabel) {
+        lastLabel = labelHtml + availability;
+        $("mp-frame").innerHTML = labelHtml;
+        rail.setAttribute("aria-valuemin", String(Math.round(current.viewport.lo)));
+        rail.setAttribute("aria-valuemax", String(Math.round(current.viewport.hi)));
+        rail.setAttribute("aria-valuenow", String(current.selectedFrame));
+        rail.setAttribute(
+          "aria-valuetext",
+          `frame ${current.selectedFrame} of ${Math.round(current.viewport.hi)}` +
+            (outside ? ", outside the frozen viewport" : "") +
+            availability
+        );
       }
-      $btn("mp-pause").textContent = current.paused ? "▶" : "⏸";
+      const pauseBtn = $btn("mp-pause");
+      pauseBtn.textContent = current.paused ? "▶" : "⏸";
+      pauseBtn.setAttribute("aria-label", current.paused ? "Resume" : "Pause");
       // A pane that boots while the session is parked must not run off on its
       // own: keep every seam's pause state converged on the focused pane's.
       // Idempotent, so this costs one boolean read per pane per frame.
@@ -658,10 +799,9 @@ export function initMultiplayerPanes({
   // the pointer at frame rate — a slow poll here reads as a sluggish sim.
   // The label and marker writes are change-guarded; the geometry writes are
   // plain style assignments (same shape as the in-frame scrubber's loop).
-  // At one client the chrono bar is display:none, so painting is skipped.
   let raf = 0;
   const tickLoop = () => {
-    if (panes.length > 1) paint();
+    paint();
     raf = requestAnimationFrame(tickLoop);
   };
   raf = requestAnimationFrame(tickLoop);
@@ -672,7 +812,7 @@ export function initMultiplayerPanes({
       for (const { pane, bridge } of mirrors) {
         bridge.reset();
         setPaneState(pane, "busy");
-        pane.iframe.src = withHiddenScrubber(src);
+        pane.iframe.src = src;
       }
     },
     // Mirror a debounced hot-reload push.

--- a/site/src/sandbox.tsx
+++ b/site/src/sandbox.tsx
@@ -116,11 +116,11 @@ const dismissBootLoader = () =>
 
 const statusBar = createStatusBarStore();
 
-// The pane system mounts at every count, but its chrome is dark at one
-// client — no chrono bar, no pane frame, the stock in-frame scrubber. The
-// single-client chrono unification follows separately with the a11y parity
-// it requires. `getSource` lets a mirror added mid-session catch up to the
-// edited buffer (`view` exists by the time any pane is added).
+// One instrument at every client count: the chrono bar is the transport UI
+// for a single client and for N — the players mount their __scrub seam with
+// no bar of their own (?scrubber=hidden). `getSource` lets a mirror added
+// mid-session catch up to the edited buffer (`view` exists by the time any
+// pane is added).
 mp = initMultiplayerPanes({
   frame,
   count: requestedClients,
@@ -347,7 +347,9 @@ const loadInline = (b64u: string) => {
   // A fresh iframe on a `?src=` data: URL, so the inline program runs its OWN
   // `init` (a set-source push would preserve the default entry's model). The
   // loader derives module `Main` for a non-identifier entry label.
-  frame.src = `player.html?src=${b64u}`;
+  // scrubber=hidden: the page's chrono bar is the transport UI; the player
+  // mounts the __scrub seam with no bar of its own.
+  frame.src = `player.html?src=${b64u}&scrubber=hidden`;
   mp?.setSrc(frame.src);
   return true;
 };
@@ -393,7 +395,7 @@ const loadExample = async (id: string) => {
   // switching examples resets state; the ready announcement re-arms pushes.
   setDoc(source, siblings, assets);
   setStatus("busy", "◌ loading…");
-  const params = new URLSearchParams({ game: url });
+  const params = new URLSearchParams({ game: url, scrubber: "hidden" });
   for (const file of files) params.append("file", file);
   frame.src = `player.html?${params}`;
   mp?.setSrc(frame.src);

--- a/site/styles.css
+++ b/site/styles.css
@@ -2584,6 +2584,17 @@ a:hover {
   pointer-events: auto;
 }
 
+/* A generous invisible hit target around the 2–3px tick (the in-frame bar
+   used an 18px-wide transparent rect for the same reason). */
+.mp-evt::before {
+  content: "";
+  position: absolute;
+  left: -8px;
+  right: -8px;
+  top: -3px;
+  bottom: -3px;
+}
+
 .mp-evt.input {
   background: #ffd166;
   width: 2px;
@@ -3105,7 +3116,7 @@ a:hover {
 
 /* ---- the extrapolation surface (single-client) + rail keyboard focus ---- */
 
-.mp-rail:focus-visible,
+.mp-playhead:focus-visible,
 .mp-preview-handle:focus-visible {
   outline: 2px solid white;
   outline-offset: 2px;

--- a/site/styles.css
+++ b/site/styles.css
@@ -2973,8 +2973,9 @@ a:hover {
 
 .mp-rail-label {
   position: absolute;
-  /* Snug under the rail, still clear of the playhead's focus ring. */
-  top: calc(100% + 2px);
+  /* Hugging the rail's bottom edge (the keyboard-focus ring may overlap the
+     label's first pixel row; acceptable — it only shows while tabbed). */
+  top: calc(100% - 1px);
   left: 50%;
   transform: translateX(-50%);
   font-size: 9px;

--- a/site/styles.css
+++ b/site/styles.css
@@ -2973,9 +2973,10 @@ a:hover {
 
 .mp-rail-label {
   position: absolute;
-  /* Inside the rail, flush under the track (which ends at 18px): the rail
-     box is 30px tall, so hanging the label below it left a 12px void. */
-  top: 20px;
+  /* Tucked 2px up into the rail's bottom edge (reviewed at several offsets;
+     this one read best). A fixed offset, not a percentage, so the label
+     stays put if the rail's height ever changes. */
+  top: calc(100% - 2px);
   left: 50%;
   transform: translateX(-50%);
   font-size: 9px;

--- a/site/styles.css
+++ b/site/styles.css
@@ -2483,7 +2483,9 @@ a:hover {
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 10px 12px 16px;
+  /* Near-equal vertical padding centers the transport row; the label fits
+     inside the trailing 14px. */
+  padding: 12px 12px 14px;
   font: 12px/1 var(--font-mono);
   color: var(--text);
   background: rgba(30, 24, 51, 0.92);
@@ -2971,8 +2973,8 @@ a:hover {
 
 .mp-rail-label {
   position: absolute;
-  /* Clear of the rail's keyboard-focus ring (2px offset below the box). */
-  top: calc(100% + 4px);
+  /* Snug under the rail, still clear of the playhead's focus ring. */
+  top: calc(100% + 2px);
   left: 50%;
   transform: translateX(-50%);
   font-size: 9px;

--- a/site/styles.css
+++ b/site/styles.css
@@ -2483,9 +2483,9 @@ a:hover {
   display: flex;
   align-items: center;
   gap: 10px;
-  /* Near-equal vertical padding centers the transport row; the label fits
-     inside the trailing 14px. */
-  padding: 12px 12px 14px;
+  /* The label lives inside the rail now, so the padding is symmetric and
+     the transport row is truly centered. */
+  padding: 12px;
   font: 12px/1 var(--font-mono);
   color: var(--text);
   background: rgba(30, 24, 51, 0.92);
@@ -2973,9 +2973,9 @@ a:hover {
 
 .mp-rail-label {
   position: absolute;
-  /* Hugging the rail's bottom edge (the keyboard-focus ring may overlap the
-     label's first pixel row; acceptable — it only shows while tabbed). */
-  top: calc(100% - 1px);
+  /* Inside the rail, flush under the track (which ends at 18px): the rail
+     box is 30px tall, so hanging the label below it left a 12px void. */
+  top: 20px;
   left: 50%;
   transform: translateX(-50%);
   font-size: 9px;

--- a/site/styles.css
+++ b/site/styles.css
@@ -2483,7 +2483,7 @@ a:hover {
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 10px 12px 14px;
+  padding: 10px 12px 16px;
   font: 12px/1 var(--font-mono);
   color: var(--text);
   background: rgba(30, 24, 51, 0.92);
@@ -2546,6 +2546,23 @@ a:hover {
 
 .mp-recorded {
   background: rgba(65, 216, 230, 0.3);
+}
+
+/* Striped "history unavailable" regions of a frozen viewport (a reload that
+   could not carry its snapshots): the same hatch as the in-frame scrubber. */
+.mp-unavailable {
+  position: absolute;
+  top: 12px;
+  left: 0;
+  height: 6px;
+  width: 0;
+  border-radius: 3px;
+  background: repeating-linear-gradient(
+    110deg,
+    rgba(155, 148, 179, 0.3) 0 3px,
+    rgba(8, 7, 14, 0.72) 3px 12px
+  );
+  pointer-events: none;
 }
 
 .mp-played {
@@ -2943,7 +2960,8 @@ a:hover {
 
 .mp-rail-label {
   position: absolute;
-  top: 100%;
+  /* Clear of the rail's keyboard-focus ring (2px offset below the box). */
+  top: calc(100% + 4px);
   left: 50%;
   transform: translateX(-50%);
   font-size: 9px;
@@ -2975,13 +2993,12 @@ a:hover {
    header — digits, roles, and link chips are multiplayer vocabulary — and the
    focus glow, since there is nothing to disambiguate. */
 .preview-pane.mp[data-count="1"] .mp-pane-hd,
-.preview-pane.mp[data-count="1"] .mp-tabs,
-.preview-pane.mp[data-count="1"] .mp-chrono {
+.preview-pane.mp[data-count="1"] .mp-tabs {
   display: none;
 }
 
-/* One client is exactly today's sandbox: no chrome frame around the game and
-   the pane's own in-frame scrubber (the chrono bar appears at 2+). */
+/* One client keeps a flush, frameless game view — but the chrono bar above
+   it is the same instrument at every count. */
 .preview-pane.mp[data-count="1"] .mp-grid {
   padding: 0;
   gap: 0;
@@ -3040,10 +3057,18 @@ a:hover {
   pointer-events: none;
 }
 
-/* The 🔮 extrapolation surface ships with the single-client chrono
-   unification (it is single-client-only by design: whole-session forward
-   extrapolation means N speculative re-simulations). Until then the chrono
-   bar carries the view toggle alone. */
+/* 🔮 is single-client only (whole-session forward extrapolation means N
+   speculative re-simulations — not v1); multiplayer gets tiled/tabs in that
+   slot, and with one client the view toggle is meaningless. Hidden, not
+   disabled (design-multiplayer-ide-frontend.md §1). */
+.preview-pane.mp:not([data-count="1"]) #mp-extrap,
+.preview-pane.mp:not([data-count="1"]) .mp-adv {
+  display: none;
+}
+
+.preview-pane.mp[data-count="1"] .mp-viewseg {
+  display: none;
+}
 
 /* ---- second ticks along the rail (every 60 frames; heavier each 5s) ---- */
 
@@ -3073,6 +3098,171 @@ a:hover {
 
 .mp-link-menu input[type="number"]::-webkit-inner-spin-button,
 .mp-link-menu input[type="number"]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+
+/* ---- the extrapolation surface (single-client) + rail keyboard focus ---- */
+
+.mp-rail:focus-visible,
+.mp-preview-handle:focus-visible {
+  outline: 2px solid white;
+  outline-offset: 2px;
+}
+
+.mp-rail-label .fut {
+  color: var(--pink);
+}
+
+.mp-rail-label .out {
+  color: #ffd166;
+}
+
+/* Playhead parked outside the frozen viewport: a white ring on top of its
+   normal glow (mirrors the in-frame scrubber's outside state). */
+.mp-playhead.outside {
+  box-shadow:
+    0 0 0 2px rgba(255, 255, 255, 0.55),
+    0 0 12px rgba(65, 216, 230, 0.6);
+}
+
+.mp-future {
+  position: absolute;
+  top: 11px;
+  height: 8px;
+  border-radius: 3px;
+  background: var(--pink);
+  opacity: 0.9;
+  box-shadow: 0 0 10px rgba(232, 88, 184, 0.5);
+}
+
+#mp-extrap.on {
+  border-color: var(--pink);
+  box-shadow: 0 0 0 1px var(--pink), 0 2px 10px rgba(232, 88, 184, 0.4);
+}
+
+.mp-preview-handle {
+  display: none;
+  position: absolute;
+  top: 15px;
+  z-index: 3;
+  width: 14px;
+  height: 20px;
+  border-radius: 4px;
+  transform: translate(-50%, -50%);
+  background: var(--pink);
+  border: 1px solid #ffd0ee;
+  box-shadow: 0 0 12px rgba(232, 88, 184, 0.6);
+  cursor: ew-resize;
+  touch-action: none;
+}
+
+.mp-preview-handle.clipped {
+  border-radius: 4px 0 0 4px;
+}
+
+/* Fully clipped (the endpoint sits on the playhead): perch above the rail so
+   the cyan playhead stays independently visible and hittable. */
+.mp-preview-handle.fully-clipped {
+  top: 0;
+  z-index: 5;
+  height: 12px;
+}
+
+.mp-overflow {
+  display: none;
+  position: absolute;
+  right: 0;
+  top: -6px;
+  z-index: 4;
+  padding: 2px 4px;
+  border: 1px solid var(--pink);
+  border-radius: 5px;
+  color: #ffd0ee;
+  background: rgba(30, 24, 51, 0.96);
+  font-size: 9px;
+  pointer-events: none;
+}
+
+.mp-adv {
+  position: relative;
+}
+
+.mp-adv > summary {
+  list-style: none;
+  user-select: none;
+  font: 13px/1 var(--font-mono);
+  color: var(--text);
+  cursor: pointer;
+  background: rgba(65, 216, 230, 0.1);
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  padding: 5px 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
+}
+
+.mp-adv > summary::-webkit-details-marker {
+  display: none;
+}
+
+.mp-adv > summary:hover,
+.mp-adv[open] > summary {
+  border-color: var(--cyan);
+}
+
+.mp-adv-pop {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  z-index: 30;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  background: rgba(30, 24, 51, 0.98);
+  border-radius: 8px;
+  border: 1px solid var(--line);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.5);
+  white-space: nowrap;
+  font-size: 12px;
+}
+
+.mp-adv-pop label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  justify-content: space-between;
+}
+
+.mp-adv-pop select,
+.mp-adv-pop input[type="number"] {
+  font: 12px/1 var(--font-mono);
+  color: var(--text);
+  background: rgba(65, 216, 230, 0.1);
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  padding: 4px 5px;
+}
+
+.mp-adv-pop select {
+  appearance: none;
+  -webkit-appearance: none;
+  padding-right: 20px;
+  cursor: pointer;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='5'%3E%3Cpath d='M0 0h8L4 5z' fill='%239b94b3'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 7px center;
+}
+
+.mp-adv-pop input[type="number"] {
+  width: 46px;
+  appearance: textfield;
+  -moz-appearance: textfield;
+}
+
+.mp-adv-pop input[type="number"]::-webkit-inner-spin-button,
+.mp-adv-pop input[type="number"]::-webkit-outer-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }


### PR DESCRIPTION
The final PR of the multiplayer dev-experience frontend stack (#522 #523 #524 #526): the sandbox's transport UI is the **host chrono bar at every client count**, single included.

- Players boot with `?scrubber=hidden` (#524's seam-without-chrome), so the in-frame overlay never mounts in the sandbox; the reversible style-injection hack from #526 is **deleted**. The hero card, standalone player, CLI dev-server page, and VSCode preview keep their in-frame bar.
- The **extrapolation surface returns** (🔮, ⚙ show/window/rate, preview handle, future bar, clip chip, `+N` label), single-client only — and the ⚙ ghost-mode now goes **through the seam** (`setPreview({ mode })` in scrubber.js) instead of the cross-frame DOM reach the #526 review correctly called unworkable on detached DOM.
- **A11y parity** with the bar it replaces: the rail is a real slider (role/tabindex/`aria-value*`, arrows / Shift-arrows / PageUp/Down / Home/End broadcast-seek), the preview handle is keyboard-adjustable, pause has a live aria-label, and the host bar renders the in-frame bar's unavailable-history stripes, outside-viewport playhead ring, and availability `aria-valuetext`.
- **e2e re-pointed, not weakened**: every sandbox scrubber check asserts the same semantics against the host bar (plus a new inversion check: the frame has `window.__scrub` and no `#scrubber`). Hero and pure-seam checks untouched. **111 checks pass** — one more than main.

Verified: `check:site` clean; `npm run test:site` ALL CHECKS PASSED (agent run + independent re-run); headless probes for the unified N=1 chrome (chrono visible, 🔮 present, view toggle hidden, seam-no-bar), extrapolation (future bar, handle, +N), and rail keyboard seek. Captures + xreview to follow before ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Before → after

The single-client sandbox's scrubber moves out of the game iframe's bottom overlay into the host chrono bar docked above the game — same rail, 🔮 extrapolation, and ⚙ settings at every client count.

![before/after — sandbox scrubber to host chrono bar](https://gist.githubusercontent.com/tommy-xr/cf1f99a440962ea18179615d056d3c0d/raw/beforeafter.png)

Extrapolation from the chrono bar (paused mid-rail, 🔮 +120 frames): pink future segment + handle on the rail, ghost trails in the scene.

![extrapolation still](https://gist.githubusercontent.com/tommy-xr/cf1f99a440962ea18179615d056d3c0d/raw/after-extrap.png)

<sub>Captured headlessly via Playwright at 1600×950 against `site/serve.mjs` builds of base and branch.</sub>



## Review dispositions (xreview: Claude + Codex, media-verified)

All Critical/High findings fixed and re-verified (suite green at 111, plus targeted probes):

- **[AGREED] weakened marker e2e check masking lost selection behavior** → the host marker click now `selectEvent()`s (highlight/activeEvent/Escape-deselect parity) and the original selection assertion is restored.
- **[AGREED] played band painted over the unavailable stripes** → in-frame geometry (`recordedStart → min(playhead, recordedEnd)`).
- **[AGREED] extrapolation orphaned on 1→N with its controls hidden** → leaving single-client disables the preview and closes ⚙ (probed).
- **[AGREED] ARIA range metadata** → slider role moved to the playhead (no nested focusable widgets), `valuemax ≥ valuenow` in the frozen state, real `aria-value*` on the preview handle, Home/End seek recorded bounds.
- **Stale ⚙ vs a fresh seam** (Codex) → host-owned config pushed on primary-seam change.
- Plus: availability text mirrors `describeRecordedAvailability` (incl. no-history), 18px marker hit targets + focus tooltips, fuller preview-handle keyboard parity, `lostpointercapture`, and `setPreview({mode})` validation in the seam.

**Acknowledged, deferred with rationale:** consolidating the hand-mirrored `TimelineView` interface / availability copy by importing `timeline-model.js` directly — it's untyped JS outside `site/tsconfig`'s include, so doing it properly means a declaration file; queued as a follow-up rather than growing this PR.