### PR TITLE
feat(cli): language_guide MCP tool over the functor-lang skill

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -10,6 +10,38 @@ design notes: `~/notes/ideas/functor-lang/`). It is deliberately small; this
 file describes **everything that exists today**. If a construct isn't here,
 it doesn't parse — do not invent syntax from F#/OCaml habits.
 
+## Quick facts (do NOT guess from F#/OCaml)
+
+The habits that break first, in one place. Each is expanded below.
+
+- **Assignment is `:=`**, only on a `let mut … in` slot, and it must be
+  followed by `;` and a continuation expression. `<-` does not exist yet.
+- **Pipelines are thread-LAST**: `x |> f(a)` is `f(a, x)` — every builtin and
+  prelude function takes its subject (list, scene) LAST.
+- **`if cond then a else b` is an EXPRESSION**: both branches required (no
+  else-less `if`), chained with `else if` (there is no `elif`). A
+  bool-literal `match` is equally valid.
+- **Operators are exhaustive**: `+ - * /`, `< > <= >= == !=`, `&& || not`.
+  There is no `<>` (inequality is `!=` only), no `%` (`Math.mod`), no `^`
+  (`Math.pow`), and no string-concatenation operator (use `$"…"`).
+- **No loops** — iterate with `List.map` / `List.filter` / `List.fold`.
+- **All numbers are `float`** (f64); type names are lowercase (`float`,
+  `string`, `bool`, `List<…>`).
+- **Every `match` arm and every variant alternative needs a leading `|`**,
+  the first one included. Arm bodies are full expressions, so a nested
+  `match` must be parenthesized.
+- **Nullary constructors take no parens** (`Point`, never `Point()`), and
+  constructors resolve bare — `Shape.Circle` is an unknown external.
+- **Local bindings are `let … in`** inside a body; top-level defs are
+  mutually visible.
+- **File = module**: every sibling `.fun` in the entry's directory loads with
+  the project, referenced or not.
+- **The engine prelude (`Scene.*`, `Camera.*`, `Frame.*`, `Physics.*`) exists
+  only under the runner host**, not in plain `functor-lang run`. Its branded
+  values refuse bare numbers: `Angle.degrees(60.0)`, `Time.seconds(0.5)`.
+- **A game is `init` / `tick` / `draw`** plus optional hooks — see The game
+  contract below.
+
 ## Verification loop (always available, no GPU)
 
 Builtin-module MEMBER names are validated at `check` time: `List.tail`,
@@ -1495,6 +1527,8 @@ timeline effects — `Physics.pause`/`resume`/`stepOnce`/`rewindTo`/
 `timelineFrame` — were removed when the whole-game scrubber superseded
 them.)
 
+
+## The game contract (entry points, effects, hot reload)
 
 A runner-hosted game (`functor -d <project-dir> run native`, with
 `functor.json` selecting `game.fun`) defines:

--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -5,8 +5,8 @@ description: Write, run, and debug Functor Lang (.fun) — Functor's F#-inspired
 
 # Functor Lang — the current language, exactly
 
-Functor Lang is Functor's interpreted game-logic language (roadmap: `docs/functor-lang.md`;
-design notes: `~/notes/ideas/functor-lang/`). It is deliberately small; this
+Functor Lang is Functor's interpreted game-logic language (roadmap:
+`docs/functor-lang.md`). It is deliberately small; this
 file describes **everything that exists today**. If a construct isn't here,
 it doesn't parse — do not invent syntax from F#/OCaml habits.
 

--- a/cli/src/commands/mcp.rs
+++ b/cli/src/commands/mcp.rs
@@ -442,13 +442,18 @@ impl FunctorMcp {
         &self,
         Parameters(args): Parameters<LanguageGuideArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let sections = guide_sections(LANGUAGE_GUIDE);
-        match args.section.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+        let (intro, sections) = guide_sections(LANGUAGE_GUIDE);
+        match args
+            .section
+            .as_deref()
+            .map(str::trim)
+            .filter(|section| !section.is_empty())
+        {
             Some(wanted) => {
-                let section = resolve!(find_guide_section(&sections, wanted));
-                ok_text(section.text)
+                let index = resolve!(find_guide_section(&sections, wanted));
+                ok_text(render_guide_section(&sections, index))
             }
-            None => ok_text(render_guide_contents(LANGUAGE_GUIDE, &sections)),
+            None => ok_text(render_guide_contents(intro, &sections)),
         }
     }
 
@@ -1246,33 +1251,38 @@ fn render_api_hits(hits: &[ApiHit], limit: Option<usize>) -> String {
     out
 }
 
-/// One addressable part of the language guide: a markdown heading plus
-/// everything under it, down to the next heading of the same or higher level.
-/// Sections are derived from the skill's own headings, never hand-listed, so a
-/// restructured skill re-sections itself.
+/// One addressable part of the language guide: a markdown heading plus the
+/// text under it, stopping at the NEXT heading of any level. Sections are
+/// derived from the skill's own headings, never hand-listed, so a restructured
+/// skill re-sections itself.
+///
+/// A subsection is therefore addressed in its own right rather than also
+/// living inside its parent (the prelude section alone is tens of kilobytes —
+/// carrying its subsections would make one call most of the guide), and a
+/// parent that has any says so in a `Continues in:` line.
 #[derive(Debug)]
 struct GuideSection<'a> {
-    /// 2 for `##`, 3 for `###`: a subsection is addressable in its own right,
-    /// and its text is NOT part of its parent's (the prelude section alone is
-    /// tens of kilobytes — nesting it whole would make the parent unreadable).
+    /// 2 for `##`, 3 for `###`.
     level: usize,
     slug: String,
-    /// Where the heading line starts in the guide (front matter aside).
-    start: usize,
     /// The heading line and its body, verbatim.
     text: &'a str,
 }
 
 /// Drop the skill's YAML front matter, which is loader metadata rather than
-/// language documentation.
+/// language documentation. CRLF is handled because a Windows checkout of a
+/// `.md` is not pinned to LF, and leaking the metadata is silent.
 fn strip_front_matter(guide: &str) -> &str {
-    let Some(rest) = guide.strip_prefix("---\n") else {
+    let Some(rest) = guide
+        .strip_prefix("---\n")
+        .or_else(|| guide.strip_prefix("---\r\n"))
+    else {
         return guide;
     };
-    match rest.find("\n---\n") {
-        Some(end) => &rest[end + "\n---\n".len()..],
-        None => guide,
-    }
+    ["\n---\n", "\n---\r\n"]
+        .iter()
+        .find_map(|delimiter| Some(&rest[rest.find(delimiter)? + delimiter.len()..]))
+        .unwrap_or(guide)
 }
 
 /// The heading level of a line, for the levels this tool addresses.
@@ -1294,17 +1304,19 @@ fn slugify(title: &str) -> String {
     slug.trim_matches('-').to_string()
 }
 
-/// Split the guide into its sections, in document order.
-fn guide_sections(guide: &str) -> Vec<GuideSection<'_>> {
+/// Split the guide into the text before its first heading and its sections,
+/// in document order.
+fn guide_sections(guide: &str) -> (&str, Vec<GuideSection<'_>>) {
     let body = strip_front_matter(guide);
     // (offset, level, title) per heading. Fenced code blocks are skipped: a
-    // shell comment in an example is not a section.
+    // shell comment in an example is not a section. A fence is recognized at
+    // column 0 only, as every fence in the guide is written.
     let mut headings: Vec<(usize, usize, &str)> = Vec::new();
     let mut fenced = false;
     let mut offset = 0;
     for line in body.split_inclusive('\n') {
         let trimmed = line.trim_end();
-        if trimmed.trim_start().starts_with("```") {
+        if trimmed.starts_with("```") {
             fenced = !fenced;
         } else if !fenced {
             if let Some(level) = heading_level(trimmed) {
@@ -1313,30 +1325,30 @@ fn guide_sections(guide: &str) -> Vec<GuideSection<'_>> {
         }
         offset += line.len();
     }
-    headings
+    let intro = headings.first().map_or(body, |(start, _, _)| &body[..*start]);
+    let sections = headings
         .iter()
         .enumerate()
         .map(|(index, &(start, level, title))| {
-            // Up to the NEXT heading of any level: a subsection is addressed on
-            // its own, and is not also part of its parent's text (the prelude
-            // section alone is tens of kilobytes — carrying its subsections too
-            // would make one call the whole guide).
             let end = headings
                 .get(index + 1)
                 .map_or(body.len(), |(next_start, _, _)| *next_start);
             GuideSection {
                 level,
                 slug: slugify(title),
-                start,
                 text: body[start..end].trim_end(),
             }
         })
-        .collect()
+        .collect();
+    (intro, sections)
 }
 
-/// A section's one-line summary: its first line of prose, code blocks skipped.
+/// A section's one-line summary: its first sentence of prose, code blocks
+/// skipped. The guide is hard-wrapped, so lines are joined until one ends a
+/// sentence rather than reported as they are broken.
 fn guide_summary(section: &GuideSection) -> String {
     let mut fenced = false;
+    let mut summary = String::new();
     for line in section.text.lines().skip(1) {
         let trimmed = line.trim();
         if trimmed.starts_with("```") {
@@ -1346,23 +1358,24 @@ fn guide_summary(section: &GuideSection) -> String {
         if fenced || trimmed.is_empty() {
             continue;
         }
-        let summary: String = trimmed
-            .trim_start_matches(['-', '*', ' '])
-            .replace("**", "")
-            .replace('`', "");
-        return match summary.char_indices().nth(100) {
-            Some((cut, _)) => format!("{}…", &summary[..cut]),
-            None => summary,
-        };
+        if !summary.is_empty() {
+            summary.push(' ');
+        }
+        summary.push_str(trimmed.trim_start_matches(['-', '*', ' ']));
+        if summary.ends_with('.') || summary.chars().count() >= 100 {
+            break;
+        }
     }
-    String::new()
+    let summary = summary.replace("**", "").replace('`', "");
+    match summary.char_indices().nth(120) {
+        Some((cut, _)) => format!("{}…", summary[..cut].trim_end()),
+        None => summary,
+    }
 }
 
 /// The guide's front page: what it is, the quick facts every caller needs
 /// before writing a line of Functor Lang, and the sections it can ask for.
-fn render_guide_contents(guide: &str, sections: &[GuideSection]) -> String {
-    let body = strip_front_matter(guide);
-    let intro = sections.first().map_or(body, |first| &body[..first.start]);
+fn render_guide_contents(intro: &str, sections: &[GuideSection]) -> String {
     let mut out = String::from(
         "The Functor Lang language guide (the `functor-lang` skill, verbatim — the source of \
 truth for the language). Call language_guide again with `section` for a section's full \
@@ -1379,10 +1392,10 @@ text; `api_reference` covers the prelude API instead.\n\n",
     }
     out.push_str("## Sections\n\n");
     for section in sections {
-        let indent = "  ".repeat(section.level - 1);
+        let indent = "  ".repeat(section.level - 2);
         let lines = section.text.lines().count();
         out.push_str(&format!(
-            "{indent}{} ({lines} lines) — {}\n",
+            "{indent}- {} ({lines} lines) — {}\n",
             section.slug,
             guide_summary(section)
         ));
@@ -1390,41 +1403,58 @@ text; `api_reference` covers the prelude API instead.\n\n",
     out
 }
 
+/// One section as served: its text, plus a pointer to the subsections that
+/// continue it — without which a truncation at a `###` heading reads like the
+/// end of the topic.
+fn render_guide_section(sections: &[GuideSection], index: usize) -> String {
+    let section = &sections[index];
+    let children: Vec<&str> = sections[index + 1..]
+        .iter()
+        .take_while(|next| next.level > section.level)
+        .map(|next| next.slug.as_str())
+        .collect();
+    match children.is_empty() {
+        true => section.text.to_string(),
+        false => format!("{}\n\nContinues in: {}\n", section.text, children.join(", ")),
+    }
+}
+
 /// Look a section up by slug, or by a unique fragment of one — an agent
 /// naturally asks for "syntax" or "the game contract". `Err` is a teaching
 /// message naming what it could have asked for.
-fn find_guide_section<'a, 'g>(
-    sections: &'a [GuideSection<'g>],
-    wanted: &str,
-) -> Result<&'a GuideSection<'g>, String> {
+fn find_guide_section(sections: &[GuideSection], wanted: &str) -> Result<usize, String> {
     let needle = slugify(wanted);
-    if let Some(exact) = sections.iter().find(|section| section.slug == needle) {
+    let unknown = || {
+        format!(
+            "unknown guide section {wanted:?}. The sections are {}.",
+            join_slugs(sections.iter())
+        )
+    };
+    if needle.is_empty() {
+        return Err(unknown());
+    }
+    if let Some(exact) = sections.iter().position(|section| section.slug == needle) {
         return Ok(exact);
     }
-    let matches: Vec<&GuideSection> = sections
+    let matches: Vec<usize> = sections
         .iter()
-        .filter(|section| !needle.is_empty() && section.slug.contains(&needle))
+        .enumerate()
+        .filter(|(_, section)| section.slug.contains(&needle))
+        .map(|(index, _)| index)
         .collect();
     match matches.as_slice() {
-        [only] => Ok(only),
-        [] => Err(format!(
-            "unknown guide section {wanted:?}. The sections are {}.",
-            guide_slugs(sections)
-        )),
+        [only] => Ok(*only),
+        [] => Err(unknown()),
         several => Err(format!(
             "{wanted:?} matches several guide sections: {}. Name one exactly.",
-            several
-                .iter()
-                .map(|section| section.slug.as_str())
-                .collect::<Vec<_>>()
-                .join(", ")
+            join_slugs(several.iter().map(|index| &sections[*index]))
         )),
     }
 }
 
-fn guide_slugs(sections: &[GuideSection]) -> String {
+/// Name a set of sections the way every teaching error here does.
+fn join_slugs<'a>(sections: impl Iterator<Item = &'a GuideSection<'a>>) -> String {
     sections
-        .iter()
         .map(|section| section.slug.as_str())
         .collect::<Vec<_>>()
         .join(", ")
@@ -1638,8 +1668,9 @@ fn tail(log: &Arc<Mutex<Vec<u8>>>) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        find_guide_section, guide_sections, render_api_hits, render_guide_contents, search_api,
-        Registry, LANGUAGE_GUIDE, QUICK_FACTS_SLUG,
+        find_guide_section, guide_sections, render_api_hits, render_guide_contents,
+        render_guide_section, search_api, strip_front_matter, Registry, LANGUAGE_GUIDE,
+        QUICK_FACTS_SLUG,
     };
     use functor_docgen::ApiReference;
 
@@ -1682,6 +1713,7 @@ mod tests {
             "the embedded skill is suspiciously small ({} bytes)",
             LANGUAGE_GUIDE.len()
         );
+        let lowercase = LANGUAGE_GUIDE.to_lowercase();
         for marker in [
             ":=",                  // assignment, not `<-`
             "thread-last",         // `x |> f(a)` is `f(a, x)`
@@ -1691,39 +1723,41 @@ mod tests {
             "let draw",
         ] {
             assert!(
-                LANGUAGE_GUIDE.to_lowercase().contains(&marker.to_lowercase()),
+                lowercase.contains(&marker.to_lowercase()),
                 "the language guide no longer covers {marker:?}"
             );
         }
 
-        let sections = guide_sections(LANGUAGE_GUIDE);
+        let (intro, sections) = guide_sections(LANGUAGE_GUIDE);
         assert!(sections.len() > 8, "sections: {}", sections.len());
-        let mut slugs: Vec<&str> = sections.iter().map(|s| s.slug.as_str()).collect();
-        slugs.sort_unstable();
-        let count = slugs.len();
-        slugs.dedup();
-        assert_eq!(count, slugs.len(), "section names must be unambiguous");
         assert!(
             sections
                 .iter()
-                .any(|s| s.slug.starts_with(QUICK_FACTS_SLUG)),
+                .any(|section| section.slug.starts_with(QUICK_FACTS_SLUG)),
             "the quick-facts section fronts the table of contents"
         );
-        // No section may swallow the whole file: sections that never end are
-        // exactly the failure mode a heading-level change would introduce.
-        assert!(sections
-            .iter()
-            .all(|section| section.text.len() < LANGUAGE_GUIDE.len() / 2));
+        // Every heading became a section, and the last one runs to the end of
+        // the file: an unbalanced code fence (or an unhandled heading level)
+        // otherwise swallows the whole tail silently.
+        let headings = LANGUAGE_GUIDE
+            .lines()
+            .filter(|line| line.starts_with("## ") || line.starts_with("### "))
+            .count();
+        assert_eq!(headings, sections.len(), "a heading was not sectioned");
+        let body = strip_front_matter(LANGUAGE_GUIDE).trim_end();
+        assert!(body.ends_with(sections.last().unwrap().text));
+        // The front matter is loader metadata, not language documentation.
+        assert!(intro.trim_start().starts_with("# Functor Lang"), "{intro}");
     }
 
     #[test]
     fn the_table_of_contents_is_short_and_leads_with_the_quick_facts() {
-        let sections = guide_sections(LANGUAGE_GUIDE);
-        let contents = render_guide_contents(LANGUAGE_GUIDE, &sections);
+        let (intro, sections) = guide_sections(LANGUAGE_GUIDE);
+        let contents = render_guide_contents(intro, &sections);
 
         assert!(contents.contains("Assignment is `:=`"), "{contents}");
         assert!(contents.contains("thread-LAST"), "{contents}");
-        assert!(contents.contains("syntax-subset"), "{contents}");
+        assert!(contents.contains("- syntax-subset ("), "{contents}");
         // The point of a table of contents is that it is not the whole guide.
         assert!(
             contents.len() < LANGUAGE_GUIDE.len() / 4,
@@ -1734,28 +1768,69 @@ mod tests {
 
     #[test]
     fn a_section_is_addressable_by_slug_or_by_a_unique_fragment() {
-        let sections = guide_sections(LANGUAGE_GUIDE);
+        let (_, sections) = guide_sections(LANGUAGE_GUIDE);
+        let text = |wanted| {
+            render_guide_section(&sections, find_guide_section(&sections, wanted).unwrap())
+        };
 
-        let syntax = find_guide_section(&sections, "syntax-subset").unwrap();
-        assert!(syntax.text.starts_with("## Syntax subset"), "{}", syntax.slug);
-        assert!(syntax.text.contains("|> APPENDS"), "{}", syntax.text);
+        let syntax = text("syntax-subset");
+        assert!(syntax.starts_with("## Syntax subset"), "{syntax}");
+        assert!(syntax.contains("|> APPENDS"), "{syntax}");
 
         // A fragment, spelled the way an agent would ask for it.
-        let contract = find_guide_section(&sections, "game contract").unwrap();
-        assert!(contract.text.contains("let draw = (model, tts)"), "{}", contract.text);
+        assert!(text("game contract").contains("let draw = (model, tts)"));
+    }
+
+    /// The parser's edges, on a fixture rather than on the skill's prose:
+    /// nesting, a heading that is really a shell comment in a code fence, and
+    /// the `Continues in:` pointer a truncated parent needs.
+    #[test]
+    fn sections_nest_fence_aware_and_a_parent_points_at_its_children() {
+        const FIXTURE: &str = "---\nname: fixture\n---\n\nIntro prose.\n\n\
+## First\n\nOne.\n\n```sh\n## not a heading\n```\n\n\
+### Nested\n\nTwo.\n\n## Second\n\nThree.\n";
+        let (intro, sections) = guide_sections(FIXTURE);
+
+        assert_eq!(intro.trim(), "Intro prose.");
+        assert_eq!(
+            sections.iter().map(|s| s.slug.as_str()).collect::<Vec<_>>(),
+            ["first", "nested", "second"]
+        );
+        // The fenced `## not a heading` stayed inside its section's text.
+        assert!(sections[0].text.contains("## not a heading"));
+        assert!(!sections[0].text.contains("### Nested"));
+
+        let first = render_guide_section(&sections, 0);
+        assert!(first.ends_with("Continues in: nested\n"), "{first}");
+        assert_eq!(render_guide_section(&sections, 2), sections[2].text);
     }
 
     #[test]
-    fn an_unknown_or_ambiguous_section_names_the_ones_that_exist() {
-        let sections = guide_sections(LANGUAGE_GUIDE);
+    fn an_unknown_ambiguous_or_empty_section_names_the_ones_that_exist() {
+        const FIXTURE: &str = "## Sound design\n\nOne.\n\n## Sound effects\n\nTwo.\n";
+        let (_, sections) = guide_sections(FIXTURE);
 
         let unknown = find_guide_section(&sections, "monads").unwrap_err();
-        assert!(unknown.contains("syntax-subset"), "{unknown}");
-        assert!(unknown.contains(QUICK_FACTS_SLUG), "{unknown}");
+        assert!(unknown.contains("sound-design, sound-effects"), "{unknown}");
+        // A blank name is a client bug, not "give me the first section".
+        assert!(find_guide_section(&sections, "   ").is_err());
 
-        // "modules" is both the modules chapter and the stdlib-modules one.
-        let ambiguous = find_guide_section(&sections, "modules").unwrap_err();
+        let ambiguous = find_guide_section(&sections, "sound").unwrap_err();
         assert!(ambiguous.contains("matches several"), "{ambiguous}");
+        assert!(ambiguous.contains("sound-design, sound-effects"), "{ambiguous}");
+    }
+
+    #[test]
+    fn front_matter_is_dropped_however_the_file_is_checked_out() {
+        assert_eq!(strip_front_matter("---\na: b\n---\n# Title\n"), "# Title\n");
+        assert_eq!(
+            strip_front_matter("---\r\na: b\r\n---\r\n# Title\r\n"),
+            "# Title\r\n"
+        );
+        // No front matter, or an unterminated one, is served as it is rather
+        // than truncated to nothing.
+        assert_eq!(strip_front_matter("# Title\n"), "# Title\n");
+        assert_eq!(strip_front_matter("---\na: b\n"), "---\na: b\n");
     }
 
     #[test]
@@ -2020,5 +2095,3 @@ mod tests {
         assert!(message.contains("unknown session"), "{message}");
     }
 }
-
-

--- a/cli/src/commands/mcp.rs
+++ b/cli/src/commands/mcp.rs
@@ -44,6 +44,16 @@ const REQUIRED_PROTOCOL_VERSION: u64 = 4;
 const LOG_TAIL_BYTES: usize = 8 * 1024;
 /// How many API-reference items one `api_reference` call returns.
 const MAX_API_RESULTS: usize = 20;
+/// The Functor Lang language guide, embedded verbatim from the `functor-lang`
+/// skill — the repository's declared source of truth for the language
+/// (`CLAUDE.md` requires it to be updated whenever the language changes). It is
+/// embedded rather than paraphrased so this tool cannot drift from it: there is
+/// exactly one copy, and `language_guide` serves sections of it mechanically.
+const LANGUAGE_GUIDE: &str = include_str!("../../../.claude/skills/functor-lang/SKILL.md");
+/// The section whose bullets front the table of contents — the "do NOT guess
+/// from F#/OCaml" list, which is what an agent needs before it writes a line.
+/// Matched as a slug PREFIX, so rewording the heading's tail cannot lose it.
+const QUICK_FACTS_SLUG: &str = "quick-facts";
 
 /// Serve MCP over stdio until the client disconnects.
 pub async fn execute() -> io::Result<()> {
@@ -365,6 +375,14 @@ pub struct ApiReferenceArgs {
     pub module: Option<String>,
 }
 
+#[derive(Deserialize, JsonSchema)]
+pub struct LanguageGuideArgs {
+    /// A section name from the guide's own table of contents, e.g.
+    /// `"syntax-subset"` or `"the-game-contract"` (a unique fragment of one is
+    /// enough). Omit it to get the table of contents plus the quick facts.
+    pub section: Option<String>,
+}
+
 #[tool_router]
 impl FunctorMcp {
     pub fn new() -> Self {
@@ -406,6 +424,32 @@ impl FunctorMcp {
         // is never truncated — only an open search is.
         let limit = (!query.trim().is_empty()).then_some(MAX_API_RESULTS);
         ok_text(render_api_hits(&hits, limit))
+    }
+
+    /// Read the Functor Lang LANGUAGE guide: syntax, semantics, the modules
+    /// model, the `init`/`tick`/`draw` game contract, and hot-reload rules —
+    /// the `functor-lang` skill, embedded verbatim, which is this repository's
+    /// source of truth for the language. Functor Lang is NOT F# or OCaml: it
+    /// has `:=` assignment, thread-LAST pipelines (`x |> f(a)` is `f(a, x)`),
+    /// `if/then/else` only as an expression, no loops and no `<>` — guessing
+    /// from F#/OCaml habits produces parse errors, so read this first. Called
+    /// with no arguments it returns the table of contents plus those quick
+    /// facts; `section` returns one section's full text. This is the language;
+    /// `api_reference` is the prelude API (`Scene.cube`'s signature). Neither
+    /// needs a session.
+    #[tool]
+    async fn language_guide(
+        &self,
+        Parameters(args): Parameters<LanguageGuideArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let sections = guide_sections(LANGUAGE_GUIDE);
+        match args.section.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+            Some(wanted) => {
+                let section = resolve!(find_guide_section(&sections, wanted));
+                ok_text(section.text)
+            }
+            None => ok_text(render_guide_contents(LANGUAGE_GUIDE, &sections)),
+        }
     }
 
     /// Start a game as a child process with its debug server on a free port,
@@ -1078,8 +1122,9 @@ is structured JSON). Rebuild that runtime from this version of Functor."
 get_trace, capture_frame) and drive it (pause, send_input, step, resume, rewind, \
 reload_source). The deterministic loop is pause → send_input → step → get_state: while the \
 clock is pinned nothing advances on its own, and injected input is level state that holds \
-across steps. api_reference searches the engine's prelude API and needs no session, so it \
-answers language/API questions before anything is launched. A game can also be AUTHORED \
+across steps. language_guide teaches the LANGUAGE (Functor Lang is not F#/OCaml — read it \
+before writing any .fun) and api_reference searches the engine's prelude API; neither needs \
+a session, so both answer before anything is launched. A game can also be AUTHORED \
 here with no filesystem of your own: launch_game with inline `files` runs source that has \
 no home, reload_source edits it live, and save_project writes what the runtime is actually \
 running to a directory. init_game scaffolds a starter project on disk instead."
@@ -1199,6 +1244,190 @@ fn render_api_hits(hits: &[ApiHit], limit: Option<usize>) -> String {
         ));
     }
     out
+}
+
+/// One addressable part of the language guide: a markdown heading plus
+/// everything under it, down to the next heading of the same or higher level.
+/// Sections are derived from the skill's own headings, never hand-listed, so a
+/// restructured skill re-sections itself.
+#[derive(Debug)]
+struct GuideSection<'a> {
+    /// 2 for `##`, 3 for `###`: a subsection is addressable in its own right,
+    /// and its text is NOT part of its parent's (the prelude section alone is
+    /// tens of kilobytes — nesting it whole would make the parent unreadable).
+    level: usize,
+    slug: String,
+    /// Where the heading line starts in the guide (front matter aside).
+    start: usize,
+    /// The heading line and its body, verbatim.
+    text: &'a str,
+}
+
+/// Drop the skill's YAML front matter, which is loader metadata rather than
+/// language documentation.
+fn strip_front_matter(guide: &str) -> &str {
+    let Some(rest) = guide.strip_prefix("---\n") else {
+        return guide;
+    };
+    match rest.find("\n---\n") {
+        Some(end) => &rest[end + "\n---\n".len()..],
+        None => guide,
+    }
+}
+
+/// The heading level of a line, for the levels this tool addresses.
+fn heading_level(line: &str) -> Option<usize> {
+    let level = line.bytes().take_while(|byte| *byte == b'#').count();
+    (matches!(level, 2 | 3) && line.as_bytes().get(level) == Some(&b' ')).then_some(level)
+}
+
+/// A heading's stable name: lowercase, non-alphanumerics collapsed to `-`.
+fn slugify(title: &str) -> String {
+    let mut slug = String::new();
+    for ch in title.chars() {
+        if ch.is_ascii_alphanumeric() {
+            slug.push(ch.to_ascii_lowercase());
+        } else if !slug.ends_with('-') {
+            slug.push('-');
+        }
+    }
+    slug.trim_matches('-').to_string()
+}
+
+/// Split the guide into its sections, in document order.
+fn guide_sections(guide: &str) -> Vec<GuideSection<'_>> {
+    let body = strip_front_matter(guide);
+    // (offset, level, title) per heading. Fenced code blocks are skipped: a
+    // shell comment in an example is not a section.
+    let mut headings: Vec<(usize, usize, &str)> = Vec::new();
+    let mut fenced = false;
+    let mut offset = 0;
+    for line in body.split_inclusive('\n') {
+        let trimmed = line.trim_end();
+        if trimmed.trim_start().starts_with("```") {
+            fenced = !fenced;
+        } else if !fenced {
+            if let Some(level) = heading_level(trimmed) {
+                headings.push((offset, level, trimmed[level + 1..].trim()));
+            }
+        }
+        offset += line.len();
+    }
+    headings
+        .iter()
+        .enumerate()
+        .map(|(index, &(start, level, title))| {
+            // Up to the NEXT heading of any level: a subsection is addressed on
+            // its own, and is not also part of its parent's text (the prelude
+            // section alone is tens of kilobytes — carrying its subsections too
+            // would make one call the whole guide).
+            let end = headings
+                .get(index + 1)
+                .map_or(body.len(), |(next_start, _, _)| *next_start);
+            GuideSection {
+                level,
+                slug: slugify(title),
+                start,
+                text: body[start..end].trim_end(),
+            }
+        })
+        .collect()
+}
+
+/// A section's one-line summary: its first line of prose, code blocks skipped.
+fn guide_summary(section: &GuideSection) -> String {
+    let mut fenced = false;
+    for line in section.text.lines().skip(1) {
+        let trimmed = line.trim();
+        if trimmed.starts_with("```") {
+            fenced = !fenced;
+            continue;
+        }
+        if fenced || trimmed.is_empty() {
+            continue;
+        }
+        let summary: String = trimmed
+            .trim_start_matches(['-', '*', ' '])
+            .replace("**", "")
+            .replace('`', "");
+        return match summary.char_indices().nth(100) {
+            Some((cut, _)) => format!("{}…", &summary[..cut]),
+            None => summary,
+        };
+    }
+    String::new()
+}
+
+/// The guide's front page: what it is, the quick facts every caller needs
+/// before writing a line of Functor Lang, and the sections it can ask for.
+fn render_guide_contents(guide: &str, sections: &[GuideSection]) -> String {
+    let body = strip_front_matter(guide);
+    let intro = sections.first().map_or(body, |first| &body[..first.start]);
+    let mut out = String::from(
+        "The Functor Lang language guide (the `functor-lang` skill, verbatim — the source of \
+truth for the language). Call language_guide again with `section` for a section's full \
+text; `api_reference` covers the prelude API instead.\n\n",
+    );
+    out.push_str(intro.trim());
+    out.push_str("\n\n");
+    if let Some(facts) = sections
+        .iter()
+        .find(|section| section.slug.starts_with(QUICK_FACTS_SLUG))
+    {
+        out.push_str(facts.text);
+        out.push_str("\n\n");
+    }
+    out.push_str("## Sections\n\n");
+    for section in sections {
+        let indent = "  ".repeat(section.level - 1);
+        let lines = section.text.lines().count();
+        out.push_str(&format!(
+            "{indent}{} ({lines} lines) — {}\n",
+            section.slug,
+            guide_summary(section)
+        ));
+    }
+    out
+}
+
+/// Look a section up by slug, or by a unique fragment of one — an agent
+/// naturally asks for "syntax" or "the game contract". `Err` is a teaching
+/// message naming what it could have asked for.
+fn find_guide_section<'a, 'g>(
+    sections: &'a [GuideSection<'g>],
+    wanted: &str,
+) -> Result<&'a GuideSection<'g>, String> {
+    let needle = slugify(wanted);
+    if let Some(exact) = sections.iter().find(|section| section.slug == needle) {
+        return Ok(exact);
+    }
+    let matches: Vec<&GuideSection> = sections
+        .iter()
+        .filter(|section| !needle.is_empty() && section.slug.contains(&needle))
+        .collect();
+    match matches.as_slice() {
+        [only] => Ok(only),
+        [] => Err(format!(
+            "unknown guide section {wanted:?}. The sections are {}.",
+            guide_slugs(sections)
+        )),
+        several => Err(format!(
+            "{wanted:?} matches several guide sections: {}. Name one exactly.",
+            several
+                .iter()
+                .map(|section| section.slug.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )),
+    }
+}
+
+fn guide_slugs(sections: &[GuideSection]) -> String {
+    sections
+        .iter()
+        .map(|section| section.slug.as_str())
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 /// A path for display: absolute where the filesystem can say so, and the
@@ -1408,7 +1637,10 @@ fn tail(log: &Arc<Mutex<Vec<u8>>>) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{render_api_hits, search_api, Registry};
+    use super::{
+        find_guide_section, guide_sections, render_api_hits, render_guide_contents, search_api,
+        Registry, LANGUAGE_GUIDE, QUICK_FACTS_SLUG,
+    };
     use functor_docgen::ApiReference;
 
     fn reference() -> ApiReference {
@@ -1438,6 +1670,92 @@ mod tests {
                 .any(|hit| hit.item.qualified_name == "Scene.cube"),
             "Scene.cube must match its own bare name"
         );
+    }
+
+    /// The drift guard. The guide is the `functor-lang` skill embedded
+    /// verbatim, so a restructure that broke the embedding (or emptied it)
+    /// must fail here rather than quietly serving an empty language surface.
+    #[test]
+    fn the_embedded_guide_still_teaches_the_language() {
+        assert!(
+            LANGUAGE_GUIDE.len() > 50_000,
+            "the embedded skill is suspiciously small ({} bytes)",
+            LANGUAGE_GUIDE.len()
+        );
+        for marker in [
+            ":=",                  // assignment, not `<-`
+            "thread-last",         // `x |> f(a)` is `f(a, x)`
+            "if cond then a else", // the conditional is an expression
+            "let init",
+            "let tick",
+            "let draw",
+        ] {
+            assert!(
+                LANGUAGE_GUIDE.to_lowercase().contains(&marker.to_lowercase()),
+                "the language guide no longer covers {marker:?}"
+            );
+        }
+
+        let sections = guide_sections(LANGUAGE_GUIDE);
+        assert!(sections.len() > 8, "sections: {}", sections.len());
+        let mut slugs: Vec<&str> = sections.iter().map(|s| s.slug.as_str()).collect();
+        slugs.sort_unstable();
+        let count = slugs.len();
+        slugs.dedup();
+        assert_eq!(count, slugs.len(), "section names must be unambiguous");
+        assert!(
+            sections
+                .iter()
+                .any(|s| s.slug.starts_with(QUICK_FACTS_SLUG)),
+            "the quick-facts section fronts the table of contents"
+        );
+        // No section may swallow the whole file: sections that never end are
+        // exactly the failure mode a heading-level change would introduce.
+        assert!(sections
+            .iter()
+            .all(|section| section.text.len() < LANGUAGE_GUIDE.len() / 2));
+    }
+
+    #[test]
+    fn the_table_of_contents_is_short_and_leads_with_the_quick_facts() {
+        let sections = guide_sections(LANGUAGE_GUIDE);
+        let contents = render_guide_contents(LANGUAGE_GUIDE, &sections);
+
+        assert!(contents.contains("Assignment is `:=`"), "{contents}");
+        assert!(contents.contains("thread-LAST"), "{contents}");
+        assert!(contents.contains("syntax-subset"), "{contents}");
+        // The point of a table of contents is that it is not the whole guide.
+        assert!(
+            contents.len() < LANGUAGE_GUIDE.len() / 4,
+            "the contents are {} bytes",
+            contents.len()
+        );
+    }
+
+    #[test]
+    fn a_section_is_addressable_by_slug_or_by_a_unique_fragment() {
+        let sections = guide_sections(LANGUAGE_GUIDE);
+
+        let syntax = find_guide_section(&sections, "syntax-subset").unwrap();
+        assert!(syntax.text.starts_with("## Syntax subset"), "{}", syntax.slug);
+        assert!(syntax.text.contains("|> APPENDS"), "{}", syntax.text);
+
+        // A fragment, spelled the way an agent would ask for it.
+        let contract = find_guide_section(&sections, "game contract").unwrap();
+        assert!(contract.text.contains("let draw = (model, tts)"), "{}", contract.text);
+    }
+
+    #[test]
+    fn an_unknown_or_ambiguous_section_names_the_ones_that_exist() {
+        let sections = guide_sections(LANGUAGE_GUIDE);
+
+        let unknown = find_guide_section(&sections, "monads").unwrap_err();
+        assert!(unknown.contains("syntax-subset"), "{unknown}");
+        assert!(unknown.contains(QUICK_FACTS_SLUG), "{unknown}");
+
+        // "modules" is both the modules chapter and the stdlib-modules one.
+        let ambiguous = find_guide_section(&sections, "modules").unwrap_err();
+        assert!(ambiguous.contains("matches several"), "{ambiguous}");
     }
 
     #[test]
@@ -1702,3 +2020,5 @@ mod tests {
         assert!(message.contains("unknown session"), "{message}");
     }
 }
+
+

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -99,7 +99,11 @@ is no second copy to rot — the skill is already required to track the language
 (`CLAUDE.md`), and this surface follows it automatically. Sections are named by
 their slugged heading (`syntax-subset`, `semantics-rules-that-will-bite-you`); a
 unique fragment (`"game contract"`) resolves too, and an unknown or ambiguous
-one comes back as a teaching error naming the candidates.
+one comes back as a teaching error naming the candidates. A section runs to the
+next heading of **any** level, so a subsection is fetched on its own rather than
+inflating its parent — a parent that has any ends with a `Continues in:` line
+naming them. Nothing is truncated: the section is the narrowing, exactly as a
+`module` listing is for `api_reference`.
 
 ```jsonc
 language_guide {}                                // TOC + the quick facts

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -77,13 +77,36 @@ URL plus, when the server launched it, the child process.
 | `init_game` | Scaffold a starter project on disk — the same `functor.json` + `game.fun` `functor init` writes. `template` is `"3d"` (default) or `"fps"`. Never overwrites; its `dir` goes straight into `launch_game`. |
 | `save_project` | Write a session's **current** source to a directory. The sources come from the RUNTIME (`GET /project`), so they include every wire-only edit. Refuses a directory that already holds a project unless `overwrite`. |
 
-**Reading the API.**
+**Learning the language and the API.** Two session-free tools, and they are
+different halves: `language_guide` is the LANGUAGE (how to write `.fun` at all),
+`api_reference` is the prelude API (what `Scene.cube` takes and returns).
 
 | Tool | What it does |
 | --- | --- |
+| `language_guide` | The Functor Lang language guide — syntax, semantics, modules, the `init`/`tick`/`draw` game contract, hot-reload rules. No args returns the table of contents plus the quick facts; `section` returns one section's full text. |
 | `api_reference` | Search the embedded `.funi` prelude — the same reference `functor docs` renders — by name, qualified path (`Scene.cube`), signature, or doc text. `module` narrows to one module, and lists all of it when `query` is omitted. **No session needed**: it answers before any game is launched. |
 
-Matches come back best-first — the item's own name, then its qualified path,
+`language_guide` exists because Functor Lang is **not** F# or OCaml, and an
+agent that guesses from those habits writes parse errors: assignment is `:=`,
+pipelines are thread-*last* (`x |> f(a)` is `f(a, x)`), `if/then/else` is only
+an expression, and there are no loops and no `<>`. Claude Code agents get this
+from the repository's `functor-lang` skill; over MCP, every other client gets
+the same text.
+
+It **is** that skill: `.claude/skills/functor-lang/SKILL.md` is embedded in the
+binary verbatim and split into sections by its own markdown headings, so there
+is no second copy to rot — the skill is already required to track the language
+(`CLAUDE.md`), and this surface follows it automatically. Sections are named by
+their slugged heading (`syntax-subset`, `semantics-rules-that-will-bite-you`); a
+unique fragment (`"game contract"`) resolves too, and an unknown or ambiguous
+one comes back as a teaching error naming the candidates.
+
+```jsonc
+language_guide {}                                // TOC + the quick facts
+language_guide { "section": "syntax-subset" }    // that section, verbatim
+```
+
+API matches come back best-first — the item's own name, then its qualified path,
 then its signature, then its prose — capped at 20 per search, with a line
 saying so. A `module` listing is never capped: the module is the narrowing.
 An unknown module, or a search with neither a query nor a module, answers with
@@ -218,5 +241,8 @@ tracking every frame).
 - [`docs/debug-runtime.md`](debug-runtime.md) — the HTTP surface these tools wrap,
   with the exact request/response shapes.
 - `e2e/mcp-server.mjs` — the end-to-end proof, speaking raw JSON-RPC to the server.
+- `.claude/skills/functor-lang/SKILL.md` — the language guide `language_guide`
+  serves, and the file to edit when the language changes.
+- [`docs/functor-lang.md`](functor-lang.md) — the language roadmap behind it.
 - `tools/functor-sdk` — the typed TypeScript SDK over the same endpoints, for
   scripts rather than agents.

--- a/e2e/mcp-server.mjs
+++ b/e2e/mcp-server.mjs
@@ -7,7 +7,9 @@
 //   1. initialize / notifications/initialized / tools/list, asserting the whole
 //      documented tool surface is advertised.
 //   2. api_reference, called before any session exists (it is session-free):
-//      a known item's signature, a module listing, and the zero-match case.
+//      a known item's signature, a module listing, and the zero-match case —
+//      and language_guide, its language-side twin: the table of contents, a
+//      section by name, and an unknown section.
 //   3. launch_game on examples/counter in HEADLESS mode (no GL, so this runs
 //      anywhere CI does), and assert /state's structured `model` arrives.
 //   4. pause, then step twice — asserting the frame advances and that `step`
@@ -54,6 +56,7 @@ const EXPECTED_TOOLS = [
   "reload_source",
   "reload_project",
   "api_reference",
+  "language_guide",
   "init_game",
   "save_project",
 ];
@@ -168,6 +171,28 @@ try {
     missed = error.message;
   }
   check(missed !== null && /Scene/.test(missed) && /Effect/.test(missed), "a query matching nothing names the available modules");
+
+  // The language surface is session-free too: an agent reads it BEFORE it has
+  // written, let alone launched, anything.
+  console.log("\n▸ the language guide, with no session");
+  const contents = await rpc.call("language_guide");
+  const sectionsBlock = contents.split("## Sections\n")[1] ?? "";
+  const sectionNames = sectionsBlock.split("\n").map((line) => line.trim()).filter(Boolean);
+  check(sectionNames.length > 3, `the table of contents lists ${sectionNames.length} sections`);
+  check(/Assignment is `:=`/.test(contents), "the contents lead with the quick facts (`:=`, not `<-`)");
+  check(/thread-LAST/.test(contents), "the thread-last pipeline rule is in the quick facts");
+
+  const syntax = await rpc.call("language_guide", { section: "syntax-subset" });
+  check(/^## Syntax subset/.test(syntax) && syntax.length > 2000, `a named section returns its full text (${syntax.length} chars)`);
+  check(/let draw = \(model, tts\)/.test(await rpc.call("language_guide", { section: "game contract" })), "a section is addressable by a fragment of its name");
+
+  let badSection = null;
+  try {
+    await rpc.call("language_guide", { section: "monad-transformers" });
+  } catch (error) {
+    badSection = error.message;
+  }
+  check(badSection !== null && /syntax-subset/.test(badSection), "an unknown section names the sections that exist");
 
   console.log("\n▸ launching a game headlessly");
   const launched = await rpc.call("launch_game", { dir: "examples/counter", mode: "headless" });

--- a/e2e/mcp-server.mjs
+++ b/e2e/mcp-server.mjs
@@ -186,6 +186,11 @@ try {
   check(/^## Syntax subset/.test(syntax) && syntax.length > 2000, `a named section returns its full text (${syntax.length} chars)`);
   check(/let draw = \(model, tts\)/.test(await rpc.call("language_guide", { section: "game contract" })), "a section is addressable by a fragment of its name");
 
+  // A section stops at its first subsection, so a parent must say where it
+  // continues rather than reading like the end of the topic.
+  const modules = await rpc.call("language_guide", { section: "modules-multi-file-projects" });
+  check(/Continues in: interface-files/.test(modules), "a parent section points at its subsections");
+
   let badSection = null;
   try {
     await rpc.call("language_guide", { section: "monad-transformers" });


### PR DESCRIPTION
## The journey

The MCP server could already teach the **prelude API** (`api_reference`, PR #531) but nothing taught the **language**. That gap is Claude-shaped: a Claude Code agent gets Functor Lang's syntax and semantics from the repository's `functor-lang` skill, which `CLAUDE.md` declares the source of truth precisely because *"Functor Lang is a small, custom language — do NOT guess syntax/semantics from F#/OCaml intuition"*. An agent in Cursor, Claude Desktop, or any other MCP client has no access to that skill, so it guesses `<-`, `%`, `<>`, thread-first pipes and else-less `if`, and meets parse errors.

`language_guide` hands every MCP-speaking agent the same text Claude gets — the docs half of competitive-analysis item 3 (the documentation path).

## The anti-drift design

The skill must not be paraphrased into a second copy that rots, so it is **not** paraphrased at all:

- `.claude/skills/functor-lang/SKILL.md` is `include_str!`d into the binary verbatim (120 KB), like the `.funi` prelude `api_reference` serves.
- Sections are derived **mechanically from the skill's own markdown headings** (`##` / `###`), fence-aware, never hand-listed — a restructured skill re-sections itself.
- The skill is already required to be updated whenever the language changes, so this surface follows it automatically. No new maintenance seat.

Two small edits to the skill itself, both of which make it better on its own terms:

- a `## Quick facts (do NOT guess from F#/OCaml)` section — the load-bearing divergences in one place — which fronts the table of contents. Hand-writing that list in `mcp.rs` would have been exactly the rotting second copy the design avoids.
- a `## The game contract (entry points, effects, hot reload)` heading for ~170 lines that were silently filed under *Character controllers*, so the `init`/`tick`/`draw` contract could not be asked for by name.

## The tool contract

Session-free, in the same `#[tool_router]` impl:

```jsonc
language_guide {}                                 // TOC + intro + the quick facts (~5 KB)
language_guide { "section": "syntax-subset" }     // that section, verbatim
language_guide { "section": "game contract" }     // a unique fragment resolves too
language_guide { "section": "monads" }            // → teaching error naming the 15 sections
```

- A section runs to the **next heading of any level**, so a `###` subsection is fetched on its own rather than inflating its parent (the prelude section is 58 KB; carrying its subsections would make one call most of the guide). A parent that has children ends with `Continues in: <slugs>`.
- Nothing is truncated: the section is the narrowing, exactly as a `module` listing is for `api_reference`. The TOC reports each section's line count so a caller can budget.
- Unknown → the section list; ambiguous → the candidates; blank → the section list. Same teaching-error style as `search_api`'s unknown module.
- **Resources: no.** rmcp's `#[tool_handler]` generates the whole `ServerHandler` impl, so adding a resource means hand-rolling capability wiring and `list`/`read` methods — not cheap — and many clients handle resources poorly. The tool is the load-bearing surface.

## Drift guard

`the_embedded_guide_still_teaches_the_language` asserts the embedded content is non-trivial (>50 KB), still contains the load-bearing markers (`:=`, thread-last, `if cond then a else`, `let init`/`tick`/`draw`), still yields >8 unique sections including the quick facts, that **every** heading became a section, that the last section runs to EOF, and that the front matter was stripped. A skill restructure that breaks embedding fails loudly instead of serving an empty guide. Parser edges (fenced pseudo-headings, nesting, `Continues in:`, unknown/ambiguous/blank lookup, CRLF front matter) are tested on fixtures, so unrelated rewording of the skill cannot fail them.

## Verification

```
cargo test -p functor-cli --no-default-features
test result: ok. 54 passed; 0 failed

node e2e/mcp-server.mjs
▸ the MCP handshake
  ✓ tools/list advertises all 19 tools
▸ the language guide, with no session
  ✓ the table of contents lists 15 sections
  ✓ the contents lead with the quick facts (`:=`, not `<-`)
  ✓ the thread-last pipeline rule is in the quick facts
  ✓ a named section returns its full text (7370 chars)
  ✓ a section is addressable by a fragment of its name
  ✓ a parent section points at its subsections
  ✓ an unknown section names the sections that exist
…
✓ mcp-server passed
```

`docs/mcp.md` gains the tool table row, the language-vs-API framing, and pointers to the skill and the language roadmap.

## Review dispositions (`/xreview`: Claude opus subagent + codex exec, both over `git diff mcp-authoring...HEAD`)

No Critical findings from either engine. Agreed findings, all fixed in 771125a:

| Finding | Disposition |
| --- | --- |
| **High/Medium (both engines)** — a section truncates at its first subsection with no signal; the struct comment claimed the opposite | Fixed: `Continues in: <slugs>` on any parent, comment and docs corrected, covered by a fixture test and an e2e check |
| **High/Medium (both)** — the drift guard was weak/hair-trigger: the "no section exceeds half the file" ratio was already at 95% for the prelude section, and a lost tail (unbalanced fence, unsupported heading level) passed silently | Fixed: replaced with structural invariants — heading count == section count, last section ends at EOF, intro starts past the front matter |
| **Medium (both)** — CRLF checkout defeats front-matter stripping, leaking YAML metadata into every no-arg response | Fixed: both newline forms handled, with a unit test |
| **Low (both)** — TOC entries were indented but not bullets (malformed markdown), and level-2 entries were indented | Fixed: real bullets, indent by depth |
| **Medium (Claude)** — summaries broke mid-clause because the skill is hard-wrapped | Fixed: lines are joined to a sentence (or ~120 chars) |
| **Low (Claude)** — `guide_slugs` duplicated the ambiguous branch's join; `!needle.is_empty()` evaluated per section; `render_guide_contents` re-derived the intro from a `start` offset | Fixed: one `join_slugs`, one empty check, `guide_sections` returns `(intro, sections)` and the `start` field is gone |
| **Low (Claude)** — the ambiguity test pinned the accident that "modules" matches two headings | Fixed: fixtures for parser/lookup branches; only the drift guard touches real prose |
| **Low (Claude)** — the skill's intro cited a private local notes path, now shipped to every MCP client | Fixed: citation dropped from `SKILL.md` |
| **High (Claude)** — the 58 KB prelude section is served uncapped | **Justified, not fixed.** The section is the narrowing, matching `api_reference`'s rule that a `module` listing is never capped; the TOC states each section's line count, and the prelude section now points at its subsection. Splitting it into `###` subsections in the skill is a worthwhile follow-up, but it is a doc restructure, not this PR. |

Stacked on #536 (`mcp-authoring`) → #531. No `cargo fmt --all` was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)