### PR TITLE
feat(cli): author a game entirely over MCP

### DIFF
--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -27,6 +27,12 @@ impl Template {
         }
     }
 
+    /// The file names this template writes — the scaffolder's own answer, so
+    /// callers that report them (the `init_game` MCP tool) cannot drift.
+    pub fn file_names(&self) -> [&'static str; 2] {
+        self.files().map(|file| file.name)
+    }
+
     fn files(&self) -> [TemplateFile; 2] {
         let game = match self {
             Self::ThreeD => GAME_3D,

--- a/cli/src/commands/mcp.rs
+++ b/cli/src/commands/mcp.rs
@@ -113,14 +113,29 @@ impl Drop for ScratchDir {
 /// Create a fresh directory this server owns, under the system temp dir.
 fn scratch_dir() -> Result<ScratchDir, String> {
     static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-    let suffix = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let path = std::env::temp_dir().join(format!("functor-mcp-{}-{suffix}", std::process::id()));
-    // `create_dir` rather than `create_dir_all`: the name is unique per
-    // process, so an existing one is someone else's directory, not ours to
-    // fill and later delete.
-    std::fs::create_dir(&path)
-        .map_err(|error| format!("could not create a scratch project dir: {error}"))?;
-    Ok(ScratchDir(path))
+    let mut last = String::new();
+    // `create_dir` rather than `create_dir_all`: an existing directory of this
+    // name is someone else's (a killed earlier server with the same pid), not
+    // ours to fill and later delete — so take the next name instead.
+    for _ in 0..16 {
+        let suffix = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let path =
+            std::env::temp_dir().join(format!("functor-mcp-{}-{suffix}", std::process::id()));
+        match std::fs::create_dir(&path) {
+            Ok(()) => {
+                // The game's source is the client's, and on a shared /tmp the
+                // default would be world-readable.
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt as _;
+                    let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o700));
+                }
+                return Ok(ScratchDir(path));
+            }
+            Err(error) => last = error.to_string(),
+        }
+    }
+    Err(format!("could not create a scratch project dir: {last}"))
 }
 
 #[derive(Default)]
@@ -333,6 +348,11 @@ pub struct SaveProjectArgs {
     /// Directory to write the project into, absolute or relative to the MCP
     /// server's working directory. Created if it does not exist.
     pub dir: String,
+    /// Replace a project already in `dir` (default false, which refuses):
+    /// its `.fun`/`.funi` modules are overwritten, and any this session does
+    /// NOT have is deleted, so the directory ends up being exactly the
+    /// running program. Its `functor.json` is kept.
+    pub overwrite: Option<bool>,
 }
 
 #[derive(Deserialize, JsonSchema)]
@@ -509,7 +529,7 @@ files writes the inline project to a scratch directory this server owns",
                 "port": port,
                 "mode": mode,
                 "owned": true,
-                "dir": dir.display().to_string(),
+                "dir": absolute(&dir),
                 "discovery": discovery,
             })
             .to_string(),
@@ -853,7 +873,7 @@ or \"fps\" (a first-person WASD + mouse-look scene)"
             serde_json::json!({
                 "dir": absolute(&dir),
                 "template": name,
-                "files": ["functor.json", "game.fun"],
+                "files": template.file_names(),
             })
             .to_string(),
         )
@@ -863,8 +883,10 @@ or \"fps\" (a first-person WASD + mouse-look scene)"
     /// authored over the wire gets a durable home. The sources come from the
     /// RUNTIME (`GET /project`), so they are what it is actually running,
     /// including every `reload_source`/`reload_project` edit that never
-    /// touched a file. A `functor.json` is written when the project has none.
-    /// Refuses a directory that already holds a DIFFERENT project.
+    /// touched a file. A single-entry `functor.json` is synthesized when the
+    /// directory has none (a project's own manifest is never rewritten, and a
+    /// multi-entry one is not reconstructed). A directory that already holds a
+    /// project is REFUSED unless `overwrite` is true.
     #[tool]
     async fn save_project(
         &self,
@@ -873,19 +895,27 @@ or \"fps\" (a first-person WASD + mouse-look scene)"
         let url = resolve!(self.url(&args.session));
         let body = match self.get(&url, "/project").await {
             Ok(body) => body,
-            Err(message) => {
+            // A 404 is specifically "this runtime predates the route"; a 501
+            // is a producer that has no sources at all, which rebuilding
+            // would not change.
+            Err(message) if message.contains("→ 404") => {
                 return tool_error(format!(
                     "{message}\n\nsave_project asks the runtime for its sources (an edited \
-session's source may exist nowhere else). A runtime older than debug protocol v5 has no \
-GET /project — rebuild it from this version of Functor."
+session's source may exist nowhere else), and GET /project needs debug protocol v5 — \
+rebuild that runtime from this version of Functor."
                 ))
             }
+            Err(message) => return tool_error(message),
         };
         let files: Vec<(String, String)> = resolve!(serde_json::from_str(&body).map_err(
             |error| format!("GET /project did not return [path, source] pairs: {error}")
         ));
         let dir = std::path::PathBuf::from(&args.dir);
-        let written = resolve!(save_project_to(&dir, &files));
+        let written = resolve!(save_project_to(
+            &dir,
+            &files,
+            args.overwrite.unwrap_or(false)
+        ));
         ok_text(
             serde_json::json!({
                 "dir": absolute(&dir),
@@ -1184,7 +1214,7 @@ fn absolute(dir: &std::path::Path) -> String {
 /// that carries none. Named entries are a project-file concern; an inline
 /// project is by construction the single-entry case.
 fn synthesized_manifest(entry: &str) -> String {
-    format!("{{\n  \"language\": \"functor-lang\",\n  \"entry\": \"{entry}\"\n}}\n")
+    serde_json::json!({ "language": "functor-lang", "entry": entry }).to_string()
 }
 
 /// A pushed file's path must name a file INSIDE the project directory: these
@@ -1253,31 +1283,61 @@ fn write_project_files(dir: &std::path::Path, files: &[(String, String)]) -> Res
     Ok(())
 }
 
+/// The project files already in `dir` — its manifest and modules, sorted.
+/// Anything else there (a README, assets) is not this tool's business.
+fn existing_project_files(dir: &std::path::Path) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut found: Vec<String> = entries
+        .filter_map(|entry| entry.ok()?.file_name().into_string().ok())
+        .filter(|name| name == "functor.json" || name.ends_with(".fun") || name.ends_with(".funi"))
+        .collect();
+    found.sort();
+    found
+}
+
 /// Persist a session's sources into `dir`, returning what was written.
-/// Re-saving the same project overwrites it (that is the point — the wire is
-/// newer than the disk), but a directory holding a DIFFERENT project is
-/// refused rather than merged into.
+///
+/// A directory that already holds a project is refused unless `overwrite` —
+/// "it has the same entry file name" is not evidence that it is the same
+/// project, since nearly every Functor project's entry is `game.fun`. With
+/// `overwrite`, modules this session does NOT have are removed as well:
+/// `file = module`, so a leftover sibling would still load and the saved copy
+/// would not be the program that ran.
 fn save_project_to(
     dir: &std::path::Path,
     files: &[(String, String)],
+    overwrite: bool,
 ) -> Result<Vec<String>, String> {
     let entry = entry_of(files)?.to_string();
-    let manifest = dir.join("functor.json");
-    if manifest.exists() && !dir.join(&entry).exists() {
+    let existing = existing_project_files(dir);
+    if !existing.is_empty() && !overwrite {
         return Err(format!(
-            "{} already holds a different project (it has a functor.json but no {entry}) — \
-save to a new directory, or remove that project first",
-            dir.display()
+            "{} already holds a project ({}) — save to a new directory, or pass \
+overwrite: true to replace it",
+            dir.display(),
+            existing.join(", ")
         ));
     }
     let mut files = files.to_vec();
     // The manifest is not part of what the runtime reports, so write one for a
-    // project that has none — and never clobber the one already there, which
+    // project that has none — and never rewrite the one already there, which
     // may declare named entries this session's sources cannot describe.
-    if !files.iter().any(|(path, _)| path == "functor.json") && !manifest.exists() {
+    if !files.iter().any(|(path, _)| path == "functor.json")
+        && !existing.iter().any(|name| name == "functor.json")
+    {
         files.push(("functor.json".to_string(), synthesized_manifest(&entry)));
     }
     write_project_files(dir, &files)?;
+    for stale in existing
+        .iter()
+        .filter(|name| name.ends_with(".fun") || name.ends_with(".funi"))
+        .filter(|name| !files.iter().any(|(path, _)| path == *name))
+    {
+        std::fs::remove_file(dir.join(stale))
+            .map_err(|error| format!("could not remove the stale module {stale}: {error}"))?;
+    }
     Ok(files.into_iter().map(|(path, _)| path).collect())
 }
 
@@ -1510,6 +1570,7 @@ mod tests {
                 ("game.fun".into(), "let init = 1".into()),
                 ("util.fun".into(), "let k = 2".into()),
             ],
+            false,
         )
         .unwrap();
 
@@ -1518,36 +1579,68 @@ mod tests {
             std::fs::read_to_string(dir.join("game.fun")).unwrap(),
             "let init = 1"
         );
-        assert!(dir.join("functor.json").is_file());
+        let manifest: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(dir.join("functor.json")).unwrap())
+                .unwrap();
+        assert_eq!(manifest["entry"], "game.fun");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
-        // Re-saving the SAME project overwrites it: the wire is the newer
-        // copy, which is the whole reason this tool exists.
-        super::save_project_to(&dir, &[("game.fun".into(), "let init = 2".into())]).unwrap();
+    /// The saved directory must BE the running program — `file = module`, so a
+    /// module the session dropped would still load from a stale file.
+    #[test]
+    fn overwriting_replaces_the_sources_and_removes_modules_the_session_lost() {
+        let dir =
+            std::env::temp_dir().join(format!("functor-mcp-save-again-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        super::save_project_to(
+            &dir,
+            &[
+                ("game.fun".into(), "let init = 1".into()),
+                ("util.fun".into(), "let k = 2".into()),
+            ],
+            false,
+        )
+        .unwrap();
+        std::fs::write(dir.join("functor.json"), "{\"entry\":\"game.fun\"}").unwrap();
+
+        super::save_project_to(&dir, &[("game.fun".into(), "let init = 2".into())], true).unwrap();
+
         assert_eq!(
             std::fs::read_to_string(dir.join("game.fun")).unwrap(),
             "let init = 2"
         );
+        assert!(!dir.join("util.fun").exists(), "a dropped module is removed");
+        assert_eq!(
+            std::fs::read_to_string(dir.join("functor.json")).unwrap(),
+            "{\"entry\":\"game.fun\"}",
+            "an existing manifest is never rewritten"
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    /// Nearly every Functor project's entry is named `game.fun`, so a matching
+    /// entry name is no evidence that this is the same project: saving into an
+    /// occupied directory takes an explicit `overwrite`.
     #[test]
-    fn saving_refuses_a_directory_holding_a_different_project() {
+    fn saving_refuses_a_directory_that_already_holds_a_project() {
         let dir =
             std::env::temp_dir().join(format!("functor-mcp-save-other-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("functor.json"), "{}").unwrap();
-        std::fs::write(dir.join("theirs.fun"), "let init = 0").unwrap();
+        std::fs::write(dir.join("game.fun"), "someone else's game").unwrap();
 
-        let error = super::save_project_to(&dir, &[("game.fun".into(), "let init = 1".into())])
-            .unwrap_err();
+        let error =
+            super::save_project_to(&dir, &[("game.fun".into(), "let init = 1".into())], false)
+                .unwrap_err();
 
-        assert!(error.contains("different project"), "{error}");
-        assert!(!dir.join("game.fun").exists(), "nothing may be written");
+        assert!(error.contains("already holds a project"), "{error}");
+        assert!(error.contains("overwrite"), "{error}");
         assert_eq!(
-            std::fs::read_to_string(dir.join("functor.json")).unwrap(),
-            "{}",
-            "the existing manifest is untouched"
+            std::fs::read_to_string(dir.join("game.fun")).unwrap(),
+            "someone else's game",
+            "nothing may be written"
         );
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/cli/src/commands/mcp.rs
+++ b/cli/src/commands/mcp.rs
@@ -91,6 +91,36 @@ struct Session {
     /// `Some` only when this server spawned the runtime. An attached session
     /// (`connect_game`) is never killed — the runtime belongs to someone else.
     child: Option<Child>,
+    /// The temporary project directory written for an inline `launch_game`,
+    /// held so it lives exactly as long as the session that runs from it.
+    /// Never read — its `Drop` is the whole point.
+    #[allow(dead_code)]
+    scratch: Option<ScratchDir>,
+}
+
+/// A project directory this server created and owns. Dropping it (when the
+/// session is stopped, or when the whole server shuts down) removes the
+/// directory — an inline-launched game's source has no durable home unless
+/// `save_project` gives it one.
+struct ScratchDir(std::path::PathBuf);
+
+impl Drop for ScratchDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+/// Create a fresh directory this server owns, under the system temp dir.
+fn scratch_dir() -> Result<ScratchDir, String> {
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let suffix = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let path = std::env::temp_dir().join(format!("functor-mcp-{}-{suffix}", std::process::id()));
+    // `create_dir` rather than `create_dir_all`: the name is unique per
+    // process, so an existing one is someone else's directory, not ours to
+    // fill and later delete.
+    std::fs::create_dir(&path)
+        .map_err(|error| format!("could not create a scratch project dir: {error}"))?;
+    Ok(ScratchDir(path))
 }
 
 #[derive(Default)]
@@ -105,11 +135,24 @@ struct Registry {
 }
 
 impl Registry {
-    fn insert(&mut self, url: String, port: Option<u16>, child: Option<Child>) -> String {
+    fn insert(
+        &mut self,
+        url: String,
+        port: Option<u16>,
+        child: Option<Child>,
+        scratch: Option<ScratchDir>,
+    ) -> String {
         self.next_id += 1;
         let id = format!("s{}", self.next_id);
-        self.sessions
-            .insert(id.clone(), Session { url, port, child });
+        self.sessions.insert(
+            id.clone(),
+            Session {
+                url,
+                port,
+                child,
+                scratch,
+            },
+        );
         id
     }
 
@@ -202,8 +245,14 @@ macro_rules! resolve {
 #[derive(Deserialize, JsonSchema)]
 pub struct LaunchArgs {
     /// Project directory (the one holding `functor.json`), absolute or relative
-    /// to the MCP server's working directory.
-    pub dir: String,
+    /// to the MCP server's working directory. Give this OR `files`.
+    pub dir: Option<String>,
+    /// `[path, source]` pairs — the whole project inline, entry `.fun` first.
+    /// The server writes them to a scratch directory it owns and removes when
+    /// the session stops, so a client with no filesystem can run a game it
+    /// just wrote. A `functor.json` pair is honored; without one the server
+    /// synthesizes a single-entry manifest. Give this OR `dir`.
+    pub files: Option<Vec<(String, String)>>,
     /// Named entry, for a project whose functor.json declares `entries`.
     pub entry: Option<String>,
     /// `"hidden"` (default) renders into an invisible window — `capture_frame`
@@ -270,6 +319,23 @@ pub struct ReloadProjectArgs {
 }
 
 #[derive(Deserialize, JsonSchema)]
+pub struct InitGameArgs {
+    /// Directory to scaffold, absolute or relative to the MCP server's
+    /// working directory. It is created if it does not exist.
+    pub dir: String,
+    /// `"3d"` (default — a small lit scene) or `"fps"` (WASD + mouse-look).
+    pub template: Option<String>,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct SaveProjectArgs {
+    pub session: String,
+    /// Directory to write the project into, absolute or relative to the MCP
+    /// server's working directory. Created if it does not exist.
+    pub dir: String,
+}
+
+#[derive(Deserialize, JsonSchema)]
 pub struct ApiReferenceArgs {
     /// What to look for, matched case-insensitively against item names,
     /// qualified paths (`Scene.cube`), signatures and doc text. Omit it (with
@@ -323,9 +389,12 @@ impl FunctorMcp {
     }
 
     /// Start a game as a child process with its debug server on a free port,
-    /// and return its session id. Defaults to `hidden` mode (an invisible GL
-    /// window, so `capture_frame` returns pixels); `headless` needs no display
-    /// or GPU at all but has no pixels, so `capture_frame` fails there.
+    /// and return its session id. The project comes from `dir` (a directory
+    /// holding `functor.json`) OR from `files` — the whole project inline, so
+    /// a client with no filesystem can run a game it just wrote. Defaults to
+    /// `hidden` mode (an invisible GL window, so `capture_frame` returns
+    /// pixels); `headless` needs no display or GPU at all but has no pixels,
+    /// so `capture_frame` fails there.
     #[tool]
     async fn launch_game(
         &self,
@@ -342,6 +411,32 @@ or \"headless\" (no GL, no capture)"
                 ))
             }
         };
+        // Exactly one source of game source: a project already on disk, or the
+        // whole project inline. The inline form is written to a scratch
+        // directory this server owns and then launched like any other, so the
+        // runtime's own load path, file-watch hot reload, and `reload_source`
+        // all keep working afterwards.
+        let (dir, scratch) = match (&args.dir, &args.files) {
+            (Some(dir), None) => (std::path::PathBuf::from(dir), None),
+            (None, Some(files)) => {
+                let files = resolve!(scratch_project_files(files));
+                let scratch = resolve!(scratch_dir());
+                resolve!(write_project_files(&scratch.0, &files));
+                (scratch.0.clone(), Some(scratch))
+            }
+            (Some(_), Some(_)) => {
+                return tool_error(
+                    "give dir OR files, not both: dir launches a project already on disk, \
+files writes the inline project to a scratch directory this server owns",
+                )
+            }
+            (None, None) => {
+                return tool_error(
+                    "give dir (a project directory holding functor.json) or files \
+([path, source] pairs, the entry .fun first) to launch a project that is not on disk",
+                )
+            }
+        };
         let port = resolve!(self
             .sessions
             .lock()
@@ -351,7 +446,7 @@ or \"headless\" (no GL, no capture)"
             .map_err(|error| format!("cannot locate the functor executable: {error}")));
 
         let mut command = Command::new(exe);
-        command.arg("-d").arg(&args.dir);
+        command.arg("-d").arg(&dir);
         if let Some(entry) = &args.entry {
             command.arg("--entry").arg(entry);
         }
@@ -405,6 +500,7 @@ or \"headless\" (no GL, no capture)"
             url.clone(),
             Some(port),
             Some(child),
+            scratch,
         );
         ok_text(
             serde_json::json!({
@@ -413,6 +509,7 @@ or \"headless\" (no GL, no capture)"
                 "port": port,
                 "mode": mode,
                 "owned": true,
+                "dir": dir.display().to_string(),
                 "discovery": discovery,
             })
             .to_string(),
@@ -429,11 +526,11 @@ or \"headless\" (no GL, no capture)"
     ) -> Result<CallToolResult, ErrorData> {
         let url = args.url.trim_end_matches('/').to_string();
         let discovery = resolve!(self.discover(&url).await);
-        let id =
-            self.sessions
-                .lock()
-                .expect("mcp registry poisoned")
-                .insert(url.clone(), None, None);
+        let id = self
+            .sessions
+            .lock()
+            .expect("mcp registry poisoned")
+            .insert(url.clone(), None, None, None);
         ok_text(
             serde_json::json!({
                 "session": id,
@@ -726,6 +823,78 @@ context at all — relaunch it with mode \"hidden\" to capture frames.",
             .await
     }
 
+    /// Scaffold a new project on disk — the same `functor.json` + `game.fun`
+    /// starter `functor init` writes. `template` is `"3d"` (default, a small
+    /// lit scene) or `"fps"` (WASD + mouse-look). Existing files are never
+    /// overwritten. The directory it returns is ready to pass straight to
+    /// `launch_game`'s `dir`.
+    #[tool]
+    async fn init_game(
+        &self,
+        Parameters(args): Parameters<InitGameArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let name = args.template.as_deref().unwrap_or("3d");
+        let template = match name {
+            "3d" => crate::commands::init::Template::ThreeD,
+            "fps" => crate::commands::init::Template::Fps,
+            other => {
+                return tool_error(format!(
+                    "unknown template {other:?}: expected \"3d\" (a small lit 3D scene) \
+or \"fps\" (a first-person WASD + mouse-look scene)"
+                ))
+            }
+        };
+        let dir = std::path::PathBuf::from(&args.dir);
+        // The scaffolder's own refusal to overwrite is the contract here: a
+        // half-written project is worse than a failed call.
+        resolve!(crate::commands::init::execute(&dir, &template)
+            .map_err(|error| format!("could not initialize a project: {error}")));
+        ok_text(
+            serde_json::json!({
+                "dir": absolute(&dir),
+                "template": name,
+                "files": ["functor.json", "game.fun"],
+            })
+            .to_string(),
+        )
+    }
+
+    /// Write a session's CURRENT project source to a directory — how a game
+    /// authored over the wire gets a durable home. The sources come from the
+    /// RUNTIME (`GET /project`), so they are what it is actually running,
+    /// including every `reload_source`/`reload_project` edit that never
+    /// touched a file. A `functor.json` is written when the project has none.
+    /// Refuses a directory that already holds a DIFFERENT project.
+    #[tool]
+    async fn save_project(
+        &self,
+        Parameters(args): Parameters<SaveProjectArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let url = resolve!(self.url(&args.session));
+        let body = match self.get(&url, "/project").await {
+            Ok(body) => body,
+            Err(message) => {
+                return tool_error(format!(
+                    "{message}\n\nsave_project asks the runtime for its sources (an edited \
+session's source may exist nowhere else). A runtime older than debug protocol v5 has no \
+GET /project — rebuild it from this version of Functor."
+                ))
+            }
+        };
+        let files: Vec<(String, String)> = resolve!(serde_json::from_str(&body).map_err(
+            |error| format!("GET /project did not return [path, source] pairs: {error}")
+        ));
+        let dir = std::path::PathBuf::from(&args.dir);
+        let written = resolve!(save_project_to(&dir, &files));
+        ok_text(
+            serde_json::json!({
+                "dir": absolute(&dir),
+                "files": written,
+            })
+            .to_string(),
+        )
+    }
+
     /// Hot-reload every sibling module at once from `[path, source]` pairs,
     /// entry first, preserving the live model. A load error is returned
     /// verbatim and the old program keeps running.
@@ -880,7 +1049,10 @@ get_trace, capture_frame) and drive it (pause, send_input, step, resume, rewind,
 reload_source). The deterministic loop is pause → send_input → step → get_state: while the \
 clock is pinned nothing advances on its own, and injected input is level state that holds \
 across steps. api_reference searches the engine's prelude API and needs no session, so it \
-answers language/API questions before anything is launched."
+answers language/API questions before anything is launched. A game can also be AUTHORED \
+here with no filesystem of your own: launch_game with inline `files` runs source that has \
+no home, reload_source edits it live, and save_project writes what the runtime is actually \
+running to a directory. init_game scaffolds a starter project on disk instead."
 )]
 impl ServerHandler for FunctorMcp {}
 
@@ -997,6 +1169,116 @@ fn render_api_hits(hits: &[ApiHit], limit: Option<usize>) -> String {
         ));
     }
     out
+}
+
+/// A path for display: absolute where the filesystem can say so, and the
+/// path as given otherwise (a directory that no longer exists, say).
+fn absolute(dir: &std::path::Path) -> String {
+    std::fs::canonicalize(dir)
+        .unwrap_or_else(|_| dir.to_path_buf())
+        .display()
+        .to_string()
+}
+
+/// The `functor.json` a project needs to be launchable, for a pushed file set
+/// that carries none. Named entries are a project-file concern; an inline
+/// project is by construction the single-entry case.
+fn synthesized_manifest(entry: &str) -> String {
+    format!("{{\n  \"language\": \"functor-lang\",\n  \"entry\": \"{entry}\"\n}}\n")
+}
+
+/// A pushed file's path must name a file INSIDE the project directory: these
+/// paths become real writes, and the file set arrives over the wire.
+fn check_project_path(path: &str) -> Result<(), String> {
+    if path.is_empty() {
+        return Err("a project file needs a path".to_string());
+    }
+    if path.contains('\\') {
+        return Err(format!("{path:?} must use forward slashes"));
+    }
+    if path.starts_with('/') || path.contains(':') {
+        return Err(format!("{path:?} must be a project-relative path"));
+    }
+    if path
+        .split('/')
+        .any(|segment| segment.is_empty() || segment == "." || segment == "..")
+    {
+        return Err(format!(
+            "{path:?} must not contain empty, `.` or `..` segments"
+        ));
+    }
+    Ok(())
+}
+
+/// The entry module of a file set: the first `.fun`. `functor.json` may travel
+/// with the sources, so "the first file" is not enough on its own.
+fn entry_of(files: &[(String, String)]) -> Result<&str, String> {
+    for (path, _) in files {
+        check_project_path(path)?;
+    }
+    files
+        .iter()
+        .map(|(path, _)| path.as_str())
+        .find(|path| path.ends_with(".fun"))
+        .ok_or_else(|| "a project needs at least one .fun file (the entry, first)".to_string())
+}
+
+/// The complete file set to write for an inline `launch_game`: the caller's
+/// files, plus the manifest the runtime's load path requires when they did
+/// not supply one.
+fn scratch_project_files(files: &[(String, String)]) -> Result<Vec<(String, String)>, String> {
+    let entry = entry_of(files)?.to_string();
+    let mut files = files.to_vec();
+    if !files.iter().any(|(path, _)| path == "functor.json") {
+        files.push(("functor.json".to_string(), synthesized_manifest(&entry)));
+    }
+    Ok(files)
+}
+
+/// Write a project's files into `dir`, creating it (and any subdirectories the
+/// paths name).
+fn write_project_files(dir: &std::path::Path, files: &[(String, String)]) -> Result<(), String> {
+    std::fs::create_dir_all(dir)
+        .map_err(|error| format!("could not create {}: {error}", dir.display()))?;
+    for (path, source) in files {
+        check_project_path(path)?;
+        let target = dir.join(path);
+        if let Some(parent) = target.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|error| format!("could not create {}: {error}", parent.display()))?;
+        }
+        std::fs::write(&target, source)
+            .map_err(|error| format!("could not write {}: {error}", target.display()))?;
+    }
+    Ok(())
+}
+
+/// Persist a session's sources into `dir`, returning what was written.
+/// Re-saving the same project overwrites it (that is the point — the wire is
+/// newer than the disk), but a directory holding a DIFFERENT project is
+/// refused rather than merged into.
+fn save_project_to(
+    dir: &std::path::Path,
+    files: &[(String, String)],
+) -> Result<Vec<String>, String> {
+    let entry = entry_of(files)?.to_string();
+    let manifest = dir.join("functor.json");
+    if manifest.exists() && !dir.join(&entry).exists() {
+        return Err(format!(
+            "{} already holds a different project (it has a functor.json but no {entry}) — \
+save to a new directory, or remove that project first",
+            dir.display()
+        ));
+    }
+    let mut files = files.to_vec();
+    // The manifest is not part of what the runtime reports, so write one for a
+    // project that has none — and never clobber the one already there, which
+    // may declare named entries this session's sources cannot describe.
+    if !files.iter().any(|(path, _)| path == "functor.json") && !manifest.exists() {
+        files.push(("functor.json".to_string(), synthesized_manifest(&entry)));
+    }
+    write_project_files(dir, &files)?;
+    Ok(files.into_iter().map(|(path, _)| path).collect())
 }
 
 /// The runtime's current time, from a `/state` document. Never defaulted: a
@@ -1177,10 +1459,104 @@ mod tests {
     }
 
     #[test]
+    fn an_inline_project_gets_a_manifest_naming_its_entry() {
+        let files =
+            super::scratch_project_files(&[("game.fun".into(), "let init = { n: 0.0 }".into())])
+                .unwrap();
+
+        assert_eq!(files.len(), 2);
+        let (path, manifest) = &files[1];
+        assert_eq!(path, "functor.json");
+        let parsed: serde_json::Value = serde_json::from_str(manifest).unwrap();
+        assert_eq!(parsed["language"], "functor-lang");
+        assert_eq!(parsed["entry"], "game.fun");
+    }
+
+    /// The entry is the first `.fun`, not the first file: a caller may push
+    /// its own manifest ahead of the sources.
+    #[test]
+    fn a_supplied_manifest_is_kept_and_does_not_become_the_entry() {
+        let files = super::scratch_project_files(&[
+            ("functor.json".into(), "{\"entry\":\"main.fun\"}".into()),
+            ("main.fun".into(), "let init = 1".into()),
+        ])
+        .unwrap();
+
+        assert_eq!(files.len(), 2, "no manifest is synthesized: {files:?}");
+        assert_eq!(super::entry_of(&files).unwrap(), "main.fun");
+    }
+
+    #[test]
+    fn a_file_set_with_no_module_or_an_escaping_path_is_refused() {
+        let no_module =
+            super::scratch_project_files(&[("readme.md".into(), "hi".into())]).unwrap_err();
+        assert!(no_module.contains(".fun"), "{no_module}");
+
+        for path in ["../evil.fun", "/etc/evil.fun", "a//b.fun", ""] {
+            let error =
+                super::scratch_project_files(&[(path.into(), "let init = 1".into())]).unwrap_err();
+            assert!(!error.is_empty(), "{path} must be refused");
+        }
+    }
+
+    #[test]
+    fn saving_writes_the_sources_and_a_manifest() {
+        let dir = std::env::temp_dir().join(format!("functor-mcp-save-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let written = super::save_project_to(
+            &dir,
+            &[
+                ("game.fun".into(), "let init = 1".into()),
+                ("util.fun".into(), "let k = 2".into()),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(written, vec!["game.fun", "util.fun", "functor.json"]);
+        assert_eq!(
+            std::fs::read_to_string(dir.join("game.fun")).unwrap(),
+            "let init = 1"
+        );
+        assert!(dir.join("functor.json").is_file());
+
+        // Re-saving the SAME project overwrites it: the wire is the newer
+        // copy, which is the whole reason this tool exists.
+        super::save_project_to(&dir, &[("game.fun".into(), "let init = 2".into())]).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(dir.join("game.fun")).unwrap(),
+            "let init = 2"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn saving_refuses_a_directory_holding_a_different_project() {
+        let dir =
+            std::env::temp_dir().join(format!("functor-mcp-save-other-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("functor.json"), "{}").unwrap();
+        std::fs::write(dir.join("theirs.fun"), "let init = 0").unwrap();
+
+        let error = super::save_project_to(&dir, &[("game.fun".into(), "let init = 1".into())])
+            .unwrap_err();
+
+        assert!(error.contains("different project"), "{error}");
+        assert!(!dir.join("game.fun").exists(), "nothing may be written");
+        assert_eq!(
+            std::fs::read_to_string(dir.join("functor.json")).unwrap(),
+            "{}",
+            "the existing manifest is untouched"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn ids_are_short_sequential_and_resolve_to_their_url() {
         let mut registry = Registry::default();
-        let first = registry.insert("http://127.0.0.1:1".into(), None, None);
-        let second = registry.insert("http://127.0.0.1:2".into(), None, None);
+        let first = registry.insert("http://127.0.0.1:1".into(), None, None, None);
+        let second = registry.insert("http://127.0.0.1:2".into(), None, None, None);
 
         assert_eq!(first, "s1");
         assert_eq!(second, "s2");
@@ -1193,8 +1569,8 @@ mod tests {
         let empty = registry.url("s1").unwrap_err();
         assert!(empty.contains("no sessions yet"), "{empty}");
 
-        registry.insert("http://127.0.0.1:1".into(), None, None);
-        registry.insert("http://127.0.0.1:2".into(), None, None);
+        registry.insert("http://127.0.0.1:1".into(), None, None, None);
+        registry.insert("http://127.0.0.1:2".into(), None, None, None);
         let unknown = registry.url("s9").unwrap_err();
         assert!(unknown.contains("s1, s2"), "{unknown}");
     }
@@ -1210,7 +1586,7 @@ mod tests {
         let other = registry.reserve_port().unwrap();
         assert_ne!(port, other);
 
-        registry.insert("http://127.0.0.1:1".into(), Some(port), None);
+        registry.insert("http://127.0.0.1:1".into(), Some(port), None, None);
         registry.remove("s1").unwrap();
         assert!(!registry.reserved.contains(&port));
     }
@@ -1218,13 +1594,13 @@ mod tests {
     #[test]
     fn removing_a_session_forgets_it_and_does_not_reuse_its_id() {
         let mut registry = Registry::default();
-        registry.insert("http://127.0.0.1:1".into(), None, None);
+        registry.insert("http://127.0.0.1:1".into(), None, None, None);
         let removed = registry.remove("s1").unwrap();
 
         assert_eq!(removed.url, "http://127.0.0.1:1");
         assert!(registry.url("s1").is_err());
         assert_eq!(
-            registry.insert("http://127.0.0.1:3".into(), None, None),
+            registry.insert("http://127.0.0.1:3".into(), None, None, None),
             "s2"
         );
         let Err(message) = registry.remove("s1") else {

--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -94,6 +94,7 @@ screenshot run has no reason to grab your mouse.
 | `POST /reload-source` | swap game logic from the request body (see below) |
 | `POST /reload-project` | swap all sibling modules from a JSON array of `[path, source]` pairs, entry first |
 | `POST /load-project` | start a new sibling-module project from the same body, initializing its model from `init` |
+| `GET /project` | the running program's own `.fun` sources as a JSON array of `[path, source]` pairs, entry first — the read half of the push routes (see below) |
 | `POST /reload-asset` | upload one project-relative texture/model/audio asset as a binary path+bytes envelope |
 | `POST /sync-assets` | finish a sync from a JSON array of current asset paths; uploaded paths absent from the manifest are removed |
 | `POST /rewind` | restore recorded model + physics to `{"frame":42}` (pin the clock first) |
@@ -369,6 +370,24 @@ starts with the project's `init` model. Its watch loop then uses
 `/reload-project`, preserving that live model across edits. Both routes carry
 all sibling `.fun`/`.funi` modules, with the same file-as-module behavior as
 desktop.
+
+### `GET /project` — read the running sources back (protocol v5)
+
+The reply is a JSON array of `[path, source]` pairs, entry first — exactly the
+body `/reload-project` accepts, so the two compose:
+
+```sh
+curl -s http://127.0.0.1:8123/project | jq -r '.[0][1]' > game.fun
+```
+
+After a `/reload-source` or `/reload-project` push, this is the only place the
+program's current source exists: the runtime is running text that may never
+have been written to a file (an agent authoring over the wire, the browser
+IDE). It reports the PROJECT's own modules — bundled prelude/stdlib modules
+are excluded — by file name. A producer whose logic is not source-shaped
+(`--replay`) answers **501**, and a pre-v5 runtime answers **404**.
+
+`functor mcp`'s `save_project` tool is built on it (docs/mcp.md).
 
 ### Project asset sync
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -75,7 +75,7 @@ URL plus, when the server launched it, the child process.
 | Tool | What it does |
 | --- | --- |
 | `init_game` | Scaffold a starter project on disk — the same `functor.json` + `game.fun` `functor init` writes. `template` is `"3d"` (default) or `"fps"`. Never overwrites; its `dir` goes straight into `launch_game`. |
-| `save_project` | Write a session's **current** source to a directory. The sources come from the RUNTIME (`GET /project`), so they include every wire-only edit. |
+| `save_project` | Write a session's **current** source to a directory. The sources come from the RUNTIME (`GET /project`), so they include every wire-only edit. Refuses a directory that already holds a project unless `overwrite`. |
 
 **Reading the API.**
 
@@ -159,9 +159,17 @@ home until `save_project` gives it one.
 `save_project` deliberately does not copy the launch directory. It asks the
 runtime for what it is *running* (`GET /project`, debug protocol v5), so a
 session edited only over the wire saves the edited source rather than the text
-it booted with. It writes a `functor.json` for a project that has none, and
-refuses a directory that already holds a **different** project (a `functor.json`
-without this project's entry file).
+it booted with.
+
+A directory that already holds a project (a `functor.json` or any `.fun` /
+`.funi`) is **refused** — nearly every project's entry is named `game.fun`, so
+a matching name is no evidence that it is the same project. Pass
+`overwrite: true` to replace it; that also **deletes modules the session does
+not have**, since `file = module` means a leftover sibling would still load and
+the saved copy would not be the program that ran. A `functor.json` is
+synthesized only when the directory has none — an existing manifest is never
+rewritten, and a multi-entry one is not reconstructed (`/project` reports
+modules, not project metadata).
 
 The other direction is `init_game`, which scaffolds the ordinary starter on
 disk — `init_game { "dir": "./my-game" }` then

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -10,7 +10,8 @@ drive a Functor game with no bespoke script, no HTTP plumbing, and no screen:
 model back as structured JSON.
 
 It is a plain HTTP client of the runtimes and lives entirely in the CLI. The
-runtimes are unchanged.
+one runtime-side addition it needs is `GET /project` (debug protocol v5), the
+read half of the project-push routes, which `save_project` is built on.
 
 ## Registering it
 
@@ -44,7 +45,7 @@ URL plus, when the server launched it, the child process.
 
 | Tool | What it does |
 | --- | --- |
-| `launch_game` | Spawn a game as a child on a free port and return its session id. `mode` is `hidden` (default) or `headless` — see below. |
+| `launch_game` | Spawn a game as a child on a free port and return its session id. The project comes from `dir` **or** from `files` — the whole project inline (see below). `mode` is `hidden` (default) or `headless`. |
 | `connect_game` | Attach to a runtime this server does **not** own (someone else's `--debug-port`, or an adb-forwarded Quest). |
 | `list_sessions` | Every session: id, url, owned/attached, and whether it currently answers. |
 | `stop_game` | Kill a launched game; merely forget an attached one. |
@@ -68,6 +69,13 @@ URL plus, when the server launched it, the child process.
 | `send_input` | Inject one `POST /input` command verbatim — key, mouse move/wheel/button, `ui_event`, or an `xr` sample. |
 | `rewind` | Restore model + physics to a recorded frame (it pins the clock first, as `/rewind` requires). |
 | `reload_source` / `reload_project` | Hot-reload the entry, or every sibling module, with the live model preserved. |
+
+**Authoring.**
+
+| Tool | What it does |
+| --- | --- |
+| `init_game` | Scaffold a starter project on disk — the same `functor.json` + `game.fun` `functor init` writes. `template` is `"3d"` (default) or `"fps"`. Never overwrites; its `dir` goes straight into `launch_game`. |
+| `save_project` | Write a session's **current** source to a directory. The sources come from the RUNTIME (`GET /project`), so they include every wire-only edit. |
 
 **Reading the API.**
 
@@ -104,7 +112,8 @@ guarantees above quietly stop holding: a pre-v3 runtime ignores a batched
 landed after one), and a pre-v4 one sends Debug text under `model` instead of
 structured JSON. This matters most
 for a device APK, which versions independently of the CLI — rebuild it from the
-same Functor version.
+same Functor version. `save_project` additionally needs **v5** (`GET /project`)
+and says so on an older runtime.
 
 Launched games are killed when the server stops, whether its client closes
 stdin or signals it (SIGTERM/Ctrl-C). Attached ones are always left running.
@@ -121,6 +130,42 @@ stdin or signals it (SIGTERM/Ctrl-C). Attached ones are always left running.
   (the game's `draw` is pure data), but there is nothing to read back:
   **`capture_frame` fails** with an explanation. Audio is silent too, so
   `Audio.playThen` completion messages are not delivered.
+
+## Authoring a game with no filesystem
+
+An agent with no filesystem of its own (an MCP client in a chat app, say) can
+still go from nothing to a running game to a durable project. `launch_game`
+takes `files` — `[path, source]` pairs, the entry `.fun` first — instead of
+`dir`:
+
+```jsonc
+launch_game { "mode": "headless",
+              "files": [["game.fun", "type Model = { n: float }\n\nlet init = …"],
+                        ["step.fun", "let amount = 1.0\n"]] }
+// → {"session":"s1","dir":"/tmp/functor-mcp-…",…}
+
+get_state     { "session": "s1" }                    // → {"model":{"n":0},…}
+reload_source { "session": "s1", "source": "…edited…" }   // model preserved
+save_project  { "session": "s1", "dir": "./my-game" }
+// → {"dir":"/abs/my-game","files":["game.fun","step.fun","functor.json"]}
+```
+
+The server writes the inline files to a scratch directory it owns and launches
+them normally, so file-watch hot reload, `reload_source` and `reload_project`
+all behave exactly as for a project on disk. That directory is **removed when
+the session stops** (or the server shuts down): an inline game has no durable
+home until `save_project` gives it one.
+
+`save_project` deliberately does not copy the launch directory. It asks the
+runtime for what it is *running* (`GET /project`, debug protocol v5), so a
+session edited only over the wire saves the edited source rather than the text
+it booted with. It writes a `functor.json` for a project that has none, and
+refuses a directory that already holds a **different** project (a `functor.json`
+without this project's entry file).
+
+The other direction is `init_game`, which scaffolds the ordinary starter on
+disk — `init_game { "dir": "./my-game" }` then
+`launch_game { "dir": "./my-game" }`.
 
 ## Driving a game deterministically
 

--- a/e2e/mcp-server.mjs
+++ b/e2e/mcp-server.mjs
@@ -277,6 +277,18 @@ let draw = (m: Model, tts) =>
   check(readFileSync(join(saveDir, "step.fun"), "utf8").trim() === "let amount = 1.0", "the pushed sibling was saved too");
   check(JSON.parse(readFileSync(join(saveDir, "functor.json"), "utf8")).entry === "game.fun", "a functor.json was synthesized for the saved project");
 
+  // A second save into the same directory is refused without an explicit
+  // overwrite: a matching entry name is no evidence of the same project.
+  let occupied = null;
+  try {
+    await rpc.call("save_project", { session: authored, dir: saveDir });
+  } catch (error) {
+    occupied = error.message;
+  }
+  check(occupied !== null && /already holds a project/.test(occupied), "save_project refuses an occupied directory");
+  await rpc.call("save_project", { session: authored, dir: saveDir, overwrite: true });
+  check(readFileSync(join(saveDir, "game.fun"), "utf8") === EDITED, "overwrite: true re-saves it");
+
   await rpc.call("stop_game", { session: authored });
   check(!existsSync(inline.dir), "the scratch project directory is removed with its session");
 

--- a/e2e/mcp-server.mjs
+++ b/e2e/mcp-server.mjs
@@ -15,13 +15,22 @@
 //   5. send_input: counter's model reacts to a UI click (its `update` handles
 //      Inc), so a `ui_event` on slot 0 must increment `count` after a step.
 //      A `key` event is also injected to exercise that shape end to end.
-//   6. stop_game, then a clean shutdown of the server itself.
+//   6. the filesystem-less authoring journey: launch_game with the whole
+//      project INLINE (no directory anywhere), edit it live with
+//      reload_source (model preserved), then save_project — asserting the
+//      saved source is the EDITED source, i.e. the wire's truth rather than
+//      whatever the launch wrote.
+//   7. init_game scaffolds a starter project on disk and it boots.
+//   8. stop_game, then a clean shutdown of the server itself.
 //
 // Run manually (needs the CLI built; the wasm bundle is not required):
 //
 //   cargo build -p functor-cli --no-default-features
 //   node e2e/mcp-server.mjs
 import { spawn } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const ROOT = fileURLToPath(new URL("..", import.meta.url));
@@ -45,6 +54,8 @@ const EXPECTED_TOOLS = [
   "reload_source",
   "reload_project",
   "api_reference",
+  "init_game",
+  "save_project",
 ];
 
 /** A line-delimited JSON-RPC client over a child's stdio. */
@@ -220,6 +231,82 @@ try {
     unknown = error.message;
   }
   check(unknown !== null && unknown.includes(session), "an unknown session id names the sessions that do exist");
+
+  console.log("\n▸ authoring a game with no filesystem");
+  // The whole project inline — an entry plus a sibling module, neither of
+  // which exists anywhere on disk.
+  const ENTRY = `type Model = { n: float }
+
+let init = { n: 0.0 }
+
+let tick = (m: Model, dt, tts) => { m with n: m.n + Step.amount }
+
+let draw = (m: Model, tts) =>
+  Frame.create(
+    Camera.lookAt(Vec3.make(0.0, 1.5, -4.0), Vec3.make(0.0, 0.0, 0.0)),
+    Scene.cube() |> Scene.rotateY(Angle.degrees(m.n)),
+  )
+`;
+  const EDITED = ENTRY.replace("m.n + Step.amount", "m.n + Step.amount * 10.0");
+
+  const inline = await rpc.call("launch_game", {
+    files: [
+      ["game.fun", ENTRY],
+      ["step.fun", "let amount = 1.0\n"],
+    ],
+    mode: "headless",
+  });
+  const authored = inline.session;
+  check(/^s\d+$/.test(authored), `an inline project launched (${authored}), from ${inline.dir}`);
+
+  await rpc.call("pause", { session: authored });
+  const ticked = await rpc.call("step", { session: authored });
+  check(ticked.model.n >= 1, `the inline game ran its own tick (n = ${ticked.model.n})`);
+
+  // A live edit of the ENTRY, with the pushed sibling still linked.
+  await rpc.call("reload_source", { session: authored, source: EDITED });
+  const beforeEdit = (await rpc.call("get_state", { session: authored })).model.n;
+  const afterEdit = (await rpc.call("step", { session: authored })).model.n;
+  check(afterEdit - beforeEdit === 10, `the edit took effect, model preserved (${beforeEdit} → ${afterEdit})`);
+
+  const saveDir = mkdtempSync(join(tmpdir(), "functor-mcp-e2e-save-"));
+  const saved = await rpc.call("save_project", { session: authored, dir: saveDir });
+  check(saved.files.includes("game.fun") && saved.files.includes("step.fun"), `save_project wrote ${saved.files}`);
+  const savedEntry = readFileSync(join(saveDir, "game.fun"), "utf8");
+  check(savedEntry === EDITED, "the SAVED source is the EDITED source (the runtime's truth, not the launch files)");
+  check(readFileSync(join(saveDir, "step.fun"), "utf8").trim() === "let amount = 1.0", "the pushed sibling was saved too");
+  check(JSON.parse(readFileSync(join(saveDir, "functor.json"), "utf8")).entry === "game.fun", "a functor.json was synthesized for the saved project");
+
+  await rpc.call("stop_game", { session: authored });
+  check(!existsSync(inline.dir), "the scratch project directory is removed with its session");
+
+  let bothSources = null;
+  try {
+    await rpc.call("launch_game", { dir: "examples/counter", files: [["game.fun", "let init = 1"]] });
+  } catch (error) {
+    bothSources = error.message;
+  }
+  check(bothSources !== null && /dir OR files/.test(bothSources), "launch_game refuses dir and files together");
+
+  console.log("\n▸ init_game scaffolds a project that boots");
+  const scaffoldRoot = mkdtempSync(join(tmpdir(), "functor-mcp-e2e-init-"));
+  const scaffold = join(scaffoldRoot, "game");
+  const scaffoldResult = await rpc.call("init_game", { dir: scaffold });
+  check(scaffoldResult.files.includes("game.fun"), `init_game wrote ${scaffoldResult.files} into ${scaffoldResult.dir}`);
+
+  const scaffolded = await rpc.call("launch_game", { dir: scaffold, mode: "headless" });
+  check(scaffolded.discovery?.service === "functor debug runtime", "the scaffolded project boots");
+  await rpc.call("stop_game", { session: scaffolded.session });
+
+  let reinit = null;
+  try {
+    await rpc.call("init_game", { dir: scaffold });
+  } catch (error) {
+    reinit = error.message;
+  }
+  check(reinit !== null && /game\.fun/.test(reinit), "init_game refuses to overwrite an existing project");
+  rmSync(saveDir, { recursive: true, force: true });
+  rmSync(scaffoldRoot, { recursive: true, force: true });
 
   console.log("\n▸ shutdown");
   const stopped = await rpc.call("stop_game", { session });

--- a/runtime/functor-runtime-common/src/debug_http.rs
+++ b/runtime/functor-runtime-common/src/debug_http.rs
@@ -270,6 +270,41 @@ fn handle(mut stream: TcpStream, tx: &mpsc::Sender<DebugRequest>) -> Option<()> 
                 ),
             }
         }
+        ("GET", "/project") => {
+            let (resp_tx, resp_rx) = mpsc::channel();
+            if tx.send(DebugRequest::Project(resp_tx)).is_err() {
+                return runtime_gone(&mut stream, cors_origin);
+            }
+            match recv(resp_rx) {
+                Ok(Some(files)) => respond_bytes(
+                    &mut stream,
+                    cors_origin,
+                    200,
+                    "OK",
+                    "application/json",
+                    serde_json::to_string(&files)
+                        .expect("project sources are strings")
+                        .as_bytes(),
+                ),
+                // Not "no files": this producer's logic is not source-shaped at
+                // all (a replay, a compiled dylib), so there is nothing a
+                // caller could save or edit.
+                Ok(None) => respond_text(
+                    &mut stream,
+                    cors_origin,
+                    501,
+                    "Not Implemented",
+                    "this runtime is not running .fun sources, so it has no project to report",
+                ),
+                Err(_) => respond_text(
+                    &mut stream,
+                    cors_origin,
+                    500,
+                    "Internal Server Error",
+                    "project failed",
+                ),
+            }
+        }
         ("POST", "/input") => {
             let command = match parse_json::<InputCommand>(&mut reader, content_length) {
                 Ok(command) => command,
@@ -697,6 +732,54 @@ mod tests {
         let response = client.join().unwrap();
         assert!(response.starts_with("HTTP/1.1 200 OK\r\n"));
         assert!(response.ends_with("reloaded project"));
+    }
+
+    #[test]
+    fn project_reports_the_running_sources_as_json() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let client = connect(
+            &listener,
+            "GET /project HTTP/1.1\r\nHost: localhost\r\n\r\n".into(),
+        );
+        let (tx, rx) = mpsc::channel();
+        let server = std::thread::spawn(move || handle(listener.accept().unwrap().0, &tx));
+
+        match rx.recv().unwrap() {
+            DebugRequest::Project(response) => response
+                .send(Some(vec![("game.fun".into(), "let init = 1".into())]))
+                .unwrap(),
+            _ => panic!("expected a project request"),
+        }
+
+        assert_eq!(server.join().unwrap(), Some(()));
+        let response = client.join().unwrap();
+        assert!(response.starts_with("HTTP/1.1 200 OK\r\n"));
+        assert!(response.contains("Content-Type: application/json\r\n"));
+        assert!(response.ends_with(r#"[["game.fun","let init = 1"]]"#));
+    }
+
+    /// A producer with no source-shaped logic must say so, rather than answer
+    /// an empty project a caller would happily save over its real files.
+    #[test]
+    fn project_is_not_implemented_when_the_producer_has_no_sources() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let client = connect(
+            &listener,
+            "GET /project HTTP/1.1\r\nHost: localhost\r\n\r\n".into(),
+        );
+        let (tx, rx) = mpsc::channel();
+        let server = std::thread::spawn(move || handle(listener.accept().unwrap().0, &tx));
+
+        match rx.recv().unwrap() {
+            DebugRequest::Project(response) => response.send(None).unwrap(),
+            _ => panic!("expected a project request"),
+        }
+
+        assert_eq!(server.join().unwrap(), Some(()));
+        assert!(client
+            .join()
+            .unwrap()
+            .starts_with("HTTP/1.1 501 Not Implemented\r\n"));
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/debug_protocol.rs
+++ b/runtime/functor-runtime-common/src/debug_protocol.rs
@@ -27,7 +27,13 @@ pub const DEBUG_PROTOCOL_SERVICE: &str = "functor debug runtime";
 /// REDEFINES `model`: a pre-v4 runtime sends the Debug text under `model`
 /// and has no `model_debug`, so clients must gate on the version before
 /// reading `model` as data.
-pub const DEBUG_PROTOCOL_VERSION: u32 = 4;
+///
+/// 5 added `GET /project`, the read half of the project-push routes: the
+/// `.fun` sources the program is CURRENTLY running, which for a
+/// wire-authored session exist nowhere else. Purely additive — every v4
+/// shape is unchanged, so a v4 client needs no revision and only a caller of
+/// `/project` needs a v5 runtime (a v4 one answers 404).
+pub const DEBUG_PROTOCOL_VERSION: u32 = 5;
 
 /// Maximum accepted body size for either reload operation.
 pub const MAX_RELOAD_BYTES: usize = 4 * 1024 * 1024;
@@ -112,6 +118,11 @@ pub const DEBUG_ROUTES: &[DebugRoute] = &[
         method: "POST",
         path: "/load-project",
         description: "load a new whole project from a JSON array of [path, source] pairs (entry first), model initialized from init — 400 with the load error on a broken push",
+    },
+    DebugRoute {
+        method: "GET",
+        path: "/project",
+        description: "the running program's own .fun sources as a JSON array of [path, source] pairs (entry first) — the wire truth after a pushed edit; 501 for producers whose logic is not source-shaped",
     },
     DebugRoute {
         method: "POST",
@@ -377,6 +388,9 @@ pub enum DebugRequest {
     /// `Err` is a conflict the operator must resolve — today, a `/time` command
     /// under an unconditional `--fixed-time` pin, which the clock cannot honor.
     Time(TimeCommand, Sender<Result<(), String>>),
+    /// `None` when the producer's logic is not source-shaped (a replay, a
+    /// compiled dylib) — reported as 501 rather than an empty project.
+    Project(Sender<Option<ProjectSources>>),
     ReloadSource(String, Sender<Result<String, String>>),
     ReloadProject(ProjectSources, Sender<Result<String, String>>),
     LoadProject(ProjectSources, Sender<Result<String, String>>),
@@ -605,6 +619,7 @@ mod tests {
             "GET /state",
             "GET /scene",
             "GET /trace",
+            "GET /project",
             "POST /input",
             "POST /time",
             "POST /reload-source",
@@ -635,6 +650,6 @@ mod tests {
         let discovery: Value = serde_json::from_str(&discovery_json()).unwrap();
         assert_eq!(discovery["service"], DEBUG_PROTOCOL_SERVICE);
         assert_eq!(discovery["protocol_version"], DEBUG_PROTOCOL_VERSION);
-        assert_eq!(DEBUG_PROTOCOL_VERSION, 4);
+        assert_eq!(DEBUG_PROTOCOL_VERSION, 5);
     }
 }

--- a/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
@@ -629,6 +629,12 @@ impl GameProducer for FunctorLangEmbeddedGame {
         self.asset_progress = Some(progress);
     }
 
+    fn project_sources(&self) -> Option<crate::debug_protocol::ProjectSources> {
+        // Every source this producer has ever run arrived over the wire, so
+        // its own buffers ARE the truth.
+        Some(self.sources.clone())
+    }
+
     fn reload_source(&mut self, source: &str) -> Result<String, String> {
         // The editor push path (docs/functor-lang.md D4), same semantics as the
         // desktop runner's `POST /reload-source`: model preserved, a broken

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -147,6 +147,17 @@ pub trait GameProducer {
         Err("this producer does not support project loading (not an .fun game)".to_string())
     }
 
+    /// The `.fun` sources the program is CURRENTLY running — `(path, source)`
+    /// pairs, the entry first, project files only (no bundled prelude
+    /// modules). The read half of the push routes above, serving
+    /// `GET /project`: after a `reload_source`/`reload_project` push the
+    /// running sources exist nowhere else, so a driver that wants to persist
+    /// what it authored must ask the RUNTIME rather than copy a directory.
+    /// `None` for producers whose logic is not source-shaped.
+    fn project_sources(&self) -> Option<crate::debug_protocol::ProjectSources> {
+        None
+    }
+
     /// Rewind the whole scene — model AND physics world — to an earlier
     /// RENDERED frame, restoring both to the state they had at the end of that
     /// frame and branching the recorded future from there (docs/time-travel.md

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -78,6 +78,11 @@ pub struct FunctorLangGame {
     /// siblings; any on-disk project edit clears it (disk is the newer whole
     /// project in the desktop shell's last-write-wins model).
     pushed_project: Option<Vec<(String, String)>>,
+    /// The `.fun` sources the CURRENT program was built from — file name and
+    /// text, entry first, project files only. Serves `GET /project`: after a
+    /// pushed edit (`reload_source`/`reload_project`) these differ from what
+    /// is on disk, and they, not the directory, are what the game is running.
+    sources: Vec<(String, String)>,
     /// The lowered (merged) module the current session came from — kept so
     /// a reload can rebind model-stored closures (old module × new module).
     module: functor_lang::ir::Module,
@@ -300,6 +305,26 @@ fn load_sources(files: &[(String, String)]) -> Result<Loaded, String> {
     finish_load(path, project)
 }
 
+/// The project's OWN files out of a linked source map: bundled prelude and
+/// stdlib modules carry `<prelude>`/`<stdlib>` pseudo-paths (the same rule
+/// `inspector_sources` uses), and a project is one flat directory, so each
+/// file is reported by its name.
+fn project_sources_of(sources: &SourceMap) -> Vec<(String, String)> {
+    sources
+        .files()
+        .iter()
+        .filter(|file| !file.path.to_string_lossy().starts_with('<'))
+        .map(|file| {
+            let name = file
+                .path
+                .file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+                .unwrap_or_else(|| file.path.to_string_lossy().into_owned());
+            (name, file.src.clone())
+        })
+        .collect()
+}
+
 /// Contract-check the already linked project. Both disk-backed and pushed
 /// projects pass through this one validation path.
 fn finish_load(path: &str, project: functor_lang::project::Project) -> Result<Loaded, String> {
@@ -472,12 +497,14 @@ impl FunctorLangGame {
         // `None` check. See `functor_lang_producer`.
         journal_arm();
         let source_hashes = inspector_sources(&loaded.sources);
+        let sources = project_sources_of(&loaded.sources);
         let runnable = functor_lang::coverage::runnable_offsets(&loaded.module);
         FunctorLangGame {
             path: path.to_string(),
             stamp,
             pushed_entry: None,
             pushed_project: None,
+            sources,
             module: loaded.module,
             session: loaded.session,
             model: loaded.init,
@@ -580,6 +607,7 @@ impl FunctorLangGame {
         // the journal + cached trace: they refer to the OLD program's spans and
         // execution (visual-debugger PR2 — hot-reload clears both).
         self.source_hashes = inspector_sources(&loaded.sources);
+        self.sources = project_sources_of(&loaded.sources);
         self.last_frame_journal.clear();
         self.journal_ring.clear(); // old program's spans
         self.runnable = functor_lang::coverage::runnable_offsets(&loaded.module);
@@ -671,6 +699,7 @@ impl FunctorLangGame {
         clear_preload_completions();
 
         self.source_hashes = inspector_sources(&loaded.sources);
+        self.sources = project_sources_of(&loaded.sources);
         self.last_frame_journal.clear();
         self.journal_ring.clear();
         self.runnable = functor_lang::coverage::runnable_offsets(&loaded.module);
@@ -815,6 +844,12 @@ impl Game for FunctorLangGame {
                 });
             }
         }
+    }
+
+    fn project_sources(&self) -> Option<functor_runtime_common::debug_protocol::ProjectSources> {
+        // What the SESSION is running, which after a push (or before a save)
+        // is not what the project directory holds.
+        Some(self.sources.clone())
     }
 
     fn reload_source(&mut self, source: &str) -> Result<String, String> {
@@ -1778,6 +1813,21 @@ mod tests {
             game.session.global("probe").expect("probe").to_string(),
             "9"
         );
+
+        // `GET /project` reports what the SESSION is running: the pushed
+        // entry (not the file still on disk) plus the pushed sibling, which
+        // has no on-disk existence at all.
+        let reported = game.project_sources().expect("an .fun game has sources");
+        assert_eq!(
+            reported
+                .iter()
+                .map(|(path, _)| path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["game.fun", "config.fun"],
+            "the entry comes first, then siblings"
+        );
+        assert!(reported[0].1.contains("Config.k + 2.0"), "{reported:?}");
+        assert_eq!(reported[1].1, "let k = 7.0\n");
 
         let broken = vec![("game.fun".to_string(), "let init =".to_string())];
         assert!(game.reload_project(&broken).is_err());

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -821,6 +821,9 @@ fn service_debug_request(
             // stable, so the producer replays it; otherwise it early-outs empty.
             let _ = resp.send(game.inspector_trace(clock.is_paused()));
         }
+        debug_server::DebugRequest::Project(resp) => {
+            let _ = resp.send(game.project_sources());
+        }
         debug_server::DebugRequest::ReloadSource(source, resp) => {
             let _ = resp.send(game.reload_source(&source));
         }

--- a/runtime/functor-runtime-oculus/src/lib.rs
+++ b/runtime/functor-runtime-oculus/src/lib.rs
@@ -734,6 +734,9 @@ tracking); use the desktop runtime's --headless/--debug-port path"
         DebugRequest::Time(command, response) => {
             let _ = response.send(clock.apply(command));
         }
+        DebugRequest::Project(response) => {
+            let _ = response.send(game.project_sources());
+        }
         DebugRequest::ReloadSource(source, response) => {
             let _ = response.send(game.reload_source(&source));
         }


### PR DESCRIPTION
Stacked on #531 (base `mcp-api-reference`).

## The journey it closes

`functor mcp` could already drive a game, but only one that already existed on disk — so an MCP client with no filesystem of its own (Claude Desktop, a chat app) could never *make* one. Three additions close the loop **filesystem-less agent → running game → durable project**:

```jsonc
launch_game { "mode": "headless",
              "files": [["game.fun", "…"], ["step.fun", "let amount = 1.0\n"]] }
get_state     { "session": "s1" }                          // → {"model":{"n":0},…}
reload_source { "session": "s1", "source": "…edited…" }    // model preserved
save_project  { "session": "s1", "dir": "./my-game" }      // it finally has a home
```

## Tool contracts

| Tool | Contract |
| --- | --- |
| `init_game { dir, template? }` | Scaffolds on disk by calling the **in-process** `functor init` scaffolder (`commands::init::execute`) — no shelling out, no duplicated template text. `template` is `"3d"` (default) or `"fps"`, exactly the CLI's set; the reported file list comes from the template itself. `functor init`'s refusal to overwrite is surfaced as a tool error. Session-free; its `dir` composes straight into `launch_game`. |
| `launch_game { dir? \| files?, entry?, mode? }` | Exactly one of `dir` / `files` — either omission or both is a teaching error. `files` is written to a scratch dir the server owns and launched normally. |
| `save_project { session, dir, overwrite? }` | Asks the **runtime** (`GET /project`) for what it is running, writes it under `dir`, synthesizes a `functor.json` when the directory has none. Refuses an occupied directory unless `overwrite`. |

**Inline launch writes files, rather than POSTing `/load-project` after boot.** The runtime needs a `functor.json` either way, so the scratch dir has to exist; once it does, the normal load path runs, and file-watch hot reload / `reload_source` / `reload_project` all keep working exactly as for an on-disk project. The `/load-project` variant would have booted a placeholder first and left the session's hot-reload watching a directory whose contents were never the running program. The scratch dir is dropped (and removed) with its session — on `stop_game` or server shutdown — so an inline game has no durable home until `save_project` gives it one.

## The `/project` design decision — option (a)

I added **`GET /project`** to the debug runtime (debug protocol **4 → 5**) rather than tracking last-pushed sources in the MCP server. Tracking in the CLI is silently wrong for desktop file-watch edits (the runtime reloads from disk and the server never sees it) and for a session someone else pushed to; and "what am I running?" is exactly the introspectability the LLM-native principle asks for — it is the read half of routes that could already write. The bump is documented as **purely additive** in `debug_protocol.rs` (a v4 client needs no revision; only a `/project` caller needs v5), so `REQUIRED_PROTOCOL_VERSION` for the other tools stays at 4 and an attached v4 Quest still works — `save_project` alone reports the version gap.

Shape: `[[path, source], …]`, entry first, project modules only (bundled `<prelude>`/`<stdlib>` filtered exactly as `inspector_sources` does), **501** for a producer whose logic is not source-shaped (`--replay`). It flows like `/state`: a `DebugRequest::Project` variant, a `GameProducer::project_sources` accessor (desktop + the shared embedded producer), wired in both shells.

## Verification

- `cargo build -p functor-cli --no-default-features` clean.
- `cargo test -p functor-cli --no-default-features` — 48 passed (new: manifest synthesis, entry/path validation, save-overwrite refusal, stale-module pruning).
- `cargo test -p functor_runtime_common` — 560 + 10 passed (new `/project` wire tests: 200 JSON, 501).
- `cargo test -p functor-runtime-desktop --lib` — 73 passed (the producer test now asserts `/project` reports the *pushed* entry and a sibling that has no on-disk existence).
- `node e2e/mcp-server.mjs` — all green, incl. the full filesystem-less journey:

```
▸ authoring a game with no filesystem
  ✓ an inline project launched (s2), from /private/var/…/functor-mcp-88305-0
  ✓ the inline game ran its own tick (n = 5)
  ✓ the edit took effect, model preserved (5 → 15)
  ✓ save_project wrote game.fun,step.fun,functor.json
  ✓ the SAVED source is the EDITED source (the runtime's truth, not the launch files)
  ✓ the pushed sibling was saved too
  ✓ a functor.json was synthesized for the saved project
  ✓ save_project refuses an occupied directory
  ✓ overwrite: true re-saves it
  ✓ the scratch project directory is removed with its session
  ✓ launch_game refuses dir and files together

▸ init_game scaffolds a project that boots
  ✓ init_game wrote functor.json,game.fun into /private/var/…/game
  ✓ the scaffolded project boots
  ✓ init_game refuses to overwrite an existing project
```

Docs: `docs/mcp.md` gains the new tools in the tables and an "author a game with no filesystem" section; `docs/debug-runtime.md` documents `GET /project`.

## Review dispositions (`/xreview` — Claude Opus subagent + `codex exec`, in parallel)

**[AGREED] High — the "different project" guard was ineffective** (`save_project`): it only tripped when the destination's entry *name* differed, and nearly every project's entry is `game.fun`, so `save_project { dir: "examples/counter" }` would have quietly overwritten it. **Fixed** — an occupied directory (any `functor.json`/`.fun`/`.funi`) is refused, and replacing takes an explicit `overwrite: true`.

**[AGREED] High/Medium — a save left stale siblings behind**, so the saved directory was not necessarily the program that ran (`file = module`: a leftover `old.fun` still loads). **Fixed** — `overwrite` prunes modules the session does not have. Both are covered by new unit tests and the e2e.

**[AGREED] Low/Medium — multi-entry manifests are not reconstructed.** `/project` reports modules, not project metadata, so saving a `--entry server` session into a fresh directory writes a single-entry manifest. **Documented** rather than fixed (tool description + `docs/mcp.md`); an existing manifest is never rewritten, so the lossy case is only the fresh-directory one, and reporting project metadata over `/project` is a larger contract than this PR needs.

**Low (Claude) — manifest built by string interpolation; `init_game`'s file list hardcoded; the v5 hint shown for a 501 too; predictable scratch-dir name and world-readable perms.** All **fixed**: `serde_json::json!`, `Template::file_names()`, the hint gated on a 404 (a 501 producer has no sources at all, so "rebuild it" is wrong advice), and the scratch dir retries a colliding name and is created `0700`.

**Medium (Codex) — writes are not symlink-hardened, and a save is not transactional.** **Justified, not fixed.** Wire paths are lexically constrained to relative names with no `..`/absolute/`\`/empty segments, and the destination directory is one the user named; a no-follow, staged-rename write is real complexity for a local dev tool whose sibling capability (`launch_game`) already runs arbitrary interpreted game code with the user's full privileges. A partial write names the file that failed.

**Low (Claude) — `entry_of` doubles as the path validator; `launch_game` reported `dir` unabsolutised.** The second is fixed (all three tools now report `absolute(...)`); the first is kept — one place that both validates and picks the entry is fewer moving parts than a separate pass, and both call sites go through it.

No duplication signals: dupfinder's cold index did not finish within its budget, so no clone evidence was folded in.
