### PR TITLE
docs(site): surface the MCP server in the AI-native story

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Games run and respond headlessly. Drive and inspect a running game entirely over
 
 `functor mcp` serves that same runtime as [MCP](https://modelcontextprotocol.io) tools over stdio, so
 any coding agent can build, run, inspect, and rewind your game — real Functor code, deterministic
-(pin the clock, inject input, step frame by frame), exported to native and web. An agent can
+(pin the clock, inject input, step frame by frame), on the runtime that ships to native and web. An agent can
 scaffold a project, launch it, iterate on it, and save it to disk entirely through the server, with
 no filesystem of its own.
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ Games run and respond headlessly. Drive and inspect a running game entirely over
 
 ![A terminal driving a headless game over HTTP: pausing it and inspecting its render tree](site/media/feature-llm-native.gif)
 
+`functor mcp` serves that same runtime as [MCP](https://modelcontextprotocol.io) tools over stdio, so
+any coding agent can build, run, inspect, and rewind your game — real Functor code, deterministic
+(pin the clock, inject input, step frame by frame), exported to native and web. An agent can
+scaffold a project, launch it, iterate on it, and save it to disk entirely through the server, with
+no filesystem of its own.
+
+```sh
+claude mcp add functor -- functor mcp
+```
+
+Any other MCP client registers it as an ordinary stdio server (`command: "functor"`, `args: ["mcp"]`) —
+see [docs/mcp.md](docs/mcp.md) for the full tool surface, or
+[Driving games with agents](https://functor.games/manual/#agents) in the manual.
+
 ### Platform support
 
 - __Browser:__ WebAssembly

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -242,6 +242,8 @@ tracking every frame).
 
 ## See also
 
+- [Driving games with agents](https://functor.games/manual/#agents) — the same story as a
+  manual section, for readers who arrive from the site rather than the repo.
 - [`docs/debug-runtime.md`](debug-runtime.md) — the HTTP surface these tools wrap,
   with the exact request/response shapes.
 - `e2e/mcp-server.mjs` — the end-to-end proof, speaking raw JSON-RPC to the server.

--- a/site/build.mjs
+++ b/site/build.mjs
@@ -202,6 +202,7 @@ await writeFile(
 - [API reference (JSON)](https://functor.games/docs/api.json): the same reference as structured data (modules → items with \`qualified_name\`, \`kind\`, \`declaration\`, \`docs\`).
 - [API reference (HTML)](https://functor.games/docs/): the searchable rendering of the same data.
 - [Manual](https://functor.games/manual/): getting started, the MVU game contract, language principles, topic guides.
+- [Driving games with agents](https://functor.games/manual/#agents): register \`functor mcp\` and drive a game over MCP — launch or attach a session, read its model, pause and step the clock, inject input, capture frames, hot-reload source.
 - [Sandbox](https://functor.games/sandbox.html): run and edit the sample games in the browser.
 
 ## Source

--- a/site/index.html
+++ b/site/index.html
@@ -177,7 +177,7 @@
               <h3>AI Native</h3>
               <p>
                 Register functor mcp and any coding agent can build, run, inspect, and rewind your
-                game — real Functor code, deterministic, exported to native and web.
+                game — real Functor code, deterministic, on the runtime that ships to native and web.
               </p>
             </div>
           </article>

--- a/site/index.html
+++ b/site/index.html
@@ -176,8 +176,8 @@
             <div class="feature-body">
               <h3>AI Native</h3>
               <p>
-                Games run and respond headlessly, so your favorite coding agent can build right
-                alongside you.
+                Register functor mcp and any coding agent can build, run, inspect, and rewind your
+                game — real Functor code, deterministic, exported to native and web.
               </p>
             </div>
           </article>

--- a/site/manual/index.html
+++ b/site/manual/index.html
@@ -757,7 +757,7 @@ type t&lt;'value, 'error> = | Ok(value: 'value) | Error(error: 'error)   // Resu
           <h3>The tools</h3>
           <table>
             <tbody>
-              <tr><td><strong>Sessions</strong><br /><code>launch_game</code> · <code>connect_game</code> · <code>list_sessions</code> · <code>stop_game</code></td><td>spawn a game as a child process on a free port, or attach to a runtime someone else is running (another <code>--debug-port</code>, or a Quest). <code>launch_game</code>'s <code>mode</code> is <code>hidden</code> (renders, so frames can be captured) or <code>headless</code> (no GL context at all — CI-friendly, but nothing to read back)</td></tr>
+              <tr><td><strong>Sessions</strong><br /><code>launch_game</code> · <code>connect_game</code> · <code>list_sessions</code> · <code>stop_game</code></td><td>spawn a game as a child process on a free port, or attach to a runtime someone else is running (another <code>--debug-port</code>, or a Quest). <code>launch_game</code>'s <code>mode</code> is <code>hidden</code> (the default — it renders, so frames can be captured) or <code>headless</code> (no GL context at all — CI-friendly, but nothing to read back)</td></tr>
               <tr><td><strong>Observing</strong><br /><code>get_state</code> · <code>get_scene</code> · <code>get_trace</code> · <code>capture_frame</code></td><td>the model as structured JSON alongside <code>frame</code>/<code>tts</code>/sampled input; the camera, scene graph, and lights <code>draw</code> produced; the paused inspector trace; a PNG of the next frame</td></tr>
               <tr><td><strong>Driving</strong><br /><code>pause</code> · <code>step</code> · <code>resume</code> · <code>send_input</code> · <code>rewind</code> · <code>reload_source</code> / <code>reload_project</code></td><td>pin the clock, run <em>n</em> frames of a fixed <em>dt</em>, inject a key / mouse / UI / XR command, restore the model and physics to a recorded frame, or hot-reload the source with the live model preserved</td></tr>
               <tr><td><strong>Authoring</strong><br /><code>init_game</code> · <code>save_project</code></td><td>scaffold the same starter <code>functor init</code> writes, and write a session's <em>current</em> source out to a directory</td></tr>
@@ -797,6 +797,7 @@ step       { "session": "s1" }
           </p>
           <pre class="shell">launch_game  { "mode": "headless",
                "files": [["game.fun", "let init = { n: 0.0 }\n…"]] }
+// → {"session":"s1","dir":"/tmp/functor-mcp-…",…}
 get_state    { "session": "s1" }                          // → {"model":{"n":0},…}
 reload_source{ "session": "s1", "source": "…edited…" }     // model preserved
 save_project { "session": "s1", "dir": "./my-game" }</pre>
@@ -804,7 +805,9 @@ save_project { "session": "s1", "dir": "./my-game" }</pre>
             <code>save_project</code> asks the <em>runtime</em> what it is running rather than
             copying the launch directory, so a session edited only over the wire saves the edited
             source. It refuses a directory that already holds a project unless you pass
-            <code>overwrite</code>. The other direction is <code>init_game</code>, which scaffolds
+            <code>overwrite</code> — which also <em>deletes</em> any module the session does not
+            have, so the directory ends up being exactly the program that ran. The other
+            direction is <code>init_game</code>, which scaffolds
             the ordinary starter on disk for <code>launch_game</code> to open.
           </p>
 

--- a/site/manual/index.html
+++ b/site/manual/index.html
@@ -32,6 +32,7 @@
         <a href="#language">The language</a>
         <a href="#prelude">The prelude</a>
         <a href="#builtins">Standard library</a>
+        <a href="#agents">Driving with agents</a>
         <a href="#sharp-edges">Sharp edges</a>
       </nav>
 
@@ -727,6 +728,104 @@ type t&lt;'value, 'error> = | Ok(value: 'value) | Error(error: 'error)   // Resu
               <tr><td><code>Mouse.t</code></td><td><code>Mouse.Left</code>, <code>Mouse.Right</code>, <code>Mouse.Middle</code> — the <code>mouseButton</code> hook's <code>button</code></td></tr>
             </tbody>
           </table>
+        </section>
+
+        <section id="agents">
+          <h2>Driving games with agents</h2>
+          <p>
+            A Functor game runs and answers questions with no window and no human: the model is
+            plain data, <code>draw</code> is pure data, and the clock can be pinned. The
+            <code>functor mcp</code> command serves exactly that as an
+            <a href="https://modelcontextprotocol.io">MCP</a> server over stdio, so any
+            MCP-speaking coding agent can build, run, inspect, and rewind your game — with no
+            bespoke script and no screen.
+          </p>
+          <p>Register it with Claude Code:</p>
+          <pre class="shell">claude mcp add functor -- functor mcp</pre>
+          <p>Any other MCP client takes the ordinary stdio-server shape:</p>
+          <pre class="shell">{
+  "mcpServers": {
+    "functor": { "command": "functor", "args": ["mcp"] }
+  }
+}</pre>
+          <p>
+            The server speaks JSON-RPC on stdout, so it takes no <code>-d</code> — every game
+            names its own directory as it is launched, and the server can hold several sessions
+            at once.
+          </p>
+
+          <h3>The tools</h3>
+          <table>
+            <tbody>
+              <tr><td><strong>Sessions</strong><br /><code>launch_game</code> · <code>connect_game</code> · <code>list_sessions</code> · <code>stop_game</code></td><td>spawn a game as a child process on a free port, or attach to a runtime someone else is running (another <code>--debug-port</code>, or a Quest). <code>launch_game</code>'s <code>mode</code> is <code>hidden</code> (renders, so frames can be captured) or <code>headless</code> (no GL context at all — CI-friendly, but nothing to read back)</td></tr>
+              <tr><td><strong>Observing</strong><br /><code>get_state</code> · <code>get_scene</code> · <code>get_trace</code> · <code>capture_frame</code></td><td>the model as structured JSON alongside <code>frame</code>/<code>tts</code>/sampled input; the camera, scene graph, and lights <code>draw</code> produced; the paused inspector trace; a PNG of the next frame</td></tr>
+              <tr><td><strong>Driving</strong><br /><code>pause</code> · <code>step</code> · <code>resume</code> · <code>send_input</code> · <code>rewind</code> · <code>reload_source</code> / <code>reload_project</code></td><td>pin the clock, run <em>n</em> frames of a fixed <em>dt</em>, inject a key / mouse / UI / XR command, restore the model and physics to a recorded frame, or hot-reload the source with the live model preserved</td></tr>
+              <tr><td><strong>Authoring</strong><br /><code>init_game</code> · <code>save_project</code></td><td>scaffold the same starter <code>functor init</code> writes, and write a session's <em>current</em> source out to a directory</td></tr>
+              <tr><td><strong>Knowledge</strong><br /><code>language_guide</code> · <code>api_reference</code></td><td>the two halves of learning Functor, and neither needs a session: the language guide (syntax, semantics, the game contract) and a search over the same <code>.funi</code> prelude this site's <a href="../docs/">API reference</a> is generated from</td></tr>
+            </tbody>
+          </table>
+
+          <h3>A deterministic loop</h3>
+          <p>
+            Pin the clock, act, step, read. Nothing advances on its own in between, and
+            <code>step</code> does not return until the steps have actually landed — so what comes
+            back is the effect of the input, not a sample of a still-moving game:
+          </p>
+          <pre class="shell">launch_game { "dir": "examples/counter", "mode": "headless" }
+// → {"session":"s1","url":"http://127.0.0.1:53127","owned":true,…}
+
+pause      { "session": "s1" }
+send_input { "session": "s1", "command": {"type":"ui_event","slot":0,"kind":"Clicked"} }
+step       { "session": "s1" }
+// → {"frame":9,"tts":0.13,"pending_steps":0,…,"model":{"count":1}}</pre>
+          <p>
+            <strong>Input is level state.</strong> A key, a held mouse button, and an injected XR
+            sample stay in force across steps until released or replaced — that is how you script a
+            paused session: press, step a few frames, release. And a batch
+            (<code>frames</code> &gt; 1) runs up to 8 ticks per rendered frame, so step one at a
+            time when the game must see input or I/O between steps.
+          </p>
+
+          <h3>Authoring without a filesystem</h3>
+          <p>
+            An agent with no disk of its own can still go from nothing to a durable project.
+            <code>launch_game</code> accepts <code>files</code> — <code>[path, source]</code> pairs,
+            the entry first — instead of <code>dir</code>; the server writes them to a scratch
+            directory it owns and runs them normally, so hot reload behaves exactly as it does for
+            a project on disk. That scratch directory is removed when the session stops, so the
+            game has no durable home until <code>save_project</code> gives it one:
+          </p>
+          <pre class="shell">launch_game  { "mode": "headless",
+               "files": [["game.fun", "let init = { n: 0.0 }\n…"]] }
+get_state    { "session": "s1" }                          // → {"model":{"n":0},…}
+reload_source{ "session": "s1", "source": "…edited…" }     // model preserved
+save_project { "session": "s1", "dir": "./my-game" }</pre>
+          <p>
+            <code>save_project</code> asks the <em>runtime</em> what it is running rather than
+            copying the launch directory, so a session edited only over the wire saves the edited
+            source. It refuses a directory that already holds a project unless you pass
+            <code>overwrite</code>. The other direction is <code>init_game</code>, which scaffolds
+            the ordinary starter on disk for <code>launch_game</code> to open.
+          </p>
+
+          <h3>Attaching to a Quest</h3>
+          <p>
+            The device runtime serves the same protocol on loopback port 8123. Forward it over USB
+            and attach — the session is <em>attached</em>, not owned, so <code>stop_game</code>
+            forgets it and leaves the headset running:
+          </p>
+          <pre class="shell">adb forward tcp:8123 tcp:8123
+connect_game { "url": "http://127.0.0.1:8123" }</pre>
+          <p>
+            Everything else is identical. <code>capture_frame</code> returns the two raw eye
+            buffers side by side, and injected <code>xr</code> samples are rejected on device —
+            the headset resamples live tracking every frame.
+          </p>
+          <p class="docs-footnote">
+            The full tool-by-tool reference — every argument, the protocol versions each tool
+            needs, and the errors they surface — is
+            <a href="https://github.com/tommy-xr/functor/blob/main/docs/mcp.md">docs/mcp.md</a>.
+          </p>
         </section>
 
         <section id="sharp-edges">


### PR DESCRIPTION
PR 6 of the MCP series. `functor mcp` shipped in #528/#529/#531/#536 (+ #537 for
`language_guide`), but nothing outside `docs/mcp.md` said so — the README and the
site still described the AI-native story as "drive it over HTTP". This surfaces
the server in the three places a newcomer actually reads.

## The copy decision

Made by the project owner, not relitigated here: **keep the "AI Native" headings**,
**rewrite the body copy** to carry the differentiators. The landing card's agreed
starting point was *"Register `functor mcp` and any coding agent can build, run,
inspect, and rewind your game — real Functor code, deterministic, exported native +
web."* — shipped essentially verbatim, with only enough polish to read as prose.

## What changed

**`README.md` — the "AI native" section.** Heading and GIF untouched; the existing
HTTP paragraph stays and the MCP story is appended: one paragraph carrying the
differentiators (build/run/inspect/rewind, real Functor code, deterministic, native
+ web) and the authoring journey, the `claude mcp add functor -- functor mcp`
one-liner, and a generic-client pointer to `docs/mcp.md` plus the new manual section.

**`site/index.html` — the "AI Native" feature card.** `<h3>` kept; body `<p>`
replaced with the agreed sentence. No markup or CSS changes — the site body font is
already JetBrains Mono, so `functor mcp` reads as a command without a `<code>` tag
that would have swapped in the browser's default mono and clashed with the sibling
cards.

**`site/manual/` — a new `#agents` section, "Driving games with agents".** Placed
between "Standard library" and "Sharp edges" (the manual runs reference-first, then
closes on gotchas), with a TOC entry. Hand-written HTML in the page's existing
idiom — `pre.shell`, the two-column `<table>` the prelude sections use, `docs-footnote`.
It covers: what `functor mcp` is, registering it (Claude Code one-liner + generic
stdio JSON), the five tool families at a glance, the deterministic drive loop, the
filesystem-less authoring journey (inline `files` → `reload_source` → `save_project`),
and the Quest attach recipe. Depth beyond a manual section links to `docs/mcp.md`.

**`docs/mcp.md`** — "See also" gains the manual page.

## Visuals

Site built at the base ref (`mcp-language-guide`) and at this change; captured with
headless Chromium at 1440×1000 and 390×844, DPR 2.

### Landing page — "AI Native" card (desktop)

| Before | After |
| --- | --- |
| ![](https://gist.githubusercontent.com/tommy-xr/b059d01183667fc8ed236527311de4c8/raw/landing-ai-native-desktop-before.png) | ![](https://gist.githubusercontent.com/tommy-xr/b059d01183667fc8ed236527311de4c8/raw/landing-ai-native-desktop-after.png) |

### Landing page — "AI Native" card (mobile, 390px)

| Before | After |
| --- | --- |
| ![](https://gist.githubusercontent.com/tommy-xr/b059d01183667fc8ed236527311de4c8/raw/landing-ai-native-mobile-before.png) | ![](https://gist.githubusercontent.com/tommy-xr/b059d01183667fc8ed236527311de4c8/raw/landing-ai-native-mobile-after.png) |

### Manual TOC (desktop)

| Before | After |
| --- | --- |
| ![](https://gist.githubusercontent.com/tommy-xr/b059d01183667fc8ed236527311de4c8/raw/manual-nav-desktop-before.png) | ![](https://gist.githubusercontent.com/tommy-xr/b059d01183667fc8ed236527311de4c8/raw/manual-nav-desktop-after.png) |

The nav column is a fixed 200px with `white-space: nowrap`, so the first label
("Driving games with agents") clipped; shortened to "Driving with agents". The
section heading keeps the full title.

### Manual — the new section (there is no "before": the section is new)

Desktop:

![](https://gist.githubusercontent.com/tommy-xr/b059d01183667fc8ed236527311de4c8/raw/manual-agents-desktop-after.png)

Mobile (390px):

![](https://gist.githubusercontent.com/tommy-xr/b059d01183667fc8ed236527311de4c8/raw/manual-agents-mobile-after.png)

## Verification

- `npm run site:build` — clean, at both the base ref and this change.
- `npm run check:site` (`tsc -p site --noEmit`) — clean. No TS touched.
- Rendered-page check at desktop + mobile (above). The new `pre` blocks scroll
  horizontally on mobile via the manual's existing `.docs-main pre { overflow-x: auto }`,
  same as every other code block on the page.
- **No manual-page e2e exists.** `npm run test:site` (`e2e/site-sandbox.mjs`) is
  sandbox-only and does not touch `manual/index.html` or the landing feature cards,
  so there is no automated check to run for the pages this PR edits — stated rather
  than invented.
- Copy accuracy was reviewed against the shipped tool surface (`cli/src/commands/mcp.rs`)
  and `docs/mcp.md`, not just against the prose.

## Review — `/xreview` (Claude Opus subagent + `codex exec`, parallel, over `mcp-language-guide...HEAD`, both given the rendered screenshots)

**[AGREED] "exported to native and web" overclaims the MCP surface — Medium. FIXED.**
There is no build/export tool in the server and `launch_game` runs native
(`mcp.rs`: `.args(["run", "native", "--debug-port"])`), so in a sentence whose subject
is "Register functor mcp and any coding agent can …" the trailing clause read as an MCP
capability. Re-anchored to the engine on both the card and in the README: "…on the
runtime that ships to native and web." The differentiator survives; the overclaim doesn't.

**[AGREED] The card's GIF shows the raw-HTTP drive loop, not MCP — Medium. ACCEPTED, not fixed.**
Correct observation. Regenerating a landing-page demo GIF is not a copy change: per
`CLAUDE.md` those are committed, reproducible scripts in `site/demos/`, so a new MCP
capture is its own PR. The existing media is not *wrong* — it shows the headless debug
runtime that `functor mcp` wraps, and the card's verbs (inspect, rewind) are exactly what
it depicts. Flagged as follow-up work rather than smuggled in here.

**Codex: "build" also overclaims (no build tool) — Medium. JUSTIFIED, not changed.**
"Build" here is *construct*, not `functor build`: `init_game` scaffolds, `launch_game`
accepts inline files, `reload_source` iterates, `save_project` persists — an agent really
does build a game end to end over MCP. Both the README paragraph and the manual section
immediately spell that journey out, so the word is defined where it is used. It is also
the owner-agreed copy, and the accuracy problem the reviewers found lived in the *export*
clause, which is fixed.

**Claude: `hidden` is never identified as `launch_game`'s default — Low. FIXED.**
Every example passes `mode` explicitly, so a reader never learned it. Now "the default".

**Claude: `overwrite` described without saying it deletes — Low. FIXED.**
`docs/mcp.md` is explicit that overwrite also deletes modules the session does not have;
a manual-only reader could have lost sibling `.fun` files. Now stated.

**Claude: the authoring snippet uses a session id `"s1"` from nowhere — Low. FIXED.**
Added the `// → {"session":"s1",…}` response line, matching the deterministic-loop snippet.

**Claude: `llms.txt` doesn't mention `functor mcp` — Medium. FIXED.**
`llms.txt` is the entry point an agent fetches, and this PR's thesis is that agents drive
Functor over MCP — the omission was pointed. Added a "Driving games with agents" line
(`site/build.mjs`).

**Claude: the `blob/main/docs/mcp.md` link 404s until this stack merges — Low. WON'T FIX.**
Correct post-merge, and it matches the manual's existing footnote convention (the
`sharp-edges` footnote links `blob/main/docs/functor-lang.md` the same way).

**Claude: the section duplicates ~100 lines of `docs/mcp.md` — Low. WON'T FIX.**
Deliberate: the manual is a first read for someone who has never opened the repo, and it
can't link into a repo doc for that. The canonical doc stays canonical and carries the
per-argument depth; the footnote points there.

Both engines independently confirmed the substance: the tool table names exactly the 19
shipped tools with no invention or omission, argument names/defaults/semantics match
`cli/src/commands/mcp.rs`, the `#agents` anchor and the README URL agree, the JSON and
shell snippets are valid, and the screenshots show no clipping, overflow, or typography
regression. Neither found a Critical or High issue.

**Re-verified after the fixes:** `npm run site:build` + `npm run check:site` clean,
screenshots re-captured (the embedded "after" images are post-fix), `llms.txt` line
confirmed in the built output.

_Process note: the first two Codex runs had to be discarded — one drifted onto an earlier
PR's `mcp.rs` diff, and both stalled on the 4772px-tall manual capture. Re-run with an
explicit scope guard (the diff written to a file, the four in-scope paths named) and
downscaled stills; the findings above are from that clean run._