### PR TITLE
feat(cli): develop serves the debug runtime on a default localhost port

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ use `./target/release/functor` instead — see [DEVELOPMENT.md](DEVELOPMENT.md).
 | `functor -d <dir> init [3d\|fps]` | Scaffold a new Functor Lang project (`3d` is the default) |
 | `functor -d <dir> build [native\|wasm]` | Typecheck the `.fun` project (diagnostics are errors) |
 | `functor -d <dir> run [native\|wasm]` | Interpret and run the game (native window / browser) |
-| `functor -d <dir> develop [native\|wasm]` | Same as `run` — Functor Lang hot-reload is built into the runtime |
+| `functor -d <dir> develop [native\|wasm]` | Same as `run` — Functor Lang hot-reload is built into the runtime — plus the debug runtime on `localhost:8077` (`--no-debug` to skip it) |
 | `functor docs [--format markdown\|json]` | Generate the engine API reference from the embedded `.funi` prelude |
 
 For build-from-source instructions and what `build`/`run` do under the hood, see

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ use `./target/release/functor` instead — see [DEVELOPMENT.md](DEVELOPMENT.md).
 | `functor -d <dir> init [3d\|fps]` | Scaffold a new Functor Lang project (`3d` is the default) |
 | `functor -d <dir> build [native\|wasm]` | Typecheck the `.fun` project (diagnostics are errors) |
 | `functor -d <dir> run [native\|wasm]` | Interpret and run the game (native window / browser) |
-| `functor -d <dir> develop [native\|wasm]` | Same as `run` — Functor Lang hot-reload is built into the runtime — plus the debug runtime on `localhost:8077` (`--no-debug` to skip it) |
+| `functor -d <dir> develop [native\|wasm]` | Same as `run` — Functor Lang hot-reload is built into the runtime — plus, on native, the debug runtime on `localhost:8077` (`--no-debug` to skip it) |
 | `functor docs [--format markdown\|json]` | Generate the engine API reference from the embedded `.funi` prelude |
 
 For build-from-source instructions and what `build`/`run` do under the hood, see

--- a/cli/src/commands/functor_lang_project.rs
+++ b/cli/src/commands/functor_lang_project.rs
@@ -19,6 +19,7 @@ use std::io::{Error, ErrorKind};
 use std::path::{Path, PathBuf};
 
 use clap::Parser;
+use functor_runtime_common::debug_protocol::DEFAULT_DEVELOP_PORT;
 
 use crate::output::{emit, Event, Severity};
 // `util` (the shell-command runner + wasm dev server) is only used by the
@@ -412,6 +413,10 @@ impl FunctorLangProject {
             "--game-path".to_string(),
             self.entry.clone(),
         ];
+        let (runner_args, debug_warning) = resolve_debug_args(develop, runner_args);
+        if let Some(message) = debug_warning {
+            emit(Event::Warning { message });
+        }
         argv.extend(runner_args.iter().cloned());
         let runtime_args = functor_runtime_desktop::Args::parse_from(argv);
 
@@ -804,6 +809,42 @@ relative path inside it (got {})",
             wasm_server_start.await
         }
     }
+}
+
+/// Resolve the debug-server args the desktop runtime is invoked with, and
+/// strip the CLI-only `--no-debug` (the runtime's clap would reject it).
+///
+/// `develop` serves the debug runtime on the well-known localhost port
+/// [`DEFAULT_DEVELOP_PORT`] by default, so an agent can attach to a human's
+/// live session without being told a port. `run` stays opt-in — only a session
+/// the developer explicitly called `develop` gets a listener for free. An
+/// explicit `--debug-port` (or `--debug-port=P`) always wins, `--no-debug`
+/// suppresses the default, and the added default carries
+/// `--debug-port-optional` so a second concurrent session degrades to "no
+/// debug server" instead of dying on the bind.
+///
+/// Returns the args to forward plus an optional warning to emit.
+fn resolve_debug_args(develop: bool, runner_args: &[String]) -> (Vec<String>, Option<String>) {
+    let explicit = runner_args
+        .iter()
+        .any(|arg| arg == "--debug-port" || arg.starts_with("--debug-port="));
+    let no_debug = runner_args.iter().any(|arg| arg == "--no-debug");
+    let mut args: Vec<String> = runner_args
+        .iter()
+        .filter(|arg| *arg != "--no-debug")
+        .cloned()
+        .collect();
+
+    if !develop || explicit || no_debug {
+        let warning = (no_debug && explicit)
+            .then(|| "--no-debug ignored: --debug-port was given explicitly".to_string());
+        return (args, warning);
+    }
+
+    args.push("--debug-port".to_string());
+    args.push(DEFAULT_DEVELOP_PORT.to_string());
+    args.push("--debug-port-optional".to_string());
+    (args, None)
 }
 
 /// Auto-reimport (B.2): regenerate a stale GENERATED `assets.fun` before the
@@ -1228,7 +1269,54 @@ fn entry_escapes_project(entry: &str) -> bool {
 mod tests {
     #[cfg(feature = "web")]
     use super::entry_escapes_project;
-    use super::{nth_line, project_asset_files, FunctorLangConfig, FunctorLangEntries};
+    use super::{
+        nth_line, project_asset_files, resolve_debug_args, FunctorLangConfig, FunctorLangEntries,
+    };
+
+    fn resolve(develop: bool, args: &[&str]) -> (Vec<String>, Option<String>) {
+        let args: Vec<String> = args.iter().map(|a| a.to_string()).collect();
+        resolve_debug_args(develop, &args)
+    }
+
+    #[test]
+    fn develop_defaults_to_the_well_known_debug_port() {
+        let (args, warning) = resolve(true, &["--hidden"]);
+        assert_eq!(
+            args,
+            ["--hidden", "--debug-port", "8077", "--debug-port-optional"]
+        );
+        assert_eq!(warning, None);
+    }
+
+    #[test]
+    fn run_stays_opt_in() {
+        assert_eq!(resolve(false, &["--hidden"]).0, ["--hidden"]);
+    }
+
+    #[test]
+    fn an_explicit_debug_port_wins() {
+        assert_eq!(
+            resolve(true, &["--debug-port", "9001"]).0,
+            ["--debug-port", "9001"]
+        );
+        assert_eq!(
+            resolve(true, &["--debug-port=9001"]).0,
+            ["--debug-port=9001"]
+        );
+    }
+
+    #[test]
+    fn no_debug_suppresses_the_default_and_never_reaches_the_runtime() {
+        assert_eq!(resolve(true, &["--no-debug", "--hidden"]).0, ["--hidden"]);
+        assert_eq!(resolve(false, &["--no-debug"]).0, Vec::<String>::new());
+    }
+
+    #[test]
+    fn no_debug_with_an_explicit_port_warns() {
+        let (args, warning) = resolve(true, &["--no-debug", "--debug-port", "9001"]);
+        assert_eq!(args, ["--debug-port", "9001"]);
+        assert!(warning.is_some_and(|w| w.contains("--no-debug ignored")));
+    }
 
     fn single(entry: &str) -> FunctorLangConfig {
         FunctorLangConfig {

--- a/cli/src/commands/functor_lang_project.rs
+++ b/cli/src/commands/functor_lang_project.rs
@@ -839,11 +839,20 @@ fn resolve_debug_args(develop: bool, runner_args: &[String]) -> (Vec<String>, Op
     let explicit = has("--debug-port");
     let bind = has("--debug-bind");
     let no_debug = runner_args.iter().any(|arg| arg == "--no-debug");
+    // `--debug-port-optional` is internal to the injected develop default: an
+    // EXPLICIT --debug-port that cannot bind must stay an error, so a
+    // user-supplied copy is stripped rather than forwarded.
+    let internal = runner_args.iter().any(|arg| arg == "--debug-port-optional");
     let mut args: Vec<String> = runner_args
         .iter()
-        .filter(|arg| *arg != "--no-debug")
+        .filter(|arg| *arg != "--no-debug" && *arg != "--debug-port-optional")
         .cloned()
         .collect();
+    let internal_warning = internal.then(|| {
+        "--debug-port-optional is internal to the develop default and was ignored \
+(an explicit --debug-port that cannot bind is an error)"
+            .to_string()
+    });
 
     if !develop || explicit || no_debug || bind {
         let warning = match (no_debug, explicit, bind) {
@@ -857,13 +866,13 @@ bind is never implicit — pass --debug-port <PORT> to start one)"
             ),
             _ => None,
         };
-        return (args, warning);
+        return (args, warning.or(internal_warning));
     }
 
     args.push("--debug-port".to_string());
     args.push(DEFAULT_DEVELOP_PORT.to_string());
     args.push("--debug-port-optional".to_string());
-    (args, None)
+    (args, internal_warning)
 }
 
 /// Auto-reimport (B.2): regenerate a stale GENERATED `assets.fun` before the
@@ -1328,6 +1337,23 @@ mod tests {
     fn no_debug_suppresses_the_default_and_never_reaches_the_runtime() {
         assert_eq!(resolve(true, &["--no-debug", "--hidden"]).0, ["--hidden"]);
         assert_eq!(resolve(false, &["--no-debug"]).0, Vec::<String>::new());
+    }
+
+    #[test]
+    fn a_user_supplied_debug_port_optional_is_stripped() {
+        // The flag is internal to the injected default: forwarded alongside an
+        // explicit --debug-port it would silently degrade the fatal-bind
+        // contract, so it never survives the CLI in any combination.
+        let (args, warning) = resolve(true, &["--debug-port", "9001", "--debug-port-optional"]);
+        assert_eq!(args, ["--debug-port", "9001"]);
+        assert!(warning.is_some_and(|w| w.contains("--debug-port-optional")));
+        let (args, warning) = resolve(true, &["--debug-port-optional"]);
+        assert_eq!(
+            args,
+            ["--debug-port", "8077", "--debug-port-optional"],
+            "the DEFAULT still carries the internal flag it injects itself"
+        );
+        assert!(warning.is_some_and(|w| w.contains("--debug-port-optional")));
     }
 
     #[test]

--- a/cli/src/commands/functor_lang_project.rs
+++ b/cli/src/commands/functor_lang_project.rs
@@ -823,11 +823,21 @@ relative path inside it (got {})",
 /// `--debug-port-optional` so a second concurrent session degrades to "no
 /// debug server" instead of dying on the bind.
 ///
+/// The default is LOCALHOST-ONLY by construction: `--debug-bind` (the flag that
+/// widens the server to the LAN, where it is an unauthenticated remote-code
+/// channel) suppresses it too, so a wide bind still takes an explicit
+/// `--debug-port`. Nothing here ever widens a bind implicitly.
+///
 /// Returns the args to forward plus an optional warning to emit.
 fn resolve_debug_args(develop: bool, runner_args: &[String]) -> (Vec<String>, Option<String>) {
-    let explicit = runner_args
-        .iter()
-        .any(|arg| arg == "--debug-port" || arg.starts_with("--debug-port="));
+    let has = |name: &str| {
+        let prefix = format!("{name}=");
+        runner_args
+            .iter()
+            .any(|arg| arg == name || arg.starts_with(&prefix))
+    };
+    let explicit = has("--debug-port");
+    let bind = has("--debug-bind");
     let no_debug = runner_args.iter().any(|arg| arg == "--no-debug");
     let mut args: Vec<String> = runner_args
         .iter()
@@ -835,9 +845,18 @@ fn resolve_debug_args(develop: bool, runner_args: &[String]) -> (Vec<String>, Op
         .cloned()
         .collect();
 
-    if !develop || explicit || no_debug {
-        let warning = (no_debug && explicit)
-            .then(|| "--no-debug ignored: --debug-port was given explicitly".to_string());
+    if !develop || explicit || no_debug || bind {
+        let warning = match (no_debug, explicit, bind) {
+            (true, true, _) => {
+                Some("--no-debug ignored: --debug-port was given explicitly".to_string())
+            }
+            (false, false, true) if develop => Some(
+                "--debug-bind without --debug-port: no debug server started (a non-localhost \
+bind is never implicit — pass --debug-port <PORT> to start one)"
+                    .to_string(),
+            ),
+            _ => None,
+        };
         return (args, warning);
     }
 
@@ -1309,6 +1328,25 @@ mod tests {
     fn no_debug_suppresses_the_default_and_never_reaches_the_runtime() {
         assert_eq!(resolve(true, &["--no-debug", "--hidden"]).0, ["--hidden"]);
         assert_eq!(resolve(false, &["--no-debug"]).0, Vec::<String>::new());
+    }
+
+    #[test]
+    fn a_bind_is_never_widened_implicitly() {
+        // The default listener has no auth, so `--debug-bind` (which exists to
+        // expose it) must not be handed a port it never asked for.
+        for args in [
+            vec!["--debug-bind", "0.0.0.0"],
+            vec!["--debug-bind=0.0.0.0"],
+        ] {
+            let (resolved, warning) = resolve(true, &args);
+            assert_eq!(resolved, args);
+            assert!(warning.is_some_and(|w| w.contains("--debug-bind")));
+        }
+        // …but an explicit port with a wide bind is still exactly what was asked.
+        assert_eq!(
+            resolve(true, &["--debug-bind", "0.0.0.0", "--debug-port", "9001"]).0,
+            ["--debug-bind", "0.0.0.0", "--debug-port", "9001"]
+        );
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -151,10 +151,11 @@ enum Command {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         runner_args: Vec<String>,
     },
-    /// Run with hot-reload (same as `run`; Functor Lang reloads on save), and
-    /// serve the debug runtime on http://127.0.0.1:8077 so an agent or script
-    /// can attach (docs/debug-runtime.md, docs/mcp.md) without being told a
-    /// port. E.g. `functor -d examples/lighting develop native`.
+    /// Run with hot-reload (same as `run`; Functor Lang reloads on save). On
+    /// native it also serves the debug runtime on http://127.0.0.1:8077 so an
+    /// agent or script can attach (docs/debug-runtime.md, docs/mcp.md) without
+    /// being told a port (`--no-debug` to skip; wasm serves pages, not the
+    /// control port). E.g. `functor -d examples/lighting develop native`.
     Develop {
         #[arg(value_enum)]
         environment: Option<Environment>,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -159,6 +159,11 @@ enum Command {
         #[arg(value_enum)]
         environment: Option<Environment>,
 
+        /// Start no debug server at all (skip the default port). Accepted
+        /// before or after the environment.
+        #[arg(long)]
+        no_debug: bool,
+
         /// Extra arguments forwarded to the in-process desktop runtime (native
         /// only). E.g. `develop native --debug-port 9001` to override the
         /// default debug port, or `--no-debug` to start no debug server at
@@ -373,12 +378,20 @@ async fn run(args: &Args) -> io::Result<()> {
         // (trailing_var_arg) — including a late `--entry server`. Honor it
         // here rather than forwarding it to the runtime's clap, which would
         // reject it with a confusing runtime-level error.
-        let (trailing_entry, runner_args) = match &args.command {
+        let (trailing_entry, mut runner_args) = match &args.command {
             Command::Run { runner_args, .. } | Command::Develop { runner_args, .. } => {
                 take_entry_arg(runner_args)?
             }
             _ => (None, Vec::new()),
         };
+        // `develop --no-debug` (before the environment) and `develop native
+        // --no-debug` (captured into runner_args) mean the same thing: fold the
+        // flag form into the args the runner-arg resolution already handles.
+        if matches!(&args.command, Command::Develop { no_debug: true, .. })
+            && !runner_args.iter().any(|arg| arg == "--no-debug")
+        {
+            runner_args.push("--no-debug".to_string());
+        }
         let project = config.select(args.entry.as_deref().or(trailing_entry.as_deref()))?;
         return match &args.command {
             Command::Docs { .. }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -151,15 +151,18 @@ enum Command {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         runner_args: Vec<String>,
     },
-    /// Run with hot-reload (same as `run`; Functor Lang reloads on save). E.g.
-    /// `functor -d examples/lighting develop native`.
+    /// Run with hot-reload (same as `run`; Functor Lang reloads on save), and
+    /// serve the debug runtime on http://127.0.0.1:8077 so an agent or script
+    /// can attach (docs/debug-runtime.md, docs/mcp.md) without being told a
+    /// port. E.g. `functor -d examples/lighting develop native`.
     Develop {
         #[arg(value_enum)]
         environment: Option<Environment>,
 
         /// Extra arguments forwarded to the in-process desktop runtime (native
-        /// only). E.g. `develop native --debug-port 8077`. A leading `--` is
-        /// also accepted.
+        /// only). E.g. `develop native --debug-port 9001` to override the
+        /// default debug port, or `--no-debug` to start no debug server at
+        /// all. A leading `--` is also accepted.
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         runner_args: Vec<String>,
     },

--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -27,13 +27,16 @@ If 8077 is already taken — a second `functor develop`, or a stale process —
 `develop` logs one line and runs the game **without** a debug server rather than
 failing to start; pass `--debug-port <PORT>` for a second session, or `--no-debug`
 to skip the listener entirely. An explicit `--debug-port` that can't bind is still
-a fatal error (automation asked for *that* port and is waiting on it).
+a fatal error (automation asked for *that* port and is waiting on it). Tooling that
+hard-codes 8077 — the TS SDK's `launch()`, the VS Code inspector's default — should
+therefore be pointed at its own port while a `develop` session is up.
 
 The server binds **localhost by default** (`127.0.0.1:<PORT>`); `--debug-bind 0.0.0.0`
 exposes it to the LAN for remote develop (see `POST /reload-source`) — there is no auth,
 so bind wide only on networks where arbitrary game-code pushes are acceptable. That is
 why only the *localhost* bind is on by default under `develop`: reaching it already
-requires code execution on the machine. `--debug-bind` is never widened implicitly. HTTP
+requires code execution on the machine. A bind is never widened implicitly —
+`develop --debug-bind …` starts no server unless `--debug-port` is given too. HTTP
 handlers never touch GL; each request is handed to the render loop and fulfilled once
 per frame.
 

--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -6,16 +6,34 @@ game without a GPU window of its own. It is the runtime arm of Functor's LLM-nat
 goal: capture frames, query state, control the frame clock, and inject input over a
 localhost socket.
 
-On desktop, start it by passing `--debug-port <PORT>`:
+On desktop, **`functor develop` starts it by default** on the well-known localhost
+port **8077** — so a script or agent can attach to a live develop session without
+being told a port:
+
+```sh
+./target/debug/functor -d examples/hello develop native
+curl -s localhost:8077/ | jq
+```
+
+`run` stays opt-in: pass `--debug-port <PORT>` there (or on `develop`, to choose a
+different port).
 
 ```sh
 # the CLI runs the game in-process and interprets the .fun
 ./target/debug/functor -d examples/hello run native --debug-port 8077
 ```
 
+If 8077 is already taken — a second `functor develop`, or a stale process —
+`develop` logs one line and runs the game **without** a debug server rather than
+failing to start; pass `--debug-port <PORT>` for a second session, or `--no-debug`
+to skip the listener entirely. An explicit `--debug-port` that can't bind is still
+a fatal error (automation asked for *that* port and is waiting on it).
+
 The server binds **localhost by default** (`127.0.0.1:<PORT>`); `--debug-bind 0.0.0.0`
 exposes it to the LAN for remote develop (see `POST /reload-source`) — there is no auth,
-so bind wide only on networks where arbitrary game-code pushes are acceptable. HTTP
+so bind wide only on networks where arbitrary game-code pushes are acceptable. That is
+why only the *localhost* bind is on by default under `develop`: reaching it already
+requires code execution on the machine. `--debug-bind` is never widened implicitly. HTTP
 handlers never touch GL; each request is handed to the render loop and fulfilled once
 per frame.
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -46,7 +46,7 @@ URL plus, when the server launched it, the child process.
 | Tool | What it does |
 | --- | --- |
 | `launch_game` | Spawn a game as a child on a free port and return its session id. The project comes from `dir` **or** from `files` — the whole project inline (see below). `mode` is `hidden` (default) or `headless`. |
-| `connect_game` | Attach to a runtime this server does **not** own (someone else's `--debug-port`, or an adb-forwarded Quest). |
+| `connect_game` | Attach to a runtime this server does **not** own (a human's `functor develop` on port 8077, someone else's `--debug-port`, or an adb-forwarded Quest). |
 | `list_sessions` | Every session: id, url, owned/attached, and whether it currently answers. |
 | `stop_game` | Kill a launched game; merely forget an attached one. |
 
@@ -219,6 +219,30 @@ stop_game  { "session": "s1" }
 Nothing advanced between the click and the step, and `step` returned only once
 the step had actually run — so `model.count` is the click's effect, not a
 sample of a still-moving game.
+
+## Debugging a human's live session
+
+`functor develop` serves the debug runtime on **http://127.0.0.1:8077** by default
+(`docs/debug-runtime.md`), so there is no port to relay: the human runs their game,
+the agent attaches to the well-known port.
+
+```sh
+functor -d examples/counter develop        # the human's window, hot-reloading on save
+```
+
+```jsonc
+connect_game { "url": "http://127.0.0.1:8077" }
+// → {"session":"s1","url":"http://127.0.0.1:8077","owned":false,…}
+```
+
+The session is **attached**: `get_state`, `get_scene`, `capture_frame`, `pause`,
+`step`, and `send_input` all drive the human's live window, and `stop_game` merely
+forgets it. Remember that pausing or injecting input affects what they are looking
+at — `resume` when done.
+
+If the human is running two develop sessions, only the first holds 8077 (the second
+logs that it is running without a debug server); ask them to start the one you need
+with an explicit `--debug-port`.
 
 ## Connecting to a Quest
 

--- a/runtime/functor-runtime-common/src/debug_protocol.rs
+++ b/runtime/functor-runtime-common/src/debug_protocol.rs
@@ -35,6 +35,11 @@ pub const DEBUG_PROTOCOL_SERVICE: &str = "functor debug runtime";
 /// `/project` needs a v5 runtime (a v4 one answers 404).
 pub const DEBUG_PROTOCOL_VERSION: u32 = 5;
 
+/// The well-known localhost port `functor develop` serves this protocol on
+/// when no explicit `--debug-port` is given, so an agent can attach to a
+/// human's live session without being told a port number.
+pub const DEFAULT_DEVELOP_PORT: u16 = 8077;
+
 /// Maximum accepted body size for either reload operation.
 pub const MAX_RELOAD_BYTES: usize = 4 * 1024 * 1024;
 

--- a/runtime/functor-runtime-desktop/src/debug_server.rs
+++ b/runtime/functor-runtime-desktop/src/debug_server.rs
@@ -22,7 +22,10 @@ pub fn spawn(bind: &str, port: u16, optional: bool) -> Option<Receiver<DebugRequ
     let address = format!("{bind}:{port}");
     let receiver = match functor_runtime_common::debug_http::spawn((bind, port)) {
         Ok(receiver) => receiver,
-        Err(error) if optional => {
+        // Only a TAKEN port degrades: any other bind failure (a bad interface,
+        // a permission denial) is a misconfiguration the fatal arm should
+        // report accurately rather than blame on another session.
+        Err(error) if optional && error.kind() == std::io::ErrorKind::AddrInUse => {
             // Stderr for the same reason as the listening notice below.
             eprintln!(
                 "[debug-server] {address} is already in use ({error}) — running without the \

--- a/runtime/functor-runtime-desktop/src/debug_server.rs
+++ b/runtime/functor-runtime-desktop/src/debug_server.rs
@@ -13,10 +13,23 @@ pub use functor_runtime_common::debug_protocol::{
 /// `127.0.0.1` keeps it local; `0.0.0.0` exposes it for remote development.
 /// There is no authentication, so wide binds are appropriate only on trusted
 /// networks where arbitrary game-code pushes are acceptable.
-pub fn spawn(bind: &str, port: u16) -> Receiver<DebugRequest> {
+///
+/// A failed bind is fatal for an explicitly requested port (the caller asked
+/// for *that* port and automation is waiting on it). With `optional` — how
+/// `functor develop` asks for its default well-known port — it instead logs
+/// and returns `None`, so a second concurrent session still runs the game.
+pub fn spawn(bind: &str, port: u16, optional: bool) -> Option<Receiver<DebugRequest>> {
     let address = format!("{bind}:{port}");
     let receiver = match functor_runtime_common::debug_http::spawn((bind, port)) {
         Ok(receiver) => receiver,
+        Err(error) if optional => {
+            // Stderr for the same reason as the listening notice below.
+            eprintln!(
+                "[debug-server] {address} is already in use ({error}) — running without the \
+debug server; pass `--debug-port <PORT>` to pick another"
+            );
+            return None;
+        }
         Err(error) => {
             eprintln!("[debug-server] failed to bind {address}: {error}");
             std::process::exit(1);
@@ -26,5 +39,5 @@ pub fn spawn(bind: &str, port: u16) -> Receiver<DebugRequest> {
     // Stderr, not stdout: `--debug-port` is a common `--json` automation combo,
     // so this notice must not land in the CLI's ndjson stream.
     eprintln!("[debug-server] listening on http://{address}");
-    receiver
+    Some(receiver)
 }

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -541,6 +541,13 @@ pub struct Args {
     #[arg(long)]
     debug_port: Option<u16>,
 
+    /// Treat a failed debug-server bind as non-fatal: log one line and run the
+    /// game without the server. `functor develop` sets this for its default
+    /// well-known port, so a second concurrent session (which finds the port
+    /// taken) still runs. An explicitly requested port stays fatal.
+    #[arg(long, requires = "debug_port")]
+    debug_port_optional: bool,
+
     /// Interface the debug server binds to. The default keeps it local;
     /// 0.0.0.0 exposes it to the LAN for remote develop (a dev machine
     /// pushing source to this runner). No auth — bind wide only on networks
@@ -1193,10 +1200,10 @@ pub fn run(args: Args) {
 
     // Optional debug control server. Runs on its own thread; the GL loop drains
     // its request channel once per frame (see below). None when --debug-port is
-    // not given, so behavior is unchanged.
+    // not given — or when an optional (default) port was already taken.
     let debug_requests = args
         .debug_port
-        .map(|port| debug_server::spawn(&args.debug_bind, port));
+        .and_then(|port| debug_server::spawn(&args.debug_bind, port, args.debug_port_optional));
 
     // Headless: drive the game + debug server with no GL window, and return.
     if args.headless {


### PR DESCRIPTION
`functor develop` now starts the debug control server on the **well-known
localhost port 8077** unless told otherwise, so a coding agent (or the VS Code
inspector, or `curl`) can attach to a human's live session with no port to relay.
`functor run` stays opt-in.

```sh
functor -d examples/counter develop      # the human's session
curl -s localhost:8077/ | jq             # …the agent attaches, no arrangement needed
```

```jsonc
connect_game { "url": "http://127.0.0.1:8077" }
```

## Why default-on is acceptable here

The server has **no authentication** and `POST /reload-source` executes pushed
game code, so this is only defensible because the default is **localhost-only**:
reaching `127.0.0.1:8077` already requires code execution on the machine. Two
guard rails keep it that way:

- **`run` stays opt-in.** Only a session the developer explicitly called
  `develop` — an interactive, hot-reloading dev loop — gets a listener for free.
  Scripted/CI `run` invocations are unchanged.
- **A bind is never widened implicitly.** `--debug-bind` (the flag that exposes
  the server to the LAN) *suppresses* the default rather than inheriting it:
  `develop --debug-bind 0.0.0.0` warns and starts no server. A wide bind still
  takes an explicit `--debug-port`.

`--no-debug` opts out entirely (accepted before or after the environment:
`develop --no-debug` and `develop native --no-debug`).

## Collision behavior (the design decision)

Two concurrent `develop` sessions, or a stale process, will collide on 8077. The
default **degrades to no debug server**: one clear line, and the game runs.

```
[debug-server] 127.0.0.1:8077 is already in use (Address already in use (os error 48)) — running without the debug server; pass `--debug-port <PORT>` to pick another
```

Why this over falling back to an ephemeral port: the whole point of the default
is that the port is *known without being told*. A silent fallback to port 54321
gives an agent nothing to connect to, and — worse — an agent that then connects
to 8077 anyway would be driving **someone else's session** while believing it
had its own. Failing closed on the listener is honest; the game itself must
never fail to start over an ancillary dev service.

An **explicit** `--debug-port` keeps the existing behavior: a failed bind is
fatal (verified against main — automation asked for *that* port and is waiting
on it). Only `AddrInUse` degrades; a bad interface or a permission denial still
reports accurately and exits.

Implementation: the CLI appends `--debug-port 8077 --debug-port-optional` when
`develop` has no explicit port; `--debug-port-optional` is the new runtime flag
that makes a bind failure non-fatal. There is no probe-then-bind (which would
race two sessions started at the same instant) — one bind, one decision.

## Changes

- `functor_runtime_common::debug_protocol::DEFAULT_DEVELOP_PORT = 8077` — one
  home for the constant, next to the protocol version. 8077 is what every doc
  example and the VS Code inspector's default already use, so the inspector now
  attaches to a plain `functor develop` out of the box.
- `resolve_debug_args` (CLI, pure + unit-tested): default resolution, flag
  precedence, `--no-debug` stripping (the runtime's clap would reject it).
- `debug_server::spawn(bind, port, optional) -> Option<Receiver>`.
- Docs: `docs/debug-runtime.md` intro + security paragraph, a "Debugging a
  human's live session" journey in `docs/mcp.md`, README CLI table, CLI help.

## Verification

- `cargo test -p functor-cli --no-default-features` — 60 passed, incl. 6 new
  tests for default resolution / precedence / `run` opt-in / `--no-debug` /
  never-widen-a-bind. `cargo test -p functor_runtime_common` (560) and
  `-p functor-runtime-desktop` (73 + suites) pass.
- Live, on `examples/counter` (`--headless`):
  - no flags → `curl localhost:8077/` returns the discovery JSON, `/state`
    advances.
  - second concurrent `develop` → the line above; the game keeps running.
  - `develop --no-debug native` and `develop native --no-debug` → nothing
    listening on 8077.
  - `develop native --debug-port 9001` → 9001 listens, 8077 does not.
  - `develop native --debug-bind 0.0.0.0` → warns, starts nothing.
  - explicit `--debug-port` on a taken port → still fatal (`failed to bind …`).
- No e2e harness change: `e2e/mcp-server.mjs` would have to spawn a real
  `develop` and race a fixed global port against anything else on the machine —
  flaky for what is pure argv-resolution logic already covered by unit tests.

## Review dispositions (`/xreview`)

The Claude reviewer ran to completion (it built the binary and verified each
finding live). **The Codex leg did not**: the first run wedged after trying to
re-enter the review skill recursively, and a second run — explicitly told to
review directly — stalled mid-analysis and produced no findings before being
killed. So this change has one adversarial engine's findings, not two, and
nothing here is tagged [AGREED].


| Finding | Disposition |
| --- | --- |
| **High** — the default port was added even with `--debug-bind`, silently opening an unauthenticated LAN listener | **Fixed** — `--debug-bind` suppresses the default and warns; new test `a_bind_is_never_widened_implicitly` |
| **Medium** — `functor develop --no-debug` (the documented form) was rejected by clap; only `develop native --no-debug` worked | **Fixed** — real `--no-debug` flag on `develop`, folded into the same resolution |
| **Medium** — the fallback/listening notices are `eprintln!`, not structured events, so `--json` automation can't tell whether it got its own listener | **Not fixed (follow-up).** Pre-existing design: `docs/cli-output.md` already classifies the "listening on…" line as free-form runtime status. Making both outcomes typed `RuntimeEvent`s is a worthwhile separate change. |
| **Medium** — tooling that hard-codes 8077 (TS SDK `launch()`, VS Code inspector) now collides with a running `develop` | **Documented**, not changed — the SDK's default is its own call; `docs/debug-runtime.md` says to point it elsewhere while a develop session is up. |
| **Low/Medium** — `--no-debug` should beat an explicit `--debug-port` rather than warn | **Not taken** — explicit-wins is the stated contract, and the conflict warns loudly. |
| **Low** — every bind error was reported as "already in use" | **Fixed** — only `AddrInUse` degrades. |
| **Low** — `--no-debug` reaches the wasm/vr "ignoring runner args" warning | **Accepted** — harmless, and the flag form is consumed before that path. |

No duplication signals; no perf-sensitive path touched (no per-frame code
changed); no visual surface changed.


> **Codex leg completed post-hoc** (the in-flight runs stalled; a clean scoped run finished after the PR opened). Findings, both addressed in `fix(cli): --debug-port-optional is internal…`:
> - **Medium — fixed:** `--debug-port-optional` was publicly forwardable, so `--debug-port 9001 --debug-port-optional` silently degraded the explicit-port-fatal contract. The CLI now strips a user-supplied copy (with a warning) and injects the flag only for the develop default; unit test added.
> - **Low — fixed:** README/help implied the 8077 default applies to `develop wasm`; qualified as native-only. The wasm path's "ignored runner argument --no-debug" warning is kept — it is accurate, not noise.
> No Critical/High; Codex confirmed the reviewed diff contained only this PR's files.
